### PR TITLE
Redesign sidebar agent rows

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -43,6 +43,7 @@
   --warn: oklch(0.78 0.13 85);
   --danger: oklch(0.7 0.18 25);
   --info: oklch(0.74 0.12 230);
+  --purple: oklch(0.7 0.15 300);
   --shadow-1: 0 1px 0 rgba(255,255,255,.04) inset, 0 1px 2px rgba(0,0,0,.25);
   --shadow-2: 0 1px 0 rgba(255,255,255,.04) inset, 0 8px 28px rgba(0,0,0,.35);
   color-scheme: dark;
@@ -69,6 +70,7 @@
   --warn: oklch(0.6 0.14 80);
   --danger: oklch(0.55 0.18 25);
   --info: oklch(0.50 0.12 230);
+  --purple: oklch(0.5 0.16 300);
   --shadow-1: 0 1px 2px rgba(0,0,0,.06);
   --shadow-2: 0 8px 28px rgba(0,0,0,.10);
   color-scheme: light;
@@ -337,7 +339,7 @@ button { cursor: default; }
 .agents {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 1px;
   margin-left: 0;
   padding: 4px 0;
   overflow: visible;
@@ -347,112 +349,155 @@ button { cursor: default; }
 .agents.closed { max-height: 0; opacity: 0; padding: 0; overflow: hidden; }
 
 .agent {
+  --ag-sync: 2.4s;
   display: block;
-  margin: 0 0 0 6px;
-  padding: 7px 10px;
+  padding: 7px 9px 7px 13px;
   border-radius: var(--r-sm);
   font-size: 12.5px; color: var(--fg-1);
-  transition: background .1s;
+  transition: background .12s;
   position: relative;
   cursor: default;
 }
 .agent:hover { background: var(--hover); }
 .agent.active { background: var(--selected); color: var(--fg-0); }
-.agent.active::before {
-  content: ""; position: absolute;
-  left: -6px; top: 8px; bottom: 8px;
-  width: 2px; border-radius: 0 2px 2px 0;
-  background: var(--accent);
+
+/* status rail — the left spine; colored by status, faint grey when idle */
+.ag-rail {
+  position: absolute; left: 0; top: 6px; bottom: 6px;
+  width: 3px; border-radius: 0 3px 3px 0;
+  background: var(--bd-soft);
+  overflow: hidden;
 }
-.agent-row { display: flex; align-items: center; gap: 7px; }
-.agent-row .ag-dot {
-  width: 6px; height: 6px;
-  border-radius: 50%;
-  background: var(--fg-3);
-  flex-shrink: 0;
+.ag-rail.err    { background: var(--danger); }
+.ag-rail.merged { background: var(--purple); }
+.ag-rail.run    { background: var(--success); }
+/* a single lighter sheen sweeps the solid rail and resets off-screen (no blink) */
+.ag-rail.run::after {
+  content: ""; position: absolute; top: 0; left: 0; right: 0; height: 55%;
+  background: linear-gradient(180deg, transparent,
+    color-mix(in oklch, white 78%, var(--success)), transparent);
+  animation: agRailFlow var(--ag-sync) linear infinite;
 }
-.agent-row .ag-glyph {
-  flex-shrink: 0;
-  color: var(--fg-2);
-  width: 16px; height: 16px;
-  display: inline-flex; align-items: center;
+@keyframes agRailFlow {
+  0%   { transform: translateY(-100%); }
+  100% { transform: translateY(200%); }
 }
-.agent.active .ag-glyph { color: var(--accent); }
-.agent-row .ag-name { font-weight: 500; color: inherit; flex-shrink: 0; }
+
+.agent-row { display: flex; align-items: center; gap: 7px; min-height: 21px; }
+.agent-row .ag-name { font-weight: 550; color: var(--fg-0); flex-shrink: 0; }
+.ag-name.ag-name-draft { color: var(--fg-1); font-weight: 500; }
+/* shimmer + rail share one clock (--ag-sync) so their sweeps move in tandem */
+.ag-name.shimmer {
+  background: linear-gradient(100deg, var(--fg-1) 34%, var(--fg-0) 50%, var(--fg-1) 66%);
+  background-size: 220% 100%;
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: agShimmer var(--ag-sync) linear infinite;
+}
+@keyframes agShimmer {
+  0%   { background-position: 140% 0; }
+  100% { background-position: -40% 0; }
+}
 .agent-row .ag-prov-chip {
   flex-shrink: 0;
   display: inline-flex; align-items: center;
-  margin-left: -2px;
 }
-.agent-row .ag-provider-inline {
-  font-size: 11.5px;
-  color: var(--fg-3);
-  font-weight: 400;
-  min-width: 0;
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-}
-.agent-row .ag-actions {
-  display: inline-flex; align-items: center; gap: 2px;
+
+/* right slot — meta and actions share one fixed space, cross-fading on
+ * hover so the row never reflows (no height jump). */
+.ag-slot {
+  position: relative;
   margin-left: auto;
-  opacity: 0;
-  transition: opacity .12s;
-  flex-shrink: 0;
+  display: inline-flex; align-items: center; justify-content: flex-end;
+  flex-shrink: 0; min-height: 21px; min-width: 18px;
 }
-.agent:hover .ag-actions,
-.agent.active .ag-actions { opacity: 1; }
+.ag-slot .ag-meta { display: inline-flex; align-items: center; gap: 7px; transition: opacity .12s; }
+.ag-slot .ag-actions {
+  position: absolute; right: 0; top: 50%; transform: translateY(-50%);
+  display: inline-flex; align-items: center; gap: 2px;
+  opacity: 0; pointer-events: none; transition: opacity .12s;
+}
+.agent:hover .ag-slot .ag-meta { opacity: 0; }
+.agent:hover .ag-slot .ag-actions { opacity: 1; pointer-events: auto; }
 .ag-act {
   display: inline-flex; align-items: center; justify-content: center;
-  width: 22px; height: 22px;
-  margin: -1px 0;
-  border-radius: 4px;
+  width: 21px; height: 21px;
+  border-radius: 5px;
   color: var(--fg-2);
   transition: background .1s, color .1s;
 }
 .ag-act:hover { background: var(--bg-3); color: var(--fg-0); }
 .ag-act:active { background: var(--selected); }
-.ag-act svg { transition: width .1s, height .1s; }
-.ag-act[aria-label="Archive"]:hover svg { width: 14px; height: 14px; }
-.ag-act.tip[data-tip]:hover::after {
-  left: auto;
-  right: 0;
-  transform: none;
+.ag-act.tip[data-tip]:hover::after { left: auto; right: 0; transform: none; }
+
+/* working indicator — three grey dots, smooth bounce + fade, synced */
+.ag-loader {
+  --d: 3.5px;
+  width: var(--d); height: var(--d); border-radius: 1.5px;
+  background: currentColor; color: var(--fg-2);
+  display: inline-block; position: relative; top: -2px;
+  margin-right: 14px; flex-shrink: 0;
+  animation: agLoader var(--ag-sync) var(--ease) infinite;
 }
+.ag-loader::before, .ag-loader::after {
+  content: ""; position: absolute; top: 0;
+  width: var(--d); height: var(--d); border-radius: 1.5px;
+  background: currentColor;
+  animation: agLoader var(--ag-sync) var(--ease) infinite;
+}
+.ag-loader::after  { left: 7px;  animation-delay: .25s; }
+.ag-loader::before { left: 14px; animation-delay: .5s; }
+@keyframes agLoader {
+  0%   { top: 0; opacity: 1; }
+  50%  { top: 4px; opacity: .22; }
+  100% { top: 0; opacity: 1; }
+}
+
+/* compact status badges (PR state, error, draft) */
+.ag-badge {
+  display: inline-flex; align-items: center; gap: 3px;
+  height: 16px; padding: 0 5px;
+  border-radius: 4px;
+  font-size: 10px; font-weight: 600;
+  font-family: var(--font-mono); letter-spacing: .01em;
+  flex-shrink: 0;
+}
+.ag-badge svg { width: 10px; height: 10px; }
+.ag-badge.pr-open   { color: var(--info);   background: color-mix(in oklch, var(--info), transparent 86%); }
+.ag-badge.pr-merged { color: var(--purple); background: color-mix(in oklch, var(--purple), transparent 86%); }
+.ag-badge.pr-closed { color: var(--fg-2);   background: color-mix(in oklch, var(--fg-2), transparent 88%); }
+.ag-badge.err       { color: var(--danger); background: color-mix(in oklch, var(--danger), transparent 86%); }
+.ag-badge.new       { color: var(--accent); background: var(--accent-soft); }
+
 .agent-sub {
   display: flex; align-items: center; gap: 8px;
-  margin-top: 3px;
-  padding-left: 13px;
-  font-size: 11.5px;
-  color: var(--fg-2);
-  font-family: var(--font-mono);
+  margin-top: 2px; min-height: 17px;
 }
-.agent.with-glyph .agent-sub { padding-left: 36px; }
-.agent-sub .a-branch { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.agent-sub .a-task {
+  flex: 1; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  font-size: 12.5px;
+  color: color-mix(in oklch, var(--fg-1), var(--fg-0) 30%);
+}
+.agent-sub .a-task.a-task-draft { color: var(--fg-3); font-style: italic; }
+.agent-sub .a-diff {
+  font-family: var(--font-mono); font-size: 10.5px;
+  letter-spacing: -.02em; flex-shrink: 0;
+}
+.agent-sub .a-diff .add { color: var(--success); }
+.agent-sub .a-diff .del { color: var(--danger); }
 .agent-sub .a-time {
   color: var(--fg-3);
   font-size: 11px;
+  font-family: var(--font-mono);
   position: relative;
   cursor: default;
   padding: 1px 3px;
   border-radius: 3px;
+  flex-shrink: 0;
   transition: background .1s, color .1s;
 }
 .agent-sub .a-time:hover { background: var(--hover); color: var(--fg-1); }
-.agent-sub .a-changes { color: var(--accent); font-size: 8px; }
-.ag-discard {
-  margin-left: auto;
-  display: none;
-  align-items: center; justify-content: center;
-  width: 16px; height: 16px;
-  padding: 0;
-  background: none; border: none;
-  color: var(--fg-3);
-  cursor: pointer;
-  border-radius: 3px;
-  flex-shrink: 0;
-}
-.ag-discard svg { width: 10px; height: 10px; stroke-width: 2; }
-.agent:hover .ag-discard { display: flex; }
-.ag-discard:hover { background: var(--hover); color: var(--fg-1); }
 
 .ag-stats-pop {
   position: absolute;
@@ -482,18 +527,13 @@ button { cursor: default; }
 .ag-stats-pop .st-bar { margin-top: 6px; height: 3px; background: var(--hover); border-radius: 2px; overflow: hidden; }
 .ag-stats-pop .st-bar-fill { height: 100%; background: var(--accent); border-radius: 2px; transition: width .25s var(--ease); }
 
-@keyframes pulse {
-  0%, 100% { box-shadow: 0 0 0 2px color-mix(in oklch, var(--success), transparent 78%); }
-  50%      { box-shadow: 0 0 0 4px color-mix(in oklch, var(--success), transparent 92%); }
-}
-
 .agent-new {
   display: flex; align-items: center; gap: 8px;
-  margin: 0 0 0 6px;
-  padding: 4px 8px;
+  padding: 8px 8px;
+  margin-bottom: 6px;
   border-radius: var(--r-sm);
   font-size: 12px; color: var(--fg-3);
-  width: calc(100% - 6px);
+  width: 100%;
   text-align: left;
 }
 .agent-new:hover { background: var(--hover); color: var(--fg-1); }

--- a/src/app.css
+++ b/src/app.css
@@ -435,7 +435,7 @@ button { cursor: default; }
   --d: 3.5px;
   width: var(--d); height: var(--d); border-radius: 1.5px;
   background: currentColor; color: var(--fg-2);
-  display: inline-block; position: relative; top: -2px;
+  display: inline-block; position: relative;
   margin-right: 14px; flex-shrink: 0;
   animation: agLoader var(--ag-sync) var(--ease) infinite;
 }
@@ -448,9 +448,9 @@ button { cursor: default; }
 .ag-loader::after  { left: 7px;  animation-delay: .25s; }
 .ag-loader::before { left: 14px; animation-delay: .5s; }
 @keyframes agLoader {
-  0%   { top: 0; opacity: 1; }
-  50%  { top: 4px; opacity: .22; }
-  100% { top: 0; opacity: 1; }
+  0%   { top: -2px; opacity: 1; }
+  50%  { top: 2px; opacity: .22; }
+  100% { top: -2px; opacity: 1; }
 }
 
 /* compact status badges (PR state, error, draft) */

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -1,13 +1,12 @@
 import { useState } from "react";
 import type { MouseEvent } from "react";
-import type { AgentRecord, AgentStatus } from "../../api";
+import type { AgentRecord, AgentStatus, PrState, ShortStats } from "../../api";
 import type { DraftAgent } from "../../store";
 import { useAppStore } from "../../store";
-import { LANDMARK_NAMES } from "../../data/landmarks";
 import { providerChip, providerLabel } from "../../data/providers";
-import { Icon, LandmarkGlyph } from "../Icon";
+import { Icon } from "../Icon";
 import { ProviderIcon } from "../ProviderIcon";
-import { formatAge, formatTokens } from "../../util/format";
+import { formatAge } from "../../util/format";
 import { useMinuteClock } from "../../util/hooks";
 import { AgentStatsPopover, type AgentStats } from "./AgentStatsPopover";
 
@@ -15,14 +14,12 @@ interface RealRowProps {
   kind: "real";
   agent: AgentRecord;
   active: boolean;
-  showGlyph: boolean;
   onClick: () => void;
 }
 interface DraftRowProps {
   kind: "draft";
   draft: DraftAgent;
   active: boolean;
-  showGlyph: boolean;
   onClick: () => void;
 }
 
@@ -35,8 +32,10 @@ export function AgentRow(props: Props) {
 
 // ── real agent ───────────────────────────────────────────────────────────────
 
-function RealRow({ agent, active, showGlyph, onClick }: RealRowProps) {
+function RealRow({ agent, active, onClick }: RealRowProps) {
   const rawTokens = useAppStore((s) => s.tokens[agent.id]);
+  const prState = useAppStore((s) => s.prStates[agent.id] ?? null);
+  const shortstats = useAppStore((s) => s.gitShortstats[agent.id]);
   const stop = useAppStore((s) => s.stop);
   const archive = useAppStore((s) => s.archive);
   const now = useMinuteClock();
@@ -45,11 +44,8 @@ function RealRow({ agent, active, showGlyph, onClick }: RealRowProps) {
   const branch = agent.repos[0]?.branch ?? null;
   const taskOrBranch = firstShort(agent.task) || branch || "—";
   const age = formatAge(agent.created_at, now);
-  const tokensLabel =
-    typeof rawTokens === "number" && rawTokens > 0
-      ? formatTokens(rawTokens)
-      : null;
-  const glyphName = LANDMARK_NAMES.includes(agent.name) ? agent.name : agent.name;
+  // spawning is the start of a run — show it as "working" too, not a dead row
+  const working = agent.status === "running" || agent.status === "spawning";
 
   const stats: AgentStats = {
     launched: age || "just now",
@@ -66,6 +62,16 @@ function RealRow({ agent, active, showGlyph, onClick }: RealRowProps) {
     agent.status === "stopped" ||
     agent.status === "error";
 
+  // The status rail doubles as the left spine: colored for live/terminal
+  // states, a merged PR claims purple, everything else is a faint grey.
+  const railClass =
+    working ? "run" :
+    agent.status === "error" ? "err" :
+    prState?.state === "merged" ? "merged" : "idle";
+
+  const hasChanges =
+    !!shortstats && (shortstats.additions > 0 || shortstats.deletions > 0);
+
   const onStop = (e: MouseEvent) => {
     e.stopPropagation();
     stop(agent.id);
@@ -76,18 +82,10 @@ function RealRow({ agent, active, showGlyph, onClick }: RealRowProps) {
   };
 
   return (
-    <div
-      className={`agent ${active ? "active" : ""} ${showGlyph ? "with-glyph" : ""}`}
-      onClick={onClick}
-    >
+    <div className={`agent ${active ? "active" : ""}`} onClick={onClick}>
+      <span className={`ag-rail ${railClass}`} />
       <div className="agent-row">
-        <StatusDot status={agent.status} />
-        {showGlyph && (
-          <span className="ag-glyph">
-            <LandmarkGlyph name={glyphName} />
-          </span>
-        )}
-        <span className="ag-name">{agent.name}</span>
+        <span className={`ag-name ${working ? "shimmer" : ""}`}>{agent.name}</span>
         <span
           className="ag-prov-chip tip"
           data-tip={providerLabel(agent.provider)}
@@ -95,32 +93,42 @@ function RealRow({ agent, active, showGlyph, onClick }: RealRowProps) {
         >
           <ProviderIcon slug={agent.provider} {...providerChip(agent.provider)} size={14} />
         </span>
-        <span className="ag-actions">
-          {stoppable && (
-            <button
-              className="ag-act tip"
-              data-tip="Stop"
-              onClick={onStop}
-              aria-label="Stop"
-            >
-              <Icon name="stop" size={11} />
-            </button>
-          )}
-          {archivable && (
-            <button
-              className="ag-act tip"
-              data-tip="Archive"
-              onClick={onArchive}
-              aria-label="Archive"
-            >
-              <Icon name="archive" size={11} />
-            </button>
-          )}
+        <span className="ag-slot">
+          <span className="ag-meta">
+            {working && <span className="ag-loader" aria-label="Working" />}
+            {agent.status === "error" && <span className="ag-badge err">error</span>}
+          </span>
+          <span className="ag-actions">
+            {stoppable && (
+              <button
+                className="ag-act tip"
+                data-tip="Stop"
+                onClick={onStop}
+                aria-label="Stop"
+              >
+                <Icon name="stop" size={11} />
+              </button>
+            )}
+            {archivable && (
+              <button
+                className="ag-act tip"
+                data-tip="Archive"
+                onClick={onArchive}
+                aria-label="Archive"
+              >
+                <Icon name="archive" size={11} />
+              </button>
+            )}
+          </span>
         </span>
       </div>
       <div className="agent-sub">
-        <span className="a-branch">{taskOrBranch}</span>
-        {tokensLabel && <span className="a-changes" title={`${rawTokens} input tokens last turn`}>●</span>}
+        <span className="a-task">{taskOrBranch}</span>
+        {prState ? (
+          <PrBadge pr={prState} />
+        ) : hasChanges ? (
+          <DiffStat stats={shortstats} />
+        ) : null}
         <span
           className="a-time"
           onMouseEnter={() => setStatsOpen(true)}
@@ -136,7 +144,7 @@ function RealRow({ agent, active, showGlyph, onClick }: RealRowProps) {
 
 // ── draft (not-yet-spawned) ──────────────────────────────────────────────────
 
-function DraftRow({ draft, active, showGlyph, onClick }: DraftRowProps) {
+function DraftRow({ draft, active, onClick }: DraftRowProps) {
   const removeDraft = useAppStore((s) => s.removeDraft);
 
   function onDiscard(e: React.MouseEvent) {
@@ -145,18 +153,10 @@ function DraftRow({ draft, active, showGlyph, onClick }: DraftRowProps) {
   }
 
   return (
-    <div
-      className={`agent ${active ? "active" : ""} ${showGlyph ? "with-glyph" : ""}`}
-      onClick={onClick}
-    >
+    <div className={`agent ${active ? "active" : ""}`} onClick={onClick}>
+      <span className="ag-rail idle" />
       <div className="agent-row">
-        <span className="ag-dot" style={{ background: "var(--fg-3)" }} />
-        {showGlyph && (
-          <span className="ag-glyph">
-            <LandmarkGlyph name={draft.name} />
-          </span>
-        )}
-        <span className="ag-name">{draft.name}</span>
+        <span className="ag-name ag-name-draft">{draft.name}</span>
         <span
           className="ag-prov-chip tip"
           data-tip={providerLabel(draft.provider)}
@@ -164,41 +164,60 @@ function DraftRow({ draft, active, showGlyph, onClick }: DraftRowProps) {
         >
           <ProviderIcon slug={draft.provider} {...providerChip(draft.provider)} size={14} />
         </span>
-        <span className="ag-provider-inline" style={{ color: "var(--accent)" }}>
-          new
+        <span className="ag-slot">
+          <span className="ag-meta">
+            <span className="ag-badge new">new</span>
+          </span>
+          <span className="ag-actions">
+            <button
+              className="ag-act tip"
+              data-tip="Discard"
+              onClick={onDiscard}
+              aria-label="Discard"
+            >
+              <Icon name="close" size={11} />
+            </button>
+          </span>
         </span>
-        <button className="ag-discard" onClick={onDiscard} title="Discard">
-          <Icon name="close" />
-        </button>
       </div>
       <div className="agent-sub">
-        <span className="a-branch">Define task…</span>
+        <span className="a-task a-task-draft">Define task…</span>
       </div>
     </div>
   );
 }
 
-// ── helpers ──────────────────────────────────────────────────────────────────
+// ── pieces ─────────────────────────────────────────────────────────────────
 
-function StatusDot({ status }: { status: AgentStatus }) {
-  const color =
-    status === "running" ? "var(--success)" :
-    status === "spawning" ? "var(--warn)" :
-    status === "error" ? "var(--danger)" : "var(--fg-3)";
-  const isRunning = status === "running";
+/** Compact PR pill mirroring the git-panel status. Note: CI/checks state is
+ *  not yet in PrState, so an open PR shows a neutral pill (no pass/fail tint). */
+function PrBadge({ pr }: { pr: PrState }) {
+  if (pr.state === "merged") {
+    return (
+      <span className="ag-badge pr-merged tip" data-tip={`PR #${pr.number} · merged`}>
+        <Icon name="merge" size={10} />#{pr.number}
+      </span>
+    );
+  }
+  const cls = pr.state === "closed" ? "pr-closed" : "pr-open";
   return (
-    <span
-      className="ag-dot"
-      style={{
-        background: color,
-        boxShadow: isRunning
-          ? "0 0 0 2px color-mix(in oklch, var(--success), transparent 78%)"
-          : "none",
-        animation: isRunning ? "pulse 2s var(--ease) infinite" : undefined,
-      }}
-    />
+    <span className={`ag-badge ${cls} tip`} data-tip={`PR #${pr.number} · ${pr.state}`}>
+      <Icon name="pr" size={10} />PR
+    </span>
   );
 }
+
+function DiffStat({ stats }: { stats: ShortStats }) {
+  return (
+    <span className="a-diff" title={`${stats.file_count} file(s) changed`}>
+      {stats.additions > 0 && <span className="add">+{stats.additions}</span>}
+      {stats.additions > 0 && stats.deletions > 0 && " "}
+      {stats.deletions > 0 && <span className="del">−{stats.deletions}</span>}
+    </span>
+  );
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
 
 function firstShort(s: string | null | undefined, max = 36): string {
   if (!s) return "";

--- a/src/components/Sidebar/ProjectGroup.tsx
+++ b/src/components/Sidebar/ProjectGroup.tsx
@@ -24,7 +24,6 @@ export function ProjectGroup({
 }: Props) {
   const selectedAgentId = useAppStore((s) => s.selectedAgentId);
   const activeDraftId = useAppStore((s) => s.activeDraftId);
-  const showLandmarks = useAppStore((s) => s.showLandmarks);
   const selectAgent = useAppStore((s) => s.selectAgent);
   const selectDraft = useAppStore((s) => s.selectDraft);
   const createDraft = useAppStore((s) => s.createDraft);
@@ -88,7 +87,6 @@ export function ProjectGroup({
             kind="draft"
             draft={d}
             active={d.id === activeDraftId}
-            showGlyph={showLandmarks}
             onClick={() => selectDraft(d.id)}
           />
         ))}
@@ -98,7 +96,6 @@ export function ProjectGroup({
             kind="real"
             agent={a}
             active={a.id === selectedAgentId}
-            showGlyph={showLandmarks}
             onClick={() => selectAgent(a.id)}
           />
         ))}


### PR DESCRIPTION
Restructures each sidebar agent/draft row around a status-rail "spine" — flowing green while running/spawning (a single lighter sheen, synced with a shimmer on the landmark name), red for error, purple for a merged PR, and faint grey when idle. The landmark name now leads with the task as a scannable subtitle, and line two surfaces PR state (open/merged/closed) or git +/− diff stats plus the age chip with its stats popover. Adds a grey three-dot working loader and cross-fades the Stop/Archive (and draft Discard) actions in a fixed-width slot so hovering no longer jumps the row height. Drops the landmark glyphs, tightens list spacing, and gives the "New agent" button more height and breathing room.

Note: an open PR shows a neutral pill because CI/checks state isn't in `PrState` yet — the green ✓ / red ✗ variant is a separate backend follow-up.