### PR TITLE
Add file-tree context menu for rename/delete/create/duplicate

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -589,8 +589,9 @@ fn primary_worktree(
 }
 
 /// List the agent's worktree files (tracked + untracked), each tagged with
-/// its git status vs the parent branch. Deleted files are included so the
-/// tree can still surface them.
+/// its git status vs the parent branch. This mirrors what's actually on disk
+/// — like a regular file explorer — so files the agent deleted are dropped
+/// rather than lingering as struck-through entries.
 #[tauri::command]
 pub async fn list_worktree_tree(
     supervisor: State<'_, Arc<Supervisor>>,
@@ -607,7 +608,15 @@ pub async fn list_worktree_tree(
         git::list_files(&worktree).await.unwrap_or_default().into_iter().collect();
     if let Some(s) = &state {
         for f in &s.files {
-            paths.insert(f.path.clone());
+            // A deleted file is gone from disk, so a file tree shouldn't show
+            // it — and `ls-files --cached` still lists it (it's in the index),
+            // so we must actively remove it. Everything else (untracked adds,
+            // modifications) belongs in the tree.
+            if matches!(f.kind, StatusKind::Deleted) {
+                paths.remove(&f.path);
+            } else {
+                paths.insert(f.path.clone());
+            }
         }
     }
 
@@ -705,6 +714,99 @@ pub async fn write_worktree_file(
         std::fs::create_dir_all(dir)?;
     }
     std::fs::write(&abs, contents)?;
+    Ok(())
+}
+
+/// Resolve a not-yet-existing destination inside the worktree: reject path
+/// traversal, refuse to clobber an existing entry, and create its parent
+/// directory. The create / rename / copy commands all share this so the
+/// no-clobber + path-safety contract lives in exactly one place.
+fn resolve_new_path(worktree: &Path, rel: &str) -> Result<PathBuf> {
+    let abs = safe_join(worktree, rel)?;
+    if abs.exists() {
+        return Err(Error::Other(format!("\"{rel}\" already exists")));
+    }
+    if let Some(dir) = abs.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+    Ok(abs)
+}
+
+/// Rename/move a worktree path (file or directory). Refuses to clobber an
+/// existing destination so a rename can never silently overwrite a sibling.
+#[tauri::command]
+pub async fn rename_worktree_path(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+    from: String,
+    to: String,
+) -> Result<()> {
+    let (worktree, _parent) = primary_worktree(&supervisor, &agent_id)?;
+    let src = safe_join(&worktree, &from)?;
+    let dst = resolve_new_path(&worktree, &to)?;
+    std::fs::rename(&src, &dst)?;
+    Ok(())
+}
+
+/// Delete a worktree path. Files are removed directly; directories are
+/// removed recursively (the UI guards this behind a confirm step). Deleting a
+/// path that's already gone is a no-op, so concurrent deletes don't error.
+#[tauri::command]
+pub async fn delete_worktree_path(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+    path: String,
+) -> Result<()> {
+    let (worktree, _parent) = primary_worktree(&supervisor, &agent_id)?;
+    let abs = safe_join(&worktree, &path)?;
+    if abs.is_dir() {
+        std::fs::remove_dir_all(&abs)?;
+    } else if abs.exists() {
+        std::fs::remove_file(&abs)?;
+    }
+    Ok(())
+}
+
+/// Create a new empty file, making parent directories as needed. Refuses to
+/// overwrite an existing path.
+#[tauri::command]
+pub async fn create_worktree_file(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+    path: String,
+) -> Result<()> {
+    let (worktree, _parent) = primary_worktree(&supervisor, &agent_id)?;
+    let abs = resolve_new_path(&worktree, &path)?;
+    std::fs::write(&abs, "")?;
+    Ok(())
+}
+
+/// Create a new directory. Refuses to clobber an existing path.
+#[tauri::command]
+pub async fn create_worktree_dir(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+    path: String,
+) -> Result<()> {
+    let (worktree, _parent) = primary_worktree(&supervisor, &agent_id)?;
+    let abs = resolve_new_path(&worktree, &path)?;
+    std::fs::create_dir_all(&abs)?;
+    Ok(())
+}
+
+/// Copy a worktree file to a new path (the explorer's "Duplicate"). Refuses
+/// to overwrite an existing destination.
+#[tauri::command]
+pub async fn copy_worktree_file(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+    from: String,
+    to: String,
+) -> Result<()> {
+    let (worktree, _parent) = primary_worktree(&supervisor, &agent_id)?;
+    let src = safe_join(&worktree, &from)?;
+    let dst = resolve_new_path(&worktree, &to)?;
+    std::fs::copy(&src, &dst)?;
     Ok(())
 }
 

--- a/src-tauri/src/git_state.rs
+++ b/src-tauri/src/git_state.rs
@@ -189,18 +189,22 @@ fn parse_porcelain(output: &str) -> Vec<FileStatus> {
         // For renamed files, git porcelain v1 formats the path as
         // `old_name -> new_name` (arrow) or `old_name\tnew_name` (tab).
         // We want the new name (destination), which is the part after the separator.
-        let path = if matches!(kind, StatusKind::Renamed) {
+        let raw = if matches!(kind, StatusKind::Renamed) {
             // Try tab separator first, then " -> "
             if let Some(pos) = path_part.find('\t') {
-                path_part[pos + 1..].to_string()
+                &path_part[pos + 1..]
             } else if let Some(pos) = path_part.find(" -> ") {
-                path_part[pos + 4..].to_string()
+                &path_part[pos + 4..]
             } else {
-                path_part.to_string()
+                path_part
             }
         } else {
-            path_part.to_string()
+            path_part
         };
+        // Paths with spaces / non-ASCII come back C-quoted (e.g. `"a b.rs"`);
+        // decode them back to the real on-disk path. Without this, the quotes
+        // leak into the tree and break path-based operations like delete.
+        let path = unquote_path(raw);
 
         files.push(FileStatus {
             path,
@@ -211,6 +215,54 @@ fn parse_porcelain(output: &str) -> Vec<FileStatus> {
         });
     }
     files
+}
+
+/// Decode a path as printed by `git status --porcelain` (without `-z`). Git
+/// wraps paths containing spaces, quotes, or non-ASCII bytes in double quotes
+/// and C-style escapes them (`\"`, `\\`, `\t`, octal `\NNN`, …). Plain,
+/// unquoted paths pass through unchanged.
+fn unquote_path(s: &str) -> String {
+    let bytes = s.as_bytes();
+    if bytes.len() < 2 || bytes[0] != b'"' || bytes[bytes.len() - 1] != b'"' {
+        return s.to_string();
+    }
+    let inner = &bytes[1..bytes.len() - 1];
+    let mut out: Vec<u8> = Vec::with_capacity(inner.len());
+    let mut i = 0;
+    while i < inner.len() {
+        if inner[i] == b'\\' && i + 1 < inner.len() {
+            match inner[i + 1] {
+                b'a' => { out.push(0x07); i += 2; }
+                b'b' => { out.push(0x08); i += 2; }
+                b't' => { out.push(b'\t'); i += 2; }
+                b'n' => { out.push(b'\n'); i += 2; }
+                b'v' => { out.push(0x0b); i += 2; }
+                b'f' => { out.push(0x0c); i += 2; }
+                b'r' => { out.push(b'\r'); i += 2; }
+                b'"' => { out.push(b'"'); i += 2; }
+                b'\\' => { out.push(b'\\'); i += 2; }
+                d @ b'0'..=b'7' => {
+                    // Up to three octal digits encode one byte (UTF-8 sequences
+                    // arrive as several such escapes).
+                    let mut val = (d - b'0') as u32;
+                    let mut j = i + 2;
+                    let mut n = 1;
+                    while j < inner.len() && n < 3 && inner[j].is_ascii_digit() && inner[j] < b'8' {
+                        val = val * 8 + (inner[j] - b'0') as u32;
+                        j += 1;
+                        n += 1;
+                    }
+                    out.push(val as u8);
+                    i = j;
+                }
+                _ => { out.push(inner[i]); i += 1; }
+            }
+        } else {
+            out.push(inner[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
 }
 
 fn status_kind(x: char, y: char) -> StatusKind {
@@ -246,10 +298,13 @@ fn parse_numstat(output: &str) -> HashMap<String, (u32, u32)> {
         // For renames, numstat emits `OLD => NEW` as the path field.
         // Index by the new name so lookups by current filename succeed.
         let path = if let Some(pos) = path.find(" => ") {
-            path[pos + 4..].to_string()
+            &path[pos + 4..]
         } else {
-            path
+            &path
         };
+        // numstat quotes non-ASCII paths just like `git status`; decode so the
+        // key matches the (unquoted) path in the file list it's merged into.
+        let path = unquote_path(path);
         // Binary files show `-\t-\t<path>`
         let adds: u32 = adds_str.parse().unwrap_or(0);
         let dels: u32 = dels_str.parse().unwrap_or(0);
@@ -381,6 +436,41 @@ mod tests {
         assert!(parse_porcelain("").is_empty());
     }
 
+    #[test]
+    fn porcelain_unquotes_path_with_space() {
+        // `git status` C-quotes paths containing spaces.
+        let input = "?? \"src/foo copy.ts\"\n";
+        let files = parse_porcelain(input);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "src/foo copy.ts");
+        assert!(matches!(files[0].kind, StatusKind::Untracked));
+    }
+
+    #[test]
+    fn porcelain_unquotes_non_ascii_octal_escapes() {
+        // "café.ts" → octal-escaped UTF-8 bytes inside quotes.
+        let input = " M \"caf\\303\\251.ts\"\n";
+        let files = parse_porcelain(input);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "café.ts");
+    }
+
+    #[test]
+    fn porcelain_unquotes_renamed_destination() {
+        let input = "R  \"old name.rs\" -> \"new name.rs\"\n";
+        let files = parse_porcelain(input);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "new name.rs");
+        assert!(matches!(files[0].kind, StatusKind::Renamed));
+    }
+
+    #[test]
+    fn unquote_passes_through_plain_paths() {
+        assert_eq!(unquote_path("src/main.rs"), "src/main.rs");
+        assert_eq!(unquote_path("\"a b.rs\""), "a b.rs");
+        assert_eq!(unquote_path("\"a\\\"b.rs\""), "a\"b.rs");
+    }
+
     // --- parse_numstat ---
 
     #[test]
@@ -419,5 +509,14 @@ mod tests {
         let map = parse_numstat(input);
         assert_eq!(map.get("src/foo.rs"), Some(&(42, 7)));
         assert_eq!(map.get("assets/logo.png"), Some(&(0, 0)));
+    }
+
+    #[test]
+    fn numstat_unquotes_non_ascii_path() {
+        // numstat C-quotes non-ASCII paths; the key must match the unquoted
+        // path used in the file list, or line counts silently drop to 0.
+        let input = "4\t0\t\"caf\\303\\251.ts\"\n";
+        let map = parse_numstat(input);
+        assert_eq!(map.get("café.ts"), Some(&(4, 0)));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -184,6 +184,11 @@ pub fn run() {
             commands::list_worktree_tree,
             commands::read_worktree_file,
             commands::write_worktree_file,
+            commands::rename_worktree_path,
+            commands::delete_worktree_path,
+            commands::create_worktree_file,
+            commands::create_worktree_dir,
+            commands::copy_worktree_file,
         ])
         .run(tauri::generate_context!())
         .expect("error while running quorum");

--- a/src/api.ts
+++ b/src/api.ts
@@ -273,6 +273,16 @@ export const api = {
     invoke<WorktreeFileContents>("read_worktree_file", { agentId, path }),
   writeWorktreeFile: (agentId: string, path: string, contents: string) =>
     invoke<void>("write_worktree_file", { agentId, path, contents }),
+  renameWorktreePath: (agentId: string, from: string, to: string) =>
+    invoke<void>("rename_worktree_path", { agentId, from, to }),
+  deleteWorktreePath: (agentId: string, path: string) =>
+    invoke<void>("delete_worktree_path", { agentId, path }),
+  createWorktreeFile: (agentId: string, path: string) =>
+    invoke<void>("create_worktree_file", { agentId, path }),
+  createWorktreeDir: (agentId: string, path: string) =>
+    invoke<void>("create_worktree_dir", { agentId, path }),
+  copyWorktreeFile: (agentId: string, from: string, to: string) =>
+    invoke<void>("copy_worktree_file", { agentId, from, to }),
 };
 
 export function onAgentOutput(

--- a/src/app.css
+++ b/src/app.css
@@ -190,8 +190,8 @@ button { cursor: default; }
 .btn-i svg { width: 14px; height: 14px; }
 .btn-i.sm { width: 22px; height: 22px; }
 .btn-i.sm svg { width: 12px; height: 12px; }
-.btn-i.xs { width: 18px; height: 18px; }
-.btn-i.xs svg { width: 11px; height: 11px; }
+.btn-i.xs { width: 22px; height: 22px; }
+.btn-i.xs svg { width: 16px; height: 16px; }
 
 .btn-t {
   display: inline-flex; align-items: center; gap: 6px;
@@ -1994,6 +1994,40 @@ button { cursor: default; }
 .fp-badge.s-a { background: color-mix(in oklch, var(--success), transparent 82%); color: var(--success); }
 .fp-badge.s-d { background: color-mix(in oklch, var(--danger), transparent 82%);  color: var(--danger); }
 .fp-badge.s-r { background: color-mix(in oklch, var(--info), transparent 82%);    color: var(--info); }
+
+/* ── inline rename / create input ── */
+.fp-name-input {
+  flex: 1; min-width: 0;
+  border: 1px solid var(--accent-line);
+  border-radius: var(--r-xs);
+  background: var(--bg-1);
+  color: var(--fg-0);
+  font: inherit;
+  padding: 0 4px; height: 19px;
+  outline: none;
+}
+.fp-name-input:focus { box-shadow: 0 0 0 2px var(--accent-soft); }
+.fp-creating { cursor: default; }
+
+/* ── file-tree context menu (uses .dd / .dd-item base styling) ── */
+.fp-ctx { min-width: 184px; }
+.fp-ctx-item { width: 100%; border: 0; background: transparent; text-align: left; cursor: default; }
+.fp-ctx-item.danger { color: var(--danger); }
+.fp-ctx-item.danger:hover { background: color-mix(in oklch, var(--danger), transparent 88%); color: var(--danger); }
+.fp-ctx-item.danger .di-i { color: var(--danger); }
+
+/* ── inline op-error bar ── */
+.fp-op-error {
+  display: flex; align-items: center; gap: 6px;
+  margin: 0 8px 4px; padding: 5px 8px;
+  border: 1px solid color-mix(in oklch, var(--danger), transparent 70%);
+  background: color-mix(in oklch, var(--danger), transparent 92%);
+  color: var(--danger);
+  border-radius: var(--r-sm);
+  font-size: 11.5px;
+}
+.fp-op-error span { flex: 1; min-width: 0; }
+.fp-op-error .fp-clear { color: var(--danger); }
 
 /* ── viewer header ── */
 .fp-viewer-h {

--- a/src/components/RightPanel/FileContextMenu.tsx
+++ b/src/components/RightPanel/FileContextMenu.tsx
@@ -1,0 +1,102 @@
+// A small right-click context menu, positioned at the cursor and clamped to
+// the viewport. Generic on its items so it isn't tied to the file tree — pass
+// a flat list of entries (with "sep" separators) and it renders + dismisses
+// itself on outside-click, Esc, scroll, or resize.
+//
+// Items may opt into a two-click confirm (`confirmLabel`): the first click
+// arms the item (swapping in the confirm label + danger styling), the second
+// runs it. Used to guard destructive actions like deleting a folder.
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { Icon, type IconName } from "../Icon";
+
+export interface ContextMenuItem {
+  icon: IconName;
+  label: string;
+  onClick: () => void;
+  danger?: boolean;
+  /** When set, the item requires a second click; its label becomes this. */
+  confirmLabel?: string;
+}
+
+export type ContextMenuEntry = ContextMenuItem | "sep";
+
+interface Props {
+  x: number;
+  y: number;
+  entries: ContextMenuEntry[];
+  onClose: () => void;
+}
+
+export function FileContextMenu({ x, y, entries, onClose }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState({ x, y });
+  // Index of the item currently armed for confirm, or -1 when none.
+  const [armed, setArmed] = useState(-1);
+
+  // Clamp into the viewport once we know the menu's size, so a click near the
+  // right/bottom edge doesn't push it off-screen.
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const { offsetWidth: w, offsetHeight: h } = el;
+    const nx = Math.min(x, window.innerWidth - w - 8);
+    const ny = Math.min(y, window.innerHeight - h - 8);
+    setPos({ x: Math.max(8, nx), y: Math.max(8, ny) });
+  }, [x, y]);
+
+  useEffect(() => {
+    const onDown = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) onClose();
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("mousedown", onDown, true);
+    window.addEventListener("keydown", onKey, true);
+    window.addEventListener("resize", onClose);
+    window.addEventListener("blur", onClose);
+    return () => {
+      window.removeEventListener("mousedown", onDown, true);
+      window.removeEventListener("keydown", onKey, true);
+      window.removeEventListener("resize", onClose);
+      window.removeEventListener("blur", onClose);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      ref={ref}
+      className="dd fp-ctx"
+      style={{ position: "fixed", left: pos.x, top: pos.y }}
+      role="menu"
+      onScroll={onClose}
+    >
+      {entries.map((entry, i) => {
+        if (entry === "sep") return <div key={i} className="dd-sep" />;
+        const isArmed = armed === i;
+        return (
+          <button
+            key={i}
+            type="button"
+            role="menuitem"
+            className={`dd-item fp-ctx-item ${entry.danger || isArmed ? "danger" : ""}`}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => {
+              if (entry.confirmLabel && !isArmed) {
+                setArmed(i);
+                return;
+              }
+              entry.onClick();
+              onClose();
+            }}
+          >
+            <span className="di-i">
+              <Icon name={entry.icon} size={13} />
+            </span>
+            <span className="di-l">{isArmed ? entry.confirmLabel : entry.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/RightPanel/FilePanel.helpers.test.ts
+++ b/src/components/RightPanel/FilePanel.helpers.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { buildTree, duplicatePath } from "./FilePanel";
+import { joinPath, parentDir } from "../../util/format";
+import type { WorktreeFile } from "../../api";
+
+const f = (path: string): WorktreeFile => ({ path, status: null, additions: 0, deletions: 0 });
+
+describe("parentDir / joinPath", () => {
+  it("splits and rejoins paths, treating root as empty", () => {
+    expect(parentDir("a/b/c.ts")).toBe("a/b");
+    expect(parentDir("top.ts")).toBe("");
+    expect(joinPath("a/b", "c.ts")).toBe("a/b/c.ts");
+    expect(joinPath("", "top.ts")).toBe("top.ts");
+  });
+});
+
+describe("duplicatePath", () => {
+  it("inserts ' copy' before the extension", () => {
+    expect(duplicatePath("a/foo.ts", new Set(["a/foo.ts"]))).toBe("a/foo copy.ts");
+  });
+
+  it("increments when the copy already exists", () => {
+    const existing = new Set(["foo.ts", "foo copy.ts", "foo copy 2.ts"]);
+    expect(duplicatePath("foo.ts", existing)).toBe("foo copy 3.ts");
+  });
+
+  it("handles extensionless and dotfile names", () => {
+    expect(duplicatePath("README", new Set(["README"]))).toBe("README copy");
+    expect(duplicatePath(".gitignore", new Set([".gitignore"]))).toBe(".gitignore copy");
+  });
+});
+
+describe("buildTree", () => {
+  it("injects empty extra directories so new folders survive a refresh", () => {
+    const tree = buildTree([f("src/app.ts")], ["src/empty"]);
+    const src = tree.find((n) => n.path === "src");
+    expect(src?.type).toBe("dir");
+    if (src?.type !== "dir") throw new Error("expected dir");
+    // dirs sort before files: empty/ then app.ts
+    expect(src.children.map((c) => c.path)).toEqual(["src/empty", "src/app.ts"]);
+    expect(src.children[0].type).toBe("dir");
+  });
+});

--- a/src/components/RightPanel/FilePanel.tsx
+++ b/src/components/RightPanel/FilePanel.tsx
@@ -19,7 +19,9 @@ import { highlightToHtml } from "../../util/highlight";
 import { useHljsTheme } from "../../util/codeTheme";
 import { langLabel } from "../../data/languages";
 import { FileIcon } from "./FileIcon";
+import { FileContextMenu, type ContextMenuEntry } from "./FileContextMenu";
 import { Icon } from "../Icon";
+import { basename, joinPath, parentDir } from "../../util/format";
 
 // ── tree model ──────────────────────────────────────────────────────────
 type DirNode = { type: "dir"; name: string; path: string; children: TreeNode[] };
@@ -32,6 +34,15 @@ type FileNode = {
   deletions: number;
 };
 type TreeNode = DirNode | FileNode;
+
+// An in-progress inline edit: renaming an existing node, or creating a new
+// file/folder inside `parentDir` ("" = repo root).
+type EditState =
+  | { mode: "rename"; path: string; isDir: boolean }
+  | { mode: "newFile" | "newFolder"; parentDir: string };
+
+// An open context menu, anchored at the cursor over `node`.
+type MenuState = { x: number; y: number; node: TreeNode };
 
 interface FilePanelProps {
   agent: AgentRecord;
@@ -46,6 +57,12 @@ export function FilePanel({ agent, canViewDiff, onViewDiff }: FilePanelProps) {
   const [query, setQuery] = useState("");
   const [changedOnly, setChangedOnly] = useState(false);
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  const [menu, setMenu] = useState<MenuState | null>(null);
+  const [edit, setEdit] = useState<EditState | null>(null);
+  const [opError, setOpError] = useState<string | null>(null);
+  // Newly-created directories that are still empty. git lists files, not dirs,
+  // so without this a brand-new folder would vanish on the next poll.
+  const [pendingDirs, setPendingDirs] = useState<Set<string>>(() => new Set());
 
   // Reset per-agent so one worktree's open file / search doesn't leak.
   useEffect(() => {
@@ -55,6 +72,10 @@ export function FilePanel({ agent, canViewDiff, onViewDiff }: FilePanelProps) {
     setLoaded(false);
     setFiles([]);
     setExpanded(new Set());
+    setMenu(null);
+    setEdit(null);
+    setOpError(null);
+    setPendingDirs(new Set());
   }, [agent.id]);
 
   const refresh = useCallback(async () => {
@@ -73,7 +94,22 @@ export function FilePanel({ agent, canViewDiff, onViewDiff }: FilePanelProps) {
   }, [openPath, refresh]);
   usePoll(pollTree, 2000, [pollTree]);
 
-  const fullTree = useMemo(() => buildTree(files), [files]);
+  const fullTree = useMemo(
+    () => buildTree(files, [...pendingDirs]),
+    [files, pendingDirs],
+  );
+
+  // Once a real file lands inside a tracked empty-dir, git lists the dir via
+  // that file, so we can stop injecting it (and keep the set from growing).
+  useEffect(() => {
+    setPendingDirs((s) => {
+      if (!s.size) return s;
+      const next = new Set(
+        [...s].filter((d) => !files.some((file) => file.path === d || file.path.startsWith(`${d}/`))),
+      );
+      return next.size === s.size ? s : next;
+    });
+  }, [files]);
 
   // Default every directory open the first time files arrive.
   const seededRef = useRef(false);
@@ -98,6 +134,132 @@ export function FilePanel({ agent, canViewDiff, onViewDiff }: FilePanelProps) {
       else n.add(path);
       return n;
     });
+
+  const expand = (path: string) =>
+    setExpanded((s) => new Set(s).add(path));
+
+  // ── file operations ───────────────────────────────────────────────────
+  const allPaths = useMemo(() => new Set(files.map((f) => f.path)), [files]);
+
+  // Begin a create: open the target dir so the inline input is visible.
+  const beginCreate = (mode: "newFile" | "newFolder", dir: string) => {
+    setOpError(null);
+    if (dir) expand(dir);
+    setEdit({ mode, parentDir: dir });
+  };
+
+  const cancelEdit = () => setEdit(null);
+
+  // Commit the active inline edit. `value` is the raw input; empty / unchanged
+  // values quietly cancel. On a backend error we surface it and keep editing.
+  const commitEdit = async (value: string) => {
+    const name = value.trim();
+    if (!edit) return;
+    if (!name) { setEdit(null); return; }
+    setOpError(null);
+    try {
+      if (edit.mode === "rename") {
+        const from = edit.path;
+        const dest = joinPath(parentDir(from), name);
+        if (dest === from) { setEdit(null); return; }
+        await api.renameWorktreePath(agent.id, from, dest);
+        // An empty folder we're tracking moves with the rename; re-point it (and
+        // any tracked descendants) or it would vanish and leave a phantom.
+        if (edit.isDir) {
+          setPendingDirs((s) => {
+            const n = new Set<string>();
+            for (const d of s) {
+              if (d === from) n.add(dest);
+              else if (d.startsWith(`${from}/`)) n.add(dest + d.slice(from.length));
+              else n.add(d);
+            }
+            return n;
+          });
+        }
+      } else if (edit.mode === "newFile") {
+        const dest = joinPath(edit.parentDir, name);
+        await api.createWorktreeFile(agent.id, dest);
+        setEdit(null);
+        await refresh();
+        setOpenPath(dest);
+        return;
+      } else {
+        const dest = joinPath(edit.parentDir, name);
+        await api.createWorktreeDir(agent.id, dest);
+        setPendingDirs((s) => new Set(s).add(dest));
+        expand(dest);
+      }
+      setEdit(null);
+      await refresh();
+    } catch (e) {
+      setOpError(errMsg(e));
+    }
+  };
+
+  const doDelete = async (node: TreeNode) => {
+    setOpError(null);
+    try {
+      await api.deleteWorktreePath(agent.id, node.path);
+      // Drop any tracked empty-dir under what we just removed.
+      setPendingDirs((s) => {
+        const n = new Set(s);
+        for (const d of n) {
+          if (d === node.path || d.startsWith(`${node.path}/`)) n.delete(d);
+        }
+        return n;
+      });
+      await refresh();
+    } catch (e) {
+      setOpError(errMsg(e));
+    }
+  };
+
+  const doDuplicate = async (node: FileNode) => {
+    setOpError(null);
+    try {
+      const dest = duplicatePath(node.path, allPaths);
+      await api.copyWorktreeFile(agent.id, node.path, dest);
+      await refresh();
+    } catch (e) {
+      setOpError(errMsg(e));
+    }
+  };
+
+  const copyPath = (node: TreeNode) => {
+    navigator.clipboard?.writeText(node.path).catch(() => {});
+  };
+
+  // Build the context-menu entries for a right-clicked node.
+  const menuEntries = (node: TreeNode): ContextMenuEntry[] => {
+    // New File / New Folder target the folder itself, or a file's parent dir.
+    const target = node.type === "dir" ? node.path : parentDir(node.path);
+    const newItems: ContextMenuEntry[] = [
+      { icon: "file", label: "New File…", onClick: () => beginCreate("newFile", target) },
+      { icon: "folder", label: "New Folder…", onClick: () => beginCreate("newFolder", target) },
+    ];
+    const common: ContextMenuEntry[] = [
+      { icon: "edit", label: "Rename…", onClick: () => { setOpError(null); setEdit({ mode: "rename", path: node.path, isDir: node.type === "dir" }); } },
+      { icon: "copy", label: "Copy Path", onClick: () => copyPath(node) },
+    ];
+    const del: ContextMenuEntry = {
+      icon: "trash",
+      label: "Delete",
+      danger: true,
+      confirmLabel: node.type === "dir" ? "Delete folder & contents?" : "Confirm Delete?",
+      onClick: () => void doDelete(node),
+    };
+    if (node.type === "dir") {
+      return [...newItems, "sep", ...common, "sep", del];
+    }
+    return [
+      ...common,
+      { icon: "copy", label: "Duplicate", onClick: () => void doDuplicate(node) },
+      "sep",
+      ...newItems,
+      "sep",
+      del,
+    ];
+  };
 
   // ── editor ──────────────────────────────────────────────────────────
   if (openPath) {
@@ -143,6 +305,20 @@ export function FilePanel({ agent, canViewDiff, onViewDiff }: FilePanelProps) {
         </button>
         <button
           className="btn-i xs"
+          title="New file"
+          onClick={() => beginCreate("newFile", "")}
+        >
+          <Icon name="file" />
+        </button>
+        <button
+          className="btn-i xs"
+          title="New folder"
+          onClick={() => beginCreate("newFolder", "")}
+        >
+          <Icon name="folder" />
+        </button>
+        <button
+          className="btn-i xs"
           title="Collapse all"
           onClick={() => setExpanded(new Set())}
         >
@@ -150,8 +326,21 @@ export function FilePanel({ agent, canViewDiff, onViewDiff }: FilePanelProps) {
         </button>
       </div>
 
+      {opError && (
+        <div className="fp-op-error" role="alert">
+          <Icon name="close" size={11} />
+          <span>{opError}</span>
+          <button className="fp-clear" onClick={() => setOpError(null)} aria-label="Dismiss">
+            <Icon name="close" size={10} />
+          </button>
+        </div>
+      )}
+
       <div className="fp-tree">
-        {tree.length === 0 ? (
+        {edit && edit.mode !== "rename" && edit.parentDir === "" && (
+          <CreateRow mode={edit.mode} depth={0} onCommit={commitEdit} onCancel={cancelEdit} />
+        )}
+        {tree.length === 0 && !edit ? (
           <div className="empty-msg" style={{ margin: "auto" }}>
             <div className="et">{loaded ? "No matching files" : "Loading…"}</div>
             {loaded && (
@@ -168,12 +357,25 @@ export function FilePanel({ agent, canViewDiff, onViewDiff }: FilePanelProps) {
               depth={0}
               expanded={expanded}
               forceOpen={filtering}
+              edit={edit}
               onToggle={toggleDir}
               onOpen={setOpenPath}
+              onMenu={(n, x, y) => setMenu({ node: n, x, y })}
+              onCommit={commitEdit}
+              onCancel={cancelEdit}
             />
           ))
         )}
       </div>
+
+      {menu && (
+        <FileContextMenu
+          x={menu.x}
+          y={menu.y}
+          entries={menuEntries(menu.node)}
+          onClose={() => setMenu(null)}
+        />
+      )}
     </div>
   );
 }
@@ -184,36 +386,65 @@ interface TreeRowProps {
   depth: number;
   expanded: Set<string>;
   forceOpen: boolean;
+  edit: EditState | null;
   onToggle: (path: string) => void;
   onOpen: (path: string) => void;
+  onMenu: (node: TreeNode, x: number, y: number) => void;
+  onCommit: (value: string) => void;
+  onCancel: () => void;
 }
 
-function TreeRow({ node, depth, expanded, forceOpen, onToggle, onOpen }: TreeRowProps) {
+function TreeRow({
+  node, depth, expanded, forceOpen, edit, onToggle, onOpen, onMenu, onCommit, onCancel,
+}: TreeRowProps) {
   const pad = 10 + depth * 13;
+  const renaming = edit?.mode === "rename" && edit.path === node.path;
 
   if (node.type === "dir") {
     const isOpen = forceOpen || expanded.has(node.path);
+    const creatingHere =
+      edit && edit.mode !== "rename" && edit.parentDir === node.path;
     return (
       <>
-        <button className="fp-row dir" style={{ paddingLeft: pad }} onClick={() => onToggle(node.path)}>
+        <button
+          className="fp-row dir"
+          style={{ paddingLeft: pad }}
+          onClick={() => onToggle(node.path)}
+          onContextMenu={(e) => { e.preventDefault(); onMenu(node, e.clientX, e.clientY); }}
+        >
           <span className={`fp-twisty ${isOpen ? "open" : ""}`}>
             <Icon name="chevR" size={11} />
           </span>
           <FileIcon name={node.name} folder open={isOpen} />
-          <span className="fp-name">{node.name}</span>
+          {renaming ? (
+            <NameInput initial={node.name} onCommit={onCommit} onCancel={onCancel} />
+          ) : (
+            <span className="fp-name">{node.name}</span>
+          )}
         </button>
-        {isOpen &&
-          node.children.map((c) => (
-            <TreeRow
-              key={c.path}
-              node={c}
-              depth={depth + 1}
-              expanded={expanded}
-              forceOpen={forceOpen}
-              onToggle={onToggle}
-              onOpen={onOpen}
-            />
-          ))}
+        {(isOpen || creatingHere) && (
+          <>
+            {creatingHere && edit && (
+              <CreateRow mode={edit.mode} depth={depth + 1} onCommit={onCommit} onCancel={onCancel} />
+            )}
+            {isOpen &&
+              node.children.map((c) => (
+                <TreeRow
+                  key={c.path}
+                  node={c}
+                  depth={depth + 1}
+                  expanded={expanded}
+                  forceOpen={forceOpen}
+                  edit={edit}
+                  onToggle={onToggle}
+                  onOpen={onOpen}
+                  onMenu={onMenu}
+                  onCommit={onCommit}
+                  onCancel={onCancel}
+                />
+              ))}
+          </>
+        )}
       </>
     );
   }
@@ -224,12 +455,82 @@ function TreeRow({ node, depth, expanded, forceOpen, onToggle, onOpen }: TreeRow
       className={`fp-row file ${node.status ? "changed s-" + st : ""}`}
       style={{ paddingLeft: pad + 13 }}
       onClick={() => onOpen(node.path)}
+      onContextMenu={(e) => { e.preventDefault(); onMenu(node, e.clientX, e.clientY); }}
       title={node.path}
     >
       <FileIcon name={node.name} />
-      <span className="fp-name">{node.name}</span>
-      {node.status && <span className={`fp-badge s-${st}`}>{node.status}</span>}
+      {renaming ? (
+        <NameInput initial={node.name} onCommit={onCommit} onCancel={onCancel} />
+      ) : (
+        <span className="fp-name">{node.name}</span>
+      )}
+      {node.status && !renaming && <span className={`fp-badge s-${st}`}>{node.status}</span>}
     </button>
+  );
+}
+
+// ── inline name input (rename + create) ──────────────────────────────────
+interface NameInputProps {
+  initial: string;
+  onCommit: (value: string) => void;
+  onCancel: () => void;
+}
+
+function NameInput({ initial, onCommit, onCancel }: NameInputProps) {
+  const ref = useRef<HTMLInputElement>(null);
+  // Commit and cancel both unmount the input, which fires onBlur — guard so a
+  // single edit resolves exactly once.
+  const doneRef = useRef(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.focus();
+    // Select the basename but not the extension, matching VS Code's rename.
+    const dot = initial.lastIndexOf(".");
+    if (dot > 0) el.setSelectionRange(0, dot);
+    else el.select();
+  }, [initial]);
+
+  const commit = (v: string) => { if (!doneRef.current) { doneRef.current = true; onCommit(v); } };
+  const cancel = () => { if (!doneRef.current) { doneRef.current = true; onCancel(); } };
+
+  return (
+    <input
+      ref={ref}
+      className="fp-name-input"
+      defaultValue={initial}
+      spellCheck={false}
+      autoCapitalize="off"
+      autoCorrect="off"
+      onClick={(e) => { e.stopPropagation(); }}
+      onMouseDown={(e) => { e.stopPropagation(); }}
+      onKeyDown={(e) => {
+        e.stopPropagation();
+        if (e.key === "Enter") { e.preventDefault(); commit(e.currentTarget.value); }
+        else if (e.key === "Escape") { e.preventDefault(); cancel(); }
+      }}
+      onBlur={(e) => commit(e.currentTarget.value)}
+    />
+  );
+}
+
+// A transient "new file / new folder" row holding just the name input.
+interface CreateRowProps {
+  mode: "newFile" | "newFolder";
+  depth: number;
+  onCommit: (value: string) => void;
+  onCancel: () => void;
+}
+
+function CreateRow({ mode, depth, onCommit, onCancel }: CreateRowProps) {
+  const pad = 10 + depth * 13;
+  const isFolder = mode === "newFolder";
+  return (
+    <div className="fp-row file fp-creating" style={{ paddingLeft: pad + 13 }}>
+      <FileIcon name="" folder={isFolder} open={isFolder} />
+      <NameInput initial="" onCommit={onCommit} onCancel={onCancel} />
+    </div>
   );
 }
 
@@ -243,9 +544,8 @@ interface FileViewerProps {
 }
 
 function FileViewer({ agent, path, canViewDiff, onViewDiff, onBack }: FileViewerProps) {
-  const parts = path.split("/");
-  const name = parts.pop() as string;
-  const dir = parts.join("/");
+  const name = basename(path);
+  const dir = parentDir(path);
 
   const [contents, setContents] = useState<WorktreeFileContents | null>(null);
   const [error, setError] = useState(false);
@@ -563,9 +863,31 @@ function ViewerHeader({ name, dir, status, dirty, onBack, actions }: ViewerHeade
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
+/** A non-colliding "… copy" path for Duplicate, e.g. `a/foo.ts` →
+ *  `a/foo copy.ts`, then `a/foo copy 2.ts`, … against `existing`. */
+export function duplicatePath(path: string, existing: Set<string>): string {
+  const dir = parentDir(path);
+  const base = basename(path);
+  const dot = base.lastIndexOf(".");
+  const stem = dot > 0 ? base.slice(0, dot) : base;
+  const ext = dot > 0 ? base.slice(dot) : "";
+  for (let n = 1; ; n++) {
+    const suffix = n === 1 ? " copy" : ` copy ${n}`;
+    const candidate = joinPath(dir, `${stem}${suffix}${ext}`);
+    if (!existing.has(candidate)) return candidate;
+  }
+}
+
+/** Best-effort message from a rejected Tauri command (errors serialize to a
+ *  display string). */
+function errMsg(e: unknown): string {
+  return typeof e === "string" ? e : e instanceof Error ? e.message : "Operation failed";
+}
+
 /** Build a sorted nested tree (dirs first, then files; alpha within each)
- *  from a flat list of worktree files. */
-function buildTree(files: WorktreeFile[]): TreeNode[] {
+ *  from a flat list of worktree files. `extraDirs` injects directories that
+ *  carry no files yet (freshly-created empty folders). */
+export function buildTree(files: WorktreeFile[], extraDirs: string[] = []): TreeNode[] {
   const roots: TreeNode[] = [];
   // path → DirNode, so we can attach children as we walk each file's segments.
   const dirIndex = new Map<string, DirNode>();
@@ -573,11 +895,11 @@ function buildTree(files: WorktreeFile[]): TreeNode[] {
   const childrenOf = (path: string): TreeNode[] =>
     path === "" ? roots : (dirIndex.get(path) as DirNode).children;
 
-  for (const f of files) {
-    const segs = f.path.split("/");
+  // Ensure a directory path (and its ancestors) exist as DirNodes.
+  const ensureDir = (dir: string): void => {
+    const segs = dir.split("/");
     let prefix = "";
-    // create intermediate directories
-    for (let i = 0; i < segs.length - 1; i++) {
+    for (let i = 0; i < segs.length; i++) {
       const parent = prefix;
       prefix = prefix ? `${prefix}/${segs[i]}` : segs[i];
       if (!dirIndex.has(prefix)) {
@@ -586,6 +908,11 @@ function buildTree(files: WorktreeFile[]): TreeNode[] {
         childrenOf(parent).push(node);
       }
     }
+  };
+
+  for (const f of files) {
+    const segs = f.path.split("/");
+    if (segs.length > 1) ensureDir(segs.slice(0, -1).join("/"));
     const parent = segs.length > 1 ? segs.slice(0, -1).join("/") : "";
     childrenOf(parent).push({
       type: "file",
@@ -596,6 +923,8 @@ function buildTree(files: WorktreeFile[]): TreeNode[] {
       deletions: f.deletions,
     });
   }
+
+  for (const d of extraDirs) if (d) ensureDir(d);
 
   sortNodes(roots);
   return roots;

--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -5,6 +5,17 @@ export function basename(p: string): string {
   return parts[parts.length - 1] ?? p;
 }
 
+/** The directory portion of a path ("" for a top-level entry). */
+export function parentDir(p: string): string {
+  const i = p.lastIndexOf("/");
+  return i === -1 ? "" : p.slice(0, i);
+}
+
+/** Join a directory and a name, tolerating the empty (root) directory. */
+export function joinPath(dir: string, name: string): string {
+  return dir ? `${dir}/${name}` : name;
+}
+
 /** Stable hue (0–360) derived from a string — used to color a project
  *  swatch consistently across reloads. */
 export function hueFromString(s: string): number {


### PR DESCRIPTION
Adds a right-click context menu to the Files panel for rename, delete, duplicate, copy path, and new file/folder, with inline VS Code-style editing. It's backed by new worktree filesystem commands (rename/delete/create/copy) that share a single path-safety + no-clobber helper. This also fixes a latent git-output bug where `status` and `numstat` paths containing spaces or non-ASCII characters were never C-unquoted — which broke Duplicate and dropped the +X/−Y line counts. The tree now mirrors the on-disk filesystem instead of showing agent-deleted files as struck-through ghosts. New Rust and Vitest tests cover the path parsing and tree helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)