### PR TITLE
Fix initial user message duplicated on conversation reopen

### DIFF
--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -734,11 +734,41 @@ impl Supervisor {
         text: &str,
         attachments: &[String],
     ) -> Result<()> {
-        // Record the user turn as a provider-agnostic canonical event before
-        // sending to the agent, so it's logged ahead of the response. This is
-        // persist-only: the frontend renders the user message optimistically
-        // on send, and replays this event through the reducer on restore — so
-        // it must not be emitted live (that would double-render).
+        self.deliver_user_message(agent_id, text, attachments)?;
+        mark_user_turn_started(&self, app, agent_id);
+        on_first_user_message(self.clone(), app.clone(), agent_id.to_string(), text.to_string());
+        Ok(())
+    }
+
+    /// Deliver a user turn to the running agent, then persist it as the
+    /// provider-agnostic canonical `user_message` event.
+    ///
+    /// Order matters: we persist *after* the agent has accepted the message,
+    /// never before. A freshly spawned agent isn't in the in-memory map yet,
+    /// so a send aimed at it fails with `AgentNotFound`; the frontend retries
+    /// until the agent is ready (`sendWhenAgentReady`). Persisting up front
+    /// would record one duplicate `user_message` event per failed retry, and
+    /// those surface as the same prompt rendered N times when the conversation
+    /// is replayed from history on reopen.
+    ///
+    /// Persist-only: the frontend renders the user message optimistically on
+    /// send and replays this event through the reducer on restore, so it must
+    /// not be emitted live (that would double-render). It still lands ahead of
+    /// the response — `send_user_message` only queues the write, so the agent's
+    /// own events arrive (and persist) strictly later.
+    fn deliver_user_message(
+        &self,
+        agent_id: &str,
+        text: &str,
+        attachments: &[String],
+    ) -> Result<()> {
+        {
+            let agents = self.agents.lock();
+            let agent = agents
+                .get(agent_id)
+                .ok_or_else(|| Error::AgentNotFound(agent_id.to_string()))?;
+            agent.send_user_message(text, attachments)?;
+        }
         let user_event = serde_json::json!({
             "type": "user_message",
             "text": text,
@@ -747,15 +777,6 @@ impl Supervisor {
         if let Err(e) = self.workspace.append_session_event(agent_id, &user_event) {
             tracing::warn!(error = %e, agent_id = %agent_id, "append user_message event failed");
         }
-        {
-            let agents = self.agents.lock();
-            let agent = agents
-                .get(agent_id)
-                .ok_or_else(|| Error::AgentNotFound(agent_id.to_string()))?;
-            agent.send_user_message(text, attachments)?;
-        }
-        mark_user_turn_started(&self, app, agent_id);
-        on_first_user_message(self.clone(), app.clone(), agent_id.to_string(), text.to_string());
         Ok(())
     }
 
@@ -2006,5 +2027,28 @@ mod tests {
             .lock()
             .insert("yosemite".to_string(), AgentStatus::Running);
         assert_eq!(sup.live_status("yosemite"), Some(AgentStatus::Running));
+    }
+
+    #[test]
+    fn delivery_to_unready_agent_persists_no_user_message() {
+        // A freshly spawned agent has a session row but isn't in the live
+        // agents map yet. The frontend retries the send until the agent is
+        // ready; if we persisted before delivery, every failed retry would
+        // record a duplicate user_message event and the prompt would render
+        // N times on reopen. Nothing must be persisted for a failed delivery.
+        let sup = test_supervisor();
+        let mut record = record_with_status("yosemite", AgentStatus::Spawning);
+        sup.workspace.add_agent(&mut record).unwrap();
+
+        let err = sup
+            .deliver_user_message("yosemite", "hello", &[])
+            .unwrap_err();
+        assert!(matches!(err, Error::AgentNotFound(_)));
+
+        let events = sup.workspace.read_session_events("yosemite").unwrap();
+        assert!(
+            events.is_empty(),
+            "failed delivery must not persist a user_message event, got {events:?}",
+        );
     }
 }

--- a/src/store.reduce.test.ts
+++ b/src/store.reduce.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { reduceStoredEvent } from "./store";
+import type { ChatItem, RawEvent } from "./adapters";
+
+/**
+ * Restore replays every persisted `session_events` row through
+ * `reduceStoredEvent`. Older histories can hold the same initial
+ * `user_message` event repeated — a send retried while the agent was still
+ * spawning used to persist one copy per attempt. Replay must collapse those
+ * so the prompt renders once, not N times.
+ */
+describe("reduceStoredEvent — user_message dedup", () => {
+  const userEvent = (text: string): RawEvent =>
+    ({ type: "user_message", text, attachments: [] }) as unknown as RawEvent;
+
+  it("collapses consecutive identical user_message events", () => {
+    let items: ChatItem[] = [];
+    for (let i = 0; i < 3; i += 1) {
+      items = reduceStoredEvent("claude", items, userEvent("read the readme"));
+    }
+    expect(items).toEqual([{ kind: "user_message", text: "read the readme" }]);
+  });
+
+  it("keeps distinct user_message events", () => {
+    let items: ChatItem[] = [];
+    items = reduceStoredEvent("claude", items, userEvent("first"));
+    items = reduceStoredEvent("claude", items, userEvent("second"));
+    expect(items).toEqual([
+      { kind: "user_message", text: "first" },
+      { kind: "user_message", text: "second" },
+    ]);
+  });
+
+  it("collapses consecutive identical passthrough slash-command notices", () => {
+    let items: ChatItem[] = [];
+    for (let i = 0; i < 3; i += 1) {
+      items = reduceStoredEvent("claude", items, userEvent("/compact"));
+    }
+    expect(items).toEqual([
+      { kind: "notice", subtype: "slash_command", text: "/compact" },
+    ]);
+  });
+});

--- a/src/store.ts
+++ b/src/store.ts
@@ -21,6 +21,7 @@ import {
 import { DEFAULT_PROVIDER_ID } from "./data/providers";
 import { commandsFor } from "./data/slashCommands";
 import { getAdapter, type ChatItem, type RawEvent } from "./adapters";
+import { dedupAgainstLast } from "./adapters/shared/reducer-helpers";
 import { getAllSettings, setSetting } from "./storage/settings";
 import {
   getOrCreateAccount,
@@ -365,7 +366,7 @@ function passthroughSlashName(
  *  send) is rendered here exactly as the optimistic live path renders it —
  *  so a restored conversation matches what was on screen. Every other event
  *  is a native provider event and goes through that provider's adapter. */
-function reduceStoredEvent(
+export function reduceStoredEvent(
   provider: string | undefined,
   prev: ChatItem[],
   rawEvent: RawEvent,
@@ -373,10 +374,29 @@ function reduceStoredEvent(
   if (rawEvent.type === "user_message") {
     const text = typeof rawEvent.text === "string" ? rawEvent.text : "";
     const slashName = passthroughSlashName(provider, text);
-    const entry: ChatItem = slashName
-      ? { kind: "notice", subtype: "slash_command", text: `/${slashName}` }
-      : { kind: "user_message", text };
-    return [...prev, entry];
+    // Dedup against the tail: older histories can hold the same user_message
+    // event repeated (a send retried while the agent was still spawning used
+    // to persist one copy per attempt). Collapsing consecutive identical
+    // entries renders the prompt once — matching how every adapter dedups its
+    // own user_message echoes via dedupAgainstLast.
+    if (slashName) {
+      const notice: ChatItem = {
+        kind: "notice",
+        subtype: "slash_command",
+        text: `/${slashName}`,
+      };
+      const last = prev[prev.length - 1];
+      if (
+        last &&
+        last.kind === "notice" &&
+        last.subtype === "slash_command" &&
+        last.text === notice.text
+      ) {
+        return prev;
+      }
+      return [...prev, notice];
+    }
+    return dedupAgainstLast(prev, { kind: "user_message", text });
   }
   try {
     return getAdapter(provider).reduce(prev, rawEvent);


### PR DESCRIPTION
The canonical `user_message` event was persisted in `send_user_message` *before* checking the agent existed, so on a freshly spawned agent the call persisted the event then returned `AgentNotFound` — and the frontend's `sendWhenAgentReady` retry loop re-ran it every 250ms, appending a duplicate per attempt (typically 3). Live view hid this via the optimistic render, but on reopen `loadHistoryTranscript` replayed every row and the synthetic `user_message` branch appended without dedup, rendering the prompt N times. This persists the event only after the agent accepts delivery (extracted into `deliver_user_message`), and dedups the synthetic event on replay via the shared `dedupAgainstLast` so already-corrupted histories also render once. Covered by a Rust test (no event persisted on failed delivery) and frontend tests for the replay dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)