### PR TITLE
Refactor terminals into a shared useXterm hook and fix right-edge clipping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-web-links": "^0.12.0",
+        "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^5.5.0",
         "lucide-react": "^1.16.0",
         "react": "^18.3.1",
@@ -677,6 +678,12 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.12.0.tgz",
       "integrity": "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-webgl": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-webgl/-/addon-webgl-0.19.0.tgz",
+      "integrity": "sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==",
       "license": "MIT"
     },
     "node_modules/@xterm/xterm": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-web-links": "^0.12.0",
+    "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^5.5.0",
     "lucide-react": "^1.16.0",
     "react": "^18.3.1",

--- a/src/app.css
+++ b/src/app.css
@@ -1570,6 +1570,20 @@ button { cursor: default; }
   to   { opacity: 1; transform: translateY(0); }
 }
 
+/* xterm host: an absolute fill of its flex slot, inset via offsets (callers
+   set `inset`) rather than padding — FitAddon measures the slot but not
+   padding, so padding would oversize the terminal and clip rows. */
+.xterm-slot {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+}
+.xterm-host {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+}
+
 /* Right-rail terminal panel */
 .term-panel {
   display: flex;

--- a/src/components/RightPanel/TermPanel.tsx
+++ b/src/components/RightPanel/TermPanel.tsx
@@ -1,12 +1,11 @@
 import { useState, useEffect, useRef } from "react";
 import { Terminal, type ITheme } from "@xterm/xterm";
-import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { SearchAddon } from "@xterm/addon-search";
-import "@xterm/xterm/css/xterm.css";
 import { open } from "@tauri-apps/plugin-shell";
 import { api, type AgentRecord } from "../../api";
 import { getShellBuffer, registerShellSink } from "../../store";
+import { useXterm } from "../../util/useXterm";
 import { Icon } from "../Icon";
 
 /** Resolve a CSS custom property to a #rrggbb hex string.
@@ -67,90 +66,67 @@ function resolveTheme(): ITheme {
 }
 
 export function TermPanel({ agent }: { agent: AgentRecord }) {
-  const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
   const searchAddonRef = useRef<SearchAddon | null>(null);
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
 
   // ── Terminal setup ──────────────────────────────────────────────
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-
-    api.openAgentShell(agent.id).catch((err) => {
-      console.error("openAgentShell failed", err);
-    });
-
-    const term = new Terminal({
-      fontFamily: "ui-monospace, 'SF Mono', Menlo, monospace",
+  const containerRef = useXterm(
+    {
       fontSize: 12,
       lineHeight: 1.2,
-      cursorBlink: true,
-      cursorStyle: "block",
       theme: resolveTheme(),
       scrollback: 20000,
-      allowProposedApi: false,
-      macOptionIsMeta: true,
-    });
-
-    const fit = new FitAddon();
-    const searchAddon = new SearchAddon();
-    term.loadAddon(fit);
-    term.loadAddon(searchAddon);
-    term.loadAddon(new WebLinksAddon((_, url) => open(url)));
-    term.open(el);
-
-    termRef.current = term;
-    searchAddonRef.current = searchAddon;
-
-    // Intercept Ctrl/Cmd+F so it opens the search bar instead of being
-    // sent to the PTY as a raw byte sequence.
-    term.attachCustomKeyEventHandler((e) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === "f" && e.type === "keydown") {
-        setSearchOpen(true);
-        return false; // prevent xterm from forwarding to PTY
-      }
-      return true;
-    });
-
-    const initialFit = requestAnimationFrame(() => {
-      try { fit.fit(); } catch { /* not measurable yet */ }
-    });
-
-    const buffered = getShellBuffer(agent.id);
-    if (buffered && buffered.length > 0) term.write(buffered);
-
-    const onResizeDisposer = term.onResize(({ cols, rows }) => {
-      api.resizeShell(agent.id, cols, rows).catch(() => {});
-    });
-    const onDataDisposer = term.onData((data) => {
-      api.writeToShell(agent.id, data).catch((err) => {
-        console.error("writeToShell failed", err);
+    },
+    (term) => {
+      api.openAgentShell(agent.id).catch((err) => {
+        console.error("openAgentShell failed", err);
       });
-    });
-    const unregister = registerShellSink(agent.id, (bytes) => term.write(bytes));
 
-    const ro = new ResizeObserver(() => {
-      try { fit.fit(); } catch { /* container may be hidden */ }
-    });
-    ro.observe(el);
-    term.focus();
+      const searchAddon = new SearchAddon();
+      term.loadAddon(searchAddon);
+      term.loadAddon(new WebLinksAddon((_, url) => open(url)));
 
-    return () => {
-      termRef.current = null;
-      searchAddonRef.current = null;
-      cancelAnimationFrame(initialFit);
-      ro.disconnect();
-      unregister();
-      onResizeDisposer.dispose();
-      onDataDisposer.dispose();
-      term.dispose();
-      // NOTE: do NOT call closeAgentShell here — VS Code behavior:
-      // shell stays alive across tab switches, only dies when agent is
-      // archived/discarded (handled by backend) or app quits.
-    };
-  }, [agent.id]);
+      termRef.current = term;
+      searchAddonRef.current = searchAddon;
+
+      // Intercept Ctrl/Cmd+F so it opens the search bar instead of being
+      // sent to the PTY as a raw byte sequence.
+      term.attachCustomKeyEventHandler((e) => {
+        if ((e.metaKey || e.ctrlKey) && e.key === "f" && e.type === "keydown") {
+          setSearchOpen(true);
+          return false; // prevent xterm from forwarding to PTY
+        }
+        return true;
+      });
+
+      const buffered = getShellBuffer(agent.id);
+      if (buffered && buffered.length > 0) term.write(buffered);
+
+      const onResize = term.onResize(({ cols, rows }) => {
+        api.resizeShell(agent.id, cols, rows).catch(() => {});
+      });
+      const onData = term.onData((data) => {
+        api.writeToShell(agent.id, data).catch((err) => {
+          console.error("writeToShell failed", err);
+        });
+      });
+      const unregister = registerShellSink(agent.id, (bytes) => term.write(bytes));
+
+      return () => {
+        termRef.current = null;
+        searchAddonRef.current = null;
+        unregister();
+        onResize.dispose();
+        onData.dispose();
+        // NOTE: do NOT call closeAgentShell here — VS Code behavior:
+        // shell stays alive across tab switches, only dies when agent is
+        // archived/discarded (handled by backend) or app quits.
+      };
+    },
+    [agent.id],
+  );
 
   // ── Theme reactivity ────────────────────────────────────────────
   // Watch <html> class for dark ↔ light switches and re-apply the theme
@@ -220,13 +196,8 @@ export function TermPanel({ agent }: { agent: AgentRecord }) {
           </button>
         </div>
       )}
-      {/* xterm host is an absolute fill of the flex slot; inset via offsets,
-          not padding, which FitAddon doesn't account for. */}
-      <div style={{ position: "relative", flex: 1, minHeight: 0 }}>
-        <div
-          ref={containerRef}
-          style={{ position: "absolute", inset: "14px 4px 14px 12px", overflow: "hidden" }}
-        />
+      <div className="xterm-slot">
+        <div ref={containerRef} className="xterm-host" style={{ inset: "14px 4px 14px 12px" }} />
       </div>
     </div>
   );

--- a/src/components/Workspace/NativeView.tsx
+++ b/src/components/Workspace/NativeView.tsx
@@ -47,7 +47,7 @@ export function NativeView({ agent }: { agent: AgentRecord }) {
 
   return (
     <div className="xterm-slot" style={{ background: NATIVE_BG }}>
-      <div ref={containerRef} className="xterm-host" style={{ inset: "8px 10px" }} />
+      <div ref={containerRef} className="xterm-host" style={{ inset: "8px 4px 8px 10px" }} />
     </div>
   );
 }

--- a/src/components/Workspace/NativeView.tsx
+++ b/src/components/Workspace/NativeView.tsx
@@ -1,94 +1,53 @@
-import { useEffect, useRef } from "react";
-import { Terminal } from "@xterm/xterm";
-import { FitAddon } from "@xterm/addon-fit";
-import "@xterm/xterm/css/xterm.css";
 import { api, type AgentRecord } from "../../api";
 import { getOutputBuffer, registerOutputSink } from "../../store";
+import { useXterm } from "../../util/useXterm";
+
+/** Fixed dark background for the native TUI view — used by both the xterm
+ *  theme and the host slot so they never drift out of sync. */
+const NATIVE_BG = "#1a1c20";
 
 /** Native view: Claude's Ink TUI is streamed verbatim into xterm.
  *  xterm owns stdin too, so slash commands, paste, arrows, escape, and
  *  other terminal interactions go straight to the PTY. */
 export function NativeView({ agent }: { agent: AgentRecord }) {
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-
-    const term = new Terminal({
-      fontFamily: "ui-monospace, 'SF Mono', Menlo, monospace",
+  const containerRef = useXterm(
+    {
       fontSize: 13,
-      cursorBlink: true,
-      cursorStyle: "block",
       theme: {
-        background: "#1a1c20",
+        background: NATIVE_BG,
         foreground: "#e6e8eb",
         cursor: "#e6e8eb",
-        cursorAccent: "#1a1c20",
+        cursorAccent: NATIVE_BG,
         selectionBackground: "#3a3f4a",
       },
       scrollback: 5000,
-      allowProposedApi: false,
-      macOptionIsMeta: true,
-    });
-    const fit = new FitAddon();
-    term.loadAddon(fit);
-    term.open(el);
+    },
+    (term) => {
+      const buffered = getOutputBuffer(agent.id);
+      if (buffered && buffered.length > 0) term.write(buffered);
 
-    const initialFit = requestAnimationFrame(() => {
-      try { fit.fit(); } catch { /* not measurable yet */ }
-    });
-
-    const buffered = getOutputBuffer(agent.id);
-    if (buffered && buffered.length > 0) {
-      term.write(buffered);
-    }
-
-    const onResizeDisposer = term.onResize(({ cols, rows }) => {
-      api.resizeAgent(agent.id, cols, rows).catch(() => {});
-    });
-
-    const onDataDisposer = term.onData((data) => {
-      api.writeToAgent(agent.id, data).catch((err) => {
-        console.error("writeToAgent failed", err);
+      const onResize = term.onResize(({ cols, rows }) => {
+        api.resizeAgent(agent.id, cols, rows).catch(() => {});
       });
-    });
+      const onData = term.onData((data) => {
+        api.writeToAgent(agent.id, data).catch((err) => {
+          console.error("writeToAgent failed", err);
+        });
+      });
+      const unregister = registerOutputSink(agent.id, (bytes) => term.write(bytes));
 
-    const unregister = registerOutputSink(agent.id, (bytes) => {
-      term.write(bytes);
-    });
-
-    const ro = new ResizeObserver(() => {
-      try { fit.fit(); } catch { /* container may be hidden */ }
-    });
-    ro.observe(el);
-    term.focus();
-
-    return () => {
-      cancelAnimationFrame(initialFit);
-      ro.disconnect();
-      unregister();
-      onResizeDisposer.dispose();
-      onDataDisposer.dispose();
-      term.dispose();
-    };
-  }, [agent.id]);
+      return () => {
+        unregister();
+        onResize.dispose();
+        onData.dispose();
+      };
+    },
+    [agent.id],
+  );
 
   return (
-    // xterm host is an absolute fill of the flex slot; inset via offsets,
-    // not padding, which FitAddon doesn't account for.
-    <div style={{ position: "relative", flex: 1, minHeight: 0, background: "#1a1c20" }}>
-      <div
-        ref={containerRef}
-        style={{
-          position: "absolute",
-          top: 8,
-          bottom: 8,
-          left: 10,
-          right: 10,
-          overflow: "hidden",
-        }}
-      />
+    <div className="xterm-slot" style={{ background: NATIVE_BG }}>
+      <div ref={containerRef} className="xterm-host" style={{ inset: "8px 10px" }} />
     </div>
   );
 }

--- a/src/util/useXterm.ts
+++ b/src/util/useXterm.ts
@@ -1,0 +1,95 @@
+import { useEffect, useRef } from "react";
+import { Terminal, type ITerminalOptions } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import { WebglAddon } from "@xterm/addon-webgl";
+import "@xterm/xterm/css/xterm.css";
+
+/** Options shared by every terminal in the app; callers override per use. */
+const XTERM_BASE_OPTIONS: ITerminalOptions = {
+  fontFamily: "ui-monospace, 'SF Mono', Menlo, monospace",
+  cursorBlink: true,
+  cursorStyle: "block",
+  allowProposedApi: false,
+  macOptionIsMeta: true,
+};
+
+/** Mount an xterm `Terminal` + `FitAddon` into a host element and own the
+ *  fit / resize / focus / dispose lifecycle.
+ *
+ *  The returned ref must be attached to a `.xterm-host` element (an absolute
+ *  fill of its flex slot, inset via offsets — which FitAddon reads correctly,
+ *  unlike padding). `options` is merged over the shared base.
+ *
+ *  Callers wire their own data flow in `onReady`: load extra addons, replay
+ *  buffered output, hook `onData`/`onResize`, register a sink, etc., and
+ *  return a cleanup that the hook runs on unmount, before disposing the
+ *  terminal. The whole lifecycle re-runs whenever `deps` change (e.g. a
+ *  different agent id).
+ */
+export function useXterm(
+  options: ITerminalOptions,
+  onReady: (term: Terminal) => (() => void) | void,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  deps: any[],
+) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const term = new Terminal({ ...XTERM_BASE_OPTIONS, ...options });
+    const fit = new FitAddon();
+    term.loadAddon(fit);
+    term.open(el);
+
+    // GPU renderer: positions cells on exact device pixels. The default DOM
+    // renderer rasterizes the last column short on fractional cell widths
+    // (e.g. 7.42px @ dpr 2), clipping the rightmost glyph. Fall back to the
+    // DOM renderer if the WebGL context is unavailable or gets lost.
+    let webgl: WebglAddon | undefined;
+    try {
+      webgl = new WebglAddon();
+      webgl.onContextLoss(() => webgl?.dispose());
+      term.loadAddon(webgl);
+    } catch {
+      // WebGL unavailable — DOM renderer remains in use
+    }
+
+    const cleanup = onReady(term);
+
+    const initialFit = requestAnimationFrame(() => {
+      try { fit.fit(); } catch { /* not measurable yet */ }
+    });
+
+    // Debounce refits to when the panel stops resizing. Fitting on every
+    // ResizeObserver tick makes the WebGL renderer clear and redraw its canvas
+    // each frame, which flashes during a drag. The terminal holds its size
+    // mid-drag (briefly clipped by the host's overflow) and reflows once.
+    let resizeTimer: ReturnType<typeof setTimeout> | undefined;
+    const ro = new ResizeObserver(() => {
+      if (resizeTimer) clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(() => {
+        try { fit.fit(); } catch { /* container may be hidden */ }
+      }, 100);
+    });
+    ro.observe(el);
+    term.focus();
+
+    return () => {
+      cancelAnimationFrame(initialFit);
+      if (resizeTimer) clearTimeout(resizeTimer);
+      ro.disconnect();
+      cleanup?.();
+      // Dispose the WebGL renderer BEFORE the terminal. Tearing it down after
+      // the core is gone dereferences a disposed _core._store and throws
+      // (React StrictMode's dev mount→unmount cycle triggers this every time).
+      // Guarded so the terminal's own addon disposal can't double-free it.
+      try { webgl?.dispose(); } catch { /* already disposed */ }
+      term.dispose();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  return containerRef;
+}


### PR DESCRIPTION
Extracts the duplicated xterm mount lifecycle from the right-rail Terminal panel and the center native view into a shared `useXterm` hook, and moves the two-div inset wrapper into `.xterm-slot`/`.xterm-host` CSS classes so each call site declares only what differs (size, theme, scrollback). Fixes the long-standing right-edge glyph clipping by switching from the default DOM renderer to the WebGL renderer (`@xterm/addon-webgl`), which positions cells on exact device pixels, with a graceful fallback to the DOM renderer. Adds the lifecycle guards that change required: disposing the WebGL addon before the terminal (avoids a `_core._store` crash under React StrictMode) and debouncing refits (stops the GL canvas from flashing while the panel is dragged). Also aligns the center terminal's scrollbar gap with the right panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)