### PR TITLE
Move "New agent" action to top of project agent list

### DIFF
--- a/src/components/Sidebar/ProjectGroup.tsx
+++ b/src/components/Sidebar/ProjectGroup.tsx
@@ -78,16 +78,10 @@ export function ProjectGroup({
       </div>
 
       <div className={`agents ${open ? "" : "closed"}`}>
-        {drafts.map((d) => (
-          <AgentRow
-            key={d.id}
-            kind="draft"
-            draft={d}
-            active={d.id === activeDraftId}
-            showGlyph={showLandmarks}
-            onClick={() => selectDraft(d.id)}
-          />
-        ))}
+        <button className="agent-new" onClick={onAddAgent}>
+          <Icon name="plus" size={11} />
+          <span>New agent</span>
+        </button>
         {agents.map((a) => (
           <AgentRow
             key={a.id}
@@ -98,10 +92,16 @@ export function ProjectGroup({
             onClick={() => selectAgent(a.id)}
           />
         ))}
-        <button className="agent-new" onClick={onAddAgent}>
-          <Icon name="plus" size={11} />
-          <span>New agent</span>
-        </button>
+        {drafts.map((d) => (
+          <AgentRow
+            key={d.id}
+            kind="draft"
+            draft={d}
+            active={d.id === activeDraftId}
+            showGlyph={showLandmarks}
+            onClick={() => selectDraft(d.id)}
+          />
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
New agents appear at the top of the list, so the "New agent" button now renders above the agents/drafts rows to match where they show up.