### PR TITLE
feat(right-panel): unify Files + Diff into one Code panel with Live mode

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -751,6 +751,18 @@ pub async fn read_worktree_file(
     })
 }
 
+/// Full unified diff of one worktree file versus the parent branch — the data
+/// behind the Code panel's Live view. Returns "" when the file is unchanged.
+#[tauri::command]
+pub async fn get_file_diff(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+    path: String,
+) -> Result<String> {
+    let (worktree, parent) = primary_worktree(&supervisor, &agent_id)?;
+    git::file_diff(&worktree, &parent, &path).await
+}
+
 /// Overwrite a worktree file with new contents (the editor's Save / Revert).
 #[tauri::command]
 pub async fn write_worktree_file(

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -582,6 +582,23 @@ pub async fn file_changed_lines(
     Ok(parse_changed_lines(&String::from_utf8_lossy(&out.stdout)))
 }
 
+/// Return the full unified diff of `path` versus `base_ref`, for the Code
+/// panel's live view. `-U3` gives three lines of surrounding context per hunk.
+pub async fn file_diff(worktree: &Path, base_ref: &str, path: &str) -> Result<String> {
+    let out = Command::new("git")
+        .current_dir(worktree)
+        .args(["diff", "--no-color", "-U3", base_ref, "--", path])
+        .output()
+        .await?;
+    if !out.status.success() {
+        return Err(Error::Git(format!(
+            "diff -U3 {base_ref} -- {path} failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
 /// Parse `git diff -U0` output into (added, modified) new-file line numbers.
 /// A hunk that only inserts lines marks them "added"; a hunk that also
 /// removes lines marks its inserted lines "modified" (a replacement).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -184,6 +184,7 @@ pub fn run() {
             commands::run_state,
             commands::list_worktree_tree,
             commands::read_worktree_file,
+            commands::get_file_diff,
             commands::write_worktree_file,
             commands::rename_worktree_path,
             commands::delete_worktree_path,

--- a/src/api.ts
+++ b/src/api.ts
@@ -311,6 +311,8 @@ export const api = {
     invoke<WorktreeFile[]>("list_worktree_tree", { agentId }),
   readWorktreeFile: (agentId: string, path: string) =>
     invoke<WorktreeFileContents>("read_worktree_file", { agentId, path }),
+  getFileDiff: (agentId: string, path: string) =>
+    invoke<string>("get_file_diff", { agentId, path }),
   writeWorktreeFile: (agentId: string, path: string, contents: string) =>
     invoke<void>("write_worktree_file", { agentId, path, contents }),
   renameWorktreePath: (agentId: string, from: string, to: string) =>

--- a/src/app.css
+++ b/src/app.css
@@ -937,6 +937,253 @@ button { cursor: default; }
 
 .right-body { flex: 1; overflow-y: auto; overflow-x: hidden; display: flex; flex-direction: column; min-height: 0; }
 
+/* ─── code panel: Files | Live, behind a secondary mode switch ───── */
+.code-panel { flex: 1; min-height: 0; display: flex; flex-direction: column; }
+.code-panel-body { flex: 1; min-height: 0; display: flex; flex-direction: column; }
+
+/* The mode switch is deliberately styled UNLIKE the panel tabs above it —
+   an inset filled-thumb pill, not an underline tab — so it reads as a control
+   within the Code panel rather than as switching between panels. */
+.code-modes {
+  display: flex; align-items: center;
+  padding: 7px 10px;
+  border-bottom: 1px solid var(--bd-soft);
+  background: var(--bg-1);
+  flex-shrink: 0;
+}
+.code-modeswitch {
+  display: inline-flex; gap: 2px;
+  padding: 2px;
+  background: var(--bg-0);
+  border: 1px solid var(--bd-soft);
+  border-radius: 8px;
+}
+.cms-seg {
+  display: inline-flex; align-items: center; gap: 5px;
+  height: 22px; padding: 0 10px;
+  border: none; background: transparent;
+  border-radius: 6px;
+  font-size: 11px; font-weight: 500;
+  color: var(--fg-2);
+  cursor: pointer;
+  position: relative;
+  transition: color .12s, background .12s, box-shadow .12s;
+}
+.cms-seg svg { width: 12px; height: 12px; opacity: .9; }
+.cms-seg:hover { color: var(--fg-0); }
+.cms-seg.active {
+  background: var(--bg-2);
+  color: var(--fg-0);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, .18);
+}
+.cms-live-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--success);
+  margin-left: 1px;
+  animation: code-tab-live 1.6s ease-in-out infinite;
+}
+
+/* Live mode — activity feed of agent edits as diffs (ported from the design). */
+.code-wrap { flex: 1; display: flex; flex-direction: column; min-height: 0; }
+
+.code-h {
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--bd-soft);
+  background: var(--bg-1);
+}
+.code-h .code-h-l {
+  flex: 1; min-width: 0;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 11.5px; color: var(--fg-1);
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+.code-h .ch-count { color: var(--fg-0); font-weight: 600; }
+.code-h .ch-count .dim { color: var(--fg-3); font-weight: 400; }
+.code-h .ch-dot { color: var(--fg-3); }
+.code-h .ch-add { color: var(--success); }
+.code-h .ch-rem { color: var(--danger); }
+
+.code-h .code-open {
+  flex-shrink: 0;
+  display: inline-flex; align-items: center; gap: 5px;
+  height: 22px; padding: 0 9px;
+  border-radius: 11px;
+  font-size: 10.5px; font-weight: 500;
+  border: 1px solid var(--bd-soft);
+  background: transparent; color: var(--fg-2);
+  cursor: pointer;
+  transition: color .12s, background .12s, border-color .12s;
+}
+.code-h .code-open:hover { color: var(--fg-0); border-color: var(--bd); background: var(--hover); }
+
+.code-h .code-follow {
+  flex-shrink: 0;
+  display: inline-flex; align-items: center; gap: 6px;
+  height: 22px; padding: 0 9px 0 8px;
+  border-radius: 11px;
+  font-size: 10.5px; font-weight: 500; letter-spacing: 0.02em;
+  border: 1px solid var(--bd-soft);
+  background: transparent; color: var(--fg-2);
+  cursor: pointer;
+  transition: color .12s, background .12s, border-color .12s;
+  white-space: nowrap;
+}
+.code-h .code-follow .cf-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--fg-3);
+  transition: background .12s, box-shadow .2s;
+}
+.code-h .code-follow.on {
+  color: var(--success);
+  border-color: color-mix(in oklch, var(--success), transparent 65%);
+  background: color-mix(in oklch, var(--success), transparent 90%);
+}
+.code-h .code-follow.on .cf-dot { background: var(--success); }
+.code-h .code-follow.on.live .cf-dot {
+  animation: code-follow-pulse 1.8s ease-in-out infinite;
+}
+@keyframes code-follow-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 color-mix(in oklch, var(--success), transparent 40%); }
+  50%      { box-shadow: 0 0 0 3px color-mix(in oklch, var(--success), transparent 88%); }
+}
+.code-h .code-follow:hover { color: var(--fg-0); border-color: var(--bd); }
+.code-h .code-follow.on:hover { background: color-mix(in oklch, var(--success), transparent 84%); }
+
+.code-tabs {
+  display: flex; gap: 4px;
+  padding: 6px 8px;
+  overflow-x: auto; overflow-y: hidden;
+  border-bottom: 1px solid var(--bd-soft);
+  background: var(--bg-0);
+  scrollbar-width: thin; scroll-behavior: smooth;
+  flex-shrink: 0;
+}
+.code-tabs::-webkit-scrollbar { height: 4px; }
+.code-tabs::-webkit-scrollbar-thumb { background: var(--bd-soft); border-radius: 2px; }
+.code-tab {
+  flex-shrink: 0;
+  display: inline-flex; align-items: center; gap: 7px;
+  height: 26px; padding: 0 9px;
+  background: transparent; border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  font-size: 11.5px; color: var(--fg-2);
+  cursor: pointer;
+  transition: background .12s, color .12s, border-color .12s;
+  position: relative;
+}
+.code-tab:hover { color: var(--fg-0); background: var(--hover); }
+.code-tab.active {
+  background: var(--bg-1); color: var(--fg-0);
+  border-color: var(--bd-soft);
+  box-shadow: 0 1px 0 var(--bg-1);
+}
+.code-tab .ct-status {
+  font-family: var(--font-mono);
+  font-size: 9.5px; font-weight: 600; letter-spacing: 0.04em;
+  width: 14px; height: 14px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 3px; flex-shrink: 0;
+}
+.code-tab.status-m .ct-status { background: color-mix(in oklch, var(--info), transparent 80%);    color: var(--info); }
+.code-tab.status-a .ct-status { background: color-mix(in oklch, var(--success), transparent 80%); color: var(--success); }
+.code-tab.status-d .ct-status { background: color-mix(in oklch, var(--danger), transparent 80%);  color: var(--danger); }
+.code-tab.status-r .ct-status { background: color-mix(in oklch, var(--warn), transparent 80%);    color: var(--warn); }
+.code-tab .ct-name { font-family: var(--font-mono); font-weight: 500; letter-spacing: -0.005em; }
+.code-tab .ct-stats {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-family: var(--font-mono); font-size: 10px;
+}
+.code-tab .ct-stats .a { color: var(--success); }
+.code-tab .ct-stats .r { color: var(--danger); }
+.code-tab .ct-live {
+  margin-left: 1px;
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--success); flex-shrink: 0;
+  animation: code-tab-live 1.6s ease-in-out infinite;
+}
+@keyframes code-tab-live {
+  0%, 100% { box-shadow: 0 0 0 0 color-mix(in oklch, var(--success), transparent 35%); }
+  50%      { box-shadow: 0 0 0 4px color-mix(in oklch, var(--success), transparent 88%); }
+}
+.code-tab.live.active { border-color: color-mix(in oklch, var(--success), transparent 60%); }
+
+.code-diff {
+  flex: 1; overflow: auto;
+  padding: 4px 0 80px;
+  background: var(--bg-0);
+  font-family: var(--font-mono);
+  font-size: 11.5px; line-height: 1.55;
+  position: relative;
+}
+.code-diff.live::before {
+  content: "";
+  position: sticky; top: 0;
+  display: block; height: 2px; margin: 0 0 2px;
+  background: linear-gradient(90deg,
+    transparent 0%,
+    color-mix(in oklch, var(--success), transparent 30%) 30%,
+    color-mix(in oklch, var(--success), transparent 30%) 70%,
+    transparent 100%);
+  background-size: 200% 100%;
+  animation: code-diff-shimmer 2.4s linear infinite;
+  z-index: 1;
+}
+@keyframes code-diff-shimmer {
+  0%   { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
+}
+.code-hunk-h {
+  padding: 6px 12px;
+  background: color-mix(in oklch, var(--accent), var(--bg-0) 88%);
+  color: var(--fg-2);
+  font-family: var(--font-mono); font-size: 11px;
+  border-top: 1px solid var(--bd-soft);
+  border-bottom: 1px solid var(--bd-soft);
+  margin: 4px 0 0;
+}
+.code-diff .dl {
+  display: grid;
+  grid-template-columns: 34px 34px 14px 1fr;
+  align-items: baseline;
+  padding: 0 12px 0 0;
+  position: relative; white-space: pre; min-height: 18px;
+}
+.code-diff .dl-num {
+  font-size: 10px; color: var(--fg-3);
+  text-align: right; padding-right: 6px; user-select: none;
+}
+.code-diff .dl-num.o { padding-left: 6px; }
+.code-diff .dl-sigil {
+  text-align: center; font-weight: 600; color: var(--fg-3); user-select: none;
+}
+.code-diff .dl-text {
+  overflow: hidden; text-overflow: clip;
+  position: relative; color: var(--fg-1);
+}
+.code-diff .dl.op-add { background: color-mix(in oklch, var(--success), transparent 92%); }
+.code-diff .dl.op-add .dl-sigil { color: var(--success); }
+.code-diff .dl.op-add .dl-num.n { color: color-mix(in oklch, var(--success), var(--fg-2) 50%); }
+.code-diff .dl.op-rem { background: color-mix(in oklch, var(--danger), transparent 92%); }
+.code-diff .dl.op-rem .dl-sigil { color: var(--danger); }
+.code-diff .dl.op-rem .dl-num.o { color: color-mix(in oklch, var(--danger), var(--fg-2) 50%); }
+.code-diff .dl.op-rem .dl-text {
+  color: color-mix(in oklch, var(--danger), var(--fg-1) 55%);
+  text-decoration: line-through;
+  text-decoration-color: color-mix(in oklch, var(--danger), transparent 60%);
+  text-decoration-thickness: 1px;
+}
+.code-diff .dl.fresh { animation: code-line-arrive 1.6s ease-out; }
+@keyframes code-line-arrive {
+  0%   { background: color-mix(in oklch, var(--success), transparent 50%); }
+  100% { background: color-mix(in oklch, var(--success), transparent 92%); }
+}
+.code-diff .dl:hover { background-color: color-mix(in oklch, currentColor, var(--bg-1) 95%); }
+.code-diff .dl.op-add:hover { background-color: color-mix(in oklch, var(--success), transparent 86%); }
+.code-diff .dl.op-rem:hover { background-color: color-mix(in oklch, var(--danger), transparent 86%); }
+.code-diff .dl.op-ctx:hover { background-color: var(--bg-1); }
+
 /* ─── git panel (smart) ─────────────────────────────────────────── */
 /* layout: fixed context header · scrollable changes · pinned action footer */
 .git-wrap {
@@ -2425,63 +2672,63 @@ button { cursor: default; }
 
 /* syntax tokens — design palette mapped onto highlight.js classes, so any
    language renders in the mockup's colors (violet kw / olive str / etc.) */
-.fp-hl.cq .hljs-keyword,
-.fp-hl.cq .hljs-keyword.hljs-type { color: oklch(0.78 0.11 295); font-weight: 500; } /* keywords — violet */
-.fp-hl.cq .hljs-string,
-.fp-hl.cq .hljs-regexp,
-.fp-hl.cq .hljs-symbol,
-.fp-hl.cq .hljs-char.escape_,
-.fp-hl.cq .hljs-meta .hljs-string { color: oklch(0.78 0.13 110); }                    /* strings — olive */
-.fp-hl.cq .hljs-comment,
-.fp-hl.cq .hljs-quote { color: var(--fg-3); font-style: italic; }
-.fp-hl.cq .hljs-number,
-.fp-hl.cq .hljs-literal { color: oklch(0.78 0.13 50); }                                /* numbers — copper */
-.fp-hl.cq .hljs-built_in,
-.fp-hl.cq .hljs-title.function_,
-.fp-hl.cq .hljs-attr,
-.fp-hl.cq .hljs-variable.language_,
-.fp-hl.cq .hljs-selector-tag { color: oklch(0.8 0.1 220); }                            /* builtins — ocean */
-.fp-hl.cq .hljs-title,
-.fp-hl.cq .hljs-title.class_,
-.fp-hl.cq .hljs-type,
-.fp-hl.cq .hljs-attribute,
-.fp-hl.cq .hljs-tag,
-.fp-hl.cq .hljs-name,
-.fp-hl.cq .hljs-section,
-.fp-hl.cq .hljs-selector-class,
-.fp-hl.cq .hljs-selector-id,
-.fp-hl.cq .hljs-doctag { color: oklch(0.82 0.07 200); }                                /* types — pale ocean */
-.fp-hl.cq .hljs-meta,
-.fp-hl.cq .hljs-punctuation,
-.fp-hl.cq .hljs-operator,
-.fp-hl.cq .hljs-bullet { color: var(--fg-2); }
-.fp-hl.cq .hljs-deletion { color: var(--danger); }
-.fp-hl.cq .hljs-addition { color: var(--success); }
+:is(.fp-hl, .code-diff).cq .hljs-keyword,
+:is(.fp-hl, .code-diff).cq .hljs-keyword.hljs-type { color: oklch(0.78 0.11 295); font-weight: 500; } /* keywords — violet */
+:is(.fp-hl, .code-diff).cq .hljs-string,
+:is(.fp-hl, .code-diff).cq .hljs-regexp,
+:is(.fp-hl, .code-diff).cq .hljs-symbol,
+:is(.fp-hl, .code-diff).cq .hljs-char.escape_,
+:is(.fp-hl, .code-diff).cq .hljs-meta .hljs-string { color: oklch(0.78 0.13 110); }                    /* strings — olive */
+:is(.fp-hl, .code-diff).cq .hljs-comment,
+:is(.fp-hl, .code-diff).cq .hljs-quote { color: var(--fg-3); font-style: italic; }
+:is(.fp-hl, .code-diff).cq .hljs-number,
+:is(.fp-hl, .code-diff).cq .hljs-literal { color: oklch(0.78 0.13 50); }                                /* numbers — copper */
+:is(.fp-hl, .code-diff).cq .hljs-built_in,
+:is(.fp-hl, .code-diff).cq .hljs-title.function_,
+:is(.fp-hl, .code-diff).cq .hljs-attr,
+:is(.fp-hl, .code-diff).cq .hljs-variable.language_,
+:is(.fp-hl, .code-diff).cq .hljs-selector-tag { color: oklch(0.8 0.1 220); }                            /* builtins — ocean */
+:is(.fp-hl, .code-diff).cq .hljs-title,
+:is(.fp-hl, .code-diff).cq .hljs-title.class_,
+:is(.fp-hl, .code-diff).cq .hljs-type,
+:is(.fp-hl, .code-diff).cq .hljs-attribute,
+:is(.fp-hl, .code-diff).cq .hljs-tag,
+:is(.fp-hl, .code-diff).cq .hljs-name,
+:is(.fp-hl, .code-diff).cq .hljs-section,
+:is(.fp-hl, .code-diff).cq .hljs-selector-class,
+:is(.fp-hl, .code-diff).cq .hljs-selector-id,
+:is(.fp-hl, .code-diff).cq .hljs-doctag { color: oklch(0.82 0.07 200); }                                /* types — pale ocean */
+:is(.fp-hl, .code-diff).cq .hljs-meta,
+:is(.fp-hl, .code-diff).cq .hljs-punctuation,
+:is(.fp-hl, .code-diff).cq .hljs-operator,
+:is(.fp-hl, .code-diff).cq .hljs-bullet { color: var(--fg-2); }
+:is(.fp-hl, .code-diff).cq .hljs-deletion { color: var(--danger); }
+:is(.fp-hl, .code-diff).cq .hljs-addition { color: var(--success); }
 
-.theme-light .fp-hl.cq .hljs-keyword,
-.theme-light .fp-hl.cq .hljs-keyword.hljs-type { color: oklch(0.4 0.18 295); }
-.theme-light .fp-hl.cq .hljs-string,
-.theme-light .fp-hl.cq .hljs-regexp,
-.theme-light .fp-hl.cq .hljs-symbol,
-.theme-light .fp-hl.cq .hljs-char.escape_,
-.theme-light .fp-hl.cq .hljs-meta .hljs-string { color: oklch(0.42 0.14 110); }
-.theme-light .fp-hl.cq .hljs-number,
-.theme-light .fp-hl.cq .hljs-literal { color: oklch(0.5 0.16 50); }
-.theme-light .fp-hl.cq .hljs-built_in,
-.theme-light .fp-hl.cq .hljs-title.function_,
-.theme-light .fp-hl.cq .hljs-attr,
-.theme-light .fp-hl.cq .hljs-variable.language_,
-.theme-light .fp-hl.cq .hljs-selector-tag { color: oklch(0.45 0.13 220); }
-.theme-light .fp-hl.cq .hljs-title,
-.theme-light .fp-hl.cq .hljs-title.class_,
-.theme-light .fp-hl.cq .hljs-type,
-.theme-light .fp-hl.cq .hljs-attribute,
-.theme-light .fp-hl.cq .hljs-tag,
-.theme-light .fp-hl.cq .hljs-name,
-.theme-light .fp-hl.cq .hljs-section,
-.theme-light .fp-hl.cq .hljs-selector-class,
-.theme-light .fp-hl.cq .hljs-selector-id,
-.theme-light .fp-hl.cq .hljs-doctag { color: oklch(0.4 0.09 200); }
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-keyword,
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-keyword.hljs-type { color: oklch(0.4 0.18 295); }
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-string,
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-regexp,
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-symbol,
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-char.escape_,
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-meta .hljs-string { color: oklch(0.42 0.14 110); }
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-number,
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-literal { color: oklch(0.5 0.16 50); }
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-built_in,
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-title.function_,
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-attr,
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-variable.language_,
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-selector-tag { color: oklch(0.45 0.13 220); }
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-title,
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-title.class_,
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-type,
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-attribute,
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-tag,
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-name,
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-section,
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-selector-class,
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-selector-id,
+.theme-light :is(.fp-hl, .code-diff).cq .hljs-doctag { color: oklch(0.4 0.09 200); }
 
 /* ═══════════════════════════════════════════════════════════════════════
    FULL-SCREEN SETTINGS  (General / Account / Providers)

--- a/src/app.css
+++ b/src/app.css
@@ -978,8 +978,11 @@ button { cursor: default; }
 }
 .cms-live-dot {
   width: 6px; height: 6px; border-radius: 50%;
-  background: var(--success);
   margin-left: 1px;
+  background: var(--fg-3); /* grey: there are changes, but nothing is happening now */
+}
+.cms-live-dot.on {
+  background: var(--success); /* green & pulsing only while the agent works */
   animation: code-tab-live 1.6s ease-in-out infinite;
 }
 
@@ -2430,6 +2433,18 @@ button { cursor: default; }
   display: inline-flex; align-items: center; justify-content: center;
   border-radius: var(--r-xs);
 }
+
+/* changed-file count on a collapsed folder */
+.fp-row.dir .fp-dir-changed {
+  flex-shrink: 0;
+  margin-left: auto;
+  min-width: 15px; height: 15px; padding: 0 4px;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-family: var(--font-mono); font-size: 9.5px; font-weight: 600;
+  border-radius: var(--r-xs);
+  background: color-mix(in oklch, var(--warn), transparent 84%);
+  color: var(--warn);
+}
 .fp-badge.s-m { background: color-mix(in oklch, var(--warn), transparent 82%);    color: var(--warn); }
 .fp-badge.s-a { background: color-mix(in oklch, var(--success), transparent 82%); color: var(--success); }
 .fp-badge.s-d { background: color-mix(in oklch, var(--danger), transparent 82%);  color: var(--danger); }
@@ -2531,6 +2546,16 @@ button { cursor: default; }
   font-family: var(--font-sans); font-size: 10.5px; font-weight: 500;
 }
 .fp-meta-btn:hover { background: var(--hover); color: var(--fg-0); border-color: var(--bd); }
+/* pressed state for the Diff view toggle */
+.fp-meta-btn.active {
+  background: color-mix(in oklch, var(--accent), transparent 86%);
+  border-color: color-mix(in oklch, var(--accent), transparent 55%);
+  color: var(--accent);
+}
+.fp-meta-btn.active:hover {
+  background: color-mix(in oklch, var(--accent), transparent 80%);
+  color: var(--accent);
+}
 
 /* syntax-theme picker (bottom-right of the editor footer) */
 .fp-theme-select {

--- a/src/components/RightPanel/Code/CodeLivePanel.tsx
+++ b/src/components/RightPanel/Code/CodeLivePanel.tsx
@@ -7,13 +7,12 @@
 // and fetches each file's diff via `get_file_diff`. True edit-streaming (a
 // typing cursor per keystroke) is a deferred follow-up.
 import { useEffect, useMemo, useRef, useState } from "react";
-import { api, type AgentRecord, type FileStatus } from "../../../api";
+import { type AgentRecord, type FileStatus } from "../../../api";
 import { useAppStore } from "../../../store";
 import { usePoll } from "../../../util/hooks";
-import { hljsLang } from "../../../data/languages";
-import { highlightToHtml } from "../../../util/highlight";
 import { useHljsTheme } from "../../../util/codeTheme";
-import { parseUnifiedDiff, type DiffHunk, type DiffLine } from "../../../util/diff";
+import { type DiffLine } from "../../../util/diff";
+import { DiffBody, useFileDiff, extOf } from "./DiffView";
 import { Icon } from "../../Icon";
 
 interface CodeLivePanelProps {
@@ -36,7 +35,6 @@ function statusLetter(kind: FileStatus["kind"]): string {
   }
 }
 
-const extOf = (path: string) => path.split(".").pop() ?? "";
 const sigOf = (f: FileStatus) => `${f.additions}:${f.deletions}`;
 
 export function CodeLivePanel({ agent, selectedPath, onSelect, onOpenInEditor }: CodeLivePanelProps) {
@@ -99,9 +97,17 @@ export function CodeLivePanel({ agent, selectedPath, onSelect, onOpenInEditor }:
       return;
     }
 
+    // If several files moved this tick, pick the one whose line counts changed
+    // the most — git status has no timestamps, so magnitude is the best proxy
+    // for "most active" (beats arbitrary array/path order).
     let moved: string | null = null;
+    let bestDelta = -1;
     for (const f of files) {
-      if (prevSig.current.get(f.path) !== sigOf(f)) moved = f.path;
+      const prev = prevSig.current.get(f.path);
+      if (prev === sigOf(f)) continue;
+      const [pa, pd] = prev ? prev.split(":").map(Number) : [0, 0];
+      const delta = Math.abs(f.additions - pa) + Math.abs(f.deletions - pd);
+      if (delta > bestDelta) { bestDelta = delta; moved = f.path; }
     }
     prevSig.current = sig;
     if (moved) setLiveFile(moved);
@@ -132,19 +138,8 @@ export function CodeLivePanel({ agent, selectedPath, onSelect, onOpenInEditor }:
   const displaySigStr = displaySig ? sigOf(displaySig) : "";
 
   // ── diff fetch ──────────────────────────────────────────────────────────
-  const [diffText, setDiffText] = useState<string | null>(null);
-  const [diffErr, setDiffErr] = useState(false);
-  useEffect(() => {
-    if (!displayPath) { setDiffText(null); setDiffErr(false); return; }
-    let cancelled = false;
-    api
-      .getFileDiff(agent.id, displayPath)
-      .then((t) => { if (!cancelled) { setDiffText(t); setDiffErr(false); } })
-      .catch(() => { if (!cancelled) { setDiffText(null); setDiffErr(true); } });
-    return () => { cancelled = true; };
-  }, [agent.id, displayPath, displaySigStr]);
-
-  const hunks = useMemo(() => (diffText ? parseUnifiedDiff(diffText) : []), [diffText]);
+  // Refetch when the shown file changes or its +/- counts move during a turn.
+  const { hunks, error: diffErr } = useFileDiff(agent.id, displayPath, displaySigStr);
 
   // ── fresh-line highlighting ──────────────────────────────────────────────
   // Mark added lines that weren't present last time we rendered this same file
@@ -168,11 +163,14 @@ export function CodeLivePanel({ agent, selectedPath, onSelect, onOpenInEditor }:
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hunks, displayPath]);
 
-  // Clicking the file the agent is editing now re-arms auto-follow; clicking
-  // any other file pauses it (the user is reading something specific).
+  // During a turn, clicking the live file re-arms auto-follow and clicking any
+  // other file pauses it (the user is reading something specific). While idle
+  // there's no live file to follow, so a click just browses — it must not touch
+  // the armed/paused state, or an armed session would silently pause for the
+  // next turn. The Follow toggle stays the explicit control while idle.
   const onPickTab = (path: string) => {
     onSelect(path);
-    setFollow(busy && path === liveFile);
+    if (busy) setFollow(path === liveFile);
   };
 
   if (files.length === 0) {
@@ -257,33 +255,14 @@ export function CodeLivePanel({ agent, selectedPath, onSelect, onOpenInEditor }:
           <div>This change has no textual diff (binary, or already committed).</div>
         </div>
       ) : (
-        <div className={`code-diff ${isQuorum ? "cq" : ""} ${follow && busy && displayPath === liveFile ? "live" : ""}`}>
-          {hunks.map((h: DiffHunk, i) => (
-            <div key={i}>
-              <div className="code-hunk-h">{h.header}</div>
-              {h.lines.map((l, j) => (
-                <LiveDiffLine key={j} line={l} lang={lang} fresh={l.op === "add" && freshKeys.has(`${l.n}:${l.t}`)} />
-              ))}
-            </div>
-          ))}
-        </div>
+        <DiffBody
+          hunks={hunks}
+          lang={lang}
+          isQuorum={isQuorum}
+          live={follow && busy && displayPath === liveFile}
+          freshKeys={freshKeys}
+        />
       )}
-    </div>
-  );
-}
-
-function LiveDiffLine({ line, lang, fresh }: { line: DiffLine; lang: string; fresh: boolean }) {
-  const sigil = line.op === "add" ? "+" : line.op === "rem" ? "−" : " ";
-  const html = useMemo(
-    () => (line.t ? highlightToHtml(line.t, hljsLang(lang) ? lang : "") : ""),
-    [line.t, lang],
-  );
-  return (
-    <div className={`dl op-${line.op}${fresh ? " fresh" : ""}`}>
-      <span className="dl-num o">{line.o ?? ""}</span>
-      <span className="dl-num n">{line.n ?? ""}</span>
-      <span className="dl-sigil">{sigil}</span>
-      <span className="dl-text" dangerouslySetInnerHTML={{ __html: html }} />
     </div>
   );
 }

--- a/src/components/RightPanel/Code/CodeLivePanel.tsx
+++ b/src/components/RightPanel/Code/CodeLivePanel.tsx
@@ -1,0 +1,289 @@
+// CodeLivePanel — the "Live" mode of the Code panel: an activity feed of the
+// agent's edits as unified diffs. Distinct from the Files explorer (browse)
+// and from Git (staged changes): it's ordered by edit recency, auto-follows
+// the file the agent is currently touching, and animates freshly-arrived lines.
+//
+// v1 is poll-based: it reuses the 1s git-state poll for the changed-file list
+// and fetches each file's diff via `get_file_diff`. True edit-streaming (a
+// typing cursor per keystroke) is a deferred follow-up.
+import { useEffect, useMemo, useRef, useState } from "react";
+import { api, type AgentRecord, type FileStatus } from "../../../api";
+import { useAppStore } from "../../../store";
+import { usePoll } from "../../../util/hooks";
+import { hljsLang } from "../../../data/languages";
+import { highlightToHtml } from "../../../util/highlight";
+import { useHljsTheme } from "../../../util/codeTheme";
+import { parseUnifiedDiff, type DiffHunk, type DiffLine } from "../../../util/diff";
+import { Icon } from "../../Icon";
+
+interface CodeLivePanelProps {
+  agent: AgentRecord;
+  /** The file shared with Files mode; may be null or point at an unchanged file. */
+  selectedPath: string | null;
+  onSelect: (path: string) => void;
+  onOpenInEditor: (path: string) => void;
+}
+
+function statusLetter(kind: FileStatus["kind"]): string {
+  switch (kind) {
+    case "modified":   return "M";
+    case "added":      return "A";
+    case "deleted":    return "D";
+    case "renamed":    return "R";
+    case "untracked":  return "?";
+    case "conflicted": return "!";
+    default:           return "?";
+  }
+}
+
+const extOf = (path: string) => path.split(".").pop() ?? "";
+const sigOf = (f: FileStatus) => `${f.additions}:${f.deletions}`;
+
+export function CodeLivePanel({ agent, selectedPath, onSelect, onOpenInEditor }: CodeLivePanelProps) {
+  const gitState = useAppStore((s) => s.gitStates[agent.id] ?? null);
+  const fetchGitState = useAppStore((s) => s.fetchGitState);
+  // Is the agent mid-turn? Same signal the chat "thinking" spinner uses, so
+  // the panel's "live" state appears and clears in lockstep with the rest of
+  // the UI. Nothing is "live" once the turn ends.
+  const busy = useAppStore((s) => s.managedBusy[agent.id] ?? false);
+  // Match the editor's syntax theme: the "quorum" palette is gated by `cq`;
+  // other families color `.hljs-*` globally via a loaded stylesheet.
+  const isQuorum = useHljsTheme();
+
+  // Reuse the same 1s git poll the Git tab uses; only one right-rail tab is
+  // mounted at a time, so this never double-polls.
+  const pollGitState = useMemo(() => () => fetchGitState(agent.id), [agent.id, fetchGitState]);
+  usePoll(pollGitState, 1000, [pollGitState]);
+
+  const files = useMemo(() => gitState?.files ?? [], [gitState]);
+  const fileSig = files.map((f) => `${f.path}#${sigOf(f)}`).join("|");
+
+  // ── recency / "live" detection ──────────────────────────────────────────
+  // Without an edit stream we approximate the agent's current file: whichever
+  // changed-file's +/- counts moved since the last poll. This only means
+  // anything while the agent is mid-turn — when it goes idle, nothing is live.
+  const prevSig = useRef<Map<string, string>>(new Map());
+  const seeded = useRef(false);
+  const [liveFile, setLiveFile] = useState<string | null>(null);
+
+  // Reset recency tracking when the agent changes — the panel stays mounted
+  // across agent switches, so stale signatures would mis-detect the live file.
+  useEffect(() => {
+    seeded.current = false;
+    prevSig.current = new Map();
+    setLiveFile(null);
+  }, [agent.id]);
+
+  useEffect(() => {
+    const sig = new Map(files.map((f) => [f.path, sigOf(f)]));
+
+    // Idle: clear the live marker, but keep the baseline current so the next
+    // turn's very first edit registers as movement.
+    if (!busy) {
+      prevSig.current = sig;
+      seeded.current = files.length > 0;
+      setLiveFile(null);
+      return;
+    }
+
+    // Turn in progress. Seed on the first poll we have files for: guess the
+    // most-changed file as the current one until real movement refines it.
+    if (!seeded.current) {
+      if (files.length === 0) return;
+      seeded.current = true;
+      prevSig.current = sig;
+      const top = [...files].sort(
+        (a, b) => b.additions + b.deletions - (a.additions + a.deletions),
+      )[0];
+      setLiveFile(top?.path ?? null);
+      return;
+    }
+
+    let moved: string | null = null;
+    for (const f of files) {
+      if (prevSig.current.get(f.path) !== sigOf(f)) moved = f.path;
+    }
+    prevSig.current = sig;
+    if (moved) setLiveFile(moved);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [busy, fileSig]);
+
+  // ── follow ────────────────────────────────────────────────────────────
+  // When armed, the rendered diff jumps to whatever file the agent is editing
+  // now. Start paused only if the user arrived with a file already selected
+  // (e.g. via "View diff" from the editor); otherwise follow the agent.
+  const [follow, setFollow] = useState(() => selectedPath == null);
+  useEffect(() => {
+    if (follow && busy && liveFile && liveFile !== selectedPath) onSelect(liveFile);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [follow, busy, liveFile]);
+
+  const changed = useMemo(() => new Set(files.map((f) => f.path)), [files]);
+  // The file actually shown: the shared selection if it's a changed file,
+  // else the live file, else the first change.
+  const displayPath =
+    selectedPath && changed.has(selectedPath)
+      ? selectedPath
+      : liveFile && changed.has(liveFile)
+        ? liveFile
+        : files[0]?.path ?? null;
+
+  const displaySig = files.find((f) => f.path === displayPath);
+  const displaySigStr = displaySig ? sigOf(displaySig) : "";
+
+  // ── diff fetch ──────────────────────────────────────────────────────────
+  const [diffText, setDiffText] = useState<string | null>(null);
+  const [diffErr, setDiffErr] = useState(false);
+  useEffect(() => {
+    if (!displayPath) { setDiffText(null); setDiffErr(false); return; }
+    let cancelled = false;
+    api
+      .getFileDiff(agent.id, displayPath)
+      .then((t) => { if (!cancelled) { setDiffText(t); setDiffErr(false); } })
+      .catch(() => { if (!cancelled) { setDiffText(null); setDiffErr(true); } });
+    return () => { cancelled = true; };
+  }, [agent.id, displayPath, displaySigStr]);
+
+  const hunks = useMemo(() => (diffText ? parseUnifiedDiff(diffText) : []), [diffText]);
+
+  // ── fresh-line highlighting ──────────────────────────────────────────────
+  // Mark added lines that weren't present last time we rendered this same file
+  // (a new file view doesn't flash its whole body).
+  const prevAdds = useRef<{ path: string; keys: Set<string> }>({ path: "", keys: new Set() });
+  const addKey = (l: DiffLine) => `${l.n}:${l.t}`;
+  const freshKeys = useMemo(() => {
+    const set = new Set<string>();
+    if (prevAdds.current.path !== displayPath) return set;
+    for (const h of hunks)
+      for (const l of h.lines)
+        if (l.op === "add" && !prevAdds.current.keys.has(addKey(l))) set.add(addKey(l));
+    return set;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hunks, displayPath]);
+  useEffect(() => {
+    const keys = new Set<string>();
+    for (const h of hunks)
+      for (const l of h.lines) if (l.op === "add") keys.add(addKey(l));
+    prevAdds.current = { path: displayPath ?? "", keys };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hunks, displayPath]);
+
+  // Clicking the file the agent is editing now re-arms auto-follow; clicking
+  // any other file pauses it (the user is reading something specific).
+  const onPickTab = (path: string) => {
+    onSelect(path);
+    setFollow(busy && path === liveFile);
+  };
+
+  if (files.length === 0) {
+    return (
+      <div className="code-wrap">
+        <div className="empty-msg" style={{ margin: "auto" }}>
+          <div className="et">No changes yet</div>
+          <div>Edits the agent makes to this worktree will stream in here.</div>
+        </div>
+      </div>
+    );
+  }
+
+  const lang = displayPath ? extOf(displayPath) : "";
+
+  return (
+    <div className="code-wrap">
+      {/* header: totals + follow toggle */}
+      <div className="code-h">
+        <div className="code-h-l">
+          <span className="ch-count">{files.length}<span className="dim"> files</span></span>
+          <span className="ch-dot">·</span>
+          <span className="ch-add">+{gitState?.additions ?? 0}</span>
+          <span className="ch-rem">−{gitState?.deletions ?? 0}</span>
+        </div>
+        {displayPath && (
+          <button
+            className="code-open tip"
+            data-tip-down
+            data-tip="Open this file in the editor"
+            onClick={() => onOpenInEditor(displayPath)}
+          >
+            <Icon name="edit" size={11} />
+            <span>Edit</span>
+          </button>
+        )}
+        <button
+          className={`code-follow ${follow ? "on" : "off"} ${busy ? "live" : ""} tip`}
+          data-tip-down
+          data-tip={follow ? "Auto-following the agent's current file" : "Click to auto-follow agent edits"}
+          onClick={() => setFollow((v) => !v)}
+        >
+          <span className="cf-dot"></span>
+          <span>{follow ? (busy ? "Following live" : "Following") : "Paused"}</span>
+        </button>
+      </div>
+
+      {/* file tabs */}
+      <div className="code-tabs" role="tablist">
+        {files.map((f) => {
+          const live = busy && f.path === liveFile;
+          const base = f.path.split("/").pop();
+          return (
+            <button
+              key={f.path}
+              role="tab"
+              className={`code-tab ${f.path === displayPath ? "active" : ""} ${live ? "live" : ""} status-${statusLetter(f.kind).toLowerCase()}`}
+              onClick={() => onPickTab(f.path)}
+              title={f.path}
+            >
+              <span className="ct-status">{statusLetter(f.kind)}</span>
+              <span className="ct-name">{base}</span>
+              <span className="ct-stats">
+                {f.additions > 0 && <span className="a">+{f.additions}</span>}
+                {f.deletions > 0 && <span className="r">−{f.deletions}</span>}
+              </span>
+              {live && <span className="ct-live"></span>}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* diff */}
+      {diffErr ? (
+        <div className="empty-msg" style={{ margin: "auto" }}>
+          <div className="et">Couldn't load diff</div>
+          <div>Retrying on the next change.</div>
+        </div>
+      ) : hunks.length === 0 ? (
+        <div className="empty-msg" style={{ margin: "auto" }}>
+          <div className="et">Nothing to show</div>
+          <div>This change has no textual diff (binary, or already committed).</div>
+        </div>
+      ) : (
+        <div className={`code-diff ${isQuorum ? "cq" : ""} ${follow && busy && displayPath === liveFile ? "live" : ""}`}>
+          {hunks.map((h: DiffHunk, i) => (
+            <div key={i}>
+              <div className="code-hunk-h">{h.header}</div>
+              {h.lines.map((l, j) => (
+                <LiveDiffLine key={j} line={l} lang={lang} fresh={l.op === "add" && freshKeys.has(`${l.n}:${l.t}`)} />
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LiveDiffLine({ line, lang, fresh }: { line: DiffLine; lang: string; fresh: boolean }) {
+  const sigil = line.op === "add" ? "+" : line.op === "rem" ? "−" : " ";
+  const html = useMemo(
+    () => (line.t ? highlightToHtml(line.t, hljsLang(lang) ? lang : "") : ""),
+    [line.t, lang],
+  );
+  return (
+    <div className={`dl op-${line.op}${fresh ? " fresh" : ""}`}>
+      <span className="dl-num o">{line.o ?? ""}</span>
+      <span className="dl-num n">{line.n ?? ""}</span>
+      <span className="dl-sigil">{sigil}</span>
+      <span className="dl-text" dangerouslySetInnerHTML={{ __html: html }} />
+    </div>
+  );
+}

--- a/src/components/RightPanel/Code/DiffView.tsx
+++ b/src/components/RightPanel/Code/DiffView.tsx
@@ -1,0 +1,121 @@
+// Shared diff rendering for the Code panel: the Live feed and the file
+// editor's "Diff" toggle both fetch a file's unified diff and render it here,
+// so there's a single implementation of the diff markup + syntax highlighting.
+import { useEffect, useMemo, useState } from "react";
+import { api } from "../../../api";
+import { hljsLang } from "../../../data/languages";
+import { highlightToHtml } from "../../../util/highlight";
+import { parseUnifiedDiff, type DiffHunk, type DiffLine } from "../../../util/diff";
+
+export const extOf = (path: string) => path.split(".").pop() ?? "";
+
+/** Fetch + parse a file's unified diff vs the parent branch. `dep` lets the
+ *  caller force a refetch (e.g. when the file's +/- counts move during a turn). */
+export function useFileDiff(agentId: string, path: string | null, dep?: string) {
+  const [hunks, setHunks] = useState<DiffHunk[]>([]);
+  const [error, setError] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!path) { setHunks([]); setError(false); setLoaded(false); return; }
+    let cancelled = false;
+    api
+      .getFileDiff(agentId, path)
+      .then((t) => { if (!cancelled) { setHunks(parseUnifiedDiff(t)); setError(false); setLoaded(true); } })
+      .catch(() => { if (!cancelled) { setHunks([]); setError(true); setLoaded(true); } });
+    return () => { cancelled = true; };
+  }, [agentId, path, dep]);
+
+  return { hunks, error, loaded };
+}
+
+/** Render parsed hunks. `live` shows the agent-is-writing shimmer; `freshKeys`
+ *  marks just-arrived added lines (both used only by the Live feed). */
+export function DiffBody({
+  hunks,
+  lang,
+  isQuorum,
+  live = false,
+  freshKeys,
+}: {
+  hunks: DiffHunk[];
+  lang: string;
+  isQuorum: boolean;
+  live?: boolean;
+  freshKeys?: Set<string>;
+}) {
+  return (
+    <div className={`code-diff ${isQuorum ? "cq" : ""} ${live ? "live" : ""}`}>
+      {hunks.map((h, i) => (
+        <div key={i}>
+          <div className="code-hunk-h">{h.header}</div>
+          {h.lines.map((l, j) => (
+            <DiffLineRow
+              key={j}
+              line={l}
+              lang={lang}
+              fresh={!!(freshKeys && l.op === "add" && freshKeys.has(`${l.n}:${l.t}`))}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function DiffLineRow({ line, lang, fresh }: { line: DiffLine; lang: string; fresh: boolean }) {
+  const sigil = line.op === "add" ? "+" : line.op === "rem" ? "−" : " ";
+  const html = useMemo(
+    () => (line.t ? highlightToHtml(line.t, hljsLang(lang) ? lang : "") : ""),
+    [line.t, lang],
+  );
+  return (
+    <div className={`dl op-${line.op}${fresh ? " fresh" : ""}`}>
+      <span className="dl-num o">{line.o ?? ""}</span>
+      <span className="dl-num n">{line.n ?? ""}</span>
+      <span className="dl-sigil">{sigil}</span>
+      <span className="dl-text" dangerouslySetInnerHTML={{ __html: html }} />
+    </div>
+  );
+}
+
+/** Self-contained file diff (fetch + states + body) for the editor's Diff
+ *  toggle, where there's no follow/fresh behavior. */
+export function FileDiff({
+  agentId,
+  path,
+  lang,
+  isQuorum,
+}: {
+  agentId: string;
+  path: string;
+  lang: string;
+  isQuorum: boolean;
+}) {
+  const { hunks, error, loaded } = useFileDiff(agentId, path);
+
+  if (!loaded) {
+    return (
+      <div className="empty-msg" style={{ margin: "auto" }}>
+        <div className="et">Loading diff…</div>
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div className="empty-msg" style={{ margin: "auto" }}>
+        <div className="et">Couldn't load diff</div>
+        <div>Try toggling back and forth, or reopen the file.</div>
+      </div>
+    );
+  }
+  if (hunks.length === 0) {
+    return (
+      <div className="empty-msg" style={{ margin: "auto" }}>
+        <div className="et">No textual diff</div>
+        <div>This change has no line-level diff to show.</div>
+      </div>
+    );
+  }
+  return <DiffBody hunks={hunks} lang={lang} isQuorum={isQuorum} />;
+}

--- a/src/components/RightPanel/Code/index.tsx
+++ b/src/components/RightPanel/Code/index.tsx
@@ -1,0 +1,98 @@
+// CodePanel — the unified "Code" right-rail tab. It hosts two modes behind a
+// secondary in-panel switch:
+//   • Files — browse & edit the worktree (the existing <FilePanel>).
+//   • Live  — an activity feed of the agent's edits as diffs (<CodeLivePanel>).
+//
+// The open/selected file is owned here so it survives a mode switch and so the
+// cross-links work: the editor's "Diff" button jumps to Live on that file, and
+// Live's "Edit" button opens the file back in Files mode.
+import { useEffect, useState } from "react";
+import type { AgentRecord } from "../../../api";
+import { useAppStore } from "../../../store";
+import { Icon } from "../../Icon";
+import { FilePanel } from "../FilePanel";
+import { CodeLivePanel } from "./CodeLivePanel";
+
+type Mode = "files" | "live";
+const MODE_KEY = "q2:codeMode";
+
+function loadMode(): Mode {
+  return localStorage.getItem(MODE_KEY) === "live" ? "live" : "files";
+}
+
+export function CodePanel({ agent }: { agent: AgentRecord }) {
+  const [mode, setMode] = useState<Mode>(loadMode);
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+
+  // The selected file is per-agent; drop it when the agent changes.
+  useEffect(() => { setSelectedPath(null); }, [agent.id]);
+
+  const changeMode = (m: Mode) => {
+    setMode(m);
+    localStorage.setItem(MODE_KEY, m);
+  };
+
+  return (
+    <div className="code-panel">
+      <ModeSwitch agent={agent} mode={mode} onChange={changeMode} />
+      <div className="code-panel-body">
+        {mode === "files" ? (
+          <FilePanel
+            agent={agent}
+            openPath={selectedPath}
+            onOpenPath={setSelectedPath}
+            canViewDiff
+            onViewDiff={() => changeMode("live")}
+          />
+        ) : (
+          <CodeLivePanel
+            agent={agent}
+            selectedPath={selectedPath}
+            onSelect={setSelectedPath}
+            onOpenInEditor={(p) => { setSelectedPath(p); changeMode("files"); }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// A secondary segmented control — deliberately styled unlike the panel tabs
+// above it (filled "thumb" pill, not an underline tab) so it reads as a control
+// within the Code panel, not as panel switching.
+function ModeSwitch({ agent, mode, onChange }: { agent: AgentRecord; mode: Mode; onChange: (m: Mode) => void }) {
+  // A live dot on the Live segment when the worktree has uncommitted changes,
+  // so the user can tell there's something to watch without leaving Files mode.
+  const hasChanges = useAppStore(
+    (s) =>
+      (s.gitStates[agent.id]?.files.length ??
+        s.gitShortstats[agent.id]?.file_count ??
+        0) > 0,
+  );
+
+  return (
+    <div className="code-modes">
+      <div className="code-modeswitch" role="tablist" aria-label="Code view mode">
+        <button
+          role="tab"
+          aria-selected={mode === "files"}
+          className={`cms-seg ${mode === "files" ? "active" : ""}`}
+          onClick={() => onChange("files")}
+        >
+          <Icon name="folder" size={12} />
+          <span>Files</span>
+        </button>
+        <button
+          role="tab"
+          aria-selected={mode === "live"}
+          className={`cms-seg ${mode === "live" ? "active" : ""}`}
+          onClick={() => onChange("live")}
+        >
+          <Icon name="zap" size={12} />
+          <span>Live</span>
+          {hasChanges && <span className="cms-live-dot"></span>}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/RightPanel/Code/index.tsx
+++ b/src/components/RightPanel/Code/index.tsx
@@ -41,8 +41,6 @@ export function CodePanel({ agent }: { agent: AgentRecord }) {
             agent={agent}
             openPath={selectedPath}
             onOpenPath={setSelectedPath}
-            canViewDiff
-            onViewDiff={() => changeMode("live")}
           />
         ) : (
           <CodeLivePanel
@@ -59,16 +57,18 @@ export function CodePanel({ agent }: { agent: AgentRecord }) {
 
 // A secondary segmented control — deliberately styled unlike the panel tabs
 // above it (filled "thumb" pill, not an underline tab) so it reads as a control
-// within the Code panel, not as panel switching.
+// within the Code panel, not as panel switching. The two modes are the two
+// ways to look at code here: explore it yourself, or watch the agent change it.
 function ModeSwitch({ agent, mode, onChange }: { agent: AgentRecord; mode: Mode; onChange: (m: Mode) => void }) {
-  // A live dot on the Live segment when the worktree has uncommitted changes,
-  // so the user can tell there's something to watch without leaving Files mode.
   const hasChanges = useAppStore(
     (s) =>
       (s.gitStates[agent.id]?.files.length ??
         s.gitShortstats[agent.id]?.file_count ??
         0) > 0,
   );
+  // Whether the agent is mid-turn — the dot is green & pulsing only then, and
+  // goes grey when work stops so it never implies activity that isn't there.
+  const busy = useAppStore((s) => s.managedBusy[agent.id] ?? false);
 
   return (
     <div className="code-modes">
@@ -76,21 +76,25 @@ function ModeSwitch({ agent, mode, onChange }: { agent: AgentRecord; mode: Mode;
         <button
           role="tab"
           aria-selected={mode === "files"}
-          className={`cms-seg ${mode === "files" ? "active" : ""}`}
+          className={`cms-seg ${mode === "files" ? "active" : ""} tip`}
+          data-tip-down
+          data-tip="Browse and edit any file in the worktree"
           onClick={() => onChange("files")}
         >
           <Icon name="folder" size={12} />
-          <span>Files</span>
+          <span>Explore</span>
         </button>
         <button
           role="tab"
           aria-selected={mode === "live"}
-          className={`cms-seg ${mode === "live" ? "active" : ""}`}
+          className={`cms-seg ${mode === "live" ? "active" : ""} tip`}
+          data-tip-down
+          data-tip="Watch the agent's changes as they happen"
           onClick={() => onChange("live")}
         >
           <Icon name="zap" size={12} />
           <span>Live</span>
-          {hasChanges && <span className="cms-live-dot"></span>}
+          {(hasChanges || busy) && <span className={`cms-live-dot ${busy ? "on" : ""}`}></span>}
         </button>
       </div>
     </div>

--- a/src/components/RightPanel/FilePanel/FileEditor.tsx
+++ b/src/components/RightPanel/FilePanel/FileEditor.tsx
@@ -1,7 +1,8 @@
 // The Files-panel editor: a transparent <textarea> over a live
 // syntax-highlight layer, with line numbers and a git-style change gutter.
-// Edit, ⌘S to save, Revert to restore the agent's version.
-import { useMemo, useRef, useState, type KeyboardEvent } from "react";
+// Edit, ⌘S to save, Revert to restore the agent's version. The "Diff" toggle
+// swaps the editor for a read-only unified diff of the agent's changes.
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import { api, type AgentRecord, type WorktreeFileContents } from "../../../api";
 import { useAppStore } from "../../../store";
 import { CODE_THEMES } from "../../../data/codeThemes";
@@ -10,6 +11,7 @@ import { useHljsTheme } from "../../../util/codeTheme";
 import { langLabel } from "../../../data/languages";
 import { Icon } from "../../Icon";
 import { ViewerHeader } from "./ViewerHeader";
+import { FileDiff } from "../Code/DiffView";
 
 interface FileEditorProps {
   agent: AgentRecord;
@@ -17,19 +19,20 @@ interface FileEditorProps {
   name: string;
   dir: string;
   file: WorktreeFileContents;
-  canViewDiff: boolean;
-  onViewDiff: () => void;
   onBack: () => void;
 }
 
-export function FileEditor({ agent, path, name, dir, file, canViewDiff, onViewDiff, onBack }: FileEditorProps) {
+export function FileEditor({ agent, path, name, dir, file, onBack }: FileEditorProps) {
   const originalText = file.text;
   const [value, setValue] = useState(originalText);
-  const [baseline, setBaseline] = useState(originalText);
-  const [copied, setCopied] = useState(false);
-  const [flash, setFlash] = useState(false); // "saved" pulse
-  const [saving, setSaving] = useState(false);
-  const [saveError, setSaveError] = useState(false);
+  // Files auto-save a short beat after you stop typing — no Save button. This
+  // drives the quiet status line; `savedRef` tracks what's currently on disk.
+  const [saveState, setSaveState] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  // "code" = editable view; "diff" = read-only unified diff of agent changes.
+  const [view, setView] = useState<"code" | "diff">("code");
+  // Only changed files have a diff worth showing.
+  const canDiff = !!file.status;
+  const diffView = view === "diff" && canDiff;
 
   // Syntax theme: "quorum" uses our palette (gated by the `cq` class); other
   // families load a highlight.js stylesheet that follows the app's dark/light.
@@ -40,10 +43,15 @@ export function FileEditor({ agent, path, name, dir, file, canViewDiff, onViewDi
   const taRef = useRef<HTMLTextAreaElement>(null);
   const hlRef = useRef<HTMLPreElement>(null);
   const gutRef = useRef<HTMLDivElement>(null);
+  // Autosave bookkeeping: last text written to disk, the latest buffer (for
+  // the unmount flush), and the pending debounce timer.
+  const savedRef = useRef(originalText);
+  const valueRef = useRef(value);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => { valueRef.current = value; }, [value]);
 
   const lines = value.split("\n");
-  const baseLines = baseline.split("\n");
-  const dirty = value !== baseline;
+  const origLines = useMemo(() => originalText.split("\n"), [originalText]);
   const editedFromAgent = value !== originalText;
   const isDeleted = file.status === "D";
 
@@ -59,17 +67,18 @@ export function FileEditor({ agent, path, name, dir, file, canViewDiff, onViewDi
     return value.endsWith("\n") ? `${out}\n` : out;
   }, [value, file.lang]);
 
-  // change gutter: pristine → show the agent's markers; editing → mark your edits
+  // change gutter: at the agent's version → show its markers; once you diverge
+  // → mark the lines you changed (vs the agent's version).
   const lineKind = (i: number): "add" | "mod" | "rem" | null => {
-    if (!dirty) {
-      if (file.status === "A" && value === originalText) return "add";
+    if (!editedFromAgent) {
+      if (file.status === "A") return "add";
       if (isDeleted) return "rem";
       if (addSet.has(i + 1)) return "add";
       if (modSet.has(i + 1)) return "mod";
       return null;
     }
-    if (i >= baseLines.length) return "add";
-    if (lines[i] !== baseLines[i]) return "mod";
+    if (i >= origLines.length) return "add";
+    if (lines[i] !== origLines[i]) return "mod";
     return null;
   };
 
@@ -83,41 +92,68 @@ export function FileEditor({ agent, path, name, dir, file, canViewDiff, onViewDi
     if (gutRef.current) gutRef.current.scrollTop = ta.scrollTop;
   };
 
-  const save = async () => {
-    if (saving) return;
-    setSaving(true);
-    setSaveError(false);
+  // Write the latest buffer to disk if it differs from what's there.
+  const flush = async () => {
+    if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null; }
+    const text = valueRef.current;
+    if (text === savedRef.current) return;
+    setSaveState("saving");
     try {
-      await api.writeWorktreeFile(agent.id, path, value);
-      setBaseline(value);
-      setFlash(true);
-      setTimeout(() => setFlash(false), 1300);
+      await api.writeWorktreeFile(agent.id, path, text);
+      savedRef.current = text;
+      // Only settle to "saved" if no newer keystroke landed mid-write.
+      setSaveState(valueRef.current === text ? "saved" : "saving");
     } catch {
-      setSaveError(true);
-    } finally {
-      setSaving(false);
+      setSaveState("error");
     }
   };
 
+  // Debounce a save after typing stops.
+  const scheduleSave = () => {
+    setSaveState("saving");
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => { void flush(); }, 600);
+  };
+
+  // Let the "Saved" tick fade back to idle.
+  useEffect(() => {
+    if (saveState !== "saved") return;
+    const t = setTimeout(() => setSaveState("idle"), 1300);
+    return () => clearTimeout(t);
+  }, [saveState]);
+
+  // Flush any pending edit when the editor closes or switches files, so a save
+  // mid-debounce is never lost.
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      const text = valueRef.current;
+      if (text !== savedRef.current) {
+        void api.writeWorktreeFile(agent.id, path, text).catch(() => {});
+      }
+    };
+  }, [agent.id, path]);
+
   const revert = async () => {
     // Restore the agent's version on disk and in the editor.
+    if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null; }
     await api.writeWorktreeFile(agent.id, path, originalText).catch(() => {});
+    savedRef.current = originalText;
     setValue(originalText);
-    setBaseline(originalText);
+    setSaveState("idle");
     requestAnimationFrame(syncScroll);
   };
 
-  const copy = () => {
-    navigator.clipboard?.writeText(value).catch(() => {});
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1400);
+  const onChange = (next: string) => {
+    setValue(next);
+    scheduleSave();
   };
 
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     const mod = e.metaKey || e.ctrlKey;
     if (mod && e.key.toLowerCase() === "s") {
       e.preventDefault();
-      if (dirty) void save();
+      void flush(); // ⌘S just flushes the pending autosave immediately
       return;
     }
     if (e.key === "Tab") {
@@ -126,102 +162,109 @@ export function FileEditor({ agent, path, name, dir, file, canViewDiff, onViewDi
       const s = ta.selectionStart;
       const en = ta.selectionEnd;
       const next = value.slice(0, s) + "  " + value.slice(en);
-      setValue(next);
+      onChange(next);
       requestAnimationFrame(() => { ta.selectionStart = ta.selectionEnd = s + 2; });
     }
   };
 
   return (
-    <div className={`fp-wrap ${dirty ? "is-dirty" : ""}`}>
+    <div className="fp-wrap">
       <ViewerHeader
         name={name}
         dir={dir}
         onBack={onBack}
         status={file.status}
-        dirty={dirty}
+        dirty={saveState === "saving"}
         actions={
-          <span className="fp-vh-actions">
-            <button className="fp-meta-btn" onClick={copy}>
-              <Icon name={copied ? "check" : "copy"} size={11} />
-              {copied ? "Copied" : "Copy"}
-            </button>
-            <button className={`fp-save ${dirty ? "" : "disabled"}`} onClick={() => void save()} disabled={!dirty}>
-              <Icon name="check" size={11} /> Save
-              <span className="fp-save-kbd">⌘S</span>
-            </button>
-          </span>
+          canDiff ? (
+            <span className="fp-vh-actions">
+              <button
+                className={`fp-meta-btn ${diffView ? "active" : ""}`}
+                title={diffView ? "Back to the file" : "Show what the agent changed"}
+                onClick={() => setView((v) => (v === "diff" ? "code" : "diff"))}
+              >
+                <Icon name="diff" size={11} /> Diff
+              </button>
+            </span>
+          ) : undefined
         }
       />
 
-      {isDeleted && (
-        <div className="fp-banner del">
-          <Icon name="trash" size={12} />
-          <span>Deleted by the agent. Edits here re-create the file.</span>
-        </div>
-      )}
-      {file.status === "A" && value === originalText && (
-        <div className="fp-banner add">
-          <Icon name="plus" size={12} />
-          <span>New file added by the agent.</span>
-        </div>
-      )}
+      {diffView ? (
+        <FileDiff agentId={agent.id} path={path} lang={file.lang} isQuorum={isQuorum} />
+      ) : (
+        <>
+          {isDeleted && (
+            <div className="fp-banner del">
+              <Icon name="trash" size={12} />
+              <span>Deleted by the agent. Edits here re-create the file.</span>
+            </div>
+          )}
+          {file.status === "A" && value === originalText && (
+            <div className="fp-banner add">
+              <Icon name="plus" size={12} />
+              <span>New file added by the agent.</span>
+            </div>
+          )}
 
-      <div className="fp-editor">
-        <div className="fp-gutter" ref={gutRef}>
-          <div className="fp-gutter-inner">
-            {lines.map((_, i) => {
-              const k = lineKind(i);
-              return (
-                <div className="fp-gline" key={i}>
-                  <span className="fp-num">{i + 1}</span>
-                  <span className={`fp-bar ${k || ""}`}></span>
-                </div>
-              );
-            })}
+          <div className="fp-editor">
+            <div className="fp-gutter" ref={gutRef}>
+              <div className="fp-gutter-inner">
+                {lines.map((_, i) => {
+                  const k = lineKind(i);
+                  return (
+                    <div className="fp-gline" key={i}>
+                      <span className="fp-num">{i + 1}</span>
+                      <span className={`fp-bar ${k || ""}`}></span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+            <div className="fp-edit-main">
+              <pre className={`fp-hl ${isQuorum ? "cq" : ""}`} ref={hlRef} aria-hidden="true">
+                <code dangerouslySetInnerHTML={{ __html: html }} />
+              </pre>
+              <textarea
+                ref={taRef}
+                className="fp-ta"
+                value={value}
+                wrap="off"
+                spellCheck={false}
+                autoCapitalize="off"
+                autoCorrect="off"
+                onChange={(e) => onChange(e.target.value)}
+                onScroll={syncScroll}
+                onKeyDown={onKeyDown}
+              />
+            </div>
           </div>
-        </div>
-        <div className="fp-edit-main">
-          <pre className={`fp-hl ${isQuorum ? "cq" : ""}`} ref={hlRef} aria-hidden="true">
-            <code dangerouslySetInnerHTML={{ __html: html }} />
-          </pre>
-          <textarea
-            ref={taRef}
-            className="fp-ta"
-            value={value}
-            wrap="off"
-            spellCheck={false}
-            autoCapitalize="off"
-            autoCorrect="off"
-            onChange={(e) => { setValue(e.target.value); setSaveError(false); }}
-            onScroll={syncScroll}
-            onKeyDown={onKeyDown}
-          />
-        </div>
-      </div>
+        </>
+      )}
 
       <div className="fp-meta">
         <span className="fp-meta-lang">{langLabel(file.lang)}</span>
-        <span className="fp-meta-dot">·</span>
-        <span>{lines.length} lines</span>
-        {dirty ? (
-          <><span className="fp-meta-dot">·</span><span className="fp-meta-unsaved">Unsaved</span></>
-        ) : flash ? (
-          <><span className="fp-meta-dot">·</span><span className="fp-meta-saved">Saved ✓</span></>
-        ) : editedFromAgent ? (
-          <><span className="fp-meta-dot">·</span><span className="fp-meta-edited">Edited</span></>
-        ) : null}
-        {saveError && (
-          <><span className="fp-meta-dot">·</span><span className="fp-meta-failed">Save failed</span></>
+        {diffView ? (
+          <><span className="fp-meta-dot">·</span><span>Diff vs {file.status === "A" ? "new file" : "base"}</span></>
+        ) : (
+          <>
+            <span className="fp-meta-dot">·</span>
+            <span>{lines.length} lines</span>
+            {saveState === "saving" ? (
+              <><span className="fp-meta-dot">·</span><span className="fp-meta-edited">Saving…</span></>
+            ) : saveState === "saved" ? (
+              <><span className="fp-meta-dot">·</span><span className="fp-meta-saved">Saved ✓</span></>
+            ) : saveState === "error" ? (
+              <><span className="fp-meta-dot">·</span><span className="fp-meta-failed">Save failed</span></>
+            ) : editedFromAgent ? (
+              <><span className="fp-meta-dot">·</span><span className="fp-meta-edited">Edited</span></>
+            ) : null}
+          </>
         )}
         <span className="fp-meta-grow"></span>
-        {editedFromAgent && (
+        {!diffView && editedFromAgent && (
           <button className="fp-meta-btn" title="Discard edits, restore the agent's version" onClick={() => void revert()}>
             <Icon name="refresh" size={11} /> Revert
-          </button>
-        )}
-        {canViewDiff && file.status && file.status !== "A" && file.status !== "D" && (
-          <button className="fp-meta-btn" onClick={onViewDiff}>
-            <Icon name="diff" size={11} /> Diff
           </button>
         )}
         <select

--- a/src/components/RightPanel/FilePanel/FileViewer.tsx
+++ b/src/components/RightPanel/FilePanel/FileViewer.tsx
@@ -10,12 +10,10 @@ import { FileEditor } from "./FileEditor";
 interface FileViewerProps {
   agent: AgentRecord;
   path: string;
-  canViewDiff: boolean;
-  onViewDiff: () => void;
   onBack: () => void;
 }
 
-export function FileViewer({ agent, path, canViewDiff, onViewDiff, onBack }: FileViewerProps) {
+export function FileViewer({ agent, path, onBack }: FileViewerProps) {
   const name = basename(path);
   const dir = parentDir(path);
 
@@ -70,8 +68,6 @@ export function FileViewer({ agent, path, canViewDiff, onViewDiff, onBack }: Fil
       name={name}
       dir={dir}
       file={contents}
-      canViewDiff={canViewDiff}
-      onViewDiff={onViewDiff}
       onBack={onBack}
     />
   );

--- a/src/components/RightPanel/FilePanel/TreeBrowser.tsx
+++ b/src/components/RightPanel/FilePanel/TreeBrowser.tsx
@@ -176,6 +176,15 @@ function TreeRow({
           ) : (
             <span className="fp-name">{node.name}</span>
           )}
+          {/* When collapsed, surface that this folder hides agent edits. */}
+          {!isOpen && !renaming && node.changedCount > 0 && (
+            <span
+              className="fp-dir-changed"
+              title={`${node.changedCount} changed file${node.changedCount === 1 ? "" : "s"} inside`}
+            >
+              {node.changedCount}
+            </span>
+          )}
         </button>
         {(isOpen || creatingHere) && (
           <>

--- a/src/components/RightPanel/FilePanel/index.tsx
+++ b/src/components/RightPanel/FilePanel/index.tsx
@@ -1,5 +1,5 @@
-// FilePanel — the right-rail "Files" tab. Browse the agent's worktree and
-// view/edit any file's contents (NOT diffs — that's the Diff panel's job).
+// FilePanel — the "Files" mode of the Code panel. Browse the agent's worktree
+// and view/edit any file's contents (diffs live in the Code panel's Live mode).
 //
 // This orchestrator owns the explorer's state + file operations and switches
 // between two modes:
@@ -36,12 +36,15 @@ interface FilePanelProps {
   agent: AgentRecord;
   canViewDiff: boolean;
   onViewDiff: () => void;
+  // The open file is owned by the parent Code panel so it survives a switch to
+  // Live mode (and so cross-panel "View diff" / "Open in editor" can target it).
+  openPath: string | null;
+  onOpenPath: (path: string | null) => void;
 }
 
-export function FilePanel({ agent, canViewDiff, onViewDiff }: FilePanelProps) {
+export function FilePanel({ agent, canViewDiff, onViewDiff, openPath, onOpenPath }: FilePanelProps) {
   const [files, setFiles] = useState<WorktreeFile[]>([]);
   const [loaded, setLoaded] = useState(false);
-  const [openPath, setOpenPath] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [changedOnly, setChangedOnly] = useState(false);
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
@@ -52,9 +55,9 @@ export function FilePanel({ agent, canViewDiff, onViewDiff }: FilePanelProps) {
   // so without this a brand-new folder would vanish on the next poll.
   const [pendingDirs, setPendingDirs] = useState<Set<string>>(() => new Set());
 
-  // Reset per-agent so one worktree's open file / search doesn't leak.
+  // Reset per-agent so one worktree's search/expansion doesn't leak. (The open
+  // file is owned by the parent and reset there.)
   useEffect(() => {
-    setOpenPath(null);
     setQuery("");
     setChangedOnly(false);
     setLoaded(false);
@@ -162,7 +165,7 @@ export function FilePanel({ agent, canViewDiff, onViewDiff }: FilePanelProps) {
         await api.createWorktreeFile(agent.id, dest);
         setEdit(null);
         await refresh();
-        setOpenPath(dest);
+        onOpenPath(dest);
         return;
       } else {
         const dest = joinPath(edit.parentDir, name);
@@ -251,7 +254,7 @@ export function FilePanel({ agent, canViewDiff, onViewDiff }: FilePanelProps) {
         path={openPath}
         canViewDiff={canViewDiff}
         onViewDiff={onViewDiff}
-        onBack={() => { setOpenPath(null); void refresh(); }}
+        onBack={() => { onOpenPath(null); void refresh(); }}
       />
     );
   }
@@ -275,7 +278,7 @@ export function FilePanel({ agent, canViewDiff, onViewDiff }: FilePanelProps) {
         edit={edit}
         onCommit={commitEdit}
         onCancel={cancelEdit}
-        onOpen={setOpenPath}
+        onOpen={onOpenPath}
         onMenu={(node, x, y) => setMenu({ node, x, y })}
         opError={opError}
         onClearOpError={() => setOpError(null)}

--- a/src/components/RightPanel/FilePanel/index.tsx
+++ b/src/components/RightPanel/FilePanel/index.tsx
@@ -34,15 +34,13 @@ import {
 
 interface FilePanelProps {
   agent: AgentRecord;
-  canViewDiff: boolean;
-  onViewDiff: () => void;
   // The open file is owned by the parent Code panel so it survives a switch to
-  // Live mode (and so cross-panel "View diff" / "Open in editor" can target it).
+  // Live mode (and so "Open in editor" from Live can target it).
   openPath: string | null;
   onOpenPath: (path: string | null) => void;
 }
 
-export function FilePanel({ agent, canViewDiff, onViewDiff, openPath, onOpenPath }: FilePanelProps) {
+export function FilePanel({ agent, openPath, onOpenPath }: FilePanelProps) {
   const [files, setFiles] = useState<WorktreeFile[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [query, setQuery] = useState("");
@@ -252,8 +250,6 @@ export function FilePanel({ agent, canViewDiff, onViewDiff, openPath, onOpenPath
         key={openPath}
         agent={agent}
         path={openPath}
-        canViewDiff={canViewDiff}
-        onViewDiff={onViewDiff}
         onBack={() => { onOpenPath(null); void refresh(); }}
       />
     );

--- a/src/components/RightPanel/FilePanel/tree.ts
+++ b/src/components/RightPanel/FilePanel/tree.ts
@@ -8,6 +8,9 @@ export type DirNode = {
   name: string;
   path: string;
   children: TreeNode[];
+  // Number of changed files anywhere under this directory — lets a collapsed
+  // folder signal that it contains agent edits.
+  changedCount: number;
 };
 export type FileNode = {
   type: "file";
@@ -70,7 +73,7 @@ export function buildTree(files: WorktreeFile[], extraDirs: string[] = []): Tree
       const parent = prefix;
       prefix = prefix ? `${prefix}/${segs[i]}` : segs[i];
       if (!dirIndex.has(prefix)) {
-        const node: DirNode = { type: "dir", name: segs[i], path: prefix, children: [] };
+        const node: DirNode = { type: "dir", name: segs[i], path: prefix, children: [], changedCount: 0 };
         dirIndex.set(prefix, node);
         childrenOf(parent).push(node);
       }
@@ -94,7 +97,23 @@ export function buildTree(files: WorktreeFile[], extraDirs: string[] = []): Tree
   for (const d of extraDirs) if (d) ensureDir(d);
 
   sortNodes(roots);
+  annotateChanged(roots);
   return roots;
+}
+
+/** Tally changed files per directory (recursively) so collapsed folders can
+ *  show how many edits they hide. Returns this level's changed-file count. */
+function annotateChanged(nodes: TreeNode[]): number {
+  let total = 0;
+  for (const n of nodes) {
+    if (n.type === "dir") {
+      n.changedCount = annotateChanged(n.children);
+      total += n.changedCount;
+    } else if (n.status) {
+      total += 1;
+    }
+  }
+  return total;
 }
 
 function sortNodes(nodes: TreeNode[]): void {

--- a/src/components/RightPanel/index.tsx
+++ b/src/components/RightPanel/index.tsx
@@ -2,12 +2,12 @@ import { useState } from "react";
 import type { AgentRecord } from "../../api";
 import { useAppStore } from "../../store";
 import { Icon, type IconName } from "../Icon";
-import { FilePanel } from "./FilePanel";
+import { CodePanel } from "./Code";
 import { GitPanel } from "./GitPanel";
 import { RunPanel } from "./RunPanel";
 import { TermPanel } from "./TermPanel";
 
-type TabId = "files" | "git" | "diff" | "run" | "term";
+type TabId = "code" | "git" | "run" | "term";
 
 interface Tab {
   id: TabId;
@@ -16,9 +16,9 @@ interface Tab {
   count?: number;
 }
 
-/** Right rail: tabs for Git / Diff / Run / Terminal (each
- *  feature-flagged in settings). For now only Git renders real content —
- *  the others show a stub. */
+/** Right rail: tabs for Code / Git / Run / Terminal (each feature-flagged in
+ *  settings). The Code tab unifies the file explorer/editor with a Live diff
+ *  feed of the agent's edits. */
 export function RightPanel({ agent }: { agent: AgentRecord }) {
   const features  = useAppStore((s) => s.features);
   // Tab badge: prefer the live file list from `gitStates` (refreshed at 1s
@@ -33,9 +33,8 @@ export function RightPanel({ agent }: { agent: AgentRecord }) {
   );
 
   const tabs: Tab[] = [
-    features.files && { id: "files", label: "Files", icon: "folder" },
+    features.code && { id: "code", label: "Code", icon: "code" },
     features.git && { id: "git", label: "Git", icon: "branch", count: gitFiles },
-    features.diff && { id: "diff", label: "Diff", icon: "code" },
     features.run && { id: "run", label: "Run", icon: "play" },
     features.terminal && { id: "term", label: "Terminal", icon: "terminal" },
   ].filter(Boolean) as Tab[];
@@ -47,7 +46,7 @@ export function RightPanel({ agent }: { agent: AgentRecord }) {
       <div className="empty-msg" style={{ margin: "auto" }}>
         <div className="et">No side panels enabled</div>
         <div>
-          Turn on Git, Diff, Run, or Terminal in{" "}
+          Turn on Code, Git, Run, or Terminal in{" "}
           <span style={{ color: "var(--accent)" }}>Settings</span>.
         </div>
       </div>
@@ -72,27 +71,11 @@ export function RightPanel({ agent }: { agent: AgentRecord }) {
         </div>
       </div>
       <div className="right-body">
-        {tab === "files" && (
-          <FilePanel
-            agent={agent}
-            canViewDiff={features.diff}
-            onViewDiff={() => setTab("diff")}
-          />
-        )}
+        {tab === "code" && <CodePanel agent={agent} />}
         {tab === "git" && <GitPanel agent={agent} />}
-        {tab === "diff" && <Stub label="Diff" />}
         {tab === "run" && <RunPanel agent={agent} />}
         {tab === "term" && <TermPanel agent={agent} />}
       </div>
     </>
-  );
-}
-
-function Stub({ label }: { label: string }) {
-  return (
-    <div className="empty-msg" style={{ margin: "auto" }}>
-      <div className="et">{label} panel coming soon</div>
-      <div>This view will be wired to the backend in a later pass.</div>
-    </div>
   );
 }

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -17,9 +17,8 @@ const FEATURE_GROUPS: { label: string; items: FeatureItem[] }[] = [
   {
     label: "Side panels",
     items: [
-      { key: "files",    title: "Files",    sub: "Browse & edit worktree files" },
+      { key: "code",     title: "Code",     sub: "Browse & edit files, plus a Live diff feed" },
       { key: "git",      title: "Git",      sub: "Branch, file changes, smart actions" },
-      { key: "diff",     title: "Diff",     sub: "Inline diff for the selected file" },
       { key: "run",      title: "Run",      sub: "Dev server with setup table" },
       { key: "terminal", title: "Terminal", sub: "Interactive shell in the worktree" },
     ],

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -11,8 +11,7 @@ interface FeatureItem {
 
 const SIDE_PANELS: FeatureItem[] = [
   { key: "git",      title: "Git",      sub: "Branch, file changes, and smart commit / push / PR actions." },
-  { key: "files",    title: "Files",    sub: "Browse the worktree and read & edit file contents." },
-  { key: "diff",     title: "Diff",     sub: "Inline diff for the selected file." },
+  { key: "code",     title: "Code",     sub: "Browse & edit worktree files, plus a Live feed of the agent's diffs." },
   { key: "run",      title: "Run",      sub: "Dev server with an auto-detected, overrideable config." },
   { key: "terminal", title: "Terminal", sub: "Interactive shell scoped to the worktree." },
 ];

--- a/src/store.ts
+++ b/src/store.ts
@@ -129,8 +129,8 @@ export type SettingsSection = "general" | "account" | "providers";
 
 export interface FeatureFlags {
   git: boolean;
-  files: boolean;
-  diff: boolean;
+  /** The unified Code panel: file explorer/editor + the Live diff feed. */
+  code: boolean;
   run: boolean;
   terminal: boolean;
   thinkingBudget: boolean;
@@ -141,8 +141,7 @@ export interface FeatureFlags {
 
 const DEFAULT_FEATURES: FeatureFlags = {
   git: true,
-  files: true,
-  diff: false,
+  code: true,
   run: false,
   terminal: false,
   thinkingBudget: true,
@@ -154,7 +153,25 @@ const DEFAULT_FEATURES: FeatureFlags = {
 function parseFeatures(raw: string | undefined): FeatureFlags {
   if (!raw) return DEFAULT_FEATURES;
   try {
-    return { ...DEFAULT_FEATURES, ...(JSON.parse(raw) as Partial<FeatureFlags>) };
+    const saved = JSON.parse(raw) as Partial<FeatureFlags> & {
+      // legacy flags folded into `code`
+      files?: boolean;
+      diff?: boolean;
+    };
+    // The old "Files" and "Diff" tabs were merged into the Code panel; honor a
+    // saved preference for either when migrating an existing settings blob.
+    const legacyCode =
+      saved.code ?? (saved.files !== undefined || saved.diff !== undefined
+        ? !!(saved.files || saved.diff)
+        : undefined);
+    const { files: _files, diff: _diff, ...rest } = saved;
+    void _files;
+    void _diff;
+    return {
+      ...DEFAULT_FEATURES,
+      ...rest,
+      ...(legacyCode !== undefined ? { code: legacyCode } : {}),
+    };
   } catch {
     return DEFAULT_FEATURES;
   }

--- a/src/util/diff.test.ts
+++ b/src/util/diff.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { parseUnifiedDiff } from "./diff";
+
+describe("parseUnifiedDiff", () => {
+  it("parses a modification hunk with correct old/new line numbers", () => {
+    const diff = [
+      "diff --git a/f.ts b/f.ts",
+      "index 111..222 100644",
+      "--- a/f.ts",
+      "+++ b/f.ts",
+      "@@ -1,3 +1,4 @@ func",
+      " const a = 1;",
+      "-const b = 2;",
+      "+const b = 20;",
+      "+const c = 3;",
+      " return a;",
+    ].join("\n");
+
+    const hunks = parseUnifiedDiff(diff);
+    expect(hunks).toHaveLength(1);
+    expect(hunks[0].header).toBe("@@ -1,3 +1,4 @@ func");
+    expect(hunks[0].lines).toEqual([
+      { op: "ctx", o: 1, n: 1, t: "const a = 1;" },
+      { op: "rem", o: 2, n: null, t: "const b = 2;" },
+      { op: "add", o: null, n: 2, t: "const b = 20;" },
+      { op: "add", o: null, n: 3, t: "const c = 3;" },
+      { op: "ctx", o: 3, n: 4, t: "return a;" },
+    ]);
+  });
+
+  it("ignores file headers and produces only hunk content", () => {
+    const diff = [
+      "diff --git a/new.ts b/new.ts",
+      "new file mode 100644",
+      "index 000..abc",
+      "--- /dev/null",
+      "+++ b/new.ts",
+      "@@ -0,0 +1,2 @@",
+      "+line one",
+      "+line two",
+    ].join("\n");
+
+    const hunks = parseUnifiedDiff(diff);
+    expect(hunks).toHaveLength(1);
+    expect(hunks[0].lines).toEqual([
+      { op: "add", o: null, n: 1, t: "line one" },
+      { op: "add", o: null, n: 2, t: "line two" },
+    ]);
+  });
+
+  it("ignores the \\ No newline at end of file marker", () => {
+    const diff = [
+      "@@ -1 +1 @@",
+      "-old",
+      "\\ No newline at end of file",
+      "+new",
+      "\\ No newline at end of file",
+    ].join("\n");
+
+    const hunks = parseUnifiedDiff(diff);
+    expect(hunks[0].lines).toEqual([
+      { op: "rem", o: 1, n: null, t: "old" },
+      { op: "add", o: null, n: 1, t: "new" },
+    ]);
+  });
+
+  it("splits multiple hunks", () => {
+    const diff = [
+      "@@ -1,1 +1,1 @@",
+      "-a",
+      "+A",
+      "@@ -10,1 +10,1 @@ ctx",
+      "-b",
+      "+B",
+    ].join("\n");
+
+    const hunks = parseUnifiedDiff(diff);
+    expect(hunks).toHaveLength(2);
+    expect(hunks[1].header).toBe("@@ -10,1 +10,1 @@ ctx");
+    expect(hunks[1].lines).toEqual([
+      { op: "rem", o: 10, n: null, t: "b" },
+      { op: "add", o: null, n: 10, t: "B" },
+    ]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(parseUnifiedDiff("")).toEqual([]);
+  });
+
+  it("drops the trailing-newline artifact but keeps real blank context lines", () => {
+    // git diff output ends with a newline (→ a phantom "" after split), while a
+    // genuinely blank context line is encoded as a single space.
+    const diff = "@@ -1,2 +1,2 @@\n a\n \n+b\n";
+    const hunks = parseUnifiedDiff(diff);
+    expect(hunks[0].lines).toEqual([
+      { op: "ctx", o: 1, n: 1, t: "a" },
+      { op: "ctx", o: 2, n: 2, t: "" },
+      { op: "add", o: null, n: 3, t: "b" },
+    ]);
+  });
+});

--- a/src/util/diff.ts
+++ b/src/util/diff.ts
@@ -1,0 +1,60 @@
+// Parse `git diff` unified output into hunks the Code/Live panel can render.
+// Mirrors the prototype's hunk shape (quorum v2 data.jsx CODE_CHANGES):
+//   { header, lines: [{ op, o, n, t }] }
+// where `op` is context / addition / removal, `o`/`n` are the old/new 1-indexed
+// line numbers (null on the side the line doesn't exist), and `t` is the line
+// text without its leading sigil.
+
+export type DiffOp = "ctx" | "add" | "rem";
+
+export interface DiffLine {
+  op: DiffOp;
+  o: number | null;
+  n: number | null;
+  t: string;
+}
+
+export interface DiffHunk {
+  header: string;
+  lines: DiffLine[];
+}
+
+const HUNK_RE = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+
+export function parseUnifiedDiff(text: string): DiffHunk[] {
+  const hunks: DiffHunk[] = [];
+  let hunk: DiffHunk | null = null;
+  let oldLine = 0;
+  let newLine = 0;
+
+  for (const line of text.split("\n")) {
+    const m = HUNK_RE.exec(line);
+    if (m) {
+      hunk = { header: line, lines: [] };
+      hunks.push(hunk);
+      oldLine = parseInt(m[1], 10);
+      newLine = parseInt(m[2], 10);
+      continue;
+    }
+    if (!hunk) continue; // skip the diff/index/---/+++ preamble
+    if (line === "") continue; // trailing-newline artifact; real lines carry a sigil
+    if (line.startsWith("\\")) continue; // "\ No newline at end of file"
+
+    const sigil = line[0];
+    const t = line.slice(1);
+    if (sigil === "+") {
+      hunk.lines.push({ op: "add", o: null, n: newLine, t });
+      newLine++;
+    } else if (sigil === "-") {
+      hunk.lines.push({ op: "rem", o: oldLine, n: null, t });
+      oldLine++;
+    } else {
+      // context line (leading space) — also covers a stray empty trailing line
+      hunk.lines.push({ op: "ctx", o: oldLine, n: newLine, t });
+      oldLine++;
+      newLine++;
+    }
+  }
+
+  return hunks;
+}


### PR DESCRIPTION
Merges the old **Files** tab and the no-op **Diff** tab into a single **Code** panel with a secondary in-panel switch between **Files** (the existing explorer/editor) and **Live** (an activity feed of the agent's edits rendered as unified diffs). Live mode reuses the 1s git-state poll for the changed-file list plus a new `get_file_diff` Tauri command for per-file diffs, parsed by a TDD'd `parseUnifiedDiff`. While a turn is in flight (gated on `managedBusy`) it auto-follows the file the agent is editing, clears the live indicators the instant the turn ends, and re-arms following when the user clicks the currently-live file — clicking any other file pauses it. The open file is shared across both modes, and `features.files`/`features.diff` collapse into a single `features.code` flag with back-compat migration of saved settings. Verified with `tsc`, `vite build`, the frontend suite (128/128), and `cargo check`/`cargo test`; not yet exercised end-to-end against a live agent turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)