### PR TITLE
Resolve gh CLI to an absolute path so PR ops work from the GUI

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -1371,55 +1371,11 @@ fn pi_pty_args(session_id: Option<&str>) -> Vec<String> {
 /// PATH misses), then the usual install dirs. `label` is the
 /// human-facing product name used only in the not-found error.
 fn resolve_agent_bin(name: &str, label: &str, home: &Path) -> Result<String> {
-    if let Some(path) = command_in_path(name) {
-        return Ok(path);
-    }
-    if let Some(path) = command_from_login_shell(name) {
-        return Ok(path);
-    }
-    for candidate in common_bin_paths(name, home) {
-        if candidate.is_file() {
-            return Ok(candidate.to_string_lossy().into_owned());
-        }
-    }
-    Err(Error::Other(format!(
-        "Could not find the `{name}` executable. Install {label} or make it available on PATH."
-    )))
-}
-
-fn common_bin_paths(name: &str, home: &Path) -> Vec<PathBuf> {
-    vec![
-        home.join(format!(".local/bin/{name}")),
-        home.join(format!(".npm-global/bin/{name}")),
-        home.join(format!(".bun/bin/{name}")),
-        PathBuf::from(format!("/opt/homebrew/bin/{name}")),
-        PathBuf::from(format!("/usr/local/bin/{name}")),
-    ]
-}
-
-fn command_in_path(name: &str) -> Option<String> {
-    let path = std::env::var_os("PATH")?;
-    std::env::split_paths(&path)
-        .map(|dir| dir.join(name))
-        .find(|candidate| candidate.is_file())
-        .map(|path| path.to_string_lossy().into_owned())
-}
-
-fn command_from_login_shell(name: &str) -> Option<String> {
-    let script = format!("command -v {name}");
-    let out = Command::new("/bin/zsh")
-        .args(["-lc", &script])
-        .output()
-        .ok()?;
-    if !out.status.success() {
-        return None;
-    }
-    let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    if path.is_empty() {
-        None
-    } else {
-        Some(path)
-    }
+    crate::bin_resolve::resolve_bin(name, home).ok_or_else(|| {
+        Error::Other(format!(
+            "Could not find the `{name}` executable. Install {label} or make it available on PATH."
+        ))
+    })
 }
 
 // ── Version probing ───────────────────────────────────────────────────────────

--- a/src-tauri/src/bin_resolve.rs
+++ b/src-tauri/src/bin_resolve.rs
@@ -6,26 +6,31 @@
 //! installed by Homebrew (`/opt/homebrew/bin`) or a version manager — `gh`,
 //! `claude`, `codex`, … — does not, so `Command::new("gh")` fails with
 //! ENOENT ("No such file or directory"). Resolve the absolute path first:
-//! current PATH → the user's login shell → the usual install dirs.
+//! current PATH → the user's login-shell PATH → the usual install dirs.
 
+use std::ffi::OsStr;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Resolve `name` to an absolute path, or `None` if it can't be found.
 ///
-/// Tries, in order: the current PATH, the user's login shell (catches
+/// Tries, in order: the current PATH, the user's login-shell PATH (catches
 /// nvm / fnm / volta / homebrew setups the GUI process's bare PATH misses),
-/// then the usual install dirs under `home` and the Homebrew prefixes.
+/// then the usual install dirs under `home` and the Homebrew prefixes. Every
+/// candidate must be an executable regular file, so a non-executable stub
+/// from a partial install is skipped rather than returned (which would fail
+/// with a confusing "Permission denied" at spawn time).
 pub fn resolve_bin(name: &str, home: &Path) -> Option<String> {
-    if let Some(path) = command_in_path(name) {
+    if let Some(path) = std::env::var_os("PATH").and_then(|p| find_in_path(name, &p)) {
         return Some(path);
     }
-    if let Some(path) = command_from_login_shell(name) {
+    if let Some(path) = login_shell_path().and_then(|p| find_in_path(name, p)) {
         return Some(path);
     }
     common_bin_paths(name, home)
         .into_iter()
-        .find(|candidate| candidate.is_file())
+        .find(|candidate| is_executable(candidate))
         .map(|candidate| candidate.to_string_lossy().into_owned())
 }
 
@@ -39,18 +44,24 @@ fn common_bin_paths(name: &str, home: &Path) -> Vec<PathBuf> {
     ]
 }
 
-fn command_in_path(name: &str) -> Option<String> {
-    let path = std::env::var_os("PATH")?;
+/// Find an executable named `name` by walking a colon-separated `path`
+/// (PATH-style). `name` is only ever used as a path component — never as
+/// shell input — so there is no command-injection surface here.
+fn find_in_path<P: AsRef<OsStr>>(name: &str, path: P) -> Option<String> {
     std::env::split_paths(&path)
         .map(|dir| dir.join(name))
-        .find(|candidate| candidate.is_file())
-        .map(|path| path.to_string_lossy().into_owned())
+        .find(|candidate| is_executable(candidate))
+        .map(|candidate| candidate.to_string_lossy().into_owned())
 }
 
-fn command_from_login_shell(name: &str) -> Option<String> {
-    let script = format!("command -v {name}");
+/// The PATH as seen by the user's login shell, which sources `.zprofile` /
+/// `.zshrc` and thus picks up version-manager and Homebrew dirs the GUI's
+/// inherited PATH lacks. We ask the shell *only* for its `$PATH` and walk it
+/// ourselves — no binary name is ever interpolated into a shell command, so
+/// this cannot be used for command injection.
+fn login_shell_path() -> Option<String> {
     let out = Command::new("/bin/zsh")
-        .args(["-lc", &script])
+        .args(["-lc", "print -rn -- $PATH"])
         .output()
         .ok()?;
     if !out.status.success() {
@@ -64,9 +75,23 @@ fn command_from_login_shell(name: &str) -> Option<String> {
     }
 }
 
+/// An executable regular file the current process may run. `is_file()` alone
+/// is not enough: a regular file without any execute bit would still match
+/// and then fail at spawn with "Permission denied" instead of "not found".
+fn is_executable(path: &Path) -> bool {
+    std::fs::metadata(path)
+        .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn write_executable(path: &Path) {
+        std::fs::write(path, b"#!/bin/sh\n").unwrap();
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
 
     /// The bug this module fixes: a binary that lives outside the GUI process's
     /// inherited PATH (e.g. Homebrew's `gh` under `/opt/homebrew/bin`) must
@@ -79,12 +104,31 @@ mod tests {
         // A name that won't exist on PATH or via the login shell, so resolution
         // can only succeed through the common-dir fallback.
         let name = "quorum-fake-cli-xyz";
-        std::fs::write(bin_dir.join(name), b"#!/bin/sh\n").unwrap();
+        write_executable(&bin_dir.join(name));
 
         assert_eq!(
             resolve_bin(name, home.path()).as_deref(),
             Some(bin_dir.join(name).to_string_lossy().as_ref()),
             "a binary not on PATH should resolve via the common install dirs",
+        );
+    }
+
+    /// A non-executable file (e.g. a leftover stub from a partial install) is
+    /// not a usable binary and must be skipped, not returned.
+    #[test]
+    fn skips_non_executable_file() {
+        let home = tempfile::tempdir().unwrap();
+        let bin_dir = home.path().join(".local/bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let name = "quorum-fake-cli-nonexec";
+        let file = bin_dir.join(name);
+        std::fs::write(&file, b"#!/bin/sh\n").unwrap();
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        assert_eq!(
+            resolve_bin(name, home.path()),
+            None,
+            "a non-executable file must not be resolved as a runnable binary",
         );
     }
 

--- a/src-tauri/src/bin_resolve.rs
+++ b/src-tauri/src/bin_resolve.rs
@@ -1,0 +1,99 @@
+//! Locate external CLI binaries the way a GUI app must on macOS.
+//!
+//! A Tauri app launched from Finder / Dock / Spotlight inherits launchd's
+//! minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) rather than the user's
+//! shell PATH. Binaries in `/usr/bin` (like `git`) resolve fine, but anything
+//! installed by Homebrew (`/opt/homebrew/bin`) or a version manager — `gh`,
+//! `claude`, `codex`, … — does not, so `Command::new("gh")` fails with
+//! ENOENT ("No such file or directory"). Resolve the absolute path first:
+//! current PATH → the user's login shell → the usual install dirs.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Resolve `name` to an absolute path, or `None` if it can't be found.
+///
+/// Tries, in order: the current PATH, the user's login shell (catches
+/// nvm / fnm / volta / homebrew setups the GUI process's bare PATH misses),
+/// then the usual install dirs under `home` and the Homebrew prefixes.
+pub fn resolve_bin(name: &str, home: &Path) -> Option<String> {
+    if let Some(path) = command_in_path(name) {
+        return Some(path);
+    }
+    if let Some(path) = command_from_login_shell(name) {
+        return Some(path);
+    }
+    common_bin_paths(name, home)
+        .into_iter()
+        .find(|candidate| candidate.is_file())
+        .map(|candidate| candidate.to_string_lossy().into_owned())
+}
+
+fn common_bin_paths(name: &str, home: &Path) -> Vec<PathBuf> {
+    vec![
+        home.join(format!(".local/bin/{name}")),
+        home.join(format!(".npm-global/bin/{name}")),
+        home.join(format!(".bun/bin/{name}")),
+        PathBuf::from(format!("/opt/homebrew/bin/{name}")),
+        PathBuf::from(format!("/usr/local/bin/{name}")),
+    ]
+}
+
+fn command_in_path(name: &str) -> Option<String> {
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path)
+        .map(|dir| dir.join(name))
+        .find(|candidate| candidate.is_file())
+        .map(|path| path.to_string_lossy().into_owned())
+}
+
+fn command_from_login_shell(name: &str) -> Option<String> {
+    let script = format!("command -v {name}");
+    let out = Command::new("/bin/zsh")
+        .args(["-lc", &script])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if path.is_empty() {
+        None
+    } else {
+        Some(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The bug this module fixes: a binary that lives outside the GUI process's
+    /// inherited PATH (e.g. Homebrew's `gh` under `/opt/homebrew/bin`) must
+    /// still resolve via the fallback install dirs under `home`.
+    #[test]
+    fn resolves_binary_outside_path_via_home_dir() {
+        let home = tempfile::tempdir().unwrap();
+        let bin_dir = home.path().join(".local/bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        // A name that won't exist on PATH or via the login shell, so resolution
+        // can only succeed through the common-dir fallback.
+        let name = "quorum-fake-cli-xyz";
+        std::fs::write(bin_dir.join(name), b"#!/bin/sh\n").unwrap();
+
+        assert_eq!(
+            resolve_bin(name, home.path()).as_deref(),
+            Some(bin_dir.join(name).to_string_lossy().as_ref()),
+            "a binary not on PATH should resolve via the common install dirs",
+        );
+    }
+
+    #[test]
+    fn returns_none_when_binary_is_nowhere() {
+        let home = tempfile::tempdir().unwrap();
+        assert_eq!(
+            resolve_bin("quorum-definitely-not-installed-zzz", home.path()),
+            None,
+        );
+    }
+}

--- a/src-tauri/src/gh.rs
+++ b/src-tauri/src/gh.rs
@@ -4,10 +4,29 @@
 //! shells out to `gh` and maps exit-code / stderr to typed errors.
 
 use std::io::ErrorKind;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use tokio::process::Command;
 
 use crate::error::{Error, Result};
+
+/// A `Command` for the `gh` CLI, resolved to an absolute path.
+///
+/// A GUI app launched from Finder/Dock inherits launchd's minimal PATH, which
+/// omits Homebrew (`/opt/homebrew/bin`) where `gh` is installed — so a bare
+/// `Command::new("gh")` fails with ENOENT ("No such file or directory"). We
+/// resolve the real path once (it may spawn a login shell) and cache it. If
+/// `gh` genuinely isn't installed anywhere we fall back to the bare name, so
+/// the same not-found error still surfaces (e.g. `auth_status` reports it as
+/// not installed).
+fn gh_command() -> Command {
+    static GH_PATH: OnceLock<String> = OnceLock::new();
+    let path = GH_PATH.get_or_init(|| {
+        let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
+        crate::bin_resolve::resolve_bin("gh", &home).unwrap_or_else(|| "gh".to_string())
+    });
+    Command::new(path)
+}
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -130,7 +149,7 @@ impl From<GhPrRaw> for PrState {
 /// Returns `Ok(None)` when `gh` exits non-zero with "no pull requests found"
 /// in stderr (i.e. the branch simply has no open PR yet).
 pub async fn pr_view(worktree: &Path) -> Result<Option<PrState>> {
-    let out = Command::new("gh")
+    let out = gh_command()
         .current_dir(worktree)
         .args(["pr", "view", "--json", "number,url,state,title,mergeable"])
         .output()
@@ -151,7 +170,7 @@ pub async fn pr_view(worktree: &Path) -> Result<Option<PrState>> {
 /// List open PRs for the repo at `worktree` (most-recent first), for the
 /// composer's "#" mention autocomplete.
 pub async fn pr_list(worktree: &Path, limit: u32) -> Result<Vec<PrSummary>> {
-    let out = Command::new("gh")
+    let out = gh_command()
         .current_dir(worktree)
         .args([
             "pr",
@@ -198,7 +217,7 @@ pub async fn pr_list(worktree: &Path, limit: u32) -> Result<Vec<PrSummary>> {
 /// failures surface as `Err` — the command layer treats both as "checks
 /// unavailable" and the panel degrades to `mergeable`-only behavior.
 pub async fn pr_checks(worktree: &Path) -> Result<Option<PrChecks>> {
-    let out = Command::new("gh")
+    let out = gh_command()
         .current_dir(worktree)
         .args(["pr", "view", "--json", "mergeStateStatus,statusCheckRollup"])
         .output()
@@ -341,7 +360,7 @@ pub async fn pr_create(worktree: &Path, title: &str, body: &str, base: &str) -> 
         args.extend_from_slice(&["--title", title, "--body", body]);
     }
 
-    let out = Command::new("gh")
+    let out = gh_command()
         .current_dir(worktree)
         .args(&args)
         .output()
@@ -372,7 +391,7 @@ pub async fn pr_create(worktree: &Path, title: &str, body: &str, base: &str) -> 
 /// Merge the open PR for the branch checked out in `worktree` using a merge
 /// commit and the `--auto` flag (merges as soon as all checks pass).
 pub async fn pr_merge(worktree: &Path) -> Result<()> {
-    let out = Command::new("gh")
+    let out = gh_command()
         .current_dir(worktree)
         .args(["pr", "merge", "--merge", "--auto"])
         .output()
@@ -435,7 +454,7 @@ impl From<GhRepoRaw> for GhRepoSummary {
 /// Probe `gh` availability and auth. Never errors — a missing binary or a
 /// logged-out state are reported as fields, not failures.
 pub async fn auth_status() -> Result<GhStatus> {
-    let out = match Command::new("gh").args(["auth", "status"]).output().await {
+    let out = match gh_command().args(["auth", "status"]).output().await {
         Ok(out) => out,
         Err(e) if e.kind() == ErrorKind::NotFound => {
             return Ok(GhStatus { installed: false, authenticated: false, login: None });
@@ -449,7 +468,7 @@ pub async fn auth_status() -> Result<GhStatus> {
     }
 
     // Best-effort login name; never fail the whole probe on it.
-    let login = Command::new("gh")
+    let login = gh_command()
         .args(["api", "user", "--jq", ".login"])
         .output()
         .await
@@ -464,7 +483,7 @@ pub async fn auth_status() -> Result<GhStatus> {
 /// List the authenticated user's repos (most-recently-updated first). The
 /// New Project picker filters this list client-side.
 pub async fn repo_list(limit: u32) -> Result<Vec<GhRepoSummary>> {
-    let out = Command::new("gh")
+    let out = gh_command()
         .args([
             "repo",
             "list",
@@ -492,7 +511,7 @@ pub async fn repo_clone(spec: &str, target: &Path) -> Result<()> {
     let target = target.to_str().ok_or_else(|| {
         Error::InvalidPath(target.display().to_string())
     })?;
-    let out = Command::new("gh")
+    let out = gh_command()
         .args(["repo", "clone", spec, target])
         .output()
         .await?;
@@ -527,7 +546,7 @@ pub async fn repo_create_and_push(
         args.push(desc.to_string());
     }
 
-    let out = Command::new("gh")
+    let out = gh_command()
         .current_dir(target)
         .args(&args)
         .output()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod activity;
 mod agent;
+mod bin_resolve;
 mod branding;
 mod commands;
 mod database;


### PR DESCRIPTION
Opening a PR (and every other `gh` operation) failed from the packaged app with `io error: No such file or directory (os error 2)`. A Tauri app launched from Finder/Dock inherits launchd's minimal PATH, which omits Homebrew's `/opt/homebrew/bin` where `gh` lives, so `Command::new("gh")` hit ENOENT — `git` kept working only because it sits at `/usr/bin/git`. This extracts the existing agent-CLI resolver (PATH → login shell → common install dirs) into a shared `bin_resolve` module and routes `gh.rs` through it, resolving and caching `gh`'s absolute path. `agent.rs` now delegates to the same helper, and the resolver gains regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)