### PR TITLE
Agent-delegated git actions + real PR check states in the git panel

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -456,6 +456,29 @@ pub async fn get_pr_state(
     gh::pr_view(&worktree).await
 }
 
+/// Fetch the PR merge gate + per-check detail (spec §6). Best-effort: any
+/// failure (no PR, gh missing, API error) returns `None` and the panel falls
+/// back to `mergeable`-only behavior.
+#[tauri::command]
+pub async fn get_pr_checks(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+) -> Result<Option<gh::PrChecks>> {
+    let record = match supervisor.workspace.agent(&agent_id) {
+        Ok(r) => r,
+        Err(_) => return Ok(None),
+    };
+    let repo = match record.repos.first() {
+        Some(r) => r,
+        None => return Ok(None),
+    };
+    if repo.branch.is_none() {
+        return Ok(None);
+    }
+    let worktree = repo_worktree_path(&agent_id, &repo.subdir)?;
+    Ok(gh::pr_checks(&worktree).await.unwrap_or(None))
+}
+
 /// Open an interactive shell PTY in the agent's primary worktree.
 /// Idempotent: if a shell is already running for this agent, does nothing.
 #[tauri::command]

--- a/src-tauri/src/gh.rs
+++ b/src-tauri/src/gh.rs
@@ -30,6 +30,57 @@ pub struct PrState {
     pub mergeable: bool,
 }
 
+/// GitHub's combined merge gate (`mergeStateStatus`), normalized. This — not
+/// `mergeable` — is what actually decides whether a PR can land (spec §6).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MergeState {
+    Clean,
+    Blocked,
+    Unstable,
+    Behind,
+    Dirty,
+    Draft,
+    HasHooks,
+    Unknown,
+}
+
+/// One CI check, normalized from gh's `statusCheckRollup` (which mixes
+/// `CheckRun` and legacy `StatusContext` shapes).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct CheckRun {
+    pub name: String,
+    /// "queued" | "in_progress" | "completed"
+    pub status: String,
+    /// "success" | "failure" | "neutral" | "cancelled" | "skipped" |
+    /// "timed_out" | "action_required" | "stale" — None until completed.
+    pub conclusion: Option<String>,
+    /// Branch-protection data needs an extra (often unauthorized) API call,
+    /// so this is always `false` for now — the merge gate comes from
+    /// `merge_state` instead (spec §6 fallback).
+    pub required: bool,
+    pub url: Option<String>,
+    pub started_at: Option<String>,
+    pub completed_at: Option<String>,
+}
+
+/// Rich PR merge-gate + per-check detail (spec §6). Heavier than `pr_view`
+/// — callers poll it on a slow cadence.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct PrChecks {
+    pub merge_state: MergeState,
+    /// "none" | "pending" | "passing" | "failing" — checks-only summary.
+    pub rollup: String,
+    pub total: u32,
+    pub passed: u32,
+    pub failed: u32,
+    pub pending: u32,
+    /// Names of failing checks. With `required` detection unavailable this
+    /// lists ALL failing checks, not just protected ones.
+    pub required_failing: Vec<String>,
+    pub runs: Vec<CheckRun>,
+}
+
 // ---------------------------------------------------------------------------
 // Internal deserialization helpers
 // ---------------------------------------------------------------------------
@@ -86,6 +137,128 @@ pub async fn pr_view(worktree: &Path) -> Result<Option<PrState>> {
 
     let raw: GhPrRaw = serde_json::from_slice(&out.stdout)?;
     Ok(Some(raw.into()))
+}
+
+/// Fetch the merge gate + per-check detail for the current branch's PR.
+/// One `gh pr view` call. Returns `Ok(None)` when there is no PR; other gh
+/// failures surface as `Err` — the command layer treats both as "checks
+/// unavailable" and the panel degrades to `mergeable`-only behavior.
+pub async fn pr_checks(worktree: &Path) -> Result<Option<PrChecks>> {
+    let out = Command::new("gh")
+        .current_dir(worktree)
+        .args(["pr", "view", "--json", "mergeStateStatus,statusCheckRollup"])
+        .output()
+        .await?;
+
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        if stderr.to_lowercase().contains("no pull requests found") {
+            return Ok(None);
+        }
+        return Err(Error::Gh(stderr.trim().to_string()));
+    }
+
+    let raw: serde_json::Value = serde_json::from_slice(&out.stdout)?;
+    let merge_state = raw["mergeStateStatus"].as_str().unwrap_or("UNKNOWN").to_string();
+    let rollup: Vec<serde_json::Value> = raw["statusCheckRollup"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    Ok(Some(parse_pr_checks(&merge_state, &rollup)))
+}
+
+/// Normalize gh's UPPERCASE payload into the spec §6 shape. Pure — unit
+/// tested against captured fixtures.
+fn parse_pr_checks(merge_state_status: &str, rollup: &[serde_json::Value]) -> PrChecks {
+    let merge_state = match merge_state_status {
+        "CLEAN" => MergeState::Clean,
+        "BLOCKED" => MergeState::Blocked,
+        "UNSTABLE" => MergeState::Unstable,
+        "BEHIND" => MergeState::Behind,
+        "DIRTY" => MergeState::Dirty,
+        "DRAFT" => MergeState::Draft,
+        "HAS_HOOKS" => MergeState::HasHooks,
+        _ => MergeState::Unknown,
+    };
+
+    let str_of = |v: &serde_json::Value, key: &str| -> Option<String> {
+        v.get(key)
+            .and_then(|x| x.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+    };
+
+    let runs: Vec<CheckRun> = rollup
+        .iter()
+        .map(|item| {
+            if item["__typename"].as_str() == Some("StatusContext") {
+                // Legacy commit status: a single `state` covers both status
+                // and conclusion.
+                let state = item["state"].as_str().unwrap_or("");
+                let (status, conclusion) = match state {
+                    "SUCCESS" => ("completed", Some("success")),
+                    "FAILURE" | "ERROR" => ("completed", Some("failure")),
+                    "EXPECTED" => ("queued", None),
+                    _ => ("in_progress", None), // PENDING
+                };
+                CheckRun {
+                    name: str_of(item, "context").unwrap_or_else(|| "status".into()),
+                    status: status.to_string(),
+                    conclusion: conclusion.map(|s| s.to_string()),
+                    required: false,
+                    url: str_of(item, "targetUrl"),
+                    started_at: str_of(item, "startedAt"),
+                    completed_at: None,
+                }
+            } else {
+                CheckRun {
+                    name: str_of(item, "name").unwrap_or_else(|| "check".into()),
+                    status: item["status"].as_str().unwrap_or("QUEUED").to_lowercase(),
+                    conclusion: str_of(item, "conclusion").map(|c| c.to_lowercase()),
+                    required: false,
+                    url: str_of(item, "detailsUrl"),
+                    started_at: str_of(item, "startedAt"),
+                    completed_at: str_of(item, "completedAt"),
+                }
+            }
+        })
+        .collect();
+
+    let is_failing = |r: &CheckRun| {
+        matches!(
+            r.conclusion.as_deref(),
+            Some("failure")
+                | Some("timed_out")
+                | Some("cancelled")
+                | Some("action_required")
+                | Some("startup_failure")
+        )
+    };
+    let total = runs.len() as u32;
+    let pending = runs.iter().filter(|r| r.status != "completed").count() as u32;
+    let failed = runs.iter().filter(|r| is_failing(r)).count() as u32;
+    let passed = total - pending - failed;
+    let rollup_summary = if total == 0 {
+        "none"
+    } else if failed > 0 {
+        "failing"
+    } else if pending > 0 {
+        "pending"
+    } else {
+        "passing"
+    };
+    let required_failing = runs.iter().filter(|r| is_failing(r)).map(|r| r.name.clone()).collect();
+
+    PrChecks {
+        merge_state,
+        rollup: rollup_summary.to_string(),
+        total,
+        passed,
+        failed,
+        pending,
+        required_failing,
+        runs,
+    }
 }
 
 /// Create a PR for the branch checked out in `worktree`.
@@ -369,6 +542,78 @@ mod tests {
         let pr = PrState::from(raw);
         assert!(matches!(pr.state, PrStatus::Closed));
         assert!(!pr.mergeable);
+    }
+
+    fn rollup_fixture() -> Vec<serde_json::Value> {
+        serde_json::from_str(
+            r#"[
+              {"__typename":"CheckRun","name":"build","status":"COMPLETED","conclusion":"SUCCESS",
+               "detailsUrl":"https://ci/build","startedAt":"2026-06-10T00:00:00Z","completedAt":"2026-06-10T00:05:00Z"},
+              {"__typename":"CheckRun","name":"test","status":"COMPLETED","conclusion":"FAILURE",
+               "detailsUrl":"https://ci/test","startedAt":"2026-06-10T00:00:00Z","completedAt":"2026-06-10T00:07:00Z"},
+              {"__typename":"CheckRun","name":"lint","status":"IN_PROGRESS","conclusion":null,
+               "detailsUrl":null,"startedAt":"2026-06-10T00:00:00Z","completedAt":null},
+              {"__typename":"StatusContext","context":"ci/legacy","state":"SUCCESS","targetUrl":"https://ci/legacy"}
+            ]"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn pr_checks_normalizes_runs_and_counts() {
+        let checks = parse_pr_checks("BLOCKED", &rollup_fixture());
+        assert!(matches!(checks.merge_state, MergeState::Blocked));
+        assert_eq!(checks.total, 4);
+        assert_eq!(checks.passed, 2); // build + legacy status context
+        assert_eq!(checks.failed, 1); // test
+        assert_eq!(checks.pending, 1); // lint
+        assert_eq!(checks.rollup, "failing");
+        assert_eq!(checks.required_failing, vec!["test".to_string()]);
+        let lint = checks.runs.iter().find(|r| r.name == "lint").unwrap();
+        assert_eq!(lint.status, "in_progress");
+        assert_eq!(lint.conclusion, None);
+        let legacy = checks.runs.iter().find(|r| r.name == "ci/legacy").unwrap();
+        assert_eq!(legacy.status, "completed");
+        assert_eq!(legacy.conclusion.as_deref(), Some("success"));
+        assert_eq!(legacy.url.as_deref(), Some("https://ci/legacy"));
+    }
+
+    #[test]
+    fn pr_checks_rollup_states() {
+        // No checks at all.
+        let none = parse_pr_checks("CLEAN", &[]);
+        assert_eq!(none.rollup, "none");
+        assert!(matches!(none.merge_state, MergeState::Clean));
+        // All passing.
+        let passing: Vec<serde_json::Value> = serde_json::from_str(
+            r#"[{"__typename":"CheckRun","name":"build","status":"COMPLETED","conclusion":"SUCCESS"}]"#,
+        )
+        .unwrap();
+        assert_eq!(parse_pr_checks("CLEAN", &passing).rollup, "passing");
+        // Pending (no failures yet).
+        let pending: Vec<serde_json::Value> = serde_json::from_str(
+            r#"[{"__typename":"CheckRun","name":"build","status":"QUEUED","conclusion":null}]"#,
+        )
+        .unwrap();
+        assert_eq!(parse_pr_checks("UNKNOWN", &pending).rollup, "pending");
+    }
+
+    #[test]
+    fn pr_checks_merge_state_mapping() {
+        for (raw, want) in [
+            ("CLEAN", MergeState::Clean),
+            ("BLOCKED", MergeState::Blocked),
+            ("UNSTABLE", MergeState::Unstable),
+            ("BEHIND", MergeState::Behind),
+            ("DIRTY", MergeState::Dirty),
+            ("DRAFT", MergeState::Draft),
+            ("HAS_HOOKS", MergeState::HasHooks),
+            ("UNKNOWN", MergeState::Unknown),
+            ("SOMETHING_NEW", MergeState::Unknown),
+        ] {
+            let got = parse_pr_checks(raw, &[]).merge_state;
+            assert_eq!(got, want, "for {raw}");
+        }
     }
 
     #[test]

--- a/src-tauri/src/gh.rs
+++ b/src-tauri/src/gh.rs
@@ -237,7 +237,10 @@ fn parse_pr_checks(merge_state_status: &str, rollup: &[serde_json::Value]) -> Pr
     let total = runs.len() as u32;
     let pending = runs.iter().filter(|r| r.status != "completed").count() as u32;
     let failed = runs.iter().filter(|r| is_failing(r)).count() as u32;
-    let passed = total - pending - failed;
+    // Computed directly, not by subtraction: gh can report a failure
+    // conclusion on a not-yet-completed run (e.g. cancelled mid-run), which
+    // would double-count into both `pending` and `failed` and underflow.
+    let passed = runs.iter().filter(|r| r.status == "completed" && !is_failing(r)).count() as u32;
     let rollup_summary = if total == 0 {
         "none"
     } else if failed > 0 {
@@ -596,6 +599,23 @@ mod tests {
         )
         .unwrap();
         assert_eq!(parse_pr_checks("UNKNOWN", &pending).rollup, "pending");
+    }
+
+    #[test]
+    fn pr_checks_tolerates_failing_conclusion_on_incomplete_run() {
+        // A cancelled-while-running check can surface as IN_PROGRESS with a
+        // failure conclusion. It must count as failed (and pending) without
+        // `passed` underflowing.
+        let rollup: Vec<serde_json::Value> = serde_json::from_str(
+            r#"[{"__typename":"CheckRun","name":"build","status":"IN_PROGRESS","conclusion":"CANCELLED"}]"#,
+        )
+        .unwrap();
+        let checks = parse_pr_checks("UNKNOWN", &rollup);
+        assert_eq!(checks.total, 1);
+        assert_eq!(checks.failed, 1);
+        assert_eq!(checks.pending, 1);
+        assert_eq!(checks.passed, 0);
+        assert_eq!(checks.rollup, "failing");
     }
 
     #[test]

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -17,13 +17,15 @@
 //!   conversation, so later turns don't re-send it (no per-turn token tax, no
 //!   accumulating copies).
 //!
-//! The injected text has two layers: editable general guidance
-//! (`instructions/system_prompt.md`) plus a Quorum-managed protocol block
-//! (`instructions/rpc_protocol.md`) that documents the file-RPC the app exposes
-//! (see `rpc.rs`). The RPC block is code-managed because it must stay in sync
-//! with the implemented op allowlist and the `QUORUM_RPC_DIR` env var; the
-//! general layer is yours to edit. Blank both files to disable injection
-//! entirely — every helper below no-ops when the combined text is empty.
+//! The injected text has three layers: editable general guidance
+//! (`instructions/system_prompt.md`), a Quorum-managed protocol block
+//! (`instructions/rpc_protocol.md`) that documents the file-RPC the app
+//! exposes (see `rpc.rs`), and the Quorum-managed git-action playbooks
+//! (`instructions/git_actions.md`) behind the panel's `[app-action]`
+//! triggers. The managed blocks are code-managed because they must stay in
+//! sync with the op allowlist / trigger names; the general layer is yours to
+//! edit. Blank all files to disable injection entirely — every helper below
+//! no-ops when the combined text is empty.
 
 /// Editable general guidance. Edit the file, not this constant.
 const SYSTEM_PROMPT: &str = include_str!("instructions/system_prompt.md");
@@ -31,17 +33,23 @@ const SYSTEM_PROMPT: &str = include_str!("instructions/system_prompt.md");
 /// Quorum-managed RPC protocol block, appended after the general guidance.
 const RPC_INSTRUCTIONS: &str = include_str!("instructions/rpc_protocol.md");
 
-/// The combined instruction text, trimmed. Empty when both sources are
+/// Quorum-managed git-action playbooks. The panel sends a short
+/// `[app-action] <name>` trigger; the full per-action instructions live here
+/// so the chat transcript stays free of boilerplate. Code-managed: must stay
+/// in sync with the trigger names the frontend sends (see
+/// `components/RightPanel/delegation.ts`).
+const GIT_ACTIONS: &str = include_str!("instructions/git_actions.md");
+
+/// The combined instruction text, trimmed. Empty when every source is
 /// blank/whitespace, which makes every injection helper a no-op.
 pub fn text() -> String {
-    let general = SYSTEM_PROMPT.trim();
-    let rpc = RPC_INSTRUCTIONS.trim();
-    match (general.is_empty(), rpc.is_empty()) {
-        (true, true) => String::new(),
-        (false, true) => general.to_string(),
-        (true, false) => rpc.to_string(),
-        (false, false) => format!("{general}\n\n{rpc}"),
-    }
+    let combined = [SYSTEM_PROMPT, RPC_INSTRUCTIONS, GIT_ACTIONS]
+        .iter()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    combined
 }
 
 /// Args for agents that expose `--append-system-prompt` (Claude, Pi).
@@ -115,6 +123,15 @@ mod tests {
     fn source_is_present_and_nonempty() {
         // The shipped default is non-empty; guards against an accidental blank.
         assert!(!text().is_empty());
+    }
+
+    #[test]
+    fn git_action_playbooks_are_injected() {
+        // The panel's `[app-action]` triggers only work if the playbook block
+        // reaches the agent's instructions.
+        let t = text();
+        assert!(t.contains("[app-action]"), "playbook block missing");
+        assert!(t.contains("### commit"), "commit playbook missing");
     }
 
     #[test]

--- a/src-tauri/src/instructions/git_actions.md
+++ b/src-tauri/src/instructions/git_actions.md
@@ -1,0 +1,35 @@
+## Quorum app git actions
+
+When the user clicks a git action in the app, the app sends a one-line request on their behalf:
+
+    [app-action] <name> key="value" ...
+
+Treat it exactly like a user request and follow the matching playbook below — nothing more, nothing less. Use the file-RPC ops (`git_commit`, `git_push`, `git_update_branch`, `open_pr`) for every git mutation; raw `git commit`/`push`/`merge` are blocked by your sandbox. Keep your reply brief: one line on what you did (plus the PR URL when you opened one).
+
+### commit
+
+Review the uncommitted changes (`git status`, `git diff HEAD`), write a clear, conventional commit message, and commit by calling `git_commit`. Commit ONLY — do not push and do not open a pull request.
+
+### commit-push
+
+Same as `commit`, then push by calling `git_push`. Do not open a pull request.
+
+### commit-pr — params: `base`
+
+Same as `commit`, then write a concise PR title and description covering ALL changes on this branch versus the `base` branch, and open the PR by calling `open_pr` with that title and body.
+
+### open-pr — params: `base`
+
+Everything is already committed. Review the branch versus `base` (`git log <base>..HEAD`, `git diff <base>...HEAD`), write a concise, descriptive PR title and body, and open the PR by calling `open_pr` with them.
+
+### resolve-conflicts
+
+Inspect each conflicted file in your worktree, reconcile both sides correctly, then complete the merge by calling `git_commit` with a short merge message — it stages everything for you.
+
+### update-branch — params: `base`
+
+The pull request can't merge cleanly because `base` has advanced. Call `git_update_branch` to merge the latest base into this branch. If it reports conflicts, resolve the affected files, complete the merge with `git_commit`, then push with `git_push`. If it merges cleanly, just push with `git_push`.
+
+### fix-checks — params: `failing` (check names)
+
+CI checks are failing on this branch's pull request. Investigate the failures, fix them, commit the fix with `git_commit`, and push with `git_push` so the checks re-run.

--- a/src-tauri/src/instructions/rpc_protocol.md
+++ b/src-tauri/src/instructions/rpc_protocol.md
@@ -26,5 +26,6 @@ Available ops:
 - `git_status` — runs `git status` in your worktree and returns its output. No args.
 - `git_commit` — stages all changes in your worktree and commits them. `args.message` (required) is the commit message.
 - `open_pr` — pushes your branch and opens a pull request against your base branch. `args.title` and `args.body` set the PR title and description; omit `title` to auto-fill from your commits.
+- `git_push` — pushes your current branch to origin (sets the upstream on first push). No args. Use it to update an existing pull request after committing fixes.
 
-Use these ops for git: your worktree's git database lives outside the sandbox, so running `git add`/`commit`/`push` yourself fails with a permission error. Commit and open PRs through `git_commit` and `open_pr` instead.
+Use these ops for git: your worktree's git database lives outside the sandbox, so running `git add`/`commit`/`push` yourself fails with a permission error. Commit through `git_commit`, push through `git_push`, and open PRs through `open_pr` instead.

--- a/src-tauri/src/instructions/rpc_protocol.md
+++ b/src-tauri/src/instructions/rpc_protocol.md
@@ -20,6 +20,21 @@ until [ -f "$QUORUM_RPC_DIR/responses/$ID.json" ]; do sleep 0.2; done
 cat "$QUORUM_RPC_DIR/responses/$ID.json"
 ```
 
+For args carrying free text (commit messages, PR bodies), do NOT hand-escape the string into a `printf`/`echo` format — `\n` and quotes get mangled by the shell. Build the body with `jq -n --arg` from a heredoc, which escapes everything correctly on the first try:
+
+```sh
+ID=$(uuidgen)
+MSG=$(cat <<'EOF'
+feat: add the thing
+
+Optional longer body, safely multi-line.
+EOF
+)
+jq -n --arg id "$ID" --arg msg "$MSG" '{id:$id,op:"git_commit",args:{message:$msg}}' \
+  > "$QUORUM_RPC_DIR/requests/$ID.json.tmp"
+mv "$QUORUM_RPC_DIR/requests/$ID.json.tmp" "$QUORUM_RPC_DIR/requests/$ID.json"
+```
+
 Available ops:
 
 - `ping` — liveness check; returns `pong`. No args.

--- a/src-tauri/src/instructions/rpc_protocol.md
+++ b/src-tauri/src/instructions/rpc_protocol.md
@@ -27,5 +27,6 @@ Available ops:
 - `git_commit` — stages all changes in your worktree and commits them. `args.message` (required) is the commit message.
 - `open_pr` — pushes your branch and opens a pull request against your base branch. `args.title` and `args.body` set the PR title and description; omit `title` to auto-fill from your commits.
 - `git_push` — pushes your current branch to origin (sets the upstream on first push). No args. Use it to update an existing pull request after committing fixes.
+- `git_update_branch` — fetches your base branch from origin and merges it into your current branch. No args. A non-zero `exit_code` with `CONFLICT` in `stdout` means the merge stopped on conflicts: resolve the listed files in your worktree, then complete the merge with `git_commit` and push with `git_push`.
 
-Use these ops for git: your worktree's git database lives outside the sandbox, so running `git add`/`commit`/`push` yourself fails with a permission error. Commit through `git_commit`, push through `git_push`, and open PRs through `open_pr` instead.
+Use these ops for git: your worktree's git database lives outside the sandbox, so running `git add`/`commit`/`merge`/`push` yourself fails with a permission error. Commit through `git_commit`, push through `git_push`, sync your base branch through `git_update_branch`, and open PRs through `open_pr` instead.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -188,6 +188,7 @@ pub fn run() {
             commands::create_pr,
             commands::merge_pr,
             commands::get_pr_state,
+            commands::get_pr_checks,
             commands::open_agent_shell,
             commands::close_agent_shell,
             commands::write_to_shell,

--- a/src-tauri/src/rpc.rs
+++ b/src-tauri/src/rpc.rs
@@ -243,6 +243,10 @@ async fn dispatch(id: &str, op: &str, args: &Value, ctx: &OpContext) -> Response
         // `args.title`/`args.body` set the PR title and description (empty title
         // → gh auto-fills from the commits).
         "open_pr" => open_pr(id, args, ctx).await,
+        // Push the current branch to origin. Blocked in the sandbox for the
+        // same reason as commit — used to update an existing PR branch after
+        // the agent fixes checks or resolves conflicts.
+        "git_push" => git_push(id, ctx).await,
         other => Response::err(id, format!("unknown op: {other}")),
     }
 }
@@ -278,6 +282,20 @@ async fn open_pr(id: &str, args: &Value, ctx: &OpContext) -> Response {
     match crate::gh::pr_create(&ctx.cwd, title, body, &ctx.base_branch).await {
         Ok(pr) => Response::ok(id, 0, pr.url, String::new()),
         Err(e) => Response::err(id, format!("open_pr: {e}")),
+    }
+}
+
+/// `git_push` — push the current branch to origin (sets upstream on first
+/// push). No args. Reuses `git::push` so behavior matches the panel's Push.
+async fn git_push(id: &str, ctx: &OpContext) -> Response {
+    let branch = match crate::git::current_branch(&ctx.cwd).await {
+        Ok(Some(b)) => b,
+        Ok(None) => return Response::err(id, "git_push: HEAD is detached — no branch to push"),
+        Err(e) => return Response::err(id, format!("git_push: {e}")),
+    };
+    match crate::git::push(&ctx.cwd, &branch).await {
+        Ok(summary) => Response::ok(id, 0, summary, String::new()),
+        Err(e) => Response::err(id, e.to_string()),
     }
 }
 
@@ -515,6 +533,35 @@ mod tests {
             .output()
             .unwrap();
         assert!(String::from_utf8_lossy(&log.stdout).contains("add new.txt"));
+    }
+
+    #[tokio::test]
+    async fn git_push_without_remote_reports_error() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        run_git(&repo, &["init", "-q", "-b", "main"]);
+        run_git(&repo, &["config", "user.email", "t@example.com"]);
+        run_git(&repo, &["config", "user.name", "Tester"]);
+        std::fs::write(repo.join("a.txt"), b"x").unwrap();
+        run_git(&repo, &["add", "-A"]);
+        run_git(&repo, &["commit", "-q", "-m", "init"]);
+
+        let rpc_dir = td.path().join("rpc");
+        ensure_mailbox(&rpc_dir).unwrap();
+        write_request(&rpc_dir.join("requests"), "p1.json", r#"{"id":"p1","op":"git_push"}"#);
+
+        let cx = OpContext { cwd: repo.clone(), base_branch: "main".to_string() };
+        process_pending(&rpc_dir, &cx).await;
+
+        let body = std::fs::read_to_string(rpc_dir.join("responses/p1.json")).unwrap();
+        let v: Value = serde_json::from_str(&body).unwrap();
+        // No origin remote → push fails; the agent gets a clear error (from a
+        // real push attempt, not an unknown-op rejection).
+        assert_eq!(v["ok"], false);
+        let err = v["error"].as_str().unwrap();
+        assert!(!err.contains("unknown op"), "got: {err}");
+        assert!(err.contains("push failed"), "got: {err}");
     }
 
     #[tokio::test]

--- a/src-tauri/src/rpc.rs
+++ b/src-tauri/src/rpc.rs
@@ -247,6 +247,11 @@ async fn dispatch(id: &str, op: &str, args: &Value, ctx: &OpContext) -> Response
         // same reason as commit — used to update an existing PR branch after
         // the agent fixes checks or resolves conflicts.
         "git_push" => git_push(id, ctx).await,
+        // Merge the latest base branch into the worktree branch (fetch +
+        // merge origin/<base>). Conflicts are reported faithfully (non-zero
+        // exit, stdout lists the files) and the merge is left in progress so
+        // the agent can resolve and finish with `git_commit` + `git_push`.
+        "git_update_branch" => git_update_branch(id, ctx).await,
         other => Response::err(id, format!("unknown op: {other}")),
     }
 }
@@ -297,6 +302,21 @@ async fn git_push(id: &str, ctx: &OpContext) -> Response {
         Ok(summary) => Response::ok(id, 0, summary, String::new()),
         Err(e) => Response::err(id, e.to_string()),
     }
+}
+
+/// `git_update_branch` — fetch the agent's base branch from origin and merge
+/// it into the current branch. No args; the base comes from [`OpContext`].
+/// A conflicting merge is NOT an op failure: the command report (exit code,
+/// stdout) is returned as-is and the merge stays open for the agent to
+/// resolve. A failed fetch (no origin, offline, unknown base) is returned
+/// faithfully too, before any merge is attempted.
+async fn git_update_branch(id: &str, ctx: &OpContext) -> Response {
+    let fetch = run_command(id, &ctx.cwd, "git", &["fetch", "origin", &ctx.base_branch]).await;
+    if !fetch.ok || fetch.exit_code != Some(0) {
+        return fetch;
+    }
+    let target = format!("origin/{}", ctx.base_branch);
+    run_command(id, &ctx.cwd, "git", &["merge", "--no-edit", &target]).await
 }
 
 /// Run a fixed command in `cwd`, capturing exit/stdout/stderr, bounded by
@@ -562,6 +582,105 @@ mod tests {
         let err = v["error"].as_str().unwrap();
         assert!(!err.contains("unknown op"), "got: {err}");
         assert!(err.contains("push failed"), "got: {err}");
+    }
+
+    /// origin (bare) + a clone on branch `feat`, with `main` advanced on
+    /// origin after `feat` forked. Returns (tempdir, clone_path).
+    fn setup_origin_and_clone() -> (tempfile::TempDir, std::path::PathBuf) {
+        let td = tempfile::tempdir().unwrap();
+        let origin = td.path().join("origin.git");
+        std::fs::create_dir_all(&origin).unwrap();
+        run_git(&origin, &["init", "-q", "--bare", "-b", "main"]);
+
+        let work = td.path().join("work");
+        let out = std::process::Command::new("git")
+            .current_dir(td.path())
+            .args(["clone", "-q", origin.to_str().unwrap(), "work"])
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "{}", String::from_utf8_lossy(&out.stderr));
+        run_git(&work, &["config", "user.email", "t@example.com"]);
+        run_git(&work, &["config", "user.name", "Tester"]);
+        run_git(&work, &["checkout", "-q", "-b", "main"]);
+        std::fs::write(work.join("a.txt"), b"base\n").unwrap();
+        run_git(&work, &["add", "-A"]);
+        run_git(&work, &["commit", "-q", "-m", "init"]);
+        run_git(&work, &["push", "-q", "-u", "origin", "main"]);
+
+        // Fork feat, then advance main on origin (push from main).
+        run_git(&work, &["checkout", "-q", "-b", "feat"]);
+        std::fs::write(work.join("feat.txt"), b"feature\n").unwrap();
+        run_git(&work, &["add", "-A"]);
+        run_git(&work, &["commit", "-q", "-m", "feat work"]);
+        run_git(&work, &["checkout", "-q", "main"]);
+        std::fs::write(work.join("b.txt"), b"advance\n").unwrap();
+        run_git(&work, &["add", "-A"]);
+        run_git(&work, &["commit", "-q", "-m", "main advances"]);
+        run_git(&work, &["push", "-q", "origin", "main"]);
+        run_git(&work, &["checkout", "-q", "feat"]);
+        (td, work)
+    }
+
+    #[tokio::test]
+    async fn git_update_branch_merges_the_advanced_base() {
+        let (td, work) = setup_origin_and_clone();
+        let rpc_dir = td.path().join("rpc");
+        ensure_mailbox(&rpc_dir).unwrap();
+        write_request(
+            &rpc_dir.join("requests"),
+            "u1.json",
+            r#"{"id":"u1","op":"git_update_branch"}"#,
+        );
+
+        let cx = OpContext { cwd: work.clone(), base_branch: "main".to_string() };
+        process_pending(&rpc_dir, &cx).await;
+
+        let body = std::fs::read_to_string(rpc_dir.join("responses/u1.json")).unwrap();
+        let v: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["ok"], true, "response: {body}");
+        assert_eq!(v["exit_code"], 0, "response: {body}");
+        // The advanced base landed in the worktree.
+        assert!(work.join("b.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn git_update_branch_reports_conflicts_and_leaves_merge_open() {
+        let (td, work) = setup_origin_and_clone();
+        // Make feat conflict with main: both edit a.txt.
+        std::fs::write(work.join("a.txt"), b"feat version\n").unwrap();
+        run_git(&work, &["add", "-A"]);
+        run_git(&work, &["commit", "-q", "-m", "feat edits a"]);
+        run_git(&work, &["checkout", "-q", "main"]);
+        std::fs::write(work.join("a.txt"), b"main version\n").unwrap();
+        run_git(&work, &["add", "-A"]);
+        run_git(&work, &["commit", "-q", "-m", "main edits a"]);
+        run_git(&work, &["push", "-q", "origin", "main"]);
+        run_git(&work, &["checkout", "-q", "feat"]);
+
+        let rpc_dir = td.path().join("rpc");
+        ensure_mailbox(&rpc_dir).unwrap();
+        write_request(
+            &rpc_dir.join("requests"),
+            "u2.json",
+            r#"{"id":"u2","op":"git_update_branch"}"#,
+        );
+
+        let cx = OpContext { cwd: work.clone(), base_branch: "main".to_string() };
+        process_pending(&rpc_dir, &cx).await;
+
+        let body = std::fs::read_to_string(rpc_dir.join("responses/u2.json")).unwrap();
+        let v: Value = serde_json::from_str(&body).unwrap();
+        // Faithful command report: the op ran, the merge exited non-zero.
+        assert_eq!(v["ok"], true, "response: {body}");
+        assert_ne!(v["exit_code"], 0, "response: {body}");
+        assert!(v["stdout"].as_str().unwrap().contains("CONFLICT"));
+        // Merge left open so the agent can resolve + git_commit.
+        let status = std::process::Command::new("git")
+            .current_dir(&work)
+            .args(["status", "--porcelain=v1"])
+            .output()
+            .unwrap();
+        assert!(String::from_utf8_lossy(&status.stdout).contains("UU a.txt"));
     }
 
     #[tokio::test]

--- a/src/api.ts
+++ b/src/api.ts
@@ -190,6 +190,41 @@ export interface PrStateChangedEvent {
   state: PrState | null;
 }
 
+/** GitHub's combined merge gate (`mergeStateStatus`), normalized (spec §6). */
+export type MergeState =
+  | "clean"
+  | "blocked"
+  | "unstable"
+  | "behind"
+  | "dirty"
+  | "draft"
+  | "has_hooks"
+  | "unknown";
+
+/** One CI check, normalized from gh's statusCheckRollup. */
+export interface CheckRun {
+  name: string;
+  status: "queued" | "in_progress" | "completed";
+  conclusion: string | null;
+  required: boolean;
+  url: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+}
+
+/** Rich PR merge-gate + per-check detail. Heavier than PrState — polled on
+ *  a slow cadence while a PR is open. */
+export interface PrChecks {
+  merge_state: MergeState;
+  rollup: "none" | "pending" | "passing" | "failing";
+  total: number;
+  passed: number;
+  failed: number;
+  pending: number;
+  required_failing: string[];
+  runs: CheckRun[];
+}
+
 export type RunPhase = "idle" | "setup" | "running" | "stopped";
 
 export interface RunStateSnapshot {
@@ -332,6 +367,8 @@ export const api = {
     invoke<Record<string, ShortStats>>("get_all_shortstats"),
   getPrState: (agentId: string) =>
     invoke<PrState | null>("get_pr_state", { agentId }),
+  getPrChecks: (agentId: string) =>
+    invoke<PrChecks | null>("get_pr_checks", { agentId }),
   pushAgent: (agentId: string) => invoke<string>("push_agent", { agentId }),
   pullAgent: (agentId: string) => invoke<void>("pull_agent", { agentId }),
   rebaseAgent: (agentId: string) => invoke<void>("rebase_agent", { agentId }),

--- a/src/app.css
+++ b/src/app.css
@@ -1571,6 +1571,14 @@ button { cursor: default; }
   color: var(--fg-3);
   white-space: nowrap;
 }
+/* quiet "view on GitHub" chip beside the status text (pr-open) */
+.git-act-status .st-ext {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 18px; height: 18px; flex-shrink: 0;
+  border: 0; border-radius: 4px; padding: 0;
+  background: none; color: var(--fg-3); cursor: pointer;
+}
+.git-act-status .st-ext:hover { background: var(--bg-3); color: var(--fg-1); }
 
 /* split button — one CTA, auto-width, right-aligned */
 .git-split {

--- a/src/app.css
+++ b/src/app.css
@@ -1670,6 +1670,37 @@ button { cursor: default; }
 }
 @keyframes git-spin { to { transform: rotate(360deg); } }
 @media (prefers-reduced-motion: reduce) { .git-spin { animation: none; } }
+.git-spin.sm { width: 8px; height: 8px; border-width: 1.5px; }
+
+/* ── PR checks (inside the PR card) ─────────────────────────────── */
+.pr-checks { display: flex; flex-direction: column; gap: 2px; margin-top: 8px; }
+.pr-checks-h {
+  display: flex; align-items: baseline; justify-content: space-between;
+  font-size: 10px; text-transform: uppercase; letter-spacing: .06em;
+  color: var(--fg-3); margin-bottom: 2px;
+}
+.pr-checks-sum.failing { color: var(--danger); }
+.pr-checks-sum.pending { color: var(--info); }
+.pr-checks-sum.passing { color: var(--success); }
+.pr-check {
+  display: flex; align-items: center; gap: 7px;
+  padding: 3px 4px; border: 0; border-radius: 5px;
+  background: none; color: var(--fg-2); font: inherit; font-size: 11.5px;
+  text-align: left; cursor: pointer; min-width: 0;
+}
+.pr-check:hover { background: var(--bg-3); color: var(--fg-1); }
+.pr-check .pc-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; }
+.pr-check svg { opacity: 0; flex: none; }
+.pr-check:hover svg { opacity: .7; }
+.pc-dot { width: 7px; height: 7px; border-radius: 50%; flex: none; }
+.pc-dot.ok   { background: var(--success); }
+.pc-dot.fail { background: var(--danger); }
+.pc-dot.skip { background: var(--fg-3); }
+.pr-checks-more {
+  align-self: flex-start; border: 0; background: none; padding: 3px 4px;
+  font: inherit; font-size: 11px; color: var(--fg-3); cursor: pointer;
+}
+.pr-checks-more:hover { color: var(--fg-1); }
 
 /* menu opens upward from the split button (reuses .dd / .dd-item base) */
 .git-split .gsa-menu {

--- a/src/components/RightPanel/GitPanel.tsx
+++ b/src/components/RightPanel/GitPanel.tsx
@@ -10,6 +10,7 @@ import {
   delegationDone,
   delegationLabel,
   delegationResolved,
+  delegationStep,
   type GitDelegationKind,
 } from "./delegation";
 import {
@@ -489,6 +490,7 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
   const delegation = useAppStore((s) => s.gitDelegations[agent.id]);
   const delegateGitAction = useAppStore((s) => s.delegateGitAction);
   const markGitDelegationRunning = useAppStore((s) => s.markGitDelegationRunning);
+  const markGitDelegationDequeued = useAppStore((s) => s.markGitDelegationDequeued);
   const clearGitDelegation = useAppStore((s) => s.clearGitDelegation);
   const gitCommitAction = useAppStore((s) => s.gitCommitAction);
   const setGitCommitAction = useAppStore((s) => s.setGitCommitAction);
@@ -565,37 +567,43 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
   useEffect(() => () => { if (noticeTimer.current) clearTimeout(noticeTimer.current); }, []);
 
   // Delegation lifecycle: while the agent holds control, watch the polled
-  // git/PR/check state for the transition that marks the action done. If the
-  // agent settles (idle/error/stopped) without it, hand control back with an
-  // honest notice. `sawRunning` + the 15s grace guard against clearing on
-  // the stale pre-send idle status.
+  // git/PR/check state for the transition that marks the action done. The
+  // step decision is pure (`delegationStep`) and handles the tricky cases —
+  // a trigger queued behind a pre-existing turn must wait that turn out
+  // (its running/settling is not ours), and a settled agent only reads as
+  // "gave up" after our own turn ran or the grace window passed.
   useEffect(() => {
     if (!delegation) return;
-    if (agent.status === "running" && !delegation.sawRunning) {
-      markGitDelegationRunning(agent.id);
-      return;
-    }
-    if (delegationResolved(delegation.kind, gitState, prState, checks)) {
-      clearGitDelegation(agent.id);
-      showNotice(delegationDone(delegation.kind));
-      // A fresh PR (or branch update) changes the merge gate — refresh now
-      // rather than waiting out the slow poll.
-      void fetchPrChecks(agent.id);
-      return;
-    }
-    const settled = agent.status !== "running" && agent.status !== "spawning";
-    const armed = delegation.sawRunning || Date.now() - delegation.startedAt > 15_000;
-    if (settled && armed) {
-      clearGitDelegation(agent.id);
-      showNotice(
-        delegation.kind === "fix-checks"
-          ? delegationDone("fix-checks")
-          : "Agent finished — review the chat for details",
-      );
+    const resolved = delegationResolved(delegation.kind, gitState, prState, checks);
+    switch (delegationStep(delegation, agent.status, resolved, Date.now())) {
+      case "resolve":
+        clearGitDelegation(agent.id);
+        showNotice(delegationDone(delegation.kind));
+        // A fresh PR (or branch update) changes the merge gate — refresh now
+        // rather than waiting out the slow poll.
+        void fetchPrChecks(agent.id);
+        break;
+      case "dequeue":
+        markGitDelegationDequeued(agent.id);
+        break;
+      case "mark-running":
+        markGitDelegationRunning(agent.id);
+        break;
+      case "give-up":
+        clearGitDelegation(agent.id);
+        showNotice(
+          delegation.kind === "fix-checks"
+            ? delegationDone("fix-checks")
+            : "Agent finished — review the chat for details",
+        );
+        break;
+      case "wait":
+        break;
     }
   }, [
     delegation, agent.id, agent.status, gitState, prState, checks,
-    markGitDelegationRunning, clearGitDelegation, showNotice, fetchPrChecks,
+    markGitDelegationRunning, markGitDelegationDequeued, clearGitDelegation,
+    showNotice, fetchPrChecks,
   ]);
 
   // Reset the override + notice + busy when switching agents so they don't

--- a/src/components/RightPanel/GitPanel.tsx
+++ b/src/components/RightPanel/GitPanel.tsx
@@ -11,18 +11,14 @@ import {
   delegationResolved,
   type GitDelegationKind,
 } from "./delegation";
-import { primaryFor, secondaryFor, type ActionTone, type GitPanelState } from "./primaryActions";
-
-function deriveState(git: GitState | null, pr: PrState | null): GitPanelState {
-  if (!git) return "loading";
-  if (git.files.some((f) => f.kind === "conflicted")) return "conflicts";
-  if (pr?.state === "merged") return "merged";
-  if (pr?.state === "open")   return "pr-open";
-  if (pr?.state === "closed") return "pr-closed";
-  if (git.files.length > 0)  return "changes";
-  if (git.ahead > 0)         return "pushed";
-  return "clean";
-}
+import {
+  deriveState,
+  isCommitAction,
+  primaryFor,
+  secondaryFor,
+  type ActionTone,
+  type GitPanelState,
+} from "./primaryActions";
 
 /** Status letter for the file badge — matches CSS `.gs.<kind>` selectors. */
 function kindLabel(kind: FileStatus["kind"]): string {
@@ -93,7 +89,9 @@ function describeHeader(
   const n = pr?.number;
   switch (state) {
     case "loading":   return { kind: "neutral", text: "Loading…" };
-    case "changes":   return { kind: "changes", pill: "Uncommitted", text: branch, diff: true };
+    // With an open PR, keep its GitHub link reachable from the header even
+    // while new uncommitted changes take over the panel.
+    case "changes":   return { kind: "changes", pill: "Uncommitted", text: branch, diff: true, ext: pr?.state === "open" };
     case "pushed":    return { kind: "info", pill: "Pushed", text: branch };
     case "conflicts": return { kind: "att", pill: "Conflicts", text: branch, sub: `← ${base}` };
     case "pr-open": {
@@ -491,6 +489,8 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
   const delegateGitAction = useAppStore((s) => s.delegateGitAction);
   const markGitDelegationRunning = useAppStore((s) => s.markGitDelegationRunning);
   const clearGitDelegation = useAppStore((s) => s.clearGitDelegation);
+  const gitCommitAction = useAppStore((s) => s.gitCommitAction);
+  const setGitCommitAction = useAppStore((s) => s.setGitCommitAction);
 
   // Poll git state for the focused agent at 1s while this panel is mounted.
   const pollGitState = useCallback(
@@ -650,7 +650,16 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
         delegate(
           "commit",
           "Commit all current changes. Review them first (`git status`, `git diff HEAD`), write a clear, conventional " +
-            "commit message, then commit by calling the `git_commit` app action with that message. Don't open a pull request.",
+            "commit message, then commit by calling the `git_commit` app action with that message. Commit ONLY — " +
+            "don't push and don't open a pull request.",
+        );
+        break;
+      case "agent-commit-push":
+        delegate(
+          "commit-push",
+          "Commit all current changes and push them. Review the changes (`git status`, `git diff HEAD`), write a " +
+            "clear, conventional commit message, commit by calling the `git_commit` app action, then push by calling " +
+            "the `git_push` app action. Don't open a pull request.",
         );
         break;
       case "agent-open-pr":
@@ -752,6 +761,8 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
     mergeable,
     mergeState,
     checksFailed: checks?.failed ?? 0,
+    commitAction: gitCommitAction,
+    prOpen,
   };
   const primary   = primaryFor(panelState, counts);
   const secondary = secondaryFor(panelState, counts);
@@ -932,6 +943,19 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
                 )}
               </span>
               {primary.statusExtra && <span className="ex">{primary.statusExtra}</span>}
+              {/* View on GitHub is a convenience link, not an action — a
+                  quiet chip beside the status, never a menu item. */}
+              {panelState === "pr-open" && prState?.url && (
+                <button
+                  type="button"
+                  className="st-ext tip"
+                  data-tip="View on GitHub"
+                  aria-label="View on GitHub"
+                  onClick={() => void open(prState.url)}
+                >
+                  <Icon name="external" size={11} />
+                </button>
+              )}
             </div>
           )}
           <SplitAction
@@ -941,7 +965,12 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
             tone={tone}
             mainDisabled={mainDisabled}
             busyLabel={busy ?? (delegation ? "Agent working…" : null)}
-            onSelect={setSelectedKey}
+            onSelect={(key) => {
+              setSelectedKey(key);
+              // Picking a commit mode is sticky: it becomes the default
+              // primary in every workspace until the user picks another.
+              if (isCommitAction(key)) setGitCommitAction(key);
+            }}
             onRun={() => runAction(effectiveKey)}
           />
         </div>

--- a/src/components/RightPanel/GitPanel.tsx
+++ b/src/components/RightPanel/GitPanel.tsx
@@ -6,6 +6,7 @@ import { usePoll } from "../../util/hooks";
 import { Icon, type IconName } from "../Icon";
 import { IconButton } from "../ui/IconButton";
 import {
+  appActionMessage,
   delegationDone,
   delegationLabel,
   delegationResolved,
@@ -637,68 +638,35 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
   function runAction(key: string) {
     switch (key) {
       // ── delegated to the coding agent (agent mode) ──
+      // Each click sends a short `[app-action]` trigger; the full playbook
+      // lives in the agent's injected instructions (git_actions.md), keeping
+      // the chat free of boilerplate. Params carry only dynamic context.
       case "agent-commit-pr":
-        delegate(
-          "commit-pr",
-          "Commit all current changes and open a pull request. Review the changes (`git status`, `git diff HEAD`), " +
-            "write a clear, conventional commit message, and commit by calling the `git_commit` app action. Then write " +
-            `a concise PR title and description covering ALL changes on this branch versus ${base}, and open the PR by ` +
-            "calling the `open_pr` app action with that title and body.",
-        );
+        delegate("commit-pr", appActionMessage("commit-pr", { base }));
         break;
       case "agent-commit":
-        delegate(
-          "commit",
-          "Commit all current changes. Review them first (`git status`, `git diff HEAD`), write a clear, conventional " +
-            "commit message, then commit by calling the `git_commit` app action with that message. Commit ONLY — " +
-            "don't push and don't open a pull request.",
-        );
+        delegate("commit", appActionMessage("commit"));
         break;
       case "agent-commit-push":
-        delegate(
-          "commit-push",
-          "Commit all current changes and push them. Review the changes (`git status`, `git diff HEAD`), write a " +
-            "clear, conventional commit message, commit by calling the `git_commit` app action, then push by calling " +
-            "the `git_push` app action. Don't open a pull request.",
-        );
+        delegate("commit-push", appActionMessage("commit-push"));
         break;
       case "agent-open-pr":
-        delegate(
-          "open-pr",
-          `Open a pull request for this branch. Review everything on it versus ${base} (\`git log ${base}..HEAD\`, ` +
-            `\`git diff ${base}...HEAD\`), write a concise, descriptive PR title and body, then open the PR by calling ` +
-            "the `open_pr` app action with that title and body.",
-        );
+        delegate("open-pr", appActionMessage("open-pr", { base }));
         break;
       case "agent-resolve":
-        delegate(
-          "resolve",
-          "Resolve the merge conflicts in your worktree. Inspect each conflicted file, reconcile both sides correctly, " +
-            "then complete the merge by calling the `git_commit` app action with a short merge commit message — it " +
-            "stages everything for you.",
-        );
+        delegate("resolve", appActionMessage("resolve-conflicts"));
         break;
       case "agent-update-branch":
         // PR can't merge cleanly with the base (the base advanced). This is NOT
         // a local in-progress merge — the agent must sync the base in first.
-        delegate(
-          "update-branch",
-          `This pull request can't merge cleanly because ${base} has advanced. Call the \`git_update_branch\` app ` +
-            "action to merge the latest base into this branch. If it reports conflicts, resolve them in the affected " +
-            "files, complete the merge with the `git_commit` app action, then push with `git_push`. If it merges " +
-            "cleanly, just push with `git_push`.",
-        );
+        delegate("update-branch", appActionMessage("update-branch", { base }));
         break;
-      case "agent-fix": {
-        const failing = checks?.required_failing ?? [];
-        const names = failing.length > 0 ? ` (${failing.join(", ")})` : "";
+      case "agent-fix":
         delegate(
           "fix-checks",
-          `Some CI checks are failing on this pull request${names}. Investigate the failures, fix them, commit the ` +
-            "fix by calling the `git_commit` app action, then push with `git_push` so the checks re-run.",
+          appActionMessage("fix-checks", { failing: (checks?.required_failing ?? []).join(", ") }),
         );
         break;
-      }
       // ── direct, agent bypassed (user typed their own message) ──
       case "commit-direct":
         if (!customActive) { openOverride(); return; }

--- a/src/components/RightPanel/GitPanel.tsx
+++ b/src/components/RightPanel/GitPanel.tsx
@@ -1,6 +1,6 @@
 import { open } from "@tauri-apps/plugin-shell";
 import { type ReactNode, type RefObject, useCallback, useEffect, useRef, useState } from "react";
-import type { AgentRecord, FileStatus, GitState, MergeState, PrState } from "../../api";
+import type { AgentRecord, CheckRun, FileStatus, GitState, MergeState, PrChecks, PrState } from "../../api";
 import { useAppStore } from "../../store";
 import { usePoll } from "../../util/hooks";
 import { Icon, type IconName } from "../Icon";
@@ -87,6 +87,8 @@ function describeHeader(
   branch: string,
   base: string,
   pr: PrState | null,
+  mergeState: MergeState | null,
+  checksFailed: number,
 ): HeaderInfo {
   const n = pr?.number;
   switch (state) {
@@ -94,12 +96,28 @@ function describeHeader(
     case "changes":   return { kind: "changes", pill: "Uncommitted", text: branch, diff: true };
     case "pushed":    return { kind: "info", pill: "Pushed", text: branch };
     case "conflicts": return { kind: "att", pill: "Conflicts", text: branch, sub: `← ${base}` };
-    case "pr-open":
-      // `mergeable` only means "no conflicts" — not that checks passed — so the
-      // header stays neutral blue, never a green "ready" all-clear.
-      return pr?.mergeable
-        ? { kind: "info", pill: n != null ? `PR #${n}` : "PR", text: "no conflicts", ext: true }
-        : { kind: "att", pill: n != null ? `PR #${n}` : "PR", text: "can’t merge yet", ext: true };
+    case "pr-open": {
+      // GitHub's combined merge gate (spec §7): the legitimate green "ready"
+      // appears only on `clean`. Without checks data, fall back to
+      // `mergeable` — which only means "no conflicts", never an all-clear.
+      const pill = n != null ? `PR #${n}` : "PR";
+      switch (mergeState) {
+        case "clean":    return { kind: "ready", pill, text: "ready to merge", ext: true };
+        case "unstable": return { kind: "changes", pill, text: "optional checks failing", ext: true };
+        case "blocked":
+          return { kind: "att", pill, text: checksFailed > 0 ? "checks failing" : "review required", ext: true };
+        case "behind":   return { kind: "att", pill, text: `behind ${base}`, ext: true };
+        case "dirty":    return { kind: "att", pill, text: `conflicts with ${base}`, ext: true };
+        case "draft":    return { kind: "info", pill, text: "draft", ext: true };
+        case "unknown":
+        case "has_hooks":
+          return { kind: "info", pill, text: "checking…", ext: true };
+        default:
+          return pr?.mergeable
+            ? { kind: "info", pill, text: "no conflicts", ext: true }
+            : { kind: "att", pill, text: "can’t merge yet", ext: true };
+      }
+    }
     case "pr-closed": return { kind: "neutral", pill: "Closed", text: n != null ? `#${n}` : "—", ext: true };
     case "merged":    return { kind: "merged", pill: "Merged", text: n != null ? `#${n} → ${base}` : `→ ${base}`, ext: true };
     default:          return { kind: "clean", text: branch, sub: `← ${base}`, dot: true };
@@ -112,14 +130,18 @@ function StatusHeader({
   base,
   git,
   pr,
+  mergeState,
+  checksFailed,
 }: {
   state: GitPanelState;
   branch: string;
   base: string;
   git: GitState | null;
   pr: PrState | null;
+  mergeState: MergeState | null;
+  checksFailed: number;
 }) {
-  const h = describeHeader(state, branch, base, pr);
+  const h = describeHeader(state, branch, base, pr, mergeState, checksFailed);
   const adds = git?.additions ?? 0;
   const dels = git?.deletions ?? 0;
   return (
@@ -311,20 +333,86 @@ function CommitComposer({
 
 // ── State cards (rendered in the scrollable body) ─────────────────
 
-function PRCard({ pr, base }: { pr: PrState; base: string }) {
+/** Visual class for one check row: ok / fail / skip dot, or a spinner while
+ *  the run is queued / in progress. */
+function checkTone(run: CheckRun): "ok" | "fail" | "skip" | "run" {
+  if (run.status !== "completed") return "run";
+  switch (run.conclusion) {
+    case "success": return "ok";
+    case "neutral":
+    case "skipped":
+    case "stale":
+    case null:      return "skip";
+    default:        return "fail"; // failure, timed_out, cancelled, action_required, …
+  }
+}
+
+function ChecksSection({ checks, prUrl }: { checks: PrChecks; prUrl: string }) {
+  if (checks.total === 0) return null;
+  // Failing first, then running, then the rest — the actionable rows lead.
+  const weight = (r: CheckRun) => (checkTone(r) === "fail" ? 0 : checkTone(r) === "run" ? 1 : 2);
+  const runs = [...checks.runs].sort((a, b) => weight(a) - weight(b));
+  const shown = runs.slice(0, 6);
+  const hidden = runs.length - shown.length;
+  const summary =
+    checks.rollup === "failing"
+      ? `${checks.failed} failing`
+      : checks.rollup === "pending"
+        ? `${checks.total - checks.pending} of ${checks.total} done`
+        : "all passing";
+  return (
+    <div className="pr-checks">
+      <div className="pr-checks-h">
+        <span>Checks</span>
+        <span className={`pr-checks-sum ${checks.rollup}`}>{summary}</span>
+      </div>
+      {shown.map((r) => {
+        const tone = checkTone(r);
+        return (
+          <button
+            type="button"
+            key={r.name}
+            className="pr-check"
+            onClick={() => void open(r.url ?? `${prUrl}/checks`)}
+          >
+            {tone === "run" ? <span className="git-spin sm" /> : <span className={`pc-dot ${tone}`} />}
+            <span className="pc-name">{r.name}</span>
+            <Icon name="external" size={10} />
+          </button>
+        );
+      })}
+      {hidden > 0 && (
+        <button type="button" className="pr-checks-more" onClick={() => void open(`${prUrl}/checks`)}>
+          +{hidden} more on GitHub
+        </button>
+      )}
+    </div>
+  );
+}
+
+function PRCard({ pr, base, checks }: { pr: PrState; base: string; checks: PrChecks | null }) {
+  // One merge-gate line, from `merge_state` when available (spec §7); the
+  // `mergeable`-only fallback claims no more than "no conflicts".
+  const ms = checks?.merge_state ?? null;
+  const gate: { cls: string; text: string } =
+    ms === "clean"    ? { cls: "ok",  text: "✓ Ready to merge" } :
+    ms === "unstable" ? { cls: "ok",  text: "✓ Mergeable — optional checks failing" } :
+    ms === "blocked"  ? { cls: "att", text: "△ Blocked by required checks or reviews" } :
+    ms === "behind"   ? { cls: "att", text: `△ Behind ${base} — update your branch` } :
+    ms === "dirty"    ? { cls: "att", text: `△ Conflicts with ${base} — update your branch` } :
+    ms === "draft"    ? { cls: "ok",  text: "Draft — mark ready on GitHub to merge" } :
+    ms != null        ? { cls: "ok",  text: "Computing merge status…" } :
+    pr.mergeable      ? { cls: "ok",  text: "✓ No merge conflicts" } :
+                        { cls: "att", text: `△ Can’t merge cleanly with ${base} — update your branch` };
   return (
     <div className="git-card">
       <div className="git-card-h">Pull request</div>
       <div className="git-card-title">{pr.title}</div>
       <div className="git-card-meta">#{pr.number} · open</div>
       <div className="git-card-row">
-        {pr.mergeable ? (
-          // `mergeable` ⇒ no merge conflicts only; it says nothing about checks.
-          <span className="ok">✓ No merge conflicts</span>
-        ) : (
-          <span className="att">△ Can’t merge cleanly with {base} — update your branch</span>
-        )}
+        <span className={gate.cls}>{gate.text}</span>
       </div>
+      {checks && <ChecksSection checks={checks} prUrl={pr.url} />}
       <div className="git-card-links">
         <button type="button" className="git-card-link" onClick={() => void open(pr.url)}>
           <Icon name="github" size={11} />
@@ -729,11 +817,19 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
   return (
     <div className="git-wrap">
       {/* ── color-coded status header: the at-a-glance state signal ── */}
-      <StatusHeader state={panelState} branch={branch} base={base} git={gitState} pr={prState} />
+      <StatusHeader
+        state={panelState}
+        branch={branch}
+        base={base}
+        git={gitState}
+        pr={prState}
+        mergeState={mergeState}
+        checksFailed={checks?.failed ?? 0}
+      />
 
       {/* ── scrollable body: the changes are the focus ── */}
       <div className={`git-body ${busy ? "busy" : ""}`}>
-        {panelState === "pr-open"   && prState && <PRCard pr={prState} base={base} />}
+        {panelState === "pr-open"   && prState && <PRCard pr={prState} base={base} checks={checks} />}
         {panelState === "pr-closed" && prState && <ClosedPRCard pr={prState} />}
         {panelState === "conflicts" && gitState && <ConflictCard files={gitState.files} />}
 

--- a/src/components/RightPanel/GitPanel.tsx
+++ b/src/components/RightPanel/GitPanel.tsx
@@ -1,10 +1,16 @@
 import { open } from "@tauri-apps/plugin-shell";
 import { type ReactNode, type RefObject, useCallback, useEffect, useRef, useState } from "react";
-import type { AgentRecord, FileStatus, GitState, PrState } from "../../api";
+import type { AgentRecord, FileStatus, GitState, MergeState, PrState } from "../../api";
 import { useAppStore } from "../../store";
 import { usePoll } from "../../util/hooks";
 import { Icon, type IconName } from "../Icon";
 import { IconButton } from "../ui/IconButton";
+import {
+  delegationDone,
+  delegationLabel,
+  delegationResolved,
+  type GitDelegationKind,
+} from "./delegation";
 import { primaryFor, secondaryFor, type ActionTone, type GitPanelState } from "./primaryActions";
 
 function deriveState(git: GitState | null, pr: PrState | null): GitPanelState {
@@ -391,7 +397,12 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
   const discardChanges   = useAppStore((s) => s.discardChanges);
   const abortMerge       = useAppStore((s) => s.abortMerge);
   const deleteBranch     = useAppStore((s) => s.deleteBranch);
-  const sendUserMessage  = useAppStore((s) => s.sendUserMessage);
+  const prChecksEntry = useAppStore((s) => s.prChecks[agent.id]);
+  const fetchPrChecks = useAppStore((s) => s.fetchPrChecks);
+  const delegation = useAppStore((s) => s.gitDelegations[agent.id]);
+  const delegateGitAction = useAppStore((s) => s.delegateGitAction);
+  const markGitDelegationRunning = useAppStore((s) => s.markGitDelegationRunning);
+  const clearGitDelegation = useAppStore((s) => s.clearGitDelegation);
 
   // Poll git state for the focused agent at 1s while this panel is mounted.
   const pollGitState = useCallback(
@@ -403,6 +414,21 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
   useEffect(() => {
     void fetchPrState(agent.id);
   }, [agent.id, fetchPrState]);
+
+  // Poll the heavier checks read at 7s, only while a PR is open. An absent
+  // entry (undefined) means the first fetch hasn't landed → the panel renders
+  // the "checking…" sub-state; null means confirmed unavailable → fall back
+  // to mergeable-only behavior.
+  const prOpen = prState?.state === "open";
+  const pollChecks = useCallback(() => {
+    if (!prOpen) return Promise.resolve();
+    return fetchPrChecks(agent.id);
+  }, [agent.id, prOpen, fetchPrChecks]);
+  usePoll(pollChecks, 7000, [pollChecks]);
+
+  const checks = prChecksEntry ?? null;
+  const mergeState: MergeState | null =
+    checks?.merge_state ?? (prOpen && prChecksEntry === undefined ? "unknown" : null);
 
   const panelState = deriveState(gitState, prState);
 
@@ -449,6 +475,40 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
   }, []);
   useEffect(() => () => { if (noticeTimer.current) clearTimeout(noticeTimer.current); }, []);
 
+  // Delegation lifecycle: while the agent holds control, watch the polled
+  // git/PR/check state for the transition that marks the action done. If the
+  // agent settles (idle/error/stopped) without it, hand control back with an
+  // honest notice. `sawRunning` + the 15s grace guard against clearing on
+  // the stale pre-send idle status.
+  useEffect(() => {
+    if (!delegation) return;
+    if (agent.status === "running" && !delegation.sawRunning) {
+      markGitDelegationRunning(agent.id);
+      return;
+    }
+    if (delegationResolved(delegation.kind, gitState, prState, checks)) {
+      clearGitDelegation(agent.id);
+      showNotice(delegationDone(delegation.kind));
+      // A fresh PR (or branch update) changes the merge gate — refresh now
+      // rather than waiting out the slow poll.
+      void fetchPrChecks(agent.id);
+      return;
+    }
+    const settled = agent.status !== "running" && agent.status !== "spawning";
+    const armed = delegation.sawRunning || Date.now() - delegation.startedAt > 15_000;
+    if (settled && armed) {
+      clearGitDelegation(agent.id);
+      showNotice(
+        delegation.kind === "fix-checks"
+          ? delegationDone("fix-checks")
+          : "Agent finished — review the chat for details",
+      );
+    }
+  }, [
+    delegation, agent.id, agent.status, gitState, prState, checks,
+    markGitDelegationRunning, clearGitDelegation, showNotice, fetchPrChecks,
+  ]);
+
   // Reset the override + notice + busy when switching agents so they don't
   // leak between worktrees.
   useEffect(() => {
@@ -473,48 +533,75 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
   const branch = gitState?.branch || agent.repos[0]?.branch || "(no branch yet)";
   const base   = gitState?.parent_branch || agent.repos[0]?.parent_branch || "main";
 
+  // Hand control to the coding agent: it writes the judgment part (message /
+  // description / conflict edits) and executes the mutation through the
+  // app's file RPC (git_commit / open_pr / git_update_branch / git_push).
+  // The panel tracks the delegation until the matching transition lands.
+  const delegate = useCallback(
+    (kind: GitDelegationKind, prompt: string) => {
+      delegateGitAction(agent.id, kind, prompt);
+    },
+    [agent.id, delegateGitAction],
+  );
+
   // Single dispatch table for every action a state can offer — the split
   // button's main click and its menu both route through here by key.
   function runAction(key: string) {
     switch (key) {
       // ── delegated to the coding agent (agent mode) ──
       case "agent-commit-pr":
-        void sendUserMessage(
-          agent.id,
-          "Commit all current changes with a clear, conventional commit message, then open a pull request with a concise, descriptive title and body.",
+        delegate(
+          "commit-pr",
+          "Commit all current changes and open a pull request. Review the changes (`git status`, `git diff HEAD`), " +
+            "write a clear, conventional commit message, and commit by calling the `git_commit` app action. Then write " +
+            `a concise PR title and description covering ALL changes on this branch versus ${base}, and open the PR by ` +
+            "calling the `open_pr` app action with that title and body.",
         );
-        showNotice("Asked the agent to commit & open a PR");
         break;
       case "agent-commit":
-        void sendUserMessage(
-          agent.id,
-          "Commit all current changes with a clear, conventional commit message.",
+        delegate(
+          "commit",
+          "Commit all current changes. Review them first (`git status`, `git diff HEAD`), write a clear, conventional " +
+            "commit message, then commit by calling the `git_commit` app action with that message. Don't open a pull request.",
         );
-        showNotice("Asked the agent to commit");
+        break;
+      case "agent-open-pr":
+        delegate(
+          "open-pr",
+          `Open a pull request for this branch. Review everything on it versus ${base} (\`git log ${base}..HEAD\`, ` +
+            `\`git diff ${base}...HEAD\`), write a concise, descriptive PR title and body, then open the PR by calling ` +
+            "the `open_pr` app action with that title and body.",
+        );
         break;
       case "agent-resolve":
-        void sendUserMessage(
-          agent.id,
-          "Resolve the current git merge conflicts: inspect each conflicted file, reconcile both sides correctly, and complete the merge.",
+        delegate(
+          "resolve",
+          "Resolve the merge conflicts in your worktree. Inspect each conflicted file, reconcile both sides correctly, " +
+            "then complete the merge by calling the `git_commit` app action with a short merge commit message — it " +
+            "stages everything for you.",
         );
-        showNotice("Asked the agent to resolve conflicts");
         break;
       case "agent-update-branch":
         // PR can't merge cleanly with the base (the base advanced). This is NOT
         // a local in-progress merge — the agent must sync the base in first.
-        void sendUserMessage(
-          agent.id,
-          `This pull request can't merge cleanly with ${base}. Update this branch with the latest ${base} (rebase onto it, or merge it in), resolve any conflicts that arise, and push so the PR becomes mergeable again.`,
+        delegate(
+          "update-branch",
+          `This pull request can't merge cleanly because ${base} has advanced. Call the \`git_update_branch\` app ` +
+            "action to merge the latest base into this branch. If it reports conflicts, resolve them in the affected " +
+            "files, complete the merge with the `git_commit` app action, then push with `git_push`. If it merges " +
+            "cleanly, just push with `git_push`.",
         );
-        showNotice(`Asked the agent to update the branch with ${base}`);
         break;
-      case "agent-fix":
-        void sendUserMessage(
-          agent.id,
-          "Some CI checks are failing on this pull request. Investigate the failures and fix them.",
+      case "agent-fix": {
+        const failing = checks?.required_failing ?? [];
+        const names = failing.length > 0 ? ` (${failing.join(", ")})` : "";
+        delegate(
+          "fix-checks",
+          `Some CI checks are failing on this pull request${names}. Investigate the failures, fix them, commit the ` +
+            "fix by calling the `git_commit` app action, then push with `git_push` so the checks re-run.",
         );
-        showNotice("Asked the agent to fix the failing checks");
         break;
+      }
       // ── direct, agent bypassed (user typed their own message) ──
       case "commit-direct":
         if (!customActive) { openOverride(); return; }
@@ -575,15 +662,21 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
     base,
     customActive,
     mergeable,
+    mergeState,
+    checksFailed: checks?.failed ?? 0,
   };
   const primary   = primaryFor(panelState, counts);
   const secondary = secondaryFor(panelState, counts);
 
   // All actions for this state, primary first. The main button shows whichever
-  // is currently selected; the default selection is the primary.
+  // is currently selected; the default selection is the primary. A secondary
+  // candidate that duplicates the primary is dropped (pr-open lists Merge
+  // unconditionally so it stays reachable from any merge_state).
   const items: SplitActionItem[] = [
     { key: primary.key, label: primary.label, icon: primary.icon },
-    ...secondary.map((s) => ({ key: s.key, label: s.label, icon: s.icon, kbd: s.kbd })),
+    ...secondary
+      .filter((s) => s.key !== primary.key)
+      .map((s) => ({ key: s.key, label: s.label, icon: s.icon, kbd: s.kbd })),
   ];
 
   // Selected action: defaults to the primary, resets whenever the state (or the
@@ -601,11 +694,15 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
   // tone/enabled state, and the dispatched action all stay in agreement.
   const effectiveKey = items.some((i) => i.key === selectedKey) ? selectedKey : primary.key;
 
-  // The CTA's main button is disabled while loading git state, while an action
-  // is in flight, and when Merge is selected but the PR can't merge yet.
+  // The CTA's main button is disabled while loading git state, while the
+  // agent holds a delegation, and when Merge is selected but the merge gate
+  // isn't open (clean/unstable per spec §7; `mergeable` fallback without
+  // checks data).
+  const mergeAllowed = checks ? mergeState === "clean" || mergeState === "unstable" : mergeable;
   const mainDisabled =
     effectiveKey === "loading" ||
-    (effectiveKey === "merge" && !mergeable);
+    delegation != null ||
+    (effectiveKey === "merge" && !mergeAllowed);
   // Tone applies only when the selected action is the state's primary; picking
   // an alternate from the menu falls back to the neutral accent fill.
   const tone: ActionTone = effectiveKey === primary.key ? primary.tone ?? "accent" : "accent";
@@ -625,8 +722,9 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
       : null;
 
   // Show the changes list only when there are uncommitted files to display.
+  // The commit composer yields while the agent holds a delegation.
   const showFiles  = panelState === "changes" || panelState === "conflicts";
-  const showCommit = panelState === "changes";
+  const showCommit = panelState === "changes" && !delegation;
 
   return (
     <div className="git-wrap">
@@ -714,6 +812,11 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
               <Spinner />
               <span className="lbl">{busy}</span>
             </div>
+          ) : delegation ? (
+            <div className="git-act-status info working">
+              <Spinner />
+              <span className="lbl">{delegationLabel(delegation.kind)}</span>
+            </div>
           ) : notice ? (
             <div className="git-notice">
               <Icon name="check" size={11} />
@@ -741,7 +844,7 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
             primaryKey={primary.key}
             tone={tone}
             mainDisabled={mainDisabled}
-            busyLabel={busy}
+            busyLabel={busy ?? (delegation ? "Agent working…" : null)}
             onSelect={setSelectedKey}
             onRun={() => runAction(effectiveKey)}
           />

--- a/src/components/RightPanel/delegation.test.ts
+++ b/src/components/RightPanel/delegation.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { GitState, PrChecks, PrState } from "../../api";
-import { delegationDone, delegationLabel, delegationResolved } from "./delegation";
+import {
+  APP_ACTION_PREFIX,
+  appActionMessage,
+  delegationDone,
+  delegationLabel,
+  delegationResolved,
+} from "./delegation";
 
 function git(over: Partial<GitState> = {}): GitState {
   return {
@@ -57,6 +63,30 @@ describe("delegationResolved", () => {
 
   it("fix-checks never resolves from state (caller resolves on agent idle)", () => {
     expect(delegationResolved("fix-checks", git(), pr(), checks("clean"))).toBe(false);
+  });
+});
+
+describe("appActionMessage", () => {
+  it("builds a bare trigger without params", () => {
+    expect(appActionMessage("commit")).toBe("[app-action] commit");
+  });
+
+  it("appends quoted key=value params", () => {
+    expect(appActionMessage("commit-pr", { base: "main" })).toBe('[app-action] commit-pr base="main"');
+    expect(appActionMessage("fix-checks", { failing: "build, test" })).toBe(
+      '[app-action] fix-checks failing="build, test"',
+    );
+  });
+
+  it("skips empty params and escapes embedded quotes", () => {
+    expect(appActionMessage("open-pr", { base: "" })).toBe("[app-action] open-pr");
+    expect(appActionMessage("fix-checks", { failing: 'say "hi"' })).toBe(
+      '[app-action] fix-checks failing="say \\"hi\\""',
+    );
+  });
+
+  it("triggers start with the shared prefix the transcript folds into a chip", () => {
+    expect(appActionMessage("commit").startsWith(APP_ACTION_PREFIX)).toBe(true);
   });
 });
 

--- a/src/components/RightPanel/delegation.test.ts
+++ b/src/components/RightPanel/delegation.test.ts
@@ -3,10 +3,17 @@ import type { GitState, PrChecks, PrState } from "../../api";
 import {
   APP_ACTION_PREFIX,
   appActionMessage,
+  DELEGATION_GIVE_UP_GRACE_MS,
   delegationDone,
   delegationLabel,
   delegationResolved,
+  delegationStep,
+  type GitDelegation,
 } from "./delegation";
+
+function d(over: Partial<GitDelegation> = {}): GitDelegation {
+  return { kind: "commit", startedAt: 1_000, sawRunning: false, queued: false, ...over };
+}
 
 function git(over: Partial<GitState> = {}): GitState {
   return {
@@ -63,6 +70,41 @@ describe("delegationResolved", () => {
 
   it("fix-checks never resolves from state (caller resolves on agent idle)", () => {
     expect(delegationResolved("fix-checks", git(), pr(), checks("clean"))).toBe(false);
+  });
+});
+
+describe("delegationStep", () => {
+  const soon = 2_000; // within the grace window of startedAt=1_000
+  const late = 1_000 + DELEGATION_GIVE_UP_GRACE_MS + 1;
+
+  it("resolution wins over everything, even while queued", () => {
+    expect(delegationStep(d({ queued: true }), "running", true, soon)).toBe("resolve");
+    expect(delegationStep(d({ sawRunning: true }), "idle", true, late)).toBe("resolve");
+  });
+
+  it("queued behind an in-flight turn: waits it out, then dequeues — never gives up", () => {
+    // The pre-existing turn is still running: not ours, just wait.
+    expect(delegationStep(d({ queued: true }), "running", false, late)).toBe("wait");
+    // That turn settles: our trigger is next — dequeue, NOT "give-up", and
+    // NOT "mark-running" off the foreign turn (the reported bug).
+    expect(delegationStep(d({ queued: true }), "idle", false, late)).toBe("dequeue");
+  });
+
+  it("after dequeue, an idle gap before our turn starts is tolerated within the grace window", () => {
+    // markGitDelegationDequeued resets startedAt, so `now` is near it again.
+    expect(delegationStep(d(), "idle", false, soon)).toBe("wait");
+    expect(delegationStep(d(), "idle", false, late)).toBe("give-up");
+  });
+
+  it("marks our own turn running exactly once, then settles into give-up", () => {
+    expect(delegationStep(d(), "running", false, soon)).toBe("mark-running");
+    expect(delegationStep(d({ sawRunning: true }), "running", false, late)).toBe("wait");
+    expect(delegationStep(d({ sawRunning: true }), "idle", false, soon)).toBe("give-up");
+  });
+
+  it("spawning counts as active, not settled", () => {
+    expect(delegationStep(d({ queued: true }), "spawning", false, late)).toBe("wait");
+    expect(delegationStep(d({ sawRunning: true }), "spawning", false, late)).toBe("wait");
   });
 });
 

--- a/src/components/RightPanel/delegation.test.ts
+++ b/src/components/RightPanel/delegation.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import type { GitState, PrChecks, PrState } from "../../api";
+import { delegationDone, delegationLabel, delegationResolved } from "./delegation";
+
+function git(over: Partial<GitState> = {}): GitState {
+  return {
+    branch: "feat", parent_branch: "main", ahead: 1, behind: 0, unpushed: 0,
+    files: [], additions: 0, deletions: 0, ...over,
+  };
+}
+const file = (kind: GitState["files"][number]["kind"]) => ({
+  path: "a.ts", kind, staged: false, additions: 1, deletions: 0,
+});
+function pr(over: Partial<PrState> = {}): PrState {
+  return { number: 7, url: "https://x", state: "open", title: "t", mergeable: true, ...over };
+}
+function checks(merge_state: PrChecks["merge_state"]): PrChecks {
+  return {
+    merge_state, rollup: "none", total: 0, passed: 0, failed: 0, pending: 0,
+    required_failing: [], runs: [],
+  };
+}
+
+describe("delegationResolved", () => {
+  it("commit resolves once the working tree is clean", () => {
+    expect(delegationResolved("commit", git({ files: [file("modified")] }), null, null)).toBe(false);
+    expect(delegationResolved("commit", git(), null, null)).toBe(true);
+    expect(delegationResolved("commit", null, null, null)).toBe(false);
+  });
+
+  it("commit-pr and open-pr resolve when a PR is open", () => {
+    expect(delegationResolved("commit-pr", git(), null, null)).toBe(false);
+    expect(delegationResolved("commit-pr", git(), pr(), null)).toBe(true);
+    expect(delegationResolved("open-pr", git(), pr({ state: "closed" }), null)).toBe(false);
+    expect(delegationResolved("open-pr", git(), pr(), null)).toBe(true);
+  });
+
+  it("resolve resolves when no conflicted files remain", () => {
+    expect(delegationResolved("resolve", git({ files: [file("conflicted")] }), null, null)).toBe(false);
+    expect(delegationResolved("resolve", git({ files: [file("modified")] }), null, null)).toBe(true);
+  });
+
+  it("update-branch waits out behind/dirty/unknown, falls back to mergeable", () => {
+    expect(delegationResolved("update-branch", git(), pr(), checks("behind"))).toBe(false);
+    expect(delegationResolved("update-branch", git(), pr(), checks("dirty"))).toBe(false);
+    expect(delegationResolved("update-branch", git(), pr(), checks("unknown"))).toBe(false);
+    expect(delegationResolved("update-branch", git(), pr(), checks("clean"))).toBe(true);
+    expect(delegationResolved("update-branch", git(), pr({ mergeable: false }), null)).toBe(false);
+    expect(delegationResolved("update-branch", git(), pr({ mergeable: true }), null)).toBe(true);
+  });
+
+  it("fix-checks never resolves from state (caller resolves on agent idle)", () => {
+    expect(delegationResolved("fix-checks", git(), pr(), checks("clean"))).toBe(false);
+  });
+});
+
+describe("copy", () => {
+  it("has a label and done message for every kind", () => {
+    for (const k of ["commit", "commit-pr", "open-pr", "resolve", "update-branch", "fix-checks"] as const) {
+      expect(delegationLabel(k).length).toBeGreaterThan(0);
+      expect(delegationDone(k).length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/components/RightPanel/delegation.test.ts
+++ b/src/components/RightPanel/delegation.test.ts
@@ -28,6 +28,12 @@ describe("delegationResolved", () => {
     expect(delegationResolved("commit", null, null, null)).toBe(false);
   });
 
+  it("commit-push resolves once the tree is clean AND everything is pushed", () => {
+    expect(delegationResolved("commit-push", git({ files: [file("modified")] }), null, null)).toBe(false);
+    expect(delegationResolved("commit-push", git({ unpushed: 1 }), null, null)).toBe(false);
+    expect(delegationResolved("commit-push", git(), null, null)).toBe(true);
+  });
+
   it("commit-pr and open-pr resolve when a PR is open", () => {
     expect(delegationResolved("commit-pr", git(), null, null)).toBe(false);
     expect(delegationResolved("commit-pr", git(), pr(), null)).toBe(true);
@@ -56,7 +62,7 @@ describe("delegationResolved", () => {
 
 describe("copy", () => {
   it("has a label and done message for every kind", () => {
-    for (const k of ["commit", "commit-pr", "open-pr", "resolve", "update-branch", "fix-checks"] as const) {
+    for (const k of ["commit", "commit-push", "commit-pr", "open-pr", "resolve", "update-branch", "fix-checks"] as const) {
       expect(delegationLabel(k).length).toBeGreaterThan(0);
       expect(delegationDone(k).length).toBeGreaterThan(0);
     }

--- a/src/components/RightPanel/delegation.ts
+++ b/src/components/RightPanel/delegation.ts
@@ -1,0 +1,73 @@
+import type { GitState, PrChecks, PrState } from "../../api";
+
+/** One agent-delegated git action: the user clicked a panel action whose
+ *  judgment part (message, description, conflict edits) belongs to the
+ *  coding agent; the agent executes the mutation through the app's file
+ *  RPC (`git_commit` / `open_pr` / `git_update_branch` / `git_push`). */
+export type GitDelegationKind =
+  | "commit"
+  | "commit-pr"
+  | "open-pr"
+  | "resolve"
+  | "update-branch"
+  | "fix-checks";
+
+export interface GitDelegation {
+  kind: GitDelegationKind;
+  /** Epoch ms when the delegation was sent — grace window for status races. */
+  startedAt: number;
+  /** The agent has been observed `running` since `startedAt`. Until then an
+   *  `idle` status is the pre-send value, not a finished turn. */
+  sawRunning: boolean;
+}
+
+/** Footer status line while the agent holds control. */
+export function delegationLabel(kind: GitDelegationKind): string {
+  switch (kind) {
+    case "commit":        return "Agent is writing the commit message…";
+    case "commit-pr":     return "Agent is committing & opening a PR…";
+    case "open-pr":       return "Agent is writing the PR description…";
+    case "resolve":       return "Agent is resolving the conflicts…";
+    case "update-branch": return "Agent is updating the branch…";
+    case "fix-checks":    return "Agent is fixing the failing checks…";
+  }
+}
+
+/** Success notice once the watched transition lands. */
+export function delegationDone(kind: GitDelegationKind): string {
+  switch (kind) {
+    case "commit":        return "Agent committed your changes";
+    case "commit-pr":     return "Committed — PR is open";
+    case "open-pr":       return "PR is open";
+    case "resolve":       return "Conflicts resolved";
+    case "update-branch": return "Branch updated";
+    case "fix-checks":    return "Agent finished — checks are re-running";
+  }
+}
+
+/** Whether the git/PR transition this delegation is waiting for has landed.
+ *  Pure — the panel evaluates it against each poll tick. `fix-checks` is the
+ *  exception: CI re-runs take minutes, so the caller resolves it as soon as
+ *  the agent goes idle and lets the checks polling carry the story from there. */
+export function delegationResolved(
+  kind: GitDelegationKind,
+  git: GitState | null,
+  pr: PrState | null,
+  checks: PrChecks | null,
+): boolean {
+  switch (kind) {
+    case "commit":
+      return git != null && git.files.length === 0;
+    case "commit-pr":
+    case "open-pr":
+      return pr?.state === "open";
+    case "resolve":
+      return git != null && !git.files.some((f) => f.kind === "conflicted");
+    case "update-branch":
+      // `unknown` = GitHub still recomputing after a push — keep waiting.
+      if (checks) return !["behind", "dirty", "unknown"].includes(checks.merge_state);
+      return pr?.mergeable === true;
+    case "fix-checks":
+      return false;
+  }
+}

--- a/src/components/RightPanel/delegation.ts
+++ b/src/components/RightPanel/delegation.ts
@@ -6,6 +6,7 @@ import type { GitState, PrChecks, PrState } from "../../api";
  *  RPC (`git_commit` / `open_pr` / `git_update_branch` / `git_push`). */
 export type GitDelegationKind =
   | "commit"
+  | "commit-push"
   | "commit-pr"
   | "open-pr"
   | "resolve"
@@ -25,6 +26,7 @@ export interface GitDelegation {
 export function delegationLabel(kind: GitDelegationKind): string {
   switch (kind) {
     case "commit":        return "Agent is writing the commit message…";
+    case "commit-push":   return "Agent is committing & pushing…";
     case "commit-pr":     return "Agent is committing & opening a PR…";
     case "open-pr":       return "Agent is writing the PR description…";
     case "resolve":       return "Agent is resolving the conflicts…";
@@ -37,6 +39,7 @@ export function delegationLabel(kind: GitDelegationKind): string {
 export function delegationDone(kind: GitDelegationKind): string {
   switch (kind) {
     case "commit":        return "Agent committed your changes";
+    case "commit-push":   return "Committed & pushed";
     case "commit-pr":     return "Committed — PR is open";
     case "open-pr":       return "PR is open";
     case "resolve":       return "Conflicts resolved";
@@ -58,6 +61,8 @@ export function delegationResolved(
   switch (kind) {
     case "commit":
       return git != null && git.files.length === 0;
+    case "commit-push":
+      return git != null && git.files.length === 0 && git.unpushed === 0;
     case "commit-pr":
     case "open-pr":
       return pr?.state === "open";

--- a/src/components/RightPanel/delegation.ts
+++ b/src/components/RightPanel/delegation.ts
@@ -1,4 +1,4 @@
-import type { GitState, PrChecks, PrState } from "../../api";
+import type { AgentStatus, GitState, PrChecks, PrState } from "../../api";
 
 /** One agent-delegated git action: the user clicked a panel action whose
  *  judgment part (message, description, conflict edits) belongs to the
@@ -15,11 +15,47 @@ export type GitDelegationKind =
 
 export interface GitDelegation {
   kind: GitDelegationKind;
-  /** Epoch ms when the delegation was sent — grace window for status races. */
+  /** Epoch ms when the delegation entered the current phase: set at send,
+   *  reset on dequeue. The give-up grace window counts from here. */
   startedAt: number;
-  /** The agent has been observed `running` since `startedAt`. Until then an
-   *  `idle` status is the pre-send value, not a finished turn. */
+  /** OUR turn has been observed `running` since `startedAt`. Until then a
+   *  settled status is pre-send state, not a finished delegation turn. */
   sawRunning: boolean;
+  /** The agent was mid-turn when the trigger was sent, so it's queued behind
+   *  that turn. The foreign turn's running/settling must not arm or clear
+   *  this delegation — it's waited out first, then `queued` drops. */
+  queued: boolean;
+}
+
+/** How long a settled agent may sit without `sawRunning` before the
+ *  delegation reads as abandoned. Covers send→turn-start latency (and the
+ *  idle gap between a dequeued trigger and its turn actually starting). */
+export const DELEGATION_GIVE_UP_GRACE_MS = 15_000;
+
+/** What the lifecycle watcher should do for the current observation. Pure —
+ *  the panel effect maps each step to a store action:
+ *  - "resolve": the watched git/PR transition landed → clear + success notice
+ *  - "wait": nothing to do this pass
+ *  - "dequeue": the pre-existing turn settled → drop `queued`, reset the clock
+ *  - "mark-running": our turn started → set `sawRunning`
+ *  - "give-up": agent settled without the transition → clear + honest notice */
+export type DelegationStep = "resolve" | "wait" | "dequeue" | "mark-running" | "give-up";
+
+export function delegationStep(
+  delegation: GitDelegation,
+  status: AgentStatus,
+  resolved: boolean,
+  now: number,
+): DelegationStep {
+  if (resolved) return "resolve";
+  const active = status === "running" || status === "spawning";
+  // Queued behind a foreign turn: its activity is not ours to interpret.
+  if (delegation.queued) return active ? "wait" : "dequeue";
+  if (status === "running" && !delegation.sawRunning) return "mark-running";
+  const armed =
+    delegation.sawRunning || now - delegation.startedAt > DELEGATION_GIVE_UP_GRACE_MS;
+  if (!active && armed) return "give-up";
+  return "wait";
 }
 
 /** Marker prefix for app-sent action triggers. The full per-action playbooks

--- a/src/components/RightPanel/delegation.ts
+++ b/src/components/RightPanel/delegation.ts
@@ -22,6 +22,25 @@ export interface GitDelegation {
   sawRunning: boolean;
 }
 
+/** Marker prefix for app-sent action triggers. The full per-action playbooks
+ *  live in the agent's injected instructions (`instructions/git_actions.md`),
+ *  so the chat carries only this one-liner — which the transcript folds into
+ *  a compact chip instead of a user bubble. */
+export const APP_ACTION_PREFIX = "[app-action] ";
+
+/** Build the one-line trigger the app sends when a git action is clicked:
+ *  `[app-action] <name> key="value" …`. Params carry only the dynamic context
+ *  the static playbook can't know (base branch, failing check names); empty
+ *  values are dropped. */
+export function appActionMessage(name: string, params?: Record<string, string>): string {
+  const parts = [`${APP_ACTION_PREFIX}${name}`];
+  for (const [key, value] of Object.entries(params ?? {})) {
+    if (!value) continue;
+    parts.push(`${key}="${value.replaceAll('"', '\\"')}"`);
+  }
+  return parts.join(" ");
+}
+
 /** Footer status line while the agent holds control. */
 export function delegationLabel(kind: GitDelegationKind): string {
   switch (kind) {

--- a/src/components/RightPanel/primaryActions.test.ts
+++ b/src/components/RightPanel/primaryActions.test.ts
@@ -1,7 +1,60 @@
 import { describe, expect, it } from "vitest";
-import { primaryFor, secondaryFor } from "./primaryActions";
+import type { GitState, PrState } from "../../api";
+import { deriveState, primaryFor, secondaryFor } from "./primaryActions";
 
 const base = { prNumber: 7, base: "main" };
+
+function git(over: Partial<GitState> = {}): GitState {
+  return {
+    branch: "feat", parent_branch: "main", ahead: 1, behind: 0, unpushed: 0,
+    files: [], additions: 0, deletions: 0, ...over,
+  };
+}
+const file = (kind: GitState["files"][number]["kind"]) => ({
+  path: "a.ts", kind, staged: false, additions: 1, deletions: 0,
+});
+function pr(over: Partial<PrState> = {}): PrState {
+  return { number: 7, url: "https://x", state: "open", title: "t", mergeable: true, ...over };
+}
+
+describe("deriveState", () => {
+  it("uncommitted changes take precedence over an open PR", () => {
+    expect(deriveState(git({ files: [file("modified")] }), pr())).toBe("changes");
+    expect(deriveState(git(), pr())).toBe("pr-open");
+  });
+
+  it("conflicts and merged still take precedence over changes", () => {
+    expect(deriveState(git({ files: [file("conflicted")] }), pr())).toBe("conflicts");
+    expect(deriveState(git({ files: [file("modified")] }), pr({ state: "merged" }))).toBe("merged");
+  });
+});
+
+describe("changes-state sticky commit action", () => {
+  it("defaults to Commit & open PR", () => {
+    const p = primaryFor("changes", { files: 2 });
+    expect(p.key).toBe("agent-commit-pr");
+  });
+
+  it("honors the persisted selection", () => {
+    expect(primaryFor("changes", { files: 2, commitAction: "agent-commit" }).key).toBe("agent-commit");
+    expect(primaryFor("changes", { files: 2, commitAction: "agent-commit-push" }).key).toBe("agent-commit-push");
+  });
+
+  it("remaps Commit & open PR to Commit & push when a PR is already open", () => {
+    const p = primaryFor("changes", { files: 2, commitAction: "agent-commit-pr", prOpen: true });
+    expect(p.key).toBe("agent-commit-push");
+  });
+
+  it("menu offers the other commit modes, and Merge PR when a PR is open", () => {
+    const closedKeys = secondaryFor("changes", { files: 2 }).map((s) => s.key);
+    expect(closedKeys).toContain("agent-commit");
+    expect(closedKeys).toContain("agent-commit-push");
+    expect(closedKeys).not.toContain("merge");
+    const openKeys = secondaryFor("changes", { files: 2, prOpen: true }).map((s) => s.key);
+    expect(openKeys).toContain("merge");
+    expect(openKeys).not.toContain("agent-commit-pr"); // meaningless with a PR open
+  });
+});
 
 describe("pr-open primary by merge_state (§7)", () => {
   it("clean → green Merge PR", () => {
@@ -63,7 +116,9 @@ describe("pr-open secondary menu", () => {
     const keys = secondaryFor("pr-open", { ...base, mergeState: "behind" }).map((s) => s.key);
     expect(keys).toContain("merge");
     expect(keys).toContain("agent-update-branch");
-    expect(keys).toContain("view-pr");
+    // View on GitHub is a convenience link (a chip next to the status), not
+    // an action — it doesn't belong in the action menu.
+    expect(keys).not.toContain("view-pr");
   });
 
   it("offers agent-fix when checks are failing", () => {

--- a/src/components/RightPanel/primaryActions.test.ts
+++ b/src/components/RightPanel/primaryActions.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { primaryFor, secondaryFor } from "./primaryActions";
+
+const base = { prNumber: 7, base: "main" };
+
+describe("pr-open primary by merge_state (§7)", () => {
+  it("clean → green Merge PR", () => {
+    const p = primaryFor("pr-open", { ...base, mergeState: "clean" });
+    expect(p.key).toBe("merge");
+    expect(p.tone).toBe("success");
+    expect(p.statusKind).toBe("ready");
+    expect(p.statusLabel).toContain("ready to merge");
+  });
+
+  it("unstable → Merge PR enabled, warn status", () => {
+    const p = primaryFor("pr-open", { ...base, mergeState: "unstable", checksFailed: 1 });
+    expect(p.key).toBe("merge");
+    expect(p.tone).toBeUndefined();
+    expect(p.statusKind).toBe("warn");
+  });
+
+  it("blocked with failing checks → Fix with agent", () => {
+    const p = primaryFor("pr-open", { ...base, mergeState: "blocked", checksFailed: 2 });
+    expect(p.key).toBe("agent-fix");
+    expect(p.statusKind).toBe("attention");
+    expect(p.statusLabel).toContain("2 checks failing");
+  });
+
+  it("blocked with no failing checks → review gate, View on GitHub", () => {
+    const p = primaryFor("pr-open", { ...base, mergeState: "blocked", checksFailed: 0 });
+    expect(p.key).toBe("view-pr");
+    expect(p.statusLabel).toContain("review");
+  });
+
+  it("behind / dirty → Update branch with agent", () => {
+    for (const ms of ["behind", "dirty"] as const) {
+      const p = primaryFor("pr-open", { ...base, mergeState: ms });
+      expect(p.key).toBe("agent-update-branch");
+      expect(p.statusKind).toBe("attention");
+    }
+  });
+
+  it("unknown / has_hooks → Merge with checking status", () => {
+    for (const ms of ["unknown", "has_hooks"] as const) {
+      const p = primaryFor("pr-open", { ...base, mergeState: ms });
+      expect(p.key).toBe("merge");
+      expect(p.statusLabel).toContain("checking");
+    }
+  });
+
+  it("no checks data falls back to mergeable-only behavior", () => {
+    const ok = primaryFor("pr-open", { ...base, mergeable: true });
+    expect(ok.key).toBe("merge");
+    expect(ok.statusLabel).toContain("no conflicts");
+    const blocked = primaryFor("pr-open", { ...base, mergeable: false });
+    expect(blocked.key).toBe("merge");
+    expect(blocked.statusKind).toBe("attention");
+  });
+});
+
+describe("pr-open secondary menu", () => {
+  it("offers merge as an alternate and update-branch when behind", () => {
+    const keys = secondaryFor("pr-open", { ...base, mergeState: "behind" }).map((s) => s.key);
+    expect(keys).toContain("merge");
+    expect(keys).toContain("agent-update-branch");
+    expect(keys).toContain("view-pr");
+  });
+
+  it("offers agent-fix when checks are failing", () => {
+    const keys = secondaryFor("pr-open", { ...base, mergeState: "unstable", checksFailed: 1 }).map((s) => s.key);
+    expect(keys).toContain("agent-fix");
+  });
+
+  it("delegated open-pr is the pushed-state primary", () => {
+    expect(primaryFor("pushed", { ahead: 2 }).key).toBe("agent-open-pr");
+    const keys = secondaryFor("pushed", {}).map((s) => s.key);
+    expect(keys).toContain("open-pr"); // direct auto-fill alternate
+  });
+});

--- a/src/components/RightPanel/primaryActions.ts
+++ b/src/components/RightPanel/primaryActions.ts
@@ -1,3 +1,4 @@
+import type { MergeState } from "../../api";
 import type { IconName } from "../Icon";
 
 /** Derived git panel state — computed from live GitState, not stored. */
@@ -43,12 +44,27 @@ export interface ActionCounts {
   /** PR-open state: whether GitHub reports the PR cleanly mergeable. Gates the
    *  Merge CTA — when false the panel reads as "can't merge yet" (attention). */
   mergeable?: boolean;
+  /** PR-open state: GitHub's combined merge gate (spec §6). Null/omitted =
+   *  checks unavailable → fall back to `mergeable`-only behavior. */
+  mergeState?: MergeState | null;
+  /** Number of failing checks (drives copy + the agent-fix CTA). */
+  checksFailed?: number;
 }
 
 /** Maps a git panel state to the panel's primary call-to-action.
  *  Pass counts for dynamic status labels; falls back to generic copy. */
 export function primaryFor(state: GitPanelState, counts?: ActionCounts): PrimaryAction {
-  const { files = 0, ahead = 0, behind = 0, prNumber, base = "main", customActive = false, mergeable = false } = counts ?? {};
+  const {
+    files = 0,
+    ahead = 0,
+    behind = 0,
+    prNumber,
+    base = "main",
+    customActive = false,
+    mergeable = false,
+    mergeState = null,
+    checksFailed = 0,
+  } = counts ?? {};
   const prLabel = prNumber != null ? `PR #${prNumber}` : "PR";
 
   switch (state) {
@@ -69,34 +85,109 @@ export function primaryFor(state: GitPanelState, counts?: ActionCounts): Primary
         statusExtra: `${files} ${files === 1 ? "file" : "files"}`,
       };
     case "pushed":
+      // The PR description is the agent's job by default (it has the full
+      // context of the branch); the direct gh --fill PR stays in the menu.
       return {
-        key: "open-pr",
+        key: "agent-open-pr",
         label: "Open PR",
         icon: "pr",
         statusLabel: ahead === 1 ? "1 commit pushed, no PR yet" : `${ahead} commits pushed, no PR yet`,
         statusKind: "info",
       };
     case "pr-open":
-      // Merge is the goal here. GitHub's `mergeable` only reports the absence of
-      // merge conflicts — NOT CI/check status — so we claim no more than that:
-      // "no conflicts", a neutral accent CTA (no green "all clear" signal until
-      // real check state lands). When not mergeable the same Merge button reads
-      // as an attention state and is disabled by the panel until it clears.
-      return mergeable
-        ? {
+      // GitHub's combined merge gate (`merge_state`, spec §7) drives the
+      // sub-states. Without checks data (null → gh missing / API failure)
+      // fall back to the `mergeable`-only behavior.
+      switch (mergeState) {
+        case "clean":
+          return {
             key: "merge",
             label: "Merge PR",
             icon: "merge",
-            statusLabel: `${prLabel} · no conflicts`,
-            statusKind: "info",
-          }
-        : {
+            tone: "success",
+            statusLabel: `${prLabel} · ready to merge`,
+            statusKind: "ready",
+          };
+        case "unstable":
+          // Only NON-required checks failing — merging is allowed, but say so.
+          return {
             key: "merge",
             label: "Merge PR",
             icon: "merge",
-            statusLabel: `${prLabel} · can’t merge yet`,
+            statusLabel: `${prLabel} · optional checks failing`,
+            statusKind: "warn",
+          };
+        case "blocked":
+          // Failing required checks are agent-fixable; a pure review gate
+          // (nothing failing) is not — send the user to GitHub instead.
+          return checksFailed > 0
+            ? {
+                key: "agent-fix",
+                label: "Fix checks with agent",
+                icon: "wrench",
+                statusLabel: `${prLabel} · ${checksFailed} ${checksFailed === 1 ? "check" : "checks"} failing`,
+                statusKind: "attention",
+              }
+            : {
+                key: "view-pr",
+                label: "View on GitHub",
+                icon: "github",
+                statusLabel: `${prLabel} · review required`,
+                statusKind: "attention",
+              };
+        case "behind":
+          return {
+            key: "agent-update-branch",
+            label: "Update branch",
+            icon: "branch",
+            statusLabel: `${prLabel} · behind ${base}`,
             statusKind: "attention",
           };
+        case "dirty":
+          return {
+            key: "agent-update-branch",
+            label: "Update branch",
+            icon: "branch",
+            statusLabel: `${prLabel} · conflicts with ${base}`,
+            statusKind: "attention",
+          };
+        case "draft":
+          return {
+            key: "view-pr",
+            label: "View draft on GitHub",
+            icon: "github",
+            tone: "ghost",
+            statusLabel: `${prLabel} · draft`,
+            statusKind: "info",
+          };
+        case "unknown":
+        case "has_hooks":
+          return {
+            key: "merge",
+            label: "Merge PR",
+            icon: "merge",
+            statusLabel: `${prLabel} · checking…`,
+            statusKind: "info",
+          };
+        default:
+          // No checks data — `mergeable` only reports the absence of merge
+          // conflicts, NOT CI status, so claim no more than that.
+          return mergeable
+            ? {
+                key: "merge",
+                label: "Merge PR",
+                icon: "merge",
+                statusLabel: `${prLabel} · no conflicts`,
+                statusKind: "info",
+              }
+            : {
+                key: "merge",
+                label: "Merge PR",
+                icon: "merge",
+                statusLabel: `${prLabel} · can’t merge yet`,
+                statusKind: "attention",
+              };
+      }
     case "conflicts":
       // Fixable, not fatal — the agent can reconcile the conflict for you.
       return {
@@ -148,7 +239,15 @@ export function primaryFor(state: GitPanelState, counts?: ActionCounts): Primary
 }
 
 export function secondaryFor(state: GitPanelState, counts?: ActionCounts): SecondaryAction[] {
-  const { behind = 0, unpushed = 0, base = "main", customActive = false, mergeable = false } = counts ?? {};
+  const {
+    behind = 0,
+    unpushed = 0,
+    base = "main",
+    customActive = false,
+    mergeable = false,
+    mergeState = null,
+    checksFailed = 0,
+  } = counts ?? {};
   // "Push more commits" only makes sense when there's something unpushed.
   const pushItem: SecondaryAction[] =
     unpushed > 0 ? [{ key: "push", label: "Push more commits", icon: "push" }] : [];
@@ -173,22 +272,33 @@ export function secondaryFor(state: GitPanelState, counts?: ActionCounts): Secon
         { key: "discard", label: "Discard all", icon: "trash" },
       ];
     case "pushed":
-      // Primary is "Open PR"; the menu offers the alternates only.
+      // Primary is the agent-written PR; the direct gh --fill PR stays one
+      // click away for users who don't want to wait on the agent.
       return [
+        { key: "open-pr", label: "Open PR (auto-fill)", icon: "pr" },
         ...pushItem,
         { key: "pull", label: "Pull", icon: "inbox" },
       ];
-    case "pr-open":
-      // Primary is "Merge PR". Surface the PR link, and — when it can't merge
-      // yet (base advanced / conflicts with base) — an agent-delegated branch
-      // update (sync base → resolve → push), distinct from the local-merge
-      // "Resolve with agent" used in the conflicts state.
+    case "pr-open": {
+      // Candidates may include the state's primary — the panel filters that
+      // out, so every alternate stays reachable regardless of merge_state.
+      // "Update branch with agent" (sync base → resolve → push) is distinct
+      // from the local-merge "Resolve with agent" used in the conflicts state.
+      const needsUpdate =
+        mergeState === "behind" || mergeState === "dirty" || (mergeState == null && !mergeable);
       return [
         { key: "view-pr", label: "View on GitHub", icon: "github" },
-        ...(mergeable ? [] : [{ key: "agent-update-branch", label: "Update branch with agent", icon: "branch" as IconName }]),
+        { key: "merge", label: "Merge PR", icon: "merge" },
+        ...(needsUpdate
+          ? [{ key: "agent-update-branch", label: "Update branch with agent", icon: "branch" as IconName }]
+          : []),
+        ...(checksFailed > 0
+          ? [{ key: "agent-fix", label: "Fix checks with agent", icon: "wrench" as IconName }]
+          : []),
         ...pushItem,
         { key: "pull", label: "Pull", icon: "inbox" },
       ];
+    }
     case "conflicts":
       return [
         { key: "abort", label: "Abort merge", icon: "close" },

--- a/src/components/RightPanel/primaryActions.ts
+++ b/src/components/RightPanel/primaryActions.ts
@@ -1,8 +1,37 @@
-import type { MergeState } from "../../api";
+import type { GitState, MergeState, PrState } from "../../api";
 import type { IconName } from "../Icon";
 
 /** Derived git panel state — computed from live GitState, not stored. */
 export type GitPanelState = "clean" | "changes" | "pushed" | "conflicts" | "pr-open" | "pr-closed" | "merged" | "loading";
+
+/** Map live git + PR state to the panel state. Uncommitted changes outrank
+ *  an open PR — the user's in-flight work is the actionable thing; the PR
+ *  (and Merge) stays one click away in the menu and the status chip. */
+export function deriveState(git: GitState | null, pr: PrState | null): GitPanelState {
+  if (!git) return "loading";
+  if (git.files.some((f) => f.kind === "conflicted")) return "conflicts";
+  if (pr?.state === "merged") return "merged";
+  if (git.files.length > 0)  return "changes";
+  if (pr?.state === "open")   return "pr-open";
+  if (pr?.state === "closed") return "pr-closed";
+  if (git.ahead > 0)         return "pushed";
+  return "clean";
+}
+
+/** The changes-state delegated commit modes. The user's dropdown pick is
+ *  persisted globally (settings table) and becomes the default everywhere
+ *  until changed. */
+export type GitCommitAction = "agent-commit" | "agent-commit-push" | "agent-commit-pr";
+
+export const COMMIT_ACTIONS: readonly GitCommitAction[] = [
+  "agent-commit",
+  "agent-commit-push",
+  "agent-commit-pr",
+];
+
+export function isCommitAction(v: unknown): v is GitCommitAction {
+  return (COMMIT_ACTIONS as readonly unknown[]).includes(v);
+}
 
 /** Drives the status-dot color in the action bar. */
 export type StatusKind = "clean" | "warn" | "info" | "attention" | "ready" | "merged" | "alert";
@@ -49,6 +78,11 @@ export interface ActionCounts {
   mergeState?: MergeState | null;
   /** Number of failing checks (drives copy + the agent-fix CTA). */
   checksFailed?: number;
+  /** Changes state: the user's sticky commit mode (defaults to commit & PR). */
+  commitAction?: GitCommitAction;
+  /** Changes state: a PR is already open for this branch — "open PR" is
+   *  meaningless (push updates it) and Merge belongs in the menu. */
+  prOpen?: boolean;
 }
 
 /** Maps a git panel state to the panel's primary call-to-action.
@@ -64,26 +98,38 @@ export function primaryFor(state: GitPanelState, counts?: ActionCounts): Primary
     mergeable = false,
     mergeState = null,
     checksFailed = 0,
+    commitAction = "agent-commit-pr",
+    prOpen = false,
   } = counts ?? {};
   const prLabel = prNumber != null ? `PR #${prNumber}` : "PR";
 
   switch (state) {
     case "loading":
       return { key: "loading", label: "Loading…", icon: "refresh", statusLabel: "loading git state", statusKind: "info" };
-    case "changes":
+    case "changes": {
       // Override: user typed their own message → direct commit, agent bypassed.
       if (customActive) {
         return { key: "commit-direct", label: "Commit", icon: "commit", statusLabel: "Direct commit", statusKind: "ready" };
       }
-      // Default: delegate the whole thing to the agent.
-      return {
-        key: "agent-commit-pr",
-        label: "Commit & open PR",
-        icon: "pr",
+      // Default: delegate to the agent, in the user's sticky commit mode.
+      // With a PR already open, "open PR" degrades to "push" — that's what
+      // updates the existing PR.
+      const effective: GitCommitAction =
+        prOpen && commitAction === "agent-commit-pr" ? "agent-commit-push" : commitAction;
+      const common = {
         statusLabel: "Ready to commit",
-        statusKind: "warn",
+        statusKind: "warn" as StatusKind,
         statusExtra: `${files} ${files === 1 ? "file" : "files"}`,
       };
+      switch (effective) {
+        case "agent-commit":
+          return { key: "agent-commit", label: "Commit", icon: "commit", ...common };
+        case "agent-commit-push":
+          return { key: "agent-commit-push", label: "Commit & push", icon: "push", ...common };
+        default:
+          return { key: "agent-commit-pr", label: "Commit & open PR", icon: "pr", ...common };
+      }
+    }
     case "pushed":
       // The PR description is the agent's job by default (it has the full
       // context of the branch); the direct gh --fill PR stays in the menu.
@@ -247,6 +293,7 @@ export function secondaryFor(state: GitPanelState, counts?: ActionCounts): Secon
     mergeable = false,
     mergeState = null,
     checksFailed = 0,
+    prOpen = false,
   } = counts ?? {};
   // "Push more commits" only makes sense when there's something unpushed.
   const pushItem: SecondaryAction[] =
@@ -263,10 +310,15 @@ export function secondaryFor(state: GitPanelState, counts?: ActionCounts): Secon
           { key: "discard", label: "Discard all", icon: "trash" },
         ];
       }
-      // Default (agent) → primary is delegated "Commit & open PR"; offer a
-      // delegated "Commit only" as the alternate.
+      // Default (agent): every commit mode is a candidate — the panel drops
+      // whichever is the sticky primary. With a PR open, "open PR" is
+      // meaningless (push updates it) and Merge joins the menu.
       return [
-        { key: "agent-commit", label: "Commit only", icon: "commit", kbd: "⌘K" },
+        { key: "agent-commit", label: "Commit", icon: "commit", kbd: "⌘K" },
+        { key: "agent-commit-push", label: "Commit & push", icon: "push" },
+        ...(prOpen
+          ? [{ key: "merge", label: "Merge PR without changes", icon: "merge" as IconName }]
+          : [{ key: "agent-commit-pr", label: "Commit & open PR", icon: "pr" as IconName }]),
         { key: "push", label: "Push only", icon: "push" },
         { key: "stash", label: "Stash changes", icon: "inbox" },
         { key: "discard", label: "Discard all", icon: "trash" },
@@ -284,10 +336,11 @@ export function secondaryFor(state: GitPanelState, counts?: ActionCounts): Secon
       // out, so every alternate stays reachable regardless of merge_state.
       // "Update branch with agent" (sync base → resolve → push) is distinct
       // from the local-merge "Resolve with agent" used in the conflicts state.
+      // "View on GitHub" is deliberately absent: it's a convenience link,
+      // rendered as a chip next to the status text, not an action.
       const needsUpdate =
         mergeState === "behind" || mergeState === "dirty" || (mergeState == null && !mergeable);
       return [
-        { key: "view-pr", label: "View on GitHub", icon: "github" },
         { key: "merge", label: "Merge PR", icon: "merge" },
         ...(needsUpdate
           ? [{ key: "agent-update-branch", label: "Update branch with agent", icon: "branch" as IconName }]

--- a/src/components/Workspace/messages/MessageItem.tsx
+++ b/src/components/Workspace/messages/MessageItem.tsx
@@ -6,12 +6,24 @@ import { ToolRow } from "./ToolRow";
 import { getPresenter } from "./presenters";
 import { AttachmentList } from "../../Composer/AttachmentList";
 import { stripInjectedInstructions } from "../../../util/instructions";
+import { APP_ACTION_PREFIX } from "../../RightPanel/delegation";
 
 /** Dispatcher for one rendered row. Accepts either a raw ChatItem or
  *  the derived `tool_pair` from pairToolItems(). */
 export function MessageItem({ item }: { item: ViewItem }) {
   switch (item.kind) {
     case "user_message":
+      // App-sent git-action triggers fold into a quiet chip (like slash
+      // commands) instead of a user bubble — one rendering rule covers both
+      // the live optimistic entry and history rebuilt from session records.
+      if (item.text.startsWith(APP_ACTION_PREFIX)) {
+        return (
+          <div className="m-reasoning" style={{ fontStyle: "italic" }}>
+            <div className="label">git action</div>
+            <code>{item.text.slice(APP_ACTION_PREFIX.length)}</code>
+          </div>
+        );
+      }
       return (
         <div className="m-user">
           {stripInjectedInstructions(item.text)}

--- a/src/store.ts
+++ b/src/store.ts
@@ -27,6 +27,10 @@ import type {
   GitDelegation,
   GitDelegationKind,
 } from "./components/RightPanel/delegation";
+import {
+  isCommitAction,
+  type GitCommitAction,
+} from "./components/RightPanel/primaryActions";
 import { commandsFor } from "./data/slashCommands";
 import { getAdapter, type ChatItem, type RawEvent } from "./adapters";
 import { getAllSettings, setSetting } from "./storage/settings";
@@ -247,6 +251,10 @@ interface AppState {
   delegateGitAction: (agentId: string, kind: GitDelegationKind, prompt: string) => void;
   markGitDelegationRunning: (agentId: string) => void;
   clearGitDelegation: (agentId: string) => void;
+  /** Sticky changes-state commit mode (Commit / & push / & open PR). Global
+   *  across workspaces, persisted in settings until the user picks another. */
+  gitCommitAction: GitCommitAction;
+  setGitCommitAction: (action: GitCommitAction) => void;
   /** Resolves to "up-to-date" | "pushed" on success, null on error. */
   pushAgent: (agentId: string) => Promise<string | null>;
   /** Resolves true on success, false on error. */
@@ -625,6 +633,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   prStates: {},
   prChecks: {},
   gitDelegations: {},
+  gitCommitAction: "agent-commit-pr" as GitCommitAction,
 
   drafts: [],
   activeDraftId: null,
@@ -668,6 +677,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         features: parseFeatures(s.features),
         providerFlags: parseProviderFlags(s.providers),
         viewMode: (s.viewMode as WorkspaceView) || "custom",
+        gitCommitAction: isCommitAction(s.gitCommitAction) ? s.gitCommitAction : "agent-commit-pr",
         onboardingComplete: s.onboardingComplete === "true",
         // Auto-open the welcome tour for new users (no completion flag yet).
         onboardingOpen: s.onboardingComplete !== "true",
@@ -1245,6 +1255,11 @@ export const useAppStore = create<AppState>((set, get) => ({
       const { [agentId]: _dropped, ...rest } = s.gitDelegations;
       return { gitDelegations: rest };
     });
+  },
+
+  setGitCommitAction: (action) => {
+    set({ gitCommitAction: action });
+    void setSetting("gitCommitAction", action);
   },
 
   pushAgent: async (agentId) => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1350,7 +1350,11 @@ export const useAppStore = create<AppState>((set, get) => ({
   mergePr: async (agentId) => {
     try {
       await api.mergePr(agentId);
-      // pr:state_changed event will update prStates
+      // Refresh immediately: no backend event fires on merge, and the panel
+      // should transition to the merged state as soon as GitHub reports it
+      // (with --auto + pending checks the PR can legitimately stay open).
+      await get().fetchPrState(agentId);
+      await get().fetchPrChecks(agentId);
     } catch (e) {
       set({ lastError: String(e) });
     }

--- a/src/store.ts
+++ b/src/store.ts
@@ -15,6 +15,7 @@ import {
   type AgentRecord,
   type AgentView,
   type GitState,
+  type PrChecks,
   type PrState,
   type SessionRecord,
   type ShortStats,
@@ -22,6 +23,10 @@ import {
   type Workspace,
 } from "./api";
 import { DEFAULT_PROVIDER_ID } from "./data/providers";
+import type {
+  GitDelegation,
+  GitDelegationKind,
+} from "./components/RightPanel/delegation";
 import { commandsFor } from "./data/slashCommands";
 import { getAdapter, type ChatItem, type RawEvent } from "./adapters";
 import { getAllSettings, setSetting } from "./storage/settings";
@@ -231,6 +236,17 @@ interface AppState {
   /** PR state per agent, keyed by agent_id. Updated by the pr:state_changed watcher event. */
   prStates: Record<string, PrState | null>;
   fetchPrState: (agentId: string) => Promise<void>;
+  /** Rich PR merge-gate + checks per agent. Absent key = not yet fetched;
+   *  `null` = confirmed unavailable (no PR / gh failure). */
+  prChecks: Record<string, PrChecks | null>;
+  fetchPrChecks: (agentId: string) => Promise<void>;
+  /** Active agent-delegated git action per agent (absent = none). Set when a
+   *  panel action hands control to the agent; cleared by the panel when the
+   *  watched git/PR transition lands or the agent gives up. */
+  gitDelegations: Record<string, GitDelegation>;
+  delegateGitAction: (agentId: string, kind: GitDelegationKind, prompt: string) => void;
+  markGitDelegationRunning: (agentId: string) => void;
+  clearGitDelegation: (agentId: string) => void;
   /** Resolves to "up-to-date" | "pushed" on success, null on error. */
   pushAgent: (agentId: string) => Promise<string | null>;
   /** Resolves true on success, false on error. */
@@ -607,6 +623,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   gitStates: {},
   gitShortstats: {},
   prStates: {},
+  prChecks: {},
+  gitDelegations: {},
 
   drafts: [],
   activeDraftId: null,
@@ -1031,6 +1049,8 @@ export const useAppStore = create<AppState>((set, get) => ({
         const { [id]: _droppedGitState, ...restGitStates } = s.gitStates;
         const { [id]: _droppedShortstats, ...restShortstats } = s.gitShortstats;
         const { [id]: _droppedPrState, ...restPrStates } = s.prStates;
+        const { [id]: _droppedChecks, ...restPrChecks } = s.prChecks;
+        const { [id]: _droppedDelegation, ...restDelegations } = s.gitDelegations;
         return {
           workspace: fresh,
           selectedAgentId: s.selectedAgentId === id ? null : s.selectedAgentId,
@@ -1042,6 +1062,8 @@ export const useAppStore = create<AppState>((set, get) => ({
           gitStates: restGitStates,
           gitShortstats: restShortstats,
           prStates: restPrStates,
+          prChecks: restPrChecks,
+          gitDelegations: restDelegations,
         };
       });
     } catch (e) {
@@ -1065,6 +1087,8 @@ export const useAppStore = create<AppState>((set, get) => ({
         const { [id]: _g, ...restGitStates } = s.gitStates;
         const { [id]: _s, ...restShortstats } = s.gitShortstats;
         const { [id]: _p, ...restPrStates } = s.prStates;
+        const { [id]: _c, ...restPrChecks } = s.prChecks;
+        const { [id]: _d, ...restDelegations } = s.gitDelegations;
         return {
           workspace: fresh ?? s.workspace,
           selectedAgentId: s.selectedAgentId === id ? null : s.selectedAgentId,
@@ -1076,6 +1100,8 @@ export const useAppStore = create<AppState>((set, get) => ({
           gitStates: restGitStates,
           gitShortstats: restShortstats,
           prStates: restPrStates,
+          prChecks: restPrChecks,
+          gitDelegations: restDelegations,
         };
       });
     } catch (e) {
@@ -1173,6 +1199,44 @@ export const useAppStore = create<AppState>((set, get) => ({
     } catch {
       // non-fatal
     }
+  },
+
+  fetchPrChecks: async (agentId) => {
+    try {
+      const checks = await api.getPrChecks(agentId);
+      // Write nulls too: null = "confirmed unavailable", distinct from the
+      // absent key ("not yet fetched") that renders as the checking… state.
+      set((s) => ({ prChecks: { ...s.prChecks, [agentId]: checks } }));
+    } catch {
+      // non-fatal — next poll tick will retry
+    }
+  },
+
+  delegateGitAction: (agentId, kind, prompt) => {
+    set((s) => ({
+      gitDelegations: {
+        ...s.gitDelegations,
+        [agentId]: { kind, startedAt: Date.now(), sawRunning: false },
+      },
+    }));
+    void get().sendUserMessage(agentId, prompt);
+  },
+
+  markGitDelegationRunning: (agentId) => {
+    set((s) => {
+      const d = s.gitDelegations[agentId];
+      if (!d || d.sawRunning) return s;
+      return {
+        gitDelegations: { ...s.gitDelegations, [agentId]: { ...d, sawRunning: true } },
+      };
+    });
+  },
+
+  clearGitDelegation: (agentId) => {
+    set((s) => {
+      const { [agentId]: _dropped, ...rest } = s.gitDelegations;
+      return { gitDelegations: rest };
+    });
   },
 
   pushAgent: async (agentId) => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1208,7 +1208,15 @@ export const useAppStore = create<AppState>((set, get) => ({
       // absent key ("not yet fetched") that renders as the checking… state.
       set((s) => ({ prChecks: { ...s.prChecks, [agentId]: checks } }));
     } catch {
-      // non-fatal — next poll tick will retry
+      // Non-fatal — the next poll tick retries. But a *first* fetch that
+      // throws would otherwise leave the key absent and pin the panel's
+      // "checking…" placeholder, so degrade it to null (mergeable-only
+      // fallback). A later transient error keeps the last good value.
+      set((s) =>
+        agentId in s.prChecks
+          ? {}
+          : { prChecks: { ...s.prChecks, [agentId]: null } },
+      );
     }
   },
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -250,6 +250,9 @@ interface AppState {
   gitDelegations: Record<string, GitDelegation>;
   delegateGitAction: (agentId: string, kind: GitDelegationKind, prompt: string) => void;
   markGitDelegationRunning: (agentId: string) => void;
+  /** The pre-existing turn the delegation was queued behind has settled —
+   *  drop `queued` and restart the give-up clock for our own turn. */
+  markGitDelegationDequeued: (agentId: string) => void;
   clearGitDelegation: (agentId: string) => void;
   /** Sticky changes-state commit mode (Commit / & push / & open PR). Global
    *  across workspaces, persisted in settings until the user picks another. */
@@ -1231,10 +1234,14 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 
   delegateGitAction: (agentId, kind, prompt) => {
+    // Sent mid-turn? Then our trigger is queued behind the in-flight turn,
+    // and that turn's running/settling must not be read as ours.
+    const status = get().workspace?.agents.find((a) => a.id === agentId)?.status;
+    const queued = status === "running";
     set((s) => ({
       gitDelegations: {
         ...s.gitDelegations,
-        [agentId]: { kind, startedAt: Date.now(), sawRunning: false },
+        [agentId]: { kind, startedAt: Date.now(), sawRunning: false, queued },
       },
     }));
     void get().sendUserMessage(agentId, prompt);
@@ -1246,6 +1253,19 @@ export const useAppStore = create<AppState>((set, get) => ({
       if (!d || d.sawRunning) return s;
       return {
         gitDelegations: { ...s.gitDelegations, [agentId]: { ...d, sawRunning: true } },
+      };
+    });
+  },
+
+  markGitDelegationDequeued: (agentId) => {
+    set((s) => {
+      const d = s.gitDelegations[agentId];
+      if (!d || !d.queued) return s;
+      return {
+        gitDelegations: {
+          ...s.gitDelegations,
+          [agentId]: { ...d, queued: false, startedAt: Date.now() },
+        },
       };
     });
   },


### PR DESCRIPTION
## Summary
Git-panel actions now hand control to the coding agent where its judgment is needed — commit messages, PR descriptions, conflict resolution, branch updates, check fixes — and the agent executes the mutation through the file-mailbox RPC (new allowlisted ops `git_push` and `git_update_branch` alongside the existing `git_commit`/`open_pr`), while mechanical actions (push/pull/rebase/merge) keep running directly in the app. Delegations are tracked in the store with a live "agent is working" status in the panel, resolved by watching the git/PR state for the completing transition, with an honest hand-back notice if the agent finishes without it. A new `get_pr_checks` command (one `gh pr view --json mergeStateStatus,statusCheckRollup` call, spec §6) drives the §7 pr-open sub-states: green "ready to merge" only on `clean`, `blocked` → "Fix checks with agent", `behind`/`dirty` → "Update branch", merge gated on `clean`/`unstable`, plus a per-check list in the PR card — degrading to the previous `mergeable`-only behavior when checks are unavailable. Covered by new Rust tests (RPC ops, checks normalization) and vitest suites (delegation resolution, §7 action mapping); merge now also refreshes PR state immediately so the panel transitions promptly.

## Test Plan
- [ ] `cargo test` (245 passing) and `bun run check && bun run test` (162 passing)
- [ ] Changes state: "Commit & open PR" → agent status shown → PR appears → checks render → merge on clean
- [ ] Conflicts: "Resolve with agent" completes the merge via `git_commit`; behind/dirty PR: "Update branch" syncs base via `git_update_branch` + `git_push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)