### PR TITLE
chore: bump version to 0.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quorum",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.2",
   "license": "AGPL-3.0-only",
   "author": "Alex Chaplinsky and fwdai.org",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3105,7 +3105,7 @@ dependencies = [
 
 [[package]]
 name = "quorum"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quorum"
-version = "0.6.1"
+version = "0.6.2"
 description = "Spawn coding agents in isolated sandboxes"
 authors = ["Alex Chaplinsky", "fwdai.org"]
 license = "AGPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Quorum",
   "mainBinaryName": "Quorum",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "com.quorum.desktop",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Bumps the application version from 0.6.1 to 0.6.2 across all version-tracked files:

- `package.json`
- `src-tauri/Cargo.toml`
- `src-tauri/tauri.conf.json`
- `src-tauri/Cargo.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)