### PR TITLE
Rest agents at Idle on boot; resume lazily instead of auto-spawning

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -125,19 +125,11 @@ pub fn run() {
 
             let workspace = Arc::new(WorkspaceManager::new(db));
             let supervisor = Arc::new(Supervisor::new(workspace));
-            app.manage(supervisor.clone());
+            app.manage(supervisor);
 
-            // Auto-resume any agent that was live before the previous
-            // shutdown. Runs on a tauri async task so we don't block
-            // app boot; events emit as they would for a manual spawn.
-            let app_handle = app.handle().clone();
-            tauri::async_runtime::spawn(async move {
-                // Tiny delay so the frontend has time to mount its
-                // event listeners and the workspace view before agents
-                // start emitting.
-                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-                supervisor.resume_persisted_agents(app_handle);
-            });
+            // Agents rest at Idle on boot — no process is spawned. The
+            // supervisor brings one up lazily on the user's next interaction
+            // (the frontend resumes on send), so nothing auto-spawns here.
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -103,8 +103,8 @@ pub struct Supervisor {
     pub activities: Mutex<HashMap<String, Box<dyn Activity>>>,
     /// In-memory source of truth for live runtime status
     /// (Spawning/Running/Idle). The DB only persists durable
-    /// dispositions, so a record loaded from it always derives `Spawning`
-    /// for a live agent; this map carries the real current status.
+    /// dispositions, so a resting record loaded from it derives `Idle`;
+    /// this map carries the real current status while an agent is live.
     pub statuses: Mutex<HashMap<String, AgentStatus>>,
     pub native_input_lines: Mutex<HashMap<String, String>>,
     pub shells: Mutex<HashMap<String, PtySession>>,
@@ -367,9 +367,9 @@ impl Supervisor {
 
     pub fn current_workspace(&self) -> Option<Workspace> {
         let mut ws = self.workspace.current()?;
-        // The DB-derived `status` reports `Spawning` for any live agent;
-        // overlay the supervisor's in-memory runtime status so the snapshot
-        // reflects the real Running/Idle/Spawning state.
+        // The DB-derived `status` rests at `Idle`; overlay the supervisor's
+        // in-memory runtime status so the snapshot reflects the real
+        // Spawning/Running/Idle state for any agent that's currently live.
         for record in &mut ws.agents {
             record.status = self.effective_status(&record.id, record);
         }
@@ -648,39 +648,6 @@ impl Supervisor {
         spawn_turn_watchdog(self.clone(), app, agent_id_str, my_gen);
 
         Ok(())
-    }
-
-    pub fn resume_persisted_agents(self: Arc<Self>, app: AppHandle) {
-        let agents = match self.workspace.current() {
-            Some(ws) => ws.agents,
-            None => return,
-        };
-
-        for record in agents {
-            if !matches!(record.status, AgentStatus::Spawning) {
-                continue;
-            }
-            // Per-turn agents legitimately have no session id until their
-            // first turn assigns one, so only treat a missing id as
-            // corruption for providers that generate it up front (claude).
-            let missing_session =
-                !is_per_turn_provider(&record.provider) && record.session_id.is_none();
-            if missing_session || record.repos.is_empty() {
-                let err = "Agent record incomplete (no session id / no repos). Remove and respawn.".to_string();
-                self.set_status(&app, &record.id, AgentStatus::Error, Some(err));
-                continue;
-            }
-
-            let sup = self.clone();
-            let app = app.clone();
-            let id = record.id.clone();
-            arm_spawn_timeout(sup.clone(), app.clone(), id.clone());
-            tauri::async_runtime::spawn(async move {
-                if let Err(e) = sup.start_process(&app, &id, false).await {
-                    fail_spawn(&sup, &app, &id, e.to_string());
-                }
-            });
-        }
     }
 
     pub async fn resume_agent(
@@ -1036,8 +1003,8 @@ impl Supervisor {
         self.set_status(&app, agent_id, AgentStatus::Spawning, None);
         let _ = app.emit("workspace:changed", ());
 
-        // Kick the resume path. start_process is the same one that
-        // resume_persisted_agents uses on app boot.
+        // Restore is an explicit user action, so bring the process up now
+        // (set_status(Spawning) above lets start_process promote to Idle).
         arm_spawn_timeout(self.clone(), app.clone(), agent_id.to_string());
         let sup = self.clone();
         let app_for_task = app.clone();

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -153,8 +153,10 @@ pub struct Workspace {
 /// Runtime status is not stored. Derive it from durable dispositions plus
 /// whether a live process currently exists (supervisor-supplied). At the
 /// storage layer `running` is always false (nothing is live mid-query), so a
-/// resting, non-stopped, non-errored workspace derives to `Spawning` — the
-/// auto-resume state that the old load-time reconciliation used to write.
+/// resting, non-stopped, non-errored agent derives to `Idle`: it has no live
+/// process and is not running a turn. A process is spawned lazily on the
+/// user's next interaction (the frontend resumes on send), so agents no
+/// longer auto-spawn at load.
 pub fn derive_status(
     archived: bool,
     stopped: bool,
@@ -170,7 +172,7 @@ pub fn derive_status(
     if last_error.is_some() {
         return AgentStatus::Error;
     }
-    AgentStatus::Spawning
+    AgentStatus::Idle
 }
 
 fn view_to_str(v: &AgentView) -> &'static str {
@@ -206,9 +208,9 @@ pub struct WorkspaceManager {
 impl WorkspaceManager {
     pub fn new(db: Arc<Mutex<Connection>>) -> Self {
         // Status is derived, not stored, so there is nothing to reconcile at
-        // load time: a resting, non-stopped, non-errored workspace already
-        // derives to `Spawning` (the supervisor's auto-resume state), while
-        // user-stopped workspaces keep their `stopped_at` and derive to
+        // load time: a resting, non-stopped, non-errored workspace derives to
+        // `Idle` (no live process; resumed lazily on the next interaction),
+        // while user-stopped workspaces keep their `stopped_at` and derive to
         // `Stopped` until the manual Resume button clears it.
         Self { db }
     }
@@ -469,14 +471,14 @@ impl WorkspaceManager {
 
     /// Clear archive metadata and re-seed `repos`. Clearing `archived_at`
     /// (with no `stopped_at`/error) makes the workspace derive back to
-    /// `Spawning`, so the supervisor's resume path picks the agent up.
+    /// `Idle`; the supervisor's restore path drives the live spawn explicitly.
     pub fn restore_agent(&self, id: &str, repos: Vec<TrackedRepo>) -> Result<()> {
         let conn = self.db.lock();
         Self::ensure_agent_exists(&conn, id)?;
 
-        // Clearing both dispositions (archived + user-stopped) is what the
-        // old `status = 'spawning'` write effectively meant: a freshly
-        // restored workspace should auto-resume, not stay stopped.
+        // Clearing both dispositions (archived + user-stopped) returns the
+        // record to its resting `Idle` state — a restored agent should be
+        // live-able again, not stuck Stopped.
         conn.execute(
             "UPDATE workspaces SET archived_at = NULL, stopped_at = NULL WHERE id = ?1",
             [id],
@@ -1178,7 +1180,7 @@ mod tests {
     }
 
     #[test]
-    fn persists_across_instances_and_reconciles_to_spawning_for_resume() {
+    fn persists_across_instances_and_rests_at_idle() {
         let db = test_db();
 
         // Seed repo paths so add_agent can look them up.
@@ -1191,7 +1193,7 @@ mod tests {
             let wm = WorkspaceManager::new(db.clone());
             wm.add_workspace_repo(repo.clone()).unwrap();
             // A resting agent has no durable disposition — it derives to
-            // `Spawning` (the auto-resume state) without any reconciliation.
+            // `Idle` (no live process, not running a turn).
             let mut running = new_agent_record(
                 "yosemite".into(),
                 "a".into(),
@@ -1218,7 +1220,7 @@ mod tests {
         }
 
         // Second instance — status is derived, so the resting agent comes
-        // back as Spawning and the stopped one stays Stopped.
+        // back as Idle and the stopped one stays Stopped.
         let wm2 = WorkspaceManager::new(db);
         let cur = wm2.current().unwrap();
         assert!(cur.repos.iter().any(|p| p == &repo));
@@ -1226,7 +1228,7 @@ mod tests {
 
         let yosemite = cur.agents.iter().find(|a| a.id == "yosemite").unwrap();
         let dolomites = cur.agents.iter().find(|a| a.id == "dolomites").unwrap();
-        assert_eq!(yosemite.status, AgentStatus::Spawning);
+        assert_eq!(yosemite.status, AgentStatus::Idle);
         assert_eq!(dolomites.status, AgentStatus::Stopped);
     }
 
@@ -1252,10 +1254,10 @@ mod tests {
             derive_status(false, false, true, Some("boom")),
             AgentStatus::Running
         );
-        // A resting, clean workspace derives to Spawning (auto-resume).
+        // A resting, clean workspace derives to Idle (lazy resume on send).
         assert_eq!(
             derive_status(false, false, false, None),
-            AgentStatus::Spawning
+            AgentStatus::Idle
         );
     }
 
@@ -1326,18 +1328,18 @@ mod tests {
         let id = rec.id.clone();
         wm.add_agent(&mut rec).unwrap();
 
-        // Fresh agent derives Spawning (no durable disposition).
-        assert_eq!(wm.agent(&id).unwrap().status, AgentStatus::Spawning);
+        // Fresh agent derives Idle (no durable disposition, no live process).
+        assert_eq!(wm.agent(&id).unwrap().status, AgentStatus::Idle);
 
         // Stopping stamps a durable disposition → derives Stopped.
         wm.update_agent_status(&id, AgentStatus::Stopped, None)
             .unwrap();
         assert_eq!(wm.agent(&id).unwrap().status, AgentStatus::Stopped);
 
-        // Resuming clears the stop disposition → back to Spawning.
+        // Resuming clears the stop disposition → back to Idle.
         wm.update_agent_status(&id, AgentStatus::Running, None)
             .unwrap();
-        assert_eq!(wm.agent(&id).unwrap().status, AgentStatus::Spawning);
+        assert_eq!(wm.agent(&id).unwrap().status, AgentStatus::Idle);
 
         // Recording an error surfaces as Error (no live process at rest).
         wm.update_agent_status(&id, AgentStatus::Error, Some("boom".into()))
@@ -1346,11 +1348,11 @@ mod tests {
         assert_eq!(a.status, AgentStatus::Error);
         assert_eq!(a.last_error.as_deref(), Some("boom"));
 
-        // Resuming again clears the error → back to Spawning.
+        // Resuming again clears the error → back to Idle.
         wm.update_agent_status(&id, AgentStatus::Spawning, None)
             .unwrap();
         let a = wm.agent(&id).unwrap();
-        assert_eq!(a.status, AgentStatus::Spawning);
+        assert_eq!(a.status, AgentStatus::Idle);
         assert!(a.last_error.is_none());
     }
 
@@ -1405,7 +1407,9 @@ mod tests {
         assert_eq!(arch.repos[0].diff_stats.additions, 12);
         assert_eq!(arch.repos[0].diff_stats.deletions, 3);
 
-        // Restore puts repos back and flips to Spawning
+        // Restore puts repos back and clears the archived/stopped
+        // disposition, so the record derives Idle. (The supervisor's
+        // restore path then drives the live spawn separately.)
         let restored = vec![TrackedRepo {
             repo_path: PathBuf::from("/some/repo"),
             subdir: "repo".into(),
@@ -1416,7 +1420,7 @@ mod tests {
         let a = wm.agent(&id).unwrap();
         assert!(a.archive.is_none());
         assert_eq!(a.repos.len(), 1);
-        assert_eq!(a.status, AgentStatus::Spawning);
+        assert_eq!(a.status, AgentStatus::Idle);
     }
 
     #[test]


### PR DESCRIPTION
On launch every persisted agent derived to `Spawning` and the supervisor eagerly auto-resumed each one, but the boot path never wrote `Spawning` into the in-memory status map — so neither the `start_process` Idle-promotion nor the 15s spawn timeout (both guarded on `Some(Spawning)`) ever fired, pinning every agent at Spawning indefinitely (yellow dot, Stop button, disabled composer, and a Stop that only worked for one agent). This changes `derive_status` to rest at `Idle` for a clean, non-stopped agent and drops the eager boot resume (`resume_persisted_agents` plus its setup task). Agents now come back `Idle` with no live process; the supervisor brings one up lazily on the user's next interaction via the existing resume-on-send path. Comments and the affected unit tests were updated to match; `cargo build`/`cargo test` (104 passing) are green.

Note: the native (PTY) view still needs a small follow-up (it can't render without a live process), and `restore_agent` intentionally still spawns eagerly since it's an explicit user action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)