### PR TITLE
Clean up custom chat noise and widen chat layout

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -498,8 +498,8 @@ button { cursor: default; }
 .chat { flex: 1; display: flex; flex-direction: column; min-height: 0; }
 .chat-scroll { flex: 1; overflow-y: auto; padding: 28px 0 16px; }
 .chat-inner {
-  max-width: 760px; margin: 0 auto; width: 100%;
-  padding: 0 40px;
+  max-width: 860px; margin: 0 auto; width: 100%;
+  padding: 0 20px;
   display: flex; flex-direction: column; gap: 22px;
 }
 @media (max-width: 1100px) {
@@ -594,9 +594,9 @@ button { cursor: default; }
 }
 
 /* composer */
-.composer-wrap { padding: 0 40px 20px; display: flex; justify-content: center; }
+.composer-wrap { padding: 0 20px 20px; display: flex; justify-content: center; }
 .composer {
-  width: 100%; max-width: 760px;
+  width: 100%; max-width: 860px;
   background: var(--bg-2);
   border: 1px solid var(--bd-strong);
   border-radius: var(--r-lg);

--- a/src/store.ts
+++ b/src/store.ts
@@ -486,7 +486,7 @@ function handleManagedEvent(
 
   if (type === "result") {
     const subtype = String(ev.subtype ?? "");
-    const isError = ev.is_error === true || subtype !== "success";
+    const isError = ev.is_error === true;
     let patches = finalizeStreamingAssistant(state, agentId);
     const working = { ...state, ...patches } as AppState;
     const list = working.managedLogs[agentId] ?? [];
@@ -494,28 +494,24 @@ function handleManagedEvent(
     const hasAssistantText = list.slice(lastUserIdx + 1).some(
       (item) => item.kind === "assistant" && item.text.trim().length > 0,
     );
+    const resultText = typeof ev.result === "string" ? ev.result : "";
     if (isError) {
       patches = mergePatches(
         patches,
         appendItem(working, agentId, {
           kind: "result",
-          text:
-            typeof ev.result === "string"
-              ? ev.result
-              : `Turn failed (${subtype || "error"})`,
+          text: hasAssistantText
+            ? `Turn failed (${subtype || "error"})`
+            : resultText || `Turn failed (${subtype || "error"})`,
           is_error: true,
         }),
       );
-    } else if (
-      !hasAssistantText &&
-      typeof ev.result === "string" &&
-      ev.result.trim()
-    ) {
+    } else if (!hasAssistantText && resultText.trim()) {
       patches = mergePatches(
         patches,
         appendItem(working, agentId, {
           kind: "assistant",
-          text: ev.result,
+          text: resultText,
         }),
       );
     }
@@ -530,21 +526,6 @@ function handleManagedEvent(
       managedBusy: { ...state.managedBusy, [agentId]: false },
       tokens,
     };
-  }
-
-  if (type === "system" && typeof ev.subtype === "string") {
-    if (ev.subtype === "status" && typeof ev.status === "string") {
-      return appendItem(state, agentId, {
-        kind: "system",
-        text: `Claude status: ${ev.status}`,
-      });
-    }
-    if (ev.subtype !== "init") {
-      return appendItem(state, agentId, {
-        kind: "system",
-        text: `Claude ${ev.subtype}`,
-      });
-    }
   }
 
   return {};


### PR DESCRIPTION
## Summary
- Drop the lifecycle `system` event branch in `handleManagedEvent` so `hook_started`, `hook_response`, and `status:*` events no longer pollute the chat log.
- Tighten the `result` handler: flag a turn as errored only on `ev.is_error === true`, and skip duplicating assistant text when an error result fires after a successful stream.
- Widen `.chat-inner` and `.composer` to 860px with 20px horizontal padding so chat and prompt share the same column width.

## Test plan
- [ ] `bun run check` passes
- [ ] Single turn in custom view: only `user` + `assistant` items appear; no "Claude hook_started / status" noise
- [ ] Multi-turn conversation looks the same — no `RESULT`-labeled duplicates
- [ ] Chat and composer are visually the same width at default and narrow viewports