### PR TITLE
feat(agents): spawn an agent forked from an explicit commit

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -177,6 +177,7 @@ pub async fn spawn_agent(
     model: Option<String>,
     instructions: Option<String>,
     custom_agent_id: Option<String>,
+    fork_base: Option<String>,
 ) -> Result<AgentRecord> {
     let sup = supervisor.inner().clone();
     sup.spawn_agent(
@@ -189,6 +190,7 @@ pub async fn spawn_agent(
         model,
         instructions,
         custom_agent_id,
+        fork_base,
     )
     .await
 }

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -567,6 +567,11 @@ impl Supervisor {
         model: Option<String>,
         instructions: Option<String>,
         custom_agent_id: Option<String>,
+        // Explicit fork point (a commit-ish). When set — e.g. a workflow step
+        // forking from the previous step's HEAD — the worktree is cut from this
+        // commit instead of the parent branch's remote fork-point. None keeps the
+        // default behavior.
+        fork_base: Option<String>,
     ) -> Result<AgentRecord> {
         if !repo_path.join(".git").exists() {
             return Err(Error::InvalidPath(format!(
@@ -653,12 +658,17 @@ impl Supervisor {
                 return;
             }
 
-            // Fork from the freshest remote state of the parent branch so the
-            // agent never starts on stale local refs. Best-effort: offline, no
-            // remote, or a local-only branch all fall back to local HEAD.
-            let base = match &parent_for_fork {
-                Some(b) => git::fetch_fork_point(&repo_path, b).await,
-                None => None,
+            // Fork point: an explicit base (a workflow step forking from the
+            // previous step's HEAD) wins; otherwise fork from the freshest remote
+            // state of the parent branch so the agent never starts on stale local
+            // refs. Best-effort: offline, no remote, or a local-only branch all
+            // fall back to local HEAD.
+            let base = match &fork_base {
+                Some(sha) => Some(sha.clone()),
+                None => match &parent_for_fork {
+                    Some(b) => git::fetch_fork_point(&repo_path, b).await,
+                    None => None,
+                },
             };
             if let Err(e) =
                 git::worktree_add_detached(&repo_path, &primary_worktree, base.as_deref()).await

--- a/src/api.ts
+++ b/src/api.ts
@@ -375,6 +375,9 @@ export const api = {
     model?: string,
     instructions?: string,
     customAgentId?: string,
+    /** Explicit fork point (commit-ish). A workflow step passes the previous
+     *  step's HEAD here so its worktree continues that work. */
+    forkBase?: string,
   ) =>
     invoke<AgentRecord>("spawn_agent", {
       view,
@@ -385,6 +388,7 @@ export const api = {
       model: model ?? null,
       instructions: instructions ?? null,
       customAgentId: customAgentId ?? null,
+      forkBase: forkBase ?? null,
     }),
   writeToAgent: (agentId: string, data: string) =>
     invoke<void>("write_to_agent", { agentId, data }),


### PR DESCRIPTION
## Summary

Adds an optional `fork_base` (a commit-ish) to `spawn_agent`. When provided, the agent's worktree is cut from that exact commit instead of the parent branch's remote fork-point. `None` preserves today's behavior byte-for-byte.

This is the single core hook the (private) Workflows feature needs: a workflow step forks its worktree from the **previous step's HEAD**, so committed work flows forward across per-step worktrees on one branch. It's a generic capability ("spawn an agent that continues from commit X") with no workflow-specific coupling.

## Changes

- **`supervisor.rs`** — `spawn_agent` takes `fork_base: Option<String>`; the fork task uses it as the worktree base when set, else the existing `fetch_fork_point(parent_branch)` path.
- **`commands.rs`** — threads `fork_base` through the Tauri command.
- **`src/api.ts`** — `spawnAgent` gains an optional `forkBase` argument.

## Notes

- Backward compatible: the parameter is optional; every existing call site is unchanged and behaves identically.
- Scope is intentionally minimal — worktree creation/teardown, sandboxing, events, transcripts, and diffs are all untouched.

## Test plan

- [x] `cargo check` clean
- [x] `tsc` clean
- [ ] Spawn a normal agent (no `fork_base`) → unchanged behavior
- [ ] Spawn with `fork_base` set to a known commit → worktree HEAD is that commit