### PR TITLE
[codex] Add agent model picker

### DIFF
--- a/src-tauri/migrations/0009_session_model.sql
+++ b/src-tauri/migrations/0009_session_model.sql
@@ -1,0 +1,4 @@
+-- Optional model chosen when the agent session was created. NULL keeps the
+-- provider CLI default for older sessions and drafts where the user did not
+-- pick a specific model.
+ALTER TABLE sessions ADD COLUMN model TEXT;

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -587,6 +587,9 @@ fn opencode_read(message_paths: &[PathBuf]) -> Vec<RawRecord> {
 // exit ends the turn, and history comes entirely from its on-disk transcript.
 // The conversation id (== session id) lives in agy's filesystem, not its output.
 
+// `_model` is intentionally unused: agy's `--print` runner ignores model
+// selection (the `--model` flag is inert in print mode), so the picker offers
+// no selectable models for antigravity (see `model_catalog::discover_one`).
 fn antigravity_build_args(prompt: &str, session_id: Option<&str>, _thinking: Option<&str>, _model: Option<&str>) -> Vec<String> {
     // `--print` takes the prompt as its *value* (i.e. `--print <prompt>`), so the
     // prompt must come last, directly after `--print`. Putting another flag
@@ -601,6 +604,8 @@ fn antigravity_build_args(prompt: &str, session_id: Option<&str>, _thinking: Opt
     args
 }
 
+// `_model` unused: agy's TUI manages its own model selection (see
+// `antigravity_build_args` and `model_catalog::discover_one`).
 fn antigravity_pty_args(session_id: Option<&str>, _model: Option<&str>) -> Vec<String> {
     // Native view: launch agy's interactive TUI (NOT `--print`, the
     // non-interactive turn runner), resuming the conversation by id.

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -69,6 +69,8 @@ pub struct PerTurnSpec {
     pub sandbox_root: PathBuf,
     /// Session id to resume, if one has been captured already.
     pub session_id: Option<String>,
+    /// Session-level model override. `None` keeps the provider CLI default.
+    pub model: Option<String>,
     /// The agent's RPC mailbox dir, exposed to the child as `QUORUM_RPC_DIR`.
     pub rpc_dir: PathBuf,
 }
@@ -86,11 +88,11 @@ pub struct PerTurnDescriptor {
     bin: &'static str,
     /// Human-facing product name, used only in the not-found error.
     label: &'static str,
-    /// Builds the CLI args for a turn: `(prompt, resume_session_id, thinking_effort)`.
-    build_args: fn(&str, Option<&str>, Option<&str>) -> Vec<String>,
+    /// Builds the CLI args for a turn: `(prompt, resume_session_id, thinking_effort, model)`.
+    build_args: fn(&str, Option<&str>, Option<&str>, Option<&str>) -> Vec<String>,
     /// Builds the args to launch this agent's interactive TUI in the native
-    /// (PTY) view: `None` = fresh session, `Some(id)` = resume.
-    pty_args: fn(Option<&str>) -> Vec<String>,
+    /// (PTY) view: first arg is session (`None` = fresh), second is model.
+    pty_args: fn(Option<&str>, Option<&str>) -> Vec<String>,
     /// Extracts the agent-assigned session id from a turn's events. No-op for
     /// `plaintext` agents (they emit no events — see `session_id_from_cwd`).
     session_id: fn(&Value) -> Option<String>,
@@ -585,7 +587,7 @@ fn opencode_read(message_paths: &[PathBuf]) -> Vec<RawRecord> {
 // exit ends the turn, and history comes entirely from its on-disk transcript.
 // The conversation id (== session id) lives in agy's filesystem, not its output.
 
-fn antigravity_build_args(prompt: &str, session_id: Option<&str>, _thinking: Option<&str>) -> Vec<String> {
+fn antigravity_build_args(prompt: &str, session_id: Option<&str>, _thinking: Option<&str>, _model: Option<&str>) -> Vec<String> {
     // `--print` takes the prompt as its *value* (i.e. `--print <prompt>`), so the
     // prompt must come last, directly after `--print`. Putting another flag
     // between them makes that flag the prompt (agy then "answers" the flag name).
@@ -599,7 +601,7 @@ fn antigravity_build_args(prompt: &str, session_id: Option<&str>, _thinking: Opt
     args
 }
 
-fn antigravity_pty_args(session_id: Option<&str>) -> Vec<String> {
+fn antigravity_pty_args(session_id: Option<&str>, _model: Option<&str>) -> Vec<String> {
     // Native view: launch agy's interactive TUI (NOT `--print`, the
     // non-interactive turn runner), resuming the conversation by id.
     let mut args = vec!["--dangerously-skip-permissions".to_string()];
@@ -731,6 +733,8 @@ pub struct SpawnSpec<'a> {
     /// no selection; claude uses its own default. Ignored by per-turn agents,
     /// which take effort per-turn via their `thinking` build-args instead.
     pub effort: Option<&'a str>,
+    /// Session-level model override. `None` keeps the provider CLI default.
+    pub model: Option<&'a str>,
     /// The agent's RPC mailbox dir, exposed to the child as `QUORUM_RPC_DIR`.
     pub rpc_dir: PathBuf,
     pub cols: u16,
@@ -812,7 +816,7 @@ impl Agent {
         } else {
             Some(spec.session_id)
         };
-        let agent_args = (desc.pty_args)(session);
+        let agent_args = (desc.pty_args)(session, spec.model);
         let env = rpc_env(&spec.rpc_dir);
 
         // Unified sandbox: run the agent's TUI under sandbox-exec with Quorum's
@@ -945,7 +949,7 @@ impl Agent {
         cb: ExecCallbacks<F, G, H>,
     ) -> Result<Self>
     where
-        A: Fn(&str, Option<&str>, Option<&str>) -> Vec<String> + Send + Sync + 'static,
+        A: Fn(&str, Option<&str>, Option<&str>, Option<&str>) -> Vec<String> + Send + Sync + 'static,
         I: Fn(&Value) -> Option<String> + Send + Sync + 'static,
         F: Fn(Value) + Send + Sync + 'static,
         G: Fn(String) + Send + Sync + 'static,
@@ -985,6 +989,7 @@ impl Agent {
                 profile: Some(profile_file),
                 cwd: spec.cwd,
                 session_id: spec.session_id,
+                model: spec.model,
                 stdout_is_json,
                 env,
             },
@@ -1096,6 +1101,13 @@ fn effort_args(effort: Option<&str>) -> Vec<String> {
     }
 }
 
+fn model_args(model: Option<&str>) -> Vec<String> {
+    match model {
+        Some(id) if !id.trim().is_empty() => vec!["--model".into(), id.to_string()],
+        _ => Vec::new(),
+    }
+}
+
 fn prepare_pty_args(
     spec: &SpawnSpec<'_>,
 ) -> Result<(tempfile::NamedTempFile, Vec<String>)> {
@@ -1119,6 +1131,7 @@ fn prepare_pty_args(
         "bypassPermissions".into(),
     ];
     args.extend(effort_args(spec.effort));
+    args.extend(model_args(spec.model));
     args.extend(instructions::append_system_prompt_args());
 
     if spec.fresh {
@@ -1174,6 +1187,7 @@ fn prepare_managed_args(
         "stdio".into(),
     ];
     args.extend(effort_args(spec.effort));
+    args.extend(model_args(spec.model));
     args.extend(instructions::append_system_prompt_args());
 
     if spec.fresh {
@@ -1199,7 +1213,7 @@ fn resolve_claude(home: &Path) -> Result<String> {
 /// sandbox-exec like every other agent, so codex's own confinement is disabled
 /// to leave a single boundary — and so codex can reach its RPC mailbox, which
 /// lives outside the worktree that `workspace-write` would have confined it to.
-fn codex_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&str>) -> Vec<String> {
+fn codex_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&str>, model: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = vec!["exec".into()];
     if let Some(id) = session_id {
         args.push("resume".into());
@@ -1215,6 +1229,7 @@ fn codex_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&st
         args.push("-c".into());
         args.push(format!("reasoning_effort=\"{effort}\""));
     }
+    args.extend(model_args(model));
     args.extend(instructions::codex_config_args());
     args.push(prompt.to_string());
     args
@@ -1235,7 +1250,7 @@ fn codex_session_id(event: &Value) -> Option<String> {
 /// `--force` runs commands without approval prompts; `--trust` trusts the
 /// workspace in headless mode. Cursor's own sandbox applies; cwd comes from
 /// the child process working directory.
-fn cursor_build_args(prompt: &str, session_id: Option<&str>, _thinking: Option<&str>) -> Vec<String> {
+fn cursor_build_args(prompt: &str, session_id: Option<&str>, _thinking: Option<&str>, model: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = vec![
         "-p".into(),
         "--output-format".into(),
@@ -1247,6 +1262,7 @@ fn cursor_build_args(prompt: &str, session_id: Option<&str>, _thinking: Option<&
         args.push("--resume".into());
         args.push(id.to_string());
     }
+    args.extend(model_args(model));
     // Prompt is positional and must come after options.
     args.push(instructions::prepend_to_prompt(prompt, session_id));
     args
@@ -1273,7 +1289,7 @@ fn cursor_session_id(event: &Value) -> Option<String> {
 /// 1.15.12. OpenCode runs in the child's cwd (no `--dir` needed) and assigns
 /// its own session id on the first turn. The prompt is positional and must
 /// come after the flags.
-fn opencode_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&str>) -> Vec<String> {
+fn opencode_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&str>, model: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = vec![
         "run".into(),
         "--format".into(),
@@ -1287,6 +1303,7 @@ fn opencode_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<
         args.push("--variant".into());
         args.push(variant.to_string());
     }
+    args.extend(model_args(model));
     if let Some(id) = session_id {
         args.push("--session".into());
         args.push(id.to_string());
@@ -1313,8 +1330,9 @@ fn opencode_session_id(event: &Value) -> Option<String> {
 /// it's the resume flag common to the versions we target — 0.74.x lacks
 /// `--session-id` entirely. Verified end-to-end against pi 0.74.2. Pi runs in
 /// the child's cwd; the prompt is positional and must come after the flags.
-fn pi_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&str>) -> Vec<String> {
+fn pi_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&str>, model: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = vec!["-p".into(), "--mode".into(), "json".into()];
+    args.extend(model_args(model));
     if let Some(level) = thinking {
         args.push("--thinking".into());
         args.push(level.to_string());
@@ -1348,8 +1366,9 @@ fn pi_session_id(event: &Value) -> Option<String> {
 /// Codex: bare `codex` launches the interactive TUI;
 /// `--dangerously-bypass-approvals-and-sandbox` runs it unattended (Quorum
 /// already isolates the worktree). `resume <id>` continues a prior session.
-fn codex_pty_args(session_id: Option<&str>) -> Vec<String> {
+fn codex_pty_args(session_id: Option<&str>, model: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = vec!["--dangerously-bypass-approvals-and-sandbox".into()];
+    args.extend(model_args(model));
     args.extend(instructions::codex_config_args());
     if let Some(id) = session_id {
         args.push("resume".into());
@@ -1360,8 +1379,9 @@ fn codex_pty_args(session_id: Option<&str>) -> Vec<String> {
 
 /// Cursor: bare `cursor-agent` launches the TUI; `--force` auto-allows
 /// commands. `--resume <id>` continues a prior chat.
-fn cursor_pty_args(session_id: Option<&str>) -> Vec<String> {
+fn cursor_pty_args(session_id: Option<&str>, model: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = vec!["--force".into()];
+    args.extend(model_args(model));
     if let Some(id) = session_id {
         args.push("--resume".into());
         args.push(id.to_string());
@@ -1375,8 +1395,9 @@ fn cursor_pty_args(session_id: Option<&str>) -> Vec<String> {
 /// subcommand and makes the *default* (TUI) command print help and exit. The
 /// TUI prompts for tool permissions interactively, which the native view
 /// handles like any other keystroke.
-fn opencode_pty_args(session_id: Option<&str>) -> Vec<String> {
+fn opencode_pty_args(session_id: Option<&str>, model: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = Vec::new();
+    args.extend(model_args(model));
     if let Some(id) = session_id {
         args.push("--session".into());
         args.push(id.to_string());
@@ -1387,8 +1408,9 @@ fn opencode_pty_args(session_id: Option<&str>) -> Vec<String> {
 /// Pi: bare `pi` launches the interactive TUI (tools auto-run there).
 /// `--session <id>` resumes — same flag the Custom-view runner uses, since the
 /// versions we target (0.74.x) lack `--session-id`.
-fn pi_pty_args(session_id: Option<&str>) -> Vec<String> {
+fn pi_pty_args(session_id: Option<&str>, model: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = instructions::append_system_prompt_args();
+    args.extend(model_args(model));
     if let Some(id) = session_id {
         args.push("--session".into());
         args.push(id.to_string());
@@ -1724,7 +1746,7 @@ mod tests {
     #[test]
     fn opencode_args_request_thinking() {
         // Without --thinking, opencode emits no `reasoning` events at all.
-        let args = opencode_build_args("hi", None, None);
+        let args = opencode_build_args("hi", None, None, None);
         assert!(args.contains(&"--thinking".to_string()));
         assert!(args.contains(&"--format".to_string()));
         // Prompt is positional and last (possibly prefixed with injected
@@ -1738,11 +1760,11 @@ mod tests {
     fn codex_pty_args_launch_tui_fresh_and_resume() {
         // Fresh: bypass approvals/sandbox so the TUI runs unattended; no
         // `exec`/`resume` subcommand means the interactive CLI.
-        let fresh = codex_pty_args(None);
+        let fresh = codex_pty_args(None, None);
         assert!(fresh.contains(&"--dangerously-bypass-approvals-and-sandbox".to_string()));
         assert!(!fresh.iter().any(|a| a == "resume"));
         // Resume: `resume <id>` continues the prior interactive session.
-        let resume = codex_pty_args(Some("abc123"));
+        let resume = codex_pty_args(Some("abc123"), None);
         assert!(resume.contains(&"--dangerously-bypass-approvals-and-sandbox".to_string()));
         let pos = resume
             .iter()
@@ -1753,10 +1775,10 @@ mod tests {
 
     #[test]
     fn cursor_pty_args_force_and_resume() {
-        let fresh = cursor_pty_args(None);
+        let fresh = cursor_pty_args(None, None);
         assert!(fresh.contains(&"--force".to_string()));
         assert!(!fresh.iter().any(|a| a == "--resume"));
-        let resume = cursor_pty_args(Some("chat-1"));
+        let resume = cursor_pty_args(Some("chat-1"), None);
         assert!(resume.contains(&"--force".to_string()));
         let pos = resume
             .iter()
@@ -1770,11 +1792,11 @@ mod tests {
         // Fresh: bare `opencode` launches the TUI. It must NOT carry
         // `--dangerously-skip-permissions` — that's a `run`-only flag, and
         // the default (TUI) command prints help and exits when given it.
-        let fresh = opencode_pty_args(None);
+        let fresh = opencode_pty_args(None, None);
         assert!(!fresh.iter().any(|a| a == "--dangerously-skip-permissions"));
         assert!(fresh.is_empty());
         // Resume: `--session <id>` continues the prior session.
-        let resume = opencode_pty_args(Some("ses_9"));
+        let resume = opencode_pty_args(Some("ses_9"), None);
         assert!(!resume.iter().any(|a| a == "--dangerously-skip-permissions"));
         let pos = resume
             .iter()
@@ -1787,10 +1809,10 @@ mod tests {
     fn pi_pty_args_bare_tui_and_session() {
         // Fresh: bare `pi` launches the interactive TUI; tools auto-run there.
         // (May carry injected --append-system-prompt args, but never a resume.)
-        let fresh = pi_pty_args(None);
+        let fresh = pi_pty_args(None, None);
         assert!(!fresh.iter().any(|a| a == "--session"), "fresh TUI has no resume flag");
         // Resume uses `--session <id>` (target pi 0.74.x lacks `--session-id`).
-        let resume = pi_pty_args(Some("u-7"));
+        let resume = pi_pty_args(Some("u-7"), None);
         let pos = resume
             .iter()
             .position(|a| a == "--session")
@@ -1803,7 +1825,7 @@ mod tests {
         // Native view is wired for every per-turn agent, so each descriptor
         // must carry a TUI arg-builder. Fresh launch never references resume.
         for d in PER_TURN_AGENTS {
-            let fresh = (d.pty_args)(None);
+            let fresh = (d.pty_args)(None, None);
             assert!(
                 !fresh
                     .iter()
@@ -1816,14 +1838,14 @@ mod tests {
 
     #[test]
     fn opencode_args_variant_when_thinking_set() {
-        let args = opencode_build_args("hi", None, Some("max"));
+        let args = opencode_build_args("hi", None, Some("max"), None);
         assert!(args.contains(&"--variant".to_string()));
         assert!(args.contains(&"max".to_string()));
     }
 
     #[test]
     fn codex_args_reasoning_effort_when_thinking_set() {
-        let args = codex_build_args("hi", None, Some("high"));
+        let args = codex_build_args("hi", None, Some("high"), None);
         assert!(args.contains(&"reasoning_effort=\"high\"".to_string()));
     }
 
@@ -1832,7 +1854,7 @@ mod tests {
         // Quorum now wraps codex in sandbox-exec, so codex's own confinement is
         // turned fully off — otherwise its workspace-write sandbox would block
         // the RPC mailbox, which lives outside the worktree.
-        let args = codex_build_args("hi", None, None);
+        let args = codex_build_args("hi", None, None, None);
         assert!(args.contains(&"sandbox_mode=\"danger-full-access\"".to_string()));
         assert!(!args.iter().any(|a| a.contains("workspace-write")));
         assert!(args.contains(&"approval_policy=\"never\"".to_string()));
@@ -1840,7 +1862,7 @@ mod tests {
 
     #[test]
     fn pi_args_thinking_when_set() {
-        let args = pi_build_args("hi", None, Some("xhigh"));
+        let args = pi_build_args("hi", None, Some("xhigh"), None);
         assert!(args.contains(&"--thinking".to_string()));
         assert!(args.contains(&"xhigh".to_string()));
     }
@@ -1860,8 +1882,8 @@ mod tests {
 
     #[test]
     fn cursor_args_ignores_thinking() {
-        let with_none = cursor_build_args("hi", None, None);
-        let with_some = cursor_build_args("hi", None, Some("high"));
+        let with_none = cursor_build_args("hi", None, None, None);
+        let with_some = cursor_build_args("hi", None, Some("high"), None);
         assert_eq!(with_none, with_some);
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -147,6 +147,7 @@ pub async fn spawn_agent(
     provider: Option<String>,
     name: Option<String>,
     effort: Option<String>,
+    model: Option<String>,
 ) -> Result<AgentRecord> {
     let sup = supervisor.inner().clone();
     sup.spawn_agent(
@@ -156,6 +157,7 @@ pub async fn spawn_agent(
         provider.unwrap_or_else(|| "claude".to_string()),
         name,
         effort,
+        model,
     )
     .await
 }

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -38,6 +38,7 @@ fn get_migrations() -> Migrations<'static> {
         M::up(include_str!("../migrations/0006_session_effort.sql")),
         M::up(include_str!("../migrations/0007_account_oauth.sql")),
         M::up(include_str!("../migrations/0008_worktree_base_sha.sql")),
+        M::up(include_str!("../migrations/0009_session_model.sql")),
     ])
 }
 

--- a/src-tauri/src/exec_session.rs
+++ b/src-tauri/src/exec_session.rs
@@ -31,7 +31,7 @@ use crate::error::{Error, Result};
 type EventCb = Arc<dyn Fn(Value) + Send + Sync>;
 type SessionIdCb = Arc<dyn Fn(String) + Send + Sync>;
 type ExitCb = Arc<dyn Fn(bool) + Send + Sync>;
-type ArgsBuilder = Arc<dyn Fn(&str, Option<&str>, Option<&str>) -> Vec<String> + Send + Sync>;
+type ArgsBuilder = Arc<dyn Fn(&str, Option<&str>, Option<&str>, Option<&str>) -> Vec<String> + Send + Sync>;
 type IdExtractor = Arc<dyn Fn(&Value) -> Option<String> + Send + Sync>;
 
 pub struct ExecSpawn {
@@ -49,6 +49,8 @@ pub struct ExecSpawn {
     pub cwd: PathBuf,
     /// Session id to resume, if one has been captured already.
     pub session_id: Option<String>,
+    /// Session-level model override. `None` keeps the provider CLI default.
+    pub model: Option<String>,
     /// When false, the turn's stdout is **plaintext** — drained without JSON
     /// parsing (no events emitted). History for such agents comes from their
     /// on-disk transcript, and the session id from the filesystem.
@@ -67,6 +69,7 @@ pub struct ExecSession {
     stdout_is_json: bool,
     env: Vec<(String, String)>,
     session_id: Arc<Mutex<Option<String>>>,
+    model: Option<String>,
     child: Arc<Mutex<Option<Child>>>,
     /// Monotonic turn counter. A reap thread only reports its exit if its
     /// turn is still the latest — so a superseded turn's late exit can't
@@ -95,7 +98,7 @@ impl ExecSession {
         cb: ExecCallbacks<F, G, H>,
     ) -> Self
     where
-        A: Fn(&str, Option<&str>, Option<&str>) -> Vec<String> + Send + Sync + 'static,
+        A: Fn(&str, Option<&str>, Option<&str>, Option<&str>) -> Vec<String> + Send + Sync + 'static,
         I: Fn(&Value) -> Option<String> + Send + Sync + 'static,
         F: Fn(Value) + Send + Sync + 'static,
         G: Fn(String) + Send + Sync + 'static,
@@ -109,6 +112,7 @@ impl ExecSession {
             stdout_is_json: spec.stdout_is_json,
             env: spec.env,
             session_id: Arc::new(Mutex::new(spec.session_id)),
+            model: spec.model,
             child: Arc::new(Mutex::new(None)),
             turn_seq: Arc::new(AtomicU64::new(0)),
             build_args: Arc::new(build_args),
@@ -144,7 +148,7 @@ impl ExecSession {
 
         let args = {
             let id = self.session_id.lock();
-            (self.build_args)(&prompt, id.as_deref(), thinking)
+            (self.build_args)(&prompt, id.as_deref(), thinking, self.model.as_deref())
         };
         let mut cmd = Command::new(&self.program);
         cmd.args(&self.prefix_args);
@@ -325,11 +329,15 @@ mod tests {
     }
 
     // A codex-style config: id from `thread.started`, end on `turn.completed`.
-    fn codex_args(prompt: &str, session_id: Option<&str>, _thinking: Option<&str>) -> Vec<String> {
+    fn codex_args(prompt: &str, session_id: Option<&str>, _thinking: Option<&str>, model: Option<&str>) -> Vec<String> {
         let mut a = vec!["exec".to_string()];
         if let Some(id) = session_id {
             a.push("resume".into());
             a.push(id.to_string());
+        }
+        if let Some(model) = model {
+            a.push("--model".into());
+            a.push(model.to_string());
         }
         a.push("--json".into());
         a.push(prompt.to_string());
@@ -365,6 +373,7 @@ mod tests {
                 profile: None,
                 cwd: dir.path().to_path_buf(),
                 session_id: None,
+                model: None,
                 stdout_is_json: true,
                 env: vec![],
             },
@@ -422,6 +431,7 @@ mod tests {
                 profile: None,
                 cwd: dir.path().to_path_buf(),
                 session_id: Some("prev-thread".into()),
+                model: Some("gpt-5.2-codex".into()),
                 stdout_is_json: true,
                 env: vec![],
             },
@@ -440,6 +450,7 @@ mod tests {
         erx.recv_timeout(Duration::from_secs(5)).unwrap();
         let args = std::fs::read_to_string(dir.path().join("argv.txt")).unwrap();
         assert!(args.contains("exec resume prev-thread"), "argv was: {args}");
+        assert!(args.contains("--model gpt-5.2-codex"), "argv was: {args}");
         assert!(args.contains("--json"));
     }
 }

--- a/src-tauri/src/model_catalog.rs
+++ b/src-tauri/src/model_catalog.rs
@@ -83,7 +83,12 @@ async fn discover_one(agent: &str, home: &Path) -> AgentModels {
         "cursor" => (None, run_cli("cursor-agent", &["models"], home).await.map(|t| parse_cursor_models(&t)).unwrap_or_default()),
         "opencode" => (None, run_cli("opencode", &["models"], home).await.map(|t| parse_opencode_models(&t)).unwrap_or_default()),
         "claude" => (Some("anthropic".to_string()), Vec::new()),
-        "antigravity" => (Some("google".to_string()), Vec::new()),
+        // agy's `--print` runner ignores model selection entirely (the `--model`
+        // flag and its persisted setting are both inert in print mode), and its
+        // model ids are display labels ("Gemini 3.5 Flash (High)"), not the
+        // models.dev ids a provider hint would yield. So antigravity contributes
+        // no selectable models — the picker treats it as a fixed-model agent.
+        "antigravity" => (None, Vec::new()),
         _ => (None, Vec::new()),
     };
     AgentModels { agent: agent.to_string(), provider_hint, models }

--- a/src-tauri/src/model_catalog.rs
+++ b/src-tauri/src/model_catalog.rs
@@ -106,7 +106,15 @@ async fn run_cli(bin: &str, args: &[&str], home: &Path) -> Option<String> {
     if !out.status.success() {
         return None;
     }
-    Some(String::from_utf8_lossy(&out.stdout).into_owned())
+    Some(cli_output_text(&out.stdout, &out.stderr))
+}
+
+fn cli_output_text(stdout: &[u8], stderr: &[u8]) -> String {
+    if stdout.iter().any(|b| !b.is_ascii_whitespace()) {
+        String::from_utf8_lossy(stdout).into_owned()
+    } else {
+        String::from_utf8_lossy(stderr).into_owned()
+    }
 }
 
 fn discover_codex(home: &Path) -> Vec<DiscoveredModel> {
@@ -193,8 +201,9 @@ fn parse_cursor_models(text: &str) -> Vec<DiscoveredModel> {
         .collect()
 }
 
-/// opencode `models`: `provider/model` per line. We key on the bare model id
-/// (what the transcript reports), dropping the provider prefix.
+/// opencode `models`: `provider/model` per line. Keep the full CLI id so the
+/// frontend can pass it back to `opencode --model`; the catalog adds a bare-id
+/// alias for transcript lookup.
 fn parse_opencode_models(text: &str) -> Vec<DiscoveredModel> {
     text.lines()
         .filter_map(|line| {
@@ -202,8 +211,7 @@ fn parse_opencode_models(text: &str) -> Vec<DiscoveredModel> {
             if line.is_empty() {
                 return None;
             }
-            let id = line.rsplit('/').next().unwrap_or(line);
-            Some(DiscoveredModel::id(id))
+            Some(DiscoveredModel::id(line))
         })
         .collect()
 }
@@ -254,6 +262,15 @@ mod tests {
     }
 
     #[test]
+    fn uses_stderr_when_successful_cli_has_empty_stdout() {
+        let text = cli_output_text(b"", b"provider model context\nanthropic claude-opus-4-8 1M\n");
+        assert!(text.contains("claude-opus-4-8"));
+
+        let text = cli_output_text(b"stdout wins", b"stderr fallback");
+        assert_eq!(text, "stdout wins");
+    }
+
+    #[test]
     fn parses_cursor_models() {
         let t = "Available models\n\nauto - Auto\ngpt-5.3-codex - Codex 5.3";
         let got = parse_cursor_models(t);
@@ -264,11 +281,11 @@ mod tests {
     }
 
     #[test]
-    fn parses_opencode_models_bare_id() {
+    fn parses_opencode_models_cli_id() {
         let t = "opencode/big-pickle\nollama/gemma4:12b\n";
         let got = parse_opencode_models(t);
         assert_eq!(got.len(), 2);
-        assert_eq!(got[0].id, "big-pickle");
-        assert_eq!(got[1].id, "gemma4:12b");
+        assert_eq!(got[0].id, "opencode/big-pickle");
+        assert_eq!(got[1].id, "ollama/gemma4:12b");
     }
 }

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -425,6 +425,7 @@ impl Supervisor {
         provider: String,
         name: Option<String>,
         effort: Option<String>,
+        model: Option<String>,
     ) -> Result<AgentRecord> {
         if !repo_path.join(".git").exists() {
             return Err(Error::InvalidPath(format!(
@@ -479,6 +480,9 @@ impl Supervisor {
         // Session-level effort (claude `--effort`); persisted so start_process
         // re-applies it on every spawn. Per-turn agents ignore it at spawn.
         record.effort = effort;
+        // Session-level model selection. `None` preserves the provider CLI
+        // default; selected values are reapplied on resume and view switches.
+        record.model = model;
         let parent_dir = agent_parent_dir(&agent_id)?;
         let primary_worktree = repo_worktree_path(&agent_id, &subdir)?;
 
@@ -695,6 +699,7 @@ impl Supervisor {
                         // Per-turn agents take effort per-turn (build-args),
                         // not at spawn.
                         effort: None,
+                        model: record.model.as_deref(),
                         rpc_dir: rpc_dir.clone(),
                         cols: 120,
                         rows: 32,
@@ -717,6 +722,7 @@ impl Supervisor {
                         cwd,
                         sandbox_root: sandbox_root.clone(),
                         session_id: session_id.clone(),
+                        model: record.model.clone(),
                         rpc_dir: rpc_dir.clone(),
                     },
                     app.clone(),
@@ -738,6 +744,7 @@ impl Supervisor {
                 // Claude's session-level effort, persisted on the record so it
                 // re-applies on every spawn (fresh, view-switch, resume).
                 effort: record.effort.as_deref(),
+                model: record.model.as_deref(),
                 rpc_dir: rpc_dir.clone(),
                 cols: 120,
                 rows: 32,

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -143,6 +143,10 @@ pub struct AgentRecord {
     /// per-turn agents take effort per-turn instead.
     #[serde(default)]
     pub effort: Option<String>,
+    /// Model selected at session creation. `None` means the provider CLI should
+    /// use its configured/default model.
+    #[serde(default)]
+    pub model: Option<String>,
     pub created_at: String,
     #[serde(default)]
     pub last_error: Option<String>,
@@ -385,8 +389,8 @@ impl WorkspaceManager {
         // not persisted — it derives from the workspace/session dispositions.
         let session_id = uuid::Uuid::new_v4().to_string();
         conn.execute(
-            "INSERT INTO sessions (id, workspace_id, provider, view, provider_session_id, last_error, effort, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            "INSERT INTO sessions (id, workspace_id, provider, view, provider_session_id, last_error, effort, model, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             rusqlite::params![
                 session_id,
                 record.id,
@@ -395,6 +399,7 @@ impl WorkspaceManager {
                 record.session_id,
                 record.last_error,
                 record.effort,
+                record.model,
                 created_millis,
             ],
         )?;
@@ -984,7 +989,7 @@ impl WorkspaceManager {
             "SELECT w.id, w.project_id, w.name, w.task, w.created_at,
                     w.stopped_at, w.archived_at,
                     s.provider, s.view, s.provider_session_id, s.last_error,
-                    s.effort
+                    s.effort, s.model
              FROM workspaces w
              LEFT JOIN sessions s ON s.workspace_id = w.id
              ORDER BY w.created_at",
@@ -1007,6 +1012,7 @@ impl WorkspaceManager {
                 let session_id: Option<String> = row.get(9)?;
                 let last_error: Option<String> = row.get(10)?;
                 let effort: Option<String> = row.get(11)?;
+                let model: Option<String> = row.get(12)?;
 
                 Ok((
                     id,
@@ -1021,6 +1027,7 @@ impl WorkspaceManager {
                     session_id,
                     last_error,
                     effort,
+                    model,
                 ))
             })
             .ok()
@@ -1041,6 +1048,7 @@ impl WorkspaceManager {
                     session_id,
                     last_error,
                     effort,
+                    model,
                 )| {
                     let is_archived = archived_millis.is_some();
 
@@ -1073,6 +1081,7 @@ impl WorkspaceManager {
                         view: str_to_view(view_str.as_deref().unwrap_or("custom")),
                         session_id,
                         effort,
+                        model,
                         created_at: millis_to_iso(created_millis),
                         last_error,
                         archive,
@@ -1288,7 +1297,7 @@ impl WorkspaceManager {
                 "SELECT w.id, w.project_id, w.name, w.task, w.created_at,
                         w.stopped_at, w.archived_at,
                         s.provider, s.view, s.provider_session_id, s.last_error,
-                        s.effort
+                        s.effort, s.model
                  FROM workspaces w
                  LEFT JOIN sessions s ON s.workspace_id = w.id
                  WHERE w.id = ?1",
@@ -1307,6 +1316,7 @@ impl WorkspaceManager {
                         row.get::<_, Option<String>>(9)?,
                         row.get::<_, Option<String>>(10)?,
                         row.get::<_, Option<String>>(11)?,
+                        row.get::<_, Option<String>>(12)?,
                     ))
                 },
             )
@@ -1325,6 +1335,7 @@ impl WorkspaceManager {
             session_id,
             last_error,
             effort,
+            model,
         ) = row;
 
         let is_archived = archived_millis.is_some();
@@ -1356,6 +1367,7 @@ impl WorkspaceManager {
             view: str_to_view(view_str.as_deref().unwrap_or("custom")),
             session_id,
             effort,
+            model,
             created_at: millis_to_iso(created_millis),
             last_error,
             archive,
@@ -1402,6 +1414,7 @@ pub fn new_agent_record(
         view,
         session_id,
         effort: None,
+        model: None,
         created_at: Utc::now().to_rfc3339(),
         last_error: None,
         archive: None,

--- a/src/api.ts
+++ b/src/api.ts
@@ -62,6 +62,8 @@ export interface AgentRecord {
   /** Claude's session-level reasoning effort (`--effort <level>`), chosen at
    *  spawn. Null for agents where effort wasn't set or isn't session-scoped. */
   effort?: string | null;
+  /** Model chosen at spawn. Null/undefined means the provider CLI default. */
+  model?: string | null;
 }
 
 export interface Workspace {
@@ -356,6 +358,7 @@ export const api = {
     provider?: string,
     name?: string,
     effort?: string,
+    model?: string,
   ) =>
     invoke<AgentRecord>("spawn_agent", {
       view,
@@ -363,6 +366,7 @@ export const api = {
       provider,
       name,
       effort: effort ?? null,
+      model: model ?? null,
     }),
   writeToAgent: (agentId: string, data: string) =>
     invoke<void>("write_to_agent", { agentId, data }),

--- a/src/app.css
+++ b/src/app.css
@@ -1114,9 +1114,26 @@ button { cursor: default; }
   min-width: 0; flex-shrink: 0;
 }
 .c-chip:hover { background: var(--hover); color: var(--fg-0); }
-.c-chip svg { width: 11px; height: 11px; color: var(--fg-2); }
+.c-chip > svg { width: 11px; height: 11px; color: var(--fg-2); }
 .c-chip .dot { width: 6px; height: 6px; border-radius: 50%; }
 .c-chip.with-border { border-color: var(--bd); }
+.c-chip:disabled { opacity: .78; cursor: default; }
+.c-chip:disabled:hover { background: transparent; color: var(--fg-1); }
+
+.model-picker { position: relative; min-width: 0; }
+.model-chip { max-width: min(390px, 48vw); }
+.model-chip-agent {
+  font-weight: 550;
+  white-space: nowrap;
+}
+.model-chip-model {
+  min-width: 0;
+  max-width: 170px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--fg-2);
+}
 
 .send {
   width: 28px; height: 28px;
@@ -1249,6 +1266,187 @@ button { cursor: default; }
   font-size: 10px; font-weight: 600;
   letter-spacing: 0.08em; text-transform: uppercase;
   color: var(--fg-3);
+}
+
+.model-dd {
+  width: min(680px, calc(100vw - 48px));
+  padding: 0;
+  overflow: hidden;
+}
+.model-dd-head {
+  display: grid;
+  grid-template-columns: 190px minmax(0, 1fr);
+  gap: 0;
+  padding: 9px 10px 8px;
+  border-bottom: 1px solid var(--bd-soft);
+  color: var(--fg-3);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+.model-dd-grid {
+  display: grid;
+  grid-template-columns: 190px minmax(0, 1fr);
+  height: min(390px, calc(100vh - 180px));
+  min-height: 270px;
+  overflow: hidden;
+}
+.model-agent-list {
+  min-height: 0;
+  padding: 6px;
+  border-right: 1px solid var(--bd-soft);
+  overflow: auto;
+}
+.model-agent {
+  width: 100%;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 8px;
+  border-radius: var(--r-sm);
+  color: var(--fg-1);
+  text-align: left;
+}
+.model-agent:hover:not(:disabled),
+.model-agent.active {
+  background: var(--hover);
+  color: var(--fg-0);
+}
+.model-agent:disabled {
+  opacity: .42;
+}
+.model-agent-text {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.model-agent-text span:first-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12.5px;
+  font-weight: 540;
+}
+.model-agent-text span:last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--fg-3);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+}
+.model-agent > svg,
+.model-mark svg {
+  color: var(--accent);
+}
+.model-list {
+  min-height: 0;
+  padding: 6px;
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+.model-option {
+  width: 100%;
+  min-width: 0;
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  border-radius: var(--r-sm);
+  color: var(--fg-1);
+  text-align: left;
+}
+.model-option:hover,
+.model-option.active {
+  background: var(--hover);
+  color: var(--fg-0);
+}
+.model-mark {
+  width: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.model-option-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.model-option-main span:first-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12.5px;
+  font-weight: 560;
+}
+.model-option-main span:last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--fg-3);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+}
+.model-option-meta {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  max-width: 190px;
+}
+.model-option-meta span {
+  padding: 2px 5px;
+  border-radius: 4px;
+  background: var(--bg-3);
+  color: var(--fg-2);
+  font-size: 10.5px;
+  white-space: nowrap;
+}
+.model-empty {
+  margin: 12px;
+  padding: 18px 14px;
+  border: 1px dashed var(--bd);
+  border-radius: var(--r-sm);
+  color: var(--fg-3);
+  font-size: 12px;
+  text-align: center;
+}
+.model-dd-foot {
+  padding: 8px 10px;
+  border-top: 1px solid var(--bd-soft);
+  color: var(--fg-3);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 760px) {
+  .model-dd {
+    width: calc(100vw - 28px);
+  }
+  .model-dd-head,
+  .model-dd-grid {
+    grid-template-columns: 150px minmax(0, 1fr);
+  }
+  .model-option {
+    grid-template-columns: 18px minmax(0, 1fr);
+  }
+  .model-option-meta {
+    grid-column: 2;
+    justify-content: flex-start;
+    max-width: none;
+  }
+  .model-chip-agent {
+    display: none;
+  }
 }
 
 /* branch picker scroll buttons */
@@ -3862,15 +4060,18 @@ button { cursor: default; }
 /* Theme-aware ink for the chip — drives `currentColor` in inlined icons and
    the monogram text, so monochrome marks are dark in light mode, light in dark. */
 .theme-light .chip-mono { color: oklch(.45 .14 var(--ph-h, 50)); }
+.chip-mono.has-brand-icon { color: white; }
 .chip-mono-svg {
   display: inline-flex;
   width: 70%; height: 70%;
-  /* Neutral, theme-aware ink for monochrome (currentColor) icons — white in
-     dark, near-black in light — so they don't pick up the chip's hue tint.
-     Full-color logos with hardcoded fills are unaffected. */
-  color: var(--fg-0);
+  /* Brand SVGs authored with currentColor should render as white marks; the
+     hue tint belongs to the chip shell and monogram fallback only. */
+  color: currentColor;
 }
-.chip-mono-svg svg { width: 100%; height: 100%; display: block; }
+.chip-mono.has-brand-icon .chip-mono-svg svg {
+  width: 100%; height: 100%; display: block;
+  color: white;
+}
 
 .set-prov-id { flex: 1; min-width: 0; }
 .set-prov-name {

--- a/src/components/Composer/ModelPicker.tsx
+++ b/src/components/Composer/ModelPicker.tsx
@@ -126,7 +126,9 @@ export function ModelPicker({ provider, model, onChange, locked = false }: Props
 
                 {focusedModels.length === 0 ? (
                   <div className="model-empty">
-                    Model catalog unavailable for {focused.label}.
+                    {focused.fixedModel
+                      ? `${focused.label} manages its own model — no selection needed.`
+                      : `Model catalog unavailable for ${focused.label}.`}
                   </div>
                 ) : (
                   focusedModels.map((m) => {

--- a/src/components/Composer/ModelPicker.tsx
+++ b/src/components/Composer/ModelPicker.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { PROVIDERS } from "../../data/providers";
 import { hasAdapter } from "../../adapters";
 import { useAppStore } from "../../store";
@@ -8,64 +8,159 @@ import { Chip } from "../ui/Chip";
 import { Scrim } from "../ui/Scrim";
 
 interface Props {
-  value: string;
-  onChange: (id: string) => void;
+  provider: string;
+  model?: string;
+  onChange: (provider: string, model?: string) => void;
+  locked?: boolean;
 }
 
-/** Pops a dropdown listing enabled providers. Providers without an adapter
- *  (no backend runner yet) are shown but disabled as "Soon" so they can't be
- *  selected and silently fall back to Claude. */
-export function ModelPicker({ value, onChange }: Props) {
+function formatContext(tokens: number): string {
+  if (!tokens) return "Context unknown";
+  if (tokens >= 1_000_000) return `${Math.round(tokens / 1_000_000)}M ctx`;
+  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}k ctx`;
+  return `${tokens} ctx`;
+}
+
+function modelFamily(name: string): string {
+  const first = name.split(/\s+/)[0];
+  return first || "Model";
+}
+
+/** Agent + model picker. The left rail previews each runner's models; selecting
+ *  a row in the right pane commits the runner/model choice. Leaving model unset
+ *  preserves the provider CLI's default. */
+export function ModelPicker({ provider, model, onChange, locked = false }: Props) {
   const [open, setOpen] = useState(false);
+  const [focusProvider, setFocusProvider] = useState(provider);
   const providerFlags = useAppStore((s) => s.providerFlags);
   const providerVersions = useAppStore((s) => s.providerVersions);
-  const selected = PROVIDERS.find((p) => p.id === value) ?? PROVIDERS[0];
+  const modelsByAgent = useAppStore((s) => s.modelsByAgent);
+
+  const selected = PROVIDERS.find((p) => p.id === provider) ?? PROVIDERS[0];
   const enabled = PROVIDERS.filter((p) => providerFlags[p.id] !== false);
+  const focused = PROVIDERS.find((p) => p.id === focusProvider) ?? selected;
+  const focusedModels = modelsByAgent[focused.id] ?? [];
+  const currentModel = useMemo(() => {
+    const list = modelsByAgent[provider] ?? [];
+    return list.find((m) => m.id === model);
+  }, [model, modelsByAgent, provider]);
+
+  useEffect(() => {
+    if (open) setFocusProvider(provider);
+  }, [open, provider]);
+
+  function pickModel(id: string | undefined) {
+    onChange(focused.id, id);
+    setOpen(false);
+  }
 
   return (
-    <div style={{ position: "relative" }}>
-      <Chip bordered onClick={() => setOpen((v) => !v)}>
+    <div className="model-picker">
+      <Chip
+        bordered
+        disabled={locked}
+        onClick={() => {
+          if (!locked) setOpen((v) => !v);
+        }}
+        tip={locked ? selected.label : "Agent and model"}
+        className="model-chip"
+      >
         <ProviderIcon
           slug={selected.id}
           short={selected.short}
           hue={selected.hue}
           size={15}
         />
-        <span style={{ fontWeight: 500 }}>{selected.label}</span>
-        <Icon name="chevD" size={9} />
+        <span className="model-chip-agent">{selected.label}</span>
+        <span className="model-chip-model">
+          {currentModel?.name ?? "Default model"}
+        </span>
+        {!locked && <Icon name="chevD" size={9} />}
       </Chip>
 
       {open && (
         <>
           <Scrim onClose={() => setOpen(false)} />
-          <div className="dd" style={{ bottom: "calc(100% + 6px)", left: 0 }}>
-            <div className="dd-sect">Coding agents</div>
-            {enabled.map((p) => {
-              const wired = hasAdapter(p.id);
-              return (
-                <div
-                  key={p.id}
-                  className={`dd-item ${p.id === value ? "active" : ""} ${wired ? "" : "is-disabled"}`}
-                  aria-disabled={!wired}
-                  onClick={
-                    wired
-                      ? () => {
-                          onChange(p.id);
-                          setOpen(false);
-                        }
-                      : undefined
-                  }
+          <div className="dd model-dd" style={{ bottom: "calc(100% + 6px)", left: 0 }}>
+            <div className="model-dd-head">
+              <span>Agent</span>
+              <span>Model</span>
+            </div>
+            <div className="model-dd-grid">
+              <div className="model-agent-list">
+                {enabled.map((p) => {
+                  const wired = hasAdapter(p.id);
+                  return (
+                    <button
+                      key={p.id}
+                      type="button"
+                      className={`model-agent ${p.id === focusProvider ? "active" : ""}`}
+                      disabled={!wired}
+                      onClick={() => wired && setFocusProvider(p.id)}
+                    >
+                      <ProviderIcon slug={p.id} short={p.short} hue={p.hue} size={18} />
+                      <span className="model-agent-text">
+                        <span>{p.label}</span>
+                        <span>{providerVersions[p.id] ?? p.version}</span>
+                      </span>
+                      {p.id === provider && <Icon name="check" size={12} />}
+                    </button>
+                  );
+                })}
+              </div>
+
+              <div className="model-list">
+                <button
+                  type="button"
+                  className={`model-option ${focused.id === provider && !model ? "active" : ""}`}
+                  onClick={() => pickModel(undefined)}
                 >
-                  <ProviderIcon slug={p.id} short={p.short} hue={p.hue} size={18} />
-                  <span className="di-l">{p.label}</span>
-                  {wired ? (
-                    <span className="di-m">{providerVersions[p.id] ?? p.version}</span>
-                  ) : (
-                    <span className="set-badge soon">Coming soon</span>
-                  )}
-                </div>
-              );
-            })}
+                  <span className="model-mark">
+                    {focused.id === provider && !model && <Icon name="check" size={12} />}
+                  </span>
+                  <span className="model-option-main">
+                    <span>Default model</span>
+                    <span>Use {focused.label}'s configured default</span>
+                  </span>
+                </button>
+
+                {focusedModels.length === 0 ? (
+                  <div className="model-empty">
+                    Model catalog unavailable for {focused.label}.
+                  </div>
+                ) : (
+                  focusedModels.map((m) => {
+                    const active = focused.id === provider && m.id === model;
+                    return (
+                      <button
+                        key={m.id}
+                        type="button"
+                        className={`model-option ${active ? "active" : ""}`}
+                        onClick={() => pickModel(m.id)}
+                      >
+                        <span className="model-mark">
+                          {active && <Icon name="check" size={12} />}
+                        </span>
+                        <span className="model-option-main">
+                          <span>{m.name}</span>
+                          <span>{m.id}</span>
+                        </span>
+                        <span className="model-option-meta">
+                          <span>{modelFamily(m.name)}</span>
+                          <span>{formatContext(m.contextWindow)}</span>
+                          {m.reasoning && <span>reasoning</span>}
+                        </span>
+                      </button>
+                    );
+                  })
+                )}
+              </div>
+            </div>
+            {currentModel && (
+              <div className="model-dd-foot">
+                {selected.label} · {currentModel.name} · {formatContext(currentModel.contextWindow)}
+              </div>
+            )}
           </div>
         </>
       )}

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -24,6 +24,8 @@ import { useCommandSource } from "./autocomplete/sources/commands";
 interface Props {
   /** Initial provider id — defaults to claude. */
   defaultProvider?: string;
+  /** Initial model id for new-agent drafts. Undefined means provider default. */
+  defaultModel?: string;
   /** When set, render a branch picker chip showing the current base branch. */
   baseBranch?: string;
   /** Repo path used to fetch available branches for the picker. */
@@ -39,6 +41,7 @@ interface Props {
   onSend: (payload: {
     text: string;
     provider: string;
+    model: string | undefined;
     /** Raw effort value for the selected provider, or undefined when the
      *  provider has no thinking levels (e.g. Cursor). */
     thinking: string | undefined;
@@ -50,6 +53,8 @@ interface Props {
    *  `action` identifier comes from the `SlashCommand` entry. The text
    *  is NOT sent to the agent; the parent decides what to do. */
   onLocalCommand?: (action: string) => void;
+  /** Fired when a new-agent draft changes its provider/model selection. */
+  onChangeSelection?: (provider: string, model?: string) => void;
   /** Supplies candidate worktree-relative file paths for the "@" mention
    *  autocomplete. Called each time a mention opens, so the list stays fresh
    *  as the agent edits files. Omit it (e.g. new sessions with no worktree
@@ -97,6 +102,7 @@ function resolveThinking(providerId: string): string | undefined {
 
 export function Composer({
   defaultProvider = DEFAULT_PROVIDER_ID,
+  defaultModel,
   baseBranch,
   repoPath,
   onChangeBase,
@@ -107,6 +113,7 @@ export function Composer({
   onSend,
   onStop,
   onLocalCommand,
+  onChangeSelection,
   mentionSource,
   listDir,
   listPrs,
@@ -124,11 +131,12 @@ export function Composer({
   // When the model is unknown (a new session before the first turn, or one the
   // catalog doesn't list) we keep the picker — better to show a no-op control
   // than to wrongly hide a real one.
-  const activeMeta = lookupModel(modelCatalog, activeModel);
-  const modelSupportsThinking = activeMeta ? activeMeta.reasoning : true;
-
   const [text, setText] = useState("");
   const [provider, setProvider] = useState(defaultProvider);
+  const [model, setModel] = useState<string | undefined>(defaultModel);
+  const activeMeta = lookupModel(modelCatalog, existingSession ? activeModel : model);
+  const modelSupportsThinking = activeMeta ? activeMeta.reasoning : true;
+
   const [attachments, setAttachments] = useState<string[]>([]);
 
   const detail = PROVIDER_DETAIL[provider as keyof typeof PROVIDER_DETAIL];
@@ -226,7 +234,7 @@ export function Composer({
       return;
     }
     if ((!trimmed && attachments.length === 0) || disabled) return;
-    onSend({ text: trimmed, provider, thinking: thinkingValue, attachments });
+    onSend({ text: trimmed, provider, model, thinking: thinkingValue, attachments });
     setText("");
     setAttachments([]);
     if (ta.current) ta.current.style.height = "auto";
@@ -288,7 +296,16 @@ export function Composer({
         }}
       />
       <div className="composer-foot">
-        <ModelPicker value={provider} onChange={setProvider} />
+        <ModelPicker
+          provider={provider}
+          model={model}
+          locked={existingSession}
+          onChange={(nextProvider, nextModel) => {
+            setProvider(nextProvider);
+            setModel(nextModel);
+            onChangeSelection?.(nextProvider, nextModel);
+          }}
+        />
         {existingSession && activeModel && (
           <Chip tip={`Model in use · ${activeModel}`}>
             <span style={{ color: "var(--fg-2)" }}>

--- a/src/components/ProviderIcon.tsx
+++ b/src/components/ProviderIcon.tsx
@@ -70,9 +70,13 @@ export function ProviderIcon({ slug, short, hue, size = 30 }: ProviderIconProps)
     };
   }, [slug]);
 
+  const cls = ["chip-mono", svg && !failed ? "has-brand-icon" : ""]
+    .filter(Boolean)
+    .join(" ");
+
   return (
     <span
-      className="chip-mono"
+      className={cls}
       style={{
         width: size,
         height: size,

--- a/src/components/Workspace/EmptyWorkspace.tsx
+++ b/src/components/Workspace/EmptyWorkspace.tsx
@@ -81,12 +81,16 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
           <Composer
             autoFocus
             defaultProvider={draft.provider}
+            defaultModel={draft.model}
             baseBranch={draft.base}
             repoPath={draft.repoPath}
             onChangeBase={(branch) => updateDraft(draft.id, { base: branch })}
+            onChangeSelection={(provider, model) =>
+              updateDraft(draft.id, { provider, model })
+            }
             placeholder="Describe the task for the agent. ↵ to spawn."
-            onSend={({ text, provider, attachments, thinking }) =>
-              spawnFromDraft(draft.id, text, provider, attachments, thinking)
+            onSend={({ text, provider, model, attachments, thinking }) =>
+              spawnFromDraft(draft.id, text, provider, model, attachments, thinking)
             }
           />
           <div className="empty-meta">

--- a/src/data/modelCatalog/build.ts
+++ b/src/data/modelCatalog/build.ts
@@ -12,14 +12,353 @@ import type { AgentModels, DiscoveredModel, ModelMeta, UnifiedCatalog } from "./
 import type { ModelsDevIndex } from "./modelsDev";
 import { lookupModel } from "./normalize";
 
+function releaseRank(meta: ModelMeta): number {
+  if (!meta.releaseDate) return 0;
+  const time = Date.parse(meta.releaseDate);
+  return Number.isFinite(time) ? time : 0;
+}
+
+function sortByReleaseDateDesc(models: ModelMeta[]): ModelMeta[] {
+  return models
+    .map((meta, index) => ({ meta, index }))
+    .sort((a, b) => {
+      const byDate = releaseRank(b.meta) - releaseRank(a.meta);
+      return byDate || a.index - b.index;
+    })
+    .map(({ meta }) => meta);
+}
+
+function cleanModelName(name: string): string {
+  return name.replace(/(?:\s*\((?:default|latest)\))*\s*$/gi, "").trim();
+}
+
+function displayModel(meta: ModelMeta): ModelMeta {
+  const name = cleanModelName(meta.name);
+  return name === meta.name ? meta : { ...meta, name };
+}
+
+function strippedCursorModelIds(id: string): string[] {
+  const out: string[] = [];
+  const add = (v: string) => {
+    if (v && !out.includes(v)) out.push(v);
+  };
+  add(id);
+
+  let stripped = id;
+  let changed = true;
+  while (changed) {
+    const next = stripped
+      .replace(/-fast$/, "")
+      .replace(/-thinking$/, "")
+      .replace(/-thinking-(low|medium|high|xhigh|max)$/, "")
+      .replace(/-(none|low|medium|high|xhigh|max|extra-high)$/, "");
+    changed = next !== stripped;
+    stripped = next;
+    add(stripped);
+  }
+
+  const claude = stripped.match(
+    /^claude-(?:(opus|sonnet|haiku)-(\d)-(\d)|(\d)\.(\d)-(opus|sonnet|haiku))/,
+  );
+  if (claude) {
+    const family = claude[1] ?? claude[6];
+    const major = claude[2] ?? claude[4];
+    const minor = claude[3] ?? claude[5];
+    add(`claude-${family}-${major}-${minor}`);
+  }
+
+  return out;
+}
+
+function lookupEnrichedModel(index: ModelsDevIndex, id: string): ModelMeta | undefined {
+  for (const candidate of strippedCursorModelIds(id)) {
+    const meta = lookupModel(index.byId, candidate);
+    if (meta) return meta;
+  }
+  return undefined;
+}
+
+function claudeFamily(meta: ModelMeta): "opus" | "sonnet" | "haiku" | null {
+  const haystack = `${meta.id} ${meta.name}`.toLowerCase();
+  if (haystack.includes("opus")) return "opus";
+  if (haystack.includes("sonnet")) return "sonnet";
+  if (haystack.includes("haiku")) return "haiku";
+  return null;
+}
+
+function claudeFamilyRank(meta: ModelMeta): number {
+  const family = claudeFamily(meta);
+  if (family === "opus") return 0;
+  if (family === "sonnet") return 1;
+  if (family === "haiku") return 2;
+  return 3;
+}
+
+function claudeMajor(meta: ModelMeta): number {
+  const m = `${meta.id} ${meta.name}`.match(/(?:claude[ -])?(?:opus|sonnet|haiku)[ -](\d+)/i);
+  return m ? Number(m[1]) : 0;
+}
+
+function claudeDedupeKey(meta: ModelMeta): string {
+  return meta.name
+    .replace(/\s*\(latest\)\s*/gi, "")
+    .trim()
+    .toLowerCase();
+}
+
+function latestAliasScore(meta: ModelMeta): number {
+  if (/\(latest\)/i.test(meta.name)) return 2;
+  if (!/-\d{8}$/.test(meta.id)) return 1;
+  return 0;
+}
+
+function dedupeClaudeReleases(models: ModelMeta[]): ModelMeta[] {
+  const byKey = new Map<string, ModelMeta>();
+  for (const meta of models) {
+    const key = claudeDedupeKey(meta);
+    const prev = byKey.get(key);
+    if (
+      !prev ||
+      latestAliasScore(meta) > latestAliasScore(prev) ||
+      (latestAliasScore(meta) === latestAliasScore(prev) && releaseRank(meta) > releaseRank(prev))
+    ) {
+      byKey.set(key, meta);
+    }
+  }
+  return [...byKey.values()];
+}
+
+function curateClaudeModels(models: ModelMeta[]): ModelMeta[] {
+  const caps = { opus: 3, sonnet: 2, haiku: 1 };
+  const counts = { opus: 0, sonnet: 0, haiku: 0 };
+
+  const selected = dedupeClaudeReleases(models)
+    .filter((meta) => {
+      const family = claudeFamily(meta);
+      return family !== null && claudeMajor(meta) >= 4;
+    })
+    .filter((meta) => {
+      const family = claudeFamily(meta);
+      if (!family) return false;
+      if (counts[family] >= caps[family]) return false;
+      counts[family] += 1;
+      return true;
+    });
+
+  return selected.sort((a, b) => {
+    const byFamily = claudeFamilyRank(a) - claudeFamilyRank(b);
+    return byFamily || releaseRank(b) - releaseRank(a);
+  });
+}
+
+function geminiVersion(meta: ModelMeta): string | null {
+  const m = `${meta.id} ${meta.name}`.toLowerCase().match(/gemini[-\s](\d+(?:\.\d+)?)/);
+  return m?.[1] ?? null;
+}
+
+function geminiTier(meta: ModelMeta): "pro" | "flash" | null {
+  const text = `${meta.id} ${meta.name}`.toLowerCase();
+  if (/\bpro\b/.test(text)) return "pro";
+  if (/\bflash\b/.test(text)) return "flash";
+  return null;
+}
+
+function isGeminiFlagship(meta: ModelMeta): boolean {
+  const text = `${meta.id} ${meta.name}`.toLowerCase();
+  return (
+    text.includes("gemini") &&
+    geminiTier(meta) !== null &&
+    !text.includes("nano banana") &&
+    !text.includes("banana") &&
+    !text.includes("lite") &&
+    !text.includes("tts") &&
+    !text.includes("embedding") &&
+    !text.includes("image") &&
+    !text.includes("imagen") &&
+    !text.includes("veo")
+  );
+}
+
+function geminiVariantScore(meta: ModelMeta): number {
+  const text = `${meta.id} ${meta.name}`.toLowerCase();
+  let score = 0;
+  if (/\bpro\b/.test(text)) score += 20;
+  if (!text.includes("preview")) score += 8;
+  if (!text.includes("experimental") && !text.includes("exp")) score += 4;
+  return score;
+}
+
+function curateAntigravityModels(models: ModelMeta[]): ModelMeta[] {
+  const byVersion = new Map<string, ModelMeta>();
+
+  for (const meta of models) {
+    if (!isGeminiFlagship(meta)) continue;
+    const version = geminiVersion(meta);
+    const tier = geminiTier(meta);
+    if (!version || !tier) continue;
+    const key = `${version}:${tier}`;
+    const prev = byVersion.get(key);
+    if (
+      !prev ||
+      releaseRank(meta) > releaseRank(prev) ||
+      (releaseRank(meta) === releaseRank(prev) && geminiVariantScore(meta) > geminiVariantScore(prev))
+    ) {
+      byVersion.set(key, meta);
+    }
+  }
+
+  return sortByReleaseDateDesc([...byVersion.values()]).slice(0, 4);
+}
+
+type CursorProvider = "anthropic" | "openai" | "google" | "xai" | "kimi";
+
+function cursorComposerVersion(meta: ModelMeta): number {
+  const m = meta.id.match(/^composer-(\d+(?:\.\d+)?)/);
+  return m ? Number(m[1]) : 0;
+}
+
+function cursorProvider(meta: ModelMeta): CursorProvider | null {
+  const text = `${meta.id} ${meta.name}`.toLowerCase();
+  if (text.includes("claude") || /\b(opus|sonnet|haiku|fable)\b/.test(text)) return "anthropic";
+  if (text.includes("gpt") || text.includes("codex") || /^o\d/.test(meta.id)) return "openai";
+  if (text.includes("gemini")) return "google";
+  if (text.includes("grok")) return "xai";
+  if (text.includes("kimi")) return "kimi";
+  return null;
+}
+
+function cursorProviderRank(provider: CursorProvider): number {
+  if (provider === "anthropic") return 0;
+  if (provider === "openai") return 1;
+  if (provider === "google") return 2;
+  if (provider === "xai") return 3;
+  return 4;
+}
+
+function cursorBaseKey(meta: ModelMeta): string {
+  return meta.name
+    .replace(/\s*\([^)]*\)\s*/g, " ")
+    .replace(/\b1m\b/gi, " ")
+    .replace(/\bno zdr\b/gi, " ")
+    .replace(/\b(low|medium|high|extra high|max|none|fast|thinking|default)\b/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function cursorVariantScore(meta: ModelMeta): number {
+  const text = `${meta.id} ${meta.name}`.toLowerCase();
+  const hasEffortSuffix = /-(none|low|medium|high|xhigh|max|extra-high)(?:-|$)/.test(meta.id);
+  const nameHasVariant = /\b(low|medium|high|extra high|max|none|fast|thinking)\b/i.test(meta.name);
+  let score = 0;
+  if (/\(default\)/i.test(meta.name)) score += 30;
+  if (!nameHasVariant) score += 20;
+  if (!hasEffortSuffix) score += 10;
+  if (/-medium(?:-|$)/.test(meta.id)) score += 6;
+  if (!text.includes("thinking")) score += 8;
+  if (!text.includes("fast")) score += 4;
+  return score;
+}
+
+function cursorBaseRepresentatives(models: ModelMeta[]): ModelMeta[] {
+  const byProvider = new Map<
+    CursorProvider,
+    Map<string, { firstIndex: number; provider: CursorProvider; best: ModelMeta }>
+  >();
+  models.forEach((meta, index) => {
+    const provider = cursorProvider(meta);
+    if (!provider) return;
+    const key = cursorBaseKey(meta);
+    if (!key) return;
+    let providerMap = byProvider.get(provider);
+    if (!providerMap) {
+      providerMap = new Map();
+      byProvider.set(provider, providerMap);
+    }
+    const prev = providerMap.get(key);
+    if (!prev) {
+      providerMap.set(key, { firstIndex: index, provider, best: meta });
+      return;
+    }
+    if (cursorVariantScore(meta) > cursorVariantScore(prev.best)) {
+      providerMap.set(key, { ...prev, best: meta });
+    }
+  });
+
+  const caps: Record<CursorProvider, number> = {
+    anthropic: 3,
+    openai: 3,
+    google: 3,
+    xai: 2,
+    kimi: 2,
+  };
+  const counts: Record<CursorProvider, number> = {
+    anthropic: 0,
+    openai: 0,
+    google: 0,
+    xai: 0,
+    kimi: 0,
+  };
+
+  const selected = [...byProvider.values()]
+    .flatMap((providerMap) => [...providerMap.values()])
+    .sort((a, b) => a.firstIndex - b.firstIndex)
+    .filter((entry) => {
+      if (counts[entry.provider] >= caps[entry.provider]) return false;
+      counts[entry.provider] += 1;
+      return true;
+    });
+
+  return selected
+    .sort((a, b) => {
+      const byProvider = cursorProviderRank(a.provider) - cursorProviderRank(b.provider);
+      if (byProvider) return byProvider;
+      if (a.provider === "anthropic" && b.provider === "anthropic") {
+        const byFamily = claudeFamilyRank(a.best) - claudeFamilyRank(b.best);
+        if (byFamily) return byFamily;
+        const byDate = releaseRank(b.best) - releaseRank(a.best);
+        return byDate || a.firstIndex - b.firstIndex;
+      }
+      const byDate = releaseRank(b.best) - releaseRank(a.best);
+      return byDate || a.firstIndex - b.firstIndex;
+    })
+    .map((entry) => entry.best);
+}
+
+function curateCursorModels(models: ModelMeta[]): ModelMeta[] {
+  const composerVersions = [
+    ...new Set(
+      models
+        .filter((meta) => meta.id.startsWith("composer-"))
+        .map((meta) => cursorComposerVersion(meta))
+        .filter((version) => version > 0),
+    ),
+  ]
+    .sort((a, b) => b - a)
+    .slice(0, 3);
+  const composer = models
+    .filter((meta) => composerVersions.includes(cursorComposerVersion(meta)))
+    .sort((a, b) => {
+      const byVersion = cursorComposerVersion(b) - cursorComposerVersion(a);
+      if (byVersion) return byVersion;
+      const byDefault = Number(/\(default\)/i.test(b.name)) - Number(/\(default\)/i.test(a.name));
+      if (byDefault) return byDefault;
+      return Number(b.id.includes("fast")) - Number(a.id.includes("fast"));
+    });
+
+  return [...composer, ...cursorBaseRepresentatives(models.filter((meta) => !meta.id.startsWith("composer-")))];
+}
+
 /** Resolve a discovered model's metadata: models.dev wins, the CLI fills gaps.
  *  `index.byId` is a SlimCatalog, so the shared normalizer does the matching. */
 function metaFor(d: DiscoveredModel, index: ModelsDevIndex): ModelMeta {
-  const dev = lookupModel(index.byId, d.id);
+  const dev = lookupEnrichedModel(index, d.id);
   return {
+    id: d.id,
     name: dev?.name ?? d.name ?? d.id,
     contextWindow: dev?.contextWindow || d.contextWindow || 0,
     reasoning: dev?.reasoning ?? d.reasoning ?? false,
+    ...(dev?.releaseDate ? { releaseDate: dev.releaseDate } : {}),
   };
 }
 
@@ -35,10 +374,25 @@ export function buildCatalog(agents: AgentModels[], index: ModelsDevIndex): Unif
     const list: ModelMeta[] = [];
     for (const [id, meta] of entries) {
       if (!meta) continue;
-      byId[id] = byId[id] ?? meta; // first writer wins; agents share metadata
-      list.push(meta);
+      const entry = meta.id === id ? meta : { ...meta, id };
+      const displayEntry = displayModel(entry);
+      byId[id] = byId[id] ?? displayEntry; // first writer wins; agents share metadata
+      if (id.includes("/")) {
+        const bare = id.split("/").pop();
+        if (bare) byId[bare] = byId[bare] ?? { ...displayEntry, id: bare };
+      }
+      list.push(entry);
     }
-    byAgent[agent] = list;
+    const sorted = sortByReleaseDateDesc(list);
+    const agentModels =
+      agent === "claude"
+        ? curateClaudeModels(sorted)
+        : agent === "antigravity"
+          ? curateAntigravityModels(sorted)
+        : agent === "cursor"
+          ? curateCursorModels(sorted)
+          : sorted;
+    byAgent[agent] = agentModels.map(displayModel);
   }
 
   return { byId, byAgent };

--- a/src/data/modelCatalog/build.ts
+++ b/src/data/modelCatalog/build.ts
@@ -1,7 +1,7 @@
 // Assemble the unified catalog from agent discovery + models.dev enrichment.
 //
 // For each agent:
-//   - providerHint set (claude/antigravity) → expand that models.dev provider.
+//   - providerHint set (claude) → expand that models.dev provider.
 //   - otherwise → use the CLI-reported ids, enriching each with models.dev
 //     metadata, falling back to whatever the CLI reported for ids models.dev
 //     doesn't know (e.g. OpenCode's free "zen" models).
@@ -26,6 +26,54 @@ function sortByReleaseDateDesc(models: ModelMeta[]): ModelMeta[] {
       return byDate || a.index - b.index;
     })
     .map(({ meta }) => meta);
+}
+
+// Shared curation primitives. Every agent's model list is curated by the same
+// shape — collapse near-duplicate releases to one representative, then keep only
+// the newest few per class — so both steps live here and the per-agent curators
+// supply the classifier/scorer/caps that genuinely differ between providers.
+
+/** Collapse models sharing a key down to a single representative, keeping the
+ *  one `prefer` ranks highest. A null key drops the model. The survivor keeps
+ *  its group's first-seen position, so a release-desc input stays release-desc. */
+export function dedupeBest(
+  models: ModelMeta[],
+  keyFn: (meta: ModelMeta) => string | null,
+  prefer: (candidate: ModelMeta, current: ModelMeta) => boolean,
+): ModelMeta[] {
+  const byKey = new Map<string, ModelMeta>();
+  const order: string[] = [];
+  for (const meta of models) {
+    const key = keyFn(meta);
+    if (key === null) continue;
+    const current = byKey.get(key);
+    if (!current) {
+      byKey.set(key, meta);
+      order.push(key);
+    } else if (prefer(meta, current)) {
+      byKey.set(key, meta);
+    }
+  }
+  return order.map((key) => byKey.get(key) as ModelMeta);
+}
+
+/** Keep at most `caps[group]` models per group, in the order given. An
+ *  unclassifiable model (null group) is dropped. Feed a release-desc list to
+ *  keep the newest N per group. */
+export function capPerGroup<G extends string>(
+  models: ModelMeta[],
+  groupFn: (meta: ModelMeta) => G | null,
+  caps: Record<G, number>,
+): ModelMeta[] {
+  const counts = {} as Record<G, number>;
+  return models.filter((meta) => {
+    const group = groupFn(meta);
+    if (group === null) return false;
+    const used = counts[group] ?? 0;
+    if (used >= caps[group]) return false;
+    counts[group] = used + 1;
+    return true;
+  });
 }
 
 function cleanModelName(name: string): string {
@@ -112,102 +160,33 @@ function latestAliasScore(meta: ModelMeta): number {
   return 0;
 }
 
-function dedupeClaudeReleases(models: ModelMeta[]): ModelMeta[] {
-  const byKey = new Map<string, ModelMeta>();
-  for (const meta of models) {
-    const key = claudeDedupeKey(meta);
-    const prev = byKey.get(key);
-    if (
-      !prev ||
-      latestAliasScore(meta) > latestAliasScore(prev) ||
-      (latestAliasScore(meta) === latestAliasScore(prev) && releaseRank(meta) > releaseRank(prev))
-    ) {
-      byKey.set(key, meta);
-    }
-  }
-  return [...byKey.values()];
+/** Prefer the `(latest)` alias over a dated id, then the newer release. */
+function preferClaudeRelease(candidate: ModelMeta, current: ModelMeta): boolean {
+  const byAlias = latestAliasScore(candidate) - latestAliasScore(current);
+  return byAlias > 0 || (byAlias === 0 && releaseRank(candidate) > releaseRank(current));
 }
 
 function curateClaudeModels(models: ModelMeta[]): ModelMeta[] {
   const caps = { opus: 3, sonnet: 2, haiku: 1 };
-  const counts = { opus: 0, sonnet: 0, haiku: 0 };
 
-  const selected = dedupeClaudeReleases(models)
-    .filter((meta) => {
-      const family = claudeFamily(meta);
-      return family !== null && claudeMajor(meta) >= 4;
-    })
-    .filter((meta) => {
-      const family = claudeFamily(meta);
-      if (!family) return false;
-      if (counts[family] >= caps[family]) return false;
-      counts[family] += 1;
-      return true;
-    });
+  const deduped = dedupeBest(models, claudeDedupeKey, preferClaudeRelease).filter(
+    (meta) => claudeFamily(meta) !== null && claudeMajor(meta) >= 4,
+  );
 
-  return selected.sort((a, b) => {
+  return capPerGroup(deduped, claudeFamily, caps).sort((a, b) => {
     const byFamily = claudeFamilyRank(a) - claudeFamilyRank(b);
     return byFamily || releaseRank(b) - releaseRank(a);
   });
 }
 
-function geminiVersion(meta: ModelMeta): string | null {
-  const m = `${meta.id} ${meta.name}`.toLowerCase().match(/gemini[-\s](\d+(?:\.\d+)?)/);
-  return m?.[1] ?? null;
-}
-
-function geminiTier(meta: ModelMeta): "pro" | "flash" | null {
-  const text = `${meta.id} ${meta.name}`.toLowerCase();
-  if (/\bpro\b/.test(text)) return "pro";
-  if (/\bflash\b/.test(text)) return "flash";
-  return null;
-}
-
-function isGeminiFlagship(meta: ModelMeta): boolean {
-  const text = `${meta.id} ${meta.name}`.toLowerCase();
-  return (
-    text.includes("gemini") &&
-    geminiTier(meta) !== null &&
-    !text.includes("nano banana") &&
-    !text.includes("banana") &&
-    !text.includes("lite") &&
-    !text.includes("tts") &&
-    !text.includes("embedding") &&
-    !text.includes("image") &&
-    !text.includes("imagen") &&
-    !text.includes("veo")
-  );
-}
-
-function geminiVariantScore(meta: ModelMeta): number {
-  const text = `${meta.id} ${meta.name}`.toLowerCase();
-  let score = 0;
-  if (/\bpro\b/.test(text)) score += 20;
-  if (!text.includes("preview")) score += 8;
-  if (!text.includes("experimental") && !text.includes("exp")) score += 4;
-  return score;
-}
-
-function curateAntigravityModels(models: ModelMeta[]): ModelMeta[] {
-  const byVersion = new Map<string, ModelMeta>();
-
-  for (const meta of models) {
-    if (!isGeminiFlagship(meta)) continue;
-    const version = geminiVersion(meta);
-    const tier = geminiTier(meta);
-    if (!version || !tier) continue;
-    const key = `${version}:${tier}`;
-    const prev = byVersion.get(key);
-    if (
-      !prev ||
-      releaseRank(meta) > releaseRank(prev) ||
-      (releaseRank(meta) === releaseRank(prev) && geminiVariantScore(meta) > geminiVariantScore(prev))
-    ) {
-      byVersion.set(key, meta);
-    }
-  }
-
-  return sortByReleaseDateDesc([...byVersion.values()]).slice(0, 4);
+// Pi is a multi-provider router whose list is dominated by the full Claude
+// lineage (v3 → v4, dated + (latest) aliases). Reuse the Claude family
+// grouping for its Anthropic models and keep any other providers after them,
+// already release-desc ordered by buildCatalog.
+function curatePiModels(models: ModelMeta[]): ModelMeta[] {
+  const claude = models.filter((meta) => claudeFamily(meta) !== null);
+  const others = models.filter((meta) => claudeFamily(meta) === null);
+  return [...curateClaudeModels(claude), ...others];
 }
 
 type CursorProvider = "anthropic" | "openai" | "google" | "xai" | "kimi";
@@ -260,69 +239,41 @@ function cursorVariantScore(meta: ModelMeta): number {
   return score;
 }
 
+const CURSOR_CAPS: Record<CursorProvider, number> = {
+  anthropic: 3,
+  openai: 3,
+  google: 3,
+  xai: 2,
+  kimi: 2,
+};
+
+/** Group key that keeps providers separate so the same base name under two
+ *  providers can't collide. Null when the model isn't a known provider/base. */
+function cursorProviderBaseKey(meta: ModelMeta): string | null {
+  const provider = cursorProvider(meta);
+  const base = cursorBaseKey(meta);
+  return provider && base ? `${provider}::${base}` : null;
+}
+
 function cursorBaseRepresentatives(models: ModelMeta[]): ModelMeta[] {
-  const byProvider = new Map<
-    CursorProvider,
-    Map<string, { firstIndex: number; provider: CursorProvider; best: ModelMeta }>
-  >();
-  models.forEach((meta, index) => {
-    const provider = cursorProvider(meta);
-    if (!provider) return;
-    const key = cursorBaseKey(meta);
-    if (!key) return;
-    let providerMap = byProvider.get(provider);
-    if (!providerMap) {
-      providerMap = new Map();
-      byProvider.set(provider, providerMap);
+  const reps = dedupeBest(
+    models,
+    cursorProviderBaseKey,
+    (candidate, current) => cursorVariantScore(candidate) > cursorVariantScore(current),
+  );
+
+  // `reps` is in first-seen (release-desc) order, so capPerGroup keeps the
+  // newest per provider and the stable sort below preserves that order on ties.
+  return capPerGroup(reps, cursorProvider, CURSOR_CAPS).sort((a, b) => {
+    const byProvider = cursorProviderRank(cursorProvider(a) as CursorProvider) -
+      cursorProviderRank(cursorProvider(b) as CursorProvider);
+    if (byProvider) return byProvider;
+    if (cursorProvider(a) === "anthropic") {
+      const byFamily = claudeFamilyRank(a) - claudeFamilyRank(b);
+      if (byFamily) return byFamily;
     }
-    const prev = providerMap.get(key);
-    if (!prev) {
-      providerMap.set(key, { firstIndex: index, provider, best: meta });
-      return;
-    }
-    if (cursorVariantScore(meta) > cursorVariantScore(prev.best)) {
-      providerMap.set(key, { ...prev, best: meta });
-    }
+    return releaseRank(b) - releaseRank(a);
   });
-
-  const caps: Record<CursorProvider, number> = {
-    anthropic: 3,
-    openai: 3,
-    google: 3,
-    xai: 2,
-    kimi: 2,
-  };
-  const counts: Record<CursorProvider, number> = {
-    anthropic: 0,
-    openai: 0,
-    google: 0,
-    xai: 0,
-    kimi: 0,
-  };
-
-  const selected = [...byProvider.values()]
-    .flatMap((providerMap) => [...providerMap.values()])
-    .sort((a, b) => a.firstIndex - b.firstIndex)
-    .filter((entry) => {
-      if (counts[entry.provider] >= caps[entry.provider]) return false;
-      counts[entry.provider] += 1;
-      return true;
-    });
-
-  return selected
-    .sort((a, b) => {
-      const byProvider = cursorProviderRank(a.provider) - cursorProviderRank(b.provider);
-      if (byProvider) return byProvider;
-      if (a.provider === "anthropic" && b.provider === "anthropic") {
-        const byFamily = claudeFamilyRank(a.best) - claudeFamilyRank(b.best);
-        if (byFamily) return byFamily;
-        const byDate = releaseRank(b.best) - releaseRank(a.best);
-        return byDate || a.firstIndex - b.firstIndex;
-      }
-      const byDate = releaseRank(b.best) - releaseRank(a.best);
-      return byDate || a.firstIndex - b.firstIndex;
-    })
-    .map((entry) => entry.best);
 }
 
 function curateCursorModels(models: ModelMeta[]): ModelMeta[] {
@@ -387,8 +338,8 @@ export function buildCatalog(agents: AgentModels[], index: ModelsDevIndex): Unif
     const agentModels =
       agent === "claude"
         ? curateClaudeModels(sorted)
-        : agent === "antigravity"
-          ? curateAntigravityModels(sorted)
+        : agent === "pi"
+          ? curatePiModels(sorted)
         : agent === "cursor"
           ? curateCursorModels(sorted)
           : sorted;

--- a/src/data/modelCatalog/index.ts
+++ b/src/data/modelCatalog/index.ts
@@ -14,7 +14,7 @@ import { buildCatalog } from "./build";
 export type { ModelMeta, SlimCatalog } from "./types";
 export { lookupModel } from "./normalize";
 
-const CACHE_KEY = "modelCatalog.cache.v2";
+const CACHE_KEY = "modelCatalog.cache.v12";
 const TTL_MS = 24 * 60 * 60 * 1000; // 24h
 
 const EMPTY: UnifiedCatalog = { byId: {}, byAgent: {} };

--- a/src/data/modelCatalog/modelCatalog.test.ts
+++ b/src/data/modelCatalog/modelCatalog.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { indexModelsDev } from "./modelsDev";
-import { buildCatalog } from "./build";
+import { buildCatalog, dedupeBest, capPerGroup } from "./build";
 import { lookupModel, modelIdCandidates } from "./normalize";
-import type { AgentModels, SlimCatalog } from "./types";
+import type { AgentModels, ModelMeta, SlimCatalog } from "./types";
 
 const API = {
   anthropic: {
@@ -114,22 +114,13 @@ describe("buildCatalog", () => {
     expect(cat.byAgent.codex).toHaveLength(1);
   });
 
-  it("curates Antigravity to a short Gemini Pro and Flash flagship list", () => {
-    const agents: AgentModels[] = [{ agent: "antigravity", providerHint: "google", models: [] }];
+  it("offers no selectable models for Antigravity (agy ignores model selection)", () => {
+    // Discovery contributes no hint and no models for antigravity, so the
+    // picker shows it as a fixed-model agent rather than offering Gemini ids
+    // agy can't honor.
+    const agents: AgentModels[] = [{ agent: "antigravity", models: [] }];
     const cat = buildCatalog(agents, idx);
-
-    expect(cat.byAgent.antigravity.map((m) => m.id)).toEqual([
-      "gemini-3.5-pro",
-      "gemini-3.5-flash",
-      "gemini-3.1-pro",
-      "gemini-3.0-flash",
-    ]);
-    expect(cat.byAgent.antigravity.map((m) => m.id)).not.toContain("nano-banana");
-    expect(cat.byAgent.antigravity.map((m) => m.id)).not.toContain("gemini-3-pro-image-preview");
-    expect(cat.byAgent.antigravity.map((m) => m.id)).not.toContain("gemini-3.1-flash-lite");
-    expect(cat.byAgent.antigravity.map((m) => m.id)).not.toContain("gemini-2.5-flash-preview-tts");
-    expect(cat.byAgent.antigravity.map((m) => m.id)).not.toContain("gemini-3.1-pro-preview");
-    expect(cat.byAgent.antigravity.map((m) => m.id)).not.toContain("gemini-1.5-pro");
+    expect(cat.byAgent.antigravity).toEqual([]);
   });
 
   it("orders discovered models by release date descending, unknown dates last", () => {
@@ -244,6 +235,58 @@ describe("buildCatalog", () => {
     ]);
   });
 
+  it("curates Pi like Claude: group by family, newest first, capped per family", () => {
+    const agents: AgentModels[] = [
+      {
+        agent: "pi",
+        models: [
+          { id: "claude-3-5-haiku-20241022" },
+          { id: "claude-3-7-sonnet-20250219" },
+          { id: "claude-3-opus-20240229" },
+          { id: "claude-haiku-4-5" },
+          { id: "claude-haiku-4-5-20251001" },
+          { id: "claude-opus-4-0" },
+          { id: "claude-opus-4-1" },
+          { id: "claude-opus-4-5" },
+          { id: "claude-opus-4-5-20251101" },
+          { id: "claude-opus-4-6" },
+          { id: "claude-opus-4-7" },
+          { id: "claude-opus-4-8" },
+          { id: "claude-sonnet-4-0" },
+          { id: "claude-sonnet-4-5" },
+          { id: "claude-sonnet-4-5-20250929" },
+          { id: "claude-sonnet-4-6" },
+        ],
+      },
+    ];
+    const cat = buildCatalog(agents, idx);
+
+    expect(cat.byAgent.pi.map((m) => m.id)).toEqual([
+      "claude-opus-4-8",
+      "claude-opus-4-7",
+      "claude-opus-4-6",
+      "claude-sonnet-4-6",
+      "claude-sonnet-4-5",
+      "claude-haiku-4-5",
+    ]);
+    expect(cat.byAgent.pi.map((m) => m.id)).not.toContain("claude-3-5-haiku-20241022");
+    expect(cat.byAgent.pi.map((m) => m.id)).not.toContain("claude-3-7-sonnet-20250219");
+    expect(cat.byAgent.pi.map((m) => m.id)).not.toContain("claude-opus-4-1");
+    expect(cat.byAgent.pi.map((m) => m.name).some((name) => name.includes("(latest)"))).toBe(false);
+  });
+
+  it("keeps Pi models from other providers after the Claude families", () => {
+    const agents: AgentModels[] = [
+      {
+        agent: "pi",
+        models: [{ id: "claude-opus-4-8" }, { id: "gpt-5.5" }, { id: "gemini-3.5-pro" }],
+      },
+    ];
+    const cat = buildCatalog(agents, idx);
+
+    expect(cat.byAgent.pi.map((m) => m.id)).toEqual(["claude-opus-4-8", "gemini-3.5-pro", "gpt-5.5"]);
+  });
+
   it("falls back to CLI metadata for ids models.dev doesn't know", () => {
     const agents: AgentModels[] = [
       { agent: "opencode", models: [{ id: "big-pickle", name: "Big Pickle", contextWindow: 32_000 }] },
@@ -279,5 +322,53 @@ describe("lookupModel", () => {
   it("returns undefined for unknown or empty ids", () => {
     expect(lookupModel(catalog, "made-up")).toBeUndefined();
     expect(lookupModel(catalog, undefined)).toBeUndefined();
+  });
+});
+
+const model = (id: string, name = id): ModelMeta => ({ id, name, contextWindow: 0, reasoning: false });
+
+describe("dedupeBest", () => {
+  // Group every model by its leading token: "a-1" and "a-2" share group "a".
+  const byPrefix = (m: ModelMeta) => m.id.split("-")[0];
+  // Higher trailing number wins.
+  const preferHigher = (a: ModelMeta, b: ModelMeta) =>
+    Number(a.id.split("-")[1]) > Number(b.id.split("-")[1]);
+
+  it("keeps the preferred representative at the group's first-seen position", () => {
+    // 'a' first appears at index 0; its best (a-3) must land there, not at a-3's index.
+    const out = dedupeBest([model("a-1"), model("b-1"), model("a-3"), model("a-2")], byPrefix, preferHigher);
+    expect(out.map((m) => m.id)).toEqual(["a-3", "b-1"]);
+  });
+
+  it("keeps the current representative when prefer rejects the candidate", () => {
+    const out = dedupeBest([model("a-3"), model("a-1")], byPrefix, preferHigher);
+    expect(out.map((m) => m.id)).toEqual(["a-3"]);
+  });
+
+  it("drops models whose key is null", () => {
+    const keyFn = (m: ModelMeta) => (m.id.startsWith("keep") ? "k" : null);
+    const out = dedupeBest([model("drop-1"), model("keep-1"), model("drop-2")], keyFn, () => false);
+    expect(out.map((m) => m.id)).toEqual(["keep-1"]);
+  });
+});
+
+describe("capPerGroup", () => {
+  const byPrefix = (m: ModelMeta) => m.id.split("-")[0] as "a" | "b";
+
+  it("keeps at most caps[group] per group, in input order", () => {
+    const models = [model("a-1"), model("a-2"), model("b-1"), model("a-3"), model("b-2")];
+    const out = capPerGroup(models, byPrefix, { a: 2, b: 1 });
+    expect(out.map((m) => m.id)).toEqual(["a-1", "a-2", "b-1"]);
+  });
+
+  it("drops models whose group is null", () => {
+    const keyFn = (m: ModelMeta) => (m.id.startsWith("keep") ? ("k" as const) : null);
+    const out = capPerGroup([model("keep-1"), model("skip-1")], keyFn, { k: 5 });
+    expect(out.map((m) => m.id)).toEqual(["keep-1"]);
+  });
+
+  it("drops every model in a group capped at zero", () => {
+    const out = capPerGroup([model("a-1"), model("b-1")], byPrefix, { a: 0, b: 1 });
+    expect(out.map((m) => m.id)).toEqual(["b-1"]);
   });
 });

--- a/src/data/modelCatalog/modelCatalog.test.ts
+++ b/src/data/modelCatalog/modelCatalog.test.ts
@@ -7,13 +7,57 @@ import type { AgentModels, SlimCatalog } from "./types";
 const API = {
   anthropic: {
     models: {
-      "claude-opus-4-8": { name: "Claude Opus 4.8", reasoning: true, limit: { context: 1_000_000 } },
-      "claude-3-5-haiku-20241022": { name: "Claude 3.5 Haiku", reasoning: false, limit: { context: 200_000 } },
+      "claude-opus-4-8": { name: "Claude Opus 4.8", reasoning: true, release_date: "2026-05-28", limit: { context: 1_000_000 } },
+      "claude-opus-4-7": { name: "Claude Opus 4.7", reasoning: true, release_date: "2026-04-16", limit: { context: 1_000_000 } },
+      "claude-opus-4-6": { name: "Claude Opus 4.6", reasoning: true, release_date: "2026-02-05", limit: { context: 1_000_000 } },
+      "claude-opus-4-5": { name: "Claude Opus 4.5 (latest)", reasoning: true, release_date: "2025-11-24", limit: { context: 200_000 } },
+      "claude-opus-4-5-20251101": { name: "Claude Opus 4.5", reasoning: true, release_date: "2025-11-01", limit: { context: 200_000 } },
+      "claude-sonnet-4-6": { name: "Claude Sonnet 4.6", reasoning: true, release_date: "2026-02-17", limit: { context: 200_000 } },
+      "claude-sonnet-4-5": { name: "Claude Sonnet 4.5 (latest)", reasoning: true, release_date: "2025-09-29", limit: { context: 200_000 } },
+      "claude-sonnet-4-5-20250929": { name: "Claude Sonnet 4.5", reasoning: true, release_date: "2025-09-29", limit: { context: 200_000 } },
+      "claude-haiku-4-5": { name: "Claude Haiku 4.5 (latest)", reasoning: true, release_date: "2025-10-15", limit: { context: 200_000 } },
+      "claude-haiku-4-5-20251001": { name: "Claude Haiku 4.5", reasoning: true, release_date: "2025-10-15", limit: { context: 200_000 } },
+      "claude-3-5-haiku-20241022": { name: "Claude 3.5 Haiku", reasoning: false, release_date: "2024-10-22", limit: { context: 200_000 } },
     },
   },
   openai: {
     models: {
-      "gpt-5.5": { name: "GPT-5.5", reasoning: true, limit: { context: 400_000 } },
+      "gpt-5.3-codex": { name: "Codex 5.3", reasoning: true, release_date: "2026-01-05", limit: { context: 400_000 } },
+      "gpt-5.5": { name: "GPT-5.5", reasoning: true, release_date: "2025-12-11", limit: { context: 400_000 } },
+      "gpt-5.4": { name: "GPT-5.4", reasoning: true, release_date: "2025-11-15", limit: { context: 400_000 } },
+      "gpt-5.2-codex": { name: "Codex 5.2", reasoning: true, release_date: "2025-10-20", limit: { context: 400_000 } },
+    },
+  },
+  google: {
+    models: {
+      "gemini-3.5-pro": { name: "Gemini 3.5 Pro", reasoning: true, release_date: "2026-05-20", limit: { context: 1_000_000 } },
+      "gemini-3.5-flash": { name: "Gemini 3.5 Flash", reasoning: true, release_date: "2026-05-19", limit: { context: 1_000_000 } },
+      "gemini-3.1-pro": { name: "Gemini 3.1 Pro", reasoning: true, release_date: "2025-12-04", limit: { context: 1_000_000 } },
+      "gemini-3.1-pro-preview": { name: "Gemini 3.1 Pro Preview", reasoning: true, release_date: "2025-12-04", limit: { context: 1_000_000 } },
+      "gemini-3.0-pro": { name: "Gemini 3.0 Pro", reasoning: true, release_date: "2025-11-10", limit: { context: 1_000_000 } },
+      "gemini-3.0-flash": { name: "Gemini 3.0 Flash", reasoning: true, release_date: "2025-11-12", limit: { context: 1_000_000 } },
+      "gemini-2.5-flash-preview-tts": { name: "Gemini 2.5 Flash Preview TTS", reasoning: true, release_date: "2025-05-01", limit: { context: 32_000 } },
+      "gemini-2.5-pro": { name: "Gemini 2.5 Pro", reasoning: true, release_date: "2025-06-17", limit: { context: 1_000_000 } },
+      "gemini-2.5-flash": { name: "Gemini 2.5 Flash", reasoning: true, release_date: "2025-06-17", limit: { context: 1_000_000 } },
+      "gemini-2.0-pro": { name: "Gemini 2.0 Pro", reasoning: true, release_date: "2025-02-05", limit: { context: 1_000_000 } },
+      "gemini-1.5-pro": { name: "Gemini 1.5 Pro", reasoning: true, release_date: "2024-05-14", limit: { context: 1_000_000 } },
+      "nano-banana": { name: "Nano Banana", reasoning: false, release_date: "2025-12-20", limit: { context: 32_000 } },
+      "gemini-3-pro-image-preview": { name: "Nano Banana Pro", reasoning: true, release_date: "2025-11-20", limit: { context: 32_000 } },
+      "gemini-3.1-flash-lite": { name: "Gemini 3.1 Flash Lite", reasoning: true, release_date: "2026-05-07", limit: { context: 1_000_000 } },
+    },
+  },
+  xai: {
+    models: {
+      "grok-4.3": { name: "Grok 4.3", reasoning: true, release_date: "2025-12-02", limit: { context: 1_000_000 } },
+      "grok-4.2": { name: "Grok 4.2", reasoning: true, release_date: "2025-11-05", limit: { context: 1_000_000 } },
+      "grok-4.1": { name: "Grok 4.1", reasoning: true, release_date: "2025-09-01", limit: { context: 1_000_000 } },
+    },
+  },
+  kimi: {
+    models: {
+      "kimi-k2.5": { name: "Kimi K2.5", reasoning: true, release_date: "2025-12-01", limit: { context: 256_000 } },
+      "kimi-k2": { name: "Kimi K2", reasoning: true, release_date: "2025-08-15", limit: { context: 256_000 } },
+      "kimi-k1": { name: "Kimi K1", reasoning: false, release_date: "2025-04-10", limit: { context: 128_000 } },
     },
   },
   // A router re-listing a canonical id with a different window.
@@ -27,7 +71,7 @@ const API = {
 describe("indexModelsDev", () => {
   it("indexes metadata by id and ids by provider", () => {
     const idx = indexModelsDev(API as never);
-    expect(idx.byId["gpt-5.5"]).toEqual({ name: "GPT-5.5", contextWindow: 400_000, reasoning: true });
+    expect(idx.byId["gpt-5.5"]).toEqual({ id: "gpt-5.5", name: "GPT-5.5", contextWindow: 400_000, reasoning: true, releaseDate: "2025-12-11" });
     expect(idx.byProvider.anthropic).toContain("claude-opus-4-8");
   });
 
@@ -43,7 +87,19 @@ describe("buildCatalog", () => {
   it("expands a provider hint (claude → all anthropic)", () => {
     const agents: AgentModels[] = [{ agent: "claude", providerHint: "anthropic", models: [] }];
     const cat = buildCatalog(agents, idx);
-    expect(cat.byAgent.claude).toHaveLength(2);
+    expect(cat.byAgent.claude).toHaveLength(6);
+    expect(cat.byAgent.claude.map((m) => m.id)).toEqual([
+      "claude-opus-4-8",
+      "claude-opus-4-7",
+      "claude-opus-4-6",
+      "claude-sonnet-4-6",
+      "claude-sonnet-4-5",
+      "claude-haiku-4-5",
+    ]);
+    expect(cat.byAgent.claude.map((m) => m.id)).not.toContain("claude-opus-4-5-20251101");
+    expect(cat.byAgent.claude.map((m) => m.id)).not.toContain("claude-3-5-haiku-20241022");
+    expect(cat.byAgent.claude.map((m) => m.name)).toContain("Claude Sonnet 4.5");
+    expect(cat.byAgent.claude.map((m) => m.name).some((name) => name.includes("(latest)"))).toBe(false);
     // The 1M variant the transcript reports resolves through the by-id map.
     expect(lookupModel(cat.byId, "claude-opus-4-8[1m]")?.contextWindow).toBe(1_000_000);
   });
@@ -54,7 +110,138 @@ describe("buildCatalog", () => {
     ];
     const cat = buildCatalog(agents, idx);
     expect(cat.byId["gpt-5.5"].contextWindow).toBe(400_000);
+    expect(cat.byId["gpt-5.5"].releaseDate).toBe("2025-12-11");
     expect(cat.byAgent.codex).toHaveLength(1);
+  });
+
+  it("curates Antigravity to a short Gemini Pro and Flash flagship list", () => {
+    const agents: AgentModels[] = [{ agent: "antigravity", providerHint: "google", models: [] }];
+    const cat = buildCatalog(agents, idx);
+
+    expect(cat.byAgent.antigravity.map((m) => m.id)).toEqual([
+      "gemini-3.5-pro",
+      "gemini-3.5-flash",
+      "gemini-3.1-pro",
+      "gemini-3.0-flash",
+    ]);
+    expect(cat.byAgent.antigravity.map((m) => m.id)).not.toContain("nano-banana");
+    expect(cat.byAgent.antigravity.map((m) => m.id)).not.toContain("gemini-3-pro-image-preview");
+    expect(cat.byAgent.antigravity.map((m) => m.id)).not.toContain("gemini-3.1-flash-lite");
+    expect(cat.byAgent.antigravity.map((m) => m.id)).not.toContain("gemini-2.5-flash-preview-tts");
+    expect(cat.byAgent.antigravity.map((m) => m.id)).not.toContain("gemini-3.1-pro-preview");
+    expect(cat.byAgent.antigravity.map((m) => m.id)).not.toContain("gemini-1.5-pro");
+  });
+
+  it("orders discovered models by release date descending, unknown dates last", () => {
+    const agents: AgentModels[] = [
+      {
+        agent: "codex",
+        models: [
+          { id: "unknown-local", name: "Unknown Local" },
+          { id: "claude-3-5-haiku-20241022" },
+          { id: "claude-opus-4-7" },
+          { id: "gpt-5.5" },
+        ],
+      },
+    ];
+    const cat = buildCatalog(agents, idx);
+    expect(cat.byAgent.codex.map((m) => m.id)).toEqual([
+      "claude-opus-4-7",
+      "gpt-5.5",
+      "claude-3-5-haiku-20241022",
+      "unknown-local",
+    ]);
+  });
+
+  it("curates Cursor to recent Composer models and a few flagship models per provider", () => {
+    const agents: AgentModels[] = [
+      {
+        agent: "cursor",
+        models: [
+          { id: "composer-2.5-fast", name: "Composer 2.5 Fast (default)" },
+          { id: "composer-2.5", name: "Composer 2.5" },
+          { id: "composer-2.4", name: "Composer 2.4" },
+          { id: "composer-2.3", name: "Composer 2.3" },
+          { id: "composer-2.2", name: "Composer 2.2" },
+          { id: "gpt-5.3-codex-low", name: "Codex 5.3 Low" },
+          { id: "gpt-5.3-codex", name: "Codex 5.3" },
+          { id: "claude-opus-4-8-thinking-high", name: "Opus 4.8 1M Thinking High" },
+          { id: "claude-opus-4-8-thinking", name: "Opus 4.8 1M Thinking" },
+          { id: "claude-opus-4-7-thinking", name: "Opus 4.7 1M Thinking" },
+          { id: "claude-4.6-sonnet-medium", name: "Sonnet 4.6 1M" },
+          { id: "claude-haiku-4-5", name: "Haiku 4.5" },
+          { id: "gpt-5.5-high", name: "GPT-5.5 1M High" },
+          { id: "gpt-5.5-medium", name: "GPT-5.5 1M" },
+          { id: "gpt-5.4-medium", name: "GPT-5.4 1M" },
+          { id: "gpt-5.2-codex", name: "Codex 5.2" },
+          { id: "gemini-3.1-pro", name: "Gemini 3.1 Pro" },
+          { id: "gemini-3.0-pro", name: "Gemini 3.0 Pro" },
+          { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro" },
+          { id: "gemini-2.0-pro", name: "Gemini 2.0 Pro" },
+          { id: "grok-4.3", name: "Grok 4.3 1M" },
+          { id: "grok-4.2", name: "Grok 4.2 1M" },
+          { id: "grok-4.1", name: "Grok 4.1 1M" },
+          { id: "kimi-k2.5", name: "Kimi K2.5" },
+          { id: "kimi-k2", name: "Kimi K2" },
+          { id: "kimi-k1", name: "Kimi K1" },
+        ],
+      },
+    ];
+    const cat = buildCatalog(agents, idx);
+
+    expect(cat.byAgent.cursor.map((m) => m.id)).toEqual([
+      "composer-2.5-fast",
+      "composer-2.5",
+      "composer-2.4",
+      "composer-2.3",
+      "claude-opus-4-8-thinking",
+      "claude-opus-4-7-thinking",
+      "claude-4.6-sonnet-medium",
+      "gpt-5.3-codex",
+      "gpt-5.5-medium",
+      "gpt-5.4-medium",
+      "gemini-3.1-pro",
+      "gemini-3.0-pro",
+      "gemini-2.5-pro",
+      "grok-4.3",
+      "grok-4.2",
+      "kimi-k2.5",
+      "kimi-k2",
+    ]);
+    expect(cat.byAgent.cursor.map((m) => m.id)).not.toContain("composer-2.2");
+    expect(cat.byAgent.cursor.map((m) => m.id)).not.toContain("claude-haiku-4-5");
+    expect(cat.byAgent.cursor.map((m) => m.id)).not.toContain("gpt-5.2-codex");
+    expect(cat.byAgent.cursor.map((m) => m.id)).not.toContain("gemini-2.0-pro");
+    expect(cat.byAgent.cursor.map((m) => m.id)).not.toContain("grok-4.1");
+    expect(cat.byAgent.cursor.map((m) => m.id)).not.toContain("kimi-k1");
+    expect(cat.byAgent.cursor[0].name).toBe("Composer 2.5 Fast");
+    expect(cat.byAgent.cursor.map((m) => m.name).some((name) => name.includes("(default)"))).toBe(false);
+    expect(cat.byId["gpt-5.5-medium"].releaseDate).toBe("2025-12-11");
+    expect(cat.byId["claude-4.6-sonnet-medium"].releaseDate).toBe("2026-02-17");
+  });
+
+  it("groups Cursor Claude models by family after Composer", () => {
+    const agents: AgentModels[] = [
+      {
+        agent: "cursor",
+        models: [
+          { id: "composer-2.5", name: "Composer 2.5" },
+          { id: "claude-opus-4-8-thinking", name: "Opus 4.8 1M Thinking" },
+          { id: "claude-haiku-4-5", name: "Haiku 4.5" },
+          { id: "claude-sonnet-4-5", name: "Sonnet 4.5" },
+          { id: "gpt-5.5-medium", name: "GPT-5.5 1M" },
+        ],
+      },
+    ];
+    const cat = buildCatalog(agents, idx);
+
+    expect(cat.byAgent.cursor.map((m) => m.id)).toEqual([
+      "composer-2.5",
+      "claude-opus-4-8-thinking",
+      "claude-sonnet-4-5",
+      "claude-haiku-4-5",
+      "gpt-5.5-medium",
+    ]);
   });
 
   it("falls back to CLI metadata for ids models.dev doesn't know", () => {
@@ -62,7 +249,7 @@ describe("buildCatalog", () => {
       { agent: "opencode", models: [{ id: "big-pickle", name: "Big Pickle", contextWindow: 32_000 }] },
     ];
     const cat = buildCatalog(agents, idx);
-    expect(cat.byId["big-pickle"]).toEqual({ name: "Big Pickle", contextWindow: 32_000, reasoning: false });
+    expect(cat.byId["big-pickle"]).toEqual({ id: "big-pickle", name: "Big Pickle", contextWindow: 32_000, reasoning: false });
   });
 });
 
@@ -82,7 +269,7 @@ describe("modelIdCandidates", () => {
 
 describe("lookupModel", () => {
   const catalog: SlimCatalog = {
-    "claude-opus-4": { name: "Claude Opus 4", contextWindow: 200_000, reasoning: true },
+    "claude-opus-4": { id: "claude-opus-4", name: "Claude Opus 4", contextWindow: 200_000, reasoning: true },
   };
 
   it("matches after stripping a date suffix and provider prefix", () => {

--- a/src/data/modelCatalog/modelsDev.ts
+++ b/src/data/modelCatalog/modelsDev.ts
@@ -13,6 +13,7 @@ const MODELS_DEV_URL = "https://models.dev/api.json";
 interface RawModel {
   name?: string;
   reasoning?: boolean;
+  release_date?: string;
   limit?: { context?: number };
 }
 
@@ -25,9 +26,11 @@ export interface ModelsDevIndex {
 
 function toMeta(id: string, m: RawModel): ModelMeta {
   return {
+    id,
     name: m.name ?? id,
     contextWindow: m.limit?.context ?? 0,
     reasoning: m.reasoning === true,
+    ...(m.release_date ? { releaseDate: m.release_date } : {}),
   };
 }
 

--- a/src/data/modelCatalog/types.ts
+++ b/src/data/modelCatalog/types.ts
@@ -6,14 +6,18 @@
 // — a flat id→meta map (`byId`, for the usage gauge) plus per-agent lists
 // (`byAgent`, for the future model picker).
 
-/** Metadata for one model, keyed in `byId` by its bare model id. */
+/** Metadata for one model, keyed in `byId` by the id used for lookup/launch. */
 export interface ModelMeta {
+  /** Bare model id as passed to the agent CLI (e.g. "claude-opus-4-8"). */
+  id: string;
   /** Human-facing model name (e.g. "Claude Opus 4.5"). */
   name: string;
   /** Context window in tokens. 0 when unknown. */
   contextWindow: number;
   /** Whether the model supports reasoning / extended thinking. */
   reasoning: boolean;
+  /** Model release date from models.dev (`YYYY-MM-DD`), when known. */
+  releaseDate?: string;
 }
 
 /** One model an agent reports it supports (from the Rust discovery command).

--- a/src/data/providers.ts
+++ b/src/data/providers.ts
@@ -24,13 +24,16 @@ export interface Provider {
   version: string;
   hue: number;
   sub: string;
+  /** Agent manages its own model and ignores a per-session selection, so the
+   *  picker offers no model choice (e.g. antigravity's `agy --print` runner). */
+  fixedModel?: boolean;
 }
 
 export const PROVIDERS: Provider[] = [
   { id: "claude",      label: "Claude Code",  short: "CC", version: "v1.0.42",     hue: 28,  sub: "Opus 4.7 · Sonnet 4.6" },
   { id: "codex",       label: "Codex",        short: "CX", version: "v0.133.0",    hue: 145, sub: "ChatGPT Plus" },
   { id: "cursor",      label: "Cursor Agent", short: "CR", version: "v2026.05.24", hue: 215, sub: "Pro Subscription" },
-  { id: "antigravity", label: "Antigravity",  short: "AG", version: "v1.0",        hue: 260, sub: "Gemini 3 Pro" },
+  { id: "antigravity", label: "Antigravity",  short: "AG", version: "v1.0",        hue: 260, sub: "Gemini 3 Pro", fixedModel: true },
   { id: "opencode",    label: "OpenCode",     short: "OC", version: "v1.15.12",    hue: 195, sub: "1 upstream connected" },
   { id: "pi",          label: "Pi",           short: "PI", version: "v0.4",        hue: 320, sub: "Pi · experimental" },
 ];

--- a/src/store.ts
+++ b/src/store.ts
@@ -141,6 +141,8 @@ export interface DraftAgent {
   name: string;
   /** Provider id (mocked — only "claude" currently spawns anything). */
   provider: string;
+  /** Optional model id to pass to the chosen provider CLI at spawn. */
+  model?: string;
   /** Base branch to fork from. */
   base: string;
 }
@@ -433,6 +435,7 @@ interface AppState {
     id: string,
     text: string,
     provider: string,
+    model?: string,
     attachments?: string[],
     thinking?: string,
   ) => Promise<void>;
@@ -1705,7 +1708,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     }));
   },
 
-  spawnFromDraft: async (id, text, provider, attachments = [], thinking?) => {
+  spawnFromDraft: async (id, text, provider, model, attachments = [], thinking?) => {
     const draft = get().drafts.find((d) => d.id === id);
     if (!draft) return;
     set({ busy: true, lastError: null });
@@ -1721,6 +1724,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         provider,
         draft.name,
         thinking,
+        model,
       );
       const fresh = await api.getWorkspace();
       set((state) => {


### PR DESCRIPTION
## Summary

Adds a two-pane composer picker so new agent drafts can choose both the coding agent and the model from the discovered model catalog.

## Changes

- Adds model ids to catalog entries and bumps the local catalog cache key.
- Stores an optional selected model on draft agents and persisted sessions.
- Threads the selected model through frontend IPC, Tauri spawn, resume/view-switch startup, and per-turn runners.
- Passes `--model` to supported agent CLIs when a model is selected, while preserving each CLI default when unset.
- Adds a `sessions.model` migration.

## Validation

- `bun run check`
- `bun test`
- `cargo test -q --manifest-path src-tauri/Cargo.toml`
