### PR TITLE
feat(settings): promote Antigravity to installed providers

### DIFF
--- a/src/components/SettingsScreen/ProvidersPane.tsx
+++ b/src/components/SettingsScreen/ProvidersPane.tsx
@@ -1,11 +1,7 @@
 import { useState } from "react";
 import { useAppStore } from "../../store";
 import { PROVIDERS, type Provider } from "../../data/providers";
-import {
-  PROVIDER_DETAIL,
-  AVAILABLE_AGENTS,
-  type AvailableAgent,
-} from "../../data/providerDetail";
+import { PROVIDER_DETAIL } from "../../data/providerDetail";
 import { Icon } from "../Icon";
 import { ProviderIcon } from "../ProviderIcon";
 import { SetHead, SetGroup, SetToggle } from "./primitives";
@@ -38,7 +34,7 @@ export function ProvidersPane() {
         }
       />
 
-      <SetGroup label="Installed on this system">
+      <SetGroup label="Installed on this system" last>
         <div className="set-prov-list">
           {installed.map((p) => (
             <ProviderRow
@@ -53,13 +49,6 @@ export function ProvidersPane() {
         </div>
       </SetGroup>
 
-      <SetGroup label="Available" last>
-        <div className="set-prov-list">
-          {AVAILABLE_AGENTS.map((a) => (
-            <AvailableRow key={a.id} agent={a} />
-          ))}
-        </div>
-      </SetGroup>
     </div>
   );
 }
@@ -125,32 +114,3 @@ function ProvDetailRow({ k, v, mono }: { k: string; v: string; mono?: boolean })
   );
 }
 
-function AvailableRow({ agent }: { agent: AvailableAgent }) {
-  const detected = agent.state === "detected";
-  const soon = agent.state === "soon";
-  return (
-    <div className="set-prov available">
-      <div className="set-prov-main">
-        <span
-          className={`set-prov-status ${detected ? "idle" : "none"}`}
-          title={detected ? "Detected" : "Not installed"}
-        />
-        <ProviderIcon slug={agent.id} short={agent.short} hue={agent.hue} />
-        <div className="set-prov-id">
-          <div className="set-prov-name">
-            {agent.label}
-            {soon && <span className="set-badge soon">Coming soon</span>}
-            {agent.version && <span className="set-prov-ver mono">{agent.version}</span>}
-          </div>
-          <div className="set-prov-sub muted">{agent.note}</div>
-        </div>
-        {detected && <button className="btn-t outline sm-t">Configure</button>}
-        {agent.state === "install" && (
-          <button className="btn-t ghost sm-t">
-            Install <Icon name="external" size={11} />
-          </button>
-        )}
-      </div>
-    </div>
-  );
-}

--- a/src/data/providerDetail.ts
+++ b/src/data/providerDetail.ts
@@ -99,18 +99,3 @@ export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
     ],
   },
 };
-
-export interface AvailableAgent {
-  id: string;
-  label: string;
-  short: string;
-  hue: number;
-  version: string | null;
-  /** "detected" = found on PATH but unconfigured; "install" = installable;
-   *  "soon" = not yet supported in Quorum (no adapter/runner). */
-  state: "detected" | "install" | "soon";
-  note: string;
-}
-
-// Agents found on PATH but not yet configured, plus ones available to install.
-export const AVAILABLE_AGENTS: AvailableAgent[] = [];

--- a/src/data/providerDetail.ts
+++ b/src/data/providerDetail.ts
@@ -71,9 +71,7 @@ export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
   antigravity: {
     path: "/Applications/Antigravity.app/…/antigravity",
     models: "Gemini 3 Pro · Flash",
-    // No adapter/runner yet — kept out of the Installed list and gated as
-    // "coming soon" in the picker. Flip to true once it's wired end-to-end.
-    installed: false,
+    installed: true,
     thinkingLevels: [],
   },
   opencode: {
@@ -115,14 +113,4 @@ export interface AvailableAgent {
 }
 
 // Agents found on PATH but not yet configured, plus ones available to install.
-export const AVAILABLE_AGENTS: AvailableAgent[] = [
-  {
-    id: "antigravity",
-    label: "Antigravity",
-    short: "AG",
-    hue: 260,
-    version: "v1.0",
-    state: "soon",
-    note: "Not yet supported in Quorum.",
-  },
-];
+export const AVAILABLE_AGENTS: AvailableAgent[] = [];


### PR DESCRIPTION
## Summary
- Flips `antigravity` from `installed: false` to `installed: true` in `providerDetail.ts` — the adapter and backend runner (`agy` binary) are already fully wired, so it now appears in the Installed list alongside Claude, Codex, Cursor, OpenCode, and Pi.
- Removes the "Available / Coming soon" section from the Providers settings pane since Antigravity was the only entry in it.
- Cleans up the now-unused `AvailableRow` component, `AVAILABLE_AGENTS` export, and related imports.

## Test Plan
- [ ] Antigravity appears in the "Installed on this system" section of Settings → Providers
- [ ] Toggle works to enable/disable Antigravity in the model picker
- [ ] No "Coming soon" badge or "Available" section visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)