### PR TITLE
refactor(chat): key chat rows by stable tool id, not array index

### DIFF
--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -5,7 +5,25 @@ import { applyPolicy, getAdapter } from "../../adapters";
 import { providerLabel } from "../../data/providers";
 import { Composer } from "../Composer";
 import { MessageItem } from "./messages/MessageItem";
-import { pairToolItems } from "./messages/pair";
+import { pairToolItems, type ViewItem } from "./messages/pair";
+
+/** Stable React key for a rendered row. Tool calls/results/pairs key off
+ *  their tool id so a row's expand state stays anchored to the tool rather
+ *  than to a list position. Messages and notices have no id and the log is
+ *  append-only, so their array index is a stable key — and keying them by
+ *  text would remount on every streaming token. */
+function rowKey(item: ViewItem, index: number): string {
+  switch (item.kind) {
+    case "tool_pair":
+      return item.call.id ? `tp:${item.call.id}` : `i:${index}`;
+    case "tool_call":
+      return item.id ? `tc:${item.id}` : `i:${index}`;
+    case "tool_result":
+      return item.tool_use_id ? `tr:${item.tool_use_id}` : `i:${index}`;
+    default:
+      return `i:${index}`;
+  }
+}
 
 /** Custom-view body: scrolling chat log + composer at the bottom.
  *  The composer here dispatches the user's message via the store; it
@@ -108,7 +126,9 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
               </div>
             </div>
           ) : (
-            items.map((item, i) => <MessageItem key={i} item={item} />)
+            items.map((item, i) => (
+              <MessageItem key={rowKey(item, i)} item={item} />
+            ))
           )}
           {busy && (
             <div className="writing">

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -7,17 +7,17 @@ import { Composer } from "../Composer";
 import { MessageItem } from "./messages/MessageItem";
 import { pairToolItems, type ViewItem } from "./messages/pair";
 
-/** Stable React key for a rendered row. Tool calls/results/pairs key off
- *  their tool id so a row's expand state stays anchored to the tool rather
- *  than to a list position. Messages and notices have no id and the log is
- *  append-only, so their array index is a stable key — and keying them by
- *  text would remount on every streaming token. */
+/** Stable React key for a rendered row. Tool pairs/results key off their tool
+ *  id so a row's expand state stays anchored to the tool rather than to a list
+ *  position. Messages and notices have no id and the log is append-only, so
+ *  their array index is a stable key — and keying them by text would remount on
+ *  every streaming token. */
 function rowKey(item: ViewItem, index: number): string {
   switch (item.kind) {
     case "tool_pair":
       return item.call.id ? `tp:${item.call.id}` : `i:${index}`;
-    case "tool_call":
-      return item.id ? `tc:${item.id}` : `i:${index}`;
+    // No `tool_call` case: pairToolItems wraps every tool_call into a
+    // tool_pair, so only orphan tool_results reach here standalone.
     case "tool_result":
       return item.tool_use_id ? `tr:${item.tool_use_id}` : `i:${index}`;
     default:


### PR DESCRIPTION
`ChatView` keyed every rendered row by its array index. Tool rows (`ToolRow`/`ToolResultItem`) hold local expand state, so keying them by position rather than by the tool itself is fragile. This keys tool calls/results/pairs off their **tool id**; messages and notices keep their index.

### Why messages stay index-keyed (deliberate)
The log is append-only, so positional keys are stable for them — and keying a streaming `agent_message` by its text would remount the row on every token.

### Scope / honesty
This is **hardening, not a live bug fix**. On inspection the reducer only appends or updates items in place (never inserts mid-list or reorders), and `chat-inner` already remounts per agent via `key={agent.id}` — so index keys weren't actively misanchoring state today. This makes the intent explicit and keeps the list correct if a future reducer ever reorders. I deliberately did **not** introduce a reducer-wide id system, which would be churn for no current benefit.

`tsc --noEmit` clean and all 122 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)