### PR TITLE
feat(turns): record per-turn start/end timestamps for run timer

### DIFF
--- a/src-tauri/migrations/0012_user_turn_timing.sql
+++ b/src-tauri/migrations/0012_user_turn_timing.sql
@@ -1,0 +1,12 @@
+-- Wall-clock timing for a turn, so the UI can show a live timer while a turn
+-- runs and "Ran 34s" once it finishes.
+--
+-- `created_at` is *send* time and pays the first-turn cold-start spawn latency,
+-- so it is not a faithful start anchor. `started_at` is stamped when the turn
+-- actually flips to Running; `ended_at` when it reaches a terminal state
+-- (clean Idle, error, or stop). `ended_at IS NULL` is the "in flight" signal
+-- the UI ticks against. Both NULL for turns created before this column existed
+-- and for turns reconstructed purely from disk; readers render no duration for
+-- those rather than a bogus 0s.
+ALTER TABLE session_user_turns ADD COLUMN started_at INTEGER;
+ALTER TABLE session_user_turns ADD COLUMN ended_at   INTEGER;

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -85,6 +85,7 @@ fn get_migrations() -> Migrations<'static> {
         M::up(include_str!("../migrations/0009_session_model.sql")),
         M::up(include_str!("../migrations/0010_worktree_pr_number.sql")),
         M::up(include_str!("../migrations/0011_custom_agents.sql")),
+        M::up(include_str!("../migrations/0012_user_turn_timing.sql")),
     ])
 }
 

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -317,6 +317,15 @@ impl Supervisor {
             }
             _ => {}
         }
+        // Close the in-flight turn's timer on any terminal state. Idle covers
+        // the in-band turn-end and clean process exit; Error covers a crash.
+        // No-op when no turn is open (resting Idle at spawn, native turns), so
+        // it's safe to run unconditionally on these transitions.
+        if matches!(status, AgentStatus::Idle | AgentStatus::Error) {
+            if let Err(e) = self.workspace.mark_user_turn_ended(agent_id) {
+                tracing::warn!(error = %e, agent_id, "stamp user turn end failed");
+            }
+        }
         emit_status(app, agent_id, status, last_error);
     }
 
@@ -1047,7 +1056,7 @@ impl Supervisor {
             agent.write_pty(bytes)?;
         }
         for submitted in observe_native_input(&self, agent_id, bytes) {
-            mark_user_turn_started(&self, app, agent_id);
+            mark_user_turn_started(&self, app, agent_id, None);
             on_first_user_message(self.clone(), app.clone(), agent_id.to_string(), submitted);
         }
         Ok(())
@@ -2418,12 +2427,24 @@ fn on_first_user_message(
     }
 }
 
-fn mark_user_turn_started(sup: &Supervisor, app: &AppHandle, agent_id: &str) {
+fn mark_user_turn_started(
+    sup: &Supervisor,
+    app: &AppHandle,
+    agent_id: &str,
+    turn_id: Option<&str>,
+) {
     // A new turn is starting, so any prior stop is moot: clear the interrupt
     // flag so this turn's natural completion flushes queued follow-ups.
     sup.interrupted.lock().remove(agent_id);
     if let Some(activity) = sup.activities.lock().get_mut(agent_id) {
         activity.reset_for_new_turn();
+    }
+    // Stamp the turn's run start. Native PTY turns have no quorum-origin row
+    // (no turn_id), so they carry no timing.
+    if let Some(turn_id) = turn_id {
+        if let Err(e) = sup.workspace.mark_user_turn_started(turn_id) {
+            tracing::warn!(error = %e, agent_id, "stamp user turn start failed");
+        }
     }
     transition_active(sup, app, agent_id, AgentStatus::Running);
 }
@@ -2444,7 +2465,7 @@ fn deliver_as_turn(
         &msg.attachments,
         msg.thinking.as_deref(),
     )?;
-    mark_user_turn_started(sup, app, agent_id);
+    mark_user_turn_started(sup, app, agent_id, Some(&msg.turn_id));
     on_first_user_message(sup.clone(), app.clone(), agent_id.to_string(), msg.text.clone());
     Ok(())
 }

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -273,6 +273,13 @@ pub struct UserTurn {
     pub attachments: Vec<String>,
     /// Matched `session_records.native_id`; `None` = pending or failed turn.
     pub native_id: Option<String>,
+    /// Wall-clock millis when the turn flipped to Running. `None` for turns
+    /// that never started a run (native PTY turns, or rows from before timing
+    /// existed).
+    pub started_at: Option<i64>,
+    /// Wall-clock millis when the turn reached a terminal state. `None` while
+    /// in flight — the live-timer signal.
+    pub ended_at: Option<i64>,
 }
 
 pub struct WorkspaceManager {
@@ -911,6 +918,39 @@ impl WorkspaceManager {
         Ok(n > 0)
     }
 
+    /// Stamp a turn's run start when it flips to Running. Guarded on
+    /// `started_at IS NULL` so a delivery retry (same `turn_id`) never resets
+    /// the clock. No-op when the row doesn't exist (native PTY turns carry no
+    /// timing row).
+    pub fn mark_user_turn_started(&self, turn_id: &str) -> Result<()> {
+        let conn = self.db.lock();
+        conn.execute(
+            "UPDATE session_user_turns SET started_at = ?1
+             WHERE turn_id = ?2 AND started_at IS NULL",
+            rusqlite::params![now_millis(), turn_id],
+        )?;
+        Ok(())
+    }
+
+    /// Close the in-flight turn at turn end by stamping `ended_at` on the open
+    /// turn (started, not yet ended) of the workspace's current session. No-op
+    /// when none is open — e.g. the resting Idle emitted at spawn, or a native
+    /// turn with no timing row. At most one turn is ever open per session
+    /// (each end closes the open turn before the next one starts), but the
+    /// `WHERE` would safely close all open turns if one were ever stranded.
+    pub fn mark_user_turn_ended(&self, workspace_id: &str) -> Result<()> {
+        let conn = self.db.lock();
+        let Some(sid) = current_session_id(&conn, workspace_id) else {
+            return Ok(());
+        };
+        conn.execute(
+            "UPDATE session_user_turns SET ended_at = ?1
+             WHERE session_id = ?2 AND started_at IS NOT NULL AND ended_at IS NULL",
+            rusqlite::params![now_millis(), sid],
+        )?;
+        Ok(())
+    }
+
     /// All outgoing user turns for the workspace's current session, in seq order.
     pub fn read_user_turns(&self, workspace_id: &str) -> Result<Vec<UserTurn>> {
         let conn = self.db.lock();
@@ -918,26 +958,38 @@ impl WorkspaceManager {
             return Ok(vec![]);
         };
         let mut stmt = conn.prepare(
-            "SELECT turn_id, seq, text, attachments, native_id
+            "SELECT turn_id, seq, text, attachments, native_id, started_at, ended_at
              FROM session_user_turns WHERE session_id = ?1 ORDER BY seq ASC",
         )?;
-        let rows: Vec<(String, i64, String, String, Option<String>)> = stmt
-            .query_map([&sid], |r| {
-                Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?))
+        let rows: Vec<(String, i64, String, String, Option<String>, Option<i64>, Option<i64>)> =
+            stmt.query_map([&sid], |r| {
+                Ok((
+                    r.get(0)?,
+                    r.get(1)?,
+                    r.get(2)?,
+                    r.get(3)?,
+                    r.get(4)?,
+                    r.get(5)?,
+                    r.get(6)?,
+                ))
             })?
             .collect::<std::result::Result<_, rusqlite::Error>>()?;
         rows.into_iter()
-            .map(|(turn_id, seq, text, attachments_text, native_id)| {
-                let attachments = serde_json::from_str(&attachments_text)
-                    .map_err(|e| Error::Other(format!("deserialize attachments: {e}")))?;
-                Ok(UserTurn {
-                    turn_id,
-                    seq,
-                    text,
-                    attachments,
-                    native_id,
-                })
-            })
+            .map(
+                |(turn_id, seq, text, attachments_text, native_id, started_at, ended_at)| {
+                    let attachments = serde_json::from_str(&attachments_text)
+                        .map_err(|e| Error::Other(format!("deserialize attachments: {e}")))?;
+                    Ok(UserTurn {
+                        turn_id,
+                        seq,
+                        text,
+                        attachments,
+                        native_id,
+                        started_at,
+                        ended_at,
+                    })
+                },
+            )
             .collect()
     }
 
@@ -2178,6 +2230,51 @@ mod tests {
         assert_eq!(turns[0].text, "hello");
         assert_eq!(turns[0].attachments, vec!["/tmp/a.png".to_string()]);
         assert_eq!(turns[0].native_id, None);
+        // Timing is unset until the turn starts/ends.
+        assert_eq!(turns[0].started_at, None);
+        assert_eq!(turns[0].ended_at, None);
+    }
+
+    #[test]
+    fn user_turn_timing_start_then_end() {
+        let db = test_db();
+        let (ws_id, wm) = make_workspace_with_session(&db);
+        wm.insert_user_turn(&ws_id, "turn-1", "hello", &[]).unwrap();
+
+        // Start stamps started_at; end stamps ended_at on the open turn.
+        wm.mark_user_turn_started("turn-1").unwrap();
+        let started = wm.read_user_turns(&ws_id).unwrap()[0].started_at;
+        assert!(started.is_some());
+        assert_eq!(wm.read_user_turns(&ws_id).unwrap()[0].ended_at, None);
+
+        wm.mark_user_turn_ended(&ws_id).unwrap();
+        let turn = wm.read_user_turns(&ws_id).unwrap().remove(0);
+        assert_eq!(turn.started_at, started, "start clock not reset by end");
+        assert!(turn.ended_at >= turn.started_at, "ended_at after started_at");
+    }
+
+    #[test]
+    fn mark_user_turn_started_is_idempotent() {
+        let db = test_db();
+        let (ws_id, wm) = make_workspace_with_session(&db);
+        wm.insert_user_turn(&ws_id, "turn-1", "hello", &[]).unwrap();
+
+        wm.mark_user_turn_started("turn-1").unwrap();
+        let first = wm.read_user_turns(&ws_id).unwrap()[0].started_at;
+        // A delivery retry re-stamps — but the guard keeps the original clock.
+        wm.mark_user_turn_started("turn-1").unwrap();
+        assert_eq!(wm.read_user_turns(&ws_id).unwrap()[0].started_at, first);
+    }
+
+    #[test]
+    fn mark_user_turn_ended_skips_turns_that_never_started() {
+        let db = test_db();
+        let (ws_id, wm) = make_workspace_with_session(&db);
+        // A row with no started_at (e.g. a never-delivered turn, or the resting
+        // Idle emitted at spawn) must not get an ended_at.
+        wm.insert_user_turn(&ws_id, "turn-1", "hello", &[]).unwrap();
+        wm.mark_user_turn_ended(&ws_id).unwrap();
+        assert_eq!(wm.read_user_turns(&ws_id).unwrap()[0].ended_at, None);
     }
 
     #[test]


### PR DESCRIPTION
Adds `started_at`/`ended_at` columns to `session_user_turns` (migration `0012`) so the UI can show a live timer while a turn runs and "Ran 34s" once it finishes. `started_at` is stamped at the Running transition — dodging the first-turn spawn latency that send-time `created_at` carries — while `ended_at` is stamped centrally in `persist_and_emit_status` on any terminal state (Idle or Error), covering in-band turn-end, clean exit, and crash in one place. Both columns are surfaced through `UserTurn`/`read_user_turns` for the frontend. Per request there's no backfill: pre-existing and native PTY turns stay null and render no duration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)