### PR TITLE
fix(chat): suppress live (isSynthetic) injected user events

### DIFF
--- a/src/adapters/claude/reduce.ts
+++ b/src/adapters/claude/reduce.ts
@@ -167,18 +167,24 @@ function handleAssistant(prev: ChatItem[], ev: RawEvent): ChatItem[] {
 
 function handleUser(prev: ChatItem[], ev: RawEvent): ChatItem[] {
   const message = asRecord(ev.message);
-  // The CLI stamps `isMeta` on user-role events it injected itself — skill
-  // bodies (SKILL.md expanded via the Skill tool), the local-command caveat,
-  // "Continue from where you left off" resume prompts, /insights context dumps.
-  // None were typed by the user, so their text must not render as a user
-  // bubble. Real prompts and slash commands are isMeta:false and unaffected.
-  // tool_result blocks (below) are still processed — meta events rarely carry
-  // them, but dropping one would orphan its tool_call.
-  const isMeta = ev.isMeta === true;
+  // The CLI flags user-role events it injected itself — skill bodies (SKILL.md
+  // expanded via the Skill tool), the local-command caveat, "Continue from
+  // where you left off" resume prompts, /insights context dumps. None were
+  // typed by the user, so their text must not render as a user bubble.
+  //
+  // The flag has two names for the SAME event depending on the path: the live
+  // stream-json wire uses `isSynthetic: true`, while the persisted `.jsonl`
+  // transcript rewrites it as `isMeta: true`. PR #296 honored only `isMeta`,
+  // which exists solely in the transcript — so the live render still bubbled
+  // the skill body (the maldives report). Honor both. Real prompts and slash
+  // commands carry neither flag and are unaffected. tool_result blocks (below)
+  // are still processed — injected events rarely carry them, but dropping one
+  // would orphan its tool_call.
+  const isInjected = ev.isMeta === true || ev.isSynthetic === true;
   const rawText = contentText(message.content);
 
   let items = prev;
-  if (rawText && !isMeta) {
+  if (rawText && !isInjected) {
     const { text, notices } = sanitizeUserText(rawText);
     if (text) {
       items = dedupAgainstLast(items, { kind: "user_message", text });

--- a/tests/adapters/claude/reduce.test.ts
+++ b/tests/adapters/claude/reduce.test.ts
@@ -101,6 +101,29 @@ describe("claudeAdapter.reduce — injected meta user events", () => {
     expect(items).toEqual([]);
   });
 
+  it("does not render an isSynthetic user event (live skill body) as a user bubble", () => {
+    // The live stream-json wire flags the SAME injected event as `isSynthetic`
+    // rather than `isMeta` (which appears only in the persisted transcript).
+    // Shape captured verbatim from `claude -p --output-format stream-json` when
+    // a skill loads. Honoring only isMeta let this bubble through live (#296
+    // regression, reported in maldives).
+    const items = reduceAll([
+      {
+        type: "user",
+        isSynthetic: true,
+        parent_tool_use_id: null,
+        session_id: "s1",
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "Base directory for this skill: /x\n\n# Greeter Skill\nhello" },
+          ],
+        },
+      },
+    ] as RawEvent[]);
+    expect(items).toEqual([]);
+  });
+
   it("still renders a normal (non-meta) user event as a bubble", () => {
     const items = reduceAll([
       {


### PR DESCRIPTION
## Problem

A skill's `SKILL.md` body still rendered as a user message bubble in a live chat turn (reported in the maldives worktree) — the exact symptom PR #296 was meant to fix.

## Root cause

PR #296 keyed the suppression on `isMeta === true`:

```ts
const isMeta = ev.isMeta === true;
if (rawText && !isMeta) { /* render user bubble */ }
```

But **`isMeta` only exists in the persisted `.jsonl` transcript.** The live `stream-json` wire that the app renders in real time flags the *same* injected event differently. Confirmed by capturing a real `claude -p --output-format stream-json` skill load:

```json
{"type":"user","message":{"role":"user","content":[{"type":"text",
 "text":"Base directory for this skill: …\n\n# Greeter Skill…"}]},
 "parent_tool_use_id":null,"session_id":"…","isSynthetic":true}
```

The live event carries `"isSynthetic": true` — no `isMeta`. Claude Code rewrites it into `isMeta: true` only when it writes the transcript file.

So the reducer ran on both paths (as #296 intended), but the live path's events never had the field it checked. The skill body bubbled live and only vanished later, once the turn's transcript was ingested and re-reduced from records — where `isMeta` *is* present. #296 verified against replay transcripts, which is why the gap slipped through.

## Fix

Honor **both** flag names — the live and persisted spellings of the same "not user-authored" marker:

```ts
const isInjected = ev.isMeta === true || ev.isSynthetic === true;
```

Real prompts and slash commands carry neither, so they're unaffected; `tool_result` blocks riding on injected events are still processed.

## Tests

- New `reduce.test.ts` case using the verbatim live `isSynthetic` event shape.
- Adapter suite: 109/109 pass (20/20 in `reduce.test.ts`); `reduce.ts` typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)