### PR TITLE
Wire Claude session-level --effort through spawn

### DIFF
--- a/src-tauri/migrations/0006_session_effort.sql
+++ b/src-tauri/migrations/0006_session_effort.sql
@@ -1,0 +1,4 @@
+-- Claude's session-level reasoning effort (`--effort <level>`), chosen in the
+-- composer at session creation and re-applied on every process spawn. NULL for
+-- existing sessions and for agents that don't use a spawn-level effort flag.
+ALTER TABLE sessions ADD COLUMN effort TEXT;

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -681,6 +681,12 @@ pub struct SpawnSpec<'a> {
     /// on disk for this session). False if we're respawning to switch
     /// views — claude should `--resume` instead of starting fresh.
     pub fresh: bool,
+    /// Claude's session-level effort (`--effort <level>`), chosen at session
+    /// creation and persisted on the `AgentRecord`. Applied on every spawn
+    /// (fresh, view-switch, resume) so it sticks for the session. `None` =
+    /// no selection; claude uses its own default. Ignored by per-turn agents,
+    /// which take effort per-turn via their `thinking` build-args instead.
+    pub effort: Option<&'a str>,
     pub cols: u16,
     pub rows: u16,
 }
@@ -956,6 +962,18 @@ fn prepare_sandbox(
     Ok(profile_file)
 }
 
+/// Claude's session-level effort flag (`--effort <level>`), shared by the
+/// managed (custom-view) and PTY (native-view) arg builders. Empty when no
+/// effort was selected for the session, so claude falls back to its own
+/// default. Effort is a spawn-time flag for the whole session, not per-turn
+/// (unlike the per-turn agents' `thinking` arg) — see `providerDetail.ts`.
+fn effort_args(effort: Option<&str>) -> Vec<String> {
+    match effort {
+        Some(level) => vec!["--effort".into(), level.to_string()],
+        None => Vec::new(),
+    }
+}
+
 fn prepare_pty_args(
     spec: &SpawnSpec<'_>,
 ) -> Result<(tempfile::NamedTempFile, Vec<String>)> {
@@ -978,6 +996,7 @@ fn prepare_pty_args(
         "--permission-mode".into(),
         "bypassPermissions".into(),
     ];
+    args.extend(effort_args(spec.effort));
 
     if spec.fresh {
         args.push("--session-id".into());
@@ -1023,6 +1042,7 @@ fn prepare_managed_args(
         "--permission-mode".into(),
         "bypassPermissions".into(),
     ];
+    args.extend(effort_args(spec.effort));
 
     if spec.fresh {
         args.push("--session-id".into());
@@ -1669,6 +1689,19 @@ mod tests {
         let args = pi_build_args("hi", None, Some("xhigh"));
         assert!(args.contains(&"--thinking".to_string()));
         assert!(args.contains(&"xhigh".to_string()));
+    }
+
+    #[test]
+    fn effort_args_present_when_set() {
+        assert_eq!(
+            effort_args(Some("xhigh")),
+            vec!["--effort".to_string(), "xhigh".to_string()]
+        );
+    }
+
+    #[test]
+    fn effort_args_empty_when_unset() {
+        assert!(effort_args(None).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -87,6 +87,7 @@ pub async fn spawn_agent(
     repo_path: String,
     provider: Option<String>,
     name: Option<String>,
+    effort: Option<String>,
 ) -> Result<AgentRecord> {
     let sup = supervisor.inner().clone();
     sup.spawn_agent(
@@ -95,6 +96,7 @@ pub async fn spawn_agent(
         PathBuf::from(repo_path),
         provider.unwrap_or_else(|| "claude".to_string()),
         name,
+        effort,
     )
     .await
 }

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -35,6 +35,7 @@ fn get_migrations() -> Migrations<'static> {
         M::up(include_str!("../migrations/0003_retire_session_events.sql")),
         M::up(include_str!("../migrations/0004_session_user_turns.sql")),
         M::up(include_str!("../migrations/0005_session_ingest_offset.sql")),
+        M::up(include_str!("../migrations/0006_session_effort.sql")),
     ])
 }
 

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -396,6 +396,7 @@ impl Supervisor {
         repo_path: PathBuf,
         provider: String,
         name: Option<String>,
+        effort: Option<String>,
     ) -> Result<AgentRecord> {
         if !repo_path.join(".git").exists() {
             return Err(Error::InvalidPath(format!(
@@ -442,6 +443,9 @@ impl Supervisor {
             String::new(),
             view,
         );
+        // Session-level effort (claude `--effort`); persisted so start_process
+        // re-applies it on every spawn. Per-turn agents ignore it at spawn.
+        record.effort = effort;
         let parent_dir = agent_parent_dir(&agent_id)?;
         let primary_worktree = repo_worktree_path(&agent_id, &subdir)?;
 
@@ -615,6 +619,9 @@ impl Supervisor {
                         // Per-turn native always resumes (the agent built its
                         // session in the Custom view first).
                         fresh: false,
+                        // Per-turn agents take effort per-turn (build-args),
+                        // not at spawn.
+                        effort: None,
                         cols: 120,
                         rows: 32,
                     };
@@ -651,6 +658,9 @@ impl Supervisor {
                 sandbox_root,
                 session_id,
                 fresh: effective_fresh,
+                // Claude's session-level effort, persisted on the record so it
+                // re-applies on every spawn (fresh, view-switch, resume).
+                effort: record.effort.as_deref(),
                 cols: 120,
                 rows: 32,
             };

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -127,6 +127,13 @@ pub struct AgentRecord {
     /// (e.g. when the user switches views).
     #[serde(default)]
     pub session_id: Option<String>,
+    /// Claude's session-level reasoning effort (`--effort <level>`), chosen in
+    /// the composer at session creation and applied on every process spawn
+    /// (fresh, view-switch, resume). `None` = no selection; claude uses its
+    /// own default. Only the persistent-runner agent (claude) consumes this;
+    /// per-turn agents take effort per-turn instead.
+    #[serde(default)]
+    pub effort: Option<String>,
     pub created_at: String,
     #[serde(default)]
     pub last_error: Option<String>,
@@ -369,8 +376,8 @@ impl WorkspaceManager {
         // not persisted — it derives from the workspace/session dispositions.
         let session_id = uuid::Uuid::new_v4().to_string();
         conn.execute(
-            "INSERT INTO sessions (id, workspace_id, provider, view, provider_session_id, last_error, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            "INSERT INTO sessions (id, workspace_id, provider, view, provider_session_id, last_error, effort, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
             rusqlite::params![
                 session_id,
                 record.id,
@@ -378,6 +385,7 @@ impl WorkspaceManager {
                 view_to_str(&record.view),
                 record.session_id,
                 record.last_error,
+                record.effort,
                 created_millis,
             ],
         )?;
@@ -941,7 +949,8 @@ impl WorkspaceManager {
         let mut stmt = match conn.prepare(
             "SELECT w.id, w.project_id, w.name, w.task, w.created_at,
                     w.stopped_at, w.archived_at,
-                    s.provider, s.view, s.provider_session_id, s.last_error
+                    s.provider, s.view, s.provider_session_id, s.last_error,
+                    s.effort
              FROM workspaces w
              LEFT JOIN sessions s ON s.workspace_id = w.id
              ORDER BY w.created_at",
@@ -963,6 +972,7 @@ impl WorkspaceManager {
                 let view_str: Option<String> = row.get(8)?;
                 let session_id: Option<String> = row.get(9)?;
                 let last_error: Option<String> = row.get(10)?;
+                let effort: Option<String> = row.get(11)?;
 
                 Ok((
                     id,
@@ -976,6 +986,7 @@ impl WorkspaceManager {
                     view_str,
                     session_id,
                     last_error,
+                    effort,
                 ))
             })
             .ok()
@@ -995,6 +1006,7 @@ impl WorkspaceManager {
                     view_str,
                     session_id,
                     last_error,
+                    effort,
                 )| {
                     let is_archived = archived_millis.is_some();
 
@@ -1026,6 +1038,7 @@ impl WorkspaceManager {
                         status,
                         view: str_to_view(view_str.as_deref().unwrap_or("custom")),
                         session_id,
+                        effort,
                         created_at: millis_to_iso(created_millis),
                         last_error,
                         archive,
@@ -1237,7 +1250,8 @@ impl WorkspaceManager {
             .query_row(
                 "SELECT w.id, w.project_id, w.name, w.task, w.created_at,
                         w.stopped_at, w.archived_at,
-                        s.provider, s.view, s.provider_session_id, s.last_error
+                        s.provider, s.view, s.provider_session_id, s.last_error,
+                        s.effort
                  FROM workspaces w
                  LEFT JOIN sessions s ON s.workspace_id = w.id
                  WHERE w.id = ?1",
@@ -1255,6 +1269,7 @@ impl WorkspaceManager {
                         row.get::<_, Option<String>>(8)?,
                         row.get::<_, Option<String>>(9)?,
                         row.get::<_, Option<String>>(10)?,
+                        row.get::<_, Option<String>>(11)?,
                     ))
                 },
             )
@@ -1272,6 +1287,7 @@ impl WorkspaceManager {
             view_str,
             session_id,
             last_error,
+            effort,
         ) = row;
 
         let is_archived = archived_millis.is_some();
@@ -1302,6 +1318,7 @@ impl WorkspaceManager {
             status,
             view: str_to_view(view_str.as_deref().unwrap_or("custom")),
             session_id,
+            effort,
             created_at: millis_to_iso(created_millis),
             last_error,
             archive,
@@ -1347,6 +1364,7 @@ pub fn new_agent_record(
         status: AgentStatus::Spawning,
         view,
         session_id,
+        effort: None,
         created_at: Utc::now().to_rfc3339(),
         last_error: None,
         archive: None,

--- a/src/api.ts
+++ b/src/api.ts
@@ -221,8 +221,15 @@ export const api = {
     repoPath: string,
     provider?: string,
     name?: string,
+    effort?: string,
   ) =>
-    invoke<AgentRecord>("spawn_agent", { view, repoPath, provider, name }),
+    invoke<AgentRecord>("spawn_agent", {
+      view,
+      repoPath,
+      provider,
+      name,
+      effort: effort ?? null,
+    }),
   writeToAgent: (agentId: string, data: string) =>
     invoke<void>("write_to_agent", { agentId, data }),
   sendUserMessage: (

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -38,6 +38,11 @@ interface Props {
    *  `action` identifier comes from the `SlashCommand` entry. The text
    *  is NOT sent to the agent; the parent decides what to do. */
   onLocalCommand?: (action: string) => void;
+  /** True when rendered for an existing agent (ChatView) rather than a new
+   *  session (EmptyWorkspace). A provider whose effort is set at spawn
+   *  (`effortAtSpawn`, e.g. claude) hides its picker here, since the value
+   *  can't change mid-session. */
+  existingSession?: boolean;
 }
 
 export function Composer({
@@ -51,6 +56,7 @@ export function Composer({
   onSend,
   onStop,
   onLocalCommand,
+  existingSession = false,
 }: Props) {
   const features = useAppStore((s) => s.features);
 
@@ -58,15 +64,16 @@ export function Composer({
   const [provider, setProvider] = useState(defaultProvider);
   const [attachments, setAttachments] = useState<string[]>([]);
 
-  const thinkingLevels = PROVIDER_DETAIL[provider as keyof typeof PROVIDER_DETAIL]?.thinkingLevels ?? [];
-  const defaultThinking = thinkingLevels.at(-1)?.value; // highest by default
+  const detail = PROVIDER_DETAIL[provider as keyof typeof PROVIDER_DETAIL];
+  const thinkingLevels = detail?.thinkingLevels ?? [];
+  // Preferred initial level, falling back to the highest.
+  const defaultThinking = detail?.defaultLevel ?? thinkingLevels.at(-1)?.value;
   const [thinkingValue, setThinkingValue] = useState<string | undefined>(defaultThinking);
 
-  // Reset to the new provider's highest level when switching providers.
+  // Reset to the new provider's default (or highest) level when switching.
   useEffect(() => {
-    setThinkingValue(
-      (PROVIDER_DETAIL[provider as keyof typeof PROVIDER_DETAIL]?.thinkingLevels ?? []).at(-1)?.value
-    );
+    const d = PROVIDER_DETAIL[provider as keyof typeof PROVIDER_DETAIL];
+    setThinkingValue(d?.defaultLevel ?? (d?.thinkingLevels ?? []).at(-1)?.value);
   }, [provider]);
   const [slashDismissed, setSlashDismissed] = useState(false);
   const [slashIndex, setSlashIndex] = useState(0);
@@ -221,7 +228,9 @@ export function Composer({
       />
       <div className="composer-foot">
         <ModelPicker value={provider} onChange={setProvider} />
-        {features.thinkingBudget && thinkingLevels.length > 0 && (
+        {features.thinkingBudget &&
+          thinkingLevels.length > 0 &&
+          !(existingSession && detail?.effortAtSpawn) && (
           <Chip
             tip="Thinking budget"
             onClick={() => {

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -112,6 +112,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
       </div>
       <div className="composer-wrap">
         <Composer
+          existingSession
           defaultProvider={agent.provider}
           disabled={!canSend}
           placeholder={

--- a/src/data/providerDetail.ts
+++ b/src/data/providerDetail.ts
@@ -23,6 +23,13 @@ export interface ProviderDetail {
   /** Thinking/reasoning effort levels supported by this provider's CLI.
    *  Empty means the provider has no effort flag — the picker hides. */
   thinkingLevels: ThinkingLevel[];
+  /** Preferred initial level. Falls back to the highest level when unset. */
+  defaultLevel?: string;
+  /** True when effort is a session-level spawn flag (claude `--effort`) rather
+   *  than a per-message arg. The composer hides the picker on an existing
+   *  session, since the value can't change mid-session without restarting the
+   *  process (which would discard the conversation's prompt cache). */
+  effortAtSpawn?: boolean;
 }
 
 export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
@@ -30,10 +37,18 @@ export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
     path: "/opt/homebrew/bin/claude",
     models: "Opus 4.7 · Sonnet 4.6 · Haiku 4",
     installed: true,
-    // Claude's `--effort` is a session-level spawn flag, not per-message.
-    // Wiring it requires threading effort through spawn_agent — tracked as
-    // a follow-up. No picker shown until then.
-    thinkingLevels: [],
+    // `claude --effort <level>` is a session-level spawn flag (not per-message):
+    // chosen at session creation, threaded through spawn_agent, and persisted on
+    // the session record so it re-applies on every spawn. Fixed for the session.
+    thinkingLevels: [
+      { label: "Low",   value: "low"    },
+      { label: "Med",   value: "medium" },
+      { label: "High",  value: "high"   },
+      { label: "xHigh", value: "xhigh"  },
+      { label: "Max",   value: "max"    },
+    ],
+    defaultLevel: "xhigh", // matches Claude Code's own default
+    effortAtSpawn: true,
   },
   codex: {
     path: "~/.codex/bin/codex",

--- a/src/store.ts
+++ b/src/store.ts
@@ -1286,7 +1286,16 @@ export const useAppStore = create<AppState>((set, get) => ({
     const turnId = crypto.randomUUID();
     try {
       const view = get().viewMode;
-      const rec = await api.spawnAgent(view, draft.repoPath, provider, draft.name);
+      // `thinking` carries the composer's effort selection. For claude it's a
+      // session-level spawn flag (--effort), applied here; per-turn agents
+      // ignore it at spawn and take it per-turn via sendUserMessage below.
+      const rec = await api.spawnAgent(
+        view,
+        draft.repoPath,
+        provider,
+        draft.name,
+        thinking,
+      );
       const fresh = await api.getWorkspace();
       set((state) => {
         const patches: Partial<AppState> = {


### PR DESCRIPTION
Claude's `--effort` is a session-level spawn flag (not per-message), so the composer's thinking-effort picker was hidden for Claude until now. This threads the selected effort through `spawn_agent`, persists it on the session record (new `sessions.effort` column + migration `0006`), and passes `--effort <level>` on every Claude spawn — fresh, view-switch, and resume — for both the custom and native views. The picker now appears on the new-session composer (defaulting to `xhigh`, matching Claude Code) and is hidden for an existing Claude session, since effort can't change mid-session without restarting the process and discarding the conversation's prompt cache. Per-turn agents (codex/opencode/pi) are unchanged; verified by the full Rust suite (135 tests, incl. new `effort_args` coverage), `tsc` typecheck, and the frontend tests (111).

🤖 Generated with [Claude Code](https://claude.com/claude-code)