### PR TITLE
Bump version to 0.1.2 for a fresh release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quorum",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "quorum"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quorum"
-version = "0.1.1"
+version = "0.1.2"
 description = "Spawn coding agents in isolated sandboxes"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Quorum",
   "mainBinaryName": "Quorum",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "com.quorum.desktop",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Bumps the version `0.1.1 → 0.1.2` across `tauri.conf.json`, `package.json`, `Cargo.toml`, and `Cargo.lock`. The existing `v0.1.1` release has no updater artifacts, and the updater-artifact fix (#60) is now on `main`, so the next Release run needs a new version to produce a clean `v0.1.2` with `latest.json`.

After merge: run the Release workflow → publish the draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)