### PR TITLE
Enhance GitPanel with pr-closed state, dynamic labels, and PR cards

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -847,6 +847,8 @@ button { cursor: default; }
 
 .git-stats { display: flex; gap: 14px; font-size: 11.5px; color: var(--fg-2); }
 .git-stats .num { color: var(--fg-0); font-family: var(--font-mono); }
+.git-stats .add { color: var(--success); font-family: var(--font-mono); }
+.git-stats .rem { color: var(--danger); font-family: var(--font-mono); }
 
 .git-primary {
   padding: 14px 18px;
@@ -889,10 +891,12 @@ button { cursor: default; }
 .git-file:hover { background: var(--hover); }
 .git-file.active { background: var(--selected); color: var(--fg-0); }
 .git-file .gs { width: 14px; text-align: center; font-size: 10px; font-weight: 600; }
-.git-file .gs.M { color: var(--warn); }
-.git-file .gs.A { color: var(--success); }
-.git-file .gs.D { color: var(--danger); }
-.git-file .gs.R { color: var(--info); }
+.git-file .gs.modified   { color: var(--warn); }
+.git-file .gs.added      { color: var(--success); }
+.git-file .gs.deleted    { color: var(--danger); }
+.git-file .gs.renamed    { color: var(--info); }
+.git-file .gs.untracked  { color: var(--fg-3); }
+.git-file .gs.conflicted { color: var(--danger); }
 .git-file .gn { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .git-file .gx { font-size: 10px; display: flex; gap: 4px; flex-shrink: 0; }
 .git-file .gx .add { color: var(--success); }
@@ -911,6 +915,81 @@ button { cursor: default; }
 .git-commit .cm-foot { display: flex; gap: 4px; margin-top: 10px; align-items: center; }
 .git-commit .cm-foot .grow { flex: 1; }
 .git-commit .cm-foot .hint { font-size: 10.5px; color: var(--fg-3); }
+
+/* Merged / conflict banner cards */
+.git-state-card {
+  margin: 0 18px 18px;
+  padding: 11px 13px;
+  border-radius: var(--r-md);
+  font-size: 12.5px;
+  line-height: 1.45;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+.git-state-card svg { flex-shrink: 0; margin-top: 1px; }
+.git-state-card.merged {
+  border: 1px solid color-mix(in oklch, var(--success), transparent 70%);
+  background: color-mix(in oklch, var(--success), transparent 92%);
+  color: var(--success);
+}
+.git-state-card.conflict {
+  border: 1px solid color-mix(in oklch, var(--danger), transparent 70%);
+  background: color-mix(in oklch, var(--danger), transparent 92%);
+  color: var(--danger);
+}
+.git-state-card .mono { font-family: var(--font-mono); font-size: 11px; }
+
+/* PR card */
+.git-pr-card {
+  padding: 14px 18px;
+  border-top: 1px solid var(--bd-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.git-pr-card .gpc-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--fg-0);
+  line-height: 1.4;
+}
+.git-pr-card .gpc-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11.5px;
+  color: var(--fg-2);
+  font-family: var(--font-mono);
+  margin-top: 2px;
+}
+.git-pr-card .gpc-badge {
+  padding: 1px 7px;
+  border-radius: 100px;
+  font-size: 10px;
+  font-family: var(--font-sans);
+  font-weight: 500;
+}
+.git-pr-card .gpc-badge.ready {
+  background: color-mix(in oklch, var(--success), transparent 85%);
+  color: var(--success);
+}
+.git-pr-card .gpc-badge.warn {
+  background: color-mix(in oklch, var(--warn), transparent 85%);
+  color: var(--warn);
+}
+.git-pr-card .gpc-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 8px;
+  font-size: 11.5px;
+  color: var(--fg-2);
+  text-decoration: none;
+  width: fit-content;
+}
+.git-pr-card .gpc-link:hover { color: var(--fg-0); }
+.git-pr-card .gpc-link svg { width: 11px; height: 11px; }
 
 /* empty workspace (draft) */
 .empty-wrap {

--- a/src/components/RightPanel/GitPanel.tsx
+++ b/src/components/RightPanel/GitPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import type { AgentRecord, GitState, PrState } from "../../api";
+import type { AgentRecord, FileStatus, GitState, PrState } from "../../api";
 import { useAppStore } from "../../store";
 import { Icon } from "../Icon";
 import { IconButton } from "../ui/IconButton";
@@ -9,24 +9,105 @@ function deriveState(git: GitState | null, pr: PrState | null): GitPanelState {
   if (!git) return "loading";
   if (git.files.some((f) => f.kind === "conflicted")) return "conflicts";
   if (pr?.state === "merged") return "merged";
-  if (pr?.state === "open") return "pr-open";
-  if (git.files.length > 0) return "changes";
-  if (git.ahead > 0) return "pushed";
+  if (pr?.state === "open")   return "pr-open";
+  if (pr?.state === "closed") return "pr-closed";
+  if (git.files.length > 0)  return "changes";
+  if (git.ahead > 0)         return "pushed";
   return "clean";
 }
+
+/** Status letter for the file badge — matches CSS `.gs.<kind>` selectors. */
+function kindLabel(kind: FileStatus["kind"]): string {
+  switch (kind) {
+    case "modified":   return "M";
+    case "added":      return "A";
+    case "deleted":    return "D";
+    case "renamed":    return "R";
+    case "untracked":  return "?";
+    case "conflicted": return "!";
+    default:           return "?";
+  }
+}
+
+// ── Sub-components ────────────────────────────────────────────────
+
+function PRCard({ pr }: { pr: PrState }) {
+  return (
+    <div className="git-pr-card">
+      <div className="gpc-title">{pr.title}</div>
+      <div className="gpc-meta">
+        <span>#{pr.number}</span>
+        {pr.mergeable
+          ? <span className="gpc-badge ready">Mergeable</span>
+          : <span className="gpc-badge warn">Not mergeable</span>}
+      </div>
+      <a
+        href={pr.url}
+        target="_blank"
+        rel="noreferrer"
+        className="gpc-link"
+      >
+        <Icon name="github" size={11} />
+        View on GitHub
+      </a>
+    </div>
+  );
+}
+
+function ClosedPRCard({ pr }: { pr: PrState }) {
+  return (
+    <div className="git-pr-card">
+      <div className="gpc-title">{pr.title}</div>
+      <div className="gpc-meta">
+        <span>#{pr.number}</span>
+        <span className="gpc-badge warn">Closed</span>
+      </div>
+      <a href={pr.url} target="_blank" rel="noreferrer" className="gpc-link">
+        <Icon name="github" size={11} />
+        View on GitHub
+      </a>
+    </div>
+  );
+}
+
+function MergedCard() {
+  return (
+    <div className="git-state-card merged">
+      <Icon name="merge" size={14} />
+      <span>Merged into base branch. Workspace can now be archived.</span>
+    </div>
+  );
+}
+
+function ConflictCard({ files }: { files: FileStatus[] }) {
+  const conflicted = files.filter((f) => f.kind === "conflicted");
+  const first = conflicted[0]?.path ?? "";
+  const rest = conflicted.length - 1;
+  return (
+    <div className="git-state-card conflict">
+      <Icon name="merge" size={14} />
+      <span>
+        Conflicts in <span className="mono">{first}</span>
+        {rest > 0 && ` and ${rest} more`}.
+      </span>
+    </div>
+  );
+}
+
+// ── Main panel ────────────────────────────────────────────────────
 
 /** State-aware git panel driven by live git state from the Tauri backend.
  *  The panel is feature-flagged off by default in settings. */
 export function GitPanel({ agent }: { agent: AgentRecord }) {
   const gitState = useAppStore((s) => s.gitStates[agent.id] ?? null);
-  const prState = useAppStore((s) => s.prStates[agent.id] ?? null);
+  const prState  = useAppStore((s) => s.prStates[agent.id] ?? null);
   const fetchGitState = useAppStore((s) => s.fetchGitState);
-  const fetchPrState = useAppStore((s) => s.fetchPrState);
-  const pushAgent = useAppStore((s) => s.pushAgent);
-  const pullAgent = useAppStore((s) => s.pullAgent);
-  const createPr = useAppStore((s) => s.createPr);
-  const mergePr = useAppStore((s) => s.mergePr);
-  const archive = useAppStore((s) => s.archive);
+  const fetchPrState  = useAppStore((s) => s.fetchPrState);
+  const pushAgent  = useAppStore((s) => s.pushAgent);
+  const pullAgent  = useAppStore((s) => s.pullAgent);
+  const createPr   = useAppStore((s) => s.createPr);
+  const mergePr    = useAppStore((s) => s.mergePr);
+  const archive    = useAppStore((s) => s.archive);
 
   useEffect(() => {
     void fetchGitState(agent.id);
@@ -36,7 +117,6 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
   const panelState = deriveState(gitState, prState);
 
   const [selected, setSelected] = useState<string | null>(null);
-
   useEffect(() => {
     setSelected((prev) => {
       const paths = gitState?.files.map((f) => f.path) ?? [];
@@ -44,11 +124,13 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
       return paths[0] ?? null;
     });
   }, [gitState]);
+
   const [moreOpen, setMoreOpen] = useState(false);
 
   function handlePrimaryClick() {
     switch (panelState) {
       case "pushed":
+      case "pr-closed":
         void createPr(agent.id, "", "");
         break;
       case "pr-open":
@@ -65,38 +147,34 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
   function handleSecondaryClick(key: string) {
     setMoreOpen(false);
     switch (key) {
-      case "push":
-        void pushAgent(agent.id);
-        break;
-      case "pull":
-        void pullAgent(agent.id);
-        break;
-      case "open-pr":
-        void createPr(agent.id, "", "");
-        break;
-      case "merge":
-        void mergePr(agent.id);
-        break;
-      case "view-pr":
-        if (prState?.url) window.open(prState.url, "_blank");
-        break;
-      case "archive":
-        void archive(agent.id);
-        break;
-      default:
-        break;
+      case "push":       void pushAgent(agent.id);             break;
+      case "pull":       void pullAgent(agent.id);             break;
+      case "open-pr":    void createPr(agent.id, "", "");      break;
+      case "merge":      void mergePr(agent.id);               break;
+      case "view-pr":    prState?.url && window.open(prState.url, "_blank"); break;
+      case "archive":    void archive(agent.id);               break;
+      default:           break;
     }
   }
 
-  const primary = primaryFor(panelState);
+  const counts = {
+    files:    gitState?.files.length ?? 0,
+    ahead:    gitState?.ahead ?? 0,
+    prNumber: prState?.number,
+  };
+  const primary   = primaryFor(panelState, counts);
   const secondary = secondaryFor(panelState);
-  const branch = gitState?.branch || agent.repos[0]?.branch || "(no branch yet)";
-  const base = gitState?.parent_branch || agent.repos[0]?.parent_branch || "main";
-  const showFiles = panelState !== "clean" && panelState !== "merged" && panelState !== "loading";
+
+  const branch   = gitState?.branch || agent.repos[0]?.branch || "(no branch yet)";
+  const base     = gitState?.parent_branch || agent.repos[0]?.parent_branch || "main";
+  // Show the file list only when there are actually uncommitted files to display.
+  // "pushed" and "pr-closed" have no local changes (files already committed).
+  const showFiles  = panelState === "changes" || panelState === "conflicts";
   const showCommit = panelState === "changes";
 
   return (
     <>
+      {/* Branch + stats */}
       <div className="git-state">
         <div className="git-branch-row">
           <Icon name="branch" />
@@ -106,9 +184,16 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
         <div className="git-stats">
           <span><span className="num">{gitState?.ahead ?? 0}</span> ahead</span>
           <span><span className="num">{gitState?.behind ?? 0}</span> behind</span>
+          {((gitState?.additions ?? 0) > 0 || (gitState?.deletions ?? 0) > 0) && (
+            <>
+              <span><span className="add">+{gitState!.additions}</span></span>
+              <span><span className="rem">−{gitState!.deletions}</span></span>
+            </>
+          )}
         </div>
       </div>
 
+      {/* Primary action + overflow menu */}
       <div className="git-primary">
         <div className="status-line">
           <span className={`d ${primary.statusKind}`} />
@@ -128,13 +213,9 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
         <div className="actions">
           <button
             type="button"
-            disabled={panelState === "loading" || panelState === "changes" || panelState === "conflicts"}
+            disabled={panelState === "loading" || panelState === "changes" || panelState === "conflicts" || panelState === "clean"}
             className={`btn-t ${primary.danger ? "outline" : "primary"}`}
-            style={
-              primary.danger
-                ? { borderColor: "var(--danger)", color: "var(--danger)" }
-                : undefined
-            }
+            style={primary.danger ? { borderColor: "var(--danger)", color: "var(--danger)" } : undefined}
             onClick={handlePrimaryClick}
           >
             <Icon name={primary.icon} />
@@ -151,10 +232,7 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
                     style={{ position: "fixed", inset: 0, zIndex: 199 }}
                     onClick={() => setMoreOpen(false)}
                   />
-                  <div
-                    className="dd"
-                    style={{ top: "calc(100% + 6px)", right: 0, minWidth: 200 }}
-                  >
+                  <div className="dd" style={{ top: "calc(100% + 6px)", right: 0, minWidth: 200 }}>
                     {secondary.map((s) => (
                       <div key={s.key} className="dd-item" onClick={() => handleSecondaryClick(s.key)}>
                         <div className="di-i"><Icon name={s.icon} size={12} /></div>
@@ -170,6 +248,7 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
         </div>
       </div>
 
+      {/* Changed file list */}
       {showFiles && (
         <>
           <div className="git-files-h">
@@ -179,14 +258,14 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
               <IconButton size="xs" tip="Refresh"><Icon name="refresh" /></IconButton>
             </div>
           </div>
-          <div style={{ flex: 1, minHeight: 0 }}>
+          <div style={{ flex: 1, minHeight: 0, overflowY: "auto" }}>
             {(gitState?.files ?? []).map((f) => (
               <div
                 key={f.path}
                 className={`git-file ${selected === f.path ? "active" : ""}`}
                 onClick={() => setSelected(f.path)}
               >
-                <span className={`gs ${f.kind}`}>{f.kind[0].toUpperCase()}</span>
+                <span className={`gs ${f.kind}`}>{kindLabel(f.kind)}</span>
                 <span className="gn">{f.path}</span>
                 <span className="gx">
                   {f.additions > 0 && <span className="add">+{f.additions}</span>}
@@ -198,6 +277,7 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
         </>
       )}
 
+      {/* Commit message card — shown when there are uncommitted changes */}
       {showCommit && (
         <div className="git-commit">
           <div className="cm-title">Commit message · auto-drafted</div>
@@ -214,6 +294,13 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
         </div>
       )}
 
+      {/* State-specific bottom cards */}
+      {panelState === "pr-open"   && prState  && <PRCard pr={prState} />}
+      {panelState === "pr-closed" && prState  && <ClosedPRCard pr={prState} />}
+      {panelState === "merged"    && <MergedCard />}
+      {panelState === "conflicts" && gitState  && <ConflictCard files={gitState.files} />}
+
+      {/* Empty / loading states */}
       {panelState === "loading" && (
         <div className="empty-msg" style={{ marginTop: "auto" }}>
           <div className="et">Loading…</div>

--- a/src/components/RightPanel/index.tsx
+++ b/src/components/RightPanel/index.tsx
@@ -14,13 +14,14 @@ interface Tab {
 }
 
 /** Right rail: tabs for Git / Diff / Run / Terminal (each
- *  feature-flagged in settings). For now only Git renders real (well,
- *  mocked) content — the others show a stub. */
+ *  feature-flagged in settings). For now only Git renders real content —
+ *  the others show a stub. */
 export function RightPanel({ agent }: { agent: AgentRecord }) {
-  const features = useAppStore((s) => s.features);
+  const features  = useAppStore((s) => s.features);
+  const gitFiles  = useAppStore((s) => s.gitStates[agent.id]?.files.length ?? 0);
 
   const tabs: Tab[] = [
-    features.git && { id: "git", label: "Git", icon: "branch", count: 0 },
+    features.git && { id: "git", label: "Git", icon: "branch", count: gitFiles },
     features.diff && { id: "diff", label: "Diff", icon: "code" },
     features.run && { id: "run", label: "Run", icon: "play" },
     features.terminal && { id: "term", label: "Terminal", icon: "terminal" },

--- a/src/components/RightPanel/primaryActions.ts
+++ b/src/components/RightPanel/primaryActions.ts
@@ -1,7 +1,7 @@
 import type { IconName } from "../Icon";
 
 /** Derived git panel state — computed from live GitState, not stored. */
-export type GitPanelState = "clean" | "changes" | "pushed" | "conflicts" | "pr-open" | "merged" | "loading";
+export type GitPanelState = "clean" | "changes" | "pushed" | "conflicts" | "pr-open" | "pr-closed" | "merged" | "loading";
 
 export interface PrimaryAction {
   label: string;
@@ -20,22 +20,66 @@ export interface SecondaryAction {
   kbd?: string;
 }
 
-/** Maps a git panel state to the panel's primary call-to-action. */
-export function primaryFor(state: GitPanelState): PrimaryAction {
+export interface ActionCounts {
+  files?: number;
+  ahead?: number;
+  prNumber?: number;
+}
+
+/** Maps a git panel state to the panel's primary call-to-action.
+ *  Pass counts for dynamic status labels; falls back to generic copy. */
+export function primaryFor(state: GitPanelState, counts?: ActionCounts): PrimaryAction {
+  const { files = 0, ahead = 0, prNumber } = counts ?? {};
+  const prLabel = prNumber != null ? `PR #${prNumber}` : "PR";
+
   switch (state) {
     case "loading":
       return { label: "Loading…", icon: "refresh", statusLabel: "loading git state", statusKind: "ready" };
     case "changes":
-      return { label: "Commit & open PR", icon: "pr", statusLabel: "changes uncommitted", statusKind: "warn" };
+      return {
+        label: "Commit & open PR",
+        icon: "pr",
+        statusLabel: files === 1 ? "1 change uncommitted" : `${files} changes uncommitted`,
+        statusKind: "warn",
+      };
     case "pushed":
-      return { label: "Open PR", icon: "pr", statusLabel: "commit pushed, no PR yet", statusKind: "warn" };
+      return {
+        label: "Open PR",
+        icon: "pr",
+        statusLabel: ahead === 1 ? "1 commit pushed, no PR yet" : `${ahead} commits pushed, no PR yet`,
+        statusKind: "warn",
+      };
     case "pr-open":
-      return { label: "View PR ↗", icon: "external", statusLabel: "PR open", statusKind: "ready", statusExtra: "checks passing" };
+      return {
+        label: "View PR ↗",
+        icon: "external",
+        statusLabel: `${prLabel} · open`,
+        statusKind: "ready",
+        statusExtra: "checks passing",
+      };
     case "conflicts":
-      return { label: "Resolve conflicts", icon: "merge", statusLabel: "merge conflicts", statusKind: "alert", danger: true };
+      return {
+        label: "Resolve conflicts",
+        icon: "merge",
+        statusLabel: "merge conflicts detected",
+        statusKind: "alert",
+        danger: true,
+      };
+    case "pr-closed":
+      return {
+        label: "Open new PR",
+        icon: "pr",
+        statusLabel: `${prLabel} · closed`,
+        statusKind: "warn",
+      };
     case "merged":
-      return { label: "Archive workspace", icon: "check", statusLabel: "PR merged", statusKind: "ready" };
-    default:
+      return {
+        label: "Archive workspace",
+        icon: "check",
+        statusLabel: `${prLabel} · merged`,
+        statusKind: "ready",
+      };
+    default: // clean
       return { label: "Nothing to do", icon: "check", statusLabel: "working tree clean", statusKind: "ready" };
   }
 }
@@ -66,6 +110,12 @@ export function secondaryFor(state: GitPanelState): SecondaryAction[] {
     case "conflicts":
       return [
         { key: "abort", label: "Abort merge", icon: "close" },
+        { key: "view-pr", label: "View on GitHub", icon: "github" },
+      ];
+    case "pr-closed":
+      return [
+        { key: "open-pr", label: "Open new PR", icon: "pr" },
+        { key: "push", label: "Push more commits", icon: "push" },
         { key: "view-pr", label: "View on GitHub", icon: "github" },
       ];
     case "merged":


### PR DESCRIPTION
Add support for closed PR state in GitPanel with several UX improvements.

- Add pr-closed state handling for closed PRs with option to open new PR
- Dynamic status labels showing actual file/commit/PR counts instead of generic text
- New component cards (PRCard, ClosedPRCard, MergedCard, ConflictCard) for state-specific messaging
- Improve file list visibility by only showing for uncommitted changes (changes/conflicts states)
- Display additions/deletions stats in the git stats row
- Update CSS class names from single letters to full kind names for better maintainability
- Add defensive default case to kindLabel function for robustness