### PR TITLE
feat(css): type-scale tokens + .text-* utilities, applied across the app

### DIFF
--- a/src/components/TitleBar/Breadcrumb.tsx
+++ b/src/components/TitleBar/Breadcrumb.tsx
@@ -12,14 +12,16 @@ export interface CrumbEntry {
 
 export function Breadcrumb({ entries }: { entries: CrumbEntry[] }) {
   return (
-    <div className="tb-crumb flex-center">
+    <div className="tb-crumb flex-center text-sm">
       {entries.map((c, i) => (
         <Fragment key={i}>
           {i > 0 && <span className="sep">/</span>}
           {c.swatchHue != null && (
             <span className="swatch" style={{ background: `oklch(0.5 0.08 ${c.swatchHue})` }} />
           )}
-          <span className={(c.active ? "active " : "") + (c.mono ? "mono" : "")}>{c.label}</span>
+          <span className={(c.active ? "active " : "") + (c.mono ? "mono text-xs" : "")}>
+            {c.label}
+          </span>
         </Fragment>
       ))}
     </div>

--- a/src/components/TitleBar/TitleBar.css
+++ b/src/components/TitleBar/TitleBar.css
@@ -17,8 +17,6 @@
 .tb-logo {
   margin-left: 12px;
   gap: 8px;
-  font-family: var(--font-sans);
-  font-size: 16px;
   font-weight: 600;
   letter-spacing: 0.005em;
   color: var(--fg-0);
@@ -45,8 +43,6 @@
 }
 .tb-badge {
   height: 16px;
-  font-family: var(--font-sans);
-  font-size: 8px;
   font-weight: 500;
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -64,7 +60,6 @@
   top: 50%;
   transform: translate(-50%, -50%);
   gap: 8px;
-  font-size: 12px;
   color: var(--fg-2);
   pointer-events: none;
   white-space: nowrap;
@@ -74,7 +69,6 @@
 }
 .tb-crumb .mono {
   font-family: var(--font-mono);
-  font-size: 11.5px;
 }
 .tb-crumb .active {
   color: var(--fg-0);

--- a/src/components/TitleBar/index.tsx
+++ b/src/components/TitleBar/index.tsx
@@ -20,12 +20,12 @@ export function TitleBar() {
   return (
     <div className="tb flex-center" data-tauri-drag-region>
       <div className="tb-lights-gutter" data-tauri-drag-region />
-      <div className="tb-logo iflex-center" data-tauri-drag-region aria-label="Quorum">
+      <div className="tb-logo iflex-center text-xl" data-tauri-drag-region aria-label="Quorum">
         <span className="tb-wordmark" aria-hidden="true">
           <QMark className="tb-qmark" />
           uorum
         </span>
-        <span className="tb-badge iflex-center">beta</span>
+        <span className="tb-badge iflex-center text-2xs">beta</span>
       </div>
       <Breadcrumb entries={entries} />
       <div className="tb-right flex-center">

--- a/src/styles/foundation/base.css
+++ b/src/styles/foundation/base.css
@@ -13,6 +13,44 @@
   white-space: nowrap;
 }
 
+/* type-scale utilities — apply on an element to size it off the scale (see
+ * the --fs-* tokens). An element's size lives in exactly ONE place: a .text-*
+ * class here, or font-size in CSS for pseudo-elements that can't take a class.
+ * Never both. */
+.text-2xs {
+  font-size: var(--fs-2xs);
+}
+.text-xs {
+  font-size: var(--fs-xs);
+}
+.text-sm {
+  font-size: var(--fs-sm);
+}
+.text-base {
+  font-size: var(--fs-base);
+}
+.text-lg {
+  font-size: var(--fs-lg);
+}
+.text-xl {
+  font-size: var(--fs-xl);
+}
+.text-2xl {
+  font-size: var(--fs-2xl);
+}
+.text-3xl {
+  font-size: var(--fs-3xl);
+}
+.text-4xl {
+  font-size: var(--fs-4xl);
+}
+.text-5xl {
+  font-size: var(--fs-5xl);
+}
+.text-6xl {
+  font-size: var(--fs-6xl);
+}
+
 /* reset */
 * {
   box-sizing: border-box;
@@ -27,7 +65,7 @@ body {
   font-family: var(--font-sans);
   background: var(--bg-0);
   color: var(--fg-0);
-  font-size: 13.5px;
+  font-size: var(--fs-base);
   font-weight: 400;
   letter-spacing: -0.005em;
   -webkit-font-smoothing: antialiased;

--- a/src/styles/foundation/tokens.css
+++ b/src/styles/foundation/tokens.css
@@ -10,6 +10,26 @@
   --font-serif: "Iowan Old Style", "Cormorant Garamond", Georgia, serif;
   --font-mono: ui-monospace, "SF Mono", Menlo, monospace;
 
+  /* ── type scale ──────────────────────────────────────────────────────
+   * <body> inherits --fs-base; everything derives from these tokens — no
+   * hardcoded font-size anywhere. Body range is 1px-stepped (at small sizes
+   * each px is a real tier, and ~90% of this UI's text is small chrome);
+   * display range follows a looser ~1.25–1.4 ratio. 10px is the legibility
+   * floor. Old half-pixel sizes snap to the nearest step; a one-off that
+   * genuinely needs its own size gets a named token, never a literal.
+   * Components migrate onto these one at a time. */
+  --fs-2xs: 10px; /* micro: badges, overlines, counts (floor) */
+  --fs-xs: 11px; /* dense chrome: sidebar meta, secondary labels */
+  --fs-sm: 12px; /* secondary / panel body */
+  --fs-base: 13px; /* regular body — inherited from <body> */
+  --fs-lg: 14px; /* emphasized body, small section titles */
+  --fs-xl: 16px; /* card / dialog titles */
+  --fs-2xl: 20px; /* section headings */
+  --fs-3xl: 24px; /* page titles */
+  --fs-4xl: 32px; /* empty-state / onboarding */
+  --fs-5xl: 44px; /* hero */
+  --fs-6xl: 56px; /* brand / splash */
+
   --r-xs: 4px;
   --r-sm: 6px;
   --r-md: 9px;


### PR DESCRIPTION
Replaces ad-hoc font sizes with a single source of truth — a token scale + `.text-*` utilities — and rolls it out across the whole app. On top of the `app.css` split (#256, merged).

## Before
310 `font-size` declarations across **28 ad-hoc values** — every 1px *and* 0.5px step from 8→56px. Zero tokens.

## The scale (`tokens.css`) — 11 tokens
1px steps through the body range (where ~90% of text lives); ~1.25–1.4 ratio for display. 10px is the legibility floor.

| token | px | actual uses | | token | px | actual uses |
|---|---|---|---|---|---|---|
| `--fs-2xs` | 10 | 52 | | `--fs-xl` | 16 | 10 |
| `--fs-xs` | 11 | 74 | | `--fs-2xl` | 20 | 2 |
| `--fs-sm` | 12 | **102** | | `--fs-3xl` | 24 | 1 |
| `--fs-base` | 13 | 85 | | `--fs-4xl` | 32 | 3 |
| `--fs-lg` | 14 | 10 | | `--fs-5xl` / `6xl` | 44 / 56 | 2 / 4 |

**345 token refs total; 313 (91%) in the 10–13px band.**

## How it's applied — single-source rule
- **Component elements → `.text-*` utility in JSX**, `font-size` deleted from the component CSS (no specificity fight).
- **Pseudo-elements, shared primitives** (badge/dropdown/tooltip/banners/terminal/icon-button), **reused base classes, and `font: inherit` elements → `font-size: var(--fs-*)` in CSS** (one definition for scattered consumers).
- **Inline `style={{fontSize}}` → `var(--fs-*)`**, except xterm.js Terminal options (canvas, must be numeric).

Result: **0 hardcoded px font-sizes in any stylesheet.**

## Intentional visual changes — please eyeball in the running app
- **Body base 13.5px → 13px** (all inherited text). One-line revert to 14 if you want it roomier.
- **"beta" badge 8px → 10px** (legibility floor).
- **Empty-draft name/title 50px → 56px** (snap rounds up).
- **All 0.5px sizes snapped** to the nearest step app-wide.
- **11 vs 12 (`xs`/`sm`) preserved, not merged** — left as a one-line experiment in tokens.css (point `--fs-sm` at `--fs-xs`) since they're a hierarchy pair in 15 of 20 components.

## Scope
Done via per-area sub-agents (one per component), then a single verification pass. 83 files, net −156 lines.

## Verification
- ✅ build + `tsc` clean
- ✅ 317/317 tests pass
- ✅ lint clean (0 errors; 48 pre-existing warnings unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)