### PR TITLE
Wire thinking budget picker to provider CLI flags

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -75,8 +75,8 @@ pub struct PerTurnDescriptor {
     bin: &'static str,
     /// Human-facing product name, used only in the not-found error.
     label: &'static str,
-    /// Builds the CLI args for a turn: `(prompt, resume_session_id)`.
-    build_args: fn(&str, Option<&str>) -> Vec<String>,
+    /// Builds the CLI args for a turn: `(prompt, resume_session_id, thinking_effort)`.
+    build_args: fn(&str, Option<&str>, Option<&str>) -> Vec<String>,
     /// Extracts the agent-assigned session id from a turn's events.
     session_id: fn(&Value) -> Option<String>,
     /// Constructs this agent's turn-end detector (custom-view `Activity`).
@@ -332,7 +332,7 @@ impl Agent {
         cb: ExecCallbacks<F, G, H>,
     ) -> Result<Self>
     where
-        A: Fn(&str, Option<&str>) -> Vec<String> + Send + Sync + 'static,
+        A: Fn(&str, Option<&str>, Option<&str>) -> Vec<String> + Send + Sync + 'static,
         I: Fn(&Value) -> Option<String> + Send + Sync + 'static,
         F: Fn(Value) + Send + Sync + 'static,
         G: Fn(String) + Send + Sync + 'static,
@@ -366,10 +366,10 @@ impl Agent {
         }
     }
 
-    pub fn send_user_message(&self, text: &str, attachments: &[String]) -> Result<()> {
+    pub fn send_user_message(&self, text: &str, attachments: &[String], thinking: Option<&str>) -> Result<()> {
         match self {
             Self::Managed(a) => a.session.send_user_message(text, attachments),
-            Self::PerTurn(a) => a.session.send_user_message(text, attachments),
+            Self::PerTurn(a) => a.session.send_user_message(text, attachments, thinking),
             Self::Pty(_) => Err(Error::Other(
                 "send_user_message called on pty agent".into(),
             )),
@@ -585,7 +585,7 @@ pub fn is_durable_event(provider: &str, ev: &Value) -> bool {
 /// workspace-write sandbox on, via `-c` (works on both `exec` and
 /// `exec resume`, unlike the `-s`/`-a` flags). Quorum does not wrap codex
 /// in sandbox-exec; codex sandboxes itself.
-fn codex_build_args(prompt: &str, session_id: Option<&str>) -> Vec<String> {
+fn codex_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = vec!["exec".into()];
     if let Some(id) = session_id {
         args.push("resume".into());
@@ -597,6 +597,10 @@ fn codex_build_args(prompt: &str, session_id: Option<&str>) -> Vec<String> {
     args.push("approval_policy=\"never\"".into());
     args.push("-c".into());
     args.push("sandbox_mode=\"workspace-write\"".into());
+    if let Some(effort) = thinking {
+        args.push("-c".into());
+        args.push(format!("reasoning_effort=\"{effort}\""));
+    }
     args.push(prompt.to_string());
     args
 }
@@ -616,7 +620,7 @@ fn codex_session_id(event: &Value) -> Option<String> {
 /// `--force` runs commands without approval prompts; `--trust` trusts the
 /// workspace in headless mode. Cursor's own sandbox applies; cwd comes from
 /// the child process working directory.
-fn cursor_build_args(prompt: &str, session_id: Option<&str>) -> Vec<String> {
+fn cursor_build_args(prompt: &str, session_id: Option<&str>, _thinking: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = vec![
         "-p".into(),
         "--output-format".into(),
@@ -654,7 +658,7 @@ fn cursor_session_id(event: &Value) -> Option<String> {
 /// 1.15.12. OpenCode runs in the child's cwd (no `--dir` needed) and assigns
 /// its own session id on the first turn. The prompt is positional and must
 /// come after the flags.
-fn opencode_build_args(prompt: &str, session_id: Option<&str>) -> Vec<String> {
+fn opencode_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = vec![
         "run".into(),
         "--format".into(),
@@ -664,6 +668,10 @@ fn opencode_build_args(prompt: &str, session_id: Option<&str>) -> Vec<String> {
         // opencode reducer and persisted via opencode_is_durable).
         "--thinking".into(),
     ];
+    if let Some(variant) = thinking {
+        args.push("--variant".into());
+        args.push(variant.to_string());
+    }
     if let Some(id) = session_id {
         args.push("--session".into());
         args.push(id.to_string());
@@ -690,8 +698,12 @@ fn opencode_session_id(event: &Value) -> Option<String> {
 /// it's the resume flag common to the versions we target — 0.74.x lacks
 /// `--session-id` entirely. Verified end-to-end against pi 0.74.2. Pi runs in
 /// the child's cwd; the prompt is positional and must come after the flags.
-fn pi_build_args(prompt: &str, session_id: Option<&str>) -> Vec<String> {
+fn pi_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = vec!["-p".into(), "--mode".into(), "json".into()];
+    if let Some(level) = thinking {
+        args.push("--thinking".into());
+        args.push(level.to_string());
+    }
     if let Some(id) = session_id {
         args.push("--session".into());
         args.push(id.to_string());
@@ -938,11 +950,38 @@ mod tests {
     #[test]
     fn opencode_args_request_thinking() {
         // Without --thinking, opencode emits no `reasoning` events at all.
-        let args = opencode_build_args("hi", None);
+        let args = opencode_build_args("hi", None, None);
         assert!(args.contains(&"--thinking".to_string()));
         assert!(args.contains(&"--format".to_string()));
         // Prompt is positional and last.
         assert_eq!(args.last().unwrap(), "hi");
+    }
+
+    #[test]
+    fn opencode_args_variant_when_thinking_set() {
+        let args = opencode_build_args("hi", None, Some("max"));
+        assert!(args.contains(&"--variant".to_string()));
+        assert!(args.contains(&"max".to_string()));
+    }
+
+    #[test]
+    fn codex_args_reasoning_effort_when_thinking_set() {
+        let args = codex_build_args("hi", None, Some("high"));
+        assert!(args.contains(&"reasoning_effort=\"high\"".to_string()));
+    }
+
+    #[test]
+    fn pi_args_thinking_when_set() {
+        let args = pi_build_args("hi", None, Some("xhigh"));
+        assert!(args.contains(&"--thinking".to_string()));
+        assert!(args.contains(&"xhigh".to_string()));
+    }
+
+    #[test]
+    fn cursor_args_ignores_thinking() {
+        let with_none = cursor_build_args("hi", None, None);
+        let with_some = cursor_build_args("hi", None, Some("high"));
+        assert_eq!(with_none, with_some);
     }
 
     // ── descriptor table ──────────────────────────────────────────────────

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -118,9 +118,10 @@ pub fn send_user_message(
     agent_id: String,
     text: String,
     attachments: Vec<String>,
+    thinking: Option<String>,
 ) -> Result<()> {
     let sup = supervisor.inner().clone();
-    sup.send_user_message(&app, &agent_id, &text, &attachments)
+    sup.send_user_message(&app, &agent_id, &text, &attachments, thinking.as_deref())
 }
 
 #[tauri::command]

--- a/src-tauri/src/exec_session.rs
+++ b/src-tauri/src/exec_session.rs
@@ -31,7 +31,7 @@ use crate::error::{Error, Result};
 type EventCb = Arc<dyn Fn(Value) + Send + Sync>;
 type SessionIdCb = Arc<dyn Fn(String) + Send + Sync>;
 type ExitCb = Arc<dyn Fn(bool) + Send + Sync>;
-type ArgsBuilder = Arc<dyn Fn(&str, Option<&str>) -> Vec<String> + Send + Sync>;
+type ArgsBuilder = Arc<dyn Fn(&str, Option<&str>, Option<&str>) -> Vec<String> + Send + Sync>;
 type IdExtractor = Arc<dyn Fn(&Value) -> Option<String> + Send + Sync>;
 
 pub struct ExecSpawn {
@@ -75,7 +75,7 @@ impl ExecSession {
         cb: ExecCallbacks<F, G, H>,
     ) -> Self
     where
-        A: Fn(&str, Option<&str>) -> Vec<String> + Send + Sync + 'static,
+        A: Fn(&str, Option<&str>, Option<&str>) -> Vec<String> + Send + Sync + 'static,
         I: Fn(&Value) -> Option<String> + Send + Sync + 'static,
         F: Fn(Value) + Send + Sync + 'static,
         G: Fn(String) + Send + Sync + 'static,
@@ -95,7 +95,7 @@ impl ExecSession {
         }
     }
 
-    pub fn send_user_message(&self, text: &str, attachments: &[String]) -> Result<()> {
+    pub fn send_user_message(&self, text: &str, attachments: &[String], thinking: Option<&str>) -> Result<()> {
         // Claim this turn's sequence number first, so a superseded turn's
         // reap thread sees it's no longer current and stays quiet.
         let seq = self.turn_seq.fetch_add(1, Ordering::SeqCst) + 1;
@@ -120,7 +120,7 @@ impl ExecSession {
 
         let args = {
             let id = self.session_id.lock();
-            (self.build_args)(&prompt, id.as_deref())
+            (self.build_args)(&prompt, id.as_deref(), thinking)
         };
         let mut cmd = Command::new(&self.program);
         cmd.args(&args);
@@ -292,7 +292,7 @@ mod tests {
     }
 
     // A codex-style config: id from `thread.started`, end on `turn.completed`.
-    fn codex_args(prompt: &str, session_id: Option<&str>) -> Vec<String> {
+    fn codex_args(prompt: &str, session_id: Option<&str>, _thinking: Option<&str>) -> Vec<String> {
         let mut a = vec!["exec".to_string()];
         if let Some(id) = session_id {
             a.push("resume".into());
@@ -346,7 +346,7 @@ mod tests {
             },
         );
 
-        session.send_user_message("hello", &[]).unwrap();
+        session.send_user_message("hello", &[], None).unwrap();
 
         let mut events = Vec::new();
         let deadline = Instant::now() + Duration::from_secs(5);
@@ -395,7 +395,7 @@ mod tests {
             },
         );
 
-        session.send_user_message("again", &[]).unwrap();
+        session.send_user_message("again", &[], None).unwrap();
         erx.recv_timeout(Duration::from_secs(5)).unwrap();
         let args = std::fs::read_to_string(dir.path().join("argv.txt")).unwrap();
         assert!(args.contains("exec resume prev-thread"), "argv was: {args}");

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -700,8 +700,9 @@ impl Supervisor {
         agent_id: &str,
         text: &str,
         attachments: &[String],
+        thinking: Option<&str>,
     ) -> Result<()> {
-        self.deliver_user_message(agent_id, text, attachments)?;
+        self.deliver_user_message(agent_id, text, attachments, thinking)?;
         mark_user_turn_started(&self, app, agent_id);
         on_first_user_message(self.clone(), app.clone(), agent_id.to_string(), text.to_string());
         Ok(())
@@ -728,13 +729,14 @@ impl Supervisor {
         agent_id: &str,
         text: &str,
         attachments: &[String],
+        thinking: Option<&str>,
     ) -> Result<()> {
         {
             let agents = self.agents.lock();
             let agent = agents
                 .get(agent_id)
                 .ok_or_else(|| Error::AgentNotFound(agent_id.to_string()))?;
-            agent.send_user_message(text, attachments)?;
+            agent.send_user_message(text, attachments, thinking)?;
         }
         let user_event = serde_json::json!({
             "type": "user_message",
@@ -2008,7 +2010,7 @@ mod tests {
         sup.workspace.add_agent(&mut record).unwrap();
 
         let err = sup
-            .deliver_user_message("yosemite", "hello", &[])
+            .deliver_user_message("yosemite", "hello", &[], None)
             .unwrap_err();
         assert!(matches!(err, Error::AgentNotFound(_)));
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -225,8 +225,8 @@ export const api = {
     invoke<AgentRecord>("spawn_agent", { view, repoPath, provider, name }),
   writeToAgent: (agentId: string, data: string) =>
     invoke<void>("write_to_agent", { agentId, data }),
-  sendUserMessage: (agentId: string, text: string, attachments: string[] = []) =>
-    invoke<void>("send_user_message", { agentId, text, attachments }),
+  sendUserMessage: (agentId: string, text: string, attachments: string[] = [], thinking?: string) =>
+    invoke<void>("send_user_message", { agentId, text, attachments, thinking: thinking ?? null }),
   resizeAgent: (agentId: string, cols: number, rows: number) =>
     invoke<void>("resize_agent", { agentId, cols, rows }),
   switchView: (agentId: string, view: AgentView) =>

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useAppStore } from "../../store";
 import { DEFAULT_PROVIDER_ID } from "../../data/providers";
+import { PROVIDER_DETAIL } from "../../data/providerDetail";
 import { filterCommands, type SlashCommand } from "../../data/slashCommands";
 import { Icon } from "../Icon";
 import { Chip } from "../ui/Chip";
@@ -9,8 +10,6 @@ import { ModelPicker } from "./ModelPicker";
 import { SlashMenu } from "./SlashMenu";
 import { AttachmentList } from "./AttachmentList";
 import { useFileDrop } from "./useFileDrop";
-
-type ThinkingBudget = "low" | "medium" | "high";
 
 interface Props {
   /** Initial provider id — defaults to claude. */
@@ -28,7 +27,9 @@ interface Props {
   onSend: (payload: {
     text: string;
     provider: string;
-    thinking: ThinkingBudget;
+    /** Raw effort value for the selected provider, or undefined when the
+     *  provider has no thinking levels (e.g. Cursor). */
+    thinking: string | undefined;
     attachments: string[];
   }) => void;
   /** Fired when the composer is showing an active stop control. */
@@ -55,8 +56,18 @@ export function Composer({
 
   const [text, setText] = useState("");
   const [provider, setProvider] = useState(defaultProvider);
-  const [thinking, setThinking] = useState<ThinkingBudget>("high");
   const [attachments, setAttachments] = useState<string[]>([]);
+
+  const thinkingLevels = PROVIDER_DETAIL[provider as keyof typeof PROVIDER_DETAIL]?.thinkingLevels ?? [];
+  const defaultThinking = thinkingLevels.at(-1)?.value; // highest by default
+  const [thinkingValue, setThinkingValue] = useState<string | undefined>(defaultThinking);
+
+  // Reset to the new provider's highest level when switching providers.
+  useEffect(() => {
+    setThinkingValue(
+      (PROVIDER_DETAIL[provider as keyof typeof PROVIDER_DETAIL]?.thinkingLevels ?? []).at(-1)?.value
+    );
+  }, [provider]);
   const [slashDismissed, setSlashDismissed] = useState(false);
   const [slashIndex, setSlashIndex] = useState(0);
   const ta = useRef<HTMLTextAreaElement>(null);
@@ -107,7 +118,7 @@ export function Composer({
       return;
     }
     if ((!trimmed && attachments.length === 0) || disabled) return;
-    onSend({ text: trimmed, provider, thinking, attachments });
+    onSend({ text: trimmed, provider, thinking: thinkingValue, attachments });
     setText("");
     setAttachments([]);
     if (ta.current) ta.current.style.height = "auto";
@@ -210,17 +221,17 @@ export function Composer({
       />
       <div className="composer-foot">
         <ModelPicker value={provider} onChange={setProvider} />
-        {features.thinkingBudget && (
+        {features.thinkingBudget && thinkingLevels.length > 0 && (
           <Chip
             tip="Thinking budget"
-            onClick={() =>
-              setThinking((t) =>
-                t === "high" ? "medium" : t === "medium" ? "low" : "high",
-              )
-            }
+            onClick={() => {
+              const idx = thinkingLevels.findIndex((l) => l.value === thinkingValue);
+              const next = thinkingLevels[(idx + 1) % thinkingLevels.length];
+              setThinkingValue(next.value);
+            }}
           >
             <Icon name="sparkle" size={11} />
-            <span style={{ textTransform: "capitalize" }}>{thinking}</span>
+            <span>{thinkingLevels.find((l) => l.value === thinkingValue)?.label ?? ""}</span>
           </Chip>
         )}
         {features.autoEdit && (

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -126,7 +126,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
                   : "Agent is not ready"
           }
           stopping={busy}
-          onSend={({ text, attachments }) => send(agent.id, text, attachments)}
+          onSend={({ text, thinking, attachments }) => send(agent.id, text, attachments, thinking)}
           onStop={() => stop(agent.id)}
         />
       </div>

--- a/src/components/Workspace/EmptyWorkspace.tsx
+++ b/src/components/Workspace/EmptyWorkspace.tsx
@@ -88,8 +88,8 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
             defaultProvider={draft.provider}
             baseBranch={draft.base}
             placeholder="Describe the task for the agent. ↵ to spawn."
-            onSend={({ text, provider, attachments }) =>
-              spawnFromDraft(draft.id, text, provider, attachments)
+            onSend={({ text, provider, attachments, thinking }) =>
+              spawnFromDraft(draft.id, text, provider, attachments, thinking)
             }
           />
           <div className="empty-meta">

--- a/src/data/providerDetail.ts
+++ b/src/data/providerDetail.ts
@@ -7,6 +7,12 @@
 
 import type { ProviderId } from "./providers";
 
+export interface ThinkingLevel {
+  label: string;
+  /** Raw value passed verbatim to the provider CLI flag. */
+  value: string;
+}
+
 export interface ProviderDetail {
   /** Fallback binary path, shown before the live probe resolves. */
   path: string;
@@ -14,6 +20,9 @@ export interface ProviderDetail {
   models: string;
   /** Detected & configured on this machine — drives the "Installed" list. */
   installed: boolean;
+  /** Thinking/reasoning effort levels supported by this provider's CLI.
+   *  Empty means the provider has no effort flag — the picker hides. */
+  thinkingLevels: ThinkingLevel[];
 }
 
 export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
@@ -21,16 +30,28 @@ export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
     path: "/opt/homebrew/bin/claude",
     models: "Opus 4.7 · Sonnet 4.6 · Haiku 4",
     installed: true,
+    // Claude's `--effort` is a session-level spawn flag, not per-message.
+    // Wiring it requires threading effort through spawn_agent — tracked as
+    // a follow-up. No picker shown until then.
+    thinkingLevels: [],
   },
   codex: {
     path: "~/.codex/bin/codex",
     models: "GPT-5.2-codex · o4-mini",
     installed: true,
+    // `codex exec -c reasoning_effort="<value>"`
+    thinkingLevels: [
+      { label: "Low",  value: "low"    },
+      { label: "Med",  value: "medium" },
+      { label: "High", value: "high"   },
+    ],
   },
   cursor: {
     path: "/Applications/Cursor.app/…/cursor-agent",
     models: "Composer · Auto",
     installed: true,
+    // Cursor encodes effort in model names — no standalone flag.
+    thinkingLevels: [],
   },
   antigravity: {
     path: "/Applications/Antigravity.app/…/antigravity",
@@ -38,16 +59,31 @@ export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
     // No adapter/runner yet — kept out of the Installed list and gated as
     // "coming soon" in the picker. Flip to true once it's wired end-to-end.
     installed: false,
+    thinkingLevels: [],
   },
   opencode: {
     path: "~/.opencode/bin/opencode",
     models: "Routed via upstream provider",
     installed: true,
+    // `opencode run --variant <value>`
+    thinkingLevels: [
+      { label: "Low",  value: "minimal" },
+      { label: "High", value: "high"    },
+      { label: "Max",  value: "max"     },
+    ],
   },
   pi: {
     path: "~/.pi/bin/pi",
     models: "Pi · experimental",
     installed: true,
+    // `pi --thinking <value>`
+    thinkingLevels: [
+      { label: "Off",   value: "off"    },
+      { label: "Low",   value: "low"    },
+      { label: "Med",   value: "medium" },
+      { label: "High",  value: "high"   },
+      { label: "xHigh", value: "xhigh" },
+    ],
   },
 };
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -285,6 +285,7 @@ interface AppState {
     id: string,
     text: string,
     attachments?: string[],
+    thinking?: string,
   ) => Promise<void>;
   switchView: (id: string, view: AgentView) => Promise<void>;
   resume: (id: string) => Promise<void>;
@@ -309,6 +310,7 @@ interface AppState {
     text: string,
     provider: string,
     attachments?: string[],
+    thinking?: string,
   ) => Promise<void>;
 
   // UI
@@ -785,7 +787,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     }
   },
 
-  sendUserMessage: async (id, text, attachments = []) => {
+  sendUserMessage: async (id, text, attachments = [], thinking) => {
     try {
       set((state) => {
         const slashName = passthroughSlashName(providerFor(state, id), text);
@@ -805,14 +807,14 @@ export const useAppStore = create<AppState>((set, get) => ({
         };
       });
       try {
-        await api.sendUserMessage(id, text, attachments);
+        await api.sendUserMessage(id, text, attachments, thinking);
       } catch (e) {
         if (String(e).includes("agent not found")) {
           // Dead idle agent (finished its prior task) — resume the
           // process in --resume mode, then deliver the message once ready.
           await api.resumeAgent(id);
           await sendWhenAgentReady(() =>
-            api.sendUserMessage(id, text, attachments),
+            api.sendUserMessage(id, text, attachments, thinking),
           );
         } else {
           throw e;
@@ -1189,7 +1191,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     }));
   },
 
-  spawnFromDraft: async (id, text, provider, attachments = []) => {
+  spawnFromDraft: async (id, text, provider, attachments = [], thinking?) => {
     const draft = get().drafts.find((d) => d.id === id);
     if (!draft) return;
     set({ busy: true, lastError: null });
@@ -1219,7 +1221,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         );
       } else {
         await sendWhenAgentReady(() =>
-          api.sendUserMessage(rec.id, text, attachments),
+          api.sendUserMessage(rec.id, text, attachments, thinking),
         );
       }
     } catch (e) {


### PR DESCRIPTION
## Summary

- Adds per-provider `thinkingLevels` config (label + raw CLI value) to `providerDetail.ts` — each entry maps directly to the provider's flag with no translation layer in Rust
- Composer chip reads the current provider's level list, cycles through options, hides when empty (Cursor, Claude), resets to highest level on provider switch
- Threads the selected value end-to-end: UI → store → IPC → `build_args` → CLI flag
  - **Codex**: `-c reasoning_effort="<value>"`
  - **OpenCode**: `--variant <value>` (alongside the existing `--thinking` flag)
  - **Pi**: `--thinking <value>`
  - **Cursor**: no-op (effort encoded in model names, no standalone flag)
  - **Claude**: deferred — `--effort` is a session-level spawn flag on a persistent `ManagedSession`; can't be changed per-message

## Test plan

- [ ] Send a message with Codex selected and each effort level; verify `-c reasoning_effort=` appears in the spawned process args
- [ ] Same for OpenCode (`--variant`) and Pi (`--thinking`)
- [ ] Switch from a provider with levels to Cursor — chip hides
- [ ] Switch providers — chip resets to highest level for the new provider
- [ ] Claude custom view — no chip shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)