### PR TITLE
refactor(adapters): extract shared buildTurnUsage + endTurn helpers

### DIFF
--- a/src/adapters/claude/usage.ts
+++ b/src/adapters/claude/usage.ts
@@ -10,25 +10,18 @@
 // Claude does not report a context-window size or cost on disk.
 
 import { asNumber, asRecord } from "../shared/json";
+import { buildTurnUsage } from "../shared/usage";
 import type { RawEvent, TurnUsage } from "../types";
 
 export function extractUsage(body: RawEvent): TurnUsage | undefined {
   if (body.type !== "assistant") return undefined;
   const message = asRecord(body.message);
   const usage = asRecord(message.usage);
-  const inputTokens = asNumber(usage.input_tokens);
-  const outputTokens = asNumber(usage.output_tokens);
-  const cacheReadTokens = asNumber(usage.cache_read_input_tokens);
-  const cacheWriteTokens = asNumber(usage.cache_creation_input_tokens);
-  if (inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens === 0) {
-    return undefined;
-  }
-  return {
-    inputTokens,
-    outputTokens,
-    cacheReadTokens,
-    cacheWriteTokens,
-    context: { input: inputTokens, cacheRead: cacheReadTokens, cacheWrite: cacheWriteTokens },
+  return buildTurnUsage({
+    inputTokens: asNumber(usage.input_tokens),
+    outputTokens: asNumber(usage.output_tokens),
+    cacheReadTokens: asNumber(usage.cache_read_input_tokens),
+    cacheWriteTokens: asNumber(usage.cache_creation_input_tokens),
     model: typeof message.model === "string" ? message.model : undefined,
-  };
+  });
 }

--- a/src/adapters/codex/reduce.ts
+++ b/src/adapters/codex/reduce.ts
@@ -18,6 +18,7 @@
 import { asRecord } from "../shared/json";
 import {
   dedupAgainstLast,
+  endTurn,
   finalizeStreamingItems,
   upsertToolCall,
 } from "../shared/reducer-helpers";
@@ -146,8 +147,7 @@ export function reduce(prev: ChatItem[], ev: RawEvent): ChatItem[] {
     }
 
     case "turn.completed": {
-      const items = finalizeStreamingItems(prev);
-      return [...items, { kind: "notice", subtype: "turn_end", text: "success" }];
+      return endTurn(finalizeStreamingItems(prev));
     }
 
     // `turn.failed` / `error` surface as a visible error notice.

--- a/src/adapters/cursor/usage.ts
+++ b/src/adapters/cursor/usage.ts
@@ -12,23 +12,16 @@
 // restart-safe. `inputTokens` is fresh (excludes cache), Anthropic-style.
 
 import { asNumber, asRecord } from "../shared/json";
+import { buildTurnUsage } from "../shared/usage";
 import type { RawEvent, TurnUsage } from "../types";
 
 export function extractUsage(body: RawEvent): TurnUsage | undefined {
   if (body.type !== "result") return undefined;
   const usage = asRecord(body.usage);
-  const inputTokens = asNumber(usage.inputTokens);
-  const outputTokens = asNumber(usage.outputTokens);
-  const cacheReadTokens = asNumber(usage.cacheReadTokens);
-  const cacheWriteTokens = asNumber(usage.cacheWriteTokens);
-  if (inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens === 0) {
-    return undefined;
-  }
-  return {
-    inputTokens,
-    outputTokens,
-    cacheReadTokens,
-    cacheWriteTokens,
-    context: { input: inputTokens, cacheRead: cacheReadTokens, cacheWrite: cacheWriteTokens },
-  };
+  return buildTurnUsage({
+    inputTokens: asNumber(usage.inputTokens),
+    outputTokens: asNumber(usage.outputTokens),
+    cacheReadTokens: asNumber(usage.cacheReadTokens),
+    cacheWriteTokens: asNumber(usage.cacheWriteTokens),
+  });
 }

--- a/src/adapters/opencode/reduce.ts
+++ b/src/adapters/opencode/reduce.ts
@@ -23,6 +23,7 @@ import { asRecord } from "../shared/json";
 import {
   aliasToolInput,
   dedupAgainstLast,
+  endTurn,
   finalizeStreamingItems,
   upsertToolCall,
 } from "../shared/reducer-helpers";
@@ -141,7 +142,7 @@ export function reduce(prev: ChatItem[], ev: RawEvent): ChatItem[] {
       // Only the turn's final step stops; intermediate `tool-calls` steps just
       // settle any still-streaming items.
       if (reason === "stop") {
-        return [...items, { kind: "notice", subtype: "turn_end", text: "success" }];
+        return endTurn(items);
       }
       return items;
     }

--- a/src/adapters/opencode/usage.ts
+++ b/src/adapters/opencode/usage.ts
@@ -16,6 +16,7 @@
 // resolves that from the catalog via `model`.
 
 import { asNumber, asRecord } from "../shared/json";
+import { buildTurnUsage } from "../shared/usage";
 import type { RawEvent, TurnUsage } from "../types";
 
 export function extractUsage(body: RawEvent): TurnUsage | undefined {
@@ -28,21 +29,12 @@ export function extractUsage(body: RawEvent): TurnUsage | undefined {
   const tokens = asRecord(src.tokens);
   const cache = asRecord(tokens.cache);
 
-  const inputTokens = asNumber(tokens.input);
-  const outputTokens = asNumber(tokens.output) + asNumber(tokens.reasoning);
-  const cacheReadTokens = asNumber(cache.read);
-  const cacheWriteTokens = asNumber(cache.write);
-  if (inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens === 0) {
-    return undefined;
-  }
-
-  return {
-    inputTokens,
-    outputTokens,
-    cacheReadTokens,
-    cacheWriteTokens,
+  return buildTurnUsage({
+    inputTokens: asNumber(tokens.input),
+    outputTokens: asNumber(tokens.output) + asNumber(tokens.reasoning),
+    cacheReadTokens: asNumber(cache.read),
+    cacheWriteTokens: asNumber(cache.write),
     costUsd: asNumber(src.cost),
-    context: { input: inputTokens, cacheRead: cacheReadTokens, cacheWrite: cacheWriteTokens },
-    ...(typeof src.modelID === "string" ? { model: src.modelID } : {}),
-  };
+    model: typeof src.modelID === "string" ? src.modelID : undefined,
+  });
 }

--- a/src/adapters/pi/reduce.ts
+++ b/src/adapters/pi/reduce.ts
@@ -23,6 +23,7 @@ import { asBlockList, asRecord } from "../shared/json";
 import {
   aliasToolInput,
   dedupAgainstLast,
+  endTurn,
   finalizeStreamingItems,
   upsertToolCall,
 } from "../shared/reducer-helpers";
@@ -113,8 +114,7 @@ export function reduce(prev: ChatItem[], ev: RawEvent): ChatItem[] {
 
     // The whole turn is done (fires once; `turn_end` fires per step).
     case "agent_end": {
-      const items = finalizeStreamingItems(prev);
-      return [...items, { kind: "notice", subtype: "turn_end", text: "success" }];
+      return endTurn(finalizeStreamingItems(prev));
     }
 
     default:

--- a/src/adapters/pi/usage.ts
+++ b/src/adapters/pi/usage.ts
@@ -10,6 +10,7 @@
 // context-window size.
 
 import { asNumber, asRecord } from "../shared/json";
+import { buildTurnUsage } from "../shared/usage";
 import type { RawEvent, TurnUsage } from "../types";
 
 export function extractUsage(body: RawEvent): TurnUsage | undefined {
@@ -18,21 +19,12 @@ export function extractUsage(body: RawEvent): TurnUsage | undefined {
   if (message.role !== "assistant") return undefined;
 
   const usage = asRecord(message.usage);
-  const inputTokens = asNumber(usage.input);
-  const outputTokens = asNumber(usage.output);
-  const cacheReadTokens = asNumber(usage.cacheRead);
-  const cacheWriteTokens = asNumber(usage.cacheWrite);
-  if (inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens === 0) {
-    return undefined;
-  }
-
-  return {
-    inputTokens,
-    outputTokens,
-    cacheReadTokens,
-    cacheWriteTokens,
+  return buildTurnUsage({
+    inputTokens: asNumber(usage.input),
+    outputTokens: asNumber(usage.output),
+    cacheReadTokens: asNumber(usage.cacheRead),
+    cacheWriteTokens: asNumber(usage.cacheWrite),
     costUsd: asNumber(asRecord(usage.cost).total),
-    context: { input: inputTokens, cacheRead: cacheReadTokens, cacheWrite: cacheWriteTokens },
     model: typeof message.model === "string" ? message.model : undefined,
-  };
+  });
 }

--- a/src/adapters/shared/reducer-helpers.ts
+++ b/src/adapters/shared/reducer-helpers.ts
@@ -10,6 +10,15 @@ function findLastIndex<T>(items: T[], predicate: (item: T) => boolean): number {
   return -1;
 }
 
+/** Append a successful turn_end notice. The agents whose live streams carry a
+ *  single, unconditional end-of-turn event (codex `turn.completed`, pi
+ *  `agent_end`, opencode `step_finish:stop`) all close the turn this way.
+ *  Claude differs — its result event encodes a pass/fail subtype — so it
+ *  builds the notice inline. */
+export function endTurn(items: ChatItem[]): ChatItem[] {
+  return [...items, { kind: "notice", subtype: "turn_end", text: "success" }];
+}
+
 /** Append text to the most recent streaming agent_message, or start a new one.
  *  Walks back across non-agent items (e.g. interleaved tool_calls) — claude
  *  emits text/tool_use as separate content blocks within one turn, and a

--- a/src/adapters/shared/usage.ts
+++ b/src/adapters/shared/usage.ts
@@ -1,0 +1,39 @@
+import type { TurnUsage } from "../types";
+
+export interface UsageTokens {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  /** Dollar cost, only for agents that report it natively (opencode, pi). */
+  costUsd?: number;
+  model?: string;
+}
+
+/** Build a per-record TurnUsage from the four normalized token counts shared by
+ *  claude/cursor/pi/opencode: applies the all-zero guard (returns undefined when
+ *  the record carries no usage) and derives the default context-fill split
+ *  `{ input, cacheRead, cacheWrite }`. Pass `costUsd`/`model` when the agent
+ *  reports them. Codex differs (cumulative totals, derived fresh input and
+ *  context) and builds its TurnUsage directly. */
+export function buildTurnUsage({
+  inputTokens,
+  outputTokens,
+  cacheReadTokens,
+  cacheWriteTokens,
+  costUsd,
+  model,
+}: UsageTokens): TurnUsage | undefined {
+  if (inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens === 0) {
+    return undefined;
+  }
+  return {
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+    ...(costUsd !== undefined ? { costUsd } : {}),
+    context: { input: inputTokens, cacheRead: cacheReadTokens, cacheWrite: cacheWriteTokens },
+    ...(model !== undefined ? { model } : {}),
+  };
+}


### PR DESCRIPTION
## Summary

Removes duplication across the chat adapters flagged in review.

- **Usage extractors** — `{claude,cursor,pi,opencode}/usage.ts` each repeated the same all-zero guard plus `context: { input, cacheRead, cacheWrite }` construction. Extracted `buildTurnUsage(...)` into `src/adapters/shared/usage.ts`; each extractor now just normalizes its agent-specific field names and delegates (cost/model passed when reported).
- **Turn-end notice** — `{codex,pi,opencode}/reduce.ts` each built `{ kind: "notice", subtype: "turn_end", text: "success" }` verbatim. Added `endTurn(items)` to `src/adapters/shared/reducer-helpers.ts` and routed the three callers through it.

## Intentionally left inline

- **Codex usage** — uses cumulative totals, a derived fresh-input, a custom context split, and a different zero-guard, so it doesn't fit `buildTurnUsage`.
- **Claude's turn_end** — its text is conditional (`error` / subtype / `success`), unlike the three unconditional cases `endTurn` covers.

Both exceptions are documented in the new helpers.

## Testing

- `tsc --noEmit` passes
- All 105 adapter tests pass (output shapes unchanged)
- Changed files lint clean under biome

🤖 Generated with [Claude Code](https://claude.com/claude-code)