### PR TITLE
Source draft agent names from backend names.rs

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5,12 +5,21 @@ use std::sync::Arc;
 use tauri::{AppHandle, State};
 
 use crate::error::Result;
+use crate::names;
 use crate::supervisor::Supervisor;
 use crate::workspace::{AgentRecord, AgentView, TrackedRepo, Workspace};
 
 #[tauri::command]
 pub fn get_workspace(supervisor: State<'_, Arc<Supervisor>>) -> Option<Workspace> {
     supervisor.current_workspace()
+}
+
+/// Allocate a fresh name from the shared place pool for a draft agent.
+/// Frontend passes the names already taken (real agents + other drafts) so
+/// the picker avoids collisions.
+#[tauri::command]
+pub fn allocate_draft_name(used: Vec<String>) -> String {
+    names::allocate(&used.into_iter().collect())
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -63,6 +63,7 @@ pub fn run() {
             commands::stop_agent,
             commands::discard_agent,
             commands::add_repo_to_agent,
+            commands::allocate_draft_name,
         ])
         .run(tauri::generate_context!())
         .expect("error while running quorum");

--- a/src/api.ts
+++ b/src/api.ts
@@ -99,6 +99,8 @@ export const api = {
     invoke<void>("discard_agent", { agentId }),
   addRepoToAgent: (agentId: string, repoPath: string) =>
     invoke<TrackedRepo>("add_repo_to_agent", { agentId, repoPath }),
+  allocateDraftName: (used: string[]) =>
+    invoke<string>("allocate_draft_name", { used }),
 };
 
 export function onAgentOutput(

--- a/src/data/landmarks.ts
+++ b/src/data/landmarks.ts
@@ -1,4 +1,5 @@
-// Worktree names + tiny location glyphs.
+// Tiny location glyphs keyed by place name. The names themselves come
+// from the backend (`names.rs`); this file only owns the visual side.
 
 import type { ReactNode } from "react";
 import { createElement, Fragment } from "react";
@@ -41,20 +42,3 @@ export const LANDMARK_GLYPHS: Record<string, ReactNode> = {
 };
 
 export const LANDMARK_NAMES = Object.keys(LANDMARK_GLYPHS);
-
-export const LANDMARK_FALLBACK = [
-  "fjord",
-  "kunlun",
-  "iguazu",
-  "tasman",
-  "norfolk",
-  "saharan",
-];
-
-/** Pick a landmark name not currently in `used`. Falls back to the
- *  fallback pool if all primary landmarks are taken. */
-export function pickLandmark(used: Set<string>): string {
-  const free = LANDMARK_NAMES.filter((n) => !used.has(n));
-  const pool = free.length > 0 ? free : LANDMARK_FALLBACK;
-  return pool[Math.floor(Math.random() * pool.length)];
-}

--- a/src/store.ts
+++ b/src/store.ts
@@ -13,7 +13,6 @@ import {
   type Workspace,
 } from "./api";
 import { DEFAULT_PROVIDER_ID } from "./data/providers";
-import { LANDMARK_NAMES, pickLandmark } from "./data/landmarks";
 
 type OutputHandler = (bytes: Uint8Array) => void;
 
@@ -200,11 +199,11 @@ interface AppState {
   clearError: () => void;
 
   // drafts
-  createDraft: (repoPath: string) => void;
+  createDraft: (repoPath: string) => Promise<void>;
   updateDraft: (id: string, patch: Partial<DraftAgent>) => void;
   removeDraft: (id: string) => void;
   selectDraft: (id: string | null) => void;
-  rerollDraftName: (id: string) => void;
+  rerollDraftName: (id: string) => Promise<void>;
   /** Spawn the real agent for a draft and dispatch the first message. */
   spawnFromDraft: (id: string, text: string, provider: string) => Promise<void>;
 
@@ -389,13 +388,11 @@ function handleManagedEvent(
   return {};
 }
 
-/** Landmarks already used by real or draft agents — passed to
- *  `pickLandmark` so re-rolling avoids collisions. */
-function usedLandmarks(workspace: Workspace | null, drafts: DraftAgent[]): Set<string> {
+/** Names already taken by real or draft agents — passed to the backend
+ *  name allocator so picks avoid collisions. */
+function usedNames(workspace: Workspace | null, drafts: DraftAgent[]): Set<string> {
   const used = new Set<string>();
-  for (const a of workspace?.agents ?? []) {
-    if (LANDMARK_NAMES.includes(a.name)) used.add(a.name);
-  }
+  for (const a of workspace?.agents ?? []) used.add(a.name);
   for (const d of drafts) used.add(d.name);
   return used;
 }
@@ -662,9 +659,10 @@ export const useAppStore = create<AppState>((set, get) => ({
   clearError: () => set({ lastError: null }),
 
   // ── drafts ─────────────────────────────────────────────────────────────────
-  createDraft: (repoPath) => {
+  createDraft: async (repoPath) => {
     const { workspace, drafts } = get();
-    const name = pickLandmark(usedLandmarks(workspace, drafts));
+    const used = [...usedNames(workspace, drafts)];
+    const name = await api.allocateDraftName(used);
     const draft: DraftAgent = {
       id: `draft-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
       repoPath,
@@ -696,16 +694,14 @@ export const useAppStore = create<AppState>((set, get) => ({
       selectedAgentId: null,
     }),
 
-  rerollDraftName: (id) => {
+  rerollDraftName: async (id) => {
     const { workspace, drafts } = get();
-    const used = usedLandmarks(workspace, drafts);
-    // exclude the current name so the reroll always changes
-    const current = drafts.find((d) => d.id === id);
-    if (current) used.delete(current.name);
-    const next = pickLandmark(new Set([...used, current?.name ?? ""]));
-    set({
-      drafts: drafts.map((d) => (d.id === id ? { ...d, name: next } : d)),
-    });
+    const used = usedNames(workspace, drafts);
+    // Keep the current name in `used` so the allocator picks a different one.
+    const next = await api.allocateDraftName([...used]);
+    set((s) => ({
+      drafts: s.drafts.map((d) => (d.id === id ? { ...d, name: next } : d)),
+    }));
   },
 
   spawnFromDraft: async (id, text, _provider) => {


### PR DESCRIPTION
## Summary

Draft agents were picking names from an 8-entry frontend pool, so freshly created drafts felt repetitive even though `src-tauri/src/names.rs` already has ~140 places. This PR exposes that allocator as a Tauri command (`allocate_draft_name`) and has the store call it for draft creation and reroll, giving drafts the same variety as real agents and leaving `names.rs` as the single source of truth. `src/data/landmarks.ts` is reduced to the glyph map — `LandmarkGlyph` already falls back to a generic mountain for names without custom art.

## Test plan
- [ ] Create several drafts in the sidebar and confirm names vary across the full pool
- [ ] Reroll a draft name and confirm it changes and avoids existing agent/draft names
- [ ] Spawn a real agent from a draft and confirm the name carries through