### PR TITLE
Make SQLite the canonical, robust agent history store

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -22,7 +22,7 @@ import { DEFAULT_PROVIDER_ID } from "./data/providers";
 import { commandsFor } from "./data/slashCommands";
 import { getAdapter, type ChatItem, type RawEvent } from "./adapters";
 import { getAllSettings, setSetting } from "./storage/settings";
-import { deleteMessages, insertMessage, listMessages } from "./storage/messages";
+import { countMessages, insertMessage, listMessages } from "./storage/messages";
 import { messageRowFor, messagesToChatItems } from "./storage/transcript";
 import {
   getOrCreateAccount,
@@ -416,25 +416,33 @@ function extractInputTokens(ev: RawEvent): number | undefined {
   return typeof n === "number" && n > 0 ? n : undefined;
 }
 
-/** Persist a chat log to our own sqlite (replace-all per agent). This is
- *  the provider-agnostic history store: it survives restart even for
- *  agents whose own on-disk transcript we can't read (e.g. cursor).
- *  Fire-and-forget — errors are logged, not surfaced. */
-async function persistTranscript(agentId: string, items: ChatItem[]): Promise<void> {
-  if (items.length === 0) return;
+/** Append newly-finalized chat items to our sqlite history store — the
+ *  canonical, provider-agnostic record that survives restart for every
+ *  provider, including those whose own on-disk transcript we can't read.
+ *
+ *  Append-only and crash-safe: the stored row count is the high-water mark,
+ *  so we only insert items beyond what's already persisted. No destructive
+ *  replace-all, so a partial write just resumes next time, and cost is O(new
+ *  items) per turn rather than O(whole log). Safe because chat items finalize
+ *  *within* a turn — by the time this runs (turn-end / archive) every item up
+ *  to that point is immutable, so appending the tail can't miss an edit to the
+ *  prefix. Fire-and-forget — errors are logged, not surfaced. */
+const persistInFlight = new Set<string>();
+
+async function persistHistory(agentId: string): Promise<void> {
+  if (persistInFlight.has(agentId)) return;
+  persistInFlight.add(agentId);
   try {
-    await deleteMessages(agentId);
-    for (let i = 0; i < items.length; i++) {
+    const items = useAppStore.getState().managedLogs[agentId] ?? [];
+    const persisted = await countMessages(agentId);
+    for (let i = persisted; i < items.length; i++) {
       await insertMessage(messageRowFor(items[i], i, agentId));
     }
   } catch (e) {
-    console.warn("[persistTranscript] failed for", agentId, e);
+    console.warn("[persistHistory] failed for", agentId, e);
+  } finally {
+    persistInFlight.delete(agentId);
   }
-}
-
-/** Snapshot an agent's current in-memory chat log to sqlite. */
-async function captureTranscript(agentId: string): Promise<void> {
-  await persistTranscript(agentId, useAppStore.getState().managedLogs[agentId] ?? []);
 }
 
 /** Names already taken by real or draft agents — passed to the backend
@@ -667,11 +675,11 @@ export const useAppStore = create<AppState>((set, get) => ({
               : state.managedBusy,
       }));
 
-      // A turn just ended — snapshot the (now-complete) log to sqlite so
-      // history survives restart for every provider, including those whose
-      // own on-disk store we can't read (cursor).
+      // A turn just ended — append the (now-finalized) new items to sqlite
+      // so history survives restart for every provider, including those
+      // whose own on-disk store we can't read (cursor).
       if (e.status === "idle") {
-        void captureTranscript(e.agent_id);
+        void persistHistory(e.agent_id);
       }
     });
 
@@ -866,7 +874,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   archive: async (id) => {
     try {
-      await captureTranscript(id);
+      await persistHistory(id);
       await api.archiveAgent(id);
       clearOutputBuffer(id);
       const fresh = await api.getWorkspace();
@@ -924,23 +932,37 @@ export const useAppStore = create<AppState>((set, get) => ({
       transcriptLoading: { ...s.transcriptLoading, [id]: true },
     }));
     try {
-      const rawLines = await api.readSessionTranscript(id);
-      const adapter = getAdapter(providerFor(get(), id));
-      const events = adapter.normalizeTranscript(rawLines);
-      let items: ChatItem[] = [];
-      for (const ev of events) {
-        items = adapter.reduce(items, ev);
-      }
-      // Fall back to our own persisted history when the agent's on-disk
-      // transcript is unavailable (e.g. cursor, whose store we can't read).
-      // This is provider-agnostic: it's whatever we last rendered + saved.
+      // SQLite is the canonical history store — restore from it first.
+      // It's provider-agnostic (whatever we rendered + persisted) and works
+      // for every agent, including those whose own on-disk store we can't read.
+      let items = messagesToChatItems(await listMessages(id));
+
+      // First open of an agent whose history predates the SQLite store (an
+      // existing claude/codex agent), seed it from the agent's native on-disk
+      // transcript and persist that, so future restores — and every other
+      // provider — come from SQLite uniformly. Agents without a readable
+      // native transcript (cursor/opencode/pi) get an empty seed and rely on
+      // live capture going forward.
       if (items.length === 0) {
-        items = messagesToChatItems(await listMessages(id));
+        const rawLines = await api.readSessionTranscript(id);
+        if (rawLines.length > 0) {
+          const adapter = getAdapter(providerFor(get(), id));
+          const events = adapter.normalizeTranscript(rawLines);
+          let imported: ChatItem[] = [];
+          for (const ev of events) {
+            imported = adapter.reduce(imported, ev);
+          }
+          if (imported.length > 0) {
+            items = imported;
+            for (let i = 0; i < imported.length; i++) {
+              await insertMessage(messageRowFor(imported[i], i, id));
+            }
+          }
+        }
       }
       set((state) => {
-        // If the on-disk JSONL produced nothing but we have an active
-        // in-memory turn, leave the log alone — claude hasn't flushed
-        // yet and we don't want to erase a turn that's still in flight.
+        // If we found nothing stored but a live turn is already rendering,
+        // leave it alone — don't erase a turn that's still in flight.
         if (items.length === 0 && (state.managedLogs[id]?.length ?? 0) > 0) {
           return {};
         }
@@ -1106,7 +1128,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     try {
       await api.mergePr(agentId);
       // pr:state_changed event will update prStates
-      void captureTranscript(agentId);
+      void persistHistory(agentId);
     } catch (e) {
       set({ lastError: String(e) });
     }


### PR DESCRIPTION
## What & why

History already lived in a provider-agnostic SQLite `messages` table that round-trips all chat-item kinds for **every** agent — but it was only a **fallback** (the agent's native on-disk transcript was tried first), and it was written **replace-all on every turn-end** (O(n²) over a session, and a crash after the `DELETE` wiped the whole log).

This is item #6 from the multi-agent audit — the "all agent history in SQLite, restorable at any point" goal.

## Changes (frontend)

**1. SQLite-canonical restore.** `loadHistoryTranscript` reads the stored history **first**. Only when it's empty does it **seed** from the agent's native on-disk transcript (claude/codex): read → `normalizeTranscript` → `reduce`, then persist into SQLite. So existing agents migrate transparently and every provider restores from one uniform path thereafter. Agents without a readable native transcript (cursor/opencode/pi) rely on live capture going forward.

**2. Append-only, crash-safe persistence.** `persistHistory` replaces the replace-all `persistTranscript`: the stored row count is the high-water mark, and only items beyond it are inserted.
- No destructive `DELETE` → a partial write just resumes next time.
- O(new items) per turn, not O(whole log).
- Safe because chat items finalize *within* a turn — by turn-end (or archive) the persisted prefix is immutable, so appending the tail can't miss a prefix edit.
- New agents start at count 0 (append all); existing agents are loaded before any turn, so the count matches the loaded log. Never deletes, so it can't corrupt or duplicate existing history.

Call sites (idle turn-end / archive / mergePr) now call `persistHistory`.

## Scope / future hardening (deliberately out)

Not re-architecting to **raw-event sourcing** (persist every provider event, replay through `reduce`) or moving capture into the **Rust backend**. The reduced `messages` store already round-trips losslessly, keeps volume low, and reuses the existing TS reduce pipeline; event-sourcing would mean re-implementing reduce in Rust plus a heavier migration. Noted as future hardening.

## Verification
- `tsc --noEmit` clean
- `vitest` — 69/69 pass (existing transcript round-trip test covers the serialize/deserialize of all item kinds)

Persistence/restore is integration-level (no DB test harness in the repo); the pure serialization is unit-tested in `storage/transcript.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)