### PR TITLE
Real OAuth (GitHub + Google) device-flow login in onboarding

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1120,8 +1120,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1131,9 +1133,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1436,6 +1440,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1931,6 +1936,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markup5ever"
@@ -2601,6 +2612,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2688,6 +2708,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quorum"
 version = "0.1.2"
 dependencies = [
@@ -2696,6 +2771,7 @@ dependencies = [
  "nix 0.29.0",
  "parking_lot",
  "portable-pty",
+ "reqwest 0.12.28",
  "rusqlite",
  "rusqlite_migration",
  "serde",
@@ -2734,6 +2810,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -2820,6 +2925,44 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
 
 [[package]]
 name = "reqwest"
@@ -2982,6 +3125,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3028,6 +3172,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3249,6 +3399,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3743,7 +3905,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3931,7 +4093,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.13.3",
  "rustls",
  "semver",
  "serde",
@@ -4816,6 +4978,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4876,6 +5048,15 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -104,6 +104,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +316,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -348,6 +372,15 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -934,6 +967,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1440,7 +1479,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1782,6 +1820,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -2733,6 +2781,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -2771,7 +2820,7 @@ dependencies = [
  "nix 0.29.0",
  "parking_lot",
  "portable-pty",
- "reqwest 0.12.28",
+ "reqwest",
  "rusqlite",
  "rusqlite_migration",
  "serde",
@@ -2928,44 +2977,6 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
@@ -2984,11 +2995,13 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -3099,6 +3112,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3162,6 +3176,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3905,7 +3920,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4093,7 +4108,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest 0.13.3",
+ "reqwest",
  "rustls",
  "semver",
  "serde",
@@ -5048,15 +5063,6 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,6 +33,7 @@ chrono = { version = "0.4", features = ["serde"] }
 tempfile = "3"
 rusqlite = { version = "0.31", features = ["bundled"] }
 rusqlite_migration = "1"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,7 +33,7 @@ chrono = { version = "0.4", features = ["serde"] }
 tempfile = "3"
 rusqlite = { version = "0.31", features = ["bundled"] }
 rusqlite_migration = "1"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "form", "rustls"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/migrations/0007_account_oauth.sql
+++ b/src-tauri/migrations/0007_account_oauth.sql
@@ -1,0 +1,3 @@
+-- Link the single local account to an external identity provider.
+ALTER TABLE accounts ADD COLUMN oauth_provider TEXT;
+ALTER TABLE accounts ADD COLUMN oauth_id TEXT;

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -36,6 +36,7 @@ fn get_migrations() -> Migrations<'static> {
         M::up(include_str!("../migrations/0004_session_user_turns.sql")),
         M::up(include_str!("../migrations/0005_session_ingest_offset.sql")),
         M::up(include_str!("../migrations/0006_session_effort.sql")),
+        M::up(include_str!("../migrations/0007_account_oauth.sql")),
     ])
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod git;
 mod git_state;
 mod managed_session;
 mod names;
+mod oauth;
 mod pty_session;
 mod run_session;
 mod sandbox;
@@ -140,6 +141,7 @@ pub fn run() {
             db_upsert,
             db_count,
             db_query,
+            oauth::oauth_device_login,
             commands::get_workspace,
             commands::get_agent_diff_stats,
             commands::add_workspace_repo,

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -139,7 +139,18 @@ pub async fn oauth_device_login(
         .await
         .map_err(|e| e.to_string())?;
 
-    let device_code = str_field(&dc, "device_code").ok_or("no device_code in response")?;
+    let device_code = match str_field(&dc, "device_code") {
+        Some(c) => c,
+        None => {
+            // No device_code means the provider rejected the request — surface
+            // its error/description (and the raw body) instead of a blind miss.
+            let err = str_field(&dc, "error").unwrap_or_default();
+            let desc = str_field(&dc, "error_description").unwrap_or_default();
+            return Err(format!(
+                "device code request rejected: {err} {desc} (raw: {dc})"
+            ));
+        }
+    };
     let user_code = str_field(&dc, "user_code").ok_or("no user_code in response")?;
     // GitHub uses `verification_uri`; Google uses `verification_url`.
     let verification = str_field(&dc, "verification_uri")

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -1,0 +1,292 @@
+//! Identity-only OAuth via the Device Authorization Grant (RFC 8628).
+//! GitHub and Google are both supported. We never persist the access token —
+//! it is used once to read the profile, then dropped.
+
+use serde::Serialize;
+use std::time::Duration;
+use tauri::{AppHandle, Emitter};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OAuthProfile {
+    pub provider: String,
+    pub provider_user_id: String,
+    pub name: Option<String>,
+    pub email: Option<String>,
+    pub avatar_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct DeviceCodePayload {
+    provider: String,
+    user_code: String,
+    verification_uri: String,
+}
+
+pub enum PollOutcome {
+    Token(String),
+    Pending,
+    SlowDown,
+    Failed(String),
+}
+
+struct ProviderCfg {
+    device_code_url: &'static str,
+    token_url: &'static str,
+    scope: &'static str,
+    client_id: String,
+    /// Google only — required by its device endpoint but, per Google's docs,
+    /// not treated as confidential for "limited-input device" clients.
+    client_secret: Option<String>,
+}
+
+fn provider_cfg(provider: &str) -> Result<ProviderCfg, String> {
+    match provider {
+        "github" => Ok(ProviderCfg {
+            device_code_url: "https://github.com/login/device/code",
+            token_url: "https://github.com/login/oauth/access_token",
+            scope: "read:user user:email",
+            client_id: std::env::var("QUORUM_GITHUB_CLIENT_ID")
+                .map_err(|_| "GitHub sign-in is not configured".to_string())?,
+            client_secret: None,
+        }),
+        "google" => Ok(ProviderCfg {
+            device_code_url: "https://oauth2.googleapis.com/device/code",
+            token_url: "https://oauth2.googleapis.com/token",
+            scope: "openid email profile",
+            client_id: std::env::var("QUORUM_GOOGLE_CLIENT_ID")
+                .map_err(|_| "Google sign-in is not configured".to_string())?,
+            client_secret: Some(
+                std::env::var("QUORUM_GOOGLE_CLIENT_SECRET")
+                    .map_err(|_| "Google sign-in is not configured".to_string())?,
+            ),
+        }),
+        other => Err(format!("unknown provider: {other}")),
+    }
+}
+
+fn str_field(v: &serde_json::Value, key: &str) -> Option<String> {
+    v.get(key).and_then(|x| x.as_str()).map(|s| s.to_string())
+}
+
+pub fn github_profile(user: &serde_json::Value, emails: &serde_json::Value) -> OAuthProfile {
+    // /user/emails carries the authoritative primary address (the /user email
+    // is often null for accounts that keep it private).
+    let email = emails
+        .as_array()
+        .and_then(|arr| {
+            arr.iter()
+                .find(|e| e.get("primary").and_then(|p| p.as_bool()).unwrap_or(false))
+                .or_else(|| arr.first())
+        })
+        .and_then(|e| str_field(e, "email"))
+        .or_else(|| str_field(user, "email"));
+    OAuthProfile {
+        provider: "github".into(),
+        provider_user_id: user
+            .get("id")
+            .map(|v| v.to_string().trim_matches('"').to_string())
+            .unwrap_or_default(),
+        name: str_field(user, "name").or_else(|| str_field(user, "login")),
+        email,
+        avatar_url: str_field(user, "avatar_url"),
+    }
+}
+
+pub fn google_profile(info: &serde_json::Value) -> OAuthProfile {
+    OAuthProfile {
+        provider: "google".into(),
+        provider_user_id: str_field(info, "sub").unwrap_or_default(),
+        name: str_field(info, "name"),
+        email: str_field(info, "email"),
+        avatar_url: str_field(info, "picture"),
+    }
+}
+
+pub fn classify_token_response(v: &serde_json::Value) -> PollOutcome {
+    if let Some(tok) = str_field(v, "access_token") {
+        return PollOutcome::Token(tok);
+    }
+    match v.get("error").and_then(|e| e.as_str()) {
+        Some("authorization_pending") => PollOutcome::Pending,
+        Some("slow_down") => PollOutcome::SlowDown,
+        Some(other) => PollOutcome::Failed(other.to_string()),
+        None => PollOutcome::Failed("malformed token response".into()),
+    }
+}
+
+/// Drive the full device flow and return a normalized profile. The access
+/// token never leaves this function — it is read once and dropped.
+#[tauri::command]
+pub async fn oauth_device_login(
+    app: AppHandle,
+    provider: String,
+) -> Result<OAuthProfile, String> {
+    let cfg = provider_cfg(&provider)?;
+    let http = reqwest::Client::builder()
+        .user_agent("Quorum")
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    // 1. Request a device + user code.
+    let dc: serde_json::Value = http
+        .post(cfg.device_code_url)
+        .header("Accept", "application/json")
+        .form(&[("client_id", cfg.client_id.as_str()), ("scope", cfg.scope)])
+        .send()
+        .await
+        .map_err(|e| e.to_string())?
+        .json()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let device_code = str_field(&dc, "device_code").ok_or("no device_code in response")?;
+    let user_code = str_field(&dc, "user_code").ok_or("no user_code in response")?;
+    // GitHub uses `verification_uri`; Google uses `verification_url`.
+    let verification = str_field(&dc, "verification_uri")
+        .or_else(|| str_field(&dc, "verification_url"))
+        .ok_or("no verification uri in response")?;
+    let mut interval = dc.get("interval").and_then(|v| v.as_u64()).unwrap_or(5);
+
+    // 2. Tell the UI to show the code (it opens the browser to `verification`).
+    let _ = app.emit(
+        "oauth:device-code",
+        DeviceCodePayload {
+            provider: provider.clone(),
+            user_code,
+            verification_uri: verification,
+        },
+    );
+
+    // 3. Poll the token endpoint until the user approves (or it fails).
+    let access_token = loop {
+        tokio::time::sleep(Duration::from_secs(interval)).await;
+        let mut poll: Vec<(&str, &str)> = vec![
+            ("client_id", cfg.client_id.as_str()),
+            ("device_code", device_code.as_str()),
+            ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+        ];
+        if let Some(secret) = &cfg.client_secret {
+            poll.push(("client_secret", secret.as_str()));
+        }
+        let resp: serde_json::Value = http
+            .post(cfg.token_url)
+            .header("Accept", "application/json")
+            .form(&poll)
+            .send()
+            .await
+            .map_err(|e| e.to_string())?
+            .json()
+            .await
+            .map_err(|e| e.to_string())?;
+        match classify_token_response(&resp) {
+            PollOutcome::Token(t) => break t,
+            PollOutcome::Pending => {}
+            PollOutcome::SlowDown => interval += 5,
+            PollOutcome::Failed(e) => return Err(format!("authorization failed: {e}")),
+        }
+    };
+
+    // 4. Read the profile, then let the token drop out of scope.
+    let profile = match provider.as_str() {
+        "github" => {
+            let user: serde_json::Value = http
+                .get("https://api.github.com/user")
+                .bearer_auth(&access_token)
+                .header("Accept", "application/vnd.github+json")
+                .send()
+                .await
+                .map_err(|e| e.to_string())?
+                .json()
+                .await
+                .map_err(|e| e.to_string())?;
+            let emails: serde_json::Value = http
+                .get("https://api.github.com/user/emails")
+                .bearer_auth(&access_token)
+                .header("Accept", "application/vnd.github+json")
+                .send()
+                .await
+                .map_err(|e| e.to_string())?
+                .json()
+                .await
+                .unwrap_or_else(|_| serde_json::json!([]));
+            github_profile(&user, &emails)
+        }
+        "google" => {
+            let info: serde_json::Value = http
+                .get("https://openidconnect.googleapis.com/v1/userinfo")
+                .bearer_auth(&access_token)
+                .send()
+                .await
+                .map_err(|e| e.to_string())?
+                .json()
+                .await
+                .map_err(|e| e.to_string())?;
+            google_profile(&info)
+        }
+        _ => return Err("unknown provider".into()),
+    };
+    Ok(profile)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_github_user_into_profile() {
+        let body = serde_json::json!({
+            "id": 4242, "login": "octocat",
+            "name": "Octo Cat", "avatar_url": "https://x/y.png"
+        });
+        let emails = serde_json::json!([
+            {"email":"a@b.com","primary":false,"verified":true},
+            {"email":"octo@github.com","primary":true,"verified":true}
+        ]);
+        let p = github_profile(&body, &emails);
+        assert_eq!(p.provider, "github");
+        assert_eq!(p.provider_user_id, "4242");
+        assert_eq!(p.name.as_deref(), Some("Octo Cat"));
+        assert_eq!(p.email.as_deref(), Some("octo@github.com")); // primary wins
+        assert_eq!(p.avatar_url.as_deref(), Some("https://x/y.png"));
+    }
+
+    #[test]
+    fn github_profile_falls_back_to_login_when_name_missing() {
+        let body = serde_json::json!({ "id": 7, "login": "ghost" });
+        let p = github_profile(&body, &serde_json::json!([]));
+        assert_eq!(p.name.as_deref(), Some("ghost"));
+        assert_eq!(p.email, None);
+    }
+
+    #[test]
+    fn parses_google_userinfo_into_profile() {
+        let body = serde_json::json!({
+            "sub": "11822", "name": "Jane Doe",
+            "email": "jane@gmail.com", "picture": "https://g/p.png"
+        });
+        let p = google_profile(&body);
+        assert_eq!(p.provider, "google");
+        assert_eq!(p.provider_user_id, "11822");
+        assert_eq!(p.email.as_deref(), Some("jane@gmail.com"));
+    }
+
+    #[test]
+    fn classifies_pending_and_terminal_poll_states() {
+        assert!(matches!(
+            classify_token_response(&serde_json::json!({"error":"authorization_pending"})),
+            PollOutcome::Pending
+        ));
+        assert!(matches!(
+            classify_token_response(&serde_json::json!({"error":"slow_down"})),
+            PollOutcome::SlowDown
+        ));
+        assert!(matches!(
+            classify_token_response(&serde_json::json!({"error":"access_denied"})),
+            PollOutcome::Failed(_)
+        ));
+        match classify_token_response(&serde_json::json!({"access_token":"tok_123"})) {
+            PollOutcome::Token(t) => assert_eq!(t, "tok_123"),
+            _ => panic!("expected token"),
+        }
+    }
+}

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -3,7 +3,7 @@
 //! it is used once to read the profile, then dropped.
 
 use serde::Serialize;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
 
 #[derive(Debug, Clone, Serialize)]
@@ -157,6 +157,9 @@ pub async fn oauth_device_login(
         .or_else(|| str_field(&dc, "verification_url"))
         .ok_or("no verification uri in response")?;
     let mut interval = dc.get("interval").and_then(|v| v.as_u64()).unwrap_or(5);
+    // Don't poll past the device code's lifetime (GitHub ~900s, Google ~1800s).
+    let expires_in = dc.get("expires_in").and_then(|v| v.as_u64()).unwrap_or(900);
+    let deadline = Instant::now() + Duration::from_secs(expires_in);
 
     // 2. Tell the UI to show the code (it opens the browser to `verification`).
     let _ = app.emit(
@@ -170,6 +173,9 @@ pub async fn oauth_device_login(
 
     // 3. Poll the token endpoint until the user approves (or it fails).
     let access_token = loop {
+        if Instant::now() >= deadline {
+            return Err("device code expired before authorization".into());
+        }
         tokio::time::sleep(Duration::from_secs(interval)).await;
         let mut poll: Vec<(&str, &str)> = vec![
             ("client_id", cfg.client_id.as_str()),

--- a/src/components/Onboarding/DeviceCode.tsx
+++ b/src/components/Onboarding/DeviceCode.tsx
@@ -1,0 +1,50 @@
+// Shown during an OAuth device-flow login: the user code to enter at the
+// provider's verification page (the browser is opened automatically), plus
+// the starting / error states. Purely presentational — the parent owns the
+// flow and the cancel behaviour.
+import type { CSSProperties } from "react";
+
+export interface DeviceCodeInfo {
+  provider: string;
+  userCode: string;
+  verificationUri: string;
+}
+
+export function DeviceCode({
+  info,
+  error,
+  onCancel,
+}: {
+  info: DeviceCodeInfo | null;
+  error: string | null;
+  onCancel: () => void;
+}) {
+  const label = (info?.provider ?? "") === "google" ? "Google" : "GitHub";
+  return (
+    <div className="ob-step">
+      <div className="ob-device ob-reveal" style={{ "--d": ".1s" } as CSSProperties}>
+        {error ? (
+          <>
+            <p className="ob-device-err">{error}</p>
+            <button className="ob-authbtn" onClick={onCancel}>
+              Back
+            </button>
+          </>
+        ) : info ? (
+          <>
+            <p className="ob-device-lede">
+              Finish signing in to {label} in your browser, then enter this code:
+            </p>
+            <div className="ob-device-code">{info.userCode}</div>
+            <p className="ob-device-uri">{info.verificationUri}</p>
+            <button className="ob-cancel" onClick={onCancel}>
+              Cancel
+            </button>
+          </>
+        ) : (
+          <p className="ob-device-lede">Starting {label} sign-in…</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Onboarding/beats.tsx
+++ b/src/components/Onboarding/beats.tsx
@@ -116,17 +116,3 @@ export const BEAT_CODE: BeatDef = {
 };
 
 export const BEATS: BeatDef[] = [BEAT_PARALLEL, BEAT_PROVIDERS, BEAT_ROOM];
-
-// ── create-step sample repositories ─────────────────────────────────
-export interface RepoOption {
-  full: string;
-  lang: string;
-  langHue: number;
-  updated: string;
-}
-
-export const REPOS: RepoOption[] = [
-  { full: "joineve/atlas-web", lang: "TypeScript", langHue: 215, updated: "2h" },
-  { full: "joineve/quorum-core", lang: "Rust", langHue: 28, updated: "1d" },
-  { full: "joineve/voyager-rs", lang: "Rust", langHue: 28, updated: "3d" },
-];

--- a/src/components/Onboarding/index.tsx
+++ b/src/components/Onboarding/index.tsx
@@ -3,7 +3,7 @@
 // General. Ported from the design prototype (onboarding/app.jsx): ambient
 // stage, step sequence, cinematic transitions, progress rail, keyboard nav.
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { open as openExternal } from "@tauri-apps/plugin-shell";
@@ -46,6 +46,11 @@ export function Onboarding() {
 
   const [device, setDevice] = useState<DeviceCodeInfo | null>(null);
   const [authError, setAuthError] = useState<string | null>(null);
+  // Monotonic id for the active sign-in. Bumping it (on cancel or a new
+  // attempt) invalidates any in-flight oauth_device_login so its late result
+  // is ignored — the backend poll keeps running until it expires, but its
+  // outcome no longer touches the UI or the DB.
+  const authRunRef = useRef(0);
 
   const step = STEPS[idx];
 
@@ -77,6 +82,8 @@ export function Onboarding() {
   const onAuth = useCallback(
     async (provider: string) => {
       if (busy) return;
+      const runId = ++authRunRef.current;
+      const stale = () => authRunRef.current !== runId;
       setBusy(provider);
       setAuthError(null);
       setDevice(null);
@@ -87,6 +94,7 @@ export function Onboarding() {
         user_code: string;
         verification_uri: string;
       }>("oauth:device-code", (e) => {
+        if (stale()) return;
         setDevice({
           provider: e.payload.provider,
           userCode: e.payload.user_code,
@@ -98,14 +106,17 @@ export function Onboarding() {
         const profile = await invoke<OAuthProfile>("oauth_device_login", {
           provider,
         });
+        if (stale()) return; // cancelled or superseded — drop the result
         const account = await getOrCreateAccount();
         await linkOAuthAccount(account.id, profile);
         await refreshAccount();
+        if (stale()) return;
         // Keep the device panel visible through the transition-out — clearing
         // `device`/`busy` here would flash the welcome buttons mid-fade. The
         // step-change effect below tears them down once we've left welcome.
         go(1);
       } catch (err) {
+        if (stale()) return;
         setAuthError(String(err));
         setBusy(null);
       } finally {
@@ -116,6 +127,7 @@ export function Onboarding() {
   );
 
   const cancelAuth = useCallback(() => {
+    authRunRef.current++; // invalidate any in-flight sign-in
     setDevice(null);
     setAuthError(null);
     setBusy(null);

--- a/src/components/Onboarding/index.tsx
+++ b/src/components/Onboarding/index.tsx
@@ -9,23 +9,21 @@ import { listen } from "@tauri-apps/api/event";
 import { open as openExternal } from "@tauri-apps/plugin-shell";
 import { useAppStore } from "../../store";
 import { Icon } from "../Icon";
-import { LANDMARK_NAMES } from "../../data/landmarks";
 import {
   getOrCreateAccount,
   linkOAuthAccount,
   type OAuthProfile,
 } from "../../storage/accounts";
 import { Ambient } from "./Ambient";
-import { WelcomeStep, Beat, CreateStep, IgniteStep } from "./steps";
+import { WelcomeStep, Beat, IgniteStep } from "./steps";
 import { DeviceCode, type DeviceCodeInfo } from "./DeviceCode";
-import { BEATS, REPOS } from "./beats";
+import { BEATS } from "./beats";
 import "./onboarding.css";
 
-// flat step model: welcome · three feature beats · create · ignition
+// flat step model: welcome · three feature beats · finale
 type Step =
   | { kind: "welcome" }
   | { kind: "beat"; beat: number }
-  | { kind: "create" }
   | { kind: "ignite" };
 
 const STEPS: Step[] = [
@@ -33,29 +31,19 @@ const STEPS: Step[] = [
   { kind: "beat", beat: 0 },
   { kind: "beat", beat: 1 },
   { kind: "beat", beat: 2 },
-  { kind: "create" },
   { kind: "ignite" },
 ];
-const RAIL_LEN = 5; // welcome..create
-
-/** Pick a landmark name at random, optionally avoiding `exclude`. */
-function freeLandmark(exclude?: string): string {
-  const pool = LANDMARK_NAMES.filter((n) => n !== exclude);
-  const from = pool.length > 0 ? pool : LANDMARK_NAMES;
-  return from[Math.floor(Math.random() * from.length)];
-}
+const RAIL_LEN = 4; // welcome..last beat (finale excluded)
 
 export function Onboarding() {
   const closeOnboarding = useAppStore((s) => s.closeOnboarding);
+  const refreshAccount = useAppStore((s) => s.refreshAccount);
 
   const [idx, setIdx] = useState(0);
   const [phase, setPhase] = useState<"in" | "out">("in");
   const [ready, setReady] = useState(false);
   const [busy, setBusy] = useState<string | null>(null);
 
-  const [repo, setRepo] = useState(REPOS[0].full);
-  const [agentName, setAgentName] = useState(() => freeLandmark());
-  const [task, setTask] = useState("");
   const [device, setDevice] = useState<DeviceCodeInfo | null>(null);
   const [authError, setAuthError] = useState<string | null>(null);
 
@@ -112,16 +100,19 @@ export function Onboarding() {
         });
         const account = await getOrCreateAccount();
         await linkOAuthAccount(account.id, profile);
-        setDevice(null);
+        await refreshAccount();
+        // Keep the device panel visible through the transition-out — clearing
+        // `device`/`busy` here would flash the welcome buttons mid-fade. The
+        // step-change effect below tears them down once we've left welcome.
         go(1);
       } catch (err) {
         setAuthError(String(err));
+        setBusy(null);
       } finally {
         unlisten();
-        setBusy(null);
       }
     },
-    [busy, go],
+    [busy, go, refreshAccount],
   );
 
   const cancelAuth = useCallback(() => {
@@ -130,9 +121,20 @@ export function Onboarding() {
     setBusy(null);
   }, []);
 
-  const reroll = () => setAgentName((n) => freeLandmark(n));
-  const onCreate = () => go(STEPS.length - 1);
-  const onEnter = () => closeOnboarding();
+  // Once we leave the welcome step, tear down any auth/device state so the
+  // panel fades out cleanly and a later return to welcome shows the sign-in
+  // buttons, not a stale code panel.
+  useEffect(() => {
+    if (step.kind !== "welcome") {
+      setBusy(null);
+      setDevice(null);
+      setAuthError(null);
+    }
+  }, [step.kind]);
+
+  // Finale handoff: just drop into the real app. Its empty state prompts the
+  // user to add their first repo from the sidebar — no auto-picker.
+  const onEnter = useCallback(() => closeOnboarding(), [closeOnboarding]);
 
   // keyboard navigation
   useEffect(() => {
@@ -155,8 +157,6 @@ export function Onboarding() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [idx, busy, step.kind, next, back]);
 
-  const projName = (REPOS.find((r) => r.full === repo) || REPOS[0]).full.split("/")[1];
-
   let content = null;
   if (step.kind === "welcome")
     content =
@@ -166,20 +166,7 @@ export function Onboarding() {
         <WelcomeStep onAuth={onAuth} busy={busy} />
       );
   else if (step.kind === "beat") content = <Beat beat={BEATS[step.beat]} />;
-  else if (step.kind === "create")
-    content = (
-      <CreateStep
-        repo={repo}
-        setRepo={setRepo}
-        agentName={agentName}
-        reroll={reroll}
-        task={task}
-        setTask={setTask}
-        onCreate={onCreate}
-      />
-    );
-  else if (step.kind === "ignite")
-    content = <IgniteStep agentName={agentName} projName={projName} onEnter={onEnter} />;
+  else if (step.kind === "ignite") content = <IgniteStep onEnter={onEnter} />;
 
   const showFoot = step.kind !== "ignite";
   const showBack = idx > 0 && step.kind !== "ignite";
@@ -199,8 +186,8 @@ export function Onboarding() {
               <b>{Math.min(idx + 1, RAIL_LEN)}</b> / {RAIL_LEN}
             </span>
           )}
-          {step.kind !== "ignite" && step.kind !== "create" && (
-            <button className="ob-skip" onClick={() => go(STEPS.length - 2)}>
+          {step.kind !== "ignite" && (
+            <button className="ob-skip" onClick={() => go(STEPS.length - 1)}>
               Skip
             </button>
           )}

--- a/src/components/Onboarding/index.tsx
+++ b/src/components/Onboarding/index.tsx
@@ -87,22 +87,26 @@ export function Onboarding() {
       setBusy(provider);
       setAuthError(null);
       setDevice(null);
-      // The backend emits the user code once the provider issues it; show it
-      // and open the verification page in the user's browser.
-      const unlisten = await listen<{
-        provider: string;
-        user_code: string;
-        verification_uri: string;
-      }>("oauth:device-code", (e) => {
-        if (stale()) return;
-        setDevice({
-          provider: e.payload.provider,
-          userCode: e.payload.user_code,
-          verificationUri: e.payload.verification_uri,
-        });
-        void openExternal(e.payload.verification_uri).catch(() => {});
-      });
+      // Default to a no-op so the finally can always call it — listen() lives
+      // inside the try so an IPC failure is caught and surfaced, not thrown
+      // unhandled (which would strand the cancel-less loading panel).
+      let unlisten: () => void = () => {};
       try {
+        // The backend emits the user code once the provider issues it; show it
+        // and open the verification page in the user's browser.
+        unlisten = await listen<{
+          provider: string;
+          user_code: string;
+          verification_uri: string;
+        }>("oauth:device-code", (e) => {
+          if (stale()) return;
+          setDevice({
+            provider: e.payload.provider,
+            userCode: e.payload.user_code,
+            verificationUri: e.payload.verification_uri,
+          });
+          void openExternal(e.payload.verification_uri).catch(() => {});
+        });
         const profile = await invoke<OAuthProfile>("oauth_device_login", {
           provider,
         });

--- a/src/components/Onboarding/index.tsx
+++ b/src/components/Onboarding/index.tsx
@@ -4,11 +4,20 @@
 // stage, step sequence, cinematic transitions, progress rail, keyboard nav.
 
 import { useCallback, useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { open as openExternal } from "@tauri-apps/plugin-shell";
 import { useAppStore } from "../../store";
 import { Icon } from "../Icon";
 import { LANDMARK_NAMES } from "../../data/landmarks";
+import {
+  getOrCreateAccount,
+  linkOAuthAccount,
+  type OAuthProfile,
+} from "../../storage/accounts";
 import { Ambient } from "./Ambient";
 import { WelcomeStep, Beat, CreateStep, IgniteStep } from "./steps";
+import { DeviceCode, type DeviceCodeInfo } from "./DeviceCode";
 import { BEATS, REPOS } from "./beats";
 import "./onboarding.css";
 
@@ -47,6 +56,8 @@ export function Onboarding() {
   const [repo, setRepo] = useState(REPOS[0].full);
   const [agentName, setAgentName] = useState(() => freeLandmark());
   const [task, setTask] = useState("");
+  const [device, setDevice] = useState<DeviceCodeInfo | null>(null);
+  const [authError, setAuthError] = useState<string | null>(null);
 
   const step = STEPS[idx];
 
@@ -75,14 +86,49 @@ export function Onboarding() {
   const next = useCallback(() => go(idx + 1), [go, idx]);
   const back = useCallback(() => go(idx - 1), [go, idx]);
 
-  const onAuth = (provider: string) => {
-    if (busy) return;
-    setBusy(provider);
-    window.setTimeout(() => {
-      setBusy(null);
-      go(1);
-    }, 1100);
-  };
+  const onAuth = useCallback(
+    async (provider: string) => {
+      if (busy) return;
+      setBusy(provider);
+      setAuthError(null);
+      setDevice(null);
+      // The backend emits the user code once the provider issues it; show it
+      // and open the verification page in the user's browser.
+      const unlisten = await listen<{
+        provider: string;
+        user_code: string;
+        verification_uri: string;
+      }>("oauth:device-code", (e) => {
+        setDevice({
+          provider: e.payload.provider,
+          userCode: e.payload.user_code,
+          verificationUri: e.payload.verification_uri,
+        });
+        void openExternal(e.payload.verification_uri).catch(() => {});
+      });
+      try {
+        const profile = await invoke<OAuthProfile>("oauth_device_login", {
+          provider,
+        });
+        const account = await getOrCreateAccount();
+        await linkOAuthAccount(account.id, profile);
+        setDevice(null);
+        go(1);
+      } catch (err) {
+        setAuthError(String(err));
+      } finally {
+        unlisten();
+        setBusy(null);
+      }
+    },
+    [busy, go],
+  );
+
+  const cancelAuth = useCallback(() => {
+    setDevice(null);
+    setAuthError(null);
+    setBusy(null);
+  }, []);
 
   const reroll = () => setAgentName((n) => freeLandmark(n));
   const onCreate = () => go(STEPS.length - 1);
@@ -112,7 +158,13 @@ export function Onboarding() {
   const projName = (REPOS.find((r) => r.full === repo) || REPOS[0]).full.split("/")[1];
 
   let content = null;
-  if (step.kind === "welcome") content = <WelcomeStep onAuth={onAuth} busy={busy} />;
+  if (step.kind === "welcome")
+    content =
+      busy || device || authError ? (
+        <DeviceCode info={device} error={authError} onCancel={cancelAuth} />
+      ) : (
+        <WelcomeStep onAuth={onAuth} busy={busy} />
+      );
   else if (step.kind === "beat") content = <Beat beat={BEATS[step.beat]} />;
   else if (step.kind === "create")
     content = (

--- a/src/components/Onboarding/onboarding.css
+++ b/src/components/Onboarding/onboarding.css
@@ -222,7 +222,7 @@
   width: 100%; max-width: 360px;
 }
 .ob-authbtn {
-  display: inline-flex; align-items: center; gap: 12px;
+  display: inline-flex; align-items: center; justify-content: center; gap: 12px;
   height: 50px; padding: 0 20px;
   border-radius: var(--r-md);
   border: 1px solid var(--bd-strong);
@@ -235,11 +235,13 @@
   position: relative;
 }
 .ob-authbtn .gl {
+  position: absolute; left: 20px;
   width: 19px; height: 19px; flex-shrink: 0;
   display: inline-flex; align-items: center; justify-content: center;
 }
-.ob-authbtn .lbl { flex: 1; text-align: left; }
+.ob-authbtn .lbl { text-align: center; }
 .ob-authbtn .ent {
+  position: absolute; right: 20px;
   font-family: var(--font-mono); font-size: 11px;
   color: var(--fg-3);
   opacity: 0; transition: opacity .15s;
@@ -260,23 +262,6 @@
 .ob-authbtn.primary .ent { color: oklch(0.30 0.04 60); }
 .ob-authbtn.primary:hover { background: oklch(from var(--accent) calc(l + 0.04) c h); }
 
-.ob-auth-alt {
-  display: flex; align-items: center; gap: 14px;
-  margin-top: 4px;
-  font-size: 12px; color: var(--fg-3);
-}
-.ob-auth-alt .ln { flex: 1; height: 1px; background: var(--bd-soft); }
-.ob-sso {
-  margin-top: 4px;
-  font-size: 12.5px; color: var(--fg-2);
-  text-align: center;
-}
-.ob-sso button {
-  color: var(--accent); font-weight: 500;
-  text-decoration: underline; text-decoration-color: var(--accent-line);
-  text-underline-offset: 2px; cursor: pointer;
-}
-.ob-sso button:hover { text-decoration-color: var(--accent); }
 .ob-legal {
   margin-top: 34px;
   font-size: 11px; line-height: 1.6; color: var(--fg-3);
@@ -593,115 +578,6 @@
   animation: ob-pulse 1.6s ease-in-out infinite;
 }
 
-/* ── create first project ─────────────────────────────────────── */
-.ob-create { max-width: 620px; margin: 0 auto; width: 100%; }
-.ob-create-head { text-align: center; margin-bottom: 30px; }
-.ob-create-head .ob-display { font-size: 46px; line-height: 1.14; margin-top: 16px; }
-.ob-create-head .ob-lede { margin-top: 16px; max-width: 460px; margin-left: auto; margin-right: auto; }
-
-.ob-card {
-  background: var(--bg-1);
-  border: 1px solid var(--bd);
-  border-radius: var(--r-lg);
-  box-shadow: var(--shadow-2);
-  overflow: hidden;
-}
-.ob-card-sect { padding: 18px 20px; border-bottom: 1px solid var(--bd-soft); }
-.ob-card-sect:last-child { border-bottom: 0; }
-.ob-card-lab {
-  display: flex; align-items: center; gap: 8px;
-  font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.1em;
-  text-transform: uppercase; color: var(--fg-3);
-  margin-bottom: 13px;
-}
-.ob-card-lab .n {
-  width: 16px; height: 16px; border-radius: 50%;
-  display: grid; place-items: center;
-  background: color-mix(in oklch, var(--accent), transparent 86%);
-  color: var(--accent); font-size: 9px; letter-spacing: 0;
-}
-.ob-card-lab .gh { margin-left: auto; display: inline-flex; align-items: center; gap: 6px; color: var(--fg-2); letter-spacing: 0; text-transform: none; font-family: var(--font-sans); font-size: 11.5px; }
-.ob-card-lab .gh .av { width: 16px; height: 16px; border-radius: 50%; background: var(--accent); color: oklch(0.18 0.02 60); display: grid; place-items: center; font-size: 9px; font-weight: 600; }
-
-.ob-repos { display: flex; flex-direction: column; gap: 7px; }
-.ob-repo {
-  display: flex; align-items: center; gap: 11px;
-  padding: 11px 13px;
-  border: 1px solid var(--bd-soft); border-radius: var(--r-md);
-  background: var(--bg-2); cursor: pointer;
-  transition: border-color .14s, background .14s;
-}
-.ob-repo:hover { border-color: var(--bd-strong); background: var(--bg-3); }
-.ob-repo.sel { border-color: var(--accent-line); background: color-mix(in oklch, var(--accent), var(--bg-2) 92%); }
-.ob-repo .rdot {
-  width: 16px; height: 16px; border-radius: 50%; flex-shrink: 0;
-  border: 1.5px solid var(--bd-strong);
-  display: grid; place-items: center;
-  transition: border-color .14s;
-}
-.ob-repo.sel .rdot { border-color: var(--accent); }
-.ob-repo.sel .rdot::after { content: ""; width: 8px; height: 8px; border-radius: 50%; background: var(--accent); }
-.ob-repo .rn { font-family: var(--font-mono); font-size: 12.5px; color: var(--fg-0); }
-.ob-repo .rmeta { margin-left: auto; display: inline-flex; align-items: center; gap: 12px; font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-3); }
-.ob-repo .rmeta .lang { display: inline-flex; align-items: center; gap: 5px; }
-.ob-repo .rmeta .lang .d { width: 7px; height: 7px; border-radius: 50%; }
-
-.ob-agentname {
-  display: flex; align-items: center; gap: 13px;
-}
-.ob-agentname .gbox {
-  width: 46px; height: 46px; flex-shrink: 0;
-  border-radius: var(--r-md);
-  border: 1px solid var(--bd-soft);
-  background: var(--bg-2);
-  display: grid; place-items: center;
-  color: var(--accent);
-}
-.ob-agentname .nmwrap { flex: 1; min-width: 0; }
-.ob-agentname .nm { font-family: var(--font-mono); font-size: 16px; color: var(--fg-0); }
-.ob-agentname .path { font-family: var(--font-mono); font-size: 11px; color: var(--fg-3); margin-top: 3px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.ob-agentname .path b { color: var(--fg-1); font-weight: 400; }
-.ob-reroll {
-  display: inline-flex; align-items: center; gap: 6px;
-  padding: 7px 11px; border-radius: var(--r-sm);
-  border: 1px solid var(--bd-soft);
-  font-size: 11.5px; color: var(--fg-2); cursor: pointer;
-  transition: color .12s, border-color .12s, background .12s;
-}
-.ob-reroll:hover { color: var(--fg-0); border-color: var(--bd-strong); background: var(--hover); }
-.ob-reroll svg { width: 11px; height: 11px; }
-
-.ob-firsttask {
-  background: var(--bg-2);
-  border: 1px solid var(--bd-strong);
-  border-radius: var(--r-md);
-  transition: border-color .15s, box-shadow .15s;
-}
-.ob-firsttask:focus-within {
-  border-color: color-mix(in oklch, var(--accent), transparent 50%);
-  box-shadow: 0 0 0 4px color-mix(in oklch, var(--accent), transparent 88%);
-}
-.ob-firsttask textarea {
-  width: 100%; resize: none;
-  padding: 13px 14px 6px;
-  font-size: 13.5px; line-height: 1.55; color: var(--fg-0);
-  min-height: 58px;
-}
-.ob-firsttask textarea::placeholder { color: var(--fg-3); }
-.ob-firsttask-foot {
-  display: flex; align-items: center; gap: 8px;
-  padding: 7px 9px;
-}
-.ob-firsttask-foot .pill {
-  display: inline-flex; align-items: center; gap: 6px;
-  height: 26px; padding: 0 9px; border-radius: var(--r-sm);
-  font-size: 11.5px; color: var(--fg-1);
-  border: 1px solid var(--bd-soft);
-}
-.ob-firsttask-foot .pill svg { width: 11px; height: 11px; color: var(--fg-2); }
-.ob-firsttask-foot .pill .dot { width: 6px; height: 6px; border-radius: 50%; }
-.ob-firsttask-foot .spacer { flex: 1; }
-
 /* ── primary CTA ──────────────────────────────────────────────── */
 .ob-cta {
   display: inline-flex; align-items: center; justify-content: center; gap: 9px;
@@ -785,21 +661,11 @@
 }
 .ob-ignite .ob-display { font-size: 50px; line-height: 1.12; }
 .ob-ignite .ob-lede { margin-top: 20px; max-width: 440px; }
-.ob-ignite .worktree {
-  margin-top: 24px;
-  display: inline-flex; align-items: center; gap: 9px;
-  padding: 9px 14px; border-radius: 999px;
-  border: 1px solid var(--bd-soft); background: var(--bg-1);
-  font-family: var(--font-mono); font-size: 11.5px; color: var(--fg-2);
-}
-.ob-ignite .worktree .gly { color: var(--accent); display: inline-flex; }
-.ob-ignite .worktree b { color: var(--fg-0); font-weight: 500; }
 .ob-ignite .ob-cta { margin-top: 36px; height: 48px; padding: 0 26px; font-size: 14.5px; }
 
 /* controls + compact labels must never wrap, whatever font is active */
-.ob-cta, .ob-next, .ob-back, .ob-reroll,
-.ob-authbtn .lbl, .ob-eyebrow, .ob-ignite .worktree,
-.ob-card-lab, .ob-step-count { white-space: nowrap; }
+.ob-cta, .ob-next, .ob-back,
+.ob-authbtn .lbl, .ob-eyebrow, .ob-step-count { white-space: nowrap; }
 @media (max-width: 1080px) {
   .ob-beat { grid-template-columns: 1fr; gap: 36px; }
   .ob-exhibit { transform: none; }

--- a/src/components/Onboarding/onboarding.css
+++ b/src/components/Onboarding/onboarding.css
@@ -811,3 +811,33 @@
   .ob-auth { margin-top: 26px; }
   .ob-view { padding-top: 24px; }
 }
+
+/* ── device-flow login panel ─────────────────────────────────────── */
+.ob-device {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  max-width: 440px;
+  margin: 0 auto;
+  text-align: center;
+}
+.ob-device-lede { opacity: .8; }
+.ob-device-code {
+  font-size: 34px;
+  letter-spacing: .18em;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.ob-device-uri { opacity: .55; font-size: 13px; word-break: break-all; }
+.ob-device-err { color: #ff6b6b; }
+.ob-cancel {
+  background: none;
+  border: none;
+  color: inherit;
+  opacity: .6;
+  cursor: pointer;
+  font: inherit;
+  padding: 6px 10px;
+}
+.ob-cancel:hover { opacity: .9; }

--- a/src/components/Onboarding/steps.tsx
+++ b/src/components/Onboarding/steps.tsx
@@ -2,11 +2,13 @@
 // project, and the ignition finale. Ported from the design prototype
 // (onboarding/steps.jsx).
 
-import { useEffect, useRef } from "react";
 import type { CSSProperties } from "react";
-import { Icon, LandmarkGlyph } from "../Icon";
-import type { BeatDef, RepoOption } from "./beats";
-import { REPOS } from "./beats";
+import { open as openExternal } from "@tauri-apps/plugin-shell";
+import { Icon } from "../Icon";
+import type { BeatDef } from "./beats";
+
+const TERMS_URL = "https://quorum.fwdai.org/terms";
+const PRIVACY_URL = "https://quorum.fwdai.org/privacy";
 
 // ── brand mark: the Quorum triple-peak ──────────────────────────────
 export function PeaksMark() {
@@ -84,21 +86,27 @@ export function WelcomeStep({
             </span>
             <span className="lbl">Continue with Google</span>
           </button>
-          <div className="ob-auth-alt">
-            <span className="ln" />
-          </div>
-          <div className="ob-sso">
-            Part of a team? <button onClick={() => onAuth("github")}>Sign in with SSO</button>
-          </div>
         </div>
 
         <p className="ob-legal ob-reveal" style={{ "--d": ".58s" } as CSSProperties}>
           By continuing you agree to Quorum's{" "}
-          <a href="#" onClick={(e) => e.preventDefault()}>
+          <a
+            href={TERMS_URL}
+            onClick={(e) => {
+              e.preventDefault();
+              void openExternal(TERMS_URL).catch(() => {});
+            }}
+          >
             Terms
           </a>{" "}
           and{" "}
-          <a href="#" onClick={(e) => e.preventDefault()}>
+          <a
+            href={PRIVACY_URL}
+            onClick={(e) => {
+              e.preventDefault();
+              void openExternal(PRIVACY_URL).catch(() => {});
+            }}
+          >
             Privacy Policy
           </a>
           . Your code never leaves your machine.
@@ -149,163 +157,8 @@ export function Beat({ beat }: { beat: BeatDef }) {
   );
 }
 
-// ── Step · create first project ─────────────────────────────────────
-export function CreateStep({
-  repo,
-  setRepo,
-  agentName,
-  reroll,
-  task,
-  setTask,
-  onCreate,
-}: {
-  repo: string;
-  setRepo: (full: string) => void;
-  agentName: string;
-  reroll: () => void;
-  task: string;
-  setTask: (v: string) => void;
-  onCreate: () => void;
-}) {
-  const selected: RepoOption = REPOS.find((r) => r.full === repo) || REPOS[0];
-  const projName = selected.full.split("/")[1];
-  const taRef = useRef<HTMLTextAreaElement>(null);
-  useEffect(() => {
-    const el = taRef.current;
-    if (!el) return;
-    el.style.height = "auto";
-    el.style.height = Math.min(el.scrollHeight, 160) + "px";
-  }, [task]);
-
-  return (
-    <div className="ob-step">
-      <div className="ob-create">
-        <div className="ob-create-head">
-          <div
-            className="ob-eyebrow ob-reveal"
-            style={{ "--d": ".05s", justifyContent: "center" } as CSSProperties}
-          >
-            <span className="ln" />
-            <span>Let's begin</span>
-            <span
-              className="ln"
-              style={{ background: "linear-gradient(270deg, var(--accent-line), transparent)" }}
-            />
-          </div>
-          <h2 className="ob-display ob-reveal" style={{ "--d": ".14s" } as CSSProperties}>
-            Point Quorum at your <em>first repo.</em>
-          </h2>
-          <p className="ob-lede ob-reveal" style={{ "--d": ".24s" } as CSSProperties}>
-            Choose a repository and describe the first task. Quorum creates the worktree —
-            everything else is handled.
-          </p>
-        </div>
-
-        <div className="ob-card ob-reveal" style={{ "--d": ".34s" } as CSSProperties}>
-          <div className="ob-card-sect">
-            <div className="ob-card-lab">
-              <span className="n">1</span>
-              <span>Repository</span>
-              <span className="gh">
-                <span className="av">M</span>maya · github
-              </span>
-            </div>
-            <div className="ob-repos">
-              {REPOS.map((r) => (
-                <div
-                  key={r.full}
-                  className={`ob-repo ${repo === r.full ? "sel" : ""}`}
-                  onClick={() => setRepo(r.full)}
-                >
-                  <span className="rdot" />
-                  <span className="rn">{r.full}</span>
-                  <span className="rmeta">
-                    <span className="lang">
-                      <span className="d" style={{ background: `oklch(0.6 0.13 ${r.langHue})` }} />
-                      {r.lang}
-                    </span>
-                    <span>{r.updated}</span>
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <div className="ob-card-sect">
-            <div className="ob-card-lab">
-              <span className="n">2</span>
-              <span>Your first agent</span>
-            </div>
-            <div className="ob-agentname">
-              <span className="gbox">
-                <LandmarkGlyph name={agentName} size={26} strokeWidth={1.1} />
-              </span>
-              <span className="nmwrap">
-                <div className="nm">{agentName}</div>
-                <div className="path">
-                  <b>{projName}</b>/.quorum/{agentName}
-                </div>
-              </span>
-              <button className="ob-reroll" onClick={reroll}>
-                <Icon name="refresh" />
-                reroll
-              </button>
-            </div>
-          </div>
-
-          <div className="ob-card-sect">
-            <div className="ob-card-lab">
-              <span className="n">3</span>
-              <span>First task</span>
-            </div>
-            <div className="ob-firsttask">
-              <textarea
-                ref={taRef}
-                value={task}
-                onChange={(e) => setTask(e.target.value)}
-                placeholder="Describe what this agent should build…"
-                autoFocus
-              />
-              <div className="ob-firsttask-foot">
-                <span className="pill">
-                  <span className="dot" style={{ background: "oklch(0.6 0.13 28)" }} />
-                  Claude Code
-                </span>
-                <span className="pill">
-                  <Icon name="branch" /> from main
-                </span>
-                <span className="spacer" />
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div
-          className="ob-reveal"
-          style={
-            { "--d": ".46s", marginTop: 22, display: "flex", justifyContent: "center" } as CSSProperties
-          }
-        >
-          <button className="ob-cta" disabled={!task.trim()} onClick={onCreate}>
-            Create worktree &amp; enter
-            <Icon name="arrowR" />
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ── Step · ignition / finale ────────────────────────────────────────
-export function IgniteStep({
-  agentName,
-  projName,
-  onEnter,
-}: {
-  agentName: string;
-  projName: string;
-  onEnter: () => void;
-}) {
+// ── Step · finale / handoff ─────────────────────────────────────────
+export function IgniteStep({ onEnter }: { onEnter: () => void }) {
   return (
     <div className="ob-step">
       <div className="ob-ignite">
@@ -313,20 +166,12 @@ export function IgniteStep({
           <PeaksMark />
         </div>
         <h2 className="ob-display ob-reveal" style={{ "--d": ".2s" } as CSSProperties}>
-          <em>{agentName}</em> is on it.
+          You're <em>all set.</em>
         </h2>
         <p className="ob-lede ob-reveal" style={{ "--d": ".34s" } as CSSProperties}>
-          Your worktree is live and the agent is reading the codebase. Welcome to Quorum — this is
-          what the rest of your engineering feels like now.
+          Add your first repository from the sidebar and Quorum spins up an isolated
+          worktree for every agent you direct.
         </p>
-        <div className="worktree ob-reveal" style={{ "--d": ".46s" } as CSSProperties}>
-          <span className="gly">
-            <LandmarkGlyph name={agentName} size={14} strokeWidth={1.3} />
-          </span>
-          <span>
-            <b>{projName}</b>/.quorum/{agentName}
-          </span>
-        </div>
         <button className="ob-cta ob-reveal" style={{ "--d": ".58s" } as CSSProperties} onClick={onEnter}>
           Enter Quorum
           <Icon name="arrowR" />

--- a/src/storage/accounts.ts
+++ b/src/storage/accounts.ts
@@ -91,7 +91,7 @@ export async function linkOAuthAccount(
       name: full,
       first_name: firstName,
       last_name: lastName,
-      email: profile.email ?? "",
+      email: profile.email,
       avatar_url: profile.avatar_url,
     },
   );

--- a/src/storage/accounts.ts
+++ b/src/storage/accounts.ts
@@ -9,6 +9,8 @@ export interface AccountRow {
   last_name: string | null;
   email: string | null;
   avatar_url: string | null;
+  oauth_provider: string | null;
+  oauth_id: string | null;
   created_at: number;
 }
 
@@ -57,6 +59,40 @@ export async function saveAccountProfile(
       last_name: patch.lastName,
       email: patch.email,
       name,
+    },
+  );
+}
+
+/** Identity returned by the `oauth_device_login` backend command. */
+export interface OAuthProfile {
+  provider: string;
+  provider_user_id: string;
+  name: string | null;
+  email: string | null;
+  avatar_url: string | null;
+}
+
+/** Persist identity fetched from an OAuth provider onto the single account.
+ *  Splits the provider display name into first/last for the profile fields. */
+export async function linkOAuthAccount(
+  id: string,
+  profile: OAuthProfile,
+): Promise<void> {
+  const full = (profile.name ?? "").trim();
+  const space = full.indexOf(" ");
+  const firstName = space === -1 ? full : full.slice(0, space);
+  const lastName = space === -1 ? "" : full.slice(space + 1);
+  await dbUpdate(
+    "accounts",
+    { id },
+    {
+      oauth_provider: profile.provider,
+      oauth_id: profile.provider_user_id,
+      name: full,
+      first_name: firstName,
+      last_name: lastName,
+      email: profile.email ?? "",
+      avatar_url: profile.avatar_url,
     },
   );
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -26,6 +26,7 @@ import { commandsFor } from "./data/slashCommands";
 import { getAdapter, type ChatItem, type RawEvent } from "./adapters";
 import { getAllSettings, setSetting } from "./storage/settings";
 import {
+  getAccount,
   getOrCreateAccount,
   saveAccountProfile,
   toProfile,
@@ -332,6 +333,9 @@ interface AppState {
   saveAccount: (
     patch: Pick<AccountProfile, "firstName" | "lastName" | "email">,
   ) => Promise<void>;
+  /** Re-read the local account row into the store — e.g. after an OAuth
+   *  sign-in writes the provider profile to SQLite. */
+  refreshAccount: () => Promise<void>;
   toggleHistory: (open?: boolean) => void;
   selectHistoryAgent: (id: string | null) => void;
   toggleLeft: () => void;
@@ -1376,6 +1380,14 @@ export const useAppStore = create<AppState>((set, get) => ({
     try {
       await saveAccountProfile(current.id, patch);
       set({ account: { ...current, ...patch } });
+    } catch (e) {
+      set({ lastError: String(e) });
+    }
+  },
+  refreshAccount: async () => {
+    try {
+      const row = await getAccount();
+      if (row) set({ account: toProfile(row) });
     } catch (e) {
       set({ lastError: String(e) });
     }


### PR DESCRIPTION
Replaces the mocked onboarding sign-in with a real, identity-only OAuth flow for GitHub and Google using the Device Authorization Grant (RFC 8628) — no local redirect server, no `client_secret` baked into the binary for GitHub, and the access token is used once to read the profile and never persisted. A new `oauth.rs` Tauri command drives the flow (with `reqwest`), migration `0007` adds `oauth_provider`/`oauth_id` to `accounts`, and the verified profile (name/email/avatar) is written to the single account row in place and refreshed into the store so it shows immediately. The rest of the diff finalizes the welcome flow: centered auth buttons, removal of the mock "Sign in with SSO" link, real Terms/Privacy links opened in the external browser, and removal of the mock "create project" step (and its dead code/CSS) in favor of an honest finale that simply lands the user in the app where the real new-project flow already lives. Provider errors from the device-code request are now surfaced verbatim for easier diagnosis.

**Setup required for a real login:** register a GitHub OAuth App (Device Flow enabled) and a Google "TVs and Limited Input devices" client, then provide `QUORUM_GITHUB_CLIENT_ID`, `QUORUM_GOOGLE_CLIENT_ID`, and `QUORUM_GOOGLE_CLIENT_SECRET` as env vars; without them the buttons show a "not configured" message. A central "signed-up users" registry was discussed but deliberately deferred (it requires a backend).
