### PR TITLE
Smooth onboarding line transitions + load .env in `bun tauri dev`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri",
+    "tauri": "if [ -f .env ]; then set -a; . ./.env; set +a; fi; tauri",
     "check": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2813,7 +2813,7 @@ dependencies = [
 
 [[package]]
 name = "quorum"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/src/components/Onboarding/Ambient.tsx
+++ b/src/components/Onboarding/Ambient.tsx
@@ -49,12 +49,19 @@ export function Ambient({ phase }: { phase: number }) {
         className={`ob-glow ${phase > 0 ? "lo" : ""}`}
         style={{ transform: `translateX(-50%) translateY(${par * -1.6}%)` }}
       />
-      <svg
+      {/* The per-step parallax transform lives on this wrapping <div>, not the
+          <svg>: WebKit (Tauri's macOS WKWebView) jumps instead of animating CSS
+          transform transitions on SVG root elements, so the lines would shift
+          sharply. A <div> transitions reliably. */}
+      <div
         className="ob-contours"
+        style={{ transform: `translateY(${par * -1.3}%) translateX(${par * -0.6}%)` }}
+      >
+      <svg
+        className="ob-contours-svg"
         viewBox="0 0 100 100"
         preserveAspectRatio="none"
         aria-hidden="true"
-        style={{ transform: `translateY(${par * -1.3}%) translateX(${par * -0.6}%)` }}
       >
         <defs>
           <linearGradient id="ob-fade" x1="0" y1="0" x2="1" y2="0">
@@ -78,6 +85,7 @@ export function Ambient({ phase }: { phase: number }) {
           ))}
         </g>
       </svg>
+      </div>
       <div className="ob-vignette" />
       <div className="ob-grain" />
     </div>

--- a/src/components/Onboarding/onboarding.css
+++ b/src/components/Onboarding/onboarding.css
@@ -104,6 +104,11 @@
   overflow: visible;
   transition: transform 1.1s var(--ease);
 }
+.ob-contours-svg {
+  display: block;
+  width: 100%; height: 100%;
+  overflow: visible;
+}
 .ob-contours .cl {
   fill: none; stroke: currentColor;
   stroke-width: 0.16;


### PR DESCRIPTION
Moves the onboarding ambient contour lines' per-step parallax transform off the `<svg>` onto a wrapping `<div>` so the existing 1.1s transition is honored — WebKit (Tauri's macOS WKWebView) snaps instead of animating transform transitions on SVG roots, which made the lines jump between steps. Also sources `.env` (when present) in the `tauri` npm script so `bun tauri dev` exports its vars into the Cargo build, enabling compile-time `option_env!` reads such as the `QUORUM_*` OAuth keys; CI is unaffected since it runs `bun run tauri` with no `.env` and injects secrets as job env vars. The `Cargo.lock` change is an incidental version bump (0.1.2 → 0.2.0) already reflected on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)