### PR TITLE
feat(ui): per-turn run timer + footer (live timer, "Ran …", copy)

### DIFF
--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -42,6 +42,16 @@ pub struct SessionRecordsAppendedPayload {
     pub agent_id: String,
 }
 
+/// Emitted when a turn flips to Running, carrying the backend's own start
+/// timestamp (the same value persisted as the turn's `started_at`). The live
+/// timer anchors to this rather than the event's client-receipt time, so it
+/// shares the footer's clock and the two never disagree by the delivery latency.
+#[derive(Clone, serde::Serialize)]
+pub struct TurnStartedPayload {
+    pub agent_id: String,
+    pub started_at: i64,
+}
+
 #[derive(Clone, serde::Serialize)]
 pub struct AgentStatusPayload {
     pub agent_id: String,
@@ -2439,13 +2449,24 @@ fn mark_user_turn_started(
     if let Some(activity) = sup.activities.lock().get_mut(agent_id) {
         activity.reset_for_new_turn();
     }
-    // Stamp the turn's run start. Native PTY turns have no quorum-origin row
-    // (no turn_id), so they carry no timing.
+    // Stamp the turn's run start with a single timestamp shared by the persisted
+    // row and the `turn:started` event, so the live timer and the footer measure
+    // from the identical instant. Native PTY turns have no quorum-origin row (no
+    // turn_id), so they carry no persisted timing — but still emit the event so
+    // their live timer has an anchor.
+    let started_at = chrono::Utc::now().timestamp_millis();
     if let Some(turn_id) = turn_id {
-        if let Err(e) = sup.workspace.mark_user_turn_started(turn_id) {
+        if let Err(e) = sup.workspace.mark_user_turn_started(turn_id, started_at) {
             tracing::warn!(error = %e, agent_id, "stamp user turn start failed");
         }
     }
+    let _ = app.emit(
+        "turn:started",
+        TurnStartedPayload {
+            agent_id: agent_id.to_string(),
+            started_at,
+        },
+    );
     transition_active(sup, app, agent_id, AgentStatus::Running);
 }
 

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -918,16 +918,17 @@ impl WorkspaceManager {
         Ok(n > 0)
     }
 
-    /// Stamp a turn's run start when it flips to Running. Guarded on
-    /// `started_at IS NULL` so a delivery retry (same `turn_id`) never resets
-    /// the clock. No-op when the row doesn't exist (native PTY turns carry no
-    /// timing row).
-    pub fn mark_user_turn_started(&self, turn_id: &str) -> Result<()> {
+    /// Stamp a turn's run start when it flips to Running, with the caller's
+    /// timestamp so the same value reaches the live timer (via the `turn:started`
+    /// event) and the persisted duration. Guarded on `started_at IS NULL` so a
+    /// delivery retry (same `turn_id`) never resets the clock. No-op when the row
+    /// doesn't exist (native PTY turns carry no timing row).
+    pub fn mark_user_turn_started(&self, turn_id: &str, started_at: i64) -> Result<()> {
         let conn = self.db.lock();
         conn.execute(
             "UPDATE session_user_turns SET started_at = ?1
              WHERE turn_id = ?2 AND started_at IS NULL",
-            rusqlite::params![now_millis(), turn_id],
+            rusqlite::params![started_at, turn_id],
         )?;
         Ok(())
     }
@@ -2242,9 +2243,9 @@ mod tests {
         wm.insert_user_turn(&ws_id, "turn-1", "hello", &[]).unwrap();
 
         // Start stamps started_at; end stamps ended_at on the open turn.
-        wm.mark_user_turn_started("turn-1").unwrap();
+        wm.mark_user_turn_started("turn-1", 1000).unwrap();
         let started = wm.read_user_turns(&ws_id).unwrap()[0].started_at;
-        assert!(started.is_some());
+        assert_eq!(started, Some(1000));
         assert_eq!(wm.read_user_turns(&ws_id).unwrap()[0].ended_at, None);
 
         wm.mark_user_turn_ended(&ws_id).unwrap();
@@ -2259,10 +2260,10 @@ mod tests {
         let (ws_id, wm) = make_workspace_with_session(&db);
         wm.insert_user_turn(&ws_id, "turn-1", "hello", &[]).unwrap();
 
-        wm.mark_user_turn_started("turn-1").unwrap();
+        wm.mark_user_turn_started("turn-1", 1000).unwrap();
         let first = wm.read_user_turns(&ws_id).unwrap()[0].started_at;
         // A delivery retry re-stamps — but the guard keeps the original clock.
-        wm.mark_user_turn_started("turn-1").unwrap();
+        wm.mark_user_turn_started("turn-1", 2000).unwrap();
         assert_eq!(wm.read_user_turns(&ws_id).unwrap()[0].started_at, first);
     }
 

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -6,7 +6,16 @@
 // for the design rationale.
 
 export type ChatItem =
-  | { kind: "user_message"; text: string; attachments?: string[] }
+  | {
+      kind: "user_message";
+      text: string;
+      attachments?: string[];
+      /** Run timing for the turn this message starts, overlaid from the
+       *  matching `UserTurn` row (epoch millis). `endedAt` null = still in
+       *  flight (the live turn); both absent for turns with no timing row. */
+      startedAt?: number;
+      endedAt?: number;
+    }
   // A follow-up the user sent mid-turn that hasn't landed in the transcript
   // yet: delivered live into the running turn (claude) or queued for the next
   // turn boundary (per-turn agents). Store-inserted only — never produced by an

--- a/src/api.ts
+++ b/src/api.ts
@@ -563,6 +563,18 @@ export function onSessionRecordsAppended(
   );
 }
 
+export interface TurnStartedEvent {
+  agent_id: string;
+  /** Backend epoch millis the turn began — the live-timer anchor. */
+  started_at: number;
+}
+
+/** Fires when a turn flips to Running, carrying the backend's own start
+ *  timestamp so the live timer shares the persisted duration's clock. */
+export function onTurnStarted(cb: (e: TurnStartedEvent) => void): Promise<UnlistenFn> {
+  return listen<TurnStartedEvent>("turn:started", (event) => cb(event.payload));
+}
+
 export function onAgentStatus(cb: (e: AgentStatusEvent) => void): Promise<UnlistenFn> {
   return listen<AgentStatusEvent>("agent:status", (event) => cb(event.payload));
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -543,6 +543,10 @@ export interface UserTurn {
   text: string;
   attachments: string[];
   native_id: string | null;
+  /** Epoch millis when the turn started running; null if it never started. */
+  started_at: number | null;
+  /** Epoch millis when the turn finished; null while in flight. */
+  ended_at: number | null;
 }
 
 export interface SessionRecordsAppendedEvent {

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -12,6 +12,7 @@ import {
   ChevronRight,
   ChevronsDownUp,
   ChevronUp,
+  Clock,
   Code,
   Combine,
   Copy,
@@ -146,6 +147,7 @@ const ICON_COMPONENTS = {
   moon: Moon,
   sun: Sun,
   zap: Zap,
+  clock: Clock,
 } satisfies Record<string, ComponentType<IconComponentProps>>;
 
 // Originally rendered with fill="currentColor". Setting fill on the root SVG

--- a/src/components/Workspace/Chat.css
+++ b/src/components/Workspace/Chat.css
@@ -16,11 +16,16 @@
   align-items: center;
   gap: 8px;
   min-height: 26px;
-  padding: 6px 6px 10px;
+  padding: 8px 6px 12px;
   margin-bottom: -4px;
   font-size: 12px;
   line-height: 1.2;
   color: var(--fg-2);
+  /* Glassy surface: translucent fill + blur so chat text scrolling under the
+     strip is veiled rather than sharply visible. */
+  background: color-mix(in oklch, var(--bg-1), transparent 25%);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
   transform: translateY(10px);
   opacity: 0;
   pointer-events: none;
@@ -55,6 +60,72 @@
 }
 .chat-status .dots i:nth-child(3) {
   animation-delay: 0.3s;
+}
+/* Live timer riding the working strip — the one moving numeric value. */
+.chat-status-sep {
+  flex-shrink: 0;
+  opacity: 0.4;
+}
+.chat-status .turn-clock-i {
+  flex-shrink: 0;
+  color: var(--accent);
+}
+.chat-status .turn-clock {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 11.5px;
+  letter-spacing: 0.02em;
+  color: var(--accent);
+}
+
+/* Turn footer — a quiet "Ran …" record plus copy, and the seam between turns.
+   Pulled up close to the message it closes; the copy button rides the right. */
+.turn-meta {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 22px;
+  margin: -6px 0 16px;
+  padding-top: 6px;
+  border-top: 1px solid color-mix(in oklch, var(--bd-soft) 55%, transparent);
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  /* Match the composer's "Default model" label. */
+  color: var(--fg-2);
+}
+/* Direct child only — the clock glyph. Must not reach the copy button's
+   nested icon (sized below) or fade it via this opacity. */
+.turn-meta > svg {
+  flex-shrink: 0;
+  width: 11px;
+  height: 11px;
+  opacity: 0.65;
+}
+/* Always visible — unlike the hover-only user-message copy, the turn footer
+   keeps its copy affordance on so the agent's reply is one click away. Same
+   tone as the "Run …" text (the composer's "Default model" label); the .btn-i
+   hover state brightens it. */
+.turn-meta .turn-copy {
+  margin-left: auto;
+  color: var(--fg-2);
+}
+
+/* The fixed 22px .btn-i.xs box clamps the copy glyph, so size the button to its
+   content (plus a small hit-area pad) and let the 12px glyph through, on both
+   the user and turn-footer copies. */
+.m-actions .btn-i.xs,
+.turn-meta .btn-i.xs {
+  width: auto;
+  height: auto;
+  padding: 3px;
+}
+.m-actions .btn-i.xs svg,
+.turn-meta .btn-i.xs svg {
+  width: 12px;
+  height: 12px;
 }
 
 /* Inline turn-pending anchor — dots only; label is in .chat-status below. */
@@ -213,7 +284,8 @@
 }
 .chat-inner {
   max-width: 860px;
-  margin: 0 auto;
+  /* Bottom gap so the last message clears the working strip's glass overlay. */
+  margin: 0 auto 24px;
   width: 100%;
   padding: 0 20px;
   display: flex;

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -232,10 +232,10 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
   // anchor is redundant.
   const turnPending = liveBusy && isTurnPending(items) && turns.length <= 1;
 
-  // Live-timer anchor: the turn's `running` timestamp (stamped alongside the
-  // backend's started_at, so the count matches the persisted "Ran …"). On
-  // reload mid-turn no `running` fired this session, so fall back to the open
-  // turn's persisted start. Absent during spawn → strip shows, timer waits.
+  // Live-timer anchor: the backend's turn-start timestamp (from `turn:started`,
+  // the same value the footer's duration uses, so they never drift). On reload
+  // mid-turn no event fired this session, so fall back to the open turn's
+  // persisted start. Absent during spawn → strip shows, timer waits.
   const liveStartedAt = liveBusy ? (turnStartedAt ?? openTurnStartedAt) : undefined;
 
   // Mid-turn follow-ups are allowed: a busy (running) agent still accepts a

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { applyPolicy, getAdapter } from "../../adapters";
 import { type AgentRecord, api } from "../../api";
 import { providerLabel } from "../../data/providers";
@@ -13,6 +13,7 @@ import { MessageItem } from "./messages/MessageItem";
 import { pairToolItems, rowKey } from "./messages/pair";
 import { isTurnPending } from "./messages/turnPending";
 import { isUserInputTool } from "./messages/UserInput/parse";
+import { TurnFooter } from "./RunTimer";
 
 /** Custom-view body: scrolling chat log + composer at the bottom.
  *  The composer here dispatches the user's message via the store; it
@@ -23,6 +24,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
   const transcriptLoaded = useAppStore((s) => s.transcriptLoaded[agent.id] ?? false);
   const busy = useAppStore((s) => s.managedBusy[agent.id] ?? false);
   const busyLabel = useAppStore((s) => s.managedBusyLabel[agent.id]);
+  const turnStartedAt = useAppStore((s) => s.turnStartedAt[agent.id]);
   const switchInFlight = useAppStore((s) => s.switchInFlight[agent.id] ?? false);
   const send = useAppStore((s) => s.sendUserMessage);
   const stop = useAppStore((s) => s.stop);
@@ -152,6 +154,40 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
     return { turns, turnIds };
   }, [items]);
 
+  // Footer closing each *ended* turn (border + "Ran …" + copy), placed at the
+  // turn's last item — the seam before the next turn. Gated on the same
+  // turn-end signal as the duration, so it only appears once the turn finishes;
+  // the open turn (started, not ended) carries no footer, just its live timer
+  // on the working strip.
+  const { turnFooters, openTurnStartedAt } = useMemo(() => {
+    const footers: ({ runSec: number; copyText: string } | null)[] = items.map(() => null);
+    let openStart: number | undefined;
+    const starts: number[] = [];
+    items.forEach((it, i) => {
+      if (it.kind === "user_message" && !it.text.startsWith(APP_ACTION_PREFIX)) starts.push(i);
+    });
+    starts.forEach((startIdx, k) => {
+      const start = items[startIdx];
+      if (start.kind !== "user_message" || start.startedAt == null) return;
+      const endExclusive = k + 1 < starts.length ? starts[k + 1] : items.length;
+      if (start.endedAt == null) {
+        openStart = start.startedAt; // turn still running
+        return;
+      }
+      // The agent's settled prose for this turn — what "copy" yields.
+      const texts: string[] = [];
+      for (let j = startIdx; j < endExclusive; j += 1) {
+        const it = items[j];
+        if (it.kind === "agent_message" && !it.streaming && it.text) texts.push(it.text);
+      }
+      footers[endExclusive - 1] = {
+        runSec: (start.endedAt - start.startedAt) / 1000,
+        copyText: texts.join("\n\n"),
+      };
+    });
+    return { turnFooters: footers, openTurnStartedAt: openStart };
+  }, [items]);
+
   // The model the agent actually used on its most recent turn (Claude, pi,
   // Codex, OpenCode report it in their transcripts). Undefined for Cursor /
   // Antigravity, or before the first turn — the composer then shows just the
@@ -173,9 +209,34 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
     );
   }, [items]);
 
+  // The backend emits a transient `idle` between process spawn and the first
+  // turn's `running` (every process rests at Idle at spawn). Raw `busy` thus
+  // dips false→true mid-startup, which would flash the working strip and
+  // restart the timer. Hold "working" through brief dips: rise immediately,
+  // fall only after a short grace period.
+  const liveBusyRaw = busy && !awaitingInput;
+  const [liveBusy, setLiveBusy] = useState(liveBusyRaw);
+  useEffect(() => {
+    if (liveBusyRaw) {
+      setLiveBusy(true);
+      return;
+    }
+    const t = window.setTimeout(() => setLiveBusy(false), 700);
+    return () => window.clearTimeout(t);
+  }, [liveBusyRaw]);
+
   // Phase A: user just sent a turn-starting prompt and nothing has landed yet.
   // A quiet inline anchor (dots only — label lives in the bottom status strip).
-  const turnPending = busy && !awaitingInput && isTurnPending(items);
+  // Only on the first turn: for later turns the chat already has content above
+  // and the bottom status strip carries the "is working" signal, so the inline
+  // anchor is redundant.
+  const turnPending = liveBusy && isTurnPending(items) && turns.length <= 1;
+
+  // Live-timer anchor: the turn's `running` timestamp (stamped alongside the
+  // backend's started_at, so the count matches the persisted "Ran …"). On
+  // reload mid-turn no `running` fired this session, so fall back to the open
+  // turn's persisted start. Absent during spawn → strip shows, timer waits.
+  const liveStartedAt = liveBusy ? (turnStartedAt ?? openTurnStartedAt) : undefined;
 
   // Mid-turn follow-ups are allowed: a busy (running) agent still accepts a
   // message — delivered live (claude) or queued for the next turn boundary
@@ -218,13 +279,15 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
               </div>
             ) : (
               items.map((item, i) => (
-                <MessageItem
-                  key={rowKey(item, i)}
-                  item={item}
-                  provider={agent.provider}
-                  agentId={agent.id}
-                  turnId={turnIds[i]}
-                />
+                <Fragment key={rowKey(item, i)}>
+                  <MessageItem
+                    item={item}
+                    provider={agent.provider}
+                    agentId={agent.id}
+                    turnId={turnIds[i]}
+                  />
+                  {turnFooters[i] != null && <TurnFooter {...turnFooters[i]!} />}
+                </Fragment>
               ))
             )}
             {turnPending && (
@@ -244,10 +307,11 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
         <div className="composer-stack">
           <div className="composer-anchor">
             <ChatWorkingStatus
-              visible={busy && !awaitingInput}
+              visible={liveBusy}
               label={
                 busyLabel ?? `${customAgent?.name ?? providerLabel(agent.provider)} is working`
               }
+              startedAt={liveStartedAt}
             />
             <Composer
               existingSession

--- a/src/components/Workspace/ChatWorkingStatus.tsx
+++ b/src/components/Workspace/ChatWorkingStatus.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from "react";
+import { Icon } from "../Icon";
+import { LiveTimer } from "./RunTimer";
 
 const DURATION_MS = 130;
 
@@ -29,7 +31,16 @@ function useSlideReveal(visible: boolean) {
 
 /** Pinned working indicator — slides up from behind the composer on show,
  *  back down on turn end. */
-export function ChatWorkingStatus({ visible, label }: { visible: boolean; label: string }) {
+export function ChatWorkingStatus({
+  visible,
+  label,
+  startedAt,
+}: {
+  visible: boolean;
+  label: string;
+  /** Epoch millis the open turn started; when set, a live timer ticks. */
+  startedAt?: number;
+}) {
   const { mounted, open } = useSlideReveal(visible);
   if (!mounted) return null;
 
@@ -41,6 +52,13 @@ export function ChatWorkingStatus({ visible, label }: { visible: boolean; label:
         <i />
       </span>
       <span className="chat-status-label">{label}</span>
+      {startedAt != null && (
+        <>
+          <span className="chat-status-sep">·</span>
+          <Icon name="clock" size={11} className="turn-clock-i" />
+          <LiveTimer startedAt={startedAt} />
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/Workspace/RunTimer.test.ts
+++ b/src/components/Workspace/RunTimer.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { fmtDur } from "./RunTimer";
+
+describe("fmtDur", () => {
+  it("shows whole seconds under a minute", () => {
+    expect(fmtDur(8)).toBe("8s");
+    expect(fmtDur(38)).toBe("38s");
+  });
+
+  it("shows minutes + zero-padded seconds at a minute or more", () => {
+    expect(fmtDur(62)).toBe("1m 02s");
+    expect(fmtDur(227)).toBe("3m 47s");
+  });
+
+  it("floors fractional seconds and clamps negatives to 0s", () => {
+    expect(fmtDur(8.9)).toBe("8s");
+    expect(fmtDur(-5)).toBe("0s");
+  });
+});

--- a/src/components/Workspace/RunTimer.tsx
+++ b/src/components/Workspace/RunTimer.tsx
@@ -1,0 +1,43 @@
+// Per-turn run timing in the chat feed. One formatter drives both variants:
+// a live timer that ticks on the open turn, and a static "Ran …" record under
+// every completed turn. See the Run Timer component spec.
+
+import { useEffect, useState } from "react";
+import { Icon } from "../Icon";
+import { CopyButton } from "../ui/CopyButton";
+
+/** Whole seconds under a minute; `{m}m {ss}s` (zero-padded seconds) at a
+ *  minute or more. Never a leading `0m`, never decimals or an hours field. */
+export function fmtDur(sec: number): string {
+  sec = Math.max(0, Math.floor(sec));
+  const m = Math.floor(sec / 60);
+  const s = sec % 60;
+  return m === 0 ? `${s}s` : `${m}m ${String(s).padStart(2, "0")}s`;
+}
+
+/** Live elapsed value, recomputed from a fixed start timestamp every second so
+ *  it never drifts when the tab is backgrounded. `startedAt` is epoch millis. */
+export function LiveTimer({ startedAt }: { startedAt: number }) {
+  const [sec, setSec] = useState(() => Math.floor((Date.now() - startedAt) / 1000));
+  useEffect(() => {
+    const tick = () => setSec(Math.floor((Date.now() - startedAt) / 1000));
+    tick(); // re-seed immediately when the open turn changes (new start)
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [startedAt]);
+
+  return <span className="turn-clock">{fmtDur(sec)}</span>;
+}
+
+/** The footer closing an ended turn: the quiet "Ran 38s" record on the left and
+ *  a dimmed copy of the turn's response on the right. Doubles as the seam
+ *  between turns (the hairline lives in CSS). */
+export function TurnFooter({ runSec, copyText }: { runSec: number; copyText: string }) {
+  return (
+    <div className="turn-meta">
+      <Icon name="clock" size={11} />
+      <span>Ran {fmtDur(runSec)}</span>
+      {copyText && <CopyButton text={copyText} className="turn-copy" />}
+    </div>
+  );
+}

--- a/src/components/Workspace/messages/MessageItem.tsx
+++ b/src/components/Workspace/messages/MessageItem.tsx
@@ -51,18 +51,15 @@ export function MessageItem({
       // lands canonically.
       return <UserBubble text={item.text} attachments={item.attachments} queued />;
     case "agent_message":
+      // Copy isn't offered here: it lives in the turn footer (see TurnFooter),
+      // right-aligned on the seam, so the message itself reserves no extra
+      // vertical space for a hover-only affordance.
       return (
         <div className="m-msg-wrap">
           <div className="m-agent text-base">
             <Markdown>{item.text}</Markdown>
             {item.streaming && <span className="term-cursor" style={{ marginLeft: 4 }} />}
           </div>
-          {/* Copy is offered once the response has settled, not mid-stream. */}
-          {!item.streaming && (
-            <div className="m-actions">
-              <CopyButton text={item.text} />
-            </div>
-          )}
         </div>
       );
     case "tool_pair": {

--- a/src/components/ui/CopyButton.tsx
+++ b/src/components/ui/CopyButton.tsx
@@ -45,7 +45,7 @@ export function CopyButton({
       onClick={onCopy}
       aria-label="Copy message"
     >
-      <Icon name={copied ? "check" : "copy"} />
+      <Icon name={copied ? "check" : "copy"} size={12} />
     </IconButton>
   );
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -64,6 +64,12 @@ export function reduceRecords(provider: string | undefined, records: SessionReco
  *    feature (no row) simply keep no attachments instead of mis-grabbing them.
  *  - Pending turns (`native_id` null — the agent never logged them, e.g. a
  *    failed send) render standalone so the message survives reload + retry. */
+/** Copy a turn's run timing onto its rendered user message, if present. */
+function applyTurnTiming(item: Extract<ChatItem, { kind: "user_message" }>, t: UserTurn): void {
+  if (t.started_at != null) item.startedAt = t.started_at;
+  if (t.ended_at != null) item.endedAt = t.ended_at;
+}
+
 export function applyUserTurns(items: ChatItem[], turns: UserTurn[]): ChatItem[] {
   if (turns.length === 0) return items;
 
@@ -81,15 +87,18 @@ export function applyUserTurns(items: ChatItem[], turns: UserTurn[]): ChatItem[]
   for (let k = 1; k <= n; k++) {
     const t = matched[matched.length - k];
     const item = result[userIdxs[userIdxs.length - k]];
-    if (item.kind === "user_message" && t.attachments.length > 0) {
-      item.attachments = t.attachments;
-      // Render the clean text the user actually typed (what the live render
-      // showed) rather than the transcript's copy, which the runner padded
-      // with `Attached file: <path>` reference lines. The stored turn text is
-      // verbatim what was sent, so it matches the optimistic render exactly.
-      // Prefix-guard so a mis-aligned match can't rewrite an unrelated message.
-      if (item.text.startsWith(t.text)) {
-        item.text = t.text;
+    if (item.kind === "user_message") {
+      applyTurnTiming(item, t);
+      if (t.attachments.length > 0) {
+        item.attachments = t.attachments;
+        // Render the clean text the user actually typed (what the live render
+        // showed) rather than the transcript's copy, which the runner padded
+        // with `Attached file: <path>` reference lines. The stored turn text is
+        // verbatim what was sent, so it matches the optimistic render exactly.
+        // Prefix-guard so a mis-aligned match can't rewrite an unrelated message.
+        if (item.text.startsWith(t.text)) {
+          item.text = t.text;
+        }
       }
     }
   }
@@ -97,6 +106,7 @@ export function applyUserTurns(items: ChatItem[], turns: UserTurn[]): ChatItem[]
   for (const t of pending) {
     const item: ChatItem = { kind: "user_message", text: t.text };
     if (t.attachments.length > 0) item.attachments = t.attachments;
+    applyTurnTiming(item, t);
     result.push(item);
   }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -245,6 +245,7 @@ export function dropAgentEntries(state: AppState, id: string): Partial<AppState>
   const { [id]: _loading, ...transcriptLoading } = state.transcriptLoading;
   const { [id]: _loaded, ...transcriptLoaded } = state.transcriptLoaded;
   const { [id]: _busy, ...managedBusy } = state.managedBusy;
+  const { [id]: _started, ...turnStartedAt } = state.turnStartedAt;
   const { [id]: _usage, ...usage } = state.usage;
   const { [id]: _git, ...gitStates } = state.gitStates;
   const { [id]: _short, ...gitShortstats } = state.gitShortstats;
@@ -266,6 +267,7 @@ export function dropAgentEntries(state: AppState, id: string): Partial<AppState>
     transcriptLoading,
     transcriptLoaded,
     managedBusy,
+    turnStartedAt,
     usage,
     gitStates,
     gitShortstats,

--- a/src/helpers.user-turns.test.ts
+++ b/src/helpers.user-turns.test.ts
@@ -4,7 +4,16 @@ import type { UserTurn } from "./api";
 import { applyUserTurns } from "./helpers";
 
 function turn(over: Partial<UserTurn>): UserTurn {
-  return { turn_id: "t", seq: 0, text: "", attachments: [], native_id: null, ...over };
+  return {
+    turn_id: "t",
+    seq: 0,
+    text: "",
+    attachments: [],
+    native_id: null,
+    started_at: null,
+    ended_at: null,
+    ...over,
+  };
 }
 
 const userMsg = (text: string): ChatItem => ({ kind: "user_message", text });
@@ -88,5 +97,22 @@ describe("applyUserTurns", () => {
   it("is a no-op when there are no user turns", () => {
     const items = [userMsg("hi"), agentMsg("yo")];
     expect(applyUserTurns(items, [])).toEqual(items);
+  });
+
+  it("overlays run timing onto a completed turn's user message", () => {
+    const items = [userMsg("go"), agentMsg("done")];
+    const turns = [turn({ native_id: "rec-A", text: "go", started_at: 1000, ended_at: 39000 })];
+
+    const out = applyUserTurns(items, turns);
+    expect(out[0]).toMatchObject({ startedAt: 1000, endedAt: 39000 });
+  });
+
+  it("overlays only startedAt on an in-flight (pending) turn", () => {
+    const items: ChatItem[] = [];
+    const turns = [turn({ native_id: null, text: "running now", started_at: 5000, ended_at: null })];
+
+    const out = applyUserTurns(items, turns);
+    expect(out[0]).toMatchObject({ kind: "user_message", startedAt: 5000 });
+    expect((out[0] as { endedAt?: number }).endedAt).toBeUndefined();
   });
 });

--- a/src/helpers.user-turns.test.ts
+++ b/src/helpers.user-turns.test.ts
@@ -109,7 +109,9 @@ describe("applyUserTurns", () => {
 
   it("overlays only startedAt on an in-flight (pending) turn", () => {
     const items: ChatItem[] = [];
-    const turns = [turn({ native_id: null, text: "running now", started_at: 5000, ended_at: null })];
+    const turns = [
+      turn({ native_id: null, text: "running now", started_at: 5000, ended_at: null }),
+    ];
 
     const out = applyUserTurns(items, turns);
     expect(out[0]).toMatchObject({ kind: "user_message", startedAt: 5000 });

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -14,6 +14,7 @@ import {
   onPrStateChanged,
   onSessionRecordsAppended,
   onShellOutput,
+  onTurnStarted,
   onWorkspaceChanged,
 } from "../api";
 import { isCommitAction } from "../components/RightPanel/primaryActions";
@@ -279,14 +280,11 @@ const registerEventListeners = async (set: AppSet, get: AppGet) => {
       })),
     };
     set((state) => {
-      // Anchor the live timer to the turn's actual start — `running` is emitted
-      // alongside the backend's `started_at`, so the live count matches the
-      // persisted "Ran …" rather than counting spawn time from the send. Clear
-      // at turn end so the next turn's send→running gap can't show a stale one.
+      // Clear the live-timer anchor at turn end so the next turn's send→running
+      // gap can't show a stale one. The anchor itself is set from the
+      // `turn:started` event (the backend's own timestamp), not here.
       const turnStartedAt = { ...state.turnStartedAt };
-      if (e.status === "running") {
-        turnStartedAt[e.agent_id] = Date.now();
-      } else if (e.status === "idle" || e.status === "error" || e.status === "stopped") {
+      if (e.status === "idle" || e.status === "error" || e.status === "stopped") {
         delete turnStartedAt[e.agent_id];
       }
       return {
@@ -318,6 +316,15 @@ const registerEventListeners = async (set: AppSet, get: AppGet) => {
         turnStartedAt,
       };
     });
+  });
+
+  // The turn's start timestamp from the backend — the live-timer anchor, shared
+  // with the persisted duration so the strip and footer measure from the same
+  // instant (no off-by-the-delivery-latency drift).
+  await onTurnStarted((e) => {
+    set((state) => ({
+      turnStartedAt: { ...state.turnStartedAt, [e.agent_id]: e.started_at },
+    }));
   });
 
   // Archive / restore reshape `repos` and `archive` on the record,

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -278,33 +278,46 @@ const registerEventListeners = async (set: AppSet, get: AppGet) => {
         last_error: e.last_error ?? a.last_error,
       })),
     };
-    set((state) => ({
-      workspace: next,
-      managedLogs:
-        e.status === "stopped" && (state.managedBusy[e.agent_id] ?? false)
-          ? {
-              ...state.managedLogs,
-              [e.agent_id]: [
-                ...(state.managedLogs[e.agent_id] ?? []),
-                {
-                  kind: "notice",
-                  subtype: "info",
-                  text: "Agent was interrupted.",
-                },
-              ],
-            }
-          : state.managedLogs,
-      // `running` is the backend's authoritative "a turn is in flight"
-      // signal — re-assert busy here so a stale `idle` (e.g. the one
-      // start_process emits just before the first turn lands) can't
-      // leave the spinner off. `idle`/`error`/`stopped` clear it.
-      managedBusy:
-        e.status === "running"
-          ? { ...state.managedBusy, [e.agent_id]: true }
-          : e.status === "error" || e.status === "stopped" || e.status === "idle"
-            ? { ...state.managedBusy, [e.agent_id]: false }
-            : state.managedBusy,
-    }));
+    set((state) => {
+      // Anchor the live timer to the turn's actual start — `running` is emitted
+      // alongside the backend's `started_at`, so the live count matches the
+      // persisted "Ran …" rather than counting spawn time from the send. Clear
+      // at turn end so the next turn's send→running gap can't show a stale one.
+      const turnStartedAt = { ...state.turnStartedAt };
+      if (e.status === "running") {
+        turnStartedAt[e.agent_id] = Date.now();
+      } else if (e.status === "idle" || e.status === "error" || e.status === "stopped") {
+        delete turnStartedAt[e.agent_id];
+      }
+      return {
+        workspace: next,
+        managedLogs:
+          e.status === "stopped" && (state.managedBusy[e.agent_id] ?? false)
+            ? {
+                ...state.managedLogs,
+                [e.agent_id]: [
+                  ...(state.managedLogs[e.agent_id] ?? []),
+                  {
+                    kind: "notice",
+                    subtype: "info",
+                    text: "Agent was interrupted.",
+                  },
+                ],
+              }
+            : state.managedLogs,
+        // `running` is the backend's authoritative "a turn is in flight"
+        // signal — re-assert busy here so a stale `idle` (e.g. the one
+        // start_process emits just before the first turn lands) can't
+        // leave the spinner off. `idle`/`error`/`stopped` clear it.
+        managedBusy:
+          e.status === "running"
+            ? { ...state.managedBusy, [e.agent_id]: true }
+            : e.status === "error" || e.status === "stopped" || e.status === "idle"
+              ? { ...state.managedBusy, [e.agent_id]: false }
+              : state.managedBusy,
+        turnStartedAt,
+      };
+    });
   });
 
   // Archive / restore reshape `repos` and `archive` on the record,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -66,9 +66,10 @@ export interface WorkspaceSlice {
    *  that turn. Drives the send-button disabled state and the
    *  "thinking…" indicator. */
   managedBusy: Record<string, boolean>;
-  /** Client wall-clock millis when the current turn entered `running` — the
-   *  live-timer anchor. Captured here (not from send time) so it lines up with
-   *  the backend's post-spawn `started_at`; re-stamped each turn. */
+  /** The backend's own start timestamp (epoch millis) for the current turn,
+   *  from the `turn:started` event — the live-timer anchor. Shared with the
+   *  persisted `started_at`, so the strip and footer measure from the identical
+   *  instant; cleared at turn end. */
   turnStartedAt: Record<string, number>;
   /** Optional label shown alongside the busy indicator, e.g. "Compacting"
    *  for `/compact`. Cleared when the turn ends. */

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -66,6 +66,10 @@ export interface WorkspaceSlice {
    *  that turn. Drives the send-button disabled state and the
    *  "thinking…" indicator. */
   managedBusy: Record<string, boolean>;
+  /** Client wall-clock millis when the current turn entered `running` — the
+   *  live-timer anchor. Captured here (not from send time) so it lines up with
+   *  the backend's post-spawn `started_at`; re-stamped each turn. */
+  turnStartedAt: Record<string, number>;
   /** Optional label shown alongside the busy indicator, e.g. "Compacting"
    *  for `/compact`. Cleared when the turn ends. */
   managedBusyLabel: Record<string, string | undefined>;

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -31,6 +31,7 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
   transcriptLoading: {},
   transcriptLoaded: {},
   managedBusy: {},
+  turnStartedAt: {},
   managedBusyLabel: {},
   switchInFlight: {},
   unseenResults: {},


### PR DESCRIPTION
Surfaces the per-turn timing recorded on `session_user_turns` (backend landed in #270): a live timer rides the working strip while a turn runs, and an ended turn closes with a footer — "Ran 38s" plus copy-the-response — that doubles as the seam between turns. The live timer is anchored to the turn's `running` event so it matches the persisted duration, and a short debounce absorbs the transient spawn `idle→running` status blip so the strip doesn't flash and the count doesn't reset. Also restricts the inline pending dots to the first turn, gives the working strip a glassy backdrop, and relocates the copy affordance off each agent message into the footer to remove the gap it left.

Verified: `tsc --noEmit`, `vite build`, and `vitest` (327 passed, incl. new `fmtDur` and timing-overlay tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)