### PR TITLE
fix(run): confine Run-panel commands under sandbox-exec


### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -14,7 +14,6 @@
 //!   spawns a fresh `codex exec [resume <id>]` (see `codex_session`).
 //!   Codex sandboxes itself rather than running under sandbox-exec.
 
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -28,8 +27,7 @@ use crate::instructions;
 use crate::managed_session::{ManagedExit, ManagedSession, ManagedSpawn, ToolUseBehavior};
 use crate::pty_session::{PtyExit, PtySession, PtySpawn};
 use crate::sandbox;
-
-const SANDBOX_EXEC: &str = "/usr/bin/sandbox-exec";
+use crate::sandbox::SANDBOX_EXEC;
 
 pub enum Agent {
     Pty(PtyAgent),
@@ -1122,18 +1120,7 @@ fn prepare_sandbox(
     let claude_config_dir = std::env::var_os("CLAUDE_CONFIG_DIR").map(PathBuf::from);
     let profile_text =
         sandbox::build_profile(writable_root, rpc_dir, home, claude_config_dir.as_deref())?;
-    let mut profile_file = tempfile::Builder::new()
-        .prefix("quorum-sandbox-")
-        .suffix(".sb")
-        .tempfile()
-        .map_err(|e| Error::Other(format!("create sandbox profile tmp: {e}")))?;
-    profile_file
-        .write_all(profile_text.as_bytes())
-        .map_err(|e| Error::Other(format!("write sandbox profile: {e}")))?;
-    profile_file
-        .flush()
-        .map_err(|e| Error::Other(format!("flush sandbox profile: {e}")))?;
-    Ok(profile_file)
+    sandbox::profile_tempfile(&profile_text)
 }
 
 /// Claude's session-level effort flag (`--effort <level>`), shared by the

--- a/src-tauri/src/run_session.rs
+++ b/src-tauri/src/run_session.rs
@@ -54,6 +54,10 @@ struct RunSessionInner {
     last_error: Option<String>,
     log: LogBuffer,
     pty: Option<PtySession>,
+    /// The `sandbox-exec` profile file the live PTY was launched under. Kept
+    /// alive alongside the PTY so the tempfile isn't unlinked out from under a
+    /// long-running dev server; dropped when the process is stopped/replaced.
+    profile: Option<tempfile::NamedTempFile>,
     /// Bumped on every `start` and `stop`. The PTY exit handler
     /// captures the generation it was spawned under; if that
     /// generation no longer matches, the exit is from a process the
@@ -69,6 +73,7 @@ impl RunSession {
                 last_error: None,
                 log: LogBuffer::new(LOG_BUFFER_CAP),
                 pty: None,
+                profile: None,
                 generation: 0,
             }),
         }
@@ -108,6 +113,7 @@ impl RunSession {
         if let Some(pty) = inner.pty.take() {
             let _ = pty.kill();
         }
+        inner.profile = None;
         inner.generation = inner.generation.wrapping_add(1);
         inner.phase = RunPhase::Stopped;
         inner.last_error = None;
@@ -136,11 +142,15 @@ impl RunSession {
         inner.generation
     }
 
-    pub fn attach_pty(&self, pty: PtySession) {
+    /// Attach a freshly spawned PTY together with the `sandbox-exec` profile
+    /// file it was launched under. The profile must outlive the process, so it
+    /// rides on the session alongside the PTY.
+    pub fn attach_pty(&self, pty: PtySession, profile: tempfile::NamedTempFile) {
         let mut inner = self.inner.lock();
-        // Replace and drop any stale handle. (Shouldn't happen — the
-        // supervisor's stop() drops it first — but defensive.)
+        // Replace and drop any stale handles. (Shouldn't happen — the
+        // supervisor's stop() drops them first — but defensive.)
         inner.pty = Some(pty);
+        inner.profile = Some(profile);
     }
 
     /// Returns true if the given generation is still the current one,
@@ -154,6 +164,7 @@ impl RunSession {
     pub fn mark_stopped(&self, error: Option<String>) {
         let mut inner = self.inner.lock();
         inner.pty = None;
+        inner.profile = None;
         inner.phase = RunPhase::Stopped;
         inner.last_error = error;
     }

--- a/src-tauri/src/run_session.rs
+++ b/src-tauri/src/run_session.rs
@@ -54,9 +54,12 @@ struct RunSessionInner {
     last_error: Option<String>,
     log: LogBuffer,
     pty: Option<PtySession>,
-    /// The `sandbox-exec` profile file the live PTY was launched under. Kept
-    /// alive alongside the PTY so the tempfile isn't unlinked out from under a
-    /// long-running dev server; dropped when the process is stopped/replaced.
+    /// The `sandbox-exec` profile file the live PTY was launched under. The
+    /// kernel compiles the SBPL into the child at `exec` and never consults the
+    /// file again, so it only needs to exist until the child has spawned. We
+    /// nonetheless hold it for the PTY's lifetime — a conservative simplification
+    /// that ties cleanup to the process (dropped on stop/replace) rather than
+    /// racing to unlink right after spawn.
     profile: Option<tempfile::NamedTempFile>,
     /// Bumped on every `start` and `stop`. The PTY exit handler
     /// captures the generation it was spawned under; if that
@@ -143,8 +146,9 @@ impl RunSession {
     }
 
     /// Attach a freshly spawned PTY together with the `sandbox-exec` profile
-    /// file it was launched under. The profile must outlive the process, so it
-    /// rides on the session alongside the PTY.
+    /// file it was launched under. The profile only needs to exist through the
+    /// child's `exec`, but we let it ride on the session alongside the PTY so
+    /// its cleanup is tied to the process lifecycle (see the field comment).
     pub fn attach_pty(&self, pty: PtySession, profile: tempfile::NamedTempFile) {
         let mut inner = self.inner.lock();
         // Replace and drop any stale handles. (Shouldn't happen — the

--- a/src-tauri/src/sandbox.rs
+++ b/src-tauri/src/sandbox.rs
@@ -204,12 +204,7 @@ pub fn build_profile(
   (subpath {gemini_state})
   (subpath {pi_state}))
 
-;; PTYs and basic device files are required for terminal programs.
-(allow file-write* (literal "/dev/null") (literal "/dev/zero"))
-(allow file-write*
-  (regex #"^/dev/tty[^/]*$")
-  (regex #"^/dev/ptmx$")
-  (regex #"^/dev/pts/[0-9]+$"))
+{DEVICE_WRITE_RULES}
 "#
     ))
 }

--- a/src-tauri/src/sandbox.rs
+++ b/src-tauri/src/sandbox.rs
@@ -26,6 +26,106 @@ use std::path::{Path, PathBuf};
 
 use crate::error::{Error, Result};
 
+/// The macOS sandbox wrapper. Every confined process (agents *and* the Run
+/// panel) is launched as `sandbox-exec -f <profile> <program> …`.
+pub const SANDBOX_EXEC: &str = "/usr/bin/sandbox-exec";
+
+/// PTY / device write rules shared by every profile — terminal programs need
+/// these ttys and null/zero devices regardless of what else they may write.
+const DEVICE_WRITE_RULES: &str = r#";; PTYs and basic device files are required for terminal programs.
+(allow file-write* (literal "/dev/null") (literal "/dev/zero"))
+(allow file-write*
+  (regex #"^/dev/tty[^/]*$")
+  (regex #"^/dev/ptmx$")
+  (regex #"^/dev/pts/[0-9]+$"))"#;
+
+/// Per-user cache/state dirs that both agents and Run processes must be able to
+/// write: package-manager caches and XDG + macOS-native app state. Returned as
+/// sbpl-quoted `subpath` argument strings (without the enclosing `(subpath …)`).
+fn standard_state_dirs(home_s: &str) -> Vec<String> {
+    [
+        ".npm",
+        ".cache",
+        ".config",
+        ".local",
+        "Library/Caches",
+        "Library/Application Support",
+    ]
+    .iter()
+    .map(|d| sbpl_string(&format!("{home_s}/{d}")))
+    .collect()
+}
+
+/// Toolchain state dirs the Run panel additionally grants so real project
+/// builds succeed. These hold package caches, downloaded toolchains, and —
+/// for some — PATH-resolved binaries (`~/.cargo/bin`, `~/go/bin`,
+/// `~/.rbenv/shims`). That last part is a residual hijack surface, which is
+/// why this superset is **Run-only** and deliberately kept off the agent
+/// profile: a running project legitimately needs its toolchain to write here,
+/// whereas an agent editing source does not.
+const RUN_TOOLCHAIN_DIRS: &[&str] = &[
+    ".cargo",          // Rust: registry, git checkouts, installed bins
+    ".rustup",         // Rust: downloaded toolchains (rust-toolchain.toml)
+    "go",              // Go: GOPATH — module cache (pkg/mod) + installed bins
+    ".bun",            // Bun: global install cache
+    "Library/pnpm",    // pnpm: content-addressable store (macOS default)
+    ".bundle",         // Bundler: config + cache
+    ".gem",            // RubyGems: default gem home
+    ".rbenv",          // rbenv: shims + installed Ruby versions
+    ".rvm",            // rvm: alternative Ruby version manager
+    "Library/Python",  // pip --user / no-venv user site-packages
+];
+
+/// Build the SBPL profile for a **Run-panel** process (setup/dev command).
+///
+/// Same shape as [`build_profile`] — reads and network stay open (`allow
+/// default`); only *writes* are confined — but tuned for arbitrary project
+/// build toolchains rather than agent CLIs. `writable_root` is the repo
+/// worktree the command runs in (build artifacts, `node_modules`, `.venv`,
+/// `target` all live inside it). On top of the worktree and the shared cache
+/// dirs, it grants [`RUN_TOOLCHAIN_DIRS`] so cargo/go/bundler/pnpm/bun runs
+/// don't fail-closed on their out-of-tree writes.
+///
+/// Unlike the agent profile it needs no rpc mailbox or agent state dirs — a
+/// Run process neither speaks RPC nor persists agent transcripts.
+pub fn build_run_profile(writable_root: &Path, home: &Path) -> Result<String> {
+    let writable_root = canonical(writable_root)?;
+    let home = canonical(home)?;
+    let writable_root_s = sbpl_string(&writable_root.to_string_lossy());
+    let home_s = home.to_string_lossy();
+
+    let mut subpaths = vec![
+        writable_root_s,
+        sbpl_string("/private/tmp"),
+        sbpl_string("/private/var/folders"),
+        sbpl_string("/private/var/tmp"),
+    ];
+    subpaths.extend(standard_state_dirs(&home_s));
+    subpaths.extend(
+        RUN_TOOLCHAIN_DIRS
+            .iter()
+            .map(|d| sbpl_string(&format!("{home_s}/{d}"))),
+    );
+    let writable_block = subpaths
+        .iter()
+        .map(|s| format!("(subpath {s})"))
+        .collect::<Vec<_>>()
+        .join("\n  ");
+
+    Ok(format!(
+        r#"(version 1)
+(allow default)
+
+;; Block writes everywhere by default, then re-allow specific subpaths.
+(deny file-write*)
+(allow file-write*
+  {writable_block})
+
+{DEVICE_WRITE_RULES}
+"#
+    ))
+}
+
 /// Build the SBPL profile. `writable_root` is the agent's parent dir;
 /// `rpc_dir` is its private file-mailbox (`~/.fletch/rpc/<id>/`), which lives
 /// outside the worktree tree and so needs its own allow entry.
@@ -112,6 +212,23 @@ pub fn build_profile(
   (regex #"^/dev/pts/[0-9]+$"))
 "#
     ))
+}
+
+/// Write an SBPL profile to a private `.sb` tempfile. `sandbox-exec -f <path>`
+/// reads it at launch, so it must live at least until the child execs; the
+/// caller keeps the returned handle alive and dropping it unlinks the file.
+pub fn profile_tempfile(text: &str) -> Result<tempfile::NamedTempFile> {
+    use std::io::Write;
+    let mut f = tempfile::Builder::new()
+        .prefix("quorum-sandbox-")
+        .suffix(".sb")
+        .tempfile()
+        .map_err(|e| Error::Other(format!("create sandbox profile tmp: {e}")))?;
+    f.write_all(text.as_bytes())
+        .map_err(|e| Error::Other(format!("write sandbox profile: {e}")))?;
+    f.flush()
+        .map_err(|e| Error::Other(format!("flush sandbox profile: {e}")))?;
+    Ok(f)
 }
 
 fn sbpl_string(s: &str) -> String {
@@ -252,5 +369,53 @@ mod tests {
     #[test]
     fn escapes_quotes_in_paths() {
         assert_eq!(sbpl_string(r#"/path/with"quote"#), r#""/path/with\"quote""#);
+    }
+
+    #[test]
+    fn run_profile_confines_writes_to_worktree_and_toolchains() {
+        let td = tempfile::tempdir().unwrap();
+        let worktree = td.path().join("repo-worktree");
+        let home = td.path().join("home");
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::create_dir_all(&home).unwrap();
+
+        let profile = build_run_profile(&worktree, &home).unwrap();
+        let canonical_worktree = std::fs::canonicalize(&worktree).unwrap();
+        let canonical_home = std::fs::canonicalize(&home).unwrap();
+
+        // Same deny-by-default posture as the agent profile.
+        assert!(profile.contains("(allow default)"));
+        assert!(profile.contains("(deny file-write*)"));
+        // The run command writes freely inside its worktree.
+        assert!(profile.contains(&format!("\"{}\"", canonical_worktree.display())));
+        // Toolchain dirs the default detected commands need (cargo/go/pnpm/bundler).
+        for dir in [".cargo", "go", "Library/pnpm", ".bundle", ".rustup", ".bun"] {
+            let expected = format!("(subpath \"{}/{dir}\")", canonical_home.display());
+            assert!(
+                profile.contains(&expected),
+                "run profile should grant {dir}: missing {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn run_profile_omits_agent_only_state_dirs() {
+        // A Run process neither speaks RPC nor persists agent transcripts, so
+        // the agent-CLI state dirs must not be on its write allow-list.
+        let td = tempfile::tempdir().unwrap();
+        let worktree = td.path().join("repo-worktree");
+        let home = td.path().join("home");
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::create_dir_all(&home).unwrap();
+
+        let profile = build_run_profile(&worktree, &home).unwrap();
+        let canonical_home = std::fs::canonicalize(&home).unwrap();
+        for dir in [".claude", ".codex", ".cursor", ".gemini", ".pi"] {
+            let unexpected = format!("(subpath \"{}/{dir}\")", canonical_home.display());
+            assert!(
+                !profile.contains(&unexpected),
+                "run profile should not grant agent state dir {dir}"
+            );
+        }
     }
 }

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -2927,8 +2927,12 @@ fn spawn_run_phase(
     cmd: String,
     chain_run_cmd: Option<String>,
 ) -> Result<()> {
-    let shell = user_shell();
-    let args = shell_args(&cmd);
+    // Confine the run command to the worktree + toolchain caches. The command
+    // string is repo-derived (package.json scripts, postinstall, dev-server
+    // config), so a malicious agent could otherwise plant a script that runs
+    // unsandboxed with full user privilege the moment the user clicks ▶. Reads
+    // and network stay open (dev servers need them); only writes are fenced.
+    let (program, args, profile_file) = sandboxed_run_command(&cwd, &cmd)?;
 
     let session_out = session.clone();
     let app_out = app.clone();
@@ -2941,7 +2945,7 @@ fn spawn_run_phase(
     let cwd_exit = cwd.clone();
 
     let pty = run_session::spawn_command(
-        &shell,
+        &program,
         &args,
         &cwd,
         move |bytes| {
@@ -2963,8 +2967,41 @@ fn spawn_run_phase(
         },
     )?;
 
-    session.attach_pty(pty);
+    session.attach_pty(pty, profile_file);
     Ok(())
+}
+
+/// Build the `sandbox-exec`-wrapped invocation for a Run-panel command:
+/// `sandbox-exec -f <profile> <shell> -lic <cmd>`. Returns the program, argv,
+/// and the profile tempfile — which the caller must keep alive (via
+/// `RunSession::attach_pty`) for the process's lifetime, since `sandbox-exec`
+/// reads it at launch.
+fn sandboxed_run_command(
+    cwd: &Path,
+    cmd: &str,
+) -> Result<(PathBuf, Vec<String>, tempfile::NamedTempFile)> {
+    let home =
+        dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
+    let profile_text = crate::sandbox::build_run_profile(cwd, &home)?;
+    let profile_file = crate::sandbox::profile_tempfile(&profile_text)?;
+    let profile_path = profile_file
+        .path()
+        .to_str()
+        .ok_or_else(|| Error::Other("profile path not utf-8".into()))?
+        .to_string();
+    let shell = user_shell();
+    let shell_str = shell
+        .to_str()
+        .ok_or_else(|| Error::Other("shell path not utf-8".into()))?
+        .to_string();
+    // sandbox-exec -f <profile> <shell> -lic <cmd>
+    let mut args = vec!["-f".to_string(), profile_path, shell_str];
+    args.extend(shell_args(cmd));
+    Ok((
+        PathBuf::from(crate::sandbox::SANDBOX_EXEC),
+        args,
+        profile_file,
+    ))
 }
 
 fn handle_run_phase_exit(

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -2973,9 +2973,10 @@ fn spawn_run_phase(
 
 /// Build the `sandbox-exec`-wrapped invocation for a Run-panel command:
 /// `sandbox-exec -f <profile> <shell> -lic <cmd>`. Returns the program, argv,
-/// and the profile tempfile — which the caller must keep alive (via
-/// `RunSession::attach_pty`) for the process's lifetime, since `sandbox-exec`
-/// reads it at launch.
+/// and the profile tempfile. `sandbox-exec` reads the profile once, at the
+/// child's `exec`, so the tempfile must survive until then; the caller parks it
+/// on the `RunSession` (via `attach_pty`), which conservatively keeps it for the
+/// process's lifetime.
 fn sandboxed_run_command(
     cwd: &Path,
     cmd: &str,


### PR DESCRIPTION
## Problem

The Run panel executed repo-derived setup/dev commands (`package.json` scripts, `postinstall`, dev-server config) directly through the user's login shell — with **no sandbox**. Every agent process is already wrapped in `sandbox-exec` with Fletch's write-confinement profile, so the Run panel was the one code-execution surface that bypassed that boundary.

Concretely: a sandboxed agent can freely write inside its worktree (including `package.json`/`postinstall`/`vite.config.js`). Those files feed the repo-derived Run commands. So a malicious agent could plant a script that runs **unconfined with full user privilege** the moment the user clicks ▶ — a sandbox escape by proxy (persistence via `~/.zshrc`/LaunchAgents, tampering with sibling repos, writes to `~/.ssh`, etc.).

## Fix

Wrap Run commands in `sandbox-exec -f <profile> <shell> -lic <cmd>`, mirroring the agent path. Reads and network stay open (dev servers need them); only **writes** are fenced — to the repo worktree plus toolchain caches. This brings the Run panel to parity with the agent that produced the code: no more privileged.

- **`sandbox.rs`** — new `build_run_profile()`: a **Run-only static superset**. Same deny-writes / allow-reads+network posture as the agent profile, but additionally grants the toolchain dirs real builds write to: `~/.cargo`, `~/.rustup`, `~/go`, `~/.bun`, `~/Library/pnpm`, `~/.bundle`, `~/.gem`, `~/.rbenv`, `~/.rvm`, `~/Library/Python`. Writable root is the repo worktree (tighter than the agent's parent-dir root). Kept **separate** from the agent profile so those PATH-bearing dirs (`~/.cargo/bin`, `~/go/bin`, `~/.rbenv/shims`) are never granted to an agent editing source. Agent-only state dirs and the RPC mailbox are omitted.
- **`sandbox.rs`** — extracted a shared `profile_tempfile()` helper and promoted the `SANDBOX_EXEC` constant here; `agent.rs` now reuses both (duplicates removed).
- **`supervisor.rs`** — `spawn_run_phase` builds the wrapped invocation via `sandboxed_run_command()`; covers both the setup and chained dev phases.
- **`run_session.rs`** — `RunSession` keeps the profile tempfile alive alongside the PTY (cleared on stop) so `sandbox-exec` can read it for the process's lifetime.

## Per-ecosystem coverage

Verified against every detector (`node`, `python`, `rust`, `ruby`, `go`): the default install/dev commands' out-of-worktree writes are all now allowed (worktree artifacts + package caches + toolchain stores).

## Verification

- `cargo build` + sandbox/run_session/supervisor tests pass; two new tests assert the Run profile grants worktree + toolchain dirs and omits agent state dirs.
- Rendered the generated SBPL — well-formed and a strict grammar subset of the production agent profile.
- Could **not** exercise `sandbox-exec` enforcement end-to-end from the dev environment (it runs inside Fletch's own macOS sandbox; nested `sandbox_apply` is blocked). The real app process is unsandboxed, so it works there — same mechanism agents already use. Confirm via clicking ▶ in the app.

## Known residual gaps (not regressions)

1. Reads + network stay open by design, so a build script can still read/exfiltrate secrets — identical to the agent's existing capability.
2. Granting `~/.cargo/bin` etc. is unavoidable for native builds (a build could plant a PATH shim there); contained to Run, off the agent profile.
3. No-venv global `pip install` into a Homebrew/system prefix now fails-closed (uncommon anti-pattern; use a venv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
