### PR TITLE
Refactor RPC into a generic transport

### DIFF
--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -19,9 +19,9 @@
 //!
 //! The injected text has three layers: editable general guidance
 //! (`instructions/system_prompt.md`), a Quorum-managed protocol block
-//! (`instructions/rpc_protocol.md`) that documents the file-RPC the app
-//! exposes (see `rpc.rs`), and the Quorum-managed git-action playbooks
-//! (`instructions/git_actions.md`) behind the panel's `[app-action]`
+//! (`instructions/rpc_protocol.md`) that documents the file-RPC transport the
+//! app exposes (see `rpc.rs`), and Quorum-managed feature playbooks (for
+//! example `instructions/git_actions.md`) behind the panel's `[app-action]`
 //! triggers. The managed blocks are code-managed because they must stay in
 //! sync with the op allowlist / trigger names; the general layer is yours to
 //! edit. Blank all files to disable injection entirely — every helper below

--- a/src-tauri/src/instructions/rpc_protocol.md
+++ b/src-tauri/src/instructions/rpc_protocol.md
@@ -44,7 +44,8 @@ cat "$QUORUM_RPC_DIR/responses/$ID.json"
 ```
 
 For free-text args, build the JSON with `jq -n --arg` so quotes and newlines
-are escaped correctly:
+are escaped correctly. The current dispatcher exposes a harmless `echo` op for
+round-trip testing:
 
 ```sh
 ID=$(uuidgen)
@@ -58,5 +59,6 @@ mv "$QUORUM_RPC_DIR/requests/$ID.json.tmp" "$QUORUM_RPC_DIR/requests/$ID.json"
 ```
 
 The exact op names are feature-specific. Quorum currently uses this same
-transport for Git actions, but future app features can define their own ops on
-top of the same mailbox.
+transport for Git actions, and the Git dispatcher also exposes `echo` as a
+simple round-trip check. Future app features can define their own ops on top of
+the same mailbox.

--- a/src-tauri/src/instructions/rpc_protocol.md
+++ b/src-tauri/src/instructions/rpc_protocol.md
@@ -1,16 +1,39 @@
-## Quorum app actions (file RPC)
+## Quorum app RPC
 
-Your writes are confined to your worktree. When a task needs an action the app must run for you, ask for it through the file mailbox at `$QUORUM_RPC_DIR` and wait for the reply. Only the ops listed below are accepted; anything else is rejected.
+Your writes are confined to your worktree. When an agent needs the app to do
+something it cannot do itself, send a JSON request through the mailbox at
+`$QUORUM_RPC_DIR` and wait for the reply.
 
-To make a call:
+Protocol shape:
 
-1. Choose a unique id (a UUID works).
-2. Write the request **atomically**: write `$QUORUM_RPC_DIR/requests/<id>.json.tmp`, then rename it to `$QUORUM_RPC_DIR/requests/<id>.json`. Body: `{"id":"<id>","op":"<op>","args":{}}`.
-3. Poll for `$QUORUM_RPC_DIR/responses/<id>.json` until it appears (every ~0.2s, with your own timeout), then read it.
+1. Pick a unique id, usually a UUID.
+2. Write the request atomically to `$QUORUM_RPC_DIR/requests/<id>.json.tmp`,
+   then rename it to `$QUORUM_RPC_DIR/requests/<id>.json`.
+3. Poll `$QUORUM_RPC_DIR/responses/<id>.json` until it appears, then read it.
 
-A success response is `{"id","ok":true,"exit_code","stdout","stderr"}`; a failure is `{"id","ok":false,"error":"..."}`.
+Request body:
 
-Wait for a reply (shell):
+```json
+{"id":"<id>","op":"<op>","args":{}}
+```
+
+`op` is an application-defined message name. `args` is an arbitrary JSON object
+for that operation's payload. The app replies with one final response payload;
+there is no streaming.
+
+A success response is:
+
+```json
+{"id":"<id>","ok":true,"exit_code":0,"stdout":"","stderr":""}
+```
+
+A failure response is:
+
+```json
+{"id":"<id>","ok":false,"error":"..."}
+```
+
+Example:
 
 ```sh
 ID=$(uuidgen)
@@ -20,28 +43,20 @@ until [ -f "$QUORUM_RPC_DIR/responses/$ID.json" ]; do sleep 0.2; done
 cat "$QUORUM_RPC_DIR/responses/$ID.json"
 ```
 
-For args carrying free text (commit messages, PR bodies), do NOT hand-escape the string into a `printf`/`echo` format — `\n` and quotes get mangled by the shell. Build the body with `jq -n --arg` from a heredoc, which escapes everything correctly on the first try:
+For free-text args, build the JSON with `jq -n --arg` so quotes and newlines
+are escaped correctly:
 
 ```sh
 ID=$(uuidgen)
 MSG=$(cat <<'EOF'
-feat: add the thing
-
-Optional longer body, safely multi-line.
+hello from the agent
 EOF
 )
-jq -n --arg id "$ID" --arg msg "$MSG" '{id:$id,op:"git_commit",args:{message:$msg}}' \
+jq -n --arg id "$ID" --arg msg "$MSG" '{id:$id,op:"echo",args:{message:$msg}}' \
   > "$QUORUM_RPC_DIR/requests/$ID.json.tmp"
 mv "$QUORUM_RPC_DIR/requests/$ID.json.tmp" "$QUORUM_RPC_DIR/requests/$ID.json"
 ```
 
-Available ops:
-
-- `ping` — liveness check; returns `pong`. No args.
-- `git_status` — runs `git status` in your worktree and returns its output. No args.
-- `git_commit` — stages all changes in your worktree and commits them. `args.message` (required) is the commit message.
-- `open_pr` — creates your branch (if you don't have one yet), pushes it, and opens a pull request against your base branch. `args.branch` is the branch name to create — choose a conventional, descriptive name like `fix/login-crash`, `feat/csv-export`, or `chore/bump-deps` (no `quorum/` prefix). Required the first time you push; omit it later to keep using your current branch (pushing again updates the same PR). Pass a *new* `args.branch` to cut a fresh branch for a second PR from the same worktree. `args.title` and `args.body` set the PR title and description; omit `title` to auto-fill from your commits.
-- `git_push` — pushes your branch to origin (sets the upstream on first push). When you're already on a branch, no args are needed — use it to update an existing pull request after committing fixes. When you don't have a branch yet, pass `args.branch` (a conventional name like `fix/…`) so it can be created at your current commit before pushing.
-- `git_update_branch` — fetches your base branch from origin and merges it into your current branch. No args. A non-zero `exit_code` with `CONFLICT` in `stdout` means the merge stopped on conflicts: resolve the listed files in your worktree, then complete the merge with `git_commit` and push with `git_push`.
-
-Use these ops for git: your worktree's git database lives outside the sandbox, so running `git add`/`commit`/`merge`/`push` yourself fails with a permission error. Commit through `git_commit`, push through `git_push`, sync your base branch through `git_update_branch`, and open PRs through `open_pr` instead.
+The exact op names are feature-specific. Quorum currently uses this same
+transport for Git actions, but future app features can define their own ops on
+top of the same mailbox.

--- a/src-tauri/src/rpc.rs
+++ b/src-tauri/src/rpc.rs
@@ -1,56 +1,27 @@
 //! File-mailbox RPC between a sandboxed agent and the app.
 //!
-//! A sandboxed agent can't run actions outside its worktree, so it asks the
-//! app to. This is tool-calling over files: the agent writes a JSON **request**
-//! (`op` + `args`) into its mailbox; an in-app watcher (see
-//! `supervisor::spawn_rpc_watcher`) executes a deterministic, allowlisted action
-//! and writes a JSON **response**; the agent reads it. The exchange is
-//! synchronous (the agent waits for the response), yields a single final payload
-//! (no streaming), and is **allowlist-only** — anything not in [`dispatch`] is
-//! rejected, which keeps the sandbox meaningful.
-//!
-//! The mailbox lives at `~/.quorum/rpc/<agent-id>/` — a private (0700) per-agent
-//! dir on the sandbox's write-allow list (see `sandbox.rs`) but entirely outside
-//! the git worktree tree, so it never pollutes a repo and is immune to git
-//! operations (`git clean`, branch switches) the agent might run. Its path is
-//! handed to the agent via the `QUORUM_RPC_DIR` env var, injected at spawn.
-//!
-//! ```text
-//! $QUORUM_RPC_DIR/
-//!   requests/<uuid>.json     # agent writes
-//!   responses/<uuid>.json    # app writes
-//! ```
-//!
-//! The mailbox protocol (parse, dispatch, atomic response, give-up) has no
-//! `Supervisor` or Tauri dependency, so it stays unit-testable in isolation;
-//! the higher-level ops reuse the app's `git`/`gh` helpers for behavior that
-//! must match the rest of Quorum (staging, push, base-branch PRs). Several ops
-//! exist precisely because the sandbox blocks them: a worktree's git database
-//! lives in the main repo's `.git/worktrees/<name>` — outside the writable
-//! root — so the agent can't `commit`/`push` itself; it asks the app to. The
-//! lifecycle glue (start a watcher per agent, stop on teardown) lives in
-//! `supervisor`, which supplies the per-agent [`OpContext`].
+//! This module owns the transport: mailbox layout, atomic request/response
+//! handling, and the dispatcher trait. Feature-specific behavior lives behind
+//! dispatchers such as `rpc::git::GitDispatcher`.
 
+use std::future::Future;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
+use std::pin::Pin;
 use std::time::{Duration, SystemTime};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tokio::process::Command;
 
 use crate::error::{Error, Result};
-
-/// App-side ceiling on a single op. A hung command surfaces as an error
-/// response rather than blocking the watcher forever. The agent runs its own
-/// (shorter) poll timeout independently — see the instruction block.
-const OP_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// How old an unparseable request must be before we give up on it. A compliant
 /// agent writes atomically (tmp + rename), so a renamed file is always complete;
 /// this grace window only tolerates a non-compliant agent caught mid-write.
 /// Past it, the file is treated as malformed: answered with an error and removed.
 const STALE_REQUEST_AGE: Duration = Duration::from_secs(5);
+
+#[path = "rpc/git.rs"]
+pub mod git;
 
 /// One request from the agent. The `id` is carried in the filename (the pairing
 /// key), so it's not parsed from the body here; `args` defaults to null when
@@ -79,32 +50,38 @@ pub struct Response {
     pub error: Option<String>,
 }
 
-/// What an op needs beyond the request body: where to run (the agent's primary
-/// worktree) and the base branch for PRs. Supplied per-agent by the watcher.
-pub struct OpContext {
-    pub cwd: PathBuf,
-    pub base_branch: String,
+/// A structured side effect emitted by a dispatcher. The transport keeps this
+/// generic so feature handlers can report whatever state the supervisor needs
+/// to persist or forward.
+#[derive(Debug, Clone)]
+pub enum RpcEvent {
+    Named { name: String, payload: Value },
 }
 
-/// A side-effect of a processed op that the supervisor-side watcher needs to
-/// observe. `rpc` itself stays free of any `Supervisor`/DB dependency (so it
-/// remains unit-testable in isolation) — it just reports what happened and lets
-/// the watcher persist it.
-#[derive(Debug, Clone)]
-pub enum RpcEffect {
-    /// `open_pr`/`git_push` materialized the agent's branch at first push
-    /// (the worktree was detached, or `open_pr` cut a fresh branch for a
-    /// second PR). The watcher persists the name against the agent and emits
-    /// `agent:branch` so the panel learns a branch now exists.
-    BranchCreated { branch: String },
-    /// `open_pr` created (or resolved an already-existing) PR with this number.
-    /// The watcher records it against the agent so later PR-state lookups go by
-    /// number, not by the recyclable branch name.
-    PrOpened { number: u32 },
+impl RpcEvent {
+    pub fn named(name: impl Into<String>, payload: Value) -> Self {
+        Self::Named {
+            name: name.into(),
+            payload,
+        }
+    }
+}
+
+pub type RpcFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// Feature-specific RPC dispatcher. The transport knows how to read and write
+/// mailbox files; the dispatcher knows what operations the app supports.
+pub trait RpcDispatcher: Send + Sync {
+    fn dispatch<'a>(
+        &'a self,
+        id: &'a str,
+        op: &'a str,
+        args: &'a Value,
+    ) -> RpcFuture<'a, (Response, Vec<RpcEvent>)>;
 }
 
 impl Response {
-    fn ok(id: &str, exit_code: i32, stdout: String, stderr: String) -> Self {
+    pub(crate) fn ok(id: &str, exit_code: i32, stdout: String, stderr: String) -> Self {
         Self {
             id: id.to_string(),
             ok: true,
@@ -115,7 +92,7 @@ impl Response {
         }
     }
 
-    fn err(id: &str, error: impl Into<String>) -> Self {
+    pub(crate) fn err(id: &str, error: impl Into<String>) -> Self {
         Self {
             id: id.to_string(),
             ok: false,
@@ -157,43 +134,35 @@ pub fn ensure_mailbox(dir: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Process every pending request file once: parse → dispatch → write response →
-/// delete the request. Driven on a fixed tick by the per-agent watcher. Errors
-/// on a single request are logged and isolated — one bad file can't stall the
-/// rest. Commands run in `cwd` (the agent's primary worktree).
-pub async fn process_pending(rpc_dir: &Path, ctx: &OpContext) -> Vec<RpcEffect> {
+/// Process every pending request file once: parse -> dispatch -> write
+/// response -> delete the request. Driven on a fixed tick by the per-agent
+/// watcher. Errors on a single request are logged and isolated — one bad file
+/// can't stall the rest.
+pub async fn process_pending(rpc_dir: &Path, dispatcher: &dyn RpcDispatcher) -> Vec<RpcEvent> {
     let requests = rpc_dir.join("requests");
     let responses = rpc_dir.join("responses");
 
     let entries = match std::fs::read_dir(&requests) {
         Ok(e) => e,
-        // No mailbox yet (or removed during teardown) — nothing to do.
         Err(_) => return Vec::new(),
     };
 
     let mut effects = Vec::new();
     for entry in entries.flatten() {
         let path = entry.path();
-        // Only consume finished `<uuid>.json` files. The agent writes
-        // atomically (tmp + rename) so we never observe a half-written one;
-        // any other extension (e.g. a stray `.tmp`) is ignored.
         if path.extension().and_then(|e| e.to_str()) != Some("json") {
             continue;
         }
-        effects.extend(handle_request_file(&path, &responses, ctx).await);
+        effects.extend(handle_request_file(&path, &responses, dispatcher).await);
     }
     effects
 }
 
-/// Handle one request file. The response filename is derived from the request's
-/// file stem (the `<uuid>` the agent polls), not the in-body `id`, so the agent
-/// always finds its reply where it expects. The stem must be a safe token —
-/// a defense-in-depth guard against a malformed id escaping the mailbox.
 async fn handle_request_file(
     path: &Path,
     responses: &Path,
-    ctx: &OpContext,
-) -> Vec<RpcEffect> {
+    dispatcher: &dyn RpcDispatcher,
+) -> Vec<RpcEvent> {
     let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
         return Vec::new();
     };
@@ -213,12 +182,6 @@ async fn handle_request_file(
     let req: Request = match serde_json::from_slice(&raw) {
         Ok(r) => r,
         Err(e) => {
-            // Could be a mid-write read (only if the agent ignored the
-            // write-atomically contract) or a genuinely malformed file. Within
-            // the grace window, leave it — a transient partial resolves on the
-            // next tick. Past it, give up: answer with an error so the agent
-            // stops waiting, and delete it so we stop re-reading (and
-            // re-logging) it every tick.
             if file_age(path).is_some_and(|age| age >= STALE_REQUEST_AGE) {
                 tracing::warn!(error = %e, file = %path.display(), "rpc: malformed request, answering with error");
                 let resp = Response::err(stem, format!("malformed request JSON: {e}"));
@@ -232,23 +195,13 @@ async fn handle_request_file(
         }
     };
 
-    let (resp, effects) = dispatch(stem, &req.op, &req.args, ctx).await;
+    let (resp, effects) = dispatcher.dispatch(stem, &req.op, &req.args).await;
 
     if let Err(e) = write_response_atomic(responses, stem, &resp) {
         tracing::warn!(error = %e, id = %stem, "rpc: write response failed");
-        // The op's side effects already landed in the world (a branch was
-        // checked out, a PR was opened), so surface them for persistence even
-        // though the agent's reply didn't write — otherwise a freshly
-        // materialized branch is created in git but never recorded in the DB,
-        // and the retry can't re-derive it (`current_branch` now returns the
-        // branch, so the op takes the no-effect path). The request is left for
-        // a retry to re-write the response; the effect-producing ops are
-        // idempotent (the re-run finds the branch already present and emits no
-        // new effect), so returning effects here can't double-apply.
         return effects;
     }
 
-    // Answered — remove the request so it's processed exactly once.
     if let Err(e) = std::fs::remove_file(path) {
         tracing::warn!(error = %e, file = %path.display(), "rpc: remove request failed");
     }
@@ -256,253 +209,6 @@ async fn handle_request_file(
     effects
 }
 
-/// The op allowlist. Adding an op is one arm here plus a line in the instruction
-/// block (`instructions/rpc_protocol.md`). Anything unmatched is rejected, which
-/// is what keeps the sandbox meaningful — the agent can only invoke vetted,
-/// deterministic actions.
-async fn dispatch(
-    id: &str,
-    op: &str,
-    args: &Value,
-    ctx: &OpContext,
-) -> (Response, Vec<RpcEffect>) {
-    // The push ops can materialize a branch and/or open a PR — effects the
-    // supervisor needs to observe — so they return their own (response,
-    // effects) pair. Everything else is side-effect-free for the watcher.
-    match op {
-        "open_pr" => return open_pr(id, args, ctx).await,
-        "git_push" => return git_push(id, args, ctx).await,
-        _ => {}
-    }
-    let resp = match op {
-        // Liveness probe — proves the round-trip with no side effects.
-        "ping" => Response::ok(id, 0, "pong".to_string(), String::new()),
-        // Read-only: run a deterministic command and report its result.
-        "git_status" => {
-            run_command(id, &ctx.cwd, "git", &["status", "--porcelain=v1", "--branch"]).await
-        }
-        // Stage everything in the worktree and commit. Blocked in the sandbox
-        // (the worktree's git index/objects live outside the writable root), so
-        // it's an app action. `args.message` is the commit message.
-        "git_commit" => git_commit(id, args, ctx).await,
-        // Merge the latest base branch into the worktree branch (fetch +
-        // merge origin/<base>). Conflicts are reported faithfully (non-zero
-        // exit, stdout lists the files) and the merge is left in progress so
-        // the agent can resolve and finish with `git_commit` + `git_push`.
-        "git_update_branch" => git_update_branch(id, ctx).await,
-        other => Response::err(id, format!("unknown op: {other}")),
-    };
-    (resp, Vec::new())
-}
-
-/// `git_commit` — `args.message` (required, non-empty) is the commit message.
-/// Reuses `git::commit_all` (stage `-A` + commit) so behavior matches the rest
-/// of the app.
-async fn git_commit(id: &str, args: &Value, ctx: &OpContext) -> Response {
-    let message = args.get("message").and_then(|v| v.as_str()).unwrap_or("");
-    if message.trim().is_empty() {
-        return Response::err(id, "git_commit requires a non-empty `message` arg");
-    }
-    match crate::git::commit_all(&ctx.cwd, message).await {
-        Ok(()) => Response::ok(id, 0, "committed".to_string(), String::new()),
-        Err(e) => Response::err(id, e.to_string()),
-    }
-}
-
-/// `open_pr` — ensure the work is on a branch, push it, then `gh pr create`
-/// against the agent's base branch.
-///
-/// The worktree is detached until its first push, so the agent supplies a
-/// conventional branch name in `args.branch` (`fix/…`, `feat/…`, `chore/…`).
-/// Branch resolution:
-/// - detached → materialize `args.branch` (or a `chore/<slug-of-title>`
-///   fallback) at HEAD;
-/// - already on a branch and `args.branch` names a *different* branch → cut a
-///   fresh branch at HEAD (a second PR from the same worktree);
-/// - otherwise → stay on the current branch (updates its PR / fills it in).
-///
-/// `args.title`/`args.body` are optional (empty title → `--fill`). Returns the
-/// PR URL in `stdout` on success, plus a `BranchCreated` effect whenever a
-/// branch was freshly materialized.
-async fn open_pr(id: &str, args: &Value, ctx: &OpContext) -> (Response, Vec<RpcEffect>) {
-    let title = args.get("title").and_then(|v| v.as_str()).unwrap_or("");
-    let body = args.get("body").and_then(|v| v.as_str()).unwrap_or("");
-    let requested = arg_branch(args);
-
-    let current = match crate::git::current_branch(&ctx.cwd).await {
-        Ok(b) => b,
-        Err(e) => return (Response::err(id, format!("open_pr: {e}")), Vec::new()),
-    };
-
-    // Resolve which branch this PR lands on, materializing one if needed.
-    let mut effects = Vec::new();
-    let branch = match (current, requested) {
-        // On a branch already, and either no explicit name or the same name →
-        // stay put (push updates the existing PR / fills a new one).
-        (Some(cur), None) => cur,
-        (Some(cur), Some(req)) if req == cur => cur,
-        // Explicit, different name while on a branch → second PR: cut fresh.
-        (Some(_), Some(req)) => match materialize_branch(&ctx.cwd, &req).await {
-            Ok(name) => {
-                effects.push(RpcEffect::BranchCreated { branch: name.clone() });
-                name
-            }
-            Err(e) => return (Response::err(id, format!("open_pr: {e}")), effects),
-        },
-        // Detached → name from the agent's choice, else a slug of the title.
-        (None, req) => {
-            let desired = req.unwrap_or_else(|| fallback_branch(title));
-            match materialize_branch(&ctx.cwd, &desired).await {
-                Ok(name) => {
-                    effects.push(RpcEffect::BranchCreated { branch: name.clone() });
-                    name
-                }
-                Err(e) => return (Response::err(id, format!("open_pr: {e}")), effects),
-            }
-        }
-    };
-
-    if let Err(e) = crate::git::push(&ctx.cwd, &branch).await {
-        return (Response::err(id, format!("open_pr push failed: {e}")), effects);
-    }
-    match crate::gh::pr_create(&ctx.cwd, title, body, &ctx.base_branch).await {
-        Ok(pr) => {
-            crate::telemetry::track("pr_opened", serde_json::json!({ "source": "agent_rpc" }));
-            effects.push(RpcEffect::PrOpened { number: pr.number });
-            (Response::ok(id, 0, pr.url, String::new()), effects)
-        }
-        Err(e) => (Response::err(id, format!("open_pr: {e}")), effects),
-    }
-}
-
-/// `git_push` — push the worktree's branch to origin (sets upstream on first
-/// push). When already on a branch, pushes it (the common "update the open PR"
-/// case) and ignores `args.branch`. When detached — the worktree hasn't been
-/// branched yet — it materializes the agent-supplied `args.branch` at HEAD
-/// first; without a name there's nothing to push to, so it errors.
-async fn git_push(id: &str, args: &Value, ctx: &OpContext) -> (Response, Vec<RpcEffect>) {
-    let current = match crate::git::current_branch(&ctx.cwd).await {
-        Ok(b) => b,
-        Err(e) => return (Response::err(id, format!("git_push: {e}")), Vec::new()),
-    };
-
-    let mut effects = Vec::new();
-    let branch = match current {
-        Some(cur) => cur,
-        None => match arg_branch(args) {
-            Some(req) => match materialize_branch(&ctx.cwd, &req).await {
-                Ok(name) => {
-                    effects.push(RpcEffect::BranchCreated { branch: name.clone() });
-                    name
-                }
-                Err(e) => return (Response::err(id, format!("git_push: {e}")), effects),
-            },
-            None => {
-                return (
-                    Response::err(
-                        id,
-                        "git_push: HEAD is detached — pass `args.branch` (e.g. \"fix/…\") to create the branch",
-                    ),
-                    effects,
-                )
-            }
-        },
-    };
-
-    match crate::git::push(&ctx.cwd, &branch).await {
-        Ok(summary) => (Response::ok(id, 0, summary, String::new()), effects),
-        Err(e) => (Response::err(id, e.to_string()), effects),
-    }
-}
-
-/// Read and clean an `args.branch` value — trimmed, empty treated as absent.
-fn arg_branch(args: &Value) -> Option<String> {
-    args.get("branch")
-        .and_then(|v| v.as_str())
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string)
-}
-
-/// Create the agent's branch at the worktree's current HEAD, resolving name
-/// collisions by suffixing. Thin wrapper so both push ops share one policy.
-async fn materialize_branch(worktree: &Path, desired: &str) -> Result<String> {
-    crate::git::checkout_new_unique_branch(worktree, desired).await
-}
-
-/// Derive a fallback branch name from a PR title when the agent didn't supply
-/// one: a `chore/`-prefixed slug. Lowercase, non-alphanumeric runs collapse to
-/// a single `-`, trimmed; an empty result becomes `chore/update`.
-fn fallback_branch(title: &str) -> String {
-    let mut slug = String::new();
-    let mut prev_dash = false;
-    for ch in title.chars() {
-        if ch.is_ascii_alphanumeric() {
-            slug.push(ch.to_ascii_lowercase());
-            prev_dash = false;
-        } else if !prev_dash {
-            slug.push('-');
-            prev_dash = true;
-        }
-    }
-    let slug = slug.trim_matches('-');
-    if slug.is_empty() {
-        "chore/update".to_string()
-    } else {
-        format!("chore/{slug}")
-    }
-}
-
-/// `git_update_branch` — fetch the agent's base branch from origin and merge
-/// it into the current branch. No args; the base comes from [`OpContext`].
-/// A conflicting merge is NOT an op failure: the command report (exit code,
-/// stdout) is returned as-is and the merge stays open for the agent to
-/// resolve. A failed fetch (no origin, offline, unknown base) is returned
-/// faithfully too, before any merge is attempted.
-async fn git_update_branch(id: &str, ctx: &OpContext) -> Response {
-    let fetch = run_command(id, &ctx.cwd, "git", &["fetch", "origin", &ctx.base_branch]).await;
-    if !fetch.ok || fetch.exit_code != Some(0) {
-        return fetch;
-    }
-    let target = format!("origin/{}", ctx.base_branch);
-    run_command(id, &ctx.cwd, "git", &["merge", "--no-edit", &target]).await
-}
-
-/// Run a fixed command in `cwd`, capturing exit/stdout/stderr, bounded by
-/// [`OP_TIMEOUT`]. `kill_on_drop` ensures a timed-out child is reaped when the
-/// timeout future is dropped.
-async fn run_command(id: &str, cwd: &Path, program: &str, args: &[&str]) -> Response {
-    let mut cmd = Command::new(program);
-    cmd.args(args)
-        .current_dir(cwd)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true);
-
-    let child = match cmd.spawn() {
-        Ok(c) => c,
-        Err(e) => return Response::err(id, format!("spawn {program}: {e}")),
-    };
-
-    match tokio::time::timeout(OP_TIMEOUT, child.wait_with_output()).await {
-        Ok(Ok(out)) => Response::ok(
-            id,
-            out.status.code().unwrap_or(-1),
-            String::from_utf8_lossy(&out.stdout).into_owned(),
-            String::from_utf8_lossy(&out.stderr).into_owned(),
-        ),
-        Ok(Err(e)) => Response::err(id, format!("run {program}: {e}")),
-        Err(_) => Response::err(
-            id,
-            format!("op timed out after {}s", OP_TIMEOUT.as_secs()),
-        ),
-    }
-}
-
-/// Write `responses/<key>.json` atomically: write a sibling `.tmp`, then rename
-/// into place (atomic on the same filesystem), so the agent never reads a
-/// half-written response.
 fn write_response_atomic(responses: &Path, key: &str, resp: &Response) -> Result<()> {
     let json = serde_json::to_vec_pretty(resp)
         .map_err(|e| Error::Other(format!("serialize rpc response: {e}")))?;
@@ -515,14 +221,12 @@ fn write_response_atomic(responses: &Path, key: &str, resp: &Response) -> Result
     Ok(())
 }
 
-/// A request/response key (the `<uuid>` stem) must be a plain token — no path
-/// separators, dots, or empties — so it can't escape the mailbox dir.
 fn is_safe_key(s: &str) -> bool {
-    !s.is_empty() && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
 }
 
-/// How long ago `path` was last modified, or `None` if that can't be determined
-/// (missing file, or an mtime in the future from clock skew — treated as fresh).
 fn file_age(path: &Path) -> Option<Duration> {
     let modified = std::fs::metadata(path).ok()?.modified().ok()?;
     SystemTime::now().duration_since(modified).ok()
@@ -536,20 +240,28 @@ mod tests {
         std::fs::write(requests.join(name), body).unwrap();
     }
 
-    fn ctx(cwd: &Path) -> OpContext {
-        OpContext {
-            cwd: cwd.to_path_buf(),
-            base_branch: "main".to_string(),
-        }
-    }
+    struct MockDispatcher;
 
-    fn run_git(repo: &Path, args: &[&str]) {
-        let out = std::process::Command::new("git")
-            .current_dir(repo)
-            .args(args)
-            .output()
-            .unwrap();
-        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+    impl RpcDispatcher for MockDispatcher {
+        fn dispatch<'a>(
+            &'a self,
+            id: &'a str,
+            op: &'a str,
+            _args: &'a Value,
+        ) -> RpcFuture<'a, (Response, Vec<RpcEvent>)> {
+            Box::pin(async move {
+                match op {
+                    "ping" => (
+                        Response::ok(id, 0, "pong".to_string(), String::new()),
+                        Vec::new(),
+                    ),
+                    other => (
+                        Response::err(id, format!("unknown op: {other}")),
+                        Vec::new(),
+                    ),
+                }
+            })
+        }
     }
 
     #[test]
@@ -559,7 +271,6 @@ mod tests {
         ensure_mailbox(&dir).unwrap();
         assert!(dir.join("requests").is_dir());
         assert!(dir.join("responses").is_dir());
-        // Idempotent.
         ensure_mailbox(&dir).unwrap();
     }
 
@@ -569,10 +280,7 @@ mod tests {
         let f = td.path().join("fresh");
         std::fs::write(&f, b"x").unwrap();
         let age = file_age(&f).expect("fresh file has an age");
-        // Just written, so well within the grace window (the give-up branch
-        // keys off `age >= STALE_REQUEST_AGE`).
         assert!(age < STALE_REQUEST_AGE);
-        // Missing file → None (not treated as stale).
         assert!(file_age(&td.path().join("nope")).is_none());
     }
 
@@ -596,9 +304,9 @@ mod tests {
             r#"{"id":"req-1","op":"ping"}"#,
         );
 
-        process_pending(&rpc_dir, &ctx(td.path())).await;
+        let dispatcher = MockDispatcher;
+        process_pending(&rpc_dir, &dispatcher).await;
 
-        // Request consumed; response written.
         assert!(!rpc_dir.join("requests/req-1.json").exists());
         let body = std::fs::read_to_string(rpc_dir.join("responses/req-1.json")).unwrap();
         let v: Value = serde_json::from_str(&body).unwrap();
@@ -606,7 +314,6 @@ mod tests {
         assert_eq!(v["ok"], true);
         assert_eq!(v["exit_code"], 0);
         assert_eq!(v["stdout"], "pong");
-        // No leftover temp file.
         assert!(!rpc_dir.join("responses/req-1.json.tmp").exists());
     }
 
@@ -621,7 +328,8 @@ mod tests {
             r#"{"id":"req-2","op":"rm_rf_everything","args":{}}"#,
         );
 
-        process_pending(&rpc_dir, &ctx(td.path())).await;
+        let dispatcher = MockDispatcher;
+        process_pending(&rpc_dir, &dispatcher).await;
 
         let body = std::fs::read_to_string(rpc_dir.join("responses/req-2.json")).unwrap();
         let v: Value = serde_json::from_str(&body).unwrap();
@@ -636,295 +344,10 @@ mod tests {
         ensure_mailbox(&rpc_dir).unwrap();
         write_request(&rpc_dir.join("requests"), "req-3.json", "{ not json");
 
-        process_pending(&rpc_dir, &ctx(td.path())).await;
+        let dispatcher = MockDispatcher;
+        process_pending(&rpc_dir, &dispatcher).await;
 
-        // Within the grace window: left in place (could be a mid-write), no
-        // response fabricated. Once older than STALE_REQUEST_AGE it would
-        // instead get an ok:false error and be removed (see file_age logic).
         assert!(rpc_dir.join("requests/req-3.json").exists());
         assert!(!rpc_dir.join("responses/req-3.json").exists());
-    }
-
-    #[tokio::test]
-    async fn git_status_runs_a_real_command() {
-        // A non-repo cwd still exercises the spawn/capture/timeout path: git
-        // exits non-zero with a message on stderr, which we report faithfully.
-        let td = tempfile::tempdir().unwrap();
-        let rpc_dir = td.path().join(".quorum-rpc");
-        ensure_mailbox(&rpc_dir).unwrap();
-        write_request(
-            &rpc_dir.join("requests"),
-            "req-4.json",
-            r#"{"id":"req-4","op":"git_status"}"#,
-        );
-
-        process_pending(&rpc_dir, &ctx(td.path())).await;
-
-        let body = std::fs::read_to_string(rpc_dir.join("responses/req-4.json")).unwrap();
-        let v: Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(v["id"], "req-4");
-        // ok:true means the command ran (regardless of git's own exit code);
-        // exit_code is present.
-        assert_eq!(v["ok"], true);
-        assert!(v["exit_code"].is_number());
-    }
-
-    #[tokio::test]
-    async fn git_commit_stages_and_commits_the_worktree() {
-        let td = tempfile::tempdir().unwrap();
-        let repo = td.path().join("repo");
-        std::fs::create_dir_all(&repo).unwrap();
-        run_git(&repo, &["init", "-q"]);
-        run_git(&repo, &["config", "user.email", "t@example.com"]);
-        run_git(&repo, &["config", "user.name", "Tester"]);
-        std::fs::write(repo.join("new.txt"), b"hello").unwrap();
-
-        // Mailbox kept outside the repo so `git add -A` only stages new.txt.
-        let rpc_dir = td.path().join("rpc");
-        ensure_mailbox(&rpc_dir).unwrap();
-        write_request(
-            &rpc_dir.join("requests"),
-            "c1.json",
-            r#"{"id":"c1","op":"git_commit","args":{"message":"add new.txt"}}"#,
-        );
-
-        let cx = OpContext { cwd: repo.clone(), base_branch: "main".to_string() };
-        process_pending(&rpc_dir, &cx).await;
-
-        let body = std::fs::read_to_string(rpc_dir.join("responses/c1.json")).unwrap();
-        let v: Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(v["ok"], true, "response: {body}");
-
-        // The commit landed with the given message.
-        let log = std::process::Command::new("git")
-            .current_dir(&repo)
-            .args(["log", "--oneline"])
-            .output()
-            .unwrap();
-        assert!(String::from_utf8_lossy(&log.stdout).contains("add new.txt"));
-    }
-
-    #[tokio::test]
-    async fn git_push_without_remote_reports_error() {
-        let td = tempfile::tempdir().unwrap();
-        let repo = td.path().join("repo");
-        std::fs::create_dir_all(&repo).unwrap();
-        run_git(&repo, &["init", "-q", "-b", "main"]);
-        run_git(&repo, &["config", "user.email", "t@example.com"]);
-        run_git(&repo, &["config", "user.name", "Tester"]);
-        std::fs::write(repo.join("a.txt"), b"x").unwrap();
-        run_git(&repo, &["add", "-A"]);
-        run_git(&repo, &["commit", "-q", "-m", "init"]);
-
-        let rpc_dir = td.path().join("rpc");
-        ensure_mailbox(&rpc_dir).unwrap();
-        write_request(&rpc_dir.join("requests"), "p1.json", r#"{"id":"p1","op":"git_push"}"#);
-
-        let cx = OpContext { cwd: repo.clone(), base_branch: "main".to_string() };
-        process_pending(&rpc_dir, &cx).await;
-
-        let body = std::fs::read_to_string(rpc_dir.join("responses/p1.json")).unwrap();
-        let v: Value = serde_json::from_str(&body).unwrap();
-        // No origin remote → push fails; the agent gets a clear error (from a
-        // real push attempt, not an unknown-op rejection).
-        assert_eq!(v["ok"], false);
-        let err = v["error"].as_str().unwrap();
-        assert!(!err.contains("unknown op"), "got: {err}");
-        assert!(err.contains("push failed"), "got: {err}");
-    }
-
-    #[tokio::test]
-    async fn git_push_detached_without_branch_arg_errors() {
-        let td = tempfile::tempdir().unwrap();
-        let repo = td.path().join("repo");
-        std::fs::create_dir_all(&repo).unwrap();
-        run_git(&repo, &["init", "-q", "-b", "main"]);
-        run_git(&repo, &["config", "user.email", "t@example.com"]);
-        run_git(&repo, &["config", "user.name", "Tester"]);
-        std::fs::write(repo.join("a.txt"), b"x").unwrap();
-        run_git(&repo, &["add", "-A"]);
-        run_git(&repo, &["commit", "-q", "-m", "init"]);
-        // Detach HEAD so there's no branch — the deferred-branch steady state.
-        run_git(&repo, &["checkout", "-q", "--detach"]);
-
-        let rpc_dir = td.path().join("rpc");
-        ensure_mailbox(&rpc_dir).unwrap();
-        write_request(&rpc_dir.join("requests"), "p1.json", r#"{"id":"p1","op":"git_push"}"#);
-
-        let cx = OpContext { cwd: repo.clone(), base_branch: "main".to_string() };
-        process_pending(&rpc_dir, &cx).await;
-
-        let body = std::fs::read_to_string(rpc_dir.join("responses/p1.json")).unwrap();
-        let v: Value = serde_json::from_str(&body).unwrap();
-        // Detached and no name supplied → actionable error telling the agent to
-        // pass `args.branch`, not a silent failure.
-        assert_eq!(v["ok"], false);
-        assert!(v["error"].as_str().unwrap().contains("args.branch"), "got: {body}");
-    }
-
-    #[tokio::test]
-    async fn git_push_detached_materializes_named_branch() {
-        let td = tempfile::tempdir().unwrap();
-        let repo = td.path().join("repo");
-        std::fs::create_dir_all(&repo).unwrap();
-        run_git(&repo, &["init", "-q", "-b", "main"]);
-        run_git(&repo, &["config", "user.email", "t@example.com"]);
-        run_git(&repo, &["config", "user.name", "Tester"]);
-        std::fs::write(repo.join("a.txt"), b"x").unwrap();
-        run_git(&repo, &["add", "-A"]);
-        run_git(&repo, &["commit", "-q", "-m", "init"]);
-        run_git(&repo, &["checkout", "-q", "--detach"]);
-
-        let rpc_dir = td.path().join("rpc");
-        ensure_mailbox(&rpc_dir).unwrap();
-        write_request(
-            &rpc_dir.join("requests"),
-            "p1.json",
-            r#"{"id":"p1","op":"git_push","args":{"branch":"fix/thing"}}"#,
-        );
-
-        let cx = OpContext { cwd: repo.clone(), base_branch: "main".to_string() };
-        let effects = process_pending(&rpc_dir, &cx).await;
-
-        // The branch was created at HEAD and checked out, even though the push
-        // itself fails (no origin) — branch materialization is the point here.
-        let head = std::process::Command::new("git")
-            .current_dir(&repo)
-            .args(["rev-parse", "--abbrev-ref", "HEAD"])
-            .output()
-            .unwrap();
-        assert_eq!(String::from_utf8_lossy(&head.stdout).trim(), "fix/thing");
-        assert!(
-            effects
-                .iter()
-                .any(|e| matches!(e, RpcEffect::BranchCreated { branch } if branch == "fix/thing")),
-            "expected a BranchCreated effect, got: {effects:?}"
-        );
-    }
-
-    #[test]
-    fn fallback_branch_slugifies_title() {
-        assert_eq!(fallback_branch("Fix the Login Crash!"), "chore/fix-the-login-crash");
-        assert_eq!(fallback_branch("  Add   CSV export  "), "chore/add-csv-export");
-        assert_eq!(fallback_branch(""), "chore/update");
-        assert_eq!(fallback_branch("!!!"), "chore/update");
-    }
-
-    /// origin (bare) + a clone on branch `feat`, with `main` advanced on
-    /// origin after `feat` forked. Returns (tempdir, clone_path).
-    fn setup_origin_and_clone() -> (tempfile::TempDir, std::path::PathBuf) {
-        let td = tempfile::tempdir().unwrap();
-        let origin = td.path().join("origin.git");
-        std::fs::create_dir_all(&origin).unwrap();
-        run_git(&origin, &["init", "-q", "--bare", "-b", "main"]);
-
-        let work = td.path().join("work");
-        let out = std::process::Command::new("git")
-            .current_dir(td.path())
-            .args(["clone", "-q", origin.to_str().unwrap(), "work"])
-            .output()
-            .unwrap();
-        assert!(out.status.success(), "{}", String::from_utf8_lossy(&out.stderr));
-        run_git(&work, &["config", "user.email", "t@example.com"]);
-        run_git(&work, &["config", "user.name", "Tester"]);
-        run_git(&work, &["checkout", "-q", "-b", "main"]);
-        std::fs::write(work.join("a.txt"), b"base\n").unwrap();
-        run_git(&work, &["add", "-A"]);
-        run_git(&work, &["commit", "-q", "-m", "init"]);
-        run_git(&work, &["push", "-q", "-u", "origin", "main"]);
-
-        // Fork feat, then advance main on origin (push from main).
-        run_git(&work, &["checkout", "-q", "-b", "feat"]);
-        std::fs::write(work.join("feat.txt"), b"feature\n").unwrap();
-        run_git(&work, &["add", "-A"]);
-        run_git(&work, &["commit", "-q", "-m", "feat work"]);
-        run_git(&work, &["checkout", "-q", "main"]);
-        std::fs::write(work.join("b.txt"), b"advance\n").unwrap();
-        run_git(&work, &["add", "-A"]);
-        run_git(&work, &["commit", "-q", "-m", "main advances"]);
-        run_git(&work, &["push", "-q", "origin", "main"]);
-        run_git(&work, &["checkout", "-q", "feat"]);
-        (td, work)
-    }
-
-    #[tokio::test]
-    async fn git_update_branch_merges_the_advanced_base() {
-        let (td, work) = setup_origin_and_clone();
-        let rpc_dir = td.path().join("rpc");
-        ensure_mailbox(&rpc_dir).unwrap();
-        write_request(
-            &rpc_dir.join("requests"),
-            "u1.json",
-            r#"{"id":"u1","op":"git_update_branch"}"#,
-        );
-
-        let cx = OpContext { cwd: work.clone(), base_branch: "main".to_string() };
-        process_pending(&rpc_dir, &cx).await;
-
-        let body = std::fs::read_to_string(rpc_dir.join("responses/u1.json")).unwrap();
-        let v: Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(v["ok"], true, "response: {body}");
-        assert_eq!(v["exit_code"], 0, "response: {body}");
-        // The advanced base landed in the worktree.
-        assert!(work.join("b.txt").exists());
-    }
-
-    #[tokio::test]
-    async fn git_update_branch_reports_conflicts_and_leaves_merge_open() {
-        let (td, work) = setup_origin_and_clone();
-        // Make feat conflict with main: both edit a.txt.
-        std::fs::write(work.join("a.txt"), b"feat version\n").unwrap();
-        run_git(&work, &["add", "-A"]);
-        run_git(&work, &["commit", "-q", "-m", "feat edits a"]);
-        run_git(&work, &["checkout", "-q", "main"]);
-        std::fs::write(work.join("a.txt"), b"main version\n").unwrap();
-        run_git(&work, &["add", "-A"]);
-        run_git(&work, &["commit", "-q", "-m", "main edits a"]);
-        run_git(&work, &["push", "-q", "origin", "main"]);
-        run_git(&work, &["checkout", "-q", "feat"]);
-
-        let rpc_dir = td.path().join("rpc");
-        ensure_mailbox(&rpc_dir).unwrap();
-        write_request(
-            &rpc_dir.join("requests"),
-            "u2.json",
-            r#"{"id":"u2","op":"git_update_branch"}"#,
-        );
-
-        let cx = OpContext { cwd: work.clone(), base_branch: "main".to_string() };
-        process_pending(&rpc_dir, &cx).await;
-
-        let body = std::fs::read_to_string(rpc_dir.join("responses/u2.json")).unwrap();
-        let v: Value = serde_json::from_str(&body).unwrap();
-        // Faithful command report: the op ran, the merge exited non-zero.
-        assert_eq!(v["ok"], true, "response: {body}");
-        assert_ne!(v["exit_code"], 0, "response: {body}");
-        assert!(v["stdout"].as_str().unwrap().contains("CONFLICT"));
-        // Merge left open so the agent can resolve + git_commit.
-        let status = std::process::Command::new("git")
-            .current_dir(&work)
-            .args(["status", "--porcelain=v1"])
-            .output()
-            .unwrap();
-        assert!(String::from_utf8_lossy(&status.stdout).contains("UU a.txt"));
-    }
-
-    #[tokio::test]
-    async fn git_commit_rejects_empty_message() {
-        let td = tempfile::tempdir().unwrap();
-        let rpc_dir = td.path().join("rpc");
-        ensure_mailbox(&rpc_dir).unwrap();
-        write_request(
-            &rpc_dir.join("requests"),
-            "c2.json",
-            r#"{"id":"c2","op":"git_commit","args":{"message":"  "}}"#,
-        );
-
-        process_pending(&rpc_dir, &ctx(td.path())).await;
-
-        let body = std::fs::read_to_string(rpc_dir.join("responses/c2.json")).unwrap();
-        let v: Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(v["ok"], false);
-        assert!(v["error"].as_str().unwrap().contains("message"));
     }
 }

--- a/src-tauri/src/rpc/git.rs
+++ b/src-tauri/src/rpc/git.rs
@@ -48,6 +48,7 @@ impl GitDispatcher {
             _ => {}
         }
         let resp = match op {
+            "echo" => self.echo(id, args).await,
             "ping" => Response::ok(id, 0, "pong".to_string(), String::new()),
             "git_status" => {
                 run_command(
@@ -63,6 +64,14 @@ impl GitDispatcher {
             other => Response::err(id, format!("unknown op: {other}")),
         };
         (resp, Vec::new())
+    }
+
+    async fn echo(&self, id: &str, args: &Value) -> Response {
+        let message = args.get("message").and_then(|v| v.as_str()).unwrap_or("");
+        if message.is_empty() {
+            return Response::err(id, "echo requires a non-empty `message` arg");
+        }
+        Response::ok(id, 0, message.to_string(), String::new())
     }
 
     async fn git_commit(&self, id: &str, args: &Value) -> Response {
@@ -293,6 +302,27 @@ mod tests {
         assert_eq!(v["id"], "req-4");
         assert_eq!(v["ok"], true);
         assert!(v["exit_code"].is_number());
+    }
+
+    #[tokio::test]
+    async fn echo_round_trips_free_text() {
+        let td = tempfile::tempdir().unwrap();
+        let rpc_dir = td.path().join(".quorum-rpc");
+        ensure_mailbox(&rpc_dir).unwrap();
+        write_request(
+            &rpc_dir.join("requests"),
+            "req-echo.json",
+            r#"{"id":"req-echo","op":"echo","args":{"message":"hello from the agent"}}"#,
+        );
+
+        let dispatcher = dispatcher(td.path());
+        process_pending(&rpc_dir, &dispatcher).await;
+
+        let body = std::fs::read_to_string(rpc_dir.join("responses/req-echo.json")).unwrap();
+        let v: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["id"], "req-echo");
+        assert_eq!(v["ok"], true);
+        assert_eq!(v["stdout"], "hello from the agent");
     }
 
     #[tokio::test]

--- a/src-tauri/src/rpc/git.rs
+++ b/src-tauri/src/rpc/git.rs
@@ -1,0 +1,570 @@
+//! Git-specific RPC dispatcher layered on top of the generic mailbox transport.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tokio::process::Command;
+
+use super::{Response, RpcDispatcher, RpcEvent, RpcFuture};
+
+/// App-side ceiling on a single op. A hung command surfaces as an error
+/// response rather than blocking the watcher forever. The agent runs its own
+/// (shorter) poll timeout independently — see the instruction block.
+const OP_TIMEOUT: Duration = Duration::from_secs(120);
+
+pub const EVENT_BRANCH_CREATED: &str = "git.branch_created";
+pub const EVENT_PR_OPENED: &str = "git.pr_opened";
+
+#[derive(Clone)]
+pub struct GitDispatcher {
+    cwd: PathBuf,
+    base_branch: String,
+}
+
+impl GitDispatcher {
+    pub fn new(cwd: PathBuf, base_branch: String) -> Self {
+        Self { cwd, base_branch }
+    }
+}
+
+impl RpcDispatcher for GitDispatcher {
+    fn dispatch<'a>(
+        &'a self,
+        id: &'a str,
+        op: &'a str,
+        args: &'a Value,
+    ) -> RpcFuture<'a, (Response, Vec<RpcEvent>)> {
+        Box::pin(async move { self.dispatch_inner(id, op, args).await })
+    }
+}
+
+impl GitDispatcher {
+    async fn dispatch_inner(&self, id: &str, op: &str, args: &Value) -> (Response, Vec<RpcEvent>) {
+        match op {
+            "open_pr" => return self.open_pr(id, args).await,
+            "git_push" => return self.git_push(id, args).await,
+            _ => {}
+        }
+        let resp = match op {
+            "ping" => Response::ok(id, 0, "pong".to_string(), String::new()),
+            "git_status" => {
+                run_command(
+                    id,
+                    &self.cwd,
+                    "git",
+                    &["status", "--porcelain=v1", "--branch"],
+                )
+                .await
+            }
+            "git_commit" => self.git_commit(id, args).await,
+            "git_update_branch" => self.git_update_branch(id).await,
+            other => Response::err(id, format!("unknown op: {other}")),
+        };
+        (resp, Vec::new())
+    }
+
+    async fn git_commit(&self, id: &str, args: &Value) -> Response {
+        let message = args.get("message").and_then(|v| v.as_str()).unwrap_or("");
+        if message.trim().is_empty() {
+            return Response::err(id, "git_commit requires a non-empty `message` arg");
+        }
+        match crate::git::commit_all(&self.cwd, message).await {
+            Ok(()) => Response::ok(id, 0, "committed".to_string(), String::new()),
+            Err(e) => Response::err(id, e.to_string()),
+        }
+    }
+
+    async fn open_pr(&self, id: &str, args: &Value) -> (Response, Vec<RpcEvent>) {
+        let title = args.get("title").and_then(|v| v.as_str()).unwrap_or("");
+        let body = args.get("body").and_then(|v| v.as_str()).unwrap_or("");
+        let requested = arg_branch(args);
+
+        let current = match crate::git::current_branch(&self.cwd).await {
+            Ok(b) => b,
+            Err(e) => return (Response::err(id, format!("open_pr: {e}")), Vec::new()),
+        };
+
+        let mut effects = Vec::new();
+        let branch = match (current, requested) {
+            (Some(cur), None) => cur,
+            (Some(cur), Some(req)) if req == cur => cur,
+            (Some(_), Some(req)) => match materialize_branch(&self.cwd, &req).await {
+                Ok(name) => {
+                    effects.push(RpcEvent::named(
+                        EVENT_BRANCH_CREATED,
+                        json!({ "branch": name }),
+                    ));
+                    name
+                }
+                Err(e) => return (Response::err(id, format!("open_pr: {e}")), effects),
+            },
+            (None, req) => {
+                let desired = req.unwrap_or_else(|| fallback_branch(title));
+                match materialize_branch(&self.cwd, &desired).await {
+                    Ok(name) => {
+                        effects.push(RpcEvent::named(
+                            EVENT_BRANCH_CREATED,
+                            json!({ "branch": name }),
+                        ));
+                        name
+                    }
+                    Err(e) => return (Response::err(id, format!("open_pr: {e}")), effects),
+                }
+            }
+        };
+
+        if let Err(e) = crate::git::push(&self.cwd, &branch).await {
+            return (
+                Response::err(id, format!("open_pr push failed: {e}")),
+                effects,
+            );
+        }
+        match crate::gh::pr_create(&self.cwd, title, body, &self.base_branch).await {
+            Ok(pr) => {
+                crate::telemetry::track("pr_opened", json!({ "source": "agent_rpc" }));
+                effects.push(RpcEvent::named(
+                    EVENT_PR_OPENED,
+                    json!({ "number": pr.number }),
+                ));
+                (Response::ok(id, 0, pr.url, String::new()), effects)
+            }
+            Err(e) => (Response::err(id, format!("open_pr: {e}")), effects),
+        }
+    }
+
+    async fn git_push(&self, id: &str, args: &Value) -> (Response, Vec<RpcEvent>) {
+        let current = match crate::git::current_branch(&self.cwd).await {
+            Ok(b) => b,
+            Err(e) => return (Response::err(id, format!("git_push: {e}")), Vec::new()),
+        };
+
+        let mut effects = Vec::new();
+        let branch = match current {
+            Some(cur) => cur,
+            None => match arg_branch(args) {
+                Some(req) => match materialize_branch(&self.cwd, &req).await {
+                    Ok(name) => {
+                        effects.push(RpcEvent::named(
+                            EVENT_BRANCH_CREATED,
+                            json!({ "branch": name }),
+                        ));
+                        name
+                    }
+                    Err(e) => return (Response::err(id, format!("git_push: {e}")), effects),
+                },
+                None => {
+                    return (
+                        Response::err(
+                            id,
+                            "git_push: HEAD is detached — pass `args.branch` (e.g. \"fix/…\") to create the branch",
+                        ),
+                        effects,
+                    )
+                }
+            },
+        };
+
+        match crate::git::push(&self.cwd, &branch).await {
+            Ok(summary) => (Response::ok(id, 0, summary, String::new()), effects),
+            Err(e) => (Response::err(id, e.to_string()), effects),
+        }
+    }
+
+    async fn git_update_branch(&self, id: &str) -> Response {
+        let fetch = run_command(
+            id,
+            &self.cwd,
+            "git",
+            &["fetch", "origin", &self.base_branch],
+        )
+        .await;
+        if !fetch.ok || fetch.exit_code != Some(0) {
+            return fetch;
+        }
+        let target = format!("origin/{}", self.base_branch);
+        run_command(id, &self.cwd, "git", &["merge", "--no-edit", &target]).await
+    }
+}
+
+fn arg_branch(args: &Value) -> Option<String> {
+    args.get("branch")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+async fn materialize_branch(worktree: &Path, desired: &str) -> std::result::Result<String, String> {
+    crate::git::checkout_new_unique_branch(worktree, desired)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+fn fallback_branch(title: &str) -> String {
+    let mut slug = String::new();
+    let mut prev_dash = false;
+    for ch in title.chars() {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch.to_ascii_lowercase());
+            prev_dash = false;
+        } else if !prev_dash {
+            slug.push('-');
+            prev_dash = true;
+        }
+    }
+    let slug = slug.trim_matches('-');
+    if slug.is_empty() {
+        "chore/update".to_string()
+    } else {
+        format!("chore/{slug}")
+    }
+}
+
+async fn run_command(id: &str, cwd: &Path, program: &str, args: &[&str]) -> Response {
+    let mut cmd = Command::new(program);
+    cmd.args(args)
+        .current_dir(cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+
+    let child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => return Response::err(id, format!("spawn {program}: {e}")),
+    };
+
+    match tokio::time::timeout(OP_TIMEOUT, child.wait_with_output()).await {
+        Ok(Ok(out)) => Response::ok(
+            id,
+            out.status.code().unwrap_or(-1),
+            String::from_utf8_lossy(&out.stdout).into_owned(),
+            String::from_utf8_lossy(&out.stderr).into_owned(),
+        ),
+        Ok(Err(e)) => Response::err(id, format!("run {program}: {e}")),
+        Err(_) => Response::err(id, format!("op timed out after {}s", OP_TIMEOUT.as_secs())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rpc::{ensure_mailbox, process_pending};
+
+    fn write_request(requests: &Path, name: &str, body: &str) {
+        std::fs::write(requests.join(name), body).unwrap();
+    }
+
+    fn run_git(repo: &Path, args: &[&str]) {
+        let out = std::process::Command::new("git")
+            .current_dir(repo)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    fn dispatcher(cwd: &Path) -> GitDispatcher {
+        GitDispatcher::new(cwd.to_path_buf(), "main".to_string())
+    }
+
+    #[tokio::test]
+    async fn git_status_runs_a_real_command() {
+        let td = tempfile::tempdir().unwrap();
+        let rpc_dir = td.path().join(".quorum-rpc");
+        ensure_mailbox(&rpc_dir).unwrap();
+        write_request(
+            &rpc_dir.join("requests"),
+            "req-4.json",
+            r#"{"id":"req-4","op":"git_status"}"#,
+        );
+
+        let dispatcher = dispatcher(td.path());
+        process_pending(&rpc_dir, &dispatcher).await;
+
+        let body = std::fs::read_to_string(rpc_dir.join("responses/req-4.json")).unwrap();
+        let v: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["id"], "req-4");
+        assert_eq!(v["ok"], true);
+        assert!(v["exit_code"].is_number());
+    }
+
+    #[tokio::test]
+    async fn git_commit_stages_and_commits_the_worktree() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        run_git(&repo, &["init", "-q"]);
+        run_git(&repo, &["config", "user.email", "t@example.com"]);
+        run_git(&repo, &["config", "user.name", "Tester"]);
+        std::fs::write(repo.join("new.txt"), b"hello").unwrap();
+
+        let rpc_dir = td.path().join("rpc");
+        ensure_mailbox(&rpc_dir).unwrap();
+        write_request(
+            &rpc_dir.join("requests"),
+            "c1.json",
+            r#"{"id":"c1","op":"git_commit","args":{"message":"add new.txt"}}"#,
+        );
+
+        let dispatcher = dispatcher(&repo);
+        process_pending(&rpc_dir, &dispatcher).await;
+
+        let body = std::fs::read_to_string(rpc_dir.join("responses/c1.json")).unwrap();
+        let v: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["ok"], true, "response: {body}");
+
+        let log = std::process::Command::new("git")
+            .current_dir(&repo)
+            .args(["log", "--oneline"])
+            .output()
+            .unwrap();
+        assert!(String::from_utf8_lossy(&log.stdout).contains("add new.txt"));
+    }
+
+    #[tokio::test]
+    async fn git_push_without_remote_reports_error() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        run_git(&repo, &["init", "-q", "-b", "main"]);
+        run_git(&repo, &["config", "user.email", "t@example.com"]);
+        run_git(&repo, &["config", "user.name", "Tester"]);
+        std::fs::write(repo.join("a.txt"), b"x").unwrap();
+        run_git(&repo, &["add", "-A"]);
+        run_git(&repo, &["commit", "-q", "-m", "init"]);
+
+        let rpc_dir = td.path().join("rpc");
+        ensure_mailbox(&rpc_dir).unwrap();
+        write_request(
+            &rpc_dir.join("requests"),
+            "p1.json",
+            r#"{"id":"p1","op":"git_push"}"#,
+        );
+
+        let dispatcher = dispatcher(&repo);
+        process_pending(&rpc_dir, &dispatcher).await;
+
+        let body = std::fs::read_to_string(rpc_dir.join("responses/p1.json")).unwrap();
+        let v: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["ok"], false);
+        let err = v["error"].as_str().unwrap();
+        assert!(!err.contains("unknown op"), "got: {err}");
+        assert!(err.contains("push failed"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn git_push_detached_without_branch_arg_errors() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        run_git(&repo, &["init", "-q", "-b", "main"]);
+        run_git(&repo, &["config", "user.email", "t@example.com"]);
+        run_git(&repo, &["config", "user.name", "Tester"]);
+        std::fs::write(repo.join("a.txt"), b"x").unwrap();
+        run_git(&repo, &["add", "-A"]);
+        run_git(&repo, &["commit", "-q", "-m", "init"]);
+        run_git(&repo, &["checkout", "-q", "--detach"]);
+
+        let rpc_dir = td.path().join("rpc");
+        ensure_mailbox(&rpc_dir).unwrap();
+        write_request(
+            &rpc_dir.join("requests"),
+            "p1.json",
+            r#"{"id":"p1","op":"git_push"}"#,
+        );
+
+        let dispatcher = dispatcher(&repo);
+        process_pending(&rpc_dir, &dispatcher).await;
+
+        let body = std::fs::read_to_string(rpc_dir.join("responses/p1.json")).unwrap();
+        let v: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["ok"], false);
+        assert!(
+            v["error"].as_str().unwrap().contains("args.branch"),
+            "got: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn git_push_detached_materializes_named_branch() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        run_git(&repo, &["init", "-q", "-b", "main"]);
+        run_git(&repo, &["config", "user.email", "t@example.com"]);
+        run_git(&repo, &["config", "user.name", "Tester"]);
+        std::fs::write(repo.join("a.txt"), b"x").unwrap();
+        run_git(&repo, &["add", "-A"]);
+        run_git(&repo, &["commit", "-q", "-m", "init"]);
+        run_git(&repo, &["checkout", "-q", "--detach"]);
+
+        let rpc_dir = td.path().join("rpc");
+        ensure_mailbox(&rpc_dir).unwrap();
+        write_request(
+            &rpc_dir.join("requests"),
+            "p1.json",
+            r#"{"id":"p1","op":"git_push","args":{"branch":"fix/thing"}}"#,
+        );
+
+        let dispatcher = dispatcher(&repo);
+        let effects = process_pending(&rpc_dir, &dispatcher).await;
+
+        let head = std::process::Command::new("git")
+            .current_dir(&repo)
+            .args(["rev-parse", "--abbrev-ref", "HEAD"])
+            .output()
+            .unwrap();
+        assert_eq!(String::from_utf8_lossy(&head.stdout).trim(), "fix/thing");
+        assert!(
+            effects.iter().any(|e| matches!(
+                e,
+                RpcEvent::Named { name, payload }
+                    if name == EVENT_BRANCH_CREATED && payload["branch"] == "fix/thing"
+            )),
+            "expected a branch-created event, got: {effects:?}"
+        );
+    }
+
+    #[test]
+    fn fallback_branch_slugifies_title() {
+        assert_eq!(
+            fallback_branch("Fix the Login Crash!"),
+            "chore/fix-the-login-crash"
+        );
+        assert_eq!(
+            fallback_branch("  Add   CSV export  "),
+            "chore/add-csv-export"
+        );
+        assert_eq!(fallback_branch(""), "chore/update");
+        assert_eq!(fallback_branch("!!!"), "chore/update");
+    }
+
+    fn setup_origin_and_clone() -> (tempfile::TempDir, std::path::PathBuf) {
+        let td = tempfile::tempdir().unwrap();
+        let origin = td.path().join("origin.git");
+        std::fs::create_dir_all(&origin).unwrap();
+        run_git(&origin, &["init", "-q", "--bare", "-b", "main"]);
+
+        let work = td.path().join("work");
+        let out = std::process::Command::new("git")
+            .current_dir(td.path())
+            .args(["clone", "-q", origin.to_str().unwrap(), "work"])
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        run_git(&work, &["config", "user.email", "t@example.com"]);
+        run_git(&work, &["config", "user.name", "Tester"]);
+        run_git(&work, &["checkout", "-q", "-b", "main"]);
+        std::fs::write(work.join("a.txt"), b"base\n").unwrap();
+        run_git(&work, &["add", "-A"]);
+        run_git(&work, &["commit", "-q", "-m", "init"]);
+        run_git(&work, &["push", "-q", "-u", "origin", "main"]);
+
+        run_git(&work, &["checkout", "-q", "-b", "feat"]);
+        std::fs::write(work.join("feat.txt"), b"feature\n").unwrap();
+        run_git(&work, &["add", "-A"]);
+        run_git(&work, &["commit", "-q", "-m", "feat work"]);
+        run_git(&work, &["checkout", "-q", "main"]);
+        std::fs::write(work.join("b.txt"), b"advance\n").unwrap();
+        run_git(&work, &["add", "-A"]);
+        run_git(&work, &["commit", "-q", "-m", "main advances"]);
+        run_git(&work, &["push", "-q", "origin", "main"]);
+        run_git(&work, &["checkout", "-q", "feat"]);
+        (td, work)
+    }
+
+    #[tokio::test]
+    async fn git_update_branch_merges_the_advanced_base() {
+        let (td, work) = setup_origin_and_clone();
+        let rpc_dir = td.path().join("rpc");
+        ensure_mailbox(&rpc_dir).unwrap();
+        write_request(
+            &rpc_dir.join("requests"),
+            "u1.json",
+            r#"{"id":"u1","op":"git_update_branch"}"#,
+        );
+
+        let dispatcher = dispatcher(&work);
+        process_pending(&rpc_dir, &dispatcher).await;
+
+        let body = std::fs::read_to_string(rpc_dir.join("responses/u1.json")).unwrap();
+        let v: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["ok"], true, "response: {body}");
+        assert_eq!(v["exit_code"], 0, "response: {body}");
+        assert!(work.join("b.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn git_update_branch_reports_conflicts_and_leaves_merge_open() {
+        let (td, work) = setup_origin_and_clone();
+        std::fs::write(work.join("a.txt"), b"feat version\n").unwrap();
+        run_git(&work, &["add", "-A"]);
+        run_git(&work, &["commit", "-q", "-m", "feat edits a"]);
+        run_git(&work, &["checkout", "-q", "main"]);
+        std::fs::write(work.join("a.txt"), b"main version\n").unwrap();
+        run_git(&work, &["add", "-A"]);
+        run_git(&work, &["commit", "-q", "-m", "main edits a"]);
+        run_git(&work, &["push", "-q", "origin", "main"]);
+        run_git(&work, &["checkout", "-q", "feat"]);
+
+        let rpc_dir = td.path().join("rpc");
+        ensure_mailbox(&rpc_dir).unwrap();
+        write_request(
+            &rpc_dir.join("requests"),
+            "u2.json",
+            r#"{"id":"u2","op":"git_update_branch"}"#,
+        );
+
+        let dispatcher = dispatcher(&work);
+        process_pending(&rpc_dir, &dispatcher).await;
+
+        let body = std::fs::read_to_string(rpc_dir.join("responses/u2.json")).unwrap();
+        let v: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["ok"], true, "response: {body}");
+        assert_ne!(v["exit_code"], 0, "response: {body}");
+        assert!(v["stdout"].as_str().unwrap().contains("CONFLICT"));
+        let status = std::process::Command::new("git")
+            .current_dir(&work)
+            .args(["status", "--porcelain=v1"])
+            .output()
+            .unwrap();
+        assert!(String::from_utf8_lossy(&status.stdout).contains("UU a.txt"));
+    }
+
+    #[tokio::test]
+    async fn git_commit_rejects_empty_message() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        run_git(&repo, &["init", "-q", "-b", "main"]);
+        run_git(&repo, &["config", "user.email", "t@example.com"]);
+        run_git(&repo, &["config", "user.name", "Tester"]);
+
+        let rpc_dir = td.path().join("rpc");
+        ensure_mailbox(&rpc_dir).unwrap();
+        write_request(
+            &rpc_dir.join("requests"),
+            "c2.json",
+            r#"{"id":"c2","op":"git_commit","args":{"message":"  "}}"#,
+        );
+
+        let dispatcher = dispatcher(&repo);
+        process_pending(&rpc_dir, &dispatcher).await;
+
+        let body = std::fs::read_to_string(rpc_dir.join("responses/c2.json")).unwrap();
+        let v: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["ok"], false);
+        assert!(v["error"].as_str().unwrap().contains("message"));
+    }
+}

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -674,12 +674,16 @@ impl Supervisor {
         let rpc_dir = rpc::mailbox_dir(agent_id)?;
         rpc::ensure_mailbox(&rpc_dir)?;
         let watcher_cwd = cwd.clone();
-        // Base branch for the `open_pr` op — the branch the agent was forked
-        // from, same default the manual PR action uses.
+        // Base branch for the git dispatcher — the branch the agent was
+        // forked from, same default the manual PR action uses.
         let base_branch = primary
             .parent_branch
             .clone()
             .unwrap_or_else(|| "main".to_string());
+        let rpc_dispatcher = Arc::new(rpc::git::GitDispatcher::new(
+            watcher_cwd.clone(),
+            base_branch.clone(),
+        ));
 
         // Claude only writes a session file once the first turn lands.
         // If task is still empty (no first user message has ever been
@@ -827,11 +831,14 @@ impl Supervisor {
 
         // Watch this agent's RPC mailbox for the life of this generation,
         // executing allowlisted ops and writing responses back.
-        let op_ctx = rpc::OpContext {
-            cwd: watcher_cwd,
-            base_branch,
-        };
-        spawn_rpc_watcher(self.clone(), app, agent_id_str, op_ctx, rpc_dir, my_gen);
+        spawn_rpc_watcher(
+            self.clone(),
+            app,
+            agent_id_str,
+            rpc_dispatcher,
+            rpc_dir,
+            my_gen,
+        );
 
         Ok(())
     }
@@ -2221,7 +2228,7 @@ fn spawn_rpc_watcher(
     sup: Arc<Supervisor>,
     app: AppHandle,
     agent_id: String,
-    ctx: rpc::OpContext,
+    dispatcher: Arc<dyn rpc::RpcDispatcher>,
     rpc_dir: PathBuf,
     gen: u64,
 ) {
@@ -2239,21 +2246,26 @@ fn spawn_rpc_watcher(
                 return;
             }
 
-            let effects = rpc::process_pending(&rpc_dir, &ctx).await;
-            for effect in effects {
-                match effect {
-                    // The agent's branch was materialized at first push (the
-                    // worktree had been detached). Persist the name against the
-                    // primary repo — the worktree the push ops run in — and tell
-                    // the panel a branch now exists. Unconditional write: a
-                    // second PR cuts a fresh branch, so the name can change.
-                    rpc::RpcEffect::BranchCreated { branch } => {
+            let events = rpc::process_pending(&rpc_dir, dispatcher.as_ref()).await;
+            for event in events {
+                match event {
+                    rpc::RpcEvent::Named { name, payload }
+                        if name == rpc::git::EVENT_BRANCH_CREATED =>
+                    {
+                        let Some(branch) = payload.get("branch").and_then(|v| v.as_str()) else {
+                            tracing::warn!(
+                                event = %name,
+                                payload = %payload,
+                                "git dispatcher emitted branch event without branch"
+                            );
+                            continue;
+                        };
                         if let Ok(record) = sup.workspace.agent(&agent_id) {
                             if let Some(repo) = record.repos.first() {
                                 if let Err(e) = sup.workspace.set_repo_branch(
                                     &agent_id,
                                     &repo.subdir,
-                                    &branch,
+                                    branch,
                                 ) {
                                     tracing::warn!(
                                         error = %e,
@@ -2267,18 +2279,24 @@ fn spawn_rpc_watcher(
                                         AgentBranchPayload {
                                             agent_id: agent_id.clone(),
                                             subdir: repo.subdir.clone(),
-                                            branch: branch.clone(),
+                                            branch: branch.to_string(),
                                         },
                                     );
                                 }
                             }
                         }
                     }
-                    // The agent opened a PR via the `open_pr` op. Bind it to the
-                    // agent by number so PR-state lookups stop depending on the
-                    // (recyclable) branch name, then refresh the panel. The PR
-                    // belongs to the primary repo — the worktree `open_pr` runs in.
-                    rpc::RpcEffect::PrOpened { number } => {
+                    rpc::RpcEvent::Named { name, payload }
+                        if name == rpc::git::EVENT_PR_OPENED =>
+                    {
+                        let Some(number) = payload.get("number").and_then(|v| v.as_u64()) else {
+                            tracing::warn!(
+                                event = %name,
+                                payload = %payload,
+                                "git dispatcher emitted PR event without number"
+                            );
+                            continue;
+                        };
                         if let Ok(record) = sup.workspace.agent(&agent_id) {
                             if let Some(repo) = record.repos.first() {
                                 if let Err(e) = sup.workspace.set_repo_pr_number(
@@ -2296,6 +2314,9 @@ fn spawn_rpc_watcher(
                             }
                         }
                         sup.fetch_and_emit_pr_state(app.clone(), agent_id.clone());
+                    }
+                    rpc::RpcEvent::Named { name, payload } => {
+                        tracing::debug!(event = %name, payload = %payload, "rpc: unhandled event");
                     }
                 }
             }


### PR DESCRIPTION
Decouple the file-mailbox RPC transport from git-specific behavior.

- Extract a generic dispatcher/event layer in `rpc.rs`
- Move git operations behind `rpc::git::GitDispatcher`
- Update supervisor handling and protocol docs to match the new shape

Validation:
- `cargo check -q --lib`
- `cargo test -q rpc::tests --lib`
- `cargo test -q rpc::git::tests --lib`