### PR TITLE
Robustness & a11y: error boundary, file-editor error surfacing, keyboard-operable sidebar rows

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { TitleBar } from "./components/TitleBar";
 import { Sidebar } from "./components/Sidebar";
 import { Workspace } from "./components/Workspace";
 import { RightPanel } from "./components/RightPanel";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import { Settings } from "./components/Settings";
 import { SettingsScreen } from "./components/SettingsScreen";
 import { Onboarding } from "./components/Onboarding";
@@ -80,7 +81,10 @@ export function App() {
             </div>
             {!leftCollapsed && <div className="splitter" onMouseDown={onLeftDrag} />}
 
-            <Workspace />
+            {/* Keyed by agent so switching agents clears a stuck error. */}
+            <ErrorBoundary label="the workspace" key={selectedAgentId ?? "none"}>
+              <Workspace />
+            </ErrorBoundary>
 
             {rightPaneVisible && <div className="splitter" onMouseDown={onRightDrag} />}
             {!activeDraftId && (
@@ -100,7 +104,9 @@ export function App() {
                 }}
               >
                 {!rightCollapsed && selectedAgent && (
-                  <RightPanel agent={selectedAgent} />
+                  <ErrorBoundary label="the side panel" key={selectedAgent.id}>
+                    <RightPanel agent={selectedAgent} />
+                  </ErrorBoundary>
                 )}
               </div>
             )}

--- a/src/app.css
+++ b/src/app.css
@@ -4195,3 +4195,16 @@ button { cursor: default; }
   transition: background .12s;
 }
 .side-foot .side-user:hover { background: var(--hover); }
+
+/* Pane-level error boundary fallback (src/components/ErrorBoundary.tsx). */
+.err-boundary { height: 100%; display: grid; place-items: center; padding: 24px; }
+.err-boundary-box {
+  max-width: 420px; text-align: center; display: flex; flex-direction: column;
+  align-items: center; gap: 10px;
+}
+.err-boundary-title { font-weight: 600; color: var(--fg-0); }
+.err-boundary-msg {
+  color: var(--fg-2); font-size: 12.5px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  white-space: pre-wrap; word-break: break-word; max-height: 6em; overflow: auto;
+}

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,49 @@
+// Pane-level error boundary. A throw while rendering (e.g. a malformed agent
+// transcript) would otherwise blank the whole window; this contains it to one
+// pane and offers a reset, so the rest of the app keeps working. Keying the
+// boundary (e.g. by agent id) makes switching agents reset it automatically.
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  /** Human label for the failing region, e.g. "the workspace". */
+  label?: string;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // Surfaced to the console (and, in release, the injected Sentry browser SDK
+    // captures it). React swallows the original throw once we render a fallback.
+    console.error("UI error boundary caught an error:", error, info.componentStack);
+  }
+
+  reset = () => this.setState({ error: null });
+
+  render() {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+    return (
+      <div className="err-boundary" role="alert">
+        <div className="err-boundary-box">
+          <div className="err-boundary-title">
+            Something went wrong{this.props.label ? ` in ${this.props.label}` : ""}.
+          </div>
+          <div className="err-boundary-msg">{error.message || String(error)}</div>
+          <button type="button" className="btn-t outline" onClick={this.reset}>
+            Try again
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/components/RightPanel/FilePanel/FileEditor.tsx
+++ b/src/components/RightPanel/FilePanel/FileEditor.tsx
@@ -39,6 +39,7 @@ export function FileEditor({ agent, path, name, dir, file, onBack }: FileEditorP
   const isQuorum = useHljsTheme();
   const codeTheme = useAppStore((s) => s.codeTheme);
   const setCodeTheme = useAppStore((s) => s.setCodeTheme);
+  const setLastError = useAppStore((s) => s.setLastError);
 
   const taRef = useRef<HTMLTextAreaElement>(null);
   const hlRef = useRef<HTMLPreElement>(null);
@@ -129,7 +130,14 @@ export function FileEditor({ agent, path, name, dir, file, onBack }: FileEditorP
       if (timerRef.current) clearTimeout(timerRef.current);
       const text = valueRef.current;
       if (text !== savedRef.current) {
-        void api.writeWorktreeFile(agent.id, path, text).catch(() => {});
+        // The component is unmounting, so local state is gone — surface a
+        // failed final save through the global banner instead of losing it
+        // silently. `getState()` avoids a stale closure in cleanup.
+        void api.writeWorktreeFile(agent.id, path, text).catch((e) => {
+          useAppStore
+            .getState()
+            .setLastError(`Couldn't save ${path}: ${String(e)}`);
+        });
       }
     };
   }, [agent.id, path]);
@@ -137,11 +145,19 @@ export function FileEditor({ agent, path, name, dir, file, onBack }: FileEditorP
   const revert = async () => {
     // Restore the agent's version on disk and in the editor.
     if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null; }
-    await api.writeWorktreeFile(agent.id, path, originalText).catch(() => {});
-    savedRef.current = originalText;
-    setValue(originalText);
-    setSaveState("idle");
-    requestAnimationFrame(syncScroll);
+    setSaveState("saving");
+    try {
+      await api.writeWorktreeFile(agent.id, path, originalText);
+      savedRef.current = originalText;
+      setValue(originalText);
+      setSaveState("idle");
+      requestAnimationFrame(syncScroll);
+    } catch (e) {
+      // Don't update the buffer/savedRef — disk still holds the edits, so the
+      // editor must keep showing them rather than claim a revert that failed.
+      setSaveState("error");
+      setLastError(`Couldn't revert ${name}: ${String(e)}`);
+    }
   };
 
   const onChange = (next: string) => {

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -110,7 +110,7 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
       className={`agent ${active ? "active" : ""}`}
       role="button"
       tabIndex={0}
-      aria-current={active ? "true" : undefined}
+      aria-current={active ? "page" : undefined}
       onClick={onClick}
       onKeyDown={(e) => activateOnKey(e, onClick)}
     >
@@ -195,7 +195,7 @@ function DraftRow({ draft, active, onClick }: DraftRowProps) {
       className={`agent ${active ? "active" : ""}`}
       role="button"
       tabIndex={0}
-      aria-current={active ? "true" : undefined}
+      aria-current={active ? "page" : undefined}
       onClick={onClick}
       onKeyDown={(e) => activateOnKey(e, onClick)}
     >

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -14,6 +14,10 @@ import { AgentStatsPopover, type AgentStats } from "./AgentStatsPopover";
  *  a `<button>`; they use `role="button"` + this handler to stay keyboard
  *  operable (Enter/Space activates the row like a click). */
 function activateOnKey(e: KeyboardEvent, fn: () => void) {
+  // Ignore key events that bubbled up from a nested control (stop/archive/
+  // discard) — otherwise pressing Space/Enter on those buttons would also
+  // select the row (and Discard would select a draft as it's removed).
+  if (e.target !== e.currentTarget) return;
   if (e.key === "Enter" || e.key === " ") {
     e.preventDefault();
     fn();

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { MouseEvent } from "react";
+import type { MouseEvent, KeyboardEvent } from "react";
 import type { AgentRecord, AgentStatus, PrState, ShortStats } from "../../api";
 import type { DraftAgent } from "../../store";
 import { useAppStore } from "../../store";
@@ -9,6 +9,16 @@ import { ProviderIcon } from "../ProviderIcon";
 import { formatAge } from "../../util/format";
 import { useMinuteClock } from "../../util/hooks";
 import { AgentStatsPopover, type AgentStats } from "./AgentStatsPopover";
+
+/** The agent rows carry nested buttons (stop/archive/discard), so they can't be
+ *  a `<button>`; they use `role="button"` + this handler to stay keyboard
+ *  operable (Enter/Space activates the row like a click). */
+function activateOnKey(e: KeyboardEvent, fn: () => void) {
+  if (e.key === "Enter" || e.key === " ") {
+    e.preventDefault();
+    fn();
+  }
+}
 
 interface RealRowProps {
   kind: "real";
@@ -92,7 +102,14 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
   };
 
   return (
-    <div className={`agent ${active ? "active" : ""}`} onClick={onClick}>
+    <div
+      className={`agent ${active ? "active" : ""}`}
+      role="button"
+      tabIndex={0}
+      aria-current={active ? "true" : undefined}
+      onClick={onClick}
+      onKeyDown={(e) => activateOnKey(e, onClick)}
+    >
       <span className={`ag-rail ${railClass}`} />
       <div className="agent-row">
         <span className={`ag-name ${working ? "shimmer" : ""}`}>{agent.name}</span>
@@ -170,7 +187,14 @@ function DraftRow({ draft, active, onClick }: DraftRowProps) {
   }
 
   return (
-    <div className={`agent ${active ? "active" : ""}`} onClick={onClick}>
+    <div
+      className={`agent ${active ? "active" : ""}`}
+      role="button"
+      tabIndex={0}
+      aria-current={active ? "true" : undefined}
+      onClick={onClick}
+      onKeyDown={(e) => activateOnKey(e, onClick)}
+    >
       <span className="ag-rail idle" />
       <div className="agent-row">
         <span className="ag-name ag-name-draft">{draft.name}</span>

--- a/src/store.ts
+++ b/src/store.ts
@@ -448,6 +448,9 @@ interface AppState {
    *  same adapter that processes live events. */
   loadHistoryTranscript: (id: string) => Promise<void>;
   clearError: () => void;
+  /** Surface a message in the global error banner. For components (which can't
+   *  call `set`) to report a failure they'd otherwise have to swallow. */
+  setLastError: (message: string) => void;
 
   /** Version string of an update that's been downloaded + staged and is
    *  waiting for a restart to take effect. `null` = none pending. */
@@ -1704,6 +1707,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 
   clearError: () => set({ lastError: null }),
+  setLastError: (message) => set({ lastError: message }),
 
   setUpdateReady: (version) => set({ updateReadyVersion: version }),
   dismissUpdate: () => set({ updateReadyVersion: null }),


### PR DESCRIPTION
Three small robustness/accessibility fixes from the v1 assessment.

- **React error boundary.** A throw while rendering (e.g. a malformed agent transcript) previously blanked the whole window — there was no boundary anywhere. Adds a reusable pane-level `ErrorBoundary` and wraps the Workspace and side panel, each **keyed by agent** so switching agents clears a stuck error. Contained fallback with a "Try again" reset.
- **File-editor failures no longer swallowed.** The unmount autosave flush and the revert both used `.catch(() => {})` — silently losing a final save on agent-switch, or claiming a revert that never reached disk. Both now report via a new `setLastError` store action (the global error banner); a failed revert keeps the on-disk edits visible and flags an error instead of faking success.
- **Keyboard-operable sidebar rows.** The agent/draft rows — the app's primary navigation surface — were `<div onClick>`, not keyboard-reachable. They carry nested buttons (stop/archive/discard) so can't become a `<button>`; instead they get `role="button"`, `tabIndex`, `aria-current`, and Enter/Space activation.

Verified: tsc clean, 295 frontend tests pass. (No backend changes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)