### PR TITLE
feat: show unseen agent completions on the app icon badge

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "core:window:default",
     "core:window:allow-show",
+    "core:window:allow-set-badge-count",
     "core:window:allow-start-dragging",
     "core:window:allow-toggle-maximize",
     "core:event:default",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { UpdateToast } from "./components/UpdateToast";
 import { useSplitter } from "./util/splitter";
 import { useGlobalShortcuts } from "./util/shortcuts";
 import { usePoll } from "./util/hooks";
+import { setAppBadgeCount } from "./util/window";
 
 export function App() {
   const init = useAppStore((s) => s.init);
@@ -39,8 +40,16 @@ export function App() {
   const historyOpen = useAppStore((s) => s.historyOpen);
   const settingsScreenOpen = useAppStore((s) => s.settingsScreenOpen);
   const onboardingOpen = useAppStore((s) => s.onboardingOpen);
+  // Count of agents that finished a turn while the user wasn't looking at them
+  // (set on completion, cleared when the agent is opened). This is the same
+  // signal behind the sidebar "new" dots — mirror it onto the app icon badge.
+  const unseenCount = useAppStore((s) => Object.keys(s.unseenResults).length);
 
   useEffect(() => { init(); }, [init]);
+
+  // Reflect the unseen-completion count on the macOS dock / taskbar icon so
+  // finished agents are visible even when the window is in the background.
+  useEffect(() => { setAppBadgeCount(unseenCount); }, [unseenCount]);
 
   // App-wide poll: refresh compact shortstats for every live agent so the
   // sidebar / right-rail badges stay current without waiting for a focused

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -239,6 +239,10 @@ export function dropAgentEntries(state: AppState, id: string): Partial<AppState>
   const { [id]: _seed, ...composerSeeds } = state.composerSeeds;
   const { [id]: _draft, ...composerDrafts } = state.composerDrafts;
   const { [id]: _delegation, ...gitDelegations } = state.gitDelegations;
+  // Drop the unseen-results flag too: otherwise archiving/discarding an agent
+  // that finished while unviewed leaves an orphaned key behind with no row to
+  // select, which would keep the app-icon badge count nonzero forever.
+  const { [id]: _seen, ...unseenResults } = state.unseenResults;
   return {
     managedLogs,
     transcriptLoading,
@@ -253,6 +257,7 @@ export function dropAgentEntries(state: AppState, id: string): Partial<AppState>
     composerSeeds,
     composerDrafts,
     gitDelegations,
+    unseenResults,
   };
 }
 

--- a/src/util/window.ts
+++ b/src/util/window.ts
@@ -25,3 +25,17 @@ export function revealAppWindow(): void {
       .catch(() => {});
   }, 0);
 }
+
+/**
+ * Reflect the number of agents with unseen completed results on the app icon
+ * (macOS dock badge / Windows taskbar overlay). Driven from the store's
+ * `unseenResults` map, so the badge tracks the same "needs your attention"
+ * signal as the sidebar dots and self-clears as you open each agent. Passing
+ * `0`/`undefined` removes the badge. Failures are swallowed: there's no Tauri
+ * window in a plain browser dev context.
+ */
+export function setAppBadgeCount(count: number): void {
+  void getCurrentWindow()
+    .setBadgeCount(count > 0 ? count : undefined)
+    .catch(() => {});
+}


### PR DESCRIPTION
## Summary

The app-icon badge that should show a count of agents that finished while you weren't looking was only half-built: the completion-tracking state (`unseenResults`) and the in-app signals (sidebar "new" dot + chime) existed, but nothing ever pushed a count to the OS app icon, so the macOS dock / Windows taskbar badge never appeared.

This wires up the missing last step, driving the badge from the same `unseenResults` signal that powers the sidebar dots.

## Changes

- **`src-tauri/capabilities/default.json`** — grant `core:window:allow-set-badge-count`; Tauri v2 gates this API, so without it the call silently rejects.
- **`src/util/window.ts`** — add a reusable `setAppBadgeCount(count)` helper; `0`/`undefined` clears the badge, failures are swallowed (no Tauri window in a plain browser dev context).
- **`src/App.tsx`** — an effect mirrors `Object.keys(unseenResults).length` onto the icon whenever it changes.

## Behavior

When an agent finishes a turn and you're not viewing that chat, the count appears on the app icon. Opening that agent clears its slot via the existing `selectAgent` logic, decrementing the badge — same lifecycle as the sidebar dots.

Note: `unseenResults` flags any agent you're not currently viewing, so the badge can show while the app is focused but on a different chat (per-chat, not strictly "app unfocused"). This matches the existing sidebar-dot/chime model.

## Testing

- `tsc --noEmit` passes (also confirms `setBadgeCount` exists in the Tauri 2.11 API typings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)