### PR TITLE
fix(security): set restrictive CSP for the webview

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -26,7 +26,10 @@
         "backgroundColor": "#0e1011"
       }
     ],
-    "security": { "csp": null }
+    "security": {
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' https: data:; connect-src 'self' ipc: http://ipc.localhost https://models.dev https://fletch.sh",
+      "devCsp": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' https: data:; connect-src 'self' ipc: http://ipc.localhost ws://localhost:* http://localhost:* https://models.dev https://fletch.sh"
+    }
   },
   "plugins": {
     "updater": {

--- a/src/data/modelCatalog/modelsDev.ts
+++ b/src/data/modelCatalog/modelsDev.ts
@@ -3,8 +3,9 @@
 // index it two ways: by bare model id (to enrich a discovered id) and by
 // provider (to expand the provider hints for agents with no list command).
 //
-// CORS is open on models.dev and the Tauri webview CSP is null, so the frontend
-// fetches it directly — no backend round-trip.
+// CORS is open on models.dev and the Tauri webview CSP allow-lists
+// https://models.dev in connect-src, so the frontend fetches it directly — no
+// backend round-trip.
 
 import type { ModelMeta } from "./types";
 


### PR DESCRIPTION
## What

Replaces `app.security.csp: null` in `tauri.conf.json` with a restrictive Content Security Policy, plus a `devCsp` for the dev server.

## Why

The webview renders agent-produced content and has powerful IPC (`db_query`, file writes, editor launch). With no CSP there was no defense-in-depth if an XSS sink ever appeared. A restrictive CSP is cheap insurance.

## The policy

**Prod `csp`:**
- `script-src 'self'` — the prod bundle emits only external self scripts (verified: built `index.html` has one external module, zero inline scripts). This is the key protection.
- `style-src 'self' 'unsafe-inline'` — required by the runtime `<style>` injection in `util/codeTheme.ts`, xterm, and ~120 inline `style` props. Style-based injection is far lower risk than script execution, which stays locked down.
- `img-src 'self' https: data:` — agent markdown, GitHub avatars, and local file icons.
- `connect-src 'self' ipc: http://ipc.localhost https://models.dev https://fletch.sh` — the Tauri IPC channel plus the only two remote origins the frontend fetches (`data/modelCatalog/modelsDev.ts`, `data/providers.ts`).

**`devCsp`** additionally allows `script-src 'unsafe-inline'` and `ws://localhost:* http://localhost:*` for Vite/React-refresh and HMR. Not shipped.

## Testing

- Config validated as JSON; `csp`/`devCsp` confirmed as valid Tauri v2 fields (`tauri-utils 2.9.2`).
- Frontend build is clean; prod `index.html` confirmed to have no inline scripts.
- ⚠️ Not verified live: the sandbox can't run a Tauri window or a headless browser, so the `ipc:` connect-src (IPC round-trip) and full click-through were not exercised at runtime. Recommend a `tauri dev` pass with devtools open, watching for `Refused to … Content Security Policy` violations — `connect-src` is the most likely thing to adjust if anything breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)