### PR TITLE
feat: rich "Needs your input" widget for agent questions

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -1013,18 +1013,6 @@ impl Agent {
         }
     }
 
-    /// Answer a paused tool call by injecting a `tool_result`. Only the managed
-    /// (Claude stream-json) transport pauses on tools this way; the per-turn and
-    /// PTY agents run fully auto-approved and never surface such a prompt.
-    pub fn send_tool_result(&self, tool_use_id: &str, content: &str) -> Result<()> {
-        match self {
-            Self::Managed(a) => a.session.send_tool_result(tool_use_id, content),
-            Self::PerTurn(_) | Self::Pty(_) => Err(Error::Other(
-                "send_tool_result is only supported for managed agents".into(),
-            )),
-        }
-    }
-
     /// Interrupt the agent's current turn without terminating the process.
     /// For PTY agents this writes Ctrl+C; for managed agents this sends SIGINT.
     pub fn interrupt(&self) {

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -1013,6 +1013,23 @@ impl Agent {
         }
     }
 
+    /// Answer a held question-tool prompt (Claude's `AskUserQuestion`) by
+    /// delivering the user's selection as the tool result. Only the managed
+    /// (Claude stream-json) transport pauses on tools this way; per-turn and
+    /// PTY agents run fully auto-approved and never surface such a prompt.
+    pub fn answer_tool_use(
+        &self,
+        request_id: &str,
+        updated_input: serde_json::Value,
+    ) -> Result<()> {
+        match self {
+            Self::Managed(a) => a.session.answer_tool_use(request_id, updated_input),
+            Self::PerTurn(_) | Self::Pty(_) => Err(Error::Other(
+                "answer_tool_use is only supported for managed agents".into(),
+            )),
+        }
+    }
+
     /// Interrupt the agent's current turn without terminating the process.
     /// For PTY agents this writes Ctrl+C; for managed agents this sends SIGINT.
     pub fn interrupt(&self) {
@@ -1128,6 +1145,13 @@ fn prepare_managed_args(
     // over stdio. --verbose is required when using stream-json output
     // so events keep flowing. --include-partial-messages emits
     // incremental assistant text deltas for a responsive UI.
+    //
+    // `--permission-mode default --permission-prompt-tool stdio` (instead of
+    // `bypassPermissions`) routes every tool through a `can_use_tool` control
+    // request on stdio. `ManagedSession` auto-approves all of them except the
+    // question tools, which it holds open so the user actually answers — see
+    // managed_session.rs. `bypassPermissions` can't do this: it auto-denies
+    // AskUserQuestion before the client is consulted.
     let mut args: Vec<String> = vec![
         "-f".into(),
         profile_path,
@@ -1139,9 +1163,10 @@ fn prepare_managed_args(
         "stream-json".into(),
         "--verbose".into(),
         "--include-partial-messages".into(),
-        "--dangerously-skip-permissions".into(),
         "--permission-mode".into(),
-        "bypassPermissions".into(),
+        "default".into(),
+        "--permission-prompt-tool".into(),
+        "stdio".into(),
     ];
     args.extend(effort_args(spec.effort));
     args.extend(instructions::append_system_prompt_args());

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -24,7 +24,7 @@ use crate::activity::{Activity, ManagedActivity};
 use crate::error::{Error, Result};
 use crate::exec_session::{ExecCallbacks, ExecSession, ExecSpawn};
 use crate::instructions;
-use crate::managed_session::{ManagedExit, ManagedSession, ManagedSpawn};
+use crate::managed_session::{ManagedExit, ManagedSession, ManagedSpawn, ToolUseBehavior};
 use crate::pty_session::{PtyExit, PtySession, PtySpawn};
 use crate::sandbox;
 
@@ -38,6 +38,7 @@ pub enum Agent {
     /// sandboxes itself, so there's no sandbox-exec profile.
     PerTurn(PerTurnAgent),
 }
+
 
 pub struct PtyAgent {
     pty: PtySession,
@@ -1013,17 +1014,21 @@ impl Agent {
         }
     }
 
-    /// Answer a held question-tool prompt (Claude's `AskUserQuestion`) by
-    /// delivering the user's selection as the tool result. Only the managed
+    /// Answer a held user-input prompt (`AskUserQuestion` / `ExitPlanMode`) by
+    /// delivering the user's selection as a control response. Only the managed
     /// (Claude stream-json) transport pauses on tools this way; per-turn and
     /// PTY agents run fully auto-approved and never surface such a prompt.
     pub fn answer_tool_use(
         &self,
         request_id: &str,
         updated_input: serde_json::Value,
+        behavior: ToolUseBehavior,
+        message: Option<String>,
     ) -> Result<()> {
         match self {
-            Self::Managed(a) => a.session.answer_tool_use(request_id, updated_input),
+            Self::Managed(a) => a
+                .session
+                .answer_tool_use(request_id, updated_input, behavior, message),
             Self::PerTurn(_) | Self::Pty(_) => Err(Error::Other(
                 "answer_tool_use is only supported for managed agents".into(),
             )),
@@ -1894,4 +1899,3 @@ mod tests {
         }
     }
 }
-

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -1013,6 +1013,18 @@ impl Agent {
         }
     }
 
+    /// Answer a paused tool call by injecting a `tool_result`. Only the managed
+    /// (Claude stream-json) transport pauses on tools this way; the per-turn and
+    /// PTY agents run fully auto-approved and never surface such a prompt.
+    pub fn send_tool_result(&self, tool_use_id: &str, content: &str) -> Result<()> {
+        match self {
+            Self::Managed(a) => a.session.send_tool_result(tool_use_id, content),
+            Self::PerTurn(_) | Self::Pty(_) => Err(Error::Other(
+                "send_tool_result is only supported for managed agents".into(),
+            )),
+        }
+    }
+
     /// Interrupt the agent's current turn without terminating the process.
     /// For PTY agents this writes Ctrl+C; for managed agents this sends SIGINT.
     pub fn interrupt(&self) {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -180,6 +180,18 @@ pub fn send_user_message(
 }
 
 #[tauri::command]
+pub fn send_tool_result(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+    tool_use_id: String,
+    content: String,
+) -> Result<()> {
+    supervisor
+        .inner()
+        .send_tool_result(&agent_id, &tool_use_id, &content)
+}
+
+#[tauri::command]
 pub fn resize_agent(
     supervisor: State<'_, Arc<Supervisor>>,
     agent_id: String,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -180,18 +180,6 @@ pub fn send_user_message(
 }
 
 #[tauri::command]
-pub fn send_tool_result(
-    supervisor: State<'_, Arc<Supervisor>>,
-    agent_id: String,
-    tool_use_id: String,
-    content: String,
-) -> Result<()> {
-    supervisor
-        .inner()
-        .send_tool_result(&agent_id, &tool_use_id, &content)
-}
-
-#[tauri::command]
 pub fn resize_agent(
     supervisor: State<'_, Arc<Supervisor>>,
     agent_id: String,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -12,6 +12,7 @@ use crate::gh::{self, GhRepoSummary, GhStatus, PrState};
 use crate::git;
 use crate::new_project;
 use crate::git_state::{self, FileStatus, GitState, ShortStats, StatusKind};
+use crate::managed_session::ToolUseBehavior;
 use crate::names;
 use crate::run_session::RunStateSnapshot;
 use crate::supervisor::Supervisor;
@@ -185,10 +186,12 @@ pub fn answer_tool_use(
     agent_id: String,
     request_id: String,
     updated_input: serde_json::Value,
+    behavior: ToolUseBehavior,
+    message: Option<String>,
 ) -> Result<()> {
     supervisor
         .inner()
-        .answer_tool_use(&agent_id, &request_id, updated_input)
+        .answer_tool_use(&agent_id, &request_id, updated_input, behavior, message)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -180,6 +180,18 @@ pub fn send_user_message(
 }
 
 #[tauri::command]
+pub fn answer_tool_use(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+    request_id: String,
+    updated_input: serde_json::Value,
+) -> Result<()> {
+    supervisor
+        .inner()
+        .answer_tool_use(&agent_id, &request_id, updated_input)
+}
+
+#[tauri::command]
 pub fn resize_agent(
     supervisor: State<'_, Arc<Supervisor>>,
     agent_id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -163,6 +163,7 @@ pub fn run() {
             commands::spawn_agent,
             commands::write_to_agent,
             commands::send_user_message,
+            commands::answer_tool_use,
             commands::resize_agent,
             commands::switch_view,
             commands::resume_agent,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -163,7 +163,6 @@ pub fn run() {
             commands::spawn_agent,
             commands::write_to_agent,
             commands::send_user_message,
-            commands::send_tool_result,
             commands::resize_agent,
             commands::switch_view,
             commands::resume_agent,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -163,6 +163,7 @@ pub fn run() {
             commands::spawn_agent,
             commands::write_to_agent,
             commands::send_user_message,
+            commands::send_tool_result,
             commands::resize_agent,
             commands::switch_view,
             commands::resume_agent,

--- a/src-tauri/src/managed_session.rs
+++ b/src-tauri/src/managed_session.rs
@@ -3,8 +3,25 @@
 //! Launches `claude --print` with `--input-format stream-json` and
 //! `--output-format stream-json` so the app owns the input box and
 //! renders structured events instead of raw terminal bytes.
+//!
+//! ## Permission control protocol
+//!
+//! We run Claude in `--permission-mode default --permission-prompt-tool stdio`
+//! (not `bypassPermissions`). In that mode the CLI does not execute a tool
+//! until the client approves it: it writes a `control_request`
+//! (`subtype: "can_use_tool"`) to stdout and blocks until we write a matching
+//! `control_response` to stdin. We auto-approve every tool the instant it
+//! arrives — preserving the prior fully-headless "run without nagging" feel —
+//! **except** the question tools (`AskUserQuestion`), which we hold open and
+//! surface to the UI so the human actually answers. Holding the response is
+//! the real pause: the agent's turn is suspended until `answer_tool_use`
+//! delivers the user's selection as the tool result.
+//!
+//! `bypassPermissions` cannot do this — it short-circuits the permission flow
+//! and auto-denies `AskUserQuestion` before the client ever sees it.
 
 use parking_lot::Mutex;
+use std::collections::HashSet;
 use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
 use std::process::{Child, ChildStdin, Command, Stdio};
@@ -16,9 +33,18 @@ use serde_json::{json, Value};
 
 use crate::error::{Error, Result};
 
+/// Tools whose `can_use_tool` request we hold open for a human answer instead
+/// of auto-approving. Everything else runs unattended.
+const HOLD_TOOLS: &[&str] = &["AskUserQuestion"];
+
+type Stdin = Arc<Mutex<Option<ChildStdin>>>;
+
 pub struct ManagedSession {
     child: Arc<Mutex<Option<Child>>>,
-    stdin: Arc<Mutex<Option<ChildStdin>>>,
+    stdin: Stdin,
+    /// `request_id`s of `can_use_tool` prompts we're holding open, awaiting a
+    /// human answer. Drained on interrupt so the turn can unwind.
+    pending: Arc<Mutex<HashSet<String>>>,
 }
 
 pub struct ManagedSpawn<'a> {
@@ -70,15 +96,44 @@ impl ManagedSession {
             .ok_or_else(|| Error::Other("managed: child stdin missing".into()))?;
 
         let child_arc = Arc::new(Mutex::new(Some(child)));
-        let stdin_arc = Arc::new(Mutex::new(Some(stdin)));
+        let stdin_arc: Stdin = Arc::new(Mutex::new(Some(stdin)));
+        let pending: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
 
+        // Establish the control channel so the CLI routes permission prompts to
+        // us (rather than auto-denying). The reply (request_id "quorum-init")
+        // comes back as a control_response, which the reader drops.
+        let _ = write_line(
+            &stdin_arc,
+            json!({
+                "type": "control_request",
+                "request_id": "quorum-init",
+                "request": { "subtype": "initialize", "hooks": {} }
+            }),
+        );
+
+        let stdin_for_reader = stdin_arc.clone();
+        let pending_for_reader = pending.clone();
         thread::spawn(move || {
             let reader = BufReader::new(stdout);
             for line in reader.lines() {
                 match line {
                     Ok(l) if l.trim().is_empty() => continue,
                     Ok(l) => match serde_json::from_str::<Value>(&l) {
-                        Ok(v) => on_event(v),
+                        Ok(v) => {
+                            match v.get("type").and_then(Value::as_str) {
+                                // Permission gate from the CLI: respond on stdin.
+                                Some("control_request") => handle_control_request(
+                                    &stdin_for_reader,
+                                    &pending_for_reader,
+                                    &on_event,
+                                    v,
+                                ),
+                                // Reply to a request we sent (e.g. initialize) —
+                                // control plane, never a transcript event.
+                                Some("control_response") => {}
+                                _ => on_event(v),
+                            }
+                        }
                         Err(e) => {
                             tracing::warn!(error = %e, raw = %l, "managed: bad json line");
                         }
@@ -148,6 +203,7 @@ impl ManagedSession {
         Ok(Self {
             child: child_arc,
             stdin: stdin_arc,
+            pending,
         })
     }
 
@@ -162,39 +218,31 @@ impl ManagedSession {
         for path in attachments {
             content.push(json!({"type": "text", "text": format!("Attached file: {path}")}));
         }
-        self.write_envelope(json!({
-            "type": "user",
-            "message": {
-                "role": "user",
-                "content": content
-            }
-        }))
+        write_line(
+            &self.stdin,
+            json!({
+                "type": "user",
+                "message": { "role": "user", "content": content }
+            }),
+        )
     }
 
-    /// Serialize one stream-json envelope as a newline-delimited line to the
-    /// agent's stdin.
-    fn write_envelope(&self, envelope: serde_json::Value) -> Result<()> {
-        let mut line = envelope.to_string();
-        line.push('\n');
-
-        let mut guard = self.stdin.lock();
-        let stdin = guard
-            .as_mut()
-            .ok_or_else(|| Error::Other("managed: stdin closed".into()))?;
-        stdin
-            .write_all(line.as_bytes())
-            .map_err(|e| Error::Other(format!("managed write: {e}")))?;
-        stdin
-            .flush()
-            .map_err(|e| Error::Other(format!("managed flush: {e}")))
+    /// Answer a held `can_use_tool` prompt (the question tools). `updated_input`
+    /// is the tool's input with the user's `answers` merged in; the CLI feeds it
+    /// back to the model as the tool result and resumes the turn.
+    pub fn answer_tool_use(&self, request_id: &str, updated_input: Value) -> Result<()> {
+        self.pending.lock().remove(request_id);
+        write_line(&self.stdin, allow_response(request_id, updated_input))
     }
 
     /// Send SIGINT to the child process to interrupt the current turn
-    /// without killing it. Claude in stream-json mode handles SIGINT by
-    /// aborting the current turn and emitting a result event, then
-    /// returning to idle. If the process does not survive SIGINT the
-    /// exit handler will transition the agent to Idle automatically.
+    /// without killing it. First releases any held permission prompts (denied),
+    /// so a turn paused on a question can unwind rather than hang.
     pub fn interrupt(&self) {
+        let held: Vec<String> = self.pending.lock().drain().collect();
+        for rid in held {
+            let _ = write_line(&self.stdin, deny_response(&rid, "Interrupted by user"));
+        }
         #[cfg(unix)]
         {
             use nix::sys::signal::{kill, Signal};
@@ -221,5 +269,127 @@ impl ManagedSession {
 impl Drop for ManagedSession {
     fn drop(&mut self) {
         let _ = self.kill();
+    }
+}
+
+/// Decide what to do with one `can_use_tool` request and act on it: auto-approve
+/// ordinary tools immediately, or hold the question tools open for the user
+/// (recording the `request_id` and surfacing the request to the UI). Non-tool
+/// control requests (hook/mcp callbacks, which we never register) are
+/// acknowledged so the agent never stalls waiting on us.
+fn handle_control_request<F: Fn(Value)>(
+    stdin: &Stdin,
+    pending: &Arc<Mutex<HashSet<String>>>,
+    on_event: &F,
+    v: Value,
+) {
+    let request_id = v
+        .get("request_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let req = v.get("request");
+    let subtype = req
+        .and_then(|r| r.get("subtype"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+
+    if subtype == "can_use_tool" {
+        let tool = req
+            .and_then(|r| r.get("tool_name"))
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if HOLD_TOOLS.contains(&tool) {
+            // The real pause: don't respond. Record it and hand the request to
+            // the UI, which answers via `answer_tool_use`.
+            pending.lock().insert(request_id);
+            on_event(v);
+        } else {
+            let input = req
+                .and_then(|r| r.get("input"))
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+            let _ = write_line(stdin, allow_response(&request_id, input));
+        }
+    } else {
+        // hook_callback / mcp_message / unknown — we register neither hooks nor
+        // SDK MCP servers, so this is unexpected; ack so the turn keeps moving.
+        tracing::warn!(subtype, "managed: unexpected control_request, acking");
+        let _ = write_line(
+            stdin,
+            json!({
+                "type": "control_response",
+                "response": { "subtype": "success", "request_id": request_id, "response": {} }
+            }),
+        );
+    }
+}
+
+fn allow_response(request_id: &str, updated_input: Value) -> Value {
+    json!({
+        "type": "control_response",
+        "response": {
+            "subtype": "success",
+            "request_id": request_id,
+            "response": { "behavior": "allow", "updatedInput": updated_input }
+        }
+    })
+}
+
+fn deny_response(request_id: &str, message: &str) -> Value {
+    json!({
+        "type": "control_response",
+        "response": {
+            "subtype": "success",
+            "request_id": request_id,
+            "response": { "behavior": "deny", "message": message }
+        }
+    })
+}
+
+/// Serialize one stream-json envelope as a newline-delimited line to the
+/// agent's stdin.
+fn write_line(stdin: &Stdin, value: Value) -> Result<()> {
+    let mut line = value.to_string();
+    line.push('\n');
+
+    let mut guard = stdin.lock();
+    let stdin = guard
+        .as_mut()
+        .ok_or_else(|| Error::Other("managed: stdin closed".into()))?;
+    stdin
+        .write_all(line.as_bytes())
+        .map_err(|e| Error::Other(format!("managed write: {e}")))?;
+    stdin
+        .flush()
+        .map_err(|e| Error::Other(format!("managed flush: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn holds_only_question_tools() {
+        assert!(HOLD_TOOLS.contains(&"AskUserQuestion"));
+        assert!(!HOLD_TOOLS.contains(&"Bash"));
+        assert!(!HOLD_TOOLS.contains(&"Edit"));
+    }
+
+    #[test]
+    fn allow_response_shape() {
+        let v = allow_response("req-1", json!({"questions": [], "answers": {"q": "a"}}));
+        assert_eq!(v["type"], "control_response");
+        assert_eq!(v["response"]["subtype"], "success");
+        assert_eq!(v["response"]["request_id"], "req-1");
+        assert_eq!(v["response"]["response"]["behavior"], "allow");
+        assert_eq!(v["response"]["response"]["updatedInput"]["answers"]["q"], "a");
+    }
+
+    #[test]
+    fn deny_response_shape() {
+        let v = deny_response("req-2", "nope");
+        assert_eq!(v["response"]["response"]["behavior"], "deny");
+        assert_eq!(v["response"]["response"]["message"], "nope");
     }
 }

--- a/src-tauri/src/managed_session.rs
+++ b/src-tauri/src/managed_session.rs
@@ -29,6 +29,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
+use serde::Deserialize;
 use serde_json::{json, Value};
 
 use crate::error::{Error, Result};
@@ -38,6 +39,13 @@ use crate::error::{Error, Result};
 const HOLD_TOOLS: &[&str] = &["AskUserQuestion", "ExitPlanMode"];
 
 type Stdin = Arc<Mutex<Option<ChildStdin>>>;
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ToolUseBehavior {
+    Allow,
+    Deny,
+}
 
 pub struct ManagedSession {
     child: Arc<Mutex<Option<Child>>>,
@@ -230,7 +238,13 @@ impl ManagedSession {
     /// Answer a held `can_use_tool` prompt (the question tools). `updated_input`
     /// is the tool's input with the user's `answers` merged in; the CLI feeds it
     /// back to the model as the tool result and resumes the turn.
-    pub fn answer_tool_use(&self, request_id: &str, updated_input: Value) -> Result<()> {
+    pub fn answer_tool_use(
+        &self,
+        request_id: &str,
+        updated_input: Value,
+        behavior: ToolUseBehavior,
+        message: Option<String>,
+    ) -> Result<()> {
         if !self.pending.lock().remove(request_id) {
             tracing::debug!(
                 request_id,
@@ -238,7 +252,13 @@ impl ManagedSession {
             );
             return Ok(());
         }
-        write_line(&self.stdin, allow_response(request_id, updated_input))
+        let response = match behavior {
+            ToolUseBehavior::Allow => allow_response(request_id, updated_input),
+            ToolUseBehavior::Deny => {
+                deny_response(request_id, message.as_deref().unwrap_or("Denied by user"))
+            }
+        };
+        write_line(&self.stdin, response)
     }
 
     /// Send SIGINT to the child process to interrupt the current turn
@@ -391,7 +411,26 @@ mod tests {
             pending: Arc::new(Mutex::new(HashSet::new())),
         };
 
-        assert!(session.answer_tool_use("already-drained", json!({})).is_ok());
+        assert!(session
+            .answer_tool_use(
+                "already-drained",
+                json!({}),
+                ToolUseBehavior::Allow,
+                None,
+            )
+            .is_ok());
+    }
+
+    #[test]
+    fn tool_use_behavior_deserializes_from_ipc_strings() {
+        assert_eq!(
+            serde_json::from_value::<ToolUseBehavior>(json!("allow")).unwrap(),
+            ToolUseBehavior::Allow
+        );
+        assert_eq!(
+            serde_json::from_value::<ToolUseBehavior>(json!("deny")).unwrap(),
+            ToolUseBehavior::Deny
+        );
     }
 
     #[test]

--- a/src-tauri/src/managed_session.rs
+++ b/src-tauri/src/managed_session.rs
@@ -12,10 +12,10 @@
 //! (`subtype: "can_use_tool"`) to stdout and blocks until we write a matching
 //! `control_response` to stdin. We auto-approve every tool the instant it
 //! arrives — preserving the prior fully-headless "run without nagging" feel —
-//! **except** the question tools (`AskUserQuestion`), which we hold open and
-//! surface to the UI so the human actually answers. Holding the response is
-//! the real pause: the agent's turn is suspended until `answer_tool_use`
-//! delivers the user's selection as the tool result.
+//! **except** the user-input tools (`AskUserQuestion`, `ExitPlanMode`), which
+//! we hold open and surface to the UI so the human actually answers. Holding
+//! the response is the real pause: the agent's turn is suspended until
+//! `answer_tool_use` delivers the user's selection as the tool result.
 //!
 //! `bypassPermissions` cannot do this — it short-circuits the permission flow
 //! and auto-denies `AskUserQuestion` before the client ever sees it.
@@ -35,7 +35,7 @@ use crate::error::{Error, Result};
 
 /// Tools whose `can_use_tool` request we hold open for a human answer instead
 /// of auto-approving. Everything else runs unattended.
-const HOLD_TOOLS: &[&str] = &["AskUserQuestion"];
+const HOLD_TOOLS: &[&str] = &["AskUserQuestion", "ExitPlanMode"];
 
 type Stdin = Arc<Mutex<Option<ChildStdin>>>;
 
@@ -231,7 +231,13 @@ impl ManagedSession {
     /// is the tool's input with the user's `answers` merged in; the CLI feeds it
     /// back to the model as the tool result and resumes the turn.
     pub fn answer_tool_use(&self, request_id: &str, updated_input: Value) -> Result<()> {
-        self.pending.lock().remove(request_id);
+        if !self.pending.lock().remove(request_id) {
+            tracing::debug!(
+                request_id,
+                "managed: ignoring answer for non-pending tool request"
+            );
+            return Ok(());
+        }
         write_line(&self.stdin, allow_response(request_id, updated_input))
     }
 
@@ -372,8 +378,20 @@ mod tests {
     #[test]
     fn holds_only_question_tools() {
         assert!(HOLD_TOOLS.contains(&"AskUserQuestion"));
+        assert!(HOLD_TOOLS.contains(&"ExitPlanMode"));
         assert!(!HOLD_TOOLS.contains(&"Bash"));
         assert!(!HOLD_TOOLS.contains(&"Edit"));
+    }
+
+    #[test]
+    fn stale_tool_answer_does_not_write() {
+        let session = ManagedSession {
+            child: Arc::new(Mutex::new(None)),
+            stdin: Arc::new(Mutex::new(None)),
+            pending: Arc::new(Mutex::new(HashSet::new())),
+        };
+
+        assert!(session.answer_tool_use("already-drained", json!({})).is_ok());
     }
 
     #[test]

--- a/src-tauri/src/managed_session.rs
+++ b/src-tauri/src/managed_session.rs
@@ -171,24 +171,6 @@ impl ManagedSession {
         }))
     }
 
-    /// Answer a tool the agent paused on (Claude's `AskUserQuestion` /
-    /// `ExitPlanMode`) by writing a `tool_result` block keyed to its
-    /// `tool_use_id`. In stream-json mode the SDK leaves the tool_use open
-    /// until this arrives, so a plain user message would not unblock the turn.
-    pub fn send_tool_result(&self, tool_use_id: &str, content: &str) -> Result<()> {
-        self.write_envelope(json!({
-            "type": "user",
-            "message": {
-                "role": "user",
-                "content": [{
-                    "type": "tool_result",
-                    "tool_use_id": tool_use_id,
-                    "content": content,
-                }]
-            }
-        }))
-    }
-
     /// Serialize one stream-json envelope as a newline-delimited line to the
     /// agent's stdin.
     fn write_envelope(&self, envelope: serde_json::Value) -> Result<()> {

--- a/src-tauri/src/managed_session.rs
+++ b/src-tauri/src/managed_session.rs
@@ -162,13 +162,36 @@ impl ManagedSession {
         for path in attachments {
             content.push(json!({"type": "text", "text": format!("Attached file: {path}")}));
         }
-        let envelope = json!({
+        self.write_envelope(json!({
             "type": "user",
             "message": {
                 "role": "user",
                 "content": content
             }
-        });
+        }))
+    }
+
+    /// Answer a tool the agent paused on (Claude's `AskUserQuestion` /
+    /// `ExitPlanMode`) by writing a `tool_result` block keyed to its
+    /// `tool_use_id`. In stream-json mode the SDK leaves the tool_use open
+    /// until this arrives, so a plain user message would not unblock the turn.
+    pub fn send_tool_result(&self, tool_use_id: &str, content: &str) -> Result<()> {
+        self.write_envelope(json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "content": content,
+                }]
+            }
+        }))
+    }
+
+    /// Serialize one stream-json envelope as a newline-delimited line to the
+    /// agent's stdin.
+    fn write_envelope(&self, envelope: serde_json::Value) -> Result<()> {
         let mut line = envelope.to_string();
         line.push('\n');
 

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -13,6 +13,7 @@ use crate::agent::{capabilities, per_turn_descriptor, Agent, PerTurnSpec, SpawnS
 use crate::branding;
 use crate::error::{Error, Result};
 use crate::git;
+use crate::managed_session::ToolUseBehavior;
 use crate::pty_session::{PtySession, PtySpawn};
 use crate::rpc;
 use crate::run_session::{
@@ -849,19 +850,21 @@ impl Supervisor {
         Ok(())
     }
 
-    /// Deliver the user's answer to a held question-tool prompt (Claude's
-    /// `AskUserQuestion`) as the tool result, unblocking the paused turn.
+    /// Deliver the user's answer to a held user-input prompt as a control
+    /// response, unblocking the paused turn.
     pub fn answer_tool_use(
         &self,
         agent_id: &str,
         request_id: &str,
         updated_input: serde_json::Value,
+        behavior: ToolUseBehavior,
+        message: Option<String>,
     ) -> Result<()> {
         let agents = self.agents.lock();
         let agent = agents
             .get(agent_id)
             .ok_or_else(|| Error::AgentNotFound(agent_id.to_string()))?;
-        agent.answer_tool_use(request_id, updated_input)
+        agent.answer_tool_use(request_id, updated_input, behavior, message)
     }
 
     pub fn resize_agent(&self, agent_id: &str, cols: u16, rows: u16) -> Result<()> {

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -849,23 +849,6 @@ impl Supervisor {
         Ok(())
     }
 
-    /// Deliver a user's answer to a paused tool call (Claude's
-    /// `AskUserQuestion` / `ExitPlanMode`) as a `tool_result` on the agent's
-    /// stdin. The agent's transcript records the injected result, so — unlike
-    /// `send_user_message` — there is no separate durable turn row to write.
-    pub fn send_tool_result(
-        &self,
-        agent_id: &str,
-        tool_use_id: &str,
-        content: &str,
-    ) -> Result<()> {
-        let agents = self.agents.lock();
-        let agent = agents
-            .get(agent_id)
-            .ok_or_else(|| Error::AgentNotFound(agent_id.to_string()))?;
-        agent.send_tool_result(tool_use_id, content)
-    }
-
     pub fn resize_agent(&self, agent_id: &str, cols: u16, rows: u16) -> Result<()> {
         let agents = self.agents.lock();
         let agent = agents

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -849,6 +849,21 @@ impl Supervisor {
         Ok(())
     }
 
+    /// Deliver the user's answer to a held question-tool prompt (Claude's
+    /// `AskUserQuestion`) as the tool result, unblocking the paused turn.
+    pub fn answer_tool_use(
+        &self,
+        agent_id: &str,
+        request_id: &str,
+        updated_input: serde_json::Value,
+    ) -> Result<()> {
+        let agents = self.agents.lock();
+        let agent = agents
+            .get(agent_id)
+            .ok_or_else(|| Error::AgentNotFound(agent_id.to_string()))?;
+        agent.answer_tool_use(request_id, updated_input)
+    }
+
     pub fn resize_agent(&self, agent_id: &str, cols: u16, rows: u16) -> Result<()> {
         let agents = self.agents.lock();
         let agent = agents

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -849,6 +849,23 @@ impl Supervisor {
         Ok(())
     }
 
+    /// Deliver a user's answer to a paused tool call (Claude's
+    /// `AskUserQuestion` / `ExitPlanMode`) as a `tool_result` on the agent's
+    /// stdin. The agent's transcript records the injected result, so — unlike
+    /// `send_user_message` — there is no separate durable turn row to write.
+    pub fn send_tool_result(
+        &self,
+        agent_id: &str,
+        tool_use_id: &str,
+        content: &str,
+    ) -> Result<()> {
+        let agents = self.agents.lock();
+        let agent = agents
+            .get(agent_id)
+            .ok_or_else(|| Error::AgentNotFound(agent_id.to_string()))?;
+        agent.send_tool_result(tool_use_id, content)
+    }
+
     pub fn resize_agent(&self, agent_id: &str, cols: u16, rows: u16) -> Result<()> {
         let agents = self.agents.lock();
         let agent = agents

--- a/src/api.ts
+++ b/src/api.ts
@@ -359,8 +359,20 @@ export const api = {
       attachments,
       thinking: thinking ?? null,
     }),
-  answerToolUse: (agentId: string, requestId: string, updatedInput: unknown) =>
-    invoke<void>("answer_tool_use", { agentId, requestId, updatedInput }),
+  answerToolUse: (
+    agentId: string,
+    requestId: string,
+    updatedInput: unknown,
+    behavior: "allow" | "deny" = "allow",
+    message?: string,
+  ) =>
+    invoke<void>("answer_tool_use", {
+      agentId,
+      requestId,
+      updatedInput,
+      behavior,
+      message: message ?? null,
+    }),
   resizeAgent: (agentId: string, cols: number, rows: number) =>
     invoke<void>("resize_agent", { agentId, cols, rows }),
   switchView: (agentId: string, view: AgentView) =>

--- a/src/api.ts
+++ b/src/api.ts
@@ -359,8 +359,6 @@ export const api = {
       attachments,
       thinking: thinking ?? null,
     }),
-  sendToolResult: (agentId: string, toolUseId: string, content: string) =>
-    invoke<void>("send_tool_result", { agentId, toolUseId, content }),
   resizeAgent: (agentId: string, cols: number, rows: number) =>
     invoke<void>("resize_agent", { agentId, cols, rows }),
   switchView: (agentId: string, view: AgentView) =>

--- a/src/api.ts
+++ b/src/api.ts
@@ -359,6 +359,8 @@ export const api = {
       attachments,
       thinking: thinking ?? null,
     }),
+  sendToolResult: (agentId: string, toolUseId: string, content: string) =>
+    invoke<void>("send_tool_result", { agentId, toolUseId, content }),
   resizeAgent: (agentId: string, cols: number, rows: number) =>
     invoke<void>("resize_agent", { agentId, cols, rows }),
   switchView: (agentId: string, view: AgentView) =>

--- a/src/api.ts
+++ b/src/api.ts
@@ -359,6 +359,8 @@ export const api = {
       attachments,
       thinking: thinking ?? null,
     }),
+  answerToolUse: (agentId: string, requestId: string, updatedInput: unknown) =>
+    invoke<void>("answer_tool_use", { agentId, requestId, updatedInput }),
   resizeAgent: (agentId: string, cols: number, rows: number) =>
     invoke<void>("resize_agent", { agentId, cols, rows }),
   switchView: (agentId: string, view: AgentView) =>

--- a/src/app.css
+++ b/src/app.css
@@ -963,6 +963,12 @@ button { cursor: default; }
 .qa-text { flex: 1; min-width: 0; font-size: 13px; font-weight: 500; color: var(--fg-0); text-wrap: pretty; }
 .qa-text.other { font-weight: 400; font-style: italic; color: var(--fg-1); }
 
+/* dismissed (interrupted before answering) — quiet, non-interactive */
+.m-q.is-dismissed { background: var(--bg-1); border-color: var(--bd-soft); }
+.m-q.is-dismissed::before { background: var(--bd-soft); }
+.q-label.dismissed { color: var(--fg-3); }
+.q-dismissed-note { margin-top: 8px; font-size: 12px; color: var(--fg-3); font-style: italic; }
+
 .m-tool {
   display: flex; align-items: center; gap: 10px;
   font-family: var(--font-mono);

--- a/src/app.css
+++ b/src/app.css
@@ -781,6 +781,188 @@ button { cursor: default; }
   font-weight: 500;
 }
 
+/* ─── "Needs your input" widget ─────────────────────────────────────
+   The agent reaches a fork and asks the user to choose (Claude's
+   AskUserQuestion / ExitPlanMode). A quiet card that reads as part of the
+   prose but is clearly actionable. Click a variant to answer; "Something
+   else…" expands an inline composer; once answered it folds to a summary. */
+.m-q-stack { display: flex; flex-direction: column; gap: 10px; }
+.m-q {
+  border: 1px solid var(--bd);
+  border-radius: var(--r-lg);
+  background: var(--bg-2);
+  padding: 15px 16px 14px;
+  box-shadow: var(--shadow-1);
+  position: relative;
+  overflow: hidden;
+}
+/* a hairline accent down the left edge — "your turn" */
+.m-q::before {
+  content: "";
+  position: absolute; left: 0; top: 0; bottom: 0;
+  width: 2px;
+  background: linear-gradient(var(--accent), color-mix(in oklch, var(--accent), transparent 55%));
+}
+
+.q-head { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }
+.q-label {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 10px; font-weight: 600;
+  letter-spacing: 0.09em; text-transform: uppercase;
+  color: var(--accent);
+}
+.q-label svg { opacity: .9; }
+.q-label.resolved { color: var(--fg-3); }
+.q-step {
+  font-family: var(--font-mono); font-size: 9.5px; font-weight: 600;
+  letter-spacing: .04em; color: var(--accent);
+  background: var(--accent-soft); padding: 1px 5px; border-radius: 999px;
+}
+.q-ctx {
+  margin-left: auto;
+  font-family: var(--font-mono); font-size: 10.5px;
+  color: var(--fg-3);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0;
+}
+
+.q-prompt { font-size: 14px; line-height: 1.6; color: var(--fg-0); text-wrap: pretty; }
+.q-prompt em { font-family: var(--font-serif); font-style: italic; color: var(--accent); font-size: 1.05em; }
+.q-prompt.resolved { color: var(--fg-2); }
+.q-body {
+  margin-top: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-md);
+  background: var(--bg-1);
+  font-size: 12.5px; line-height: 1.55; color: var(--fg-1);
+  max-height: 280px; overflow: auto;
+}
+.q-body > *:first-child { margin-top: 0; }
+.q-body > *:last-child { margin-bottom: 0; }
+
+.q-opts { display: flex; flex-direction: column; gap: 7px; margin-top: 13px; }
+.q-opt {
+  display: flex; align-items: flex-start; gap: 11px;
+  width: 100%; text-align: left;
+  padding: 11px 12px;
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-md);
+  background: var(--bg-1);
+  transition: border-color .14s var(--ease), background .14s var(--ease), transform .08s var(--ease);
+  animation: q-opt-in .34s var(--ease) both;
+}
+@keyframes q-opt-in {
+  from { opacity: 0; transform: translateY(5px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.q-opt:hover { border-color: var(--accent-line); background: var(--hover); }
+.q-opt:active { transform: scale(.992); }
+.q-opt.is-checked { border-color: var(--accent-line); background: var(--accent-soft); }
+
+.q-radio {
+  width: 16px; height: 16px;
+  border-radius: 50%;
+  border: 1.5px solid var(--bd-strong);
+  flex-shrink: 0; margin-top: 1px;
+  position: relative;
+  display: inline-flex; align-items: center; justify-content: center;
+  color: var(--fg-3);
+  transition: border-color .14s, color .14s;
+}
+.q-radio::after {
+  content: ""; width: 7px; height: 7px; border-radius: 50%;
+  background: var(--accent); transform: scale(0);
+  transition: transform .14s var(--ease);
+}
+.q-opt:hover .q-radio { border-color: var(--accent); }
+.q-opt:hover .q-radio::after { transform: scale(1); }
+.q-radio.plus { border-style: dashed; }
+.q-radio.plus::after, .q-radio.check::after { display: none; }
+.q-radio.check { border-radius: 5px; }
+.q-opt.is-checked .q-radio.check { border-color: var(--accent); color: var(--accent); }
+.q-opt:hover .q-radio.plus { color: var(--accent); }
+
+.q-opt-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 3px; }
+.q-opt-top { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+.q-opt-label { font-size: 13px; font-weight: 500; color: var(--fg-0); letter-spacing: -0.005em; }
+.q-opt-label.muted { color: var(--fg-2); }
+.q-rec {
+  font-size: 9px; font-weight: 600;
+  letter-spacing: 0.05em; text-transform: uppercase;
+  color: var(--accent); background: var(--accent-soft);
+  padding: 1.5px 6px; border-radius: 999px;
+}
+.q-opt-desc { font-size: 12px; line-height: 1.5; color: var(--fg-2); text-wrap: pretty; }
+.q-kbd {
+  flex-shrink: 0; width: 18px; height: 18px; margin-top: 1px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border: 1px solid var(--bd-soft); border-radius: 4px;
+  font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-3);
+  transition: border-color .14s, color .14s;
+}
+.q-opt:hover .q-kbd { border-color: var(--accent-line); color: var(--accent); }
+
+/* "other" composer */
+.q-other {
+  border: 1px solid var(--accent-line);
+  border-radius: var(--r-md);
+  background: var(--bg-1);
+  overflow: hidden;
+  animation: q-opt-in .2s var(--ease) both;
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent), transparent 90%);
+}
+.q-other-input {
+  width: 100%; padding: 11px 12px 6px;
+  font-size: 13px; line-height: 1.55; color: var(--fg-0);
+  resize: none; min-height: 56px; max-height: 160px;
+  background: transparent; border: 0; font-family: inherit;
+}
+.q-other-input:focus { outline: none; }
+.q-other-input::placeholder { color: var(--fg-3); }
+.q-other-foot { display: flex; align-items: center; gap: 8px; padding: 6px 8px 8px 12px; }
+.q-other-hint { font-size: 11px; color: var(--fg-3); display: inline-flex; align-items: center; gap: 6px; }
+.q-other-hint .kbd, .q-other-hint .grow { }
+.q-other-foot .grow { flex: 1; }
+.q-multi-foot { display: flex; justify-content: flex-end; margin-top: 2px; }
+.q-other-cancel {
+  height: 26px; padding: 0 10px; border-radius: var(--r-sm);
+  font-size: 12px; color: var(--fg-2); font-weight: 500;
+  background: transparent; border: 0;
+  transition: background .12s, color .12s;
+}
+.q-other-cancel:hover { background: var(--hover); color: var(--fg-0); }
+.q-other-send {
+  display: inline-flex; align-items: center; gap: 6px;
+  height: 26px; padding: 0 11px; border-radius: var(--r-sm);
+  font-size: 12px; font-weight: 600;
+  background: var(--accent); color: oklch(0.16 0.02 60);
+  border: 0; transition: background .12s, opacity .12s;
+}
+.theme-light .q-other-send { color: oklch(0.98 0.005 60); }
+.q-other-send:hover:not(:disabled) { background: oklch(from var(--accent) calc(l + 0.04) c h); }
+.q-other-send svg { opacity: .9; }
+.q-other-send:disabled { background: var(--hover); color: var(--fg-3); cursor: default; }
+
+/* answered (resolved) state */
+.m-q.is-answered { background: var(--bg-1); border-color: var(--bd-soft); }
+.m-q.is-answered::before { background: var(--accent-line); }
+.q-answer {
+  display: flex; align-items: center; gap: 10px;
+  margin-top: 12px; padding: 10px 12px;
+  border: 1px solid var(--accent-line); border-radius: var(--r-md);
+  background: var(--accent-soft);
+  animation: q-opt-in .26s var(--ease) both;
+}
+.qa-mark {
+  flex-shrink: 0; width: 18px; height: 18px; border-radius: 50%;
+  background: var(--accent); color: oklch(0.16 0.02 60);
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.theme-light .qa-mark { color: oklch(0.98 0.005 60); }
+.qa-text { flex: 1; min-width: 0; font-size: 13px; font-weight: 500; color: var(--fg-0); text-wrap: pretty; }
+.qa-text.other { font-weight: 400; font-style: italic; color: var(--fg-1); }
+
 .m-tool {
   display: flex; align-items: center; gap: 10px;
   font-family: var(--font-mono);

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -6,6 +6,7 @@ import { providerLabel } from "../../data/providers";
 import { Composer } from "../Composer";
 import { MessageItem } from "./messages/MessageItem";
 import { pairToolItems, rowKey } from "./messages/pair";
+import { isUserInputTool } from "./messages/UserInput/parse";
 
 /** Custom-view body: scrolling chat log + composer at the bottom.
  *  The composer here dispatches the user's message via the store; it
@@ -100,6 +101,19 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
     }
     return undefined;
   }, [items]);
+  // When the last row is an unanswered user-input widget, the agent is paused
+  // on that tool waiting for the user — not working — so suppress the
+  // "is thinking" spinner (the widget itself signals it's the user's turn).
+  const awaitingInput = useMemo(() => {
+    const last = items[items.length - 1];
+    return Boolean(
+      last &&
+        last.kind === "tool_pair" &&
+        isUserInputTool(last.call.name) &&
+        !last.result,
+    );
+  }, [items]);
+
   const canSend =
     !transcriptLoading &&
     !switchInFlight &&
@@ -130,10 +144,15 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
             </div>
           ) : (
             items.map((item, i) => (
-              <MessageItem key={rowKey(item, i)} item={item} provider={agent.provider} />
+              <MessageItem
+                key={rowKey(item, i)}
+                item={item}
+                provider={agent.provider}
+                agentId={agent.id}
+              />
             ))
           )}
-          {busy && (
+          {busy && !awaitingInput && (
             <div className="writing">
               <span className="dots">
                 <i /><i /><i />

--- a/src/components/Workspace/messages/MessageItem.tsx
+++ b/src/components/Workspace/messages/MessageItem.tsx
@@ -6,6 +6,8 @@ import { pairToolItems, rowKey, type ViewItem } from "./pair";
 import { ToolResultItem } from "./ToolResultItem";
 import { ToolRow } from "./ToolRow";
 import { getPresenter } from "./presenters";
+import { UserInput } from "./UserInput";
+import { isUserInputTool } from "./UserInput/parse";
 import { AttachmentList } from "../../Composer/AttachmentList";
 import { stripInjectedInstructions } from "../../../util/instructions";
 import { APP_ACTION_PREFIX } from "../../RightPanel/delegation";
@@ -13,13 +15,16 @@ import { APP_ACTION_PREFIX } from "../../RightPanel/delegation";
 /** Dispatcher for one rendered row. Accepts either a raw ChatItem or
  *  the derived `tool_pair` from pairToolItems(). `provider` carries the
  *  agent's adapter id down so nested subagent threads filter/pair their
- *  rows with the same display policy as the main log. */
+ *  rows with the same display policy as the main log. `agentId` lets the
+ *  user-input widget route its answer back to this agent's stdin. */
 export function MessageItem({
   item,
   provider,
+  agentId,
 }: {
   item: ViewItem;
   provider?: string;
+  agentId?: string;
 }) {
   switch (item.kind) {
     case "user_message":
@@ -52,6 +57,16 @@ export function MessageItem({
         </div>
       );
     case "tool_pair": {
+      if (isUserInputTool(item.call.name)) {
+        return (
+          <UserInput
+            tool={item.call.name}
+            call={item.call}
+            result={item.result}
+            agentId={agentId}
+          />
+        );
+      }
       const presenter = getPresenter(item.call.name);
       const children = item.call.children ?? [];
       return (
@@ -64,7 +79,11 @@ export function MessageItem({
             <>
               {presenter.expanded(item.call, item.result)}
               {children.length > 0 && (
-                <SubagentThread items={children} provider={provider} />
+                <SubagentThread
+                  items={children}
+                  provider={provider}
+                  agentId={agentId}
+                />
               )}
             </>
           }
@@ -75,6 +94,11 @@ export function MessageItem({
       // Bare tool_call without pairing — happens only if the caller
       // bypasses pairToolItems(). Render through the presenter anyway,
       // with a null result.
+      if (isUserInputTool(item.name)) {
+        return (
+          <UserInput tool={item.name} call={item} result={null} agentId={agentId} />
+        );
+      }
       const presenter = getPresenter(item.name);
       return (
         <ToolRow
@@ -100,9 +124,11 @@ export function MessageItem({
 function SubagentThread({
   items,
   provider,
+  agentId,
 }: {
   items: ChatItem[];
   provider?: string;
+  agentId?: string;
 }) {
   // Re-derive only when the children or provider change — not on every parent
   // re-render (e.g. a streaming token elsewhere in the main log).
@@ -120,7 +146,12 @@ function SubagentThread({
       }}
     >
       {rows.map((row, i) => (
-        <MessageItem key={rowKey(row, i)} item={row} provider={provider} />
+        <MessageItem
+          key={rowKey(row, i)}
+          item={row}
+          provider={provider}
+          agentId={agentId}
+        />
       ))}
     </div>
   );

--- a/src/components/Workspace/messages/UserInput/QuestionCard.tsx
+++ b/src/components/Workspace/messages/UserInput/QuestionCard.tsx
@@ -30,11 +30,13 @@ export function QuestionCard({
   const [otherText, setOtherText] = useState("");
   const otherRef = useRef<HTMLTextAreaElement>(null);
 
-  const answerOne = (label: string) => onAnswer({ labels: [label], isOther: false });
+  const answerOne = (option: UIQuestion["options"][number]) =>
+    onAnswer({ labels: [option.label], optionIds: [option.id], isOther: false });
   const confirmMulti = () => {
     if (picks.size === 0) return;
     onAnswer({
       labels: opts.filter((o) => picks.has(o.id)).map((o) => o.label),
+      optionIds: opts.filter((o) => picks.has(o.id)).map((o) => o.id),
       isOther: false,
     });
   };
@@ -54,7 +56,7 @@ export function QuestionCard({
       const n = Number.parseInt(e.key, 10);
       if (n >= 1 && n <= opts.length) {
         e.preventDefault();
-        answerOne(opts[n - 1].label);
+        answerOne(opts[n - 1]);
       }
     };
     window.addEventListener("keydown", onKey);
@@ -128,7 +130,7 @@ export function QuestionCard({
                     return next;
                   });
                 } else {
-                  answerOne(o.label);
+                  answerOne(o);
                 }
               }}
             >

--- a/src/components/Workspace/messages/UserInput/QuestionCard.tsx
+++ b/src/components/Workspace/messages/UserInput/QuestionCard.tsx
@@ -1,0 +1,229 @@
+import { useEffect, useRef, useState } from "react";
+import { Icon } from "../../../Icon";
+import { Markdown } from "../../../Markdown";
+import type { UIAnswer, UIQuestion } from "./parse";
+
+/** One question rendered as the prototype's `.m-q` card. Live until answered;
+ *  once `committed` it folds into a quiet resolved summary. Single-select
+ *  answers immediately on click; multiSelect collects picks behind a Confirm;
+ *  "Something else…" opens an inline free-text composer. */
+export function QuestionCard({
+  question,
+  index,
+  total,
+  committed,
+  answer,
+  onAnswer,
+}: {
+  question: UIQuestion;
+  index: number;
+  total: number;
+  /** True once the answer has been sent to the agent — render resolved, no edits. */
+  committed: boolean;
+  /** The chosen answer, when one exists (live multi-question or committed). */
+  answer: UIAnswer | null;
+  onAnswer: (answer: UIAnswer) => void;
+}) {
+  const opts = question.options;
+  const [picks, setPicks] = useState<Set<string>>(new Set());
+  const [otherOpen, setOtherOpen] = useState(false);
+  const [otherText, setOtherText] = useState("");
+  const otherRef = useRef<HTMLTextAreaElement>(null);
+
+  const answerOne = (label: string) => onAnswer({ labels: [label], isOther: false });
+  const confirmMulti = () => {
+    if (picks.size === 0) return;
+    onAnswer({
+      labels: opts.filter((o) => picks.has(o.id)).map((o) => o.label),
+      isOther: false,
+    });
+  };
+  const answerOther = () => {
+    const t = otherText.trim();
+    if (t) onAnswer({ labels: [t], isOther: true });
+  };
+
+  // Number keys (1..n) pick an option — only for a lone single-select question,
+  // so shortcuts don't clash across stacked cards. Disabled once committed.
+  useEffect(() => {
+    if (committed || total !== 1 || question.multiSelect) return;
+    const onKey = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA") return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      const n = Number.parseInt(e.key, 10);
+      if (n >= 1 && n <= opts.length) {
+        e.preventDefault();
+        answerOne(opts[n - 1].label);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [committed, total, question.multiSelect, opts]);
+
+  useEffect(() => {
+    if (otherOpen) otherRef.current?.focus();
+  }, [otherOpen]);
+
+  // ── resolved ──────────────────────────────────────────────────────
+  if (committed && answer) {
+    return (
+      <div className="m-q is-answered">
+        <div className="q-head">
+          <span className="q-label resolved">
+            <Icon name="check" size={11} /> Answered
+          </span>
+          {question.header && <span className="q-ctx">{question.header}</span>}
+        </div>
+        <div className="q-prompt resolved">{question.prompt}</div>
+        <div className="q-answer">
+          <span className="qa-mark">
+            <Icon name="check" size={10} />
+          </span>
+          <span className={`qa-text ${answer.isOther ? "other" : ""}`}>
+            {answer.labels.join(", ")}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  // ── live ──────────────────────────────────────────────────────────
+  return (
+    <div className="m-q">
+      <div className="q-head">
+        <span className="q-label">
+          <Icon name="sparkle" size={11} /> Needs your input
+          {total > 1 && (
+            <span className="q-step">
+              {index + 1}/{total}
+            </span>
+          )}
+        </span>
+        {question.header && <span className="q-ctx">{question.header}</span>}
+      </div>
+      <div className="q-prompt">{question.prompt}</div>
+      {question.body && (
+        <div className="q-body">
+          <Markdown>{question.body}</Markdown>
+        </div>
+      )}
+
+      <div className="q-opts">
+        {opts.map((o, i) => {
+          const checked = picks.has(o.id);
+          return (
+            <button
+              key={o.id}
+              type="button"
+              className={`q-opt ${checked ? "is-checked" : ""}`}
+              style={{ animationDelay: `${0.04 * i + 0.02}s` }}
+              onClick={() => {
+                if (question.multiSelect) {
+                  setPicks((prev) => {
+                    const next = new Set(prev);
+                    if (next.has(o.id)) next.delete(o.id);
+                    else next.add(o.id);
+                    return next;
+                  });
+                } else {
+                  answerOne(o.label);
+                }
+              }}
+            >
+              <span className={`q-radio ${question.multiSelect ? "check" : ""}`}>
+                {question.multiSelect && checked && <Icon name="check" size={10} />}
+              </span>
+              <span className="q-opt-body">
+                <span className="q-opt-top">
+                  <span className="q-opt-label">{o.label}</span>
+                  {o.recommended && <span className="q-rec">Recommended</span>}
+                </span>
+                {o.desc && <span className="q-opt-desc">{o.desc}</span>}
+              </span>
+              {!question.multiSelect && <span className="q-kbd">{i + 1}</span>}
+            </button>
+          );
+        })}
+
+        {question.allowOther && !otherOpen && (
+          <button
+            type="button"
+            className="q-opt q-other-trigger"
+            style={{ animationDelay: `${0.04 * opts.length + 0.02}s` }}
+            onClick={() => setOtherOpen(true)}
+          >
+            <span className="q-radio plus">
+              <Icon name="plus" size={10} />
+            </span>
+            <span className="q-opt-body">
+              <span className="q-opt-label muted">Something else…</span>
+              <span className="q-opt-desc">Write your own answer for the agent.</span>
+            </span>
+          </button>
+        )}
+
+        {question.allowOther && otherOpen && (
+          <div className="q-other">
+            <textarea
+              ref={otherRef}
+              className="q-other-input"
+              placeholder="Tell the agent what you'd prefer…"
+              value={otherText}
+              onChange={(e) => setOtherText(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  answerOther();
+                }
+                if (e.key === "Escape") {
+                  setOtherOpen(false);
+                  setOtherText("");
+                }
+              }}
+            />
+            <div className="q-other-foot">
+              <span className="q-other-hint">
+                <span className="kbd">↵</span> to send
+              </span>
+              <span className="grow" />
+              <button
+                type="button"
+                className="q-other-cancel"
+                onClick={() => {
+                  setOtherOpen(false);
+                  setOtherText("");
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="q-other-send"
+                disabled={!otherText.trim()}
+                onClick={answerOther}
+              >
+                Send <Icon name="arrowUp" size={11} />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {question.multiSelect && (
+          <div className="q-multi-foot">
+            <button
+              type="button"
+              className="q-other-send"
+              disabled={picks.size === 0}
+              onClick={confirmMulti}
+            >
+              Confirm{picks.size > 0 ? ` (${picks.size})` : ""}{" "}
+              <Icon name="arrowUp" size={11} />
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Workspace/messages/UserInput/QuestionCard.tsx
+++ b/src/components/Workspace/messages/UserInput/QuestionCard.tsx
@@ -32,6 +32,11 @@ export function QuestionCard({
 
   const answerOne = (option: UIQuestion["options"][number]) =>
     onAnswer({ labels: [option.label], optionIds: [option.id], isOther: false });
+  // Keep the keydown listener (below) pointed at the current answer handler
+  // without re-subscribing on every render: `onAnswer` is a fresh closure each
+  // parent render and closes over the parent's latest answers/committed state.
+  const answerOneRef = useRef(answerOne);
+  answerOneRef.current = answerOne;
   const confirmMulti = () => {
     if (picks.size === 0) return;
     onAnswer({
@@ -56,12 +61,11 @@ export function QuestionCard({
       const n = Number.parseInt(e.key, 10);
       if (n >= 1 && n <= opts.length) {
         e.preventDefault();
-        answerOne(opts[n - 1]);
+        answerOneRef.current(opts[n - 1]);
       }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [committed, total, question.multiSelect, opts]);
 
   useEffect(() => {

--- a/src/components/Workspace/messages/UserInput/index.tsx
+++ b/src/components/Workspace/messages/UserInput/index.tsx
@@ -1,0 +1,110 @@
+import { useMemo, useState } from "react";
+import { Icon } from "../../../Icon";
+import { useAppStore } from "../../../../store";
+import type { ToolCall, ToolResult } from "../presenters/types";
+import { QuestionCard } from "./QuestionCard";
+import {
+  formatToolResult,
+  parseUserInput,
+  type UIAnswer,
+  type UserInputTool,
+} from "./parse";
+
+/** Rich widget for the agent's "needs your input" tools (Claude's
+ *  `AskUserQuestion` / `ExitPlanMode`). Renders one card per question; once
+ *  every question is answered it sends a `tool_result` back to the agent's
+ *  stdin (keyed to the tool_use id) to unblock the paused turn. A paired
+ *  `result` — present after the turn is replayed from the transcript — folds
+ *  the widget into a resolved summary. */
+export function UserInput({
+  tool,
+  call,
+  result,
+  agentId,
+}: {
+  tool: UserInputTool;
+  call: ToolCall;
+  result: ToolResult | null;
+  agentId?: string;
+}) {
+  const model = useMemo(() => parseUserInput(tool, call.input), [tool, call.input]);
+  const sendToolResult = useAppStore((s) => s.sendToolResult);
+
+  // Keyed by question index rather than a fixed-length array: the model's
+  // question count can grow as the tool_use input streams in, and we must not
+  // treat a partially-filled multi-question call as complete.
+  const [answers, setAnswers] = useState<Record<number, UIAnswer>>({});
+  const [committedLocally, setCommittedLocally] = useState(false);
+
+  const handleAnswer = (i: number, ans: UIAnswer) => {
+    const next = { ...answers, [i]: ans };
+    setAnswers(next);
+    if (model.questions.every((_, idx) => next[idx])) {
+      setCommittedLocally(true);
+      if (agentId) {
+        const ordered = model.questions.map((_, idx) => next[idx]);
+        void sendToolResult(agentId, call.id, formatToolResult(model, ordered));
+      }
+    }
+  };
+
+  if (model.questions.length === 0) return null;
+
+  // Resolved from the transcript (loaded after the turn already completed):
+  // we have the answer text the agent received but not the structured picks,
+  // so show a compact summary rather than reconstructing each card.
+  if (!committedLocally && result) {
+    return (
+      <div className="m-q is-answered">
+        <div className="q-head">
+          <span className="q-label resolved">
+            <Icon name="check" size={11} /> Answered
+          </span>
+        </div>
+        {model.questions.map((q) => (
+          <div key={q.id} className="q-prompt resolved">
+            {q.prompt}
+          </div>
+        ))}
+        <div className="q-answer">
+          <span className="qa-mark">
+            <Icon name="check" size={10} />
+          </span>
+          <span className="qa-text">{resultText(result.content)}</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="m-q-stack">
+      {model.questions.map((q, i) => (
+        <QuestionCard
+          key={q.id}
+          question={q}
+          index={i}
+          total={model.questions.length}
+          committed={committedLocally}
+          answer={answers[i] ?? null}
+          onAnswer={(ans) => handleAnswer(i, ans)}
+        />
+      ))}
+    </div>
+  );
+}
+
+/** Flatten a tool_result's content (string or content-block array) to text. */
+function resultText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((b) =>
+        b && typeof b === "object" && "text" in b
+          ? String((b as { text: unknown }).text)
+          : "",
+      )
+      .join("")
+      .trim();
+  }
+  return "";
+}

--- a/src/components/Workspace/messages/UserInput/index.tsx
+++ b/src/components/Workspace/messages/UserInput/index.tsx
@@ -60,15 +60,26 @@ export function UserInput({
       if (!agentId) return;
       const ordered = model.questions.map((_, idx) => next[idx]);
       if (pendingRequestId) {
-        // True pause: return the structured answer as the tool result.
+        // True pause: return the structured answer as the tool result. For
+        // ExitPlanMode, "Keep planning" is a permission denial, not a tool
+        // result approval.
         const rawInput =
           call.input && typeof call.input === "object"
             ? (call.input as Record<string, unknown>)
             : {};
-        void answerToolUse(agentId, call.id, {
-          ...rawInput,
-          answers: buildAnswers(model, ordered),
-        });
+        const keepPlanning =
+          model.tool === "ExitPlanMode" &&
+          (ordered[0]?.optionIds?.[0] === "reject" || ordered[0]?.isOther);
+        void answerToolUse(
+          agentId,
+          call.id,
+          {
+            ...rawInput,
+            answers: buildAnswers(model, ordered),
+          },
+          keepPlanning ? "deny" : "allow",
+          keepPlanning ? formatAnswer(model, ordered) : undefined,
+        );
       } else {
         // No held prompt (replayed history) — answer as an ordinary message.
         void sendUserMessage(agentId, formatAnswer(model, ordered));

--- a/src/components/Workspace/messages/UserInput/index.tsx
+++ b/src/components/Workspace/messages/UserInput/index.tsx
@@ -4,6 +4,7 @@ import { useAppStore } from "../../../../store";
 import type { ToolCall, ToolResult } from "../presenters/types";
 import { QuestionCard } from "./QuestionCard";
 import {
+  buildAnswers,
   formatAnswer,
   parseUserInput,
   type UIAnswer,
@@ -12,19 +13,18 @@ import {
 
 /** Rich widget for the agent's "needs your input" tools (Claude's
  *  `AskUserQuestion` / `ExitPlanMode`). Renders one card per question; once
- *  every question is answered it sends the chosen answer back as the next
- *  user message.
+ *  every question is answered it delivers the answer to the agent.
  *
- *  Why a user message and not a tool_result: in headless `--print` mode the
- *  Claude CLI has no interactive surface to present the question, so it
- *  auto-rejects the tool with an `is_error` tool_result within milliseconds
- *  and the model continues. By the time we render, that tool_use is already
- *  closed — a tool_result keyed to it would be a duplicate. So we ignore the
- *  CLI's error result, surface the options as quick replies, and let the
- *  user's pick ride in as an ordinary turn, which the model reads and answers.
+ *  Two answer routes:
+ *   - **True pause** (live): when the backend is holding this tool's
+ *     `can_use_tool` prompt open (a `request_id` for `call.id` exists in
+ *     `pendingToolUse`), the agent is genuinely suspended. We answer via
+ *     `answerToolUse`, which returns the selection as the tool result and
+ *     resumes the turn — no failed tool call, no redundant text.
+ *   - **Fallback** (replayed/legacy history, no held prompt): send the answer
+ *     as an ordinary user message so it still reaches the model.
  *
- *  A genuine (non-error) `result` — e.g. from a future interactive flow —
- *  still folds the widget into a resolved summary. */
+ *  A genuine (non-error) `result` folds the widget into a resolved summary. */
 export function UserInput({
   tool,
   call,
@@ -38,6 +38,12 @@ export function UserInput({
 }) {
   const model = useMemo(() => parseUserInput(tool, call.input), [tool, call.input]);
   const sendUserMessage = useAppStore((s) => s.sendUserMessage);
+  const answerToolUse = useAppStore((s) => s.answerToolUse);
+  // The held control-protocol request for this tool call, if the agent is
+  // currently paused on it (true-pause path). Undefined for replayed history.
+  const pendingRequestId = useAppStore((s) =>
+    agentId ? s.pendingToolUse[agentId]?.[call.id] : undefined,
+  );
 
   // Keyed by question index rather than a fixed-length array: the model's
   // question count can grow as the tool_use input streams in, and we must not
@@ -50,8 +56,20 @@ export function UserInput({
     setAnswers(next);
     if (model.questions.every((_, idx) => next[idx])) {
       setCommittedLocally(true);
-      if (agentId) {
-        const ordered = model.questions.map((_, idx) => next[idx]);
+      if (!agentId) return;
+      const ordered = model.questions.map((_, idx) => next[idx]);
+      if (pendingRequestId) {
+        // True pause: return the structured answer as the tool result.
+        const rawInput =
+          call.input && typeof call.input === "object"
+            ? (call.input as Record<string, unknown>)
+            : {};
+        void answerToolUse(agentId, call.id, {
+          ...rawInput,
+          answers: buildAnswers(model, ordered),
+        });
+      } else {
+        // No held prompt (replayed history) — answer as an ordinary message.
         void sendUserMessage(agentId, formatAnswer(model, ordered));
       }
     }

--- a/src/components/Workspace/messages/UserInput/index.tsx
+++ b/src/components/Workspace/messages/UserInput/index.tsx
@@ -4,7 +4,7 @@ import { useAppStore } from "../../../../store";
 import type { ToolCall, ToolResult } from "../presenters/types";
 import { QuestionCard } from "./QuestionCard";
 import {
-  formatToolResult,
+  formatAnswer,
   parseUserInput,
   type UIAnswer,
   type UserInputTool,
@@ -12,10 +12,19 @@ import {
 
 /** Rich widget for the agent's "needs your input" tools (Claude's
  *  `AskUserQuestion` / `ExitPlanMode`). Renders one card per question; once
- *  every question is answered it sends a `tool_result` back to the agent's
- *  stdin (keyed to the tool_use id) to unblock the paused turn. A paired
- *  `result` — present after the turn is replayed from the transcript — folds
- *  the widget into a resolved summary. */
+ *  every question is answered it sends the chosen answer back as the next
+ *  user message.
+ *
+ *  Why a user message and not a tool_result: in headless `--print` mode the
+ *  Claude CLI has no interactive surface to present the question, so it
+ *  auto-rejects the tool with an `is_error` tool_result within milliseconds
+ *  and the model continues. By the time we render, that tool_use is already
+ *  closed — a tool_result keyed to it would be a duplicate. So we ignore the
+ *  CLI's error result, surface the options as quick replies, and let the
+ *  user's pick ride in as an ordinary turn, which the model reads and answers.
+ *
+ *  A genuine (non-error) `result` — e.g. from a future interactive flow —
+ *  still folds the widget into a resolved summary. */
 export function UserInput({
   tool,
   call,
@@ -28,7 +37,7 @@ export function UserInput({
   agentId?: string;
 }) {
   const model = useMemo(() => parseUserInput(tool, call.input), [tool, call.input]);
-  const sendToolResult = useAppStore((s) => s.sendToolResult);
+  const sendUserMessage = useAppStore((s) => s.sendUserMessage);
 
   // Keyed by question index rather than a fixed-length array: the model's
   // question count can grow as the tool_use input streams in, and we must not
@@ -43,17 +52,17 @@ export function UserInput({
       setCommittedLocally(true);
       if (agentId) {
         const ordered = model.questions.map((_, idx) => next[idx]);
-        void sendToolResult(agentId, call.id, formatToolResult(model, ordered));
+        void sendUserMessage(agentId, formatAnswer(model, ordered));
       }
     }
   };
 
   if (model.questions.length === 0) return null;
 
-  // Resolved from the transcript (loaded after the turn already completed):
-  // we have the answer text the agent received but not the structured picks,
-  // so show a compact summary rather than reconstructing each card.
-  if (!committedLocally && result) {
+  // A genuine (non-error) tool_result means the question was actually answered
+  // through it — show a compact summary. The CLI's `is_error` auto-rejection
+  // (headless mode) is NOT a real answer, so we fall through to live options.
+  if (!committedLocally && result && !result.is_error) {
     return (
       <div className="m-q is-answered">
         <div className="q-head">

--- a/src/components/Workspace/messages/UserInput/index.tsx
+++ b/src/components/Workspace/messages/UserInput/index.tsx
@@ -4,6 +4,7 @@ import { useAppStore } from "../../../../store";
 import type { ToolCall, ToolResult } from "../presenters/types";
 import { QuestionCard } from "./QuestionCard";
 import {
+  answersFromResultText,
   buildAnswers,
   formatAnswer,
   parseUserInput,
@@ -77,10 +78,23 @@ export function UserInput({
 
   if (model.questions.length === 0) return null;
 
-  // A genuine (non-error) tool_result means the question was actually answered
-  // through it — show a compact summary. The CLI's `is_error` auto-rejection
-  // (headless mode) is NOT a real answer, so we fall through to live options.
-  if (!committedLocally && result && !result.is_error) {
+  // Resolved purely from the transcript (the widget was rebuilt after the turn
+  // completed): the CLI's `is_error` auto-rejection is NOT a real answer, so we
+  // only treat a genuine result as resolved. Reconstruct the structured answers
+  // from the result text so reload shows the same answer chips as the live
+  // session rather than the CLI's raw "Your questions have been answered…"
+  // sentence.
+  const fromTranscript =
+    !committedLocally && result && !result.is_error
+      ? answersFromResultText(model, resultText(result.content))
+      : null;
+  const committed = committedLocally || !!fromTranscript;
+  const answerFor = (i: number): UIAnswer | null =>
+    committedLocally ? (answers[i] ?? null) : (fromTranscript?.[i] ?? null);
+
+  // Answered, but the result didn't parse into per-question answers — fall back
+  // to a compact summary of the raw result text rather than showing nothing.
+  if (!committedLocally && result && !result.is_error && !fromTranscript) {
     return (
       <div className="m-q is-answered">
         <div className="q-head">
@@ -111,8 +125,8 @@ export function UserInput({
           question={q}
           index={i}
           total={model.questions.length}
-          committed={committedLocally}
-          answer={answers[i] ?? null}
+          committed={committed}
+          answer={answerFor(i)}
           onAnswer={(ans) => handleAnswer(i, ans)}
         />
       ))}

--- a/src/components/Workspace/messages/UserInput/index.tsx
+++ b/src/components/Workspace/messages/UserInput/index.tsx
@@ -78,6 +78,28 @@ export function UserInput({
 
   if (model.questions.length === 0) return null;
 
+  // Interrupted: an is_error result with no live prompt means the user hit Stop
+  // (the held prompt was denied) — or it's an old pre-feature auto-deny. Either
+  // way the agent is no longer waiting, so show a quiet "Dismissed" state rather
+  // than answerable options that would imply it still is.
+  if (!committedLocally && result?.is_error && !pendingRequestId) {
+    return (
+      <div className="m-q is-dismissed">
+        <div className="q-head">
+          <span className="q-label dismissed">
+            <Icon name="close" size={11} /> Dismissed
+          </span>
+        </div>
+        {model.questions.map((q) => (
+          <div key={q.id} className="q-prompt resolved">
+            {q.prompt}
+          </div>
+        ))}
+        <div className="q-dismissed-note">Not answered — you stopped the agent.</div>
+      </div>
+    );
+  }
+
   // Resolved purely from the transcript (the widget was rebuilt after the turn
   // completed): the CLI's `is_error` auto-rejection is NOT a real answer, so we
   // only treat a genuine result as resolved. Reconstruct the structured answers

--- a/src/components/Workspace/messages/UserInput/parse.test.ts
+++ b/src/components/Workspace/messages/UserInput/parse.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import {
+  isUserInputTool,
+  parseUserInput,
+  formatToolResult,
+  type UIAnswer,
+} from "./parse";
+
+describe("isUserInputTool", () => {
+  it("matches the two question tools and nothing else", () => {
+    expect(isUserInputTool("AskUserQuestion")).toBe(true);
+    expect(isUserInputTool("ExitPlanMode")).toBe(true);
+    expect(isUserInputTool("Bash")).toBe(false);
+    expect(isUserInputTool("askuserquestion")).toBe(false); // case-sensitive
+  });
+});
+
+describe("parseUserInput — AskUserQuestion", () => {
+  it("normalizes a single question with options", () => {
+    const model = parseUserInput("AskUserQuestion", {
+      questions: [
+        {
+          question: "Which database should we use?",
+          header: "Storage",
+          options: [
+            { label: "Postgres", description: "Relational", recommended: true },
+            { label: "SQLite" },
+          ],
+        },
+      ],
+    });
+    expect(model.tool).toBe("AskUserQuestion");
+    expect(model.questions).toHaveLength(1);
+    const q = model.questions[0];
+    expect(q.prompt).toBe("Which database should we use?");
+    expect(q.header).toBe("Storage");
+    expect(q.multiSelect).toBe(false);
+    expect(q.allowOther).toBe(true);
+    expect(q.options[0]).toMatchObject({
+      label: "Postgres",
+      desc: "Relational",
+      recommended: true,
+    });
+    expect(q.options[1]).toMatchObject({ label: "SQLite", recommended: false });
+  });
+
+  it("carries multiSelect through and handles multiple questions", () => {
+    const model = parseUserInput("AskUserQuestion", {
+      questions: [
+        { question: "Pick languages", multiSelect: true, options: [{ label: "TS" }] },
+        { question: "Pick a license", options: [{ label: "MIT" }] },
+      ],
+    });
+    expect(model.questions).toHaveLength(2);
+    expect(model.questions[0].multiSelect).toBe(true);
+    expect(model.questions[1].multiSelect).toBe(false);
+  });
+
+  it("falls back to a flat {question, options} shape", () => {
+    const model = parseUserInput("AskUserQuestion", {
+      question: "Proceed?",
+      options: [{ label: "Yes" }, { label: "No" }],
+    });
+    expect(model.questions).toHaveLength(1);
+    expect(model.questions[0].prompt).toBe("Proceed?");
+    expect(model.questions[0].options).toHaveLength(2);
+  });
+
+  it("never throws on garbage input", () => {
+    expect(parseUserInput("AskUserQuestion", null).questions).toEqual([]);
+    expect(parseUserInput("AskUserQuestion", { questions: "nope" }).questions).toEqual(
+      [],
+    );
+  });
+});
+
+describe("parseUserInput — ExitPlanMode", () => {
+  it("renders the plan as a body with approve/reject options", () => {
+    const model = parseUserInput("ExitPlanMode", { plan: "1. Do thing\n2. Profit" });
+    expect(model.tool).toBe("ExitPlanMode");
+    expect(model.questions).toHaveLength(1);
+    const q = model.questions[0];
+    expect(q.body).toBe("1. Do thing\n2. Profit");
+    expect(q.options.map((o) => o.label)).toEqual(["Approve & proceed", "Keep planning"]);
+    expect(q.options[0].recommended).toBe(true);
+    expect(q.allowOther).toBe(true);
+  });
+});
+
+describe("formatToolResult", () => {
+  const opt = (label: string): UIAnswer => ({ labels: [label], isOther: false });
+
+  it("sends just the answer for a single question", () => {
+    const model = parseUserInput("AskUserQuestion", {
+      questions: [{ question: "DB?", options: [{ label: "Postgres" }] }],
+    });
+    expect(formatToolResult(model, [opt("Postgres")])).toBe("Postgres");
+  });
+
+  it("joins multiSelect labels with commas", () => {
+    const model = parseUserInput("AskUserQuestion", {
+      questions: [{ question: "Langs?", multiSelect: true, options: [] }],
+    });
+    expect(
+      formatToolResult(model, [{ labels: ["TS", "Rust"], isOther: false }]),
+    ).toBe("TS, Rust");
+  });
+
+  it("labels each line for multi-question calls", () => {
+    const model = parseUserInput("AskUserQuestion", {
+      questions: [
+        { question: "DB?", header: "Storage", options: [] },
+        { question: "License?", header: "License", options: [] },
+      ],
+    });
+    const out = formatToolResult(model, [opt("Postgres"), opt("MIT")]);
+    expect(out).toBe("Storage: Postgres\nLicense: MIT");
+  });
+
+  it("approves or keeps planning for ExitPlanMode", () => {
+    const model = parseUserInput("ExitPlanMode", { plan: "x" });
+    expect(formatToolResult(model, [opt("Approve & proceed")])).toBe(
+      "Approved. Proceed with the plan.",
+    );
+    expect(formatToolResult(model, [opt("Keep planning")])).toBe(
+      "Not yet — keep planning.",
+    );
+  });
+
+  it("includes free-text feedback when keeping planning", () => {
+    const model = parseUserInput("ExitPlanMode", { plan: "x" });
+    const out = formatToolResult(model, [
+      { labels: ["Use a queue instead"], isOther: true },
+    ]);
+    expect(out).toBe("Not yet — keep planning. Use a queue instead");
+  });
+});

--- a/src/components/Workspace/messages/UserInput/parse.test.ts
+++ b/src/components/Workspace/messages/UserInput/parse.test.ts
@@ -3,6 +3,7 @@ import {
   isUserInputTool,
   parseUserInput,
   formatAnswer,
+  buildAnswers,
   type UIAnswer,
 } from "./parse";
 
@@ -133,5 +134,30 @@ describe("formatAnswer", () => {
       { labels: ["Use a queue instead"], isOther: true },
     ]);
     expect(out).toBe("Not yet — keep planning. Use a queue instead");
+  });
+});
+
+describe("buildAnswers", () => {
+  const opt = (label: string): UIAnswer => ({ labels: [label], isOther: false });
+
+  it("keys answers by original question text", () => {
+    const model = parseUserInput("AskUserQuestion", {
+      questions: [{ question: "Which DB?", options: [{ label: "Postgres" }] }],
+    });
+    expect(buildAnswers(model, [opt("Postgres")])).toEqual({ "Which DB?": "Postgres" });
+  });
+
+  it("returns an array for multiSelect and a joined string otherwise", () => {
+    const model = parseUserInput("AskUserQuestion", {
+      questions: [
+        { question: "Langs?", multiSelect: true, options: [] },
+        { question: "License?", options: [] },
+      ],
+    });
+    const out = buildAnswers(model, [
+      { labels: ["TS", "Rust"], isOther: false },
+      opt("MIT"),
+    ]);
+    expect(out).toEqual({ "Langs?": ["TS", "Rust"], "License?": "MIT" });
   });
 });

--- a/src/components/Workspace/messages/UserInput/parse.test.ts
+++ b/src/components/Workspace/messages/UserInput/parse.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   isUserInputTool,
   parseUserInput,
-  formatToolResult,
+  formatAnswer,
   type UIAnswer,
 } from "./parse";
 
@@ -87,14 +87,14 @@ describe("parseUserInput — ExitPlanMode", () => {
   });
 });
 
-describe("formatToolResult", () => {
+describe("formatAnswer", () => {
   const opt = (label: string): UIAnswer => ({ labels: [label], isOther: false });
 
   it("sends just the answer for a single question", () => {
     const model = parseUserInput("AskUserQuestion", {
       questions: [{ question: "DB?", options: [{ label: "Postgres" }] }],
     });
-    expect(formatToolResult(model, [opt("Postgres")])).toBe("Postgres");
+    expect(formatAnswer(model, [opt("Postgres")])).toBe("Postgres");
   });
 
   it("joins multiSelect labels with commas", () => {
@@ -102,7 +102,7 @@ describe("formatToolResult", () => {
       questions: [{ question: "Langs?", multiSelect: true, options: [] }],
     });
     expect(
-      formatToolResult(model, [{ labels: ["TS", "Rust"], isOther: false }]),
+      formatAnswer(model, [{ labels: ["TS", "Rust"], isOther: false }]),
     ).toBe("TS, Rust");
   });
 
@@ -113,23 +113,23 @@ describe("formatToolResult", () => {
         { question: "License?", header: "License", options: [] },
       ],
     });
-    const out = formatToolResult(model, [opt("Postgres"), opt("MIT")]);
+    const out = formatAnswer(model, [opt("Postgres"), opt("MIT")]);
     expect(out).toBe("Storage: Postgres\nLicense: MIT");
   });
 
   it("approves or keeps planning for ExitPlanMode", () => {
     const model = parseUserInput("ExitPlanMode", { plan: "x" });
-    expect(formatToolResult(model, [opt("Approve & proceed")])).toBe(
+    expect(formatAnswer(model, [opt("Approve & proceed")])).toBe(
       "Approved. Proceed with the plan.",
     );
-    expect(formatToolResult(model, [opt("Keep planning")])).toBe(
+    expect(formatAnswer(model, [opt("Keep planning")])).toBe(
       "Not yet — keep planning.",
     );
   });
 
   it("includes free-text feedback when keeping planning", () => {
     const model = parseUserInput("ExitPlanMode", { plan: "x" });
-    const out = formatToolResult(model, [
+    const out = formatAnswer(model, [
       { labels: ["Use a queue instead"], isOther: true },
     ]);
     expect(out).toBe("Not yet — keep planning. Use a queue instead");

--- a/src/components/Workspace/messages/UserInput/parse.test.ts
+++ b/src/components/Workspace/messages/UserInput/parse.test.ts
@@ -121,12 +121,16 @@ describe("formatAnswer", () => {
 
   it("approves or keeps planning for ExitPlanMode", () => {
     const model = parseUserInput("ExitPlanMode", { plan: "x" });
-    expect(formatAnswer(model, [opt("Approve & proceed")])).toBe(
-      "Approved. Proceed with the plan.",
-    );
-    expect(formatAnswer(model, [opt("Keep planning")])).toBe(
-      "Not yet — keep planning.",
-    );
+    expect(
+      formatAnswer(model, [
+        { labels: ["Approve & proceed"], optionIds: ["approve"], isOther: false },
+      ]),
+    ).toBe("Approved. Proceed with the plan.");
+    expect(
+      formatAnswer(model, [
+        { labels: ["Keep planning"], optionIds: ["reject"], isOther: false },
+      ]),
+    ).toBe("Not yet — keep planning.");
   });
 
   it("includes free-text feedback when keeping planning", () => {

--- a/src/components/Workspace/messages/UserInput/parse.test.ts
+++ b/src/components/Workspace/messages/UserInput/parse.test.ts
@@ -4,6 +4,7 @@ import {
   parseUserInput,
   formatAnswer,
   buildAnswers,
+  answersFromResultText,
   type UIAnswer,
 } from "./parse";
 
@@ -134,6 +135,35 @@ describe("formatAnswer", () => {
       { labels: ["Use a queue instead"], isOther: true },
     ]);
     expect(out).toBe("Not yet — keep planning. Use a queue instead");
+  });
+});
+
+describe("answersFromResultText", () => {
+  const model = parseUserInput("AskUserQuestion", {
+    questions: [
+      {
+        question: "Do you prefer tabs or spaces for indentation?",
+        options: [{ label: "Tabs" }, { label: "Spaces" }],
+      },
+    ],
+  });
+
+  it("reconstructs a chosen option label from the CLI result sentence", () => {
+    const text =
+      'Your questions have been answered: "Do you prefer tabs or spaces for indentation?"="Tabs". You can now continue with these answers in mind.';
+    const out = answersFromResultText(model, text);
+    expect(out).toEqual([{ labels: ["Tabs"], isOther: false }]);
+  });
+
+  it("flags a free-text answer that isn't one of the options as isOther", () => {
+    const text =
+      'Your questions have been answered: "Do you prefer tabs or spaces for indentation?"="whatever the file uses".';
+    const out = answersFromResultText(model, text);
+    expect(out).toEqual([{ labels: ["whatever the file uses"], isOther: true }]);
+  });
+
+  it("returns null when nothing parses", () => {
+    expect(answersFromResultText(model, "no pairs here")).toBeNull();
   });
 });
 

--- a/src/components/Workspace/messages/UserInput/parse.ts
+++ b/src/components/Workspace/messages/UserInput/parse.ts
@@ -129,10 +129,12 @@ export function parseUserInput(
   return { tool, questions };
 }
 
-/** Build the `tool_result` text sent back to Claude from the collected answers.
- *  Single-question calls send just the answer; multi-question calls label each
- *  line with its header/prompt so the model can tell them apart. */
-export function formatToolResult(
+/** Build the answer text sent back to the agent as the next user message.
+ *  The CLI auto-rejects AskUserQuestion in headless mode before we could return
+ *  a real tool_result (see UserInput/index.tsx), so the answer rides in as a
+ *  normal turn instead. Single-question calls send just the answer;
+ *  multi-question calls label each line so the model can tell them apart. */
+export function formatAnswer(
   model: UserInputModel,
   answers: UIAnswer[],
 ): string {

--- a/src/components/Workspace/messages/UserInput/parse.ts
+++ b/src/components/Workspace/messages/UserInput/parse.ts
@@ -129,6 +129,23 @@ export function parseUserInput(
   return { tool, questions };
 }
 
+/** Build the `answers` map for an `AskUserQuestion` tool result: keys are the
+ *  original question text, values the chosen option label(s) (an array for
+ *  multiSelect, the user's free text for an "other" answer). This is merged
+ *  into the tool's input and returned to the model via the control protocol. */
+export function buildAnswers(
+  model: UserInputModel,
+  answers: UIAnswer[],
+): Record<string, string | string[]> {
+  const out: Record<string, string | string[]> = {};
+  model.questions.forEach((q, i) => {
+    const a = answers[i];
+    if (!a) return;
+    out[q.prompt] = q.multiSelect ? a.labels : a.labels.join(", ");
+  });
+  return out;
+}
+
 /** Build the answer text sent back to the agent as the next user message.
  *  The CLI auto-rejects AskUserQuestion in headless mode before we could return
  *  a real tool_result (see UserInput/index.tsx), so the answer rides in as a

--- a/src/components/Workspace/messages/UserInput/parse.ts
+++ b/src/components/Workspace/messages/UserInput/parse.ts
@@ -1,0 +1,158 @@
+// Normalizes the two Claude tools that pause to ask the user — `AskUserQuestion`
+// (structured multiple-choice) and `ExitPlanMode` (plan approval) — into one
+// model the widget renders, plus the inverse: turning the user's picks back
+// into the `tool_result` text we feed to Claude's stdin to unblock the turn.
+//
+// Only Claude surfaces these in the custom-view JSON stream today; every other
+// provider Quorum drives runs fully auto-approved (see the adapter map). The
+// model is provider-agnostic, so any tool reported under these names renders
+// the widget without per-adapter branching.
+
+export const USER_INPUT_TOOLS = ["AskUserQuestion", "ExitPlanMode"] as const;
+export type UserInputTool = (typeof USER_INPUT_TOOLS)[number];
+
+export function isUserInputTool(name: string): name is UserInputTool {
+  return (USER_INPUT_TOOLS as readonly string[]).includes(name);
+}
+
+export interface UIOption {
+  id: string;
+  label: string;
+  desc?: string;
+  recommended?: boolean;
+}
+
+export interface UIQuestion {
+  id: string;
+  /** Short context tag shown in the card header (AskUserQuestion `header`). */
+  header?: string;
+  /** The question text itself. */
+  prompt: string;
+  /** Optional markdown body shown above the options (the ExitPlanMode plan). */
+  body?: string;
+  options: UIOption[];
+  multiSelect: boolean;
+  /** Whether to offer the free-text "Something else…" escape hatch. */
+  allowOther: boolean;
+}
+
+export interface UserInputModel {
+  tool: UserInputTool;
+  questions: UIQuestion[];
+}
+
+/** One answer per question: the chosen option labels (one unless multiSelect),
+ *  or free-text when the user took the "Something else…" path. */
+export interface UIAnswer {
+  labels: string[];
+  /** True when the labels came from the free-text composer, not an option. */
+  isOther: boolean;
+}
+
+function asRecord(v: unknown): Record<string, unknown> {
+  return v && typeof v === "object" ? (v as Record<string, unknown>) : {};
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+
+function parseOptions(raw: unknown): UIOption[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.map((o, i) => {
+    const r = asRecord(o);
+    return {
+      id: asString(r.id) ?? `opt-${i}`,
+      label: asString(r.label) ?? asString(r.title) ?? `Option ${i + 1}`,
+      desc: asString(r.description) ?? asString(r.desc),
+      recommended: r.recommended === true,
+    };
+  });
+}
+
+function parseAskUserQuestion(input: Record<string, unknown>): UIQuestion[] {
+  const raw = Array.isArray(input.questions) ? input.questions : [];
+  const questions = raw.map((q, i): UIQuestion => {
+    const r = asRecord(q);
+    return {
+      id: asString(r.id) ?? `q-${i}`,
+      header: asString(r.header),
+      prompt: asString(r.question) ?? asString(r.prompt) ?? "",
+      options: parseOptions(r.options),
+      multiSelect: r.multiSelect === true,
+      allowOther: true,
+    };
+  });
+  // Defensive fallback: a flat {question, options} shape with no `questions[]`.
+  if (questions.length === 0 && (input.question || input.options)) {
+    return [
+      {
+        id: "q-0",
+        header: asString(input.header),
+        prompt: asString(input.question) ?? "",
+        options: parseOptions(input.options),
+        multiSelect: input.multiSelect === true,
+        allowOther: true,
+      },
+    ];
+  }
+  return questions;
+}
+
+function parseExitPlanMode(input: Record<string, unknown>): UIQuestion[] {
+  const plan = asString(input.plan) ?? "";
+  return [
+    {
+      id: "plan",
+      header: "Plan review",
+      prompt: "Ready to proceed with this plan?",
+      body: plan || undefined,
+      options: [
+        { id: "approve", label: "Approve & proceed", recommended: true },
+        { id: "reject", label: "Keep planning" },
+      ],
+      multiSelect: false,
+      allowOther: true,
+    },
+  ];
+}
+
+export function parseUserInput(
+  tool: UserInputTool,
+  rawInput: unknown,
+): UserInputModel {
+  const input = asRecord(rawInput);
+  const questions =
+    tool === "ExitPlanMode"
+      ? parseExitPlanMode(input)
+      : parseAskUserQuestion(input);
+  return { tool, questions };
+}
+
+/** Build the `tool_result` text sent back to Claude from the collected answers.
+ *  Single-question calls send just the answer; multi-question calls label each
+ *  line with its header/prompt so the model can tell them apart. */
+export function formatToolResult(
+  model: UserInputModel,
+  answers: UIAnswer[],
+): string {
+  if (model.tool === "ExitPlanMode") {
+    const a = answers[0];
+    const picked = a?.labels[0] ?? "";
+    if (a?.isOther) {
+      return `Not yet — keep planning. ${a.labels.join(" ")}`.trim();
+    }
+    return picked === "Approve & proceed"
+      ? "Approved. Proceed with the plan."
+      : "Not yet — keep planning.";
+  }
+
+  const lines = model.questions.map((q, i) => {
+    const a = answers[i];
+    const value = a ? a.labels.join(", ") : "";
+    if (model.questions.length === 1) return value;
+    const tag = q.header || q.prompt;
+    return `${tag}: ${value}`;
+  });
+  return lines.join("\n");
+}

--- a/src/components/Workspace/messages/UserInput/parse.ts
+++ b/src/components/Workspace/messages/UserInput/parse.ts
@@ -129,6 +129,34 @@ export function parseUserInput(
   return { tool, questions };
 }
 
+/** Reconstruct per-question answers from the tool_result the CLI writes once an
+ *  AskUserQuestion is answered — format: `… "Question"="Answer", "Q2"="A2". …`.
+ *  Lets a widget rebuilt from the transcript show the same clean answer chips as
+ *  the live session, instead of the raw sentence. Returns one entry per question
+ *  (null where unmatched), or null if nothing parsed. An answer that isn't one
+ *  of the question's option labels is flagged `isOther` (free text). */
+export function answersFromResultText(
+  model: UserInputModel,
+  text: string,
+): (UIAnswer | null)[] | null {
+  const pairs: Record<string, string> = {};
+  const re = /"([^"]+)"\s*=\s*"([^"]*)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) pairs[m[1]] = m[2];
+
+  let matched = false;
+  const answers = model.questions.map((q): UIAnswer | null => {
+    const value = pairs[q.prompt];
+    if (value == null) return null;
+    matched = true;
+    return {
+      labels: [value],
+      isOther: !q.options.some((o) => o.label === value),
+    };
+  });
+  return matched ? answers : null;
+}
+
 /** Build the `answers` map for an `AskUserQuestion` tool result: keys are the
  *  original question text, values the chosen option label(s) (an array for
  *  multiSelect, the user's free text for an "other" answer). This is merged

--- a/src/components/Workspace/messages/UserInput/parse.ts
+++ b/src/components/Workspace/messages/UserInput/parse.ts
@@ -45,6 +45,8 @@ export interface UserInputModel {
  *  or free-text when the user took the "Something else…" path. */
 export interface UIAnswer {
   labels: string[];
+  /** Original option ids for non-free-text answers, used for tool semantics. */
+  optionIds?: string[];
   /** True when the labels came from the free-text composer, not an option. */
   isOther: boolean;
 }
@@ -185,11 +187,11 @@ export function formatAnswer(
 ): string {
   if (model.tool === "ExitPlanMode") {
     const a = answers[0];
-    const picked = a?.labels[0] ?? "";
+    const picked = a?.optionIds?.[0] ?? a?.labels[0] ?? "";
     if (a?.isOther) {
       return `Not yet — keep planning. ${a.labels.join(" ")}`.trim();
     }
-    return picked === "Approve & proceed"
+    return picked === "approve" || picked === "Approve & proceed"
       ? "Approved. Proceed with the plan."
       : "Not yet — keep planning.";
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -208,6 +208,13 @@ interface AppState {
   lastError: string | null;
   initialized: boolean;
   managedLogs: Record<string, ChatItem[]>;
+  /** Question tools the agent is paused on, awaiting a human answer.
+   *  Keyed by agent id, then by the tool_use id of the held `AskUserQuestion`
+   *  call → the control-protocol `request_id` to answer it with. Populated when
+   *  the backend forwards a held `can_use_tool` request; cleared on answer or
+   *  turn end. The widget uses it to know a question is answerable and to route
+   *  the answer back as the tool result (the real pause). */
+  pendingToolUse: Record<string, Record<string, string>>;
   /** True while an on-disk Claude transcript is being replayed into
    *  the custom-view log. */
   transcriptLoading: Record<string, boolean>;
@@ -354,6 +361,16 @@ interface AppState {
     text: string,
     attachments?: string[],
     thinking?: string,
+  ) => Promise<void>;
+  /** Answer a paused question tool (Claude's AskUserQuestion). Looks up the
+   *  held control-protocol request for `toolUseId` and delivers `updatedInput`
+   *  (the tool's input with the user's `answers` merged in) as the tool result,
+   *  resuming the turn. No-op if no held request matches (e.g. replayed
+   *  history, where the answer routes as a normal message instead). */
+  answerToolUse: (
+    id: string,
+    toolUseId: string,
+    updatedInput: unknown,
   ) => Promise<void>;
   switchView: (id: string, view: AgentView) => Promise<void>;
   resume: (id: string) => Promise<void>;
@@ -644,6 +661,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   updateReadyVersion: null,
   initialized: false,
   managedLogs: {},
+  pendingToolUse: {},
   transcriptLoading: {},
   transcriptLoaded: {},
   managedBusy: {},
@@ -748,12 +766,42 @@ export const useAppStore = create<AppState>((set, get) => ({
     });
 
     await onAgentEvent((e) => {
+      const ev = e.event as RawEvent;
+      // A held permission prompt the backend forwarded for a human to answer
+      // (Claude's AskUserQuestion). Record request_id ↔ tool_use_id so the
+      // widget can answer it; this is control plane, not a transcript event, so
+      // don't feed the reducer. The agent is paused awaiting input — the
+      // composer stays disabled (busy) and ChatView hides the "thinking" dots.
+      if (ev?.type === "control_request") {
+        const req = (ev as { request?: Record<string, unknown> }).request;
+        const requestId = (ev as { request_id?: string }).request_id;
+        const toolUseId = req?.tool_use_id;
+        if (req?.subtype === "can_use_tool" && typeof toolUseId === "string" && requestId) {
+          set((state) => ({
+            pendingToolUse: {
+              ...state.pendingToolUse,
+              [e.agent_id]: {
+                ...(state.pendingToolUse[e.agent_id] ?? {}),
+                [toolUseId]: requestId,
+              },
+            },
+          }));
+        }
+        return;
+      }
       let turnEnded = false;
       set((state) => {
         const result = applyEvent(state, e.agent_id, e.event as RawEvent);
         turnEnded = result.turnEnded;
         return result.patch;
       });
+      // A turn can't end with prompts still held — clear any stale entries
+      // (e.g. an interrupt that denied a pending question).
+      if (turnEnded && get().pendingToolUse[e.agent_id]) {
+        set((state) => ({
+          pendingToolUse: { ...state.pendingToolUse, [e.agent_id]: {} },
+        }));
+      }
       // Side effect lives here, at the call-site, rather than inside the pure
       // updater: chime when an agent turn lands successfully. Skip it if the
       // user stopped this agent — the turn_end is just the killed process
@@ -1046,6 +1094,31 @@ export const useAppStore = create<AppState>((set, get) => ({
           throw e;
         }
       }
+    } catch (e) {
+      set((state) => ({
+        lastError: String(e),
+        managedBusy: { ...state.managedBusy, [id]: false },
+      }));
+    }
+  },
+
+  answerToolUse: async (id, toolUseId, updatedInput) => {
+    const requestId = get().pendingToolUse[id]?.[toolUseId];
+    if (!requestId) return;
+    // Drop the held prompt and mark busy: feeding the answer resumes the
+    // paused turn. The transcript records the resulting tool_result, so there's
+    // no separate durable row to write.
+    set((state) => {
+      const forAgent = { ...(state.pendingToolUse[id] ?? {}) };
+      delete forAgent[toolUseId];
+      return {
+        pendingToolUse: { ...state.pendingToolUse, [id]: forAgent },
+        managedBusy: { ...state.managedBusy, [id]: true },
+        managedBusyLabel: { ...state.managedBusyLabel, [id]: undefined },
+      };
+    });
+    try {
+      await api.answerToolUse(id, requestId, updatedInput);
     } catch (e) {
       set((state) => ({
         lastError: String(e),

--- a/src/store.ts
+++ b/src/store.ts
@@ -362,15 +362,18 @@ interface AppState {
     attachments?: string[],
     thinking?: string,
   ) => Promise<void>;
-  /** Answer a paused question tool (Claude's AskUserQuestion). Looks up the
-   *  held control-protocol request for `toolUseId` and delivers `updatedInput`
-   *  (the tool's input with the user's `answers` merged in) as the tool result,
-   *  resuming the turn. No-op if no held request matches (e.g. replayed
-   *  history, where the answer routes as a normal message instead). */
+  /** Answer a paused user-input tool (Claude's AskUserQuestion/ExitPlanMode).
+   *  Looks up the held control-protocol request for `toolUseId` and delivers
+   *  `updatedInput` (the tool's input with the user's `answers` merged in) as
+   *  an allow/deny control response, resuming the turn. No-op if no held request
+   *  matches (e.g. replayed history, where the answer routes as a normal
+   *  message instead). */
   answerToolUse: (
     id: string,
     toolUseId: string,
     updatedInput: unknown,
+    behavior?: "allow" | "deny",
+    message?: string,
   ) => Promise<void>;
   switchView: (id: string, view: AgentView) => Promise<void>;
   resume: (id: string) => Promise<void>;
@@ -768,9 +771,9 @@ export const useAppStore = create<AppState>((set, get) => ({
     await onAgentEvent((e) => {
       const ev = e.event as RawEvent;
       // A held permission prompt the backend forwarded for a human to answer
-      // (Claude's AskUserQuestion). Record request_id ↔ tool_use_id so the
-      // widget can answer it; this is control plane, not a transcript event, so
-      // don't feed the reducer. The agent is paused awaiting input — the
+      // (Claude's AskUserQuestion / ExitPlanMode). Record request_id ↔
+      // tool_use_id so the widget can answer it; this is control plane, not a
+      // transcript event, so don't feed the reducer. The agent is paused awaiting input — the
       // composer stays disabled (busy) and ChatView hides the "thinking" dots.
       if (ev?.type === "control_request") {
         const req = (ev as { request?: Record<string, unknown> }).request;
@@ -1102,7 +1105,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     }
   },
 
-  answerToolUse: async (id, toolUseId, updatedInput) => {
+  answerToolUse: async (id, toolUseId, updatedInput, behavior = "allow", message) => {
     const requestId = get().pendingToolUse[id]?.[toolUseId];
     if (!requestId) return;
     // Drop the held prompt and mark busy: feeding the answer resumes the
@@ -1118,7 +1121,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       };
     });
     try {
-      await api.answerToolUse(id, requestId, updatedInput);
+      await api.answerToolUse(id, requestId, updatedInput, behavior, message);
     } catch (e) {
       set((state) => ({
         lastError: String(e),

--- a/src/store.ts
+++ b/src/store.ts
@@ -355,13 +355,6 @@ interface AppState {
     attachments?: string[],
     thinking?: string,
   ) => Promise<void>;
-  /** Answer a paused tool call (Claude's AskUserQuestion / ExitPlanMode) by
-   *  writing a tool_result keyed to `toolUseId` to the agent's stdin. */
-  sendToolResult: (
-    id: string,
-    toolUseId: string,
-    content: string,
-  ) => Promise<void>;
   switchView: (id: string, view: AgentView) => Promise<void>;
   resume: (id: string) => Promise<void>;
   stop: (id: string) => Promise<void>;
@@ -1053,24 +1046,6 @@ export const useAppStore = create<AppState>((set, get) => ({
           throw e;
         }
       }
-    } catch (e) {
-      set((state) => ({
-        lastError: String(e),
-        managedBusy: { ...state.managedBusy, [id]: false },
-      }));
-    }
-  },
-
-  sendToolResult: async (id, toolUseId, content) => {
-    // Mark busy optimistically: feeding the tool_result unblocks the paused
-    // turn, so the agent resumes immediately. The transcript records the
-    // injected result, so no durable user-turn row is needed here.
-    set((state) => ({
-      managedBusy: { ...state.managedBusy, [id]: true },
-      managedBusyLabel: { ...state.managedBusyLabel, [id]: undefined },
-    }));
-    try {
-      await api.sendToolResult(id, toolUseId, content);
     } catch (e) {
       set((state) => ({
         lastError: String(e),

--- a/src/store.ts
+++ b/src/store.ts
@@ -355,6 +355,13 @@ interface AppState {
     attachments?: string[],
     thinking?: string,
   ) => Promise<void>;
+  /** Answer a paused tool call (Claude's AskUserQuestion / ExitPlanMode) by
+   *  writing a tool_result keyed to `toolUseId` to the agent's stdin. */
+  sendToolResult: (
+    id: string,
+    toolUseId: string,
+    content: string,
+  ) => Promise<void>;
   switchView: (id: string, view: AgentView) => Promise<void>;
   resume: (id: string) => Promise<void>;
   stop: (id: string) => Promise<void>;
@@ -1046,6 +1053,24 @@ export const useAppStore = create<AppState>((set, get) => ({
           throw e;
         }
       }
+    } catch (e) {
+      set((state) => ({
+        lastError: String(e),
+        managedBusy: { ...state.managedBusy, [id]: false },
+      }));
+    }
+  },
+
+  sendToolResult: async (id, toolUseId, content) => {
+    // Mark busy optimistically: feeding the tool_result unblocks the paused
+    // turn, so the agent resumes immediately. The transcript records the
+    // injected result, so no durable user-turn row is needed here.
+    set((state) => ({
+      managedBusy: { ...state.managedBusy, [id]: true },
+      managedBusyLabel: { ...state.managedBusyLabel, [id]: undefined },
+    }));
+    try {
+      await api.sendToolResult(id, toolUseId, content);
     } catch (e) {
       set((state) => ({
         lastError: String(e),


### PR DESCRIPTION
Renders Claude's `AskUserQuestion` / `ExitPlanMode` tool calls as an interactive "Needs your input" card — options with descriptions, "Recommended" badges, multi-select, number-key shortcuts, and a "Something else…" free-text escape hatch — instead of the previous raw-JSON tool row. Detection lives at the provider-agnostic presenter seam in `MessageItem`; only Claude surfaces these prompts today since every other provider runs fully auto-approved. Answering routes a `tool_result` keyed to the `tool_use` id to Claude's stdin (new `send_tool_result` path through `managed_session → agent → supervisor → command`), which is what unblocks a paused stream-json turn. `ChatView` suppresses the "thinking" spinner while a question is pending, and a replayed transcript folds the widget into a resolved "Answered" summary. Includes a normalization/format layer (`parse.ts`) with unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)