### PR TITLE
Add per-agent custom binary path overrides in Providers settings

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -711,7 +711,7 @@ pub fn cached_provider_version(provider: &str) -> Option<String> {
     }
     let version = provider_bin_label(provider).and_then(|(bin, label)| {
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
-        resolve_agent_bin(bin, label, &home)
+        resolve_agent_bin(provider, bin, label, &home)
             .ok()
             .and_then(|p| probe_version(&p))
     });
@@ -815,7 +815,7 @@ impl Agent {
             .ok_or_else(|| Error::Other(format!("no per-turn descriptor for `{provider}`")))?;
         let home =
             dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
-        let bin = resolve_agent_bin(desc.bin, desc.label, &home)?;
+        let bin = resolve_agent_bin(desc.id, desc.bin, desc.label, &home)?;
         let session = if spec.fresh {
             None
         } else {
@@ -924,7 +924,7 @@ impl Agent {
     {
         let home = dirs::home_dir()
             .ok_or_else(|| Error::Other("HOME directory not available".into()))?;
-        let program = PathBuf::from(resolve_agent_bin(desc.bin, desc.label, &home)?);
+        let program = PathBuf::from(resolve_agent_bin(desc.id, desc.bin, desc.label, &home)?);
         Self::spawn_exec(
             program,
             spec,
@@ -1207,7 +1207,7 @@ fn prepare_managed_args(
 }
 
 fn resolve_claude(home: &Path) -> Result<String> {
-    resolve_agent_bin("claude", "Claude Code", home)
+    resolve_agent_bin("claude", "claude", "Claude Code", home)
 }
 
 // ── per-turn provider configs ─────────────────────────────────────────────
@@ -1427,7 +1427,17 @@ fn pi_pty_args(session_id: Option<&str>, model: Option<&str>) -> Vec<String> {
 /// (catches nvm / fnm / volta / homebrew setups the GUI process's bare
 /// PATH misses), then the usual install dirs. `label` is the
 /// human-facing product name used only in the not-found error.
-fn resolve_agent_bin(name: &str, label: &str, home: &Path) -> Result<String> {
+fn resolve_agent_bin(agent_id: &str, name: &str, label: &str, home: &Path) -> Result<String> {
+    // A user-set custom path wins over PATH discovery. If it no longer points
+    // at an executable we surface a clear error rather than silently falling
+    // back to a different binary off PATH — the user chose this one explicitly.
+    if let Some(result) = crate::bin_resolve::resolve_agent_override(agent_id, home) {
+        return result.map_err(|path| {
+            Error::Other(format!(
+                "The custom binary path for {label} is not executable: {path}"
+            ))
+        });
+    }
     crate::bin_resolve::resolve_bin(name, home).ok_or_else(|| {
         Error::Other(format!(
             "Could not find the `{name}` executable. Install {label} or make it available on PATH."
@@ -1442,6 +1452,29 @@ pub struct ProviderProbe {
     pub id: String,
     pub version: Option<String>,
     pub path: Option<String>,
+}
+
+#[derive(serde::Serialize)]
+pub struct BinValidation {
+    /// The path is an executable regular file (after `~` expansion).
+    pub executable: bool,
+    /// The version `<path> --version` reported, if it ran and parsed.
+    pub version: Option<String>,
+}
+
+/// Pre-flight a user-entered custom binary path before it's saved as an
+/// override: expand a leading `~`, confirm it's an executable file, and probe
+/// `--version` when it is. Powers the providers settings UI's inline feedback.
+pub fn validate_bin(path: &str) -> BinValidation {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
+    let expanded = crate::bin_resolve::expand_tilde(path, &home);
+    let executable = crate::bin_resolve::is_executable_path(&expanded);
+    let version = if executable {
+        probe_version(&expanded.to_string_lossy())
+    } else {
+        None
+    };
+    BinValidation { executable, version }
 }
 
 /// Probe every known provider in parallel and return their resolved path +
@@ -1463,7 +1496,7 @@ pub async fn probe_all_providers() -> Vec<ProviderProbe> {
         let bin = bin.to_string();
         let label = label.to_string();
         handles.push(tokio::task::spawn_blocking(move || {
-            let path = resolve_agent_bin(&bin, &label, &home).ok();
+            let path = resolve_agent_bin(&id, &bin, &label, &home).ok();
             let version = path.as_deref().and_then(probe_version);
             ProviderProbe { id, version, path }
         }));

--- a/src-tauri/src/bin_resolve.rs
+++ b/src-tauri/src/bin_resolve.rs
@@ -8,10 +8,77 @@
 //! ENOENT ("No such file or directory"). Resolve the absolute path first:
 //! current PATH → the user's login-shell PATH → the usual install dirs.
 
+use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::{OnceLock, RwLock};
+
+/// User-set absolute binary paths, keyed by agent id (e.g. "claude",
+/// "cursor"). When an agent has an entry here, it overrides PATH discovery
+/// entirely (see `resolve_agent_override`) — the user pointed us at a specific
+/// binary and we honor it rather than silently picking a different one off
+/// PATH. Populated once at startup from the `settings` table and updated by the
+/// `set_agent_bin_override` command, so resolution never needs a DB handle.
+fn overrides() -> &'static RwLock<HashMap<String, String>> {
+    static OVERRIDES: OnceLock<RwLock<HashMap<String, String>>> = OnceLock::new();
+    OVERRIDES.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// Replace the entire override map. Called at startup with every
+/// `agent_bin_path_*` setting and on each single-key change (the caller folds
+/// the change into the full map). An empty path clears that agent's override.
+pub fn set_agent_overrides(map: HashMap<String, String>) {
+    *overrides().write().unwrap() = map
+        .into_iter()
+        .filter(|(_, path)| !path.trim().is_empty())
+        .collect();
+}
+
+/// The raw override path for `agent_id`, if the user set one. Not yet
+/// tilde-expanded or executability-checked — that happens in
+/// `resolve_agent_override`.
+pub fn agent_override(agent_id: &str) -> Option<String> {
+    overrides().read().unwrap().get(agent_id).cloned()
+}
+
+/// Resolve `agent_id`'s override to an executable absolute path. Returns:
+/// - `None` — no override set; caller should fall back to PATH discovery.
+/// - `Some(Ok(path))` — override set and points at an executable file.
+/// - `Some(Err(path))` — override set but missing / not executable. The path
+///   is returned so callers can surface it (the error message, the "missing"
+///   UI). We deliberately do NOT fall back to PATH here: the user chose this
+///   binary explicitly, so masking a broken choice with a different one off
+///   PATH would be more confusing than a clear "not executable" error.
+pub fn resolve_agent_override(agent_id: &str, home: &Path) -> Option<Result<String, String>> {
+    let raw = agent_override(agent_id)?;
+    let expanded = expand_tilde(&raw, home);
+    if is_executable(&expanded) {
+        Some(Ok(expanded.to_string_lossy().into_owned()))
+    } else {
+        Some(Err(expanded.to_string_lossy().into_owned()))
+    }
+}
+
+/// Expand a single leading `~` (or `~/…`) to `home`. Any other use of `~`
+/// (e.g. `~user`) is left untouched — we only handle the common case.
+pub fn expand_tilde(path: &str, home: &Path) -> PathBuf {
+    if path == "~" {
+        home.to_path_buf()
+    } else if let Some(rest) = path.strip_prefix("~/") {
+        home.join(rest)
+    } else {
+        PathBuf::from(path)
+    }
+}
+
+/// Whether `path` (tilde already expanded) is an executable regular file —
+/// the same check resolution uses. Exposed for the `validate_agent_bin`
+/// command so the UI can pre-flight a custom path before saving.
+pub fn is_executable_path(path: &Path) -> bool {
+    is_executable(path)
+}
 
 /// Resolve `name` to an absolute path, or `None` if it can't be found.
 ///
@@ -139,5 +206,76 @@ mod tests {
             resolve_bin("quorum-definitely-not-installed-zzz", home.path()),
             None,
         );
+    }
+
+    #[test]
+    fn expand_tilde_handles_bare_home_subpath_and_absolute() {
+        let home = Path::new("/Users/test");
+        assert_eq!(expand_tilde("~", home), PathBuf::from("/Users/test"));
+        assert_eq!(
+            expand_tilde("~/bin/claude", home),
+            PathBuf::from("/Users/test/bin/claude"),
+        );
+        // An absolute path (and a `~user` form we don't handle) is untouched.
+        assert_eq!(
+            expand_tilde("/opt/homebrew/bin/claude", home),
+            PathBuf::from("/opt/homebrew/bin/claude"),
+        );
+        assert_eq!(expand_tilde("~bob/x", home), PathBuf::from("~bob/x"));
+    }
+
+    /// The override registry is process-global, so this is the ONLY test that
+    /// mutates it — keeping resolution deterministic without cross-test races.
+    /// It covers the two branches `resolve_agent_override` reports: an
+    /// executable override wins, a non-executable one is surfaced as `Err`
+    /// (never silently falling back to PATH).
+    #[test]
+    fn agent_override_wins_when_executable_and_errors_when_not() {
+        let home = tempfile::tempdir().unwrap();
+        let bin = home.path().join("custom-claude");
+        write_executable(&bin);
+        let bin_str = bin.to_string_lossy().into_owned();
+
+        // No override set → caller falls back to PATH (None here).
+        assert!(resolve_agent_override("override-test-agent", home.path()).is_none());
+
+        set_agent_overrides(HashMap::from([
+            ("override-test-agent".to_string(), bin_str.clone()),
+            // Blank paths are dropped, so this clears rather than sets.
+            ("blank-agent".to_string(), "   ".to_string()),
+            ("missing-agent".to_string(), "/no/such/binary-xyz".to_string()),
+        ]));
+
+        assert_eq!(
+            resolve_agent_override("override-test-agent", home.path()),
+            Some(Ok(bin_str)),
+            "an executable override must win over PATH discovery",
+        );
+        assert!(
+            resolve_agent_override("blank-agent", home.path()).is_none(),
+            "a blank override is dropped and falls back to PATH",
+        );
+        assert!(
+            matches!(
+                resolve_agent_override("missing-agent", home.path()),
+                Some(Err(_)),
+            ),
+            "a non-executable override is reported as Err, not silently ignored",
+        );
+
+        // Tilde expansion flows through resolution too.
+        set_agent_overrides(HashMap::from([(
+            "tilde-agent".to_string(),
+            "~/custom-claude".to_string(),
+        )]));
+        // home dir here is the tempdir, where custom-claude is executable.
+        assert_eq!(
+            resolve_agent_override("tilde-agent", home.path()),
+            Some(Ok(bin.to_string_lossy().into_owned())),
+            "a leading ~ in an override expands to home before the exec check",
+        );
+
+        // Leave the global registry empty for any later-running test.
+        set_agent_overrides(HashMap::new());
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6,7 +6,7 @@ use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use tauri::{AppHandle, State};
 
-use crate::agent::ProviderProbe;
+use crate::agent::{BinValidation, ProviderProbe};
 use crate::error::{Error, Result};
 use crate::gh::{self, GhRepoSummary, GhStatus, PrState};
 use crate::git;
@@ -1111,6 +1111,20 @@ pub async fn copy_worktree_file(
 #[tauri::command]
 pub async fn probe_provider_versions() -> Vec<ProviderProbe> {
     crate::agent::probe_all_providers().await
+}
+
+/// Validate a candidate custom agent binary path: is it an executable file,
+/// and what `--version` does it report? The providers settings UI calls this
+/// before saving a path override so it can show immediate inline feedback
+/// (green version on success, error on failure) and block a broken save.
+#[tauri::command]
+pub async fn validate_agent_bin(path: String) -> BinValidation {
+    tokio::task::spawn_blocking(move || crate::agent::validate_bin(&path))
+        .await
+        .unwrap_or(BinValidation {
+            executable: false,
+            version: None,
+        })
 }
 
 /// Discover the models each agent CLI reports it supports (raw ids + any cheap

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -12,6 +12,34 @@ const ALLOWED_TABLES: &[&str] = &[
     "sessions", "settings", "workspaces", "worktrees",
 ];
 
+/// `settings` key prefix for per-agent custom binary path overrides. The agent
+/// id follows the prefix (e.g. `agent_bin_path_claude`); the value is the raw
+/// absolute path the user entered. Shared by the startup loader and the
+/// `set_agent_bin_override` command so both agree on the key format.
+pub const AGENT_BIN_PREFIX: &str = "agent_bin_path_";
+
+/// Read every `agent_bin_path_*` setting into an id → path map. Called once at
+/// startup to seed `bin_resolve`'s in-memory override registry so binary
+/// resolution never needs a DB handle. Blank values are skipped (a cleared
+/// override).
+pub fn load_agent_bin_overrides(conn: &Connection) -> std::collections::HashMap<String, String> {
+    let mut map = std::collections::HashMap::new();
+    let rows = match db_select(conn, "settings", json!({})) {
+        Ok(rows) => rows,
+        Err(_) => return map,
+    };
+    for row in rows {
+        let key = row.get("key").and_then(Value::as_str).unwrap_or("");
+        let value = row.get("value").and_then(Value::as_str).unwrap_or("");
+        if let Some(id) = key.strip_prefix(AGENT_BIN_PREFIX) {
+            if !value.trim().is_empty() {
+                map.insert(id.to_string(), value.to_string());
+            }
+        }
+    }
+    map
+}
+
 fn validate_table(table: &str) -> Result<()> {
     if ALLOWED_TABLES.contains(&table) {
         Ok(())
@@ -617,6 +645,27 @@ mod tests {
         let rows = db_select(&conn, "settings", json!({ "where": { "key": "theme" } })).unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0]["value"], "light");
+    }
+
+    #[test]
+    fn load_agent_bin_overrides_picks_prefixed_keys_and_skips_blanks() {
+        let db = test_db();
+        let conn = db.lock();
+
+        let set = |k: &str, v: &str| {
+            db_upsert(&conn, "settings", json!({ "key": k, "value": v }), "key").unwrap();
+        };
+        set("theme", "dark"); // unrelated setting, must be ignored
+        set("agent_bin_path_claude", "/opt/homebrew/bin/claude");
+        set("agent_bin_path_cursor", "~/bin/cursor-agent");
+        set("agent_bin_path_codex", "   "); // blank → cleared, must be skipped
+
+        let map = load_agent_bin_overrides(&conn);
+        assert_eq!(map.len(), 2);
+        assert_eq!(map["claude"], "/opt/homebrew/bin/claude");
+        assert_eq!(map["cursor"], "~/bin/cursor-agent");
+        assert!(!map.contains_key("codex"));
+        assert!(!map.contains_key("theme"));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,7 +25,7 @@ mod workspace;
 
 use parking_lot::Mutex;
 use rusqlite::Connection;
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::sync::Arc;
 use tauri::Manager;
 
@@ -108,6 +108,32 @@ async fn db_query(
     serde_json::to_value(rows).map_err(|e| e.to_string())
 }
 
+/// Set or clear a per-agent custom binary path override. Writes (or deletes,
+/// for an empty path) the `agent_bin_path_<id>` setting, then refreshes the
+/// in-memory registry binary resolution reads — keeping the DB and the
+/// registry in sync through a single call so the frontend doesn't have to.
+#[tauri::command]
+async fn set_agent_bin_override(
+    id: String,
+    path: Option<String>,
+    state: tauri::State<'_, DbState>,
+) -> Result<(), String> {
+    let conn = state.lock();
+    let key = format!("{}{}", database::AGENT_BIN_PREFIX, id);
+    match path.as_deref().map(str::trim) {
+        Some(p) if !p.is_empty() => {
+            database::db_upsert(&conn, "settings", json!({ "key": key, "value": p }), "key")
+                .map_err(|e| e.to_string())?;
+        }
+        _ => {
+            database::db_delete(&conn, "settings", json!({ "where": { "key": key } }))
+                .map_err(|e| e.to_string())?;
+        }
+    }
+    bin_resolve::set_agent_overrides(database::load_agent_bin_overrides(&conn));
+    Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tracing_subscriber::fmt()
@@ -133,6 +159,12 @@ pub fn run() {
 
             let db = database::init(&data_dir)
                 .expect("failed to initialize database");
+
+            // Seed the in-memory agent binary override registry so binary
+            // resolution (deep in spawn/probe paths, with no DB handle) can
+            // honor user-set custom paths without touching the DB each time.
+            bin_resolve::set_agent_overrides(database::load_agent_bin_overrides(&db.lock()));
+
             app.manage(db.clone());
 
             let workspace = Arc::new(WorkspaceManager::new(db));
@@ -152,6 +184,7 @@ pub fn run() {
             db_upsert,
             db_count,
             db_query,
+            set_agent_bin_override,
             oauth::oauth_device_login,
             commands::get_workspace,
             commands::get_agent_diff_stats,
@@ -214,6 +247,7 @@ pub fn run() {
             commands::create_worktree_dir,
             commands::copy_worktree_file,
             commands::probe_provider_versions,
+            commands::validate_agent_bin,
             commands::discover_supported_models,
         ])
         .run(tauri::generate_context!())

--- a/src/api.ts
+++ b/src/api.ts
@@ -313,6 +313,14 @@ export interface ProviderProbe {
   path: string | null;
 }
 
+/** Result of pre-flighting a custom agent binary path before saving it as an
+ *  override. `executable` is whether the path is a runnable file; `version` is
+ *  what `<path> --version` reported (null if it didn't run or didn't parse). */
+export interface BinValidation {
+  executable: boolean;
+  version: string | null;
+}
+
 /** Whether the `gh` CLI is installed and authenticated (New Project flow). */
 export interface GhStatus {
   installed: boolean;
@@ -492,6 +500,13 @@ export const api = {
     invoke<void>("copy_worktree_file", { agentId, from, to }),
   probeProviderVersions: () =>
     invoke<ProviderProbe[]>("probe_provider_versions"),
+  /** Check a candidate custom binary path before saving it as an override. */
+  validateAgentBin: (path: string) =>
+    invoke<BinValidation>("validate_agent_bin", { path }),
+  /** Set (or clear, with a null/blank path) a per-agent custom binary path.
+   *  Persists the setting and refreshes the backend's resolution registry. */
+  setAgentBinOverride: (id: string, path: string | null) =>
+    invoke<void>("set_agent_bin_override", { id, path }),
   /** Per-agent supported-model discovery (raw ids + any cheap CLI metadata).
    *  The frontend enriches these against models.dev. */
   discoverSupportedModels: () =>

--- a/src/app.css
+++ b/src/app.css
@@ -4135,6 +4135,45 @@ button { cursor: default; }
 }
 .set-prov-dk { color: var(--fg-3); }
 .set-prov-dv { color: var(--fg-1); min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+.set-prov-dv.broken { color: var(--warn); }
+
+/* Binary path row: read-only by default, edit-in-place on the pencil. */
+.set-prov-bin-view { display: flex; align-items: center; gap: 8px; min-width: 0; }
+.set-prov-bin-view .grow { flex: 1; }
+.set-badge.custom {
+  background: color-mix(in oklch, var(--accent), transparent 84%);
+  color: var(--accent);
+}
+.set-prov-bin-warn {
+  font-size: 10px; font-weight: 600; letter-spacing: 0.02em;
+  color: var(--warn); white-space: nowrap;
+}
+.btn-i.sm-i {
+  width: 24px; height: 24px; flex-shrink: 0;
+  border-radius: var(--r-sm);
+  color: var(--fg-3);
+  display: inline-flex; align-items: center; justify-content: center;
+  transition: background .12s, color .12s;
+}
+.btn-i.sm-i:hover:not(:disabled) { background: var(--hover); color: var(--fg-0); }
+.btn-i.sm-i:disabled { opacity: 0.5; }
+
+.set-prov-bin-edit { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
+.set-prov-bin-input-row { display: flex; align-items: center; gap: 6px; min-width: 0; }
+.set-prov-bin-input {
+  flex: 1; min-width: 0;
+  height: 26px; padding: 0 8px;
+  font-size: 12px;
+  color: var(--fg-0);
+  background: var(--bg-1);
+  border: 1px solid var(--bd);
+  border-radius: var(--r-sm);
+  outline: none;
+  transition: border-color .12s;
+}
+.set-prov-bin-input:focus { border-color: var(--accent); }
+.set-prov-bin-hint { font-size: 11px; color: var(--fg-3); }
+.set-prov-bin-err { font-size: 11px; color: var(--danger); }
 .set-prov-detail-actions {
   display: flex; align-items: center; gap: 6px;
   margin-top: 12px;

--- a/src/components/SettingsScreen/BinaryPathRow.tsx
+++ b/src/components/SettingsScreen/BinaryPathRow.tsx
@@ -77,9 +77,14 @@ export function BinaryPathRow({
   const reset = async () => {
     if (busy) return;
     setBusy(true);
+    setError(null);
     try {
       await onSave(null);
       setEditing(false);
+    } catch {
+      // Mirror commit()'s failure feedback — reset runs from the display view,
+      // so the error renders below the row there (see the !editing branch).
+      setError("Couldn't reset this path. Try again.");
     } finally {
       setBusy(false);
     }
@@ -140,27 +145,34 @@ export function BinaryPathRow({
           )}
         </div>
       ) : (
-        <div className="set-prov-bin-view">
-          <span className={`set-prov-dv mono ${broken ? "broken" : ""}`}>
-            {effectivePath}
-          </span>
-          {override && <span className="set-badge custom">Custom</span>}
-          {broken && <span className="set-prov-bin-warn">not found</span>}
-          <span className="grow" />
-          {override && (
-            <button className="btn-t ghost sm-t" onClick={() => void reset()}>
-              Reset to auto
+        <div className="set-prov-bin-edit">
+          <div className="set-prov-bin-view">
+            <span className={`set-prov-dv mono ${broken ? "broken" : ""}`}>
+              {effectivePath}
+            </span>
+            {override && <span className="set-badge custom">Custom</span>}
+            {broken && <span className="set-prov-bin-warn">not found</span>}
+            <span className="grow" />
+            {override && (
+              <button
+                className="btn-t ghost sm-t"
+                disabled={busy}
+                onClick={() => void reset()}
+              >
+                Reset to auto
+              </button>
+            )}
+            <button
+              className="btn-i sm-i tip"
+              data-tip-down
+              data-tip="Edit path"
+              aria-label="Edit binary path"
+              onClick={beginEdit}
+            >
+              <Icon name="edit" size={13} />
             </button>
-          )}
-          <button
-            className="btn-i sm-i tip"
-            data-tip-down
-            data-tip="Edit path"
-            aria-label="Edit binary path"
-            onClick={beginEdit}
-          >
-            <Icon name="edit" size={13} />
-          </button>
+          </div>
+          {error && <div className="set-prov-bin-err">{error}</div>}
         </div>
       )}
     </div>

--- a/src/components/SettingsScreen/BinaryPathRow.tsx
+++ b/src/components/SettingsScreen/BinaryPathRow.tsx
@@ -1,0 +1,167 @@
+import { useRef, useState } from "react";
+import { api } from "../../api";
+import { Icon } from "../Icon";
+
+/** The "Binary" detail row in a provider card. Read-only by default — showing
+ *  the effective path the way it always has — but with an inline pencil that
+ *  turns it into a validated text editor. Saving runs `validate_agent_bin` so a
+ *  broken path is rejected with an inline error before it's ever persisted; an
+ *  empty value clears the override and reverts to auto-detection.
+ *
+ *  The override itself lives in the store (and the settings DB); this component
+ *  only renders state and reports edits up through `onSave`. */
+export function BinaryPathRow({
+  providerLabel,
+  effectivePath,
+  override,
+  versionDetected,
+  onSave,
+}: {
+  providerLabel: string;
+  /** What to display when not editing: override ?? live probe ?? default. */
+  effectivePath: string;
+  /** The raw custom path, if one is set. Drives the "Custom" tag. */
+  override?: string;
+  /** Whether the probe found a version for the effective binary. When an
+   *  override is set but this is false, the path is flagged as not-runnable. */
+  versionDetected: boolean;
+  /** Persist (path) or clear (null) the override. Resolves once the store and
+   *  backend have updated; rejects to keep the editor open on failure. */
+  onSave: (path: string | null) => Promise<void>;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const broken = !!override && !versionDetected;
+
+  const beginEdit = () => {
+    setDraft(override ?? "");
+    setError(null);
+    setEditing(true);
+    // Focus after the input mounts.
+    requestAnimationFrame(() => inputRef.current?.focus());
+  };
+
+  const cancel = () => {
+    setEditing(false);
+    setError(null);
+  };
+
+  const commit = async () => {
+    if (busy) return;
+    const value = draft.trim();
+    setBusy(true);
+    setError(null);
+    try {
+      // Empty clears the override — no validation needed to go back to auto.
+      if (value) {
+        const result = await api.validateAgentBin(value);
+        if (!result.executable) {
+          setError("No executable file at this path.");
+          return;
+        }
+      }
+      await onSave(value || null);
+      setEditing(false);
+    } catch {
+      setError("Couldn't save this path. Try again.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const reset = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await onSave(null);
+      setEditing(false);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="set-prov-drow">
+      <span className="set-prov-dk">Binary</span>
+      {editing ? (
+        <div className="set-prov-bin-edit">
+          <div className="set-prov-bin-input-row">
+            <input
+              ref={inputRef}
+              className="set-prov-bin-input mono"
+              value={draft}
+              placeholder={effectivePath}
+              spellCheck={false}
+              autoCapitalize="off"
+              autoCorrect="off"
+              disabled={busy}
+              onChange={(e) => {
+                setDraft(e.target.value);
+                if (error) setError(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void commit();
+                else if (e.key === "Escape") cancel();
+              }}
+            />
+            <button
+              className="btn-i sm-i tip"
+              data-tip-down
+              data-tip="Save"
+              aria-label="Save path"
+              disabled={busy}
+              onClick={() => void commit()}
+            >
+              <Icon name="check" size={14} />
+            </button>
+            <button
+              className="btn-i sm-i tip"
+              data-tip-down
+              data-tip="Cancel"
+              aria-label="Cancel"
+              disabled={busy}
+              onClick={cancel}
+            >
+              <Icon name="close" size={14} />
+            </button>
+          </div>
+          {error ? (
+            <div className="set-prov-bin-err">{error}</div>
+          ) : (
+            <div className="set-prov-bin-hint">
+              Absolute path to the {providerLabel} binary. Leave blank to
+              auto-detect.
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="set-prov-bin-view">
+          <span className={`set-prov-dv mono ${broken ? "broken" : ""}`}>
+            {effectivePath}
+          </span>
+          {override && <span className="set-badge custom">Custom</span>}
+          {broken && <span className="set-prov-bin-warn">not found</span>}
+          <span className="grow" />
+          {override && (
+            <button className="btn-t ghost sm-t" onClick={() => void reset()}>
+              Reset to auto
+            </button>
+          )}
+          <button
+            className="btn-i sm-i tip"
+            data-tip-down
+            data-tip="Edit path"
+            aria-label="Edit binary path"
+            onClick={beginEdit}
+          >
+            <Icon name="edit" size={13} />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SettingsScreen/BinaryPathRow.tsx
+++ b/src/components/SettingsScreen/BinaryPathRow.tsx
@@ -14,7 +14,7 @@ export function BinaryPathRow({
   providerLabel,
   effectivePath,
   override,
-  versionDetected,
+  resolved,
   onSave,
 }: {
   providerLabel: string;
@@ -22,9 +22,10 @@ export function BinaryPathRow({
   effectivePath: string;
   /** The raw custom path, if one is set. Drives the "Custom" tag. */
   override?: string;
-  /** Whether the probe found a version for the effective binary. When an
-   *  override is set but this is false, the path is flagged as not-runnable. */
-  versionDetected: boolean;
+  /** Whether the probe resolved the binary to an executable file (the probe's
+   *  `path`, not its parsed version — a working CLI may report no version). An
+   *  override that fails this is flagged as not-runnable. */
+  resolved: boolean;
   /** Persist (path) or clear (null) the override. Resolves once the store and
    *  backend have updated; rejects to keep the editor open on failure. */
   onSave: (path: string | null) => Promise<void>;
@@ -35,7 +36,7 @@ export function BinaryPathRow({
   const [busy, setBusy] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const broken = !!override && !versionDetected;
+  const broken = !!override && !resolved;
 
   const beginEdit = () => {
     setDraft(override ?? "");

--- a/src/components/SettingsScreen/ProvidersPane.tsx
+++ b/src/components/SettingsScreen/ProvidersPane.tsx
@@ -5,12 +5,15 @@ import { PROVIDER_DETAIL } from "../../data/providerDetail";
 import { Icon } from "../Icon";
 import { ProviderIcon } from "../ProviderIcon";
 import { SetHead, SetGroup, SetToggle } from "./primitives";
+import { BinaryPathRow } from "./BinaryPathRow";
 
 export function ProvidersPane() {
   const providerFlags = useAppStore((s) => s.providerFlags);
   const setProviderEnabled = useAppStore((s) => s.setProviderEnabled);
   const providerVersions = useAppStore((s) => s.providerVersions);
   const providerPaths = useAppStore((s) => s.providerPaths);
+  const providerPathOverrides = useAppStore((s) => s.providerPathOverrides);
+  const setProviderPathOverride = useAppStore((s) => s.setProviderPathOverride);
   const refreshProviderVersions = useAppStore((s) => s.refreshProviderVersions);
   const [scanning, setScanning] = useState(false);
 
@@ -69,6 +72,8 @@ export function ProvidersPane() {
               onToggle={() => setProviderEnabled(p.id, providerFlags[p.id] === false)}
               liveVersion={providerVersions[p.id]}
               livePath={providerPaths[p.id]}
+              override={providerPathOverrides[p.id]}
+              onSavePath={(path) => setProviderPathOverride(p.id, path)}
             />
           ))}
         </div>
@@ -84,16 +89,25 @@ function ProviderRow({
   onToggle,
   liveVersion,
   livePath,
+  override,
+  onSavePath,
 }: {
   provider: Provider;
   enabled: boolean;
   onToggle: () => void;
   liveVersion?: string;
   livePath?: string;
+  override?: string;
+  onSavePath: (path: string | null) => Promise<void>;
 }) {
   const [open, setOpen] = useState(false);
   const d = PROVIDER_DETAIL[provider.id];
   if (!d) return null;
+
+  // What the binary row shows: an explicit override wins, then the live probe,
+  // then the hardcoded default. The override leads even when not yet resolved
+  // so a custom (and possibly broken) path stays visible to the user.
+  const effectivePath = override ?? livePath ?? d.path;
 
   return (
     <div className={`set-prov ${enabled ? "" : "off"} ${open ? "open" : ""}`}>
@@ -105,7 +119,7 @@ function ProviderRow({
             {provider.label}
             <span className="set-prov-ver mono">{liveVersion ?? provider.version}</span>
           </div>
-          <div className="set-prov-sub mono">{livePath ?? d.path}</div>
+          <div className="set-prov-sub mono">{effectivePath}</div>
         </div>
         <button
           className={`set-prov-chev ${open ? "open" : ""}`}
@@ -119,7 +133,13 @@ function ProviderRow({
 
       {open && (
         <div className="set-prov-detail">
-          <ProvDetailRow k="Binary" v={livePath ?? d.path} mono />
+          <BinaryPathRow
+            providerLabel={provider.label}
+            effectivePath={effectivePath}
+            override={override}
+            versionDetected={!!liveVersion}
+            onSave={onSavePath}
+          />
           <ProvDetailRow k="Models" v={d.models} />
           <div className="set-prov-detail-actions">
             <button className="btn-t ghost sm-t">View logs</button>

--- a/src/components/SettingsScreen/ProvidersPane.tsx
+++ b/src/components/SettingsScreen/ProvidersPane.tsx
@@ -137,7 +137,7 @@ function ProviderRow({
             providerLabel={provider.label}
             effectivePath={effectivePath}
             override={override}
-            versionDetected={!!liveVersion}
+            resolved={!!livePath}
             onSave={onSavePath}
           />
           <ProvDetailRow k="Models" v={d.models} />

--- a/src/store.provider-overrides.test.ts
+++ b/src/store.provider-overrides.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { parseProviderPathOverrides } from "./store";
+
+describe("parseProviderPathOverrides", () => {
+  it("extracts agent_bin_path_<id> rows and strips the prefix", () => {
+    const overrides = parseProviderPathOverrides({
+      theme: "dark",
+      agent_bin_path_claude: "/opt/homebrew/bin/claude",
+      agent_bin_path_cursor: "~/bin/cursor-agent",
+      providers: "{}",
+    });
+    expect(overrides).toEqual({
+      claude: "/opt/homebrew/bin/claude",
+      cursor: "~/bin/cursor-agent",
+    });
+  });
+
+  it("drops blank values (a cleared override) and ignores unrelated keys", () => {
+    const overrides = parseProviderPathOverrides({
+      agent_bin_path_codex: "   ",
+      agent_bin_path_pi: "",
+      density: "comfortable",
+    });
+    expect(overrides).toEqual({});
+  });
+
+  it("returns an empty map when there are no overrides", () => {
+    expect(parseProviderPathOverrides({})).toEqual({});
+  });
+});

--- a/src/store.ts
+++ b/src/store.ts
@@ -213,6 +213,24 @@ function parseProviderFlags(raw: string | undefined): Record<string, boolean> {
   }
 }
 
+/** Settings-key prefix for per-agent custom binary paths. Must match the
+ *  backend's `database::AGENT_BIN_PREFIX` so both read/write the same rows. */
+const AGENT_BIN_PREFIX = "agent_bin_path_";
+
+/** Pull the `agent_bin_path_<id>` rows out of the flat settings map into an
+ *  id → path override map (blank values dropped, matching the backend). */
+export function parseProviderPathOverrides(
+  s: Record<string, string>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(s)) {
+    if (key.startsWith(AGENT_BIN_PREFIX) && value.trim()) {
+      out[key.slice(AGENT_BIN_PREFIX.length)] = value;
+    }
+  }
+  return out;
+}
+
 interface AppState {
   workspace: Workspace | null;
   selectedAgentId: string | null;
@@ -359,6 +377,10 @@ interface AppState {
   providerVersions: Record<string, string>;
   /** Resolved binary paths keyed by provider id, from the version probe. */
   providerPaths: Record<string, string>;
+  /** User-set custom binary paths keyed by provider id (the raw value entered,
+   *  before resolution). Absent = auto-detect. This is the source of truth for
+   *  the "Custom" tag in the providers settings, independent of the probe. */
+  providerPathOverrides: Record<string, string>;
   /** Per-model metadata (context window, reasoning) keyed by bare model id —
    *  the `byId` view of the hybrid catalog. Seeded from the localStorage cache
    *  on init, rebuilt from agent discovery + models.dev when stale (24h). */
@@ -473,6 +495,9 @@ interface AppState {
   /** Re-probe installed provider CLIs for versions + binary paths. Runs once
    *  on init and again when the user re-scans from the Providers settings. */
   refreshProviderVersions: () => Promise<void>;
+  /** Set (path) or clear (null) a provider's custom binary path. Persists the
+   *  override, updates local state, and re-probes so the version/path refresh. */
+  setProviderPathOverride: (id: string, path: string | null) => Promise<void>;
   /** Rebuild the model catalog (agent discovery + models.dev) when the cache is
    *  stale (24h). Runs once on init; non-fatal on failure (keeps cached data). */
   refreshModelCatalog: () => Promise<void>;
@@ -768,6 +793,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   providerFlags: {},
   providerVersions: {},
   providerPaths: {},
+  providerPathOverrides: {},
   modelCatalog: cachedCatalog.byId,
   modelsByAgent: cachedCatalog.byAgent,
   viewMode: "custom" as WorkspaceView,
@@ -787,6 +813,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         showLandmarks: s.showLandmarks !== "false",
         features: parseFeatures(s.features),
         providerFlags: parseProviderFlags(s.providers),
+        providerPathOverrides: parseProviderPathOverrides(s),
         viewMode: (s.viewMode as WorkspaceView) || "custom",
         gitCommitAction: isCommitAction(s.gitCommitAction) ? s.gitCommitAction : "agent-commit-pr",
         onboardingComplete: s.onboardingComplete === "true",
@@ -1865,6 +1892,20 @@ export const useAppStore = create<AppState>((set, get) => ({
     } catch {
       // Non-fatal — UI falls back to hardcoded versions.
     }
+  },
+  setProviderPathOverride: async (id, path) => {
+    const trimmed = path?.trim() || null;
+    // The backend command persists the setting and refreshes its resolution
+    // registry in one call; we mirror the change into local state so the UI
+    // updates immediately, then re-probe to pick up the new version/path.
+    await api.setAgentBinOverride(id, trimmed);
+    set((s) => {
+      const next = { ...s.providerPathOverrides };
+      if (trimmed) next[id] = trimmed;
+      else delete next[id];
+      return { providerPathOverrides: next };
+    });
+    await get().refreshProviderVersions();
   },
   refreshModelCatalog: async () => {
     // Cache holds for 24h; the init seed already reflects it when fresh.


### PR DESCRIPTION
Lets users point any agent (Claude, Codex, Cursor, …) at a custom CLI binary through an inline edit-in-place control on the Binary row in Providers settings — read-only by default, with a pencil that opens a validated text input. Saving runs a new `validate_agent_bin` command so a non-executable path is rejected inline before it's persisted, and a set override shows a "Custom" tag with a "Reset to auto" link. Overrides persist as `agent_bin_path_<id>` rows in the existing settings table (no migration) and seed a process-global registry that `resolve_agent_bin` consults before PATH discovery, so an override wins unconditionally and errors clearly when missing rather than silently falling back to another binary (`git`/`gh` resolution is untouched). Verified: 270 Rust lib tests and 295 frontend tests pass (including new coverage for override resolution, `~` expansion, the settings loader, and override parsing), `tsc` is clean, and the production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)