### PR TITLE
Pin worker observability setting in wrangler.toml

### DIFF
--- a/cloudflare-worker/wrangler.toml
+++ b/cloudflare-worker/wrangler.toml
@@ -7,3 +7,7 @@ compatibility_date = "2025-01-01"
 routes = [
   { pattern = "updater.quorum.fwdai.org", custom_domain = true }
 ]
+
+# Keep dashboard-managed settings in the config so they survive `wrangler deploy`.
+[observability]
+enabled = false


### PR DESCRIPTION
Adds `[observability] enabled = false` to `cloudflare-worker/wrangler.toml` so the dashboard-managed setting is consistent across `wrangler deploy` runs instead of being reset each time. (This change was pushed just after PR #58 merged, so it didn't ride along.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)