### PR TITLE
ci: auto-generate release notes when publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,9 @@ jobs:
           TAG="v$(jq -r .version src-tauri/tauri.conf.json)"
           NOTES=$(gh api "repos/${{ github.repository }}/releases/generate-notes" \
             -f tag_name="$TAG" --jq .body)
-          gh release edit "$TAG" --notes "$NOTES"
+          if [ -n "$NOTES" ] && [ "$NOTES" != "null" ]; then
+            gh release edit "$TAG" --notes "$NOTES"
+          fi
 
       # Kick off a Cloudflare Workers Builds deploy of the marketing site
       # (fwdai/quorum-web) so it rebuilds against the freshly published release.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,18 @@ jobs:
           tauriScript: bun run tauri
           args: --target universal-apple-darwin
 
+      # Replace the placeholder release body with GitHub's auto-generated
+      # release notes (the same "What's Changed" list the UI button produces),
+      # built from PRs/commits since the previous release.
+      - name: Generate release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v$(jq -r .version src-tauri/tauri.conf.json)"
+          NOTES=$(gh api "repos/${{ github.repository }}/releases/generate-notes" \
+            -f tag_name="$TAG" --jq .body)
+          gh release edit "$TAG" --notes "$NOTES"
+
       # Kick off a Cloudflare Workers Builds deploy of the marketing site
       # (fwdai/quorum-web) so it rebuilds against the freshly published release.
       # WEB_DEPLOY_HOOK is the deploy-hook URL from the Worker's Settings > Builds.


### PR DESCRIPTION
## Problem

Published releases have no release notes — the body is hardcoded to a placeholder in `release.yml`:

```yaml
releaseBody: See the assets to download and install this version.
```

`tauri-apps/tauri-action` creates the release itself and just writes that static string. The "Generate release notes" button in the GitHub UI is a separate feature (the `POST /releases/generate-notes` API), which tauri-action doesn't expose, so it never runs.

## Change

Adds a follow-up step after the build/publish step that calls the same generate-notes API the UI button uses and writes the result onto the just-published release:

```yaml
- name: Generate release notes
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  run: |
    TAG="v$(jq -r .version src-tauri/tauri.conf.json)"
    NOTES=$(gh api "repos/${{ github.repository }}/releases/generate-notes" \
      -f tag_name="$TAG" --jq .body)
    gh release edit "$TAG" --notes "$NOTES"
```

The tag is resolved from `tauri.conf.json` (same source of truth as the build), and GitHub auto-detects the previous release to diff against.

## Notes

- The in-app auto-updater reads `latest.json`, not the release body, so rewriting the body afterward is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)