### PR TITLE
refactor(adapters): consolidate identical display policies

### DIFF
--- a/src/adapters/antigravity/policy.ts
+++ b/src/adapters/antigravity/policy.ts
@@ -1,11 +1,2 @@
-import type { DisplayPolicy } from "../types";
-
-// Mirrors the other adapters' policy.
-export const antigravityPolicy: DisplayPolicy = {
-  "notice:turn_end": "hide",
-  "notice:hook_output": "hide",
-  "notice:info": "show",
-  "notice:reasoning": "show",
-  "notice:slash_command": "show",
-  "notice:error": "show",
-};
+// Antigravity uses the shared default policy unchanged.
+export { DEFAULT_POLICY as antigravityPolicy } from "../shared/default-policy";

--- a/src/adapters/claude/policy.ts
+++ b/src/adapters/claude/policy.ts
@@ -1,10 +1,9 @@
 import type { DisplayPolicy } from "../types";
+import { DEFAULT_POLICY } from "../shared/default-policy";
 
+// Claude is the one adapter that hides slash-command notices; everything else
+// follows the shared default.
 export const claudePolicy: DisplayPolicy = {
-  "notice:turn_end": "hide",
-  "notice:hook_output": "hide",
-  "notice:info": "show",
-  "notice:reasoning": "show",
+  ...DEFAULT_POLICY,
   "notice:slash_command": "hide",
-  "notice:error": "show",
 };

--- a/src/adapters/codex/policy.ts
+++ b/src/adapters/codex/policy.ts
@@ -1,13 +1,3 @@
-import type { DisplayPolicy } from "../types";
-
-// Codex is the one agent whose stream already carries reasoning items
-// (reduce.ts emits `notice:reasoning`), so we surface its thinking. Other
-// adapters keep reasoning hidden until their reducers capture it too.
-export const codexPolicy: DisplayPolicy = {
-  "notice:turn_end": "hide",
-  "notice:hook_output": "hide",
-  "notice:info": "show",
-  "notice:reasoning": "show",
-  "notice:slash_command": "show",
-  "notice:error": "show",
-};
+// Codex's stream carries reasoning items (reduce.ts emits `notice:reasoning`),
+// which the shared default already surfaces — so it matches the others here.
+export { DEFAULT_POLICY as codexPolicy } from "../shared/default-policy";

--- a/src/adapters/opencode/policy.ts
+++ b/src/adapters/opencode/policy.ts
@@ -1,12 +1,3 @@
-import type { DisplayPolicy } from "../types";
-
-// Mirrors claudePolicy. OpenCode's `step_finish:stop` is surfaced as a
-// `turn_end` notice, which (like the others) stays hidden.
-export const opencodePolicy: DisplayPolicy = {
-  "notice:turn_end": "hide",
-  "notice:hook_output": "hide",
-  "notice:info": "show",
-  "notice:reasoning": "show",
-  "notice:slash_command": "show",
-  "notice:error": "show",
-};
+// OpenCode's `step_finish:stop` is surfaced as a `turn_end` notice, which
+// (like the others) stays hidden — so the shared default applies unchanged.
+export { DEFAULT_POLICY as opencodePolicy } from "../shared/default-policy";

--- a/src/adapters/pi/policy.ts
+++ b/src/adapters/pi/policy.ts
@@ -1,12 +1,3 @@
-import type { DisplayPolicy } from "../types";
-
-// Mirrors claudePolicy. Pi's `agent_end` is surfaced as a `turn_end` notice,
-// which (like the others) stays hidden.
-export const piPolicy: DisplayPolicy = {
-  "notice:turn_end": "hide",
-  "notice:hook_output": "hide",
-  "notice:info": "show",
-  "notice:reasoning": "show",
-  "notice:slash_command": "show",
-  "notice:error": "show",
-};
+// Pi's `agent_end` is surfaced as a `turn_end` notice, which (like the others)
+// stays hidden — so the shared default applies unchanged.
+export { DEFAULT_POLICY as piPolicy } from "../shared/default-policy";

--- a/src/adapters/shared/default-policy.ts
+++ b/src/adapters/shared/default-policy.ts
@@ -1,0 +1,14 @@
+import type { DisplayPolicy } from "../types";
+
+/** Display policy shared by every adapter whose stream surfaces the same set
+ *  of notice kinds: turn-end and hook output stay hidden, everything else
+ *  shows. Adapters re-export this as their named policy; per-adapter
+ *  deviations (e.g. Claude hiding slash commands) compose on top of it. */
+export const DEFAULT_POLICY: DisplayPolicy = {
+  "notice:turn_end": "hide",
+  "notice:hook_output": "hide",
+  "notice:info": "show",
+  "notice:reasoning": "show",
+  "notice:slash_command": "show",
+  "notice:error": "show",
+};


### PR DESCRIPTION
The `codex`, `pi`, `opencode`, and `antigravity` adapters each defined a **byte-identical** `DisplayPolicy`. This extracts that into `src/adapters/shared/default-policy.ts` as `DEFAULT_POLICY`:

- those four now `export { DEFAULT_POLICY as <name>Policy }`
- `claude` composes its one deviation (`slash_command: "hide"`) on top of the shared default
- `cursor` already re-exports claude's policy — unchanged

Single source of truth for the shared notice policy; per-adapter comments preserved. **No behavior change** — `tsc --noEmit` clean and all 122 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)