### PR TITLE
Unify custom & native views on a canonical session_records store (PR1: all file-backed agents)

### DIFF
--- a/src-tauri/migrations/0002_session_records.sql
+++ b/src-tauri/migrations/0002_session_records.sql
@@ -1,0 +1,20 @@
+-- The canonical, per-agent verbatim session store. Each row is one durable
+-- record: a transcript line (Claude/Codex/Pi/Cursor), a reassembled blob
+-- (OpenCode), or a turn-end compiled entry (live-compiled agents). Bodies are
+-- stored verbatim in the agent's own shape and normalized on read by the
+-- per-provider adapter. Supersedes session_events (kept read-only for legacy
+-- sessions until a later cutover).
+CREATE TABLE session_records (
+    id            INTEGER PRIMARY KEY,
+    session_id    TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    seq           INTEGER NOT NULL,          -- per-session monotonic insert order
+    provider      TEXT NOT NULL,             -- denormalized from sessions for hot read
+    source        TEXT NOT NULL,             -- 'transcript' | 'live_compiled'
+    native_id     TEXT NOT NULL,             -- per-agent dedup key; positional 'ln:{n}' where no native id
+    agent_version TEXT,                       -- probed agent CLI version at ingest (nullable)
+    body          TEXT NOT NULL,             -- verbatim record JSON
+    created_at    INTEGER NOT NULL,          -- ms epoch (ingest time)
+    UNIQUE(session_id, seq),
+    UNIQUE(session_id, native_id)
+);
+CREATE INDEX idx_session_records_session_seq ON session_records(session_id, seq);

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -212,7 +212,10 @@ const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         // from the SQLite log until that's mapped.
         transcript_replay: false,
         is_durable: opencode_is_durable,
-        transcript: None,
+        transcript: Some(TranscriptReader {
+            locate: opencode_locate,
+            read: opencode_read,
+        }),
     },
     PerTurnDescriptor {
         id: "pi",
@@ -375,6 +378,83 @@ fn cursor_read(paths: &[PathBuf]) -> Vec<RawRecord> {
         .flat_map(|p| crate::supervisor::read_jsonl_values(p).unwrap_or_default())
         .collect();
     records_with_id(values, None)
+}
+
+// ── OpenCode ──
+// OpenCode stores a blob store under `$XDG_DATA_HOME/opencode/storage` (defaults
+// to `~/.local/share/opencode/storage`, even on macOS): message blobs at
+// `message/<ses>/<msg>.json` (role + metadata, no content) and part blobs at
+// `part/<msg>/<part>.json` (the content). We emit each message record then its
+// parts, in id order (ids are time-sortable); the frontend reassembles. ids are
+// globally unique, so they're the native dedup key.
+
+fn opencode_storage_root() -> Option<PathBuf> {
+    let base = std::env::var_os("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|h| h.join(".local/share")))?;
+    Some(base.join("opencode").join("storage"))
+}
+
+/// Sorted `*.json` files directly in `dir` (filenames are id-prefixed, so
+/// lexical sort == creation order).
+fn json_files_in(dir: &Path) -> Vec<PathBuf> {
+    let mut paths: Vec<PathBuf> = std::fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("json"))
+        .collect();
+    paths.sort();
+    paths
+}
+
+fn read_json_value(path: &Path) -> Option<Value> {
+    serde_json::from_str(&std::fs::read_to_string(path).ok()?).ok()
+}
+
+fn opencode_locate(session_id: &str, _cwd: &Path) -> Vec<PathBuf> {
+    let Some(root) = opencode_storage_root() else {
+        return Vec::new();
+    };
+    json_files_in(&root.join("message").join(session_id))
+}
+
+fn opencode_read(message_paths: &[PathBuf]) -> Vec<RawRecord> {
+    let mut out = Vec::new();
+    for msg_path in message_paths {
+        let Some(msg) = read_json_value(msg_path) else {
+            continue;
+        };
+        let Some(msg_id) = msg.get("id").and_then(|v| v.as_str()).map(str::to_string) else {
+            continue;
+        };
+        out.push(RawRecord {
+            native_id: msg_id.clone(),
+            body: msg,
+        });
+        // Parts live at `<storage>/part/<msg_id>/`; derive <storage> from the
+        // message path `<storage>/message/<ses>/<msg>.json` (three parents up).
+        let Some(part_dir) = msg_path
+            .parent()
+            .and_then(|p| p.parent())
+            .and_then(|p| p.parent())
+            .map(|storage| storage.join("part").join(&msg_id))
+        else {
+            continue;
+        };
+        for pf in json_files_in(&part_dir) {
+            if let Some(part) = read_json_value(&pf) {
+                if let Some(pid) = part.get("id").and_then(|v| v.as_str()) {
+                    out.push(RawRecord {
+                        native_id: pid.to_string(),
+                        body: part,
+                    });
+                }
+            }
+        }
+    }
+    out
 }
 
 /// The transcript reader for a provider, or `None` if it has no on-disk
@@ -1169,8 +1249,8 @@ mod tests {
         assert!(transcript_reader("pi").is_some());
         assert!(transcript_reader("codex").is_some());
         assert!(transcript_reader("cursor").is_some());
-        // Not yet wired / unknown.
-        assert!(transcript_reader("opencode").is_none());
+        assert!(transcript_reader("opencode").is_some());
+        // Unknown providers have none.
         assert!(transcript_reader("nope").is_none());
     }
 

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -171,8 +171,10 @@ const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         // frontend codex adapter replay it.
         transcript_replay: true,
         is_durable: codex_is_durable,
-        // session_records ingestion wired in a later commit.
-        transcript: None,
+        transcript: Some(TranscriptReader {
+            locate: codex_locate,
+            read: codex_read,
+        }),
     },
     PerTurnDescriptor {
         id: "cursor",
@@ -192,7 +194,10 @@ const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         // dedicated tool_call event (started/completed) rather than
         // Claude's assistant.content tool_use + user.content tool_result.
         is_durable: cursor_is_durable,
-        transcript: None,
+        transcript: Some(TranscriptReader {
+            locate: cursor_locate,
+            read: cursor_read,
+        }),
     },
     PerTurnDescriptor {
         id: "opencode",
@@ -323,6 +328,54 @@ static CLAUDE_TRANSCRIPT: TranscriptReader = TranscriptReader {
     locate: claude_locate,
     read: claude_read,
 };
+
+// ── Codex ──
+// Codex writes `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<id>.jsonl`.
+// Lines are `{timestamp,type,payload}` dual-channel with no stable per-line id,
+// so records key positionally. The codex frontend adapter already normalizes.
+fn codex_locate(session_id: &str, _cwd: &Path) -> Vec<PathBuf> {
+    crate::supervisor::find_codex_rollouts(session_id)
+}
+
+fn codex_read(paths: &[PathBuf]) -> Vec<RawRecord> {
+    let values: Vec<Value> = paths
+        .iter()
+        .flat_map(|p| crate::supervisor::read_jsonl_values(p).unwrap_or_default())
+        .collect();
+    records_with_id(values, None)
+}
+
+// ── Cursor ──
+// cursor-agent writes `~/.cursor/projects/<slug>/agent-transcripts/<id>/<id>.jsonl`.
+// The session-id dir is unique, so glob by it (like claude) rather than
+// reverse-engineering the undocumented slug. Lines have no per-line id →
+// positional keys.
+fn cursor_locate(session_id: &str, _cwd: &Path) -> Vec<PathBuf> {
+    let Some(home) = dirs::home_dir() else {
+        return Vec::new();
+    };
+    let rel = format!("agent-transcripts/{session_id}/{session_id}.jsonl");
+    let projects = home.join(".cursor").join("projects");
+    let mut out = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(&projects) {
+        for entry in entries.flatten() {
+            let path = entry.path().join(&rel);
+            if path.exists() {
+                out.push(path);
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
+fn cursor_read(paths: &[PathBuf]) -> Vec<RawRecord> {
+    let values: Vec<Value> = paths
+        .iter()
+        .flat_map(|p| crate::supervisor::read_jsonl_values(p).unwrap_or_default())
+        .collect();
+    records_with_id(values, None)
+}
 
 /// The transcript reader for a provider, or `None` if it has no on-disk
 /// transcript wired. Per-turn agents read theirs from the descriptor table;
@@ -1111,12 +1164,12 @@ mod tests {
 
     #[test]
     fn transcript_reader_dispatch() {
-        // Claude (persistent runner, not a per-turn agent) and Pi have readers.
+        // Claude (persistent runner, not a per-turn agent) + Pi/Codex/Cursor.
         assert!(transcript_reader("claude").is_some());
         assert!(transcript_reader("pi").is_some());
-        // Not yet wired (own commits) / unknown.
-        assert!(transcript_reader("codex").is_none());
-        assert!(transcript_reader("cursor").is_none());
+        assert!(transcript_reader("codex").is_some());
+        assert!(transcript_reader("cursor").is_some());
+        // Not yet wired / unknown.
         assert!(transcript_reader("opencode").is_none());
         assert!(transcript_reader("nope").is_none());
     }

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -95,6 +95,27 @@ pub struct PerTurnDescriptor {
     /// True if this event is a finalized/durable form worth persisting to
     /// session_events; false for ephemeral streaming/lifecycle events.
     pub is_durable: fn(&Value) -> bool,
+    /// Reader for this agent's on-disk transcript, used by `sync_session` to
+    /// ingest verbatim records into `session_records`. `None` = no readable
+    /// transcript yet (or a live-compiled agent).
+    pub transcript: Option<TranscriptReader>,
+}
+
+/// One verbatim durable record from an agent's transcript: the raw body in the
+/// agent's own shape plus a stable per-record dedup key (`native_id`).
+#[derive(Debug, Clone)]
+pub struct RawRecord {
+    pub native_id: String,
+    pub body: Value,
+}
+
+/// How to find and parse a provider's on-disk transcript into ordered records.
+pub struct TranscriptReader {
+    /// Ordered transcript artifact paths for a session (empty if none / not
+    /// yet flushed). Multiple paths concatenate in order (resume can split).
+    pub locate: fn(session_id: &str, cwd: &Path) -> Vec<PathBuf>,
+    /// Parse located artifacts into ordered verbatim records.
+    pub read: fn(paths: &[PathBuf]) -> Vec<RawRecord>,
 }
 
 /// What an agent can do *right now*. These are rollout flags, not fixed
@@ -150,6 +171,8 @@ const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         // frontend codex adapter replay it.
         transcript_replay: true,
         is_durable: codex_is_durable,
+        // session_records ingestion wired in a later commit.
+        transcript: None,
     },
     PerTurnDescriptor {
         id: "cursor",
@@ -169,6 +192,7 @@ const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         // dedicated tool_call event (started/completed) rather than
         // Claude's assistant.content tool_use + user.content tool_result.
         is_durable: cursor_is_durable,
+        transcript: None,
     },
     PerTurnDescriptor {
         id: "opencode",
@@ -183,6 +207,7 @@ const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         // from the SQLite log until that's mapped.
         transcript_replay: false,
         is_durable: opencode_is_durable,
+        transcript: None,
     },
     PerTurnDescriptor {
         id: "pi",
@@ -193,10 +218,14 @@ const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         session_id: pi_session_id,
         activity: || Box::new(ManagedActivity::pi()),
         native_view: true,
-        // Pi persists a `session.jsonl` that's wireable later; restore from
-        // the SQLite log until then.
+        // Pi persists a per-session JSONL whose lines match its live event
+        // shape; `pi_*` read it into session_records (the reference reader).
         transcript_replay: false,
         is_durable: pi_is_durable,
+        transcript: Some(TranscriptReader {
+            locate: pi_locate,
+            read: pi_read,
+        }),
     },
 ];
 
@@ -205,6 +234,68 @@ const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
 /// Pty/Managed runners) or isn't a known agent at all.
 pub fn per_turn_descriptor(id: &str) -> Option<&'static PerTurnDescriptor> {
     PER_TURN_AGENTS.iter().find(|d| d.id == id)
+}
+
+// ── Transcript readers ──────────────────────────────────────────────────────
+
+/// Build ordered `RawRecord`s from a parsed JSONL stream. `native_id` is the
+/// value's `id_field` (a string) when present, else a positional `ln:{i}` key
+/// over the global stream offset — stable across append-only multi-file reads.
+pub fn records_with_id(values: Vec<Value>, id_field: Option<&str>) -> Vec<RawRecord> {
+    values
+        .into_iter()
+        .enumerate()
+        .map(|(i, body)| {
+            let native_id = id_field
+                .and_then(|f| body.get(f))
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+                .unwrap_or_else(|| format!("ln:{i}"));
+            RawRecord { native_id, body }
+        })
+        .collect()
+}
+
+/// JSONL files directly in `dir` whose filename ends with `suffix`, sorted
+/// lexically (filenames are timestamp-prefixed, so lexical == chronological).
+fn jsonl_files_ending(dir: &Path, suffix: &str) -> Vec<PathBuf> {
+    let mut paths: Vec<PathBuf> = std::fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.ends_with(suffix))
+        })
+        .collect();
+    paths.sort();
+    paths
+}
+
+/// Pi's session-dir slug: cwd with `/` → `-`, wrapped in `--…--`.
+/// `/Users/alex/Code/amux` → `--Users-alex-Code-amux--`. Dots are preserved.
+fn pi_session_slug(cwd: &Path) -> String {
+    format!("-{}--", cwd.to_string_lossy().replace('/', "-"))
+}
+
+fn pi_locate(session_id: &str, cwd: &Path) -> Vec<PathBuf> {
+    let Some(home) = dirs::home_dir() else {
+        return Vec::new();
+    };
+    let dir = home.join(".pi/agent/sessions").join(pi_session_slug(cwd));
+    // Files are `<ts>_<session_id>.jsonl`.
+    jsonl_files_ending(&dir, &format!("_{session_id}.jsonl"))
+}
+
+fn pi_read(paths: &[PathBuf]) -> Vec<RawRecord> {
+    let values: Vec<Value> = paths
+        .iter()
+        .flat_map(|p| crate::supervisor::read_jsonl_values(p).unwrap_or_default())
+        .collect();
+    // Pi's JSONL lines carry a stable `id`.
+    records_with_id(values, Some("id"))
 }
 
 pub struct SpawnSpec<'a> {
@@ -977,6 +1068,78 @@ fn parse_semver(s: &str) -> Option<String> {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    // ── transcript readers ────────────────────────────────────────────────
+
+    #[test]
+    fn pi_slug_wraps_cwd_with_dashes() {
+        assert_eq!(
+            pi_session_slug(Path::new("/Users/alex/Code/amux")),
+            "--Users-alex-Code-amux--"
+        );
+        // Dots are preserved (unlike Cursor) — only slashes are replaced.
+        assert_eq!(
+            pi_session_slug(Path::new("/Users/alex/.quorum/worktrees/balkhash/agent")),
+            "--Users-alex-.quorum-worktrees-balkhash-agent--"
+        );
+    }
+
+    #[test]
+    fn records_with_id_uses_id_field_when_present() {
+        let values = vec![json!({"id": "abc", "v": 1}), json!({"id": "def", "v": 2})];
+        let recs = records_with_id(values, Some("id"));
+        assert_eq!(recs[0].native_id, "abc");
+        assert_eq!(recs[1].native_id, "def");
+        assert_eq!(recs[0].body, json!({"id": "abc", "v": 1}));
+    }
+
+    #[test]
+    fn records_with_id_positional_fallback_is_global() {
+        // First line has an id, second doesn't; the positional index is the
+        // global stream offset, not reset per missing line.
+        let values = vec![json!({"id": "abc"}), json!({"no_id": true})];
+        let recs = records_with_id(values, Some("id"));
+        assert_eq!(recs[0].native_id, "abc");
+        assert_eq!(recs[1].native_id, "ln:1");
+    }
+
+    #[test]
+    fn records_with_id_none_field_is_all_positional() {
+        let values = vec![json!({"a": 1}), json!({"a": 2})];
+        let recs = records_with_id(values, None);
+        assert_eq!(recs[0].native_id, "ln:0");
+        assert_eq!(recs[1].native_id, "ln:1");
+    }
+
+    #[test]
+    fn jsonl_files_ending_filters_and_sorts() {
+        let td = tempfile::tempdir().unwrap();
+        let dir = td.path();
+        std::fs::write(dir.join("2026-06-04T19-10-20Z_sess-1.jsonl"), "{}").unwrap();
+        std::fs::write(dir.join("2026-06-04T08-00-00Z_sess-1.jsonl"), "{}").unwrap();
+        std::fs::write(dir.join("2026-06-04T09-00-00Z_other.jsonl"), "{}").unwrap();
+        std::fs::write(dir.join("notes.txt"), "x").unwrap();
+
+        let found = jsonl_files_ending(dir, "_sess-1.jsonl");
+        let names: Vec<String> = found
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        // Only the two matching files, sorted lexically (== chronological here).
+        assert_eq!(
+            names,
+            vec![
+                "2026-06-04T08-00-00Z_sess-1.jsonl".to_string(),
+                "2026-06-04T19-10-20Z_sess-1.jsonl".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn missing_dir_yields_no_files() {
+        let td = tempfile::tempdir().unwrap();
+        assert!(jsonl_files_ending(&td.path().join("nope"), "_x.jsonl").is_empty());
+    }
 
     // ── is_durable_event ──────────────────────────────────────────────────
 

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -469,6 +469,38 @@ pub fn transcript_reader(provider: &str) -> Option<&'static TranscriptReader> {
     }
 }
 
+/// (binary, human label) for a provider, or `None` if unknown. Same dispatch
+/// as `transcript_reader`: per-turn descriptors + the claude special case.
+fn provider_bin_label(provider: &str) -> Option<(&'static str, &'static str)> {
+    match per_turn_descriptor(provider) {
+        Some(d) => Some((d.bin, d.label)),
+        None if provider == "claude" => Some(("claude", "Claude Code")),
+        None => None,
+    }
+}
+
+/// The probed CLI version for a provider (`v1.2.3`), memoized per process so the
+/// `--version` subprocess runs at most once per provider. Stamped onto
+/// session_records at ingest so read-time normalizers can branch by version
+/// when a vendor format changes. `None` if the binary is missing/unparseable.
+pub fn cached_provider_version(provider: &str) -> Option<String> {
+    static CACHE: std::sync::OnceLock<
+        parking_lot::Mutex<std::collections::HashMap<String, Option<String>>>,
+    > = std::sync::OnceLock::new();
+    let cache = CACHE.get_or_init(|| parking_lot::Mutex::new(std::collections::HashMap::new()));
+    if let Some(v) = cache.lock().get(provider) {
+        return v.clone();
+    }
+    let version = provider_bin_label(provider).and_then(|(bin, label)| {
+        let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
+        resolve_agent_bin(bin, label, &home)
+            .ok()
+            .and_then(|p| probe_version(&p))
+    });
+    cache.lock().insert(provider.to_string(), version.clone());
+    version
+}
+
 pub struct SpawnSpec<'a> {
     pub agent_id: &'a str,
     /// Claude's working directory — the primary repo's worktree.
@@ -1241,6 +1273,14 @@ mod tests {
     use serde_json::json;
 
     // ── transcript readers ────────────────────────────────────────────────
+
+    #[test]
+    fn provider_bin_label_dispatch() {
+        assert_eq!(provider_bin_label("claude"), Some(("claude", "Claude Code")));
+        assert!(provider_bin_label("codex").is_some());
+        assert!(provider_bin_label("pi").is_some());
+        assert!(provider_bin_label("nope").is_none());
+    }
 
     #[test]
     fn transcript_reader_dispatch() {

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -298,6 +298,44 @@ fn pi_read(paths: &[PathBuf]) -> Vec<RawRecord> {
     records_with_id(values, Some("id"))
 }
 
+// ── Claude ──
+// Claude is the lone persistent-runner agent (not in PER_TURN_AGENTS), launched
+// `--session-id <uuid>` / `--resume <uuid>`, so it writes
+// `~/.claude/projects/<slug>/<uuid>.jsonl`. find_session_jsonl already locates
+// it (the existing transcript_replay path). Content lines carry a top-level
+// `uuid`; metadata lines (mode/permission-mode/…) don't → positional fallback.
+
+fn claude_locate(session_id: &str, _cwd: &Path) -> Vec<PathBuf> {
+    crate::supervisor::find_session_jsonl(session_id)
+        .into_iter()
+        .collect()
+}
+
+fn claude_read(paths: &[PathBuf]) -> Vec<RawRecord> {
+    let values: Vec<Value> = paths
+        .iter()
+        .flat_map(|p| crate::supervisor::read_jsonl_values(p).unwrap_or_default())
+        .collect();
+    records_with_id(values, Some("uuid"))
+}
+
+static CLAUDE_TRANSCRIPT: TranscriptReader = TranscriptReader {
+    locate: claude_locate,
+    read: claude_read,
+};
+
+/// The transcript reader for a provider, or `None` if it has no on-disk
+/// transcript wired. Per-turn agents read theirs from the descriptor table;
+/// claude (persistent runner) is special-cased here. Callers gate on this, not
+/// on the provider id.
+pub fn transcript_reader(provider: &str) -> Option<&'static TranscriptReader> {
+    match per_turn_descriptor(provider) {
+        Some(d) => d.transcript.as_ref(),
+        None if provider == "claude" => Some(&CLAUDE_TRANSCRIPT),
+        None => None,
+    }
+}
+
 pub struct SpawnSpec<'a> {
     pub agent_id: &'a str,
     /// Claude's working directory — the primary repo's worktree.
@@ -1070,6 +1108,18 @@ mod tests {
     use serde_json::json;
 
     // ── transcript readers ────────────────────────────────────────────────
+
+    #[test]
+    fn transcript_reader_dispatch() {
+        // Claude (persistent runner, not a per-turn agent) and Pi have readers.
+        assert!(transcript_reader("claude").is_some());
+        assert!(transcript_reader("pi").is_some());
+        // Not yet wired (own commits) / unknown.
+        assert!(transcript_reader("codex").is_none());
+        assert!(transcript_reader("cursor").is_none());
+        assert!(transcript_reader("opencode").is_none());
+        assert!(transcript_reader("nope").is_none());
+    }
 
     #[test]
     fn pi_slug_wraps_cwd_with_dashes() {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -211,6 +211,14 @@ pub fn read_session_events(
 }
 
 #[tauri::command]
+pub fn read_session_records(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+) -> Result<Vec<crate::workspace::SessionRecord>> {
+    supervisor.workspace.read_session_records(&agent_id)
+}
+
+#[tauri::command]
 pub async fn add_repo_to_agent(
     supervisor: State<'_, Arc<Supervisor>>,
     app: AppHandle,

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -31,6 +31,7 @@ fn validate_column(col: &str) -> Result<()> {
 fn get_migrations() -> Migrations<'static> {
     Migrations::new(vec![
         M::up(include_str!("../migrations/0001_initial_schema.sql")),
+        M::up(include_str!("../migrations/0002_session_records.sql")),
     ])
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -156,6 +156,7 @@ pub fn run() {
             commands::restore_agent,
             commands::read_session_transcript,
             commands::read_session_events,
+            commands::read_session_records,
             commands::add_repo_to_agent,
             commands::allocate_draft_name,
             commands::get_git_state,

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -1316,9 +1316,19 @@ pub(crate) fn find_session_jsonl(session_id: &str) -> Option<PathBuf> {
 /// `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<id>.jsonl` (CODEX_HOME
 /// defaults to `~/.codex`); the id suffix is the thread id we captured.
 fn find_codex_rollout(session_id: &str) -> Option<PathBuf> {
-    let home = std::env::var_os("CODEX_HOME")
+    find_codex_rollouts(session_id).into_iter().next()
+}
+
+/// All of codex's rollout files for a thread id, ordered (filenames are
+/// timestamp-prefixed, so lexical sort == chronological). Resume normally keeps
+/// one file per session, but returning all is correct if it ever splits.
+pub(crate) fn find_codex_rollouts(session_id: &str) -> Vec<PathBuf> {
+    let Some(home) = std::env::var_os("CODEX_HOME")
         .map(PathBuf::from)
-        .or_else(|| dirs::home_dir().map(|h| h.join(".codex")))?;
+        .or_else(|| dirs::home_dir().map(|h| h.join(".codex")))
+    else {
+        return Vec::new();
+    };
     // Anchor on the `-<id>.jsonl` boundary (filenames are
     // `rollout-<ts>-<id>.jsonl`) so one thread id can't match another whose
     // name merely ends with the same characters.
@@ -1334,6 +1344,7 @@ fn find_codex_rollout(session_id: &str) -> Option<PathBuf> {
             .collect()
     }
     let sessions = home.join("sessions");
+    let mut out = Vec::new();
     for year in dirs_in(&sessions) {
         for month in dirs_in(&year) {
             for day in dirs_in(&month) {
@@ -1344,13 +1355,14 @@ fn find_codex_rollout(session_id: &str) -> Option<PathBuf> {
                         .and_then(|n| n.to_str())
                         .is_some_and(|n| n.ends_with(&suffix))
                     {
-                        return Some(path);
+                        out.push(path);
                     }
                 }
             }
         }
     }
-    None
+    out.sort();
+    out
 }
 
 /// Read a JSONL file into a vec of parsed values, skipping blank or

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -1136,55 +1136,14 @@ impl Supervisor {
         }
     }
 
-    /// Ingest the agent's on-disk transcript into `session_records`, idempotent
-    /// per `native_id`. Returns `None` if this provider has no transcript
-    /// reader wired (nothing to do, don't retry); otherwise `Some(n)` with the
-    /// number of *new* records inserted (`0` = reader ran but found nothing
-    /// yet — the file may not be flushed, or its location/format changed).
-    pub fn sync_session(&self, agent_id: &str) -> Option<usize> {
-        let record = self.workspace.agent(agent_id).ok()?;
-        let reader = per_turn_descriptor(&record.provider)?.transcript.as_ref()?;
-
-        // A reader exists; from here any shortfall is "nothing yet" → Some(0).
-        let Some(session_id) = record.session_id.as_deref() else {
-            return Some(0);
-        };
-        let Some(repo) = record.repos.first() else {
-            return Some(0);
-        };
-        let Ok(cwd) = repo_worktree_path(agent_id, &repo.subdir) else {
-            return Some(0);
-        };
-
-        let paths = (reader.locate)(session_id, &cwd);
-        let records = (reader.read)(&paths);
-
-        let mut inserted = 0usize;
-        for rec in &records {
-            match self.workspace.append_session_record(
-                agent_id,
-                &record.provider,
-                "transcript",
-                &rec.native_id,
-                None, // agent_version stamped in a later pass
-                &rec.body,
-            ) {
-                Ok(true) => inserted += 1,
-                Ok(false) => {}
-                Err(e) => {
-                    tracing::warn!(error = %e, agent_id, "append_session_record failed")
-                }
-            }
-        }
-        Some(inserted)
-    }
-
     /// Fire-and-forget transcript ingest at turn-end. Retries with backoff to
     /// ride out the agent's flush lag; emits `session:records-appended` when new
     /// records land. WARNs once if a reader-backed agent ingests nothing after
     /// all retries — the early signal that its transcript path/format changed.
-    pub fn trigger_session_sync(self: &Arc<Self>, app: AppHandle, agent_id: String) {
-        let sup = self.clone();
+    /// Called from `transition_active` whenever any agent reaches Idle, so it
+    /// covers managed, per-turn, and native turn-ends uniformly.
+    pub fn trigger_session_sync(&self, app: AppHandle, agent_id: String) {
+        let workspace = self.workspace.clone();
         tauri::async_runtime::spawn(async move {
             // Immediate attempt, then back off (ms) for flush lag.
             let backoffs = [0u64, 200, 400, 800, 1600];
@@ -1194,7 +1153,7 @@ impl Supervisor {
                 if wait > 0 {
                     tokio::time::sleep(Duration::from_millis(wait)).await;
                 }
-                match sup.sync_session(&agent_id) {
+                match sync_session_records(&workspace, &agent_id) {
                     None => return, // no transcript reader — nothing to do
                     Some(0) => had_reader = true,
                     Some(_) => {
@@ -1299,7 +1258,47 @@ impl Supervisor {
 /// for `<session-id>.jsonl`. Claude's path-encoding scheme isn't part
 /// of its public API, so we glob instead of recomputing the encoded
 /// directory name from the worktree path.
-fn find_session_jsonl(session_id: &str) -> Option<PathBuf> {
+/// Ingest the agent's on-disk transcript into `session_records`, idempotent per
+/// `native_id`. `None` = no transcript reader for this provider (skip, don't
+/// retry); `Some(n)` = reader ran, `n` new records inserted (`0` = nothing yet:
+/// file not flushed, or its location/format changed).
+fn sync_session_records(workspace: &WorkspaceManager, agent_id: &str) -> Option<usize> {
+    let record = workspace.agent(agent_id).ok()?;
+    let reader = crate::agent::transcript_reader(&record.provider)?;
+
+    // A reader exists; from here any shortfall is "nothing yet" → Some(0).
+    let Some(session_id) = record.session_id.as_deref() else {
+        return Some(0);
+    };
+    let Some(repo) = record.repos.first() else {
+        return Some(0);
+    };
+    let Ok(cwd) = repo_worktree_path(agent_id, &repo.subdir) else {
+        return Some(0);
+    };
+
+    let paths = (reader.locate)(session_id, &cwd);
+    let records = (reader.read)(&paths);
+
+    let mut inserted = 0usize;
+    for rec in &records {
+        match workspace.append_session_record(
+            agent_id,
+            &record.provider,
+            "transcript",
+            &rec.native_id,
+            None, // agent_version stamped in a later pass
+            &rec.body,
+        ) {
+            Ok(true) => inserted += 1,
+            Ok(false) => {}
+            Err(e) => tracing::warn!(error = %e, agent_id, "append_session_record failed"),
+        }
+    }
+    Some(inserted)
+}
+
+pub(crate) fn find_session_jsonl(session_id: &str) -> Option<PathBuf> {
     let home = dirs::home_dir()?;
     let projects = home.join(".claude").join("projects");
     let entries = std::fs::read_dir(&projects).ok()?;
@@ -1577,9 +1576,8 @@ fn spawn_per_turn_agent(
         // We don't surface non-success as Error: a user-initiated Stop
         // (SIGINT) is also non-success, and real agent errors are reported
         // in-band as events.
+        // Turn-end ingest fires from transition_active's Idle transition.
         transition_active(&sup_for_exit, &app_for_exit, &id_for_exit, AgentStatus::Idle);
-        // Ingest the just-completed turn's transcript into session_records.
-        sup_for_exit.trigger_session_sync(app_for_exit.clone(), id_for_exit.clone());
     };
 
     let spec = PerTurnSpec { cwd, session_id };
@@ -1868,6 +1866,11 @@ fn transition_active(
         sup.set_status(app, agent_id, new.clone(), None);
         if matches!(new, AgentStatus::Idle) {
             sup.fetch_and_emit_pr_state(app.clone(), agent_id.to_string());
+            // Turn ended (managed in-band, per-turn exit, or native silence all
+            // converge here). Ingest the just-written transcript into
+            // session_records. Idempotent + reader-gated, so it's a cheap no-op
+            // for agents without a reader.
+            sup.trigger_session_sync(app.clone(), agent_id.to_string());
         }
     }
 }

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -36,6 +36,11 @@ pub struct AgentEventPayload {
 }
 
 #[derive(Clone, serde::Serialize)]
+pub struct SessionRecordsAppendedPayload {
+    pub agent_id: String,
+}
+
+#[derive(Clone, serde::Serialize)]
 pub struct AgentStatusPayload {
     pub agent_id: String,
     pub status: AgentStatus,
@@ -1131,6 +1136,87 @@ impl Supervisor {
         }
     }
 
+    /// Ingest the agent's on-disk transcript into `session_records`, idempotent
+    /// per `native_id`. Returns `None` if this provider has no transcript
+    /// reader wired (nothing to do, don't retry); otherwise `Some(n)` with the
+    /// number of *new* records inserted (`0` = reader ran but found nothing
+    /// yet — the file may not be flushed, or its location/format changed).
+    pub fn sync_session(&self, agent_id: &str) -> Option<usize> {
+        let record = self.workspace.agent(agent_id).ok()?;
+        let reader = per_turn_descriptor(&record.provider)?.transcript.as_ref()?;
+
+        // A reader exists; from here any shortfall is "nothing yet" → Some(0).
+        let Some(session_id) = record.session_id.as_deref() else {
+            return Some(0);
+        };
+        let Some(repo) = record.repos.first() else {
+            return Some(0);
+        };
+        let Ok(cwd) = repo_worktree_path(agent_id, &repo.subdir) else {
+            return Some(0);
+        };
+
+        let paths = (reader.locate)(session_id, &cwd);
+        let records = (reader.read)(&paths);
+
+        let mut inserted = 0usize;
+        for rec in &records {
+            match self.workspace.append_session_record(
+                agent_id,
+                &record.provider,
+                "transcript",
+                &rec.native_id,
+                None, // agent_version stamped in a later pass
+                &rec.body,
+            ) {
+                Ok(true) => inserted += 1,
+                Ok(false) => {}
+                Err(e) => {
+                    tracing::warn!(error = %e, agent_id, "append_session_record failed")
+                }
+            }
+        }
+        Some(inserted)
+    }
+
+    /// Fire-and-forget transcript ingest at turn-end. Retries with backoff to
+    /// ride out the agent's flush lag; emits `session:records-appended` when new
+    /// records land. WARNs once if a reader-backed agent ingests nothing after
+    /// all retries — the early signal that its transcript path/format changed.
+    pub fn trigger_session_sync(self: &Arc<Self>, app: AppHandle, agent_id: String) {
+        let sup = self.clone();
+        tauri::async_runtime::spawn(async move {
+            // Immediate attempt, then back off (ms) for flush lag.
+            let backoffs = [0u64, 200, 400, 800, 1600];
+            let mut had_reader = false;
+            let mut inserted_any = false;
+            for wait in backoffs {
+                if wait > 0 {
+                    tokio::time::sleep(Duration::from_millis(wait)).await;
+                }
+                match sup.sync_session(&agent_id) {
+                    None => return, // no transcript reader — nothing to do
+                    Some(0) => had_reader = true,
+                    Some(_) => {
+                        inserted_any = true;
+                        break;
+                    }
+                }
+            }
+            if inserted_any {
+                let _ = app.emit(
+                    "session:records-appended",
+                    SessionRecordsAppendedPayload { agent_id },
+                );
+            } else if had_reader {
+                tracing::warn!(
+                    agent_id,
+                    "session sync ingested 0 records after retries (transcript not found or unchanged)"
+                );
+            }
+        });
+    }
+
     /// Fetch the current PR state for an agent's primary repo and emit
     /// a `pr:state_changed` event. Runs as a background task — never blocks the caller.
     pub fn fetch_and_emit_pr_state(&self, app: AppHandle, agent_id: String) {
@@ -1270,7 +1356,7 @@ fn find_codex_rollout(session_id: &str) -> Option<PathBuf> {
 
 /// Read a JSONL file into a vec of parsed values, skipping blank or
 /// unparseable lines.
-fn read_jsonl_values(path: &Path) -> Result<Vec<Value>> {
+pub(crate) fn read_jsonl_values(path: &Path) -> Result<Vec<Value>> {
     use std::io::BufRead;
     let file = std::fs::File::open(path)
         .map_err(|e| Error::Other(format!("open transcript: {e}")))?;
@@ -1492,6 +1578,8 @@ fn spawn_per_turn_agent(
         // (SIGINT) is also non-success, and real agent errors are reported
         // in-band as events.
         transition_active(&sup_for_exit, &app_for_exit, &id_for_exit, AgentStatus::Idle);
+        // Ingest the just-completed turn's transcript into session_records.
+        sup_for_exit.trigger_session_sync(app_for_exit.clone(), id_for_exit.clone());
     };
 
     let spec = PerTurnSpec { cwd, session_id };

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -1280,6 +1280,10 @@ fn sync_session_records(workspace: &WorkspaceManager, agent_id: &str) -> Option<
     let paths = (reader.locate)(session_id, &cwd);
     let records = (reader.read)(&paths);
 
+    // Version-frozen snapshot tag (memoized probe — at most one --version per
+    // provider per process).
+    let version = crate::agent::cached_provider_version(&record.provider);
+
     let mut inserted = 0usize;
     for rec in &records {
         match workspace.append_session_record(
@@ -1287,7 +1291,7 @@ fn sync_session_records(workspace: &WorkspaceManager, agent_id: &str) -> Option<
             &record.provider,
             "transcript",
             &rec.native_id,
-            None, // agent_version stamped in a later pass
+            version.as_deref(),
             &rec.body,
         ) {
             Ok(true) => inserted += 1,

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -201,6 +201,18 @@ fn now_millis() -> i64 {
 
 // ── WorkspaceManager ──────────────────────────────────────────────────────
 
+/// One canonical durable record from `session_records`, in the agent's own
+/// verbatim shape. Normalized into ChatItems on read by the per-provider adapter.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SessionRecord {
+    pub seq: i64,
+    pub provider: String,
+    pub source: String,
+    pub native_id: String,
+    pub agent_version: Option<String>,
+    pub body: serde_json::Value,
+}
+
 pub struct WorkspaceManager {
     db: Arc<Mutex<Connection>>,
 }
@@ -608,6 +620,103 @@ impl WorkspaceManager {
             .map(|text| {
                 serde_json::from_str(&text)
                     .map_err(|e| Error::Other(format!("deserialize event: {e}")))
+            })
+            .collect()
+    }
+
+    /// Append a canonical record to the workspace's current session. Idempotent
+    /// on `(session_id, native_id)`: a duplicate native_id is ignored and the
+    /// original row's body is retained. Returns `true` if a new row was
+    /// inserted, `false` if it was a duplicate or the workspace has no session.
+    pub fn append_session_record(
+        &self,
+        workspace_id: &str,
+        provider: &str,
+        source: &str,
+        native_id: &str,
+        agent_version: Option<&str>,
+        body: &serde_json::Value,
+    ) -> Result<bool> {
+        let conn = self.db.lock();
+
+        let sid: Option<String> = conn
+            .query_row(
+                "SELECT id FROM sessions WHERE workspace_id = ?1 ORDER BY created_at DESC LIMIT 1",
+                [workspace_id],
+                |r| r.get(0),
+            )
+            .ok();
+
+        let Some(sid) = sid else {
+            return Ok(false);
+        };
+
+        let body_json = serde_json::to_string(body)
+            .map_err(|e| Error::Other(format!("serialize record body: {e}")))?;
+
+        let tx = conn.unchecked_transaction()?;
+        let seq: i64 = tx.query_row(
+            "SELECT COALESCE(MAX(seq), 0) + 1 FROM session_records WHERE session_id = ?1",
+            [&sid],
+            |r| r.get(0),
+        )?;
+        let n = tx.execute(
+            "INSERT OR IGNORE INTO session_records
+                (session_id, seq, provider, source, native_id, agent_version, body, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            rusqlite::params![sid, seq, provider, source, native_id, agent_version, body_json, now_millis()],
+        )?;
+        tx.commit()?;
+
+        Ok(n > 0)
+    }
+
+    /// All canonical records for the workspace's current session, in seq order.
+    pub fn read_session_records(&self, workspace_id: &str) -> Result<Vec<SessionRecord>> {
+        let conn = self.db.lock();
+
+        let sid: Option<String> = conn
+            .query_row(
+                "SELECT id FROM sessions WHERE workspace_id = ?1 ORDER BY created_at DESC LIMIT 1",
+                [workspace_id],
+                |r| r.get(0),
+            )
+            .ok();
+
+        let Some(sid) = sid else {
+            return Ok(vec![]);
+        };
+
+        let mut stmt = conn.prepare(
+            "SELECT seq, provider, source, native_id, agent_version, body
+             FROM session_records WHERE session_id = ?1 ORDER BY seq ASC",
+        )?;
+
+        let rows: Vec<(i64, String, String, String, Option<String>, String)> = stmt
+            .query_map([&sid], |r| {
+                Ok((
+                    r.get(0)?,
+                    r.get(1)?,
+                    r.get(2)?,
+                    r.get(3)?,
+                    r.get(4)?,
+                    r.get(5)?,
+                ))
+            })?
+            .collect::<std::result::Result<_, rusqlite::Error>>()?;
+
+        rows.into_iter()
+            .map(|(seq, provider, source, native_id, agent_version, body_text)| {
+                let body = serde_json::from_str(&body_text)
+                    .map_err(|e| Error::Other(format!("deserialize record body: {e}")))?;
+                Ok(SessionRecord {
+                    seq,
+                    provider,
+                    source,
+                    native_id,
+                    agent_version,
+                    body,
+                })
             })
             .collect()
     }
@@ -1629,6 +1738,87 @@ mod tests {
         // And read must return empty.
         let events = wm.read_session_events(&ws_id).unwrap();
         assert!(events.is_empty());
+    }
+
+    // ── session record store (canonical) ──────────────────────────────────
+
+    #[test]
+    fn append_and_read_session_records_roundtrip() {
+        let db = test_db();
+        let (ws_id, wm) = make_workspace_with_session(&db);
+
+        let body = serde_json::json!({"role": "user", "content": "hello"});
+        let inserted = wm
+            .append_session_record(&ws_id, "claude", "transcript", "uuid-1", Some("1.2.3"), &body)
+            .unwrap();
+        assert!(inserted);
+
+        let records = wm.read_session_records(&ws_id).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].provider, "claude");
+        assert_eq!(records[0].source, "transcript");
+        assert_eq!(records[0].native_id, "uuid-1");
+        assert_eq!(records[0].agent_version.as_deref(), Some("1.2.3"));
+        assert_eq!(records[0].body, body);
+        assert_eq!(records[0].seq, 1);
+    }
+
+    #[test]
+    fn append_session_record_is_idempotent_on_native_id() {
+        let db = test_db();
+        let (ws_id, wm) = make_workspace_with_session(&db);
+
+        let first = serde_json::json!({"n": 1});
+        let dup = serde_json::json!({"n": 2});
+        assert!(wm
+            .append_session_record(&ws_id, "pi", "transcript", "id-a", None, &first)
+            .unwrap());
+        // Same (session, native_id) — must be ignored, original body retained.
+        assert!(!wm
+            .append_session_record(&ws_id, "pi", "transcript", "id-a", None, &dup)
+            .unwrap());
+
+        let records = wm.read_session_records(&ws_id).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].body, first);
+        assert_eq!(records[0].agent_version, None);
+    }
+
+    #[test]
+    fn session_records_seq_increments_in_order() {
+        let db = test_db();
+        let (ws_id, wm) = make_workspace_with_session(&db);
+
+        wm.append_session_record(&ws_id, "pi", "transcript", "ln:0", None, &serde_json::json!({"a": 1}))
+            .unwrap();
+        wm.append_session_record(&ws_id, "pi", "transcript", "ln:1", None, &serde_json::json!({"a": 2}))
+            .unwrap();
+
+        let records = wm.read_session_records(&ws_id).unwrap();
+        let seqs: Vec<i64> = records.iter().map(|r| r.seq).collect();
+        assert_eq!(seqs, vec![1, 2]);
+        assert_eq!(records[0].native_id, "ln:0");
+        assert_eq!(records[1].native_id, "ln:1");
+    }
+
+    #[test]
+    fn read_session_records_empty_when_none() {
+        let db = test_db();
+        let (ws_id, wm) = make_workspace_with_session(&db);
+        assert!(wm.read_session_records(&ws_id).unwrap().is_empty());
+    }
+
+    #[test]
+    fn append_session_record_to_workspace_with_no_session_is_noop() {
+        let db = test_db();
+        make_workspace_with_session(&db);
+        let wm = WorkspaceManager::new(db.clone());
+        // Unknown workspace id → no session → returns false, read empty.
+        let inserted = wm
+            .append_session_record("no-such-ws", "claude", "transcript", "x", None, &serde_json::json!({}))
+            .unwrap();
+        assert!(!inserted);
+        assert!(wm.read_session_records("no-such-ws").unwrap().is_empty());
     }
 
     #[test]

--- a/src/adapters/cursor/normalize.test.ts
+++ b/src/adapters/cursor/normalize.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { cursorAdapter } from "./index";
+import type { ChatItem, RawEvent } from "../types";
+
+function render(lines: unknown[]): ChatItem[] {
+  return cursorAdapter
+    .normalizeTranscript(lines)
+    .reduce<ChatItem[]>((acc, ev) => cursorAdapter.reduce(acc, ev as RawEvent), []);
+}
+
+// Cursor's on-disk transcript
+// (~/.cursor/projects/<slug>/agent-transcripts/<id>/<id>.jsonl) is Claude-shaped
+// content blocks (text / tool_use) but with `role` at the top level instead of
+// `type`, and — unlike Claude — tool_use blocks carry NO `id` and there are NO
+// tool_result rows (tool outputs aren't persisted).
+const onDisk: unknown[] = [
+  { role: "user", message: { content: [{ type: "text", text: "do it" }] } },
+  {
+    role: "assistant",
+    message: {
+      content: [
+        { type: "text", text: "ok" },
+        { type: "tool_use", name: "Glob", input: { glob_pattern: "**/*.ts" } },
+        { type: "tool_use", name: "Read", input: { path: "a.ts" } },
+      ],
+    },
+  },
+];
+
+describe("cursorAdapter.normalizeTranscript", () => {
+  it("maps role→type and renders text + tool calls", () => {
+    const items = render(onDisk);
+    expect(items[0]).toEqual({ kind: "user_message", text: "do it" });
+    expect(items[1]).toEqual({ kind: "agent_message", text: "ok", streaming: false });
+  });
+
+  it("synthesizes distinct ids so multiple id-less tool calls don't collapse", () => {
+    const items = render(onDisk);
+    const calls = items.filter((i) => i.kind === "tool_call") as Array<
+      Extract<ChatItem, { kind: "tool_call" }>
+    >;
+    expect(calls.map((c) => [c.id, c.name])).toEqual([
+      ["cursor-tool-0", "Glob"],
+      ["cursor-tool-1", "Read"],
+    ]);
+  });
+
+  it("is defensive against malformed lines", () => {
+    expect(() =>
+      cursorAdapter.normalizeTranscript([null, 1, {}, { role: "system" }]),
+    ).not.toThrow();
+    expect(cursorAdapter.normalizeTranscript([{ role: "system" }])).toEqual([]);
+  });
+});

--- a/src/adapters/cursor/normalize.ts
+++ b/src/adapters/cursor/normalize.ts
@@ -1,13 +1,32 @@
-// Cursor transcript replay isn't wired in v1.
+// Cursor transcript replay.
 //
-// Cursor stores chats in an internal, undocumented format under
-// `~/.cursor/chats` (no `export` command), so the Rust transport returns
-// an empty transcript for cursor agents (see `read_session_transcript`).
-// Live turns render via the reducer; `--resume` still continues the
-// conversation. Mapping the on-disk store is a follow-up.
+// cursor-agent persists `~/.cursor/projects/<slug>/agent-transcripts/<id>/<id>.jsonl`.
+// Each line is Claude-shaped content (text / tool_use blocks) but with `role`
+// at the top level instead of `type`, so cursor/reduce.ts (which delegates
+// user/assistant to the Claude reducer) handles it once we rename role→type.
+//
+// Two on-disk quirks: tool_use blocks carry NO `id` (Claude's do), and there
+// are NO tool_result rows (tool outputs aren't persisted). We synthesize a
+// stable id per tool_use so multiple calls don't collapse in upsertToolCall;
+// tool calls therefore render without results, which is expected for Cursor.
 
 import type { RawEvent } from "../types";
+import { asBlockList, asRecord } from "../shared/json";
 
-export function normalizeTranscript(_lines: unknown[]): RawEvent[] {
-  return [];
+export function normalizeTranscript(lines: unknown[]): RawEvent[] {
+  const out: RawEvent[] = [];
+  let toolSeq = 0;
+  for (const line of lines) {
+    const rec = asRecord(line);
+    const role = rec.role;
+    if (role !== "user" && role !== "assistant") continue; // drop unknown roles
+    const msg = asRecord(rec.message);
+    const content = asBlockList(msg.content).map((b) =>
+      b.type === "tool_use" && b.id == null
+        ? { ...b, id: `cursor-tool-${toolSeq++}` }
+        : b,
+    );
+    out.push({ type: role, message: { ...msg, content } });
+  }
+  return out;
 }

--- a/src/adapters/opencode/normalize.test.ts
+++ b/src/adapters/opencode/normalize.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { opencodeAdapter } from "./index";
+import type { ChatItem, RawEvent } from "../types";
+
+function render(lines: unknown[]): ChatItem[] {
+  return opencodeAdapter
+    .normalizeTranscript(lines)
+    .reduce<ChatItem[]>((acc, ev) => opencodeAdapter.reduce(acc, ev as RawEvent), []);
+}
+
+// OpenCode's on-disk store is a blob store, not JSONL: message blobs
+// (storage/message/<ses>/<msg>.json — role + metadata, NO `type` field, NO
+// content) and part blobs (storage/part/<msg>/<part>.json — the content, with a
+// `type`). The Rust reader emits each message record then its part records, in
+// order. normalizeTranscript reassembles: a part's role comes from its parent
+// message (messageID→role); user text parts become user_message, everything
+// else maps part.type → the live `{type, part}` event the reducer consumes.
+const records: unknown[] = [
+  { id: "m1", role: "user", sessionID: "s" }, // message blob (no `type`)
+  { id: "p1", type: "text", messageID: "m1", text: "hello" },
+  { id: "m2", role: "assistant", sessionID: "s" },
+  { id: "p2", type: "text", messageID: "m2", text: "hi there" },
+  {
+    id: "p3",
+    type: "tool",
+    messageID: "m2",
+    callID: "c1",
+    tool: "bash",
+    state: { status: "completed", input: { command: "ls" }, output: "file.txt" },
+  },
+  { id: "p4", type: "step-finish", messageID: "m2", reason: "stop" },
+];
+
+describe("opencodeAdapter.normalizeTranscript", () => {
+  it("reassembles message+part blobs into a rendered conversation", () => {
+    const items = render(records);
+    expect(items).toEqual([
+      { kind: "user_message", text: "hello" },
+      { kind: "agent_message", text: "hi there" },
+      { kind: "tool_call", id: "c1", name: "bash", input: { command: "ls" }, streaming: false },
+      { kind: "tool_result", tool_use_id: "c1", content: "file.txt", is_error: false },
+      { kind: "notice", subtype: "turn_end", text: "success" },
+    ]);
+  });
+
+  it("is defensive against malformed records", () => {
+    expect(() =>
+      opencodeAdapter.normalizeTranscript([null, 7, {}, { type: "subtask" }]),
+    ).not.toThrow();
+  });
+});

--- a/src/adapters/opencode/normalize.ts
+++ b/src/adapters/opencode/normalize.ts
@@ -1,14 +1,56 @@
-// OpenCode transcript replay isn't wired in v1.
+// OpenCode transcript replay.
 //
-// OpenCode has an `export <session-id>` command, but its on-disk schema
-// differs from the live `run --format json` event stream the reducer
-// consumes, so mapping it is a follow-up. The Rust transport returns an
-// empty transcript for opencode agents (see `read_session_transcript`);
-// re-attaching replays from the provider-agnostic SQLite event log, and
-// `--session <id>` continues the conversation.
+// OpenCode's on-disk store is a blob store, not JSONL: message blobs
+// (storage/message/<ses>/<msg>.json — role + metadata, no `type` field, no
+// content) and part blobs (storage/part/<msg>/<part>.json — the content, each
+// with a `type`). The Rust reader emits each message record followed by its
+// part records, in order.
+//
+// We reassemble: a part's role comes from its parent message (messageID→role).
+// A user message's text part becomes a `user_message` event (the prompt is
+// only in the transcript, never the live stream). Every other part maps its
+// on-disk `type` to the live `{type, part}` event the reducer consumes
+// (the part blob IS the live event's inner `part`).
 
 import type { RawEvent } from "../types";
+import { asRecord } from "../shared/json";
 
-export function normalizeTranscript(_lines: unknown[]): RawEvent[] {
-  return [];
+// On-disk part type → live event type the reducer switches on.
+const PART_TO_LIVE: Record<string, string> = {
+  text: "text",
+  reasoning: "reasoning",
+  tool: "tool_use",
+  "step-start": "step_start",
+  "step-finish": "step_finish",
+};
+
+export function normalizeTranscript(lines: unknown[]): RawEvent[] {
+  // First pass: messageID → role (message blobs have role + id, no `type`).
+  const roleOf = new Map<string, string>();
+  for (const line of lines) {
+    const rec = asRecord(line);
+    if (rec.type == null && typeof rec.id === "string" && typeof rec.role === "string") {
+      roleOf.set(rec.id, rec.role);
+    }
+  }
+
+  const out: RawEvent[] = [];
+  for (const line of lines) {
+    const rec = asRecord(line);
+    if (typeof rec.type !== "string") continue; // message blob — role captured above
+
+    const msgRole =
+      typeof rec.messageID === "string" ? roleOf.get(rec.messageID) : undefined;
+
+    // A user message's text is the prompt.
+    if (rec.type === "text" && msgRole === "user") {
+      out.push({ type: "user_message", text: typeof rec.text === "string" ? rec.text : "" });
+      continue;
+    }
+
+    const liveType = PART_TO_LIVE[rec.type];
+    if (!liveType) continue; // subtask / unknown — nothing renderable
+    out.push({ type: liveType, part: rec });
+  }
+  return out;
 }

--- a/src/adapters/opencode/reduce.ts
+++ b/src/adapters/opencode/reduce.ts
@@ -62,6 +62,15 @@ export function reduce(prev: ChatItem[], ev: RawEvent): ChatItem[] {
     case "step_start":
       return prev;
 
+    // The user's prompt. Never emitted live (Quorum injects the provider-
+    // agnostic user_message there); normalizeTranscript synthesizes it from a
+    // user message's text part during transcript replay.
+    case "user_message": {
+      const text = typeof ev.text === "string" ? ev.text : "";
+      if (!text) return prev;
+      return dedupAgainstLast(prev, { kind: "user_message", text });
+    }
+
     // Finalized assistant text for a step (no streaming deltas in run mode).
     case "text": {
       const part = asRecord(ev.part);

--- a/src/adapters/pi/normalize.test.ts
+++ b/src/adapters/pi/normalize.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { piAdapter } from "./index";
+import type { ChatItem, RawEvent } from "../types";
+
+// Renders the on-disk transcript the way re-attach will: normalizeTranscript
+// (raw lines → RawEvent[]) then reduce (→ ChatItem[]).
+function render(lines: unknown[]): ChatItem[] {
+  return piAdapter
+    .normalizeTranscript(lines)
+    .reduce<ChatItem[]>((acc, ev) => piAdapter.reduce(acc, ev as RawEvent), []);
+}
+
+// Real persisted on-disk shape: `~/.pi/agent/sessions/<slug>/<ts>_<id>.jsonl`.
+// Lines are `type:"message"` with a full message object (role user / assistant
+// / toolResult), preceded by session/model_change/thinking_level_change. This
+// is NOT the live `message_start/_update/_end` stream the reducer was built on,
+// so normalizeTranscript translates: message → message_end, toolResult →
+// tool_execution_end (reduce skips toolResult-role message_end).
+const onDisk: unknown[] = [
+  { type: "session", version: 3, id: "019e", cwd: "/x" },
+  { type: "model_change", id: "m1", modelId: "claude-opus-4-8" },
+  { type: "thinking_level_change", id: "t1", thinkingLevel: "medium" },
+  {
+    type: "message",
+    id: "u1",
+    message: { role: "user", content: [{ type: "text", text: "hi" }] },
+  },
+  {
+    type: "message",
+    id: "a1",
+    message: {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "pondering" },
+        { type: "toolCall", id: "call-1", name: "bash", arguments: { command: "ls" } },
+      ],
+    },
+  },
+  {
+    type: "message",
+    id: "r1",
+    message: {
+      role: "toolResult",
+      toolCallId: "call-1",
+      toolName: "bash",
+      content: [{ type: "text", text: "file.txt" }],
+      isError: false,
+    },
+  },
+  {
+    type: "message",
+    id: "a2",
+    message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+  },
+];
+
+describe("piAdapter.normalizeTranscript", () => {
+  it("renders on-disk transcript: drops preamble, maps messages + tool results", () => {
+    const items = render(onDisk);
+    expect(items).toEqual([
+      { kind: "user_message", text: "hi" },
+      { kind: "notice", subtype: "reasoning", text: "pondering" },
+      {
+        kind: "tool_call",
+        id: "call-1",
+        name: "bash",
+        input: { command: "ls" },
+        streaming: false,
+      },
+      { kind: "tool_result", tool_use_id: "call-1", content: "file.txt", is_error: false },
+      { kind: "agent_message", text: "done" },
+    ]);
+  });
+
+  it("does not throw on malformed lines (defensive)", () => {
+    expect(() =>
+      piAdapter.normalizeTranscript([null, 42, "x", {}, { type: "weird" }]),
+    ).not.toThrow();
+    expect(piAdapter.normalizeTranscript([{ type: "weird" }, {}])).toEqual([]);
+  });
+});

--- a/src/adapters/pi/normalize.ts
+++ b/src/adapters/pi/normalize.ts
@@ -1,14 +1,39 @@
-// Pi transcript replay isn't wired in v1.
+// Pi transcript replay.
 //
-// Pi persists a `session.jsonl` of its live events under its session-dir
-// (default `~/.pi/agent/sessions/<path>/`), so replay is wireable later by
-// reading that file. For v1 the Rust transport returns an empty transcript
-// for pi agents (see `read_session_transcript`); re-attaching replays from
-// the provider-agnostic SQLite event log, and `--session <id>` continues the
-// conversation.
+// Pi persists `~/.pi/agent/sessions/<slug>/<ts>_<id>.jsonl`. Unlike its live
+// `--mode json` stream (message_start/_update/_end, tool_execution_*, agent_end),
+// the on-disk lines are settled `type:"message"` records with a full message
+// object — role `user` / `assistant` / `toolResult` — preceded by
+// session/model_change/thinking_level_change preamble lines.
+//
+// The reducer (reduce.ts) was built on the live stream: it folds whole messages
+// off `message_end` and renders tool results off `tool_execution_end` (skipping
+// toolResult-role messages). So we translate the on-disk shape into those two
+// events and drop everything else.
 
 import type { RawEvent } from "../types";
+import { asRecord } from "../shared/json";
 
-export function normalizeTranscript(_lines: unknown[]): RawEvent[] {
-  return [];
+export function normalizeTranscript(lines: unknown[]): RawEvent[] {
+  const out: RawEvent[] = [];
+  for (const line of lines) {
+    const rec = asRecord(line);
+    if (rec.type !== "message") continue; // drop session/model_change/thinking_level_change/unknown
+    const msg = asRecord(rec.message);
+
+    if (msg.role === "toolResult") {
+      // reduce renders results off tool_execution_end, not toolResult messages.
+      out.push({
+        type: "tool_execution_end",
+        toolCallId: msg.toolCallId,
+        result: { content: msg.content },
+        isError: msg.isError === true,
+      });
+    } else {
+      // user / assistant: reduce's message_end arm parses the content blocks
+      // (text / thinking / toolCall).
+      out.push({ type: "message_end", message: msg });
+    }
+  }
+  return out;
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -250,6 +250,8 @@ export const api = {
       "read_session_events",
       { agentId },
     ),
+  readSessionRecords: (agentId: string) =>
+    invoke<SessionRecord[]>("read_session_records", { agentId }),
   addRepoToAgent: (agentId: string, repoPath: string) =>
     invoke<TrackedRepo>("add_repo_to_agent", { agentId, repoPath }),
   allocateDraftName: (used: string[]) =>
@@ -328,6 +330,32 @@ export function onAgentEvent(
   cb: (e: AgentManagedEvent) => void,
 ): Promise<UnlistenFn> {
   return listen<AgentManagedEvent>("agent:event", (event) => cb(event.payload));
+}
+
+/** One canonical record from session_records: a verbatim per-provider
+ *  transcript body plus its dedup key and provenance. */
+export interface SessionRecord {
+  seq: number;
+  provider: string;
+  source: string;
+  native_id: string;
+  agent_version: string | null;
+  body: Record<string, unknown> & { type?: string };
+}
+
+export interface SessionRecordsAppendedEvent {
+  agent_id: string;
+}
+
+/** Fires when a turn's transcript has been ingested into session_records, so
+ *  the canonical render can replace the ephemeral live one. */
+export function onSessionRecordsAppended(
+  cb: (e: SessionRecordsAppendedEvent) => void,
+): Promise<UnlistenFn> {
+  return listen<SessionRecordsAppendedEvent>(
+    "session:records-appended",
+    (event) => cb(event.payload),
+  );
 }
 
 export function onAgentStatus(

--- a/src/store.records.test.ts
+++ b/src/store.records.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { reduceRecords } from "./store";
+import type { SessionRecord } from "./api";
+
+// Canonical session_records hold verbatim per-provider transcript bodies.
+// reduceRecords renders them the same way on-disk replay does:
+// normalizeTranscript → reduce.
+function rec(body: Record<string, unknown>): SessionRecord {
+  return {
+    seq: 0,
+    provider: "pi",
+    source: "transcript",
+    native_id: "x",
+    agent_version: null,
+    body,
+  };
+}
+
+describe("reduceRecords", () => {
+  it("renders Pi on-disk records via normalizeTranscript + reduce", () => {
+    const records = [
+      rec({ type: "session", id: "s" }),
+      rec({ type: "message", message: { role: "user", content: [{ type: "text", text: "hi" }] } }),
+      rec({
+        type: "message",
+        message: { role: "assistant", content: [{ type: "text", text: "yo" }] },
+      }),
+    ];
+    expect(reduceRecords("pi", records)).toEqual([
+      { kind: "user_message", text: "hi" },
+      { kind: "agent_message", text: "yo" },
+    ]);
+  });
+
+  it("is defensive against malformed bodies", () => {
+    const records = [
+      rec(null as unknown as Record<string, unknown>),
+      rec({ type: "weird" }),
+    ];
+    expect(() => reduceRecords("pi", records)).not.toThrow();
+    expect(reduceRecords("pi", records)).toEqual([]);
+  });
+});

--- a/src/store.ts
+++ b/src/store.ts
@@ -9,12 +9,14 @@ import {
   onAgentTask,
   onAgentView,
   onPrStateChanged,
+  onSessionRecordsAppended,
   onShellOutput,
   onWorkspaceChanged,
   type AgentRecord,
   type AgentView,
   type GitState,
   type PrState,
+  type SessionRecord,
   type ShortStats,
   type Workspace,
 } from "./api";
@@ -417,6 +419,40 @@ export function reduceStoredEvent(
   }
 }
 
+/** Render canonical `session_records` (verbatim per-provider transcript
+ *  bodies) into chat items via the same pipeline as on-disk replay:
+ *  `normalizeTranscript` → `reduce`. Defensive: a malformed body or an adapter
+ *  throw degrades gracefully instead of failing the whole restore. */
+export function reduceRecords(
+  provider: string | undefined,
+  records: SessionRecord[],
+): ChatItem[] {
+  const adapter = getAdapter(provider);
+  let rawEvents: RawEvent[];
+  try {
+    rawEvents = adapter.normalizeTranscript(records.map((r) => r.body));
+  } catch (err) {
+    console.error("[adapters] normalizeTranscript threw during restore", {
+      provider,
+      err,
+    });
+    return [];
+  }
+  let items: ChatItem[] = [];
+  for (const ev of rawEvents) {
+    try {
+      items = adapter.reduce(items, ev);
+    } catch (err) {
+      console.error("[adapters] reduce threw during records restore", {
+        provider,
+        type: ev.type,
+        err,
+      });
+    }
+  }
+  return items;
+}
+
 /** Apply one raw event to an agent's log via its provider adapter. Catches
  *  adapter throws so a single malformed event can't poison the whole log. */
 function applyEvent(
@@ -610,6 +646,26 @@ export const useAppStore = create<AppState>((set, get) => ({
 
     await onAgentEvent((e) => {
       set((state) => applyEvent(state, e.agent_id, e.event as RawEvent));
+    });
+
+    // A turn's transcript was ingested into session_records: replace the
+    // ephemeral live render with the canonical one (richer — e.g. tool results
+    // the live stream dropped). No-op if nothing was stored.
+    await onSessionRecordsAppended((e) => {
+      const id = e.agent_id;
+      void (async () => {
+        try {
+          const records = await api.readSessionRecords(id);
+          if (records.length === 0) return;
+          const provider = providerFor(get(), id);
+          const items = reduceRecords(provider, records);
+          set((state) => ({
+            managedLogs: { ...state.managedLogs, [id]: items },
+          }));
+        } catch {
+          // Non-critical refresh; the next load picks up the records.
+        }
+      })();
     });
 
     await onAgentBranch((e) => {
@@ -963,13 +1019,20 @@ export const useAppStore = create<AppState>((set, get) => ({
     if (get().transcriptLoading[id]) return;
     set((s) => ({ transcriptLoading: { ...s.transcriptLoading, [id]: true } }));
     try {
-      // session_events is the canonical history — replay the stored raw events
-      // through the same reducer used live, so restore matches the live render.
       const provider = providerFor(get(), id);
-      const events = await api.readSessionEvents(id);
+      // session_records is the canonical store: per-provider verbatim transcript
+      // bodies, rendered via normalizeTranscript→reduce. Fall back to the legacy
+      // session_events log for sessions not yet ingested (agents without a
+      // transcript reader, or pre-migration history).
+      const records = await api.readSessionRecords(id);
       let items: ChatItem[] = [];
-      for (const ev of events) {
-        items = reduceStoredEvent(provider, items, ev as RawEvent);
+      if (records.length > 0) {
+        items = reduceRecords(provider, records);
+      } else {
+        const events = await api.readSessionEvents(id);
+        for (const ev of events) {
+          items = reduceStoredEvent(provider, items, ev as RawEvent);
+        }
       }
       set((state) => {
         // Nothing stored but a live turn is already rendering — don't clobber it.


### PR DESCRIPTION
## Problem

The two renderings of a session drew from different stores and could drift. The **custom view** replayed durable JSON events from SQLite (`session_events`), while the **native view** rendered raw PTY bytes and, on re-attach, the agent's own on-disk transcript. Native-view turns never reached SQLite, and the stored live-stream shape differs from each agent's on-disk transcript shape — so you couldn't ingest a whole transcript into the same shape, and per-session history diverged.

## Approach

One canonical store, **`session_records`**, is the single source of truth for rendering across both views. Records are stored **verbatim in each agent's own shape** and **normalized on read** by the per-provider adapter (no write-time normalization, no per-agent tables). Population is per-agent via a `TranscriptReader` (locate + read) that ingests the agent's on-disk transcript at every turn-end; the frontend renders from records with a legacy `session_events` fallback so nothing regresses.

## What's included (all five file-backed agents)

- **Storage** — `session_records` table (`provider`, `source`, `native_id`, `agent_version`, verbatim `body`) with idempotent append keyed on `(session_id, native_id)`.
- **Sync engine** — a per-provider `transcript_reader(provider)` dispatch + `sync_session_records`, triggered once per turn-end at the single `transition_active` Running→Idle point — so it covers **managed (Claude), per-turn, and native** turn-ends uniformly. Retries with backoff for flush lag; WARNs once if a reader-backed agent ingests nothing (transcript path/format-drift signal).
- **Readers** — Claude (`uuid` keys), Pi (`id`), Codex + Cursor (positional; Cursor located by its unique session-id dir, sidestepping the undocumented slug), and OpenCode (**blob-store reassembly** of `message/` + `part/` JSON).
- **Frontend** — `read_session_records` command; `loadHistoryTranscript` prefers records (via `normalizeTranscript`→`reduce`) and falls back to `session_events`; a **live→canonical swap** on `session:records-appended` replaces the ephemeral in-flight render with the richer stored one. Implemented the previously-stubbed Pi/Cursor/OpenCode `normalizeTranscript`.
- **agent_version** stamped per record via a memoized version probe (≤1 `--version` per provider/process), so a record captured under vN can later be read by a vN-aware normalizer.

## Notable findings (verified against real on-disk data, not fixtures)

- Each agent's **on-disk transcript shape differs from its live stream** (e.g. Pi persists settled `type:"message"` records, not its `message_start/_end` stream; Cursor is Claude-shaped with `role` at top and no `tool_result` rows; OpenCode is a blob store).
- Cursor's transcript **is** discoverable (`~/.cursor/projects/*/agent-transcripts/<id>/<id>.jsonl`) — the "undocumented format" code comment was stale.

## Simplifications

Single turn-end sync point in `transition_active` (replaced per-turn-specific wiring and delivered native-view turn-end for free); `find_codex_rollout` DRY'd into `find_codex_rollouts`; reused `records_with_id` / `read_jsonl_values` across readers.

## Explicitly deferred to PR2

- **Antigravity** (`agy`) — its conversation store is encrypted `.pb`, so it'll be a `LiveCompiled`, text-only agent (compile from live events; SQLite is its sole copy).
- **Cutover** — backfill existing sessions into `session_records`, then render solely from records. `session_events` is **kept as a write-only audit log for now** (forensics during development; storage cost is negligible — whole DB is ~1.3 MB), with full retirement a trivial later follow-up.
- Folding `find_*` helpers into the readers / retiring `read_session_transcript`; deriving/removing the `transcript_replay` flag.

## Verification

TDD throughout (every reader/normalizer written test-first against real transcripts). **Rust 127/127, TS 103/103, `tsc` clean**, build warning-free. Manually smoke-tested in the running app. A full live end-to-end pass of the swap/flush-race acceptance checks is recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)