### PR TITLE
chore: remove unused storage/store exports

### DIFF
--- a/src/storage/accounts.ts
+++ b/src/storage/accounts.ts
@@ -96,10 +96,3 @@ export async function linkOAuthAccount(
     },
   );
 }
-
-export async function updateAccount(
-  id: string,
-  data: Partial<Omit<AccountRow, "id" | "created_at">>,
-): Promise<void> {
-  await dbUpdate("accounts", { id }, data as Record<string, unknown>);
-}

--- a/src/storage/settings.ts
+++ b/src/storage/settings.ts
@@ -1,32 +1,13 @@
-import { dbSelect, dbDelete, dbUpsert } from "./db";
+import { dbSelect, dbUpsert } from "./db";
 
 export interface SettingRow {
   key: string;
   value: string;
 }
 
-export async function getSetting(key: string): Promise<string | null> {
-  const rows = await dbSelect<SettingRow>("settings", { where: { key } });
-  return rows[0]?.value ?? null;
-}
-
-export async function getSettingParsed<T>(key: string, fallback: T): Promise<T> {
-  const raw = await getSetting(key);
-  if (raw == null) return fallback;
-  try {
-    return JSON.parse(raw) as T;
-  } catch {
-    return fallback;
-  }
-}
-
 export async function setSetting(key: string, value: unknown): Promise<void> {
   const encoded = typeof value === "string" ? value : JSON.stringify(value);
   await dbUpsert("settings", { key, value: encoded }, "key");
-}
-
-export async function deleteSetting(key: string): Promise<void> {
-  await dbDelete("settings", { key });
 }
 
 export async function getAllSettings(): Promise<Record<string, string>> {

--- a/src/store.ts
+++ b/src/store.ts
@@ -88,10 +88,6 @@ export function getShellBuffer(agentId: string): Uint8Array | undefined {
   return shellBuffers.get(agentId);
 }
 
-export function clearShellBuffer(agentId: string) {
-  shellBuffers.delete(agentId);
-}
-
 export function registerShellSink(
   agentId: string,
   handler: OutputHandler,


### PR DESCRIPTION
Removes dead exports that have **zero callers** anywhere in the tree (verified by grep across `src`, including tests):

- `store.ts` — `clearShellBuffer`
- `storage/accounts.ts` — `updateAccount`
- `storage/settings.ts` — `getSettingParsed`, `deleteSetting`, and `getSetting` (whose only caller was `getSettingParsed`), plus the now-unused `dbDelete` import

First of a small dead-code / duplication cleanup series. No behavior change — `tsc --noEmit` clean and all 122 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)