### PR TITLE
Extract shared aliasToolInput helper

### DIFF
--- a/src/adapters/opencode/reduce.ts
+++ b/src/adapters/opencode/reduce.ts
@@ -22,30 +22,22 @@
 import type { ChatItem, RawEvent } from "../types";
 import { asRecord } from "../shared/json";
 import {
+  aliasToolInput,
   dedupAgainstLast,
   finalizeStreamingItems,
   upsertToolCall,
 } from "../shared/reducer-helpers";
 
 /** OpenCode uses camelCase file fields (`filePath`/`oldString`/`newString`)
- *  while the shared tool presenters read Claude's snake_case names. Add the
- *  aliases so Read/Write/Edit render the path + diff without bespoke
- *  presenters. Returns the input untouched when nothing needs aliasing. */
+ *  while the shared tool presenters read Claude's snake_case names. Alias
+ *  them so Read/Write/Edit render the path + diff without bespoke
+ *  presenters. */
 function normalizeToolInput(input: unknown): unknown {
-  const rec = asRecord(input);
-  const aliases: Array<[string, string]> = [
+  return aliasToolInput(input, [
     ["filePath", "file_path"],
     ["oldString", "old_string"],
     ["newString", "new_string"],
-  ];
-  let out: Record<string, unknown> | null = null;
-  for (const [from, to] of aliases) {
-    if (typeof rec[from] === "string" && rec[to] === undefined) {
-      out = out ?? { ...rec };
-      out[to] = rec[from];
-    }
-  }
-  return out ?? input;
+  ]);
 }
 
 /** The result text to show for a finished tool. */

--- a/src/adapters/pi/reduce.ts
+++ b/src/adapters/pi/reduce.ts
@@ -22,21 +22,16 @@
 import type { ChatItem, RawEvent } from "../types";
 import { asBlockList, asRecord } from "../shared/json";
 import {
+  aliasToolInput,
   dedupAgainstLast,
   finalizeStreamingItems,
   upsertToolCall,
 } from "../shared/reducer-helpers";
 
 /** Pi names file tools' path argument `path`; the shared presenters read
- *  Claude's `file_path`. Add the alias so Read/Write/Edit render the path.
- *  Returns the input untouched when there's nothing to alias (e.g. bash's
- *  `command`). */
+ *  Claude's `file_path`. Alias it so Read/Write/Edit render the path. */
 function normalizeToolInput(input: unknown): unknown {
-  const rec = asRecord(input);
-  if (typeof rec.path === "string" && rec.file_path === undefined) {
-    return { ...rec, file_path: rec.path };
-  }
-  return input;
+  return aliasToolInput(input, [["path", "file_path"]]);
 }
 
 /** Flatten a content-block array (`[{type:"text",text}]`) to a string. */

--- a/src/adapters/shared/reducer-helpers.test.ts
+++ b/src/adapters/shared/reducer-helpers.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { aliasToolInput } from "./reducer-helpers";
+
+describe("aliasToolInput", () => {
+  const PI = [["path", "file_path"]] as const;
+  const OPENCODE = [
+    ["filePath", "file_path"],
+    ["oldString", "old_string"],
+    ["newString", "new_string"],
+  ] as const;
+
+  it("copies a string field to its alias", () => {
+    expect(aliasToolInput({ path: "note.txt" }, PI)).toEqual({
+      path: "note.txt",
+      file_path: "note.txt",
+    });
+  });
+
+  it("applies multiple aliases at once", () => {
+    expect(
+      aliasToolInput({ filePath: "/a", oldString: "x", newString: "y" }, OPENCODE),
+    ).toEqual({
+      filePath: "/a",
+      oldString: "x",
+      newString: "y",
+      file_path: "/a",
+      old_string: "x",
+      new_string: "y",
+    });
+  });
+
+  it("returns the input untouched (same reference) when nothing aliases", () => {
+    const input = { command: "ls -la" };
+    expect(aliasToolInput(input, PI)).toBe(input);
+  });
+
+  it("does not overwrite a target field that's already set", () => {
+    const input = { path: "from-path", file_path: "explicit" };
+    expect(aliasToolInput(input, PI)).toBe(input);
+  });
+
+  it("ignores non-string source values", () => {
+    const input = { path: 42 };
+    expect(aliasToolInput(input, PI)).toBe(input);
+  });
+
+  it("only copies the aliases that apply", () => {
+    expect(aliasToolInput({ filePath: "/a" }, OPENCODE)).toEqual({
+      filePath: "/a",
+      file_path: "/a",
+    });
+  });
+});

--- a/src/adapters/shared/reducer-helpers.ts
+++ b/src/adapters/shared/reducer-helpers.ts
@@ -1,4 +1,5 @@
 import type { ChatItem } from "../types";
+import { asRecord } from "./json";
 
 // Walk from the end since the items we care about (latest streaming
 // agent_message, latest tool_call) are always near the tail.
@@ -126,4 +127,26 @@ export function dedupAgainstLast(
     return items;
   }
   return [...items, candidate];
+}
+
+/** Alias tool-input fields so the shared Read/Write/Edit presenters — which
+ *  read Claude's snake_case names (`file_path`, `old_string`, …) — render
+ *  correctly for agents that use different field names. For each
+ *  `[from, to]` pair, copies a string `from` value to `to` when `to` isn't
+ *  already set. Returns the input untouched (same reference) when there's
+ *  nothing to alias, so callers can pass through non-file tools (e.g. bash's
+ *  `command`) for free. */
+export function aliasToolInput(
+  input: unknown,
+  aliases: ReadonlyArray<readonly [from: string, to: string]>,
+): unknown {
+  const rec = asRecord(input);
+  let out: Record<string, unknown> | null = null;
+  for (const [from, to] of aliases) {
+    if (typeof rec[from] === "string" && rec[to] === undefined) {
+      out = out ?? { ...rec };
+      out[to] = rec[from];
+    }
+  }
+  return out ?? input;
 }


### PR DESCRIPTION
## What & why

Pi and OpenCode each inlined the same tool-input field aliasing: copy a string field to its Claude-snake_case name so the shared Read/Write/Edit presenters render without bespoke per-agent code.

- Pi: `path` → `file_path`
- OpenCode: `filePath`/`oldString`/`newString` → snake_case

OpenCode's loop was literally the general form; Pi's was a one-entry special case of it. This is item #9 from the multi-agent audit (the small DRY cleanup).

## Change

Pull the mechanism into one helper next to the other tool-call helpers:

```ts
// shared/reducer-helpers.ts
export function aliasToolInput(
  input: unknown,
  aliases: ReadonlyArray<readonly [from: string, to: string]>,
): unknown
```

Each adapter keeps a thin `normalizeToolInput` wrapper holding its own alias list + rationale, so **call sites and per-agent docs are unchanged** — only the shared mechanism moves:

```ts
// pi
const normalizeToolInput = (i) => aliasToolInput(i, [["path", "file_path"]]);
// opencode
const normalizeToolInput = (i) => aliasToolInput(i, [["filePath","file_path"], ...]);
```

## Verification
- `tsc --noEmit` clean
- `vitest` — **75/75** pass (existing pi/opencode reduce tests cover the behavior end-to-end; **+6** focused unit tests for the helper: passthrough returns the same reference, no-overwrite of an already-set target, non-string source ignored)

Net: +85 / −22 (most of which is the new test file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)