### PR TITLE
feat(telemetry): add turn_completed event for turn volume and usage-weighted provider mix

### DIFF
--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -22,7 +22,7 @@ use crate::run_session::{
 use crate::workspace::{
     agent_parent_dir, allocate_repo_subdir, is_per_turn_provider, new_agent_record,
     repo_worktree_path, AgentRecord, AgentStatus, AgentView, ArchiveMetadata, ArchivedRepoSnapshot,
-    DiffStats, TrackedRepo, Workspace, WorkspaceManager,
+    ClosedTurn, DiffStats, TrackedRepo, Workspace, WorkspaceManager,
 };
 
 /// Serialize raw PTY bytes as a base64 string rather than serde's default
@@ -342,14 +342,38 @@ impl Supervisor {
         }
         // Close the in-flight turn's timer on any terminal state. Idle covers
         // the in-band turn-end and clean process exit; Error covers a crash.
-        // No-op when no turn is open (resting Idle at spawn, native turns), so
-        // it's safe to run unconditionally on these transitions.
+        // A closed turn (started, not native, not the resting Idle at spawn)
+        // yields stats we report as `turn_completed`.
         if matches!(status, AgentStatus::Idle | AgentStatus::Error) {
-            if let Err(e) = self.workspace.mark_user_turn_ended(agent_id) {
-                tracing::warn!(error = %e, agent_id, "stamp user turn end failed");
+            match self.workspace.mark_user_turn_ended(agent_id) {
+                Ok(Some(turn)) => self.track_turn_completed(agent_id, &status, turn),
+                Ok(None) => {}
+                Err(e) => tracing::warn!(error = %e, agent_id, "stamp user turn end failed"),
             }
         }
         emit_status(app, agent_id, status, last_error);
+    }
+
+    /// Report a completed turn to product telemetry: usage-weighted provider
+    /// mix (unlike `agent_spawned`, which only counts starts) plus turn shape
+    /// (duration, size, whether it errored). All properties are categorical or
+    /// numeric aggregates — no prompt content. No-op unless consent is on.
+    fn track_turn_completed(&self, agent_id: &str, status: &AgentStatus, turn: ClosedTurn) {
+        let (provider, model) = self
+            .workspace
+            .agent(agent_id)
+            .map(|r| (r.provider, r.model))
+            .unwrap_or_else(|_| ("unknown".into(), None));
+        crate::telemetry::track(
+            "turn_completed",
+            serde_json::json!({
+                "provider": provider,
+                "model": model,
+                "duration_ms": turn.duration_ms,
+                "record_count": turn.record_count,
+                "errored": matches!(status, AgentStatus::Error),
+            }),
+        );
     }
 
     /// The live (in-memory) runtime status, if the supervisor is tracking

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -2282,11 +2282,15 @@ mod tests {
         assert_eq!(wm.read_user_turns(&ws_id).unwrap()[0].ended_at, None);
 
         let closed = wm.mark_user_turn_ended(&ws_id).unwrap().expect("open turn closed");
-        assert!(closed.duration_ms >= 0, "non-negative duration");
-        assert_eq!(closed.record_count, 0, "no records ingested in this test");
         let turn = wm.read_user_turns(&ws_id).unwrap().remove(0);
         assert_eq!(turn.started_at, started, "start clock not reset by end");
         assert!(turn.ended_at >= turn.started_at, "ended_at after started_at");
+        assert_eq!(
+            closed.duration_ms,
+            turn.ended_at.unwrap() - turn.started_at.unwrap(),
+            "duration_ms matches stored ended_at − started_at"
+        );
+        assert_eq!(closed.record_count, 0, "no records ingested in this test");
     }
 
     #[test]

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -282,6 +282,17 @@ pub struct UserTurn {
     pub ended_at: Option<i64>,
 }
 
+/// Stats for a turn that `mark_user_turn_ended` just closed, returned so the
+/// caller can emit per-turn telemetry. `None` from that call means no open turn
+/// existed (resting Idle at spawn, or a native turn with no timing row).
+pub struct ClosedTurn {
+    /// Wall-clock run duration (`ended_at - started_at`).
+    pub duration_ms: i64,
+    /// Transcript records ingested during the turn window — a proxy for how
+    /// much the agent produced this turn.
+    pub record_count: i64,
+}
+
 pub struct WorkspaceManager {
     db: Arc<Mutex<Connection>>,
 }
@@ -934,22 +945,44 @@ impl WorkspaceManager {
     }
 
     /// Close the in-flight turn at turn end by stamping `ended_at` on the open
-    /// turn (started, not yet ended) of the workspace's current session. No-op
-    /// when none is open — e.g. the resting Idle emitted at spawn, or a native
-    /// turn with no timing row. At most one turn is ever open per session
-    /// (each end closes the open turn before the next one starts), but the
-    /// `WHERE` would safely close all open turns if one were ever stranded.
-    pub fn mark_user_turn_ended(&self, workspace_id: &str) -> Result<()> {
+    /// turn (started, not yet ended) of the workspace's current session, and
+    /// return its stats for telemetry. `None` when none is open — e.g. the
+    /// resting Idle emitted at spawn, or a native turn with no timing row. At
+    /// most one turn is ever open per session (each end closes the open turn
+    /// before the next one starts), but the `WHERE` would safely close all open
+    /// turns if one were ever stranded; duration then anchors on the earliest.
+    pub fn mark_user_turn_ended(&self, workspace_id: &str) -> Result<Option<ClosedTurn>> {
         let conn = self.db.lock();
         let Some(sid) = current_session_id(&conn, workspace_id) else {
-            return Ok(());
+            return Ok(None);
         };
+        let started_at: Option<i64> = conn.query_row(
+            "SELECT MIN(started_at) FROM session_user_turns
+             WHERE session_id = ?1 AND started_at IS NOT NULL AND ended_at IS NULL",
+            [&sid],
+            |r| r.get(0),
+        )?;
+        let Some(started_at) = started_at else {
+            return Ok(None);
+        };
+        let now = now_millis();
         conn.execute(
             "UPDATE session_user_turns SET ended_at = ?1
              WHERE session_id = ?2 AND started_at IS NOT NULL AND ended_at IS NULL",
-            rusqlite::params![now_millis(), sid],
+            rusqlite::params![now, sid],
         )?;
-        Ok(())
+        // Records land before the terminal event that trips turn-end detection,
+        // so the window is complete by the time we get here.
+        let record_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM session_records
+             WHERE session_id = ?1 AND created_at BETWEEN ?2 AND ?3",
+            rusqlite::params![sid, started_at, now],
+            |r| r.get(0),
+        )?;
+        Ok(Some(ClosedTurn {
+            duration_ms: now - started_at,
+            record_count,
+        }))
     }
 
     /// All outgoing user turns for the workspace's current session, in seq order.
@@ -2248,7 +2281,9 @@ mod tests {
         assert_eq!(started, Some(1000));
         assert_eq!(wm.read_user_turns(&ws_id).unwrap()[0].ended_at, None);
 
-        wm.mark_user_turn_ended(&ws_id).unwrap();
+        let closed = wm.mark_user_turn_ended(&ws_id).unwrap().expect("open turn closed");
+        assert!(closed.duration_ms >= 0, "non-negative duration");
+        assert_eq!(closed.record_count, 0, "no records ingested in this test");
         let turn = wm.read_user_turns(&ws_id).unwrap().remove(0);
         assert_eq!(turn.started_at, started, "start clock not reset by end");
         assert!(turn.ended_at >= turn.started_at, "ended_at after started_at");
@@ -2274,7 +2309,10 @@ mod tests {
         // A row with no started_at (e.g. a never-delivered turn, or the resting
         // Idle emitted at spawn) must not get an ended_at.
         wm.insert_user_turn(&ws_id, "turn-1", "hello", &[]).unwrap();
-        wm.mark_user_turn_ended(&ws_id).unwrap();
+        assert!(
+            wm.mark_user_turn_ended(&ws_id).unwrap().is_none(),
+            "no open turn to close"
+        );
         assert_eq!(wm.read_user_turns(&ws_id).unwrap()[0].ended_at, None);
     }
 

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -119,7 +119,7 @@ export function GeneralPane() {
       <SetGroup label="Diagnostics" last>
         <SetRow
           title="Usage analytics"
-          sub="Share anonymous usage events (app opens, agents spawned, PRs opened) to help improve Fletch. No code, file paths, repo names, or prompts are ever sent."
+          sub="Share anonymous usage events (app opens, agents spawned, turns completed, PRs opened) to help improve Fletch. No code, file paths, repo names, or prompts are ever sent."
         >
           <SetToggle on={telemetryEnabled} onClick={() => setTelemetryEnabled(!telemetryEnabled)} />
         </SetRow>


### PR DESCRIPTION
## What

Adds a `turn_completed` telemetry event so we can answer product questions about **turn volume** and **usage-weighted provider mix** — gaps the telemetry stack couldn't cover before.

## Why

`agent_spawned` already carries `provider`/`model`, but it only counts *starts* — it can't tell you what people actually *use*, and there was zero coverage of turn volume. `turn_completed` closes both in one event.

## How

- **Emit hook:** `persist_and_emit_status` (`supervisor.rs`) is the single choke point every turn end funnels through (in-band turn end + clean exit → Idle; crash → Error). The new `track_turn_completed` helper emits there.
- **`mark_user_turn_ended` now returns `Option<ClosedTurn>`** (`workspace.rs`) instead of `()`. `None` = no open turn closed (resting Idle at spawn, native PTY turns), so the event fires **only on real turns** — no spurious emissions. `ClosedTurn` carries `duration_ms` (from `started_at`/`ended_at`) and `record_count` (transcript records ingested in the turn window — a size proxy).
- **Event payload:** `provider`, `model`, `duration_ms`, `record_count`, `errored`. All categorical/numeric aggregates — no prompt content — matching the module's privacy contract, and it inherits the existing consent gate in `track()`.
- **Disclosure:** updated the Settings "Usage analytics" copy to enumerate "turns completed".

## Testing

- `cargo check` — clean.
- `cargo test --lib user_turn` — 6 passed. Strengthened two tests: one asserts the returned `ClosedTurn` (non-negative duration, zero records with no ingest), one asserts `None` when no turn was open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)