### PR TITLE
Fix multi-agent registry drift and gate unwired providers

### DIFF
--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -1345,10 +1345,13 @@ fn spawn_per_turn_agent(
 
     let spec = PerTurnSpec { cwd, session_id };
     match provider {
+        "codex" => Agent::spawn_codex(spec, on_event, on_session_id, on_turn_exit),
         "cursor" => Agent::spawn_cursor(spec, on_event, on_session_id, on_turn_exit),
         "opencode" => Agent::spawn_opencode(spec, on_event, on_session_id, on_turn_exit),
         "pi" => Agent::spawn_pi(spec, on_event, on_session_id, on_turn_exit),
-        _ => Agent::spawn_codex(spec, on_event, on_session_id, on_turn_exit),
+        other => Err(Error::Other(format!(
+            "unknown per-turn agent provider: {other}"
+        ))),
     }
 }
 

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -4,11 +4,15 @@ import { cursorAdapter } from "./cursor";
 import { opencodeAdapter } from "./opencode";
 import { piAdapter } from "./pi";
 import type { ChatAdapter } from "./types";
+import type { ProviderId } from "../data/providers";
 
 export type { ChatAdapter, ChatItem, DisplayPolicy, NoticeSubtype, RawEvent } from "./types";
 export { applyPolicy, modeFor } from "./policy";
 
-export const ADAPTERS: Record<string, ChatAdapter> = {
+// Partial: not every provider is wired. Agents listed in PROVIDERS without an
+// entry here (e.g. antigravity) are "coming soon" — the picker gates them via
+// `hasAdapter` so they can never be selected and silently fall back to Claude.
+export const ADAPTERS: Partial<Record<ProviderId, ChatAdapter>> = {
   claude: claudeAdapter,
   codex: codexAdapter,
   cursor: cursorAdapter,
@@ -16,15 +20,20 @@ export const ADAPTERS: Record<string, ChatAdapter> = {
   pi: piAdapter,
 };
 
-export const DEFAULT_ADAPTER_ID = "claude";
+export const DEFAULT_ADAPTER_ID: ProviderId = "claude";
+
+/** True if `provider` has a real adapter (i.e. is runnable, not coming-soon). */
+export function hasAdapter(provider: string | null | undefined): boolean {
+  return !!provider && provider in ADAPTERS;
+}
 
 export function getAdapter(provider: string | null | undefined): ChatAdapter {
   if (provider) {
-    const found = ADAPTERS[provider];
+    const found = ADAPTERS[provider as ProviderId];
     if (found) return found;
     console.warn(
       `[adapters] unknown provider "${provider}", falling back to ${DEFAULT_ADAPTER_ID}`,
     );
   }
-  return ADAPTERS[DEFAULT_ADAPTER_ID];
+  return ADAPTERS[DEFAULT_ADAPTER_ID]!;
 }

--- a/src/app.css
+++ b/src/app.css
@@ -2796,6 +2796,10 @@ button { cursor: default; }
   background: color-mix(in oklch, var(--warn), transparent 82%);
   color: var(--warn);
 }
+.set-badge.soon {
+  background: color-mix(in oklch, var(--fg-3), transparent 84%);
+  color: var(--fg-2);
+}
 .set-prov-update {
   display: inline-flex; align-items: center; justify-content: center;
   width: 17px; height: 17px; border-radius: 50%;

--- a/src/components/Composer/ModelPicker.tsx
+++ b/src/components/Composer/ModelPicker.tsx
@@ -57,7 +57,11 @@ export function ModelPicker({ value, onChange }: Props) {
                 >
                   <ProviderIcon slug={p.id} short={p.short} hue={p.hue} size={18} />
                   <span className="di-l">{p.label}</span>
-                  <span className="di-m">{wired ? p.version : "Soon"}</span>
+                  {wired ? (
+                    <span className="di-m">{p.version}</span>
+                  ) : (
+                    <span className="set-badge soon">Coming soon</span>
+                  )}
                 </div>
               );
             })}

--- a/src/components/Composer/ModelPicker.tsx
+++ b/src/components/Composer/ModelPicker.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { PROVIDERS } from "../../data/providers";
+import { hasAdapter } from "../../adapters";
 import { useAppStore } from "../../store";
 import { Icon } from "../Icon";
 import { ProviderIcon } from "../ProviderIcon";
@@ -11,9 +12,9 @@ interface Props {
   onChange: (id: string) => void;
 }
 
-/** Pops a dropdown listing enabled providers. Only `claude` actually
- *  runs today — the other entries are decorative until we wire more
- *  backends. */
+/** Pops a dropdown listing enabled providers. Providers without an adapter
+ *  (no backend runner yet, e.g. antigravity) are shown but disabled as
+ *  "Soon" so they can't be selected and silently fall back to Claude. */
 export function ModelPicker({ value, onChange }: Props) {
   const [open, setOpen] = useState(false);
   const providerFlags = useAppStore((s) => s.providerFlags);
@@ -38,20 +39,28 @@ export function ModelPicker({ value, onChange }: Props) {
           <Scrim onClose={() => setOpen(false)} />
           <div className="dd" style={{ bottom: "calc(100% + 6px)", left: 0 }}>
             <div className="dd-sect">Coding agents</div>
-            {enabled.map((p) => (
-              <div
-                key={p.id}
-                className={`dd-item ${p.id === value ? "active" : ""}`}
-                onClick={() => {
-                  onChange(p.id);
-                  setOpen(false);
-                }}
-              >
-                <ProviderIcon slug={p.id} short={p.short} hue={p.hue} size={18} />
-                <span className="di-l">{p.label}</span>
-                <span className="di-m">{p.version}</span>
-              </div>
-            ))}
+            {enabled.map((p) => {
+              const wired = hasAdapter(p.id);
+              return (
+                <div
+                  key={p.id}
+                  className={`dd-item ${p.id === value ? "active" : ""} ${wired ? "" : "is-disabled"}`}
+                  aria-disabled={!wired}
+                  onClick={
+                    wired
+                      ? () => {
+                          onChange(p.id);
+                          setOpen(false);
+                        }
+                      : undefined
+                  }
+                >
+                  <ProviderIcon slug={p.id} short={p.short} hue={p.hue} size={18} />
+                  <span className="di-l">{p.label}</span>
+                  <span className="di-m">{wired ? p.version : "Soon"}</span>
+                </div>
+              );
+            })}
           </div>
         </>
       )}

--- a/src/components/SettingsScreen/ProvidersPane.tsx
+++ b/src/components/SettingsScreen/ProvidersPane.tsx
@@ -137,6 +137,7 @@ function ProvDetailRow({ k, v, mono }: { k: string; v: string; mono?: boolean })
 
 function AvailableRow({ agent }: { agent: AvailableAgent }) {
   const detected = agent.state === "detected";
+  const soon = agent.state === "soon";
   return (
     <div className="set-prov available">
       <div className="set-prov-main">
@@ -148,13 +149,13 @@ function AvailableRow({ agent }: { agent: AvailableAgent }) {
         <div className="set-prov-id">
           <div className="set-prov-name">
             {agent.label}
+            {soon && <span className="set-badge soon">Coming soon</span>}
             {agent.version && <span className="set-prov-ver mono">{agent.version}</span>}
           </div>
           <div className="set-prov-sub muted">{agent.note}</div>
         </div>
-        {detected ? (
-          <button className="btn-t outline sm-t">Configure</button>
-        ) : (
+        {detected && <button className="btn-t outline sm-t">Configure</button>}
+        {agent.state === "install" && (
           <button className="btn-t ghost sm-t">
             Install <Icon name="external" size={11} />
           </button>

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -4,7 +4,6 @@ import type { AgentRecord, AgentStatus } from "../../api";
 import type { DraftAgent } from "../../store";
 import { useAppStore } from "../../store";
 import { LANDMARK_NAMES } from "../../data/landmarks";
-import { DEFAULT_PROVIDER_ID } from "../../data/providers";
 import { Icon, LandmarkGlyph } from "../Icon";
 import { formatAge, formatTokens } from "../../util/format";
 import { useMinuteClock } from "../../util/hooks";
@@ -87,7 +86,7 @@ function RealRow({ agent, active, showGlyph, onClick }: RealRowProps) {
           </span>
         )}
         <span className="ag-name">{agent.name}</span>
-        <span className="ag-provider-inline">· {DEFAULT_PROVIDER_ID}</span>
+        <span className="ag-provider-inline">· {agent.provider}</span>
         <span className="ag-actions">
           {stoppable && (
             <button

--- a/src/data/providerDetail.ts
+++ b/src/data/providerDetail.ts
@@ -82,8 +82,9 @@ export interface AvailableAgent {
   short: string;
   hue: number;
   version: string | null;
-  /** "detected" = found on PATH but unconfigured; "install" = installable. */
-  state: "detected" | "install";
+  /** "detected" = found on PATH but unconfigured; "install" = installable;
+   *  "soon" = not yet supported in Quorum (no adapter/runner). */
+  state: "detected" | "install" | "soon";
   note: string;
 }
 
@@ -95,7 +96,7 @@ export const AVAILABLE_AGENTS: AvailableAgent[] = [
     short: "AG",
     hue: 260,
     version: "v1.0",
-    state: "install",
-    note: "Not yet supported in Quorum — coming soon.",
+    state: "soon",
+    note: "Not yet supported in Quorum.",
   },
 ];

--- a/src/data/providerDetail.ts
+++ b/src/data/providerDetail.ts
@@ -2,6 +2,12 @@
 // the `PROVIDERS` id in data/providers.ts. This is mock data: real detection /
 // authentication isn't wired yet, so these describe how a configured agent
 // *would* present. The enable toggle still drives the real `providerFlags`.
+//
+// Typed as a full Record<ProviderId, …> so every provider must have an entry;
+// `installed: false` keeps a provider out of the "Installed" list (e.g.
+// antigravity, which has no adapter/runner yet).
+
+import type { ProviderId } from "./providers";
 
 export interface ProviderDetail {
   /** Account the agent is authenticated as. */
@@ -20,7 +26,7 @@ export interface ProviderDetail {
   installed: boolean;
 }
 
-export const PROVIDER_DETAIL: Record<string, ProviderDetail> = {
+export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
   claude: {
     account: "alex@joineve.ai",
     plan: "Claude Team",
@@ -49,13 +55,23 @@ export const PROVIDER_DETAIL: Record<string, ProviderDetail> = {
     plan: "Google AI Pro",
     path: "/Applications/Antigravity.app/…/antigravity",
     models: "Gemini 3 Pro · Flash",
-    installed: true,
+    // No adapter/runner yet — kept out of the Installed list and gated as
+    // "coming soon" in the picker. Flip to true once it's wired end-to-end.
+    installed: false,
   },
   opencode: {
     account: "opencode",
     plan: "1 upstream connected",
     path: "~/.opencode/bin/opencode",
     models: "Routed via upstream provider",
+    installed: true,
+  },
+  pi: {
+    account: "pi",
+    plan: "Experimental",
+    path: "~/.pi/bin/pi",
+    models: "Pi · experimental",
+    earlyAccess: true,
     installed: true,
   },
 };
@@ -74,12 +90,12 @@ export interface AvailableAgent {
 // Agents found on PATH but not yet configured, plus ones available to install.
 export const AVAILABLE_AGENTS: AvailableAgent[] = [
   {
-    id: "pi",
-    label: "Pi",
-    short: "PI",
-    hue: 320,
-    version: "v0.4",
-    state: "detected",
-    note: "Detected on PATH — not configured yet.",
+    id: "antigravity",
+    label: "Antigravity",
+    short: "AG",
+    hue: 260,
+    version: "v1.0",
+    state: "install",
+    note: "Not yet supported in Quorum — coming soon.",
   },
 ];

--- a/src/data/providers.ts
+++ b/src/data/providers.ts
@@ -1,9 +1,24 @@
-// Coding-agent providers. Only "claude" is actually wired; others are
-// listed so the model picker has something to show. When real backends
-// land, drop the mocks and add a `provider` field on AgentRecord.
+// Coding-agent providers shown in the composer's model picker.
+//
+// `ProviderId` is the single source of truth for the set of agents. Every
+// keyed registry (ADAPTERS, PROVIDER_DETAIL, PROVIDER_COMMANDS) is typed
+// against it, so adding/removing an agent surfaces as a compile error
+// anywhere it isn't kept in sync.
+//
+// "Wired" (runnable) === has an entry in the frontend `ADAPTERS` registry
+// plus a backend runner. Agents without an adapter (e.g. antigravity) still
+// appear here but are gated as "coming soon" in the picker (see ModelPicker).
+
+export type ProviderId =
+  | "claude"
+  | "codex"
+  | "cursor"
+  | "antigravity"
+  | "opencode"
+  | "pi";
 
 export interface Provider {
-  id: string;
+  id: ProviderId;
   label: string;
   short: string;
   version: string;

--- a/src/data/slashCommands.ts
+++ b/src/data/slashCommands.ts
@@ -18,6 +18,8 @@
 // "/foo isn't available in this environment" if proxied. If we want
 // them, they need a `local` entry with Quorum-side implementations.
 
+import type { ProviderId } from "./providers";
+
 export type SlashCommand =
   | {
       kind: "passthrough";
@@ -33,7 +35,7 @@ export type SlashCommand =
       action: string;
     };
 
-export const PROVIDER_COMMANDS: Record<string, SlashCommand[]> = {
+export const PROVIDER_COMMANDS: Record<ProviderId, SlashCommand[]> = {
   claude: [
     { kind: "passthrough", name: "help",    description: "Show available commands" },
     { kind: "passthrough", name: "compact", description: "Compact prior turns into a summary" },
@@ -47,7 +49,7 @@ export const PROVIDER_COMMANDS: Record<string, SlashCommand[]> = {
 };
 
 export function commandsFor(providerId: string): SlashCommand[] {
-  return PROVIDER_COMMANDS[providerId] ?? [];
+  return PROVIDER_COMMANDS[providerId as ProviderId] ?? [];
 }
 
 export function filterCommands(


### PR DESCRIPTION
## What & why

The frontend provider registries had drifted: `data/providers.ts` / `providerDetail.ts` started as mock data ("only claude is wired"), but real adapters + backends later landed for codex/cursor/opencode/pi. The four hand-synced lists (`PROVIDERS`, `ADAPTERS`, `PROVIDER_DETAIL`, `PROVIDER_COMMANDS`) disagreed, and nothing was type-checked (`provider` was a bare `string`). This fixes the drift and locks it in.

## Changes

**Bugs**
- **Sidebar mislabel** — `AgentRow` rendered a hardcoded `· claude` for every agent; now uses `agent.provider`.
- **Pi settings** — Pi was fully wired but presented as "detected on PATH, not configured"; promoted to an installed `PROVIDER_DETAIL` entry.

**Antigravity (no adapter/runner yet)** — was selectable and silently fell back to Claude. Gated as **coming soon**: `ModelPicker` disables providers without an adapter (via `hasAdapter`) and shows a "Soon" label; it drops out of the Installed list (`installed: false`) and appears under Available.

**Backend safety** — unknown per-turn provider previously defaulted to spawning **Codex** (`supervisor.rs`); now returns an explicit `Error::Other`.

**Type lock-in** — `ProviderId` union is the single source of truth. `PROVIDER_DETAIL` / `PROVIDER_COMMANDS` are full `Record<ProviderId, …>` and `ADAPTERS` is `Partial<Record<ProviderId, …>>`, so future registry drift is a compile error.

## Verification
- `tsc --noEmit` clean
- `vitest` — 69/69 pass
- `cargo check` — builds

## Out of scope (tracked separately)
Transcript replay for Cursor/Pi/OpenCode, a backend agent-descriptor table to replace scattered `match provider` arms, an explicit capability model, and a shared tool-input normalizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)