### PR TITLE
Remove dead Status bar toggle, wire up Token usage to composer meter

### DIFF
--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -362,7 +362,9 @@ export function Composer({
           <Icon name="attach" size={11} />
         </Chip>
         <span style={{ flex: 1 }} />
-        {usage && usage.contextTokens > 0 && <UsageMeter usage={usage} />}
+        {features.tokenUsage && usage && usage.contextTokens > 0 && (
+          <UsageMeter usage={usage} />
+        )}
         <button
           type="button"
           className={`send ${stopping ? "is-stop" : ""}`}

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -28,13 +28,7 @@ const FEATURE_GROUPS: { label: string; items: FeatureItem[] }[] = [
     items: [
       { key: "thinkingBudget", title: "Thinking budget", sub: "Low / medium / high cap" },
       { key: "autoEdit",       title: "Auto-edit",       sub: "Skip approval for write tools" },
-    ],
-  },
-  {
-    label: "Status",
-    items: [
-      { key: "statusBar",  title: "Status bar",  sub: "Persistent bar with branch, server, tokens" },
-      { key: "tokenUsage", title: "Token usage", sub: "Context window % in status bar" },
+      { key: "tokenUsage",     title: "Token usage",     sub: "Context window % meter in the composer" },
     ],
   },
 ];

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -19,11 +19,7 @@ const SIDE_PANELS: FeatureItem[] = [
 const COMPOSER: FeatureItem[] = [
   { key: "thinkingBudget", title: "Thinking budget", sub: "Show a low / medium / high reasoning cap in the composer." },
   { key: "autoEdit",       title: "Auto-edit",       sub: "Let agents apply write tools without per-tool approval." },
-];
-
-const STATUS: FeatureItem[] = [
-  { key: "statusBar",  title: "Status bar",  sub: "Persistent footer with branch, server, and token usage." },
-  { key: "tokenUsage", title: "Token usage", sub: "Context window % in the status bar." },
+  { key: "tokenUsage",     title: "Token usage",     sub: "Show the context-window % meter in the composer." },
 ];
 
 export function GeneralPane() {
@@ -104,14 +100,8 @@ export function GeneralPane() {
         ))}
       </SetGroup>
 
-      <SetGroup label="Composer">
+      <SetGroup label="Composer" last>
         {COMPOSER.map((it) => (
-          <FeatureRow key={it.key} item={it} />
-        ))}
-      </SetGroup>
-
-      <SetGroup label="Status" last>
-        {STATUS.map((it) => (
           <FeatureRow key={it.key} item={it} />
         ))}
       </SetGroup>

--- a/src/store.ts
+++ b/src/store.ts
@@ -162,7 +162,7 @@ export interface FeatureFlags {
   terminal: boolean;
   thinkingBudget: boolean;
   autoEdit: boolean;
-  statusBar: boolean;
+  /** Show the context-window usage meter in the composer foot. */
   tokenUsage: boolean;
 }
 
@@ -173,8 +173,7 @@ const DEFAULT_FEATURES: FeatureFlags = {
   terminal: false,
   thinkingBudget: true,
   autoEdit: false,
-  statusBar: false,
-  tokenUsage: false,
+  tokenUsage: true,
 };
 
 function parseFeatures(raw: string | undefined): FeatureFlags {
@@ -184,6 +183,8 @@ function parseFeatures(raw: string | undefined): FeatureFlags {
       // legacy flags folded into `code`
       files?: boolean;
       diff?: boolean;
+      // removed in this version; its presence marks a pre-migration blob
+      statusBar?: boolean;
     };
     // The old "Files" and "Diff" tabs were merged into the Code panel; honor a
     // saved preference for either when migrating an existing settings blob.
@@ -191,9 +192,16 @@ function parseFeatures(raw: string | undefined): FeatureFlags {
       saved.code ?? (saved.files !== undefined || saved.diff !== undefined
         ? !!(saved.files || saved.diff)
         : undefined);
-    const { files: _files, diff: _diff, ...rest } = saved;
+    // A blob still carrying the removed `statusBar` flag predates `tokenUsage`
+    // gating the composer meter — back then it was a no-op that defaulted off.
+    // Drop its stored `tokenUsage` so the new default (meter on, matching the
+    // old always-visible behavior) applies; honor the value for newer blobs.
+    const preMigration = saved.statusBar !== undefined;
+    const { files: _files, diff: _diff, statusBar: _statusBar, ...rest } = saved;
     void _files;
     void _diff;
+    void _statusBar;
+    if (preMigration) delete rest.tokenUsage;
     return {
       ...DEFAULT_FEATURES,
       ...rest,


### PR DESCRIPTION
## Summary

Audit of the settings surfaces turned up two feature toggles connected to nothing. This PR removes one and gives the other a real job.

**Removed the Status bar toggle.** `features.statusBar` backed a status bar component that never existed — no component read the flag, so the toggle was a no-op in both the quick-settings popover and the full settings screen. Dropped from the `FeatureFlags` type, the defaults, and both settings UIs.

**Wired up the Token usage toggle.** `features.tokenUsage` was also dead. It now gates the composer's context-window usage meter (`UsageMeter`), which was previously always rendered whenever usage data existed. Defaulted to `true` to preserve the always-visible behavior, moved into the **Composer** settings group, and relabeled ("Context window % meter in the composer") since it no longer refers to a status bar.

## Migration

Old settings blobs persisted `tokenUsage: false` (the prior dead default) for anyone who'd toggled any feature. Since the meter used to always show, the now-removed `statusBar` key is used as a one-time marker: if a saved blob still contains `statusBar`, it predates this change, so its stored `tokenUsage` is dropped and the new default (meter on) applies. Blobs written by this version onward honor the user's choice normally.

## Files

- `store.ts` — drop `statusBar` from `FeatureFlags`/defaults; default `tokenUsage` to `true`; migrate pre-existing blobs in `parseFeatures`.
- `Composer/index.tsx` — gate `UsageMeter` behind `features.tokenUsage`.
- `SettingsScreen/GeneralPane.tsx`, `Settings/index.tsx` — remove the Status group; move Token usage into the Composer group with updated copy.

## Testing

Not typechecked locally — this worktree has no `node_modules` installed. Changes are small and self-consistent; recommend `bun install && bun run check` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)