### PR TITLE
feat(sidebar): tint PR pill by CI checks rollup

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -788,8 +788,11 @@ pub async fn refresh_all_pr_states(
 /// sidebar can tint each PR pill pass/fail without opening the Git panel. Mirror
 /// of `refresh_all_pr_states`: skips archived agents and any without a PR so we
 /// never fan a `gh` call out needlessly, and runs the per-agent `pr_checks`
-/// queries in parallel via a `JoinSet`. Each entry is best-effort — a failing
-/// `gh` call maps to `None` (checks unavailable) rather than dropping the agent.
+/// queries in parallel via a `JoinSet`. Best-effort per agent: only *definitive*
+/// results land in the map — `Ok(Some)` (checks) and `Ok(None)` (no PR / none
+/// configured). A transient `gh` failure (network, rate-limit, missing binary)
+/// is omitted entirely, so the frontend's merge keeps that agent's last-known
+/// tint instead of wiping it — matching `fetchPrAux`'s per-agent contract.
 #[tauri::command]
 pub async fn refresh_all_pr_checks(
     supervisor: State<'_, Arc<Supervisor>>,
@@ -808,14 +811,13 @@ pub async fn refresh_all_pr_checks(
         }
         let Ok(worktree) = repo_worktree_path(&agent.id, &repo.subdir) else { continue };
         let agent_id = agent.id.clone();
-        set.spawn(async move {
-            let checks = gh::pr_checks(&worktree).await.unwrap_or(None);
-            (agent_id, checks)
-        });
+        set.spawn(async move { (agent_id, gh::pr_checks(&worktree).await) });
     }
     let mut out = std::collections::HashMap::new();
     while let Some(res) = set.join_next().await {
-        if let Ok((id, checks)) = res {
+        // Record only definitive outcomes; drop errored agents so their prior
+        // value survives the frontend merge.
+        if let Ok((id, Ok(checks))) = res {
             out.insert(id, checks);
         }
     }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -784,6 +784,44 @@ pub async fn refresh_all_pr_states(
     Ok(out)
 }
 
+/// Refresh CI checks for every agent with an open PR in one round-trip, so the
+/// sidebar can tint each PR pill pass/fail without opening the Git panel. Mirror
+/// of `refresh_all_pr_states`: skips archived agents and any without a PR so we
+/// never fan a `gh` call out needlessly, and runs the per-agent `pr_checks`
+/// queries in parallel via a `JoinSet`. Each entry is best-effort — a failing
+/// `gh` call maps to `None` (checks unavailable) rather than dropping the agent.
+#[tauri::command]
+pub async fn refresh_all_pr_checks(
+    supervisor: State<'_, Arc<Supervisor>>,
+) -> Result<std::collections::HashMap<String, Option<gh::PrChecks>>> {
+    let Some(workspace) = supervisor.workspace.current() else {
+        return Ok(Default::default());
+    };
+    let mut set = tokio::task::JoinSet::new();
+    for agent in workspace.agents {
+        if agent.archive.is_some() {
+            continue;
+        }
+        let Some(repo) = agent.repos.first() else { continue };
+        if repo.branch.is_none() || repo.pr_number.is_none() {
+            continue;
+        }
+        let Ok(worktree) = repo_worktree_path(&agent.id, &repo.subdir) else { continue };
+        let agent_id = agent.id.clone();
+        set.spawn(async move {
+            let checks = gh::pr_checks(&worktree).await.unwrap_or(None);
+            (agent_id, checks)
+        });
+    }
+    let mut out = std::collections::HashMap::new();
+    while let Some(res) = set.join_next().await {
+        if let Ok((id, checks)) = res {
+            out.insert(id, checks);
+        }
+    }
+    Ok(out)
+}
+
 // ---------------------------------------------------------------------------
 // File panel — browse the worktree, view & edit file contents.
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -497,6 +497,7 @@ pub fn run() {
             commands::merge_pr,
             commands::get_pr_state,
             commands::refresh_all_pr_states,
+            commands::refresh_all_pr_checks,
             commands::get_pr_checks,
             commands::get_pr_comments,
             commands::open_agent_shell,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ export function App() {
   const init = useAppStore((s) => s.init);
   const fetchAllShortstats = useAppStore((s) => s.fetchAllShortstats);
   const refreshAllPrStates = useAppStore((s) => s.refreshAllPrStates);
+  const refreshAllPrChecks = useAppStore((s) => s.refreshAllPrChecks);
 
   const theme = useAppStore((s) => s.theme);
   const accent = useAppStore((s) => s.accent);
@@ -69,6 +70,12 @@ export function App() {
   // the local shortstats poll, and the backend only touches agents that
   // actually have a PR.
   usePoll(refreshAllPrStates, 45000, [refreshAllPrStates]);
+
+  // App-wide poll for CI checks so each sidebar PR pill can be tinted pass/fail
+  // at a glance. One `gh` call per open PR, so this rides an even gentler
+  // cadence than PR state — checks flip over minutes, not seconds, and the
+  // focused Git panel keeps its own faster per-agent checks poll.
+  usePoll(refreshAllPrChecks, 60000, [refreshAllPrChecks]);
 
   // Apply theme + density via html classes; accent via CSS vars.
   useEffect(() => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -462,6 +462,7 @@ export const api = {
   getAllShortstats: () => invoke<Record<string, ShortStats>>("get_all_shortstats"),
   getPrState: (agentId: string) => invoke<PrState | null>("get_pr_state", { agentId }),
   refreshAllPrStates: () => invoke<Record<string, PrState | null>>("refresh_all_pr_states"),
+  refreshAllPrChecks: () => invoke<Record<string, PrChecks | null>>("refresh_all_pr_checks"),
   getPrChecks: (agentId: string) => invoke<PrChecks | null>("get_pr_checks", { agentId }),
   getPrComments: (agentId: string) => invoke<PrComments | null>("get_pr_comments", { agentId }),
   pushAgent: (agentId: string) => invoke<string>("push_agent", { agentId }),

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -1,10 +1,10 @@
 import type { KeyboardEvent, MouseEvent } from "react";
 import { useState } from "react";
-import type { AgentRecord, AgentStatus, PrState, ShortStats } from "@/api";
+import type { AgentRecord, AgentStatus, PrChecks, PrState, ShortStats } from "@/api";
 import { Icon } from "@/components/Icon";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import { Mono } from "@/components/SettingsScreen/CustomAgents/Mono";
-import { Badge } from "@/components/ui/Badge";
+import { Badge, type BadgeVariant } from "@/components/ui/Badge";
 import { lookupModel } from "@/data/modelCatalog";
 import { providerChip, providerLabel } from "@/data/providers";
 import type { DraftAgent } from "@/store";
@@ -52,6 +52,10 @@ export function AgentRow(props: Props) {
 function RealRow({ agent, active, onClick }: RealRowProps) {
   const usage = useAppStore((s) => s.usage[agent.id]);
   const prState = useAppStore((s) => s.prStates[agent.id] ?? null);
+  // CI rollup for this agent's PR, fed by the app-wide refreshAllPrChecks poll
+  // (see App.tsx) — lets the PR pill tint pass/fail across every row, not just
+  // the focused one. Null until the first poll lands or when there's no PR.
+  const prChecks = useAppStore((s) => s.prChecks[agent.id] ?? null);
   const shortstats = useAppStore((s) => s.gitShortstats[agent.id]);
   const unseen = useAppStore((s) => s.unseenResults[agent.id] ?? false);
   // Dev-server state for this worktree — orthogonal to the agent's turn status,
@@ -224,7 +228,11 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
       </div>
       <div className="agent-sub flex-center">
         <span className="a-task">{taskOrBranch}</span>
-        {prState ? <PrBadge pr={prState} /> : hasChanges ? <DiffStat stats={shortstats} /> : null}
+        {prState ? (
+          <PrBadge pr={prState} checks={prChecks} />
+        ) : hasChanges ? (
+          <DiffStat stats={shortstats} />
+        ) : null}
         <span
           className="a-time"
           onMouseEnter={() => setStatsOpen(true)}
@@ -292,9 +300,10 @@ function DraftRow({ draft, active, onClick }: DraftRowProps) {
 
 // ── pieces ─────────────────────────────────────────────────────────────────
 
-/** Compact PR pill mirroring the git-panel status. Note: CI/checks state is
- *  not yet in PrState, so an open PR shows a neutral pill (no pass/fail tint). */
-function PrBadge({ pr }: { pr: PrState }) {
+/** Compact PR pill mirroring the git-panel status. An open PR is tinted by its
+ *  CI rollup (green pass / red fail) once `checks` land from the app-wide poll;
+ *  merged / closed / pending / no-checks keep their own neutral tones. */
+function PrBadge({ pr, checks }: { pr: PrState; checks: PrChecks | null }) {
   if (pr.state === "merged") {
     return (
       <Badge variant="pr-merged" tip={`PR #${pr.number} · merged`}>
@@ -302,13 +311,37 @@ function PrBadge({ pr }: { pr: PrState }) {
       </Badge>
     );
   }
-  const variant = pr.state === "closed" ? "pr-closed" : "pr-open";
+  if (pr.state === "closed") {
+    return (
+      <Badge variant="pr-closed" tip={`PR #${pr.number} · closed`}>
+        <Icon name="pr" size={10} />
+        PR
+      </Badge>
+    );
+  }
+  const ci = ciTint(checks);
   return (
-    <Badge variant={variant} tip={`PR #${pr.number} · ${pr.state}`}>
+    <Badge variant={ci.variant} tip={`PR #${pr.number} · open${ci.tip}`}>
       <Icon name="pr" size={10} />
       PR
     </Badge>
   );
+}
+
+/** Map an open PR's CI rollup to a pill variant + tooltip suffix. Pending and
+ *  "no checks configured" stay on the neutral pr-open blue — only a settled
+ *  pass/fail earns a color. */
+function ciTint(checks: PrChecks | null): { variant: BadgeVariant; tip: string } {
+  switch (checks?.rollup) {
+    case "passing":
+      return { variant: "pr-pass", tip: ` · checks passing (${checks.passed}/${checks.total})` };
+    case "failing":
+      return { variant: "pr-fail", tip: ` · checks failing (${checks.failed} failed)` };
+    case "pending":
+      return { variant: "pr-open", tip: ` · checks running (${checks.pending} pending)` };
+    default:
+      return { variant: "pr-open", tip: "" };
+  }
 }
 
 function DiffStat({ stats }: { stats: ShortStats }) {

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,6 +1,14 @@
 import type { ReactNode } from "react";
 
-export type BadgeVariant = "neutral" | "new" | "err" | "pr-open" | "pr-merged" | "pr-closed";
+export type BadgeVariant =
+  | "neutral"
+  | "new"
+  | "err"
+  | "pr-open"
+  | "pr-merged"
+  | "pr-closed"
+  | "pr-pass"
+  | "pr-fail";
 
 interface Props {
   children: ReactNode;

--- a/src/store/git.ts
+++ b/src/store/git.ts
@@ -103,6 +103,18 @@ export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
     }
   },
 
+  refreshAllPrChecks: async () => {
+    try {
+      // Merge (like refreshAllPrStates) so the focused panel's per-agent
+      // checks poll isn't clobbered between bulk ticks. Absent agents keep
+      // their last value; agents with a `null` reply record "no checks".
+      const map = await api.refreshAllPrChecks();
+      set((s) => ({ prChecks: { ...s.prChecks, ...map } }));
+    } catch {
+      // non-fatal — next poll tick will retry
+    }
+  },
+
   fetchPrChecks: (agentId) => fetchPrAux(set, agentId, "prChecks", api.getPrChecks),
 
   fetchPrComments: (agentId) => fetchPrAux(set, agentId, "prComments", api.getPrComments),

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -198,6 +198,10 @@ export interface GitSlice {
    *  (used by the app-wide background poll). Backend emits `pr:state_changed`
    *  per agent, so the sidebar badge updates without opening the Git panel. */
   refreshAllPrStates: () => Promise<void>;
+  /** Refresh CI checks for every agent with an open PR in one round-trip
+   *  (used by the app-wide background poll) so the sidebar PR pill can tint
+   *  pass/fail without opening the Git panel. */
+  refreshAllPrChecks: () => Promise<void>;
   fetchPrChecks: (agentId: string) => Promise<void>;
   fetchPrComments: (agentId: string) => Promise<void>;
   delegateGitAction: (agentId: string, kind: GitDelegationKind, prompt: string) => void;

--- a/src/styles/shared/badge.css
+++ b/src/styles/shared/badge.css
@@ -18,12 +18,22 @@
 .ag-badge.pr-open,
 .ag-badge.pr-merged,
 .ag-badge.pr-closed,
+.ag-badge.pr-pass,
+.ag-badge.pr-fail,
 .ag-badge.err {
   background: color-mix(in oklch, var(--badge-color), transparent 86%);
   color: var(--badge-color);
 }
 .ag-badge.pr-open {
   --badge-color: var(--info);
+}
+/* open-PR CI tint: green when checks pass, red when they fail. Pending / no
+ * checks keep the neutral pr-open blue. */
+.ag-badge.pr-pass {
+  --badge-color: var(--success);
+}
+.ag-badge.pr-fail {
+  --badge-color: var(--danger);
 }
 .ag-badge.pr-merged {
   --badge-color: var(--purple);


### PR DESCRIPTION
## Summary

The sidebar PR pill rendered a neutral tone for every open PR, because CI checks were only ever fetched for the **focused** agent (git panel + titlebar) — so `prChecks` was empty for every other row. This wires an all-agent checks feed so each open-PR row is tinted pass/fail at a glance, which is core value for a run-many-agents dashboard.

## Changes

- **Backend** (`commands.rs`, `lib.rs`): new `refresh_all_pr_checks` command, a direct mirror of `refresh_all_pr_states` — parallel `JoinSet` of `gh::pr_checks`, skipping archived agents and any without a PR so it never fans a `gh` call out needlessly. Best-effort per agent (a failed call → `None`, not a dropped row).
- **Store + API** (`api.ts`, `store/git.ts`, `store/types.ts`): `refreshAllPrChecks` action that merges into the existing `prChecks` map, so the focused panel's faster per-agent poll isn't clobbered.
- **Poll** (`App.tsx`): app-wide poll at a gentle 60s cadence — checks flip over minutes and each is a `gh` network call, so it rides slower than PR state's 45s.
- **UI** (`AgentRow.tsx`, `Badge.tsx`, `badge.css`): `PrBadge` reads `prChecks[agent.id]` and tints open PRs via a `ciTint` helper — green (`pr-pass`) passing, red (`pr-fail`) failing, neutral blue for pending / no-checks. Tooltip gains a check summary. Merged/closed pills unchanged. Replaces the stale self-documenting comment that flagged this gap.

## Notes

- `cargo check` passes clean. TS/biome could not be run in this worktree (no `node_modules`); changes verified by inspection against the existing `PrChecks` type and `BadgeVariant`.
- At 60s cadence a freshly-created PR's pill stays neutral until the next tick (the focused Git panel updates it faster). A post-`create_pr` single-agent refresh could make it instant if desired — left out for now to keep scope tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)