### PR TITLE
rebrand: rename incidental quorum mentions in Rust test fixtures

### DIFF
--- a/src-tauri/src/bin_resolve.rs
+++ b/src-tauri/src/bin_resolve.rs
@@ -212,7 +212,7 @@ mod tests {
         std::fs::create_dir_all(&bin_dir).unwrap();
         // A name that won't exist on PATH or via the login shell, so resolution
         // can only succeed through the common-dir fallback.
-        let name = "quorum-fake-cli-xyz";
+        let name = "fletch-fake-cli-xyz";
         write_executable(&bin_dir.join(name));
 
         assert_eq!(
@@ -229,7 +229,7 @@ mod tests {
         let home = tempfile::tempdir().unwrap();
         let bin_dir = home.path().join(".local/bin");
         std::fs::create_dir_all(&bin_dir).unwrap();
-        let name = "quorum-fake-cli-nonexec";
+        let name = "fletch-fake-cli-nonexec";
         let file = bin_dir.join(name);
         std::fs::write(&file, b"#!/bin/sh\n").unwrap();
         std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644)).unwrap();
@@ -245,7 +245,7 @@ mod tests {
     fn returns_none_when_binary_is_nowhere() {
         let home = tempfile::tempdir().unwrap();
         assert_eq!(
-            resolve_bin("quorum-definitely-not-installed-zzz", home.path()),
+            resolve_bin("fletch-definitely-not-installed-zzz", home.path()),
             None,
         );
     }

--- a/src-tauri/src/rpc.rs
+++ b/src-tauri/src/rpc.rs
@@ -267,7 +267,7 @@ mod tests {
     #[test]
     fn ensure_mailbox_creates_both_subdirs() {
         let td = tempfile::tempdir().unwrap();
-        let dir = td.path().join(".quorum-rpc");
+        let dir = td.path().join(".fletch-rpc");
         ensure_mailbox(&dir).unwrap();
         assert!(dir.join("requests").is_dir());
         assert!(dir.join("responses").is_dir());
@@ -296,7 +296,7 @@ mod tests {
     #[tokio::test]
     async fn ping_round_trips_to_a_response_file() {
         let td = tempfile::tempdir().unwrap();
-        let rpc_dir = td.path().join(".quorum-rpc");
+        let rpc_dir = td.path().join(".fletch-rpc");
         ensure_mailbox(&rpc_dir).unwrap();
         write_request(
             &rpc_dir.join("requests"),
@@ -320,7 +320,7 @@ mod tests {
     #[tokio::test]
     async fn unknown_op_is_rejected() {
         let td = tempfile::tempdir().unwrap();
-        let rpc_dir = td.path().join(".quorum-rpc");
+        let rpc_dir = td.path().join(".fletch-rpc");
         ensure_mailbox(&rpc_dir).unwrap();
         write_request(
             &rpc_dir.join("requests"),
@@ -340,7 +340,7 @@ mod tests {
     #[tokio::test]
     async fn fresh_unparseable_request_is_left_for_retry() {
         let td = tempfile::tempdir().unwrap();
-        let rpc_dir = td.path().join(".quorum-rpc");
+        let rpc_dir = td.path().join(".fletch-rpc");
         ensure_mailbox(&rpc_dir).unwrap();
         write_request(&rpc_dir.join("requests"), "req-3.json", "{ not json");
 

--- a/src-tauri/src/rpc/git.rs
+++ b/src-tauri/src/rpc/git.rs
@@ -306,7 +306,7 @@ mod tests {
     #[tokio::test]
     async fn git_status_runs_a_real_command() {
         let td = tempfile::tempdir().unwrap();
-        let rpc_dir = td.path().join(".quorum-rpc");
+        let rpc_dir = td.path().join(".fletch-rpc");
         ensure_mailbox(&rpc_dir).unwrap();
         write_request(
             &rpc_dir.join("requests"),
@@ -327,7 +327,7 @@ mod tests {
     #[tokio::test]
     async fn echo_round_trips_free_text() {
         let td = tempfile::tempdir().unwrap();
-        let rpc_dir = td.path().join(".quorum-rpc");
+        let rpc_dir = td.path().join(".fletch-rpc");
         ensure_mailbox(&rpc_dir).unwrap();
         write_request(
             &rpc_dir.join("requests"),

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -3153,7 +3153,7 @@ mod tests {
         // configured projects dir is.
         let cfg = tempfile::tempdir().unwrap();
         let projects = cfg.path().join("projects");
-        let slug = projects.join("-Users-alex--quorum-worktrees-transylvania-quorum");
+        let slug = projects.join("-Users-alex--fletch-worktrees-transylvania-fletch");
         std::fs::create_dir_all(&slug).unwrap();
         let sid = "f90f9c57-6dd1-45a0-9b69-5b5963979d5b";
         let jsonl = slug.join(format!("{sid}.jsonl"));

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -1912,7 +1912,7 @@ mod tests {
             repos: vec![ArchivedRepoSnapshot {
                 repo_path: PathBuf::from("/some/repo"),
                 subdir: "repo".into(),
-                branch_name: Some("quorum/do-the-thing".into()),
+                branch_name: Some("feat/do-the-thing".into()),
                 branch_tip_sha: Some("deadbeef".into()),
                 parent_branch: Some("main".into()),
                 parent_branch_sha: Some("cafebabe".into()),
@@ -1947,7 +1947,7 @@ mod tests {
         let restored = vec![TrackedRepo {
             repo_path: PathBuf::from("/some/repo"),
             subdir: "repo".into(),
-            branch: Some("quorum/do-the-thing".into()),
+            branch: Some("feat/do-the-thing".into()),
             parent_branch: Some("main".into()),
             base_sha: None,
             pr_number: None,


### PR DESCRIPTION
Cleans up leftover `quorum` in **Rust test fixtures** — arbitrary strings with no functional meaning.

## Renamed (all cosmetic, none cross-referenced by an assertion)
- `bin_resolve.rs` — fake-CLI names `quorum-fake-cli-*` / `quorum-definitely-not-installed-zzz` → `fletch-*`
- `rpc.rs`, `rpc/git.rs` — `.quorum-rpc` tempdir scratch names → `.fletch-rpc`
- `supervisor.rs` — transcript-slug fixture path → `.fletch/worktrees` form
- `workspace.rs` — branch-name fixture `quorum/do-the-thing` → `feat/do-the-thing` (verified: only stored/restored in the archive round-trip test, never asserted)

## Intentionally KEPT (these test real, retained things — not branding)
- **`instructions.rs` `<quorum-system>` assertions** — that's the actual protocol tag the app injects (`instructions.rs:110`). Renaming the test without renaming the tag would fail; renaming the tag itself is a separate, riskier change (it must stay in sync with the frontend stripper and risks existing stored transcripts).
- **`gh.rs` `fwdai/quorum`** — the repo-URL parse test; the GitHub repo isn't renamed.

## Verification
- `cargo test` — 326 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)