### PR TITLE
Show agent icons in the composer model picker

### DIFF
--- a/src/components/Composer/ModelPicker.tsx
+++ b/src/components/Composer/ModelPicker.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { PROVIDERS } from "../../data/providers";
 import { useAppStore } from "../../store";
 import { Icon } from "../Icon";
+import { ProviderIcon } from "../ProviderIcon";
 import { Chip } from "../ui/Chip";
 import { Scrim } from "../ui/Scrim";
 
@@ -22,9 +23,11 @@ export function ModelPicker({ value, onChange }: Props) {
   return (
     <div style={{ position: "relative" }}>
       <Chip bordered onClick={() => setOpen((v) => !v)}>
-        <span
-          className="dot"
-          style={{ background: `oklch(0.7 0.1 ${selected.hue})` }}
+        <ProviderIcon
+          slug={selected.id}
+          short={selected.short}
+          hue={selected.hue}
+          size={15}
         />
         <span style={{ fontWeight: 500 }}>{selected.label}</span>
         <Icon name="chevD" size={9} />
@@ -44,16 +47,7 @@ export function ModelPicker({ value, onChange }: Props) {
                   setOpen(false);
                 }}
               >
-                <div className="di-i">
-                  <span
-                    style={{
-                      width: 8,
-                      height: 8,
-                      borderRadius: "50%",
-                      background: `oklch(0.7 0.1 ${p.hue})`,
-                    }}
-                  />
-                </div>
+                <ProviderIcon slug={p.id} short={p.short} hue={p.hue} size={18} />
                 <span className="di-l">{p.label}</span>
                 <span className="di-m">{p.version}</span>
               </div>

--- a/src/components/ProviderIcon.tsx
+++ b/src/components/ProviderIcon.tsx
@@ -76,6 +76,11 @@ export function ProviderIcon({ slug, short, hue, size = 30 }: ProviderIconProps)
       style={{
         width: size,
         height: size,
+        // Scale the corner radius and monogram with `size` so the chip stays
+        // proportionate at any scale. The ratios reproduce the CSS defaults
+        // (7px radius, 10.5px text) exactly at the 30px settings size.
+        borderRadius: Math.max(3, Math.round(size * 0.233)),
+        fontSize: Math.round(size * 0.35 * 10) / 10,
         ["--ph-h" as string]: hue,
         ["--ph" as string]: "oklch(.65 .13 var(--ph-h))",
       }}


### PR DESCRIPTION
The composer's agent picker showed plain hue-tinted dots, while Settings shows the real branded `ProviderIcon` (CDN SVG with a monogram fallback). This reuses `ProviderIcon` in the picker — size 15 in the selected chip, size 18 in the dropdown rows — so the icons match Settings. To fit smaller sizes cleanly, `ProviderIcon` now scales its corner radius and monogram font from `size`, with ratios that reproduce the 7px/10.5px defaults exactly at the 30px Settings size, leaving Settings unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)