### PR TITLE
feat: native notifications for turn-end & needs-input, with sound toggle

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@fontsource/geist-sans": "^5.2.5",
         "@tauri-apps/api": "^2.11.1",
         "@tauri-apps/plugin-dialog": "^2.7.1",
+        "@tauri-apps/plugin-notification": "^2.3.1",
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-shell": "^2.3.5",
         "@tauri-apps/plugin-updater": "^2.10.1",
@@ -241,6 +242,8 @@
     "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.3", "", { "os": "win32", "cpu": "x64" }, "sha512-GlciF75GdbseajOyib2aCHwE3BXIqZ1liGKWLFRvCdN5wm8h8hFssEVKQ/6E+2jsMLg9v7LCTb983YFnn0QSww=="],
 
     "@tauri-apps/plugin-dialog": ["@tauri-apps/plugin-dialog@2.7.1", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ=="],
+
+    "@tauri-apps/plugin-notification": ["@tauri-apps/plugin-notification@2.3.3", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg=="],
 
     "@tauri-apps/plugin-process": ["@tauri-apps/plugin-process@2.3.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA=="],
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@fontsource/geist-sans": "^5.2.5",
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-dialog": "^2.7.1",
+    "@tauri-apps/plugin-notification": "^2.3.1",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-shell": "^2.3.5",
     "@tauri-apps/plugin-updater": "^2.10.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+tauri-plugin-notification = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,6 +12,7 @@
     "core:window:allow-toggle-maximize",
     "core:event:default",
     "dialog:default",
+    "notification:default",
     "shell:default",
     "updater:default",
     "process:allow-restart",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -326,7 +326,8 @@ pub fn run() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
-        .plugin(tauri_plugin_process::init());
+        .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_notification::init());
 
     // Persist window size/position/maximized state across restarts. Desktop
     // only — the plugin isn't available on mobile targets. VISIBLE is excluded

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -43,6 +43,8 @@ export function GeneralPane() {
   const setDensity = useAppStore((s) => s.setDensity);
   const features = useAppStore((s) => s.features);
   const setFeature = useAppStore((s) => s.setFeature);
+  const soundEnabled = useAppStore((s) => s.soundEnabled);
+  const setSoundEnabled = useAppStore((s) => s.setSoundEnabled);
   const telemetryEnabled = useAppStore((s) => s.telemetryEnabled);
   const setTelemetryEnabled = useAppStore((s) => s.setTelemetryEnabled);
   const revealLogs = useAppStore((s) => s.revealLogs);
@@ -114,6 +116,15 @@ export function GeneralPane() {
         {COMPOSER.map((it) => (
           <FeatureRow key={it.key} item={it} />
         ))}
+      </SetGroup>
+
+      <SetGroup label="Notifications">
+        <SetRow
+          title="Sound"
+          sub="Play a chime when an agent finishes a turn or needs your input while you're looking elsewhere. Native notifications fire either way."
+        >
+          <SetToggle on={soundEnabled} onClick={() => setSoundEnabled(!soundEnabled)} />
+        </SetRow>
       </SetGroup>
 
       <SetGroup label="Diagnostics" last>

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -45,12 +45,30 @@ import {
 } from "@/storage/preferences";
 import { getAllSettings } from "@/storage/settings";
 import { checkForUpdate } from "@/util/autoUpdate";
+import { notify } from "@/util/notify";
 import { playAgentDone } from "@/util/sound";
 import { interruptedAgents } from "./interrupted";
 import type { AppSlice, SliceCreator } from "./types";
 
 type AppSet = Parameters<SliceCreator<AppSlice>>[0];
 type AppGet = Parameters<SliceCreator<AppSlice>>[1];
+
+// "Watching" an agent means its window holds focus AND its chat is on screen.
+// Out-of-app signals (chime + native notification) fire only when you're NOT
+// watching — otherwise you already see the update.
+const watchingChat = (get: AppGet, agentId: string) =>
+  document.hasFocus() && get().selectedAgentId === agentId;
+
+const agentName = (get: AppGet, agentId: string) =>
+  get().workspace?.agents.find((a) => a.id === agentId)?.name ?? "Agent";
+
+// Signal an out-of-app event for an agent the user isn't watching: a native
+// notification always, plus the chime unless it's been muted in settings.
+const signalAway = (get: AppGet, agentId: string, title: string) => {
+  if (watchingChat(get, agentId)) return;
+  if (get().soundEnabled) playAgentDone();
+  notify(title, agentName(get, agentId));
+};
 
 type AgentPatch = Partial<AgentRecord> | ((a: AgentRecord) => Partial<AgentRecord>);
 
@@ -86,6 +104,8 @@ const hydrateSettings = async (set: AppSet) => {
       accent: s.accent || "copper",
       density: (s.density as Density) || "comfortable",
       features: parseFeatures(s.features),
+      // Opt-out chime: only an explicit "false" mutes it.
+      soundEnabled: s.soundEnabled !== "false",
       providerFlags: parseProviderFlags(s.providers),
       providerPathOverrides: parseProviderPathOverrides(s),
       newDraftProvider,
@@ -148,6 +168,10 @@ const registerEventListeners = async (set: AppSet, get: AppGet) => {
       const requestId = (ev as { request_id?: string }).request_id;
       const toolUseId = req?.tool_use_id;
       if (req?.subtype === "can_use_tool" && typeof toolUseId === "string" && requestId) {
+        // Only signal on the transition into "blocked": a turn can forward
+        // several prompts at once (parallel tool calls), and one notification
+        // for the batch beats one per prompt.
+        const wasIdle = !Object.keys(get().pendingToolUse[e.agent_id] ?? {}).length;
         set((state) => ({
           pendingToolUse: {
             ...state.pendingToolUse,
@@ -157,6 +181,8 @@ const registerEventListeners = async (set: AppSet, get: AppGet) => {
             },
           },
         }));
+        // The only out-of-app signal this widget has ever had.
+        if (wasIdle) signalAway(get, e.agent_id, "Needs your input");
       }
       return;
     }
@@ -185,15 +211,9 @@ const registerEventListeners = async (set: AppSet, get: AppGet) => {
       // flag once and gate both the chime and the unseen-results marker on
       // a genuine completion (a manual stop is neither).
       if (!interruptedAgents.delete(e.agent_id)) {
-        // The chime exists to notify you when you're NOT watching this
-        // agent — so skip it when you already are. "Watching" means the
-        // window holds focus AND this is the chat on screen; if either is
-        // false (other app focused, window minimized, or a different chat
-        // selected) the sound still fires.
-        const watchingThisChat = document.hasFocus() && get().selectedAgentId === e.agent_id;
-        if (!watchingThisChat) {
-          playAgentDone();
-        }
+        // Notify (chime + native) when you're NOT watching this agent —
+        // skipped when you already are, see signalAway.
+        signalAway(get, e.agent_id, "Turn complete");
         // Flag results for review on any agent the user isn't currently
         // looking at — this is the only signal for research-only turns that
         // leave no diff behind. Cleared when the agent is selected.

--- a/src/store/appearance.ts
+++ b/src/store/appearance.ts
@@ -13,6 +13,7 @@ export const createAppearanceSlice: SliceCreator<AppearanceSlice> = (set) => ({
   accent: "copper",
   density: "comfortable" as Density,
   features: DEFAULT_FEATURES,
+  soundEnabled: true,
   viewMode: "custom" as WorkspaceView,
 
   // ── appearance ──────────────────────────────────────────────────────────────
@@ -38,6 +39,10 @@ export const createAppearanceSlice: SliceCreator<AppearanceSlice> = (set) => ({
       setSetting("features", next);
       return { features: next };
     }),
+  setSoundEnabled: (on) => {
+    set({ soundEnabled: on });
+    setSetting("soundEnabled", String(on));
+  },
   setViewMode: (v) => {
     set({ viewMode: v });
     setSetting("viewMode", v);

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -329,6 +329,9 @@ export interface AppearanceSlice {
   accent: string;
   density: Density;
   features: FeatureFlags;
+  /** Play the chime when an agent turn finishes or needs input while you're
+   *  not watching that chat. Native notifications fire regardless. Opt-out. */
+  soundEnabled: boolean;
   /** View mode preference for the workspace pane. Persisted; falls
    *  back to the agent's own `view` field for native vs. custom
    *  switching. */
@@ -340,6 +343,7 @@ export interface AppearanceSlice {
   setAccent: (a: string) => void;
   setDensity: (d: Density) => void;
   setFeature: <K extends keyof FeatureFlags>(k: K, v: FeatureFlags[K]) => void;
+  setSoundEnabled: (on: boolean) => void;
   setViewMode: (v: WorkspaceView) => void;
 }
 

--- a/src/util/notify.ts
+++ b/src/util/notify.ts
@@ -1,0 +1,37 @@
+// Native OS notifications for out-of-app agent signals (turn finished, needs
+// your input). Best-effort like the chime: permission is requested lazily on
+// first use, cached, and every failure is swallowed — a missed notification is
+// never important enough to surface as an error.
+
+import {
+  isPermissionGranted,
+  requestPermission,
+  sendNotification,
+} from "@tauri-apps/plugin-notification";
+
+// null = not yet asked; resolved to a boolean after the first request so we
+// don't re-prompt (or re-hit the plugin) on every subsequent notification.
+let granted: boolean | null = null;
+
+async function ensurePermission(): Promise<boolean> {
+  if (granted !== null) return granted;
+  try {
+    granted = (await isPermissionGranted()) || (await requestPermission()) === "granted";
+  } catch {
+    granted = false;
+  }
+  return granted;
+}
+
+/** Fire a native notification. No-op (silently) without OS permission or when
+ *  the plugin is unavailable. */
+export function notify(title: string, body: string): void {
+  void ensurePermission().then((ok) => {
+    if (!ok) return;
+    try {
+      sendNotification({ title, body });
+    } catch {
+      // ignore — notifications are best-effort
+    }
+  });
+}

--- a/src/util/notify.ts
+++ b/src/util/notify.ts
@@ -9,18 +9,22 @@ import {
   sendNotification,
 } from "@tauri-apps/plugin-notification";
 
-// null = not yet asked; resolved to a boolean after the first request so we
+// null = not yet asked; resolves to a boolean after the first request so we
 // don't re-prompt (or re-hit the plugin) on every subsequent notification.
-let granted: boolean | null = null;
+// Caching the Promise (not the result) closes the race between concurrent
+// notify() calls that both see null before the first resolution.
+let permissionPromise: Promise<boolean> | null = null;
 
 async function ensurePermission(): Promise<boolean> {
-  if (granted !== null) return granted;
-  try {
-    granted = (await isPermissionGranted()) || (await requestPermission()) === "granted";
-  } catch {
-    granted = false;
-  }
-  return granted;
+  if (permissionPromise !== null) return permissionPromise;
+  permissionPromise = (async () => {
+    try {
+      return (await isPermissionGranted()) || (await requestPermission()) === "granted";
+    } catch {
+      return false;
+    }
+  })();
+  return permissionPromise;
 }
 
 /** Fire a native notification. No-op (silently) without OS permission or when


### PR DESCRIPTION
## Summary

Adds native OS notifications for agent turn-end and needs-input events, and makes the notification chime toggleable. Previously only a hard-wired chime fired on turn-end, and the "Needs your input" widget had no out-of-app signal at all.

## Changes

**Tauri notification plugin**
- Add `tauri-plugin-notification` (Rust dependency + plugin registration) and the `@tauri-apps/plugin-notification` JS package
- Add `notification:default` to the default capability

**Notification helper** — `src/util/notify.ts`
- `notify(title, body)` lazily requests OS permission (cached) then fires a native notification; best-effort, all failures swallowed (mirrors `sound.ts`)

**Store wiring** — `src/store/app.ts`
- Extract `signalAway()`: when the user isn't watching that chat, fire a native notification (always) plus the chime (only when Sound is enabled)
- Turn-end fires "Turn complete"; the transition into a blocked `can_use_tool` prompt fires "Needs your input", deduped so a batch of parallel prompts yields one notification

**Sound toggle** — one `SetRow` in General settings
- `soundEnabled` preference (opt-out, default true), persisted via `setSetting` and hydrated like peers
- Native notifications fire regardless of the toggle — it only mutes the chime

## Follow-up (required before shipping)

Lockfiles could not be regenerated in the sandboxed worktree: run `bun install` and a `cargo build` to update `bun.lock` / `Cargo.lock` and pull the plugin. Typecheck/lint were also not run (no `node_modules`) — please compile before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)