### PR TITLE
Fix native agent terminal input

### DIFF
--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -70,6 +70,7 @@ pub struct Supervisor {
     pub agents: Mutex<HashMap<String, Agent>>,
     pub generations: Mutex<HashMap<String, u64>>,
     pub activities: Mutex<HashMap<String, Box<dyn Activity>>>,
+    pub native_input_lines: Mutex<HashMap<String, String>>,
 }
 
 impl Supervisor {
@@ -79,6 +80,7 @@ impl Supervisor {
             agents: Mutex::new(HashMap::new()),
             generations: Mutex::new(HashMap::new()),
             activities: Mutex::new(HashMap::new()),
+            native_input_lines: Mutex::new(HashMap::new()),
         }
     }
 
@@ -384,10 +386,10 @@ impl Supervisor {
                 .ok_or_else(|| Error::AgentNotFound(agent_id.to_string()))?;
             agent.write_pty(bytes)?;
         }
-        mark_user_turn_started(&self, app, agent_id);
-        let text = String::from_utf8_lossy(bytes);
-        let trimmed = text.trim_end_matches(['\r', '\n']);
-        on_first_user_message(self.clone(), app.clone(), agent_id.to_string(), trimmed.to_string());
+        for submitted in observe_native_input(&self, agent_id, bytes) {
+            mark_user_turn_started(&self, app, agent_id);
+            on_first_user_message(self.clone(), app.clone(), agent_id.to_string(), submitted);
+        }
         Ok(())
     }
 
@@ -432,6 +434,7 @@ impl Supervisor {
             let _ = agent.shutdown();
         }
         self.activities.lock().remove(agent_id);
+        self.native_input_lines.lock().remove(agent_id);
 
         self.workspace.update_agent_view(agent_id, new_view)?;
         let _ = app.emit(
@@ -467,6 +470,7 @@ impl Supervisor {
             let _ = agent.shutdown();
         }
         self.activities.lock().remove(agent_id);
+        self.native_input_lines.lock().remove(agent_id);
         match self
             .workspace
             .update_agent_status(agent_id, AgentStatus::Stopped, None)
@@ -487,6 +491,7 @@ impl Supervisor {
             let _ = agent.shutdown();
         }
         self.activities.lock().remove(agent_id);
+        self.native_input_lines.lock().remove(agent_id);
 
         // Tear down each tracked repo's worktree + branch.
         for repo in &repos {
@@ -601,6 +606,89 @@ fn spawn_managed_agent(
     )
 }
 
+fn observe_native_input(sup: &Supervisor, agent_id: &str, bytes: &[u8]) -> Vec<String> {
+    let mut submitted = Vec::new();
+    let mut lines = sup.native_input_lines.lock();
+    let line = lines.entry(agent_id.to_string()).or_default();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\r' | b'\n' => {
+                let trimmed = line.trim().to_string();
+                line.clear();
+                if !trimmed.is_empty() {
+                    submitted.push(trimmed);
+                }
+                i += 1;
+            }
+            0x7f | 0x08 => {
+                line.pop();
+                i += 1;
+            }
+            0x03 | 0x15 => {
+                line.clear();
+                i += 1;
+            }
+            0x1b => {
+                i = skip_escape_sequence(bytes, i);
+            }
+            b if b < 0x20 => {
+                i += 1;
+            }
+            _ => match std::str::from_utf8(&bytes[i..]) {
+                Ok(rest) => {
+                    if let Some(ch) = rest.chars().next() {
+                        line.push(ch);
+                        i += ch.len_utf8();
+                    } else {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    let valid = e.valid_up_to();
+                    if valid > 0 {
+                        if let Ok(s) = std::str::from_utf8(&bytes[i..i + valid]) {
+                            if let Some(ch) = s.chars().next() {
+                                line.push(ch);
+                                i += ch.len_utf8();
+                            } else {
+                                i += valid;
+                            }
+                        } else {
+                            i += valid;
+                        }
+                    } else {
+                        i += 1;
+                    }
+                }
+            },
+        }
+    }
+
+    submitted
+}
+
+fn skip_escape_sequence(bytes: &[u8], start: usize) -> usize {
+    let mut i = start + 1;
+    if i < bytes.len() && bytes[i] == b'[' {
+        i += 1;
+        while i < bytes.len() {
+            let b = bytes[i];
+            i += 1;
+            if (0x40..=0x7e).contains(&b) {
+                break;
+            }
+        }
+        return i;
+    }
+    if i < bytes.len() {
+        i + 1
+    } else {
+        i
+    }
+}
+
 /// Fire-and-forget handler for the user's first message: persists it
 /// as the agent's `task` and kicks branch creation for every
 /// branchless tracked repo.
@@ -612,6 +700,9 @@ fn on_first_user_message(
 ) {
     let trimmed = text.trim().to_string();
     if trimmed.is_empty() {
+        return;
+    }
+    if trimmed.starts_with('/') {
         return;
     }
 
@@ -832,6 +923,7 @@ fn apply_exit_if_current(
 
     sup.agents.lock().remove(agent_id);
     sup.activities.lock().remove(agent_id);
+    sup.native_input_lines.lock().remove(agent_id);
 
     let (status, err) = if success {
         (AgentStatus::Stopped, None)

--- a/src/components/Workspace/NativeView.tsx
+++ b/src/components/Workspace/NativeView.tsx
@@ -1,15 +1,13 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
 import { api, type AgentRecord } from "../../api";
 import { getOutputBuffer, registerOutputSink } from "../../store";
 
-/** Native view: claude's TUI is streamed verbatim into xterm. We
- *  ship newlines from the composer (via `Composer`) by writing
- *  `<text>\r` to the PTY. Claude's own input prompt remains visible
- *  inside the terminal — that's deliberate. The terminal fills the
- *  body; the composer below it is owned by `Workspace`. */
+/** Native view: Claude's Ink TUI is streamed verbatim into xterm.
+ *  xterm owns stdin too, so slash commands, paste, arrows, escape, and
+ *  other terminal interactions go straight to the PTY. */
 export function NativeView({ agent }: { agent: AgentRecord }) {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -20,16 +18,18 @@ export function NativeView({ agent }: { agent: AgentRecord }) {
     const term = new Terminal({
       fontFamily: "ui-monospace, 'SF Mono', Menlo, monospace",
       fontSize: 13,
-      cursorBlink: false,
-      cursorStyle: "underline",
-      disableStdin: true,
+      cursorBlink: true,
+      cursorStyle: "block",
       theme: {
         background: "#1a1c20",
         foreground: "#e6e8eb",
-        cursor: "#1a1c20",
+        cursor: "#e6e8eb",
+        cursorAccent: "#1a1c20",
         selectionBackground: "#3a3f4a",
       },
       scrollback: 5000,
+      allowProposedApi: false,
+      macOptionIsMeta: true,
     });
     const fit = new FitAddon();
     term.loadAddon(fit);
@@ -48,6 +48,12 @@ export function NativeView({ agent }: { agent: AgentRecord }) {
       api.resizeAgent(agent.id, cols, rows).catch(() => {});
     });
 
+    const onDataDisposer = term.onData((data) => {
+      api.writeToAgent(agent.id, data).catch((err) => {
+        console.error("writeToAgent failed", err);
+      });
+    });
+
     const unregister = registerOutputSink(agent.id, (bytes) => {
       term.write(bytes);
     });
@@ -56,12 +62,14 @@ export function NativeView({ agent }: { agent: AgentRecord }) {
       try { fit.fit(); } catch { /* container may be hidden */ }
     });
     ro.observe(el);
+    term.focus();
 
     return () => {
       cancelAnimationFrame(initialFit);
       ro.disconnect();
       unregister();
       onResizeDisposer.dispose();
+      onDataDisposer.dispose();
       term.dispose();
     };
   }, [agent.id]);
@@ -72,39 +80,10 @@ export function NativeView({ agent }: { agent: AgentRecord }) {
       style={{
         flex: 1,
         minHeight: 0,
-        padding: "12px 16px",
+        padding: "8px 10px",
         background: "#1a1c20",
+        overflow: "hidden",
       }}
     />
   );
-}
-
-/** Send a single message to the PTY (newlines collapsed to spaces so
- *  ink-based TUIs treat the whole text as one turn). Exported so the
- *  Workspace can wire its composer to it. */
-export async function sendToPty(agentId: string, text: string, setBusy?: (b: boolean) => void) {
-  const t = text.trim();
-  if (!t) return;
-  setBusy?.(true);
-  try {
-    const normalized = t.replace(/\r?\n/g, " ");
-    await api.writeToAgent(agentId, normalized + "\r");
-  } catch (err) {
-    console.error("writeToAgent failed", err);
-  } finally {
-    setBusy?.(false);
-  }
-}
-
-/** Wrapper that exposes a busy flag for the composer disabled state.
- *  Local to the Native body so the Workspace doesn't need to track
- *  per-keystroke writes. */
-export function useNativeSend(agent: AgentRecord) {
-  const [sending, setSending] = useState(false);
-  const canSend =
-    !sending && (agent.status === "running" || agent.status === "idle");
-  return {
-    canSend,
-    send: (text: string) => sendToPty(agent.id, text, setSending),
-  };
 }

--- a/src/components/Workspace/WorkspaceHeader.tsx
+++ b/src/components/Workspace/WorkspaceHeader.tsx
@@ -14,7 +14,6 @@ interface Props {
 }
 
 export function WorkspaceHeader({ agent }: Props) {
-  const viewMode = useAppStore((s) => s.viewMode);
   const switchView = useAppStore((s) => s.switchView);
   const switchInFlight = useAppStore((s) => s.switchInFlight[agent.id]);
   const leftCollapsed = useAppStore((s) => s.leftCollapsed);
@@ -47,7 +46,7 @@ export function WorkspaceHeader({ agent }: Props) {
       </div>
 
       <ViewToggle
-        value={viewMode}
+        value={agent.view}
         onChange={(v) => switchView(agent.id, v)}
         disabled={switchInFlight}
       />

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -1,10 +1,9 @@
 import { EMPTY_AGENTS, useAppStore } from "../../store";
 import { Icon } from "../Icon";
 import { IconButton } from "../ui/IconButton";
-import { Composer } from "../Composer";
 import { WorkspaceHeader } from "./WorkspaceHeader";
 import { ChatView } from "./ChatView";
-import { NativeView, useNativeSend } from "./NativeView";
+import { NativeView } from "./NativeView";
 import { EmptyWorkspace } from "./EmptyWorkspace";
 import type { AgentRecord } from "../../api";
 
@@ -17,7 +16,6 @@ export function Workspace() {
   const selectedId = useAppStore((s) => s.selectedAgentId);
   const drafts = useAppStore((s) => s.drafts);
   const activeDraftId = useAppStore((s) => s.activeDraftId);
-  const viewMode = useAppStore((s) => s.viewMode);
   const leftCollapsed = useAppStore((s) => s.leftCollapsed);
   const toggleLeft = useAppStore((s) => s.toggleLeft);
 
@@ -53,7 +51,7 @@ export function Workspace() {
   return (
     <div className="pane center fade-in" key={agent.id}>
       <WorkspaceHeader agent={agent} />
-      {viewMode === "native" ? (
+      {agent.view === "native" ? (
         <NativeBody agent={agent} />
       ) : (
         <ChatView agent={agent} />
@@ -63,21 +61,9 @@ export function Workspace() {
 }
 
 function NativeBody({ agent }: { agent: AgentRecord }) {
-  // Wraps NativeView + a Composer below it that writes to the PTY.
-  // Native and custom share the composer shell so the bottom of the
-  // window always feels the same.
-  const { canSend, send } = useNativeSend(agent);
   return (
     <div className="chat" style={{ background: "#1a1c20" }}>
       <NativeView agent={agent} />
-      <div className="composer-wrap" style={{ background: "var(--bg-1)" }}>
-        <Composer
-          defaultProvider="claude"
-          disabled={!canSend}
-          placeholder={canSend ? "Message claude — ⌘↵ to send" : "Agent is not ready"}
-          onSend={({ text }) => send(text)}
-        />
-      </div>
     </div>
   );
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -283,6 +283,25 @@ function mergePatches(
   };
 }
 
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function sendWhenAgentReady(send: () => Promise<void>) {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    try {
+      await send();
+      return;
+    } catch (e) {
+      lastError = e;
+      if (!String(e).includes("agent not found")) {
+        throw e;
+      }
+      await sleep(250);
+    }
+  }
+  throw lastError;
+}
+
 function handleManagedEvent(
   state: AppState,
   agentId: string,
@@ -604,10 +623,11 @@ export const useAppStore = create<AppState>((set, get) => ({
     set((state) => ({
       managedBusy: { ...state.managedBusy, [id]: false },
       switchInFlight: { ...state.switchInFlight, [id]: true },
-      viewMode: view,
     }));
     try {
       await api.switchView(id, view);
+      localStorage.setItem("quorum:viewMode", view);
+      set({ viewMode: view });
     } catch (e) {
       set({ lastError: String(e) });
     } finally {
@@ -713,21 +733,32 @@ export const useAppStore = create<AppState>((set, get) => ({
     if (!draft) return;
     set({ busy: true, lastError: null });
     try {
-      const rec = await api.spawnAgent("custom", draft.repoPath);
+      const view = get().viewMode;
+      const rec = await api.spawnAgent(view, draft.repoPath);
       const fresh = await api.getWorkspace();
-      set((state) => ({
-        workspace: fresh,
-        selectedAgentId: rec.id,
-        drafts: state.drafts.filter((d) => d.id !== id),
-        activeDraftId: null,
-        managedLogs: {
-          ...state.managedLogs,
-          [rec.id]: [{ kind: "user", text }],
-        },
-        managedBusy: { ...state.managedBusy, [rec.id]: true },
-      }));
-      // Fire-and-await the first message
-      await api.sendUserMessage(rec.id, text);
+      set((state) => {
+        const patches: Partial<AppState> = {
+          workspace: fresh,
+          selectedAgentId: rec.id,
+          drafts: state.drafts.filter((d) => d.id !== id),
+          activeDraftId: null,
+        };
+        if (view === "custom") {
+          patches.managedLogs = {
+            ...state.managedLogs,
+            [rec.id]: [{ kind: "user", text }],
+          };
+          patches.managedBusy = { ...state.managedBusy, [rec.id]: true };
+        }
+        return patches;
+      });
+      if (view === "native") {
+        await sendWhenAgentReady(() =>
+          api.writeToAgent(rec.id, text.replace(/\r?\n/g, " ") + "\r"),
+        );
+      } else {
+        await sendWhenAgentReady(() => api.sendUserMessage(rec.id, text));
+      }
     } catch (e) {
       set({ lastError: String(e) });
     } finally {


### PR DESCRIPTION
Native mode now renders Claude's Ink app as an interactive xterm PTY instead of using a separate app composer.

Keystrokes, paste, arrow keys, escape, and slash commands are forwarded directly to Claude while submitted lines still drive task and branch setup.

The fix also keeps UI rendering aligned with the agent's actual backend view and retries the first draft message until the process is ready.

Validated with `npm run check`, `npm run build`, and `cargo test`.