### PR TITLE
feat(chat): add ⌘F find-in-conversation search

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1139,10 +1139,87 @@ button {
 
 /* chat */
 .chat {
+  position: relative;
   flex: 1;
   display: flex;
   flex-direction: column;
   min-height: 0;
+}
+
+/* Find-in-conversation bar (⌘F) — floats over the top-right of the log so it
+   never reflows the messages underneath it. */
+.chat-search {
+  position: absolute;
+  top: 12px;
+  right: 24px;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 6px 5px 10px;
+  background: var(--bg-2);
+  border: 1px solid var(--bd-strong);
+  border-radius: var(--r-md);
+  box-shadow: var(--shadow-2);
+  animation: chat-search-in 120ms ease-out;
+}
+@keyframes chat-search-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+.chat-search-icon {
+  color: var(--fg-3);
+  flex-shrink: 0;
+}
+.chat-search-input {
+  width: 200px;
+  height: 24px;
+  padding: 0 2px;
+  border: 0;
+  background: transparent;
+  color: var(--fg-0);
+  font-size: 13px;
+  outline: none;
+}
+.chat-search-input::placeholder {
+  color: var(--fg-3);
+}
+.chat-search-count {
+  flex-shrink: 0;
+  min-width: 38px;
+  text-align: right;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--fg-2);
+}
+.chat-search-count.no-match {
+  color: var(--danger);
+}
+.chat-search-actions {
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  padding-left: 4px;
+  margin-left: 2px;
+  border-left: 1px solid var(--bd-soft);
+}
+
+/* Painted by the CSS Custom Highlight API (see useChatSearch). These pseudo-
+   elements style Range objects without touching the DOM React owns. */
+::highlight(chat-find) {
+  background: var(--accent-soft);
+  border-radius: 2px;
+}
+::highlight(chat-find-current) {
+  background: var(--accent);
+  color: var(--bg-0);
 }
 .chat-scroll {
   flex: 1;

--- a/src/components/Workspace/ChatSearch/index.tsx
+++ b/src/components/Workspace/ChatSearch/index.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useRef } from "react";
+import { Icon } from "../../Icon";
+import { useChatSearch } from "./useChatSearch";
+
+/** Floating "find in conversation" bar, opened with ⌘F over the chat log.
+ *  Highlights matches in place and steps through them with Enter / ⇧Enter or
+ *  the up/down buttons. Esc closes. */
+export function ChatSearch({
+  containerRef,
+  query,
+  onQueryChange,
+  contentVersion,
+  onClose,
+}: {
+  containerRef: React.RefObject<HTMLElement | null>;
+  query: string;
+  onQueryChange: (value: string) => void;
+  contentVersion: unknown;
+  onClose: () => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { total, current, next, prev } = useChatSearch(containerRef, query, true, contentVersion);
+
+  // Focus + select on open so a second ⌘F (which re-mounts nothing) is handled
+  // by ChatView refocusing this same input via its id.
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  const noMatches = query.length > 0 && total === 0;
+
+  return (
+    <div className="chat-search" role="search">
+      <Icon name="search" size={12} className="chat-search-icon" />
+      <input
+        id="chat-search-input"
+        ref={inputRef}
+        className="chat-search-input"
+        placeholder="Find in conversation…"
+        value={query}
+        spellCheck={false}
+        onChange={(e) => onQueryChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            if (e.shiftKey) prev();
+            else next();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            onClose();
+          }
+        }}
+      />
+      <span className={`chat-search-count${noMatches ? " no-match" : ""}`}>
+        {query ? `${current}/${total}` : ""}
+      </span>
+      <div className="chat-search-actions">
+        <button
+          className="btn-i sm tip"
+          data-tip="Previous (⇧⏎)"
+          disabled={total === 0}
+          onClick={prev}
+        >
+          <Icon name="chevU" />
+        </button>
+        <button
+          className="btn-i sm tip"
+          data-tip="Next (⏎)"
+          disabled={total === 0}
+          onClick={next}
+        >
+          <Icon name="chevD" />
+        </button>
+        <button className="btn-i sm tip" data-tip="Close (Esc)" onClick={onClose}>
+          <Icon name="close" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Workspace/ChatSearch/index.tsx
+++ b/src/components/Workspace/ChatSearch/index.tsx
@@ -64,12 +64,7 @@ export function ChatSearch({
         >
           <Icon name="chevU" />
         </button>
-        <button
-          className="btn-i sm tip"
-          data-tip="Next (⏎)"
-          disabled={total === 0}
-          onClick={next}
-        >
+        <button className="btn-i sm tip" data-tip="Next (⏎)" disabled={total === 0} onClick={next}>
           <Icon name="chevD" />
         </button>
         <button className="btn-i sm tip" data-tip="Close (Esc)" onClick={onClose}>

--- a/src/components/Workspace/ChatSearch/useChatSearch.ts
+++ b/src/components/Workspace/ChatSearch/useChatSearch.ts
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/** Names of the two registered CSS custom highlights. One paints every match
+ *  faintly; the other paints the active match in the accent colour. */
+const HL_ALL = "chat-find";
+const HL_CURRENT = "chat-find-current";
+
+/** The CSS Custom Highlight API lets us paint matches over the existing text
+ *  nodes via Range objects — without mutating the DOM that React owns, so we
+ *  never fight re-renders or break the markdown tree. Feature-detected because
+ *  it only landed in WebKit 17.2; where missing, navigation still works (we
+ *  scroll to each match) but nothing is painted. */
+const HIGHLIGHT_SUPPORTED =
+  typeof CSS !== "undefined" &&
+  "highlights" in CSS &&
+  typeof (globalThis as { Highlight?: unknown }).Highlight !== "undefined";
+
+export interface ChatSearchState {
+  /** Total number of matches currently in the (visible) conversation. */
+  total: number;
+  /** 1-based index of the active match for display; 0 when there are none. */
+  current: number;
+  /** Advance to the next match, wrapping around at the end. */
+  next: () => void;
+  /** Step to the previous match, wrapping around at the start. */
+  prev: () => void;
+}
+
+/** Walk every visible text node under `container` and collect a Range for each
+ *  case-insensitive occurrence of `query`. Matches are returned in document
+ *  order, which is also visual (top-to-bottom) order in this scroll log. */
+function collectRanges(container: HTMLElement, query: string): Range[] {
+  const ranges: Range[] = [];
+  const needle = query.toLowerCase();
+  if (!needle) return ranges;
+
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      return node.nodeValue && node.nodeValue.length > 0
+        ? NodeFilter.FILTER_ACCEPT
+        : NodeFilter.FILTER_REJECT;
+    },
+  });
+
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    const haystack = (node.nodeValue ?? "").toLowerCase();
+    let from = haystack.indexOf(needle);
+    while (from !== -1) {
+      const range = document.createRange();
+      range.setStart(node, from);
+      range.setEnd(node, from + needle.length);
+      ranges.push(range);
+      from = haystack.indexOf(needle, from + needle.length);
+    }
+  }
+  return ranges;
+}
+
+/** Scroll the container so `range` is comfortably visible. Leaves it alone when
+ *  already fully in view, so typing more characters doesn't yank a still-visible
+ *  match around; otherwise centres it. */
+function scrollRangeIntoView(container: HTMLElement, range: Range): void {
+  const rRect = range.getBoundingClientRect();
+  if (rRect.width === 0 && rRect.height === 0) return; // detached / zero-size
+  const cRect = container.getBoundingClientRect();
+  if (rRect.top >= cRect.top && rRect.bottom <= cRect.bottom) return; // visible
+  const offset = rRect.top - cRect.top - container.clientHeight / 2 + rRect.height / 2;
+  container.scrollTo({ top: container.scrollTop + offset, behavior: "smooth" });
+}
+
+function clearHighlights(): void {
+  if (!HIGHLIGHT_SUPPORTED) return;
+  CSS.highlights.delete(HL_ALL);
+  CSS.highlights.delete(HL_CURRENT);
+}
+
+/** In-conversation find. Recomputes match ranges whenever the query, the
+ *  conversation content, or the active flag changes, and exposes next/prev
+ *  navigation that paints + scrolls to the active match.
+ *
+ *  @param containerRef   the scrollable chat log element to search within
+ *  @param query          the search text (empty clears everything)
+ *  @param active         whether the search bar is open
+ *  @param contentVersion any value whose identity changes when the rendered
+ *                        conversation changes (e.g. the derived items array),
+ *                        used to recompute matches as messages stream in */
+export function useChatSearch(
+  containerRef: React.RefObject<HTMLElement | null>,
+  query: string,
+  active: boolean,
+  contentVersion: unknown,
+): ChatSearchState {
+  const [total, setTotal] = useState(0);
+  const [idx, setIdx] = useState(0);
+  const rangesRef = useRef<Range[]>([]);
+
+  // Recompute the match set. Resetting idx to 0 keeps "type, then Enter to walk
+  // matches" behaving like every other find box.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!active || !container || !query) {
+      rangesRef.current = [];
+      setTotal(0);
+      setIdx(0);
+      clearHighlights();
+      return;
+    }
+    const ranges = collectRanges(container, query);
+    rangesRef.current = ranges;
+    setTotal(ranges.length);
+    setIdx(0);
+  }, [containerRef, query, active, contentVersion]);
+
+  // Paint the current match set and bring the active one into view. Runs after
+  // the recompute effect (idx/total just changed) and on every next/prev.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const ranges = rangesRef.current;
+    if (HIGHLIGHT_SUPPORTED) {
+      clearHighlights();
+      if (ranges.length > 0) {
+        CSS.highlights.set(HL_ALL, new Highlight(...ranges));
+        const cur = ranges[idx];
+        if (cur) CSS.highlights.set(HL_CURRENT, new Highlight(cur));
+      }
+    }
+    const cur = ranges[idx];
+    if (cur) scrollRangeIntoView(container, cur);
+  }, [containerRef, idx, total]);
+
+  // Always drop highlights when the hook unmounts (search closed / view gone).
+  useEffect(() => clearHighlights, []);
+
+  const next = useCallback(() => {
+    setIdx((i) => {
+      const n = rangesRef.current.length;
+      return n === 0 ? 0 : (i + 1) % n;
+    });
+  }, []);
+
+  const prev = useCallback(() => {
+    setIdx((i) => {
+      const n = rangesRef.current.length;
+      return n === 0 ? 0 : (i - 1 + n) % n;
+    });
+  }, []);
+
+  return { total, current: total === 0 ? 0 : idx + 1, next, prev };
+}

--- a/src/components/Workspace/ChatSearch/useChatSearch.ts
+++ b/src/components/Workspace/ChatSearch/useChatSearch.ts
@@ -26,13 +26,31 @@ export interface ChatSearchState {
   prev: () => void;
 }
 
+/** Escape a user query so it can be matched literally inside a RegExp. */
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 /** Walk every visible text node under `container` and collect a Range for each
  *  case-insensitive occurrence of `query`. Matches are returned in document
- *  order, which is also visual (top-to-bottom) order in this scroll log. */
+ *  order, which is also visual (top-to-bottom) order in this scroll log.
+ *
+ *  Matching runs against the original node text via a case-insensitive RegExp,
+ *  so `match.index` / length are always valid offsets into that same node. We
+ *  deliberately do NOT lowercase the text first: for code points whose
+ *  lowercase form expands (e.g. "İ" → "i" + combining dot), offsets computed
+ *  on the lowercased string would drift past the original node length and make
+ *  range.setEnd throw mid-search. */
 function collectRanges(container: HTMLElement, query: string): Range[] {
   const ranges: Range[] = [];
-  const needle = query.toLowerCase();
-  if (!needle) return ranges;
+  if (!query) return ranges;
+
+  let matcher: RegExp;
+  try {
+    matcher = new RegExp(escapeRegExp(query), "gi");
+  } catch {
+    return ranges; // malformed pattern — nothing to highlight
+  }
 
   const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, {
     acceptNode(node) {
@@ -43,14 +61,16 @@ function collectRanges(container: HTMLElement, query: string): Range[] {
   });
 
   for (let node = walker.nextNode(); node; node = walker.nextNode()) {
-    const haystack = (node.nodeValue ?? "").toLowerCase();
-    let from = haystack.indexOf(needle);
-    while (from !== -1) {
+    const text = node.nodeValue ?? "";
+    matcher.lastIndex = 0;
+    for (let m = matcher.exec(text); m; m = matcher.exec(text)) {
       const range = document.createRange();
-      range.setStart(node, from);
-      range.setEnd(node, from + needle.length);
+      range.setStart(node, m.index);
+      range.setEnd(node, m.index + m[0].length);
       ranges.push(range);
-      from = haystack.indexOf(needle, from + needle.length);
+      // Guard against zero-length matches (defensive — the escaped query is
+      // never empty here) so exec() can't loop forever.
+      if (m[0].length === 0) matcher.lastIndex += 1;
     }
   }
   return ranges;

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { applyPolicy, getAdapter } from "../../adapters";
 import { type AgentRecord, api } from "../../api";
 import { providerLabel } from "../../data/providers";
 import { useAppStore } from "../../store";
 import { Composer } from "../Composer";
+import { ChatSearch } from "./ChatSearch";
 import { MessageItem } from "./messages/MessageItem";
 import { pairToolItems, rowKey } from "./messages/pair";
 import { isUserInputTool } from "./messages/UserInput/parse";
@@ -38,6 +39,43 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
   );
 
   const scrollRef = useRef<HTMLDivElement>(null);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const closeSearch = useCallback(() => {
+    setSearchOpen(false);
+    setSearchQuery("");
+  }, []);
+
+  // ⌘F / Ctrl+F opens find-in-conversation. A repeat press while open just
+  // refocuses + selects the existing input (the bar is already mounted), which
+  // mirrors how browsers behave.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && (e.key === "f" || e.key === "F")) {
+        // The right-panel terminal has its own ⌘F (handled by xterm); its
+        // keydown still bubbles to window, so ignore presses originating there.
+        if ((e.target as HTMLElement | null)?.closest(".term-panel")) return;
+        e.preventDefault();
+        setSearchOpen(true);
+        requestAnimationFrame(() => {
+          const el = document.getElementById("chat-search-input") as HTMLInputElement | null;
+          el?.focus();
+          el?.select();
+        });
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  // Close the find bar when switching conversations — its matches belong to the
+  // log we're leaving.
+  useEffect(() => {
+    setSearchOpen(false);
+    setSearchQuery("");
+  }, [agent.id]);
+
   // Whether the chat is "pinned" to the bottom. While true we follow new
   // messages; once the user scrolls up we stop auto-scrolling and leave their
   // position alone until they scroll back down to the bottom.
@@ -123,6 +161,15 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
 
   return (
     <div className="chat">
+      {searchOpen && (
+        <ChatSearch
+          containerRef={scrollRef}
+          query={searchQuery}
+          onQueryChange={setSearchQuery}
+          contentVersion={items}
+          onClose={closeSearch}
+        />
+      )}
       <div className="chat-scroll" ref={scrollRef} onScroll={handleScroll}>
         <div className="chat-inner fade-in" key={agent.id}>
           {transcriptLoading && items.length === 0 ? (


### PR DESCRIPTION
## What

Adds a **find-in-conversation** search to the chat frame, opened with **⌘F / Ctrl+F**. Previously the only way to locate something in a long conversation was to scroll and scan manually.

## UX

- Floating bar over the top-right of the chat log — it does **not** reflow the messages underneath.
- Live highlighting as you type: all matches tinted with the accent color, the active match gets a solid accent fill.
- Match counter (`3/17`), red on zero matches.
- Keyboard: `Enter` → next, `⇧Enter` → previous (both wrap), `Esc` → close. Up/down/close buttons mirror this with tooltips.
- Auto-scroll only fires when the active match is off-screen, then centers it smoothly.
- A second ⌘F refocuses + selects the input; switching agents closes the bar.

## How

Highlighting uses the **CSS Custom Highlight API** (`::highlight()` + `Range` objects), which paints over existing text nodes without mutating the DOM React owns — so it never fights markdown re-renders or streaming. Feature-detected; navigation/scroll still work where unsupported. The ⌘F handler ignores presses originating in the right-panel terminal, which has its own ⌘F.

## Files

- `src/components/Workspace/ChatSearch/useChatSearch.ts` — match collection, highlight painting, next/prev navigation hook
- `src/components/Workspace/ChatSearch/index.tsx` — search bar UI
- `src/components/Workspace/ChatView.tsx` — ⌘F handling + mounts the bar
- `src/app.css` — bar styling + highlight pseudo-elements

## Limitation

Search matches only visible text — collapsed tool rows and subagent threads aren't in the DOM until expanded, so they aren't searched (same as browser find). Reaching inside collapsed rows would be a larger follow-up.

## Testing

- `tsc --noEmit` passes
- `biome check` passes
- Not launched live (Tauri desktop GUI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)