### PR TITLE
Build app target so updater artifacts (latest.json) are produced

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -34,7 +34,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["dmg"],
+    "targets": ["app", "dmg"],
     "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
The successful release build emitted only a signed DMG and no updater artifacts. The bundler logged: *"configured to create updater artifacts but no updater-enabled targets were built. Please enable one of these targets: app, ..."* — because `bundle.targets` was `["dmg"]`, and the macOS updater artifact (`Quorum.app.tar.gz` + `.sig`) comes from the **`app`** target, not `dmg`. As a result `tauri-action` found no updater signature and skipped uploading `latest.json`. This adds `app` to the targets so both the updater artifact and the DMG are produced.

After merge: re-run the Release workflow (bump to v0.1.2 or delete the artifact-less v0.1.1), publish the draft, and the worker will serve a real `latest.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)