### PR TITLE
ci: cache apt packages in rust-test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+          version: 1.0
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Problem

The `rust-test` CI job re-installed the Tauri system dependencies
(`libwebkit2gtk-4.1-dev`, `libgtk-3-dev`, `libayatana-appindicator3-dev`,
`librsvg2-dev`) from scratch on every run via `apt-get update` + install.
That webkit/gtk dependency tree is hundreds of MB and was completely
uncached, so every CI run paid the full download/unpack cost — made worse
by the `ubuntu-latest` migration to 24.04 (noble).

## Fix

Replace the manual `apt-get` step with `awalsh128/cache-apt-pkgs-action`,
which caches the resolved `.deb` packages between runs and restores them
in seconds. No `apt-get update`, no mirror downloads on cache hits.

- First run after this change installs normally and populates the cache.
- Subsequent runs restore from cache, dropping the step from minutes to
  seconds.
- The `version: 1.0` key suffix can be bumped to force a fresh cache when
  the package list changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)