### PR TITLE
Add SQLite persistence layer with FTS5 full-text search

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,6 +786,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,6 +1294,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1282,6 +1315,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -1834,6 +1876,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2632,6 +2685,8 @@ dependencies = [
  "notify-debouncer-mini",
  "parking_lot",
  "portable-pty",
+ "rusqlite",
+ "rusqlite_migration",
  "serde",
  "serde_json",
  "tauri",
@@ -2809,6 +2864,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
+name = "rusqlite_migration"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55709bc01054c69e2f1cefdc886642b5e6376a8db3c86f761be0c423eebf178b"
+dependencies = [
+ "log",
+ "rusqlite",
 ]
 
 [[package]]
@@ -4315,6 +4394,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5313,6 +5398,26 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,6 +30,8 @@ nix = { version = "0.29", features = ["signal"] }
 chrono = { version = "0.4", features = ["serde"] }
 tempfile = "3"
 notify-debouncer-mini = "0.4"
+rusqlite = { version = "0.31", features = ["bundled"] }
+rusqlite_migration = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/migrations/0001_initial_schema.sql
+++ b/src-tauri/migrations/0001_initial_schema.sql
@@ -1,0 +1,83 @@
+-- Quorum persistence schema
+
+-- Pinned sidebar repos
+CREATE TABLE workspace_repos (
+    id TEXT PRIMARY KEY,
+    repo_path TEXT NOT NULL UNIQUE,
+    created_at INTEGER NOT NULL
+);
+
+-- Agent records (replaces agents array in workspaces.json)
+CREATE TABLE agents (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    provider TEXT NOT NULL DEFAULT 'claude',
+    task TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'spawning'
+        CHECK (status IN ('spawning', 'running', 'idle', 'stopped', 'error')),
+    view TEXT NOT NULL DEFAULT 'custom'
+        CHECK (view IN ('custom', 'native')),
+    session_id TEXT,
+    created_at INTEGER NOT NULL,
+    last_error TEXT,
+    archived_at INTEGER
+);
+
+CREATE INDEX idx_agents_status ON agents(status);
+CREATE INDEX idx_agents_created_at ON agents(created_at);
+CREATE INDEX idx_agents_archived_at ON agents(archived_at);
+
+-- Repos tracked per agent (one agent can have multiple worktrees)
+CREATE TABLE agent_repos (
+    id TEXT PRIMARY KEY,
+    agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    repo_path TEXT NOT NULL,
+    subdir TEXT NOT NULL,
+    branch TEXT,
+    parent_branch TEXT,
+    is_primary INTEGER NOT NULL DEFAULT 0 CHECK (is_primary IN (0, 1)),
+    -- Populated at archive time, NULL for live agents
+    branch_tip_sha TEXT,
+    parent_branch_sha TEXT,
+    diff_additions INTEGER NOT NULL DEFAULT 0,
+    diff_deletions INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(agent_id, subdir)
+);
+
+CREATE INDEX idx_agent_repos_agent_id ON agent_repos(agent_id);
+
+-- Conversation messages
+CREATE TABLE messages (
+    id TEXT PRIMARY KEY,
+    agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    kind TEXT NOT NULL
+        CHECK (kind IN ('user_message', 'agent_message', 'tool_call', 'tool_result', 'notice')),
+    content TEXT NOT NULL DEFAULT '',
+    metadata_json TEXT,
+    sequence INTEGER NOT NULL,
+    created_at INTEGER NOT NULL
+);
+
+CREATE INDEX idx_messages_agent_id ON messages(agent_id, sequence);
+
+-- Full-text search on message content
+CREATE VIRTUAL TABLE messages_fts USING fts5(
+    content,
+    content='messages',
+    content_rowid='rowid'
+);
+
+CREATE TRIGGER messages_fts_insert AFTER INSERT ON messages BEGIN
+    INSERT INTO messages_fts(rowid, content) VALUES (new.rowid, new.content);
+END;
+
+CREATE TRIGGER messages_fts_delete AFTER DELETE ON messages BEGIN
+    INSERT INTO messages_fts(messages_fts, rowid, content)
+        VALUES ('delete', old.rowid, old.content);
+END;
+
+CREATE TRIGGER messages_fts_update AFTER UPDATE OF content ON messages BEGIN
+    INSERT INTO messages_fts(messages_fts, rowid, content)
+        VALUES ('delete', old.rowid, old.content);
+    INSERT INTO messages_fts(rowid, content) VALUES (new.rowid, new.content);
+END;

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -1,0 +1,542 @@
+use parking_lot::Mutex;
+use rusqlite::{params_from_iter, Connection};
+use rusqlite_migration::{Migrations, M};
+use serde_json::{json, Map, Value};
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::error::{Error, Result};
+
+const ALLOWED_TABLES: &[&str] = &["agents", "agent_repos", "messages", "workspace_repos"];
+
+fn validate_table(table: &str) -> Result<()> {
+    if ALLOWED_TABLES.contains(&table) {
+        Ok(())
+    } else {
+        Err(Error::Other(format!("unknown table: {table}")))
+    }
+}
+
+fn validate_column(col: &str) -> Result<()> {
+    if !col.is_empty() && col.len() <= 64 && col.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_') {
+        Ok(())
+    } else {
+        Err(Error::Other(format!("invalid column name: {col}")))
+    }
+}
+
+fn get_migrations() -> Migrations<'static> {
+    Migrations::new(vec![
+        M::up(include_str!("../migrations/0001_initial_schema.sql")),
+    ])
+}
+
+pub fn init(data_dir: &Path) -> Result<Arc<Mutex<Connection>>> {
+    std::fs::create_dir_all(data_dir)?;
+    let db_path = data_dir.join("quorum.db");
+    let mut conn = Connection::open(&db_path)?;
+
+    conn.execute_batch(
+        "PRAGMA journal_mode = WAL;
+         PRAGMA synchronous = NORMAL;
+         PRAGMA temp_store = MEMORY;
+         PRAGMA foreign_keys = ON;
+         PRAGMA busy_timeout = 5000;",
+    )?;
+
+    get_migrations()
+        .to_latest(&mut conn)
+        .map_err(|e| Error::Other(format!("migration failed: {e}")))?;
+
+    Ok(Arc::new(Mutex::new(conn)))
+}
+
+fn now_millis() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64
+}
+
+fn json_to_sql(value: &Value) -> Result<Box<dyn rusqlite::ToSql>> {
+    match value {
+        Value::Null => Ok(Box::new(rusqlite::types::Null)),
+        Value::Bool(b) => Ok(Box::new(if *b { 1i64 } else { 0i64 })),
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Ok(Box::new(i))
+            } else if let Some(f) = n.as_f64() {
+                Ok(Box::new(f))
+            } else {
+                Err(Error::Other("unsupported number type".into()))
+            }
+        }
+        Value::String(s) => Ok(Box::new(s.clone())),
+        Value::Array(_) | Value::Object(_) => Ok(Box::new(serde_json::to_string(value)?)),
+    }
+}
+
+fn row_to_json(
+    row: &rusqlite::Row,
+    columns: &[String],
+) -> std::result::Result<Map<String, Value>, rusqlite::Error> {
+    let mut map = Map::new();
+    for (i, col) in columns.iter().enumerate() {
+        let val = match row.get_ref(i)? {
+            rusqlite::types::ValueRef::Null => Value::Null,
+            rusqlite::types::ValueRef::Integer(n) => json!(n),
+            rusqlite::types::ValueRef::Real(f) => json!(f),
+            rusqlite::types::ValueRef::Text(s) => {
+                Value::String(String::from_utf8_lossy(s).into_owned())
+            }
+            rusqlite::types::ValueRef::Blob(b) => {
+                Value::String(hex_encode(b))
+            }
+        };
+        map.insert(col.clone(), val);
+    }
+    Ok(map)
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+fn append_where(
+    where_obj: &Map<String, Value>,
+    sql: &mut String,
+    params: &mut Vec<Box<dyn rusqlite::ToSql>>,
+) -> Result<()> {
+    let mut clauses = Vec::new();
+    for (col, val) in where_obj {
+        validate_column(col)?;
+        if val.is_null() {
+            clauses.push(format!("{col} IS NULL"));
+        } else {
+            let idx = params.len() + 1;
+            clauses.push(format!("{col} = ?{idx}"));
+            params.push(json_to_sql(val)?);
+        }
+    }
+    if !clauses.is_empty() {
+        sql.push_str(" WHERE ");
+        sql.push_str(&clauses.join(" AND "));
+    }
+    Ok(())
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+pub fn db_insert(conn: &Connection, table: &str, mut data: Value) -> Result<String> {
+    validate_table(table)?;
+    let obj = data
+        .as_object_mut()
+        .ok_or_else(|| Error::Other("data must be a JSON object".into()))?;
+
+    let id = match obj.get("id").and_then(|v| v.as_str()) {
+        Some(existing) => existing.to_string(),
+        None => {
+            let id = uuid::Uuid::new_v4().to_string();
+            obj.insert("id".to_string(), json!(id));
+            id
+        }
+    };
+
+    let now = now_millis();
+    obj.entry("created_at").or_insert(json!(now));
+
+    let mut columns = Vec::new();
+    let mut placeholders = Vec::new();
+    let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+
+    for (i, (col, val)) in obj.iter().enumerate() {
+        validate_column(col)?;
+        columns.push(col.as_str());
+        placeholders.push(format!("?{}", i + 1));
+        params.push(json_to_sql(val)?);
+    }
+
+    let sql = format!(
+        "INSERT INTO {table} ({}) VALUES ({})",
+        columns.join(", "),
+        placeholders.join(", ")
+    );
+
+    conn.prepare(&sql)?
+        .execute(params_from_iter(params))?;
+
+    Ok(id)
+}
+
+pub fn db_select(conn: &Connection, table: &str, query: Value) -> Result<Vec<Map<String, Value>>> {
+    validate_table(table)?;
+    let q = query
+        .as_object()
+        .ok_or_else(|| Error::Other("query must be a JSON object".into()))?;
+
+    let mut sql = format!("SELECT * FROM {table}");
+    let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+
+    if let Some(w) = q.get("where").and_then(|v| v.as_object()) {
+        if !w.is_empty() {
+            append_where(w, &mut sql, &mut params)?;
+        }
+    }
+
+    if let Some(col) = q.get("orderBy").and_then(|v| v.as_str()) {
+        validate_column(col)?;
+        let dir = match q.get("orderDirection").and_then(|v| v.as_str()) {
+            Some(d) if d.eq_ignore_ascii_case("desc") => "DESC",
+            _ => "ASC",
+        };
+        sql.push_str(&format!(" ORDER BY {col} {dir}"));
+    }
+
+    if let Some(n) = q.get("limit").and_then(|v| v.as_i64()) {
+        if n > 0 {
+            sql.push_str(&format!(" LIMIT {n}"));
+        }
+    }
+
+    if let Some(n) = q.get("offset").and_then(|v| v.as_i64()) {
+        if n > 0 {
+            sql.push_str(&format!(" OFFSET {n}"));
+        }
+    }
+
+    let mut stmt = conn.prepare(&sql)?;
+    let columns: Vec<String> = stmt.column_names().iter().map(|s| s.to_string()).collect();
+
+    let rows: std::result::Result<Vec<_>, _> = stmt
+        .query_map(params_from_iter(params), |row| row_to_json(row, &columns))?
+        .collect();
+
+    Ok(rows?)
+}
+
+pub fn db_update(conn: &Connection, table: &str, query: Value, data: Value) -> Result<usize> {
+    validate_table(table)?;
+    let q = query
+        .as_object()
+        .ok_or_else(|| Error::Other("query must be a JSON object".into()))?;
+    let d = data
+        .as_object()
+        .ok_or_else(|| Error::Other("data must be a JSON object".into()))?;
+
+    if d.is_empty() {
+        return Err(Error::Other("cannot update with empty data".into()));
+    }
+
+    let mut set_clauses = Vec::new();
+    let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+
+    for (col, val) in d {
+        validate_column(col)?;
+        let idx = params.len() + 1;
+        set_clauses.push(format!("{col} = ?{idx}"));
+        params.push(json_to_sql(val)?);
+    }
+
+    let mut sql = format!("UPDATE {table} SET {}", set_clauses.join(", "));
+
+    if let Some(w) = q.get("where").and_then(|v| v.as_object()) {
+        if !w.is_empty() {
+            append_where(w, &mut sql, &mut params)?;
+        }
+    }
+
+    let changed = conn.prepare(&sql)?.execute(params_from_iter(params))?;
+    Ok(changed)
+}
+
+pub fn db_delete(conn: &Connection, table: &str, query: Value) -> Result<usize> {
+    validate_table(table)?;
+    let q = query
+        .as_object()
+        .ok_or_else(|| Error::Other("query must be a JSON object".into()))?;
+
+    let mut sql = format!("DELETE FROM {table}");
+    let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+
+    if let Some(w) = q.get("where").and_then(|v| v.as_object()) {
+        if !w.is_empty() {
+            append_where(w, &mut sql, &mut params)?;
+        }
+    }
+
+    let changed = conn.prepare(&sql)?.execute(params_from_iter(params))?;
+    Ok(changed)
+}
+
+pub fn db_count(conn: &Connection, table: &str, query: Value) -> Result<i64> {
+    validate_table(table)?;
+    let q = query
+        .as_object()
+        .ok_or_else(|| Error::Other("query must be a JSON object".into()))?;
+
+    let mut sql = format!("SELECT COUNT(*) FROM {table}");
+    let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+
+    if let Some(w) = q.get("where").and_then(|v| v.as_object()) {
+        if !w.is_empty() {
+            append_where(w, &mut sql, &mut params)?;
+        }
+    }
+
+    let count: i64 = conn.query_row(&sql, params_from_iter(params), |row| row.get(0))?;
+    Ok(count)
+}
+
+pub fn db_query(
+    conn: &Connection,
+    sql: &str,
+    params: Vec<Value>,
+) -> Result<Vec<Map<String, Value>>> {
+    let sql_trimmed = sql.trim();
+    if !sql_trimmed
+        .get(..6)
+        .map(|s| s.eq_ignore_ascii_case("select"))
+        .unwrap_or(false)
+    {
+        return Err(Error::Other("db_query only allows SELECT statements".into()));
+    }
+
+    let sql_params: Vec<Box<dyn rusqlite::ToSql>> = params
+        .iter()
+        .map(json_to_sql)
+        .collect::<Result<_>>()?;
+
+    let mut stmt = conn.prepare(sql_trimmed)?;
+    let columns: Vec<String> = stmt.column_names().iter().map(|s| s.to_string()).collect();
+
+    let rows: std::result::Result<Vec<_>, _> = stmt
+        .query_map(params_from_iter(sql_params), |row| {
+            row_to_json(row, &columns)
+        })?
+        .collect();
+
+    Ok(rows?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_db() -> Arc<Mutex<Connection>> {
+        let dir = tempfile::tempdir().unwrap();
+        init(dir.path()).unwrap()
+    }
+
+    #[test]
+    fn insert_and_select() {
+        let db = test_db();
+        let conn = db.lock();
+
+        let id = db_insert(
+            &conn,
+            "agents",
+            json!({ "name": "test-agent", "provider": "claude" }),
+        )
+        .unwrap();
+
+        let rows = db_select(&conn, "agents", json!({ "where": { "id": id } })).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["name"], "test-agent");
+        assert_eq!(rows[0]["provider"], "claude");
+        assert_eq!(rows[0]["status"], "spawning");
+    }
+
+    #[test]
+    fn update_and_delete() {
+        let db = test_db();
+        let conn = db.lock();
+
+        let id = db_insert(
+            &conn,
+            "agents",
+            json!({ "name": "a", "provider": "claude" }),
+        )
+        .unwrap();
+
+        let changed = db_update(
+            &conn,
+            "agents",
+            json!({ "where": { "id": id } }),
+            json!({ "status": "running" }),
+        )
+        .unwrap();
+        assert_eq!(changed, 1);
+
+        let rows = db_select(&conn, "agents", json!({ "where": { "id": id } })).unwrap();
+        assert_eq!(rows[0]["status"], "running");
+
+        let deleted = db_delete(&conn, "agents", json!({ "where": { "id": id } })).unwrap();
+        assert_eq!(deleted, 1);
+
+        let count = db_count(&conn, "agents", json!({})).unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn rejects_unknown_table() {
+        let db = test_db();
+        let conn = db.lock();
+        assert!(db_select(&conn, "evil_table", json!({})).is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_column() {
+        let db = test_db();
+        let conn = db.lock();
+        assert!(
+            db_select(&conn, "agents", json!({ "where": { "id; DROP TABLE agents": "x" } }))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn fts_search() {
+        let db = test_db();
+        let conn = db.lock();
+
+        let agent_id = db_insert(
+            &conn,
+            "agents",
+            json!({ "name": "search-test", "provider": "claude" }),
+        )
+        .unwrap();
+
+        db_insert(
+            &conn,
+            "messages",
+            json!({
+                "agent_id": agent_id,
+                "kind": "agent_message",
+                "content": "I decided to use polling instead of websockets because the server doesn't support persistent connections",
+                "sequence": 1
+            }),
+        )
+        .unwrap();
+
+        db_insert(
+            &conn,
+            "messages",
+            json!({
+                "agent_id": agent_id,
+                "kind": "user_message",
+                "content": "Why did you choose that approach?",
+                "sequence": 2
+            }),
+        )
+        .unwrap();
+
+        let results = db_query(
+            &conn,
+            "SELECT m.id, m.agent_id, m.kind, m.content, m.sequence \
+             FROM messages m \
+             JOIN messages_fts ON messages_fts.rowid = m.rowid \
+             WHERE messages_fts MATCH ?1 \
+             ORDER BY rank",
+            vec![json!("polling websockets")],
+        )
+        .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0]["content"]
+            .as_str()
+            .unwrap()
+            .contains("polling"));
+    }
+
+    #[test]
+    fn db_query_rejects_non_select() {
+        let db = test_db();
+        let conn = db.lock();
+        assert!(db_query(&conn, "DELETE FROM agents", vec![]).is_err());
+        assert!(db_query(&conn, "DROP TABLE agents", vec![]).is_err());
+    }
+
+    #[test]
+    fn auto_generates_uuid_and_timestamp() {
+        let db = test_db();
+        let conn = db.lock();
+
+        let id = db_insert(
+            &conn,
+            "agents",
+            json!({ "name": "auto", "provider": "claude" }),
+        )
+        .unwrap();
+
+        assert!(!id.is_empty());
+        assert!(uuid::Uuid::parse_str(&id).is_ok());
+
+        let rows = db_select(&conn, "agents", json!({ "where": { "id": id } })).unwrap();
+        let created = rows[0]["created_at"].as_i64().unwrap();
+        assert!(created > 0);
+    }
+
+    #[test]
+    fn cascade_deletes_messages_with_agent() {
+        let db = test_db();
+        let conn = db.lock();
+
+        let agent_id = db_insert(
+            &conn,
+            "agents",
+            json!({ "name": "cascade", "provider": "claude" }),
+        )
+        .unwrap();
+
+        db_insert(
+            &conn,
+            "messages",
+            json!({ "agent_id": agent_id, "kind": "user_message", "content": "hello", "sequence": 1 }),
+        )
+        .unwrap();
+
+        db_delete(&conn, "agents", json!({ "where": { "id": agent_id } })).unwrap();
+
+        let count = db_count(
+            &conn,
+            "messages",
+            json!({ "where": { "agent_id": agent_id } }),
+        )
+        .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn null_where_clause() {
+        let db = test_db();
+        let conn = db.lock();
+
+        db_insert(
+            &conn,
+            "agents",
+            json!({ "name": "with-error", "provider": "claude", "last_error": "boom" }),
+        )
+        .unwrap();
+
+        db_insert(
+            &conn,
+            "agents",
+            json!({ "name": "no-error", "provider": "claude" }),
+        )
+        .unwrap();
+
+        let rows = db_select(
+            &conn,
+            "agents",
+            json!({ "where": { "last_error": null } }),
+        )
+        .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["name"], "no-error");
+    }
+}

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -24,6 +24,9 @@ pub enum Error {
     #[error("json error: {0}")]
     Json(#[from] serde_json::Error),
 
+    #[error("database error: {0}")]
+    Database(#[from] rusqlite::Error),
+
     #[error("{0}")]
     Other(String),
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod activity;
 mod agent;
 mod branding;
 mod commands;
+mod database;
 mod error;
 mod gh;
 mod git;
@@ -14,11 +15,79 @@ mod supervisor;
 mod watcher;
 mod workspace;
 
+use parking_lot::Mutex;
+use rusqlite::Connection;
+use serde_json::Value;
 use std::sync::Arc;
 use tauri::Manager;
 
 use crate::supervisor::Supervisor;
 use crate::workspace::WorkspaceManager;
+
+type DbState = Arc<Mutex<Connection>>;
+
+#[tauri::command]
+async fn db_insert(
+    table: String,
+    data: Value,
+    state: tauri::State<'_, DbState>,
+) -> Result<String, String> {
+    let conn = state.lock();
+    database::db_insert(&conn, &table, data).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn db_select(
+    table: String,
+    query: Value,
+    state: tauri::State<'_, DbState>,
+) -> Result<Value, String> {
+    let conn = state.lock();
+    let rows = database::db_select(&conn, &table, query).map_err(|e| e.to_string())?;
+    serde_json::to_value(rows).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn db_update(
+    table: String,
+    query: Value,
+    data: Value,
+    state: tauri::State<'_, DbState>,
+) -> Result<usize, String> {
+    let conn = state.lock();
+    database::db_update(&conn, &table, query, data).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn db_delete(
+    table: String,
+    query: Value,
+    state: tauri::State<'_, DbState>,
+) -> Result<usize, String> {
+    let conn = state.lock();
+    database::db_delete(&conn, &table, query).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn db_count(
+    table: String,
+    query: Value,
+    state: tauri::State<'_, DbState>,
+) -> Result<i64, String> {
+    let conn = state.lock();
+    database::db_count(&conn, &table, query).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn db_query(
+    sql: String,
+    params: Vec<Value>,
+    state: tauri::State<'_, DbState>,
+) -> Result<Value, String> {
+    let conn = state.lock();
+    let rows = database::db_query(&conn, &sql, params).map_err(|e| e.to_string())?;
+    serde_json::to_value(rows).map_err(|e| e.to_string())
+}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -35,6 +104,10 @@ pub fn run() {
         .setup(|app| {
             let app_data = app.path().app_data_dir()?;
             std::fs::create_dir_all(&app_data)?;
+
+            let db = database::init(&app_data)
+                .expect("failed to initialize database");
+            app.manage(db);
 
             let workspace = Arc::new(WorkspaceManager::new(app_data)?);
             let supervisor = Arc::new(Supervisor::new(workspace));
@@ -54,6 +127,12 @@ pub fn run() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
+            db_insert,
+            db_select,
+            db_update,
+            db_delete,
+            db_count,
+            db_query,
             commands::get_workspace,
             commands::get_agent_diff_stats,
             commands::add_workspace_repo,

--- a/src/storage/agents.ts
+++ b/src/storage/agents.ts
@@ -1,0 +1,107 @@
+import { dbSelect, dbSelectOne, dbInsert, dbUpdate, dbDelete, dbCount } from "./db";
+
+export interface AgentRow {
+  id: string;
+  name: string;
+  provider: string;
+  task: string;
+  status: string;
+  view: string;
+  session_id: string | null;
+  created_at: number;
+  last_error: string | null;
+  archived_at: number | null;
+}
+
+export interface AgentRepoRow {
+  id: string;
+  agent_id: string;
+  repo_path: string;
+  subdir: string;
+  branch: string | null;
+  parent_branch: string | null;
+  is_primary: number;
+  branch_tip_sha: string | null;
+  parent_branch_sha: string | null;
+  diff_additions: number;
+  diff_deletions: number;
+}
+
+export async function listAgents(status?: string): Promise<AgentRow[]> {
+  const where: Record<string, unknown> = {};
+  if (status) where.status = status;
+  return dbSelect<AgentRow>("agents", {
+    where,
+    orderBy: "created_at",
+    orderDirection: "desc",
+  });
+}
+
+export async function listLiveAgents(): Promise<AgentRow[]> {
+  return dbSelect<AgentRow>("agents", {
+    where: { archived_at: null },
+    orderBy: "created_at",
+    orderDirection: "desc",
+  });
+}
+
+export async function listArchivedAgents(): Promise<AgentRow[]> {
+  // archived_at IS NOT NULL — can't express with generic CRUD, use non-null filter in TS
+  const all = await dbSelect<AgentRow>("agents", {
+    orderBy: "created_at",
+    orderDirection: "desc",
+  });
+  return all.filter((a) => a.archived_at != null);
+}
+
+export async function getAgent(id: string): Promise<AgentRow | null> {
+  return dbSelectOne<AgentRow>("agents", { where: { id } });
+}
+
+export async function insertAgent(
+  data: Omit<AgentRow, "created_at">,
+): Promise<string> {
+  return dbInsert("agents", data as Record<string, unknown>);
+}
+
+export async function updateAgent(
+  id: string,
+  data: Partial<AgentRow>,
+): Promise<void> {
+  await dbUpdate("agents", { id }, data as Record<string, unknown>);
+}
+
+export async function deleteAgent(id: string): Promise<void> {
+  await dbDelete("agents", { id });
+}
+
+export async function countAgents(
+  where?: Record<string, unknown>,
+): Promise<number> {
+  return dbCount("agents", where);
+}
+
+// ── Agent repos ─────────────────────────────────────────────────────────────
+
+export async function listAgentRepos(agentId: string): Promise<AgentRepoRow[]> {
+  return dbSelect<AgentRepoRow>("agent_repos", {
+    where: { agent_id: agentId },
+  });
+}
+
+export async function insertAgentRepo(
+  data: Omit<AgentRepoRow, "id" | "branch_tip_sha" | "parent_branch_sha" | "diff_additions" | "diff_deletions">,
+): Promise<string> {
+  return dbInsert("agent_repos", data as Record<string, unknown>);
+}
+
+export async function updateAgentRepo(
+  id: string,
+  data: Partial<AgentRepoRow>,
+): Promise<void> {
+  await dbUpdate("agent_repos", { id }, data as Record<string, unknown>);
+}
+
+export async function deleteAgentRepos(agentId: string): Promise<void> {
+  await dbDelete("agent_repos", { agent_id: agentId });
+}

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -1,0 +1,55 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export async function dbInsert(
+  table: string,
+  data: Record<string, unknown>,
+): Promise<string> {
+  return invoke<string>("db_insert", { table, data });
+}
+
+export async function dbSelect<T>(
+  table: string,
+  query: Record<string, unknown> = {},
+): Promise<T[]> {
+  const rows = await invoke<T[]>("db_select", { table, query });
+  return Array.isArray(rows) ? rows : [];
+}
+
+export async function dbSelectOne<T>(
+  table: string,
+  query: Record<string, unknown> = {},
+): Promise<T | null> {
+  const rows = await dbSelect<T>(table, { ...query, limit: 1 });
+  return rows[0] ?? null;
+}
+
+export async function dbUpdate(
+  table: string,
+  where: Record<string, unknown>,
+  data: Record<string, unknown>,
+): Promise<number> {
+  return invoke<number>("db_update", { table, query: { where }, data });
+}
+
+export async function dbDelete(
+  table: string,
+  where: Record<string, unknown>,
+): Promise<number> {
+  return invoke<number>("db_delete", { table, query: { where } });
+}
+
+export async function dbCount(
+  table: string,
+  where?: Record<string, unknown>,
+): Promise<number> {
+  const query = where ? { where } : {};
+  return invoke<number>("db_count", { table, query });
+}
+
+export async function dbQuery<T>(
+  sql: string,
+  params: unknown[] = [],
+): Promise<T[]> {
+  const rows = await invoke<T[]>("db_query", { sql, params });
+  return Array.isArray(rows) ? rows : [];
+}

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,0 +1,4 @@
+export { dbInsert, dbSelect, dbSelectOne, dbUpdate, dbDelete, dbCount, dbQuery } from "./db";
+export type { AgentRow, AgentRepoRow } from "./agents";
+export type { MessageRow, SearchResult } from "./messages";
+export type { WorkspaceRepoRow } from "./workspace";

--- a/src/storage/messages.ts
+++ b/src/storage/messages.ts
@@ -1,0 +1,82 @@
+import { dbInsert, dbSelect, dbDelete, dbCount, dbQuery } from "./db";
+
+export interface MessageRow {
+  id: string;
+  agent_id: string;
+  kind: string;
+  content: string;
+  metadata_json: string | null;
+  sequence: number;
+  created_at: number;
+}
+
+export interface SearchResult {
+  id: string;
+  agent_id: string;
+  agent_name: string;
+  agent_task: string;
+  kind: string;
+  content: string;
+  sequence: number;
+  created_at: number;
+}
+
+export async function insertMessage(
+  data: Omit<MessageRow, "id" | "created_at">,
+): Promise<string> {
+  return dbInsert("messages", data as Record<string, unknown>);
+}
+
+export async function listMessages(
+  agentId: string,
+  opts?: { limit?: number; offset?: number },
+): Promise<MessageRow[]> {
+  return dbSelect<MessageRow>("messages", {
+    where: { agent_id: agentId },
+    orderBy: "sequence",
+    orderDirection: "asc",
+    ...(opts?.limit && { limit: opts.limit }),
+    ...(opts?.offset && { offset: opts.offset }),
+  });
+}
+
+export async function countMessages(agentId: string): Promise<number> {
+  return dbCount("messages", { agent_id: agentId });
+}
+
+export async function deleteMessages(agentId: string): Promise<void> {
+  await dbDelete("messages", { agent_id: agentId });
+}
+
+export async function searchMessages(
+  query: string,
+  opts?: { agentId?: string; limit?: number },
+): Promise<SearchResult[]> {
+  const limit = opts?.limit ?? 50;
+
+  if (opts?.agentId) {
+    return dbQuery<SearchResult>(
+      `SELECT m.id, m.agent_id, a.name AS agent_name, a.task AS agent_task,
+              m.kind, m.content, m.sequence, m.created_at
+       FROM messages m
+       JOIN messages_fts ON messages_fts.rowid = m.rowid
+       JOIN agents a ON a.id = m.agent_id
+       WHERE messages_fts MATCH ?1 AND m.agent_id = ?2
+       ORDER BY rank
+       LIMIT ?3`,
+      [query, opts.agentId, limit],
+    );
+  }
+
+  return dbQuery<SearchResult>(
+    `SELECT m.id, m.agent_id, a.name AS agent_name, a.task AS agent_task,
+            m.kind, m.content, m.sequence, m.created_at
+     FROM messages m
+     JOIN messages_fts ON messages_fts.rowid = m.rowid
+     JOIN agents a ON a.id = m.agent_id
+     WHERE messages_fts MATCH ?1
+     ORDER BY rank
+     LIMIT ?2`,
+    [query, limit],
+  );
+}

--- a/src/storage/workspace.ts
+++ b/src/storage/workspace.ts
@@ -1,0 +1,22 @@
+import { dbSelect, dbInsert, dbDelete } from "./db";
+
+export interface WorkspaceRepoRow {
+  id: string;
+  repo_path: string;
+  created_at: number;
+}
+
+export async function listWorkspaceRepos(): Promise<WorkspaceRepoRow[]> {
+  return dbSelect<WorkspaceRepoRow>("workspace_repos", {
+    orderBy: "created_at",
+    orderDirection: "asc",
+  });
+}
+
+export async function addWorkspaceRepo(repoPath: string): Promise<string> {
+  return dbInsert("workspace_repos", { repo_path: repoPath });
+}
+
+export async function removeWorkspaceRepo(repoPath: string): Promise<void> {
+  await dbDelete("workspace_repos", { repo_path: repoPath });
+}


### PR DESCRIPTION
## Summary

- Adds a complete SQLite persistence layer to replace the monolithic `workspaces.json` file, with schema for agents, agent repos, messages, and workspace repos
- Rust side is a thin generic CRUD API (insert, select, update, delete, count, query) with table/column name allowlisting and a SELECT-only raw query command for FTS5 joins
- TS side provides typed domain modules (`src/storage/`) for agents, messages (with full-text search across all sessions), and workspace repos
- Includes FTS5 virtual table with auto-sync triggers for searching conversation content — enabling discovery of *why* decisions were made, not just *what* changed
- 9 new Rust tests covering CRUD, FTS search, cascade deletes, SQL injection rejection; all 61 existing tests pass

## Test plan

- [x] `cargo test` — all 61 tests pass (9 new database tests)
- [x] `npx tsc --noEmit` — TypeScript compiles clean
- [x] `cargo build` — no warnings