### PR TITLE
refactor(sessions): extract shared child-process I/O into child_io

### DIFF
--- a/src-tauri/src/child_io.rs
+++ b/src-tauri/src/child_io.rs
@@ -19,8 +19,18 @@ use serde_json::Value;
 /// Read newline-delimited JSON off a child's stdout, calling `on_value` for
 /// each parsed object. Blank lines are skipped, unparseable lines logged and
 /// skipped, and a read error ends the loop. Runs on its own thread.
-pub fn spawn_json_reader<R>(stdout: R, name: &'static str, on_value: impl Fn(Value) + Send + 'static)
-where
+///
+/// `closed_level` is the level for the terminal "stdout closed" line — pass
+/// `INFO` for a long-lived process whose pipe closing is a lifecycle event
+/// worth seeing in production, `DEBUG` for chatty per-turn readers. It can
+/// precede the process exit (e.g. a crash before the reaper's `try_wait`
+/// fires), so it isn't always redundant with the exit log.
+pub fn spawn_json_reader<R>(
+    stdout: R,
+    name: &'static str,
+    closed_level: tracing::Level,
+    on_value: impl Fn(Value) + Send + 'static,
+) where
     R: Read + Send + 'static,
 {
     thread::spawn(move || {
@@ -37,8 +47,17 @@ where
                 }
             }
         }
-        tracing::debug!(name, "stdout closed");
+        log_stdout_closed(name, closed_level);
     });
+}
+
+/// Emit the "stdout closed" line at a caller-chosen level. The `tracing` macros
+/// bake the level in at compile time, so a runtime level needs this dispatch.
+fn log_stdout_closed(name: &'static str, level: tracing::Level) {
+    match level {
+        tracing::Level::INFO => tracing::info!(name, "stdout closed"),
+        _ => tracing::debug!(name, "stdout closed"),
+    }
 }
 
 /// Drain a child's stdout to EOF without parsing — for agents whose stdout is
@@ -147,7 +166,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut child = spawn(&dir.path(), "echo '{\"a\":1}'\necho ''\necho 'not json'\necho '{\"a\":2}'\n");
         let (tx, rx) = mpsc::channel();
-        spawn_json_reader(child.stdout.take().unwrap(), "t", move |v| {
+        spawn_json_reader(child.stdout.take().unwrap(), "t", tracing::Level::DEBUG, move |v| {
             let _ = tx.send(v);
         });
         let first = rx.recv_timeout(Duration::from_secs(2)).unwrap();

--- a/src-tauri/src/child_io.rs
+++ b/src-tauri/src/child_io.rs
@@ -49,7 +49,12 @@ where
     R: Read + Send + 'static,
 {
     thread::spawn(move || {
-        for _ in BufReader::new(stdout).lines().map_while(Result::ok) {}
+        for line in BufReader::new(stdout).lines() {
+            if let Err(e) = line {
+                tracing::warn!(name, error = %e, "stdout read error (drain)");
+                break;
+            }
+        }
         tracing::debug!(name, "stdout closed");
     });
 }

--- a/src-tauri/src/child_io.rs
+++ b/src-tauri/src/child_io.rs
@@ -1,0 +1,201 @@
+//! Shared I/O plumbing for child-process agents.
+//!
+//! Both the persistent stream-json runner (`managed_session`) and the per-turn
+//! runner (`exec_session`) drive their children the same way: read
+//! newline-delimited JSON off stdout, log stderr, and reap the child through a
+//! shared slot. The reap loop in particular carries a subtle race guard — a
+//! newer owner can take the child out from under the reaper — so it lives here
+//! and is exercised once.
+
+use std::io::{BufRead, BufReader, Read};
+use std::process::{Child, ExitStatus};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use parking_lot::Mutex;
+use serde_json::Value;
+
+/// Read newline-delimited JSON off a child's stdout, calling `on_value` for
+/// each parsed object. Blank lines are skipped, unparseable lines logged and
+/// skipped, and a read error ends the loop. Runs on its own thread.
+pub fn spawn_json_reader<R>(stdout: R, name: &'static str, on_value: impl Fn(Value) + Send + 'static)
+where
+    R: Read + Send + 'static,
+{
+    thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            match line {
+                Ok(l) if l.trim().is_empty() => continue,
+                Ok(l) => match serde_json::from_str::<Value>(&l) {
+                    Ok(v) => on_value(v),
+                    Err(e) => tracing::warn!(name, error = %e, raw = %l, "bad json line"),
+                },
+                Err(e) => {
+                    tracing::warn!(name, error = %e, "stdout read error");
+                    break;
+                }
+            }
+        }
+        tracing::debug!(name, "stdout closed");
+    });
+}
+
+/// Drain a child's stdout to EOF without parsing — for agents whose stdout is
+/// plaintext (their history comes from an on-disk transcript). Draining keeps
+/// the pipe from filling and blocking the child. Runs on its own thread.
+pub fn spawn_drain<R>(stdout: R, name: &'static str)
+where
+    R: Read + Send + 'static,
+{
+    thread::spawn(move || {
+        for _ in BufReader::new(stdout).lines().map_while(Result::ok) {}
+        tracing::debug!(name, "stdout closed");
+    });
+}
+
+/// Log every stderr line as a warning and forward it to `sink`, followed by a
+/// terminating `None` once the stream ends (EOF or read error). The `sink` lets
+/// callers capture stderr — e.g. to fold into an exit message; pass a no-op to
+/// only log. Runs on its own thread.
+pub fn spawn_stderr_reader<R>(
+    stderr: R,
+    name: &'static str,
+    sink: impl Fn(Option<String>) + Send + 'static,
+) where
+    R: Read + Send + 'static,
+{
+    thread::spawn(move || {
+        for line in BufReader::new(stderr).lines().map_while(Result::ok) {
+            tracing::warn!(name, stderr = %line, "stderr");
+            sink(Some(line));
+        }
+        sink(None);
+    });
+}
+
+/// Poll a shared child slot until the process exits, then hand the terminal
+/// status to `on_exit` exactly once. Runs on its own thread.
+///
+/// The slot is shared with whatever spawns replacement children. If that code
+/// takes the child out from under us — a kill+take for a superseded turn — we
+/// observe `None` and return silently, leaving the new owner to report its own
+/// lifecycle. On a genuine exit we `take()` the child so it is reaped once, then
+/// fire `on_exit`; a handed-off slot never fires it.
+pub fn spawn_reaper<F>(slot: Arc<Mutex<Option<Child>>>, name: &'static str, on_exit: F)
+where
+    F: FnOnce(std::io::Result<ExitStatus>) + Send + 'static,
+{
+    thread::spawn(move || loop {
+        let outcome = {
+            let mut guard = slot.lock();
+            let Some(child) = guard.as_mut() else {
+                return;
+            };
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    let _ = guard.take();
+                    tracing::debug!(name, %status, "child exited");
+                    Some(Ok(status))
+                }
+                Ok(None) => None,
+                Err(e) => {
+                    let _ = guard.take();
+                    tracing::warn!(name, error = %e, "child wait failed");
+                    Some(Err(e))
+                }
+            }
+        };
+        match outcome {
+            Some(status) => return on_exit(status),
+            None => thread::sleep(Duration::from_millis(50)),
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::{Command, Stdio};
+    use std::sync::mpsc;
+    use std::time::Instant;
+
+    fn script(dir: &std::path::Path, body: &str) -> std::path::PathBuf {
+        let path = dir.join("s.sh");
+        std::fs::write(&path, format!("#!/bin/sh\n{body}")).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
+    fn spawn(dir: &std::path::Path, body: &str) -> Child {
+        Command::new(script(dir, body))
+            .current_dir(dir)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap()
+    }
+
+    #[test]
+    fn json_reader_forwards_parsed_values_and_skips_junk() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut child = spawn(&dir.path(), "echo '{\"a\":1}'\necho ''\necho 'not json'\necho '{\"a\":2}'\n");
+        let (tx, rx) = mpsc::channel();
+        spawn_json_reader(child.stdout.take().unwrap(), "t", move |v| {
+            let _ = tx.send(v);
+        });
+        let first = rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        let second = rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert_eq!(first["a"], 1);
+        assert_eq!(second["a"], 2);
+        assert!(rx.recv_timeout(Duration::from_millis(200)).is_err());
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn stderr_reader_forwards_lines_then_none_sentinel() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut child = spawn(&dir.path(), "echo 'boom' >&2\n");
+        let (tx, rx) = mpsc::channel();
+        spawn_stderr_reader(child.stderr.take().unwrap(), "t", move |line| {
+            let _ = tx.send(line);
+        });
+        assert_eq!(rx.recv_timeout(Duration::from_secs(2)).unwrap(), Some("boom".into()));
+        assert_eq!(rx.recv_timeout(Duration::from_secs(2)).unwrap(), None);
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn reaper_reports_a_genuine_exit() {
+        let dir = tempfile::tempdir().unwrap();
+        let slot = Arc::new(Mutex::new(Some(spawn(&dir.path(), "exit 3\n"))));
+        let (tx, rx) = mpsc::channel();
+        spawn_reaper(slot, "t", move |status| {
+            let _ = tx.send(status.unwrap().code());
+        });
+        assert_eq!(rx.recv_timeout(Duration::from_secs(2)).unwrap(), Some(3));
+    }
+
+    /// The race guard: if a newer owner empties the slot before the reaper sees
+    /// the exit, the reaper must stay silent — the new owner reports instead.
+    #[test]
+    fn reaper_stays_silent_when_the_slot_is_taken_away() {
+        let dir = tempfile::tempdir().unwrap();
+        let slot = Arc::new(Mutex::new(Some(spawn(&dir.path(), "sleep 30\n"))));
+        let (tx, rx) = mpsc::channel();
+        // Empty the slot (and reap the child) as the superseding owner would,
+        // before starting the reaper so it observes `None` on its first poll.
+        let mut taken = slot.lock().take().unwrap();
+        let _ = taken.kill();
+        let _ = taken.wait();
+        spawn_reaper(slot, "t", move |_| {
+            let _ = tx.send(());
+        });
+        let deadline = Instant::now() + Duration::from_millis(300);
+        while Instant::now() < deadline {
+            assert!(rx.try_recv().is_err(), "reaper fired on a handed-off slot");
+            thread::sleep(Duration::from_millis(20));
+        }
+    }
+}

--- a/src-tauri/src/exec_session.rs
+++ b/src-tauri/src/exec_session.rs
@@ -219,7 +219,7 @@ impl ExecSession {
             let on_session_id = self.on_session_id.clone();
             let extract_session_id = self.extract_session_id.clone();
             let session_id = self.session_id.clone();
-            child_io::spawn_json_reader(stdout, "agent", move |v| {
+            child_io::spawn_json_reader(stdout, "agent", tracing::Level::DEBUG, move |v| {
                 maybe_capture_session_id(&v, &extract_session_id, &session_id, &on_session_id);
                 on_event(v);
             });

--- a/src-tauri/src/exec_session.rs
+++ b/src-tauri/src/exec_session.rs
@@ -16,16 +16,15 @@
 //!     capture it from the first turn and reuse it to resume.
 
 use parking_lot::Mutex;
-use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{mpsc, Arc};
-use std::thread;
 use std::time::Duration;
 
 use serde_json::Value;
 
+use crate::child_io;
 use crate::error::{Error, Result};
 
 type EventCb = Arc<dyn Fn(Value) + Send + Sync>;
@@ -215,108 +214,58 @@ impl ExecSession {
             self.sigint_child();
         }
 
-        let on_event = self.on_event.clone();
-        let on_session_id = self.on_session_id.clone();
-        let extract_session_id = self.extract_session_id.clone();
-        let session_id = self.session_id.clone();
-        let stdout_is_json = self.stdout_is_json;
-        thread::spawn(move || {
-            let reader = BufReader::new(stdout);
-            for line in reader.lines() {
-                match line {
-                    Ok(l) if l.trim().is_empty() => continue,
-                    // Plaintext turn runner (e.g. agy): drain stdout without
-                    // parsing — there are no events; history comes from the
-                    // on-disk transcript ingested at turn-end.
-                    Ok(_) if !stdout_is_json => continue,
-                    Ok(l) => match serde_json::from_str::<Value>(&l) {
-                        Ok(v) => {
-                            maybe_capture_session_id(
-                                &v,
-                                &extract_session_id,
-                                &session_id,
-                                &on_session_id,
-                            );
-                            on_event(v);
-                        }
-                        Err(e) => {
-                            tracing::warn!(error = %e, raw = %l, "agent: bad json line");
-                        }
-                    },
-                    Err(e) => {
-                        tracing::warn!(error = %e, "agent: stdout read error");
-                        break;
-                    }
-                }
-            }
-            tracing::debug!("agent: turn stdout closed");
-        });
+        if self.stdout_is_json {
+            let on_event = self.on_event.clone();
+            let on_session_id = self.on_session_id.clone();
+            let extract_session_id = self.extract_session_id.clone();
+            let session_id = self.session_id.clone();
+            child_io::spawn_json_reader(stdout, "agent", move |v| {
+                maybe_capture_session_id(&v, &extract_session_id, &session_id, &on_session_id);
+                on_event(v);
+            });
+        } else {
+            // Plaintext turn runner (e.g. agy): no events — history comes from
+            // the on-disk transcript ingested at turn-end. Just drain stdout.
+            child_io::spawn_drain(stdout, "agent");
+        }
 
         let (stderr_tx, stderr_rx) = mpsc::channel::<Option<String>>();
-        thread::spawn(move || {
-            let reader = BufReader::new(stderr);
-            for line in reader.lines().map_while(std::result::Result::ok) {
-                tracing::warn!(stderr = %line, "agent: stderr");
-                let _ = stderr_tx.send(Some(line));
-            }
-            let _ = stderr_tx.send(None);
+        child_io::spawn_stderr_reader(stderr, "agent", move |line| {
+            let _ = stderr_tx.send(line);
         });
 
         // Reap the per-turn child when it exits, and report the exit so the
         // supervisor can end the turn — covering turns that exit without an
         // in-band turn-end event (interrupt, crash). The agent stays alive.
-        let child_for_wait = self.child.clone();
         let turn_seq = self.turn_seq.clone();
         let on_exit = self.on_exit.clone();
         let interrupted = self.interrupted.clone();
-        thread::spawn(move || loop {
-            let exited_status = {
-                let mut guard = child_for_wait.lock();
-                let Some(c) = guard.as_mut() else {
-                    // Slot emptied by a newer turn (kill+take) — that turn
-                    // owns the lifecycle now; stay quiet.
-                    return;
-                };
-                match c.try_wait() {
-                    Ok(Some(status)) => {
-                        let _ = guard.take();
-                        tracing::debug!(status = %status, "agent: turn exited");
-                        Some(Ok(status))
-                    }
-                    Ok(None) => None,
-                    Err(e) => {
-                        let _ = guard.take();
-                        tracing::warn!(error = %e, "agent: wait failed");
-                        Some(Err(format!("wait failed: {e}")))
+        child_io::spawn_reaper(self.child.clone(), "agent", move |status| {
+            let interrupted = interrupted.load(Ordering::SeqCst);
+            let exit = match status {
+                Ok(status) => {
+                    let stderr = drain_stderr(&stderr_rx).join("\n");
+                    ExecExit {
+                        success: status.success(),
+                        interrupted,
+                        message: if stderr.is_empty() {
+                            status.to_string()
+                        } else {
+                            format!("{status}: {stderr}")
+                        },
                     }
                 }
+                Err(e) => ExecExit {
+                    success: false,
+                    interrupted,
+                    message: format!("wait failed: {e}"),
+                },
             };
-            if let Some(exited_status) = exited_status {
-                let exit = match exited_status {
-                    Ok(status) => {
-                        let stderr = drain_stderr(&stderr_rx).join("\n");
-                        ExecExit {
-                            success: status.success(),
-                            interrupted: interrupted.load(Ordering::SeqCst),
-                            message: if stderr.is_empty() {
-                                status.to_string()
-                            } else {
-                                format!("{status}: {stderr}")
-                            },
-                        }
-                    }
-                    Err(message) => ExecExit {
-                        success: false,
-                        interrupted: interrupted.load(Ordering::SeqCst),
-                        message,
-                    },
-                };
-                if turn_seq.load(Ordering::SeqCst) == seq {
-                    on_exit(exit);
-                }
-                return;
+            // Only the latest turn reports; a superseded turn's late exit is
+            // dropped so it can't flip the status of the turn that replaced it.
+            if turn_seq.load(Ordering::SeqCst) == seq {
+                on_exit(exit);
             }
-            thread::sleep(Duration::from_millis(50));
         });
 
         Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod activity;
 mod agent;
 mod bin_resolve;
+mod child_io;
 mod commands;
 mod database;
 mod editors;

--- a/src-tauri/src/managed_session.rs
+++ b/src-tauri/src/managed_session.rs
@@ -22,16 +22,15 @@
 
 use parking_lot::Mutex;
 use std::collections::HashSet;
-use std::io::{BufRead, BufReader, Write};
+use std::io::Write;
 use std::path::Path;
 use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::Arc;
-use std::thread;
-use std::time::Duration;
 
 use serde::Deserialize;
 use serde_json::{json, Value};
 
+use crate::child_io;
 use crate::error::{Error, Result};
 
 /// Tools whose `can_use_tool` request we hold open for a human answer instead
@@ -122,92 +121,35 @@ impl ManagedSession {
 
         let stdin_for_reader = stdin_arc.clone();
         let pending_for_reader = pending.clone();
-        thread::spawn(move || {
-            let reader = BufReader::new(stdout);
-            for line in reader.lines() {
-                match line {
-                    Ok(l) if l.trim().is_empty() => continue,
-                    Ok(l) => match serde_json::from_str::<Value>(&l) {
-                        Ok(v) => {
-                            match v.get("type").and_then(Value::as_str) {
-                                // Permission gate from the CLI: respond on stdin.
-                                Some("control_request") => handle_control_request(
-                                    &stdin_for_reader,
-                                    &pending_for_reader,
-                                    &on_event,
-                                    v,
-                                ),
-                                // Reply to a request we sent (e.g. initialize) —
-                                // control plane, never a transcript event.
-                                Some("control_response") => {}
-                                _ => on_event(v),
-                            }
-                        }
-                        Err(e) => {
-                            tracing::warn!(error = %e, raw = %l, "managed: bad json line");
-                        }
-                    },
-                    Err(e) => {
-                        tracing::warn!(error = %e, "managed: stdout read error");
-                        break;
-                    }
+        child_io::spawn_json_reader(stdout, "managed", move |v| {
+            match v.get("type").and_then(Value::as_str) {
+                // Permission gate from the CLI: respond on stdin.
+                Some("control_request") => {
+                    handle_control_request(&stdin_for_reader, &pending_for_reader, &on_event, v)
                 }
-            }
-            tracing::info!("managed: stdout closed");
-        });
-
-        thread::spawn(move || {
-            let reader = BufReader::new(stderr);
-            for line in reader.lines() {
-                match line {
-                    Ok(l) => tracing::warn!(stderr = %l, "managed: stderr"),
-                    Err(_) => break,
-                }
+                // Reply to a request we sent (e.g. initialize) — control plane,
+                // never a transcript event.
+                Some("control_response") => {}
+                _ => on_event(v),
             }
         });
 
-        {
-            let child_for_wait = child_arc.clone();
-            thread::spawn(move || {
-                let exit = loop {
-                    let status = {
-                        let mut guard = child_for_wait.lock();
-                        let Some(child) = guard.as_mut() else {
-                            return;
-                        };
-                        match child.try_wait() {
-                            Ok(Some(status)) => {
-                                let _ = guard.take();
-                                Some(Ok(status))
-                            }
-                            Ok(None) => None,
-                            Err(e) => {
-                                let _ = guard.take();
-                                Some(Err(e))
-                            }
-                        }
-                    };
+        child_io::spawn_stderr_reader(stderr, "managed", |_| {});
 
-                    match status {
-                        Some(Ok(status)) => {
-                            break ManagedExit {
-                                success: status.success(),
-                                message: format!("{status}"),
-                            };
-                        }
-                        Some(Err(e)) => {
-                            break ManagedExit {
-                                success: false,
-                                message: format!("wait failed: {e}"),
-                            };
-                        }
-                        None => thread::sleep(Duration::from_millis(50)),
-                    }
-                };
-                tracing::info!(success = exit.success, message = %exit.message, "managed: exited");
-                on_exit(exit);
-            });
-        }
+        child_io::spawn_reaper(child_arc.clone(), "managed", move |status| {
+            let exit = match status {
+                Ok(status) => ManagedExit {
+                    success: status.success(),
+                    message: format!("{status}"),
+                },
+                Err(e) => ManagedExit {
+                    success: false,
+                    message: format!("wait failed: {e}"),
+                },
+            };
+            tracing::info!(success = exit.success, message = %exit.message, "managed: exited");
+            on_exit(exit);
+        });
 
         Ok(Self {
             child: child_arc,

--- a/src-tauri/src/managed_session.rs
+++ b/src-tauri/src/managed_session.rs
@@ -121,7 +121,7 @@ impl ManagedSession {
 
         let stdin_for_reader = stdin_arc.clone();
         let pending_for_reader = pending.clone();
-        child_io::spawn_json_reader(stdout, "managed", move |v| {
+        child_io::spawn_json_reader(stdout, "managed", tracing::Level::INFO, move |v| {
             match v.get("type").and_then(Value::as_str) {
                 // Permission gate from the CLI: respond on stdin.
                 Some("control_request") => {


### PR DESCRIPTION
## What

`exec_session.rs` and `managed_session.rs` duplicated ~120 lines of child-process plumbing: newline-delimited JSON stdout reading, stderr draining, and the child-reap poll loop. This extracts that logic into a new `child_io` module so the subtle race-guard in the reaper is implemented and tested once.

## Changes

New `src-tauri/src/child_io.rs` with four thread-spawning helpers:

- **`spawn_json_reader`** — reads newline-JSON off stdout; skips blanks, logs+skips unparseable lines; calls a per-`Value` closure. Provider-specific dispatch (exec's session-id capture, managed's `control_request`/`control_response` routing) lives in each caller's closure.
- **`spawn_drain`** — drains plaintext stdout to EOF (exec's non-JSON agents).
- **`spawn_stderr_reader`** — logs each stderr line and forwards it to a `sink` with a terminating `None`; exec captures into its exit-message channel, managed passes a no-op.
- **`spawn_reaper`** — the race-guarded poll loop over the shared `Arc<Mutex<Option<Child>>>`. If a newer owner takes the child out from under it, it observes `None` and returns silently; otherwise it `take()`s on exit and fires `on_exit` once. exec's turn-sequence check and interrupted flag stay in its closure.

Both call sites now delegate the plumbing and drop the now-dead imports.

## Testing

- `cargo test --lib`: all pass except the pre-existing, environment-flaky `pty_session::tests::streams_output_and_reports_exit` (untouched file; passes in isolation).
- New `child_io` tests cover the JSON reader, stderr sentinel, a genuine reap, and the hand-off race guard (`reaper_stays_silent_when_the_slot_is_taken_away`).
- `cargo clippy --lib` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)