### PR TITLE
Rebrand code sweep: Quorum → Fletch (comments, docs, internals)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 <h1>
   <img src="docs/quorum_dark.png" alt="" width="48" valign="middle">
-  Quorum
+  Fletch
 </h1>
 
 ### Run a fleet of AI coding agents in parallel — each in its own sandbox and git worktree.
 
-Quorum is an open-source macOS app for running and managing multiple AI coding agents at once — Claude Code, Codex, Cursor, OpenCode, and more — against a single repository, without them stepping on each other.
+Fletch is an open-source macOS app for running and managing multiple AI coding agents at once — Claude Code, Codex, Cursor, OpenCode, and more — against a single repository, without them stepping on each other.
 
 [![Download for macOS](https://img.shields.io/badge/Download%20for%20macOS-Apple%20Silicon%20%26%20Intel-111?style=for-the-badge&logo=apple)](https://quorum.fwdai.org)
 
@@ -16,28 +16,28 @@ Quorum is an open-source macOS app for running and managing multiple AI coding a
 ![Built with Tauri](https://img.shields.io/badge/Built%20with-Tauri%202-24C8DB.svg)
 
 <!-- Drop a short demo GIF here. Record one full loop: spawn an agent → it works → review the diff → commit/PR. Save it to docs/demo.gif. -->
-<img src="docs/quorum_control_room.jpg" alt="Quorum: spawning multiple AI coding agents in parallel, each in its own git worktree" width="820">
+<img src="docs/quorum_control_room.jpg" alt="Fletch: spawning multiple AI coding agents in parallel, each in its own git worktree" width="820">
 
 </div>
 
 ---
 
-A _quorum_ is the number of members a body needs present to do business. Convene one on your codebase: many coding agents, each isolated in its own worktree and sandbox, all working the same problem in parallel — with you presiding.
+_Fletching_ is the set of feathers that steadies an arrow on its way to the target. Fletch does the same for your codebase: many coding agents, each isolated in its own worktree and sandbox, all working the same problem in parallel — with you presiding.
 
 Every agent runs in its own git worktree under a macOS sandbox, so you can run a dozen at once and they physically can't touch each other's files — or write outside their box. Watch each one as a readable chat or its raw terminal, see its edits as live diffs the moment they land, and commit, push, or open a PR from the same window. Need more throughput? Spawn another. Done with one? Discard it — worktree and branch with it — in a click.
 
-## Why Quorum
+## Why Fletch
 
 - **Real parallelism, no collisions.** Every agent gets its own git worktree and branch. Two agents editing the same file is impossible — they're working different checkouts of the same repo.
 - **Isolated by default.** Each agent runs under a macOS `sandbox-exec` profile that denies writes outside its worktree (plus the agent's own cache/config). It's a write-protection boundary, not a full VM — honest about what it does.
-- **Bring your own agent.** Quorum drives the CLIs you already use and pay for — Claude Code, Codex, Cursor, OpenCode, Pi — through one interface. No new model subscription, no lock-in.
+- **Bring your own agent.** Fletch drives the CLIs you already use and pay for — Claude Code, Codex, Cursor, OpenCode, Pi — through one interface. No new model subscription, no lock-in.
 - **One cockpit.** A normalized chat view of every agent's reasoning and tool calls, a native terminal for its raw TUI, a live feed of its diffs as it edits, an integrated Git/PR panel, plus optional Run and Terminal panels — all per agent.
 - **Start projects, not just sessions.** Clone a repo from GitHub or create a new one (local + published) without dropping to a shell.
-- **Local and private.** A native desktop app. Your code and agent transcripts stay on your machine; nothing routes through a Quorum server.
+- **Local and private.** A native desktop app. Your code and agent transcripts stay on your machine; nothing routes through a Fletch server.
 
 ## Supported agents
 
-Quorum normalizes each agent's transcript into one consistent view, so they all look and behave the same to you.
+Fletch normalizes each agent's transcript into one consistent view, so they all look and behave the same to you.
 
 | Agent                                                             | Status                      |
 | ----------------------------------------------------------------- | --------------------------- |
@@ -48,11 +48,11 @@ Quorum normalizes each agent's transcript into one consistent view, so they all 
 | [Pi](https://pi.dev/)                                             | ✅ Supported                |
 | [Antigravity](https://antigravity.google/product/antigravity-cli) | ✅ Supported (experimental) |
 
-You install and authenticate the agent CLIs you want to use; Quorum detects them on your `PATH` and common install locations.
+You install and authenticate the agent CLIs you want to use; Fletch detects them on your `PATH` and common install locations.
 
 ## Download
 
-**[Download Quorum for macOS →](https://quorum.fwdai.org)** (universal — Apple Silicon & Intel)
+**[Download Fletch for macOS →](https://quorum.fwdai.org)** (universal — Apple Silicon & Intel)
 
 The app is signed, notarized, and updates itself in the background.
 
@@ -66,8 +66,8 @@ No VM, no Docker, no containers.
 
 ## How it works
 
-1. **Point** Quorum at a local git repo.
-2. **Spawn** an agent with a task. Quorum creates an isolated worktree at `~/.quorum/worktrees/<id>/` on a fresh branch.
+1. **Point** Fletch at a local git repo.
+2. **Spawn** an agent with a task. Fletch creates an isolated worktree at `~/.quorum/worktrees/<id>/` on a fresh branch.
 3. **Run.** It launches the agent's CLI in that worktree under `sandbox-exec`, bridged through a local PTY.
 4. **Watch.** Output streams into a tab — switch between a normalized chat view and the raw native terminal.
 5. **Review.** See the agent's edits as live diffs; browse and edit files directly.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,6 +1,6 @@
-# Releasing Quorum
+# Releasing Fletch
 
-Quorum ships as a signed + notarized **universal** macOS app, distributed via
+Fletch ships as a signed + notarized **universal** macOS app, distributed via
 GitHub Releases, with a silent in-app auto-updater. This doc covers the one-time
 setup and the per-release procedure.
 
@@ -16,7 +16,7 @@ bump version → run Release workflow (manual) → CI builds/signs/notarizes
 - **Sign:** Developer ID Application cert (Team `UFBL3F444A`).
 - **Notarize + staple:** handled automatically by `tauri-apps/tauri-action`.
 - **Update artifacts:** `createUpdaterArtifacts: true` emits `<app>.app.tar.gz`
-  and a `.sig` signed with the Quorum minisign key.
+  and a `.sig` signed with the Fletch minisign key.
 
 ## One-time setup
 
@@ -25,7 +25,7 @@ bump version → run Release workflow (manual) → CI builds/signs/notarizes
 A minisign keypair signs every update artifact; the app verifies it with the
 public key embedded in `src-tauri/tauri.conf.json` (`plugins.updater.pubkey`).
 
-A keypair was generated for Quorum and the **public** key is already committed.
+A keypair was generated for Fletch and the **public** key is already committed.
 The **private** key lives outside the repo at `~/.tauri/quorum.key`. To
 regenerate (e.g. to set a password), run:
 
@@ -93,7 +93,7 @@ the app verifies against the embedded pubkey — the proxy can't forge an update
    - `src-tauri/Cargo.toml` → `version`
 2. Merge that to `main`.
 3. Run the **Release** workflow: GitHub → Actions → *Release* → *Run workflow*.
-4. Wait for it to finish. It creates a **draft** release `Quorum v<version>`
+4. Wait for it to finish. It creates a **draft** release `Fletch v<version>`
    with the `.dmg`, `.app.tar.gz`, `.app.tar.gz.sig`, and `latest.json`.
 5. Review the draft, then **Publish** it. Once published, the endpoint serves
    the new `latest.json` and installed apps pick it up on next launch.

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Quorum</title>
+    <title>Fletch</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Default capability for Quorum",
+  "description": "Default capability for Fletch",
   "windows": ["main"],
   "permissions": [
     "core:default",

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -73,7 +73,7 @@ pub struct PerTurnSpec {
     /// Session-level model override. `None` keeps the provider CLI default.
     pub model: Option<String>,
     /// A custom agent's standing instructions, snapshotted on the session and
-    /// injected into every turn (appended after Quorum's global system prompt).
+    /// injected into every turn (appended after Fletch's global system prompt).
     /// `None` for a plain built-in spawn.
     pub instructions: Option<String>,
     /// The agent's RPC mailbox dir, exposed to the child as `QUORUM_RPC_DIR`.
@@ -758,7 +758,7 @@ pub struct SpawnSpec<'a> {
     pub effort: Option<&'a str>,
     /// Session-level model override. `None` keeps the provider CLI default.
     pub model: Option<&'a str>,
-    /// A custom agent's standing instructions, injected after Quorum's global
+    /// A custom agent's standing instructions, injected after Fletch's global
     /// system prompt on every spawn/resume. `None` for a plain built-in spawn.
     pub instructions: Option<&'a str>,
     /// The agent's RPC mailbox dir, exposed to the child as `QUORUM_RPC_DIR`.
@@ -767,7 +767,7 @@ pub struct SpawnSpec<'a> {
     pub rows: u16,
 }
 
-/// The environment Quorum injects into every agent child: the absolute path to
+/// The environment Fletch injects into every agent child: the absolute path to
 /// its file-mailbox RPC dir. The agent posts requests there for the app to
 /// execute (see `rpc.rs`). Layered on top of the inherited environment.
 fn rpc_env(rpc_dir: &Path) -> Vec<(String, String)> {
@@ -845,7 +845,7 @@ impl Agent {
         let agent_args = (desc.pty_args)(session, spec.model, spec.instructions);
         let env = rpc_env(&spec.rpc_dir);
 
-        // Unified sandbox: run the agent's TUI under sandbox-exec with Quorum's
+        // Unified sandbox: run the agent's TUI under sandbox-exec with Fletch's
         // profile (the agent's own sandbox is disabled in its arg builder), so
         // per-turn agents are confined exactly like claude. argv becomes
         // `sandbox-exec -f <profile> <agent-bin> <agent-args…>`.
@@ -989,7 +989,7 @@ impl Agent {
         H: Fn(ExecExit) + Send + Sync + 'static,
     {
         // Unified sandbox: wrap each turn's process in sandbox-exec with
-        // Quorum's profile. The agent binary moves into `prefix_args`
+        // Fletch's profile. The agent binary moves into `prefix_args`
         // (`sandbox-exec -f <profile> <agent-bin>`), and the profile tempfile
         // rides on the ExecSession so it outlives the per-turn respawns.
         let home = dirs::home_dir()
@@ -1118,7 +1118,7 @@ fn prepare_sandbox(
     home: &Path,
 ) -> Result<tempfile::NamedTempFile> {
     // The agent inherits the app's env, so the CLAUDE_CONFIG_DIR it'll write to
-    // is whatever this process sees (quorum doesn't override it). Grant it.
+    // is whatever this process sees (fletch doesn't override it). Grant it.
     let claude_config_dir = std::env::var_os("CLAUDE_CONFIG_DIR").map(PathBuf::from);
     let profile_text =
         sandbox::build_profile(writable_root, rpc_dir, home, claude_config_dir.as_deref())?;
@@ -1267,7 +1267,7 @@ fn resolve_claude(home: &Path) -> Result<String> {
 
 /// Codex: `codex exec [resume <id>] --json …`. Approvals off and codex's own
 /// sandbox set to `danger-full-access` via `-c` (works on both `exec` and
-/// `exec resume`, unlike the `-s`/`-a` flags). Quorum now runs codex under
+/// `exec resume`, unlike the `-s`/`-a` flags). Fletch now runs codex under
 /// sandbox-exec like every other agent, so codex's own confinement is disabled
 /// to leave a single boundary — and so codex can reach its RPC mailbox, which
 /// lives outside the worktree that `workspace-write` would have confined it to.
@@ -1412,7 +1412,7 @@ fn pi_session_id(event: &Value) -> Option<String> {
 // cursor-agent 2026.06, opencode 1.15, pi 0.74+.
 
 /// Codex: bare `codex` launches the interactive TUI;
-/// `--dangerously-bypass-approvals-and-sandbox` runs it unattended (Quorum
+/// `--dangerously-bypass-approvals-and-sandbox` runs it unattended (Fletch
 /// already isolates the worktree). `resume <id>` continues a prior session.
 fn codex_pty_args(session_id: Option<&str>, model: Option<&str>, extra: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = vec!["--dangerously-bypass-approvals-and-sandbox".into()];
@@ -1946,7 +1946,7 @@ mod tests {
 
     #[test]
     fn codex_args_disable_codex_own_sandbox() {
-        // Quorum now wraps codex in sandbox-exec, so codex's own confinement is
+        // Fletch now wraps codex in sandbox-exec, so codex's own confinement is
         // turned fully off — otherwise its workspace-write sandbox would block
         // the RPC mailbox, which lives outside the worktree.
         let args = codex_build_args("hi", None, None, None, None);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -25,9 +25,9 @@ pub fn get_workspace(supervisor: State<'_, Arc<Supervisor>>) -> Option<Workspace
     supervisor.current_workspace()
 }
 
-/// Reveal Quorum's log folder in the OS file manager so a user can attach
+/// Reveal Fletch's log folder in the OS file manager so a user can attach
 /// logs to a bug report. Creates the folder if no session has written to it
-/// yet. Quorum ships macOS-only (sandbox-exec), but the CI build runs on
+/// yet. Fletch ships macOS-only (sandbox-exec), but the CI build runs on
 /// Linux, so the opener binary is chosen per-platform rather than hard-coding
 /// `open`.
 #[tauri::command]

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -1,10 +1,10 @@
 //! Agent instruction injection.
 //!
-//! A single source of truth for the system-prompt-level instructions Quorum
+//! A single source of truth for the system-prompt-level instructions Fletch
 //! injects into every agent — edit `instructions/system_prompt.md` and every
 //! agent picks it up on its next spawn. There is no other copy.
 //!
-//! Quorum drives heterogeneous agent CLIs, and they expose different slots for
+//! Fletch drives heterogeneous agent CLIs, and they expose different slots for
 //! app-supplied guidance, so the *delivery* is per-agent while the *text* is
 //! shared:
 //!
@@ -18,9 +18,9 @@
 //!   accumulating copies).
 //!
 //! The injected text has three layers: editable general guidance
-//! (`instructions/system_prompt.md`), a Quorum-managed protocol block
+//! (`instructions/system_prompt.md`), a Fletch-managed protocol block
 //! (`instructions/rpc_protocol.md`) that documents the file-RPC transport the
-//! app exposes (see `rpc.rs`), and Quorum-managed feature playbooks (for
+//! app exposes (see `rpc.rs`), and Fletch-managed feature playbooks (for
 //! example `instructions/git_actions.md`) behind the panel's `[app-action]`
 //! triggers. The managed blocks are code-managed because they must stay in
 //! sync with the op allowlist / trigger names; the general layer is yours to
@@ -30,10 +30,10 @@
 /// Editable general guidance. Edit the file, not this constant.
 const SYSTEM_PROMPT: &str = include_str!("instructions/system_prompt.md");
 
-/// Quorum-managed RPC protocol block, appended after the general guidance.
+/// Fletch-managed RPC protocol block, appended after the general guidance.
 const RPC_INSTRUCTIONS: &str = include_str!("instructions/rpc_protocol.md");
 
-/// Quorum-managed git-action playbooks. The panel sends a short
+/// Fletch-managed git-action playbooks. The panel sends a short
 /// `[app-action] <name>` trigger; the full per-action instructions live here
 /// so the chat transcript stays free of boilerplate. Code-managed: must stay
 /// in sync with the trigger names the frontend sends (see
@@ -106,7 +106,7 @@ pub fn prepend_to_prompt(prompt: &str, session_id: Option<&str>, extra: Option<&
     }
     // Wrap in a namespaced tag so the UI can strip this block from the user
     // bubble (these agents echo the prompt back into the transcript). The tag
-    // is Quorum-specific to avoid colliding with real user content.
+    // is Fletch-specific to avoid colliding with real user content.
     format!("<quorum-system>\n{text}\n</quorum-system>\n\n{prompt}")
 }
 

--- a/src-tauri/src/instructions/git_actions.md
+++ b/src-tauri/src/instructions/git_actions.md
@@ -1,4 +1,4 @@
-## Quorum app git actions
+## Fletch app git actions
 
 When the user clicks a git action in the app, the app sends a one-line request on their behalf:
 

--- a/src-tauri/src/instructions/rpc_protocol.md
+++ b/src-tauri/src/instructions/rpc_protocol.md
@@ -1,4 +1,4 @@
-## Quorum app RPC
+## Fletch app RPC
 
 Your writes are confined to your worktree. When an agent needs the app to do
 something it cannot do itself, send a JSON request through the mailbox at
@@ -58,7 +58,7 @@ jq -n --arg id "$ID" --arg msg "$MSG" '{id:$id,op:"echo",args:{message:$msg}}' \
 mv "$QUORUM_RPC_DIR/requests/$ID.json.tmp" "$QUORUM_RPC_DIR/requests/$ID.json"
 ```
 
-The exact op names are feature-specific. Quorum currently uses this same
+The exact op names are feature-specific. Fletch currently uses this same
 transport for Git actions, and the Git dispatcher also exposes `echo` as a
 simple round-trip check. Future app features can define their own ops on top of
 the same mailbox.

--- a/src-tauri/src/instructions/system_prompt.md
+++ b/src-tauri/src/instructions/system_prompt.md
@@ -1,3 +1,3 @@
-You are running inside Quorum, which runs you in an isolated git worktree under a macOS sandbox: you can read anywhere your user can, but writes are confined to your worktree. Treat the worktree as your workspace and keep all changes inside it.
+You are running inside Fletch, which runs you in an isolated git worktree under a macOS sandbox: you can read anywhere your user can, but writes are confined to your worktree. Treat the worktree as your workspace and keep all changes inside it.
 
 When a task needs an action that the sandbox blocks or that must run outside your worktree, say so explicitly rather than silently failing or trying to work around the sandbox.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,7 +37,7 @@ use crate::workspace::WorkspaceManager;
 
 type DbState = Arc<Mutex<Connection>>;
 
-/// Quorum's on-disk data directory — `~/Library/Application Support/
+/// Fletch's on-disk data directory — `~/Library/Application Support/
 /// com.quorum.desktop` (with a `dev` subfolder under debug builds), matching
 /// what `app.path().app_data_dir()` resolves to in `setup`. Computed without
 /// an `AppHandle` so logging can be initialized before the Tauri app is built,

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -222,7 +222,7 @@ pub async fn oauth_device_login(
 ) -> Result<OAuthProfile, String> {
     let cfg = provider_cfg(&provider)?;
     let http = reqwest::Client::builder()
-        .user_agent("Quorum")
+        .user_agent("Fletch")
         .build()
         .map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/sandbox.rs
+++ b/src-tauri/src/sandbox.rs
@@ -1,5 +1,5 @@
 //! Per-agent macOS sandbox profile — the single, unified isolation layer for
-//! every agent Quorum runs.
+//! every agent Fletch runs.
 //!
 //! The app launches each agent (Claude *and* the per-turn agents — codex,
 //! cursor, opencode, pi, antigravity) under `sandbox-exec` with this profile,

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -1162,7 +1162,7 @@ impl Supervisor {
     /// retries via `sendWhenAgentReady`, reusing the same `turn_id` → one row).
     /// On reload a never-delivered turn renders standalone so the user can retry.
     ///
-    /// This row carries Quorum-origin metadata (text + attachments) that the
+    /// This row carries Fletch-origin metadata (text + attachments) that the
     /// transcript can't; it lives outside `session_records`, which stays a pure
     /// 1:1 mirror of the agent's jsonl. At turn-end `sync_session_records`
     /// matches the row to its canonical transcript user-message and fills in
@@ -2451,7 +2451,7 @@ fn mark_user_turn_started(
     }
     // Stamp the turn's run start with a single timestamp shared by the persisted
     // row and the `turn:started` event, so the live timer and the footer measure
-    // from the identical instant. Native PTY turns have no quorum-origin row (no
+    // from the identical instant. Native PTY turns have no fletch-origin row (no
     // turn_id), so they carry no persisted timing — but still emit the event so
     // their live timer has an anchor.
     let started_at = chrono::Utc::now().timestamp_millis();

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -155,7 +155,7 @@ pub struct AgentRecord {
     #[serde(default)]
     pub model: Option<String>,
     /// A custom agent's standing instructions, snapshotted at spawn and
-    /// re-injected on every process spawn/resume (after Quorum's global system
+    /// re-injected on every process spawn/resume (after Fletch's global system
     /// prompt). `None` for a plain built-in spawn. Snapshotting (rather than
     /// re-resolving from `custom_agents`) keeps a running agent's brief stable
     /// even if the custom agent is later edited or deleted.
@@ -262,7 +262,7 @@ pub struct SessionRecord {
     pub body: serde_json::Value,
 }
 
-/// One Quorum-origin outgoing user message (the `session_user_turns` table).
+/// One Fletch-origin outgoing user message (the `session_user_turns` table).
 /// Carries the attachment metadata the transcript doesn't, plus a `native_id`
 /// link to the canonical `session_records` row once matched at turn-end.
 #[derive(Debug, Clone, serde::Serialize)]
@@ -407,7 +407,7 @@ impl WorkspaceManager {
         // unless a directory still lingers on disk (cleanup failed, or it
         // belongs to another running instance such as a dev build, which shares
         // this same worktrees root). The on-disk listing closes that gap: it's
-        // the only namespace shared across every Quorum process on the machine,
+        // the only namespace shared across every Fletch process on the machine,
         // so a collision there is what actually breaks `git worktree add`.
         let mut stmt =
             conn.prepare("SELECT id FROM workspaces WHERE archived_at IS NULL")?;
@@ -1521,7 +1521,7 @@ pub fn allocate_repo_subdir(repo_path: &Path, used: &[String]) -> String {
 }
 
 /// Absolute path to the root holding every agent's worktrees:
-/// `~/.quorum/worktrees/`. Shared by *all* Quorum processes on the machine
+/// `~/.quorum/worktrees/`. Shared by *all* Fletch processes on the machine
 /// (release and dev builds alike — only the database is namespaced per build),
 /// which is why name allocation has to consult it directly.
 pub fn worktrees_root() -> Result<PathBuf> {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "Quorum",
-  "mainBinaryName": "Quorum",
+  "productName": "Fletch",
+  "mainBinaryName": "Fletch",
   "version": "0.6.5",
   "identifier": "com.quorum.desktop",
   "build": {
@@ -13,7 +13,7 @@
   "app": {
     "windows": [
       {
-        "title": "Quorum",
+        "title": "Fletch",
         "width": 1280,
         "height": 800,
         "minWidth": 900,

--- a/src/adapters/claude/sanitize.ts
+++ b/src/adapters/claude/sanitize.ts
@@ -76,7 +76,7 @@ export function sanitizeUserText(raw: string): SanitizeResult {
     text = cursorQuery[1];
   }
 
-  // Strip the Quorum-injected instruction block at the data layer (not just at
+  // Strip the Fletch-injected instruction block at the data layer (not just at
   // render) so the stored text equals what the user typed — this lets dedup
   // merge the agent's echoed turn with the optimistic one. No-op when absent.
   text = stripInjectedInstructions(text);

--- a/src/adapters/opencode/index.ts
+++ b/src/adapters/opencode/index.ts
@@ -12,7 +12,7 @@ export const opencodeAdapter: ChatAdapter = {
   reduce,
   normalizeTranscript,
   policy: opencodePolicy,
-  // `opencode run` never writes the on-disk blob store Quorum reads, so usage
+  // `opencode run` never writes the on-disk blob store Fletch reads, so usage
   // would never fold from a transcript. Capture it from the live `step_finish`
   // stream instead — persisted into session_records like Cursor's.
   persistLiveUsage: true,

--- a/src/adapters/opencode/reduce.ts
+++ b/src/adapters/opencode/reduce.ts
@@ -63,7 +63,7 @@ export function reduce(prev: ChatItem[], ev: RawEvent): ChatItem[] {
     case "step_start":
       return prev;
 
-    // The user's prompt. Never emitted live (Quorum injects the provider-
+    // The user's prompt. Never emitted live (Fletch injects the provider-
     // agnostic user_message there); normalizeTranscript synthesizes it from a
     // user message's text part during transcript replay.
     case "user_message": {

--- a/src/adapters/opencode/usage.ts
+++ b/src/adapters/opencode/usage.ts
@@ -3,7 +3,7 @@
 // OpenCode reports usage in three shapes depending on the source:
 //   - LIVE `run --format json` stream — the per-step delta nested under `.part`:
 //       {"type":"step_finish","part":{"tokens":{…},"cost":0,"modelID":"…"}}
-//     This is the only path that fires for Quorum: `opencode run` never writes
+//     This is the only path that fires for Fletch: `opencode run` never writes
 //     the on-disk blob store, so usage is captured live (persistLiveUsage) and
 //     stored into session_records.
 //   - ON-DISK assistant message blob (when a transcript is read):

--- a/src/api.ts
+++ b/src/api.ts
@@ -533,7 +533,7 @@ export interface SessionRecord {
   body: Record<string, unknown> & { type?: string };
 }
 
-/** One Quorum-origin outgoing user message (session_user_turns). Carries the
+/** One Fletch-origin outgoing user message (session_user_turns). Carries the
  *  attachment metadata the transcript lacks; `native_id` links it to the
  *  canonical session_records user-message once matched at turn-end (null =
  *  pending or failed — rendered standalone for retry). */

--- a/src/app.css
+++ b/src/app.css
@@ -1,4 +1,4 @@
-/* Quorum styles — split from the original monolithic app.css.
+/* Fletch styles — split from the original monolithic app.css.
  * This file is an ORDERED import manifest: imports are listed in the exact
  * source order of the original stylesheet so the cascade is byte-identical.
  * Foundation → shared primitives → components, each block in original order.

--- a/src/components/Onboarding/beats.tsx
+++ b/src/components/Onboarding/beats.tsx
@@ -55,7 +55,7 @@ const BEAT_PROVIDERS: BeatDef = {
   ),
   lede: (
     <>
-      Point Quorum at the agents you already pay for. Switch per task, compare side by side —{" "}
+      Point Fletch at the agents you already pay for. Switch per task, compare side by side —{" "}
       <b>no lock-in, ever.</b>
     </>
   ),
@@ -88,7 +88,7 @@ const BEAT_ROOM: BeatDef = {
   lede: (
     <>
       Home shows you what's running, what's waiting, and what needs you — across every project.{" "}
-      <b>The whole quorum, one room.</b>
+      <b>The whole fleet, one room.</b>
     </>
   ),
   points: [

--- a/src/components/Onboarding/exhibits.tsx
+++ b/src/components/Onboarding/exhibits.tsx
@@ -1,4 +1,4 @@
-// Onboarding exhibits — small, real-feeling fragments of the Quorum UI,
+// Onboarding exhibits — small, real-feeling fragments of the Fletch UI,
 // framed inside each feature beat. Built from the same visual language as the
 // app so the tour previews the actual product. Ported from the design
 // prototype (onboarding/exhibits.jsx).

--- a/src/components/Onboarding/exhibits.tsx
+++ b/src/components/Onboarding/exhibits.tsx
@@ -123,7 +123,7 @@ export function ExhibitParallel() {
   return (
     <div className="ob-exhibit-wrap ob-reveal" style={{ "--d": ".25s" } as React.CSSProperties}>
       <div className="ob-exhibit">
-        <ExBar title="quorum — worktrees" />
+        <ExBar title="fletch — worktrees" />
         <div className="ex-side">
           <div className="proj">
             <div className="proj-h flex-center open">
@@ -161,7 +161,7 @@ export function ExhibitProviders() {
   return (
     <div className="ob-exhibit-wrap ob-reveal" style={{ "--d": ".25s" } as React.CSSProperties}>
       <div className="ob-exhibit">
-        <ExBar title="quorum — providers" />
+        <ExBar title="fletch — providers" />
         <div className="ex-providers">
           {list.map((p, i) => (
             <div key={p.id} className={`ex-prov ${i < lit ? "on" : ""}`}>
@@ -249,12 +249,12 @@ export function ExhibitRoom() {
   return (
     <div className="ob-exhibit-wrap ob-reveal" style={{ "--d": ".25s" } as React.CSSProperties}>
       <div className="ob-exhibit">
-        <ExBar title="quorum — home" />
+        <ExBar title="fletch — home" />
         <div className="ex-room">
           <div className="ex-room-head">
             <div className="ex-room-mark">
               <span className="d" />
-              QUORUM
+              FLETCH
             </div>
             <div className="ex-room-when">
               Thu, Jun 4<span className="sep">·</span>9:24 AM
@@ -332,7 +332,7 @@ export function ExhibitCode() {
   return (
     <div className="ob-exhibit-wrap ob-reveal" style={{ "--d": ".25s" } as React.CSSProperties}>
       <div className="ob-exhibit">
-        <ExBar title="quorum — code" />
+        <ExBar title="fletch — code" />
         <div className="ex-code">
           <div className="ex-code-tabs">
             <span className="ex-ctab active">

--- a/src/components/Onboarding/index.tsx
+++ b/src/components/Onboarding/index.tsx
@@ -1,4 +1,4 @@
-// Onboarding — a cinematic, native-feeling entry into Quorum. Full-screen
+// Onboarding — a cinematic, native-feeling entry into Fletch. Full-screen
 // overlay shown to new users on first launch and re-openable from Settings ›
 // General. Ported from the design prototype (onboarding/app.jsx): ambient
 // stage, step sequence, cinematic transitions, progress rail, keyboard nav.

--- a/src/components/Onboarding/index.tsx
+++ b/src/components/Onboarding/index.tsx
@@ -191,7 +191,7 @@ export function Onboarding() {
         <div className="ob-tb-gutter" data-tauri-drag-region />
         <div className="ob-tb-mark text-xs">
           <span className="d" />
-          <span>QUORUM</span>
+          <span>FLETCH</span>
         </div>
         <div className="ob-tb-right">
           {step.kind !== "ignite" && (

--- a/src/components/Onboarding/onboarding.css
+++ b/src/components/Onboarding/onboarding.css
@@ -1,7 +1,7 @@
-/* ─── Quorum · Onboarding ─────────────────────────────────────────
-   A cinematic, native-feeling entry into Quorum. Builds entirely on the
+/* ─── Fletch · Onboarding ─────────────────────────────────────────
+   A cinematic, native-feeling entry into Fletch. Builds entirely on the
    app's design tokens (app.css): the cool-neutral grays, copper accent,
-   and the landmark/topographic brand DNA. Ported from the Quorum design
+   and the landmark/topographic brand DNA. Ported from the Fletch design
    prototype (onboarding/onboarding.css). */
 
 /* ── overlay frame ────────────────────────────────────────────── */

--- a/src/components/Onboarding/steps.tsx
+++ b/src/components/Onboarding/steps.tsx
@@ -70,13 +70,13 @@ export function WelcomeStep({
           <span className="mk">
             <PeaksMark />
           </span>
-          <span className="wd text-lg">QUORUM</span>
+          <span className="wd text-lg">FLETCH</span>
         </div>
         <h1 className="ob-display ob-reveal" style={{ "--d": ".16s" } as CSSProperties}>
           A new era of <em>agentic</em> engineering.
         </h1>
         <p className="ob-lede ob-reveal" style={{ "--d": ".30s" } as CSSProperties}>
-          Direct a quorum of coding agents in parallel — each in its own worktree. Review, refine,
+          Direct a fleet of coding agents in parallel — each in its own worktree. Review, refine,
           and ship from one quiet control room.
         </p>
 
@@ -103,7 +103,7 @@ export function WelcomeStep({
         </div>
 
         <p className="ob-legal ob-reveal text-xs" style={{ "--d": ".58s" } as CSSProperties}>
-          By continuing you agree to Quorum's{" "}
+          By continuing you agree to Fletch's{" "}
           <a
             href={TERMS_URL}
             onClick={(e) => {
@@ -201,7 +201,7 @@ export function IgniteStep({ onEnter }: { onEnter: () => void }) {
           )}
         </h2>
         <p className="ob-lede ob-reveal" style={{ "--d": ".28s" } as CSSProperties}>
-          Signing in connected your Quorum identity. To run agents you bring your own CLIs — here's
+          Signing in connected your Fletch identity. To run agents you bring your own CLIs — here's
           what's on your machine.
         </p>
         <div className="ob-readiness ob-reveal" style={{ "--d": ".4s" } as CSSProperties}>
@@ -212,11 +212,11 @@ export function IgniteStep({ onEnter }: { onEnter: () => void }) {
           style={{ "--d": ".56s" } as CSSProperties}
           onClick={onEnter}
         >
-          Enter Quorum
+          Enter Fletch
           <Icon name="arrowR" />
         </button>
         <p className="ob-fineprint ob-reveal text-sm" style={{ "--d": ".64s" } as CSSProperties}>
-          Quorum shares anonymous usage data to improve the app. Turn it off anytime in Settings ›
+          Fletch shares anonymous usage data to improve the app. Turn it off anytime in Settings ›
           General.
         </p>
       </div>

--- a/src/components/Onboarding/steps.tsx
+++ b/src/components/Onboarding/steps.tsx
@@ -12,7 +12,7 @@ import { OnboardingReadiness } from "./OnboardingReadiness";
 const TERMS_URL = "https://quorum.fwdai.org/terms";
 const PRIVACY_URL = "https://quorum.fwdai.org/privacy";
 
-// ── brand mark: the Quorum triple-peak ──────────────────────────────
+// ── brand mark: the Fletch triple-peak ──────────────────────────────
 export function PeaksMark() {
   return (
     <svg
@@ -173,8 +173,8 @@ export function Beat({ beat }: { beat: BeatDef }) {
 
 // ── Step · finale / handoff + readiness ─────────────────────────────
 // The closer doubles as the real setup screen: signing in only connected the
-// user's Quorum identity — agents are their own CLIs, so this is where we show
-// what's actually installed. Non-blocking: "Enter Quorum" is always enabled.
+// user's Fletch identity — agents are their own CLIs, so this is where we show
+// what's actually installed. Non-blocking: "Enter Fletch" is always enabled.
 export function IgniteStep({ onEnter }: { onEnter: () => void }) {
   const providerPaths = useAppStore((s) => s.providerPaths);
   const providersProbed = useAppStore((s) => s.providersProbed);

--- a/src/components/RightPanel/Code/CodeLivePanel.tsx
+++ b/src/components/RightPanel/Code/CodeLivePanel.tsx
@@ -58,7 +58,7 @@ export function CodeLivePanel({
   const busy = useAppStore((s) => s.managedBusy[agent.id] ?? false);
   // Match the editor's syntax theme: the "quorum" palette is gated by `cq`;
   // other families color `.hljs-*` globally via a loaded stylesheet.
-  const isQuorum = useHljsTheme();
+  const isBuiltInTheme = useHljsTheme();
 
   // Reuse the same 1s git poll the Git tab uses; only one right-rail tab is
   // mounted at a time, so this never double-polls.
@@ -277,7 +277,7 @@ export function CodeLivePanel({
         <DiffBody
           hunks={hunks}
           lang={lang}
-          isQuorum={isQuorum}
+          isBuiltInTheme={isBuiltInTheme}
           live={follow && busy && displayPath === liveFile}
           freshKeys={freshKeys}
         />

--- a/src/components/RightPanel/Code/DiffView.tsx
+++ b/src/components/RightPanel/Code/DiffView.tsx
@@ -53,18 +53,18 @@ export function useFileDiff(agentId: string, path: string | null, dep?: string) 
 export function DiffBody({
   hunks,
   lang,
-  isQuorum,
+  isBuiltInTheme,
   live = false,
   freshKeys,
 }: {
   hunks: DiffHunk[];
   lang: string;
-  isQuorum: boolean;
+  isBuiltInTheme: boolean;
   live?: boolean;
   freshKeys?: Set<string>;
 }) {
   return (
-    <div className={`code-diff text-sm ${isQuorum ? "cq" : ""} ${live ? "live" : ""}`}>
+    <div className={`code-diff text-sm ${isBuiltInTheme ? "cq" : ""} ${live ? "live" : ""}`}>
       {hunks.map((h, i) => (
         <div key={i}>
           <div className="code-hunk-h text-xs">{h.header}</div>
@@ -104,12 +104,12 @@ export function FileDiff({
   agentId,
   path,
   lang,
-  isQuorum,
+  isBuiltInTheme,
 }: {
   agentId: string;
   path: string;
   lang: string;
-  isQuorum: boolean;
+  isBuiltInTheme: boolean;
 }) {
   const { hunks, error, loaded } = useFileDiff(agentId, path);
 
@@ -136,5 +136,5 @@ export function FileDiff({
       </div>
     );
   }
-  return <DiffBody hunks={hunks} lang={lang} isQuorum={isQuorum} />;
+  return <DiffBody hunks={hunks} lang={lang} isBuiltInTheme={isBuiltInTheme} />;
 }

--- a/src/components/RightPanel/FilePanel/FileEditor.tsx
+++ b/src/components/RightPanel/FilePanel/FileEditor.tsx
@@ -36,7 +36,7 @@ export function FileEditor({ agent, path, name, dir, file, onBack }: FileEditorP
 
   // Syntax theme: "quorum" uses our palette (gated by the `cq` class); other
   // families load a highlight.js stylesheet that follows the app's dark/light.
-  const isQuorum = useHljsTheme();
+  const isBuiltInTheme = useHljsTheme();
   const codeTheme = useAppStore((s) => s.codeTheme);
   const setCodeTheme = useAppStore((s) => s.setCodeTheme);
   const setLastError = useAppStore((s) => s.setLastError);
@@ -217,7 +217,7 @@ export function FileEditor({ agent, path, name, dir, file, onBack }: FileEditorP
       />
 
       {diffView ? (
-        <FileDiff agentId={agent.id} path={path} lang={file.lang} isQuorum={isQuorum} />
+        <FileDiff agentId={agent.id} path={path} lang={file.lang} isBuiltInTheme={isBuiltInTheme} />
       ) : (
         <>
           {isDeleted && (
@@ -248,7 +248,7 @@ export function FileEditor({ agent, path, name, dir, file, onBack }: FileEditorP
               </div>
             </div>
             <div className="fp-edit-main">
-              <pre className={`fp-hl ${isQuorum ? "cq" : ""}`} ref={hlRef} aria-hidden="true">
+              <pre className={`fp-hl ${isBuiltInTheme ? "cq" : ""}`} ref={hlRef} aria-hidden="true">
                 <code dangerouslySetInnerHTML={{ __html: html }} />
               </pre>
               <textarea

--- a/src/components/RightPanel/FilePanel/index.tsx
+++ b/src/components/RightPanel/FilePanel/index.tsx
@@ -12,7 +12,7 @@
 // through the editor — notably `pendingDirs`, which tracks freshly-created
 // empty folders that git wouldn't otherwise list.
 //
-// Faithful port of the design (quorum v2 files.jsx), wired to the real
+// Faithful port of the design (fletch v2 files.jsx), wired to the real
 // worktree via the `*_worktree_*` Tauri commands.
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { type AgentRecord, api, type WorktreeFile } from "../../../api";

--- a/src/components/RightPanel/RunPanel.css
+++ b/src/components/RightPanel/RunPanel.css
@@ -1,4 +1,4 @@
-/* run panel — styles ported from Quorum v2 prototype */
+/* run panel — styles ported from Fletch v2 prototype */
 .run-wrap {
   flex: 1;
   display: flex;

--- a/src/components/SettingsScreen/DeveloperPane.tsx
+++ b/src/components/SettingsScreen/DeveloperPane.tsx
@@ -15,7 +15,7 @@ export function DeveloperPane() {
       <SetHead
         eyebrow="Settings · Developer"
         title="Developer"
-        desc="Tools for working on Quorum itself. Only available in development builds."
+        desc="Tools for working on Fletch itself. Only available in development builds."
       />
 
       <SetGroup label="Onboarding">

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -61,7 +61,7 @@ export function GeneralPane() {
       <SetHead
         eyebrow="Settings · General"
         title="General"
-        desc="Tune how Quorum looks and which surfaces appear while you work. Changes apply instantly across every agent."
+        desc="Tune how Fletch looks and which surfaces appear while you work. Changes apply instantly across every agent."
       />
 
       <SetGroup label="Appearance">
@@ -119,13 +119,13 @@ export function GeneralPane() {
       <SetGroup label="Diagnostics" last>
         <SetRow
           title="Usage analytics"
-          sub="Share anonymous usage events (app opens, agents spawned, PRs opened) to help improve Quorum. No code, file paths, repo names, or prompts are ever sent."
+          sub="Share anonymous usage events (app opens, agents spawned, PRs opened) to help improve Fletch. No code, file paths, repo names, or prompts are ever sent."
         >
           <SetToggle on={telemetryEnabled} onClick={() => setTelemetryEnabled(!telemetryEnabled)} />
         </SetRow>
         <SetRow
           title="Logs"
-          sub="Quorum writes a local log file. Reveal it to attach to a bug report."
+          sub="Fletch writes a local log file. Reveal it to attach to a bug report."
         >
           <Button variant="outline" onClick={() => void revealLogs()}>
             <Icon name="folder" size={12} />

--- a/src/components/SettingsScreen/index.tsx
+++ b/src/components/SettingsScreen/index.tsx
@@ -75,7 +75,7 @@ export function SettingsScreen() {
           ))}
         </div>
         <div className="set-nav-foot text-xs">
-          <span className="mono">Quorum</span>
+          <span className="mono">Fletch</span>
           <span className="mono dim">v{pkg.version}</span>
         </div>
       </nav>

--- a/src/components/TitleBar/TitleBar.css
+++ b/src/components/TitleBar/TitleBar.css
@@ -24,22 +24,7 @@
   pointer-events: none;
 }
 .tb-wordmark {
-  /* plain inline context so the Q mark aligns via vertical-align (see
-   * .tb-qmark) — avoids the flex replaced-element baseline quirks that
-   * differ across WebKit/Gecko (this ships in WKWebView under Tauri) */
   font-family: var(--font-geist);
-}
-.tb-qmark {
-  /* sized so the ring reads at the x-height of the lowercase "uorum"
-   * rather than towering at cap height */
-  width: 0.7em;
-  height: 0.7em;
-  /* vertical-align: middle == baseline + half the parent x-height, i.e.
-   * the optical center of the lowercase "uorum". Deterministic across
-   * engines, unlike replaced-element baseline alignment. */
-  vertical-align: middle;
-  /* small gap so the mark reads as the leading glyph of "uorum" */
-  margin-right: 1px;
 }
 .tb-badge {
   height: 16px;

--- a/src/components/TitleBar/index.tsx
+++ b/src/components/TitleBar/index.tsx
@@ -1,7 +1,6 @@
 import { useAppStore } from "../../store";
 import { basename, hueFromString } from "../../util/format";
 import { Icon } from "../Icon";
-import { QMark } from "../QMark";
 import { IconButton } from "../ui/IconButton";
 import { Breadcrumb, type CrumbEntry } from "./Breadcrumb";
 
@@ -20,10 +19,9 @@ export function TitleBar() {
   return (
     <div className="tb flex-center" data-tauri-drag-region>
       <div className="tb-lights-gutter" data-tauri-drag-region />
-      <div className="tb-logo iflex-center text-lg" data-tauri-drag-region aria-label="Quorum">
+      <div className="tb-logo iflex-center text-lg" data-tauri-drag-region aria-label="Fletch">
         <span className="tb-wordmark" aria-hidden="true">
-          <QMark className="tb-qmark" />
-          uorum
+          Fletch
         </span>
         <span className="tb-badge iflex-center text-xs">beta</span>
       </div>

--- a/src/components/TitleBar/index.tsx
+++ b/src/components/TitleBar/index.tsx
@@ -4,7 +4,7 @@ import { Icon } from "../Icon";
 import { IconButton } from "../ui/IconButton";
 import { Breadcrumb, type CrumbEntry } from "./Breadcrumb";
 
-/** Top-of-window bar. Houses the breadcrumb (Quorum / repo / agent)
+/** Top-of-window bar. Houses the breadcrumb (Fletch / repo / agent)
  *  and the settings toggle. Drag + native double-click-to-zoom is
  *  handled by Tauri via the `data-tauri-drag-region` attribute — any
  *  click whose target carries that attribute is processed by the
@@ -38,7 +38,7 @@ export function TitleBar() {
   );
 }
 
-/** Derive the breadcrumb from active draft / agent. Quorum > repo > agent. */
+/** Derive the breadcrumb from active draft / agent. Fletch > repo > agent. */
 function useCrumb(): CrumbEntry[] {
   const workspace = useAppStore((s) => s.workspace);
   const selectedId = useAppStore((s) => s.selectedAgentId);

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -40,7 +40,7 @@ export function Workspace() {
           title={!workspace ? "Loading…" : agents.length === 0 ? "No agents yet" : "Pick an agent"}
           body={
             !workspace
-              ? "Connecting to Quorum…"
+              ? "Connecting to Fletch…"
               : agents.length === 0
                 ? "Click the + button on a project to spawn one, or add a repo from the sidebar."
                 : "Choose an agent from the sidebar to attach."

--- a/src/components/Workspace/messages/UserInput/parse.ts
+++ b/src/components/Workspace/messages/UserInput/parse.ts
@@ -4,7 +4,7 @@
 // into the `tool_result` text we feed to Claude's stdin to unblock the turn.
 //
 // Only Claude surfaces these in the custom-view JSON stream today; every other
-// provider Quorum drives runs fully auto-approved (see the adapter map). The
+// provider Fletch drives runs fully auto-approved (see the adapter map). The
 // model is provider-agnostic, so any tool reported under these names renders
 // the widget without per-adapter branching.
 

--- a/src/data/codeThemes.ts
+++ b/src/data/codeThemes.ts
@@ -6,7 +6,7 @@ export interface CodeThemeDef {
   id: string;
   label: string;
   /** highlight.js style stem for the app's dark / light mode; null for the
-   *  built-in Quorum palette. */
+   *  built-in Fletch palette. */
   dark: string | null;
   light: string | null;
 }

--- a/src/data/codeThemes.ts
+++ b/src/data/codeThemes.ts
@@ -12,7 +12,7 @@ export interface CodeThemeDef {
 }
 
 export const CODE_THEMES: CodeThemeDef[] = [
-  { id: "quorum", label: "Quorum", dark: null, light: null },
+  { id: "quorum", label: "Fletch", dark: null, light: null },
   { id: "github", label: "GitHub", dark: "github-dark", light: "github" },
   { id: "atom-one", label: "Atom One", dark: "atom-one-dark", light: "atom-one-light" },
   { id: "tokyo-night", label: "Tokyo Night", dark: "tokyo-night-dark", light: "tokyo-night-light" },

--- a/src/data/slashCommands.ts
+++ b/src/data/slashCommands.ts
@@ -7,7 +7,7 @@
 //    skills, and a handful of built-ins implemented as skills. Picking
 //    one inserts `/<name> ` into the input; the user then sends.
 //
-//  - `local` — handled by Quorum itself. The text never reaches the
+//  - `local` — handled by Fletch itself. The text never reaches the
 //    agent. Pick triggers the action identified by `action`. We don't
 //    define any yet, but the type slot is here so adding (e.g.) a
 //    `/clear` that wipes the transcript view is a one-liner later.
@@ -16,7 +16,7 @@
 // `/resume`, `/agents`, `/mcp`, `/doctor`) are intentionally absent —
 // they don't resolve over Claude's stream-json input and produce
 // "/foo isn't available in this environment" if proxied. If we want
-// them, they need a `local` entry with Quorum-side implementations.
+// them, they need a `local` entry with Fletch-side implementations.
 
 import type { ProviderId } from "./providers";
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -56,7 +56,7 @@ export function reduceRecords(provider: string | undefined, records: SessionReco
   return items;
 }
 
-/** Overlay Quorum-origin outgoing-turn metadata (attachments) onto the
+/** Overlay Fletch-origin outgoing-turn metadata (attachments) onto the
  *  transcript-rendered conversation. Additive only — never replaces transcript
  *  content (which stays the canonical, re-ingestable history):
  *  - Matched turns (`native_id` set) hang their attachments on the rendered

--- a/src/styles/foundation/tokens.css
+++ b/src/styles/foundation/tokens.css
@@ -1,4 +1,4 @@
-/* Quorum — quiet & editorial. Ported from the Quorum v2 prototype.
+/* Fletch — quiet & editorial. Ported from the Fletch v2 prototype.
  * Color tokens are OKLCH; theme via `.theme-dark` / `.theme-light` on <html>;
  * density via `.density-comfortable` / `.density-compact`; accent vars are
  * overridden at runtime by App.tsx based on the selected palette.

--- a/src/util/codeTheme.ts
+++ b/src/util/codeTheme.ts
@@ -41,7 +41,7 @@ const THEME_URLS: Record<string, string> = {
 const LINK_ID = "hljs-code-theme";
 
 /** Sync the highlight.js theme stylesheet with the chosen family + app theme.
- *  Returns true when the built-in Quorum palette should drive token colors
+ *  Returns true when the built-in Fletch palette should drive token colors
  *  (so the caller can tag the editor with the gating class). */
 export function useHljsTheme(): boolean {
   const codeTheme = useAppStore((s) => s.codeTheme);

--- a/src/util/diff.ts
+++ b/src/util/diff.ts
@@ -1,5 +1,5 @@
 // Parse `git diff` unified output into hunks the Code/Live panel can render.
-// Mirrors the prototype's hunk shape (quorum v2 data.jsx CODE_CHANGES):
+// Mirrors the prototype's hunk shape (fletch v2 data.jsx CODE_CHANGES):
 //   { header, lines: [{ op, o, n, t }] }
 // where `op` is context / addition / removal, `o`/`n` are the old/new 1-indexed
 // line numbers (null on the side the line doesn't exist), and `t` is the line

--- a/src/util/instructions.ts
+++ b/src/util/instructions.ts
@@ -1,10 +1,10 @@
-/** Strip the Quorum-injected instruction block from displayed user text.
+/** Strip the Fletch-injected instruction block from displayed user text.
  *
  *  The prepend-style agents (cursor, opencode, antigravity) receive the
  *  instructions as a `<quorum-system>…</quorum-system>` block prepended to the
  *  first user message, and echo it back into their transcript. This removes
  *  that block so the UI shows only what the user typed. The `<quorum-system>`
- *  tag is Quorum-specific, so removing it anywhere is safe — and it must be
+ *  tag is Fletch-specific, so removing it anywhere is safe — and it must be
  *  un-anchored because some agents (e.g. cursor) nest the user message inside
  *  their own envelope, leaving our block mid-string rather than at the start.
  *  No-op on messages that don't carry it. */


### PR DESCRIPTION
Second of the two rebrand PRs — the **internal code sweep**. **Stacked on #274** (base is `rebrand/user-facing-branding`); please merge that one first, then this retargets to `main` cleanly.

This sweep is strictly non-functional: it renames *references* to the old name in comments/docs/prose and one internal variable, while leaving **every functional identifier untouched**.

## Changed
- **Comments & doc prose** across `.rs` / `.ts` / `.tsx` / `.css` — product-name mentions → Fletch
- **`docs/RELEASING.md`** prose + **`capabilities/default.json`** description
- **Agent-facing instructions:** `system_prompt.md` ("You are running inside **Fletch**…"), `git_actions.md` / `rpc_protocol.md` titles
- **Internal rename** `isQuorum` → `isBuiltInTheme` (`DiffView`, `CodeLivePanel`, `FileEditor`) — clearer now that the theme is labeled "Fletch"; the `cq` CSS class is unchanged
- **Outbound HTTP** `user_agent("Quorum")` → `"Fletch"` (`oauth.rs`)

## Intentionally KEPT (functional literals — changing them breaks things)
| Kept | Why |
|---|---|
| `com.quorum.desktop`, `quorum.db`, `~/.quorum/*` paths | On-disk data/worktree/RPC locations — changing orphans existing installs |
| All `QUORUM_*` env vars | Agent RPC contract + CI/telemetry/OAuth build secrets |
| `<quorum-system>` tag + `QUORUM_SYSTEM_BLOCK` | Matched injector (`instructions.rs`) ↔ stripper (`util/instructions.ts`); renaming risks stored transcripts showing the raw tag. Only the surrounding comments were updated — note the comment now says "Fletch-specific" while the literal stays `quorum-system` (retained for back-compat) |
| `quorum.fwdai.org` URLs, `fwdai/quorum` slug, `~/.tauri/quorum.key` | Live site/CDN, GitHub repo, existing signing key |
| Cargo crates (`quorum`, `quorum_lib`), npm package name | Renaming crates ripples through imports/artifacts; no user impact — a separate, deliberate change if wanted |
| Code-theme id `"quorum"` | Persisted preference key; label already reads "Fletch" |

## Still open after both PRs (need design / infra / migration)
- **Bundle id + data-dir migration** (`com.quorum.desktop` → new id) so the app can adopt a Fletch data path without abandoning existing users' data — needs a migration step.
- **New logo/mark** (`QMark.tsx` "Q" letterform is now dead code) and **README image assets** (`docs/quorum_*.png|jpg`).
- **Infra rename**: `quorum.fwdai.org` site/updater/CDN, `QUORUM_*` CI secrets, GitHub repo slug, crate/package names.

## Verification
- `bun run check` (tsc) — clean
- `bun run test` — 327 passed
- `cargo check` — compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)