### PR TITLE
fix(telemetry): address review feedback on consent, flush, and key naming

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -243,6 +243,12 @@ async fn set_agent_bin_override(
 /// Flip the anonymous-telemetry consent flag. Persists it to `settings` (so the
 /// renderer's `getAllSettings` sees it) and toggles the live pipeline, like
 /// `set_agent_bin_override` keeps the DB and in-memory state in sync.
+///
+/// Note the snake_case key: `telemetry_enabled` is backend-owned (written here,
+/// never via a frontend `setSetting`), so it intentionally breaks the camelCase
+/// convention of frontend-set settings. The renderer reads it as
+/// `s.telemetry_enabled`; do not introduce a `setSetting("telemetryEnabled", …)`
+/// caller — that would write a different key and silently break the toggle.
 #[tauri::command]
 async fn set_telemetry_enabled(
     enabled: bool,
@@ -255,6 +261,15 @@ async fn set_telemetry_enabled(
     }
     telemetry::set_enabled(enabled);
     Ok(())
+}
+
+/// Emit the deferred first `app_opened`. The frontend calls this once, when the
+/// user finishes onboarding (after the data-sharing disclosure on the final
+/// step). On a fresh install `setup` skips the launch-time `app_opened`, so this
+/// is the first such event — sent only once consent has been disclosed.
+#[tauri::command]
+fn track_app_opened() {
+    telemetry::track("app_opened", json!({}));
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -327,7 +342,7 @@ pub fn run() {
             // event fires. No-op in unconfigured builds (no PostHog key baked
             // in), so dev sends nothing.
             let version = app.package_info().version.to_string();
-            let (distinct_id, telemetry_enabled, prev_version) = {
+            let (distinct_id, telemetry_enabled, onboarding_complete, prev_version) = {
                 let conn = db.lock();
                 let distinct_id = match database::get_setting(&conn, "telemetry_distinct_id") {
                     Some(id) if !id.trim().is_empty() => id,
@@ -340,12 +355,23 @@ pub fn run() {
                 // Opt-out: anything but an explicit "false" means enabled.
                 let enabled =
                     database::get_setting(&conn, "telemetry_enabled").as_deref() != Some("false");
+                // Frontend-owned flag (camelCase), written when the user finishes
+                // the first-run onboarding — the flow that carries the data-sharing
+                // disclosure. Absent on a brand-new install.
+                let onboarded =
+                    database::get_setting(&conn, "onboardingComplete").as_deref() == Some("true");
                 let prev = database::get_setting(&conn, "last_seen_version");
                 let _ = database::set_setting(&conn, "last_seen_version", &version);
-                (distinct_id, enabled, prev)
+                (distinct_id, enabled, onboarded, prev)
             };
             telemetry::init(distinct_id, telemetry_enabled, version.clone());
-            telemetry::track("app_opened", json!({}));
+            // On a fresh install the first `app_opened` is deferred until
+            // onboarding completes (see the `track_app_opened` command), so no
+            // event is sent before the user has seen the data-sharing disclosure.
+            // Once onboarded, every launch reports `app_opened` here as usual.
+            if onboarding_complete {
+                telemetry::track("app_opened", json!({}));
+            }
             if let Some(prev) = prev_version {
                 if !prev.is_empty() && prev != version {
                     telemetry::track(
@@ -403,6 +429,7 @@ pub fn run() {
             db_query,
             set_agent_bin_override,
             set_telemetry_enabled,
+            track_app_opened,
             oauth::oauth_device_login,
             commands::get_workspace,
             commands::get_agent_diff_stats,
@@ -481,6 +508,12 @@ pub fn run() {
                 if let Some(supervisor) = app.try_state::<Arc<Supervisor>>() {
                     supervisor.shutdown();
                 }
+                // Give in-flight telemetry sends a brief, bounded chance to
+                // finish before the runtime tears down, rather than dropping
+                // events that fired just before quit (e.g. `pr_opened`).
+                tauri::async_runtime::block_on(telemetry::flush(
+                    std::time::Duration::from_secs(3),
+                ));
             }
         });
 }

--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -13,11 +13,12 @@
 //! email); event properties carry only categorical values, never paths, repo
 //! names, branches, or prompts.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::OnceLock;
 use std::time::Duration;
 
 use serde_json::{json, Map, Value};
+use tokio::sync::Notify;
 
 static TELEMETRY: OnceLock<Telemetry> = OnceLock::new();
 
@@ -29,6 +30,11 @@ struct Telemetry {
     super_props: Map<String, Value>,
     enabled: AtomicBool,
     client: reqwest::Client,
+    /// Count of send tasks still in flight, so `flush` can wait for them on
+    /// shutdown instead of letting the runtime cancel them mid-request.
+    inflight: AtomicUsize,
+    /// Notified whenever `inflight` drops back to zero.
+    idle: Notify,
 }
 
 /// PostHog project (capture) key, baked in at build time. Empty/unset disables
@@ -67,6 +73,8 @@ pub fn init(distinct_id: String, enabled: bool, version: String) {
         super_props,
         enabled: AtomicBool::new(enabled),
         client: reqwest::Client::new(),
+        inflight: AtomicUsize::new(0),
+        idle: Notify::new(),
     });
 }
 
@@ -95,6 +103,9 @@ pub fn track(event: &str, props: Value) {
     // `Client` is internally ref-counted, so cloning just shares the pool.
     let client = tel.client.clone();
     let url = tel.capture_url.clone();
+    // Register the task before spawning so a `flush` racing this call always
+    // sees it. `tel` is a `&'static`, so the task can decrement on completion.
+    tel.inflight.fetch_add(1, Ordering::SeqCst);
     tauri::async_runtime::spawn(async move {
         if let Err(e) = client
             .post(&url)
@@ -105,7 +116,30 @@ pub fn track(event: &str, props: Value) {
         {
             tracing::debug!(error = %e, "telemetry: send failed");
         }
+        if tel.inflight.fetch_sub(1, Ordering::SeqCst) == 1 {
+            tel.idle.notify_waiters();
+        }
     });
+}
+
+/// Wait up to `timeout` for in-flight sends to drain. Called on app exit so the
+/// last few events (e.g. one fired right before quit) aren't cancelled when the
+/// async runtime tears down — the same shutdown courtesy PostHog's own SDKs
+/// extend. Best-effort: anything still outstanding past the deadline is dropped.
+pub async fn flush(timeout: Duration) {
+    let Some(tel) = TELEMETRY.get() else { return };
+    let _ = tokio::time::timeout(timeout, async {
+        loop {
+            // Arm the wakeup *before* reading the counter so a task that finishes
+            // between the check and the await can't be missed.
+            let idle = tel.idle.notified();
+            if tel.inflight.load(Ordering::SeqCst) == 0 {
+                break;
+            }
+            idle.await;
+        }
+    })
+    .await;
 }
 
 /// Flip consent live (from the settings toggle). Takes effect on the next

--- a/src/api.ts
+++ b/src/api.ts
@@ -350,6 +350,9 @@ export const api = {
   // pipeline (events themselves are emitted from the backend).
   setTelemetryEnabled: (enabled: boolean) =>
     invoke<void>("set_telemetry_enabled", { enabled }),
+  // Emit the deferred first `app_opened` once onboarding completes — i.e. after
+  // the data-sharing disclosure has been shown. See `track_app_opened` (Rust).
+  trackAppOpened: () => invoke<void>("track_app_opened"),
   getAgentDiffStats: (agentId: string) =>
     invoke<DiffStats>("get_agent_diff_stats", { agentId }),
   addWorkspaceRepo: (repoPath: string) =>

--- a/src/store.ts
+++ b/src/store.ts
@@ -968,7 +968,16 @@ export const useAppStore = create<AppState>((set, get) => ({
         // flag once and gate both the chime and the unseen-results marker on
         // a genuine completion (a manual stop is neither).
         if (!interruptedAgents.delete(e.agent_id)) {
-          playAgentDone();
+          // The chime exists to notify you when you're NOT watching this
+          // agent — so skip it when you already are. "Watching" means the
+          // window holds focus AND this is the chat on screen; if either is
+          // false (other app focused, window minimized, or a different chat
+          // selected) the sound still fires.
+          const watchingThisChat =
+            document.hasFocus() && get().selectedAgentId === e.agent_id;
+          if (!watchingThisChat) {
+            playAgentDone();
+          }
           // Flag results for review on any agent the user isn't currently
           // looking at — this is the only signal for research-only turns that
           // leave no diff behind. Cleared when the agent is selected.

--- a/src/store.ts
+++ b/src/store.ts
@@ -869,7 +869,12 @@ export const useAppStore = create<AppState>((set, get) => ({
         viewMode: (s.viewMode as WorkspaceView) || "custom",
         gitCommitAction: isCommitAction(s.gitCommitAction) ? s.gitCommitAction : "agent-commit-pr",
         onboardingComplete: s.onboardingComplete === "true",
-        // Telemetry is opt-out: only an explicit "false" disables it.
+        // Telemetry is opt-out: only an explicit "false" disables it. The key is
+        // snake_case (not camelCase like its peers) on purpose: it's backend-
+        // owned — written by the `set_telemetry_enabled` Rust command, never by a
+        // frontend `setSetting` — so we read it as `s.telemetry_enabled`. Don't
+        // switch a caller to `setSetting("telemetryEnabled", …)`: that's a
+        // different key and the toggle would silently stop working.
         telemetryEnabled: s.telemetry_enabled !== "false",
         // Auto-open the welcome tour for new users (no completion flag yet).
         onboardingOpen: s.onboardingComplete !== "true",
@@ -1887,8 +1892,13 @@ export const useAppStore = create<AppState>((set, get) => ({
   setSettingsSection: (section) => set({ settingsSection: section }),
   openOnboarding: () => set({ onboardingOpen: true }),
   closeOnboarding: () => {
+    const firstCompletion = !get().onboardingComplete;
     set({ onboardingOpen: false, onboardingComplete: true });
     setSetting("onboardingComplete", "true");
+    // On a fresh install the backend defers the first `app_opened` until now, so
+    // the event lands only after the data-sharing disclosure shown during
+    // onboarding has been seen. Fire it once, on the first completion.
+    if (firstCompletion) void api.trackAppOpened();
   },
   saveAccount: async (patch) => {
     const current = get().account;

--- a/src/store.ts
+++ b/src/store.ts
@@ -974,7 +974,16 @@ export const useAppStore = create<AppState>((set, get) => ({
         // flag once and gate both the chime and the unseen-results marker on
         // a genuine completion (a manual stop is neither).
         if (!interruptedAgents.delete(e.agent_id)) {
-          playAgentDone();
+          // The chime exists to notify you when you're NOT watching this
+          // agent — so skip it when you already are. "Watching" means the
+          // window holds focus AND this is the chat on screen; if either is
+          // false (other app focused, window minimized, or a different chat
+          // selected) the sound still fires.
+          const watchingThisChat =
+            document.hasFocus() && get().selectedAgentId === e.agent_id;
+          if (!watchingThisChat) {
+            playAgentDone();
+          }
           // Flag results for review on any agent the user isn't currently
           // looking at — this is the only signal for research-only turns that
           // leave no diff behind. Cleared when the agent is selected.


### PR DESCRIPTION
Resolves the three Greptile comments on #190.

- Defer first `app_opened` until onboarding completes, so no event is sent
  before the data-sharing disclosure is shown. New `track_app_opened`
  command fires it on first completion; returning users report it every
  launch as before.
- Flush in-flight telemetry sends on exit — outstanding tasks are awaited
  (bounded to 3s) in the `ExitRequested` handler so events fired right
  before quit aren't cancelled by runtime teardown.
- Document that `telemetry_enabled` is a backend-owned, intentionally
  snake_case settings key, warning against a `setSetting("telemetryEnabled")`
  caller that would silently break the toggle.
