### PR TITLE
fix(chat): badge mid-turn follow-ups only while queued, keep them at injection point

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -224,6 +224,8 @@ pub fn write_to_agent(
     sup.write_to_agent(&app, &agent_id, data.as_bytes())
 }
 
+/// Returns `true` when the follow-up was enqueued for a later turn boundary
+/// rather than delivered now (see `Supervisor::send_user_message`).
 #[tauri::command]
 pub fn send_user_message(
     supervisor: State<'_, Arc<Supervisor>>,
@@ -233,7 +235,7 @@ pub fn send_user_message(
     text: String,
     attachments: Vec<String>,
     thinking: Option<String>,
-) -> Result<()> {
+) -> Result<bool> {
     let sup = supervisor.inner().clone();
     sup.send_user_message(
         &app,

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -1078,6 +1078,11 @@ impl Supervisor {
     /// - idle, queue full    → flush the leftovers + this message, coalesced,
     /// - busy, claude live    → inject into the running turn over stdin,
     /// - busy, per-turn / tool-gated → queue for the next turn boundary.
+    /// Returns `true` when the message was *enqueued* (held for a later turn
+    /// boundary) rather than delivered now — the frontend uses this to badge the
+    /// optimistic bubble as "queued" only while it genuinely is. Any variant that
+    /// delivers now (including a `WriteLive` that falls back to a fresh turn)
+    /// returns `false`.
     pub fn send_user_message(
         self: Arc<Self>,
         app: &AppHandle,
@@ -1086,7 +1091,7 @@ impl Supervisor {
         text: &str,
         attachments: &[String],
         thinking: Option<&str>,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let mode = injection_mode(&self.workspace.agent(agent_id)?.provider);
         let busy = matches!(
             self.live_status(agent_id),
@@ -1106,7 +1111,8 @@ impl Supervisor {
             thinking: thinking.map(str::to_string),
         };
 
-        match decide_delivery(busy, mode, tool_gated, queue_nonempty) {
+        let delivery = decide_delivery(busy, mode, tool_gated, queue_nonempty);
+        match delivery {
             Delivery::DeliverNow => deliver_as_turn(&self, app, agent_id, &msg)?,
             Delivery::FlushNow => {
                 self.message_queue.lock().enqueue(agent_id, msg);
@@ -1127,7 +1133,9 @@ impl Supervisor {
             }
             Delivery::Enqueue => self.message_queue.lock().enqueue(agent_id, msg),
         }
-        Ok(())
+        // Only `Enqueue` holds the message back; every other path delivered it
+        // now (WriteLive's fallback still delivers as a fresh turn).
+        Ok(matches!(delivery, Delivery::Enqueue))
     }
 
     /// Inject a message into the running turn over the managed agent's open

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -21,7 +21,19 @@ export type ChatItem =
   // turn boundary (per-turn agents). Store-inserted only — never produced by an
   // adapter's reduce(). Reconciled away once the canonical transcript catches
   // up (see app.ts onSessionRecordsAppended). Renders with the user bubble.
-  | { kind: "queued_message"; text: string; attachments?: string[] }
+  | {
+      kind: "queued_message";
+      text: string;
+      attachments?: string[];
+      /** True only while the message is genuinely held for a later turn
+       *  boundary (per-turn agents, or claude paused on a tool gate). A message
+       *  injected/delivered now clears this and renders as a plain bubble. Set
+       *  from the send's delivery outcome. */
+      queued?: boolean;
+      /** Client turn id, used to locate this optimistic item and flip `queued`
+       *  once the backend reports the delivery outcome. */
+      turnId?: string;
+    }
   | {
       kind: "agent_message";
       text: string;

--- a/src/api.ts
+++ b/src/api.ts
@@ -404,6 +404,8 @@ export const api = {
     }),
   writeToAgent: (agentId: string, data: string) =>
     invoke<void>("write_to_agent", { agentId, data }),
+  /** Resolves to `true` when the message was enqueued for a later turn boundary
+   *  rather than delivered now (injected live / sent as a new turn). */
   sendUserMessage: (
     agentId: string,
     turnId: string,
@@ -411,7 +413,7 @@ export const api = {
     attachments: string[] = [],
     thinking?: string,
   ) =>
-    invoke<void>("send_user_message", {
+    invoke<boolean>("send_user_message", {
       agentId,
       turnId,
       text,

--- a/src/components/Workspace/Chat.css
+++ b/src/components/Workspace/Chat.css
@@ -465,8 +465,9 @@
   scroll-margin-top: 24px;
 }
 
-/* A mid-turn follow-up not yet in the transcript: same bubble, dimmed, with a
-   small "queued" tag. Reconciled to a normal user_message once it lands. */
+/* A mid-turn follow-up still held for a later turn boundary: same bubble,
+   dimmed, with a small "queued" tag. Cleared to a plain bubble once delivered,
+   then reconciled to a canonical user_message once the transcript lands. */
 .m-user--queued {
   opacity: 0.7;
   border-style: dashed;

--- a/src/components/Workspace/messages/MessageItem.tsx
+++ b/src/components/Workspace/messages/MessageItem.tsx
@@ -46,10 +46,11 @@ export function MessageItem({
       }
       return <UserBubble text={item.text} attachments={item.attachments} turnId={turnId} />;
     case "queued_message":
-      // Same bubble, marked queued: a follow-up the user sent mid-turn that the
-      // transcript hasn't caught up to yet. Reconciled away in app.ts once it
-      // lands canonically.
-      return <UserBubble text={item.text} attachments={item.attachments} queued />;
+      // A follow-up the user sent mid-turn. Badged "queued" only while it's
+      // genuinely held for a later turn boundary (item.queued); once delivered/
+      // injected it renders as a plain bubble at its injection point. Either way
+      // it's reconciled away once the transcript catches up (app.ts).
+      return <UserBubble text={item.text} attachments={item.attachments} queued={item.queued} />;
     case "agent_message":
       // Copy isn't offered here: it lives in the turn footer (see TurnFooter),
       // right-aligned on the seam, so the message itself reserves no extra
@@ -140,7 +141,7 @@ function UserBubble({
         )}
         {queued && <span className="m-user__queued-tag text-xs">queued</span>}
       </div>
-      {/* A queued follow-up isn't canonical yet, so skip its copy affordance. */}
+      {/* A still-queued follow-up isn't canonical yet, so skip its copy affordance. */}
       {!queued && (
         <div className="m-actions">
           <CopyButton text={display} />

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -114,18 +114,25 @@ export function applyUserTurns(items: ChatItem[], turns: UserTurn[]): ChatItem[]
 }
 
 /** Locate a `prev` item within the freshly-rebuilt transcript so a carried-over
- *  follow-up can be re-anchored next to it. Tool calls match on their stable id;
- *  user/agent messages on exact text (most-recent occurrence wins). Other kinds
- *  aren't reliable anchors. Returns -1 when not found. */
-function locateAnchor(rebuilt: ChatItem[], item: ChatItem): number {
-  if (item.kind === "tool_call") {
-    return rebuilt.findIndex((r) => r.kind === "tool_call" && r.id === item.id);
+ *  follow-up can be re-anchored next to it. Scans forward from `from` and
+ *  returns the FIRST match, so callers advancing `from` in step with a forward
+ *  walk through `prev` get a monotonically-advancing anchor: duplicate text
+ *  (e.g. repeated "OK" acknowledgements) then resolves to the occurrence at this
+ *  point in the turn rather than the last one in the log. Tool calls match on
+ *  their stable id; user/agent messages on exact text; other kinds aren't
+ *  reliable anchors. Returns -1 when not found at or after `from`. */
+function locateAnchor(rebuilt: ChatItem[], item: ChatItem, from: number): number {
+  if (item.kind !== "tool_call" && item.kind !== "user_message" && item.kind !== "agent_message") {
+    return -1;
   }
-  if (item.kind === "user_message" || item.kind === "agent_message") {
-    const textOf = (r: ChatItem): string | undefined =>
-      r.kind === "user_message" || r.kind === "agent_message" ? r.text : undefined;
-    for (let i = rebuilt.length - 1; i >= 0; i -= 1) {
-      if (rebuilt[i].kind === item.kind && textOf(rebuilt[i]) === item.text) return i;
+  const textOf = (r: ChatItem): string | undefined =>
+    r.kind === "user_message" || r.kind === "agent_message" ? r.text : undefined;
+  for (let i = Math.max(from, 0); i < rebuilt.length; i += 1) {
+    const r = rebuilt[i];
+    if (item.kind === "tool_call") {
+      if (r.kind === "tool_call" && r.id === item.id) return i;
+    } else if (r.kind === item.kind && textOf(r) === item.text) {
+      return i;
     }
   }
   return -1;
@@ -158,7 +165,9 @@ export function carryForwardQueued(rebuilt: ChatItem[], prev: ChatItem[]): ChatI
 
   // Walk prev, tracking the rebuilt-index of the most recent locatable item.
   // Each unmatched follow-up is bucketed to insert after that anchor; -1 means
-  // no anchor was found yet, so it falls to the end.
+  // no anchor was found yet, so it falls to the end. Searching forward from
+  // `anchor + 1` keeps the anchor advancing in lockstep with the walk, so
+  // repeated text resolves to the right occurrence.
   const insertAfter = new Map<number, ChatItem[]>();
   let anchor = -1;
   for (const it of prev) {
@@ -168,7 +177,7 @@ export function carryForwardQueued(rebuilt: ChatItem[], prev: ChatItem[]): ChatI
       bucket.push(it);
       insertAfter.set(anchor, bucket);
     } else {
-      const idx = locateAnchor(rebuilt, it);
+      const idx = locateAnchor(rebuilt, it, anchor + 1);
       if (idx >= 0) anchor = idx;
     }
   }

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -113,25 +113,76 @@ export function applyUserTurns(items: ChatItem[], turns: UserTurn[]): ChatItem[]
   return result;
 }
 
+/** Locate a `prev` item within the freshly-rebuilt transcript so a carried-over
+ *  follow-up can be re-anchored next to it. Tool calls match on their stable id;
+ *  user/agent messages on exact text (most-recent occurrence wins). Other kinds
+ *  aren't reliable anchors. Returns -1 when not found. */
+function locateAnchor(rebuilt: ChatItem[], item: ChatItem): number {
+  if (item.kind === "tool_call") {
+    return rebuilt.findIndex((r) => r.kind === "tool_call" && r.id === item.id);
+  }
+  if (item.kind === "user_message" || item.kind === "agent_message") {
+    const textOf = (r: ChatItem): string | undefined =>
+      r.kind === "user_message" || r.kind === "agent_message" ? r.text : undefined;
+    for (let i = rebuilt.length - 1; i >= 0; i -= 1) {
+      if (rebuilt[i].kind === item.kind && textOf(rebuilt[i]) === item.text) return i;
+    }
+  }
+  return -1;
+}
+
 /** Carry forward optimistic mid-turn follow-ups (`queued_message`) onto a log
  *  just rebuilt from canonical records, so they don't blink out before the
  *  transcript catches up. Drops any the rebuilt conversation already accounts
  *  for — its text (or first attachment path) now appears in a user message,
  *  whether the follow-up was delivered live (claude) or coalesced (per-turn) —
- *  mirroring the backend matcher's substring association. An attachment-only
- *  follow-up with no needle is kept until it can be matched. */
+ *  mirroring the backend matcher's substring association.
+ *
+ *  A follow-up that isn't in the transcript is re-inserted at its injection
+ *  point: right after the nearest preceding item we can still locate in the
+ *  rebuilt log. This keeps a live-injected message (which claude does not
+ *  persist as its own mid-turn record) in its place within the turn instead of
+ *  jumping to the bottom below the answer it prompted. Follow-ups with no
+ *  locatable anchor (e.g. an attachment-only one with no needle) fall to the
+ *  end, held there until they can be matched. */
 export function carryForwardQueued(rebuilt: ChatItem[], prev: ChatItem[]): ChatItem[] {
-  const stillQueued = prev.filter((it) => {
-    if (it.kind !== "queued_message") return false;
-    const needle = it.text || it.attachments?.[0];
-    if (!needle) return true;
-    return !rebuilt.some(
+  const matched = (q: Extract<ChatItem, { kind: "queued_message" }>): boolean => {
+    const needle = q.text || q.attachments?.[0];
+    if (!needle) return false;
+    return rebuilt.some(
       (r) =>
         r.kind === "user_message" &&
         (r.text.includes(needle) || (r.attachments?.includes(needle) ?? false)),
     );
+  };
+
+  // Walk prev, tracking the rebuilt-index of the most recent locatable item.
+  // Each unmatched follow-up is bucketed to insert after that anchor; -1 means
+  // no anchor was found yet, so it falls to the end.
+  const insertAfter = new Map<number, ChatItem[]>();
+  let anchor = -1;
+  for (const it of prev) {
+    if (it.kind === "queued_message") {
+      if (matched(it)) continue;
+      const bucket = insertAfter.get(anchor) ?? [];
+      bucket.push(it);
+      insertAfter.set(anchor, bucket);
+    } else {
+      const idx = locateAnchor(rebuilt, it);
+      if (idx >= 0) anchor = idx;
+    }
+  }
+  if (insertAfter.size === 0) return rebuilt;
+
+  const result: ChatItem[] = [];
+  rebuilt.forEach((r, i) => {
+    result.push(r);
+    const add = insertAfter.get(i);
+    if (add) result.push(...add);
   });
-  return [...rebuilt, ...stillQueued];
+  const tail = insertAfter.get(-1);
+  if (tail) result.push(...tail);
+  return result;
 }
 
 /** Apply one raw event to an agent's log via its provider adapter. Pure: it
@@ -284,7 +335,7 @@ export function dropAgentEntries(state: AppState, id: string): Partial<AppState>
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-export async function sendWhenAgentReady(send: () => Promise<void>) {
+export async function sendWhenAgentReady(send: () => Promise<unknown>) {
   let lastError: unknown;
   for (let attempt = 0; attempt < 40; attempt += 1) {
     try {

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -95,10 +95,13 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
     try {
       set((state) => {
         const slashName = wasBusy ? null : passthroughSlashName(providerFor(state, id), text);
+        // Optimistic mid-turn follow-up: default to no badge (the common case is
+        // immediate live injection). If the backend reports it was enqueued, we
+        // flip `queued` on below — carried by `turnId` so we can find it again.
         const entry: ChatItem = wasBusy
           ? attachments.length > 0
-            ? { kind: "queued_message", text, attachments }
-            : { kind: "queued_message", text }
+            ? { kind: "queued_message", text, attachments, turnId }
+            : { kind: "queued_message", text, turnId }
           : slashName
             ? { kind: "notice", subtype: "slash_command", text: `/${slashName}` }
             : attachments.length > 0
@@ -122,11 +125,24 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
         };
       });
       try {
-        await api.sendUserMessage(id, turnId, text, attachments, thinking);
+        const enqueued = await api.sendUserMessage(id, turnId, text, attachments, thinking);
+        // Only a genuinely-held message wears the badge; a delivered one stays a
+        // plain bubble. Match by turnId — agent output may have appended since.
+        if (wasBusy && enqueued) {
+          set((state) => ({
+            managedLogs: {
+              ...state.managedLogs,
+              [id]: (state.managedLogs[id] ?? []).map((it) =>
+                it.kind === "queued_message" && it.turnId === turnId ? { ...it, queued: true } : it,
+              ),
+            },
+          }));
+        }
       } catch (e) {
         if (String(e).includes("agent not found")) {
           // Dead idle agent (finished its prior task) — resume the
           // process in --resume mode, then deliver the message once ready.
+          // Not busy, so it lands as a new turn (never queued) — no badge.
           await api.resumeAgent(id);
           await sendWhenAgentReady(() =>
             api.sendUserMessage(id, turnId, text, attachments, thinking),

--- a/tests/helpers/queued.test.ts
+++ b/tests/helpers/queued.test.ts
@@ -5,6 +5,7 @@ import { carryForwardQueued } from "@/helpers";
 const userMsg = (text: string, attachments?: string[]): ChatItem =>
   attachments ? { kind: "user_message", text, attachments } : { kind: "user_message", text };
 const agentMsg = (text: string): ChatItem => ({ kind: "agent_message", text });
+const toolCall = (id: string): ChatItem => ({ kind: "tool_call", id, name: "Bash", input: "" });
 const queued = (text: string, attachments?: string[]): ChatItem =>
   attachments ? { kind: "queued_message", text, attachments } : { kind: "queued_message", text };
 
@@ -55,5 +56,23 @@ describe("carryForwardQueued", () => {
   it("is a no-op when there are no queued items", () => {
     const rebuilt = [userMsg("hi"), agentMsg("ok")];
     expect(carryForwardQueued(rebuilt, rebuilt)).toEqual(rebuilt);
+  });
+
+  it("keeps an unreconciled mid-turn follow-up at its injection point, not the end", () => {
+    // claude live-injects mid-turn but never persists the message as its own
+    // transcript record, so the rebuilt log lacks it. It must stay where it was
+    // injected (after the tool call, before the answer it prompted) rather than
+    // jump below the answer.
+    const rebuilt = [userMsg("start"), toolCall("t1"), agentMsg("after")];
+    const prev = [userMsg("start"), toolCall("t1"), queued("mid"), agentMsg("after")];
+    const out = carryForwardQueued(rebuilt, prev);
+    expect(out).toEqual([userMsg("start"), toolCall("t1"), queued("mid"), agentMsg("after")]);
+  });
+
+  it("anchors a follow-up to the preceding agent message when there's no tool call", () => {
+    const rebuilt = [userMsg("start"), agentMsg("thinking"), agentMsg("done")];
+    const prev = [userMsg("start"), agentMsg("thinking"), queued("mid"), agentMsg("done")];
+    const out = carryForwardQueued(rebuilt, prev);
+    expect(out).toEqual([userMsg("start"), agentMsg("thinking"), queued("mid"), agentMsg("done")]);
   });
 });

--- a/tests/helpers/queued.test.ts
+++ b/tests/helpers/queued.test.ts
@@ -75,4 +75,34 @@ describe("carryForwardQueued", () => {
     const out = carryForwardQueued(rebuilt, prev);
     expect(out).toEqual([userMsg("start"), agentMsg("thinking"), queued("mid"), agentMsg("done")]);
   });
+
+  it("anchors to the occurrence at the injection point when the same text repeats", () => {
+    // Two identical "ok" acks in the turn. The follow-up was injected after the
+    // FIRST one, so it must land there — not after the second (which a
+    // last-match scan would wrongly pick).
+    const rebuilt = [
+      userMsg("start"),
+      agentMsg("ok"),
+      toolCall("t1"),
+      agentMsg("ok"),
+      agentMsg("done"),
+    ];
+    const prev = [
+      userMsg("start"),
+      agentMsg("ok"),
+      queued("mid"),
+      toolCall("t1"),
+      agentMsg("ok"),
+      agentMsg("done"),
+    ];
+    const out = carryForwardQueued(rebuilt, prev);
+    expect(out).toEqual([
+      userMsg("start"),
+      agentMsg("ok"),
+      queued("mid"),
+      toolCall("t1"),
+      agentMsg("ok"),
+      agentMsg("done"),
+    ]);
+  });
 });


### PR DESCRIPTION
## Problem

When a follow-up is sent while an agent is running, it was always labelled **"queued"** — even for claude, where it's injected into the running turn immediately and influences the answer. Worse, once the turn finished the message **jumped to the bottom** of the chat, below the answer it prompted, breaking question→answer lineage.

## Root cause

1. The frontend hardcoded the "queued" badge for every mid-turn follow-up; the backend decided delivery (`decide_delivery`) but never reported the outcome back.
2. claude `--print` stream-json does **not** persist a live-injected mid-turn message as its own transcript record. So `carryForwardQueued` could never reconcile it, and its `[...rebuilt, ...stillQueued]` appended the optimistic bubble at the very end. (Confirmed: the badge never cleared → the item was never matched; a scan of `~/.claude/projects` found zero mid-turn user records.)

## Fix

**Badge honesty** — `send_user_message` (backend command + `Supervisor`) now returns a bool = *enqueued* (true only for `Delivery::Enqueue`; every delivered path, including a `WriteLive` that falls back to a fresh turn, returns false). The store flips `queued_message.queued` from that outcome (matched by client `turnId`). The badge now shows **only while a message is genuinely held**; a live-injected claude message renders as a plain bubble immediately.

**Lineage** — `carryForwardQueued` now re-inserts an unmatched follow-up at its **injection point**: anchored to the nearest preceding item it can still locate in the rebuilt log (tool_call by id, user/agent message by text), falling to the end only when no anchor is found. Messages that *do* appear in the transcript (per-turn coalesced delivery) still reconcile away as before.

## Behaviour after

- **claude, delivered live:** no badge, stays at its injection point after the turn completes.
- **per-turn / tool-gated (genuinely queued):** badged "queued" while held; reconciles into the next turn when flushed.

## Tests
- `tsc` + biome clean; backend `cargo check` + `message_queue` tests pass.
- Full frontend suite: **337 passed**, including 2 new `carryForwardQueued` tests asserting injection-point preservation.

## Known limitation (not addressed here)
On a full **reload**, the message is re-derived from the pending `session_user_turns` row via `applyUserTurns`, which pushes un-associated turns at the end — so it would reappear at the bottom. Fixing that requires the backend to record the injection position (schema change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)