### PR TITLE
refactor(providers): remove dead "coming soon" adapter gating

### DIFF
--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -10,10 +10,9 @@ import type { ChatAdapter } from "./types";
 export { applyPolicy, modeFor } from "./policy";
 export type { ChatAdapter, ChatItem, DisplayPolicy, NoticeSubtype, RawEvent } from "./types";
 
-// Partial: not every provider is wired. Agents listed in PROVIDERS without an
-// entry here are "coming soon" — the picker gates them via `hasAdapter` so they
-// can never be selected and silently fall back to Claude.
-export const ADAPTERS: Partial<Record<ProviderId, ChatAdapter>> = {
+// Every provider is wired: the full Record makes adding a `ProviderId` without
+// an adapter a compile error, keeping this registry in sync with the agent set.
+export const ADAPTERS: Record<ProviderId, ChatAdapter> = {
   antigravity: antigravityAdapter,
   claude: claudeAdapter,
   codex: codexAdapter,
@@ -24,11 +23,6 @@ export const ADAPTERS: Partial<Record<ProviderId, ChatAdapter>> = {
 
 export const DEFAULT_ADAPTER_ID: ProviderId = "claude";
 
-/** True if `provider` has a real adapter (i.e. is runnable, not coming-soon). */
-export function hasAdapter(provider: string | null | undefined): boolean {
-  return !!provider && provider in ADAPTERS;
-}
-
 export function getAdapter(provider: string | null | undefined): ChatAdapter {
   if (provider) {
     const found = ADAPTERS[provider as ProviderId];
@@ -37,7 +31,5 @@ export function getAdapter(provider: string | null | undefined): ChatAdapter {
       `[adapters] unknown provider "${provider}", falling back to ${DEFAULT_ADAPTER_ID}`,
     );
   }
-  const fallback = ADAPTERS[DEFAULT_ADAPTER_ID];
-  if (!fallback) throw new Error(`missing adapter: ${DEFAULT_ADAPTER_ID}`);
-  return fallback;
+  return ADAPTERS[DEFAULT_ADAPTER_ID];
 }

--- a/src/components/Composer/ModelPicker.tsx
+++ b/src/components/Composer/ModelPicker.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useState } from "react";
-import { hasAdapter } from "@/adapters";
 import { Icon } from "@/components/Icon";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import { Mono } from "@/components/SettingsScreen/CustomAgents/Mono";
@@ -173,36 +172,34 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
                 <span className="model-sect-line" />
               </div>
               {enabled.map((p) => {
-                const wired = hasAdapter(p.id);
                 // Fail open: only gate on the path once a probe has actually
                 // succeeded (`providersProbed`). While probing, or if the probe
                 // failed, treat as installed so a transient detection error
                 // never disables an agent the user really has.
                 const installed = !providersProbed || !!providerPaths[p.id];
-                const usable = wired && installed;
-                const missing = wired && providersProbed && !installed;
+                const missing = providersProbed && !installed;
                 const isSelected = p.id === provider && !customAgentId;
                 const isOpen = hovered === p.id;
                 return (
                   <button
                     key={p.id}
                     type="button"
-                    disabled={!usable}
+                    disabled={!installed}
                     className={`model-agent-row flex-center ${isSelected ? "active" : ""} ${isOpen ? "hot" : ""}`}
                     title={
                       missing
                         ? "Not installed — see Settings › Providers"
                         : "Click to use the default model · hover to choose a model"
                     }
-                    onMouseEnter={() => usable && setHovered(p.id)}
-                    onClick={() => usable && pickModel(p.id, undefined)}
+                    onMouseEnter={() => installed && setHovered(p.id)}
+                    onClick={() => installed && pickModel(p.id, undefined)}
                   >
                     <ProviderIcon slug={p.id} short={p.short} hue={p.hue} size={26} />
                     <span className="model-agent-name truncate text-base">{p.label}</span>
                     <span className="model-agent-ver text-xs">
                       {missing ? "Not installed" : (providerVersions[p.id] ?? p.version)}
                     </span>
-                    {usable && <Icon name="chevR" size={12} />}
+                    {installed && <Icon name="chevR" size={12} />}
                   </button>
                 );
               })}

--- a/src/components/Onboarding/OnboardingReadiness.tsx
+++ b/src/components/Onboarding/OnboardingReadiness.tsx
@@ -7,7 +7,6 @@
 
 import { open as openExternal } from "@tauri-apps/plugin-shell";
 import { useCallback, useEffect, useState } from "react";
-import { hasAdapter } from "@/adapters";
 import { api, type GhStatus, type ToolStatus } from "@/api";
 import { Icon } from "@/components/Icon";
 import { ProviderIcon } from "@/components/ProviderIcon";
@@ -42,7 +41,7 @@ export function OnboardingReadiness() {
     recheck();
   }, [recheck]);
 
-  const agents = PROVIDERS.filter((p) => hasAdapter(p.id) && providerFlags[p.id] !== false);
+  const agents = PROVIDERS.filter((p) => providerFlags[p.id] !== false);
   const detected = agents.filter((p) => !!providerPaths[p.id]).length;
 
   const gitState: S = git ? (git.installed ? "ok" : "bad") : checking ? "checking" : "warn";

--- a/src/components/ProviderReadiness/index.tsx
+++ b/src/components/ProviderReadiness/index.tsx
@@ -9,7 +9,6 @@
 
 import { open as openExternal } from "@tauri-apps/plugin-shell";
 import { type ReactNode, useCallback, useEffect, useState } from "react";
-import { hasAdapter } from "@/adapters";
 import { api, type GhStatus, type ToolStatus } from "@/api";
 import { Icon } from "@/components/Icon";
 import { ProviderIcon } from "@/components/ProviderIcon";
@@ -115,9 +114,8 @@ export function ProviderReadiness() {
     recheck();
   }, [recheck]);
 
-  // Only agents with a wired runner are worth checking; antigravity etc. are
-  // gated "coming soon" and never spawnable.
-  const agents = PROVIDERS.filter((p) => hasAdapter(p.id) && providerFlags[p.id] !== false);
+  // Skip agents the user has toggled off; the rest are all runnable.
+  const agents = PROVIDERS.filter((p) => providerFlags[p.id] !== false);
   const detected = agents.filter((p) => !!providerPaths[p.id]).length;
 
   // git/gh come from local state (null until their probe resolves); agents come

--- a/src/components/SettingsScreen/ProvidersPane.tsx
+++ b/src/components/SettingsScreen/ProvidersPane.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { hasAdapter } from "@/adapters";
 import { Icon } from "@/components/Icon";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import { Button } from "@/components/ui/Button";
@@ -20,8 +19,7 @@ export function ProvidersPane() {
   const refreshProviderVersions = useAppStore((s) => s.refreshProviderVersions);
   const [scanning, setScanning] = useState(false);
 
-  const installed = PROVIDERS.filter((p) => hasAdapter(p.id));
-  const enabledCount = installed.filter((p) => providerFlags[p.id] !== false).length;
+  const enabledCount = PROVIDERS.filter((p) => providerFlags[p.id] !== false).length;
 
   const rescan = async () => {
     if (scanning) return;
@@ -38,13 +36,10 @@ export function ProvidersPane() {
       <SetHead
         eyebrow="Settings · Providers"
         title="Providers"
-        desc={`${enabledCount} of ${installed.length} agents enabled. Toggle an agent off to hide it from the composer's model picker without signing out.`}
+        desc={`${enabledCount} of ${PROVIDERS.length} agents enabled. Toggle an agent off to hide it from the composer's model picker without signing out.`}
         actions={
           <>
             {scanning && <span className="set-checked mono text-xs">Scanning…</span>}
-            <IconButton tipDown tip="Coming soon" aria-label="Add provider" disabled>
-              <Icon name="plus" />
-            </IconButton>
             <IconButton
               tipDown
               tip="Re-scan system"
@@ -60,7 +55,7 @@ export function ProvidersPane() {
 
       <SetGroup label="Installed on this system" last>
         <div className="set-prov-list">
-          {installed.map((p) => (
+          {PROVIDERS.map((p) => (
             <ProviderRow
               key={p.id}
               provider={p}

--- a/src/data/providers.ts
+++ b/src/data/providers.ts
@@ -5,9 +5,9 @@
 // against it, so adding/removing an agent surfaces as a compile error
 // anywhere it isn't kept in sync.
 //
-// "Wired" (runnable) === has an entry in the frontend `ADAPTERS` registry
-// plus a backend runner. Agents without an adapter (e.g. antigravity) still
-// appear here but are gated as "coming soon" in the picker (see ModelPicker).
+// Every agent here is wired: it has an entry in the frontend `ADAPTERS`
+// registry (a full Record<ProviderId, …>) plus a backend runner, so a
+// ProviderId without an adapter is a compile error.
 
 export type ProviderId = "claude" | "codex" | "cursor" | "antigravity" | "opencode" | "pi";
 


### PR DESCRIPTION
## What

Antigravity (and every other provider) is now wired with a real adapter, so the "coming soon" gating machinery is dead code. This removes it.

## Changes

- **`adapters/index.ts`**: `ADAPTERS` is now a full `Record<ProviderId, ChatAdapter>` instead of `Partial<…>` — a `ProviderId` without an adapter is now a compile error. Deleted `hasAdapter()` (always returned `true` for the provider list) and simplified `getAdapter()`'s fallback (the missing-default throw was unreachable once the record is total).
- **`data/providers.ts`**: rewrote the stale doc comment about antigravity being gated "coming soon."
- **`Composer/ModelPicker.tsx`**: dropped the `wired = hasAdapter(...)` gate; `usable` collapsed into the real `installed` binary-detection check, the only thing that legitimately disables a row.
- **`ProviderReadiness` / `Onboarding/OnboardingReadiness`**: removed the `hasAdapter` filter; agents are still filtered by the user's enable toggle.
- **`SettingsScreen/ProvidersPane.tsx`**: removed the permanently-disabled "Add provider" button and the dead `hasAdapter` filter.

Binary-detection logic (`providersProbed` / `providerPaths` → "Not installed") is untouched — that's real state, not scaffolding.

## Verification

Biome passes on all six changed files (no unused imports, formatting intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)