### PR TITLE
refactor(supervisor): factor shared spawn-wrapper closures

### DIFF
--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -1914,6 +1914,87 @@ pub(crate) fn read_jsonl_values(path: &Path) -> Result<Vec<Value>> {
     Ok(out)
 }
 
+/// Process-exit outcomes that feed `apply_exit_if_current`. `PtyExit` and
+/// `ManagedExit` are distinct types but carry the same fields, so this trait
+/// lets `make_exit_handler` cover both spawners with one closure.
+trait ExitOutcome {
+    fn into_parts(self) -> (bool, String);
+}
+
+impl ExitOutcome for crate::pty_session::PtyExit {
+    fn into_parts(self) -> (bool, String) {
+        (self.success, self.message)
+    }
+}
+
+impl ExitOutcome for crate::managed_session::ManagedExit {
+    fn into_parts(self) -> (bool, String) {
+        (self.success, self.message)
+    }
+}
+
+/// Raw-byte output callback shared by the PTY spawners: record activity, then
+/// emit `agent:output`.
+fn make_output_handler(
+    sup: Arc<Supervisor>,
+    app: AppHandle,
+    agent_id: String,
+) -> impl Fn(Vec<u8>) + Send + Sync + 'static {
+    move |bytes: Vec<u8>| {
+        if let Some(activity) = sup.activities.lock().get_mut(&agent_id) {
+            activity.observe_bytes(&bytes);
+        }
+
+        if let Err(e) = app.emit(
+            "agent:output",
+            AgentOutputPayload {
+                agent_id: agent_id.clone(),
+                bytes,
+            },
+        ) {
+            tracing::warn!(error = %e, agent_id = %agent_id, "emit agent:output failed");
+        }
+    }
+}
+
+/// Parsed-JSON event callback shared by the managed + per-turn spawners:
+/// record activity, then emit `agent:event`.
+fn make_event_handler(
+    sup: Arc<Supervisor>,
+    app: AppHandle,
+    agent_id: String,
+) -> impl Fn(Value) + Send + Sync + 'static {
+    move |event: Value| {
+        if let Some(activity) = sup.activities.lock().get_mut(&agent_id) {
+            activity.observe_event(&event);
+        }
+
+        if let Err(e) = app.emit(
+            "agent:event",
+            AgentEventPayload {
+                agent_id: agent_id.clone(),
+                event,
+            },
+        ) {
+            tracing::warn!(error = %e, agent_id = %agent_id, "emit agent:event failed");
+        }
+    }
+}
+
+/// Process-exit callback shared by the pty/managed spawners: hand the outcome
+/// to `apply_exit_if_current`, which ignores exits from a stale generation.
+fn make_exit_handler<E: ExitOutcome>(
+    sup: Arc<Supervisor>,
+    app: AppHandle,
+    agent_id: String,
+    gen: u64,
+) -> impl Fn(E) + Send + Sync + 'static {
+    move |exit: E| {
+        let (success, message) = exit.into_parts();
+        apply_exit_if_current(&sup, &app, &agent_id, gen, success, message);
+    }
+}
+
 fn spawn_pty_agent(
     spec: SpawnSpec<'_>,
     app: AppHandle,
@@ -1921,36 +2002,10 @@ fn spawn_pty_agent(
     sup: Arc<Supervisor>,
     gen: u64,
 ) -> Result<Agent> {
-    let app_for_output = app.clone();
-    let id_for_output = agent_id.clone();
-    let sup_for_output = sup.clone();
-    let sup_for_exit = sup;
-    let app_for_exit = app.clone();
-    let id_for_exit = agent_id.clone();
     Agent::spawn_pty(
         spec,
-        move |bytes| {
-            if let Some(activity) = sup_for_output
-                .activities
-                .lock()
-                .get_mut(&id_for_output)
-            {
-                activity.observe_bytes(&bytes);
-            }
-
-            if let Err(e) = app_for_output.emit(
-                "agent:output",
-                AgentOutputPayload {
-                    agent_id: id_for_output.clone(),
-                    bytes,
-                },
-            ) {
-                tracing::warn!(error = %e, agent_id = %id_for_output, "emit agent:output failed");
-            }
-        },
-        move |exit| {
-            apply_exit_if_current(&sup_for_exit, &app_for_exit, &id_for_exit, gen, exit.success, exit.message);
-        },
+        make_output_handler(sup.clone(), app.clone(), agent_id.clone()),
+        make_exit_handler(sup, app, agent_id, gen),
     )
 }
 
@@ -1965,33 +2020,11 @@ fn spawn_pty_per_turn_agent(
     sup: Arc<Supervisor>,
     gen: u64,
 ) -> Result<Agent> {
-    let app_for_output = app.clone();
-    let id_for_output = agent_id.clone();
-    let sup_for_output = sup.clone();
-    let sup_for_exit = sup;
-    let app_for_exit = app.clone();
-    let id_for_exit = agent_id.clone();
     Agent::spawn_pty_native(
         spec,
         &provider,
-        move |bytes| {
-            if let Some(activity) = sup_for_output.activities.lock().get_mut(&id_for_output) {
-                activity.observe_bytes(&bytes);
-            }
-
-            if let Err(e) = app_for_output.emit(
-                "agent:output",
-                AgentOutputPayload {
-                    agent_id: id_for_output.clone(),
-                    bytes,
-                },
-            ) {
-                tracing::warn!(error = %e, agent_id = %id_for_output, "emit agent:output failed");
-            }
-        },
-        move |exit| {
-            apply_exit_if_current(&sup_for_exit, &app_for_exit, &id_for_exit, gen, exit.success, exit.message);
-        },
+        make_output_handler(sup.clone(), app.clone(), agent_id.clone()),
+        make_exit_handler(sup, app, agent_id, gen),
     )
 }
 
@@ -2002,36 +2035,10 @@ fn spawn_managed_agent(
     sup: Arc<Supervisor>,
     gen: u64,
 ) -> Result<Agent> {
-    let app_for_event = app.clone();
-    let id_for_event = agent_id.clone();
-    let sup_for_event = sup.clone();
-    let sup_for_exit = sup.clone();
-    let app_for_exit = app.clone();
-    let id_for_exit = agent_id.clone();
     Agent::spawn_managed(
         spec,
-        move |event| {
-            if let Some(activity) = sup_for_event
-                .activities
-                .lock()
-                .get_mut(&id_for_event)
-            {
-                activity.observe_event(&event);
-            }
-
-            if let Err(e) = app_for_event.emit(
-                "agent:event",
-                AgentEventPayload {
-                    agent_id: id_for_event.clone(),
-                    event,
-                },
-            ) {
-                tracing::warn!(error = %e, agent_id = %id_for_event, "emit agent:event failed");
-            }
-        },
-        move |exit| {
-            apply_exit_if_current(&sup_for_exit, &app_for_exit, &id_for_exit, gen, exit.success, exit.message);
-        },
+        make_event_handler(sup.clone(), app.clone(), agent_id.clone()),
+        make_exit_handler(sup, app, agent_id, gen),
     )
 }
 
@@ -2053,29 +2060,13 @@ fn spawn_per_turn_agent(
     sup: Arc<Supervisor>,
     gen: u64,
 ) -> Result<Agent> {
-    let app_for_event = app.clone();
-    let id_for_event = agent_id.clone();
-    let sup_for_event = sup.clone();
     let id_for_sid = agent_id.clone();
     let sup_for_sid = sup.clone();
-    let app_for_exit = app;
-    let id_for_exit = agent_id;
-    let sup_for_exit = sup;
+    let app_for_exit = app.clone();
+    let id_for_exit = agent_id.clone();
+    let sup_for_exit = sup.clone();
 
-    let on_event = move |event: Value| {
-        if let Some(activity) = sup_for_event.activities.lock().get_mut(&id_for_event) {
-            activity.observe_event(&event);
-        }
-        if let Err(e) = app_for_event.emit(
-            "agent:event",
-            AgentEventPayload {
-                agent_id: id_for_event.clone(),
-                event,
-            },
-        ) {
-            tracing::warn!(error = %e, agent_id = %id_for_event, "emit agent:event failed");
-        }
-    };
+    let on_event = make_event_handler(sup, app, agent_id);
     let on_session_id = move |sid: String| {
         if let Err(e) = sup_for_sid.workspace.set_agent_session_id(&id_for_sid, &sid) {
             tracing::warn!(error = %e, agent_id = %id_for_sid, "persist session id failed");


### PR DESCRIPTION
## Summary

AI review flagged four near-identical agent spawn wrappers in `supervisor.rs` (`spawn_pty_agent`, `spawn_pty_per_turn_agent`, `spawn_managed_agent`, `spawn_per_turn_agent`) that each hand-rolled the same `*_for_output`/`*_for_event`/`*_for_exit` clone boilerplate plus identical output/event/exit closure bodies.

This factors the shared closures into three constructors:

- `make_output_handler(sup, app, agent_id)` → `impl Fn(Vec<u8>)` — record activity, emit `agent:output` (pty spawners)
- `make_event_handler(sup, app, agent_id)` → `impl Fn(Value)` — record activity, emit `agent:event` (managed + per-turn spawners)
- `make_exit_handler::<E>(sup, app, agent_id, gen)` → `impl Fn(E)` — hand the outcome to `apply_exit_if_current` (pty/managed spawners)

A small local `ExitOutcome` trait (implemented for `PtyExit` and `ManagedExit`, which carry identical `success`/`message` fields) lets one generic exit closure cover both exit types without per-call boilerplate.

`spawn_per_turn_agent` keeps its distinct session-id and per-turn-exit closures (different lifecycle — it intentionally does not use `apply_exit_if_current`) but now reuses `make_event_handler` for its identical event closure.

## Result

- The `agent:output`/`agent:event` emit logic and the exit generation-guard each now live in exactly one place.
- Net ~91 insertions / ~100 deletions; each wrapper collapses from ~25–35 lines to the spawn call plus helper invocations.

## Testing

- `cargo check` — clean
- `cargo clippy --all-targets` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)