### PR TITLE
feat(db): separate dev and prod database paths

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -120,9 +120,14 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .setup(|app| {
             let app_data = app.path().app_data_dir()?;
-            std::fs::create_dir_all(&app_data)?;
+            let data_dir = if cfg!(debug_assertions) {
+                app_data.join("dev")
+            } else {
+                app_data
+            };
+            std::fs::create_dir_all(&data_dir)?;
 
-            let db = database::init(&app_data)
+            let db = database::init(&data_dir)
                 .expect("failed to initialize database");
             app.manage(db.clone());
 


### PR DESCRIPTION
## Summary

- Dev builds now use `<app_data_dir>/dev/quorum.db`; production uses `<app_data_dir>/quorum.db`
- Separation is compile-time via `cfg!(debug_assertions)` — zero runtime overhead
- No schema changes; the dev directory is created fresh with all migrations applied on first run

## Test plan

- [ ] Run `cargo tauri dev` and confirm data is written to `~/Library/Application Support/com.quorum.desktop/dev/`
- [ ] Verify the installed production build continues to use `~/Library/Application Support/com.quorum.desktop/quorum.db` unaffected