### PR TITLE
feat(sidebar): show waiting-for-input state on agent rows

### DIFF
--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -28,6 +28,7 @@ import {
   GitCommitHorizontal,
   GitMerge,
   GitPullRequest,
+  Hand,
   History,
   Inbox,
   Layers,
@@ -148,6 +149,7 @@ const ICON_COMPONENTS = {
   sun: Sun,
   zap: Zap,
   clock: Clock,
+  hand: Hand,
 } satisfies Record<string, ComponentType<IconComponentProps>>;
 
 // Originally rendered with fill="currentColor". Setting fill on the root SVG

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -54,6 +54,7 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
   const prState = useAppStore((s) => s.prStates[agent.id] ?? null);
   const shortstats = useAppStore((s) => s.gitShortstats[agent.id]);
   const unseen = useAppStore((s) => s.unseenResults[agent.id] ?? false);
+  const pending = useAppStore((s) => s.pendingToolUse[agent.id]);
   const stop = useAppStore((s) => s.stop);
   const archive = useAppStore((s) => s.archive);
   // The custom agent this session was spawned from, if any (and still present).
@@ -70,6 +71,11 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
   const age = formatAge(agent.created_at, now);
   // spawning is the start of a run — show it as "working" too, not a dead row
   const working = agent.status === "running" || agent.status === "spawning";
+  // The agent has paused on a question/plan tool and is waiting for a human
+  // answer (AskUserQuestion / ExitPlanMode). Status stays `running`, so this
+  // separate signal is what distinguishes "the ball's in your court" from
+  // "still thinking". Mirrors ChatView's `awaitingInput`.
+  const awaiting = working && !!pending && Object.keys(pending).length > 0;
 
   const catalog = useAppStore((s) => s.modelCatalog);
   const hasUsage = !!usage && usage.contextTokens > 0;
@@ -101,13 +107,16 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
 
   // The status rail doubles as the left spine: colored for live/terminal
   // states, a merged PR claims purple, everything else is a faint grey.
-  const railClass = working
-    ? "run"
-    : agent.status === "error"
-      ? "err"
-      : prState?.state === "merged"
-        ? "merged"
-        : "idle";
+  // A pending question outranks the plain running green — amber says "you".
+  const railClass = awaiting
+    ? "wait"
+    : working
+      ? "run"
+      : agent.status === "error"
+        ? "err"
+        : prState?.state === "merged"
+          ? "merged"
+          : "idle";
 
   const hasChanges = !!shortstats && (shortstats.additions > 0 || shortstats.deletions > 0);
 
@@ -122,7 +131,7 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
 
   return (
     <div
-      className={`agent ${active ? "active" : ""}`}
+      className={`agent ${active ? "active" : ""} ${awaiting ? "awaiting" : ""}`}
       role="button"
       tabIndex={0}
       aria-current={active ? "page" : undefined}
@@ -131,7 +140,7 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
     >
       <span className={`ag-rail ${railClass}`} />
       <div className="agent-row flex-center">
-        <span className={`ag-name ${working ? "shimmer" : ""}`}>{agent.name}</span>
+        <span className={`ag-name ${working && !awaiting ? "shimmer" : ""}`}>{agent.name}</span>
         <span
           className="ag-prov-chip tip"
           data-tip={
@@ -148,8 +157,18 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
           )}
         </span>
         <span className="ag-slot iflex-center">
-          <span className="ag-meta">
-            {working && <span className="ag-loader" aria-label="Working" />}
+          <span className={`ag-meta ${agent.status === "error" ? "wide" : ""}`}>
+            {awaiting ? (
+              <span
+                className="ag-waiting tip"
+                data-tip="Waiting for user input"
+                aria-label="Waiting for user input"
+              >
+                <Icon name="hand" size={12} />
+              </span>
+            ) : (
+              working && <span className="ag-loader" aria-label="Working" />
+            )}
             {agent.status === "idle" && !active && unseen && (
               <span
                 className="ag-unseen tip"
@@ -160,7 +179,7 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
             {agent.status === "error" && <Badge variant="err">error</Badge>}
           </span>
           <span className="ag-actions">
-            {stoppable && (
+            {stoppable && !awaiting && (
               <button
                 className="ag-act iflex-center tip"
                 data-tip="Stop"

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -248,7 +248,7 @@ function DraftRow({ draft, active, onClick }: DraftRowProps) {
           <ProviderIcon slug={draft.provider} {...providerChip(draft.provider)} size={14} />
         </span>
         <span className="ag-slot iflex-center">
-          <span className="ag-meta">
+          <span className="ag-meta wide">
             <Badge variant="new">new</Badge>
           </span>
           <span className="ag-actions">

--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -205,6 +205,10 @@
 .ag-rail.run {
   background: var(--success);
 }
+/* paused on a question — amber says the turn is the user's */
+.ag-rail.wait {
+  background: var(--warn);
+}
 /* a single lighter sheen sweeps the solid rail and resets off-screen (no blink) */
 .ag-rail.run::after {
   content: "";
@@ -271,17 +275,17 @@
 .ag-slot {
   position: relative;
   margin-left: auto;
-  justify-content: flex-end;
   flex-shrink: 0;
   min-height: 21px;
-  min-width: 18px;
+  /* reserve exactly one action-button's width so meta and actions stack in
+   * the same footprint (see below) — the row never reflows on hover */
+  min-width: 21px;
 }
-.ag-slot .ag-meta {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  transition: opacity 0.12s;
-}
+/* meta and actions occupy the SAME right-anchored 21px box and cross-fade in
+ * place: a single indicator (loader / hand / unseen dot) is centered on the
+ * exact spot the action-button icon lands, so any swap looks like a morph, not
+ * a jump. The error badge is text, not an icon, so it opts out via `.wide`. */
+.ag-slot .ag-meta,
 .ag-slot .ag-actions {
   position: absolute;
   right: 0;
@@ -289,10 +293,20 @@
   transform: translateY(-50%);
   display: inline-flex;
   align-items: center;
+  justify-content: center;
+  transition: opacity 0.12s;
+}
+.ag-slot .ag-meta {
+  width: 21px;
+}
+.ag-slot .ag-meta.wide {
+  width: auto;
+  justify-content: flex-end;
+}
+.ag-slot .ag-actions {
   gap: 2px;
   opacity: 0;
   pointer-events: none;
-  transition: opacity 0.12s;
 }
 .agent:hover .ag-slot .ag-meta {
   opacity: 0;
@@ -300,6 +314,15 @@
 .agent:hover .ag-slot .ag-actions {
   opacity: 1;
   pointer-events: auto;
+}
+/* an agent paused on a question keeps its hand (and tooltip) on hover instead
+ * of swapping to Stop — the turn is the user's, stopping isn't the next move */
+.agent.awaiting:hover .ag-slot .ag-meta {
+  opacity: 1;
+}
+.agent.awaiting:hover .ag-slot .ag-actions {
+  opacity: 0;
+  pointer-events: none;
 }
 .ag-act {
   justify-content: center;
@@ -322,6 +345,35 @@
   left: auto;
   right: 0;
   transform: none;
+}
+
+/* waiting-for-input indicator — amber hand, a soft breathing pulse so it
+ * reads as an ask, not a dead icon */
+.ag-waiting {
+  display: inline-flex;
+  align-items: center;
+  color: var(--warn);
+}
+/* pulse only the glyph — animating the wrapper's opacity would drag its
+ * `::after` tooltip along with it */
+.ag-waiting svg {
+  animation: agWaiting 2s var(--ease) infinite;
+}
+/* pinned to the row's right edge like the action buttons — anchor the tooltip
+ * right so it never spills past the sidebar */
+.ag-waiting.tip[data-tip]:hover::after {
+  left: auto;
+  right: 0;
+  transform: none;
+}
+@keyframes agWaiting {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
 }
 
 /* working indicator — three grey dots, smooth bounce + fade, synced */

--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -284,7 +284,7 @@
 /* meta and actions occupy the SAME right-anchored 21px box and cross-fade in
  * place: a single indicator (loader / hand / unseen dot) is centered on the
  * exact spot the action-button icon lands, so any swap looks like a morph, not
- * a jump. The error badge is text, not an icon, so it opts out via `.wide`. */
+ * a jump. Text badges (error, draft "new") opt out of the box via `.wide`. */
 .ag-slot .ag-meta,
 .ag-slot .ag-actions {
   position: absolute;


### PR DESCRIPTION
## What

Surfaces a "waiting for user input" state on sidebar agent rows, and tidies the meta/action alignment while doing so.

When an agent pauses on a question/plan tool (`AskUserQuestion` / `ExitPlanMode`), its status stays `running` — so previously the sidebar showed the same green rail + loading dots as an actively-working agent. Now that pause is visible:

- **Amber rail** — outranks the running green; signals the turn is the user's.
- **Pulsing hand** replaces the loader, with a "Waiting for user input" tooltip. Only the glyph pulses (not the tooltip).
- **No Stop-on-hover** — a paused agent keeps its hand + tooltip on hover instead of swapping to Stop, since stopping isn't the next move.

The signal is the store's `pendingToolUse[agentId]` map (populated from held `can_use_tool` control requests, cleared on answer / turn end), mirroring `ChatView`'s `awaitingInput`.

## Alignment fix

`.ag-meta` (loader / hand / unseen dot) sat flush-right while `.ag-actions` buttons center their icon in a 21px box, so hover cross-fades jumped. Meta and actions now share one right-anchored 21px box with centered content, so indicators morph in place into stop/archive. The error badge is text, not an icon, so it opts out via a `.wide` modifier.

## Files
- `Icon.tsx` — register `hand` (lucide `Hand`).
- `Sidebar/AgentRow.tsx` — derive `awaiting`; amber rail; hand indicator; hide Stop / keep name un-shimmered while awaiting.
- `Sidebar/Sidebar.css` — amber `.ag-rail.wait`; shared meta/actions footprint; `awaiting` hover rules; pulsing hand + right-anchored tooltip.

Scope note: `pendingToolUse` is fed by Claude's held tool requests; providers without that pause mechanism won't trigger the amber state — consistent with the existing in-chat waiting UI.

## Testing
`tsc --noEmit` and `biome check` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)