### PR TITLE
feat(sidebar): always-visible per-project new-agent button

### DIFF
--- a/src/components/Sidebar/ProjectGroup.tsx
+++ b/src/components/Sidebar/ProjectGroup.tsx
@@ -61,7 +61,13 @@ export function ProjectGroup({
         <Icon name="chevR" size={10} className="chev" />
         <span className="pname">{label}</span>
         <span className="pcount">{count}</span>
-        <button className="padd tip" data-tip="New agent" data-tip-down="" onClick={onAddAgent}>
+        <button
+          className="padd tip"
+          data-tip="New agent  ⌘N"
+          data-tip-down=""
+          onClick={onAddAgent}
+          aria-label="New agent"
+        >
           <Icon name="plus" size={11} />
         </button>
         {removable && (
@@ -78,10 +84,6 @@ export function ProjectGroup({
       </div>
 
       <div className={`agents ${open ? "" : "closed"}`}>
-        <button className="agent-new flex-center" onClick={onAddAgent}>
-          <Icon name="plus" size={11} />
-          <span>New agent</span>
-        </button>
         {drafts.map((d) => (
           <AgentRow
             key={d.id}

--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -103,40 +103,41 @@
   transform: rotate(90deg);
 }
 .proj-h .pname {
-  flex: 1;
+  flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* count sits next to the name (middot-separated) and its auto margin pushes
+ * the action buttons to the far right. */
 .proj-h .pcount {
-  width: 22px;
-  text-align: center;
+  flex-shrink: 0;
+  margin-right: auto;
   font-family: var(--font-mono);
   font-size: var(--fs-xs);
   color: var(--fg-3);
+}
+.proj-h .pcount::before {
+  content: "·";
+  margin-right: 4px;
 }
 .proj-h .padd {
   width: 22px;
   height: 22px;
   border-radius: 4px;
-  display: none;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   color: var(--fg-2);
+  background: var(--bd-soft);
   transition: var(--transition-ui);
 }
-.proj-h:hover .padd {
-  display: inline-flex;
-}
-.proj-h:hover .pcount {
-  display: none;
-}
 .proj-h .padd:hover {
-  background: var(--selected);
+  background: var(--accent-soft);
   color: var(--accent);
 }
-.proj-h .padd[data-tip="New agent"] svg {
+.proj-h .padd[aria-label="New agent"] svg {
   width: 15px;
   height: 15px;
   flex-shrink: 0;
@@ -178,10 +179,10 @@
   cursor: default;
 }
 .agent:hover {
-  background: var(--hover);
+  background: color-mix(in oklch, var(--bd-soft) 50%, transparent);
 }
 .agent.active {
-  background: var(--selected);
+  background: var(--bd-soft);
   color: var(--fg-0);
 }
 

--- a/src/styles/shared/badge.css
+++ b/src/styles/shared/badge.css
@@ -133,25 +133,6 @@
   transition: width 0.25s var(--ease);
 }
 
-.agent-new {
-  gap: 8px;
-  padding: 8px 8px;
-  margin-bottom: 6px;
-  border-radius: var(--r-sm);
-  font-size: var(--fs-sm);
-  color: var(--fg-3);
-  width: 100%;
-  text-align: left;
-}
-.agent-new:hover {
-  background: var(--hover);
-  color: var(--fg-1);
-}
-.agent-new svg {
-  width: 15px;
-  height: 15px;
-}
-
 .side-foot {
   height: 52px;
   padding: 0 12px;


### PR DESCRIPTION
## Summary

Reworks the sidebar project row so it's always clear where to add a new agent.

- **Always-visible "+" button.** The per-project new-agent button on the right of the project name is now always shown (previously hover-only), rendered as a subtle `--bd-soft` chip. Its `⌘N` shortcut is surfaced in the tooltip.
- **Removed the redundant in-list button.** The "New agent" row that used to sit at the top of each expanded project list is gone (along with its now-unused `.agent-new` styles).
- **Count moved inline.** The agent count now sits next to the project name, middot-separated (`name · 3`), instead of on the right; its auto margin pushes the action button to the far edge, and long names still ellipsis-truncate.
- **Selection/hover polish.** Selected agent rows use `--bd-soft`; agent hover is a more translucent mix of the same token so the visual hierarchy reads hover < selected, consistent across light and dark themes.

The `⌘N` shortcut itself already existed in `util/shortcuts.ts` — no logic changes there.

## Testing

- `npx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)