### PR TITLE
feat(account): cache OAuth avatar in SQLite and show it in the UI

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2815,6 +2815,7 @@ dependencies = [
 name = "quorum"
 version = "0.2.0"
 dependencies = [
+ "base64 0.22.1",
  "chrono",
  "dirs 5.0.1",
  "nix 0.29.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,6 +36,7 @@ tempfile = "3"
 rusqlite = { version = "0.31", features = ["bundled"] }
 rusqlite_migration = "1"
 reqwest = { version = "0.13", default-features = false, features = ["json", "form", "rustls"] }
+base64 = "0.22"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -144,12 +144,28 @@ fn sized_avatar_url(provider: &str, url: &str) -> String {
     }
 }
 
+/// Resolve a response `Content-Type` to an image MIME, or `None` if it is not
+/// an image. This guards against a CDN answering an avatar URL with text/html
+/// or JSON (an error page, a redirect-to-login): without it we would base64
+/// non-image bytes straight into the database. A blank type on an otherwise-OK
+/// response is assumed to be PNG.
+fn image_mime(content_type: &str) -> Option<String> {
+    let mime = content_type
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase();
+    if mime.is_empty() {
+        return Some("image/png".to_string());
+    }
+    mime.starts_with("image/").then_some(mime)
+}
+
 /// Assemble a self-contained `data:` URI from image bytes so the avatar can be
 /// stored in SQLite and rendered without a network round-trip (or CSP concerns).
-fn to_data_uri(content_type: &str, bytes: &[u8]) -> String {
+fn to_data_uri(mime: &str, bytes: &[u8]) -> String {
     use base64::{engine::general_purpose::STANDARD, Engine};
-    let mime = content_type.split(';').next().unwrap_or("").trim();
-    let mime = if mime.is_empty() { "image/png" } else { mime };
     format!("data:{mime};base64,{}", STANDARD.encode(bytes))
 }
 
@@ -170,17 +186,19 @@ async fn fetch_avatar_data_uri(
     if !resp.status().is_success() {
         return None;
     }
-    let content_type = resp
-        .headers()
-        .get(reqwest::header::CONTENT_TYPE)
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("image/png")
-        .to_string();
+    // Reject non-image responses before downloading the body, so a CDN error
+    // page is never base64-encoded into the database.
+    let mime = image_mime(
+        resp.headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or(""),
+    )?;
     let bytes = resp.bytes().await.ok()?;
     if bytes.is_empty() || bytes.len() > AVATAR_MAX_BYTES {
         return None;
     }
-    Some(to_data_uri(&content_type, &bytes))
+    Some(to_data_uri(&mime, &bytes))
 }
 
 pub fn classify_token_response(v: &serde_json::Value) -> PollOutcome {
@@ -409,16 +427,25 @@ mod tests {
     }
 
     #[test]
+    fn image_mime_accepts_images_and_rejects_others() {
+        assert_eq!(image_mime("image/png").as_deref(), Some("image/png"));
+        // Strips charset params and lowercases.
+        assert_eq!(
+            image_mime("IMAGE/JPEG; charset=binary").as_deref(),
+            Some("image/jpeg")
+        );
+        // Blank type on an OK response is assumed to be an image (PNG).
+        assert_eq!(image_mime("").as_deref(), Some("image/png"));
+        // Non-image types are rejected — they must not reach the database.
+        assert_eq!(image_mime("text/html"), None);
+        assert_eq!(image_mime("application/json"), None);
+    }
+
+    #[test]
     fn builds_data_uri_from_bytes() {
         // "hi" → base64 "aGk=".
         assert_eq!(to_data_uri("image/png", b"hi"), "data:image/png;base64,aGk=");
-        // Strips charset params from the content type.
-        assert_eq!(
-            to_data_uri("image/jpeg; charset=binary", b"hi"),
-            "data:image/jpeg;base64,aGk="
-        );
-        // Falls back to image/png when the content type is blank.
-        assert_eq!(to_data_uri("", b"hi"), "data:image/png;base64,aGk=");
+        assert_eq!(to_data_uri("image/jpeg", b"hi"), "data:image/jpeg;base64,aGk=");
     }
 
     #[test]

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -121,6 +121,10 @@ const AVATAR_SIZE: u32 = 256;
 /// Refuse to cache anything larger than this — guards the DB against a rogue
 /// or mis-typed response. A 256px avatar is well under 100 KB.
 const AVATAR_MAX_BYTES: usize = 2 * 1024 * 1024;
+/// Hard cap on the avatar download. It runs *after* the user has approved the
+/// login, and is purely best-effort, so a stalled CDN must degrade to initials
+/// rather than hang `oauth_device_login` forever.
+const AVATAR_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Rewrite a provider avatar URL to request our preferred pixel size, so the
 /// bytes we download (and cache) are small. Unknown providers pass through.
@@ -157,7 +161,12 @@ async fn fetch_avatar_data_uri(
     provider: &str,
     url: &str,
 ) -> Option<String> {
-    let resp = http.get(sized_avatar_url(provider, url)).send().await.ok()?;
+    let resp = http
+        .get(sized_avatar_url(provider, url))
+        .timeout(AVATAR_TIMEOUT)
+        .send()
+        .await
+        .ok()?;
     if !resp.status().is_success() {
         return None;
     }

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -115,6 +115,65 @@ pub fn google_profile(info: &serde_json::Value) -> OAuthProfile {
     }
 }
 
+/// Pixel size we request when caching an avatar. Large enough to stay crisp on
+/// retina displays, small enough to keep the base64 blob tiny.
+const AVATAR_SIZE: u32 = 256;
+/// Refuse to cache anything larger than this — guards the DB against a rogue
+/// or mis-typed response. A 256px avatar is well under 100 KB.
+const AVATAR_MAX_BYTES: usize = 2 * 1024 * 1024;
+
+/// Rewrite a provider avatar URL to request our preferred pixel size, so the
+/// bytes we download (and cache) are small. Unknown providers pass through.
+fn sized_avatar_url(provider: &str, url: &str) -> String {
+    match provider {
+        // GitHub honours an `s=` query param.
+        "github" => {
+            let sep = if url.contains('?') { '&' } else { '?' };
+            format!("{url}{sep}s={AVATAR_SIZE}")
+        }
+        // Google photo URLs carry a trailing size directive like `=s96-c`.
+        "google" => match url.rfind("=s") {
+            Some(i) => format!("{}=s{AVATAR_SIZE}-c", &url[..i]),
+            None => format!("{url}=s{AVATAR_SIZE}-c"),
+        },
+        _ => url.to_string(),
+    }
+}
+
+/// Assemble a self-contained `data:` URI from image bytes so the avatar can be
+/// stored in SQLite and rendered without a network round-trip (or CSP concerns).
+fn to_data_uri(content_type: &str, bytes: &[u8]) -> String {
+    use base64::{engine::general_purpose::STANDARD, Engine};
+    let mime = content_type.split(';').next().unwrap_or("").trim();
+    let mime = if mime.is_empty() { "image/png" } else { mime };
+    format!("data:{mime};base64,{}", STANDARD.encode(bytes))
+}
+
+/// Download an avatar and return it as a `data:` URI. Best-effort: any failure
+/// (network, non-success status, empty/oversized body) yields `None`, and the
+/// caller falls back to initials.
+async fn fetch_avatar_data_uri(
+    http: &reqwest::Client,
+    provider: &str,
+    url: &str,
+) -> Option<String> {
+    let resp = http.get(sized_avatar_url(provider, url)).send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let content_type = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("image/png")
+        .to_string();
+    let bytes = resp.bytes().await.ok()?;
+    if bytes.is_empty() || bytes.len() > AVATAR_MAX_BYTES {
+        return None;
+    }
+    Some(to_data_uri(&content_type, &bytes))
+}
+
 pub fn classify_token_response(v: &serde_json::Value) -> PollOutcome {
     if let Some(tok) = str_field(v, "access_token") {
         return PollOutcome::Token(tok);
@@ -255,6 +314,13 @@ pub async fn oauth_device_login(
         }
         _ => return Err("unknown provider".into()),
     };
+
+    // 5. Cache the avatar as a self-contained data URI so it can be stored in
+    //    SQLite and rendered offline. On any failure we drop it (initials show).
+    let mut profile = profile;
+    if let Some(url) = profile.avatar_url.take() {
+        profile.avatar_url = fetch_avatar_data_uri(&http, &provider, &url).await;
+    }
     Ok(profile)
 }
 
@@ -298,6 +364,52 @@ mod tests {
         assert_eq!(p.provider, "google");
         assert_eq!(p.provider_user_id, "11822");
         assert_eq!(p.email.as_deref(), Some("jane@gmail.com"));
+    }
+
+    #[test]
+    fn sizes_github_avatar_url() {
+        // No existing query → add one.
+        assert_eq!(
+            sized_avatar_url("github", "https://avatars.githubusercontent.com/u/42"),
+            "https://avatars.githubusercontent.com/u/42?s=256"
+        );
+        // Existing query (e.g. ?v=4) → append.
+        assert_eq!(
+            sized_avatar_url("github", "https://avatars.githubusercontent.com/u/42?v=4"),
+            "https://avatars.githubusercontent.com/u/42?v=4&s=256"
+        );
+    }
+
+    #[test]
+    fn sizes_google_avatar_url() {
+        // Replace an existing size directive.
+        assert_eq!(
+            sized_avatar_url("google", "https://lh3.googleusercontent.com/a/ABC=s96-c"),
+            "https://lh3.googleusercontent.com/a/ABC=s256-c"
+        );
+        // Append when there is none.
+        assert_eq!(
+            sized_avatar_url("google", "https://lh3.googleusercontent.com/a/ABC"),
+            "https://lh3.googleusercontent.com/a/ABC=s256-c"
+        );
+    }
+
+    #[test]
+    fn unknown_provider_url_passes_through() {
+        assert_eq!(sized_avatar_url("other", "https://x/y.png"), "https://x/y.png");
+    }
+
+    #[test]
+    fn builds_data_uri_from_bytes() {
+        // "hi" → base64 "aGk=".
+        assert_eq!(to_data_uri("image/png", b"hi"), "data:image/png;base64,aGk=");
+        // Strips charset params from the content type.
+        assert_eq!(
+            to_data_uri("image/jpeg; charset=binary", b"hi"),
+            "data:image/jpeg;base64,aGk="
+        );
+        // Falls back to image/png when the content type is blank.
+        assert_eq!(to_data_uri("", b"hi"), "data:image/png;base64,aGk=");
     }
 
     #[test]

--- a/src/app.css
+++ b/src/app.css
@@ -506,6 +506,14 @@ button { cursor: default; }
   display: flex; align-items: center; justify-content: center;
   font-size: 10.5px; font-weight: 600;
   flex-shrink: 0;
+  overflow: hidden;
+}
+.user-avatar img,
+.set-avatar img {
+  width: 100%; height: 100%;
+  object-fit: cover;
+  border-radius: inherit;
+  display: block;
 }
 .user-info { flex: 1; min-width: 0; }
 .user-info .un { font-size: 12px; color: var(--fg-0); font-weight: 500; }
@@ -2980,6 +2988,7 @@ button { cursor: default; }
   font-size: 17px; font-weight: 600; letter-spacing: -0.02em;
   flex-shrink: 0;
   box-shadow: var(--shadow-1);
+  overflow: hidden;
 }
 .set-profile-body { flex: 1; min-width: 0; }
 .set-profile-name { font-size: 17px; font-weight: 600; color: var(--fg-0); letter-spacing: -0.015em; }

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+
+interface AvatarProps {
+  /** A `data:` URI (or URL) for the avatar image, or null for none. */
+  avatarUrl: string | null;
+  /** Shown when there is no image, or if it fails to load. */
+  initials: string;
+  /** Sizing/shape class for the wrapper (e.g. "user-avatar", "set-avatar"). */
+  className: string;
+  alt?: string;
+}
+
+/** Renders an account avatar image when available, falling back to initials.
+ *  Shared by the sidebar footer and the account settings pane so both stay in
+ *  sync. The `onError` fallback covers a malformed data URI or a stale row that
+ *  still holds an unreachable remote URL. */
+export function Avatar({ avatarUrl, initials, className, alt = "" }: AvatarProps) {
+  const [failed, setFailed] = useState(false);
+  // Re-attempt loading when the source changes (e.g. after re-login).
+  useEffect(() => setFailed(false), [avatarUrl]);
+
+  return (
+    <div className={className}>
+      {avatarUrl && !failed ? (
+        <img
+          src={avatarUrl}
+          alt={alt}
+          draggable={false}
+          onError={() => setFailed(true)}
+        />
+      ) : (
+        initials
+      )}
+    </div>
+  );
+}

--- a/src/components/SettingsScreen/AccountPane.tsx
+++ b/src/components/SettingsScreen/AccountPane.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useAppStore } from "../../store";
 import { accountInitials } from "../../util/format";
+import { Avatar } from "../Avatar";
 import { SetHead, SetGroup } from "./primitives";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -50,7 +51,12 @@ export function AccountPane() {
       <SetHead eyebrow="Settings · Account" title="Account" />
 
       <div className="set-profile">
-        <div className="set-avatar">{accountInitials(firstName, lastName, email)}</div>
+        <Avatar
+          className="set-avatar"
+          avatarUrl={account?.avatarUrl ?? null}
+          initials={accountInitials(firstName, lastName, email)}
+          alt={fullName}
+        />
         <div className="set-profile-body">
           <div className="set-profile-name">
             {fullName || <span className="set-profile-empty">Your name</span>}

--- a/src/components/Sidebar/SidebarFooter.tsx
+++ b/src/components/Sidebar/SidebarFooter.tsx
@@ -1,5 +1,6 @@
 import { Icon } from "../Icon";
 import { IconButton } from "../ui/IconButton";
+import { Avatar } from "../Avatar";
 import { useAppStore } from "../../store";
 import { accountInitials } from "../../util/format";
 
@@ -24,7 +25,12 @@ export function SidebarFooter() {
         onClick={() => openSettingsScreen("account")}
         aria-label="Account settings"
       >
-        <div className="user-avatar">{initial}</div>
+        <Avatar
+          className="user-avatar"
+          avatarUrl={account?.avatarUrl ?? null}
+          initials={initial}
+          alt={name}
+        />
         <div className="user-info">
           <div className="un">{name}</div>
           <div className="ue">{sub}</div>


### PR DESCRIPTION
During GitHub/Google device-flow login, the avatar is now downloaded server-side at 256px, encoded as a self-contained `data:` URI, and persisted in the existing `accounts.avatar_url` column (no schema change, no CSP exposure). A new reusable `Avatar` component renders the cached image in both the sidebar footer and the account settings pane, falling back to initials when there's no avatar or the image fails to load. The download is best-effort — any network/oversize failure drops to initials. Added the `base64` crate and unit tests for the URL-sizing and data-URI logic; existing accounts upgrade their stored avatar on next login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)