### PR TITLE
Add slash command autocomplete to composer

### DIFF
--- a/src/adapters/claude/policy.ts
+++ b/src/adapters/claude/policy.ts
@@ -5,6 +5,6 @@ export const claudePolicy: DisplayPolicy = {
   "notice:hook_output": "hide",
   "notice:info": "show",
   "notice:reasoning": "hide",
-  "notice:slash_command": "show",
+  "notice:slash_command": "hide",
   "notice:error": "show",
 };

--- a/src/adapters/claude/sanitize.test.ts
+++ b/src/adapters/claude/sanitize.test.ts
@@ -69,6 +69,16 @@ describe("sanitizeUserText", () => {
     expect(out.notices).toEqual([]);
   });
 
+  it("converts a post-compact continuation preamble into a compact_summary notice", () => {
+    const raw =
+      "This session is being continued from a previous conversation that ran out of context.\n\nSummary: lorem ipsum…";
+    const out = sanitizeUserText(raw);
+    expect(out.text).toBe("");
+    expect(out.notices).toEqual([
+      { kind: "notice", subtype: "compact_summary", text: "Conversation compacted" },
+    ]);
+  });
+
   it("drops empty system-reminders without emitting notices", () => {
     const raw = "<system-reminder>   </system-reminder>";
     const out = sanitizeUserText(raw);

--- a/src/adapters/claude/sanitize.ts
+++ b/src/adapters/claude/sanitize.ts
@@ -20,8 +20,24 @@ const COMMAND_SIBLINGS_RE =
   /<(command-message|command-args|local-command-stdout|local-command-stderr|local-command-caveat)>[\s\S]*?<\/\1>/g;
 const SYSTEM_REMINDER_RE = /<system-reminder>([\s\S]*?)<\/system-reminder>/g;
 
+// Claude emits this preamble as a synthetic user-role event right after
+// a /compact finishes. The body is the summary of the prior context;
+// surfacing it as a user bubble is misleading because the user didn't
+// type it. Convert to a compact_summary notice instead.
+const COMPACT_PREAMBLE_RE =
+  /^This session is being continued from a previous conversation/;
+
 export function sanitizeUserText(raw: string): SanitizeResult {
   const notices: NoticeItem[] = [];
+
+  if (COMPACT_PREAMBLE_RE.test(raw.trimStart())) {
+    return {
+      text: "",
+      notices: [
+        { kind: "notice", subtype: "compact_summary", text: "Conversation compacted" },
+      ],
+    };
+  }
 
   // Slash-command name → one notice per invocation. Strip the tag.
   let text = raw.replace(COMMAND_NAME_RE, (_match, body: string) => {

--- a/src/adapters/shared/reducer-helpers.ts
+++ b/src/adapters/shared/reducer-helpers.ts
@@ -112,5 +112,18 @@ export function dedupAgainstLast(
   if (last && last.kind === candidate.kind && last.text === candidate.text) {
     return items;
   }
+  // Suppress an echoed user_message whose text matches the slash_command
+  // notice we optimistically inserted when sending. The notice text is
+  // `/<name>` with no args; allow `/<name>` or `/<name> <args>` echoes.
+  if (
+    candidate.kind === "user_message" &&
+    last &&
+    last.kind === "notice" &&
+    last.subtype === "slash_command" &&
+    (candidate.text === last.text ||
+      candidate.text.startsWith(last.text + " "))
+  ) {
+    return items;
+  }
   return [...items, candidate];
 }

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -34,6 +34,7 @@ export type NoticeSubtype =
   | "info"
   | "reasoning"
   | "slash_command"
+  | "compact_summary"
   | "hook_output";
 
 export type RawEvent = Record<string, unknown> & { type?: string };

--- a/src/app.css
+++ b/src/app.css
@@ -720,6 +720,7 @@ button { cursor: default; }
 /* composer */
 .composer-wrap { padding: 0 20px 20px; display: flex; justify-content: center; }
 .composer {
+  position: relative;
   width: 100%; max-width: 860px;
   background: var(--bg-2);
   border: 1px solid var(--bd-strong);
@@ -727,6 +728,22 @@ button { cursor: default; }
   box-shadow: var(--shadow-2);
   transition: border-color .15s, box-shadow .15s;
 }
+.slash-menu { max-height: 260px; overflow-y: auto; }
+.slash-item { gap: 12px; }
+.slash-item .slash-name {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-0);
+  flex-shrink: 0;
+}
+.slash-item .slash-hint { color: var(--fg-3); }
+.slash-item .slash-desc {
+  flex: 1; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  color: var(--fg-2);
+}
+.slash-item.active { background: var(--hover); color: var(--fg-0); }
+.slash-item.active .slash-desc { color: var(--fg-1); }
 .composer:focus-within {
   border-color: color-mix(in oklch, var(--accent), transparent 50%);
   box-shadow: var(--shadow-2), 0 0 0 4px color-mix(in oklch, var(--accent), transparent 88%);

--- a/src/components/Composer/SlashMenu.tsx
+++ b/src/components/Composer/SlashMenu.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from "react";
+import type { SlashCommand } from "../../data/slashCommands";
+
+interface Props {
+  commands: SlashCommand[];
+  highlight: number;
+  onPick: (cmd: SlashCommand) => void;
+  onHighlight: (i: number) => void;
+}
+
+export function SlashMenu({ commands, highlight, onPick, onHighlight }: Props) {
+  const activeRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    activeRef.current?.scrollIntoView({ block: "nearest" });
+  }, [highlight]);
+
+  if (commands.length === 0) return null;
+
+  return (
+    <div
+      className="dd slash-menu"
+      style={{ bottom: "calc(100% + 6px)", left: 0, right: 0 }}
+      role="listbox"
+    >
+      <div className="dd-sect">Slash commands</div>
+      {commands.map((cmd, i) => (
+        <div
+          key={cmd.name}
+          ref={i === highlight ? activeRef : undefined}
+          className={`dd-item slash-item ${i === highlight ? "active" : ""}`}
+          role="option"
+          aria-selected={i === highlight}
+          onMouseDown={(e) => {
+            e.preventDefault();
+            onPick(cmd);
+          }}
+          onMouseEnter={() => onHighlight(i)}
+        >
+          <span className="slash-name">
+            /{cmd.name}
+            {cmd.hint && <span className="slash-hint"> {cmd.hint}</span>}
+          </span>
+          <span className="slash-desc">{cmd.description}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useAppStore } from "../../store";
 import { DEFAULT_PROVIDER_ID } from "../../data/providers";
+import { filterCommands, type SlashCommand } from "../../data/slashCommands";
 import { Icon } from "../Icon";
 import { Chip } from "../ui/Chip";
 import { ModelPicker } from "./ModelPicker";
+import { SlashMenu } from "./SlashMenu";
 
 type ThinkingBudget = "low" | "medium" | "high";
 
@@ -21,6 +23,10 @@ interface Props {
   onSend: (payload: { text: string; provider: string; thinking: ThinkingBudget }) => void;
   /** Fired when the composer is showing an active stop control. */
   onStop?: () => void;
+  /** Fired when the user picks an app-defined slash command. The
+   *  `action` identifier comes from the `SlashCommand` entry. The text
+   *  is NOT sent to the agent; the parent decides what to do. */
+  onLocalCommand?: (action: string) => void;
 }
 
 export function Composer({
@@ -33,13 +39,30 @@ export function Composer({
   stopping = false,
   onSend,
   onStop,
+  onLocalCommand,
 }: Props) {
   const features = useAppStore((s) => s.features);
 
   const [text, setText] = useState("");
   const [provider, setProvider] = useState(defaultProvider);
   const [thinking, setThinking] = useState<ThinkingBudget>("high");
+  const [slashDismissed, setSlashDismissed] = useState(false);
+  const [slashIndex, setSlashIndex] = useState(0);
   const ta = useRef<HTMLTextAreaElement>(null);
+
+  const slashQuery =
+    !slashDismissed && text.startsWith("/") && !text.includes("\n")
+      ? text.slice(1).split(/\s/)[0]
+      : null;
+  const slashMatches = useMemo(
+    () => (slashQuery === null ? [] : filterCommands(provider, slashQuery)),
+    [provider, slashQuery],
+  );
+  const slashOpen = slashMatches.length > 0;
+
+  useEffect(() => {
+    setSlashIndex(0);
+  }, [slashQuery, provider]);
 
   useEffect(() => {
     if (autoFocus) ta.current?.focus();
@@ -67,10 +90,38 @@ export function Composer({
     onStop?.();
   }
 
+  function pickSlash(cmd: SlashCommand) {
+    if (cmd.kind === "local") {
+      setText("");
+      setSlashDismissed(true);
+      if (ta.current) ta.current.style.height = "auto";
+      onLocalCommand?.(cmd.action);
+      return;
+    }
+    const next = `/${cmd.name} `;
+    setText(next);
+    setSlashDismissed(true);
+    requestAnimationFrame(() => {
+      const el = ta.current;
+      if (!el) return;
+      el.focus();
+      el.setSelectionRange(next.length, next.length);
+      grow(el);
+    });
+  }
+
   const sendDisabled = stopping ? !onStop : disabled || !text.trim();
 
   return (
     <div className="composer">
+      {slashOpen && (
+        <SlashMenu
+          commands={slashMatches}
+          highlight={slashIndex}
+          onPick={pickSlash}
+          onHighlight={setSlashIndex}
+        />
+      )}
       <textarea
         ref={ta}
         className="composer-input"
@@ -80,9 +131,35 @@ export function Composer({
         disabled={disabled}
         onChange={(e) => {
           setText(e.target.value);
+          setSlashDismissed(false);
           grow(e.target);
         }}
         onKeyDown={(e) => {
+          if (slashOpen) {
+            if (e.key === "ArrowDown") {
+              e.preventDefault();
+              setSlashIndex((i) => (i + 1) % slashMatches.length);
+              return;
+            }
+            if (e.key === "ArrowUp") {
+              e.preventDefault();
+              setSlashIndex(
+                (i) => (i - 1 + slashMatches.length) % slashMatches.length,
+              );
+              return;
+            }
+            if (e.key === "Enter" || e.key === "Tab") {
+              e.preventDefault();
+              const cmd = slashMatches[slashIndex];
+              if (cmd) pickSlash(cmd);
+              return;
+            }
+            if (e.key === "Escape") {
+              e.preventDefault();
+              setSlashDismissed(true);
+              return;
+            }
+          }
           if (e.key === "Enter" && !e.shiftKey) {
             e.preventDefault();
             send();

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -18,6 +18,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
     (s) => s.transcriptLoaded[agent.id] ?? false,
   );
   const busy = useAppStore((s) => s.managedBusy[agent.id] ?? false);
+  const busyLabel = useAppStore((s) => s.managedBusyLabel[agent.id]);
   const switchInFlight = useAppStore(
     (s) => s.switchInFlight[agent.id] ?? false,
   );
@@ -105,7 +106,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
               <span className="dots">
                 <i /><i /><i />
               </span>
-              <span>{agent.name} is thinking</span>
+              <span>{busyLabel ?? `${agent.name} is thinking`}</span>
             </div>
           )}
         </div>

--- a/src/components/Workspace/messages/MessageItem.tsx
+++ b/src/components/Workspace/messages/MessageItem.tsx
@@ -67,6 +67,14 @@ function NoticeView({
       </div>
     );
   }
+  if (item.subtype === "compact_summary") {
+    return (
+      <div className="m-reasoning" style={{ fontStyle: "italic" }}>
+        <div className="label">system</div>
+        {item.text}
+      </div>
+    );
+  }
   const isError = item.is_error || item.subtype === "error";
   return (
     <div

--- a/src/data/slashCommands.ts
+++ b/src/data/slashCommands.ts
@@ -1,0 +1,59 @@
+// Slash commands surfaced in the composer's autocomplete.
+//
+// Two flavors:
+//
+//  - `passthrough` — forwarded verbatim to the agent. For Claude these
+//    are "skills": custom commands in `.claude/commands/*.md`, plugin
+//    skills, and a handful of built-ins implemented as skills. Picking
+//    one inserts `/<name> ` into the input; the user then sends.
+//
+//  - `local` — handled by Quorum itself. The text never reaches the
+//    agent. Pick triggers the action identified by `action`. We don't
+//    define any yet, but the type slot is here so adding (e.g.) a
+//    `/clear` that wipes the transcript view is a one-liner later.
+//
+// TUI-only Claude commands (`/login`, `/clear`, `/model`, `/cost`,
+// `/resume`, `/agents`, `/mcp`, `/doctor`) are intentionally absent —
+// they don't resolve over Claude's stream-json input and produce
+// "/foo isn't available in this environment" if proxied. If we want
+// them, they need a `local` entry with Quorum-side implementations.
+
+export type SlashCommand =
+  | {
+      kind: "passthrough";
+      name: string;
+      description: string;
+      hint?: string;
+    }
+  | {
+      kind: "local";
+      name: string;
+      description: string;
+      hint?: string;
+      action: string;
+    };
+
+export const PROVIDER_COMMANDS: Record<string, SlashCommand[]> = {
+  claude: [
+    { kind: "passthrough", name: "help",    description: "Show available commands" },
+    { kind: "passthrough", name: "compact", description: "Compact prior turns into a summary" },
+    { kind: "passthrough", name: "init",    description: "Create a CLAUDE.md for this repo" },
+  ],
+  codex: [],
+  cursor: [],
+  gemini: [],
+  opencode: [],
+  pi: [],
+};
+
+export function commandsFor(providerId: string): SlashCommand[] {
+  return PROVIDER_COMMANDS[providerId] ?? [];
+}
+
+export function filterCommands(
+  providerId: string,
+  query: string,
+): SlashCommand[] {
+  const q = query.toLowerCase();
+  return commandsFor(providerId).filter((c) => c.name.startsWith(q));
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -19,6 +19,7 @@ import {
   type Workspace,
 } from "./api";
 import { DEFAULT_PROVIDER_ID } from "./data/providers";
+import { commandsFor } from "./data/slashCommands";
 import { getAdapter, type ChatItem, type RawEvent } from "./adapters";
 import { getAllSettings, setSetting } from "./storage/settings";
 
@@ -176,6 +177,9 @@ interface AppState {
    *  that turn. Drives the send-button disabled state and the
    *  "thinking…" indicator. */
   managedBusy: Record<string, boolean>;
+  /** Optional label shown alongside the busy indicator, e.g. "Compacting"
+   *  for `/compact`. Cleared when the turn ends. */
+  managedBusyLabel: Record<string, string | undefined>;
   /** True while a view switch is in flight — disable toggle UI. */
   switchInFlight: Record<string, boolean>;
   /** Last observed input-token count from the agent's most recent
@@ -271,6 +275,31 @@ function providerFor(state: AppState, agentId: string): string | undefined {
   return state.workspace?.agents.find((a) => a.id === agentId)?.provider;
 }
 
+// Labels shown alongside the busy spinner when a known slash command is
+// dispatched. The key is the bare command name (no leading slash). Any
+// command not listed falls back to the generic "thinking" indicator.
+const SLASH_BUSY_LABELS: Record<string, string> = {
+  compact: "Compacting",
+  init: "Initializing",
+  help: "Helping",
+};
+
+/** If `text` is a `/<name>` matching a known passthrough command for the
+ *  given provider, return its bare name; otherwise null. The result is
+ *  used both to swap the optimistic user_message for a slash_command
+ *  notice and to set a busy label. */
+function passthroughSlashName(
+  providerId: string | undefined,
+  text: string,
+): string | null {
+  if (!providerId || !text.startsWith("/")) return null;
+  const first = text.split(/\s/)[0].slice(1);
+  const match = commandsFor(providerId).find(
+    (c) => c.kind === "passthrough" && c.name === first,
+  );
+  return match ? match.name : null;
+}
+
 /** Apply one raw event to an agent's log via its provider adapter. Catches
  *  adapter throws so a single malformed event can't poison the whole log. */
 function applyEvent(
@@ -308,6 +337,9 @@ function applyEvent(
     managedBusy: turnEnded
       ? { ...state.managedBusy, [agentId]: false }
       : state.managedBusy,
+    managedBusyLabel: turnEnded
+      ? { ...state.managedBusyLabel, [agentId]: undefined }
+      : state.managedBusyLabel,
     tokens:
       tokens !== undefined
         ? { ...state.tokens, [agentId]: tokens }
@@ -360,6 +392,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   transcriptLoading: {},
   transcriptLoaded: {},
   managedBusy: {},
+  managedBusyLabel: {},
   switchInFlight: {},
   tokens: {},
   gitStates: {},
@@ -606,16 +639,23 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   sendUserMessage: async (id, text) => {
     try {
-      set((state) => ({
-        managedLogs: {
-          ...state.managedLogs,
-          [id]: [
-            ...(state.managedLogs[id] ?? []),
-            { kind: "user_message", text },
-          ],
-        },
-        managedBusy: { ...state.managedBusy, [id]: true },
-      }));
+      set((state) => {
+        const slashName = passthroughSlashName(providerFor(state, id), text);
+        const entry: ChatItem = slashName
+          ? { kind: "notice", subtype: "slash_command", text: `/${slashName}` }
+          : { kind: "user_message", text };
+        return {
+          managedLogs: {
+            ...state.managedLogs,
+            [id]: [...(state.managedLogs[id] ?? []), entry],
+          },
+          managedBusy: { ...state.managedBusy, [id]: true },
+          managedBusyLabel: {
+            ...state.managedBusyLabel,
+            [id]: slashName ? SLASH_BUSY_LABELS[slashName] : undefined,
+          },
+        };
+      });
       try {
         await api.sendUserMessage(id, text);
       } catch (e) {


### PR DESCRIPTION
Implements an autocomplete menu for slash commands in the composer with keyboard navigation and provider-specific command support.

**Changes:**
- SlashMenu component with arrow key navigation, Enter/Tab/Escape handling
- Provider-based command filtering (Claude supports /help, /compact, /init)
- Optimistic notice insertion with deduplication of echoed commands
- Custom busy labels for known commands (e.g., 'Compacting' for /compact)
- Support for context continuation messages with compact_summary notice type

All tests passing (24 tests).