### PR TITLE
feat(layout): persist panel layout & window size across restarts

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3126,6 +3126,7 @@ dependencies = [
  "tauri-plugin-sentry",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
+ "tauri-plugin-window-state",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -4635,6 +4636,21 @@ dependencies = [
  "url",
  "windows-sys 0.60.2",
  "zip",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.11.1",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,6 +45,10 @@ rusqlite_migration = "1"
 reqwest = { version = "0.13", default-features = false, features = ["json", "form", "rustls"] }
 base64 = "0.22"
 
+# Window state (size/position/maximized) persistence — desktop only.
+[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
+tauri-plugin-window-state = "2"
+
 [dev-dependencies]
 tempfile = "3"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -262,12 +262,20 @@ pub fn run() {
     init_logging();
     install_panic_logging();
 
-    tauri::Builder::default()
+    let builder = tauri::Builder::default()
         .plugin(tauri_plugin_sentry::init(&_sentry))
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
-        .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_process::init());
+
+    // Persist window size/position/maximized state across restarts. Desktop
+    // only — the plugin isn't available on mobile targets.
+    #[cfg(desktop)]
+    let builder =
+        builder.plugin(tauri_plugin_window_state::Builder::default().build());
+
+    builder
         .setup(|app| {
             let app_data = app.path().app_data_dir()?;
             let data_dir = if cfg!(debug_assertions) {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,8 @@
         "decorations": true,
         "transparent": false,
         "titleBarStyle": "Overlay",
-        "hiddenTitle": true
+        "hiddenTitle": true,
+        "visible": false
       }
     ],
     "security": { "csp": null }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,8 @@ export function App() {
   const rightWidth = useAppStore((s) => s.rightWidth);
   const setLeftWidth = useAppStore((s) => s.setLeftWidth);
   const setRightWidth = useAppStore((s) => s.setRightWidth);
+  const commitLeftWidth = useAppStore((s) => s.commitLeftWidth);
+  const commitRightWidth = useAppStore((s) => s.commitRightWidth);
   const lastError = useAppStore((s) => s.lastError);
   const clearError = useAppStore((s) => s.clearError);
   const activeDraftId = useAppStore((s) => s.activeDraftId);
@@ -58,8 +60,8 @@ export function App() {
   }, [accent]);
 
   useGlobalShortcuts();
-  const onLeftDrag = useSplitter(leftWidth, setLeftWidth, "left");
-  const onRightDrag = useSplitter(rightWidth, setRightWidth, "right");
+  const onLeftDrag = useSplitter(leftWidth, setLeftWidth, "left", commitLeftWidth);
+  const onRightDrag = useSplitter(rightWidth, setRightWidth, "right", commitRightWidth);
 
   const selectedAgent = workspace?.agents.find((a) => a.id === selectedAgentId);
   const rightPaneVisible = !rightCollapsed && !activeDraftId && selectedAgent;

--- a/src/store.ts
+++ b/src/store.ts
@@ -221,6 +221,24 @@ function parseProviderFlags(raw: string | undefined): Record<string, boolean> {
   }
 }
 
+/** Default pane widths (px); also the fallback when a stored value is missing
+ *  or corrupt. Mirrored in the initial store state below. */
+const DEFAULT_LEFT_WIDTH = 312;
+const DEFAULT_RIGHT_WIDTH = 520;
+/** Lower bound matches the splitter's MIN_WIDTH; the right pane's true upper
+ *  bound is dynamic (capped at render via CSS `min()`), so we only guard
+ *  against absurd/NaN persisted values here. */
+const MIN_PANE_WIDTH = 220;
+const MAX_PANE_WIDTH = 4000;
+
+/** Restore a persisted pane width, clamping to a sane range and falling back
+ *  to the default on a missing or non-numeric value. */
+function parsePaneWidth(raw: string | undefined, fallback: number): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(MAX_PANE_WIDTH, Math.max(MIN_PANE_WIDTH, n));
+}
+
 /** Settings-key prefix for per-agent custom binary paths. Must match the
  *  backend's `database::AGENT_BIN_PREFIX` so both read/write the same rows. */
 const AGENT_BIN_PREFIX = "agent_bin_path_";
@@ -497,8 +515,12 @@ interface AppState {
   selectHistoryAgent: (id: string | null) => void;
   toggleLeft: () => void;
   toggleRight: () => void;
+  /** Live (in-memory) width update during a splitter drag. */
   setLeftWidth: (w: number) => void;
   setRightWidth: (w: number) => void;
+  /** Persist the final width once a splitter drag ends. */
+  commitLeftWidth: (w: number) => void;
+  commitRightWidth: (w: number) => void;
 
   // appearance
   setTheme: (t: ThemeMode) => void;
@@ -797,8 +819,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   selectedHistoryAgentId: null,
   leftCollapsed: false,
   rightCollapsed: false,
-  leftWidth: 312,
-  rightWidth: 520,
+  leftWidth: DEFAULT_LEFT_WIDTH,
+  rightWidth: DEFAULT_RIGHT_WIDTH,
 
   theme: "dark" as ThemeMode,
   codeTheme: "quorum",
@@ -836,6 +858,11 @@ export const useAppStore = create<AppState>((set, get) => ({
         onboardingComplete: s.onboardingComplete === "true",
         // Auto-open the welcome tour for new users (no completion flag yet).
         onboardingOpen: s.onboardingComplete !== "true",
+        // Panel layout — restore the user's last splitter widths and collapse state.
+        leftCollapsed: s.leftCollapsed === "true",
+        rightCollapsed: s.rightCollapsed === "true",
+        leftWidth: parsePaneWidth(s.leftWidth, DEFAULT_LEFT_WIDTH),
+        rightWidth: parsePaneWidth(s.rightWidth, DEFAULT_RIGHT_WIDTH),
       });
     } catch {
       // First launch or DB not ready — defaults are fine.
@@ -1866,10 +1893,24 @@ export const useAppStore = create<AppState>((set, get) => ({
         : { historyOpen: false, selectedHistoryAgentId: null };
     }),
   selectHistoryAgent: (id) => set({ selectedHistoryAgentId: id }),
-  toggleLeft: () => set((s) => ({ leftCollapsed: !s.leftCollapsed })),
-  toggleRight: () => set((s) => ({ rightCollapsed: !s.rightCollapsed })),
+  toggleLeft: () =>
+    set((s) => {
+      const leftCollapsed = !s.leftCollapsed;
+      setSetting("leftCollapsed", String(leftCollapsed));
+      return { leftCollapsed };
+    }),
+  toggleRight: () =>
+    set((s) => {
+      const rightCollapsed = !s.rightCollapsed;
+      setSetting("rightCollapsed", String(rightCollapsed));
+      return { rightCollapsed };
+    }),
+  // Width changes fire on every drag frame, so these only update in-memory
+  // state. Persistence is deferred to commit*Width on drag end (see splitter).
   setLeftWidth: (w) => set({ leftWidth: w }),
   setRightWidth: (w) => set({ rightWidth: w }),
+  commitLeftWidth: (w) => setSetting("leftWidth", String(w)),
+  commitRightWidth: (w) => setSetting("rightWidth", String(w)),
 
   // ── appearance ──────────────────────────────────────────────────────────────
   setTheme: (t) => {

--- a/src/util/splitter.ts
+++ b/src/util/splitter.ts
@@ -8,16 +8,20 @@ const LEFT_MAX = 520;
 /** Pane-resize drag handler. Returns an `onMouseDown` to attach to a
  *  splitter element; while dragging it sets the receiving width via
  *  `set`. Left width is clamped to [220, 520]; the right pane may expand
- *  until it is as wide as the center pane. */
+ *  until it is as wide as the center pane. `commit`, if given, fires once
+ *  on drag end with the final width — use it to persist (the per-frame
+ *  `set` stays in-memory only). */
 export function useSplitter(
   current: number,
   set: (w: number) => void,
   side: "left" | "right",
+  commit?: (w: number) => void,
 ) {
   return (e: MouseEvent<HTMLDivElement>) => {
     e.preventDefault();
     const startX = e.clientX;
     const startW = current;
+    let lastW = current;
     const el = e.currentTarget;
     // The right pane may grow until it matches the center pane. With the
     // left pane and window fixed, `center + right` is constant for the
@@ -34,12 +38,14 @@ export function useSplitter(
     const move = (ev: globalThis.MouseEvent) => {
       const dx = ev.clientX - startX;
       const next = side === "left" ? startW + dx : startW - dx;
-      set(Math.max(MIN_WIDTH, Math.min(max, next)));
+      lastW = Math.max(MIN_WIDTH, Math.min(max, next));
+      set(lastW);
     };
     const up = () => {
       el.classList.remove("dragging");
       window.removeEventListener("mousemove", move);
       window.removeEventListener("mouseup", up);
+      if (lastW !== startW) commit?.(lastW);
     };
     window.addEventListener("mousemove", move);
     window.addEventListener("mouseup", up);


### PR DESCRIPTION
Layout state was lost on every restart. This wires it into persistence — splitting cleanly into the two layers it lives in.

## Panel layout (in-webview) → SQLite settings
`leftCollapsed`, `rightCollapsed`, `leftWidth`, `rightWidth` were the only user preferences never written to the settings store. Now they ride the same `setSetting`/`getAllSettings` rail as `theme`, restored in `init()`.

- **Writes:** toggles persist immediately; widths persist **on drag end** via new `commitLeftWidth`/`commitRightWidth` actions fired from `useSplitter`'s mouseup. The per-frame `setLeftWidth`/`setRightWidth` during a drag stay in-memory, so we don't hammer the DB while dragging.
- **Restore:** `parsePaneWidth` clamps to a sane range with a NaN/missing-value fallback to the defaults, so a corrupt value can't wedge the layout. The right pane's dynamic upper bound is still capped at render via the existing CSS `min()`.
- All collapse entry points (⌘B/⌘/ shortcuts, header buttons, empty-state buttons) already route through `toggleLeft`/`toggleRight`, so coverage is complete.

## Window size/position → tauri-plugin-window-state
The OS window had no persistence (fixed 1280×800 default). Added the official `tauri-plugin-window-state`, which auto-saves/restores size, position, and maximized state via the Rust Builder — **no JS package, no per-frame code**. Gated desktop-only (`#[cfg(desktop)]` + a target-scoped Cargo dependency) so mobile targets still compile.

> Why the plugin instead of localStorage / the SQLite settings table: window geometry is OS-level state Tauri already owns, and the plugin handles the gnarly bits (multi-monitor position validity, maximized/fullscreen, flicker-free restore-before-show) that a hand-rolled solution would get wrong. Keeping it out of the settings DB also avoids splitting one concern across two restore paths.

## Verification
- `npm run check` (tsc) passes.
- `cargo check` passes (`tauri-plugin-window-state v2.4.1` compiles and links).
- Not yet exercised by an actual app restart — recommend a manual check: resize panes + window, quit, relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)