### PR TITLE
Add @ file-mention autocomplete to the composer

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -643,6 +643,23 @@ pub async fn get_all_shortstats(
 /// the UI shows a "no preview" notice instead of choking the editor.
 const MAX_FILE_BYTES: u64 = 2 * 1024 * 1024;
 
+/// One entry in an arbitrary directory listing (for the composer's `@`
+/// file-mention autocomplete when the user types a filesystem path).
+#[derive(Serialize)]
+pub struct DirEntry {
+    pub name: String,
+    pub is_dir: bool,
+}
+
+/// A directory listing plus the absolute path that was listed, so the
+/// caller can build absolute attachment paths from entry names.
+#[derive(Serialize)]
+pub struct DirListing {
+    /// Absolute, tilde-expanded directory that was read.
+    pub base: String,
+    pub entries: Vec<DirEntry>,
+}
+
 /// One entry in the worktree file list. Directories are derived on the
 /// frontend from the path segments; only files are sent over IPC.
 #[derive(Serialize)]
@@ -763,6 +780,43 @@ pub async fn list_worktree_tree(
             }
         })
         .collect())
+}
+
+/// Expand a leading `~` (or `~/…`) to the user's home directory. Any other
+/// path is returned unchanged. Used to resolve filesystem paths the user
+/// types into the composer's `@` mention.
+fn expand_tilde(path: &str) -> PathBuf {
+    if let Some(rest) = path.strip_prefix('~') {
+        if rest.is_empty() || rest.starts_with('/') {
+            if let Some(home) = dirs::home_dir() {
+                return home.join(rest.strip_prefix('/').unwrap_or(rest));
+            }
+        }
+    }
+    PathBuf::from(path)
+}
+
+/// List the entries of an arbitrary directory for the composer's `@`
+/// mention autocomplete (e.g. `@~/Downloads/`). The path may start with
+/// `~`; the resolved absolute directory comes back as `base` so the caller
+/// can attach files by absolute path.
+#[tauri::command]
+pub async fn list_dir(path: String) -> Result<DirListing> {
+    let dir = expand_tilde(&path);
+    let read = std::fs::read_dir(&dir)
+        .map_err(|e| Error::Other(format!("read_dir {}: {e}", dir.display())))?;
+
+    let mut entries = Vec::new();
+    for entry in read.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+        entries.push(DirEntry { name, is_dir });
+    }
+
+    Ok(DirListing {
+        base: dir.to_string_lossy().to_string(),
+        entries,
+    })
 }
 
 /// Read a worktree file for the viewer/editor: contents, language hint,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -802,12 +802,18 @@ fn expand_tilde(path: &str) -> PathBuf {
 /// can attach files by absolute path.
 #[tauri::command]
 pub async fn list_dir(path: String) -> Result<DirListing> {
+    // Stop reading well above what the picker shows (the frontend filters and
+    // caps display at 10) so a huge directory like /usr/lib or node_modules
+    // can't stall the read or bloat the IPC payload. Hidden entries are kept
+    // so typing a leading "." can still reveal dotfiles.
+    const MAX_ENTRIES: usize = 1000;
+
     let dir = expand_tilde(&path);
     let read = std::fs::read_dir(&dir)
         .map_err(|e| Error::Other(format!("read_dir {}: {e}", dir.display())))?;
 
     let mut entries = Vec::new();
-    for entry in read.flatten() {
+    for entry in read.flatten().take(MAX_ENTRIES) {
         let name = entry.file_name().to_string_lossy().to_string();
         let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
         entries.push(DirEntry { name, is_dir });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -198,6 +198,7 @@ pub fn run() {
             commands::run_state,
             commands::detect_run_config,
             commands::list_worktree_tree,
+            commands::list_dir,
             commands::read_worktree_file,
             commands::get_file_diff,
             commands::write_worktree_file,

--- a/src/api.ts
+++ b/src/api.ts
@@ -162,6 +162,20 @@ export interface WorktreeFile {
   deletions: number;
 }
 
+/** One entry in an arbitrary directory listing, used by the composer's `@`
+ *  file-mention autocomplete when the user types a filesystem path. */
+export interface DirEntry {
+  name: string;
+  is_dir: boolean;
+}
+
+/** A directory listing plus the absolute (tilde-expanded) path that was
+ *  read, returned by `list_dir`. */
+export interface DirListing {
+  base: string;
+  entries: DirEntry[];
+}
+
 /** A worktree file's contents plus the metadata the File-panel editor
  *  needs. `chg_add` / `chg_mod` are 1-indexed line numbers the agent
  *  added / modified (drives the change gutter). */
@@ -402,6 +416,7 @@ export const api = {
     invoke<DetectedConfig[]>("detect_run_config", { agentId }),
   listWorktreeTree: (agentId: string) =>
     invoke<WorktreeFile[]>("list_worktree_tree", { agentId }),
+  listDir: (path: string) => invoke<DirListing>("list_dir", { path }),
   readWorktreeFile: (agentId: string, path: string) =>
     invoke<WorktreeFileContents>("read_worktree_file", { agentId, path }),
   getFileDiff: (agentId: string, path: string) =>

--- a/src/app.css
+++ b/src/app.css
@@ -829,6 +829,22 @@ button { cursor: default; }
 }
 .slash-item.active { background: var(--hover); color: var(--fg-0); }
 .slash-item.active .slash-desc { color: var(--fg-1); }
+.mention-item { gap: 8px; align-items: center; }
+.mention-item .mention-name {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-0);
+  flex-shrink: 0;
+}
+.mention-item .mention-dir {
+  flex: 1; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  direction: rtl; text-align: left;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--fg-3);
+}
+.mention-item.active { background: var(--hover); color: var(--fg-0); }
 .composer:focus-within {
   border-color: color-mix(in oklch, var(--accent), transparent 50%);
   box-shadow: var(--shadow-2), 0 0 0 4px color-mix(in oklch, var(--accent), transparent 88%);

--- a/src/components/Composer/MentionMenu.tsx
+++ b/src/components/Composer/MentionMenu.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from "react";
+import { FileIcon } from "../RightPanel/FileIcon";
+
+/** One row in the mention menu. `detail` is muted secondary text (e.g. the
+ *  containing folder for a worktree file); `isDir` selects a folder icon and
+ *  shows a trailing slash. */
+export interface MentionRow {
+  name: string;
+  detail?: string;
+  isDir: boolean;
+}
+
+interface Props {
+  items: MentionRow[];
+  highlight: number;
+  onPick: (i: number) => void;
+  onHighlight: (i: number) => void;
+}
+
+export function MentionMenu({ items, highlight, onPick, onHighlight }: Props) {
+  const activeRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    activeRef.current?.scrollIntoView({ block: "nearest" });
+  }, [highlight]);
+
+  if (items.length === 0) return null;
+
+  return (
+    <div
+      className="dd slash-menu mention-menu"
+      style={{ bottom: "calc(100% + 6px)", left: 0, right: 0 }}
+      role="listbox"
+    >
+      <div className="dd-sect">Attach file</div>
+      {items.map((item, i) => (
+        <div
+          key={`${item.name}-${i}`}
+          ref={i === highlight ? activeRef : undefined}
+          className={`dd-item mention-item ${i === highlight ? "active" : ""}`}
+          role="option"
+          aria-selected={i === highlight}
+          onMouseDown={(e) => {
+            e.preventDefault();
+            onPick(i);
+          }}
+          onMouseEnter={() => onHighlight(i)}
+        >
+          <FileIcon name={item.name} folder={item.isDir} open={false} />
+          <span className="mention-name">
+            {item.name}
+            {item.isDir && "/"}
+          </span>
+          {item.detail && <span className="mention-dir">{item.detail}</span>}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -10,8 +10,18 @@ import { Chip } from "../ui/Chip";
 import { ModelPicker } from "./ModelPicker";
 import { BranchPicker } from "./BranchPicker";
 import { SlashMenu } from "./SlashMenu";
+import { MentionMenu } from "./MentionMenu";
 import { AttachmentList } from "./AttachmentList";
 import { useFileDrop } from "./useFileDrop";
+import type { DirListing } from "../../api";
+import {
+  filterDirEntries,
+  filterFiles,
+  isFsPath,
+  joinTypedDir,
+  mentionQueryAt,
+  splitFsPath,
+} from "./mentions";
 
 interface Props {
   /** Initial provider id — defaults to claude. */
@@ -42,6 +52,15 @@ interface Props {
    *  `action` identifier comes from the `SlashCommand` entry. The text
    *  is NOT sent to the agent; the parent decides what to do. */
   onLocalCommand?: (action: string) => void;
+  /** Supplies candidate worktree-relative file paths for the "@" mention
+   *  autocomplete. Called each time a mention opens, so the list stays fresh
+   *  as the agent edits files. Omit it (e.g. new sessions with no worktree
+   *  yet) to disable "@" mentions; drag-drop / browse attach still work. */
+  mentionSource?: () => Promise<string[]>;
+  /** Lists an arbitrary directory so "@" can complete filesystem paths the
+   *  user types (e.g. `@~/Downloads/`), attaching files outside the worktree
+   *  by absolute path. Omit to restrict "@" to worktree files. */
+  listDir?: (path: string) => Promise<DirListing>;
   /** True when rendered for an existing agent (ChatView) rather than a new
    *  session (EmptyWorkspace). A provider whose effort is set at spawn
    *  (`effortAtSpawn`, e.g. claude) shows a read-only badge here instead of
@@ -78,6 +97,8 @@ export function Composer({
   onSend,
   onStop,
   onLocalCommand,
+  mentionSource,
+  listDir,
   existingSession = false,
   initialThinking,
   activeModel,
@@ -101,6 +122,20 @@ export function Composer({
   }, [provider]);
   const [slashDismissed, setSlashDismissed] = useState(false);
   const [slashIndex, setSlashIndex] = useState(0);
+  // Caret offset, tracked so the "@" mention can be detected at the cursor
+  // rather than only at the start of the text (unlike slash commands).
+  const [caret, setCaret] = useState(0);
+  const [mentionFiles, setMentionFiles] = useState<string[]>([]);
+  const [mentionIndex, setMentionIndex] = useState(0);
+  const [mentionDismissed, setMentionDismissed] = useState(false);
+  // Cached listing for the directory the user is currently typing a path
+  // into. `reqDir` is the typed dir it answers, so a stale in-flight result
+  // for a different dir isn't shown.
+  const [fsListing, setFsListing] = useState<{
+    reqDir: string;
+    base: string;
+    entries: DirListing["entries"];
+  } | null>(null);
   const ta = useRef<HTMLTextAreaElement>(null);
 
   function addPaths(paths: string[]) {
@@ -132,6 +167,109 @@ export function Composer({
   useEffect(() => {
     setSlashIndex(0);
   }, [slashQuery, provider]);
+
+  // "@" mention: active when the caret sits in an "@token" and a source is
+  // wired (and the slash menu isn't already claiming the input).
+  const mention =
+    (mentionSource || listDir) && !slashOpen && !mentionDismissed
+      ? mentionQueryAt(text, caret)
+      : null;
+  // A "~/…" or "/…" style query completes real filesystem paths via listDir;
+  // anything else searches the agent's worktree files.
+  const fs =
+    mention && listDir && isFsPath(mention.query)
+      ? splitFsPath(mention.query)
+      : null;
+
+  // What picking a row does: attach a file (worktree-relative or absolute),
+  // or drill into a directory by rewriting the typed "@query".
+  type MentionAction =
+    | { kind: "attach"; path: string }
+    | { kind: "navigate"; query: string };
+
+  const { rows, actions } = useMemo<{
+    rows: { name: string; detail?: string; isDir: boolean }[];
+    actions: MentionAction[];
+  }>(() => {
+    if (!mention) return { rows: [], actions: [] };
+    if (fs) {
+      if (!fsListing || fsListing.reqDir !== fs.dir) return { rows: [], actions: [] };
+      const base = fsListing.base;
+      const matched = filterDirEntries(fsListing.entries, fs.partial);
+      return {
+        rows: matched.map((e) => ({ name: e.name, isDir: e.is_dir })),
+        actions: matched.map((e) =>
+          e.is_dir
+            ? { kind: "navigate", query: joinTypedDir(fs.dir, e.name) }
+            : {
+                kind: "attach",
+                path: base.endsWith("/") ? base + e.name : `${base}/${e.name}`,
+              },
+        ),
+      };
+    }
+    if (!mentionSource) return { rows: [], actions: [] };
+    const matched = filterFiles(mentionFiles, mention.query);
+    return {
+      rows: matched.map((p) => {
+        const i = p.lastIndexOf("/");
+        return {
+          name: i === -1 ? p : p.slice(i + 1),
+          detail: i === -1 ? undefined : p.slice(0, i + 1),
+          isDir: false,
+        };
+      }),
+      actions: matched.map((p) => ({ kind: "attach", path: p })),
+    };
+    // `mention`/`fs` objects recreate each render; depend on their fields.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mention?.query, fs?.dir, fs?.partial, fsListing, mentionFiles, mentionSource]);
+
+  const mentionOpen = rows.length > 0;
+
+  useEffect(() => {
+    setMentionIndex(0);
+  }, [mention?.query]);
+
+  // Worktree-file mode: refetch the list each time the mention opens (held in
+  // a ref so an inline `mentionSource` prop doesn't refire the effect).
+  const worktreeActive = mention !== null && !fs && !!mentionSource;
+  const mentionSrcRef = useRef(mentionSource);
+  mentionSrcRef.current = mentionSource;
+  useEffect(() => {
+    if (!worktreeActive || !mentionSrcRef.current) return;
+    let alive = true;
+    mentionSrcRef
+      .current()
+      .then((files) => {
+        if (alive) setMentionFiles(files);
+      })
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, [worktreeActive]);
+
+  // Filesystem mode: re-list only when the typed directory changes, not on
+  // every keystroke within the same directory.
+  const fsDir = fs?.dir ?? null;
+  const listDirRef = useRef(listDir);
+  listDirRef.current = listDir;
+  useEffect(() => {
+    if (fsDir === null || !listDirRef.current) return;
+    let alive = true;
+    listDirRef
+      .current(fsDir)
+      .then((res) => {
+        if (alive) setFsListing({ reqDir: fsDir, base: res.base, entries: res.entries });
+      })
+      .catch(() => {
+        if (alive) setFsListing(null);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [fsDir]);
 
   useEffect(() => {
     if (autoFocus) ta.current?.focus();
@@ -180,6 +318,39 @@ export function Composer({
     });
   }
 
+  function placeCaret(pos: number) {
+    requestAnimationFrame(() => {
+      const el = ta.current;
+      if (!el) return;
+      el.focus();
+      el.setSelectionRange(pos, pos);
+      grow(el);
+    });
+  }
+
+  function pickMention(i: number) {
+    const action = actions[i];
+    if (!action || !mention) return;
+    if (action.kind === "attach") {
+      addPaths([action.path]);
+      // Splice out the "@query" span; the file lives in the attachment chips,
+      // so it never pollutes the typed prose.
+      const next = text.slice(0, mention.start) + text.slice(caret);
+      setText(next);
+      setCaret(mention.start);
+      placeCaret(mention.start);
+    } else {
+      // Drill into the directory: rewrite the "@query" to the chosen path so
+      // the next keystroke (or selection) continues from inside it.
+      const inserted = `@${action.query}`;
+      const next = text.slice(0, mention.start) + inserted + text.slice(caret);
+      const pos = mention.start + inserted.length;
+      setText(next);
+      setCaret(pos);
+      placeCaret(pos);
+    }
+  }
+
   const sendDisabled = stopping
     ? !onStop
     : disabled || (!text.trim() && attachments.length === 0);
@@ -200,6 +371,14 @@ export function Composer({
           onHighlight={setSlashIndex}
         />
       )}
+      {mentionOpen && (
+        <MentionMenu
+          items={rows}
+          highlight={mentionIndex}
+          onPick={pickMention}
+          onHighlight={setMentionIndex}
+        />
+      )}
       {attachments.length > 0 && (
         <AttachmentList
           paths={attachments}
@@ -215,10 +394,35 @@ export function Composer({
         disabled={disabled}
         onChange={(e) => {
           setText(e.target.value);
+          setCaret(e.target.selectionStart ?? e.target.value.length);
           setSlashDismissed(false);
+          setMentionDismissed(false);
           grow(e.target);
         }}
+        onSelect={(e) => setCaret(e.currentTarget.selectionStart ?? 0)}
         onKeyDown={(e) => {
+          if (mentionOpen) {
+            if (e.key === "ArrowDown") {
+              e.preventDefault();
+              setMentionIndex((i) => (i + 1) % rows.length);
+              return;
+            }
+            if (e.key === "ArrowUp") {
+              e.preventDefault();
+              setMentionIndex((i) => (i - 1 + rows.length) % rows.length);
+              return;
+            }
+            if (e.key === "Enter" || e.key === "Tab") {
+              e.preventDefault();
+              pickMention(mentionIndex);
+              return;
+            }
+            if (e.key === "Escape") {
+              e.preventDefault();
+              setMentionDismissed(true);
+              return;
+            }
+          }
           if (slashOpen) {
             if (e.key === "ArrowDown") {
               e.preventDefault();

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -20,6 +20,7 @@ import {
   isFsPath,
   joinTypedDir,
   mentionQueryAt,
+  mentionTokenEnd,
   splitFsPath,
 } from "./mentions";
 
@@ -331,19 +332,21 @@ export function Composer({
   function pickMention(i: number) {
     const action = actions[i];
     if (!action || !mention) return;
+    // Replace the entire "@token", not just up to the caret — the user may
+    // have moved the cursor back into the middle of it before picking.
+    const end = mentionTokenEnd(text, caret);
     if (action.kind === "attach") {
       addPaths([action.path]);
-      // Splice out the "@query" span; the file lives in the attachment chips,
-      // so it never pollutes the typed prose.
-      const next = text.slice(0, mention.start) + text.slice(caret);
+      // The file lives in the attachment chips, so it never pollutes prose.
+      const next = text.slice(0, mention.start) + text.slice(end);
       setText(next);
       setCaret(mention.start);
       placeCaret(mention.start);
     } else {
-      // Drill into the directory: rewrite the "@query" to the chosen path so
+      // Drill into the directory: rewrite the "@token" to the chosen path so
       // the next keystroke (or selection) continues from inside it.
       const inserted = `@${action.query}`;
-      const next = text.slice(0, mention.start) + inserted + text.slice(caret);
+      const next = text.slice(0, mention.start) + inserted + text.slice(end);
       const pos = mention.start + inserted.length;
       setText(next);
       setCaret(pos);

--- a/src/components/Composer/mentions.test.ts
+++ b/src/components/Composer/mentions.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import {
+  mentionQueryAt,
+  filterFiles,
+  isFsPath,
+  splitFsPath,
+  joinTypedDir,
+  filterDirEntries,
+} from "./mentions";
+
+describe("mentionQueryAt", () => {
+  it("detects an @ token at the start of the text", () => {
+    expect(mentionQueryAt("@src", 4)).toEqual({ query: "src", start: 0 });
+  });
+
+  it("detects an @ token after whitespace", () => {
+    expect(mentionQueryAt("look at @comp", 13)).toEqual({ query: "comp", start: 8 });
+  });
+
+  it("matches an empty query right after @", () => {
+    expect(mentionQueryAt("hi @", 4)).toEqual({ query: "", start: 3 });
+  });
+
+  it("ignores @ that is part of a word (e.g. an email)", () => {
+    expect(mentionQueryAt("foo@bar", 7)).toBeNull();
+  });
+
+  it("ends the token at whitespace, so a finished mention no longer triggers", () => {
+    expect(mentionQueryAt("@src/foo.ts done", 16)).toBeNull();
+  });
+
+  it("uses the caret, not the end of the text", () => {
+    // caret sits right after "@sr"; the trailing "c more" is past the caret.
+    expect(mentionQueryAt("@src more", 3)).toEqual({ query: "sr", start: 0 });
+  });
+});
+
+describe("filterFiles", () => {
+  const files = [
+    "src/components/Composer/index.tsx",
+    "src/components/Composer/SlashMenu.tsx",
+    "src/api.ts",
+    "src/store.ts",
+    "README.md",
+  ];
+
+  it("returns the first N files for an empty query", () => {
+    expect(filterFiles(files, "", 2)).toEqual(files.slice(0, 2));
+  });
+
+  it("ranks a basename prefix match first", () => {
+    expect(filterFiles(files, "index")[0]).toBe(
+      "src/components/Composer/index.tsx",
+    );
+  });
+
+  it("matches anywhere in the path", () => {
+    expect(filterFiles(files, "composer")).toContain(
+      "src/components/Composer/SlashMenu.tsx",
+    );
+  });
+
+  it("falls back to a fuzzy subsequence match", () => {
+    expect(filterFiles(files, "slmnu")).toContain(
+      "src/components/Composer/SlashMenu.tsx",
+    );
+  });
+
+  it("excludes non-matches", () => {
+    expect(filterFiles(files, "xyzzy")).toEqual([]);
+  });
+
+  it("honors the result limit", () => {
+    expect(filterFiles(files, "s").length).toBeLessThanOrEqual(8);
+  });
+});
+
+describe("isFsPath", () => {
+  it.each(["~", "~/Downloads", "/etc", "./src", "../x"])(
+    "treats %s as a filesystem path",
+    (q) => expect(isFsPath(q)).toBe(true),
+  );
+  it.each(["src", "Composer", "index.ts", ""])(
+    "treats %s as a worktree search",
+    (q) => expect(isFsPath(q)).toBe(false),
+  );
+});
+
+describe("splitFsPath", () => {
+  it("splits a tilde root", () => {
+    expect(splitFsPath("~/Down")).toEqual({ dir: "~", partial: "Down" });
+  });
+  it("keeps the bare prefix when there's no slash", () => {
+    expect(splitFsPath("~")).toEqual({ dir: "~", partial: "" });
+  });
+  it("treats the filesystem root specially", () => {
+    expect(splitFsPath("/Us")).toEqual({ dir: "/", partial: "Us" });
+  });
+  it("splits a nested path", () => {
+    expect(splitFsPath("/Users/alex/Do")).toEqual({
+      dir: "/Users/alex",
+      partial: "Do",
+    });
+  });
+});
+
+describe("joinTypedDir", () => {
+  it.each([
+    ["~", "Downloads", "~/Downloads"],
+    ["/", "Users", "/Users"],
+    ["~/Downloads", "img", "~/Downloads/img"],
+    ["~/Downloads/", "img", "~/Downloads/img"],
+  ])("joins %s + %s", (dir, name, expected) => {
+    expect(joinTypedDir(dir, name)).toBe(expected);
+  });
+});
+
+describe("filterDirEntries", () => {
+  const entries = [
+    { name: "Documents", is_dir: true },
+    { name: "archive.zip", is_dir: false },
+    { name: "1.png", is_dir: false },
+    { name: ".hidden", is_dir: false },
+    { name: "apps", is_dir: true },
+  ];
+
+  it("lists directories before files", () => {
+    const out = filterDirEntries(entries, "");
+    const firstFile = out.findIndex((e) => !e.is_dir);
+    const lastDir = out.map((e) => e.is_dir).lastIndexOf(true);
+    expect(lastDir).toBeLessThan(firstFile);
+  });
+
+  it("hides dotfiles unless the partial starts with a dot", () => {
+    expect(filterDirEntries(entries, "").some((e) => e.name === ".hidden")).toBe(
+      false,
+    );
+    expect(filterDirEntries(entries, ".").map((e) => e.name)).toContain(
+      ".hidden",
+    );
+  });
+
+  it("filters by case-insensitive substring", () => {
+    expect(filterDirEntries(entries, "png").map((e) => e.name)).toEqual([
+      "1.png",
+    ]);
+  });
+});

--- a/src/components/Composer/mentions.test.ts
+++ b/src/components/Composer/mentions.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   mentionQueryAt,
+  mentionTokenEnd,
   filterFiles,
   isFsPath,
   splitFsPath,
@@ -72,6 +73,26 @@ describe("filterFiles", () => {
 
   it("honors the result limit", () => {
     expect(filterFiles(files, "s").length).toBeLessThanOrEqual(8);
+  });
+});
+
+describe("mentionTokenEnd", () => {
+  it("scans to the end when the caret is mid-token", () => {
+    // @components, caret moved back to 4 (after "@com") — the whole token
+    // ends at 11, so picking removes "ponents" too rather than leaving it.
+    expect(mentionTokenEnd("@components", 4)).toBe(11);
+  });
+
+  it("stops at the first whitespace after the caret", () => {
+    expect(mentionTokenEnd("@src more", 3)).toBe(4);
+  });
+
+  it("stops at a following @ (token boundary)", () => {
+    expect(mentionTokenEnd("@a@b", 1)).toBe(2);
+  });
+
+  it("returns the caret when it already sits at the token end", () => {
+    expect(mentionTokenEnd("@src", 4)).toBe(4);
   });
 });
 

--- a/src/components/Composer/mentions.ts
+++ b/src/components/Composer/mentions.ts
@@ -71,6 +71,17 @@ export function filterDirEntries<T extends { name: string; is_dir: boolean }>(
   return scored.slice(0, limit).map((s) => s.e);
 }
 
+/** Index where the "@" token under the caret ends: the first whitespace or
+ *  "@" at or after `from`, else the end of the text. Mirrors the `[^\s@]`
+ *  token class `mentionQueryAt` uses, so picking removes the *whole* token
+ *  even when the caret was moved back into the middle of it (otherwise the
+ *  tail past the caret, e.g. "ponents" in "@components", would survive). */
+export function mentionTokenEnd(text: string, from: number): number {
+  let end = from;
+  while (end < text.length && !/[\s@]/.test(text[end])) end++;
+  return end;
+}
+
 /** True when `query`'s characters appear in `text` in order (fuzzy match). */
 function isSubsequence(text: string, query: string): boolean {
   let i = 0;

--- a/src/components/Composer/mentions.ts
+++ b/src/components/Composer/mentions.ts
@@ -1,0 +1,112 @@
+// Pure helpers for the composer's "@" file-mention autocomplete.
+//
+// Typing "@" (at the start, or after whitespace) opens a menu of the
+// agent's worktree files. Picking one removes the "@query" text and adds
+// the file to the message attachments — matching the existing attach flow,
+// so the agent receives it as a separate "Attached file: <path>" block.
+
+/** The active "@" mention under the caret, or null when there isn't one.
+ *  `start` is the index of the "@" itself, so callers can splice out the
+ *  whole `@query` span. The "@" must be at the start of the text or
+ *  preceded by whitespace, so addresses like `foo@bar` don't trigger it. */
+export function mentionQueryAt(
+  text: string,
+  caret: number,
+): { query: string; start: number } | null {
+  const upto = text.slice(0, caret);
+  const m = /(?:^|\s)@([^\s@]*)$/.exec(upto);
+  if (!m) return null;
+  const query = m[1];
+  return { query, start: caret - query.length - 1 };
+}
+
+/** A mention query is a filesystem path (resolved via `list_dir`) rather
+ *  than a worktree-file search when it starts with `~`, `/`, `./` or `../`. */
+export function isFsPath(query: string): boolean {
+  return /^(~|\/|\.\/|\.\.\/)/.test(query);
+}
+
+/** Split a typed filesystem path into the directory to list and the partial
+ *  basename to filter by. The `dir` keeps the user's prefix (e.g. `~`) so we
+ *  can re-display it; `list_dir` resolves the real path. */
+export function splitFsPath(query: string): { dir: string; partial: string } {
+  const slash = query.lastIndexOf("/");
+  if (slash === -1) return { dir: query, partial: "" };
+  return { dir: query.slice(0, slash) || "/", partial: query.slice(slash + 1) };
+}
+
+/** Append `name` to a typed directory, normalizing the separator (so `~` →
+ *  `~/name`, `/` → `/name`, `~/Downloads` → `~/Downloads/name`). */
+export function joinTypedDir(dir: string, name: string): string {
+  return (dir.endsWith("/") ? dir : dir + "/") + name;
+}
+
+/** Rank directory entries against a partial basename for the `@` menu:
+ *  directories first, then prefix matches, then substrings, alpha within.
+ *  Dotfiles are hidden unless the partial itself starts with ".". */
+export function filterDirEntries<T extends { name: string; is_dir: boolean }>(
+  entries: T[],
+  partial: string,
+  limit = 10,
+): T[] {
+  const q = partial.toLowerCase();
+  const showHidden = partial.startsWith(".");
+  const scored: { e: T; score: number }[] = [];
+  for (const e of entries) {
+    if (!showHidden && e.name.startsWith(".")) continue;
+    const lower = e.name.toLowerCase();
+    let score: number;
+    if (!q) score = 0;
+    else if (lower.startsWith(q)) score = 0;
+    else if (lower.includes(q)) score = 1;
+    else continue;
+    scored.push({ e, score });
+  }
+  scored.sort(
+    (a, b) =>
+      Number(b.e.is_dir) - Number(a.e.is_dir) ||
+      a.score - b.score ||
+      (a.e.name < b.e.name ? -1 : 1),
+  );
+  return scored.slice(0, limit).map((s) => s.e);
+}
+
+/** True when `query`'s characters appear in `text` in order (fuzzy match). */
+function isSubsequence(text: string, query: string): boolean {
+  let i = 0;
+  for (let j = 0; j < text.length && i < query.length; j++) {
+    if (text[j] === query[i]) i++;
+  }
+  return i === query.length;
+}
+
+/** Rank worktree file paths against a mention query. Best matches first:
+ *  basename prefix, then basename substring, then anywhere in the path,
+ *  then a fuzzy subsequence fallback. Ties break on the shorter, then
+ *  alphabetically-earlier, path. An empty query lists the first `limit`. */
+export function filterFiles(files: string[], query: string, limit = 8): string[] {
+  const q = query.toLowerCase();
+  if (!q) return files.slice(0, limit);
+
+  const scored: { path: string; score: number }[] = [];
+  for (const path of files) {
+    const lower = path.toLowerCase();
+    const base = lower.slice(lower.lastIndexOf("/") + 1);
+    const baseIdx = base.indexOf(q);
+    let score: number;
+    if (baseIdx === 0) score = 0;
+    else if (baseIdx > 0) score = 1;
+    else if (lower.includes(q)) score = 2;
+    else if (isSubsequence(lower, q)) score = 3;
+    else continue;
+    scored.push({ path, score });
+  }
+
+  scored.sort(
+    (a, b) =>
+      a.score - b.score ||
+      a.path.length - b.path.length ||
+      (a.path < b.path ? -1 : 1),
+  );
+  return scored.slice(0, limit).map((s) => s.path);
+}

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from "react";
-import type { AgentRecord } from "../../api";
+import { api, type AgentRecord } from "../../api";
 import { useAppStore } from "../../store";
 import { applyPolicy, getAdapter } from "../../adapters";
 import { providerLabel } from "../../data/providers";
@@ -161,6 +161,10 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
                   : "Agent is not ready"
           }
           stopping={busy}
+          mentionSource={() =>
+            api.listWorktreeTree(agent.id).then((files) => files.map((f) => f.path))
+          }
+          listDir={api.listDir}
           onSend={({ text, thinking, attachments }) => send(agent.id, text, attachments, thinking)}
           onStop={() => stop(agent.id)}
         />


### PR DESCRIPTION
Typing `@` in the composer now opens a file-picker autocomplete that adds the chosen file to the message attachments, making the long-standing "@ to attach" placeholder real. `@comp` fuzzy-searches the agent's worktree files, while a filesystem-style query like `@~/Downloads/` navigates real directories (via a new `list_dir` Tauri command with `~` expansion) and attaches files outside the worktree by absolute path. The menu mirrors the existing slash-command pattern — full keyboard navigation and reuse of the `.dd` styling — and renders the file-panel's Material file icons per row. Picked files are added as attachment chips and the `@query` text is spliced out, so paths never pollute the typed prose; the agent receives each as a separate "Attached file" block. Pure logic lives in `mentions.ts` with 32 unit tests covering query detection, ranking, and path handling.