### PR TITLE
feat(observability): forward tracing WARN/ERROR to Sentry

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,7 +33,7 @@ tracing-appender = "0.2"
 # dependency on the Linux CI build. The Tauri plugin uses the Rust SDK as a
 # single transport and auto-injects @sentry/browser, so frontend + backend
 # errors land in one project. Disabled (no-op) when no DSN is baked in.
-sentry = { version = "0.42", default-features = false, features = ["backtrace", "contexts", "panic", "reqwest", "rustls"] }
+sentry = { version = "0.42", default-features = false, features = ["backtrace", "contexts", "panic", "reqwest", "rustls", "tracing"] }
 tauri-plugin-sentry = "0.5"
 portable-pty = "0.8"
 parking_lot = "0.12"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -111,10 +111,24 @@ fn init_logging() {
         }
     };
 
+    // Forward tracing events to Sentry: ERROR and WARN become captured events,
+    // so handled failures on users' machines (not just panics) surface in
+    // Sentry alongside the local log file. Lower levels become breadcrumbs that
+    // give those events context. Capture is a no-op when no DSN is baked in, so
+    // this stays inert in dev and unconfigured builds.
+    let sentry_layer = sentry::integrations::tracing::layer().event_filter(|md| {
+        use sentry::integrations::tracing::EventFilter;
+        match *md.level() {
+            tracing::Level::ERROR | tracing::Level::WARN => EventFilter::Event,
+            _ => EventFilter::Breadcrumb,
+        }
+    });
+
     tracing_subscriber::registry()
         .with(filter)
         .with(tracing_subscriber::fmt::layer())
         .with(file_layer)
+        .with(sentry_layer)
         .init();
 }
 


### PR DESCRIPTION
## Why

Sentry was only capturing Rust panics and native hard crashes. Handled failures on users' app instances — the kind logged via `tracing::warn!`/`error!` (e.g. `session sync ingested 0 records`, `No conversation found with session ID`) — never reached Sentry; they only landed in the local rolling log file. That's exactly the field signal we want for improving the app.

## What

Wire the Sentry SDK's `tracing` integration into the subscriber registry in `init_logging`:

- Add the `tracing` feature to the existing `sentry` dependency (no new crate).
- Add a `sentry::integrations::tracing::layer()` with a level-based filter:
  - `ERROR` and `WARN` → captured Sentry **events**
  - `INFO`/`DEBUG`/`TRACE` → **breadcrumbs** that give those events context

The layer sits behind the same `EnvFilter`, so nothing below the existing threshold changes. Capture is a no-op when no DSN is baked in (`QUORUM_SENTRY_DSN`), so dev and unconfigured builds stay inert — same gating as the panic hook.

## Notes

- Takes effect on the next DSN-enabled release build; the running 0.5.3 won't have it.
- Per the chosen policy, **all** WARN/ERROR are forwarded, including the benign recurring `session sync ... (transcript not found or unchanged)` warning (~88% of WARN volume). Sentry groups it into a single issue, but each occurrence counts against quota — can be muted in the Sentry UI or downgraded later if noisy.
- Frontend `ErrorBoundary` still only `console.error`s caught React errors (not forwarded); follow-up if we want those too.

## Test

`cargo check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)