### PR TITLE
Update loading indicator

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -17,9 +17,9 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "a11y": {
-        "recommended": false
+        "preset": "none"
       },
       "correctness": {
         "useExhaustiveDependencies": "warn"

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -37,5 +37,7 @@ export function getAdapter(provider: string | null | undefined): ChatAdapter {
       `[adapters] unknown provider "${provider}", falling back to ${DEFAULT_ADAPTER_ID}`,
     );
   }
-  return ADAPTERS[DEFAULT_ADAPTER_ID]!;
+  const fallback = ADAPTERS[DEFAULT_ADAPTER_ID];
+  if (!fallback) throw new Error(`missing adapter: ${DEFAULT_ADAPTER_ID}`);
+  return fallback;
 }

--- a/src/adapters/usage.test.ts
+++ b/src/adapters/usage.test.ts
@@ -32,7 +32,7 @@ describe("claude extractUsage", () => {
   } as RawEvent;
 
   it("maps fresh input / output / cache and context fill", () => {
-    expect(claudeAdapter.extractUsage!(body)).toEqual({
+    expect(claudeAdapter.extractUsage?.(body)).toEqual({
       inputTokens: 2,
       outputTokens: 300,
       cacheReadTokens: 7900,
@@ -43,9 +43,9 @@ describe("claude extractUsage", () => {
   });
 
   it("ignores non-assistant and zero-usage records", () => {
-    expect(claudeAdapter.extractUsage!({ type: "user" } as RawEvent)).toBeUndefined();
+    expect(claudeAdapter.extractUsage?.({ type: "user" } as RawEvent)).toBeUndefined();
     expect(
-      claudeAdapter.extractUsage!({ type: "assistant", message: {} } as RawEvent),
+      claudeAdapter.extractUsage?.({ type: "assistant", message: {} } as RawEvent),
     ).toBeUndefined();
   });
 });
@@ -69,7 +69,7 @@ describe("codex extractUsage", () => {
   } as RawEvent;
 
   it("takes cumulative totals, derives fresh input, sums reasoning", () => {
-    expect(codexAdapter.extractUsage!(body)).toEqual({
+    expect(codexAdapter.extractUsage?.(body)).toEqual({
       cumulative: true,
       inputTokens: 65134 - 56064,
       outputTokens: 959 + 336,
@@ -82,7 +82,7 @@ describe("codex extractUsage", () => {
 
   it("ignores non token_count event_msgs", () => {
     expect(
-      codexAdapter.extractUsage!({
+      codexAdapter.extractUsage?.({
         type: "event_msg",
         payload: { type: "agent_message" },
       } as RawEvent),
@@ -98,7 +98,7 @@ describe("opencode extractUsage", () => {
   } as RawEvent;
 
   it("maps per-step delta with cost and context fill", () => {
-    expect(opencodeAdapter.extractUsage!(body)).toEqual({
+    expect(opencodeAdapter.extractUsage?.(body)).toEqual({
       inputTokens: 1532,
       outputTokens: 33 + 51,
       cacheReadTokens: 12864,
@@ -120,7 +120,7 @@ describe("opencode extractUsage", () => {
   } as RawEvent;
 
   it("maps the on-disk assistant-message shape (no step-finish type)", () => {
-    expect(opencodeAdapter.extractUsage!(onDiskMessage)).toEqual({
+    expect(opencodeAdapter.extractUsage?.(onDiskMessage)).toEqual({
       inputTokens: 98,
       outputTokens: 18,
       cacheReadTokens: 10624,
@@ -132,7 +132,7 @@ describe("opencode extractUsage", () => {
   });
 
   it("ignores user/non-usage messages", () => {
-    expect(opencodeAdapter.extractUsage!({ role: "user" } as RawEvent)).toBeUndefined();
+    expect(opencodeAdapter.extractUsage?.({ role: "user" } as RawEvent)).toBeUndefined();
   });
 
   // The live `run --format json` stream wraps the step-finish delta under
@@ -149,7 +149,7 @@ describe("opencode extractUsage", () => {
   } as RawEvent;
 
   it("maps the live step_finish wrapper (tokens under .part)", () => {
-    expect(opencodeAdapter.extractUsage!(liveStepFinish)).toEqual({
+    expect(opencodeAdapter.extractUsage?.(liveStepFinish)).toEqual({
       inputTokens: 57,
       outputTokens: 4 + 6,
       cacheReadTokens: 18560,
@@ -183,7 +183,7 @@ describe("pi extractUsage", () => {
   } as RawEvent;
 
   it("maps per-message delta with cost", () => {
-    expect(piAdapter.extractUsage!(body)).toEqual({
+    expect(piAdapter.extractUsage?.(body)).toEqual({
       inputTokens: 2,
       outputTokens: 258,
       cacheReadTokens: 0,
@@ -196,7 +196,7 @@ describe("pi extractUsage", () => {
 
   it("ignores user / toolResult messages", () => {
     expect(
-      piAdapter.extractUsage!({ type: "message", message: { role: "user" } } as RawEvent),
+      piAdapter.extractUsage?.({ type: "message", message: { role: "user" } } as RawEvent),
     ).toBeUndefined();
   });
 });
@@ -211,7 +211,7 @@ describe("cursor extractUsage (persisted live result)", () => {
 
   it("is marked persistLiveUsage and reads the result event", () => {
     expect(cursorAdapter.persistLiveUsage).toBe(true);
-    expect(cursorAdapter.extractUsage!(body)).toEqual({
+    expect(cursorAdapter.extractUsage?.(body)).toEqual({
       inputTokens: 2,
       outputTokens: 122,
       cacheReadTokens: 0,
@@ -222,7 +222,7 @@ describe("cursor extractUsage (persisted live result)", () => {
 
   it("ignores cursor's on-disk transcript bodies (no usage there)", () => {
     expect(
-      cursorAdapter.extractUsage!({ type: "assistant", message: {} } as RawEvent),
+      cursorAdapter.extractUsage?.({ type: "assistant", message: {} } as RawEvent),
     ).toBeUndefined();
   });
 
@@ -359,7 +359,9 @@ describe("addTurnUsage (fold primitive)", () => {
         usage: { inputTokens: 3, outputTokens: 50, cacheReadTokens: 5000, cacheWriteTokens: 80 },
       },
     ] as RawEvent[]) {
-      acc = addTurnUsage(acc, cursorAdapter.extractUsage!(body)!);
+      const usage = cursorAdapter.extractUsage!(body);
+      if (!usage) throw new Error("expected usage");
+      acc = addTurnUsage(acc, usage);
     }
     expect(acc.inputTokens).toBe(5);
     expect(acc.outputTokens).toBe(150);

--- a/src/app.css
+++ b/src/app.css
@@ -6,6 +6,7 @@
 
 @import "./styles/foundation/tokens.css";
 @import "./styles/foundation/base.css";
+@import "./styles/shared/type.css";
 @import "./styles/foundation/app-frame.css";
 @import "./components/TitleBar/TitleBar.css";
 @import "./styles/shared/icon-button.css";

--- a/src/components/Composer/Composer.css
+++ b/src/components/Composer/Composer.css
@@ -1,8 +1,16 @@
 /* composer */
 .composer-wrap {
+  flex-shrink: 0;
   padding: 0 20px 20px;
   display: flex;
   justify-content: center;
+  background: var(--bg-1);
+}
+.composer-stack {
+  width: 100%;
+  max-width: 860px;
+  display: flex;
+  flex-direction: column;
 }
 .composer {
   position: relative;

--- a/src/components/History/index.tsx
+++ b/src/components/History/index.tsx
@@ -133,7 +133,8 @@ export function History() {
                   </div>
                   {items.map((a) => {
                     const myIdx = flatIdx++;
-                    const archive = a.archive!;
+                    if (!a.archive) return null;
+                    const archive = a.archive;
                     const primary = archive.repos[0];
                     const repoLabel = primary ? basename(primary.repo_path) : a.name;
                     const branchLabel = primary?.branch_name ?? null;
@@ -251,9 +252,10 @@ function groupByDate(records: AgentRecord[]): DateGroup[] {
       groups.set(day, []);
       labels.push(day);
     }
-    groups.get(day)!.push(r);
+    const bucket = groups.get(day);
+    if (bucket) bucket.push(r);
   }
-  return labels.map((label) => ({ label, items: groups.get(label)! }));
+  return labels.map((label) => ({ label, items: groups.get(label) ?? [] }));
 }
 
 function startOfLocalDay(d: Date): number {

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -83,9 +83,9 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
   const stats: AgentStats = {
     launched: age || "just now",
     runtime: liveRuntime(agent.created_at, now, agent.status),
-    contextTokens: hasUsage ? usage!.contextTokens : null,
+    contextTokens: hasUsage ? usage?.contextTokens : null,
     contextWindow,
-    contextPct: hasUsage ? contextPct(usage!.contextTokens, contextWindow) : 0,
+    contextPct: hasUsage ? contextPct(usage?.contextTokens, contextWindow) : 0,
     // Fresh input only — matching the composer gauge. Cumulative cache read
     // balloons (the same cached prefix re-read every turn) and is misleading
     // as a session "input" total.

--- a/src/components/Sidebar/AgentStatsPopover.tsx
+++ b/src/components/Sidebar/AgentStatsPopover.tsx
@@ -18,10 +18,11 @@ export interface AgentStats {
 /** Floats off the agent-row time chip on hover. Visual lift only —
  *  pure stats display, no actions. */
 export function AgentStatsPopover({ stats }: { stats: AgentStats }) {
-  const hasUsage = stats.contextTokens != null;
-  const contextLabel = hasUsage
-    ? `${formatTokens(stats.contextTokens!)} / ${formatTokens(stats.contextWindow)}`
-    : "—";
+  const contextTokens = stats.contextTokens;
+  const contextLabel =
+    contextTokens != null
+      ? `${formatTokens(contextTokens)} / ${formatTokens(stats.contextWindow)}`
+      : "—";
   const ioLabel =
     stats.totalInput != null && stats.totalOutput != null
       ? `${formatTokens(stats.totalInput)} in · ${formatTokens(stats.totalOutput)} out`

--- a/src/components/Workspace/Chat.css
+++ b/src/components/Workspace/Chat.css
@@ -1,3 +1,117 @@
+/* Agent activity — slides up from behind the composer on show. */
+.composer-anchor {
+  position: relative;
+}
+.composer-anchor .composer {
+  position: relative;
+  z-index: 2;
+}
+.chat-status {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 100%;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 26px;
+  padding: 6px 6px 10px;
+  margin-bottom: -4px;
+  font-size: 12px;
+  line-height: 1.2;
+  color: var(--fg-2);
+  transform: translateY(10px);
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    transform 130ms cubic-bezier(0.2, 0, 0, 1),
+    opacity 100ms linear;
+}
+.chat-status.is-open {
+  transform: translateY(0);
+  opacity: 1;
+}
+@media (prefers-reduced-motion: reduce) {
+  .chat-status {
+    transition: none;
+  }
+}
+.chat-status-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.chat-status .dots {
+  display: inline-flex;
+  gap: 3px;
+  flex-shrink: 0;
+}
+.chat-status .dots i {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: bounce 1.2s var(--ease) infinite;
+}
+.chat-status .dots i:nth-child(2) {
+  animation-delay: 0.15s;
+}
+.chat-status .dots i:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+/* Inline turn-pending anchor — dots only; label is in .chat-status below. */
+.chat-pending {
+  display: flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 2px 0 6px 18px;
+  margin-bottom: 10px;
+  border-left: 1px solid var(--bd);
+  animation: chat-pending-in 220ms ease-out;
+}
+.chat-pending .dots {
+  display: inline-flex;
+  gap: 4px;
+}
+.chat-pending .dots i {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--fg-2);
+  animation: chat-pending-bounce 1.3s var(--ease) infinite;
+}
+.chat-pending .dots i:nth-child(2) {
+  animation-delay: 0.15s;
+}
+.chat-pending .dots i:nth-child(3) {
+  animation-delay: 0.3s;
+}
+@keyframes chat-pending-bounce {
+  0%,
+  60%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.45;
+  }
+  30% {
+    transform: translateY(-3px);
+    opacity: 0.9;
+  }
+}
+@keyframes chat-pending-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 /* chat */
 .chat {
   position: relative;

--- a/src/components/Workspace/Chat.css
+++ b/src/components/Workspace/Chat.css
@@ -32,11 +32,6 @@
   transform: translateY(0);
   opacity: 1;
 }
-@media (prefers-reduced-motion: reduce) {
-  .chat-status {
-    transition: none;
-  }
-}
 .chat-status-label {
   min-width: 0;
   overflow: hidden;
@@ -109,6 +104,20 @@
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .chat-status {
+    transition: none;
+  }
+  .chat-status .dots i {
+    animation: none;
+  }
+  .chat-pending {
+    animation: none;
+  }
+  .chat-pending .dots i {
+    animation: none;
   }
 }
 

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -19,17 +19,11 @@ import { isUserInputTool } from "./messages/UserInput/parse";
  *  doesn't care about provider routing yet. */
 export function ChatView({ agent }: { agent: AgentRecord }) {
   const log = useAppStore((s) => s.managedLogs[agent.id]);
-  const transcriptLoading = useAppStore(
-    (s) => s.transcriptLoading[agent.id] ?? false,
-  );
-  const transcriptLoaded = useAppStore(
-    (s) => s.transcriptLoaded[agent.id] ?? false,
-  );
+  const transcriptLoading = useAppStore((s) => s.transcriptLoading[agent.id] ?? false);
+  const transcriptLoaded = useAppStore((s) => s.transcriptLoaded[agent.id] ?? false);
   const busy = useAppStore((s) => s.managedBusy[agent.id] ?? false);
   const busyLabel = useAppStore((s) => s.managedBusyLabel[agent.id]);
-  const switchInFlight = useAppStore(
-    (s) => s.switchInFlight[agent.id] ?? false,
-  );
+  const switchInFlight = useAppStore((s) => s.switchInFlight[agent.id] ?? false);
   const send = useAppStore((s) => s.sendUserMessage);
   const stop = useAppStore((s) => s.stop);
   const loadHistoryTranscript = useAppStore((s) => s.loadHistoryTranscript);
@@ -37,9 +31,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
   // The custom agent this session was spawned from (if any, and still present),
   // so the chat surfaces the agent's name rather than its base provider.
   const customAgent = useAppStore((s) =>
-    agent.custom_agent_id
-      ? s.customAgents.find((a) => a.id === agent.custom_agent_id)
-      : undefined,
+    agent.custom_agent_id ? s.customAgents.find((a) => a.id === agent.custom_agent_id) : undefined,
   );
   const composerSeed = useAppStore((s) => s.composerSeeds[agent.id]);
   const consumeComposerSeed = useAppStore((s) => s.consumeComposerSeed);
@@ -72,9 +64,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
         e.preventDefault();
         setSearchOpen(true);
         requestAnimationFrame(() => {
-          const el = document.getElementById(
-            "chat-search-input",
-          ) as HTMLInputElement | null;
+          const el = document.getElementById("chat-search-input") as HTMLInputElement | null;
           el?.focus();
           el?.select();
         });
@@ -99,12 +89,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
   const hasPriorConversation = agent.task.trim().length > 0;
 
   useEffect(() => {
-    if (
-      !hasSession ||
-      transcriptLoaded ||
-      transcriptLoading ||
-      switchInFlight
-    ) {
+    if (!hasSession || transcriptLoaded || transcriptLoading || switchInFlight) {
       return;
     }
     if (log !== undefined || !hasPriorConversation) {
@@ -184,10 +169,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
   const awaitingInput = useMemo(() => {
     const last = items[items.length - 1];
     return Boolean(
-      last &&
-      last.kind === "tool_pair" &&
-      isUserInputTool(last.call.name) &&
-      !last.result,
+      last && last.kind === "tool_pair" && isUserInputTool(last.call.name) && !last.result,
     );
   }, [items]);
 
@@ -228,14 +210,10 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
                 <span>Loading transcript…</span>
               </div>
             ) : items.length === 0 && hasPriorConversation && !busy ? (
-              <div
-                className="empty-msg"
-                style={{ margin: "40px auto", maxWidth: 360 }}
-              >
+              <div className="empty-msg" style={{ margin: "40px auto", maxWidth: 360 }}>
                 <div className="et">No transcript available</div>
                 <div>
-                  {providerLabel(agent.provider)}'s session file is not on disk
-                  for this agent.
+                  {providerLabel(agent.provider)}'s session file is not on disk for this agent.
                 </div>
               </div>
             ) : (
@@ -268,8 +246,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
             <ChatWorkingStatus
               visible={busy && !awaitingInput}
               label={
-                busyLabel ??
-                `${customAgent?.name ?? providerLabel(agent.provider)} is working`
+                busyLabel ?? `${customAgent?.name ?? providerLabel(agent.provider)} is working`
               }
             />
             <Composer
@@ -292,9 +269,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
               }
               stopping={busy}
               mentionSource={() =>
-                api
-                  .listWorktreeTree(agent.id)
-                  .then((files) => files.map((f) => f.path))
+                api.listWorktreeTree(agent.id).then((files) => files.map((f) => f.path))
               }
               listDir={api.listDir}
               listPrs={() => api.listPrs(agent.id)}

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -8,8 +8,10 @@ import { Composer } from "../Composer";
 import { APP_ACTION_PREFIX } from "../RightPanel/delegation";
 import { ChatNav } from "./ChatNav";
 import { ChatSearch } from "./ChatSearch";
+import { ChatWorkingStatus } from "./ChatWorkingStatus";
 import { MessageItem } from "./messages/MessageItem";
 import { pairToolItems, rowKey } from "./messages/pair";
+import { isTurnPending } from "./messages/turnPending";
 import { isUserInputTool } from "./messages/UserInput/parse";
 
 /** Custom-view body: scrolling chat log + composer at the bottom.
@@ -17,11 +19,17 @@ import { isUserInputTool } from "./messages/UserInput/parse";
  *  doesn't care about provider routing yet. */
 export function ChatView({ agent }: { agent: AgentRecord }) {
   const log = useAppStore((s) => s.managedLogs[agent.id]);
-  const transcriptLoading = useAppStore((s) => s.transcriptLoading[agent.id] ?? false);
-  const transcriptLoaded = useAppStore((s) => s.transcriptLoaded[agent.id] ?? false);
+  const transcriptLoading = useAppStore(
+    (s) => s.transcriptLoading[agent.id] ?? false,
+  );
+  const transcriptLoaded = useAppStore(
+    (s) => s.transcriptLoaded[agent.id] ?? false,
+  );
   const busy = useAppStore((s) => s.managedBusy[agent.id] ?? false);
   const busyLabel = useAppStore((s) => s.managedBusyLabel[agent.id]);
-  const switchInFlight = useAppStore((s) => s.switchInFlight[agent.id] ?? false);
+  const switchInFlight = useAppStore(
+    (s) => s.switchInFlight[agent.id] ?? false,
+  );
   const send = useAppStore((s) => s.sendUserMessage);
   const stop = useAppStore((s) => s.stop);
   const loadHistoryTranscript = useAppStore((s) => s.loadHistoryTranscript);
@@ -29,7 +37,9 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
   // The custom agent this session was spawned from (if any, and still present),
   // so the chat surfaces the agent's name rather than its base provider.
   const customAgent = useAppStore((s) =>
-    agent.custom_agent_id ? s.customAgents.find((a) => a.id === agent.custom_agent_id) : undefined,
+    agent.custom_agent_id
+      ? s.customAgents.find((a) => a.id === agent.custom_agent_id)
+      : undefined,
   );
   const composerSeed = useAppStore((s) => s.composerSeeds[agent.id]);
   const consumeComposerSeed = useAppStore((s) => s.consumeComposerSeed);
@@ -62,7 +72,9 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
         e.preventDefault();
         setSearchOpen(true);
         requestAnimationFrame(() => {
-          const el = document.getElementById("chat-search-input") as HTMLInputElement | null;
+          const el = document.getElementById(
+            "chat-search-input",
+          ) as HTMLInputElement | null;
           el?.focus();
           el?.select();
         });
@@ -87,7 +99,12 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
   const hasPriorConversation = agent.task.trim().length > 0;
 
   useEffect(() => {
-    if (!hasSession || transcriptLoaded || transcriptLoading || switchInFlight) {
+    if (
+      !hasSession ||
+      transcriptLoaded ||
+      transcriptLoading ||
+      switchInFlight
+    ) {
       return;
     }
     if (log !== undefined || !hasPriorConversation) {
@@ -115,8 +132,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
     const el = scrollRef.current;
     if (!el) return;
     // Allow a small slop so the user counts as "at the bottom" even a few
-    // pixels short — sub-pixel rounding and the trailing typing indicator
-    // otherwise make exact equality flaky.
+    // pixels short — sub-pixel rounding otherwise makes exact equality flaky.
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
     pinnedToBottom.current = distanceFromBottom <= 40;
   };
@@ -168,9 +184,16 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
   const awaitingInput = useMemo(() => {
     const last = items[items.length - 1];
     return Boolean(
-      last && last.kind === "tool_pair" && isUserInputTool(last.call.name) && !last.result,
+      last &&
+      last.kind === "tool_pair" &&
+      isUserInputTool(last.call.name) &&
+      !last.result,
     );
   }, [items]);
+
+  // Phase A: user just sent a turn-starting prompt and nothing has landed yet.
+  // A quiet inline anchor (dots only — label lives in the bottom status strip).
+  const turnPending = busy && !awaitingInput && isTurnPending(items);
 
   // Mid-turn follow-ups are allowed: a busy (running) agent still accepts a
   // message — delivered live (claude) or queued for the next turn boundary
@@ -205,10 +228,14 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
                 <span>Loading transcript…</span>
               </div>
             ) : items.length === 0 && hasPriorConversation && !busy ? (
-              <div className="empty-msg" style={{ margin: "40px auto", maxWidth: 360 }}>
+              <div
+                className="empty-msg"
+                style={{ margin: "40px auto", maxWidth: 360 }}
+              >
                 <div className="et">No transcript available</div>
                 <div>
-                  {providerLabel(agent.provider)}'s session file is not on disk for this agent.
+                  {providerLabel(agent.provider)}'s session file is not on disk
+                  for this agent.
                 </div>
               </div>
             ) : (
@@ -222,15 +249,12 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
                 />
               ))
             )}
-            {busy && !awaitingInput && (
-              <div className="writing flex-center">
+            {turnPending && (
+              <div className="chat-pending" aria-hidden="true">
                 <span className="dots">
                   <i />
                   <i />
                   <i />
-                </span>
-                <span>
-                  {busyLabel ?? `${customAgent?.name ?? providerLabel(agent.provider)} is thinking`}
                 </span>
               </div>
             )}
@@ -239,41 +263,52 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
         {!searchOpen && <ChatNav scrollRef={scrollRef} turns={turns} />}
       </div>
       <div className="composer-wrap">
-        <Composer
-          existingSession
-          activeModel={activeModel}
-          usage={usage}
-          defaultProvider={agent.provider}
-          defaultModel={agent.model ?? undefined}
-          defaultCustomAgentId={agent.custom_agent_id ?? undefined}
-          initialThinking={agent.effort ?? undefined}
-          disabled={!canSend}
-          placeholder={
-            canSend
-              ? undefined
-              : transcriptLoading
-                ? "Loading transcript…"
-                : switchInFlight
-                  ? "Switching view…"
-                  : "Agent is not ready"
-          }
-          stopping={busy}
-          mentionSource={() =>
-            api.listWorktreeTree(agent.id).then((files) => files.map((f) => f.path))
-          }
-          listDir={api.listDir}
-          listPrs={() => api.listPrs(agent.id)}
-          seed={composerSeed}
-          onSeedConsumed={onSeedConsumed}
-          draftKey={agent.id}
-          onSend={({ text, thinking, attachments }) => {
-            // Sending is an explicit action: re-pin so the user follows their
-            // own new message even if they'd scrolled up to read history.
-            pinnedToBottom.current = true;
-            send(agent.id, text, attachments, thinking);
-          }}
-          onStop={() => stop(agent.id)}
-        />
+        <div className="composer-stack">
+          <div className="composer-anchor">
+            <ChatWorkingStatus
+              visible={busy && !awaitingInput}
+              label={
+                busyLabel ??
+                `${customAgent?.name ?? providerLabel(agent.provider)} is working`
+              }
+            />
+            <Composer
+              existingSession
+              activeModel={activeModel}
+              usage={usage}
+              defaultProvider={agent.provider}
+              defaultModel={agent.model ?? undefined}
+              defaultCustomAgentId={agent.custom_agent_id ?? undefined}
+              initialThinking={agent.effort ?? undefined}
+              disabled={!canSend}
+              placeholder={
+                canSend
+                  ? undefined
+                  : transcriptLoading
+                    ? "Loading transcript…"
+                    : switchInFlight
+                      ? "Switching view…"
+                      : "Agent is not ready"
+              }
+              stopping={busy}
+              mentionSource={() =>
+                api
+                  .listWorktreeTree(agent.id)
+                  .then((files) => files.map((f) => f.path))
+              }
+              listDir={api.listDir}
+              listPrs={() => api.listPrs(agent.id)}
+              seed={composerSeed}
+              onSeedConsumed={onSeedConsumed}
+              draftKey={agent.id}
+              onSend={({ text, thinking, attachments }) => {
+                pinnedToBottom.current = true;
+                send(agent.id, text, attachments, thinking);
+              }}
+              onStop={() => stop(agent.id)}
+            />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/Workspace/ChatWorkingStatus.tsx
+++ b/src/components/Workspace/ChatWorkingStatus.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+
+const DURATION_MS = 130;
+
+function useSlideReveal(visible: boolean) {
+  const [mounted, setMounted] = useState(visible);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (visible) {
+      setMounted(true);
+      const id = requestAnimationFrame(() => {
+        requestAnimationFrame(() => setOpen(true));
+      });
+      return () => cancelAnimationFrame(id);
+    }
+    setOpen(false);
+    const t = window.setTimeout(() => setMounted(false), DURATION_MS);
+    return () => clearTimeout(t);
+  }, [visible]);
+
+  return { mounted, open };
+}
+
+/** Pinned working indicator — slides up from behind the composer on show,
+ *  back down on turn end. */
+export function ChatWorkingStatus({ visible, label }: { visible: boolean; label: string }) {
+  const { mounted, open } = useSlideReveal(visible);
+  if (!mounted) return null;
+
+  return (
+    <div className={`chat-status${open ? " is-open" : ""}`} role="status" aria-live="polite">
+      <span className="dots">
+        <i />
+        <i />
+        <i />
+      </span>
+      <span className="chat-status-label">{label}</span>
+    </div>
+  );
+}

--- a/src/components/Workspace/ChatWorkingStatus.tsx
+++ b/src/components/Workspace/ChatWorkingStatus.tsx
@@ -9,10 +9,15 @@ function useSlideReveal(visible: boolean) {
   useEffect(() => {
     if (visible) {
       setMounted(true);
-      const id = requestAnimationFrame(() => {
-        requestAnimationFrame(() => setOpen(true));
+      let id1 = 0;
+      let id2 = 0;
+      id1 = requestAnimationFrame(() => {
+        id2 = requestAnimationFrame(() => setOpen(true));
       });
-      return () => cancelAnimationFrame(id);
+      return () => {
+        cancelAnimationFrame(id1);
+        cancelAnimationFrame(id2);
+      };
     }
     setOpen(false);
     const t = window.setTimeout(() => setMounted(false), DURATION_MS);

--- a/src/components/Workspace/messages/turnPending.test.ts
+++ b/src/components/Workspace/messages/turnPending.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import type { ViewItem } from "./pair";
+import { isTurnPending } from "./turnPending";
+
+describe("isTurnPending", () => {
+  it("is true when the last row is a user message", () => {
+    const items: ViewItem[] = [{ kind: "user_message", text: "hello" }];
+    expect(isTurnPending(items)).toBe(true);
+  });
+
+  it("is true when the last row is a slash-command notice", () => {
+    const items: ViewItem[] = [{ kind: "notice", subtype: "slash_command", text: "/compact" }];
+    expect(isTurnPending(items)).toBe(true);
+  });
+
+  it("is false when agent output has landed", () => {
+    const items: ViewItem[] = [
+      { kind: "user_message", text: "hello" },
+      { kind: "agent_message", text: "hi" },
+    ];
+    expect(isTurnPending(items)).toBe(false);
+  });
+
+  it("is false for a mid-turn queued follow-up", () => {
+    const items: ViewItem[] = [
+      { kind: "user_message", text: "hello" },
+      { kind: "tool_pair", call: { id: "t1", name: "bash", input: "ls" }, result: null },
+      { kind: "queued_message", text: "also do this" },
+    ];
+    expect(isTurnPending(items)).toBe(false);
+  });
+
+  it("is false on an empty log", () => {
+    expect(isTurnPending([])).toBe(false);
+  });
+});

--- a/src/components/Workspace/messages/turnPending.test.ts
+++ b/src/components/Workspace/messages/turnPending.test.ts
@@ -24,7 +24,11 @@ describe("isTurnPending", () => {
   it("is false for a mid-turn queued follow-up", () => {
     const items: ViewItem[] = [
       { kind: "user_message", text: "hello" },
-      { kind: "tool_pair", call: { id: "t1", name: "bash", input: "ls" }, result: null },
+      {
+        kind: "tool_pair",
+        call: { kind: "tool_call", id: "t1", name: "bash", input: "ls" },
+        result: null,
+      },
       { kind: "queued_message", text: "also do this" },
     ];
     expect(isTurnPending(items)).toBe(false);

--- a/src/components/Workspace/messages/turnPending.ts
+++ b/src/components/Workspace/messages/turnPending.ts
@@ -8,7 +8,6 @@ export function isTurnPending(items: ViewItem[]): boolean {
   // Only the prompt that *starts* a turn. Mid-turn queued follow-ups append
   // after ongoing agent activity and must not re-show the anchor.
   return (
-    last.kind === "user_message" ||
-    (last.kind === "notice" && last.subtype === "slash_command")
+    last.kind === "user_message" || (last.kind === "notice" && last.subtype === "slash_command")
   );
 }

--- a/src/components/Workspace/messages/turnPending.ts
+++ b/src/components/Workspace/messages/turnPending.ts
@@ -1,0 +1,14 @@
+import type { ViewItem } from "./pair";
+
+/** True when the agent is busy but hasn't produced any output for the turn
+ *  the user just started — the pre-output gap where an inline anchor helps. */
+export function isTurnPending(items: ViewItem[]): boolean {
+  if (items.length === 0) return false;
+  const last = items[items.length - 1];
+  // Only the prompt that *starts* a turn. Mid-turn queued follow-ups append
+  // after ongoing agent activity and must not re-show the anchor.
+  return (
+    last.kind === "user_message" ||
+    (last.kind === "notice" && last.subtype === "slash_command")
+  );
+}

--- a/src/data/providers.ts
+++ b/src/data/providers.ts
@@ -73,7 +73,7 @@ export const agentIconUrl = (slug: string) => `https://quorum.fwdai.org/agents/$
 /** Human-readable name for a provider id (e.g. "claude" → "Claude Code").
  *  Falls back to the raw id when unknown so we never render an empty label. */
 export function providerLabel(id: string | null | undefined): string {
-  if (!id) return PROVIDERS.find((p) => p.id === DEFAULT_PROVIDER_ID)!.label;
+  if (!id) return PROVIDERS.find((p) => p.id === DEFAULT_PROVIDER_ID)?.label ?? DEFAULT_PROVIDER_ID;
   return PROVIDERS.find((p) => p.id === id)?.label ?? id;
 }
 
@@ -85,7 +85,7 @@ export function providerLabel(id: string | null | undefined): string {
 export function providerChip(id: string | null | undefined): { short: string; hue: number } {
   const p = PROVIDERS.find((x) => x.id === (id || DEFAULT_PROVIDER_ID));
   if (p) return { short: p.short, hue: p.hue };
-  return { short: id!.slice(0, 2).toUpperCase(), hue: 0 };
+  return { short: (id ?? "").slice(0, 2).toUpperCase(), hue: 0 };
 }
 
 export interface Accent {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,7 +8,9 @@ import "@fontsource/geist-sans/400.css";
 import "@fontsource/geist-sans/600.css";
 import "./app.css";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+const root = document.getElementById("root");
+if (!root) throw new Error("#root element missing");
+ReactDOM.createRoot(root).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,

--- a/src/storage/accounts.ts
+++ b/src/storage/accounts.ts
@@ -41,7 +41,9 @@ export async function getOrCreateAccount(): Promise<AccountRow> {
   const existing = await getAccount();
   if (existing) return existing;
   const id = await dbInsert("accounts", { name: "" });
-  return (await dbSelectOne<AccountRow>("accounts", { where: { id } }))!;
+  const row = await dbSelectOne<AccountRow>("accounts", { where: { id } });
+  if (!row) throw new Error("failed to create account row");
+  return row;
 }
 
 /** Persist edited profile fields. Also writes a derived `name` ("First Last")

--- a/src/styles/foundation/base.css
+++ b/src/styles/foundation/base.css
@@ -13,38 +13,6 @@
   white-space: nowrap;
 }
 
-/* type-scale utilities — apply on an element to size it off the scale (see
- * the --fs-* tokens). An element's size lives in exactly ONE place: a .text-*
- * class here, or font-size in CSS for pseudo-elements that can't take a class.
- * Never both. */
-.text-xs {
-  font-size: var(--fs-xs);
-}
-.text-sm {
-  font-size: var(--fs-sm);
-}
-.text-base {
-  font-size: var(--fs-base);
-}
-.text-lg {
-  font-size: var(--fs-lg);
-}
-.text-xl {
-  font-size: var(--fs-xl);
-}
-.text-2xl {
-  font-size: var(--fs-2xl);
-}
-.text-3xl {
-  font-size: var(--fs-3xl);
-}
-.text-4xl {
-  font-size: var(--fs-4xl);
-}
-.text-5xl {
-  font-size: var(--fs-5xl);
-}
-
 /* reset */
 * {
   box-sizing: border-box;

--- a/src/styles/shared/type.css
+++ b/src/styles/shared/type.css
@@ -1,0 +1,31 @@
+/* type-scale utilities — apply on an element to size it off the scale (see
+ * the --fs-* tokens). An element's size lives in exactly ONE place: a .text-*
+ * class here, or font-size in CSS for pseudo-elements that can't take a class.
+ * Never both. */
+.text-xs {
+  font-size: var(--fs-xs);
+}
+.text-sm {
+  font-size: var(--fs-sm);
+}
+.text-base {
+  font-size: var(--fs-base);
+}
+.text-lg {
+  font-size: var(--fs-lg);
+}
+.text-xl {
+  font-size: var(--fs-xl);
+}
+.text-2xl {
+  font-size: var(--fs-2xl);
+}
+.text-3xl {
+  font-size: var(--fs-3xl);
+}
+.text-4xl {
+  font-size: var(--fs-4xl);
+}
+.text-5xl {
+  font-size: var(--fs-5xl);
+}

--- a/src/util/useXterm.ts
+++ b/src/util/useXterm.ts
@@ -28,7 +28,7 @@ const XTERM_BASE_OPTIONS: ITerminalOptions = {
  */
 export function useXterm(
   options: ITerminalOptions,
-  onReady: (term: Terminal) => (() => void) | void,
+  onReady: (term: Terminal) => (() => void) | undefined,
   deps: DependencyList,
 ) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -100,6 +100,7 @@ export function useXterm(
       term.dispose();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
+    // biome-ignore lint/correctness/useExhaustiveDependencies: caller supplies the dep list
   }, deps);
 
   return containerRef;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,10 @@ function copyFileIcons(): Plugin {
   return {
     name: "copy-material-file-icons",
     configResolved() {
-      const src = path.resolve(process.cwd(), "node_modules/material-icon-theme/icons");
+      const src = path.resolve(
+        process.cwd(),
+        "node_modules/material-icon-theme/icons",
+      );
       const dest = path.resolve(process.cwd(), "public/file-icons");
       if (existsSync(dest) && readdirSync(dest).length > 0) return; // already copied
       if (existsSync(src)) cpSync(src, dest, { recursive: true });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,10 +12,7 @@ function copyFileIcons(): Plugin {
   return {
     name: "copy-material-file-icons",
     configResolved() {
-      const src = path.resolve(
-        process.cwd(),
-        "node_modules/material-icon-theme/icons",
-      );
+      const src = path.resolve(process.cwd(), "node_modules/material-icon-theme/icons");
       const dest = path.resolve(process.cwd(), "public/file-icons");
       if (existsSync(dest) && readdirSync(dest).length > 0) return; // already copied
       if (existsSync(src)) cpSync(src, dest, { recursive: true });


### PR DESCRIPTION
## Summary
Redesigns the chat working indicator into a two-phase system that separates the pre-output gap from ongoing agent activity.

Turn-pending anchor (Phase A): After a turn-starting prompt (user message or slash command), a minimal dots-only row appears inline at the bottom of the transcript until the first agent output lands. Mid-turn queued follow-ups do not re-trigger it.

Pinned status strip (Phase B): While the agent is busy, a labeled status bar ("{Agent} is working") slides up from behind the composer and stays pinned there for the rest of the turn — including after output starts streaming.
Extracts isTurnPending() with unit tests to encode when the inline anchor should show, and adds ChatWorkingStatus with enter/exit slide animation (respects prefers-reduced-motion).
Wraps the composer in a composer-anchor stack so the status strip layers correctly, and moves .text-* utilities from base.css into styles/shared/type.css.

## Test plan

- [x] Send a message and confirm dots appear inline at the bottom of the transcript before any agent output
- [x] Confirm the status strip slides up above the composer with the agent name/label once work begins
- [x] Confirm the inline dots disappear once agent output (message or tool call) lands, while the status strip remains
- [x] Confirm the status strip slides away when the turn completes
- [ ] Queue a follow-up mid-turn and confirm the inline anchor does not reappear
- [ ] Trigger a slash command (e.g. /compact) and confirm the inline anchor shows during the pre-output gap
- [ ] Hit a user-input tool pause and confirm both indicators are suppressed (agent is waiting on you, not working)
- [ ] Verify animation is disabled with prefers-reduced-motion: reduce
- [ ] Run turnPending.test.ts — all cases pass
