### PR TITLE
feat(sidebar): wire up project creation (clone from GitHub + create new)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -8,8 +8,9 @@ use tauri::{AppHandle, State};
 
 use crate::agent::ProviderProbe;
 use crate::error::{Error, Result};
-use crate::gh::{self, PrState};
+use crate::gh::{self, GhRepoSummary, GhStatus, PrState};
 use crate::git;
+use crate::new_project;
 use crate::git_state::{self, FileStatus, GitState, ShortStats, StatusKind};
 use crate::names;
 use crate::run_session::RunStateSnapshot;
@@ -77,6 +78,51 @@ pub fn remove_workspace_repo(
     repo_path: String,
 ) -> Result<Workspace> {
     supervisor.remove_workspace_repo(PathBuf::from(repo_path))
+}
+
+/// Whether the `gh` CLI is installed and authenticated — drives the New
+/// Project flow's gating (clone and create both require `gh`).
+#[tauri::command]
+pub async fn gh_status() -> Result<GhStatus> {
+    gh::auth_status().await
+}
+
+/// The authenticated user's GitHub repos, newest first, for the clone picker.
+#[tauri::command]
+pub async fn gh_repo_list() -> Result<Vec<GhRepoSummary>> {
+    gh::repo_list(200).await
+}
+
+/// Clone a GitHub repo into `dest_parent/<repo-name>` and register it as a
+/// workspace project.
+#[tauri::command]
+pub async fn clone_repo(
+    supervisor: State<'_, Arc<Supervisor>>,
+    spec: String,
+    dest_parent: String,
+) -> Result<Workspace> {
+    let target = new_project::clone(&spec, Path::new(&dest_parent)).await?;
+    supervisor.add_workspace_repo(target)
+}
+
+/// Create a fresh repo locally + on GitHub, then register it as a workspace
+/// project.
+#[tauri::command]
+pub async fn create_repo(
+    supervisor: State<'_, Arc<Supervisor>>,
+    name: String,
+    dest_parent: String,
+    private: bool,
+    description: Option<String>,
+) -> Result<Workspace> {
+    let target = new_project::create(
+        &name,
+        Path::new(&dest_parent),
+        private,
+        description.as_deref(),
+    )
+    .await?;
+    supervisor.add_workspace_repo(target)
 }
 
 #[tauri::command]

--- a/src-tauri/src/gh.rs
+++ b/src-tauri/src/gh.rs
@@ -3,6 +3,7 @@
 //! Follows the same subprocess pattern as `git.rs` — each function
 //! shells out to `gh` and maps exit-code / stderr to typed errors.
 
+use std::io::ErrorKind;
 use std::path::Path;
 use tokio::process::Command;
 
@@ -136,6 +137,159 @@ pub async fn pr_merge(worktree: &Path) -> Result<()> {
         ));
     }
 
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Account / discovery (used by the New Project flow)
+// ---------------------------------------------------------------------------
+
+/// Whether `gh` is installed and authenticated. Drives the New Project UI:
+/// clone and create both go through `gh`, so we surface a clear prompt up
+/// front instead of letting an operation fail half-way.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct GhStatus {
+    pub installed: bool,
+    pub authenticated: bool,
+    pub login: Option<String>,
+}
+
+/// One repo as returned by `gh repo list --json`. `gh` emits camelCase keys;
+/// we re-expose the snake_case shape the rest of the IPC surface uses.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct GhRepoSummary {
+    pub name_with_owner: String,
+    pub description: Option<String>,
+    pub is_private: bool,
+    pub updated_at: String,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhRepoRaw {
+    name_with_owner: String,
+    description: Option<String>,
+    is_private: bool,
+    updated_at: String,
+}
+
+impl From<GhRepoRaw> for GhRepoSummary {
+    fn from(r: GhRepoRaw) -> Self {
+        GhRepoSummary {
+            name_with_owner: r.name_with_owner,
+            // `gh` returns "" rather than null for an empty description.
+            description: r.description.filter(|d| !d.is_empty()),
+            is_private: r.is_private,
+            updated_at: r.updated_at,
+        }
+    }
+}
+
+/// Probe `gh` availability and auth. Never errors — a missing binary or a
+/// logged-out state are reported as fields, not failures.
+pub async fn auth_status() -> Result<GhStatus> {
+    let out = match Command::new("gh").args(["auth", "status"]).output().await {
+        Ok(out) => out,
+        Err(e) if e.kind() == ErrorKind::NotFound => {
+            return Ok(GhStatus { installed: false, authenticated: false, login: None });
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    if !out.status.success() {
+        // `gh` is installed but no account is logged in.
+        return Ok(GhStatus { installed: true, authenticated: false, login: None });
+    }
+
+    // Best-effort login name; never fail the whole probe on it.
+    let login = Command::new("gh")
+        .args(["api", "user", "--jq", ".login"])
+        .output()
+        .await
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|s| !s.is_empty());
+
+    Ok(GhStatus { installed: true, authenticated: true, login })
+}
+
+/// List the authenticated user's repos (most-recently-updated first). The
+/// New Project picker filters this list client-side.
+pub async fn repo_list(limit: u32) -> Result<Vec<GhRepoSummary>> {
+    let out = Command::new("gh")
+        .args([
+            "repo",
+            "list",
+            "--json",
+            "nameWithOwner,description,isPrivate,updatedAt",
+            "--limit",
+            &limit.to_string(),
+        ])
+        .output()
+        .await?;
+
+    if !out.status.success() {
+        return Err(Error::Gh(
+            String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        ));
+    }
+
+    let raw: Vec<GhRepoRaw> = serde_json::from_slice(&out.stdout)?;
+    Ok(raw.into_iter().map(Into::into).collect())
+}
+
+/// Clone `spec` (an `owner/repo`, an https URL, or an ssh URL — `gh` accepts
+/// all three) into `target`.
+pub async fn repo_clone(spec: &str, target: &Path) -> Result<()> {
+    let target = target.to_str().ok_or_else(|| {
+        Error::InvalidPath(target.display().to_string())
+    })?;
+    let out = Command::new("gh")
+        .args(["repo", "clone", spec, target])
+        .output()
+        .await?;
+    if !out.status.success() {
+        return Err(Error::Gh(
+            String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Create a GitHub repo from the existing git repo at `target` and push the
+/// initial commit. `target` must already be a git repo with at least one
+/// commit (see `new_project::create`).
+pub async fn repo_create_and_push(
+    target: &Path,
+    name: &str,
+    private: bool,
+    description: Option<&str>,
+) -> Result<()> {
+    let mut args = vec![
+        "repo".to_string(),
+        "create".to_string(),
+        name.to_string(),
+        if private { "--private".to_string() } else { "--public".to_string() },
+        "--source=.".to_string(),
+        "--remote=origin".to_string(),
+        "--push".to_string(),
+    ];
+    if let Some(desc) = description.filter(|d| !d.is_empty()) {
+        args.push("--description".to_string());
+        args.push(desc.to_string());
+    }
+
+    let out = Command::new("gh")
+        .current_dir(target)
+        .args(&args)
+        .output()
+        .await?;
+    if !out.status.success() {
+        return Err(Error::Gh(
+            String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        ));
+    }
     Ok(())
 }
 

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -54,6 +54,57 @@ pub async fn checkout_new_branch(worktree: &Path, branch: &str) -> Result<()> {
     Ok(())
 }
 
+/// `git init` a fresh repository at `path` (created if absent). Used by the
+/// New Project "create" flow before seeding an initial commit.
+pub async fn init_repo(path: &Path) -> Result<()> {
+    let out = Command::new("git")
+        .args([
+            "init",
+            path.to_str().ok_or_else(|| {
+                Error::InvalidPath(path.display().to_string())
+            })?,
+        ])
+        .output()
+        .await?;
+    if !out.status.success() {
+        return Err(Error::Git(format!(
+            "init failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
+/// Stage everything and create a commit in `repo`. Relies on the user's
+/// global git identity (`user.name` / `user.email`); a missing identity
+/// surfaces as a `git commit` error.
+pub async fn commit_all(repo: &Path, message: &str) -> Result<()> {
+    let add = Command::new("git")
+        .current_dir(repo)
+        .args(["add", "-A"])
+        .output()
+        .await?;
+    if !add.status.success() {
+        return Err(Error::Git(format!(
+            "add -A failed: {}",
+            String::from_utf8_lossy(&add.stderr).trim()
+        )));
+    }
+
+    let out = Command::new("git")
+        .current_dir(repo)
+        .args(["commit", "-m", message])
+        .output()
+        .await?;
+    if !out.status.success() {
+        return Err(Error::Git(format!(
+            "commit failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
 pub async fn worktree_remove(repo: &Path, worktree_path: &Path, force: bool) -> Result<()> {
     let mut args = vec!["worktree", "remove"];
     if force {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod git;
 mod git_state;
 mod managed_session;
 mod names;
+mod new_project;
 mod oauth;
 mod pty_session;
 mod run_session;
@@ -146,6 +147,10 @@ pub fn run() {
             commands::get_agent_diff_stats,
             commands::add_workspace_repo,
             commands::remove_workspace_repo,
+            commands::gh_status,
+            commands::gh_repo_list,
+            commands::clone_repo,
+            commands::create_repo,
             commands::spawn_agent,
             commands::write_to_agent,
             commands::send_user_message,

--- a/src-tauri/src/new_project.rs
+++ b/src-tauri/src/new_project.rs
@@ -47,6 +47,13 @@ pub fn validate_new_name(name: &str) -> Result<()> {
     if name == "." || name == ".." {
         return Err(Error::InvalidPath("invalid project name".into()));
     }
+    // A leading hyphen is read as a flag by `gh` (e.g. `--push`), and GitHub
+    // disallows it anyway — reject before it can reach the CLI.
+    if name.starts_with('-') {
+        return Err(Error::InvalidPath(
+            "project name may not start with '-'".into(),
+        ));
+    }
     if name
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_'))
@@ -92,17 +99,29 @@ pub async fn create(
     let target = resolve_target(dest_parent, name)?;
 
     std::fs::create_dir_all(&target)?;
-    git::init_repo(&target).await?;
 
-    let readme = target.join("README.md");
-    let body = match description.map(str::trim).filter(|d| !d.is_empty()) {
-        Some(desc) => format!("# {name}\n\n{desc}\n"),
-        None => format!("# {name}\n"),
-    };
-    std::fs::write(&readme, body)?;
+    // Once the directory exists, any later failure must remove it — otherwise
+    // the orphaned folder makes `resolve_target` reject every retry.
+    let result = async {
+        git::init_repo(&target).await?;
 
-    git::commit_all(&target, "Initial commit").await?;
-    gh::repo_create_and_push(&target, name, private, description).await?;
+        let readme = target.join("README.md");
+        let body = match description.map(str::trim).filter(|d| !d.is_empty()) {
+            Some(desc) => format!("# {name}\n\n{desc}\n"),
+            None => format!("# {name}\n"),
+        };
+        std::fs::write(&readme, body)?;
+
+        git::commit_all(&target, "Initial commit").await?;
+        gh::repo_create_and_push(&target, name, private, description).await?;
+        Ok::<(), Error>(())
+    }
+    .await;
+
+    if let Err(e) = result {
+        let _ = std::fs::remove_dir_all(&target);
+        return Err(e);
+    }
     Ok(target)
 }
 
@@ -163,7 +182,7 @@ mod tests {
 
     #[test]
     fn validate_rejects_bad_names() {
-        for bad in ["", "  ", ".", "..", "a/b", "a b", "a:b", "café"] {
+        for bad in ["", "  ", ".", "..", "a/b", "a b", "a:b", "café", "-foo", "--push"] {
             assert!(validate_new_name(bad).is_err(), "{bad} should be invalid");
         }
     }

--- a/src-tauri/src/new_project.rs
+++ b/src-tauri/src/new_project.rs
@@ -1,0 +1,182 @@
+//! New Project flows: clone an existing GitHub repo, or create a fresh repo
+//! locally and on GitHub. Both terminate by handing a local path to
+//! `WorkspaceManager::add_workspace_repo` (done by the command layer).
+//!
+//! All GitHub work goes through the `gh` CLI (see `gh.rs`) — the same trusted
+//! path the PR flow already uses.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::{Error, Result};
+use crate::{gh, git};
+
+/// Derive the repository name from a clone spec. Accepts:
+///   - `owner/repo`
+///   - `https://github.com/owner/repo` (optionally `.git`, trailing slash)
+///   - `git@github.com:owner/repo.git`
+///
+/// Returns just the repo segment (`repo`), which becomes the local dir name.
+pub fn repo_name_from_spec(spec: &str) -> Result<String> {
+    let spec = spec.trim();
+    if spec.is_empty() {
+        return Err(Error::InvalidPath("empty repository".into()));
+    }
+
+    // Take the last path-ish segment, after either `/` or `:` (ssh form).
+    let tail = spec
+        .trim_end_matches('/')
+        .rsplit(['/', ':'])
+        .next()
+        .unwrap_or(spec);
+
+    let name = tail.strip_suffix(".git").unwrap_or(tail).trim();
+    if name.is_empty() {
+        return Err(Error::InvalidPath(format!("cannot parse repo name from: {spec}")));
+    }
+    validate_new_name(name)?;
+    Ok(name.to_string())
+}
+
+/// Validate a name the user typed for a brand-new repo. GitHub allows letters,
+/// digits, `.`, `-`, `_`; no slashes, spaces, or path traversal.
+pub fn validate_new_name(name: &str) -> Result<()> {
+    let name = name.trim();
+    if name.is_empty() {
+        return Err(Error::InvalidPath("project name is required".into()));
+    }
+    if name == "." || name == ".." {
+        return Err(Error::InvalidPath("invalid project name".into()));
+    }
+    if name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_'))
+    {
+        Ok(())
+    } else {
+        Err(Error::InvalidPath(
+            "project name may only contain letters, digits, '.', '-', '_'".into(),
+        ))
+    }
+}
+
+/// Compute the local target path and reject a collision before doing any work.
+fn resolve_target(dest_parent: &Path, name: &str) -> Result<PathBuf> {
+    let target = dest_parent.join(name);
+    if target.exists() {
+        return Err(Error::InvalidPath(format!(
+            "a folder already exists at {}",
+            target.display()
+        )));
+    }
+    Ok(target)
+}
+
+/// Clone `spec` into `dest_parent/<repo-name>` and return the local path.
+pub async fn clone(spec: &str, dest_parent: &Path) -> Result<PathBuf> {
+    let name = repo_name_from_spec(spec)?;
+    let target = resolve_target(dest_parent, &name)?;
+    gh::repo_clone(spec, &target).await?;
+    Ok(target)
+}
+
+/// Create a new local repo at `dest_parent/<name>` (seeded with a README and an
+/// initial commit), publish it to GitHub, and return the local path.
+pub async fn create(
+    name: &str,
+    dest_parent: &Path,
+    private: bool,
+    description: Option<&str>,
+) -> Result<PathBuf> {
+    let name = name.trim();
+    validate_new_name(name)?;
+    let target = resolve_target(dest_parent, name)?;
+
+    std::fs::create_dir_all(&target)?;
+    git::init_repo(&target).await?;
+
+    let readme = target.join("README.md");
+    let body = match description.map(str::trim).filter(|d| !d.is_empty()) {
+        Some(desc) => format!("# {name}\n\n{desc}\n"),
+        None => format!("# {name}\n"),
+    };
+    std::fs::write(&readme, body)?;
+
+    git::commit_all(&target, "Initial commit").await?;
+    gh::repo_create_and_push(&target, name, private, description).await?;
+    Ok(target)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_from_owner_repo() {
+        assert_eq!(repo_name_from_spec("octocat/hello").unwrap(), "hello");
+    }
+
+    #[test]
+    fn name_from_https_url() {
+        assert_eq!(
+            repo_name_from_spec("https://github.com/octocat/Hello-World").unwrap(),
+            "Hello-World"
+        );
+    }
+
+    #[test]
+    fn name_from_https_url_with_git_suffix_and_slash() {
+        assert_eq!(
+            repo_name_from_spec("https://github.com/octocat/Hello-World.git/").unwrap(),
+            "Hello-World"
+        );
+    }
+
+    #[test]
+    fn name_from_ssh_url() {
+        assert_eq!(
+            repo_name_from_spec("git@github.com:octocat/my_repo.git").unwrap(),
+            "my_repo"
+        );
+    }
+
+    #[test]
+    fn name_rejects_empty() {
+        assert!(repo_name_from_spec("   ").is_err());
+    }
+
+    #[test]
+    fn name_rejects_illegal_chars() {
+        // A spec whose tail contains spaces is not a legal repo name.
+        assert!(repo_name_from_spec("owner/bad name").is_err());
+    }
+
+    #[test]
+    fn validate_accepts_typical_names() {
+        for ok in ["my-app", "my_app", "App.2", "x"] {
+            assert!(validate_new_name(ok).is_ok(), "{ok} should be valid");
+        }
+    }
+
+    #[test]
+    fn validate_rejects_bad_names() {
+        for bad in ["", "  ", ".", "..", "a/b", "a b", "a:b", "café"] {
+            assert!(validate_new_name(bad).is_err(), "{bad} should be invalid");
+        }
+    }
+
+    #[test]
+    fn resolve_target_rejects_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path();
+        std::fs::create_dir(parent.join("taken")).unwrap();
+        assert!(resolve_target(parent, "taken").is_err());
+        assert_eq!(
+            resolve_target(parent, "fresh").unwrap(),
+            parent.join("fresh")
+        );
+    }
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -211,6 +211,21 @@ export interface ProviderProbe {
   path: string | null;
 }
 
+/** Whether the `gh` CLI is installed and authenticated (New Project flow). */
+export interface GhStatus {
+  installed: boolean;
+  authenticated: boolean;
+  login: string | null;
+}
+
+/** One repo from `gh repo list`, for the clone picker. */
+export interface GhRepoSummary {
+  name_with_owner: string;
+  description: string | null;
+  is_private: boolean;
+  updated_at: string;
+}
+
 export const api = {
   getWorkspace: () => invoke<Workspace | null>("get_workspace"),
   getAgentDiffStats: (agentId: string) =>
@@ -219,6 +234,22 @@ export const api = {
     invoke<Workspace>("add_workspace_repo", { repoPath }),
   removeWorkspaceRepo: (repoPath: string) =>
     invoke<Workspace>("remove_workspace_repo", { repoPath }),
+  ghStatus: () => invoke<GhStatus>("gh_status"),
+  ghRepoList: () => invoke<GhRepoSummary[]>("gh_repo_list"),
+  cloneRepo: (spec: string, destParent: string) =>
+    invoke<Workspace>("clone_repo", { spec, destParent }),
+  createRepo: (
+    name: string,
+    destParent: string,
+    isPrivate: boolean,
+    description?: string,
+  ) =>
+    invoke<Workspace>("create_repo", {
+      name,
+      destParent,
+      private: isPrivate,
+      description: description ?? null,
+    }),
   spawnAgent: (
     view: AgentView,
     repoPath: string,

--- a/src/app.css
+++ b/src/app.css
@@ -1967,7 +1967,13 @@ button { cursor: default; }
   border-radius: var(--r-md);
   box-shadow: 0 24px 64px rgba(0,0,0,.4);
   z-index: 301;
-  animation: ddIn .15s var(--ease);
+  /* Own keyframe (not ddIn): the animated transform must keep the
+     translate(-50%,-50%) centering, or it jumps from the corner to center. */
+  animation: np-modal-in .18s var(--ease);
+}
+@keyframes np-modal-in {
+  from { opacity: 0; transform: translate(-50%, calc(-50% + 6px)) scale(.985); }
+  to   { opacity: 1; transform: translate(-50%, -50%) scale(1); }
 }
 .np-modal-h {
   display: flex; align-items: center; gap: 8px;

--- a/src/app.css
+++ b/src/app.css
@@ -1953,6 +1953,166 @@ button { cursor: default; }
 .np-item .np-t { font-size: 13px; font-weight: 500; color: var(--fg-0); }
 .np-item .np-s { font-size: 11.5px; color: var(--fg-2); margin-top: 2px; }
 
+/* ── New Project modal ────────────────────────────────────────────── */
+.np-modal {
+  position: fixed;
+  left: 50%; top: 50%;
+  transform: translate(-50%, -50%);
+  width: 460px;
+  max-width: calc(100vw - 48px);
+  max-height: calc(100vh - 96px);
+  display: flex; flex-direction: column;
+  background: var(--bg-2);
+  border: 1px solid var(--bd);
+  border-radius: var(--r-md);
+  box-shadow: 0 24px 64px rgba(0,0,0,.4);
+  z-index: 301;
+  animation: ddIn .15s var(--ease);
+}
+.np-modal-h {
+  display: flex; align-items: center; gap: 8px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--bd);
+  font-size: 13px; font-weight: 600; color: var(--fg-0);
+}
+.np-modal-h svg { color: var(--accent); }
+.np-modal-h span { flex: 1; }
+.np-close {
+  display: flex; align-items: center; justify-content: center;
+  width: 24px; height: 24px; border-radius: var(--r-sm);
+  color: var(--fg-2);
+}
+.np-close:hover { background: var(--hover); color: var(--fg-0); }
+
+.np-body {
+  display: flex; flex-direction: column; gap: 14px;
+  padding: 16px;
+  overflow-y: auto;
+}
+.np-field { display: flex; flex-direction: column; gap: 6px; }
+.np-field > label {
+  font-size: 11.5px; font-weight: 500; color: var(--fg-2);
+}
+.np-field .np-opt { color: var(--fg-3); font-weight: 400; }
+.np-field input {
+  height: 34px; padding: 0 10px;
+  background: var(--bg-1);
+  border: 1px solid var(--bd);
+  border-radius: var(--r-sm);
+  font-size: 13px; color: var(--fg-0);
+}
+.np-field input:focus { border-color: var(--accent); outline: none; }
+.np-hint { font-size: 11.5px; color: var(--fg-2); }
+.np-hint.e, .np-error { color: var(--danger); }
+.np-error {
+  font-size: 12px;
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--danger) 35%, transparent);
+  border-radius: var(--r-sm);
+  padding: 8px 10px;
+}
+.np-link {
+  align-self: flex-start;
+  font-size: 12px; color: var(--accent);
+}
+.np-link:hover { text-decoration: underline; }
+
+/* Destination chooser */
+.np-dest {
+  display: flex; align-items: center; gap: 8px;
+  height: 36px; padding: 0 10px;
+  background: var(--bg-1);
+  border: 1px solid var(--bd);
+  border-radius: var(--r-sm);
+  text-align: left;
+}
+.np-dest:hover { border-color: var(--accent); }
+.np-dest svg { color: var(--fg-2); flex-shrink: 0; }
+.np-dest .np-dest-path {
+  flex: 1; min-width: 0;
+  font-size: 12.5px; color: var(--fg-0);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  direction: rtl; text-align: left;
+}
+.np-dest .np-dest-name { color: var(--accent); }
+.np-dest .np-dest-empty { flex: 1; font-size: 12.5px; color: var(--fg-3); }
+
+/* Repo picker */
+.np-list-wrap { display: flex; flex-direction: column; gap: 8px; }
+.np-search {
+  display: flex; align-items: center; gap: 8px;
+  height: 34px; padding: 0 10px;
+  background: var(--bg-1);
+  border: 1px solid var(--bd);
+  border-radius: var(--r-sm);
+}
+.np-search svg { color: var(--fg-3); flex-shrink: 0; }
+.np-search input {
+  flex: 1; background: transparent; border: none;
+  font-size: 13px; color: var(--fg-0);
+}
+.np-search input:focus { outline: none; }
+.np-list {
+  display: flex; flex-direction: column;
+  max-height: 240px; overflow-y: auto;
+  border: 1px solid var(--bd);
+  border-radius: var(--r-sm);
+}
+.np-list-msg { padding: 16px; font-size: 12.5px; color: var(--fg-2); text-align: center; }
+.np-list-msg.e { color: var(--danger); }
+.np-repo {
+  display: flex; align-items: flex-start; gap: 10px;
+  padding: 9px 11px;
+  text-align: left; width: 100%;
+  border-bottom: 1px solid var(--bd);
+}
+.np-repo:last-child { border-bottom: none; }
+.np-repo:hover { background: var(--hover); }
+.np-repo.active { background: color-mix(in srgb, var(--accent) 16%, transparent); }
+.np-repo svg { color: var(--fg-2); margin-top: 1px; flex-shrink: 0; }
+.np-repo-text { flex: 1; min-width: 0; }
+.np-repo-name {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 12.5px; color: var(--fg-0);
+}
+.np-priv {
+  font-size: 9.5px; font-weight: 600; letter-spacing: .03em;
+  text-transform: uppercase;
+  color: var(--fg-2);
+  border: 1px solid var(--bd);
+  border-radius: 4px; padding: 1px 5px;
+}
+.np-repo-desc {
+  font-size: 11.5px; color: var(--fg-2); margin-top: 2px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+
+/* Actions + gate */
+.np-actions { display: flex; justify-content: flex-end; margin-top: 2px; }
+.np-primary {
+  display: flex; align-items: center; gap: 7px;
+  height: 34px; padding: 0 16px;
+  background: var(--accent); color: oklch(0.16 0.02 60);
+  border-radius: var(--r-sm);
+  font-size: 13px; font-weight: 600;
+}
+.theme-light .np-primary { color: oklch(0.98 0.005 60); }
+.np-primary:disabled { opacity: .5; }
+.np-primary:not(:disabled):hover { background: oklch(from var(--accent) calc(l + 0.04) c h); }
+.np-primary svg { animation: np-spin 1s linear infinite; }
+@keyframes np-spin { to { transform: rotate(360deg); } }
+.np-gate {
+  display: flex; flex-direction: column; align-items: center; gap: 8px;
+  text-align: center; padding: 24px 12px;
+  color: var(--accent);
+}
+.np-gate-t { font-size: 13px; font-weight: 600; color: var(--fg-0); margin-top: 4px; }
+.np-gate-s { font-size: 12px; color: var(--fg-2); line-height: 1.5; max-width: 320px; }
+.np-gate code {
+  background: var(--bg-1); border: 1px solid var(--bd);
+  border-radius: 4px; padding: 1px 5px; font-size: 11.5px; color: var(--fg-0);
+}
+
 /* error banner */
 .error-banner {
   position: fixed;

--- a/src/components/NewProject/CloneView.tsx
+++ b/src/components/NewProject/CloneView.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+import { useAppStore } from "../../store";
+import { parseRepoSpec } from "../../util/repoSpec";
+import { Icon } from "../Icon";
+import { RepoList } from "./RepoList";
+import { DestRow, GhGate, type NewProjectShared } from "./shared";
+
+/** Clone an existing GitHub repo — pick from the user's repos or paste a
+ *  URL / owner-repo spec. */
+export function CloneView({ shared, onDone }: { shared: NewProjectShared; onDone: () => void }) {
+  const cloneRepo = useAppStore((s) => s.cloneRepo);
+  const { parent, pickParent, gh } = shared;
+
+  const [selected, setSelected] = useState<string | null>(null);
+  const [url, setUrl] = useState("");
+  const [pasteMode, setPasteMode] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (gh && (!gh.installed || !gh.authenticated)) return <GhGate gh={gh} />;
+
+  // The active spec is the pasted URL (when in paste mode) or the selected repo.
+  const spec = pasteMode ? url.trim() : selected ?? "";
+  const parsed = parseRepoSpec(spec);
+  const canClone = !!parent && parsed.valid && !busy;
+
+  const onClone = async () => {
+    if (!canClone) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await cloneRepo(spec, parent);
+      onDone();
+    } catch (e) {
+      setError(String(e));
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="np-body">
+      {pasteMode ? (
+        <div className="np-field">
+          <label>Repository URL or owner/repo</label>
+          <input
+            autoFocus
+            placeholder="https://github.com/owner/repo  ·  owner/repo"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+          />
+          <button className="np-link" onClick={() => setPasteMode(false)}>
+            Pick from my repositories instead
+          </button>
+        </div>
+      ) : (
+        <>
+          <RepoList selected={selected} onSelect={setSelected} />
+          <button className="np-link" onClick={() => setPasteMode(true)}>
+            Paste a URL instead
+          </button>
+        </>
+      )}
+
+      <DestRow parent={parent} onPick={pickParent} name={parsed.name} />
+
+      {error && <div className="np-error">{error}</div>}
+
+      <div className="np-actions">
+        <button className="np-primary" disabled={!canClone} onClick={onClone}>
+          {busy ? (
+            <>
+              <Icon name="refresh" size={13} /> Cloning…
+            </>
+          ) : (
+            "Clone repository"
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/NewProject/CreateView.tsx
+++ b/src/components/NewProject/CreateView.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { useAppStore } from "../../store";
+import { isValidRepoName } from "../../util/repoSpec";
+import { Segmented } from "../Settings/Segmented";
+import { Icon } from "../Icon";
+import { DestRow, GhGate, type NewProjectShared } from "./shared";
+
+/** Create a brand-new repo locally and publish it to GitHub. */
+export function CreateView({ shared, onDone }: { shared: NewProjectShared; onDone: () => void }) {
+  const createRepo = useAppStore((s) => s.createRepo);
+  const { parent, pickParent, gh } = shared;
+
+  const [name, setName] = useState("");
+  const [visibility, setVisibility] = useState<"private" | "public">("private");
+  const [description, setDescription] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (gh && (!gh.installed || !gh.authenticated)) return <GhGate gh={gh} />;
+
+  const nameOk = isValidRepoName(name);
+  const showNameError = name.trim().length > 0 && !nameOk;
+  const canCreate = !!parent && nameOk && !busy;
+
+  const onCreate = async () => {
+    if (!canCreate) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await createRepo(name.trim(), parent, visibility === "private", description.trim() || undefined);
+      onDone();
+    } catch (e) {
+      setError(String(e));
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="np-body">
+      <div className="np-field">
+        <label>Project name</label>
+        <input
+          autoFocus
+          placeholder="my-new-project"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        {showNameError && (
+          <div className="np-hint e">
+            Use only letters, digits, “.”, “-”, “_”.
+          </div>
+        )}
+      </div>
+
+      <div className="np-field">
+        <label>Visibility</label>
+        <Segmented
+          value={visibility}
+          onChange={setVisibility}
+          options={[
+            { value: "private", label: "Private" },
+            { value: "public", label: "Public" },
+          ]}
+        />
+      </div>
+
+      <div className="np-field">
+        <label>Description <span className="np-opt">(optional)</span></label>
+        <input
+          placeholder="What is this project?"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+      </div>
+
+      <DestRow parent={parent} onPick={pickParent} name={nameOk ? name.trim() : undefined} />
+
+      {error && <div className="np-error">{error}</div>}
+
+      <div className="np-actions">
+        <button className="np-primary" disabled={!canCreate} onClick={onCreate}>
+          {busy ? (
+            <>
+              <Icon name="refresh" size={13} /> Creating…
+            </>
+          ) : (
+            "Create project"
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/NewProject/RepoList.tsx
+++ b/src/components/NewProject/RepoList.tsx
@@ -60,7 +60,11 @@ export function RepoList({ selected, onSelect }: Props) {
       </div>
       <div className="np-list">
         {filtered.length === 0 && (
-          <div className="np-list-msg">No repositories match “{query}”.</div>
+          <div className="np-list-msg">
+            {query.trim()
+              ? `No repositories match “${query}”.`
+              : "No repositories found."}
+          </div>
         )}
         {filtered.map((r) => (
           <button

--- a/src/components/NewProject/RepoList.tsx
+++ b/src/components/NewProject/RepoList.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useMemo, useState } from "react";
+import { api, type GhRepoSummary } from "../../api";
+import { Icon } from "../Icon";
+
+interface Props {
+  selected: string | null;
+  onSelect: (nameWithOwner: string) => void;
+}
+
+/** Searchable list of the user's GitHub repos for the clone picker.
+ *  Fetches once; filtering is client-side. */
+export function RepoList({ selected, onSelect }: Props) {
+  const [repos, setRepos] = useState<GhRepoSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .ghRepoList()
+      .then((r) => {
+        if (!cancelled) setRepos(r);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(String(e));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const filtered = useMemo(() => {
+    if (!repos) return [];
+    const q = query.trim().toLowerCase();
+    if (!q) return repos;
+    return repos.filter(
+      (r) =>
+        r.name_with_owner.toLowerCase().includes(q) ||
+        (r.description?.toLowerCase().includes(q) ?? false),
+    );
+  }, [repos, query]);
+
+  if (error) {
+    return <div className="np-list-msg e">Couldn’t load your repos: {error}</div>;
+  }
+  if (!repos) {
+    return <div className="np-list-msg">Loading your repositories…</div>;
+  }
+
+  return (
+    <div className="np-list-wrap">
+      <div className="np-search">
+        <Icon name="search" size={13} />
+        <input
+          autoFocus
+          placeholder="Search your repositories…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+      </div>
+      <div className="np-list">
+        {filtered.length === 0 && (
+          <div className="np-list-msg">No repositories match “{query}”.</div>
+        )}
+        {filtered.map((r) => (
+          <button
+            key={r.name_with_owner}
+            className={`np-repo ${selected === r.name_with_owner ? "active" : ""}`}
+            onClick={() => onSelect(r.name_with_owner)}
+          >
+            <Icon name="github" size={13} />
+            <div className="np-repo-text">
+              <div className="np-repo-name">
+                {r.name_with_owner}
+                {r.is_private && <span className="np-priv">Private</span>}
+              </div>
+              {r.description && <div className="np-repo-desc">{r.description}</div>}
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/NewProject/index.tsx
+++ b/src/components/NewProject/index.tsx
@@ -1,0 +1,39 @@
+import { Scrim } from "../ui/Scrim";
+import { Icon } from "../Icon";
+import { CloneView } from "./CloneView";
+import { CreateView } from "./CreateView";
+import { useNewProject } from "./useNewProject";
+
+export type NewProjectMode = "clone" | "create";
+
+/** Centered modal for adding a project by cloning from GitHub or creating a
+ *  fresh repo. Launched from the sidebar's "+" popover. */
+export function NewProject({
+  mode,
+  onClose,
+}: {
+  mode: NewProjectMode;
+  onClose: () => void;
+}) {
+  const shared = useNewProject();
+
+  return (
+    <>
+      <Scrim onClose={onClose} zIndex={300} />
+      <div className="np-modal" role="dialog" aria-modal="true">
+        <div className="np-modal-h">
+          <Icon name={mode === "clone" ? "github" : "sparkle"} size={15} />
+          <span>{mode === "clone" ? "Clone from GitHub" : "Create new project"}</span>
+          <button className="np-close" aria-label="Close" onClick={onClose}>
+            <Icon name="close" size={14} />
+          </button>
+        </div>
+        {mode === "clone" ? (
+          <CloneView shared={shared} onDone={onClose} />
+        ) : (
+          <CreateView shared={shared} onDone={onClose} />
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/components/NewProject/shared.tsx
+++ b/src/components/NewProject/shared.tsx
@@ -1,0 +1,75 @@
+import type { GhStatus } from "../../api";
+import { Icon } from "../Icon";
+
+/** Shared state passed from the modal shell to each view. */
+export interface NewProjectShared {
+  parent: string;
+  setParent: (p: string) => void;
+  pickParent: () => Promise<void>;
+  gh: GhStatus | null;
+}
+
+/** Destination-folder row: shows the chosen parent and, when known, the final
+ *  `<parent>/<name>` path so the user sees exactly where the repo lands. */
+export function DestRow({
+  parent,
+  onPick,
+  name,
+}: {
+  parent: string;
+  onPick: () => void;
+  name?: string;
+}) {
+  const sep = parent.includes("\\") ? "\\" : "/";
+  const trimmed = parent.replace(/[/\\]+$/, "");
+  return (
+    <div className="np-field">
+      <label>Location</label>
+      <button className="np-dest" onClick={onPick}>
+        <Icon name="folder" size={14} />
+        {parent ? (
+          <span className="np-dest-path">
+            {trimmed}
+            {name ? (
+              <span className="np-dest-name">
+                {sep}
+                {name}
+              </span>
+            ) : null}
+          </span>
+        ) : (
+          <span className="np-dest-empty">Choose a folder…</span>
+        )}
+        <Icon name="chevR" size={13} />
+      </button>
+    </div>
+  );
+}
+
+/** Shown when `gh` is missing or logged out — both flows need it. */
+export function GhGate({ gh }: { gh: GhStatus }) {
+  return (
+    <div className="np-body">
+      <div className="np-gate">
+        <Icon name="github" size={22} />
+        {!gh.installed ? (
+          <>
+            <div className="np-gate-t">GitHub CLI not found</div>
+            <div className="np-gate-s">
+              Install the <code>gh</code> CLI to clone and create GitHub
+              repositories, then reopen this dialog.
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="np-gate-t">Not signed in to GitHub</div>
+            <div className="np-gate-s">
+              Run <code>gh auth login</code> in your terminal, then reopen this
+              dialog.
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/NewProject/useNewProject.ts
+++ b/src/components/NewProject/useNewProject.ts
@@ -15,9 +15,18 @@ export function useNewProject() {
 
   useEffect(() => {
     let cancelled = false;
-    api.ghStatus().then((s) => {
-      if (!cancelled) setGh(s);
-    });
+    api
+      .ghStatus()
+      .then((s) => {
+        if (!cancelled) setGh(s);
+      })
+      .catch(() => {
+        // If the probe itself fails, treat gh as unavailable so the gate shows
+        // immediately rather than leaving the form live with a deferred error.
+        if (!cancelled) {
+          setGh({ installed: false, authenticated: false, login: null });
+        }
+      });
     return () => {
       cancelled = true;
     };

--- a/src/components/NewProject/useNewProject.ts
+++ b/src/components/NewProject/useNewProject.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useState } from "react";
+import { open } from "@tauri-apps/plugin-dialog";
+import { api, type GhStatus } from "../../api";
+
+// The last parent folder a project was created in, pre-filled next time.
+const PARENT_KEY = "q2:newProjectParent";
+
+/** Shared state for the New Project modal: destination parent (remembered),
+ *  the gh availability probe, and the directory picker. */
+export function useNewProject() {
+  const [parent, setParentState] = useState<string>(
+    () => localStorage.getItem(PARENT_KEY) ?? "",
+  );
+  const [gh, setGh] = useState<GhStatus | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    api.ghStatus().then((s) => {
+      if (!cancelled) setGh(s);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const setParent = useCallback((p: string) => {
+    setParentState(p);
+    localStorage.setItem(PARENT_KEY, p);
+  }, []);
+
+  const pickParent = useCallback(async () => {
+    const picked = await open({
+      directory: true,
+      multiple: false,
+      title: "Choose where to create the project",
+      defaultPath: parent || undefined,
+    });
+    if (typeof picked === "string") setParent(picked);
+  }, [parent, setParent]);
+
+  return { parent, setParent, pickParent, gh };
+}

--- a/src/components/Sidebar/NewProjectPopover.tsx
+++ b/src/components/Sidebar/NewProjectPopover.tsx
@@ -2,11 +2,18 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { useAppStore } from "../../store";
 import { Icon, type IconName } from "../Icon";
 import { Scrim } from "../ui/Scrim";
+import type { NewProjectMode } from "../NewProject";
 
-/** Choose how to add a project to the sidebar. "Folder" is the only
- *  path currently wired; the other options are placeholders for
- *  future GitHub clone / new-repo flows. */
-export function NewProjectPopover({ onClose }: { onClose: () => void }) {
+/** Choose how to add a project to the sidebar: open a local folder, clone
+ *  from GitHub, or create a new repo. The latter two open the New Project
+ *  modal (hosted by the sidebar) via `onChoose`. */
+export function NewProjectPopover({
+  onClose,
+  onChoose,
+}: {
+  onClose: () => void;
+  onChoose: (mode: NewProjectMode) => void;
+}) {
   const addWorkspaceRepo = useAppStore((s) => s.addWorkspaceRepo);
 
   async function onOpenFolder() {
@@ -34,14 +41,14 @@ export function NewProjectPopover({ onClose }: { onClose: () => void }) {
         <Item
           icon="github"
           title="Clone from GitHub"
-          subtitle="Coming soon"
-          onClick={onClose}
+          subtitle="Pick a repo or paste a URL"
+          onClick={() => onChoose("clone")}
         />
         <Item
           icon="sparkle"
           title="Create new project"
-          subtitle="Coming soon"
-          onClick={onClose}
+          subtitle="New repo, local + on GitHub"
+          onClick={() => onChoose("create")}
         />
       </div>
     </>

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -8,6 +8,7 @@ import { SidebarHeader } from "./SidebarHeader";
 import { SidebarFooter } from "./SidebarFooter";
 import { ProjectGroup } from "./ProjectGroup";
 import { NewProjectPopover } from "./NewProjectPopover";
+import { NewProject, type NewProjectMode } from "../NewProject";
 
 interface RepoGroup {
   repoPath: string;
@@ -73,6 +74,7 @@ export function Sidebar() {
   const [query, setQuery] = useState("");
   const [openMap, setOpenMap] = useState<Record<string, boolean>>({});
   const [npOpen, setNpOpen] = useState(false);
+  const [npMode, setNpMode] = useState<NewProjectMode | null>(null);
 
   const liveAgents = useMemo(
     () => (workspace?.agents ?? []).filter((a) => !a.archive),
@@ -139,7 +141,16 @@ export function Sidebar() {
 
       <SidebarFooter />
 
-      {npOpen && <NewProjectPopover onClose={() => setNpOpen(false)} />}
+      {npOpen && (
+        <NewProjectPopover
+          onClose={() => setNpOpen(false)}
+          onChoose={(mode) => {
+            setNpOpen(false);
+            setNpMode(mode);
+          }}
+        />
+      )}
+      {npMode && <NewProject mode={npMode} onClose={() => setNpMode(null)} />}
     </>
   );
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -301,6 +301,15 @@ interface AppState {
   selectAgent: (id: string | null) => void;
   addWorkspaceRepo: (path: string) => Promise<void>;
   removeWorkspaceRepo: (path: string) => Promise<void>;
+  // Clone/create resolve on success and throw on failure, so the New Project
+  // modal can show the error inline rather than in the global banner.
+  cloneRepo: (spec: string, destParent: string) => Promise<void>;
+  createRepo: (
+    name: string,
+    destParent: string,
+    isPrivate: boolean,
+    description?: string,
+  ) => Promise<void>;
   spawn: (view: AgentView, repoPath: string) => Promise<AgentRecord | null>;
   sendUserMessage: (
     id: string,
@@ -862,6 +871,18 @@ export const useAppStore = create<AppState>((set, get) => ({
     } catch (e) {
       set({ lastError: String(e) });
     }
+  },
+
+  cloneRepo: async (spec, destParent) => {
+    // The new project appears in the sidebar via the refreshed workspace.
+    // Errors propagate to the caller (the modal) for inline display.
+    const ws = await api.cloneRepo(spec, destParent);
+    set({ workspace: ws });
+  },
+
+  createRepo: async (name, destParent, isPrivate, description) => {
+    const ws = await api.createRepo(name, destParent, isPrivate, description);
+    set({ workspace: ws });
   },
 
   spawn: async (view, repoPath) => {

--- a/src/util/repoSpec.test.ts
+++ b/src/util/repoSpec.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { parseRepoSpec, isValidRepoName } from "./repoSpec";
+
+describe("parseRepoSpec", () => {
+  it("parses owner/repo", () => {
+    expect(parseRepoSpec("octocat/hello")).toEqual({ valid: true, name: "hello" });
+  });
+
+  it("parses an https url", () => {
+    expect(parseRepoSpec("https://github.com/octocat/Hello-World")).toEqual({
+      valid: true,
+      name: "Hello-World",
+    });
+  });
+
+  it("strips a .git suffix and trailing slash", () => {
+    expect(parseRepoSpec("https://github.com/octocat/Hello-World.git/")).toEqual({
+      valid: true,
+      name: "Hello-World",
+    });
+  });
+
+  it("parses an ssh url", () => {
+    expect(parseRepoSpec("git@github.com:octocat/my_repo.git")).toEqual({
+      valid: true,
+      name: "my_repo",
+    });
+  });
+
+  it("rejects empty input", () => {
+    expect(parseRepoSpec("   ").valid).toBe(false);
+  });
+
+  it("rejects a tail with illegal characters", () => {
+    expect(parseRepoSpec("owner/bad name").valid).toBe(false);
+  });
+});
+
+describe("isValidRepoName", () => {
+  it("accepts typical names", () => {
+    for (const ok of ["my-app", "my_app", "App.2", "x"]) {
+      expect(isValidRepoName(ok)).toBe(true);
+    }
+  });
+
+  it("rejects bad names", () => {
+    for (const bad of ["", "  ", ".", "..", "a/b", "a b", "a:b", "café"]) {
+      expect(isValidRepoName(bad)).toBe(false);
+    }
+  });
+});

--- a/src/util/repoSpec.test.ts
+++ b/src/util/repoSpec.test.ts
@@ -34,6 +34,10 @@ describe("parseRepoSpec", () => {
   it("rejects a tail with illegal characters", () => {
     expect(parseRepoSpec("owner/bad name").valid).toBe(false);
   });
+
+  it("rejects a tail starting with a hyphen (gh flag injection)", () => {
+    expect(parseRepoSpec("owner/-foo").valid).toBe(false);
+  });
 });
 
 describe("isValidRepoName", () => {
@@ -44,7 +48,7 @@ describe("isValidRepoName", () => {
   });
 
   it("rejects bad names", () => {
-    for (const bad of ["", "  ", ".", "..", "a/b", "a b", "a:b", "café"]) {
+    for (const bad of ["", "  ", ".", "..", "a/b", "a b", "a:b", "café", "-foo", "--push"]) {
       expect(isValidRepoName(bad)).toBe(false);
     }
   });

--- a/src/util/repoSpec.ts
+++ b/src/util/repoSpec.ts
@@ -1,0 +1,32 @@
+// Parse/validate the clone spec and new-project name in the browser, so the
+// New Project flow gives instant feedback. Mirrors the Rust logic in
+// `src-tauri/src/new_project.rs` (repo_name_from_spec / validate_new_name).
+
+const NAME_RE = /^[A-Za-z0-9._-]+$/;
+
+/** A GitHub repo name is legal: letters, digits, '.', '-', '_'; not '.'/'..'. */
+export function isValidRepoName(name: string): boolean {
+  const n = name.trim();
+  if (!n || n === "." || n === "..") return false;
+  return NAME_RE.test(n);
+}
+
+export interface ParsedSpec {
+  valid: boolean;
+  /** The derived repo (and local dir) name, when valid. */
+  name?: string;
+}
+
+/**
+ * Derive the repo name from a clone spec. Accepts `owner/repo`,
+ * `https://github.com/owner/repo(.git)`, and `git@github.com:owner/repo.git`.
+ */
+export function parseRepoSpec(input: string): ParsedSpec {
+  const spec = input.trim();
+  if (!spec) return { valid: false };
+
+  const tail = spec.replace(/\/+$/, "").split(/[/:]/).pop() ?? spec;
+  const name = tail.replace(/\.git$/, "").trim();
+  if (!name || !isValidRepoName(name)) return { valid: false };
+  return { valid: true, name };
+}

--- a/src/util/repoSpec.ts
+++ b/src/util/repoSpec.ts
@@ -2,7 +2,10 @@
 // New Project flow gives instant feedback. Mirrors the Rust logic in
 // `src-tauri/src/new_project.rs` (repo_name_from_spec / validate_new_name).
 
-const NAME_RE = /^[A-Za-z0-9._-]+$/;
+// Leading '-' is rejected: `gh` reads it as a flag (e.g. `--push`) and GitHub
+// disallows it. First char must not be a hyphen; mirrors validate_new_name in
+// src-tauri/src/new_project.rs.
+const NAME_RE = /^[A-Za-z0-9._][A-Za-z0-9._-]*$/;
 
 /** A GitHub repo name is legal: letters, digits, '.', '-', '_'; not '.'/'..'. */
 export function isValidRepoName(name: string): boolean {


### PR DESCRIPTION
## What

Replaces the two "Coming soon" stubs in the add-project popover with working flows. Both route through the `gh` CLI (the same trusted path the PR flow already uses) and terminate in the existing `add_workspace_repo` command.

- **Clone from GitHub** — pick from your GitHub repos (searchable list via `gh repo list`) **or** paste a URL / `owner/repo`.
- **Create new project** — a fresh local repo (`git init` + README + initial commit) published to GitHub via `gh repo create --push`, with a Private/Public toggle and optional description.
- **Destination** — prompts for a parent folder, pre-filled with the last-used one; lands at `<parent>/<name>`. Existing-folder collisions error inline (no silent rename).
- **`gh` missing / logged out** — detected up front; the modal shows a clear gate instead of failing mid-operation.

## Design decisions

| Decision | Choice |
|---|---|
| "Create new" scope | New local repo **+** create on GitHub and push |
| GitHub auth | Lean entirely on the `gh` CLI (one auth story with the PR flow) |
| Destination | Prompt each time, pre-filled with remembered last parent |
| Collision | Block with inline error |
| Clone source | Both repo-list picker and paste-URL |
| Container | Centered modal launched from the popover |

## Implementation

**Backend (Rust)**
- `new_project.rs` *(new)* — pure helpers (`repo_name_from_spec`, `validate_new_name`, collision check) + async `clone`/`create` orchestration.
- `gh.rs` — `auth_status`, `repo_list`, `repo_clone`, `repo_create_and_push` + `GhStatus`/`GhRepoSummary`.
- `git.rs` — `init_repo`, `commit_all`.
- `commands.rs` + `lib.rs` — four IPC commands (`gh_status`, `gh_repo_list`, `clone_repo`, `create_repo`).

**Frontend (React/TS)**
- `components/NewProject/` — modal shell + `CloneView`, `CreateView`, `RepoList`, `shared` (dest row + gh gate), `useNewProject` hook.
- `util/repoSpec.ts` — browser-side spec parsing/validation mirroring the Rust logic.
- `api.ts` typed wrappers, `store.ts` actions, `NewProjectPopover`/`Sidebar` wiring, `app.css` styles.

## Tests

- **+9 Rust** unit tests (`new_project`: spec parsing across URL forms, name validation, collision).
- **+8 frontend** tests (`repoSpec`).
- Typecheck clean; full suites green (**148** Rust, **136** frontend).

## Verified / not verified

Verified: `bun run check`, `bun run test`, `cargo test` all pass. **Not** verified: a live end-to-end clone/create against GitHub (needs an authenticated `gh`, network, and creating real repos). The subprocess wiring follows the existing `gh.rs` pattern; parse/validate/collision logic is unit-tested. Worth a manual smoke test before merge.

## Out of scope (deliberately deferred)

Fine-grained clone-progress streaming, mid-flight cancel, AI/template scaffolding, in-app-OAuth-token git path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)