### PR TITLE
perf(pty): coalesce output and base64-encode over IPC

### DIFF
--- a/src-tauri/src/pty_session.rs
+++ b/src-tauri/src/pty_session.rs
@@ -6,8 +6,10 @@
 use parking_lot::Mutex;
 use portable_pty::{ChildKiller, CommandBuilder, ExitStatus, MasterPty, PtySize};
 use std::io::{Read, Write};
+use std::sync::mpsc::{self, RecvTimeoutError};
 use std::sync::Arc;
 use std::thread;
+use std::time::{Duration, Instant};
 
 use crate::error::{Error, Result};
 
@@ -99,6 +101,10 @@ impl PtySession {
         let master = Arc::new(Mutex::new(pair.master));
         let writer = Arc::new(Mutex::new(writer));
 
+        // Reader thread keeps a tight blocking-read loop so the PTY drains
+        // promptly, handing each chunk to the coalescer over a channel. Batching
+        // the emits happens downstream, not here.
+        let (tx, rx) = mpsc::channel::<Vec<u8>>();
         thread::spawn({
             let mut reader = reader;
             move || {
@@ -112,8 +118,9 @@ impl PtySession {
                         }
                         Ok(n) => {
                             total += n;
-                            tracing::trace!(bytes = n, total = total, "pty reader: chunk");
-                            on_output(buf[..n].to_vec());
+                            if tx.send(buf[..n].to_vec()).is_err() {
+                                break; // coalescer gone; nothing left to feed
+                            }
                         }
                         Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
                         Err(e) => {
@@ -122,8 +129,10 @@ impl PtySession {
                         }
                     }
                 }
+                // tx drops here → coalescer sees Disconnected and flushes the tail.
             }
         });
+        thread::spawn(move || coalesce_output(rx, on_output));
 
         thread::spawn(move || match child.wait() {
             Ok(status) => {
@@ -181,6 +190,48 @@ impl PtySession {
             .lock()
             .kill()
             .map_err(|e| Error::Other(format!("pty kill: {e}")))
+    }
+}
+
+/// Batch bursty PTY reads into fewer, larger `on_output` calls. A single 4 KB
+/// read per emit means hundreds of IPC events/sec under heavy output; here we
+/// accumulate until the batch reaches `MAX_BATCH` or `FLUSH_INTERVAL` elapses
+/// since the batch's first byte, bounding added latency to one frame while
+/// collapsing the event count. Byte order and content are preserved exactly.
+fn coalesce_output<F: Fn(Vec<u8>)>(rx: mpsc::Receiver<Vec<u8>>, on_output: F) {
+    const FLUSH_INTERVAL: Duration = Duration::from_millis(16);
+    const MAX_BATCH: usize = 64 * 1024;
+
+    let mut batch: Vec<u8> = Vec::new();
+    let mut deadline: Option<Instant> = None;
+    loop {
+        let timeout = deadline
+            .map(|d| d.saturating_duration_since(Instant::now()))
+            .unwrap_or(FLUSH_INTERVAL);
+        match rx.recv_timeout(timeout) {
+            Ok(chunk) => {
+                if batch.is_empty() {
+                    deadline = Some(Instant::now() + FLUSH_INTERVAL);
+                }
+                batch.extend_from_slice(&chunk);
+                if batch.len() >= MAX_BATCH {
+                    on_output(std::mem::take(&mut batch));
+                    deadline = None;
+                }
+            }
+            Err(RecvTimeoutError::Timeout) => {
+                if !batch.is_empty() {
+                    on_output(std::mem::take(&mut batch));
+                    deadline = None;
+                }
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                if !batch.is_empty() {
+                    on_output(batch);
+                }
+                break;
+            }
+        }
     }
 }
 

--- a/src-tauri/src/pty_session.rs
+++ b/src-tauri/src/pty_session.rs
@@ -214,7 +214,11 @@ fn coalesce_output<F: Fn(Vec<u8>)>(rx: mpsc::Receiver<Vec<u8>>, on_output: F) {
                     deadline = Some(Instant::now() + FLUSH_INTERVAL);
                 }
                 batch.extend_from_slice(&chunk);
-                if batch.len() >= MAX_BATCH {
+                // Flush on size, or once the frame elapses — checked here too so a
+                // continuously-ready channel (recv_timeout never times out) can't
+                // stretch the batch past one frame while waiting to hit MAX_BATCH.
+                let expired = deadline.is_some_and(|d| Instant::now() >= d);
+                if batch.len() >= MAX_BATCH || expired {
                     on_output(std::mem::take(&mut batch));
                     deadline = None;
                 }

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -25,9 +25,21 @@ use crate::workspace::{
     DiffStats, TrackedRepo, Workspace, WorkspaceManager,
 };
 
+/// Serialize raw PTY bytes as a base64 string rather than serde's default
+/// JSON number array (`[27,91,...]`), which inflates the payload ~3.5×. The
+/// frontend base64-decodes back to the identical byte stream.
+fn serialize_bytes_b64<S: serde::Serializer>(
+    bytes: &[u8],
+    s: S,
+) -> std::result::Result<S::Ok, S::Error> {
+    use base64::Engine;
+    s.serialize_str(&base64::engine::general_purpose::STANDARD.encode(bytes))
+}
+
 #[derive(Clone, serde::Serialize)]
 pub struct AgentOutputPayload {
     pub agent_id: String,
+    #[serde(serialize_with = "serialize_bytes_b64")]
     pub bytes: Vec<u8>,
 }
 
@@ -96,6 +108,7 @@ pub struct AgentGitActionPayload {
 #[derive(Clone, serde::Serialize)]
 pub struct ShellOutputPayload {
     pub agent_id: String,
+    #[serde(serialize_with = "serialize_bytes_b64")]
     pub bytes: Vec<u8>,
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -72,7 +72,8 @@ export interface Workspace {
 
 export interface AgentOutputEvent {
   agent_id: string;
-  bytes: number[];
+  /** Raw PTY bytes, base64-encoded over IPC. Decode with `decodeBase64`. */
+  bytes: string;
 }
 
 /** Raw stream-json event from claude in custom view. Shape varies by
@@ -523,7 +524,8 @@ export function onAgentOutput(cb: (e: AgentOutputEvent) => void): Promise<Unlist
 
 export interface ShellOutputEvent {
   agent_id: string;
-  bytes: number[];
+  /** Raw PTY bytes, base64-encoded over IPC. Decode with `decodeBase64`. */
+  bytes: string;
 }
 
 export function onShellOutput(cb: (e: ShellOutputEvent) => void): Promise<UnlistenFn> {

--- a/src/pty/decode.ts
+++ b/src/pty/decode.ts
@@ -1,0 +1,9 @@
+// PTY output crosses the Tauri IPC boundary base64-encoded (the backend avoids
+// serde's JSON number-array encoding, which inflates raw bytes ~3.5×). Decode
+// back to the exact byte stream xterm expects.
+export function decodeBase64(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}

--- a/src/pty/decode.ts
+++ b/src/pty/decode.ts
@@ -2,7 +2,16 @@
 // serde's JSON number-array encoding, which inflates raw bytes ~3.5×). Decode
 // back to the exact byte stream xterm expects.
 export function decodeBase64(b64: string): Uint8Array {
-  const bin = atob(b64);
+  let bin: string;
+  try {
+    bin = atob(b64);
+  } catch {
+    // Backend always emits well-formed base64; a throw here means transport
+    // corruption. Drop the chunk rather than let the exception unwind the
+    // event callback and stall the stream.
+    console.error("[pty] decodeBase64: invalid base64 payload, dropping chunk");
+    return new Uint8Array(0);
+  }
   const out = new Uint8Array(bin.length);
   for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
   return out;

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -29,6 +29,7 @@ import {
   reduceRecords,
 } from "@/helpers";
 import { pushAgentOutput, pushShellOutput } from "@/pty/buffers";
+import { decodeBase64 } from "@/pty/decode";
 import { getOrCreateAccount, toProfile } from "@/storage/accounts";
 import {
   DEFAULT_LEFT_WIDTH,
@@ -128,11 +129,11 @@ const hydrateAccount = async (set: AppSet) => {
 // Subscribe to every backend event stream, folding each into store state.
 const registerEventListeners = async (set: AppSet, get: AppGet) => {
   await onAgentOutput((e) => {
-    pushAgentOutput(e.agent_id, new Uint8Array(e.bytes));
+    pushAgentOutput(e.agent_id, decodeBase64(e.bytes));
   });
 
   await onShellOutput((e) => {
-    pushShellOutput(e.agent_id, new Uint8Array(e.bytes));
+    pushShellOutput(e.agent_id, decodeBase64(e.bytes));
   });
 
   await onAgentEvent((e) => {


### PR DESCRIPTION
## Problem

PTY terminal output crossed the Tauri IPC boundary inefficiently:

- **One event per 4 KB read** — `pty_session.rs` emitted on every read syscall, firing hundreds of IPC events/sec under bursty output, each paying full serialize + hop + deserialize cost.
- **JSON number-array encoding** — `bytes: Vec<u8>` serialized as `[27,91,48,...]`, ~3.5× larger than the raw bytes.

## Changes

**Coalesce in Rust (`pty_session.rs`)** — the tight blocking-read loop now forwards chunks over an `mpsc` channel to a new `coalesce_output` thread, which batches into a single `on_output` call per ~16 ms frame or 64 KB (whichever comes first) and flushes the tail on EOF/disconnect. Because it lives in `PtySession`, both the agent PTY and the side shell get it for free — no call-site changes.

**base64 over IPC (`supervisor.rs`)** — a `serialize_bytes_b64` serde helper encodes the `bytes` field of `AgentOutputPayload` and `ShellOutputPayload` as base64 (~1.33× vs ~3.5×), using the existing `base64` dep.

**Frontend** — `src/pty/decode.ts` adds `decodeBase64`; `AgentOutputEvent`/`ShellOutputEvent` `bytes` retyped `number[]` → `string`; the two consumers in `store/app.ts` decode before buffering.

## Correctness

Byte order and content reaching xterm and the replay ring buffer are identical — only chunking and wire-encoding change; latency is bounded to one frame. The `run:output` path (`RunPanel`) is a separate event and left untouched.

## Verification

- `cargo check` ✓, `cargo test pty_session` (streaming/exit test) ✓
- `tsc --noEmit` ✓, `biome check` on touched files ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)