### PR TITLE
feat: per-agent token usage tracking + composer context gauge

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -300,6 +300,29 @@ pub fn sync_session(supervisor: State<'_, Arc<Supervisor>>, agent_id: String) ->
     Ok(())
 }
 
+/// Persist a runtime-compiled record (`source = 'live_compiled'`) the frontend
+/// holds but the on-disk transcript lacks — currently cursor's per-turn token
+/// usage, which it emits only on its live `result` event. Idempotent on
+/// `native_id` (use the event's `request_id`), so re-sending a turn is a no-op.
+/// Returns whether a new row was inserted.
+#[tauri::command]
+pub fn append_live_record(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+    provider: String,
+    native_id: String,
+    body: serde_json::Value,
+) -> Result<bool> {
+    let inserted = supervisor.workspace.append_session_records(
+        &agent_id,
+        &provider,
+        "live_compiled",
+        None,
+        &[(native_id.as_str(), &body)],
+    )?;
+    Ok(inserted > 0)
+}
+
 #[tauri::command]
 pub async fn add_repo_to_agent(
     supervisor: State<'_, Arc<Supervisor>>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -174,6 +174,7 @@ pub fn run() {
             commands::read_session_records,
             commands::read_user_turns,
             commands::sync_session,
+            commands::append_live_record,
             commands::add_repo_to_agent,
             commands::allocate_draft_name,
             commands::get_git_state,

--- a/src/adapters/claude/index.ts
+++ b/src/adapters/claude/index.ts
@@ -2,10 +2,12 @@ import type { ChatAdapter } from "../types";
 import { reduce } from "./reduce";
 import { normalizeTranscript } from "./normalize";
 import { claudePolicy } from "./policy";
+import { extractUsage } from "./usage";
 
 export const claudeAdapter: ChatAdapter = {
   id: "claude",
   reduce,
   normalizeTranscript,
   policy: claudePolicy,
+  extractUsage,
 };

--- a/src/adapters/claude/usage.ts
+++ b/src/adapters/claude/usage.ts
@@ -1,0 +1,34 @@
+// Token usage from Claude's on-disk transcript.
+//
+// Each persisted `assistant` record carries a per-message usage delta on
+// `message.usage`:
+//   {"type":"assistant","message":{"model":"claude-…","usage":{
+//      "input_tokens":2,"output_tokens":300,
+//      "cache_creation_input_tokens":10783,"cache_read_input_tokens":7900}}}
+// `input_tokens` is the FRESH (non-cached) input — Anthropic excludes cache
+// reads/writes from it — so context fill is the sum of all three input fields.
+// Claude does not report a context-window size or cost on disk.
+
+import type { RawEvent, TurnUsage } from "../types";
+import { asNumber, asRecord } from "../shared/json";
+
+export function extractUsage(body: RawEvent): TurnUsage | undefined {
+  if (body.type !== "assistant") return undefined;
+  const message = asRecord(body.message);
+  const usage = asRecord(message.usage);
+  const inputTokens = asNumber(usage.input_tokens);
+  const outputTokens = asNumber(usage.output_tokens);
+  const cacheReadTokens = asNumber(usage.cache_read_input_tokens);
+  const cacheWriteTokens = asNumber(usage.cache_creation_input_tokens);
+  if (inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens === 0) {
+    return undefined;
+  }
+  return {
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+    context: { input: inputTokens, cacheRead: cacheReadTokens, cacheWrite: cacheWriteTokens },
+    model: typeof message.model === "string" ? message.model : undefined,
+  };
+}

--- a/src/adapters/codex/index.ts
+++ b/src/adapters/codex/index.ts
@@ -2,6 +2,7 @@ import type { ChatAdapter } from "../types";
 import { reduce } from "./reduce";
 import { normalizeTranscript } from "./normalize";
 import { codexPolicy } from "./policy";
+import { extractUsage } from "./usage";
 
 // Reduces Codex's `codex exec --json` thread/turn/item event stream
 // (verified against codex-cli 0.135.0 — see ./reduce.ts). Transcript
@@ -11,4 +12,5 @@ export const codexAdapter: ChatAdapter = {
   reduce,
   normalizeTranscript,
   policy: codexPolicy,
+  extractUsage,
 };

--- a/src/adapters/codex/usage.ts
+++ b/src/adapters/codex/usage.ts
@@ -1,0 +1,54 @@
+// Token usage from Codex's on-disk rollout.
+//
+// Codex emits a `token_count` event (on the `event_msg` channel) carrying both
+// a running cumulative total and the last turn's delta:
+//   {"type":"event_msg","payload":{"type":"token_count","info":{
+//      "total_token_usage":{"input_tokens","cached_input_tokens",
+//                           "output_tokens","reasoning_output_tokens"},
+//      "last_token_usage":{…same shape…},
+//      "model_context_window":258400}}}
+// We take the CUMULATIVE `total_token_usage` (latest record wins) rather than
+// summing — codex re-emits identical token_count lines, so summing the delta
+// would double-count. `input_tokens` INCLUDES cached input, so fresh input is
+// `input_tokens - cached_input_tokens`. Context fill is the latest turn's
+// `last_token_usage.input_tokens` (the live window size), against
+// `model_context_window`.
+
+import type { RawEvent, TurnUsage } from "../types";
+import { asNumber, asRecord } from "../shared/json";
+
+export function extractUsage(body: RawEvent): TurnUsage | undefined {
+  if (body.type !== "event_msg") return undefined;
+  const payload = asRecord(body.payload);
+  if (payload.type !== "token_count") return undefined;
+
+  const info = asRecord(payload.info);
+  const total = asRecord(info.total_token_usage);
+  const last = asRecord(info.last_token_usage);
+
+  const totalInput = asNumber(total.input_tokens);
+  const cacheReadTokens = asNumber(total.cached_input_tokens);
+  const outputTokens =
+    asNumber(total.output_tokens) + asNumber(total.reasoning_output_tokens);
+  if (totalInput + outputTokens === 0) return undefined;
+
+  // Context fill is the latest turn's window: last_token_usage.input_tokens
+  // includes cached, so split it into cached vs fresh. Codex reports no cache
+  // write separately.
+  const lastInput = asNumber(last.input_tokens);
+  const lastCached = asNumber(last.cached_input_tokens);
+  const contextWindow = asNumber(info.model_context_window);
+
+  return {
+    cumulative: true,
+    inputTokens: Math.max(0, totalInput - cacheReadTokens),
+    outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens: 0,
+    context:
+      lastInput > 0
+        ? { input: Math.max(0, lastInput - lastCached), cacheRead: lastCached, cacheWrite: 0 }
+        : undefined,
+    contextWindow: contextWindow > 0 ? contextWindow : undefined,
+  };
+}

--- a/src/adapters/cursor/index.ts
+++ b/src/adapters/cursor/index.ts
@@ -2,12 +2,17 @@ import type { ChatAdapter } from "../types";
 import { reduce } from "./reduce";
 import { normalizeTranscript } from "./normalize";
 import { cursorPolicy } from "./policy";
+import { extractUsage } from "./usage";
 
 // Cursor Agent's stream-json is Claude Code's schema except for tool calls
 // (see ./reduce.ts), so most of the adapter delegates to the Claude reducer.
+// Usage isn't on disk — it's on the live `result` event, which the store
+// persists into session_records so it folds like the rest (see ./usage.ts).
 export const cursorAdapter: ChatAdapter = {
   id: "cursor",
   reduce,
   normalizeTranscript,
   policy: cursorPolicy,
+  persistLiveUsage: true,
+  extractUsage,
 };

--- a/src/adapters/cursor/usage.ts
+++ b/src/adapters/cursor/usage.ts
@@ -1,0 +1,34 @@
+// Token usage from Cursor's `result` event.
+//
+// Unlike the other agents, cursor-agent does not persist usage to its on-disk
+// transcript — it only emits it once per turn on the live `result` event
+// (Claude-shaped, but camelCase):
+//   {"type":"result","subtype":"success",…,"request_id":"…","usage":{
+//      "inputTokens":2,"outputTokens":122,
+//      "cacheReadTokens":0,"cacheWriteTokens":27987}}
+// The adapter sets `persistLiveUsage`, so the store writes this event into
+// session_records (`source = 'live_compiled'`, keyed by `request_id`) at
+// turn-end; from then on usage folds from records like every other agent —
+// restart-safe. `inputTokens` is fresh (excludes cache), Anthropic-style.
+
+import type { RawEvent, TurnUsage } from "../types";
+import { asNumber, asRecord } from "../shared/json";
+
+export function extractUsage(body: RawEvent): TurnUsage | undefined {
+  if (body.type !== "result") return undefined;
+  const usage = asRecord(body.usage);
+  const inputTokens = asNumber(usage.inputTokens);
+  const outputTokens = asNumber(usage.outputTokens);
+  const cacheReadTokens = asNumber(usage.cacheReadTokens);
+  const cacheWriteTokens = asNumber(usage.cacheWriteTokens);
+  if (inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens === 0) {
+    return undefined;
+  }
+  return {
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+    context: { input: inputTokens, cacheRead: cacheReadTokens, cacheWrite: cacheWriteTokens },
+  };
+}

--- a/src/adapters/opencode/index.ts
+++ b/src/adapters/opencode/index.ts
@@ -2,6 +2,7 @@ import type { ChatAdapter } from "../types";
 import { reduce } from "./reduce";
 import { normalizeTranscript } from "./normalize";
 import { opencodePolicy } from "./policy";
+import { extractUsage } from "./usage";
 
 // Reduces OpenCode's `opencode run --format json` step/part event stream
 // (verified against opencode 1.15.12 — see ./reduce.ts). Transcript replay
@@ -11,4 +12,5 @@ export const opencodeAdapter: ChatAdapter = {
   reduce,
   normalizeTranscript,
   policy: opencodePolicy,
+  extractUsage,
 };

--- a/src/adapters/opencode/usage.ts
+++ b/src/adapters/opencode/usage.ts
@@ -1,0 +1,34 @@
+// Token usage from OpenCode's on-disk part blobs.
+//
+// Each `step-finish` part blob carries that step's usage delta and cost:
+//   {"type":"step-finish","tokens":{"input":1532,"output":33,"reasoning":51,
+//      "cache":{"read":12864,"write":0}},"cost":0}
+// `tokens.input` is FRESH input (cache reads are separate), so summing the
+// per-step deltas yields the session total. Cost is reported natively (0 for
+// local models). OpenCode does not persist a context-window size.
+
+import type { RawEvent, TurnUsage } from "../types";
+import { asNumber, asRecord } from "../shared/json";
+
+export function extractUsage(body: RawEvent): TurnUsage | undefined {
+  if (body.type !== "step-finish") return undefined;
+  const tokens = asRecord(body.tokens);
+  const cache = asRecord(tokens.cache);
+
+  const inputTokens = asNumber(tokens.input);
+  const outputTokens = asNumber(tokens.output) + asNumber(tokens.reasoning);
+  const cacheReadTokens = asNumber(cache.read);
+  const cacheWriteTokens = asNumber(cache.write);
+  if (inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens === 0) {
+    return undefined;
+  }
+
+  return {
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+    costUsd: asNumber(body.cost),
+    context: { input: inputTokens, cacheRead: cacheReadTokens, cacheWrite: cacheWriteTokens },
+  };
+}

--- a/src/adapters/pi/index.ts
+++ b/src/adapters/pi/index.ts
@@ -2,6 +2,7 @@ import type { ChatAdapter } from "../types";
 import { reduce } from "./reduce";
 import { normalizeTranscript } from "./normalize";
 import { piPolicy } from "./policy";
+import { extractUsage } from "./usage";
 
 // Reduces Pi's `pi -p --mode json` event stream (verified against pi 0.74.2 —
 // see ./reduce.ts). Transcript replay on re-attach is a follow-up (see
@@ -11,4 +12,5 @@ export const piAdapter: ChatAdapter = {
   reduce,
   normalizeTranscript,
   policy: piPolicy,
+  extractUsage,
 };

--- a/src/adapters/pi/usage.ts
+++ b/src/adapters/pi/usage.ts
@@ -1,0 +1,38 @@
+// Token usage from Pi's on-disk transcript.
+//
+// Pi persists settled `type:"message"` records; assistant messages carry a
+// per-message usage delta with native cost:
+//   {"type":"message","message":{"role":"assistant","model":"claude-…",
+//      "usage":{"input":2,"output":14,"cacheRead":0,"cacheWrite":3159,
+//               "totalTokens":3175,"cost":{"total":0.0201}}}}
+// `input` is FRESH input (cache read/write are separate), so summing the
+// per-message deltas yields the session total. Pi does not persist a
+// context-window size.
+
+import type { RawEvent, TurnUsage } from "../types";
+import { asNumber, asRecord } from "../shared/json";
+
+export function extractUsage(body: RawEvent): TurnUsage | undefined {
+  if (body.type !== "message") return undefined;
+  const message = asRecord(body.message);
+  if (message.role !== "assistant") return undefined;
+
+  const usage = asRecord(message.usage);
+  const inputTokens = asNumber(usage.input);
+  const outputTokens = asNumber(usage.output);
+  const cacheReadTokens = asNumber(usage.cacheRead);
+  const cacheWriteTokens = asNumber(usage.cacheWrite);
+  if (inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens === 0) {
+    return undefined;
+  }
+
+  return {
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+    costUsd: asNumber(asRecord(usage.cost).total),
+    context: { input: inputTokens, cacheRead: cacheReadTokens, cacheWrite: cacheWriteTokens },
+    model: typeof message.model === "string" ? message.model : undefined,
+  };
+}

--- a/src/adapters/shared/json.ts
+++ b/src/adapters/shared/json.ts
@@ -9,3 +9,9 @@ export function asRecord(v: unknown): Record<string, unknown> {
 export function asBlockList(v: unknown): Array<Record<string, unknown>> {
   return Array.isArray(v) ? v.filter(isRecord) : [];
 }
+
+/** A finite number, or 0. Used by the usage extractors to coerce token counts
+ *  that may be missing or non-numeric in a transcript body. */
+export function asNumber(v: unknown): number {
+  return typeof v === "number" && Number.isFinite(v) ? v : 0;
+}

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -63,9 +63,46 @@ export type DisplayMode = "show" | "hide";
 // `${kind}:${subtype}` entry wins when both are present.
 export type DisplayPolicy = Record<string, DisplayMode>;
 
+/** Normalized token usage extracted from ONE persisted session_record body.
+ *
+ *  Unlike `reduce`/`normalizeTranscript`, the usage extractors read each
+ *  agent's ON-DISK transcript body shape directly (see `<agent>/usage.ts`),
+ *  not the live event stream. Usage is folded over session_records — the
+ *  canonical store — rather than the ephemeral live stream, so cumulative
+ *  totals survive restarts and never double-count a turn rendered both live
+ *  and from records. See src/adapters/usage.ts for the fold. */
+export interface TurnUsage {
+  /** When true, the fields are running cumulative totals and the latest record
+   *  wins; when false/absent they are a per-record delta and are summed. Codex
+   *  reports cumulative `total_token_usage`; claude/opencode/pi report deltas. */
+  cumulative?: boolean;
+  /** Fresh, non-cached input tokens. */
+  inputTokens: number;
+  /** Output tokens, including reasoning/thinking tokens. */
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  /** Dollar cost, only for agents that report it natively (opencode, pi). */
+  costUsd?: number;
+  /** This record's context-window composition (latest record wins in the fold).
+   *  Its parts sum to the window fill and drive the meter's segmented bar:
+   *  `cacheRead` = reused/cached context, `cacheWrite` = newly cached this turn,
+   *  `input` = fresh non-cached input. The semantic split the design mocks up
+   *  (system / conversation / reasoning) is NOT recoverable from any agent's
+   *  transcript — this cache-state split is the truthful equivalent. */
+  context?: { input: number; cacheRead: number; cacheWrite: number };
+  /** Model context window size in tokens, when the agent reports it (codex). */
+  contextWindow?: number;
+  model?: string;
+}
+
 export interface ChatAdapter {
   readonly id: string;
   reduce(prevItems: ChatItem[], rawEvent: RawEvent): ChatItem[];
   normalizeTranscript(transcriptLines: unknown[]): RawEvent[];
   readonly policy: DisplayPolicy;
+  /** Extract token usage from one persisted session_record body, or undefined
+   *  when the record carries none. Optional: agents that don't persist usage
+   *  on disk (cursor, antigravity) omit it entirely. */
+  extractUsage?(recordBody: RawEvent): TurnUsage | undefined;
 }

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -101,8 +101,14 @@ export interface ChatAdapter {
   reduce(prevItems: ChatItem[], rawEvent: RawEvent): ChatItem[];
   normalizeTranscript(transcriptLines: unknown[]): RawEvent[];
   readonly policy: DisplayPolicy;
-  /** Extract token usage from one persisted session_record body, or undefined
-   *  when the record carries none. Optional: agents that don't persist usage
-   *  on disk (cursor, antigravity) omit it entirely. */
+  /** True when the agent emits usage ONLY on its live `result` event and never
+   *  persists it on disk (cursor). The store persists that event into
+   *  session_records (`source = 'live_compiled'`) at turn-end so usage is then
+   *  folded uniformly from records like every other agent — restart-safe, no
+   *  in-memory accumulation. `extractUsage` reads that same `result` body. */
+  readonly persistLiveUsage?: boolean;
+  /** Extract token usage from one session_record body, or undefined when it
+   *  carries none. Optional: agents that report no usage at all (antigravity)
+   *  omit it entirely. */
   extractUsage?(recordBody: RawEvent): TurnUsage | undefined;
 }

--- a/src/adapters/usage.test.ts
+++ b/src/adapters/usage.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from "vitest";
+
+import { claudeAdapter } from "./claude";
+import { codexAdapter } from "./codex";
+import { opencodeAdapter } from "./opencode";
+import { piAdapter } from "./pi";
+import { cursorAdapter } from "./cursor";
+import { antigravityAdapter } from "./antigravity";
+import { usageFromRecords, EMPTY_USAGE } from "./usage";
+import type { SessionRecord } from "../api";
+import type { RawEvent } from "./types";
+
+// Bodies below are the agents' real ON-DISK transcript shapes (captured from
+// live sessions), which is what session_records persists and what the usage
+// extractors read — distinct from the live event stream the reducers consume.
+
+function record(provider: string, body: RawEvent, seq = 0): SessionRecord {
+  return { seq, provider, source: "transcript", native_id: `n${seq}`, agent_version: null, body };
+}
+
+describe("claude extractUsage", () => {
+  const body = {
+    type: "assistant",
+    message: {
+      model: "claude-opus-4-8",
+      usage: {
+        input_tokens: 2,
+        output_tokens: 300,
+        cache_creation_input_tokens: 10783,
+        cache_read_input_tokens: 7900,
+      },
+    },
+  } as RawEvent;
+
+  it("maps fresh input / output / cache and context fill", () => {
+    expect(claudeAdapter.extractUsage!(body)).toEqual({
+      inputTokens: 2,
+      outputTokens: 300,
+      cacheReadTokens: 7900,
+      cacheWriteTokens: 10783,
+      context: { input: 2, cacheRead: 7900, cacheWrite: 10783 },
+      model: "claude-opus-4-8",
+    });
+  });
+
+  it("ignores non-assistant and zero-usage records", () => {
+    expect(claudeAdapter.extractUsage!({ type: "user" } as RawEvent)).toBeUndefined();
+    expect(
+      claudeAdapter.extractUsage!({ type: "assistant", message: {} } as RawEvent),
+    ).toBeUndefined();
+  });
+});
+
+describe("codex extractUsage", () => {
+  const body = {
+    type: "event_msg",
+    payload: {
+      type: "token_count",
+      info: {
+        total_token_usage: {
+          input_tokens: 65134,
+          cached_input_tokens: 56064,
+          output_tokens: 959,
+          reasoning_output_tokens: 336,
+        },
+        last_token_usage: { input_tokens: 33939, cached_input_tokens: 31104 },
+        model_context_window: 258400,
+      },
+    },
+  } as RawEvent;
+
+  it("takes cumulative totals, derives fresh input, sums reasoning", () => {
+    expect(codexAdapter.extractUsage!(body)).toEqual({
+      cumulative: true,
+      inputTokens: 65134 - 56064,
+      outputTokens: 959 + 336,
+      cacheReadTokens: 56064,
+      cacheWriteTokens: 0,
+      context: { input: 33939 - 31104, cacheRead: 31104, cacheWrite: 0 },
+      contextWindow: 258400,
+    });
+  });
+
+  it("ignores non token_count event_msgs", () => {
+    expect(
+      codexAdapter.extractUsage!({ type: "event_msg", payload: { type: "agent_message" } } as RawEvent),
+    ).toBeUndefined();
+  });
+});
+
+describe("opencode extractUsage", () => {
+  const body = {
+    type: "step-finish",
+    tokens: { input: 1532, output: 33, reasoning: 51, cache: { read: 12864, write: 0 } },
+    cost: 0.0123,
+  } as RawEvent;
+
+  it("maps per-step delta with cost and context fill", () => {
+    expect(opencodeAdapter.extractUsage!(body)).toEqual({
+      inputTokens: 1532,
+      outputTokens: 33 + 51,
+      cacheReadTokens: 12864,
+      cacheWriteTokens: 0,
+      costUsd: 0.0123,
+      context: { input: 1532, cacheRead: 12864, cacheWrite: 0 },
+    });
+  });
+});
+
+describe("pi extractUsage", () => {
+  const body = {
+    type: "message",
+    message: {
+      role: "assistant",
+      model: "claude-opus-4-7",
+      usage: {
+        input: 2,
+        output: 258,
+        cacheRead: 0,
+        cacheWrite: 4387,
+        totalTokens: 4647,
+        cost: { total: 0.0338 },
+      },
+    },
+  } as RawEvent;
+
+  it("maps per-message delta with cost", () => {
+    expect(piAdapter.extractUsage!(body)).toEqual({
+      inputTokens: 2,
+      outputTokens: 258,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 4387,
+      costUsd: 0.0338,
+      context: { input: 2, cacheRead: 0, cacheWrite: 4387 },
+      model: "claude-opus-4-7",
+    });
+  });
+
+  it("ignores user / toolResult messages", () => {
+    expect(
+      piAdapter.extractUsage!({ type: "message", message: { role: "user" } } as RawEvent),
+    ).toBeUndefined();
+  });
+});
+
+it("cursor and antigravity expose no usage extractor", () => {
+  expect(cursorAdapter.extractUsage).toBeUndefined();
+  expect(antigravityAdapter.extractUsage).toBeUndefined();
+});
+
+describe("usageFromRecords fold", () => {
+  it("sums per-message deltas (claude) and tracks latest context fill", () => {
+    const recs = [
+      record("claude", {
+        type: "assistant",
+        message: { usage: { input_tokens: 5, output_tokens: 100, cache_creation_input_tokens: 2000, cache_read_input_tokens: 0 } },
+      } as RawEvent, 0),
+      record("claude", {
+        type: "assistant",
+        message: { usage: { input_tokens: 3, output_tokens: 50, cache_creation_input_tokens: 80, cache_read_input_tokens: 2000 } },
+      } as RawEvent, 1),
+    ];
+    const u = usageFromRecords("claude", recs);
+    expect(u.inputTokens).toBe(8);
+    expect(u.outputTokens).toBe(150);
+    expect(u.cacheWriteTokens).toBe(2080);
+    expect(u.cacheReadTokens).toBe(2000);
+    // context fill + breakdown = latest record's composition (not summed)
+    expect(u.contextTokens).toBe(3 + 2000 + 80);
+    expect(u.contextInput).toBe(3);
+    expect(u.contextCacheRead).toBe(2000);
+    expect(u.contextCacheWrite).toBe(80);
+    expect(u.costUsd).toBe(0);
+  });
+
+  it("takes the latest cumulative snapshot (codex), not the sum", () => {
+    const mk = (total: number, last: number, seq: number) =>
+      record("codex", {
+        type: "event_msg",
+        payload: {
+          type: "token_count",
+          info: {
+            total_token_usage: { input_tokens: total, cached_input_tokens: 0, output_tokens: 10, reasoning_output_tokens: 0 },
+            last_token_usage: { input_tokens: last },
+            model_context_window: 258400,
+          },
+        },
+      } as RawEvent, seq);
+    // duplicate first event (codex re-emits) must not double-count
+    const u = usageFromRecords("codex", [mk(100, 100, 0), mk(100, 100, 1), mk(250, 150, 2)]);
+    expect(u.inputTokens).toBe(250);
+    expect(u.contextTokens).toBe(150);
+    expect(u.contextWindow).toBe(258400);
+  });
+
+  it("accumulates native cost (pi/opencode)", () => {
+    const recs = [
+      record("opencode", { type: "step-finish", tokens: { input: 10, output: 5, cache: {} }, cost: 0.01 } as RawEvent, 0),
+      record("opencode", { type: "step-finish", tokens: { input: 20, output: 5, cache: {} }, cost: 0.02 } as RawEvent, 1),
+    ];
+    expect(usageFromRecords("opencode", recs).costUsd).toBeCloseTo(0.03);
+  });
+
+  it("returns EMPTY_USAGE for providers without an extractor or with no usage", () => {
+    expect(usageFromRecords("cursor", [record("cursor", { type: "assistant" } as RawEvent)])).toBe(EMPTY_USAGE);
+    expect(usageFromRecords("claude", [])).toBe(EMPTY_USAGE);
+  });
+});

--- a/src/adapters/usage.test.ts
+++ b/src/adapters/usage.test.ts
@@ -6,7 +6,7 @@ import { opencodeAdapter } from "./opencode";
 import { piAdapter } from "./pi";
 import { cursorAdapter } from "./cursor";
 import { antigravityAdapter } from "./antigravity";
-import { usageFromRecords, EMPTY_USAGE } from "./usage";
+import { usageFromRecords, addTurnUsage, EMPTY_USAGE } from "./usage";
 import type { SessionRecord } from "../api";
 import type { RawEvent } from "./types";
 
@@ -143,8 +143,40 @@ describe("pi extractUsage", () => {
   });
 });
 
-it("cursor and antigravity expose no usage extractor", () => {
-  expect(cursorAdapter.extractUsage).toBeUndefined();
+describe("cursor extractUsage (persisted live result)", () => {
+  const body = {
+    type: "result",
+    subtype: "success",
+    request_id: "req-1",
+    usage: { inputTokens: 2, outputTokens: 122, cacheReadTokens: 0, cacheWriteTokens: 27987 },
+  } as RawEvent;
+
+  it("is marked persistLiveUsage and reads the result event", () => {
+    expect(cursorAdapter.persistLiveUsage).toBe(true);
+    expect(cursorAdapter.extractUsage!(body)).toEqual({
+      inputTokens: 2,
+      outputTokens: 122,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 27987,
+      context: { input: 2, cacheRead: 0, cacheWrite: 27987 },
+    });
+  });
+
+  it("ignores cursor's on-disk transcript bodies (no usage there)", () => {
+    expect(
+      cursorAdapter.extractUsage!({ type: "assistant", message: {} } as RawEvent),
+    ).toBeUndefined();
+  });
+
+  it("folds from records once the result is persisted (live_compiled)", () => {
+    const u = usageFromRecords("cursor", [record("cursor", body)]);
+    expect(u.outputTokens).toBe(122);
+    expect(u.cacheWriteTokens).toBe(27987);
+    expect(u.contextTokens).toBe(2 + 0 + 27987);
+  });
+});
+
+it("antigravity exposes no usage extractor", () => {
   expect(antigravityAdapter.extractUsage).toBeUndefined();
 });
 
@@ -204,5 +236,23 @@ describe("usageFromRecords fold", () => {
   it("returns EMPTY_USAGE for providers without an extractor or with no usage", () => {
     expect(usageFromRecords("cursor", [record("cursor", { type: "assistant" } as RawEvent)])).toBe(EMPTY_USAGE);
     expect(usageFromRecords("claude", [])).toBe(EMPTY_USAGE);
+  });
+});
+
+describe("addTurnUsage (fold primitive)", () => {
+  it("sums deltas across turns and tracks the latest context fill", () => {
+    let acc = { ...EMPTY_USAGE };
+    for (const body of [
+      { type: "result", usage: { inputTokens: 2, outputTokens: 100, cacheReadTokens: 0, cacheWriteTokens: 5000 } },
+      { type: "result", usage: { inputTokens: 3, outputTokens: 50, cacheReadTokens: 5000, cacheWriteTokens: 80 } },
+    ] as RawEvent[]) {
+      acc = addTurnUsage(acc, cursorAdapter.extractUsage!(body)!);
+    }
+    expect(acc.inputTokens).toBe(5);
+    expect(acc.outputTokens).toBe(150);
+    expect(acc.cacheWriteTokens).toBe(5080);
+    // latest turn wins for the window breakdown
+    expect(acc.contextTokens).toBe(3 + 5000 + 80);
+    expect(acc.contextCacheRead).toBe(5000);
   });
 });

--- a/src/adapters/usage.ts
+++ b/src/adapters/usage.ts
@@ -52,10 +52,45 @@ export function hasUsage(u: AgentUsage): boolean {
   return u.inputTokens + u.outputTokens + u.cacheReadTokens + u.cacheWriteTokens > 0;
 }
 
+/** Apply one extracted `TurnUsage` to a running total, returning a new object.
+ *  Shared by the records fold and the live accumulator (cursor) so both treat
+ *  cumulative-vs-delta and the context breakdown identically. */
+export function addTurnUsage(acc: AgentUsage, u: TurnUsage): AgentUsage {
+  const next: AgentUsage = { ...acc };
+  if (u.cumulative) {
+    // Running total — the latest record wins, don't sum.
+    next.inputTokens = u.inputTokens;
+    next.outputTokens = u.outputTokens;
+    next.cacheReadTokens = u.cacheReadTokens;
+    next.cacheWriteTokens = u.cacheWriteTokens;
+    if (u.costUsd != null) next.costUsd = u.costUsd;
+  } else {
+    next.inputTokens += u.inputTokens;
+    next.outputTokens += u.outputTokens;
+    next.cacheReadTokens += u.cacheReadTokens;
+    next.cacheWriteTokens += u.cacheWriteTokens;
+    if (u.costUsd != null) next.costUsd += u.costUsd;
+  }
+  if (u.context) {
+    const fill = u.context.input + u.context.cacheRead + u.context.cacheWrite;
+    if (fill > 0) {
+      // Latest turn wins — the window reflects the most recent turn, not a sum.
+      next.contextInput = u.context.input;
+      next.contextCacheRead = u.context.cacheRead;
+      next.contextCacheWrite = u.context.cacheWrite;
+      next.contextTokens = fill;
+    }
+  }
+  if (u.contextWindow != null && u.contextWindow > 0) next.contextWindow = u.contextWindow;
+  if (u.model) next.model = u.model;
+  return next;
+}
+
 /** Fold a session's records into one cumulative usage total. Returns the shared
- *  `EMPTY_USAGE` when the provider doesn't extract usage (cursor, antigravity)
- *  or no record carried any. Defensive: a throwing extractor skips its record
- *  rather than failing the whole fold. */
+ *  `EMPTY_USAGE` when the provider doesn't extract usage (antigravity) or no
+ *  record carried any. Cursor is included: its live `result` is persisted into
+ *  session_records (see `persistLiveUsage`), so it folds here like the rest.
+ *  Defensive: a throwing extractor skips its record, not the whole fold. */
 export function usageFromRecords(
   provider: string | undefined,
   records: SessionRecord[],
@@ -63,7 +98,7 @@ export function usageFromRecords(
   const adapter = getAdapter(provider);
   if (!adapter.extractUsage) return EMPTY_USAGE;
 
-  const acc: AgentUsage = { ...EMPTY_USAGE };
+  let acc: AgentUsage = { ...EMPTY_USAGE };
   for (const rec of records) {
     let u: TurnUsage | undefined;
     try {
@@ -71,36 +106,7 @@ export function usageFromRecords(
     } catch {
       u = undefined;
     }
-    if (!u) continue;
-
-    if (u.cumulative) {
-      // Running total — the latest record wins, don't sum.
-      acc.inputTokens = u.inputTokens;
-      acc.outputTokens = u.outputTokens;
-      acc.cacheReadTokens = u.cacheReadTokens;
-      acc.cacheWriteTokens = u.cacheWriteTokens;
-      if (u.costUsd != null) acc.costUsd = u.costUsd;
-    } else {
-      acc.inputTokens += u.inputTokens;
-      acc.outputTokens += u.outputTokens;
-      acc.cacheReadTokens += u.cacheReadTokens;
-      acc.cacheWriteTokens += u.cacheWriteTokens;
-      if (u.costUsd != null) acc.costUsd += u.costUsd;
-    }
-    if (u.context) {
-      const fill = u.context.input + u.context.cacheRead + u.context.cacheWrite;
-      if (fill > 0) {
-        // Latest turn wins — the window reflects the most recent turn, not a sum.
-        acc.contextInput = u.context.input;
-        acc.contextCacheRead = u.context.cacheRead;
-        acc.contextCacheWrite = u.context.cacheWrite;
-        acc.contextTokens = fill;
-      }
-    }
-    if (u.contextWindow != null && u.contextWindow > 0) {
-      acc.contextWindow = u.contextWindow;
-    }
-    if (u.model) acc.model = u.model;
+    if (u) acc = addTurnUsage(acc, u);
   }
   return hasUsage(acc) ? acc : EMPTY_USAGE;
 }

--- a/src/adapters/usage.ts
+++ b/src/adapters/usage.ts
@@ -1,0 +1,106 @@
+// Fold per-record token usage into a per-agent cumulative total.
+//
+// Usage is computed from session_records — the canonical, persisted transcript
+// store — NOT the ephemeral live stream, so totals survive restarts and a turn
+// rendered both live and from records is never counted twice. Each adapter's
+// `extractUsage` reads its agent's on-disk body shape (see <agent>/usage.ts);
+// this fold is provider-agnostic.
+
+import type { SessionRecord } from "../api";
+import { getAdapter } from "./index";
+import type { TurnUsage } from "./types";
+
+export interface AgentUsage {
+  /** Cumulative fresh (non-cached) input tokens across the session. */
+  inputTokens: number;
+  /** Cumulative output tokens (incl. reasoning) across the session. */
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  /** Cumulative dollar cost; 0 when no agent in the session reports cost. */
+  costUsd: number;
+  // ── latest turn's context-window composition (drives the meter + its bar) ──
+  /** Fresh, non-cached input in the current window. */
+  contextInput: number;
+  /** Reused/cached context in the current window. */
+  contextCacheRead: number;
+  /** Newly-cached tokens in the current window (0 for codex). */
+  contextCacheWrite: number;
+  /** Context-window fill in tokens = the three context* parts above. */
+  contextTokens: number;
+  /** Model context window in tokens; 0 when the agent doesn't report one (the
+   *  UI falls back to a default). */
+  contextWindow: number;
+  model?: string;
+}
+
+export const EMPTY_USAGE: AgentUsage = Object.freeze({
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadTokens: 0,
+  cacheWriteTokens: 0,
+  costUsd: 0,
+  contextInput: 0,
+  contextCacheRead: 0,
+  contextCacheWrite: 0,
+  contextTokens: 0,
+  contextWindow: 0,
+});
+
+/** True once any token field is non-zero — i.e. the agent reported usage. */
+export function hasUsage(u: AgentUsage): boolean {
+  return u.inputTokens + u.outputTokens + u.cacheReadTokens + u.cacheWriteTokens > 0;
+}
+
+/** Fold a session's records into one cumulative usage total. Returns the shared
+ *  `EMPTY_USAGE` when the provider doesn't extract usage (cursor, antigravity)
+ *  or no record carried any. Defensive: a throwing extractor skips its record
+ *  rather than failing the whole fold. */
+export function usageFromRecords(
+  provider: string | undefined,
+  records: SessionRecord[],
+): AgentUsage {
+  const adapter = getAdapter(provider);
+  if (!adapter.extractUsage) return EMPTY_USAGE;
+
+  const acc: AgentUsage = { ...EMPTY_USAGE };
+  for (const rec of records) {
+    let u: TurnUsage | undefined;
+    try {
+      u = adapter.extractUsage(rec.body);
+    } catch {
+      u = undefined;
+    }
+    if (!u) continue;
+
+    if (u.cumulative) {
+      // Running total — the latest record wins, don't sum.
+      acc.inputTokens = u.inputTokens;
+      acc.outputTokens = u.outputTokens;
+      acc.cacheReadTokens = u.cacheReadTokens;
+      acc.cacheWriteTokens = u.cacheWriteTokens;
+      if (u.costUsd != null) acc.costUsd = u.costUsd;
+    } else {
+      acc.inputTokens += u.inputTokens;
+      acc.outputTokens += u.outputTokens;
+      acc.cacheReadTokens += u.cacheReadTokens;
+      acc.cacheWriteTokens += u.cacheWriteTokens;
+      if (u.costUsd != null) acc.costUsd += u.costUsd;
+    }
+    if (u.context) {
+      const fill = u.context.input + u.context.cacheRead + u.context.cacheWrite;
+      if (fill > 0) {
+        // Latest turn wins — the window reflects the most recent turn, not a sum.
+        acc.contextInput = u.context.input;
+        acc.contextCacheRead = u.context.cacheRead;
+        acc.contextCacheWrite = u.context.cacheWrite;
+        acc.contextTokens = fill;
+      }
+    }
+    if (u.contextWindow != null && u.contextWindow > 0) {
+      acc.contextWindow = u.contextWindow;
+    }
+    if (u.model) acc.model = u.model;
+  }
+  return hasUsage(acc) ? acc : EMPTY_USAGE;
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -412,6 +412,14 @@ export const api = {
     invoke<UserTurn[]>("read_user_turns", { agentId }),
   syncSession: (agentId: string) =>
     invoke<void>("sync_session", { agentId }),
+  /** Persist a runtime-compiled record (e.g. cursor's per-turn usage from its
+   *  live `result` event) into session_records. Idempotent on `nativeId`. */
+  appendLiveRecord: (
+    agentId: string,
+    provider: string,
+    nativeId: string,
+    body: Record<string, unknown>,
+  ) => invoke<boolean>("append_live_record", { agentId, provider, nativeId, body }),
   addRepoToAgent: (agentId: string, repoPath: string) =>
     invoke<TrackedRepo>("add_repo_to_agent", { agentId, repoPath }),
   allocateDraftName: (used: string[]) =>

--- a/src/app.css
+++ b/src/app.css
@@ -1139,6 +1139,82 @@ button { cursor: default; }
   background: oklch(from var(--danger) calc(l + 0.04) c h);
 }
 
+/* composer · token usage meter */
+.usage { position: relative; display: inline-flex; }
+.usage-chip {
+  display: inline-flex; align-items: center; gap: 5px;
+  height: 24px; padding: 0 7px 0 5px;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--fg-2);
+  transition: background .12s, color .12s;
+}
+.usage:hover .usage-chip { background: var(--hover); color: var(--fg-1); }
+.usage-ring { flex-shrink: 0; transition: transform .15s var(--ease); }
+.usage:hover .usage-ring { transform: rotate(8deg); }
+.usage-val {
+  font-family: var(--font-mono); font-size: 10.5px;
+  font-variant-numeric: tabular-nums; letter-spacing: 0;
+}
+
+.usage-pop {
+  position: absolute; bottom: calc(100% + 9px); right: -6px;
+  width: 256px;
+  background: var(--bg-2);
+  border: 1px solid var(--bd);
+  border-radius: var(--r-md);
+  box-shadow: 0 16px 44px rgba(0,0,0,.32);
+  padding: 12px 13px 11px;
+  z-index: 300;
+  animation: ddIn .14s var(--ease);
+}
+.usage-pop::after {
+  content: ""; position: absolute; top: 100%; right: 11px;
+  border: 5px solid transparent; border-top-color: var(--bg-2);
+  filter: drop-shadow(0 1px 0 var(--bd));
+}
+.up-head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  margin-bottom: 9px;
+}
+.up-title {
+  font-size: 10px; font-weight: 600; letter-spacing: .07em;
+  text-transform: uppercase; color: var(--fg-3);
+}
+.up-frac {
+  font-family: var(--font-mono); font-size: 11px;
+  font-variant-numeric: tabular-nums; color: var(--fg-2);
+}
+.up-frac b { color: var(--fg-0); font-weight: 600; }
+.up-bar {
+  display: flex; gap: 2px; height: 6px;
+  border-radius: 99px; overflow: hidden;
+  margin-bottom: 11px;
+}
+.up-seg { display: block; min-width: 0; }
+.up-seg.track { background: var(--bd-strong); }
+.up-legend { display: flex; flex-direction: column; gap: 6px; }
+.up-leg {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 11.5px; color: var(--fg-1);
+}
+.up-dot { width: 7px; height: 7px; border-radius: 2px; flex-shrink: 0; }
+.up-dot.track { background: var(--bd-strong); }
+.up-k { flex: 1; }
+.up-v, .up-rv {
+  font-family: var(--font-mono); font-size: 11px;
+  font-variant-numeric: tabular-nums; color: var(--fg-2);
+}
+.up-sep { height: 1px; background: var(--bd-soft); margin: 11px 0 9px; }
+.up-rows { display: flex; flex-direction: column; gap: 6px; }
+.up-row {
+  display: flex; align-items: center; justify-content: space-between;
+  font-size: 11.5px; color: var(--fg-1);
+}
+.up-row.total { margin-top: 2px; }
+.up-row.total span:first-child { color: var(--fg-2); }
+.up-row.total .up-rv { color: var(--accent); }
+
 /* dropdown */
 .dd {
   position: absolute;

--- a/src/components/Composer/UsageMeter.tsx
+++ b/src/components/Composer/UsageMeter.tsx
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import type { AgentUsage } from "../../store";
+import { formatTokens, formatCost } from "../../util/format";
+
+/** Laconic context gauge for the composer foot — a donut ring + %, hover for a
+ *  full breakdown. Mirrors the v2 design (.usage / .up-* styles in app.css).
+ *
+ *  The segmented bar splits the CURRENT context window by cache state — reused
+ *  (cache read), newly cached (cache write), fresh input — which is the
+ *  truthful equivalent of the design's mocked system/conversation/reasoning
+ *  split (that semantic split isn't recoverable from any agent's transcript).
+ *  The rows below are SESSION cumulative totals. */
+export function UsageMeter({ usage }: { usage: AgentUsage }) {
+  const [open, setOpen] = useState(false);
+
+  const window = usage.contextWindow || DEFAULT_CONTEXT_WINDOW;
+  const used = usage.contextTokens;
+  const free = Math.max(0, window - used);
+  const pct = Math.min(100, Math.round((used / window) * 100));
+
+  const segments = [
+    { key: "cacheRead", label: "Cache read", tokens: usage.contextCacheRead, color: "var(--accent)" },
+    { key: "cacheWrite", label: "Cache write", tokens: usage.contextCacheWrite, color: "var(--info)" },
+    { key: "input", label: "Input", tokens: usage.contextInput, color: "var(--fg-2)" },
+  ].filter((s) => s.tokens > 0);
+
+  // ring geometry — a 13px donut whose arc length encodes pct
+  const R = 6.5;
+  const C = 2 * Math.PI * R;
+  const ringColor = pct >= 90 ? "var(--danger)" : pct >= 75 ? "var(--warn)" : "var(--accent)";
+
+  return (
+    <div className="usage" onMouseEnter={() => setOpen(true)} onMouseLeave={() => setOpen(false)}>
+      <button type="button" className="usage-chip" aria-label={`Context ${pct}% used`}>
+        <svg className="usage-ring" viewBox="0 0 18 18" width="15" height="15">
+          <circle cx="9" cy="9" r={R} fill="none" stroke="var(--bd-strong)" strokeWidth="2.2" />
+          <circle
+            cx="9"
+            cy="9"
+            r={R}
+            fill="none"
+            stroke={ringColor}
+            strokeWidth="2.2"
+            strokeLinecap="round"
+            strokeDasharray={C}
+            strokeDashoffset={C * (1 - pct / 100)}
+            transform="rotate(-90 9 9)"
+          />
+        </svg>
+        <span className="usage-val">{pct}%</span>
+      </button>
+
+      {open && (
+        <div className="usage-pop">
+          <div className="up-head">
+            <span className="up-title">Context window</span>
+            <span className="up-frac">
+              <b>{formatTokens(used)}</b> / {formatTokens(window)}
+            </span>
+          </div>
+
+          <div className="up-bar">
+            {segments.map((s) => (
+              <span key={s.key} className="up-seg" style={{ flex: s.tokens, background: s.color }} />
+            ))}
+            <span className="up-seg track" style={{ flex: free }} />
+          </div>
+
+          <div className="up-legend">
+            {segments.map((s) => (
+              <div key={s.key} className="up-leg">
+                <span className="up-dot" style={{ background: s.color }} />
+                <span className="up-k">{s.label}</span>
+                <span className="up-v">{formatTokens(s.tokens)}</span>
+              </div>
+            ))}
+            <div className="up-leg">
+              <span className="up-dot track" />
+              <span className="up-k">Free</span>
+              <span className="up-v">{formatTokens(free)}</span>
+            </div>
+          </div>
+
+          <div className="up-sep" />
+
+          <div className="up-rows">
+            <Row label="Input" value={formatTokens(usage.inputTokens)} />
+            <Row label="Output" value={formatTokens(usage.outputTokens)} />
+            {usage.costUsd > 0 && (
+              <div className="up-row total">
+                <span>Est. cost</span>
+                <span className="up-rv">{formatCost(usage.costUsd)}</span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="up-row">
+      <span>{label}</span>
+      <span className="up-rv">{value}</span>
+    </div>
+  );
+}
+
+/** Fallback window for agents that don't report their own (claude/opencode/pi
+ *  all run 200k-class models here); codex reports its own. */
+const DEFAULT_CONTEXT_WINDOW = 200_000;

--- a/src/components/Composer/UsageMeter.tsx
+++ b/src/components/Composer/UsageMeter.tsx
@@ -13,10 +13,10 @@ import { formatTokens, formatCost } from "../../util/format";
 export function UsageMeter({ usage }: { usage: AgentUsage }) {
   const [open, setOpen] = useState(false);
 
-  const window = usage.contextWindow || DEFAULT_CONTEXT_WINDOW;
+  const contextWindow = usage.contextWindow || DEFAULT_CONTEXT_WINDOW;
   const used = usage.contextTokens;
-  const free = Math.max(0, window - used);
-  const pct = Math.min(100, Math.round((used / window) * 100));
+  const free = Math.max(0, contextWindow - used);
+  const pct = Math.min(100, Math.round((used / contextWindow) * 100));
 
   const segments = [
     { key: "cacheRead", label: "Cache read", tokens: usage.contextCacheRead, color: "var(--accent)" },
@@ -55,7 +55,7 @@ export function UsageMeter({ usage }: { usage: AgentUsage }) {
           <div className="up-head">
             <span className="up-title">Context window</span>
             <span className="up-frac">
-              <b>{formatTokens(used)}</b> / {formatTokens(window)}
+              <b>{formatTokens(used)}</b> / {formatTokens(contextWindow)}
             </span>
           </div>
 

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -8,6 +8,8 @@ import { Icon } from "../Icon";
 import { Chip } from "../ui/Chip";
 import { ModelPicker } from "./ModelPicker";
 import { BranchPicker } from "./BranchPicker";
+import { UsageMeter } from "./UsageMeter";
+import type { AgentUsage } from "../../store";
 import { AttachmentList } from "./AttachmentList";
 import { useFileDrop } from "./useFileDrop";
 import type { DirListing, PrSummary } from "../../api";
@@ -78,6 +80,10 @@ interface Props {
    *  Undefined for Cursor / Antigravity (no model in their transcript) or
    *  before the first agent turn. */
   activeModel?: string;
+  /** Per-agent token usage for the context gauge in the foot. Omit for new
+   *  sessions (no agent yet) or agents that report no usage (cursor,
+   *  antigravity) — the gauge then hides. */
+  usage?: AgentUsage;
 }
 
 function resolveThinking(providerId: string): string | undefined {
@@ -108,6 +114,7 @@ export function Composer({
   existingSession = false,
   initialThinking,
   activeModel,
+  usage,
 }: Props) {
   const features = useAppStore((s) => s.features);
 
@@ -329,6 +336,7 @@ export function Composer({
           <Icon name="attach" size={11} />
         </Chip>
         <span style={{ flex: 1 }} />
+        {usage && usage.contextTokens > 0 && <UsageMeter usage={usage} />}
         <button
           type="button"
           className={`send ${stopping ? "is-stop" : ""}`}

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -33,7 +33,7 @@ export function AgentRow(props: Props) {
 // ── real agent ───────────────────────────────────────────────────────────────
 
 function RealRow({ agent, active, onClick }: RealRowProps) {
-  const rawTokens = useAppStore((s) => s.tokens[agent.id]);
+  const usage = useAppStore((s) => s.usage[agent.id]);
   const prState = useAppStore((s) => s.prStates[agent.id] ?? null);
   const shortstats = useAppStore((s) => s.gitShortstats[agent.id]);
   const unseen = useAppStore((s) => s.unseenResults[agent.id] ?? false);
@@ -48,11 +48,17 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
   // spawning is the start of a run — show it as "working" too, not a dead row
   const working = agent.status === "running" || agent.status === "spawning";
 
+  const hasUsage = !!usage && usage.contextTokens > 0;
+  const contextWindow = usage?.contextWindow || DEFAULT_CONTEXT_WINDOW;
   const stats: AgentStats = {
     launched: age || "just now",
     runtime: liveRuntime(agent.created_at, now, agent.status),
-    tokens: rawTokens ?? null,
-    contextPct: contextPctFromTokens(rawTokens),
+    contextTokens: hasUsage ? usage!.contextTokens : null,
+    contextWindow,
+    contextPct: hasUsage ? contextPct(usage!.contextTokens, contextWindow) : 0,
+    totalInput: usage ? usage.inputTokens + usage.cacheReadTokens + usage.cacheWriteTokens : null,
+    totalOutput: usage ? usage.outputTokens : null,
+    costUsd: usage ? usage.costUsd : null,
   };
 
   const stoppable =
@@ -244,7 +250,11 @@ function liveRuntime(iso: string, now: number, status: AgentStatus): string {
   return `${m}m ${s}s`;
 }
 
-function contextPctFromTokens(tokens: number | undefined): number {
-  if (typeof tokens !== "number" || tokens <= 0) return 0;
-  return Math.min(100, Math.round((tokens / 200_000) * 100));
+/** Fallback context window for agents that don't report their own (claude,
+ *  opencode, pi all run 200k-class models here). */
+const DEFAULT_CONTEXT_WINDOW = 200_000;
+
+function contextPct(tokens: number, window: number): number {
+  if (tokens <= 0 || window <= 0) return 0;
+  return Math.min(100, Math.round((tokens / window) * 100));
 }

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -56,7 +56,10 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
     contextTokens: hasUsage ? usage!.contextTokens : null,
     contextWindow,
     contextPct: hasUsage ? contextPct(usage!.contextTokens, contextWindow) : 0,
-    totalInput: usage ? usage.inputTokens + usage.cacheReadTokens + usage.cacheWriteTokens : null,
+    // Fresh input only — matching the composer gauge. Cumulative cache read
+    // balloons (the same cached prefix re-read every turn) and is misleading
+    // as a session "input" total.
+    totalInput: usage ? usage.inputTokens : null,
     totalOutput: usage ? usage.outputTokens : null,
     costUsd: usage ? usage.costUsd : null,
   };

--- a/src/components/Sidebar/AgentStatsPopover.tsx
+++ b/src/components/Sidebar/AgentStatsPopover.tsx
@@ -1,25 +1,45 @@
-import { formatTokens } from "../../util/format";
+import { formatTokens, formatCost } from "../../util/format";
 
 export interface AgentStats {
   launched: string;
   runtime: string;
-  tokens: number | null;
+  /** Context-window fill in tokens, or null when the agent reports no usage. */
+  contextTokens: number | null;
+  /** Context window size in tokens (provider-reported or default). */
+  contextWindow: number;
   contextPct: number;
+  /** Cumulative session totals, or null when the agent reports no usage. */
+  totalInput: number | null;
+  totalOutput: number | null;
+  /** Cumulative dollar cost, or null when no usage / the agent doesn't report cost. */
+  costUsd: number | null;
 }
 
 /** Floats off the agent-row time chip on hover. Visual lift only —
  *  pure stats display, no actions. */
 export function AgentStatsPopover({ stats }: { stats: AgentStats }) {
-  const tokenLabel = stats.tokens != null ? `${formatTokens(stats.tokens)} / 200k` : "—";
+  const hasUsage = stats.contextTokens != null;
+  const contextLabel = hasUsage
+    ? `${formatTokens(stats.contextTokens!)} / ${formatTokens(stats.contextWindow)}`
+    : "—";
+  const ioLabel =
+    stats.totalInput != null && stats.totalOutput != null
+      ? `${formatTokens(stats.totalInput)} in · ${formatTokens(stats.totalOutput)} out`
+      : "—";
+
   return (
     <div className="ag-stats-pop" onClick={(e) => e.stopPropagation()}>
       <Row label="Launched" value={stats.launched} />
       <Row label="Runtime" value={stats.runtime} />
-      <Row label="Last turn" value={tokenLabel} />
+      <Row label="Context" value={contextLabel} />
       <div className="st-bar">
         <div className="st-bar-fill" style={{ width: `${stats.contextPct}%` }} />
       </div>
       <Row label="Context used" value={`${stats.contextPct}%`} />
+      <Row label="Tokens" value={ioLabel} />
+      {stats.costUsd != null && stats.costUsd > 0 && (
+        <Row label="Cost" value={formatCost(stats.costUsd)} />
+      )}
     </div>
   );
 }

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -27,6 +27,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
   const send = useAppStore((s) => s.sendUserMessage);
   const stop = useAppStore((s) => s.stop);
   const loadHistoryTranscript = useAppStore((s) => s.loadHistoryTranscript);
+  const usage = useAppStore((s) => s.usage[agent.id]);
   const composerSeed = useAppStore((s) => s.composerSeeds[agent.id]);
   const consumeComposerSeed = useAppStore((s) => s.consumeComposerSeed);
   // Stable identity: the Composer's seed effect lists this in its deps, so an
@@ -177,6 +178,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
         <Composer
           existingSession
           activeModel={activeModel}
+          usage={usage}
           defaultProvider={agent.provider}
           initialThinking={agent.effort ?? undefined}
           disabled={!canSend}

--- a/src/store.ts
+++ b/src/store.ts
@@ -34,6 +34,7 @@ import {
 } from "./components/RightPanel/primaryActions";
 import { commandsFor } from "./data/slashCommands";
 import { getAdapter, type ChatItem, type RawEvent } from "./adapters";
+import { usageFromRecords, type AgentUsage } from "./adapters/usage";
 import { getAllSettings, setSetting } from "./storage/settings";
 import {
   getAccount,
@@ -118,6 +119,7 @@ export function registerShellSink(
 //      import from "./adapters" directly; managedLogs is typed in terms
 //      of this. -----------------------------------------------------------
 export type { ChatItem } from "./adapters";
+export type { AgentUsage } from "./adapters/usage";
 
 // ---- Drafts ----------------------------------------------------------------
 // A draft is a new agent the user is about to spawn. It owns a landmark
@@ -236,10 +238,11 @@ interface AppState {
    *  non-selected agent (covers research-only turns with no diff), cleared
    *  when the agent is selected. */
   unseenResults: Record<string, boolean>;
-  /** Last observed input-token count from the agent's most recent
-   *  `result` event. Persists across agents so the right-rail
-   *  cost panel can show a stable number after a turn completes. */
-  tokens: Record<string, number>;
+  /** Per-agent cumulative token usage (and latest context-window fill),
+   *  folded from session_records at turn-end and on transcript load. Keyed by
+   *  agent_id; absent until the agent's first turn lands. Empty for agents that
+   *  don't persist usage on disk (cursor, antigravity). See adapters/usage.ts. */
+  usage: Record<string, AgentUsage>;
   /** Full git state, keyed by agent_id — branch, ahead/behind, file list,
    *  totals. Only populated for the focused agent (by GitPanel's 1s poll
    *  while it's mounted). For sidebar shortstats / right-rail badges of
@@ -599,8 +602,6 @@ function applyEvent(
     next[next.length - 1]?.kind === "notice" &&
     (next[next.length - 1] as { subtype?: string }).subtype === "turn_end";
 
-  const tokens = extractInputTokens(rawEvent);
-
   return {
     turnEnded,
     patch: {
@@ -611,19 +612,8 @@ function applyEvent(
       managedBusyLabel: turnEnded
         ? { ...state.managedBusyLabel, [agentId]: undefined }
         : state.managedBusyLabel,
-      tokens:
-        tokens !== undefined
-          ? { ...state.tokens, [agentId]: tokens }
-          : state.tokens,
     },
   };
-}
-
-function extractInputTokens(ev: RawEvent): number | undefined {
-  if (ev.type !== "result") return undefined;
-  const usage = ev.usage as Record<string, unknown> | undefined;
-  const n = usage?.input_tokens;
-  return typeof n === "number" && n > 0 ? n : undefined;
 }
 
 /** A per-turn agent captures its session id on its first turn (e.g. agy reads
@@ -682,7 +672,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   managedBusyLabel: {},
   switchInFlight: {},
   unseenResults: {},
-  tokens: {},
+  usage: {},
   gitStates: {},
   gitShortstats: {},
   prStates: {},
@@ -854,8 +844,10 @@ export const useAppStore = create<AppState>((set, get) => ({
           if (records.length === 0) return;
           const provider = providerFor(get(), id);
           const items = applyUserTurns(reduceRecords(provider, records), turns);
+          const usage = usageFromRecords(provider, records);
           set((state) => ({
             managedLogs: { ...state.managedLogs, [id]: items },
+            usage: { ...state.usage, [id]: usage },
           }));
           // The first turn captures the agent's session id in the DB; pull it
           // into the live workspace so the Native toggle unblocks without a
@@ -1204,7 +1196,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         const { [id]: _droppedTranscriptLoaded, ...restTranscriptLoaded } =
           s.transcriptLoaded;
         const { [id]: _droppedBusy, ...restBusy } = s.managedBusy;
-        const { [id]: _droppedTokens, ...restTokens } = s.tokens;
+        const { [id]: _droppedUsage, ...restUsage } = s.usage;
         const { [id]: _droppedGitState, ...restGitStates } = s.gitStates;
         const { [id]: _droppedShortstats, ...restShortstats } = s.gitShortstats;
         const { [id]: _droppedPrState, ...restPrStates } = s.prStates;
@@ -1219,7 +1211,7 @@ export const useAppStore = create<AppState>((set, get) => ({
           transcriptLoading: restTranscriptLoading,
           transcriptLoaded: restTranscriptLoaded,
           managedBusy: restBusy,
-          tokens: restTokens,
+          usage: restUsage,
           gitStates: restGitStates,
           gitShortstats: restShortstats,
           prStates: restPrStates,
@@ -1246,7 +1238,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         const { [id]: _tl, ...restTranscriptLoading } = s.transcriptLoading;
         const { [id]: _td, ...restTranscriptLoaded } = s.transcriptLoaded;
         const { [id]: _b, ...restBusy } = s.managedBusy;
-        const { [id]: _t, ...restTokens } = s.tokens;
+        const { [id]: _t, ...restUsage } = s.usage;
         const { [id]: _g, ...restGitStates } = s.gitStates;
         const { [id]: _s, ...restShortstats } = s.gitShortstats;
         const { [id]: _p, ...restPrStates } = s.prStates;
@@ -1261,7 +1253,7 @@ export const useAppStore = create<AppState>((set, get) => ({
           transcriptLoading: restTranscriptLoading,
           transcriptLoaded: restTranscriptLoaded,
           managedBusy: restBusy,
-          tokens: restTokens,
+          usage: restUsage,
           gitStates: restGitStates,
           gitShortstats: restShortstats,
           prStates: restPrStates,
@@ -1313,6 +1305,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       // a failed send still shows on reload even when there are no records yet.
       const turns = await api.readUserTurns(id);
       const items = applyUserTurns(reduceRecords(provider, records), turns);
+      const usage = usageFromRecords(provider, records);
       set((state) => {
         // Nothing stored but a live turn is already rendering — don't clobber it.
         if (items.length === 0 && (state.managedLogs[id]?.length ?? 0) > 0) {
@@ -1321,6 +1314,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         return {
           managedLogs: { ...state.managedLogs, [id]: items },
           managedBusy: { ...state.managedBusy, [id]: false },
+          usage: { ...state.usage, [id]: usage },
         };
       });
     } catch (e) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -34,7 +34,7 @@ import {
 } from "./components/RightPanel/primaryActions";
 import { commandsFor } from "./data/slashCommands";
 import { getAdapter, type ChatItem, type RawEvent } from "./adapters";
-import { usageFromRecords, type AgentUsage } from "./adapters/usage";
+import { usageFromRecords, hasUsage, type AgentUsage } from "./adapters/usage";
 import { getAllSettings, setSetting } from "./storage/settings";
 import {
   getAccount,
@@ -616,6 +616,37 @@ function applyEvent(
   };
 }
 
+/** Cursor reports token usage only on its live `result` event (never on disk),
+ *  so persist that event into session_records (`live_compiled`) when it lands —
+ *  then usage folds from records like every other agent, surviving restarts.
+ *  Idempotent on the event's `request_id`; after persisting, re-fold so the
+ *  gauge updates this turn rather than only on the next records refresh. */
+async function persistLiveUsage(
+  get: () => AppState,
+  set: (patch: Partial<AppState>) => void,
+  agentId: string,
+  rawEvent: RawEvent,
+): Promise<void> {
+  const provider = providerFor(get(), agentId);
+  const adapter = getAdapter(provider);
+  if (!adapter.persistLiveUsage || !adapter.extractUsage) return;
+  if (!adapter.extractUsage(rawEvent)) return; // nothing to persist this event
+  const nativeId =
+    typeof rawEvent.request_id === "string" && rawEvent.request_id
+      ? rawEvent.request_id
+      : `usage:${Date.now()}`;
+  try {
+    await api.appendLiveRecord(agentId, provider ?? adapter.id, nativeId, rawEvent);
+    const records = await api.readSessionRecords(agentId);
+    const usage = usageFromRecords(provider, records);
+    if (hasUsage(usage)) {
+      set({ usage: { ...get().usage, [agentId]: usage } });
+    }
+  } catch {
+    // Non-critical: the next records refresh or restart re-folds it.
+  }
+}
+
 /** A per-turn agent captures its session id on its first turn (e.g. agy reads
  *  it from disk at turn-end), but the id only reaches the live frontend via a
  *  full `getWorkspace`. True when an agent's turn just landed yet its session
@@ -801,6 +832,9 @@ export const useAppStore = create<AppState>((set, get) => ({
         turnEnded = result.turnEnded;
         return result.patch;
       });
+      // Capture usage that lives only on the live stream (cursor) into
+      // session_records so it folds like every other agent (see persistLiveUsage).
+      void persistLiveUsage(get, set, e.agent_id, e.event as RawEvent);
       // A turn can't end with prompts still held — clear any stale entries
       // (e.g. an interrupt that denied a pending question).
       if (turnEnded && get().pendingToolUse[e.agent_id]) {
@@ -847,7 +881,9 @@ export const useAppStore = create<AppState>((set, get) => ({
           const usage = usageFromRecords(provider, records);
           set((state) => ({
             managedLogs: { ...state.managedLogs, [id]: items },
-            usage: { ...state.usage, [id]: usage },
+            // Only overwrite when records carried usage — cursor folds usage
+            // live, so an empty records result must not wipe it.
+            usage: hasUsage(usage) ? { ...state.usage, [id]: usage } : state.usage,
           }));
           // The first turn captures the agent's session id in the DB; pull it
           // into the live workspace so the Native toggle unblocks without a
@@ -1314,7 +1350,9 @@ export const useAppStore = create<AppState>((set, get) => ({
         return {
           managedLogs: { ...state.managedLogs, [id]: items },
           managedBusy: { ...state.managedBusy, [id]: false },
-          usage: { ...state.usage, [id]: usage },
+          // Only overwrite when records carried usage — cursor folds usage
+          // live, so an empty records result must not wipe it.
+          ...(hasUsage(usage) ? { usage: { ...state.usage, [id]: usage } } : {}),
         };
       });
     } catch (e) {

--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -62,9 +62,9 @@ export function formatTokens(n: number): string {
   return `${(n / 1_000_000).toFixed(1)}M`;
 }
 
-/** A dollar cost: cents-precision below $10, sub-cent below $1 so small
- *  sessions don't round to "$0.00". */
+/** A dollar cost: 2 decimals at $1 and up ($5.00), sub-cent precision below $1
+ *  ($0.034) so small sessions don't round to "$0.00". */
 export function formatCost(usd: number): string {
   if (usd > 0 && usd < 0.01) return "<$0.01";
-  return `$${usd.toFixed(usd < 10 ? 3 : 2)}`;
+  return `$${usd.toFixed(usd < 1 ? 3 : 2)}`;
 }

--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -61,3 +61,10 @@ export function formatTokens(n: number): string {
   if (n < 1_000_000) return `${(n / 1_000).toFixed(n < 10_000 ? 1 : 0)}k`;
   return `${(n / 1_000_000).toFixed(1)}M`;
 }
+
+/** A dollar cost: cents-precision below $10, sub-cent below $1 so small
+ *  sessions don't round to "$0.00". */
+export function formatCost(usd: number): string {
+  if (usd > 0 && usd < 0.01) return "<$0.01";
+  return `$${usd.toFixed(usd < 10 ? 3 : 2)}`;
+}


### PR DESCRIPTION
## What

Adds token-usage tracking for every agent and surfaces it as a context-window gauge in the composer foot.

## How it works

Usage is folded from **session_records** (the canonical, persisted transcript store), not the ephemeral live stream — so totals survive restarts and a turn rendered both live and from records is never double-counted. Each adapter gains an `extractUsage` that reads its agent's native on-disk body shape:

| Agent | Source | Reporting |
|---|---|---|
| claude | `assistant.message.usage` | per-message delta |
| codex | `token_count` event | cumulative `total_token_usage` (latest wins — codex re-emits identical lines); reports its own context window |
| opencode | `step-finish` part blob | per-step delta, native cost |
| pi | assistant `message.usage` | per-message delta, native cost |
| cursor / antigravity | — | no usage persisted on disk → gauge hides |

## UI

The composer gauge mirrors the v2 design: a donut ring + %, threshold-colored (accent → warn ≥75% → danger ≥90%), with a hover popover showing:
- the `used / window` fraction
- a segmented bar of the **current window** (cache read / cache write / input) + free
- session totals (input/output, plus cost where the agent reports it natively)

The sidebar agent-stats popover reads the same data.

## Notable decisions

- **Segmented bar = real cache-state split**, not the design's mocked *system / conversation / reasoning* split — that semantic split isn't recoverable from any agent's transcript. Cache-read tokens genuinely occupy the context window (caching changes billing/latency, not size), so counting them toward fill is accurate.
- **Cumulative cache-read is omitted from the rows.** Summed across turns it balloons into the tens of millions (the same cached prefix re-read every turn) and is misleading next to input/output. Cache effort stays visible in the current-window bar.

## Known gaps (follow-ups)

- No cost for claude/codex/cursor (would need a static model→price table; opencode/pi report cost natively).
- Context window defaults to 200k for claude/opencode/pi (only codex reports its own); a long Claude turn can sum slightly over 200k and clamp to 100%. A model→window map would fix the percentage.

## Testing

`tsc --noEmit`, `vitest` (263 passed incl. new `adapters/usage.test.ts`), and `bun run build` all green.