### PR TITLE
style(sidebar): bump account block name to base, email to sm

### DIFF
--- a/src/styles/shared/badge.css
+++ b/src/styles/shared/badge.css
@@ -184,11 +184,11 @@
   min-width: 0;
 }
 .user-info .un {
-  font-size: var(--fs-sm);
+  font-size: var(--fs-base);
   color: var(--fg-0);
   font-weight: 500;
 }
 .user-info .ue {
-  font-size: var(--fs-xs);
+  font-size: var(--fs-sm);
   color: var(--fg-3);
 }


### PR DESCRIPTION
## Summary
Steps the sidebar account block up one rung on the type scale for a clearer hierarchy in the footer.

| Element | Before | After |
|---|---|---|
| Name (`.un`) | `--fs-sm` (12px) | `--fs-base` (14px) |
| Email (`.ue`) | `--fs-xs` (11px) | `--fs-sm` (12px) |

Avatar initials stay at `--fs-xs` since they are constrained to a 24px circle. All values remain on the `--fs-*` token scale.

_File:_ `src/styles/shared/badge.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)