### PR TITLE
chore: bump app version to v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quorum",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quorum"
-version = "0.1.2"
+version = "0.2.0"
 description = "Spawn coding agents in isolated sandboxes"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Quorum",
   "mainBinaryName": "Quorum",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "identifier": "com.quorum.desktop",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary
- Bumps version from `0.1.2` to `0.2.0` in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`.

## Test Plan
- [ ] All 122 existing tests pass (`bun run test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)