### PR TITLE
Dynamic provider icons from CDN with monogram fallback

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -2591,21 +2591,29 @@ button { cursor: default; }
   background: var(--fg-3); box-shadow: none;
 }
 
-.set-mono-tile {
+.chip-mono {
   flex-shrink: 0;
+  position: relative;
   display: inline-flex; align-items: center; justify-content: center;
-  border-radius: 9px;
-  background: oklch(0.42 0.08 var(--h) / .28);
-  color: oklch(0.84 0.12 var(--h));
-  box-shadow: inset 0 0 0 1px oklch(0.6 0.1 var(--h) / .4);
-  font-family: var(--font-mono); font-size: 11px; font-weight: 600;
-  letter-spacing: -0.02em;
+  border-radius: 7px;
+  font-family: var(--font-mono); font-size: 10.5px; font-weight: 600;
+  letter-spacing: .02em;
+  border: 1px solid color-mix(in oklch, var(--ph, var(--accent)) 50%, transparent);
+  background: color-mix(in oklch, oklch(.65 .13 var(--ph-h, 50)) 16%, var(--bg-2));
+  color: oklch(.82 .1 var(--ph-h, 50));
 }
-.theme-light .set-mono-tile {
-  background: oklch(0.88 0.06 var(--h) / .6);
-  color: oklch(0.44 0.15 var(--h));
-  box-shadow: inset 0 0 0 1px oklch(0.7 0.11 var(--h) / .5);
+/* Theme-aware ink for the chip — drives `currentColor` in inlined icons and
+   the monogram text, so monochrome marks are dark in light mode, light in dark. */
+.theme-light .chip-mono { color: oklch(.45 .14 var(--ph-h, 50)); }
+.chip-mono-svg {
+  display: inline-flex;
+  width: 70%; height: 70%;
+  /* Neutral, theme-aware ink for monochrome (currentColor) icons — white in
+     dark, near-black in light — so they don't pick up the chip's hue tint.
+     Full-color logos with hardcoded fills are unaffected. */
+  color: var(--fg-0);
 }
+.chip-mono-svg svg { width: 100%; height: 100%; display: block; }
 
 .set-prov-id { flex: 1; min-width: 0; }
 .set-prov-name {

--- a/src/components/ProviderIcon.tsx
+++ b/src/components/ProviderIcon.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from "react";
+import { agentIconUrl } from "../data/providers";
+
+interface ProviderIconProps {
+  /** Provider/agent slug; builds the icon URL and identifies the agent. */
+  slug: string;
+  /** Abbreviation shown in the monogram fallback (e.g. "CC"). */
+  short: string;
+  /** Hue (oklch) tinting the chip border, background, and fallback text. */
+  hue: number;
+  size?: number;
+}
+
+/** Parsed-and-sanitized SVG markup, keyed by slug, so re-opening the pane
+ *  doesn't re-fetch or flash. The webview's HTTP cache backs the network side;
+ *  this just skips the empty frame on remount. */
+const svgCache = new Map<string, string>();
+
+/** Strip executable content from a trusted-origin SVG before inlining it:
+ *  <script> elements, inline on* handlers, and <foreignObject> (which can host
+ *  arbitrary HTML). Defense-in-depth — the markup comes from our own CDN. */
+function sanitizeSvg(svg: string): string {
+  return svg
+    .replace(/<script[\s\S]*?<\/script>/gi, "")
+    .replace(/<foreignObject[\s\S]*?<\/foreignObject>/gi, "")
+    .replace(/\son\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, "");
+}
+
+/**
+ * A provider's brand icon shown inside a hue-tinted chip. The SVG is fetched
+ * from the website CDN (https://quorum.fwdai.org/agents/<slug>.svg) and
+ * inlined, so icons authored with `fill="currentColor"` inherit the chip's
+ * theme-aware color (dark in light mode, light in dark mode) while full-color
+ * logos keep their own fills. If the icon is missing or hasn't loaded —
+ * offline first run, 404, network/CORS error — the chip falls back to the
+ * abbreviation monogram. Because the URL is fixed, swapping the SVG on the CDN
+ * updates the icon for everyone without an app release.
+ */
+export function ProviderIcon({ slug, short, hue, size = 30 }: ProviderIconProps) {
+  const [svg, setSvg] = useState<string | null>(() => svgCache.get(slug) ?? null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    const cached = svgCache.get(slug);
+    if (cached) {
+      setSvg(cached);
+      setFailed(false);
+      return;
+    }
+    setSvg(null);
+    setFailed(false);
+    const ctrl = new AbortController();
+    let active = true;
+    fetch(agentIconUrl(slug), { signal: ctrl.signal })
+      .then((r) => {
+        if (!r.ok) throw new Error(String(r.status));
+        return r.text();
+      })
+      .then((text) => {
+        const clean = sanitizeSvg(text);
+        svgCache.set(slug, clean);
+        if (active) setSvg(clean);
+      })
+      .catch((e) => {
+        if (active && e.name !== "AbortError") setFailed(true);
+      });
+    return () => {
+      active = false;
+      ctrl.abort();
+    };
+  }, [slug]);
+
+  return (
+    <span
+      className="chip-mono"
+      style={{
+        width: size,
+        height: size,
+        ["--ph-h" as string]: hue,
+        ["--ph" as string]: "oklch(.65 .13 var(--ph-h))",
+      }}
+    >
+      {failed ? (
+        short
+      ) : svg ? (
+        <span className="chip-mono-svg" dangerouslySetInnerHTML={{ __html: svg }} />
+      ) : null}
+    </span>
+  );
+}

--- a/src/components/SettingsScreen/ProvidersPane.tsx
+++ b/src/components/SettingsScreen/ProvidersPane.tsx
@@ -7,6 +7,7 @@ import {
   type AvailableAgent,
 } from "../../data/providerDetail";
 import { Icon } from "../Icon";
+import { ProviderIcon } from "../ProviderIcon";
 import { SetHead, SetGroup, SetToggle } from "./primitives";
 
 export function ProvidersPane() {
@@ -59,17 +60,6 @@ export function ProvidersPane() {
   );
 }
 
-function Monogram({ short, hue, size = 30 }: { short: string; hue: number; size?: number }) {
-  return (
-    <span
-      className="set-mono-tile"
-      style={{ width: size, height: size, ["--h" as string]: hue }}
-    >
-      {short}
-    </span>
-  );
-}
-
 function ProviderRow({
   provider,
   enabled,
@@ -87,7 +77,7 @@ function ProviderRow({
     <div className={`set-prov ${enabled ? "" : "off"} ${open ? "open" : ""}`}>
       <div className="set-prov-main">
         <span className="set-prov-status" title="Authenticated" />
-        <Monogram short={provider.short} hue={provider.hue} />
+        <ProviderIcon slug={provider.id} short={provider.short} hue={provider.hue} />
         <div className="set-prov-id">
           <div className="set-prov-name">
             {provider.label}
@@ -154,7 +144,7 @@ function AvailableRow({ agent }: { agent: AvailableAgent }) {
           className={`set-prov-status ${detected ? "idle" : "none"}`}
           title={detected ? "Detected" : "Not installed"}
         />
-        <Monogram short={agent.short} hue={agent.hue} />
+        <ProviderIcon slug={agent.id} short={agent.short} hue={agent.hue} />
         <div className="set-prov-id">
           <div className="set-prov-name">
             {agent.label}

--- a/src/data/providerDetail.ts
+++ b/src/data/providerDetail.ts
@@ -44,11 +44,11 @@ export const PROVIDER_DETAIL: Record<string, ProviderDetail> = {
     earlyAccess: true,
     installed: true,
   },
-  gemini: {
+  antigravity: {
     account: "alex@joineve.ai",
-    plan: "Gemini Advanced",
-    path: "~/.gemini/bin/gemini",
-    models: "Gemini 2.5 Pro · Flash",
+    plan: "Google AI Pro",
+    path: "/Applications/Antigravity.app/…/antigravity",
+    models: "Gemini 3 Pro · Flash",
     installed: true,
   },
   opencode: {
@@ -81,23 +81,5 @@ export const AVAILABLE_AGENTS: AvailableAgent[] = [
     version: "v0.4",
     state: "detected",
     note: "Detected on PATH — not configured yet.",
-  },
-  {
-    id: "aider",
-    label: "Aider",
-    short: "AI",
-    hue: 95,
-    version: "v0.71.1",
-    state: "detected",
-    note: "Detected on PATH — not configured yet.",
-  },
-  {
-    id: "amp",
-    label: "Amp",
-    short: "AM",
-    hue: 175,
-    version: null,
-    state: "install",
-    note: "Sourcegraph's agentic coding CLI.",
   },
 ];

--- a/src/data/providers.ts
+++ b/src/data/providers.ts
@@ -12,15 +12,23 @@ export interface Provider {
 }
 
 export const PROVIDERS: Provider[] = [
-  { id: "claude",   label: "Claude Code",  short: "CC", version: "v1.0.42",     hue: 28,  sub: "Opus 4.7 · Sonnet 4.6" },
-  { id: "codex",    label: "Codex",        short: "CX", version: "v0.133.0",    hue: 145, sub: "ChatGPT Plus" },
-  { id: "cursor",   label: "Cursor Agent", short: "CR", version: "v2026.05.24", hue: 215, sub: "Pro Subscription" },
-  { id: "gemini",   label: "Gemini CLI",   short: "GM", version: "v0.18",       hue: 260, sub: "Gemini 2.5 Pro" },
-  { id: "opencode", label: "OpenCode",     short: "OC", version: "v1.15.10",    hue: 195, sub: "1 upstream connected" },
-  { id: "pi",       label: "Pi Coder",     short: "PI", version: "v0.4",        hue: 320, sub: "Pi · experimental" },
+  { id: "claude",      label: "Claude Code",  short: "CC", version: "v1.0.42",     hue: 28,  sub: "Opus 4.7 · Sonnet 4.6" },
+  { id: "codex",       label: "Codex",        short: "CX", version: "v0.133.0",    hue: 145, sub: "ChatGPT Plus" },
+  { id: "cursor",      label: "Cursor Agent", short: "CR", version: "v2026.05.24", hue: 215, sub: "Pro Subscription" },
+  { id: "antigravity", label: "Antigravity",  short: "AG", version: "v1.0",        hue: 260, sub: "Gemini 3 Pro" },
+  { id: "opencode",    label: "OpenCode",     short: "OC", version: "v1.15.10",    hue: 195, sub: "1 upstream connected" },
+  { id: "pi",          label: "Pi Coder",     short: "PI", version: "v0.4",        hue: 320, sub: "Pi · experimental" },
 ];
 
 export const DEFAULT_PROVIDER_ID = "claude";
+
+/** URL for a provider/agent's brand icon on the website CDN. Icons live at
+ *  /agents/<slug>.svg (slug === provider id), so a rebrand only needs the SVG
+ *  re-uploaded — no app release. The webview's disk cache serves it offline
+ *  after the first load; consumers fall back to the abbreviation monogram when
+ *  the image is missing or hasn't loaded yet. */
+export const agentIconUrl = (slug: string) =>
+  `https://quorum.fwdai.org/agents/${slug}.svg`;
 
 /** Human-readable name for a provider id (e.g. "claude" → "Claude Code").
  *  Falls back to the raw id when unknown so we never render an empty label. */

--- a/src/data/slashCommands.ts
+++ b/src/data/slashCommands.ts
@@ -41,7 +41,7 @@ export const PROVIDER_COMMANDS: Record<string, SlashCommand[]> = {
   ],
   codex: [],
   cursor: [],
-  gemini: [],
+  antigravity: [],
   opencode: [],
   pi: [],
 };


### PR DESCRIPTION
Replaces the abbreviation tiles (e.g. "CC"/"CX") in the Providers settings pane with brand icons fetched from the website CDN (`/agents/<slug>.svg`) and shown inside a hue-tinted chip. Icons are inlined so monochrome marks authored with `currentColor` adapt to the light/dark theme while full-color logos keep their own fills, and a fetch failure falls back to the abbreviation monogram. Because the URL is fixed, swapping an icon is a CDN re-upload with no app release (CDN must serve `Access-Control-Allow-Origin` since the SVG is fetched, not `<img>`-loaded). This PR also swaps the Gemini CLI provider for Antigravity and removes the Aider and Amp available-agent options.

Test plan: `bun run test` (35 pass) and `bun run check` pass; verified icons render and fall back to monograms for not-yet-uploaded slugs in the dev app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)