### PR TITLE
style(sidebar): tighten agent status rail insets

### DIFF
--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -188,9 +188,9 @@
 /* status rail — the left spine; colored by status, faint grey when idle */
 .ag-rail {
   position: absolute;
-  left: 0;
-  top: 6px;
-  bottom: 6px;
+  left: 1px;
+  top: 4px;
+  bottom: 4px;
   width: 3px;
   border-radius: 0 3px 3px 0;
   background: var(--bd-soft);


### PR DESCRIPTION
Adjusts the `.ag-rail` status spine on sidebar agent rows for a more deliberate, consistently-floating look.

- `top`/`bottom` inset tightened from `6px` to `4px`
- Added a `1px` left inset (was flush at `left: 0`) so the rail floats evenly on all sides rather than bleeding into the sidebar edge

Orientation and width are unchanged — rounded corners still face inward toward the row content, 3px wide.