### PR TITLE
User-message attachments: durable capture + live/restore rendering

### DIFF
--- a/src-tauri/migrations/0004_session_user_turns.sql
+++ b/src-tauri/migrations/0004_session_user_turns.sql
@@ -1,0 +1,21 @@
+-- Quorum-origin capture of outgoing user messages, kept OUT of session_records
+-- so that store stays a pure 1:1 mirror of the agent's on-disk transcript.
+--
+-- One row per outgoing user message, written eagerly at send time (so a message
+-- survives even if the agent call fails). `native_id` is filled at turn-end once
+-- the matching transcript user-message lands in session_records; it points at
+-- that canonical row via the stable (session_id, native_id) key, so the
+-- association survives a full re-ingest from disk. NULL native_id = pending or
+-- failed (rendered standalone for retry). `attachments` is a JSON array of
+-- file paths attached to the message.
+CREATE TABLE session_user_turns (
+    turn_id     TEXT PRIMARY KEY,           -- frontend-generated uuid; idempotent across send retries
+    session_id  TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    seq         INTEGER NOT NULL,           -- per-session monotonic send order
+    text        TEXT NOT NULL,              -- original prompt (no injected "Attached file:" lines)
+    attachments TEXT NOT NULL,              -- JSON array of attachment paths
+    native_id   TEXT,                       -- matched session_records.native_id; NULL = pending/failed
+    created_at  INTEGER NOT NULL,
+    UNIQUE(session_id, seq)
+);
+CREATE INDEX idx_session_user_turns_session ON session_user_turns(session_id);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -115,12 +115,20 @@ pub fn send_user_message(
     supervisor: State<'_, Arc<Supervisor>>,
     app: AppHandle,
     agent_id: String,
+    turn_id: String,
     text: String,
     attachments: Vec<String>,
     thinking: Option<String>,
 ) -> Result<()> {
     let sup = supervisor.inner().clone();
-    sup.send_user_message(&app, &agent_id, &text, &attachments, thinking.as_deref())
+    sup.send_user_message(
+        &app,
+        &agent_id,
+        &turn_id,
+        &text,
+        &attachments,
+        thinking.as_deref(),
+    )
 }
 
 #[tauri::command]
@@ -199,6 +207,14 @@ pub fn read_session_records(
     agent_id: String,
 ) -> Result<Vec<crate::workspace::SessionRecord>> {
     supervisor.workspace.read_session_records(&agent_id)
+}
+
+#[tauri::command]
+pub fn read_user_turns(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+) -> Result<Vec<crate::workspace::UserTurn>> {
+    supervisor.workspace.read_user_turns(&agent_id)
 }
 
 /// Ingest the agent's on-disk transcript into session_records now (lazy

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -33,6 +33,7 @@ fn get_migrations() -> Migrations<'static> {
         M::up(include_str!("../migrations/0001_initial_schema.sql")),
         M::up(include_str!("../migrations/0002_session_records.sql")),
         M::up(include_str!("../migrations/0003_retire_session_events.sql")),
+        M::up(include_str!("../migrations/0004_session_user_turns.sql")),
     ])
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -155,6 +155,7 @@ pub fn run() {
             commands::archive_agent,
             commands::restore_agent,
             commands::read_session_records,
+            commands::read_user_turns,
             commands::sync_session,
             commands::add_repo_to_agent,
             commands::allocate_draft_name,

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -1098,8 +1098,9 @@ impl Supervisor {
         sync_session_records(&self.workspace, agent_id)
     }
 
-    /// Fire-and-forget transcript ingest at turn-end. Retries with backoff to
-    /// ride out the agent's flush lag; emits `session:records-appended` when new
+    /// Fire-and-forget transcript ingest at turn-end. Polls with backoff to ride
+    /// out the agent's flush lag, accumulating records until the transcript
+    /// settles (see `TranscriptPoll`); emits `session:records-appended` when new
     /// records land. WARNs once if a reader-backed agent ingests nothing after
     /// all retries — the early signal that its transcript path/format changed.
     /// Called from `transition_active` whenever any agent reaches Idle, so it
@@ -1107,33 +1108,34 @@ impl Supervisor {
     pub fn trigger_session_sync(&self, app: AppHandle, agent_id: String) {
         let workspace = self.workspace.clone();
         tauri::async_runtime::spawn(async move {
-            // Immediate attempt, then back off (ms) for flush lag.
+            // Immediate attempt, then back off (ms) across the whole window for
+            // flush lag — accumulating every batch (see `TranscriptPoll`), so a
+            // late-flushing final answer is captured this turn, not the next.
             let backoffs = [0u64, 200, 400, 800, 1600];
-            let mut had_reader = false;
-            let mut inserted_any = false;
+            let mut poll = TranscriptPoll::default();
             for wait in backoffs {
                 if wait > 0 {
                     tokio::time::sleep(Duration::from_millis(wait)).await;
                 }
-                match sync_session_records(&workspace, &agent_id) {
-                    None => return, // no transcript reader — nothing to do
-                    Some(0) => had_reader = true,
-                    Some(_) => {
-                        inserted_any = true;
-                        break;
-                    }
+                let result = sync_session_records(&workspace, &agent_id);
+                if matches!(poll.observe(result), PollControl::Stop) {
+                    break;
                 }
             }
-            if inserted_any {
-                let _ = app.emit(
-                    "session:records-appended",
-                    SessionRecordsAppendedPayload { agent_id },
-                );
-            } else if had_reader {
-                tracing::warn!(
-                    agent_id,
-                    "session sync ingested 0 records after retries (transcript not found or unchanged)"
-                );
+            match poll.outcome() {
+                PollOutcome::Appended(_) => {
+                    let _ = app.emit(
+                        "session:records-appended",
+                        SessionRecordsAppendedPayload { agent_id },
+                    );
+                }
+                PollOutcome::NothingIngested => {
+                    tracing::warn!(
+                        agent_id,
+                        "session sync ingested 0 records after retries (transcript not found or unchanged)"
+                    );
+                }
+                PollOutcome::NoReader => {}
             }
         });
     }
@@ -1213,6 +1215,76 @@ impl Supervisor {
 
         self.workspace.remove_agent(agent_id)?;
         Ok(())
+    }
+}
+
+/// Whether the turn-end transcript poll should keep going.
+#[derive(Debug, PartialEq, Eq)]
+enum PollControl {
+    Continue,
+    Stop,
+}
+
+/// What to do once the poll loop ends.
+#[derive(Debug, PartialEq, Eq)]
+enum PollOutcome {
+    /// No transcript reader for this provider — nothing was or will be ingested.
+    NoReader,
+    /// At least one record landed; emit `session:records-appended`.
+    Appended(usize),
+    /// A reader ran but the transcript yielded nothing (not flushed / unchanged).
+    NothingIngested,
+}
+
+/// Accumulating decision logic for the turn-end transcript sync, split out from
+/// `trigger_session_sync` so the "keep polling until the tail flushes" behavior
+/// is unit-testable without timers or the filesystem.
+///
+/// A single turn's lines can flush to the jsonl in more than one batch, separated
+/// by a gap — e.g. a tool-use plus a large tool-result (and session bookkeeping)
+/// land first, then the final assistant answer a phase later (it may not even be
+/// generated when the turn-end first fires). The old behavior stopped at the
+/// first non-empty batch, committing the turn *minus* its answer and emitting —
+/// so the answer was dropped until the next turn re-read the file.
+///
+/// Because any early-stop heuristic can be defeated by a gap at least as long as
+/// the heuristic's threshold, we don't try to detect "settled": we poll the
+/// whole backoff window, accumulating every batch, and emit once at the end. The
+/// only early exit is "no reader for this provider" — then there's no transcript
+/// to wait for. The window is bounded (~3s); anything that flushes later is still
+/// swept up by the next turn's sync (each sync re-reads the full file).
+#[derive(Default)]
+struct TranscriptPoll {
+    had_reader: bool,
+    inserted: usize,
+}
+
+impl TranscriptPoll {
+    /// Fold one `sync_session_records` result into the running decision and say
+    /// whether to keep polling.
+    fn observe(&mut self, result: Option<usize>) -> PollControl {
+        match result {
+            // No reader for this provider — nothing to wait for, bail at once.
+            None => PollControl::Stop,
+            // A reader ran. Whether or not it added rows this pass, keep polling
+            // the rest of the window: a later batch (the answer) may still land,
+            // possibly after an empty pass. The for-loop's backoff bounds this.
+            Some(n) => {
+                self.had_reader = true;
+                self.inserted += n;
+                PollControl::Continue
+            }
+        }
+    }
+
+    fn outcome(&self) -> PollOutcome {
+        if self.inserted > 0 {
+            PollOutcome::Appended(self.inserted)
+        } else if self.had_reader {
+            PollOutcome::NothingIngested
+        } else {
+            PollOutcome::NoReader
+        }
     }
 }
 
@@ -2183,5 +2255,52 @@ mod tests {
         assert_eq!(turns[0].turn_id, "turn-1");
         assert_eq!(turns[0].text, "hello");
         assert_eq!(turns[0].native_id, None);
+    }
+
+    // ── TranscriptPoll: turn-end ingest must not stop at the first flushed batch ──
+
+    #[test]
+    fn poll_does_not_stop_on_first_batch() {
+        // Regression: an image turn flushes the user msg + tool-use + large
+        // tool-result first, then the final answer a beat later. The poll must
+        // keep going after the first batch so the answer is still captured this
+        // turn (not dropped until the next one).
+        let mut poll = TranscriptPoll::default();
+        assert_eq!(poll.observe(Some(7)), PollControl::Continue);
+    }
+
+    #[test]
+    fn poll_accumulates_across_a_gap_before_the_late_answer() {
+        // The decisive case from the live evidence: the turn's lines flush in
+        // batches separated by a gap. The answer can be a phase *after* the
+        // tool-result + bookkeeping — so there's an empty pass BEFORE it lands.
+        // The poll must NOT settle on that empty pass; it has to keep reading
+        // through the window so the late answer is still ingested this turn.
+        let mut poll = TranscriptPoll::default();
+        assert_eq!(poll.observe(Some(7)), PollControl::Continue); // user + tool-use + result + meta
+        assert_eq!(poll.observe(Some(0)), PollControl::Continue); // gap — answer not flushed yet
+        assert_eq!(poll.observe(Some(2)), PollControl::Continue); // the answer (+ trailing meta)
+        assert_eq!(poll.observe(Some(0)), PollControl::Continue);
+        assert_eq!(poll.observe(Some(0)), PollControl::Continue);
+        assert_eq!(poll.outcome(), PollOutcome::Appended(9));
+    }
+
+    #[test]
+    fn poll_no_reader_stops_immediately() {
+        // Readerless providers must bail at once — no point polling a window for
+        // a transcript that will never exist.
+        let mut poll = TranscriptPoll::default();
+        assert_eq!(poll.observe(None), PollControl::Stop);
+        assert_eq!(poll.outcome(), PollOutcome::NoReader);
+    }
+
+    #[test]
+    fn poll_reader_but_nothing_ingested_warns() {
+        // Reader ran every pass but the transcript never yielded a record.
+        let mut poll = TranscriptPoll::default();
+        for _ in 0..5 {
+            assert_eq!(poll.observe(Some(0)), PollControl::Continue);
+        }
+        assert_eq!(poll.outcome(), PollOutcome::NothingIngested);
     }
 }

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -736,49 +736,52 @@ impl Supervisor {
         self: Arc<Self>,
         app: &AppHandle,
         agent_id: &str,
+        turn_id: &str,
         text: &str,
         attachments: &[String],
         thinking: Option<&str>,
     ) -> Result<()> {
-        self.deliver_user_message(agent_id, text, attachments, thinking)?;
+        self.deliver_user_message(agent_id, turn_id, text, attachments, thinking)?;
         mark_user_turn_started(&self, app, agent_id);
         on_first_user_message(self.clone(), app.clone(), agent_id.to_string(), text.to_string());
         Ok(())
     }
 
-    /// Deliver a user turn to the running agent, then persist it as the
-    /// provider-agnostic canonical `user_message` event.
+    /// Capture the outgoing user turn durably, then deliver it to the agent.
     ///
-    /// Order matters: we persist *after* the agent has accepted the message,
-    /// never before. A freshly spawned agent isn't in the in-memory map yet,
-    /// so a send aimed at it fails with `AgentNotFound`; the frontend retries
-    /// until the agent is ready (`sendWhenAgentReady`). Persisting up front
-    /// would record one duplicate `user_message` event per failed retry, and
-    /// those surface as the same prompt rendered N times when the conversation
-    /// is replayed from history on reopen.
+    /// Order matters: we persist the `session_user_turns` row *before* the agent
+    /// send, idempotently on `turn_id`. So the message survives even if delivery
+    /// fails (agent not yet spawned → `AgentNotFound`; the frontend resumes and
+    /// retries via `sendWhenAgentReady`, reusing the same `turn_id` → one row).
+    /// On reload a never-delivered turn renders standalone so the user can retry.
     ///
-    /// Persist-only: the frontend renders the user message optimistically on
-    /// send and replays this event through the reducer on restore, so it must
-    /// not be emitted live (that would double-render). It still lands ahead of
-    /// the response — `send_user_message` only queues the write, so the agent's
-    /// own events arrive (and persist) strictly later.
+    /// This row carries Quorum-origin metadata (text + attachments) that the
+    /// transcript can't; it lives outside `session_records`, which stays a pure
+    /// 1:1 mirror of the agent's jsonl. At turn-end `sync_session_records`
+    /// matches the row to its canonical transcript user-message and fills in
+    /// `native_id`. It is never rendered as a message when matched (the
+    /// transcript renders the turn; this only hangs attachments) — so no
+    /// double-render with the optimistic live render.
     fn deliver_user_message(
         &self,
         agent_id: &str,
+        turn_id: &str,
         text: &str,
         attachments: &[String],
         thinking: Option<&str>,
     ) -> Result<()> {
+        // Durable capture first — independent of whether the agent accepts.
+        if let Err(e) = self
+            .workspace
+            .insert_user_turn(agent_id, turn_id, text, attachments)
         {
-            let agents = self.agents.lock();
-            let agent = agents
-                .get(agent_id)
-                .ok_or_else(|| Error::AgentNotFound(agent_id.to_string()))?;
-            agent.send_user_message(text, attachments, thinking)?;
+            tracing::warn!(error = %e, agent_id, "persist outgoing user turn failed");
         }
-        // The user's prompt is persisted via the agent's own transcript (ingested
-        // into session_records at turn-end); the live view renders it
-        // optimistically on send. No separate event log to write.
+        let agents = self.agents.lock();
+        let agent = agents
+            .get(agent_id)
+            .ok_or_else(|| Error::AgentNotFound(agent_id.to_string()))?;
+        agent.send_user_message(text, attachments, thinking)?;
         Ok(())
     }
 
@@ -1274,6 +1277,13 @@ fn sync_session_records(workspace: &WorkspaceManager, agent_id: &str) -> Option<
             Err(e) => tracing::warn!(error = %e, agent_id, "append_session_record failed"),
         }
     }
+
+    // Link any pending outgoing user turns to the canonical transcript
+    // user-message rows just ingested (fills in their `native_id`).
+    if let Err(e) = workspace.associate_pending_user_turns(agent_id) {
+        tracing::warn!(error = %e, agent_id, "associate user turns failed");
+    }
+
     Some(inserted)
 }
 
@@ -2145,23 +2155,33 @@ mod tests {
     }
 
     #[test]
-    fn delivery_to_unready_agent_persists_nothing() {
+    fn delivery_to_unready_agent_leaves_canonical_store_clean_but_captures_turn() {
         // A freshly spawned agent has a session row but isn't in the live agents
         // map yet (the frontend retries the send until it's ready). A failed
-        // delivery must not write anything to the canonical store.
+        // delivery must not touch the canonical transcript store — but the
+        // outgoing user turn IS captured durably so it isn't lost and can be
+        // retried.
         let sup = test_supervisor();
         let mut record = record_with_status("yosemite", AgentStatus::Spawning);
         sup.workspace.add_agent(&mut record).unwrap();
 
         let err = sup
-            .deliver_user_message("yosemite", "hello", &[], None)
+            .deliver_user_message("yosemite", "turn-1", "hello", &[], None)
             .unwrap_err();
         assert!(matches!(err, Error::AgentNotFound(_)));
 
+        // Canonical store untouched.
         let records = sup.workspace.read_session_records("yosemite").unwrap();
         assert!(
             records.is_empty(),
-            "failed delivery must persist nothing, got {records:?}",
+            "failed delivery must not write the canonical store, got {records:?}",
         );
+
+        // Outgoing turn captured, pending (no transcript yet) → renders standalone.
+        let turns = sup.workspace.read_user_turns("yosemite").unwrap();
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].turn_id, "turn-1");
+        assert_eq!(turns[0].text, "hello");
+        assert_eq!(turns[0].native_id, None);
     }
 }

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -199,6 +199,17 @@ fn now_millis() -> i64 {
     Utc::now().timestamp_millis()
 }
 
+/// The workspace's current session id (the most recent session row). `None`
+/// when the workspace has no session yet.
+fn current_session_id(conn: &Connection, workspace_id: &str) -> Option<String> {
+    conn.query_row(
+        "SELECT id FROM sessions WHERE workspace_id = ?1 ORDER BY created_at DESC LIMIT 1",
+        [workspace_id],
+        |r| r.get(0),
+    )
+    .ok()
+}
+
 // ── WorkspaceManager ──────────────────────────────────────────────────────
 
 /// One canonical durable record from `session_records`, in the agent's own
@@ -211,6 +222,19 @@ pub struct SessionRecord {
     pub native_id: String,
     pub agent_version: Option<String>,
     pub body: serde_json::Value,
+}
+
+/// One Quorum-origin outgoing user message (the `session_user_turns` table).
+/// Carries the attachment metadata the transcript doesn't, plus a `native_id`
+/// link to the canonical `session_records` row once matched at turn-end.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct UserTurn {
+    pub turn_id: String,
+    pub seq: i64,
+    pub text: String,
+    pub attachments: Vec<String>,
+    /// Matched `session_records.native_id`; `None` = pending or failed turn.
+    pub native_id: Option<String>,
 }
 
 pub struct WorkspaceManager {
@@ -640,6 +664,150 @@ impl WorkspaceManager {
                 })
             })
             .collect()
+    }
+
+    // ── Outgoing user turns (session_user_turns) ──────────────────────────
+
+    /// Insert an outgoing user message for the workspace's current session.
+    /// Idempotent on `turn_id` (send auto-retries reuse the same id). Returns
+    /// `true` if a new row was inserted, `false` on duplicate / no session.
+    pub fn insert_user_turn(
+        &self,
+        workspace_id: &str,
+        turn_id: &str,
+        text: &str,
+        attachments: &[String],
+    ) -> Result<bool> {
+        let conn = self.db.lock();
+        let Some(sid) = current_session_id(&conn, workspace_id) else {
+            return Ok(false);
+        };
+        let attachments_json = serde_json::to_string(attachments)
+            .map_err(|e| Error::Other(format!("serialize attachments: {e}")))?;
+
+        let tx = conn.unchecked_transaction()?;
+        let seq: i64 = tx.query_row(
+            "SELECT COALESCE(MAX(seq), 0) + 1 FROM session_user_turns WHERE session_id = ?1",
+            [&sid],
+            |r| r.get(0),
+        )?;
+        let n = tx.execute(
+            "INSERT OR IGNORE INTO session_user_turns
+                (turn_id, session_id, seq, text, attachments, native_id, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6)",
+            rusqlite::params![turn_id, sid, seq, text, attachments_json, now_millis()],
+        )?;
+        tx.commit()?;
+        Ok(n > 0)
+    }
+
+    /// All outgoing user turns for the workspace's current session, in seq order.
+    pub fn read_user_turns(&self, workspace_id: &str) -> Result<Vec<UserTurn>> {
+        let conn = self.db.lock();
+        let Some(sid) = current_session_id(&conn, workspace_id) else {
+            return Ok(vec![]);
+        };
+        let mut stmt = conn.prepare(
+            "SELECT turn_id, seq, text, attachments, native_id
+             FROM session_user_turns WHERE session_id = ?1 ORDER BY seq ASC",
+        )?;
+        let rows: Vec<(String, i64, String, String, Option<String>)> = stmt
+            .query_map([&sid], |r| {
+                Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?))
+            })?
+            .collect::<std::result::Result<_, rusqlite::Error>>()?;
+        rows.into_iter()
+            .map(|(turn_id, seq, text, attachments_text, native_id)| {
+                let attachments = serde_json::from_str(&attachments_text)
+                    .map_err(|e| Error::Other(format!("deserialize attachments: {e}")))?;
+                Ok(UserTurn {
+                    turn_id,
+                    seq,
+                    text,
+                    attachments,
+                    native_id,
+                })
+            })
+            .collect()
+    }
+
+    /// Match pending (`native_id IS NULL`) user turns to their canonical
+    /// `session_records` user-message rows and fill in `native_id`. Run at
+    /// turn-end after transcript ingest. Matching: for each pending turn (seq
+    /// order) find the lowest-seq transcript record not already claimed whose
+    /// body contains the turn's distinctive marker — the first attachment path
+    /// (injected by the runner as `Attached file: <path>`) when present, else
+    /// the prompt text. Returns the number newly associated.
+    pub fn associate_pending_user_turns(&self, workspace_id: &str) -> Result<usize> {
+        let conn = self.db.lock();
+        let Some(sid) = current_session_id(&conn, workspace_id) else {
+            return Ok(0);
+        };
+
+        // Pending turns, oldest first.
+        let pending: Vec<(String, String, String)> = {
+            let mut stmt = conn.prepare(
+                "SELECT turn_id, text, attachments FROM session_user_turns
+                 WHERE session_id = ?1 AND native_id IS NULL ORDER BY seq ASC",
+            )?;
+            let v = stmt
+                .query_map([&sid], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))?
+                .collect::<std::result::Result<_, rusqlite::Error>>()?;
+            v
+        };
+        if pending.is_empty() {
+            return Ok(0);
+        }
+
+        // Transcript records, oldest first.
+        let records: Vec<(String, String)> = {
+            let mut stmt = conn.prepare(
+                "SELECT native_id, body FROM session_records
+                 WHERE session_id = ?1 AND source = 'transcript' ORDER BY seq ASC",
+            )?;
+            let v = stmt
+                .query_map([&sid], |r| Ok((r.get(0)?, r.get(1)?)))?
+                .collect::<std::result::Result<_, rusqlite::Error>>()?;
+            v
+        };
+
+        // native_ids already claimed by any user turn for this session.
+        let mut claimed: std::collections::HashSet<String> = {
+            let mut stmt = conn.prepare(
+                "SELECT native_id FROM session_user_turns
+                 WHERE session_id = ?1 AND native_id IS NOT NULL",
+            )?;
+            let v = stmt
+                .query_map([&sid], |r| r.get::<_, String>(0))?
+                .collect::<std::result::Result<_, rusqlite::Error>>()?;
+            v
+        };
+
+        let tx = conn.unchecked_transaction()?;
+        let mut associated = 0usize;
+        for (turn_id, text, attachments_text) in pending {
+            let attachments: Vec<String> =
+                serde_json::from_str(&attachments_text).unwrap_or_default();
+            // Distinctive needle: an attachment path beats the prompt text
+            // (paths are unique; text can be empty or duplicated).
+            let needle = attachments.first().cloned().unwrap_or(text);
+            if needle.is_empty() {
+                continue;
+            }
+            let hit = records
+                .iter()
+                .find(|(nid, body)| !claimed.contains(nid) && body.contains(&needle));
+            if let Some((nid, _)) = hit {
+                tx.execute(
+                    "UPDATE session_user_turns SET native_id = ?1 WHERE turn_id = ?2",
+                    rusqlite::params![nid, turn_id],
+                )?;
+                claimed.insert(nid.clone());
+                associated += 1;
+            }
+        }
+        tx.commit()?;
+        Ok(associated)
     }
 
     // ── Internal helpers ──────────────────────────────────────────────────
@@ -1630,6 +1798,95 @@ mod tests {
             .unwrap();
         assert!(!inserted);
         assert!(wm.read_session_records("no-such-ws").unwrap().is_empty());
+    }
+
+    #[test]
+    fn insert_and_read_user_turns_roundtrip() {
+        let db = test_db();
+        let (ws_id, wm) = make_workspace_with_session(&db);
+
+        assert!(wm
+            .insert_user_turn(&ws_id, "turn-1", "hello", &["/tmp/a.png".into()])
+            .unwrap());
+
+        let turns = wm.read_user_turns(&ws_id).unwrap();
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].turn_id, "turn-1");
+        assert_eq!(turns[0].seq, 1);
+        assert_eq!(turns[0].text, "hello");
+        assert_eq!(turns[0].attachments, vec!["/tmp/a.png".to_string()]);
+        assert_eq!(turns[0].native_id, None);
+    }
+
+    #[test]
+    fn insert_user_turn_is_idempotent_on_turn_id() {
+        let db = test_db();
+        let (ws_id, wm) = make_workspace_with_session(&db);
+
+        assert!(wm.insert_user_turn(&ws_id, "turn-1", "first", &[]).unwrap());
+        // Same turn_id (a send retry) — ignored, original retained, no new row.
+        assert!(!wm.insert_user_turn(&ws_id, "turn-1", "second", &[]).unwrap());
+
+        let turns = wm.read_user_turns(&ws_id).unwrap();
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].text, "first");
+    }
+
+    #[test]
+    fn associate_pending_user_turns_matches_attachment_path_then_text() {
+        let db = test_db();
+        let (ws_id, wm) = make_workspace_with_session(&db);
+
+        // Two outgoing turns: one with an attachment, one plain.
+        wm.insert_user_turn(&ws_id, "t1", "look at this", &["/tmp/diagram.png".into()])
+            .unwrap();
+        wm.insert_user_turn(&ws_id, "t2", "now refactor", &[]).unwrap();
+
+        // Transcript user-message records as the agent logged them (attachment
+        // turn carries the injected reference line; plain turn is just text).
+        wm.append_session_record(
+            &ws_id,
+            "claude",
+            "transcript",
+            "rec-A",
+            None,
+            &serde_json::json!({"role": "user", "text": "look at this\nAttached file: /tmp/diagram.png"}),
+        )
+        .unwrap();
+        wm.append_session_record(
+            &ws_id,
+            "claude",
+            "transcript",
+            "rec-B",
+            None,
+            &serde_json::json!({"role": "user", "text": "now refactor"}),
+        )
+        .unwrap();
+
+        let n = wm.associate_pending_user_turns(&ws_id).unwrap();
+        assert_eq!(n, 2);
+
+        let turns = wm.read_user_turns(&ws_id).unwrap();
+        assert_eq!(turns[0].native_id.as_deref(), Some("rec-A"));
+        assert_eq!(turns[1].native_id.as_deref(), Some("rec-B"));
+
+        // Idempotent: re-running associates nothing new.
+        assert_eq!(wm.associate_pending_user_turns(&ws_id).unwrap(), 0);
+    }
+
+    #[test]
+    fn associate_leaves_unmatched_turn_pending() {
+        let db = test_db();
+        let (ws_id, wm) = make_workspace_with_session(&db);
+
+        // Sent, but the agent never logged it (call failed) — no transcript row.
+        wm.insert_user_turn(&ws_id, "t1", "never delivered", &[])
+            .unwrap();
+        assert_eq!(wm.associate_pending_user_turns(&ws_id).unwrap(), 0);
+
+        let turns = wm.read_user_turns(&ws_id).unwrap();
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].native_id, None); // still pending → renders standalone
     }
 
     #[test]

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -6,7 +6,7 @@
 // for the design rationale.
 
 export type ChatItem =
-  | { kind: "user_message"; text: string }
+  | { kind: "user_message"; text: string; attachments?: string[] }
   | { kind: "agent_message"; text: string; streaming?: boolean }
   | {
       kind: "tool_call";

--- a/src/api.ts
+++ b/src/api.ts
@@ -225,8 +225,20 @@ export const api = {
     invoke<AgentRecord>("spawn_agent", { view, repoPath, provider, name }),
   writeToAgent: (agentId: string, data: string) =>
     invoke<void>("write_to_agent", { agentId, data }),
-  sendUserMessage: (agentId: string, text: string, attachments: string[] = [], thinking?: string) =>
-    invoke<void>("send_user_message", { agentId, text, attachments, thinking: thinking ?? null }),
+  sendUserMessage: (
+    agentId: string,
+    turnId: string,
+    text: string,
+    attachments: string[] = [],
+    thinking?: string,
+  ) =>
+    invoke<void>("send_user_message", {
+      agentId,
+      turnId,
+      text,
+      attachments,
+      thinking: thinking ?? null,
+    }),
   resizeAgent: (agentId: string, cols: number, rows: number) =>
     invoke<void>("resize_agent", { agentId, cols, rows }),
   switchView: (agentId: string, view: AgentView) =>
@@ -242,6 +254,8 @@ export const api = {
     invoke<void>("restore_agent", { agentId }),
   readSessionRecords: (agentId: string) =>
     invoke<SessionRecord[]>("read_session_records", { agentId }),
+  readUserTurns: (agentId: string) =>
+    invoke<UserTurn[]>("read_user_turns", { agentId }),
   syncSession: (agentId: string) =>
     invoke<void>("sync_session", { agentId }),
   addRepoToAgent: (agentId: string, repoPath: string) =>
@@ -333,6 +347,18 @@ export interface SessionRecord {
   native_id: string;
   agent_version: string | null;
   body: Record<string, unknown> & { type?: string };
+}
+
+/** One Quorum-origin outgoing user message (session_user_turns). Carries the
+ *  attachment metadata the transcript lacks; `native_id` links it to the
+ *  canonical session_records user-message once matched at turn-end (null =
+ *  pending or failed — rendered standalone for retry). */
+export interface UserTurn {
+  turn_id: string;
+  seq: number;
+  text: string;
+  attachments: string[];
+  native_id: string | null;
 }
 
 export interface SessionRecordsAppendedEvent {

--- a/src/app.css
+++ b/src/app.css
@@ -798,6 +798,11 @@ button { cursor: default; }
   display: flex; flex-wrap: wrap; gap: 6px;
   padding: 10px 12px 0;
 }
+/* Read-only attachment chips shown on a sent user message. */
+.message-attachments {
+  display: flex; flex-wrap: wrap; gap: 6px;
+  margin-top: 8px;
+}
 .attachment {
   display: inline-flex; align-items: center; gap: 6px;
   max-width: 220px; height: 24px; padding: 0 4px 0 8px;

--- a/src/components/Composer/AttachmentList.tsx
+++ b/src/components/Composer/AttachmentList.tsx
@@ -7,27 +7,33 @@ function basename(path: string) {
 
 interface Props {
   paths: string[];
-  onRemove: (path: string) => void;
+  /** Omit for a read-only list (e.g. chips on a sent message); when present
+   *  each chip gets a remove button (the composer's staged-files view). */
+  onRemove?: (path: string) => void;
+  className?: string;
 }
 
-/** Preview chips for files staged in the composer. v1 shows a file icon
- *  + filename with the absolute path as tooltip; the paths are folded
- *  into the message text on send so the agent reads each via its tools. */
-export function AttachmentList({ paths, onRemove }: Props) {
+/** File chips: a file icon + filename with the absolute path as tooltip.
+ *  Used both for files staged in the composer (with `onRemove`) and read-only
+ *  on a sent message. Paths are folded into the message text on send so the
+ *  agent reads each via its tools. */
+export function AttachmentList({ paths, onRemove, className = "composer-attachments" }: Props) {
   return (
-    <div className="composer-attachments">
+    <div className={className}>
       {paths.map((path) => (
         <span key={path} className="attachment" title={path}>
           <Icon name="file" size={12} />
           <span className="attachment-name">{basename(path)}</span>
-          <button
-            type="button"
-            className="attachment-remove"
-            aria-label={`Remove ${basename(path)}`}
-            onClick={() => onRemove(path)}
-          >
-            <Icon name="close" size={11} />
-          </button>
+          {onRemove && (
+            <button
+              type="button"
+              className="attachment-remove"
+              aria-label={`Remove ${basename(path)}`}
+              onClick={() => onRemove(path)}
+            >
+              <Icon name="close" size={11} />
+            </button>
+          )}
         </span>
       ))}
     </div>

--- a/src/components/Workspace/messages/MessageItem.tsx
+++ b/src/components/Workspace/messages/MessageItem.tsx
@@ -5,13 +5,21 @@ import type { ViewItem } from "./pair";
 import { ToolResultItem } from "./ToolResultItem";
 import { ToolRow } from "./ToolRow";
 import { getPresenter } from "./presenters";
+import { AttachmentList } from "../../Composer/AttachmentList";
 
 /** Dispatcher for one rendered row. Accepts either a raw ChatItem or
  *  the derived `tool_pair` from pairToolItems(). */
 export function MessageItem({ item }: { item: ViewItem }) {
   switch (item.kind) {
     case "user_message":
-      return <div className="m-user">{item.text}</div>;
+      return (
+        <div className="m-user">
+          {item.text}
+          {item.attachments && item.attachments.length > 0 && (
+            <AttachmentList paths={item.attachments} className="message-attachments" />
+          )}
+        </div>
+      );
     case "agent_message":
       return (
         <div className="m-agent">

--- a/src/store.ts
+++ b/src/store.ts
@@ -431,6 +431,14 @@ export function applyUserTurns(items: ChatItem[], turns: UserTurn[]): ChatItem[]
     const item = result[userIdxs[userIdxs.length - k]];
     if (item.kind === "user_message" && t.attachments.length > 0) {
       item.attachments = t.attachments;
+      // Render the clean text the user actually typed (what the live render
+      // showed) rather than the transcript's copy, which the runner padded
+      // with `Attached file: <path>` reference lines. The stored turn text is
+      // verbatim what was sent, so it matches the optimistic render exactly.
+      // Prefix-guard so a mis-aligned match can't rewrite an unrelated message.
+      if (item.text.startsWith(t.text)) {
+        item.text = t.text;
+      }
     }
   }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -18,6 +18,7 @@ import {
   type PrState,
   type SessionRecord,
   type ShortStats,
+  type UserTurn,
   type Workspace,
 } from "./api";
 import { DEFAULT_PROVIDER_ID } from "./data/providers";
@@ -403,6 +404,45 @@ export function reduceRecords(
   return items;
 }
 
+/** Overlay Quorum-origin outgoing-turn metadata (attachments) onto the
+ *  transcript-rendered conversation. Additive only — never replaces transcript
+ *  content (which stays the canonical, re-ingestable history):
+ *  - Matched turns (`native_id` set) hang their attachments on the rendered
+ *    user message. Aligned from the end, so older turns that predate this
+ *    feature (no row) simply keep no attachments instead of mis-grabbing them.
+ *  - Pending turns (`native_id` null — the agent never logged them, e.g. a
+ *    failed send) render standalone so the message survives reload + retry. */
+export function applyUserTurns(items: ChatItem[], turns: UserTurn[]): ChatItem[] {
+  if (turns.length === 0) return items;
+
+  const matched = turns.filter((t) => t.native_id);
+  const pending = turns.filter((t) => !t.native_id);
+  const result = items.map((it) => ({ ...it }));
+
+  const userIdxs: number[] = [];
+  result.forEach((it, i) => {
+    if (it.kind === "user_message") userIdxs.push(i);
+  });
+
+  // End-align matched turns to the trailing rendered user messages.
+  const n = Math.min(matched.length, userIdxs.length);
+  for (let k = 1; k <= n; k++) {
+    const t = matched[matched.length - k];
+    const item = result[userIdxs[userIdxs.length - k]];
+    if (item.kind === "user_message" && t.attachments.length > 0) {
+      item.attachments = t.attachments;
+    }
+  }
+
+  for (const t of pending) {
+    const item: ChatItem = { kind: "user_message", text: t.text };
+    if (t.attachments.length > 0) item.attachments = t.attachments;
+    result.push(item);
+  }
+
+  return result;
+}
+
 /** Apply one raw event to an agent's log via its provider adapter. Catches
  *  adapter throws so a single malformed event can't poison the whole log. */
 function applyEvent(
@@ -605,10 +645,13 @@ export const useAppStore = create<AppState>((set, get) => ({
       const id = e.agent_id;
       void (async () => {
         try {
-          const records = await api.readSessionRecords(id);
+          const [records, turns] = await Promise.all([
+            api.readSessionRecords(id),
+            api.readUserTurns(id),
+          ]);
           if (records.length === 0) return;
           const provider = providerFor(get(), id);
-          const items = reduceRecords(provider, records);
+          const items = applyUserTurns(reduceRecords(provider, records), turns);
           set((state) => ({
             managedLogs: { ...state.managedLogs, [id]: items },
           }));
@@ -794,12 +837,17 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 
   sendUserMessage: async (id, text, attachments = [], thinking) => {
+    // Stable per-turn id, reused across the agent-not-ready retry below so the
+    // backend's session_user_turns write is idempotent (one row per turn).
+    const turnId = crypto.randomUUID();
     try {
       set((state) => {
         const slashName = passthroughSlashName(providerFor(state, id), text);
         const entry: ChatItem = slashName
           ? { kind: "notice", subtype: "slash_command", text: `/${slashName}` }
-          : { kind: "user_message", text };
+          : attachments.length > 0
+            ? { kind: "user_message", text, attachments }
+            : { kind: "user_message", text };
         return {
           managedLogs: {
             ...state.managedLogs,
@@ -813,14 +861,14 @@ export const useAppStore = create<AppState>((set, get) => ({
         };
       });
       try {
-        await api.sendUserMessage(id, text, attachments, thinking);
+        await api.sendUserMessage(id, turnId, text, attachments, thinking);
       } catch (e) {
         if (String(e).includes("agent not found")) {
           // Dead idle agent (finished its prior task) — resume the
           // process in --resume mode, then deliver the message once ready.
           await api.resumeAgent(id);
           await sendWhenAgentReady(() =>
-            api.sendUserMessage(id, text, attachments, thinking),
+            api.sendUserMessage(id, turnId, text, attachments, thinking),
           );
         } else {
           throw e;
@@ -979,7 +1027,10 @@ export const useAppStore = create<AppState>((set, get) => ({
         await api.syncSession(id);
         records = await api.readSessionRecords(id);
       }
-      const items = reduceRecords(provider, records);
+      // Overlay outgoing-turn attachments + any undelivered (pending) turns, so
+      // a failed send still shows on reload even when there are no records yet.
+      const turns = await api.readUserTurns(id);
+      const items = applyUserTurns(reduceRecords(provider, records), turns);
       set((state) => {
         // Nothing stored but a live turn is already rendering — don't clobber it.
         if (items.length === 0 && (state.managedLogs[id]?.length ?? 0) > 0) {
@@ -1204,6 +1255,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     const draft = get().drafts.find((d) => d.id === id);
     if (!draft) return;
     set({ busy: true, lastError: null });
+    const turnId = crypto.randomUUID();
     try {
       const view = get().viewMode;
       const rec = await api.spawnAgent(view, draft.repoPath, provider, draft.name);
@@ -1218,7 +1270,11 @@ export const useAppStore = create<AppState>((set, get) => ({
         if (view === "custom") {
           patches.managedLogs = {
             ...state.managedLogs,
-            [rec.id]: [{ kind: "user_message", text }],
+            [rec.id]: [
+              attachments.length > 0
+                ? { kind: "user_message", text, attachments }
+                : { kind: "user_message", text },
+            ],
           };
           patches.managedBusy = { ...state.managedBusy, [rec.id]: true };
         }
@@ -1230,7 +1286,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         );
       } else {
         await sendWhenAgentReady(() =>
-          api.sendUserMessage(rec.id, text, attachments, thinking),
+          api.sendUserMessage(rec.id, turnId, text, attachments, thinking),
         );
       }
     } catch (e) {

--- a/src/store.user-turns.test.ts
+++ b/src/store.user-turns.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { applyUserTurns } from "./store";
+import type { ChatItem } from "./adapters";
+import type { UserTurn } from "./api";
+
+function turn(over: Partial<UserTurn>): UserTurn {
+  return { turn_id: "t", seq: 0, text: "", attachments: [], native_id: null, ...over };
+}
+
+const userMsg = (text: string): ChatItem => ({ kind: "user_message", text });
+const agentMsg = (text: string): ChatItem => ({ kind: "agent_message", text });
+
+describe("applyUserTurns", () => {
+  it("hangs attachments on the matching transcript user message (no duplicate turn)", () => {
+    const items = [userMsg("look"), agentMsg("ok")];
+    const turns = [turn({ native_id: "rec-A", text: "look", attachments: ["/tmp/a.png"] })];
+
+    const out = applyUserTurns(items, turns);
+    expect(out).toEqual([
+      { kind: "user_message", text: "look", attachments: ["/tmp/a.png"] },
+      { kind: "agent_message", text: "ok" },
+    ]);
+  });
+
+  it("end-aligns so older un-tracked turns keep no attachments", () => {
+    // First user turn predates the feature (no row); only the second has one.
+    const items = [userMsg("old"), agentMsg("a"), userMsg("new"), agentMsg("b")];
+    const turns = [turn({ native_id: "rec-2", text: "new", attachments: ["/tmp/x"] })];
+
+    const out = applyUserTurns(items, turns);
+    expect(out[0]).toEqual({ kind: "user_message", text: "old" }); // untouched
+    expect(out[2]).toEqual({ kind: "user_message", text: "new", attachments: ["/tmp/x"] });
+  });
+
+  it("renders a pending (unmatched) turn standalone so a failed send survives", () => {
+    const items: ChatItem[] = [userMsg("delivered"), agentMsg("reply")];
+    const turns = [
+      turn({ native_id: "rec-A", text: "delivered" }),
+      turn({ native_id: null, text: "never sent", attachments: ["/tmp/lost"] }),
+    ];
+
+    const out = applyUserTurns(items, turns);
+    expect(out[out.length - 1]).toEqual({
+      kind: "user_message",
+      text: "never sent",
+      attachments: ["/tmp/lost"],
+    });
+  });
+
+  it("is a no-op when there are no user turns", () => {
+    const items = [userMsg("hi"), agentMsg("yo")];
+    expect(applyUserTurns(items, [])).toEqual(items);
+  });
+});

--- a/src/store.user-turns.test.ts
+++ b/src/store.user-turns.test.ts
@@ -48,6 +48,44 @@ describe("applyUserTurns", () => {
     });
   });
 
+  it("shows the clean typed text on restore, not the runner's injected 'Attached file' lines", () => {
+    // The transcript copy of the user message carries the runner-injected
+    // reference line(s); the live render showed only the clean typed text +
+    // chips. Restore must match: clean text, attachments as chips.
+    const items = [
+      userMsg("What's on this image?\nAttached file: /Users/alex/Downloads/Clair.png"),
+      agentMsg("It's a UI screen."),
+    ];
+    const turns = [
+      turn({
+        native_id: "rec-A",
+        text: "What's on this image?",
+        attachments: ["/Users/alex/Downloads/Clair.png"],
+      }),
+    ];
+
+    const out = applyUserTurns(items, turns);
+    expect(out[0]).toEqual({
+      kind: "user_message",
+      text: "What's on this image?",
+      attachments: ["/Users/alex/Downloads/Clair.png"],
+    });
+  });
+
+  it("leaves text alone if the stored text isn't a prefix (guards a mis-aligned match)", () => {
+    const items = [userMsg("totally different message")];
+    const turns = [turn({ native_id: "rec-A", text: "what I typed", attachments: ["/tmp/x"] })];
+
+    const out = applyUserTurns(items, turns);
+    // Attachments still hang (existing behavior), but we don't rewrite the
+    // text to something that doesn't belong to this message.
+    expect(out[0]).toEqual({
+      kind: "user_message",
+      text: "totally different message",
+      attachments: ["/tmp/x"],
+    });
+  });
+
   it("is a no-op when there are no user turns", () => {
     const items = [userMsg("hi"), agentMsg("yo")];
     expect(applyUserTurns(items, [])).toEqual(items);


### PR DESCRIPTION
A new `session_user_turns` table (migration 0004) durably captures every outgoing user message at send time — idempotent on a frontend-generated `turn_id`, holding text + attachment paths — so a message survives even if the agent send fails (it renders standalone for retry). At turn-end each pending row is associated to its canonical transcript user-message by `native_id`, keeping `session_records` a pure 1:1 jsonl mirror while making the link survive a full re-ingest from disk. The frontend threads the `turn_id` through send, shows attachment chips live, and overlays them additively on restore via `applyUserTurns`. This also fixes a turn-end ingest race where `trigger_session_sync` stopped at the first flushed batch and dropped a late-flushing final answer (surfaced by image attachments → `Read` round-trips) — it now polls the whole backoff window, accumulating every batch via a unit-tested `TranscriptPoll`. Finally, restored attachment messages render the clean typed text instead of the runner's injected `Attached file: <path>` lines, so a message reads identically before and after the agent responds.

Tests: backend `cargo test --lib` 128 + warning-free build; frontend `tsc` clean + `vitest` 108 (incl. `session_user_turns` roundtrip/associate, `TranscriptPoll` late-flush, and `applyUserTurns` overlay/consistency cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)