### PR TITLE
feat(chat): retry button on a failed user turn

### DIFF
--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -23,6 +23,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
   const busyLabel = useAppStore((s) => s.managedBusyLabel[agent.id]);
   const switchInFlight = useAppStore((s) => s.switchInFlight[agent.id] ?? false);
   const send = useAppStore((s) => s.sendUserMessage);
+  const retry = useAppStore((s) => s.retryUserMessage);
   const stop = useAppStore((s) => s.stop);
   const loadHistoryTranscript = useAppStore((s) => s.loadHistoryTranscript);
   const usage = useAppStore((s) => s.usage[agent.id]);
@@ -151,6 +152,19 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
     return { turns, turnIds };
   }, [items]);
 
+  // When the agent's last response failed (status "error"), offer a one-click
+  // Retry on the most recent user turn: it resumes the crashed process if
+  // needed and re-delivers that message, sparing the user a copy-paste or a
+  // manual "continue". Index of that bubble (git-action chips excluded).
+  const lastUserIndex = useMemo(() => {
+    for (let i = items.length - 1; i >= 0; i -= 1) {
+      const it = items[i];
+      if (it.kind === "user_message" && !it.text.startsWith(APP_ACTION_PREFIX)) return i;
+    }
+    return -1;
+  }, [items]);
+  const canRetry = agent.status === "error";
+
   // The model the agent actually used on its most recent turn (Claude, pi,
   // Codex, OpenCode report it in their transcripts). Undefined for Cursor /
   // Antigravity, or before the first turn — the composer then shows just the
@@ -219,6 +233,14 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
                   provider={agent.provider}
                   agentId={agent.id}
                   turnId={turnIds[i]}
+                  onRetry={
+                    canRetry && i === lastUserIndex && item.kind === "user_message"
+                      ? () => {
+                          pinnedToBottom.current = true;
+                          void retry(agent.id, item.text, item.attachments ?? []);
+                        }
+                      : undefined
+                  }
                 />
               ))
             )}

--- a/src/components/Workspace/messages/MessageItem.tsx
+++ b/src/components/Workspace/messages/MessageItem.tsx
@@ -6,6 +6,7 @@ import { AttachmentList } from "../../Composer/AttachmentList";
 import { Markdown } from "../../Markdown";
 import { APP_ACTION_PREFIX } from "../../RightPanel/delegation";
 import { CopyButton } from "../../ui/CopyButton";
+import { RetryButton } from "../../ui/RetryButton";
 import { pairToolItems, rowKey, type ViewItem } from "./pair";
 import { getPresenter } from "./presenters";
 import { ToolResultItem } from "./ToolResultItem";
@@ -23,6 +24,7 @@ export function MessageItem({
   provider,
   agentId,
   turnId,
+  onRetry,
 }: {
   item: ViewItem;
   provider?: string;
@@ -30,6 +32,9 @@ export function MessageItem({
   /** Ordinal of this user turn, used by ChatNav to locate the bubble in the
    *  DOM. Set only for top-level navigable user prompts. */
   turnId?: number;
+  /** Re-run this user turn. Set only on the last user message when the agent's
+   *  last response failed; renders a Retry button beside Copy. */
+  onRetry?: () => void;
 }) {
   switch (item.kind) {
     case "user_message":
@@ -44,7 +49,14 @@ export function MessageItem({
           </div>
         );
       }
-      return <UserBubble text={item.text} attachments={item.attachments} turnId={turnId} />;
+      return (
+        <UserBubble
+          text={item.text}
+          attachments={item.attachments}
+          turnId={turnId}
+          onRetry={onRetry}
+        />
+      );
     case "queued_message":
       // Same bubble, marked queued: a follow-up the user sent mid-turn that the
       // transcript hasn't caught up to yet. Reconciled away in app.ts once it
@@ -127,11 +139,13 @@ function UserBubble({
   attachments,
   queued,
   turnId,
+  onRetry,
 }: {
   text: string;
   attachments?: string[];
   queued?: boolean;
   turnId?: number;
+  onRetry?: () => void;
 }) {
   const display = stripInjectedInstructions(text);
   return (
@@ -147,6 +161,9 @@ function UserBubble({
       {!queued && (
         <div className="m-actions">
           <CopyButton text={display} />
+          {/* Retry only appears when this is the last user turn and the agent's
+           *  response failed — see ChatView's `onRetry` wiring. */}
+          {onRetry && <RetryButton onRetry={onRetry} />}
         </div>
       )}
     </div>

--- a/src/components/ui/RetryButton.tsx
+++ b/src/components/ui/RetryButton.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react";
+import { Icon } from "../Icon";
+import { IconButton } from "./IconButton";
+
+/** Re-runs a failed user turn. Shown in the action row under the last user
+ *  message when the agent's response errored out (connection drop, auth, a
+ *  crashed process). Mirrors CopyButton's placement; the actual resume/resend
+ *  lives in the `retryUserMessage` store action. */
+export function RetryButton({
+  onRetry,
+  tip = "Retry",
+  className,
+}: {
+  onRetry: () => void | Promise<void>;
+  tip?: string;
+  className?: string;
+}) {
+  const [retrying, setRetrying] = useState(false);
+  return (
+    <IconButton
+      size="xs"
+      tip={retrying ? "Retrying…" : tip}
+      className={className}
+      disabled={retrying}
+      onClick={() => {
+        // Guard against a double-click firing two sends: the button stays
+        // mounted (status is still "error") until the resume/resend lands.
+        setRetrying(true);
+        void Promise.resolve(onRetry()).finally(() => setRetrying(false));
+      }}
+      aria-label="Retry message"
+    >
+      <Icon name="refresh" />
+    </IconButton>
+  );
+}

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -90,6 +90,12 @@ export interface WorkspaceSlice {
     attachments?: string[],
     thinking?: string,
   ) => Promise<void>;
+  /** Re-send the last user turn after it failed (connection drop, auth error,
+   *  a crashed process). If the agent's process exited (status "error") it's
+   *  resumed first, then the message is re-delivered. Unlike sendUserMessage
+   *  this never appends a new bubble — the message is already in the log; it
+   *  just re-runs that turn. */
+  retryUserMessage: (id: string, text: string, attachments?: string[]) => Promise<void>;
   /** Answer a paused user-input tool (Claude's AskUserQuestion/ExitPlanMode).
    *  Looks up the held control-protocol request for `toolUseId` and delivers
    *  `updatedInput` (the tool's input with the user's `answers` merged in) as

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -142,6 +142,39 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
     }
   },
 
+  retryUserMessage: async (id, text, attachments = []) => {
+    // Fresh per-turn id: the failed turn produced no completed transcript row,
+    // so there's nothing to dedupe against.
+    const turnId = crypto.randomUUID();
+    const status = get().workspace?.agents.find((a) => a.id === id)?.status;
+    // Clear the prior failure and re-assert busy. The message is already in the
+    // log (left there optimistically on the failed send), so unlike
+    // sendUserMessage we do NOT append a new bubble — we just re-run its turn.
+    set((state) => ({
+      lastError: null,
+      managedBusy: { ...state.managedBusy, [id]: true },
+      managedBusyLabel: { ...state.managedBusyLabel, [id]: undefined },
+    }));
+    try {
+      if (status === "error") {
+        // The process exited — restart it in --resume mode, then deliver once
+        // it's back (sendWhenAgentReady polls past the transient "agent not
+        // found" while the new process spins up). Same pattern sendUserMessage
+        // uses for a dead idle agent.
+        clearOutputBuffer(id);
+        await api.resumeAgent(id);
+        await sendWhenAgentReady(() => api.sendUserMessage(id, turnId, text, attachments));
+      } else {
+        await api.sendUserMessage(id, turnId, text, attachments);
+      }
+    } catch (e) {
+      set((state) => ({
+        lastError: String(e),
+        managedBusy: { ...state.managedBusy, [id]: false },
+      }));
+    }
+  },
+
   answerToolUse: async (id, toolUseId, updatedInput, behavior = "allow", message) => {
     const requestId = get().pendingToolUse[id]?.[toolUseId];
     if (!requestId) return;


### PR DESCRIPTION
Adds a **Retry** action beside Copy on the last user message, shown only when the agent's last response failed (`agent.status === "error"` — connection drop, auth/not-logged-in error, or a crashed process). One click resumes the process if it exited, then re-delivers the message's text + attachments **without** appending a duplicate bubble, sparing the user the copy-paste or manual "continue". The button auto-disappears once the agent starts running again. Behavior lives in a new `retryUserMessage` store action; a new reusable `RetryButton` mirrors `CopyButton`. The existing `CrashBanner`/Resume is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)