### PR TITLE
fix: eliminate white window flash on launch

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "core:window:default",
+    "core:window:allow-show",
     "core:window:allow-start-dragging",
     "core:window:allow-toggle-maximize",
     "core:event:default",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -327,10 +327,20 @@ pub fn run() {
         .plugin(tauri_plugin_process::init());
 
     // Persist window size/position/maximized state across restarts. Desktop
-    // only — the plugin isn't available on mobile targets.
+    // only — the plugin isn't available on mobile targets. VISIBLE is excluded
+    // from the tracked flags so the plugin doesn't reveal the window during
+    // restore (which happens early, before the webview has painted, and is the
+    // source of the white launch flash). The frontend shows it after first
+    // paint instead — see `revealAppWindow` / `src/main.tsx`.
     #[cfg(desktop)]
-    let builder =
-        builder.plugin(tauri_plugin_window_state::Builder::default().build());
+    let builder = builder.plugin(
+        tauri_plugin_window_state::Builder::default()
+            .with_state_flags(
+                tauri_plugin_window_state::StateFlags::all()
+                    & !tauri_plugin_window_state::StateFlags::VISIBLE,
+            )
+            .build(),
+    );
 
     builder
         .setup(|app| {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,8 @@
         "transparent": false,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "visible": false
+        "visible": false,
+        "backgroundColor": "#0e1011"
       }
     ],
     "security": { "csp": null }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "./App";
 import { runStartupUpdateCheck } from "./util/autoUpdate";
+import { revealAppWindow } from "./util/window";
 import { useAppStore } from "./store";
 import "@fontsource/geist-sans/400.css";
 import "@fontsource/geist-sans/600.css";
@@ -12,6 +13,10 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     <App />
   </React.StrictMode>,
 );
+
+// Reveal the (initially hidden) window after first paint, so the white webview
+// flash never shows. See `revealAppWindow`.
+revealAppWindow();
 
 // Check for and download updates on launch (no-op in dev). Fire-and-forget so
 // it never delays first paint; once an update is staged it surfaces a toast

--- a/src/util/window.ts
+++ b/src/util/window.ts
@@ -1,0 +1,27 @@
+// Window reveal: the main window is created hidden (`visible: false` in
+// tauri.conf.json) and the window-state plugin is configured not to show it on
+// restore, so nothing reveals it natively. We do it here, after the first
+// paint, so the user never sees the empty white webview — the OS window's
+// background is already our dark `--bg-0` (`backgroundColor` in the config),
+// and by the time we show it the React UI has painted over it.
+
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+/**
+ * Reveal the main window after the initial React commit. We must NOT gate this
+ * on `requestAnimationFrame`: a hidden window produces no frames, so rAF
+ * callbacks never run — and `show()` is the only thing that makes the window
+ * visible, so that would deadlock and the window would never appear. A
+ * macrotask (`setTimeout`) fires regardless of visibility. By the time it runs
+ * the DOM is committed, and the window's dark `backgroundColor` covers the
+ * sub-frame gap before the webview paints. Failures are swallowed: in a plain
+ * browser dev context there's no Tauri window, and startup must never hang.
+ */
+export function revealAppWindow(): void {
+  setTimeout(() => {
+    void getCurrentWindow()
+      .show()
+      .then(() => getCurrentWindow().setFocus())
+      .catch(() => {});
+  }, 0);
+}


### PR DESCRIPTION
## What

Removes the white window flash shown on every app launch and replaces it with a clean reveal of the already-rendered dark UI.

## Why

The window is configured `visible: false`, but `tauri-plugin-window-state` was revealing it during state restore — which runs early, before the webview has painted — so users saw a white window frame for a moment on each launch.

## Changes

- **Dark native background** — set the window `backgroundColor` to the app's `--bg-0` (`#0e1011`) in `tauri.conf.json`, so the OS window never paints white.
- **Stop the early reveal** — exclude `VISIBLE` from the window-state plugin's tracked flags (`lib.rs`); it still restores size/position/maximized, but no longer shows the window during restore.
- **Frontend-controlled reveal** — `src/util/window.ts` adds `revealAppWindow()`, called from `main.tsx` right after the initial React commit, so the window appears already-rendered. It uses `setTimeout` rather than `requestAnimationFrame`: rAF never fires while the window is hidden (no frames are produced), which would deadlock the reveal.
- **Permission** — grant `core:window:allow-show` so the frontend `show()` is allowed.

## Notes

Because the plugin no longer tracks `VISIBLE`, the app always launches visible — the desired behavior here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)