### PR TITLE
Open chat at the bottom consistently on first view

### DIFF
--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -27,7 +27,6 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
   const loadHistoryTranscript = useAppStore((s) => s.loadHistoryTranscript);
 
   const scrollRef = useRef<HTMLDivElement>(null);
-  const wasTranscriptLoading = useRef(false);
   const hasSession = Boolean(agent.session_id);
   const hasPriorConversation = agent.task.trim().length > 0;
 
@@ -58,12 +57,6 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
-    if (wasTranscriptLoading.current && !transcriptLoading) {
-      el.scrollTop = 0;
-      wasTranscriptLoading.current = false;
-      return;
-    }
-    wasTranscriptLoading.current = transcriptLoading;
     if (transcriptLoading) return;
     el.scrollTop = el.scrollHeight;
   }, [log, transcriptLoading]);


### PR DESCRIPTION
Fixes the inconsistent chat scroll position when opening an agent. The scroll effect in `ChatView` scrolled to the top after a transcript finished loading (`transcriptLoading` going `true → false`), a transition that only occurs on an agent's first open; on later switches the transcript is already cached, so the effect fell through to scroll-to-bottom. This made the first view land at the top while subsequent views landed at the bottom. This change removes the scroll-to-top special-case (and the now-unused `wasTranscriptLoading` ref) so the chat always opens at the last message, matching behavior across first and repeat visits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)