### PR TITLE
Fix sidebar agent ordering

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -335,8 +335,11 @@ button { cursor: default; }
 }
 
 .agents {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
   margin-left: 0;
-  padding: 2px 0;
+  padding: 4px 0;
   overflow: visible;
   max-height: 1200px;
   transition: max-height .25s var(--ease), opacity .2s var(--ease);
@@ -345,7 +348,7 @@ button { cursor: default; }
 
 .agent {
   display: block;
-  margin: 1px 0 1px 6px;
+  margin: 0 0 0 6px;
   padding: 7px 10px;
   border-radius: var(--r-sm);
   font-size: 12.5px; color: var(--fg-1);
@@ -481,7 +484,7 @@ button { cursor: default; }
 
 .agent-new {
   display: flex; align-items: center; gap: 8px;
-  margin: 1px 0 2px 6px;
+  margin: 0 0 0 6px;
   padding: 4px 8px;
   border-radius: var(--r-sm);
   font-size: 12px; color: var(--fg-3);

--- a/src/components/Sidebar/ProjectGroup.tsx
+++ b/src/components/Sidebar/ProjectGroup.tsx
@@ -82,16 +82,6 @@ export function ProjectGroup({
           <Icon name="plus" size={11} />
           <span>New agent</span>
         </button>
-        {agents.map((a) => (
-          <AgentRow
-            key={a.id}
-            kind="real"
-            agent={a}
-            active={a.id === selectedAgentId}
-            showGlyph={showLandmarks}
-            onClick={() => selectAgent(a.id)}
-          />
-        ))}
         {drafts.map((d) => (
           <AgentRow
             key={d.id}
@@ -100,6 +90,16 @@ export function ProjectGroup({
             active={d.id === activeDraftId}
             showGlyph={showLandmarks}
             onClick={() => selectDraft(d.id)}
+          />
+        ))}
+        {agents.map((a) => (
+          <AgentRow
+            key={a.id}
+            kind="real"
+            agent={a}
+            active={a.id === selectedAgentId}
+            showGlyph={showLandmarks}
+            onClick={() => selectAgent(a.id)}
           />
         ))}
       </div>

--- a/src/store.ts
+++ b/src/store.ts
@@ -1292,7 +1292,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       base: "main",
     };
     set((s) => ({
-      drafts: [...s.drafts, draft],
+      drafts: [draft, ...s.drafts],
       activeDraftId: draft.id,
       selectedAgentId: null,
     }));


### PR DESCRIPTION
Adjust the sidebar agent list to use a consistent 4px vertical gap that also includes the New agent button.

Render draft agents before existing agents and prepend newly-created drafts so a new agent appears at the top of its project list.

This fixes the ordering regression where the New agent action selected a draft but displayed it below live agents.

Validated with `npm run check`.
