### PR TITLE
refactor(css): normalize non-standard font-weights

### DIFF
--- a/src/components/Composer/Composer.css
+++ b/src/components/Composer/Composer.css
@@ -194,7 +194,7 @@
   max-width: min(390px, 48vw);
 }
 .model-chip-agent {
-  font-weight: 550;
+  font-weight: 600;
   white-space: nowrap;
 }
 .model-chip-model {

--- a/src/components/Composer/ModelPicker.css
+++ b/src/components/Composer/ModelPicker.css
@@ -159,7 +159,7 @@
 .model-side-fly-name {
   flex: 1;
   min-width: 0;
-  font-weight: 550;
+  font-weight: 600;
   color: var(--fg-0);
 }
 .model-side-fly-tag {
@@ -205,11 +205,11 @@
   gap: 1px;
 }
 .model-option-name {
-  font-weight: 450;
+  font-weight: 500;
   color: var(--fg-0);
 }
 .model-option-name.def {
-  font-weight: 550;
+  font-weight: 600;
 }
 .model-option-desc {
   color: var(--fg-3);

--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -235,7 +235,7 @@
   min-height: 21px;
 }
 .agent-row .ag-name {
-  font-weight: 550;
+  font-weight: 600;
   color: var(--fg-0);
   flex-shrink: 0;
 }

--- a/src/components/Workspace/Chat.css
+++ b/src/components/Workspace/Chat.css
@@ -357,7 +357,7 @@
 .m-agent h3,
 .m-agent h4 {
   margin: 22px 0 10px;
-  font-weight: 650;
+  font-weight: 600;
   line-height: 1.25;
   color: var(--fg-0);
 }


### PR DESCRIPTION
Small cleanup: six declarations used off-ladder weights — `450`(×1), `550`(×4), `650`(×1) — sitting between the standard steps. Snapped them to the set the app already uses, preserving each element's relative emphasis.

| element | was | now |
|---|---|---|
| `.model-option-name` | 450 | 500 |
| `.model-option-name.def` | 550 | 600 |
| `.agent-row .ag-name` | 550 | 600 |
| `.model-side-fly-name` | 550 | 600 |
| `.model-chip-agent` | 550 | 600 |
| `.m-agent h2/h3/h4` | 650 | 600 |

Default option stays heavier than a normal one; names stay emphasized — just on standard weights. Distribution is now `400 / 500 / 600` (+ one `700` left as-is, a legit bold).

## Eyeball
Six elements shift ~50 weight units: the sidebar **agent name** and **model name/chip** (550→600, slightly bolder) and **agent-message subheadings** (650→600, slightly lighter). Subtle.

## Verification
- ✅ build + `tsc` clean
- ✅ 317/317 tests pass
- ✅ lint clean (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)