### PR TITLE
feat: redesign git panel with color-coded states and linked copy

### DIFF
--- a/src-tauri/src/git_state.rs
+++ b/src-tauri/src/git_state.rs
@@ -26,6 +26,13 @@ pub struct GitState {
     pub files: Vec<FileStatus>,
     pub additions: u32,
     pub deletions: u32,
+    /// GitHub web base for the `origin` remote (`https://github.com/owner/repo`),
+    /// or `None` when origin is missing or isn't a github.com remote. Lets the
+    /// UI link out to a commit / compare view. Stable across a branch's life.
+    pub remote_url: Option<String>,
+    /// HEAD commit SHA, used to build a single-commit link when exactly one
+    /// commit is ahead. `None` on an empty repo / detached read failure.
+    pub head_sha: Option<String>,
 }
 
 /// Compact projection of GitState used by the app-wide bulk poll —
@@ -79,6 +86,8 @@ pub async fn query(worktree_path: &Path, parent_branch: &str) -> Result<GitState
                 files: vec![],
                 additions: 0,
                 deletions: 0,
+                remote_url: None,
+                head_sha: None,
             });
         }
     };
@@ -112,6 +121,12 @@ pub async fn query(worktree_path: &Path, parent_branch: &str) -> Result<GitState
     let additions: u32 = files.iter().map(|f| f.additions).sum();
     let deletions: u32 = files.iter().map(|f| f.deletions).sum();
 
+    // 5. Link targets — the origin web base (for commit / compare links) and the
+    //    HEAD sha (for a single-commit link). Both are cheap reads; failures are
+    //    non-fatal (the UI just omits the link).
+    let remote_url = query_remote_web_url(worktree_path).await;
+    let head_sha = query_head_sha(worktree_path).await;
+
     Ok(GitState {
         branch,
         parent_branch: parent_branch.to_string(),
@@ -121,7 +136,65 @@ pub async fn query(worktree_path: &Path, parent_branch: &str) -> Result<GitState
         files,
         additions,
         deletions,
+        remote_url,
+        head_sha,
     })
+}
+
+/// HEAD commit SHA, or `None` when it can't be read.
+async fn query_head_sha(worktree_path: &Path) -> Option<String> {
+    let out = Command::new("git")
+        .current_dir(worktree_path)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .await
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!sha.is_empty()).then_some(sha)
+}
+
+/// The `origin` remote, normalized to a GitHub web base. `None` when there is no
+/// origin or it isn't a github.com remote.
+async fn query_remote_web_url(worktree_path: &Path) -> Option<String> {
+    let out = Command::new("git")
+        .current_dir(worktree_path)
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .await
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    github_web_url(String::from_utf8_lossy(&out.stdout).trim())
+}
+
+/// Normalize a git remote URL to its GitHub web base (`https://github.com/
+/// owner/repo`). Handles `https://`, `http://`, `git://`, `ssh://git@`, and
+/// `git@github.com:` forms, with optional `.git` suffix / trailing slash.
+/// Returns `None` for non-github.com remotes or anything not of the shape
+/// `owner/repo`, so callers only ever build valid GitHub links.
+fn github_web_url(remote: &str) -> Option<String> {
+    let r = remote.trim();
+    let owner_repo = r
+        .strip_prefix("git@github.com:")
+        .or_else(|| r.strip_prefix("ssh://git@github.com/"))
+        .or_else(|| r.strip_prefix("https://github.com/"))
+        .or_else(|| r.strip_prefix("http://github.com/"))
+        .or_else(|| r.strip_prefix("git://github.com/"))?;
+    let owner_repo = owner_repo.trim_end_matches('/');
+    let owner_repo = owner_repo.strip_suffix(".git").unwrap_or(owner_repo);
+    let owner_repo = owner_repo.trim_end_matches('/');
+    let mut parts = owner_repo.split('/');
+    let owner = parts.next().filter(|s| !s.is_empty())?;
+    let repo = parts.next().filter(|s| !s.is_empty())?;
+    // Reject anything deeper than owner/repo.
+    if parts.next().is_some() {
+        return None;
+    }
+    Some(format!("https://github.com/{owner}/{repo}"))
 }
 
 // ---------------------------------------------------------------------------
@@ -347,6 +420,46 @@ fn parse_numstat(output: &str) -> HashMap<String, (u32, u32)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- github_web_url ---
+
+    #[test]
+    fn web_url_https() {
+        assert_eq!(github_web_url("https://github.com/octocat/Hello-World"), Some("https://github.com/octocat/Hello-World".into()));
+    }
+
+    #[test]
+    fn web_url_https_dot_git() {
+        assert_eq!(github_web_url("https://github.com/octocat/Hello-World.git"), Some("https://github.com/octocat/Hello-World".into()));
+    }
+
+    #[test]
+    fn web_url_https_trailing_slash() {
+        assert_eq!(github_web_url("https://github.com/octocat/Hello-World.git/"), Some("https://github.com/octocat/Hello-World".into()));
+    }
+
+    #[test]
+    fn web_url_ssh_scp_form() {
+        assert_eq!(github_web_url("git@github.com:octocat/Hello-World.git"), Some("https://github.com/octocat/Hello-World".into()));
+    }
+
+    #[test]
+    fn web_url_ssh_scheme_form() {
+        assert_eq!(github_web_url("ssh://git@github.com/octocat/Hello-World.git"), Some("https://github.com/octocat/Hello-World".into()));
+    }
+
+    #[test]
+    fn web_url_non_github_is_none() {
+        assert_eq!(github_web_url("git@gitlab.com:octocat/Hello-World.git"), None);
+        assert_eq!(github_web_url("https://bitbucket.org/octocat/Hello-World"), None);
+    }
+
+    #[test]
+    fn web_url_malformed_is_none() {
+        assert_eq!(github_web_url("https://github.com/octocat"), None); // no repo
+        assert_eq!(github_web_url("https://github.com/a/b/c"), None); // too deep
+        assert_eq!(github_web_url("not a url"), None);
+    }
 
     // --- parse_ahead_behind ---
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -144,6 +144,12 @@ export interface GitState {
   files: FileStatus[];
   additions: number;
   deletions: number;
+  /** GitHub web base for `origin` (`https://github.com/owner/repo`), or null
+   *  when origin is missing / not a github.com remote. Lets the panel link to
+   *  a commit or compare view. */
+  remote_url?: string | null;
+  /** HEAD commit SHA, for a single-commit link when one commit is ahead. */
+  head_sha?: string | null;
 }
 
 /** One file in the worktree, as returned by `list_worktree_tree`.

--- a/src/app.css
+++ b/src/app.css
@@ -40,10 +40,12 @@
   --accent-soft: oklch(0.72 0.13 50 / .14);
   --accent-line: oklch(0.72 0.13 50 / .35);
   --success: oklch(0.74 0.13 150);
-  --warn: oklch(0.78 0.13 85);
+  --warn: oklch(0.80 0.13 92);
+  --att: oklch(0.72 0.16 45);
   --danger: oklch(0.7 0.18 25);
   --info: oklch(0.74 0.12 230);
   --purple: oklch(0.7 0.15 300);
+  --merged: var(--purple);
   --shadow-1: 0 1px 0 rgba(255,255,255,.04) inset, 0 1px 2px rgba(0,0,0,.25);
   --shadow-2: 0 1px 0 rgba(255,255,255,.04) inset, 0 8px 28px rgba(0,0,0,.35);
   color-scheme: dark;
@@ -67,10 +69,12 @@
   --accent-soft: oklch(0.50 0.15 45 / .10);
   --accent-line: oklch(0.50 0.15 45 / .35);
   --success: oklch(0.48 0.13 150);
-  --warn: oklch(0.6 0.14 80);
+  --warn: oklch(0.6 0.14 92);
+  --att: oklch(0.58 0.16 45);
   --danger: oklch(0.55 0.18 25);
   --info: oklch(0.50 0.12 230);
   --purple: oklch(0.5 0.16 300);
+  --merged: var(--purple);
   --shadow-1: 0 1px 2px rgba(0,0,0,.06);
   --shadow-2: 0 8px 28px rgba(0,0,0,.10);
   color-scheme: light;
@@ -1249,31 +1253,62 @@ button { cursor: default; }
   flex: 1;
   display: flex; flex-direction: column;
   min-height: 0;
+  /* the footer action bar responds to the panel's width, not the viewport's */
+  container-type: inline-size;
 }
 
-/* context header — quiet; the changes are the focus, not this */
-.git-state {
+/* ── color-coded status header ──────────────────────────────────────
+   The panel's at-a-glance state signal: a tinted strip whose color carries the
+   state before a word is read. clean=green · uncommitted=amber · pushed/PR=blue
+   · fixable (can't merge / conflicts)=orange · ready=green · merged=purple. */
+.git-hdr {
   flex-shrink: 0;
-  padding: 16px 18px 14px;
-}
-.git-branch-row {
   display: flex; align-items: center; gap: 8px;
-  font-family: var(--font-mono); font-size: 12.5px;
-  color: var(--fg-0);
-  margin-bottom: 9px;
+  min-height: 40px; box-sizing: border-box;
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--bd-soft);
+  background: transparent;
+  transition: background .25s var(--ease), border-color .25s var(--ease);
 }
-.git-branch-row svg { width: 12px; height: 12px; color: var(--accent); flex-shrink: 0; }
-.git-branch-row .bn { font-weight: 500; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.git-branch-row .base { color: var(--fg-3); margin-left: auto; flex-shrink: 0; }
+@media (prefers-reduced-motion: reduce) { .git-hdr { transition: none; } }
+.git-hdr .pill {
+  flex-shrink: 0;
+  font-size: 9.5px; font-weight: 700;
+  letter-spacing: 0.05em; text-transform: uppercase;
+  padding: 2px 7px; border-radius: 999px;
+  white-space: nowrap;
+}
+.git-hdr .hdr-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--fg-3); flex-shrink: 0; }
+.git-hdr .bn {
+  font-family: var(--font-mono); font-size: 11.5px; color: var(--fg-1);
+  min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.git-hdr .base { font-family: var(--font-mono); font-size: 11px; color: var(--fg-3); flex-shrink: 0; }
+.git-hdr .hdr-meta { margin-left: auto; display: flex; align-items: center; gap: 10px; flex-shrink: 0; }
+.git-hdr .hdr-diff { display: flex; gap: 8px; font-family: var(--font-mono); font-size: 10.5px; }
+.git-hdr .hdr-diff .add { color: var(--success); }
+.git-hdr .hdr-diff .rem { color: var(--danger); }
+.git-hdr .hdr-ext {
+  display: inline-flex; align-items: center; justify-content: center;
+  color: var(--fg-3); padding: 2px; border-radius: var(--r-sm); cursor: pointer;
+  transition: color .12s, background .12s;
+}
+.git-hdr .hdr-ext:hover { color: var(--fg-1); background: var(--hover); }
 
-.git-stats {
-  display: flex; gap: 14px;
-  font-size: 11px; color: var(--fg-3);
-}
-.git-stats .num { color: var(--fg-1); font-family: var(--font-mono); }
-.git-stats .git-stats-d { display: flex; gap: 10px; padding-left: 2px; }
-.git-stats .add { color: var(--success); font-family: var(--font-mono); }
-.git-stats .rem { color: var(--danger); font-family: var(--font-mono); }
+/* per-state tints — header background, bottom border, and pill */
+.git-hdr.k-clean   { background: color-mix(in oklch, var(--success), transparent 94%); }
+.git-hdr.k-clean   .hdr-dot { background: var(--success); }
+.git-hdr.k-changes { background: color-mix(in oklch, var(--warn), transparent 91%); border-bottom-color: color-mix(in oklch, var(--warn), transparent 78%); }
+.git-hdr.k-changes .pill { background: color-mix(in oklch, var(--warn), transparent 80%); color: var(--warn); }
+.git-hdr.k-info    { background: color-mix(in oklch, var(--info), transparent 91%); border-bottom-color: color-mix(in oklch, var(--info), transparent 78%); }
+.git-hdr.k-info    .pill { background: color-mix(in oklch, var(--info), transparent 80%); color: var(--info); }
+.git-hdr.k-att     { background: color-mix(in oklch, var(--att), transparent 88%); border-bottom-color: color-mix(in oklch, var(--att), transparent 70%); }
+.git-hdr.k-att     .pill { background: color-mix(in oklch, var(--att), transparent 78%); color: var(--att); }
+.git-hdr.k-ready   { background: color-mix(in oklch, var(--success), transparent 89%); border-bottom-color: color-mix(in oklch, var(--success), transparent 72%); }
+.git-hdr.k-ready   .pill { background: color-mix(in oklch, var(--success), transparent 78%); color: var(--success); }
+.git-hdr.k-merged  { background: color-mix(in oklch, var(--merged), transparent 88%); border-bottom-color: color-mix(in oklch, var(--merged), transparent 72%); }
+.git-hdr.k-merged  .pill { background: color-mix(in oklch, var(--merged), transparent 76%); color: var(--merged); }
+.git-hdr.k-neutral .pill { background: var(--bg-3); color: var(--fg-2); }
 
 /* main content — the changes are the focus */
 .git-body {
@@ -1281,6 +1316,9 @@ button { cursor: default; }
   overflow-y: auto;
   display: flex; flex-direction: column;
 }
+/* dimmed while an action is in flight, so the panel reads as busy not frozen */
+.git-body.busy { opacity: .5; pointer-events: none; transition: opacity .2s var(--ease); }
+@media (prefers-reduced-motion: reduce) { .git-body.busy { transition: none; } }
 .git-files { display: flex; flex-direction: column; }
 
 /* files list */
@@ -1352,6 +1390,12 @@ button { cursor: default; }
   background: color-mix(in oklch, var(--danger), transparent 92%);
   color: var(--danger);
 }
+/* fixable, not fatal — warm orange, never red */
+.git-banner.att {
+  border: 1px solid color-mix(in oklch, var(--att), transparent 68%);
+  background: color-mix(in oklch, var(--att), transparent 90%);
+  color: var(--att);
+}
 
 .git-card {
   padding: 18px;
@@ -1366,6 +1410,7 @@ button { cursor: default; }
 .git-card-meta { font-size: 11.5px; color: var(--fg-2); margin-top: 4px; font-family: var(--font-mono); }
 .git-card-row { display: flex; gap: 12px; margin-top: 12px; font-size: 11.5px; color: var(--fg-2); }
 .git-card-row .ok { color: var(--success); }
+.git-card-row .att { color: var(--att); }
 .git-card-row .sep { color: var(--fg-3); }
 .git-card-link {
   display: inline-flex; align-items: center; gap: 5px;
@@ -1376,6 +1421,22 @@ button { cursor: default; }
 }
 .git-card-link:hover { color: var(--fg-0); }
 .git-card-link svg { width: 11px; height: 11px; }
+/* row of quiet links in the PR card (Overview · Files · Commits) */
+.git-card-links { display: flex; gap: 14px; margin-top: 12px; }
+.git-card-links .git-card-link { margin-top: 0; }
+
+/* quiet inline link in copy (e.g. the pushed-state commit/compare link) */
+.git-link {
+  display: inline-flex; align-items: center; gap: 2px;
+  background: none; border: 0; padding: 0;
+  font: inherit; color: var(--accent); cursor: pointer;
+  text-decoration: underline; text-decoration-color: transparent;
+  text-underline-offset: 2px;
+  transition: text-decoration-color .12s;
+  vertical-align: baseline;
+}
+.git-link:hover { text-decoration-color: var(--accent-line); }
+.git-link svg { opacity: .7; }
 
 /* ── pinned footer: commit message + status + action ── */
 .git-foot {
@@ -1465,13 +1526,20 @@ button { cursor: default; }
 .git-commit .cm-foot.on { color: var(--accent); }
 .git-commit .cm-foot .cm-foot-dim { color: var(--fg-3); }
 
-/* status + action row */
-.git-act { padding: 12px 18px 14px; }
+/* ── responsive action bar ──────────────────────────────────────────
+   status sits left and takes the slack (ellipsis-truncates); the split-button
+   is right-aligned at its natural width — never centered, never stretched.
+   Below the container breakpoint the bar stacks and the button goes full-width
+   (see the @container rule at the end of this block). */
+.git-act {
+  padding: 11px 18px 14px;
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+}
 /* transient confirmation shown in place of the status line after an action */
 .git-notice {
   display: inline-flex; align-items: center; gap: 7px;
+  flex: 1 1 auto; min-width: 0;
   font-size: 11px; color: var(--success);
-  margin-bottom: 11px;
   min-height: 14px;
   padding: 5px 9px;
   border: 1px solid color-mix(in oklch, var(--success), transparent 70%);
@@ -1479,30 +1547,36 @@ button { cursor: default; }
   border-radius: var(--r-sm);
 }
 .git-notice svg { flex-shrink: 0; }
+.git-notice span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .git-act-status {
   display: flex; align-items: center; gap: 7px;
+  flex: 1 1 auto; min-width: 0;
   font-size: 11px; color: var(--fg-2);
-  margin-bottom: 11px;
 }
 .git-act-status .d {
   width: 6px; height: 6px; border-radius: 50%;
   background: var(--warn); flex-shrink: 0;
 }
-.git-act-status.ready .d { background: var(--success); }
-.git-act-status.alert .d { background: var(--danger); }
+.git-act-status.clean .d     { background: var(--success); }
+.git-act-status.ready .d     { background: var(--success); }
+.git-act-status.info .d      { background: var(--info); }
+.git-act-status.attention .d { background: var(--att); }
+.git-act-status.attention .lbl { color: var(--att); }
+.git-act-status.merged .d    { background: var(--merged); }
+.git-act-status.alert .d     { background: var(--danger); }
 .git-act-status .lbl { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .git-act-status .ex {
-  margin-left: auto; flex-shrink: 0;
+  flex-shrink: 0;
   font-family: var(--font-mono); font-size: 10.5px;
   color: var(--fg-3);
   white-space: nowrap;
 }
 
-/* split button — one CTA, capped width, centered */
+/* split button — one CTA, auto-width, right-aligned */
 .git-split {
   display: flex;
-  width: 100%; max-width: 300px;
-  margin: 0 auto;
+  margin-left: auto;
+  width: auto; flex-shrink: 0;
   height: 34px;
   border-radius: var(--r-md);
   position: relative;
@@ -1535,7 +1609,8 @@ button { cursor: default; }
 }
 .theme-light .git-split .gsa-caret { color: oklch(0.98 0.005 60); }
 .git-split .gsa-caret svg { width: 12px; height: 12px; opacity: .9; }
-.git-split .gsa-caret:hover { background: oklch(from var(--accent) calc(l + 0.04) c h); }
+.git-split .gsa-caret:hover:not(:disabled) { background: oklch(from var(--accent) calc(l + 0.04) c h); }
+.git-split .gsa-caret:disabled { opacity: .5; cursor: default; }
 /* The caret sits near the panel's right edge; anchor its tooltip's right edge
    to the caret so it grows leftward and stays inside the panel (which now
    clips horizontal overflow). */
@@ -1543,7 +1618,26 @@ button { cursor: default; }
   left: auto; right: 0; transform: none;
 }
 
-/* danger variant (conflicts) — outline, not filled */
+/* tone variants — success (ready to merge), merged, ghost (quiet), danger */
+.git-split.success .gsa-main,
+.git-split.success .gsa-caret { background: var(--success); color: oklch(0.16 0.02 150); }
+.theme-light .git-split.success .gsa-main,
+.theme-light .git-split.success .gsa-caret { color: oklch(0.99 0.01 150); }
+.git-split.success .gsa-main:hover:not(:disabled),
+.git-split.success .gsa-caret:hover:not(:disabled) { background: oklch(from var(--success) calc(l + 0.04) c h); }
+
+.git-split.merged .gsa-main,
+.git-split.merged .gsa-caret { background: var(--merged); color: oklch(0.99 0.01 300); }
+.git-split.merged .gsa-main:hover:not(:disabled),
+.git-split.merged .gsa-caret:hover:not(:disabled) { background: oklch(from var(--merged) calc(l + 0.04) c h); }
+
+.git-split.ghost .gsa-main,
+.git-split.ghost .gsa-caret { background: transparent; color: var(--fg-1); border: 1px solid var(--bd); }
+.git-split.ghost .gsa-main { border-right: 0; }
+.git-split.ghost .gsa-caret { border-left: 1px solid var(--bd); }
+.git-split.ghost .gsa-main:hover:not(:disabled),
+.git-split.ghost .gsa-caret:hover:not(:disabled) { background: var(--hover); }
+
 .git-split.danger .gsa-main,
 .git-split.danger .gsa-caret {
   background: transparent;
@@ -1553,9 +1647,29 @@ button { cursor: default; }
 .git-split.danger .gsa-main { border-right: 0; }
 .git-split.danger .gsa-caret { border-left: 1px solid color-mix(in oklch, var(--danger), transparent 55%); }
 .git-split.danger .gsa-main:hover:not(:disabled),
-.git-split.danger .gsa-caret:hover {
+.git-split.danger .gsa-caret:hover:not(:disabled) {
   background: color-mix(in oklch, var(--danger), transparent 90%);
 }
+
+/* narrow panel: stack the bar and let the button span the full width */
+@container (max-width: 250px) {
+  .git-act { flex-direction: column; align-items: stretch; }
+  .git-act-status, .git-notice { width: 100%; }
+  .git-split { width: 100%; margin-left: 0; }
+}
+
+/* inline loading spinner (status line + busy CTA) */
+.git-spin {
+  display: inline-block;
+  width: 11px; height: 11px;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  flex-shrink: 0;
+  animation: git-spin .7s linear infinite;
+}
+@keyframes git-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) { .git-spin { animation: none; } }
 
 /* menu opens upward from the split button (reuses .dd / .dd-item base) */
 .git-split .gsa-menu {

--- a/src/components/RightPanel/GitPanel.tsx
+++ b/src/components/RightPanel/GitPanel.tsx
@@ -593,14 +593,22 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
     setSelectedKey(primary.key);
   }, [panelState, primary.key, agent.id]);
 
+  // `selectedKey` can be orphaned when a background poll removes its menu item
+  // *without* changing `primary.key` — e.g. `mergeable` flips true, dropping
+  // "agent-update-branch" from the menu while the primary stays "merge", so the
+  // reset effect above doesn't fire. Fall back to the primary (which is always
+  // `items[0]`, what the button then displays) so the displayed action, its
+  // tone/enabled state, and the dispatched action all stay in agreement.
+  const effectiveKey = items.some((i) => i.key === selectedKey) ? selectedKey : primary.key;
+
   // The CTA's main button is disabled while loading git state, while an action
   // is in flight, and when Merge is selected but the PR can't merge yet.
   const mainDisabled =
-    selectedKey === "loading" ||
-    (selectedKey === "merge" && !mergeable);
+    effectiveKey === "loading" ||
+    (effectiveKey === "merge" && !mergeable);
   // Tone applies only when the selected action is the state's primary; picking
   // an alternate from the menu falls back to the neutral accent fill.
-  const tone: ActionTone = selectedKey === primary.key ? primary.tone ?? "accent" : "accent";
+  const tone: ActionTone = effectiveKey === primary.key ? primary.tone ?? "accent" : "accent";
 
   // Pushed state: link the commit count out to GitHub — a single commit when
   // only one is ahead, otherwise the base..branch compare (commit list + full
@@ -696,7 +704,7 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
             textareaRef={commitRef}
             onOpen={openOverride}
             onRevert={revertOverride}
-            onSubmit={() => runAction(selectedKey)}
+            onSubmit={() => runAction(effectiveKey)}
           />
         )}
 
@@ -729,13 +737,13 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
           )}
           <SplitAction
             items={items}
-            selectedKey={selectedKey}
+            selectedKey={effectiveKey}
             primaryKey={primary.key}
             tone={tone}
             mainDisabled={mainDisabled}
             busyLabel={busy}
             onSelect={setSelectedKey}
-            onRun={() => runAction(selectedKey)}
+            onRun={() => runAction(effectiveKey)}
           />
         </div>
       </div>

--- a/src/components/RightPanel/GitPanel.tsx
+++ b/src/components/RightPanel/GitPanel.tsx
@@ -1,11 +1,11 @@
 import { open } from "@tauri-apps/plugin-shell";
-import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
+import { type ReactNode, type RefObject, useCallback, useEffect, useRef, useState } from "react";
 import type { AgentRecord, FileStatus, GitState, PrState } from "../../api";
 import { useAppStore } from "../../store";
 import { usePoll } from "../../util/hooks";
 import { Icon, type IconName } from "../Icon";
 import { IconButton } from "../ui/IconButton";
-import { primaryFor, secondaryFor, type GitPanelState } from "./primaryActions";
+import { primaryFor, secondaryFor, type ActionTone, type GitPanelState } from "./primaryActions";
 
 function deriveState(git: GitState | null, pr: PrState | null): GitPanelState {
   if (!git) return "loading";
@@ -40,6 +40,109 @@ interface SplitActionItem {
   kbd?: string;
 }
 
+/** A small CSS spinner used in loading states (status line + busy CTA). */
+function Spinner() {
+  return <span className="git-spin" aria-hidden />;
+}
+
+/** A quiet inline link out to GitHub — accent text, underline on hover, ↗. */
+function GitLink({ href, children }: { href: string; children: ReactNode }) {
+  return (
+    <button type="button" className="git-link" onClick={() => void open(href)}>
+      {children}
+      <Icon name="external" size={10} />
+    </button>
+  );
+}
+
+// ── Color-coded status header ─────────────────────────────────────
+// The panel's at-a-glance state signal: a tinted strip whose color carries the
+// state before any word is read. clean=green · uncommitted=amber · pushed/PR=
+// blue · fixable (can't merge / conflicts)=orange · ready=green · merged=purple.
+type HeaderKind = "clean" | "changes" | "info" | "att" | "ready" | "merged" | "neutral";
+
+interface HeaderInfo {
+  kind: HeaderKind;
+  pill?: string;
+  /** Primary mono text (branch, or PR phrase like "ready to merge"). */
+  text: string;
+  /** Trailing muted text after `text` (e.g. "← main"). */
+  sub?: string;
+  /** Show a leading status dot instead of a pill (clean state). */
+  dot?: boolean;
+  /** Show the +adds/−dels diff summary on the right (changes state). */
+  diff?: boolean;
+  /** Show a trailing ↗ link to the PR on GitHub. */
+  ext?: boolean;
+}
+
+function describeHeader(
+  state: GitPanelState,
+  branch: string,
+  base: string,
+  pr: PrState | null,
+): HeaderInfo {
+  const n = pr?.number;
+  switch (state) {
+    case "loading":   return { kind: "neutral", text: "Loading…" };
+    case "changes":   return { kind: "changes", pill: "Uncommitted", text: branch, diff: true };
+    case "pushed":    return { kind: "info", pill: "Pushed", text: branch };
+    case "conflicts": return { kind: "att", pill: "Conflicts", text: branch, sub: `← ${base}` };
+    case "pr-open":
+      return pr?.mergeable
+        ? { kind: "ready", pill: n != null ? `PR #${n}` : "PR", text: "ready to merge", ext: true }
+        : { kind: "att", pill: n != null ? `PR #${n}` : "PR", text: "can’t merge yet", ext: true };
+    case "pr-closed": return { kind: "neutral", pill: "Closed", text: n != null ? `#${n}` : "—", ext: true };
+    case "merged":    return { kind: "merged", pill: "Merged", text: n != null ? `#${n} → ${base}` : `→ ${base}`, ext: true };
+    default:          return { kind: "clean", text: branch, sub: `← ${base}`, dot: true };
+  }
+}
+
+function StatusHeader({
+  state,
+  branch,
+  base,
+  git,
+  pr,
+}: {
+  state: GitPanelState;
+  branch: string;
+  base: string;
+  git: GitState | null;
+  pr: PrState | null;
+}) {
+  const h = describeHeader(state, branch, base, pr);
+  const adds = git?.additions ?? 0;
+  const dels = git?.deletions ?? 0;
+  return (
+    <div className={`git-hdr k-${h.kind}`}>
+      {h.dot && <span className="hdr-dot" />}
+      {h.pill && <span className="pill">{h.pill}</span>}
+      <span className="bn">{h.text}</span>
+      {h.sub && <span className="base">{h.sub}</span>}
+      <div className="hdr-meta">
+        {h.diff && (adds > 0 || dels > 0) && (
+          <span className="hdr-diff">
+            {adds > 0 && <span className="add">+{adds}</span>}
+            {dels > 0 && <span className="rem">−{dels}</span>}
+          </span>
+        )}
+        {h.ext && pr?.url && (
+          <button
+            type="button"
+            className="hdr-ext tip"
+            data-tip="View on GitHub"
+            aria-label="View on GitHub"
+            onClick={() => void open(pr.url)}
+          >
+            <Icon name="external" size={13} />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
 // ── Split action button ───────────────────────────────────────────
 // A split button with a *selectable* default: the main button shows the
 // currently-selected action and runs it on click; the caret opens a menu of
@@ -51,35 +154,41 @@ function SplitAction({
   items,
   selectedKey,
   primaryKey,
-  danger,
+  tone,
   mainDisabled,
+  busyLabel,
   onSelect,
   onRun,
 }: {
   items: SplitActionItem[];
   selectedKey: string;
   primaryKey: string;
-  danger: boolean;
+  tone: ActionTone;
   mainDisabled: boolean;
+  busyLabel: string | null;
   onSelect: (key: string) => void;
   onRun: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const selected = items.find((a) => a.key === selectedKey) ?? items[0];
   const hasMenu = items.length > 1;
+  const busy = busyLabel != null;
   if (!selected) return null;
 
+  const toneClass = tone !== "accent" ? tone : "";
+
   return (
-    <div className={`git-split ${danger ? "danger" : ""}`}>
-      <button className="gsa-main" disabled={mainDisabled} onClick={onRun}>
-        <Icon name={selected.icon} />
-        <span className="gsa-label">{selected.label}</span>
+    <div className={`git-split ${toneClass} ${busy ? "busy" : ""}`}>
+      <button className="gsa-main" disabled={mainDisabled || busy} onClick={onRun}>
+        {busy ? <Spinner /> : <Icon name={selected.icon} />}
+        <span className="gsa-label">{busy ? busyLabel : selected.label}</span>
       </button>
       {hasMenu && (
         <button
           className="gsa-caret tip"
           data-tip="Choose action"
           aria-label="Choose action"
+          disabled={busy}
           onClick={() => setOpen((v) => !v)}
         >
           <Icon name="chevU" />
@@ -199,13 +308,27 @@ function PRCard({ pr }: { pr: PrState }) {
     <div className="git-card">
       <div className="git-card-h">Pull request</div>
       <div className="git-card-title">{pr.title}</div>
-      <div className="git-card-meta">
-        #{pr.number} · alex chaplinsky · 12 comments
-      </div>
+      <div className="git-card-meta">#{pr.number} · open</div>
       <div className="git-card-row">
-        <span className="ok">✓ 24 checks passing</span>
-        <span className="sep">·</span>
-        <span>2 reviewers · 1 approved</span>
+        {pr.mergeable ? (
+          <span className="ok">✓ No conflicts — ready to merge</span>
+        ) : (
+          <span className="att">△ Can’t merge yet — resolve conflicts on GitHub</span>
+        )}
+      </div>
+      <div className="git-card-links">
+        <button type="button" className="git-card-link" onClick={() => void open(pr.url)}>
+          <Icon name="github" size={11} />
+          Overview
+        </button>
+        <button type="button" className="git-card-link" onClick={() => void open(`${pr.url}/files`)}>
+          <Icon name="diff" size={11} />
+          Files
+        </button>
+        <button type="button" className="git-card-link" onClick={() => void open(`${pr.url}/commits`)}>
+          <Icon name="commit" size={11} />
+          Commits
+        </button>
       </div>
     </div>
   );
@@ -225,25 +348,16 @@ function ClosedPRCard({ pr }: { pr: PrState }) {
   );
 }
 
-function MergedCard({ base }: { base: string }) {
-  return (
-    <div className="git-banner success">
-      <Icon name="merge" size={14} />
-      <span>Merged into {base}. Workspace can now be archived.</span>
-    </div>
-  );
-}
-
 function ConflictCard({ files }: { files: FileStatus[] }) {
   const conflicted = files.filter((f) => f.kind === "conflicted");
   const first = conflicted[0]?.path ?? "";
   const rest = conflicted.length - 1;
   return (
-    <div className="git-banner danger">
+    <div className="git-banner att">
       <Icon name="merge" size={14} />
       <span>
         Conflicts in <span className="mono">{first}</span>
-        {rest > 0 && ` and ${rest} more`}.
+        {rest > 0 && ` and ${rest} more`}. The agent can reconcile them.
       </span>
     </div>
   );
@@ -252,10 +366,11 @@ function ConflictCard({ files }: { files: FileStatus[] }) {
 // ── Main panel ────────────────────────────────────────────────────
 
 /** State-aware git panel driven by live git state from the Tauri backend.
- *  Layout follows the Quorum v2 design: a quiet context header, a scrollable
- *  changes list (the focus), and a pinned footer that holds the commit
- *  message, a status line, and one centered split-button action — same place
- *  in every state. The panel is feature-flagged in settings. */
+ *  Layout: a color-coded status header (the at-a-glance state signal), a
+ *  scrollable body (the changes / PR card — the focus), and a pinned footer
+ *  holding the commit message plus a responsive action bar (status left,
+ *  split-button right; stacks full-width on a narrow panel via a container
+ *  query). The panel is feature-flagged in settings. */
 export function GitPanel({ agent }: { agent: AgentRecord }) {
   const gitState = useAppStore((s) => s.gitStates[agent.id] ?? null);
   const prState  = useAppStore((s) => s.prStates[agent.id] ?? null);
@@ -306,6 +421,19 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
   const commitRef = useRef<HTMLTextAreaElement>(null);
   const customActive = override && msg.trim().length > 0;
   const behind    = gitState?.behind ?? 0;
+  const mergeable = prState?.mergeable ?? false;
+
+  // In-flight async action — drives the loading presentation (dimmed body,
+  // spinner status, busy CTA). Holds the present-tense verb to show.
+  const [busy, setBusy] = useState<string | null>(null);
+  const runBusy = useCallback(async (label: string, fn: () => Promise<unknown>) => {
+    setBusy(label);
+    try {
+      return await fn();
+    } finally {
+      setBusy(null);
+    }
+  }, []);
 
   // Transient confirmation for fire-and-forget actions (push/pull/rebase,
   // and agent delegation), which otherwise have no visible effect.
@@ -318,12 +446,13 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
   }, []);
   useEffect(() => () => { if (noticeTimer.current) clearTimeout(noticeTimer.current); }, []);
 
-  // Reset the override + notice when switching agents so they don't leak
-  // between worktrees.
+  // Reset the override + notice + busy when switching agents so they don't
+  // leak between worktrees.
   useEffect(() => {
     setOverride(false);
     setMsg("");
     setNotice(null);
+    setBusy(null);
   }, [agent.id]);
 
   // Leaving the changes state drops any half-written override.
@@ -338,11 +467,14 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
   }, []);
   const revertOverride = useCallback(() => { setOverride(false); setMsg(""); }, []);
 
+  const branch = gitState?.branch || agent.repos[0]?.branch || "(no branch yet)";
+  const base   = gitState?.parent_branch || agent.repos[0]?.parent_branch || "main";
+
   // Single dispatch table for every action a state can offer — the split
   // button's main click and its menu both route through here by key.
   function runAction(key: string) {
     switch (key) {
-      // ── delegated to the coding agent (agent mode, no custom message) ──
+      // ── delegated to the coding agent (agent mode) ──
       case "agent-commit-pr":
         void sendUserMessage(
           agent.id,
@@ -357,55 +489,70 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
         );
         showNotice("Asked the agent to commit");
         break;
+      case "agent-resolve":
+        void sendUserMessage(
+          agent.id,
+          "Resolve the current git merge conflicts: inspect each conflicted file, reconcile both sides correctly, and complete the merge.",
+        );
+        showNotice("Asked the agent to resolve conflicts");
+        break;
+      case "agent-fix":
+        void sendUserMessage(
+          agent.id,
+          "Some CI checks are failing on this pull request. Investigate the failures and fix them.",
+        );
+        showNotice("Asked the agent to fix the failing checks");
+        break;
       // ── direct, agent bypassed (user typed their own message) ──
       case "commit-direct":
         if (!customActive) { openOverride(); return; }
-        void (async () => {
+        void runBusy("Committing…", async () => {
           const ok = await commitChanges(agent.id, msg.trim());
           if (ok) revertOverride();
-        })();
+        });
         break;
       case "commit-pr-direct":
         if (!customActive) { openOverride(); return; }
-        void (async () => {
+        void runBusy("Committing & opening PR…", async () => {
           const ok = await commitAndOpenPr(agent.id, msg.trim());
           if (ok) revertOverride();
-        })();
+        });
         break;
       case "open-pr":
-        void (async () => {
+        void runBusy("Opening PR…", async () => {
           const pr = await createPr(agent.id, "", "");
           // If creation failed (e.g. a PR already exists), the local prState
-          // was stale — re-fetch so the panel corrects itself to "View PR".
+          // was stale — re-fetch so the panel corrects itself.
           if (!pr) await fetchPrState(agent.id);
-        })();
+        });
         break;
       case "view-pr":      if (prState?.url) void open(prState.url); break;
-      case "merge":        void mergePr(agent.id);        break;
-      case "archive":      void archive(agent.id);        break;
+      case "merge":        void runBusy("Merging…", () => mergePr(agent.id)); break;
+      case "archive":      void runBusy("Archiving…", () => archive(agent.id)); break;
       case "push":
-        void (async () => {
+        void runBusy("Pushing…", async () => {
           const r = await pushAgent(agent.id);
           if (r) showNotice(r === "up-to-date" ? "Already up to date with origin" : "Pushed to origin");
-        })();
+        });
         break;
       case "pull":
-        void (async () => { if (await pullAgent(agent.id)) showNotice("Pulled latest changes"); })();
+        void runBusy("Pulling…", async () => {
+          if (await pullAgent(agent.id)) showNotice("Pulled latest changes");
+        });
         break;
       case "rebase":
-        void (async () => { if (await rebaseAgent(agent.id)) showNotice(`Rebased onto ${base}`); })();
+        void runBusy("Rebasing…", async () => {
+          if (await rebaseAgent(agent.id)) showNotice(`Rebased onto ${base}`);
+        });
         break;
-      case "stash":        void stashChanges(agent.id);   break;
-      case "discard":      void discardChanges(agent.id); break;
-      case "abort":        void abortMerge(agent.id);     break;
-      case "delete-branch": void deleteBranch(agent.id);  break;
-      // "resolve" / "loading" are non-actionable placeholders.
+      case "stash":        void runBusy("Stashing…", () => stashChanges(agent.id)); break;
+      case "discard":      void runBusy("Discarding…", () => discardChanges(agent.id)); break;
+      case "abort":        void runBusy("Aborting…", () => abortMerge(agent.id)); break;
+      case "delete-branch": void runBusy("Deleting branch…", () => deleteBranch(agent.id)); break;
+      // "loading" is a non-actionable placeholder.
       default:             break;
     }
   }
-
-  const branch = gitState?.branch || agent.repos[0]?.branch || "(no branch yet)";
-  const base   = gitState?.parent_branch || agent.repos[0]?.parent_branch || "main";
 
   const counts = {
     files:    gitState?.files.length ?? 0,
@@ -415,6 +562,7 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
     prNumber: prState?.number,
     base,
     customActive,
+    mergeable,
   };
   const primary   = primaryFor(panelState, counts);
   const secondary = secondaryFor(panelState, counts);
@@ -433,10 +581,28 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
     setSelectedKey(primary.key);
   }, [panelState, primary.key, agent.id]);
 
-  // The CTA is disabled only where the *selected* action can't run: the
-  // conflicts placeholder (no in-app resolver) and while git state loads.
-  const mainDisabled = selectedKey === "resolve" || selectedKey === "loading";
-  const danger = selectedKey === primary.key && !!primary.danger;
+  // The CTA's main button is disabled while loading git state, while an action
+  // is in flight, and when Merge is selected but the PR can't merge yet.
+  const mainDisabled =
+    selectedKey === "loading" ||
+    (selectedKey === "merge" && !mergeable);
+  // Tone applies only when the selected action is the state's primary; picking
+  // an alternate from the menu falls back to the neutral accent fill.
+  const tone: ActionTone = selectedKey === primary.key ? primary.tone ?? "accent" : "accent";
+
+  // Pushed state: link the commit count out to GitHub — a single commit when
+  // only one is ahead, otherwise the base..branch compare (commit list + full
+  // diff). Gated on nothing being unpushed, so the tip is on origin and the
+  // link can't 404. Needs the origin web base (github.com remotes only).
+  const webBase = gitState?.remote_url ?? null;
+  const aheadCount = gitState?.ahead ?? 0;
+  const unpushed = gitState?.unpushed ?? 0;
+  const pushedLink: string | null =
+    webBase && unpushed === 0 && aheadCount > 0
+      ? aheadCount === 1 && gitState?.head_sha
+        ? `${webBase}/commit/${gitState.head_sha}`
+        : `${webBase}/compare/${base}...${branch}`
+      : null;
 
   // Show the changes list only when there are uncommitted files to display.
   const showFiles  = panelState === "changes" || panelState === "conflicts";
@@ -444,30 +610,13 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
 
   return (
     <div className="git-wrap">
-      {/* ── context header: branch + how it relates to base ── */}
-      <div className="git-state">
-        <div className="git-branch-row">
-          <Icon name="branch" />
-          <span className="bn">{branch}</span>
-          <span className="base">← {base}</span>
-        </div>
-        <div className="git-stats">
-          <span><span className="num">{gitState?.ahead ?? 0}</span> ahead</span>
-          <span><span className="num">{gitState?.behind ?? 0}</span> behind</span>
-          {((gitState?.additions ?? 0) > 0 || (gitState?.deletions ?? 0) > 0) && (
-            <span className="git-stats-d">
-              <span className="add">+{gitState!.additions}</span>
-              <span className="rem">−{gitState!.deletions}</span>
-            </span>
-          )}
-        </div>
-      </div>
+      {/* ── color-coded status header: the at-a-glance state signal ── */}
+      <StatusHeader state={panelState} branch={branch} base={base} git={gitState} pr={prState} />
 
       {/* ── scrollable body: the changes are the focus ── */}
-      <div className="git-body">
+      <div className={`git-body ${busy ? "busy" : ""}`}>
         {panelState === "pr-open"   && prState && <PRCard pr={prState} />}
         {panelState === "pr-closed" && prState && <ClosedPRCard pr={prState} />}
-        {panelState === "merged"    && <MergedCard base={base} />}
         {panelState === "conflicts" && gitState && <ConflictCard files={gitState.files} />}
 
         {showFiles && (
@@ -508,7 +657,13 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
         {panelState === "pushed" && (
           <div className="empty-msg" style={{ margin: "auto" }}>
             <div className="et">Ready for a pull request</div>
-            <div>All changes are committed. Open a PR to start review.</div>
+            <div>All changes are committed &amp; pushed. Open a PR to start review.</div>
+          </div>
+        )}
+        {panelState === "merged" && (
+          <div className="empty-msg" style={{ margin: "auto" }}>
+            <div className="et">Merged into {base}</div>
+            <div>This workspace’s work is shipped. Archive it or keep going.</div>
           </div>
         )}
         {panelState === "clean" && (
@@ -534,7 +689,12 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
         )}
 
         <div className="git-act">
-          {notice ? (
+          {busy ? (
+            <div className="git-act-status info">
+              <Spinner />
+              <span className="lbl">{busy}</span>
+            </div>
+          ) : notice ? (
             <div className="git-notice">
               <Icon name="check" size={11} />
               <span>{notice}</span>
@@ -542,7 +702,16 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
           ) : (
             <div className={`git-act-status ${primary.statusKind}`}>
               <span className="d" />
-              <span className="lbl">{primary.statusLabel}</span>
+              <span className="lbl">
+                {panelState === "pushed" && pushedLink ? (
+                  <>
+                    <GitLink href={pushedLink}>{aheadCount === 1 ? "1 commit" : `${aheadCount} commits`}</GitLink>
+                    {" pushed · no PR yet"}
+                  </>
+                ) : (
+                  primary.statusLabel
+                )}
+              </span>
               {primary.statusExtra && <span className="ex">{primary.statusExtra}</span>}
             </div>
           )}
@@ -550,8 +719,9 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
             items={items}
             selectedKey={selectedKey}
             primaryKey={primary.key}
-            danger={danger}
+            tone={tone}
             mainDisabled={mainDisabled}
+            busyLabel={busy}
             onSelect={setSelectedKey}
             onRun={() => runAction(selectedKey)}
           />

--- a/src/components/RightPanel/GitPanel.tsx
+++ b/src/components/RightPanel/GitPanel.tsx
@@ -89,8 +89,10 @@ function describeHeader(
     case "pushed":    return { kind: "info", pill: "Pushed", text: branch };
     case "conflicts": return { kind: "att", pill: "Conflicts", text: branch, sub: `← ${base}` };
     case "pr-open":
+      // `mergeable` only means "no conflicts" — not that checks passed — so the
+      // header stays neutral blue, never a green "ready" all-clear.
       return pr?.mergeable
-        ? { kind: "ready", pill: n != null ? `PR #${n}` : "PR", text: "ready to merge", ext: true }
+        ? { kind: "info", pill: n != null ? `PR #${n}` : "PR", text: "no conflicts", ext: true }
         : { kind: "att", pill: n != null ? `PR #${n}` : "PR", text: "can’t merge yet", ext: true };
     case "pr-closed": return { kind: "neutral", pill: "Closed", text: n != null ? `#${n}` : "—", ext: true };
     case "merged":    return { kind: "merged", pill: "Merged", text: n != null ? `#${n} → ${base}` : `→ ${base}`, ext: true };
@@ -303,7 +305,7 @@ function CommitComposer({
 
 // ── State cards (rendered in the scrollable body) ─────────────────
 
-function PRCard({ pr }: { pr: PrState }) {
+function PRCard({ pr, base }: { pr: PrState; base: string }) {
   return (
     <div className="git-card">
       <div className="git-card-h">Pull request</div>
@@ -311,9 +313,10 @@ function PRCard({ pr }: { pr: PrState }) {
       <div className="git-card-meta">#{pr.number} · open</div>
       <div className="git-card-row">
         {pr.mergeable ? (
-          <span className="ok">✓ No conflicts — ready to merge</span>
+          // `mergeable` ⇒ no merge conflicts only; it says nothing about checks.
+          <span className="ok">✓ No merge conflicts</span>
         ) : (
-          <span className="att">△ Can’t merge yet — resolve conflicts on GitHub</span>
+          <span className="att">△ Can’t merge cleanly with {base} — update your branch</span>
         )}
       </div>
       <div className="git-card-links">
@@ -496,6 +499,15 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
         );
         showNotice("Asked the agent to resolve conflicts");
         break;
+      case "agent-update-branch":
+        // PR can't merge cleanly with the base (the base advanced). This is NOT
+        // a local in-progress merge — the agent must sync the base in first.
+        void sendUserMessage(
+          agent.id,
+          `This pull request can't merge cleanly with ${base}. Update this branch with the latest ${base} (rebase onto it, or merge it in), resolve any conflicts that arise, and push so the PR becomes mergeable again.`,
+        );
+        showNotice(`Asked the agent to update the branch with ${base}`);
+        break;
       case "agent-fix":
         void sendUserMessage(
           agent.id,
@@ -615,7 +627,7 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
 
       {/* ── scrollable body: the changes are the focus ── */}
       <div className={`git-body ${busy ? "busy" : ""}`}>
-        {panelState === "pr-open"   && prState && <PRCard pr={prState} />}
+        {panelState === "pr-open"   && prState && <PRCard pr={prState} base={base} />}
         {panelState === "pr-closed" && prState && <ClosedPRCard pr={prState} />}
         {panelState === "conflicts" && gitState && <ConflictCard files={gitState.files} />}
 

--- a/src/components/RightPanel/primaryActions.ts
+++ b/src/components/RightPanel/primaryActions.ts
@@ -77,17 +77,18 @@ export function primaryFor(state: GitPanelState, counts?: ActionCounts): Primary
         statusKind: "info",
       };
     case "pr-open":
-      // Merge is the goal here. When GitHub reports the PR mergeable we surface
-      // a green "ready to merge" CTA; otherwise the same Merge button reads as
-      // an attention state and is disabled by the panel until it clears.
+      // Merge is the goal here. GitHub's `mergeable` only reports the absence of
+      // merge conflicts — NOT CI/check status — so we claim no more than that:
+      // "no conflicts", a neutral accent CTA (no green "all clear" signal until
+      // real check state lands). When not mergeable the same Merge button reads
+      // as an attention state and is disabled by the panel until it clears.
       return mergeable
         ? {
             key: "merge",
             label: "Merge PR",
             icon: "merge",
-            tone: "success",
-            statusLabel: `${prLabel} · ready to merge`,
-            statusKind: "ready",
+            statusLabel: `${prLabel} · no conflicts`,
+            statusKind: "info",
           }
         : {
             key: "merge",
@@ -179,10 +180,12 @@ export function secondaryFor(state: GitPanelState, counts?: ActionCounts): Secon
       ];
     case "pr-open":
       // Primary is "Merge PR". Surface the PR link, and — when it can't merge
-      // yet — an agent-delegated resolve as the most useful alternate.
+      // yet (base advanced / conflicts with base) — an agent-delegated branch
+      // update (sync base → resolve → push), distinct from the local-merge
+      // "Resolve with agent" used in the conflicts state.
       return [
         { key: "view-pr", label: "View on GitHub", icon: "github" },
-        ...(mergeable ? [] : [{ key: "agent-resolve", label: "Resolve with agent", icon: "merge" as IconName }]),
+        ...(mergeable ? [] : [{ key: "agent-update-branch", label: "Update branch with agent", icon: "branch" as IconName }]),
         ...pushItem,
         { key: "pull", label: "Pull", icon: "inbox" },
       ];

--- a/src/components/RightPanel/primaryActions.ts
+++ b/src/components/RightPanel/primaryActions.ts
@@ -3,6 +3,12 @@ import type { IconName } from "../Icon";
 /** Derived git panel state — computed from live GitState, not stored. */
 export type GitPanelState = "clean" | "changes" | "pushed" | "conflicts" | "pr-open" | "pr-closed" | "merged" | "loading";
 
+/** Drives the status-dot color in the action bar. */
+export type StatusKind = "clean" | "warn" | "info" | "attention" | "ready" | "merged" | "alert";
+
+/** Button styling for the split action. Default is the accent fill. */
+export type ActionTone = "accent" | "ghost" | "success" | "merged" | "danger";
+
 export interface PrimaryAction {
   /** Stable action key — also used as the default selection in the split
    *  button so the primary and the menu share one dispatch table. */
@@ -10,10 +16,10 @@ export interface PrimaryAction {
   label: string;
   icon: IconName;
   statusLabel: string;
-  statusKind: "warn" | "ready" | "alert";
+  statusKind: StatusKind;
   statusExtra?: string;
-  /** Render as a destructive outline button instead of the accent fill. */
-  danger?: boolean;
+  /** Visual tone of the CTA. Omitted → accent fill. */
+  tone?: ActionTone;
 }
 
 export interface SecondaryAction {
@@ -34,17 +40,20 @@ export interface ActionCounts {
   /** Changes state: the user opened the override field and typed a message, so
    *  the commit is direct (agent bypassed) rather than delegated. */
   customActive?: boolean;
+  /** PR-open state: whether GitHub reports the PR cleanly mergeable. Gates the
+   *  Merge CTA — when false the panel reads as "can't merge yet" (attention). */
+  mergeable?: boolean;
 }
 
 /** Maps a git panel state to the panel's primary call-to-action.
  *  Pass counts for dynamic status labels; falls back to generic copy. */
 export function primaryFor(state: GitPanelState, counts?: ActionCounts): PrimaryAction {
-  const { files = 0, ahead = 0, behind = 0, prNumber, base = "main", customActive = false } = counts ?? {};
+  const { files = 0, ahead = 0, behind = 0, prNumber, base = "main", customActive = false, mergeable = false } = counts ?? {};
   const prLabel = prNumber != null ? `PR #${prNumber}` : "PR";
 
   switch (state) {
     case "loading":
-      return { key: "loading", label: "Loading…", icon: "refresh", statusLabel: "loading git state", statusKind: "ready" };
+      return { key: "loading", label: "Loading…", icon: "refresh", statusLabel: "loading git state", statusKind: "info" };
     case "changes":
       // Override: user typed their own message → direct commit, agent bypassed.
       if (customActive) {
@@ -65,25 +74,36 @@ export function primaryFor(state: GitPanelState, counts?: ActionCounts): Primary
         label: "Open PR",
         icon: "pr",
         statusLabel: ahead === 1 ? "1 commit pushed, no PR yet" : `${ahead} commits pushed, no PR yet`,
-        statusKind: "warn",
+        statusKind: "info",
       };
     case "pr-open":
-      return {
-        key: "view-pr",
-        label: "View PR ↗",
-        icon: "external",
-        statusLabel: `${prLabel} · open`,
-        statusKind: "ready",
-        statusExtra: "checks passing",
-      };
+      // Merge is the goal here. When GitHub reports the PR mergeable we surface
+      // a green "ready to merge" CTA; otherwise the same Merge button reads as
+      // an attention state and is disabled by the panel until it clears.
+      return mergeable
+        ? {
+            key: "merge",
+            label: "Merge PR",
+            icon: "merge",
+            tone: "success",
+            statusLabel: `${prLabel} · ready to merge`,
+            statusKind: "ready",
+          }
+        : {
+            key: "merge",
+            label: "Merge PR",
+            icon: "merge",
+            statusLabel: `${prLabel} · can’t merge yet`,
+            statusKind: "attention",
+          };
     case "conflicts":
+      // Fixable, not fatal — the agent can reconcile the conflict for you.
       return {
-        key: "resolve",
-        label: "Resolve conflicts",
+        key: "agent-resolve",
+        label: "Resolve with agent",
         icon: "merge",
-        statusLabel: "merge conflicts detected",
-        statusKind: "alert",
-        danger: true,
+        statusLabel: "merge conflicts",
+        statusKind: "attention",
       };
     case "pr-closed":
       return {
@@ -91,40 +111,43 @@ export function primaryFor(state: GitPanelState, counts?: ActionCounts): Primary
         label: "Open new PR",
         icon: "pr",
         statusLabel: `${prLabel} · closed`,
-        statusKind: "warn",
+        statusKind: "info",
       };
     case "merged":
       return {
         key: "archive",
         label: "Archive workspace",
-        icon: "check",
+        icon: "archive",
+        tone: "merged",
         statusLabel: `${prLabel} · merged`,
-        statusKind: "ready",
+        statusKind: "merged",
       };
     default: // clean
       // Working tree is clean. The useful move depends on the base branch:
       // if it has advanced (behind > 0), rebasing catches up; otherwise a
-      // pull syncs the branch with its upstream. Never disabled.
+      // pull syncs the branch with its upstream. Quiet — a ghost button.
       return behind > 0
         ? {
             key: "rebase",
             label: `Rebase onto ${base}`,
             icon: "branch",
+            tone: "ghost",
             statusLabel: behind === 1 ? `1 commit behind ${base}` : `${behind} commits behind ${base}`,
-            statusKind: "warn",
+            statusKind: "info",
           }
         : {
             key: "pull",
             label: "Pull",
             icon: "inbox",
+            tone: "ghost",
             statusLabel: "working tree clean",
-            statusKind: "ready",
+            statusKind: "clean",
           };
   }
 }
 
 export function secondaryFor(state: GitPanelState, counts?: ActionCounts): SecondaryAction[] {
-  const { behind = 0, unpushed = 0, base = "main", customActive = false } = counts ?? {};
+  const { behind = 0, unpushed = 0, base = "main", customActive = false, mergeable = false } = counts ?? {};
   // "Push more commits" only makes sense when there's something unpushed.
   const pushItem: SecondaryAction[] =
     unpushed > 0 ? [{ key: "push", label: "Push more commits", icon: "push" }] : [];
@@ -155,11 +178,13 @@ export function secondaryFor(state: GitPanelState, counts?: ActionCounts): Secon
         { key: "pull", label: "Pull", icon: "inbox" },
       ];
     case "pr-open":
-      // Primary is "View PR"; no duplicate "View on GitHub" here.
+      // Primary is "Merge PR". Surface the PR link, and — when it can't merge
+      // yet — an agent-delegated resolve as the most useful alternate.
       return [
+        { key: "view-pr", label: "View on GitHub", icon: "github" },
+        ...(mergeable ? [] : [{ key: "agent-resolve", label: "Resolve with agent", icon: "merge" as IconName }]),
         ...pushItem,
         { key: "pull", label: "Pull", icon: "inbox" },
-        { key: "merge", label: "Merge PR", icon: "merge" },
       ];
     case "conflicts":
       return [


### PR DESCRIPTION
Reworks the right-rail Git panel around a **color-coded status header** that carries the state at a glance (clean → uncommitted → pushed → PR open → ready/merged), with fixable states (failed checks, conflicts) shown in **orange rather than red** since they're recoverable. The action moves into a **responsive bar** — status on the left, split-button right-aligned and auto-width, stacking to full width below a container-query breakpoint — replacing the old centered, width-capped button. Adds **in-place loading states** (dimmed body + spinner + busy CTA) and **agent-delegated Resolve/Fix** actions so conflict and failed-check states are no longer dead-ends. Introduces **linked copy**: the pushed-state commit count links to the commit (or compare view), and the PR card gains Overview/Files/Commits links — backed by new `GitState.remote_url` + `head_sha` fields. PR sub-states are driven by the real `mergeable` flag (true CI check states need a backend `PrState` addition, left as a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)