### PR TITLE
Allow re-using worktree names that's been used previously

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -97,7 +97,11 @@ pub async fn get_agent_diff_stats(
 /// the picker avoids collisions.
 #[tauri::command]
 pub fn allocate_draft_name(used: Vec<String>) -> String {
-    names::allocate(&used.into_iter().collect())
+    // Fold in the names already on disk (other instances, stale worktrees) so a
+    // draft never previews a name that `git worktree add` would later reject.
+    let mut reserved: std::collections::HashSet<String> = used.into_iter().collect();
+    reserved.extend(crate::workspace::occupied_worktree_dirs());
+    names::allocate(&reserved)
 }
 
 #[tauri::command]

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -83,7 +83,13 @@ pub async fn worktree_add_detached(
     // path still isn't a live worktree, clear the orphan and retry once. We
     // never delete a *registered* worktree: that would be someone else's live
     // checkout, so in that case we fall through to the original error.
-    if stderr.contains("already exists") && !is_registered_worktree(repo, worktree_path).await {
+    //
+    // We gate on `worktree_path.exists()` rather than on the git error text:
+    // the stderr phrasing ("already exists") varies by git version and is
+    // translated under non-C locales, so matching it would silently skip the
+    // recovery on, say, a French or Japanese machine. The on-disk check is the
+    // actual condition this branch handles and is locale-independent.
+    if worktree_path.exists() && !is_registered_worktree(repo, worktree_path).await {
         let _ = worktree_prune(repo).await;
         if !is_registered_worktree(repo, worktree_path).await && worktree_path.exists() {
             if let Err(e) = tokio::fs::remove_dir_all(worktree_path).await {
@@ -124,18 +130,25 @@ async fn is_registered_worktree(repo: &Path, path: &Path) -> bool {
         Ok(out) if out.status.success() => out,
         _ => return false,
     };
-    let canonical = std::fs::canonicalize(path);
-    String::from_utf8_lossy(&out.stdout)
-        .lines()
-        .filter_map(|l| l.strip_prefix("worktree "))
-        .any(|p| {
-            let listed = Path::new(p);
-            listed == path
-                || match (&canonical, std::fs::canonicalize(listed)) {
-                    (Ok(a), Ok(b)) => a == &b,
-                    _ => false,
+    // `tokio::fs::canonicalize` keeps these path-resolution syscalls off the
+    // executor thread — `std::fs` would block it if the filesystem is slow
+    // (network mount, loaded disk).
+    let canonical = tokio::fs::canonicalize(path).await.ok();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for listed in stdout.lines().filter_map(|l| l.strip_prefix("worktree ")) {
+        let listed = Path::new(listed);
+        if listed == path {
+            return true;
+        }
+        if let Some(a) = &canonical {
+            if let Ok(b) = tokio::fs::canonicalize(listed).await {
+                if a == &b {
+                    return true;
                 }
-        })
+            }
+        }
+    }
+    false
 }
 
 /// Best-effort fetch of `branch` from `origin` so a freshly-spawned worktree

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -72,13 +72,70 @@ pub async fn worktree_add_detached(
         .args(&args)
         .output()
         .await?;
-    if !out.status.success() {
-        return Err(Error::Git(format!(
-            "worktree add --detach failed: {}",
-            String::from_utf8_lossy(&out.stderr).trim()
-        )));
+    if out.status.success() {
+        return Ok(());
     }
-    Ok(())
+    let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+
+    // Recoverable case: the target path already exists but git doesn't track it
+    // as a worktree — an orphan left by a crashed spawn or another instance
+    // that shares this worktrees root. Prune stale registrations, and if the
+    // path still isn't a live worktree, clear the orphan and retry once. We
+    // never delete a *registered* worktree: that would be someone else's live
+    // checkout, so in that case we fall through to the original error.
+    if stderr.contains("already exists") && !is_registered_worktree(repo, worktree_path).await {
+        let _ = worktree_prune(repo).await;
+        if !is_registered_worktree(repo, worktree_path).await && worktree_path.exists() {
+            if let Err(e) = tokio::fs::remove_dir_all(worktree_path).await {
+                tracing::warn!(path = %worktree_path.display(), error = %e, "orphan worktree dir cleanup failed");
+            }
+        }
+        if !worktree_path.exists() {
+            let retry = Command::new("git")
+                .current_dir(repo)
+                .args(&args)
+                .output()
+                .await?;
+            if retry.status.success() {
+                tracing::info!(path = %worktree_path.display(), "recovered orphan worktree path on spawn");
+                return Ok(());
+            }
+            return Err(Error::Git(format!(
+                "worktree add --detach failed: {}",
+                String::from_utf8_lossy(&retry.stderr).trim()
+            )));
+        }
+    }
+
+    Err(Error::Git(format!("worktree add --detach failed: {stderr}")))
+}
+
+/// Is `path` currently registered as a worktree of `repo`? Used by spawn to
+/// tell an orphan directory (safe to clear) from a live checkout (must not
+/// touch). Any error listing worktrees is treated as "not registered" — the
+/// caller's follow-up `path.exists()` guard keeps that conservative.
+async fn is_registered_worktree(repo: &Path, path: &Path) -> bool {
+    let out = match Command::new("git")
+        .current_dir(repo)
+        .args(["worktree", "list", "--porcelain"])
+        .output()
+        .await
+    {
+        Ok(out) if out.status.success() => out,
+        _ => return false,
+    };
+    let canonical = std::fs::canonicalize(path);
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(|l| l.strip_prefix("worktree "))
+        .any(|p| {
+            let listed = Path::new(p);
+            listed == path
+                || match (&canonical, std::fs::canonicalize(listed)) {
+                    (Ok(a), Ok(b)) => a == &b,
+                    _ => false,
+                }
+        })
 }
 
 /// Best-effort fetch of `branch` from `origin` so a freshly-spawned worktree
@@ -451,6 +508,54 @@ mod tests {
         let wt2 = td.path().join("wt2");
         worktree_add_detached(repo, &wt2, None).await.unwrap();
         assert_eq!(rev_parse(&wt2, "HEAD").await.unwrap(), head);
+    }
+
+    #[tokio::test]
+    async fn worktree_add_detached_recovers_orphan_dir() {
+        // An orphan directory at the target path (left by a crashed spawn or a
+        // foreign instance) is not a registered worktree, so add should clear
+        // it and succeed rather than failing with "already exists".
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        init_repo(&repo).await.unwrap();
+        config(&repo, "user.email", "t@example.com").await;
+        config(&repo, "user.name", "Tester").await;
+        std::fs::write(repo.join("a.txt"), b"x").unwrap();
+        commit_all(&repo, "first").await.unwrap();
+
+        // Pre-create the target as a plain, untracked directory with a file.
+        let wt = td.path().join("orphan");
+        std::fs::create_dir_all(&wt).unwrap();
+        std::fs::write(wt.join("leftover.txt"), b"stale").unwrap();
+
+        worktree_add_detached(&repo, &wt, None).await.unwrap();
+        assert!(is_registered_worktree(&repo, &wt).await);
+        // The stale contents were cleared and replaced by the checkout.
+        assert!(!wt.join("leftover.txt").exists());
+        assert!(wt.join("a.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn worktree_add_detached_refuses_to_clobber_live_worktree() {
+        // If the path is a *registered* worktree (someone's live checkout), add
+        // must fail rather than delete it.
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        init_repo(&repo).await.unwrap();
+        config(&repo, "user.email", "t@example.com").await;
+        config(&repo, "user.name", "Tester").await;
+        std::fs::write(repo.join("a.txt"), b"x").unwrap();
+        commit_all(&repo, "first").await.unwrap();
+
+        let wt = td.path().join("live");
+        worktree_add_detached(&repo, &wt, None).await.unwrap();
+        std::fs::write(wt.join("precious.txt"), b"keep me").unwrap();
+
+        // A second add at the same live path must error and leave it untouched.
+        assert!(worktree_add_detached(&repo, &wt, None).await.is_err());
+        assert!(wt.join("precious.txt").exists());
     }
 }
 

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -118,8 +118,11 @@ pub async fn worktree_add_detached(
 
 /// Is `path` currently registered as a worktree of `repo`? Used by spawn to
 /// tell an orphan directory (safe to clear) from a live checkout (must not
-/// touch). Any error listing worktrees is treated as "not registered" — the
-/// caller's follow-up `path.exists()` guard keeps that conservative.
+/// touch). A `false` here authorizes the caller to `remove_dir_all` the path,
+/// so when the listing itself fails (transient lock contention, a process-limit
+/// spike) we return `true`: "can't confirm it's an orphan, so don't touch it."
+/// The caller then falls through to the original error rather than risking the
+/// deletion of a live checkout.
 async fn is_registered_worktree(repo: &Path, path: &Path) -> bool {
     let out = match Command::new("git")
         .current_dir(repo)
@@ -128,7 +131,7 @@ async fn is_registered_worktree(repo: &Path, path: &Path) -> bool {
         .await
     {
         Ok(out) if out.status.success() => out,
-        _ => return false,
+        _ => return true,
     };
     // `tokio::fs::canonicalize` keeps these path-resolution syscalls off the
     // executor thread — `std::fs` would block it if the filesystem is slow

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -374,24 +374,6 @@ impl WorkspaceManager {
     pub fn add_agent(&self, record: &mut AgentRecord) -> Result<()> {
         let conn = self.db.lock();
 
-        // Recycling a freed name: the allocator only hands back ids held by
-        // *archived* agents (live ones and on-disk worktrees are excluded), but
-        // the archived row still owns this primary key. Evict it so the INSERT
-        // below doesn't trip the PK constraint. Cascades clear its sessions,
-        // worktrees, and session records. A *live* row with this id would be a
-        // genuine bug, so we deliberately don't touch those — the INSERT will
-        // surface the conflict instead of silently clobbering a running agent.
-        let recycled = conn.execute(
-            "DELETE FROM workspaces WHERE id = ?1 AND archived_at IS NOT NULL",
-            rusqlite::params![record.id],
-        )?;
-        if recycled > 0 {
-            tracing::info!(
-                agent_id = %record.id,
-                "reusing archived agent name; evicted its archived record",
-            );
-        }
-
         // Look up project_id from the primary repo path.
         let project_id = if let Some(primary) = record.repos.first() {
             let path_str = primary.repo_path.to_string_lossy().to_string();
@@ -406,8 +388,34 @@ impl WorkspaceManager {
             .map(|dt| dt.timestamp_millis())
             .unwrap_or_else(|_| now_millis());
 
+        // Evicting the recycled archived row and writing its replacement must be
+        // atomic. Without a transaction the DELETE auto-commits immediately, so
+        // any later failure (a failed INSERT, disk-full, UUID collision) would
+        // leave the archived agent — and its cascaded sessions/worktrees —
+        // permanently gone with nothing in its place. The transaction rolls the
+        // DELETE back on any error before `commit`.
+        let tx = conn.unchecked_transaction()?;
+
+        // Recycling a freed name: the allocator only hands back ids held by
+        // *archived* agents (live ones and on-disk worktrees are excluded), but
+        // the archived row still owns this primary key. Evict it so the INSERT
+        // below doesn't trip the PK constraint. Cascades clear its sessions,
+        // worktrees, and session records. A *live* row with this id would be a
+        // genuine bug, so we deliberately don't touch those — the INSERT will
+        // surface the conflict instead of silently clobbering a running agent.
+        let recycled = tx.execute(
+            "DELETE FROM workspaces WHERE id = ?1 AND archived_at IS NOT NULL",
+            rusqlite::params![record.id],
+        )?;
+        if recycled > 0 {
+            tracing::info!(
+                agent_id = %record.id,
+                "reusing archived agent name; evicted its archived record",
+            );
+        }
+
         // The workspace is the durable work-area (identity + task metadata).
-        conn.execute(
+        tx.execute(
             "INSERT INTO workspaces (id, project_id, name, task, created_at)
              VALUES (?1, ?2, ?3, ?4, ?5)",
             rusqlite::params![
@@ -422,7 +430,7 @@ impl WorkspaceManager {
         // Exactly one provider run per workspace today. The runtime status is
         // not persisted — it derives from the workspace/session dispositions.
         let session_id = uuid::Uuid::new_v4().to_string();
-        conn.execute(
+        tx.execute(
             "INSERT INTO sessions (id, workspace_id, provider, view, provider_session_id, last_error, effort, model, created_at)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             rusqlite::params![
@@ -440,9 +448,10 @@ impl WorkspaceManager {
 
         // Insert worktree records for each TrackedRepo.
         for repo in &record.repos {
-            Self::insert_worktree(&conn, &record.id, repo)?;
+            Self::insert_worktree(&tx, &record.id, repo)?;
         }
 
+        tx.commit()?;
         Ok(())
     }
 

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -354,16 +354,43 @@ impl WorkspaceManager {
 
     pub fn allocate_agent_id(&self) -> Result<String> {
         let conn = self.db.lock();
-        let mut stmt = conn.prepare("SELECT id FROM workspaces")?;
-        let used: HashSet<String> = stmt
+        // Only *live* (non-archived) agents reserve their name. Once an agent
+        // is archived its worktree is torn down, so the name is free to reuse —
+        // unless a directory still lingers on disk (cleanup failed, or it
+        // belongs to another running instance such as a dev build, which shares
+        // this same worktrees root). The on-disk listing closes that gap: it's
+        // the only namespace shared across every Quorum process on the machine,
+        // so a collision there is what actually breaks `git worktree add`.
+        let mut stmt =
+            conn.prepare("SELECT id FROM workspaces WHERE archived_at IS NULL")?;
+        let mut used: HashSet<String> = stmt
             .query_map([], |row| row.get::<_, String>(0))?
             .filter_map(|r| r.ok())
             .collect();
+        used.extend(occupied_worktree_dirs());
         Ok(names::allocate(&used))
     }
 
     pub fn add_agent(&self, record: &mut AgentRecord) -> Result<()> {
         let conn = self.db.lock();
+
+        // Recycling a freed name: the allocator only hands back ids held by
+        // *archived* agents (live ones and on-disk worktrees are excluded), but
+        // the archived row still owns this primary key. Evict it so the INSERT
+        // below doesn't trip the PK constraint. Cascades clear its sessions,
+        // worktrees, and session records. A *live* row with this id would be a
+        // genuine bug, so we deliberately don't touch those — the INSERT will
+        // surface the conflict instead of silently clobbering a running agent.
+        let recycled = conn.execute(
+            "DELETE FROM workspaces WHERE id = ?1 AND archived_at IS NOT NULL",
+            rusqlite::params![record.id],
+        )?;
+        if recycled > 0 {
+            tracing::info!(
+                agent_id = %record.id,
+                "reusing archived agent name; evicted its archived record",
+            );
+        }
 
         // Look up project_id from the primary repo path.
         let project_id = if let Some(primary) = record.repos.first() {
@@ -1470,12 +1497,42 @@ pub fn allocate_repo_subdir(repo_path: &Path, used: &[String]) -> String {
     }
 }
 
+/// Absolute path to the root holding every agent's worktrees:
+/// `~/.quorum/worktrees/`. Shared by *all* Quorum processes on the machine
+/// (release and dev builds alike — only the database is namespaced per build),
+/// which is why name allocation has to consult it directly.
+pub fn worktrees_root() -> Result<PathBuf> {
+    let home = dirs::home_dir()
+        .ok_or_else(|| Error::Other("HOME directory not available".into()))?;
+    Ok(home.join(".quorum").join("worktrees"))
+}
+
+/// The set of agent-id directories that physically exist under the worktrees
+/// root. These are off-limits as new agent ids regardless of what any single
+/// database knows: the directory is the resource `git worktree add` collides
+/// on. Best-effort — a missing or unreadable root just yields an empty set.
+pub fn occupied_worktree_dirs() -> HashSet<String> {
+    match worktrees_root() {
+        Ok(root) => occupied_worktree_dirs_in(&root),
+        Err(_) => HashSet::new(),
+    }
+}
+
+fn occupied_worktree_dirs_in(root: &Path) -> HashSet<String> {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return HashSet::new();
+    };
+    entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+        .filter_map(|e| e.file_name().into_string().ok())
+        .collect()
+}
+
 /// Absolute path to the dir holding all of one agent's worktrees:
 /// `~/.quorum/worktrees/<agent-id>/`.
 pub fn agent_parent_dir(agent_id: &str) -> Result<PathBuf> {
-    let home = dirs::home_dir()
-        .ok_or_else(|| Error::Other("HOME directory not available".into()))?;
-    Ok(home.join(".quorum").join("worktrees").join(agent_id))
+    Ok(worktrees_root()?.join(agent_id))
 }
 
 /// Absolute path to one tracked repo's worktree:
@@ -2206,6 +2263,156 @@ mod tests {
         assert_eq!(
             allocate_repo_subdir(Path::new("/foo/fresh"), &used),
             "fresh"
+        );
+    }
+
+    #[test]
+    fn occupied_worktree_dirs_lists_only_subdirs() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("kilimanjaro")).unwrap();
+        std::fs::create_dir_all(root.path().join("seychelles")).unwrap();
+        // A stray file (not a dir) must not be reported as an occupied name.
+        std::fs::write(root.path().join("notes.txt"), b"x").unwrap();
+
+        let found = occupied_worktree_dirs_in(root.path());
+        assert_eq!(found.len(), 2);
+        assert!(found.contains("kilimanjaro"));
+        assert!(found.contains("seychelles"));
+        assert!(!found.contains("notes.txt"));
+    }
+
+    #[test]
+    fn occupied_worktree_dirs_empty_when_root_missing() {
+        let root = tempfile::tempdir().unwrap();
+        let missing = root.path().join("does-not-exist");
+        assert!(occupied_worktree_dirs_in(&missing).is_empty());
+    }
+
+    /// Mark a workspace archived directly (tests don't go through the full
+    /// archive flow, which needs live worktrees on disk).
+    fn mark_archived(db: &Arc<Mutex<Connection>>, id: &str) {
+        let conn = db.lock();
+        conn.execute(
+            "UPDATE workspaces SET archived_at = ?1 WHERE id = ?2",
+            rusqlite::params![now_millis(), id],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn add_agent_reuses_archived_name() {
+        let db = test_db();
+        seed_repo(&db, "/r");
+        let wm = WorkspaceManager::new(db.clone());
+
+        let mut first = new_agent_record(
+            "kilimanjaro".into(),
+            "first".into(),
+            "claude".into(),
+            mk_repo("/r"),
+            String::new(),
+            AgentView::Custom,
+        );
+        wm.add_agent(&mut first).unwrap();
+        mark_archived(&db, "kilimanjaro");
+
+        // Recycling the freed name must succeed — the archived row is evicted
+        // rather than tripping the primary-key constraint.
+        let mut second = new_agent_record(
+            "kilimanjaro".into(),
+            "second".into(),
+            "claude".into(),
+            mk_repo("/r"),
+            String::new(),
+            AgentView::Custom,
+        );
+        wm.add_agent(&mut second).unwrap();
+
+        let conn = db.lock();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM workspaces WHERE id = 'kilimanjaro'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1, "exactly one row should remain");
+        let (name, archived): (String, Option<i64>) = conn
+            .query_row(
+                "SELECT name, archived_at FROM workspaces WHERE id = 'kilimanjaro'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(name, "second", "the live agent should have replaced it");
+        assert!(archived.is_none(), "the recycled agent must be live");
+    }
+
+    #[test]
+    fn add_agent_does_not_evict_a_live_name_clash() {
+        let db = test_db();
+        seed_repo(&db, "/r");
+        let wm = WorkspaceManager::new(db.clone());
+
+        let mut first = new_agent_record(
+            "kilimanjaro".into(),
+            "first".into(),
+            "claude".into(),
+            mk_repo("/r"),
+            String::new(),
+            AgentView::Custom,
+        );
+        wm.add_agent(&mut first).unwrap();
+
+        // A *live* id clash is a real bug: the INSERT must fail loudly rather
+        // than clobber the running agent.
+        let mut clash = new_agent_record(
+            "kilimanjaro".into(),
+            "second".into(),
+            "claude".into(),
+            mk_repo("/r"),
+            String::new(),
+            AgentView::Custom,
+        );
+        assert!(wm.add_agent(&mut clash).is_err());
+
+        let conn = db.lock();
+        let name: String = conn
+            .query_row(
+                "SELECT name FROM workspaces WHERE id = 'kilimanjaro'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(name, "first", "the original live agent must survive");
+    }
+
+    #[test]
+    fn allocate_agent_id_excludes_archived_from_reservation() {
+        let db = test_db();
+        seed_repo(&db, "/r");
+        let wm = WorkspaceManager::new(db.clone());
+
+        // Fill the whole pool with archived agents, then one live agent.
+        for place in names::PLACES {
+            let mut rec = new_agent_record(
+                (*place).into(),
+                (*place).into(),
+                "claude".into(),
+                mk_repo("/r"),
+                String::new(),
+                AgentView::Custom,
+            );
+            wm.add_agent(&mut rec).unwrap();
+            mark_archived(&db, place);
+        }
+
+        // Every pool name is archived (so all are reusable) — the allocator
+        // should hand back a bare pool name, never a "-N" exhaustion suffix.
+        let id = wm.allocate_agent_id().unwrap();
+        assert!(
+            names::PLACES.contains(&id.as_str()),
+            "expected a reusable pool name, got {id}"
         );
     }
 }


### PR DESCRIPTION
## Changes

1. workspace.rs — filesystem-aware, active-only allocation
allocate_agent_id now reserves names from SELECT id FROM workspaces WHERE archived_at IS NULL unioned with the on-disk worktree directories (occupied_worktree_dirs). The directory listing is the only namespace shared across all instances, so checking it is what actually prevents the collision — and it also covers orphan dirs from failed cleanups. Added worktrees_root() + occupied_worktree_dirs() (with a testable _in(root) inner fn); agent_parent_dir now routes through worktrees_root.

2. workspace.rs — archived names become reusable (your request)
Since the place-name is the workspace primary key and archived rows keep it, add_agent now evicts a same-named archived row (cascade) right before inserting. Live id clashes are deliberately not evicted — those stay a hard error so a running agent can never be clobbered. (Renaming the archived row instead was a dead end: no ON UPDATE CASCADE, and the claude session JSONL is keyed off the worktree path, so a rename would break restore.)

3. git.rs — resilient spawn
worktree_add_detached, on an "already exists" failure, prunes and — only if the path is not a registered worktree — clears the orphan dir and retries once. A live registered worktree is never touched.

4. commands.rs — allocate_draft_name folds in the on-disk dirs too, so the sidebar never previews a name that would later fail.