### PR TITLE
Incremental O(new) transcript ingest: batch, byte-offset tail, settle poll

### DIFF
--- a/src-tauri/migrations/0005_session_ingest_offset.sql
+++ b/src-tauri/migrations/0005_session_ingest_offset.sql
@@ -1,0 +1,6 @@
+-- Byte offset into the agent's append-only JSONL transcript up to which we've
+-- ingested records into session_records. Lets the single-file readers tail the
+-- file (read only the new bytes) instead of re-parsing the whole conversation
+-- every turn. 0 = nothing ingested yet (also the default for existing sessions,
+-- so their first sync after upgrade tails from the start — a one-time full read).
+ALTER TABLE sessions ADD COLUMN ingest_offset INTEGER NOT NULL DEFAULT 0;

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -114,6 +114,15 @@ pub struct RawRecord {
     pub body: Value,
 }
 
+/// Marks a reader whose transcript is a single append-only JSONL file, so it can
+/// be read incrementally from a byte offset (`read_jsonl_tail`) instead of fully
+/// re-parsed each turn. `id_field` is the per-line native-id field (matching the
+/// reader's full `read`), or None for positional `ln:{i}` ids.
+#[derive(Clone, Copy)]
+pub struct JsonlTail {
+    pub id_field: Option<&'static str>,
+}
+
 /// How to find and parse a provider's on-disk transcript into ordered records.
 pub struct TranscriptReader {
     /// Ordered transcript artifact paths for a session (empty if none / not
@@ -121,6 +130,10 @@ pub struct TranscriptReader {
     pub locate: fn(session_id: &str, cwd: &Path) -> Vec<PathBuf>,
     /// Parse located artifacts into ordered verbatim records.
     pub read: fn(paths: &[PathBuf]) -> Vec<RawRecord>,
+    /// Set for single-file JSONL readers to enable incremental tail ingest.
+    /// `None` for multi-file (codex) / blob-dir (opencode) readers, which fall
+    /// back to a full read + idempotent batched insert.
+    pub tail: Option<JsonlTail>,
 }
 
 /// What an agent can do *right now*. A rollout flag, not a fixed trait: native
@@ -167,6 +180,7 @@ const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         transcript: Some(TranscriptReader {
             locate: codex_locate,
             read: codex_read,
+            tail: None, // multiple rollout files
         }),
     },
     PerTurnDescriptor {
@@ -185,6 +199,7 @@ const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         transcript: Some(TranscriptReader {
             locate: cursor_locate,
             read: cursor_read,
+            tail: Some(JsonlTail { id_field: None }), // single jsonl, positional ids
         }),
     },
     PerTurnDescriptor {
@@ -201,6 +216,7 @@ const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         transcript: Some(TranscriptReader {
             locate: opencode_locate,
             read: opencode_read,
+            tail: None, // blob-store directory, not a single file
         }),
     },
     PerTurnDescriptor {
@@ -218,6 +234,7 @@ const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         transcript: Some(TranscriptReader {
             locate: pi_locate,
             read: pi_read,
+            tail: Some(JsonlTail { id_field: Some("id") }), // single jsonl when one file
         }),
     },
     PerTurnDescriptor {
@@ -239,6 +256,7 @@ const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         transcript: Some(TranscriptReader {
             locate: antigravity_locate,
             read: antigravity_read,
+            tail: None, // per-turn agent; full read on exit is bounded
         }),
     },
 ];
@@ -255,6 +273,60 @@ pub fn per_turn_descriptor(id: &str) -> Option<&'static PerTurnDescriptor> {
 /// Build ordered `RawRecord`s from a parsed JSONL stream. `native_id` is the
 /// value's `id_field` (a string) when present, else a positional `ln:{i}` key
 /// over the global stream offset — stable across append-only multi-file reads.
+/// Incrementally read an append-only JSONL transcript from byte `offset` to EOF,
+/// returning the new records and the byte offset just past the last **complete**
+/// line consumed. A torn trailing line (the writer is mid-append, no newline yet)
+/// is left unconsumed so it's picked up — whole — on the next read; this is what
+/// makes tailing safe against the flush race. Positional `ln:{i}` ids continue
+/// from `start_index` (the count of records already ingested) so they match what
+/// a full read would have assigned; `id_field` (e.g. claude's `uuid`) overrides
+/// when present. Mirrors `records_with_id` parsing, just over the new tail only.
+pub fn read_jsonl_tail(
+    path: &Path,
+    offset: u64,
+    start_index: usize,
+    id_field: Option<&str>,
+) -> (Vec<RawRecord>, u64) {
+    use std::io::{Read, Seek, SeekFrom};
+
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return (Vec::new(), offset);
+    };
+    if file.seek(SeekFrom::Start(offset)).is_err() {
+        return (Vec::new(), offset);
+    }
+    let mut buf = Vec::new();
+    if file.read_to_end(&mut buf).is_err() {
+        return (Vec::new(), offset);
+    }
+    // Consume only up to the last newline; anything after is a partial line.
+    let Some(last_nl) = buf.iter().rposition(|&b| b == b'\n') else {
+        return (Vec::new(), offset);
+    };
+
+    let mut out = Vec::new();
+    let mut idx = start_index;
+    for line in buf[..=last_nl].split(|&b| b == b'\n') {
+        let Ok(text) = std::str::from_utf8(line) else {
+            continue;
+        };
+        if text.trim().is_empty() {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<Value>(text) {
+            let native_id = id_field
+                .and_then(|f| v.get(f))
+                .and_then(|x| x.as_str())
+                .map(str::to_string)
+                .unwrap_or_else(|| format!("ln:{idx}"));
+            out.push(RawRecord { native_id, body: v });
+            idx += 1;
+        }
+    }
+
+    (out, offset + last_nl as u64 + 1)
+}
+
 pub fn records_with_id(values: Vec<Value>, id_field: Option<&str>) -> Vec<RawRecord> {
     values
         .into_iter()
@@ -336,6 +408,7 @@ fn claude_read(paths: &[PathBuf]) -> Vec<RawRecord> {
 static CLAUDE_TRANSCRIPT: TranscriptReader = TranscriptReader {
     locate: claude_locate,
     read: claude_read,
+    tail: Some(JsonlTail { id_field: Some("uuid") }), // single persistent jsonl
 };
 
 // ── Codex ──
@@ -1298,6 +1371,66 @@ mod tests {
     use serde_json::json;
 
     // ── transcript readers ────────────────────────────────────────────────
+
+    #[test]
+    fn read_jsonl_tail_consumes_complete_lines_holds_partial_then_resumes() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("t.jsonl");
+
+        // Two complete lines, then a torn trailing line (no newline yet — the
+        // writer is mid-append).
+        {
+            let mut f = std::fs::File::create(&path).unwrap();
+            write!(
+                f,
+                "{}\n{}\n{}",
+                r#"{"uuid":"a","type":"user"}"#,
+                r#"{"uuid":"b","type":"assistant"}"#,
+                r#"{"uuid":"c","#
+            )
+            .unwrap();
+        }
+
+        let (recs, off) = read_jsonl_tail(&path, 0, 0, Some("uuid"));
+        assert_eq!(
+            recs.iter().map(|r| r.native_id.as_str()).collect::<Vec<_>>(),
+            vec!["a", "b"],
+            "only complete lines ingested; the torn line is held back",
+        );
+
+        // The writer finishes line c and appends d. Resume from the held offset
+        // with start_index = 2 (we consumed 2 records).
+        {
+            let mut f = std::fs::OpenOptions::new().append(true).open(&path).unwrap();
+            write!(f, "{}\n{}\n", r#""type":"assistant"}"#, r#"{"uuid":"d","type":"user"}"#).unwrap();
+        }
+
+        let (recs2, _off2) = read_jsonl_tail(&path, off, 2, Some("uuid"));
+        assert_eq!(
+            recs2.iter().map(|r| r.native_id.as_str()).collect::<Vec<_>>(),
+            vec!["c", "d"],
+            "resume picks up the now-complete line + the new one, no re-emit",
+        );
+    }
+
+    #[test]
+    fn read_jsonl_tail_positional_ids_continue_from_start_index() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("p.jsonl");
+        {
+            let mut f = std::fs::File::create(&path).unwrap();
+            // No `uuid` field → positional `ln:{global_index}` fallback.
+            write!(f, "{}\n{}\n", r#"{"type":"mode"}"#, r#"{"type":"summary"}"#).unwrap();
+        }
+        // Pretend 5 records were already ingested.
+        let (recs, _off) = read_jsonl_tail(&path, 0, 5, None);
+        assert_eq!(
+            recs.iter().map(|r| r.native_id.as_str()).collect::<Vec<_>>(),
+            vec!["ln:5", "ln:6"],
+        );
+    }
 
     #[test]
     fn provider_bin_label_dispatch() {

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -34,6 +34,7 @@ fn get_migrations() -> Migrations<'static> {
         M::up(include_str!("../migrations/0002_session_records.sql")),
         M::up(include_str!("../migrations/0003_retire_session_events.sql")),
         M::up(include_str!("../migrations/0004_session_user_turns.sql")),
+        M::up(include_str!("../migrations/0005_session_ingest_offset.sql")),
     ])
 }
 

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -1328,14 +1328,27 @@ fn sync_session_records(workspace: &WorkspaceManager, agent_id: &str) -> Option<
     };
 
     let paths = (reader.locate)(&session_id, &cwd);
-    let records = (reader.read)(&paths);
 
     // Version-frozen snapshot tag (memoized probe — at most one --version per
     // provider per process).
     let version = crate::agent::cached_provider_version(&record.provider);
 
-    // One batched transaction for the whole turn instead of a commit per record
-    // — turn-end ingest is then O(batch) commits, not O(conversation).
+    // Read only what's new. Single-file JSONL readers tail from the stored byte
+    // offset (O(new), not O(conversation) — the key win for long claude/image
+    // sessions); multi-file / blob-dir readers fall back to a full read whose
+    // already-stored rows are idempotently skipped. Either way the batch lands
+    // in one transaction.
+    let (records, new_offset) = match (reader.tail, paths.as_slice()) {
+        (Some(tail), [path]) => {
+            let offset = workspace.session_ingest_offset(agent_id).unwrap_or(0);
+            let start_index = workspace.session_record_count(agent_id).unwrap_or(0);
+            let (recs, next) =
+                crate::agent::read_jsonl_tail(path, offset, start_index, tail.id_field);
+            (recs, Some(next))
+        }
+        _ => ((reader.read)(&paths), None),
+    };
+
     let batch: Vec<(&str, &serde_json::Value)> =
         records.iter().map(|r| (r.native_id.as_str(), &r.body)).collect();
     let inserted = match workspace.append_session_records(
@@ -1351,6 +1364,14 @@ fn sync_session_records(workspace: &WorkspaceManager, agent_id: &str) -> Option<
             0
         }
     };
+
+    // Advance the tail cursor past the complete lines we just consumed (only for
+    // the single-file readers; `None` leaves it untouched).
+    if let Some(next) = new_offset {
+        if let Err(e) = workspace.set_session_ingest_offset(agent_id, next) {
+            tracing::warn!(error = %e, agent_id, "persist ingest offset failed");
+        }
+    }
 
     // Link any pending outgoing user turns to the canonical transcript
     // user-message rows just ingested (fills in their `native_id`).

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -1334,21 +1334,23 @@ fn sync_session_records(workspace: &WorkspaceManager, agent_id: &str) -> Option<
     // provider per process).
     let version = crate::agent::cached_provider_version(&record.provider);
 
-    let mut inserted = 0usize;
-    for rec in &records {
-        match workspace.append_session_record(
-            agent_id,
-            &record.provider,
-            "transcript",
-            &rec.native_id,
-            version.as_deref(),
-            &rec.body,
-        ) {
-            Ok(true) => inserted += 1,
-            Ok(false) => {}
-            Err(e) => tracing::warn!(error = %e, agent_id, "append_session_record failed"),
+    // One batched transaction for the whole turn instead of a commit per record
+    // — turn-end ingest is then O(batch) commits, not O(conversation).
+    let batch: Vec<(&str, &serde_json::Value)> =
+        records.iter().map(|r| (r.native_id.as_str(), &r.body)).collect();
+    let inserted = match workspace.append_session_records(
+        agent_id,
+        &record.provider,
+        "transcript",
+        version.as_deref(),
+        &batch,
+    ) {
+        Ok(n) => n,
+        Err(e) => {
+            tracing::warn!(error = %e, agent_id, "append_session_records failed");
+            0
         }
-    }
+    };
 
     // Link any pending outgoing user turns to the canonical transcript
     // user-message rows just ingested (fills in their `native_id`).

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -1098,21 +1098,31 @@ impl Supervisor {
         sync_session_records(&self.workspace, agent_id)
     }
 
-    /// Fire-and-forget transcript ingest at turn-end. Polls with backoff to ride
-    /// out the agent's flush lag, accumulating records until the transcript
-    /// settles (see `TranscriptPoll`); emits `session:records-appended` when new
-    /// records land. WARNs once if a reader-backed agent ingests nothing after
-    /// all retries — the early signal that its transcript path/format changed.
-    /// Called from `transition_active` whenever any agent reaches Idle, so it
-    /// covers managed, per-turn, and native turn-ends uniformly.
+    /// Fire-and-forget transcript ingest at turn-end. Called from
+    /// `transition_active` whenever any agent reaches Idle. Emits
+    /// `session:records-appended` when new records land; WARNs once if a
+    /// reader-backed agent ingests nothing.
+    ///
+    /// The polling shape depends on whether the agent's process persists across
+    /// turns (see `SyncPoll`):
+    /// - **Per-turn agents** (custom view) have *exited* by turn-end, so the
+    ///   file is complete and quiescent — we just ride out any flush lag and stop
+    ///   at the first non-empty read.
+    /// - **Claude / native-view agents** keep the transcript file open, so the
+    ///   final line can still be flushing. We poll until the file settles (two
+    ///   consecutive reads add nothing) before trusting the turn is fully on disk.
     pub fn trigger_session_sync(&self, app: AppHandle, agent_id: String) {
         let workspace = self.workspace.clone();
+        let persistent = workspace
+            .agent(&agent_id)
+            .map(|r| is_persistent_runner(&r))
+            .unwrap_or(true);
         tauri::async_runtime::spawn(async move {
-            // Immediate attempt, then back off (ms) across the whole window for
-            // flush lag — accumulating every batch (see `TranscriptPoll`), so a
-            // late-flushing final answer is captured this turn, not the next.
-            let backoffs = [0u64, 200, 400, 800, 1600];
-            let mut poll = TranscriptPoll::default();
+            // Immediate attempt, then fine-grained backoff (ms) to ride out flush
+            // lag / detect settle. Reads are incremental (O(new)), so polling is
+            // cheap even on long transcripts.
+            let backoffs = [0u64, 150, 150, 150, 200, 300, 400, 600];
+            let mut poll = SyncPoll::new(persistent);
             for wait in backoffs {
                 if wait > 0 {
                     tokio::time::sleep(Duration::from_millis(wait)).await;
@@ -1122,20 +1132,16 @@ impl Supervisor {
                     break;
                 }
             }
-            match poll.outcome() {
-                PollOutcome::Appended(_) => {
-                    let _ = app.emit(
-                        "session:records-appended",
-                        SessionRecordsAppendedPayload { agent_id },
-                    );
-                }
-                PollOutcome::NothingIngested => {
-                    tracing::warn!(
-                        agent_id,
-                        "session sync ingested 0 records after retries (transcript not found or unchanged)"
-                    );
-                }
-                PollOutcome::NoReader => {}
+            if poll.should_emit() {
+                let _ = app.emit(
+                    "session:records-appended",
+                    SessionRecordsAppendedPayload { agent_id },
+                );
+            } else if poll.reader_ingested_nothing() {
+                tracing::warn!(
+                    agent_id,
+                    "session sync ingested 0 records after retries (transcript not found or unchanged)"
+                );
             }
         });
     }
@@ -1218,6 +1224,16 @@ impl Supervisor {
     }
 }
 
+/// Does this agent keep its transcript file open across turns? Per-turn agents
+/// in the custom view *exit* at each turn-end, so the file is complete and
+/// quiescent the moment we sync. Everything else — claude, and any agent in the
+/// native (PTY/TUI) view — holds the file open, so the final line may still be
+/// flushing and we must poll until it settles.
+fn is_persistent_runner(record: &AgentRecord) -> bool {
+    let per_turn = per_turn_descriptor(&record.provider).is_some();
+    !(per_turn && record.view == AgentView::Custom)
+}
+
 /// Whether the turn-end transcript poll should keep going.
 #[derive(Debug, PartialEq, Eq)]
 enum PollControl {
@@ -1225,66 +1241,73 @@ enum PollControl {
     Stop,
 }
 
-/// What to do once the poll loop ends.
-#[derive(Debug, PartialEq, Eq)]
-enum PollOutcome {
-    /// No transcript reader for this provider — nothing was or will be ingested.
-    NoReader,
-    /// At least one record landed; emit `session:records-appended`.
-    Appended(usize),
-    /// A reader ran but the transcript yielded nothing (not flushed / unchanged).
-    NothingIngested,
-}
-
-/// Accumulating decision logic for the turn-end transcript sync, split out from
-/// `trigger_session_sync` so the "keep polling until the tail flushes" behavior
-/// is unit-testable without timers or the filesystem.
+/// Decision logic for the turn-end transcript sync, split out from
+/// `trigger_session_sync` so it's unit-testable without timers or the
+/// filesystem. Fed each `sync_session_records` result (`None` = no reader,
+/// `Some(n)` = n new records this pass).
 ///
-/// A single turn's lines can flush to the jsonl in more than one batch, separated
-/// by a gap — e.g. a tool-use plus a large tool-result (and session bookkeeping)
-/// land first, then the final assistant answer a phase later (it may not even be
-/// generated when the turn-end first fires). The old behavior stopped at the
-/// first non-empty batch, committing the turn *minus* its answer and emitting —
-/// so the answer was dropped until the next turn re-read the file.
-///
-/// Because any early-stop heuristic can be defeated by a gap at least as long as
-/// the heuristic's threshold, we don't try to detect "settled": we poll the
-/// whole backoff window, accumulating every batch, and emit once at the end. The
-/// only early exit is "no reader for this provider" — then there's no transcript
-/// to wait for. The window is bounded (~3s); anything that flushes later is still
-/// swept up by the next turn's sync (each sync re-reads the full file).
-#[derive(Default)]
-struct TranscriptPoll {
+/// The stop condition depends on whether the runner persists:
+/// - **Non-persistent (per-turn, exited):** the file is complete, so stop at the
+///   first non-empty read — earlier empty reads just ride out flush lag.
+/// - **Persistent (claude / native):** the final line may still be flushing,
+///   possibly after a gap, so keep polling until the file *settles* — two
+///   consecutive reads that add nothing once we've started ingesting. A later
+///   batch resets the counter, so a multi-phase flush (tool-result, then the
+///   answer) is still captured this turn.
+struct SyncPoll {
+    persistent: bool,
     had_reader: bool,
     inserted: usize,
+    stable_polls: u32,
 }
 
-impl TranscriptPoll {
-    /// Fold one `sync_session_records` result into the running decision and say
-    /// whether to keep polling.
+impl SyncPoll {
+    fn new(persistent: bool) -> Self {
+        Self {
+            persistent,
+            had_reader: false,
+            inserted: 0,
+            stable_polls: 0,
+        }
+    }
+
     fn observe(&mut self, result: Option<usize>) -> PollControl {
         match result {
-            // No reader for this provider — nothing to wait for, bail at once.
-            None => PollControl::Stop,
-            // A reader ran. Whether or not it added rows this pass, keep polling
-            // the rest of the window: a later batch (the answer) may still land,
-            // possibly after an empty pass. The for-loop's backoff bounds this.
+            None => PollControl::Stop, // no reader — nothing to wait for
+            Some(0) => {
+                self.had_reader = true;
+                if self.inserted == 0 {
+                    return PollControl::Continue; // not flushed yet — keep waiting
+                }
+                if !self.persistent {
+                    return PollControl::Stop; // exited → first batch was the whole turn
+                }
+                self.stable_polls += 1;
+                if self.stable_polls >= 2 {
+                    PollControl::Stop // file quiet for two polls → settled
+                } else {
+                    PollControl::Continue
+                }
+            }
             Some(n) => {
                 self.had_reader = true;
                 self.inserted += n;
-                PollControl::Continue
+                self.stable_polls = 0; // new content → not settled
+                if self.persistent {
+                    PollControl::Continue
+                } else {
+                    PollControl::Stop // exited → the batch is complete
+                }
             }
         }
     }
 
-    fn outcome(&self) -> PollOutcome {
-        if self.inserted > 0 {
-            PollOutcome::Appended(self.inserted)
-        } else if self.had_reader {
-            PollOutcome::NothingIngested
-        } else {
-            PollOutcome::NoReader
-        }
+    fn should_emit(&self) -> bool {
+        self.inserted > 0
+    }
+
+    fn reader_ingested_nothing(&self) -> bool {
+        self.had_reader && self.inserted == 0
     }
 }
 
@@ -2280,50 +2303,58 @@ mod tests {
         assert_eq!(turns[0].native_id, None);
     }
 
-    // ── TranscriptPoll: turn-end ingest must not stop at the first flushed batch ──
+    // ── SyncPoll: per-turn stops on first batch; persistent waits for settle ──
 
     #[test]
-    fn poll_does_not_stop_on_first_batch() {
-        // Regression: an image turn flushes the user msg + tool-use + large
-        // tool-result first, then the final answer a beat later. The poll must
-        // keep going after the first batch so the answer is still captured this
-        // turn (not dropped until the next one).
-        let mut poll = TranscriptPoll::default();
+    fn sync_poll_per_turn_stops_at_first_non_empty_read() {
+        // A per-turn agent has exited, so the file is complete: the first batch
+        // is the whole turn. Empty reads before it just ride out flush lag.
+        let mut poll = SyncPoll::new(false);
+        assert_eq!(poll.observe(Some(0)), PollControl::Continue); // not flushed yet
+        assert_eq!(poll.observe(Some(6)), PollControl::Stop); // complete — done
+        assert!(poll.should_emit());
+    }
+
+    #[test]
+    fn sync_poll_persistent_settles_after_two_quiet_polls() {
+        // Claude keeps the file open; only stop once it's been quiet for two
+        // consecutive reads after we started ingesting.
+        let mut poll = SyncPoll::new(true);
+        assert_eq!(poll.observe(Some(5)), PollControl::Continue);
+        assert_eq!(poll.observe(Some(0)), PollControl::Continue); // quiet 1
+        assert_eq!(poll.observe(Some(0)), PollControl::Stop); // quiet 2 → settled
+        assert!(poll.should_emit());
+    }
+
+    #[test]
+    fn sync_poll_persistent_captures_a_late_answer_across_a_gap() {
+        // The live-evidence case: tool-result + bookkeeping flush first, then the
+        // final answer a phase later (an empty read in between). A new batch
+        // resets the settle counter, so the answer is still ingested this turn.
+        let mut poll = SyncPoll::new(true);
         assert_eq!(poll.observe(Some(7)), PollControl::Continue);
+        assert_eq!(poll.observe(Some(0)), PollControl::Continue); // gap, quiet 1
+        assert_eq!(poll.observe(Some(2)), PollControl::Continue); // answer lands → reset
+        assert_eq!(poll.observe(Some(0)), PollControl::Continue); // quiet 1
+        assert_eq!(poll.observe(Some(0)), PollControl::Stop); // quiet 2 → settled
+        assert!(poll.should_emit());
     }
 
     #[test]
-    fn poll_accumulates_across_a_gap_before_the_late_answer() {
-        // The decisive case from the live evidence: the turn's lines flush in
-        // batches separated by a gap. The answer can be a phase *after* the
-        // tool-result + bookkeeping — so there's an empty pass BEFORE it lands.
-        // The poll must NOT settle on that empty pass; it has to keep reading
-        // through the window so the late answer is still ingested this turn.
-        let mut poll = TranscriptPoll::default();
-        assert_eq!(poll.observe(Some(7)), PollControl::Continue); // user + tool-use + result + meta
-        assert_eq!(poll.observe(Some(0)), PollControl::Continue); // gap — answer not flushed yet
-        assert_eq!(poll.observe(Some(2)), PollControl::Continue); // the answer (+ trailing meta)
-        assert_eq!(poll.observe(Some(0)), PollControl::Continue);
-        assert_eq!(poll.observe(Some(0)), PollControl::Continue);
-        assert_eq!(poll.outcome(), PollOutcome::Appended(9));
-    }
-
-    #[test]
-    fn poll_no_reader_stops_immediately() {
-        // Readerless providers must bail at once — no point polling a window for
-        // a transcript that will never exist.
-        let mut poll = TranscriptPoll::default();
+    fn sync_poll_no_reader_stops_immediately() {
+        let mut poll = SyncPoll::new(true);
         assert_eq!(poll.observe(None), PollControl::Stop);
-        assert_eq!(poll.outcome(), PollOutcome::NoReader);
+        assert!(!poll.should_emit());
+        assert!(!poll.reader_ingested_nothing());
     }
 
     #[test]
-    fn poll_reader_but_nothing_ingested_warns() {
-        // Reader ran every pass but the transcript never yielded a record.
-        let mut poll = TranscriptPoll::default();
+    fn sync_poll_reader_but_nothing_ingested_warns() {
+        let mut poll = SyncPoll::new(true);
         for _ in 0..5 {
             assert_eq!(poll.observe(Some(0)), PollControl::Continue);
         }
-        assert_eq!(poll.outcome(), PollOutcome::NothingIngested);
+        assert!(!poll.should_emit());
+        assert!(poll.reader_ingested_nothing());
     }
 }

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -635,6 +635,54 @@ impl WorkspaceManager {
         Ok(inserted)
     }
 
+    /// Byte offset into the current session's transcript up to which records have
+    /// been ingested — the resume point for an incremental tail read. 0 if there
+    /// is no session yet or nothing has been ingested.
+    pub fn session_ingest_offset(&self, workspace_id: &str) -> Result<u64> {
+        let conn = self.db.lock();
+        let offset: Option<i64> = conn
+            .query_row(
+                "SELECT ingest_offset FROM sessions WHERE workspace_id = ?1 ORDER BY created_at DESC LIMIT 1",
+                [workspace_id],
+                |r| r.get(0),
+            )
+            .ok();
+        Ok(offset.unwrap_or(0).max(0) as u64)
+    }
+
+    /// Persist the tail offset for the current session after an incremental read.
+    pub fn set_session_ingest_offset(&self, workspace_id: &str, offset: u64) -> Result<()> {
+        let conn = self.db.lock();
+        conn.execute(
+            "UPDATE sessions SET ingest_offset = ?2
+             WHERE id = (SELECT id FROM sessions WHERE workspace_id = ?1 ORDER BY created_at DESC LIMIT 1)",
+            rusqlite::params![workspace_id, offset as i64],
+        )?;
+        Ok(())
+    }
+
+    /// Count of records already ingested for the current session (= MAX(seq)) —
+    /// the starting index for positional `ln:{i}` native ids on the next read.
+    pub fn session_record_count(&self, workspace_id: &str) -> Result<usize> {
+        let conn = self.db.lock();
+        let sid: Option<String> = conn
+            .query_row(
+                "SELECT id FROM sessions WHERE workspace_id = ?1 ORDER BY created_at DESC LIMIT 1",
+                [workspace_id],
+                |r| r.get(0),
+            )
+            .ok();
+        let Some(sid) = sid else {
+            return Ok(0);
+        };
+        let count: i64 = conn.query_row(
+            "SELECT COALESCE(MAX(seq), 0) FROM session_records WHERE session_id = ?1",
+            [&sid],
+            |r| r.get(0),
+        )?;
+        Ok(count.max(0) as usize)
+    }
+
     /// All canonical records for the workspace's current session, in seq order.
     pub fn read_session_records(&self, workspace_id: &str) -> Result<Vec<SessionRecord>> {
         let conn = self.db.lock();
@@ -1832,6 +1880,26 @@ mod tests {
         assert_eq!(records.iter().map(|r| r.seq).collect::<Vec<_>>(), vec![1, 2, 3, 4]);
         assert_eq!(records[3].native_id, "id-d");
         assert_eq!(records[3].body, d);
+    }
+
+    #[test]
+    fn ingest_offset_and_record_count_roundtrip() {
+        let db = test_db();
+        let (ws_id, wm) = make_workspace_with_session(&db);
+
+        // Defaults before anything is ingested.
+        assert_eq!(wm.session_ingest_offset(&ws_id).unwrap(), 0);
+        assert_eq!(wm.session_record_count(&ws_id).unwrap(), 0);
+
+        let a = serde_json::json!({"n": 1});
+        let b = serde_json::json!({"n": 2});
+        wm.append_session_records(&ws_id, "claude", "transcript", None, &[("x", &a), ("y", &b)])
+            .unwrap();
+        // record_count tracks MAX(seq) — the start index for the next tail read.
+        assert_eq!(wm.session_record_count(&ws_id).unwrap(), 2);
+
+        wm.set_session_ingest_offset(&ws_id, 4096).unwrap();
+        assert_eq!(wm.session_ingest_offset(&ws_id).unwrap(), 4096);
     }
 
     #[test]

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -573,15 +573,23 @@ impl WorkspaceManager {
     /// on `(session_id, native_id)`: a duplicate native_id is ignored and the
     /// original row's body is retained. Returns `true` if a new row was
     /// inserted, `false` if it was a duplicate or the workspace has no session.
-    pub fn append_session_record(
+    /// Append many transcript records in a single transaction. Same idempotency
+    /// as `append_session_record` (ignored on a `(session_id, native_id)`
+    /// conflict), but one commit for the whole batch instead of one per record —
+    /// so turn-end ingest is O(batch) commits, not O(conversation). `seq` stays
+    /// contiguous: an ignored duplicate doesn't burn a number. Returns how many
+    /// rows were actually inserted.
+    pub fn append_session_records(
         &self,
         workspace_id: &str,
         provider: &str,
         source: &str,
-        native_id: &str,
         agent_version: Option<&str>,
-        body: &serde_json::Value,
-    ) -> Result<bool> {
+        records: &[(&str, &serde_json::Value)],
+    ) -> Result<usize> {
+        if records.is_empty() {
+            return Ok(0);
+        }
         let conn = self.db.lock();
 
         let sid: Option<String> = conn
@@ -591,29 +599,40 @@ impl WorkspaceManager {
                 |r| r.get(0),
             )
             .ok();
-
         let Some(sid) = sid else {
-            return Ok(false);
+            return Ok(0);
         };
 
-        let body_json = serde_json::to_string(body)
-            .map_err(|e| Error::Other(format!("serialize record body: {e}")))?;
-
+        let now = now_millis();
         let tx = conn.unchecked_transaction()?;
-        let seq: i64 = tx.query_row(
-            "SELECT COALESCE(MAX(seq), 0) + 1 FROM session_records WHERE session_id = ?1",
+        let mut seq: i64 = tx.query_row(
+            "SELECT COALESCE(MAX(seq), 0) FROM session_records WHERE session_id = ?1",
             [&sid],
             |r| r.get(0),
         )?;
-        let n = tx.execute(
-            "INSERT OR IGNORE INTO session_records
-                (session_id, seq, provider, source, native_id, agent_version, body, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-            rusqlite::params![sid, seq, provider, source, native_id, agent_version, body_json, now_millis()],
-        )?;
+        let mut inserted = 0usize;
+        {
+            let mut stmt = tx.prepare(
+                "INSERT OR IGNORE INTO session_records
+                    (session_id, seq, provider, source, native_id, agent_version, body, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            )?;
+            for (native_id, body) in records {
+                let body_json = serde_json::to_string(body)
+                    .map_err(|e| Error::Other(format!("serialize record body: {e}")))?;
+                let next = seq + 1;
+                let n = stmt.execute(rusqlite::params![
+                    sid, next, provider, source, native_id, agent_version, body_json, now
+                ])?;
+                if n > 0 {
+                    seq = next; // consumed only on a real insert; dups keep seq dense
+                    inserted += 1;
+                }
+            }
+        }
         tx.commit()?;
 
-        Ok(n > 0)
+        Ok(inserted)
     }
 
     /// All canonical records for the workspace's current session, in seq order.
@@ -1728,9 +1747,9 @@ mod tests {
 
         let body = serde_json::json!({"role": "user", "content": "hello"});
         let inserted = wm
-            .append_session_record(&ws_id, "claude", "transcript", "uuid-1", Some("1.2.3"), &body)
+            .append_session_records(&ws_id, "claude", "transcript", Some("1.2.3"), &[("uuid-1", &body)])
             .unwrap();
-        assert!(inserted);
+        assert_eq!(inserted, 1);
 
         let records = wm.read_session_records(&ws_id).unwrap();
         assert_eq!(records.len(), 1);
@@ -1749,13 +1768,17 @@ mod tests {
 
         let first = serde_json::json!({"n": 1});
         let dup = serde_json::json!({"n": 2});
-        assert!(wm
-            .append_session_record(&ws_id, "pi", "transcript", "id-a", None, &first)
-            .unwrap());
+        assert_eq!(
+            wm.append_session_records(&ws_id, "pi", "transcript", None, &[("id-a", &first)])
+                .unwrap(),
+            1
+        );
         // Same (session, native_id) — must be ignored, original body retained.
-        assert!(!wm
-            .append_session_record(&ws_id, "pi", "transcript", "id-a", None, &dup)
-            .unwrap());
+        assert_eq!(
+            wm.append_session_records(&ws_id, "pi", "transcript", None, &[("id-a", &dup)])
+                .unwrap(),
+            0
+        );
 
         let records = wm.read_session_records(&ws_id).unwrap();
         assert_eq!(records.len(), 1);
@@ -1764,13 +1787,63 @@ mod tests {
     }
 
     #[test]
+    fn append_session_records_batches_in_one_pass_and_is_idempotent() {
+        let db = test_db();
+        let (ws_id, wm) = make_workspace_with_session(&db);
+
+        let a = serde_json::json!({"n": 1});
+        let b = serde_json::json!({"n": 2});
+        let c = serde_json::json!({"n": 3});
+
+        // First batch: all three land, seq contiguous in order.
+        let inserted = wm
+            .append_session_records(
+                &ws_id,
+                "claude",
+                "transcript",
+                None,
+                &[("id-a", &a), ("id-b", &b), ("id-c", &c)],
+            )
+            .unwrap();
+        assert_eq!(inserted, 3);
+
+        let records = wm.read_session_records(&ws_id).unwrap();
+        assert_eq!(records.iter().map(|r| r.seq).collect::<Vec<_>>(), vec![1, 2, 3]);
+        assert_eq!(
+            records.iter().map(|r| r.native_id.as_str()).collect::<Vec<_>>(),
+            vec!["id-a", "id-b", "id-c"],
+        );
+
+        // Re-running with two already-stored + one new inserts only the new one,
+        // and seq stays contiguous (ignored dups don't burn a seq).
+        let d = serde_json::json!({"n": 4});
+        let inserted = wm
+            .append_session_records(
+                &ws_id,
+                "claude",
+                "transcript",
+                None,
+                &[("id-b", &b), ("id-c", &c), ("id-d", &d)],
+            )
+            .unwrap();
+        assert_eq!(inserted, 1);
+
+        let records = wm.read_session_records(&ws_id).unwrap();
+        assert_eq!(records.iter().map(|r| r.seq).collect::<Vec<_>>(), vec![1, 2, 3, 4]);
+        assert_eq!(records[3].native_id, "id-d");
+        assert_eq!(records[3].body, d);
+    }
+
+    #[test]
     fn session_records_seq_increments_in_order() {
         let db = test_db();
         let (ws_id, wm) = make_workspace_with_session(&db);
 
-        wm.append_session_record(&ws_id, "pi", "transcript", "ln:0", None, &serde_json::json!({"a": 1}))
+        let a = serde_json::json!({"a": 1});
+        let b = serde_json::json!({"a": 2});
+        wm.append_session_records(&ws_id, "pi", "transcript", None, &[("ln:0", &a)])
             .unwrap();
-        wm.append_session_record(&ws_id, "pi", "transcript", "ln:1", None, &serde_json::json!({"a": 2}))
+        wm.append_session_records(&ws_id, "pi", "transcript", None, &[("ln:1", &b)])
             .unwrap();
 
         let records = wm.read_session_records(&ws_id).unwrap();
@@ -1792,11 +1865,12 @@ mod tests {
         let db = test_db();
         make_workspace_with_session(&db);
         let wm = WorkspaceManager::new(db.clone());
-        // Unknown workspace id → no session → returns false, read empty.
+        // Unknown workspace id → no session → nothing inserted, read empty.
+        let body = serde_json::json!({});
         let inserted = wm
-            .append_session_record("no-such-ws", "claude", "transcript", "x", None, &serde_json::json!({}))
+            .append_session_records("no-such-ws", "claude", "transcript", None, &[("x", &body)])
             .unwrap();
-        assert!(!inserted);
+        assert_eq!(inserted, 0);
         assert!(wm.read_session_records("no-such-ws").unwrap().is_empty());
     }
 
@@ -1844,22 +1918,14 @@ mod tests {
 
         // Transcript user-message records as the agent logged them (attachment
         // turn carries the injected reference line; plain turn is just text).
-        wm.append_session_record(
+        let rec_a = serde_json::json!({"role": "user", "text": "look at this\nAttached file: /tmp/diagram.png"});
+        let rec_b = serde_json::json!({"role": "user", "text": "now refactor"});
+        wm.append_session_records(
             &ws_id,
             "claude",
             "transcript",
-            "rec-A",
             None,
-            &serde_json::json!({"role": "user", "text": "look at this\nAttached file: /tmp/diagram.png"}),
-        )
-        .unwrap();
-        wm.append_session_record(
-            &ws_id,
-            "claude",
-            "transcript",
-            "rec-B",
-            None,
-            &serde_json::json!({"role": "user", "text": "now refactor"}),
+            &[("rec-A", &rec_a), ("rec-B", &rec_b)],
         )
         .unwrap();
 


### PR DESCRIPTION
Turn-end ingest re-read the entire transcript and committed one transaction per record, so it was O(conversation) on every turn; this reworks it to O(new). A turn's records now land in a single batched transaction (`append_session_records`), and single-file readers (claude/cursor/pi) tail only the new bytes from a stored `sessions.ingest_offset` (migration 0005) via `read_jsonl_tail`, which holds back a torn trailing line so a mid-flush read is safe — while codex/opencode keep a full read + idempotent batched insert. Triggers now match the runner: per-turn agents have *exited* by turn-end (file complete) so they ingest once and stop at the first non-empty read, whereas claude and native-view agents keep the file open and poll until it settles (two quiet reads, with a new batch resetting the counter so a multi-phase flush — tool-result then the late answer — is still captured this turn). The fixed full-window `TranscriptPoll` is replaced by a policy-aware, unit-tested `SyncPoll`.

Verified: `cargo test --lib` 133 passed, warning-free build, clippy clean on the new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)