### PR TITLE
refactor: consolidate color-mix badge pattern via --badge-color

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -874,14 +874,20 @@ button {
   background: color-mix(in oklch, var(--badge-color), transparent 86%);
   color: var(--badge-color);
 }
-.ag-badge.pr-open   { --badge-color: var(--info); }
-.ag-badge.pr-merged { --badge-color: var(--purple); }
+.ag-badge.pr-open {
+  --badge-color: var(--info);
+}
+.ag-badge.pr-merged {
+  --badge-color: var(--purple);
+}
 .ag-badge.pr-closed {
   --badge-color: var(--fg-2);
   /* pr-closed is slightly more transparent than the other variants */
   background: color-mix(in oklch, var(--badge-color), transparent 88%);
 }
-.ag-badge.err       { --badge-color: var(--danger); }
+.ag-badge.err {
+  --badge-color: var(--danger);
+}
 .ag-badge.new {
   color: var(--accent);
   background: var(--accent-soft);
@@ -6456,10 +6462,18 @@ button {
   background: color-mix(in oklch, var(--badge-color), transparent 82%);
   color: var(--badge-color);
 }
-.fp-badge.s-m { --badge-color: var(--warn); }
-.fp-badge.s-a { --badge-color: var(--success); }
-.fp-badge.s-d { --badge-color: var(--danger); }
-.fp-badge.s-r { --badge-color: var(--info); }
+.fp-badge.s-m {
+  --badge-color: var(--warn);
+}
+.fp-badge.s-a {
+  --badge-color: var(--success);
+}
+.fp-badge.s-d {
+  --badge-color: var(--danger);
+}
+.fp-badge.s-r {
+  --badge-color: var(--info);
+}
 
 /* ── inline rename / create input ── */
 .fp-name-input {

--- a/src/app.css
+++ b/src/app.css
@@ -866,22 +866,22 @@ button {
   width: 10px;
   height: 10px;
 }
-.ag-badge.pr-open {
-  color: var(--info);
-  background: color-mix(in oklch, var(--info), transparent 86%);
-}
-.ag-badge.pr-merged {
-  color: var(--purple);
-  background: color-mix(in oklch, var(--purple), transparent 86%);
-}
-.ag-badge.pr-closed {
-  color: var(--fg-2);
-  background: color-mix(in oklch, var(--fg-2), transparent 88%);
-}
+/* badge base — color-mix formula written once for ag-badge variants */
+.ag-badge.pr-open,
+.ag-badge.pr-merged,
+.ag-badge.pr-closed,
 .ag-badge.err {
-  color: var(--danger);
-  background: color-mix(in oklch, var(--danger), transparent 86%);
+  background: color-mix(in oklch, var(--badge-color), transparent 86%);
+  color: var(--badge-color);
 }
+.ag-badge.pr-open   { --badge-color: var(--info); }
+.ag-badge.pr-merged { --badge-color: var(--purple); }
+.ag-badge.pr-closed {
+  --badge-color: var(--fg-2);
+  /* pr-closed is slightly more transparent than the other variants */
+  background: color-mix(in oklch, var(--badge-color), transparent 88%);
+}
+.ag-badge.err       { --badge-color: var(--danger); }
 .ag-badge.new {
   color: var(--accent);
   background: var(--accent-soft);
@@ -6444,25 +6444,22 @@ button {
   font-size: 9.5px;
   font-weight: 600;
   border-radius: var(--r-xs);
-  background: color-mix(in oklch, var(--warn), transparent 84%);
-  color: var(--warn);
+  --badge-color: var(--warn);
+  background: color-mix(in oklch, var(--badge-color), transparent 84%);
+  color: var(--badge-color);
 }
-.fp-badge.s-m {
-  background: color-mix(in oklch, var(--warn), transparent 82%);
-  color: var(--warn);
-}
-.fp-badge.s-a {
-  background: color-mix(in oklch, var(--success), transparent 82%);
-  color: var(--success);
-}
-.fp-badge.s-d {
-  background: color-mix(in oklch, var(--danger), transparent 82%);
-  color: var(--danger);
-}
+/* badge base — color-mix formula written once for fp-badge variants */
+.fp-badge.s-m,
+.fp-badge.s-a,
+.fp-badge.s-d,
 .fp-badge.s-r {
-  background: color-mix(in oklch, var(--info), transparent 82%);
-  color: var(--info);
+  background: color-mix(in oklch, var(--badge-color), transparent 82%);
+  color: var(--badge-color);
 }
+.fp-badge.s-m { --badge-color: var(--warn); }
+.fp-badge.s-a { --badge-color: var(--success); }
+.fp-badge.s-d { --badge-color: var(--danger); }
+.fp-badge.s-r { --badge-color: var(--info); }
 
 /* ── inline rename / create input ── */
 .fp-name-input {


### PR DESCRIPTION
## Summary

Eliminates repeated `color-mix(in oklch, var(--X), transparent N%)` + `color: var(--X)` pairs across badge variants via a `--badge-color` CSS custom property.

**Before** (repeated per variant):
```css
.ag-badge.pr-open   { color: var(--info);   background: color-mix(in oklch, var(--info),   transparent 86%); }
.ag-badge.pr-merged { color: var(--purple); background: color-mix(in oklch, var(--purple), transparent 86%); }
```

**After** (formula written once):
```css
.ag-badge.pr-open, .ag-badge.pr-merged, .ag-badge.pr-closed, .ag-badge.err {
  background: color-mix(in oklch, var(--badge-color), transparent 86%);
  color: var(--badge-color);
}
.ag-badge.pr-open   { --badge-color: var(--info); }
.ag-badge.pr-merged { --badge-color: var(--purple); }
```

**Scope:** `ag-badge` and `fp-badge` variant groups. `.git-hdr .pill` variants left untouched (per-variant transparency values, no clean single baseline). CSS-only change.