### PR TITLE
fix(model-picker): surface new Claude families like Fable via models.dev

### DIFF
--- a/src/data/modelCatalog/build.ts
+++ b/src/data/modelCatalog/build.ts
@@ -58,19 +58,23 @@ export function dedupeBest(
 }
 
 /** Keep at most `caps[group]` models per group, in the order given. An
- *  unclassifiable model (null group) is dropped. Feed a release-desc list to
- *  keep the newest N per group. */
+ *  unclassifiable model (null group) is dropped. A group with no entry in `caps`
+ *  uses `defaultCap` if given, and is otherwise left uncapped. Feed a
+ *  release-desc list to keep the newest N per group. */
 export function capPerGroup<G extends string>(
   models: ModelMeta[],
   groupFn: (meta: ModelMeta) => G | null,
   caps: Record<G, number>,
+  defaultCap?: number,
 ): ModelMeta[] {
   const counts = {} as Record<G, number>;
   return models.filter((meta) => {
     const group = groupFn(meta);
     if (group === null) return false;
+    const cap = caps[group] ?? defaultCap;
+    if (cap === undefined) return true;
     const used = counts[group] ?? 0;
-    if (used >= caps[group]) return false;
+    if (used >= cap) return false;
     counts[group] = used + 1;
     return true;
   });
@@ -126,7 +130,22 @@ function lookupEnrichedModel(index: ModelsDevIndex, id: string): ModelMeta | und
   return undefined;
 }
 
-function claudeFamily(meta: ModelMeta): "opus" | "sonnet" | "haiku" | null {
+// Curated display order for the Claude families we know how to rank. Families
+// absent here (a brand-new tier like "fable") are still shown — they just sort
+// ahead of the ranked ones (see claudeFamilyRank) so a new flagship isn't buried.
+const CLAUDE_FAMILY_ORDER: Record<string, number> = { opus: 0, sonnet: 1, haiku: 2 };
+
+/** How many models to keep for a Claude family without a curated cap above. */
+const CLAUDE_DEFAULT_FAMILY_CAP = 2;
+
+/** The Claude family a model belongs to, e.g. "opus" / "fable". Prefers the
+ *  authoritative models.dev `family` ("claude-<family>"), so new families flow
+ *  through without a code change; falls back to name matching for CLI-only ids
+ *  models.dev doesn't know. Returns null for non-Claude models (their own
+ *  `family`, e.g. "gpt-5", must not be mistaken for a Claude family). */
+function claudeFamily(meta: ModelMeta): string | null {
+  const family = meta.family?.toLowerCase();
+  if (family?.startsWith("claude-")) return family.slice("claude-".length);
   const haystack = `${meta.id} ${meta.name}`.toLowerCase();
   if (haystack.includes("opus")) return "opus";
   if (haystack.includes("sonnet")) return "sonnet";
@@ -136,15 +155,8 @@ function claudeFamily(meta: ModelMeta): "opus" | "sonnet" | "haiku" | null {
 
 function claudeFamilyRank(meta: ModelMeta): number {
   const family = claudeFamily(meta);
-  if (family === "opus") return 0;
-  if (family === "sonnet") return 1;
-  if (family === "haiku") return 2;
-  return 3;
-}
-
-function claudeMajor(meta: ModelMeta): number {
-  const m = `${meta.id} ${meta.name}`.match(/(?:claude[ -])?(?:opus|sonnet|haiku)[ -](\d+)/i);
-  return m ? Number(m[1]) : 0;
+  if (family && family in CLAUDE_FAMILY_ORDER) return CLAUDE_FAMILY_ORDER[family];
+  return -1;
 }
 
 function claudeDedupeKey(meta: ModelMeta): string {
@@ -169,11 +181,14 @@ function preferClaudeRelease(candidate: ModelMeta, current: ModelMeta): boolean 
 function curateClaudeModels(models: ModelMeta[]): ModelMeta[] {
   const caps = { opus: 3, sonnet: 2, haiku: 1 };
 
+  // Keep only Claude-family models; the per-family caps below (newest first)
+  // drop older generations without needing a hardcoded version gate.
   const deduped = dedupeBest(models, claudeDedupeKey, preferClaudeRelease).filter(
-    (meta) => claudeFamily(meta) !== null && claudeMajor(meta) >= 4,
+    (meta) => claudeFamily(meta) !== null,
   );
 
-  return capPerGroup(deduped, claudeFamily, caps).sort((a, b) => {
+  // New families we don't have a curated cap for get CLAUDE_DEFAULT_FAMILY_CAP.
+  return capPerGroup(deduped, claudeFamily, caps, CLAUDE_DEFAULT_FAMILY_CAP).sort((a, b) => {
     const byFamily = claudeFamilyRank(a) - claudeFamilyRank(b);
     return byFamily || releaseRank(b) - releaseRank(a);
   });
@@ -313,6 +328,7 @@ function metaFor(d: DiscoveredModel, index: ModelsDevIndex): ModelMeta {
     name: dev?.name ?? d.name ?? d.id,
     contextWindow: dev?.contextWindow || d.contextWindow || 0,
     reasoning: dev?.reasoning ?? d.reasoning ?? false,
+    ...(dev?.family ? { family: dev.family } : {}),
     ...(dev?.releaseDate ? { releaseDate: dev.releaseDate } : {}),
   };
 }

--- a/src/data/modelCatalog/modelCatalog.test.ts
+++ b/src/data/modelCatalog/modelCatalog.test.ts
@@ -493,6 +493,65 @@ describe("buildCatalog", () => {
   });
 });
 
+describe("buildCatalog — data-driven Claude families", () => {
+  // Faithful to models.dev: every model carries a `family` (e.g. "claude-fable"),
+  // including a family the name-based classifier would never recognize.
+  const FAMILY_API = {
+    anthropic: {
+      models: {
+        "claude-opus-4-8": {
+          name: "Claude Opus 4.8",
+          family: "claude-opus",
+          reasoning: true,
+          release_date: "2026-05-28",
+          limit: { context: 1_000_000 },
+        },
+        "claude-fable-5": {
+          name: "Claude Fable 5",
+          family: "claude-fable",
+          reasoning: true,
+          release_date: "2026-06-09",
+          limit: { context: 1_000_000 },
+        },
+      },
+    },
+    openai: {
+      models: {
+        "gpt-5.5": {
+          name: "GPT-5.5",
+          family: "gpt-5",
+          reasoning: true,
+          release_date: "2025-12-11",
+          limit: { context: 400_000 },
+        },
+      },
+    },
+  };
+  const idx = indexModelsDev(FAMILY_API as never);
+
+  it("surfaces a new Claude family (Fable) via the models.dev family field", () => {
+    const agents: AgentModels[] = [{ agent: "claude", providerHint: "anthropic", models: [] }];
+    const ids = buildCatalog(agents, idx).byAgent.claude.map((m) => m.id);
+
+    // Fable's name/id contain no opus/sonnet/haiku, so it's recognized only by
+    // the family field — and a new flagship family sorts ahead, not buried.
+    expect(ids).toContain("claude-fable-5");
+    expect(ids[0]).toBe("claude-fable-5");
+  });
+
+  it("does not misclassify a non-Claude family as Claude in Pi curation", () => {
+    // gpt-5.5 has a family field too; it must stay after the Claude models,
+    // not get grouped as a Claude family.
+    const agents: AgentModels[] = [
+      { agent: "pi", models: [{ id: "claude-opus-4-8" }, { id: "gpt-5.5" }] },
+    ];
+    expect(buildCatalog(agents, idx).byAgent.pi.map((m) => m.id)).toEqual([
+      "claude-opus-4-8",
+      "gpt-5.5",
+    ]);
+  });
+});
+
 describe("modelIdCandidates", () => {
   it("strips provider prefix and date suffix, in priority order", () => {
     expect(modelIdCandidates("anthropic/claude-opus-4-20250514")).toEqual([

--- a/src/data/modelCatalog/modelsDev.ts
+++ b/src/data/modelCatalog/modelsDev.ts
@@ -13,6 +13,7 @@ const MODELS_DEV_URL = "https://models.dev/api.json";
 interface RawModel {
   name?: string;
   reasoning?: boolean;
+  family?: string;
   release_date?: string;
   limit?: { context?: number };
 }
@@ -30,6 +31,7 @@ function toMeta(id: string, m: RawModel): ModelMeta {
     name: m.name ?? id,
     contextWindow: m.limit?.context ?? 0,
     reasoning: m.reasoning === true,
+    ...(m.family ? { family: m.family } : {}),
     ...(m.release_date ? { releaseDate: m.release_date } : {}),
   };
 }

--- a/src/data/modelCatalog/types.ts
+++ b/src/data/modelCatalog/types.ts
@@ -16,6 +16,9 @@ export interface ModelMeta {
   contextWindow: number;
   /** Whether the model supports reasoning / extended thinking. */
   reasoning: boolean;
+  /** Model family from models.dev (e.g. "claude-opus", "claude-fable"), when
+   *  known. Used to group/curate a provider's lineage without hardcoding names. */
+  family?: string;
   /** Model release date from models.dev (`YYYY-MM-DD`), when known. */
   releaseDate?: string;
 }


### PR DESCRIPTION
The model picker classified Claude models by substring-matching `opus`/`sonnet`/`haiku`, so `claude-fable-5` was filtered out during curation even though models.dev serves it correctly. This derives the family from the authoritative models.dev `family` field instead — guarded by the `claude-` prefix so a non-Claude provider's family (e.g. `gpt-5`) isn't misclassified in Pi curation — so new families appear with zero code changes. It also drops the now-redundant hardcoded major-version gate (the per-family newest-N caps already exclude old generations) and gives `capPerGroup` a default cap so a new family is bounded rather than uncapped. New families sort ahead of the ranked ones so a new flagship isn't buried. Adds tests covering Fable surfacing via the `family` field and the non-Claude-family guard; full suite (329) passes and `tsc` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)