### PR TITLE
fix(ui): clearer commit/push notice, restore spinner, error flash

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1163,10 +1163,14 @@ button { cursor: default; }
 .git-act { padding: 12px 18px 14px; }
 /* transient confirmation shown in place of the status line after an action */
 .git-notice {
-  display: flex; align-items: center; gap: 7px;
+  display: inline-flex; align-items: center; gap: 7px;
   font-size: 11px; color: var(--success);
   margin-bottom: 11px;
   min-height: 14px;
+  padding: 5px 9px;
+  border: 1px solid color-mix(in oklch, var(--success), transparent 70%);
+  background: color-mix(in oklch, var(--success), transparent 90%);
+  border-radius: var(--r-sm);
 }
 .git-notice svg { flex-shrink: 0; }
 .git-act-status {
@@ -2035,6 +2039,16 @@ button { cursor: default; }
   transition: opacity .12s var(--ease);
 }
 .hrow:hover .hr-goto { opacity: 1; }
+/* while a restore is in flight, keep the indicator visible without hover */
+.hr-goto.restoring { opacity: 1; pointer-events: none; }
+.hr-goto .dots { display: inline-flex; gap: 3px; }
+.hr-goto .dots i {
+  width: 4px; height: 4px; border-radius: 50%;
+  background: currentColor;
+  animation: bounce 1.2s var(--ease) infinite;
+}
+.hr-goto .dots i:nth-child(2) { animation-delay: .15s; }
+.hr-goto .dots i:nth-child(3) { animation-delay: .3s; }
 
 /* foot hint */
 .history-foot {
@@ -2204,6 +2218,13 @@ button { cursor: default; }
   color: var(--danger);
   border-radius: var(--r-sm);
   font-size: 11.5px;
+  /* The banner is pinned above the tree, so it can't scroll off-screen — a
+     brief flash on appear draws the eye when an op fails deep in the list. */
+  animation: fp-op-error-flash .6s var(--ease);
+}
+@keyframes fp-op-error-flash {
+  0%, 100% { background: color-mix(in oklch, var(--danger), transparent 92%); }
+  35%      { background: color-mix(in oklch, var(--danger), transparent 70%); }
 }
 .fp-op-error span { flex: 1; min-width: 0; }
 .fp-op-error .fp-clear { color: var(--danger); }

--- a/src/components/History/index.tsx
+++ b/src/components/History/index.tsx
@@ -170,11 +170,20 @@ export function History() {
                         </span>
                       )}
                       <span className="hr-date">{when}</span>
-                      <span className="hr-goto">
-                        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                          <polyline points="9 18 15 12 9 6" />
-                        </svg>
-                        Restore
+                      <span className={`hr-goto${isRestoring ? " restoring" : ""}`}>
+                        {isRestoring ? (
+                          <>
+                            <span className="dots"><i /><i /><i /></span>
+                            Restoring…
+                          </>
+                        ) : (
+                          <>
+                            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                              <polyline points="9 18 15 12 9 6" />
+                            </svg>
+                            Restore
+                          </>
+                        )}
                       </span>
                     </button>
                   );

--- a/src/components/History/index.tsx
+++ b/src/components/History/index.tsx
@@ -148,7 +148,10 @@ export function History() {
                       onClick={() => onRowClick(a.id)}
                       onMouseEnter={() => setFocusedIndex(myIdx)}
                       disabled={!!restoringId}
-                      style={{ opacity: isRestoring ? 0.5 : undefined }}
+                      // Dim the other rows during a restore, but keep the active
+                      // row at full opacity so its spinner stays visible (a
+                      // parent opacity would otherwise cap the child rule).
+                      style={{ opacity: !isRestoring && restoringId ? 0.5 : undefined }}
                     >
                       <span className="hr-status">
                         <Icon name="dot" size={6} />

--- a/src/components/RightPanel/FilePanel.tsx
+++ b/src/components/RightPanel/FilePanel.tsx
@@ -320,7 +320,9 @@ export function FilePanel({ agent, canViewDiff, onViewDiff }: FilePanelProps) {
       </div>
 
       {opError && (
-        <div className="fp-op-error" role="alert">
+        // Key by message so a new error remounts the banner and re-runs the
+        // attention flash even when one is already showing.
+        <div key={opError} className="fp-op-error" role="alert">
           <Icon name="close" size={11} />
           <span>{opError}</span>
           <button className="fp-clear" onClick={() => setOpError(null)} aria-label="Dismiss">


### PR DESCRIPTION
A small UX-feedback polish pass (item #9 from the improvements audit).

### 1. GitPanel notice is easy to catch
The transient commit/push/pull/rebase confirmation was bare green text. Now it renders as a green **chip** (translucent bg + border), mirroring the existing error-banner styling.

### 2. History "Restore" shows progress
While a restore is in flight the row only dimmed to 0.5 opacity. Now the action shows a spinner + "Restoring…", kept visible without hover, so the user sees something is happening.

### 3. FilePanel error flash (instead of scroll-into-view)
The audit suggested scrolling file-op errors into view. On inspection that's a **no-op** — the banner is pinned above the scrollable `.fp-tree`, so it never scrolls off-screen. Instead the banner now does a brief one-time **flash** on appear to draw the eye when an op fails deep in the tree, and is keyed by message so a new error re-flashes even if one is already showing.

`tsc --noEmit` clean and all 122 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)