### PR TITLE
feat(right-panel): remember last-open tab per agent

### DIFF
--- a/src/components/RightPanel/index.tsx
+++ b/src/components/RightPanel/index.tsx
@@ -1,13 +1,12 @@
 import { useState } from "react";
 import type { AgentRecord } from "../../api";
 import { useAppStore } from "../../store";
+import type { RightPanelTab as TabId } from "../../store/types";
 import { Icon, type IconName } from "../Icon";
 import { CodePanel } from "./Code";
 import { GitPanel } from "./GitPanel";
 import { RunPanel } from "./RunPanel";
 import { TermPanel } from "./TermPanel";
-
-type TabId = "code" | "git" | "run" | "term";
 
 interface Tab {
   id: TabId;
@@ -39,7 +38,20 @@ export function RightPanel({ agent }: { agent: AgentRecord }) {
     features.terminal && { id: "term", label: "Terminal", icon: "terminal" },
   ].filter(Boolean) as Tab[];
 
-  const [tab, setTab] = useState<TabId>(tabs[0]?.id ?? "git");
+  // Restore the tab this agent was last viewing (the panel remounts per agent),
+  // falling back to the first enabled tab. Guard against a saved tab whose
+  // feature has since been disabled.
+  const savedTab = useAppStore((s) => s.rightPanelTabs[agent.id]);
+  const setRightPanelTab = useAppStore((s) => s.setRightPanelTab);
+  const [tab, setTab] = useState<TabId>(
+    savedTab && tabs.some((t) => t.id === savedTab)
+      ? savedTab
+      : (tabs[0]?.id ?? "git"),
+  );
+  const selectTab = (id: TabId) => {
+    setTab(id);
+    setRightPanelTab(agent.id, id);
+  };
 
   if (tabs.length === 0) {
     return (
@@ -61,7 +73,7 @@ export function RightPanel({ agent }: { agent: AgentRecord }) {
             <button
               key={t.id}
               className={`r-tab ${tab === t.id ? "active" : ""}`}
-              onClick={() => setTab(t.id)}
+              onClick={() => selectTab(t.id)}
             >
               <Icon name={t.icon} />
               {t.label}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -243,6 +243,9 @@ export function dropAgentEntries(state: AppState, id: string): Partial<AppState>
   // that finished while unviewed leaves an orphaned key behind with no row to
   // select, which would keep the app-icon badge count nonzero forever.
   const { [id]: _seen, ...unseenResults } = state.unseenResults;
+  // Drop the remembered right-rail tab so an archived/discarded agent's UI
+  // state doesn't outlive it as a stale key for the rest of the session.
+  const { [id]: _tab, ...rightPanelTabs } = state.rightPanelTabs;
   return {
     managedLogs,
     transcriptLoading,
@@ -258,6 +261,7 @@ export function dropAgentEntries(state: AppState, id: string): Partial<AppState>
     composerDrafts,
     gitDelegations,
     unseenResults,
+    rightPanelTabs,
   };
 }
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -215,6 +215,10 @@ export interface ComposerSlice {
   setComposerDraft: (key: string, text: string) => void;
 }
 
+/** Right-rail panel tabs. Mirrors the `Tab` ids in RightPanel; kept here so the
+ *  store can remember the last-open tab per agent without importing a component. */
+export type RightPanelTab = "code" | "git" | "run" | "term";
+
 export interface UiSlice {
   /** Quick-settings popover (gear / ⌘,). */
   settingsOpen: boolean;
@@ -242,6 +246,10 @@ export interface UiSlice {
   rightCollapsed: boolean;
   leftWidth: number;
   rightWidth: number;
+  /** Last-open right-rail tab per agent, keyed by agent id. Lets the panel
+   *  restore the tab the user was on (e.g. Git) when they switch back to an
+   *  agent, instead of always resetting to the first tab. In-memory only. */
+  rightPanelTabs: Record<string, RightPanelTab>;
 
   toggleSettings: (open?: boolean) => void;
   openSettingsScreen: (section?: SettingsSection, intent?: SettingsIntent) => void;
@@ -263,6 +271,8 @@ export interface UiSlice {
   /** Persist the final width once a splitter drag ends. */
   commitLeftWidth: (w: number) => void;
   commitRightWidth: (w: number) => void;
+  /** Remember the right-rail tab an agent was last viewing. */
+  setRightPanelTab: (agentId: string, tab: RightPanelTab) => void;
 }
 
 export interface AccountSlice {

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -20,6 +20,7 @@ export const createUiSlice: SliceCreator<UiSlice> = (set, get) => ({
   rightCollapsed: false,
   leftWidth: DEFAULT_LEFT_WIDTH,
   rightWidth: DEFAULT_RIGHT_WIDTH,
+  rightPanelTabs: {},
 
   // ── UI ──────────────────────────────────────────────────────────────────────
   toggleSettings: (open) =>
@@ -73,4 +74,6 @@ export const createUiSlice: SliceCreator<UiSlice> = (set, get) => ({
   setRightWidth: (w) => set({ rightWidth: w }),
   commitLeftWidth: (w) => setSetting("leftWidth", String(w)),
   commitRightWidth: (w) => setSetting("rightWidth", String(w)),
+  setRightPanelTab: (agentId, tab) =>
+    set((s) => ({ rightPanelTabs: { ...s.rightPanelTabs, [agentId]: tab } })),
 });


### PR DESCRIPTION
## Problem

When switching between agents, the right rail always reset to the **Code** panel — even if you'd been working in the **Git** panel with a PR. Getting back meant re-selecting the agent and clicking Git again.

The `RightPanel` is mounted with `key={selectedAgent.id}` in `App.tsx`, so it fully remounts on every agent switch. Its `tab` lived in local `useState` initialized to the first enabled tab, so the choice was lost each time.

## Fix

Remember the last-open right-rail tab **per agent** and restore it on mount.

- `store/types.ts` — add a `RightPanelTab` type plus `rightPanelTabs: Record<string, RightPanelTab>` and `setRightPanelTab(agentId, tab)` on `UiSlice`.
- `store/ui.ts` — initialize `rightPanelTabs: {}` and implement the setter.
- `components/RightPanel/index.tsx` — initialize `tab` from the saved per-agent value (fallback: first enabled tab; guarded against a saved tab whose feature was since disabled), and persist the choice on every tab click.

State is in-memory for the session, matching the app's other per-agent UI state (e.g. `gitStates`).

## Testing

- `npx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)