### PR TITLE
Make agent failures visible and recoverable

### DIFF
--- a/src-tauri/src/gh.rs
+++ b/src-tauri/src/gh.rs
@@ -509,11 +509,9 @@ pub async fn pr_create(worktree: &Path, title: &str, body: &str, base: &str) -> 
         args.extend_from_slice(&["--title", title, "--body", body]);
     }
 
-    let out = gh_command()
-        .current_dir(worktree)
-        .args(&args)
-        .output()
-        .await?;
+    let mut cmd = gh_command();
+    cmd.current_dir(worktree).args(&args);
+    let out = crate::git::output_timed(&mut cmd, "gh pr create").await?;
 
     if !out.status.success() {
         let stderr = String::from_utf8_lossy(&out.stderr);
@@ -540,11 +538,9 @@ pub async fn pr_create(worktree: &Path, title: &str, body: &str, base: &str) -> 
 /// Merge the open PR for the branch checked out in `worktree` using a merge
 /// commit and the `--auto` flag (merges as soon as all checks pass).
 pub async fn pr_merge(worktree: &Path) -> Result<()> {
-    let out = gh_command()
-        .current_dir(worktree)
-        .args(["pr", "merge", "--merge", "--auto"])
-        .output()
-        .await?;
+    let mut cmd = gh_command();
+    cmd.current_dir(worktree).args(["pr", "merge", "--merge", "--auto"]);
+    let out = crate::git::output_timed(&mut cmd, "gh pr merge").await?;
 
     if !out.status.success() {
         return Err(Error::Gh(

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -35,7 +35,10 @@ pub(crate) async fn output_timed(cmd: &mut Command, what: &str) -> Result<std::p
     tokio::time::timeout(NET_TIMEOUT, cmd.output())
         .await
         .map_err(|_| {
-            Error::Git(format!(
+            // `Error::Other` (not `Error::Git`) — `what` already names the op
+            // (e.g. "gh pr create"), so the "git command failed:" prefix would
+            // mislabel non-git callers.
+            Error::Other(format!(
                 "{what} timed out after {}s — check your network connection",
                 NET_TIMEOUT.as_secs()
             ))

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -17,6 +17,32 @@ use crate::error::{Error, Result};
 /// inside the spawn budget; on timeout we fall back to local HEAD.
 const FETCH_TIMEOUT: Duration = Duration::from_secs(8);
 
+/// Hard cap on quick network-bound ops (push/pull and the gh PR actions) so a
+/// dropped connection surfaces as a finite error the UI can show, instead of
+/// hanging a spinner for the OS keep-alive window. Deliberately generous —
+/// these transfer little data, so 60s only ever trips on a stalled connection,
+/// not on slow-but-progressing work. NOT used for `clone` (a large repo can
+/// legitimately take minutes); clone's retry wedge is handled by self-heal in
+/// `new_project::clone` instead.
+const NET_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Run a network-bound command under `NET_TIMEOUT`, killing the process (and
+/// its SSH/HTTP child) on expiry via `kill_on_drop` rather than orphaning it.
+/// `what` names the op for the timeout message. Mirrors `fetch_fork_point`'s
+/// inline pattern; shared so push/pull and the gh PR ops stay consistent.
+pub(crate) async fn output_timed(cmd: &mut Command, what: &str) -> Result<std::process::Output> {
+    cmd.kill_on_drop(true);
+    tokio::time::timeout(NET_TIMEOUT, cmd.output())
+        .await
+        .map_err(|_| {
+            Error::Git(format!(
+                "{what} timed out after {}s — check your network connection",
+                NET_TIMEOUT.as_secs()
+            ))
+        })?
+        .map_err(Error::from)
+}
+
 /// Create a worktree on detached HEAD (no branch yet). Used by the
 /// instant-spawn flow so we don't pollute `git branch` for agents
 /// that may never receive a user message. The branch is created
@@ -495,11 +521,9 @@ pub async fn worktree_add_branch(
 /// push), otherwise `"pushed"`. Lets the UI confirm the outcome instead of
 /// silently doing nothing when there was nothing to send.
 pub async fn push(worktree: &Path, branch: &str) -> Result<String> {
-    let out = Command::new("git")
-        .current_dir(worktree)
-        .args(["push", "-u", "origin", branch])
-        .output()
-        .await?;
+    let mut cmd = Command::new("git");
+    cmd.current_dir(worktree).args(["push", "-u", "origin", branch]);
+    let out = output_timed(&mut cmd, "git push").await?;
     if !out.status.success() {
         return Err(Error::Git(format!(
             "push failed: {}",
@@ -522,11 +546,9 @@ pub async fn push(worktree: &Path, branch: &str) -> Result<String> {
 /// Pull latest from the tracking remote branch.
 /// Requires `push -u` to have been called first to establish an upstream.
 pub async fn pull(worktree: &Path) -> Result<()> {
-    let out = Command::new("git")
-        .current_dir(worktree)
-        .args(["pull"])
-        .output()
-        .await?;
+    let mut cmd = Command::new("git");
+    cmd.current_dir(worktree).args(["pull"]);
+    let out = output_timed(&mut cmd, "git pull").await?;
     if !out.status.success() {
         return Err(Error::Git(format!(
             "pull failed: {}",

--- a/src-tauri/src/new_project.rs
+++ b/src-tauri/src/new_project.rs
@@ -82,7 +82,14 @@ fn resolve_target(dest_parent: &Path, name: &str) -> Result<PathBuf> {
 pub async fn clone(spec: &str, dest_parent: &Path) -> Result<PathBuf> {
     let name = repo_name_from_spec(spec)?;
     let target = resolve_target(dest_parent, &name)?;
-    gh::repo_clone(spec, &target).await?;
+    // `gh` creates `target` and clones into it; if the clone fails partway
+    // (e.g. a dropped connection) the partial dir would otherwise make
+    // `resolve_target` reject every retry with "a folder already exists".
+    // Remove it on failure — same self-heal as `create`.
+    if let Err(e) = gh::repo_clone(spec, &target).await {
+        let _ = std::fs::remove_dir_all(&target);
+        return Err(e);
+    }
     Ok(target)
 }
 

--- a/src-tauri/src/new_project.rs
+++ b/src-tauri/src/new_project.rs
@@ -87,7 +87,9 @@ pub async fn clone(spec: &str, dest_parent: &Path) -> Result<PathBuf> {
     // `resolve_target` reject every retry with "a folder already exists".
     // Remove it on failure — same self-heal as `create`.
     if let Err(e) = gh::repo_clone(spec, &target).await {
-        let _ = std::fs::remove_dir_all(&target);
+        // Async remove: a large partial clone could otherwise block the
+        // executor thread while tearing down hundreds of files.
+        let _ = tokio::fs::remove_dir_all(&target).await;
         return Err(e);
     }
     Ok(target)

--- a/src/app.css
+++ b/src/app.css
@@ -2896,6 +2896,33 @@ button { cursor: default; }
   color: var(--fg-0);
 }
 
+/* Inline per-agent crash notice under the workspace header (status === error).
+   Same danger tint as .error-banner, but inline (not a floating toast). */
+.crash-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 8px 12px 0;
+  padding: 8px 10px 8px 12px;
+  background: color-mix(in srgb, var(--danger), var(--bg-0) 86%);
+  border: 1px solid color-mix(in srgb, var(--danger), var(--bg-0) 70%);
+  border-radius: var(--r-md);
+  font-size: 12.5px;
+}
+.crash-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; flex: 1; }
+.crash-title { color: var(--danger); font-weight: 600; }
+.crash-detail {
+  color: var(--fg-2);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11.5px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  /* Crash reasons can be long; clamp so the banner doesn't dominate. */
+  max-height: 4.5em;
+  overflow: auto;
+}
+.crash-banner .btn-t { flex-shrink: 0; }
+
 /* update-ready toast — bottom-right, offers restart now / skip */
 .update-toast {
   position: fixed;

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -51,11 +51,37 @@ export function Workspace() {
   return (
     <div className="pane center fade-in" key={agent.id}>
       <WorkspaceHeader agent={agent} />
+      {agent.status === "error" && <CrashBanner agent={agent} />}
       {agent.view === "native" ? (
         <NativeBody agent={agent} />
       ) : (
         <ChatView agent={agent} />
       )}
+    </div>
+  );
+}
+
+/** Shown when an agent's process exited with an error. Surfaces the crash
+ *  reason (otherwise only a red dot in the sidebar) and a Resume action —
+ *  both already captured on the record / available in the store, just never
+ *  rendered. Sits under the header so the transcript leading up to the crash
+ *  stays visible. */
+function CrashBanner({ agent }: { agent: AgentRecord }) {
+  const resume = useAppStore((s) => s.resume);
+  return (
+    <div className="crash-banner" role="alert">
+      <div className="crash-text">
+        <span className="crash-title">Agent stopped unexpectedly</span>
+        {agent.last_error && <span className="crash-detail">{agent.last_error}</span>}
+      </div>
+      <button
+        type="button"
+        className="btn-t outline"
+        onClick={() => void resume(agent.id)}
+      >
+        <Icon name="play" size={12} />
+        Resume
+      </button>
     </div>
   );
 }

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { EMPTY_AGENTS, useAppStore } from "../../store";
 import { Icon } from "../Icon";
 import { IconButton } from "../ui/IconButton";
@@ -68,6 +69,12 @@ export function Workspace() {
  *  stays visible. */
 function CrashBanner({ agent }: { agent: AgentRecord }) {
   const resume = useAppStore((s) => s.resume);
+  // Guard against a double-click firing two concurrent resumes: status stays
+  // "error" until the backend's status event lands, so the banner (and button)
+  // linger through that window. `resume` catches internally, so on success the
+  // banner unmounts and on failure we re-enable. (Harmless no-op if it unmounts
+  // before `finally` runs.)
+  const [resuming, setResuming] = useState(false);
   return (
     <div className="crash-banner" role="alert">
       <div className="crash-text">
@@ -77,10 +84,14 @@ function CrashBanner({ agent }: { agent: AgentRecord }) {
       <button
         type="button"
         className="btn-t outline"
-        onClick={() => void resume(agent.id)}
+        disabled={resuming}
+        onClick={() => {
+          setResuming(true);
+          void resume(agent.id).finally(() => setResuming(false));
+        }}
       >
         <Icon name="play" size={12} />
-        Resume
+        {resuming ? "Resuming…" : "Resume"}
       </button>
     </div>
   );


### PR DESCRIPTION
Follow-up to the error-reporting/Sentry work (now on `main`): that captured failures for *us*; this surfaces them to the *user* and stops two ways the UI could wedge.

- **Crash banner + Resume.** When an agent's process exits with an error, the captured `last_error` now renders in a banner under the workspace header with a **Resume** button — previously a crash showed only a red dot in the sidebar with no reason and no recovery. The error text and the `resume` action already existed; they just weren't surfaced. The transcript leading up to the crash stays visible.
- **Network timeouts.** The quick user-initiated network ops (`git push`/`pull`, `gh pr create`/`merge`) now run under a 60s timeout that kills the hung process, so a dropped connection becomes a finite, visible error instead of an infinite spinner. Mirrors the existing `fetch_fork_point` pattern via one shared `output_timed` helper.
- **Clone self-heal.** `clone()` removes the partial target directory when a clone fails partway, so a retry isn't rejected with "a folder already exists" — the same cleanup `create()` already does.

**Scoped out deliberately (kept lean):** no cancel UI (the timeout already converts a hang into a visible error); `clone` itself isn't timed out (a large repo legitimately takes minutes — its retry wedge is handled by the self-heal above); no speculative worktree pruning (worktree paths are unique UUIDs, so they don't collide).

Verified: tsc clean, 295 frontend tests, 271 Rust tests, no new clippy warnings. (The crash banner is a conditional render verified by the typechecker; the timeout reuses an existing proven pattern — neither was runtime-smoked since forcing a crash / hung connection headlessly isn't practical.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)