### PR TITLE
Wire Run panel buttons to a real PTY-backed run process

### DIFF
--- a/src-tauri/migrations/0003_run_setup_completed.sql
+++ b/src-tauri/migrations/0003_run_setup_completed.sql
@@ -1,0 +1,5 @@
+-- Tracks whether the Run panel's setup command has succeeded for
+-- this agent at least once. NULL means setup still needs to run on
+-- the next Start click; a millisecond timestamp means it's done and
+-- subsequent starts skip straight to the run command.
+ALTER TABLE agents ADD COLUMN setup_completed_at INTEGER;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10,6 +10,7 @@ use crate::gh::{self, PrState};
 use crate::git;
 use crate::git_state::{self, GitState};
 use crate::names;
+use crate::run_session::RunStateSnapshot;
 use crate::supervisor::Supervisor;
 use crate::workspace::{
     repo_worktree_path, AgentRecord, AgentView, DiffStats, TrackedRepo, Workspace,
@@ -327,6 +328,38 @@ pub fn resize_shell(
     rows: u16,
 ) -> Result<()> {
     supervisor.resize_shell(&agent_id, cols, rows)
+}
+
+/// Start the Run-panel process for an agent.
+/// Runs setup-then-run on first start, then run only on subsequent.
+#[tauri::command]
+pub fn run_start(
+    supervisor: State<'_, Arc<Supervisor>>,
+    app: AppHandle,
+    agent_id: String,
+) -> Result<()> {
+    let sup = supervisor.inner().clone();
+    sup.run_start(app, &agent_id)
+}
+
+/// Stop the Run-panel process for an agent. Idempotent.
+#[tauri::command]
+pub fn run_stop(
+    supervisor: State<'_, Arc<Supervisor>>,
+    app: AppHandle,
+    agent_id: String,
+) -> Result<()> {
+    supervisor.run_stop(app, &agent_id)
+}
+
+/// Snapshot of the Run-panel state and accumulated log buffer for
+/// rehydrating the panel on mount.
+#[tauri::command]
+pub fn run_state(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+) -> Result<RunStateSnapshot> {
+    Ok(supervisor.run_state(&agent_id))
 }
 
 /// Returns git state for the agent's primary repo.

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -31,6 +31,7 @@ fn get_migrations() -> Migrations<'static> {
     Migrations::new(vec![
         M::up(include_str!("../migrations/0001_initial_schema.sql")),
         M::up(include_str!("../migrations/0002_project_settings.sql")),
+        M::up(include_str!("../migrations/0003_run_setup_completed.sql")),
     ])
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod git_state;
 mod managed_session;
 mod names;
 mod pty_session;
+mod run_session;
 mod sandbox;
 mod supervisor;
 mod watcher;
@@ -172,6 +173,9 @@ pub fn run() {
             commands::close_agent_shell,
             commands::write_to_shell,
             commands::resize_shell,
+            commands::run_start,
+            commands::run_stop,
+            commands::run_state,
         ])
         .run(tauri::generate_context!())
         .expect("error while running quorum");

--- a/src-tauri/src/run_session.rs
+++ b/src-tauri/src/run_session.rs
@@ -1,0 +1,277 @@
+//! Per-agent "Run" process: spawns the project's setup + dev command
+//! inside the agent's worktree, streams output to the frontend, and
+//! tracks state across panel mounts.
+//!
+//! Separate from the agent's claude PTY (`agent.rs`) and from the
+//! user-facing shell PTY (`open_agent_shell` in `supervisor.rs`).
+//! The Run panel owns this session — clicking ▶ starts it, ■ kills
+//! it. Setup runs at most once per agent lifetime (until archive).
+
+use parking_lot::Mutex;
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+
+use crate::error::Result;
+use crate::pty_session::{PtyExit, PtySession, PtySpawn};
+
+/// How much PTY output we keep around for panel rehydration.
+/// 5 MB is enough for ~50k lines of average-width terminal output and
+/// caps memory growth for long-lived dev servers.
+const LOG_BUFFER_CAP: usize = 5 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum RunPhase {
+    /// No process. Default state. Play button is enabled.
+    Idle,
+    /// Setup command in progress (e.g. `pnpm install`).
+    Setup,
+    /// Dev command in progress (e.g. `pnpm dev`).
+    Running,
+    /// Last process exited (or was killed). Holds last_error.
+    Stopped,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct RunStateSnapshot {
+    pub phase: RunPhase,
+    pub last_error: Option<String>,
+    /// Cumulative PTY output bytes (latest first dropped on overflow).
+    /// Encoded as a byte array so the frontend can render or strip
+    /// ANSI without re-decoding.
+    pub log: Vec<u8>,
+}
+
+/// State for one agent's run process. Reused across start/stop cycles
+/// (the log buffer survives stops so the panel can show what happened
+/// the previous time you ran it).
+pub struct RunSession {
+    inner: Mutex<RunSessionInner>,
+}
+
+struct RunSessionInner {
+    phase: RunPhase,
+    last_error: Option<String>,
+    log: LogBuffer,
+    pty: Option<PtySession>,
+    /// Bumped on every `start` and `stop`. The PTY exit handler
+    /// captures the generation it was spawned under; if that
+    /// generation no longer matches, the exit is from a process the
+    /// user already stopped or replaced and is ignored.
+    generation: u64,
+}
+
+impl RunSession {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(RunSessionInner {
+                phase: RunPhase::Idle,
+                last_error: None,
+                log: LogBuffer::new(LOG_BUFFER_CAP),
+                pty: None,
+                generation: 0,
+            }),
+        }
+    }
+
+    pub fn snapshot(&self) -> RunStateSnapshot {
+        let inner = self.inner.lock();
+        RunStateSnapshot {
+            phase: inner.phase,
+            last_error: inner.last_error.clone(),
+            log: inner.log.bytes().to_vec(),
+        }
+    }
+
+    pub fn phase(&self) -> RunPhase {
+        self.inner.lock().phase
+    }
+
+    pub fn is_active(&self) -> bool {
+        matches!(self.phase(), RunPhase::Setup | RunPhase::Running)
+    }
+
+    /// Append PTY output to the rolling buffer. Called from the
+    /// per-spawn output callback.
+    pub fn append_log(&self, bytes: &[u8]) {
+        self.inner.lock().log.append(bytes);
+    }
+
+    /// Kill the active PTY (if any), bump generation so any in-flight
+    /// exit callback bails, and transition to Stopped. The on_exit
+    /// from the killed PTY is ignored due to the generation bump.
+    /// Returns the prior phase so callers can decide whether to emit
+    /// state change.
+    pub fn stop(&self) -> RunPhase {
+        let mut inner = self.inner.lock();
+        let prior = inner.phase;
+        if let Some(pty) = inner.pty.take() {
+            let _ = pty.kill();
+        }
+        inner.generation = inner.generation.wrapping_add(1);
+        inner.phase = RunPhase::Stopped;
+        inner.last_error = None;
+        prior
+    }
+
+    /// Begin a fresh start sequence. Bumps the generation token (so
+    /// any in-flight callbacks from a previous start are now stale),
+    /// sets the initial phase, and clears `last_error`. Use
+    /// `transition_phase` for chained transitions inside the same
+    /// sequence (setup → run) — those keep the generation stable.
+    pub fn begin_phase(&self, phase: RunPhase) -> u64 {
+        let mut inner = self.inner.lock();
+        inner.generation = inner.generation.wrapping_add(1);
+        inner.phase = phase;
+        inner.last_error = None;
+        inner.generation
+    }
+
+    /// Like begin_phase but keeps the same generation. Used when one
+    /// phase ends successfully and we chain into the next (setup→run).
+    pub fn transition_phase(&self, phase: RunPhase) -> u64 {
+        let mut inner = self.inner.lock();
+        inner.phase = phase;
+        inner.last_error = None;
+        inner.generation
+    }
+
+    pub fn attach_pty(&self, pty: PtySession) {
+        let mut inner = self.inner.lock();
+        // Replace and drop any stale handle. (Shouldn't happen — the
+        // supervisor's stop() drops it first — but defensive.)
+        inner.pty = Some(pty);
+    }
+
+    /// Returns true if the given generation is still the current one,
+    /// meaning this PTY exit corresponds to the live phase.
+    pub fn is_current_generation(&self, gen: u64) -> bool {
+        self.inner.lock().generation == gen
+    }
+
+    /// Mark the current phase as Stopped with an error message. Drops
+    /// the PTY handle. Called on natural exits.
+    pub fn mark_stopped(&self, error: Option<String>) {
+        let mut inner = self.inner.lock();
+        inner.pty = None;
+        inner.phase = RunPhase::Stopped;
+        inner.last_error = error;
+    }
+}
+
+/// Spawn a single phase's PTY. The caller is responsible for
+/// `stop()` / `begin_phase` / `transition_phase` bookkeeping and for
+/// wiring up the on_output / on_exit closures (which need supervisor
+/// access to chain phases).
+pub fn spawn_command<F, G>(
+    program: &Path,
+    args: &[String],
+    cwd: &Path,
+    on_output: F,
+    on_exit: G,
+) -> Result<PtySession>
+where
+    F: Fn(Vec<u8>) + Send + 'static,
+    G: Fn(PtyExit) + Send + 'static,
+{
+    PtySession::spawn(
+        PtySpawn {
+            program,
+            args,
+            cwd,
+            cols: 120,
+            rows: 32,
+        },
+        on_output,
+        on_exit,
+    )
+}
+
+/// Resolve the shell binary to use for `-lc <cmd>` invocations.
+/// Falls back to /bin/zsh which is the default on every macOS the app
+/// targets.
+pub fn user_shell() -> PathBuf {
+    PathBuf::from(std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string()))
+}
+
+/// Build the args for running `cmd` through the user's shell as a
+/// login + interactive shell. Login pulls .zprofile / .bash_profile
+/// (PATH); interactive pulls .zshrc (where most users put pnpm /
+/// nvm shims). Single `-c` argument means the shell exits as soon
+/// as the command completes.
+pub fn shell_args(cmd: &str) -> Vec<String> {
+    vec!["-lic".to_string(), cmd.to_string()]
+}
+
+// ── Log buffer ───────────────────────────────────────────────────────────────
+
+struct LogBuffer {
+    bytes: Vec<u8>,
+    cap: usize,
+}
+
+impl LogBuffer {
+    fn new(cap: usize) -> Self {
+        Self {
+            bytes: Vec::new(),
+            cap,
+        }
+    }
+
+    fn append(&mut self, b: &[u8]) {
+        self.bytes.extend_from_slice(b);
+        // Compact only when we've drifted ≥50% past cap so per-byte
+        // amortized work stays O(1).
+        if self.bytes.len() > self.cap + self.cap / 2 {
+            let drop = self.bytes.len() - self.cap;
+            self.bytes.drain(..drop);
+        }
+    }
+
+    fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_buffer_evicts_oldest_bytes() {
+        let mut buf = LogBuffer::new(100);
+        for _ in 0..20 {
+            buf.append(&[b'x'; 50]);
+        }
+        // After many appends past cap, len stays within [cap, 1.5*cap]
+        // and the most recent bytes are still present.
+        assert!(buf.bytes().len() >= 100);
+        assert!(buf.bytes().len() <= 150);
+        assert!(buf.bytes().iter().all(|&b| b == b'x'));
+    }
+
+    #[test]
+    fn phase_starts_idle() {
+        let s = RunSession::new();
+        assert_eq!(s.phase(), RunPhase::Idle);
+        assert!(!s.is_active());
+    }
+
+    #[test]
+    fn stop_bumps_generation_and_marks_stopped() {
+        let s = RunSession::new();
+        let g1 = s.begin_phase(RunPhase::Running);
+        s.stop();
+        assert_eq!(s.phase(), RunPhase::Stopped);
+        assert!(!s.is_current_generation(g1));
+    }
+
+    #[test]
+    fn transition_phase_keeps_generation() {
+        let s = RunSession::new();
+        let g1 = s.begin_phase(RunPhase::Setup);
+        let g2 = s.transition_phase(RunPhase::Running);
+        assert_eq!(g1, g2);
+        assert!(s.is_current_generation(g1));
+    }
+}

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -15,6 +15,9 @@ use crate::error::{Error, Result};
 use crate::git;
 use crate::git_state::{self, GitState};
 use crate::pty_session::{PtySession, PtySpawn};
+use crate::run_session::{
+    self, shell_args, user_shell, RunPhase, RunSession, RunStateSnapshot,
+};
 use crate::watcher::WatcherRegistry;
 use crate::workspace::{
     agent_parent_dir, allocate_repo_subdir, new_agent_record, repo_worktree_path, AgentRecord,
@@ -84,6 +87,19 @@ pub struct PrStateChangedPayload {
     pub state: Option<crate::gh::PrState>,
 }
 
+#[derive(Clone, serde::Serialize)]
+pub struct RunOutputPayload {
+    pub agent_id: String,
+    pub bytes: Vec<u8>,
+}
+
+#[derive(Clone, serde::Serialize)]
+pub struct RunStatePayload {
+    pub agent_id: String,
+    pub phase: RunPhase,
+    pub last_error: Option<String>,
+}
+
 const WATCHDOG_TICK: Duration = Duration::from_millis(500);
 const SPAWN_TIMEOUT: Duration = Duration::from_secs(15);
 
@@ -95,6 +111,9 @@ pub struct Supervisor {
     pub native_input_lines: Mutex<HashMap<String, String>>,
     pub watcher_registry: Mutex<WatcherRegistry>,
     pub shells: Mutex<HashMap<String, PtySession>>,
+    /// Per-agent run-panel processes (dev server + setup). Reused
+    /// across start/stop cycles so the log buffer survives.
+    pub runs: Mutex<HashMap<String, Arc<RunSession>>>,
 }
 
 impl Supervisor {
@@ -107,6 +126,7 @@ impl Supervisor {
             native_input_lines: Mutex::new(HashMap::new()),
             watcher_registry: Mutex::new(WatcherRegistry::new()),
             shells: Mutex::new(HashMap::new()),
+            runs: Mutex::new(HashMap::new()),
         }
     }
 
@@ -185,6 +205,121 @@ impl Supervisor {
             .get(agent_id)
             .ok_or_else(|| Error::Other("no shell for agent".into()))?
             .resize(cols, rows)
+    }
+
+    /// Start the Run-panel process for an agent.
+    ///
+    /// If the agent has never completed setup before, runs the setup
+    /// command first; on exit 0 marks setup complete and chains into
+    /// the run command. On setup failure → does NOT proceed to run.
+    /// If setup is already complete, starts the run command directly.
+    ///
+    /// No-op if a run is already in progress for this agent.
+    pub fn run_start(self: Arc<Self>, app: AppHandle, agent_id: &str) -> Result<()> {
+        let record = self.workspace.agent(agent_id)?;
+        if record.archive.is_some() {
+            return Err(Error::Other("agent is archived".into()));
+        }
+        let primary = record
+            .repos
+            .first()
+            .ok_or_else(|| Error::Other("agent has no repos".into()))?;
+        let cwd = repo_worktree_path(agent_id, &primary.subdir)?;
+
+        let (setup_cmd, run_cmd) = self.read_run_commands(&record.project_id);
+        let setup_done = self.workspace.is_setup_completed(agent_id)?;
+
+        let session = {
+            let mut runs = self.runs.lock();
+            runs.entry(agent_id.to_string())
+                .or_insert_with(|| Arc::new(RunSession::new()))
+                .clone()
+        };
+
+        if session.is_active() {
+            return Ok(()); // already running, idempotent
+        }
+
+        let needs_setup = !setup_done && !setup_cmd.trim().is_empty();
+        let (first_phase, first_cmd, chains_to_run) = if needs_setup {
+            (RunPhase::Setup, setup_cmd.clone(), true)
+        } else {
+            (RunPhase::Running, run_cmd.clone(), false)
+        };
+
+        let gen = session.begin_phase(first_phase);
+        emit_run_state(&app, agent_id, first_phase, None);
+        write_header(&app, agent_id, &session, &first_cmd);
+
+        spawn_run_phase(
+            self.clone(),
+            app,
+            agent_id.to_string(),
+            session,
+            gen,
+            cwd,
+            first_phase,
+            first_cmd,
+            if chains_to_run { Some(run_cmd) } else { None },
+        )
+    }
+
+    /// Stop the Run-panel process for an agent. Idempotent.
+    pub fn run_stop(&self, app: AppHandle, agent_id: &str) -> Result<()> {
+        let session = {
+            let runs = self.runs.lock();
+            runs.get(agent_id).cloned()
+        };
+        let Some(session) = session else {
+            return Ok(());
+        };
+        let prior = session.stop();
+        if matches!(prior, RunPhase::Setup | RunPhase::Running) {
+            emit_run_state(&app, agent_id, RunPhase::Stopped, None);
+        }
+        Ok(())
+    }
+
+    /// Snapshot of the current state and accumulated log for the
+    /// panel to rehydrate on mount.
+    pub fn run_state(&self, agent_id: &str) -> RunStateSnapshot {
+        let session = {
+            let runs = self.runs.lock();
+            runs.get(agent_id).cloned()
+        };
+        match session {
+            Some(s) => s.snapshot(),
+            None => RunStateSnapshot {
+                phase: RunPhase::Idle,
+                last_error: None,
+                log: Vec::new(),
+            },
+        }
+    }
+
+    /// Read the setup + run commands from project_settings, falling
+    /// back to the same inferred defaults the panel UI shows. Keys
+    /// match the RunPanel storage scheme (`run.install`, `run.dev`).
+    fn read_run_commands(&self, project_id: &str) -> (String, String) {
+        let conn = self.workspace.db_handle();
+        let install_default = "pnpm install".to_string();
+        let dev_default = "pnpm dev".to_string();
+        if project_id.is_empty() {
+            return (install_default, dev_default);
+        }
+        let read = |key: &str| -> Option<String> {
+            let conn = conn.lock();
+            conn.query_row(
+                "SELECT value FROM project_settings WHERE project_id = ?1 AND key = ?2",
+                rusqlite::params![project_id, key],
+                |row| row.get::<_, String>(0),
+            )
+            .ok()
+        };
+        (
+            read("run.install").unwrap_or(install_default),
+            read("run.dev").unwrap_or(dev_default),
+        )
     }
 
     pub fn current_workspace(&self) -> Option<Workspace> {
@@ -748,6 +883,9 @@ impl Supervisor {
         self.activities.lock().remove(agent_id);
         self.native_input_lines.lock().remove(agent_id);
         self.shells.lock().remove(agent_id);
+        if let Some(run) = self.runs.lock().remove(agent_id) {
+            run.stop();
+        }
         self.watcher_registry.lock().unregister_prefix(agent_id);
 
         let mut snapshots: Vec<ArchivedRepoSnapshot> = Vec::with_capacity(record.repos.len());
@@ -1052,6 +1190,9 @@ impl Supervisor {
         self.activities.lock().remove(agent_id);
         self.native_input_lines.lock().remove(agent_id);
         self.shells.lock().remove(agent_id);
+        if let Some(run) = self.runs.lock().remove(agent_id) {
+            run.stop();
+        }
         self.watcher_registry.lock().unregister_prefix(agent_id);
 
         // Tear down each tracked repo's worktree + branch.
@@ -1531,6 +1672,171 @@ fn apply_exit_if_current(
         }
         emit_status(app, agent_id, status, err);
     }
+}
+
+fn emit_run_state(
+    app: &AppHandle,
+    agent_id: &str,
+    phase: RunPhase,
+    last_error: Option<String>,
+) {
+    let _ = app.emit(
+        "run:state",
+        RunStatePayload {
+            agent_id: agent_id.to_string(),
+            phase,
+            last_error,
+        },
+    );
+}
+
+fn emit_run_output(app: &AppHandle, agent_id: &str, bytes: Vec<u8>) {
+    let _ = app.emit(
+        "run:output",
+        RunOutputPayload {
+            agent_id: agent_id.to_string(),
+            bytes,
+        },
+    );
+}
+
+/// Inject a "$ <cmd>" header line into the log so each phase has a
+/// visible boundary, then emit it like any other PTY output.
+fn write_header(app: &AppHandle, agent_id: &str, session: &Arc<RunSession>, cmd: &str) {
+    // Dim ANSI for the prompt — the frontend strips ANSI for v1,
+    // so the line still reads fine without color support.
+    let line = format!("\x1b[2m$ {cmd}\x1b[0m\r\n");
+    let bytes = line.into_bytes();
+    session.append_log(&bytes);
+    emit_run_output(app, agent_id, bytes);
+}
+
+/// Spawn one phase's PTY (setup or run). Wires up output streaming
+/// and the exit handler that chains setup→run or transitions to
+/// Stopped on natural exit. Out-of-band stops are handled via the
+/// generation check.
+fn spawn_run_phase(
+    sup: Arc<Supervisor>,
+    app: AppHandle,
+    agent_id: String,
+    session: Arc<RunSession>,
+    gen: u64,
+    cwd: std::path::PathBuf,
+    phase: RunPhase,
+    cmd: String,
+    chain_run_cmd: Option<String>,
+) -> Result<()> {
+    let shell = user_shell();
+    let args = shell_args(&cmd);
+
+    let session_out = session.clone();
+    let app_out = app.clone();
+    let id_out = agent_id.clone();
+
+    let sup_exit = sup.clone();
+    let app_exit = app.clone();
+    let id_exit = agent_id.clone();
+    let session_exit = session.clone();
+    let cwd_exit = cwd.clone();
+
+    let pty = run_session::spawn_command(
+        &shell,
+        &args,
+        &cwd,
+        move |bytes| {
+            session_out.append_log(&bytes);
+            emit_run_output(&app_out, &id_out, bytes);
+        },
+        move |exit| {
+            handle_run_phase_exit(
+                sup_exit.clone(),
+                app_exit.clone(),
+                id_exit.clone(),
+                session_exit.clone(),
+                gen,
+                phase,
+                exit,
+                cwd_exit.clone(),
+                chain_run_cmd.clone(),
+            );
+        },
+    )?;
+
+    session.attach_pty(pty);
+    Ok(())
+}
+
+fn handle_run_phase_exit(
+    sup: Arc<Supervisor>,
+    app: AppHandle,
+    agent_id: String,
+    session: Arc<RunSession>,
+    gen: u64,
+    phase: RunPhase,
+    exit: crate::pty_session::PtyExit,
+    cwd: std::path::PathBuf,
+    chain_run_cmd: Option<String>,
+) {
+    // If the user clicked Stop (or started a fresh run), our
+    // generation is stale — just drop this event.
+    if !session.is_current_generation(gen) {
+        tracing::debug!(
+            agent_id = %agent_id,
+            phase = ?phase,
+            "ignoring stale run-phase exit"
+        );
+        return;
+    }
+
+    if matches!(phase, RunPhase::Setup) && exit.success {
+        // Setup finished cleanly — persist the flag and chain into
+        // the run command (if we have one).
+        if let Err(e) = sup.workspace.mark_setup_completed(&agent_id) {
+            tracing::warn!(error = %e, agent_id = %agent_id, "mark_setup_completed failed");
+        }
+        if let Some(run_cmd) = chain_run_cmd {
+            session.transition_phase(RunPhase::Running);
+            emit_run_state(&app, &agent_id, RunPhase::Running, None);
+            write_header(&app, &agent_id, &session, &run_cmd);
+            if let Err(e) = spawn_run_phase(
+                sup,
+                app.clone(),
+                agent_id.clone(),
+                session.clone(),
+                gen,
+                cwd,
+                RunPhase::Running,
+                run_cmd,
+                None,
+            ) {
+                let msg = format!("Failed to start run command: {e}");
+                session.mark_stopped(Some(msg.clone()));
+                emit_run_state(&app, &agent_id, RunPhase::Stopped, Some(msg));
+            }
+            return;
+        }
+        // No run command to chain into — treat as clean stop.
+        session.mark_stopped(None);
+        emit_run_state(&app, &agent_id, RunPhase::Stopped, None);
+        return;
+    }
+
+    // Setup failed → do NOT proceed to run. Surface the error.
+    if matches!(phase, RunPhase::Setup) && !exit.success {
+        let msg = format!("Setup failed: {}", exit.message);
+        session.mark_stopped(Some(msg.clone()));
+        emit_run_state(&app, &agent_id, RunPhase::Stopped, Some(msg));
+        return;
+    }
+
+    // Run-phase exit — natural end or crash. Either way → Stopped.
+    let err = if exit.success {
+        None
+    } else {
+        Some(format!("Run exited: {}", exit.message))
+    };
+    session.mark_stopped(err.clone());
+    emit_run_state(&app, &agent_id, RunPhase::Stopped, err);
 }
 
 fn emit_status(

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -223,6 +223,13 @@ impl WorkspaceManager {
         mgr
     }
 
+    /// Direct access to the connection — used by supervisor pieces
+    /// (e.g. Run panel's project-settings lookup) that don't have a
+    /// dedicated typed method on this manager yet.
+    pub fn db_handle(&self) -> Arc<Mutex<Connection>> {
+        self.db.clone()
+    }
+
     pub fn current(&self) -> Option<Workspace> {
         let conn = self.db.lock();
 
@@ -464,8 +471,11 @@ impl WorkspaceManager {
             .map(|dt| dt.timestamp_millis())
             .unwrap_or_else(|_| now_millis());
 
+        // Clear setup_completed_at too — restore recreates the worktree
+        // from scratch, so node_modules etc. won't be there.
         conn.execute(
-            "UPDATE agents SET archived_at = ?1, status = 'stopped' WHERE id = ?2",
+            "UPDATE agents SET archived_at = ?1, status = 'stopped',
+                    setup_completed_at = NULL WHERE id = ?2",
             rusqlite::params![archived_millis, id],
         )?;
 
@@ -511,6 +521,32 @@ impl WorkspaceManager {
             )?;
         }
 
+        Ok(())
+    }
+
+    /// Has the Run panel's setup command ever succeeded for this agent?
+    /// Cleared on archive so a restored agent re-runs setup against the
+    /// freshly-recreated worktree.
+    pub fn is_setup_completed(&self, id: &str) -> Result<bool> {
+        let conn = self.db.lock();
+        let value: Option<i64> = conn
+            .query_row(
+                "SELECT setup_completed_at FROM agents WHERE id = ?1",
+                [id],
+                |row| row.get(0),
+            )
+            .map_err(|_| Error::AgentNotFound(id.to_string()))?;
+        Ok(value.is_some())
+    }
+
+    /// Stamp the setup command as having succeeded. Idempotent.
+    pub fn mark_setup_completed(&self, id: &str) -> Result<()> {
+        let conn = self.db.lock();
+        Self::ensure_agent_exists(&conn, id)?;
+        conn.execute(
+            "UPDATE agents SET setup_completed_at = ?1 WHERE id = ?2",
+            rusqlite::params![now_millis(), id],
+        )?;
         Ok(())
     }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -151,6 +151,27 @@ export interface PrStateChangedEvent {
   state: PrState | null;
 }
 
+export type RunPhase = "idle" | "setup" | "running" | "stopped";
+
+export interface RunStateSnapshot {
+  phase: RunPhase;
+  last_error: string | null;
+  /** Raw PTY bytes accumulated since the panel was last cleared.
+   *  Sent as a JSON array of u8 values; decode with TextDecoder. */
+  log: number[];
+}
+
+export interface RunOutputEvent {
+  agent_id: string;
+  bytes: number[];
+}
+
+export interface RunStateEvent {
+  agent_id: string;
+  phase: RunPhase;
+  last_error: string | null;
+}
+
 export const api = {
   getWorkspace: () => invoke<Workspace | null>("get_workspace"),
   getAgentDiffStats: (agentId: string) =>
@@ -204,6 +225,10 @@ export const api = {
     invoke<void>("write_to_shell", { agentId, data }),
   resizeShell: (agentId: string, cols: number, rows: number) =>
     invoke<void>("resize_shell", { agentId, cols, rows }),
+  runStart: (agentId: string) => invoke<void>("run_start", { agentId }),
+  runStop: (agentId: string) => invoke<void>("run_stop", { agentId }),
+  runState: (agentId: string) =>
+    invoke<RunStateSnapshot>("run_state", { agentId }),
 };
 
 export function onAgentOutput(
@@ -277,4 +302,16 @@ export function onPrStateChanged(
   cb: (e: PrStateChangedEvent) => void,
 ): Promise<UnlistenFn> {
   return listen<PrStateChangedEvent>("pr:state_changed", (event) => cb(event.payload));
+}
+
+export function onRunOutput(
+  cb: (e: RunOutputEvent) => void,
+): Promise<UnlistenFn> {
+  return listen<RunOutputEvent>("run:output", (event) => cb(event.payload));
+}
+
+export function onRunState(
+  cb: (e: RunStateEvent) => void,
+): Promise<UnlistenFn> {
+  return listen<RunStateEvent>("run:state", (event) => cb(event.payload));
 }

--- a/src/components/RightPanel/RunPanel.tsx
+++ b/src/components/RightPanel/RunPanel.tsx
@@ -1,5 +1,11 @@
-import { useEffect, useState } from "react";
-import type { AgentRecord } from "../../api";
+import { useEffect, useRef, useState } from "react";
+import {
+  api,
+  onRunOutput,
+  onRunState,
+  type AgentRecord,
+  type RunPhase,
+} from "../../api";
 import { Icon } from "../Icon";
 import {
   deleteProjectSetting,
@@ -8,17 +14,14 @@ import {
 } from "../../storage/projectSettings";
 import { RunSettingsSheet, type SetupRow } from "./RunSettingsSheet";
 
-// Settings keys we persist are prefixed so the project_settings table can
-// hold overrides from other panels (env, build, etc.) without collisions.
+// Settings keys are namespaced under `run.` so the project_settings
+// table can hold overrides from other panels without colliding.
 const RUN_KEY_PREFIX = "run.";
 const runKey = (id: string) => `${RUN_KEY_PREFIX}${id}`;
 
-// ── Static mock data (UI pass — replaced by real data in wiring PR) ──────────
-// Rows match the Quorum v2 prototype exactly: 3 groups, 8 rows.
-// Each entry carries an inferred value + WHERE it was detected from, so the
-// run-settings sheet can surface that as the "auto-detected" baseline and the
-// user can override any one of them.
-
+// Inferred defaults the panel shows when a project has no overrides.
+// The backend reads `run.install` / `run.dev` from project_settings and
+// falls back to these same strings — keep them in sync.
 const RUN_SETUP: SetupRow[] = [
   { id: "pm",      group: "Environment", key: "Package manager", value: "pnpm 9.7.1",   source: "package.json · packageManager" },
   { id: "node",    group: "Environment", key: "Node version",    value: "v22.4.0",      source: ".nvmrc" },
@@ -30,46 +33,26 @@ const RUN_SETUP: SetupRow[] = [
   { id: "env",     group: "Server",      key: "Env file",        value: ".env.local",   source: "auto-detected" },
 ];
 
-interface LogEntry { c: string; t: string; }
-
-const RUN_LOGS: LogEntry[] = [
-  { c: "term-dim",     t: "$ pnpm dev" },
-  { c: "",             t: "" },
-  { c: "term-bold",    t: "  ▲ Next.js 15.4.0" },
-  { c: "term-dim",     t: "  - Local:        http://localhost:3000" },
-  { c: "term-dim",     t: "  - Workspace:    ~/dev/atlas-web/.quorum/patagonia" },
-  { c: "term-dim",     t: "  - Environments: .env.local" },
-  { c: "",             t: "" },
-  { c: "term-success", t: " ✓ Ready in 1.4s" },
-  { c: "term-dim",     t: " ○ Compiling /billing ..." },
-  { c: "term-success", t: " ✓ Compiled /billing in 482ms (1290 modules)" },
-  { c: "term-dim",     t: " GET /billing 200 in 612ms" },
-  { c: "term-dim",     t: " GET /api/billing/customer 200 in 84ms" },
-  { c: "term-warn",    t: " ⚠ Fast Refresh had to perform a full reload due to a runtime error" },
-  { c: "term-success", t: " ✓ Compiled /api/billing/portal in 211ms" },
-  { c: "term-dim",     t: " POST /api/billing/checkout 303 in 142ms" },
-  { c: "term-info",    t: "   → redirect: https://billing.stripe.com/session/..." },
-];
-
-const LOG_CLASS: Record<string, string> = {
-  "term-prompt":  "p",
-  "term-dim":     "d",
-  "term-success": "s",
-  "term-warn":    "w",
-  "term-error":   "e",
-  "term-info":    "i",
-  "term-bold":    "b",
-};
-
-// ── Component ────────────────────────────────────────────────────────────────
+// Strip ANSI escape sequences before rendering. v1 keeps log rendering
+// dead-simple (plain text with pre-wrap); colorization can come later.
+// Covers CSI (ESC [ ... letter) and OSC (ESC ] ... BEL / ST).
+const ANSI_RE = /\x1b\[[0-9;?]*[a-zA-Z]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
+const stripAnsi = (s: string) => s.replace(ANSI_RE, "");
 
 export function RunPanel({ agent }: { agent: AgentRecord }) {
-  const [running, setRunning] = useState(true);
+  const [phase, setPhase] = useState<RunPhase>("idle");
+  const [lastError, setLastError] = useState<string | null>(null);
+  const [log, setLog] = useState<string>("");
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [overrides, setOverrides] = useState<Record<string, string>>({});
+  const logRef = useRef<HTMLDivElement | null>(null);
+  // Streaming UTF-8 decoder so a multi-byte rune split across two
+  // PTY chunks doesn't produce a replacement character. Reset each
+  // time we re-subscribe (agent switch).
+  const decoderRef = useRef<TextDecoder | null>(null);
 
-  // Load persisted overrides for this project. Re-loads when the
-  // selected agent (and thus project) changes.
+  // Load persisted command overrides for this project. Re-loads when
+  // the selected agent (and thus project) changes.
   useEffect(() => {
     let cancelled = false;
     if (!agent.project_id) {
@@ -91,17 +74,74 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
     };
   }, [agent.project_id]);
 
+  // Subscribe to run output and state events for this agent.
+  // Rehydrate snapshot on mount/agent-switch so the panel preserves
+  // logs from prior starts (and across panel mounts).
+  useEffect(() => {
+    let cancelled = false;
+    const cleanups: Array<() => void> = [];
+    const decoder = new TextDecoder("utf-8", { fatal: false });
+    decoderRef.current = decoder;
+
+    api.runState(agent.id).then((snap) => {
+      if (cancelled) return;
+      setPhase(snap.phase);
+      setLastError(snap.last_error);
+      // Snapshot is a one-shot buffer — decode it without streaming
+      // mode using its own decoder so it doesn't pollute the live
+      // stream decoder.
+      const snapDecoder = new TextDecoder("utf-8", { fatal: false });
+      setLog(stripAnsi(snapDecoder.decode(new Uint8Array(snap.log))));
+    });
+
+    onRunOutput((e) => {
+      if (e.agent_id !== agent.id) return;
+      const chunk = stripAnsi(
+        decoder.decode(new Uint8Array(e.bytes), { stream: true }),
+      );
+      setLog((prev) => prev + chunk);
+    }).then((un) => cleanups.push(un));
+
+    onRunState((e) => {
+      if (e.agent_id !== agent.id) return;
+      setPhase(e.phase);
+      setLastError(e.last_error);
+    }).then((un) => cleanups.push(un));
+
+    return () => {
+      cancelled = true;
+      for (const c of cleanups) c();
+    };
+  }, [agent.id]);
+
+  // Auto-scroll to bottom on log append.
+  useEffect(() => {
+    const el = logRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [log]);
+
   const valueOf = (id: string) => {
     const row = RUN_SETUP.find((r) => r.id === id);
     return overrides[id] ?? row?.value ?? "";
   };
 
   const devCmd = valueOf("dev");
-  const port   = valueOf("port");
+  const port = valueOf("port");
+  const isActive = phase === "setup" || phase === "running";
+  const linkLive = phase === "running";
+
+  const onPlay = () => {
+    if (isActive) {
+      void api.runStop(agent.id);
+    } else {
+      void api.runStart(agent.id);
+    }
+  };
 
   const onApply = (next: Record<string, string>) => {
-    // Persist only true overrides — anything that matches the inferred
-    // default is treated as "no override" and removed from the DB.
+    // Persist only true overrides — values that match the inferred
+    // default are removed from the DB so the row reads as "auto".
     const projectId = agent.project_id;
     const cleaned: Record<string, string> = {};
     if (projectId) {
@@ -125,7 +165,6 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
         }
       }
     } else {
-      // No project — keep in-memory only (shouldn't happen in practice).
       for (const row of RUN_SETUP) {
         const nextVal = next[row.id];
         if (nextVal !== undefined && nextVal !== row.value) {
@@ -136,21 +175,22 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
 
     setOverrides(cleaned);
     setSettingsOpen(false);
-    setRunning(true);
   };
 
   const hasOverrides = Object.keys(overrides).length > 0;
+  const buttonLabel = isActive ? "Stop" : "Start";
 
   return (
     <div className="run-wrap">
       {/* ── Bar ── */}
       <div className="run-bar v2">
         <button
-          className={`run-go ${running ? "live" : "stopped"}`}
-          onClick={() => setRunning((v) => !v)}
-          aria-label={running ? "Stop" : "Start"}
+          className={`run-go ${isActive ? "live" : "stopped"}`}
+          onClick={onPlay}
+          aria-label={buttonLabel}
+          title={phase === "setup" ? "Setup running — click to stop" : buttonLabel}
         >
-          <Icon name={running ? "stop" : "play"} size={12} />
+          <Icon name={isActive ? "stop" : "play"} size={12} />
         </button>
 
         <div className="run-cmd">
@@ -162,8 +202,8 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
           href={`http://localhost:${port}`}
           target="_blank"
           rel="noreferrer"
-          className={`run-link${running ? "" : " disabled"}`}
-          onClick={(e) => { if (!running) e.preventDefault(); }}
+          className={`run-link${linkLive ? "" : " disabled"}`}
+          onClick={(e) => { if (!linkLive) e.preventDefault(); }}
         >
           <span className="colon">:</span>
           <span className="port">{port}</span>
@@ -181,13 +221,12 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
       </div>
 
       {/* ── Logs ── */}
-      <div className="run-logs">
-        {RUN_LOGS.map((l, i) => {
-          const cls = LOG_CLASS[l.c] ?? "";
-          const text = l.t.split('localhost:3000').join(`localhost:${port}`);
-          return <div key={i} className={cls || undefined}>{text}</div>;
-        })}
-        {running && (
+      <div className="run-logs" ref={logRef}>
+        {log.length > 0 && <div>{log}</div>}
+        {lastError && phase === "stopped" && (
+          <div className="e">{lastError}</div>
+        )}
+        {isActive && (
           <div className="p">
             {"› "}
             <span className="term-cursor" />

--- a/src/components/RightPanel/RunPanel.tsx
+++ b/src/components/RightPanel/RunPanel.tsx
@@ -78,8 +78,15 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
   // Rehydrate snapshot on mount/agent-switch so the panel preserves
   // logs from prior starts (and across panel mounts).
   useEffect(() => {
+    // `onRunOutput` / `onRunState` return promises that resolve to
+    // the unlisten fn. StrictMode runs effects twice in dev, and the
+    // cleanup may fire before those promises resolve — so we track a
+    // cancelled flag and dispose any unlistener that arrives late.
+    // Without this, the first mount's listener leaks and every event
+    // is delivered twice.
     let cancelled = false;
-    const cleanups: Array<() => void> = [];
+    let unlistenOutput: (() => void) | null = null;
+    let unlistenState: (() => void) | null = null;
     const decoder = new TextDecoder("utf-8", { fatal: false });
     decoderRef.current = decoder;
 
@@ -100,17 +107,30 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
         decoder.decode(new Uint8Array(e.bytes), { stream: true }),
       );
       setLog((prev) => prev + chunk);
-    }).then((un) => cleanups.push(un));
+    }).then((un) => {
+      if (cancelled) {
+        un();
+        return;
+      }
+      unlistenOutput = un;
+    });
 
     onRunState((e) => {
       if (e.agent_id !== agent.id) return;
       setPhase(e.phase);
       setLastError(e.last_error);
-    }).then((un) => cleanups.push(un));
+    }).then((un) => {
+      if (cancelled) {
+        un();
+        return;
+      }
+      unlistenState = un;
+    });
 
     return () => {
       cancelled = true;
-      for (const c of cleanups) c();
+      unlistenOutput?.();
+      unlistenState?.();
     };
   }, [agent.id]);
 


### PR DESCRIPTION
## Summary
- New per-agent ``RunSession`` (PTY + rolling 5MB log buffer + generation-tracked state machine) and supervisor methods ``run_start`` / ``run_stop`` / ``run_state`` exposed as Tauri commands; output and phase changes stream to the frontend via ``run:output`` / ``run:state`` events.
- First start of a freshly created agent runs the setup command (``pnpm install`` by default, configurable via ``project_settings.run.install``) inside the agent's worktree; on exit 0 it stamps ``agents.setup_completed_at`` (new column, cleared on archive) and chains into the dev command. Setup failure does not proceed to run.
- ``RunPanel.tsx`` drops the mock log and ``useState(true)`` toggle: it now rehydrates from ``run_state`` on mount, streams real PTY output (ANSI-stripped, streaming UTF-8 decode), and the button actually starts/stops the process.

## Test plan
- [ ] Spawn a fresh agent in a JS project; open the Run panel; click ▶ — verify ``pnpm install`` runs first, then ``pnpm dev`` chains in automatically.
- [ ] Click ▶ again on the same agent later — setup is skipped, dev starts directly.
- [ ] Click ■ mid-run — process is killed; clicking ▶ again starts cleanly.
- [ ] Force a setup failure (e.g. break ``package.json``) — verify run does NOT start and the error surfaces in the log.
- [ ] Close and reopen the panel mid-run — log and state rehydrate from the backend snapshot.
- [ ] Archive and restore an agent — restored agent re-runs setup.