### PR TITLE
Bake OAuth client keys into production builds at compile time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,11 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # OAuth client keys, baked into the binary at compile time (see
+          # src-tauri/src/oauth.rs). Add these as repository Actions secrets.
+          QUORUM_GITHUB_CLIENT_ID: ${{ secrets.QUORUM_GITHUB_CLIENT_ID }}
+          QUORUM_GOOGLE_CLIENT_ID: ${{ secrets.QUORUM_GOOGLE_CLIENT_ID }}
+          QUORUM_GOOGLE_CLIENT_SECRET: ${{ secrets.QUORUM_GOOGLE_CLIENT_SECRET }}
         with:
           tagName: v__VERSION__
           releaseName: Quorum v__VERSION__

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,13 @@
 fn main() {
+    // OAuth client keys are embedded at compile time via `option_env!`. Cargo
+    // doesn't track those env vars on its own, so declare them here — otherwise
+    // a cached/incremental build could ship a stale or empty value.
+    for key in [
+        "QUORUM_GITHUB_CLIENT_ID",
+        "QUORUM_GOOGLE_CLIENT_ID",
+        "QUORUM_GOOGLE_CLIENT_SECRET",
+    ] {
+        println!("cargo::rerun-if-env-changed={key}");
+    }
     tauri_build::build()
 }

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -39,25 +39,38 @@ struct ProviderCfg {
     client_secret: Option<String>,
 }
 
+/// A build-time config value, baked into the binary via `option_env!`.
+/// Returns `None` when the variable was unset *or empty* at compile time, so a
+/// missing CI secret reads as "not configured" rather than a confusing
+/// provider error. (Runtime env is not used: a macOS .app launched from Finder
+/// gets a minimal environment, so the keys must be embedded at build time.)
+macro_rules! config_value {
+    ($key:literal) => {
+        option_env!($key)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    };
+}
+
 fn provider_cfg(provider: &str) -> Result<ProviderCfg, String> {
     match provider {
         "github" => Ok(ProviderCfg {
             device_code_url: "https://github.com/login/device/code",
             token_url: "https://github.com/login/oauth/access_token",
             scope: "read:user user:email",
-            client_id: std::env::var("QUORUM_GITHUB_CLIENT_ID")
-                .map_err(|_| "GitHub sign-in is not configured".to_string())?,
+            client_id: config_value!("QUORUM_GITHUB_CLIENT_ID")
+                .ok_or_else(|| "GitHub sign-in is not configured".to_string())?,
             client_secret: None,
         }),
         "google" => Ok(ProviderCfg {
             device_code_url: "https://oauth2.googleapis.com/device/code",
             token_url: "https://oauth2.googleapis.com/token",
             scope: "openid email profile",
-            client_id: std::env::var("QUORUM_GOOGLE_CLIENT_ID")
-                .map_err(|_| "Google sign-in is not configured".to_string())?,
+            client_id: config_value!("QUORUM_GOOGLE_CLIENT_ID")
+                .ok_or_else(|| "Google sign-in is not configured".to_string())?,
             client_secret: Some(
-                std::env::var("QUORUM_GOOGLE_CLIENT_SECRET")
-                    .map_err(|_| "Google sign-in is not configured".to_string())?,
+                config_value!("QUORUM_GOOGLE_CLIENT_SECRET")
+                    .ok_or_else(|| "Google sign-in is not configured".to_string())?,
             ),
         }),
         other => Err(format!("unknown provider: {other}")),


### PR DESCRIPTION
The OAuth client keys were read at runtime via `std::env::var`, which never reaches a packaged macOS `.app` (Finder-launched apps get a minimal environment), so production builds always reported "not configured." This bakes the keys into the binary at compile time with `option_env!`, declares them as build inputs in `build.rs` so cached/incremental builds recompile when a key changes, and passes them to the signed release build as Actions secrets. Empty values are treated as unset so a missing CI secret degrades to "not configured" rather than a cryptic provider error, and dev is unchanged (`source .env && bun tauri dev` still compiles them in).

**Action required before the next release:** add three repository Actions secrets — `QUORUM_GITHUB_CLIENT_ID`, `QUORUM_GOOGLE_CLIENT_ID`, `QUORUM_GOOGLE_CLIENT_SECRET`. Note these end up extractable from the distributed binary (acceptable here: GitHub client IDs are public and Google treats the device-client secret as non-confidential); a backend auth broker would be the way to avoid that if ever needed.
