### PR TITLE
Add interactive branch picker to new-agent composer

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -312,6 +312,13 @@ pub async fn abort_merge_agent(
     git::merge_abort(&worktree).await
 }
 
+/// List all local branches in a repo. Used by the new-agent composer to
+/// let the user pick the base branch before spawning.
+#[tauri::command]
+pub async fn list_repo_branches(repo_path: String) -> Result<Vec<String>> {
+    git::list_local_branches(Path::new(&repo_path)).await
+}
+
 /// Force-delete the agent's local branch from its parent repository.
 /// Used by the merged-state UI to clean up after a PR lands. Safe-noops
 /// if the branch is already gone (matches `git::branch_delete` semantics).

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -499,6 +499,27 @@ pub async fn branch_delete(repo: &Path, branch: &str) -> Result<()> {
     )))
 }
 
+/// List all local branches in the repo, sorted alphabetically.
+pub async fn list_local_branches(repo: &Path) -> Result<Vec<String>> {
+    let out = Command::new("git")
+        .current_dir(repo)
+        .args(["for-each-ref", "refs/heads", "--format=%(refname:short)", "--sort=refname"])
+        .output()
+        .await?;
+    if !out.status.success() {
+        return Err(Error::Git(format!(
+            "for-each-ref failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    let branches = String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| l.to_string())
+        .collect();
+    Ok(branches)
+}
+
 /// List the worktree's relevant files: everything tracked plus untracked
 /// files that aren't gitignored. Paths are repo-relative with forward
 /// slashes (git's native form). This is what the File panel browses — it

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -169,6 +169,7 @@ pub fn run() {
             commands::stash_agent,
             commands::abort_merge_agent,
             commands::delete_branch_agent,
+            commands::list_repo_branches,
             commands::create_pr,
             commands::merge_pr,
             commands::get_pr_state,

--- a/src/api.ts
+++ b/src/api.ts
@@ -287,6 +287,8 @@ export const api = {
     invoke<void>("abort_merge_agent", { agentId }),
   deleteBranchAgent: (agentId: string) =>
     invoke<void>("delete_branch_agent", { agentId }),
+  listRepoBranches: (repoPath: string) =>
+    invoke<string[]>("list_repo_branches", { repoPath }),
   createPr: (agentId: string, title: string, body: string) =>
     invoke<PrState>("create_pr", { agentId, title, body }),
   mergePr: (agentId: string) => invoke<void>("merge_pr", { agentId }),

--- a/src/app.css
+++ b/src/app.css
@@ -838,6 +838,7 @@ button { cursor: default; }
   font-size: 11.5px; color: var(--fg-1);
   border: 1px solid transparent;
   transition: background .12s, border-color .12s;
+  min-width: 0; flex-shrink: 0;
 }
 .c-chip:hover { background: var(--hover); color: var(--fg-0); }
 .c-chip svg { width: 11px; height: 11px; color: var(--fg-2); }
@@ -900,6 +901,17 @@ button { cursor: default; }
   letter-spacing: 0.08em; text-transform: uppercase;
   color: var(--fg-3);
 }
+
+/* branch picker scroll buttons */
+.bp-scroll-btn {
+  display: flex; align-items: center; justify-content: center;
+  width: 100%; height: 24px;
+  background: none; border: none; border-top: 1px solid var(--bd-soft);
+  color: var(--fg-3); cursor: default;
+  transition: background 0.1s, color 0.1s;
+}
+.bp-scroll-btn:first-of-type { border-top: none; border-bottom: 1px solid var(--bd-soft); }
+.bp-scroll-btn:hover { background: var(--hover); color: var(--fg-0); }
 
 /* right pane */
 .right-h {
@@ -1565,7 +1577,8 @@ button { cursor: default; }
   transition: background .12s, border-color .12s;
   cursor: default;
 }
-.empty-meta .pill:hover { background: var(--hover); border-color: var(--bd); color: var(--fg-0); }
+.empty-meta .pill.is-action { cursor: pointer; }
+.empty-meta .pill.is-action:hover { background: var(--hover); border-color: var(--bd); color: var(--fg-0); }
 .empty-meta .pill svg { width: 11px; height: 11px; }
 .empty-meta .pill .v { color: var(--fg-0); }
 

--- a/src/components/Composer/BranchPicker.tsx
+++ b/src/components/Composer/BranchPicker.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useRef, useState } from "react";
+import { api } from "../../api";
+import { Icon } from "../Icon";
+import { Chip } from "../ui/Chip";
+import { Scrim } from "../ui/Scrim";
+
+const ITEM_HEIGHT = 34; // approximate px per dd-item row
+const VISIBLE_ITEMS = 8;
+const MAX_HEIGHT = ITEM_HEIGHT * VISIBLE_ITEMS;
+const SCROLL_STEP = ITEM_HEIGHT * 3;
+
+interface Props {
+  repoPath: string;
+  value: string;
+  onChange: (branch: string) => void;
+}
+
+export function BranchPicker({ repoPath, value, onChange }: Props) {
+  const [open, setOpen] = useState(false);
+  const [branches, setBranches] = useState<string[]>([]);
+  const [canScrollUp, setCanScrollUp] = useState(false);
+  const [canScrollDown, setCanScrollDown] = useState(false);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    api.listRepoBranches(repoPath).then((bs) => {
+      setBranches(bs);
+      // after render, check if the selected branch needs scroll and update indicators
+      requestAnimationFrame(() => updateScrollState());
+    }).catch(() => setBranches([]));
+  }, [open, repoPath]);
+
+  function updateScrollState() {
+    const el = listRef.current;
+    if (!el) return;
+    setCanScrollUp(el.scrollTop > 0);
+    setCanScrollDown(el.scrollTop + el.clientHeight < el.scrollHeight - 1);
+  }
+
+  function scrollBy(delta: number) {
+    listRef.current?.scrollBy({ top: delta, behavior: "smooth" });
+  }
+
+  return (
+    <div style={{ position: "relative", minWidth: 0 }}>
+      <Chip tip={value} onClick={() => setOpen((v) => !v)}>
+        <Icon name="branch" size={11} />
+        <span style={{ color: "var(--fg-2)" }}>from</span>
+        <span style={{
+          fontFamily: "var(--font-mono)",
+          maxWidth: 140,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}>{value}</span>
+        <Icon name="chevD" size={9} />
+      </Chip>
+
+      {open && (
+        <>
+          <Scrim onClose={() => setOpen(false)} />
+          <div className="dd" style={{ bottom: "calc(100% + 6px)", left: 0, padding: 0, overflow: "hidden" }}>
+            <div className="dd-sect" style={{ padding: "7px 9px 4px" }}>Local branches</div>
+
+            {canScrollUp && (
+              <button
+                type="button"
+                className="bp-scroll-btn"
+                onClick={() => scrollBy(-SCROLL_STEP)}
+              >
+                <Icon name="chevU" size={11} />
+              </button>
+            )}
+
+            <div
+              ref={listRef}
+              style={{ maxHeight: MAX_HEIGHT, overflowY: "auto" }}
+              onScroll={updateScrollState}
+            >
+              {branches.length === 0 ? (
+                <div className="dd-item is-disabled" style={{ padding: "7px 9px" }}>Loading…</div>
+              ) : (
+                branches.map((b) => (
+                  <div
+                    key={b}
+                    className={`dd-item ${b === value ? "active" : ""}`}
+                    style={{ padding: "7px 9px" }}
+                    onClick={() => {
+                      onChange(b);
+                      setOpen(false);
+                    }}
+                  >
+                    <Icon name="branch" size={14} />
+                    <span className="di-l" style={{ fontFamily: "var(--font-mono)" }}>{b}</span>
+                  </div>
+                ))
+              )}
+            </div>
+
+            {canScrollDown && (
+              <button
+                type="button"
+                className="bp-scroll-btn"
+                onClick={() => scrollBy(SCROLL_STEP)}
+              >
+                <Icon name="chevD" size={11} />
+              </button>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -7,6 +7,7 @@ import { filterCommands, type SlashCommand } from "../../data/slashCommands";
 import { Icon } from "../Icon";
 import { Chip } from "../ui/Chip";
 import { ModelPicker } from "./ModelPicker";
+import { BranchPicker } from "./BranchPicker";
 import { SlashMenu } from "./SlashMenu";
 import { AttachmentList } from "./AttachmentList";
 import { useFileDrop } from "./useFileDrop";
@@ -14,9 +15,11 @@ import { useFileDrop } from "./useFileDrop";
 interface Props {
   /** Initial provider id — defaults to claude. */
   defaultProvider?: string;
-  /** When set, render a `from <branch>` chip and call `onChangeBase` on click. */
+  /** When set, render a branch picker chip showing the current base branch. */
   baseBranch?: string;
-  onChangeBase?: () => void;
+  /** Repo path used to fetch available branches for the picker. */
+  repoPath?: string;
+  onChangeBase?: (branch: string) => void;
   placeholder?: string;
   autoFocus?: boolean;
   disabled?: boolean;
@@ -48,6 +51,7 @@ interface Props {
 export function Composer({
   defaultProvider = DEFAULT_PROVIDER_ID,
   baseBranch,
+  repoPath,
   onChangeBase,
   placeholder,
   autoFocus,
@@ -249,8 +253,15 @@ export function Composer({
             <span>Auto-edit</span>
           </Chip>
         )}
-        {baseBranch && (
-          <Chip tip="Base branch" onClick={onChangeBase}>
+        {baseBranch && repoPath && onChangeBase && (
+          <BranchPicker
+            repoPath={repoPath}
+            value={baseBranch}
+            onChange={onChangeBase}
+          />
+        )}
+        {baseBranch && (!repoPath || !onChangeBase) && (
+          <Chip tip="Base branch">
             <Icon name="branch" size={11} />
             <span style={{ color: "var(--fg-2)" }}>from</span>
             <span style={{ fontFamily: "var(--font-mono)" }}>{baseBranch}</span>

--- a/src/components/Workspace/EmptyWorkspace.tsx
+++ b/src/components/Workspace/EmptyWorkspace.tsx
@@ -13,6 +13,7 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
   const rerollDraftName = useAppStore((s) => s.rerollDraftName);
   const spawnFromDraft = useAppStore((s) => s.spawnFromDraft);
   const removeDraft = useAppStore((s) => s.removeDraft);
+  const updateDraft = useAppStore((s) => s.updateDraft);
   const toggleLeft = useAppStore((s) => s.toggleLeft);
   const leftCollapsed = useAppStore((s) => s.leftCollapsed);
 
@@ -87,6 +88,8 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
             autoFocus
             defaultProvider={draft.provider}
             baseBranch={draft.base}
+            repoPath={draft.repoPath}
+            onChangeBase={(branch) => updateDraft(draft.id, { base: branch })}
             placeholder="Describe the task for the agent. ↵ to spawn."
             onSend={({ text, provider, attachments, thinking }) =>
               spawnFromDraft(draft.id, text, provider, attachments, thinking)
@@ -102,7 +105,7 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
               <span style={{ color: "var(--fg-2)" }}>from</span>
               <span className="v">{draft.base}</span>
             </span>
-            <span className="pill" onClick={() => rerollDraftName(draft.id)}>
+            <span className="pill is-action" onClick={() => rerollDraftName(draft.id)}>
               <Icon name="refresh" />
               <span>reroll name</span>
             </span>


### PR DESCRIPTION
## Summary
- Clicking the \"from <branch>\" chip in the new-agent screen opens a scrollable dropdown listing all local branches, letting the user choose the base branch before spawning
- Long branch names in the chip are truncated with ellipsis (max 140px) and the full name appears in a tooltip
- The dropdown caps at 8 visible items with scroll-up/down buttons that appear when there's hidden content
- Informational meta pills (project folder, branch) no longer show a hover effect — only the "reroll name" pill is styled as interactive

## Test Plan
- [ ] Open new agent screen, click the branch chip, verify dropdown lists local branches
- [ ] Select a non-default branch and confirm the chip and meta pill update
- [ ] Test with a repo that has many branches — verify scroll buttons appear and work
- [ ] Verify long branch names truncate in the chip without wrapping or squeezing other footer elements