### PR TITLE
feat(chat): copy action on user and agent messages

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1430,6 +1430,37 @@ button {
   white-space: nowrap;
 }
 
+/* Groups a message bubble/response with its hover-revealed action row (copy).
+   The wrapper carries the bottom margin so the actions sit tight under the
+   message rather than 16px below it. */
+.m-msg-wrap {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 16px;
+}
+.m-msg-wrap.is-user {
+  align-self: flex-end;
+  align-items: flex-end;
+  max-width: 78%;
+}
+.m-msg-wrap > .m-user,
+.m-msg-wrap > .m-agent {
+  margin-bottom: 0;
+  max-width: 100%;
+}
+
+.m-actions {
+  display: flex;
+  gap: 2px;
+  margin-top: 2px;
+  opacity: 0;
+  transition: opacity 0.12s var(--ease);
+}
+.m-msg-wrap:hover .m-actions,
+.m-actions:focus-within {
+  opacity: 1;
+}
+
 .m-user {
   align-self: flex-end;
   max-width: 78%;

--- a/src/components/Workspace/messages/MessageItem.tsx
+++ b/src/components/Workspace/messages/MessageItem.tsx
@@ -5,6 +5,7 @@ import { stripInjectedInstructions } from "../../../util/instructions";
 import { AttachmentList } from "../../Composer/AttachmentList";
 import { Markdown } from "../../Markdown";
 import { APP_ACTION_PREFIX } from "../../RightPanel/delegation";
+import { CopyButton } from "../../ui/CopyButton";
 import { pairToolItems, rowKey, type ViewItem } from "./pair";
 import { getPresenter } from "./presenters";
 import { ToolResultItem } from "./ToolResultItem";
@@ -51,9 +52,17 @@ export function MessageItem({
       return <UserBubble text={item.text} attachments={item.attachments} queued />;
     case "agent_message":
       return (
-        <div className="m-agent">
-          <Markdown>{item.text}</Markdown>
-          {item.streaming && <span className="term-cursor" style={{ marginLeft: 4 }} />}
+        <div className="m-msg-wrap">
+          <div className="m-agent">
+            <Markdown>{item.text}</Markdown>
+            {item.streaming && <span className="term-cursor" style={{ marginLeft: 4 }} />}
+          </div>
+          {/* Copy is offered once the response has settled, not mid-stream. */}
+          {!item.streaming && (
+            <div className="m-actions">
+              <CopyButton text={item.text} />
+            </div>
+          )}
         </div>
       );
     case "tool_pair": {
@@ -124,13 +133,22 @@ function UserBubble({
   queued?: boolean;
   turnId?: number;
 }) {
+  const display = stripInjectedInstructions(text);
   return (
-    <div className={queued ? "m-user m-user--queued" : "m-user"} data-chat-turn={turnId}>
-      {stripInjectedInstructions(text)}
-      {attachments && attachments.length > 0 && (
-        <AttachmentList paths={attachments} className="message-attachments" />
+    <div className="m-msg-wrap is-user">
+      <div className={queued ? "m-user m-user--queued" : "m-user"} data-chat-turn={turnId}>
+        {display}
+        {attachments && attachments.length > 0 && (
+          <AttachmentList paths={attachments} className="message-attachments" />
+        )}
+        {queued && <span className="m-user__queued-tag">queued</span>}
+      </div>
+      {/* A queued follow-up isn't canonical yet, so skip its copy affordance. */}
+      {!queued && (
+        <div className="m-actions">
+          <CopyButton text={display} />
+        </div>
       )}
-      {queued && <span className="m-user__queued-tag">queued</span>}
     </div>
   );
 }

--- a/src/components/ui/CopyButton.tsx
+++ b/src/components/ui/CopyButton.tsx
@@ -20,15 +20,21 @@ export function CopyButton({
   // Clear the pending revert if the button unmounts mid-confirmation.
   useEffect(() => () => clearTimeout(timer.current), []);
 
-  const onCopy = () => {
-    navigator.clipboard
-      ?.writeText(text)
-      .then(() => {
-        setCopied(true);
-        clearTimeout(timer.current);
-        timer.current = setTimeout(() => setCopied(false), 1500);
-      })
-      .catch(() => {});
+  const onCopy = async () => {
+    // Guard the whole call: the Clipboard API is absent in insecure contexts,
+    // some webviews, and most test runtimes, and writeText can throw
+    // synchronously (not just reject) — which a trailing .catch() would miss.
+    try {
+      if (!navigator.clipboard?.writeText) return;
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // Denied or unavailable — leave the icon as-is rather than falsely
+      // confirming a copy that didn't happen.
+      return;
+    }
+    setCopied(true);
+    clearTimeout(timer.current);
+    timer.current = setTimeout(() => setCopied(false), 1500);
   };
 
   return (

--- a/src/components/ui/CopyButton.tsx
+++ b/src/components/ui/CopyButton.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useRef, useState } from "react";
+import { Icon } from "../Icon";
+import { IconButton } from "./IconButton";
+
+/** Copies `text` to the clipboard and briefly swaps the copy icon for a check
+ *  as confirmation. Used under chat messages; generic enough for any "copy
+ *  this string" affordance. */
+export function CopyButton({
+  text,
+  tip = "Copy",
+  className,
+}: {
+  text: string;
+  tip?: string;
+  className?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout>>();
+
+  // Clear the pending revert if the button unmounts mid-confirmation.
+  useEffect(() => () => clearTimeout(timer.current), []);
+
+  const onCopy = () => {
+    navigator.clipboard
+      ?.writeText(text)
+      .then(() => {
+        setCopied(true);
+        clearTimeout(timer.current);
+        timer.current = setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(() => {});
+  };
+
+  return (
+    <IconButton
+      size="xs"
+      tip={copied ? "Copied" : tip}
+      className={className}
+      onClick={onCopy}
+      aria-label="Copy message"
+    >
+      <Icon name={copied ? "check" : "copy"} />
+    </IconButton>
+  );
+}


### PR DESCRIPTION
## What

Adds a copy action at the bottom of each user prompt and agent response. Clicking copies the message text to the clipboard and the icon briefly swaps to a check as confirmation.

## Changes

- **New `CopyButton` (`src/components/ui/CopyButton.tsx`)** — reusable, wraps the existing `IconButton` + `Icon`. Uses `navigator.clipboard.writeText`, toggles `copy` → `check` for ~1.5s (timeout cleared on unmount).
- **`MessageItem.tsx`** — user bubbles and agent responses are wrapped in `.m-msg-wrap` with a hover-revealed `.m-actions` row. Agent copy appears only once streaming finishes; user copy uses the displayed text (injected instructions stripped) and is skipped for not-yet-canonical queued follow-ups.
- **`app.css`** — wrapper now carries the 16px bottom margin so the action sits tight under the message; `.m-actions` fades in on hover or keyboard focus.

`data-chat-turn` stays on the inner bubble, so ChatNav scroll-to-turn is unaffected.

## Test plan

- [x] `tsc --noEmit` passes
- [x] biome lint passes on changed files
- [ ] Manual: hover a user message and an agent response, click copy, confirm clipboard contents and the check-icon flip

🤖 Generated with [Claude Code](https://claude.com/claude-code)