### PR TITLE
Custom agents: reusable provider presets with per-session instruction injection

### DIFF
--- a/src-tauri/migrations/0011_custom_agents.sql
+++ b/src-tauri/migrations/0011_custom_agents.sql
@@ -1,0 +1,25 @@
+-- Custom agents: user-defined presets that wrap a base provider with a name,
+-- color, model, reasoning effort, and a standing instruction brief. They show
+-- up in the composer alongside the built-in providers and inject their
+-- instructions into the agent they spawn.
+CREATE TABLE custom_agents (
+    id           TEXT PRIMARY KEY,
+    name         TEXT NOT NULL,
+    description  TEXT NOT NULL DEFAULT '',
+    color        INTEGER NOT NULL,          -- hue (0-360) for the monogram tile
+    base         TEXT NOT NULL,             -- base provider id (claude/codex/…)
+    model        TEXT,                      -- NULL = provider CLI default
+    effort       TEXT,                      -- reasoning budget; NULL = none
+    instructions TEXT NOT NULL DEFAULT '',
+    created_at   INTEGER NOT NULL,
+    updated_at   INTEGER NOT NULL
+);
+
+-- A session spawned from a custom agent snapshots that agent's instructions
+-- here, so they re-inject identically on every respawn/resume even if the
+-- custom agent is later edited or deleted. NULL = a plain built-in spawn.
+ALTER TABLE sessions ADD COLUMN instructions TEXT;
+
+-- Reference to the custom agent this session was spawned from, used to show
+-- the agent's name/color in the sidebar. NULL = a plain built-in spawn.
+ALTER TABLE sessions ADD COLUMN custom_agent_id TEXT;

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -71,6 +71,10 @@ pub struct PerTurnSpec {
     pub session_id: Option<String>,
     /// Session-level model override. `None` keeps the provider CLI default.
     pub model: Option<String>,
+    /// A custom agent's standing instructions, snapshotted on the session and
+    /// injected into every turn (appended after Quorum's global system prompt).
+    /// `None` for a plain built-in spawn.
+    pub instructions: Option<String>,
     /// The agent's RPC mailbox dir, exposed to the child as `QUORUM_RPC_DIR`.
     pub rpc_dir: PathBuf,
 }
@@ -88,11 +92,12 @@ pub struct PerTurnDescriptor {
     bin: &'static str,
     /// Human-facing product name, used only in the not-found error.
     label: &'static str,
-    /// Builds the CLI args for a turn: `(prompt, resume_session_id, thinking_effort, model)`.
-    build_args: fn(&str, Option<&str>, Option<&str>, Option<&str>) -> Vec<String>,
+    /// Builds the CLI args for a turn:
+    /// `(prompt, resume_session_id, thinking_effort, model, custom_instructions)`.
+    build_args: fn(&str, Option<&str>, Option<&str>, Option<&str>, Option<&str>) -> Vec<String>,
     /// Builds the args to launch this agent's interactive TUI in the native
-    /// (PTY) view: first arg is session (`None` = fresh), second is model.
-    pty_args: fn(Option<&str>, Option<&str>) -> Vec<String>,
+    /// (PTY) view: `(session [None = fresh], model, custom_instructions)`.
+    pty_args: fn(Option<&str>, Option<&str>, Option<&str>) -> Vec<String>,
     /// Extracts the agent-assigned session id from a turn's events. No-op for
     /// `plaintext` agents (they emit no events — see `session_id_from_cwd`).
     session_id: fn(&Value) -> Option<String>,
@@ -591,7 +596,7 @@ fn opencode_read(message_paths: &[PathBuf]) -> Vec<RawRecord> {
 // `_model` is intentionally unused: agy's `--print` runner ignores model
 // selection (the `--model` flag is inert in print mode), so the picker offers
 // no selectable models for antigravity (see `model_catalog::discover_one`).
-fn antigravity_build_args(prompt: &str, session_id: Option<&str>, _thinking: Option<&str>, _model: Option<&str>) -> Vec<String> {
+fn antigravity_build_args(prompt: &str, session_id: Option<&str>, _thinking: Option<&str>, _model: Option<&str>, extra: Option<&str>) -> Vec<String> {
     // `--print` takes the prompt as its *value* (i.e. `--print <prompt>`), so the
     // prompt must come last, directly after `--print`. Putting another flag
     // between them makes that flag the prompt (agy then "answers" the flag name).
@@ -601,13 +606,15 @@ fn antigravity_build_args(prompt: &str, session_id: Option<&str>, _thinking: Opt
         args.push(id.to_string());
     }
     args.push("--print".into());
-    args.push(instructions::prepend_to_prompt(prompt, session_id));
+    args.push(instructions::prepend_to_prompt(prompt, session_id, extra));
     args
 }
 
 // `_model` unused: agy's TUI manages its own model selection (see
-// `antigravity_build_args` and `model_catalog::discover_one`).
-fn antigravity_pty_args(session_id: Option<&str>, _model: Option<&str>) -> Vec<String> {
+// `antigravity_build_args` and `model_catalog::discover_one`). `_extra` unused:
+// the standing brief rides the first `--print` turn (above), which lives in the
+// resumed conversation the TUI then continues.
+fn antigravity_pty_args(session_id: Option<&str>, _model: Option<&str>, _extra: Option<&str>) -> Vec<String> {
     // Native view: launch agy's interactive TUI (NOT `--print`, the
     // non-interactive turn runner), resuming the conversation by id.
     let mut args = vec!["--dangerously-skip-permissions".to_string()];
@@ -741,6 +748,9 @@ pub struct SpawnSpec<'a> {
     pub effort: Option<&'a str>,
     /// Session-level model override. `None` keeps the provider CLI default.
     pub model: Option<&'a str>,
+    /// A custom agent's standing instructions, injected after Quorum's global
+    /// system prompt on every spawn/resume. `None` for a plain built-in spawn.
+    pub instructions: Option<&'a str>,
     /// The agent's RPC mailbox dir, exposed to the child as `QUORUM_RPC_DIR`.
     pub rpc_dir: PathBuf,
     pub cols: u16,
@@ -822,7 +832,7 @@ impl Agent {
         } else {
             Some(spec.session_id)
         };
-        let agent_args = (desc.pty_args)(session, spec.model);
+        let agent_args = (desc.pty_args)(session, spec.model, spec.instructions);
         let env = rpc_env(&spec.rpc_dir);
 
         // Unified sandbox: run the agent's TUI under sandbox-exec with Quorum's
@@ -926,10 +936,17 @@ impl Agent {
         let home = dirs::home_dir()
             .ok_or_else(|| Error::Other("HOME directory not available".into()))?;
         let program = PathBuf::from(resolve_agent_bin(desc.id, desc.bin, desc.label, &home)?);
+        // A custom agent's standing brief is constant for the session, so bind
+        // it into the per-turn args builder once here rather than threading it
+        // through every turn. `ExecSession` keeps calling a 4-arg builder.
+        let build_args = desc.build_args;
+        let extra = spec.instructions.clone();
         Self::spawn_exec(
             program,
             spec,
-            desc.build_args,
+            move |prompt, sid, thinking, model| {
+                build_args(prompt, sid, thinking, model, extra.as_deref())
+            },
             desc.session_id,
             !desc.plaintext,
             ExecCallbacks {
@@ -1142,7 +1159,7 @@ fn prepare_pty_args(
     ];
     args.extend(effort_args(spec.effort));
     args.extend(model_args(spec.model));
-    args.extend(instructions::append_system_prompt_args());
+    args.extend(instructions::append_system_prompt_args(spec.instructions));
 
     if spec.fresh {
         args.push("--session-id".into());
@@ -1198,7 +1215,7 @@ fn prepare_managed_args(
     ];
     args.extend(effort_args(spec.effort));
     args.extend(model_args(spec.model));
-    args.extend(instructions::append_system_prompt_args());
+    args.extend(instructions::append_system_prompt_args(spec.instructions));
 
     if spec.fresh {
         args.push("--session-id".into());
@@ -1223,7 +1240,7 @@ fn resolve_claude(home: &Path) -> Result<String> {
 /// sandbox-exec like every other agent, so codex's own confinement is disabled
 /// to leave a single boundary — and so codex can reach its RPC mailbox, which
 /// lives outside the worktree that `workspace-write` would have confined it to.
-fn codex_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&str>, model: Option<&str>) -> Vec<String> {
+fn codex_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&str>, model: Option<&str>, extra: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = vec!["exec".into()];
     if let Some(id) = session_id {
         args.push("resume".into());
@@ -1240,7 +1257,7 @@ fn codex_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&st
         args.push(format!("reasoning_effort=\"{effort}\""));
     }
     args.extend(model_args(model));
-    args.extend(instructions::codex_config_args());
+    args.extend(instructions::codex_config_args(extra));
     args.push(prompt.to_string());
     args
 }
@@ -1260,7 +1277,7 @@ fn codex_session_id(event: &Value) -> Option<String> {
 /// `--force` runs commands without approval prompts; `--trust` trusts the
 /// workspace in headless mode. Cursor's own sandbox applies; cwd comes from
 /// the child process working directory.
-fn cursor_build_args(prompt: &str, session_id: Option<&str>, _thinking: Option<&str>, model: Option<&str>) -> Vec<String> {
+fn cursor_build_args(prompt: &str, session_id: Option<&str>, _thinking: Option<&str>, model: Option<&str>, extra: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = vec![
         "-p".into(),
         "--output-format".into(),
@@ -1274,7 +1291,7 @@ fn cursor_build_args(prompt: &str, session_id: Option<&str>, _thinking: Option<&
     }
     args.extend(model_args(model));
     // Prompt is positional and must come after options.
-    args.push(instructions::prepend_to_prompt(prompt, session_id));
+    args.push(instructions::prepend_to_prompt(prompt, session_id, extra));
     args
 }
 
@@ -1299,7 +1316,7 @@ fn cursor_session_id(event: &Value) -> Option<String> {
 /// 1.15.12. OpenCode runs in the child's cwd (no `--dir` needed) and assigns
 /// its own session id on the first turn. The prompt is positional and must
 /// come after the flags.
-fn opencode_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&str>, model: Option<&str>) -> Vec<String> {
+fn opencode_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&str>, model: Option<&str>, extra: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = vec![
         "run".into(),
         "--format".into(),
@@ -1318,7 +1335,7 @@ fn opencode_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<
         args.push("--session".into());
         args.push(id.to_string());
     }
-    args.push(instructions::prepend_to_prompt(prompt, session_id));
+    args.push(instructions::prepend_to_prompt(prompt, session_id, extra));
     args
 }
 
@@ -1340,14 +1357,14 @@ fn opencode_session_id(event: &Value) -> Option<String> {
 /// it's the resume flag common to the versions we target — 0.74.x lacks
 /// `--session-id` entirely. Verified end-to-end against pi 0.74.2. Pi runs in
 /// the child's cwd; the prompt is positional and must come after the flags.
-fn pi_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&str>, model: Option<&str>) -> Vec<String> {
+fn pi_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&str>, model: Option<&str>, extra: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = vec!["-p".into(), "--mode".into(), "json".into()];
     args.extend(model_args(model));
     if let Some(level) = thinking {
         args.push("--thinking".into());
         args.push(level.to_string());
     }
-    args.extend(instructions::append_system_prompt_args());
+    args.extend(instructions::append_system_prompt_args(extra));
     if let Some(id) = session_id {
         args.push("--session".into());
         args.push(id.to_string());
@@ -1376,10 +1393,10 @@ fn pi_session_id(event: &Value) -> Option<String> {
 /// Codex: bare `codex` launches the interactive TUI;
 /// `--dangerously-bypass-approvals-and-sandbox` runs it unattended (Quorum
 /// already isolates the worktree). `resume <id>` continues a prior session.
-fn codex_pty_args(session_id: Option<&str>, model: Option<&str>) -> Vec<String> {
+fn codex_pty_args(session_id: Option<&str>, model: Option<&str>, extra: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = vec!["--dangerously-bypass-approvals-and-sandbox".into()];
     args.extend(model_args(model));
-    args.extend(instructions::codex_config_args());
+    args.extend(instructions::codex_config_args(extra));
     if let Some(id) = session_id {
         args.push("resume".into());
         args.push(id.to_string());
@@ -1388,8 +1405,10 @@ fn codex_pty_args(session_id: Option<&str>, model: Option<&str>) -> Vec<String> 
 }
 
 /// Cursor: bare `cursor-agent` launches the TUI; `--force` auto-allows
-/// commands. `--resume <id>` continues a prior chat.
-fn cursor_pty_args(session_id: Option<&str>, model: Option<&str>) -> Vec<String> {
+/// commands. `--resume <id>` continues a prior chat. `_extra` unused: cursor
+/// has no system-prompt slot, so the brief was prepended on the first
+/// Custom-view turn and now lives in the resumed conversation.
+fn cursor_pty_args(session_id: Option<&str>, model: Option<&str>, _extra: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = vec!["--force".into()];
     args.extend(model_args(model));
     if let Some(id) = session_id {
@@ -1405,7 +1424,7 @@ fn cursor_pty_args(session_id: Option<&str>, model: Option<&str>) -> Vec<String>
 /// subcommand and makes the *default* (TUI) command print help and exit. The
 /// TUI prompts for tool permissions interactively, which the native view
 /// handles like any other keystroke.
-fn opencode_pty_args(session_id: Option<&str>, model: Option<&str>) -> Vec<String> {
+fn opencode_pty_args(session_id: Option<&str>, model: Option<&str>, _extra: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = Vec::new();
     args.extend(model_args(model));
     if let Some(id) = session_id {
@@ -1418,8 +1437,8 @@ fn opencode_pty_args(session_id: Option<&str>, model: Option<&str>) -> Vec<Strin
 /// Pi: bare `pi` launches the interactive TUI (tools auto-run there).
 /// `--session <id>` resumes — same flag the Custom-view runner uses, since the
 /// versions we target (0.74.x) lack `--session-id`.
-fn pi_pty_args(session_id: Option<&str>, model: Option<&str>) -> Vec<String> {
-    let mut args: Vec<String> = instructions::append_system_prompt_args();
+fn pi_pty_args(session_id: Option<&str>, model: Option<&str>, extra: Option<&str>) -> Vec<String> {
+    let mut args: Vec<String> = instructions::append_system_prompt_args(extra);
     args.extend(model_args(model));
     if let Some(id) = session_id {
         args.push("--session".into());
@@ -1813,7 +1832,7 @@ mod tests {
     #[test]
     fn opencode_args_request_thinking() {
         // Without --thinking, opencode emits no `reasoning` events at all.
-        let args = opencode_build_args("hi", None, None, None);
+        let args = opencode_build_args("hi", None, None, None, None);
         assert!(args.contains(&"--thinking".to_string()));
         assert!(args.contains(&"--format".to_string()));
         // Prompt is positional and last (possibly prefixed with injected
@@ -1827,11 +1846,11 @@ mod tests {
     fn codex_pty_args_launch_tui_fresh_and_resume() {
         // Fresh: bypass approvals/sandbox so the TUI runs unattended; no
         // `exec`/`resume` subcommand means the interactive CLI.
-        let fresh = codex_pty_args(None, None);
+        let fresh = codex_pty_args(None, None, None);
         assert!(fresh.contains(&"--dangerously-bypass-approvals-and-sandbox".to_string()));
         assert!(!fresh.iter().any(|a| a == "resume"));
         // Resume: `resume <id>` continues the prior interactive session.
-        let resume = codex_pty_args(Some("abc123"), None);
+        let resume = codex_pty_args(Some("abc123"), None, None);
         assert!(resume.contains(&"--dangerously-bypass-approvals-and-sandbox".to_string()));
         let pos = resume
             .iter()
@@ -1842,10 +1861,10 @@ mod tests {
 
     #[test]
     fn cursor_pty_args_force_and_resume() {
-        let fresh = cursor_pty_args(None, None);
+        let fresh = cursor_pty_args(None, None, None);
         assert!(fresh.contains(&"--force".to_string()));
         assert!(!fresh.iter().any(|a| a == "--resume"));
-        let resume = cursor_pty_args(Some("chat-1"), None);
+        let resume = cursor_pty_args(Some("chat-1"), None, None);
         assert!(resume.contains(&"--force".to_string()));
         let pos = resume
             .iter()
@@ -1859,11 +1878,11 @@ mod tests {
         // Fresh: bare `opencode` launches the TUI. It must NOT carry
         // `--dangerously-skip-permissions` — that's a `run`-only flag, and
         // the default (TUI) command prints help and exits when given it.
-        let fresh = opencode_pty_args(None, None);
+        let fresh = opencode_pty_args(None, None, None);
         assert!(!fresh.iter().any(|a| a == "--dangerously-skip-permissions"));
         assert!(fresh.is_empty());
         // Resume: `--session <id>` continues the prior session.
-        let resume = opencode_pty_args(Some("ses_9"), None);
+        let resume = opencode_pty_args(Some("ses_9"), None, None);
         assert!(!resume.iter().any(|a| a == "--dangerously-skip-permissions"));
         let pos = resume
             .iter()
@@ -1876,10 +1895,10 @@ mod tests {
     fn pi_pty_args_bare_tui_and_session() {
         // Fresh: bare `pi` launches the interactive TUI; tools auto-run there.
         // (May carry injected --append-system-prompt args, but never a resume.)
-        let fresh = pi_pty_args(None, None);
+        let fresh = pi_pty_args(None, None, None);
         assert!(!fresh.iter().any(|a| a == "--session"), "fresh TUI has no resume flag");
         // Resume uses `--session <id>` (target pi 0.74.x lacks `--session-id`).
-        let resume = pi_pty_args(Some("u-7"), None);
+        let resume = pi_pty_args(Some("u-7"), None, None);
         let pos = resume
             .iter()
             .position(|a| a == "--session")
@@ -1892,7 +1911,7 @@ mod tests {
         // Native view is wired for every per-turn agent, so each descriptor
         // must carry a TUI arg-builder. Fresh launch never references resume.
         for d in PER_TURN_AGENTS {
-            let fresh = (d.pty_args)(None, None);
+            let fresh = (d.pty_args)(None, None, None);
             assert!(
                 !fresh
                     .iter()
@@ -1905,14 +1924,14 @@ mod tests {
 
     #[test]
     fn opencode_args_variant_when_thinking_set() {
-        let args = opencode_build_args("hi", None, Some("max"), None);
+        let args = opencode_build_args("hi", None, Some("max"), None, None);
         assert!(args.contains(&"--variant".to_string()));
         assert!(args.contains(&"max".to_string()));
     }
 
     #[test]
     fn codex_args_reasoning_effort_when_thinking_set() {
-        let args = codex_build_args("hi", None, Some("high"), None);
+        let args = codex_build_args("hi", None, Some("high"), None, None);
         assert!(args.contains(&"reasoning_effort=\"high\"".to_string()));
     }
 
@@ -1921,7 +1940,7 @@ mod tests {
         // Quorum now wraps codex in sandbox-exec, so codex's own confinement is
         // turned fully off — otherwise its workspace-write sandbox would block
         // the RPC mailbox, which lives outside the worktree.
-        let args = codex_build_args("hi", None, None, None);
+        let args = codex_build_args("hi", None, None, None, None);
         assert!(args.contains(&"sandbox_mode=\"danger-full-access\"".to_string()));
         assert!(!args.iter().any(|a| a.contains("workspace-write")));
         assert!(args.contains(&"approval_policy=\"never\"".to_string()));
@@ -1929,7 +1948,7 @@ mod tests {
 
     #[test]
     fn pi_args_thinking_when_set() {
-        let args = pi_build_args("hi", None, Some("xhigh"), None);
+        let args = pi_build_args("hi", None, Some("xhigh"), None, None);
         assert!(args.contains(&"--thinking".to_string()));
         assert!(args.contains(&"xhigh".to_string()));
     }
@@ -1949,8 +1968,8 @@ mod tests {
 
     #[test]
     fn cursor_args_ignores_thinking() {
-        let with_none = cursor_build_args("hi", None, None, None);
-        let with_some = cursor_build_args("hi", None, Some("high"), None);
+        let with_none = cursor_build_args("hi", None, None, None, None);
+        let with_some = cursor_build_args("hi", None, Some("high"), None, None);
         assert_eq!(with_none, with_some);
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -175,6 +175,8 @@ pub async fn spawn_agent(
     name: Option<String>,
     effort: Option<String>,
     model: Option<String>,
+    instructions: Option<String>,
+    custom_agent_id: Option<String>,
 ) -> Result<AgentRecord> {
     let sup = supervisor.inner().clone();
     sup.spawn_agent(
@@ -185,6 +187,8 @@ pub async fn spawn_agent(
         name,
         effort,
         model,
+        instructions,
+        custom_agent_id,
     )
     .await
 }

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use crate::error::{Error, Result};
 
 const ALLOWED_TABLES: &[&str] = &[
-    "accounts", "project_settings", "projects", "repos",
+    "accounts", "custom_agents", "project_settings", "projects", "repos",
     "sessions", "settings", "workspaces", "worktrees",
 ];
 
@@ -84,6 +84,7 @@ fn get_migrations() -> Migrations<'static> {
         M::up(include_str!("../migrations/0008_worktree_base_sha.sql")),
         M::up(include_str!("../migrations/0009_session_model.sql")),
         M::up(include_str!("../migrations/0010_worktree_pr_number.sql")),
+        M::up(include_str!("../migrations/0011_custom_agents.sql")),
     ])
 }
 

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -52,24 +52,39 @@ pub fn text() -> String {
     combined
 }
 
-/// Args for agents that expose `--append-system-prompt` (Claude, Pi).
-/// Empty when there's nothing to inject.
-pub fn append_system_prompt_args() -> Vec<String> {
-    let text = text();
+/// The global instruction text plus an optional per-session suffix (a custom
+/// agent's standing brief). The suffix is appended *after* the global block so
+/// project/global guidance composes with the agent's role rather than replacing
+/// it. Empty (a no-op for every helper) only when both layers are blank.
+fn combined(extra: Option<&str>) -> String {
+    let base = text();
+    match extra.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(custom) if base.is_empty() => custom.to_string(),
+        Some(custom) => format!("{base}\n\n{custom}"),
+        None => base,
+    }
+}
+
+/// Args for agents that expose `--append-system-prompt` (Claude, Pi). `extra`
+/// carries a custom agent's per-session instructions. Empty when there's
+/// nothing to inject.
+pub fn append_system_prompt_args(extra: Option<&str>) -> Vec<String> {
+    let text = combined(extra);
     if text.is_empty() {
         return Vec::new();
     }
-    vec!["--append-system-prompt".into(), text.to_string()]
+    vec!["--append-system-prompt".into(), text]
 }
 
 /// Args for Codex's developer-instructions config override
-/// (`-c developer_instructions="…"`). Empty when there's nothing to inject.
+/// (`-c developer_instructions="…"`). `extra` carries a custom agent's
+/// per-session instructions. Empty when there's nothing to inject.
 ///
 /// The value is a TOML basic string passed as a single argv element (no shell
 /// is involved — `Command`/`portable-pty` pass argv directly), so only TOML
 /// string escaping matters, not shell quoting.
-pub fn codex_config_args() -> Vec<String> {
-    let text = text();
+pub fn codex_config_args(extra: Option<&str>) -> Vec<String> {
+    let text = combined(extra);
     if text.is_empty() {
         return Vec::new();
     }
@@ -82,9 +97,10 @@ pub fn codex_config_args() -> Vec<String> {
 /// For agents with no system-prompt slot (Cursor, OpenCode, Antigravity), fold
 /// the instructions into the prompt — but only on the first turn of a session
 /// (`session_id` is `None`). On later turns the text is already in the resumed
-/// history, so the original prompt is returned unchanged.
-pub fn prepend_to_prompt(prompt: &str, session_id: Option<&str>) -> String {
-    let text = text();
+/// history, so the original prompt is returned unchanged. `extra` carries a
+/// custom agent's per-session instructions.
+pub fn prepend_to_prompt(prompt: &str, session_id: Option<&str>, extra: Option<&str>) -> String {
+    let text = combined(extra);
     if text.is_empty() || session_id.is_some() {
         return prompt.to_string();
     }
@@ -136,14 +152,14 @@ mod tests {
 
     #[test]
     fn append_args_carry_the_text() {
-        let args = append_system_prompt_args();
+        let args = append_system_prompt_args(None);
         assert_eq!(args[0], "--append-system-prompt");
         assert_eq!(args[1], text());
     }
 
     #[test]
     fn codex_args_are_a_toml_developer_instructions_override() {
-        let args = codex_config_args();
+        let args = codex_config_args(None);
         assert_eq!(args[0], "-c");
         assert!(args[1].starts_with("developer_instructions=\""));
         assert!(args[1].ends_with('"'));
@@ -151,14 +167,41 @@ mod tests {
 
     #[test]
     fn prepend_only_on_first_turn() {
-        let first = prepend_to_prompt("do the thing", None);
+        let first = prepend_to_prompt("do the thing", None, None);
         assert!(first.starts_with("<quorum-system>"));
         assert!(first.contains(text().as_str()));
         assert!(first.contains("</quorum-system>"));
         assert!(first.ends_with("do the thing"));
 
         // Resumed turn: untouched (the text is already in history).
-        assert_eq!(prepend_to_prompt("do the thing", Some("sess-1")), "do the thing");
+        assert_eq!(prepend_to_prompt("do the thing", Some("sess-1"), None), "do the thing");
+    }
+
+    #[test]
+    fn custom_instructions_append_after_global_block() {
+        let custom = "You are the Reviewer. Be terse.";
+
+        // Append-style: the global text and the custom brief both ride in the
+        // single --append-system-prompt arg, global first.
+        let args = append_system_prompt_args(Some(custom));
+        let base = text();
+        assert_eq!(args[1], format!("{base}\n\n{custom}"));
+
+        // Codex developer_instructions carries the combined text too.
+        let codex = codex_config_args(Some(custom));
+        assert!(codex[1].contains(custom));
+
+        // Prepend-style: custom brief lands in the first-turn block.
+        let first = prepend_to_prompt("do it", None, Some(custom));
+        assert!(first.contains(custom));
+        assert!(first.contains(base.as_str()));
+        // Still suppressed on resume (the text is already in history).
+        assert_eq!(prepend_to_prompt("do it", Some("s"), Some(custom)), "do it");
+    }
+
+    #[test]
+    fn blank_custom_instructions_are_a_noop() {
+        assert_eq!(append_system_prompt_args(Some("   ")), append_system_prompt_args(None));
     }
 
     #[test]

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -461,6 +461,8 @@ impl Supervisor {
         name: Option<String>,
         effort: Option<String>,
         model: Option<String>,
+        instructions: Option<String>,
+        custom_agent_id: Option<String>,
     ) -> Result<AgentRecord> {
         if !repo_path.join(".git").exists() {
             return Err(Error::InvalidPath(format!(
@@ -519,6 +521,10 @@ impl Supervisor {
         // Session-level model selection. `None` preserves the provider CLI
         // default; selected values are reapplied on resume and view switches.
         record.model = model;
+        // Custom agent identity + snapshotted brief. Both `None` for a plain
+        // built-in spawn. The brief is re-injected on every spawn/resume.
+        record.instructions = instructions;
+        record.custom_agent_id = custom_agent_id;
         let parent_dir = agent_parent_dir(&agent_id)?;
         let primary_worktree = repo_worktree_path(&agent_id, &subdir)?;
 
@@ -736,6 +742,7 @@ impl Supervisor {
                         // not at spawn.
                         effort: None,
                         model: record.model.as_deref(),
+                        instructions: record.instructions.as_deref(),
                         rpc_dir: rpc_dir.clone(),
                         cols: 120,
                         rows: 32,
@@ -759,6 +766,7 @@ impl Supervisor {
                         sandbox_root: sandbox_root.clone(),
                         session_id: session_id.clone(),
                         model: record.model.clone(),
+                        instructions: record.instructions.clone(),
                         rpc_dir: rpc_dir.clone(),
                     },
                     app.clone(),
@@ -781,6 +789,7 @@ impl Supervisor {
                 // re-applies on every spawn (fresh, view-switch, resume).
                 effort: record.effort.as_deref(),
                 model: record.model.as_deref(),
+                instructions: record.instructions.as_deref(),
                 rpc_dir: rpc_dir.clone(),
                 cols: 120,
                 rows: 32,

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -154,6 +154,17 @@ pub struct AgentRecord {
     /// use its configured/default model.
     #[serde(default)]
     pub model: Option<String>,
+    /// A custom agent's standing instructions, snapshotted at spawn and
+    /// re-injected on every process spawn/resume (after Quorum's global system
+    /// prompt). `None` for a plain built-in spawn. Snapshotting (rather than
+    /// re-resolving from `custom_agents`) keeps a running agent's brief stable
+    /// even if the custom agent is later edited or deleted.
+    #[serde(default)]
+    pub instructions: Option<String>,
+    /// The custom agent this session was spawned from, used to show its
+    /// name/color in the sidebar. `None` for a plain built-in spawn.
+    #[serde(default)]
+    pub custom_agent_id: Option<String>,
     pub created_at: String,
     #[serde(default)]
     pub last_error: Option<String>,
@@ -431,8 +442,8 @@ impl WorkspaceManager {
         // not persisted — it derives from the workspace/session dispositions.
         let session_id = uuid::Uuid::new_v4().to_string();
         tx.execute(
-            "INSERT INTO sessions (id, workspace_id, provider, view, provider_session_id, last_error, effort, model, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            "INSERT INTO sessions (id, workspace_id, provider, view, provider_session_id, last_error, effort, model, instructions, custom_agent_id, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
             rusqlite::params![
                 session_id,
                 record.id,
@@ -442,6 +453,8 @@ impl WorkspaceManager {
                 record.last_error,
                 record.effort,
                 record.model,
+                record.instructions,
+                record.custom_agent_id,
                 created_millis,
             ],
         )?;
@@ -1049,7 +1062,7 @@ impl WorkspaceManager {
             "SELECT w.id, w.project_id, w.name, w.task, w.created_at,
                     w.stopped_at, w.archived_at,
                     s.provider, s.view, s.provider_session_id, s.last_error,
-                    s.effort, s.model
+                    s.effort, s.model, s.instructions, s.custom_agent_id
              FROM workspaces w
              LEFT JOIN sessions s ON s.workspace_id = w.id
              ORDER BY w.created_at",
@@ -1073,6 +1086,8 @@ impl WorkspaceManager {
                 let last_error: Option<String> = row.get(10)?;
                 let effort: Option<String> = row.get(11)?;
                 let model: Option<String> = row.get(12)?;
+                let instructions: Option<String> = row.get(13)?;
+                let custom_agent_id: Option<String> = row.get(14)?;
 
                 Ok((
                     id,
@@ -1088,6 +1103,8 @@ impl WorkspaceManager {
                     last_error,
                     effort,
                     model,
+                    instructions,
+                    custom_agent_id,
                 ))
             })
             .ok()
@@ -1109,6 +1126,8 @@ impl WorkspaceManager {
                     last_error,
                     effort,
                     model,
+                    instructions,
+                    custom_agent_id,
                 )| {
                     let is_archived = archived_millis.is_some();
 
@@ -1142,6 +1161,8 @@ impl WorkspaceManager {
                         session_id,
                         effort,
                         model,
+                        instructions,
+                        custom_agent_id,
                         created_at: millis_to_iso(created_millis),
                         last_error,
                         archive,
@@ -1359,7 +1380,7 @@ impl WorkspaceManager {
                 "SELECT w.id, w.project_id, w.name, w.task, w.created_at,
                         w.stopped_at, w.archived_at,
                         s.provider, s.view, s.provider_session_id, s.last_error,
-                        s.effort, s.model
+                        s.effort, s.model, s.instructions, s.custom_agent_id
                  FROM workspaces w
                  LEFT JOIN sessions s ON s.workspace_id = w.id
                  WHERE w.id = ?1",
@@ -1379,6 +1400,8 @@ impl WorkspaceManager {
                         row.get::<_, Option<String>>(10)?,
                         row.get::<_, Option<String>>(11)?,
                         row.get::<_, Option<String>>(12)?,
+                        row.get::<_, Option<String>>(13)?,
+                        row.get::<_, Option<String>>(14)?,
                     ))
                 },
             )
@@ -1398,6 +1421,8 @@ impl WorkspaceManager {
             last_error,
             effort,
             model,
+            instructions,
+            custom_agent_id,
         ) = row;
 
         let is_archived = archived_millis.is_some();
@@ -1430,6 +1455,8 @@ impl WorkspaceManager {
             session_id,
             effort,
             model,
+            instructions,
+            custom_agent_id,
             created_at: millis_to_iso(created_millis),
             last_error,
             archive,
@@ -1477,6 +1504,8 @@ pub fn new_agent_record(
         session_id,
         effort: None,
         model: None,
+        instructions: None,
+        custom_agent_id: None,
         created_at: Utc::now().to_rfc3339(),
         last_error: None,
         archive: None,
@@ -1733,6 +1762,56 @@ mod tests {
         // may reference a now-deleted repo — that's fine, the sidebar
         // union logic handles it).
         assert_eq!(cur.agents.len(), 1);
+    }
+
+    #[test]
+    fn custom_agent_instructions_and_id_round_trip() {
+        let db = test_db();
+        let wm = WorkspaceManager::new(db.clone());
+        seed_repo(&db, "/r");
+
+        let mut rec = new_agent_record(
+            "shasta".into(),
+            "a".into(),
+            "claude".into(),
+            mk_repo("/r"),
+            "task".into(),
+            AgentView::Custom,
+        );
+        let id = rec.id.clone();
+        rec.instructions = Some("You are the Reviewer. Be terse.".into());
+        rec.custom_agent_id = Some("ca-reviewer".into());
+        wm.add_agent(&mut rec).unwrap();
+
+        // Read back via load_agent (single-row path)…
+        let loaded = wm.agent(&id).unwrap();
+        assert_eq!(loaded.instructions.as_deref(), Some("You are the Reviewer. Be terse."));
+        assert_eq!(loaded.custom_agent_id.as_deref(), Some("ca-reviewer"));
+
+        // …and via the full list (query_all_agents path).
+        let listed = wm
+            .current()
+            .unwrap()
+            .agents
+            .into_iter()
+            .find(|a| a.id == id)
+            .unwrap();
+        assert_eq!(listed.custom_agent_id.as_deref(), Some("ca-reviewer"));
+
+        // A plain built-in spawn leaves both columns null.
+        let mut plain = new_agent_record(
+            "tahoe".into(),
+            "b".into(),
+            "claude".into(),
+            mk_repo("/r"),
+            "task".into(),
+            AgentView::Custom,
+        );
+        let plain_id = plain.id.clone();
+        wm.add_agent(&mut plain).unwrap();
+        let plain_loaded = wm.agent(&plain_id).unwrap();
+        assert_eq!(plain_loaded.instructions, None);
+        assert_eq!(plain_loaded.custom_agent_id, None);
     }
 
     #[test]

--- a/src/api.ts
+++ b/src/api.ts
@@ -64,6 +64,9 @@ export interface AgentRecord {
   effort?: string | null;
   /** Model chosen at spawn. Null/undefined means the provider CLI default. */
   model?: string | null;
+  /** The custom agent this session was spawned from (null for a built-in
+   *  spawn). Used to show the custom agent's name/color in the sidebar. */
+  custom_agent_id?: string | null;
 }
 
 export interface Workspace {
@@ -382,6 +385,8 @@ export const api = {
     name?: string,
     effort?: string,
     model?: string,
+    instructions?: string,
+    customAgentId?: string,
   ) =>
     invoke<AgentRecord>("spawn_agent", {
       view,
@@ -390,6 +395,8 @@ export const api = {
       name,
       effort: effort ?? null,
       model: model ?? null,
+      instructions: instructions ?? null,
+      customAgentId: customAgentId ?? null,
     }),
   writeToAgent: (agentId: string, data: string) =>
     invoke<void>("write_to_agent", { agentId, data }),

--- a/src/app.css
+++ b/src/app.css
@@ -4240,3 +4240,174 @@ button { cursor: default; }
 .rdy-hint { color: var(--fg-3); font-size: 11.5px; }
 .rdy-foot { display: flex; align-items: center; justify-content: space-between; margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--bg-2); }
 .rdy-count { color: var(--fg-2); font-size: 12px; }
+
+/* ── CUSTOM AGENTS ───────────────────────────────────────────────────── */
+/* Colored monogram tile standing in for a custom agent avatar; `--h` is the
+   agent's hue (0-360). Used in the list, editor head, and composer picker. */
+.ca-mono {
+  display: inline-flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+  font-weight: 600; font-family: var(--font-mono);
+  letter-spacing: -0.01em;
+  color: oklch(0.82 0.11 var(--h));
+  background: oklch(0.62 0.14 var(--h) / 0.16);
+  border: 1px solid oklch(0.7 0.12 var(--h) / 0.32);
+}
+.theme-light .ca-mono { color: oklch(0.5 0.16 var(--h)); }
+
+/* list */
+.ca-list { display: flex; flex-direction: column; gap: 8px; }
+.ca-card {
+  display: flex; align-items: center; gap: 13px;
+  padding: 12px 14px;
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-lg);
+  background: var(--bg-2);
+  cursor: pointer;
+  transition: border-color .15s, background .15s;
+}
+.ca-card:hover { border-color: var(--bd); background: var(--hover); }
+.ca-card:focus-visible { outline: 2px solid var(--accent-line); outline-offset: 1px; }
+.ca-id { flex: 1; min-width: 0; }
+.ca-name {
+  display: flex; align-items: center; gap: 10px;
+  font-size: 13.5px; font-weight: 500; color: var(--fg-0);
+}
+.ca-base {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 11px; color: var(--fg-3); font-weight: 400;
+}
+.ca-base-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+.ca-desc {
+  font-size: 12px; color: var(--fg-2); margin-top: 3px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.ca-acts { display: flex; align-items: center; gap: 2px; flex-shrink: 0; }
+
+.ca-empty {
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 10px; width: 100%; min-height: 130px;
+  border: 1px dashed var(--bd); border-radius: var(--r-lg);
+  background: var(--bg-1); color: var(--fg-2);
+  font-size: 13px; cursor: pointer;
+  transition: border-color .15s, color .15s, background .15s;
+}
+.ca-empty:hover { border-color: var(--accent-line); color: var(--fg-0); background: var(--hover); }
+.ca-empty-ic {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 34px; height: 34px; border-radius: 50%;
+  background: var(--bg-3); color: var(--fg-1);
+}
+
+/* editor */
+.ca-editor { display: flex; flex-direction: column; gap: 18px; max-width: 640px; }
+.ca-ed-back {
+  align-self: flex-start;
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 12px; color: var(--fg-2);
+  padding: 4px 0; margin-bottom: 4px;
+}
+.ca-ed-back:hover { color: var(--fg-0); }
+.ca-ed-head { display: flex; align-items: center; gap: 14px; }
+.ca-ed-mono { width: 46px; height: 46px; border-radius: 11px; font-size: 15px; }
+.ca-ed-name {
+  flex: 1; min-width: 0;
+  height: 40px; padding: 0 12px;
+  font-size: 18px; font-weight: 500; color: var(--fg-0);
+  background: transparent; border: 1px solid transparent; border-radius: var(--r-md);
+  transition: border-color .15s, background .15s;
+}
+.ca-ed-name::placeholder { color: var(--fg-3); }
+.ca-ed-name:hover { background: var(--bg-2); }
+.ca-ed-name:focus { background: var(--bg-0); border-color: var(--accent-line); }
+.ca-hues { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
+.ca-hue {
+  width: 18px; height: 18px; border-radius: 50%;
+  background: oklch(0.68 0.14 var(--h));
+  border: 2px solid transparent;
+  transition: transform .12s, border-color .12s;
+}
+.ca-hue:hover { transform: scale(1.12); }
+.ca-hue.active { border-color: var(--fg-0); }
+
+.ca-field { margin: 0; }
+.ca-field-hint { color: var(--fg-3); font-weight: 400; margin-left: 8px; }
+.ca-req { color: var(--accent); }
+.ca-grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+.ca-textarea {
+  height: auto; min-height: 150px; padding: 11px 12px;
+  line-height: 1.55; resize: vertical; font-family: var(--font-sans);
+}
+.ca-inject {
+  display: flex; align-items: center; gap: 7px;
+  font-size: 12px; color: var(--fg-2);
+  padding: 9px 12px; border-radius: var(--r-md);
+  background: var(--bg-2); border: 1px solid var(--bd-soft);
+  margin-top: -4px;
+}
+.ca-inject svg { color: var(--accent); flex-shrink: 0; }
+.ca-inject b { color: var(--fg-1); font-weight: 500; font-family: var(--font-mono); font-size: 11.5px; }
+
+.ca-ed-foot {
+  display: flex; align-items: center; gap: 12px;
+  margin-top: 6px; padding-top: 18px;
+  border-top: 1px solid var(--bd-soft);
+}
+.ca-grow { flex: 1; }
+
+/* Custom agents section at the top of the model picker dropdown. */
+.model-custom { padding: 6px; border-bottom: 1px solid var(--bd-soft); }
+.model-custom-head {
+  padding: 4px 6px 6px;
+  color: var(--fg-3); font-size: 10px; font-weight: 650;
+  letter-spacing: .08em; text-transform: uppercase;
+}
+.model-custom-row {
+  width: 100%; display: flex; align-items: center; gap: 9px;
+  padding: 7px 8px; border-radius: var(--r-sm);
+  color: var(--fg-1); text-align: left;
+  transition: background .12s;
+}
+.model-custom-row:hover { background: var(--hover); }
+.model-custom-row.active { background: var(--selected); }
+.model-custom-row > svg { margin-left: auto; color: var(--accent); flex-shrink: 0; }
+.model-custom-text { min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+.model-custom-text > span:first-child {
+  font-size: 12.5px; color: var(--fg-0); font-weight: 500;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.model-custom-text > span:last-child {
+  font-size: 11px; color: var(--fg-3);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+
+/* ── UI SELECT (custom dropdown replacing native <select>) ───────────────── */
+.ui-select { position: relative; }
+.ui-select-trigger {
+  width: 100%;
+  height: 36px; padding: 0 10px 0 12px;
+  display: flex; align-items: center; gap: 8px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--bd);
+  background: var(--bg-0);
+  font-size: 13px; color: var(--fg-0);
+  cursor: pointer; text-align: left;
+  transition: border-color .15s, box-shadow .15s;
+}
+.ui-select-trigger:hover:not(:disabled) { border-color: var(--fg-3); }
+.ui-select-trigger.open {
+  border-color: var(--accent-line);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent), transparent 90%);
+}
+.ui-select-trigger:disabled { opacity: .5; cursor: not-allowed; }
+.ui-select-trigger > svg { color: var(--fg-3); flex-shrink: 0; }
+.ui-select-icon { display: inline-flex; align-items: center; flex-shrink: 0; }
+.ui-select-value { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ui-select-value.is-placeholder { color: var(--fg-3); }
+.ui-select-dd {
+  top: calc(100% + 4px); left: 0;
+  width: 100%; min-width: 0;
+  max-height: min(300px, 40vh); overflow-y: auto;
+}
+.ui-select-dd .dd-item .di-l { font-size: 13px; }
+.ui-select-dd .dd-item > svg { margin-left: auto; color: var(--accent); flex-shrink: 0; }

--- a/src/app.css
+++ b/src/app.css
@@ -4164,6 +4164,8 @@ button { cursor: default; }
 .set-prov-detail-actions .grow { flex: 1; }
 .btn-t.sm-t { height: 26px; padding: 0 10px; font-size: 11.5px; white-space: nowrap; }
 .btn-t.danger { color: var(--danger); }
+.btn-i.danger { color: var(--danger); }
+.btn-i.danger:hover { background: color-mix(in oklch, var(--danger), transparent 88%); }
 .btn-t.outline.danger:hover {
   border-color: color-mix(in oklch, var(--danger), transparent 55%);
   background: color-mix(in oklch, var(--danger), transparent 92%);
@@ -4409,5 +4411,15 @@ button { cursor: default; }
   width: 100%; min-width: 0;
   max-height: min(300px, 40vh); overflow-y: auto;
 }
+/* Options are <button>s for keyboard operability — reset UA chrome and make
+   them full-width so they read like the div-based .dd-item rows elsewhere. */
+.ui-select-dd .dd-item {
+  width: 100%; background: none; border: 0; cursor: pointer;
+  font: inherit; text-align: left;
+}
 .ui-select-dd .dd-item .di-l { font-size: 13px; }
 .ui-select-dd .dd-item > svg { margin-left: auto; color: var(--accent); flex-shrink: 0; }
+.ui-select-dd .dd-item:focus-visible {
+  outline: none; background: var(--hover);
+  box-shadow: inset 0 0 0 1px var(--accent-line);
+}

--- a/src/components/Composer/ModelPicker.tsx
+++ b/src/components/Composer/ModelPicker.tsx
@@ -1,16 +1,20 @@
 import { useEffect, useMemo, useState } from "react";
-import { PROVIDERS } from "../../data/providers";
+import { PROVIDERS, providerLabel } from "../../data/providers";
 import { hasAdapter } from "../../adapters";
 import { useAppStore } from "../../store";
 import { Icon } from "../Icon";
 import { ProviderIcon } from "../ProviderIcon";
+import { Mono } from "../SettingsScreen/CustomAgents/Mono";
 import { Chip } from "../ui/Chip";
 import { Scrim } from "../ui/Scrim";
 
 interface Props {
   provider: string;
   model?: string;
-  onChange: (provider: string, model?: string) => void;
+  /** Selected custom agent id, if the user picked one rather than a built-in
+   *  provider. Drives the chip's identity and the dropdown's active row. */
+  customAgentId?: string;
+  onChange: (provider: string, model?: string, customAgentId?: string) => void;
   locked?: boolean;
 }
 
@@ -29,7 +33,7 @@ function modelFamily(name: string): string {
 /** Agent + model picker. The left rail previews each runner's models; selecting
  *  a row in the right pane commits the runner/model choice. Leaving model unset
  *  preserves the provider CLI's default. */
-export function ModelPicker({ provider, model, onChange, locked = false }: Props) {
+export function ModelPicker({ provider, model, customAgentId, onChange, locked = false }: Props) {
   const [open, setOpen] = useState(false);
   const [focusProvider, setFocusProvider] = useState(provider);
   const providerFlags = useAppStore((s) => s.providerFlags);
@@ -37,6 +41,7 @@ export function ModelPicker({ provider, model, onChange, locked = false }: Props
   const providerPaths = useAppStore((s) => s.providerPaths);
   const providersProbed = useAppStore((s) => s.providersProbed);
   const modelsByAgent = useAppStore((s) => s.modelsByAgent);
+  const customAgents = useAppStore((s) => s.customAgents);
 
   const selected = PROVIDERS.find((p) => p.id === provider) ?? PROVIDERS[0];
   const enabled = PROVIDERS.filter((p) => providerFlags[p.id] !== false);
@@ -47,12 +52,23 @@ export function ModelPicker({ provider, model, onChange, locked = false }: Props
     return list.find((m) => m.id === model);
   }, [model, modelsByAgent, provider]);
 
+  // The active custom agent (chip identity + dropdown highlight). Only custom
+  // agents whose base provider is enabled are offered.
+  const activeCustom = customAgents.find((a) => a.id === customAgentId);
+  const selectableCustom = customAgents.filter((a) => providerFlags[a.base] !== false);
+
   useEffect(() => {
     if (open) setFocusProvider(provider);
   }, [open, provider]);
 
   function pickModel(id: string | undefined) {
-    onChange(focused.id, id);
+    // Selecting a built-in model clears any custom-agent selection.
+    onChange(focused.id, id, undefined);
+    setOpen(false);
+  }
+
+  function pickCustom(agentId: string, base: string, agentModel: string | null) {
+    onChange(base, agentModel ?? undefined, agentId);
     setOpen(false);
   }
 
@@ -64,19 +80,29 @@ export function ModelPicker({ provider, model, onChange, locked = false }: Props
         onClick={() => {
           if (!locked) setOpen((v) => !v);
         }}
-        tip={locked ? selected.label : "Agent and model"}
+        tip={locked ? (activeCustom?.name ?? selected.label) : "Agent and model"}
         className="model-chip"
       >
-        <ProviderIcon
-          slug={selected.id}
-          short={selected.short}
-          hue={selected.hue}
-          size={15}
-        />
-        <span className="model-chip-agent">{selected.label}</span>
-        <span className="model-chip-model">
-          {currentModel?.name ?? "Default model"}
-        </span>
+        {activeCustom ? (
+          <>
+            <Mono name={activeCustom.name} hue={activeCustom.color} size={15} />
+            <span className="model-chip-agent">{activeCustom.name}</span>
+            <span className="model-chip-model">{providerLabel(activeCustom.base)}</span>
+          </>
+        ) : (
+          <>
+            <ProviderIcon
+              slug={selected.id}
+              short={selected.short}
+              hue={selected.hue}
+              size={15}
+            />
+            <span className="model-chip-agent">{selected.label}</span>
+            <span className="model-chip-model">
+              {currentModel?.name ?? "Default model"}
+            </span>
+          </>
+        )}
         {!locked && <Icon name="chevD" size={9} />}
       </Chip>
 
@@ -84,6 +110,29 @@ export function ModelPicker({ provider, model, onChange, locked = false }: Props
         <>
           <Scrim onClose={() => setOpen(false)} />
           <div className="dd model-dd" style={{ bottom: "calc(100% + 6px)", left: 0 }}>
+            {selectableCustom.length > 0 && (
+              <div className="model-custom">
+                <div className="model-custom-head">Custom agents</div>
+                {selectableCustom.map((a) => {
+                  const active = a.id === customAgentId;
+                  return (
+                    <button
+                      key={a.id}
+                      type="button"
+                      className={`model-custom-row ${active ? "active" : ""}`}
+                      onClick={() => pickCustom(a.id, a.base, a.model)}
+                    >
+                      <Mono name={a.name} hue={a.color} size={20} />
+                      <span className="model-custom-text">
+                        <span>{a.name}</span>
+                        <span>{a.description || providerLabel(a.base)}</span>
+                      </span>
+                      {active && <Icon name="check" size={12} />}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
             <div className="model-dd-head">
               <span>Agent</span>
               <span>Model</span>
@@ -113,7 +162,7 @@ export function ModelPicker({ provider, model, onChange, locked = false }: Props
                         <span>{p.label}</span>
                         <span>{missing ? "Not installed" : providerVersions[p.id] ?? p.version}</span>
                       </span>
-                      {p.id === provider && <Icon name="check" size={12} />}
+                      {p.id === provider && !customAgentId && <Icon name="check" size={12} />}
                     </button>
                   );
                 })}
@@ -122,7 +171,7 @@ export function ModelPicker({ provider, model, onChange, locked = false }: Props
               <div className="model-list">
                 <button
                   type="button"
-                  className={`model-option ${focused.id === provider && !model ? "active" : ""}`}
+                  className={`model-option ${focused.id === provider && !model && !customAgentId ? "active" : ""}`}
                   onClick={() => pickModel(undefined)}
                 >
                   <span className="model-mark">
@@ -142,7 +191,7 @@ export function ModelPicker({ provider, model, onChange, locked = false }: Props
                   </div>
                 ) : (
                   focusedModels.map((m) => {
-                    const active = focused.id === provider && m.id === model;
+                    const active = focused.id === provider && m.id === model && !customAgentId;
                     return (
                       <button
                         key={m.id}

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -25,6 +25,8 @@ interface Props {
   defaultProvider?: string;
   /** Initial model id for new-agent drafts. Undefined means provider default. */
   defaultModel?: string;
+  /** Initial custom-agent id for new-agent drafts, if one was selected. */
+  defaultCustomAgentId?: string;
   /** When set, render a branch picker chip showing the current base branch. */
   baseBranch?: string;
   /** Repo path used to fetch available branches for the picker. */
@@ -44,6 +46,8 @@ interface Props {
     /** Raw effort value for the selected provider, or undefined when the
      *  provider has no thinking levels (e.g. Cursor). */
     thinking: string | undefined;
+    /** The selected custom agent's id, or undefined for a built-in spawn. */
+    customAgentId: string | undefined;
     attachments: string[];
   }) => void;
   /** Fired when the composer is showing an active stop control. */
@@ -52,8 +56,9 @@ interface Props {
    *  `action` identifier comes from the `SlashCommand` entry. The text
    *  is NOT sent to the agent; the parent decides what to do. */
   onLocalCommand?: (action: string) => void;
-  /** Fired when a new-agent draft changes its provider/model selection. */
-  onChangeSelection?: (provider: string, model?: string) => void;
+  /** Fired when a new-agent draft changes its provider/model/custom-agent
+   *  selection. `customAgentId` is set when a custom agent is picked. */
+  onChangeSelection?: (provider: string, model?: string, customAgentId?: string) => void;
   /** Supplies candidate worktree-relative file paths for the "@" mention
    *  autocomplete. Called each time a mention opens, so the list stays fresh
    *  as the agent edits files. Omit it (e.g. new sessions with no worktree
@@ -107,6 +112,7 @@ function resolveThinking(providerId: string): string | undefined {
 export function Composer({
   defaultProvider = DEFAULT_PROVIDER_ID,
   defaultModel,
+  defaultCustomAgentId,
   baseBranch,
   repoPath,
   onChangeBase,
@@ -132,6 +138,7 @@ export function Composer({
   const features = useAppStore((s) => s.features);
   const modelCatalog = useAppStore((s) => s.modelCatalog);
   const setComposerDraft = useAppStore((s) => s.setComposerDraft);
+  const customAgents = useAppStore((s) => s.customAgents);
 
   // Hide the thinking-effort picker for a model the catalog knows can't reason.
   // When the model is unknown (a new session before the first turn, or one the
@@ -145,6 +152,9 @@ export function Composer({
   );
   const [provider, setProvider] = useState(defaultProvider);
   const [model, setModel] = useState<string | undefined>(defaultModel);
+  const [customAgentId, setCustomAgentId] = useState<string | undefined>(
+    defaultCustomAgentId,
+  );
   const activeMeta = lookupModel(
     modelCatalog,
     existingSession ? activeModel ?? model : model,
@@ -160,10 +170,16 @@ export function Composer({
     () => resolveThinking(defaultProvider),
   );
 
-  // When switching providers, restore the last-used level for that provider.
+  // When switching providers, restore the last-used level for that provider —
+  // unless a custom agent is selected with its own reasoning budget, which
+  // takes precedence (runs after the provider change a custom pick triggers,
+  // so it wins).
   useEffect(() => {
-    setThinkingValue(resolveThinking(provider));
-  }, [provider]);
+    const custom = customAgentId
+      ? customAgents.find((a) => a.id === customAgentId)
+      : undefined;
+    setThinkingValue(custom?.effort || resolveThinking(provider));
+  }, [provider, customAgentId, customAgents]);
   // Caret offset, tracked so triggers can be detected at the cursor (not just
   // at the start of the text).
   const [caret, setCaret] = useState(0);
@@ -254,7 +270,7 @@ export function Composer({
       return;
     }
     if ((!trimmed && attachments.length === 0) || disabled) return;
-    onSend({ text: trimmed, provider, model, thinking: thinkingValue, attachments });
+    onSend({ text: trimmed, provider, model, thinking: thinkingValue, customAgentId, attachments });
     setText("");
     setAttachments([]);
     if (ta.current) ta.current.style.height = "auto";
@@ -319,11 +335,15 @@ export function Composer({
         <ModelPicker
           provider={provider}
           model={model}
+          customAgentId={customAgentId}
           locked={existingSession}
-          onChange={(nextProvider, nextModel) => {
+          onChange={(nextProvider, nextModel, nextCustomAgentId) => {
+            // Effort follows from the selection via the effect above (a custom
+            // agent's reasoning budget, else the per-provider default).
             setProvider(nextProvider);
             setModel(nextModel);
-            onChangeSelection?.(nextProvider, nextModel);
+            setCustomAgentId(nextCustomAgentId);
+            onChangeSelection?.(nextProvider, nextModel, nextCustomAgentId);
           }}
         />
         {features.thinkingBudget && thinkingLevels.length > 0 && modelSupportsThinking && (

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -170,16 +170,23 @@ export function Composer({
     () => resolveThinking(defaultProvider),
   );
 
+  // Latest custom agents, read via a ref inside the effect below so that
+  // editing an agent elsewhere doesn't re-fire it (which would clobber a
+  // manually-adjusted thinking level). Kept current on every render.
+  const customAgentsRef = useRef(customAgents);
+  customAgentsRef.current = customAgents;
+
   // When switching providers, restore the last-used level for that provider —
   // unless a custom agent is selected with its own reasoning budget, which
   // takes precedence (runs after the provider change a custom pick triggers,
-  // so it wins).
+  // so it wins). Fires only on genuine provider/custom-agent *selection*
+  // changes, not when the agent list mutates.
   useEffect(() => {
     const custom = customAgentId
-      ? customAgents.find((a) => a.id === customAgentId)
+      ? customAgentsRef.current.find((a) => a.id === customAgentId)
       : undefined;
     setThinkingValue(custom?.effort || resolveThinking(provider));
-  }, [provider, customAgentId, customAgents]);
+  }, [provider, customAgentId]);
   // Caret offset, tracked so triggers can be detected at the cursor (not just
   // at the start of the text).
   const [caret, setCaret] = useState(0);

--- a/src/components/SettingsScreen/CustomAgents/AgentEditor.tsx
+++ b/src/components/SettingsScreen/CustomAgents/AgentEditor.tsx
@@ -1,0 +1,211 @@
+import { useState } from "react";
+import { PROVIDERS } from "../../../data/providers";
+import { useAppStore } from "../../../store";
+import type { NewCustomAgent } from "../../../storage/customAgents";
+import { Icon } from "../../Icon";
+import { ProviderIcon } from "../../ProviderIcon";
+import { Select } from "../../ui/Select";
+import { SetSeg } from "../primitives";
+import { CA_HUES, INJECTION_HINT, shortFor } from "./shared";
+
+/** Mutable editor form state. `model`/`effort` use "" as the "provider default"
+ *  sentinel so the <select> has a concrete value; converted to null on save. */
+interface Form {
+  name: string;
+  description: string;
+  color: number;
+  base: string;
+  model: string;
+  effort: string;
+  instructions: string;
+}
+
+const EFFORTS = [
+  { value: "", label: "Default" },
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Med" },
+  { value: "high", label: "High" },
+];
+
+export function AgentEditor({
+  initial,
+  isNew,
+  onCancel,
+  onSave,
+}: {
+  initial: NewCustomAgent;
+  isNew: boolean;
+  onCancel: () => void;
+  onSave: (values: NewCustomAgent) => void;
+}) {
+  const modelsByAgent = useAppStore((s) => s.modelsByAgent);
+  const providerFlags = useAppStore((s) => s.providerFlags);
+
+  const [form, setForm] = useState<Form>({
+    name: initial.name,
+    description: initial.description,
+    color: initial.color,
+    base: initial.base,
+    model: initial.model ?? "",
+    effort: initial.effort ?? "",
+    instructions: initial.instructions,
+  });
+
+  const set = (patch: Partial<Form>) => setForm((f) => ({ ...f, ...patch }));
+
+  // Only providers the user hasn't disabled can be a base. Built-in providers
+  // are the building blocks; a custom agent instances one of them.
+  const bases = PROVIDERS.filter((p) => providerFlags[p.id] !== false);
+  const base = PROVIDERS.find((p) => p.id === form.base) ?? bases[0];
+  const models = modelsByAgent[form.base] ?? [];
+
+  // Keep the model valid when the base changes: drop a selection the new base
+  // doesn't offer back to its default.
+  const onBase = (next: string) => {
+    const nextModels = modelsByAgent[next] ?? [];
+    const keep = nextModels.some((m) => m.id === form.model);
+    set({ base: next, model: keep ? form.model : "" });
+  };
+
+  const canSave = form.name.trim().length > 0;
+
+  const submit = () => {
+    if (!canSave) return;
+    onSave({
+      name: form.name.trim(),
+      description: form.description.trim(),
+      color: form.color,
+      base: form.base,
+      model: form.model || null,
+      effort: form.effort || null,
+      instructions: form.instructions,
+    });
+  };
+
+  return (
+    <div className="set-pane">
+      <div className="ca-editor">
+        <button className="ca-ed-back" onClick={onCancel}>
+          <Icon name="chevL" size={13} /> All custom agents
+        </button>
+
+        {/* identity */}
+        <div className="ca-ed-head">
+          <span className="ca-mono ca-ed-mono" style={{ ["--h" as string]: form.color }}>
+            {shortFor(form.name)}
+          </span>
+          <input
+            className="ca-ed-name"
+            placeholder="Name this agent…"
+            value={form.name}
+            autoFocus
+            onChange={(e) => set({ name: e.target.value })}
+          />
+          <div className="ca-hues">
+            {CA_HUES.map((h) => (
+              <button
+                key={h}
+                className={`ca-hue ${h === form.color ? "active" : ""}`}
+                style={{ ["--h" as string]: h }}
+                aria-label={`Color ${h}`}
+                onClick={() => set({ color: h })}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* description */}
+        <div className="set-field ca-field">
+          <label className="set-field-label">
+            Description
+            <span className="ca-field-hint">A short role tagline, shown in the picker</span>
+          </label>
+          <input
+            className="set-text"
+            placeholder="e.g. Plans before coding · writes PLAN.md"
+            value={form.description}
+            onChange={(e) => set({ description: e.target.value })}
+          />
+        </div>
+
+        {/* base + model */}
+        <div className="ca-grid2">
+          <div className="set-field">
+            <label className="set-field-label">
+              Base agent <span className="ca-req">*</span>
+            </label>
+            <Select
+              ariaLabel="Base agent"
+              value={form.base}
+              onChange={onBase}
+              options={bases.map((p) => ({
+                value: p.id,
+                label: p.label,
+                icon: (
+                  <ProviderIcon slug={p.id} short={p.short} hue={p.hue} size={16} />
+                ),
+              }))}
+            />
+          </div>
+          <div className="set-field">
+            <label className="set-field-label">Model</label>
+            <Select
+              ariaLabel="Model"
+              value={form.model}
+              disabled={base?.fixedModel}
+              onChange={(v) => set({ model: v })}
+              options={[
+                { value: "", label: "Default model" },
+                ...models.map((m) => ({ value: m.id, label: m.name })),
+              ]}
+            />
+          </div>
+        </div>
+
+        <div className="ca-inject">
+          <Icon name="zap" size={13} />
+          <span>
+            Instructions injected via <b>{INJECTION_HINT[form.base] ?? "the agent's CLI"}</b>
+          </span>
+        </div>
+
+        {/* reasoning budget */}
+        <div className="set-field ca-field">
+          <label className="set-field-label">
+            Reasoning budget
+            <span className="ca-field-hint">Default thinking depth when this agent runs</span>
+          </label>
+          <SetSeg
+            value={form.effort}
+            options={EFFORTS}
+            onChange={(v) => set({ effort: v })}
+          />
+        </div>
+
+        {/* instructions */}
+        <div className="set-field ca-field">
+          <label className="set-field-label">
+            Instructions
+            <span className="ca-field-hint">The standing system prompt for this agent</span>
+          </label>
+          <textarea
+            className="set-text ca-textarea"
+            value={form.instructions}
+            placeholder="Describe this agent's role, how it should work, and what it should hand off…"
+            onChange={(e) => set({ instructions: e.target.value })}
+          />
+        </div>
+
+        <div className="ca-ed-foot">
+          <span className="ca-grow" />
+          <button className="btn-t ghost" onClick={onCancel}>
+            Cancel
+          </button>
+          <button className="btn-t primary" disabled={!canSave} onClick={submit}>
+            <Icon name="check" size={13} /> {isNew ? "Create agent" : "Save changes"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SettingsScreen/CustomAgents/AgentList.tsx
+++ b/src/components/SettingsScreen/CustomAgents/AgentList.tsx
@@ -1,0 +1,119 @@
+import { PROVIDERS } from "../../../data/providers";
+import { useAppStore } from "../../../store";
+import type { CustomAgent } from "../../../storage/customAgents";
+import { Icon } from "../../Icon";
+import { SetHead } from "../primitives";
+import { Mono } from "./Mono";
+
+export function AgentList({
+  agents,
+  onNew,
+  onEdit,
+  onDuplicate,
+  onDelete,
+}: {
+  agents: CustomAgent[];
+  onNew: () => void;
+  onEdit: (a: CustomAgent) => void;
+  onDuplicate: (a: CustomAgent) => void;
+  onDelete: (a: CustomAgent) => void;
+}) {
+  const modelsByAgent = useAppStore((s) => s.modelsByAgent);
+
+  const modelLabel = (a: CustomAgent): string => {
+    if (!a.model) return "Default model";
+    const found = (modelsByAgent[a.base] ?? []).find((m) => m.id === a.model);
+    return found?.name ?? a.model;
+  };
+
+  return (
+    <div className="set-pane">
+      <SetHead
+        eyebrow="Settings · Custom agents"
+        title="Custom agents"
+        desc="Give a base coding agent a name, a model, and a standing brief. Custom agents show up in the composer next to the built-ins."
+        actions={
+          <button className="btn-t primary" onClick={onNew}>
+            <Icon name="plus" size={13} /> New agent
+          </button>
+        }
+      />
+
+      {agents.length === 0 ? (
+        <button className="ca-empty" onClick={onNew}>
+          <span className="ca-empty-ic">
+            <Icon name="plus" />
+          </span>
+          <span>Create your first custom agent</span>
+        </button>
+      ) : (
+        <div className="ca-list">
+          {agents.map((a) => {
+            const prov = PROVIDERS.find((p) => p.id === a.base);
+            return (
+              <div
+                key={a.id}
+                className="ca-card"
+                role="button"
+                tabIndex={0}
+                onClick={() => onEdit(a)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onEdit(a);
+                  }
+                }}
+              >
+                <Mono name={a.name} hue={a.color} />
+                <div className="ca-id">
+                  <div className="ca-name">
+                    {a.name}
+                    <span className="ca-base">
+                      <span
+                        className="ca-base-dot"
+                        style={{ background: `oklch(0.7 0.1 ${prov?.hue ?? 30})` }}
+                      />
+                      {prov?.label ?? a.base} · {modelLabel(a)}
+                    </span>
+                  </div>
+                  <div className="ca-desc">
+                    {a.description || a.instructions || "No instructions yet."}
+                  </div>
+                </div>
+                <div className="ca-acts" onClick={(e) => e.stopPropagation()}>
+                  <button
+                    className="btn-i sm tip"
+                    data-tip-down
+                    data-tip="Duplicate"
+                    aria-label="Duplicate"
+                    onClick={() => onDuplicate(a)}
+                  >
+                    <Icon name="copy" />
+                  </button>
+                  <button
+                    className="btn-i sm tip"
+                    data-tip-down
+                    data-tip="Edit"
+                    aria-label="Edit"
+                    onClick={() => onEdit(a)}
+                  >
+                    <Icon name="edit" />
+                  </button>
+                  <button
+                    className="btn-i sm tip"
+                    data-tip-down
+                    data-tip="Delete"
+                    aria-label="Delete"
+                    onClick={() => onDelete(a)}
+                  >
+                    <Icon name="trash" />
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SettingsScreen/CustomAgents/AgentList.tsx
+++ b/src/components/SettingsScreen/CustomAgents/AgentList.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { PROVIDERS } from "../../../data/providers";
 import { useAppStore } from "../../../store";
 import type { CustomAgent } from "../../../storage/customAgents";
@@ -19,6 +20,15 @@ export function AgentList({
   onDelete: (a: CustomAgent) => void;
 }) {
   const modelsByAgent = useAppStore((s) => s.modelsByAgent);
+  // Two-click delete confirm (matches the FileContextMenu "Confirm Delete?"
+  // idiom): the first trash click arms the row, the second deletes. Auto-disarms
+  // after a few seconds so a stray click never leaves a row stuck in danger.
+  const [armedDeleteId, setArmedDeleteId] = useState<string | null>(null);
+  useEffect(() => {
+    if (!armedDeleteId) return;
+    const t = setTimeout(() => setArmedDeleteId(null), 3000);
+    return () => clearTimeout(t);
+  }, [armedDeleteId]);
 
   const modelLabel = (a: CustomAgent): string => {
     if (!a.model) return "Default model";
@@ -100,13 +110,20 @@ export function AgentList({
                     <Icon name="edit" />
                   </button>
                   <button
-                    className="btn-i sm tip"
+                    className={`btn-i sm tip ${armedDeleteId === a.id ? "danger" : ""}`}
                     data-tip-down
-                    data-tip="Delete"
-                    aria-label="Delete"
-                    onClick={() => onDelete(a)}
+                    data-tip={armedDeleteId === a.id ? "Click again to delete" : "Delete"}
+                    aria-label={armedDeleteId === a.id ? "Confirm delete" : "Delete"}
+                    onClick={() => {
+                      if (armedDeleteId === a.id) {
+                        onDelete(a);
+                        setArmedDeleteId(null);
+                      } else {
+                        setArmedDeleteId(a.id);
+                      }
+                    }}
                   >
-                    <Icon name="trash" />
+                    <Icon name={armedDeleteId === a.id ? "check" : "trash"} />
                   </button>
                 </div>
               </div>

--- a/src/components/SettingsScreen/CustomAgents/Mono.tsx
+++ b/src/components/SettingsScreen/CustomAgents/Mono.tsx
@@ -1,0 +1,28 @@
+import { shortFor } from "./shared";
+
+/** Colored monogram tile standing in for a custom agent's avatar. The hue is
+ *  the agent's `color`; the glyph is its name's initials. */
+export function Mono({
+  name,
+  hue,
+  size = 38,
+}: {
+  name: string;
+  hue: number;
+  size?: number;
+}) {
+  return (
+    <span
+      className="ca-mono"
+      style={{
+        width: size,
+        height: size,
+        borderRadius: size > 30 ? 9 : 6,
+        fontSize: size > 30 ? 13 : 10.5,
+        ["--h" as string]: hue,
+      }}
+    >
+      {shortFor(name)}
+    </span>
+  );
+}

--- a/src/components/SettingsScreen/CustomAgents/index.tsx
+++ b/src/components/SettingsScreen/CustomAgents/index.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import { DEFAULT_PROVIDER_ID } from "../../../data/providers";
+import { useAppStore } from "../../../store";
+import type { CustomAgent, NewCustomAgent } from "../../../storage/customAgents";
+import { AgentEditor } from "./AgentEditor";
+import { AgentList } from "./AgentList";
+import { CA_HUES } from "./shared";
+
+// Custom Agents settings pane: a list ⇄ editor switch. The list shows every
+// saved preset; the editor creates or edits one. All mutations go through the
+// store slice, which writes to the db and keeps the list in sync.
+
+/** A blank agent for the "New agent" flow. A fresh hue each time keeps new
+ *  agents visually distinct (index by current count, wrapping). */
+function blankAgent(seed: number): NewCustomAgent {
+  return {
+    name: "",
+    description: "",
+    color: CA_HUES[seed % CA_HUES.length],
+    base: DEFAULT_PROVIDER_ID,
+    model: null,
+    effort: null,
+    instructions: "",
+  };
+}
+
+type EditTarget =
+  | { mode: "new"; initial: NewCustomAgent }
+  | { mode: "edit"; id: string; initial: NewCustomAgent };
+
+export function CustomAgentsPane() {
+  const agents = useAppStore((s) => s.customAgents);
+  const createCustomAgent = useAppStore((s) => s.createCustomAgent);
+  const updateCustomAgent = useAppStore((s) => s.updateCustomAgent);
+  const deleteCustomAgent = useAppStore((s) => s.deleteCustomAgent);
+  const duplicateCustomAgent = useAppStore((s) => s.duplicateCustomAgent);
+  const setLastError = useAppStore((s) => s.setLastError);
+
+  const [editing, setEditing] = useState<EditTarget | null>(null);
+
+  const startNew = () => setEditing({ mode: "new", initial: blankAgent(agents.length) });
+  const startEdit = (a: CustomAgent) =>
+    setEditing({ mode: "edit", id: a.id, initial: a });
+
+  const save = async (values: NewCustomAgent) => {
+    try {
+      if (editing?.mode === "edit") {
+        await updateCustomAgent(editing.id, values);
+      } else {
+        await createCustomAgent(values);
+      }
+      setEditing(null);
+    } catch (e) {
+      setLastError(`Failed to save custom agent: ${e}`);
+    }
+  };
+
+  const remove = async (a: CustomAgent) => {
+    try {
+      await deleteCustomAgent(a.id);
+    } catch (e) {
+      setLastError(`Failed to delete custom agent: ${e}`);
+    }
+  };
+
+  const duplicate = async (a: CustomAgent) => {
+    try {
+      await duplicateCustomAgent(a.id);
+    } catch (e) {
+      setLastError(`Failed to duplicate custom agent: ${e}`);
+    }
+  };
+
+  if (editing) {
+    return (
+      <AgentEditor
+        initial={editing.initial}
+        isNew={editing.mode === "new"}
+        onCancel={() => setEditing(null)}
+        onSave={save}
+      />
+    );
+  }
+
+  return (
+    <AgentList
+      agents={agents}
+      onNew={startNew}
+      onEdit={startEdit}
+      onDuplicate={duplicate}
+      onDelete={remove}
+    />
+  );
+}

--- a/src/components/SettingsScreen/CustomAgents/shared.ts
+++ b/src/components/SettingsScreen/CustomAgents/shared.ts
@@ -1,0 +1,29 @@
+// Shared helpers + constants for the Custom Agents settings pane.
+
+/** Preset hues for the monogram tile (evenly spread around the wheel). */
+export const CA_HUES = [265, 150, 25, 215, 320, 95, 175, 50] as const;
+
+/** Two-letter monogram derived from an agent's name (initials), falling back to
+ *  a neutral dot when unnamed. Mirrors the prototype's `shortFor`. */
+export function shortFor(name: string): string {
+  const initials = (name || "")
+    .trim()
+    .split(/\s+/)
+    .map((w) => w[0] ?? "")
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+  return initials || "·";
+}
+
+/** How each base provider receives a custom agent's instructions — surfaced as
+ *  a hint in the editor so the UI is honest about the per-adapter delivery
+ *  (mirrors `instructions.rs`). */
+export const INJECTION_HINT: Record<string, string> = {
+  claude: "--append-system-prompt",
+  codex: "developer instructions (config)",
+  cursor: "prepended to the first message",
+  opencode: "prepended to the first message",
+  antigravity: "prepended to the first message",
+  pi: "--append-system-prompt",
+};

--- a/src/components/SettingsScreen/index.tsx
+++ b/src/components/SettingsScreen/index.tsx
@@ -6,6 +6,7 @@ import pkg from "../../../package.json";
 import { GeneralPane } from "./GeneralPane";
 import { AccountPane } from "./AccountPane";
 import { ProvidersPane } from "./ProvidersPane";
+import { CustomAgentsPane } from "./CustomAgents";
 import { ExperimentalPane } from "./ExperimentalPane";
 
 // Lazily loaded behind `import.meta.env.DEV`. In production the ternary's dead
@@ -21,6 +22,7 @@ const NAV: { id: SettingsSection; label: string; icon: IconName }[] = [
   { id: "account", label: "Account", icon: "user" },
   { id: "general", label: "General", icon: "settings" },
   { id: "providers", label: "Providers", icon: "cube" },
+  { id: "agents", label: "Custom agents", icon: "bot" },
   { id: "experimental", label: "Experimental", icon: "flask" },
   // Dev-only: omitted entirely from production builds.
   ...(DeveloperPane
@@ -65,6 +67,7 @@ export function SettingsScreen() {
         <div className="set-content">
           {section === "account" && <AccountPane />}
           {section === "providers" && <ProvidersPane />}
+          {section === "agents" && <CustomAgentsPane />}
           {section === "experimental" && <ExperimentalPane />}
           {section === "developer" && DeveloperPane && (
             <Suspense fallback={null}>

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -6,6 +6,7 @@ import { useAppStore } from "../../store";
 import { providerChip, providerLabel } from "../../data/providers";
 import { Icon } from "../Icon";
 import { ProviderIcon } from "../ProviderIcon";
+import { Mono } from "../SettingsScreen/CustomAgents/Mono";
 import { formatAge } from "../../util/format";
 import { useMinuteClock } from "../../util/hooks";
 import { AgentStatsPopover, type AgentStats } from "./AgentStatsPopover";
@@ -53,6 +54,14 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
   const unseen = useAppStore((s) => s.unseenResults[agent.id] ?? false);
   const stop = useAppStore((s) => s.stop);
   const archive = useAppStore((s) => s.archive);
+  // The custom agent this session was spawned from, if any (and still present).
+  // Drives the row's identity chip; falls back to the base provider when the
+  // custom agent has since been deleted.
+  const customAgent = useAppStore((s) =>
+    agent.custom_agent_id
+      ? s.customAgents.find((a) => a.id === agent.custom_agent_id)
+      : undefined,
+  );
   const now = useMinuteClock();
   const [statsOpen, setStatsOpen] = useState(false);
 
@@ -119,10 +128,18 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
         <span className={`ag-name ${working ? "shimmer" : ""}`}>{agent.name}</span>
         <span
           className="ag-prov-chip tip"
-          data-tip={providerLabel(agent.provider)}
+          data-tip={
+            customAgent
+              ? `${customAgent.name} · ${providerLabel(agent.provider)}`
+              : providerLabel(agent.provider)
+          }
           data-tip-down=""
         >
-          <ProviderIcon slug={agent.provider} {...providerChip(agent.provider)} size={14} />
+          {customAgent ? (
+            <Mono name={customAgent.name} hue={customAgent.color} size={14} />
+          ) : (
+            <ProviderIcon slug={agent.provider} {...providerChip(agent.provider)} size={14} />
+          )}
         </span>
         <span className="ag-slot">
           <span className="ag-meta">

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -28,6 +28,13 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
   const stop = useAppStore((s) => s.stop);
   const loadHistoryTranscript = useAppStore((s) => s.loadHistoryTranscript);
   const usage = useAppStore((s) => s.usage[agent.id]);
+  // The custom agent this session was spawned from (if any, and still present),
+  // so the chat surfaces the agent's name rather than its base provider.
+  const customAgent = useAppStore((s) =>
+    agent.custom_agent_id
+      ? s.customAgents.find((a) => a.id === agent.custom_agent_id)
+      : undefined,
+  );
   const composerSeed = useAppStore((s) => s.composerSeeds[agent.id]);
   const consumeComposerSeed = useAppStore((s) => s.consumeComposerSeed);
   // Stable identity: the Composer's seed effect lists this in its deps, so an
@@ -168,7 +175,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
                 <i /><i /><i />
               </span>
               <span>
-                {busyLabel ?? `${providerLabel(agent.provider)} is thinking`}
+                {busyLabel ?? `${customAgent?.name ?? providerLabel(agent.provider)} is thinking`}
               </span>
             </div>
           )}
@@ -181,6 +188,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
           usage={usage}
           defaultProvider={agent.provider}
           defaultModel={agent.model ?? undefined}
+          defaultCustomAgentId={agent.custom_agent_id ?? undefined}
           initialThinking={agent.effort ?? undefined}
           disabled={!canSend}
           placeholder={

--- a/src/components/Workspace/EmptyWorkspace.tsx
+++ b/src/components/Workspace/EmptyWorkspace.tsx
@@ -81,16 +81,17 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
             draftKey={draft.id}
             defaultProvider={draft.provider}
             defaultModel={draft.model}
+            defaultCustomAgentId={draft.customAgentId}
             baseBranch={draft.base}
             repoPath={draft.repoPath}
             onChangeBase={(branch) => updateDraft(draft.id, { base: branch })}
-            onChangeSelection={(provider, model) => {
-              updateDraft(draft.id, { provider, model });
-              setNewDraftSelection(provider, model);
+            onChangeSelection={(provider, model, customAgentId) => {
+              updateDraft(draft.id, { provider, model, customAgentId });
+              setNewDraftSelection(provider, model, customAgentId);
             }}
             placeholder="Describe the task for the agent. ↵ to spawn."
-            onSend={({ text, provider, model, attachments, thinking }) =>
-              spawnFromDraft(draft.id, text, provider, model, attachments, thinking)
+            onSend={({ text, provider, model, attachments, thinking, customAgentId }) =>
+              spawnFromDraft(draft.id, text, provider, model, attachments, thinking, customAgentId)
             }
           />
           <div className="empty-meta">

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,0 +1,82 @@
+import { useState, type ReactNode } from "react";
+import { Icon } from "../Icon";
+import { Scrim } from "./Scrim";
+
+export interface SelectOption<T extends string> {
+  value: T;
+  label: string;
+  /** Optional secondary text shown muted to the right of the label. */
+  hint?: string;
+  /** Optional leading visual (e.g. a provider icon) shown before the label,
+   *  in both the trigger and the option row. */
+  icon?: ReactNode;
+}
+
+interface Props<T extends string> {
+  value: T;
+  options: SelectOption<T>[];
+  onChange: (value: T) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  ariaLabel?: string;
+}
+
+/** A styled single-select dropdown — a drop-in replacement for a native
+ *  `<select>` that matches the app's `.dd` popover look (built on `Scrim`).
+ *  Generic over the option value type so callers keep their string unions. */
+export function Select<T extends string>({
+  value,
+  options,
+  onChange,
+  disabled = false,
+  placeholder = "Select…",
+  ariaLabel,
+}: Props<T>) {
+  const [open, setOpen] = useState(false);
+  const selected = options.find((o) => o.value === value);
+
+  return (
+    <div className="ui-select">
+      <button
+        type="button"
+        className={`ui-select-trigger ${open ? "open" : ""}`}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => !disabled && setOpen((v) => !v)}
+      >
+        {selected?.icon && <span className="ui-select-icon">{selected.icon}</span>}
+        <span className={`ui-select-value ${selected ? "" : "is-placeholder"}`}>
+          {selected?.label ?? placeholder}
+        </span>
+        <Icon name="chevD" size={11} />
+      </button>
+
+      {open && (
+        <>
+          <Scrim onClose={() => setOpen(false)} />
+          <div className="dd ui-select-dd" role="listbox">
+            {options.map((o) => (
+              <div
+                key={o.value}
+                role="option"
+                aria-selected={o.value === value}
+                className={`dd-item ${o.value === value ? "active" : ""}`}
+                onClick={() => {
+                  onChange(o.value);
+                  setOpen(false);
+                }}
+              >
+                {o.icon && <span className="ui-select-icon">{o.icon}</span>}
+                <span className="di-l">{o.label}</span>
+                {o.hint && <span className="di-m">{o.hint}</span>}
+                {o.value === value && <Icon name="check" size={12} />}
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { Icon } from "../Icon";
 import { Scrim } from "./Scrim";
 
@@ -23,7 +23,11 @@ interface Props<T extends string> {
 
 /** A styled single-select dropdown — a drop-in replacement for a native
  *  `<select>` that matches the app's `.dd` popover look (built on `Scrim`).
- *  Generic over the option value type so callers keep their string unions. */
+ *  Generic over the option value type so callers keep their string unions.
+ *
+ *  Keyboard: options are real `<button>`s (focusable, Enter/Space select);
+ *  ArrowUp/Down move between them, Home/End jump to the ends, and Escape
+ *  closes (handled by `Scrim`). The selected option is focused on open. */
 export function Select<T extends string>({
   value,
   options,
@@ -34,6 +38,47 @@ export function Select<T extends string>({
 }: Props<T>) {
   const [open, setOpen] = useState(false);
   const selected = options.find((o) => o.value === value);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // On open, move focus to the selected option (or the first) so arrow keys
+  // and Enter work immediately without a Tab.
+  useEffect(() => {
+    if (!open) return;
+    const list = listRef.current;
+    if (!list) return;
+    const items = list.querySelectorAll<HTMLButtonElement>("[role='option']");
+    const activeIdx = Math.max(
+      0,
+      options.findIndex((o) => o.value === value),
+    );
+    items[activeIdx]?.focus();
+  }, [open, options, value]);
+
+  function onListKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    const items = Array.from(
+      listRef.current?.querySelectorAll<HTMLButtonElement>("[role='option']") ?? [],
+    );
+    if (items.length === 0) return;
+    const current = items.indexOf(document.activeElement as HTMLButtonElement);
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      items[(current + 1) % items.length]?.focus();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      items[(current - 1 + items.length) % items.length]?.focus();
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      items[0]?.focus();
+    } else if (e.key === "End") {
+      e.preventDefault();
+      items[items.length - 1]?.focus();
+    }
+  }
+
+  function pick(v: T) {
+    onChange(v);
+    setOpen(false);
+  }
 
   return (
     <div className="ui-select">
@@ -56,23 +101,26 @@ export function Select<T extends string>({
       {open && (
         <>
           <Scrim onClose={() => setOpen(false)} />
-          <div className="dd ui-select-dd" role="listbox">
+          <div
+            ref={listRef}
+            className="dd ui-select-dd"
+            role="listbox"
+            onKeyDown={onListKeyDown}
+          >
             {options.map((o) => (
-              <div
+              <button
                 key={o.value}
+                type="button"
                 role="option"
                 aria-selected={o.value === value}
                 className={`dd-item ${o.value === value ? "active" : ""}`}
-                onClick={() => {
-                  onChange(o.value);
-                  setOpen(false);
-                }}
+                onClick={() => pick(o.value)}
               >
                 {o.icon && <span className="ui-select-icon">{o.icon}</span>}
                 <span className="di-l">{o.label}</span>
                 {o.hint && <span className="di-m">{o.hint}</span>}
                 {o.value === value && <Icon name="check" size={12} />}
-              </div>
+              </button>
             ))}
           </div>
         </>

--- a/src/storage/customAgents.test.ts
+++ b/src/storage/customAgents.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the generic db layer so we can assert the exact row shape the storage
+// module hands to SQLite, without a real Tauri backend.
+const dbInsert = vi.fn(async (..._a: unknown[]) => "ok");
+const dbUpdate = vi.fn(async (..._a: unknown[]) => 1);
+const dbDelete = vi.fn(async (..._a: unknown[]) => 1);
+const dbSelect = vi.fn(async (..._a: unknown[]) => [] as unknown[]);
+
+vi.mock("./db", () => ({
+  dbInsert: (...a: unknown[]) => dbInsert(...a),
+  dbUpdate: (...a: unknown[]) => dbUpdate(...a),
+  dbDelete: (...a: unknown[]) => dbDelete(...a),
+  dbSelect: (...a: unknown[]) => dbSelect(...a),
+}));
+
+import {
+  createCustomAgent,
+  deleteCustomAgent,
+  listCustomAgents,
+  updateCustomAgent,
+  type CustomAgent,
+} from "./customAgents";
+
+const NEW = {
+  name: "Reviewer",
+  description: "Critical reviewer",
+  color: 25,
+  base: "codex",
+  model: "gpt-5.2-codex",
+  effort: "high",
+  instructions: "Be terse.",
+};
+
+describe("customAgents storage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-24T00:00:00Z"));
+  });
+
+  it("stamps id + timestamps on create and inserts the full row", async () => {
+    const agent = await createCustomAgent(NEW);
+    expect(agent.id).toMatch(/^ca-/);
+    expect(agent.created_at).toBe(agent.updated_at);
+    expect(agent.created_at).toBe(Date.now());
+
+    const [table, row] = dbInsert.mock.calls[0] as unknown as [string, CustomAgent];
+    expect(table).toBe("custom_agents");
+    expect(row).toMatchObject({ ...NEW, id: agent.id });
+  });
+
+  it("bumps updated_at and never writes the id/created_at columns on update", async () => {
+    const current: CustomAgent = {
+      ...NEW,
+      id: "ca-x",
+      created_at: 1000,
+      updated_at: 1000,
+    };
+    vi.setSystemTime(new Date("2026-06-25T00:00:00Z"));
+    const next = await updateCustomAgent(current, { name: "Renamed" });
+
+    expect(next.name).toBe("Renamed");
+    expect(next.created_at).toBe(1000);
+    expect(next.updated_at).toBe(Date.now());
+
+    const [table, where, data] = dbUpdate.mock.calls[0] as unknown as [
+      string,
+      Record<string, unknown>,
+      Record<string, unknown>,
+    ];
+    expect(table).toBe("custom_agents");
+    expect(where).toEqual({ id: "ca-x" });
+    // The primary key and creation time must not be in the UPDATE set.
+    expect(data).not.toHaveProperty("id");
+    expect(data).not.toHaveProperty("created_at");
+    expect(data.name).toBe("Renamed");
+  });
+
+  it("lists newest-edited first", async () => {
+    await listCustomAgents();
+    expect(dbSelect).toHaveBeenCalledWith("custom_agents", {
+      orderBy: "updated_at",
+      orderDirection: "desc",
+    });
+  });
+
+  it("deletes by id", async () => {
+    await deleteCustomAgent("ca-x");
+    expect(dbDelete).toHaveBeenCalledWith("custom_agents", { id: "ca-x" });
+  });
+});

--- a/src/storage/customAgents.ts
+++ b/src/storage/customAgents.ts
@@ -1,0 +1,82 @@
+import { dbDelete, dbInsert, dbSelect, dbUpdate } from "./db";
+
+// Custom agents: user-defined presets that wrap a base provider (claude/codex/…)
+// with a name, color, model, reasoning effort, and a standing instruction brief.
+// They show up in the composer next to the built-ins; spawning one launches its
+// base provider with its model/effort and injects its instructions for that
+// session. Persisted in the `custom_agents` table via the generic db layer.
+
+export interface CustomAgent {
+  id: string;
+  name: string;
+  /** Short role tagline shown in the list and composer picker. */
+  description: string;
+  /** Monogram-tile hue (0–360). */
+  color: number;
+  /** Base provider id this agent instances. */
+  base: string;
+  /** Model id passed to the base CLI, or null for its default. */
+  model: string | null;
+  /** Reasoning budget (low/medium/high), or null for the CLI default. */
+  effort: string | null;
+  /** The standing system-prompt-level brief injected when this agent runs. */
+  instructions: string;
+  created_at: number;
+  updated_at: number;
+}
+
+/** A new custom agent before it's persisted: everything except the db-managed
+ *  id and timestamps. */
+export type NewCustomAgent = Omit<CustomAgent, "id" | "created_at" | "updated_at">;
+
+const TABLE = "custom_agents";
+
+/** Generate a stable, collision-resistant id for a new custom agent. */
+function newId(): string {
+  return `ca-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/** All custom agents, newest-edited first. */
+export async function listCustomAgents(): Promise<CustomAgent[]> {
+  return dbSelect<CustomAgent>(TABLE, {
+    orderBy: "updated_at",
+    orderDirection: "desc",
+  });
+}
+
+/** Insert a new custom agent and return the persisted row. */
+export async function createCustomAgent(
+  agent: NewCustomAgent,
+): Promise<CustomAgent> {
+  const now = Date.now();
+  const row: CustomAgent = {
+    ...agent,
+    id: newId(),
+    created_at: now,
+    updated_at: now,
+  };
+  await dbInsert(TABLE, row as unknown as Record<string, unknown>);
+  return row;
+}
+
+/** Patch an existing custom agent (bumping `updated_at`) and return the merged
+ *  row so callers can update local state without a re-read. */
+export async function updateCustomAgent(
+  current: CustomAgent,
+  patch: Partial<NewCustomAgent>,
+): Promise<CustomAgent> {
+  const next: CustomAgent = { ...current, ...patch, updated_at: Date.now() };
+  const { id, created_at, ...writable } = next;
+  void id;
+  void created_at;
+  await dbUpdate(
+    TABLE,
+    { id: current.id },
+    writable as unknown as Record<string, unknown>,
+  );
+  return next;
+}
+
+export async function deleteCustomAgent(id: string): Promise<void> {
+  await dbDelete(TABLE, { id });
+}

--- a/src/storage/preferences.new-draft-selection.test.ts
+++ b/src/storage/preferences.new-draft-selection.test.ts
@@ -20,4 +20,18 @@ describe("parseNewDraftSelection", () => {
       parseNewDraftSelection(JSON.stringify({ provider: "cursor", model: "   " })),
     ).toEqual({ provider: "cursor" });
   });
+
+  it("reads a persisted custom agent id", () => {
+    expect(
+      parseNewDraftSelection(
+        JSON.stringify({ provider: "claude", model: "opus", customAgentId: "ca-1" }),
+      ),
+    ).toEqual({ provider: "claude", model: "opus", customAgentId: "ca-1" });
+  });
+
+  it("drops a blank custom agent id", () => {
+    expect(
+      parseNewDraftSelection(JSON.stringify({ provider: "claude", customAgentId: "  " })),
+    ).toEqual({ provider: "claude" });
+  });
 });

--- a/src/storage/preferences.ts
+++ b/src/storage/preferences.ts
@@ -14,6 +14,7 @@ export type SettingsSection =
   | "general"
   | "account"
   | "providers"
+  | "agents"
   | "experimental"
   | "developer";
 
@@ -94,6 +95,9 @@ export function parseProviderFlags(
 export interface NewDraftSelection {
   provider: string;
   model?: string;
+  /** The custom agent the new-draft picker last selected, if any. Resolved
+   *  against the live `custom_agents` list on use — a stale id is ignored. */
+  customAgentId?: string;
 }
 
 export const DEFAULT_NEW_DRAFT_SELECTION: NewDraftSelection = {
@@ -114,7 +118,15 @@ export function parseNewDraftSelection(
       typeof saved.model === "string" && saved.model.trim()
         ? saved.model
         : undefined;
-    return model ? { provider, model } : { provider };
+    const customAgentId =
+      typeof saved.customAgentId === "string" && saved.customAgentId.trim()
+        ? saved.customAgentId
+        : undefined;
+    return {
+      provider,
+      ...(model ? { model } : {}),
+      ...(customAgentId ? { customAgentId } : {}),
+    };
   } catch {
     return DEFAULT_NEW_DRAFT_SELECTION;
   }

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -58,8 +58,11 @@ export const createAppSlice: SliceCreator<AppSlice> = (set, get) => ({
     // Load persisted settings from DB.
     try {
       const s = await getAllSettings();
-      const { provider: newDraftProvider, model: newDraftModel } =
-        parseNewDraftSelection(s.newDraftSelection);
+      const {
+        provider: newDraftProvider,
+        model: newDraftModel,
+        customAgentId: newDraftCustomAgentId,
+      } = parseNewDraftSelection(s.newDraftSelection);
       set({
         theme: (s.theme as ThemeMode) || "dark",
         codeTheme: s.codeTheme || "quorum",
@@ -70,6 +73,7 @@ export const createAppSlice: SliceCreator<AppSlice> = (set, get) => ({
         providerPathOverrides: parseProviderPathOverrides(s),
         newDraftProvider,
         newDraftModel,
+        newDraftCustomAgentId,
         viewMode: (s.viewMode as WorkspaceView) || "custom",
         gitCommitAction: isCommitAction(s.gitCommitAction) ? s.gitCommitAction : "agent-commit-pr",
         onboardingComplete: s.onboardingComplete === "true",
@@ -107,6 +111,10 @@ export const createAppSlice: SliceCreator<AppSlice> = (set, get) => ({
     // Rebuild the model catalog if stale (async, non-blocking). State is seeded
     // from the localStorage cache, so lookups work immediately regardless.
     void get().refreshModelCatalog();
+
+    // Load custom agent presets (async, non-blocking). Empty until loaded — the
+    // composer picker and settings pane just show the built-ins meanwhile.
+    void get().loadCustomAgents();
 
     await onAgentOutput((e) => {
       pushAgentOutput(e.agent_id, new Uint8Array(e.bytes));

--- a/src/store/customAgents.ts
+++ b/src/store/customAgents.ts
@@ -1,0 +1,62 @@
+import {
+  createCustomAgent as dbCreate,
+  deleteCustomAgent as dbDelete,
+  listCustomAgents,
+  updateCustomAgent as dbUpdate,
+  type CustomAgent,
+  type NewCustomAgent,
+} from "../storage/customAgents";
+import type { CustomAgentsSlice, SliceCreator } from "./types";
+
+// Store slice for custom agents. The list mirrors the `custom_agents` table and
+// is loaded once on init; every mutation writes through to the db and updates
+// the in-memory list so the settings pane and composer picker stay in sync
+// without re-reading.
+
+export const createCustomAgentsSlice: SliceCreator<CustomAgentsSlice> = (
+  set,
+  get,
+) => ({
+  customAgents: [],
+
+  loadCustomAgents: async () => {
+    const agents = await listCustomAgents();
+    set({ customAgents: agents });
+  },
+
+  createCustomAgent: async (agent) => {
+    const created = await dbCreate(agent);
+    set((s) => ({ customAgents: [created, ...s.customAgents] }));
+    return created;
+  },
+
+  updateCustomAgent: async (id, patch) => {
+    const current = get().customAgents.find((a) => a.id === id);
+    if (!current) return null;
+    const next = await dbUpdate(current, patch);
+    // Re-sort by updated_at desc so the just-edited agent floats to the top,
+    // matching the load order.
+    set((s) => ({
+      customAgents: [next, ...s.customAgents.filter((a) => a.id !== id)],
+    }));
+    return next;
+  },
+
+  deleteCustomAgent: async (id) => {
+    await dbDelete(id);
+    set((s) => ({ customAgents: s.customAgents.filter((a) => a.id !== id) }));
+  },
+
+  duplicateCustomAgent: async (id) => {
+    const src = get().customAgents.find((a) => a.id === id);
+    if (!src) return null;
+    const { id: _id, created_at, updated_at, ...rest } = src;
+    void _id;
+    void created_at;
+    void updated_at;
+    const copy: NewCustomAgent = { ...rest, name: `${src.name} copy` };
+    return get().createCustomAgent(copy);
+  },
+});
+
+export type { CustomAgent };

--- a/src/store/drafts.ts
+++ b/src/store/drafts.ts
@@ -19,6 +19,10 @@ export interface DraftAgent {
   provider: string;
   /** Optional model id to pass to the chosen provider CLI at spawn. */
   model?: string;
+  /** The custom agent this draft will spawn, if the picker selected one. Its
+   *  provider/model are mirrored into `provider`/`model`; this id additionally
+   *  carries its instructions (resolved at spawn) and sidebar identity. */
+  customAgentId?: string;
   /** Base branch to fork from. */
   base: string;
 }
@@ -50,19 +54,26 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
   activeDraftId: null,
   newDraftProvider: DEFAULT_PROVIDER_ID,
   newDraftModel: undefined,
+  newDraftCustomAgentId: undefined,
 
   // ── drafts ─────────────────────────────────────────────────────────────────
   createDraft: async (repoPath) => {
-    const { workspace, drafts, newDraftProvider, newDraftModel, modelsByAgent } = get();
+    const { workspace, drafts, newDraftProvider, newDraftModel, newDraftCustomAgentId, modelsByAgent } = get();
     const used = [...usedNames(workspace, drafts)];
     const name = await api.allocateDraftName(used);
     const selection = normalizeDraftSelection(newDraftProvider, newDraftModel, modelsByAgent);
+    // Carry the sticky custom-agent pick onto the new draft, but only if it
+    // still exists (it may have been deleted since it was last persisted).
+    const customAgentId = get().customAgents.some((a) => a.id === newDraftCustomAgentId)
+      ? newDraftCustomAgentId
+      : undefined;
     const draft: DraftAgent = {
       id: `draft-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
       repoPath,
       name,
       provider: selection.provider,
       model: selection.model,
+      customAgentId,
       base: "main",
     };
     set((s) => ({
@@ -93,13 +104,21 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
       selectedAgentId: null,
     }),
 
-  setNewDraftSelection: (provider, model) => {
+  setNewDraftSelection: (provider, model, customAgentId) => {
     const selection = normalizeDraftSelection(provider, model, get().modelsByAgent);
+    // Only remember a custom-agent pick that resolves to a live agent.
+    const resolvedCustomAgentId = get().customAgents.some((a) => a.id === customAgentId)
+      ? customAgentId
+      : undefined;
     set({
       newDraftProvider: selection.provider,
       newDraftModel: selection.model,
+      newDraftCustomAgentId: resolvedCustomAgentId,
     });
-    void setSetting(NEW_DRAFT_SELECTION_SETTING, selection);
+    void setSetting(NEW_DRAFT_SELECTION_SETTING, {
+      ...selection,
+      ...(resolvedCustomAgentId ? { customAgentId: resolvedCustomAgentId } : {}),
+    });
   },
 
   rerollDraftName: async (id) => {
@@ -112,13 +131,21 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
     }));
   },
 
-  spawnFromDraft: async (id, text, provider, model, attachments = [], thinking?) => {
+  spawnFromDraft: async (id, text, provider, model, attachments = [], thinking?, customAgentId?) => {
     const draft = get().drafts.find((d) => d.id === id);
     if (!draft) return;
     set({ busy: true, lastError: null });
     const turnId = crypto.randomUUID();
     try {
       const view = get().viewMode;
+      // Resolve the selected custom agent's standing brief. Snapshotted at spawn
+      // (passed by value, not by id) so the running agent is unaffected if the
+      // custom agent is later edited or deleted. Empty/blank instructions inject
+      // nothing — the backend treats a blank brief as a no-op.
+      const custom = customAgentId
+        ? get().customAgents.find((a) => a.id === customAgentId)
+        : undefined;
+      const instructions = custom?.instructions?.trim() ? custom.instructions : undefined;
       // `thinking` carries the composer's effort selection. For claude it's a
       // session-level spawn flag (--effort), applied here; per-turn agents
       // ignore it at spawn and take it per-turn via sendUserMessage below.
@@ -129,6 +156,8 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
         draft.name,
         thinking,
         model,
+        instructions,
+        custom?.id,
       );
       const fresh = await api.getWorkspace();
       set((state) => {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -10,6 +10,7 @@ import { createUiSlice } from "./ui";
 import { createAccountSlice } from "./account";
 import { createAppearanceSlice } from "./appearance";
 import { createProvidersSlice } from "./providers";
+import { createCustomAgentsSlice } from "./customAgents";
 import type { AgentRecord } from "../api"; // for EMPTY_AGENTS
 
 export const EMPTY_AGENTS: readonly AgentRecord[] = Object.freeze([]);
@@ -25,6 +26,7 @@ export const useAppStore = create<AppState>()((...a) => ({
   ...createAccountSlice(...a),
   ...createAppearanceSlice(...a),
   ...createProvidersSlice(...a),
+  ...createCustomAgentsSlice(...a),
 }));
 
 export type { AppState } from "./types";

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -25,6 +25,7 @@ import type {
   FeatureFlags,
 } from "../storage/preferences";
 import type { AccountProfile } from "../storage/accounts";
+import type { CustomAgent, NewCustomAgent } from "../storage/customAgents";
 import type { DraftAgent } from "./drafts";
 
 export interface AppSlice {
@@ -333,13 +334,19 @@ export interface DraftsSlice {
   activeDraftId: string | null;
   newDraftProvider: string;
   newDraftModel?: string;
+  /** Sticky custom-agent selection for the next new draft (persisted). */
+  newDraftCustomAgentId?: string;
 
   // drafts
   createDraft: (repoPath: string) => Promise<void>;
   updateDraft: (id: string, patch: Partial<DraftAgent>) => void;
   removeDraft: (id: string) => void;
   selectDraft: (id: string | null) => void;
-  setNewDraftSelection: (provider: string, model?: string) => void;
+  setNewDraftSelection: (
+    provider: string,
+    model?: string,
+    customAgentId?: string,
+  ) => void;
   rerollDraftName: (id: string) => Promise<void>;
   /** Spawn the real agent for a draft and dispatch the first message. */
   spawnFromDraft: (
@@ -349,7 +356,27 @@ export interface DraftsSlice {
     model?: string,
     attachments?: string[],
     thinking?: string,
+    customAgentId?: string,
   ) => Promise<void>;
+}
+
+export interface CustomAgentsSlice {
+  /** User-defined agent presets, mirrored from the `custom_agents` table and
+   *  ordered newest-edited first. Loaded once on init. */
+  customAgents: CustomAgent[];
+
+  loadCustomAgents: () => Promise<void>;
+  createCustomAgent: (agent: NewCustomAgent) => Promise<CustomAgent>;
+  /** Patch an existing custom agent; resolves to the merged row, or null if the
+   *  id is unknown. */
+  updateCustomAgent: (
+    id: string,
+    patch: Partial<NewCustomAgent>,
+  ) => Promise<CustomAgent | null>;
+  deleteCustomAgent: (id: string) => Promise<void>;
+  /** Clone a custom agent ("… copy"); resolves to the new row, or null if the
+   *  source id is unknown. */
+  duplicateCustomAgent: (id: string) => Promise<CustomAgent | null>;
 }
 
 export type AppState = AppSlice &
@@ -361,6 +388,7 @@ export type AppState = AppSlice &
   UiSlice &
   AccountSlice &
   AppearanceSlice &
-  ProvidersSlice;
+  ProvidersSlice &
+  CustomAgentsSlice;
 
 export type SliceCreator<T> = StateCreator<AppState, [], [], T>;


### PR DESCRIPTION
Adds user-defined **custom agents** — personal presets that wrap a base provider with a name, color, model, reasoning budget, and a standing instruction brief — managed under **Settings → Custom agents** and persisted to SQLite (new `custom_agents` table + `sessions.instructions`/`custom_agent_id` columns). They appear in the composer's agent/model picker next to the built-ins; spawning one launches its base provider with that model/effort and injects its instructions for the session, snapshotted on the session so editing or deleting the agent never changes a running one (delivered through the existing per-provider injection path in `instructions.rs`, covering all six agents). The spawned agent surfaces the custom agent's name/color in the sidebar and chat, and the new-agent form uses a reusable custom `Select` dropdown (with provider icons) in place of native selects. Backend and frontend test suites and the production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)