### PR TITLE
fix(chat): don't render CLI-injected (isMeta) user events as user bubbles

### DIFF
--- a/src/adapters/claude/reduce.test.ts
+++ b/src/adapters/claude/reduce.test.ts
@@ -83,6 +83,55 @@ describe("claudeAdapter — transcript replay", () => {
   });
 });
 
+describe("claudeAdapter.reduce — injected meta user events", () => {
+  it("does not render an isMeta user event (e.g. a skill body) as a user bubble", () => {
+    // Shape mirrors a real Skill-tool injection: a user-role event whose text
+    // block holds the SKILL.md body, flagged isMeta:true by the CLI.
+    const items = reduceAll([
+      {
+        type: "user",
+        isMeta: true,
+        sourceToolUseID: "toolu_skill",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "Base directory for this skill: /x\n\n# gstack" }],
+        },
+      },
+    ] as RawEvent[]);
+    expect(items).toEqual([]);
+  });
+
+  it("still renders a normal (non-meta) user event as a bubble", () => {
+    const items = reduceAll([
+      {
+        type: "user",
+        message: { role: "user", content: [{ type: "text", text: "real prompt" }] },
+      },
+    ] as RawEvent[]);
+    expect(items).toEqual([{ kind: "user_message", text: "real prompt" }]);
+  });
+
+  it("keeps a tool_result carried on a meta user event", () => {
+    // Defensive: the meta flag suppresses stray text, not tool plumbing.
+    const items = reduceAll([
+      {
+        type: "user",
+        isMeta: true,
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "injected preamble" },
+            { type: "tool_result", tool_use_id: "toolu_1", content: "ok" },
+          ],
+        },
+      },
+    ] as RawEvent[]);
+    expect(items).toEqual([
+      { kind: "tool_result", tool_use_id: "toolu_1", content: "ok", is_error: false },
+    ]);
+  });
+});
+
 describe("claudeAdapter.reduce — error result", () => {
   it("emits a notice with is_error=true", () => {
     const items = reduceAll([

--- a/src/adapters/claude/reduce.ts
+++ b/src/adapters/claude/reduce.ts
@@ -167,10 +167,18 @@ function handleAssistant(prev: ChatItem[], ev: RawEvent): ChatItem[] {
 
 function handleUser(prev: ChatItem[], ev: RawEvent): ChatItem[] {
   const message = asRecord(ev.message);
+  // The CLI stamps `isMeta` on user-role events it injected itself — skill
+  // bodies (SKILL.md expanded via the Skill tool), the local-command caveat,
+  // "Continue from where you left off" resume prompts, /insights context dumps.
+  // None were typed by the user, so their text must not render as a user
+  // bubble. Real prompts and slash commands are isMeta:false and unaffected.
+  // tool_result blocks (below) are still processed — meta events rarely carry
+  // them, but dropping one would orphan its tool_call.
+  const isMeta = ev.isMeta === true;
   const rawText = contentText(message.content);
 
   let items = prev;
-  if (rawText) {
+  if (rawText && !isMeta) {
     const { text, notices } = sanitizeUserText(rawText);
     if (text) {
       items = dedupAgainstLast(items, { kind: "user_message", text });


### PR DESCRIPTION
## Problem

In a chat turn, a skill's `SKILL.md` body (the `browse`/gstack instructions) rendered as if the user had typed it — a large "Base directory for this skill: … # gstack …" block appearing as a user message bubble.

## Root cause

Claude Code delivers skill instructions (and other synthetic context) as a `user`-role event with a plain `text` block, flagged **`isMeta: true`** — the CLI's own marker for "not user-authored." Confirmed against the real transcript record:

```json
{"type":"user","message":{"role":"user","content":[{"type":"text","text":"Base directory for this skill: …gstack…"}]},"isMeta":true,"sourceToolUseID":"toolu_…"}
```

The Claude adapter's `handleUser` classified user events only by type/role/content shape and never consulted `isMeta`, so the injected text flowed through `contentText` → `sanitizeUserText` (no wrapper tag to strip) → `user_message` → rendered as a `UserBubble`.

This also affected other injected `isMeta` events (`Continue from where you left off.`, `/insights` context dumps, the local-command caveat).

## Fix

Honor the flag in `handleUser` (`src/adapters/claude/reduce.ts`): skip the text→`user_message` emission when `ev.isMeta` is set, while still processing any `tool_result` blocks the event carries (defensive — dropping one would orphan its `tool_call`). One chokepoint covers both the live and canonical replay paths.

Verified across all local transcripts that genuine prompts **and** slash commands are `isMeta:false` (58/58 `<command-name>` events), so they are unaffected and slash-command chips still render.

## Tests

- New `reduce.test.ts` cases: meta event → no bubble; normal event → bubble (regression guard); meta event with a `tool_result` → result preserved.
- Full suite: 332/332 pass; `tsc --noEmit` clean.
- Additionally replayed the **real** namib transcript record end-to-end through `normalizeTranscript → reduce` — now produces zero user bubbles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)