### PR TITLE
Rebrand: rename Cargo crate quorum → fletch

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -986,6 +986,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "fletch"
+version = "0.6.5"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "dirs 5.0.1",
+ "nix 0.29.0",
+ "parking_lot",
+ "portable-pty",
+ "reqwest 0.13.3",
+ "rusqlite",
+ "rusqlite_migration",
+ "sentry",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-build",
+ "tauri-plugin-dialog",
+ "tauri-plugin-process",
+ "tauri-plugin-sentry",
+ "tauri-plugin-shell",
+ "tauri-plugin-updater",
+ "tauri-plugin-window-state",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3101,39 +3134,6 @@ dependencies = [
  "socket2",
  "tracing",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "quorum"
-version = "0.6.5"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "dirs 5.0.1",
- "nix 0.29.0",
- "parking_lot",
- "portable-pty",
- "reqwest 0.13.3",
- "rusqlite",
- "rusqlite_migration",
- "sentry",
- "serde",
- "serde_json",
- "tauri",
- "tauri-build",
- "tauri-plugin-dialog",
- "tauri-plugin-process",
- "tauri-plugin-sentry",
- "tauri-plugin-shell",
- "tauri-plugin-updater",
- "tauri-plugin-window-state",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "tracing-appender",
- "tracing-subscriber",
- "uuid",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "quorum"
+name = "fletch"
 version = "0.6.5"
 description = "Spawn coding agents in isolated sandboxes"
 authors = ["Alex Chaplinsky", "fwdai.org"]
@@ -8,7 +8,7 @@ edition = "2021"
 rust-version = "1.77"
 
 [lib]
-name = "quorum_lib"
+name = "fletch_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -87,7 +87,7 @@ fn init_logging() {
     use tracing_subscriber::prelude::*;
 
     let filter = tracing_subscriber::EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info,quorum_lib=debug"));
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info,fletch_lib=debug"));
 
     let dir = logs_dir();
     let appender = std::fs::create_dir_all(&dir)
@@ -95,7 +95,7 @@ fn init_logging() {
         .and_then(|()| {
             tracing_appender::rolling::Builder::new()
                 .rotation(tracing_appender::rolling::Rotation::DAILY)
-                .filename_prefix("quorum")
+                .filename_prefix("fletch")
                 .filename_suffix("log")
                 .max_log_files(LOG_RETENTION_FILES)
                 .build(&dir)
@@ -535,7 +535,7 @@ pub fn run() {
             commands::reveal_logs,
         ])
         .build(tauri::generate_context!())
-        .expect("error while building quorum")
+        .expect("error while building fletch")
         .run(|app, event| {
             // On quit, explicitly kill every live agent/shell/run child.
             // tauri-managed state isn't reliably dropped on macOS app

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    quorum_lib::run()
+    fletch_lib::run()
 }


### PR DESCRIPTION
Internal crate rename `quorum` → `fletch` (`quorum_lib` → `fletch_lib`). Finishes what the earlier `package.json` rename started.

## Why the blast radius is small
- **Shipped binary/`.app` already decoupled** — `mainBinaryName: "Fletch"` in `tauri.conf.json` already differs from the crate name, so the app builds as "Fletch" today *despite* the crate being `quorum`. Renaming the crate changes nothing the user sees.
- **Release pipeline doesn't reference it** — `release.yml` builds via `tauri-action` (driven by `tauri.conf.json`), and references only `QUORUM_*` secrets and the release title — never the crate name or a `target/release/quorum` path.
- **No scattered usage** — no `use quorum_lib::` anywhere, no integration tests, no mobile entry point. Confirmed by grep.

## Changed (all in `src-tauri/`)
- `Cargo.toml` — `[package] name` + `[lib] name`
- `Cargo.lock` — regenerated by cargo
- `main.rs` — `fletch_lib::run()`
- `lib.rs` — tracing filter `fletch_lib=debug` (**kept in sync with the lib name** — this is the one spot that would silently drop crate debug-logging if missed), log `filename_prefix` `quorum` → `fletch`, and the build-error message

## Minor, not breakage
- Log files now use the `fletch` prefix; existing `quorum*.log` files remain (harmless discontinuity).
- First local `cargo build` recompiles from scratch (new crate identity → new target artifacts).

## Verification
- `cargo check` — compiles as `fletch v0.6.5`
- `cargo test` — 326 passed, 1 ignored
- No stray `quorum_lib` / `quorum::` references remain

## Adjacent straggler NOT included (flagging for a separate call)
`release.yml:67` `releaseName: Quorum v__VERSION__` — the GitHub Release title is still "Quorum." One-line CI-only change; left out to keep this PR scoped to the crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)