### PR TITLE
perf(chat): memoize message rows to stop streaming re-render storm

### DIFF
--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -11,7 +11,7 @@ import { ChatNav } from "./ChatNav";
 import { ChatSearch } from "./ChatSearch";
 import { ChatWorkingStatus } from "./ChatWorkingStatus";
 import { MessageItem } from "./messages/MessageItem";
-import { pairToolItems, rowKey } from "./messages/pair";
+import { type PairCache, pairToolItems, rowKey } from "./messages/pair";
 import { isTurnPending } from "./messages/turnPending";
 import { isUserInputTool } from "./messages/UserInput/parse";
 import { TurnFooter } from "./RunTimer";
@@ -133,10 +133,15 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
     el.scrollTop = el.scrollHeight;
   }, [log, transcriptLoading]);
 
+  // Persist tool_pair wrapper identity across renders so memoized rows survive
+  // streaming deltas (see PairCache). Self-evicts stale ids each pass, so it
+  // needs no reset when switching agents (tool-use ids never collide).
+  const pairCache = useRef<PairCache>(new Map());
+
   const items = useMemo(() => {
     const adapter = getAdapter(agent.provider);
     const visible = applyPolicy(log ?? [], adapter.policy);
-    return pairToolItems(visible);
+    return pairToolItems(visible, pairCache.current);
   }, [log, agent.provider]);
 
   // Navigable turns = the real user prompts (git-action chips excluded). Each

--- a/src/components/Workspace/messages/MessageItem.tsx
+++ b/src/components/Workspace/messages/MessageItem.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { memo, useMemo } from "react";
 import { applyPolicy, getAdapter } from "@/adapters";
 import { AttachmentList } from "@/components/Composer/AttachmentList";
 import { Markdown } from "@/components/Markdown";
@@ -18,7 +18,11 @@ import { isUserInputTool } from "./UserInput/parse";
  *  agent's adapter id down so nested subagent threads filter/pair their
  *  rows with the same display policy as the main log. `agentId` lets the
  *  user-input widget route its answer back to this agent's stdin. */
-export function MessageItem({
+/** Memoized: ChatView re-renders on every streaming delta, but the reducer
+ *  preserves item identity for settled rows and ChatView caches tool_pair
+ *  wrappers, so shallow-prop memo skips re-rendering (and re-parsing markdown
+ *  for) everything except the row that actually changed this tick. */
+export const MessageItem = memo(function MessageItem({
   item,
   provider,
   agentId,
@@ -114,7 +118,7 @@ export function MessageItem({
     case "notice":
       return <NoticeView item={item} />;
   }
-}
+});
 
 /** The user-prompt bubble, shared by the canonical `user_message` and the
  *  optimistic `queued_message` (a mid-turn follow-up not yet in the transcript)

--- a/src/components/Workspace/messages/MessageItem.tsx
+++ b/src/components/Workspace/messages/MessageItem.tsx
@@ -17,8 +17,9 @@ import { isUserInputTool } from "./UserInput/parse";
  *  the derived `tool_pair` from pairToolItems(). `provider` carries the
  *  agent's adapter id down so nested subagent threads filter/pair their
  *  rows with the same display policy as the main log. `agentId` lets the
- *  user-input widget route its answer back to this agent's stdin. */
-/** Memoized: ChatView re-renders on every streaming delta, but the reducer
+ *  user-input widget route its answer back to this agent's stdin.
+ *
+ *  Memoized: ChatView re-renders on every streaming delta, but the reducer
  *  preserves item identity for settled rows and ChatView caches tool_pair
  *  wrappers, so shallow-prop memo skips re-rendering (and re-parsing markdown
  *  for) everything except the row that actually changed this tick. */

--- a/src/components/Workspace/messages/pair.ts
+++ b/src/components/Workspace/messages/pair.ts
@@ -5,11 +5,19 @@
 import type { ChatItem } from "@/store";
 import type { ToolCall, ToolResult } from "./presenters/types";
 
-export type ViewItem = ChatItem | { kind: "tool_pair"; call: ToolCall; result: ToolResult | null };
+export type ToolPair = { kind: "tool_pair"; call: ToolCall; result: ToolResult | null };
+export type ViewItem = ChatItem | ToolPair;
 
-export function pairToolItems(items: ChatItem[]): ViewItem[] {
+/** Caller-owned identity cache keyed by tool_call id. Reused across renders so a
+ *  tool_pair wrapper keeps its reference when its call+result are unchanged —
+ *  lets React.memo(MessageItem) skip settled tool rows during a streaming delta.
+ *  The reducer already preserves call/result identity; only the wrapper is new. */
+export type PairCache = Map<string, ToolPair>;
+
+export function pairToolItems(items: ChatItem[], cache?: PairCache): ViewItem[] {
   const consumed = new Set<number>();
   const out: ViewItem[] = [];
+  const seen = cache ? new Set<string>() : null;
 
   for (let i = 0; i < items.length; i += 1) {
     if (consumed.has(i)) continue;
@@ -25,14 +33,36 @@ export function pairToolItems(items: ChatItem[]): ViewItem[] {
           break;
         }
       }
-      out.push({ kind: "tool_pair", call: item, result });
+      out.push(pairFor(item, result, cache, seen));
       continue;
     }
 
     out.push(item);
   }
 
+  // Drop wrappers for tool_calls no longer present, keeping the cache bounded.
+  if (cache && seen) for (const id of cache.keys()) if (!seen.has(id)) cache.delete(id);
+
   return out;
+}
+
+/** Reuse the cached wrapper when call+result references match; otherwise build a
+ *  fresh one and cache it. Uncached (no cache passed) always builds fresh. */
+function pairFor(
+  call: ToolCall,
+  result: ToolResult | null,
+  cache: PairCache | undefined,
+  seen: Set<string> | null,
+): ToolPair {
+  // Skip the cache for id-less calls (defensive bypass) — a shared "" key would
+  // alias distinct rows onto one wrapper.
+  if (!cache || !seen || !call.id) return { kind: "tool_pair", call, result };
+  seen.add(call.id);
+  const cached = cache.get(call.id);
+  if (cached && cached.call === call && cached.result === result) return cached;
+  const pair: ToolPair = { kind: "tool_pair", call, result };
+  cache.set(call.id, pair);
+  return pair;
 }
 
 /** Stable React key for a rendered row. Tool pairs/results key off their tool


### PR DESCRIPTION
## Problem

The chat log slowed down as sessions grew: **every streaming token delta re-rendered the entire conversation and re-parsed every message's markdown.** Two causes:

- `MessageItem` was a plain function component (not memoized), so React re-rendered every row on each delta regardless of prop identity — and each `agent_message` re-ran the full `ReactMarkdown` (remark/rehype) parse.
- `pairToolItems` minted a fresh `{ kind: "tool_pair", ... }` wrapper on every pass, breaking referential identity for tool rows even when their underlying call/result were unchanged.

The reducers already preserve item identity for settled rows (`extendLastAssistant` clones only the growing message; `applyPolicy` is a `.filter()`), so memoization is viable with a small change.

## Fix

- **`MessageItem` → `React.memo`.** Default shallow-prop compare is correct here: `provider`/`agentId` are stable strings, `turnId` is value-stable, and `item` identity is now stable for every settled row.
- **Stable `tool_pair` identity.** `pairToolItems` takes an optional caller-owned `PairCache` (keyed by `call.id`) and reuses the same wrapper when `call` + `result` references are unchanged. It self-evicts ids not seen in the current pass (bounded; no cross-agent collisions) and skips id-less bypass calls so they can't alias onto a shared `""` key. The param is optional — `SubagentThread` and existing tests are untouched.
- **`ChatView`** holds the cache in a `useRef` and threads it through.

## Effect

Per delta, only the one row that actually changed gets a new object identity; every other row is skipped by `memo`, so its markdown is no longer re-parsed. Render cost per token goes from O(whole conversation) to O(changed row). Streaming and the live cursor still update correctly (the in-flight message's identity legitimately changes each tick).

## Testing

- `tsc --noEmit` clean
- `vitest run` — 335/335 pass
- No new lint warnings in the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)