### PR TITLE
Open chat links in the default browser

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -1,0 +1,38 @@
+// Shared markdown renderer for chat content. Wraps react-markdown and
+// overrides anchor rendering so links open in the user's default browser
+// (via the Tauri shell plugin) instead of navigating inside the app window.
+
+import type { AnchorHTMLAttributes } from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { open as openExternal } from "@tauri-apps/plugin-shell";
+
+function ExternalLink({
+  href,
+  children,
+  ...rest
+}: AnchorHTMLAttributes<HTMLAnchorElement>) {
+  return (
+    <a
+      {...rest}
+      href={href}
+      onClick={(e) => {
+        if (!href) return;
+        e.preventDefault();
+        void openExternal(href).catch(() => {});
+      }}
+    >
+      {children}
+    </a>
+  );
+}
+
+const components: Components = { a: ExternalLink };
+
+export function Markdown({ children }: { children: string }) {
+  return (
+    <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+      {children}
+    </ReactMarkdown>
+  );
+}

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -2,7 +2,7 @@
 // overrides anchor rendering so links open in the user's default browser
 // (via the Tauri shell plugin) instead of navigating inside the app window.
 
-import type { AnchorHTMLAttributes } from "react";
+import type { AnchorHTMLAttributes, MouseEvent } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { open as openExternal } from "@tauri-apps/plugin-shell";
@@ -12,16 +12,16 @@ function ExternalLink({
   children,
   ...rest
 }: AnchorHTMLAttributes<HTMLAnchorElement>) {
+  // Handle both primary clicks (onClick) and auxiliary clicks such as
+  // middle-click (onAuxClick); the latter is not covered by onClick and
+  // would otherwise let the webview navigate away from the app.
+  const openInBrowser = (e: MouseEvent<HTMLAnchorElement>) => {
+    if (!href) return;
+    e.preventDefault();
+    void openExternal(href).catch(() => {});
+  };
   return (
-    <a
-      {...rest}
-      href={href}
-      onClick={(e) => {
-        if (!href) return;
-        e.preventDefault();
-        void openExternal(href).catch(() => {});
-      }}
-    >
+    <a {...rest} href={href} onClick={openInBrowser} onAuxClick={openInBrowser}>
       {children}
     </a>
   );

--- a/src/components/Workspace/messages/MessageItem.tsx
+++ b/src/components/Workspace/messages/MessageItem.tsx
@@ -1,5 +1,4 @@
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { Markdown } from "../../Markdown";
 import type { ChatItem } from "../../../store";
 import type { ViewItem } from "./pair";
 import { ToolResultItem } from "./ToolResultItem";
@@ -24,7 +23,7 @@ export function MessageItem({ item }: { item: ViewItem }) {
     case "agent_message":
       return (
         <div className="m-agent">
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{item.text}</ReactMarkdown>
+          <Markdown>{item.text}</Markdown>
           {item.streaming && (
             <span className="term-cursor" style={{ marginLeft: 4 }} />
           )}

--- a/src/components/Workspace/messages/presenters/Agent.tsx
+++ b/src/components/Workspace/messages/presenters/Agent.tsx
@@ -1,5 +1,4 @@
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { Markdown } from "../../../Markdown";
 import type { ToolPresenter } from "./types";
 import { getStringField, renderToolResult } from "./util";
 
@@ -49,9 +48,7 @@ export const agentPresenter: ToolPresenter = {
               fontSize: 13.5,
             }}
           >
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>
-              {renderToolResult(result.content)}
-            </ReactMarkdown>
+            <Markdown>{renderToolResult(result.content)}</Markdown>
           </div>
         )}
       </>


### PR DESCRIPTION
Chat markdown links previously navigated inside the Tauri window instead of opening externally. This adds a shared `Markdown` component that wraps `react-markdown` and intercepts anchor clicks, opening URLs in the user's default browser via the Tauri shell plugin (the same pattern already used in onboarding). Both chat markdown render sites — agent messages and subagent results — now use it, so link handling lives in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)