### PR TITLE
feat(pr): bind PR identity to worktree row, not branch name

### DIFF
--- a/src-tauri/migrations/0010_worktree_pr_number.sql
+++ b/src-tauri/migrations/0010_worktree_pr_number.sql
@@ -1,0 +1,9 @@
+-- The GitHub PR number a worktree's branch was opened as, captured when the
+-- PR is created (via the open_pr RPC or the panel's Create PR action) or
+-- adopted from an OPEN out-of-band PR discovered by branch. Once stored, PR
+-- state is fetched by this number rather than by the current branch name.
+--
+-- This is what unbinds PR identity from the (recyclable) workspace/branch
+-- name: a fresh agent starts with NULL here, so a reused workspace name can
+-- never inherit a previous agent's now-merged PR. NULL = no known PR yet.
+ALTER TABLE worktrees ADD COLUMN pr_number INTEGER;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -475,7 +475,13 @@ pub async fn create_pr(
         .ok_or_else(|| crate::error::Error::Other("agent has no repos".into()))?;
     let worktree = repo_worktree_path(&agent_id, &repo.subdir)?;
     let base = repo.parent_branch.as_deref().unwrap_or("main");
-    gh::pr_create(&worktree, &title, &body, base).await
+    let pr = gh::pr_create(&worktree, &title, &body, base).await?;
+    // Bind the PR to this agent by number so later lookups don't rely on the
+    // (recyclable) branch name.
+    let _ = supervisor
+        .workspace
+        .set_repo_pr_number(&agent_id, &repo.subdir, pr.number as i64);
+    Ok(pr)
 }
 
 /// Merge the open PR for the agent's current branch.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -477,10 +477,20 @@ pub async fn create_pr(
     let base = repo.parent_branch.as_deref().unwrap_or("main");
     let pr = gh::pr_create(&worktree, &title, &body, base).await?;
     // Bind the PR to this agent by number so later lookups don't rely on the
-    // (recyclable) branch name.
-    let _ = supervisor
+    // (recyclable) branch name. A failure here isn't fatal — the next idle/push
+    // poll re-binds it via guarded discovery once the PR shows OPEN — but log it
+    // so the gap is observable rather than silent.
+    if let Err(e) = supervisor
         .workspace
-        .set_repo_pr_number(&agent_id, &repo.subdir, pr.number as i64);
+        .set_repo_pr_number(&agent_id, &repo.subdir, pr.number as i64)
+    {
+        tracing::warn!(
+            error = %e,
+            agent_id = %agent_id,
+            pr = pr.number,
+            "create_pr: failed to persist PR number"
+        );
+    }
     Ok(pr)
 }
 

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -39,6 +39,7 @@ fn get_migrations() -> Migrations<'static> {
         M::up(include_str!("../migrations/0007_account_oauth.sql")),
         M::up(include_str!("../migrations/0008_worktree_base_sha.sql")),
         M::up(include_str!("../migrations/0009_session_model.sql")),
+        M::up(include_str!("../migrations/0010_worktree_pr_number.sql")),
     ])
 }
 

--- a/src-tauri/src/gh.rs
+++ b/src-tauri/src/gh.rs
@@ -197,6 +197,35 @@ pub async fn pr_view(worktree: &Path) -> Result<Option<PrState>> {
     Ok(Some(raw.into()))
 }
 
+/// Fetch PR state by explicit PR number, regardless of the branch currently
+/// checked out in `worktree`. This is the lookup that doesn't rely on branch
+/// identity: once we've recorded a PR number for an agent we fetch by it, so a
+/// recycled workspace/branch name can't resolve to a different (e.g. a prior
+/// agent's merged) PR.
+///
+/// Returns `Ok(None)` when the PR can't be found (e.g. it was deleted) so the
+/// caller can treat it the same as "no PR".
+pub async fn pr_view_number(worktree: &Path, number: u32) -> Result<Option<PrState>> {
+    let num = number.to_string();
+    let out = gh_command()
+        .current_dir(worktree)
+        .args(["pr", "view", &num, "--json", "number,url,state,title,mergeable"])
+        .output()
+        .await?;
+
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        let low = stderr.to_lowercase();
+        if low.contains("no pull requests found") || low.contains("could not resolve") {
+            return Ok(None);
+        }
+        return Err(Error::Gh(stderr.trim().to_string()));
+    }
+
+    let raw: GhPrRaw = serde_json::from_slice(&out.stdout)?;
+    Ok(Some(raw.into()))
+}
+
 /// List open PRs for the repo at `worktree` (most-recent first), for the
 /// composer's "#" mention autocomplete.
 pub async fn pr_list(worktree: &Path, limit: u32) -> Result<Vec<PrSummary>> {

--- a/src-tauri/src/gh.rs
+++ b/src-tauri/src/gh.rs
@@ -216,7 +216,12 @@ pub async fn pr_view_number(worktree: &Path, number: u32) -> Result<Option<PrSta
     if !out.status.success() {
         let stderr = String::from_utf8_lossy(&out.stderr);
         let low = stderr.to_lowercase();
-        if low.contains("no pull requests found") || low.contains("could not resolve") {
+        // gh's "missing PR" wording varies by lookup and version: branch lookups
+        // say "no pull requests found", a bad number says "pull request not
+        // found" or "could not resolve to a PullRequest". `contains("not found")`
+        // covers the first two; keep the resolve case explicit. All map to the
+        // documented `Ok(None)` so callers treat it as "no PR".
+        if low.contains("not found") || low.contains("could not resolve") {
             return Ok(None);
         }
         return Err(Error::Gh(stderr.trim().to_string()));

--- a/src-tauri/src/rpc.rs
+++ b/src-tauri/src/rpc.rs
@@ -86,6 +86,18 @@ pub struct OpContext {
     pub base_branch: String,
 }
 
+/// A side-effect of a processed op that the supervisor-side watcher needs to
+/// observe. `rpc` itself stays free of any `Supervisor`/DB dependency (so it
+/// remains unit-testable in isolation) — it just reports what happened and lets
+/// the watcher persist it.
+#[derive(Debug, Clone)]
+pub enum RpcEffect {
+    /// `open_pr` created (or resolved an already-existing) PR with this number.
+    /// The watcher records it against the agent so later PR-state lookups go by
+    /// number, not by the recyclable branch name.
+    PrOpened { number: u32 },
+}
+
 impl Response {
     fn ok(id: &str, exit_code: i32, stdout: String, stderr: String) -> Self {
         Self {
@@ -144,16 +156,17 @@ pub fn ensure_mailbox(dir: &Path) -> Result<()> {
 /// delete the request. Driven on a fixed tick by the per-agent watcher. Errors
 /// on a single request are logged and isolated — one bad file can't stall the
 /// rest. Commands run in `cwd` (the agent's primary worktree).
-pub async fn process_pending(rpc_dir: &Path, ctx: &OpContext) {
+pub async fn process_pending(rpc_dir: &Path, ctx: &OpContext) -> Vec<RpcEffect> {
     let requests = rpc_dir.join("requests");
     let responses = rpc_dir.join("responses");
 
     let entries = match std::fs::read_dir(&requests) {
         Ok(e) => e,
         // No mailbox yet (or removed during teardown) — nothing to do.
-        Err(_) => return,
+        Err(_) => return Vec::new(),
     };
 
+    let mut effects = Vec::new();
     for entry in entries.flatten() {
         let path = entry.path();
         // Only consume finished `<uuid>.json` files. The agent writes
@@ -162,28 +175,35 @@ pub async fn process_pending(rpc_dir: &Path, ctx: &OpContext) {
         if path.extension().and_then(|e| e.to_str()) != Some("json") {
             continue;
         }
-        handle_request_file(&path, &responses, ctx).await;
+        if let Some(effect) = handle_request_file(&path, &responses, ctx).await {
+            effects.push(effect);
+        }
     }
+    effects
 }
 
 /// Handle one request file. The response filename is derived from the request's
 /// file stem (the `<uuid>` the agent polls), not the in-body `id`, so the agent
 /// always finds its reply where it expects. The stem must be a safe token —
 /// a defense-in-depth guard against a malformed id escaping the mailbox.
-async fn handle_request_file(path: &Path, responses: &Path, ctx: &OpContext) {
+async fn handle_request_file(
+    path: &Path,
+    responses: &Path,
+    ctx: &OpContext,
+) -> Option<RpcEffect> {
     let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
-        return;
+        return None;
     };
     if !is_safe_key(stem) {
         tracing::warn!(file = %path.display(), "rpc: unsafe request filename, skipping");
-        return;
+        return None;
     }
 
     let raw = match std::fs::read(path) {
         Ok(b) => b,
         Err(e) => {
             tracing::warn!(error = %e, file = %path.display(), "rpc: read request failed");
-            return;
+            return None;
         }
     };
 
@@ -205,30 +225,43 @@ async fn handle_request_file(path: &Path, responses: &Path, ctx: &OpContext) {
             } else {
                 tracing::debug!(error = %e, file = %path.display(), "rpc: unparseable request (will retry)");
             }
-            return;
+            return None;
         }
     };
 
-    let resp = dispatch(stem, &req.op, &req.args, ctx).await;
+    let (resp, effect) = dispatch(stem, &req.op, &req.args, ctx).await;
 
     if let Err(e) = write_response_atomic(responses, stem, &resp) {
         tracing::warn!(error = %e, id = %stem, "rpc: write response failed");
         // Leave the request so a later tick can retry rather than dropping it.
-        return;
+        // Don't surface the effect either — the op will re-run next tick.
+        return None;
     }
 
     // Answered — remove the request so it's processed exactly once.
     if let Err(e) = std::fs::remove_file(path) {
         tracing::warn!(error = %e, file = %path.display(), "rpc: remove request failed");
     }
+
+    effect
 }
 
 /// The op allowlist. Adding an op is one arm here plus a line in the instruction
 /// block (`instructions/rpc_protocol.md`). Anything unmatched is rejected, which
 /// is what keeps the sandbox meaningful — the agent can only invoke vetted,
 /// deterministic actions.
-async fn dispatch(id: &str, op: &str, args: &Value, ctx: &OpContext) -> Response {
-    match op {
+async fn dispatch(
+    id: &str,
+    op: &str,
+    args: &Value,
+    ctx: &OpContext,
+) -> (Response, Option<RpcEffect>) {
+    // `open_pr` is the only op that produces an effect the supervisor needs to
+    // observe (the new PR number); it returns its own (response, effect) pair.
+    if op == "open_pr" {
+        return open_pr(id, args, ctx).await;
+    }
+    let resp = match op {
         // Liveness probe — proves the round-trip with no side effects.
         "ping" => Response::ok(id, 0, "pong".to_string(), String::new()),
         // Read-only: run a deterministic command and report its result.
@@ -239,10 +272,6 @@ async fn dispatch(id: &str, op: &str, args: &Value, ctx: &OpContext) -> Response
         // (the worktree's git index/objects live outside the writable root), so
         // it's an app action. `args.message` is the commit message.
         "git_commit" => git_commit(id, args, ctx).await,
-        // Push the current branch and open a PR against the agent's base branch.
-        // `args.title`/`args.body` set the PR title and description (empty title
-        // → gh auto-fills from the commits).
-        "open_pr" => open_pr(id, args, ctx).await,
         // Push the current branch to origin. Blocked in the sandbox for the
         // same reason as commit — used to update an existing PR branch after
         // the agent fixes checks or resolves conflicts.
@@ -253,7 +282,8 @@ async fn dispatch(id: &str, op: &str, args: &Value, ctx: &OpContext) -> Response
         // the agent can resolve and finish with `git_commit` + `git_push`.
         "git_update_branch" => git_update_branch(id, ctx).await,
         other => Response::err(id, format!("unknown op: {other}")),
-    }
+    };
+    (resp, None)
 }
 
 /// `git_commit` — `args.message` (required, non-empty) is the commit message.
@@ -273,20 +303,28 @@ async fn git_commit(id: &str, args: &Value, ctx: &OpContext) -> Response {
 /// `open_pr` — push the current branch, then `gh pr create` against the agent's
 /// base branch. `args.title`/`args.body` are optional (empty title → `--fill`).
 /// Returns the PR URL in `stdout` on success.
-async fn open_pr(id: &str, args: &Value, ctx: &OpContext) -> Response {
+async fn open_pr(id: &str, args: &Value, ctx: &OpContext) -> (Response, Option<RpcEffect>) {
     let title = args.get("title").and_then(|v| v.as_str()).unwrap_or("");
     let body = args.get("body").and_then(|v| v.as_str()).unwrap_or("");
     let branch = match crate::git::current_branch(&ctx.cwd).await {
         Ok(Some(b)) => b,
-        Ok(None) => return Response::err(id, "open_pr: HEAD is detached — no branch to push"),
-        Err(e) => return Response::err(id, format!("open_pr: {e}")),
+        Ok(None) => {
+            return (
+                Response::err(id, "open_pr: HEAD is detached — no branch to push"),
+                None,
+            )
+        }
+        Err(e) => return (Response::err(id, format!("open_pr: {e}")), None),
     };
     if let Err(e) = crate::git::push(&ctx.cwd, &branch).await {
-        return Response::err(id, format!("open_pr push failed: {e}"));
+        return (Response::err(id, format!("open_pr push failed: {e}")), None);
     }
     match crate::gh::pr_create(&ctx.cwd, title, body, &ctx.base_branch).await {
-        Ok(pr) => Response::ok(id, 0, pr.url, String::new()),
-        Err(e) => Response::err(id, format!("open_pr: {e}")),
+        Ok(pr) => (
+            Response::ok(id, 0, pr.url, String::new()),
+            Some(RpcEffect::PrOpened { number: pr.number }),
+        ),
+        Err(e) => (Response::err(id, format!("open_pr: {e}")), None),
     }
 }
 

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -467,6 +467,7 @@ impl Supervisor {
             branch: None, // created later from first user message
             parent_branch,
             base_sha: None, // captured by the fork task once HEAD is known
+            pr_number: None, // set when a PR is opened for this branch
         };
 
         let mut record = new_agent_record(
@@ -577,6 +578,7 @@ impl Supervisor {
             branch: None,
             parent_branch,
             base_sha,
+            pr_number: None,
         };
         self.workspace
             .append_tracked_repo(agent_id, repo.clone())?;
@@ -778,7 +780,7 @@ impl Supervisor {
             self.set_status(&app, &agent_id_str, AgentStatus::Idle, None);
         }
 
-        spawn_turn_watchdog(self.clone(), app, agent_id_str.clone(), my_gen);
+        spawn_turn_watchdog(self.clone(), app.clone(), agent_id_str.clone(), my_gen);
 
         // Watch this agent's RPC mailbox for the life of this generation,
         // executing allowlisted ops and writing responses back.
@@ -786,7 +788,7 @@ impl Supervisor {
             cwd: watcher_cwd,
             base_branch,
         };
-        spawn_rpc_watcher(self.clone(), agent_id_str, op_ctx, rpc_dir, my_gen);
+        spawn_rpc_watcher(self.clone(), app, agent_id_str, op_ctx, rpc_dir, my_gen);
 
         Ok(())
     }
@@ -1199,6 +1201,9 @@ impl Supervisor {
                 // this literal value is never written back — None is a
                 // placeholder to satisfy the struct.
                 base_sha: None,
+                // Likewise preserved in the worktrees row across restore;
+                // placeholder to satisfy the struct.
+                pr_number: None,
             });
         }
 
@@ -1293,11 +1298,33 @@ impl Supervisor {
             if repo.branch.is_none() {
                 return;
             }
-            let worktree = match crate::workspace::repo_worktree_path(&agent_id, &repo.subdir) {
+            let subdir = repo.subdir.clone();
+            let worktree = match crate::workspace::repo_worktree_path(&agent_id, &subdir) {
                 Ok(p) => p,
                 Err(_) => return,
             };
-            let state = crate::gh::pr_view(&worktree).await.unwrap_or(None);
+            let state = if let Some(number) = repo.pr_number {
+                // Known PR: fetch by number, never by branch. This is what keeps
+                // PR identity bound to the agent rather than the recyclable
+                // branch name.
+                crate::gh::pr_view_number(&worktree, number as u32)
+                    .await
+                    .unwrap_or(None)
+            } else {
+                // No PR recorded yet. Discover one created out-of-band (agent ran
+                // `gh pr create`, or it was opened on github.com), but only adopt
+                // it if it's OPEN — a stale merged/closed PR sitting on a recycled
+                // branch must not be claimed as this agent's. Once adopted we
+                // persist the number so all later lookups go by number.
+                match crate::gh::pr_view(&worktree).await.unwrap_or(None) {
+                    Some(pr) if matches!(pr.state, crate::gh::PrStatus::Open) => {
+                        let _ =
+                            workspace.set_repo_pr_number(&agent_id, &subdir, pr.number as i64);
+                        Some(pr)
+                    }
+                    _ => None,
+                }
+            };
             let _ = app.emit(
                 "pr:state_changed",
                 PrStateChangedPayload { agent_id, state },
@@ -2110,6 +2137,7 @@ fn spawn_turn_watchdog(
 /// the transcript-sync style already used elsewhere.
 fn spawn_rpc_watcher(
     sup: Arc<Supervisor>,
+    app: AppHandle,
     agent_id: String,
     ctx: rpc::OpContext,
     rpc_dir: PathBuf,
@@ -2129,7 +2157,27 @@ fn spawn_rpc_watcher(
                 return;
             }
 
-            rpc::process_pending(&rpc_dir, &ctx).await;
+            let effects = rpc::process_pending(&rpc_dir, &ctx).await;
+            for effect in effects {
+                match effect {
+                    // The agent opened a PR via the `open_pr` op. Bind it to the
+                    // agent by number so PR-state lookups stop depending on the
+                    // (recyclable) branch name, then refresh the panel. The PR
+                    // belongs to the primary repo — the worktree `open_pr` runs in.
+                    rpc::RpcEffect::PrOpened { number } => {
+                        if let Ok(record) = sup.workspace.agent(&agent_id) {
+                            if let Some(repo) = record.repos.first() {
+                                let _ = sup.workspace.set_repo_pr_number(
+                                    &agent_id,
+                                    &repo.subdir,
+                                    number as i64,
+                                );
+                            }
+                        }
+                        sup.fetch_and_emit_pr_state(app.clone(), agent_id.clone());
+                    }
+                }
+            }
         }
     });
 }
@@ -2525,6 +2573,7 @@ mod tests {
                 branch: None,
                 parent_branch: None,
                 base_sha: None,
+                pr_number: None,
             },
             String::new(),
             AgentView::Custom,

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -1318,8 +1318,16 @@ impl Supervisor {
                 // persist the number so all later lookups go by number.
                 match crate::gh::pr_view(&worktree).await.unwrap_or(None) {
                     Some(pr) if matches!(pr.state, crate::gh::PrStatus::Open) => {
-                        let _ =
-                            workspace.set_repo_pr_number(&agent_id, &subdir, pr.number as i64);
+                        if let Err(e) =
+                            workspace.set_repo_pr_number(&agent_id, &subdir, pr.number as i64)
+                        {
+                            tracing::warn!(
+                                error = %e,
+                                agent_id = %agent_id,
+                                pr = pr.number,
+                                "pr discovery: failed to persist PR number"
+                            );
+                        }
                         Some(pr)
                     }
                     _ => None,
@@ -2167,11 +2175,18 @@ fn spawn_rpc_watcher(
                     rpc::RpcEffect::PrOpened { number } => {
                         if let Ok(record) = sup.workspace.agent(&agent_id) {
                             if let Some(repo) = record.repos.first() {
-                                let _ = sup.workspace.set_repo_pr_number(
+                                if let Err(e) = sup.workspace.set_repo_pr_number(
                                     &agent_id,
                                     &repo.subdir,
                                     number as i64,
-                                );
+                                ) {
+                                    tracing::warn!(
+                                        error = %e,
+                                        agent_id = %agent_id,
+                                        pr = number,
+                                        "open_pr: failed to persist PR number"
+                                    );
+                                }
                             }
                         }
                         sup.fetch_and_emit_pr_state(app.clone(), agent_id.clone());

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -66,6 +66,13 @@ pub struct TrackedRepo {
     /// for PR/merge bases.
     #[serde(default)]
     pub base_sha: Option<String>,
+    /// The GitHub PR number this worktree's branch was opened as, once known.
+    /// Set when a PR is created through the app or adopted from an OPEN
+    /// out-of-band PR. PR state is fetched by this number, not by branch name,
+    /// so a recycled workspace name can't resolve to a prior agent's PR.
+    /// `None` until a PR exists.
+    #[serde(default)]
+    pub pr_number: Option<i64>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -464,6 +471,24 @@ impl WorkspaceManager {
         conn.execute(
             "UPDATE worktrees SET base_sha = ?1 WHERE workspace_id = ?2 AND subdir = ?3",
             rusqlite::params![base_sha, agent_id, subdir],
+        )?;
+        Ok(())
+    }
+
+    /// Record the GitHub PR number for a tracked repo, identified by subdir.
+    /// Written when a PR is created through the app or adopted from an OPEN
+    /// out-of-band PR. Overwrites unconditionally — the latest PR opened for
+    /// the branch is the one we track.
+    pub fn set_repo_pr_number(
+        &self,
+        agent_id: &str,
+        subdir: &str,
+        pr_number: i64,
+    ) -> Result<()> {
+        let conn = self.db.lock();
+        conn.execute(
+            "UPDATE worktrees SET pr_number = ?1 WHERE workspace_id = ?2 AND subdir = ?3",
+            rusqlite::params![pr_number, agent_id, subdir],
         )?;
         Ok(())
     }
@@ -1095,7 +1120,7 @@ impl WorkspaceManager {
 
     fn query_tracked_repos(conn: &Connection, agent_id: &str) -> Vec<TrackedRepo> {
         let mut stmt = match conn.prepare(
-            "SELECT r.path, w.subdir, w.branch, w.parent_branch, w.base_sha
+            "SELECT r.path, w.subdir, w.branch, w.parent_branch, w.base_sha, w.pr_number
              FROM worktrees w
              JOIN repos r ON r.id = w.repo_id
              WHERE w.workspace_id = ?1
@@ -1111,12 +1136,14 @@ impl WorkspaceManager {
             let branch: Option<String> = row.get(2)?;
             let parent_branch: Option<String> = row.get(3)?;
             let base_sha: Option<String> = row.get(4)?;
+            let pr_number: Option<i64> = row.get(5)?;
             Ok(TrackedRepo {
                 repo_path: PathBuf::from(path),
                 subdir,
                 branch,
                 parent_branch,
                 base_sha,
+                pr_number,
             })
         })
         .ok()
@@ -1480,6 +1507,7 @@ mod tests {
             branch: None,
             parent_branch: None,
             base_sha: None,
+            pr_number: None,
         }
     }
 
@@ -1643,6 +1671,48 @@ mod tests {
     }
 
     #[test]
+    fn pr_number_persists_and_resets_on_name_reuse() {
+        let db = test_db();
+        let wm = WorkspaceManager::new(db.clone());
+        seed_repo(&db, "/r");
+
+        // Spawn an agent named "denali" and record a PR number for it.
+        let mut rec = new_agent_record(
+            "denali".into(),
+            "a".into(),
+            "claude".into(),
+            mk_repo("/r"),
+            "task".into(),
+            AgentView::Custom,
+        );
+        let id = rec.id.clone();
+        wm.add_agent(&mut rec).unwrap();
+        let subdir = wm.agent(&id).unwrap().repos[0].subdir.clone();
+
+        // No PR until one is recorded.
+        assert_eq!(wm.agent(&id).unwrap().repos[0].pr_number, None);
+        wm.set_repo_pr_number(&id, &subdir, 42).unwrap();
+        assert_eq!(wm.agent(&id).unwrap().repos[0].pr_number, Some(42));
+
+        // Deleting the agent drops its worktree row. A future agent that reuses
+        // the same name (and therefore the same branch) starts with no PR — so
+        // it can't resolve to the deleted agent's now-merged PR. This is the
+        // crux of binding PR identity to the worktree row, not the branch name.
+        wm.remove_agent(&id).unwrap();
+        let mut reused = new_agent_record(
+            "denali".into(),
+            "a".into(),
+            "claude".into(),
+            mk_repo("/r"),
+            "task".into(),
+            AgentView::Custom,
+        );
+        let reused_id = reused.id.clone();
+        wm.add_agent(&mut reused).unwrap();
+        assert_eq!(wm.agent(&reused_id).unwrap().repos[0].pr_number, None);
+    }
+
+    #[test]
     fn agent_status_transitions() {
         let db = test_db();
         let td = tempfile::tempdir().unwrap();
@@ -1750,6 +1820,7 @@ mod tests {
             branch: Some("quorum/do-the-thing".into()),
             parent_branch: Some("main".into()),
             base_sha: None,
+            pr_number: None,
         }];
         wm.restore_agent(&id, restored).unwrap();
         let a = wm.agent(&id).unwrap();
@@ -1814,6 +1885,7 @@ mod tests {
                 branch: None,
                 parent_branch: None,
                 base_sha: None,
+                pr_number: None,
             },
             "task".into(),
             AgentView::Custom,


### PR DESCRIPTION
## Problem

PR state was resolved on demand by running `gh pr view` against a worktree's **current branch**, with nothing persisted. Because a worktree's branch is `quorum/<workspace-name>` and workspace names are drawn from a finite, **recyclable** pool, a reused name could land on the same branch and have `gh pr view` surface a *previous* agent's now-merged PR.

## Fix

Persist the PR **number** against the immutable worktree row and look it up by number instead of by branch.

- **`migrations/0010_worktree_pr_number.sql`** — adds nullable `worktrees.pr_number` (mirrors the `base_sha` precedent). Survives archive/restore (restore UPDATEs rows), cascade-deletes with the agent.
- **`gh::pr_view_number`** — fetches PR state by explicit number, ignoring the checked-out branch.
- **`fetch_and_emit_pr_state`** — fetches by stored number when known; otherwise does **guarded discovery**: adopts and persists an out-of-band PR (agent ran `gh pr create`, or it was opened on github.com) **only if it is OPEN**, so a stale merged/closed PR on a recycled branch is never claimed.
- **Both PR-creation paths persist the number:** `commands::create_pr` (panel button) writes it directly; `rpc::open_pr` (agent) surfaces it via a new `RpcEffect::PrOpened` that the supervisor's RPC watcher records — keeping `rpc` decoupled from `Supervisor`/DB.

A recycled workspace name now starts with `NULL` `pr_number` and can no longer resolve to a prior agent's PR.

## Notes

- No frontend changes: the `pr:state_changed` payload and `PrState` shape are unchanged.
- Guarded discovery adopts an OPEN out-of-band PR on first sight. In the rare case a deleted workspace left an *open* PR on the remote and a new agent recycles that exact branch, the new agent adopts it — arguably correct, since it would push to the same head ref anyway. The merged/closed stale-PR case (the actual bug) is always ignored.

## Testing

- `cargo check` clean; full suite passes (267 tests), including a new `pr_number_persists_and_resets_on_name_reuse` test asserting a reused name comes back with no PR.
- The one failure (`pty_session::streams_output_and_reports_exit`) is a pre-existing, environment-flaky PTY test — fails identically with these changes stashed and touches no PR/workspace code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)