### PR TITLE
fix: restore display:inline-flex on agent icon and composer model chip

### DIFF
--- a/src/components/History/index.tsx
+++ b/src/components/History/index.tsx
@@ -174,7 +174,7 @@ export function History() {
                           </span>
                         )}
                         <span className="hr-date">{when}</span>
-                        <span className={`hr-goto${isRestoring ? " restoring" : ""}`}>
+                        <span className={`hr-goto iflex-center${isRestoring ? " restoring" : ""}`}>
                           {isRestoring ? (
                             <>
                               <span className="dots">

--- a/src/components/ProviderIcon.tsx
+++ b/src/components/ProviderIcon.tsx
@@ -70,7 +70,9 @@ export function ProviderIcon({ slug, short, hue, size = 30 }: ProviderIconProps)
     };
   }, [slug]);
 
-  const cls = ["chip-mono", svg && !failed ? "has-brand-icon" : ""].filter(Boolean).join(" ");
+  const cls = ["chip-mono", "iflex-center", svg && !failed ? "has-brand-icon" : ""]
+    .filter(Boolean)
+    .join(" ");
 
   return (
     <span

--- a/src/components/RightPanel/RunSettingsSheet.tsx
+++ b/src/components/RightPanel/RunSettingsSheet.tsx
@@ -165,7 +165,7 @@ function ConfigRow({ row, override, onChange, onRevert }: ConfigRowProps) {
   const display = hasOverride ? override : row.value;
 
   return (
-    <div className={`rs-row${hasOverride ? " overridden" : ""}`}>
+    <div className={`rs-row flex-center${hasOverride ? " overridden" : ""}`}>
       <div className="rs-row-l">
         <div className="rs-label">{row.key}</div>
         <div className="rs-source iflex-center">

--- a/src/components/ui/Chip.tsx
+++ b/src/components/ui/Chip.tsx
@@ -13,7 +13,13 @@ interface Props {
  *  base-branch selector. Visual sibling of `IconButton` but with a
  *  text label slot. */
 export function Chip({ children, onClick, bordered, tip, className, disabled }: Props) {
-  const cls = ["c-chip", bordered ? "with-border" : "", tip ? "tip" : "", className ?? ""]
+  const cls = [
+    "c-chip",
+    "iflex-center",
+    bordered ? "with-border" : "",
+    tip ? "tip" : "",
+    className ?? "",
+  ]
     .filter(Boolean)
     .join(" ");
   return (

--- a/src/components/ui/IconButton.tsx
+++ b/src/components/ui/IconButton.tsx
@@ -35,6 +35,7 @@ export function IconButton({
 }: Props) {
   const cls = [
     "btn-i",
+    "iflex-center",
     size === "sm" ? "sm" : size === "xs" ? "xs" : "",
     active ? "active" : "",
     tip ? "tip" : "",


### PR DESCRIPTION
The #245 CSS refactor extracted `.flex-center`/`.iflex-center` utilities and stripped `display: flex/inline-flex; align-items: center` from many rules, expecting each element's JSX to adopt the utility class — but five components were missed, breaking their layout. This restores them: `iflex-center` on `ProviderIcon` (`.chip-mono` — the broken agent icon in the composer picker), `ui/Chip` (`.c-chip` — the model chip that lost its gap), `ui/IconButton` (`.btn-i` — the shared icon button used across title bar, sidebar, composer, and right panel), and `History`'s `.hr-goto`; plus `flex-center` on `RunSettingsSheet`'s `.rs-row`. A parallel audit cross-checked every other rule the refactor touched and confirmed those were already compensated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)