### PR TITLE
refactor: rebrand agent-visible strings from quorum to fletch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Updater artifact signing (minisign keypair generated for Quorum).
+          # Updater artifact signing (minisign keypair generated for Fletch).
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           # macOS code signing (Developer ID Application cert) + notarization.
@@ -64,7 +64,7 @@ jobs:
           QUORUM_POSTHOG_KEY: ${{ secrets.QUORUM_POSTHOG_KEY }}
         with:
           tagName: v__VERSION__
-          releaseName: Quorum v__VERSION__
+          releaseName: Fletch v__VERSION__
           releaseBody: See the assets to download and install this version.
           releaseDraft: false
           prerelease: false

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -74,7 +74,7 @@ pub struct PerTurnSpec {
     /// injected into every turn (appended after Fletch's global system prompt).
     /// `None` for a plain built-in spawn.
     pub instructions: Option<String>,
-    /// The agent's RPC mailbox dir, exposed to the child as `QUORUM_RPC_DIR`.
+    /// The agent's RPC mailbox dir, exposed to the child as `FLETCH_RPC_DIR`.
     pub rpc_dir: PathBuf,
 }
 
@@ -759,7 +759,7 @@ pub struct SpawnSpec<'a> {
     /// A custom agent's standing instructions, injected after Fletch's global
     /// system prompt on every spawn/resume. `None` for a plain built-in spawn.
     pub instructions: Option<&'a str>,
-    /// The agent's RPC mailbox dir, exposed to the child as `QUORUM_RPC_DIR`.
+    /// The agent's RPC mailbox dir, exposed to the child as `FLETCH_RPC_DIR`.
     pub rpc_dir: PathBuf,
     pub cols: u16,
     pub rows: u16,
@@ -770,7 +770,7 @@ pub struct SpawnSpec<'a> {
 /// execute (see `rpc.rs`). Layered on top of the inherited environment.
 fn rpc_env(rpc_dir: &Path) -> Vec<(String, String)> {
     vec![(
-        "QUORUM_RPC_DIR".to_string(),
+        "FLETCH_RPC_DIR".to_string(),
         rpc_dir.to_string_lossy().into_owned(),
     )]
 }

--- a/src-tauri/src/exec_session.rs
+++ b/src-tauri/src/exec_session.rs
@@ -54,7 +54,7 @@ pub struct ExecSpawn {
     /// parsing (no events emitted). History for such agents comes from their
     /// on-disk transcript, and the session id from the filesystem.
     pub stdout_is_json: bool,
-    /// Extra environment variables (e.g. `QUORUM_RPC_DIR`) set on every turn's
+    /// Extra environment variables (e.g. `FLETCH_RPC_DIR`) set on every turn's
     /// child process, layered on top of the inherited environment.
     pub env: Vec<(String, String)>,
 }

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -107,7 +107,7 @@ pub fn prepend_to_prompt(prompt: &str, session_id: Option<&str>, extra: Option<&
     // Wrap in a namespaced tag so the UI can strip this block from the user
     // bubble (these agents echo the prompt back into the transcript). The tag
     // is Fletch-specific to avoid colliding with real user content.
-    format!("<quorum-system>\n{text}\n</quorum-system>\n\n{prompt}")
+    format!("<fletch-system>\n{text}\n</fletch-system>\n\n{prompt}")
 }
 
 /// Encode `s` as a TOML basic string (double-quoted, with escapes), so it can
@@ -168,9 +168,9 @@ mod tests {
     #[test]
     fn prepend_only_on_first_turn() {
         let first = prepend_to_prompt("do the thing", None, None);
-        assert!(first.starts_with("<quorum-system>"));
+        assert!(first.starts_with("<fletch-system>"));
         assert!(first.contains(text().as_str()));
-        assert!(first.contains("</quorum-system>"));
+        assert!(first.contains("</fletch-system>"));
         assert!(first.ends_with("do the thing"));
 
         // Resumed turn: untouched (the text is already in history).

--- a/src-tauri/src/instructions/rpc_protocol.md
+++ b/src-tauri/src/instructions/rpc_protocol.md
@@ -2,14 +2,14 @@
 
 Your writes are confined to your worktree. When an agent needs the app to do
 something it cannot do itself, send a JSON request through the mailbox at
-`$QUORUM_RPC_DIR` and wait for the reply.
+`$FLETCH_RPC_DIR` and wait for the reply.
 
 Protocol shape:
 
 1. Pick a unique id, usually a UUID.
-2. Write the request atomically to `$QUORUM_RPC_DIR/requests/<id>.json.tmp`,
-   then rename it to `$QUORUM_RPC_DIR/requests/<id>.json`.
-3. Poll `$QUORUM_RPC_DIR/responses/<id>.json` until it appears, then read it.
+2. Write the request atomically to `$FLETCH_RPC_DIR/requests/<id>.json.tmp`,
+   then rename it to `$FLETCH_RPC_DIR/requests/<id>.json`.
+3. Poll `$FLETCH_RPC_DIR/responses/<id>.json` until it appears, then read it.
 
 Request body:
 
@@ -37,10 +37,10 @@ Example:
 
 ```sh
 ID=$(uuidgen)
-printf '{"id":"%s","op":"ping"}' "$ID" > "$QUORUM_RPC_DIR/requests/$ID.json.tmp"
-mv "$QUORUM_RPC_DIR/requests/$ID.json.tmp" "$QUORUM_RPC_DIR/requests/$ID.json"
-until [ -f "$QUORUM_RPC_DIR/responses/$ID.json" ]; do sleep 0.2; done
-cat "$QUORUM_RPC_DIR/responses/$ID.json"
+printf '{"id":"%s","op":"ping"}' "$ID" > "$FLETCH_RPC_DIR/requests/$ID.json.tmp"
+mv "$FLETCH_RPC_DIR/requests/$ID.json.tmp" "$FLETCH_RPC_DIR/requests/$ID.json"
+until [ -f "$FLETCH_RPC_DIR/responses/$ID.json" ]; do sleep 0.2; done
+cat "$FLETCH_RPC_DIR/responses/$ID.json"
 ```
 
 For free-text args, build the JSON with `jq -n --arg` so quotes and newlines
@@ -54,8 +54,8 @@ hello from the agent
 EOF
 )
 jq -n --arg id "$ID" --arg msg "$MSG" '{id:$id,op:"echo",args:{message:$msg}}' \
-  > "$QUORUM_RPC_DIR/requests/$ID.json.tmp"
-mv "$QUORUM_RPC_DIR/requests/$ID.json.tmp" "$QUORUM_RPC_DIR/requests/$ID.json"
+  > "$FLETCH_RPC_DIR/requests/$ID.json.tmp"
+mv "$FLETCH_RPC_DIR/requests/$ID.json.tmp" "$FLETCH_RPC_DIR/requests/$ID.json"
 ```
 
 The exact op names are feature-specific. Fletch currently uses this same

--- a/src-tauri/src/managed_session.rs
+++ b/src-tauri/src/managed_session.rs
@@ -58,7 +58,7 @@ pub struct ManagedSpawn<'a> {
     pub program: &'a Path,
     pub args: &'a [String],
     pub cwd: &'a Path,
-    /// Extra environment variables (e.g. `QUORUM_RPC_DIR`). `Command` inherits
+    /// Extra environment variables (e.g. `FLETCH_RPC_DIR`). `Command` inherits
     /// the parent environment by default; these are layered on top.
     pub env: &'a [(String, String)],
 }

--- a/src-tauri/src/pty_session.rs
+++ b/src-tauri/src/pty_session.rs
@@ -77,7 +77,7 @@ impl PtySession {
         // to a line-buffered mode that doesn't match what the user expects.
         cmd.env("TERM", "xterm-256color");
         cmd.env("COLORTERM", "truecolor");
-        // Caller-supplied overrides (e.g. QUORUM_RPC_DIR) last, so they win.
+        // Caller-supplied overrides (e.g. FLETCH_RPC_DIR) last, so they win.
         for (k, v) in spec.env {
             cmd.env(k, v);
         }

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -827,7 +827,7 @@ impl Supervisor {
         let sandbox_root = agent_parent_dir(agent_id)?;
 
         // The agent's file-mailbox RPC dir, created before spawn so the watcher
-        // (and the agent's `QUORUM_RPC_DIR`) have a target from turn one.
+        // (and the agent's `FLETCH_RPC_DIR`) have a target from turn one.
         let rpc_dir = rpc::mailbox_dir(agent_id)?;
         rpc::ensure_mailbox(&rpc_dir)?;
         // Base branch for the git dispatcher — the branch the agent was

--- a/src/util/instructions.ts
+++ b/src/util/instructions.ts
@@ -1,15 +1,16 @@
 /** Strip the Fletch-injected instruction block from displayed user text.
  *
  *  The prepend-style agents (cursor, opencode, antigravity) receive the
- *  instructions as a `<quorum-system>…</quorum-system>` block prepended to the
+ *  instructions as a `<fletch-system>…</fletch-system>` block prepended to the
  *  first user message, and echo it back into their transcript. This removes
- *  that block so the UI shows only what the user typed. The `<quorum-system>`
+ *  that block so the UI shows only what the user typed. The `<fletch-system>`
  *  tag is Fletch-specific, so removing it anywhere is safe — and it must be
  *  un-anchored because some agents (e.g. cursor) nest the user message inside
  *  their own envelope, leaving our block mid-string rather than at the start.
- *  No-op on messages that don't carry it. */
-const QUORUM_SYSTEM_BLOCK = /\s*<quorum-system>[\s\S]*?<\/quorum-system>\s*/g;
+ *  The legacy `<quorum-system>` tag is still matched so transcripts recorded
+ *  before the rebrand keep stripping cleanly. No-op on messages without it. */
+const SYSTEM_BLOCK = /\s*<(?:fletch|quorum)-system>[\s\S]*?<\/(?:fletch|quorum)-system>\s*/g;
 
 export function stripInjectedInstructions(text: string): string {
-  return text.replace(QUORUM_SYSTEM_BLOCK, "").trim();
+  return text.replace(SYSTEM_BLOCK, "").trim();
 }

--- a/src/util/instructions.ts
+++ b/src/util/instructions.ts
@@ -9,7 +9,7 @@
  *  their own envelope, leaving our block mid-string rather than at the start.
  *  The legacy `<quorum-system>` tag is still matched so transcripts recorded
  *  before the rebrand keep stripping cleanly. No-op on messages without it. */
-const SYSTEM_BLOCK = /\s*<(?:fletch|quorum)-system>[\s\S]*?<\/(?:fletch|quorum)-system>\s*/g;
+const SYSTEM_BLOCK = /\s*<(fletch|quorum)-system>[\s\S]*?<\/\1-system>\s*/g;
 
 export function stripInjectedInstructions(text: string): string {
   return text.replace(SYSTEM_BLOCK, "").trim();

--- a/tests/adapters/claude/sanitize.test.ts
+++ b/tests/adapters/claude/sanitize.test.ts
@@ -86,11 +86,16 @@ describe("sanitizeUserText", () => {
     expect(sanitizeUserText(raw).text).toBe("Hey");
   });
 
-  it("strips an injected quorum-system block, even nested in the envelope", () => {
+  it("strips an injected fletch-system block, even nested in the envelope", () => {
     const raw =
-      "<timestamp>Tue, Jun 9, 2026</timestamp>\n<user_query>\n<quorum-system>\nfollow the rules\n</quorum-system>\n\nHey\n</user_query>";
+      "<timestamp>Tue, Jun 9, 2026</timestamp>\n<user_query>\n<fletch-system>\nfollow the rules\n</fletch-system>\n\nHey\n</user_query>";
     // Cleaned to exactly what the user typed, so it dedups against the
     // optimistic turn and renders as a single clean bubble.
+    expect(sanitizeUserText(raw).text).toBe("Hey");
+  });
+
+  it("still strips the legacy quorum-system block from pre-rebrand transcripts", () => {
+    const raw = "<quorum-system>\nfollow the rules\n</quorum-system>\n\nHey";
     expect(sanitizeUserText(raw).text).toBe("Hey");
   });
 });


### PR DESCRIPTION
## What

Rebrand pass on **agent-visible strings**, renaming the old `quorum` brand to `fletch` where it leaks into transcripts or user-facing release output.

### The two transcript leaks
- **`<quorum-system>` → `<fletch-system>`** — the tag wrapping system instructions prepended to prepend-style agents (Cursor, OpenCode, Antigravity), which echo it back into their transcripts. Renamed the producer (`instructions.rs`) and the display-time sanitizer (`src/util/instructions.ts`). The sanitizer now matches **both** the new and legacy tag, so sessions recorded before the rebrand still strip cleanly. Added a regression test for the legacy case.
- **`QUORUM_RPC_DIR` → `FLETCH_RPC_DIR`** — the RPC mailbox env var exposed to every agent child. Renamed where it's set (`agent.rs`), in the agent-facing RPC protocol instructions (`rpc_protocol.md`), and in surrounding doc comments.

### Release output
- `releaseName: Quorum v__VERSION__` → `Fletch v__VERSION__`, matching what `docs/RELEASING.md` already documents. Also updated the signing-key comment.

## Deliberately deferred
Tracked as one breaking-rename ticket, left untouched here:
- `quorum.db` and its migration comments
- `QUORUM_*` env **secret** names (build.rs / telemetry.rs / lib.rs / oauth.rs / release.yml / .env.example)
- the `fwdai/quorum` repo slug and `~/.tauri/quorum.key` external path
- the `~/.quorum/worktrees/` runtime data dir (README/docs are accurate to current code)
- README logo/screenshot asset filenames

Two internal identifiers also still read `quorum` but are **not** transcript-visible, so they're left for the same ticket: the `"quorum-init"` control-channel request_id and the `quorum-sandbox-` temp profile prefix.

## Testing
String/comment-only changes; no logic touched. Verified statically that no stale `QUORUM_SYSTEM_BLOCK` / `QUORUM_RPC_DIR` / `quorum-system` identifiers dangle and `format!` placeholders are intact. (Suites weren't run — no `bun`/`node_modules` in the worktree.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)