### PR TITLE
fix(editors): silence private_interfaces warning on Kind enum

### DIFF
--- a/src-tauri/src/editors.rs
+++ b/src-tauri/src/editors.rs
@@ -14,7 +14,7 @@ use crate::error::{Error, Result};
 /// glyph fallback) in the picker.
 #[derive(Clone, Copy, Serialize)]
 #[serde(rename_all = "lowercase")]
-enum Kind {
+pub(crate) enum Kind {
     Editor,
     Terminal,
 }


### PR DESCRIPTION
## Summary

Makes the `Kind` enum `pub(crate)` so it matches the visibility of the `DetectedEditor::kind` field that exposes it.

The field was declared `pub` while its type `Kind` was module-private, triggering the `private_interfaces` lint on build:

```
warning: type `editors::Kind` is more private than the item `DetectedEditor::kind`
```

Build-only warning, no behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)