### PR TITLE
refactor: decompose oversized multi-responsibility functions

### DIFF
--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -126,6 +126,43 @@ pub struct Supervisor {
     pub respawn_pending: Mutex<HashSet<String>>,
 }
 
+/// Resolved, per-spawn inputs for `spawn_agent_process` — everything that
+/// isn't already carried on the `AgentRecord` (paths, session id, and this
+/// spawn's generation number).
+struct ProcessLaunch {
+    cwd: PathBuf,
+    sandbox_root: PathBuf,
+    rpc_dir: PathBuf,
+    session_id: Option<String>,
+    per_turn: bool,
+    effective_fresh: bool,
+    my_gen: u64,
+}
+
+/// Pick the turn-end detector for an agent by provider class and view, and
+/// reset it when this spawn begins a fresh turn.
+///
+/// Per-turn agents carry their detector in the descriptor table — but only for
+/// the Custom (exec/JSON) view. In the native view they run their interactive
+/// TUI in a PTY with no JSON stream, so turn-end is detected by silence, the
+/// same as claude's native view. Claude (no descriptor) picks by view too.
+fn build_activity(record: &AgentRecord, effective_fresh: bool) -> Box<dyn Activity> {
+    let mut activity: Box<dyn Activity> = match per_turn_descriptor(&record.provider) {
+        Some(desc) => match record.view {
+            AgentView::Native => Box::new(ClaudeNativeActivity::new()),
+            AgentView::Custom => (desc.activity)(),
+        },
+        None => match record.view {
+            AgentView::Native => Box::new(ClaudeNativeActivity::new()),
+            AgentView::Custom => Box::new(ManagedActivity::claude()),
+        },
+    };
+    if effective_fresh {
+        activity.reset_for_new_turn();
+    }
+    activity
+}
+
 impl Supervisor {
     pub fn new(workspace: Arc<WorkspaceManager>) -> Self {
         Self {
@@ -658,8 +695,7 @@ impl Supervisor {
         fresh: bool,
     ) -> Result<()> {
         let record = self.workspace.agent(agent_id)?;
-        let provider = record.provider.clone();
-        let per_turn = is_per_turn_provider(&provider);
+        let per_turn = is_per_turn_provider(&record.provider);
         // Claude carries a session id we generated at create time; per-turn
         // agents (codex, cursor) are assigned one by the CLI on their first
         // turn, so it may be None until then.
@@ -680,17 +716,13 @@ impl Supervisor {
         // (and the agent's `QUORUM_RPC_DIR`) have a target from turn one.
         let rpc_dir = rpc::mailbox_dir(agent_id)?;
         rpc::ensure_mailbox(&rpc_dir)?;
-        let watcher_cwd = cwd.clone();
         // Base branch for the git dispatcher — the branch the agent was
         // forked from, same default the manual PR action uses.
         let base_branch = primary
             .parent_branch
             .clone()
             .unwrap_or_else(|| "main".to_string());
-        let rpc_dispatcher = Arc::new(rpc::git::GitDispatcher::new(
-            watcher_cwd.clone(),
-            base_branch.clone(),
-        ));
+        let rpc_dispatcher = Arc::new(rpc::git::GitDispatcher::new(cwd.clone(), base_branch));
 
         // Claude only writes a session file once the first turn lands.
         // If task is still empty (no first user message has ever been
@@ -701,7 +733,6 @@ impl Supervisor {
         let no_messages_yet = record.task.trim().is_empty();
         let effective_fresh = fresh || no_messages_yet;
 
-        let app = app.clone();
         let agent_id_str = agent_id.to_string();
 
         let my_gen = {
@@ -711,27 +742,74 @@ impl Supervisor {
             *entry
         };
 
-        // Per-turn agents carry their turn-end detector in the descriptor
-        // table — but only for the Custom (exec/JSON) view. In the native
-        // view they run their interactive TUI in a PTY with no JSON stream,
-        // so turn-end is detected by silence, the same as claude's native
-        // view. Claude (no descriptor) picks its detector by view too.
-        let mut activity: Box<dyn Activity> = match per_turn_descriptor(&provider) {
-            Some(desc) => match record.view {
-                AgentView::Native => Box::new(ClaudeNativeActivity::new()),
-                AgentView::Custom => (desc.activity)(),
-            },
-            None => match record.view {
-                AgentView::Native => Box::new(ClaudeNativeActivity::new()),
-                AgentView::Custom => Box::new(ManagedActivity::claude()),
-            },
-        };
-        if effective_fresh {
-            activity.reset_for_new_turn();
-        }
-        self.activities.lock().insert(agent_id_str.clone(), activity);
+        self.activities
+            .lock()
+            .insert(agent_id_str.clone(), build_activity(&record, effective_fresh));
 
-        let agent = if per_turn {
+        let agent = self.spawn_agent_process(
+            app,
+            &agent_id_str,
+            &record,
+            ProcessLaunch {
+                cwd,
+                sandbox_root,
+                rpc_dir: rpc_dir.clone(),
+                session_id,
+                per_turn,
+                effective_fresh,
+                my_gen,
+            },
+        )?;
+
+        self.agents.lock().insert(agent_id_str.clone(), agent);
+
+        // Initial status is always Idle now — at process start there's
+        // never an in-flight turn (we no longer pass a task as a spawn
+        // arg). The user's first send flips it to Running. Only promote
+        // out of the live Spawning state (a turn that already started
+        // mustn't be clobbered).
+        if matches!(self.live_status(&agent_id_str), Some(AgentStatus::Spawning)) {
+            self.set_status(app, &agent_id_str, AgentStatus::Idle, None);
+        }
+
+        spawn_turn_watchdog(self.clone(), app.clone(), agent_id_str.clone(), my_gen);
+
+        // Watch this agent's RPC mailbox for the life of this generation,
+        // executing allowlisted ops and writing responses back.
+        spawn_rpc_watcher(
+            self.clone(),
+            app.clone(),
+            agent_id_str,
+            rpc_dispatcher,
+            rpc_dir,
+            my_gen,
+        );
+
+        Ok(())
+    }
+
+    /// Spawn the agent's child process, dispatching on provider class
+    /// (per-turn vs. claude) and view (Native PTY vs. Custom managed/exec).
+    /// Returns the live `Agent` handle for the supervisor to track.
+    fn spawn_agent_process(
+        self: &Arc<Self>,
+        app: &AppHandle,
+        agent_id: &str,
+        record: &AgentRecord,
+        launch: ProcessLaunch,
+    ) -> Result<Agent> {
+        let ProcessLaunch {
+            cwd,
+            sandbox_root,
+            rpc_dir,
+            session_id,
+            per_turn,
+            effective_fresh,
+            my_gen,
+        } = launch;
+        let agent_id_str = agent_id.to_string();
+
+        if per_turn {
             match record.view {
                 // Native view: launch the agent's interactive TUI in a PTY,
                 // resuming the session the Custom view established. The
@@ -744,7 +822,7 @@ impl Supervisor {
                     let spec = SpawnSpec {
                         agent_id: &agent_id_str,
                         cwd,
-                        sandbox_root: sandbox_root.clone(),
+                        sandbox_root,
                         session_id,
                         // Per-turn native always resumes (the agent built its
                         // session in the Custom view first).
@@ -754,37 +832,37 @@ impl Supervisor {
                         effort: None,
                         model: record.model.as_deref(),
                         instructions: record.instructions.as_deref(),
-                        rpc_dir: rpc_dir.clone(),
+                        rpc_dir,
                         cols: 120,
                         rows: 32,
                     };
                     spawn_pty_per_turn_agent(
                         spec,
-                        provider.clone(),
+                        record.provider.clone(),
                         app.clone(),
                         agent_id_str.clone(),
                         self.clone(),
                         my_gen,
-                    )?
+                    )
                 }
                 // Custom view: per-turn runner — no process spawns until the
                 // first user message. No sandbox profile: the agent sandboxes
                 // itself rather than running under sandbox-exec.
                 AgentView::Custom => spawn_per_turn_agent(
-                    &provider,
+                    &record.provider,
                     PerTurnSpec {
                         cwd,
-                        sandbox_root: sandbox_root.clone(),
-                        session_id: session_id.clone(),
+                        sandbox_root,
+                        session_id,
                         model: record.model.clone(),
                         instructions: record.instructions.clone(),
-                        rpc_dir: rpc_dir.clone(),
+                        rpc_dir,
                     },
                     app.clone(),
                     agent_id_str.clone(),
                     self.clone(),
                     my_gen,
-                )?,
+                ),
             }
         } else {
             let session_id = session_id
@@ -793,7 +871,7 @@ impl Supervisor {
             let spec = SpawnSpec {
                 agent_id: &agent_id_str,
                 cwd,
-                sandbox_root: sandbox_root.clone(),
+                sandbox_root,
                 session_id,
                 fresh: effective_fresh,
                 // Claude's session-level effort, persisted on the record so it
@@ -801,7 +879,7 @@ impl Supervisor {
                 effort: record.effort.as_deref(),
                 model: record.model.as_deref(),
                 instructions: record.instructions.as_deref(),
-                rpc_dir: rpc_dir.clone(),
+                rpc_dir,
                 cols: 120,
                 rows: 32,
             };
@@ -812,42 +890,16 @@ impl Supervisor {
                     agent_id_str.clone(),
                     self.clone(),
                     my_gen,
-                )?,
+                ),
                 AgentView::Custom => spawn_managed_agent(
                     spec,
                     app.clone(),
                     agent_id_str.clone(),
                     self.clone(),
                     my_gen,
-                )?,
+                ),
             }
-        };
-
-        self.agents.lock().insert(agent_id_str.clone(), agent);
-
-        // Initial status is always Idle now — at process start there's
-        // never an in-flight turn (we no longer pass a task as a spawn
-        // arg). The user's first send flips it to Running. Only promote
-        // out of the live Spawning state (a turn that already started
-        // mustn't be clobbered).
-        if matches!(self.live_status(&agent_id_str), Some(AgentStatus::Spawning)) {
-            self.set_status(&app, &agent_id_str, AgentStatus::Idle, None);
         }
-
-        spawn_turn_watchdog(self.clone(), app.clone(), agent_id_str.clone(), my_gen);
-
-        // Watch this agent's RPC mailbox for the life of this generation,
-        // executing allowlisted ops and writing responses back.
-        spawn_rpc_watcher(
-            self.clone(),
-            app,
-            agent_id_str,
-            rpc_dispatcher,
-            rpc_dir,
-            my_gen,
-        );
-
-        Ok(())
     }
 
     pub async fn resume_agent(
@@ -1159,104 +1211,19 @@ impl Supervisor {
             ));
         }
 
-        if let Some(agent) = self.agents.lock().remove(agent_id) {
-            let _ = agent.shutdown();
-        }
-        self.activities.lock().remove(agent_id);
-        self.statuses.lock().remove(agent_id);
-        self.native_input_lines.lock().remove(agent_id);
-        self.shells.lock().remove(agent_id);
-        if let Some(run) = self.runs.lock().remove(agent_id) {
-            run.stop();
-        }
+        self.detach_runtime(agent_id);
 
-        let mut snapshots: Vec<ArchivedRepoSnapshot> = Vec::with_capacity(record.repos.len());
-        let mut total_adds: u32 = 0;
-        let mut total_dels: u32 = 0;
-
-        for repo in &record.repos {
-            // Resolve SHAs first so we capture state before any
-            // destructive step. The tip is the worktree's HEAD — works whether
-            // it's on a branch or still detached (a branchless agent that never
-            // pushed), so both restore from the exact committed tip.
-            let branch_tip_sha = match repo_worktree_path(agent_id, &repo.subdir) {
-                Ok(wt) => git::rev_parse(&wt, "HEAD").await.ok(),
-                Err(_) => None,
-            };
-            // Prefer the immutable fork point; only fall back to resolving the
-            // parent branch name (which may have drifted) for pre-migration
-            // agents that never captured a base_sha.
-            let parent_branch_sha = match &repo.base_sha {
-                Some(sha) => Some(sha.clone()),
-                None => match &repo.parent_branch {
-                    Some(b) => git::rev_parse(&repo.repo_path, b).await.ok(),
-                    None => None,
-                },
-            };
-
-            let mut adds = 0u32;
-            let mut dels = 0u32;
-            if let (Some(from), Some(to)) = (&parent_branch_sha, &branch_tip_sha) {
-                if from != to {
-                    if let Ok((a, d)) = git::diff_shortstat(&repo.repo_path, from, to).await {
-                        adds = a;
-                        dels = d;
-                    }
-                }
-            }
-            total_adds = total_adds.saturating_add(adds);
-            total_dels = total_dels.saturating_add(dels);
-
-            snapshots.push(ArchivedRepoSnapshot {
-                repo_path: repo.repo_path.clone(),
-                subdir: repo.subdir.clone(),
-                branch_name: repo.branch.clone(),
-                branch_tip_sha,
-                parent_branch: repo.parent_branch.clone(),
-                parent_branch_sha,
-                diff_stats: DiffStats {
-                    additions: adds,
-                    deletions: dels,
-                },
-            });
-        }
-
-        // Tear down worktrees + branches (best-effort: a single failure
-        // shouldn't block archive, since the user's intent is "get rid
-        // of this", but we surface git errors via tracing).
-        for repo in &record.repos {
-            let worktree = match repo_worktree_path(agent_id, &repo.subdir) {
-                Ok(p) => p,
-                Err(e) => {
-                    tracing::warn!(error = %e, subdir = %repo.subdir, "archive: worktree_path failed");
-                    continue;
-                }
-            };
-            let _ = git::worktree_prune(&repo.repo_path).await;
-            if let Err(e) = git::worktree_remove(&repo.repo_path, &worktree, true).await {
-                tracing::warn!(error = %e, subdir = %repo.subdir, "archive: worktree remove failed");
-            }
-            if let Some(branch) = &repo.branch {
-                if let Err(e) = git::branch_delete(&repo.repo_path, branch).await {
-                    tracing::warn!(%branch, error = %e, "archive: branch delete failed");
-                }
-            }
-        }
-
-        // Best-effort parent dir cleanup.
-        if let Ok(parent) = agent_parent_dir(agent_id) {
-            if parent.exists() {
-                let _ = std::fs::remove_dir_all(&parent);
-            }
-        }
+        // Snapshot SHAs + diff stats before any destructive step, then tear
+        // down the worktrees/branches (best-effort — a single git failure
+        // shouldn't block archive, since the user's intent is "get rid of
+        // this").
+        let (snapshots, diff_stats) = capture_repo_snapshots(agent_id, &record.repos).await;
+        teardown_agent_worktrees(agent_id, &record.repos, "archive").await;
 
         let archive = ArchiveMetadata {
             archived_at: chrono::Utc::now().to_rfc3339(),
             repos: snapshots,
-            diff_stats: DiffStats {
-                additions: total_adds,
-                deletions: total_dels,
-            },
+            diff_stats,
         };
 
         self.workspace.archive_agent(agent_id, archive)?;
@@ -1501,8 +1468,18 @@ impl Supervisor {
     pub async fn discard_agent(self: Arc<Self>, agent_id: &str) -> Result<()> {
         let record = self.workspace.agent(agent_id).ok();
         let repos = record.as_ref().map(|r| r.repos.clone()).unwrap_or_default();
-        let parent_dir = agent_parent_dir(agent_id).ok();
 
+        self.detach_runtime(agent_id);
+        teardown_agent_worktrees(agent_id, &repos, "discard").await;
+
+        self.workspace.remove_agent(agent_id)?;
+        Ok(())
+    }
+
+    /// Detach an agent's live runtime: shut down its process and drop its
+    /// in-memory state (activity detector, status, native input buffer, shell,
+    /// and run-panel session). Shared by archive and discard.
+    fn detach_runtime(&self, agent_id: &str) {
         if let Some(agent) = self.agents.lock().remove(agent_id) {
             let _ = agent.shutdown();
         }
@@ -1513,37 +1490,106 @@ impl Supervisor {
         if let Some(run) = self.runs.lock().remove(agent_id) {
             run.stop();
         }
+    }
+}
 
-        // Tear down each tracked repo's worktree + branch.
-        for repo in &repos {
-            let worktree = match repo_worktree_path(agent_id, &repo.subdir) {
-                Ok(p) => p,
-                Err(e) => {
-                    tracing::warn!(error = %e, subdir = %repo.subdir, "discard: worktree_path failed");
-                    continue;
-                }
-            };
-            let _ = git::worktree_prune(&repo.repo_path).await;
-            if let Err(e) = git::worktree_remove(&repo.repo_path, &worktree, true).await {
-                tracing::warn!(error = %e, subdir = %repo.subdir, "discard: worktree remove failed");
-            }
-            if let Some(branch) = &repo.branch {
-                if let Err(e) = git::branch_delete(&repo.repo_path, branch).await {
-                    tracing::warn!(%branch, error = %e, "discard: branch delete failed");
+/// Snapshot each tracked repo's tip SHA + diff stats against its fork point,
+/// returning the per-repo snapshots plus the aggregate add/delete totals.
+///
+/// Resolves SHAs without mutating anything, so callers can capture state before
+/// any destructive teardown. The tip is the worktree's HEAD — works whether the
+/// agent is on a branch or still detached (never pushed), so both restore from
+/// the exact committed tip.
+async fn capture_repo_snapshots(
+    agent_id: &str,
+    repos: &[TrackedRepo],
+) -> (Vec<ArchivedRepoSnapshot>, DiffStats) {
+    let mut snapshots: Vec<ArchivedRepoSnapshot> = Vec::with_capacity(repos.len());
+    let mut total_adds: u32 = 0;
+    let mut total_dels: u32 = 0;
+
+    for repo in repos {
+        let branch_tip_sha = match repo_worktree_path(agent_id, &repo.subdir) {
+            Ok(wt) => git::rev_parse(&wt, "HEAD").await.ok(),
+            Err(_) => None,
+        };
+        // Prefer the immutable fork point; only fall back to resolving the
+        // parent branch name (which may have drifted) for pre-migration
+        // agents that never captured a base_sha.
+        let parent_branch_sha = match &repo.base_sha {
+            Some(sha) => Some(sha.clone()),
+            None => match &repo.parent_branch {
+                Some(b) => git::rev_parse(&repo.repo_path, b).await.ok(),
+                None => None,
+            },
+        };
+
+        let mut adds = 0u32;
+        let mut dels = 0u32;
+        if let (Some(from), Some(to)) = (&parent_branch_sha, &branch_tip_sha) {
+            if from != to {
+                if let Ok((a, d)) = git::diff_shortstat(&repo.repo_path, from, to).await {
+                    adds = a;
+                    dels = d;
                 }
             }
         }
+        total_adds = total_adds.saturating_add(adds);
+        total_dels = total_dels.saturating_add(dels);
 
-        // Remove the parent dir (may contain orphan files if any
-        // worktree removal failed). Best-effort.
-        if let Some(parent) = parent_dir {
-            if parent.exists() {
-                let _ = std::fs::remove_dir_all(&parent);
+        snapshots.push(ArchivedRepoSnapshot {
+            repo_path: repo.repo_path.clone(),
+            subdir: repo.subdir.clone(),
+            branch_name: repo.branch.clone(),
+            branch_tip_sha,
+            parent_branch: repo.parent_branch.clone(),
+            parent_branch_sha,
+            diff_stats: DiffStats {
+                additions: adds,
+                deletions: dels,
+            },
+        });
+    }
+
+    (
+        snapshots,
+        DiffStats {
+            additions: total_adds,
+            deletions: total_dels,
+        },
+    )
+}
+
+/// Best-effort teardown of every tracked repo's worktree + branch, plus the
+/// agent's parent dir. Failures are logged (tagged with `op` for context) but
+/// never abort the sweep — the caller's intent is to get rid of the agent.
+/// Shared by archive and discard.
+async fn teardown_agent_worktrees(agent_id: &str, repos: &[TrackedRepo], op: &str) {
+    for repo in repos {
+        let worktree = match repo_worktree_path(agent_id, &repo.subdir) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(error = %e, subdir = %repo.subdir, op, "worktree_path failed");
+                continue;
+            }
+        };
+        let _ = git::worktree_prune(&repo.repo_path).await;
+        if let Err(e) = git::worktree_remove(&repo.repo_path, &worktree, true).await {
+            tracing::warn!(error = %e, subdir = %repo.subdir, op, "worktree remove failed");
+        }
+        if let Some(branch) = &repo.branch {
+            if let Err(e) = git::branch_delete(&repo.repo_path, branch).await {
+                tracing::warn!(%branch, error = %e, op, "branch delete failed");
             }
         }
+    }
 
-        self.workspace.remove_agent(agent_id)?;
-        Ok(())
+    // Remove the parent dir (may still hold orphan files if any worktree
+    // removal failed). Best-effort.
+    if let Ok(parent) = agent_parent_dir(agent_id) {
+        if parent.exists() {
+            let _ = std::fs::remove_dir_all(&parent);
+        }
     }
 }
 

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -225,9 +225,7 @@ const registerEventListeners = async (set: AppSet, get: AppGet) => {
           a.id === e.agent_id
             ? {
                 ...a,
-                repos: a.repos.map((r) =>
-                  r.subdir === e.subdir ? { ...r, branch: e.branch } : r,
-                ),
+                repos: a.repos.map((r) => (r.subdir === e.subdir ? { ...r, branch: e.branch } : r)),
               }
             : a,
         ),

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -42,6 +42,335 @@ import { playAgentDone } from "../util/sound";
 import { interruptedAgents } from "./interrupted";
 import type { AppSlice, SliceCreator } from "./types";
 
+type AppSet = Parameters<SliceCreator<AppSlice>>[0];
+type AppGet = Parameters<SliceCreator<AppSlice>>[1];
+
+// Load persisted settings from the DB and hydrate the matching UI state.
+// First launch / DB-not-ready is non-fatal — defaults stand in.
+const hydrateSettings = async (set: AppSet) => {
+  try {
+    const s = await getAllSettings();
+    const {
+      provider: newDraftProvider,
+      model: newDraftModel,
+      customAgentId: newDraftCustomAgentId,
+    } = parseNewDraftSelection(s.newDraftSelection);
+    set({
+      theme: (s.theme as ThemeMode) || "dark",
+      codeTheme: s.codeTheme || "quorum",
+      accent: s.accent || "copper",
+      density: (s.density as Density) || "comfortable",
+      features: parseFeatures(s.features),
+      providerFlags: parseProviderFlags(s.providers),
+      providerPathOverrides: parseProviderPathOverrides(s),
+      newDraftProvider,
+      newDraftModel,
+      newDraftCustomAgentId,
+      lastRepoPath: s.lastRepoPath || undefined,
+      viewMode: (s.viewMode as WorkspaceView) || "custom",
+      gitCommitAction: isCommitAction(s.gitCommitAction) ? s.gitCommitAction : "agent-commit-pr",
+      onboardingComplete: s.onboardingComplete === "true",
+      // Telemetry is opt-out: only an explicit "false" disables it. The key is
+      // snake_case (not camelCase like its peers) on purpose: it's backend-
+      // owned — written by the `set_telemetry_enabled` Rust command, never by a
+      // frontend `setSetting` — so we read it as `s.telemetry_enabled`. Don't
+      // switch a caller to `setSetting("telemetryEnabled", …)`: that's a
+      // different key and the toggle would silently stop working.
+      telemetryEnabled: s.telemetry_enabled !== "false",
+      // Auto-open the welcome tour for new users (no completion flag yet).
+      onboardingOpen: s.onboardingComplete !== "true",
+      // Panel layout — restore the user's last splitter widths and collapse state.
+      leftCollapsed: s.leftCollapsed === "true",
+      rightCollapsed: s.rightCollapsed === "true",
+      leftWidth: parsePaneWidth(s.leftWidth, DEFAULT_LEFT_WIDTH),
+      rightWidth: parsePaneWidth(s.rightWidth, DEFAULT_RIGHT_WIDTH),
+    });
+  } catch {
+    // First launch or DB not ready — defaults are fine.
+  }
+};
+
+// Load (or lazily create) the single local account profile. Non-fatal — the
+// Account screen shows empty fields until a save succeeds.
+const hydrateAccount = async (set: AppSet) => {
+  try {
+    const row = await getOrCreateAccount();
+    set({ account: toProfile(row) });
+  } catch {
+    // Non-fatal — Account screen shows empty fields until a save succeeds.
+  }
+};
+
+// Subscribe to every backend event stream, folding each into store state.
+const registerEventListeners = async (set: AppSet, get: AppGet) => {
+  await onAgentOutput((e) => {
+    pushAgentOutput(e.agent_id, new Uint8Array(e.bytes));
+  });
+
+  await onShellOutput((e) => {
+    pushShellOutput(e.agent_id, new Uint8Array(e.bytes));
+  });
+
+  await onAgentEvent((e) => {
+    const ev = e.event as RawEvent;
+    // A held permission prompt the backend forwarded for a human to answer
+    // (Claude's AskUserQuestion / ExitPlanMode). Record request_id ↔
+    // tool_use_id so the widget can answer it; this is control plane, not a
+    // transcript event, so don't feed the reducer. The agent is paused awaiting input — the
+    // composer stays disabled (busy) and ChatView hides the "thinking" dots.
+    if (ev?.type === "control_request") {
+      const req = (ev as { request?: Record<string, unknown> }).request;
+      const requestId = (ev as { request_id?: string }).request_id;
+      const toolUseId = req?.tool_use_id;
+      if (req?.subtype === "can_use_tool" && typeof toolUseId === "string" && requestId) {
+        set((state) => ({
+          pendingToolUse: {
+            ...state.pendingToolUse,
+            [e.agent_id]: {
+              ...(state.pendingToolUse[e.agent_id] ?? {}),
+              [toolUseId]: requestId,
+            },
+          },
+        }));
+      }
+      return;
+    }
+    let turnEnded = false;
+    set((state) => {
+      const result = applyEvent(state, e.agent_id, e.event as RawEvent);
+      turnEnded = result.turnEnded;
+      return result.patch;
+    });
+    // Capture usage that lives only on the live stream (cursor) into
+    // session_records so it folds like every other agent (see persistLiveUsage).
+    void persistLiveUsage(get, set, e.agent_id, e.event as RawEvent);
+    // A turn can't end with prompts still held — clear any stale entries
+    // (e.g. an interrupt that denied a pending question).
+    if (turnEnded && get().pendingToolUse[e.agent_id]) {
+      set((state) => ({
+        pendingToolUse: { ...state.pendingToolUse, [e.agent_id]: {} },
+      }));
+    }
+    // Side effect lives here, at the call-site, rather than inside the pure
+    // updater: chime when an agent turn lands successfully. Skip it if the
+    // user stopped this agent — the turn_end is just the killed process
+    // flushing its final event, not a real completion.
+    if (turnEnded) {
+      // `delete` returns true when the agent was interrupted; consume the
+      // flag once and gate both the chime and the unseen-results marker on
+      // a genuine completion (a manual stop is neither).
+      if (!interruptedAgents.delete(e.agent_id)) {
+        // The chime exists to notify you when you're NOT watching this
+        // agent — so skip it when you already are. "Watching" means the
+        // window holds focus AND this is the chat on screen; if either is
+        // false (other app focused, window minimized, or a different chat
+        // selected) the sound still fires.
+        const watchingThisChat = document.hasFocus() && get().selectedAgentId === e.agent_id;
+        if (!watchingThisChat) {
+          playAgentDone();
+        }
+        // Flag results for review on any agent the user isn't currently
+        // looking at — this is the only signal for research-only turns that
+        // leave no diff behind. Cleared when the agent is selected.
+        if (get().selectedAgentId !== e.agent_id) {
+          set((state) => ({
+            unseenResults: { ...state.unseenResults, [e.agent_id]: true },
+          }));
+        }
+      }
+    }
+  });
+
+  // A turn's transcript was ingested into session_records: replace the
+  // ephemeral live render with the canonical one (richer — e.g. tool results
+  // the live stream dropped). No-op if nothing was stored.
+  await onSessionRecordsAppended((e) => {
+    const id = e.agent_id;
+    void (async () => {
+      try {
+        const [records, turns] = await Promise.all([
+          api.readSessionRecords(id),
+          api.readUserTurns(id),
+        ]);
+        if (records.length === 0) return;
+        const provider = providerFor(get(), id);
+        const items = applyUserTurns(reduceRecords(provider, records), turns);
+        const usage = usageFromRecords(provider, records);
+        set((state) => ({
+          managedLogs: { ...state.managedLogs, [id]: items },
+          // Only overwrite when records carried usage — cursor folds usage
+          // live, so an empty records result must not wipe it.
+          usage: hasUsage(usage) ? { ...state.usage, [id]: usage } : state.usage,
+        }));
+        // The first turn captures the agent's session id in the DB; pull it
+        // into the live workspace so the Native toggle unblocks without a
+        // reload. Only when still missing locally — avoids per-turn re-fetch.
+        if (needsSessionIdRefresh(get().workspace, id)) {
+          const fresh = await api.getWorkspace();
+          if (fresh) set({ workspace: fresh });
+        }
+      } catch {
+        // Non-critical refresh; the next load picks up the records.
+      }
+    })();
+  });
+
+  await onAgentBranch((e) => {
+    const ws = get().workspace;
+    if (!ws) return;
+    set({
+      workspace: {
+        ...ws,
+        agents: ws.agents.map((a) =>
+          a.id === e.agent_id
+            ? {
+                ...a,
+                repos: a.repos.map((r) =>
+                  r.subdir === e.subdir ? { ...r, branch: e.branch } : r,
+                ),
+              }
+            : a,
+        ),
+      },
+    });
+  });
+
+  await onAgentRepoAdded((e) => {
+    const ws = get().workspace;
+    if (!ws) return;
+    set({
+      workspace: {
+        ...ws,
+        agents: ws.agents.map((a) =>
+          a.id === e.agent_id ? { ...a, repos: [...a.repos, e.repo] } : a,
+        ),
+      },
+    });
+  });
+
+  await onAgentTask((e) => {
+    const ws = get().workspace;
+    if (!ws) return;
+    set({
+      workspace: {
+        ...ws,
+        agents: ws.agents.map((a) => (a.id === e.agent_id ? { ...a, task: e.task } : a)),
+      },
+    });
+  });
+
+  await onAgentView((e) => {
+    const ws = get().workspace;
+    if (!ws) return;
+    set({
+      workspace: {
+        ...ws,
+        agents: ws.agents.map((a) => (a.id === e.agent_id ? { ...a, view: e.view } : a)),
+      },
+    });
+  });
+
+  await onAgentStatus((e) => {
+    const ws = get().workspace;
+    if (!ws) return;
+    // A new turn starting clears any stale stop-suppression flag: if the
+    // killed process never flushed a turn_end, this ensures the next genuine
+    // completion still chimes.
+    if (e.status === "running") interruptedAgents.delete(e.agent_id);
+    const next = {
+      ...ws,
+      agents: ws.agents.map((a) =>
+        a.id === e.agent_id
+          ? {
+              ...a,
+              status: e.status,
+              last_error: e.last_error ?? a.last_error,
+            }
+          : a,
+      ),
+    };
+    set((state) => ({
+      workspace: next,
+      managedLogs:
+        e.status === "stopped" && (state.managedBusy[e.agent_id] ?? false)
+          ? {
+              ...state.managedLogs,
+              [e.agent_id]: [
+                ...(state.managedLogs[e.agent_id] ?? []),
+                {
+                  kind: "notice",
+                  subtype: "info",
+                  text: "Agent was interrupted.",
+                },
+              ],
+            }
+          : state.managedLogs,
+      // `running` is the backend's authoritative "a turn is in flight"
+      // signal — re-assert busy here so a stale `idle` (e.g. the one
+      // start_process emits just before the first turn lands) can't
+      // leave the spinner off. `idle`/`error`/`stopped` clear it.
+      managedBusy:
+        e.status === "running"
+          ? { ...state.managedBusy, [e.agent_id]: true }
+          : e.status === "error" || e.status === "stopped" || e.status === "idle"
+            ? { ...state.managedBusy, [e.agent_id]: false }
+            : state.managedBusy,
+    }));
+  });
+
+  // Archive / restore reshape `repos` and `archive` on the record,
+  // which `agent:status` alone doesn't cover. The backend emits this
+  // small ping after either operation; we reload the workspace.
+  await onWorkspaceChanged(async () => {
+    const fresh = await api.getWorkspace();
+    if (fresh) set({ workspace: fresh });
+  });
+
+  await onPrStateChanged((e) => {
+    set((s) => ({ prStates: { ...s.prStates, [e.agent_id]: e.state } }));
+  });
+};
+
+// Reconcile against the backend's authoritative status when the window comes
+// back to the foreground. Live `agent:status` events are the steady-state path,
+// but a single event missed while the OS had the webview backgrounded would
+// otherwise strand a row's status (e.g. a sidebar agent stuck "idle" while it's
+// actually running) until its next transition. The refetch is cheap and
+// `get_workspace` overlays live in-memory status, so it's authoritative.
+// `managedBusy` is reconciled from that same status the way an `agent:status`
+// event would (see `onAgentStatus`), so the composer/spinner can't drift either.
+const setupResync = (set: AppSet) => {
+  let resyncInFlight = false;
+  const resyncWorkspace = async () => {
+    if (resyncInFlight) return;
+    resyncInFlight = true;
+    try {
+      const fresh = await api.getWorkspace();
+      if (!fresh) return;
+      set((state) => {
+        const managedBusy = { ...state.managedBusy };
+        for (const a of fresh.agents) {
+          if (a.status === "running" || a.status === "spawning") {
+            managedBusy[a.id] = true;
+          } else if (a.status === "idle" || a.status === "stopped" || a.status === "error") {
+            managedBusy[a.id] = false;
+          }
+        }
+        return { workspace: fresh, managedBusy };
+      });
+    } catch {
+      // Best-effort; the next event or resync recovers.
+    } finally {
+      resyncInFlight = false;
+    }
+  };
+  const onVisible = () => {
+    if (!document.hidden) void resyncWorkspace();
+  };
+  document.addEventListener("visibilitychange", onVisible);
+  window.addEventListener("focus", () => void resyncWorkspace());
+};
+
 export const createAppSlice: SliceCreator<AppSlice> = (set, get) => ({
   busy: false,
   lastError: null,
@@ -52,333 +381,21 @@ export const createAppSlice: SliceCreator<AppSlice> = (set, get) => ({
     if (get().initialized) return;
     set({ initialized: true });
 
-    // Load persisted settings from DB.
-    try {
-      const s = await getAllSettings();
-      const {
-        provider: newDraftProvider,
-        model: newDraftModel,
-        customAgentId: newDraftCustomAgentId,
-      } = parseNewDraftSelection(s.newDraftSelection);
-      set({
-        theme: (s.theme as ThemeMode) || "dark",
-        codeTheme: s.codeTheme || "quorum",
-        accent: s.accent || "copper",
-        density: (s.density as Density) || "comfortable",
-        features: parseFeatures(s.features),
-        providerFlags: parseProviderFlags(s.providers),
-        providerPathOverrides: parseProviderPathOverrides(s),
-        newDraftProvider,
-        newDraftModel,
-        newDraftCustomAgentId,
-        lastRepoPath: s.lastRepoPath || undefined,
-        viewMode: (s.viewMode as WorkspaceView) || "custom",
-        gitCommitAction: isCommitAction(s.gitCommitAction) ? s.gitCommitAction : "agent-commit-pr",
-        onboardingComplete: s.onboardingComplete === "true",
-        // Telemetry is opt-out: only an explicit "false" disables it. The key is
-        // snake_case (not camelCase like its peers) on purpose: it's backend-
-        // owned — written by the `set_telemetry_enabled` Rust command, never by a
-        // frontend `setSetting` — so we read it as `s.telemetry_enabled`. Don't
-        // switch a caller to `setSetting("telemetryEnabled", …)`: that's a
-        // different key and the toggle would silently stop working.
-        telemetryEnabled: s.telemetry_enabled !== "false",
-        // Auto-open the welcome tour for new users (no completion flag yet).
-        onboardingOpen: s.onboardingComplete !== "true",
-        // Panel layout — restore the user's last splitter widths and collapse state.
-        leftCollapsed: s.leftCollapsed === "true",
-        rightCollapsed: s.rightCollapsed === "true",
-        leftWidth: parsePaneWidth(s.leftWidth, DEFAULT_LEFT_WIDTH),
-        rightWidth: parsePaneWidth(s.rightWidth, DEFAULT_RIGHT_WIDTH),
-      });
-    } catch {
-      // First launch or DB not ready — defaults are fine.
-    }
-
-    // Load (or lazily create) the single local account profile.
-    try {
-      const row = await getOrCreateAccount();
-      set({ account: toProfile(row) });
-    } catch {
-      // Non-fatal — Account screen shows empty fields until a save succeeds.
-    }
+    await hydrateSettings(set);
+    await hydrateAccount(set);
 
     // Probe installed provider CLIs for real versions + paths (async,
     // non-blocking). Errors are non-fatal — UI falls back to hardcoded versions.
     void get().refreshProviderVersions();
-
     // Rebuild the model catalog if stale (async, non-blocking). State is seeded
     // from the localStorage cache, so lookups work immediately regardless.
     void get().refreshModelCatalog();
-
     // Load custom agent presets (async, non-blocking). Empty until loaded — the
     // composer picker and settings pane just show the built-ins meanwhile.
     void get().loadCustomAgents();
 
-    await onAgentOutput((e) => {
-      pushAgentOutput(e.agent_id, new Uint8Array(e.bytes));
-    });
-
-    await onShellOutput((e) => {
-      pushShellOutput(e.agent_id, new Uint8Array(e.bytes));
-    });
-
-    await onAgentEvent((e) => {
-      const ev = e.event as RawEvent;
-      // A held permission prompt the backend forwarded for a human to answer
-      // (Claude's AskUserQuestion / ExitPlanMode). Record request_id ↔
-      // tool_use_id so the widget can answer it; this is control plane, not a
-      // transcript event, so don't feed the reducer. The agent is paused awaiting input — the
-      // composer stays disabled (busy) and ChatView hides the "thinking" dots.
-      if (ev?.type === "control_request") {
-        const req = (ev as { request?: Record<string, unknown> }).request;
-        const requestId = (ev as { request_id?: string }).request_id;
-        const toolUseId = req?.tool_use_id;
-        if (req?.subtype === "can_use_tool" && typeof toolUseId === "string" && requestId) {
-          set((state) => ({
-            pendingToolUse: {
-              ...state.pendingToolUse,
-              [e.agent_id]: {
-                ...(state.pendingToolUse[e.agent_id] ?? {}),
-                [toolUseId]: requestId,
-              },
-            },
-          }));
-        }
-        return;
-      }
-      let turnEnded = false;
-      set((state) => {
-        const result = applyEvent(state, e.agent_id, e.event as RawEvent);
-        turnEnded = result.turnEnded;
-        return result.patch;
-      });
-      // Capture usage that lives only on the live stream (cursor) into
-      // session_records so it folds like every other agent (see persistLiveUsage).
-      void persistLiveUsage(get, set, e.agent_id, e.event as RawEvent);
-      // A turn can't end with prompts still held — clear any stale entries
-      // (e.g. an interrupt that denied a pending question).
-      if (turnEnded && get().pendingToolUse[e.agent_id]) {
-        set((state) => ({
-          pendingToolUse: { ...state.pendingToolUse, [e.agent_id]: {} },
-        }));
-      }
-      // Side effect lives here, at the call-site, rather than inside the pure
-      // updater: chime when an agent turn lands successfully. Skip it if the
-      // user stopped this agent — the turn_end is just the killed process
-      // flushing its final event, not a real completion.
-      if (turnEnded) {
-        // `delete` returns true when the agent was interrupted; consume the
-        // flag once and gate both the chime and the unseen-results marker on
-        // a genuine completion (a manual stop is neither).
-        if (!interruptedAgents.delete(e.agent_id)) {
-          // The chime exists to notify you when you're NOT watching this
-          // agent — so skip it when you already are. "Watching" means the
-          // window holds focus AND this is the chat on screen; if either is
-          // false (other app focused, window minimized, or a different chat
-          // selected) the sound still fires.
-          const watchingThisChat = document.hasFocus() && get().selectedAgentId === e.agent_id;
-          if (!watchingThisChat) {
-            playAgentDone();
-          }
-          // Flag results for review on any agent the user isn't currently
-          // looking at — this is the only signal for research-only turns that
-          // leave no diff behind. Cleared when the agent is selected.
-          if (get().selectedAgentId !== e.agent_id) {
-            set((state) => ({
-              unseenResults: { ...state.unseenResults, [e.agent_id]: true },
-            }));
-          }
-        }
-      }
-    });
-
-    // A turn's transcript was ingested into session_records: replace the
-    // ephemeral live render with the canonical one (richer — e.g. tool results
-    // the live stream dropped). No-op if nothing was stored.
-    await onSessionRecordsAppended((e) => {
-      const id = e.agent_id;
-      void (async () => {
-        try {
-          const [records, turns] = await Promise.all([
-            api.readSessionRecords(id),
-            api.readUserTurns(id),
-          ]);
-          if (records.length === 0) return;
-          const provider = providerFor(get(), id);
-          const items = applyUserTurns(reduceRecords(provider, records), turns);
-          const usage = usageFromRecords(provider, records);
-          set((state) => ({
-            managedLogs: { ...state.managedLogs, [id]: items },
-            // Only overwrite when records carried usage — cursor folds usage
-            // live, so an empty records result must not wipe it.
-            usage: hasUsage(usage) ? { ...state.usage, [id]: usage } : state.usage,
-          }));
-          // The first turn captures the agent's session id in the DB; pull it
-          // into the live workspace so the Native toggle unblocks without a
-          // reload. Only when still missing locally — avoids per-turn re-fetch.
-          if (needsSessionIdRefresh(get().workspace, id)) {
-            const fresh = await api.getWorkspace();
-            if (fresh) set({ workspace: fresh });
-          }
-        } catch {
-          // Non-critical refresh; the next load picks up the records.
-        }
-      })();
-    });
-
-    await onAgentBranch((e) => {
-      const ws = get().workspace;
-      if (!ws) return;
-      set({
-        workspace: {
-          ...ws,
-          agents: ws.agents.map((a) =>
-            a.id === e.agent_id
-              ? {
-                  ...a,
-                  repos: a.repos.map((r) =>
-                    r.subdir === e.subdir ? { ...r, branch: e.branch } : r,
-                  ),
-                }
-              : a,
-          ),
-        },
-      });
-    });
-
-    await onAgentRepoAdded((e) => {
-      const ws = get().workspace;
-      if (!ws) return;
-      set({
-        workspace: {
-          ...ws,
-          agents: ws.agents.map((a) =>
-            a.id === e.agent_id ? { ...a, repos: [...a.repos, e.repo] } : a,
-          ),
-        },
-      });
-    });
-
-    await onAgentTask((e) => {
-      const ws = get().workspace;
-      if (!ws) return;
-      set({
-        workspace: {
-          ...ws,
-          agents: ws.agents.map((a) => (a.id === e.agent_id ? { ...a, task: e.task } : a)),
-        },
-      });
-    });
-
-    await onAgentView((e) => {
-      const ws = get().workspace;
-      if (!ws) return;
-      set({
-        workspace: {
-          ...ws,
-          agents: ws.agents.map((a) => (a.id === e.agent_id ? { ...a, view: e.view } : a)),
-        },
-      });
-    });
-
-    await onAgentStatus((e) => {
-      const ws = get().workspace;
-      if (!ws) return;
-      // A new turn starting clears any stale stop-suppression flag: if the
-      // killed process never flushed a turn_end, this ensures the next genuine
-      // completion still chimes.
-      if (e.status === "running") interruptedAgents.delete(e.agent_id);
-      const next = {
-        ...ws,
-        agents: ws.agents.map((a) =>
-          a.id === e.agent_id
-            ? {
-                ...a,
-                status: e.status,
-                last_error: e.last_error ?? a.last_error,
-              }
-            : a,
-        ),
-      };
-      set((state) => ({
-        workspace: next,
-        managedLogs:
-          e.status === "stopped" && (state.managedBusy[e.agent_id] ?? false)
-            ? {
-                ...state.managedLogs,
-                [e.agent_id]: [
-                  ...(state.managedLogs[e.agent_id] ?? []),
-                  {
-                    kind: "notice",
-                    subtype: "info",
-                    text: "Agent was interrupted.",
-                  },
-                ],
-              }
-            : state.managedLogs,
-        // `running` is the backend's authoritative "a turn is in flight"
-        // signal — re-assert busy here so a stale `idle` (e.g. the one
-        // start_process emits just before the first turn lands) can't
-        // leave the spinner off. `idle`/`error`/`stopped` clear it.
-        managedBusy:
-          e.status === "running"
-            ? { ...state.managedBusy, [e.agent_id]: true }
-            : e.status === "error" || e.status === "stopped" || e.status === "idle"
-              ? { ...state.managedBusy, [e.agent_id]: false }
-              : state.managedBusy,
-      }));
-    });
-
-    // Archive / restore reshape `repos` and `archive` on the record,
-    // which `agent:status` alone doesn't cover. The backend emits this
-    // small ping after either operation; we reload the workspace.
-    await onWorkspaceChanged(async () => {
-      const fresh = await api.getWorkspace();
-      if (fresh) set({ workspace: fresh });
-    });
-
-    await onPrStateChanged((e) => {
-      set((s) => ({ prStates: { ...s.prStates, [e.agent_id]: e.state } }));
-    });
-
-    // Reconcile against the backend's authoritative status when the window
-    // comes back to the foreground. Live `agent:status` events are the steady-
-    // state path, but a single event missed while the OS had the webview
-    // backgrounded would otherwise strand a row's status (e.g. a sidebar agent
-    // stuck "idle" while it's actually running) until its next transition. The
-    // refetch is cheap and `get_workspace` overlays live in-memory status, so
-    // it's authoritative. `managedBusy` is reconciled from that same status the
-    // way an `agent:status` event would (see `onAgentStatus` above), so the
-    // composer/spinner can't be left out of sync either.
-    let resyncInFlight = false;
-    const resyncWorkspace = async () => {
-      if (resyncInFlight) return;
-      resyncInFlight = true;
-      try {
-        const fresh = await api.getWorkspace();
-        if (!fresh) return;
-        set((state) => {
-          const managedBusy = { ...state.managedBusy };
-          for (const a of fresh.agents) {
-            if (a.status === "running" || a.status === "spawning") {
-              managedBusy[a.id] = true;
-            } else if (a.status === "idle" || a.status === "stopped" || a.status === "error") {
-              managedBusy[a.id] = false;
-            }
-          }
-          return { workspace: fresh, managedBusy };
-        });
-      } catch {
-        // Best-effort; the next event or resync recovers.
-      } finally {
-        resyncInFlight = false;
-      }
-    };
-    const onVisible = () => {
-      if (!document.hidden) void resyncWorkspace();
-    };
-    document.addEventListener("visibilitychange", onVisible);
-    window.addEventListener("focus", () => void resyncWorkspace());
+    await registerEventListeners(set, get);
+    setupResync(set);
 
     const workspace = await api.getWorkspace();
     set({ workspace });


### PR DESCRIPTION
## What

Decomposes three oversized, multi-responsibility functions into named single-purpose helpers. Pure refactor — no behavior change.

### `supervisor.rs`
- **`start_process`** (~200 lines → ~95): extracted `build_activity` (turn-end detector selection by provider class × view + fresh-turn reset) and `spawn_agent_process` (the per-turn/claude × Native/Custom spawn branching), fed by a new `ProcessLaunch` struct bundling resolved paths/session-id/generation.
- **`archive_agent`** (~120 lines → ~35): extracted `detach_runtime` (process shutdown + in-memory state cleanup), `capture_repo_snapshots` (per-repo SHA/diff capture → snapshots + aggregate `DiffStats`), and `teardown_agent_worktrees` (best-effort worktree/branch/parent-dir teardown).
- **`discard_agent`**: now reuses `detach_runtime` and `teardown_agent_worktrees`, removing ~40 lines of duplicated teardown logic (an `op` param tags log lines `"archive"` vs `"discard"`).

### `store/app.ts`
- **`init`** (345 lines → ~30): extracted module-level helpers `hydrateSettings`, `hydrateAccount`, `registerEventListeners` (all 11 event subscriptions), and `setupResync`. `init` now reads as a clear sequence: hydrate → background probes → register listeners → resync → load workspace.

## Verification
- `cargo check`: passes (no errors/warnings)
- `tsc --noEmit`: passes
- Biome/vitest could not run in the sandbox (blocked global cache / missing dev-deps) — recommend running `bun run lint` and `bun test` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)