### PR TITLE
fix(files): restore flex layout on broken file tree rows

### DIFF
--- a/src/components/RightPanel/FilePanel/TreeBrowser.tsx
+++ b/src/components/RightPanel/FilePanel/TreeBrowser.tsx
@@ -242,7 +242,7 @@ function TreeRow({
   const st = node.status ? node.status.toLowerCase() : "";
   return (
     <button
-      className={`fp-row file ${node.status ? `changed s-${st}` : ""}`}
+      className={`fp-row flex-center file ${node.status ? `changed s-${st}` : ""}`}
       style={{ paddingLeft: pad + 13 }}
       onClick={() => onOpen(node.path)}
       onContextMenu={(e) => {


### PR DESCRIPTION
File rows in the Files panel had dropped the `flex-center` utility class — likely lost in the recent `app.css` split refactor (#256) — so the file-type icon stacked above the filename instead of sitting beside it, while folder rows and the create-row stayed correct. This adds `flex-center` back to the file row so it matches its sibling rows and restores the intended single-line icon-beside-name layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)