### PR TITLE
Display agent diff stats in workspace header

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,18 +1,53 @@
 //! Tauri IPC command handlers — the thin frontend-facing surface.
 
+use serde_json::Value;
 use std::path::PathBuf;
 use std::sync::Arc;
-use serde_json::Value;
 use tauri::{AppHandle, State};
 
 use crate::error::Result;
+use crate::git;
 use crate::names;
 use crate::supervisor::Supervisor;
-use crate::workspace::{AgentRecord, AgentView, TrackedRepo, Workspace};
+use crate::workspace::{
+    repo_worktree_path, AgentRecord, AgentView, DiffStats, TrackedRepo, Workspace,
+};
 
 #[tauri::command]
 pub fn get_workspace(supervisor: State<'_, Arc<Supervisor>>) -> Option<Workspace> {
     supervisor.current_workspace()
+}
+
+#[tauri::command]
+pub async fn get_agent_diff_stats(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+) -> Result<DiffStats> {
+    let record = supervisor.workspace.agent(&agent_id)?;
+    let mut stats = DiffStats::default();
+
+    for repo in &record.repos {
+        let worktree = repo_worktree_path(&agent_id, &repo.subdir)?;
+        let base_ref = repo.parent_branch.as_deref().unwrap_or("HEAD");
+        let diff = match git::worktree_diff_shortstat(&worktree, base_ref).await {
+            Ok(diff) => diff,
+            Err(err) if base_ref != "HEAD" => {
+                tracing::warn!(
+                    error = %err,
+                    agent_id = %agent_id,
+                    subdir = %repo.subdir,
+                    base_ref = %base_ref,
+                    "agent diff: falling back to HEAD"
+                );
+                git::worktree_diff_shortstat(&worktree, "HEAD").await?
+            }
+            Err(err) => return Err(err),
+        };
+        stats.additions = stats.additions.saturating_add(diff.0);
+        stats.deletions = stats.deletions.saturating_add(diff.1);
+    }
+
+    Ok(stats)
 }
 
 /// Allocate a fresh name from the shared place pool for a draft agent.

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -193,6 +193,27 @@ pub async fn diff_shortstat(
     Ok(parse_shortstat(&line))
 }
 
+/// Run `git diff --shortstat <base>` from a live worktree. This compares the
+/// current working tree, including uncommitted changes, against the base ref.
+pub async fn worktree_diff_shortstat(
+    worktree: &Path,
+    base_ref: &str,
+) -> Result<(u32, u32)> {
+    let out = Command::new("git")
+        .current_dir(worktree)
+        .args(["diff", "--shortstat", base_ref])
+        .output()
+        .await?;
+    if !out.status.success() {
+        return Err(Error::Git(format!(
+            "diff --shortstat {base_ref} failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    let line = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    Ok(parse_shortstat(&line))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -52,6 +52,7 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             commands::get_workspace,
+            commands::get_agent_diff_stats,
             commands::add_workspace_repo,
             commands::remove_workspace_repo,
             commands::spawn_agent,

--- a/src/api.ts
+++ b/src/api.ts
@@ -101,6 +101,8 @@ export interface AgentRepoAddedEvent {
 
 export const api = {
   getWorkspace: () => invoke<Workspace | null>("get_workspace"),
+  getAgentDiffStats: (agentId: string) =>
+    invoke<DiffStats>("get_agent_diff_stats", { agentId }),
   addWorkspaceRepo: (repoPath: string) =>
     invoke<Workspace>("add_workspace_repo", { repoPath }),
   removeWorkspaceRepo: (repoPath: string) =>

--- a/src/app.css
+++ b/src/app.css
@@ -512,6 +512,9 @@ button { cursor: default; }
   font-family: var(--font-mono);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
+.center-h .t-diff { color: var(--fg-3); }
+.center-h .t-diff.has-changes .t-diff-add { color: var(--success); }
+.center-h .t-diff.has-changes .t-diff-del { color: var(--danger); }
 
 .view-toggle {
   display: flex;

--- a/src/components/Workspace/WorkspaceHeader.tsx
+++ b/src/components/Workspace/WorkspaceHeader.tsx
@@ -1,4 +1,5 @@
-import type { AgentRecord, AgentStatus } from "../../api";
+import { useEffect, useState } from "react";
+import { api, type AgentRecord, type AgentStatus, type DiffStats } from "../../api";
 import { useAppStore } from "../../store";
 import { Icon } from "../Icon";
 import { IconButton } from "../ui/IconButton";
@@ -21,9 +22,30 @@ export function WorkspaceHeader({ agent }: Props) {
   const toggleLeft = useAppStore((s) => s.toggleLeft);
   const toggleRight = useAppStore((s) => s.toggleRight);
   const now = useMinuteClock();
+  const [diffStats, setDiffStats] = useState<DiffStats | null>(null);
 
   const branch = agent.repos[0]?.branch ?? "—";
   const age = formatAge(agent.created_at, now);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const next = await api.getAgentDiffStats(agent.id);
+        if (!cancelled) setDiffStats(next);
+      } catch {
+        if (!cancelled) setDiffStats(null);
+      }
+    };
+
+    load();
+    const interval = window.setInterval(load, 30_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [agent.id, branch, agent.status]);
 
   return (
     <div className="center-h">
@@ -37,10 +59,10 @@ export function WorkspaceHeader({ agent }: Props) {
       <div className="task">
         <div className="t-name">
           <StatusDot status={agent.status} />
-          <span>{agent.task || agent.name}</span>
+          <span>{agent.name}</span>
         </div>
         <div className="t-meta">
-          {agent.name} · {branch}
+          {branch} · <DiffLabel stats={diffStats} />
           {age && <> · <span>{age}</span></>}
         </div>
       </div>
@@ -59,6 +81,21 @@ export function WorkspaceHeader({ agent }: Props) {
         <Icon name="sidebarR" />
       </IconButton>
     </div>
+  );
+}
+
+function DiffLabel({ stats }: { stats: DiffStats | null }) {
+  const additions = stats ? String(stats.additions) : "--";
+  const deletions = stats ? String(stats.deletions) : "--";
+  const changed = Boolean(
+    stats && (stats.additions > 0 || stats.deletions > 0),
+  );
+
+  return (
+    <span className={`t-diff ${changed ? "has-changes" : ""}`}>
+      <span className="t-diff-add">+{additions}</span>{" "}
+      <span className="t-diff-del">-{deletions}</span>
+    </span>
   );
 }
 


### PR DESCRIPTION
Add diff stats (+/-) display showing agent changes in the workspace header metadata. Includes a new Tauri command to fetch diff stats from agent worktrees, supporting multiple repos per agent with fallback to HEAD if parent branch is unavailable. The header now always displays the agent name with diff stats and branch in the metadata row, removing the task-or-name toggle. Stats refresh every 30 seconds.