### PR TITLE
chore(settings): remove dead Landmark glyphs toggle

### DIFF
--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -56,8 +56,6 @@ function Popover({ onClose }: { onClose: () => void }) {
   const setAccent = useAppStore((s) => s.setAccent);
   const density = useAppStore((s) => s.density);
   const setDensity = useAppStore((s) => s.setDensity);
-  const showLandmarks = useAppStore((s) => s.showLandmarks);
-  const setShowLandmarks = useAppStore((s) => s.setShowLandmarks);
   const openSettingsScreen = useAppStore((s) => s.openSettingsScreen);
 
   return (
@@ -104,12 +102,6 @@ function Popover({ onClose }: { onClose: () => void }) {
             ]}
             onChange={setDensity}
           />
-        </SettingsRow>
-        <SettingsRow
-          label="Landmark glyphs"
-          description="Tiny location marks beside agent names"
-        >
-          <Toggle value={showLandmarks} onChange={setShowLandmarks} />
         </SettingsRow>
       </SettingsSection>
 

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -29,8 +29,6 @@ export function GeneralPane() {
   const setAccent = useAppStore((s) => s.setAccent);
   const density = useAppStore((s) => s.density);
   const setDensity = useAppStore((s) => s.setDensity);
-  const showLandmarks = useAppStore((s) => s.showLandmarks);
-  const setShowLandmarks = useAppStore((s) => s.setShowLandmarks);
   const features = useAppStore((s) => s.features);
   const setFeature = useAppStore((s) => s.setFeature);
   const revealLogs = useAppStore((s) => s.revealLogs);
@@ -89,9 +87,6 @@ export function GeneralPane() {
             ]}
             onChange={setDensity}
           />
-        </SetRow>
-        <SetRow title="Landmark glyphs" sub="Tiny location marks beside each agent name.">
-          <SetToggle on={showLandmarks} onClick={() => setShowLandmarks(!showLandmarks)} />
         </SetRow>
       </SetGroup>
 

--- a/src/components/Workspace/EmptyWorkspace.tsx
+++ b/src/components/Workspace/EmptyWorkspace.tsx
@@ -9,7 +9,6 @@ import { basename } from "../../util/format";
  *  First message in the composer spawns the real agent and dispatches
  *  the message in one go. */
 export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
-  const showLandmarks = useAppStore((s) => s.showLandmarks);
   const rerollDraftName = useAppStore((s) => s.rerollDraftName);
   const spawnFromDraft = useAppStore((s) => s.spawnFromDraft);
   const removeDraft = useAppStore((s) => s.removeDraft);
@@ -57,14 +56,12 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
             onClick={() => rerollDraftName(draft.id)}
             title="Reroll name"
           >
-            {showLandmarks && (
-              <LandmarkGlyph
-                name={draft.name}
-                size={36}
-                strokeWidth={1.1}
-                style={{ display: "inline-block", verticalAlign: "-6px", marginRight: 6 }}
-              />
-            )}
+            <LandmarkGlyph
+              name={draft.name}
+              size={36}
+              strokeWidth={1.1}
+              style={{ display: "inline-block", verticalAlign: "-6px", marginRight: 6 }}
+            />
             {draft.name}
           </div>
         </div>

--- a/src/store.ts
+++ b/src/store.ts
@@ -395,7 +395,6 @@ interface AppState {
   codeTheme: string;
   accent: string;
   density: Density;
-  showLandmarks: boolean;
   features: FeatureFlags;
   providerFlags: Record<string, boolean>;
   /** Live-probed version strings keyed by provider id. Populated async on
@@ -530,7 +529,6 @@ interface AppState {
   setCodeTheme: (id: string) => void;
   setAccent: (a: string) => void;
   setDensity: (d: Density) => void;
-  setShowLandmarks: (v: boolean) => void;
   setFeature: <K extends keyof FeatureFlags>(k: K, v: FeatureFlags[K]) => void;
   setProviderEnabled: (id: string, enabled: boolean) => void;
   /** Re-probe installed provider CLIs for versions + binary paths. Runs once
@@ -829,7 +827,6 @@ export const useAppStore = create<AppState>((set, get) => ({
   codeTheme: "quorum",
   accent: "copper",
   density: "comfortable" as Density,
-  showLandmarks: true,
   features: DEFAULT_FEATURES,
   providerFlags: {},
   providerVersions: {},
@@ -852,7 +849,6 @@ export const useAppStore = create<AppState>((set, get) => ({
         codeTheme: s.codeTheme || "quorum",
         accent: s.accent || "copper",
         density: (s.density as Density) || "comfortable",
-        showLandmarks: s.showLandmarks !== "false",
         features: parseFeatures(s.features),
         providerFlags: parseProviderFlags(s.providers),
         providerPathOverrides: parseProviderPathOverrides(s),
@@ -1932,10 +1928,6 @@ export const useAppStore = create<AppState>((set, get) => ({
   setDensity: (d) => {
     set({ density: d });
     setSetting("density", d);
-  },
-  setShowLandmarks: (v) => {
-    set({ showLandmarks: v });
-    setSetting("showLandmarks", String(v));
   },
   setFeature: (k, v) =>
     set((s) => {


### PR DESCRIPTION
Landmark glyphs were removed from the agent-list UI, leaving the `showLandmarks` toggle gating nothing visible. This removes the toggle from both the General Settings pane and the quick-settings popup, along with the `showLandmarks` store state, setter, and persistence. The one remaining live render site — the draft-name glyph in `EmptyWorkspace` — now renders unconditionally, matching the prior default-on behavior.

Note: `LandmarkGlyph` and `src/data/landmarks.ts` are still used (EmptyWorkspace draft name + onboarding exhibits) and were intentionally left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)