### PR TITLE
Run panel: UI implementation (static pass)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -198,6 +198,8 @@ button { cursor: default; }
 .btn-t svg { width: 12px; height: 12px; opacity: .8; }
 .btn-t.outline { border-color: var(--bd); background: var(--bg-1); }
 .btn-t.outline:hover { border-color: var(--fg-3); background: var(--hover); }
+.btn-t.ghost { border-color: var(--bd-soft); }
+.btn-t.ghost:hover { border-color: var(--bd); }
 .btn-t.primary {
   background: var(--accent);
   color: oklch(0.16 0.02 60);
@@ -911,6 +913,244 @@ button { cursor: default; }
 .git-commit .cm-foot { display: flex; gap: 4px; margin-top: 10px; align-items: center; }
 .git-commit .cm-foot .grow { flex: 1; }
 .git-commit .cm-foot .hint { font-size: 10.5px; color: var(--fg-3); }
+
+/* run panel — styles ported from Quorum v2 prototype */
+.run-wrap { flex: 1; display: flex; flex-direction: column; min-height: 0; position: relative; }
+
+.run-bar.v2 {
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--bd-soft);
+  background: var(--bg-1);
+  position: relative; z-index: 2;
+  flex-shrink: 0;
+}
+
+.run-bar.v2 .run-go {
+  position: relative; flex-shrink: 0;
+  width: 26px; height: 26px;
+  border-radius: 50%;
+  border: 0;
+  display: inline-flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  transition: transform .1s, background .12s, color .12s;
+}
+.run-bar.v2 .run-go svg { display: block; position: relative; z-index: 1; }
+.run-bar.v2 .run-go:hover  { transform: scale(1.05); }
+.run-bar.v2 .run-go:active { transform: scale(0.96); }
+.run-bar.v2 .run-go.live    { background: var(--success); color: oklch(0.18 0.04 145); }
+.run-bar.v2 .run-go.stopped { background: var(--bg-2); color: var(--fg-2); border: 1px solid var(--bd-soft); }
+.run-bar.v2 .run-go.stopped:hover { color: var(--success); border-color: color-mix(in oklch, var(--success), transparent 50%); }
+
+.run-bar.v2 .run-cmd {
+  flex: 1; min-width: 0;
+  display: inline-flex; align-items: center; gap: 7px;
+  padding: 4px 9px;
+  border-radius: var(--r-sm);
+  background: var(--bg-0);
+  border: 1px solid var(--bd-soft);
+  font-family: var(--font-mono); font-size: 11.5px; color: var(--fg-0);
+  overflow: hidden;
+}
+.run-bar.v2 .run-cmd .p { color: var(--accent); flex-shrink: 0; }
+.run-bar.v2 .run-cmd .cmd-text { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+.run-bar.v2 .run-link {
+  flex-shrink: 0;
+  display: inline-flex; align-items: center; gap: 3px;
+  height: 22px; padding: 0 8px;
+  border-radius: var(--r-sm);
+  font-family: var(--font-mono); font-size: 11px; color: var(--fg-1);
+  text-decoration: none;
+  border: 1px solid var(--bd-soft);
+  background: var(--bg-2);
+  transition: background .12s, border-color .12s, color .12s;
+}
+.run-bar.v2 .run-link:hover {
+  color: var(--accent);
+  border-color: color-mix(in oklch, var(--accent), transparent 65%);
+  background: color-mix(in oklch, var(--accent), transparent 92%);
+}
+.run-bar.v2 .run-link .colon { color: var(--fg-3); margin-right: -1px; }
+.run-bar.v2 .run-link .port  { color: var(--fg-0); }
+.run-bar.v2 .run-link svg { opacity: 0.55; margin-left: 2px; }
+.run-bar.v2 .run-link.disabled { opacity: 0.4; pointer-events: none; }
+
+.run-bar.v2 .run-gear {
+  flex-shrink: 0; position: relative;
+  width: 26px; height: 26px;
+  border-radius: var(--r-sm);
+  background: transparent; border: 0;
+  color: var(--fg-2);
+  display: inline-flex; align-items: center; justify-content: center;
+  transition: background .12s, color .12s;
+}
+.run-bar.v2 .run-gear:hover  { background: var(--hover);    color: var(--fg-0); }
+.run-bar.v2 .run-gear.active { background: var(--selected); color: var(--fg-0); }
+.run-bar.v2 .run-gear .dot {
+  position: absolute; top: 4px; right: 4px;
+  width: 5px; height: 5px; border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 1.5px var(--bg-1);
+}
+
+.run-logs {
+  flex: 1; overflow-y: auto; min-height: 0;
+  font-family: var(--font-mono); font-size: 11.5px; line-height: 1.65;
+  padding: 10px 18px 16px;
+  color: var(--fg-1);
+  white-space: pre-wrap; word-break: break-word;
+}
+.run-logs .p { color: var(--accent); }
+.run-logs .d { color: var(--fg-3); }
+.run-logs .s { color: var(--success); }
+.run-logs .w { color: var(--warn); }
+.run-logs .e { color: var(--danger); }
+.run-logs .i { color: var(--info); }
+.run-logs .b { font-weight: 600; color: var(--fg-0); }
+
+@keyframes term-blink { 50% { opacity: 0; } }
+.term-cursor {
+  display: inline-block; width: 7px; height: 14px;
+  vertical-align: text-bottom;
+  background: var(--accent);
+  animation: term-blink 1s steps(2) infinite;
+}
+
+/* run settings sheet */
+@keyframes rs-fade { from { opacity: 0; } }
+@keyframes rs-drop { from { transform: translateY(-8px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+
+.run-sheet-scrim {
+  position: absolute; top: 41px; left: 0; right: 0; bottom: 0;
+  background: color-mix(in oklch, var(--bg-0), transparent 35%);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  z-index: 5;
+  animation: rs-fade .14s var(--ease);
+}
+.run-sheet {
+  position: absolute; top: 41px; left: 8px; right: 8px;
+  max-height: calc(100% - 49px);
+  display: flex; flex-direction: column;
+  background: var(--bg-1);
+  border: 1px solid var(--bd);
+  border-radius: var(--r-md);
+  box-shadow: 0 22px 56px rgba(0,0,0,.45),
+              0 0 0 1px color-mix(in oklch, var(--accent), transparent 92%) inset;
+  z-index: 6;
+  overflow: hidden;
+  animation: rs-drop .18s var(--ease);
+}
+.theme-light .run-sheet { box-shadow: 0 18px 48px rgba(0,0,0,.18); }
+
+.run-sheet-h {
+  display: flex; align-items: flex-start; gap: 10px;
+  padding: 14px 14px 12px;
+  border-bottom: 1px solid var(--bd-soft);
+  flex-shrink: 0;
+}
+.rsh-left { flex: 1; min-width: 0; }
+.rsh-title { font-size: 13px; font-weight: 600; color: var(--fg-0); letter-spacing: -0.005em; }
+.rsh-sub { margin-top: 3px; font-size: 11.5px; color: var(--fg-2); }
+.rsh-sub code {
+  font-family: var(--font-mono); font-size: 11px; color: var(--fg-1);
+  padding: 0 4px;
+  background: var(--bg-2); border: 1px solid var(--bd-soft); border-radius: 3px;
+}
+.run-sheet-x {
+  flex-shrink: 0; width: 22px; height: 22px;
+  border-radius: var(--r-xs); background: transparent; border: 0;
+  color: var(--fg-3);
+  display: inline-flex; align-items: center; justify-content: center;
+  transition: background .1s, color .1s;
+}
+.run-sheet-x:hover { background: var(--hover); color: var(--fg-0); }
+
+.run-sheet-body { flex: 1; overflow-y: auto; padding: 6px 14px 14px; }
+.rs-group { margin-top: 14px; }
+.rs-group-h {
+  font-size: 9.5px; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--fg-3); padding: 0 2px 6px;
+}
+.rs-group-rows {
+  display: flex; flex-direction: column;
+  gap: 1px;
+  background: var(--bd-soft);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-sm);
+  overflow: hidden;
+}
+.rs-row {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 12px;
+  background: var(--bg-1);
+  transition: background .1s;
+  position: relative;
+}
+.rs-row:hover { background: var(--bg-2); }
+.rs-row.overridden { background: color-mix(in oklch, var(--accent), var(--bg-1) 92%); }
+.rs-row.overridden::before {
+  content: ""; position: absolute;
+  left: 0; top: 0; bottom: 0; width: 2px;
+  background: var(--accent);
+}
+.rs-row-l { flex: 1; min-width: 0; }
+.rs-label { font-size: 12.5px; color: var(--fg-0); font-weight: 500; }
+.rs-source {
+  margin-top: 2px; font-size: 10.5px; color: var(--fg-3);
+  display: inline-flex; align-items: center; gap: 4px;
+}
+.rs-source code { font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-2); }
+.rs-source .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--accent); }
+.rs-row.overridden .rs-source { color: var(--accent); }
+.rs-row-r { display: inline-flex; align-items: center; gap: 6px; flex-shrink: 0; }
+.rs-value {
+  display: inline-flex; align-items: center; gap: 6px;
+  max-width: 220px; height: 28px; padding: 0 9px;
+  background: var(--bg-0); border: 1px solid var(--bd-soft); border-radius: var(--r-sm);
+  font-family: var(--font-mono); font-size: 11.5px; color: var(--fg-0);
+  cursor: text;
+  transition: border-color .1s, background .1s;
+}
+.rs-value:hover { border-color: var(--bd); background: var(--bg-2); }
+.rs-value .rsv-text { max-width: 180px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rs-value svg { color: var(--fg-3); flex-shrink: 0; }
+.rs-input {
+  width: 220px; height: 28px; padding: 0 9px;
+  background: var(--bg-0); border: 1px solid var(--accent); outline: none;
+  border-radius: var(--r-sm);
+  font-family: var(--font-mono); font-size: 11.5px; color: var(--fg-0);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent), transparent 85%);
+}
+.rs-revert {
+  width: 22px; height: 22px; border-radius: var(--r-xs);
+  background: transparent; border: 0; color: var(--fg-3);
+  display: inline-flex; align-items: center; justify-content: center;
+  transition: background .1s, color .1s, transform .1s;
+}
+.rs-revert:hover { background: var(--hover); color: var(--fg-0); transform: rotate(-180deg); }
+
+.run-sheet-f {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 12px; padding: 10px 14px;
+  border-top: 1px solid var(--bd-soft);
+  background: var(--bg-1);
+  flex-shrink: 0;
+}
+.rsf-status {
+  font-size: 11.5px; color: var(--fg-2);
+  min-width: 0; flex: 1;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.rsf-actions { display: inline-flex; gap: 6px; flex-shrink: 0; }
+.run-sheet-f .btn-t.ghost {
+  background: transparent; border: 0; color: var(--fg-2);
+  font-size: 11.5px; padding: 6px 10px; border-radius: var(--r-sm);
+}
+.run-sheet-f .btn-t.ghost:hover:not(:disabled) { background: var(--hover); color: var(--fg-0); }
+.run-sheet-f .btn-t.ghost:disabled { opacity: .4; cursor: not-allowed; }
+.run-sheet-f .btn-t.primary:disabled { opacity: .4; pointer-events: none; }
 
 /* empty workspace (draft) */
 .empty-wrap {

--- a/src/components/RightPanel/RunPanel.tsx
+++ b/src/components/RightPanel/RunPanel.tsx
@@ -1,0 +1,143 @@
+import { useState } from "react";
+import type { AgentRecord } from "../../api";
+import { Icon } from "../Icon";
+import { RunSettingsSheet, type SetupRow } from "./RunSettingsSheet";
+
+// ── Static mock data (UI pass — replaced by real data in wiring PR) ──────────
+// Rows match the Quorum v2 prototype exactly: 3 groups, 8 rows.
+// Each entry carries an inferred value + WHERE it was detected from, so the
+// run-settings sheet can surface that as the "auto-detected" baseline and the
+// user can override any one of them.
+
+const RUN_SETUP: SetupRow[] = [
+  { id: "pm",      group: "Environment", key: "Package manager", value: "pnpm 9.7.1",   source: "package.json · packageManager" },
+  { id: "node",    group: "Environment", key: "Node version",    value: "v22.4.0",      source: ".nvmrc" },
+  { id: "install", group: "Scripts",     key: "Install",         value: "pnpm install", source: "convention (pm + install)" },
+  { id: "dev",     group: "Scripts",     key: "Dev",             value: "pnpm dev",     source: "package.json · scripts.dev" },
+  { id: "build",   group: "Scripts",     key: "Build",           value: "pnpm build",   source: "package.json · scripts.build" },
+  { id: "test",    group: "Scripts",     key: "Test",            value: "pnpm test",    source: "package.json · scripts.test" },
+  { id: "port",    group: "Server",      key: "Port",            value: "3000",         source: "next.config.js" },
+  { id: "env",     group: "Server",      key: "Env file",        value: ".env.local",   source: "auto-detected" },
+];
+
+interface LogEntry { c: string; t: string; }
+
+const RUN_LOGS: LogEntry[] = [
+  { c: "term-dim",     t: "$ pnpm dev" },
+  { c: "",             t: "" },
+  { c: "term-bold",    t: "  ▲ Next.js 15.4.0" },
+  { c: "term-dim",     t: "  - Local:        http://localhost:3000" },
+  { c: "term-dim",     t: "  - Workspace:    ~/dev/atlas-web/.quorum/patagonia" },
+  { c: "term-dim",     t: "  - Environments: .env.local" },
+  { c: "",             t: "" },
+  { c: "term-success", t: " ✓ Ready in 1.4s" },
+  { c: "term-dim",     t: " ○ Compiling /billing ..." },
+  { c: "term-success", t: " ✓ Compiled /billing in 482ms (1290 modules)" },
+  { c: "term-dim",     t: " GET /billing 200 in 612ms" },
+  { c: "term-dim",     t: " GET /api/billing/customer 200 in 84ms" },
+  { c: "term-warn",    t: " ⚠ Fast Refresh had to perform a full reload due to a runtime error" },
+  { c: "term-success", t: " ✓ Compiled /api/billing/portal in 211ms" },
+  { c: "term-dim",     t: " POST /api/billing/checkout 303 in 142ms" },
+  { c: "term-info",    t: "   → redirect: https://billing.stripe.com/session/..." },
+];
+
+const LOG_CLASS: Record<string, string> = {
+  "term-prompt":  "p",
+  "term-dim":     "d",
+  "term-success": "s",
+  "term-warn":    "w",
+  "term-error":   "e",
+  "term-info":    "i",
+  "term-bold":    "b",
+};
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export function RunPanel({ agent }: { agent: AgentRecord }) {
+  const [running, setRunning] = useState(true);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [overrides, setOverrides] = useState<Record<string, string>>({});
+
+  const valueOf = (id: string) => {
+    const row = RUN_SETUP.find((r) => r.id === id);
+    return overrides[id] ?? row?.value ?? "";
+  };
+
+  const devCmd = valueOf("dev");
+  const port   = valueOf("port");
+
+  const onApply = (next: Record<string, string>) => {
+    setOverrides(next);
+    setSettingsOpen(false);
+    setRunning(true);
+  };
+
+  const hasOverrides = Object.keys(overrides).length > 0;
+
+  return (
+    <div className="run-wrap">
+      {/* ── Bar ── */}
+      <div className="run-bar v2">
+        <button
+          className={`run-go ${running ? "live" : "stopped"}`}
+          onClick={() => setRunning((v) => !v)}
+          aria-label={running ? "Stop" : "Start"}
+        >
+          <Icon name={running ? "stop" : "play"} size={11} />
+        </button>
+
+        <div className="run-cmd">
+          <span className="p">$</span>
+          <span className="cmd-text">{devCmd}</span>
+        </div>
+
+        <a
+          href={`http://localhost:${port}`}
+          target="_blank"
+          rel="noreferrer"
+          className={`run-link${running ? "" : " disabled"}`}
+          onClick={(e) => { if (!running) e.preventDefault(); }}
+        >
+          <span className="colon">:</span>
+          <span className="port">{port}</span>
+          <Icon name="external" size={10} />
+        </a>
+
+        <button
+          className={`run-gear${settingsOpen ? " active" : ""}${hasOverrides ? " has-overrides" : ""}`}
+          aria-label="Run configuration"
+          onClick={() => setSettingsOpen((v) => !v)}
+        >
+          <Icon name="settings" size={13} />
+          {hasOverrides && <span className="dot" />}
+        </button>
+      </div>
+
+      {/* ── Logs ── */}
+      <div className="run-logs">
+        {RUN_LOGS.map((l, i) => {
+          const cls = LOG_CLASS[l.c] ?? "";
+          const text = l.t.split('localhost:3000').join(`localhost:${port}`);
+          return <div key={i} className={cls || undefined}>{text}</div>;
+        })}
+        {running && (
+          <div className="p">
+            {"› "}
+            <span className="term-cursor" />
+          </div>
+        )}
+      </div>
+
+      {/* ── Settings sheet ── */}
+      {settingsOpen && (
+        <RunSettingsSheet
+          rows={RUN_SETUP}
+          overrides={overrides}
+          agent={agent}
+          onClose={() => setSettingsOpen(false)}
+          onApply={onApply}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/RightPanel/RunSettingsSheet.tsx
+++ b/src/components/RightPanel/RunSettingsSheet.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useRef, useState } from "react";
+import type { AgentRecord } from "../../api";
+import { Icon } from "../Icon";
+
+export interface SetupRow {
+  id:     string;
+  group:  string;
+  key:    string;
+  value:  string;  // inferred / default
+  source: string;  // e.g. "scripts.dev", "vite.config.ts"
+}
+
+interface Props {
+  rows:      SetupRow[];
+  overrides: Record<string, string>;
+  agent:     AgentRecord;
+  onClose:   () => void;
+  onApply:   (overrides: Record<string, string>) => void;
+}
+
+export function RunSettingsSheet({ rows, overrides, agent, onClose, onApply }: Props) {
+  // Draft = working copy while the sheet is open; uncommitted until Apply.
+  const [draft, setDraft] = useState<Record<string, string>>(overrides);
+
+  const groups = Array.from(new Set(rows.map((r) => r.group)));
+
+  const setRow = (id: string, v: string | null) =>
+    setDraft((d) => {
+      const next = { ...d };
+      if (v == null || v === "") delete next[id];
+      else next[id] = v;
+      return next;
+    });
+
+  const revert = (id: string) => setRow(id, null);
+
+  // Rows whose draft differs from the inferred value
+  const changed = rows.filter((r) => draft[r.id] != null && draft[r.id] !== r.value);
+  const dirty =
+    changed.length > 0 ||
+    Object.keys(draft).length !== Object.keys(overrides).length ||
+    Object.keys(draft).some((k) => draft[k] !== overrides[k]);
+
+  // Close on Escape
+  useEffect(() => {
+    const h = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", h);
+    return () => window.removeEventListener("keydown", h);
+  }, [onClose]);
+
+  return (
+    <>
+      {/* Fixed transparent layer — captures clicks outside the run panel */}
+      <div style={{ position: "fixed", inset: 0, zIndex: 4 }} onClick={onClose} />
+      {/* Visual scrim — blurs the logs area behind the sheet */}
+      <div className="run-sheet-scrim" onClick={onClose} />
+      <div className="run-sheet" role="dialog" aria-label="Run configuration">
+        {/* Header */}
+        <div className="run-sheet-h">
+          <div className="rsh-left">
+            <div className="rsh-title">Run configuration</div>
+            <div className="rsh-sub">
+              Auto-detected from{" "}
+              <code>{agent?.name ? `worktree/${agent.name}/package.json` : "package.json"}</code>
+            </div>
+          </div>
+          <button className="run-sheet-x" onClick={onClose} aria-label="Close">
+            <Icon name="close" size={12} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="run-sheet-body">
+          {groups.map((g) => (
+            <div key={g} className="rs-group">
+              <div className="rs-group-h">{g}</div>
+              <div className="rs-group-rows">
+                {rows
+                  .filter((r) => r.group === g)
+                  .map((r) => (
+                    <ConfigRow
+                      key={r.id}
+                      row={r}
+                      override={draft[r.id]}
+                      onChange={(v) => setRow(r.id, v)}
+                      onRevert={() => revert(r.id)}
+                    />
+                  ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div className="run-sheet-f">
+          <div className="rsf-status">
+            {changed.length === 0 ? (
+              <span style={{ color: "var(--fg-3)" }}>No overrides — using detected values</span>
+            ) : (
+              <span>
+                <b style={{ color: "var(--fg-0)" }}>{changed.length}</b>
+                {" override"}
+                {changed.length === 1 ? "" : "s"}
+                {" pending"}
+              </span>
+            )}
+          </div>
+          <div className="rsf-actions">
+            <button
+              className="btn-t ghost"
+              onClick={() => setDraft({})}
+              disabled={Object.keys(draft).length === 0}
+            >
+              Reset all
+            </button>
+
+            <button
+              className="btn-t primary"
+              onClick={() => onApply(draft)}
+              disabled={!dirty}
+            >
+              <Icon name="refresh" size={11} />
+              Apply &amp; restart
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ── Config row ───────────────────────────────────────────────────────────────
+
+interface ConfigRowProps {
+  row:      SetupRow;
+  override: string | undefined;
+  onChange: (v: string) => void;
+  onRevert: () => void;
+}
+
+function ConfigRow({ row, override, onChange, onRevert }: ConfigRowProps) {
+  const [editing, setEditing] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing) inputRef.current?.focus();
+  }, [editing]);
+
+  const hasOverride = override != null;
+  const display = hasOverride ? override : row.value;
+
+  return (
+    <div className={`rs-row${hasOverride ? " overridden" : ""}`}>
+      <div className="rs-row-l">
+        <div className="rs-label">{row.key}</div>
+        <div className="rs-source">
+          {hasOverride ? (
+            <><span className="dot" />Manual override</>
+          ) : (
+            <>Detected · <code>{row.source}</code></>
+          )}
+        </div>
+      </div>
+      <div className="rs-row-r">
+        {editing ? (
+          <input
+            ref={inputRef}
+            className="rs-input"
+            type="text"
+            defaultValue={display}
+            placeholder={row.value}
+            onBlur={(e) => {
+              const v = e.target.value.trim();
+              if (v === "" || v === row.value) onRevert();
+              else onChange(v);
+              setEditing(false);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") e.currentTarget.blur();
+              if (e.key === "Escape") {
+                e.currentTarget.value = display;
+                e.currentTarget.blur();
+              }
+            }}
+          />
+        ) : (
+          <button className="rs-value" onClick={() => setEditing(true)}>
+            <span className="rsv-text">{display}</span>
+            <Icon name="edit" size={10} />
+          </button>
+        )}
+        {hasOverride && !editing && (
+          <button className="rs-revert tip" data-tip="Revert to detected" onClick={onRevert}>
+            <Icon name="refresh" size={11} />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/RightPanel/index.tsx
+++ b/src/components/RightPanel/index.tsx
@@ -3,6 +3,7 @@ import type { AgentRecord } from "../../api";
 import { useAppStore } from "../../store";
 import { Icon, type IconName } from "../Icon";
 import { GitPanel } from "./GitPanel";
+import { RunPanel } from "./RunPanel";
 
 type TabId = "git" | "diff" | "run" | "term";
 
@@ -60,7 +61,7 @@ export function RightPanel({ agent }: { agent: AgentRecord }) {
       <div className="right-body">
         {tab === "git" && <GitPanel agent={agent} />}
         {tab === "diff" && <Stub label="Diff" />}
-        {tab === "run" && <Stub label="Run" />}
+        {tab === "run" && <RunPanel agent={agent} />}
         {tab === "term" && <Stub label="Terminal" />}
       </div>
     </>


### PR DESCRIPTION
Implements the Run tab in the right panel, replacing the stub placeholder with a full static UI.

Adds `RunPanel` with a status bar (start/stop button, command pill, localhost link, settings gear) and a terminal-style log area. Adds `RunSettingsSheet` — a floating popover with 8 auto-detected config rows across Environment / Scripts / Server groups, with per-row inline editing, draft/apply, and reset-all. CSS ported from the Quorum v2 prototype, including OKLCH color tokens, accent ring shadow, blur scrim, and drop animation. Backend wiring (real detected values, live process I/O) is deferred to a follow-up PR.