### PR TITLE
rebrand: bundle id com.quorum.desktop → com.fletch.desktop

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -38,14 +38,14 @@ use crate::workspace::WorkspaceManager;
 type DbState = Arc<Mutex<Connection>>;
 
 /// Fletch's on-disk data directory — `~/Library/Application Support/
-/// com.quorum.desktop` (with a `dev` subfolder under debug builds), matching
+/// com.fletch.desktop` (with a `dev` subfolder under debug builds), matching
 /// what `app.path().app_data_dir()` resolves to in `setup`. Computed without
 /// an `AppHandle` so logging can be initialized before the Tauri app is built,
 /// and reused by the `reveal_logs` command.
 pub(crate) fn data_dir() -> PathBuf {
     let base = dirs::data_dir()
         .unwrap_or_else(std::env::temp_dir)
-        .join("com.quorum.desktop");
+        .join("com.fletch.desktop");
     if cfg!(debug_assertions) {
         base.join("dev")
     } else {
@@ -64,7 +64,7 @@ mod tests {
     #[test]
     fn data_dir_is_under_the_bundle_id_and_logs_nest_within() {
         let dir = data_dir();
-        assert!(dir.to_string_lossy().contains("com.quorum.desktop"));
+        assert!(dir.to_string_lossy().contains("com.fletch.desktop"));
         // Tests build in debug, so the dev sandbox subfolder is used.
         assert_eq!(dir.file_name().unwrap(), "dev");
         assert!(logs_dir().starts_with(&dir));

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -3,7 +3,7 @@
   "productName": "Fletch",
   "mainBinaryName": "Fletch",
   "version": "0.6.5",
-  "identifier": "com.quorum.desktop",
+  "identifier": "com.fletch.desktop",
   "build": {
     "beforeDevCommand": "bun run dev",
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Changes the app's bundle identifier. Clean-slate, **no migration** (no users yet).

## What it touches (4 spots, fully contained)
- `tauri.conf.json` → `identifier: "com.fletch.desktop"`
- `lib.rs` `data_dir()` — the hardcoded `.join("com.fletch.desktop")`, its doc comment, and the `data_dir_is_under_the_bundle_id…` test assertion

These must stay in lockstep: Tauri derives `app_data_dir()` from the identifier, and `lib.rs` hardcodes the same string to compute the path *before* the app is built (for early logging). Grep confirms there are **no other references** — no Info.plist, entitlements, CI, or Cloudflare-worker mentions.

## Consequence (expected, accepted)
The identifier is what macOS uses for the app-data directory, so this moves everything the app persists to a fresh location: the **SQLite DB, logs, and window state start empty** at `~/Library/Application Support/com.fletch.desktop/`. The old `com.quorum.desktop/` data is orphaned — fine, since there's nothing to preserve and you asked not to migrate. macOS also treats the new identifier as a distinct app (Launch Services, any per-app permission grants reset).

## Local cleanup (Alex)
After merge you can `rm -rf ~/Library/Application\ Support/com.quorum.desktop` and delete any old installed "Quorum"/old-id app bundle.

## Choice to confirm
I used **`com.fletch.desktop`**, mirroring the old `com.<name>.desktop` pattern. If you'd rather the reverse-DNS of the real domain — **`sh.fletch.desktop`** (fletch.sh) — it's a trivial 4-spot change; say the word. Cheap to change now, pre-release; permanent once you ship.

## Out of scope (still `quorum`)
`quorum.db` *filename* (inside the now-renamed dir — harmless, can rename separately), `QUORUM_*` env vars, `<quorum-system>` tag, theme id, `fwdai/quorum` repo slug, `release.yml` release title.

## Verification
- `cargo test` — 326 passed (incl. the data_dir test)
- `bun run check` (tsc) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)