### PR TITLE
fix(custom-agents): scale monogram initials to chip size

### DIFF
--- a/src/components/SettingsScreen/CustomAgents/AgentEditor.tsx
+++ b/src/components/SettingsScreen/CustomAgents/AgentEditor.tsx
@@ -7,7 +7,8 @@ import { Select } from "@/components/ui/Select";
 import { PROVIDERS } from "@/data/providers";
 import type { NewCustomAgent } from "@/storage/customAgents";
 import { useAppStore } from "@/store";
-import { CA_HUES, INJECTION_HINT, shortFor } from "./shared";
+import { Mono } from "./Mono";
+import { CA_HUES, INJECTION_HINT } from "./shared";
 
 /** Mutable editor form state. `model`/`effort` use "" as the "provider default"
  *  sentinel so the <select> has a concrete value; converted to null on save. */
@@ -92,12 +93,7 @@ export function AgentEditor({
 
         {/* identity */}
         <div className="ca-ed-head flex-center">
-          <span
-            className="ca-mono iflex-center ca-ed-mono text-lg"
-            style={{ ["--h" as string]: form.color }}
-          >
-            {shortFor(form.name)}
-          </span>
+          <Mono name={form.name} hue={form.color} size={46} />
           <input
             className="ca-ed-name text-xl"
             placeholder="Name this agent…"

--- a/src/components/SettingsScreen/CustomAgents/CustomAgents.css
+++ b/src/components/SettingsScreen/CustomAgents/CustomAgents.css
@@ -119,11 +119,6 @@
 .ca-ed-head {
   gap: 14px;
 }
-.ca-ed-mono {
-  width: 46px;
-  height: 46px;
-  border-radius: 11px;
-}
 .ca-ed-name {
   flex: 1;
   min-width: 0;

--- a/src/components/SettingsScreen/CustomAgents/Mono.tsx
+++ b/src/components/SettingsScreen/CustomAgents/Mono.tsx
@@ -1,7 +1,9 @@
 import { shortFor } from "./shared";
 
 /** Colored monogram tile standing in for a custom agent's avatar. The hue is
- *  the agent's `color`; the glyph is its name's initials. */
+ *  the agent's `color`; the glyph is its name's initials. Corner radius and
+ *  glyph size scale with `size`, so every chip — from the 14px sidebar dot to
+ *  the 46px editor head — keeps the same proportions and never crowds its edges. */
 export function Mono({ name, hue, size = 38 }: { name: string; hue: number; size?: number }) {
   return (
     <span
@@ -9,8 +11,8 @@ export function Mono({ name, hue, size = 38 }: { name: string; hue: number; size
       style={{
         width: size,
         height: size,
-        borderRadius: size > 30 ? 9 : 6,
-        fontSize: size > 30 ? 13 : 10.5,
+        borderRadius: Math.round(size * 0.24),
+        fontSize: Math.round((5 + size * 0.18) * 2) / 2,
         ["--h" as string]: hue,
       }}
     >


### PR DESCRIPTION
## Summary
Custom-agent monogram initials were sized with two hardcoded font-size tiers, so chips of sizes 14, 15, and 26 all shared one 9.5px glyph. On the smallest chips (sidebar agent row, model picker) the letters crowded the chip edges.

## Changes
- **`Mono` scales with `size`** — both glyph font-size (`5 + size*0.18`) and corner radius (`size*0.24`) now derive from the tile size, so the 14px sidebar chip gets smaller letters than the 26px picker chip and no chip crowds its edges. Large tiles keep their existing 9/11px radii.
- **Single reusable chip** — the agent editor header hand-rolled its own monogram (`ca-mono … ca-ed-mono` span + `shortFor`). It now renders `<Mono size={46}>` like everywhere else, and the redundant `.ca-ed-mono` CSS rule is removed. `Mono` is now the only place the chip is built.

## Testing
- `npx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)