### PR TITLE
refactor(css): tokenize line-height onto a 5-step scale

### DIFF
--- a/src/components/Composer/Composer.css
+++ b/src/components/Composer/Composer.css
@@ -130,7 +130,7 @@
 .composer-input {
   width: 100%;
   padding: 12px 14px 8px;
-  line-height: 1.55;
+  line-height: var(--lh-normal);
   color: var(--fg-0);
   resize: none;
   min-height: 24px;

--- a/src/components/NewProject/NewProject.css
+++ b/src/components/NewProject/NewProject.css
@@ -333,7 +333,7 @@
 }
 .np-gate-s {
   color: var(--fg-2);
-  line-height: 1.5;
+  line-height: var(--lh-normal);
   max-width: 320px;
 }
 .np-gate code {

--- a/src/components/Onboarding/onboarding.css
+++ b/src/components/Onboarding/onboarding.css
@@ -278,7 +278,7 @@
 }
 .ob-lede {
   font-size: var(--fs-lg);
-  line-height: 1.66;
+  line-height: var(--lh-relaxed);
   color: var(--fg-2);
   margin: 0;
   text-wrap: pretty;
@@ -335,7 +335,7 @@
 }
 .ob-welcome .ob-display {
   font-size: var(--fs-5xl);
-  line-height: 1.14;
+  line-height: var(--lh-tight);
 }
 .ob-welcome .ob-lede {
   margin-top: 26px;
@@ -421,7 +421,7 @@
 
 .ob-legal {
   margin-top: 34px;
-  line-height: 1.6;
+  line-height: var(--lh-relaxed);
   color: var(--fg-3);
   max-width: 360px;
   text-align: center;
@@ -481,7 +481,7 @@
 }
 .ob-beat-copy .ob-display {
   font-size: var(--fs-4xl);
-  line-height: 1.18;
+  line-height: var(--lh-tight);
   margin-top: 22px;
 }
 .ob-beat-copy .ob-lede {
@@ -498,7 +498,7 @@
   align-items: flex-start;
   gap: 11px;
   font-size: var(--fs-base);
-  line-height: 1.5;
+  line-height: var(--lh-normal);
   color: var(--fg-1);
 }
 .ob-point .ic {
@@ -864,7 +864,7 @@
   border-bottom: 1px solid var(--bd-soft);
   background: color-mix(in oklch, var(--success), var(--bg-1) 93%);
   font-size: var(--fs-xs);
-  line-height: 1.45;
+  line-height: var(--lh-snug);
   color: var(--fg-1);
   font-style: italic;
   text-wrap: pretty;
@@ -877,7 +877,7 @@
 .ex-diff {
   font-family: var(--font-mono);
   font-size: var(--fs-xs);
-  line-height: 1.62;
+  line-height: var(--lh-relaxed);
   padding: 6px 0 10px;
   max-height: 304px;
   overflow: hidden;
@@ -1028,7 +1028,7 @@
 .ex-room-title {
   font-family: var(--font-serif);
   font-size: var(--fs-2xl);
-  line-height: 1.18;
+  line-height: var(--lh-tight);
   color: var(--fg-0);
   letter-spacing: -0.01em;
   margin-bottom: 16px;
@@ -1168,7 +1168,7 @@
 .ob-fineprint {
   margin: 14px 0 0;
   max-width: 40ch;
-  line-height: 1.5;
+  line-height: var(--lh-normal);
   color: var(--fg-3);
   text-wrap: pretty;
 }
@@ -1329,7 +1329,7 @@
 }
 .ob-ignite .ob-display {
   font-size: var(--fs-5xl);
-  line-height: 1.12;
+  line-height: var(--lh-tight);
 }
 .ob-ignite .ob-lede {
   margin-top: 20px;
@@ -1533,7 +1533,7 @@
   font-size: var(--fs-xs);
   font-weight: 600;
   color: var(--fg-0);
-  line-height: 1.2;
+  line-height: var(--lh-tight);
 }
 .ob-rdy-tile-foot {
   display: flex;

--- a/src/components/RightPanel/Code/Code.css
+++ b/src/components/RightPanel/Code/Code.css
@@ -311,7 +311,7 @@
   padding: 4px 0 80px;
   background: var(--bg-0);
   font-family: var(--font-mono);
-  line-height: 1.55;
+  line-height: var(--lh-normal);
   position: relative;
 }
 .code-diff.live::before {

--- a/src/components/RightPanel/GitPanel/GitPanel.css
+++ b/src/components/RightPanel/GitPanel/GitPanel.css
@@ -266,7 +266,7 @@
   margin: 18px;
   padding: 12px;
   border-radius: var(--r-md);
-  line-height: 1.45;
+  line-height: var(--lh-snug);
   gap: 8px;
 }
 .git-banner svg {
@@ -306,7 +306,7 @@
 .git-card-title {
   font-weight: 500;
   color: var(--fg-0);
-  line-height: 1.4;
+  line-height: var(--lh-snug);
 }
 .git-card-meta {
   color: var(--fg-2);
@@ -424,7 +424,7 @@
 
 /* collapsed note (agent default) — quiet one-liner */
 .cm-note {
-  line-height: 1.55;
+  line-height: var(--lh-normal);
   color: var(--fg-3);
   text-wrap: pretty;
 }
@@ -497,7 +497,7 @@
   box-sizing: border-box;
   resize: none;
   font-family: var(--font-mono);
-  line-height: 1.5;
+  line-height: var(--lh-normal);
   color: var(--fg-0);
   padding: 9px 11px;
   border: 1px solid var(--bd);
@@ -519,7 +519,7 @@
   align-items: center;
   gap: 6px;
   margin-top: 7px;
-  line-height: 1.4;
+  line-height: var(--lh-snug);
   color: var(--fg-3);
 }
 .git-commit .cm-foot svg {
@@ -970,7 +970,7 @@
 }
 .pr-comment .pc-text {
   color: var(--fg-2);
-  line-height: 1.35;
+  line-height: var(--lh-snug);
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;

--- a/src/components/RightPanel/RunPanel.css
+++ b/src/components/RightPanel/RunPanel.css
@@ -161,7 +161,7 @@
   overflow-y: auto;
   min-height: 0;
   font-family: var(--font-mono);
-  line-height: 1.65;
+  line-height: var(--lh-relaxed);
   padding: 10px 18px 16px;
   color: var(--fg-1);
   white-space: pre-wrap;

--- a/src/components/SettingsScreen/CustomAgents/CustomAgents.css
+++ b/src/components/SettingsScreen/CustomAgents/CustomAgents.css
@@ -189,7 +189,7 @@
   height: auto;
   min-height: 150px;
   padding: 11px 12px;
-  line-height: 1.55;
+  line-height: var(--lh-normal);
   resize: vertical;
   font-family: var(--font-sans);
 }
@@ -250,7 +250,7 @@
   display: flex;
   flex-direction: column;
   gap: 1px;
-  line-height: 1.2;
+  line-height: var(--lh-tight);
 }
 .model-custom-text > span:first-child {
   font-size: var(--fs-base);

--- a/src/components/SettingsScreen/SettingsScreen.css
+++ b/src/components/SettingsScreen/SettingsScreen.css
@@ -157,10 +157,10 @@
   letter-spacing: -0.025em;
   color: var(--fg-0);
   margin: 0;
-  line-height: 1.05;
+  line-height: var(--lh-none);
 }
 .set-lead {
-  line-height: 1.6;
+  line-height: var(--lh-relaxed);
   color: var(--fg-2);
   margin: 12px 0 0;
   max-width: 56ch;
@@ -212,7 +212,7 @@
 }
 .set-row-s {
   color: var(--fg-2);
-  line-height: 1.5;
+  line-height: var(--lh-normal);
   margin-top: 3px;
   max-width: 52ch;
   text-wrap: pretty;

--- a/src/components/TitleBar/TitleBar.css
+++ b/src/components/TitleBar/TitleBar.css
@@ -50,7 +50,7 @@
   background: var(--bg-3);
   padding: 0 5px;
   border-radius: var(--r-xs);
-  line-height: 1;
+  line-height: var(--lh-none);
   position: relative;
   top: 1px;
 }

--- a/src/components/Workspace/Chat.css
+++ b/src/components/Workspace/Chat.css
@@ -273,7 +273,7 @@
   color: var(--accent);
 }
 .chat-nav-row-t {
-  line-height: 1.4;
+  line-height: var(--lh-snug);
 }
 
 /* Groups a message bubble/response with its hover-revealed action row (copy).
@@ -315,7 +315,7 @@
   border: 1px solid var(--bd-soft);
   border-radius: 16px 16px 4px 16px;
   font-size: var(--fs-base);
-  line-height: 1.55;
+  line-height: var(--lh-normal);
   color: var(--fg-0);
   white-space: pre-wrap;
   margin-bottom: 16px;
@@ -339,7 +339,7 @@
 }
 
 .m-agent {
-  line-height: 1.7;
+  line-height: var(--lh-relaxed);
   color: var(--fg-0);
   margin-bottom: 16px;
 }
@@ -358,7 +358,7 @@
 .m-agent h4 {
   margin: 22px 0 10px;
   font-weight: 650;
-  line-height: 1.25;
+  line-height: var(--lh-tight);
   color: var(--fg-0);
 }
 .m-agent h1 {
@@ -453,7 +453,7 @@
 
 .m-reasoning {
   font-size: var(--fs-base);
-  line-height: 1.65;
+  line-height: var(--lh-relaxed);
   color: var(--fg-2);
   padding: 4px 18px;
   border-left: 1px solid var(--accent-line);

--- a/src/components/Workspace/Draft.css
+++ b/src/components/Workspace/Draft.css
@@ -30,7 +30,7 @@
   font-family: var(--font-serif);
   font-weight: 400;
   letter-spacing: -0.025em;
-  line-height: 1.05;
+  line-height: var(--lh-none);
   font-style: italic;
   color: var(--accent);
   border-bottom: 1px dashed var(--accent-line);
@@ -45,7 +45,7 @@
   letter-spacing: -0.025em;
   color: var(--fg-0);
   margin: 0 0 14px;
-  line-height: 1.05;
+  line-height: var(--lh-none);
   text-align: center;
   font-style: italic;
 }
@@ -54,7 +54,7 @@
   margin: 0 0 32px;
   max-width: 560px;
   text-align: center;
-  line-height: 1.55;
+  line-height: var(--lh-normal);
 }
 .empty-composer {
   width: 100%;

--- a/src/components/Workspace/messages/UserInput/UserInput.css
+++ b/src/components/Workspace/messages/UserInput/UserInput.css
@@ -66,7 +66,7 @@
 
 .q-prompt {
   font-size: var(--fs-base);
-  line-height: 1.6;
+  line-height: var(--lh-relaxed);
   color: var(--fg-0);
   text-wrap: pretty;
 }
@@ -85,7 +85,7 @@
   border: 1px solid var(--bd-soft);
   border-radius: var(--r-md);
   background: var(--bg-1);
-  line-height: 1.55;
+  line-height: var(--lh-normal);
   color: var(--fg-1);
   max-height: 280px;
   overflow: auto;
@@ -227,7 +227,7 @@
 }
 .q-opt-desc {
   font-size: var(--fs-sm);
-  line-height: 1.5;
+  line-height: var(--lh-normal);
   color: var(--fg-2);
   text-wrap: pretty;
 }
@@ -262,7 +262,7 @@
 .q-other-input {
   width: 100%;
   padding: 11px 12px 6px;
-  line-height: 1.55;
+  line-height: var(--lh-normal);
   color: var(--fg-0);
   resize: none;
   min-height: 56px;

--- a/src/styles/foundation/tokens.css
+++ b/src/styles/foundation/tokens.css
@@ -28,6 +28,14 @@
   --fs-4xl: 44px; /* hero */
   --fs-5xl: 56px; /* brand / splash */
 
+  /* line-height — unitless so it inherits as a ratio. (Code editor/gutter
+   * keep their own px line-height for glyph alignment — not on this scale.) */
+  --lh-none: 1; /* single-line UI + tight display titles */
+  --lh-tight: 1.2; /* headings */
+  --lh-snug: 1.4; /* sub-headings, dense multi-line */
+  --lh-normal: 1.5; /* default body */
+  --lh-relaxed: 1.65; /* prose / agent messages */
+
   --r-xs: 4px;
   --r-sm: 6px;
   --r-md: 9px;

--- a/src/styles/shared/banners.css
+++ b/src/styles/shared/banners.css
@@ -141,7 +141,7 @@
   flex-direction: column;
   gap: 2px;
   font-size: var(--fs-base);
-  line-height: 1.4;
+  line-height: var(--lh-snug);
 }
 .update-toast-text strong {
   color: var(--fg-0);


### PR DESCRIPTION
`line-height` had **18 distinct values** across ~40 declarations — clear drift (1.5/1.55, 1.6/1.62/1.65/1.66, 1.12/1.14/1.18/1.2/1.25). Collapsed them onto an unitless scale (unitless so it inherits as a ratio).

| token | value | absorbs |
|---|---|---|
| `--lh-none` | 1 | 1, 1.05 (single-line UI + tight display titles) |
| `--lh-tight` | 1.2 | 1.12, 1.14, 1.18, 1.2, 1.25 (headings) |
| `--lh-snug` | 1.4 | 1.35, 1.4, 1.45 |
| `--lh-normal` | 1.5 | 1.5, 1.55 (body) |
| `--lh-relaxed` | 1.65 | 1.6, 1.62, 1.65, 1.66, 1.7 (prose / agent messages) |

**40 usages snapped**, max shift **0.08** (mostly ≤0.05) — very subtle vertical-rhythm changes.

## Deliberately left alone
The two `line-height: 18px` in the file editor + line-number gutter — those are a **px alignment metric the stacked code layers must share** (not typographic leading), so they stay px and off this scale.

## Note on approach
Used `line-height: var(--lh-*)` in component CSS rather than `.leading-*` utilities (unlike `.text-*`): line-height is coupled to each element's typography in its own rule, and there are few of them. Easy to add utilities later if wanted.

## Verification
- ✅ build + `tsc` clean
- ✅ 317/317 tests pass
- ✅ lint clean (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)