### PR TITLE
Fork new workspaces from fresh remote state

### DIFF
--- a/src-tauri/migrations/0008_worktree_base_sha.sql
+++ b/src-tauri/migrations/0008_worktree_base_sha.sql
@@ -1,0 +1,6 @@
+-- The immutable fork-point commit a worktree was created from. Captured at
+-- spawn time (after a best-effort fetch of the parent branch) so diffs are
+-- measured against the exact commit the agent started from, not a branch name
+-- that may resolve to stale local state. NULL for agents created before this
+-- column existed; readers fall back to the parent branch name.
+ALTER TABLE worktrees ADD COLUMN base_sha TEXT;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -24,6 +24,17 @@ pub fn get_workspace(supervisor: State<'_, Arc<Supervisor>>) -> Option<Workspace
     supervisor.current_workspace()
 }
 
+/// The ref a worktree's *committed* changes are diffed against: the immutable
+/// fork-point SHA captured at spawn when known, else the parent branch name
+/// (pre-migration agents), which may have drifted from the actual fork point.
+/// PR/merge/rebase bases and ahead/behind use `parent_branch` directly instead,
+/// since those need a live branch name, not a commit.
+fn diff_base(repo: &TrackedRepo) -> Option<String> {
+    repo.base_sha
+        .clone()
+        .or_else(|| repo.parent_branch.clone())
+}
+
 #[tauri::command]
 pub async fn get_agent_diff_stats(
     supervisor: State<'_, Arc<Supervisor>>,
@@ -34,7 +45,8 @@ pub async fn get_agent_diff_stats(
 
     for repo in &record.repos {
         let worktree = repo_worktree_path(&agent_id, &repo.subdir)?;
-        let base_ref = repo.parent_branch.as_deref().unwrap_or("HEAD");
+        let base = diff_base(repo);
+        let base_ref = base.as_deref().unwrap_or("HEAD");
         let diff = match git::worktree_diff_shortstat(&worktree, base_ref).await {
             Ok(diff) => diff,
             Err(err) if base_ref != "HEAD" => {
@@ -748,7 +760,8 @@ fn primary_worktree(
         .first()
         .ok_or_else(|| Error::Other("agent has no repos".into()))?;
     let worktree = repo_worktree_path(agent_id, &repo.subdir)?;
-    let parent = repo.parent_branch.clone().unwrap_or_else(|| "main".to_string());
+    // File tree / per-file diffs compare committed work against the fork point.
+    let parent = diff_base(repo).unwrap_or_else(|| "main".to_string());
     Ok((worktree, parent))
 }
 

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -37,6 +37,7 @@ fn get_migrations() -> Migrations<'static> {
         M::up(include_str!("../migrations/0005_session_ingest_offset.sql")),
         M::up(include_str!("../migrations/0006_session_effort.sql")),
         M::up(include_str!("../migrations/0007_account_oauth.sql")),
+        M::up(include_str!("../migrations/0008_worktree_base_sha.sql")),
     ])
 }
 

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -4,9 +4,18 @@
 //! worktree on a fresh branch and remove it later.
 
 use std::path::Path;
+use std::time::Duration;
 use tokio::process::Command;
 
 use crate::error::{Error, Result};
+
+/// Hard cap on the spawn-time `git fetch`. A fetch over a hung SSH/TCP
+/// connection can otherwise block for the OS keep-alive window (75–120s), far
+/// past the supervisor's 15s spawn watchdog — which would mark the agent
+/// `Error` while the background task later still runs `start_process`, leaving
+/// a live process under a failed-looking agent. Bounding it keeps the fetch
+/// inside the spawn budget; on timeout we fall back to local HEAD.
+const FETCH_TIMEOUT: Duration = Duration::from_secs(8);
 
 /// Create a worktree on detached HEAD (no branch yet). Used by the
 /// instant-spawn flow so we don't pollute `git branch` for agents
@@ -52,13 +61,21 @@ pub async fn worktree_add_detached(
 /// Never errors: a missing `origin`, an offline machine, or a purely local
 /// branch are all expected and simply mean "use local state".
 pub async fn fetch_fork_point(repo: &Path, branch: &str) -> Option<String> {
-    let fetched = Command::new("git")
-        .current_dir(repo)
-        .args(["fetch", "origin", branch])
-        .output()
-        .await;
+    // `kill_on_drop` so a timeout actually tears down the hung git process
+    // (and its SSH child) rather than orphaning it to keep blocking on the
+    // dead connection.
+    let fetched = tokio::time::timeout(
+        FETCH_TIMEOUT,
+        Command::new("git")
+            .current_dir(repo)
+            .args(["fetch", "origin", branch])
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await;
+    // Timed out, failed to spawn, or non-zero exit → fall back to local HEAD.
     match fetched {
-        Ok(out) if out.status.success() => {}
+        Ok(Ok(out)) if out.status.success() => {}
         _ => return None,
     }
     // Confirm the remote-tracking ref resolves before handing it back — a

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -13,17 +13,25 @@ use crate::error::{Error, Result};
 /// that may never receive a user message. The branch is created
 /// later via `checkout_new_branch` when we have a slug from the
 /// first user message.
-pub async fn worktree_add_detached(repo: &Path, worktree_path: &Path) -> Result<()> {
+///
+/// `base` is the commit-ish the worktree starts from (e.g. `origin/main`
+/// after a fresh fetch). When `None`, it starts from the repo's current
+/// HEAD — the legacy behavior.
+pub async fn worktree_add_detached(
+    repo: &Path,
+    worktree_path: &Path,
+    base: Option<&str>,
+) -> Result<()> {
+    let path = worktree_path
+        .to_str()
+        .ok_or_else(|| Error::InvalidPath(worktree_path.display().to_string()))?;
+    let mut args = vec!["worktree", "add", "--detach", path];
+    if let Some(base) = base {
+        args.push(base);
+    }
     let out = Command::new("git")
         .current_dir(repo)
-        .args([
-            "worktree",
-            "add",
-            "--detach",
-            worktree_path.to_str().ok_or_else(|| {
-                Error::InvalidPath(worktree_path.display().to_string())
-            })?,
-        ])
+        .args(&args)
         .output()
         .await?;
     if !out.status.success() {
@@ -33,6 +41,31 @@ pub async fn worktree_add_detached(repo: &Path, worktree_path: &Path) -> Result<
         )));
     }
     Ok(())
+}
+
+/// Best-effort fetch of `branch` from `origin` so a freshly-spawned worktree
+/// can fork from the latest remote state rather than a stale local ref.
+/// Returns the commit-ish a worktree should be based on — `origin/<branch>`
+/// when the fetch succeeded and the remote branch resolves — otherwise `None`,
+/// signalling the caller to fall back to local HEAD.
+///
+/// Never errors: a missing `origin`, an offline machine, or a purely local
+/// branch are all expected and simply mean "use local state".
+pub async fn fetch_fork_point(repo: &Path, branch: &str) -> Option<String> {
+    let fetched = Command::new("git")
+        .current_dir(repo)
+        .args(["fetch", "origin", branch])
+        .output()
+        .await;
+    match fetched {
+        Ok(out) if out.status.success() => {}
+        _ => return None,
+    }
+    // Confirm the remote-tracking ref resolves before handing it back — a
+    // refspec that doesn't map this branch into refs/remotes would otherwise
+    // leave us pointing at a ref that `worktree add` can't use.
+    let remote_ref = format!("origin/{branch}");
+    rev_parse(repo, &remote_ref).await.ok().map(|_| remote_ref)
 }
 
 /// Inside an existing worktree, create a new branch at the current
@@ -329,6 +362,49 @@ mod tests {
         let err = commit_all(repo, "second").await.unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("nothing to commit"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn fetch_fork_point_without_remote_is_none() {
+        // No `origin` configured → best-effort fetch fails and we fall back to
+        // local HEAD (None), never an error.
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path();
+        init_repo(repo).await.unwrap();
+        config(repo, "user.email", "t@example.com").await;
+        config(repo, "user.name", "Tester").await;
+        std::fs::write(repo.join("a.txt"), b"x").unwrap();
+        commit_all(repo, "first").await.unwrap();
+
+        assert_eq!(fetch_fork_point(repo, "main").await, None);
+    }
+
+    #[tokio::test]
+    async fn worktree_add_detached_uses_base_commit_when_given() {
+        // A worktree forked from an explicit commit-ish starts at that commit,
+        // not at the repo's current HEAD.
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path();
+        init_repo(repo).await.unwrap();
+        config(repo, "user.email", "t@example.com").await;
+        config(repo, "user.name", "Tester").await;
+
+        std::fs::write(repo.join("a.txt"), b"one").unwrap();
+        commit_all(repo, "first").await.unwrap();
+        let first = rev_parse(repo, "HEAD").await.unwrap();
+        std::fs::write(repo.join("b.txt"), b"two").unwrap();
+        commit_all(repo, "second").await.unwrap();
+
+        // Base the worktree on the first commit even though HEAD is now `second`.
+        let wt = td.path().join("wt");
+        worktree_add_detached(repo, &wt, Some(&first)).await.unwrap();
+        assert_eq!(rev_parse(&wt, "HEAD").await.unwrap(), first);
+
+        // With no base it tracks current HEAD (`second`).
+        let head = rev_parse(repo, "HEAD").await.unwrap();
+        let wt2 = td.path().join("wt2");
+        worktree_add_detached(repo, &wt2, None).await.unwrap();
+        assert_eq!(rev_parse(&wt2, "HEAD").await.unwrap(), head);
     }
 }
 

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -454,12 +454,17 @@ impl Supervisor {
         // branch the user was on when they hit Spawn.
         let parent_branch = git::current_branch(&repo_path).await.ok().flatten();
         let subdir = allocate_repo_subdir(&repo_path, &[]);
+        // Cloned for the background fork task — `parent_branch`/`subdir` are
+        // moved into `primary` below.
+        let parent_for_fork = parent_branch.clone();
+        let subdir_for_fork = subdir.clone();
 
         let primary = TrackedRepo {
             repo_path: repo_path.clone(),
             subdir: subdir.clone(),
             branch: None, // created later from first user message
             parent_branch,
+            base_sha: None, // captured by the fork task once HEAD is known
         };
 
         let mut record = new_agent_record(
@@ -489,9 +494,27 @@ impl Supervisor {
                 return;
             }
 
-            if let Err(e) = git::worktree_add_detached(&repo_path, &primary_worktree).await {
+            // Fork from the freshest remote state of the parent branch so the
+            // agent never starts on stale local refs. Best-effort: offline, no
+            // remote, or a local-only branch all fall back to local HEAD.
+            let base = match &parent_for_fork {
+                Some(b) => git::fetch_fork_point(&repo_path, b).await,
+                None => None,
+            };
+            if let Err(e) =
+                git::worktree_add_detached(&repo_path, &primary_worktree, base.as_deref()).await
+            {
                 fail_spawn(&sup, &app_for_task, &id_for_task, e.to_string());
                 return;
+            }
+
+            // Record the fork point so diffs measure against the exact starting
+            // commit rather than a branch name that can drift. Non-fatal: a
+            // missing base_sha just falls back to the parent branch name.
+            if let Ok(sha) = git::rev_parse(&primary_worktree, "HEAD").await {
+                let _ = sup
+                    .workspace
+                    .set_repo_base_sha(&id_for_task, &subdir_for_fork, &sha);
             }
 
             tokio::time::sleep(Duration::from_millis(350)).await;
@@ -534,13 +557,21 @@ impl Supervisor {
         let worktree = repo_worktree_path(agent_id, &subdir)?;
         let parent_branch = git::current_branch(&repo_path).await.ok().flatten();
 
-        git::worktree_add_detached(&repo_path, &worktree).await?;
+        // Fork from the freshest remote state of the parent branch (best-effort,
+        // falls back to local HEAD), then record the fork point as the diff base.
+        let base = match &parent_branch {
+            Some(b) => git::fetch_fork_point(&repo_path, b).await,
+            None => None,
+        };
+        git::worktree_add_detached(&repo_path, &worktree, base.as_deref()).await?;
+        let base_sha = git::rev_parse(&worktree, "HEAD").await.ok();
 
         let repo = TrackedRepo {
             repo_path: repo_path.clone(),
             subdir: subdir.clone(),
             branch: None,
             parent_branch,
+            base_sha,
         };
         self.workspace
             .append_tracked_repo(agent_id, repo.clone())?;
@@ -975,10 +1006,15 @@ impl Supervisor {
             } else {
                 None
             };
-            let parent_branch_sha = if let Some(b) = &repo.parent_branch {
-                git::rev_parse(&repo.repo_path, b).await.ok()
-            } else {
-                None
+            // Prefer the immutable fork point; only fall back to resolving the
+            // parent branch name (which may have drifted) for pre-migration
+            // agents that never captured a base_sha.
+            let parent_branch_sha = match &repo.base_sha {
+                Some(sha) => Some(sha.clone()),
+                None => match &repo.parent_branch {
+                    Some(b) => git::rev_parse(&repo.repo_path, b).await.ok(),
+                    None => None,
+                },
             };
 
             let mut adds = 0u32;
@@ -1133,6 +1169,11 @@ impl Supervisor {
                 subdir: snap.subdir.clone(),
                 branch: Some(chosen),
                 parent_branch: snap.parent_branch.clone(),
+                // The fork point persists in the worktrees row across
+                // archive/restore (restore_agent doesn't clear base_sha), so
+                // this literal value is never written back — None is a
+                // placeholder to satisfy the struct.
+                base_sha: None,
             });
         }
 
@@ -2458,6 +2499,7 @@ mod tests {
                 subdir: "repo".to_string(),
                 branch: None,
                 parent_branch: None,
+                base_sha: None,
             },
             String::new(),
             AgentView::Custom,

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -57,6 +57,15 @@ pub struct TrackedRepo {
     pub branch: Option<String>,
     #[serde(default)]
     pub parent_branch: Option<String>,
+    /// The immutable fork-point commit this worktree was created from,
+    /// captured at spawn after a best-effort fetch. Used as the diff base so
+    /// agent changes are measured against the exact starting commit rather
+    /// than a branch name that may drift. `None` for pre-migration agents and
+    /// when the fork SHA couldn't be resolved; readers fall back to
+    /// `parent_branch`. Distinct from `parent_branch`, which names the branch
+    /// for PR/merge bases.
+    #[serde(default)]
+    pub base_sha: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -434,6 +443,24 @@ impl WorkspaceManager {
             rusqlite::params![branch, agent_id, subdir],
         )?;
         Ok(changed > 0)
+    }
+
+    /// Record the fork-point SHA for a tracked repo, identified by subdir.
+    /// Written once the spawn task has created the worktree and resolved its
+    /// HEAD. Overwrites unconditionally — the fork point is fixed for the
+    /// worktree's life, so a re-write only ever sets the same value.
+    pub fn set_repo_base_sha(
+        &self,
+        agent_id: &str,
+        subdir: &str,
+        base_sha: &str,
+    ) -> Result<()> {
+        let conn = self.db.lock();
+        conn.execute(
+            "UPDATE worktrees SET base_sha = ?1 WHERE workspace_id = ?2 AND subdir = ?3",
+            rusqlite::params![base_sha, agent_id, subdir],
+        )?;
+        Ok(())
     }
 
     pub fn append_tracked_repo(&self, agent_id: &str, repo: TrackedRepo) -> Result<()> {
@@ -1059,7 +1086,7 @@ impl WorkspaceManager {
 
     fn query_tracked_repos(conn: &Connection, agent_id: &str) -> Vec<TrackedRepo> {
         let mut stmt = match conn.prepare(
-            "SELECT r.path, w.subdir, w.branch, w.parent_branch
+            "SELECT r.path, w.subdir, w.branch, w.parent_branch, w.base_sha
              FROM worktrees w
              JOIN repos r ON r.id = w.repo_id
              WHERE w.workspace_id = ?1
@@ -1074,11 +1101,13 @@ impl WorkspaceManager {
             let subdir: String = row.get(1)?;
             let branch: Option<String> = row.get(2)?;
             let parent_branch: Option<String> = row.get(3)?;
+            let base_sha: Option<String> = row.get(4)?;
             Ok(TrackedRepo {
                 repo_path: PathBuf::from(path),
                 subdir,
                 branch,
                 parent_branch,
+                base_sha,
             })
         })
         .ok()
@@ -1223,8 +1252,8 @@ impl WorkspaceManager {
 
         let wt_id = uuid::Uuid::new_v4().to_string();
         conn.execute(
-            "INSERT INTO worktrees (id, workspace_id, repo_id, subdir, branch, parent_branch, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            "INSERT INTO worktrees (id, workspace_id, repo_id, subdir, branch, parent_branch, base_sha, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
             rusqlite::params![
                 wt_id,
                 agent_id,
@@ -1232,6 +1261,7 @@ impl WorkspaceManager {
                 repo.subdir,
                 repo.branch,
                 repo.parent_branch,
+                repo.base_sha,
                 now_millis(),
             ],
         )?;
@@ -1436,6 +1466,7 @@ mod tests {
             subdir: "repo".into(),
             branch: None,
             parent_branch: None,
+            base_sha: None,
         }
     }
 
@@ -1705,6 +1736,7 @@ mod tests {
             subdir: "repo".into(),
             branch: Some("quorum/do-the-thing".into()),
             parent_branch: Some("main".into()),
+            base_sha: None,
         }];
         wm.restore_agent(&id, restored).unwrap();
         let a = wm.agent(&id).unwrap();
@@ -1768,6 +1800,7 @@ mod tests {
                 subdir: "repo".into(),
                 branch: None,
                 parent_branch: None,
+                base_sha: None,
             },
             "task".into(),
             AgentView::Custom,


### PR DESCRIPTION
## Problem

When a workspace was created, its worktree was forked from the main repo's
**local** HEAD. If the local clone was behind `origin`, the agent started on
stale code with no fetch anywhere in the spawn path — the only `git fetch`
lived in the `git_update_branch` RPC, which the agent had to invoke manually.

## Fix

Best-effort `git fetch origin <branch>` before forking, base the worktree on
`origin/<branch>` when it resolves, and record the resulting HEAD as an
immutable fork-point `base_sha`. Surfaces that diff **committed** work now
measure against that SHA instead of the parent branch name (which can drift),
so freshly-pulled base commits no longer appear as phantom agent changes.

### The gotcha this avoids

`parent_branch` was reused as both the diff base and the PR/merge base. Forking
from `origin/<branch>` while diffing against the local branch name would show
every base commit the clone was behind by as "agent changes." So the diff base
(fork-point SHA) is now separated from the PR base (branch name).

## Changes

- **`git.rs`** — `worktree_add_detached` takes an optional base commit-ish; new
  `fetch_fork_point` helper (returns `origin/<branch>` or `None`, never errors).
- **`supervisor.rs`** — fetch + fork + capture `base_sha` in `spawn_agent`
  (background task, preserving instant spawn) and `add_repo_to_agent`; archive
  uses `base_sha` as the diff base.
- **`workspace.rs`** + **migration 0008** — new `base_sha` column, `TrackedRepo`
  field, and `set_repo_base_sha`. Persists across archive/restore for free.
- **`commands.rs`** — `diff_base` helper prefers the fork SHA for the
  committed-work diff surfaces (`get_agent_diff_stats`, file tree / per-file
  diffs). PR/merge/rebase bases and git-state ahead/behind keep the branch name.

## Fallback behavior

Offline, no remote, detached HEAD, or a local-only branch → `fetch_fork_point`
returns `None`, the worktree forks from local HEAD, and `base_sha` records that
HEAD — i.e. today's behavior, just recorded. Pre-migration agents (`base_sha`
NULL) fall back to the branch name.

## Testing

- New `git.rs` tests: `fetch_fork_point` returns `None` without a remote;
  `worktree_add_detached` honors an explicit base commit and otherwise tracks
  current HEAD.
- Full lib suite green except a pre-existing, environment-dependent PTY-timing
  test (`pty_session::streams_output_and_reports_exit`) in untouched code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)