### PR TITLE
Consolidate per-turn agents into a descriptor table

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -20,6 +20,7 @@ use std::process::Command;
 
 use serde_json::Value;
 
+use crate::activity::{Activity, ManagedActivity};
 use crate::error::{Error, Result};
 use crate::exec_session::{ExecCallbacks, ExecSession, ExecSpawn};
 use crate::managed_session::{ManagedExit, ManagedSession, ManagedSpawn};
@@ -59,6 +60,71 @@ pub struct PerTurnSpec {
     pub cwd: PathBuf,
     /// Session id to resume, if one has been captured already.
     pub session_id: Option<String>,
+}
+
+/// Everything that varies between per-turn agents. The runner lifecycle —
+/// one fresh process per turn via `ExecSession` — is identical for all of
+/// them; only the binary, CLI args, session-id extraction, and turn-end
+/// detector differ. Capturing those four as a table entry means a new
+/// per-turn agent is one `PER_TURN_AGENTS` row, with no new `spawn_*`
+/// method, `resolve_*` helper, or `match provider` arm anywhere.
+pub struct PerTurnDescriptor {
+    /// Provider id (matches the frontend adapter / `AgentRecord.provider`).
+    pub id: &'static str,
+    /// Executable name resolved via `resolve_agent_bin`.
+    bin: &'static str,
+    /// Human-facing product name, used only in the not-found error.
+    label: &'static str,
+    /// Builds the CLI args for a turn: `(prompt, resume_session_id)`.
+    build_args: fn(&str, Option<&str>) -> Vec<String>,
+    /// Extracts the agent-assigned session id from a turn's events.
+    session_id: fn(&Value) -> Option<String>,
+    /// Constructs this agent's turn-end detector (custom-view `Activity`).
+    pub activity: fn() -> Box<dyn Activity>,
+}
+
+const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
+    PerTurnDescriptor {
+        id: "codex",
+        bin: "codex",
+        label: "Codex",
+        build_args: codex_build_args,
+        session_id: codex_session_id,
+        activity: || Box::new(ManagedActivity::codex()),
+    },
+    PerTurnDescriptor {
+        id: "cursor",
+        bin: "cursor-agent",
+        label: "Cursor",
+        build_args: cursor_build_args,
+        session_id: cursor_session_id,
+        // Cursor emits Claude-shaped stream-json incl. a `result` turn-end,
+        // so it reuses the Claude managed detector.
+        activity: || Box::new(ManagedActivity::claude()),
+    },
+    PerTurnDescriptor {
+        id: "opencode",
+        bin: "opencode",
+        label: "OpenCode",
+        build_args: opencode_build_args,
+        session_id: opencode_session_id,
+        activity: || Box::new(ManagedActivity::opencode()),
+    },
+    PerTurnDescriptor {
+        id: "pi",
+        bin: "pi",
+        label: "Pi",
+        build_args: pi_build_args,
+        session_id: pi_session_id,
+        activity: || Box::new(ManagedActivity::pi()),
+    },
+];
+
+/// Look up the descriptor for a per-turn provider id. `None` means the
+/// provider isn't a per-turn agent (e.g. claude, which has its own
+/// Pty/Managed runners) or isn't a known agent at all.
+pub fn per_turn_descriptor(id: &str) -> Option<&'static PerTurnDescriptor> {
+    PER_TURN_AGENTS.iter().find(|d| d.id == id)
 }
 
 pub struct SpawnSpec<'a> {
@@ -149,9 +215,14 @@ impl Agent {
         }))
     }
 
-    /// Build a Codex per-turn runner (`codex exec [resume <id>] --json`).
-    /// See `spawn_per_turn` for the shared lifecycle.
-    pub fn spawn_codex<F, G, H>(
+    /// Build a per-turn runner (codex, cursor, opencode, pi) from its
+    /// `PerTurnDescriptor`. The binary, CLI args, and session-id extraction
+    /// come from the descriptor; the lifecycle is the shared `spawn_exec`.
+    /// Per-turn agents hold no live process between turns — each user
+    /// message spawns a fresh process — and sandbox themselves, so there's
+    /// no sandbox-exec profile.
+    pub fn spawn_per_turn<F, G, H>(
+        desc: &PerTurnDescriptor,
         spec: PerTurnSpec,
         on_event: F,
         on_session_id: G,
@@ -164,12 +235,12 @@ impl Agent {
     {
         let home = dirs::home_dir()
             .ok_or_else(|| Error::Other("HOME directory not available".into()))?;
-        let program = PathBuf::from(resolve_codex(&home)?);
-        Self::spawn_per_turn(
+        let program = PathBuf::from(resolve_agent_bin(desc.bin, desc.label, &home)?);
+        Self::spawn_exec(
             program,
             spec,
-            codex_build_args,
-            codex_session_id,
+            desc.build_args,
+            desc.session_id,
             ExecCallbacks {
                 on_event,
                 on_session_id,
@@ -178,108 +249,13 @@ impl Agent {
         )
     }
 
-    /// Build a Cursor per-turn runner
-    /// (`cursor-agent -p --output-format stream-json [--resume <id>]`).
-    /// Cursor emits Claude-shaped stream-json events, so it reuses the
-    /// Claude reducer + `result`-based turn-end on the frontend.
-    pub fn spawn_cursor<F, G, H>(
-        spec: PerTurnSpec,
-        on_event: F,
-        on_session_id: G,
-        on_turn_exit: H,
-    ) -> Result<Self>
-    where
-        F: Fn(Value) + Send + Sync + 'static,
-        G: Fn(String) + Send + Sync + 'static,
-        H: Fn(bool) + Send + Sync + 'static,
-    {
-        let home = dirs::home_dir()
-            .ok_or_else(|| Error::Other("HOME directory not available".into()))?;
-        let program = PathBuf::from(resolve_cursor(&home)?);
-        Self::spawn_per_turn(
-            program,
-            spec,
-            cursor_build_args,
-            cursor_session_id,
-            ExecCallbacks {
-                on_event,
-                on_session_id,
-                on_exit: on_turn_exit,
-            },
-        )
-    }
-
-    /// Build an OpenCode per-turn runner
-    /// (`opencode run --format json --dangerously-skip-permissions [--session <id>]`).
-    /// OpenCode emits its own step/part event schema (see `src/adapters/opencode`),
-    /// so the frontend reduces it with a dedicated reducer; the lifecycle is the
-    /// shared `spawn_per_turn`.
-    pub fn spawn_opencode<F, G, H>(
-        spec: PerTurnSpec,
-        on_event: F,
-        on_session_id: G,
-        on_turn_exit: H,
-    ) -> Result<Self>
-    where
-        F: Fn(Value) + Send + Sync + 'static,
-        G: Fn(String) + Send + Sync + 'static,
-        H: Fn(bool) + Send + Sync + 'static,
-    {
-        let home = dirs::home_dir()
-            .ok_or_else(|| Error::Other("HOME directory not available".into()))?;
-        let program = PathBuf::from(resolve_opencode(&home)?);
-        Self::spawn_per_turn(
-            program,
-            spec,
-            opencode_build_args,
-            opencode_session_id,
-            ExecCallbacks {
-                on_event,
-                on_session_id,
-                on_exit: on_turn_exit,
-            },
-        )
-    }
-
-    /// Build a Pi per-turn runner
-    /// (`pi -p --mode json [--session <id>] <prompt>`). Pi emits its own
-    /// step/message event schema (see `src/adapters/pi`), so the frontend
-    /// reduces it with a dedicated reducer; the lifecycle is the shared
-    /// `spawn_per_turn`.
-    pub fn spawn_pi<F, G, H>(
-        spec: PerTurnSpec,
-        on_event: F,
-        on_session_id: G,
-        on_turn_exit: H,
-    ) -> Result<Self>
-    where
-        F: Fn(Value) + Send + Sync + 'static,
-        G: Fn(String) + Send + Sync + 'static,
-        H: Fn(bool) + Send + Sync + 'static,
-    {
-        let home = dirs::home_dir()
-            .ok_or_else(|| Error::Other("HOME directory not available".into()))?;
-        let program = PathBuf::from(resolve_pi(&home)?);
-        Self::spawn_per_turn(
-            program,
-            spec,
-            pi_build_args,
-            pi_session_id,
-            ExecCallbacks {
-                on_event,
-                on_session_id,
-                on_exit: on_turn_exit,
-            },
-        )
-    }
-
-    /// Shared per-turn runner. Spawns no process yet — the first turn is
-    /// launched when the first user message arrives. `on_exit(success)`
+    /// Shared per-turn exec lifecycle. Spawns no process yet — the first
+    /// turn is launched when the first user message arrives. `on_exit(success)`
     /// fires when a turn's process exits (and that turn is still current)
     /// — the per-turn analogue of a turn-end signal, so an interrupted or
     /// failed turn that never emits an in-band turn-end still leaves the
     /// agent promptly.
-    fn spawn_per_turn<A, I, F, G, H>(
+    fn spawn_exec<A, I, F, G, H>(
         program: PathBuf,
         spec: PerTurnSpec,
         build_args: A,
@@ -460,22 +436,6 @@ fn prepare_managed_args(
 
 fn resolve_claude(home: &Path) -> Result<String> {
     resolve_agent_bin("claude", "Claude Code", home)
-}
-
-fn resolve_codex(home: &Path) -> Result<String> {
-    resolve_agent_bin("codex", "Codex", home)
-}
-
-fn resolve_cursor(home: &Path) -> Result<String> {
-    resolve_agent_bin("cursor-agent", "Cursor", home)
-}
-
-fn resolve_opencode(home: &Path) -> Result<String> {
-    resolve_agent_bin("opencode", "OpenCode", home)
-}
-
-fn resolve_pi(home: &Path) -> Result<String> {
-    resolve_agent_bin("pi", "Pi", home)
 }
 
 // ── per-turn provider configs ────────────────────────────────────────────

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use tauri::{AppHandle, Emitter};
 
 use crate::activity::{Activity, ClaudeNativeActivity, ManagedActivity};
-use crate::agent::{Agent, PerTurnSpec, SpawnSpec};
+use crate::agent::{per_turn_descriptor, Agent, PerTurnSpec, SpawnSpec};
 use crate::branding;
 use crate::error::{Error, Result};
 use crate::git;
@@ -506,16 +506,12 @@ impl Supervisor {
             *entry
         };
 
-        let mut activity: Box<dyn Activity> = match provider.as_str() {
-            "codex" => Box::new(ManagedActivity::codex()),
-            // cursor emits Claude-shaped stream-json, incl. a `result`
-            // turn-end event — reuse the Claude managed detector.
-            "cursor" => Box::new(ManagedActivity::claude()),
-            // opencode ends a turn on a `step_finish` with reason "stop".
-            "opencode" => Box::new(ManagedActivity::opencode()),
-            // pi ends a turn on a single `agent_end` event.
-            "pi" => Box::new(ManagedActivity::pi()),
-            _ => match record.view {
+        // Per-turn agents carry their turn-end detector in the descriptor
+        // table; everything else is claude (native PTY silence or the
+        // managed `result` detector, by view).
+        let mut activity: Box<dyn Activity> = match per_turn_descriptor(&provider) {
+            Some(desc) => (desc.activity)(),
+            None => match record.view {
                 AgentView::Native => Box::new(ClaudeNativeActivity::new()),
                 AgentView::Custom => Box::new(ManagedActivity::claude()),
             },
@@ -1344,15 +1340,10 @@ fn spawn_per_turn_agent(
     };
 
     let spec = PerTurnSpec { cwd, session_id };
-    match provider {
-        "codex" => Agent::spawn_codex(spec, on_event, on_session_id, on_turn_exit),
-        "cursor" => Agent::spawn_cursor(spec, on_event, on_session_id, on_turn_exit),
-        "opencode" => Agent::spawn_opencode(spec, on_event, on_session_id, on_turn_exit),
-        "pi" => Agent::spawn_pi(spec, on_event, on_session_id, on_turn_exit),
-        other => Err(Error::Other(format!(
-            "unknown per-turn agent provider: {other}"
-        ))),
-    }
+    let desc = per_turn_descriptor(provider).ok_or_else(|| {
+        Error::Other(format!("unknown per-turn agent provider: {provider}"))
+    })?;
+    Agent::spawn_per_turn(desc, spec, on_event, on_session_id, on_turn_exit)
 }
 
 fn observe_native_input(sup: &Supervisor, agent_id: &str, bytes: &[u8]) -> Vec<String> {

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -936,9 +936,10 @@ impl WorkspaceManager {
 
 /// Per-turn agents run one process per turn, assign their own session id
 /// (captured from their first turn's events rather than generated up
-/// front), and render only in the structured (Custom) view for now.
+/// front), and render only in the structured (Custom) view for now. The
+/// canonical set is the `agent::PER_TURN_AGENTS` descriptor table.
 pub fn is_per_turn_provider(provider: &str) -> bool {
-    matches!(provider, "codex" | "cursor" | "opencode" | "pi")
+    crate::agent::per_turn_descriptor(provider).is_some()
 }
 
 /// Build a fresh AgentRecord with one primary tracked repo.


### PR DESCRIPTION
## What & why

The four per-turn agents (codex, cursor, opencode, pi) share an identical runner lifecycle but were wired through scattered per-agent code:

- four near-identical `Agent::spawn_*` methods
- four `resolve_*` binary helpers
- three separate `match provider` arms — spawn dispatch, activity factory, and `is_per_turn_provider`

Adding an agent meant touching all of them. This is item #7 from the multi-agent audit ("push only the truly-different parts into adapters/data").

## Change

Introduce a single `PerTurnDescriptor` table in `agent.rs`. Each row holds only what actually varies between these agents:

```rust
struct PerTurnDescriptor {
    id, bin, label,
    build_args: fn(&str, Option<&str>) -> Vec<String>,
    session_id: fn(&Value) -> Option<String>,
    activity:   fn() -> Box<dyn Activity>,
}
const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[ codex, cursor, opencode, pi ];
```

The lifecycle stays the shared `ExecSession` path (the private helper `spawn_per_turn` is renamed `spawn_exec`; the new public `Agent::spawn_per_turn` takes a descriptor). The existing `*_build_args` / `*_session_id` bodies are unchanged — just referenced by the table.

Call sites now look up the descriptor instead of matching on provider:
- spawn dispatch → `per_turn_descriptor(provider)` + `Agent::spawn_per_turn`
- activity factory → `(desc.activity)()`
- `workspace::is_per_turn_provider` → `per_turn_descriptor(p).is_some()`

The table is now the **single source of truth** for the set of per-turn agents — adding one is a single row.

## Scope

- **Pure refactor, no behavior change.** Same binaries, args, session-id extraction, and turn-end detection per agent.
- **Claude's Pty/Managed runners are intentionally untouched** — they're a genuinely different shape (sandbox-exec, native PTY view) and folding them in would balloon the scope.
- Capability model (#8) is deliberately **not** included here.

## Verification
- `cargo check` clean
- `cargo clippy` — no new warnings (the 3 remaining are pre-existing at `supervisor.rs:1738/1789`, `workspace.rs:40`)
- `cargo test` — 87/87 pass

Net: **+95 / −143** lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)