### PR TITLE
feat(chat): turn navigator for jumping between messages

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1144,6 +1144,12 @@ button {
   flex-direction: column;
   min-height: 0;
 }
+.chat-scroll-wrap {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
 .chat-scroll {
   flex: 1;
   overflow-y: auto;
@@ -1175,6 +1181,178 @@ button {
   }
 }
 
+/* Turn navigator — compact pill docked bottom-right of the transcript. */
+.chat-nav {
+  position: absolute;
+  right: 18px;
+  top: 16px;
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+  user-select: none;
+}
+.chat-nav-bar {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  background: var(--bg-2);
+  border: 1px solid var(--bd-soft);
+  border-radius: 10px;
+  box-shadow: var(--shadow-2);
+  overflow: hidden;
+  opacity: 0.55;
+  transition: opacity 0.18s var(--ease);
+}
+.chat-nav:hover .chat-nav-bar,
+.chat-nav:focus-within .chat-nav-bar {
+  opacity: 1;
+}
+.chat-nav-btn,
+.chat-nav-count {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--fg-1);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background 0.12s var(--ease),
+    color 0.12s var(--ease);
+}
+.chat-nav-btn {
+  /* Stretch to the bar's width (set by the widest row — usually the count) so
+     the chevron glyphs stay centered even with large turn counts like 44/54. */
+  width: 100%;
+  min-width: 32px;
+  height: 26px;
+  padding: 0 4px;
+}
+.chat-nav-btn:hover:not(:disabled) {
+  background: var(--hover);
+  color: var(--fg-0);
+}
+.chat-nav-btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+.chat-nav-btn svg {
+  width: 12px;
+  height: 12px;
+}
+/* The count and the list glyph share one grid cell: at rest the pill shows
+   "n / N"; on hover (or while open) it cross-dissolves into ☰ with a gentle
+   scale so it reads as a morph rather than a blink, hinting that clicking
+   reveals the table of contents. The cell sizes to the wider child (the
+   number), so the swap doesn't shift layout. */
+.chat-nav-count {
+  display: grid;
+  place-items: center;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  min-height: 28px;
+  padding: 6px 4px;
+  white-space: nowrap;
+  border-top: 1px solid var(--bd-soft);
+  border-bottom: 1px solid var(--bd-soft);
+}
+.chat-nav-count-n,
+.chat-nav-count svg {
+  grid-area: 1 / 1;
+  transition:
+    opacity 0.34s var(--ease),
+    transform 0.34s var(--ease);
+}
+.chat-nav-count-n {
+  display: inline-flex;
+  align-items: baseline;
+}
+.chat-nav-count svg {
+  width: 15px;
+  height: 15px;
+  color: var(--fg-0);
+  opacity: 0;
+  transform: scale(0.7);
+}
+.chat-nav-count:hover .chat-nav-count-n,
+.chat-nav-count[aria-expanded="true"] .chat-nav-count-n {
+  opacity: 0;
+  transform: scale(0.7);
+}
+.chat-nav-count:hover svg,
+.chat-nav-count[aria-expanded="true"] svg {
+  opacity: 1;
+  transform: scale(1);
+}
+.chat-nav-count:hover,
+.chat-nav-count[aria-expanded="true"] {
+  background: var(--hover);
+  color: var(--fg-0);
+}
+.chat-nav-count[aria-expanded="true"] svg {
+  color: var(--accent);
+}
+.chat-nav-sep {
+  opacity: 0.5;
+  margin: 0 1px;
+}
+.chat-nav-list {
+  background: var(--bg-2);
+  border: 1px solid var(--bd-soft);
+  border-radius: 12px;
+  box-shadow: var(--shadow-2);
+  width: 300px;
+  max-height: 340px;
+  overflow-y: auto;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.chat-nav-row {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  border-radius: 8px;
+  cursor: pointer;
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+  padding: 7px 9px;
+  text-align: left;
+  color: var(--fg-1);
+  transition: background 0.12s var(--ease);
+}
+.chat-nav-row:hover {
+  background: var(--hover);
+  color: var(--fg-0);
+}
+.chat-nav-row.is-active {
+  background: var(--accent-line);
+  color: var(--fg-0);
+}
+.chat-nav-row-n {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--fg-3);
+  min-width: 16px;
+  text-align: right;
+  flex-shrink: 0;
+}
+.chat-nav-row.is-active .chat-nav-row-n {
+  color: var(--accent);
+}
+.chat-nav-row-t {
+  font-size: 12.5px;
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .m-user {
   align-self: flex-end;
   max-width: 78%;
@@ -1187,6 +1365,8 @@ button {
   color: var(--fg-0);
   white-space: pre-wrap;
   margin-bottom: 16px;
+  /* Leaves breathing room under the top padding when ChatNav jumps here. */
+  scroll-margin-top: 24px;
 }
 
 .m-agent {

--- a/src/components/Workspace/ChatNav/index.tsx
+++ b/src/components/Workspace/ChatNav/index.tsx
@@ -1,0 +1,223 @@
+import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
+
+/** One navigable turn: `id` matches the `data-chat-turn` attribute on the
+ *  rendered user bubble; `text` is the prompt preview shown in the outline. */
+export interface ChatTurn {
+  id: number;
+  text: string;
+}
+
+/** Sleek turn navigator docked to the top-right of the transcript.
+ *
+ *  - `▲ / ▼` (and Alt+↑ / Alt+↓) step one user turn at a time for sequential
+ *    reading.
+ *  - Clicking the `n / N` counter opens an outline of every user prompt, so any
+ *    message is reachable in a single click — no scrolling the whole log.
+ *
+ *  Self-contained: it reads turn positions straight from the scroll
+ *  container's DOM (`[data-chat-turn]`), so it needs no per-message wiring
+ *  beyond that attribute. Hidden when there's nothing to navigate (< 2 turns). */
+export function ChatNav({
+  scrollRef,
+  turns,
+}: {
+  scrollRef: RefObject<HTMLDivElement | null>;
+  turns: ChatTurn[];
+}) {
+  const [activeId, setActiveId] = useState(0);
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  // The active turn is the last one whose top has scrolled to/above the
+  // reading line (a little below the top fold) — standard scroll-spy.
+  const recompute = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const top = el.getBoundingClientRect().top;
+    let current = 0;
+    el.querySelectorAll<HTMLElement>("[data-chat-turn]").forEach((node) => {
+      if (node.getBoundingClientRect().top - top <= 96) {
+        const id = Number(node.dataset.chatTurn);
+        if (!Number.isNaN(id)) current = id;
+      }
+    });
+    setActiveId(current);
+  }, [scrollRef]);
+
+  // Keep the active turn in sync with what's on screen. Re-run on scroll, on
+  // turn changes, and — via ResizeObserver — when content above the fold grows
+  // or collapses (streaming replies, expanding tool rows) without a scroll.
+  // All paths share one rAF so bursts coalesce into a single recompute.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    let raf: number | null = null;
+    const schedule = () => {
+      if (raf != null) return;
+      raf = requestAnimationFrame(() => {
+        raf = null;
+        recompute();
+      });
+    };
+    el.addEventListener("scroll", schedule, { passive: true });
+    const content = el.firstElementChild;
+    const ro = content ? new ResizeObserver(schedule) : null;
+    if (content && ro) ro.observe(content);
+    schedule();
+    return () => {
+      el.removeEventListener("scroll", schedule);
+      ro?.disconnect();
+      if (raf != null) cancelAnimationFrame(raf);
+    };
+  }, [scrollRef, recompute, turns]);
+
+  const jumpTo = useCallback(
+    (id: number) => {
+      const target = scrollRef.current?.querySelector<HTMLElement>(
+        `[data-chat-turn="${id}"]`,
+      );
+      if (!target) return;
+      target.scrollIntoView({ behavior: "smooth", block: "start" });
+      setActiveId(id);
+      setOpen(false);
+    },
+    [scrollRef],
+  );
+
+  const activeIndex = turns.findIndex((t) => t.id === activeId);
+  const idx = activeIndex < 0 ? 0 : activeIndex;
+
+  const goPrev = useCallback(() => {
+    if (idx > 0) jumpTo(turns[idx - 1].id);
+  }, [idx, turns, jumpTo]);
+  const goNext = useCallback(() => {
+    if (idx < turns.length - 1) jumpTo(turns[idx + 1].id);
+  }, [idx, turns, jumpTo]);
+
+  // Alt+↑ / Alt+↓ step between turns from anywhere except while editing text.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!e.altKey || (e.key !== "ArrowUp" && e.key !== "ArrowDown")) return;
+      const ae = document.activeElement as HTMLElement | null;
+      const tag = ae?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || ae?.isContentEditable) return;
+      e.preventDefault();
+      if (e.key === "ArrowUp") goPrev();
+      else goNext();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [goPrev, goNext]);
+
+  // Dismiss the outline on outside click or Escape.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: PointerEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("pointerdown", onDown);
+    window.addEventListener("keydown", onEsc);
+    return () => {
+      window.removeEventListener("pointerdown", onDown);
+      window.removeEventListener("keydown", onEsc);
+    };
+  }, [open]);
+
+  if (turns.length < 2) return null;
+
+  return (
+    <div className="chat-nav" ref={rootRef}>
+      <div className="chat-nav-bar">
+        <button
+          type="button"
+          className="chat-nav-btn"
+          aria-label="Previous message"
+          title="Previous message (Alt+↑)"
+          disabled={idx <= 0}
+          onClick={goPrev}
+        >
+          <Chevron up />
+        </button>
+        <button
+          type="button"
+          className="chat-nav-count"
+          aria-label="Show all messages"
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          title="Show all messages"
+          onClick={() => setOpen((o) => !o)}
+        >
+          <span className="chat-nav-count-n">
+            {idx + 1}
+            <span className="chat-nav-sep">/</span>
+            {turns.length}
+          </span>
+          <MenuIcon />
+        </button>
+        <button
+          type="button"
+          className="chat-nav-btn"
+          aria-label="Next message"
+          title="Next message (Alt+↓)"
+          disabled={idx >= turns.length - 1}
+          onClick={goNext}
+        >
+          <Chevron />
+        </button>
+      </div>
+      {open && (
+        <div className="chat-nav-list" role="listbox" aria-label="Conversation turns">
+          {turns.map((t, i) => (
+            <button
+              key={t.id}
+              type="button"
+              role="option"
+              aria-selected={t.id === activeId}
+              className={`chat-nav-row${t.id === activeId ? " is-active" : ""}`}
+              onClick={() => jumpTo(t.id)}
+            >
+              <span className="chat-nav-row-n">{i + 1}</span>
+              <span className="chat-nav-row-t">{preview(t.text)}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function preview(text: string): string {
+  const oneLine = text.replace(/\s+/g, " ").trim();
+  return oneLine.length > 64 ? `${oneLine.slice(0, 64)}…` : oneLine;
+}
+
+function Chevron({ up = false }: { up?: boolean }) {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path
+        d={up ? "M3.5 10L8 5.5L12.5 10" : "M3.5 6L8 10.5L12.5 6"}
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+/** Table-of-contents glyph (three lines) signalling the counter opens a list. */
+function MenuIcon() {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path
+        d="M3 5h10M3 8h10M3 11h7"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/src/components/Workspace/ChatNav/index.tsx
+++ b/src/components/Workspace/ChatNav/index.tsx
@@ -73,9 +73,7 @@ export function ChatNav({
 
   const jumpTo = useCallback(
     (id: number) => {
-      const target = scrollRef.current?.querySelector<HTMLElement>(
-        `[data-chat-turn="${id}"]`,
-      );
+      const target = scrollRef.current?.querySelector<HTMLElement>(`[data-chat-turn="${id}"]`);
       if (!target) return;
       target.scrollIntoView({ behavior: "smooth", block: "start" });
       setActiveId(id);

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -3,7 +3,10 @@ import { applyPolicy, getAdapter } from "../../adapters";
 import { type AgentRecord, api } from "../../api";
 import { providerLabel } from "../../data/providers";
 import { useAppStore } from "../../store";
+import { stripInjectedInstructions } from "../../util/instructions";
 import { Composer } from "../Composer";
+import { APP_ACTION_PREFIX } from "../RightPanel/delegation";
+import { ChatNav } from "./ChatNav";
 import { MessageItem } from "./messages/MessageItem";
 import { pairToolItems, rowKey } from "./messages/pair";
 import { isUserInputTool } from "./messages/UserInput/parse";
@@ -94,6 +97,22 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
     return pairToolItems(visible);
   }, [log, agent.provider]);
 
+  // Navigable turns = the real user prompts (git-action chips excluded). Each
+  // gets a stable ordinal that maps an item to its `data-chat-turn` marker, so
+  // ChatNav can jump straight to any bubble.
+  const { turns, turnIds } = useMemo(() => {
+    const turns: { id: number; text: string }[] = [];
+    const turnIds = items.map((it) => {
+      if (it.kind !== "user_message" || it.text.startsWith(APP_ACTION_PREFIX)) {
+        return undefined;
+      }
+      const id = turns.length;
+      turns.push({ id, text: stripInjectedInstructions(it.text) });
+      return id;
+    });
+    return { turns, turnIds };
+  }, [items]);
+
   // The model the agent actually used on its most recent turn (Claude, pi,
   // Codex, OpenCode report it in their transcripts). Undefined for Cursor /
   // Antigravity, or before the first turn — the composer then shows just the
@@ -123,47 +142,51 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
 
   return (
     <div className="chat">
-      <div className="chat-scroll" ref={scrollRef} onScroll={handleScroll}>
-        <div className="chat-inner fade-in" key={agent.id}>
-          {transcriptLoading && items.length === 0 ? (
-            <div className="writing">
-              <span className="dots">
-                <i />
-                <i />
-                <i />
-              </span>
-              <span>Loading transcript…</span>
-            </div>
-          ) : items.length === 0 && hasPriorConversation && !busy ? (
-            <div className="empty-msg" style={{ margin: "40px auto", maxWidth: 360 }}>
-              <div className="et">No transcript available</div>
-              <div>
-                {providerLabel(agent.provider)}'s session file is not on disk for this agent.
+      <div className="chat-scroll-wrap">
+        <div className="chat-scroll" ref={scrollRef} onScroll={handleScroll}>
+          <div className="chat-inner fade-in" key={agent.id}>
+            {transcriptLoading && items.length === 0 ? (
+              <div className="writing">
+                <span className="dots">
+                  <i />
+                  <i />
+                  <i />
+                </span>
+                <span>Loading transcript…</span>
               </div>
-            </div>
-          ) : (
-            items.map((item, i) => (
-              <MessageItem
-                key={rowKey(item, i)}
-                item={item}
-                provider={agent.provider}
-                agentId={agent.id}
-              />
-            ))
-          )}
-          {busy && !awaitingInput && (
-            <div className="writing">
-              <span className="dots">
-                <i />
-                <i />
-                <i />
-              </span>
-              <span>
-                {busyLabel ?? `${customAgent?.name ?? providerLabel(agent.provider)} is thinking`}
-              </span>
-            </div>
-          )}
+            ) : items.length === 0 && hasPriorConversation && !busy ? (
+              <div className="empty-msg" style={{ margin: "40px auto", maxWidth: 360 }}>
+                <div className="et">No transcript available</div>
+                <div>
+                  {providerLabel(agent.provider)}'s session file is not on disk for this agent.
+                </div>
+              </div>
+            ) : (
+              items.map((item, i) => (
+                <MessageItem
+                  key={rowKey(item, i)}
+                  item={item}
+                  provider={agent.provider}
+                  agentId={agent.id}
+                  turnId={turnIds[i]}
+                />
+              ))
+            )}
+            {busy && !awaitingInput && (
+              <div className="writing">
+                <span className="dots">
+                  <i />
+                  <i />
+                  <i />
+                </span>
+                <span>
+                  {busyLabel ?? `${customAgent?.name ?? providerLabel(agent.provider)} is thinking`}
+                </span>
+              </div>
+            )}
+          </div>
         </div>
+        <ChatNav scrollRef={scrollRef} turns={turns} />
       </div>
       <div className="composer-wrap">
         <Composer

--- a/src/components/Workspace/messages/MessageItem.tsx
+++ b/src/components/Workspace/messages/MessageItem.tsx
@@ -21,10 +21,14 @@ export function MessageItem({
   item,
   provider,
   agentId,
+  turnId,
 }: {
   item: ViewItem;
   provider?: string;
   agentId?: string;
+  /** Ordinal of this user turn, used by ChatNav to locate the bubble in the
+   *  DOM. Set only for top-level navigable user prompts. */
+  turnId?: number;
 }) {
   switch (item.kind) {
     case "user_message":
@@ -40,7 +44,7 @@ export function MessageItem({
         );
       }
       return (
-        <div className="m-user">
+        <div className="m-user" data-chat-turn={turnId}>
           {stripInjectedInstructions(item.text)}
           {item.attachments && item.attachments.length > 0 && (
             <AttachmentList paths={item.attachments} className="message-attachments" />


### PR DESCRIPTION
## Summary

Long conversations were only navigable by scrolling all the way to a message. This adds a compact, sleek **turn navigator** docked to the top-right of the transcript so any message is reachable in one click.

- **`▲ / ▼` chevrons** (and `Alt+↑` / `Alt+↓`) step one user turn at a time for sequential reading.
- **`n / N` counter** cross-dissolves to a list (☰) glyph on hover — signalling it's clickable — and opens a **table-of-contents popover** of every user prompt (numbered + preview, active one highlighted). One click jumps anywhere.
- **Scroll-spy** highlights the current turn, kept in sync on scroll, turn changes, and content resize (streaming replies, expanding tool rows) via a shared rAF-throttled `ResizeObserver`.
- Hidden entirely when there are fewer than 2 turns; fades to low opacity at rest to stay unobtrusive.

## Design notes

- The "turn" unit is the **user message** (git-action chips excluded) — the natural anchor people navigate by.
- `ChatNav` is **self-contained**: it reads turn positions straight from the DOM via the `data-chat-turn` attribute, so the only wiring in `ChatView`/`MessageItem` is computing turn ordinals and stamping that attribute.
- Chose an explicit hover-morph affordance over hover-to-open: the counter sits between the chevrons, so hover-open would trigger constantly during normal navigation, and it wouldn't work on touch.

## Files

- `src/components/Workspace/ChatNav/index.tsx` (new) — the navigator.
- `src/components/Workspace/ChatView.tsx` — derives turns, wraps the scroll area, mounts `ChatNav`.
- `src/components/Workspace/messages/MessageItem.tsx` — stamps `data-chat-turn` on top-level user bubbles.
- `src/app.css` — `.chat-nav*` styles using existing theme tokens.

## Testing

- `tsc --noEmit` passes.
- Biome could not be run in the dev sandbox (no local `node_modules`); please run `npm run lint` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)