### PR TITLE
Map Codex `shell` tool to the Bash presenter

### DIFF
--- a/src/components/Workspace/messages/presenters/Bash.tsx
+++ b/src/components/Workspace/messages/presenters/Bash.tsx
@@ -2,6 +2,7 @@ import type { ToolPresenter } from "./types";
 import {
   ToolBlock,
   firstLineOf,
+  getCommandField,
   getStringField,
   renderToolResult,
 } from "./util";
@@ -9,11 +10,11 @@ import {
 export const bashPresenter: ToolPresenter = {
   icon: "terminal",
   summary: (call) => {
-    const cmd = getStringField(call.input, "command");
+    const cmd = getCommandField(call.input);
     return cmd ? firstLineOf(cmd, 140) : "(no command)";
   },
   expanded: (call, result) => {
-    const cmd = getStringField(call.input, "command");
+    const cmd = getCommandField(call.input);
     const description = getStringField(call.input, "description");
     return (
       <>

--- a/src/components/Workspace/messages/presenters/index.ts
+++ b/src/components/Workspace/messages/presenters/index.ts
@@ -17,6 +17,8 @@ export type { ToolPresenter, ToolCall, ToolResult } from "./types";
 export const PRESENTERS: Record<string, ToolPresenter> = {
   Agent: agentPresenter,
   Bash: bashPresenter,
+  // Codex names its shell tool `shell`; same UI as Claude's `Bash`.
+  shell: bashPresenter,
   Read: readPresenter,
   Edit: editPresenter,
   MultiEdit: multiEditPresenter,

--- a/src/components/Workspace/messages/presenters/util.tsx
+++ b/src/components/Workspace/messages/presenters/util.tsx
@@ -109,6 +109,18 @@ export function getStringField(input: unknown, field: string): string {
   return "";
 }
 
+/** Read a shell command from a tool input, accepting both Claude's `Bash`
+ *  shape (`command` is a string) and Codex's `shell` shape (`command` is an
+ *  argv array like ["bash", "-lc", "…"]). */
+export function getCommandField(input: unknown, field = "command"): string {
+  if (input && typeof input === "object" && field in input) {
+    const v = (input as Record<string, unknown>)[field];
+    if (typeof v === "string") return v;
+    if (Array.isArray(v)) return v.map((part) => String(part)).join(" ");
+  }
+  return "";
+}
+
 /** Truncate at the first newline, with an ellipsis if there's more. */
 export function firstLineOf(text: string, max = 120): string {
   const nl = text.indexOf("\n");


### PR DESCRIPTION
Codex names its shell tool `shell` while Claude Code uses `Bash`; this aliases `shell` to the existing Bash presenter so both render with the same terminal UI. To support Codex's argv-array command shape (`["bash","-lc","…"]`), it adds a `getCommandField` helper that reads `command` as either a string or an array, joining array parts so the summary no longer falls back to "(no command)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)