### PR TITLE
Derive agent branch name from workspace name

### DIFF
--- a/src-tauri/src/branding.rs
+++ b/src-tauri/src/branding.rs
@@ -9,44 +9,13 @@
 /// available to anything else that needs to identify the app.
 pub const APP_NAME: &str = "quorum";
 
-/// Build the full agent branch name from a slug. Always namespaced
-/// under APP_NAME so the branches are easy to spot and filter:
-/// `git branch | grep ^quorum/`.
-pub fn branch_for(slug: &str) -> String {
-    format!("{APP_NAME}/{slug}")
-}
-
-/// Turn an arbitrary task description into an ASCII slug suitable for
-/// a git branch name. Returns an empty string for inputs with no
-/// representable characters (callers should fall back to the agent's
-/// place id in that case).
-///
-/// Rules: lowercase, ASCII alphanumerics kept, every other run of
-/// chars becomes a single `-`, leading/trailing `-` trimmed. Capped at
-/// 32 chars, truncating at the last word boundary so we don't leave a
-/// half-word at the end.
-pub fn slugify_task(task: &str) -> String {
-    const MAX_LEN: usize = 32;
-    let mut out = String::new();
-    let mut prev_sep = true;
-    for ch in task.chars().flat_map(|c| c.to_lowercase()) {
-        if ch.is_ascii_alphanumeric() {
-            out.push(ch);
-            prev_sep = false;
-        } else if !prev_sep {
-            out.push('-');
-            prev_sep = true;
-        }
-    }
-    while out.ends_with('-') {
-        out.pop();
-    }
-    if out.len() <= MAX_LEN {
-        return out;
-    }
-    let cut = out[..MAX_LEN].rfind('-').unwrap_or(MAX_LEN);
-    out.truncate(cut);
-    out
+/// Build the full agent branch name from a name component (the agent's
+/// place id, e.g. `everest`). Always namespaced under APP_NAME so the
+/// branches are easy to spot and filter: `git branch | grep ^quorum/`.
+/// The branch deliberately mirrors the workspace name so the worktree,
+/// sandbox, and branch all share one identifier.
+pub fn branch_for(name: &str) -> String {
+    format!("{APP_NAME}/{name}")
 }
 
 #[cfg(test)]
@@ -55,38 +24,6 @@ mod tests {
 
     #[test]
     fn branch_uses_app_name() {
-        assert_eq!(branch_for("foo"), "quorum/foo");
-    }
-
-    #[test]
-    fn slug_basic() {
-        assert_eq!(slugify_task("Fix the bug"), "fix-the-bug");
-    }
-
-    #[test]
-    fn slug_caps_at_word_boundary() {
-        let s = slugify_task("Refactor the auth flow to use middleware");
-        assert_eq!(s, "refactor-the-auth-flow-to-use");
-        assert!(s.len() <= 32);
-    }
-
-    #[test]
-    fn slug_strips_punctuation_and_unicode() {
-        assert_eq!(slugify_task("Add @user/foo as a dep!"), "add-user-foo-as-a-dep");
-        assert_eq!(slugify_task("修复 login bug"), "login-bug");
-    }
-
-    #[test]
-    fn slug_empty_for_pure_non_ascii() {
-        assert_eq!(slugify_task("修复登录问题"), "");
-        assert_eq!(slugify_task("🐛🔥"), "");
-        assert_eq!(slugify_task(""), "");
-        assert_eq!(slugify_task("   "), "");
-    }
-
-    #[test]
-    fn slug_long_single_word_truncates_hard() {
-        let s = slugify_task("supercalifragilisticexpialidociousness");
-        assert_eq!(s.len(), 32);
+        assert_eq!(branch_for("everest"), "quorum/everest");
     }
 }

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -1833,27 +1833,44 @@ fn on_first_user_message(
     create_branches_for_branchless_repos(sup, app, agent_id);
 }
 
-/// Find a branch name that doesn't yet exist in `repo`, starting from
-/// `base` and falling back to `base-2`, `base-3`, … on collision.
-async fn free_branch_name(repo: &std::path::Path, base: &str) -> String {
-    if !git::branch_exists(repo, base).await.unwrap_or(false) {
-        return base.to_string();
-    }
-    let mut n = 2;
-    loop {
-        let candidate = format!("{base}-{n}");
-        if !git::branch_exists(repo, &candidate).await.unwrap_or(false) {
-            return candidate;
+/// Most stale same-named branches we'll step over before giving up. A
+/// modest cap so a pathological pile-up (e.g. bulk-deleted agents that
+/// all kept their branch) surfaces as a logged error instead of an
+/// unbounded probe loop.
+const MAX_BRANCH_SUFFIX: u32 = 1000;
+
+/// Find a single branch name that's free across *every* given repo,
+/// starting from `base` and stepping through `base-2`, `base-3`, … —
+/// so all of an agent's repos land on one canonical branch rather than
+/// diverging when a stale branch exists in some repos but not others.
+/// Returns `None` if no free name is found within `MAX_BRANCH_SUFFIX`.
+async fn free_branch_name_across(repos: &[PathBuf], base: &str) -> Option<String> {
+    for n in 1..=MAX_BRANCH_SUFFIX {
+        let candidate = if n == 1 {
+            base.to_string()
+        } else {
+            format!("{base}-{n}")
+        };
+        let mut taken = false;
+        for repo in repos {
+            if git::branch_exists(repo, &candidate).await.unwrap_or(false) {
+                taken = true;
+                break;
+            }
         }
-        n += 1;
+        if !taken {
+            return Some(candidate);
+        }
     }
+    None
 }
 
 /// For every tracked repo on the agent that doesn't have a branch yet,
 /// create `quorum/<workspace-name>` inside that repo's worktree — the
 /// branch mirrors the workspace (place) name so worktree, sandbox, and
-/// branch all share one identifier. Runs in a background task.
-/// Idempotent — `set_repo_branch_if_empty` guards each write.
+/// branch all share one identifier. Every repo on the agent lands on the
+/// same branch name. Runs in a background task. Idempotent —
+/// `set_repo_branch_if_empty` guards each write.
 fn create_branches_for_branchless_repos(
     sup: Arc<Supervisor>,
     app: AppHandle,
@@ -1868,12 +1885,37 @@ fn create_branches_for_branchless_repos(
             }
         };
 
-        let branch_base = branding::branch_for(&agent_id);
+        let pending: Vec<&TrackedRepo> =
+            record.repos.iter().filter(|r| r.branch.is_none()).collect();
+        if pending.is_empty() {
+            return;
+        }
 
-        for repo in record.repos.iter() {
-            if repo.branch.is_some() {
-                continue;
+        // One canonical branch per agent: reuse the name already
+        // established on another repo if there is one (e.g. a repo added
+        // after the agent started), otherwise pick a name that's free
+        // across all the repos we're about to branch — so a stale branch
+        // in one repo can't make them diverge.
+        let branch = match record.repos.iter().find_map(|r| r.branch.clone()) {
+            Some(existing) => existing,
+            None => {
+                let base = branding::branch_for(&agent_id);
+                let paths: Vec<PathBuf> = pending.iter().map(|r| r.repo_path.clone()).collect();
+                match free_branch_name_across(&paths, &base).await {
+                    Some(name) => name,
+                    None => {
+                        tracing::warn!(
+                            agent_id = %agent_id,
+                            base = %base,
+                            "branch creation: no free branch name within cap; leaving repos branchless"
+                        );
+                        return;
+                    }
+                }
             }
+        };
+
+        for repo in pending {
             let worktree = match repo_worktree_path(&agent_id, &repo.subdir) {
                 Ok(p) => p,
                 Err(e) => {
@@ -1881,11 +1923,6 @@ fn create_branches_for_branchless_repos(
                     continue;
                 }
             };
-            // The workspace name is unique among live agents, but a branch
-            // from a since-deleted agent of the same name can linger. Append
-            // a numeric suffix until we find a free name, mirroring how place
-            // ids disambiguate (`-2`, `-3`, …).
-            let branch = free_branch_name(&repo.repo_path, &branch_base).await;
             if let Err(e) = git::checkout_new_branch(&worktree, &branch).await {
                 tracing::warn!(
                     error = %e,

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -548,15 +548,14 @@ impl Supervisor {
             },
         );
 
-        // If the agent already has a task (slug), create the branch
-        // in the freshly-added repo right away.
-        let task = record.task.trim().to_string();
-        if !task.is_empty() {
+        // If the agent has already started (its first message set the
+        // task), create the branch in the freshly-added repo right away;
+        // otherwise defer, consistent with the primary repo.
+        if !record.task.trim().is_empty() {
             create_branches_for_branchless_repos(
                 self.clone(),
                 app.clone(),
                 agent_id.to_string(),
-                task,
             );
         }
 
@@ -1831,18 +1830,34 @@ fn on_first_user_message(
         }
     }
 
-    create_branches_for_branchless_repos(sup, app, agent_id, trimmed);
+    create_branches_for_branchless_repos(sup, app, agent_id);
+}
+
+/// Find a branch name that doesn't yet exist in `repo`, starting from
+/// `base` and falling back to `base-2`, `base-3`, … on collision.
+async fn free_branch_name(repo: &std::path::Path, base: &str) -> String {
+    if !git::branch_exists(repo, base).await.unwrap_or(false) {
+        return base.to_string();
+    }
+    let mut n = 2;
+    loop {
+        let candidate = format!("{base}-{n}");
+        if !git::branch_exists(repo, &candidate).await.unwrap_or(false) {
+            return candidate;
+        }
+        n += 1;
+    }
 }
 
 /// For every tracked repo on the agent that doesn't have a branch yet,
-/// derive a slug from the agent's task and create `quorum/<slug>` inside
-/// that repo's worktree. Runs in a background task. Idempotent —
-/// `set_repo_branch_if_empty` guards each write.
+/// create `quorum/<workspace-name>` inside that repo's worktree — the
+/// branch mirrors the workspace (place) name so worktree, sandbox, and
+/// branch all share one identifier. Runs in a background task.
+/// Idempotent — `set_repo_branch_if_empty` guards each write.
 fn create_branches_for_branchless_repos(
     sup: Arc<Supervisor>,
     app: AppHandle,
     agent_id: String,
-    task: String,
 ) {
     tauri::async_runtime::spawn(async move {
         let record = match sup.workspace.agent(&agent_id) {
@@ -1853,12 +1868,7 @@ fn create_branches_for_branchless_repos(
             }
         };
 
-        let slug_base = branding::slugify_task(&task);
-        let slug = if slug_base.is_empty() {
-            agent_id.clone()
-        } else {
-            slug_base
-        };
+        let branch_base = branding::branch_for(&agent_id);
 
         for repo in record.repos.iter() {
             if repo.branch.is_some() {
@@ -1871,13 +1881,11 @@ fn create_branches_for_branchless_repos(
                     continue;
                 }
             };
-            let mut branch = branding::branch_for(&slug);
-            if git::branch_exists(&repo.repo_path, &branch)
-                .await
-                .unwrap_or(false)
-            {
-                branch = format!("{branch}-{agent_id}");
-            }
+            // The workspace name is unique among live agents, but a branch
+            // from a since-deleted agent of the same name can linger. Append
+            // a numeric suffix until we find a free name, mirroring how place
+            // ids disambiguate (`-2`, `-3`, …).
+            let branch = free_branch_name(&repo.repo_path, &branch_base).await;
             if let Err(e) = git::checkout_new_branch(&worktree, &branch).await {
                 tracing::warn!(
                     error = %e,


### PR DESCRIPTION
Agent branch names now mirror the workspace (landmark) name as `quorum/<workspace-name>`, instead of being slugified from the user's first message, so the worktree, sandbox, and branch all share one identifier. This removes the brittle `slugify_task` derivation from `branding.rs`. Collisions (e.g. a branch left behind by a since-deleted agent of the same name) are disambiguated with a numeric `-2`/`-3` suffix via a new `free_branch_name` helper, replacing the old `-{agent_id}` fallback that would have produced `quorum/everest-everest`. Lazy branch creation on the first message is preserved so unused agents don't pollute `git branch`, and the task is still persisted for the UI — it just no longer drives the branch name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)