### PR TITLE
Fix Codex shell `(no command)` label and surface Codex thinking

### DIFF
--- a/src/adapters/codex/policy.ts
+++ b/src/adapters/codex/policy.ts
@@ -1,12 +1,13 @@
 import type { DisplayPolicy } from "../types";
 
-// Mirrors claudePolicy for now. Diverges when real codex output reveals
-// agent-specific notice categories worth surfacing or hiding.
+// Codex is the one agent whose stream already carries reasoning items
+// (reduce.ts emits `notice:reasoning`), so we surface its thinking. Other
+// adapters keep reasoning hidden until their reducers capture it too.
 export const codexPolicy: DisplayPolicy = {
   "notice:turn_end": "hide",
   "notice:hook_output": "hide",
   "notice:info": "show",
-  "notice:reasoning": "hide",
+  "notice:reasoning": "show",
   "notice:slash_command": "show",
   "notice:error": "show",
 };

--- a/src/adapters/codex/reduce.test.ts
+++ b/src/adapters/codex/reduce.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { codexAdapter } from "./index";
+import { applyPolicy } from "../policy";
 import type { ChatItem, RawEvent } from "../types";
 
 // Fixtures are real `codex exec --json` output captured from
@@ -188,5 +189,26 @@ describe("codexAdapter", () => {
   it("exposes id and policy on the adapter", () => {
     expect(codexAdapter.id).toBe("codex");
     expect(codexAdapter.policy["notice:turn_end"]).toBe("hide");
+  });
+
+  it("surfaces reasoning as a thinking notice (not hidden by policy)", () => {
+    const items = run([
+      {
+        type: "item.completed",
+        item: { id: "r1", type: "reasoning", text: "Let me think…" },
+      } as RawEvent,
+    ]);
+    expect(items).toContainEqual({
+      kind: "notice",
+      subtype: "reasoning",
+      text: "Let me think…",
+    });
+    // And the display policy keeps it visible.
+    const visible = applyPolicy(items, codexAdapter.policy);
+    expect(visible).toContainEqual({
+      kind: "notice",
+      subtype: "reasoning",
+      text: "Let me think…",
+    });
   });
 });

--- a/src/components/Workspace/messages/presenters/index.test.ts
+++ b/src/components/Workspace/messages/presenters/index.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import { PRESENTERS, getPresenter } from "./index";
 import { defaultPresenter } from "./default";
+import { bashPresenter } from "./Bash";
+import type { ToolCall } from "./types";
+
+const toolCall = (input: unknown): ToolCall =>
+  ({ kind: "tool_call", id: "x", name: "shell", input }) as ToolCall;
 
 describe("getPresenter", () => {
   it("matches canonical Claude names", () => {
@@ -21,5 +26,32 @@ describe("getPresenter", () => {
 
   it("falls back to the default presenter for unknown tools", () => {
     expect(getPresenter("someNovelTool")).toBe(defaultPresenter);
+  });
+});
+
+describe("bashPresenter.summary", () => {
+  // Claude's `Bash` hands over an object input; Codex/Cursor `shell` hand over
+  // the command as a bare value. All three must render the command, not the
+  // "(no command)" fallback.
+  it("renders Claude's { command } object shape", () => {
+    expect(bashPresenter.summary(toolCall({ command: "ls -la" }), null)).toBe(
+      "ls -la",
+    );
+  });
+
+  it("renders Codex/Cursor's bare command string", () => {
+    expect(bashPresenter.summary(toolCall("/bin/zsh -lc 'echo hi'"), null)).toBe(
+      "/bin/zsh -lc 'echo hi'",
+    );
+  });
+
+  it("renders a bare argv array", () => {
+    expect(
+      bashPresenter.summary(toolCall(["bash", "-lc", "echo hi"]), null),
+    ).toBe("bash -lc echo hi");
+  });
+
+  it("falls back to (no command) when there is genuinely no command", () => {
+    expect(bashPresenter.summary(toolCall({}), null)).toBe("(no command)");
   });
 });

--- a/src/components/Workspace/messages/presenters/util.tsx
+++ b/src/components/Workspace/messages/presenters/util.tsx
@@ -109,10 +109,13 @@ export function getStringField(input: unknown, field: string): string {
   return "";
 }
 
-/** Read a shell command from a tool input, accepting both Claude's `Bash`
- *  shape (`command` is a string) and Codex's `shell` shape (`command` is an
- *  argv array like ["bash", "-lc", "…"]). */
+/** Read a shell command from a tool input. Handles every shape adapters
+ *  produce: Claude's `Bash` wraps it in a `{ command }` object, while Codex
+ *  and Cursor hand over the command as a bare value — either a string or an
+ *  argv array like ["bash", "-lc", "…"]. */
 export function getCommandField(input: unknown, field = "command"): string {
+  if (typeof input === "string") return input;
+  if (Array.isArray(input)) return input.map((part) => String(part)).join(" ");
   if (input && typeof input === "object" && field in input) {
     const v = (input as Record<string, unknown>)[field];
     if (typeof v === "string") return v;


### PR DESCRIPTION
The Bash presenter rendered Codex/Cursor shell calls as `(no command)` because `getCommandField` only read `command` from an object, while those adapters hand the command over as a bare string/argv; it now accepts bare values too, fixing both agents at the shared presenter choke-point. This also flips Codex's `notice:reasoning` display policy to `show` — Codex is the one agent whose reducer already captures reasoning items and the "Thinking" render path already exists, so its thinking now surfaces with no other changes. Added tests cover the presenter's input shapes and that Codex reasoning survives the display policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)