### PR TITLE
fix(claude): honor CLAUDE_CONFIG_DIR for transcript locate + sandbox

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -432,8 +432,9 @@ fn pi_read(paths: &[PathBuf]) -> Vec<RawRecord> {
 // ── Claude ──
 // Claude is the lone persistent-runner agent (not in PER_TURN_AGENTS), launched
 // `--session-id <uuid>` / `--resume <uuid>`, so it writes
-// `~/.claude/projects/<slug>/<uuid>.jsonl`. find_session_jsonl already locates
-// it. Content lines carry a top-level
+// `<config-dir>/projects/<slug>/<uuid>.jsonl` (config-dir = CLAUDE_CONFIG_DIR or
+// `~/.claude`). find_session_jsonl already locates it. Content lines carry a
+// top-level
 // `uuid`; metadata lines (mode/permission-mode/…) don't → positional fallback.
 
 fn claude_locate(session_id: &str, _cwd: &Path) -> Vec<PathBuf> {
@@ -1079,7 +1080,11 @@ fn prepare_sandbox(
     rpc_dir: &Path,
     home: &Path,
 ) -> Result<tempfile::NamedTempFile> {
-    let profile_text = sandbox::build_profile(writable_root, rpc_dir, home)?;
+    // The agent inherits the app's env, so the CLAUDE_CONFIG_DIR it'll write to
+    // is whatever this process sees (quorum doesn't override it). Grant it.
+    let claude_config_dir = std::env::var_os("CLAUDE_CONFIG_DIR").map(PathBuf::from);
+    let profile_text =
+        sandbox::build_profile(writable_root, rpc_dir, home, claude_config_dir.as_deref())?;
     let mut profile_file = tempfile::Builder::new()
         .prefix("quorum-sandbox-")
         .suffix(".sb")

--- a/src-tauri/src/sandbox.rs
+++ b/src-tauri/src/sandbox.rs
@@ -22,7 +22,7 @@
 //! `danger-full-access`) so the two don't fight, leaving `sandbox-exec` as the
 //! sole boundary.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::error::{Error, Result};
 
@@ -49,9 +49,12 @@ pub fn build_profile(
     let claude_state = sbpl_string(&format!("{home_s}/.claude"));
     let claude_json = sbpl_string(&format!("{home_s}/.claude.json"));
     // A non-default `CLAUDE_CONFIG_DIR` is where claude actually writes its
-    // config/transcripts/auth, so grant it too. Skip when it's the default
-    // `~/.claude` already allowed above, to avoid a redundant entry.
+    // config/transcripts/auth, so grant it too. Resolve symlinks first so the
+    // SBPL path matches what the sandbox sees at write time (every other entry
+    // is canonical); then skip it when it's the default `~/.claude` already
+    // allowed above, to avoid a redundant entry.
     let claude_config_extra = claude_config_dir
+        .map(resolve_existing_prefix)
         .map(|p| p.to_string_lossy().into_owned())
         .filter(|p| *p != format!("{home_s}/.claude"))
         .map(|p| format!("\n  (subpath {})", sbpl_string(&p)))
@@ -116,9 +119,35 @@ fn sbpl_string(s: &str) -> String {
     format!("\"{escaped}\"")
 }
 
-fn canonical(p: &Path) -> Result<std::path::PathBuf> {
+fn canonical(p: &Path) -> Result<PathBuf> {
     std::fs::canonicalize(p)
         .map_err(|e| Error::Other(format!("canonicalize {}: {e}", p.display())))
+}
+
+/// Resolve symlinks in the longest existing prefix of `p`, then re-append the
+/// not-yet-existing tail. `fs::canonicalize` alone can't be used because it
+/// requires the whole path to exist, but `CLAUDE_CONFIG_DIR` may point at a dir
+/// claude hasn't created yet. Resolving the existing prefix still collapses the
+/// well-known macOS symlinks (`/tmp` → `/private/tmp`, `/var` → `/private/var`),
+/// so the emitted SBPL path matches the sandbox's resolved write path. Falls
+/// back to `p` unchanged if nothing resolves (e.g. a bogus path).
+fn resolve_existing_prefix(p: &Path) -> PathBuf {
+    let mut cur = p.to_path_buf();
+    let mut tail: Vec<std::ffi::OsString> = Vec::new();
+    loop {
+        if let Ok(real) = std::fs::canonicalize(&cur) {
+            let mut out = real;
+            out.extend(tail.iter().rev());
+            return out;
+        }
+        match cur.file_name() {
+            Some(name) => tail.push(name.to_os_string()),
+            None => return p.to_path_buf(),
+        }
+        if !cur.pop() {
+            return p.to_path_buf();
+        }
+    }
 }
 
 #[cfg(test)]
@@ -167,9 +196,41 @@ mod tests {
         // ~/.claude was on the allow-list.
         let (_td, root, rpc, home) = sandbox_dirs();
         let cfg = home.join(".claude-eve");
+        std::fs::create_dir_all(&cfg).unwrap();
 
         let profile = build_profile(&root, &rpc, &home, Some(cfg.as_path())).unwrap();
-        assert!(profile.contains(&format!("(subpath \"{}\")", cfg.display())));
+        // The emitted path must be canonical (symlink-resolved) so it matches
+        // what the sandbox resolves at write time — e.g. on macOS the tempdir
+        // lives under /var → /private/var.
+        let canonical_cfg = std::fs::canonicalize(&cfg).unwrap();
+        assert!(profile.contains(&format!("(subpath \"{}\")", canonical_cfg.display())));
+    }
+
+    #[test]
+    fn resolve_existing_prefix_resolves_symlinks_through_missing_leaf() {
+        // CLAUDE_CONFIG_DIR may point at a dir claude hasn't created yet, under
+        // a symlinked prefix (the /tmp → /private/tmp case). The existing prefix
+        // must be symlink-resolved and the missing leaf re-appended verbatim.
+        let td = tempfile::tempdir().unwrap();
+        let real = td.path().join("real");
+        std::fs::create_dir_all(&real).unwrap();
+        let link = td.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let resolved = resolve_existing_prefix(&link.join("not-created-yet"));
+        let expected = std::fs::canonicalize(&real).unwrap().join("not-created-yet");
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn resolve_existing_prefix_canonicalizes_an_existing_dir() {
+        let td = tempfile::tempdir().unwrap();
+        let dir = td.path().join("cfg");
+        std::fs::create_dir_all(&dir).unwrap();
+        assert_eq!(
+            resolve_existing_prefix(&dir),
+            std::fs::canonicalize(&dir).unwrap()
+        );
     }
 
     #[test]

--- a/src-tauri/src/sandbox.rs
+++ b/src-tauri/src/sandbox.rs
@@ -29,7 +29,15 @@ use crate::error::{Error, Result};
 /// Build the SBPL profile. `writable_root` is the agent's parent dir;
 /// `rpc_dir` is its private file-mailbox (`~/.quorum/rpc/<id>/`), which lives
 /// outside the worktree tree and so needs its own allow entry.
-pub fn build_profile(writable_root: &Path, rpc_dir: &Path, home: &Path) -> Result<String> {
+/// `claude_config_dir` is the value of `CLAUDE_CONFIG_DIR` the agent runs with
+/// (`None` = default `~/.claude`); when set elsewhere the agent writes its
+/// config/transcripts/auth there, so it must be writable too.
+pub fn build_profile(
+    writable_root: &Path,
+    rpc_dir: &Path,
+    home: &Path,
+    claude_config_dir: Option<&Path>,
+) -> Result<String> {
     let writable_root = canonical(writable_root)?;
     let rpc_root = canonical(rpc_dir)?;
     let home = canonical(home)?;
@@ -40,6 +48,14 @@ pub fn build_profile(writable_root: &Path, rpc_dir: &Path, home: &Path) -> Resul
 
     let claude_state = sbpl_string(&format!("{home_s}/.claude"));
     let claude_json = sbpl_string(&format!("{home_s}/.claude.json"));
+    // A non-default `CLAUDE_CONFIG_DIR` is where claude actually writes its
+    // config/transcripts/auth, so grant it too. Skip when it's the default
+    // `~/.claude` already allowed above, to avoid a redundant entry.
+    let claude_config_extra = claude_config_dir
+        .map(|p| p.to_string_lossy().into_owned())
+        .filter(|p| *p != format!("{home_s}/.claude"))
+        .map(|p| format!("\n  (subpath {})", sbpl_string(&p)))
+        .unwrap_or_default();
     let npm_state = sbpl_string(&format!("{home_s}/.npm"));
     let cache_state = sbpl_string(&format!("{home_s}/.cache"));
     let config_state = sbpl_string(&format!("{home_s}/.config"));
@@ -73,7 +89,7 @@ pub fn build_profile(writable_root: &Path, rpc_dir: &Path, home: &Path) -> Resul
   (subpath "/private/var/folders")
   (subpath "/private/var/tmp")
   (subpath {claude_state})
-  (literal {claude_json})
+  (literal {claude_json}){claude_config_extra}
   (subpath {npm_state})
   (subpath {cache_state})
   (subpath {config_state})
@@ -108,6 +124,7 @@ fn canonical(p: &Path) -> Result<std::path::PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     #[test]
     fn profile_includes_writable_root_and_denies_writes_by_default() {
@@ -119,7 +136,7 @@ mod tests {
         std::fs::create_dir_all(&rpc).unwrap();
         std::fs::create_dir_all(&home).unwrap();
 
-        let profile = build_profile(&root, &rpc, &home).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None).unwrap();
         let canonical_root = std::fs::canonicalize(&root).unwrap();
         let canonical_rpc = std::fs::canonicalize(&rpc).unwrap();
 
@@ -130,6 +147,45 @@ mod tests {
         // macOS-native per-user state dirs, needed by the agents' toolchains.
         assert!(profile.contains("/Library/Caches"));
         assert!(profile.contains("/Library/Application Support"));
+    }
+
+    fn sandbox_dirs() -> (tempfile::TempDir, PathBuf, PathBuf, PathBuf) {
+        let td = tempfile::tempdir().unwrap();
+        let root = td.path().join("agent-parent");
+        let rpc = td.path().join("rpc");
+        let home = td.path().join("home");
+        for p in [&root, &rpc, &home] {
+            std::fs::create_dir_all(p).unwrap();
+        }
+        (td, root, rpc, home)
+    }
+
+    #[test]
+    fn profile_grants_custom_claude_config_dir() {
+        // Regression: a sandboxed agent running with CLAUDE_CONFIG_DIR outside
+        // ~/.claude couldn't write its config/transcripts/auth, because only
+        // ~/.claude was on the allow-list.
+        let (_td, root, rpc, home) = sandbox_dirs();
+        let cfg = home.join(".claude-eve");
+
+        let profile = build_profile(&root, &rpc, &home, Some(cfg.as_path())).unwrap();
+        assert!(profile.contains(&format!("(subpath \"{}\")", cfg.display())));
+    }
+
+    #[test]
+    fn profile_does_not_duplicate_default_config_dir() {
+        // CLAUDE_CONFIG_DIR explicitly set to the default ~/.claude must not add
+        // a second, redundant allow entry.
+        let (_td, root, rpc, home) = sandbox_dirs();
+        let default_claude = std::fs::canonicalize(&home).unwrap().join(".claude");
+
+        let profile = build_profile(&root, &rpc, &home, Some(default_claude.as_path())).unwrap();
+        let needle = format!("(subpath \"{}\")", default_claude.display());
+        assert_eq!(
+            profile.matches(&needle).count(),
+            1,
+            "default ~/.claude should appear exactly once"
+        );
     }
 
     #[test]

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -1604,10 +1604,10 @@ impl SyncPoll {
     }
 }
 
-/// Locate the claude session JSONL by scanning `~/.claude/projects/*/`
-/// for `<session-id>.jsonl`. Claude's path-encoding scheme isn't part
-/// of its public API, so we glob instead of recomputing the encoded
-/// directory name from the worktree path.
+/// Locate the claude session JSONL by scanning the candidate `projects/*/`
+/// dirs (see [`claude_projects_dirs`]) for `<session-id>.jsonl`. Claude's
+/// path-encoding scheme isn't part of its public API, so we glob instead of
+/// recomputing the encoded directory name from the worktree path.
 /// Ingest the agent's on-disk transcript into `session_records`, idempotent per
 /// `native_id`. `None` = no transcript reader for this provider (skip, don't
 /// retry); `Some(n)` = reader ran, `n` new records inserted (`0` = nothing yet:
@@ -1709,14 +1709,58 @@ fn sync_session_records(workspace: &WorkspaceManager, agent_id: &str) -> Option<
 }
 
 pub(crate) fn find_session_jsonl(session_id: &str) -> Option<PathBuf> {
-    let home = dirs::home_dir()?;
-    let projects = home.join(".claude").join("projects");
-    let entries = std::fs::read_dir(&projects).ok()?;
+    find_session_jsonl_in(&claude_projects_dirs(), session_id)
+}
+
+/// Candidate `projects` directories Claude may have written transcripts to.
+/// Honors `CLAUDE_CONFIG_DIR` (Claude CLI's own config-dir override) and always
+/// also includes the default `~/.claude`, so a transcript is located regardless
+/// of which config dir was active when the agent was spawned. Mirrors the way
+/// `find_codex_rollouts` honors `CODEX_HOME` — without this, an agent spawned
+/// with `CLAUDE_CONFIG_DIR` set wrote its transcript somewhere we never scanned,
+/// so it was never ingested into `session_records` and was lost when that dir
+/// moved.
+fn claude_projects_dirs() -> Vec<PathBuf> {
+    projects_dirs_from(
+        std::env::var_os("CLAUDE_CONFIG_DIR").map(PathBuf::from),
+        dirs::home_dir(),
+    )
+}
+
+/// Pure core of [`claude_projects_dirs`]: configured dir first (if any), then
+/// the default `~/.claude`, deduped so an explicit `CLAUDE_CONFIG_DIR=~/.claude`
+/// doesn't double-scan.
+fn projects_dirs_from(config_dir: Option<PathBuf>, home: Option<PathBuf>) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    let mut push = |base: PathBuf| {
+        let p = base.join("projects");
+        if !out.contains(&p) {
+            out.push(p);
+        }
+    };
+    if let Some(cfg) = config_dir {
+        push(cfg);
+    }
+    if let Some(home) = home {
+        push(home.join(".claude"));
+    }
+    out
+}
+
+/// Scan the given `projects` dirs for `<session-id>.jsonl`, returning the first
+/// match. A missing/unreadable candidate dir is skipped, not fatal, so a later
+/// candidate is still searched.
+fn find_session_jsonl_in(projects_dirs: &[PathBuf], session_id: &str) -> Option<PathBuf> {
     let filename = format!("{session_id}.jsonl");
-    for entry in entries.flatten() {
-        let path = entry.path().join(&filename);
-        if path.exists() {
-            return Some(path);
+    for projects in projects_dirs {
+        let Ok(entries) = std::fs::read_dir(projects) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path().join(&filename);
+            if path.exists() {
+                return Some(path);
+            }
         }
     }
     None
@@ -2717,6 +2761,75 @@ mod tests {
         assert_eq!(plan.first_phase, RunPhase::Running);
         assert_eq!(plan.first_cmd, "cargo run");
         assert_eq!(plan.chained_run_cmd, None);
+    }
+
+    // ── claude transcript location (CLAUDE_CONFIG_DIR) ────────────────────────
+
+    #[test]
+    fn projects_dirs_prefers_config_dir_then_default_home() {
+        let dirs = projects_dirs_from(
+            Some(PathBuf::from("/home/u/.claude-eve")),
+            Some(PathBuf::from("/home/u")),
+        );
+        assert_eq!(
+            dirs,
+            vec![
+                PathBuf::from("/home/u/.claude-eve/projects"),
+                PathBuf::from("/home/u/.claude/projects"),
+            ],
+        );
+    }
+
+    #[test]
+    fn projects_dirs_dedups_when_config_is_default() {
+        // CLAUDE_CONFIG_DIR explicitly set to ~/.claude must not double-scan.
+        let dirs = projects_dirs_from(
+            Some(PathBuf::from("/home/u/.claude")),
+            Some(PathBuf::from("/home/u")),
+        );
+        assert_eq!(dirs, vec![PathBuf::from("/home/u/.claude/projects")]);
+    }
+
+    #[test]
+    fn projects_dirs_falls_back_to_home_when_config_unset() {
+        let dirs = projects_dirs_from(None, Some(PathBuf::from("/home/u")));
+        assert_eq!(dirs, vec![PathBuf::from("/home/u/.claude/projects")]);
+    }
+
+    #[test]
+    fn find_session_jsonl_locates_transcript_in_relocated_config_dir() {
+        // Regression: the locator used to hardcode `~/.claude/projects`, so an
+        // agent spawned with CLAUDE_CONFIG_DIR pointing elsewhere wrote its
+        // transcript to a dir we never scanned — it was never ingested and was
+        // lost when that dir moved. The transcript must be found wherever the
+        // configured projects dir is.
+        let cfg = tempfile::tempdir().unwrap();
+        let projects = cfg.path().join("projects");
+        let slug = projects.join("-Users-alex--quorum-worktrees-transylvania-quorum");
+        std::fs::create_dir_all(&slug).unwrap();
+        let sid = "f90f9c57-6dd1-45a0-9b69-5b5963979d5b";
+        let jsonl = slug.join(format!("{sid}.jsonl"));
+        std::fs::write(&jsonl, b"{}\n").unwrap();
+
+        let found = find_session_jsonl_in(&[projects], sid);
+        assert_eq!(found.as_deref(), Some(jsonl.as_path()));
+    }
+
+    #[test]
+    fn find_session_jsonl_skips_missing_dir_and_scans_the_next() {
+        // A non-existent candidate dir (e.g. the default ~/.claude when only the
+        // relocated config dir has the file) must not short-circuit the scan.
+        let cfg = tempfile::tempdir().unwrap();
+        let projects = cfg.path().join("projects");
+        let slug = projects.join("slug");
+        std::fs::create_dir_all(&slug).unwrap();
+        let sid = "abc";
+        let jsonl = slug.join(format!("{sid}.jsonl"));
+        std::fs::write(&jsonl, b"{}\n").unwrap();
+
+        let missing = cfg.path().join("does-not-exist");
+        let found = find_session_jsonl_in(&[missing, projects], sid);
+        assert_eq!(found.as_deref(), Some(jsonl.as_path()));
     }
 
     fn test_supervisor() -> Supervisor {


### PR DESCRIPTION
The Claude transcript locator hardcoded `~/.claude/projects` and the sandbox profile hardcoded write access to `~/.claude`, both ignoring `CLAUDE_CONFIG_DIR` — so an agent spawned with that env set wrote its transcript to a dir we never scanned, was never ingested into `session_records`, and was lost the moment that dir moved. `find_session_jsonl` now scans candidate projects dirs (`CLAUDE_CONFIG_DIR` then `~/.claude`, deduped) and skips missing dirs instead of bailing. `build_profile` now takes the agent's `CLAUDE_CONFIG_DIR` and grants it as a writable subpath, mirroring how the codex reader already honors `CODEX_HOME`. Logic is split into pure helpers covered by 7 new env-free tests (280/280 lib tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)