### PR TITLE
fix(providers): remove fabricated provider version and status strings

### DIFF
--- a/src/components/Composer/ModelPicker.tsx
+++ b/src/components/Composer/ModelPicker.tsx
@@ -200,7 +200,7 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
                     <ProviderIcon slug={p.id} short={p.short} hue={p.hue} size={26} />
                     <span className="model-agent-name truncate text-base">{p.label}</span>
                     <span className="model-agent-ver text-xs">
-                      {missing ? "Not installed" : (providerVersions[p.id] ?? p.version)}
+                      {missing ? "Not installed" : providerVersions[p.id]}
                     </span>
                     {usable && <Icon name="chevR" size={12} />}
                   </button>

--- a/src/components/Onboarding/exhibits.tsx
+++ b/src/components/Onboarding/exhibits.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from "react";
 import { Icon, LandmarkGlyph } from "@/components/Icon";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import { Badge } from "@/components/ui/Badge";
+import { PROVIDER_DETAIL } from "@/data/providerDetail";
 import type { ProviderId } from "@/data/providers";
 import { PROVIDERS, providerChip } from "@/data/providers";
 
@@ -168,7 +169,7 @@ export function ExhibitProviders() {
               <ProviderIcon slug={p.id} short={p.short} hue={p.hue} size={30} />
               <span className="meta">
                 <span className="pl">{p.label}</span>
-                <span className="ps">{p.sub}</span>
+                <span className="ps">{PROVIDER_DETAIL[p.id].models}</span>
               </span>
               <span className="chk">
                 <Icon name="check" size={11} strokeWidth={2} />

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -124,7 +124,7 @@ function Popover({ onClose }: { onClose: () => void }) {
           // version when the backend has resolved it — never a fabricated plan
           // name or version string.
           const version = providerVersions[p.id];
-          const models = PROVIDER_DETAIL[p.id]?.models;
+          const models = PROVIDER_DETAIL[p.id].models;
           const description = [models, version].filter(Boolean).join(" · ");
           return (
             <SettingsRow key={p.id} label={p.label} description={description}>

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -1,6 +1,7 @@
 import { Icon } from "@/components/Icon";
 import { IconButton } from "@/components/ui/IconButton";
 import { Scrim } from "@/components/ui/Scrim";
+import { PROVIDER_DETAIL } from "@/data/providerDetail";
 import { ACCENTS, PROVIDERS } from "@/data/providers";
 import type { Density, FeatureFlags, ThemeMode } from "@/storage/preferences";
 import { useAppStore } from "@/store";
@@ -57,6 +58,7 @@ function Popover({ onClose }: { onClose: () => void }) {
   const setAccent = useAppStore((s) => s.setAccent);
   const density = useAppStore((s) => s.density);
   const setDensity = useAppStore((s) => s.setDensity);
+  const providerVersions = useAppStore((s) => s.providerVersions);
   const openSettingsScreen = useAppStore((s) => s.openSettingsScreen);
 
   return (
@@ -117,14 +119,22 @@ function Popover({ onClose }: { onClose: () => void }) {
       ))}
 
       <SettingsSection title="Providers">
-        {PROVIDERS.map((p) => (
-          <SettingsRow key={p.id} label={p.label} description={`${p.sub} · ${p.version}`}>
-            <Toggle
-              value={providerFlags[p.id] !== false}
-              onChange={(v) => setProviderEnabled(p.id, v)}
-            />
-          </SettingsRow>
-        ))}
+        {PROVIDERS.map((p) => {
+          // Honest, non-user-specific model routing, plus the live-probed
+          // version when the backend has resolved it — never a fabricated plan
+          // name or version string.
+          const version = providerVersions[p.id];
+          const models = PROVIDER_DETAIL[p.id]?.models;
+          const description = [models, version].filter(Boolean).join(" · ");
+          return (
+            <SettingsRow key={p.id} label={p.label} description={description}>
+              <Toggle
+                value={providerFlags[p.id] !== false}
+                onChange={(v) => setProviderEnabled(p.id, v)}
+              />
+            </SettingsRow>
+          );
+        })}
       </SettingsSection>
 
       <button className="sp-allbtn flex-center" onClick={() => openSettingsScreen("general")}>

--- a/src/components/SettingsScreen/ProvidersPane.tsx
+++ b/src/components/SettingsScreen/ProvidersPane.tsx
@@ -115,7 +115,7 @@ function ProviderRow({
         <div className="set-prov-id">
           <div className="set-prov-name flex-center text-base">
             {provider.label}
-            <span className="set-prov-ver mono text-xs">{liveVersion ?? provider.version}</span>
+            <span className="set-prov-ver mono text-xs">{liveVersion}</span>
           </div>
           <div className="set-prov-sub flex-center truncate mono text-sm">{effectivePath}</div>
         </div>

--- a/src/data/providers.ts
+++ b/src/data/providers.ts
@@ -15,50 +15,22 @@ export interface Provider {
   id: ProviderId;
   label: string;
   short: string;
-  version: string;
   hue: number;
-  sub: string;
   /** Agent manages its own model and ignores a per-session selection, so the
    *  picker offers no model choice (e.g. antigravity's `agy --print` runner). */
   fixedModel?: boolean;
 }
 
+// Versions and per-account status are never hardcoded here: the backend probes
+// real versions into the store (`providerVersions`, see refreshProviderVersions),
+// and honest, non-user-specific model routing lives in PROVIDER_DETAIL.
 export const PROVIDERS: Provider[] = [
-  {
-    id: "claude",
-    label: "Claude Code",
-    short: "CC",
-    version: "v1.0.42",
-    hue: 28,
-    sub: "Opus 4.7 · Sonnet 4.6",
-  },
-  { id: "codex", label: "Codex", short: "CX", version: "v0.133.0", hue: 145, sub: "ChatGPT Plus" },
-  {
-    id: "cursor",
-    label: "Cursor Agent",
-    short: "CR",
-    version: "v2026.05.24",
-    hue: 215,
-    sub: "Pro Subscription",
-  },
-  {
-    id: "antigravity",
-    label: "Antigravity",
-    short: "AG",
-    version: "v1.0",
-    hue: 260,
-    sub: "Gemini 3 Pro",
-    fixedModel: true,
-  },
-  {
-    id: "opencode",
-    label: "OpenCode",
-    short: "OC",
-    version: "v1.15.12",
-    hue: 195,
-    sub: "1 upstream connected",
-  },
-  { id: "pi", label: "Pi", short: "PI", version: "v0.4", hue: 320, sub: "Pi · experimental" },
+  { id: "claude", label: "Claude Code", short: "CC", hue: 28 },
+  { id: "codex", label: "Codex", short: "CX", hue: 145 },
+  { id: "cursor", label: "Cursor Agent", short: "CR", hue: 215 },
+  { id: "antigravity", label: "Antigravity", short: "AG", hue: 260, fixedModel: true },
+  { id: "opencode", label: "OpenCode", short: "OC", hue: 195 },
+  { id: "pi", label: "Pi", short: "PI", hue: 320 },
 ];
 
 export const DEFAULT_PROVIDER_ID = "claude";

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -346,7 +346,7 @@ export interface AppearanceSlice {
 export interface ProvidersSlice {
   providerFlags: Record<string, boolean>;
   /** Live-probed version strings keyed by provider id. Populated async on
-   *  init; falls back to hardcoded defaults in PROVIDERS when missing. */
+   *  init; absent until a probe resolves (never a hardcoded default). */
   providerVersions: Record<string, string>;
   /** Resolved binary paths keyed by provider id, from the version probe. */
   providerPaths: Record<string, string>;


### PR DESCRIPTION
## Problem

`src/data/providers.ts` hardcoded fake per-provider data — versions
(`v1.0.42`, `v0.133.0`, `v2026.05.24`, …) and per-account status
(`ChatGPT Plus`, `Pro Subscription`, `1 upstream connected`, …). The
Settings popover rendered these as `sub · version`, presenting invented
plan names and stale versions as if they were live account state. The
backend already probes real versions into the store, so this was purely
misleading.

## Change

- Delete the `version` and `sub` fields from the `Provider` interface and
  all six `PROVIDERS` entries.
- **Settings popover** (`Settings/index.tsx`) — the offending render — now
  builds its description from the live-probed version (`providerVersions`)
  plus honest, non-user-specific model routing (`PROVIDER_DETAIL.models`),
  joined only when present.
- **ModelPicker** and **ProvidersPane** — drop the `?? p.version` fake
  fallbacks; both already read the live-probed version.
- **Onboarding exhibit** — subtitle now uses `PROVIDER_DETAIL.models`
  instead of the fake `sub`, so it no longer flashes "ChatGPT Plus" /
  "Pro Subscription".
- Fix the now-stale `providerVersions` doc comment in `store/types.ts`.

Versions still populate normally: the probe runs on init
(`store/app.ts`). Before a probe resolves the UI shows nothing rather than
a fabricated value — honest by construction.

## Note

Could not typecheck locally — this worktree has no `node_modules`. Changes
are mechanical (field removal + consumer updates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)