### PR TITLE
feat: move Replay tour to a dev-only Developer settings section

### DIFF
--- a/src/components/SettingsScreen/DeveloperPane.tsx
+++ b/src/components/SettingsScreen/DeveloperPane.tsx
@@ -1,0 +1,39 @@
+import { useAppStore } from "../../store";
+import { Icon } from "../Icon";
+import { SetHead, SetGroup, SetRow } from "./primitives";
+
+/** Dev-only settings surface. The nav entry that routes here is gated on
+ *  `import.meta.env.DEV`, so this pane only ships under `bun tauri dev`. */
+export function DeveloperPane() {
+  const openOnboarding = useAppStore((s) => s.openOnboarding);
+  const closeSettingsScreen = useAppStore((s) => s.closeSettingsScreen);
+
+  return (
+    <div className="set-pane">
+      <SetHead
+        eyebrow="Settings · Developer"
+        title="Developer"
+        desc="Tools for working on Quorum itself. Only available in development builds."
+      />
+
+      <SetGroup label="Onboarding" last>
+        <SetRow
+          title="Welcome tour"
+          sub="Replay the cinematic onboarding — the feature tour and first-project walkthrough."
+        >
+          <button
+            type="button"
+            className="btn-t outline"
+            onClick={() => {
+              closeSettingsScreen();
+              openOnboarding();
+            }}
+          >
+            <Icon name="sparkle" size={12} />
+            Replay tour
+          </button>
+        </SetRow>
+      </SetGroup>
+    </div>
+  );
+}

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -37,8 +37,6 @@ export function GeneralPane() {
   const setShowLandmarks = useAppStore((s) => s.setShowLandmarks);
   const features = useAppStore((s) => s.features);
   const setFeature = useAppStore((s) => s.setFeature);
-  const openOnboarding = useAppStore((s) => s.openOnboarding);
-  const closeSettingsScreen = useAppStore((s) => s.closeSettingsScreen);
 
   const FeatureRow = ({ item }: { item: FeatureItem }) => (
     <SetRow title={item.title} sub={item.sub}>
@@ -97,25 +95,6 @@ export function GeneralPane() {
         </SetRow>
         <SetRow title="Landmark glyphs" sub="Tiny location marks beside each agent name.">
           <SetToggle on={showLandmarks} onClick={() => setShowLandmarks(!showLandmarks)} />
-        </SetRow>
-      </SetGroup>
-
-      <SetGroup label="Getting started">
-        <SetRow
-          title="Welcome tour"
-          sub="Replay the cinematic onboarding — the feature tour and first-project walkthrough."
-        >
-          <button
-            type="button"
-            className="btn-t outline"
-            onClick={() => {
-              closeSettingsScreen();
-              openOnboarding();
-            }}
-          >
-            <Icon name="sparkle" size={12} />
-            Replay tour
-          </button>
         </SetRow>
       </SetGroup>
 

--- a/src/components/SettingsScreen/index.tsx
+++ b/src/components/SettingsScreen/index.tsx
@@ -4,11 +4,16 @@ import pkg from "../../../package.json";
 import { GeneralPane } from "./GeneralPane";
 import { AccountPane } from "./AccountPane";
 import { ProvidersPane } from "./ProvidersPane";
+import { DeveloperPane } from "./DeveloperPane";
 
 const NAV: { id: SettingsSection; label: string; icon: IconName }[] = [
   { id: "account", label: "Account", icon: "user" },
   { id: "general", label: "General", icon: "settings" },
   { id: "providers", label: "Providers", icon: "cube" },
+  // Dev-only: omitted entirely from production builds.
+  ...(import.meta.env.DEV
+    ? [{ id: "developer" as const, label: "Developer", icon: "wrench" as const }]
+    : []),
 ];
 
 /** Dedicated full-screen settings surface. Rendered in place of the workspace
@@ -46,9 +51,13 @@ export function SettingsScreen() {
 
       <div className="set-main">
         <div className="set-content">
-          {section === "general" && <GeneralPane />}
           {section === "account" && <AccountPane />}
           {section === "providers" && <ProvidersPane />}
+          {section === "developer" && import.meta.env.DEV && <DeveloperPane />}
+          {/* Fallback: "developer" can't be selected in prod (no nav entry), but
+              guard the render so a stale section value still shows something. */}
+          {(section === "general" ||
+            (section === "developer" && !import.meta.env.DEV)) && <GeneralPane />}
         </div>
       </div>
     </div>

--- a/src/components/SettingsScreen/index.tsx
+++ b/src/components/SettingsScreen/index.tsx
@@ -1,17 +1,26 @@
+import { Suspense, lazy } from "react";
 import { useAppStore, type SettingsSection } from "../../store";
 import { Icon, type IconName } from "../Icon";
 import pkg from "../../../package.json";
 import { GeneralPane } from "./GeneralPane";
 import { AccountPane } from "./AccountPane";
 import { ProvidersPane } from "./ProvidersPane";
-import { DeveloperPane } from "./DeveloperPane";
+
+// Lazily loaded behind `import.meta.env.DEV`. In production the ternary's dead
+// branch — including the dynamic import() — is dropped by Rollup, so the
+// DeveloperPane chunk is never emitted into the build (not merely unloaded).
+const DeveloperPane = import.meta.env.DEV
+  ? lazy(() =>
+      import("./DeveloperPane").then((m) => ({ default: m.DeveloperPane })),
+    )
+  : null;
 
 const NAV: { id: SettingsSection; label: string; icon: IconName }[] = [
   { id: "account", label: "Account", icon: "user" },
   { id: "general", label: "General", icon: "settings" },
   { id: "providers", label: "Providers", icon: "cube" },
   // Dev-only: omitted entirely from production builds.
-  ...(import.meta.env.DEV
+  ...(DeveloperPane
     ? [{ id: "developer" as const, label: "Developer", icon: "wrench" as const }]
     : []),
 ];
@@ -53,11 +62,15 @@ export function SettingsScreen() {
         <div className="set-content">
           {section === "account" && <AccountPane />}
           {section === "providers" && <ProvidersPane />}
-          {section === "developer" && import.meta.env.DEV && <DeveloperPane />}
-          {/* Fallback: "developer" can't be selected in prod (no nav entry), but
-              guard the render so a stale section value still shows something. */}
+          {section === "developer" && DeveloperPane && (
+            <Suspense fallback={null}>
+              <DeveloperPane />
+            </Suspense>
+          )}
+          {/* Fallback: "developer" can't be selected in prod (no nav entry, and
+              DeveloperPane is null), so a stale section value falls back here. */}
           {(section === "general" ||
-            (section === "developer" && !import.meta.env.DEV)) && <GeneralPane />}
+            (section === "developer" && !DeveloperPane)) && <GeneralPane />}
         </div>
       </div>
     </div>

--- a/src/store.ts
+++ b/src/store.ts
@@ -126,7 +126,7 @@ export interface DraftAgent {
 export type ThemeMode = "dark" | "light";
 export type Density = "comfortable" | "compact";
 export type WorkspaceView = "custom" | "native";
-export type SettingsSection = "general" | "account" | "providers";
+export type SettingsSection = "general" | "account" | "providers" | "developer";
 
 export interface FeatureFlags {
   git: boolean;


### PR DESCRIPTION
Moves the **Replay tour** control out of General settings into a new dedicated **Developer** settings section, shown last in the settings nav. The section is gated on `import.meta.env.DEV`, so it appears under `bun tauri dev` but is omitted entirely from production builds. A render fallback routes a stale `developer` section value to the General pane in prod, avoiding a blank pane. The General pane's "Getting started" group and its now-unused onboarding handlers were removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)