### PR TITLE
feat: show provider brand-icon chips in sidebar agent rows

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -376,6 +376,11 @@ button { cursor: default; }
 }
 .agent.active .ag-glyph { color: var(--accent); }
 .agent-row .ag-name { font-weight: 500; color: inherit; flex-shrink: 0; }
+.agent-row .ag-prov-chip {
+  flex-shrink: 0;
+  display: inline-flex; align-items: center;
+  margin-left: -2px;
+}
 .agent-row .ag-provider-inline {
   font-size: 11.5px;
   color: var(--fg-3);

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -4,7 +4,9 @@ import type { AgentRecord, AgentStatus } from "../../api";
 import type { DraftAgent } from "../../store";
 import { useAppStore } from "../../store";
 import { LANDMARK_NAMES } from "../../data/landmarks";
+import { providerChip, providerLabel } from "../../data/providers";
 import { Icon, LandmarkGlyph } from "../Icon";
+import { ProviderIcon } from "../ProviderIcon";
 import { formatAge, formatTokens } from "../../util/format";
 import { useMinuteClock } from "../../util/hooks";
 import { AgentStatsPopover, type AgentStats } from "./AgentStatsPopover";
@@ -86,7 +88,9 @@ function RealRow({ agent, active, showGlyph, onClick }: RealRowProps) {
           </span>
         )}
         <span className="ag-name">{agent.name}</span>
-        <span className="ag-provider-inline">· {agent.provider}</span>
+        <span className="ag-prov-chip" title={providerLabel(agent.provider)}>
+          <ProviderIcon slug={agent.provider} {...providerChip(agent.provider)} size={15} />
+        </span>
         <span className="ag-actions">
           {stoppable && (
             <button
@@ -149,8 +153,11 @@ function DraftRow({ draft, active, showGlyph, onClick }: DraftRowProps) {
           </span>
         )}
         <span className="ag-name">{draft.name}</span>
+        <span className="ag-prov-chip" title={providerLabel(draft.provider)}>
+          <ProviderIcon slug={draft.provider} {...providerChip(draft.provider)} size={15} />
+        </span>
         <span className="ag-provider-inline" style={{ color: "var(--accent)" }}>
-          · new
+          new
         </span>
         <button className="ag-discard" onClick={onDiscard} title="Discard">
           <Icon name="close" />

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -89,7 +89,7 @@ function RealRow({ agent, active, showGlyph, onClick }: RealRowProps) {
         )}
         <span className="ag-name">{agent.name}</span>
         <span className="ag-prov-chip" title={providerLabel(agent.provider)}>
-          <ProviderIcon slug={agent.provider} {...providerChip(agent.provider)} size={15} />
+          <ProviderIcon slug={agent.provider} {...providerChip(agent.provider)} size={18} />
         </span>
         <span className="ag-actions">
           {stoppable && (
@@ -154,7 +154,7 @@ function DraftRow({ draft, active, showGlyph, onClick }: DraftRowProps) {
         )}
         <span className="ag-name">{draft.name}</span>
         <span className="ag-prov-chip" title={providerLabel(draft.provider)}>
-          <ProviderIcon slug={draft.provider} {...providerChip(draft.provider)} size={15} />
+          <ProviderIcon slug={draft.provider} {...providerChip(draft.provider)} size={18} />
         </span>
         <span className="ag-provider-inline" style={{ color: "var(--accent)" }}>
           new

--- a/src/data/providers.ts
+++ b/src/data/providers.ts
@@ -52,6 +52,15 @@ export function providerLabel(id: string | null | undefined): string {
   return PROVIDERS.find((p) => p.id === id)?.label ?? id;
 }
 
+/** Chip metadata (monogram + hue) for a provider id, used to render a brand
+ *  icon via {@link ProviderIcon}. Unknown ids get a derived two-letter monogram
+ *  and neutral hue so the chip still renders rather than breaking. */
+export function providerChip(id: string | null | undefined): { short: string; hue: number } {
+  const p = PROVIDERS.find((x) => x.id === id);
+  if (p) return { short: p.short, hue: p.hue };
+  return { short: (id ?? "?").slice(0, 2).toUpperCase(), hue: 0 };
+}
+
 export interface Accent {
   id: string;
   label: string;


### PR DESCRIPTION
## What

Replaces the plain text provider labels in the sidebar agent rows (`· claude`, `· codex`, `· pi`, etc.) with the hue-tinted **`ProviderIcon`** chip — the same brand-icon chip already used in the composer's model picker and the Settings → Providers pane. The native brand icon now shows consistently everywhere.

## Why

The sidebar was the one remaining place rendering the provider as raw text. Reusing the existing `ProviderIcon` component keeps the UI consistent and surfaces recognizable brand icons at a glance.

## Changes

- **`src/components/Sidebar/AgentRow.tsx`** — swap the `· {provider}` text for `<ProviderIcon>` in both real-agent and draft rows. The dropped text stays discoverable via a `title` tooltip (human-readable provider name). Drafts keep their accent-colored "new" indicator next to the chip.
- **`src/data/providers.ts`** — add a reusable `providerChip(id)` helper returning `{ short, hue }`, with a derived monogram + neutral hue fallback for unknown ids.
- **`src/app.css`** — add `.ag-prov-chip` for inline alignment/spacing.

Brand SVGs are fetched from the CDN by `ProviderIcon`; it falls back to a two-letter monogram when an icon is missing or offline.

## Verification

Not yet run in a live build — this sandbox has no `node_modules`, so `tsc`/dev server can't run. The edits mirror existing `ProviderIcon` call sites exactly. Worth an eyeball in the running app to confirm the 15px chip size/spacing feels right in the tighter sidebar rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)