### PR TITLE
fix(ask-question): show single-select choice before all questions answered

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -883,6 +883,8 @@ button { cursor: default; }
 }
 .q-opt:hover .q-radio { border-color: var(--accent); }
 .q-opt:hover .q-radio::after { transform: scale(1); }
+.q-opt.is-checked .q-radio { border-color: var(--accent); }
+.q-opt.is-checked .q-radio::after { transform: scale(1); }
 .q-radio.plus { border-style: dashed; }
 .q-radio.plus::after, .q-radio.check::after { display: none; }
 .q-radio.check { border-radius: 5px; }

--- a/src/components/Workspace/messages/UserInput/QuestionCard.tsx
+++ b/src/components/Workspace/messages/UserInput/QuestionCard.tsx
@@ -118,7 +118,11 @@ export function QuestionCard({
 
       <div className="q-opts">
         {opts.map((o, i) => {
-          const checked = picks.has(o.id);
+          // multiSelect tracks picks locally; single-select reflects the
+          // chosen answer passed down so a selection shows before commit.
+          const checked = question.multiSelect
+            ? picks.has(o.id)
+            : !!answer?.optionIds?.includes(o.id);
           return (
             <button
               key={o.id}

--- a/src/components/Workspace/messages/UserInput/index.tsx
+++ b/src/components/Workspace/messages/UserInput/index.tsx
@@ -122,8 +122,12 @@ export function UserInput({
       ? answersFromResultText(model, resultText(result.content))
       : null;
   const committed = committedLocally || !!fromTranscript;
+  // Reflect a locally chosen answer immediately, before the whole widget
+  // commits: in a multi-question stack the user may answer questions one at a
+  // time, and each card must show its own selection right away rather than
+  // staying blank until the last question is answered.
   const answerFor = (i: number): UIAnswer | null =>
-    committedLocally ? (answers[i] ?? null) : (fromTranscript?.[i] ?? null);
+    answers[i] ?? (committedLocally ? null : fromTranscript?.[i]) ?? null;
 
   // Answered, but the result didn't parse into per-question answers — fall back
   // to a compact summary of the raw result text rather than showing nothing.


### PR DESCRIPTION
## Problem

When an agent asks **two (or more) questions** via `AskUserQuestion`, multiple option-selection blocks render. Clicking an option in the first block had **no visible effect** — the selection only appeared once the *last* question was also answered, at which point all blocks updated to their selected/resolved state simultaneously.

## Root cause

- `UserInput` only marks the widget committed (`committedLocally`) once **every** question is answered (`index.tsx`), and `answerFor` withheld each card's answer until then.
- For single-select, `QuestionCard` derived its checked state solely from the local `picks` set, which is only maintained for `multiSelect`. So a single-select click never produced any highlight pre-commit.

Net result: no per-question feedback until the whole stack committed.

## Fix

- **`index.tsx`** — `answerFor` now surfaces a locally chosen answer immediately (`answers[i] ?? …`) instead of waiting for full commit.
- **`QuestionCard.tsx`** — single-select derives `checked` from the `answer` prop; multiSelect still uses local `picks`.
- **`app.css`** — added `.q-opt.is-checked .q-radio` rules so the single-select radio dot fills when checked (previously it only filled on hover).

Cards still fold into the shared "Answered" state together once all questions are answered — the commit condition is unchanged.

## Testing

- `npx tsc --noEmit` passes.
- Behavior: clicking an option in the first question now highlights it instantly and remains re-clickable until all questions are submitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)