### PR TITLE
Add Codex agent support

### DIFF
--- a/src-tauri/src/activity.rs
+++ b/src-tauri/src/activity.rs
@@ -83,6 +83,48 @@ impl Activity for ClaudeManagedActivity {
     }
 }
 
+/// Custom view: codex runs as a per-turn `codex exec --json` process.
+/// `turn.completed` is its official end-of-turn signal; we trust it and
+/// fall back to silence only if it never arrives. (The per-turn process
+/// exiting is handled separately by `CodexSession`; it does not feed
+/// this detector.)
+pub struct CodexManagedActivity {
+    last_event_at: Option<Instant>,
+    explicit_turn_end: bool,
+}
+
+impl CodexManagedActivity {
+    pub fn new() -> Self {
+        Self {
+            last_event_at: None,
+            explicit_turn_end: false,
+        }
+    }
+}
+
+impl Activity for CodexManagedActivity {
+    fn observe_event(&mut self, event: &Value) {
+        self.last_event_at = Some(Instant::now());
+        if event.get("type").and_then(|v| v.as_str()) == Some("turn.completed") {
+            self.explicit_turn_end = true;
+        }
+    }
+
+    fn turn_ended(&self) -> bool {
+        if self.explicit_turn_end {
+            return true;
+        }
+        self.last_event_at
+            .map(|t| t.elapsed() >= MANAGED_SILENCE_BACKSTOP)
+            .unwrap_or(false)
+    }
+
+    fn reset_for_new_turn(&mut self) {
+        self.last_event_at = Some(Instant::now());
+        self.explicit_turn_end = false;
+    }
+}
+
 /// Native view: claude runs in a PTY rendering its full TUI. There's
 /// no clean external turn-end event, so we use the silence between
 /// PTY chunks. Claude's TUI animates its "working" state with
@@ -133,6 +175,27 @@ mod tests {
     fn managed_resets_after_new_turn() {
         let mut a = ClaudeManagedActivity::new();
         a.observe_event(&serde_json::json!({"type": "result"}));
+        assert!(a.turn_ended());
+        a.reset_for_new_turn();
+        assert!(!a.turn_ended());
+    }
+
+    #[test]
+    fn codex_ends_on_turn_completed_event() {
+        let mut a = CodexManagedActivity::new();
+        assert!(!a.turn_ended());
+        a.observe_event(&serde_json::json!({"type": "turn.started"}));
+        assert!(!a.turn_ended());
+        a.observe_event(&serde_json::json!({"type": "item.completed"}));
+        assert!(!a.turn_ended());
+        a.observe_event(&serde_json::json!({"type": "turn.completed", "usage": {}}));
+        assert!(a.turn_ended());
+    }
+
+    #[test]
+    fn codex_resets_after_new_turn() {
+        let mut a = CodexManagedActivity::new();
+        a.observe_event(&serde_json::json!({"type": "turn.completed"}));
         assert!(a.turn_ended());
         a.reset_for_new_turn();
         assert!(!a.turn_ended());

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -1,15 +1,18 @@
 //! Per-agent lifecycle.
 //!
-//! An agent is a git worktree + a sandboxed `claude` process running
-//! inside it. The process runs either in a PTY (native view — xterm
-//! shows claude's TUI; the app overlays its own input over claude's
-//! prompt) or as a stream-json subprocess (custom view — the app
-//! renders structured chat messages itself).
+//! An agent is a git worktree + a coding-agent process running inside
+//! it. There are three runner shapes:
 //!
-//! Both shapes attach to the *same* conversation via claude's
-//! `--session-id <uuid>` on first spawn and `--resume <uuid>` on
-//! subsequent spawns (view switches). Only one process is alive at a
-//! time per agent.
+//! - **Pty** (claude native view): a sandboxed `claude` process in a PTY
+//!   rendering its TUI; the app overlays its own input over the prompt.
+//! - **Managed** (claude custom view): a sandboxed, persistent
+//!   `claude --print` stream-json subprocess; the app renders structured
+//!   chat. Both claude shapes attach to the same conversation via
+//!   `--session-id <uuid>` on first spawn and `--resume <uuid>` after.
+//! - **CodexManaged** (codex custom view): codex's `exec` runs one turn
+//!   and exits, so there's no persistent process — each user message
+//!   spawns a fresh `codex exec [resume <id>]` (see `codex_session`).
+//!   Codex sandboxes itself rather than running under sandbox-exec.
 
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -17,6 +20,7 @@ use std::process::Command;
 
 use serde_json::Value;
 
+use crate::codex_session::{CodexSession, CodexSpawn};
 use crate::error::{Error, Result};
 use crate::managed_session::{ManagedExit, ManagedSession, ManagedSpawn};
 use crate::pty_session::{PtyExit, PtySession, PtySpawn};
@@ -27,6 +31,9 @@ const SANDBOX_EXEC: &str = "/usr/bin/sandbox-exec";
 pub enum Agent {
     Pty(PtyAgent),
     Managed(ManagedAgent),
+    /// Codex's per-turn `exec` runner. Holds no live process between
+    /// turns; each user message spawns a fresh `codex exec`.
+    CodexManaged(CodexManagedAgent),
 }
 
 pub struct PtyAgent {
@@ -37,6 +44,20 @@ pub struct PtyAgent {
 pub struct ManagedAgent {
     session: ManagedSession,
     _profile_file: tempfile::NamedTempFile,
+}
+
+pub struct CodexManagedAgent {
+    session: CodexSession,
+}
+
+/// Parameters for spawning a Codex runner. Unlike `SpawnSpec` there's
+/// no sandbox profile (codex sandboxes itself) and the session id is
+/// optional — codex assigns one on the first turn.
+pub struct CodexSpawnSpec {
+    /// Codex's working directory — the primary repo's worktree.
+    pub cwd: PathBuf,
+    /// Codex thread id to resume, if one has been captured already.
+    pub session_id: Option<String>,
 }
 
 pub struct SpawnSpec<'a> {
@@ -127,11 +148,53 @@ impl Agent {
         }))
     }
 
+    /// Build a Codex per-turn runner. Spawns no process yet — the first
+    /// `codex exec` is launched when the first user message arrives.
+    /// `on_turn_exit(success)` fires when a turn's process exits (and that
+    /// turn is still the current one) — the per-turn analogue of the
+    /// turn-end signal, so an interrupted or failed turn that never emits
+    /// `turn.completed` still leaves the agent promptly.
+    pub fn spawn_codex<F, G, H>(
+        spec: CodexSpawnSpec,
+        on_event: F,
+        on_session_id: G,
+        on_turn_exit: H,
+    ) -> Result<Self>
+    where
+        F: Fn(Value) + Send + Sync + 'static,
+        G: Fn(String) + Send + Sync + 'static,
+        H: Fn(bool) + Send + Sync + 'static,
+    {
+        let home = dirs::home_dir()
+            .ok_or_else(|| Error::Other("HOME directory not available".into()))?;
+        let codex = resolve_codex(&home)?;
+
+        tracing::info!(
+            codex = %codex,
+            cwd = %spec.cwd.display(),
+            resume = spec.session_id.is_some(),
+            "preparing codex runner"
+        );
+
+        let session = CodexSession::new(
+            CodexSpawn {
+                codex: PathBuf::from(codex),
+                cwd: spec.cwd,
+                session_id: spec.session_id,
+            },
+            on_event,
+            on_session_id,
+            on_turn_exit,
+        );
+
+        Ok(Self::CodexManaged(CodexManagedAgent { session }))
+    }
+
     pub fn write_pty(&self, bytes: &[u8]) -> Result<()> {
         match self {
             Self::Pty(a) => a.pty.write(bytes),
-            Self::Managed(_) => Err(Error::Other(
-                "write_pty called on managed agent".into(),
+            Self::Managed(_) | Self::CodexManaged(_) => Err(Error::Other(
+                "write_pty called on a managed agent".into(),
             )),
         }
     }
@@ -139,6 +202,7 @@ impl Agent {
     pub fn send_user_message(&self, text: &str, attachments: &[String]) -> Result<()> {
         match self {
             Self::Managed(a) => a.session.send_user_message(text, attachments),
+            Self::CodexManaged(a) => a.session.send_user_message(text, attachments),
             Self::Pty(_) => Err(Error::Other(
                 "send_user_message called on pty agent".into(),
             )),
@@ -155,13 +219,16 @@ impl Agent {
             Self::Managed(a) => {
                 a.session.interrupt();
             }
+            Self::CodexManaged(a) => {
+                a.session.interrupt();
+            }
         }
     }
 
     pub fn resize(&self, cols: u16, rows: u16) -> Result<()> {
         match self {
             Self::Pty(a) => a.pty.resize(cols, rows),
-            Self::Managed(_) => Ok(()),
+            Self::Managed(_) | Self::CodexManaged(_) => Ok(()),
         }
     }
 
@@ -270,24 +337,42 @@ fn prepare_managed_args(
 }
 
 fn resolve_claude(home: &Path) -> Result<String> {
-    if let Some(path) = command_in_path("claude") {
+    resolve_agent_bin("claude", "Claude Code", home)
+}
+
+fn resolve_codex(home: &Path) -> Result<String> {
+    resolve_agent_bin("codex", "Codex", home)
+}
+
+/// Locate an agent CLI by name: PATH first, then the user's login shell
+/// (catches nvm / fnm / volta / homebrew setups the GUI process's bare
+/// PATH misses), then the usual install dirs. `label` is the
+/// human-facing product name used only in the not-found error.
+fn resolve_agent_bin(name: &str, label: &str, home: &Path) -> Result<String> {
+    if let Some(path) = command_in_path(name) {
         return Ok(path);
     }
-
-    if let Some(path) = command_from_login_shell("claude") {
+    if let Some(path) = command_from_login_shell(name) {
         return Ok(path);
     }
-
-    for candidate in common_claude_paths(home) {
+    for candidate in common_bin_paths(name, home) {
         if candidate.is_file() {
             return Ok(candidate.to_string_lossy().into_owned());
         }
     }
+    Err(Error::Other(format!(
+        "Could not find the `{name}` executable. Install {label} or make it available on PATH."
+    )))
+}
 
-    Err(Error::Other(
-        "Could not find the `claude` executable. Install Claude Code or make it available on PATH."
-            .into(),
-    ))
+fn common_bin_paths(name: &str, home: &Path) -> Vec<PathBuf> {
+    vec![
+        home.join(format!(".local/bin/{name}")),
+        home.join(format!(".npm-global/bin/{name}")),
+        home.join(format!(".bun/bin/{name}")),
+        PathBuf::from(format!("/opt/homebrew/bin/{name}")),
+        PathBuf::from(format!("/usr/local/bin/{name}")),
+    ]
 }
 
 fn command_in_path(name: &str) -> Option<String> {
@@ -315,12 +400,3 @@ fn command_from_login_shell(name: &str) -> Option<String> {
     }
 }
 
-fn common_claude_paths(home: &Path) -> Vec<PathBuf> {
-    vec![
-        home.join(".local/bin/claude"),
-        home.join(".npm-global/bin/claude"),
-        home.join(".bun/bin/claude"),
-        PathBuf::from("/opt/homebrew/bin/claude"),
-        PathBuf::from("/usr/local/bin/claude"),
-    ]
-}

--- a/src-tauri/src/codex_session.rs
+++ b/src-tauri/src/codex_session.rs
@@ -1,0 +1,395 @@
+//! Per-turn runner for Codex "custom view" agents.
+//!
+//! Unlike Claude's persistent stream-json pipe (`managed_session.rs`),
+//! Codex's `exec` subcommand runs **one turn to completion and exits**.
+//! So each user message spawns a fresh `codex exec [resume <id>]`
+//! process; the process exiting is the *turn* boundary, not the agent
+//! dying. Turn-end is signalled in-band by codex's `turn.completed`
+//! event (see `CodexManagedActivity`), so the per-turn child exit is
+//! purely internal cleanup and never tears the agent down.
+//!
+//! Codex assigns its own session ("thread") id, emitted as
+//! `thread.started` on the first turn. We capture it, hand it to the
+//! `on_session_id` callback (the supervisor persists it), and reuse it
+//! via `codex exec resume <id>` on every later turn.
+
+use parking_lot::Mutex;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use serde_json::Value;
+
+use crate::error::{Error, Result};
+
+type EventCb = Arc<dyn Fn(Value) + Send + Sync>;
+type SessionIdCb = Arc<dyn Fn(String) + Send + Sync>;
+type ExitCb = Arc<dyn Fn(bool) + Send + Sync>;
+
+pub struct CodexSpawn {
+    /// Resolved path to the `codex` binary.
+    pub codex: PathBuf,
+    /// The agent's primary worktree — codex reads it as the workspace
+    /// root (we set it as the child's cwd rather than passing `-C`,
+    /// since `exec resume` doesn't accept `-C`).
+    pub cwd: PathBuf,
+    /// Codex thread id to resume, if we've already captured one.
+    pub session_id: Option<String>,
+}
+
+pub struct CodexSession {
+    codex: PathBuf,
+    cwd: PathBuf,
+    session_id: Arc<Mutex<Option<String>>>,
+    child: Arc<Mutex<Option<Child>>>,
+    /// Monotonic turn counter. A reap thread only reports its exit if its
+    /// turn is still the latest — so a superseded turn's late exit can't
+    /// flip the status of the turn that replaced it.
+    turn_seq: Arc<AtomicU64>,
+    on_event: EventCb,
+    on_session_id: SessionIdCb,
+    on_exit: ExitCb,
+}
+
+impl CodexSession {
+    /// Build the session. Spawns **no** process — the first child is
+    /// created when the first user message arrives.
+    pub fn new<F, G, H>(spec: CodexSpawn, on_event: F, on_session_id: G, on_exit: H) -> Self
+    where
+        F: Fn(Value) + Send + Sync + 'static,
+        G: Fn(String) + Send + Sync + 'static,
+        H: Fn(bool) + Send + Sync + 'static,
+    {
+        Self {
+            codex: spec.codex,
+            cwd: spec.cwd,
+            session_id: Arc::new(Mutex::new(spec.session_id)),
+            child: Arc::new(Mutex::new(None)),
+            turn_seq: Arc::new(AtomicU64::new(0)),
+            on_event: Arc::new(on_event),
+            on_session_id: Arc::new(on_session_id),
+            on_exit: Arc::new(on_exit),
+        }
+    }
+
+    fn build_args(&self, prompt: &str) -> Vec<String> {
+        let mut args: Vec<String> = vec!["exec".into()];
+        // Resume an existing thread once codex has handed us its id;
+        // otherwise this is the first turn and codex starts fresh.
+        if let Some(id) = self.session_id.lock().as_ref() {
+            args.push("resume".into());
+            args.push(id.clone());
+        }
+        args.push("--json".into());
+        args.push("--skip-git-repo-check".into());
+        // Approvals off + codex's own workspace-write sandbox on. Passed
+        // as `-c` config (works on both `exec` and `exec resume`, unlike
+        // the `-s`/`-a` flags which only exist on `exec`). Quorum does
+        // not wrap codex in sandbox-exec; codex sandboxes itself.
+        args.push("-c".into());
+        args.push("approval_policy=\"never\"".into());
+        args.push("-c".into());
+        args.push("sandbox_mode=\"workspace-write\"".into());
+        args.push(prompt.to_string());
+        args
+    }
+
+    pub fn send_user_message(&self, text: &str, attachments: &[String]) -> Result<()> {
+        // Claim this turn's sequence number first, so a superseded turn's
+        // reap thread sees it's no longer current and stays quiet.
+        let seq = self.turn_seq.fetch_add(1, Ordering::SeqCst) + 1;
+
+        // A new turn supersedes any still-running one (e.g. the user
+        // sent again before the prior turn finished). Kill + reap it.
+        if let Some(mut prev) = self.child.lock().take() {
+            let _ = prev.kill();
+            let _ = prev.wait();
+        }
+
+        // The typed message plus one reference line per attachment, so
+        // file paths never pollute the user's prose. Mirrors the Claude
+        // managed path; codex reads each path with its own file tools.
+        let mut prompt = text.to_string();
+        for path in attachments {
+            if !prompt.is_empty() {
+                prompt.push_str("\n\n");
+            }
+            prompt.push_str(&format!("Attached file: {path}"));
+        }
+
+        let args = self.build_args(&prompt);
+        let mut cmd = Command::new(&self.codex);
+        cmd.args(&args);
+        cmd.current_dir(&self.cwd);
+        cmd.stdin(Stdio::null());
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+
+        tracing::info!(
+            codex = %self.codex.display(),
+            cwd = %self.cwd.display(),
+            resume = self.session_id.lock().is_some(),
+            "spawning codex exec turn"
+        );
+
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| Error::Other(format!("codex spawn: {e}")))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| Error::Other("codex: child stdout missing".into()))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| Error::Other("codex: child stderr missing".into()))?;
+
+        *self.child.lock() = Some(child);
+
+        let on_event = self.on_event.clone();
+        let on_session_id = self.on_session_id.clone();
+        let session_id = self.session_id.clone();
+        thread::spawn(move || {
+            let reader = BufReader::new(stdout);
+            for line in reader.lines() {
+                match line {
+                    Ok(l) if l.trim().is_empty() => continue,
+                    Ok(l) => match serde_json::from_str::<Value>(&l) {
+                        Ok(v) => {
+                            maybe_capture_session_id(&v, &session_id, &on_session_id);
+                            on_event(v);
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, raw = %l, "codex: bad json line");
+                        }
+                    },
+                    Err(e) => {
+                        tracing::warn!(error = %e, "codex: stdout read error");
+                        break;
+                    }
+                }
+            }
+            tracing::debug!("codex: turn stdout closed");
+        });
+
+        thread::spawn(move || {
+            let reader = BufReader::new(stderr);
+            for line in reader.lines().map_while(std::result::Result::ok) {
+                tracing::warn!(stderr = %line, "codex: stderr");
+            }
+        });
+
+        // Reap the per-turn child when it exits so it doesn't linger as a
+        // zombie, and report the exit so the supervisor can end the turn.
+        // This is the per-turn analogue of a turn-end signal: a turn that
+        // exits without emitting `turn.completed` (interrupt, crash, error)
+        // still leaves the agent promptly instead of waiting for the
+        // silence backstop. The agent itself stays alive across turns.
+        let child_for_wait = self.child.clone();
+        let turn_seq = self.turn_seq.clone();
+        let on_exit = self.on_exit.clone();
+        thread::spawn(move || loop {
+            let exited = {
+                let mut guard = child_for_wait.lock();
+                let Some(c) = guard.as_mut() else {
+                    // Slot emptied by a newer turn (kill+take) — that turn
+                    // owns the lifecycle now; stay quiet.
+                    return;
+                };
+                match c.try_wait() {
+                    Ok(Some(status)) => {
+                        let _ = guard.take();
+                        tracing::debug!(status = %status, "codex: turn exited");
+                        Some(status.success())
+                    }
+                    Ok(None) => None,
+                    Err(e) => {
+                        let _ = guard.take();
+                        tracing::warn!(error = %e, "codex: wait failed");
+                        Some(false)
+                    }
+                }
+            };
+            if let Some(success) = exited {
+                // Only the current turn reports — a superseded turn's exit
+                // must not flip the status of the turn that replaced it.
+                if turn_seq.load(Ordering::SeqCst) == seq {
+                    on_exit(success);
+                }
+                return;
+            }
+            thread::sleep(Duration::from_millis(50));
+        });
+
+        Ok(())
+    }
+
+    /// Interrupt the in-flight turn (SIGINT). Codex exits the current
+    /// `exec` process; the agent stays alive for the next message.
+    pub fn interrupt(&self) {
+        #[cfg(unix)]
+        {
+            use nix::sys::signal::{kill, Signal};
+            use nix::unistd::Pid;
+            if let Some(child) = self.child.lock().as_ref() {
+                let _ = kill(Pid::from_raw(child.id() as i32), Signal::SIGINT);
+            }
+        }
+    }
+
+    pub fn kill(&self) -> Result<()> {
+        if let Some(mut child) = self.child.lock().take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        Ok(())
+    }
+}
+
+/// On the first turn codex emits `{"type":"thread.started","thread_id":…}`.
+/// Capture the id once for resume, and notify the caller so it can be
+/// persisted to the agent record.
+fn maybe_capture_session_id(
+    event: &Value,
+    session_id: &Arc<Mutex<Option<String>>>,
+    on_session_id: &SessionIdCb,
+) {
+    if event.get("type").and_then(|t| t.as_str()) != Some("thread.started") {
+        return;
+    }
+    let Some(tid) = event.get("thread_id").and_then(|t| t.as_str()) else {
+        return;
+    };
+    let mut guard = session_id.lock();
+    if guard.as_deref() == Some(tid) {
+        return;
+    }
+    *guard = Some(tid.to_string());
+    drop(guard);
+    on_session_id(tid.to_string());
+}
+
+impl Drop for CodexSession {
+    fn drop(&mut self) {
+        let _ = self.kill();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+    use std::sync::mpsc;
+    use std::time::{Duration, Instant};
+
+    /// Write an executable shell script that ignores its args and prints
+    /// canned JSONL — a stand-in for `codex exec` so we can exercise the
+    /// per-turn spawn + event plumbing without the real binary or API.
+    fn fake_codex(dir: &std::path::Path, body: &str) -> PathBuf {
+        let script = dir.join("fakecodex.sh");
+        std::fs::write(&script, format!("#!/bin/sh\ncat <<'EOF'\n{body}\nEOF\n")).unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        script
+    }
+
+    #[test]
+    fn spawns_a_turn_forwards_events_and_captures_session_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = fake_codex(
+            dir.path(),
+            r#"{"type":"thread.started","thread_id":"abc-123"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"hi"}}
+{"type":"turn.completed","usage":{}}"#,
+        );
+
+        let (etx, erx) = mpsc::channel();
+        let (stx, srx) = mpsc::channel();
+        let (xtx, xrx) = mpsc::channel();
+        let session = CodexSession::new(
+            CodexSpawn {
+                codex: script,
+                cwd: dir.path().to_path_buf(),
+                session_id: None,
+            },
+            move |ev| {
+                let _ = etx.send(ev);
+            },
+            move |sid| {
+                let _ = stx.send(sid);
+            },
+            move |success| {
+                let _ = xtx.send(success);
+            },
+        );
+
+        session.send_user_message("hello", &[]).unwrap();
+
+        let mut events = Vec::new();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if let Ok(ev) = erx.recv_timeout(Duration::from_millis(100)) {
+                let done = ev.get("type").and_then(|t| t.as_str()) == Some("turn.completed");
+                events.push(ev);
+                if done {
+                    break;
+                }
+            }
+        }
+
+        // The thread id was reported to the callback and stored internally
+        // so the next turn resumes it.
+        assert_eq!(srx.recv_timeout(Duration::from_secs(1)).unwrap(), "abc-123");
+        assert_eq!(session.session_id.lock().as_deref(), Some("abc-123"));
+
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].get("type").unwrap(), "thread.started");
+        assert_eq!(events[2].get("type").unwrap(), "turn.completed");
+
+        // The per-turn process exit is reported so the supervisor can end
+        // the turn even if `turn.completed` were absent.
+        assert_eq!(xrx.recv_timeout(Duration::from_secs(2)).unwrap(), true);
+    }
+
+    #[test]
+    fn resume_turn_passes_the_session_id_as_an_arg() {
+        let dir = tempfile::tempdir().unwrap();
+        // This fake records its own argv to a file (avoiding JSON-escaping
+        // the quoted `-c` args) and emits one valid event so the turn
+        // completes. CodexSession runs it with cwd = dir, so argv.txt
+        // lands there.
+        let script = dir.path().join("argecho.sh");
+        std::fs::write(
+            &script,
+            "#!/bin/sh\nprintf '%s' \"$*\" > argv.txt\necho '{\"type\":\"turn.completed\"}'\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let (etx, erx) = mpsc::channel();
+        let session = CodexSession::new(
+            CodexSpawn {
+                codex: script,
+                cwd: dir.path().to_path_buf(),
+                session_id: Some("prev-thread".into()),
+            },
+            move |ev| {
+                let _ = etx.send(ev);
+            },
+            |_sid| {},
+            |_success| {},
+        );
+
+        session.send_user_message("again", &[]).unwrap();
+
+        // Wait for the turn to finish so argv.txt is fully written.
+        erx.recv_timeout(Duration::from_secs(5)).unwrap();
+        let args = std::fs::read_to_string(dir.path().join("argv.txt")).unwrap();
+        assert!(args.contains("exec resume prev-thread"), "argv was: {args}");
+        assert!(args.contains("--json"));
+        assert!(args.contains("sandbox_mode=\"workspace-write\""), "argv was: {args}");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod activity;
 mod agent;
 mod branding;
+mod codex_session;
 mod commands;
 mod database;
 mod error;

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -3,13 +3,13 @@
 use parking_lot::Mutex;
 use serde_json::Value;
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 use tauri::{AppHandle, Emitter};
 
-use crate::activity::{Activity, ClaudeManagedActivity, ClaudeNativeActivity};
-use crate::agent::{Agent, SpawnSpec};
+use crate::activity::{Activity, ClaudeManagedActivity, ClaudeNativeActivity, CodexManagedActivity};
+use crate::agent::{Agent, CodexSpawnSpec, SpawnSpec};
 use crate::branding;
 use crate::error::{Error, Result};
 use crate::git;
@@ -339,6 +339,16 @@ impl Supervisor {
             )));
         }
 
+        // Codex only renders in the structured (Custom) view for now: its
+        // per-turn `exec` runtime emits stream-json events, not the PTY
+        // bytes the native view expects. The native codex TUI view is a
+        // follow-up.
+        let view = if provider == "codex" {
+            AgentView::Custom
+        } else {
+            view
+        };
+
         let agent_id = self.workspace.allocate_agent_id()?;
         let name = agent_id.clone();
 
@@ -463,16 +473,19 @@ impl Supervisor {
         fresh: bool,
     ) -> Result<()> {
         let record = self.workspace.agent(agent_id)?;
-        let session_id = record
-            .session_id
-            .clone()
-            .ok_or_else(|| Error::Other("agent record missing session_id".into()))?;
+        let is_codex = record.provider == "codex";
+        // Claude carries a session id we generated at create time; Codex
+        // is assigned one by the CLI on its first turn, so it may be None
+        // until then.
+        let session_id = record.session_id.clone();
+        if !is_codex && session_id.is_none() {
+            return Err(Error::Other("agent record missing session_id".into()));
+        }
         let primary = record
             .repos
             .first()
             .ok_or_else(|| Error::Other("agent has no tracked repos".into()))?;
         let cwd = repo_worktree_path(agent_id, &primary.subdir)?;
-        let sandbox_root = agent_parent_dir(agent_id)?;
 
         // Claude only writes a session file once the first turn lands.
         // If task is still empty (no first user message has ever been
@@ -493,40 +506,63 @@ impl Supervisor {
             *entry
         };
 
-        let mut activity: Box<dyn Activity> = match record.view {
-            AgentView::Native => Box::new(ClaudeNativeActivity::new()),
-            AgentView::Custom => Box::new(ClaudeManagedActivity::new()),
+        let mut activity: Box<dyn Activity> = if is_codex {
+            Box::new(CodexManagedActivity::new())
+        } else {
+            match record.view {
+                AgentView::Native => Box::new(ClaudeNativeActivity::new()),
+                AgentView::Custom => Box::new(ClaudeManagedActivity::new()),
+            }
         };
         if effective_fresh {
             activity.reset_for_new_turn();
         }
         self.activities.lock().insert(agent_id_str.clone(), activity);
 
-        let spec = SpawnSpec {
-            agent_id: &agent_id_str,
-            cwd,
-            sandbox_root,
-            session_id: &session_id,
-            fresh: effective_fresh,
-            cols: 120,
-            rows: 32,
-        };
-
-        let agent = match record.view {
-            AgentView::Native => spawn_pty_agent(
-                spec,
+        let agent = if is_codex {
+            // Codex is a per-turn `exec` runner — no process spawns until
+            // the first user message. It's always rendered in the
+            // structured (Custom) view; the native PTY view isn't wired
+            // for codex yet. No sandbox profile: codex sandboxes itself
+            // rather than running under sandbox-exec.
+            spawn_codex_agent(
+                cwd,
+                session_id.clone(),
                 app.clone(),
                 agent_id_str.clone(),
                 self.clone(),
                 my_gen,
-            )?,
-            AgentView::Custom => spawn_managed_agent(
-                spec,
-                app.clone(),
-                agent_id_str.clone(),
-                self.clone(),
-                my_gen,
-            )?,
+            )?
+        } else {
+            let session_id = session_id
+                .as_deref()
+                .expect("non-codex agents always have a session id");
+            let sandbox_root = agent_parent_dir(agent_id)?;
+            let spec = SpawnSpec {
+                agent_id: &agent_id_str,
+                cwd,
+                sandbox_root,
+                session_id,
+                fresh: effective_fresh,
+                cols: 120,
+                rows: 32,
+            };
+            match record.view {
+                AgentView::Native => spawn_pty_agent(
+                    spec,
+                    app.clone(),
+                    agent_id_str.clone(),
+                    self.clone(),
+                    my_gen,
+                )?,
+                AgentView::Custom => spawn_managed_agent(
+                    spec,
+                    app.clone(),
+                    agent_id_str.clone(),
+                    self.clone(),
+                    my_gen,
+                )?,
+            }
         };
 
         self.agents.lock().insert(agent_id_str.clone(), agent);
@@ -559,7 +595,11 @@ impl Supervisor {
             if !matches!(record.status, AgentStatus::Spawning) {
                 continue;
             }
-            if record.session_id.is_none() || record.repos.is_empty() {
+            // Codex agents legitimately have no session id until their
+            // first turn assigns one, so only treat a missing id as
+            // corruption for providers that generate it up front (claude).
+            let missing_session = record.provider != "codex" && record.session_id.is_none();
+            if missing_session || record.repos.is_empty() {
                 let err = "Agent record incomplete (no session id / no repos). Remove and respawn.".to_string();
                 let _ = self.workspace.update_agent_status(
                     &record.id,
@@ -591,7 +631,9 @@ impl Supervisor {
         if self.agents.lock().contains_key(agent_id) {
             return Ok(());
         }
-        if record.session_id.is_none() {
+        // Codex is assigned a session id on its first turn, so a missing
+        // one is only an error for providers that generate it up front.
+        if record.provider != "codex" && record.session_id.is_none() {
             return Err(Error::Other(
                 "Agent has no session id; remove and respawn.".into(),
             ));
@@ -662,6 +704,12 @@ impl Supervisor {
         if record.view == new_view {
             return Ok(());
         }
+        // Codex has no native PTY view yet — keep it on the structured one.
+        if record.provider == "codex" && new_view == AgentView::Native {
+            return Err(Error::Other(
+                "Codex agents only support the structured view".into(),
+            ));
+        }
 
         if let Some(agent) = self.agents.lock().remove(agent_id) {
             let _ = agent.shutdown();
@@ -698,11 +746,11 @@ impl Supervisor {
     }
 
     pub async fn stop_agent(self: Arc<Self>, app: AppHandle, agent_id: &str) -> Result<()> {
-        // Interrupt the current turn without exiting the process.
-        // The natural result-event + turn-watchdog path will transition
-        // the agent to Idle once the interrupt is processed. If the
-        // process does exit (e.g. it doesn't survive SIGINT), the exit
-        // handler in apply_exit_if_current will also move it to Idle.
+        // Interrupt the current turn. How it returns to Idle depends on
+        // the runner: claude (managed) emits a `result` event and, if it
+        // exits, `apply_exit_if_current` moves it to Idle; codex's
+        // per-turn `exec` exits on SIGINT and its `on_turn_exit` handler
+        // ends the turn (it emits no `turn.completed` when interrupted).
         let _ = app;
         let agents = self.agents.lock();
         if let Some(agent) = agents.get(agent_id) {
@@ -932,37 +980,37 @@ impl Supervisor {
         Ok(())
     }
 
-    /// Read the persisted claude session JSONL for an archived (or
-    /// live) agent and return the events as a Vec<Value>. The frontend
-    /// feeds these through the same event handler it uses for live
-    /// stream-json output, so we don't need a parallel renderer.
+    /// Read the persisted session JSONL for an archived (or live) agent
+    /// and return its raw lines as a Vec<Value>. The frontend's
+    /// per-provider adapter normalizes these into renderable events, so
+    /// we don't need a parallel renderer here. Claude's file lives under
+    /// `~/.claude/projects`; codex's rollout under `$CODEX_HOME/sessions`.
     ///
-    /// Returns an empty vec if the JSONL is missing (claude pruned it,
-    /// user deleted it, session never reached the first turn).
+    /// Returns an empty vec if the file is missing (pruned, deleted, or
+    /// the session never reached its first turn).
     pub fn read_session_transcript(&self, agent_id: &str) -> Result<Vec<Value>> {
         let record = self.workspace.agent(agent_id)?;
-        let session_id = record
-            .session_id
-            .as_deref()
-            .ok_or_else(|| Error::Other("agent has no session id".into()))?;
-        let path = match find_session_jsonl(session_id) {
-            Some(p) => p,
-            None => return Ok(Vec::new()),
+        let session_id = match record.session_id.as_deref() {
+            Some(s) => s,
+            // Codex's id is only assigned on the first turn; before that
+            // there's nothing to replay.
+            None if record.provider == "codex" => return Ok(Vec::new()),
+            None => return Err(Error::Other("agent has no session id".into())),
         };
-        let file = std::fs::File::open(&path)
-            .map_err(|e| Error::Other(format!("open transcript: {e}")))?;
-        let reader = std::io::BufReader::new(file);
-        let mut out = Vec::new();
-        use std::io::BufRead;
-        for line in reader.lines().map_while(std::result::Result::ok) {
-            if line.trim().is_empty() {
-                continue;
-            }
-            if let Ok(v) = serde_json::from_str::<Value>(&line) {
-                out.push(v);
-            }
+
+        // Each provider persists its conversation in a different place and
+        // format. The frontend's per-provider adapter (`normalizeTranscript`)
+        // translates these raw lines into renderable events, so here we just
+        // locate the file and hand back its JSONL.
+        let path = if record.provider == "codex" {
+            find_codex_rollout(session_id)
+        } else {
+            find_session_jsonl(session_id)
+        };
+        match path {
+            Some(p) => read_jsonl_values(&p),
+            None => Ok(Vec::new()),
         }
-        Ok(out)
     }
 
     /// Fetch the current PR state for an agent's primary repo and emit
@@ -1060,6 +1108,66 @@ fn find_session_jsonl(session_id: &str) -> Option<PathBuf> {
     None
 }
 
+/// Locate codex's rollout file for a thread id. Codex stores sessions at
+/// `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<id>.jsonl` (CODEX_HOME
+/// defaults to `~/.codex`); the id suffix is the thread id we captured.
+fn find_codex_rollout(session_id: &str) -> Option<PathBuf> {
+    let home = std::env::var_os("CODEX_HOME")
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|h| h.join(".codex")))?;
+    // Anchor on the `-<id>.jsonl` boundary (filenames are
+    // `rollout-<ts>-<id>.jsonl`) so one thread id can't match another whose
+    // name merely ends with the same characters.
+    let suffix = format!("-{session_id}.jsonl");
+    // Walk the YYYY/MM/DD tree (three dir levels) and match the suffix.
+    fn dirs_in(p: &Path) -> Vec<PathBuf> {
+        std::fs::read_dir(p)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| p.is_dir())
+            .collect()
+    }
+    let sessions = home.join("sessions");
+    for year in dirs_in(&sessions) {
+        for month in dirs_in(&year) {
+            for day in dirs_in(&month) {
+                for entry in std::fs::read_dir(&day).into_iter().flatten().flatten() {
+                    let path = entry.path();
+                    if path
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .is_some_and(|n| n.ends_with(&suffix))
+                    {
+                        return Some(path);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Read a JSONL file into a vec of parsed values, skipping blank or
+/// unparseable lines.
+fn read_jsonl_values(path: &Path) -> Result<Vec<Value>> {
+    use std::io::BufRead;
+    let file = std::fs::File::open(path)
+        .map_err(|e| Error::Other(format!("open transcript: {e}")))?;
+    let reader = std::io::BufReader::new(file);
+    let mut out = Vec::new();
+    for line in reader.lines().map_while(std::result::Result::ok) {
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<Value>(&line) {
+            out.push(v);
+        }
+    }
+    Ok(out)
+}
+
 fn spawn_pty_agent(
     spec: SpawnSpec<'_>,
     app: AppHandle,
@@ -1136,6 +1244,75 @@ fn spawn_managed_agent(
         },
         move |exit| {
             apply_exit_if_current(&sup_for_exit, &app_for_exit, &id_for_exit, gen, exit.success, exit.message);
+        },
+    )
+}
+
+/// Build a Codex agent. A codex `exec` process exits at the end of
+/// *every* turn — that's normal, not the agent dying — so unlike the
+/// pty/managed spawners we don't wire `apply_exit_if_current` (which
+/// would remove the agent from the map). Instead the per-turn exit is
+/// reported via `on_turn_exit`, which ends the turn (Idle) without
+/// tearing the agent down. This covers turns that exit without a
+/// `turn.completed` event (interrupt, crash) so the agent doesn't sit
+/// Running until the silence backstop. The session-id callback persists
+/// the thread id codex assigns on the first turn so later turns (and
+/// re-attach after restart) resume it.
+fn spawn_codex_agent(
+    cwd: PathBuf,
+    session_id: Option<String>,
+    app: AppHandle,
+    agent_id: String,
+    sup: Arc<Supervisor>,
+    gen: u64,
+) -> Result<Agent> {
+    let app_for_event = app.clone();
+    let id_for_event = agent_id.clone();
+    let sup_for_event = sup.clone();
+    let id_for_sid = agent_id.clone();
+    let sup_for_sid = sup.clone();
+    let app_for_exit = app;
+    let id_for_exit = agent_id;
+    let sup_for_exit = sup;
+    Agent::spawn_codex(
+        CodexSpawnSpec { cwd, session_id },
+        move |event| {
+            if let Some(activity) = sup_for_event.activities.lock().get_mut(&id_for_event) {
+                activity.observe_event(&event);
+            }
+            if let Err(e) = app_for_event.emit(
+                "agent:event",
+                AgentEventPayload {
+                    agent_id: id_for_event.clone(),
+                    event,
+                },
+            ) {
+                tracing::warn!(error = %e, agent_id = %id_for_event, "emit agent:event failed");
+            }
+        },
+        move |sid| {
+            if let Err(e) = sup_for_sid.workspace.set_agent_session_id(&id_for_sid, &sid) {
+                tracing::warn!(error = %e, agent_id = %id_for_sid, "persist codex session id failed");
+            }
+        },
+        move |_success| {
+            // The turn's process exited. Ignore if a respawn/teardown has
+            // since bumped the generation (e.g. the session was dropped).
+            let current = sup_for_exit
+                .generations
+                .lock()
+                .get(&id_for_exit)
+                .copied()
+                .unwrap_or(0);
+            if current != gen {
+                return;
+            }
+            // End the turn. Idempotent with the `turn.completed` watchdog
+            // path; the win is the interrupt/crash case where no such
+            // event arrives. We don't surface non-success as Error: a
+            // user-initiated Stop (SIGINT) is also non-success, and real
+            // codex errors are reported in-band as events.
+            transition_active(&sup_for_exit, &app_for_exit, &id_for_exit, AgentStatus::Idle);
         },
     )
 }

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -443,6 +443,19 @@ impl WorkspaceManager {
         Ok(())
     }
 
+    /// Persist the agent's session id. Used for Codex, whose thread id
+    /// is assigned by the CLI and captured from its first turn's events
+    /// (Claude's id is generated up front, so it never changes here).
+    pub fn set_agent_session_id(&self, id: &str, session_id: &str) -> Result<()> {
+        let conn = self.db.lock();
+        Self::ensure_agent_exists(&conn, id)?;
+        conn.execute(
+            "UPDATE agents SET session_id = ?1 WHERE id = ?2",
+            rusqlite::params![session_id, id],
+        )?;
+        Ok(())
+    }
+
     pub fn update_agent_view(&self, id: &str, view: AgentView) -> Result<()> {
         let conn = self.db.lock();
         Self::ensure_agent_exists(&conn, id)?;
@@ -930,6 +943,14 @@ pub fn new_agent_record(
     task: String,
     view: AgentView,
 ) -> AgentRecord {
+    // Claude attaches to a session id we generate up front (passed as
+    // `--session-id`). Codex assigns its own thread id on the first turn
+    // (captured from `thread.started`), so it starts with none.
+    let session_id = if provider == "codex" {
+        None
+    } else {
+        Some(uuid::Uuid::new_v4().to_string())
+    };
     AgentRecord {
         id,
         // Populated by WorkspaceManager::add_agent (looked up from the
@@ -941,7 +962,7 @@ pub fn new_agent_record(
         task,
         status: AgentStatus::Spawning,
         view,
-        session_id: Some(uuid::Uuid::new_v4().to_string()),
+        session_id,
         created_at: Utc::now().to_rfc3339(),
         last_error: None,
         archive: None,

--- a/src/adapters/codex/fixtures/rollout.jsonl
+++ b/src/adapters/codex/fixtures/rollout.jsonl
@@ -1,0 +1,12 @@
+{"type":"session_meta","payload":{"id":"019e8cc9","cwd":"/tmp/codex-spike","cli_version":"0.135.0"}}
+{"type":"turn_context","payload":{"cwd":"/tmp/codex-spike"}}
+{"type":"event_msg","payload":{"type":"task_started","turn_id":"t1"}}
+{"type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"<permissions instructions noise>"}]}}
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"# AGENTS.md noise"}]}}
+{"type":"event_msg","payload":{"type":"user_message","message":"run echo hello","images":[]}}
+{"type":"response_item","payload":{"type":"reasoning","summary":[],"encrypted_content":"gAAAA"}}
+{"type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"echo hello\",\"workdir\":\"/tmp\"}","call_id":"call_1"}}
+{"type":"response_item","payload":{"type":"function_call_output","call_id":"call_1","output":"Process exited with code 0\nOutput:\nhello\n"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10}}}}
+{"type":"event_msg","payload":{"type":"agent_message","message":"It printed hello."}}
+{"type":"event_msg","payload":{"type":"task_complete","turn_id":"t1","last_agent_message":"It printed hello."}}

--- a/src/adapters/codex/fixtures/sample.jsonl
+++ b/src/adapters/codex/fixtures/sample.jsonl
@@ -1,9 +1,6 @@
-{"type":"user","content":"add a button"}
-{"type":"response.output_text.delta","delta":"Add"}
-{"type":"response.output_text.delta","delta":"ing it now."}
-{"type":"response.function_call.started","call_id":"fc_1","name":"edit","arguments":""}
-{"type":"response.function_call_arguments.delta","output_index":0,"delta":"{\"file\""}
-{"type":"response.function_call_arguments.delta","output_index":0,"delta":":\"App.tsx\"}"}
-{"type":"function_call","call_id":"fc_1","name":"edit","arguments":{"file":"App.tsx"}}
-{"type":"function_call_output","call_id":"fc_1","output":{"content":"ok","is_error":false}}
-{"type":"response.completed"}
+{"type":"thread.started","thread_id":"019e8cc9-89c0-7850-9738-2e1919708482"}
+{"type":"turn.started"}
+{"type":"item.started","item":{"id":"item_0","type":"command_execution","command":"/bin/zsh -lc 'echo hello'","aggregated_output":"","exit_code":null,"status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_0","type":"command_execution","command":"/bin/zsh -lc 'echo hello'","aggregated_output":"hello\n","exit_code":0,"status":"completed"}}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"It printed `hello`."}}
+{"type":"turn.completed","usage":{"input_tokens":61043,"cached_input_tokens":39936,"output_tokens":179,"reasoning_output_tokens":69}}

--- a/src/adapters/codex/index.ts
+++ b/src/adapters/codex/index.ts
@@ -3,10 +3,9 @@ import { reduce } from "./reduce";
 import { normalizeTranscript } from "./normalize";
 import { codexPolicy } from "./policy";
 
-// TODO(codex-real-impl): see ./reduce.ts and ./normalize.ts. The shape
-// of this adapter is real; the body is best-effort against public
-// Responses-API docs and needs verification once codex's Rust transport
-// is wired and we can observe its actual stdout shape.
+// Reduces Codex's `codex exec --json` thread/turn/item event stream
+// (verified against codex-cli 0.135.0 — see ./reduce.ts). Transcript
+// replay on re-attach is a follow-up (see ./normalize.ts).
 export const codexAdapter: ChatAdapter = {
   id: "codex",
   reduce,

--- a/src/adapters/codex/normalize.ts
+++ b/src/adapters/codex/normalize.ts
@@ -1,25 +1,133 @@
-// TODO(codex-real-impl): codex transcript format isn't yet verified.
-// This normalizer assumes JSONL records carrying the same `type` strings
-// the reducer recognizes — pass them through unchanged. Real transcripts
-// may need translation when the codex CLI's on-disk format is known.
+// Translates Codex's on-disk rollout file into the live-event shapes the
+// reducer understands, so re-attaching to an agent replays its history.
+//
+// The rollout (`$CODEX_HOME/sessions/.../rollout-*-<id>.jsonl`) is a
+// different, dual-channel schema from the live `exec --json` stream:
+//   { "type":"session_meta" | "turn_context", … }                  // metadata
+//   { "type":"event_msg",     "payload":{ "type":"user_message" | "agent_message" | "task_complete" | … } }
+//   { "type":"response_item", "payload":{ "type":"message" | "function_call" | "function_call_output" | "reasoning" | … } }
+//
+// We take the conversational backbone (user/agent text, turn end) from the
+// clean `event_msg` channel, and tool activity from `response_item`
+// function calls (which cover both shell `exec_command` and MCP calls).
+// `response_item` user/assistant messages are skipped — they duplicate the
+// event_msg ones and carry injected noise (AGENTS.md, permissions blurb).
 
 import type { RawEvent } from "../types";
 import { asRecord } from "../shared/json";
 
-const PASS_THROUGH = new Set([
-  "user",
-  "message",
-  "function_call",
-  "function_call_output",
-  "result",
-]);
+function parseArgs(v: unknown): unknown {
+  if (typeof v === "string") {
+    try {
+      return JSON.parse(v);
+    } catch {
+      return v;
+    }
+  }
+  return v ?? {};
+}
 
 export function normalizeTranscript(lines: unknown[]): RawEvent[] {
+  // Pre-pass: a tool call's output lands on a later `function_call_output`
+  // line, so index outputs by call_id first.
+  const outputs = new Map<string, string>();
+  for (const raw of lines) {
+    const env = asRecord(raw);
+    if (env.type !== "response_item") continue;
+    const p = asRecord(env.payload);
+    if (p.type === "function_call_output") {
+      const id = String(p.call_id ?? "");
+      if (id) {
+        outputs.set(
+          id,
+          typeof p.output === "string" ? p.output : JSON.stringify(p.output ?? ""),
+        );
+      }
+    }
+  }
+
   const out: RawEvent[] = [];
   for (const raw of lines) {
-    const rec = asRecord(raw);
-    const type = typeof rec.type === "string" ? rec.type : undefined;
-    if (type && PASS_THROUGH.has(type)) out.push(rec as RawEvent);
+    const env = asRecord(raw);
+    const p = asRecord(env.payload);
+    const ptype = typeof p.type === "string" ? p.type : "";
+
+    if (env.type === "event_msg") {
+      if (ptype === "user_message") {
+        const text = typeof p.message === "string" ? p.message : "";
+        if (text) out.push({ type: "user", text });
+      } else if (ptype === "agent_message") {
+        const text = typeof p.message === "string" ? p.message : "";
+        if (text) {
+          out.push({
+            type: "item.completed",
+            item: { id: `msg_${out.length}`, type: "agent_message", text },
+          });
+        }
+      } else if (ptype === "task_complete") {
+        out.push({ type: "turn.completed" });
+      }
+      continue;
+    }
+
+    if (env.type === "response_item" && ptype === "function_call") {
+      const id = String(p.call_id ?? "");
+      if (!id) continue;
+      const name = typeof p.name === "string" ? p.name : "";
+      const namespace = typeof p.namespace === "string" ? p.namespace : "";
+      const args = parseArgs(p.arguments);
+      const output = outputs.get(id) ?? "";
+
+      const argRec = asRecord(args);
+      if (namespace) {
+        // MCP tool call (namespace e.g. "mcp__server_name").
+        out.push({
+          type: "item.completed",
+          item: {
+            id,
+            type: "mcp_tool_call",
+            server: namespace.replace(/^mcp__/, ""),
+            tool: name,
+            arguments: args,
+            result: output,
+            status: "completed",
+          },
+        });
+      } else if (name === "exec_command" || typeof argRec.cmd === "string") {
+        // Shell / exec command. Parse the real exit code out of codex's
+        // wrapped output so a failed command isn't replayed as a success.
+        const m = output.match(/exited with code (\d+)/);
+        const code = m ? Number(m[1]) : undefined;
+        const command = typeof argRec.cmd === "string" ? argRec.cmd : name;
+        out.push({
+          type: "item.completed",
+          item: {
+            id,
+            type: "command_execution",
+            command,
+            aggregated_output: output,
+            exit_code: code,
+            status: code !== undefined && code !== 0 ? "failed" : "completed",
+          },
+        });
+      } else {
+        // Other built-in tool (apply_patch, update_plan, …): render as a
+        // named tool call preserving its arguments rather than mislabeling
+        // it as a shell command and dropping the args.
+        out.push({
+          type: "item.completed",
+          item: {
+            id,
+            type: "mcp_tool_call",
+            server: "",
+            tool: name,
+            arguments: args,
+            result: output,
+            status: "completed",
+          },
+        });
+      }
+    }
   }
   return out;
 }

--- a/src/adapters/codex/reduce.test.ts
+++ b/src/adapters/codex/reduce.test.ts
@@ -6,9 +6,8 @@ import { fileURLToPath } from "node:url";
 import { codexAdapter } from "./index";
 import type { ChatItem, RawEvent } from "../types";
 
-// NOTE: these tests assert against the *skeleton* adapter's current
-// best-effort parsing. They will need to be updated when the real codex
-// event shapes are verified — see TODO(codex-real-impl) in ./reduce.ts.
+// Fixtures are real `codex exec --json` output captured from
+// codex-cli 0.135.0 (thread / turn / item event model).
 
 const here = fileURLToPath(new URL(".", import.meta.url));
 
@@ -19,37 +18,171 @@ function readJsonl(name: string): unknown[] {
     .map((l) => JSON.parse(l));
 }
 
-describe("codexAdapter — skeleton", () => {
-  it("reduces the sample fixture to a sensible ChatItem list", () => {
-    const events = readJsonl("sample.jsonl") as RawEvent[];
-    const items = events.reduce<ChatItem[]>(
-      (acc, ev) => codexAdapter.reduce(acc, ev),
-      [],
-    );
+function run(events: RawEvent[]): ChatItem[] {
+  return events.reduce<ChatItem[]>((acc, ev) => codexAdapter.reduce(acc, ev), []);
+}
+
+describe("codexAdapter", () => {
+  it("reduces a real command + message turn", () => {
+    const items = run(readJsonl("sample.jsonl") as RawEvent[]);
     expect(items).toEqual([
-      { kind: "user_message", text: "add a button" },
-      { kind: "agent_message", text: "Adding it now.", streaming: false },
       {
         kind: "tool_call",
-        id: "fc_1",
-        name: "edit",
-        input: { file: "App.tsx" },
+        id: "item_0",
+        name: "shell",
+        input: "/bin/zsh -lc 'echo hello'",
         streaming: false,
       },
       {
         kind: "tool_result",
-        tool_use_id: "fc_1",
-        content: "ok",
+        tool_use_id: "item_0",
+        content: "hello\n",
         is_error: false,
       },
+      { kind: "agent_message", text: "It printed `hello`." },
       { kind: "notice", subtype: "turn_end", text: "success" },
     ]);
   });
 
+  it("marks a tool_call streaming until its item.completed", () => {
+    const started = codexAdapter.reduce([], {
+      type: "item.started",
+      item: { id: "x", type: "command_execution", command: "ls", status: "in_progress" },
+    } as RawEvent);
+    expect(started).toEqual([
+      { kind: "tool_call", id: "x", name: "shell", input: "ls", streaming: true },
+    ]);
+  });
+
+  it("renders an mcp_tool_call and flags failures", () => {
+    const items = run([
+      {
+        type: "item.completed",
+        item: {
+          id: "item_0",
+          type: "mcp_tool_call",
+          server: "tasks",
+          tool: "check_active",
+          arguments: {},
+          result: null,
+          error: { message: "denied" },
+          status: "failed",
+        },
+      },
+    ] as RawEvent[]);
+    expect(items).toEqual([
+      { kind: "tool_call", id: "item_0", name: "tasks.check_active", input: {}, streaming: false },
+      {
+        kind: "tool_result",
+        tool_use_id: "item_0",
+        content: { message: "denied" },
+        is_error: true,
+      },
+    ]);
+  });
+
+  it("flags non-zero shell exits as errors", () => {
+    const items = run([
+      {
+        type: "item.completed",
+        item: {
+          id: "item_0",
+          type: "command_execution",
+          command: "false",
+          aggregated_output: "",
+          exit_code: 1,
+          status: "completed",
+        },
+      },
+    ] as RawEvent[]);
+    const result = items.find((i) => i.kind === "tool_result");
+    expect(result).toMatchObject({ tool_use_id: "item_0", is_error: true });
+  });
+
+  it("does not reset on a per-turn thread.started", () => {
+    const prev: ChatItem[] = [{ kind: "agent_message", text: "earlier" }];
+    expect(codexAdapter.reduce(prev, { type: "thread.started", thread_id: "t" } as RawEvent)).toBe(
+      prev,
+    );
+  });
+
+  it("replays a rollout transcript into the conversation", () => {
+    const lines = readJsonl("rollout.jsonl");
+    const events = codexAdapter.normalizeTranscript(lines);
+    const items = run(events as RawEvent[]);
+    expect(items).toEqual([
+      { kind: "user_message", text: "run echo hello" },
+      { kind: "tool_call", id: "call_1", name: "shell", input: "echo hello", streaming: false },
+      {
+        kind: "tool_result",
+        tool_use_id: "call_1",
+        content: "Process exited with code 0\nOutput:\nhello\n",
+        is_error: false,
+      },
+      { kind: "agent_message", text: "It printed hello." },
+      { kind: "notice", subtype: "turn_end", text: "success" },
+    ]);
+  });
+
+  it("replays a failed shell command as an error, not a success", () => {
+    const events = codexAdapter.normalizeTranscript([
+      {
+        type: "response_item",
+        payload: {
+          type: "function_call",
+          name: "exec_command",
+          arguments: '{"cmd":"false"}',
+          call_id: "c1",
+        },
+      },
+      {
+        type: "response_item",
+        payload: {
+          type: "function_call_output",
+          call_id: "c1",
+          output: "Process exited with code 1\nOutput:\n",
+        },
+      },
+    ]);
+    const items = run(events as RawEvent[]);
+    const result = items.find((i) => i.kind === "tool_result");
+    expect(result).toMatchObject({ tool_use_id: "c1", is_error: true });
+  });
+
+  it("renders a non-shell built-in tool by name, preserving its args", () => {
+    const events = codexAdapter.normalizeTranscript([
+      {
+        type: "response_item",
+        payload: {
+          type: "function_call",
+          name: "apply_patch",
+          arguments: '{"patch":"diff..."}',
+          call_id: "p1",
+        },
+      },
+      {
+        type: "response_item",
+        payload: { type: "function_call_output", call_id: "p1", output: "applied" },
+      },
+    ]);
+    const items = run(events as RawEvent[]);
+    const call = items.find((i) => i.kind === "tool_call");
+    // Not mislabeled "shell"; args preserved (not dropped).
+    expect(call).toMatchObject({ name: "apply_patch", input: { patch: "diff..." } });
+  });
+
+  it("drops injected noise (response_item user/developer messages, reasoning)", () => {
+    const lines = readJsonl("rollout.jsonl");
+    const events = codexAdapter.normalizeTranscript(lines);
+    // Only the clean event_msg user prompt survives, not the AGENTS.md /
+    // permissions response_item messages.
+    const userEvents = events.filter((e) => (e as RawEvent).type === "user");
+    expect(userEvents).toHaveLength(1);
+  });
+
   it("returns prevItems unchanged for unknown event types", () => {
     const prev: ChatItem[] = [{ kind: "user_message", text: "hi" }];
-    const next = codexAdapter.reduce(prev, { type: "??" } as RawEvent);
-    expect(next).toBe(prev);
+    expect(codexAdapter.reduce(prev, { type: "??" } as RawEvent)).toBe(prev);
   });
 
   it("exposes id and policy on the adapter", () => {

--- a/src/adapters/codex/reduce.ts
+++ b/src/adapters/codex/reduce.ts
@@ -1,99 +1,170 @@
-// TODO(codex-real-impl): event shapes here are inferred from OpenAI's
-// public Responses-API streaming docs and are not yet verified against
-// real `codex` CLI output. When codex's Rust transport ships and we can
-// observe its actual events, replace these stubs with the verified
-// mapping and add comprehensive fixtures.
+// Reducer for Codex's `codex exec --json` event stream.
 //
-// The interface contract is the same as Claude's reducer; only the
-// per-event parsing differs.
+// Verified against codex-cli 0.135.0. Codex emits a thread / turn / item
+// model (NOT the OpenAI Responses-API shapes an earlier stub guessed):
+//
+//   {"type":"thread.started","thread_id":"…"}            // session id
+//   {"type":"turn.started"}
+//   {"type":"item.started",  "item":{"id","type","status":"in_progress",…}}
+//   {"type":"item.completed","item":{"id","type","status",…}}
+//   {"type":"turn.completed","usage":{…}}                // end of turn
+//
+// Observed `item.type` values: `agent_message` ({text}), `command_execution`
+// ({command, aggregated_output, exit_code, status}), `mcp_tool_call`
+// ({server, tool, arguments, result, error, status}). There are no
+// token-level text deltas in exec mode — items arrive whole, so assistant
+// text and tool calls render on their `item.completed`.
 
 import type { ChatItem, RawEvent } from "../types";
 import { asRecord } from "../shared/json";
 import {
-  appendToolInputDelta,
   dedupAgainstLast,
-  extendLastAssistant,
   finalizeStreamingItems,
   upsertToolCall,
 } from "../shared/reducer-helpers";
 
+/** Human label for a tool-call item. */
+function toolName(item: Record<string, unknown>): string {
+  const type = typeof item.type === "string" ? item.type : "";
+  if (type === "command_execution") return "shell";
+  if (type === "mcp_tool_call") {
+    const server = typeof item.server === "string" ? item.server : "";
+    const tool = typeof item.tool === "string" ? item.tool : "tool";
+    return server ? `${server}.${tool}` : tool;
+  }
+  return type || "tool";
+}
+
+/** The input/arguments to display for a tool-call item. */
+function toolInput(item: Record<string, unknown>): unknown {
+  if (item.type === "command_execution") return item.command ?? "";
+  if (item.type === "mcp_tool_call") return item.arguments ?? {};
+  return {};
+}
+
+/** Did a finished tool item fail? */
+function isToolError(item: Record<string, unknown>): boolean {
+  if (item.status === "failed") return true;
+  if (item.type === "command_execution") {
+    return typeof item.exit_code === "number" && item.exit_code !== 0;
+  }
+  if (item.type === "mcp_tool_call") {
+    return item.error != null;
+  }
+  return false;
+}
+
+/** The result payload to show for a finished tool item. */
+function toolResult(item: Record<string, unknown>): unknown {
+  if (item.type === "command_execution") return item.aggregated_output ?? "";
+  if (item.type === "mcp_tool_call") return item.error ?? item.result ?? "";
+  return "";
+}
+
+const TOOL_TYPES = new Set(["command_execution", "mcp_tool_call"]);
+
 export function reduce(prev: ChatItem[], ev: RawEvent): ChatItem[] {
   const type = typeof ev.type === "string" ? ev.type : undefined;
 
-  // Responses-style streaming text deltas.
-  if (type === "response.output_text.delta") {
-    const delta = typeof ev.delta === "string" ? ev.delta : "";
-    return delta ? extendLastAssistant(prev, delta) : prev;
-  }
+  switch (type) {
+    // Session id capture happens in the Rust transport; nothing to render.
+    // `thread.started` also re-fires on every per-turn process, so it must
+    // never reset the transcript.
+    case "thread.started":
+    case "turn.started":
+      return prev;
 
-  // Finalized assistant text.
-  if (type === "response.output_text.done" || type === "message") {
-    let items = finalizeStreamingItems(prev);
-    const text =
-      typeof ev.text === "string"
-        ? ev.text
-        : typeof (ev as { content?: unknown }).content === "string"
-          ? ((ev as { content: string }).content)
-          : "";
-    if (!text) return items;
-    items = dedupAgainstLast(items, { kind: "agent_message", text });
-    return items;
-  }
+    // User turns never appear in the live `exec` stream (the composer adds
+    // them optimistically on send) — they only arrive via transcript replay
+    // (`normalizeTranscript` emits this synthetic shape from the rollout).
+    case "user": {
+      const text = typeof ev.text === "string" ? ev.text : "";
+      if (!text) return prev;
+      return dedupAgainstLast(prev, { kind: "user_message", text });
+    }
 
-  // Function/tool calls in Responses-API form.
-  if (type === "response.function_call.started" || type === "function_call") {
-    const id = String(ev.call_id ?? ev.id ?? "");
-    if (!id) return prev;
-    return upsertToolCall(prev, {
-      kind: "tool_call",
-      id,
-      name: String(ev.name ?? "tool"),
-      input: ev.arguments ?? "",
-      streaming: type === "response.function_call.started",
-    });
-  }
+    // A tool item begins executing — show it streaming until completion.
+    case "item.started":
+    case "item.updated": {
+      const item = asRecord(ev.item);
+      const id = typeof item.id === "string" ? item.id : "";
+      const itemType = typeof item.type === "string" ? item.type : "";
+      if (!id || !TOOL_TYPES.has(itemType)) return prev;
+      return upsertToolCall(prev, {
+        kind: "tool_call",
+        id,
+        name: toolName(item),
+        input: toolInput(item),
+        streaming: true,
+      });
+    }
 
-  if (type === "response.function_call_arguments.delta") {
-    const idx = typeof ev.output_index === "number" ? ev.output_index : 0;
-    const partial = typeof ev.delta === "string" ? ev.delta : "";
-    return partial ? appendToolInputDelta(prev, idx, partial) : prev;
-  }
+    case "item.completed": {
+      const item = asRecord(ev.item);
+      const id = typeof item.id === "string" ? item.id : "";
+      const itemType = typeof item.type === "string" ? item.type : "";
 
-  if (type === "function_call_output") {
-    const output = asRecord(ev.output);
-    return [
-      ...prev,
-      {
-        kind: "tool_result",
-        tool_use_id: String(ev.call_id ?? ""),
-        content: output.content ?? ev.output ?? "",
-        is_error: output.is_error === true,
-      },
-    ];
-  }
+      if (itemType === "agent_message") {
+        const items = finalizeStreamingItems(prev);
+        const text = typeof item.text === "string" ? item.text : "";
+        if (!text) return items;
+        return dedupAgainstLast(items, { kind: "agent_message", text });
+      }
 
-  // User echo (codex transcripts often include the user prompt).
-  if (type === "user") {
-    const text =
-      typeof ev.content === "string"
-        ? ev.content
-        : typeof (asRecord(ev.message) as { content?: unknown }).content ===
-            "string"
-          ? String((asRecord(ev.message) as { content: string }).content)
-          : "";
-    if (!text) return prev;
-    return dedupAgainstLast(prev, { kind: "user_message", text });
-  }
+      if (itemType === "reasoning") {
+        const text = typeof item.text === "string" ? item.text : "";
+        if (!text) return prev;
+        return [...prev, { kind: "notice", subtype: "reasoning", text }];
+      }
 
-  // Turn completion.
-  if (type === "response.completed" || type === "result") {
-    let items = finalizeStreamingItems(prev);
-    items = [
-      ...items,
-      { kind: "notice", subtype: "turn_end", text: "success" },
-    ];
-    return items;
-  }
+      if (TOOL_TYPES.has(itemType) && id) {
+        // Settle the (possibly streaming) tool_call with final args, then
+        // append its result.
+        let items = upsertToolCall(prev, {
+          kind: "tool_call",
+          id,
+          name: toolName(item),
+          input: toolInput(item),
+          streaming: false,
+        });
+        items = [
+          ...items,
+          {
+            kind: "tool_result",
+            tool_use_id: id,
+            content: toolResult(item),
+            is_error: isToolError(item),
+          },
+        ];
+        return items;
+      }
 
-  return prev;
+      return prev;
+    }
+
+    case "turn.completed": {
+      const items = finalizeStreamingItems(prev);
+      return [...items, { kind: "notice", subtype: "turn_end", text: "success" }];
+    }
+
+    // `turn.failed` / `error` surface as a visible error notice.
+    case "turn.failed":
+    case "error": {
+      const items = finalizeStreamingItems(prev);
+      const message =
+        typeof ev.message === "string"
+          ? ev.message
+          : typeof (asRecord(ev.error) as { message?: unknown }).message ===
+              "string"
+            ? String((asRecord(ev.error) as { message: string }).message)
+            : "Codex reported an error.";
+      return [
+        ...items,
+        { kind: "notice", subtype: "error", text: message, is_error: true },
+      ];
+    }
+
+    default:
+      return prev;
+  }
 }

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -90,7 +90,10 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
               style={{ margin: "40px auto", maxWidth: 360 }}
             >
               <div className="et">No transcript available</div>
-              <div>Claude's session file is not on disk for this agent.</div>
+              <div>
+                {providerLabel(agent.provider)}'s session file is not on disk
+                for this agent.
+              </div>
             </div>
           ) : (
             items.map((item, i) => <MessageItem key={i} item={item} />)
@@ -109,6 +112,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
       </div>
       <div className="composer-wrap">
         <Composer
+          defaultProvider={agent.provider}
           disabled={!canSend}
           placeholder={
             canSend

--- a/src/store.ts
+++ b/src/store.ts
@@ -678,10 +678,18 @@ export const useAppStore = create<AppState>((set, get) => ({
                 ],
               }
             : state.managedLogs,
+        // `running` is the backend's authoritative "a turn is in flight"
+        // signal — re-assert busy here so a stale `idle` (e.g. the one
+        // start_process emits just before the first turn lands) can't
+        // leave the spinner off. `idle`/`error`/`stopped` clear it.
         managedBusy:
-          e.status === "error" || e.status === "stopped" || e.status === "idle"
-            ? { ...state.managedBusy, [e.agent_id]: false }
-            : state.managedBusy,
+          e.status === "running"
+            ? { ...state.managedBusy, [e.agent_id]: true }
+            : e.status === "error" ||
+                e.status === "stopped" ||
+                e.status === "idle"
+              ? { ...state.managedBusy, [e.agent_id]: false }
+              : state.managedBusy,
       }));
     });
 


### PR DESCRIPTION
Adds Codex (OpenAI's CLI) as a first-class agent alongside Claude. Codex runs process-per-turn — each message spawns a fresh `codex exec [resume <id>] --json` (sandboxed by codex itself, approvals off), capturing the thread id from `thread.started` to resume later turns and reporting per-turn exit so interrupted/failed turns end promptly; it sits behind the existing `Agent` dispatch via a new `CodexManaged` runner and `CodexManagedActivity` (turn-end on `turn.completed`), leaving Claude's persistent stream-json pipe untouched. The frontend Codex adapter parses the real thread/turn/item event stream (replacing an earlier Responses-API guess) and replays on-disk rollout transcripts so re-attaching shows prior turns, with Codex pinned to the structured (Custom) view for v1. Also includes review-driven hardening: provider-aware session-id handling so Codex agents survive a restart before their first turn, an anchored rollout-file lookup, accurate replay of failed and non-shell tool calls, a spinner-state fix on turn start, and dedup of the agent-binary resolver. Verified with 83 Rust and 43 frontend tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)