### PR TITLE
feat: editable project chip on new-agent draft

### DIFF
--- a/src/components/Composer/ProjectPicker.tsx
+++ b/src/components/Composer/ProjectPicker.tsx
@@ -1,0 +1,65 @@
+import { useAppStore } from "../../store";
+import { Icon } from "../Icon";
+import { Scrim } from "../ui/Scrim";
+import { basename } from "../../util/format";
+import { useState } from "react";
+
+interface Props {
+  /** Currently selected repo path. */
+  value: string;
+  onChange: (repoPath: string) => void;
+}
+
+/** Lets a new-agent draft switch which project it will spawn under, before the
+ *  first message is sent. Lists the workspace's tracked repos, always including
+ *  the current value (a draft's repo may not be pinned). Styled as an
+ *  `empty-meta` pill so it matches the sibling base-branch / reroll pills. */
+export function ProjectPicker({ value, onChange }: Props) {
+  const [open, setOpen] = useState(false);
+  const repos = useAppStore((s) => s.workspace?.repos ?? []);
+
+  const options = repos.includes(value) ? repos : [value, ...repos];
+
+  return (
+    <div style={{ position: "relative", minWidth: 0 }}>
+      <span
+        className="pill is-action"
+        title={value}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <Icon name="folder" />
+        <span className="v" style={{
+          maxWidth: 160,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}>{basename(value)}</span>
+        <Icon name="chevD" size={9} />
+      </span>
+
+      {open && (
+        <>
+          <Scrim onClose={() => setOpen(false)} />
+          <div className="dd" style={{ bottom: "calc(100% + 6px)", left: 0, padding: 0, overflow: "hidden" }}>
+            <div className="dd-sect" style={{ padding: "7px 9px 4px" }}>Projects</div>
+            {options.map((p) => (
+              <div
+                key={p}
+                className={`dd-item ${p === value ? "active" : ""}`}
+                style={{ padding: "7px 9px" }}
+                title={p}
+                onClick={() => {
+                  onChange(p);
+                  setOpen(false);
+                }}
+              >
+                <Icon name="folder" size={14} />
+                <span className="di-l">{basename(p)}</span>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/Sidebar/ProjectGroup.tsx
+++ b/src/components/Sidebar/ProjectGroup.tsx
@@ -1,6 +1,5 @@
 import { ask } from "@tauri-apps/plugin-dialog";
 import type { AgentRecord } from "../../api";
-import type { DraftAgent } from "../../store";
 import { useAppStore } from "../../store";
 import { Icon } from "../Icon";
 import { AgentRow } from "./AgentRow";
@@ -11,7 +10,6 @@ interface Props {
   /** Full repo path — used as the group's stable id. */
   repoPath: string;
   agents: AgentRecord[];
-  drafts: DraftAgent[];
   /** Whether the user has expanded this group. */
   open: boolean;
   /** Show the remove (×) button — only true when this is a pinned-but-empty group. */
@@ -20,16 +18,14 @@ interface Props {
 }
 
 export function ProjectGroup({
-  label, repoPath, agents, drafts, open, removable, onToggle,
+  label, repoPath, agents, open, removable, onToggle,
 }: Props) {
   const selectedAgentId = useAppStore((s) => s.selectedAgentId);
-  const activeDraftId = useAppStore((s) => s.activeDraftId);
   const selectAgent = useAppStore((s) => s.selectAgent);
-  const selectDraft = useAppStore((s) => s.selectDraft);
   const createDraft = useAppStore((s) => s.createDraft);
   const removeWorkspaceRepo = useAppStore((s) => s.removeWorkspaceRepo);
 
-  const count = agents.length + drafts.length;
+  const count = agents.length;
 
   async function onRemove(e: React.MouseEvent) {
     e.stopPropagation();
@@ -81,15 +77,6 @@ export function ProjectGroup({
           <Icon name="plus" size={11} />
           <span>New agent</span>
         </button>
-        {drafts.map((d) => (
-          <AgentRow
-            key={d.id}
-            kind="draft"
-            draft={d}
-            active={d.id === activeDraftId}
-            onClick={() => selectDraft(d.id)}
-          />
-        ))}
         {agents.map((a) => (
           <AgentRow
             key={a.id}

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
 import type { AgentRecord } from "../../api";
-import type { DraftAgent } from "../../store";
 import { useAppStore } from "../../store";
 import { Icon } from "../Icon";
 import { basename } from "../../util/format";
@@ -13,32 +12,26 @@ import { NewProject, type NewProjectMode } from "../NewProject";
 interface RepoGroup {
   repoPath: string;
   agents: AgentRecord[];
-  drafts: DraftAgent[];
   pinned: boolean;
 }
 
-/** Build groups from (a) pinned repos, (b) any repo referenced by an
- *  existing agent, (c) any repo referenced by a draft. */
+/** Build groups from (a) pinned repos and (b) any repo referenced by an
+ *  existing agent. Drafts are excluded — they surface in the sidebar only once
+ *  spawned into real agents. */
 function groupByRepo(
   pinned: string[],
   agents: readonly AgentRecord[],
-  drafts: readonly DraftAgent[],
 ): RepoGroup[] {
   const map = new Map<string, RepoGroup>();
   for (const p of pinned) {
-    map.set(p, { repoPath: p, agents: [], drafts: [], pinned: true });
+    map.set(p, { repoPath: p, agents: [], pinned: true });
   }
   for (const a of agents) {
     const primary = a.repos[0]?.repo_path;
     if (!primary) continue;
     const existing = map.get(primary);
     if (existing) existing.agents.push(a);
-    else map.set(primary, { repoPath: primary, agents: [a], drafts: [], pinned: false });
-  }
-  for (const d of drafts) {
-    const existing = map.get(d.repoPath);
-    if (existing) existing.drafts.push(d);
-    else map.set(d.repoPath, { repoPath: d.repoPath, agents: [], drafts: [d], pinned: false });
+    else map.set(primary, { repoPath: primary, agents: [a], pinned: false });
   }
   return Array.from(map.values());
 }
@@ -55,21 +48,17 @@ function applySearch(groups: RepoGroup[], q: string): RepoGroup[] {
           a.task.toLowerCase().includes(needle) ||
           a.repos[0]?.branch?.toLowerCase().includes(needle),
       ),
-      drafts: g.drafts.filter((d) => d.name.toLowerCase().includes(needle)),
     }))
     .filter(
       (g) =>
         g.agents.length > 0 ||
-        g.drafts.length > 0 ||
         basename(g.repoPath).toLowerCase().includes(needle),
     );
 }
 
 export function Sidebar() {
   const workspace = useAppStore((s) => s.workspace);
-  const drafts = useAppStore((s) => s.drafts);
   const selectedAgentId = useAppStore((s) => s.selectedAgentId);
-  const activeDraftId = useAppStore((s) => s.activeDraftId);
 
   const [query, setQuery] = useState("");
   const [openMap, setOpenMap] = useState<Record<string, boolean>>({});
@@ -84,26 +73,28 @@ export function Sidebar() {
         .sort((a, b) => (a.created_at < b.created_at ? 1 : -1)),
     [workspace?.agents],
   );
+  // Drafts are intentionally excluded: an in-progress draft lives only in the
+  // center pane and joins the sidebar (as a real agent) once its first message
+  // spawns it.
   const groups = useMemo(
-    () => groupByRepo(workspace?.repos ?? [], liveAgents, drafts),
-    [workspace?.repos, liveAgents, drafts],
+    () => groupByRepo(workspace?.repos ?? [], liveAgents),
+    [workspace?.repos, liveAgents],
   );
   const filtered = useMemo(() => applySearch(groups, query), [groups, query]);
 
-  // Auto-expand a project when its agent or draft is selected.
+  // Auto-expand a project when its agent is selected.
   useEffect(() => {
     setOpenMap((prev) => {
       const next = { ...prev };
       for (const g of groups) {
         if (g.agents.some((a) => a.id === selectedAgentId)) next[g.repoPath] = true;
-        if (g.drafts.some((d) => d.id === activeDraftId)) next[g.repoPath] = true;
         if (!(g.repoPath in next)) {
-          next[g.repoPath] = g.agents.length > 0 || g.drafts.length > 0;
+          next[g.repoPath] = g.agents.length > 0;
         }
       }
       return next;
     });
-  }, [groups, selectedAgentId, activeDraftId]);
+  }, [groups, selectedAgentId]);
 
   return (
     <>
@@ -131,9 +122,8 @@ export function Sidebar() {
                 label={basename(g.repoPath)}
                 repoPath={g.repoPath}
                 agents={g.agents}
-                drafts={g.drafts}
                 open={openMap[g.repoPath] ?? false}
-                removable={g.pinned && g.agents.length === 0 && g.drafts.length === 0}
+                removable={g.pinned && g.agents.length === 0}
                 onToggle={() =>
                   setOpenMap((m) => ({ ...m, [g.repoPath]: !m[g.repoPath] }))
                 }

--- a/src/components/Workspace/EmptyWorkspace.tsx
+++ b/src/components/Workspace/EmptyWorkspace.tsx
@@ -2,8 +2,8 @@ import type { DraftAgent } from "../../store";
 import { useAppStore } from "../../store";
 import { Icon, LandmarkGlyph } from "../Icon";
 import { Composer } from "../Composer";
+import { ProjectPicker } from "../Composer/ProjectPicker";
 import { IconButton } from "../ui/IconButton";
-import { basename } from "../../util/format";
 
 /** Empty-state pane shown when the user has started a draft agent.
  *  First message in the composer spawns the real agent and dispatches
@@ -16,8 +16,6 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
   const setNewDraftSelection = useAppStore((s) => s.setNewDraftSelection);
   const toggleLeft = useAppStore((s) => s.toggleLeft);
   const leftCollapsed = useAppStore((s) => s.leftCollapsed);
-
-  const projectName = basename(draft.repoPath);
 
   return (
     <div className="pane center">
@@ -95,10 +93,13 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
             }
           />
           <div className="empty-meta">
-            <span className="pill">
-              <Icon name="folder" />
-              <span className="v">{projectName}</span>
-            </span>
+            <ProjectPicker
+              value={draft.repoPath}
+              onChange={(repoPath) => {
+                if (repoPath !== draft.repoPath)
+                  updateDraft(draft.id, { repoPath, base: "main" });
+              }}
+            />
             <span className="pill">
               <Icon name="branch" />
               <span style={{ color: "var(--fg-2)" }}>from</span>

--- a/src/store/drafts.ts
+++ b/src/store/drafts.ts
@@ -58,6 +58,22 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
 
   // ── drafts ─────────────────────────────────────────────────────────────────
   createDraft: async (repoPath) => {
+    // Single draft at a time: if one already exists, refocus it (preserving its
+    // name, provider/model, and unsent composer text) and point it at the
+    // latest requested project rather than stacking a second draft.
+    const existing = get().drafts[0];
+    if (existing) {
+      set((s) => ({
+        drafts: s.drafts.map((d) =>
+          d.id === existing.id
+            ? { ...d, repoPath, base: d.repoPath === repoPath ? d.base : "main" }
+            : d,
+        ),
+        activeDraftId: existing.id,
+        selectedAgentId: null,
+      }));
+      return;
+    }
     const { workspace, drafts, newDraftProvider, newDraftModel, newDraftCustomAgentId, modelsByAgent } = get();
     const used = [...usedNames(workspace, drafts)];
     const name = await api.allocateDraftName(used);


### PR DESCRIPTION
## Summary

Two improvements to the new-agent (Cmd+N) flow:

1. **Editable project chip.** The project chip under the new-agent composer is now a picker. Previously it was static, so if Cmd+N guessed the wrong project (it inherits from whatever was in focus) there was no way to change it. Clicking the chip opens a dropdown of the workspace's projects; picking one repoints the draft (and resets its base branch to `main`, since the previously chosen branch may not exist in the new repo).

2. **Defer drafts in the sidebar until sent.** An in-progress draft now lives only in the center pane and joins the sidebar — as a real agent — only once its first message spawns it. This avoids a draft appearing under a project the user never intended (and jumping between groups as the project changes).

Per the agreed product decision, there is **one draft at a time**: `createDraft` now reuses and refocuses an existing draft (preserving its name, provider/model, and unsent composer text) instead of stacking a new one.

## Changes

- **New** `src/components/Composer/ProjectPicker.tsx` — an `empty-meta` pill (matching the sibling base-branch / reroll pills) with a dropdown of `workspace.repos`, always including the current value.
- `src/components/Workspace/EmptyWorkspace.tsx` — replace the static folder pill with `ProjectPicker`.
- `src/store/drafts.ts` — single-draft semantics in `createDraft`.
- `src/components/Sidebar/index.tsx` + `ProjectGroup.tsx` — drop drafts from sidebar grouping/rendering; groups are now pinned repos + real agents only.

## Testing

- `tsc --noEmit` passes.
- The repo's vitest setup is not installed in this worktree, so the suite could not run here; no tests cover the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)