### PR TITLE
Replace sidebar settings icon with theme toggle

### DIFF
--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -19,6 +19,7 @@ import {
   GitPullRequest,
   Inbox,
   Minus,
+  Moon,
   MoreHorizontal,
   PanelLeft,
   PanelRight,
@@ -32,6 +33,7 @@ import {
   Settings,
   Sparkles,
   Square,
+  Sun,
   Terminal,
   Trash2,
   User,
@@ -102,6 +104,8 @@ const ICON_COMPONENTS = {
   trash: Trash2,
   thinking: Ellipsis,
   wrench: Wrench,
+  moon: Moon,
+  sun: Sun,
 } satisfies Record<string, ComponentType<IconComponentProps>>;
 
 // Originally rendered with fill="currentColor". Setting fill on the root SVG

--- a/src/components/Sidebar/SidebarFooter.tsx
+++ b/src/components/Sidebar/SidebarFooter.tsx
@@ -3,7 +3,9 @@ import { IconButton } from "../ui/IconButton";
 import { useAppStore } from "../../store";
 
 export function SidebarFooter() {
-  const toggleSettings = useAppStore((s) => s.toggleSettings);
+  const theme = useAppStore((s) => s.theme);
+  const setTheme = useAppStore((s) => s.setTheme);
+  const isDark = theme === "dark";
   return (
     <div className="side-foot">
       <div className="user-avatar">A</div>
@@ -11,8 +13,12 @@ export function SidebarFooter() {
         <div className="un">you</div>
         <div className="ue">local workspace</div>
       </div>
-      <IconButton tip="Settings (⌘,)" onClick={() => toggleSettings(true)}>
-        <Icon name="settings" />
+      <IconButton
+        tip={isDark ? "Light theme (⌘⇧L)" : "Dark theme (⌘⇧L)"}
+        onClick={() => setTheme(isDark ? "light" : "dark")}
+        aria-label="Toggle theme"
+      >
+        <Icon name={isDark ? "sun" : "moon"} />
       </IconButton>
     </div>
   );


### PR DESCRIPTION
## Summary
- Replaced the duplicated settings icon in the sidebar footer with a sun/moon theme toggle that flips between light and dark via the existing `setTheme` store action. Settings remains accessible from the title bar.
- Added `moon` and `sun` icons (lucide-react) to the shared `Icon` component.

## Test plan
- [ ] Click the icon in the sidebar footer and confirm the theme toggles between light and dark
- [ ] Confirm the tooltip reflects the next state ("Light theme" when dark, "Dark theme" when light)
- [ ] Confirm ⌘⇧L still toggles the theme and the icon updates accordingly
- [ ] Confirm Settings is still reachable from the title bar