### PR TITLE
Fix updater endpoint URL to updater.quorum.fwdai.org

### DIFF
--- a/cloudflare-worker/README.md
+++ b/cloudflare-worker/README.md
@@ -22,7 +22,7 @@ wrangler deploy
 
 ## Custom domain
 
-`wrangler.toml` binds the Worker to `updates.quorum.app`, which is the URL in
+`wrangler.toml` binds the Worker to `updater.quorum.fwdai.org`, which is the URL in
 `src-tauri/tauri.conf.json` → `plugins.updater.endpoints`. The domain must be on
 your Cloudflare account; Wrangler provisions the custom-domain route on deploy.
 If you use a different host, update both `wrangler.toml` and `tauri.conf.json`.

--- a/cloudflare-worker/wrangler.toml
+++ b/cloudflare-worker/wrangler.toml
@@ -5,5 +5,5 @@ compatibility_date = "2025-01-01"
 # Custom domain that backs the updater endpoint in src-tauri/tauri.conf.json
 # (plugins.updater.endpoints). You must own this domain and have it on Cloudflare.
 routes = [
-  { pattern = "updates.quorum.app", custom_domain = true }
+  { pattern = "updater.quorum.fwdai.org", custom_domain = true }
 ]

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -61,7 +61,7 @@ as a secret and proxies `latest.json` + asset downloads, rewriting the manifest
 URLs to point back at itself. `tauri.conf.json` already points at it:
 
 ```json
-"endpoints": ["https://updates.quorum.app/latest.json"]
+"endpoints": ["https://updater.quorum.fwdai.org/latest.json"]
 ```
 
 Deploy it once:
@@ -73,7 +73,7 @@ wrangler secret put GITHUB_TOKEN   # fine-grained PAT, Contents: read on fwdai/q
 wrangler deploy
 ```
 
-The domain `updates.quorum.app` must be on your Cloudflare account (Wrangler
+The domain `updater.quorum.fwdai.org` must be on your Cloudflare account (Wrangler
 provisions the custom-domain route). If you use a different host, change both
 `cloudflare-worker/wrangler.toml` and `tauri.conf.json`. See
 `cloudflare-worker/README.md` for endpoint details.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,7 +29,7 @@
   "plugins": {
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDY2Njg3OUNDQ0E2MUYxNDUKUldSRjhXSEt6SGxvWnZTdnplUDEzRHVSdmR2OEJwanhLTEJLQ2MzTnVLU0tZVTBnVElzbjV1Vk0K",
-      "endpoints": ["https://updates.quorum.app/latest.json"]
+      "endpoints": ["https://updater.quorum.fwdai.org/latest.json"]
     }
   },
   "bundle": {


### PR DESCRIPTION
PR #56 merged with the placeholder updater endpoint `updates.quorum.app`, but a follow-up commit changing it to the real custom domain `updater.quorum.fwdai.org` landed after the merge and never reached `main`. This applies that fix across `tauri.conf.json`, the Cloudflare Worker route, and the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)