### PR TITLE
docs: rewrite README for multi-agent positioning + download CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ No VM, no Docker, no containers.
 ## How it works
 
 1. **Point** Quorum at a local git repo.
-2. **Spawn** an agent with a task. Quorum creates `.worktrees/<id>` on a fresh branch.
+2. **Spawn** an agent with a task. Quorum creates an isolated worktree at `~/.quorum/worktrees/<id>/` on a fresh branch.
 3. **Run.** It launches the agent's CLI in that worktree under `sandbox-exec`, bridged through a local PTY.
 4. **Watch.** Output streams into a tab — switch between a normalized chat view and the raw native terminal.
 5. **Review.** See the agent's edits as live diffs; browse and edit files directly.
@@ -75,10 +75,12 @@ Agent history is captured to a local SQLite store, so reopening a session replay
 
 Each agent runs as **your user** under a per-agent `sandbox-exec` profile that denies writes by default and re-allows them only for:
 
-- the agent's worktree under `.worktrees/<id>`
-- temp dirs (`/private/tmp`, `/private/var/folders`, …)
-- the agent's own state (`~/.claude`, `~/.config`, `~/.cache`, `~/.npm`, `~/.local`, …)
-- the PTY/device files terminal programs need
+- the agent's worktree root under `~/.quorum/worktrees/<id>/`
+- `/private/tmp`, `/private/var/tmp`, and `/private/var/folders`
+- the agent's own state: `~/.claude`, `~/.claude.json`, `~/.npm`, `~/.cache`, `~/.config`, and `~/.local`
+- the PTY and device files terminal programs need (`/dev/tty*`, `/dev/ptmx`, `/dev/pts/*`, `/dev/null`, `/dev/zero`)
+
+This list is the complete write-allow set; everything else is denied. See [`src-tauri/src/sandbox.rs`](src-tauri/src/sandbox.rs) for the exact profile.
 
 This is a **write-protection sandbox, not a VM**: the agent can still read files your user can read and use the network. It's the difference between "can't trash the rest of your repo or machine" and "fully air-gapped." Choose tasks accordingly.
 

--- a/README.md
+++ b/README.md
@@ -1,77 +1,113 @@
+<div align="center">
+
 # Quorum
 
-> Run multiple [Claude Code](https://docs.anthropic.com/en/docs/claude-code) sessions against one repo, each in its own git worktree, sandbox, and terminal tab.
+### Run a fleet of AI coding agents in parallel — each in its own sandbox and git worktree.
 
-**Status:** v1 / pre-release. macOS only.
+Quorum is an open-source macOS app for running and managing multiple AI coding agents at once — Claude Code, Codex, Cursor, OpenCode, and more — against a single repository, without them stepping on each other.
 
-## What it does
+[![Download for macOS](https://img.shields.io/badge/Download%20for%20macOS-Apple%20Silicon%20%26%20Intel-111?style=for-the-badge&logo=apple)](https://quorum.fwdai.org)
 
-- Point it at a git repo.
-- Click "+ Spawn", give the agent a task in plain English.
-- It creates `.worktrees/<id>` on a fresh branch.
-- It launches `claude --dangerously-skip-permissions --permission-mode bypassPermissions` in that worktree under `sandbox-exec`.
-- The sandbox allows reads and network, but limits writes to the agent worktree plus standard Claude/cache/temp locations.
-- It streams the process through a local PTY into an xterm.js tab.
-- You can switch between running sessions, type into any terminal, stop a process, or remove its worktree and branch.
+[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
+![Platform: macOS 13+](https://img.shields.io/badge/Platform-macOS%2013%2B-lightgrey.svg)
+![Built with Tauri](https://img.shields.io/badge/Built%20with-Tauri%202-24C8DB.svg)
 
-## Architecture (one paragraph)
+<!-- Drop a short demo GIF here. Record one full loop: spawn an agent → it works → review the diff → commit/PR. Save it to docs/demo.gif. -->
+<img src="docs/demo.gif" alt="Quorum: spawning multiple AI coding agents in parallel, each in its own git worktree" width="820">
 
-A Tauri 2 app. Frontend is React 18 + TypeScript + Zustand + xterm.js. The Rust backend owns a `Supervisor` that creates a git worktree, returns the agent record so the frontend can mount the terminal, then starts `sandbox-exec -f <profile> claude ...` in a local PTY and bridges PTY output to the frontend over Tauri events. Workspace state persists as JSON in `~/Library/Application Support/com.quorum.desktop/`.
+</div>
 
-## Requirements
+---
 
+A *quorum* is the number of members a body needs present to do business. Convene one on your codebase: many coding agents, each isolated in its own worktree and sandbox, all working the same problem in parallel — with you presiding.
+
+Every agent runs in its own git worktree under a macOS sandbox, so you can run a dozen at once and they physically can't touch each other's files — or write outside their box. Watch each one as a readable chat or its raw terminal, see its edits as live diffs the moment they land, and commit, push, or open a PR from the same window. Need more throughput? Spawn another. Done with one? Discard it — worktree and branch with it — in a click.
+
+## Why Quorum
+
+- **Real parallelism, no collisions.** Every agent gets its own git worktree and branch. Two agents editing the same file is impossible — they're working different checkouts of the same repo.
+- **Isolated by default.** Each agent runs under a macOS `sandbox-exec` profile that denies writes outside its worktree (plus the agent's own cache/config). It's a write-protection boundary, not a full VM — honest about what it does.
+- **Bring your own agent.** Quorum drives the CLIs you already use and pay for — Claude Code, Codex, Cursor, OpenCode, Pi — through one interface. No new model subscription, no lock-in.
+- **One cockpit.** A normalized chat view of every agent's reasoning and tool calls, a native terminal for its raw TUI, a live feed of its diffs as it edits, an integrated Git/PR panel, plus optional Run and Terminal panels — all per agent.
+- **Start projects, not just sessions.** Clone a repo from GitHub or create a new one (local + published) without dropping to a shell.
+- **Local and private.** A native desktop app. Your code and agent transcripts stay on your machine; nothing routes through a Quorum server.
+
+## Supported agents
+
+Quorum normalizes each agent's transcript into one consistent view, so they all look and behave the same to you.
+
+| Agent | Status |
+| --- | --- |
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | ✅ Supported |
+| [Codex](https://github.com/openai/codex) | ✅ Supported |
+| [Cursor Agent](https://cursor.com) | ✅ Supported |
+| [OpenCode](https://opencode.ai) | ✅ Supported |
+| Pi | ✅ Supported (experimental) |
+| Antigravity | 🔜 Coming soon |
+
+You install and authenticate the agent CLIs you want to use; Quorum detects them on your `PATH` and common install locations.
+
+## Download
+
+**[Download Quorum for macOS →](https://quorum.fwdai.org)** (universal — Apple Silicon & Intel)
+
+The app is signed, notarized, and updates itself in the background.
+
+**Requirements**
 - macOS 13+ (`sandbox-exec` is macOS-only)
-- Claude Code installed. The app looks for `claude` on `PATH`, via a login shell, and common install locations such as `~/.local/bin/claude`, `/opt/homebrew/bin/claude`, and `/usr/local/bin/claude`.
-- [Bun](https://bun.com/) 1.3+
-- Rust (stable)
+- At least one supported agent CLI installed (e.g. `claude`)
+- `git`, and `gh` (GitHub CLI) for the PR and project-creation features
 
-That's it. No VM, no Docker, no Tart, no install dance.
+No VM, no Docker, no containers.
 
-## First-time setup
+## How it works
+
+1. **Point** Quorum at a local git repo.
+2. **Spawn** an agent with a task. Quorum creates `.worktrees/<id>` on a fresh branch.
+3. **Run.** It launches the agent's CLI in that worktree under `sandbox-exec`, bridged through a local PTY.
+4. **Watch.** Output streams into a tab — switch between a normalized chat view and the raw native terminal.
+5. **Review.** See the agent's edits as live diffs; browse and edit files directly.
+6. **Ship.** Commit, push, open or merge a PR from the Git panel. Or discard the agent — and its worktree and branch — in one click.
+
+Agent history is captured to a local SQLite store, so reopening a session replays the full transcript.
+
+## Isolation & security
+
+Each agent runs as **your user** under a per-agent `sandbox-exec` profile that denies writes by default and re-allows them only for:
+
+- the agent's worktree under `.worktrees/<id>`
+- temp dirs (`/private/tmp`, `/private/var/folders`, …)
+- the agent's own state (`~/.claude`, `~/.config`, `~/.cache`, `~/.npm`, `~/.local`, …)
+- the PTY/device files terminal programs need
+
+This is a **write-protection sandbox, not a VM**: the agent can still read files your user can read and use the network. It's the difference between "can't trash the rest of your repo or machine" and "fully air-gapped." Choose tasks accordingly.
+
+## Build from source
 
 ```bash
 bun install
 bun tauri dev
 ```
 
-## Project layout
+**Toolchain:** [Bun](https://bun.com) 1.3+ and a stable Rust toolchain. The frontend is React 18 + TypeScript + Zustand + xterm.js; the backend is Rust via [Tauri 2](https://tauri.app).
 
 ```
-src/                       # React 18 + TS frontend
-  main.tsx                 # entry
-  App.tsx                  # shell layout
-  api.ts                   # typed Tauri IPC + event wrappers
-  store.ts                 # Zustand store
-  components/              # WorkspaceBar, ChooseRepoDialog, AgentList,
-                           # AgentPanes, AgentTerminal, SpawnDialog
-src-tauri/
-  src/lib.rs               # Tauri setup + IPC registration
-  src/pty_session.rs       # local PTY around the Claude process
-  src/agent.rs             # per-agent lifecycle
-  src/sandbox.rs           # per-agent sandbox-exec profile
-  src/git.rs               # git worktree add/remove/prune + branch -D
-  src/workspace.rs         # workspace JSON state + agent records
-  src/supervisor.rs        # registry + Tauri command coordination
-  src/commands.rs          # #[tauri::command] handlers (thin)
+src/                  React + TypeScript frontend (store, adapters, components)
+src-tauri/src/        Rust backend (supervisor, sessions, sandbox, git, gh)
+src-tauri/migrations/ SQLite schema
 ```
 
-## Isolation
+Run the tests:
 
-Each agent gets its own git worktree and branch. The process also runs under a macOS `sandbox-exec` profile that denies writes by default and re-allows writes to:
+```bash
+bun run test                  # frontend (vitest)
+cd src-tauri && cargo test    # backend
+```
 
-- the agent worktree under `.worktrees/<id>`
-- `/private/tmp`, `/private/var/tmp`, and `/private/var/folders`
-- `~/.claude`, `~/.claude.json`, `~/.npm`, `~/.cache`, `~/.config`, and `~/.local`
-- PTY/basic device files required by terminal programs
+## Contributing
 
-This is a write-protection sandbox, not a full VM. Claude still runs as your user, can read files your user can read, and can use the network.
-
-## Notes
-
-- Claude is started after the frontend has selected the agent, so xterm is mounted before Claude performs terminal startup negotiation.
-- Terminal output is buffered in the frontend so switching between agent tabs can replay recent output.
-- Removing an agent stops the process, removes its `.worktrees/<id>` directory, deletes its branch, and drops the app record.
+Issues and pull requests are welcome. If you're planning a larger change, open an issue first so we can align on direction. Please keep PRs focused and run both test suites before submitting.
 
 ## License
 
-TBD.
+[AGPL-3.0](LICENSE). See [NOTICE](NOTICE) for attribution.


### PR DESCRIPTION
## What

Rewrites the README to match what Quorum actually is today and to attract developers searching for a way to manage AI coding agents.

- **Repositions** from "multiple Claude Code sessions" → a multi-agent app: Claude Code, Codex, Cursor, OpenCode, Pi (Antigravity coming soon), with a **supported-agents table**.
- **Download-first CTA** — "Download for macOS" (signed, notarized, self-updating universal build) as the hero, build-from-source kept lower down.
- **Concise and concrete** — trimmed marketing filler; the intro leads with the differentiators (sandbox isolation, per-worktree parallelism, live diffs, the chat/native-terminal cockpit, integrated git/PR) instead of narrating obvious agent-onboarding steps.
- **Name hook** — a short, intentional explanation of "Quorum."
- **Honest framing kept** — "write-protection sandbox, not a VM."
- **SEO** — primary search phrases woven into the H1, opening paragraph, and section headers (no keyword stuffing).

## Needs a follow-up before/after merge

- **Demo GIF** — placeholder at `docs/demo.gif` (HTML comment notes what to record). Renders once the file is added.
- **Download URL** — links point to `https://quorum.fwdai.org` (inferred from the icon CDN base). Confirm/adjust if the public download page differs.
- **Agent links** — Codex/Cursor/OpenCode point at their project sites; adjust if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)