### PR TITLE
refactor(git-panel): centralize merge-gate semantics into describeMergeGate

### DIFF
--- a/src/components/RightPanel/GitPanel/StatusHeader.tsx
+++ b/src/components/RightPanel/GitPanel/StatusHeader.tsx
@@ -1,4 +1,5 @@
 import type { GitState, MergeState, PrState } from "../../../api";
+import { describeMergeGate, type MergeGateTone } from "../mergeGate";
 import type { GitPanelState } from "../primaryActions";
 import { ViewOnGitHub } from "./shared";
 
@@ -7,6 +8,31 @@ import { ViewOnGitHub } from "./shared";
 // state before any word is read. clean=green · uncommitted=amber · pushed/PR=
 // blue · fixable (can't merge / conflicts)=orange · ready=green · merged=purple.
 type HeaderKind = "clean" | "changes" | "info" | "att" | "ready" | "merged" | "neutral";
+
+/** Render the shared merge-gate tone as a header kind. */
+const HEADER_KIND_BY_TONE: Record<MergeGateTone, HeaderKind> = {
+  ready: "ready",
+  warn: "changes",
+  attention: "att",
+  info: "info",
+};
+
+/** Terse merge-gate phrasing for the at-a-glance header. */
+const HEADER_TEXT_BY_SITUATION: Record<
+  ReturnType<typeof describeMergeGate>["situation"],
+  (base: string) => string
+> = {
+  ready: () => "ready to merge",
+  "mergeable-soft": () => "optional checks failing",
+  "checks-failing": () => "checks failing",
+  "review-required": () => "review required",
+  behind: (base) => `behind ${base}`,
+  conflicts: (base) => `conflicts with ${base}`,
+  draft: () => "draft",
+  computing: () => "checking…",
+  "no-conflicts": () => "no conflicts",
+  "cant-merge": () => "can’t merge yet",
+};
 
 interface HeaderInfo {
   kind: HeaderKind;
@@ -50,36 +76,19 @@ export function describeHeader(
     case "conflicts":
       return { kind: "att", pill: "Conflicts", text: branch, sub: `← ${base}` };
     case "pr-open": {
-      // GitHub's combined merge gate (spec §7): the legitimate green "ready"
-      // appears only on `clean`. Without checks data, fall back to
-      // `mergeable` — which only means "no conflicts", never an all-clear.
+      // Gate classification + tone live in describeMergeGate; the header only
+      // picks its terse phrasing and renders the shared tone.
       const pill = n != null ? `PR #${n}` : "PR";
-      switch (mergeState) {
-        case "clean":
-          return { kind: "ready", pill, text: "ready to merge", ext: true };
-        case "unstable":
-          return { kind: "changes", pill, text: "optional checks failing", ext: true };
-        case "blocked":
-          return {
-            kind: "att",
-            pill,
-            text: checksFailed > 0 ? "checks failing" : "review required",
-            ext: true,
-          };
-        case "behind":
-          return { kind: "att", pill, text: `behind ${base}`, ext: true };
-        case "dirty":
-          return { kind: "att", pill, text: `conflicts with ${base}`, ext: true };
-        case "draft":
-          return { kind: "info", pill, text: "draft", ext: true };
-        case "unknown":
-        case "has_hooks":
-          return { kind: "info", pill, text: "checking…", ext: true };
-        default:
-          return pr?.mergeable
-            ? { kind: "info", pill, text: "no conflicts", ext: true }
-            : { kind: "att", pill, text: "can’t merge yet", ext: true };
-      }
+      const gate = describeMergeGate(mergeState, {
+        checksFailed,
+        mergeable: !!pr?.mergeable,
+      });
+      return {
+        kind: HEADER_KIND_BY_TONE[gate.tone],
+        pill,
+        text: HEADER_TEXT_BY_SITUATION[gate.situation](base),
+        ext: true,
+      };
     }
     case "pr-closed":
       return { kind: "neutral", pill: "Closed", text: n != null ? `#${n}` : "—", ext: true };

--- a/src/components/RightPanel/GitPanel/cards/PRCard.tsx
+++ b/src/components/RightPanel/GitPanel/cards/PRCard.tsx
@@ -1,8 +1,30 @@
 import { open } from "@tauri-apps/plugin-shell";
 import type { PrChecks, PrComment, PrComments, PrState } from "../../../../api";
 import { Icon } from "../../../Icon";
+import { describeMergeGate, type MergeGateSituation } from "../../mergeGate";
 import { ChecksSection } from "./ChecksSection";
 import { CommentsSection } from "./CommentsSection";
+
+/** The card's verbose merge-gate line. `blocked` collapses its two sub-states
+ *  (failing checks vs. review gate) into one message here. */
+const CARD_GATE_BY_SITUATION: Record<
+  MergeGateSituation,
+  { cls: string; text: (base: string) => string }
+> = {
+  ready: { cls: "ok", text: () => "✓ Ready to merge" },
+  "mergeable-soft": { cls: "ok", text: () => "✓ Mergeable — optional checks failing" },
+  "checks-failing": { cls: "att", text: () => "△ Blocked by required checks or reviews" },
+  "review-required": { cls: "att", text: () => "△ Blocked by required checks or reviews" },
+  behind: { cls: "att", text: (base) => `△ Behind ${base} — update your branch` },
+  conflicts: { cls: "att", text: (base) => `△ Conflicts with ${base} — update your branch` },
+  draft: { cls: "ok", text: () => "Draft — mark ready on GitHub to merge" },
+  computing: { cls: "ok", text: () => "Computing merge status…" },
+  "no-conflicts": { cls: "ok", text: () => "✓ No merge conflicts" },
+  "cant-merge": {
+    cls: "att",
+    text: (base) => `△ Can’t merge cleanly with ${base} — update your branch`,
+  },
+};
 
 export function PRCard({
   pr,
@@ -17,37 +39,20 @@ export function PRCard({
   comments: PrComments | null;
   onAddToChat: (c: PrComment) => void;
 }) {
-  // One merge-gate line, from `merge_state` when available (spec §7); the
-  // `mergeable`-only fallback claims no more than "no conflicts".
-  const ms = checks?.merge_state ?? null;
-  const gate: { cls: string; text: string } =
-    ms === "clean"
-      ? { cls: "ok", text: "✓ Ready to merge" }
-      : ms === "unstable"
-        ? { cls: "ok", text: "✓ Mergeable — optional checks failing" }
-        : ms === "blocked"
-          ? { cls: "att", text: "△ Blocked by required checks or reviews" }
-          : ms === "behind"
-            ? { cls: "att", text: `△ Behind ${base} — update your branch` }
-            : ms === "dirty"
-              ? { cls: "att", text: `△ Conflicts with ${base} — update your branch` }
-              : ms === "draft"
-                ? { cls: "ok", text: "Draft — mark ready on GitHub to merge" }
-                : ms != null
-                  ? { cls: "ok", text: "Computing merge status…" }
-                  : pr.mergeable
-                    ? { cls: "ok", text: "✓ No merge conflicts" }
-                    : {
-                        cls: "att",
-                        text: `△ Can’t merge cleanly with ${base} — update your branch`,
-                      };
+  // One merge-gate line. Gate semantics live in describeMergeGate (spec §6);
+  // the card just renders the verbose copy for the resulting situation.
+  const { situation } = describeMergeGate(checks?.merge_state ?? null, {
+    checksFailed: checks?.failed ?? 0,
+    mergeable: pr.mergeable,
+  });
+  const gate = CARD_GATE_BY_SITUATION[situation];
   return (
     <div className="git-card">
       <div className="git-card-h">Pull request</div>
       <div className="git-card-title">{pr.title}</div>
       <div className="git-card-meta">#{pr.number} · open</div>
       <div className="git-card-row">
-        <span className={gate.cls}>{gate.text}</span>
+        <span className={gate.cls}>{gate.text(base)}</span>
       </div>
       {checks && <ChecksSection checks={checks} prUrl={pr.url} />}
       {comments && <CommentsSection comments={comments} onAddToChat={onAddToChat} />}

--- a/src/components/RightPanel/GitPanel/hooks/useActionBarModel.ts
+++ b/src/components/RightPanel/GitPanel/hooks/useActionBarModel.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import type { GitState, MergeState, PrChecks, PrState } from "../../../../api";
 import { useAppStore } from "../../../../store";
+import { describeMergeGate } from "../../mergeGate";
 import {
   type ActionTone,
   type GitPanelState,
@@ -90,8 +91,11 @@ export function useActionBarModel(input: {
 
   // The CTA's main button is disabled while loading git state, while the agent
   // holds a delegation, and when Merge is selected but the merge gate isn't
-  // open (clean/unstable per spec §7; `mergeable` fallback without checks data).
-  const mergeAllowed = checks ? mergeState === "clean" || mergeState === "unstable" : mergeable;
+  // open. Gate semantics live in describeMergeGate (spec §6).
+  const { mergeAllowed } = describeMergeGate(checks ? mergeState : null, {
+    checksFailed: checks?.failed ?? 0,
+    mergeable,
+  });
   const mainDisabled =
     effectiveKey === "loading" || delegationActive || (effectiveKey === "merge" && !mergeAllowed);
   // Tone applies only when the selected action is the state's primary; picking

--- a/src/components/RightPanel/mergeGate.ts
+++ b/src/components/RightPanel/mergeGate.ts
@@ -1,0 +1,88 @@
+import type { MergeState } from "../../api";
+
+// ── Merge-gate semantics: the single source of truth ──────────────────────
+// GitHub's combined merge gate (`mergeStateStatus`, spec §6) feeds three
+// surfaces — the status header, the PR card, and the action bar — each of which
+// needs to know how merge-ready a PR is and in what tone to say so. Classifying
+// `MergeState` independently in each surface meant a backend gate change had to
+// be mirrored in three (then four) places and could silently drift. This module
+// owns that classification once; surfaces render their own copy off the stable
+// `situation`/`tone`, never off the raw `MergeState`.
+
+/** Canonical merge-gate situation — stable across backend gate-semantics
+ *  changes, so surfaces switch on this rather than on raw `MergeState`. */
+export type MergeGateSituation =
+  | "ready" // clean — green light, merge now
+  | "mergeable-soft" // unstable — only optional (non-required) checks failing
+  | "checks-failing" // blocked by failing required checks — agent-fixable
+  | "review-required" // blocked purely by a review/other gate — send to GitHub
+  | "behind" // behind base — update the branch
+  | "conflicts" // dirty — conflicts with base, update the branch
+  | "draft" // draft — mark ready on GitHub before it can merge
+  | "computing" // unknown/has_hooks — gate still resolving
+  | "no-conflicts" // no checks data, `mergeable` only → no conflicts (not an all-clear)
+  | "cant-merge"; // no checks data, not mergeable → can't merge yet
+
+/** Shared severity. A subset of `StatusKind`/`HeaderKind` so every surface can
+ *  derive its own tone class from one decision. */
+export type MergeGateTone = "ready" | "warn" | "attention" | "info";
+
+export interface MergeGate {
+  situation: MergeGateSituation;
+  tone: MergeGateTone;
+  /** The merge CTA is actually clickable (gate open). Drives the disabled
+   *  state of a "Merge" button regardless of whether it's the primary action. */
+  mergeAllowed: boolean;
+  /** Branch is out of sync with base (behind / conflicting / unmergeable
+   *  fallback); gates the "Update branch with agent" remediation. */
+  needsUpdate: boolean;
+}
+
+export interface MergeGateContext {
+  /** Number of failing required checks — splits `blocked` into agent-fixable
+   *  (checks failing) vs. a pure review gate. */
+  checksFailed: number;
+  /** `PrState.mergeable` — the only signal when `merge_state` is unavailable; it
+   *  reports the absence of conflicts, never CI status. */
+  mergeable: boolean;
+}
+
+/** Map GitHub's combined merge gate to the canonical situation + tone every
+ *  surface renders from. Pass `mergeState: null` (no checks data) to get the
+ *  conservative `mergeable`-only fallback. */
+export function describeMergeGate(
+  mergeState: MergeState | null,
+  { checksFailed, mergeable }: MergeGateContext,
+): MergeGate {
+  switch (mergeState) {
+    case "clean":
+      return { situation: "ready", tone: "ready", mergeAllowed: true, needsUpdate: false };
+    case "unstable":
+      return { situation: "mergeable-soft", tone: "warn", mergeAllowed: true, needsUpdate: false };
+    case "blocked":
+      // Failing required checks are agent-fixable; a pure review gate is not.
+      return checksFailed > 0
+        ? { situation: "checks-failing", tone: "attention", mergeAllowed: false, needsUpdate: false }
+        : {
+            situation: "review-required",
+            tone: "attention",
+            mergeAllowed: false,
+            needsUpdate: false,
+          };
+    case "behind":
+      return { situation: "behind", tone: "attention", mergeAllowed: false, needsUpdate: true };
+    case "dirty":
+      return { situation: "conflicts", tone: "attention", mergeAllowed: false, needsUpdate: true };
+    case "draft":
+      return { situation: "draft", tone: "info", mergeAllowed: false, needsUpdate: false };
+    case "unknown":
+    case "has_hooks":
+      return { situation: "computing", tone: "info", mergeAllowed: false, needsUpdate: false };
+    default:
+      // No checks data — `mergeable` only reports the absence of merge
+      // conflicts, NOT CI status, so claim no more than that.
+      return mergeable
+        ? { situation: "no-conflicts", tone: "info", mergeAllowed: true, needsUpdate: false }
+        : { situation: "cant-merge", tone: "attention", mergeAllowed: false, needsUpdate: true };
+  }
+}

--- a/src/components/RightPanel/mergeGate.ts
+++ b/src/components/RightPanel/mergeGate.ts
@@ -62,7 +62,12 @@ export function describeMergeGate(
     case "blocked":
       // Failing required checks are agent-fixable; a pure review gate is not.
       return checksFailed > 0
-        ? { situation: "checks-failing", tone: "attention", mergeAllowed: false, needsUpdate: false }
+        ? {
+            situation: "checks-failing",
+            tone: "attention",
+            mergeAllowed: false,
+            needsUpdate: false,
+          }
         : {
             situation: "review-required",
             tone: "attention",

--- a/src/components/RightPanel/primaryActions.ts
+++ b/src/components/RightPanel/primaryActions.ts
@@ -1,5 +1,6 @@
 import type { GitState, MergeState, PrState } from "../../api";
 import type { IconName } from "../Icon";
+import { describeMergeGate } from "./mergeGate";
 
 /** Derived git panel state — computed from live GitState, not stored. */
 export type GitPanelState =
@@ -161,62 +162,56 @@ export function primaryFor(state: GitPanelState, counts?: ActionCounts): Primary
           ahead === 1 ? "1 commit pushed, no PR yet" : `${ahead} commits pushed, no PR yet`,
         statusKind: "info",
       };
-    case "pr-open":
-      // GitHub's combined merge gate (`merge_state`, spec §7) drives the
-      // sub-states. Without checks data (null → gh missing / API failure)
-      // fall back to the `mergeable`-only behavior.
-      switch (mergeState) {
-        case "clean":
-          return {
-            key: "merge",
-            label: "Merge PR",
-            icon: "merge",
-            tone: "success",
-            statusLabel: `${prLabel} · ready to merge`,
-            statusKind: "ready",
-          };
-        case "unstable":
+    case "pr-open": {
+      // Gate semantics (which MergeState means what, in which tone) live in
+      // describeMergeGate; here we only pick the action + status phrasing.
+      const gate = describeMergeGate(mergeState, { checksFailed, mergeable });
+      const status = (text: string): Pick<PrimaryAction, "statusLabel" | "statusKind"> => ({
+        statusLabel: `${prLabel} · ${text}`,
+        statusKind: gate.tone,
+      });
+      const merge = (text: string, tone?: ActionTone): PrimaryAction => ({
+        key: "merge",
+        label: "Merge PR",
+        icon: "merge",
+        ...(tone ? { tone } : {}),
+        ...status(text),
+      });
+      switch (gate.situation) {
+        case "ready":
+          return merge("ready to merge", "success");
+        case "mergeable-soft":
           // Only NON-required checks failing — merging is allowed, but say so.
+          return merge("optional checks failing");
+        case "checks-failing":
+          // Failing required checks are agent-fixable.
           return {
-            key: "merge",
-            label: "Merge PR",
-            icon: "merge",
-            statusLabel: `${prLabel} · optional checks failing`,
-            statusKind: "warn",
+            key: "agent-fix",
+            label: "Fix checks with agent",
+            icon: "wrench",
+            ...status(`${checksFailed} ${checksFailed === 1 ? "check" : "checks"} failing`),
           };
-        case "blocked":
-          // Failing required checks are agent-fixable; a pure review gate
-          // (nothing failing) is not — send the user to GitHub instead.
-          return checksFailed > 0
-            ? {
-                key: "agent-fix",
-                label: "Fix checks with agent",
-                icon: "wrench",
-                statusLabel: `${prLabel} · ${checksFailed} ${checksFailed === 1 ? "check" : "checks"} failing`,
-                statusKind: "attention",
-              }
-            : {
-                key: "view-pr",
-                label: "View on GitHub",
-                icon: "github",
-                statusLabel: `${prLabel} · review required`,
-                statusKind: "attention",
-              };
+        case "review-required":
+          // A pure review gate is not agent-fixable — send the user to GitHub.
+          return {
+            key: "view-pr",
+            label: "View on GitHub",
+            icon: "github",
+            ...status("review required"),
+          };
         case "behind":
           return {
             key: "agent-update-branch",
             label: "Update branch",
             icon: "branch",
-            statusLabel: `${prLabel} · behind ${base}`,
-            statusKind: "attention",
+            ...status(`behind ${base}`),
           };
-        case "dirty":
+        case "conflicts":
           return {
             key: "agent-update-branch",
             label: "Update branch",
             icon: "branch",
-            statusLabel: `${prLabel} · conflicts with ${base}`,
-            statusKind: "attention",
+            ...status(`conflicts with ${base}`),
           };
         case "draft":
           return {
@@ -224,37 +219,18 @@ export function primaryFor(state: GitPanelState, counts?: ActionCounts): Primary
             label: "View draft on GitHub",
             icon: "github",
             tone: "ghost",
-            statusLabel: `${prLabel} · draft`,
-            statusKind: "info",
+            ...status("draft"),
           };
-        case "unknown":
-        case "has_hooks":
-          return {
-            key: "merge",
-            label: "Merge PR",
-            icon: "merge",
-            statusLabel: `${prLabel} · checking…`,
-            statusKind: "info",
-          };
-        default:
+        case "computing":
+          return merge("checking…");
+        case "no-conflicts":
           // No checks data — `mergeable` only reports the absence of merge
           // conflicts, NOT CI status, so claim no more than that.
-          return mergeable
-            ? {
-                key: "merge",
-                label: "Merge PR",
-                icon: "merge",
-                statusLabel: `${prLabel} · no conflicts`,
-                statusKind: "info",
-              }
-            : {
-                key: "merge",
-                label: "Merge PR",
-                icon: "merge",
-                statusLabel: `${prLabel} · can’t merge yet`,
-                statusKind: "attention",
-              };
+          return merge("no conflicts");
+        default: // cant-merge
+          return merge("can’t merge yet");
       }
+    }
     case "conflicts":
       // Fixable, not fatal — the agent can reconcile the conflict for you.
       return {
@@ -360,8 +336,7 @@ export function secondaryFor(state: GitPanelState, counts?: ActionCounts): Secon
       // from the local-merge "Resolve with agent" used in the conflicts state.
       // "View on GitHub" is deliberately absent: it's a convenience link,
       // rendered as a chip next to the status text, not an action.
-      const needsUpdate =
-        mergeState === "behind" || mergeState === "dirty" || (mergeState == null && !mergeable);
+      const { needsUpdate } = describeMergeGate(mergeState, { checksFailed, mergeable });
       return [
         { key: "merge", label: "Merge PR", icon: "merge" },
         ...(needsUpdate


### PR DESCRIPTION
## Problem

The `MergeState → user copy/tone` mapping was duplicated across **four** independent `switch`/ternary blocks, each re-deciding the same merge-gate semantics:

1. `StatusHeader.tsx` `describeHeader` — `pr-open` switch
2. `cards/PRCard.tsx` — the `gate` ternary
3. `primaryActions.ts` `primaryFor` — `pr-open` switch
4. `secondaryFor`'s `needsUpdate` and `useActionBarModel`'s `mergeAllowed` (two more latent copies of the same logic)

A backend gate change (a new `MergeState`, or re-meaning `blocked`) needed up to five coordinated edits that could silently drift. The original issue flagged three copies; the GitPanel split refactor carried it over and grew it to five.

## Fix

New `src/components/RightPanel/mergeGate.ts` exposes a single `describeMergeGate(mergeState, { checksFailed, mergeable })` that owns the classification and returns a stable descriptor:

- `situation` — canonical enum (`ready`, `mergeable-soft`, `checks-failing`, `review-required`, `behind`, `conflicts`, `draft`, `computing`, `no-conflicts`, `cant-merge`) that does **not** change when backend gate semantics shift
- `tone` — shared severity (a subset of the existing `StatusKind`/`HeaderKind`)
- `mergeAllowed` — whether the Merge button is clickable
- `needsUpdate` — whether the "Update branch" remediation applies

Each surface now renders its own copy keyed off the stable `situation` and derives its tone class from the single `tone` decision. Presentation stays surface-specific (terse header, verbose card, action label); the gate **semantics** live in exactly one place.

## Verification

- No behavior change — every branch's tone/copy cross-checked against the originals
- `tsc --noEmit` clean
- Full suite passes: 304 tests (including the 16 `primaryActions` tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)