### PR TITLE
feat(chat): accept follow-up messages mid-turn

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,33 @@
+# TODOS
+
+## Mid-turn follow-up messages (composer unlock)
+
+### Verify Claude mid-turn injection during pure token generation
+**What:** Re-run the mid-turn injection spike, but inject while the model is streaming
+text (no tool running), not during a tool-wait.
+**Why:** The original spike (2026-06-27) only covered injection while a Bash tool was
+running — the message buffered and folded into the same turn at the next inference
+boundary (single `result`). Behavior during raw token generation is unverified and
+could differ (buffered vs. ignored vs. spawning a new turn).
+**Context:** Live mode (Claude) relies on writing a `{"type":"user"}` envelope to the
+open stream-json stdin mid-turn. The tool-wait window is the dominant real-world case,
+so this is low-likelihood-of-surprise, but worth confirming before relying on Live mode
+broadly. Start from the same harness: spawn `claude --print --input-format stream-json
+--output-format stream-json`, send a prompt that produces a long text response (no
+tools), inject a second user message ~1s in, observe ordering and the number of
+`result` events.
+**Depends on:** nothing.
+
+### Optimize associate_pending_user_turns substring scan
+**What:** Anchor the matcher's record search to a seq window instead of scanning the
+whole session.
+**Why:** `associate_pending_user_turns` (workspace.rs:973) loads all transcript records
+for the session and runs `body.contains(needle)` for every pending turn × every record
+— O(records × pending × body_len) per turn-end. Mid-turn injection nudges `pending` up
+per window, and long sessions make the full scan costly.
+**Context:** Pre-existing and currently negligible (`pending` is single digits), so this
+is explicitly deferred — not a correctness issue, and fixing it now would widen the diff
+of the riskiest function. Start by restricting the records query to those with `seq`
+greater than the highest already-matched user turn's record, so each turn-end only scans
+the newly-appended tail.
+**Depends on:** nothing; orthogonal to the mid-turn feature.

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -23,6 +23,7 @@ use serde_json::Value;
 use crate::activity::{Activity, ManagedActivity};
 use crate::error::{Error, Result};
 use crate::exec_session::{ExecCallbacks, ExecExit, ExecSession, ExecSpawn};
+use crate::message_queue::InjectionMode;
 use crate::instructions;
 use crate::managed_session::{ManagedExit, ManagedSession, ManagedSpawn, ToolUseBehavior};
 use crate::pty_session::{PtyExit, PtySession, PtySpawn};
@@ -179,6 +180,19 @@ pub fn capabilities(provider: &str) -> AgentCapabilities {
         None => AgentCapabilities {
             native_view: false,
         },
+    }
+}
+
+/// How a provider accepts a follow-up message sent mid-turn. Claude (the lone
+/// persistent-runner agent) keeps an open stream-json stdin, so it can take a
+/// message live; per-turn agents are one-shot processes with no live stdin, so
+/// they queue until the next turn boundary. Unknown providers default to the
+/// safe boundary path.
+pub fn injection_mode(provider: &str) -> InjectionMode {
+    match per_turn_descriptor(provider) {
+        Some(_) => InjectionMode::AtTurnBoundary,
+        None if provider == "claude" => InjectionMode::Live,
+        None => InjectionMode::AtTurnBoundary,
     }
 }
 
@@ -1035,6 +1049,16 @@ impl Agent {
             Self::Pty(_) => Err(Error::Other(
                 "send_user_message called on pty agent".into(),
             )),
+        }
+    }
+
+    /// True while a turn is paused on a held permission prompt. Only the managed
+    /// (Claude stream-json) transport can pause this way; per-turn and PTY
+    /// agents run fully auto-approved and never gate.
+    pub fn is_tool_gated(&self) -> bool {
+        match self {
+            Self::Managed(a) => a.session.is_tool_gated(),
+            Self::PerTurn(_) | Self::Pty(_) => false,
         }
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod git;
 mod git_state;
 mod instructions;
 mod managed_session;
+mod message_queue;
 mod model_catalog;
 mod names;
 mod new_project;

--- a/src-tauri/src/managed_session.rs
+++ b/src-tauri/src/managed_session.rs
@@ -262,6 +262,13 @@ impl ManagedSession {
         write_line(&self.stdin, response)
     }
 
+    /// True while the turn is paused on a held permission prompt (a question
+    /// tool). We can't write a new user message into a paused turn, so the
+    /// supervisor queues mid-turn follow-ups instead of injecting them live.
+    pub fn is_tool_gated(&self) -> bool {
+        !self.pending.lock().is_empty()
+    }
+
     /// Send SIGINT to the child process to interrupt the current turn
     /// without killing it. First releases any held permission prompts (denied),
     /// so a turn paused on a question can unwind rather than hang.

--- a/src-tauri/src/message_queue.rs
+++ b/src-tauri/src/message_queue.rs
@@ -1,0 +1,322 @@
+//! Mid-turn follow-up messages.
+//!
+//! When an agent is working, the user can still send follow-up messages. How
+//! they're delivered depends on the provider:
+//!
+//! ```text
+//!  user sends message
+//!         │
+//!         ▼
+//!   ┌──────────────┐  busy = backend Activity/status (source of truth)
+//!   │ agent busy?  │── no & queue empty ─▶ DeliverNow  (direct, new turn)
+//!   └──────┬───────┘── no & queue full  ─▶ FlushNow    (coalesce leftovers + this)
+//!         yes
+//!          ▼
+//!   ┌──────────────────┐
+//!   │ injection mode?  │
+//!   └──┬────────────┬──┘
+//!   Live         AtTurnBoundary
+//!     │               └──────────────▶ Enqueue (deliver at next turn boundary)
+//!   tool-gate paused?
+//!     │
+//!   yes ─▶ Enqueue (can't write into a paused turn)
+//!   no  ─▶ WriteLive (write into the running turn's stdin)
+//! ```
+//!
+//! This module is **pure**: it owns the per-agent queue and the coalescing /
+//! decision logic, but performs no I/O. The supervisor executes the chosen
+//! [`Delivery`] (stdin write, DB persist, process spawn). Queued messages live
+//! only in memory — if the app exits mid-turn the turn itself is aborted, so
+//! dropping its queued follow-ups is consistent.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+/// How a provider accepts a follow-up sent while a turn is in progress.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InjectionMode {
+    /// Write into the running turn's open stdin immediately (claude managed).
+    /// The CLI folds the message into the in-flight turn at its next inference
+    /// boundary, so each live message stays its own transcript record.
+    Live,
+    /// Can't inject mid-turn (one-shot-per-turn processes with no live stdin):
+    /// queue and deliver at the next turn boundary, coalesced into one prompt.
+    /// All per-turn agents (codex/cursor/opencode/pi/antigravity).
+    AtTurnBoundary,
+}
+
+/// One follow-up message the user sent. `text` + `attachments` are what get
+/// coalesced; `thinking` rides along to the delivery path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingMsg {
+    pub turn_id: String,
+    pub text: String,
+    pub attachments: Vec<String>,
+    pub thinking: Option<String>,
+}
+
+/// What to do with a freshly-sent message. Pure decision — see
+/// [`decide_delivery`]; the supervisor performs the matching I/O.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Delivery {
+    /// Idle, nothing queued: deliver this message directly as a new turn
+    /// (the pre-existing send path).
+    DeliverNow,
+    /// Idle but messages are queued (e.g. left over after a stop): enqueue this
+    /// one, then flush the whole queue coalesced, now.
+    FlushNow,
+    /// Busy, provider supports live injection and isn't paused on a tool gate:
+    /// write into the running turn.
+    WriteLive,
+    /// Busy (or Live but paused on a tool gate): hold for the next boundary.
+    Enqueue,
+}
+
+/// Decide how a freshly-sent message should be handled. Pure over the four
+/// inputs so the full matrix is unit-testable without spawning a process.
+///
+/// `busy` is the backend's runtime truth (the agent is Spawning/Running),
+/// `tool_gated` is true when the managed session is paused on a held
+/// permission prompt, and `queue_nonempty` reflects leftovers (typically from
+/// a prior stop that kept the queue).
+pub fn decide_delivery(
+    busy: bool,
+    mode: InjectionMode,
+    tool_gated: bool,
+    queue_nonempty: bool,
+) -> Delivery {
+    match (busy, mode, tool_gated) {
+        (false, _, _) if queue_nonempty => Delivery::FlushNow,
+        (false, _, _) => Delivery::DeliverNow,
+        (true, InjectionMode::Live, false) => Delivery::WriteLive,
+        (true, _, _) => Delivery::Enqueue,
+    }
+}
+
+/// In-memory per-agent FIFO of follow-up messages awaiting delivery.
+#[derive(Default)]
+pub struct MessageQueue {
+    by_agent: HashMap<String, VecDeque<PendingMsg>>,
+}
+
+impl MessageQueue {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn enqueue(&mut self, agent_id: &str, msg: PendingMsg) {
+        self.by_agent
+            .entry(agent_id.to_string())
+            .or_default()
+            .push_back(msg);
+    }
+
+    pub fn is_empty(&self, agent_id: &str) -> bool {
+        self.by_agent.get(agent_id).is_none_or(VecDeque::is_empty)
+    }
+
+    pub fn len(&self, agent_id: &str) -> usize {
+        self.by_agent.get(agent_id).map_or(0, VecDeque::len)
+    }
+
+    /// Remove and return all queued messages for an agent, coalesced into a
+    /// single [`PendingMsg`]. `None` if nothing was queued.
+    pub fn drain_coalesced(&mut self, agent_id: &str) -> Option<PendingMsg> {
+        let q = self.by_agent.get_mut(agent_id)?;
+        if q.is_empty() {
+            return None;
+        }
+        let msgs: Vec<PendingMsg> = q.drain(..).collect();
+        Some(coalesce(msgs))
+    }
+
+    /// Drop every queued message for an agent (teardown / archive).
+    pub fn clear(&mut self, agent_id: &str) {
+        self.by_agent.remove(agent_id);
+    }
+}
+
+/// Merge queued messages into one delivery:
+/// - text: non-empty bodies newline-joined in send order,
+/// - attachments: unioned, order-preserving, deduped,
+/// - metadata (`thinking`) + `turn_id`: taken from the LAST message — most
+///   recent intent (CQ1-A), and a real client-known id for the coalesced row.
+///
+/// A single queued message passes through untouched (no separators, no churn).
+fn coalesce(msgs: Vec<PendingMsg>) -> PendingMsg {
+    debug_assert!(!msgs.is_empty(), "coalesce called with no messages");
+    if msgs.len() == 1 {
+        return msgs.into_iter().next().expect("len checked");
+    }
+    let mut texts: Vec<&str> = Vec::new();
+    let mut attachments: Vec<String> = Vec::new();
+    let mut seen: HashSet<&str> = HashSet::new();
+    for m in &msgs {
+        if !m.text.is_empty() {
+            texts.push(&m.text);
+        }
+        for a in &m.attachments {
+            if seen.insert(a.as_str()) {
+                attachments.push(a.clone());
+            }
+        }
+    }
+    let last = msgs.last().expect("len > 1");
+    PendingMsg {
+        turn_id: last.turn_id.clone(),
+        text: texts.join("\n\n"),
+        attachments,
+        thinking: last.thinking.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn msg(turn_id: &str, text: &str, attachments: &[&str], thinking: Option<&str>) -> PendingMsg {
+        PendingMsg {
+            turn_id: turn_id.into(),
+            text: text.into(),
+            attachments: attachments.iter().map(|s| s.to_string()).collect(),
+            thinking: thinking.map(str::to_string),
+        }
+    }
+
+    // ── decide_delivery matrix ────────────────────────────────────────────
+
+    #[test]
+    fn idle_empty_queue_delivers_now() {
+        for mode in [InjectionMode::Live, InjectionMode::AtTurnBoundary] {
+            assert_eq!(decide_delivery(false, mode, false, false), Delivery::DeliverNow);
+        }
+    }
+
+    #[test]
+    fn idle_with_leftovers_flushes_now() {
+        // Leftovers (e.g. after a stop) flush together with the new message.
+        for mode in [InjectionMode::Live, InjectionMode::AtTurnBoundary] {
+            assert_eq!(decide_delivery(false, mode, false, true), Delivery::FlushNow);
+        }
+    }
+
+    #[test]
+    fn busy_live_not_gated_writes_live() {
+        assert_eq!(
+            decide_delivery(true, InjectionMode::Live, false, false),
+            Delivery::WriteLive
+        );
+    }
+
+    #[test]
+    fn busy_live_tool_gated_enqueues() {
+        // Can't write into a turn paused on a permission prompt.
+        assert_eq!(
+            decide_delivery(true, InjectionMode::Live, true, false),
+            Delivery::Enqueue
+        );
+    }
+
+    #[test]
+    fn busy_per_turn_always_enqueues() {
+        for gated in [false, true] {
+            for q in [false, true] {
+                assert_eq!(
+                    decide_delivery(true, InjectionMode::AtTurnBoundary, gated, q),
+                    Delivery::Enqueue
+                );
+            }
+        }
+    }
+
+    // ── queue FIFO + lifecycle ────────────────────────────────────────────
+
+    #[test]
+    fn enqueue_len_and_emptiness() {
+        let mut q = MessageQueue::new();
+        assert!(q.is_empty("a"));
+        assert_eq!(q.len("a"), 0);
+        q.enqueue("a", msg("t1", "hi", &[], None));
+        q.enqueue("a", msg("t2", "there", &[], None));
+        assert!(!q.is_empty("a"));
+        assert_eq!(q.len("a"), 2);
+        // isolation between agents
+        assert!(q.is_empty("b"));
+    }
+
+    #[test]
+    fn drain_empty_is_none() {
+        let mut q = MessageQueue::new();
+        assert_eq!(q.drain_coalesced("a"), None);
+    }
+
+    #[test]
+    fn drain_clears_the_queue() {
+        let mut q = MessageQueue::new();
+        q.enqueue("a", msg("t1", "hi", &[], None));
+        assert!(q.drain_coalesced("a").is_some());
+        assert!(q.is_empty("a"));
+        assert_eq!(q.drain_coalesced("a"), None);
+    }
+
+    #[test]
+    fn clear_drops_messages() {
+        let mut q = MessageQueue::new();
+        q.enqueue("a", msg("t1", "hi", &[], None));
+        q.clear("a");
+        assert!(q.is_empty("a"));
+    }
+
+    // ── coalescing ────────────────────────────────────────────────────────
+
+    #[test]
+    fn single_message_passes_through() {
+        let mut q = MessageQueue::new();
+        let m = msg("t1", "only", &["/a.txt"], Some("high"));
+        q.enqueue("a", m.clone());
+        assert_eq!(q.drain_coalesced("a"), Some(m));
+    }
+
+    #[test]
+    fn coalesce_joins_text_in_order() {
+        let mut q = MessageQueue::new();
+        q.enqueue("a", msg("t1", "first", &[], None));
+        q.enqueue("a", msg("t2", "second", &[], None));
+        q.enqueue("a", msg("t3", "third", &[], None));
+        let out = q.drain_coalesced("a").unwrap();
+        assert_eq!(out.text, "first\n\nsecond\n\nthird");
+    }
+
+    #[test]
+    fn coalesce_skips_empty_text_bodies() {
+        // An attachment-only message contributes no text line.
+        let mut q = MessageQueue::new();
+        q.enqueue("a", msg("t1", "hello", &[], None));
+        q.enqueue("a", msg("t2", "", &["/img.png"], None));
+        let out = q.drain_coalesced("a").unwrap();
+        assert_eq!(out.text, "hello");
+        assert_eq!(out.attachments, vec!["/img.png".to_string()]);
+    }
+
+    #[test]
+    fn coalesce_unions_attachments_dedup_preserving_order() {
+        let mut q = MessageQueue::new();
+        q.enqueue("a", msg("t1", "x", &["/a.txt", "/b.txt"], None));
+        q.enqueue("a", msg("t2", "y", &["/b.txt", "/c.txt"], None));
+        let out = q.drain_coalesced("a").unwrap();
+        assert_eq!(
+            out.attachments,
+            vec!["/a.txt".to_string(), "/b.txt".to_string(), "/c.txt".to_string()]
+        );
+    }
+
+    #[test]
+    fn coalesce_takes_last_message_metadata_and_turn_id() {
+        // CQ1-A: last-message-wins for thinking; turn_id is the last id.
+        let mut q = MessageQueue::new();
+        q.enqueue("a", msg("t1", "x", &[], Some("low")));
+        q.enqueue("a", msg("t2", "y", &[], Some("high")));
+        let out = q.drain_coalesced("a").unwrap();
+        assert_eq!(out.thinking, Some("high".to_string()));
+        assert_eq!(out.turn_id, "t2");
+    }
+}

--- a/src-tauri/src/message_queue.rs
+++ b/src-tauri/src/message_queue.rs
@@ -110,8 +110,20 @@ impl MessageQueue {
             .push_back(msg);
     }
 
+    /// Put a message back at the *front* of the queue — used when a flush failed
+    /// to deliver (raced with teardown/respawn), so it stays ahead of anything
+    /// queued since and the original send order is preserved.
+    pub fn requeue_front(&mut self, agent_id: &str, msg: PendingMsg) {
+        self.by_agent
+            .entry(agent_id.to_string())
+            .or_default()
+            .push_front(msg);
+    }
+
     pub fn is_empty(&self, agent_id: &str) -> bool {
-        self.by_agent.get(agent_id).is_none_or(VecDeque::is_empty)
+        // `map_or(true, …)` rather than `is_none_or` to stay on the crate's
+        // declared rust-version (1.77; `is_none_or` landed in 1.82).
+        self.by_agent.get(agent_id).map_or(true, VecDeque::is_empty)
     }
 
     pub fn len(&self, agent_id: &str) -> usize {
@@ -256,6 +268,17 @@ mod tests {
         assert!(q.drain_coalesced("a").is_some());
         assert!(q.is_empty("a"));
         assert_eq!(q.drain_coalesced("a"), None);
+    }
+
+    #[test]
+    fn requeue_front_keeps_failed_flush_ahead_of_newer_messages() {
+        // A failed flush re-queues the coalesced batch; a message queued since
+        // must not jump ahead of it.
+        let mut q = MessageQueue::new();
+        q.enqueue("a", msg("t-new", "queued after the failed flush", &[], None));
+        q.requeue_front("a", msg("t-coalesced", "first\n\nsecond", &[], None));
+        let out = q.drain_coalesced("a").unwrap();
+        assert_eq!(out.text, "first\n\nsecond\n\nqueued after the failed flush");
     }
 
     #[test]

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -9,10 +9,11 @@ use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
 
 use crate::activity::{Activity, ClaudeNativeActivity, ManagedActivity};
-use crate::agent::{capabilities, per_turn_descriptor, Agent, PerTurnSpec, SpawnSpec};
+use crate::agent::{capabilities, injection_mode, per_turn_descriptor, Agent, PerTurnSpec, SpawnSpec};
 use crate::error::{Error, Result};
 use crate::git;
 use crate::managed_session::ToolUseBehavior;
+use crate::message_queue::{decide_delivery, Delivery, MessageQueue, PendingMsg};
 use crate::pty_session::{PtySession, PtySpawn};
 use crate::rpc;
 use crate::run_session::{
@@ -124,6 +125,15 @@ pub struct Supervisor {
     /// transition (see `transition_active`), which respawns them onto the
     /// new binary. Empty in the common case.
     pub respawn_pending: Mutex<HashSet<String>>,
+    /// Follow-up messages sent while a turn is in progress, awaiting delivery
+    /// at the next turn boundary (per-turn agents, or claude paused on a tool
+    /// gate). In-memory only — see `message_queue`.
+    pub message_queue: Mutex<MessageQueue>,
+    /// Agent ids whose current turn was stopped by the user. The dying process
+    /// still converges on the Idle transition, so this flag lets the turn-end
+    /// flush distinguish a natural completion (flush queued follow-ups) from a
+    /// stop (keep them queued, don't auto-send — see `drain_message_queue`).
+    pub interrupted: Mutex<HashSet<String>>,
 }
 
 /// Resolved, per-spawn inputs for `spawn_agent_process` — everything that
@@ -175,6 +185,8 @@ impl Supervisor {
             shells: Mutex::new(HashMap::new()),
             runs: Mutex::new(HashMap::new()),
             respawn_pending: Mutex::new(HashSet::new()),
+            message_queue: Mutex::new(MessageQueue::new()),
+            interrupted: Mutex::new(HashSet::new()),
         }
     }
 
@@ -995,6 +1007,12 @@ impl Supervisor {
         Ok(())
     }
 
+    /// Route a user message by the provider's injection mode and the agent's
+    /// current state (see `message_queue::decide_delivery`):
+    /// - idle, queue empty  → deliver now as a new turn (the original path),
+    /// - idle, queue full    → flush the leftovers + this message, coalesced,
+    /// - busy, claude live    → inject into the running turn over stdin,
+    /// - busy, per-turn / tool-gated → queue for the next turn boundary.
     pub fn send_user_message(
         self: Arc<Self>,
         app: &AppHandle,
@@ -1004,10 +1022,66 @@ impl Supervisor {
         attachments: &[String],
         thinking: Option<&str>,
     ) -> Result<()> {
-        self.deliver_user_message(agent_id, turn_id, text, attachments, thinking)?;
-        mark_user_turn_started(&self, app, agent_id);
-        on_first_user_message(self.clone(), app.clone(), agent_id.to_string(), text.to_string());
+        let mode = injection_mode(&self.workspace.agent(agent_id)?.provider);
+        let busy = matches!(
+            self.live_status(agent_id),
+            Some(AgentStatus::Spawning | AgentStatus::Running)
+        );
+        let tool_gated = self
+            .agents
+            .lock()
+            .get(agent_id)
+            .is_some_and(Agent::is_tool_gated);
+        let queue_nonempty = !self.message_queue.lock().is_empty(agent_id);
+
+        let msg = PendingMsg {
+            turn_id: turn_id.to_string(),
+            text: text.to_string(),
+            attachments: attachments.to_vec(),
+            thinking: thinking.map(str::to_string),
+        };
+
+        match decide_delivery(busy, mode, tool_gated, queue_nonempty) {
+            Delivery::DeliverNow => deliver_as_turn(&self, app, agent_id, &msg)?,
+            Delivery::FlushNow => {
+                self.message_queue.lock().enqueue(agent_id, msg);
+                flush_queued(&self, app, agent_id)?;
+            }
+            Delivery::WriteLive => self.inject_live(agent_id, msg),
+            Delivery::Enqueue => self.message_queue.lock().enqueue(agent_id, msg),
+        }
         Ok(())
+    }
+
+    /// Inject a message into the running turn over the managed agent's open
+    /// stdin (claude). On success, persist its row so it matches the transcript
+    /// record the live message produces (the matcher stays 1→1 per live
+    /// message). If the write fails — the turn ended or the pipe broke in the
+    /// race window between the busy check and the write — re-enqueue it
+    /// (CQ3-A): the message is not lost and flushes at the next boundary.
+    fn inject_live(&self, agent_id: &str, msg: PendingMsg) {
+        let sent = self
+            .agents
+            .lock()
+            .get(agent_id)
+            .ok_or_else(|| Error::AgentNotFound(agent_id.to_string()))
+            .and_then(|a| {
+                a.send_user_message(&msg.text, &msg.attachments, msg.thinking.as_deref())
+            });
+        match sent {
+            Ok(()) => {
+                if let Err(e) =
+                    self.workspace
+                        .insert_user_turn(agent_id, &msg.turn_id, &msg.text, &msg.attachments)
+                {
+                    tracing::warn!(error = %e, agent_id, "persist live-injected user turn failed");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, agent_id, "live inject failed; re-enqueueing for next turn");
+                self.message_queue.lock().enqueue(agent_id, msg);
+            }
+        }
     }
 
     /// Capture the outgoing user turn durably, then deliver it to the agent.
@@ -1231,6 +1305,9 @@ impl Supervisor {
         // per-turn `exec` exits on SIGINT and its `on_turn_exit` handler
         // ends the turn (it emits no `turn.completed` when interrupted).
         let _ = app;
+        // Mark the stop so the turn-end Idle transition keeps the queue intact
+        // instead of auto-flushing it (A2-A). Cleared when a new turn starts.
+        self.interrupted.lock().insert(agent_id.to_string());
         let agents = self.agents.lock();
         if let Some(agent) = agents.get(agent_id) {
             agent.interrupt();
@@ -1537,6 +1614,8 @@ impl Supervisor {
         self.activities.lock().remove(agent_id);
         self.statuses.lock().remove(agent_id);
         self.native_input_lines.lock().remove(agent_id);
+        self.message_queue.lock().clear(agent_id);
+        self.interrupted.lock().remove(agent_id);
         self.shells.lock().remove(agent_id);
         if let Some(run) = self.runs.lock().remove(agent_id) {
             run.stop();
@@ -2274,10 +2353,75 @@ fn on_first_user_message(
 }
 
 fn mark_user_turn_started(sup: &Supervisor, app: &AppHandle, agent_id: &str) {
+    // A new turn is starting, so any prior stop is moot: clear the interrupt
+    // flag so this turn's natural completion flushes queued follow-ups.
+    sup.interrupted.lock().remove(agent_id);
     if let Some(activity) = sup.activities.lock().get_mut(agent_id) {
         activity.reset_for_new_turn();
     }
     transition_active(sup, app, agent_id, AgentStatus::Running);
+}
+
+/// Deliver a single message as a fresh turn: persist it durably, hand it to the
+/// agent, and mark the turn started. The pre-existing send path, now shared by
+/// the direct-send and queue-flush routes.
+fn deliver_as_turn(
+    sup: &Arc<Supervisor>,
+    app: &AppHandle,
+    agent_id: &str,
+    msg: &PendingMsg,
+) -> Result<()> {
+    sup.deliver_user_message(
+        agent_id,
+        &msg.turn_id,
+        &msg.text,
+        &msg.attachments,
+        msg.thinking.as_deref(),
+    )?;
+    mark_user_turn_started(sup, app, agent_id);
+    on_first_user_message(sup.clone(), app.clone(), agent_id.to_string(), msg.text.clone());
+    Ok(())
+}
+
+/// Coalesce every queued follow-up for an agent into one prompt and deliver it
+/// as the next turn. No-op if the queue is empty. Persists a single
+/// `session_user_turns` row (the coalesced message's `turn_id`), so the matcher
+/// stays 1→1 with the one transcript record the turn produces.
+fn flush_queued(sup: &Arc<Supervisor>, app: &AppHandle, agent_id: &str) -> Result<()> {
+    let count = sup.message_queue.lock().len(agent_id);
+    let Some(coalesced) = sup.message_queue.lock().drain_coalesced(agent_id) else {
+        return Ok(());
+    };
+    if count > 1 {
+        tracing::debug!(agent_id, count, "flushing coalesced follow-up messages as one turn");
+    }
+    deliver_as_turn(sup, app, agent_id, &coalesced)
+}
+
+/// At a turn-end Idle transition, flush any queued follow-up messages as the
+/// next turn — but only on a *natural* completion. A user stop converges on the
+/// same Idle (the dying process emits its result), so when the interrupt flag
+/// is set we clear it and keep the queue intact (A2-A: stop never auto-sends).
+/// Spawns the flush because `transition_active` holds only `&Supervisor`, and
+/// the delivery needs an owned `Arc` (recovered from Tauri state, like
+/// `drain_pending_bin_respawn`).
+fn drain_message_queue(sup: &Supervisor, app: &AppHandle, agent_id: &str) {
+    if sup.interrupted.lock().remove(agent_id) {
+        return;
+    }
+    if sup.message_queue.lock().is_empty(agent_id) {
+        return;
+    }
+    let Some(sup_arc) = app.try_state::<Arc<Supervisor>>().map(|s| s.inner().clone()) else {
+        return;
+    };
+    let app = app.clone();
+    let agent_id = agent_id.to_string();
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = flush_queued(&sup_arc, &app, &agent_id) {
+            tracing::warn!(error = %e, agent_id, "flush queued follow-up messages failed");
+        }
+    });
 }
 
 fn spawn_turn_watchdog(
@@ -2468,6 +2612,7 @@ fn transition_active(
             // for agents without a reader.
             sup.trigger_session_sync(app.clone(), agent_id.to_string());
             drain_pending_bin_respawn(sup, app, agent_id);
+            drain_message_queue(sup, app, agent_id);
         }
     }
 }

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -1047,7 +1047,19 @@ impl Supervisor {
                 self.message_queue.lock().enqueue(agent_id, msg);
                 flush_queued(&self, app, agent_id)?;
             }
-            Delivery::WriteLive => self.inject_live(agent_id, msg),
+            Delivery::WriteLive => {
+                if let Err(e) = self.inject_live(agent_id, &msg) {
+                    // The turn ended (or the pipe broke) in the race window
+                    // between the busy check and the write. Deliver as a fresh
+                    // turn *now* rather than only re-queueing: the turn-end Idle
+                    // drain may already have run against an empty queue, so a
+                    // bare re-enqueue would strand the follow-up until the next
+                    // user message (CQ3-A).
+                    tracing::warn!(error = %e, agent_id, "live inject failed; delivering as a new turn");
+                    self.message_queue.lock().enqueue(agent_id, msg);
+                    flush_queued(&self, app, agent_id)?;
+                }
+            }
             Delivery::Enqueue => self.message_queue.lock().enqueue(agent_id, msg),
         }
         Ok(())
@@ -1056,32 +1068,25 @@ impl Supervisor {
     /// Inject a message into the running turn over the managed agent's open
     /// stdin (claude). On success, persist its row so it matches the transcript
     /// record the live message produces (the matcher stays 1→1 per live
-    /// message). If the write fails — the turn ended or the pipe broke in the
-    /// race window between the busy check and the write — re-enqueue it
-    /// (CQ3-A): the message is not lost and flushes at the next boundary.
-    fn inject_live(&self, agent_id: &str, msg: PendingMsg) {
-        let sent = self
-            .agents
+    /// message). Returns `Err` if the write fails — the turn ended or the pipe
+    /// broke in the race window between the busy check and the write — leaving
+    /// the message untouched so the caller can fall back without double-handling
+    /// it.
+    fn inject_live(&self, agent_id: &str, msg: &PendingMsg) -> Result<()> {
+        self.agents
             .lock()
             .get(agent_id)
             .ok_or_else(|| Error::AgentNotFound(agent_id.to_string()))
             .and_then(|a| {
                 a.send_user_message(&msg.text, &msg.attachments, msg.thinking.as_deref())
-            });
-        match sent {
-            Ok(()) => {
-                if let Err(e) =
-                    self.workspace
-                        .insert_user_turn(agent_id, &msg.turn_id, &msg.text, &msg.attachments)
-                {
-                    tracing::warn!(error = %e, agent_id, "persist live-injected user turn failed");
-                }
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, agent_id, "live inject failed; re-enqueueing for next turn");
-                self.message_queue.lock().enqueue(agent_id, msg);
-            }
+            })?;
+        if let Err(e) =
+            self.workspace
+                .insert_user_turn(agent_id, &msg.turn_id, &msg.text, &msg.attachments)
+        {
+            tracing::warn!(error = %e, agent_id, "persist live-injected user turn failed");
         }
+        Ok(())
     }
 
     /// Capture the outgoing user turn durably, then deliver it to the agent.
@@ -1295,6 +1300,17 @@ impl Supervisor {
             let err = e.to_string();
             tracing::warn!(agent_id, error = %err, "binary-swap respawn failed");
             self.set_status(app, agent_id, AgentStatus::Error, Some(err));
+            return;
+        }
+
+        // This respawn passed through a turn-end Idle where the normal queue
+        // drain deferred to us (see `drain_message_queue`). Now that the agent
+        // is back, deliver any follow-ups queued during that turn — unless the
+        // user stopped (A2-A), which we own the interrupt check for here.
+        if !self.interrupted.lock().remove(agent_id) {
+            if let Err(e) = flush_queued(self, app, agent_id) {
+                tracing::warn!(agent_id, error = %e, "post-respawn queue flush failed");
+            }
         }
     }
 
@@ -2395,17 +2411,36 @@ fn flush_queued(sup: &Arc<Supervisor>, app: &AppHandle, agent_id: &str) -> Resul
     if count > 1 {
         tracing::debug!(agent_id, count, "flushing coalesced follow-up messages as one turn");
     }
-    deliver_as_turn(sup, app, agent_id, &coalesced)
+    if let Err(e) = deliver_as_turn(sup, app, agent_id, &coalesced) {
+        // Delivery raced with teardown/respawn (e.g. AgentNotFound). Put the
+        // follow-ups back rather than dropping them; a later boundary or the
+        // post-respawn flush retries. Re-queue at the front to preserve order.
+        tracing::warn!(error = %e, agent_id, "flush delivery failed; re-queueing follow-ups");
+        sup.message_queue.lock().requeue_front(agent_id, coalesced);
+    }
+    Ok(())
 }
 
 /// At a turn-end Idle transition, flush any queued follow-up messages as the
-/// next turn — but only on a *natural* completion. A user stop converges on the
-/// same Idle (the dying process emits its result), so when the interrupt flag
-/// is set we clear it and keep the queue intact (A2-A: stop never auto-sends).
+/// next turn — but only on a *natural* completion. Order of the guards matters:
+///
+/// 1. A pending binary-swap respawn owns the flush (and the interrupt check):
+///    it tears down and restarts the agent, then flushes once it's ready (see
+///    `respawn_agent_for_bin`). Flushing here would race that teardown and
+///    `AgentNotFound` could drop the queue. The flag is still set at this point
+///    — `transition_active` calls us synchronously right after
+///    `drain_pending_bin_respawn`, before its spawned task clears it.
+/// 2. A user stop converges on this same Idle (the dying process emits its
+///    result), so when the interrupt flag is set we clear it and keep the queue
+///    intact (A2-A: stop never auto-sends).
+///
 /// Spawns the flush because `transition_active` holds only `&Supervisor`, and
 /// the delivery needs an owned `Arc` (recovered from Tauri state, like
 /// `drain_pending_bin_respawn`).
 fn drain_message_queue(sup: &Supervisor, app: &AppHandle, agent_id: &str) {
+    if sup.respawn_pending.lock().contains(agent_id) {
+        return;
+    }
     if sup.interrupted.lock().remove(agent_id) {
         return;
     }

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -2268,6 +2268,85 @@ mod tests {
         assert_eq!(turns[0].native_id, None); // still pending → renders standalone
     }
 
+    // ── mid-turn follow-up messages (coalesced delivery + live injection) ──
+
+    #[test]
+    fn coalesced_follow_ups_persist_one_row_that_matches_one_record() {
+        // Per-turn flush (A5-A): N queued follow-ups coalesce into ONE prompt,
+        // delivered as one turn → one transcript record → one user_turn row
+        // that matches 1:1. No orphans.
+        let db = test_db();
+        let (ws_id, wm) = make_workspace_with_session(&db);
+
+        wm.insert_user_turn(&ws_id, "t-coalesced", "first\n\nsecond", &[])
+            .unwrap();
+
+        let rec = serde_json::json!({"role": "user", "text": "first\n\nsecond"});
+        wm.append_session_records(&ws_id, "codex", "transcript", None, &[("rec-1", &rec)])
+            .unwrap();
+
+        assert_eq!(wm.associate_pending_user_turns(&ws_id).unwrap(), 1);
+        let turns = wm.read_user_turns(&ws_id).unwrap();
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].native_id.as_deref(), Some("rec-1"));
+    }
+
+    #[test]
+    fn live_injected_follow_ups_each_match_their_own_record() {
+        // Claude live: each injected message is its own transcript user record,
+        // so two follow-ups inside one turn window match N→N (no coalescing).
+        let db = test_db();
+        let (ws_id, wm) = make_workspace_with_session(&db);
+
+        wm.insert_user_turn(&ws_id, "t1", "original", &[]).unwrap();
+        wm.insert_user_turn(&ws_id, "t2", "actually also do X", &[])
+            .unwrap();
+
+        let rec_a = serde_json::json!({"role": "user", "text": "original"});
+        let rec_b = serde_json::json!({"role": "user", "text": "actually also do X"});
+        wm.append_session_records(
+            &ws_id,
+            "claude",
+            "transcript",
+            None,
+            &[("rec-A", &rec_a), ("rec-B", &rec_b)],
+        )
+        .unwrap();
+
+        assert_eq!(wm.associate_pending_user_turns(&ws_id).unwrap(), 2);
+        let turns = wm.read_user_turns(&ws_id).unwrap();
+        assert_eq!(turns[0].native_id.as_deref(), Some("rec-A"));
+        assert_eq!(turns[1].native_id.as_deref(), Some("rec-B"));
+    }
+
+    #[test]
+    fn per_message_rows_orphan_against_a_coalesced_record() {
+        // Guards the A5-A decision: if a coalesced delivery (one merged record)
+        // were persisted as N separate rows instead of one, the claim-set lets
+        // only the first row match and the rest orphan forever. This is the bug
+        // we avoid by persisting a single coalesced row — documented here so a
+        // future change back to per-message rows fails loudly.
+        let db = test_db();
+        let (ws_id, wm) = make_workspace_with_session(&db);
+
+        wm.insert_user_turn(&ws_id, "t1", "first", &[]).unwrap();
+        wm.insert_user_turn(&ws_id, "t2", "second", &[]).unwrap();
+
+        let rec = serde_json::json!({"role": "user", "text": "first\n\nsecond"});
+        wm.append_session_records(&ws_id, "codex", "transcript", None, &[("rec-1", &rec)])
+            .unwrap();
+
+        // Only one row can claim the single record; the other stays pending.
+        assert_eq!(wm.associate_pending_user_turns(&ws_id).unwrap(), 1);
+        let pending = wm
+            .read_user_turns(&ws_id)
+            .unwrap()
+            .into_iter()
+            .filter(|t| t.native_id.is_none())
+            .count();
+        assert_eq!(pending, 1, "the unclaimed row orphans — hence we coalesce to one row");
+    }
+
     #[test]
     fn allocate_subdir_handles_collision() {
         let used = vec!["luxembourg".to_string()];

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -7,6 +7,12 @@
 
 export type ChatItem =
   | { kind: "user_message"; text: string; attachments?: string[] }
+  // A follow-up the user sent mid-turn that hasn't landed in the transcript
+  // yet: delivered live into the running turn (claude) or queued for the next
+  // turn boundary (per-turn agents). Store-inserted only — never produced by an
+  // adapter's reduce(). Reconciled away once the canonical transcript catches
+  // up (see app.ts onSessionRecordsAppended). Renders with the user bubble.
+  | { kind: "queued_message"; text: string; attachments?: string[] }
   | {
       kind: "agent_message";
       text: string;

--- a/src/app.css
+++ b/src/app.css
@@ -1446,6 +1446,22 @@ button {
   scroll-margin-top: 24px;
 }
 
+/* A mid-turn follow-up not yet in the transcript: same bubble, dimmed, with a
+   small "queued" tag. Reconciled to a normal user_message once it lands. */
+.m-user--queued {
+  opacity: 0.7;
+  border-style: dashed;
+}
+
+.m-user__queued-tag {
+  display: block;
+  margin-top: 4px;
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--fg-2);
+}
+
 .m-agent {
   font-size: 14.5px;
   line-height: 1.7;

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -258,7 +258,10 @@ export function Composer({
 
   function send() {
     const trimmed = text.trim();
-    if (stopping) {
+    // While the agent works, an empty composer's primary action is Stop; once
+    // the user types, it becomes Send so the message can be queued/injected
+    // mid-turn (the agent keeps running — see store.sendUserMessage).
+    if (showStop) {
       onStop?.();
       return;
     }
@@ -270,7 +273,7 @@ export function Composer({
   }
 
   function stop() {
-    if (!stopping) return;
+    if (!showStop) return;
     onStop?.();
   }
 
@@ -284,7 +287,11 @@ export function Composer({
     });
   }
 
-  const sendDisabled = stopping ? !onStop : disabled || (!text.trim() && attachments.length === 0);
+  const hasContent = text.trim().length > 0 || attachments.length > 0;
+  // Busy + empty → Stop; busy + typed (or idle) → Send. So a mid-turn
+  // follow-up sends with Enter, and an empty composer still stops the turn.
+  const showStop = stopping && !hasContent;
+  const sendDisabled = showStop ? !onStop : disabled || !hasContent;
 
   return (
     <div className={`composer${isDropTarget ? " is-drop-target" : ""}`}>
@@ -377,12 +384,12 @@ export function Composer({
         {features.tokenUsage && usage && usage.contextTokens > 0 && <UsageMeter usage={usage} />}
         <button
           type="button"
-          className={`send ${stopping ? "is-stop" : ""}`}
+          className={`send ${showStop ? "is-stop" : ""}`}
           disabled={sendDisabled}
-          onClick={stopping ? stop : send}
-          aria-label={stopping ? "Stop" : "Send"}
+          onClick={showStop ? stop : send}
+          aria-label={showStop ? "Stop" : "Send"}
         >
-          <Icon name={stopping ? "stop" : "arrowUp"} size={13} />
+          <Icon name={showStop ? "stop" : "arrowUp"} size={13} />
         </button>
       </div>
     </div>

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -172,10 +172,13 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
     );
   }, [items]);
 
+  // Mid-turn follow-ups are allowed: a busy (running) agent still accepts a
+  // message — delivered live (claude) or queued for the next turn boundary
+  // (per-turn agents). So `canSend` no longer gates on `busy`; the Composer
+  // shows Stop when empty and Send once the user types (see Composer).
   const canSend =
     !transcriptLoading &&
     !switchInFlight &&
-    !busy &&
     (agent.status === "running" || agent.status === "idle");
 
   return (
@@ -252,9 +255,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
                 ? "Loading transcript…"
                 : switchInFlight
                   ? "Switching view…"
-                  : busy
-                    ? "Waiting…"
-                    : "Agent is not ready"
+                  : "Agent is not ready"
           }
           stopping={busy}
           mentionSource={() =>

--- a/src/components/Workspace/messages/MessageItem.tsx
+++ b/src/components/Workspace/messages/MessageItem.tsx
@@ -43,14 +43,12 @@ export function MessageItem({
           </div>
         );
       }
-      return (
-        <div className="m-user" data-chat-turn={turnId}>
-          {stripInjectedInstructions(item.text)}
-          {item.attachments && item.attachments.length > 0 && (
-            <AttachmentList paths={item.attachments} className="message-attachments" />
-          )}
-        </div>
-      );
+      return <UserBubble text={item.text} attachments={item.attachments} turnId={turnId} />;
+    case "queued_message":
+      // Same bubble, marked queued: a follow-up the user sent mid-turn that the
+      // transcript hasn't caught up to yet. Reconciled away in app.ts once it
+      // lands canonically.
+      return <UserBubble text={item.text} attachments={item.attachments} queued />;
     case "agent_message":
       return (
         <div className="m-agent">
@@ -110,6 +108,31 @@ export function MessageItem({
     case "notice":
       return <NoticeView item={item} />;
   }
+}
+
+/** The user-prompt bubble, shared by the canonical `user_message` and the
+ *  optimistic `queued_message` (a mid-turn follow-up not yet in the transcript)
+ *  so both render identically aside from the queued marker. */
+function UserBubble({
+  text,
+  attachments,
+  queued,
+  turnId,
+}: {
+  text: string;
+  attachments?: string[];
+  queued?: boolean;
+  turnId?: number;
+}) {
+  return (
+    <div className={queued ? "m-user m-user--queued" : "m-user"} data-chat-turn={turnId}>
+      {stripInjectedInstructions(text)}
+      {attachments && attachments.length > 0 && (
+        <AttachmentList paths={attachments} className="message-attachments" />
+      )}
+      {queued && <span className="m-user__queued-tag">queued</span>}
+    </div>
+  );
 }
 
 /** A subagent's threaded sub-conversation, rendered inside its spawning

--- a/src/helpers.queued.test.ts
+++ b/src/helpers.queued.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { ChatItem } from "./adapters";
+import { carryForwardQueued } from "./helpers";
+
+const userMsg = (text: string, attachments?: string[]): ChatItem =>
+  attachments ? { kind: "user_message", text, attachments } : { kind: "user_message", text };
+const agentMsg = (text: string): ChatItem => ({ kind: "agent_message", text });
+const queued = (text: string, attachments?: string[]): ChatItem =>
+  attachments ? { kind: "queued_message", text, attachments } : { kind: "queued_message", text };
+
+describe("carryForwardQueued", () => {
+  it("keeps an undelivered follow-up the transcript hasn't caught up to", () => {
+    const rebuilt = [userMsg("first"), agentMsg("done")];
+    const prev = [...rebuilt, queued("a follow-up")];
+    const out = carryForwardQueued(rebuilt, prev);
+    expect(out).toEqual([...rebuilt, queued("a follow-up")]);
+  });
+
+  it("drops a follow-up once its text lands in a user message (no duplicate bubble)", () => {
+    // Per-turn coalescing: queued "a" and "b" arrive as one "a\n\nb" user turn.
+    const rebuilt = [userMsg("first"), agentMsg("done"), userMsg("a\n\nb")];
+    const prev = [userMsg("first"), agentMsg("done"), queued("a"), queued("b")];
+    const out = carryForwardQueued(rebuilt, prev);
+    expect(out).toEqual(rebuilt); // both reconciled away
+  });
+
+  it("drops a live-delivered follow-up matched as its own transcript message", () => {
+    // Claude live: the injected message becomes its own user record.
+    const rebuilt = [userMsg("first"), agentMsg("..."), userMsg("inject me")];
+    const prev = [userMsg("first"), agentMsg("..."), queued("inject me")];
+    expect(carryForwardQueued(rebuilt, prev)).toEqual(rebuilt);
+  });
+
+  it("matches an attachment-only follow-up by its attachment path", () => {
+    const rebuilt = [userMsg("look", ["/tmp/a.png"])];
+    const prev = [queued("", ["/tmp/a.png"])];
+    expect(carryForwardQueued(rebuilt, prev)).toEqual(rebuilt);
+  });
+
+  it("keeps an attachment-only follow-up with no needle until it can match", () => {
+    const rebuilt = [userMsg("first")];
+    const prev = [queued("")];
+    const out = carryForwardQueued(rebuilt, prev);
+    expect(out).toEqual([userMsg("first"), queued("")]);
+  });
+
+  it("does not match a follow-up against an agent message containing its text", () => {
+    // Only user messages reconcile a follow-up; an agent echo must not.
+    const rebuilt = [userMsg("hi"), agentMsg("you said follow-up")];
+    const prev = [...rebuilt, queued("follow-up")];
+    const out = carryForwardQueued(rebuilt, prev);
+    expect(out).toEqual([...rebuilt, queued("follow-up")]);
+  });
+
+  it("is a no-op when there are no queued items", () => {
+    const rebuilt = [userMsg("hi"), agentMsg("ok")];
+    expect(carryForwardQueued(rebuilt, rebuilt)).toEqual(rebuilt);
+  });
+});

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -103,6 +103,27 @@ export function applyUserTurns(items: ChatItem[], turns: UserTurn[]): ChatItem[]
   return result;
 }
 
+/** Carry forward optimistic mid-turn follow-ups (`queued_message`) onto a log
+ *  just rebuilt from canonical records, so they don't blink out before the
+ *  transcript catches up. Drops any the rebuilt conversation already accounts
+ *  for — its text (or first attachment path) now appears in a user message,
+ *  whether the follow-up was delivered live (claude) or coalesced (per-turn) —
+ *  mirroring the backend matcher's substring association. An attachment-only
+ *  follow-up with no needle is kept until it can be matched. */
+export function carryForwardQueued(rebuilt: ChatItem[], prev: ChatItem[]): ChatItem[] {
+  const stillQueued = prev.filter((it) => {
+    if (it.kind !== "queued_message") return false;
+    const needle = it.text || it.attachments?.[0];
+    if (!needle) return true;
+    return !rebuilt.some(
+      (r) =>
+        r.kind === "user_message" &&
+        (r.text.includes(needle) || (r.attachments?.includes(needle) ?? false)),
+    );
+  });
+  return [...rebuilt, ...stillQueued];
+}
+
 /** Apply one raw event to an agent's log via its provider adapter. Pure: it
  *  returns the state patch plus a `turnEnded` flag so the caller can fire any
  *  side effects (e.g. the completion chime). Catches adapter throws so a single

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -19,6 +19,7 @@ import { isCommitAction } from "../components/RightPanel/primaryActions";
 import {
   applyEvent,
   applyUserTurns,
+  carryForwardQueued,
   needsSessionIdRefresh,
   persistLiveUsage,
   providerFor,
@@ -213,7 +214,10 @@ const registerEventListeners = async (set: AppSet, get: AppGet) => {
         ]);
         if (records.length === 0) return;
         const provider = providerFor(get(), id);
-        const items = applyUserTurns(reduceRecords(provider, records), turns);
+        const rebuilt = applyUserTurns(reduceRecords(provider, records), turns);
+        // Keep optimistic mid-turn follow-ups visible until the transcript
+        // catches up (then they reconcile away). See carryForwardQueued.
+        const items = carryForwardQueued(rebuilt, get().managedLogs[id] ?? []);
         const usage = usageFromRecords(provider, records);
         set((state) => ({
           managedLogs: { ...state.managedLogs, [id]: items },

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -84,24 +84,38 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
     // Stable per-turn id, reused across the agent-not-ready retry below so the
     // backend's session_user_turns write is idempotent (one row per turn).
     const turnId = crypto.randomUUID();
+    // Sent mid-turn? Then this is a follow-up: render it as a queued_message
+    // and leave the running turn's busy state untouched. The backend decides
+    // whether to inject it live (claude) or queue it (per-turn agents); the
+    // store never drives delivery.
+    const wasBusy = get().managedBusy[id] === true;
     try {
       set((state) => {
-        const slashName = passthroughSlashName(providerFor(state, id), text);
-        const entry: ChatItem = slashName
-          ? { kind: "notice", subtype: "slash_command", text: `/${slashName}` }
-          : attachments.length > 0
-            ? { kind: "user_message", text, attachments }
-            : { kind: "user_message", text };
+        const slashName = wasBusy ? null : passthroughSlashName(providerFor(state, id), text);
+        const entry: ChatItem = wasBusy
+          ? attachments.length > 0
+            ? { kind: "queued_message", text, attachments }
+            : { kind: "queued_message", text }
+          : slashName
+            ? { kind: "notice", subtype: "slash_command", text: `/${slashName}` }
+            : attachments.length > 0
+              ? { kind: "user_message", text, attachments }
+              : { kind: "user_message", text };
         return {
           managedLogs: {
             ...state.managedLogs,
             [id]: [...(state.managedLogs[id] ?? []), entry],
           },
-          managedBusy: { ...state.managedBusy, [id]: true },
-          managedBusyLabel: {
-            ...state.managedBusyLabel,
-            [id]: slashName ? SLASH_BUSY_LABELS[slashName] : undefined,
-          },
+          // Only assert busy / set the slash label when *starting* a turn.
+          ...(wasBusy
+            ? {}
+            : {
+                managedBusy: { ...state.managedBusy, [id]: true },
+                managedBusyLabel: {
+                  ...state.managedBusyLabel,
+                  [id]: slashName ? SLASH_BUSY_LABELS[slashName] : undefined,
+                },
+              }),
         };
       });
       try {
@@ -121,7 +135,9 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
     } catch (e) {
       set((state) => ({
         lastError: String(e),
-        managedBusy: { ...state.managedBusy, [id]: false },
+        // Only clear busy if this call started the turn; a failed mid-turn
+        // follow-up must not stop the still-running turn.
+        ...(wasBusy ? {} : { managedBusy: { ...state.managedBusy, [id]: false } }),
       }));
     }
   },


### PR DESCRIPTION
## What

Unlocks the composer while an agent is working, so users can send follow-up messages mid-turn instead of waiting for the turn to finish.

## How it works (provider-shaped, one queue)

```
 user sends message
        │  busy = backend Activity (source of truth)
        ▼
  idle & queue empty → deliver now (new turn)
  idle & queue full  → flush leftovers + this, coalesced
  busy + claude      → inject into running turn over stdin (live)
  busy + per-turn    → queue, flush at next turn boundary
  busy + tool-gated  → queue (can't write into a paused turn)
```

- **Claude** (managed, persistent stream-json stdin) takes the message **live** — a spike confirmed the CLI folds an injected message into the in-flight turn at its next inference boundary, without preempting a running tool and as a single `result`.
- **Per-turn agents** (codex/cursor/opencode/pi/antigravity) are one-shot processes with no live stdin, so the message is **queued and flushed, coalesced, as the next resumed turn**.

## Design

- New pure **`message_queue`** module owns the per-agent FIFO + coalescing (newline-join text, union attachments, last-wins metadata) + the `decide_delivery()` decision. The supervisor performs all I/O.
- Flush fires **only on natural-completion Idle**; a user **stop keeps the queue intact** (gated by a backend `interrupted` flag, since the dying process also converges on Idle).
- Coalesced delivery persists **one** `session_user_turns` row, so the existing matcher stays 1:1 with the single transcript record (live messages stay one-row-per-message, matched N:N).
- On a live-write failure (turn ended / broken pipe in the race window), the message is **re-enqueued** and flushes next boundary — never lost.

## Frontend

- `canSend` no longer gates on `busy`; the Composer shows **Stop when empty, Send once you type** (Enter sends the follow-up).
- New `queued_message` ChatItem kind sharing the user bubble component, dimmed with a "queued" tag.
- `carryForwardQueued` reconciles optimistic queued bubbles against the canonical transcript — no flicker, no duplicates.

## Tests

- **Rust:** 14 unit tests for `decide_delivery`/coalesce/FIFO; 3 matcher tests (coalesced 1→1, live N→N, orphan-avoidance guard).
- **Frontend:** 7 vitest tests for queued reconciliation. Full suites green (existing 318 Rust / 311 vitest).

## Follow-ups (see `TODOS.md`)

- Verify Claude mid-turn injection during pure token generation (spike only covered the tool-wait window).
- Optimize the `associate_pending_user_turns` substring scan (pre-existing, latent on long sessions).

## Notes / not in scope

- Cancelling a running tool on new input; per-turn streaming-stdin transport.
- No Composer component-render test — the repo has no jsdom/testing-library infra; followed that convention. The natural-Idle-vs-stop flush guard is a small `interrupted`-flag check not unit-tested (only reachable via the process-spawning supervisor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)