### PR TITLE
Show provider name instead of workspace name in chat loader

### DIFF
--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef } from "react";
 import type { AgentRecord } from "../../api";
 import { useAppStore } from "../../store";
 import { applyPolicy, getAdapter } from "../../adapters";
+import { providerLabel } from "../../data/providers";
 import { Composer } from "../Composer";
 import { MessageItem } from "./messages/MessageItem";
 import { pairToolItems } from "./messages/pair";
@@ -106,7 +107,9 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
               <span className="dots">
                 <i /><i /><i />
               </span>
-              <span>{busyLabel ?? `${agent.name} is thinking`}</span>
+              <span>
+                {busyLabel ?? `${providerLabel(agent.provider)} is thinking`}
+              </span>
             </div>
           )}
         </div>

--- a/src/data/providers.ts
+++ b/src/data/providers.ts
@@ -22,6 +22,13 @@ export const PROVIDERS: Provider[] = [
 
 export const DEFAULT_PROVIDER_ID = "claude";
 
+/** Human-readable name for a provider id (e.g. "claude" → "Claude Code").
+ *  Falls back to the raw id when unknown so we never render an empty label. */
+export function providerLabel(id: string | null | undefined): string {
+  if (!id) return PROVIDERS.find((p) => p.id === DEFAULT_PROVIDER_ID)!.label;
+  return PROVIDERS.find((p) => p.id === id)?.label ?? id;
+}
+
 export interface Accent {
   id: string;
   label: string;


### PR DESCRIPTION
The chat "is thinking" loading indicator rendered `agent.name`, which is the workspace slug (e.g. "balkans") rather than the agent — making it look like the workspace was the agent. This adds a `providerLabel` helper in `src/data/providers.ts` that maps a provider id to its display name (falling back to the default/raw id so it never renders empty), and updates `ChatView` to show `"<provider> is thinking"` (e.g. "Claude Code is thinking"). The `busyLabel` override is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)