### PR TITLE
Agent instruction injection, plus Antigravity and Cursor transcript fixes

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -282,11 +282,42 @@ pub fn per_turn_descriptor(id: &str) -> Option<&'static PerTurnDescriptor> {
 /// from `start_index` (the count of records already ingested) so they match what
 /// a full read would have assigned; `id_field` (e.g. claude's `uuid`) overrides
 /// when present. Mirrors `records_with_id` parsing, just over the new tail only.
+/// Parse one JSONL line into a `RawRecord`. Returns `None` for blank lines,
+/// non-UTF-8, or incomplete/invalid JSON — so a half-written trailing line is
+/// simply skipped rather than ingested.
+fn parse_jsonl_record(line: &[u8], id_field: Option<&str>, idx: usize) -> Option<RawRecord> {
+    let text = std::str::from_utf8(line).ok()?;
+    if text.trim().is_empty() {
+        return None;
+    }
+    let v: Value = serde_json::from_str(text).ok()?;
+    let native_id = id_field
+        .and_then(|f| v.get(f))
+        .and_then(|x| x.as_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("ln:{idx}"));
+    Some(RawRecord { native_id, body: v })
+}
+
+/// Read new JSONL records from `path` starting at byte `offset`.
+///
+/// Newline-terminated lines are always safe to consume. The segment *after* the
+/// last newline is an unterminated trailing line:
+/// - For a **live writer** (`consume_trailing == false`, e.g. claude's open
+///   transcript) it may be half-written, so we hold it and re-read once it's
+///   terminated — the byte offset stays before it.
+/// - For an **exited writer** (`consume_trailing == true`, i.e. a per-turn agent
+///   in Custom view that has finished the turn) the trailing line is the final,
+///   complete line. Cursor and Pi write their last line with no trailing
+///   newline, so without this they'd never be ingested. We consume it *only if
+///   it parses as JSON*, so a genuinely partial line (caught mid-write) is still
+///   held rather than ingested.
 pub fn read_jsonl_tail(
     path: &Path,
     offset: u64,
     start_index: usize,
     id_field: Option<&str>,
+    consume_trailing: bool,
 ) -> (Vec<RawRecord>, u64) {
     use std::io::{Read, Seek, SeekFrom};
 
@@ -300,32 +331,36 @@ pub fn read_jsonl_tail(
     if file.read_to_end(&mut buf).is_err() {
         return (Vec::new(), offset);
     }
-    // Consume only up to the last newline; anything after is a partial line.
-    let Some(last_nl) = buf.iter().rposition(|&b| b == b'\n') else {
-        return (Vec::new(), offset);
-    };
+
+    // Bytes through the last newline are complete lines; the rest is the
+    // unterminated trailing segment.
+    let complete_end = buf
+        .iter()
+        .rposition(|&b| b == b'\n')
+        .map(|p| p + 1)
+        .unwrap_or(0);
 
     let mut out = Vec::new();
     let mut idx = start_index;
-    for line in buf[..=last_nl].split(|&b| b == b'\n') {
-        let Ok(text) = std::str::from_utf8(line) else {
-            continue;
-        };
-        if text.trim().is_empty() {
-            continue;
-        }
-        if let Ok(v) = serde_json::from_str::<Value>(text) {
-            let native_id = id_field
-                .and_then(|f| v.get(f))
-                .and_then(|x| x.as_str())
-                .map(str::to_string)
-                .unwrap_or_else(|| format!("ln:{idx}"));
-            out.push(RawRecord { native_id, body: v });
+    let mut consumed = complete_end;
+
+    for line in buf[..complete_end].split(|&b| b == b'\n') {
+        if let Some(rec) = parse_jsonl_record(line, id_field, idx) {
+            out.push(rec);
             idx += 1;
         }
     }
 
-    (out, offset + last_nl as u64 + 1)
+    if consume_trailing {
+        if let Some(rec) = parse_jsonl_record(&buf[complete_end..], id_field, idx) {
+            out.push(rec);
+            // The trailing line parsed cleanly, so it was complete — consume to
+            // EOF so we don't re-read it next time.
+            consumed = buf.len();
+        }
+    }
+
+    (out, offset + consumed as u64)
 }
 
 pub fn records_with_id(values: Vec<Value>, id_field: Option<&str>) -> Vec<RawRecord> {
@@ -1419,7 +1454,7 @@ mod tests {
             .unwrap();
         }
 
-        let (recs, off) = read_jsonl_tail(&path, 0, 0, Some("uuid"));
+        let (recs, off) = read_jsonl_tail(&path, 0, 0, Some("uuid"), false);
         assert_eq!(
             recs.iter().map(|r| r.native_id.as_str()).collect::<Vec<_>>(),
             vec!["a", "b"],
@@ -1433,7 +1468,7 @@ mod tests {
             write!(f, "{}\n{}\n", r#""type":"assistant"}"#, r#"{"uuid":"d","type":"user"}"#).unwrap();
         }
 
-        let (recs2, _off2) = read_jsonl_tail(&path, off, 2, Some("uuid"));
+        let (recs2, _off2) = read_jsonl_tail(&path, off, 2, Some("uuid"), false);
         assert_eq!(
             recs2.iter().map(|r| r.native_id.as_str()).collect::<Vec<_>>(),
             vec!["c", "d"],
@@ -1452,10 +1487,58 @@ mod tests {
             write!(f, "{}\n{}\n", r#"{"type":"mode"}"#, r#"{"type":"summary"}"#).unwrap();
         }
         // Pretend 5 records were already ingested.
-        let (recs, _off) = read_jsonl_tail(&path, 0, 5, None);
+        let (recs, _off) = read_jsonl_tail(&path, 0, 5, None, false);
         assert_eq!(
             recs.iter().map(|r| r.native_id.as_str()).collect::<Vec<_>>(),
             vec!["ln:5", "ln:6"],
+        );
+    }
+
+    #[test]
+    fn read_jsonl_tail_consume_trailing_reads_unterminated_final_line() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+
+        // A complete line + a complete-but-unterminated final line — how cursor
+        // and pi write their last (assistant) line: no trailing newline.
+        let path = dir.path().join("c.jsonl");
+        {
+            let mut f = std::fs::File::create(&path).unwrap();
+            write!(
+                f,
+                "{}\n{}",
+                r#"{"uuid":"a","type":"user"}"#,
+                r#"{"uuid":"b","type":"assistant"}"#,
+            )
+            .unwrap();
+        }
+
+        // Exited writer: the unterminated final line is consumed, to EOF.
+        let (recs, off) = read_jsonl_tail(&path, 0, 0, Some("uuid"), true);
+        assert_eq!(
+            recs.iter().map(|r| r.native_id.as_str()).collect::<Vec<_>>(),
+            vec!["a", "b"],
+        );
+        assert_eq!(off, std::fs::metadata(&path).unwrap().len(), "consumed to EOF");
+
+        // Live writer (same bytes): the unterminated final line is held back.
+        let (held, _) = read_jsonl_tail(&path, 0, 0, Some("uuid"), false);
+        assert_eq!(
+            held.iter().map(|r| r.native_id.as_str()).collect::<Vec<_>>(),
+            vec!["a"],
+        );
+
+        // A genuinely torn final line (invalid JSON) is held even when consuming.
+        let torn = dir.path().join("torn.jsonl");
+        {
+            let mut f = std::fs::File::create(&torn).unwrap();
+            write!(f, "{}\n{}", r#"{"uuid":"a","type":"user"}"#, r#"{"uuid":"x","#).unwrap();
+        }
+        let (recs_torn, _) = read_jsonl_tail(&torn, 0, 0, Some("uuid"), true);
+        assert_eq!(
+            recs_torn.iter().map(|r| r.native_id.as_str()).collect::<Vec<_>>(),
+            vec!["a"],
+            "a mid-write torn line is held even with consume_trailing",
         );
     }
 

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -23,6 +23,7 @@ use serde_json::Value;
 use crate::activity::{Activity, ManagedActivity};
 use crate::error::{Error, Result};
 use crate::exec_session::{ExecCallbacks, ExecSession, ExecSpawn};
+use crate::instructions;
 use crate::managed_session::{ManagedExit, ManagedSession, ManagedSpawn};
 use crate::pty_session::{PtyExit, PtySession, PtySpawn};
 use crate::sandbox;
@@ -552,7 +553,7 @@ fn antigravity_build_args(prompt: &str, session_id: Option<&str>, _thinking: Opt
         args.push(id.to_string());
     }
     args.push("--print".into());
-    args.push(prompt.to_string());
+    args.push(instructions::prepend_to_prompt(prompt, session_id));
     args
 }
 
@@ -998,6 +999,7 @@ fn prepare_pty_args(
         "bypassPermissions".into(),
     ];
     args.extend(effort_args(spec.effort));
+    args.extend(instructions::append_system_prompt_args());
 
     if spec.fresh {
         args.push("--session-id".into());
@@ -1044,6 +1046,7 @@ fn prepare_managed_args(
         "bypassPermissions".into(),
     ];
     args.extend(effort_args(spec.effort));
+    args.extend(instructions::append_system_prompt_args());
 
     if spec.fresh {
         args.push("--session-id".into());
@@ -1082,6 +1085,7 @@ fn codex_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&st
         args.push("-c".into());
         args.push(format!("reasoning_effort=\"{effort}\""));
     }
+    args.extend(instructions::codex_config_args());
     args.push(prompt.to_string());
     args
 }
@@ -1114,7 +1118,7 @@ fn cursor_build_args(prompt: &str, session_id: Option<&str>, _thinking: Option<&
         args.push(id.to_string());
     }
     // Prompt is positional and must come after options.
-    args.push(prompt.to_string());
+    args.push(instructions::prepend_to_prompt(prompt, session_id));
     args
 }
 
@@ -1157,7 +1161,7 @@ fn opencode_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<
         args.push("--session".into());
         args.push(id.to_string());
     }
-    args.push(prompt.to_string());
+    args.push(instructions::prepend_to_prompt(prompt, session_id));
     args
 }
 
@@ -1185,6 +1189,7 @@ fn pi_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&str>)
         args.push("--thinking".into());
         args.push(level.to_string());
     }
+    args.extend(instructions::append_system_prompt_args());
     if let Some(id) = session_id {
         args.push("--session".into());
         args.push(id.to_string());
@@ -1215,6 +1220,7 @@ fn pi_session_id(event: &Value) -> Option<String> {
 /// already isolates the worktree). `resume <id>` continues a prior session.
 fn codex_pty_args(session_id: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = vec!["--dangerously-bypass-approvals-and-sandbox".into()];
+    args.extend(instructions::codex_config_args());
     if let Some(id) = session_id {
         args.push("resume".into());
         args.push(id.to_string());
@@ -1252,7 +1258,7 @@ fn opencode_pty_args(session_id: Option<&str>) -> Vec<String> {
 /// `--session <id>` resumes — same flag the Custom-view runner uses, since the
 /// versions we target (0.74.x) lack `--session-id`.
 fn pi_pty_args(session_id: Option<&str>) -> Vec<String> {
-    let mut args: Vec<String> = Vec::new();
+    let mut args: Vec<String> = instructions::append_system_prompt_args();
     if let Some(id) = session_id {
         args.push("--session".into());
         args.push(id.to_string());
@@ -1587,8 +1593,9 @@ mod tests {
         let args = opencode_build_args("hi", None, None);
         assert!(args.contains(&"--thinking".to_string()));
         assert!(args.contains(&"--format".to_string()));
-        // Prompt is positional and last.
-        assert_eq!(args.last().unwrap(), "hi");
+        // Prompt is positional and last (possibly prefixed with injected
+        // instructions on a fresh turn, so match the tail rather than equality).
+        assert!(args.last().unwrap().ends_with("hi"), "prompt is positional and last");
     }
 
     // ── pty (native TUI) args ──────────────────────────────────────────────
@@ -1645,8 +1652,9 @@ mod tests {
     #[test]
     fn pi_pty_args_bare_tui_and_session() {
         // Fresh: bare `pi` launches the interactive TUI; tools auto-run there.
+        // (May carry injected --append-system-prompt args, but never a resume.)
         let fresh = pi_pty_args(None);
-        assert!(fresh.is_empty());
+        assert!(!fresh.iter().any(|a| a == "--session"), "fresh TUI has no resume flag");
         // Resume uses `--session <id>` (target pi 0.74.x lacks `--session-id`).
         let resume = pi_pty_args(Some("u-7"));
         let pos = resume

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -543,14 +543,15 @@ fn opencode_read(message_paths: &[PathBuf]) -> Vec<RawRecord> {
 // The conversation id (== session id) lives in agy's filesystem, not its output.
 
 fn antigravity_build_args(prompt: &str, session_id: Option<&str>, _thinking: Option<&str>) -> Vec<String> {
-    let mut args = vec![
-        "--print".to_string(),
-        "--dangerously-skip-permissions".to_string(),
-    ];
+    // `--print` takes the prompt as its *value* (i.e. `--print <prompt>`), so the
+    // prompt must come last, directly after `--print`. Putting another flag
+    // between them makes that flag the prompt (agy then "answers" the flag name).
+    let mut args = vec!["--dangerously-skip-permissions".to_string()];
     if let Some(id) = session_id {
         args.push("--conversation".into());
         args.push(id.to_string());
     }
+    args.push("--print".into());
     args.push(prompt.to_string());
     args
 }

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -1,0 +1,139 @@
+//! Agent instruction injection.
+//!
+//! A single source of truth for the system-prompt-level instructions Quorum
+//! injects into every agent — edit `instructions/system_prompt.md` and every
+//! agent picks it up on its next spawn. There is no other copy.
+//!
+//! Quorum drives heterogeneous agent CLIs, and they expose different slots for
+//! app-supplied guidance, so the *delivery* is per-agent while the *text* is
+//! shared:
+//!
+//! - **Claude, Pi** — `--append-system-prompt <text>` (appends to the real
+//!   system prompt; re-passed every spawn, one non-accumulating copy).
+//! - **Codex** — `-c developer_instructions=<text>` (the developer-role layer
+//!   on top of Codex's base prompt; re-passed every turn, non-accumulating).
+//! - **Cursor, OpenCode, Antigravity** — no system-prompt slot, so the text is
+//!   prepended to the *first* turn's prompt. It then lives in the resumed
+//!   conversation, so later turns don't re-send it (no per-turn token tax, no
+//!   accumulating copies).
+//!
+//! Blank the markdown file to disable injection: every helper below no-ops when
+//! the source is empty.
+
+/// The single source of truth. Edit the file, not this constant.
+const SYSTEM_PROMPT: &str = include_str!("instructions/system_prompt.md");
+
+/// The instruction text, trimmed. Empty when the source is blank/whitespace,
+/// which makes every injection helper a no-op.
+pub fn text() -> &'static str {
+    SYSTEM_PROMPT.trim()
+}
+
+/// Args for agents that expose `--append-system-prompt` (Claude, Pi).
+/// Empty when there's nothing to inject.
+pub fn append_system_prompt_args() -> Vec<String> {
+    let text = text();
+    if text.is_empty() {
+        return Vec::new();
+    }
+    vec!["--append-system-prompt".into(), text.to_string()]
+}
+
+/// Args for Codex's developer-instructions config override
+/// (`-c developer_instructions="…"`). Empty when there's nothing to inject.
+///
+/// The value is a TOML basic string passed as a single argv element (no shell
+/// is involved — `Command`/`portable-pty` pass argv directly), so only TOML
+/// string escaping matters, not shell quoting.
+pub fn codex_config_args() -> Vec<String> {
+    let text = text();
+    if text.is_empty() {
+        return Vec::new();
+    }
+    vec![
+        "-c".into(),
+        format!("developer_instructions={}", toml_basic_string(text)),
+    ]
+}
+
+/// For agents with no system-prompt slot (Cursor, OpenCode, Antigravity), fold
+/// the instructions into the prompt — but only on the first turn of a session
+/// (`session_id` is `None`). On later turns the text is already in the resumed
+/// history, so the original prompt is returned unchanged.
+pub fn prepend_to_prompt(prompt: &str, session_id: Option<&str>) -> String {
+    let text = text();
+    if text.is_empty() || session_id.is_some() {
+        return prompt.to_string();
+    }
+    // Wrap in a namespaced tag so the UI can strip this block from the user
+    // bubble (these agents echo the prompt back into the transcript). The tag
+    // is Quorum-specific to avoid colliding with real user content.
+    format!("<quorum-system>\n{text}\n</quorum-system>\n\n{prompt}")
+}
+
+/// Encode `s` as a TOML basic string (double-quoted, with escapes), so it can
+/// be passed as the value half of a `-c key=value` config override.
+fn toml_basic_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            // Other control chars are illegal raw in a TOML basic string.
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04X}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_is_present_and_nonempty() {
+        // The shipped default is non-empty; guards against an accidental blank.
+        assert!(!text().is_empty());
+    }
+
+    #[test]
+    fn append_args_carry_the_text() {
+        let args = append_system_prompt_args();
+        assert_eq!(args[0], "--append-system-prompt");
+        assert_eq!(args[1], text());
+    }
+
+    #[test]
+    fn codex_args_are_a_toml_developer_instructions_override() {
+        let args = codex_config_args();
+        assert_eq!(args[0], "-c");
+        assert!(args[1].starts_with("developer_instructions=\""));
+        assert!(args[1].ends_with('"'));
+    }
+
+    #[test]
+    fn prepend_only_on_first_turn() {
+        let first = prepend_to_prompt("do the thing", None);
+        assert!(first.starts_with("<quorum-system>"));
+        assert!(first.contains(text()));
+        assert!(first.contains("</quorum-system>"));
+        assert!(first.ends_with("do the thing"));
+
+        // Resumed turn: untouched (the text is already in history).
+        assert_eq!(prepend_to_prompt("do the thing", Some("sess-1")), "do the thing");
+    }
+
+    #[test]
+    fn toml_escaping_handles_quotes_newlines_and_backslashes() {
+        assert_eq!(toml_basic_string("a\"b"), r#""a\"b""#);
+        assert_eq!(toml_basic_string("a\nb"), r#""a\nb""#);
+        assert_eq!(toml_basic_string("a\\b"), r#""a\\b""#);
+        assert_eq!(toml_basic_string("tab\there"), r#""tab\there""#);
+    }
+}

--- a/src-tauri/src/instructions/system_prompt.md
+++ b/src-tauri/src/instructions/system_prompt.md
@@ -1,0 +1,3 @@
+You are running inside Quorum, which runs you in an isolated git worktree under a macOS sandbox: you can read anywhere your user can, but writes are confined to your worktree. Treat the worktree as your workspace and keep all changes inside it.
+
+When a task needs an action that the sandbox blocks or that must run outside your worktree, say so explicitly rather than silently failing or trying to work around the sandbox.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod exec_session;
 mod gh;
 mod git;
 mod git_state;
+mod instructions;
 mod managed_session;
 mod names;
 mod new_project;

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -1394,12 +1394,22 @@ fn sync_session_records(workspace: &WorkspaceManager, agent_id: &str) -> Option<
     // sessions); multi-file / blob-dir readers fall back to a full read whose
     // already-stored rows are idempotently skipped. Either way the batch lands
     // in one transaction.
+    // Per-turn agents in Custom view have exited by turn-end, so their final
+    // line is complete even without a trailing newline (cursor/pi write it that
+    // way) — consume it. Persistent writers (claude) keep the file open, so a
+    // trailing line may be mid-write; hold it until it's newline-terminated.
+    let consume_trailing = !is_persistent_runner(&record);
     let (records, new_offset) = match (reader.tail, paths.as_slice()) {
         (Some(tail), [path]) => {
             let offset = workspace.session_ingest_offset(agent_id).unwrap_or(0);
             let start_index = workspace.session_record_count(agent_id).unwrap_or(0);
-            let (recs, next) =
-                crate::agent::read_jsonl_tail(path, offset, start_index, tail.id_field);
+            let (recs, next) = crate::agent::read_jsonl_tail(
+                path,
+                offset,
+                start_index,
+                tail.id_field,
+                consume_trailing,
+            );
             (recs, Some(next))
         }
         _ => ((reader.read)(&paths), None),

--- a/src/adapters/claude/sanitize.test.ts
+++ b/src/adapters/claude/sanitize.test.ts
@@ -85,4 +85,18 @@ describe("sanitizeUserText", () => {
     expect(out.text).toBe("");
     expect(out.notices).toEqual([]);
   });
+
+  it("unwraps Cursor's timestamp/user_query envelope", () => {
+    const raw =
+      "<timestamp>Tue, Jun 9, 2026</timestamp>\n<user_query>\nHey\n</user_query>";
+    expect(sanitizeUserText(raw).text).toBe("Hey");
+  });
+
+  it("strips an injected quorum-system block, even nested in the envelope", () => {
+    const raw =
+      "<timestamp>Tue, Jun 9, 2026</timestamp>\n<user_query>\n<quorum-system>\nfollow the rules\n</quorum-system>\n\nHey\n</user_query>";
+    // Cleaned to exactly what the user typed, so it dedups against the
+    // optimistic turn and renders as a single clean bubble.
+    expect(sanitizeUserText(raw).text).toBe("Hey");
+  });
 });

--- a/src/adapters/claude/sanitize.ts
+++ b/src/adapters/claude/sanitize.ts
@@ -4,6 +4,7 @@
 // user-authored content and shouldn't render as user bubbles.
 
 import type { ChatItem } from "../types";
+import { stripInjectedInstructions } from "../../util/instructions";
 
 type NoticeItem = Extract<ChatItem, { kind: "notice" }>;
 
@@ -26,6 +27,12 @@ const SYSTEM_REMINDER_RE = /<system-reminder>([\s\S]*?)<\/system-reminder>/g;
 // type it. Convert to a compact_summary notice instead.
 const COMPACT_PREAMBLE_RE =
   /^This session is being continued from a previous conversation/;
+
+// Cursor (which reuses this sanitizer) wraps every user turn in its own
+// envelope: a `<timestamp>` line followed by the query inside `<user_query>`.
+// Neither is user-authored. Claude never emits these, so it's a no-op there.
+const CURSOR_TIMESTAMP_RE = /<timestamp>[\s\S]*?<\/timestamp>/g;
+const CURSOR_USER_QUERY_RE = /<user_query>([\s\S]*?)<\/user_query>/;
 
 export function sanitizeUserText(raw: string): SanitizeResult {
   const notices: NoticeItem[] = [];
@@ -64,6 +71,18 @@ export function sanitizeUserText(raw: string): SanitizeResult {
     }
     return "";
   });
+
+  // Unwrap Cursor's user-turn envelope (no-op for Claude).
+  text = text.replace(CURSOR_TIMESTAMP_RE, "");
+  const cursorQuery = text.match(CURSOR_USER_QUERY_RE);
+  if (cursorQuery) {
+    text = cursorQuery[1];
+  }
+
+  // Strip the Quorum-injected instruction block at the data layer (not just at
+  // render) so the stored text equals what the user typed — this lets dedup
+  // merge the agent's echoed turn with the optimistic one. No-op when absent.
+  text = stripInjectedInstructions(text);
 
   return { text: text.trim(), notices };
 }

--- a/src/components/Workspace/messages/MessageItem.tsx
+++ b/src/components/Workspace/messages/MessageItem.tsx
@@ -6,6 +6,7 @@ import { ToolResultItem } from "./ToolResultItem";
 import { ToolRow } from "./ToolRow";
 import { getPresenter } from "./presenters";
 import { AttachmentList } from "../../Composer/AttachmentList";
+import { stripInjectedInstructions } from "../../../util/instructions";
 
 /** Dispatcher for one rendered row. Accepts either a raw ChatItem or
  *  the derived `tool_pair` from pairToolItems(). */
@@ -14,7 +15,7 @@ export function MessageItem({ item }: { item: ViewItem }) {
     case "user_message":
       return (
         <div className="m-user">
-          {item.text}
+          {stripInjectedInstructions(item.text)}
           {item.attachments && item.attachments.length > 0 && (
             <AttachmentList paths={item.attachments} className="message-attachments" />
           )}

--- a/src/util/instructions.ts
+++ b/src/util/instructions.ts
@@ -1,0 +1,15 @@
+/** Strip the Quorum-injected instruction block from displayed user text.
+ *
+ *  The prepend-style agents (cursor, opencode, antigravity) receive the
+ *  instructions as a `<quorum-system>…</quorum-system>` block prepended to the
+ *  first user message, and echo it back into their transcript. This removes
+ *  that block so the UI shows only what the user typed. The `<quorum-system>`
+ *  tag is Quorum-specific, so removing it anywhere is safe — and it must be
+ *  un-anchored because some agents (e.g. cursor) nest the user message inside
+ *  their own envelope, leaving our block mid-string rather than at the start.
+ *  No-op on messages that don't carry it. */
+const QUORUM_SYSTEM_BLOCK = /\s*<quorum-system>[\s\S]*?<\/quorum-system>\s*/g;
+
+export function stripInjectedInstructions(text: string): string {
+  return text.replace(QUORUM_SYSTEM_BLOCK, "").trim();
+}


### PR DESCRIPTION
Adds a single-source instruction-injection module that delivers shared system-prompt-level guidance to every supported agent through the strongest channel each CLI exposes — `--append-system-prompt` (Claude, Pi), `-c developer_instructions` (Codex), and a first-turn prompt prepend wrapped in a `<quorum-system>` tag the UI strips from the user bubble (Cursor, OpenCode, Antigravity); blank `system_prompt.md` to disable it everywhere. It also fixes two pre-existing, unrelated bugs this work surfaced: Antigravity's `--print` was eating `--dangerously-skip-permissions` as its prompt value (so the agent never received real prompts), now reordered so the prompt is `--print`'s value. And Cursor's assistant response was lost on turn-completion refresh because its final transcript line has no trailing newline and the tail reader skipped it — `read_jsonl_tail` now consumes the unterminated final line for exited per-turn agents (Claude and full-read agents unchanged), and the sanitizer unwraps Cursor's `<timestamp>`/`<user_query>` envelope so the bubble shows only what the user typed. All changes are covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
