### PR TITLE
feat: add TaskCreate tool call presenter

### DIFF
--- a/src/components/Workspace/messages/presenters/TaskCreate.tsx
+++ b/src/components/Workspace/messages/presenters/TaskCreate.tsx
@@ -1,0 +1,92 @@
+import { Markdown } from "../../../Markdown";
+import type { ToolPresenter } from "./types";
+import { ToolBlock, getStringField, renderToolResult } from "./util";
+
+/** Pull a metadata object off the input bag, if present and non-empty. */
+function getMetadata(input: unknown): Record<string, unknown> | null {
+  if (input && typeof input === "object" && "metadata" in input) {
+    const v = (input as Record<string, unknown>).metadata;
+    if (v && typeof v === "object" && Object.keys(v).length > 0) {
+      return v as Record<string, unknown>;
+    }
+  }
+  return null;
+}
+
+/** Extract the created task number from a result like
+ *  "Task #4 created successfully: …". Returns "" when not found. */
+function getTaskNumber(
+  result: { content: unknown; is_error?: boolean } | null,
+): string {
+  if (!result || result.is_error) return "";
+  const match = renderToolResult(result.content).match(/#(\d+)/);
+  return match ? `#${match[1]}` : "";
+}
+
+export const taskCreatePresenter: ToolPresenter = {
+  icon: "check",
+  summary: (call, result) => {
+    const subject = getStringField(call.input, "subject");
+    const number = getTaskNumber(result);
+    return (
+      <>
+        {number && (
+          <span style={{ color: "var(--fg-3)", marginRight: 8 }}>{number}</span>
+        )}
+        {subject || "(untitled task)"}
+      </>
+    );
+  },
+  expanded: (call, result) => {
+    const description = getStringField(call.input, "description");
+    const activeForm = getStringField(call.input, "activeForm");
+    const metadata = getMetadata(call.input);
+    return (
+      <>
+        {description && (
+          <blockquote
+            style={{
+              margin: "0 0 12px",
+              padding: "4px 0 4px 14px",
+              color: "var(--fg-2)",
+              borderLeft: "2px solid var(--accent-line)",
+              fontSize: 13.5,
+              lineHeight: 1.6,
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
+            }}
+          >
+            {description}
+          </blockquote>
+        )}
+        {activeForm && (
+          <div
+            style={{
+              marginBottom: metadata || result ? 12 : 0,
+              color: "var(--fg-3)",
+              fontSize: 13,
+            }}
+          >
+            ⟳ {activeForm}
+          </div>
+        )}
+        {metadata && (
+          <ToolBlock label="metadata">
+            {JSON.stringify(metadata, null, 2)}
+          </ToolBlock>
+        )}
+        {result && (
+          <div
+            className={result.is_error ? "m-agent" : "m-agent m-agent-dim"}
+            style={{
+              color: result.is_error ? "var(--danger)" : undefined,
+              fontSize: 13.5,
+            }}
+          >
+            <Markdown>{renderToolResult(result.content)}</Markdown>
+          </div>
+        )}
+      </>
+    );
+  },
+};

--- a/src/components/Workspace/messages/presenters/index.ts
+++ b/src/components/Workspace/messages/presenters/index.ts
@@ -7,6 +7,7 @@ import { multiEditPresenter } from "./MultiEdit";
 import { writePresenter } from "./Write";
 import { grepPresenter } from "./Grep";
 import { globPresenter } from "./Glob";
+import { taskCreatePresenter } from "./TaskCreate";
 import { defaultPresenter } from "./default";
 
 export type { ToolPresenter, ToolCall, ToolResult } from "./types";
@@ -22,6 +23,7 @@ export const PRESENTERS: Record<string, ToolPresenter> = {
   Write: writePresenter,
   Grep: grepPresenter,
   Glob: globPresenter,
+  TaskCreate: taskCreatePresenter,
 };
 
 // Look up on the lowercased tool name so adapters that report the same tool


### PR DESCRIPTION
Adds a dedicated presenter for `TaskCreate` tool calls, mirroring the existing `Agent` presenter pattern. The collapsed row shows the task `subject` prefixed with a muted task-number badge (e.g. `#4`) parsed from the result string, while the expanded view renders the `description` as a quoted block, the optional `activeForm` as a muted spinner-label line, optional `metadata` as a JSON block, and the result (red on error). All fields are read defensively, so missing input never breaks rendering, and the presenter is registered under `TaskCreate` in the presenter registry. No CSS changes — it reuses existing CSS vars and sibling presenter styles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)