### PR TITLE
feat(run-panel): auto-detect run config across Node/Python/Ruby/Rust/Go

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -485,6 +485,17 @@ pub fn run_state(
     Ok(supervisor.run_state(&agent_id))
 }
 
+/// Detect the run configuration for an agent's primary repo, ranked by
+/// confidence. The panel renders the first entry and layers persisted
+/// overrides on top.
+#[tauri::command]
+pub fn detect_run_config(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+) -> Result<Vec<crate::run_detect::DetectedConfig>> {
+    supervisor.detect_run_config(&agent_id)
+}
+
 /// Returns git state for the agent's primary repo.
 /// For multi-repo agents only the first repo's state is returned.
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ mod managed_session;
 mod names;
 mod oauth;
 mod pty_session;
+mod run_detect;
 mod run_session;
 mod sandbox;
 mod supervisor;
@@ -182,6 +183,7 @@ pub fn run() {
             commands::run_start,
             commands::run_stop,
             commands::run_state,
+            commands::detect_run_config,
             commands::list_worktree_tree,
             commands::read_worktree_file,
             commands::get_file_diff,

--- a/src-tauri/src/run_detect/go.rs
+++ b/src-tauri/src/run_detect/go.rs
@@ -1,0 +1,93 @@
+//! Go detector.
+
+use super::{
+    exists, read_trimmed, DetectedConfig, DetectedRow, RowGroup, RunDetector,
+    CONFIDENCE_LOCKFILE, CONFIDENCE_MANIFEST,
+};
+use std::path::Path;
+
+pub struct GoDetector;
+
+impl RunDetector for GoDetector {
+    fn detect(&self, worktree: &Path) -> Option<DetectedConfig> {
+        let go_mod = read_trimmed(worktree, "go.mod")?;
+        let confidence = if exists(worktree, "go.sum") {
+            CONFIDENCE_LOCKFILE
+        } else {
+            CONFIDENCE_MANIFEST
+        };
+
+        let mut rows = Vec::new();
+
+        // version: the `go X.Y` directive in go.mod.
+        if let Some(version) = go_mod.lines().find_map(|l| {
+            let l = l.trim();
+            l.strip_prefix("go ")
+                .map(|v| v.trim().to_string())
+                .filter(|v| !v.is_empty())
+        }) {
+            rows.push(DetectedRow::new(
+                "version",
+                RowGroup::Environment,
+                "Go version",
+                version,
+                "go.mod · go directive",
+            ));
+        }
+
+        rows.push(DetectedRow::new("install", RowGroup::Scripts, "Install", "go mod download", "convention"));
+        rows.push(DetectedRow::new("dev", RowGroup::Scripts, "Run", "go run .", "convention"));
+        rows.push(DetectedRow::new("build", RowGroup::Scripts, "Build", "go build ./...", "convention"));
+        rows.push(DetectedRow::new("test", RowGroup::Scripts, "Test", "go test ./...", "convention"));
+
+        Some(DetectedConfig {
+            ecosystem: "go".to_string(),
+            confidence,
+            rows,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{fixture, val};
+    use super::super::CONFIDENCE_LOCKFILE;
+    use super::*;
+
+    fn detect(files: &[(&str, &str)]) -> Option<DetectedConfig> {
+        GoDetector.detect(fixture(files).path())
+    }
+
+    #[test]
+    fn no_go_mod_is_none() {
+        assert!(detect(&[("package.json", "{}")]).is_none());
+    }
+
+    #[test]
+    fn go_sum_yields_high_confidence() {
+        let cfg = detect(&[("go.mod", "module x\n"), ("go.sum", "")]).unwrap();
+        assert_eq!(cfg.ecosystem, "go");
+        assert_eq!(cfg.confidence, CONFIDENCE_LOCKFILE);
+    }
+
+    #[test]
+    fn standard_go_commands() {
+        let cfg = detect(&[("go.mod", "module x\n")]).unwrap();
+        assert_eq!(val(&cfg, "install"), "go mod download");
+        assert_eq!(val(&cfg, "dev"), "go run .");
+        assert_eq!(val(&cfg, "build"), "go build ./...");
+        assert_eq!(val(&cfg, "test"), "go test ./...");
+    }
+
+    #[test]
+    fn go_directive_drives_version() {
+        let cfg = detect(&[("go.mod", "module x\n\ngo 1.22\n")]).unwrap();
+        assert_eq!(val(&cfg, "version"), "1.22");
+    }
+
+    #[test]
+    fn no_go_directive_omits_version() {
+        let cfg = detect(&[("go.mod", "module x\n")]).unwrap();
+        assert!(cfg.rows.iter().all(|r| r.id != "version"));
+    }
+}

--- a/src-tauri/src/run_detect/mod.rs
+++ b/src-tauri/src/run_detect/mod.rs
@@ -1,0 +1,185 @@
+//! Multi-language run-config detection.
+//!
+//! Each ecosystem has a [`RunDetector`] that reads a few files at a
+//! worktree root and, if it recognizes the project, returns a
+//! [`DetectedConfig`] with a confidence score. [`detect_all`] runs every
+//! detector and returns the surviving configs ranked by confidence.
+//!
+//! Detectors are pure (`&Path -> Option<DetectedConfig>`) so they can be
+//! unit-tested against fixture directories with no Tauri/DB setup.
+//!
+//! The rows map onto the panel's hybrid schema: the core rows
+//! (`version`, `install`, `dev`, `test`, `build`) are attempted for every
+//! ecosystem; the optional rows (`port`, `env`) are emitted only when
+//! detected. Rows a detector can't fill are simply omitted.
+
+use serde::Serialize;
+use std::path::Path;
+
+mod go;
+mod node;
+mod port;
+mod python;
+mod ruby;
+mod rust;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RowGroup {
+    Environment,
+    Scripts,
+    Server,
+}
+
+/// A single configuration row the panel renders.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DetectedRow {
+    /// Stable id matching the panel's override-key scheme
+    /// (`version` | `install` | `dev` | `test` | `build` | `port` | `env`).
+    pub id: String,
+    pub group: RowGroup,
+    /// Human label, e.g. "Node version", "Toolchain".
+    pub key: String,
+    /// Detected value, e.g. "v22.4.0", "cargo run".
+    pub value: String,
+    /// Where the value came from, e.g. ".nvmrc", "package.json · scripts.dev".
+    pub source: String,
+}
+
+impl DetectedRow {
+    fn new(
+        id: &str,
+        group: RowGroup,
+        key: &str,
+        value: impl Into<String>,
+        source: &str,
+    ) -> Self {
+        Self {
+            id: id.to_string(),
+            group,
+            key: key.to_string(),
+            value: value.into(),
+            source: source.to_string(),
+        }
+    }
+}
+
+/// One ecosystem's worth of detected configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DetectedConfig {
+    /// "node" | "python" | "ruby" | "rust" | "go".
+    pub ecosystem: String,
+    /// 0–100. Lockfile present → high; manifest only → medium;
+    /// bare source files → low.
+    pub confidence: u8,
+    pub rows: Vec<DetectedRow>,
+}
+
+/// Confidence tiers. A lockfile is strong evidence the project is both
+/// real and uses a known toolchain; a bare manifest is weaker; loose
+/// source files weakest.
+const CONFIDENCE_LOCKFILE: u8 = 90;
+const CONFIDENCE_MANIFEST: u8 = 60;
+
+pub trait RunDetector {
+    fn detect(&self, worktree: &Path) -> Option<DetectedConfig>;
+}
+
+fn detectors() -> Vec<Box<dyn RunDetector>> {
+    vec![
+        Box::new(node::NodeDetector),
+        Box::new(python::PythonDetector),
+        Box::new(ruby::RubyDetector),
+        Box::new(rust::RustDetector),
+        Box::new(go::GoDetector),
+    ]
+}
+
+/// Run every detector over `worktree` and return the recognized configs
+/// ranked by confidence (highest first). Empty when nothing matched —
+/// callers treat that as the no-op fallback.
+pub fn detect_all(worktree: &Path) -> Vec<DetectedConfig> {
+    let mut configs: Vec<DetectedConfig> = detectors()
+        .iter()
+        .filter_map(|d| d.detect(worktree))
+        .collect();
+    // Stable sort by confidence desc so ties keep detector registration
+    // order (node before python before … — a deterministic primary).
+    configs.sort_by(|a, b| b.confidence.cmp(&a.confidence));
+    configs
+}
+
+// ── shared file helpers ──────────────────────────────────────────────────────
+
+/// Read a file at `worktree/name`, trimmed. None if absent/unreadable.
+fn read_trimmed(worktree: &Path, name: &str) -> Option<String> {
+    std::fs::read_to_string(worktree.join(name))
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn exists(worktree: &Path, name: &str) -> bool {
+    worktree.join(name).exists()
+}
+
+/// Shared fixture/assertion helpers for the per-detector test modules.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::{DetectedConfig, DetectedRow};
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Build a fixture dir from (relative path, contents) pairs.
+    pub(crate) fn fixture(files: &[(&str, &str)]) -> TempDir {
+        let dir = TempDir::new().unwrap();
+        for (path, contents) in files {
+            let full = dir.path().join(path);
+            if let Some(parent) = full.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(full, contents).unwrap();
+        }
+        dir
+    }
+
+    pub(crate) fn row<'a>(cfg: &'a DetectedConfig, id: &str) -> Option<&'a DetectedRow> {
+        cfg.rows.iter().find(|r| r.id == id)
+    }
+
+    pub(crate) fn val(cfg: &DetectedConfig, id: &str) -> String {
+        row(cfg, id).map(|r| r.value.clone()).unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::fixture;
+    use super::*;
+
+    // ── empty / fallback ──────────────────────────────────────────────────
+
+    #[test]
+    fn empty_dir_detects_nothing() {
+        let dir = fixture(&[]);
+        assert!(detect_all(dir.path()).is_empty());
+    }
+
+    // ── ranking / polyglot ────────────────────────────────────────────────
+
+    #[test]
+    fn node_root_outranks_rust_subdir() {
+        // This repo's own shape: Node at root, Rust under src-tauri/.
+        // Detection runs at the worktree root, so only the root Node
+        // project is seen — but even a root Cargo.toml must lose to the
+        // root lockfile-backed Node project.
+        let dir = fixture(&[
+            ("package.json", r#"{"scripts":{"dev":"vite"}}"#),
+            ("pnpm-lock.yaml", ""),
+            ("Cargo.toml", "[package]\nname = \"x\"\n"),
+        ]);
+        let configs = detect_all(dir.path());
+        assert_eq!(configs[0].ecosystem, "node");
+        assert!(configs[0].confidence > configs[1].confidence);
+    }
+}

--- a/src-tauri/src/run_detect/node.rs
+++ b/src-tauri/src/run_detect/node.rs
@@ -9,11 +9,13 @@ use std::path::Path;
 
 pub struct NodeDetector;
 
-/// (lockfile name, package-manager name) in priority order.
+/// (lockfile name, package-manager name) in priority order. Bun has two
+/// forms: the binary `bun.lockb` and, since Bun 1.2, a text `bun.lock`.
 const LOCKFILES: &[(&str, &str)] = &[
     ("pnpm-lock.yaml", "pnpm"),
     ("yarn.lock", "yarn"),
     ("package-lock.json", "npm"),
+    ("bun.lock", "bun"),
     ("bun.lockb", "bun"),
 ];
 
@@ -199,6 +201,14 @@ mod tests {
         )])
         .unwrap();
         assert_eq!(val(&cfg, "install"), "pnpm install");
+    }
+
+    #[test]
+    fn bun_text_lockfile_yields_high_confidence() {
+        // Bun >= 1.2 writes a text-format `bun.lock`, not `bun.lockb`.
+        let cfg = detect(&[("package.json", "{}"), ("bun.lock", "")]).unwrap();
+        assert_eq!(cfg.confidence, CONFIDENCE_LOCKFILE);
+        assert_eq!(val(&cfg, "install"), "bun install");
     }
 
     #[test]

--- a/src-tauri/src/run_detect/node.rs
+++ b/src-tauri/src/run_detect/node.rs
@@ -1,0 +1,300 @@
+//! Node / JavaScript / TypeScript detector.
+
+use super::port::detect_port;
+use super::{
+    exists, read_trimmed, DetectedConfig, DetectedRow, RowGroup, RunDetector,
+    CONFIDENCE_LOCKFILE, CONFIDENCE_MANIFEST,
+};
+use std::path::Path;
+
+pub struct NodeDetector;
+
+/// (lockfile name, package-manager name) in priority order.
+const LOCKFILES: &[(&str, &str)] = &[
+    ("pnpm-lock.yaml", "pnpm"),
+    ("yarn.lock", "yarn"),
+    ("package-lock.json", "npm"),
+    ("bun.lockb", "bun"),
+];
+
+impl RunDetector for NodeDetector {
+    fn detect(&self, worktree: &Path) -> Option<DetectedConfig> {
+        let raw = read_trimmed(worktree, "package.json")?;
+        let pkg: serde_json::Value = serde_json::from_str(&raw).ok()?;
+
+        // Package manager: `packageManager` field → lockfile → npm.
+        let lockfile = LOCKFILES.iter().find(|(f, _)| exists(worktree, f));
+        let pm = pkg
+            .get("packageManager")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.split('@').next())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .or_else(|| lockfile.map(|(_, pm)| pm.to_string()))
+            .unwrap_or_else(|| "npm".to_string());
+
+        let confidence = if lockfile.is_some() {
+            CONFIDENCE_LOCKFILE
+        } else {
+            CONFIDENCE_MANIFEST
+        };
+
+        let mut rows = Vec::new();
+
+        // version: .nvmrc → .node-version → engines.node.
+        if let Some((value, source)) = read_trimmed(worktree, ".nvmrc")
+            .map(|v| (v, ".nvmrc"))
+            .or_else(|| read_trimmed(worktree, ".node-version").map(|v| (v, ".node-version")))
+            .or_else(|| {
+                pkg.get("engines")
+                    .and_then(|e| e.get("node"))
+                    .and_then(|v| v.as_str())
+                    .map(|v| (v.to_string(), "package.json · engines.node"))
+            })
+        {
+            rows.push(DetectedRow::new(
+                "version",
+                RowGroup::Environment,
+                "Node version",
+                value,
+                source,
+            ));
+        }
+
+        // install — always available once a package manager is known.
+        rows.push(DetectedRow::new(
+            "install",
+            RowGroup::Scripts,
+            "Install",
+            format!("{pm} install"),
+            "package manager",
+        ));
+
+        let scripts = pkg.get("scripts");
+        let script = |name: &str| -> Option<&str> {
+            scripts.and_then(|s| s.get(name)).and_then(|v| v.as_str())
+        };
+
+        // dev: scripts.dev → scripts.start.
+        let dev_value = if script("dev").is_some() {
+            Some(("dev", format!("{pm} dev")))
+        } else if script("start").is_some() {
+            Some(("start", format!("{pm} start")))
+        } else {
+            None
+        };
+        if let Some((script_name, value)) = &dev_value {
+            rows.push(DetectedRow::new(
+                "dev",
+                RowGroup::Scripts,
+                "Dev",
+                value.clone(),
+                &format!("package.json · scripts.{script_name}"),
+            ));
+        }
+
+        if script("build").is_some() {
+            rows.push(DetectedRow::new(
+                "build",
+                RowGroup::Scripts,
+                "Build",
+                format!("{pm} build"),
+                "package.json · scripts.build",
+            ));
+        }
+        if script("test").is_some() {
+            rows.push(DetectedRow::new(
+                "test",
+                RowGroup::Scripts,
+                "Test",
+                format!("{pm} test"),
+                "package.json · scripts.test",
+            ));
+        }
+
+        // port (optional): scan the resolved dev command + framework deps.
+        let deps = dependency_names(&pkg);
+        let dev_cmd = dev_value
+            .as_ref()
+            .and_then(|(name, _)| script(name))
+            .unwrap_or("");
+        if let Some((port, source)) = detect_port(dev_cmd, &deps) {
+            rows.push(DetectedRow::new(
+                "port",
+                RowGroup::Server,
+                "Port",
+                port.to_string(),
+                &source,
+            ));
+        }
+
+        // env (optional): .env.local → .env.
+        if let Some(file) = [".env.local", ".env"].iter().find(|f| exists(worktree, f)) {
+            rows.push(DetectedRow::new(
+                "env",
+                RowGroup::Server,
+                "Env file",
+                *file,
+                "present in worktree",
+            ));
+        }
+
+        Some(DetectedConfig {
+            ecosystem: "node".to_string(),
+            confidence,
+            rows,
+        })
+    }
+}
+
+/// Collect lowercased dependency names from `dependencies` and
+/// `devDependencies` for framework/port heuristics.
+fn dependency_names(pkg: &serde_json::Value) -> Vec<String> {
+    let mut names = Vec::new();
+    for field in ["dependencies", "devDependencies"] {
+        if let Some(map) = pkg.get(field).and_then(|v| v.as_object()) {
+            names.extend(map.keys().map(|k| k.to_lowercase()));
+        }
+    }
+    names
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{fixture, val};
+    use super::*;
+
+    fn detect(files: &[(&str, &str)]) -> Option<DetectedConfig> {
+        let dir = fixture(files);
+        NodeDetector.detect(dir.path())
+    }
+
+    #[test]
+    fn no_package_json_is_none() {
+        assert!(detect(&[("Cargo.toml", "")]).is_none());
+    }
+
+    #[test]
+    fn lockfile_yields_high_confidence() {
+        let cfg = detect(&[
+            ("package.json", r#"{"scripts":{"dev":"vite"}}"#),
+            ("pnpm-lock.yaml", ""),
+        ])
+        .unwrap();
+        assert_eq!(cfg.ecosystem, "node");
+        assert_eq!(cfg.confidence, CONFIDENCE_LOCKFILE);
+    }
+
+    #[test]
+    fn manifest_only_is_medium_confidence() {
+        let cfg = detect(&[("package.json", "{}")]).unwrap();
+        assert_eq!(cfg.confidence, CONFIDENCE_MANIFEST);
+    }
+
+    #[test]
+    fn package_manager_field_drives_install_command() {
+        let cfg = detect(&[(
+            "package.json",
+            r#"{"packageManager":"pnpm@9.7.1","scripts":{"dev":"x"}}"#,
+        )])
+        .unwrap();
+        assert_eq!(val(&cfg, "install"), "pnpm install");
+    }
+
+    #[test]
+    fn lockfile_drives_pm_when_no_field() {
+        let cfg = detect(&[
+            ("package.json", "{}"),
+            ("yarn.lock", ""),
+        ])
+        .unwrap();
+        assert_eq!(val(&cfg, "install"), "yarn install");
+    }
+
+    #[test]
+    fn defaults_to_npm() {
+        let cfg = detect(&[("package.json", "{}")]).unwrap();
+        assert_eq!(val(&cfg, "install"), "npm install");
+    }
+
+    #[test]
+    fn scripts_become_rows() {
+        let cfg = detect(&[(
+            "package.json",
+            r#"{"packageManager":"pnpm@9","scripts":{"dev":"next dev","build":"next build","test":"vitest"}}"#,
+        )])
+        .unwrap();
+        assert_eq!(val(&cfg, "dev"), "pnpm dev");
+        assert_eq!(val(&cfg, "build"), "pnpm build");
+        assert_eq!(val(&cfg, "test"), "pnpm test");
+    }
+
+    #[test]
+    fn dev_falls_back_to_start_script() {
+        let cfg = detect(&[(
+            "package.json",
+            r#"{"scripts":{"start":"node server.js"}}"#,
+        )])
+        .unwrap();
+        assert_eq!(val(&cfg, "dev"), "npm start");
+    }
+
+    #[test]
+    fn missing_scripts_are_omitted() {
+        let cfg = detect(&[("package.json", r#"{"scripts":{"dev":"x"}}"#)]).unwrap();
+        assert!(cfg.rows.iter().all(|r| r.id != "build"));
+        assert!(cfg.rows.iter().all(|r| r.id != "test"));
+    }
+
+    #[test]
+    fn nvmrc_yields_version() {
+        let cfg = detect(&[
+            ("package.json", "{}"),
+            (".nvmrc", "v22.4.0\n"),
+        ])
+        .unwrap();
+        assert_eq!(val(&cfg, "version"), "v22.4.0");
+    }
+
+    #[test]
+    fn engines_node_is_version_fallback() {
+        let cfg = detect(&[("package.json", r#"{"engines":{"node":">=20"}}"#)]).unwrap();
+        assert_eq!(val(&cfg, "version"), ">=20");
+    }
+
+    #[test]
+    fn no_version_source_omits_version_row() {
+        let cfg = detect(&[("package.json", "{}")]).unwrap();
+        assert!(cfg.rows.iter().all(|r| r.id != "version"));
+    }
+
+    #[test]
+    fn env_local_emits_env_row() {
+        let cfg = detect(&[
+            ("package.json", "{}"),
+            (".env.local", "X=1"),
+        ])
+        .unwrap();
+        assert_eq!(val(&cfg, "env"), ".env.local");
+    }
+
+    #[test]
+    fn vite_dep_yields_default_port() {
+        let cfg = detect(&[(
+            "package.json",
+            r#"{"scripts":{"dev":"vite"},"devDependencies":{"vite":"^5"}}"#,
+        )])
+        .unwrap();
+        assert_eq!(val(&cfg, "port"), "5173");
+    }
+
+    #[test]
+    fn explicit_port_flag_wins() {
+        let cfg = detect(&[(
+            "package.json",
+            r#"{"scripts":{"dev":"vite --port 4000"},"devDependencies":{"vite":"^5"}}"#,
+        )])
+        .unwrap();
+        assert_eq!(val(&cfg, "port"), "4000");
+    }
+}

--- a/src-tauri/src/run_detect/port.rs
+++ b/src-tauri/src/run_detect/port.rs
@@ -1,0 +1,131 @@
+//! Port detection: scan the resolved dev/run command for an explicit
+//! port token, else fall back to a framework-default table. No config
+//! file parsing.
+
+/// Detect a port for `dev_cmd`, given the set of dependency names present
+/// in the project (lowercased). Returns `(port, source)` or None when no
+/// port can be inferred (e.g. Rust/Go/plain scripts).
+pub fn detect_port(dev_cmd: &str, deps: &[String]) -> Option<(u16, String)> {
+    if let Some(p) = explicit_port(dev_cmd) {
+        return Some((p, "dev command".to_string()));
+    }
+    framework_default(deps).map(|(p, fw)| (p, format!("default ({fw})")))
+}
+
+/// Scan a command string for an explicit port token in any of the common
+/// forms: `--port 3001`, `--port=3001`, `-p 3001`, `PORT=3001`, `:3001`.
+fn explicit_port(cmd: &str) -> Option<u16> {
+    let tokens: Vec<&str> = cmd.split_whitespace().collect();
+    for (i, tok) in tokens.iter().enumerate() {
+        // --port=N / -p=N / PORT=N
+        if let Some(rest) = tok
+            .strip_prefix("--port=")
+            .or_else(|| tok.strip_prefix("-p="))
+            .or_else(|| tok.strip_prefix("PORT="))
+        {
+            if let Ok(p) = rest.parse() {
+                return Some(p);
+            }
+        }
+        // --port N / -p N (value in the next token)
+        if (*tok == "--port" || *tok == "-p") && i + 1 < tokens.len() {
+            if let Ok(p) = tokens[i + 1].parse() {
+                return Some(p);
+            }
+        }
+        // bare :N (e.g. "serve :8080")
+        if let Some(rest) = tok.strip_prefix(':') {
+            if let Ok(p) = rest.parse() {
+                return Some(p);
+            }
+        }
+    }
+    None
+}
+
+/// Map a known framework dependency to its conventional dev-server port.
+/// First match wins; order matters where defaults overlap.
+fn framework_default(deps: &[String]) -> Option<(u16, &'static str)> {
+    const TABLE: &[(&str, u16, &str)] = &[
+        ("next", 3000, "Next.js"),
+        ("nuxt", 3000, "Nuxt"),
+        ("@remix-run/dev", 3000, "Remix"),
+        ("astro", 4321, "Astro"),
+        ("vite", 5173, "Vite"),
+        ("react-scripts", 3000, "CRA"),
+        ("@angular/core", 4200, "Angular"),
+        ("vue-cli-service", 8080, "Vue CLI"),
+        ("django", 8000, "Django"),
+        ("flask", 5000, "Flask"),
+        ("rails", 3000, "Rails"),
+    ];
+    for (name, port, label) in TABLE {
+        if deps.iter().any(|d| d == name) {
+            return Some((*port, label));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn deps(names: &[&str]) -> Vec<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn explicit_flag_space_separated() {
+        assert_eq!(detect_port("vite --port 4000", &[]).unwrap().0, 4000);
+    }
+
+    #[test]
+    fn explicit_flag_equals() {
+        assert_eq!(detect_port("vite --port=4001", &[]).unwrap().0, 4001);
+    }
+
+    #[test]
+    fn explicit_short_flag() {
+        assert_eq!(detect_port("next dev -p 4002", &[]).unwrap().0, 4002);
+    }
+
+    #[test]
+    fn explicit_env_assignment() {
+        assert_eq!(detect_port("PORT=4003 node server.js", &[]).unwrap().0, 4003);
+    }
+
+    #[test]
+    fn explicit_colon_form() {
+        assert_eq!(detect_port("serve :8081", &[]).unwrap().0, 8081);
+    }
+
+    #[test]
+    fn explicit_beats_framework_default() {
+        let (port, source) = detect_port("vite --port 9000", &deps(&["vite"])).unwrap();
+        assert_eq!(port, 9000);
+        assert_eq!(source, "dev command");
+    }
+
+    #[test]
+    fn framework_default_when_no_flag() {
+        let (port, source) = detect_port("vite", &deps(&["vite"])).unwrap();
+        assert_eq!(port, 5173);
+        assert_eq!(source, "default (Vite)");
+    }
+
+    #[test]
+    fn next_default_is_3000() {
+        assert_eq!(detect_port("next dev", &deps(&["next"])).unwrap().0, 3000);
+    }
+
+    #[test]
+    fn unknown_framework_no_flag_is_none() {
+        assert!(detect_port("node server.js", &deps(&["express"])).is_none());
+    }
+
+    #[test]
+    fn empty_is_none() {
+        assert!(detect_port("", &[]).is_none());
+    }
+}

--- a/src-tauri/src/run_detect/port.rs
+++ b/src-tauri/src/run_detect/port.rs
@@ -45,6 +45,11 @@ fn explicit_port(cmd: &str) -> Option<u16> {
 
 /// Map a known framework dependency to its conventional dev-server port.
 /// First match wins; order matters where defaults overlap.
+///
+/// `detect_port` is currently called only by the Node detector, whose
+/// `deps` are npm package names — so this table lists only JS frameworks.
+/// Python/Ruby frameworks (Django, Flask, Rails) set their ports directly
+/// in their own detectors; adding them here would be unreachable.
 fn framework_default(deps: &[String]) -> Option<(u16, &'static str)> {
     const TABLE: &[(&str, u16, &str)] = &[
         ("next", 3000, "Next.js"),
@@ -55,9 +60,6 @@ fn framework_default(deps: &[String]) -> Option<(u16, &'static str)> {
         ("react-scripts", 3000, "CRA"),
         ("@angular/core", 4200, "Angular"),
         ("vue-cli-service", 8080, "Vue CLI"),
-        ("django", 8000, "Django"),
-        ("flask", 5000, "Flask"),
-        ("rails", 3000, "Rails"),
     ];
     for (name, port, label) in TABLE {
         if deps.iter().any(|d| d == name) {

--- a/src-tauri/src/run_detect/python.rs
+++ b/src-tauri/src/run_detect/python.rs
@@ -1,0 +1,188 @@
+//! Python detector.
+
+use super::{
+    exists, read_trimmed, DetectedConfig, DetectedRow, RowGroup, RunDetector,
+    CONFIDENCE_LOCKFILE, CONFIDENCE_MANIFEST,
+};
+use std::path::Path;
+
+pub struct PythonDetector;
+
+impl RunDetector for PythonDetector {
+    fn detect(&self, worktree: &Path) -> Option<DetectedConfig> {
+        let has_pyproject = exists(worktree, "pyproject.toml");
+        let has_requirements = exists(worktree, "requirements.txt");
+        let has_pipfile = exists(worktree, "Pipfile");
+        if !(has_pyproject || has_requirements || has_pipfile) {
+            return None;
+        }
+
+        // install command + confidence keyed off the lockfile/manifest mix.
+        let (install, lock_present) = if exists(worktree, "uv.lock") {
+            ("uv sync", true)
+        } else if exists(worktree, "poetry.lock") {
+            ("poetry install", true)
+        } else if has_pipfile {
+            ("pipenv install", exists(worktree, "Pipfile.lock"))
+        } else if has_requirements {
+            ("pip install -r requirements.txt", false)
+        } else {
+            ("pip install .", false)
+        };
+        let confidence = if lock_present {
+            CONFIDENCE_LOCKFILE
+        } else {
+            CONFIDENCE_MANIFEST
+        };
+
+        // Combined lowercased dependency text for framework heuristics.
+        let deps_text = ["requirements.txt", "pyproject.toml", "Pipfile"]
+            .iter()
+            .filter_map(|f| read_trimmed(worktree, f))
+            .collect::<Vec<_>>()
+            .join("\n")
+            .to_lowercase();
+        let has_dep = |name: &str| deps_text.contains(name);
+
+        let mut rows = Vec::new();
+
+        // version: .python-version → pyproject requires-python.
+        if let Some((value, source)) = read_trimmed(worktree, ".python-version")
+            .map(|v| (v, ".python-version"))
+            .or_else(|| {
+                read_trimmed(worktree, "pyproject.toml")
+                    .and_then(|s| requires_python(&s))
+                    .map(|v| (v, "pyproject.toml · requires-python"))
+            })
+        {
+            rows.push(DetectedRow::new(
+                "version",
+                RowGroup::Environment,
+                "Python version",
+                value,
+                source,
+            ));
+        }
+
+        rows.push(DetectedRow::new("install", RowGroup::Scripts, "Install", install, "convention"));
+
+        // dev + port: Django (needs manage.py) → runserver:8000; Flask → 5000.
+        if exists(worktree, "manage.py") && has_dep("django") {
+            rows.push(DetectedRow::new("dev", RowGroup::Scripts, "Run", "python manage.py runserver", "Django"));
+            rows.push(DetectedRow::new("port", RowGroup::Server, "Port", "8000", "default (Django)"));
+        } else if has_dep("flask") {
+            rows.push(DetectedRow::new("dev", RowGroup::Scripts, "Run", "flask run", "Flask"));
+            rows.push(DetectedRow::new("port", RowGroup::Server, "Port", "5000", "default (Flask)"));
+        }
+
+        if has_dep("pytest") {
+            rows.push(DetectedRow::new("test", RowGroup::Scripts, "Test", "pytest", "pytest dependency"));
+        }
+
+        Some(DetectedConfig {
+            ecosystem: "python".to_string(),
+            confidence,
+            rows,
+        })
+    }
+}
+
+/// Extract `requires-python = "..."` from pyproject.toml text.
+fn requires_python(toml: &str) -> Option<String> {
+    toml.lines().find_map(|l| {
+        let l = l.trim();
+        l.strip_prefix("requires-python")
+            .and_then(|r| r.trim_start().strip_prefix('='))
+            .map(|v| v.trim().trim_matches('"').to_string())
+            .filter(|v| !v.is_empty())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{fixture, val};
+    use super::super::{CONFIDENCE_LOCKFILE, CONFIDENCE_MANIFEST};
+    use super::*;
+
+    fn detect(files: &[(&str, &str)]) -> Option<DetectedConfig> {
+        PythonDetector.detect(fixture(files).path())
+    }
+
+    #[test]
+    fn no_python_markers_is_none() {
+        assert!(detect(&[("package.json", "{}")]).is_none());
+    }
+
+    #[test]
+    fn requirements_txt_triggers_pip_install() {
+        let cfg = detect(&[("requirements.txt", "flask\n")]).unwrap();
+        assert_eq!(cfg.ecosystem, "python");
+        assert_eq!(val(&cfg, "install"), "pip install -r requirements.txt");
+        assert_eq!(cfg.confidence, CONFIDENCE_MANIFEST);
+    }
+
+    #[test]
+    fn uv_lock_yields_uv_sync_and_high_confidence() {
+        let cfg = detect(&[("pyproject.toml", "[project]\n"), ("uv.lock", "")]).unwrap();
+        assert_eq!(val(&cfg, "install"), "uv sync");
+        assert_eq!(cfg.confidence, CONFIDENCE_LOCKFILE);
+    }
+
+    #[test]
+    fn poetry_lock_yields_poetry_install() {
+        let cfg = detect(&[("pyproject.toml", "[tool.poetry]\n"), ("poetry.lock", "")]).unwrap();
+        assert_eq!(val(&cfg, "install"), "poetry install");
+    }
+
+    #[test]
+    fn pipfile_yields_pipenv_install() {
+        let cfg = detect(&[("Pipfile", "[packages]\n")]).unwrap();
+        assert_eq!(val(&cfg, "install"), "pipenv install");
+    }
+
+    #[test]
+    fn python_version_file() {
+        let cfg = detect(&[("requirements.txt", ""), (".python-version", "3.12.1\n")]).unwrap();
+        assert_eq!(val(&cfg, "version"), "3.12.1");
+    }
+
+    #[test]
+    fn requires_python_fallback() {
+        let cfg = detect(&[(
+            "pyproject.toml",
+            "[project]\nrequires-python = \">=3.11\"\n",
+        )])
+        .unwrap();
+        assert_eq!(val(&cfg, "version"), ">=3.11");
+    }
+
+    #[test]
+    fn django_dev_and_port() {
+        let cfg = detect(&[
+            ("requirements.txt", "Django==5.0\n"),
+            ("manage.py", ""),
+        ])
+        .unwrap();
+        assert_eq!(val(&cfg, "dev"), "python manage.py runserver");
+        assert_eq!(val(&cfg, "port"), "8000");
+    }
+
+    #[test]
+    fn flask_dev_and_port() {
+        let cfg = detect(&[("requirements.txt", "flask\n")]).unwrap();
+        assert_eq!(val(&cfg, "dev"), "flask run");
+        assert_eq!(val(&cfg, "port"), "5000");
+    }
+
+    #[test]
+    fn pytest_test_row() {
+        let cfg = detect(&[("requirements.txt", "pytest\n")]).unwrap();
+        assert_eq!(val(&cfg, "test"), "pytest");
+    }
+
+    #[test]
+    fn plain_script_has_no_port() {
+        let cfg = detect(&[("requirements.txt", "requests\n")]).unwrap();
+        assert!(cfg.rows.iter().all(|r| r.id != "port"));
+    }
+}

--- a/src-tauri/src/run_detect/ruby.rs
+++ b/src-tauri/src/run_detect/ruby.rs
@@ -1,0 +1,128 @@
+//! Ruby detector.
+
+use super::{
+    exists, read_trimmed, DetectedConfig, DetectedRow, RowGroup, RunDetector,
+    CONFIDENCE_LOCKFILE, CONFIDENCE_MANIFEST,
+};
+use std::path::Path;
+
+pub struct RubyDetector;
+
+impl RunDetector for RubyDetector {
+    fn detect(&self, worktree: &Path) -> Option<DetectedConfig> {
+        let gemfile = read_trimmed(worktree, "Gemfile")?;
+        let confidence = if exists(worktree, "Gemfile.lock") {
+            CONFIDENCE_LOCKFILE
+        } else {
+            CONFIDENCE_MANIFEST
+        };
+        let gems = gemfile.to_lowercase();
+        let has_gem = |name: &str| gems.contains(&format!("'{name}'")) || gems.contains(&format!("\"{name}\""));
+        let is_rails = has_gem("rails");
+
+        let mut rows = Vec::new();
+
+        // version: .ruby-version → `ruby "x"` line in the Gemfile.
+        if let Some(version) = read_trimmed(worktree, ".ruby-version").or_else(|| {
+            gemfile.lines().find_map(|l| {
+                let l = l.trim();
+                l.strip_prefix("ruby ")
+                    .map(|v| v.trim().trim_matches(['"', '\'']).to_string())
+                    .filter(|v| !v.is_empty())
+            })
+        }) {
+            rows.push(DetectedRow::new(
+                "version",
+                RowGroup::Environment,
+                "Ruby version",
+                version,
+                ".ruby-version",
+            ));
+        }
+
+        rows.push(DetectedRow::new("install", RowGroup::Scripts, "Install", "bundle install", "convention"));
+
+        if is_rails {
+            rows.push(DetectedRow::new("dev", RowGroup::Scripts, "Run", "bin/rails server", "Rails"));
+        }
+
+        // test: rspec if present, else rake.
+        let test_cmd = if has_gem("rspec") || has_gem("rspec-rails") {
+            "bundle exec rspec"
+        } else {
+            "bundle exec rake test"
+        };
+        rows.push(DetectedRow::new("test", RowGroup::Scripts, "Test", test_cmd, "convention"));
+
+        // port (optional): Rails conventional dev port.
+        if is_rails {
+            rows.push(DetectedRow::new("port", RowGroup::Server, "Port", "3000", "default (Rails)"));
+        }
+
+        Some(DetectedConfig {
+            ecosystem: "ruby".to_string(),
+            confidence,
+            rows,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{fixture, val};
+    use super::super::CONFIDENCE_LOCKFILE;
+    use super::*;
+
+    fn detect(files: &[(&str, &str)]) -> Option<DetectedConfig> {
+        RubyDetector.detect(fixture(files).path())
+    }
+
+    #[test]
+    fn no_gemfile_is_none() {
+        assert!(detect(&[("package.json", "{}")]).is_none());
+    }
+
+    #[test]
+    fn gemfile_lock_yields_high_confidence() {
+        let cfg = detect(&[("Gemfile", "source 'x'\n"), ("Gemfile.lock", "")]).unwrap();
+        assert_eq!(cfg.ecosystem, "ruby");
+        assert_eq!(cfg.confidence, CONFIDENCE_LOCKFILE);
+    }
+
+    #[test]
+    fn bundle_install_command() {
+        let cfg = detect(&[("Gemfile", "source 'x'\n")]).unwrap();
+        assert_eq!(val(&cfg, "install"), "bundle install");
+    }
+
+    #[test]
+    fn rails_dev_and_port() {
+        let cfg = detect(&[("Gemfile", "gem 'rails', '~> 7.0'\n")]).unwrap();
+        assert_eq!(val(&cfg, "dev"), "bin/rails server");
+        assert_eq!(val(&cfg, "port"), "3000");
+    }
+
+    #[test]
+    fn non_rails_has_no_port() {
+        let cfg = detect(&[("Gemfile", "gem 'sinatra'\n")]).unwrap();
+        assert!(cfg.rows.iter().all(|r| r.id != "port"));
+    }
+
+    #[test]
+    fn rspec_test_command() {
+        let cfg = detect(&[("Gemfile", "gem 'rspec'\n")]).unwrap();
+        assert_eq!(val(&cfg, "test"), "bundle exec rspec");
+    }
+
+    #[test]
+    fn default_test_is_rake() {
+        let cfg = detect(&[("Gemfile", "gem 'rails'\n")]).unwrap();
+        assert_eq!(val(&cfg, "test"), "bundle exec rake test");
+    }
+
+    #[test]
+    fn ruby_version_file() {
+        let cfg = detect(&[("Gemfile", "source 'x'\n"), (".ruby-version", "3.3.0\n")]).unwrap();
+        assert_eq!(val(&cfg, "version"), "3.3.0");
+    }
+}

--- a/src-tauri/src/run_detect/ruby.rs
+++ b/src-tauri/src/run_detect/ruby.rs
@@ -22,21 +22,28 @@ impl RunDetector for RubyDetector {
 
         let mut rows = Vec::new();
 
-        // version: .ruby-version → `ruby "x"` line in the Gemfile.
-        if let Some(version) = read_trimmed(worktree, ".ruby-version").or_else(|| {
-            gemfile.lines().find_map(|l| {
-                let l = l.trim();
-                l.strip_prefix("ruby ")
-                    .map(|v| v.trim().trim_matches(['"', '\'']).to_string())
-                    .filter(|v| !v.is_empty())
+        // version: .ruby-version → `ruby "x"` line in the Gemfile. The
+        // source reflects whichever branch actually supplied the value.
+        if let Some((version, source)) = read_trimmed(worktree, ".ruby-version")
+            .map(|v| (v, ".ruby-version"))
+            .or_else(|| {
+                gemfile
+                    .lines()
+                    .find_map(|l| {
+                        let l = l.trim();
+                        l.strip_prefix("ruby ")
+                            .map(|v| v.trim().trim_matches(['"', '\'']).to_string())
+                            .filter(|v| !v.is_empty())
+                    })
+                    .map(|v| (v, "Gemfile · ruby"))
             })
-        }) {
+        {
             rows.push(DetectedRow::new(
                 "version",
                 RowGroup::Environment,
                 "Ruby version",
                 version,
-                ".ruby-version",
+                source,
             ));
         }
 
@@ -69,7 +76,7 @@ impl RunDetector for RubyDetector {
 
 #[cfg(test)]
 mod tests {
-    use super::super::test_support::{fixture, val};
+    use super::super::test_support::{fixture, row, val};
     use super::super::CONFIDENCE_LOCKFILE;
     use super::*;
 
@@ -124,5 +131,15 @@ mod tests {
     fn ruby_version_file() {
         let cfg = detect(&[("Gemfile", "source 'x'\n"), (".ruby-version", "3.3.0\n")]).unwrap();
         assert_eq!(val(&cfg, "version"), "3.3.0");
+        assert_eq!(row(&cfg, "version").unwrap().source, ".ruby-version");
+    }
+
+    #[test]
+    fn gemfile_ruby_directive_reports_gemfile_source() {
+        // No .ruby-version: the value comes from the Gemfile `ruby`
+        // directive, so the source must say so — not ".ruby-version".
+        let cfg = detect(&[("Gemfile", "ruby \"3.2.2\"\nsource 'x'\n")]).unwrap();
+        assert_eq!(val(&cfg, "version"), "3.2.2");
+        assert_eq!(row(&cfg, "version").unwrap().source, "Gemfile · ruby");
     }
 }

--- a/src-tauri/src/run_detect/rust.rs
+++ b/src-tauri/src/run_detect/rust.rs
@@ -1,0 +1,126 @@
+//! Rust / Cargo detector.
+
+use super::{
+    exists, read_trimmed, DetectedConfig, DetectedRow, RowGroup, RunDetector,
+    CONFIDENCE_LOCKFILE, CONFIDENCE_MANIFEST,
+};
+use std::path::Path;
+
+pub struct RustDetector;
+
+impl RunDetector for RustDetector {
+    fn detect(&self, worktree: &Path) -> Option<DetectedConfig> {
+        if !exists(worktree, "Cargo.toml") {
+            return None;
+        }
+        let confidence = if exists(worktree, "Cargo.lock") {
+            CONFIDENCE_LOCKFILE
+        } else {
+            CONFIDENCE_MANIFEST
+        };
+
+        let mut rows = Vec::new();
+
+        // version: rust-toolchain.toml `channel`, or legacy bare
+        // rust-toolchain file.
+        if let Some(channel) = read_trimmed(worktree, "rust-toolchain.toml")
+            .and_then(|s| toml_string_value(&s, "channel"))
+        {
+            rows.push(DetectedRow::new(
+                "version",
+                RowGroup::Environment,
+                "Toolchain",
+                channel,
+                "rust-toolchain.toml · channel",
+            ));
+        } else if let Some(channel) = read_trimmed(worktree, "rust-toolchain") {
+            rows.push(DetectedRow::new(
+                "version",
+                RowGroup::Environment,
+                "Toolchain",
+                channel,
+                "rust-toolchain",
+            ));
+        }
+
+        rows.push(DetectedRow::new("install", RowGroup::Scripts, "Install", "cargo fetch", "convention"));
+        rows.push(DetectedRow::new("dev", RowGroup::Scripts, "Run", "cargo run", "convention"));
+        rows.push(DetectedRow::new("build", RowGroup::Scripts, "Build", "cargo build", "convention"));
+        rows.push(DetectedRow::new("test", RowGroup::Scripts, "Test", "cargo test", "convention"));
+
+        Some(DetectedConfig {
+            ecosystem: "rust".to_string(),
+            confidence,
+            rows,
+        })
+    }
+}
+
+/// Pull a `key = "value"` string out of simple TOML text. Good enough for
+/// reading single scalar fields without a full TOML parser.
+fn toml_string_value(toml: &str, key: &str) -> Option<String> {
+    for line in toml.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix(key) {
+            let rest = rest.trim_start();
+            if let Some(rest) = rest.strip_prefix('=') {
+                return Some(rest.trim().trim_matches('"').to_string());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{fixture, val};
+    use super::super::CONFIDENCE_LOCKFILE;
+    use super::*;
+
+    fn detect(files: &[(&str, &str)]) -> Option<DetectedConfig> {
+        RustDetector.detect(fixture(files).path())
+    }
+
+    #[test]
+    fn no_cargo_toml_is_none() {
+        assert!(detect(&[("package.json", "{}")]).is_none());
+    }
+
+    #[test]
+    fn cargo_lock_yields_high_confidence() {
+        let cfg = detect(&[("Cargo.toml", "[package]\nname=\"x\""), ("Cargo.lock", "")]).unwrap();
+        assert_eq!(cfg.ecosystem, "rust");
+        assert_eq!(cfg.confidence, CONFIDENCE_LOCKFILE);
+    }
+
+    #[test]
+    fn standard_cargo_commands() {
+        let cfg = detect(&[("Cargo.toml", "[package]\nname=\"x\"")]).unwrap();
+        assert_eq!(val(&cfg, "install"), "cargo fetch");
+        assert_eq!(val(&cfg, "dev"), "cargo run");
+        assert_eq!(val(&cfg, "build"), "cargo build");
+        assert_eq!(val(&cfg, "test"), "cargo test");
+    }
+
+    #[test]
+    fn toolchain_file_drives_version() {
+        let cfg = detect(&[
+            ("Cargo.toml", "[package]"),
+            ("rust-toolchain.toml", "[toolchain]\nchannel = \"1.75.0\"\n"),
+        ])
+        .unwrap();
+        assert_eq!(val(&cfg, "version"), "1.75.0");
+    }
+
+    #[test]
+    fn no_toolchain_omits_version() {
+        let cfg = detect(&[("Cargo.toml", "[package]")]).unwrap();
+        assert!(cfg.rows.iter().all(|r| r.id != "version"));
+    }
+
+    #[test]
+    fn no_port_row() {
+        let cfg = detect(&[("Cargo.toml", "[package]")]).unwrap();
+        assert!(cfg.rows.iter().all(|r| r.id != "port"));
+    }
+}

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -288,16 +288,15 @@ impl Supervisor {
             return Ok(()); // already running, idempotent
         }
 
-        let needs_setup = !setup_done && !setup_cmd.trim().is_empty();
-        let (first_phase, first_cmd, chains_to_run) = if needs_setup {
-            (RunPhase::Setup, setup_cmd.clone(), true)
-        } else {
-            (RunPhase::Running, run_cmd.clone(), false)
+        // Nothing to run (unrecognized ecosystem with no install/dev) —
+        // leave the button Idle rather than spawning an empty command.
+        let Some(plan) = plan_run_phases(setup_done, &setup_cmd, &run_cmd) else {
+            return Ok(());
         };
 
-        let gen = session.begin_phase(first_phase);
-        emit_run_state(&app, agent_id, first_phase, None);
-        write_header(&app, agent_id, &session, &first_cmd);
+        let gen = session.begin_phase(plan.first_phase);
+        emit_run_state(&app, agent_id, plan.first_phase, None);
+        write_header(&app, agent_id, &session, &plan.first_cmd);
 
         spawn_run_phase(
             self.clone(),
@@ -306,9 +305,9 @@ impl Supervisor {
             session,
             gen,
             cwd,
-            first_phase,
-            first_cmd,
-            if chains_to_run { Some(run_cmd) } else { None },
+            plan.first_phase,
+            plan.first_cmd,
+            plan.chained_run_cmd,
         )
     }
 
@@ -2092,6 +2091,42 @@ fn write_header(app: &AppHandle, agent_id: &str, session: &Arc<RunSession>, cmd:
     emit_run_output(app, agent_id, bytes);
 }
 
+/// The phases to spawn for a single `run_start`, derived from the
+/// resolved commands and whether setup has already completed.
+#[derive(Debug)]
+struct RunPlan {
+    first_phase: RunPhase,
+    first_cmd: String,
+    /// Run command to chain after a successful setup phase. `None` when
+    /// the first phase is already the run, or when there is no run
+    /// command to chain (so we never spawn an empty command).
+    chained_run_cmd: Option<String>,
+}
+
+/// Decide what to spawn. Returns `None` when there is nothing to run —
+/// neither a setup nor a run command — so the caller can leave the
+/// button Idle instead of spawning an empty command that would exit 0
+/// and flash the panel to Stopped with no explanation.
+fn plan_run_phases(setup_done: bool, setup_cmd: &str, run_cmd: &str) -> Option<RunPlan> {
+    let needs_setup = !setup_done && !setup_cmd.trim().is_empty();
+    let has_run_cmd = !run_cmd.trim().is_empty();
+    if needs_setup {
+        Some(RunPlan {
+            first_phase: RunPhase::Setup,
+            first_cmd: setup_cmd.to_string(),
+            chained_run_cmd: has_run_cmd.then(|| run_cmd.to_string()),
+        })
+    } else if has_run_cmd {
+        Some(RunPlan {
+            first_phase: RunPhase::Running,
+            first_cmd: run_cmd.to_string(),
+            chained_run_cmd: None,
+        })
+    } else {
+        None
+    }
+}
+
 /// Spawn one phase's PTY (setup or run). Wires up output streaming
 /// and the exit handler that chains setup→run or transitions to
 /// Stopped on natural exit. Out-of-band stops are handled via the
@@ -2239,6 +2274,57 @@ fn emit_status(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── plan_run_phases ───────────────────────────────────────────────────
+
+    #[test]
+    fn plan_runs_dev_directly_when_setup_done() {
+        let plan = plan_run_phases(true, "pnpm install", "pnpm dev").unwrap();
+        assert_eq!(plan.first_phase, RunPhase::Running);
+        assert_eq!(plan.first_cmd, "pnpm dev");
+        assert_eq!(plan.chained_run_cmd, None);
+    }
+
+    #[test]
+    fn plan_runs_setup_then_chains_dev() {
+        let plan = plan_run_phases(false, "pnpm install", "pnpm dev").unwrap();
+        assert_eq!(plan.first_phase, RunPhase::Setup);
+        assert_eq!(plan.first_cmd, "pnpm install");
+        assert_eq!(plan.chained_run_cmd.as_deref(), Some("pnpm dev"));
+    }
+
+    #[test]
+    fn plan_does_not_chain_into_empty_run_cmd() {
+        // Setup needed but no dev command (e.g. a plain Python project with
+        // an install but no recognized run). Setup runs alone — no empty
+        // command chained after it.
+        let plan = plan_run_phases(false, "pip install -r requirements.txt", "").unwrap();
+        assert_eq!(plan.first_phase, RunPhase::Setup);
+        assert_eq!(plan.chained_run_cmd, None);
+    }
+
+    #[test]
+    fn plan_is_none_when_nothing_to_run() {
+        // Wholly unrecognized ecosystem: no setup, no run. Nothing should
+        // be spawned — the button stays Idle instead of flashing Stopped.
+        assert!(plan_run_phases(true, "", "").is_none());
+        assert!(plan_run_phases(false, "", "").is_none());
+        assert!(plan_run_phases(false, "   ", "  ").is_none());
+    }
+
+    #[test]
+    fn plan_skips_completed_setup_even_if_run_empty() {
+        // Setup already done and no run command → nothing to do.
+        assert!(plan_run_phases(true, "pnpm install", "").is_none());
+    }
+
+    #[test]
+    fn plan_runs_only_run_cmd_when_no_setup_needed() {
+        let plan = plan_run_phases(true, "", "cargo run").unwrap();
+        assert_eq!(plan.first_phase, RunPhase::Running);
+        assert_eq!(plan.first_cmd, "cargo run");
+        assert_eq!(plan.chained_run_cmd, None);
+    }
 
     fn test_supervisor() -> Supervisor {
         let dir = tempfile::tempdir().unwrap();

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -274,7 +274,7 @@ impl Supervisor {
             .ok_or_else(|| Error::Other("agent has no repos".into()))?;
         let cwd = repo_worktree_path(agent_id, &primary.subdir)?;
 
-        let (setup_cmd, run_cmd) = self.read_run_commands(&record.project_id);
+        let (setup_cmd, run_cmd) = self.read_run_commands(&record.project_id, &cwd);
         let setup_done = self.workspace.is_setup_completed(agent_id)?;
 
         let session = {
@@ -345,16 +345,26 @@ impl Supervisor {
         }
     }
 
-    /// Read the setup + run commands from project_settings, falling
-    /// back to the same inferred defaults the panel UI shows. Keys
-    /// match the RunPanel storage scheme (`run.install`, `run.dev`).
-    fn read_run_commands(&self, project_id: &str) -> (String, String) {
-        let conn = self.workspace.db_handle();
-        let install_default = "pnpm install".to_string();
-        let dev_default = "pnpm dev".to_string();
+    /// Read the setup + run commands for an agent. The detector provides
+    /// the baseline (same values the panel shows), and any persisted
+    /// `run.install` / `run.dev` overrides in project_settings take
+    /// precedence. One detector feeds both the panel and the runner, so
+    /// there is no hardcoded default to keep in sync.
+    fn read_run_commands(&self, project_id: &str, worktree: &Path) -> (String, String) {
+        let configs = crate::run_detect::detect_all(worktree);
+        let detected = |id: &str| -> String {
+            configs
+                .first()
+                .and_then(|c| c.rows.iter().find(|r| r.id == id))
+                .map(|r| r.value.clone())
+                .unwrap_or_default()
+        };
+        let install_default = detected("install");
+        let dev_default = detected("dev");
         if project_id.is_empty() {
             return (install_default, dev_default);
         }
+        let conn = self.workspace.db_handle();
         let read = |key: &str| -> Option<String> {
             let conn = conn.lock();
             conn.query_row(
@@ -368,6 +378,20 @@ impl Supervisor {
             read("run.install").unwrap_or(install_default),
             read("run.dev").unwrap_or(dev_default),
         )
+    }
+
+    /// Detect the run configuration for an agent's primary repo,
+    /// ranked by confidence. The panel renders the first (highest
+    /// confidence) entry; the rest are returned for future
+    /// multi-ecosystem selection.
+    pub fn detect_run_config(&self, agent_id: &str) -> Result<Vec<crate::run_detect::DetectedConfig>> {
+        let record = self.workspace.agent(agent_id)?;
+        let primary = record
+            .repos
+            .first()
+            .ok_or_else(|| Error::Other("agent has no repos".into()))?;
+        let worktree = repo_worktree_path(agent_id, &primary.subdir)?;
+        Ok(crate::run_detect::detect_all(&worktree))
     }
 
     pub fn current_workspace(&self) -> Option<Workspace> {

--- a/src/api.ts
+++ b/src/api.ts
@@ -194,6 +194,23 @@ export interface RunStateSnapshot {
   log: number[];
 }
 
+/** A single detected run-config row (see Rust `run_detect::DetectedRow`). */
+export interface DetectedRow {
+  /** "version" | "install" | "dev" | "test" | "build" | "port" | "env" */
+  id: string;
+  group: "environment" | "scripts" | "server";
+  key: string;
+  value: string;
+  source: string;
+}
+
+/** One ecosystem's detected config (see Rust `run_detect::DetectedConfig`). */
+export interface DetectedConfig {
+  ecosystem: string;
+  confidence: number;
+  rows: DetectedRow[];
+}
+
 export interface RunOutputEvent {
   agent_id: string;
   bytes: number[];
@@ -307,6 +324,8 @@ export const api = {
   runStop: (agentId: string) => invoke<void>("run_stop", { agentId }),
   runState: (agentId: string) =>
     invoke<RunStateSnapshot>("run_state", { agentId }),
+  detectRunConfig: (agentId: string) =>
+    invoke<DetectedConfig[]>("detect_run_config", { agentId }),
   listWorktreeTree: (agentId: string) =>
     invoke<WorktreeFile[]>("list_worktree_tree", { agentId }),
   readWorktreeFile: (agentId: string, path: string) =>

--- a/src/components/RightPanel/RunPanel.tsx
+++ b/src/components/RightPanel/RunPanel.tsx
@@ -19,19 +19,15 @@ import { RunSettingsSheet, type SetupRow } from "./RunSettingsSheet";
 const RUN_KEY_PREFIX = "run.";
 const runKey = (id: string) => `${RUN_KEY_PREFIX}${id}`;
 
-// Inferred defaults the panel shows when a project has no overrides.
-// The backend reads `run.install` / `run.dev` from project_settings and
-// falls back to these same strings — keep them in sync.
-const RUN_SETUP: SetupRow[] = [
-  { id: "pm",      group: "Environment", key: "Package manager", value: "pnpm 9.7.1",   source: "package.json · packageManager" },
-  { id: "node",    group: "Environment", key: "Node version",    value: "v22.4.0",      source: ".nvmrc" },
-  { id: "install", group: "Scripts",     key: "Install",         value: "pnpm install", source: "convention (pm + install)" },
-  { id: "dev",     group: "Scripts",     key: "Dev",             value: "pnpm dev",     source: "package.json · scripts.dev" },
-  { id: "build",   group: "Scripts",     key: "Build",           value: "pnpm build",   source: "package.json · scripts.build" },
-  { id: "test",    group: "Scripts",     key: "Test",            value: "pnpm test",    source: "package.json · scripts.test" },
-  { id: "port",    group: "Server",      key: "Port",            value: "3000",         source: "next.config.js" },
-  { id: "env",     group: "Server",      key: "Env file",        value: ".env.local",   source: "auto-detected" },
-];
+// Detected run config replaces the old hardcoded defaults. The backend
+// (`detect_run_config`) returns rows per ecosystem; the panel shows the
+// highest-confidence one. The `run.*` overrides in project_settings layer
+// on top of these detected values.
+const GROUP_LABEL: Record<string, string> = {
+  environment: "Environment",
+  scripts: "Scripts",
+  server: "Server",
+};
 
 // Strip ANSI escape sequences before rendering. v1 keeps log rendering
 // dead-simple (plain text with pre-wrap); colorization can come later.
@@ -45,6 +41,8 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
   const [log, setLog] = useState<string>("");
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [overrides, setOverrides] = useState<Record<string, string>>({});
+  const [rows, setRows] = useState<SetupRow[]>([]);
+  const [ecosystem, setEcosystem] = useState<string | null>(null);
   const logRef = useRef<HTMLDivElement | null>(null);
   // Streaming UTF-8 decoder so a multi-byte rune split across two
   // PTY chunks doesn't produce a replacement character. Reset each
@@ -73,6 +71,38 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
       cancelled = true;
     };
   }, [agent.project_id]);
+
+  // Detect the run config for this agent's worktree. Re-runs on agent
+  // switch. The highest-confidence ecosystem fills the table; an empty
+  // result means nothing was recognized (no-op fallback).
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .detectRunConfig(agent.id)
+      .then((configs) => {
+        if (cancelled) return;
+        const primary = configs[0];
+        setEcosystem(primary?.ecosystem ?? null);
+        setRows(
+          (primary?.rows ?? []).map((r) => ({
+            id: r.id,
+            group: GROUP_LABEL[r.group] ?? r.group,
+            key: r.key,
+            value: r.value,
+            source: r.source,
+          })),
+        );
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.error("detectRunConfig failed", err);
+        setRows([]);
+        setEcosystem(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [agent.id]);
 
   // Subscribe to run output and state events for this agent.
   // Rehydrate snapshot on mount/agent-switch so the panel preserves
@@ -142,7 +172,7 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
   }, [log]);
 
   const valueOf = (id: string) => {
-    const row = RUN_SETUP.find((r) => r.id === id);
+    const row = rows.find((r) => r.id === id);
     return overrides[id] ?? row?.value ?? "";
   };
 
@@ -166,7 +196,7 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
     const cleaned: Record<string, string> = {};
     if (projectId) {
       const previous = overrides;
-      for (const row of RUN_SETUP) {
+      for (const row of rows) {
         const nextVal = next[row.id];
         const wasSet = previous[row.id] !== undefined;
         const isOverride = nextVal !== undefined && nextVal !== row.value;
@@ -185,7 +215,7 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
         }
       }
     } else {
-      for (const row of RUN_SETUP) {
+      for (const row of rows) {
         const nextVal = next[row.id];
         if (nextVal !== undefined && nextVal !== row.value) {
           cleaned[row.id] = nextVal;
@@ -257,9 +287,9 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
       {/* ── Settings sheet ── */}
       {settingsOpen && (
         <RunSettingsSheet
-          rows={RUN_SETUP}
+          rows={rows}
           overrides={overrides}
-          agent={agent}
+          ecosystem={ecosystem}
           onClose={() => setSettingsOpen(false)}
           onApply={onApply}
         />

--- a/src/components/RightPanel/RunPanel.tsx
+++ b/src/components/RightPanel/RunPanel.tsx
@@ -13,6 +13,7 @@ import {
   setProjectSetting,
 } from "../../storage/projectSettings";
 import { RunSettingsSheet, type SetupRow } from "./RunSettingsSheet";
+import { reconcileOverrides } from "./reconcileOverrides";
 
 // Settings keys are namespaced under `run.` so the project_settings
 // table can hold overrides from other panels without colliding.
@@ -190,36 +191,22 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
   };
 
   const onApply = (next: Record<string, string>) => {
-    // Persist only true overrides — values that match the inferred
-    // default are removed from the DB so the row reads as "auto".
+    // Reconcile the draft against the detected rows: keep only real
+    // overrides, and prune keys (including stale ones whose row no longer
+    // exists after an ecosystem change) from the DB so the override
+    // indicator can't get stuck lit.
+    const { cleaned, toSet, toDelete } = reconcileOverrides(rows, overrides, next);
     const projectId = agent.project_id;
-    const cleaned: Record<string, string> = {};
     if (projectId) {
-      const previous = overrides;
-      for (const row of rows) {
-        const nextVal = next[row.id];
-        const wasSet = previous[row.id] !== undefined;
-        const isOverride = nextVal !== undefined && nextVal !== row.value;
-
-        if (isOverride) {
-          cleaned[row.id] = nextVal;
-          if (previous[row.id] !== nextVal) {
-            setProjectSetting(projectId, runKey(row.id), nextVal).catch(
-              (err) => console.error("setProjectSetting failed", err),
-            );
-          }
-        } else if (wasSet) {
-          deleteProjectSetting(projectId, runKey(row.id)).catch((err) =>
-            console.error("deleteProjectSetting failed", err),
-          );
-        }
+      for (const { id, value } of toSet) {
+        setProjectSetting(projectId, runKey(id), value).catch((err) =>
+          console.error("setProjectSetting failed", err),
+        );
       }
-    } else {
-      for (const row of rows) {
-        const nextVal = next[row.id];
-        if (nextVal !== undefined && nextVal !== row.value) {
-          cleaned[row.id] = nextVal;
-        }
+      for (const id of toDelete) {
+        deleteProjectSetting(projectId, runKey(id)).catch((err) =>
+          console.error("deleteProjectSetting failed", err),
+        );
       }
     }
 

--- a/src/components/RightPanel/RunSettingsSheet.tsx
+++ b/src/components/RightPanel/RunSettingsSheet.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from "react";
-import type { AgentRecord } from "../../api";
 import { Icon } from "../Icon";
 
 export interface SetupRow {
@@ -13,12 +12,21 @@ export interface SetupRow {
 interface Props {
   rows:      SetupRow[];
   overrides: Record<string, string>;
-  agent:     AgentRecord;
+  /** Detected ecosystem ("node", "rust", …), or null if none recognized. */
+  ecosystem: string | null;
   onClose:   () => void;
   onApply:   (overrides: Record<string, string>) => void;
 }
 
-export function RunSettingsSheet({ rows, overrides, agent, onClose, onApply }: Props) {
+const ECOSYSTEM_LABEL: Record<string, string> = {
+  node:   "Node",
+  python: "Python",
+  ruby:   "Ruby",
+  rust:   "Rust",
+  go:     "Go",
+};
+
+export function RunSettingsSheet({ rows, overrides, ecosystem, onClose, onApply }: Props) {
   // Draft = working copy while the sheet is open; uncommitted until Apply.
   const [draft, setDraft] = useState<Record<string, string>>(overrides);
 
@@ -60,8 +68,11 @@ export function RunSettingsSheet({ rows, overrides, agent, onClose, onApply }: P
           <div className="rsh-left">
             <div className="rsh-title">Run configuration</div>
             <div className="rsh-sub">
-              Auto-detected from{" "}
-              <code>{agent?.name ? `worktree/${agent.name}/package.json` : "package.json"}</code>
+              {ecosystem ? (
+                <>Detected · <code>{ECOSYSTEM_LABEL[ecosystem] ?? ecosystem}</code></>
+              ) : (
+                <>No ecosystem detected — edit values below</>
+              )}
             </div>
           </div>
           <button className="run-sheet-x" onClick={onClose} aria-label="Close">

--- a/src/components/RightPanel/reconcileOverrides.test.ts
+++ b/src/components/RightPanel/reconcileOverrides.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { reconcileOverrides } from "./reconcileOverrides";
+import type { SetupRow } from "./RunSettingsSheet";
+
+const row = (id: string, value: string): SetupRow => ({
+  id,
+  group: "Scripts",
+  key: id,
+  value,
+  source: "test",
+});
+
+const ROWS: SetupRow[] = [row("dev", "pnpm dev"), row("port", "5173")];
+
+describe("reconcileOverrides", () => {
+  it("keeps and persists a value that differs from the detected default", () => {
+    const r = reconcileOverrides(ROWS, {}, { dev: "pnpm start" });
+    expect(r.cleaned).toEqual({ dev: "pnpm start" });
+    expect(r.toSet).toEqual([{ id: "dev", value: "pnpm start" }]);
+    expect(r.toDelete).toEqual([]);
+  });
+
+  it("drops and deletes a value equal to the detected default", () => {
+    const r = reconcileOverrides(ROWS, { dev: "pnpm start" }, { dev: "pnpm dev" });
+    expect(r.cleaned).toEqual({});
+    expect(r.toSet).toEqual([]);
+    expect(r.toDelete).toEqual(["dev"]);
+  });
+
+  it("does not re-write an unchanged override", () => {
+    const r = reconcileOverrides(ROWS, { dev: "pnpm start" }, { dev: "pnpm start" });
+    expect(r.cleaned).toEqual({ dev: "pnpm start" });
+    expect(r.toSet).toEqual([]);
+    expect(r.toDelete).toEqual([]);
+  });
+
+  it("prunes a stale override whose row no longer exists in detection", () => {
+    // The project flipped ecosystems: `port` was overridden under the old
+    // config but the new detected rows have no `port` row. The stale key
+    // must be deleted, not left dangling in the DB.
+    const newRows: SetupRow[] = [row("dev", "cargo run")];
+    const r = reconcileOverrides(newRows, { port: "4000" }, { port: "4000" });
+    expect(r.cleaned).toEqual({});
+    expect(r.toDelete).toEqual(["port"]);
+    expect(r.toSet).toEqual([]);
+  });
+
+  it("clears a stale override via reset-all (empty next)", () => {
+    const newRows: SetupRow[] = [row("dev", "cargo run")];
+    const r = reconcileOverrides(newRows, { port: "4000" }, {});
+    expect(r.cleaned).toEqual({});
+    expect(r.toDelete).toEqual(["port"]);
+  });
+
+  it("leaves rows without overrides untouched", () => {
+    const r = reconcileOverrides(ROWS, {}, {});
+    expect(r.cleaned).toEqual({});
+    expect(r.toSet).toEqual([]);
+    expect(r.toDelete).toEqual([]);
+  });
+
+  it("handles set and prune together in one apply", () => {
+    const newRows: SetupRow[] = [row("dev", "cargo run")];
+    const r = reconcileOverrides(
+      newRows,
+      { port: "4000" }, // stale, to delete
+      { port: "4000", dev: "cargo run --release" }, // new dev override
+    );
+    expect(r.cleaned).toEqual({ dev: "cargo run --release" });
+    expect(r.toSet).toEqual([{ id: "dev", value: "cargo run --release" }]);
+    expect(r.toDelete).toEqual(["port"]);
+  });
+});

--- a/src/components/RightPanel/reconcileOverrides.ts
+++ b/src/components/RightPanel/reconcileOverrides.ts
@@ -1,0 +1,58 @@
+import type { SetupRow } from "./RunSettingsSheet";
+
+/** The outcome of reconciling a draft against the detected rows. */
+export interface OverrideReconciliation {
+  /** Override map to keep in component state (live + differing-from-default). */
+  cleaned: Record<string, string>;
+  /** Keys whose DB value should be upserted. */
+  toSet: Array<{ id: string; value: string }>;
+  /** Keys whose DB value should be deleted. */
+  toDelete: string[];
+}
+
+/**
+ * Decide which run-config overrides to keep, persist, and delete.
+ *
+ * A value is a real override only when it has a matching detected row AND
+ * differs from that row's detected default. Everything else is dropped:
+ * values that match the default, and — crucially — keys that no longer
+ * correspond to any detected row (stale entries left behind when the
+ * project changes ecosystem). Without pruning those, they accumulate in
+ * the DB and keep the override indicator lit with no way to clear them.
+ *
+ * The key set is the union of the current rows, the previously persisted
+ * overrides, and the draft — so disappeared rows are still reconciled.
+ */
+export function reconcileOverrides(
+  rows: SetupRow[],
+  previous: Record<string, string>,
+  next: Record<string, string>,
+): OverrideReconciliation {
+  const ids = new Set<string>([
+    ...rows.map((r) => r.id),
+    ...Object.keys(previous),
+    ...Object.keys(next),
+  ]);
+
+  const cleaned: Record<string, string> = {};
+  const toSet: Array<{ id: string; value: string }> = [];
+  const toDelete: string[] = [];
+
+  for (const id of ids) {
+    const row = rows.find((r) => r.id === id);
+    const nextVal = next[id];
+    const isOverride =
+      row !== undefined && nextVal !== undefined && nextVal !== row.value;
+
+    if (isOverride) {
+      cleaned[id] = nextVal;
+      if (previous[id] !== nextVal) {
+        toSet.push({ id, value: nextVal });
+      }
+    } else if (previous[id] !== undefined) {
+      toDelete.push(id);
+    }
+  }
+
+  return { cleaned, toSet, toDelete };
+}


### PR DESCRIPTION
The Run panel's setup table was cosmetic — hardcoded `pnpm`/Node strings that didn't reflect the actual project. This adds a pluggable Rust detector registry (`src-tauri/src/run_detect/`) where each ecosystem (Node, Python, Ruby, Rust, Go) reads manifest/lockfile/version files to fill a hybrid row schema (core `version`/`install`/`dev`/`test`/`build` plus optional `port`/`env`), with configs ranked by confidence so the primary ecosystem wins in polyglot repos. `read_run_commands` now sources its defaults from the same detector, giving the panel and the runner one source of truth and dropping the prior "keep in sync" hardcoded strings. A new `detect_run_config` Tauri command feeds the panel, which renders detected rows on mount and layers persisted `run.*` overrides on top; the settings sheet header now shows the detected ecosystem. Verified with 57 new test-first detector/port unit tests (196 total Rust tests pass), `tsc --noEmit`, and clean clippy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)