### PR TITLE
rebrand: move worktree + RPC dirs to ~/.fletch

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -1774,8 +1774,8 @@ mod tests {
         );
         // Dots are preserved (unlike Cursor) — only slashes are replaced.
         assert_eq!(
-            pi_session_slug(Path::new("/Users/alex/.quorum/worktrees/balkhash/agent")),
-            "--Users-alex-.quorum-worktrees-balkhash-agent--"
+            pi_session_slug(Path::new("/Users/alex/.fletch/worktrees/balkhash/agent")),
+            "--Users-alex-.fletch-worktrees-balkhash-agent--"
         );
     }
 

--- a/src-tauri/src/rpc.rs
+++ b/src-tauri/src/rpc.rs
@@ -104,11 +104,11 @@ impl Response {
     }
 }
 
-/// `~/.quorum/rpc/<agent-id>/` — the agent's private mailbox root.
+/// `~/.fletch/rpc/<agent-id>/` — the agent's private mailbox root.
 pub fn mailbox_dir(agent_id: &str) -> Result<PathBuf> {
     let home =
         dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
-    Ok(home.join(".quorum").join("rpc").join(agent_id))
+    Ok(home.join(".fletch").join("rpc").join(agent_id))
 }
 
 /// Create the mailbox and its `requests/`/`responses/` subdirs. Idempotent;

--- a/src-tauri/src/sandbox.rs
+++ b/src-tauri/src/sandbox.rs
@@ -6,7 +6,7 @@
 //! rather than relying on each CLI's own sandbox. `sandbox-exec` is just the
 //! process wrapper around the PTY/exec child, so terminal streaming and startup
 //! timing are unchanged while *writes* are constrained to the agent's parent dir
-//! (under `~/.quorum/worktrees/<id>/`) plus standard state/cache locations and
+//! (under `~/.fletch/worktrees/<id>/`) plus standard state/cache locations and
 //! each agent's own on-disk session store. The agent's per-repo worktrees live
 //! as subdirs of that parent, so each inherits the writable allowance.
 //!
@@ -27,7 +27,7 @@ use std::path::{Path, PathBuf};
 use crate::error::{Error, Result};
 
 /// Build the SBPL profile. `writable_root` is the agent's parent dir;
-/// `rpc_dir` is its private file-mailbox (`~/.quorum/rpc/<id>/`), which lives
+/// `rpc_dir` is its private file-mailbox (`~/.fletch/rpc/<id>/`), which lives
 /// outside the worktree tree and so needs its own allow entry.
 /// `claude_config_dir` is the value of `CLAUDE_CONFIG_DIR` the agent runs with
 /// (`None` = default `~/.claude`); when set elsewhere the agent writes its

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -730,7 +730,7 @@ impl Supervisor {
     }
 
     /// Bring a second (or third…) repo into a live agent. Creates a
-    /// detached worktree at `~/.quorum/worktrees/<agent-id>/<subdir>/`
+    /// detached worktree at `~/.fletch/worktrees/<agent-id>/<subdir>/`
     /// and appends a TrackedRepo entry. The worktree stays detached until
     /// its first push, consistent with the primary repo.
     pub async fn add_repo_to_agent(

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -1521,13 +1521,13 @@ pub fn allocate_repo_subdir(repo_path: &Path, used: &[String]) -> String {
 }
 
 /// Absolute path to the root holding every agent's worktrees:
-/// `~/.quorum/worktrees/`. Shared by *all* Fletch processes on the machine
+/// `~/.fletch/worktrees/`. Shared by *all* Fletch processes on the machine
 /// (release and dev builds alike — only the database is namespaced per build),
 /// which is why name allocation has to consult it directly.
 pub fn worktrees_root() -> Result<PathBuf> {
     let home = dirs::home_dir()
         .ok_or_else(|| Error::Other("HOME directory not available".into()))?;
-    Ok(home.join(".quorum").join("worktrees"))
+    Ok(home.join(".fletch").join("worktrees"))
 }
 
 /// The set of agent-id directories that physically exist under the worktrees
@@ -1553,13 +1553,13 @@ fn occupied_worktree_dirs_in(root: &Path) -> HashSet<String> {
 }
 
 /// Absolute path to the dir holding all of one agent's worktrees:
-/// `~/.quorum/worktrees/<agent-id>/`.
+/// `~/.fletch/worktrees/<agent-id>/`.
 pub fn agent_parent_dir(agent_id: &str) -> Result<PathBuf> {
     Ok(worktrees_root()?.join(agent_id))
 }
 
 /// Absolute path to one tracked repo's worktree:
-/// `~/.quorum/worktrees/<agent-id>/<subdir>/`.
+/// `~/.fletch/worktrees/<agent-id>/<subdir>/`.
 pub fn repo_worktree_path(agent_id: &str, subdir: &str) -> Result<PathBuf> {
     Ok(agent_parent_dir(agent_id)?.join(subdir))
 }

--- a/src/components/Workspace/EmptyWorkspace.tsx
+++ b/src/components/Workspace/EmptyWorkspace.tsx
@@ -75,7 +75,7 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
         <p className="empty-sub text-base">
           A worktree and sandbox will be created at{" "}
           <span style={{ fontFamily: "var(--font-mono)", color: "var(--fg-1)" }}>
-            ~/.quorum/worktrees/{draft.name}
+            ~/.fletch/worktrees/{draft.name}
           </span>
         </p>
 


### PR DESCRIPTION
Renames the home-dir roots the app uses from `~/.quorum` to `~/.fletch`.

- `worktrees_root()` → `~/.fletch/worktrees/` (`workspace.rs`)
- `mailbox_dir()` → `~/.fletch/rpc/<agent-id>/` (`rpc.rs`)
- doc comments naming those paths (`sandbox.rs`, `supervisor.rs`)
- the path shown in the empty-workspace UI (`EmptyWorkspace.tsx`)
- a `pi_session_slug` test fixture

## Why this is a safe plain rename (no migration)
- **Worktree paths are derived, never stored.** `repo_worktree_path()` recomputes from `worktrees_root() + agent_id + subdir` everywhere; the DB persists only the *original* repo path (`repos.path`) + agent_id + subdir. Flipping the root constant redirects all derivation — no DB rewrite.
- **RPC dirs are ephemeral** — recreated at each spawn.
- **No users yet**, so there's no data to preserve. We skipped both the migrate-and-`git worktree repair` path and the read-fallback path — they'd be complexity for data nobody has. Any existing `~/.quorum` worktrees are simply orphaned.

## One-time local cleanup (Alex)
Your current `~/.quorum` worktrees won't be found under the new root. After merging: discard the current agents in-app, then `rm -rf ~/.quorum` (and `git worktree prune` in any affected repos to drop stale registrations).

## Out of scope
- `com.quorum.desktop` (bundle id / app-data + DB dir) — separate, riskier migration.
- Incidental test-scratch dir names (`.quorum-rpc` tempdirs, a slug fixture) — arbitrary, not the app's real path.

## Verification
- `cargo check` + `cargo test` — 326 passed
- `bun run check` (tsc) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)