### PR TITLE
perf: trim git polling, lazy-load icon manifest, cap run log

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -691,13 +691,15 @@ pub async fn get_git_state(
 /// every live agent's primary repo, keyed by agent id. Used by the
 /// app-wide background poll that powers per-agent shortstats in the
 /// sidebar and the right-rail file-count badge. The focused panel calls
-/// `get_git_state` separately for its own full state. Agents whose
-/// state can't be queried (missing repo, archived, git error) are omitted.
+/// `get_git_state` separately for its own full state. Archived agents and
+/// agents with no resolvable repo are omitted; a git error degrades to zeroes.
 ///
-/// Queries run in parallel so total latency is bounded by the slowest
-/// agent's git invocation, not the sum. The reply contains only the
-/// three numbers per agent — no file list — to keep the IPC payload
-/// flat as the agent count grows.
+/// Each agent's stats come from `git_state::shortstats`, which spawns just the
+/// two git processes the badge reads (status + numstat) rather than the ~7 a
+/// full `GitState` needs. Agents are queried in parallel, so total latency is
+/// bounded by the slowest agent's git invocation, not the sum. The reply
+/// carries only the three numbers per agent — no file list — to keep the IPC
+/// payload flat as the agent count grows.
 #[tauri::command]
 pub async fn get_all_shortstats(
     supervisor: State<'_, Arc<Supervisor>>,
@@ -713,23 +715,12 @@ pub async fn get_all_shortstats(
         }
         let Some(repo) = agent.repos.first() else { continue };
         let Ok(worktree) = repo_worktree_path(&agent.id, &repo.subdir) else { continue };
-        let parent = repo.parent_branch.clone().unwrap_or_else(|| "main".to_string());
         let agent_id = agent.id.clone();
-        set.spawn(async move {
-            let state = git_state::query(&worktree, &parent).await.ok()?;
-            Some((
-                agent_id,
-                ShortStats {
-                    additions: state.additions,
-                    deletions: state.deletions,
-                    file_count: state.files.len() as u32,
-                },
-            ))
-        });
+        set.spawn(async move { (agent_id, git_state::shortstats(&worktree).await) });
     }
     let mut out = std::collections::HashMap::new();
     while let Some(res) = set.join_next().await {
-        if let Ok(Some((id, stats))) = res {
+        if let Ok((id, stats)) = res {
             out.insert(id, stats);
         }
     }

--- a/src-tauri/src/git_state.rs
+++ b/src-tauri/src/git_state.rs
@@ -141,6 +141,25 @@ pub async fn query(worktree_path: &Path, parent_branch: &str) -> Result<GitState
     })
 }
 
+/// Slim projection for the app-wide bulk poll. Where `query` spawns ~7 git
+/// subprocesses to assemble a full `GitState`, this reads only what the
+/// shortstats badge needs: `git status` for the file count and `git diff
+/// --numstat` for the line totals. The two run concurrently, so latency is a
+/// single git invocation. Failures degrade to zeroes rather than dropping the
+/// agent, matching the badge's "no news is zero" contract.
+pub async fn shortstats(worktree_path: &Path) -> ShortStats {
+    let (status, numstat) = tokio::join!(run_status(worktree_path), run_numstat(worktree_path));
+    let file_count = status.map(|o| parse_porcelain(&o).len() as u32).unwrap_or(0);
+    let (additions, deletions) = numstat
+        .map(|o| {
+            parse_numstat(&o)
+                .values()
+                .fold((0, 0), |(a, d), &(adds, dels)| (a + adds, d + dels))
+        })
+        .unwrap_or((0, 0));
+    ShortStats { additions, deletions, file_count }
+}
+
 /// HEAD commit SHA, or `None` when it can't be read.
 async fn query_head_sha(worktree_path: &Path) -> Option<String> {
     let out = Command::new("git")

--- a/src/components/RightPanel/FileIcon.tsx
+++ b/src/components/RightPanel/FileIcon.tsx
@@ -25,10 +25,17 @@ let loading: Promise<void> | null = null;
 const listeners = new Set<() => void>();
 
 function loadManifest(): Promise<void> {
-  loading ??= import("material-icon-theme/dist/material-icons.json").then((mod) => {
-    manifest = mod.default as unknown as Manifest;
-    for (const notify of listeners) notify();
-  });
+  loading ??= import("material-icon-theme/dist/material-icons.json")
+    .then((mod) => {
+      manifest = mod.default as unknown as Manifest;
+      for (const notify of listeners) notify();
+    })
+    .catch((err) => {
+      // Drop the rejected promise so a later mount can retry, rather than
+      // caching the failure and leaving every icon a placeholder for good.
+      loading = null;
+      console.error("FileIcon: failed to load icon manifest", err);
+    });
   return loading;
 }
 

--- a/src/components/RightPanel/FileIcon.tsx
+++ b/src/components/RightPanel/FileIcon.tsx
@@ -3,9 +3,11 @@
 // file names / extensions / folder names to icon ids.
 //
 // The SVGs are served as static assets from /file-icons (copied into public/
-// by a Vite plugin, see vite.config.ts), so resolution is synchronous and the
-// 1200+ icon set adds no per-icon chunks to the bundle.
-import manifest from "material-icon-theme/dist/material-icons.json";
+// by a Vite plugin, see vite.config.ts). The manifest itself is ~450 KB, so
+// it's loaded lazily — the first FileIcon mount kicks off a dynamic import
+// (splitting it out of the startup bundle); every icon shares that one promise
+// and re-renders via `useSyncExternalStore` once it resolves.
+import { useSyncExternalStore } from "react";
 
 interface Manifest {
   iconDefinitions: Record<string, { iconPath: string }>;
@@ -17,15 +19,37 @@ interface Manifest {
   folder: string;
   folderExpanded: string;
 }
-const m = manifest as unknown as Manifest;
+
+let manifest: Manifest | null = null;
+let loading: Promise<void> | null = null;
+const listeners = new Set<() => void>();
+
+function loadManifest(): Promise<void> {
+  loading ??= import("material-icon-theme/dist/material-icons.json").then((mod) => {
+    manifest = mod.default as unknown as Manifest;
+    for (const notify of listeners) notify();
+  });
+  return loading;
+}
+
+function useManifest(): Manifest | null {
+  return useSyncExternalStore(
+    (notify) => {
+      listeners.add(notify);
+      void loadManifest();
+      return () => listeners.delete(notify);
+    },
+    () => manifest,
+  );
+}
 
 /** icon id → svg basename, e.g. "typescript" → "typescript.svg"
  *  (most match by name, but ~72 point at a differently-named file). */
-function basenameForId(id: string): string {
+function basenameForId(m: Manifest, id: string): string {
   return m.iconDefinitions[id]?.iconPath.split("/").pop() ?? `${id}.svg`;
 }
 
-function fileBasename(name: string): string {
+function fileBasename(m: Manifest, name: string): string {
   const lower = name.toLowerCase();
   let id: string | undefined = m.fileNames[lower];
   if (!id) {
@@ -39,12 +63,12 @@ function fileBasename(name: string): string {
       }
     }
   }
-  return basenameForId(id || m.file);
+  return basenameForId(m, id || m.file);
 }
 
-function folderBasename(name: string, open: boolean): string {
+function folderBasename(m: Manifest, name: string, open: boolean): string {
   const named = (open ? m.folderNamesExpanded : m.folderNames)[name.toLowerCase()];
-  return basenameForId(named || (open ? m.folderExpanded : m.folder));
+  return basenameForId(m, named || (open ? m.folderExpanded : m.folder));
 }
 
 interface FileIconProps {
@@ -55,6 +79,10 @@ interface FileIconProps {
 
 /** Material file/folder icon for the File panel. */
 export function FileIcon({ name, folder, open }: FileIconProps) {
-  const base = folder ? folderBasename(name, !!open) : fileBasename(name);
+  const m = useManifest();
+  // No src while the manifest loads: reserves the icon's box without a
+  // broken-image glyph or a stray request.
+  if (!m) return <img className="fp-ico-img" alt="" draggable={false} />;
+  const base = folder ? folderBasename(m, name, !!open) : fileBasename(m, name);
   return <img className="fp-ico-img" src={`/file-icons/${base}`} alt="" draggable={false} />;
 }

--- a/src/components/RightPanel/RunPanel.tsx
+++ b/src/components/RightPanel/RunPanel.tsx
@@ -31,6 +31,17 @@ const GROUP_LABEL: Record<string, string> = {
 const ANSI_RE = /\x1b\[[0-9;?]*[a-zA-Z]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
 const stripAnsi = (s: string) => s.replace(ANSI_RE, "");
 
+// Cap the in-memory log so a long-running dev server can't grow React state
+// without bound. Keep the tail — what a terminal would show — and trim from
+// the front on a line boundary so a half-line never gets rendered.
+const MAX_LOG_CHARS = 256 * 1024;
+const capLog = (s: string): string => {
+  if (s.length <= MAX_LOG_CHARS) return s;
+  const tail = s.slice(s.length - MAX_LOG_CHARS);
+  const nl = tail.indexOf("\n");
+  return nl === -1 ? tail : tail.slice(nl + 1);
+};
+
 export function RunPanel({ agent }: { agent: AgentRecord }) {
   // Phase is owned by the store (fed by an app-wide `run:state` subscription) so
   // the Run tab's running dot survives this panel unmounting on a tab switch.
@@ -130,13 +141,13 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
       // mode using its own decoder so it doesn't pollute the live
       // stream decoder.
       const snapDecoder = new TextDecoder("utf-8", { fatal: false });
-      setLog(stripAnsi(snapDecoder.decode(new Uint8Array(snap.log))));
+      setLog(capLog(stripAnsi(snapDecoder.decode(new Uint8Array(snap.log)))));
     });
 
     onRunOutput((e) => {
       if (e.agent_id !== agent.id) return;
       const chunk = stripAnsi(decoder.decode(new Uint8Array(e.bytes), { stream: true }));
-      setLog((prev) => prev + chunk);
+      setLog((prev) => capLog(prev + chunk));
     }).then((un) => {
       if (cancelled) {
         un();


### PR DESCRIPTION
Three independent performance fixes to reduce steady-state cost.

## 1. `get_all_shortstats` — ~7 git processes → 2 per agent
The app-wide bulk poll built a full `GitState` for every live agent every ~5s, spawning ~7 git subprocesses each (branch, ahead/behind, unpushed, status, numstat, remote-url, head-sha) only to keep 3 numbers. Added `git_state::shortstats`, which runs just the two the badge reads — `git status --porcelain` (file count) and `git diff --numstat HEAD` (line totals) — concurrently via `tokio::join!`. Behavior parity: archived / no-repo agents are still omitted; git errors degrade to zeroes (the runners already swallowed errors to empty output, matching the old path).

## 2. material-icons.json (~450 KB) off the startup bundle
`FileIcon` imported the ~450 KB manifest statically, so it shipped in the initial bundle. It now loads lazily via a dynamic `import()` on first mount; all icons share one promise and re-render through `useSyncExternalStore` when it resolves. While loading, the icon renders a src-less `<img>` — reserves its box, no broken-image glyph, no stray request.

## 3. RunPanel log capped
The Run panel appended every PTY chunk into a React-state string with no ceiling, so a long-running dev server grew it unbounded. Added a 256 KB cap applied to both the rehydrated snapshot and each streamed chunk, trimming from the front on a newline boundary so a half-line is never rendered.

## Verification
- `cargo check` — clean
- `tsc --noEmit` — pass
- `biome check` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)