### PR TITLE
fix(run): unstick Run panel when the first-phase PTY fails to spawn

### DIFF
--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -536,17 +536,27 @@ impl Supervisor {
         emit_run_state(&app, agent_id, plan.first_phase, None);
         write_header(&app, agent_id, &session, &plan.first_cmd);
 
-        spawn_run_phase(
+        // begin_phase already flipped the session active. If the spawn fails we
+        // must reset to Stopped — otherwise is_active() stays true and every
+        // later ▶ click no-ops on the idempotency guard. Mirrors the chained
+        // run-phase failure path in handle_run_phase_exit.
+        if let Err(e) = spawn_run_phase(
             self.clone(),
-            app,
+            app.clone(),
             agent_id.to_string(),
-            session,
+            session.clone(),
             gen,
             cwd,
             plan.first_phase,
             plan.first_cmd,
             plan.chained_run_cmd,
-        )
+        ) {
+            let msg = format!("Failed to start command: {e}");
+            session.mark_stopped(Some(msg.clone()));
+            emit_run_state(&app, agent_id, RunPhase::Stopped, Some(msg));
+            return Err(e);
+        }
+        Ok(())
     }
 
     /// Stop the Run-panel process for an agent. Idempotent.


### PR DESCRIPTION
## Problem

The Run panel gets stuck "active" if the PTY fails to spawn on the first phase (`supervisor.rs` `run_start`). Later ▶ clicks silently no-op until the user presses Stop.

`run_start()` calls `session.begin_phase()` — flipping the session into an active phase (`Setup`/`Running`) — *before* spawning the PTY. When the spawn fails (PTY spawn error, or `sandboxed_run_command` failing to build the sandbox profile), the `Err` propagates out but the session is left in an active phase with no live PTY. `is_active()` then keeps returning `true`, so the idempotency guard (`if session.is_active() { return Ok(()) }`) makes every subsequent ▶ click a silent no-op — only Stop resets it.

## Fix

On first-phase spawn failure, reset the session to `Stopped` and emit the `Stopped` state before returning the error — mirroring the chained setup→run failure path already handled in `handle_run_phase_exit`. The panel now reflects the failure and ▶ works again immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)