### PR TITLE
Add gh CLI wrapper and wire PR actions in GitPanel

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -210,6 +210,7 @@ pub async fn add_repo_to_agent(
 #[tauri::command]
 pub async fn push_agent(
     supervisor: State<'_, Arc<Supervisor>>,
+    app: AppHandle,
     agent_id: String,
 ) -> Result<()> {
     let record = supervisor.workspace.agent(&agent_id)?;
@@ -217,8 +218,12 @@ pub async fn push_agent(
         .ok_or_else(|| crate::error::Error::Other("agent has no repos".into()))?;
     let worktree = repo_worktree_path(&agent_id, &repo.subdir)?;
     let branch = repo.branch.as_deref()
-        .ok_or_else(|| crate::error::Error::Other("agent has no branch yet".into()))?;
-    git::push(&worktree, branch).await
+        .ok_or_else(|| crate::error::Error::Other("agent has no branch yet".into()))?
+        .to_string();
+    git::push(&worktree, &branch).await?;
+    // After successful push, fetch PR state in background
+    supervisor.inner().fetch_and_emit_pr_state(app, agent_id);
+    Ok(())
 }
 
 /// Pull latest into the primary repo's worktree.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use tauri::{AppHandle, State};
 
 use crate::error::Result;
+use crate::gh::{self, PrState};
 use crate::git;
 use crate::git_state::{self, GitState};
 use crate::names;
@@ -203,6 +204,81 @@ pub async fn add_repo_to_agent(
     let sup = supervisor.inner().clone();
     sup.add_repo_to_agent(app, &agent_id, PathBuf::from(repo_path))
         .await
+}
+
+/// Push the primary repo's current branch to origin.
+#[tauri::command]
+pub async fn push_agent(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+) -> Result<()> {
+    let record = supervisor.workspace.agent(&agent_id)?;
+    let repo = record.repos.first()
+        .ok_or_else(|| crate::error::Error::Other("agent has no repos".into()))?;
+    let worktree = repo_worktree_path(&agent_id, &repo.subdir)?;
+    let branch = repo.branch.as_deref()
+        .ok_or_else(|| crate::error::Error::Other("agent has no branch yet".into()))?;
+    git::push(&worktree, branch).await
+}
+
+/// Pull latest into the primary repo's worktree.
+#[tauri::command]
+pub async fn pull_agent(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+) -> Result<()> {
+    let record = supervisor.workspace.agent(&agent_id)?;
+    let repo = record.repos.first()
+        .ok_or_else(|| crate::error::Error::Other("agent has no repos".into()))?;
+    let worktree = repo_worktree_path(&agent_id, &repo.subdir)?;
+    git::pull(&worktree).await
+}
+
+/// Create a PR for the agent's current branch.
+/// Pass empty title/body to auto-fill from commits.
+#[tauri::command]
+pub async fn create_pr(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+    title: String,
+    body: String,
+) -> Result<PrState> {
+    let record = supervisor.workspace.agent(&agent_id)?;
+    let repo = record.repos.first()
+        .ok_or_else(|| crate::error::Error::Other("agent has no repos".into()))?;
+    let worktree = repo_worktree_path(&agent_id, &repo.subdir)?;
+    let base = repo.parent_branch.as_deref().unwrap_or("main");
+    gh::pr_create(&worktree, &title, &body, base).await
+}
+
+/// Merge the open PR for the agent's current branch.
+#[tauri::command]
+pub async fn merge_pr(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+) -> Result<()> {
+    let record = supervisor.workspace.agent(&agent_id)?;
+    let repo = record.repos.first()
+        .ok_or_else(|| crate::error::Error::Other("agent has no repos".into()))?;
+    let worktree = repo_worktree_path(&agent_id, &repo.subdir)?;
+    gh::pr_merge(&worktree).await
+}
+
+/// Fetch and return the current PR state for the agent's branch.
+#[tauri::command]
+pub async fn get_pr_state(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+) -> Result<Option<PrState>> {
+    let record = supervisor.workspace.agent(&agent_id)?;
+    let repo = record.repos.first()
+        .ok_or_else(|| crate::error::Error::Other("agent has no repos".into()))?;
+    // Only fetch if the agent has a branch
+    if repo.branch.is_none() {
+        return Ok(None);
+    }
+    let worktree = repo_worktree_path(&agent_id, &repo.subdir)?;
+    gh::pr_view(&worktree).await
 }
 
 /// Returns git state for the agent's primary repo.

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -6,6 +6,9 @@ pub enum Error {
     #[error("git command failed: {0}")]
     Git(String),
 
+    #[error("gh command failed: {0}")]
+    Gh(String),
+
     #[error("agent not found: {0}")]
     AgentNotFound(String),
 

--- a/src-tauri/src/gh.rs
+++ b/src-tauri/src/gh.rs
@@ -80,7 +80,7 @@ pub async fn pr_view(worktree: &Path) -> Result<Option<PrState>> {
         if stderr.to_lowercase().contains("no pull requests found") {
             return Ok(None);
         }
-        return Err(Error::Git(stderr.trim().to_string()));
+        return Err(Error::Gh(stderr.trim().to_string()));
     }
 
     let raw: GhPrRaw = serde_json::from_slice(&out.stdout)?;
@@ -92,14 +92,16 @@ pub async fn pr_view(worktree: &Path) -> Result<Option<PrState>> {
 /// If `title` is empty the `--fill` flag is used so `gh` auto-fills the
 /// title and body from the commit log. Otherwise `--title` / `--body` are
 /// passed explicitly.
+///
+/// `gh pr create` does not support `--json`, so we run it for its side-effect
+/// (creating the PR) and then call `pr_view` to fetch the full `PrState`.
 pub async fn pr_create(worktree: &Path, title: &str, body: &str, base: &str) -> Result<PrState> {
-    let mut args = vec!["pr", "create", "--json", "number,url,state,title,mergeable"];
+    let mut args = vec!["pr", "create", "--base", base];
     if title.is_empty() {
         args.push("--fill");
     } else {
         args.extend_from_slice(&["--title", title, "--body", body]);
     }
-    args.extend_from_slice(&["--base", base]);
 
     let out = Command::new("gh")
         .current_dir(worktree)
@@ -108,13 +110,15 @@ pub async fn pr_create(worktree: &Path, title: &str, body: &str, base: &str) -> 
         .await?;
 
     if !out.status.success() {
-        return Err(Error::Git(
+        return Err(Error::Gh(
             String::from_utf8_lossy(&out.stderr).trim().to_string(),
         ));
     }
 
-    let raw: GhPrRaw = serde_json::from_slice(&out.stdout)?;
-    Ok(raw.into())
+    // `gh pr create` only prints the PR URL on success; fetch full state.
+    pr_view(worktree).await?.ok_or_else(|| {
+        Error::Gh("PR was created but could not be fetched".into())
+    })
 }
 
 /// Merge the open PR for the branch checked out in `worktree` using a merge
@@ -127,10 +131,75 @@ pub async fn pr_merge(worktree: &Path) -> Result<()> {
         .await?;
 
     if !out.status.success() {
-        return Err(Error::Git(
+        return Err(Error::Gh(
             String::from_utf8_lossy(&out.stderr).trim().to_string(),
         ));
     }
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pr_raw_open_mergeable() {
+        let raw = GhPrRaw {
+            number: 42,
+            url: "https://github.com/owner/repo/pull/42".into(),
+            state: "OPEN".into(),
+            title: "My PR".into(),
+            mergeable: "MERGEABLE".into(),
+        };
+        let pr = PrState::from(raw);
+        assert!(matches!(pr.state, PrStatus::Open));
+        assert!(pr.mergeable);
+        assert_eq!(pr.number, 42);
+    }
+
+    #[test]
+    fn pr_raw_merged_conflicting() {
+        let raw = GhPrRaw {
+            number: 1,
+            url: "u".into(),
+            state: "MERGED".into(),
+            title: "t".into(),
+            mergeable: "CONFLICTING".into(),
+        };
+        let pr = PrState::from(raw);
+        assert!(matches!(pr.state, PrStatus::Merged));
+        assert!(!pr.mergeable);
+    }
+
+    #[test]
+    fn pr_raw_closed_unknown() {
+        let raw = GhPrRaw {
+            number: 2,
+            url: "u".into(),
+            state: "CLOSED".into(),
+            title: "t".into(),
+            mergeable: "UNKNOWN".into(),
+        };
+        let pr = PrState::from(raw);
+        assert!(matches!(pr.state, PrStatus::Closed));
+        assert!(!pr.mergeable);
+    }
+
+    #[test]
+    fn pr_raw_unknown_state_defaults_to_open() {
+        let raw = GhPrRaw {
+            number: 3,
+            url: "u".into(),
+            state: "SOMETHING_NEW".into(),
+            title: "t".into(),
+            mergeable: "MERGEABLE".into(),
+        };
+        let pr = PrState::from(raw);
+        assert!(matches!(pr.state, PrStatus::Open));
+    }
 }

--- a/src-tauri/src/gh.rs
+++ b/src-tauri/src/gh.rs
@@ -1,0 +1,136 @@
+//! Thin wrapper around the `gh` CLI for GitHub PR operations.
+//!
+//! Follows the same subprocess pattern as `git.rs` — each function
+//! shells out to `gh` and maps exit-code / stderr to typed errors.
+
+use std::path::Path;
+use tokio::process::Command;
+
+use crate::error::{Error, Result};
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PrStatus {
+    Open,
+    Merged,
+    Closed,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct PrState {
+    pub number: u32,
+    pub url: String,
+    pub state: PrStatus,
+    pub title: String,
+    pub mergeable: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Internal deserialization helpers
+// ---------------------------------------------------------------------------
+
+/// Raw shape returned by `gh pr view --json ...`. `gh` uses uppercase
+/// strings for both `state` and `mergeable`.
+#[derive(serde::Deserialize)]
+struct GhPrRaw {
+    number: u32,
+    url: String,
+    state: String,     // "OPEN" | "MERGED" | "CLOSED"
+    title: String,
+    mergeable: String, // "MERGEABLE" | "CONFLICTING" | "UNKNOWN"
+}
+
+impl From<GhPrRaw> for PrState {
+    fn from(raw: GhPrRaw) -> Self {
+        PrState {
+            number: raw.number,
+            url: raw.url,
+            state: match raw.state.as_str() {
+                "MERGED" => PrStatus::Merged,
+                "CLOSED" => PrStatus::Closed,
+                _ => PrStatus::Open,
+            },
+            title: raw.title,
+            mergeable: raw.mergeable == "MERGEABLE",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public async functions
+// ---------------------------------------------------------------------------
+
+/// Fetch the current PR state for the branch checked out in `worktree`.
+///
+/// Returns `Ok(None)` when `gh` exits non-zero with "no pull requests found"
+/// in stderr (i.e. the branch simply has no open PR yet).
+pub async fn pr_view(worktree: &Path) -> Result<Option<PrState>> {
+    let out = Command::new("gh")
+        .current_dir(worktree)
+        .args(["pr", "view", "--json", "number,url,state,title,mergeable"])
+        .output()
+        .await?;
+
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        if stderr.to_lowercase().contains("no pull requests found") {
+            return Ok(None);
+        }
+        return Err(Error::Git(stderr.trim().to_string()));
+    }
+
+    let raw: GhPrRaw = serde_json::from_slice(&out.stdout)?;
+    Ok(Some(raw.into()))
+}
+
+/// Create a PR for the branch checked out in `worktree`.
+///
+/// If `title` is empty the `--fill` flag is used so `gh` auto-fills the
+/// title and body from the commit log. Otherwise `--title` / `--body` are
+/// passed explicitly.
+pub async fn pr_create(worktree: &Path, title: &str, body: &str, base: &str) -> Result<PrState> {
+    let mut args = vec!["pr", "create", "--json", "number,url,state,title,mergeable"];
+    if title.is_empty() {
+        args.push("--fill");
+    } else {
+        args.extend_from_slice(&["--title", title, "--body", body]);
+    }
+    args.extend_from_slice(&["--base", base]);
+
+    let out = Command::new("gh")
+        .current_dir(worktree)
+        .args(&args)
+        .output()
+        .await?;
+
+    if !out.status.success() {
+        return Err(Error::Git(
+            String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        ));
+    }
+
+    let raw: GhPrRaw = serde_json::from_slice(&out.stdout)?;
+    Ok(raw.into())
+}
+
+/// Merge the open PR for the branch checked out in `worktree` using a merge
+/// commit and the `--auto` flag (merges as soon as all checks pass).
+pub async fn pr_merge(worktree: &Path) -> Result<()> {
+    let out = Command::new("gh")
+        .current_dir(worktree)
+        .args(["pr", "merge", "--merge", "--auto"])
+        .output()
+        .await?;
+
+    if !out.status.success() {
+        return Err(Error::Git(
+            String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        ));
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -312,6 +312,39 @@ pub async fn worktree_add_branch(
     Ok(())
 }
 
+/// Push the current branch to `origin`. Uses `-u` to set the upstream
+/// tracking ref on the first push.
+pub async fn push(worktree: &Path, branch: &str) -> Result<()> {
+    let out = Command::new("git")
+        .current_dir(worktree)
+        .args(["push", "-u", "origin", branch])
+        .output()
+        .await?;
+    if !out.status.success() {
+        return Err(Error::Git(format!(
+            "push failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
+/// Pull latest from the tracking remote branch.
+pub async fn pull(worktree: &Path) -> Result<()> {
+    let out = Command::new("git")
+        .current_dir(worktree)
+        .args(["pull"])
+        .output()
+        .await?;
+    if !out.status.success() {
+        return Err(Error::Git(format!(
+            "pull failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
 /// Force-delete a local branch. Returns Ok even if the branch never
 /// existed in the first place — that's exactly the state the caller
 /// usually wants to converge on. Errors only for genuine git failures

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -330,6 +330,7 @@ pub async fn push(worktree: &Path, branch: &str) -> Result<()> {
 }
 
 /// Pull latest from the tracking remote branch.
+/// Requires `push -u` to have been called first to establish an upstream.
 pub async fn pull(worktree: &Path) -> Result<()> {
     let out = Command::new("git")
         .current_dir(worktree)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod agent;
 mod branding;
 mod commands;
 mod error;
+mod gh;
 mod git;
 mod git_state;
 mod managed_session;
@@ -71,6 +72,11 @@ pub fn run() {
             commands::add_repo_to_agent,
             commands::allocate_draft_name,
             commands::get_git_state,
+            commands::push_agent,
+            commands::pull_agent,
+            commands::create_pr,
+            commands::merge_pr,
+            commands::get_pr_state,
         ])
         .run(tauri::generate_context!())
         .expect("error while running quorum");

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -71,6 +71,12 @@ pub struct GitStateChangedPayload {
     pub state: GitState,
 }
 
+#[derive(Clone, serde::Serialize)]
+pub struct PrStateChangedPayload {
+    pub agent_id: String,
+    pub state: Option<crate::gh::PrState>,
+}
+
 const WATCHDOG_TICK: Duration = Duration::from_millis(500);
 const SPAWN_TIMEOUT: Duration = Duration::from_secs(15);
 
@@ -919,6 +925,35 @@ impl Supervisor {
         Ok(out)
     }
 
+    /// Fetch the current PR state for an agent's primary repo and emit
+    /// a `pr:state_changed` event. Runs as a background task — never blocks the caller.
+    pub fn fetch_and_emit_pr_state(&self, app: AppHandle, agent_id: String) {
+        let workspace = self.workspace.clone();
+        tauri::async_runtime::spawn(async move {
+            let record = match workspace.agent(&agent_id) {
+                Ok(r) => r,
+                Err(_) => return,
+            };
+            let repo = match record.repos.first() {
+                Some(r) => r,
+                None => return,
+            };
+            // Only fetch if there's a branch (agent may still be on detached HEAD)
+            if repo.branch.is_none() {
+                return;
+            }
+            let worktree = match crate::workspace::repo_worktree_path(&agent_id, &repo.subdir) {
+                Ok(p) => p,
+                Err(_) => return,
+            };
+            let state = crate::gh::pr_view(&worktree).await.unwrap_or(None);
+            let _ = app.emit(
+                "pr:state_changed",
+                PrStateChangedPayload { agent_id, state },
+            );
+        });
+    }
+
     pub async fn discard_agent(self: Arc<Self>, agent_id: &str) -> Result<()> {
         let record = self.workspace.agent(agent_id).ok();
         let repos = record.as_ref().map(|r| r.repos.clone()).unwrap_or_default();
@@ -1349,7 +1384,10 @@ fn transition_active(
         },
     );
     if matches!(changed, Ok(true)) {
-        emit_status(app, agent_id, new, None);
+        emit_status(app, agent_id, new.clone(), None);
+        if matches!(new, AgentStatus::Idle) {
+            sup.fetch_and_emit_pr_state(app.clone(), agent_id.to_string());
+        }
     }
 }
 
@@ -1400,6 +1438,9 @@ fn apply_exit_if_current(
         },
     );
     if matches!(changed, Ok(true)) {
+        if matches!(status, AgentStatus::Idle) {
+            sup.fetch_and_emit_pr_state(app.clone(), agent_id.to_string());
+        }
         emit_status(app, agent_id, status, err);
     }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -133,6 +133,21 @@ export interface GitStateChangedEvent {
   state: GitState;
 }
 
+export type PrStatus = "open" | "merged" | "closed";
+
+export interface PrState {
+  number: number;
+  url: string;
+  state: PrStatus;
+  title: string;
+  mergeable: boolean;
+}
+
+export interface PrStateChangedEvent {
+  agent_id: string;
+  state: PrState | null;
+}
+
 export const api = {
   getWorkspace: () => invoke<Workspace | null>("get_workspace"),
   getAgentDiffStats: (agentId: string) =>
@@ -171,6 +186,13 @@ export const api = {
     invoke<string>("allocate_draft_name", { used }),
   getGitState: (agentId: string) =>
     invoke<GitState | null>("get_git_state", { agentId }),
+  getPrState: (agentId: string) =>
+    invoke<PrState | null>("get_pr_state", { agentId }),
+  pushAgent: (agentId: string) => invoke<void>("push_agent", { agentId }),
+  pullAgent: (agentId: string) => invoke<void>("pull_agent", { agentId }),
+  createPr: (agentId: string, title: string, body: string) =>
+    invoke<PrState>("create_pr", { agentId, title, body }),
+  mergePr: (agentId: string) => invoke<void>("merge_pr", { agentId }),
 };
 
 export function onAgentOutput(
@@ -227,4 +249,10 @@ export function onGitStateChanged(
   cb: (e: GitStateChangedEvent) => void,
 ): Promise<UnlistenFn> {
   return listen<GitStateChangedEvent>("git:state_changed", (event) => cb(event.payload));
+}
+
+export function onPrStateChanged(
+  cb: (e: PrStateChangedEvent) => void,
+): Promise<UnlistenFn> {
+  return listen<PrStateChangedEvent>("pr:state_changed", (event) => cb(event.payload));
 }

--- a/src/components/RightPanel/GitPanel.tsx
+++ b/src/components/RightPanel/GitPanel.tsx
@@ -52,7 +52,7 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
         void createPr(agent.id, "", "");
         break;
       case "pr-open":
-        if (prState?.url) window.open(prState.url);
+        if (prState?.url) window.open(prState.url, "_blank");
         break;
       case "merged":
         void archive(agent.id);
@@ -78,7 +78,7 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
         void mergePr(agent.id);
         break;
       case "view-pr":
-        if (prState?.url) window.open(prState.url);
+        if (prState?.url) window.open(prState.url, "_blank");
         break;
       case "archive":
         void archive(agent.id);
@@ -128,7 +128,7 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
         <div className="actions">
           <button
             type="button"
-            disabled={panelState === "loading"}
+            disabled={panelState === "loading" || panelState === "changes" || panelState === "conflicts"}
             className={`btn-t ${primary.danger ? "outline" : "primary"}`}
             style={
               primary.danger

--- a/src/components/RightPanel/GitPanel.tsx
+++ b/src/components/RightPanel/GitPanel.tsx
@@ -1,15 +1,17 @@
 import { useEffect, useState } from "react";
-import type { AgentRecord, GitState } from "../../api";
+import type { AgentRecord, GitState, PrState } from "../../api";
 import { useAppStore } from "../../store";
 import { Icon } from "../Icon";
 import { IconButton } from "../ui/IconButton";
 import { primaryFor, secondaryFor, type GitPanelState } from "./primaryActions";
 
-function deriveState(s: GitState | null): GitPanelState {
-  if (!s) return "loading";
-  if (s.files.some((f) => f.kind === "conflicted")) return "conflicts";
-  if (s.files.length > 0) return "changes";
-  if (s.ahead > 0) return "pushed";
+function deriveState(git: GitState | null, pr: PrState | null): GitPanelState {
+  if (!git) return "loading";
+  if (git.files.some((f) => f.kind === "conflicted")) return "conflicts";
+  if (pr?.state === "merged") return "merged";
+  if (pr?.state === "open") return "pr-open";
+  if (git.files.length > 0) return "changes";
+  if (git.ahead > 0) return "pushed";
   return "clean";
 }
 
@@ -17,13 +19,21 @@ function deriveState(s: GitState | null): GitPanelState {
  *  The panel is feature-flagged off by default in settings. */
 export function GitPanel({ agent }: { agent: AgentRecord }) {
   const gitState = useAppStore((s) => s.gitStates[agent.id] ?? null);
+  const prState = useAppStore((s) => s.prStates[agent.id] ?? null);
   const fetchGitState = useAppStore((s) => s.fetchGitState);
+  const fetchPrState = useAppStore((s) => s.fetchPrState);
+  const pushAgent = useAppStore((s) => s.pushAgent);
+  const pullAgent = useAppStore((s) => s.pullAgent);
+  const createPr = useAppStore((s) => s.createPr);
+  const mergePr = useAppStore((s) => s.mergePr);
+  const archive = useAppStore((s) => s.archive);
 
   useEffect(() => {
     void fetchGitState(agent.id);
-  }, [agent.id, fetchGitState]);
+    void fetchPrState(agent.id);
+  }, [agent.id, fetchGitState, fetchPrState]);
 
-  const panelState = deriveState(gitState);
+  const panelState = deriveState(gitState, prState);
 
   const [selected, setSelected] = useState<string | null>(null);
 
@@ -35,6 +45,48 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
     });
   }, [gitState]);
   const [moreOpen, setMoreOpen] = useState(false);
+
+  function handlePrimaryClick() {
+    switch (panelState) {
+      case "pushed":
+        void createPr(agent.id, "", "");
+        break;
+      case "pr-open":
+        if (prState?.url) window.open(prState.url);
+        break;
+      case "merged":
+        void archive(agent.id);
+        break;
+      default:
+        break;
+    }
+  }
+
+  function handleSecondaryClick(key: string) {
+    setMoreOpen(false);
+    switch (key) {
+      case "push":
+        void pushAgent(agent.id);
+        break;
+      case "pull":
+        void pullAgent(agent.id);
+        break;
+      case "open-pr":
+        void createPr(agent.id, "", "");
+        break;
+      case "merge":
+        void mergePr(agent.id);
+        break;
+      case "view-pr":
+        if (prState?.url) window.open(prState.url);
+        break;
+      case "archive":
+        void archive(agent.id);
+        break;
+      default:
+        break;
+    }
+  }
 
   const primary = primaryFor(panelState);
   const secondary = secondaryFor(panelState);
@@ -83,6 +135,7 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
                 ? { borderColor: "var(--danger)", color: "var(--danger)" }
                 : undefined
             }
+            onClick={handlePrimaryClick}
           >
             <Icon name={primary.icon} />
             {primary.label}
@@ -103,7 +156,7 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
                     style={{ top: "calc(100% + 6px)", right: 0, minWidth: 200 }}
                   >
                     {secondary.map((s) => (
-                      <div key={s.label} className="dd-item" onClick={() => setMoreOpen(false)}>
+                      <div key={s.key} className="dd-item" onClick={() => handleSecondaryClick(s.key)}>
                         <div className="di-i"><Icon name={s.icon} size={12} /></div>
                         <span className="di-l">{s.label}</span>
                         {s.kbd && <span className="di-m">{s.kbd}</span>}

--- a/src/components/RightPanel/primaryActions.ts
+++ b/src/components/RightPanel/primaryActions.ts
@@ -14,6 +14,7 @@ export interface PrimaryAction {
 }
 
 export interface SecondaryAction {
+  key: string;
   label: string;
   icon: IconName;
   kbd?: string;
@@ -43,31 +44,40 @@ export function secondaryFor(state: GitPanelState): SecondaryAction[] {
   switch (state) {
     case "changes":
       return [
-        { label: "Commit only", icon: "commit", kbd: "⌘K" },
-        { label: "Push only", icon: "push" },
-        { label: "Stash changes", icon: "inbox" },
-        { label: "Discard all", icon: "trash" },
+        { key: "commit", label: "Commit only", icon: "commit", kbd: "⌘K" },
+        { key: "push", label: "Push only", icon: "push" },
+        { key: "stash", label: "Stash changes", icon: "inbox" },
+        { key: "discard", label: "Discard all", icon: "trash" },
       ];
     case "pushed":
       return [
-        { label: "Open draft PR", icon: "pr" },
-        { label: "Push more commits", icon: "push" },
+        { key: "open-pr", label: "Open draft PR", icon: "pr" },
+        { key: "push", label: "Push more commits", icon: "push" },
+        { key: "pull", label: "Pull", icon: "inbox" },
       ];
     case "pr-open":
       return [
-        { label: "Push more commits", icon: "push" },
-        { label: "Request review", icon: "user" },
-        { label: "View on GitHub", icon: "github" },
+        { key: "push", label: "Push more commits", icon: "push" },
+        { key: "pull", label: "Pull", icon: "inbox" },
+        { key: "merge", label: "Merge PR", icon: "merge" },
+        { key: "view-pr", label: "View on GitHub", icon: "github" },
+        { key: "request-review", label: "Request review", icon: "user" },
       ];
     case "conflicts":
       return [
-        { label: "Abort merge", icon: "close" },
-        { label: "View on GitHub", icon: "github" },
+        { key: "abort", label: "Abort merge", icon: "close" },
+        { key: "view-pr", label: "View on GitHub", icon: "github" },
       ];
     case "merged":
       return [
-        { label: "Delete branch", icon: "trash" },
-        { label: "Start new agent", icon: "plus" },
+        { key: "archive", label: "Archive workspace", icon: "check" },
+        { key: "delete-branch", label: "Delete branch", icon: "trash" },
+        { key: "start-new", label: "Start new agent", icon: "plus" },
+      ];
+    case "clean":
+      return [
+        { key: "push", label: "Push", icon: "push" },
+        { key: "pull", label: "Pull", icon: "inbox" },
       ];
     default:
       return [];

--- a/src/store.ts
+++ b/src/store.ts
@@ -761,6 +761,9 @@ export const useAppStore = create<AppState>((set, get) => ({
   fetchPrState: async (agentId) => {
     try {
       const state = await api.getPrState(agentId);
+      // Always write (including null) to distinguish "confirmed: no PR" from
+      // "not yet fetched" (absent key). Unlike fetchGitState which guards the
+      // write, PR state being null is meaningful.
       set((s) => ({ prStates: { ...s.prStates, [agentId]: state } }));
     } catch {
       // non-fatal

--- a/src/store.ts
+++ b/src/store.ts
@@ -9,10 +9,12 @@ import {
   onAgentTask,
   onAgentView,
   onGitStateChanged,
+  onPrStateChanged,
   onWorkspaceChanged,
   type AgentRecord,
   type AgentView,
   type GitState,
+  type PrState,
   type Workspace,
 } from "./api";
 import { DEFAULT_PROVIDER_ID } from "./data/providers";
@@ -168,6 +170,13 @@ interface AppState {
   gitStates: Record<string, GitState>;
   /** Fetch git state for an agent immediately (initial load before watcher fires). */
   fetchGitState: (agentId: string) => Promise<void>;
+  /** PR state per agent, keyed by agent_id. Updated by the pr:state_changed watcher event. */
+  prStates: Record<string, PrState | null>;
+  fetchPrState: (agentId: string) => Promise<void>;
+  pushAgent: (agentId: string) => Promise<void>;
+  pullAgent: (agentId: string) => Promise<void>;
+  createPr: (agentId: string, title: string, body: string) => Promise<PrState | null>;
+  mergePr: (agentId: string) => Promise<void>;
 
   drafts: DraftAgent[];
   activeDraftId: string | null;
@@ -338,6 +347,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   switchInFlight: {},
   tokens: {},
   gitStates: {},
+  prStates: {},
 
   drafts: [],
   activeDraftId: null,
@@ -479,6 +489,10 @@ export const useAppStore = create<AppState>((set, get) => ({
 
     await onGitStateChanged((e) => {
       set((s) => ({ gitStates: { ...s.gitStates, [e.agent_id]: e.state } }));
+    });
+
+    await onPrStateChanged((e) => {
+      set((s) => ({ prStates: { ...s.prStates, [e.agent_id]: e.state } }));
     });
 
     const workspace = await api.getWorkspace();
@@ -629,6 +643,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         const { [id]: _droppedBusy, ...restBusy } = s.managedBusy;
         const { [id]: _droppedTokens, ...restTokens } = s.tokens;
         const { [id]: _droppedGitState, ...restGitStates } = s.gitStates;
+        const { [id]: _droppedPrState, ...restPrStates } = s.prStates;
         return {
           workspace: fresh,
           selectedAgentId: s.selectedAgentId === id ? null : s.selectedAgentId,
@@ -638,6 +653,7 @@ export const useAppStore = create<AppState>((set, get) => ({
           managedBusy: restBusy,
           tokens: restTokens,
           gitStates: restGitStates,
+          prStates: restPrStates,
         };
       });
     } catch (e) {
@@ -659,6 +675,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         const { [id]: _b, ...restBusy } = s.managedBusy;
         const { [id]: _t, ...restTokens } = s.tokens;
         const { [id]: _g, ...restGitStates } = s.gitStates;
+        const { [id]: _p, ...restPrStates } = s.prStates;
         return {
           workspace: fresh ?? s.workspace,
           selectedAgentId: s.selectedAgentId === id ? null : s.selectedAgentId,
@@ -668,6 +685,7 @@ export const useAppStore = create<AppState>((set, get) => ({
           managedBusy: restBusy,
           tokens: restTokens,
           gitStates: restGitStates,
+          prStates: restPrStates,
         };
       });
     } catch (e) {
@@ -737,6 +755,52 @@ export const useAppStore = create<AppState>((set, get) => ({
       }
     } catch {
       // non-fatal — watcher will provide updates
+    }
+  },
+
+  fetchPrState: async (agentId) => {
+    try {
+      const state = await api.getPrState(agentId);
+      set((s) => ({ prStates: { ...s.prStates, [agentId]: state } }));
+    } catch {
+      // non-fatal
+    }
+  },
+
+  pushAgent: async (agentId) => {
+    try {
+      await api.pushAgent(agentId);
+      // pr:state_changed event will update prStates automatically
+    } catch (e) {
+      set({ lastError: String(e) });
+    }
+  },
+
+  pullAgent: async (agentId) => {
+    try {
+      await api.pullAgent(agentId);
+    } catch (e) {
+      set({ lastError: String(e) });
+    }
+  },
+
+  createPr: async (agentId, title, body) => {
+    try {
+      const pr = await api.createPr(agentId, title, body);
+      set((s) => ({ prStates: { ...s.prStates, [agentId]: pr } }));
+      return pr;
+    } catch (e) {
+      set({ lastError: String(e) });
+      return null;
+    }
+  },
+
+  mergePr: async (agentId) => {
+    try {
+      await api.mergePr(agentId);
+      // pr:state_changed event will update prStates
+    } catch (e) {
+      set({ lastError: String(e) });
     }
   },
 


### PR DESCRIPTION
Adds `gh.rs` wrapping the GitHub CLI for `pr_view`, `pr_create`, and `pr_merge`, plus `push`/`pull` in `git.rs`. Five new Tauri commands (`push_agent`, `pull_agent`, `create_pr`, `merge_pr`, `get_pr_state`) are registered and wired into the supervisor, which emits `pr:state_changed` after pushes and when an agent goes idle. The frontend gains `PrState`/`PrStatus` types, a `prStates` record in the Zustand store with event subscription and cleanup, and a fully-wired `GitPanel` where `deriveState` now incorporates PR state to drive `pr-open`/`merged` panel modes and their action buttons.