### PR TITLE
Publish releases and trigger website redeploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,9 @@ name: Release
 
 # Manual only. Bump `version` in src-tauri/tauri.conf.json (and keep
 # package.json + Cargo.toml in sync) before running. This builds, signs, and
-# notarizes a universal macOS app and creates a DRAFT GitHub release with the
-# .dmg, the updater artifact (.app.tar.gz + .sig), and latest.json. Publishing
-# the draft makes it available to the in-app auto-updater.
+# notarizes a universal macOS app and creates a PUBLISHED GitHub release with
+# the .dmg, the updater artifact (.app.tar.gz + .sig), and latest.json.
+# Publishing makes it available to the in-app auto-updater.
 on:
   workflow_dispatch:
 
@@ -35,7 +35,7 @@ jobs:
       - name: Install frontend dependencies
         run: bun install --frozen-lockfile
 
-      - name: Build, sign, notarize and draft release
+      - name: Build, sign, notarize and publish release
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -53,7 +53,13 @@ jobs:
           tagName: v__VERSION__
           releaseName: Quorum v__VERSION__
           releaseBody: See the assets to download and install this version.
-          releaseDraft: true
+          releaseDraft: false
           prerelease: false
           tauriScript: bun run tauri
           args: --target universal-apple-darwin
+
+      # Kick off a Cloudflare Workers Builds deploy of the marketing site
+      # (fwdai/quorum-web) so it rebuilds against the freshly published release.
+      # WEB_DEPLOY_HOOK is the deploy-hook URL from the Worker's Settings > Builds.
+      - name: Trigger website redeploy
+        run: curl -fsS -X POST "${{ secrets.WEB_DEPLOY_HOOK }}"


### PR DESCRIPTION
## What

Two changes to the manual `Release` workflow (`.github/workflows/release.yml`):

1. **Publish instead of draft** — `releaseDraft: true` → `false`. The release now goes live as soon as the build/sign/notarize/upload finishes, so the in-app auto-updater picks it up without a manual "Publish" click on the GitHub draft.
2. **Trigger the website redeploy** — after `tauri-action` succeeds, `POST` a Cloudflare Workers Builds **deploy hook** so the marketing site (`fwdai/quorum-web`) rebuilds against the freshly published release.

`quorum-web` already auto-deploys on push to `main` via Cloudflare's git integration, so no GitHub Actions deploy workflow or cross-repo PAT is needed — just the deploy-hook URL. The `curl -f` exits non-zero on an HTTP error, so a bad/expired hook fails the step rather than passing silently.

## Required before this works

- [ ] Create the deploy hook in Cloudflare (the Worker → **Settings → Builds → Deploy Hooks**, branch `main`).
- [ ] `gh secret set WEB_DEPLOY_HOOK --repo fwdai/quorum --body 'https://...'`

## Note

Publishing now happens automatically, removing the manual gate to review release assets before the auto-updater serves them. Revert `releaseDraft` to `true` if that gate is wanted back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)