### PR TITLE
Fix terminal panel overflow: absolute-fill xterm host with inset offsets

### DIFF
--- a/src/components/RightPanel/TermPanel.tsx
+++ b/src/components/RightPanel/TermPanel.tsx
@@ -220,10 +220,14 @@ export function TermPanel({ agent }: { agent: AgentRecord }) {
           </button>
         </div>
       )}
-      <div
-        ref={containerRef}
-        style={{ flex: 1, minHeight: 0, padding: "14px 18px", overflow: "hidden" }}
-      />
+      {/* xterm host is an absolute fill of the flex slot; inset via offsets,
+          not padding, which FitAddon doesn't account for. */}
+      <div style={{ position: "relative", flex: 1, minHeight: 0 }}>
+        <div
+          ref={containerRef}
+          style={{ position: "absolute", inset: "14px 4px 14px 12px", overflow: "hidden" }}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/Workspace/NativeView.tsx
+++ b/src/components/Workspace/NativeView.tsx
@@ -75,15 +75,20 @@ export function NativeView({ agent }: { agent: AgentRecord }) {
   }, [agent.id]);
 
   return (
-    <div
-      ref={containerRef}
-      style={{
-        flex: 1,
-        minHeight: 0,
-        padding: "8px 10px",
-        background: "#1a1c20",
-        overflow: "hidden",
-      }}
-    />
+    // xterm host is an absolute fill of the flex slot; inset via offsets,
+    // not padding, which FitAddon doesn't account for.
+    <div style={{ position: "relative", flex: 1, minHeight: 0, background: "#1a1c20" }}>
+      <div
+        ref={containerRef}
+        style={{
+          position: "absolute",
+          top: 8,
+          bottom: 8,
+          left: 10,
+          right: 10,
+          overflow: "hidden",
+        }}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
The xterm host in both the right-rail Terminal panel and the center native view was a padded `flex:1` child, but FitAddon ignores the host's padding and oversized the terminal — so content ran below the fold and the bottom rows were clipped. This wraps each host in a relative `flex:1` slot and makes the terminal an absolutely-positioned fill, applying the visual inset via offsets (`inset: "14px 4px 14px 12px"` for the Terminal panel, `8/10` for the native view) instead of padding so the measured size matches the rendered size. Layout-only change; terminal behavior is otherwise unchanged.

## Test Plan
- [x] `npm test` (24 passing) and `tsc --noEmit` clean
- [ ] Open the Terminal tab with long output and confirm content stays within the panel (no below-the-fold overflow, no clipped bottom rows)