### PR TITLE
First-run readiness check: detect agent CLIs + git

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -1477,6 +1477,27 @@ pub fn validate_bin(path: &str) -> BinValidation {
     BinValidation { executable, version }
 }
 
+#[derive(serde::Serialize)]
+pub struct ToolStatus {
+    pub installed: bool,
+    pub version: Option<String>,
+    pub path: Option<String>,
+}
+
+/// Resolve a plain CLI on PATH (e.g. `git`) and probe its `--version`. Used by
+/// the first-run readiness check for required tools that aren't agent
+/// providers. Binary presence only — no auth/config check.
+pub fn check_cli(name: &str) -> ToolStatus {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
+    let path = crate::bin_resolve::resolve_bin(name, &home);
+    let version = path.as_deref().and_then(probe_version);
+    ToolStatus {
+        installed: path.is_some(),
+        version,
+        path,
+    }
+}
+
 /// Probe every known provider in parallel and return their resolved path +
 /// version string. Missing/uninstalled providers return `None` for both fields;
 /// the frontend falls back to the hardcoded defaults in that case.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6,7 +6,7 @@ use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use tauri::{AppHandle, State};
 
-use crate::agent::{BinValidation, ProviderProbe};
+use crate::agent::{BinValidation, ProviderProbe, ToolStatus};
 use crate::error::{Error, Result};
 use crate::gh::{self, GhRepoSummary, GhStatus, PrState};
 use crate::git;
@@ -1134,6 +1134,19 @@ pub async fn copy_worktree_file(
 #[tauri::command]
 pub async fn probe_provider_versions() -> Vec<ProviderProbe> {
     crate::agent::probe_all_providers().await
+}
+
+/// Resolve a plain required CLI (e.g. `git`) and probe its `--version`. Drives
+/// the first-run readiness check. Binary presence only — no auth check.
+#[tauri::command]
+pub async fn check_cli(name: String) -> ToolStatus {
+    tokio::task::spawn_blocking(move || crate::agent::check_cli(&name))
+        .await
+        .unwrap_or(ToolStatus {
+            installed: false,
+            version: None,
+            path: None,
+        })
 }
 
 /// Validate a candidate custom agent binary path: is it an executable file,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -394,6 +394,7 @@ pub fn run() {
             commands::create_worktree_dir,
             commands::copy_worktree_file,
             commands::probe_provider_versions,
+            commands::check_cli,
             commands::validate_agent_bin,
             commands::discover_supported_models,
             commands::reveal_logs,

--- a/src/api.ts
+++ b/src/api.ts
@@ -313,6 +313,13 @@ export interface ProviderProbe {
   path: string | null;
 }
 
+/** Presence of a required non-agent CLI (e.g. `git`) for the readiness check. */
+export interface ToolStatus {
+  installed: boolean;
+  version: string | null;
+  path: string | null;
+}
+
 /** Result of pre-flighting a custom agent binary path before saving it as an
  *  override. `executable` is whether the path is a runnable file; `version` is
  *  what `<path> --version` reported (null if it didn't run or didn't parse). */
@@ -501,6 +508,8 @@ export const api = {
     invoke<void>("copy_worktree_file", { agentId, from, to }),
   probeProviderVersions: () =>
     invoke<ProviderProbe[]>("probe_provider_versions"),
+  /** Resolve a required non-agent CLI (e.g. "git") and probe its version. */
+  checkCli: (name: string) => invoke<ToolStatus>("check_cli", { name }),
   /** Check a candidate custom binary path before saving it as an override. */
   validateAgentBin: (path: string) =>
     invoke<BinValidation>("validate_agent_bin", { path }),

--- a/src/app.css
+++ b/src/app.css
@@ -4195,3 +4195,29 @@ button { cursor: default; }
   transition: background .12s;
 }
 .side-foot .side-user:hover { background: var(--hover); }
+
+/* Provider readiness check — onboarding finale + Settings → Providers. */
+.readiness { display: flex; flex-direction: column; }
+.rdy-row { display: flex; gap: 10px; padding: 8px 2px; align-items: flex-start; }
+.rdy-icon { width: 20px; display: flex; justify-content: center; padding-top: 1px; color: var(--fg-2); flex-shrink: 0; }
+.rdy-main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 5px; }
+.rdy-line { display: flex; align-items: center; gap: 8px; }
+.rdy-name { font-weight: 600; font-size: 12.5px; color: var(--fg-0); }
+.rdy-status { color: var(--fg-2); font-size: 12px; }
+.rdy-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
+.rdy-dot.ok { background: var(--success); }
+.rdy-dot.warn { background: var(--warn); }
+.rdy-dot.bad { background: var(--danger); }
+.rdy-dot.checking { background: var(--fg-3); }
+.rdy-fix { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; }
+.rdy-cmd {
+  display: inline-flex; align-items: center; gap: 8px; min-width: 0; max-width: 100%;
+  padding: 4px 8px; border-radius: var(--r-sm);
+  background: var(--bg-1); border: 1px solid var(--bg-2); color: var(--fg-1);
+}
+.rdy-cmd code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11.5px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rdy-cmd:hover { border-color: var(--fg-3); }
+.rdy-docs { display: inline-flex; align-items: center; gap: 4px; color: var(--accent); font-size: 11.5px; }
+.rdy-hint { color: var(--fg-3); font-size: 11.5px; }
+.rdy-foot { display: flex; align-items: center; justify-content: space-between; margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--bg-2); }
+.rdy-count { color: var(--fg-2); font-size: 12px; }

--- a/src/components/Composer/ModelPicker.tsx
+++ b/src/components/Composer/ModelPicker.tsx
@@ -34,6 +34,8 @@ export function ModelPicker({ provider, model, onChange, locked = false }: Props
   const [focusProvider, setFocusProvider] = useState(provider);
   const providerFlags = useAppStore((s) => s.providerFlags);
   const providerVersions = useAppStore((s) => s.providerVersions);
+  const providerPaths = useAppStore((s) => s.providerPaths);
+  const providersProbed = useAppStore((s) => s.providersProbed);
   const modelsByAgent = useAppStore((s) => s.modelsByAgent);
 
   const selected = PROVIDERS.find((p) => p.id === provider) ?? PROVIDERS[0];
@@ -90,18 +92,24 @@ export function ModelPicker({ provider, model, onChange, locked = false }: Props
               <div className="model-agent-list">
                 {enabled.map((p) => {
                   const wired = hasAdapter(p.id);
+                  // Treat "not probed yet" as installed so agents don't flash
+                  // as missing on boot; only gate once the probe has resolved.
+                  const installed = !providersProbed || !!providerPaths[p.id];
+                  const usable = wired && installed;
+                  const missing = wired && providersProbed && !installed;
                   return (
                     <button
                       key={p.id}
                       type="button"
                       className={`model-agent ${p.id === focusProvider ? "active" : ""}`}
-                      disabled={!wired}
-                      onClick={() => wired && setFocusProvider(p.id)}
+                      disabled={!usable}
+                      title={missing ? "Not installed — see Settings › Providers" : undefined}
+                      onClick={() => usable && setFocusProvider(p.id)}
                     >
                       <ProviderIcon slug={p.id} short={p.short} hue={p.hue} size={18} />
                       <span className="model-agent-text">
                         <span>{p.label}</span>
-                        <span>{providerVersions[p.id] ?? p.version}</span>
+                        <span>{missing ? "Not installed" : providerVersions[p.id] ?? p.version}</span>
                       </span>
                       {p.id === provider && <Icon name="check" size={12} />}
                     </button>

--- a/src/components/Composer/ModelPicker.tsx
+++ b/src/components/Composer/ModelPicker.tsx
@@ -92,8 +92,10 @@ export function ModelPicker({ provider, model, onChange, locked = false }: Props
               <div className="model-agent-list">
                 {enabled.map((p) => {
                   const wired = hasAdapter(p.id);
-                  // Treat "not probed yet" as installed so agents don't flash
-                  // as missing on boot; only gate once the probe has resolved.
+                  // Fail open: only gate on the path once a probe has actually
+                  // succeeded (`providersProbed`). While probing, or if the
+                  // probe failed, treat as installed so a transient detection
+                  // error never disables an agent the user really has.
                   const installed = !providersProbed || !!providerPaths[p.id];
                   const usable = wired && installed;
                   const missing = wired && providersProbed && !installed;

--- a/src/components/Onboarding/onboarding.css
+++ b/src/components/Onboarding/onboarding.css
@@ -712,3 +712,17 @@
   padding: 6px 10px;
 }
 .ob-cancel:hover { opacity: .9; }
+
+/* Finale doubles as the setup/readiness screen — tighten the hero so the
+   readiness list fits without the step scrolling on common heights. */
+.ob-ignite-setup { max-width: 560px; }
+.ob-ignite-setup .seal { width: 64px; height: 64px; margin-bottom: 18px; }
+.ob-ignite-setup .seal svg { width: 34px; height: 34px; }
+.ob-ignite-setup .ob-display { font-size: 38px; }
+.ob-ignite-setup .ob-lede { margin-top: 14px; max-width: 460px; }
+.ob-ignite-setup .ob-cta { margin-top: 24px; }
+.ob-readiness {
+  width: 100%; max-width: 480px; margin: 24px auto 0; text-align: left;
+  background: var(--bg-1); border: 1px solid var(--bg-2);
+  border-radius: var(--r-md); padding: 8px 14px 14px;
+}

--- a/src/components/Onboarding/steps.tsx
+++ b/src/components/Onboarding/steps.tsx
@@ -5,6 +5,8 @@
 import type { CSSProperties } from "react";
 import { open as openExternal } from "@tauri-apps/plugin-shell";
 import { Icon } from "../Icon";
+import { useAppStore } from "../../store";
+import { ProviderReadiness } from "../ProviderReadiness";
 import type { BeatDef } from "./beats";
 
 const TERMS_URL = "https://quorum.fwdai.org/terms";
@@ -157,22 +159,37 @@ export function Beat({ beat }: { beat: BeatDef }) {
   );
 }
 
-// ── Step · finale / handoff ─────────────────────────────────────────
+// ── Step · finale / handoff + readiness ─────────────────────────────
+// The closer doubles as the real setup screen: signing in only connected the
+// user's Quorum identity — agents are their own CLIs, so this is where we show
+// what's actually installed. Non-blocking: "Enter Quorum" is always enabled.
 export function IgniteStep({ onEnter }: { onEnter: () => void }) {
+  const providerPaths = useAppStore((s) => s.providerPaths);
+  const providersProbed = useAppStore((s) => s.providersProbed);
+  const hasAgent = Object.keys(providerPaths).length > 0;
   return (
     <div className="ob-step">
-      <div className="ob-ignite">
+      <div className="ob-ignite ob-ignite-setup">
         <div className="seal ob-reveal" style={{ "--d": ".05s" } as CSSProperties}>
           <PeaksMark />
         </div>
-        <h2 className="ob-display ob-reveal" style={{ "--d": ".2s" } as CSSProperties}>
-          You're <em>all set.</em>
+        <h2 className="ob-display ob-reveal" style={{ "--d": ".16s" } as CSSProperties}>
+          {!providersProbed ? (
+            <>Almost <em>there.</em></>
+          ) : hasAgent ? (
+            <>You're <em>all set.</em></>
+          ) : (
+            <>One <em>last step.</em></>
+          )}
         </h2>
-        <p className="ob-lede ob-reveal" style={{ "--d": ".34s" } as CSSProperties}>
-          Add your first repository from the sidebar and Quorum spins up an isolated
-          worktree for every agent you direct.
+        <p className="ob-lede ob-reveal" style={{ "--d": ".28s" } as CSSProperties}>
+          Signing in connected your Quorum identity. To run agents you bring your
+          own CLIs — here's what's on your machine.
         </p>
-        <button className="ob-cta ob-reveal" style={{ "--d": ".58s" } as CSSProperties} onClick={onEnter}>
+        <div className="ob-readiness ob-reveal" style={{ "--d": ".4s" } as CSSProperties}>
+          <ProviderReadiness />
+        </div>
+        <button className="ob-cta ob-reveal" style={{ "--d": ".56s" } as CSSProperties} onClick={onEnter}>
           Enter Quorum
           <Icon name="arrowR" />
         </button>

--- a/src/components/ProviderReadiness/index.tsx
+++ b/src/components/ProviderReadiness/index.tsx
@@ -93,7 +93,9 @@ export function ProviderReadiness() {
 
   const [git, setGit] = useState<ToolStatus | null>(null);
   const [gh, setGh] = useState<GhStatus | null>(null);
-  const [checking, setChecking] = useState(false);
+  // Start in the checking state — we always probe on mount, so this avoids a
+  // flash of "couldn't detect" before the effect runs.
+  const [checking, setChecking] = useState(true);
 
   const recheck = useCallback(() => {
     setChecking(true);
@@ -113,15 +115,21 @@ export function ProviderReadiness() {
   const agents = PROVIDERS.filter((p) => hasAdapter(p.id) && providerFlags[p.id] !== false);
   const detected = agents.filter((p) => !!providerPaths[p.id]).length;
 
-  const gitState: RowState = git ? (git.installed ? "ok" : "bad") : "checking";
-  const ghState: RowState = gh ? (gh.installed && gh.authenticated ? "ok" : "warn") : "checking";
-  const ghFix = !gh
-    ? undefined
-    : !gh.installed
-      ? "brew install gh"
-      : !gh.authenticated
-        ? "gh auth login"
-        : undefined;
+  // git/gh come from local state (null until their probe resolves); agents come
+  // from the store's `providersProbed` (= a probe succeeded). In all three, a
+  // probe that finished without a result is "couldn't detect" (warn), never a
+  // false "not installed".
+  const gitState: RowState = git ? (git.installed ? "ok" : "bad") : checking ? "checking" : "warn";
+  const ghState: RowState = gh
+    ? gh.installed && gh.authenticated
+      ? "ok"
+      : "warn"
+    : checking
+      ? "checking"
+      : "warn";
+  // gh sign-in is universal; install is not — rely on the cross-platform docs
+  // link rather than a Homebrew-only `brew install gh`.
+  const ghFix = gh && gh.installed && !gh.authenticated ? "gh auth login" : undefined;
 
   return (
     <div className="readiness">
@@ -130,20 +138,28 @@ export function ProviderReadiness() {
         name="Git"
         state={gitState}
         statusText={
-          gitState === "checking"
-            ? "Checking…"
-            : git?.installed
+          git
+            ? git.installed
               ? git.version ?? "Installed"
               : "Not found — required to run any agent"
+            : checking
+              ? "Checking…"
+              : "Couldn't check"
         }
-        fix="xcode-select --install"
+        fix={gitState === "bad" ? "xcode-select --install" : undefined}
         docs="https://git-scm.com/downloads"
       />
 
       {agents.map((p) => {
         const d = PROVIDER_DETAIL[p.id];
         const path = providerPaths[p.id];
-        const state: RowState = !providersProbed ? "checking" : path ? "ok" : "bad";
+        const state: RowState = checking
+          ? "checking"
+          : providersProbed
+            ? path
+              ? "ok"
+              : "bad"
+            : "warn";
         return (
           <Row
             key={p.id}
@@ -153,11 +169,15 @@ export function ProviderReadiness() {
             statusText={
               state === "checking"
                 ? "Checking…"
-                : path
-                  ? providerVersions[p.id] ?? "Installed"
-                  : "Not installed"
+                : state === "warn"
+                  ? "Couldn't detect"
+                  : path
+                    ? providerVersions[p.id] ?? "Installed"
+                    : "Not installed"
             }
-            fix={d.install}
+            // Only offer the install command when we know it's missing, not
+            // when detection itself failed.
+            fix={state === "bad" ? d.install : undefined}
             docs={d.docs}
             hint={d.signIn}
           />
@@ -169,21 +189,27 @@ export function ProviderReadiness() {
         name="GitHub CLI · optional"
         state={ghState}
         statusText={
-          !gh
-            ? "Checking…"
-            : !gh.installed
+          gh
+            ? !gh.installed
               ? "Not found — needed for clone & PRs"
               : !gh.authenticated
                 ? "Installed — not signed in"
                 : `Signed in${gh.login ? ` as ${gh.login}` : ""}`
+            : checking
+              ? "Checking…"
+              : "Couldn't check"
         }
         fix={ghFix}
-        docs={gh && !gh.installed ? "https://cli.github.com" : undefined}
+        docs={!gh?.installed ? "https://cli.github.com" : undefined}
       />
 
       <div className="rdy-foot">
         <span className="rdy-count">
-          {detected} of {agents.length} agents detected
+          {checking
+            ? "Checking…"
+            : providersProbed
+              ? `${detected} of ${agents.length} agents detected`
+              : "Couldn't detect agents"}
         </span>
         <button type="button" className="btn-t outline" onClick={recheck} disabled={checking}>
           <Icon name="refresh" size={12} />

--- a/src/components/ProviderReadiness/index.tsx
+++ b/src/components/ProviderReadiness/index.tsx
@@ -1,0 +1,195 @@
+// First-run / settings readiness check. Reusable surface that shows whether
+// the tools needed to actually run agents are present on this machine — git
+// (required), each wired agent CLI, and the GitHub CLI (optional, for
+// clone/PRs) — with copy-paste fixes. Used in the onboarding finale and in
+// Settings → Providers.
+//
+// We detect *binary presence* (and gh auth, which we can read), not agent
+// auth (varies per CLI), so installed rows still nudge the user to sign in.
+
+import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { open as openExternal } from "@tauri-apps/plugin-shell";
+import { useAppStore } from "../../store";
+import { api, type GhStatus, type ToolStatus } from "../../api";
+import { PROVIDERS } from "../../data/providers";
+import { PROVIDER_DETAIL } from "../../data/providerDetail";
+import { hasAdapter } from "../../adapters";
+import { ProviderIcon } from "../ProviderIcon";
+import { Icon } from "../Icon";
+
+type RowState = "ok" | "warn" | "bad" | "checking";
+
+function CopyCmd({ cmd }: { cmd: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      className="rdy-cmd"
+      title="Copy command"
+      onClick={() => {
+        void navigator.clipboard.writeText(cmd);
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 1200);
+      }}
+    >
+      <code>{cmd}</code>
+      <Icon name={copied ? "check" : "copy"} size={11} />
+    </button>
+  );
+}
+
+function Row({
+  icon,
+  name,
+  state,
+  statusText,
+  fix,
+  docs,
+  hint,
+}: {
+  icon: ReactNode;
+  name: string;
+  state: RowState;
+  statusText: string;
+  /** Copy-paste command that resolves the issue (install or sign-in). */
+  fix?: string;
+  docs?: string;
+  /** Shown when installed — e.g. a sign-in nudge we can't verify. */
+  hint?: string;
+}) {
+  const needsFix = state === "bad" || state === "warn";
+  return (
+    <div className="rdy-row">
+      <span className="rdy-icon">{icon}</span>
+      <div className="rdy-main">
+        <div className="rdy-line">
+          <span className="rdy-name">{name}</span>
+          <span className={`rdy-dot ${state}`} />
+          <span className="rdy-status">{statusText}</span>
+        </div>
+        {needsFix && (fix || docs) && (
+          <div className="rdy-fix">
+            {fix && <CopyCmd cmd={fix} />}
+            {docs && (
+              <button type="button" className="rdy-docs" onClick={() => void openExternal(docs)}>
+                Setup guide
+                <Icon name="external" size={10} />
+              </button>
+            )}
+          </div>
+        )}
+        {state === "ok" && hint && <div className="rdy-hint">{hint}</div>}
+      </div>
+    </div>
+  );
+}
+
+export function ProviderReadiness() {
+  const providerVersions = useAppStore((s) => s.providerVersions);
+  const providerPaths = useAppStore((s) => s.providerPaths);
+  const providersProbed = useAppStore((s) => s.providersProbed);
+  const refresh = useAppStore((s) => s.refreshProviderVersions);
+  const providerFlags = useAppStore((s) => s.providerFlags);
+
+  const [git, setGit] = useState<ToolStatus | null>(null);
+  const [gh, setGh] = useState<GhStatus | null>(null);
+  const [checking, setChecking] = useState(false);
+
+  const recheck = useCallback(() => {
+    setChecking(true);
+    void Promise.allSettled([
+      refresh(),
+      api.checkCli("git").then(setGit),
+      api.ghStatus().then(setGh),
+    ]).finally(() => setChecking(false));
+  }, [refresh]);
+
+  useEffect(() => {
+    recheck();
+  }, [recheck]);
+
+  // Only agents with a wired runner are worth checking; antigravity etc. are
+  // gated "coming soon" and never spawnable.
+  const agents = PROVIDERS.filter((p) => hasAdapter(p.id) && providerFlags[p.id] !== false);
+  const detected = agents.filter((p) => !!providerPaths[p.id]).length;
+
+  const gitState: RowState = git ? (git.installed ? "ok" : "bad") : "checking";
+  const ghState: RowState = gh ? (gh.installed && gh.authenticated ? "ok" : "warn") : "checking";
+  const ghFix = !gh
+    ? undefined
+    : !gh.installed
+      ? "brew install gh"
+      : !gh.authenticated
+        ? "gh auth login"
+        : undefined;
+
+  return (
+    <div className="readiness">
+      <Row
+        icon={<Icon name="branch" size={15} />}
+        name="Git"
+        state={gitState}
+        statusText={
+          gitState === "checking"
+            ? "Checking…"
+            : git?.installed
+              ? git.version ?? "Installed"
+              : "Not found — required to run any agent"
+        }
+        fix="xcode-select --install"
+        docs="https://git-scm.com/downloads"
+      />
+
+      {agents.map((p) => {
+        const d = PROVIDER_DETAIL[p.id];
+        const path = providerPaths[p.id];
+        const state: RowState = !providersProbed ? "checking" : path ? "ok" : "bad";
+        return (
+          <Row
+            key={p.id}
+            icon={<ProviderIcon slug={p.id} short={p.short} hue={p.hue} size={18} />}
+            name={p.label}
+            state={state}
+            statusText={
+              state === "checking"
+                ? "Checking…"
+                : path
+                  ? providerVersions[p.id] ?? "Installed"
+                  : "Not installed"
+            }
+            fix={d.install}
+            docs={d.docs}
+            hint={d.signIn}
+          />
+        );
+      })}
+
+      <Row
+        icon={<Icon name="github" size={15} />}
+        name="GitHub CLI · optional"
+        state={ghState}
+        statusText={
+          !gh
+            ? "Checking…"
+            : !gh.installed
+              ? "Not found — needed for clone & PRs"
+              : !gh.authenticated
+                ? "Installed — not signed in"
+                : `Signed in${gh.login ? ` as ${gh.login}` : ""}`
+        }
+        fix={ghFix}
+        docs={gh && !gh.installed ? "https://cli.github.com" : undefined}
+      />
+
+      <div className="rdy-foot">
+        <span className="rdy-count">
+          {detected} of {agents.length} agents detected
+        </span>
+        <button type="button" className="btn-t outline" onClick={recheck} disabled={checking}>
+          <Icon name="refresh" size={12} />
+          {checking ? "Checking…" : "Re-check"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SettingsScreen/ProvidersPane.tsx
+++ b/src/components/SettingsScreen/ProvidersPane.tsx
@@ -4,6 +4,7 @@ import { PROVIDERS, type Provider } from "../../data/providers";
 import { PROVIDER_DETAIL } from "../../data/providerDetail";
 import { Icon } from "../Icon";
 import { ProviderIcon } from "../ProviderIcon";
+import { ProviderReadiness } from "../ProviderReadiness";
 import { SetHead, SetGroup, SetToggle } from "./primitives";
 import { BinaryPathRow } from "./BinaryPathRow";
 
@@ -62,6 +63,10 @@ export function ProvidersPane() {
         }
       />
 
+      <SetGroup label="Readiness">
+        <ProviderReadiness />
+      </SetGroup>
+
       <SetGroup label="Installed on this system" last>
         <div className="set-prov-list">
           {installed.map((p) => (
@@ -112,7 +117,10 @@ function ProviderRow({
   return (
     <div className={`set-prov ${enabled ? "" : "off"} ${open ? "open" : ""}`}>
       <div className="set-prov-main">
-        <span className="set-prov-status" title="Authenticated" />
+        <span
+          className={`set-prov-status ${livePath ? "" : "none"}`}
+          title={livePath ? "Detected on this system" : "Not found"}
+        />
         <ProviderIcon slug={provider.id} short={provider.short} hue={provider.hue} />
         <div className="set-prov-id">
           <div className="set-prov-name">

--- a/src/data/providerDetail.ts
+++ b/src/data/providerDetail.ts
@@ -20,6 +20,16 @@ export interface ProviderDetail {
   models: string;
   /** Detected & configured on this machine — drives the "Installed" list. */
   installed: boolean;
+  /** Copy-paste shell command to install the CLI, shown in the readiness
+   *  check when the binary isn't found. Omit when there's no reliable
+   *  one-liner — the UI falls back to the `docs` link. */
+  install?: string;
+  /** Setup / docs URL — always offered as "learn more" and the fallback when
+   *  there's no `install` command. */
+  docs: string;
+  /** One-line hint for signing in after install. We detect the binary, not
+   *  auth (which varies per CLI), so this nudges the user to complete it. */
+  signIn?: string;
   /** Thinking/reasoning effort levels supported by this provider's CLI.
    *  Empty means the provider has no effort flag — the picker hides. */
   thinkingLevels: ThinkingLevel[];
@@ -37,6 +47,9 @@ export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
     path: "/opt/homebrew/bin/claude",
     models: "Opus 4.7 · Sonnet 4.6 · Haiku 4",
     installed: true,
+    install: "npm install -g @anthropic-ai/claude-code",
+    docs: "https://docs.anthropic.com/en/docs/claude-code",
+    signIn: "Run `claude` once in a terminal to sign in.",
     // `claude --effort <level>` is a session-level spawn flag (not per-message):
     // chosen at session creation, threaded through spawn_agent, and persisted on
     // the session record so it re-applies on every spawn. Fixed for the session.
@@ -54,6 +67,9 @@ export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
     path: "~/.codex/bin/codex",
     models: "GPT-5.2-codex · o4-mini",
     installed: true,
+    install: "npm install -g @openai/codex",
+    docs: "https://github.com/openai/codex",
+    signIn: "Run `codex` once in a terminal to sign in.",
     // `codex exec -c reasoning_effort="<value>"`
     thinkingLevels: [
       { label: "Low",  value: "low"    },
@@ -65,6 +81,9 @@ export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
     path: "/Applications/Cursor.app/…/cursor-agent",
     models: "Composer · Auto",
     installed: true,
+    install: "curl https://cursor.com/install -fsS | bash",
+    docs: "https://cursor.com",
+    signIn: "Run `cursor-agent login` to sign in.",
     // Cursor encodes effort in model names — no standalone flag.
     thinkingLevels: [],
   },
@@ -72,12 +91,16 @@ export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
     path: "/Applications/Antigravity.app/…/antigravity",
     models: "Gemini 3 Pro · Flash",
     installed: true,
+    docs: "https://antigravity.google/product/antigravity-cli",
     thinkingLevels: [],
   },
   opencode: {
     path: "~/.opencode/bin/opencode",
     models: "Routed via upstream provider",
     installed: true,
+    install: "curl -fsSL https://opencode.ai/install | bash",
+    docs: "https://opencode.ai",
+    signIn: "Run `opencode auth login` to connect a provider.",
     // `opencode run --variant <value>`
     thinkingLevels: [
       { label: "Low",  value: "minimal" },
@@ -89,6 +112,7 @@ export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
     path: "~/.pi/bin/pi",
     models: "Pi · experimental",
     installed: true,
+    docs: "https://pi.dev/",
     // `pi --thinking <value>`
     thinkingLevels: [
       { label: "Off",   value: "off"    },

--- a/src/store.ts
+++ b/src/store.ts
@@ -385,9 +385,10 @@ interface AppState {
   providerVersions: Record<string, string>;
   /** Resolved binary paths keyed by provider id, from the version probe. */
   providerPaths: Record<string, string>;
-  /** True once the first provider probe has completed. Lets install-aware UI
-   *  (the model picker, readiness check) distinguish "not probed yet" from
-   *  "probed and not installed" so it doesn't flash agents as missing on boot. */
+  /** True once a provider probe has *succeeded*. Stays false while probing and
+   *  after a failed probe, so install-aware UI (model picker, readiness check)
+   *  fails open — treating install state as unknown rather than "all missing" —
+   *  instead of disabling every agent on a transient IPC error or on boot. */
   providersProbed: boolean;
   /** User-set custom binary paths keyed by provider id (the raw value entered,
    *  before resolution). Absent = auto-detect. This is the source of truth for
@@ -1914,10 +1915,11 @@ export const useAppStore = create<AppState>((set, get) => ({
       }
       set({ providerVersions: versions, providerPaths: paths, providersProbed: true });
     } catch {
-      // Non-fatal — UI falls back to hardcoded versions. Still mark probed so
-      // install-aware UI stops waiting (it treats a failed probe as "unknown",
-      // not "all missing", by reading providerPaths defensively).
-      set({ providersProbed: true });
+      // Non-fatal. Deliberately do NOT flip `providersProbed`: it means "we have
+      // a successful probe result", so a failed probe (IPC error, panic) leaves
+      // it false and install-aware UI fails OPEN (treats install state as
+      // unknown — agents stay selectable) instead of disabling every agent. A
+      // prior success's results are kept as last-known-good.
     }
   },
   setProviderPathOverride: async (id, path) => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -385,6 +385,10 @@ interface AppState {
   providerVersions: Record<string, string>;
   /** Resolved binary paths keyed by provider id, from the version probe. */
   providerPaths: Record<string, string>;
+  /** True once the first provider probe has completed. Lets install-aware UI
+   *  (the model picker, readiness check) distinguish "not probed yet" from
+   *  "probed and not installed" so it doesn't flash agents as missing on boot. */
+  providersProbed: boolean;
   /** User-set custom binary paths keyed by provider id (the raw value entered,
    *  before resolution). Absent = auto-detect. This is the source of truth for
    *  the "Custom" tag in the providers settings, independent of the probe. */
@@ -804,6 +808,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   providerFlags: {},
   providerVersions: {},
   providerPaths: {},
+  providersProbed: false,
   providerPathOverrides: {},
   modelCatalog: cachedCatalog.byId,
   modelsByAgent: cachedCatalog.byAgent,
@@ -1907,9 +1912,12 @@ export const useAppStore = create<AppState>((set, get) => ({
         if (probe.version) versions[probe.id] = probe.version;
         if (probe.path) paths[probe.id] = probe.path;
       }
-      set({ providerVersions: versions, providerPaths: paths });
+      set({ providerVersions: versions, providerPaths: paths, providersProbed: true });
     } catch {
-      // Non-fatal — UI falls back to hardcoded versions.
+      // Non-fatal — UI falls back to hardcoded versions. Still mark probed so
+      // install-aware UI stops waiting (it treats a failed probe as "unknown",
+      // not "all missing", by reading providerPaths defensively).
+      set({ providersProbed: true });
     }
   },
   setProviderPathOverride: async (id, path) => {


### PR DESCRIPTION
Onboarding signed users in but never checked they could actually run an agent: no CLI detection, the "Continue with GitHub" OAuth is Quorum-identity-only (not agent auth, though users assume otherwise), and the model picker gated on `hasAdapter()` — so an uninstalled agent looked selectable and only failed at spawn.

- **Reusable `ProviderReadiness` component.** Shows git (required), each wired agent CLI, and the GitHub CLI (optional) as detected/missing, with copy-paste install/sign-in commands and a Re-check button. It detects *binary presence* (and `gh` auth, which we can actually read); since per-CLI agent auth varies, installed rows nudge sign-in rather than falsely asserting "authenticated."
- **Folded into the onboarding finale** (no new step). The closer doubles as the real setup screen with readiness-aware copy ("Almost there" → "You're all set" / "One last step") and honestly reframes the OAuth. Non-blocking — "Enter Quorum" is always enabled.
- **Wired into Settings → Providers** (same component), replacing the hardcoded/faked "Authenticated" status dot with a real detected/not-found indicator.
- **ModelPicker is install-aware**: uninstalled agents are disabled with a hint, but never *during* the initial probe (no flash on boot, via a new `providersProbed` store flag).
- **Backend**: a small reusable `check_cli` command (resolve + `--version`) for git; provider metadata gains `install`/`docs`/`signIn`.

**Scoped out (kept lean):** no per-CLI agent-auth detection (fragile; instructions instead); no blocking gate.

Verified: tsc clean, 295 frontend tests, 272 Rust tests, no new clippy warnings. **Not visually smoke-tested** (the finale only shows pre-completion and Settings needs navigation) — reviewer should eyeball via Settings → Developer → Replay tour and Settings → Providers. Install commands are best-effort: Pi links to docs only (no confident one-liner) and Antigravity is excluded (no adapter / "coming soon") — worth a sanity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)