### PR TITLE
fix(ui): wire ⌘K search, re-scan providers, copy-path feedback

### DIFF
--- a/src/components/RightPanel/FileContextMenu.tsx
+++ b/src/components/RightPanel/FileContextMenu.tsx
@@ -38,6 +38,15 @@ export function FileContextMenu({ x, y, entries, onClose }: Props) {
   const [armed, setArmed] = useState(-1);
   // Index of the item showing post-click feedback, or -1 when none.
   const [done, setDone] = useState(-1);
+  // Pending deferred-close timer (feedbackLabel path), cleared on unmount so it
+  // can't fire onClose again after an early close (Esc / outside-click / blur).
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (closeTimer.current) clearTimeout(closeTimer.current);
+    },
+    [],
+  );
 
   // Clamp into the viewport once we know the menu's size, so a click near the
   // right/bottom edge doesn't push it off-screen.
@@ -96,7 +105,7 @@ export function FileContextMenu({ x, y, entries, onClose }: Props) {
               entry.onClick();
               if (entry.feedbackLabel) {
                 setDone(i);
-                window.setTimeout(onClose, 900);
+                closeTimer.current = setTimeout(onClose, 900);
               } else {
                 onClose();
               }

--- a/src/components/RightPanel/FileContextMenu.tsx
+++ b/src/components/RightPanel/FileContextMenu.tsx
@@ -16,6 +16,10 @@ export interface ContextMenuItem {
   danger?: boolean;
   /** When set, the item requires a second click; its label becomes this. */
   confirmLabel?: string;
+  /** When set, clicking runs the action then briefly shows this label with a
+   *  check before the menu dismisses — used to confirm fire-and-forget actions
+   *  like "Copy Path". */
+  feedbackLabel?: string;
 }
 
 export type ContextMenuEntry = ContextMenuItem | "sep";
@@ -32,6 +36,8 @@ export function FileContextMenu({ x, y, entries, onClose }: Props) {
   const [pos, setPos] = useState({ x, y });
   // Index of the item currently armed for confirm, or -1 when none.
   const [armed, setArmed] = useState(-1);
+  // Index of the item showing post-click feedback, or -1 when none.
+  const [done, setDone] = useState(-1);
 
   // Clamp into the viewport once we know the menu's size, so a click near the
   // right/bottom edge doesn't push it off-screen.
@@ -74,6 +80,7 @@ export function FileContextMenu({ x, y, entries, onClose }: Props) {
       {entries.map((entry, i) => {
         if (entry === "sep") return <div key={i} className="dd-sep" />;
         const isArmed = armed === i;
+        const isDone = done === i;
         return (
           <button
             key={i}
@@ -87,13 +94,20 @@ export function FileContextMenu({ x, y, entries, onClose }: Props) {
                 return;
               }
               entry.onClick();
-              onClose();
+              if (entry.feedbackLabel) {
+                setDone(i);
+                window.setTimeout(onClose, 900);
+              } else {
+                onClose();
+              }
             }}
           >
             <span className="di-i">
-              <Icon name={entry.icon} size={13} />
+              <Icon name={isDone ? "check" : entry.icon} size={13} />
             </span>
-            <span className="di-l">{isArmed ? entry.confirmLabel : entry.label}</span>
+            <span className="di-l">
+              {isArmed ? entry.confirmLabel : isDone ? entry.feedbackLabel : entry.label}
+            </span>
           </button>
         );
       })}

--- a/src/components/RightPanel/FilePanel.tsx
+++ b/src/components/RightPanel/FilePanel.tsx
@@ -232,7 +232,7 @@ export function FilePanel({ agent, canViewDiff, onViewDiff }: FilePanelProps) {
     ];
     const common: ContextMenuEntry[] = [
       { icon: "edit", label: "Rename…", onClick: () => { setOpError(null); setEdit({ mode: "rename", path: node.path, isDir: node.type === "dir" }); } },
-      { icon: "copy", label: "Copy Path", onClick: () => copyPath(node) },
+      { icon: "copy", label: "Copy Path", feedbackLabel: "Copied", onClick: () => copyPath(node) },
     ];
     const del: ContextMenuEntry = {
       icon: "trash",

--- a/src/components/SettingsScreen/ProvidersPane.tsx
+++ b/src/components/SettingsScreen/ProvidersPane.tsx
@@ -11,9 +11,21 @@ export function ProvidersPane() {
   const setProviderEnabled = useAppStore((s) => s.setProviderEnabled);
   const providerVersions = useAppStore((s) => s.providerVersions);
   const providerPaths = useAppStore((s) => s.providerPaths);
+  const refreshProviderVersions = useAppStore((s) => s.refreshProviderVersions);
+  const [scanning, setScanning] = useState(false);
 
   const installed = PROVIDERS.filter((p) => PROVIDER_DETAIL[p.id]?.installed);
   const enabledCount = installed.filter((p) => providerFlags[p.id] !== false).length;
+
+  const rescan = async () => {
+    if (scanning) return;
+    setScanning(true);
+    try {
+      await refreshProviderVersions();
+    } finally {
+      setScanning(false);
+    }
+  };
 
   return (
     <div className="set-pane">
@@ -23,11 +35,24 @@ export function ProvidersPane() {
         desc={`${enabledCount} of ${installed.length} installed agents enabled. Toggle an agent off to hide it from the composer's model picker without signing out.`}
         actions={
           <>
-            <span className="set-checked mono">Checked just now</span>
-            <button className="btn-i tip" data-tip-down data-tip="Add provider" aria-label="Add provider">
+            {scanning && <span className="set-checked mono">Scanning…</span>}
+            <button
+              className="btn-i tip"
+              data-tip-down
+              data-tip="Coming soon"
+              aria-label="Add provider"
+              disabled
+            >
               <Icon name="plus" />
             </button>
-            <button className="btn-i tip" data-tip-down data-tip="Re-scan system" aria-label="Re-scan system">
+            <button
+              className="btn-i tip"
+              data-tip-down
+              data-tip="Re-scan system"
+              aria-label="Re-scan system"
+              onClick={rescan}
+              disabled={scanning}
+            >
               <Icon name="refresh" />
             </button>
           </>

--- a/src/components/Sidebar/SidebarHeader.tsx
+++ b/src/components/Sidebar/SidebarHeader.tsx
@@ -15,6 +15,7 @@ export function SidebarHeader({ query, onChange }: Props) {
       <div className="search">
         <Icon name="search" size={12} />
         <input
+          id="sidebar-search"
           placeholder="Search agents, branches…"
           value={query}
           onChange={(e) => onChange(e.target.value)}

--- a/src/store.ts
+++ b/src/store.ts
@@ -351,6 +351,9 @@ interface AppState {
   setShowLandmarks: (v: boolean) => void;
   setFeature: <K extends keyof FeatureFlags>(k: K, v: FeatureFlags[K]) => void;
   setProviderEnabled: (id: string, enabled: boolean) => void;
+  /** Re-probe installed provider CLIs for versions + binary paths. Runs once
+   *  on init and again when the user re-scans from the Providers settings. */
+  refreshProviderVersions: () => Promise<void>;
   setViewMode: (v: WorkspaceView) => void;
 }
 
@@ -634,18 +637,9 @@ export const useAppStore = create<AppState>((set, get) => ({
       // Non-fatal — Account screen shows empty fields until a save succeeds.
     }
 
-    // Probe installed provider CLIs for real versions + paths (async, non-blocking).
-    api.probeProviderVersions().then((probes) => {
-      const versions: Record<string, string> = {};
-      const paths: Record<string, string> = {};
-      for (const probe of probes) {
-        if (probe.version) versions[probe.id] = probe.version;
-        if (probe.path) paths[probe.id] = probe.path;
-      }
-      set({ providerVersions: versions, providerPaths: paths });
-    }).catch(() => {
-      // Non-fatal — UI falls back to hardcoded versions.
-    });
+    // Probe installed provider CLIs for real versions + paths (async,
+    // non-blocking). Errors are non-fatal — UI falls back to hardcoded versions.
+    void get().refreshProviderVersions();
 
     await onAgentOutput((e) => {
       const chunk = new Uint8Array(e.bytes);
@@ -1440,6 +1434,20 @@ export const useAppStore = create<AppState>((set, get) => ({
       setSetting("providers", next);
       return { providerFlags: next };
     }),
+  refreshProviderVersions: async () => {
+    try {
+      const probes = await api.probeProviderVersions();
+      const versions: Record<string, string> = {};
+      const paths: Record<string, string> = {};
+      for (const probe of probes) {
+        if (probe.version) versions[probe.id] = probe.version;
+        if (probe.path) paths[probe.id] = probe.path;
+      }
+      set({ providerVersions: versions, providerPaths: paths });
+    } catch {
+      // Non-fatal — UI falls back to hardcoded versions.
+    }
+  },
   setViewMode: (v) => {
     set({ viewMode: v });
     setSetting("viewMode", v);

--- a/src/util/shortcuts.ts
+++ b/src/util/shortcuts.ts
@@ -25,7 +25,7 @@ export function useGlobalShortcuts() {
       if (mod && e.key === "b") {
         e.preventDefault();
         toggleLeft();
-      } else if (mod && e.key === "k") {
+      } else if (mod && e.key === "k" && !inField) {
         e.preventDefault();
         // Reveal the sidebar if collapsed, then focus its search input.
         // When the sidebar was hidden the input mounts this frame, so defer

--- a/src/util/shortcuts.ts
+++ b/src/util/shortcuts.ts
@@ -2,10 +2,11 @@ import { useEffect } from "react";
 import { useAppStore } from "../store";
 
 /** Global keyboard shortcuts: ⌘B sidebar, ⌘/ right panel, ⌘,
- *  settings, ⌘⇧L theme flip, ⌘N new agent in active project, Esc
- *  closes popovers. */
+ *  settings, ⌘⇧L theme flip, ⌘N new agent in active project, ⌘K focus
+ *  sidebar search, Esc closes popovers. */
 export function useGlobalShortcuts() {
   const toggleLeft = useAppStore((s) => s.toggleLeft);
+  const leftCollapsed = useAppStore((s) => s.leftCollapsed);
   const toggleRight = useAppStore((s) => s.toggleRight);
   const toggleSettings = useAppStore((s) => s.toggleSettings);
   const closeSettingsScreen = useAppStore((s) => s.closeSettingsScreen);
@@ -24,6 +25,20 @@ export function useGlobalShortcuts() {
       if (mod && e.key === "b") {
         e.preventDefault();
         toggleLeft();
+      } else if (mod && e.key === "k") {
+        e.preventDefault();
+        // Reveal the sidebar if collapsed, then focus its search input.
+        // When the sidebar was hidden the input mounts this frame, so defer
+        // the focus to the next frame.
+        const focus = () => {
+          document.getElementById("sidebar-search")?.focus();
+        };
+        if (leftCollapsed) {
+          toggleLeft();
+          requestAnimationFrame(focus);
+        } else {
+          focus();
+        }
       } else if (mod && e.key === "/") {
         e.preventDefault();
         toggleRight();
@@ -49,5 +64,5 @@ export function useGlobalShortcuts() {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [toggleLeft, toggleRight, toggleSettings, closeSettingsScreen, setTheme, theme, createDraft, workspace, selectedAgentId]);
+  }, [toggleLeft, leftCollapsed, toggleRight, toggleSettings, closeSettingsScreen, setTheme, theme, createDraft, workspace, selectedAgentId]);
 }


### PR DESCRIPTION
Fixes three affordances that were visible but did nothing / gave no feedback.

### 1. `⌘K` focuses sidebar search
The search input rendered a `⌘K` hint (`SidebarHeader.tsx`) but no handler existed. Wired in `useGlobalShortcuts`: reveals the sidebar if collapsed, then focuses the input (given an `id`).

### 2. Providers settings: working "Re-scan", honest "Add provider"
"Re-scan system" and "Add provider" had no `onClick`, and "Checked just now" was static text.
- Extracted the provider-version probe into a reusable `refreshProviderVersions` store action (`init` now reuses it — no duplication).
- "Re-scan system" calls it with a transient "Scanning…" state.
- "Add provider" is `disabled` with a "Coming soon" tip (no backend yet).
- Removed the misleading static "Checked just now" label.

### 3. "Copy Path" gives feedback
The file-tree context menu copied silently while the file *editor's* copy button already shows a "copied" state. Added a generic `feedbackLabel` to `FileContextMenu` (briefly shows "Copied" + a check before dismissing) and used it for Copy Path — reusable for any fire-and-forget menu action.

`tsc --noEmit` clean and all 122 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)