### PR TITLE
Restructure composer agent picker into flat list + model side panel

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1379,7 +1379,10 @@ button { cursor: default; }
   top: 0;
   bottom: 0;
   left: calc(100% - 16px);
-  width: 252px;
+  /* Cap against the viewport so the panel can't run off-screen on a narrow
+   *  window. 280px = the main card's 296px width minus the 16px tuck-under;
+   *  44px leaves a small right margin. */
+  width: min(252px, calc(100vw - 280px - 44px));
   z-index: 1;
   animation: modelSideFly .28s cubic-bezier(.22, 1, .36, 1);
 }

--- a/src/app.css
+++ b/src/app.css
@@ -1274,182 +1274,251 @@ button { cursor: default; }
   color: var(--fg-3);
 }
 
-.model-dd {
-  width: min(680px, calc(100vw - 48px));
-  padding: 0;
-  overflow: hidden;
+/* Transparent positioning wrapper. Holds the main card (above) and the model
+ *  side panel (below it) so the panel slides out from underneath the dropdown. */
+.model-dd-wrap {
+  position: absolute;
+  z-index: 200;
+  /* The side panel is absolute, so it must not be clipped by the wrapper. */
+  overflow: visible;
 }
-.model-dd-head {
-  display: grid;
-  grid-template-columns: 190px minmax(0, 1fr);
-  gap: 0;
-  padding: 9px 10px 8px;
-  border-bottom: 1px solid var(--bd-soft);
+.model-dd-main {
+  position: relative;
+  z-index: 2;
+  width: min(296px, calc(100vw - 28px));
+  padding: 5px;
+  background: var(--bg-2);
+  border: 1px solid var(--bd);
+  border-radius: 13px;
+  box-shadow:
+    0 1px 0 rgba(255,255,255,.04) inset,
+    0 18px 48px -12px rgba(0,0,0,.55),
+    0 4px 12px rgba(0,0,0,.3);
+  max-height: calc(100vh - 96px);
+  overflow-y: auto;
+  transform-origin: bottom left;
+  animation: modelDdIn .17s var(--ease);
+}
+@keyframes modelDdIn {
+  from { opacity: 0; transform: translateY(7px) scale(.975); }
+  to   { opacity: 1; transform: none; }
+}
+/* Section header with trailing rule, mirroring the prototype's dividers. */
+.model-sect {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 9px 10px 5px;
   color: var(--fg-3);
   font-size: 10px;
-  font-weight: 650;
-  letter-spacing: .08em;
+  font-weight: 600;
+  letter-spacing: .07em;
   text-transform: uppercase;
 }
-.model-dd-grid {
-  display: grid;
-  grid-template-columns: 190px minmax(0, 1fr);
-  height: min(390px, calc(100vh - 180px));
-  min-height: 270px;
+.model-sect-line {
+  flex: 1;
+  height: 1px;
+  background: var(--bd-soft);
+}
+/* Coding agent row: name, version, chevron. Hovering opens the side panel. */
+.model-agent-row {
+  width: 100%;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 9px;
+  border-radius: 9px;
+  color: var(--fg-1);
+  text-align: left;
+  transition: background .12s var(--ease);
+}
+.model-agent-row:not(:disabled):hover,
+.model-agent-row.hot {
+  background: var(--hover);
+}
+.model-agent-row.active {
+  background: var(--selected);
+}
+.model-agent-row:disabled {
+  opacity: .42;
+}
+.model-agent-name {
+  flex: 1;
+  min-width: 0;
   overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--fg-0);
 }
-.model-agent-list {
+.model-agent-ver {
+  flex-shrink: 0;
+  color: var(--fg-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+.model-agent-row > svg:last-child {
+  flex-shrink: 0;
+  color: var(--fg-3);
+  opacity: .65;
+  transition: transform .16s var(--ease), color .16s, opacity .16s;
+}
+.model-agent-row:not(:disabled):hover > svg:last-child,
+.model-agent-row.hot > svg:last-child {
+  color: var(--accent);
+  opacity: 1;
+  transform: translateX(2px);
+}
+/* Model side panel — full height of the main card, tucked ~16px under its right
+ *  edge (z-index below the main, no left border/radius) so it reads as sliding
+ *  out from underneath rather than floating beside it. */
+.model-side-fly {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: calc(100% - 16px);
+  width: 252px;
+  z-index: 1;
+  animation: modelSideFly .28s cubic-bezier(.22, 1, .36, 1);
+}
+@keyframes modelSideFly {
+  from { transform: translateX(-30px); opacity: 0; }
+  to   { transform: none; opacity: 1; }
+}
+.model-side-fly-card {
+  height: 100%;
+  /* Left padding clears the tucked-under strip so content starts at the
+   *  main card's visible right edge. */
+  padding-left: 16px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--bg-2);
+  border: 1px solid var(--bd);
+  border-left: 0;
+  border-radius: 0 13px 13px 0;
+  box-shadow:
+    5px 0 16px -7px rgba(0,0,0,.55),
+    0 18px 48px -12px rgba(0,0,0,.55);
+}
+.model-side-fly-inner {
+  display: flex;
+  flex-direction: column;
   min-height: 0;
-  padding: 6px;
-  border-right: 1px solid var(--bd-soft);
-  overflow: auto;
+  height: 100%;
+  animation: modelFadeSwap .2s var(--ease);
 }
-.model-agent {
+@keyframes modelFadeSwap {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+.model-side-fly-head {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 9px 11px;
+  border-bottom: 1px solid var(--bd-soft);
+}
+.model-side-fly-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12.5px;
+  font-weight: 550;
+  color: var(--fg-0);
+}
+.model-side-fly-tag {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  color: var(--fg-3);
+}
+.model-side-fly-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 5px;
+}
+.model-list {
+  min-height: 0;
+}
+.model-option {
   width: 100%;
   min-width: 0;
   display: flex;
   align-items: center;
   gap: 9px;
-  padding: 8px;
-  border-radius: var(--r-sm);
+  padding: 6px 9px;
+  border-radius: 8px;
   color: var(--fg-1);
   text-align: left;
+  transition: background .1s var(--ease);
 }
-.model-agent:hover:not(:disabled),
-.model-agent.active {
+.model-option:hover {
   background: var(--hover);
-  color: var(--fg-0);
 }
-.model-agent:disabled {
-  opacity: .42;
+.model-option.active {
+  background: var(--selected);
 }
-.model-agent-text {
-  min-width: 0;
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-.model-agent-text span:first-child {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 12.5px;
-  font-weight: 540;
-}
-.model-agent-text span:last-child {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--fg-3);
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-}
-.model-agent > svg,
-.model-mark svg {
+.model-option > svg {
+  flex-shrink: 0;
   color: var(--accent);
 }
-.model-list {
-  min-height: 0;
-  padding: 6px;
-  overflow: auto;
-  overscroll-behavior: contain;
-}
-.model-option {
-  width: 100%;
-  min-width: 0;
-  display: grid;
-  grid-template-columns: 18px minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 8px;
-  padding: 8px;
-  border-radius: var(--r-sm);
-  color: var(--fg-1);
-  text-align: left;
-}
-.model-option:hover,
-.model-option.active {
-  background: var(--hover);
-  color: var(--fg-0);
-}
-.model-mark {
-  width: 18px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
 .model-option-main {
+  flex: 1;
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 1px;
 }
-.model-option-main span:first-child {
+.model-option-name {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 12.5px;
-  font-weight: 560;
+  font-weight: 450;
+  color: var(--fg-0);
 }
-.model-option-main span:last-child {
+.model-option-name.def {
+  font-weight: 550;
+}
+.model-option-desc {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--fg-3);
-  font-family: var(--font-mono);
   font-size: 10.5px;
 }
-.model-option-meta {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  max-width: 190px;
-}
-.model-option-meta span {
+.model-ctx {
+  flex-shrink: 0;
   padding: 2px 5px;
-  border-radius: 4px;
-  background: var(--bg-3);
+  border: 1px solid var(--bd-soft);
+  border-radius: 5px;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
   color: var(--fg-2);
-  font-size: 10.5px;
   white-space: nowrap;
+}
+.model-option.active .model-ctx {
+  border-color: var(--accent);
+  color: var(--accent);
 }
 .model-empty {
-  margin: 12px;
-  padding: 18px 14px;
+  margin: 8px;
+  padding: 16px 14px;
   border: 1px dashed var(--bd);
-  border-radius: var(--r-sm);
+  border-radius: 9px;
   color: var(--fg-3);
-  font-size: 12px;
+  font-size: 11.5px;
   text-align: center;
 }
-.model-dd-foot {
-  padding: 8px 10px;
-  border-top: 1px solid var(--bd-soft);
-  color: var(--fg-3);
-  font-size: 11px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 @media (max-width: 760px) {
-  .model-dd {
-    width: calc(100vw - 28px);
-  }
-  .model-dd-head,
-  .model-dd-grid {
-    grid-template-columns: 150px minmax(0, 1fr);
-  }
-  .model-option {
-    grid-template-columns: 18px minmax(0, 1fr);
-  }
-  .model-option-meta {
-    grid-column: 2;
-    justify-content: flex-start;
-    max-width: none;
-  }
   .model-chip-agent {
     display: none;
   }
@@ -4357,31 +4426,44 @@ button { cursor: default; }
 }
 .ca-grow { flex: 1; }
 
-/* Custom agents section at the top of the model picker dropdown. */
-.model-custom { padding: 6px; border-bottom: 1px solid var(--bd-soft); }
-.model-custom-head {
-  padding: 4px 6px 6px;
-  color: var(--fg-3); font-size: 10px; font-weight: 650;
-  letter-spacing: .08em; text-transform: uppercase;
-}
+/* Custom agents section of the model picker dropdown — mirrors .model-agent-row. */
 .model-custom-row {
-  width: 100%; display: flex; align-items: center; gap: 9px;
-  padding: 7px 8px; border-radius: var(--r-sm);
+  width: 100%; display: flex; align-items: center; gap: 10px;
+  padding: 7px 9px; border-radius: 9px;
   color: var(--fg-1); text-align: left;
-  transition: background .12s;
+  transition: background .12s var(--ease);
 }
 .model-custom-row:hover { background: var(--hover); }
 .model-custom-row.active { background: var(--selected); }
 .model-custom-row > svg { margin-left: auto; color: var(--accent); flex-shrink: 0; }
-.model-custom-text { min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+.model-custom-text { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 1px; line-height: 1.2; }
 .model-custom-text > span:first-child {
-  font-size: 12.5px; color: var(--fg-0); font-weight: 500;
+  font-size: 13px; color: var(--fg-0); font-weight: 500;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 .model-custom-text > span:last-child {
-  font-size: 11px; color: var(--fg-3);
+  font-size: 11px; color: var(--fg-2);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
+
+/* Empty-state call to action — opens the new-custom-agent editor. */
+.model-custom-cta {
+  width: 100%; display: flex; align-items: center; gap: 10px;
+  padding: 7px 9px; border-radius: 9px;
+  color: var(--fg-2); text-align: left;
+  transition: background .12s var(--ease), color .12s var(--ease);
+}
+.model-custom-cta:hover { background: var(--hover); color: var(--fg-1); }
+.model-custom-cta .model-custom-text > span:first-child { color: var(--fg-1); font-weight: 500; }
+.model-custom-cta:hover .model-custom-text > span:first-child { color: var(--fg-0); }
+.model-custom-cta-icon {
+  width: 26px; height: 26px; flex-shrink: 0;
+  display: grid; place-items: center;
+  border: 1px dashed var(--bd); border-radius: 7px;
+  color: var(--fg-3);
+  transition: border-color .12s var(--ease), color .12s var(--ease);
+}
+.model-custom-cta:hover .model-custom-cta-icon { border-color: var(--accent); color: var(--accent); }
 
 /* ── UI SELECT (custom dropdown replacing native <select>) ───────────────── */
 .ui-select { position: relative; }

--- a/src/components/Composer/ModelPicker.tsx
+++ b/src/components/Composer/ModelPicker.tsx
@@ -192,7 +192,11 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
                     type="button"
                     disabled={!usable}
                     className={`model-agent-row ${isSelected ? "active" : ""} ${isOpen ? "hot" : ""}`}
-                    title={missing ? "Not installed — see Settings › Providers" : undefined}
+                    title={
+                      missing
+                        ? "Not installed — see Settings › Providers"
+                        : "Click to use the default model · hover to choose a model"
+                    }
                     onMouseEnter={() => usable && setHovered(p.id)}
                     onClick={() => usable && pickModel(p.id, undefined)}
                   >

--- a/src/components/Composer/ModelPicker.tsx
+++ b/src/components/Composer/ModelPicker.tsx
@@ -25,28 +25,24 @@ function formatContext(tokens: number): string {
   return `${tokens} ctx`;
 }
 
-function modelFamily(name: string): string {
-  const first = name.split(/\s+/)[0];
-  return first || "Model";
-}
-
-/** Agent + model picker. The left rail previews each runner's models; selecting
- *  a row in the right pane commits the runner/model choice. Leaving model unset
- *  preserves the provider CLI's default. */
+/** Agent + model picker. A flat list groups coding agents and custom agents;
+ *  hovering a coding agent opens a flyout on the right for model selection.
+ *  Clicking an agent row commits its default model; leaving model unset
+ *  preserves the provider CLI's default. Selections stay sticky via `onChange`. */
 export function ModelPicker({ provider, model, customAgentId, onChange, locked = false }: Props) {
   const [open, setOpen] = useState(false);
-  const [focusProvider, setFocusProvider] = useState(provider);
+  // Coding agent whose model flyout is currently expanded (null = none).
+  const [hovered, setHovered] = useState<string | null>(null);
   const providerFlags = useAppStore((s) => s.providerFlags);
   const providerVersions = useAppStore((s) => s.providerVersions);
   const providerPaths = useAppStore((s) => s.providerPaths);
   const providersProbed = useAppStore((s) => s.providersProbed);
   const modelsByAgent = useAppStore((s) => s.modelsByAgent);
   const customAgents = useAppStore((s) => s.customAgents);
+  const openSettingsScreen = useAppStore((s) => s.openSettingsScreen);
 
   const selected = PROVIDERS.find((p) => p.id === provider) ?? PROVIDERS[0];
   const enabled = PROVIDERS.filter((p) => providerFlags[p.id] !== false);
-  const focused = PROVIDERS.find((p) => p.id === focusProvider) ?? selected;
-  const focusedModels = modelsByAgent[focused.id] ?? [];
   const currentModel = useMemo(() => {
     const list = modelsByAgent[provider] ?? [];
     return list.find((m) => m.id === model);
@@ -56,20 +52,77 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
   // agents whose base provider is enabled are offered.
   const activeCustom = customAgents.find((a) => a.id === customAgentId);
   const selectableCustom = customAgents.filter((a) => providerFlags[a.base] !== false);
+  // The coding agent whose model panel is currently shown (null = none).
+  const hoveredAgent = hovered ? (PROVIDERS.find((p) => p.id === hovered) ?? null) : null;
 
+  // Reset the flyout each time the dropdown opens.
   useEffect(() => {
-    if (open) setFocusProvider(provider);
-  }, [open, provider]);
+    if (open) setHovered(null);
+  }, [open]);
 
-  function pickModel(id: string | undefined) {
+  function pickModel(providerId: string, id: string | undefined) {
     // Selecting a built-in model clears any custom-agent selection.
-    onChange(focused.id, id, undefined);
+    onChange(providerId, id, undefined);
     setOpen(false);
   }
 
   function pickCustom(agentId: string, base: string, agentModel: string | null) {
     onChange(base, agentModel ?? undefined, agentId);
     setOpen(false);
+  }
+
+  function renderModelList(p: (typeof PROVIDERS)[number]) {
+    const models = modelsByAgent[p.id] ?? [];
+    const isCurrent = p.id === provider && !customAgentId;
+    return (
+      <div className="model-list">
+        <button
+          type="button"
+          className={`model-option ${isCurrent && !model ? "active" : ""}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            pickModel(p.id, undefined);
+          }}
+        >
+          <span className="model-option-main">
+            <span className="model-option-name def">Default model</span>
+            <span className="model-option-desc">Use {p.label}'s configured default</span>
+          </span>
+          {isCurrent && !model && <Icon name="check" size={13} />}
+        </button>
+
+        {models.length === 0 ? (
+          <div className="model-empty">
+            {p.fixedModel
+              ? `${p.label} manages its own model — no selection needed.`
+              : `Model catalog unavailable for ${p.label}.`}
+          </div>
+        ) : (
+          models.map((m) => {
+            const active = isCurrent && m.id === model;
+            return (
+              <button
+                key={m.id}
+                type="button"
+                className={`model-option ${active ? "active" : ""}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  pickModel(p.id, m.id);
+                }}
+              >
+                <span className="model-option-main">
+                  <span className="model-option-name">{m.name}</span>
+                </span>
+                {m.contextWindow > 0 && (
+                  <span className="model-ctx">{formatContext(m.contextWindow)}</span>
+                )}
+                {active && <Icon name="check" size={13} />}
+              </button>
+            );
+          })
+        )}
+      </div>
+    );
   }
 
   return (
@@ -109,20 +162,66 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
       {open && (
         <>
           <Scrim onClose={() => setOpen(false)} />
-          <div className="dd model-dd" style={{ bottom: "calc(100% + 6px)", left: 0 }}>
-            {selectableCustom.length > 0 && (
-              <div className="model-custom">
-                <div className="model-custom-head">Custom agents</div>
-                {selectableCustom.map((a) => {
+          {/* Transparent wrapper: the main card sits above (z-index 2) the
+           *  model side panel (z-index 1) so the panel slides out from
+           *  underneath the dropdown rather than floating beside it. */}
+          <div
+            className="model-dd-wrap"
+            style={{ bottom: "calc(100% + 6px)", left: 0 }}
+            onMouseLeave={() => setHovered(null)}
+          >
+            <div className="model-dd-main">
+              <div className="model-sect">
+                <span>Coding agents</span>
+                <span className="model-sect-line" />
+              </div>
+              {enabled.map((p) => {
+                const wired = hasAdapter(p.id);
+                // Fail open: only gate on the path once a probe has actually
+                // succeeded (`providersProbed`). While probing, or if the probe
+                // failed, treat as installed so a transient detection error
+                // never disables an agent the user really has.
+                const installed = !providersProbed || !!providerPaths[p.id];
+                const usable = wired && installed;
+                const missing = wired && providersProbed && !installed;
+                const isSelected = p.id === provider && !customAgentId;
+                const isOpen = hovered === p.id;
+                return (
+                  <button
+                    key={p.id}
+                    type="button"
+                    disabled={!usable}
+                    className={`model-agent-row ${isSelected ? "active" : ""} ${isOpen ? "hot" : ""}`}
+                    title={missing ? "Not installed — see Settings › Providers" : undefined}
+                    onMouseEnter={() => usable && setHovered(p.id)}
+                    onClick={() => usable && pickModel(p.id, undefined)}
+                  >
+                    <ProviderIcon slug={p.id} short={p.short} hue={p.hue} size={26} />
+                    <span className="model-agent-name">{p.label}</span>
+                    <span className="model-agent-ver">
+                      {missing ? "Not installed" : providerVersions[p.id] ?? p.version}
+                    </span>
+                    {usable && <Icon name="chevR" size={12} />}
+                  </button>
+                );
+              })}
+
+              <div className="model-sect">
+                <span>Custom agents</span>
+                <span className="model-sect-line" />
+              </div>
+              {selectableCustom.length > 0 ? (
+                selectableCustom.map((a) => {
                   const active = a.id === customAgentId;
                   return (
                     <button
                       key={a.id}
                       type="button"
                       className={`model-custom-row ${active ? "active" : ""}`}
+                      onMouseEnter={() => setHovered(null)}
                       onClick={() => pickCustom(a.id, a.base, a.model)}
                     >
-                      <Mono name={a.name} hue={a.color} size={20} />
+                      <Mono name={a.name} hue={a.color} size={26} />
                       <span className="model-custom-text">
                         <span>{a.name}</span>
                         <span>{a.description || providerLabel(a.base)}</span>
@@ -130,96 +229,45 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
                       {active && <Icon name="check" size={12} />}
                     </button>
                   );
-                })}
-              </div>
-            )}
-            <div className="model-dd-head">
-              <span>Agent</span>
-              <span>Model</span>
-            </div>
-            <div className="model-dd-grid">
-              <div className="model-agent-list">
-                {enabled.map((p) => {
-                  const wired = hasAdapter(p.id);
-                  // Fail open: only gate on the path once a probe has actually
-                  // succeeded (`providersProbed`). While probing, or if the
-                  // probe failed, treat as installed so a transient detection
-                  // error never disables an agent the user really has.
-                  const installed = !providersProbed || !!providerPaths[p.id];
-                  const usable = wired && installed;
-                  const missing = wired && providersProbed && !installed;
-                  return (
-                    <button
-                      key={p.id}
-                      type="button"
-                      className={`model-agent ${p.id === focusProvider ? "active" : ""}`}
-                      disabled={!usable}
-                      title={missing ? "Not installed — see Settings › Providers" : undefined}
-                      onClick={() => usable && setFocusProvider(p.id)}
-                    >
-                      <ProviderIcon slug={p.id} short={p.short} hue={p.hue} size={18} />
-                      <span className="model-agent-text">
-                        <span>{p.label}</span>
-                        <span>{missing ? "Not installed" : providerVersions[p.id] ?? p.version}</span>
-                      </span>
-                      {p.id === provider && !customAgentId && <Icon name="check" size={12} />}
-                    </button>
-                  );
-                })}
-              </div>
-
-              <div className="model-list">
+                })
+              ) : (
                 <button
                   type="button"
-                  className={`model-option ${focused.id === provider && !model && !customAgentId ? "active" : ""}`}
-                  onClick={() => pickModel(undefined)}
+                  className="model-custom-cta"
+                  onMouseEnter={() => setHovered(null)}
+                  onClick={() => {
+                    setOpen(false);
+                    openSettingsScreen("agents", "new-custom-agent");
+                  }}
                 >
-                  <span className="model-mark">
-                    {focused.id === provider && !model && <Icon name="check" size={12} />}
+                  <span className="model-custom-cta-icon">
+                    <Icon name="plus" size={14} />
                   </span>
-                  <span className="model-option-main">
-                    <span>Default model</span>
-                    <span>Use {focused.label}'s configured default</span>
+                  <span className="model-custom-text">
+                    <span>Set up a custom agent</span>
+                    <span>Pair an agent with a model and a standing brief</span>
                   </span>
                 </button>
-
-                {focusedModels.length === 0 ? (
-                  <div className="model-empty">
-                    {focused.fixedModel
-                      ? `${focused.label} manages its own model — no selection needed.`
-                      : `Model catalog unavailable for ${focused.label}.`}
-                  </div>
-                ) : (
-                  focusedModels.map((m) => {
-                    const active = focused.id === provider && m.id === model && !customAgentId;
-                    return (
-                      <button
-                        key={m.id}
-                        type="button"
-                        className={`model-option ${active ? "active" : ""}`}
-                        onClick={() => pickModel(m.id)}
-                      >
-                        <span className="model-mark">
-                          {active && <Icon name="check" size={12} />}
-                        </span>
-                        <span className="model-option-main">
-                          <span>{m.name}</span>
-                          <span>{m.id}</span>
-                        </span>
-                        <span className="model-option-meta">
-                          <span>{modelFamily(m.name)}</span>
-                          <span>{formatContext(m.contextWindow)}</span>
-                          {m.reasoning && <span>reasoning</span>}
-                        </span>
-                      </button>
-                    );
-                  })
-                )}
-              </div>
+              )}
             </div>
-            {currentModel && (
-              <div className="model-dd-foot">
-                {selected.label} · {currentModel.name} · {formatContext(currentModel.contextWindow)}
+
+            {hoveredAgent && (
+              <div className="model-side-fly">
+                <div className="model-side-fly-card">
+                  <div className="model-side-fly-inner" key={hoveredAgent.id}>
+                    <div className="model-side-fly-head">
+                      <ProviderIcon
+                        slug={hoveredAgent.id}
+                        short={hoveredAgent.short}
+                        hue={hoveredAgent.hue}
+                        size={20}
+                      />
+                      <span className="model-side-fly-name">{hoveredAgent.label}</span>
+                      <span className="model-side-fly-tag">model</span>
+                    </div>
+                    <div className="model-side-fly-list">{renderModelList(hoveredAgent)}</div>
+                  </div>
+                </div>
               </div>
             )}
           </div>

--- a/src/components/SettingsScreen/CustomAgents/index.tsx
+++ b/src/components/SettingsScreen/CustomAgents/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { DEFAULT_PROVIDER_ID } from "../../../data/providers";
 import { useAppStore } from "../../../store";
 import type { CustomAgent, NewCustomAgent } from "../../../storage/customAgents";
@@ -35,10 +35,22 @@ export function CustomAgentsPane() {
   const deleteCustomAgent = useAppStore((s) => s.deleteCustomAgent);
   const duplicateCustomAgent = useAppStore((s) => s.duplicateCustomAgent);
   const setLastError = useAppStore((s) => s.setLastError);
+  const settingsIntent = useAppStore((s) => s.settingsIntent);
+  const clearSettingsIntent = useAppStore((s) => s.clearSettingsIntent);
 
   const [editing, setEditing] = useState<EditTarget | null>(null);
 
   const startNew = () => setEditing({ mode: "new", initial: blankAgent(agents.length) });
+
+  // A deep-link (e.g. the composer's "Set up a custom agent" CTA) opens this
+  // pane straight in the new-agent editor. Consume the one-shot intent once.
+  useEffect(() => {
+    if (settingsIntent === "new-custom-agent") {
+      startNew();
+      clearSettingsIntent();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settingsIntent]);
   const startEdit = (a: CustomAgent) =>
     setEditing({ mode: "edit", id: a.id, initial: a });
 

--- a/src/storage/preferences.ts
+++ b/src/storage/preferences.ts
@@ -18,6 +18,9 @@ export type SettingsSection =
   | "experimental"
   | "developer";
 
+/** One-shot deep-link intent handed to a settings pane when it opens. */
+export type SettingsIntent = "new-custom-agent";
+
 export interface FeatureFlags {
   git: boolean;
   /** The unified Code panel: file explorer/editor + the Live diff feed. */

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -22,6 +22,7 @@ import type {
   Density,
   WorkspaceView,
   SettingsSection,
+  SettingsIntent,
   FeatureFlags,
 } from "../storage/preferences";
 import type { AccountProfile } from "../storage/accounts";
@@ -217,6 +218,10 @@ export interface UiSlice {
    *  Replaces the workspace panes while open. */
   settingsScreenOpen: boolean;
   settingsSection: SettingsSection;
+  /** One-shot deep-link intent for the settings screen, consumed and cleared
+   *  by the target pane on mount (e.g. open the new-custom-agent editor
+   *  straight from the composer's agent picker). */
+  settingsIntent: SettingsIntent | null;
   /** First-run onboarding overlay. `onboardingComplete` is persisted (DB
    *  settings); the overlay auto-opens for new users on init and is
    *  re-openable any time from Settings › General. */
@@ -235,9 +240,11 @@ export interface UiSlice {
   rightWidth: number;
 
   toggleSettings: (open?: boolean) => void;
-  openSettingsScreen: (section?: SettingsSection) => void;
+  openSettingsScreen: (section?: SettingsSection, intent?: SettingsIntent) => void;
   closeSettingsScreen: () => void;
   setSettingsSection: (section: SettingsSection) => void;
+  /** Clear a consumed `settingsIntent` so it fires only once. */
+  clearSettingsIntent: () => void;
   /** Open the onboarding overlay (e.g. "Replay tour" from Settings). */
   openOnboarding: () => void;
   /** Dismiss onboarding and mark it complete so it won't auto-open again. */

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -11,6 +11,7 @@ export const createUiSlice: SliceCreator<UiSlice> = (set, get) => ({
   settingsOpen: false,
   settingsScreenOpen: false,
   settingsSection: "general" as SettingsSection,
+  settingsIntent: null,
   onboardingOpen: false,
   onboardingComplete: false,
   historyOpen: false,
@@ -23,15 +24,17 @@ export const createUiSlice: SliceCreator<UiSlice> = (set, get) => ({
   // ── UI ──────────────────────────────────────────────────────────────────────
   toggleSettings: (open) =>
     set((s) => ({ settingsOpen: open ?? !s.settingsOpen })),
-  openSettingsScreen: (section) =>
+  openSettingsScreen: (section, intent) =>
     set((s) => ({
       settingsScreenOpen: true,
       settingsSection: section ?? s.settingsSection,
+      settingsIntent: intent ?? null,
       // The full screen takes over — dismiss the quick popover behind it.
       settingsOpen: false,
     })),
   closeSettingsScreen: () => set({ settingsScreenOpen: false }),
   setSettingsSection: (section) => set({ settingsSection: section }),
+  clearSettingsIntent: () => set({ settingsIntent: null }),
   openOnboarding: () => set({ onboardingOpen: true }),
   closeOnboarding: () => {
     const firstCompletion = !get().onboardingComplete;


### PR DESCRIPTION
Reworks the composer's agent/model picker from the old two-pane grid into a flat list grouped into **Coding agents** and **Custom agents**, where hovering a coding agent slides out a full-height model panel that tucks under the dropdown's right edge (appearing from underneath rather than floating beside it), with the default model preselected. The **Custom agents** section now always shows, including an empty-state CTA that deep-links straight into the new-custom-agent editor via a one-shot `settingsIntent`. Model rows drop the redundant id/family/reasoning chips and keep only the context-window badge, and the whole dropdown adopts the prototype's geometry (sizes, radii, spacing, elevation) while staying on the existing calm dark palette. Agent/model stickiness is preserved throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)