### PR TITLE
Persist Run panel overrides per project

### DIFF
--- a/src-tauri/migrations/0002_project_settings.sql
+++ b/src-tauri/migrations/0002_project_settings.sql
@@ -1,0 +1,8 @@
+CREATE TABLE project_settings (
+    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    key TEXT NOT NULL,
+    value TEXT NOT NULL,
+    PRIMARY KEY (project_id, key)
+);
+
+CREATE INDEX idx_project_settings_project_id ON project_settings(project_id);

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use crate::error::{Error, Result};
 
 const ALLOWED_TABLES: &[&str] = &[
-    "accounts", "agents", "messages", "projects", "repos", "settings", "worktrees",
+    "accounts", "agents", "messages", "project_settings", "projects", "repos", "settings", "worktrees",
 ];
 
 fn validate_table(table: &str) -> Result<()> {
@@ -30,6 +30,7 @@ fn validate_column(col: &str) -> Result<()> {
 fn get_migrations() -> Migrations<'static> {
     Migrations::new(vec![
         M::up(include_str!("../migrations/0001_initial_schema.sql")),
+        M::up(include_str!("../migrations/0002_project_settings.sql")),
     ])
 }
 
@@ -304,7 +305,13 @@ pub fn db_upsert(
     conflict_column: &str,
 ) -> Result<String> {
     validate_table(table)?;
-    validate_column(conflict_column)?;
+    let conflict_cols: Vec<&str> = conflict_column.split(',').map(|s| s.trim()).collect();
+    if conflict_cols.is_empty() {
+        return Err(Error::Other("conflict_column must not be empty".into()));
+    }
+    for col in &conflict_cols {
+        validate_column(col)?;
+    }
     let obj = data
         .as_object()
         .ok_or_else(|| Error::Other("data must be a JSON object".into()))?;
@@ -323,22 +330,32 @@ pub fn db_upsert(
         columns.push(col.as_str());
         placeholders.push(format!("?{}", i + 1));
         params.push(json_to_sql(val)?);
-        if col != conflict_column {
+        if !conflict_cols.contains(&col.as_str()) {
             update_clauses.push(format!("{col} = excluded.{col}"));
         }
     }
 
-    let sql = format!(
-        "INSERT INTO {table} ({}) VALUES ({}) ON CONFLICT({conflict_column}) DO UPDATE SET {}",
-        columns.join(", "),
-        placeholders.join(", "),
-        update_clauses.join(", ")
-    );
+    let conflict_target = conflict_cols.join(", ");
+    let sql = if update_clauses.is_empty() {
+        format!(
+            "INSERT INTO {table} ({}) VALUES ({}) ON CONFLICT({conflict_target}) DO NOTHING",
+            columns.join(", "),
+            placeholders.join(", "),
+        )
+    } else {
+        format!(
+            "INSERT INTO {table} ({}) VALUES ({}) ON CONFLICT({conflict_target}) DO UPDATE SET {}",
+            columns.join(", "),
+            placeholders.join(", "),
+            update_clauses.join(", ")
+        )
+    };
 
     conn.prepare(&sql)?.execute(params_from_iter(params))?;
 
-    let id = obj
-        .get(conflict_column)
+    let id = conflict_cols
+        .first()
+        .and_then(|c| obj.get(*c))
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -229,7 +229,7 @@ impl Supervisor {
             parent_branch,
         };
 
-        let record = new_agent_record(
+        let mut record = new_agent_record(
             agent_id.clone(),
             name,
             provider,
@@ -240,7 +240,7 @@ impl Supervisor {
         let parent_dir = agent_parent_dir(&agent_id)?;
         let primary_worktree = repo_worktree_path(&agent_id, &subdir)?;
 
-        self.workspace.add_agent(record.clone())?;
+        self.workspace.add_agent(&mut record)?;
         emit_status(&app, &agent_id, AgentStatus::Spawning, None);
         arm_spawn_timeout(self.clone(), app.clone(), agent_id.clone());
 

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -104,6 +104,11 @@ fn default_provider() -> String {
 pub struct AgentRecord {
     pub id: String,
     pub name: String,
+    /// The project this agent belongs to. Populated by `add_agent`
+    /// (looked up from the primary repo path) and re-read from the
+    /// `agents.project_id` column.
+    #[serde(default)]
+    pub project_id: String,
     /// Which CLI backend powers this agent. Currently only "claude" has a
     /// Rust transport; other providers will land here as their backends
     /// ship. Missing in older workspace JSON → defaults to "claude".
@@ -295,7 +300,7 @@ impl WorkspaceManager {
         Ok(names::allocate(&used))
     }
 
-    pub fn add_agent(&self, record: AgentRecord) -> Result<()> {
+    pub fn add_agent(&self, record: &mut AgentRecord) -> Result<()> {
         let conn = self.db.lock();
 
         // Look up project_id from the primary repo path.
@@ -305,6 +310,7 @@ impl WorkspaceManager {
         } else {
             return Err(Error::Other("agent must have at least one repo".into()));
         };
+        record.project_id = project_id.clone();
 
         // Parse created_at ISO string to millis.
         let created_millis = chrono::DateTime::parse_from_rfc3339(&record.created_at)
@@ -531,7 +537,7 @@ impl WorkspaceManager {
 
     fn query_all_agents(conn: &Connection) -> Vec<AgentRecord> {
         let mut stmt = match conn.prepare(
-            "SELECT id, name, provider, task, status, view, session_id,
+            "SELECT id, project_id, name, provider, task, status, view, session_id,
                     created_at, last_error, archived_at
              FROM agents ORDER BY created_at",
         ) {
@@ -542,18 +548,20 @@ impl WorkspaceManager {
         let agents: Vec<AgentRecord> = stmt
             .query_map([], |row| {
                 let id: String = row.get(0)?;
-                let name: String = row.get(1)?;
-                let provider: String = row.get(2)?;
-                let task: String = row.get(3)?;
-                let status_str: String = row.get(4)?;
-                let view_str: String = row.get(5)?;
-                let session_id: Option<String> = row.get(6)?;
-                let created_millis: i64 = row.get(7)?;
-                let last_error: Option<String> = row.get(8)?;
-                let archived_millis: Option<i64> = row.get(9)?;
+                let project_id: String = row.get(1)?;
+                let name: String = row.get(2)?;
+                let provider: String = row.get(3)?;
+                let task: String = row.get(4)?;
+                let status_str: String = row.get(5)?;
+                let view_str: String = row.get(6)?;
+                let session_id: Option<String> = row.get(7)?;
+                let created_millis: i64 = row.get(8)?;
+                let last_error: Option<String> = row.get(9)?;
+                let archived_millis: Option<i64> = row.get(10)?;
 
                 Ok((
                     id,
+                    project_id,
                     name,
                     provider,
                     task,
@@ -572,6 +580,7 @@ impl WorkspaceManager {
             .map(
                 |(
                     id,
+                    project_id,
                     name,
                     provider,
                     task,
@@ -597,6 +606,7 @@ impl WorkspaceManager {
 
                     AgentRecord {
                         id,
+                        project_id,
                         name,
                         provider,
                         repos,
@@ -811,7 +821,7 @@ impl WorkspaceManager {
     fn load_agent(conn: &Connection, id: &str) -> Result<AgentRecord> {
         let row = conn
             .query_row(
-                "SELECT id, name, provider, task, status, view, session_id,
+                "SELECT id, project_id, name, provider, task, status, view, session_id,
                         created_at, last_error, archived_at
                  FROM agents WHERE id = ?1",
                 [id],
@@ -823,10 +833,11 @@ impl WorkspaceManager {
                         row.get::<_, String>(3)?,
                         row.get::<_, String>(4)?,
                         row.get::<_, String>(5)?,
-                        row.get::<_, Option<String>>(6)?,
-                        row.get::<_, i64>(7)?,
-                        row.get::<_, Option<String>>(8)?,
-                        row.get::<_, Option<i64>>(9)?,
+                        row.get::<_, String>(6)?,
+                        row.get::<_, Option<String>>(7)?,
+                        row.get::<_, i64>(8)?,
+                        row.get::<_, Option<String>>(9)?,
+                        row.get::<_, Option<i64>>(10)?,
                     ))
                 },
             )
@@ -834,6 +845,7 @@ impl WorkspaceManager {
 
         let (
             agent_id,
+            project_id,
             name,
             provider,
             task,
@@ -858,6 +870,7 @@ impl WorkspaceManager {
 
         Ok(AgentRecord {
             id: agent_id,
+            project_id,
             name,
             provider,
             repos,
@@ -883,6 +896,9 @@ pub fn new_agent_record(
 ) -> AgentRecord {
     AgentRecord {
         id,
+        // Populated by WorkspaceManager::add_agent (looked up from the
+        // primary repo path) — empty here because callers don't know it.
+        project_id: String::new(),
         name,
         provider,
         repos: vec![primary],
@@ -1009,7 +1025,7 @@ mod tests {
                 AgentView::Custom,
             );
             running.status = AgentStatus::Running;
-            wm.add_agent(running).unwrap();
+            wm.add_agent(&mut running).unwrap();
 
             let mut stopped = new_agent_record(
                 "dolomites".into(),
@@ -1020,7 +1036,7 @@ mod tests {
                 AgentView::Custom,
             );
             stopped.status = AgentStatus::Stopped;
-            wm.add_agent(stopped).unwrap();
+            wm.add_agent(&mut stopped).unwrap();
         }
 
         // Second instance — reconciliation should flip Running → Spawning.
@@ -1065,7 +1081,7 @@ mod tests {
         wm.add_workspace_repo(repo.clone()).unwrap();
 
         let repo_str = repo.to_str().unwrap();
-        let rec = new_agent_record(
+        let mut rec = new_agent_record(
             "yosemite".into(),
             "a".into(),
             "claude".into(),
@@ -1073,7 +1089,7 @@ mod tests {
             "".into(),
             AgentView::Custom,
         );
-        wm.add_agent(rec).unwrap();
+        wm.add_agent(&mut rec).unwrap();
         wm.remove_workspace_repo(&repo).unwrap();
         let cur = wm.current().unwrap();
         // The repo record is deleted, but the agent remains (its worktree
@@ -1091,7 +1107,7 @@ mod tests {
         wm.add_workspace_repo(repo).unwrap();
 
         seed_repo(&db, "/r");
-        let rec = new_agent_record(
+        let mut rec = new_agent_record(
             "test-id".into(),
             "a".into(),
             "claude".into(),
@@ -1100,7 +1116,7 @@ mod tests {
             AgentView::Custom,
         );
         let id = rec.id.clone();
-        wm.add_agent(rec).unwrap();
+        wm.add_agent(&mut rec).unwrap();
 
         wm.update_agent_status(&id, AgentStatus::Running, None)
             .unwrap();
@@ -1114,7 +1130,7 @@ mod tests {
         seed_repo(&db, "/some/repo");
         let wm = WorkspaceManager::new(db);
 
-        let rec = new_agent_record(
+        let mut rec = new_agent_record(
             "yosemite".into(),
             "yosemite".into(),
             "claude".into(),
@@ -1123,7 +1139,7 @@ mod tests {
             AgentView::Custom,
         );
         let id = rec.id.clone();
-        wm.add_agent(rec).unwrap();
+        wm.add_agent(&mut rec).unwrap();
 
         let archive = ArchiveMetadata {
             archived_at: "2026-05-26T12:00:00+00:00".into(),
@@ -1180,7 +1196,7 @@ mod tests {
 
         {
             let wm = WorkspaceManager::new(db.clone());
-            let rec = new_agent_record(
+            let mut rec = new_agent_record(
                 "yosemite".into(),
                 "yosemite".into(),
                 "claude".into(),
@@ -1189,7 +1205,7 @@ mod tests {
                 AgentView::Custom,
             );
             let id = rec.id.clone();
-            wm.add_agent(rec).unwrap();
+            wm.add_agent(&mut rec).unwrap();
             wm.archive_agent(
                 &id,
                 ArchiveMetadata {

--- a/src/api.ts
+++ b/src/api.ts
@@ -40,6 +40,9 @@ export interface ArchiveMetadata {
 
 export interface AgentRecord {
   id: string;
+  /** Project this agent belongs to. Used to scope project-level
+   *  settings (e.g. Run panel overrides). */
+  project_id: string;
   name: string;
   /** Which CLI backend powers this agent (claude, codex, ...). Maps to
    *  the TS adapter registered under the same id. */

--- a/src/app.css
+++ b/src/app.css
@@ -1174,7 +1174,14 @@ button { cursor: default; }
   background: var(--bd-soft);
   border: 1px solid var(--bd-soft);
   border-radius: var(--r-sm);
-  overflow: hidden;
+}
+.rs-group-rows > .rs-row:first-child {
+  border-top-left-radius: calc(var(--r-sm) - 1px);
+  border-top-right-radius: calc(var(--r-sm) - 1px);
+}
+.rs-group-rows > .rs-row:last-child {
+  border-bottom-left-radius: calc(var(--r-sm) - 1px);
+  border-bottom-right-radius: calc(var(--r-sm) - 1px);
 }
 .rs-row {
   display: flex; align-items: center; gap: 12px;
@@ -1222,9 +1229,17 @@ button { cursor: default; }
   width: 22px; height: 22px; border-radius: var(--r-xs);
   background: transparent; border: 0; color: var(--fg-3);
   display: inline-flex; align-items: center; justify-content: center;
-  transition: background .1s, color .1s, transform .1s;
+  transition: background .1s, color .1s;
 }
-.rs-revert:hover { background: var(--hover); color: var(--fg-0); transform: rotate(-180deg); }
+.rs-revert:hover { background: var(--hover); color: var(--fg-0); }
+/* Rotate only the inner icon, so the tooltip ::after on the button
+ * doesn't rotate with it (and the button doesn't form a stacking context
+ * that would trap the tooltip under the next row). */
+.rs-revert-ic {
+  display: inline-flex; align-items: center; justify-content: center;
+  transition: transform .1s;
+}
+.rs-revert:hover .rs-revert-ic { transform: rotate(-180deg); }
 
 .run-sheet-f {
   display: flex; align-items: center; justify-content: space-between;

--- a/src/components/RightPanel/RunPanel.tsx
+++ b/src/components/RightPanel/RunPanel.tsx
@@ -1,7 +1,17 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { AgentRecord } from "../../api";
 import { Icon } from "../Icon";
+import {
+  deleteProjectSetting,
+  getProjectSettings,
+  setProjectSetting,
+} from "../../storage/projectSettings";
 import { RunSettingsSheet, type SetupRow } from "./RunSettingsSheet";
+
+// Settings keys we persist are prefixed so the project_settings table can
+// hold overrides from other panels (env, build, etc.) without collisions.
+const RUN_KEY_PREFIX = "run.";
+const runKey = (id: string) => `${RUN_KEY_PREFIX}${id}`;
 
 // ── Static mock data (UI pass — replaced by real data in wiring PR) ──────────
 // Rows match the Quorum v2 prototype exactly: 3 groups, 8 rows.
@@ -58,6 +68,29 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [overrides, setOverrides] = useState<Record<string, string>>({});
 
+  // Load persisted overrides for this project. Re-loads when the
+  // selected agent (and thus project) changes.
+  useEffect(() => {
+    let cancelled = false;
+    if (!agent.project_id) {
+      setOverrides({});
+      return;
+    }
+    getProjectSettings(agent.project_id).then((all) => {
+      if (cancelled) return;
+      const loaded: Record<string, string> = {};
+      for (const [k, v] of Object.entries(all)) {
+        if (k.startsWith(RUN_KEY_PREFIX)) {
+          loaded[k.slice(RUN_KEY_PREFIX.length)] = v;
+        }
+      }
+      setOverrides(loaded);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [agent.project_id]);
+
   const valueOf = (id: string) => {
     const row = RUN_SETUP.find((r) => r.id === id);
     return overrides[id] ?? row?.value ?? "";
@@ -67,7 +100,41 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
   const port   = valueOf("port");
 
   const onApply = (next: Record<string, string>) => {
-    setOverrides(next);
+    // Persist only true overrides — anything that matches the inferred
+    // default is treated as "no override" and removed from the DB.
+    const projectId = agent.project_id;
+    const cleaned: Record<string, string> = {};
+    if (projectId) {
+      const previous = overrides;
+      for (const row of RUN_SETUP) {
+        const nextVal = next[row.id];
+        const wasSet = previous[row.id] !== undefined;
+        const isOverride = nextVal !== undefined && nextVal !== row.value;
+
+        if (isOverride) {
+          cleaned[row.id] = nextVal;
+          if (previous[row.id] !== nextVal) {
+            setProjectSetting(projectId, runKey(row.id), nextVal).catch(
+              (err) => console.error("setProjectSetting failed", err),
+            );
+          }
+        } else if (wasSet) {
+          deleteProjectSetting(projectId, runKey(row.id)).catch((err) =>
+            console.error("deleteProjectSetting failed", err),
+          );
+        }
+      }
+    } else {
+      // No project — keep in-memory only (shouldn't happen in practice).
+      for (const row of RUN_SETUP) {
+        const nextVal = next[row.id];
+        if (nextVal !== undefined && nextVal !== row.value) {
+          cleaned[row.id] = nextVal;
+        }
+      }
+    }
+
+    setOverrides(cleaned);
     setSettingsOpen(false);
     setRunning(true);
   };
@@ -83,7 +150,7 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
           onClick={() => setRunning((v) => !v)}
           aria-label={running ? "Stop" : "Start"}
         >
-          <Icon name={running ? "stop" : "play"} size={11} />
+          <Icon name={running ? "stop" : "play"} size={12} />
         </button>
 
         <div className="run-cmd">

--- a/src/components/RightPanel/RunSettingsSheet.tsx
+++ b/src/components/RightPanel/RunSettingsSheet.tsx
@@ -191,7 +191,9 @@ function ConfigRow({ row, override, onChange, onRevert }: ConfigRowProps) {
         )}
         {hasOverride && !editing && (
           <button className="rs-revert tip" data-tip="Revert to detected" onClick={onRevert}>
-            <Icon name="refresh" size={11} />
+            <span className="rs-revert-ic">
+              <Icon name="refresh" size={11} />
+            </span>
           </button>
         )}
       </div>

--- a/src/storage/projectSettings.ts
+++ b/src/storage/projectSettings.ts
@@ -1,0 +1,39 @@
+import { dbSelect, dbDelete, dbUpsert } from "./db";
+
+export interface ProjectSettingRow {
+  project_id: string;
+  key: string;
+  value: string;
+}
+
+export async function getProjectSettings(
+  projectId: string,
+): Promise<Record<string, string>> {
+  const rows = await dbSelect<ProjectSettingRow>("project_settings", {
+    where: { project_id: projectId },
+  });
+  const out: Record<string, string> = {};
+  for (const row of rows) {
+    out[row.key] = row.value;
+  }
+  return out;
+}
+
+export async function setProjectSetting(
+  projectId: string,
+  key: string,
+  value: string,
+): Promise<void> {
+  await dbUpsert(
+    "project_settings",
+    { project_id: projectId, key, value },
+    "project_id,key",
+  );
+}
+
+export async function deleteProjectSetting(
+  projectId: string,
+  key: string,
+): Promise<void> {
+  await dbDelete("project_settings", { project_id: projectId, key });
+}


### PR DESCRIPTION
## Summary
- New `project_settings(project_id, key, value)` table; Run panel writes overrides keyed by `agent.project_id` and only persists values that differ from the auto-detected default (reverting deletes the row).
- `AgentRecord` now exposes `project_id` (selected in `query_all_agents` / `load_agent`, populated in `add_agent`) so panels can scope per-project state; `db_upsert` extended to accept composite conflict targets (`"project_id,key"`).
- Fixed the "Revert to detected" tooltip: it was clipped by `overflow:hidden` on the row group and then trapped under the next row because the button's hover rotation formed a new stacking context. Rotation now lives on an inner `<span>`, so the tooltip `::after` on the button stays upright and above siblings.

## Test plan
- [ ] Open Run settings, edit a value, Apply, restart app — override survives.
- [ ] Edit a value back to the detected default — DB row for that key is removed.
- [ ] Hover the revert icon — tooltip is fully visible (not clipped, not covered by the next row, not rotated).