### PR TITLE
feat(onboarding): preview real sidebar rows & provider brand icons

### DIFF
--- a/src/components/Onboarding/exhibits.tsx
+++ b/src/components/Onboarding/exhibits.tsx
@@ -5,7 +5,9 @@
 
 import { useEffect, useState } from "react";
 import { Icon, LandmarkGlyph } from "../Icon";
-import { PROVIDERS } from "../../data/providers";
+import { ProviderIcon } from "../ProviderIcon";
+import { PROVIDERS, providerChip } from "../../data/providers";
+import type { ProviderId } from "../../data/providers";
 
 // ── tiny faux window chrome for an exhibit ──────────────────────────
 function ExBar({ title }: { title: string }) {
@@ -22,20 +24,65 @@ function ExBar({ title }: { title: string }) {
 }
 
 // ── Exhibit 1 · parallel agents in isolated worktrees ───────────────
+// Renders the real sidebar agent row (the `.agent` markup + classes from
+// app.css) against mock data, so the preview matches the product exactly.
 interface ParallelAgent {
   name: string;
-  landmark: string;
-  branch: string;
-  status: "running" | "waiting";
+  provider: ProviderId;
+  task: string;
+  status: "running" | "idle" | "error";
+  add: number;
+  rem: number;
+  age: string;
+  /** Idle agent with results the user hasn't reviewed — the "needs you" cue. */
+  unseen?: boolean;
   active?: boolean;
 }
 
 const PARALLEL_AGENTS: ParallelAgent[] = [
-  { name: "dolomites", landmark: "dolomites", branch: "feat/agent-runtime", status: "running", active: true },
-  { name: "andes", landmark: "andes", branch: "feat/zero-copy", status: "running" },
-  { name: "caspian", landmark: "caspian", branch: "fix/diff-jitter", status: "waiting" },
-  { name: "sierra", landmark: "sierra", branch: "docs/migration", status: "running" },
+  { name: "dolomites", provider: "claude",   task: "Stripe portal sync",  status: "running", add: 187, rem: 64,  age: "4m",  active: true },
+  { name: "andes",     provider: "codex",    task: "Zero-copy decoder",   status: "running", add: 624, rem: 312, age: "12m" },
+  { name: "caspian",   provider: "cursor",   task: "Diff repaint jitter", status: "idle",    add: 14,  rem: 22,  age: "1h",  unseen: true },
+  { name: "sierra",    provider: "opencode", task: "v3 migration guide",  status: "running", add: 240, rem: 12,  age: "26m" },
 ];
+
+// Mirrors AgentRow's RealRow markup (static, no store/interactivity).
+function ExhibitAgentRow({ a }: { a: ParallelAgent }) {
+  const working = a.status === "running";
+  const rail = working ? "run" : a.status === "error" ? "err" : "idle";
+  return (
+    <div className={`agent ${a.active ? "active" : ""}`}>
+      <span className={`ag-rail ${rail}`} />
+      <div className="agent-row">
+        <span className={`ag-name ${working ? "shimmer" : ""}`}>{a.name}</span>
+        <span className="ag-prov-chip">
+          <ProviderIcon slug={a.provider} {...providerChip(a.provider)} size={14} />
+        </span>
+        <span className="ag-slot">
+          <span className="ag-meta">
+            {working && <span className="ag-loader" aria-label="Working" />}
+            {!working && a.unseen && (
+              <span className="ag-unseen" aria-label="New results to review" />
+            )}
+            {a.status === "error" && <span className="ag-badge err">error</span>}
+          </span>
+          <span className="ag-actions">
+            <span className="ag-act">
+              <Icon name={working ? "stop" : "archive"} size={11} />
+            </span>
+          </span>
+        </span>
+      </div>
+      <div className="agent-sub">
+        <span className="a-task">{a.task}</span>
+        <span className="a-diff">
+          <span className="add">+{a.add}</span> <span className="del">−{a.rem}</span>
+        </span>
+        <span className="a-time">{a.age}</span>
+      </div>
+    </div>
+  );
+}
 
 export function ExhibitParallel() {
   return (
@@ -43,22 +90,17 @@ export function ExhibitParallel() {
       <div className="ob-exhibit">
         <ExBar title="quorum — worktrees" />
         <div className="ex-side">
-          <div className="ex-proj">
-            <span className="sw" style={{ background: "oklch(0.6 0.08 28)" }} />
-            <span>quorum-core</span>
-            <span className="cnt">4</span>
-          </div>
-          <div className="ex-agents">
-            {PARALLEL_AGENTS.map((a) => (
-              <div key={a.name} className={`ex-agent ${a.active ? "active" : ""}`}>
-                <span className={`ex-stat ${a.status}`} />
-                <span className="gly">
-                  <LandmarkGlyph name={a.landmark} size={14} strokeWidth={1.3} />
-                </span>
-                <span className="nm">{a.name}</span>
-                <span className="br">{a.branch}</span>
-              </div>
-            ))}
+          <div className="proj">
+            <div className="proj-h open">
+              <Icon name="chevR" size={10} className="chev" />
+              <span className="pname">quorum-core</span>
+              <span className="pcount">4</span>
+            </div>
+            <div className="agents">
+              {PARALLEL_AGENTS.map((a) => (
+                <ExhibitAgentRow key={a.name} a={a} />
+              ))}
+            </div>
           </div>
         </div>
         <div className="ob-exhibit-cap">

--- a/src/components/Onboarding/exhibits.tsx
+++ b/src/components/Onboarding/exhibits.tsx
@@ -130,9 +130,7 @@ export function ExhibitProviders() {
         <div className="ex-providers">
           {list.map((p, i) => (
             <div key={p.id} className={`ex-prov ${i < lit ? "on" : ""}`}>
-              <span className="badge" style={{ background: `oklch(0.55 0.13 ${p.hue})` }}>
-                {p.short}
-              </span>
+              <ProviderIcon slug={p.id} short={p.short} hue={p.hue} size={30} />
               <span className="meta">
                 <span className="pl">{p.label}</span>
                 <span className="ps">{p.sub}</span>

--- a/src/components/Onboarding/onboarding.css
+++ b/src/components/Onboarding/onboarding.css
@@ -401,13 +401,6 @@
   transition: border-color .25s var(--ease), background .25s var(--ease);
 }
 .ex-prov.on { border-color: var(--accent-line); background: color-mix(in oklch, var(--accent), var(--bg-2) 90%); }
-.ex-prov .badge {
-  width: 30px; height: 30px; flex-shrink: 0;
-  border-radius: var(--r-sm);
-  display: grid; place-items: center;
-  font-family: var(--font-mono); font-size: 11px; font-weight: 600;
-  color: #fff;
-}
 .ex-prov .meta { min-width: 0; display: flex; flex-direction: column; gap: 2px; }
 .ex-prov .pl { display: block; font-size: 12.5px; color: var(--fg-0); font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .ex-prov .ps { display: block; font-family: var(--font-mono); font-size: 10px; color: var(--fg-3); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }

--- a/src/components/Onboarding/onboarding.css
+++ b/src/components/Onboarding/onboarding.css
@@ -379,52 +379,12 @@
   white-space: nowrap;
 }
 
-/* ── exhibit: parallel agents (mini sidebar) ──────────────────── */
-.ex-side { padding: 12px 10px 44px; display: flex; flex-direction: column; gap: 2px; }
-.ex-proj {
-  display: flex; align-items: center; gap: 8px;
-  padding: 7px 9px; border-radius: var(--r-sm);
-  font-size: 12.5px; color: var(--fg-0); font-weight: 500;
-  white-space: nowrap;
-}
-.ex-proj .sw { width: 8px; height: 8px; border-radius: 2px; }
-.ex-proj .cnt { margin-left: auto; font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-3); }
-.ex-agents { margin-left: 12px; border-left: 1px solid var(--bd-soft); padding-left: 4px; }
-.ex-agent {
-  display: flex; align-items: center; gap: 9px;
-  margin: 1px 0 1px 4px;
-  padding: 8px 10px; border-radius: var(--r-sm);
-  position: relative;
-}
-.ex-agent.active { background: var(--selected); }
-.ex-agent.active::before {
-  content: ""; position: absolute; left: -5px; top: 9px; bottom: 9px;
-  width: 2px; border-radius: 0 2px 2px 0; background: var(--accent);
-}
-.ex-agent .gly { color: var(--fg-2); display: inline-flex; }
-.ex-agent.active .gly { color: var(--accent); }
-.ex-agent .nm { font-family: var(--font-mono); font-size: 12px; color: var(--fg-1); white-space: nowrap; }
-.ex-agent.active .nm { color: var(--fg-0); }
-.ex-agent .br { font-size: 11px; color: var(--fg-3); margin-left: auto; font-family: var(--font-mono); white-space: nowrap; }
-.ex-stat {
-  width: 9px; height: 9px; border-radius: 50%; flex-shrink: 0; position: relative;
-}
-.ex-stat.running {
-  background: radial-gradient(circle at 35% 30%,
-    color-mix(in oklch, var(--success), white 25%) 0%,
-    color-mix(in oklch, var(--success), transparent 35%) 70%);
-  box-shadow: 0 0 0 1px color-mix(in oklch, var(--success), transparent 78%);
-}
-.ex-stat.running::after {
-  content: ""; position: absolute; inset: 0; border-radius: 50%;
-  background: linear-gradient(115deg, transparent 38%, color-mix(in oklch, white, transparent 30%) 50%, transparent 62%);
-  background-size: 240% 100%; background-position: 100% 0;
-  animation: ex-shimmer 2.2s cubic-bezier(.4,0,.2,1) infinite;
-  mix-blend-mode: screen;
-}
-@keyframes ex-shimmer { 0%{background-position:130% 0;} 60%,100%{background-position:-30% 0;} }
-.ex-stat.waiting { background: transparent; box-shadow: inset 0 0 0 1.5px var(--warn); }
-.ex-stat.idle { background: var(--fg-3); opacity: .4; }
+/* ── exhibit: parallel agents (the real sidebar agent list) ───────
+   The rows render the live `.agent` markup styled in app.css, so the
+   preview matches the sidebar exactly. This only frames that list inside
+   the faux window and clears the caption bar pinned to the bottom. */
+.ex-side { padding: 8px 8px 46px; }
+.ex-side .proj { margin-bottom: 0; }
 
 /* ── exhibit: providers ───────────────────────────────────────── */
 .ex-providers {


### PR DESCRIPTION
Makes the onboarding tour previews match the real product instead of using simplified/fallback stand-ins.

## Step 2 — agent list preview
The `.ex-agents` preview now renders the **live sidebar agent row** markup (`.agent`, `.ag-rail`, `.agent-row`, `.ag-name`, `.ag-prov-chip`, `.ag-slot`, `.agent-sub`, …) against mock data, reusing the global `app.css` classes. Each row shows what the sidebar shows: provider chip, status rail (animated when running), working dots, and a task / +− diff / age line. The old single-line `dot · glyph · name · branch` mock and its dead `.ex-proj`/`.ex-agent`/`.ex-stat` styles are removed.

- "running" → animated rail + shimmer name + working dots
- the old "waiting" agent → idle with the `.ag-unseen` "needs you" dot (the sidebar's real equivalent)
- project header now matches the real `.proj-h` (chevron + UPPERCASE name + count)

> Tradeoff: this replicates the row markup rather than reusing the store-wired `AgentRow` component. Faithful today via shared CSS; if the sidebar row markup changes substantially this static preview won't auto-track it.

## Step 3 — providers grid
The provider grid was always showing the monogram **fallback**. Swapped the `.badge` monogram for the shared `ProviderIcon` (the same component the model picker, sidebar, and settings use), so it renders real brand SVGs with monogram fallback only when an icon is missing/offline.

## Verification
- `npm run check` (tsc) passes.
- Not yet eyeballed in-app; the brand SVGs load from the CDN at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)