### PR TITLE
Fix agent env and per-turn failure surfacing

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -22,7 +22,7 @@ use serde_json::Value;
 
 use crate::activity::{Activity, ManagedActivity};
 use crate::error::{Error, Result};
-use crate::exec_session::{ExecCallbacks, ExecSession, ExecSpawn};
+use crate::exec_session::{ExecCallbacks, ExecExit, ExecSession, ExecSpawn};
 use crate::instructions;
 use crate::managed_session::{ManagedExit, ManagedSession, ManagedSpawn, ToolUseBehavior};
 use crate::pty_session::{PtyExit, PtySession, PtySpawn};
@@ -921,7 +921,7 @@ impl Agent {
     where
         F: Fn(Value) + Send + Sync + 'static,
         G: Fn(String) + Send + Sync + 'static,
-        H: Fn(bool) + Send + Sync + 'static,
+        H: Fn(ExecExit) + Send + Sync + 'static,
     {
         let home = dirs::home_dir()
             .ok_or_else(|| Error::Other("HOME directory not available".into()))?;
@@ -941,7 +941,7 @@ impl Agent {
     }
 
     /// Shared per-turn exec lifecycle. Spawns no process yet — the first
-    /// turn is launched when the first user message arrives. `on_exit(success)`
+    /// turn is launched when the first user message arrives. `on_exit`
     /// fires when a turn's process exits (and that turn is still current)
     /// — the per-turn analogue of a turn-end signal, so an interrupted or
     /// failed turn that never emits an in-band turn-end still leaves the
@@ -959,7 +959,7 @@ impl Agent {
         I: Fn(&Value) -> Option<String> + Send + Sync + 'static,
         F: Fn(Value) + Send + Sync + 'static,
         G: Fn(String) + Send + Sync + 'static,
-        H: Fn(bool) + Send + Sync + 'static,
+        H: Fn(ExecExit) + Send + Sync + 'static,
     {
         // Unified sandbox: wrap each turn's process in sandbox-exec with
         // Quorum's profile. The agent binary moves into `prefix_args`
@@ -1541,7 +1541,10 @@ pub async fn probe_all_providers() -> Vec<ProviderProbe> {
 /// (or stderr as fallback). Returns `None` if the binary errors or emits no
 /// recognisable version.
 fn probe_version(bin: &str) -> Option<String> {
-    let out = Command::new(bin).arg("--version").output().ok()?;
+    let mut cmd = Command::new(bin);
+    cmd.arg("--version");
+    crate::bin_resolve::apply_login_shell_env(&mut cmd);
+    let out = cmd.output().ok()?;
     let text = if !out.stdout.is_empty() {
         String::from_utf8_lossy(&out.stdout).into_owned()
     } else {

--- a/src-tauri/src/bin_resolve.rs
+++ b/src-tauri/src/bin_resolve.rs
@@ -142,25 +142,38 @@ fn find_in_path<P: AsRef<OsStr>>(name: &str, path: P) -> Option<String> {
 
 /// The PATH as seen by the user's login shell, which sources `.zprofile` /
 /// `.zshrc` and thus picks up version-manager and Homebrew dirs the GUI's
-/// inherited PATH lacks. We ask the shell *only* for its `$PATH` and walk it
-/// ourselves — no binary name is ever interpolated into a shell command, so
-/// this cannot be used for command injection.
+/// inherited PATH lacks. We ask the shell for its exported environment and walk
+/// PATH ourselves — no binary name is ever interpolated into a shell command,
+/// so this cannot be used for command injection.
 fn login_shell_path() -> Option<String> {
     login_shell_env().and_then(|env| env.get("PATH").cloned())
 }
 
 fn load_login_shell_env() -> Option<HashMap<String, String>> {
     let out = Command::new("/bin/zsh")
-        .args(["-lc", "env"])
+        .args(["-lc", "env -0"])
         .output()
         .ok()?;
     if !out.status.success() {
         return None;
     }
 
+    let env = parse_env_output(&out.stdout, b'\0');
+    if env.is_empty() {
+        None
+    } else {
+        Some(env)
+    }
+}
+
+fn parse_env_output(bytes: &[u8], delimiter: u8) -> HashMap<String, String> {
     let mut env = HashMap::new();
-    for line in String::from_utf8_lossy(&out.stdout).lines() {
-        let Some((k, v)) = line.split_once('=') else {
+    for entry in bytes.split(|b| *b == delimiter) {
+        if entry.is_empty() {
+            continue;
+        }
+        let text = String::from_utf8_lossy(entry);
+        let Some((k, v)) = text.split_once('=') else {
             continue;
         };
         if k.is_empty() || matches!(k, "PWD" | "OLDPWD" | "SHLVL" | "_") {
@@ -168,12 +181,7 @@ fn load_login_shell_env() -> Option<HashMap<String, String>> {
         }
         env.insert(k.to_string(), v.to_string());
     }
-
-    if env.is_empty() {
-        None
-    } else {
-        Some(env)
-    }
+    env
 }
 
 /// An executable regular file the current process may run. `is_file()` alone
@@ -256,6 +264,24 @@ mod tests {
             PathBuf::from("/opt/homebrew/bin/claude"),
         );
         assert_eq!(expand_tilde("~bob/x", home), PathBuf::from("~bob/x"));
+    }
+
+    #[test]
+    fn parse_env_output_preserves_multiline_values() {
+        let env = parse_env_output(
+            b"PATH=/opt/homebrew/bin:/usr/bin\0MULTI=line1\nline2=a\0PWD=/tmp\0",
+            b'\0',
+        );
+
+        assert_eq!(
+            env.get("PATH").map(String::as_str),
+            Some("/opt/homebrew/bin:/usr/bin"),
+        );
+        assert_eq!(
+            env.get("MULTI").map(String::as_str),
+            Some("line1\nline2=a"),
+        );
+        assert!(!env.contains_key("PWD"));
     }
 
     /// The override registry is process-global, so this is the ONLY test that

--- a/src-tauri/src/bin_resolve.rs
+++ b/src-tauri/src/bin_resolve.rs
@@ -101,6 +101,25 @@ pub fn resolve_bin(name: &str, home: &Path) -> Option<String> {
         .map(|candidate| candidate.to_string_lossy().into_owned())
 }
 
+/// Exported environment as seen by the user's login shell, cached once per app
+/// process. Finder/Dock-launched GUI apps inherit launchd's sparse environment;
+/// agent CLIs usually expect the richer shell environment where version
+/// managers, API keys, and Homebrew paths are configured.
+pub fn login_shell_env() -> Option<&'static HashMap<String, String>> {
+    static ENV: OnceLock<Option<HashMap<String, String>>> = OnceLock::new();
+    ENV.get_or_init(load_login_shell_env).as_ref()
+}
+
+/// Apply the cached login-shell environment to a std process command. Caller
+/// supplied env should be layered afterwards when it must win on collision.
+pub fn apply_login_shell_env(cmd: &mut Command) {
+    if let Some(env) = login_shell_env() {
+        for (k, v) in env {
+            cmd.env(k, v);
+        }
+    }
+}
+
 fn common_bin_paths(name: &str, home: &Path) -> Vec<PathBuf> {
     vec![
         home.join(format!(".local/bin/{name}")),
@@ -127,18 +146,33 @@ fn find_in_path<P: AsRef<OsStr>>(name: &str, path: P) -> Option<String> {
 /// ourselves — no binary name is ever interpolated into a shell command, so
 /// this cannot be used for command injection.
 fn login_shell_path() -> Option<String> {
+    login_shell_env().and_then(|env| env.get("PATH").cloned())
+}
+
+fn load_login_shell_env() -> Option<HashMap<String, String>> {
     let out = Command::new("/bin/zsh")
-        .args(["-lc", "print -rn -- $PATH"])
+        .args(["-lc", "env"])
         .output()
         .ok()?;
     if !out.status.success() {
         return None;
     }
-    let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    if path.is_empty() {
+
+    let mut env = HashMap::new();
+    for line in String::from_utf8_lossy(&out.stdout).lines() {
+        let Some((k, v)) = line.split_once('=') else {
+            continue;
+        };
+        if k.is_empty() || matches!(k, "PWD" | "OLDPWD" | "SHLVL" | "_") {
+            continue;
+        }
+        env.insert(k.to_string(), v.to_string());
+    }
+
+    if env.is_empty() {
         None
     } else {
-        Some(path)
+        Some(env)
     }
 }
 

--- a/src-tauri/src/exec_session.rs
+++ b/src-tauri/src/exec_session.rs
@@ -248,7 +248,7 @@ impl ExecSession {
         let on_exit = self.on_exit.clone();
         let interrupted = self.interrupted.clone();
         thread::spawn(move || loop {
-            let exited = {
+            let exited_status = {
                 let mut guard = child_for_wait.lock();
                 let Some(c) = guard.as_mut() else {
                     // Slot emptied by a newer turn (kill+take) — that turn
@@ -259,8 +259,21 @@ impl ExecSession {
                     Ok(Some(status)) => {
                         let _ = guard.take();
                         tracing::debug!(status = %status, "agent: turn exited");
+                        Some(Ok(status))
+                    }
+                    Ok(None) => None,
+                    Err(e) => {
+                        let _ = guard.take();
+                        tracing::warn!(error = %e, "agent: wait failed");
+                        Some(Err(format!("wait failed: {e}")))
+                    }
+                }
+            };
+            if let Some(exited_status) = exited_status {
+                let exit = match exited_status {
+                    Ok(status) => {
                         let stderr = drain_stderr(&stderr_rx).join("\n");
-                        Some(ExecExit {
+                        ExecExit {
                             success: status.success(),
                             interrupted: interrupted.load(Ordering::SeqCst),
                             message: if stderr.is_empty() {
@@ -268,21 +281,14 @@ impl ExecSession {
                             } else {
                                 format!("{status}: {stderr}")
                             },
-                        })
+                        }
                     }
-                    Ok(None) => None,
-                    Err(e) => {
-                        let _ = guard.take();
-                        tracing::warn!(error = %e, "agent: wait failed");
-                        Some(ExecExit {
-                            success: false,
-                            interrupted: interrupted.load(Ordering::SeqCst),
-                            message: format!("wait failed: {e}"),
-                        })
-                    }
-                }
-            };
-            if let Some(exit) = exited {
+                    Err(message) => ExecExit {
+                        success: false,
+                        interrupted: interrupted.load(Ordering::SeqCst),
+                        message,
+                    },
+                };
                 if turn_seq.load(Ordering::SeqCst) == seq {
                     on_exit(exit);
                 }

--- a/src-tauri/src/exec_session.rs
+++ b/src-tauri/src/exec_session.rs
@@ -19,7 +19,7 @@ use parking_lot::Mutex;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
@@ -30,7 +30,7 @@ use crate::error::{Error, Result};
 
 type EventCb = Arc<dyn Fn(Value) + Send + Sync>;
 type SessionIdCb = Arc<dyn Fn(String) + Send + Sync>;
-type ExitCb = Arc<dyn Fn(bool) + Send + Sync>;
+type ExitCb = Arc<dyn Fn(ExecExit) + Send + Sync>;
 type ArgsBuilder = Arc<dyn Fn(&str, Option<&str>, Option<&str>, Option<&str>) -> Vec<String> + Send + Sync>;
 type IdExtractor = Arc<dyn Fn(&Value) -> Option<String> + Send + Sync>;
 
@@ -71,6 +71,7 @@ pub struct ExecSession {
     session_id: Arc<Mutex<Option<String>>>,
     model: Option<String>,
     child: Arc<Mutex<Option<Child>>>,
+    interrupted: Arc<AtomicBool>,
     /// Monotonic turn counter. A reap thread only reports its exit if its
     /// turn is still the latest — so a superseded turn's late exit can't
     /// flip the status of the turn that replaced it.
@@ -80,6 +81,13 @@ pub struct ExecSession {
     on_event: EventCb,
     on_session_id: SessionIdCb,
     on_exit: ExitCb,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExecExit {
+    pub success: bool,
+    pub interrupted: bool,
+    pub message: String,
 }
 
 pub struct ExecCallbacks<F, G, H> {
@@ -102,7 +110,7 @@ impl ExecSession {
         I: Fn(&Value) -> Option<String> + Send + Sync + 'static,
         F: Fn(Value) + Send + Sync + 'static,
         G: Fn(String) + Send + Sync + 'static,
-        H: Fn(bool) + Send + Sync + 'static,
+        H: Fn(ExecExit) + Send + Sync + 'static,
     {
         Self {
             program: spec.program,
@@ -114,6 +122,7 @@ impl ExecSession {
             session_id: Arc::new(Mutex::new(spec.session_id)),
             model: spec.model,
             child: Arc::new(Mutex::new(None)),
+            interrupted: Arc::new(AtomicBool::new(false)),
             turn_seq: Arc::new(AtomicU64::new(0)),
             build_args: Arc::new(build_args),
             extract_session_id: Arc::new(extract_session_id),
@@ -127,6 +136,7 @@ impl ExecSession {
         // Claim this turn's sequence number first, so a superseded turn's
         // reap thread sees it's no longer current and stays quiet.
         let seq = self.turn_seq.fetch_add(1, Ordering::SeqCst) + 1;
+        self.interrupted.store(false, Ordering::SeqCst);
 
         // A new turn supersedes any still-running one (e.g. the user
         // sent again before the prior turn finished). Kill + reap it.
@@ -154,6 +164,7 @@ impl ExecSession {
         cmd.args(&self.prefix_args);
         cmd.args(&args);
         cmd.current_dir(&self.cwd);
+        crate::bin_resolve::apply_login_shell_env(&mut cmd);
         for (k, v) in &self.env {
             cmd.env(k, v);
         }
@@ -219,10 +230,13 @@ impl ExecSession {
             tracing::debug!("agent: turn stdout closed");
         });
 
+        let stderr_lines = Arc::new(Mutex::new(Vec::<String>::new()));
+        let stderr_for_reader = stderr_lines.clone();
         thread::spawn(move || {
             let reader = BufReader::new(stderr);
             for line in reader.lines().map_while(std::result::Result::ok) {
                 tracing::warn!(stderr = %line, "agent: stderr");
+                stderr_for_reader.lock().push(line);
             }
         });
 
@@ -232,6 +246,7 @@ impl ExecSession {
         let child_for_wait = self.child.clone();
         let turn_seq = self.turn_seq.clone();
         let on_exit = self.on_exit.clone();
+        let interrupted = self.interrupted.clone();
         thread::spawn(move || loop {
             let exited = {
                 let mut guard = child_for_wait.lock();
@@ -244,19 +259,32 @@ impl ExecSession {
                     Ok(Some(status)) => {
                         let _ = guard.take();
                         tracing::debug!(status = %status, "agent: turn exited");
-                        Some(status.success())
+                        let stderr = stderr_lines.lock().join("\n");
+                        Some(ExecExit {
+                            success: status.success(),
+                            interrupted: interrupted.load(Ordering::SeqCst),
+                            message: if stderr.is_empty() {
+                                status.to_string()
+                            } else {
+                                format!("{status}: {stderr}")
+                            },
+                        })
                     }
                     Ok(None) => None,
                     Err(e) => {
                         let _ = guard.take();
                         tracing::warn!(error = %e, "agent: wait failed");
-                        Some(false)
+                        Some(ExecExit {
+                            success: false,
+                            interrupted: interrupted.load(Ordering::SeqCst),
+                            message: format!("wait failed: {e}"),
+                        })
                     }
                 }
             };
-            if let Some(success) = exited {
+            if let Some(exit) = exited {
                 if turn_seq.load(Ordering::SeqCst) == seq {
-                    on_exit(success);
+                    on_exit(exit);
                 }
                 return;
             }
@@ -274,6 +302,7 @@ impl ExecSession {
             use nix::sys::signal::{kill, Signal};
             use nix::unistd::Pid;
             if let Some(child) = self.child.lock().as_ref() {
+                self.interrupted.store(true, Ordering::SeqCst);
                 let _ = kill(Pid::from_raw(child.id() as i32), Signal::SIGINT);
             }
         }
@@ -386,8 +415,8 @@ mod tests {
                 on_session_id: move |sid| {
                     let _ = stx.send(sid);
                 },
-                on_exit: move |success| {
-                    let _ = xtx.send(success);
+                on_exit: move |exit| {
+                    let _ = xtx.send(exit);
                 },
             },
         );
@@ -409,7 +438,7 @@ mod tests {
         assert_eq!(srx.recv_timeout(Duration::from_secs(1)).unwrap(), "abc-123");
         assert_eq!(session.session_id.lock().as_deref(), Some("abc-123"));
         assert_eq!(events.len(), 3);
-        assert_eq!(xrx.recv_timeout(Duration::from_secs(2)).unwrap(), true);
+        assert!(xrx.recv_timeout(Duration::from_secs(2)).unwrap().success);
     }
 
     #[test]
@@ -442,7 +471,7 @@ mod tests {
                     let _ = etx.send(ev);
                 },
                 on_session_id: |_sid| {},
-                on_exit: |_success| {},
+                on_exit: |_exit| {},
             },
         );
 
@@ -452,5 +481,43 @@ mod tests {
         assert!(args.contains("exec resume prev-thread"), "argv was: {args}");
         assert!(args.contains("--model gpt-5.2-codex"), "argv was: {args}");
         assert!(args.contains("--json"));
+    }
+
+    #[test]
+    fn failed_turn_reports_exit_message_with_stderr() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("failagent.sh");
+        std::fs::write(&script, "#!/bin/sh\necho 'node missing' >&2\nexit 127\n").unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let (xtx, xrx) = mpsc::channel();
+        let session = ExecSession::new(
+            ExecSpawn {
+                program: script,
+                prefix_args: vec![],
+                profile: None,
+                cwd: dir.path().to_path_buf(),
+                session_id: None,
+                model: None,
+                stdout_is_json: true,
+                env: vec![],
+            },
+            codex_args,
+            codex_id,
+            ExecCallbacks {
+                on_event: |_ev| {},
+                on_session_id: |_sid| {},
+                on_exit: move |exit| {
+                    let _ = xtx.send(exit);
+                },
+            },
+        );
+
+        session.send_user_message("hello", &[], None).unwrap();
+        let exit = xrx.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert!(!exit.success);
+        assert!(!exit.interrupted);
+        assert!(exit.message.contains("exit status: 127"), "{}", exit.message);
+        assert!(exit.message.contains("node missing"), "{}", exit.message);
     }
 }

--- a/src-tauri/src/exec_session.rs
+++ b/src-tauri/src/exec_session.rs
@@ -20,7 +20,7 @@ use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::Duration;
 
@@ -230,14 +230,14 @@ impl ExecSession {
             tracing::debug!("agent: turn stdout closed");
         });
 
-        let stderr_lines = Arc::new(Mutex::new(Vec::<String>::new()));
-        let stderr_for_reader = stderr_lines.clone();
+        let (stderr_tx, stderr_rx) = mpsc::channel::<Option<String>>();
         thread::spawn(move || {
             let reader = BufReader::new(stderr);
             for line in reader.lines().map_while(std::result::Result::ok) {
                 tracing::warn!(stderr = %line, "agent: stderr");
-                stderr_for_reader.lock().push(line);
+                let _ = stderr_tx.send(Some(line));
             }
+            let _ = stderr_tx.send(None);
         });
 
         // Reap the per-turn child when it exits, and report the exit so the
@@ -259,7 +259,7 @@ impl ExecSession {
                     Ok(Some(status)) => {
                         let _ = guard.take();
                         tracing::debug!(status = %status, "agent: turn exited");
-                        let stderr = stderr_lines.lock().join("\n");
+                        let stderr = drain_stderr(&stderr_rx).join("\n");
                         Some(ExecExit {
                             success: status.success(),
                             interrupted: interrupted.load(Ordering::SeqCst),
@@ -315,6 +315,19 @@ impl ExecSession {
         }
         Ok(())
     }
+}
+
+fn drain_stderr(rx: &mpsc::Receiver<Option<String>>) -> Vec<String> {
+    let mut lines = Vec::new();
+    loop {
+        match rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(Some(line)) => lines.push(line),
+            Ok(None)
+            | Err(mpsc::RecvTimeoutError::Timeout)
+            | Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    lines
 }
 
 /// Capture the agent-assigned session id the first time it appears, and

--- a/src-tauri/src/gh.rs
+++ b/src-tauri/src/gh.rs
@@ -25,7 +25,13 @@ fn gh_command() -> Command {
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
         crate::bin_resolve::resolve_bin("gh", &home).unwrap_or_else(|| "gh".to_string())
     });
-    Command::new(path)
+    let mut cmd = Command::new(path);
+    if let Some(env) = crate::bin_resolve::login_shell_env() {
+        for (k, v) in env {
+            cmd.env(k, v);
+        }
+    }
+    cmd
 }
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/managed_session.rs
+++ b/src-tauri/src/managed_session.rs
@@ -79,6 +79,7 @@ impl ManagedSession {
         let mut cmd = Command::new(spec.program);
         cmd.args(spec.args);
         cmd.current_dir(spec.cwd);
+        crate::bin_resolve::apply_login_shell_env(&mut cmd);
         for (k, v) in spec.env {
             cmd.env(k, v);
         }

--- a/src-tauri/src/model_catalog.rs
+++ b/src-tauri/src/model_catalog.rs
@@ -99,10 +99,14 @@ async fn discover_one(agent: &str, home: &Path) -> AgentModels {
 /// child is reaped rather than leaked.
 async fn run_cli(bin: &str, args: &[&str], home: &Path) -> Option<String> {
     let path = crate::bin_resolve::resolve_bin(bin, home)?;
-    let run = tokio::process::Command::new(&path)
-        .args(args)
-        .kill_on_drop(true)
-        .output();
+    let mut cmd = tokio::process::Command::new(&path);
+    cmd.args(args).kill_on_drop(true);
+    if let Some(env) = crate::bin_resolve::login_shell_env() {
+        for (k, v) in env {
+            cmd.env(k, v);
+        }
+    }
+    let run = cmd.output();
     // Outer `?` = timed out; inner `?` = spawn/IO error.
     let out = tokio::time::timeout(CLI_TIMEOUT, run).await.ok()?.ok()?;
     // A non-zero exit means the listing failed (not logged in, bad flag, …);

--- a/src-tauri/src/pty_session.rs
+++ b/src-tauri/src/pty_session.rs
@@ -65,6 +65,11 @@ impl PtySession {
         for (k, v) in std::env::vars() {
             cmd.env(k, v);
         }
+        if let Some(env) = crate::bin_resolve::login_shell_env() {
+            for (k, v) in env {
+                cmd.env(k, v);
+            }
+        }
         // Explicit terminal type — claude code uses ink which checks TERM
         // for capability lookups. Without this, input handling falls back
         // to a line-buffered mode that doesn't match what the user expects.

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -2008,7 +2008,7 @@ fn spawn_per_turn_agent(
             tracing::warn!(error = %e, agent_id = %id_for_sid, "persist session id failed");
         }
     };
-    let on_turn_exit = move |_success: bool| {
+    let on_turn_exit = move |exit: crate::exec_session::ExecExit| {
         // The turn's process exited. Ignore if a respawn/teardown has since
         // bumped the generation (e.g. the session was dropped).
         let current = sup_for_exit
@@ -2020,13 +2020,19 @@ fn spawn_per_turn_agent(
         if current != gen {
             return;
         }
-        // End the turn. Idempotent with the in-band turn-end watchdog path;
-        // the win is the interrupt/crash case where no such event arrives.
-        // We don't surface non-success as Error: a user-initiated Stop
-        // (SIGINT) is also non-success, and real agent errors are reported
-        // in-band as events.
-        // Turn-end ingest fires from transition_active's Idle transition.
-        transition_active(&sup_for_exit, &app_for_exit, &id_for_exit, AgentStatus::Idle);
+        // End the turn. Idempotent with the in-band turn-end watchdog path.
+        // User Stop is an expected non-zero exit; a non-interrupted failure
+        // before the CLI emits JSON is a real crash and must be surfaced.
+        if exit.success || exit.interrupted {
+            transition_active(&sup_for_exit, &app_for_exit, &id_for_exit, AgentStatus::Idle);
+        } else {
+            sup_for_exit.set_status(
+                &app_for_exit,
+                &id_for_exit,
+                AgentStatus::Error,
+                Some(format!("Agent process exited: {}", exit.message)),
+            );
+        }
     };
 
     let desc = per_turn_descriptor(provider).ok_or_else(|| {

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -2026,6 +2026,10 @@ fn spawn_per_turn_agent(
         if exit.success || exit.interrupted {
             transition_active(&sup_for_exit, &app_for_exit, &id_for_exit, AgentStatus::Idle);
         } else {
+            sup_for_exit.agents.lock().remove(&id_for_exit);
+            sup_for_exit.activities.lock().remove(&id_for_exit);
+            sup_for_exit.native_input_lines.lock().remove(&id_for_exit);
+            sup_for_exit.trigger_session_sync(app_for_exit.clone(), id_for_exit.clone());
             sup_for_exit.set_status(
                 &app_for_exit,
                 &id_for_exit,


### PR DESCRIPTION
## Summary
- Load the user login-shell environment once and apply it to agent/tool subprocesses so GUI-launched Quorum can run CLIs installed through version managers like nvm.
- Carry per-turn process exit details, including stderr and interrupt state, so real pre-JSON CLI crashes surface as agent errors while user Stop remains non-fatal.
- Cover the failed-turn stderr path with a focused exec-session regression test.

## Validation
- cargo test exec_session
- cargo test bin_resolve