### PR TITLE
Let right panel default to its old max and expand to center width

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -466,7 +466,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   leftCollapsed: false,
   rightCollapsed: false,
   leftWidth: 312,
-  rightWidth: 320,
+  rightWidth: 520,
 
   theme: "dark" as ThemeMode,
   accent: "copper",

--- a/src/util/splitter.ts
+++ b/src/util/splitter.ts
@@ -1,8 +1,14 @@
 import type { MouseEvent } from "react";
 
+const MIN_WIDTH = 220;
+/** Left pane stays bounded; the right pane can grow up to the center
+ *  pane's width (computed per-drag below). */
+const LEFT_MAX = 520;
+
 /** Pane-resize drag handler. Returns an `onMouseDown` to attach to a
  *  splitter element; while dragging it sets the receiving width via
- *  `set`. Width is clamped to [220, 520]. */
+ *  `set`. Left width is clamped to [220, 520]; the right pane may expand
+ *  until it is as wide as the center pane. */
 export function useSplitter(
   current: number,
   set: (w: number) => void,
@@ -13,11 +19,22 @@ export function useSplitter(
     const startX = e.clientX;
     const startW = current;
     const el = e.currentTarget;
+    // The right pane may grow until it matches the center pane. With the
+    // left pane and window fixed, `center + right` is constant for the
+    // duration of the drag, so the cap is half their combined width —
+    // measured once from the splitter's siblings (center precedes it,
+    // the right pane follows it).
+    let max = LEFT_MAX;
+    if (side === "right") {
+      const center = el.previousElementSibling?.getBoundingClientRect().width ?? 0;
+      const right = el.nextElementSibling?.getBoundingClientRect().width ?? startW;
+      max = Math.max(MIN_WIDTH, Math.floor((center + right) / 2));
+    }
     el.classList.add("dragging");
     const move = (ev: globalThis.MouseEvent) => {
       const dx = ev.clientX - startX;
       const next = side === "left" ? startW + dx : startW - dx;
-      set(Math.max(220, Math.min(520, next)));
+      set(Math.max(MIN_WIDTH, Math.min(max, next)));
     };
     const up = () => {
       el.classList.remove("dragging");


### PR DESCRIPTION
The right panel's default width is now 520 (the value that was previously its hardcoded maximum), so it opens wider on every launch. The fixed 520 drag cap is replaced with a per-drag bound computed from the center and right pane widths, letting the panel expand until it is as wide as the center pane. The left pane keeps its existing [220, 520] clamp and the right pane keeps a 220 minimum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)