### PR TITLE
refactor(store): extract PTY buffers and settings parsers out of store.ts

### DIFF
--- a/src/components/RightPanel/TermPanel.tsx
+++ b/src/components/RightPanel/TermPanel.tsx
@@ -4,7 +4,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { SearchAddon } from "@xterm/addon-search";
 import { open } from "@tauri-apps/plugin-shell";
 import { api, type AgentRecord } from "../../api";
-import { getShellBuffer, registerShellSink } from "../../store";
+import { getShellBuffer, registerShellSink } from "../../pty/buffers";
 import { useXterm } from "../../util/useXterm";
 import { Icon } from "../Icon";
 

--- a/src/components/Workspace/NativeView.tsx
+++ b/src/components/Workspace/NativeView.tsx
@@ -1,5 +1,5 @@
 import { api, type AgentRecord } from "../../api";
-import { getOutputBuffer, registerOutputSink } from "../../store";
+import { getOutputBuffer, registerOutputSink } from "../../pty/buffers";
 import { useXterm } from "../../util/useXterm";
 
 /** Fixed dark background for the native TUI view — used by both the xterm

--- a/src/pty/buffers.ts
+++ b/src/pty/buffers.ts
@@ -1,0 +1,85 @@
+// Per-agent PTY output buffering, kept outside the Zustand store on purpose:
+// raw terminal bytes arrive at high frequency and are consumed imperatively by
+// xterm-backed views, so routing them through React state would be wasteful.
+//
+// Two parallel channels — the agent's own PTY and its side shell — each pair a
+// ring buffer (replayed when a view remounts after a tab/view switch) with an
+// optional live sink (the mounted view's writer).
+
+export type OutputHandler = (bytes: Uint8Array) => void;
+
+const MAX_BUFFER_BYTES = 256 * 1024;
+
+// ---- Agent PTY ----------------------------------------------------------------
+const outputSinks = new Map<string, OutputHandler>();
+const outputBuffers = new Map<string, Uint8Array>();
+
+// ---- Side shell PTY -----------------------------------------------------------
+const shellSinks = new Map<string, OutputHandler>();
+const shellBuffers = new Map<string, Uint8Array>();
+
+/** Append a chunk to an agent's ring buffer, trimming the oldest bytes once it
+ *  grows past the cap so a long-lived session can't grow without bound. */
+function appendToRing(
+  buffers: Map<string, Uint8Array>,
+  agentId: string,
+  chunk: Uint8Array,
+) {
+  const existing = buffers.get(agentId);
+  let next: Uint8Array;
+  if (!existing) {
+    next = chunk;
+  } else {
+    next = new Uint8Array(existing.length + chunk.length);
+    next.set(existing, 0);
+    next.set(chunk, existing.length);
+  }
+  if (next.length > MAX_BUFFER_BYTES) {
+    next = next.slice(next.length - MAX_BUFFER_BYTES);
+  }
+  buffers.set(agentId, next);
+}
+
+/** Buffer an agent-output chunk and forward it to the live view sink (if any). */
+export function pushAgentOutput(agentId: string, chunk: Uint8Array) {
+  appendToRing(outputBuffers, agentId, chunk);
+  outputSinks.get(agentId)?.(chunk);
+}
+
+export function getOutputBuffer(agentId: string): Uint8Array | undefined {
+  return outputBuffers.get(agentId);
+}
+
+export function clearOutputBuffer(agentId: string) {
+  outputBuffers.delete(agentId);
+}
+
+export function registerOutputSink(
+  agentId: string,
+  handler: OutputHandler,
+): () => void {
+  outputSinks.set(agentId, handler);
+  return () => {
+    if (outputSinks.get(agentId) === handler) outputSinks.delete(agentId);
+  };
+}
+
+/** Buffer a shell-output chunk and forward it to the live TermPanel sink. */
+export function pushShellOutput(agentId: string, chunk: Uint8Array) {
+  appendToRing(shellBuffers, agentId, chunk);
+  shellSinks.get(agentId)?.(chunk);
+}
+
+export function getShellBuffer(agentId: string): Uint8Array | undefined {
+  return shellBuffers.get(agentId);
+}
+
+export function registerShellSink(
+  agentId: string,
+  handler: OutputHandler,
+): () => void {
+  shellSinks.set(agentId, handler);
+  return () => {
+    if (shellSinks.get(agentId) === handler) shellSinks.delete(agentId);
+  };
+}

--- a/src/storage/preferences.ts
+++ b/src/storage/preferences.ts
@@ -1,0 +1,130 @@
+// Typed app-preference parsers: turn the flat string→string settings blob read
+// by ./settings.ts into the structured values the store holds. Kept out of the
+// store so the migration/clamping logic lives next to the persistence layer it
+// belongs to and can be unit-tested in isolation.
+
+// ---- Appearance & feature-flag types -----------------------------------------
+
+export type ThemeMode = "dark" | "light";
+export type Density = "comfortable" | "compact";
+export type WorkspaceView = "custom" | "native";
+export type SettingsSection =
+  | "general"
+  | "account"
+  | "providers"
+  | "experimental"
+  | "developer";
+
+export interface FeatureFlags {
+  git: boolean;
+  /** The unified Code panel: file explorer/editor + the Live diff feed. */
+  code: boolean;
+  run: boolean;
+  terminal: boolean;
+  thinkingBudget: boolean;
+  autoEdit: boolean;
+  /** Show the context-window usage meter in the composer foot. */
+  tokenUsage: boolean;
+  /** Experimental: expose the Custom/Native view switcher so agents can be
+   *  driven through the provider's own terminal UI. Off by default — native
+   *  mode isn't equally solid across providers yet. */
+  nativeView: boolean;
+}
+
+export const DEFAULT_FEATURES: FeatureFlags = {
+  git: true,
+  code: true,
+  run: false,
+  terminal: false,
+  thinkingBudget: true,
+  autoEdit: false,
+  tokenUsage: true,
+  nativeView: false,
+};
+
+export function parseFeatures(raw: string | undefined): FeatureFlags {
+  if (!raw) return DEFAULT_FEATURES;
+  try {
+    const saved = JSON.parse(raw) as Partial<FeatureFlags> & {
+      // legacy flags folded into `code`
+      files?: boolean;
+      diff?: boolean;
+      // removed in this version; its presence marks a pre-migration blob
+      statusBar?: boolean;
+    };
+    // The old "Files" and "Diff" tabs were merged into the Code panel; honor a
+    // saved preference for either when migrating an existing settings blob.
+    const legacyCode =
+      saved.code ?? (saved.files !== undefined || saved.diff !== undefined
+        ? !!(saved.files || saved.diff)
+        : undefined);
+    // A blob still carrying the removed `statusBar` flag predates `tokenUsage`
+    // gating the composer meter — back then it was a no-op that defaulted off.
+    // Drop its stored `tokenUsage` so the new default (meter on, matching the
+    // old always-visible behavior) applies; honor the value for newer blobs.
+    const preMigration = saved.statusBar !== undefined;
+    const { files: _files, diff: _diff, statusBar: _statusBar, ...rest } = saved;
+    void _files;
+    void _diff;
+    void _statusBar;
+    if (preMigration) delete rest.tokenUsage;
+    return {
+      ...DEFAULT_FEATURES,
+      ...rest,
+      ...(legacyCode !== undefined ? { code: legacyCode } : {}),
+    };
+  } catch {
+    return DEFAULT_FEATURES;
+  }
+}
+
+export function parseProviderFlags(
+  raw: string | undefined,
+): Record<string, boolean> {
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as Record<string, boolean>;
+  } catch {
+    return {};
+  }
+}
+
+// ---- Pane widths --------------------------------------------------------------
+
+/** Default pane widths (px); also the fallback when a stored value is missing
+ *  or corrupt. Mirrored in the initial store state. */
+export const DEFAULT_LEFT_WIDTH = 312;
+export const DEFAULT_RIGHT_WIDTH = 520;
+/** Lower bound matches the splitter's MIN_WIDTH; the right pane's true upper
+ *  bound is dynamic (capped at render via CSS `min()`), so we only guard
+ *  against absurd/NaN persisted values here. */
+const MIN_PANE_WIDTH = 220;
+const MAX_PANE_WIDTH = 4000;
+
+/** Restore a persisted pane width, clamping to a sane range and falling back
+ *  to the default on a missing or non-numeric value. */
+export function parsePaneWidth(raw: string | undefined, fallback: number): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(MAX_PANE_WIDTH, Math.max(MIN_PANE_WIDTH, n));
+}
+
+// ---- Provider binary path overrides ------------------------------------------
+
+/** Settings-key prefix for per-agent custom binary paths. Must match the
+ *  backend's `database::AGENT_BIN_PREFIX` so both read/write the same rows. */
+const AGENT_BIN_PREFIX = "agent_bin_path_";
+
+/** Pull the `agent_bin_path_<id>` rows out of the flat settings map into an
+ *  id → path override map (blank values dropped, matching the backend). */
+export function parseProviderPathOverrides(
+  s: Record<string, string>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(s)) {
+    if (key.startsWith(AGENT_BIN_PREFIX) && value.trim()) {
+      out[key.slice(AGENT_BIN_PREFIX.length)] = value;
+    }
+  }
+  return out;
+}

--- a/src/store.provider-overrides.test.ts
+++ b/src/store.provider-overrides.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseProviderPathOverrides } from "./store";
+import { parseProviderPathOverrides } from "./storage/preferences";
 
 describe("parseProviderPathOverrides", () => {
   it("extracts agent_bin_path_<id> rows and strips the prefix", () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -44,6 +44,25 @@ import {
 } from "./data/modelCatalog";
 import { getAllSettings, setSetting } from "./storage/settings";
 import {
+  DEFAULT_FEATURES,
+  parseFeatures,
+  parseProviderFlags,
+  parsePaneWidth,
+  parseProviderPathOverrides,
+  DEFAULT_LEFT_WIDTH,
+  DEFAULT_RIGHT_WIDTH,
+  type ThemeMode,
+  type Density,
+  type WorkspaceView,
+  type SettingsSection,
+  type FeatureFlags,
+} from "./storage/preferences";
+import {
+  pushAgentOutput,
+  pushShellOutput,
+  clearOutputBuffer,
+} from "./pty/buffers";
+import {
   getAccount,
   getOrCreateAccount,
   saveAccountProfile,
@@ -52,75 +71,23 @@ import {
 } from "./storage/accounts";
 import { playAgentDone } from "./util/sound";
 
-type OutputHandler = (bytes: Uint8Array) => void;
-
 export const EMPTY_AGENTS: readonly AgentRecord[] = Object.freeze([]);
 
-const outputSinks = new Map<string, OutputHandler>();
-
-// ---- Per-agent PTY output buffer ----------------------------------------
-// Used by native view to repaint after tab switch / view switch.
-const outputBuffers = new Map<string, Uint8Array>();
-const MAX_BUFFER_BYTES = 256 * 1024;
-
-function appendToBuffer(agentId: string, chunk: Uint8Array) {
-  const existing = outputBuffers.get(agentId);
-  let next: Uint8Array;
-  if (!existing) {
-    next = chunk;
-  } else {
-    next = new Uint8Array(existing.length + chunk.length);
-    next.set(existing, 0);
-    next.set(chunk, existing.length);
-  }
-  if (next.length > MAX_BUFFER_BYTES) {
-    next = next.slice(next.length - MAX_BUFFER_BYTES);
-  }
-  outputBuffers.set(agentId, next);
-}
-
-export function getOutputBuffer(agentId: string): Uint8Array | undefined {
-  return outputBuffers.get(agentId);
-}
-
-export function clearOutputBuffer(agentId: string) {
-  outputBuffers.delete(agentId);
-}
-
-export function registerOutputSink(
-  agentId: string,
-  handler: OutputHandler,
-): () => void {
-  outputSinks.set(agentId, handler);
-  return () => {
-    if (outputSinks.get(agentId) === handler) outputSinks.delete(agentId);
-  };
-}
-
-// ---- Per-agent shell PTY output buffer ----------------------------------
-// Mirrors the agent output buffer. Used by TermPanel to repaint after
-// tab switch.
-const shellSinks = new Map<string, OutputHandler>();
-const shellBuffers = new Map<string, Uint8Array>();
+// Re-export the preference types: they're part of the store's public state
+// shape (theme, density, features, …), so consumers that read those fields
+// import the types from here.
+export type {
+  ThemeMode,
+  Density,
+  WorkspaceView,
+  SettingsSection,
+  FeatureFlags,
+} from "./storage/preferences";
 
 // Agents the user just stopped. A killed turn may still flush a final `result`
 // event (→ turn_end) as it dies; this set suppresses the completion chime for
 // that one turn_end so a manual stop doesn't sound like a successful finish.
 const interruptedAgents = new Set<string>();
-
-export function getShellBuffer(agentId: string): Uint8Array | undefined {
-  return shellBuffers.get(agentId);
-}
-
-export function registerShellSink(
-  agentId: string,
-  handler: OutputHandler,
-): () => void {
-  shellSinks.set(agentId, handler);
-  return () => {
-    if (shellSinks.get(agentId) === handler) shellSinks.delete(agentId);
-  };
-}
 
 // ---- Re-export the normalized ChatItem so component files don't need to
 //      import from "./adapters" directly; managedLogs is typed in terms
@@ -145,126 +112,6 @@ export interface DraftAgent {
   model?: string;
   /** Base branch to fork from. */
   base: string;
-}
-
-// ---- Feature flags & appearance --------------------------------------------
-
-export type ThemeMode = "dark" | "light";
-export type Density = "comfortable" | "compact";
-export type WorkspaceView = "custom" | "native";
-export type SettingsSection =
-  | "general"
-  | "account"
-  | "providers"
-  | "experimental"
-  | "developer";
-
-export interface FeatureFlags {
-  git: boolean;
-  /** The unified Code panel: file explorer/editor + the Live diff feed. */
-  code: boolean;
-  run: boolean;
-  terminal: boolean;
-  thinkingBudget: boolean;
-  autoEdit: boolean;
-  /** Show the context-window usage meter in the composer foot. */
-  tokenUsage: boolean;
-  /** Experimental: expose the Custom/Native view switcher so agents can be
-   *  driven through the provider's own terminal UI. Off by default — native
-   *  mode isn't equally solid across providers yet. */
-  nativeView: boolean;
-}
-
-const DEFAULT_FEATURES: FeatureFlags = {
-  git: true,
-  code: true,
-  run: false,
-  terminal: false,
-  thinkingBudget: true,
-  autoEdit: false,
-  tokenUsage: true,
-  nativeView: false,
-};
-
-function parseFeatures(raw: string | undefined): FeatureFlags {
-  if (!raw) return DEFAULT_FEATURES;
-  try {
-    const saved = JSON.parse(raw) as Partial<FeatureFlags> & {
-      // legacy flags folded into `code`
-      files?: boolean;
-      diff?: boolean;
-      // removed in this version; its presence marks a pre-migration blob
-      statusBar?: boolean;
-    };
-    // The old "Files" and "Diff" tabs were merged into the Code panel; honor a
-    // saved preference for either when migrating an existing settings blob.
-    const legacyCode =
-      saved.code ?? (saved.files !== undefined || saved.diff !== undefined
-        ? !!(saved.files || saved.diff)
-        : undefined);
-    // A blob still carrying the removed `statusBar` flag predates `tokenUsage`
-    // gating the composer meter — back then it was a no-op that defaulted off.
-    // Drop its stored `tokenUsage` so the new default (meter on, matching the
-    // old always-visible behavior) applies; honor the value for newer blobs.
-    const preMigration = saved.statusBar !== undefined;
-    const { files: _files, diff: _diff, statusBar: _statusBar, ...rest } = saved;
-    void _files;
-    void _diff;
-    void _statusBar;
-    if (preMigration) delete rest.tokenUsage;
-    return {
-      ...DEFAULT_FEATURES,
-      ...rest,
-      ...(legacyCode !== undefined ? { code: legacyCode } : {}),
-    };
-  } catch {
-    return DEFAULT_FEATURES;
-  }
-}
-
-function parseProviderFlags(raw: string | undefined): Record<string, boolean> {
-  if (!raw) return {};
-  try {
-    return JSON.parse(raw) as Record<string, boolean>;
-  } catch {
-    return {};
-  }
-}
-
-/** Default pane widths (px); also the fallback when a stored value is missing
- *  or corrupt. Mirrored in the initial store state below. */
-const DEFAULT_LEFT_WIDTH = 312;
-const DEFAULT_RIGHT_WIDTH = 520;
-/** Lower bound matches the splitter's MIN_WIDTH; the right pane's true upper
- *  bound is dynamic (capped at render via CSS `min()`), so we only guard
- *  against absurd/NaN persisted values here. */
-const MIN_PANE_WIDTH = 220;
-const MAX_PANE_WIDTH = 4000;
-
-/** Restore a persisted pane width, clamping to a sane range and falling back
- *  to the default on a missing or non-numeric value. */
-function parsePaneWidth(raw: string | undefined, fallback: number): number {
-  const n = Number(raw);
-  if (!Number.isFinite(n)) return fallback;
-  return Math.min(MAX_PANE_WIDTH, Math.max(MIN_PANE_WIDTH, n));
-}
-
-/** Settings-key prefix for per-agent custom binary paths. Must match the
- *  backend's `database::AGENT_BIN_PREFIX` so both read/write the same rows. */
-const AGENT_BIN_PREFIX = "agent_bin_path_";
-
-/** Pull the `agent_bin_path_<id>` rows out of the flat settings map into an
- *  id → path override map (blank values dropped, matching the backend). */
-export function parseProviderPathOverrides(
-  s: Record<string, string>,
-): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const [key, value] of Object.entries(s)) {
-    if (key.startsWith(AGENT_BIN_PREFIX) && value.trim()) {
-      out[key.slice(AGENT_BIN_PREFIX.length)] = value;
-    }
-  }
-  return out;
 }
 
 interface AppState {
@@ -912,29 +759,11 @@ export const useAppStore = create<AppState>((set, get) => ({
     void get().refreshModelCatalog();
 
     await onAgentOutput((e) => {
-      const chunk = new Uint8Array(e.bytes);
-      appendToBuffer(e.agent_id, chunk);
-      const sink = outputSinks.get(e.agent_id);
-      if (sink) sink(chunk);
+      pushAgentOutput(e.agent_id, new Uint8Array(e.bytes));
     });
 
     await onShellOutput((e) => {
-      const chunk = new Uint8Array(e.bytes);
-      const existing = shellBuffers.get(e.agent_id);
-      let next: Uint8Array;
-      if (!existing) {
-        next = chunk;
-      } else {
-        next = new Uint8Array(existing.length + chunk.length);
-        next.set(existing, 0);
-        next.set(chunk, existing.length);
-      }
-      if (next.length > MAX_BUFFER_BYTES) {
-        next = next.slice(next.length - MAX_BUFFER_BYTES);
-      }
-      shellBuffers.set(e.agent_id, next);
-      const sink = shellSinks.get(e.agent_id);
-      if (sink) sink(chunk);
+      pushShellOutput(e.agent_id, new Uint8Array(e.bytes));
     });
 
     await onAgentEvent((e) => {


### PR DESCRIPTION
## What

First step of breaking up the 2056-line `store.ts`: extract two genuinely store-independent concerns into dedicated modules. `store.ts` drops to ~1885 lines.

### New modules
- **`src/pty/buffers.ts`** — per-agent and side-shell PTY ring buffers + live sinks. The maps are now private; the module exposes `pushAgentOutput`/`pushShellOutput` (append + dispatch in one call) plus `getOutputBuffer`/`clearOutputBuffer`/`registerOutputSink` and the shell equivalents. The duplicated buffer grow/trim logic (previously inlined in `onShellOutput`) folds into a single `appendToRing` helper.
- **`src/storage/preferences.ts`** — settings-blob parsers (`parseFeatures` with its legacy migration, `parseProviderFlags`, `parsePaneWidth`, `parseProviderPathOverrides`), the pane-width / `AGENT_BIN_PREFIX` constants, and the `ThemeMode` / `Density` / `WorkspaceView` / `SettingsSection` / `FeatureFlags` types. Placed next to the existing `storage/settings.ts` DB accessor whose raw output it parses.

### Notes
- `interruptedAgents` deliberately stays in `store.ts` — it's chime-suppression logic tied to agent stop/turn-end, not PTY buffering, despite sitting next to the shell buffers before.
- `store.ts` re-exports the five preference **types** (they're part of its public state shape: `theme`, `density`, `features`, …), so components reading them keep importing from `./store` unchanged.
- `NativeView.tsx` and `TermPanel.tsx` now import the buffer helpers directly from `./pty/buffers`; the `parseProviderPathOverrides` test imports from `./storage/preferences`.

## Testing
- `tsc --noEmit` clean
- Full `vitest run` green — 295 tests, 33 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)