### PR TITLE
feat(ui): add Button primitive, migrate .btn-t text buttons

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -3,6 +3,7 @@
 // pane and offers a reset, so the rest of the app keeps working. Keying the
 // boundary (e.g. by agent id) makes switching agents reset it automatically.
 import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Button } from "./ui/Button";
 
 interface Props {
   children: ReactNode;
@@ -39,9 +40,9 @@ export class ErrorBoundary extends Component<Props, State> {
             Something went wrong{this.props.label ? ` in ${this.props.label}` : ""}.
           </div>
           <div className="err-boundary-msg">{error.message || String(error)}</div>
-          <button type="button" className="btn-t iflex-center outline" onClick={this.reset}>
+          <Button variant="outline" onClick={this.reset}>
             Try again
-          </button>
+          </Button>
         </div>
       </div>
     );

--- a/src/components/Onboarding/OnboardingReadiness.tsx
+++ b/src/components/Onboarding/OnboardingReadiness.tsx
@@ -14,6 +14,7 @@ import { PROVIDERS } from "../../data/providers";
 import { useAppStore } from "../../store";
 import { Icon } from "../Icon";
 import { ProviderIcon } from "../ProviderIcon";
+import { Button } from "../ui/Button";
 
 type S = "ok" | "warn" | "bad" | "checking";
 
@@ -130,15 +131,10 @@ export function OnboardingReadiness() {
               ? `${detected} of ${agents.length} agents detected`
               : "couldn't detect agents"}
         </span>
-        <button
-          type="button"
-          className="btn-t iflex-center outline"
-          onClick={recheck}
-          disabled={checking}
-        >
+        <Button variant="outline" onClick={recheck} disabled={checking}>
           <Icon name="refresh" size={11} />
           {checking ? "checking…" : "re-check"}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/components/ProviderReadiness/index.tsx
+++ b/src/components/ProviderReadiness/index.tsx
@@ -16,6 +16,7 @@ import { PROVIDERS } from "../../data/providers";
 import { useAppStore } from "../../store";
 import { Icon } from "../Icon";
 import { ProviderIcon } from "../ProviderIcon";
+import { Button } from "../ui/Button";
 
 type RowState = "ok" | "warn" | "bad" | "checking";
 
@@ -215,15 +216,10 @@ export function ProviderReadiness() {
               ? `${detected} of ${agents.length} agents detected`
               : "Couldn't detect agents"}
         </span>
-        <button
-          type="button"
-          className="btn-t iflex-center outline"
-          onClick={recheck}
-          disabled={checking}
-        >
+        <Button variant="outline" onClick={recheck} disabled={checking}>
           <Icon name="refresh" size={12} />
           {checking ? "Checking…" : "Re-check"}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/components/RightPanel/RunSettingsSheet.tsx
+++ b/src/components/RightPanel/RunSettingsSheet.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Icon } from "../Icon";
+import { Button } from "../ui/Button";
 
 export interface SetupRow {
   id: string;
@@ -121,22 +122,18 @@ export function RunSettingsSheet({ rows, overrides, ecosystem, onClose, onApply 
             )}
           </div>
           <div className="rsf-actions">
-            <button
-              className="btn-t iflex-center ghost"
+            <Button
+              variant="ghost"
               onClick={() => setDraft({})}
               disabled={Object.keys(draft).length === 0}
             >
               Reset all
-            </button>
+            </Button>
 
-            <button
-              className="btn-t iflex-center primary"
-              onClick={() => onApply(draft)}
-              disabled={!dirty}
-            >
+            <Button variant="primary" onClick={() => onApply(draft)} disabled={!dirty}>
               <Icon name="refresh" size={11} />
               Apply &amp; restart
-            </button>
+            </Button>
           </div>
         </div>
       </div>

--- a/src/components/SettingsScreen/AccountPane.tsx
+++ b/src/components/SettingsScreen/AccountPane.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useAppStore } from "../../store";
 import { accountInitials } from "../../util/format";
 import { Avatar } from "../Avatar";
+import { Button } from "../ui/Button";
 import { DevToolsStatus } from "./DevToolsStatus";
 import { SetGroup, SetHead } from "./primitives";
 
@@ -115,14 +116,9 @@ export function AccountPane() {
 
           <div className="set-form-actions flex-center">
             {savedAt && !dirty && <span className="set-saved mono text-sm">Saved</span>}
-            <button
-              type="button"
-              className="btn-t iflex-center primary"
-              disabled={!canSave}
-              onClick={onSave}
-            >
+            <Button variant="primary" disabled={!canSave} onClick={onSave}>
               {saving ? "Saving…" : "Save changes"}
-            </button>
+            </Button>
           </div>
         </div>
       </SetGroup>

--- a/src/components/SettingsScreen/BinaryPathRow.tsx
+++ b/src/components/SettingsScreen/BinaryPathRow.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 import { api } from "../../api";
 import { Icon } from "../Icon";
+import { Button } from "../ui/Button";
 
 /** The "Binary" detail row in a provider card. Read-only by default — showing
  *  the effective path the way it always has — but with an inline pencil that
@@ -151,13 +152,9 @@ export function BinaryPathRow({
             {broken && <span className="set-prov-bin-warn text-xs">not found</span>}
             <span className="grow" />
             {override && (
-              <button
-                className="btn-t iflex-center ghost sm-t"
-                disabled={busy}
-                onClick={() => void reset()}
-              >
+              <Button variant="ghost" size="sm" disabled={busy} onClick={() => void reset()}>
                 Reset to auto
-              </button>
+              </Button>
             )}
             <button
               className="btn-i iflex-center sm-i tip"

--- a/src/components/SettingsScreen/CustomAgents/AgentEditor.tsx
+++ b/src/components/SettingsScreen/CustomAgents/AgentEditor.tsx
@@ -4,6 +4,7 @@ import type { NewCustomAgent } from "../../../storage/customAgents";
 import { useAppStore } from "../../../store";
 import { Icon } from "../../Icon";
 import { ProviderIcon } from "../../ProviderIcon";
+import { Button } from "../../ui/Button";
 import { Select } from "../../ui/Select";
 import { SetSeg } from "../primitives";
 import { CA_HUES, INJECTION_HINT, shortFor } from "./shared";
@@ -195,12 +196,12 @@ export function AgentEditor({
 
         <div className="ca-ed-foot flex-center">
           <span className="ca-grow" />
-          <button className="btn-t iflex-center ghost" onClick={onCancel}>
+          <Button variant="ghost" onClick={onCancel}>
             Cancel
-          </button>
-          <button className="btn-t iflex-center primary" disabled={!canSave} onClick={submit}>
+          </Button>
+          <Button variant="primary" disabled={!canSave} onClick={submit}>
             <Icon name="check" size={13} /> {isNew ? "Create agent" : "Save changes"}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/components/SettingsScreen/CustomAgents/AgentList.tsx
+++ b/src/components/SettingsScreen/CustomAgents/AgentList.tsx
@@ -3,6 +3,7 @@ import { PROVIDERS } from "../../../data/providers";
 import type { CustomAgent } from "../../../storage/customAgents";
 import { useAppStore } from "../../../store";
 import { Icon } from "../../Icon";
+import { Button } from "../../ui/Button";
 import { SetHead } from "../primitives";
 import { Mono } from "./Mono";
 
@@ -43,9 +44,9 @@ export function AgentList({
         title="Custom agents"
         desc="Give a base coding agent a name, a model, and a standing brief. Custom agents show up in the composer next to the built-ins."
         actions={
-          <button className="btn-t iflex-center primary" onClick={onNew}>
+          <Button variant="primary" onClick={onNew}>
             <Icon name="plus" size={13} /> New agent
-          </button>
+          </Button>
         }
       />
 

--- a/src/components/SettingsScreen/DevToolsStatus.tsx
+++ b/src/components/SettingsScreen/DevToolsStatus.tsx
@@ -2,6 +2,7 @@ import { open as openExternal } from "@tauri-apps/plugin-shell";
 import { type ReactNode, useCallback, useEffect, useState } from "react";
 import { api, type GhStatus, type ToolStatus } from "../../api";
 import { Icon } from "../Icon";
+import { Button } from "../ui/Button";
 
 type S = "ok" | "warn" | "bad" | "checking";
 
@@ -69,15 +70,10 @@ export function DevToolsStatus() {
       />
       <div className="rdy-foot flex-center">
         <span className="rdy-count" />
-        <button
-          type="button"
-          className="btn-t iflex-center outline"
-          onClick={recheck}
-          disabled={checking}
-        >
+        <Button variant="outline" onClick={recheck} disabled={checking}>
           <Icon name="refresh" size={12} />
           {checking ? "Checking…" : "Re-check"}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/components/SettingsScreen/DeveloperPane.tsx
+++ b/src/components/SettingsScreen/DeveloperPane.tsx
@@ -1,5 +1,6 @@
 import { useAppStore } from "../../store";
 import { Icon } from "../Icon";
+import { Button } from "../ui/Button";
 import { SetGroup, SetHead, SetRow } from "./primitives";
 
 /** Dev-only settings surface. The nav entry that routes here is gated on
@@ -22,9 +23,8 @@ export function DeveloperPane() {
           title="Welcome tour"
           sub="Replay the cinematic onboarding — the feature tour and first-project walkthrough."
         >
-          <button
-            type="button"
-            className="btn-t iflex-center outline"
+          <Button
+            variant="outline"
             onClick={() => {
               closeSettingsScreen();
               openOnboarding();
@@ -32,7 +32,7 @@ export function DeveloperPane() {
           >
             <Icon name="sparkle" size={12} />
             Replay tour
-          </button>
+          </Button>
         </SetRow>
       </SetGroup>
 
@@ -41,9 +41,8 @@ export function DeveloperPane() {
           title="Update-ready toast"
           sub="Show the “Update ready” restart toast with a fake version, without releasing a build. Restart now will actually relaunch."
         >
-          <button
-            type="button"
-            className="btn-t iflex-center outline"
+          <Button
+            variant="outline"
             onClick={() => {
               closeSettingsScreen();
               setUpdateReady("9.9.9-test");
@@ -51,7 +50,7 @@ export function DeveloperPane() {
           >
             <Icon name="sparkle" size={12} />
             Trigger toast
-          </button>
+          </Button>
         </SetRow>
       </SetGroup>
     </div>

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -2,6 +2,7 @@ import { ACCENTS } from "../../data/providers";
 import type { Density, ThemeMode } from "../../storage/preferences";
 import { useAppStore } from "../../store";
 import { Icon } from "../Icon";
+import { Button } from "../ui/Button";
 import { type FeatureItem, SetGroup, SetHead, SetRow, SetSeg, SetToggle } from "./primitives";
 
 const SIDE_PANELS: FeatureItem[] = [
@@ -126,14 +127,10 @@ export function GeneralPane() {
           title="Logs"
           sub="Quorum writes a local log file. Reveal it to attach to a bug report."
         >
-          <button
-            type="button"
-            className="btn-t iflex-center outline"
-            onClick={() => void revealLogs()}
-          >
+          <Button variant="outline" onClick={() => void revealLogs()}>
             <Icon name="folder" size={12} />
             Reveal logs
-          </button>
+          </Button>
         </SetRow>
       </SetGroup>
     </div>

--- a/src/components/SettingsScreen/ProvidersPane.tsx
+++ b/src/components/SettingsScreen/ProvidersPane.tsx
@@ -5,6 +5,7 @@ import { PROVIDERS, type Provider } from "../../data/providers";
 import { useAppStore } from "../../store";
 import { Icon } from "../Icon";
 import { ProviderIcon } from "../ProviderIcon";
+import { Button } from "../ui/Button";
 import { BinaryPathRow } from "./BinaryPathRow";
 import { SetGroup, SetHead, SetToggle } from "./primitives";
 
@@ -145,7 +146,9 @@ function ProviderRow({
           />
           <ProvDetailRow k="Models" v={d.models} />
           <div className="set-prov-detail-actions flex-center">
-            <button className="btn-t iflex-center ghost sm-t">View logs</button>
+            <Button variant="ghost" size="sm">
+              View logs
+            </Button>
           </div>
         </div>
       )}

--- a/src/components/UpdateToast.tsx
+++ b/src/components/UpdateToast.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useAppStore } from "../store";
 import { restartForUpdate } from "../util/autoUpdate";
 import { Icon } from "./Icon";
+import { Button } from "./ui/Button";
 
 /**
  * Toast shown when an update has been downloaded and staged. Offers "Restart
@@ -37,12 +38,12 @@ export function UpdateToast() {
           <span>Version {version} has been downloaded.</span>
         </div>
         <div className="update-toast-actions">
-          <button className="btn-t iflex-center ghost" onClick={dismiss} disabled={restarting}>
+          <Button variant="ghost" onClick={dismiss} disabled={restarting}>
             Skip for now
-          </button>
-          <button className="btn-t iflex-center primary" onClick={onRestart} disabled={restarting}>
+          </Button>
+          <Button variant="primary" onClick={onRestart} disabled={restarting}>
             {restarting ? "Restarting…" : "Restart now"}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import type { AgentRecord } from "../../api";
 import { EMPTY_AGENTS, useAppStore } from "../../store";
 import { Icon } from "../Icon";
+import { Button } from "../ui/Button";
 import { IconButton } from "../ui/IconButton";
 import { ChatView } from "./ChatView";
 import { EmptyWorkspace } from "./EmptyWorkspace";
@@ -77,9 +78,8 @@ function CrashBanner({ agent }: { agent: AgentRecord }) {
         <span className="crash-title">Agent stopped unexpectedly</span>
         {agent.last_error && <span className="crash-detail">{agent.last_error}</span>}
       </div>
-      <button
-        type="button"
-        className="btn-t iflex-center outline"
+      <Button
+        variant="outline"
         disabled={resuming}
         onClick={() => {
           setResuming(true);
@@ -88,7 +88,7 @@ function CrashBanner({ agent }: { agent: AgentRecord }) {
       >
         <Icon name="play" size={12} />
         {resuming ? "Resuming…" : "Resume"}
-      </button>
+      </Button>
     </div>
   );
 }

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,59 @@
+import type { CSSProperties, MouseEvent, ReactNode } from "react";
+
+export type ButtonVariant = "ghost" | "outline" | "primary";
+
+interface Props {
+  children: ReactNode;
+  /** Visual style. Maps to the `.btn-t` variant classes in icon-button.css. */
+  variant: ButtonVariant;
+  /** Danger tint — composes with `ghost`/`outline`. */
+  danger?: boolean;
+  /** `sm` applies the compact `.sm-t` sizing. */
+  size?: "md" | "sm";
+  onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
+  /** Text for the CSS-only hover tooltip. */
+  tip?: string;
+  disabled?: boolean;
+  className?: string;
+  style?: CSSProperties;
+  type?: "button" | "submit";
+}
+
+/** Text-label button — CTAs and dialog actions (Cancel / Save / Restart …).
+ *  Sibling of `IconButton`, which handles icon-only buttons. */
+export function Button({
+  children,
+  variant,
+  danger,
+  size = "md",
+  onClick,
+  tip,
+  disabled,
+  className,
+  style,
+  type = "button",
+}: Props) {
+  const cls = [
+    "btn-t",
+    "iflex-center",
+    variant,
+    danger ? "danger" : "",
+    size === "sm" ? "sm-t" : "",
+    tip ? "tip" : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <button
+      type={type}
+      className={cls}
+      onClick={onClick}
+      disabled={disabled}
+      style={style}
+      data-tip={tip}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/ui/README.md
+++ b/src/components/ui/README.md
@@ -7,6 +7,7 @@ and is the path of least resistance for new UI.
 | Primitive | Use for | Underlying class |
 |---|---|---|
 | `Badge` | Compact status pill — agent state (`new`/`err`) and PR state (`pr-open`/`pr-merged`/`pr-closed`). Non-interactive. | `.ag-badge` |
+| `Button` | Text-label button — CTAs and dialog actions (Cancel / Save / Restart). Variants `ghost` / `outline` / `primary` (+ `danger`), `size="sm"`. | `.btn-t` |
 | `IconButton` | Square icon-only button (title bar, sidebar, panels). Built-in CSS tooltip via `tip`. | `.btn-i` |
 | `Chip` | Composer footer chip with a text label (model picker, base branch, attach). | `.c-chip` |
 | `Select` | Custom `<select>` replacement (keyboard-operable dropdown of string options). | `.ui-select-*` |
@@ -23,5 +24,4 @@ Tooltips are CSS-only: pass `tip="…"` (and `tipDown` where supported) — it s
   (`import { Badge } from "../ui"`).
 
 ## Planned
-- `Button` — text-button CTAs (`.btn-t`: ghost / outline / primary / danger).
 - `Dropdown` — shared menu shell + items (`.dd` / `.dd-item`).

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -4,6 +4,8 @@
 
 export type { BadgeVariant } from "./Badge";
 export { Badge } from "./Badge";
+export type { ButtonVariant } from "./Button";
+export { Button } from "./Button";
 export { Chip } from "./Chip";
 export { CopyButton } from "./CopyButton";
 export { IconButton } from "./IconButton";


### PR DESCRIPTION
**PR 2 of the shared-primitive series** (issue #257), on top of #266 (Badge, merged).

## `<Button>`
- Adds `ui/Button.tsx` — `<Button variant="ghost|outline|primary" danger? size="md|sm" onClick disabled tip>`. Text-label sibling of `IconButton` (which stays for icon-only). Variants map to the existing `.btn-t` classes.
- Migrates **all 18 hand-rolled `.btn-t` buttons** across 14 files (UpdateToast, ErrorBoundary, Workspace crash banner, RunSettingsSheet, 8 SettingsScreen panes, CustomAgents editor/list, both readiness checks). **No raw `.btn-t` left in JSX.**
- Adds `Button` to the `ui/` barrel + README.

## Notes
- `.btn-i` icon buttons untouched — `IconButton`'s job.
- Two `sm-t` buttons → `size="sm"`; redundant `type="button"` dropped throughout.
- `danger` is in the API (CSS supports `.ghost.danger`/`.outline.danger`) though no current site uses it.
- Done via two area-scoped sub-agents + a single verification pass.

## Verification
- ✅ build + `tsc` clean
- ✅ 317/317 tests pass
- ✅ lint clean (0 errors)
- Visuals identical — `Button` emits the same classes.

## Next
**PR 3 — `<Dropdown>`**: the `.dd`/`.dd-item` shell across 7 divergent sites; needs its own design pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)