### PR TITLE
Wire native (PTY/TUI) view for Antigravity + fix live session-id refresh

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -231,8 +231,9 @@ const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         // No event stream to detect turn-end from — the turn's process exit ends
         // the turn (on_turn_exit). The detector is never fed, so any is fine.
         activity: || Box::new(ManagedActivity::claude()),
-        // Native PTY view is a follow-up; custom view only for v1.
-        native_view: false,
+        // Native PTY view runs agy's interactive TUI, resuming the conversation
+        // the custom view established (see antigravity_pty_args).
+        native_view: true,
         plaintext: true,
         session_id_from_cwd: Some(antigravity_session_id_from_cwd),
         transcript: Some(TranscriptReader {
@@ -482,8 +483,8 @@ fn antigravity_build_args(prompt: &str, session_id: Option<&str>, _thinking: Opt
 }
 
 fn antigravity_pty_args(session_id: Option<&str>) -> Vec<String> {
-    // Native view is a follow-up (native_view: false); kept consistent for when
-    // it's wired — launch the TUI, resuming when we have an id.
+    // Native view: launch agy's interactive TUI (NOT `--print`, the
+    // non-interactive turn runner), resuming the conversation by id.
     let mut args = vec!["--dangerously-skip-permissions".to_string()];
     if let Some(id) = session_id {
         args.push("--conversation".into());
@@ -1347,10 +1348,11 @@ mod tests {
         assert_eq!(recs[2].native_id, "ln:2"); // no step_index → positional
     }
 
-    // agy has no native_view yet (custom view only); native rollout test pins it.
+    // agy's native (PTY/TUI) view is wired — it resumes the conversation the
+    // custom view established. Rollout test below pins the full matrix.
     #[test]
-    fn antigravity_is_custom_view_only_for_now() {
-        assert!(!capabilities("antigravity").native_view);
+    fn antigravity_native_view_is_wired() {
+        assert!(capabilities("antigravity").native_view);
     }
 
     #[test]
@@ -1565,6 +1567,7 @@ mod tests {
             ("cursor", true),
             ("opencode", true),
             ("pi", true),
+            ("antigravity", true),
             ("unknown", false),
         ];
         for (provider, native_view) in cases {

--- a/src/store.session-refresh.test.ts
+++ b/src/store.session-refresh.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { needsSessionIdRefresh } from "./store";
+import type { AgentRecord, Workspace } from "./api";
+
+function agent(overrides: Partial<AgentRecord> = {}): AgentRecord {
+  return {
+    id: "a1",
+    name: "agent",
+    provider: "antigravity",
+    view: "custom",
+    status: "idle",
+    repos: [],
+    ...overrides,
+  } as AgentRecord;
+}
+
+function ws(agents: AgentRecord[]): Workspace {
+  return { agents } as Workspace;
+}
+
+describe("needsSessionIdRefresh", () => {
+  it("is true when the agent has no session id yet (first turn just landed)", () => {
+    expect(needsSessionIdRefresh(ws([agent({ session_id: null })]), "a1")).toBe(true);
+    expect(needsSessionIdRefresh(ws([agent({ session_id: undefined })]), "a1")).toBe(true);
+    expect(needsSessionIdRefresh(ws([agent({ session_id: "" })]), "a1")).toBe(true);
+  });
+
+  it("is false once the agent already has a session id (avoids re-fetch churn)", () => {
+    expect(needsSessionIdRefresh(ws([agent({ session_id: "215e97ad" })]), "a1")).toBe(false);
+  });
+
+  it("is false for an unknown agent or a null workspace", () => {
+    expect(needsSessionIdRefresh(ws([agent({ session_id: null })]), "nope")).toBe(false);
+    expect(needsSessionIdRefresh(null, "a1")).toBe(false);
+  });
+});

--- a/src/store.ts
+++ b/src/store.ts
@@ -457,6 +457,19 @@ function extractInputTokens(ev: RawEvent): number | undefined {
   return typeof n === "number" && n > 0 ? n : undefined;
 }
 
+/** A per-turn agent captures its session id on its first turn (e.g. agy reads
+ *  it from disk at turn-end), but the id only reaches the live frontend via a
+ *  full `getWorkspace`. True when an agent's turn just landed yet its session
+ *  id is still missing locally — the cue to re-fetch so the Native toggle
+ *  unblocks without a reload. False once present, to avoid per-turn re-fetch. */
+export function needsSessionIdRefresh(
+  workspace: Workspace | null,
+  agentId: string,
+): boolean {
+  const agent = workspace?.agents.find((a) => a.id === agentId);
+  return !!agent && !agent.session_id;
+}
+
 /** Names already taken by real or draft agents — passed to the backend
  *  name allocator so picks avoid collisions. */
 function usedNames(workspace: Workspace | null, drafts: DraftAgent[]): Set<string> {
@@ -612,6 +625,13 @@ export const useAppStore = create<AppState>((set, get) => ({
           set((state) => ({
             managedLogs: { ...state.managedLogs, [id]: items },
           }));
+          // The first turn captures the agent's session id in the DB; pull it
+          // into the live workspace so the Native toggle unblocks without a
+          // reload. Only when still missing locally — avoids per-turn re-fetch.
+          if (needsSessionIdRefresh(get().workspace, id)) {
+            const fresh = await api.getWorkspace();
+            if (fresh) set({ workspace: fresh });
+          }
         } catch {
           // Non-critical refresh; the next load picks up the records.
         }


### PR DESCRIPTION
Enables the native (PTY/TUI) view for Antigravity (agy) by flipping its descriptor to `native_view: true`, so users can switch agy into its interactive TUI (resuming the conversation the custom view established via `--conversation <id>`); native turn-end and transcript ingest already worked for all per-turn agents, so no new persistence code was needed. While verifying, this surfaced a pre-existing staleness bug: a per-turn agent's session id is captured into the DB at turn-end but only reached the frontend via `getWorkspace`, leaving the Native toggle (gated on `agent.session_id`) blocked until a manual reload. The `session:records-appended` handler now re-fetches the workspace once when the agent still lacks a local session id, unblocking the toggle live — and since it's provider-agnostic, codex/cursor/opencode/pi benefit too. Verified with `cargo test --lib` (120), `npx vitest run` (105), and `npx tsc --noEmit`, plus manual in-app confirmation that agy's TUI renders and accepts input under our PTY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)