### PR TITLE
Add file-mailbox RPC and unify agent sandboxing under sandbox-exec

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -62,8 +62,14 @@ pub struct PerTurnAgent {
 pub struct PerTurnSpec {
     /// The agent's working directory — the primary repo's worktree.
     pub cwd: PathBuf,
+    /// Sandbox writable root — the agent's parent dir (same role as
+    /// `SpawnSpec::sandbox_root`). Per-turn agents now run under sandbox-exec
+    /// too, so they need it to build the profile.
+    pub sandbox_root: PathBuf,
     /// Session id to resume, if one has been captured already.
     pub session_id: Option<String>,
+    /// The agent's RPC mailbox dir, exposed to the child as `QUORUM_RPC_DIR`.
+    pub rpc_dir: PathBuf,
 }
 
 /// Everything that varies between per-turn agents. The runner lifecycle —
@@ -724,8 +730,20 @@ pub struct SpawnSpec<'a> {
     /// no selection; claude uses its own default. Ignored by per-turn agents,
     /// which take effort per-turn via their `thinking` build-args instead.
     pub effort: Option<&'a str>,
+    /// The agent's RPC mailbox dir, exposed to the child as `QUORUM_RPC_DIR`.
+    pub rpc_dir: PathBuf,
     pub cols: u16,
     pub rows: u16,
+}
+
+/// The environment Quorum injects into every agent child: the absolute path to
+/// its file-mailbox RPC dir. The agent posts requests there for the app to
+/// execute (see `rpc.rs`). Layered on top of the inherited environment.
+fn rpc_env(rpc_dir: &Path) -> Vec<(String, String)> {
+    vec![(
+        "QUORUM_RPC_DIR".to_string(),
+        rpc_dir.to_string_lossy().into_owned(),
+    )]
 }
 
 impl Agent {
@@ -735,6 +753,7 @@ impl Agent {
         G: Fn(PtyExit) + Send + 'static,
     {
         let (profile_file, args) = prepare_pty_args(&spec)?;
+        let env = rpc_env(&spec.rpc_dir);
 
         tracing::info!(
             agent_id = %spec.agent_id,
@@ -752,6 +771,7 @@ impl Agent {
                 program: Path::new(SANDBOX_EXEC),
                 args: &args,
                 cwd: &spec.cwd,
+                env: &env,
                 cols: spec.cols,
                 rows: spec.rows,
             },
@@ -791,7 +811,21 @@ impl Agent {
         } else {
             Some(spec.session_id)
         };
-        let args = (desc.pty_args)(session);
+        let agent_args = (desc.pty_args)(session);
+        let env = rpc_env(&spec.rpc_dir);
+
+        // Unified sandbox: run the agent's TUI under sandbox-exec with Quorum's
+        // profile (the agent's own sandbox is disabled in its arg builder), so
+        // per-turn agents are confined exactly like claude. argv becomes
+        // `sandbox-exec -f <profile> <agent-bin> <agent-args…>`.
+        let profile_file = prepare_sandbox(&spec.sandbox_root, &spec.rpc_dir, &home)?;
+        let profile_path = profile_file
+            .path()
+            .to_str()
+            .ok_or_else(|| Error::Other("profile path not utf-8".into()))?
+            .to_string();
+        let mut args: Vec<String> = vec!["-f".into(), profile_path, bin.clone()];
+        args.extend(agent_args);
 
         tracing::info!(
             agent_id = %spec.agent_id,
@@ -799,16 +833,18 @@ impl Agent {
             session = %spec.session_id,
             fresh = spec.fresh,
             cwd = %spec.cwd.display(),
+            sandbox_root = %spec.sandbox_root.display(),
             bin = %bin,
             argv = ?args,
-            "spawning native pty per-turn agent"
+            "spawning sandboxed native pty per-turn agent"
         );
 
         let pty = PtySession::spawn(
             PtySpawn {
-                program: Path::new(&bin),
+                program: Path::new(SANDBOX_EXEC),
                 args: &args,
                 cwd: &spec.cwd,
+                env: &env,
                 cols: spec.cols,
                 rows: spec.rows,
             },
@@ -818,7 +854,7 @@ impl Agent {
 
         Ok(Self::Pty(PtyAgent {
             pty,
-            _profile_file: None,
+            _profile_file: Some(profile_file),
         }))
     }
 
@@ -828,6 +864,7 @@ impl Agent {
         G: Fn(ManagedExit) + Send + 'static,
     {
         let (profile_file, args) = prepare_managed_args(&spec)?;
+        let env = rpc_env(&spec.rpc_dir);
 
         tracing::info!(
             agent_id = %spec.agent_id,
@@ -845,6 +882,7 @@ impl Agent {
                 program: Path::new(SANDBOX_EXEC),
                 args: &args,
                 cwd: &spec.cwd,
+                env: &env,
             },
             on_event,
             on_exit,
@@ -912,18 +950,42 @@ impl Agent {
         G: Fn(String) + Send + Sync + 'static,
         H: Fn(bool) + Send + Sync + 'static,
     {
+        // Unified sandbox: wrap each turn's process in sandbox-exec with
+        // Quorum's profile. The agent binary moves into `prefix_args`
+        // (`sandbox-exec -f <profile> <agent-bin>`), and the profile tempfile
+        // rides on the ExecSession so it outlives the per-turn respawns.
+        let home = dirs::home_dir()
+            .ok_or_else(|| Error::Other("HOME directory not available".into()))?;
+        let profile_file = prepare_sandbox(&spec.sandbox_root, &spec.rpc_dir, &home)?;
+        let profile_path = profile_file
+            .path()
+            .to_str()
+            .ok_or_else(|| Error::Other("profile path not utf-8".into()))?
+            .to_string();
+        let agent_bin = program
+            .to_str()
+            .ok_or_else(|| Error::Other("agent bin path not utf-8".into()))?
+            .to_string();
+        let prefix_args = vec!["-f".to_string(), profile_path, agent_bin];
+
         tracing::info!(
-            program = %program.display(),
+            program = %SANDBOX_EXEC,
+            agent_bin = %program.display(),
             cwd = %spec.cwd.display(),
+            sandbox_root = %spec.sandbox_root.display(),
             resume = spec.session_id.is_some(),
-            "preparing per-turn runner"
+            "preparing sandboxed per-turn runner"
         );
+        let env = rpc_env(&spec.rpc_dir);
         let session = ExecSession::new(
             ExecSpawn {
-                program,
+                program: PathBuf::from(SANDBOX_EXEC),
+                prefix_args,
+                profile: Some(profile_file),
                 cwd: spec.cwd,
                 session_id: spec.session_id,
                 stdout_is_json,
+                env,
             },
             build_args,
             extract_session_id,
@@ -981,10 +1043,11 @@ impl Agent {
 }
 
 fn prepare_sandbox(
-    worktree: &Path,
+    writable_root: &Path,
+    rpc_dir: &Path,
     home: &Path,
 ) -> Result<tempfile::NamedTempFile> {
-    let profile_text = sandbox::build_profile(worktree, home)?;
+    let profile_text = sandbox::build_profile(writable_root, rpc_dir, home)?;
     let mut profile_file = tempfile::Builder::new()
         .prefix("quorum-sandbox-")
         .suffix(".sb")
@@ -1017,7 +1080,7 @@ fn prepare_pty_args(
     let home = dirs::home_dir()
         .ok_or_else(|| Error::Other("HOME directory not available".into()))?;
     let claude = resolve_claude(&home)?;
-    let profile_file = prepare_sandbox(&spec.sandbox_root, &home)?;
+    let profile_file = prepare_sandbox(&spec.sandbox_root, &spec.rpc_dir, &home)?;
 
     let profile_path = profile_file
         .path()
@@ -1053,7 +1116,7 @@ fn prepare_managed_args(
     let home = dirs::home_dir()
         .ok_or_else(|| Error::Other("HOME directory not available".into()))?;
     let claude = resolve_claude(&home)?;
-    let profile_file = prepare_sandbox(&spec.sandbox_root, &home)?;
+    let profile_file = prepare_sandbox(&spec.sandbox_root, &spec.rpc_dir, &home)?;
 
     let profile_path = profile_file
         .path()
@@ -1100,10 +1163,12 @@ fn resolve_claude(home: &Path) -> Result<String> {
 
 // ── per-turn provider configs ─────────────────────────────────────────────
 
-/// Codex: `codex exec [resume <id>] --json …`. Approvals off + codex's own
-/// workspace-write sandbox on, via `-c` (works on both `exec` and
-/// `exec resume`, unlike the `-s`/`-a` flags). Quorum does not wrap codex
-/// in sandbox-exec; codex sandboxes itself.
+/// Codex: `codex exec [resume <id>] --json …`. Approvals off and codex's own
+/// sandbox set to `danger-full-access` via `-c` (works on both `exec` and
+/// `exec resume`, unlike the `-s`/`-a` flags). Quorum now runs codex under
+/// sandbox-exec like every other agent, so codex's own confinement is disabled
+/// to leave a single boundary — and so codex can reach its RPC mailbox, which
+/// lives outside the worktree that `workspace-write` would have confined it to.
 fn codex_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = vec!["exec".into()];
     if let Some(id) = session_id {
@@ -1115,7 +1180,7 @@ fn codex_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&st
     args.push("-c".into());
     args.push("approval_policy=\"never\"".into());
     args.push("-c".into());
-    args.push("sandbox_mode=\"workspace-write\"".into());
+    args.push("sandbox_mode=\"danger-full-access\"".into());
     if let Some(effort) = thinking {
         args.push("-c".into());
         args.push(format!("reasoning_effort=\"{effort}\""));
@@ -1774,6 +1839,17 @@ mod tests {
     fn codex_args_reasoning_effort_when_thinking_set() {
         let args = codex_build_args("hi", None, Some("high"));
         assert!(args.contains(&"reasoning_effort=\"high\"".to_string()));
+    }
+
+    #[test]
+    fn codex_args_disable_codex_own_sandbox() {
+        // Quorum now wraps codex in sandbox-exec, so codex's own confinement is
+        // turned fully off — otherwise its workspace-write sandbox would block
+        // the RPC mailbox, which lives outside the worktree.
+        let args = codex_build_args("hi", None, None);
+        assert!(args.contains(&"sandbox_mode=\"danger-full-access\"".to_string()));
+        assert!(!args.iter().any(|a| a.contains("workspace-write")));
+        assert!(args.contains(&"approval_policy=\"never\"".to_string()));
     }
 
     #[test]

--- a/src-tauri/src/exec_session.rs
+++ b/src-tauri/src/exec_session.rs
@@ -35,8 +35,16 @@ type ArgsBuilder = Arc<dyn Fn(&str, Option<&str>, Option<&str>) -> Vec<String> +
 type IdExtractor = Arc<dyn Fn(&Value) -> Option<String> + Send + Sync>;
 
 pub struct ExecSpawn {
-    /// Resolved path to the agent binary.
+    /// Program to launch each turn. Normally `sandbox-exec`, with the real
+    /// agent binary carried in `prefix_args`; tests pass the agent directly.
     pub program: PathBuf,
+    /// Args inserted before the per-turn args on every spawn — e.g.
+    /// `["-f", <profile>, <agent_bin>]` when `program` is `sandbox-exec`. Empty
+    /// when the agent runs unwrapped.
+    pub prefix_args: Vec<String>,
+    /// Sandbox profile tempfile, held for the session's lifetime so the profile
+    /// path embedded in `prefix_args` stays valid across the per-turn respawns.
+    pub profile: Option<tempfile::NamedTempFile>,
     /// The agent's primary worktree — set as the child's cwd.
     pub cwd: PathBuf,
     /// Session id to resume, if one has been captured already.
@@ -45,12 +53,19 @@ pub struct ExecSpawn {
     /// parsing (no events emitted). History for such agents comes from their
     /// on-disk transcript, and the session id from the filesystem.
     pub stdout_is_json: bool,
+    /// Extra environment variables (e.g. `QUORUM_RPC_DIR`) set on every turn's
+    /// child process, layered on top of the inherited environment.
+    pub env: Vec<(String, String)>,
 }
 
 pub struct ExecSession {
     program: PathBuf,
+    prefix_args: Vec<String>,
+    /// Kept alive (not read) so the sandbox profile file outlives the session.
+    _profile: Option<tempfile::NamedTempFile>,
     cwd: PathBuf,
     stdout_is_json: bool,
+    env: Vec<(String, String)>,
     session_id: Arc<Mutex<Option<String>>>,
     child: Arc<Mutex<Option<Child>>>,
     /// Monotonic turn counter. A reap thread only reports its exit if its
@@ -88,8 +103,11 @@ impl ExecSession {
     {
         Self {
             program: spec.program,
+            prefix_args: spec.prefix_args,
+            _profile: spec.profile,
             cwd: spec.cwd,
             stdout_is_json: spec.stdout_is_json,
+            env: spec.env,
             session_id: Arc::new(Mutex::new(spec.session_id)),
             child: Arc::new(Mutex::new(None)),
             turn_seq: Arc::new(AtomicU64::new(0)),
@@ -129,8 +147,12 @@ impl ExecSession {
             (self.build_args)(&prompt, id.as_deref(), thinking)
         };
         let mut cmd = Command::new(&self.program);
+        cmd.args(&self.prefix_args);
         cmd.args(&args);
         cmd.current_dir(&self.cwd);
+        for (k, v) in &self.env {
+            cmd.env(k, v);
+        }
         cmd.stdin(Stdio::null());
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
@@ -339,9 +361,12 @@ mod tests {
         let session = ExecSession::new(
             ExecSpawn {
                 program: script,
+                prefix_args: vec![],
+                profile: None,
                 cwd: dir.path().to_path_buf(),
                 session_id: None,
                 stdout_is_json: true,
+                env: vec![],
             },
             codex_args,
             codex_id,
@@ -393,9 +418,12 @@ mod tests {
         let session = ExecSession::new(
             ExecSpawn {
                 program: script,
+                prefix_args: vec![],
+                profile: None,
                 cwd: dir.path().to_path_buf(),
                 session_id: Some("prev-thread".into()),
                 stdout_is_json: true,
+                env: vec![],
             },
             codex_args,
             codex_id,

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -17,16 +17,31 @@
 //!   conversation, so later turns don't re-send it (no per-turn token tax, no
 //!   accumulating copies).
 //!
-//! Blank the markdown file to disable injection: every helper below no-ops when
-//! the source is empty.
+//! The injected text has two layers: editable general guidance
+//! (`instructions/system_prompt.md`) plus a Quorum-managed protocol block
+//! (`instructions/rpc_protocol.md`) that documents the file-RPC the app exposes
+//! (see `rpc.rs`). The RPC block is code-managed because it must stay in sync
+//! with the implemented op allowlist and the `QUORUM_RPC_DIR` env var; the
+//! general layer is yours to edit. Blank both files to disable injection
+//! entirely — every helper below no-ops when the combined text is empty.
 
-/// The single source of truth. Edit the file, not this constant.
+/// Editable general guidance. Edit the file, not this constant.
 const SYSTEM_PROMPT: &str = include_str!("instructions/system_prompt.md");
 
-/// The instruction text, trimmed. Empty when the source is blank/whitespace,
-/// which makes every injection helper a no-op.
-pub fn text() -> &'static str {
-    SYSTEM_PROMPT.trim()
+/// Quorum-managed RPC protocol block, appended after the general guidance.
+const RPC_INSTRUCTIONS: &str = include_str!("instructions/rpc_protocol.md");
+
+/// The combined instruction text, trimmed. Empty when both sources are
+/// blank/whitespace, which makes every injection helper a no-op.
+pub fn text() -> String {
+    let general = SYSTEM_PROMPT.trim();
+    let rpc = RPC_INSTRUCTIONS.trim();
+    match (general.is_empty(), rpc.is_empty()) {
+        (true, true) => String::new(),
+        (false, true) => general.to_string(),
+        (true, false) => rpc.to_string(),
+        (false, false) => format!("{general}\n\n{rpc}"),
+    }
 }
 
 /// Args for agents that expose `--append-system-prompt` (Claude, Pi).
@@ -52,7 +67,7 @@ pub fn codex_config_args() -> Vec<String> {
     }
     vec![
         "-c".into(),
-        format!("developer_instructions={}", toml_basic_string(text)),
+        format!("developer_instructions={}", toml_basic_string(&text)),
     ]
 }
 
@@ -121,7 +136,7 @@ mod tests {
     fn prepend_only_on_first_turn() {
         let first = prepend_to_prompt("do the thing", None);
         assert!(first.starts_with("<quorum-system>"));
-        assert!(first.contains(text()));
+        assert!(first.contains(text().as_str()));
         assert!(first.contains("</quorum-system>"));
         assert!(first.ends_with("do the thing"));
 

--- a/src-tauri/src/instructions/rpc_protocol.md
+++ b/src-tauri/src/instructions/rpc_protocol.md
@@ -1,0 +1,26 @@
+## Quorum app actions (file RPC)
+
+Your writes are confined to your worktree. When a task needs an action the app must run for you, ask for it through the file mailbox at `$QUORUM_RPC_DIR` and wait for the reply. Only the ops listed below are accepted; anything else is rejected.
+
+To make a call:
+
+1. Choose a unique id (a UUID works).
+2. Write the request **atomically**: write `$QUORUM_RPC_DIR/requests/<id>.json.tmp`, then rename it to `$QUORUM_RPC_DIR/requests/<id>.json`. Body: `{"id":"<id>","op":"<op>","args":{}}`.
+3. Poll for `$QUORUM_RPC_DIR/responses/<id>.json` until it appears (every ~0.2s, with your own timeout), then read it.
+
+A success response is `{"id","ok":true,"exit_code","stdout","stderr"}`; a failure is `{"id","ok":false,"error":"..."}`.
+
+Wait for a reply (shell):
+
+```sh
+ID=$(uuidgen)
+printf '{"id":"%s","op":"ping"}' "$ID" > "$QUORUM_RPC_DIR/requests/$ID.json.tmp"
+mv "$QUORUM_RPC_DIR/requests/$ID.json.tmp" "$QUORUM_RPC_DIR/requests/$ID.json"
+until [ -f "$QUORUM_RPC_DIR/responses/$ID.json" ]; do sleep 0.2; done
+cat "$QUORUM_RPC_DIR/responses/$ID.json"
+```
+
+Available ops:
+
+- `ping` — liveness check; returns `pong`. No args.
+- `git_status` — runs `git status` in your worktree and returns its output. No args.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ mod names;
 mod new_project;
 mod oauth;
 mod pty_session;
+mod rpc;
 mod run_detect;
 mod run_session;
 mod sandbox;

--- a/src-tauri/src/managed_session.rs
+++ b/src-tauri/src/managed_session.rs
@@ -25,6 +25,9 @@ pub struct ManagedSpawn<'a> {
     pub program: &'a Path,
     pub args: &'a [String],
     pub cwd: &'a Path,
+    /// Extra environment variables (e.g. `QUORUM_RPC_DIR`). `Command` inherits
+    /// the parent environment by default; these are layered on top.
+    pub env: &'a [(String, String)],
 }
 
 #[derive(Debug, Clone)]
@@ -42,6 +45,9 @@ impl ManagedSession {
         let mut cmd = Command::new(spec.program);
         cmd.args(spec.args);
         cmd.current_dir(spec.cwd);
+        for (k, v) in spec.env {
+            cmd.env(k, v);
+        }
         cmd.stdin(Stdio::piped());
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());

--- a/src-tauri/src/pty_session.rs
+++ b/src-tauri/src/pty_session.rs
@@ -24,6 +24,9 @@ pub struct PtySpawn<'a> {
     pub args: &'a [String],
     /// Working directory inside the PTY.
     pub cwd: &'a std::path::Path,
+    /// Extra environment variables to set on the child, applied after the
+    /// inherited environment (so they win on collision).
+    pub env: &'a [(String, String)],
     pub cols: u16,
     pub rows: u16,
 }
@@ -67,6 +70,10 @@ impl PtySession {
         // to a line-buffered mode that doesn't match what the user expects.
         cmd.env("TERM", "xterm-256color");
         cmd.env("COLORTERM", "truecolor");
+        // Caller-supplied overrides (e.g. QUORUM_RPC_DIR) last, so they win.
+        for (k, v) in spec.env {
+            cmd.env(k, v);
+        }
 
         let mut child = pair
             .slave
@@ -205,6 +212,7 @@ mod tests {
                     "printf hello-from-pty".to_string(),
                 ],
                 cwd: td.path(),
+                env: &[],
                 cols: 80,
                 rows: 24,
             },

--- a/src-tauri/src/rpc.rs
+++ b/src-tauri/src/rpc.rs
@@ -1,0 +1,413 @@
+//! File-mailbox RPC between a sandboxed agent and the app.
+//!
+//! A sandboxed agent can't run actions outside its worktree, so it asks the
+//! app to. This is tool-calling over files: the agent writes a JSON **request**
+//! (`op` + `args`) into its mailbox; an in-app watcher (see
+//! `supervisor::spawn_rpc_watcher`) executes a deterministic, allowlisted action
+//! and writes a JSON **response**; the agent reads it. The exchange is
+//! synchronous (the agent waits for the response), yields a single final payload
+//! (no streaming), and is **allowlist-only** — anything not in [`dispatch`] is
+//! rejected, which keeps the sandbox meaningful.
+//!
+//! The mailbox lives at `~/.quorum/rpc/<agent-id>/` — a private (0700) per-agent
+//! dir on the sandbox's write-allow list (see `sandbox.rs`) but entirely outside
+//! the git worktree tree, so it never pollutes a repo and is immune to git
+//! operations (`git clean`, branch switches) the agent might run. Its path is
+//! handed to the agent via the `QUORUM_RPC_DIR` env var, injected at spawn.
+//!
+//! ```text
+//! $QUORUM_RPC_DIR/
+//!   requests/<uuid>.json     # agent writes
+//!   responses/<uuid>.json    # app writes
+//! ```
+//!
+//! This module is intentionally self-contained — no `Supervisor` or Tauri
+//! dependency — so the protocol is unit-testable in isolation. The lifecycle
+//! glue (start a watcher per agent, stop it on teardown) lives in `supervisor`.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::{Duration, SystemTime};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::process::Command;
+
+use crate::error::{Error, Result};
+
+/// App-side ceiling on a single op. A hung command surfaces as an error
+/// response rather than blocking the watcher forever. The agent runs its own
+/// (shorter) poll timeout independently — see the instruction block.
+const OP_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// How old an unparseable request must be before we give up on it. A compliant
+/// agent writes atomically (tmp + rename), so a renamed file is always complete;
+/// this grace window only tolerates a non-compliant agent caught mid-write.
+/// Past it, the file is treated as malformed: answered with an error and removed.
+const STALE_REQUEST_AGE: Duration = Duration::from_secs(5);
+
+/// One request from the agent. The `id` is carried in the filename (the pairing
+/// key), so it's not parsed from the body here; `args` defaults to null when
+/// omitted. Unknown body fields (including a redundant `id`) are ignored.
+#[derive(Debug, Deserialize)]
+pub struct Request {
+    pub op: String,
+    #[serde(default)]
+    pub args: Value,
+}
+
+/// One response written back to the agent. `exit_code`/`stdout`/`stderr` are
+/// present on success; `error` on failure. Serialized fields are omitted when
+/// `None` so the two shapes stay clean on disk.
+#[derive(Debug, Serialize)]
+pub struct Response {
+    pub id: String,
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stdout: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stderr: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl Response {
+    fn ok(id: &str, exit_code: i32, stdout: String, stderr: String) -> Self {
+        Self {
+            id: id.to_string(),
+            ok: true,
+            exit_code: Some(exit_code),
+            stdout: Some(stdout),
+            stderr: Some(stderr),
+            error: None,
+        }
+    }
+
+    fn err(id: &str, error: impl Into<String>) -> Self {
+        Self {
+            id: id.to_string(),
+            ok: false,
+            exit_code: None,
+            stdout: None,
+            stderr: None,
+            error: Some(error.into()),
+        }
+    }
+}
+
+/// `~/.quorum/rpc/<agent-id>/` — the agent's private mailbox root.
+pub fn mailbox_dir(agent_id: &str) -> Result<PathBuf> {
+    let home =
+        dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
+    Ok(home.join(".quorum").join("rpc").join(agent_id))
+}
+
+/// Create the mailbox and its `requests/`/`responses/` subdirs. Idempotent;
+/// called at spawn. The agent's dir is locked down to 0700 — it's a private
+/// control channel, not shared.
+pub fn ensure_mailbox(dir: &Path) -> Result<()> {
+    let requests = dir.join("requests");
+    let responses = dir.join("responses");
+    for sub in [&requests, &responses] {
+        std::fs::create_dir_all(sub)
+            .map_err(|e| Error::Other(format!("create rpc mailbox {}: {e}", sub.display())))?;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // 0700 on the root *and* both subdirs — the responses can carry
+        // sensitive tool output, so don't rely on umask for the children.
+        for p in [dir, requests.as_path(), responses.as_path()] {
+            std::fs::set_permissions(p, std::fs::Permissions::from_mode(0o700))
+                .map_err(|e| Error::Other(format!("chmod rpc mailbox {}: {e}", p.display())))?;
+        }
+    }
+    Ok(())
+}
+
+/// Process every pending request file once: parse → dispatch → write response →
+/// delete the request. Driven on a fixed tick by the per-agent watcher. Errors
+/// on a single request are logged and isolated — one bad file can't stall the
+/// rest. Commands run in `cwd` (the agent's primary worktree).
+pub async fn process_pending(rpc_dir: &Path, cwd: &Path) {
+    let requests = rpc_dir.join("requests");
+    let responses = rpc_dir.join("responses");
+
+    let entries = match std::fs::read_dir(&requests) {
+        Ok(e) => e,
+        // No mailbox yet (or removed during teardown) — nothing to do.
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        // Only consume finished `<uuid>.json` files. The agent writes
+        // atomically (tmp + rename) so we never observe a half-written one;
+        // any other extension (e.g. a stray `.tmp`) is ignored.
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        handle_request_file(&path, &responses, cwd).await;
+    }
+}
+
+/// Handle one request file. The response filename is derived from the request's
+/// file stem (the `<uuid>` the agent polls), not the in-body `id`, so the agent
+/// always finds its reply where it expects. The stem must be a safe token —
+/// a defense-in-depth guard against a malformed id escaping the mailbox.
+async fn handle_request_file(path: &Path, responses: &Path, cwd: &Path) {
+    let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+        return;
+    };
+    if !is_safe_key(stem) {
+        tracing::warn!(file = %path.display(), "rpc: unsafe request filename, skipping");
+        return;
+    }
+
+    let raw = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!(error = %e, file = %path.display(), "rpc: read request failed");
+            return;
+        }
+    };
+
+    let req: Request = match serde_json::from_slice(&raw) {
+        Ok(r) => r,
+        Err(e) => {
+            // Could be a mid-write read (only if the agent ignored the
+            // write-atomically contract) or a genuinely malformed file. Within
+            // the grace window, leave it — a transient partial resolves on the
+            // next tick. Past it, give up: answer with an error so the agent
+            // stops waiting, and delete it so we stop re-reading (and
+            // re-logging) it every tick.
+            if file_age(path).is_some_and(|age| age >= STALE_REQUEST_AGE) {
+                tracing::warn!(error = %e, file = %path.display(), "rpc: malformed request, answering with error");
+                let resp = Response::err(stem, format!("malformed request JSON: {e}"));
+                if write_response_atomic(responses, stem, &resp).is_ok() {
+                    let _ = std::fs::remove_file(path);
+                }
+            } else {
+                tracing::debug!(error = %e, file = %path.display(), "rpc: unparseable request (will retry)");
+            }
+            return;
+        }
+    };
+
+    let resp = dispatch(stem, &req.op, &req.args, cwd).await;
+
+    if let Err(e) = write_response_atomic(responses, stem, &resp) {
+        tracing::warn!(error = %e, id = %stem, "rpc: write response failed");
+        // Leave the request so a later tick can retry rather than dropping it.
+        return;
+    }
+
+    // Answered — remove the request so it's processed exactly once.
+    if let Err(e) = std::fs::remove_file(path) {
+        tracing::warn!(error = %e, file = %path.display(), "rpc: remove request failed");
+    }
+}
+
+/// The op allowlist. Adding an op is one arm here plus a line in the instruction
+/// block (`instructions/rpc_protocol.md`). Anything unmatched is rejected, which
+/// is what keeps the sandbox meaningful — the agent can only invoke vetted,
+/// deterministic actions.
+async fn dispatch(id: &str, op: &str, _args: &Value, cwd: &Path) -> Response {
+    match op {
+        // Liveness probe — proves the round-trip with no side effects.
+        "ping" => Response::ok(id, 0, "pong".to_string(), String::new()),
+        // Example real op: run a deterministic command and report its result.
+        "git_status" => {
+            run_command(id, cwd, "git", &["status", "--porcelain=v1", "--branch"]).await
+        }
+        other => Response::err(id, format!("unknown op: {other}")),
+    }
+}
+
+/// Run a fixed command in `cwd`, capturing exit/stdout/stderr, bounded by
+/// [`OP_TIMEOUT`]. `kill_on_drop` ensures a timed-out child is reaped when the
+/// timeout future is dropped.
+async fn run_command(id: &str, cwd: &Path, program: &str, args: &[&str]) -> Response {
+    let mut cmd = Command::new(program);
+    cmd.args(args)
+        .current_dir(cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+
+    let child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => return Response::err(id, format!("spawn {program}: {e}")),
+    };
+
+    match tokio::time::timeout(OP_TIMEOUT, child.wait_with_output()).await {
+        Ok(Ok(out)) => Response::ok(
+            id,
+            out.status.code().unwrap_or(-1),
+            String::from_utf8_lossy(&out.stdout).into_owned(),
+            String::from_utf8_lossy(&out.stderr).into_owned(),
+        ),
+        Ok(Err(e)) => Response::err(id, format!("run {program}: {e}")),
+        Err(_) => Response::err(
+            id,
+            format!("op timed out after {}s", OP_TIMEOUT.as_secs()),
+        ),
+    }
+}
+
+/// Write `responses/<key>.json` atomically: write a sibling `.tmp`, then rename
+/// into place (atomic on the same filesystem), so the agent never reads a
+/// half-written response.
+fn write_response_atomic(responses: &Path, key: &str, resp: &Response) -> Result<()> {
+    let json = serde_json::to_vec_pretty(resp)
+        .map_err(|e| Error::Other(format!("serialize rpc response: {e}")))?;
+    let final_path = responses.join(format!("{key}.json"));
+    let tmp_path = responses.join(format!("{key}.json.tmp"));
+    std::fs::write(&tmp_path, &json)
+        .map_err(|e| Error::Other(format!("write rpc response tmp: {e}")))?;
+    std::fs::rename(&tmp_path, &final_path)
+        .map_err(|e| Error::Other(format!("rename rpc response: {e}")))?;
+    Ok(())
+}
+
+/// A request/response key (the `<uuid>` stem) must be a plain token — no path
+/// separators, dots, or empties — so it can't escape the mailbox dir.
+fn is_safe_key(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+/// How long ago `path` was last modified, or `None` if that can't be determined
+/// (missing file, or an mtime in the future from clock skew — treated as fresh).
+fn file_age(path: &Path) -> Option<Duration> {
+    let modified = std::fs::metadata(path).ok()?.modified().ok()?;
+    SystemTime::now().duration_since(modified).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_request(requests: &Path, name: &str, body: &str) {
+        std::fs::write(requests.join(name), body).unwrap();
+    }
+
+    #[test]
+    fn ensure_mailbox_creates_both_subdirs() {
+        let td = tempfile::tempdir().unwrap();
+        let dir = td.path().join(".quorum-rpc");
+        ensure_mailbox(&dir).unwrap();
+        assert!(dir.join("requests").is_dir());
+        assert!(dir.join("responses").is_dir());
+        // Idempotent.
+        ensure_mailbox(&dir).unwrap();
+    }
+
+    #[test]
+    fn file_age_is_small_for_a_fresh_file() {
+        let td = tempfile::tempdir().unwrap();
+        let f = td.path().join("fresh");
+        std::fs::write(&f, b"x").unwrap();
+        let age = file_age(&f).expect("fresh file has an age");
+        // Just written, so well within the grace window (the give-up branch
+        // keys off `age >= STALE_REQUEST_AGE`).
+        assert!(age < STALE_REQUEST_AGE);
+        // Missing file → None (not treated as stale).
+        assert!(file_age(&td.path().join("nope")).is_none());
+    }
+
+    #[test]
+    fn is_safe_key_rejects_traversal() {
+        assert!(is_safe_key("abc-123_DEF"));
+        assert!(!is_safe_key(""));
+        assert!(!is_safe_key("../escape"));
+        assert!(!is_safe_key("a/b"));
+        assert!(!is_safe_key("with.dot"));
+    }
+
+    #[tokio::test]
+    async fn ping_round_trips_to_a_response_file() {
+        let td = tempfile::tempdir().unwrap();
+        let rpc_dir = td.path().join(".quorum-rpc");
+        ensure_mailbox(&rpc_dir).unwrap();
+        write_request(
+            &rpc_dir.join("requests"),
+            "req-1.json",
+            r#"{"id":"req-1","op":"ping"}"#,
+        );
+
+        process_pending(&rpc_dir, td.path()).await;
+
+        // Request consumed; response written.
+        assert!(!rpc_dir.join("requests/req-1.json").exists());
+        let body = std::fs::read_to_string(rpc_dir.join("responses/req-1.json")).unwrap();
+        let v: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["id"], "req-1");
+        assert_eq!(v["ok"], true);
+        assert_eq!(v["exit_code"], 0);
+        assert_eq!(v["stdout"], "pong");
+        // No leftover temp file.
+        assert!(!rpc_dir.join("responses/req-1.json.tmp").exists());
+    }
+
+    #[tokio::test]
+    async fn unknown_op_is_rejected() {
+        let td = tempfile::tempdir().unwrap();
+        let rpc_dir = td.path().join(".quorum-rpc");
+        ensure_mailbox(&rpc_dir).unwrap();
+        write_request(
+            &rpc_dir.join("requests"),
+            "req-2.json",
+            r#"{"id":"req-2","op":"rm_rf_everything","args":{}}"#,
+        );
+
+        process_pending(&rpc_dir, td.path()).await;
+
+        let body = std::fs::read_to_string(rpc_dir.join("responses/req-2.json")).unwrap();
+        let v: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["ok"], false);
+        assert!(v["error"].as_str().unwrap().contains("unknown op"));
+    }
+
+    #[tokio::test]
+    async fn fresh_unparseable_request_is_left_for_retry() {
+        let td = tempfile::tempdir().unwrap();
+        let rpc_dir = td.path().join(".quorum-rpc");
+        ensure_mailbox(&rpc_dir).unwrap();
+        write_request(&rpc_dir.join("requests"), "req-3.json", "{ not json");
+
+        process_pending(&rpc_dir, td.path()).await;
+
+        // Within the grace window: left in place (could be a mid-write), no
+        // response fabricated. Once older than STALE_REQUEST_AGE it would
+        // instead get an ok:false error and be removed (see file_age logic).
+        assert!(rpc_dir.join("requests/req-3.json").exists());
+        assert!(!rpc_dir.join("responses/req-3.json").exists());
+    }
+
+    #[tokio::test]
+    async fn git_status_runs_a_real_command() {
+        // A non-repo cwd still exercises the spawn/capture/timeout path: git
+        // exits non-zero with a message on stderr, which we report faithfully.
+        let td = tempfile::tempdir().unwrap();
+        let rpc_dir = td.path().join(".quorum-rpc");
+        ensure_mailbox(&rpc_dir).unwrap();
+        write_request(
+            &rpc_dir.join("requests"),
+            "req-4.json",
+            r#"{"id":"req-4","op":"git_status"}"#,
+        );
+
+        process_pending(&rpc_dir, td.path()).await;
+
+        let body = std::fs::read_to_string(rpc_dir.join("responses/req-4.json")).unwrap();
+        let v: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["id"], "req-4");
+        // ok:true means the command ran (regardless of git's own exit code);
+        // exit_code is present.
+        assert_eq!(v["ok"], true);
+        assert!(v["exit_code"].is_number());
+    }
+}

--- a/src-tauri/src/run_session.rs
+++ b/src-tauri/src/run_session.rs
@@ -179,6 +179,7 @@ where
             program,
             args,
             cwd,
+            env: &[],
             cols: 120,
             rows: 32,
         },

--- a/src-tauri/src/sandbox.rs
+++ b/src-tauri/src/sandbox.rs
@@ -1,22 +1,41 @@
-//! Per-agent macOS sandbox profile for yolo-mode Claude.
+//! Per-agent macOS sandbox profile — the single, unified isolation layer for
+//! every agent Quorum runs.
 //!
-//! The app still launches Claude in a normal PTY. `sandbox-exec` is only
-//! the process wrapper around that PTY child, so terminal streaming and
-//! startup timing stay the same while writes are constrained to the
-//! agent's parent dir (under `~/.quorum/worktrees/<id>/`) plus standard
-//! state/cache locations. The agent's per-repo worktrees live as
-//! subdirs of that parent, so each one inherits the writable allowance
-//! without re-spawning claude.
+//! The app launches each agent (Claude *and* the per-turn agents — codex,
+//! cursor, opencode, pi, antigravity) under `sandbox-exec` with this profile,
+//! rather than relying on each CLI's own sandbox. `sandbox-exec` is just the
+//! process wrapper around the PTY/exec child, so terminal streaming and startup
+//! timing are unchanged while *writes* are constrained to the agent's parent dir
+//! (under `~/.quorum/worktrees/<id>/`) plus standard state/cache locations and
+//! each agent's own on-disk session store. The agent's per-repo worktrees live
+//! as subdirs of that parent, so each inherits the writable allowance.
+//!
+//! Because confinement is by *write* path (reads and network stay open via
+//! `allow default`), each agent that the wrapper covers must have its
+//! out-of-worktree write locations (session transcripts, config, auth refresh)
+//! on the allow-list below — otherwise it can't persist its own state. That
+//! covers the agents' own dot-dir stores plus the standard per-user
+//! cache/state dirs in both XDG (`~/.cache`, `~/.config`, `~/.local`) and
+//! macOS-native (`~/Library/Caches`, `~/Library/Application Support`) form,
+//! since the agents' subprocess toolchains and macOS frameworks write to the
+//! latter. The agent CLIs' own sandboxes are disabled (e.g. codex runs
+//! `danger-full-access`) so the two don't fight, leaving `sandbox-exec` as the
+//! sole boundary.
 
 use std::path::Path;
 
 use crate::error::{Error, Result};
 
-pub fn build_profile(writable_root: &Path, home: &Path) -> Result<String> {
+/// Build the SBPL profile. `writable_root` is the agent's parent dir;
+/// `rpc_dir` is its private file-mailbox (`~/.quorum/rpc/<id>/`), which lives
+/// outside the worktree tree and so needs its own allow entry.
+pub fn build_profile(writable_root: &Path, rpc_dir: &Path, home: &Path) -> Result<String> {
     let writable_root = canonical(writable_root)?;
+    let rpc_root = canonical(rpc_dir)?;
     let home = canonical(home)?;
 
     let writable_root_s = sbpl_string(&writable_root.to_string_lossy());
+    let rpc_root_s = sbpl_string(&rpc_root.to_string_lossy());
     let home_s = home.to_string_lossy();
 
     let claude_state = sbpl_string(&format!("{home_s}/.claude"));
@@ -25,6 +44,21 @@ pub fn build_profile(writable_root: &Path, home: &Path) -> Result<String> {
     let cache_state = sbpl_string(&format!("{home_s}/.cache"));
     let config_state = sbpl_string(&format!("{home_s}/.config"));
     let local_state = sbpl_string(&format!("{home_s}/.local"));
+    // macOS-native equivalents of the XDG cache/state dirs above. Native
+    // toolchains the agents invoke (node/npm tooling, git, language SDKs) and
+    // macOS framework caches (CFNetwork, fonts, per-bundle state) write here; a
+    // denied write ranges from a harmless cache miss to a fatal auth-token
+    // write, so allow them on the same "per-user app state, not source/system"
+    // basis as `~/.cache`/`~/.config`.
+    let library_caches = sbpl_string(&format!("{home_s}/Library/Caches"));
+    let library_app_support = sbpl_string(&format!("{home_s}/Library/Application Support"));
+    // Per-agent on-disk session stores (transcripts, config, auth) for the
+    // per-turn agents now covered by this profile. OpenCode's store lives under
+    // `~/.local/share/opencode`, already covered by `local_state`.
+    let codex_state = sbpl_string(&format!("{home_s}/.codex"));
+    let cursor_state = sbpl_string(&format!("{home_s}/.cursor"));
+    let gemini_state = sbpl_string(&format!("{home_s}/.gemini"));
+    let pi_state = sbpl_string(&format!("{home_s}/.pi"));
 
     Ok(format!(
         r#"(version 1)
@@ -34,6 +68,7 @@ pub fn build_profile(writable_root: &Path, home: &Path) -> Result<String> {
 (deny file-write*)
 (allow file-write*
   (subpath {writable_root_s})
+  (subpath {rpc_root_s})
   (subpath "/private/tmp")
   (subpath "/private/var/folders")
   (subpath "/private/var/tmp")
@@ -42,7 +77,13 @@ pub fn build_profile(writable_root: &Path, home: &Path) -> Result<String> {
   (subpath {npm_state})
   (subpath {cache_state})
   (subpath {config_state})
-  (subpath {local_state}))
+  (subpath {local_state})
+  (subpath {library_caches})
+  (subpath {library_app_support})
+  (subpath {codex_state})
+  (subpath {cursor_state})
+  (subpath {gemini_state})
+  (subpath {pi_state}))
 
 ;; PTYs and basic device files are required for terminal programs.
 (allow file-write* (literal "/dev/null") (literal "/dev/zero"))
@@ -72,15 +113,23 @@ mod tests {
     fn profile_includes_writable_root_and_denies_writes_by_default() {
         let td = tempfile::tempdir().unwrap();
         let root = td.path().join("agent-parent");
+        let rpc = td.path().join("rpc");
         let home = td.path().join("home");
         std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&rpc).unwrap();
         std::fs::create_dir_all(&home).unwrap();
 
-        let profile = build_profile(&root, &home).unwrap();
+        let profile = build_profile(&root, &rpc, &home).unwrap();
         let canonical_root = std::fs::canonicalize(&root).unwrap();
+        let canonical_rpc = std::fs::canonicalize(&rpc).unwrap();
 
         assert!(profile.contains("(deny file-write*)"));
         assert!(profile.contains(&format!("\"{}\"", canonical_root.display())));
+        // The mailbox lives outside the worktree tree, so it needs its own entry.
+        assert!(profile.contains(&format!("\"{}\"", canonical_rpc.display())));
+        // macOS-native per-user state dirs, needed by the agents' toolchains.
+        assert!(profile.contains("/Library/Caches"));
+        assert!(profile.contains("/Library/Application Support"));
     }
 
     #[test]

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -14,6 +14,7 @@ use crate::branding;
 use crate::error::{Error, Result};
 use crate::git;
 use crate::pty_session::{PtySession, PtySpawn};
+use crate::rpc;
 use crate::run_session::{
     self, shell_args, user_shell, RunPhase, RunSession, RunStateSnapshot,
 };
@@ -100,6 +101,8 @@ pub struct RunStatePayload {
 
 const WATCHDOG_TICK: Duration = Duration::from_millis(500);
 const SPAWN_TIMEOUT: Duration = Duration::from_secs(15);
+/// How often the per-agent RPC watcher scans its mailbox for new requests.
+const RPC_TICK: Duration = Duration::from_millis(100);
 
 pub struct Supervisor {
     pub workspace: Arc<WorkspaceManager>,
@@ -203,6 +206,7 @@ impl Supervisor {
                 program: &shell_path,
                 args: &[],
                 cwd: &worktree,
+                env: &[],
                 cols: 120,
                 rows: 32,
             },
@@ -583,6 +587,15 @@ impl Supervisor {
             .first()
             .ok_or_else(|| Error::Other("agent has no tracked repos".into()))?;
         let cwd = repo_worktree_path(agent_id, &primary.subdir)?;
+        // Sandbox writable root — the agent's parent dir. Every agent (claude
+        // and per-turn alike) now runs under sandbox-exec rooted here.
+        let sandbox_root = agent_parent_dir(agent_id)?;
+
+        // The agent's file-mailbox RPC dir, created before spawn so the watcher
+        // (and the agent's `QUORUM_RPC_DIR`) have a target from turn one.
+        let rpc_dir = rpc::mailbox_dir(agent_id)?;
+        rpc::ensure_mailbox(&rpc_dir)?;
+        let watcher_cwd = cwd.clone();
 
         // Claude only writes a session file once the first turn lands.
         // If task is still empty (no first user message has ever been
@@ -636,7 +649,7 @@ impl Supervisor {
                     let spec = SpawnSpec {
                         agent_id: &agent_id_str,
                         cwd,
-                        sandbox_root: agent_parent_dir(agent_id)?,
+                        sandbox_root: sandbox_root.clone(),
                         session_id,
                         // Per-turn native always resumes (the agent built its
                         // session in the Custom view first).
@@ -644,6 +657,7 @@ impl Supervisor {
                         // Per-turn agents take effort per-turn (build-args),
                         // not at spawn.
                         effort: None,
+                        rpc_dir: rpc_dir.clone(),
                         cols: 120,
                         rows: 32,
                     };
@@ -661,8 +675,12 @@ impl Supervisor {
                 // itself rather than running under sandbox-exec.
                 AgentView::Custom => spawn_per_turn_agent(
                     &provider,
-                    cwd,
-                    session_id.clone(),
+                    PerTurnSpec {
+                        cwd,
+                        sandbox_root: sandbox_root.clone(),
+                        session_id: session_id.clone(),
+                        rpc_dir: rpc_dir.clone(),
+                    },
                     app.clone(),
                     agent_id_str.clone(),
                     self.clone(),
@@ -673,16 +691,16 @@ impl Supervisor {
             let session_id = session_id
                 .as_deref()
                 .expect("non-codex agents always have a session id");
-            let sandbox_root = agent_parent_dir(agent_id)?;
             let spec = SpawnSpec {
                 agent_id: &agent_id_str,
                 cwd,
-                sandbox_root,
+                sandbox_root: sandbox_root.clone(),
                 session_id,
                 fresh: effective_fresh,
                 // Claude's session-level effort, persisted on the record so it
                 // re-applies on every spawn (fresh, view-switch, resume).
                 effort: record.effort.as_deref(),
+                rpc_dir: rpc_dir.clone(),
                 cols: 120,
                 rows: 32,
             };
@@ -715,7 +733,11 @@ impl Supervisor {
             self.set_status(&app, &agent_id_str, AgentStatus::Idle, None);
         }
 
-        spawn_turn_watchdog(self.clone(), app, agent_id_str, my_gen);
+        spawn_turn_watchdog(self.clone(), app, agent_id_str.clone(), my_gen);
+
+        // Watch this agent's RPC mailbox for the life of this generation,
+        // executing allowlisted ops and writing responses back.
+        spawn_rpc_watcher(self.clone(), agent_id_str, watcher_cwd, rpc_dir, my_gen);
 
         Ok(())
     }
@@ -1661,8 +1683,7 @@ fn spawn_managed_agent(
 /// resume it.
 fn spawn_per_turn_agent(
     provider: &str,
-    cwd: PathBuf,
-    session_id: Option<String>,
+    spec: PerTurnSpec,
     app: AppHandle,
     agent_id: String,
     sup: Arc<Supervisor>,
@@ -1717,7 +1738,6 @@ fn spawn_per_turn_agent(
         transition_active(&sup_for_exit, &app_for_exit, &id_for_exit, AgentStatus::Idle);
     };
 
-    let spec = PerTurnSpec { cwd, session_id };
     let desc = per_turn_descriptor(provider).ok_or_else(|| {
         Error::Other(format!("unknown per-turn agent provider: {provider}"))
     })?;
@@ -2003,6 +2023,37 @@ fn spawn_turn_watchdog(
             if ended {
                 transition_active(&sup, &app, &agent_id, AgentStatus::Idle);
             }
+        }
+    });
+}
+
+/// Drive the agent's file-mailbox RPC for the life of this generation: each
+/// tick, execute any pending requests and write responses. Gen-guarded like
+/// `spawn_turn_watchdog`, so it exits cleanly when the agent is respawned or
+/// torn down (no explicit handle to track). Polling (no `notify` crate) mirrors
+/// the transcript-sync style already used elsewhere.
+fn spawn_rpc_watcher(
+    sup: Arc<Supervisor>,
+    agent_id: String,
+    cwd: PathBuf,
+    rpc_dir: PathBuf,
+    gen: u64,
+) {
+    tauri::async_runtime::spawn(async move {
+        loop {
+            tokio::time::sleep(RPC_TICK).await;
+
+            let current_gen = sup
+                .generations
+                .lock()
+                .get(&agent_id)
+                .copied()
+                .unwrap_or(0);
+            if current_gen != gen {
+                return;
+            }
+
+            rpc::process_pending(&rpc_dir, &cwd).await;
         }
     });
 }


### PR DESCRIPTION
Adds a file-based RPC channel so a sandboxed agent can ask the app to run allowlisted actions: it writes a JSON request to a private per-agent mailbox (`~/.quorum/rpc/<id>/`, 0700, passed via `QUORUM_RPC_DIR`), and a generation-guarded in-app watcher runs the op (`ping`, `git_status`) outside the sandbox and writes an atomic response. To make that out-of-worktree mailbox reachable by every agent, all agents now run under Quorum's `sandbox-exec` profile (previously Claude-only) — the per-turn native-PTY and exec paths are wrapped, and each agent's own sandbox is disabled (codex → `danger-full-access`) so `sandbox-exec` is the single confinement boundary. The profile gains the RPC dir, each per-turn agent's dot-dir store (`~/.codex`, `~/.cursor`, `~/.gemini`, `~/.pi`), and the macOS-native per-user state dirs (`~/Library/Caches`, `~/Library/Application Support`) that agents' subprocess toolchains and macOS frameworks write to — verified under `sandbox-exec` that these parse, allow writes, and still deny writes outside the allow-list. Builds on the instruction-injection module from #128; 227 lib tests pass with no new clippy warnings.

Remaining check before relying on it broadly: smoke-test a turn + an RPC `ping` for codex/cursor/opencode/pi/antigravity in the app to confirm each CLI runs under `sandbox-exec` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)