### PR TITLE
Make composer stop interrupt agents

### DIFF
--- a/src-tauri/src/managed_session.rs
+++ b/src-tauri/src/managed_session.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::Arc;
 use std::thread;
+use std::time::Duration;
 
 use serde_json::{json, Value};
 
@@ -98,19 +99,40 @@ impl ManagedSession {
         {
             let child_for_wait = child_arc.clone();
             thread::spawn(move || {
-                let mut taken = match child_for_wait.lock().take() {
-                    Some(c) => c,
-                    None => return,
-                };
-                let exit = match taken.wait() {
-                    Ok(status) => ManagedExit {
-                        success: status.success(),
-                        message: format!("{status}"),
-                    },
-                    Err(e) => ManagedExit {
-                        success: false,
-                        message: format!("wait failed: {e}"),
-                    },
+                let exit = loop {
+                    let status = {
+                        let mut guard = child_for_wait.lock();
+                        let Some(child) = guard.as_mut() else {
+                            return;
+                        };
+                        match child.try_wait() {
+                            Ok(Some(status)) => {
+                                let _ = guard.take();
+                                Some(Ok(status))
+                            }
+                            Ok(None) => None,
+                            Err(e) => {
+                                let _ = guard.take();
+                                Some(Err(e))
+                            }
+                        }
+                    };
+
+                    match status {
+                        Some(Ok(status)) => {
+                            break ManagedExit {
+                                success: status.success(),
+                                message: format!("{status}"),
+                            };
+                        }
+                        Some(Err(e)) => {
+                            break ManagedExit {
+                                success: false,
+                                message: format!("wait failed: {e}"),
+                            };
+                        }
+                        None => thread::sleep(Duration::from_millis(50)),
+                    }
                 };
                 tracing::info!(success = exit.success, message = %exit.message, "managed: exited");
                 on_exit(exit);

--- a/src/app.css
+++ b/src/app.css
@@ -660,6 +660,7 @@ button { cursor: default; }
   text-transform: uppercase;
   color: var(--fg-3);
   font-style: normal;
+  margin-right: 8px;
   margin-bottom: 4px;
   font-weight: 500;
 }
@@ -753,6 +754,13 @@ button { cursor: default; }
 .send:active:not(:disabled) { transform: scale(.94); }
 .send svg { width: 13px; height: 13px; }
 .send:disabled { background: var(--hover); color: var(--fg-3); }
+.send.is-stop {
+  background: var(--danger);
+  color: oklch(0.98 0.005 60);
+}
+.send.is-stop:hover:not(:disabled) {
+  background: oklch(from var(--danger) calc(l + 0.04) c h);
+}
 
 /* dropdown */
 .dd {

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -16,8 +16,11 @@ interface Props {
   placeholder?: string;
   autoFocus?: boolean;
   disabled?: boolean;
+  stopping?: boolean;
   /** Fired on Cmd/Ctrl+Enter or send-button click. */
   onSend: (payload: { text: string; provider: string; thinking: ThinkingBudget }) => void;
+  /** Fired when the composer is showing an active stop control. */
+  onStop?: () => void;
 }
 
 export function Composer({
@@ -27,7 +30,9 @@ export function Composer({
   placeholder,
   autoFocus,
   disabled,
+  stopping = false,
   onSend,
+  onStop,
 }: Props) {
   const features = useAppStore((s) => s.features);
 
@@ -47,11 +52,22 @@ export function Composer({
 
   function send() {
     const trimmed = text.trim();
+    if (stopping) {
+      onStop?.();
+      return;
+    }
     if (!trimmed || disabled) return;
     onSend({ text: trimmed, provider, thinking });
     setText("");
     if (ta.current) ta.current.style.height = "auto";
   }
+
+  function stop() {
+    if (!stopping) return;
+    onStop?.();
+  }
+
+  const sendDisabled = stopping ? !onStop : disabled || !text.trim();
 
   return (
     <div className="composer">
@@ -110,12 +126,12 @@ export function Composer({
         </span>
         <button
           type="button"
-          className="send"
-          disabled={disabled || !text.trim()}
-          onClick={send}
-          aria-label="Send"
+          className={`send ${stopping ? "is-stop" : ""}`}
+          disabled={sendDisabled}
+          onClick={stopping ? stop : send}
+          aria-label={stopping ? "Stop" : "Send"}
         >
-          <Icon name="arrowUp" size={13} />
+          <Icon name={stopping ? "stop" : "arrowUp"} size={13} />
         </button>
       </div>
     </div>

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -20,6 +20,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
     (s) => s.switchInFlight[agent.id] ?? false,
   );
   const send = useAppStore((s) => s.sendUserMessage);
+  const stop = useAppStore((s) => s.stop);
   const loadHistoryTranscript = useAppStore((s) => s.loadHistoryTranscript);
 
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -36,7 +37,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
     ) {
       return;
     }
-    if (log !== undefined && !hasPriorConversation) {
+    if (log !== undefined || !hasPriorConversation) {
       return;
     }
     void loadHistoryTranscript(agent.id);
@@ -82,7 +83,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
               </span>
               <span>Loading transcript…</span>
             </div>
-          ) : items.length === 0 && hasPriorConversation ? (
+          ) : items.length === 0 && hasPriorConversation && !busy ? (
             <div
               className="empty-msg"
               style={{ margin: "40px auto", maxWidth: 360 }}
@@ -117,7 +118,9 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
                   ? "Waiting…"
                   : "Agent is not ready"
           }
+          stopping={busy}
           onSend={({ text }) => send(agent.id, text)}
+          onStop={() => stop(agent.id)}
         />
       </div>
     </div>

--- a/src/store.ts
+++ b/src/store.ts
@@ -735,6 +735,16 @@ export const useAppStore = create<AppState>((set, get) => ({
       };
       set((state) => ({
         workspace: next,
+        managedLogs:
+          e.status === "stopped" && (state.managedBusy[e.agent_id] ?? false)
+            ? {
+                ...state.managedLogs,
+                [e.agent_id]: [
+                  ...(state.managedLogs[e.agent_id] ?? []),
+                  { kind: "system", text: "Agent was interrupted." },
+                ],
+              }
+            : state.managedLogs,
         managedBusy:
           e.status === "error" || e.status === "stopped"
             ? { ...state.managedBusy, [e.agent_id]: false }
@@ -969,10 +979,14 @@ export const useAppStore = create<AppState>((set, get) => ({
         items: transcriptEventsToItems(events),
       });
       // Reset any prior log for this id, then project Claude's saved
-      // JSONL into visible chat messages. Saved session JSONL includes
-      // thinking blocks, tool calls, and tool results; Custom view
-      // history should show the user/assistant conversation.
-      set((state) => replayTranscriptEvents(state, id, events));
+      // JSONL into visible chat messages. If Claude has not written
+      // the JSONL yet, do not erase an active in-memory turn.
+      const items = transcriptEventsToItems(events);
+      set((state) =>
+        items.length === 0 && (state.managedLogs[id]?.length ?? 0) > 0
+          ? {}
+          : replayTranscriptEvents(state, id, events),
+      );
     } catch (e) {
       set({ lastError: String(e) });
     } finally {


### PR DESCRIPTION
Changes the composer send button into a stop control while a custom-view agent is busy and routes it to the existing stop action. Fixes the managed subprocess lifecycle so interruption can actually kill Claude instead of losing the child handle to the wait thread. Adds an interrupted system message, preserves live chat state when transcript JSONL is not available yet, and fixes system-label spacing. Validated with bun run check and cargo test.