### PR TITLE
Add dedicated presenter for Agent (subagent) tool calls

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -647,6 +647,15 @@ button { cursor: default; }
   border-top: 1px solid var(--bd-soft);
 }
 
+.m-agent.m-agent-dim,
+.m-agent.m-agent-dim h1,
+.m-agent.m-agent-dim h2,
+.m-agent.m-agent-dim h3,
+.m-agent.m-agent-dim h4,
+.m-agent.m-agent-dim th {
+  color: var(--fg-2);
+}
+
 .m-reasoning {
   font-size: 13px; line-height: 1.65;
   color: var(--fg-2);

--- a/src/app.css
+++ b/src/app.css
@@ -490,7 +490,7 @@ button { cursor: default; }
 .center-h {
   display: flex; align-items: center; gap: 10px;
   padding: 0 16px;
-  height: 44px; flex-shrink: 0;
+  height: 48px; flex-shrink: 0;
   border-bottom: 1px solid var(--bd-soft);
   background: var(--bg-1);
 }
@@ -814,7 +814,7 @@ button { cursor: default; }
 .right-h {
   display: flex; align-items: center; gap: 2px;
   padding: 0 8px 0 16px;
-  height: 44px; flex-shrink: 0;
+  height: 48px; flex-shrink: 0;
   border-bottom: 1px solid var(--bd-soft);
   background: var(--bg-1);
 }

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -43,6 +43,7 @@ import {
   User,
   Wrench,
   X,
+  Zap,
 } from "lucide-react";
 import { LANDMARK_GLYPHS } from "../data/landmarks";
 
@@ -114,6 +115,7 @@ const ICON_COMPONENTS = {
   archiveRestore: ArchiveRestore,
   moon: Moon,
   sun: Sun,
+  zap: Zap,
 } satisfies Record<string, ComponentType<IconComponentProps>>;
 
 // Originally rendered with fill="currentColor". Setting fill on the root SVG

--- a/src/components/Workspace/messages/presenters/Agent.tsx
+++ b/src/components/Workspace/messages/presenters/Agent.tsx
@@ -1,0 +1,60 @@
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import type { ToolPresenter } from "./types";
+import { getStringField, renderToolResult } from "./util";
+
+export const agentPresenter: ToolPresenter = {
+  icon: "zap",
+  summary: (call) => {
+    const subagentType = getStringField(call.input, "subagent_type");
+    const description = getStringField(call.input, "description");
+    return (
+      <>
+        {subagentType && (
+          <span style={{ color: "var(--fg-3)", marginRight: 8 }}>
+            {subagentType}
+          </span>
+        )}
+        {description}
+      </>
+    );
+  },
+  expanded: (call, result) => {
+    const prompt = getStringField(call.input, "prompt");
+    return (
+      <>
+        {prompt && (
+          <blockquote
+            style={{
+              margin: "0 0 12px",
+              padding: "4px 0 4px 14px",
+              color: "var(--fg-2)",
+              borderLeft: "2px solid var(--accent-line)",
+              fontSize: 13.5,
+              lineHeight: 1.6,
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
+            }}
+          >
+            {prompt}
+          </blockquote>
+        )}
+        {result && (
+          <div
+            className={
+              result.is_error ? "m-agent" : "m-agent m-agent-dim"
+            }
+            style={{
+              color: result.is_error ? "var(--danger)" : undefined,
+              fontSize: 13.5,
+            }}
+          >
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+              {renderToolResult(result.content)}
+            </ReactMarkdown>
+          </div>
+        )}
+      </>
+    );
+  },
+};

--- a/src/components/Workspace/messages/presenters/index.ts
+++ b/src/components/Workspace/messages/presenters/index.ts
@@ -1,4 +1,5 @@
 import type { ToolPresenter } from "./types";
+import { agentPresenter } from "./Agent";
 import { bashPresenter } from "./Bash";
 import { readPresenter } from "./Read";
 import { editPresenter } from "./Edit";
@@ -12,6 +13,7 @@ export type { ToolPresenter, ToolCall, ToolResult } from "./types";
 // that emit different names for the same conceptual tool can either
 // register an alias here or normalize the name in their reducer.
 export const PRESENTERS: Record<string, ToolPresenter> = {
+  Agent: agentPresenter,
   Bash: bashPresenter,
   Read: readPresenter,
   Edit: editPresenter,


### PR DESCRIPTION
## Summary

- New `Agent` tool presenter shows a ⚡ icon, the subagent_type as a subtle label after the tool name, and the description as the collapsed summary.
- Expanded view renders the prompt as a quote block and the result as markdown in dimmed (`--fg-2`) color, with headings/table headers dimmed via a new `m-agent-dim` modifier on the shared markdown styles.
- Registers `Zap` in the icon set and wires the presenter into the `PRESENTERS` registry.

## Test plan

- [ ] Trigger a subagent call and confirm the collapsed row reads `⚡ Agent <subagent_type> <description>` with subagent_type rendered subtly.
- [ ] Expand the row and verify the prompt renders as a quote and the markdown result (including headings) renders in gray.
- [ ] Error results still show in the danger color.