### PR TITLE
Fix Cursor glob/read/edit tool labels via input aliasing

### DIFF
--- a/src/adapters/cursor/reduce.test.ts
+++ b/src/adapters/cursor/reduce.test.ts
@@ -93,6 +93,84 @@ describe("cursorAdapter", () => {
     ]);
   });
 
+  // Cursor names file-tool args differently from Claude (globPattern,
+  // targetDirectory, path, streamContent). The reducer aliases them to the
+  // snake_case fields the shared presenters read, so glob/read/edit don't
+  // render "(no pattern)"/"(no path)". Events captured from cursor-agent
+  // 2026.06.03.
+  it("aliases glob/read/edit tool args to the presenters' field names", () => {
+    const items = run([
+      {
+        type: "tool_call",
+        subtype: "completed",
+        call_id: "g1",
+        tool_call: {
+          globToolCall: {
+            args: { targetDirectory: "/repo/src", globPattern: "*.txt" },
+            result: { success: { files: ["sample.txt"], totalFiles: 1 } },
+          },
+        },
+      },
+      {
+        type: "tool_call",
+        subtype: "completed",
+        call_id: "r1",
+        tool_call: {
+          readToolCall: {
+            args: { path: "/repo/src/sample.txt" },
+            result: { success: { content: "hi\n", totalLines: 1 } },
+          },
+        },
+      },
+      {
+        type: "tool_call",
+        subtype: "completed",
+        call_id: "e1",
+        tool_call: {
+          editToolCall: {
+            args: { path: "/repo/src/note.md", streamContent: "bye" },
+            result: { success: {} },
+          },
+        },
+      },
+    ] as RawEvent[]);
+
+    const calls = items.filter((i) => i.kind === "tool_call");
+    expect(calls).toEqual([
+      {
+        kind: "tool_call",
+        id: "g1",
+        name: "glob",
+        input: {
+          targetDirectory: "/repo/src",
+          globPattern: "*.txt",
+          pattern: "*.txt",
+          path: "/repo/src",
+        },
+        streaming: false,
+      },
+      {
+        kind: "tool_call",
+        id: "r1",
+        name: "read",
+        input: { path: "/repo/src/sample.txt", file_path: "/repo/src/sample.txt" },
+        streaming: false,
+      },
+      {
+        kind: "tool_call",
+        id: "e1",
+        name: "edit",
+        input: {
+          path: "/repo/src/note.md",
+          file_path: "/repo/src/note.md",
+          streamContent: "bye",
+          new_string: "bye",
+        },
+        streaming: false,
+      },
+    ]);
+  });
+
   it("exposes id and reuses Claude's policy", () => {
     expect(cursorAdapter.id).toBe("cursor");
     expect(cursorAdapter.policy["notice:turn_end"]).toBe("hide");

--- a/src/adapters/cursor/reduce.ts
+++ b/src/adapters/cursor/reduce.ts
@@ -13,8 +13,23 @@
 
 import type { ChatItem, RawEvent } from "../types";
 import { asRecord } from "../shared/json";
-import { upsertToolCall } from "../shared/reducer-helpers";
+import { aliasToolInput, upsertToolCall } from "../shared/reducer-helpers";
 import { reduce as claudeReduce } from "../claude/reduce";
+
+/** Cursor names its file-tool fields differently from Claude — glob uses
+ *  `globPattern`/`targetDirectory`, read/edit use `path`, edit carries the new
+ *  content in `streamContent`. Alias them to the snake_case names the shared
+ *  Glob/Read/Edit presenters read, so they render the pattern/path/diff
+ *  instead of "(no pattern)"/"(no path)". (Grep already uses `pattern`/`path`,
+ *  and shell goes through the command-string branch — both untouched.) */
+function normalizeToolInput(input: unknown): unknown {
+  return aliasToolInput(input, [
+    ["globPattern", "pattern"],
+    ["targetDirectory", "path"],
+    ["path", "file_path"],
+    ["streamContent", "new_string"],
+  ]);
+}
 
 /** Pull a renderable (name, input) out of Cursor's typed tool_call payload.
  *  The payload is a single-key object like `{shellToolCall: {args, result}}`. */
@@ -28,8 +43,12 @@ function toolCallParts(ev: RawEvent): {
   const inner = asRecord(tc[key]);
   const name = key.replace(/ToolCall$/, "") || "tool";
   const args = asRecord(inner.args);
-  // Shell calls read best as the command string; other tools show their args.
-  const input = typeof args.command === "string" ? args.command : (inner.args ?? {});
+  // Shell calls read best as the command string; other tools show their args
+  // (with field names aliased to what the shared presenters expect).
+  const input =
+    typeof args.command === "string"
+      ? args.command
+      : normalizeToolInput(inner.args ?? {});
   return { name, input, inner };
 }
 


### PR DESCRIPTION
Cursor agent tool calls displayed as `glob (no pattern)` and `read (no path)` because Cursor names its file-tool args differently from Claude (`globPattern`, `targetDirectory`, `path`, `streamContent`) while the shared Glob/Read/Edit presenters read Claude's snake_case names. This aliases those fields to `pattern`/`path`/`file_path`/`new_string` in the Cursor reducer, mirroring the existing OpenCode/Pi adapters, so glob/read/edit render their pattern, path, and diff correctly. Field names were confirmed against real `cursor-agent 2026.06.03` output, and a test built from those captured events is included. Codex was verified to have no equivalent issue (its file ops are shell commands, already handled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)