### PR TITLE
refactor: extract .flex-center, .iflex-center, .truncate utility classes

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -93,9 +93,19 @@
 }
 
 /* ── UTILITIES ─────────────────────────────────────────────────────────── */
-.flex-center   { display: flex; align-items: center; }
-.iflex-center  { display: inline-flex; align-items: center; }
-.truncate      { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.flex-center {
+  display: flex;
+  align-items: center;
+}
+.iflex-center {
+  display: inline-flex;
+  align-items: center;
+}
+.truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
 /* reset */
 * {
@@ -2151,7 +2161,9 @@ button {
   color: var(--fg-2);
   flex-shrink: 0;
 }
-.attachment-name { min-width: 0; }
+.attachment-name {
+  min-width: 0;
+}
 .attachment-remove {
   justify-content: center;
   width: 16px;

--- a/src/app.css
+++ b/src/app.css
@@ -92,6 +92,11 @@
   --dens-lg: 12px;
 }
 
+/* ── UTILITIES ─────────────────────────────────────────────────────────── */
+.flex-center   { display: flex; align-items: center; }
+.iflex-center  { display: inline-flex; align-items: center; }
+.truncate      { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
 /* reset */
 * {
   box-sizing: border-box;
@@ -153,8 +158,6 @@ button {
 .tb {
   height: 36px;
   flex-shrink: 0;
-  display: flex;
-  align-items: center;
   padding: 0 10px;
   border-bottom: 1px solid var(--bd-soft);
   position: relative;
@@ -166,8 +169,6 @@ button {
 }
 .tb-logo {
   margin-left: 12px;
-  display: inline-flex;
-  align-items: center;
   gap: 8px;
   font-family: var(--font-sans);
   font-size: 16px;
@@ -196,8 +197,6 @@ button {
   margin-right: 1px;
 }
 .tb-badge {
-  display: inline-flex;
-  align-items: center;
   height: 16px;
   font-family: var(--font-sans);
   font-size: 8px;
@@ -217,8 +216,6 @@ button {
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
-  display: flex;
-  align-items: center;
   gap: 8px;
   font-size: 12px;
   color: var(--fg-2);
@@ -242,16 +239,12 @@ button {
 }
 .tb-right {
   margin-left: auto;
-  display: flex;
-  align-items: center;
   gap: 2px;
   -webkit-app-region: no-drag;
 }
 
 /* icon button */
 .btn-i {
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
   width: 26px;
   height: 26px;
@@ -297,8 +290,6 @@ button {
 }
 
 .btn-t {
-  display: inline-flex;
-  align-items: center;
   gap: 6px;
   height: 28px;
   padding: 0 11px;
@@ -437,15 +428,11 @@ button {
 /* sidebar */
 .side-head {
   padding: 14px 12px 10px;
-  display: flex;
-  align-items: center;
   gap: 8px;
   flex-shrink: 0;
 }
 .search {
   flex: 1;
-  display: flex;
-  align-items: center;
   gap: 8px;
   height: 30px;
   padding: 0 10px;
@@ -490,8 +477,6 @@ button {
   padding: 4px;
 }
 .add-proj-cta {
-  display: flex;
-  align-items: center;
   justify-content: center;
   gap: 6px;
   width: 100%;
@@ -521,8 +506,6 @@ button {
   margin-bottom: 16px;
 }
 .proj-h {
-  display: flex;
-  align-items: center;
   gap: 6px;
   padding: 0 8px;
   height: 28px;
@@ -679,8 +662,6 @@ button {
 }
 
 .agent-row {
-  display: flex;
-  align-items: center;
   gap: 7px;
   min-height: 21px;
 }
@@ -721,8 +702,6 @@ button {
 .ag-slot {
   position: relative;
   margin-left: auto;
-  display: inline-flex;
-  align-items: center;
   justify-content: flex-end;
   flex-shrink: 0;
   min-height: 21px;
@@ -754,8 +733,6 @@ button {
   pointer-events: auto;
 }
 .ag-act {
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
   width: 21px;
   height: 21px;
@@ -850,8 +827,6 @@ button {
 
 /* compact status badges (PR state, error, draft) */
 .ag-badge {
-  display: inline-flex;
-  align-items: center;
   gap: 3px;
   height: 16px;
   padding: 0 5px;
@@ -888,8 +863,6 @@ button {
 }
 
 .agent-sub {
-  display: flex;
-  align-items: center;
   gap: 8px;
   margin-top: 2px;
   min-height: 17px;
@@ -982,8 +955,6 @@ button {
 }
 
 .agent-new {
-  display: flex;
-  align-items: center;
   gap: 8px;
   padding: 8px 8px;
   margin-bottom: 6px;
@@ -1006,8 +977,6 @@ button {
   height: 52px;
   padding: 0 12px;
   border-top: 1px solid var(--bd-soft);
-  display: flex;
-  align-items: center;
   gap: 10px;
   flex-shrink: 0;
 }
@@ -1017,8 +986,6 @@ button {
   border-radius: 50%;
   background: var(--accent);
   color: oklch(0.16 0.02 60);
-  display: flex;
-  align-items: center;
   justify-content: center;
   font-size: 10.5px;
   font-weight: 600;
@@ -1049,8 +1016,6 @@ button {
 
 /* center pane */
 .center-h {
-  display: flex;
-  align-items: center;
   gap: 10px;
   padding: 0 16px;
   height: 48px;
@@ -1159,8 +1124,6 @@ button {
   top: 12px;
   right: 24px;
   z-index: 20;
-  display: flex;
-  align-items: center;
   gap: 6px;
   padding: 5px 6px 5px 10px;
   background: var(--bg-2);
@@ -1209,8 +1172,6 @@ button {
   color: var(--danger);
 }
 .chat-search-actions {
-  display: flex;
-  align-items: center;
   gap: 1px;
   padding-left: 4px;
   margin-left: 2px;
@@ -1293,8 +1254,6 @@ button {
   border: 0;
   color: var(--fg-1);
   cursor: pointer;
-  display: flex;
-  align-items: center;
   justify-content: center;
   transition:
     background 0.12s var(--ease),
@@ -1425,9 +1384,6 @@ button {
 .chat-nav-row-t {
   font-size: 12.5px;
   line-height: 1.4;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .m-user {
@@ -1631,14 +1587,10 @@ button {
 }
 
 .q-head {
-  display: flex;
-  align-items: center;
   gap: 10px;
   margin-bottom: 10px;
 }
 .q-label {
-  display: inline-flex;
-  align-items: center;
   gap: 6px;
   font-family: var(--font-mono);
   font-size: 10px;
@@ -1668,9 +1620,6 @@ button {
   font-family: var(--font-mono);
   font-size: 10.5px;
   color: var(--fg-3);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   min-width: 0;
 }
 
@@ -1760,8 +1709,6 @@ button {
   flex-shrink: 0;
   margin-top: 1px;
   position: relative;
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
   color: var(--fg-3);
   transition:
@@ -1850,8 +1797,6 @@ button {
   width: 18px;
   height: 18px;
   margin-top: 1px;
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
   border: 1px solid var(--bd-soft);
   border-radius: 4px;
@@ -1896,16 +1841,12 @@ button {
   color: var(--fg-3);
 }
 .q-other-foot {
-  display: flex;
-  align-items: center;
   gap: 8px;
   padding: 6px 8px 8px 12px;
 }
 .q-other-hint {
   font-size: 11px;
   color: var(--fg-3);
-  display: inline-flex;
-  align-items: center;
   gap: 6px;
 }
 .q-other-hint .kbd,
@@ -1937,8 +1878,6 @@ button {
   color: var(--fg-0);
 }
 .q-other-send {
-  display: inline-flex;
-  align-items: center;
   gap: 6px;
   height: 26px;
   padding: 0 11px;
@@ -1976,8 +1915,6 @@ button {
   background: var(--accent-line);
 }
 .q-answer {
-  display: flex;
-  align-items: center;
   gap: 10px;
   margin-top: 12px;
   padding: 10px 12px;
@@ -1993,8 +1930,6 @@ button {
   border-radius: 50%;
   background: var(--accent);
   color: oklch(0.16 0.02 60);
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
 }
 .theme-light .qa-mark {
@@ -2033,8 +1968,6 @@ button {
 }
 
 .m-tool {
-  display: flex;
-  align-items: center;
   gap: 10px;
   font-family: var(--font-mono);
   font-size: 12px;
@@ -2066,8 +1999,6 @@ button {
 }
 
 .writing {
-  display: flex;
-  align-items: center;
   gap: 8px;
   font-size: 12.5px;
   color: var(--fg-3);
@@ -2178,9 +2109,7 @@ button {
   position: absolute;
   inset: 0;
   z-index: 2;
-  display: flex;
   flex-direction: column;
-  align-items: center;
   justify-content: center;
   gap: 8px;
   border-radius: var(--r-lg);
@@ -2208,8 +2137,6 @@ button {
   margin-top: 8px;
 }
 .attachment {
-  display: inline-flex;
-  align-items: center;
   gap: 6px;
   max-width: 220px;
   height: 24px;
@@ -2224,14 +2151,7 @@ button {
   color: var(--fg-2);
   flex-shrink: 0;
 }
-.attachment-name {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
 .attachment-remove {
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
   width: 16px;
   height: 16px;
@@ -2263,14 +2183,10 @@ button {
   opacity: 0.55;
 }
 .composer-foot {
-  display: flex;
-  align-items: center;
   gap: 6px;
   padding: 6px 8px 6px 10px;
 }
 .c-chip {
-  display: inline-flex;
-  align-items: center;
   gap: 5px;
   height: 24px;
   padding: 0 8px;
@@ -2324,9 +2240,6 @@ button {
 .model-chip-model {
   min-width: 0;
   max-width: 170px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   color: var(--fg-2);
 }
 
@@ -2336,8 +2249,6 @@ button {
   border-radius: var(--r-sm);
   background: var(--accent);
   color: oklch(0.18 0.02 60);
-  display: flex;
-  align-items: center;
   justify-content: center;
   transition:
     background 0.12s,
@@ -2374,8 +2285,6 @@ button {
   display: inline-flex;
 }
 .usage-chip {
-  display: inline-flex;
-  align-items: center;
   gap: 5px;
   height: 24px;
   padding: 0 7px 0 5px;
@@ -2470,8 +2379,6 @@ button {
   gap: 6px;
 }
 .up-leg {
-  display: flex;
-  align-items: center;
   gap: 8px;
   font-size: 11.5px;
   color: var(--fg-1);
@@ -2506,8 +2413,6 @@ button {
   gap: 6px;
 }
 .up-row {
-  display: flex;
-  align-items: center;
   justify-content: space-between;
   font-size: 11.5px;
   color: var(--fg-1);
@@ -2545,8 +2450,6 @@ button {
   }
 }
 .dd-item {
-  display: flex;
-  align-items: center;
   gap: 9px;
   padding: 7px 9px;
   border-radius: var(--r-sm);
@@ -2631,8 +2534,6 @@ button {
 }
 /* Section header with trailing rule, mirroring the prototype's dividers. */
 .model-sect {
-  display: flex;
-  align-items: center;
   gap: 7px;
   padding: 9px 10px 5px;
   color: var(--fg-3);
@@ -2650,8 +2551,6 @@ button {
 .model-agent-row {
   width: 100%;
   min-width: 0;
-  display: flex;
-  align-items: center;
   gap: 10px;
   padding: 7px 9px;
   border-radius: 9px;
@@ -2672,9 +2571,6 @@ button {
 .model-agent-name {
   flex: 1;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   font-size: 13px;
   font-weight: 500;
   color: var(--fg-0);
@@ -2758,8 +2654,6 @@ button {
 }
 .model-side-fly-head {
   flex-shrink: 0;
-  display: flex;
-  align-items: center;
   gap: 9px;
   padding: 9px 11px;
   border-bottom: 1px solid var(--bd-soft);
@@ -2767,9 +2661,6 @@ button {
 .model-side-fly-name {
   flex: 1;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   font-size: 12.5px;
   font-weight: 550;
   color: var(--fg-0);
@@ -2793,8 +2684,6 @@ button {
 .model-option {
   width: 100%;
   min-width: 0;
-  display: flex;
-  align-items: center;
   gap: 9px;
   padding: 6px 9px;
   border-radius: 8px;
@@ -2820,9 +2709,6 @@ button {
   gap: 1px;
 }
 .model-option-name {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   font-size: 12.5px;
   font-weight: 450;
   color: var(--fg-0);
@@ -2831,9 +2717,6 @@ button {
   font-weight: 550;
 }
 .model-option-desc {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   color: var(--fg-3);
   font-size: 10.5px;
 }
@@ -2868,8 +2751,6 @@ button {
 
 /* branch picker scroll buttons */
 .bp-scroll-btn {
-  display: flex;
-  align-items: center;
   justify-content: center;
   width: 100%;
   height: 24px;
@@ -2893,8 +2774,6 @@ button {
 
 /* right pane */
 .right-h {
-  display: flex;
-  align-items: center;
   gap: 2px;
   padding: 0 8px 0 16px;
   height: 48px;
@@ -2914,8 +2793,6 @@ button {
   border-radius: var(--r-sm);
   font-size: 12px;
   color: var(--fg-2);
-  display: inline-flex;
-  align-items: center;
   gap: 6px;
   font-weight: 500;
 }
@@ -2968,8 +2845,6 @@ button {
    an inset filled-thumb pill, not an underline tab — so it reads as a control
    within the Code panel rather than as switching between panels. */
 .code-modes {
-  display: flex;
-  align-items: center;
   padding: 7px 10px;
   border-bottom: 1px solid var(--bd-soft);
   background: var(--bg-1);
@@ -2984,8 +2859,6 @@ button {
   border-radius: 8px;
 }
 .cms-seg {
-  display: inline-flex;
-  align-items: center;
   gap: 5px;
   height: 22px;
   padding: 0 10px;
@@ -3036,8 +2909,6 @@ button {
 }
 
 .code-h {
-  display: flex;
-  align-items: center;
   gap: 8px;
   padding: 8px 12px;
   border-bottom: 1px solid var(--bd-soft);
@@ -3176,8 +3047,6 @@ button {
 }
 .code-tab {
   flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
   gap: 7px;
   height: 26px;
   padding: 0 9px;
@@ -3414,8 +3283,6 @@ button {
    · fixable (can't merge / conflicts)=orange · ready=green · merged=purple. */
 .git-hdr {
   flex-shrink: 0;
-  display: flex;
-  align-items: center;
   gap: 8px;
   min-height: 40px;
   box-sizing: border-box;
@@ -3589,8 +3456,6 @@ button {
   color: var(--fg-3);
   border-top: 1px solid var(--bd-soft);
   border-bottom: 1px solid var(--bd-soft);
-  display: flex;
-  align-items: center;
   justify-content: space-between;
   white-space: nowrap;
 }
@@ -3613,8 +3478,6 @@ button {
   padding: 4px 0;
 }
 .git-file {
-  display: flex;
-  align-items: center;
   gap: 10px;
   padding: 6px 18px;
   font-family: var(--font-mono);
@@ -3681,8 +3544,6 @@ button {
   border-radius: var(--r-md);
   font-size: 12.5px;
   line-height: 1.45;
-  display: flex;
-  align-items: center;
   gap: 8px;
 }
 .git-banner svg {
@@ -3750,8 +3611,6 @@ button {
   color: var(--fg-3);
 }
 .git-card-link {
-  display: inline-flex;
-  align-items: center;
   gap: 5px;
   margin-top: 10px;
   font-size: 11.5px;
@@ -3782,8 +3641,6 @@ button {
 
 /* quiet inline link in copy (e.g. the pushed-state commit/compare link) */
 .git-link {
-  display: inline-flex;
-  align-items: center;
   gap: 2px;
   background: none;
   border: 0;
@@ -3975,15 +3832,11 @@ button {
    (see the @container rule at the end of this block). */
 .git-act {
   padding: 11px 18px 14px;
-  display: flex;
-  align-items: center;
   gap: 10px;
   flex-wrap: wrap;
 }
 /* transient confirmation shown in place of the status line after an action */
 .git-notice {
-  display: inline-flex;
-  align-items: center;
   gap: 7px;
   flex: 1 1 auto;
   min-width: 0;
@@ -4005,8 +3858,6 @@ button {
   white-space: nowrap;
 }
 .git-act-status {
-  display: flex;
-  align-items: center;
   gap: 7px;
   flex: 1 1 auto;
   min-width: 0;
@@ -4286,8 +4137,6 @@ button {
   color: var(--success);
 }
 .pr-check {
-  display: flex;
-  align-items: center;
   gap: 7px;
   padding: 3px 4px;
   border: 0;
@@ -4771,8 +4620,6 @@ button {
   background: transparent;
   border: 0;
   color: var(--fg-3);
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
   transition:
     background 0.1s,
@@ -4816,8 +4663,6 @@ button {
   border-bottom-right-radius: calc(var(--r-sm) - 1px);
 }
 .rs-row {
-  display: flex;
-  align-items: center;
   gap: 12px;
   padding: 10px 12px;
   background: var(--bg-1);
@@ -4852,8 +4697,6 @@ button {
   margin-top: 2px;
   font-size: 10.5px;
   color: var(--fg-3);
-  display: inline-flex;
-  align-items: center;
   gap: 4px;
 }
 .rs-source code {
@@ -4871,14 +4714,10 @@ button {
   color: var(--accent);
 }
 .rs-row-r {
-  display: inline-flex;
-  align-items: center;
   gap: 6px;
   flex-shrink: 0;
 }
 .rs-value {
-  display: inline-flex;
-  align-items: center;
   gap: 6px;
   max-width: 220px;
   height: 28px;
@@ -4928,8 +4767,6 @@ button {
   background: transparent;
   border: 0;
   color: var(--fg-3);
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
   transition:
     background 0.1s,
@@ -4943,8 +4780,6 @@ button {
  * doesn't rotate with it (and the button doesn't form a stacking context
  * that would trap the tooltip under the next row). */
 .rs-revert-ic {
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
   transition: transform 0.1s;
 }
@@ -4953,8 +4788,6 @@ button {
 }
 
 .run-sheet-f {
-  display: flex;
-  align-items: center;
   justify-content: space-between;
   gap: 12px;
   padding: 10px 14px;
@@ -4967,9 +4800,6 @@ button {
   color: var(--fg-2);
   min-width: 0;
   flex: 1;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 .rsf-actions {
   display: inline-flex;
@@ -5000,23 +4830,17 @@ button {
 /* empty workspace (draft) */
 .empty-wrap {
   flex: 1;
-  display: flex;
   flex-direction: column;
-  align-items: center;
   justify-content: center;
   padding: 40px 40px 60px;
   position: relative;
 }
 /* identity group: eyebrow + rerollable workspace name, tightly grouped */
 .empty-id {
-  display: flex;
   flex-direction: column;
-  align-items: center;
   margin-bottom: 28px;
 }
 .empty-mark {
-  display: flex;
-  align-items: center;
   gap: 8px;
   font-family: var(--font-mono);
   font-size: 10.5px;
@@ -5073,9 +4897,7 @@ button {
 
 .empty-meta {
   margin-top: 16px;
-  display: flex;
   gap: 8px;
-  align-items: center;
   justify-content: center;
   flex-wrap: wrap;
 }
@@ -5128,8 +4950,6 @@ button {
   overflow-y: auto;
 }
 .sp-h {
-  display: flex;
-  align-items: center;
   font-size: 13px;
   font-weight: 500;
   margin-bottom: 10px;
@@ -5152,8 +4972,6 @@ button {
   padding: 0 4px 6px;
 }
 .sp-row {
-  display: flex;
-  align-items: center;
   gap: 10px;
   padding: 8px 10px;
   border-radius: var(--r-sm);
@@ -5328,8 +5146,6 @@ button {
   }
 }
 .np-modal-h {
-  display: flex;
-  align-items: center;
   gap: 8px;
   padding: 14px 16px;
   border-bottom: 1px solid var(--bd);
@@ -5344,8 +5160,6 @@ button {
   flex: 1;
 }
 .np-close {
-  display: flex;
-  align-items: center;
   justify-content: center;
   width: 24px;
   height: 24px;
@@ -5417,8 +5231,6 @@ button {
 
 /* Destination chooser */
 .np-dest {
-  display: flex;
-  align-items: center;
   gap: 8px;
   height: 36px;
   padding: 0 10px;
@@ -5461,8 +5273,6 @@ button {
   gap: 8px;
 }
 .np-search {
-  display: flex;
-  align-items: center;
   gap: 8px;
   height: 34px;
   padding: 0 10px;
@@ -5529,8 +5339,6 @@ button {
   min-width: 0;
 }
 .np-repo-name {
-  display: flex;
-  align-items: center;
   gap: 8px;
   font-size: 12.5px;
   color: var(--fg-0);
@@ -5549,9 +5357,6 @@ button {
   font-size: 11.5px;
   color: var(--fg-2);
   margin-top: 2px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 /* Actions + gate */
@@ -5561,8 +5366,6 @@ button {
   margin-top: 2px;
 }
 .np-primary {
-  display: flex;
-  align-items: center;
   gap: 7px;
   height: 34px;
   padding: 0 16px;
@@ -5590,9 +5393,7 @@ button {
   }
 }
 .np-gate {
-  display: flex;
   flex-direction: column;
-  align-items: center;
   gap: 8px;
   text-align: center;
   padding: 24px 12px;
@@ -5660,8 +5461,6 @@ button {
 /* Inline per-agent crash notice under the workspace header (status === error).
    Same danger tint as .error-banner, but inline (not a floating toast). */
 .crash-banner {
-  display: flex;
-  align-items: center;
   gap: 12px;
   margin: 8px 12px 0;
   padding: 8px 10px 8px 12px;
@@ -5859,8 +5658,6 @@ button {
 
 /* Terminal in-panel search bar */
 .term-search {
-  display: flex;
-  align-items: center;
   gap: 4px;
   padding: 5px 10px;
   background: var(--bg-2);
@@ -5970,8 +5767,6 @@ button {
   border-bottom: 1px solid var(--bd-soft);
 }
 .hh-search {
-  display: flex;
-  align-items: center;
   gap: 10px;
   height: 36px;
   font-size: 14px;
@@ -6037,8 +5832,6 @@ button {
 /* row */
 .hrow {
   width: 100%;
-  display: flex;
-  align-items: center;
   gap: 10px;
   padding: 5px 24px 5px 28px;
   text-align: left;
@@ -6066,8 +5859,6 @@ button {
 }
 
 .hr-status {
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
   width: 16px;
   flex-shrink: 0;
@@ -6083,9 +5874,6 @@ button {
   font-size: 13px;
   color: var(--fg-2);
   font-weight: 400;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .hr-sep {
@@ -6098,9 +5886,6 @@ button {
   color: var(--fg-0);
   font-weight: 500;
   font-size: 13px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   flex-shrink: 1;
   min-width: 0;
   max-width: 56%;
@@ -6116,9 +5901,6 @@ button {
   color: var(--fg-2);
   font-family: var(--font-mono);
   font-size: 12px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   flex-shrink: 1;
   min-width: 0;
 }
@@ -6129,8 +5911,6 @@ button {
 }
 
 .hr-diff {
-  display: inline-flex;
-  align-items: center;
   gap: 6px;
   padding: 1px 7px;
   border: 1px solid var(--bd-soft);
@@ -6163,8 +5943,6 @@ button {
 .hr-goto {
   position: absolute;
   right: 24px;
-  display: inline-flex;
-  align-items: center;
   gap: 4px;
   color: var(--fg-1);
   font-size: 12px;
@@ -6202,8 +5980,6 @@ button {
 .history-foot {
   flex-shrink: 0;
   border-top: 1px solid var(--bd-soft);
-  display: flex;
-  align-items: center;
   gap: 16px;
   padding: 8px 20px;
   font-size: 11px;
@@ -6230,8 +6006,6 @@ button {
 /* toolbar: search + changed-filter + collapse */
 .fp-toolbar {
   flex-shrink: 0;
-  display: flex;
-  align-items: center;
   gap: 6px;
   padding: 8px 10px;
   border-bottom: 1px solid var(--bd-soft);
@@ -6239,8 +6013,6 @@ button {
 .fp-search {
   flex: 1;
   min-width: 0;
-  display: flex;
-  align-items: center;
   gap: 6px;
   height: 26px;
   padding: 0 8px;
@@ -6271,8 +6043,6 @@ button {
   color: var(--fg-3);
 }
 .fp-clear {
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
   width: 16px;
   height: 16px;
@@ -6290,8 +6060,6 @@ button {
 
 .fp-filter {
   flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
   gap: 6px;
   height: 26px;
   padding: 0 9px;
@@ -6345,8 +6113,6 @@ button {
   flex-direction: column;
 }
 .fp-row {
-  display: flex;
-  align-items: center;
   gap: 6px;
   width: 100%;
   height: 24px;
@@ -6367,8 +6133,6 @@ button {
   color: var(--fg-0);
 }
 .fp-twisty {
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
   width: 12px;
   flex-shrink: 0;
@@ -6392,9 +6156,6 @@ button {
 .fp-name {
   flex: 1;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 /* changed files — colored name + status badge (VS Code style) */
@@ -6424,8 +6185,6 @@ button {
   font-weight: 600;
   width: 15px;
   height: 15px;
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
   border-radius: var(--r-xs);
 }
@@ -6508,8 +6267,6 @@ button {
 
 /* ── inline op-error bar ── */
 .fp-op-error {
-  display: flex;
-  align-items: center;
   gap: 6px;
   margin: 0 8px 4px;
   padding: 5px 8px;
@@ -6542,16 +6299,12 @@ button {
 /* ── viewer header ── */
 .fp-viewer-h {
   flex-shrink: 0;
-  display: flex;
-  align-items: center;
   gap: 8px;
   padding: 8px 12px 8px 8px;
   border-bottom: 1px solid var(--bd-soft);
   background: var(--bg-1);
 }
 .fp-back {
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
   width: 24px;
   height: 24px;
@@ -6567,8 +6320,6 @@ button {
   color: var(--fg-0);
 }
 .fp-vh-actions {
-  display: inline-flex;
-  align-items: center;
   gap: 6px;
   flex-shrink: 0;
 }
@@ -6606,8 +6357,6 @@ button {
 /* ── viewer meta line ── */
 .fp-meta {
   flex-shrink: 0;
-  display: flex;
-  align-items: center;
   gap: 7px;
   padding: 6px 12px;
   font-family: var(--font-mono);
@@ -6637,8 +6386,6 @@ button {
   font-weight: 500;
 }
 .fp-meta-btn {
-  display: inline-flex;
-  align-items: center;
   gap: 4px;
   height: 20px;
   padding: 0 7px;
@@ -6692,8 +6439,6 @@ button {
 /* ── viewer banners (added / deleted file) ── */
 .fp-banner {
   flex-shrink: 0;
-  display: flex;
-  align-items: center;
   gap: 8px;
   padding: 8px 12px;
   font-size: 11.5px;
@@ -6961,8 +6706,6 @@ button {
   padding: 14px 12px 10px;
 }
 .set-back {
-  display: flex;
-  align-items: center;
   gap: 9px;
   white-space: nowrap;
   padding: 8px 10px;
@@ -6992,8 +6735,6 @@ button {
   gap: 1px;
 }
 .set-nav-item {
-  display: flex;
-  align-items: center;
   gap: 11px;
   padding: 9px 11px;
   border-radius: var(--r-md);
@@ -7094,8 +6835,6 @@ button {
   min-width: 0;
 }
 .set-head-actions {
-  display: flex;
-  align-items: center;
   gap: 4px;
   flex-shrink: 0;
 }
@@ -7150,8 +6889,6 @@ button {
 }
 
 .set-row {
-  display: flex;
-  align-items: center;
   gap: 24px;
   padding: 16px 0;
   border-bottom: 1px solid var(--bd-soft);
@@ -7182,8 +6919,6 @@ button {
 }
 .set-row-c {
   flex-shrink: 0;
-  display: flex;
-  align-items: center;
   gap: 8px;
 }
 
@@ -7263,8 +6998,6 @@ button {
   height: 26px;
   border-radius: 8px;
   background: var(--sw);
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
   color: oklch(0.18 0.02 60);
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.18);
@@ -7287,8 +7020,6 @@ button {
 
 /* ── ACCOUNT ─────────────────────────────────────────────────────────── */
 .set-profile {
-  display: flex;
-  align-items: center;
   gap: 16px;
   padding: 4px 0 4px;
   margin-bottom: 8px;
@@ -7303,8 +7034,6 @@ button {
     color-mix(in oklch, var(--accent), black 22%)
   );
   color: oklch(0.18 0.02 60);
-  display: flex;
-  align-items: center;
   justify-content: center;
   font-size: 17px;
   font-weight: 600;
@@ -7391,8 +7120,6 @@ button {
   color: var(--danger);
 }
 .set-form-actions {
-  display: flex;
-  align-items: center;
   justify-content: flex-end;
   gap: 12px;
   margin-top: 4px;
@@ -7443,8 +7170,6 @@ button {
 }
 
 .set-prov-main {
-  display: flex;
-  align-items: center;
   gap: 13px;
   padding: 13px 15px;
 }
@@ -7468,8 +7193,6 @@ button {
 .chip-mono {
   flex-shrink: 0;
   position: relative;
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
   border-radius: 7px;
   font-family: var(--font-mono);
@@ -7508,8 +7231,6 @@ button {
   min-width: 0;
 }
 .set-prov-name {
-  display: flex;
-  align-items: center;
   gap: 9px;
   flex-wrap: nowrap;
   font-size: 13.5px;
@@ -7527,15 +7248,10 @@ button {
   white-space: nowrap;
 }
 .set-prov-sub {
-  display: flex;
-  align-items: center;
   gap: 6px;
   font-size: 12px;
   color: var(--fg-2);
   margin-top: 3px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 .set-prov-sub.muted {
   color: var(--fg-3);
@@ -7547,8 +7263,6 @@ button {
   flex-shrink: 0;
   border-radius: var(--r-sm);
   color: var(--fg-3);
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
   transition:
     background 0.12s,
@@ -7591,8 +7305,6 @@ button {
 
 /* Binary path row: read-only by default, edit-in-place on the pencil. */
 .set-prov-bin-view {
-  display: flex;
-  align-items: center;
   gap: 8px;
   min-width: 0;
 }
@@ -7638,8 +7350,6 @@ button {
   min-width: 0;
 }
 .set-prov-bin-input-row {
-  display: flex;
-  align-items: center;
   gap: 6px;
   min-width: 0;
 }
@@ -7668,8 +7378,6 @@ button {
   color: var(--danger);
 }
 .set-prov-detail-actions {
-  display: flex;
-  align-items: center;
   gap: 6px;
   margin-top: 12px;
 }
@@ -7709,8 +7417,6 @@ button {
 
 /* ── quick-popover "All settings" footer button ──────────────────────── */
 .sp-allbtn {
-  display: flex;
-  align-items: center;
   gap: 9px;
   width: 100%;
   margin-top: 6px;
@@ -7768,9 +7474,7 @@ button {
 .err-boundary-box {
   max-width: 420px;
   text-align: center;
-  display: flex;
   flex-direction: column;
-  align-items: center;
   gap: 10px;
 }
 .err-boundary-title {
@@ -7814,8 +7518,6 @@ button {
   gap: 5px;
 }
 .rdy-line {
-  display: flex;
-  align-items: center;
   gap: 8px;
 }
 .rdy-name {
@@ -7846,14 +7548,10 @@ button {
   background: var(--fg-3);
 }
 .rdy-fix {
-  display: flex;
   flex-wrap: wrap;
-  align-items: center;
   gap: 8px;
 }
 .rdy-cmd {
-  display: inline-flex;
-  align-items: center;
   gap: 8px;
   min-width: 0;
   max-width: 100%;
@@ -7874,8 +7572,6 @@ button {
   border-color: var(--fg-3);
 }
 .rdy-docs {
-  display: inline-flex;
-  align-items: center;
   gap: 4px;
   color: var(--accent);
   font-size: 11.5px;
@@ -7885,8 +7581,6 @@ button {
   font-size: 11.5px;
 }
 .rdy-foot {
-  display: flex;
-  align-items: center;
   justify-content: space-between;
   margin-top: 12px;
   padding-top: 12px;
@@ -7901,8 +7595,6 @@ button {
 /* Colored monogram tile standing in for a custom agent avatar; `--h` is the
    agent's hue (0-360). Used in the list, editor head, and composer picker. */
 .ca-mono {
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
   flex-shrink: 0;
   font-weight: 600;
@@ -7923,8 +7615,6 @@ button {
   gap: 8px;
 }
 .ca-card {
-  display: flex;
-  align-items: center;
   gap: 13px;
   padding: 12px 14px;
   border: 1px solid var(--bd-soft);
@@ -7948,16 +7638,12 @@ button {
   min-width: 0;
 }
 .ca-name {
-  display: flex;
-  align-items: center;
   gap: 10px;
   font-size: 13.5px;
   font-weight: 500;
   color: var(--fg-0);
 }
 .ca-base {
-  display: inline-flex;
-  align-items: center;
   gap: 5px;
   font-size: 11px;
   color: var(--fg-3);
@@ -7973,21 +7659,14 @@ button {
   font-size: 12px;
   color: var(--fg-2);
   margin-top: 3px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 .ca-acts {
-  display: flex;
-  align-items: center;
   gap: 2px;
   flex-shrink: 0;
 }
 
 .ca-empty {
-  display: flex;
   flex-direction: column;
-  align-items: center;
   justify-content: center;
   gap: 10px;
   width: 100%;
@@ -8009,8 +7688,6 @@ button {
   background: var(--hover);
 }
 .ca-empty-ic {
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
   width: 34px;
   height: 34px;
@@ -8028,8 +7705,6 @@ button {
 }
 .ca-ed-back {
   align-self: flex-start;
-  display: inline-flex;
-  align-items: center;
   gap: 5px;
   font-size: 12px;
   color: var(--fg-2);
@@ -8040,8 +7715,6 @@ button {
   color: var(--fg-0);
 }
 .ca-ed-head {
-  display: flex;
-  align-items: center;
   gap: 14px;
 }
 .ca-ed-mono {
@@ -8076,8 +7749,6 @@ button {
   border-color: var(--accent-line);
 }
 .ca-hues {
-  display: flex;
-  align-items: center;
   gap: 6px;
   flex-shrink: 0;
 }
@@ -8123,8 +7794,6 @@ button {
   font-family: var(--font-sans);
 }
 .ca-inject {
-  display: flex;
-  align-items: center;
   gap: 7px;
   font-size: 12px;
   color: var(--fg-2);
@@ -8146,8 +7815,6 @@ button {
 }
 
 .ca-ed-foot {
-  display: flex;
-  align-items: center;
   gap: 12px;
   margin-top: 6px;
   padding-top: 18px;
@@ -8160,8 +7827,6 @@ button {
 /* Custom agents section of the model picker dropdown — mirrors .model-agent-row. */
 .model-custom-row {
   width: 100%;
-  display: flex;
-  align-items: center;
   gap: 10px;
   padding: 7px 9px;
   border-radius: 9px;
@@ -8207,8 +7872,6 @@ button {
 /* Empty-state call to action — opens the new-custom-agent editor. */
 .model-custom-cta {
   width: 100%;
-  display: flex;
-  align-items: center;
   gap: 10px;
   padding: 7px 9px;
   border-radius: 9px;
@@ -8255,8 +7918,6 @@ button {
   width: 100%;
   height: 36px;
   padding: 0 10px 0 12px;
-  display: flex;
-  align-items: center;
   gap: 8px;
   border-radius: var(--r-md);
   border: 1px solid var(--bd);
@@ -8285,16 +7946,11 @@ button {
   flex-shrink: 0;
 }
 .ui-select-icon {
-  display: inline-flex;
-  align-items: center;
   flex-shrink: 0;
 }
 .ui-select-value {
   flex: 1;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 .ui-select-value.is-placeholder {
   color: var(--fg-3);

--- a/src/app.css
+++ b/src/app.css
@@ -2151,6 +2151,7 @@ button {
   color: var(--fg-2);
   flex-shrink: 0;
 }
+.attachment-name { min-width: 0; }
 .attachment-remove {
   justify-content: center;
   width: 16px;

--- a/src/components/Composer/AttachmentList.tsx
+++ b/src/components/Composer/AttachmentList.tsx
@@ -23,7 +23,7 @@ export function AttachmentList({ paths, onRemove, className = "composer-attachme
       {paths.map((path) => (
         <span key={path} className="attachment iflex-center" title={path}>
           <Icon name="file" size={12} />
-          <span className="attachment-name">{basename(path)}</span>
+          <span className="attachment-name truncate">{basename(path)}</span>
           {onRemove && (
             <button
               type="button"

--- a/src/components/Composer/AttachmentList.tsx
+++ b/src/components/Composer/AttachmentList.tsx
@@ -21,13 +21,13 @@ export function AttachmentList({ paths, onRemove, className = "composer-attachme
   return (
     <div className={className}>
       {paths.map((path) => (
-        <span key={path} className="attachment" title={path}>
+        <span key={path} className="attachment iflex-center" title={path}>
           <Icon name="file" size={12} />
           <span className="attachment-name">{basename(path)}</span>
           {onRemove && (
             <button
               type="button"
-              className="attachment-remove"
+              className="attachment-remove iflex-center"
               aria-label={`Remove ${basename(path)}`}
               onClick={() => onRemove(path)}
             >

--- a/src/components/Composer/BranchPicker.tsx
+++ b/src/components/Composer/BranchPicker.tsx
@@ -77,7 +77,7 @@ export function BranchPicker({ repoPath, value, onChange }: Props) {
             {canScrollUp && (
               <button
                 type="button"
-                className="bp-scroll-btn"
+                className="bp-scroll-btn flex-center"
                 onClick={() => scrollBy(-SCROLL_STEP)}
               >
                 <Icon name="chevU" size={11} />
@@ -90,14 +90,14 @@ export function BranchPicker({ repoPath, value, onChange }: Props) {
               onScroll={updateScrollState}
             >
               {branches.length === 0 ? (
-                <div className="dd-item is-disabled" style={{ padding: "7px 9px" }}>
+                <div className="dd-item flex-center is-disabled" style={{ padding: "7px 9px" }}>
                   Loading…
                 </div>
               ) : (
                 branches.map((b) => (
                   <div
                     key={b}
-                    className={`dd-item ${b === value ? "active" : ""}`}
+                    className={`dd-item flex-center ${b === value ? "active" : ""}`}
                     style={{ padding: "7px 9px" }}
                     onClick={() => {
                       onChange(b);
@@ -114,7 +114,7 @@ export function BranchPicker({ repoPath, value, onChange }: Props) {
             </div>
 
             {canScrollDown && (
-              <button type="button" className="bp-scroll-btn" onClick={() => scrollBy(SCROLL_STEP)}>
+              <button type="button" className="bp-scroll-btn flex-center" onClick={() => scrollBy(SCROLL_STEP)}>
                 <Icon name="chevD" size={11} />
               </button>
             )}

--- a/src/components/Composer/BranchPicker.tsx
+++ b/src/components/Composer/BranchPicker.tsx
@@ -114,7 +114,11 @@ export function BranchPicker({ repoPath, value, onChange }: Props) {
             </div>
 
             {canScrollDown && (
-              <button type="button" className="bp-scroll-btn flex-center" onClick={() => scrollBy(SCROLL_STEP)}>
+              <button
+                type="button"
+                className="bp-scroll-btn flex-center"
+                onClick={() => scrollBy(SCROLL_STEP)}
+              >
                 <Icon name="chevD" size={11} />
               </button>
             )}

--- a/src/components/Composer/ModelPicker.tsx
+++ b/src/components/Composer/ModelPicker.tsx
@@ -146,7 +146,9 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
           <>
             <ProviderIcon slug={selected.id} short={selected.short} hue={selected.hue} size={15} />
             <span className="model-chip-agent">{selected.label}</span>
-            <span className="model-chip-model truncate">{currentModel?.name ?? "Default model"}</span>
+            <span className="model-chip-model truncate">
+              {currentModel?.name ?? "Default model"}
+            </span>
           </>
         )}
         {!locked && <Icon name="chevD" size={9} />}

--- a/src/components/Composer/ModelPicker.tsx
+++ b/src/components/Composer/ModelPicker.tsx
@@ -78,15 +78,15 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
       <div className="model-list">
         <button
           type="button"
-          className={`model-option ${isCurrent && !model ? "active" : ""}`}
+          className={`model-option flex-center ${isCurrent && !model ? "active" : ""}`}
           onClick={(e) => {
             e.stopPropagation();
             pickModel(p.id, undefined);
           }}
         >
           <span className="model-option-main">
-            <span className="model-option-name def">Default model</span>
-            <span className="model-option-desc">Use {p.label}'s configured default</span>
+            <span className="model-option-name truncate def">Default model</span>
+            <span className="model-option-desc truncate">Use {p.label}'s configured default</span>
           </span>
           {isCurrent && !model && <Icon name="check" size={13} />}
         </button>
@@ -104,14 +104,14 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
               <button
                 key={m.id}
                 type="button"
-                className={`model-option ${active ? "active" : ""}`}
+                className={`model-option flex-center ${active ? "active" : ""}`}
                 onClick={(e) => {
                   e.stopPropagation();
                   pickModel(p.id, m.id);
                 }}
               >
                 <span className="model-option-main">
-                  <span className="model-option-name">{m.name}</span>
+                  <span className="model-option-name truncate">{m.name}</span>
                 </span>
                 {m.contextWindow > 0 && (
                   <span className="model-ctx">{formatContext(m.contextWindow)}</span>
@@ -140,13 +140,13 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
           <>
             <Mono name={activeCustom.name} hue={activeCustom.color} size={15} />
             <span className="model-chip-agent">{activeCustom.name}</span>
-            <span className="model-chip-model">{providerLabel(activeCustom.base)}</span>
+            <span className="model-chip-model truncate">{providerLabel(activeCustom.base)}</span>
           </>
         ) : (
           <>
             <ProviderIcon slug={selected.id} short={selected.short} hue={selected.hue} size={15} />
             <span className="model-chip-agent">{selected.label}</span>
-            <span className="model-chip-model">{currentModel?.name ?? "Default model"}</span>
+            <span className="model-chip-model truncate">{currentModel?.name ?? "Default model"}</span>
           </>
         )}
         {!locked && <Icon name="chevD" size={9} />}
@@ -164,7 +164,7 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
             onMouseLeave={() => setHovered(null)}
           >
             <div className="model-dd-main">
-              <div className="model-sect">
+              <div className="model-sect flex-center">
                 <span>Coding agents</span>
                 <span className="model-sect-line" />
               </div>
@@ -184,7 +184,7 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
                     key={p.id}
                     type="button"
                     disabled={!usable}
-                    className={`model-agent-row ${isSelected ? "active" : ""} ${isOpen ? "hot" : ""}`}
+                    className={`model-agent-row flex-center ${isSelected ? "active" : ""} ${isOpen ? "hot" : ""}`}
                     title={
                       missing
                         ? "Not installed — see Settings › Providers"
@@ -194,7 +194,7 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
                     onClick={() => usable && pickModel(p.id, undefined)}
                   >
                     <ProviderIcon slug={p.id} short={p.short} hue={p.hue} size={26} />
-                    <span className="model-agent-name">{p.label}</span>
+                    <span className="model-agent-name truncate">{p.label}</span>
                     <span className="model-agent-ver">
                       {missing ? "Not installed" : (providerVersions[p.id] ?? p.version)}
                     </span>
@@ -203,7 +203,7 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
                 );
               })}
 
-              <div className="model-sect">
+              <div className="model-sect flex-center">
                 <span>Custom agents</span>
                 <span className="model-sect-line" />
               </div>
@@ -214,7 +214,7 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
                     <button
                       key={a.id}
                       type="button"
-                      className={`model-custom-row ${active ? "active" : ""}`}
+                      className={`model-custom-row flex-center ${active ? "active" : ""}`}
                       onMouseEnter={() => setHovered(null)}
                       onClick={() => pickCustom(a.id, a.base, a.model)}
                     >
@@ -230,7 +230,7 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
               ) : (
                 <button
                   type="button"
-                  className="model-custom-cta"
+                  className="model-custom-cta flex-center"
                   onMouseEnter={() => setHovered(null)}
                   onClick={() => {
                     setOpen(false);
@@ -252,14 +252,14 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
               <div className="model-side-fly">
                 <div className="model-side-fly-card">
                   <div className="model-side-fly-inner" key={hoveredAgent.id}>
-                    <div className="model-side-fly-head">
+                    <div className="model-side-fly-head flex-center">
                       <ProviderIcon
                         slug={hoveredAgent.id}
                         short={hoveredAgent.short}
                         hue={hoveredAgent.hue}
                         size={20}
                       />
-                      <span className="model-side-fly-name">{hoveredAgent.label}</span>
+                      <span className="model-side-fly-name truncate">{hoveredAgent.label}</span>
                       <span className="model-side-fly-tag">model</span>
                     </div>
                     <div className="model-side-fly-list">{renderModelList(hoveredAgent)}</div>

--- a/src/components/Composer/ProjectPicker.tsx
+++ b/src/components/Composer/ProjectPicker.tsx
@@ -39,7 +39,7 @@ export function ProjectPicker({ value, repos, onChange }: Props) {
               {repos.map((r) => (
                 <div
                   key={r}
-                  className={`dd-item ${r === value ? "active" : ""}`}
+                  className={`dd-item flex-center ${r === value ? "active" : ""}`}
                   style={{ padding: "7px 9px" }}
                   title={r}
                   onClick={() => {

--- a/src/components/Composer/UsageMeter.tsx
+++ b/src/components/Composer/UsageMeter.tsx
@@ -48,7 +48,11 @@ export function UsageMeter({ usage }: { usage: AgentUsage }) {
   const ringColor = pct >= 90 ? "var(--danger)" : pct >= 75 ? "var(--warn)" : "var(--accent)";
 
   return (
-    <div className="usage iflex-center" onMouseEnter={() => setOpen(true)} onMouseLeave={() => setOpen(false)}>
+    <div
+      className="usage iflex-center"
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+    >
       <button type="button" className="usage-chip iflex-center" aria-label={`Context ${pct}% used`}>
         <svg className="usage-ring" viewBox="0 0 18 18" width="15" height="15">
           <circle cx="9" cy="9" r={R} fill="none" stroke="var(--bd-strong)" strokeWidth="2.2" />

--- a/src/components/Composer/UsageMeter.tsx
+++ b/src/components/Composer/UsageMeter.tsx
@@ -48,8 +48,8 @@ export function UsageMeter({ usage }: { usage: AgentUsage }) {
   const ringColor = pct >= 90 ? "var(--danger)" : pct >= 75 ? "var(--warn)" : "var(--accent)";
 
   return (
-    <div className="usage" onMouseEnter={() => setOpen(true)} onMouseLeave={() => setOpen(false)}>
-      <button type="button" className="usage-chip" aria-label={`Context ${pct}% used`}>
+    <div className="usage iflex-center" onMouseEnter={() => setOpen(true)} onMouseLeave={() => setOpen(false)}>
+      <button type="button" className="usage-chip iflex-center" aria-label={`Context ${pct}% used`}>
         <svg className="usage-ring" viewBox="0 0 18 18" width="15" height="15">
           <circle cx="9" cy="9" r={R} fill="none" stroke="var(--bd-strong)" strokeWidth="2.2" />
           <circle
@@ -90,13 +90,13 @@ export function UsageMeter({ usage }: { usage: AgentUsage }) {
 
           <div className="up-legend">
             {segments.map((s) => (
-              <div key={s.key} className="up-leg">
+              <div key={s.key} className="up-leg flex-center">
                 <span className="up-dot" style={{ background: s.color }} />
                 <span className="up-k">{s.label}</span>
                 <span className="up-v">{formatTokens(s.tokens)}</span>
               </div>
             ))}
-            <div className="up-leg">
+            <div className="up-leg flex-center">
               <span className="up-dot track" />
               <span className="up-k">Free</span>
               <span className="up-v">{formatTokens(free)}</span>
@@ -109,7 +109,7 @@ export function UsageMeter({ usage }: { usage: AgentUsage }) {
             <Row label="Input" value={formatTokens(usage.inputTokens)} />
             <Row label="Output" value={formatTokens(usage.outputTokens)} />
             {usage.costUsd > 0 && (
-              <div className="up-row total">
+              <div className="up-row flex-center total">
                 <span>Est. cost</span>
                 <span className="up-rv">{formatCost(usage.costUsd)}</span>
               </div>
@@ -123,7 +123,7 @@ export function UsageMeter({ usage }: { usage: AgentUsage }) {
 
 function Row({ label, value }: { label: string; value: string }) {
   return (
-    <div className="up-row">
+    <div className="up-row flex-center">
       <span>{label}</span>
       <span className="up-rv">{value}</span>
     </div>

--- a/src/components/Composer/autocomplete/AutocompleteMenu.tsx
+++ b/src/components/Composer/autocomplete/AutocompleteMenu.tsx
@@ -41,7 +41,7 @@ export function AutocompleteMenu({ heading, rows, highlight, onPick, onHighlight
         <div
           key={i}
           ref={i === highlight ? activeRef : undefined}
-          className={`dd-item ac-item ${i === highlight ? "active" : ""}`}
+          className={`dd-item flex-center ac-item ${i === highlight ? "active" : ""}`}
           role="option"
           aria-selected={i === highlight}
           onMouseDown={(e) => {

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -296,7 +296,7 @@ export function Composer({
   return (
     <div className={`composer${isDropTarget ? " is-drop-target" : ""}`}>
       {isDropTarget && (
-        <div className="composer-drop-overlay">
+        <div className="composer-drop-overlay flex-center">
           <Icon name="upload" size={20} />
           <span>Drop files to attach</span>
         </div>
@@ -329,7 +329,7 @@ export function Composer({
           }
         }}
       />
-      <div className="composer-foot">
+      <div className="composer-foot flex-center">
         <ModelPicker
           provider={provider}
           model={model}
@@ -384,7 +384,7 @@ export function Composer({
         {features.tokenUsage && usage && usage.contextTokens > 0 && <UsageMeter usage={usage} />}
         <button
           type="button"
-          className={`send ${showStop ? "is-stop" : ""}`}
+          className={`send flex-center ${showStop ? "is-stop" : ""}`}
           disabled={sendDisabled}
           onClick={showStop ? stop : send}
           aria-label={showStop ? "Stop" : "Send"}

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -34,12 +34,12 @@ export class ErrorBoundary extends Component<Props, State> {
     if (!error) return this.props.children;
     return (
       <div className="err-boundary" role="alert">
-        <div className="err-boundary-box">
+        <div className="err-boundary-box flex-center">
           <div className="err-boundary-title">
             Something went wrong{this.props.label ? ` in ${this.props.label}` : ""}.
           </div>
           <div className="err-boundary-msg">{error.message || String(error)}</div>
-          <button type="button" className="btn-t outline" onClick={this.reset}>
+          <button type="button" className="btn-t iflex-center outline" onClick={this.reset}>
             Try again
           </button>
         </div>

--- a/src/components/History/index.tsx
+++ b/src/components/History/index.tsx
@@ -104,7 +104,7 @@ export function History() {
       <div className="history-sheet" onClick={(e) => e.stopPropagation()}>
         {/* Search header */}
         <div className="hh">
-          <div className="hh-search">
+          <div className="hh-search flex-center">
             <Icon name="search" size={16} />
             <input
               autoFocus
@@ -145,7 +145,7 @@ export function History() {
                     return (
                       <button
                         key={a.id}
-                        className={`hrow archived${isFocused ? " focused" : ""}`}
+                        className={`hrow flex-center archived${isFocused ? " focused" : ""}`}
                         onClick={() => onRowClick(a.id)}
                         onMouseEnter={() => setFocusedIndex(myIdx)}
                         disabled={!!restoringId}
@@ -154,21 +154,21 @@ export function History() {
                         // parent opacity would otherwise cap the child rule).
                         style={{ opacity: !isRestoring && restoringId ? 0.5 : undefined }}
                       >
-                        <span className="hr-status">
+                        <span className="hr-status iflex-center">
                           <Icon name="dot" size={6} />
                         </span>
-                        <span className="hr-project">{repoLabel}</span>
+                        <span className="hr-project truncate">{repoLabel}</span>
                         <span className="hr-sep">/</span>
-                        <span className="hr-title">{task}</span>
+                        <span className="hr-title truncate">{task}</span>
                         {branchLabel && (
                           <>
                             <span className="hr-dot">·</span>
-                            <span className="hr-branch">{branchLabel}</span>
+                            <span className="hr-branch truncate">{branchLabel}</span>
                           </>
                         )}
                         <span className="hr-spacer" />
                         {showStats && (
-                          <span className="hr-diff">
+                          <span className="hr-diff iflex-center">
                             <span className="add">+{adds}</span>
                             <span className="rem">-{dels}</span>
                           </span>
@@ -212,7 +212,7 @@ export function History() {
         </div>
 
         {/* Footer */}
-        <div className="history-foot">
+        <div className="history-foot flex-center">
           <span>
             <kbd className="kbd">Esc</kbd> <span className="dim">to close</span>
           </span>

--- a/src/components/NewProject/CloneView.tsx
+++ b/src/components/NewProject/CloneView.tsx
@@ -66,7 +66,7 @@ export function CloneView({ shared, onDone }: { shared: NewProjectShared; onDone
       {error && <div className="np-error">{error}</div>}
 
       <div className="np-actions">
-        <button className="np-primary" disabled={!canClone} onClick={onClone}>
+        <button className="np-primary flex-center" disabled={!canClone} onClick={onClone}>
           {busy ? (
             <>
               <Icon name="refresh" size={13} /> Cloning…

--- a/src/components/NewProject/CreateView.tsx
+++ b/src/components/NewProject/CreateView.tsx
@@ -81,7 +81,7 @@ export function CreateView({ shared, onDone }: { shared: NewProjectShared; onDon
       {error && <div className="np-error">{error}</div>}
 
       <div className="np-actions">
-        <button className="np-primary" disabled={!canCreate} onClick={onCreate}>
+        <button className="np-primary flex-center" disabled={!canCreate} onClick={onCreate}>
           {busy ? (
             <>
               <Icon name="refresh" size={13} /> Creating…

--- a/src/components/NewProject/RepoList.tsx
+++ b/src/components/NewProject/RepoList.tsx
@@ -49,7 +49,7 @@ export function RepoList({ selected, onSelect }: Props) {
 
   return (
     <div className="np-list-wrap">
-      <div className="np-search">
+      <div className="np-search flex-center">
         <Icon name="search" size={13} />
         <input
           autoFocus
@@ -72,11 +72,11 @@ export function RepoList({ selected, onSelect }: Props) {
           >
             <Icon name="github" size={13} />
             <div className="np-repo-text">
-              <div className="np-repo-name">
+              <div className="np-repo-name flex-center">
                 {r.name_with_owner}
                 {r.is_private && <span className="np-priv">Private</span>}
               </div>
-              {r.description && <div className="np-repo-desc">{r.description}</div>}
+              {r.description && <div className="np-repo-desc truncate">{r.description}</div>}
             </div>
           </button>
         ))}

--- a/src/components/NewProject/index.tsx
+++ b/src/components/NewProject/index.tsx
@@ -15,10 +15,10 @@ export function NewProject({ mode, onClose }: { mode: NewProjectMode; onClose: (
     <>
       <Scrim onClose={onClose} zIndex={300} />
       <div className="np-modal" role="dialog" aria-modal="true">
-        <div className="np-modal-h">
+        <div className="np-modal-h flex-center">
           <Icon name={mode === "clone" ? "github" : "sparkle"} size={15} />
           <span>{mode === "clone" ? "Clone from GitHub" : "Create new project"}</span>
-          <button className="np-close" aria-label="Close" onClick={onClose}>
+          <button className="np-close flex-center" aria-label="Close" onClick={onClose}>
             <Icon name="close" size={14} />
           </button>
         </div>

--- a/src/components/NewProject/shared.tsx
+++ b/src/components/NewProject/shared.tsx
@@ -25,7 +25,7 @@ export function DestRow({
   return (
     <div className="np-field">
       <label>Location</label>
-      <button className="np-dest" onClick={onPick}>
+      <button className="np-dest flex-center" onClick={onPick}>
         <Icon name="folder" size={14} />
         {parent ? (
           <span className="np-dest-path">
@@ -50,7 +50,7 @@ export function DestRow({
 export function GhGate({ gh }: { gh: GhStatus }) {
   return (
     <div className="np-body">
-      <div className="np-gate">
+      <div className="np-gate flex-center">
         <Icon name="github" size={22} />
         {!gh.installed ? (
           <>

--- a/src/components/Onboarding/OnboardingReadiness.tsx
+++ b/src/components/Onboarding/OnboardingReadiness.tsx
@@ -130,7 +130,12 @@ export function OnboardingReadiness() {
               ? `${detected} of ${agents.length} agents detected`
               : "couldn't detect agents"}
         </span>
-        <button type="button" className="btn-t iflex-center outline" onClick={recheck} disabled={checking}>
+        <button
+          type="button"
+          className="btn-t iflex-center outline"
+          onClick={recheck}
+          disabled={checking}
+        >
           <Icon name="refresh" size={11} />
           {checking ? "checking…" : "re-check"}
         </button>
@@ -165,7 +170,11 @@ function CheckRow({
         <div className="ob-rdy-check-fix">
           {fix && <CopyCmd cmd={fix} />}
           {docs && (
-            <button type="button" className="rdy-docs iflex-center" onClick={() => void openExternal(docs)}>
+            <button
+              type="button"
+              className="rdy-docs iflex-center"
+              onClick={() => void openExternal(docs)}
+            >
               guide <Icon name="external" size={9} />
             </button>
           )}
@@ -203,7 +212,11 @@ function AgentTile({
         <div className="ob-rdy-tile-fix">
           {fix && <CopyCmd cmd={fix} />}
           {docs && (
-            <button type="button" className="rdy-docs iflex-center" onClick={() => void openExternal(docs)}>
+            <button
+              type="button"
+              className="rdy-docs iflex-center"
+              onClick={() => void openExternal(docs)}
+            >
               install <Icon name="external" size={9} />
             </button>
           )}

--- a/src/components/Onboarding/OnboardingReadiness.tsx
+++ b/src/components/Onboarding/OnboardingReadiness.tsx
@@ -130,7 +130,7 @@ export function OnboardingReadiness() {
               ? `${detected} of ${agents.length} agents detected`
               : "couldn't detect agents"}
         </span>
-        <button type="button" className="btn-t outline" onClick={recheck} disabled={checking}>
+        <button type="button" className="btn-t iflex-center outline" onClick={recheck} disabled={checking}>
           <Icon name="refresh" size={11} />
           {checking ? "checking…" : "re-check"}
         </button>
@@ -165,7 +165,7 @@ function CheckRow({
         <div className="ob-rdy-check-fix">
           {fix && <CopyCmd cmd={fix} />}
           {docs && (
-            <button type="button" className="rdy-docs" onClick={() => void openExternal(docs)}>
+            <button type="button" className="rdy-docs iflex-center" onClick={() => void openExternal(docs)}>
               guide <Icon name="external" size={9} />
             </button>
           )}
@@ -203,7 +203,7 @@ function AgentTile({
         <div className="ob-rdy-tile-fix">
           {fix && <CopyCmd cmd={fix} />}
           {docs && (
-            <button type="button" className="rdy-docs" onClick={() => void openExternal(docs)}>
+            <button type="button" className="rdy-docs iflex-center" onClick={() => void openExternal(docs)}>
               install <Icon name="external" size={9} />
             </button>
           )}
@@ -218,7 +218,7 @@ function CopyCmd({ cmd }: { cmd: string }) {
   return (
     <button
       type="button"
-      className="rdy-cmd"
+      className="rdy-cmd iflex-center"
       title="Copy command"
       onClick={() => {
         void navigator.clipboard.writeText(cmd);

--- a/src/components/Onboarding/exhibits.tsx
+++ b/src/components/Onboarding/exhibits.tsx
@@ -87,27 +87,27 @@ function ExhibitAgentRow({ a }: { a: ParallelAgent }) {
   return (
     <div className={`agent ${a.active ? "active" : ""}`}>
       <span className={`ag-rail ${rail}`} />
-      <div className="agent-row">
+      <div className="agent-row flex-center">
         <span className={`ag-name ${working ? "shimmer" : ""}`}>{a.name}</span>
         <span className="ag-prov-chip">
           <ProviderIcon slug={a.provider} {...providerChip(a.provider)} size={14} />
         </span>
-        <span className="ag-slot">
+        <span className="ag-slot iflex-center">
           <span className="ag-meta">
             {working && <span className="ag-loader" aria-label="Working" />}
             {!working && a.unseen && (
               <span className="ag-unseen" aria-label="New results to review" />
             )}
-            {a.status === "error" && <span className="ag-badge err">error</span>}
+            {a.status === "error" && <span className="ag-badge iflex-center err">error</span>}
           </span>
           <span className="ag-actions">
-            <span className="ag-act">
+            <span className="ag-act iflex-center">
               <Icon name={working ? "stop" : "archive"} size={11} />
             </span>
           </span>
         </span>
       </div>
-      <div className="agent-sub">
+      <div className="agent-sub flex-center">
         <span className="a-task">{a.task}</span>
         <span className="a-diff">
           <span className="add">+{a.add}</span> <span className="del">−{a.rem}</span>
@@ -125,7 +125,7 @@ export function ExhibitParallel() {
         <ExBar title="quorum — worktrees" />
         <div className="ex-side">
           <div className="proj">
-            <div className="proj-h open">
+            <div className="proj-h flex-center open">
               <Icon name="chevR" size={10} className="chev" />
               <span className="pname">quorum-core</span>
               <span className="pcount">4</span>

--- a/src/components/ProviderReadiness/index.tsx
+++ b/src/components/ProviderReadiness/index.tsx
@@ -71,7 +71,11 @@ function Row({
           <div className="rdy-fix flex-center">
             {fix && <CopyCmd cmd={fix} />}
             {docs && (
-              <button type="button" className="rdy-docs iflex-center" onClick={() => void openExternal(docs)}>
+              <button
+                type="button"
+                className="rdy-docs iflex-center"
+                onClick={() => void openExternal(docs)}
+              >
                 Setup guide
                 <Icon name="external" size={10} />
               </button>
@@ -211,7 +215,12 @@ export function ProviderReadiness() {
               ? `${detected} of ${agents.length} agents detected`
               : "Couldn't detect agents"}
         </span>
-        <button type="button" className="btn-t iflex-center outline" onClick={recheck} disabled={checking}>
+        <button
+          type="button"
+          className="btn-t iflex-center outline"
+          onClick={recheck}
+          disabled={checking}
+        >
           <Icon name="refresh" size={12} />
           {checking ? "Checking…" : "Re-check"}
         </button>

--- a/src/components/ProviderReadiness/index.tsx
+++ b/src/components/ProviderReadiness/index.tsx
@@ -24,7 +24,7 @@ function CopyCmd({ cmd }: { cmd: string }) {
   return (
     <button
       type="button"
-      className="rdy-cmd"
+      className="rdy-cmd iflex-center"
       title="Copy command"
       onClick={() => {
         void navigator.clipboard.writeText(cmd);
@@ -62,16 +62,16 @@ function Row({
     <div className="rdy-row">
       <span className="rdy-icon">{icon}</span>
       <div className="rdy-main">
-        <div className="rdy-line">
+        <div className="rdy-line flex-center">
           <span className="rdy-name">{name}</span>
           <span className={`rdy-dot ${state}`} />
           <span className="rdy-status">{statusText}</span>
         </div>
         {needsFix && (fix || docs) && (
-          <div className="rdy-fix">
+          <div className="rdy-fix flex-center">
             {fix && <CopyCmd cmd={fix} />}
             {docs && (
-              <button type="button" className="rdy-docs" onClick={() => void openExternal(docs)}>
+              <button type="button" className="rdy-docs iflex-center" onClick={() => void openExternal(docs)}>
                 Setup guide
                 <Icon name="external" size={10} />
               </button>
@@ -203,7 +203,7 @@ export function ProviderReadiness() {
         docs={!gh?.installed ? "https://cli.github.com" : undefined}
       />
 
-      <div className="rdy-foot">
+      <div className="rdy-foot flex-center">
         <span className="rdy-count">
           {checking
             ? "Checking…"
@@ -211,7 +211,7 @@ export function ProviderReadiness() {
               ? `${detected} of ${agents.length} agents detected`
               : "Couldn't detect agents"}
         </span>
-        <button type="button" className="btn-t outline" onClick={recheck} disabled={checking}>
+        <button type="button" className="btn-t iflex-center outline" onClick={recheck} disabled={checking}>
           <Icon name="refresh" size={12} />
           {checking ? "Checking…" : "Re-check"}
         </button>

--- a/src/components/RightPanel/Code/CodeLivePanel.tsx
+++ b/src/components/RightPanel/Code/CodeLivePanel.tsx
@@ -203,7 +203,7 @@ export function CodeLivePanel({
   return (
     <div className="code-wrap">
       {/* header: totals + follow toggle */}
-      <div className="code-h">
+      <div className="code-h flex-center">
         <div className="code-h-l">
           <span className="ch-count">
             {files.length}
@@ -246,7 +246,7 @@ export function CodeLivePanel({
             <button
               key={f.path}
               role="tab"
-              className={`code-tab ${f.path === displayPath ? "active" : ""} ${live ? "live" : ""} status-${statusLetter(f.kind).toLowerCase()}`}
+              className={`code-tab iflex-center ${f.path === displayPath ? "active" : ""} ${live ? "live" : ""} status-${statusLetter(f.kind).toLowerCase()}`}
               onClick={() => onPickTab(f.path)}
               title={f.path}
             >

--- a/src/components/RightPanel/Code/index.tsx
+++ b/src/components/RightPanel/Code/index.tsx
@@ -77,12 +77,12 @@ function ModeSwitch({
   const busy = useAppStore((s) => s.managedBusy[agent.id] ?? false);
 
   return (
-    <div className="code-modes">
+    <div className="code-modes flex-center">
       <div className="code-modeswitch" role="tablist" aria-label="Code view mode">
         <button
           role="tab"
           aria-selected={mode === "files"}
-          className={`cms-seg ${mode === "files" ? "active" : ""} tip`}
+          className={`cms-seg iflex-center ${mode === "files" ? "active" : ""} tip`}
           data-tip-down
           data-tip="Browse and edit any file in the worktree"
           onClick={() => onChange("files")}
@@ -93,7 +93,7 @@ function ModeSwitch({
         <button
           role="tab"
           aria-selected={mode === "live"}
-          className={`cms-seg ${mode === "live" ? "active" : ""} tip`}
+          className={`cms-seg iflex-center ${mode === "live" ? "active" : ""} tip`}
           data-tip-down
           data-tip="Watch the agent's changes as they happen"
           onClick={() => onChange("live")}

--- a/src/components/RightPanel/FileContextMenu.tsx
+++ b/src/components/RightPanel/FileContextMenu.tsx
@@ -95,7 +95,7 @@ export function FileContextMenu({ x, y, entries, onClose }: Props) {
             key={i}
             type="button"
             role="menuitem"
-            className={`dd-item fp-ctx-item ${entry.danger || isArmed ? "danger" : ""}`}
+            className={`dd-item flex-center fp-ctx-item ${entry.danger || isArmed ? "danger" : ""}`}
             onMouseDown={(e) => e.preventDefault()}
             onClick={() => {
               if (entry.confirmLabel && !isArmed) {

--- a/src/components/RightPanel/FilePanel/FileEditor.tsx
+++ b/src/components/RightPanel/FilePanel/FileEditor.tsx
@@ -203,9 +203,9 @@ export function FileEditor({ agent, path, name, dir, file, onBack }: FileEditorP
         dirty={saveState === "saving"}
         actions={
           canDiff ? (
-            <span className="fp-vh-actions">
+            <span className="fp-vh-actions iflex-center">
               <button
-                className={`fp-meta-btn ${diffView ? "active" : ""}`}
+                className={`fp-meta-btn iflex-center ${diffView ? "active" : ""}`}
                 title={diffView ? "Back to the file" : "Show what the agent changed"}
                 onClick={() => setView((v) => (v === "diff" ? "code" : "diff"))}
               >
@@ -221,13 +221,13 @@ export function FileEditor({ agent, path, name, dir, file, onBack }: FileEditorP
       ) : (
         <>
           {isDeleted && (
-            <div className="fp-banner del">
+            <div className="fp-banner flex-center del">
               <Icon name="trash" size={12} />
               <span>Deleted by the agent. Edits here re-create the file.</span>
             </div>
           )}
           {file.status === "A" && value === originalText && (
-            <div className="fp-banner add">
+            <div className="fp-banner flex-center add">
               <Icon name="plus" size={12} />
               <span>New file added by the agent.</span>
             </div>
@@ -268,7 +268,7 @@ export function FileEditor({ agent, path, name, dir, file, onBack }: FileEditorP
         </>
       )}
 
-      <div className="fp-meta">
+      <div className="fp-meta flex-center">
         <span className="fp-meta-lang">{langLabel(file.lang)}</span>
         {diffView ? (
           <>
@@ -305,7 +305,7 @@ export function FileEditor({ agent, path, name, dir, file, onBack }: FileEditorP
         <span className="fp-meta-grow"></span>
         {!diffView && editedFromAgent && (
           <button
-            className="fp-meta-btn"
+            className="fp-meta-btn iflex-center"
             title="Discard edits, restore the agent's version"
             onClick={() => void revert()}
           >

--- a/src/components/RightPanel/FilePanel/TreeBrowser.tsx
+++ b/src/components/RightPanel/FilePanel/TreeBrowser.tsx
@@ -52,8 +52,8 @@ export function TreeBrowser({
 }: TreeBrowserProps) {
   return (
     <div className="fp-wrap">
-      <div className="fp-toolbar">
-        <div className="fp-search">
+      <div className="fp-toolbar flex-center">
+        <div className="fp-search flex-center">
           <Icon name="search" size={12} />
           <input
             type="text"
@@ -63,13 +63,13 @@ export function TreeBrowser({
             spellCheck={false}
           />
           {query && (
-            <button className="fp-clear" onClick={() => onQueryChange("")} aria-label="Clear">
+            <button className="fp-clear iflex-center" onClick={() => onQueryChange("")} aria-label="Clear">
               <Icon name="close" size={10} />
             </button>
           )}
         </div>
         <button
-          className={`fp-filter ${changedOnly ? "on" : ""}`}
+          className={`fp-filter iflex-center ${changedOnly ? "on" : ""}`}
           title={changedOnly ? "Showing changed files only" : "Show only files the agent changed"}
           onClick={onToggleChangedOnly}
         >
@@ -77,17 +77,17 @@ export function TreeBrowser({
           Changed
           <span className="fp-filter-count">{changedCount}</span>
         </button>
-        <button className="btn-i xs" title="New file" onClick={() => onBeginCreate("newFile", "")}>
+        <button className="btn-i iflex-center xs" title="New file" onClick={() => onBeginCreate("newFile", "")}>
           <Icon name="file" />
         </button>
         <button
-          className="btn-i xs"
+          className="btn-i iflex-center xs"
           title="New folder"
           onClick={() => onBeginCreate("newFolder", "")}
         >
           <Icon name="folder" />
         </button>
-        <button className="btn-i xs" title="Collapse all" onClick={onCollapseAll}>
+        <button className="btn-i iflex-center xs" title="Collapse all" onClick={onCollapseAll}>
           <Icon name="shrink" />
         </button>
       </div>
@@ -95,10 +95,10 @@ export function TreeBrowser({
       {opError && (
         // Key by message so a new error remounts the banner and re-runs the
         // attention flash even when one is already showing.
-        <div key={opError} className="fp-op-error" role="alert">
+        <div key={opError} className="fp-op-error flex-center" role="alert">
           <Icon name="close" size={11} />
           <span>{opError}</span>
-          <button className="fp-clear" onClick={onClearOpError} aria-label="Dismiss">
+          <button className="fp-clear iflex-center" onClick={onClearOpError} aria-label="Dismiss">
             <Icon name="close" size={10} />
           </button>
         </div>
@@ -172,7 +172,7 @@ function TreeRow({
     return (
       <>
         <button
-          className="fp-row dir"
+          className="fp-row flex-center dir"
           style={{ paddingLeft: pad }}
           onClick={() => onToggle(node.path)}
           onContextMenu={(e) => {
@@ -180,14 +180,14 @@ function TreeRow({
             onMenu(node, e.clientX, e.clientY);
           }}
         >
-          <span className={`fp-twisty ${isOpen ? "open" : ""}`}>
+          <span className={`fp-twisty iflex-center ${isOpen ? "open" : ""}`}>
             <Icon name="chevR" size={11} />
           </span>
           <FileIcon name={node.name} folder open={isOpen} />
           {renaming ? (
             <NameInput initial={node.name} onCommit={onCommit} onCancel={onCancel} />
           ) : (
-            <span className="fp-name">{node.name}</span>
+            <span className="fp-name truncate">{node.name}</span>
           )}
           {/* When collapsed, surface that this folder hides agent edits. */}
           {!isOpen && !renaming && node.changedCount > 0 && (
@@ -247,9 +247,9 @@ function TreeRow({
       {renaming ? (
         <NameInput initial={node.name} onCommit={onCommit} onCancel={onCancel} />
       ) : (
-        <span className="fp-name">{node.name}</span>
+        <span className="fp-name truncate">{node.name}</span>
       )}
-      {node.status && !renaming && <span className={`fp-badge s-${st}`}>{node.status}</span>}
+      {node.status && !renaming && <span className={`fp-badge iflex-center s-${st}`}>{node.status}</span>}
     </button>
   );
 }
@@ -331,7 +331,7 @@ function CreateRow({ mode, depth, onCommit, onCancel }: CreateRowProps) {
   const pad = 10 + depth * 13;
   const isFolder = mode === "newFolder";
   return (
-    <div className="fp-row file fp-creating" style={{ paddingLeft: pad + 13 }}>
+    <div className="fp-row flex-center file fp-creating" style={{ paddingLeft: pad + 13 }}>
       <FileIcon name="" folder={isFolder} open={isFolder} />
       <NameInput initial="" onCommit={onCommit} onCancel={onCancel} />
     </div>

--- a/src/components/RightPanel/FilePanel/TreeBrowser.tsx
+++ b/src/components/RightPanel/FilePanel/TreeBrowser.tsx
@@ -63,7 +63,11 @@ export function TreeBrowser({
             spellCheck={false}
           />
           {query && (
-            <button className="fp-clear iflex-center" onClick={() => onQueryChange("")} aria-label="Clear">
+            <button
+              className="fp-clear iflex-center"
+              onClick={() => onQueryChange("")}
+              aria-label="Clear"
+            >
               <Icon name="close" size={10} />
             </button>
           )}
@@ -77,7 +81,11 @@ export function TreeBrowser({
           Changed
           <span className="fp-filter-count">{changedCount}</span>
         </button>
-        <button className="btn-i iflex-center xs" title="New file" onClick={() => onBeginCreate("newFile", "")}>
+        <button
+          className="btn-i iflex-center xs"
+          title="New file"
+          onClick={() => onBeginCreate("newFile", "")}
+        >
           <Icon name="file" />
         </button>
         <button
@@ -249,7 +257,9 @@ function TreeRow({
       ) : (
         <span className="fp-name truncate">{node.name}</span>
       )}
-      {node.status && !renaming && <span className={`fp-badge iflex-center s-${st}`}>{node.status}</span>}
+      {node.status && !renaming && (
+        <span className={`fp-badge iflex-center s-${st}`}>{node.status}</span>
+      )}
     </button>
   );
 }

--- a/src/components/RightPanel/FilePanel/ViewerHeader.tsx
+++ b/src/components/RightPanel/FilePanel/ViewerHeader.tsx
@@ -17,8 +17,8 @@ interface ViewerHeaderProps {
 export function ViewerHeader({ name, dir, status, dirty, onBack, actions }: ViewerHeaderProps) {
   const st = status ? status.toLowerCase() : "";
   return (
-    <div className="fp-viewer-h">
-      <button className="fp-back" title="Back to files" onClick={onBack}>
+    <div className="fp-viewer-h flex-center">
+      <button className="fp-back iflex-center" title="Back to files" onClick={onBack}>
         <Icon name="chevL" size={13} />
       </button>
       <FileIcon name={name} />
@@ -27,7 +27,7 @@ export function ViewerHeader({ name, dir, status, dirty, onBack, actions }: View
         <span className="fp-crumb-file">{name}</span>
         {dirty && <span className="fp-crumb-dot" title="Unsaved changes"></span>}
       </div>
-      {status && <span className={`fp-badge s-${st}`}>{status}</span>}
+      {status && <span className={`fp-badge iflex-center s-${st}`}>{status}</span>}
       {actions}
     </div>
   );

--- a/src/components/RightPanel/GitPanel/ActionBar.tsx
+++ b/src/components/RightPanel/GitPanel/ActionBar.tsx
@@ -42,24 +42,24 @@ export function ActionBar({
   onRun: () => void;
 }) {
   return (
-    <div className="git-act">
+    <div className="git-act flex-center">
       {busy ? (
-        <div className="git-act-status info">
+        <div className="git-act-status flex-center info">
           <Spinner />
           <span className="lbl">{busy}</span>
         </div>
       ) : delegationLabel ? (
-        <div className="git-act-status info working">
+        <div className="git-act-status flex-center info working">
           <Spinner />
           <span className="lbl">{delegationLabel}</span>
         </div>
       ) : notice ? (
-        <div className="git-notice">
+        <div className="git-notice iflex-center">
           <Icon name="check" size={11} />
           <span>{notice}</span>
         </div>
       ) : (
-        <div className={`git-act-status ${statusKind}`}>
+        <div className={`git-act-status flex-center ${statusKind}`}>
           <span className="d" />
           <span className="lbl">
             {panelState === "pushed" && pushedLink ? (

--- a/src/components/RightPanel/GitPanel/ChangesList.tsx
+++ b/src/components/RightPanel/GitPanel/ChangesList.tsx
@@ -36,7 +36,7 @@ export function ChangesList({
 }) {
   return (
     <div className="git-files">
-      <div className="git-files-h">
+      <div className="git-files-h flex-center">
         <span>
           Changes <span className="n">{files.length}</span>
         </span>
@@ -50,7 +50,7 @@ export function ChangesList({
         {files.map((f) => (
           <div
             key={f.path}
-            className={`git-file ${selected === f.path ? "active" : ""}`}
+            className={`git-file flex-center ${selected === f.path ? "active" : ""}`}
             onClick={() => onSelect(f.path)}
           >
             <span className={`gs ${f.kind}`}>{kindLabel(f.kind)}</span>

--- a/src/components/RightPanel/GitPanel/SplitAction.tsx
+++ b/src/components/RightPanel/GitPanel/SplitAction.tsx
@@ -71,7 +71,7 @@ export function SplitAction({
             {items.map((a) => (
               <div
                 key={a.key}
-                className={`dd-item ${a.key === selectedKey ? "active" : ""}`}
+                className={`dd-item flex-center ${a.key === selectedKey ? "active" : ""}`}
                 onClick={() => {
                   onSelect(a.key);
                   setOpen(false);

--- a/src/components/RightPanel/GitPanel/StatusHeader.tsx
+++ b/src/components/RightPanel/GitPanel/StatusHeader.tsx
@@ -125,7 +125,7 @@ export function StatusHeader({
   const adds = git?.additions ?? 0;
   const dels = git?.deletions ?? 0;
   return (
-    <div className={`git-hdr k-${h.kind}`}>
+    <div className={`git-hdr flex-center k-${h.kind}`}>
       {h.dot && <span className="hdr-dot" />}
       {h.pill && <span className="pill">{h.pill}</span>}
       <span className="bn">{h.text}</span>

--- a/src/components/RightPanel/GitPanel/cards/ChecksSection.tsx
+++ b/src/components/RightPanel/GitPanel/cards/ChecksSection.tsx
@@ -44,7 +44,7 @@ export function ChecksSection({ checks, prUrl }: { checks: PrChecks; prUrl: stri
           <button
             type="button"
             key={r.name}
-            className="pr-check"
+            className="pr-check flex-center"
             onClick={() => void open(r.url ?? `${prUrl}/checks`)}
           >
             {tone === "run" ? (

--- a/src/components/RightPanel/GitPanel/cards/ConflictCard.tsx
+++ b/src/components/RightPanel/GitPanel/cards/ConflictCard.tsx
@@ -6,7 +6,7 @@ export function ConflictCard({ files }: { files: FileStatus[] }) {
   const first = conflicted[0]?.path ?? "";
   const rest = conflicted.length - 1;
   return (
-    <div className="git-banner att">
+    <div className="git-banner flex-center att">
       <Icon name="merge" size={14} />
       <span>
         Conflicts in <span className="mono">{first}</span>

--- a/src/components/RightPanel/GitPanel/cards/PRCard.tsx
+++ b/src/components/RightPanel/GitPanel/cards/PRCard.tsx
@@ -57,7 +57,11 @@ export function PRCard({
       {checks && <ChecksSection checks={checks} prUrl={pr.url} />}
       {comments && <CommentsSection comments={comments} onAddToChat={onAddToChat} />}
       <div className="git-card-links">
-        <button type="button" className="git-card-link iflex-center" onClick={() => void open(pr.url)}>
+        <button
+          type="button"
+          className="git-card-link iflex-center"
+          onClick={() => void open(pr.url)}
+        >
           <Icon name="github" size={11} />
           Overview
         </button>
@@ -88,7 +92,11 @@ export function ClosedPRCard({ pr }: { pr: PrState }) {
       <div className="git-card-h">Pull request</div>
       <div className="git-card-title">{pr.title}</div>
       <div className="git-card-meta">#{pr.number} · closed</div>
-      <button type="button" className="git-card-link iflex-center" onClick={() => void open(pr.url)}>
+      <button
+        type="button"
+        className="git-card-link iflex-center"
+        onClick={() => void open(pr.url)}
+      >
         <Icon name="github" size={11} />
         View on GitHub
       </button>

--- a/src/components/RightPanel/GitPanel/cards/PRCard.tsx
+++ b/src/components/RightPanel/GitPanel/cards/PRCard.tsx
@@ -57,13 +57,13 @@ export function PRCard({
       {checks && <ChecksSection checks={checks} prUrl={pr.url} />}
       {comments && <CommentsSection comments={comments} onAddToChat={onAddToChat} />}
       <div className="git-card-links">
-        <button type="button" className="git-card-link" onClick={() => void open(pr.url)}>
+        <button type="button" className="git-card-link iflex-center" onClick={() => void open(pr.url)}>
           <Icon name="github" size={11} />
           Overview
         </button>
         <button
           type="button"
-          className="git-card-link"
+          className="git-card-link iflex-center"
           onClick={() => void open(`${pr.url}/files`)}
         >
           <Icon name="diff" size={11} />
@@ -71,7 +71,7 @@ export function PRCard({
         </button>
         <button
           type="button"
-          className="git-card-link"
+          className="git-card-link iflex-center"
           onClick={() => void open(`${pr.url}/commits`)}
         >
           <Icon name="commit" size={11} />
@@ -88,7 +88,7 @@ export function ClosedPRCard({ pr }: { pr: PrState }) {
       <div className="git-card-h">Pull request</div>
       <div className="git-card-title">{pr.title}</div>
       <div className="git-card-meta">#{pr.number} · closed</div>
-      <button type="button" className="git-card-link" onClick={() => void open(pr.url)}>
+      <button type="button" className="git-card-link iflex-center" onClick={() => void open(pr.url)}>
         <Icon name="github" size={11} />
         View on GitHub
       </button>

--- a/src/components/RightPanel/GitPanel/shared.tsx
+++ b/src/components/RightPanel/GitPanel/shared.tsx
@@ -10,7 +10,7 @@ export function Spinner() {
 /** A quiet inline link out to GitHub — accent text, underline on hover, ↗. */
 export function GitLink({ href, children }: { href: string; children: ReactNode }) {
   return (
-    <button type="button" className="git-link" onClick={() => void open(href)}>
+    <button type="button" className="git-link iflex-center" onClick={() => void open(href)}>
       {children}
       <Icon name="external" size={10} />
     </button>

--- a/src/components/RightPanel/RunSettingsSheet.tsx
+++ b/src/components/RightPanel/RunSettingsSheet.tsx
@@ -129,7 +129,11 @@ export function RunSettingsSheet({ rows, overrides, ecosystem, onClose, onApply 
               Reset all
             </button>
 
-            <button className="btn-t iflex-center primary" onClick={() => onApply(draft)} disabled={!dirty}>
+            <button
+              className="btn-t iflex-center primary"
+              onClick={() => onApply(draft)}
+              disabled={!dirty}
+            >
               <Icon name="refresh" size={11} />
               Apply &amp; restart
             </button>
@@ -206,7 +210,11 @@ function ConfigRow({ row, override, onChange, onRevert }: ConfigRowProps) {
           </button>
         )}
         {hasOverride && !editing && (
-          <button className="rs-revert iflex-center tip" data-tip="Revert to detected" onClick={onRevert}>
+          <button
+            className="rs-revert iflex-center tip"
+            data-tip="Revert to detected"
+            onClick={onRevert}
+          >
             <span className="rs-revert-ic iflex-center">
               <Icon name="refresh" size={11} />
             </span>

--- a/src/components/RightPanel/RunSettingsSheet.tsx
+++ b/src/components/RightPanel/RunSettingsSheet.tsx
@@ -79,7 +79,7 @@ export function RunSettingsSheet({ rows, overrides, ecosystem, onClose, onApply 
               )}
             </div>
           </div>
-          <button className="run-sheet-x" onClick={onClose} aria-label="Close">
+          <button className="run-sheet-x iflex-center" onClick={onClose} aria-label="Close">
             <Icon name="close" size={12} />
           </button>
         </div>
@@ -107,8 +107,8 @@ export function RunSettingsSheet({ rows, overrides, ecosystem, onClose, onApply 
         </div>
 
         {/* Footer */}
-        <div className="run-sheet-f">
-          <div className="rsf-status">
+        <div className="run-sheet-f flex-center">
+          <div className="rsf-status truncate">
             {changed.length === 0 ? (
               <span style={{ color: "var(--fg-3)" }}>No overrides — using detected values</span>
             ) : (
@@ -122,14 +122,14 @@ export function RunSettingsSheet({ rows, overrides, ecosystem, onClose, onApply 
           </div>
           <div className="rsf-actions">
             <button
-              className="btn-t ghost"
+              className="btn-t iflex-center ghost"
               onClick={() => setDraft({})}
               disabled={Object.keys(draft).length === 0}
             >
               Reset all
             </button>
 
-            <button className="btn-t primary" onClick={() => onApply(draft)} disabled={!dirty}>
+            <button className="btn-t iflex-center primary" onClick={() => onApply(draft)} disabled={!dirty}>
               <Icon name="refresh" size={11} />
               Apply &amp; restart
             </button>
@@ -164,7 +164,7 @@ function ConfigRow({ row, override, onChange, onRevert }: ConfigRowProps) {
     <div className={`rs-row${hasOverride ? " overridden" : ""}`}>
       <div className="rs-row-l">
         <div className="rs-label">{row.key}</div>
-        <div className="rs-source">
+        <div className="rs-source iflex-center">
           {hasOverride ? (
             <>
               <span className="dot" />
@@ -177,7 +177,7 @@ function ConfigRow({ row, override, onChange, onRevert }: ConfigRowProps) {
           )}
         </div>
       </div>
-      <div className="rs-row-r">
+      <div className="rs-row-r iflex-center">
         {editing ? (
           <input
             ref={inputRef}
@@ -200,14 +200,14 @@ function ConfigRow({ row, override, onChange, onRevert }: ConfigRowProps) {
             }}
           />
         ) : (
-          <button className="rs-value" onClick={() => setEditing(true)}>
+          <button className="rs-value iflex-center" onClick={() => setEditing(true)}>
             <span className="rsv-text">{display}</span>
             <Icon name="edit" size={10} />
           </button>
         )}
         {hasOverride && !editing && (
-          <button className="rs-revert tip" data-tip="Revert to detected" onClick={onRevert}>
-            <span className="rs-revert-ic">
+          <button className="rs-revert iflex-center tip" data-tip="Revert to detected" onClick={onRevert}>
+            <span className="rs-revert-ic iflex-center">
               <Icon name="refresh" size={11} />
             </span>
           </button>

--- a/src/components/RightPanel/TermPanel.tsx
+++ b/src/components/RightPanel/TermPanel.tsx
@@ -182,7 +182,11 @@ export function TermPanel({ agent }: { agent: AgentRecord }) {
           >
             <Icon name="chevD" />
           </button>
-          <button className="btn-i iflex-center sm tip" data-tip="Close (Esc)" onClick={closeSearch}>
+          <button
+            className="btn-i iflex-center sm tip"
+            data-tip="Close (Esc)"
+            onClick={closeSearch}
+          >
             <Icon name="close" />
           </button>
         </div>

--- a/src/components/RightPanel/TermPanel.tsx
+++ b/src/components/RightPanel/TermPanel.tsx
@@ -153,7 +153,7 @@ export function TermPanel({ agent }: { agent: AgentRecord }) {
   return (
     <div className="term-panel">
       {searchOpen && (
-        <div className="term-search">
+        <div className="term-search flex-center">
           <input
             autoFocus
             className="term-search-input"
@@ -169,20 +169,20 @@ export function TermPanel({ agent }: { agent: AgentRecord }) {
             }}
           />
           <button
-            className="btn-i sm tip"
+            className="btn-i iflex-center sm tip"
             data-tip="Previous (Shift+Enter)"
             onClick={() => runSearch(searchQuery, "prev")}
           >
             <Icon name="chevU" />
           </button>
           <button
-            className="btn-i sm tip"
+            className="btn-i iflex-center sm tip"
             data-tip="Next (Enter)"
             onClick={() => runSearch(searchQuery, "next")}
           >
             <Icon name="chevD" />
           </button>
-          <button className="btn-i sm tip" data-tip="Close (Esc)" onClick={closeSearch}>
+          <button className="btn-i iflex-center sm tip" data-tip="Close (Esc)" onClick={closeSearch}>
             <Icon name="close" />
           </button>
         </div>

--- a/src/components/RightPanel/index.tsx
+++ b/src/components/RightPanel/index.tsx
@@ -62,12 +62,12 @@ export function RightPanel({ agent }: { agent: AgentRecord }) {
 
   return (
     <>
-      <div className="right-h">
+      <div className="right-h flex-center">
         <div className="right-tabs">
           {tabs.map((t) => (
             <button
               key={t.id}
-              className={`r-tab ${tab === t.id ? "active" : ""}`}
+              className={`r-tab iflex-center ${tab === t.id ? "active" : ""}`}
               onClick={() => selectTab(t.id)}
             >
               <Icon name={t.icon} />

--- a/src/components/Settings/SettingsRow.tsx
+++ b/src/components/Settings/SettingsRow.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export function SettingsRow({ label, description, children }: Props) {
   return (
-    <div className="sp-row">
+    <div className="sp-row flex-center">
       <div className="sp-l">
         {label}
         {description && <small>{description}</small>}

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -61,7 +61,7 @@ function Popover({ onClose }: { onClose: () => void }) {
 
   return (
     <div className="settings-pop">
-      <div className="sp-h">
+      <div className="sp-h flex-center">
         <span>Settings</span>
         <span className="grow" />
         <IconButton size="sm" onClick={onClose} aria-label="Close">
@@ -127,7 +127,7 @@ function Popover({ onClose }: { onClose: () => void }) {
         ))}
       </SettingsSection>
 
-      <button className="sp-allbtn" onClick={() => openSettingsScreen("general")}>
+      <button className="sp-allbtn flex-center" onClick={() => openSettingsScreen("general")}>
         <Icon name="settings" size={13} />
         <span>All settings</span>
         <span className="grow" />

--- a/src/components/SettingsScreen/AccountPane.tsx
+++ b/src/components/SettingsScreen/AccountPane.tsx
@@ -49,9 +49,9 @@ export function AccountPane() {
     <div className="set-pane">
       <SetHead eyebrow="Settings · Account" title="Account" />
 
-      <div className="set-profile">
+      <div className="set-profile flex-center">
         <Avatar
-          className="set-avatar"
+          className="set-avatar flex-center"
           avatarUrl={account?.avatarUrl ?? null}
           initials={accountInitials(firstName, lastName, email)}
           alt={fullName}
@@ -111,9 +111,9 @@ export function AccountPane() {
             {!emailValid && <span className="set-field-error">Enter a valid email address.</span>}
           </label>
 
-          <div className="set-form-actions">
+          <div className="set-form-actions flex-center">
             {savedAt && !dirty && <span className="set-saved mono">Saved</span>}
-            <button type="button" className="btn-t primary" disabled={!canSave} onClick={onSave}>
+            <button type="button" className="btn-t iflex-center primary" disabled={!canSave} onClick={onSave}>
               {saving ? "Saving…" : "Save changes"}
             </button>
           </div>

--- a/src/components/SettingsScreen/AccountPane.tsx
+++ b/src/components/SettingsScreen/AccountPane.tsx
@@ -113,7 +113,12 @@ export function AccountPane() {
 
           <div className="set-form-actions flex-center">
             {savedAt && !dirty && <span className="set-saved mono">Saved</span>}
-            <button type="button" className="btn-t iflex-center primary" disabled={!canSave} onClick={onSave}>
+            <button
+              type="button"
+              className="btn-t iflex-center primary"
+              disabled={!canSave}
+              onClick={onSave}
+            >
               {saving ? "Saving…" : "Save changes"}
             </button>
           </div>

--- a/src/components/SettingsScreen/BinaryPathRow.tsx
+++ b/src/components/SettingsScreen/BinaryPathRow.tsx
@@ -95,7 +95,7 @@ export function BinaryPathRow({
       <span className="set-prov-dk">Binary</span>
       {editing ? (
         <div className="set-prov-bin-edit">
-          <div className="set-prov-bin-input-row">
+          <div className="set-prov-bin-input-row flex-center">
             <input
               ref={inputRef}
               className="set-prov-bin-input mono"
@@ -115,7 +115,7 @@ export function BinaryPathRow({
               }}
             />
             <button
-              className="btn-i sm-i tip"
+              className="btn-i iflex-center sm-i tip"
               data-tip-down
               data-tip="Save"
               aria-label="Save path"
@@ -125,7 +125,7 @@ export function BinaryPathRow({
               <Icon name="check" size={14} />
             </button>
             <button
-              className="btn-i sm-i tip"
+              className="btn-i iflex-center sm-i tip"
               data-tip-down
               data-tip="Cancel"
               aria-label="Cancel"
@@ -145,18 +145,18 @@ export function BinaryPathRow({
         </div>
       ) : (
         <div className="set-prov-bin-edit">
-          <div className="set-prov-bin-view">
+          <div className="set-prov-bin-view flex-center">
             <span className={`set-prov-dv mono ${broken ? "broken" : ""}`}>{effectivePath}</span>
             {override && <span className="set-badge custom">Custom</span>}
             {broken && <span className="set-prov-bin-warn">not found</span>}
             <span className="grow" />
             {override && (
-              <button className="btn-t ghost sm-t" disabled={busy} onClick={() => void reset()}>
+              <button className="btn-t iflex-center ghost sm-t" disabled={busy} onClick={() => void reset()}>
                 Reset to auto
               </button>
             )}
             <button
-              className="btn-i sm-i tip"
+              className="btn-i iflex-center sm-i tip"
               data-tip-down
               data-tip="Edit path"
               aria-label="Edit binary path"

--- a/src/components/SettingsScreen/BinaryPathRow.tsx
+++ b/src/components/SettingsScreen/BinaryPathRow.tsx
@@ -151,7 +151,11 @@ export function BinaryPathRow({
             {broken && <span className="set-prov-bin-warn">not found</span>}
             <span className="grow" />
             {override && (
-              <button className="btn-t iflex-center ghost sm-t" disabled={busy} onClick={() => void reset()}>
+              <button
+                className="btn-t iflex-center ghost sm-t"
+                disabled={busy}
+                onClick={() => void reset()}
+              >
                 Reset to auto
               </button>
             )}

--- a/src/components/SettingsScreen/CustomAgents/AgentEditor.tsx
+++ b/src/components/SettingsScreen/CustomAgents/AgentEditor.tsx
@@ -85,13 +85,13 @@ export function AgentEditor({
   return (
     <div className="set-pane">
       <div className="ca-editor">
-        <button className="ca-ed-back" onClick={onCancel}>
+        <button className="ca-ed-back iflex-center" onClick={onCancel}>
           <Icon name="chevL" size={13} /> All custom agents
         </button>
 
         {/* identity */}
-        <div className="ca-ed-head">
-          <span className="ca-mono ca-ed-mono" style={{ ["--h" as string]: form.color }}>
+        <div className="ca-ed-head flex-center">
+          <span className="ca-mono iflex-center ca-ed-mono" style={{ ["--h" as string]: form.color }}>
             {shortFor(form.name)}
           </span>
           <input
@@ -101,7 +101,7 @@ export function AgentEditor({
             autoFocus
             onChange={(e) => set({ name: e.target.value })}
           />
-          <div className="ca-hues">
+          <div className="ca-hues flex-center">
             {CA_HUES.map((h) => (
               <button
                 key={h}
@@ -160,7 +160,7 @@ export function AgentEditor({
           </div>
         </div>
 
-        <div className="ca-inject">
+        <div className="ca-inject flex-center">
           <Icon name="zap" size={13} />
           <span>
             Instructions injected via <b>{INJECTION_HINT[form.base] ?? "the agent's CLI"}</b>
@@ -190,12 +190,12 @@ export function AgentEditor({
           />
         </div>
 
-        <div className="ca-ed-foot">
+        <div className="ca-ed-foot flex-center">
           <span className="ca-grow" />
-          <button className="btn-t ghost" onClick={onCancel}>
+          <button className="btn-t iflex-center ghost" onClick={onCancel}>
             Cancel
           </button>
-          <button className="btn-t primary" disabled={!canSave} onClick={submit}>
+          <button className="btn-t iflex-center primary" disabled={!canSave} onClick={submit}>
             <Icon name="check" size={13} /> {isNew ? "Create agent" : "Save changes"}
           </button>
         </div>

--- a/src/components/SettingsScreen/CustomAgents/AgentEditor.tsx
+++ b/src/components/SettingsScreen/CustomAgents/AgentEditor.tsx
@@ -91,7 +91,10 @@ export function AgentEditor({
 
         {/* identity */}
         <div className="ca-ed-head flex-center">
-          <span className="ca-mono iflex-center ca-ed-mono" style={{ ["--h" as string]: form.color }}>
+          <span
+            className="ca-mono iflex-center ca-ed-mono"
+            style={{ ["--h" as string]: form.color }}
+          >
             {shortFor(form.name)}
           </span>
           <input

--- a/src/components/SettingsScreen/CustomAgents/AgentList.tsx
+++ b/src/components/SettingsScreen/CustomAgents/AgentList.tsx
@@ -43,15 +43,15 @@ export function AgentList({
         title="Custom agents"
         desc="Give a base coding agent a name, a model, and a standing brief. Custom agents show up in the composer next to the built-ins."
         actions={
-          <button className="btn-t primary" onClick={onNew}>
+          <button className="btn-t iflex-center primary" onClick={onNew}>
             <Icon name="plus" size={13} /> New agent
           </button>
         }
       />
 
       {agents.length === 0 ? (
-        <button className="ca-empty" onClick={onNew}>
-          <span className="ca-empty-ic">
+        <button className="ca-empty flex-center" onClick={onNew}>
+          <span className="ca-empty-ic iflex-center">
             <Icon name="plus" />
           </span>
           <span>Create your first custom agent</span>
@@ -63,7 +63,7 @@ export function AgentList({
             return (
               <div
                 key={a.id}
-                className="ca-card"
+                className="ca-card flex-center"
                 role="button"
                 tabIndex={0}
                 onClick={() => onEdit(a)}
@@ -76,9 +76,9 @@ export function AgentList({
               >
                 <Mono name={a.name} hue={a.color} />
                 <div className="ca-id">
-                  <div className="ca-name">
+                  <div className="ca-name flex-center">
                     {a.name}
-                    <span className="ca-base">
+                    <span className="ca-base iflex-center">
                       <span
                         className="ca-base-dot"
                         style={{ background: `oklch(0.7 0.1 ${prov?.hue ?? 30})` }}
@@ -86,13 +86,13 @@ export function AgentList({
                       {prov?.label ?? a.base} · {modelLabel(a)}
                     </span>
                   </div>
-                  <div className="ca-desc">
+                  <div className="ca-desc truncate">
                     {a.description || a.instructions || "No instructions yet."}
                   </div>
                 </div>
-                <div className="ca-acts" onClick={(e) => e.stopPropagation()}>
+                <div className="ca-acts flex-center" onClick={(e) => e.stopPropagation()}>
                   <button
-                    className="btn-i sm tip"
+                    className="btn-i iflex-center sm tip"
                     data-tip-down
                     data-tip="Duplicate"
                     aria-label="Duplicate"
@@ -101,7 +101,7 @@ export function AgentList({
                     <Icon name="copy" />
                   </button>
                   <button
-                    className="btn-i sm tip"
+                    className="btn-i iflex-center sm tip"
                     data-tip-down
                     data-tip="Edit"
                     aria-label="Edit"
@@ -110,7 +110,7 @@ export function AgentList({
                     <Icon name="edit" />
                   </button>
                   <button
-                    className={`btn-i sm tip ${armedDeleteId === a.id ? "danger" : ""}`}
+                    className={`btn-i iflex-center sm tip ${armedDeleteId === a.id ? "danger" : ""}`}
                     data-tip-down
                     data-tip={armedDeleteId === a.id ? "Click again to delete" : "Delete"}
                     aria-label={armedDeleteId === a.id ? "Confirm delete" : "Delete"}

--- a/src/components/SettingsScreen/CustomAgents/Mono.tsx
+++ b/src/components/SettingsScreen/CustomAgents/Mono.tsx
@@ -5,7 +5,7 @@ import { shortFor } from "./shared";
 export function Mono({ name, hue, size = 38 }: { name: string; hue: number; size?: number }) {
   return (
     <span
-      className="ca-mono"
+      className="ca-mono iflex-center"
       style={{
         width: size,
         height: size,

--- a/src/components/SettingsScreen/DevToolsStatus.tsx
+++ b/src/components/SettingsScreen/DevToolsStatus.tsx
@@ -69,7 +69,12 @@ export function DevToolsStatus() {
       />
       <div className="rdy-foot flex-center">
         <span className="rdy-count" />
-        <button type="button" className="btn-t iflex-center outline" onClick={recheck} disabled={checking}>
+        <button
+          type="button"
+          className="btn-t iflex-center outline"
+          onClick={recheck}
+          disabled={checking}
+        >
           <Icon name="refresh" size={12} />
           {checking ? "Checking…" : "Re-check"}
         </button>
@@ -107,7 +112,11 @@ function ToolRow({
           <div className="rdy-fix flex-center">
             {fix && <CopyCmd cmd={fix} />}
             {docs && (
-              <button type="button" className="rdy-docs iflex-center" onClick={() => void openExternal(docs)}>
+              <button
+                type="button"
+                className="rdy-docs iflex-center"
+                onClick={() => void openExternal(docs)}
+              >
                 Setup guide
                 <Icon name="external" size={10} />
               </button>

--- a/src/components/SettingsScreen/DevToolsStatus.tsx
+++ b/src/components/SettingsScreen/DevToolsStatus.tsx
@@ -67,9 +67,9 @@ export function DevToolsStatus() {
         fix={ghFix}
         docs={!gh?.installed ? "https://cli.github.com" : undefined}
       />
-      <div className="rdy-foot">
+      <div className="rdy-foot flex-center">
         <span className="rdy-count" />
-        <button type="button" className="btn-t outline" onClick={recheck} disabled={checking}>
+        <button type="button" className="btn-t iflex-center outline" onClick={recheck} disabled={checking}>
           <Icon name="refresh" size={12} />
           {checking ? "Checking…" : "Re-check"}
         </button>
@@ -98,16 +98,16 @@ function ToolRow({
     <div className="rdy-row">
       <span className="rdy-icon">{icon}</span>
       <div className="rdy-main">
-        <div className="rdy-line">
+        <div className="rdy-line flex-center">
           <span className="rdy-name">{name}</span>
           <span className={`rdy-dot ${state}`} />
           <span className="rdy-status">{statusText}</span>
         </div>
         {needsFix && (fix || docs) && (
-          <div className="rdy-fix">
+          <div className="rdy-fix flex-center">
             {fix && <CopyCmd cmd={fix} />}
             {docs && (
-              <button type="button" className="rdy-docs" onClick={() => void openExternal(docs)}>
+              <button type="button" className="rdy-docs iflex-center" onClick={() => void openExternal(docs)}>
                 Setup guide
                 <Icon name="external" size={10} />
               </button>
@@ -124,7 +124,7 @@ function CopyCmd({ cmd }: { cmd: string }) {
   return (
     <button
       type="button"
-      className="rdy-cmd"
+      className="rdy-cmd iflex-center"
       title="Copy command"
       onClick={() => {
         void navigator.clipboard.writeText(cmd);

--- a/src/components/SettingsScreen/DeveloperPane.tsx
+++ b/src/components/SettingsScreen/DeveloperPane.tsx
@@ -24,7 +24,7 @@ export function DeveloperPane() {
         >
           <button
             type="button"
-            className="btn-t outline"
+            className="btn-t iflex-center outline"
             onClick={() => {
               closeSettingsScreen();
               openOnboarding();
@@ -43,7 +43,7 @@ export function DeveloperPane() {
         >
           <button
             type="button"
-            className="btn-t outline"
+            className="btn-t iflex-center outline"
             onClick={() => {
               closeSettingsScreen();
               setUpdateReady("9.9.9-test");

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -80,7 +80,7 @@ export function GeneralPane() {
               <button
                 key={a.id}
                 type="button"
-                className={`set-swatch ${a.id === accent ? "active" : ""}`}
+                className={`set-swatch iflex-center ${a.id === accent ? "active" : ""}`}
                 style={{ ["--sw" as string]: a.color }}
                 title={a.label}
                 aria-label={a.label}
@@ -126,7 +126,7 @@ export function GeneralPane() {
           title="Logs"
           sub="Quorum writes a local log file. Reveal it to attach to a bug report."
         >
-          <button type="button" className="btn-t outline" onClick={() => void revealLogs()}>
+          <button type="button" className="btn-t iflex-center outline" onClick={() => void revealLogs()}>
             <Icon name="folder" size={12} />
             Reveal logs
           </button>

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -126,7 +126,11 @@ export function GeneralPane() {
           title="Logs"
           sub="Quorum writes a local log file. Reveal it to attach to a bug report."
         >
-          <button type="button" className="btn-t iflex-center outline" onClick={() => void revealLogs()}>
+          <button
+            type="button"
+            className="btn-t iflex-center outline"
+            onClick={() => void revealLogs()}
+          >
             <Icon name="folder" size={12} />
             Reveal logs
           </button>

--- a/src/components/SettingsScreen/ProvidersPane.tsx
+++ b/src/components/SettingsScreen/ProvidersPane.tsx
@@ -41,7 +41,7 @@ export function ProvidersPane() {
           <>
             {scanning && <span className="set-checked mono">Scanning…</span>}
             <button
-              className="btn-i tip"
+              className="btn-i iflex-center tip"
               data-tip-down
               data-tip="Coming soon"
               aria-label="Add provider"
@@ -50,7 +50,7 @@ export function ProvidersPane() {
               <Icon name="plus" />
             </button>
             <button
-              className="btn-i tip"
+              className="btn-i iflex-center tip"
               data-tip-down
               data-tip="Re-scan system"
               aria-label="Re-scan system"
@@ -111,21 +111,21 @@ function ProviderRow({
 
   return (
     <div className={`set-prov ${enabled ? "" : "off"} ${open ? "open" : ""}`}>
-      <div className="set-prov-main">
+      <div className="set-prov-main flex-center">
         <span
           className={`set-prov-status ${livePath ? "" : "none"}`}
           title={livePath ? "Detected on this system" : "Not found"}
         />
         <ProviderIcon slug={provider.id} short={provider.short} hue={provider.hue} />
         <div className="set-prov-id">
-          <div className="set-prov-name">
+          <div className="set-prov-name flex-center">
             {provider.label}
             <span className="set-prov-ver mono">{liveVersion ?? provider.version}</span>
           </div>
-          <div className="set-prov-sub mono">{effectivePath}</div>
+          <div className="set-prov-sub flex-center truncate mono">{effectivePath}</div>
         </div>
         <button
-          className={`set-prov-chev ${open ? "open" : ""}`}
+          className={`set-prov-chev iflex-center ${open ? "open" : ""}`}
           aria-label={open ? "Collapse details" : "Expand details"}
           onClick={() => setOpen((v) => !v)}
         >
@@ -144,8 +144,8 @@ function ProviderRow({
             onSave={onSavePath}
           />
           <ProvDetailRow k="Models" v={d.models} />
-          <div className="set-prov-detail-actions">
-            <button className="btn-t ghost sm-t">View logs</button>
+          <div className="set-prov-detail-actions flex-center">
+            <button className="btn-t iflex-center ghost sm-t">View logs</button>
           </div>
         </div>
       )}

--- a/src/components/SettingsScreen/index.tsx
+++ b/src/components/SettingsScreen/index.tsx
@@ -58,7 +58,7 @@ export function SettingsScreen() {
   return (
     <div className="set-screen">
       <nav className="set-nav">
-        <button className="set-back" onClick={close}>
+        <button className="set-back flex-center" onClick={close}>
           <Icon name="chevL" size={13} />
           <span>Back to app</span>
         </button>
@@ -66,7 +66,7 @@ export function SettingsScreen() {
           {NAV.map((n) => (
             <button
               key={n.id}
-              className={`set-nav-item ${section === n.id ? "active" : ""}`}
+              className={`set-nav-item flex-center ${section === n.id ? "active" : ""}`}
               onClick={() => setSection(n.id)}
             >
               <Icon name={n.icon} size={14} />

--- a/src/components/SettingsScreen/primitives.tsx
+++ b/src/components/SettingsScreen/primitives.tsx
@@ -31,7 +31,7 @@ export function SetHead({
           <div className="set-eyebrow mono">{eyebrow}</div>
           <h1 className="set-h1">{title}</h1>
         </div>
-        {actions && <div className="set-head-actions">{actions}</div>}
+        {actions && <div className="set-head-actions flex-center">{actions}</div>}
       </div>
       {desc && <p className="set-lead">{desc}</p>}
     </header>
@@ -67,12 +67,12 @@ export function SetRow({
   children?: ReactNode;
 }) {
   return (
-    <div className={`set-row ${align === "start" ? "align-start" : ""}`}>
+    <div className={`set-row flex-center ${align === "start" ? "align-start" : ""}`}>
       <div className="set-row-l">
         <div className="set-row-t">{title}</div>
         {sub && <div className="set-row-s">{sub}</div>}
       </div>
-      {children && <div className="set-row-c">{children}</div>}
+      {children && <div className="set-row-c flex-center">{children}</div>}
     </div>
   );
 }

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -160,7 +160,12 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
           </span>
           <span className="ag-actions">
             {stoppable && (
-              <button className="ag-act iflex-center tip" data-tip="Stop" onClick={onStop} aria-label="Stop">
+              <button
+                className="ag-act iflex-center tip"
+                data-tip="Stop"
+                onClick={onStop}
+                aria-label="Stop"
+              >
                 <Icon name="stop" size={11} />
               </button>
             )}
@@ -259,7 +264,10 @@ function PrBadge({ pr }: { pr: PrState }) {
   }
   const cls = pr.state === "closed" ? "pr-closed" : "pr-open";
   return (
-    <span className={`ag-badge iflex-center ${cls} tip`} data-tip={`PR #${pr.number} · ${pr.state}`}>
+    <span
+      className={`ag-badge iflex-center ${cls} tip`}
+      data-tip={`PR #${pr.number} · ${pr.state}`}
+    >
       <Icon name="pr" size={10} />
       PR
     </span>

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -129,7 +129,7 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
       onKeyDown={(e) => activateOnKey(e, onClick)}
     >
       <span className={`ag-rail ${railClass}`} />
-      <div className="agent-row">
+      <div className="agent-row flex-center">
         <span className={`ag-name ${working ? "shimmer" : ""}`}>{agent.name}</span>
         <span
           className="ag-prov-chip tip"
@@ -146,7 +146,7 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
             <ProviderIcon slug={agent.provider} {...providerChip(agent.provider)} size={14} />
           )}
         </span>
-        <span className="ag-slot">
+        <span className="ag-slot iflex-center">
           <span className="ag-meta">
             {working && <span className="ag-loader" aria-label="Working" />}
             {agent.status === "idle" && !active && unseen && (
@@ -156,17 +156,17 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
                 aria-label="New results to review"
               />
             )}
-            {agent.status === "error" && <span className="ag-badge err">error</span>}
+            {agent.status === "error" && <span className="ag-badge iflex-center err">error</span>}
           </span>
           <span className="ag-actions">
             {stoppable && (
-              <button className="ag-act tip" data-tip="Stop" onClick={onStop} aria-label="Stop">
+              <button className="ag-act iflex-center tip" data-tip="Stop" onClick={onStop} aria-label="Stop">
                 <Icon name="stop" size={11} />
               </button>
             )}
             {archivable && (
               <button
-                className="ag-act tip"
+                className="ag-act iflex-center tip"
                 data-tip="Archive"
                 onClick={onArchive}
                 aria-label="Archive"
@@ -177,7 +177,7 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
           </span>
         </span>
       </div>
-      <div className="agent-sub">
+      <div className="agent-sub flex-center">
         <span className="a-task">{taskOrBranch}</span>
         {prState ? <PrBadge pr={prState} /> : hasChanges ? <DiffStat stats={shortstats} /> : null}
         <span
@@ -213,7 +213,7 @@ function DraftRow({ draft, active, onClick }: DraftRowProps) {
       onKeyDown={(e) => activateOnKey(e, onClick)}
     >
       <span className="ag-rail idle" />
-      <div className="agent-row">
+      <div className="agent-row flex-center">
         <span className="ag-name ag-name-draft">{draft.name}</span>
         <span
           className="ag-prov-chip tip"
@@ -222,13 +222,13 @@ function DraftRow({ draft, active, onClick }: DraftRowProps) {
         >
           <ProviderIcon slug={draft.provider} {...providerChip(draft.provider)} size={14} />
         </span>
-        <span className="ag-slot">
+        <span className="ag-slot iflex-center">
           <span className="ag-meta">
-            <span className="ag-badge new">new</span>
+            <span className="ag-badge iflex-center new">new</span>
           </span>
           <span className="ag-actions">
             <button
-              className="ag-act tip"
+              className="ag-act iflex-center tip"
               data-tip="Discard"
               onClick={onDiscard}
               aria-label="Discard"
@@ -238,7 +238,7 @@ function DraftRow({ draft, active, onClick }: DraftRowProps) {
           </span>
         </span>
       </div>
-      <div className="agent-sub">
+      <div className="agent-sub flex-center">
         <span className="a-task a-task-draft">Define task…</span>
       </div>
     </div>
@@ -252,14 +252,14 @@ function DraftRow({ draft, active, onClick }: DraftRowProps) {
 function PrBadge({ pr }: { pr: PrState }) {
   if (pr.state === "merged") {
     return (
-      <span className="ag-badge pr-merged tip" data-tip={`PR #${pr.number} · merged`}>
+      <span className="ag-badge iflex-center pr-merged tip" data-tip={`PR #${pr.number} · merged`}>
         <Icon name="merge" size={10} />#{pr.number}
       </span>
     );
   }
   const cls = pr.state === "closed" ? "pr-closed" : "pr-open";
   return (
-    <span className={`ag-badge ${cls} tip`} data-tip={`PR #${pr.number} · ${pr.state}`}>
+    <span className={`ag-badge iflex-center ${cls} tip`} data-tip={`PR #${pr.number} · ${pr.state}`}>
       <Icon name="pr" size={10} />
       PR
     </span>

--- a/src/components/Sidebar/ProjectGroup.tsx
+++ b/src/components/Sidebar/ProjectGroup.tsx
@@ -53,7 +53,11 @@ export function ProjectGroup({
 
   return (
     <div className="proj">
-      <div className={`proj-h flex-center ${open ? "open" : ""}`} onClick={onToggle} title={repoPath}>
+      <div
+        className={`proj-h flex-center ${open ? "open" : ""}`}
+        onClick={onToggle}
+        title={repoPath}
+      >
         <Icon name="chevR" size={10} className="chev" />
         <span className="pname">{label}</span>
         <span className="pcount">{count}</span>

--- a/src/components/Sidebar/ProjectGroup.tsx
+++ b/src/components/Sidebar/ProjectGroup.tsx
@@ -53,7 +53,7 @@ export function ProjectGroup({
 
   return (
     <div className="proj">
-      <div className={`proj-h ${open ? "open" : ""}`} onClick={onToggle} title={repoPath}>
+      <div className={`proj-h flex-center ${open ? "open" : ""}`} onClick={onToggle} title={repoPath}>
         <Icon name="chevR" size={10} className="chev" />
         <span className="pname">{label}</span>
         <span className="pcount">{count}</span>
@@ -74,7 +74,7 @@ export function ProjectGroup({
       </div>
 
       <div className={`agents ${open ? "" : "closed"}`}>
-        <button className="agent-new" onClick={onAddAgent}>
+        <button className="agent-new flex-center" onClick={onAddAgent}>
           <Icon name="plus" size={11} />
           <span>New agent</span>
         </button>

--- a/src/components/Sidebar/SidebarFooter.tsx
+++ b/src/components/Sidebar/SidebarFooter.tsx
@@ -19,14 +19,14 @@ export function SidebarFooter() {
   const sub = account?.email || "local workspace";
 
   return (
-    <div className="side-foot">
+    <div className="side-foot flex-center">
       <button
         className="side-user"
         onClick={() => openSettingsScreen("account")}
         aria-label="Account settings"
       >
         <Avatar
-          className="user-avatar"
+          className="user-avatar flex-center"
           avatarUrl={account?.avatarUrl ?? null}
           initials={initial}
           alt={name}

--- a/src/components/Sidebar/SidebarHeader.tsx
+++ b/src/components/Sidebar/SidebarHeader.tsx
@@ -11,8 +11,8 @@ interface Props {
 export function SidebarHeader({ query, onChange }: Props) {
   const [focused, setFocused] = useState(false);
   return (
-    <div className="side-head">
-      <div className="search">
+    <div className="side-head flex-center">
+      <div className="search flex-center">
         <Icon name="search" size={12} />
         <input
           id="sidebar-search"

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -110,7 +110,11 @@ export function Sidebar() {
       <SidebarHeader query={query} onChange={setQuery} />
       <div className="side-scroll">
         <div className="side-section">
-          <button className="add-proj-cta flex-center" onClick={() => setNpOpen(true)} aria-label="Add project">
+          <button
+            className="add-proj-cta flex-center"
+            onClick={() => setNpOpen(true)}
+            aria-label="Add project"
+          >
             <Icon name="plus" size={13} />
             <span>Add project</span>
           </button>

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -110,7 +110,7 @@ export function Sidebar() {
       <SidebarHeader query={query} onChange={setQuery} />
       <div className="side-scroll">
         <div className="side-section">
-          <button className="add-proj-cta" onClick={() => setNpOpen(true)} aria-label="Add project">
+          <button className="add-proj-cta flex-center" onClick={() => setNpOpen(true)} aria-label="Add project">
             <Icon name="plus" size={13} />
             <span>Add project</span>
           </button>

--- a/src/components/TitleBar/Breadcrumb.tsx
+++ b/src/components/TitleBar/Breadcrumb.tsx
@@ -12,7 +12,7 @@ export interface CrumbEntry {
 
 export function Breadcrumb({ entries }: { entries: CrumbEntry[] }) {
   return (
-    <div className="tb-crumb">
+    <div className="tb-crumb flex-center">
       {entries.map((c, i) => (
         <Fragment key={i}>
           {i > 0 && <span className="sep">/</span>}

--- a/src/components/TitleBar/index.tsx
+++ b/src/components/TitleBar/index.tsx
@@ -18,17 +18,17 @@ export function TitleBar() {
   const entries = useCrumb();
 
   return (
-    <div className="tb" data-tauri-drag-region>
+    <div className="tb flex-center" data-tauri-drag-region>
       <div className="tb-lights-gutter" data-tauri-drag-region />
-      <div className="tb-logo" data-tauri-drag-region aria-label="Quorum">
+      <div className="tb-logo iflex-center" data-tauri-drag-region aria-label="Quorum">
         <span className="tb-wordmark" aria-hidden="true">
           <QMark className="tb-qmark" />
           uorum
         </span>
-        <span className="tb-badge">beta</span>
+        <span className="tb-badge iflex-center">beta</span>
       </div>
       <Breadcrumb entries={entries} />
-      <div className="tb-right">
+      <div className="tb-right flex-center">
         <IconButton tip="History" active={historyOpen} onClick={() => toggleHistory()}>
           <Icon name="history" />
         </IconButton>

--- a/src/components/UpdateToast.tsx
+++ b/src/components/UpdateToast.tsx
@@ -37,10 +37,10 @@ export function UpdateToast() {
           <span>Version {version} has been downloaded.</span>
         </div>
         <div className="update-toast-actions">
-          <button className="btn-t ghost" onClick={dismiss} disabled={restarting}>
+          <button className="btn-t iflex-center ghost" onClick={dismiss} disabled={restarting}>
             Skip for now
           </button>
-          <button className="btn-t primary" onClick={onRestart} disabled={restarting}>
+          <button className="btn-t iflex-center primary" onClick={onRestart} disabled={restarting}>
             {restarting ? "Restarting…" : "Restart now"}
           </button>
         </div>

--- a/src/components/Workspace/ChatNav/index.tsx
+++ b/src/components/Workspace/ChatNav/index.tsx
@@ -141,7 +141,7 @@ export function ChatNav({
         </button>
         <button
           type="button"
-          className="chat-nav-count"
+          className="chat-nav-count flex-center"
           aria-label="Show all messages"
           aria-haspopup="listbox"
           aria-expanded={open}
@@ -178,7 +178,7 @@ export function ChatNav({
               onClick={() => jumpTo(t.id)}
             >
               <span className="chat-nav-row-n">{i + 1}</span>
-              <span className="chat-nav-row-t">{preview(t.text)}</span>
+              <span className="chat-nav-row-t truncate">{preview(t.text)}</span>
             </button>
           ))}
         </div>

--- a/src/components/Workspace/ChatSearch/index.tsx
+++ b/src/components/Workspace/ChatSearch/index.tsx
@@ -31,7 +31,7 @@ export function ChatSearch({
   const noMatches = query.length > 0 && total === 0;
 
   return (
-    <div className="chat-search" role="search">
+    <div className="chat-search flex-center" role="search">
       <Icon name="search" size={12} className="chat-search-icon" />
       <input
         id="chat-search-input"
@@ -55,19 +55,19 @@ export function ChatSearch({
       <span className={`chat-search-count${noMatches ? " no-match" : ""}`}>
         {query ? `${current}/${total}` : ""}
       </span>
-      <div className="chat-search-actions">
+      <div className="chat-search-actions flex-center">
         <button
-          className="btn-i sm tip"
+          className="btn-i iflex-center sm tip"
           data-tip="Previous (⇧⏎)"
           disabled={total === 0}
           onClick={prev}
         >
           <Icon name="chevU" />
         </button>
-        <button className="btn-i sm tip" data-tip="Next (⏎)" disabled={total === 0} onClick={next}>
+        <button className="btn-i iflex-center sm tip" data-tip="Next (⏎)" disabled={total === 0} onClick={next}>
           <Icon name="chevD" />
         </button>
-        <button className="btn-i sm tip" data-tip="Close (Esc)" onClick={onClose}>
+        <button className="btn-i iflex-center sm tip" data-tip="Close (Esc)" onClick={onClose}>
           <Icon name="close" />
         </button>
       </div>

--- a/src/components/Workspace/ChatSearch/index.tsx
+++ b/src/components/Workspace/ChatSearch/index.tsx
@@ -64,7 +64,12 @@ export function ChatSearch({
         >
           <Icon name="chevU" />
         </button>
-        <button className="btn-i iflex-center sm tip" data-tip="Next (⏎)" disabled={total === 0} onClick={next}>
+        <button
+          className="btn-i iflex-center sm tip"
+          data-tip="Next (⏎)"
+          disabled={total === 0}
+          onClick={next}
+        >
           <Icon name="chevD" />
         </button>
         <button className="btn-i iflex-center sm tip" data-tip="Close (Esc)" onClick={onClose}>

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -196,7 +196,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
         <div className="chat-scroll" ref={scrollRef} onScroll={handleScroll}>
           <div className="chat-inner fade-in" key={agent.id}>
             {transcriptLoading && items.length === 0 ? (
-              <div className="writing">
+              <div className="writing flex-center">
                 <span className="dots">
                   <i />
                   <i />
@@ -223,7 +223,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
               ))
             )}
             {busy && !awaitingInput && (
-              <div className="writing">
+              <div className="writing flex-center">
                 <span className="dots">
                   <i />
                   <i />

--- a/src/components/Workspace/EmptyWorkspace.tsx
+++ b/src/components/Workspace/EmptyWorkspace.tsx
@@ -22,7 +22,7 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
 
   return (
     <div className="pane center">
-      <div className="center-h">
+      <div className="center-h flex-center">
         <IconButton
           tip={leftCollapsed ? "Show sidebar (⌘B)" : "Hide sidebar (⌘B)"}
           onClick={toggleLeft}
@@ -50,9 +50,9 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
         </IconButton>
       </div>
 
-      <div className="empty-wrap fade-in">
-        <div className="empty-id">
-          <div className="empty-mark">
+      <div className="empty-wrap flex-center fade-in">
+        <div className="empty-id flex-center">
+          <div className="empty-mark flex-center">
             <span className="d" />
             <span>NEW WORKSPACE</span>
           </div>
@@ -91,7 +91,7 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
               spawnFromDraft(draft.id, text, provider, model, attachments, thinking, customAgentId)
             }
           />
-          <div className="empty-meta">
+          <div className="empty-meta flex-center">
             <ProjectPicker
               value={draft.repoPath}
               repos={repos}

--- a/src/components/Workspace/WorkspaceHeader.tsx
+++ b/src/components/Workspace/WorkspaceHeader.tsx
@@ -54,7 +54,7 @@ export function WorkspaceHeader({ agent }: Props) {
   }, [nativeView, agent.view, agent.id, switchInFlight, switchView]);
 
   return (
-    <div className="center-h">
+    <div className="center-h flex-center">
       <IconButton
         tip={leftCollapsed ? "Show sidebar (⌘B)" : "Hide sidebar (⌘B)"}
         onClick={toggleLeft}

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -27,7 +27,7 @@ export function Workspace() {
   if (!workspace || !agent) {
     return (
       <div className="pane center">
-        <div className="center-h">
+        <div className="center-h flex-center">
           <IconButton
             tip={leftCollapsed ? "Show sidebar (⌘B)" : "Hide sidebar (⌘B)"}
             onClick={toggleLeft}
@@ -72,14 +72,14 @@ function CrashBanner({ agent }: { agent: AgentRecord }) {
   // before `finally` runs.)
   const [resuming, setResuming] = useState(false);
   return (
-    <div className="crash-banner" role="alert">
+    <div className="crash-banner flex-center" role="alert">
       <div className="crash-text">
         <span className="crash-title">Agent stopped unexpectedly</span>
         {agent.last_error && <span className="crash-detail">{agent.last_error}</span>}
       </div>
       <button
         type="button"
-        className="btn-t outline"
+        className="btn-t iflex-center outline"
         disabled={resuming}
         onClick={() => {
           setResuming(true);

--- a/src/components/Workspace/messages/ToolResultItem.tsx
+++ b/src/components/Workspace/messages/ToolResultItem.tsx
@@ -11,7 +11,7 @@ export function ToolResultItem({ item }: { item: Extract<ChatItem, { kind: "tool
     <div>
       <button
         type="button"
-        className="m-tool"
+        className="m-tool flex-center"
         onClick={() => setOpen((o) => !o)}
         style={{
           width: "100%",

--- a/src/components/Workspace/messages/ToolRow.tsx
+++ b/src/components/Workspace/messages/ToolRow.tsx
@@ -22,7 +22,7 @@ export function ToolRow({
     <div>
       <button
         type="button"
-        className="m-tool"
+        className="m-tool flex-center"
         onClick={() => setOpen((o) => !o)}
         style={{ width: "100%", textAlign: "left", color: dangerColor }}
       >

--- a/src/components/Workspace/messages/UserInput/QuestionCard.tsx
+++ b/src/components/Workspace/messages/UserInput/QuestionCard.tsx
@@ -76,15 +76,15 @@ export function QuestionCard({
   if (committed && answer) {
     return (
       <div className="m-q is-answered">
-        <div className="q-head">
-          <span className="q-label resolved">
+        <div className="q-head flex-center">
+          <span className="q-label iflex-center resolved">
             <Icon name="check" size={11} /> Answered
           </span>
-          {question.header && <span className="q-ctx">{question.header}</span>}
+          {question.header && <span className="q-ctx truncate">{question.header}</span>}
         </div>
         <div className="q-prompt resolved">{question.prompt}</div>
-        <div className="q-answer">
-          <span className="qa-mark">
+        <div className="q-answer flex-center">
+          <span className="qa-mark iflex-center">
             <Icon name="check" size={10} />
           </span>
           <span className={`qa-text ${answer.isOther ? "other" : ""}`}>
@@ -98,8 +98,8 @@ export function QuestionCard({
   // ── live ──────────────────────────────────────────────────────────
   return (
     <div className="m-q">
-      <div className="q-head">
-        <span className="q-label">
+      <div className="q-head flex-center">
+        <span className="q-label iflex-center">
           <Icon name="sparkle" size={11} /> Needs your input
           {total > 1 && (
             <span className="q-step">
@@ -107,7 +107,7 @@ export function QuestionCard({
             </span>
           )}
         </span>
-        {question.header && <span className="q-ctx">{question.header}</span>}
+        {question.header && <span className="q-ctx truncate">{question.header}</span>}
       </div>
       <div className="q-prompt">{question.prompt}</div>
       {question.body && (
@@ -142,7 +142,7 @@ export function QuestionCard({
                 }
               }}
             >
-              <span className={`q-radio ${question.multiSelect ? "check" : ""}`}>
+              <span className={`q-radio iflex-center ${question.multiSelect ? "check" : ""}`}>
                 {question.multiSelect && checked && <Icon name="check" size={10} />}
               </span>
               <span className="q-opt-body">
@@ -152,7 +152,7 @@ export function QuestionCard({
                 </span>
                 {o.desc && <span className="q-opt-desc">{o.desc}</span>}
               </span>
-              {!question.multiSelect && <span className="q-kbd">{i + 1}</span>}
+              {!question.multiSelect && <span className="q-kbd iflex-center">{i + 1}</span>}
             </button>
           );
         })}
@@ -164,7 +164,7 @@ export function QuestionCard({
             style={{ animationDelay: `${0.04 * opts.length + 0.02}s` }}
             onClick={() => setOtherOpen(true)}
           >
-            <span className="q-radio plus">
+            <span className="q-radio iflex-center plus">
               <Icon name="plus" size={10} />
             </span>
             <span className="q-opt-body">
@@ -193,8 +193,8 @@ export function QuestionCard({
                 }
               }}
             />
-            <div className="q-other-foot">
-              <span className="q-other-hint">
+            <div className="q-other-foot flex-center">
+              <span className="q-other-hint iflex-center">
                 <span className="kbd">↵</span> to send
               </span>
               <span className="grow" />
@@ -210,7 +210,7 @@ export function QuestionCard({
               </button>
               <button
                 type="button"
-                className="q-other-send"
+                className="q-other-send iflex-center"
                 disabled={!otherText.trim()}
                 onClick={answerOther}
               >
@@ -224,7 +224,7 @@ export function QuestionCard({
           <div className="q-multi-foot">
             <button
               type="button"
-              className="q-other-send"
+              className="q-other-send iflex-center"
               disabled={picks.size === 0}
               onClick={confirmMulti}
             >

--- a/src/components/Workspace/messages/UserInput/index.tsx
+++ b/src/components/Workspace/messages/UserInput/index.tsx
@@ -96,8 +96,8 @@ export function UserInput({
   if (!committedLocally && result?.is_error && !pendingRequestId) {
     return (
       <div className="m-q is-dismissed">
-        <div className="q-head">
-          <span className="q-label dismissed">
+        <div className="q-head flex-center">
+          <span className="q-label iflex-center dismissed">
             <Icon name="close" size={11} /> Dismissed
           </span>
         </div>
@@ -134,8 +134,8 @@ export function UserInput({
   if (!committedLocally && result && !result.is_error && !fromTranscript) {
     return (
       <div className="m-q is-answered">
-        <div className="q-head">
-          <span className="q-label resolved">
+        <div className="q-head flex-center">
+          <span className="q-label iflex-center resolved">
             <Icon name="check" size={11} /> Answered
           </span>
         </div>
@@ -144,8 +144,8 @@ export function UserInput({
             {q.prompt}
           </div>
         ))}
-        <div className="q-answer">
-          <span className="qa-mark">
+        <div className="q-answer flex-center">
+          <span className="qa-mark iflex-center">
             <Icon name="check" size={10} />
           </span>
           <span className="qa-text">{resultText(result.content)}</span>

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -84,15 +84,15 @@ export function Select<T extends string>({
     <div className="ui-select">
       <button
         type="button"
-        className={`ui-select-trigger ${open ? "open" : ""}`}
+        className={`ui-select-trigger flex-center ${open ? "open" : ""}`}
         disabled={disabled}
         aria-label={ariaLabel}
         aria-haspopup="listbox"
         aria-expanded={open}
         onClick={() => !disabled && setOpen((v) => !v)}
       >
-        {selected?.icon && <span className="ui-select-icon">{selected.icon}</span>}
-        <span className={`ui-select-value ${selected ? "" : "is-placeholder"}`}>
+        {selected?.icon && <span className="ui-select-icon iflex-center">{selected.icon}</span>}
+        <span className={`ui-select-value truncate ${selected ? "" : "is-placeholder"}`}>
           {selected?.label ?? placeholder}
         </span>
         <Icon name="chevD" size={11} />
@@ -108,10 +108,10 @@ export function Select<T extends string>({
                 type="button"
                 role="option"
                 aria-selected={o.value === value}
-                className={`dd-item ${o.value === value ? "active" : ""}`}
+                className={`dd-item flex-center ${o.value === value ? "active" : ""}`}
                 onClick={() => pick(o.value)}
               >
-                {o.icon && <span className="ui-select-icon">{o.icon}</span>}
+                {o.icon && <span className="ui-select-icon iflex-center">{o.icon}</span>}
                 <span className="di-l">{o.label}</span>
                 {o.hint && <span className="di-m">{o.hint}</span>}
                 {o.value === value && <Icon name="check" size={12} />}


### PR DESCRIPTION
## Summary

Defines three layout utility classes and eliminates ~151 duplicated CSS declarations across the codebase.

**Utilities added to `app.css`:**
```css
.flex-center   { display: flex; align-items: center; }
.iflex-center  { display: inline-flex; align-items: center; }
.truncate      { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
```

**Changes:**
- Removes `display: flex/inline-flex` + `align-items: center` from ~151 CSS rules
- Removes the truncate trio from matching rules (`.attachment-name` rule deleted entirely)
- Adds the appropriate utility class to `className` props in 66 TSX files
- Net: **−344 lines**

All changes are mechanical — no layout logic altered.