### PR TITLE
feat: surface running dev-server state in Run tab and sidebar

### DIFF
--- a/src/components/RightPanel/RightPanel.css
+++ b/src/components/RightPanel/RightPanel.css
@@ -41,6 +41,25 @@
 .r-tab.active .count {
   color: var(--accent);
 }
+/* "Live" dot on the Run tab while the project's app is up — mirrors the Code
+   panel's cms-live-dot.on so a running app is visible from any tab. */
+.r-tab-live-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  margin-left: 1px;
+  background: var(--success);
+  animation: r-tab-live 1.6s ease-in-out infinite;
+}
+@keyframes r-tab-live {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in oklch, var(--success), transparent 35%);
+  }
+  50% {
+    box-shadow: 0 0 0 4px color-mix(in oklch, var(--success), transparent 88%);
+  }
+}
 
 .right-body {
   flex: 1;

--- a/src/components/RightPanel/RunPanel.tsx
+++ b/src/components/RightPanel/RunPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
-import { type AgentRecord, api, onRunOutput, onRunState, type RunPhase } from "@/api";
+import { type AgentRecord, api, onRunOutput, onRunState } from "@/api";
 import { Icon } from "@/components/Icon";
+import { useAppStore } from "@/store";
 import {
   deleteProjectSetting,
   getProjectSettings,
@@ -31,7 +32,11 @@ const ANSI_RE = /\x1b\[[0-9;?]*[a-zA-Z]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
 const stripAnsi = (s: string) => s.replace(ANSI_RE, "");
 
 export function RunPanel({ agent }: { agent: AgentRecord }) {
-  const [phase, setPhase] = useState<RunPhase>("idle");
+  // Phase is owned by the store (fed by an app-wide `run:state` subscription) so
+  // the Run tab's running dot survives this panel unmounting on a tab switch.
+  const phase = useAppStore((s) => s.runPhases[agent.id] ?? "idle");
+  const setRunPhase = useAppStore((s) => s.setRunPhase);
+  const setRunPort = useAppStore((s) => s.setRunPort);
   const [lastError, setLastError] = useState<string | null>(null);
   const [log, setLog] = useState<string>("");
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -117,7 +122,9 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
 
     api.runState(agent.id).then((snap) => {
       if (cancelled) return;
-      setPhase(snap.phase);
+      // Rehydrate the store phase too, so a running app opened after an app
+      // reload lights the tab dot even before the next live event arrives.
+      setRunPhase(agent.id, snap.phase);
       setLastError(snap.last_error);
       // Snapshot is a one-shot buffer — decode it without streaming
       // mode using its own decoder so it doesn't pollute the live
@@ -140,7 +147,8 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
 
     onRunState((e) => {
       if (e.agent_id !== agent.id) return;
-      setPhase(e.phase);
+      // Phase flows through the store via the app-wide listener; this local
+      // subscription only mirrors last_error, which the store doesn't track.
       setLastError(e.last_error);
     }).then((un) => {
       if (cancelled) {
@@ -155,7 +163,7 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
       unlistenOutput?.();
       unlistenState?.();
     };
-  }, [agent.id]);
+  }, [agent.id, setRunPhase]);
 
   // Auto-scroll to bottom on log append.
   useEffect(() => {
@@ -173,6 +181,13 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
   const port = fieldValue("port");
   const isActive = phase === "setup" || phase === "running";
   const linkLive = phase === "running";
+
+  // Publish the resolved port to the store so the sidebar's running indicator
+  // can show `:port`. The port isn't on the `run:state` event, so the panel —
+  // which already resolves detected value + overrides — is the source.
+  useEffect(() => {
+    if (port) setRunPort(agent.id, port);
+  }, [agent.id, port, setRunPort]);
 
   const onPlay = () => {
     if (isActive) {

--- a/src/components/RightPanel/RunPanel.tsx
+++ b/src/components/RightPanel/RunPanel.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useRef, useState } from "react";
 import { type AgentRecord, api, onRunOutput, onRunState } from "@/api";
 import { Icon } from "@/components/Icon";
-import { useAppStore } from "@/store";
 import {
   deleteProjectSetting,
   getProjectSettings,
   setProjectSetting,
 } from "@/storage/projectSettings";
+import { useAppStore } from "@/store";
 import { RunSettingsSheet, type SetupRow } from "./RunSettingsSheet";
 import { reconcileOverrides } from "./reconcileOverrides";
 

--- a/src/components/RightPanel/index.tsx
+++ b/src/components/RightPanel/index.tsx
@@ -13,6 +13,9 @@ interface Tab {
   label: string;
   icon: IconName;
   count?: number;
+  /** Show a pulsing green "live" dot on the tab (e.g. the Run tab while the
+   *  project's app is up), so activity is visible from any other tab. */
+  live?: boolean;
 }
 
 /** Right rail: tabs for Code / Git / Run / Terminal (each feature-flagged in
@@ -27,11 +30,17 @@ export function RightPanel({ agent }: { agent: AgentRecord }) {
   const gitFiles = useAppStore(
     (s) => s.gitStates[agent.id]?.files.length ?? s.gitShortstats[agent.id]?.file_count ?? 0,
   );
+  // Live run state (setup or running) → the Run tab shows a green dot, matching
+  // the Code panel's "Live" indicator, so a running app is visible from any tab.
+  const runActive = useAppStore((s) => {
+    const phase = s.runPhases[agent.id];
+    return phase === "setup" || phase === "running";
+  });
 
   const tabs: Tab[] = [
     features.code && { id: "code", label: "Code", icon: "code" },
     features.git && { id: "git", label: "Git", icon: "branch", count: gitFiles },
-    features.run && { id: "run", label: "Run", icon: "play" },
+    features.run && { id: "run", label: "Run", icon: "play", live: runActive },
     features.terminal && { id: "term", label: "Terminal", icon: "terminal" },
   ].filter(Boolean) as Tab[];
 
@@ -73,6 +82,7 @@ export function RightPanel({ agent }: { agent: AgentRecord }) {
               <Icon name={t.icon} />
               {t.label}
               {t.count != null && t.count > 0 && <span className="count text-xs">{t.count}</span>}
+              {t.live && <span className="r-tab-live-dot" />}
             </button>
           ))}
         </div>

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -54,6 +54,17 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
   const prState = useAppStore((s) => s.prStates[agent.id] ?? null);
   const shortstats = useAppStore((s) => s.gitShortstats[agent.id]);
   const unseen = useAppStore((s) => s.unseenResults[agent.id] ?? false);
+  // Dev-server state for this worktree — orthogonal to the agent's turn status,
+  // so it shows as its own play chip beside the identity chip, not among the
+  // activity cues (rail / loader / shimmer). Fed by the app-wide `run:state`
+  // subscription (see store/app.ts), so it stays correct from any tab.
+  const runLive = useAppStore((s) => {
+    const phase = s.runPhases[agent.id];
+    return phase === "setup" || phase === "running";
+  });
+  // Dev-server port, if the RunPanel has resolved it this session — surfaced in
+  // the running chip's tooltip (":port"). Absent until then.
+  const runPort = useAppStore((s) => s.runPorts[agent.id]);
   const pending = useAppStore((s) => s.pendingToolUse[agent.id]);
   const stop = useAppStore((s) => s.stop);
   const archive = useAppStore((s) => s.archive);
@@ -156,6 +167,15 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
             <ProviderIcon slug={agent.provider} {...providerChip(agent.provider)} size={14} />
           )}
         </span>
+        {runLive && (
+          <span
+            className="ag-run tip"
+            data-tip={runPort ? `Dev server running on :${runPort}` : "Dev server running"}
+            aria-label={runPort ? `Dev server running on port ${runPort}` : "Dev server running"}
+          >
+            <Icon name="play" size={9} />
+          </span>
+        )}
         <span className="ag-slot iflex-center">
           <span className={`ag-meta ${agent.status === "error" ? "wide" : ""}`}>
             {awaiting ? (

--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -270,6 +270,38 @@
   display: inline-flex;
   align-items: center;
 }
+/* dev-server "running" indicator — a green play mark in a tinted, bordered
+ * circle beside the identity chip. Signals the worktree's app is up, distinct
+ * from the agent's turn status (rail / loader / shimmer). The slow breathing
+ * halo reads as a live "heartbeat" — sleek, not an alarm. */
+.agent-row .ag-run {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  color: var(--success);
+  background: color-mix(in oklch, var(--success), transparent 88%);
+  border: 1px solid color-mix(in oklch, var(--success), transparent 58%);
+  animation: agRun 2.6s var(--ease) infinite;
+}
+/* optical-center the play triangle within its circle */
+.agent-row .ag-run svg {
+  margin-left: 1px;
+}
+@keyframes agRun {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in oklch, var(--success), transparent 80%);
+    border-color: color-mix(in oklch, var(--success), transparent 62%);
+  }
+  50% {
+    box-shadow: 0 0 7px 0 color-mix(in oklch, var(--success), transparent 42%);
+    border-color: color-mix(in oklch, var(--success), transparent 34%);
+  }
+}
 
 /* right slot — meta and actions share one fixed space, cross-fading on
  * hover so the row never reflows (no height jump). */

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -12,6 +12,7 @@ import {
   onAgentTask,
   onAgentView,
   onPrStateChanged,
+  onRunState,
   onSessionRecordsAppended,
   onShellOutput,
   onTurnStarted,
@@ -338,6 +339,13 @@ const registerEventListeners = async (set: AppSet, get: AppGet) => {
 
   await onPrStateChanged((e) => {
     set((s) => ({ prStates: { ...s.prStates, [e.agent_id]: e.state } }));
+  });
+
+  // App-wide run-phase tracking. The RunPanel unmounts when its tab isn't
+  // active, so its own subscription can't keep the Run tab's "app is running"
+  // dot lit from another tab — this always-on listener owns `runPhases`.
+  await onRunState((e) => {
+    set((s) => ({ runPhases: { ...s.runPhases, [e.agent_id]: e.phase } }));
   });
 };
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -8,6 +8,7 @@ import type {
   PrChecks,
   PrComments,
   PrState,
+  RunPhase,
   ShortStats,
   Workspace,
 } from "@/api";
@@ -93,6 +94,17 @@ export interface WorkspaceSlice {
    *  agent_id; absent until the agent's first turn lands. Empty for agents that
    *  don't persist usage on disk (cursor, antigravity). See adapters/usage.ts. */
   usage: Record<string, AgentUsage>;
+  /** Live run phase per agent, keyed by agent_id, from the `run:state` event
+   *  stream. Absent = never started (read as "idle"). Fed by an app-wide
+   *  subscription (not the RunPanel, which unmounts on tab switch) so the Run
+   *  tab's "app is running" green dot stays lit from any tab. Single source of
+   *  truth for phase — the RunPanel reads it rather than holding its own copy. */
+  runPhases: Record<string, RunPhase>;
+  /** Dev-server port per agent, keyed by agent_id. Written by the RunPanel when
+   *  it resolves the run config (detected value + overrides), so the sidebar's
+   *  running indicator can show `:port`. Absent until that agent's Run panel has
+   *  been opened this session (the port isn't on the `run:state` event yet). */
+  runPorts: Record<string, string>;
 
   selectAgent: (id: string | null) => void;
   spawn: (view: AgentView, repoPath: string) => Promise<AgentRecord | null>;
@@ -116,6 +128,12 @@ export interface WorkspaceSlice {
     message?: string,
   ) => Promise<void>;
   switchView: (id: string, view: AgentView) => Promise<void>;
+  /** Record an agent's run phase (from a `run:state` event or a RunPanel
+   *  snapshot rehydrate). Drives the Run tab's running indicator. */
+  setRunPhase: (id: string, phase: RunPhase) => void;
+  /** Record an agent's resolved dev-server port (from the RunPanel), for the
+   *  sidebar's `:port` running indicator. */
+  setRunPort: (id: string, port: string) => void;
   resume: (id: string) => Promise<void>;
   stop: (id: string) => Promise<void>;
   discard: (id: string) => Promise<void>;

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -36,6 +36,8 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
   switchInFlight: {},
   unseenResults: {},
   usage: {},
+  runPhases: {},
+  runPorts: {},
 
   selectAgent: (id) =>
     set((state) => {
@@ -191,6 +193,14 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
       }));
     }
   },
+
+  setRunPhase: (id, phase) =>
+    set((state) => ({ runPhases: { ...state.runPhases, [id]: phase } })),
+
+  setRunPort: (id, port) =>
+    set((state) =>
+      state.runPorts[id] === port ? state : { runPorts: { ...state.runPorts, [id]: port } },
+    ),
 
   resume: async (id) => {
     clearOutputBuffer(id);

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -194,8 +194,7 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
     }
   },
 
-  setRunPhase: (id, phase) =>
-    set((state) => ({ runPhases: { ...state.runPhases, [id]: phase } })),
+  setRunPhase: (id, phase) => set((state) => ({ runPhases: { ...state.runPhases, [id]: phase } })),
 
   setRunPort: (id, port) =>
     set((state) =>


### PR DESCRIPTION
## What & why
Adds a visible indicator that a worktree's project app (dev server) is running, so you can tell at a glance — from any tab, and from the sidebar — which agents have a live app.

## Changes
- **App-wide run-phase tracking.** A single always-on `run:state` subscription owns a `runPhases` store map, instead of relying on the RunPanel (which unmounts on tab switch). The RunPanel now reads phase from the store as the single source of truth and publishes the resolved dev-server port (`runPorts`).
- **Run tab dot.** The Run tab shows a pulsing green dot while the app is up, mirroring the Code panel's "Live" indicator.
- **Sidebar chip.** A breathing green play chip renders beside the agent's identity chip when its app is running; the port is surfaced in the chip's tooltip (e.g. "Dev server running on :5173").

## Notes / follow-ups (not in this PR)
- Phase and port populate from live events and when a Run panel is opened. After a frontend reload with the backend still alive, an already-running app shows once its state changes or its panel is opened. A phase-only bulk `run_states` command seeded at startup would close that gap.
- The port comes from the RunPanel (detected config + overrides), not the `run:state` event, so it's known only after that agent's panel has been opened this session. Plumbing `port` through the event would make it always-available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)