### PR TITLE
feat(ui): add Badge primitive + ui/ barrel & README

### DIFF
--- a/src/components/Onboarding/exhibits.tsx
+++ b/src/components/Onboarding/exhibits.tsx
@@ -8,6 +8,7 @@ import type { ProviderId } from "../../data/providers";
 import { PROVIDERS, providerChip } from "../../data/providers";
 import { Icon, LandmarkGlyph } from "../Icon";
 import { ProviderIcon } from "../ProviderIcon";
+import { Badge } from "../ui/Badge";
 
 // ── tiny faux window chrome for an exhibit ──────────────────────────
 function ExBar({ title }: { title: string }) {
@@ -98,7 +99,7 @@ function ExhibitAgentRow({ a }: { a: ParallelAgent }) {
             {!working && a.unseen && (
               <span className="ag-unseen" aria-label="New results to review" />
             )}
-            {a.status === "error" && <span className="ag-badge iflex-center err">error</span>}
+            {a.status === "error" && <Badge variant="err">error</Badge>}
           </span>
           <span className="ag-actions">
             <span className="ag-act iflex-center">

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -10,6 +10,7 @@ import { useMinuteClock } from "../../util/hooks";
 import { Icon } from "../Icon";
 import { ProviderIcon } from "../ProviderIcon";
 import { Mono } from "../SettingsScreen/CustomAgents/Mono";
+import { Badge } from "../ui/Badge";
 import { type AgentStats, AgentStatsPopover } from "./AgentStatsPopover";
 
 /** The agent rows carry nested buttons (stop/archive/discard), so they can't be
@@ -156,7 +157,7 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
                 aria-label="New results to review"
               />
             )}
-            {agent.status === "error" && <span className="ag-badge iflex-center err">error</span>}
+            {agent.status === "error" && <Badge variant="err">error</Badge>}
           </span>
           <span className="ag-actions">
             {stoppable && (
@@ -229,7 +230,7 @@ function DraftRow({ draft, active, onClick }: DraftRowProps) {
         </span>
         <span className="ag-slot iflex-center">
           <span className="ag-meta">
-            <span className="ag-badge iflex-center new">new</span>
+            <Badge variant="new">new</Badge>
           </span>
           <span className="ag-actions">
             <button
@@ -257,20 +258,17 @@ function DraftRow({ draft, active, onClick }: DraftRowProps) {
 function PrBadge({ pr }: { pr: PrState }) {
   if (pr.state === "merged") {
     return (
-      <span className="ag-badge iflex-center pr-merged tip" data-tip={`PR #${pr.number} · merged`}>
+      <Badge variant="pr-merged" tip={`PR #${pr.number} · merged`}>
         <Icon name="merge" size={10} />#{pr.number}
-      </span>
+      </Badge>
     );
   }
-  const cls = pr.state === "closed" ? "pr-closed" : "pr-open";
+  const variant = pr.state === "closed" ? "pr-closed" : "pr-open";
   return (
-    <span
-      className={`ag-badge iflex-center ${cls} tip`}
-      data-tip={`PR #${pr.number} · ${pr.state}`}
-    >
+    <Badge variant={variant} tip={`PR #${pr.number} · ${pr.state}`}>
       <Icon name="pr" size={10} />
       PR
-    </span>
+    </Badge>
   );
 }
 

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from "react";
+
+export type BadgeVariant = "neutral" | "new" | "err" | "pr-open" | "pr-merged" | "pr-closed";
+
+interface Props {
+  children: ReactNode;
+  /** Color/tone. Maps to the `.ag-badge` variants in styles/shared/badge.css. */
+  variant?: BadgeVariant;
+  /** Text for the CSS-only hover tooltip. */
+  tip?: string;
+  className?: string;
+}
+
+/** Compact status pill — agent state (new / error) and PR state (open / merged
+ *  / closed). Non-interactive (renders a <span>); mono + color-coded. Sibling
+ *  of IconButton/Chip. */
+export function Badge({ children, variant = "neutral", tip, className }: Props) {
+  const cls = [
+    "ag-badge",
+    "iflex-center",
+    variant === "neutral" ? "" : variant,
+    tip ? "tip" : "",
+    className ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <span className={cls} data-tip={tip}>
+      {children}
+    </span>
+  );
+}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -20,7 +20,7 @@ export function Badge({ children, variant = "neutral", tip, className }: Props) 
     "iflex-center",
     variant === "neutral" ? "" : variant,
     tip ? "tip" : "",
-    className ?? "",
+    className,
   ]
     .filter(Boolean)
     .join(" ");

--- a/src/components/ui/README.md
+++ b/src/components/ui/README.md
@@ -1,0 +1,27 @@
+# UI primitives
+
+Shared, presentational building blocks. **Reach for these instead of
+re-applying the underlying CSS classes by hand** — it keeps styling consistent
+and is the path of least resistance for new UI.
+
+| Primitive | Use for | Underlying class |
+|---|---|---|
+| `Badge` | Compact status pill — agent state (`new`/`err`) and PR state (`pr-open`/`pr-merged`/`pr-closed`). Non-interactive. | `.ag-badge` |
+| `IconButton` | Square icon-only button (title bar, sidebar, panels). Built-in CSS tooltip via `tip`. | `.btn-i` |
+| `Chip` | Composer footer chip with a text label (model picker, base branch, attach). | `.c-chip` |
+| `Select` | Custom `<select>` replacement (keyboard-operable dropdown of string options). | `.ui-select-*` |
+| `CopyButton` | Copy-to-clipboard affordance with copied-state feedback. | — |
+| `Scrim` | Full-screen dim/click-catcher behind popovers and overlays. | — |
+
+Tooltips are CSS-only: pass `tip="…"` (and `tipDown` where supported) — it sets
+`.tip` + `data-tip` and renders on hover. No JS tooltip library.
+
+## Conventions
+- Each primitive is a thin wrapper: a typed `Props`, a `className` passthrough,
+  and a class-join. Match that shape when adding one.
+- Import directly (`import { Badge } from "../ui/Badge"`) or via the barrel
+  (`import { Badge } from "../ui"`).
+
+## Planned
+- `Button` — text-button CTAs (`.btn-t`: ghost / outline / primary / danger).
+- `Dropdown` — shared menu shell + items (`.dd` / `.dd-item`).

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,12 @@
+// Shared UI primitives. Prefer these over hand-rolling the underlying
+// classes (.ag-badge, .btn-i, .c-chip, …) so styling stays consistent.
+// See ./README.md.
+
+export type { BadgeVariant } from "./Badge";
+export { Badge } from "./Badge";
+export { Chip } from "./Chip";
+export { CopyButton } from "./CopyButton";
+export { IconButton } from "./IconButton";
+export { Scrim } from "./Scrim";
+export type { SelectOption } from "./Select";
+export { Select } from "./Select";


### PR DESCRIPTION
**PR 1 of the shared-primitive series** (issue #257). The goal: stop hand-rolling shared UI (badges, dropdowns, buttons) so styling stays consistent and agents/devs reach for a known component.

## This PR — `<Badge>`
- Adds `ui/Badge.tsx` — `<Badge variant="new|err|pr-open|pr-merged|pr-closed|neutral" tip?>`. Presentational `<span>`, mirrors the `Chip`/`IconButton` shape (typed props + class-join + CSS `tip`).
- Migrates all **5 `.ag-badge` render sites** (4 in `AgentRow`/`PrBadge`, 1 in `exhibits`) to `<Badge>`. No raw `.ag-badge` markup left.
- Adds **`ui/index.ts` barrel + `ui/README.md`** — the discoverability lever: documents each primitive, when to use it, and the "reuse over re-hand-roll" convention.

## Scope decisions
- **`.fp-badge`** (file-status colored letters) left alone — it's a different visual model (tinted filename, not a pill), so folding it into `Badge` would muddy the API.
- Existing imports unchanged; new code can use the barrel or direct paths.

## Verification
- ✅ build + `tsc` clean
- ✅ 317/317 tests pass
- ✅ lint clean (0 errors)
- Visuals identical — `Badge` emits the same classes the markup did.

## Next in the series
- **PR 2 — `<Button>`** (text CTAs: `.btn-t` ghost/outline/primary/danger; ~17 sites).
- **PR 3 — `<Dropdown>`** (the `.dd`/`.dd-item` shell across 7 divergent sites; needs its own design pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)