### PR TITLE
Show the actual model per agent turn in the composer

### DIFF
--- a/src/adapters/claude/reduce.test.ts
+++ b/src/adapters/claude/reduce.test.ts
@@ -159,3 +159,66 @@ describe("claudeAdapter.reduce — extended thinking", () => {
     expect(claudeAdapter.policy["notice:reasoning"]).toBe("show");
   });
 });
+
+describe("claudeAdapter.reduce — model", () => {
+  it("stamps the model from a finalized assistant event onto the agent_message", () => {
+    const items = reduceAll([
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          model: "claude-opus-4-8",
+          content: [{ type: "text", text: "Hi there" }],
+        },
+      },
+    ] as RawEvent[]);
+    expect(items).toEqual([
+      {
+        kind: "agent_message",
+        text: "Hi there",
+        streaming: false,
+        model: "claude-opus-4-8",
+      },
+    ]);
+  });
+
+  it("stamps the model onto a message that streamed in before the finalized event", () => {
+    const items = reduceAll([
+      {
+        type: "stream_event",
+        event: {
+          type: "content_block_start",
+          content_block: { type: "text", text: "Hi there" },
+        },
+      },
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "text", text: "Hi there" }],
+        },
+      },
+    ] as RawEvent[]);
+    expect(items).toEqual([
+      {
+        kind: "agent_message",
+        text: "Hi there",
+        streaming: false,
+        model: "claude-sonnet-4-6",
+      },
+    ]);
+  });
+
+  it("leaves model undefined when the event carries none", () => {
+    const items = reduceAll([
+      {
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "text", text: "Hi" }] },
+      },
+    ] as RawEvent[]);
+    expect(items).toEqual([
+      { kind: "agent_message", text: "Hi", streaming: false },
+    ]);
+  });
+});

--- a/src/adapters/claude/reduce.ts
+++ b/src/adapters/claude/reduce.ts
@@ -65,6 +65,11 @@ function handleStreamEvent(prev: ChatItem[], ev: RawEvent): ChatItem[] {
 function handleAssistant(prev: ChatItem[], ev: RawEvent): ChatItem[] {
   const message = asRecord(ev.message);
   const content = asBlockList(message.content);
+  // The model that produced this turn (Claude reports it on the finalized
+  // assistant event). Stamped onto the turn's agent_message so the UI can show
+  // the actual model in use; absent on stream deltas, so a turn that streamed
+  // in gets its model only once this finalized event arrives.
+  const model = typeof message.model === "string" ? message.model : undefined;
   let items = finalizeStreamingItems(prev);
   // The finalized assistant event arrives after the stream events for the
   // same turn. Anything already in items past the last user_message belongs
@@ -91,11 +96,25 @@ function handleAssistant(prev: ChatItem[], ev: RawEvent): ChatItem[] {
       if (exists) continue;
       items = [...items, { kind: "notice", subtype: "reasoning", text }];
     } else if (block.type === "text" && typeof block.text === "string") {
-      const exists = items
+      // The text may already exist as a streamed agent_message for this turn
+      // (deltas arrived before this finalized event). If so, stamp the model
+      // onto it rather than appending a duplicate; otherwise append fresh.
+      const existingIdx = items
         .slice(turnStart)
-        .some((it) => it.kind === "agent_message" && it.text === block.text);
-      if (exists) continue;
-      items = [...items, { kind: "agent_message", text: block.text, streaming: false }];
+        .findIndex((it) => it.kind === "agent_message" && it.text === block.text);
+      if (existingIdx !== -1) {
+        const absIdx = turnStart + existingIdx;
+        const existing = items[absIdx];
+        if (existing.kind === "agent_message" && model && existing.model !== model) {
+          items = items.slice();
+          items[absIdx] = { ...existing, model };
+        }
+        continue;
+      }
+      items = [
+        ...items,
+        { kind: "agent_message", text: block.text, streaming: false, model },
+      ];
     } else if (block.type === "tool_use") {
       items = upsertToolCall(items, {
         kind: "tool_call",

--- a/src/adapters/codex/normalize.ts
+++ b/src/adapters/codex/normalize.ts
@@ -47,10 +47,20 @@ export function normalizeTranscript(lines: unknown[]): RawEvent[] {
   }
 
   const out: RawEvent[] = [];
+  // The model is reported on `turn_context` records (`payload.model`), which
+  // precede the turn's events. Track the latest and stamp it onto the agent
+  // messages that follow so the UI can show the model in use on replay.
+  let currentModel: string | undefined;
   for (const raw of lines) {
     const env = asRecord(raw);
     const p = asRecord(env.payload);
     const ptype = typeof p.type === "string" ? p.type : "";
+
+    if (env.type === "turn_context") {
+      const m = p.model;
+      if (typeof m === "string") currentModel = m;
+      continue;
+    }
 
     if (env.type === "event_msg") {
       if (ptype === "user_message") {
@@ -61,7 +71,7 @@ export function normalizeTranscript(lines: unknown[]): RawEvent[] {
         if (text) {
           out.push({
             type: "item.completed",
-            item: { id: `msg_${out.length}`, type: "agent_message", text },
+            item: { id: `msg_${out.length}`, type: "agent_message", text, model: currentModel },
           });
         }
       } else if (ptype === "task_complete") {

--- a/src/adapters/codex/reduce.test.ts
+++ b/src/adapters/codex/reduce.test.ts
@@ -125,6 +125,21 @@ describe("codexAdapter", () => {
     ]);
   });
 
+  it("stamps the turn_context model onto replayed agent messages", () => {
+    const events = codexAdapter.normalizeTranscript([
+      { type: "turn_context", payload: { model: "gpt-5.2-codex" } },
+      { type: "event_msg", payload: { type: "user_message", message: "hi" } },
+      { type: "event_msg", payload: { type: "agent_message", message: "hello back" } },
+      { type: "event_msg", payload: { type: "task_complete" } },
+    ]);
+    const items = run(events as RawEvent[]);
+    expect(items).toContainEqual({
+      kind: "agent_message",
+      text: "hello back",
+      model: "gpt-5.2-codex",
+    });
+  });
+
   it("replays a failed shell command as an error, not a success", () => {
     const events = codexAdapter.normalizeTranscript([
       {

--- a/src/adapters/codex/reduce.ts
+++ b/src/adapters/codex/reduce.ts
@@ -108,7 +108,10 @@ export function reduce(prev: ChatItem[], ev: RawEvent): ChatItem[] {
         const items = finalizeStreamingItems(prev);
         const text = typeof item.text === "string" ? item.text : "";
         if (!text) return items;
-        return dedupAgainstLast(items, { kind: "agent_message", text });
+        // `model` is attached by normalizeTranscript from the turn_context
+        // record; absent on the live exec stream (which omits it).
+        const model = typeof item.model === "string" ? item.model : undefined;
+        return dedupAgainstLast(items, { kind: "agent_message", text, model });
       }
 
       if (itemType === "reasoning") {

--- a/src/adapters/opencode/normalize.test.ts
+++ b/src/adapters/opencode/normalize.test.ts
@@ -19,7 +19,7 @@ function render(lines: unknown[]): ChatItem[] {
 const records: unknown[] = [
   { id: "m1", role: "user", sessionID: "s" }, // message blob (no `type`)
   { id: "p1", type: "text", messageID: "m1", text: "hello" },
-  { id: "m2", role: "assistant", sessionID: "s" },
+  { id: "m2", role: "assistant", sessionID: "s", modelID: "grok-code" },
   { id: "p2", type: "text", messageID: "m2", text: "hi there" },
   {
     id: "p3",
@@ -37,7 +37,8 @@ describe("opencodeAdapter.normalizeTranscript", () => {
     const items = render(records);
     expect(items).toEqual([
       { kind: "user_message", text: "hello" },
-      { kind: "agent_message", text: "hi there" },
+      // The assistant blob's modelID rides through onto the agent_message.
+      { kind: "agent_message", text: "hi there", model: "grok-code" },
       { kind: "tool_call", id: "c1", name: "bash", input: { command: "ls" }, streaming: false },
       { kind: "tool_result", tool_use_id: "c1", content: "file.txt", is_error: false },
       { kind: "notice", subtype: "turn_end", text: "success" },

--- a/src/adapters/opencode/normalize.ts
+++ b/src/adapters/opencode/normalize.ts
@@ -26,11 +26,15 @@ const PART_TO_LIVE: Record<string, string> = {
 
 export function normalizeTranscript(lines: unknown[]): RawEvent[] {
   // First pass: messageID → role (message blobs have role + id, no `type`).
+  // Assistant message blobs also carry `modelID` (the model that produced the
+  // turn); index it so the emitted text event can carry the model to the UI.
   const roleOf = new Map<string, string>();
+  const modelOf = new Map<string, string>();
   for (const line of lines) {
     const rec = asRecord(line);
     if (rec.type == null && typeof rec.id === "string" && typeof rec.role === "string") {
       roleOf.set(rec.id, rec.role);
+      if (typeof rec.modelID === "string") modelOf.set(rec.id, rec.modelID);
     }
   }
 
@@ -50,7 +54,9 @@ export function normalizeTranscript(lines: unknown[]): RawEvent[] {
 
     const liveType = PART_TO_LIVE[rec.type];
     if (!liveType) continue; // subtask / unknown — nothing renderable
-    out.push({ type: liveType, part: rec });
+    const model =
+      typeof rec.messageID === "string" ? modelOf.get(rec.messageID) : undefined;
+    out.push({ type: liveType, part: rec, model });
   }
   return out;
 }

--- a/src/adapters/opencode/reduce.ts
+++ b/src/adapters/opencode/reduce.ts
@@ -77,7 +77,10 @@ export function reduce(prev: ChatItem[], ev: RawEvent): ChatItem[] {
       const text = typeof part.text === "string" ? part.text : "";
       if (!text) return prev;
       const items = finalizeStreamingItems(prev);
-      return dedupAgainstLast(items, { kind: "agent_message", text });
+      // `model` is attached by normalizeTranscript from the parent message
+      // blob's `modelID`; absent on the live run stream (which omits it).
+      const model = typeof ev.model === "string" ? ev.model : undefined;
+      return dedupAgainstLast(items, { kind: "agent_message", text, model });
     }
 
     // A reasoning part (`opencode run --thinking`, verified against 1.15.12):

--- a/src/adapters/pi/reduce.test.ts
+++ b/src/adapters/pi/reduce.test.ts
@@ -55,7 +55,12 @@ describe("piAdapter", () => {
       is_error: false,
     });
 
-    expect(items[3]).toEqual({ kind: "agent_message", text: 'It printed "hello".' });
+    // The agent_message carries the model pi reports on the message_end event.
+    expect(items[3]).toEqual({
+      kind: "agent_message",
+      text: 'It printed "hello".',
+      model: "claude-opus-4-7",
+    });
     expect(items[4]).toEqual({ kind: "notice", subtype: "turn_end", text: "success" });
   });
 

--- a/src/adapters/pi/reduce.ts
+++ b/src/adapters/pi/reduce.ts
@@ -57,6 +57,9 @@ export function reduce(prev: ChatItem[], ev: RawEvent): ChatItem[] {
       }
 
       if (role === "assistant") {
+        // pi reports the model on every message object; stamp it onto the
+        // turn's agent_message so the UI can show the actual model in use.
+        const model = typeof msg.model === "string" ? msg.model : undefined;
         let items = prev;
         for (const block of asBlockList(msg.content)) {
           if (block.type === "thinking") {
@@ -67,7 +70,12 @@ export function reduce(prev: ChatItem[], ev: RawEvent): ChatItem[] {
             if (text) items = [...items, { kind: "notice", subtype: "reasoning", text }];
           } else if (block.type === "text") {
             const text = typeof block.text === "string" ? block.text : "";
-            if (text) items = dedupAgainstLast(items, { kind: "agent_message", text });
+            if (text)
+              items = dedupAgainstLast(items, {
+                kind: "agent_message",
+                text,
+                model,
+              });
           } else if (block.type === "toolCall") {
             const id = typeof block.id === "string" ? block.id : "";
             if (!id) continue;

--- a/src/adapters/shared/reducer-helpers.ts
+++ b/src/adapters/shared/reducer-helpers.ts
@@ -111,6 +111,19 @@ export function dedupAgainstLast(
 ): ChatItem[] {
   const last = items[items.length - 1];
   if (last && last.kind === candidate.kind && last.text === candidate.text) {
+    // Same text already there. If the candidate carries a model the existing
+    // item lacks (the finalized event arriving after a streamed one), stamp it
+    // on rather than dropping it.
+    if (
+      candidate.kind === "agent_message" &&
+      last.kind === "agent_message" &&
+      candidate.model &&
+      last.model !== candidate.model
+    ) {
+      const next = items.slice();
+      next[next.length - 1] = { ...last, model: candidate.model };
+      return next;
+    }
     return items;
   }
   // Suppress an echoed user_message whose text matches the slash_command

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -7,7 +7,18 @@
 
 export type ChatItem =
   | { kind: "user_message"; text: string; attachments?: string[] }
-  | { kind: "agent_message"; text: string; streaming?: boolean }
+  | {
+      kind: "agent_message";
+      text: string;
+      streaming?: boolean;
+      /** The model that produced this turn, when the agent reports it in its
+       *  transcript: Claude/pi `message.model` (live + replay); Codex
+       *  `turn_context.model` and OpenCode message-blob `modelID` (replay only —
+       *  their live streams omit it). Absent for Cursor (model only in the live
+       *  `init` event, not the on-disk transcript) and Antigravity (no model in
+       *  the transcript) — consumers fall back to the static provider label. */
+      model?: string;
+    }
   | {
       kind: "tool_call";
       id: string;

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -3,6 +3,7 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { useAppStore } from "../../store";
 import { DEFAULT_PROVIDER_ID } from "../../data/providers";
 import { PROVIDER_DETAIL } from "../../data/providerDetail";
+import { prettyModelLabel } from "../../data/modelLabel";
 import { filterCommands, type SlashCommand } from "../../data/slashCommands";
 import { Icon } from "../Icon";
 import { Chip } from "../ui/Chip";
@@ -43,6 +44,12 @@ interface Props {
    *  (`effortAtSpawn`, e.g. claude) hides its picker here, since the value
    *  can't change mid-session. */
   existingSession?: boolean;
+  /** The model the agent actually used on its most recent turn, read from the
+   *  transcript (Claude, pi, Codex, OpenCode report it). Shown as a read-only
+   *  chip next to the provider so the user can see the real model in use.
+   *  Undefined for Cursor / Antigravity (no model in their transcript) or
+   *  before the first agent turn. */
+  activeModel?: string;
 }
 
 export function Composer({
@@ -57,6 +64,7 @@ export function Composer({
   onStop,
   onLocalCommand,
   existingSession = false,
+  activeModel,
 }: Props) {
   const features = useAppStore((s) => s.features);
 
@@ -228,6 +236,13 @@ export function Composer({
       />
       <div className="composer-foot">
         <ModelPicker value={provider} onChange={setProvider} />
+        {existingSession && activeModel && (
+          <Chip tip={`Model in use · ${activeModel}`}>
+            <span style={{ color: "var(--fg-2)" }}>
+              {prettyModelLabel(activeModel)}
+            </span>
+          </Chip>
+        )}
         {features.thinkingBudget &&
           thinkingLevels.length > 0 &&
           !(existingSession && detail?.effortAtSpawn) && (

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -67,6 +67,18 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
     const visible = applyPolicy(log ?? [], adapter.policy);
     return pairToolItems(visible);
   }, [log, agent.provider]);
+
+  // The model the agent actually used on its most recent turn (Claude, pi,
+  // Codex, OpenCode report it in their transcripts). Undefined for Cursor /
+  // Antigravity, or before the first turn — the composer then shows just the
+  // provider.
+  const activeModel = useMemo(() => {
+    for (let i = items.length - 1; i >= 0; i -= 1) {
+      const it = items[i];
+      if (it.kind === "agent_message" && it.model) return it.model;
+    }
+    return undefined;
+  }, [items]);
   const canSend =
     !transcriptLoading &&
     !switchInFlight &&
@@ -113,6 +125,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
       <div className="composer-wrap">
         <Composer
           existingSession
+          activeModel={activeModel}
           defaultProvider={agent.provider}
           disabled={!canSend}
           placeholder={

--- a/src/data/modelLabel.test.ts
+++ b/src/data/modelLabel.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { prettyModelLabel } from "./modelLabel";
+
+describe("prettyModelLabel", () => {
+  it("formats Claude ids", () => {
+    expect(prettyModelLabel("claude-opus-4-7")).toBe("Claude Opus 4.7");
+    expect(prettyModelLabel("claude-sonnet-4-6")).toBe("Claude Sonnet 4.6");
+    expect(prettyModelLabel("claude-haiku-4-5")).toBe("Claude Haiku 4.5");
+    expect(prettyModelLabel("claude-opus-4-8")).toBe("Claude Opus 4.8");
+  });
+
+  it("drops a trailing date snapshot", () => {
+    expect(prettyModelLabel("claude-haiku-4-5-20251001")).toBe("Claude Haiku 4.5");
+  });
+
+  it("formats GPT / Codex ids", () => {
+    expect(prettyModelLabel("gpt-5.5")).toBe("GPT-5.5");
+    expect(prettyModelLabel("gpt-5.2-codex")).toBe("GPT-5.2 Codex");
+  });
+
+  it("keeps the o-series lowercase convention", () => {
+    expect(prettyModelLabel("o4-mini")).toBe("o4-mini");
+  });
+
+  it("formats Gemini and Grok ids", () => {
+    expect(prettyModelLabel("gemini-3-pro")).toBe("Gemini 3 Pro");
+    expect(prettyModelLabel("grok-code")).toBe("Grok Code");
+  });
+
+  it("leaves unknown/routed model ids unchanged", () => {
+    expect(prettyModelLabel("big-pickle")).toBe("big-pickle");
+    expect(prettyModelLabel("deepseek-v4-flash-free")).toBe("deepseek-v4-flash-free");
+  });
+
+  it("handles empty input", () => {
+    expect(prettyModelLabel("")).toBe("");
+  });
+});

--- a/src/data/modelLabel.ts
+++ b/src/data/modelLabel.ts
@@ -1,0 +1,49 @@
+// Turns a raw model id from an agent transcript (e.g. `claude-opus-4-7`,
+// `gpt-5.2-codex`, `gemini-3-pro`) into a human label (`Claude Opus 4.7`,
+// `GPT-5.2 Codex`, `Gemini 3 Pro`) for display next to the provider.
+//
+// Best-effort: known families (Claude, GPT, OpenAI o-series, Gemini, Grok) get
+// a tailored label; anything unrecognized (OpenCode can route arbitrary
+// upstream models) is returned unchanged rather than mangled.
+
+function cap(word: string): string {
+  return word ? word[0].toUpperCase() + word.slice(1) : word;
+}
+
+/** Capitalize each dash-separated token: `flash-free` → `Flash Free`. */
+function titleizeTokens(s: string): string {
+  return s.split("-").filter(Boolean).map(cap).join(" ");
+}
+
+export function prettyModelLabel(id: string): string {
+  const raw = id.trim();
+  if (!raw) return raw;
+
+  // Drop a trailing date snapshot (`claude-haiku-4-5-20251001`).
+  const base = raw.replace(/-\d{8}$/, "");
+
+  // Claude: claude-<tier>-<major>-<minor> → "Claude Opus 4.7".
+  let m = base.match(/^claude-(opus|sonnet|haiku)-(\d+)-(\d+)$/);
+  if (m) return `Claude ${cap(m[1])} ${m[2]}.${m[3]}`;
+  // Claude without a minor: claude-opus-4 → "Claude Opus 4".
+  m = base.match(/^claude-(opus|sonnet|haiku)-(\d+)$/);
+  if (m) return `Claude ${cap(m[1])} ${m[2]}`;
+
+  // GPT: gpt-5.2-codex → "GPT-5.2 Codex"; gpt-5.5 → "GPT-5.5".
+  m = base.match(/^gpt-([\d.]+)(?:-(.+))?$/);
+  if (m) return `GPT-${m[1]}${m[2] ? ` ${titleizeTokens(m[2])}` : ""}`;
+
+  // OpenAI o-series keeps its lowercase-o convention: o4-mini → "o4-mini".
+  if (/^o\d/.test(base)) return base;
+
+  // Gemini: gemini-3-pro → "Gemini 3 Pro".
+  m = base.match(/^gemini-(.+)$/);
+  if (m) return `Gemini ${titleizeTokens(m[1])}`;
+
+  // Grok: grok-code → "Grok Code".
+  m = base.match(/^grok-(.+)$/);
+  if (m) return `Grok ${titleizeTokens(m[1])}`;
+
+  // Unknown shape (e.g. a routed upstream model) — leave as-is.
+  return raw;
+}


### PR DESCRIPTION
Surfaces the real model each agent used on its most recent turn as a read-only, prettified chip next to the provider in the composer, read from the transcript the app already ingests. The model is carried on the `agent_message` ChatItem: Claude and pi report it on the message (live + replay), while Codex (`turn_context.model`) and OpenCode (message-blob `modelID`) are captured during transcript normalize (replay path); Cursor and Antigravity have no model in their transcript and fall back to the provider label. Adds a reusable `prettyModelLabel` helper (e.g. `claude-opus-4-7` → Claude Opus 4.7, `gpt-5.2-codex` → GPT-5.2 Codex) with the raw id kept in the chip tooltip, and unknown/routed ids left unchanged. All adapter reducers, the shared dedup helper, and `ChatView` were updated to thread the model through; 122 tests pass and `tsc` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)