### PR TITLE
Add an explicit per-agent capability model

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -65,7 +65,7 @@ pub struct PerTurnSpec {
 /// Everything that varies between per-turn agents. The runner lifecycle —
 /// one fresh process per turn via `ExecSession` — is identical for all of
 /// them; only the binary, CLI args, session-id extraction, and turn-end
-/// detector differ. Capturing those four as a table entry means a new
+/// detector differ. Capturing those as a table entry means a new
 /// per-turn agent is one `PER_TURN_AGENTS` row, with no new `spawn_*`
 /// method, `resolve_*` helper, or `match provider` arm anywhere.
 pub struct PerTurnDescriptor {
@@ -81,6 +81,49 @@ pub struct PerTurnDescriptor {
     session_id: fn(&Value) -> Option<String>,
     /// Constructs this agent's turn-end detector (custom-view `Activity`).
     pub activity: fn() -> Box<dyn Activity>,
+    /// Rollout flags — see `AgentCapabilities`. These describe what's wired
+    /// *today*, not a permanent limit; each is being brought to every agent
+    /// in follow-up PRs, at which point its flag flips to `true`.
+    native_view: bool,
+    transcript_replay: bool,
+}
+
+/// What an agent can do *right now*. These are rollout flags, not fixed
+/// traits: the roadmap is native (PTY/TUI) views and on-disk transcript
+/// replay for every agent, with the SQLite event log as the canonical
+/// history store you can always restore from. As each capability is wired
+/// for an agent, its flag flips — callers gate on the capability, never on
+/// the provider id, so nothing else changes when support lands.
+pub struct AgentCapabilities {
+    /// Can render in the native PTY view (its interactive TUI streamed into
+    /// xterm), in addition to the structured custom view. Today: claude
+    /// only; per-turn agents are custom-only until their TUI path is wired.
+    pub native_view: bool,
+    /// Has its native on-disk transcript wired for replay (parsed by the
+    /// frontend adapter's `normalizeTranscript`). When false, re-attaching
+    /// still restores history from the provider-agnostic SQLite event log —
+    /// this flag only governs the richer native-format path.
+    pub transcript_replay: bool,
+}
+
+/// Capabilities for a provider. Per-turn agents read theirs from the
+/// descriptor table; claude (the lone persistent-runner agent) is the
+/// fully-wired baseline. Unknown providers get nothing.
+pub fn capabilities(provider: &str) -> AgentCapabilities {
+    match per_turn_descriptor(provider) {
+        Some(d) => AgentCapabilities {
+            native_view: d.native_view,
+            transcript_replay: d.transcript_replay,
+        },
+        None if provider == "claude" => AgentCapabilities {
+            native_view: true,
+            transcript_replay: true,
+        },
+        None => AgentCapabilities {
+            native_view: false,
+            transcript_replay: false,
+        },
+    }
 }
 
 const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
@@ -91,6 +134,10 @@ const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         build_args: codex_build_args,
         session_id: codex_session_id,
         activity: || Box::new(ManagedActivity::codex()),
+        native_view: false,
+        // Codex persists a `rollout-*.jsonl`; `find_codex_rollout` + the
+        // frontend codex adapter replay it.
+        transcript_replay: true,
     },
     PerTurnDescriptor {
         id: "cursor",
@@ -101,6 +148,10 @@ const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         // Cursor emits Claude-shaped stream-json incl. a `result` turn-end,
         // so it reuses the Claude managed detector.
         activity: || Box::new(ManagedActivity::claude()),
+        native_view: false,
+        // Cursor's on-disk chat format is undocumented; restore from the
+        // SQLite log until a native transcript path is wired.
+        transcript_replay: false,
     },
     PerTurnDescriptor {
         id: "opencode",
@@ -109,6 +160,10 @@ const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         build_args: opencode_build_args,
         session_id: opencode_session_id,
         activity: || Box::new(ManagedActivity::opencode()),
+        native_view: false,
+        // OpenCode's `export` schema differs from its live stream; restore
+        // from the SQLite log until that's mapped.
+        transcript_replay: false,
     },
     PerTurnDescriptor {
         id: "pi",
@@ -117,6 +172,10 @@ const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         build_args: pi_build_args,
         session_id: pi_session_id,
         activity: || Box::new(ManagedActivity::pi()),
+        native_view: false,
+        // Pi persists a `session.jsonl` that's wireable later; restore from
+        // the SQLite log until then.
+        transcript_replay: false,
     },
 ];
 
@@ -617,6 +676,44 @@ fn command_from_login_shell(name: &str) -> Option<String> {
         None
     } else {
         Some(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_per_turn_agent_resolves_to_its_descriptor() {
+        for d in PER_TURN_AGENTS {
+            assert_eq!(per_turn_descriptor(d.id).map(|x| x.id), Some(d.id));
+        }
+        assert!(per_turn_descriptor("claude").is_none());
+        assert!(per_turn_descriptor("nope").is_none());
+    }
+
+    /// Pins the current capability rollout. The roadmap is native views and
+    /// transcript replay for every agent; when a follow-up wires one, it
+    /// flips the descriptor flag and updates the expectation here on purpose.
+    #[test]
+    fn capability_rollout_matches_what_is_wired_today() {
+        let cases = [
+            // provider     native_view  transcript_replay
+            ("claude", true, true),
+            ("codex", false, true),
+            ("cursor", false, false),
+            ("opencode", false, false),
+            ("pi", false, false),
+            ("unknown", false, false),
+        ];
+        for (provider, native_view, transcript_replay) in cases {
+            let caps = capabilities(provider);
+            assert_eq!(caps.native_view, native_view, "native_view for {provider}");
+            assert_eq!(
+                caps.transcript_replay, transcript_replay,
+                "transcript_replay for {provider}"
+            );
+        }
     }
 }
 

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use tauri::{AppHandle, Emitter};
 
 use crate::activity::{Activity, ClaudeNativeActivity, ManagedActivity};
-use crate::agent::{per_turn_descriptor, Agent, PerTurnSpec, SpawnSpec};
+use crate::agent::{capabilities, per_turn_descriptor, Agent, PerTurnSpec, SpawnSpec};
 use crate::branding;
 use crate::error::{Error, Result};
 use crate::git;
@@ -339,13 +339,13 @@ impl Supervisor {
             )));
         }
 
-        // Per-turn agents (codex, cursor) only render in the structured
-        // (Custom) view for now: they emit stream-json events, not the PTY
-        // bytes the native view expects. Native TUI views are a follow-up.
-        let view = if is_per_turn_provider(&provider) {
-            AgentView::Custom
-        } else {
+        // Only agents with a wired native (PTY/TUI) view can honor a Native
+        // request; the rest fall back to the structured Custom view. Native
+        // views are being rolled out per agent (see `AgentCapabilities`).
+        let view = if capabilities(&provider).native_view {
             view
+        } else {
+            AgentView::Custom
         };
 
         let agent_id = self.workspace.allocate_agent_id()?;
@@ -709,11 +709,11 @@ impl Supervisor {
         if record.view == new_view {
             return Ok(());
         }
-        // Per-turn agents (codex, cursor) have no native PTY view yet —
-        // keep them on the structured one.
-        if is_per_turn_provider(&record.provider) && new_view == AgentView::Native {
+        // Reject switching to native for agents whose native view isn't
+        // wired yet (rolling out per agent — see `AgentCapabilities`).
+        if new_view == AgentView::Native && !capabilities(&record.provider).native_view {
             return Err(Error::Other(
-                "This agent only supports the structured view".into(),
+                "The native view isn't available for this agent yet".into(),
             ));
         }
 
@@ -997,20 +997,12 @@ impl Supervisor {
     pub fn read_session_transcript(&self, agent_id: &str) -> Result<Vec<Value>> {
         let record = self.workspace.agent(agent_id)?;
 
-        // Cursor stores chats in an internal, undocumented format (no
-        // `export`), so transcript replay isn't wired for it in v1 — live
-        // turns render fine and `--resume` still continues the conversation.
-        //
-        // OpenCode does have an `export` command, but its on-disk schema
-        // differs from the live event stream the reducer consumes, so
-        // wiring it is a follow-up. Re-attaching replays from the
-        // provider-agnostic SQLite event log; `--session <id>` resumes the
-        // conversation.
-        //
-        // Pi persists a `session.jsonl` of its live events, so transcript
-        // replay is wireable later; for v1 it falls back to the SQLite log
-        // like the others, and `--session <id>` resumes the conversation.
-        if matches!(record.provider.as_str(), "cursor" | "opencode" | "pi") {
+        // Agents whose native on-disk transcript isn't wired yet have
+        // nothing to hand back here; re-attaching restores their history
+        // from the provider-agnostic SQLite event log instead, and
+        // `--resume`/`--session <id>` still continues the conversation.
+        // (Per-agent rollout — see `AgentCapabilities::transcript_replay`.)
+        if !capabilities(&record.provider).transcript_replay {
             return Ok(Vec::new());
         }
 


### PR DESCRIPTION
## What & why

Native (PTY/TUI) view support and on-disk transcript replay were inferred implicitly:

- native view from `!is_per_turn_provider`
- transcript replay from a `matches!(provider, "cursor"|"opencode"|"pi")` hardcode

That conflated **"uses the per-turn runner"** with **"can't do X"** — which is only *accidentally* true today. Both capabilities are on the roadmap for every agent, so the limitation isn't structural; it's just "not wired yet."

This is item #8 from the multi-agent audit, scoped per the agreed plan.

## Change

Model the capabilities as explicit **rollout flags**:

```rust
pub struct AgentCapabilities { pub native_view: bool, pub transcript_replay: bool }
pub fn capabilities(provider: &str) -> AgentCapabilities { … }
```

- Per-turn agents carry `native_view` / `transcript_replay` in the `PerTurnDescriptor` table; Claude is the fully-wired baseline.
- The three call sites now gate on the capability, never on the provider id:
  - spawn view-forcing → `capabilities(p).native_view`
  - view-switch guard → `capabilities(p).native_view`
  - transcript read → `capabilities(p).transcript_replay` (kills the `matches!` hardcode)

When a follow-up wires (say) Codex's native TUI, it flips **one flag** and nothing else changes.

## Framing (per the roadmap)

These are **transitional**, not fixed traits. The end state is native views and transcript replay for *every* agent, with the **SQLite event log as the canonical, always-restorable history store**. `transcript_replay` only governs the richer native-on-disk path — re-attaching already falls back to SQLite for all agents today.

A unit test pins the current rollout per agent, so flipping a flag is a deliberate, visible change.

## Scope
- Backend only. Frontend already shows the Native toggle for all agents and relies on the backend to gate — unchanged.
- Pure refactor, no behavior change. The runner-shape uses of `is_per_turn_provider` are intentionally left as-is (different axis).
- Does **not** implement the SQLite-canonical end state — that's the larger follow-up (#6).

## Verification
- `cargo check` clean
- `cargo clippy` — no new warnings (3 pre-existing remain)
- `cargo test` — **89/89** pass (incl. 2 new capability tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)