### PR TITLE
Make file panel rows 24px for a denser list

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -2112,7 +2112,7 @@ button { cursor: default; }
 .fp-row {
   display: flex; align-items: center; gap: 6px;
   width: 100%;
-  height: 26px; flex-shrink: 0; padding-right: 12px;
+  height: 24px; flex-shrink: 0; padding-right: 12px;
   border: 0; background: transparent; cursor: pointer;
   text-align: left;
   color: var(--fg-1);


### PR DESCRIPTION
Reduces the `.fp-row` height in the file panel tree from 26px to 24px so the file list renders a bit denser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)