### PR TITLE
refactor(store): extract shared git mutation + agent-patch helpers

### DIFF
--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -1,5 +1,6 @@
 import type { RawEvent } from "../adapters";
 import { hasUsage, usageFromRecords } from "../adapters/usage";
+import type { AgentRecord, Workspace } from "../api";
 import {
   api,
   onAgentBranch,
@@ -41,6 +42,27 @@ import { getAllSettings } from "../storage/settings";
 import { playAgentDone } from "../util/sound";
 import { interruptedAgents } from "./interrupted";
 import type { AppSlice, SliceCreator } from "./types";
+
+type AppSet = Parameters<SliceCreator<AppSlice>>[0];
+type AppGet = Parameters<SliceCreator<AppSlice>>[1];
+
+type AgentPatch = Partial<AgentRecord> | ((a: AgentRecord) => Partial<AgentRecord>);
+
+// Map the agent matching `agentId` through `patch` (a flat partial or a
+// function of the current record), leaving the rest untouched. Returns the new
+// agents array; callers fold it into the workspace.
+const mapAgents = (ws: Workspace, agentId: string, patch: AgentPatch): AgentRecord[] =>
+  ws.agents.map((a) =>
+    a.id === agentId ? { ...a, ...(typeof patch === "function" ? patch(a) : patch) } : a,
+  );
+
+// Patch a single agent in the workspace and commit it. No-op when the
+// workspace isn't loaded yet.
+const patchAgent = (get: AppGet, set: AppSet, agentId: string, patch: AgentPatch) => {
+  const ws = get().workspace;
+  if (!ws) return;
+  set({ workspace: { ...ws, agents: mapAgents(ws, agentId, patch) } });
+};
 
 export const createAppSlice: SliceCreator<AppSlice> = (set, get) => ({
   busy: false,
@@ -227,58 +249,21 @@ export const createAppSlice: SliceCreator<AppSlice> = (set, get) => ({
     });
 
     await onAgentBranch((e) => {
-      const ws = get().workspace;
-      if (!ws) return;
-      set({
-        workspace: {
-          ...ws,
-          agents: ws.agents.map((a) =>
-            a.id === e.agent_id
-              ? {
-                  ...a,
-                  repos: a.repos.map((r) =>
-                    r.subdir === e.subdir ? { ...r, branch: e.branch } : r,
-                  ),
-                }
-              : a,
-          ),
-        },
-      });
+      patchAgent(get, set, e.agent_id, (a) => ({
+        repos: a.repos.map((r) => (r.subdir === e.subdir ? { ...r, branch: e.branch } : r)),
+      }));
     });
 
     await onAgentRepoAdded((e) => {
-      const ws = get().workspace;
-      if (!ws) return;
-      set({
-        workspace: {
-          ...ws,
-          agents: ws.agents.map((a) =>
-            a.id === e.agent_id ? { ...a, repos: [...a.repos, e.repo] } : a,
-          ),
-        },
-      });
+      patchAgent(get, set, e.agent_id, (a) => ({ repos: [...a.repos, e.repo] }));
     });
 
     await onAgentTask((e) => {
-      const ws = get().workspace;
-      if (!ws) return;
-      set({
-        workspace: {
-          ...ws,
-          agents: ws.agents.map((a) => (a.id === e.agent_id ? { ...a, task: e.task } : a)),
-        },
-      });
+      patchAgent(get, set, e.agent_id, { task: e.task });
     });
 
     await onAgentView((e) => {
-      const ws = get().workspace;
-      if (!ws) return;
-      set({
-        workspace: {
-          ...ws,
-          agents: ws.agents.map((a) => (a.id === e.agent_id ? { ...a, view: e.view } : a)),
-        },
-      });
+      patchAgent(get, set, e.agent_id, { view: e.view });
     });
 
     await onAgentStatus((e) => {
@@ -290,15 +275,10 @@ export const createAppSlice: SliceCreator<AppSlice> = (set, get) => ({
       if (e.status === "running") interruptedAgents.delete(e.agent_id);
       const next = {
         ...ws,
-        agents: ws.agents.map((a) =>
-          a.id === e.agent_id
-            ? {
-                ...a,
-                status: e.status,
-                last_error: e.last_error ?? a.last_error,
-              }
-            : a,
-        ),
+        agents: mapAgents(ws, e.agent_id, (a) => ({
+          status: e.status,
+          last_error: e.last_error ?? a.last_error,
+        })),
       };
       set((state) => ({
         workspace: next,

--- a/src/store/git.ts
+++ b/src/store/git.ts
@@ -3,6 +3,47 @@ import type { GitCommitAction } from "../components/RightPanel/primaryActions";
 import { setSetting } from "../storage/settings";
 import type { GitSlice, SliceCreator } from "./types";
 
+type GitSet = Parameters<SliceCreator<GitSlice>>[0];
+type GitGet = Parameters<SliceCreator<GitSlice>>[1];
+
+// Shared shape for the simple git mutations: run the backend call, refresh git
+// state on success, otherwise record the error and report failure.
+const runGitMutation = async (
+  get: GitGet,
+  agentId: string,
+  fn: () => Promise<unknown>,
+): Promise<boolean> => {
+  try {
+    await fn();
+    await get().fetchGitState(agentId);
+    return true;
+  } catch (e) {
+    get().setLastError(String(e));
+    return false;
+  }
+};
+
+// fetchPrChecks/fetchPrComments are identical except for the slice key and the
+// backend call: write the value (including null = "confirmed unavailable") on
+// success; on a *first* failure degrade the absent key to null so the panel
+// drops the "checking…" placeholder, while a later transient error keeps the
+// last good value.
+const fetchPrAux = async <K extends "prChecks" | "prComments">(
+  set: GitSet,
+  agentId: string,
+  key: K,
+  fetch: (agentId: string) => Promise<GitSlice[K][string]>,
+): Promise<void> => {
+  try {
+    const value = await fetch(agentId);
+    set((s) => ({ [key]: { ...s[key], [agentId]: value } }) as Partial<GitSlice>);
+  } catch {
+    set((s) =>
+      agentId in s[key] ? {} : ({ [key]: { ...s[key], [agentId]: null } } as Partial<GitSlice>),
+    );
+  }
+};
+
 export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
   gitStates: {},
   gitShortstats: {},
@@ -61,33 +102,9 @@ export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
     }
   },
 
-  fetchPrChecks: async (agentId) => {
-    try {
-      const checks = await api.getPrChecks(agentId);
-      // Write nulls too: null = "confirmed unavailable", distinct from the
-      // absent key ("not yet fetched") that renders as the checking… state.
-      set((s) => ({ prChecks: { ...s.prChecks, [agentId]: checks } }));
-    } catch {
-      // Non-fatal — the next poll tick retries. But a *first* fetch that
-      // throws would otherwise leave the key absent and pin the panel's
-      // "checking…" placeholder, so degrade it to null (mergeable-only
-      // fallback). A later transient error keeps the last good value.
-      set((s) => (agentId in s.prChecks ? {} : { prChecks: { ...s.prChecks, [agentId]: null } }));
-    }
-  },
+  fetchPrChecks: (agentId) => fetchPrAux(set, agentId, "prChecks", api.getPrChecks),
 
-  fetchPrComments: async (agentId) => {
-    try {
-      const comments = await api.getPrComments(agentId);
-      set((s) => ({ prComments: { ...s.prComments, [agentId]: comments } }));
-    } catch {
-      // Non-fatal — the next poll tick retries. Degrade a first failure to
-      // null (section omitted) rather than leaving the key absent.
-      set((s) =>
-        agentId in s.prComments ? {} : { prComments: { ...s.prComments, [agentId]: null } },
-      );
-    }
-  },
+  fetchPrComments: (agentId) => fetchPrAux(set, agentId, "prComments", api.getPrComments),
 
   delegateGitAction: (agentId, kind, prompt) => {
     // Sent mid-turn? Then our trigger is queued behind the in-flight turn,
@@ -151,38 +168,12 @@ export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
     }
   },
 
-  pullAgent: async (agentId) => {
-    try {
-      await api.pullAgent(agentId);
-      await get().fetchGitState(agentId);
-      return true;
-    } catch (e) {
-      set({ lastError: String(e) });
-      return false;
-    }
-  },
+  pullAgent: (agentId) => runGitMutation(get, agentId, () => api.pullAgent(agentId)),
 
-  rebaseAgent: async (agentId) => {
-    try {
-      await api.rebaseAgent(agentId);
-      await get().fetchGitState(agentId);
-      return true;
-    } catch (e) {
-      set({ lastError: String(e) });
-      return false;
-    }
-  },
+  rebaseAgent: (agentId) => runGitMutation(get, agentId, () => api.rebaseAgent(agentId)),
 
-  commitChanges: async (agentId, message) => {
-    try {
-      await api.commitAgent(agentId, message);
-      await get().fetchGitState(agentId);
-      return true;
-    } catch (e) {
-      set({ lastError: String(e) });
-      return false;
-    }
-  },
+  commitChanges: (agentId, message) =>
+    runGitMutation(get, agentId, () => api.commitAgent(agentId, message)),
 
   commitAndOpenPr: async (agentId, message) => {
     try {
@@ -200,39 +191,19 @@ export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
   },
 
   stashChanges: async (agentId) => {
-    try {
-      await api.stashAgent(agentId);
-      await get().fetchGitState(agentId);
-    } catch (e) {
-      set({ lastError: String(e) });
-    }
+    await runGitMutation(get, agentId, () => api.stashAgent(agentId));
   },
 
   discardChanges: async (agentId) => {
-    try {
-      await api.discardAgentChanges(agentId);
-      await get().fetchGitState(agentId);
-    } catch (e) {
-      set({ lastError: String(e) });
-    }
+    await runGitMutation(get, agentId, () => api.discardAgentChanges(agentId));
   },
 
   abortMerge: async (agentId) => {
-    try {
-      await api.abortMergeAgent(agentId);
-      await get().fetchGitState(agentId);
-    } catch (e) {
-      set({ lastError: String(e) });
-    }
+    await runGitMutation(get, agentId, () => api.abortMergeAgent(agentId));
   },
 
   deleteBranch: async (agentId) => {
-    try {
-      await api.deleteBranchAgent(agentId);
-      await get().fetchGitState(agentId);
-    } catch (e) {
-      set({ lastError: String(e) });
-    }
+    await runGitMutation(get, agentId, () => api.deleteBranchAgent(agentId));
   },
 
   createPr: async (agentId, title, body) => {


### PR DESCRIPTION
## Summary

Removes duplicated mutation/patch patterns in the store slices flagged by review, replacing them with small shared helpers. Behavior-preserving — net **-49 lines**.

## Changes

**`src/store/git.ts`**
- `runGitMutation(get, agentId, fn)` — collapses the repeated `try { api.X(); fetchGitState(); return true } catch { setError; return false }` shape. Applied to `pullAgent`, `rebaseAgent`, `commitChanges`, `stashChanges`, `discardChanges`, `abortMerge`, `deleteBranch`. Only needs `get`, since `fetchGitState` and `setLastError` are both store actions.
- `fetchPrAux(set, agentId, key, fetch)` — generic over `"prChecks" | "prComments"`, folding the two near-identical fetchers (including the first-failure-degrades-to-null behavior) into one. `fetchPrChecks`/`fetchPrComments` are now one-liners.
- Left as-is intentionally: `pushAgent` (returns a summary), `createPr` (no git-state refresh), `mergePr` (refreshes PR state/checks), and `commitAndOpenPr` (multi-step + refreshes on the catch path).

**`src/store/app.ts`**
- `mapAgents(ws, id, patch)` (pure) + `patchAgent(get, set, id, patch)` — replace the repeated `agents.map(a => a.id === id ? {...a, ...} : a)` across `onAgentBranch`, `onAgentRepoAdded`, `onAgentTask`, `onAgentView`. `patch` accepts a flat partial or `(a) => partial` for patches that read the current record.
- `onAgentStatus` reuses the pure `mapAgents` directly so it keeps its single batched `set` (which also writes `managedLogs`/`managedBusy`).

## Verification
- `tsc --noEmit` clean across the project.
- `@biomejs/biome@2.5.1 check` clean.
- No store tests cover these slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)