### PR TITLE
fix: thread subagent messages under their tool call instead of leaking into chat

### DIFF
--- a/src/adapters/claude/reduce.test.ts
+++ b/src/adapters/claude/reduce.test.ts
@@ -222,3 +222,103 @@ describe("claudeAdapter.reduce — model", () => {
     ]);
   });
 });
+
+describe("claudeAdapter.reduce — subagent sidechain routing", () => {
+  const spawn: RawEvent = {
+    type: "assistant",
+    message: {
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: "toolu_task",
+          name: "Agent",
+          input: { subagent_type: "Explore", description: "look", prompt: "go" },
+        },
+      ],
+    },
+  };
+
+  it("nests sidechain events under the spawning tool_call, not the main log", () => {
+    const items = reduceAll([
+      spawn,
+      // The subagent's own turns, tagged with the parent Task tool_use id.
+      {
+        type: "user",
+        parent_tool_use_id: "toolu_task",
+        message: { role: "user", content: "go" },
+      },
+      {
+        type: "assistant",
+        parent_tool_use_id: "toolu_task",
+        message: { role: "assistant", content: [{ type: "text", text: "found it" }] },
+      },
+      // The Task's own result rides on a main-level user message (no parent).
+      {
+        type: "user",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "toolu_task", content: "done" }],
+        },
+      },
+    ] as RawEvent[]);
+
+    // Main timeline holds only the tool_call and its result — no stray
+    // user/agent bubbles from the subagent.
+    expect(items.map((i) => i.kind)).toEqual(["tool_call", "tool_result"]);
+    const call = items[0];
+    expect(call.kind).toBe("tool_call");
+    if (call.kind === "tool_call") {
+      expect(call.children).toEqual([
+        { kind: "user_message", text: "go" },
+        { kind: "agent_message", text: "found it", streaming: false },
+      ]);
+    }
+  });
+
+  it("drops a sidechain event whose parent tool_call hasn't arrived yet", () => {
+    const items = reduceAll([
+      {
+        type: "user",
+        parent_tool_use_id: "toolu_missing",
+        message: { role: "user", content: "orphan" },
+      },
+    ] as RawEvent[]);
+    expect(items).toEqual([]);
+  });
+
+  it("threads a nested subagent under its parent subagent", () => {
+    const items = reduceAll([
+      spawn,
+      // The outer subagent spawns its own Task.
+      {
+        type: "assistant",
+        parent_tool_use_id: "toolu_task",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "toolu_inner", name: "Agent", input: {} },
+          ],
+        },
+      },
+      // The inner subagent's turn references the inner tool_use id.
+      {
+        type: "assistant",
+        parent_tool_use_id: "toolu_inner",
+        message: { role: "assistant", content: [{ type: "text", text: "deep" }] },
+      },
+    ] as RawEvent[]);
+
+    const outer = items[0];
+    expect(outer.kind).toBe("tool_call");
+    if (outer.kind === "tool_call") {
+      const inner = outer.children?.[0];
+      expect(inner?.kind).toBe("tool_call");
+      if (inner?.kind === "tool_call") {
+        expect(inner.children).toEqual([
+          { kind: "agent_message", text: "deep", streaming: false },
+        ]);
+      }
+    }
+  });
+});

--- a/src/adapters/claude/reduce.test.ts
+++ b/src/adapters/claude/reduce.test.ts
@@ -276,6 +276,49 @@ describe("claudeAdapter.reduce — subagent sidechain routing", () => {
     }
   });
 
+  it("routes streaming tool_use deltas into the children slice", () => {
+    const items = reduceAll([
+      spawn,
+      // The subagent's tool call streams in: content_block_start opens it,
+      // input_json_delta fills its input — both tagged with the parent id, so
+      // upsertToolCall / appendToolInputDelta must operate on the children
+      // slice (positional index 0 there), not the main items list.
+      {
+        type: "stream_event",
+        parent_tool_use_id: "toolu_task",
+        event: {
+          type: "content_block_start",
+          content_block: { type: "tool_use", id: "toolu_child", name: "Read", input: "" },
+        },
+      },
+      {
+        type: "stream_event",
+        parent_tool_use_id: "toolu_task",
+        event: {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "input_json_delta", partial_json: '{"path":"/x"}' },
+        },
+      },
+    ] as RawEvent[]);
+
+    // Main timeline holds only the spawning Agent call.
+    expect(items.map((i) => i.kind)).toEqual(["tool_call"]);
+    const call = items[0];
+    expect(call.kind).toBe("tool_call");
+    if (call.kind === "tool_call") {
+      expect(call.children).toEqual([
+        {
+          kind: "tool_call",
+          id: "toolu_child",
+          name: "Read",
+          input: '{"path":"/x"}',
+          streaming: true,
+        },
+      ]);
+    }
+  });
+
   it("drops a sidechain event whose parent tool_call hasn't arrived yet", () => {
     const items = reduceAll([
       {

--- a/src/adapters/claude/reduce.ts
+++ b/src/adapters/claude/reduce.ts
@@ -18,6 +18,15 @@ import { contentText } from "./content";
 import { sanitizeUserText } from "./sanitize";
 
 export function reduce(prev: ChatItem[], ev: RawEvent): ChatItem[] {
+  // Subagent (sidechain) events are tagged with the parent Task/Agent
+  // tool_use id; route them under that tool_call's nested log instead of the
+  // main timeline. Main-agent events have no parent and reduce normally.
+  const parentId = parentToolUseId(ev);
+  if (parentId) return routeToChild(prev, parentId, ev);
+  return reduceTop(prev, ev);
+}
+
+function reduceTop(prev: ChatItem[], ev: RawEvent): ChatItem[] {
   const type = typeof ev.type === "string" ? ev.type : undefined;
 
   if (type === "stream_event") return handleStreamEvent(prev, ev);
@@ -25,6 +34,47 @@ export function reduce(prev: ChatItem[], ev: RawEvent): ChatItem[] {
   if (type === "user") return handleUser(prev, ev);
   if (type === "result") return handleResult(prev, ev);
   return prev;
+}
+
+/** Claude's stream-json tags every event belonging to a subagent with the
+ *  spawning Task/Agent tool_use id (top-level `parent_tool_use_id`, set on
+ *  user/assistant/result/stream_event envelopes alike). Null/absent for the
+ *  main agent. */
+function parentToolUseId(ev: RawEvent): string | null {
+  const v = ev.parent_tool_use_id;
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+/** Fold a sidechain event into the children of the tool_call it belongs to,
+ *  reducing it there with the same top-level logic. Searches nested
+ *  tool_calls so a subagent that itself spawns a subagent threads correctly.
+ *  If the parent tool_call isn't present yet (ordering race), returns `items`
+ *  unchanged — the event is dropped rather than leaked into the main log. */
+function routeToChild(
+  items: ChatItem[],
+  parentId: string,
+  ev: RawEvent,
+): ChatItem[] {
+  for (let i = items.length - 1; i >= 0; i -= 1) {
+    const it = items[i];
+    if (it.kind !== "tool_call") continue;
+    if (it.id === parentId) {
+      const next = items.slice();
+      next[i] = { ...it, children: reduceTop(it.children ?? [], ev) };
+      return next;
+    }
+    if (it.children && it.children.length > 0) {
+      const updated = routeToChild(it.children, parentId, ev);
+      // routeToChild returns the same array reference when it finds no match,
+      // so an identity change means the parent lived inside these children.
+      if (updated !== it.children) {
+        const next = items.slice();
+        next[i] = { ...it, children: updated };
+        return next;
+      }
+    }
+  }
+  return items;
 }
 
 function handleStreamEvent(prev: ChatItem[], ev: RawEvent): ChatItem[] {

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -25,6 +25,13 @@ export type ChatItem =
       name: string;
       input: unknown;
       streaming?: boolean;
+      /** Sub-conversation produced by a subagent spawned through this tool
+       *  call (Claude's Task/Agent tool). The reducer routes sidechain events
+       *  — those the SDK tags with `parent_tool_use_id === this id` — into a
+       *  nested ChatItem log here instead of the main timeline, so the
+       *  subagent's reasoning/tool use threads under its row rather than
+       *  leaking into the chat. Absent for ordinary tool calls. */
+      children?: ChatItem[];
     }
   | {
       kind: "tool_result";

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -5,25 +5,7 @@ import { applyPolicy, getAdapter } from "../../adapters";
 import { providerLabel } from "../../data/providers";
 import { Composer } from "../Composer";
 import { MessageItem } from "./messages/MessageItem";
-import { pairToolItems, type ViewItem } from "./messages/pair";
-
-/** Stable React key for a rendered row. Tool pairs/results key off their tool
- *  id so a row's expand state stays anchored to the tool rather than to a list
- *  position. Messages and notices have no id and the log is append-only, so
- *  their array index is a stable key — and keying them by text would remount on
- *  every streaming token. */
-function rowKey(item: ViewItem, index: number): string {
-  switch (item.kind) {
-    case "tool_pair":
-      return item.call.id ? `tp:${item.call.id}` : `i:${index}`;
-    // No `tool_call` case: pairToolItems wraps every tool_call into a
-    // tool_pair, so only orphan tool_results reach here standalone.
-    case "tool_result":
-      return item.tool_use_id ? `tr:${item.tool_use_id}` : `i:${index}`;
-    default:
-      return `i:${index}`;
-  }
-}
+import { pairToolItems, rowKey } from "./messages/pair";
 
 /** Custom-view body: scrolling chat log + composer at the bottom.
  *  The composer here dispatches the user's message via the store; it
@@ -127,7 +109,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
             </div>
           ) : (
             items.map((item, i) => (
-              <MessageItem key={rowKey(item, i)} item={item} />
+              <MessageItem key={rowKey(item, i)} item={item} provider={agent.provider} />
             ))
           )}
           {busy && (

--- a/src/components/Workspace/messages/MessageItem.tsx
+++ b/src/components/Workspace/messages/MessageItem.tsx
@@ -1,6 +1,7 @@
 import { Markdown } from "../../Markdown";
 import type { ChatItem } from "../../../store";
-import type { ViewItem } from "./pair";
+import { applyPolicy, getAdapter } from "../../../adapters";
+import { pairToolItems, rowKey, type ViewItem } from "./pair";
 import { ToolResultItem } from "./ToolResultItem";
 import { ToolRow } from "./ToolRow";
 import { getPresenter } from "./presenters";
@@ -9,8 +10,16 @@ import { stripInjectedInstructions } from "../../../util/instructions";
 import { APP_ACTION_PREFIX } from "../../RightPanel/delegation";
 
 /** Dispatcher for one rendered row. Accepts either a raw ChatItem or
- *  the derived `tool_pair` from pairToolItems(). */
-export function MessageItem({ item }: { item: ViewItem }) {
+ *  the derived `tool_pair` from pairToolItems(). `provider` carries the
+ *  agent's adapter id down so nested subagent threads filter/pair their
+ *  rows with the same display policy as the main log. */
+export function MessageItem({
+  item,
+  provider,
+}: {
+  item: ViewItem;
+  provider?: string;
+}) {
   switch (item.kind) {
     case "user_message":
       // App-sent git-action triggers fold into a quiet chip (like slash
@@ -43,13 +52,21 @@ export function MessageItem({ item }: { item: ViewItem }) {
       );
     case "tool_pair": {
       const presenter = getPresenter(item.call.name);
+      const children = item.call.children ?? [];
       return (
         <ToolRow
           name={item.call.name}
           icon={presenter.icon}
           isError={item.result?.is_error}
           summary={presenter.summary(item.call, item.result)}
-          expanded={presenter.expanded(item.call, item.result)}
+          expanded={
+            <>
+              {presenter.expanded(item.call, item.result)}
+              {children.length > 0 && (
+                <SubagentThread items={children} provider={provider} />
+              )}
+            </>
+          }
         />
       );
     }
@@ -72,6 +89,36 @@ export function MessageItem({ item }: { item: ViewItem }) {
     case "notice":
       return <NoticeView item={item} />;
   }
+}
+
+/** A subagent's threaded sub-conversation, rendered inside its spawning
+ *  tool row's expanded body. Runs the children through the same
+ *  policy → pairing → MessageItem pipeline as the main log (so tool calls
+ *  pair with their results and hidden notices stay hidden), nested under a
+ *  quiet left rail. Recurses for subagents that spawn their own subagents. */
+function SubagentThread({
+  items,
+  provider,
+}: {
+  items: ChatItem[];
+  provider?: string;
+}) {
+  const adapter = getAdapter(provider);
+  const rows = pairToolItems(applyPolicy(items, adapter.policy));
+  if (rows.length === 0) return null;
+  return (
+    <div
+      style={{
+        marginTop: 8,
+        paddingLeft: 12,
+        borderLeft: "2px solid var(--accent-line)",
+      }}
+    >
+      {rows.map((row, i) => (
+        <MessageItem key={rowKey(row, i)} item={row} provider={provider} />
+      ))}
+    </div>
+  );
 }
 
 function NoticeView({

--- a/src/components/Workspace/messages/MessageItem.tsx
+++ b/src/components/Workspace/messages/MessageItem.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Markdown } from "../../Markdown";
 import type { ChatItem } from "../../../store";
 import { applyPolicy, getAdapter } from "../../../adapters";
@@ -103,8 +104,12 @@ function SubagentThread({
   items: ChatItem[];
   provider?: string;
 }) {
-  const adapter = getAdapter(provider);
-  const rows = pairToolItems(applyPolicy(items, adapter.policy));
+  // Re-derive only when the children or provider change — not on every parent
+  // re-render (e.g. a streaming token elsewhere in the main log).
+  const rows = useMemo(
+    () => pairToolItems(applyPolicy(items, getAdapter(provider).policy)),
+    [items, provider],
+  );
   if (rows.length === 0) return null;
   return (
     <div

--- a/src/components/Workspace/messages/pair.ts
+++ b/src/components/Workspace/messages/pair.ts
@@ -39,3 +39,21 @@ export function pairToolItems(items: ChatItem[]): ViewItem[] {
 
   return out;
 }
+
+/** Stable React key for a rendered row. Tool pairs/results key off their tool
+ *  id so a row's expand state stays anchored to the tool rather than to a list
+ *  position. Messages and notices have no id and the log is append-only, so
+ *  their array index is a stable key — and keying them by text would remount on
+ *  every streaming token. */
+export function rowKey(item: ViewItem, index: number): string {
+  switch (item.kind) {
+    case "tool_pair":
+      return item.call.id ? `tp:${item.call.id}` : `i:${index}`;
+    // No `tool_call` case: pairToolItems wraps every tool_call into a
+    // tool_pair, so only orphan tool_results reach here standalone.
+    case "tool_result":
+      return item.tool_use_id ? `tr:${item.tool_use_id}` : `i:${index}`;
+    default:
+      return `i:${index}`;
+  }
+}


### PR DESCRIPTION
## Problem

When the main agent spawns a subagent (Task/Agent tool), the subagent's internal prompt/reasoning leaked into the **main chat** as a `user` message bubble while it ran, then disappeared when the subagent finished.

**Root cause.** Claude's `stream-json` tags every event belonging to a subagent with the spawning tool's id via top-level `parent_tool_use_id`. The reducer (`reduce.ts`) never read it, so `handleUser` turned the subagent's prompt into a top-level `user_message`. The appear-then-vanish came from two log builders: the live stream accumulates the bubble, but on reload the log is rebuilt from `session_records`, which is sourced only from the main on-disk transcript — Claude stores subagents in a separate `…/subagents/agent-*.jsonl` the app never ingests (verified: the main file has zero `isSidechain:true` lines).

## Fix (live path, end-to-end)

- **Model** (`types.ts`): `tool_call` gains an optional nested `children: ChatItem[]`.
- **Reducer** (`reduce.ts`): events carrying `parent_tool_use_id` are routed into the spawning `tool_call`'s `children`, reduced with the same top-level logic. Recurses, so a subagent that spawns its own subagent threads correctly. Events whose parent tool_call isn't present yet are dropped (no leak) rather than appended to the main log.
- **Renderer** (`MessageItem.tsx`): the tool row renders the subagent's sub-conversation inside its expanded body via the same `applyPolicy → pairToolItems → MessageItem` pipeline, behind a quiet left rail. `provider` is threaded down so nested rows filter/pair with the same policy.
- **DRY**: `rowKey` moved from `ChatView` into `pair.ts`, shared by the main list and the nested thread.

## Tests

Added reducer coverage: sidechain events nest under the tool_call (not the main log), unmatched-parent events are dropped, and nested subagents thread one level deeper. Full suite: 226 passing, clean `tsc`.

## Follow-up (not in this PR)

Reload parity — ingesting the on-disk `subagents/*.jsonl` + `.meta.json` (whose `toolUseId` links back to the parent Agent call) so the thread survives a transcript rebuild. That needs the Rust single-file tail-sync (`agent.rs`/`supervisor.rs`) to handle multiple growing files, a larger change. Reload does not currently leak, so this is an enhancement rather than a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)