### PR TITLE
Rebrand user-facing name: Quorum → Fletch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 <h1>
   <img src="docs/quorum_dark.png" alt="" width="48" valign="middle">
-  Quorum
+  Fletch
 </h1>
 
 ### Run a fleet of AI coding agents in parallel — each in its own sandbox and git worktree.
 
-Quorum is an open-source macOS app for running and managing multiple AI coding agents at once — Claude Code, Codex, Cursor, OpenCode, and more — against a single repository, without them stepping on each other.
+Fletch is an open-source macOS app for running and managing multiple AI coding agents at once — Claude Code, Codex, Cursor, OpenCode, and more — against a single repository, without them stepping on each other.
 
 [![Download for macOS](https://img.shields.io/badge/Download%20for%20macOS-Apple%20Silicon%20%26%20Intel-111?style=for-the-badge&logo=apple)](https://quorum.fwdai.org)
 
@@ -16,28 +16,28 @@ Quorum is an open-source macOS app for running and managing multiple AI coding a
 ![Built with Tauri](https://img.shields.io/badge/Built%20with-Tauri%202-24C8DB.svg)
 
 <!-- Drop a short demo GIF here. Record one full loop: spawn an agent → it works → review the diff → commit/PR. Save it to docs/demo.gif. -->
-<img src="docs/quorum_control_room.jpg" alt="Quorum: spawning multiple AI coding agents in parallel, each in its own git worktree" width="820">
+<img src="docs/quorum_control_room.jpg" alt="Fletch: spawning multiple AI coding agents in parallel, each in its own git worktree" width="820">
 
 </div>
 
 ---
 
-A _quorum_ is the number of members a body needs present to do business. Convene one on your codebase: many coding agents, each isolated in its own worktree and sandbox, all working the same problem in parallel — with you presiding.
+_Fletching_ is the set of feathers that steadies an arrow on its way to the target. Fletch does the same for your codebase: many coding agents, each isolated in its own worktree and sandbox, all working the same problem in parallel — with you presiding.
 
 Every agent runs in its own git worktree under a macOS sandbox, so you can run a dozen at once and they physically can't touch each other's files — or write outside their box. Watch each one as a readable chat or its raw terminal, see its edits as live diffs the moment they land, and commit, push, or open a PR from the same window. Need more throughput? Spawn another. Done with one? Discard it — worktree and branch with it — in a click.
 
-## Why Quorum
+## Why Fletch
 
 - **Real parallelism, no collisions.** Every agent gets its own git worktree and branch. Two agents editing the same file is impossible — they're working different checkouts of the same repo.
 - **Isolated by default.** Each agent runs under a macOS `sandbox-exec` profile that denies writes outside its worktree (plus the agent's own cache/config). It's a write-protection boundary, not a full VM — honest about what it does.
-- **Bring your own agent.** Quorum drives the CLIs you already use and pay for — Claude Code, Codex, Cursor, OpenCode, Pi — through one interface. No new model subscription, no lock-in.
+- **Bring your own agent.** Fletch drives the CLIs you already use and pay for — Claude Code, Codex, Cursor, OpenCode, Pi — through one interface. No new model subscription, no lock-in.
 - **One cockpit.** A normalized chat view of every agent's reasoning and tool calls, a native terminal for its raw TUI, a live feed of its diffs as it edits, an integrated Git/PR panel, plus optional Run and Terminal panels — all per agent.
 - **Start projects, not just sessions.** Clone a repo from GitHub or create a new one (local + published) without dropping to a shell.
-- **Local and private.** A native desktop app. Your code and agent transcripts stay on your machine; nothing routes through a Quorum server.
+- **Local and private.** A native desktop app. Your code and agent transcripts stay on your machine; nothing routes through a Fletch server.
 
 ## Supported agents
 
-Quorum normalizes each agent's transcript into one consistent view, so they all look and behave the same to you.
+Fletch normalizes each agent's transcript into one consistent view, so they all look and behave the same to you.
 
 | Agent                                                             | Status                      |
 | ----------------------------------------------------------------- | --------------------------- |
@@ -48,11 +48,11 @@ Quorum normalizes each agent's transcript into one consistent view, so they all 
 | [Pi](https://pi.dev/)                                             | ✅ Supported                |
 | [Antigravity](https://antigravity.google/product/antigravity-cli) | ✅ Supported (experimental) |
 
-You install and authenticate the agent CLIs you want to use; Quorum detects them on your `PATH` and common install locations.
+You install and authenticate the agent CLIs you want to use; Fletch detects them on your `PATH` and common install locations.
 
 ## Download
 
-**[Download Quorum for macOS →](https://quorum.fwdai.org)** (universal — Apple Silicon & Intel)
+**[Download Fletch for macOS →](https://quorum.fwdai.org)** (universal — Apple Silicon & Intel)
 
 The app is signed, notarized, and updates itself in the background.
 
@@ -66,8 +66,8 @@ No VM, no Docker, no containers.
 
 ## How it works
 
-1. **Point** Quorum at a local git repo.
-2. **Spawn** an agent with a task. Quorum creates an isolated worktree at `~/.quorum/worktrees/<id>/` on a fresh branch.
+1. **Point** Fletch at a local git repo.
+2. **Spawn** an agent with a task. Fletch creates an isolated worktree at `~/.quorum/worktrees/<id>/` on a fresh branch.
 3. **Run.** It launches the agent's CLI in that worktree under `sandbox-exec`, bridged through a local PTY.
 4. **Watch.** Output streams into a tab — switch between a normalized chat view and the raw native terminal.
 5. **Review.** See the agent's edits as live diffs; browse and edit files directly.

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Quorum</title>
+    <title>Fletch</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "Quorum",
-  "mainBinaryName": "Quorum",
+  "productName": "Fletch",
+  "mainBinaryName": "Fletch",
   "version": "0.6.5",
   "identifier": "com.quorum.desktop",
   "build": {
@@ -13,7 +13,7 @@
   "app": {
     "windows": [
       {
-        "title": "Quorum",
+        "title": "Fletch",
         "width": 1280,
         "height": 800,
         "minWidth": 900,

--- a/src/components/Onboarding/beats.tsx
+++ b/src/components/Onboarding/beats.tsx
@@ -55,7 +55,7 @@ const BEAT_PROVIDERS: BeatDef = {
   ),
   lede: (
     <>
-      Point Quorum at the agents you already pay for. Switch per task, compare side by side —{" "}
+      Point Fletch at the agents you already pay for. Switch per task, compare side by side —{" "}
       <b>no lock-in, ever.</b>
     </>
   ),
@@ -88,7 +88,7 @@ const BEAT_ROOM: BeatDef = {
   lede: (
     <>
       Home shows you what's running, what's waiting, and what needs you — across every project.{" "}
-      <b>The whole quorum, one room.</b>
+      <b>The whole fleet, one room.</b>
     </>
   ),
   points: [

--- a/src/components/Onboarding/exhibits.tsx
+++ b/src/components/Onboarding/exhibits.tsx
@@ -123,7 +123,7 @@ export function ExhibitParallel() {
   return (
     <div className="ob-exhibit-wrap ob-reveal" style={{ "--d": ".25s" } as React.CSSProperties}>
       <div className="ob-exhibit">
-        <ExBar title="quorum — worktrees" />
+        <ExBar title="fletch — worktrees" />
         <div className="ex-side">
           <div className="proj">
             <div className="proj-h flex-center open">
@@ -161,7 +161,7 @@ export function ExhibitProviders() {
   return (
     <div className="ob-exhibit-wrap ob-reveal" style={{ "--d": ".25s" } as React.CSSProperties}>
       <div className="ob-exhibit">
-        <ExBar title="quorum — providers" />
+        <ExBar title="fletch — providers" />
         <div className="ex-providers">
           {list.map((p, i) => (
             <div key={p.id} className={`ex-prov ${i < lit ? "on" : ""}`}>
@@ -249,12 +249,12 @@ export function ExhibitRoom() {
   return (
     <div className="ob-exhibit-wrap ob-reveal" style={{ "--d": ".25s" } as React.CSSProperties}>
       <div className="ob-exhibit">
-        <ExBar title="quorum — home" />
+        <ExBar title="fletch — home" />
         <div className="ex-room">
           <div className="ex-room-head">
             <div className="ex-room-mark">
               <span className="d" />
-              QUORUM
+              FLETCH
             </div>
             <div className="ex-room-when">
               Thu, Jun 4<span className="sep">·</span>9:24 AM
@@ -332,7 +332,7 @@ export function ExhibitCode() {
   return (
     <div className="ob-exhibit-wrap ob-reveal" style={{ "--d": ".25s" } as React.CSSProperties}>
       <div className="ob-exhibit">
-        <ExBar title="quorum — code" />
+        <ExBar title="fletch — code" />
         <div className="ex-code">
           <div className="ex-code-tabs">
             <span className="ex-ctab active">

--- a/src/components/Onboarding/index.tsx
+++ b/src/components/Onboarding/index.tsx
@@ -191,7 +191,7 @@ export function Onboarding() {
         <div className="ob-tb-gutter" data-tauri-drag-region />
         <div className="ob-tb-mark text-xs">
           <span className="d" />
-          <span>QUORUM</span>
+          <span>FLETCH</span>
         </div>
         <div className="ob-tb-right">
           {step.kind !== "ignite" && (

--- a/src/components/Onboarding/steps.tsx
+++ b/src/components/Onboarding/steps.tsx
@@ -70,13 +70,13 @@ export function WelcomeStep({
           <span className="mk">
             <PeaksMark />
           </span>
-          <span className="wd text-lg">QUORUM</span>
+          <span className="wd text-lg">FLETCH</span>
         </div>
         <h1 className="ob-display ob-reveal" style={{ "--d": ".16s" } as CSSProperties}>
           A new era of <em>agentic</em> engineering.
         </h1>
         <p className="ob-lede ob-reveal" style={{ "--d": ".30s" } as CSSProperties}>
-          Direct a quorum of coding agents in parallel — each in its own worktree. Review, refine,
+          Direct a fleet of coding agents in parallel — each in its own worktree. Review, refine,
           and ship from one quiet control room.
         </p>
 
@@ -103,7 +103,7 @@ export function WelcomeStep({
         </div>
 
         <p className="ob-legal ob-reveal text-xs" style={{ "--d": ".58s" } as CSSProperties}>
-          By continuing you agree to Quorum's{" "}
+          By continuing you agree to Fletch's{" "}
           <a
             href={TERMS_URL}
             onClick={(e) => {
@@ -201,7 +201,7 @@ export function IgniteStep({ onEnter }: { onEnter: () => void }) {
           )}
         </h2>
         <p className="ob-lede ob-reveal" style={{ "--d": ".28s" } as CSSProperties}>
-          Signing in connected your Quorum identity. To run agents you bring your own CLIs — here's
+          Signing in connected your Fletch identity. To run agents you bring your own CLIs — here's
           what's on your machine.
         </p>
         <div className="ob-readiness ob-reveal" style={{ "--d": ".4s" } as CSSProperties}>
@@ -212,11 +212,11 @@ export function IgniteStep({ onEnter }: { onEnter: () => void }) {
           style={{ "--d": ".56s" } as CSSProperties}
           onClick={onEnter}
         >
-          Enter Quorum
+          Enter Fletch
           <Icon name="arrowR" />
         </button>
         <p className="ob-fineprint ob-reveal text-sm" style={{ "--d": ".64s" } as CSSProperties}>
-          Quorum shares anonymous usage data to improve the app. Turn it off anytime in Settings ›
+          Fletch shares anonymous usage data to improve the app. Turn it off anytime in Settings ›
           General.
         </p>
       </div>

--- a/src/components/SettingsScreen/DeveloperPane.tsx
+++ b/src/components/SettingsScreen/DeveloperPane.tsx
@@ -15,7 +15,7 @@ export function DeveloperPane() {
       <SetHead
         eyebrow="Settings · Developer"
         title="Developer"
-        desc="Tools for working on Quorum itself. Only available in development builds."
+        desc="Tools for working on Fletch itself. Only available in development builds."
       />
 
       <SetGroup label="Onboarding">

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -61,7 +61,7 @@ export function GeneralPane() {
       <SetHead
         eyebrow="Settings · General"
         title="General"
-        desc="Tune how Quorum looks and which surfaces appear while you work. Changes apply instantly across every agent."
+        desc="Tune how Fletch looks and which surfaces appear while you work. Changes apply instantly across every agent."
       />
 
       <SetGroup label="Appearance">
@@ -119,13 +119,13 @@ export function GeneralPane() {
       <SetGroup label="Diagnostics" last>
         <SetRow
           title="Usage analytics"
-          sub="Share anonymous usage events (app opens, agents spawned, PRs opened) to help improve Quorum. No code, file paths, repo names, or prompts are ever sent."
+          sub="Share anonymous usage events (app opens, agents spawned, PRs opened) to help improve Fletch. No code, file paths, repo names, or prompts are ever sent."
         >
           <SetToggle on={telemetryEnabled} onClick={() => setTelemetryEnabled(!telemetryEnabled)} />
         </SetRow>
         <SetRow
           title="Logs"
-          sub="Quorum writes a local log file. Reveal it to attach to a bug report."
+          sub="Fletch writes a local log file. Reveal it to attach to a bug report."
         >
           <Button variant="outline" onClick={() => void revealLogs()}>
             <Icon name="folder" size={12} />

--- a/src/components/SettingsScreen/index.tsx
+++ b/src/components/SettingsScreen/index.tsx
@@ -75,7 +75,7 @@ export function SettingsScreen() {
           ))}
         </div>
         <div className="set-nav-foot text-xs">
-          <span className="mono">Quorum</span>
+          <span className="mono">Fletch</span>
           <span className="mono dim">v{pkg.version}</span>
         </div>
       </nav>

--- a/src/components/TitleBar/TitleBar.css
+++ b/src/components/TitleBar/TitleBar.css
@@ -24,22 +24,7 @@
   pointer-events: none;
 }
 .tb-wordmark {
-  /* plain inline context so the Q mark aligns via vertical-align (see
-   * .tb-qmark) — avoids the flex replaced-element baseline quirks that
-   * differ across WebKit/Gecko (this ships in WKWebView under Tauri) */
   font-family: var(--font-geist);
-}
-.tb-qmark {
-  /* sized so the ring reads at the x-height of the lowercase "uorum"
-   * rather than towering at cap height */
-  width: 0.7em;
-  height: 0.7em;
-  /* vertical-align: middle == baseline + half the parent x-height, i.e.
-   * the optical center of the lowercase "uorum". Deterministic across
-   * engines, unlike replaced-element baseline alignment. */
-  vertical-align: middle;
-  /* small gap so the mark reads as the leading glyph of "uorum" */
-  margin-right: 1px;
 }
 .tb-badge {
   height: 16px;

--- a/src/components/TitleBar/index.tsx
+++ b/src/components/TitleBar/index.tsx
@@ -1,7 +1,6 @@
 import { useAppStore } from "../../store";
 import { basename, hueFromString } from "../../util/format";
 import { Icon } from "../Icon";
-import { QMark } from "../QMark";
 import { IconButton } from "../ui/IconButton";
 import { Breadcrumb, type CrumbEntry } from "./Breadcrumb";
 
@@ -20,10 +19,9 @@ export function TitleBar() {
   return (
     <div className="tb flex-center" data-tauri-drag-region>
       <div className="tb-lights-gutter" data-tauri-drag-region />
-      <div className="tb-logo iflex-center text-lg" data-tauri-drag-region aria-label="Quorum">
+      <div className="tb-logo iflex-center text-lg" data-tauri-drag-region aria-label="Fletch">
         <span className="tb-wordmark" aria-hidden="true">
-          <QMark className="tb-qmark" />
-          uorum
+          Fletch
         </span>
         <span className="tb-badge iflex-center text-xs">beta</span>
       </div>

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -40,7 +40,7 @@ export function Workspace() {
           title={!workspace ? "Loading…" : agents.length === 0 ? "No agents yet" : "Pick an agent"}
           body={
             !workspace
-              ? "Connecting to Quorum…"
+              ? "Connecting to Fletch…"
               : agents.length === 0
                 ? "Click the + button on a project to spawn one, or add a repo from the sidebar."
                 : "Choose an agent from the sidebar to attach."

--- a/src/data/codeThemes.ts
+++ b/src/data/codeThemes.ts
@@ -12,7 +12,7 @@ export interface CodeThemeDef {
 }
 
 export const CODE_THEMES: CodeThemeDef[] = [
-  { id: "quorum", label: "Quorum", dark: null, light: null },
+  { id: "quorum", label: "Fletch", dark: null, light: null },
   { id: "github", label: "GitHub", dark: "github-dark", light: "github" },
   { id: "atom-one", label: "Atom One", dark: "atom-one-dark", light: "atom-one-light" },
   { id: "tokyo-night", label: "Tokyo Night", dark: "tokyo-night-dark", light: "tokyo-night-light" },


### PR DESCRIPTION
First of two PRs for the **Quorum → Fletch** rebrand. This one covers **user-facing branding only** — every place a user reads the app name. It's intentionally limited to display strings so it's safe to ship without breaking existing installs.

## What changed
- **App shell:** `tauri.conf.json` `productName` / `mainBinaryName` / window title; `index.html` `<title>`
- **Onboarding:** wordmarks, hero lede, legal line, "Enter Fletch" CTA, exhibit mock titlebars
- **Settings** panes, **TitleBar**, and the "Connecting to Fletch…" empty state
- **Code-theme label** → "Fletch" (the persisted `id` stays `"quorum"` so saved preferences don't reset)
- **README** prose + the naming rationale, which was a pun on the word *quorum* — rewritten around a *fletching* (the feathers that steady an arrow) metaphor

The TitleBar used to spell the name with a **"Q" letterform** (`QMark`) followed by "uorum". That trick can't render "Fletch", so the title bar now uses a plain text wordmark and the associated dead CSS is removed.

## Deliberately NOT changed (follow-up needed)
These would break existing installs, need a design asset, or are infra — left for the code-sweep PR / a coordinated change:

| Item | Why left alone |
|---|---|
| `com.quorum.desktop` bundle id, `data_dir`, `quorum.db` | Changing orphans every existing user's data and breaks auto-updates — needs a migration |
| Updater endpoint + README download URLs (`quorum.fwdai.org`) | Live site / infra |
| `QUORUM_*` build env vars | CI/build secrets |
| `~/.quorum/worktrees/` paths | Real on-disk paths; change with the migration |
| `QMark.tsx` letterform + `docs/quorum_*.png\|jpg` | Need a new Fletch logo/screenshots (design) |

## Copy judgment calls (please sanity-check wording)
- "Direct a **fleet** of coding agents" (was "a quorum of") — "fleet" already appears in the README tagline
- "The whole **fleet**, one room." (was "The whole quorum, one room.")
- README rationale rewritten to the fletching/arrow metaphor

## Verification
- `bun run check` (tsc) — clean
- `bun run test` — 327 passed
- lint on changed files — no new errors

Follow-up PR will do the internal code sweep (comments, `isQuorum` vars, `<quorum-system>` tag, `package.json` name, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)