### PR TITLE
refactor(agent): bundle spawn/turn args into named structs

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -78,6 +78,24 @@ pub struct PerTurnSpec {
     pub rpc_dir: PathBuf,
 }
 
+/// The per-turn inputs a `*_build_args` builder turns into CLI argv. Bundled
+/// so builders and their call sites read as named fields instead of a row of
+/// positional `Option<&str>`s. `Default` (all-`None`, empty prompt) keeps test
+/// call sites terse: `TurnArgs { prompt: "hi", ..Default::default() }`.
+#[derive(Clone, Copy, Default)]
+pub struct TurnArgs<'a> {
+    /// The user's message for this turn (positional in most agents' argv).
+    pub prompt: &'a str,
+    /// Resume target: `None` starts a fresh session, `Some(id)` resumes it.
+    pub session_id: Option<&'a str>,
+    /// Reasoning-effort level, for agents that expose one.
+    pub thinking: Option<&'a str>,
+    /// Session-level model override; `None` keeps the provider CLI default.
+    pub model: Option<&'a str>,
+    /// A custom agent's standing brief, injected into the turn.
+    pub extra: Option<&'a str>,
+}
+
 /// Everything that varies between per-turn agents. The runner lifecycle —
 /// one fresh process per turn via `ExecSession` — is identical for all of
 /// them; only the binary, CLI args, session-id extraction, and turn-end
@@ -91,9 +109,8 @@ pub struct PerTurnDescriptor {
     bin: &'static str,
     /// Human-facing product name, used only in the not-found error.
     label: &'static str,
-    /// Builds the CLI args for a turn:
-    /// `(prompt, resume_session_id, thinking_effort, model, custom_instructions)`.
-    build_args: fn(&str, Option<&str>, Option<&str>, Option<&str>, Option<&str>) -> Vec<String>,
+    /// Builds the CLI args for one turn from the turn's [`TurnArgs`].
+    build_args: fn(&TurnArgs) -> Vec<String>,
     /// Builds the args to launch this agent's interactive TUI in the native
     /// (PTY) view: `(session [None = fresh], model, custom_instructions)`.
     pty_args: fn(Option<&str>, Option<&str>, Option<&str>) -> Vec<String>,
@@ -610,7 +627,8 @@ fn opencode_read(message_paths: &[PathBuf]) -> Vec<RawRecord> {
 // `_model` is intentionally unused: agy's `--print` runner ignores model
 // selection (the `--model` flag is inert in print mode), so the picker offers
 // no selectable models for antigravity (see `model_catalog::discover_one`).
-fn antigravity_build_args(prompt: &str, session_id: Option<&str>, _thinking: Option<&str>, _model: Option<&str>, extra: Option<&str>) -> Vec<String> {
+fn antigravity_build_args(turn: &TurnArgs) -> Vec<String> {
+    let &TurnArgs { prompt, session_id, extra, .. } = turn;
     // `--print` takes the prompt as its *value* (i.e. `--print <prompt>`), so the
     // prompt must come last, directly after `--print`. Putting another flag
     // between them makes that flag the prompt (agy then "answers" the flag name).
@@ -952,8 +970,8 @@ impl Agent {
         Self::spawn_exec(
             program,
             spec,
-            move |prompt, sid, thinking, model| {
-                build_args(prompt, sid, thinking, model, extra.as_deref())
+            move |prompt, session_id, thinking, model| {
+                build_args(&TurnArgs { prompt, session_id, thinking, model, extra: extra.as_deref() })
             },
             desc.session_id,
             !desc.plaintext,
@@ -1258,7 +1276,8 @@ fn resolve_claude(home: &Path) -> Result<String> {
 /// sandbox-exec like every other agent, so codex's own confinement is disabled
 /// to leave a single boundary — and so codex can reach its RPC mailbox, which
 /// lives outside the worktree that `workspace-write` would have confined it to.
-fn codex_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&str>, model: Option<&str>, extra: Option<&str>) -> Vec<String> {
+fn codex_build_args(turn: &TurnArgs) -> Vec<String> {
+    let &TurnArgs { prompt, session_id, thinking, model, extra } = turn;
     let mut args: Vec<String> = vec!["exec".into()];
     push_opt(&mut args, "resume", session_id);
     args.push("--json".into());
@@ -1309,7 +1328,8 @@ fn codex_session_id(event: &Value) -> Option<String> {
 /// `--force` runs commands without approval prompts; `--trust` trusts the
 /// workspace in headless mode. Cursor's own sandbox applies; cwd comes from
 /// the child process working directory.
-fn cursor_build_args(prompt: &str, session_id: Option<&str>, _thinking: Option<&str>, model: Option<&str>, extra: Option<&str>) -> Vec<String> {
+fn cursor_build_args(turn: &TurnArgs) -> Vec<String> {
+    let &TurnArgs { prompt, session_id, model, extra, .. } = turn;
     let mut args: Vec<String> = vec![
         "-p".into(),
         "--output-format".into(),
@@ -1336,7 +1356,8 @@ fn cursor_session_id(event: &Value) -> Option<String> {
 /// 1.15.12. OpenCode runs in the child's cwd (no `--dir` needed) and assigns
 /// its own session id on the first turn. The prompt is positional and must
 /// come after the flags.
-fn opencode_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&str>, model: Option<&str>, extra: Option<&str>) -> Vec<String> {
+fn opencode_build_args(turn: &TurnArgs) -> Vec<String> {
+    let &TurnArgs { prompt, session_id, thinking, model, extra } = turn;
     let mut args: Vec<String> = vec![
         "run".into(),
         "--format".into(),
@@ -1371,7 +1392,8 @@ fn opencode_session_id(event: &Value) -> Option<String> {
 /// it's the resume flag common to the versions we target — 0.74.x lacks
 /// `--session-id` entirely. Verified end-to-end against pi 0.74.2. Pi runs in
 /// the child's cwd; the prompt is positional and must come after the flags.
-fn pi_build_args(prompt: &str, session_id: Option<&str>, thinking: Option<&str>, model: Option<&str>, extra: Option<&str>) -> Vec<String> {
+fn pi_build_args(turn: &TurnArgs) -> Vec<String> {
+    let &TurnArgs { prompt, session_id, thinking, model, extra } = turn;
     let mut args: Vec<String> = vec!["-p".into(), "--mode".into(), "json".into()];
     args.extend(model_args(model));
     if let Some(level) = thinking {
@@ -1828,7 +1850,7 @@ mod tests {
     #[test]
     fn opencode_args_request_thinking() {
         // Without --thinking, opencode emits no `reasoning` events at all.
-        let args = opencode_build_args("hi", None, None, None, None);
+        let args = opencode_build_args(&TurnArgs { prompt: "hi", ..Default::default() });
         assert!(args.contains(&"--thinking".to_string()));
         assert!(args.contains(&"--format".to_string()));
         // Prompt is positional and last (possibly prefixed with injected
@@ -1920,14 +1942,14 @@ mod tests {
 
     #[test]
     fn opencode_args_variant_when_thinking_set() {
-        let args = opencode_build_args("hi", None, Some("max"), None, None);
+        let args = opencode_build_args(&TurnArgs { prompt: "hi", thinking: Some("max"), ..Default::default() });
         assert!(args.contains(&"--variant".to_string()));
         assert!(args.contains(&"max".to_string()));
     }
 
     #[test]
     fn codex_args_reasoning_effort_when_thinking_set() {
-        let args = codex_build_args("hi", None, Some("high"), None, None);
+        let args = codex_build_args(&TurnArgs { prompt: "hi", thinking: Some("high"), ..Default::default() });
         assert!(args.contains(&"reasoning_effort=\"high\"".to_string()));
     }
 
@@ -1936,7 +1958,7 @@ mod tests {
         // Fletch now wraps codex in sandbox-exec, so codex's own confinement is
         // turned fully off — otherwise its workspace-write sandbox would block
         // the RPC mailbox, which lives outside the worktree.
-        let args = codex_build_args("hi", None, None, None, None);
+        let args = codex_build_args(&TurnArgs { prompt: "hi", ..Default::default() });
         assert!(args.contains(&"sandbox_mode=\"danger-full-access\"".to_string()));
         assert!(!args.iter().any(|a| a.contains("workspace-write")));
         assert!(args.contains(&"approval_policy=\"never\"".to_string()));
@@ -1944,7 +1966,7 @@ mod tests {
 
     #[test]
     fn pi_args_thinking_when_set() {
-        let args = pi_build_args("hi", None, Some("xhigh"), None, None);
+        let args = pi_build_args(&TurnArgs { prompt: "hi", thinking: Some("xhigh"), ..Default::default() });
         assert!(args.contains(&"--thinking".to_string()));
         assert!(args.contains(&"xhigh".to_string()));
     }
@@ -1964,8 +1986,8 @@ mod tests {
 
     #[test]
     fn cursor_args_ignores_thinking() {
-        let with_none = cursor_build_args("hi", None, None, None, None);
-        let with_some = cursor_build_args("hi", None, Some("high"), None, None);
+        let with_none = cursor_build_args(&TurnArgs { prompt: "hi", ..Default::default() });
+        let with_some = cursor_build_args(&TurnArgs { prompt: "hi", thinking: Some("high"), ..Default::default() });
         assert_eq!(with_none, with_some);
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -15,7 +15,7 @@ use crate::git_state::{self, FileStatus, GitState, ShortStats, StatusKind};
 use crate::managed_session::ToolUseBehavior;
 use crate::names;
 use crate::run_session::RunStateSnapshot;
-use crate::supervisor::Supervisor;
+use crate::supervisor::{SpawnRequest, Supervisor};
 use crate::workspace::{
     repo_worktree_path, AgentRecord, AgentView, DiffStats, TrackedRepo, Workspace,
 };
@@ -200,15 +200,17 @@ pub async fn spawn_agent(
     let sup = supervisor.inner().clone();
     sup.spawn_agent(
         app,
-        view.unwrap_or_default(),
-        PathBuf::from(repo_path),
-        provider.unwrap_or_else(|| "claude".to_string()),
-        name,
-        effort,
-        model,
-        instructions,
-        custom_agent_id,
-        fork_base,
+        SpawnRequest {
+            view: view.unwrap_or_default(),
+            repo_path: PathBuf::from(repo_path),
+            provider: provider.unwrap_or_else(|| "claude".to_string()),
+            name,
+            effort,
+            model,
+            instructions,
+            custom_agent_id,
+            fork_base,
+        },
     )
     .await
 }

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -191,6 +191,32 @@ fn build_activity(record: &AgentRecord, effective_fresh: bool) -> Box<dyn Activi
     activity
 }
 
+/// Everything a caller supplies to spawn a fresh agent. Bundled so the (single)
+/// call site reads as named fields rather than nine positional arguments.
+pub struct SpawnRequest {
+    /// Requested view; downgraded to `Custom` for providers without a native view.
+    pub view: AgentView,
+    /// Primary repo the agent forks its worktree from.
+    pub repo_path: PathBuf,
+    /// Provider id (e.g. `"claude"`, `"codex"`).
+    pub provider: String,
+    /// Pre-allocated agent id from the draft; `None`/blank allocates a fresh one.
+    pub name: Option<String>,
+    /// Session-level effort (claude `--effort`), reapplied on every spawn.
+    pub effort: Option<String>,
+    /// Session-level model override; `None` keeps the provider CLI default.
+    pub model: Option<String>,
+    /// Custom agent's standing brief, re-injected on every spawn/resume.
+    pub instructions: Option<String>,
+    /// Custom agent identity; `None` for a plain built-in spawn.
+    pub custom_agent_id: Option<String>,
+    /// Explicit fork point (a commit-ish). When set — e.g. a workflow step
+    /// forking from the previous step's HEAD — the worktree is cut from this
+    /// commit instead of the parent branch's remote fork-point. `None` keeps the
+    /// default behavior.
+    pub fork_base: Option<String>,
+}
+
 impl Supervisor {
     pub fn new(workspace: Arc<WorkspaceManager>) -> Self {
         Self {
@@ -590,20 +616,19 @@ impl Supervisor {
     pub async fn spawn_agent(
         self: Arc<Self>,
         app: AppHandle,
-        view: AgentView,
-        repo_path: PathBuf,
-        provider: String,
-        name: Option<String>,
-        effort: Option<String>,
-        model: Option<String>,
-        instructions: Option<String>,
-        custom_agent_id: Option<String>,
-        // Explicit fork point (a commit-ish). When set — e.g. a workflow step
-        // forking from the previous step's HEAD — the worktree is cut from this
-        // commit instead of the parent branch's remote fork-point. None keeps the
-        // default behavior.
-        fork_base: Option<String>,
+        req: SpawnRequest,
     ) -> Result<AgentRecord> {
+        let SpawnRequest {
+            view,
+            repo_path,
+            provider,
+            name,
+            effort,
+            model,
+            instructions,
+            custom_agent_id,
+            fork_base,
+        } = req;
         if !repo_path.join(".git").exists() {
             return Err(Error::InvalidPath(format!(
                 "not a git repository: {}",


### PR DESCRIPTION
## What

Two pure-readability refactors that replace wide positional-argument signatures with named-field structs. No behavior change.

### `TurnArgs` (`agent.rs`)
Bundles the five per-turn CLI-build inputs — `prompt`, `session_id`, `thinking`, `model`, `extra`.

- `PerTurnDescriptor.build_args` fn pointer: `fn(&str, Option<&str>, Option<&str>, Option<&str>, Option<&str>)` → `fn(&TurnArgs)`.
- All five builders (`codex_`/`cursor_`/`opencode_`/`pi_`/`antigravity_build_args`) take `turn: &TurnArgs` and destructure only the fields they use.
- `ExecSession` keeps its generic 4-arg closure — `exec_session.rs` is untouched — the session-constant `extra` is bound once at the adapter boundary.
- Test call sites go from `codex_build_args("hi", None, Some("high"), None, None)` to `codex_build_args(&TurnArgs { prompt: "hi", thinking: Some("high"), ..Default::default() })`.

### `SpawnRequest` (`supervisor.rs`)
`Supervisor::spawn_agent` now takes `(self, app, req: SpawnRequest)` instead of nine positional args, destructured at the top so the body is unchanged. The Tauri command keeps its flat frontend-facing signature (the IPC contract) and constructs a `SpawnRequest`.

## Testing

- `cargo check --tests` clean
- `cargo test args` — 15 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)