### PR TITLE
fix(supervisor): stop poll loops leaking after clean agent exit

### DIFF
--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -2882,6 +2882,11 @@ fn apply_exit_if_current(
         return;
     }
 
+    // The process is gone and we don't restart here (a clean exit stays Idle/
+    // resumable). Invalidate this generation so the gen-guarded turn watchdog
+    // and RPC watcher stop polling instead of spinning for the app's lifetime.
+    sup.bump_generation(agent_id);
+
     sup.agents.lock().remove(agent_id);
     sup.activities.lock().remove(agent_id);
     sup.native_input_lines.lock().remove(agent_id);


### PR DESCRIPTION
## Problem

`apply_exit_if_current` (src-tauri/src/supervisor.rs) tears down an exited-but-not-archived agent — removing it from the `agents` map and leaving it `Idle`/resumable — but never bumped the agent's spawn generation.

The turn watchdog (500ms) and RPC directory scanner (100ms) are gen-guarded background loops that captured the spawn's generation. Because the generation was never invalidated on exit, they kept seeing `current_gen == gen` and polled forever. With 10+ idle agents that's ~100 filesystem scans/second, needlessly draining battery and disk.

## Fix

Call `bump_generation` once the exit is confirmed to be for the current generation. This is exactly what the `bump_generation` doc comment (supervisor.rs:255-258) prescribes: non-restarting teardown paths must invalidate the generation, "or their loops spin for the app's lifetime."

- Placed after the `current != gen` staleness guard, so stale exits still return early untouched.
- On resume, `start_process` bumps the generation again and starts fresh loops, so resumability is unaffected.

## Notes

Not built/tested locally: the sandbox blocks `cargo` from fetching deps into the registry cache, and the offline cache is missing `tauri-plugin-notification`. The change is a single call to an existing method matching call patterns already in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)