### PR TITLE
style(sidebar): set agent row second-line task text to --fs-sm

### DIFF
--- a/src/styles/shared/badge.css
+++ b/src/styles/shared/badge.css
@@ -52,7 +52,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: var(--fs-base);
+  font-size: var(--fs-sm);
   color: color-mix(in oklch, var(--fg-1), var(--fg-0) 30%);
 }
 .agent-sub .a-task.a-task-draft {


### PR DESCRIPTION
Reduces the font-size of the second line (the task/branch label) in the sidebar agent item from `--fs-base` to `--fs-sm`, bringing it down a tier to better match the supporting metadata on that row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)