### PR TITLE
fix: keep agent status live during long tool calls and across focus

### DIFF
--- a/src-tauri/src/activity.rs
+++ b/src-tauri/src/activity.rs
@@ -9,6 +9,7 @@
 //! shapes. Adding gemini / codex / etc. means writing new impls
 //! against this trait, not touching the supervisor.
 
+use std::collections::HashSet;
 use std::time::{Duration, Instant};
 
 use serde_json::Value;
@@ -53,6 +54,14 @@ pub struct ManagedActivity {
     explicit_turn_end: bool,
     /// Returns true for the event that marks the end of a turn.
     is_turn_end: fn(&Value) -> bool,
+    /// Whether to track outstanding tool calls (Claude-shaped streams only).
+    /// A long, quiet tool call (a build, a test run) emits no events while it
+    /// runs, so the silence backstop would otherwise wrongly flag the turn as
+    /// ended mid-tool. While a tool is outstanding we suppress that backstop.
+    track_tools: bool,
+    /// `tool_use` ids seen without a matching `tool_result` yet. Non-empty
+    /// means a tool is mid-flight, so silence is expected, not turn-end.
+    outstanding_tools: HashSet<String>,
 }
 
 impl ManagedActivity {
@@ -61,6 +70,8 @@ impl ManagedActivity {
             last_event_at: None,
             explicit_turn_end: false,
             is_turn_end,
+            track_tools: false,
+            outstanding_tools: HashSet::new(),
         }
     }
 
@@ -68,7 +79,9 @@ impl ManagedActivity {
     /// `result` event. Cursor emits Claude-shaped stream-json, so it shares
     /// this detector.
     pub fn claude() -> Self {
-        Self::new(|event| event.get("type").and_then(|v| v.as_str()) == Some("result"))
+        let mut a = Self::new(|event| event.get("type").and_then(|v| v.as_str()) == Some("result"));
+        a.track_tools = true;
+        a
     }
 
     /// Codex (`codex exec --json`) ends a turn with `turn.completed`. (The
@@ -107,11 +120,19 @@ impl Activity for ManagedActivity {
         if (self.is_turn_end)(event) {
             self.explicit_turn_end = true;
         }
+        if self.track_tools {
+            self.track_tool_lifecycle(event);
+        }
     }
 
     fn turn_ended(&self) -> bool {
         if self.explicit_turn_end {
             return true;
+        }
+        // A tool call is in flight (e.g. a long build/test). It emits no events
+        // while it runs, so the silence below is expected — not a finished turn.
+        if !self.outstanding_tools.is_empty() {
+            return false;
         }
         self.last_event_at
             .map(|t| t.elapsed() >= MANAGED_SILENCE_BACKSTOP)
@@ -121,6 +142,39 @@ impl Activity for ManagedActivity {
     fn reset_for_new_turn(&mut self) {
         self.last_event_at = Some(Instant::now());
         self.explicit_turn_end = false;
+        self.outstanding_tools.clear();
+    }
+}
+
+impl ManagedActivity {
+    /// Track Claude-shaped tool calls: an `assistant` message's `tool_use`
+    /// blocks open a tool; the matching `user` message's `tool_result` blocks
+    /// close it. Used only to know whether silence is "waiting on a tool" vs
+    /// "turn done".
+    fn track_tool_lifecycle(&mut self, event: &Value) {
+        let Some(kind) = event.get("type").and_then(|v| v.as_str()) else {
+            return;
+        };
+        let blocks = event
+            .get("message")
+            .and_then(|m| m.get("content"))
+            .and_then(|c| c.as_array());
+        let Some(blocks) = blocks else { return };
+        for block in blocks {
+            match (kind, block.get("type").and_then(|v| v.as_str())) {
+                ("assistant", Some("tool_use")) => {
+                    if let Some(id) = block.get("id").and_then(|v| v.as_str()) {
+                        self.outstanding_tools.insert(id.to_string());
+                    }
+                }
+                ("user", Some("tool_result")) => {
+                    if let Some(id) = block.get("tool_use_id").and_then(|v| v.as_str()) {
+                        self.outstanding_tools.remove(id);
+                    }
+                }
+                _ => {}
+            }
+        }
     }
 }
 
@@ -177,6 +231,63 @@ mod tests {
         assert!(a.turn_ended());
         a.reset_for_new_turn();
         assert!(!a.turn_ended());
+    }
+
+    #[test]
+    fn managed_suppresses_silence_while_tool_outstanding() {
+        let mut a = ManagedActivity::claude();
+        // Assistant opens a tool call; no result yet.
+        a.observe_event(&serde_json::json!({
+            "type": "assistant",
+            "message": {"content": [{"type": "tool_use", "id": "toolu_1", "name": "Bash"}]}
+        }));
+        // Simulate a long, quiet tool run well past the silence backstop.
+        a.last_event_at = Some(Instant::now() - MANAGED_SILENCE_BACKSTOP - Duration::from_secs(5));
+        // Tool still outstanding → silence must NOT be read as turn-end.
+        assert!(!a.turn_ended());
+        // Tool result arrives → tool closed; silence now genuinely means idle.
+        a.observe_event(&serde_json::json!({
+            "type": "user",
+            "message": {"content": [{"type": "tool_result", "tool_use_id": "toolu_1"}]}
+        }));
+        a.last_event_at = Some(Instant::now() - MANAGED_SILENCE_BACKSTOP - Duration::from_secs(5));
+        assert!(a.turn_ended());
+    }
+
+    #[test]
+    fn managed_result_ends_even_with_outstanding_tool() {
+        // An explicit turn-end always wins over outstanding-tool suppression.
+        let mut a = ManagedActivity::claude();
+        a.observe_event(&serde_json::json!({
+            "type": "assistant",
+            "message": {"content": [{"type": "tool_use", "id": "toolu_1"}]}
+        }));
+        a.observe_event(&serde_json::json!({"type": "result", "subtype": "success"}));
+        assert!(a.turn_ended());
+    }
+
+    #[test]
+    fn managed_reset_clears_outstanding_tools() {
+        let mut a = ManagedActivity::claude();
+        a.observe_event(&serde_json::json!({
+            "type": "assistant",
+            "message": {"content": [{"type": "tool_use", "id": "toolu_1"}]}
+        }));
+        assert!(!a.outstanding_tools.is_empty());
+        a.reset_for_new_turn();
+        assert!(a.outstanding_tools.is_empty());
+    }
+
+    #[test]
+    fn codex_does_not_track_tools() {
+        // Only the Claude-shaped detector tracks tool lifecycle; others ignore
+        // the (foreign-shaped) blocks entirely.
+        let mut a = ManagedActivity::codex();
+        a.observe_event(&serde_json::json!({
+            "type": "assistant",
+            "message": {"content": [{"type": "tool_use", "id": "x"}]}
+        }));
+        assert!(a.outstanding_tools.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -181,9 +181,16 @@ impl Supervisor {
         status: AgentStatus,
         last_error: Option<String>,
     ) {
-        self.statuses
+        let prev = self
+            .statuses
             .lock()
             .insert(agent_id.to_string(), status.clone());
+        tracing::debug!(
+            agent_id = %agent_id,
+            from = ?prev,
+            to = ?status,
+            "agent status transition"
+        );
         // Persist durable side-effects: Error stores last_error; Spawning/Running
         // clear stale stopped/error; Idle persists nothing.
         match status {
@@ -1946,12 +1953,19 @@ fn spawn_managed_agent(
     Agent::spawn_managed(
         spec,
         move |event| {
+            let mut still_active = false;
             if let Some(activity) = sup_for_event
                 .activities
                 .lock()
                 .get_mut(&id_for_event)
             {
                 activity.observe_event(&event);
+                still_active = !activity.turn_ended();
+            }
+            // An event that isn't the turn-end means the agent is working;
+            // recover it if a premature backstop wrongly parked it at Idle.
+            if still_active {
+                note_stream_activity(&sup_for_event, &app_for_event, &id_for_event);
             }
 
             if let Err(e) = app_for_event.emit(
@@ -1998,8 +2012,15 @@ fn spawn_per_turn_agent(
     let sup_for_exit = sup;
 
     let on_event = move |event: Value| {
+        let mut still_active = false;
         if let Some(activity) = sup_for_event.activities.lock().get_mut(&id_for_event) {
             activity.observe_event(&event);
+            still_active = !activity.turn_ended();
+        }
+        // An event that isn't the turn-end means the agent is working; recover
+        // it if a premature backstop wrongly parked it at Idle.
+        if still_active {
+            note_stream_activity(&sup_for_event, &app_for_event, &id_for_event);
         }
         if let Err(e) = app_for_event.emit(
             "agent:event",
@@ -2352,6 +2373,20 @@ fn transition_active(
             sup.trigger_session_sync(app.clone(), agent_id.to_string());
             drain_pending_bin_respawn(sup, app, agent_id);
         }
+    }
+}
+
+/// An agent that's still streaming events is, by definition, still working —
+/// so recover it if a premature turn-end (the silence backstop firing during a
+/// long quiet tool call) wrongly parked it at `Idle`. Only acts on a live
+/// `Idle`: a fresh user turn already sets `Running`, the turn-end event itself
+/// is excluded by the caller, and no events arrive once a turn truly ends — so
+/// this never fights a legitimate idle. The tool-aware backstop
+/// (`ManagedActivity`) prevents most false idles for Claude; this is the
+/// provider-agnostic safety net for the rest.
+fn note_stream_activity(sup: &Supervisor, app: &AppHandle, agent_id: &str) {
+    if matches!(sup.live_status(agent_id), Some(AgentStatus::Idle)) {
+        sup.set_status(app, agent_id, AgentStatus::Running, None);
     }
 }
 

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -1953,19 +1953,12 @@ fn spawn_managed_agent(
     Agent::spawn_managed(
         spec,
         move |event| {
-            let mut still_active = false;
             if let Some(activity) = sup_for_event
                 .activities
                 .lock()
                 .get_mut(&id_for_event)
             {
                 activity.observe_event(&event);
-                still_active = !activity.turn_ended();
-            }
-            // An event that isn't the turn-end means the agent is working;
-            // recover it if a premature backstop wrongly parked it at Idle.
-            if still_active {
-                note_stream_activity(&sup_for_event, &app_for_event, &id_for_event);
             }
 
             if let Err(e) = app_for_event.emit(
@@ -2012,15 +2005,8 @@ fn spawn_per_turn_agent(
     let sup_for_exit = sup;
 
     let on_event = move |event: Value| {
-        let mut still_active = false;
         if let Some(activity) = sup_for_event.activities.lock().get_mut(&id_for_event) {
             activity.observe_event(&event);
-            still_active = !activity.turn_ended();
-        }
-        // An event that isn't the turn-end means the agent is working; recover
-        // it if a premature backstop wrongly parked it at Idle.
-        if still_active {
-            note_stream_activity(&sup_for_event, &app_for_event, &id_for_event);
         }
         if let Err(e) = app_for_event.emit(
             "agent:event",
@@ -2373,20 +2359,6 @@ fn transition_active(
             sup.trigger_session_sync(app.clone(), agent_id.to_string());
             drain_pending_bin_respawn(sup, app, agent_id);
         }
-    }
-}
-
-/// An agent that's still streaming events is, by definition, still working —
-/// so recover it if a premature turn-end (the silence backstop firing during a
-/// long quiet tool call) wrongly parked it at `Idle`. Only acts on a live
-/// `Idle`: a fresh user turn already sets `Running`, the turn-end event itself
-/// is excluded by the caller, and no events arrive once a turn truly ends — so
-/// this never fights a legitimate idle. The tool-aware backstop
-/// (`ManagedActivity`) prevents most false idles for Claude; this is the
-/// provider-agnostic safety net for the rest.
-fn note_stream_activity(sup: &Supervisor, app: &AppHandle, agent_id: &str) {
-    if matches!(sup.live_status(agent_id), Some(AgentStatus::Idle)) {
-        sup.set_status(app, agent_id, AgentStatus::Running, None);
     }
 }
 

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -350,6 +350,49 @@ export const createAppSlice: SliceCreator<AppSlice> = (set, get) => ({
       set((s) => ({ prStates: { ...s.prStates, [e.agent_id]: e.state } }));
     });
 
+    // Reconcile against the backend's authoritative status when the window
+    // comes back to the foreground. Live `agent:status` events are the steady-
+    // state path, but a single event missed while the OS had the webview
+    // backgrounded would otherwise strand a row's status (e.g. a sidebar agent
+    // stuck "idle" while it's actually running) until its next transition. The
+    // refetch is cheap and `get_workspace` overlays live in-memory status, so
+    // it's authoritative. `managedBusy` is reconciled from that same status the
+    // way an `agent:status` event would (see `onAgentStatus` above), so the
+    // composer/spinner can't be left out of sync either.
+    let resyncInFlight = false;
+    const resyncWorkspace = async () => {
+      if (resyncInFlight) return;
+      resyncInFlight = true;
+      try {
+        const fresh = await api.getWorkspace();
+        if (!fresh) return;
+        set((state) => {
+          const managedBusy = { ...state.managedBusy };
+          for (const a of fresh.agents) {
+            if (a.status === "running" || a.status === "spawning") {
+              managedBusy[a.id] = true;
+            } else if (
+              a.status === "idle" ||
+              a.status === "stopped" ||
+              a.status === "error"
+            ) {
+              managedBusy[a.id] = false;
+            }
+          }
+          return { workspace: fresh, managedBusy };
+        });
+      } catch {
+        // Best-effort; the next event or resync recovers.
+      } finally {
+        resyncInFlight = false;
+      }
+    };
+    const onVisible = () => {
+      if (!document.hidden) void resyncWorkspace();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", () => void resyncWorkspace());
+
     const workspace = await api.getWorkspace();
     set({ workspace });
   },


### PR DESCRIPTION
## Problem

Sidebar agents could show **idle** while the agent was actually still running (logs kept streaming in the chat). It surfaced after focusing out/in, switching between agents, or during long-running work.

## Root causes & fixes

Three independent gaps, fixed at each layer:

- **`activity.rs` — false idle from the silence backstop.** The 30s `MANAGED_SILENCE_BACKSTOP` fired during long *quiet* tool calls (a build/test run emits no stream events while it executes), ending the turn prematurely. `ManagedActivity` now tracks outstanding Claude-shaped tool calls (`tool_use` opens, `tool_result` closes) and suppresses the backstop while a tool is in flight. The explicit `result` turn-end still ends the turn immediately. Gated to the Claude/Cursor detector — codex/opencode/pi are unchanged.

- **`supervisor.rs` — provider-agnostic recovery net.** New `note_stream_activity`: any non-turn-end event arriving while an agent is parked at `Idle` recovers it to `Running` and re-emits `agent:status`. Wired into both the managed and per-turn event paths. Never fights a legitimate idle (no events arrive once a turn truly ends).

- **`src/store/app.ts` — reconcile on focus/visibility.** After init, status was fed *only* by live events with no catch-up, so a single `agent:status` event missed while the OS backgrounded the webview stranded a row. Now re-fetches `get_workspace()` (which overlays authoritative live status) and reconciles `managedBusy` on window focus/visibility return.

Also adds a `tracing::debug!` for every status transition (`from → to`) for future debugging — run with `RUST_LOG=quorum=debug`.

## Tests

4 new `activity` tests (tool-outstanding suppression, explicit-end precedence, reset clears tools, non-Claude detectors don't track). Full Rust lib suite passes (the one unrelated `pty_session` I/O-timing test is flaky under sandbox and untouched here).

## Notes

Targets managed/custom-view agents. Native-PTY agents detect activity via TUI redraw bytes and were never affected by the false idle; the focus-resync covers them too.