### PR TITLE
feat(extensions): let a settings pane opt into a wider column

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -3892,6 +3892,11 @@ button { cursor: default; }
   margin: 0 auto;
   padding: 52px 56px 96px;
 }
+/* Wider column for panes that opt in (extension `wide` flag) — e.g. a builder
+   that needs room. Centers within the main area like the default column. */
+.set-content.is-wide {
+  max-width: 1080px;
+}
 @media (max-width: 1080px) {
   .set-content { padding: 40px 36px 80px; }
 }

--- a/src/components/SettingsScreen/index.tsx
+++ b/src/components/SettingsScreen/index.tsx
@@ -54,6 +54,9 @@ export function SettingsScreen() {
   const setSection = useAppStore((s) => s.setSettingsSection);
   const close = useAppStore((s) => s.closeSettingsScreen);
 
+  // An extension pane can opt into a wider content column (e.g. a builder).
+  const wide = extSettingsPanes.some((p) => p.id === section && p.wide);
+
   return (
     <div className="set-screen">
       <nav className="set-nav">
@@ -80,7 +83,7 @@ export function SettingsScreen() {
       </nav>
 
       <div className="set-main">
-        <div className="set-content">
+        <div className={`set-content ${wide ? "is-wide" : ""}`}>
           {section === "account" && <AccountPane />}
           {section === "providers" && <ProvidersPane />}
           {section === "agents" && <CustomAgentsPane />}

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -28,6 +28,9 @@ export interface ExtensionSettingsPane {
    *  Experimental (50). Omit to append after the built-ins (defaults to 100).
    *  Ties keep contribution order. */
   order?: number;
+  /** Render in a wider content column. The default settings column is narrow
+   *  (tuned for forms); a builder/table/canvas pane can request more room. */
+  wide?: boolean;
 }
 
 /** What a single extension exports (as `export const extension: Extension`)


### PR DESCRIPTION
## Summary

Follow-up to #212 (now merged). Adds a small, generic seam so an extension-contributed settings pane can request a wider content column — useful for panes that aren't simple forms (a builder, a table, a canvas).

## Changes

- **`ExtensionSettingsPane.wide`** — new optional flag.
- **`SettingsScreen`** — applies an `is-wide` class to `.set-content` when the active extension pane sets `wide`.
- **`app.css`** — `.set-content.is-wide { max-width: 1080px }` (vs the default 720px). It still centers within the main area like the default column, so there are no breakout/negative-margin hacks fighting the settings nav offset.

## Notes

- Generic and workflow-agnostic — any builder/table/canvas pane can opt in.
- Backward compatible: `wide` is optional; unset panes render exactly as before.

## Test plan

- [x] `tsc` clean (host + a private extension consuming the seam)
- [ ] Open a wide-flagged pane → column is 1080px and centered; other panes unchanged at 720px