### PR TITLE
Add Glob tool presenter

### DIFF
--- a/src/components/Workspace/messages/presenters/Glob.tsx
+++ b/src/components/Workspace/messages/presenters/Glob.tsx
@@ -1,0 +1,33 @@
+import type { ToolPresenter } from "./types";
+import {
+  ToolBlock,
+  firstLineOf,
+  getStringField,
+  renderToolResult,
+} from "./util";
+
+export const globPresenter: ToolPresenter = {
+  icon: "search",
+  summary: (call) => {
+    const pattern = getStringField(call.input, "pattern");
+    const path = getStringField(call.input, "path");
+    if (!pattern) return "(no pattern)";
+    const text = path ? `${pattern}  in  ${path}` : pattern;
+    return firstLineOf(text, 140);
+  },
+  expanded: (call, result) => {
+    const pattern = getStringField(call.input, "pattern");
+    const path = getStringField(call.input, "path");
+    return (
+      <>
+        <ToolBlock label="$">{pattern}</ToolBlock>
+        {path && <ToolBlock label="path">{path}</ToolBlock>}
+        {result && (
+          <ToolBlock label="↳" isError={result.is_error}>
+            {renderToolResult(result.content)}
+          </ToolBlock>
+        )}
+      </>
+    );
+  },
+};

--- a/src/components/Workspace/messages/presenters/index.ts
+++ b/src/components/Workspace/messages/presenters/index.ts
@@ -5,6 +5,7 @@ import { readPresenter } from "./Read";
 import { editPresenter } from "./Edit";
 import { writePresenter } from "./Write";
 import { grepPresenter } from "./Grep";
+import { globPresenter } from "./Glob";
 import { defaultPresenter } from "./default";
 
 export type { ToolPresenter, ToolCall, ToolResult } from "./types";
@@ -19,6 +20,7 @@ export const PRESENTERS: Record<string, ToolPresenter> = {
   Edit: editPresenter,
   Write: writePresenter,
   Grep: grepPresenter,
+  Glob: globPresenter,
 };
 
 export function getPresenter(toolName: string): ToolPresenter {


### PR DESCRIPTION
## Summary
- Adds a custom presenter for the `Glob` tool, registered in `presenters/index.ts`.
- Uses the `search` icon and a Bash-style `$ <pattern>` expanded view, with an optional `path` line when present.

## Test plan
- [ ] Trigger a `Glob` tool call in the workspace and verify the row renders with the search icon, pattern summary, and expanded layout.