### PR TITLE
feat(composer): ⌘N new agent in last-used project + active project/branch pickers

### DIFF
--- a/src/components/Composer/BranchPicker.tsx
+++ b/src/components/Composer/BranchPicker.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { api } from "../../api";
 import { Icon } from "../Icon";
-import { Chip } from "../ui/Chip";
 import { Scrim } from "../ui/Scrim";
 
 const ITEM_HEIGHT = 34; // approximate px per dd-item row
@@ -43,19 +42,18 @@ export function BranchPicker({ repoPath, value, onChange }: Props) {
   }
 
   return (
-    <div style={{ position: "relative", minWidth: 0 }}>
-      <Chip tip={value} onClick={() => setOpen((v) => !v)}>
-        <Icon name="branch" size={11} />
+    <span style={{ position: "relative", minWidth: 0 }}>
+      <span className="pill is-action" title={value} onClick={() => setOpen((v) => !v)}>
+        <Icon name="branch" />
         <span style={{ color: "var(--fg-2)" }}>from</span>
-        <span style={{
-          fontFamily: "var(--font-mono)",
+        <span className="v" style={{
           maxWidth: 140,
           overflow: "hidden",
           textOverflow: "ellipsis",
           whiteSpace: "nowrap",
         }}>{value}</span>
         <Icon name="chevD" size={9} />
-      </Chip>
+      </span>
 
       {open && (
         <>
@@ -110,6 +108,6 @@ export function BranchPicker({ repoPath, value, onChange }: Props) {
           </div>
         </>
       )}
-    </div>
+    </span>
   );
 }

--- a/src/components/Composer/ProjectPicker.tsx
+++ b/src/components/Composer/ProjectPicker.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import { Icon } from "../Icon";
+import { Scrim } from "../ui/Scrim";
+import { basename } from "../../util/format";
+
+interface Props {
+  /** Currently selected repo path. */
+  value: string;
+  /** Available repo paths (sidebar projects). */
+  repos: string[];
+  onChange: (repoPath: string) => void;
+}
+
+/** Project picker for the new-agent draft screen. Mirrors BranchPicker's
+ *  dropdown, but rendered as an `empty-meta` pill so it sits inline with the
+ *  branch/reroll pills below the composer. */
+export function ProjectPicker({ value, repos, onChange }: Props) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <span style={{ position: "relative" }}>
+      <span className="pill is-action" onClick={() => setOpen((v) => !v)}>
+        <Icon name="folder" />
+        <span className="v">{basename(value)}</span>
+        <Icon name="chevD" size={9} />
+      </span>
+
+      {open && (
+        <>
+          <Scrim onClose={() => setOpen(false)} />
+          <div className="dd" style={{ bottom: "calc(100% + 6px)", left: 0, padding: 0, overflow: "hidden" }}>
+            <div className="dd-sect" style={{ padding: "7px 9px 4px" }}>Projects</div>
+            <div style={{ maxHeight: 272, overflowY: "auto" }}>
+              {repos.map((r) => (
+                <div
+                  key={r}
+                  className={`dd-item ${r === value ? "active" : ""}`}
+                  style={{ padding: "7px 9px" }}
+                  title={r}
+                  onClick={() => {
+                    onChange(r);
+                    setOpen(false);
+                  }}
+                >
+                  <Icon name="folder" size={14} />
+                  <span className="di-l">{basename(r)}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+    </span>
+  );
+}

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -7,7 +7,6 @@ import { lookupModel } from "../../data/modelCatalog";
 import { Icon } from "../Icon";
 import { Chip } from "../ui/Chip";
 import { ModelPicker } from "./ModelPicker";
-import { BranchPicker } from "./BranchPicker";
 import { UsageMeter } from "./UsageMeter";
 import type { AgentUsage } from "../../store";
 import { AttachmentList } from "./AttachmentList";
@@ -27,11 +26,6 @@ interface Props {
   defaultModel?: string;
   /** Initial custom-agent id for new-agent drafts, if one was selected. */
   defaultCustomAgentId?: string;
-  /** When set, render a branch picker chip showing the current base branch. */
-  baseBranch?: string;
-  /** Repo path used to fetch available branches for the picker. */
-  repoPath?: string;
-  onChangeBase?: (branch: string) => void;
   placeholder?: string;
   autoFocus?: boolean;
   disabled?: boolean;
@@ -113,9 +107,6 @@ export function Composer({
   defaultProvider = DEFAULT_PROVIDER_ID,
   defaultModel,
   defaultCustomAgentId,
-  baseBranch,
-  repoPath,
-  onChangeBase,
   placeholder,
   autoFocus,
   disabled,
@@ -382,20 +373,6 @@ export function Composer({
           <Chip tip="Auto-approve writes">
             <Icon name="check" size={11} />
             <span>Auto-edit</span>
-          </Chip>
-        )}
-        {baseBranch && repoPath && onChangeBase && (
-          <BranchPicker
-            repoPath={repoPath}
-            value={baseBranch}
-            onChange={onChangeBase}
-          />
-        )}
-        {baseBranch && (!repoPath || !onChangeBase) && (
-          <Chip tip="Base branch">
-            <Icon name="branch" size={11} />
-            <span style={{ color: "var(--fg-2)" }}>from</span>
-            <span style={{ fontFamily: "var(--font-mono)" }}>{baseBranch}</span>
           </Chip>
         )}
         <Chip tip="Attach" onClick={browse}>

--- a/src/components/Workspace/EmptyWorkspace.tsx
+++ b/src/components/Workspace/EmptyWorkspace.tsx
@@ -2,8 +2,9 @@ import type { DraftAgent } from "../../store";
 import { useAppStore } from "../../store";
 import { Icon, LandmarkGlyph } from "../Icon";
 import { Composer } from "../Composer";
+import { ProjectPicker } from "../Composer/ProjectPicker";
+import { BranchPicker } from "../Composer/BranchPicker";
 import { IconButton } from "../ui/IconButton";
-import { basename } from "../../util/format";
 
 /** Empty-state pane shown when the user has started a draft agent.
  *  First message in the composer spawns the real agent and dispatches
@@ -14,10 +15,10 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
   const removeDraft = useAppStore((s) => s.removeDraft);
   const updateDraft = useAppStore((s) => s.updateDraft);
   const setNewDraftSelection = useAppStore((s) => s.setNewDraftSelection);
+  const setLastRepoPath = useAppStore((s) => s.setLastRepoPath);
+  const repos = useAppStore((s) => s.workspace?.repos ?? []);
   const toggleLeft = useAppStore((s) => s.toggleLeft);
   const leftCollapsed = useAppStore((s) => s.leftCollapsed);
-
-  const projectName = basename(draft.repoPath);
 
   return (
     <div className="pane center">
@@ -82,9 +83,6 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
             defaultProvider={draft.provider}
             defaultModel={draft.model}
             defaultCustomAgentId={draft.customAgentId}
-            baseBranch={draft.base}
-            repoPath={draft.repoPath}
-            onChangeBase={(branch) => updateDraft(draft.id, { base: branch })}
             onChangeSelection={(provider, model, customAgentId) => {
               updateDraft(draft.id, { provider, model, customAgentId });
               setNewDraftSelection(provider, model, customAgentId);
@@ -95,15 +93,21 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
             }
           />
           <div className="empty-meta">
-            <span className="pill">
-              <Icon name="folder" />
-              <span className="v">{projectName}</span>
-            </span>
-            <span className="pill">
-              <Icon name="branch" />
-              <span style={{ color: "var(--fg-2)" }}>from</span>
-              <span className="v">{draft.base}</span>
-            </span>
+            <ProjectPicker
+              value={draft.repoPath}
+              repos={repos}
+              onChange={(repoPath) => {
+                // Switching projects: the previously chosen base branch may not
+                // exist in the new repo, so reset to main.
+                updateDraft(draft.id, { repoPath, base: "main" });
+                setLastRepoPath(repoPath);
+              }}
+            />
+            <BranchPicker
+              repoPath={draft.repoPath}
+              value={draft.base}
+              onChange={(branch) => updateDraft(draft.id, { base: branch })}
+            />
             <span className="pill is-action" onClick={() => rerollDraftName(draft.id)}>
               <Icon name="refresh" />
               <span>reroll name</span>

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -74,6 +74,7 @@ export const createAppSlice: SliceCreator<AppSlice> = (set, get) => ({
         newDraftProvider,
         newDraftModel,
         newDraftCustomAgentId,
+        lastRepoPath: s.lastRepoPath || undefined,
         viewMode: (s.viewMode as WorkspaceView) || "custom",
         gitCommitAction: isCommitAction(s.gitCommitAction) ? s.gitCommitAction : "agent-commit-pr",
         onboardingComplete: s.onboardingComplete === "true",

--- a/src/store/drafts.ts
+++ b/src/store/drafts.ts
@@ -28,6 +28,7 @@ export interface DraftAgent {
 }
 
 const NEW_DRAFT_SELECTION_SETTING = "newDraftSelection";
+const LAST_REPO_PATH_SETTING = "lastRepoPath";
 
 function normalizeDraftSelection(
   provider: string,
@@ -55,6 +56,13 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
   newDraftProvider: DEFAULT_PROVIDER_ID,
   newDraftModel: undefined,
   newDraftCustomAgentId: undefined,
+  lastRepoPath: undefined,
+
+  setLastRepoPath: (repoPath) => {
+    if (get().lastRepoPath === repoPath) return;
+    set({ lastRepoPath: repoPath });
+    void setSetting(LAST_REPO_PATH_SETTING, repoPath);
+  },
 
   // ── drafts ─────────────────────────────────────────────────────────────────
   createDraft: async (repoPath) => {
@@ -81,6 +89,7 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
       activeDraftId: draft.id,
       selectedAgentId: null,
     }));
+    get().setLastRepoPath(repoPath);
   },
 
   updateDraft: (id, patch) =>
@@ -134,6 +143,7 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
   spawnFromDraft: async (id, text, provider, model, attachments = [], thinking?, customAgentId?) => {
     const draft = get().drafts.find((d) => d.id === id);
     if (!draft) return;
+    get().setLastRepoPath(draft.repoPath);
     set({ busy: true, lastError: null });
     const turnId = crypto.randomUUID();
     try {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -357,9 +357,14 @@ export interface DraftsSlice {
   newDraftModel?: string;
   /** Sticky custom-agent selection for the next new draft (persisted). */
   newDraftCustomAgentId?: string;
+  /** The project a new agent was last started in (persisted). Seeds ⌘N's
+   *  default project; validated against the live repo list on use. */
+  lastRepoPath?: string;
 
   // drafts
   createDraft: (repoPath: string) => Promise<void>;
+  /** Remember the last project an agent was started in and persist it. */
+  setLastRepoPath: (repoPath: string) => void;
   updateDraft: (id: string, patch: Partial<DraftAgent>) => void;
   removeDraft: (id: string) => void;
   selectDraft: (id: string | null) => void;

--- a/src/util/shortcuts.ts
+++ b/src/util/shortcuts.ts
@@ -15,6 +15,7 @@ export function useGlobalShortcuts() {
   const createDraft = useAppStore((s) => s.createDraft);
   const workspace = useAppStore((s) => s.workspace);
   const selectedAgentId = useAppStore((s) => s.selectedAgentId);
+  const lastRepoPath = useAppStore((s) => s.lastRepoPath);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -50,10 +51,13 @@ export function useGlobalShortcuts() {
         setTheme(theme === "dark" ? "light" : "dark");
       } else if (mod && e.key === "n" && !inField) {
         e.preventDefault();
-        // Pick the active project; fall back to the first one.
+        // Default to the last project an agent was started in (if it still
+        // exists); fall back to the selected agent's project, then the first.
         const repos = workspace?.repos ?? [];
         const agents = workspace?.agents ?? [];
+        const recent = lastRepoPath && repos.includes(lastRepoPath) ? lastRepoPath : undefined;
         const active =
+          recent ??
           agents.find((a) => a.id === selectedAgentId)?.repos[0]?.repo_path ??
           repos[0];
         if (active) createDraft(active);
@@ -64,5 +68,5 @@ export function useGlobalShortcuts() {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [toggleLeft, leftCollapsed, toggleRight, toggleSettings, closeSettingsScreen, setTheme, theme, createDraft, workspace, selectedAgentId]);
+  }, [toggleLeft, leftCollapsed, toggleRight, toggleSettings, closeSettingsScreen, setTheme, theme, createDraft, workspace, selectedAgentId, lastRepoPath]);
 }


### PR DESCRIPTION
## What

Adds a fast keyboard path to start a new agent and makes the draft screen's project/branch selectors interactive.

### ⌘N → focused new-agent composer
- `⌘N` opens the new-agent draft screen with the composer autofocused, defaulting the project to the **last project an agent was started in** (persisted across restarts), falling back to the selected agent's project, then the first project.
- `lastRepoPath` is persisted via the existing settings layer (recorded on draft creation and on spawn), validated against the live repo list before use so a deleted repo just falls back.

### Active project & branch pickers below the composer
- The previously read-only project pill is now a `ProjectPicker` dropdown listing sidebar projects. Switching projects updates the draft and resets the base branch to `main` (the prior branch may not exist in the new repo).
- The base-branch picker now sits next to the project picker in the meta row. `BranchPicker`'s trigger was restyled from a `Chip` to a `pill` so the two match visually.
- The branch picker was **removed from the composer foot**; since the composer was its only other caller, the now-unused `baseBranch` / `repoPath` / `onChangeBase` props were dropped from `Composer`.

## Files
- `src/util/shortcuts.ts` — ⌘N project resolution order
- `src/store/{types,drafts,app}.ts` — `lastRepoPath` state, `setLastRepoPath`, persistence + load
- `src/components/Composer/ProjectPicker.tsx` — new picker
- `src/components/Composer/BranchPicker.tsx` — pill-styled trigger
- `src/components/Composer/index.tsx` — drop branch UI/props
- `src/components/Workspace/EmptyWorkspace.tsx` — wire both pickers into the meta row

## Testing
- `npx tsc --noEmit` passes. The vitest suite couldn't run in this worktree (partial `node_modules`); the change adds no new tested logic (raw-string storage, no new parser).

Manual checklist for reviewer:
1. ⌘N from anywhere → draft opens in last-used project, composer focused.
2. Switch project via the pill → branch picker refetches for the new repo, base resets to `main`.
3. Restart → ⌘N defaults to the last project used.
4. ⌘N while typing in a field → does not fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)