### PR TITLE
fix(supervisor): flush stranded follow-up when turn ends mid-enqueue

### DIFF
--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -1149,11 +1149,11 @@ impl Supervisor {
     /// - idle, queue full    → flush the leftovers + this message, coalesced,
     /// - busy, claude live    → inject into the running turn over stdin,
     /// - busy, per-turn / tool-gated → queue for the next turn boundary.
-    /// Returns `true` when the message was *enqueued* (held for a later turn
-    /// boundary) rather than delivered now — the frontend uses this to badge the
-    /// optimistic bubble as "queued" only while it genuinely is. Any variant that
-    /// delivers now (including a `WriteLive` that falls back to a fresh turn)
-    /// returns `false`.
+    /// Returns `true` when the message is *held* for a later turn boundary
+    /// rather than delivered now — a busy enqueue, or a flush whose delivery
+    /// failed and re-queued it (raced with teardown/respawn). The frontend uses
+    /// this to badge the optimistic bubble as "queued" only while it genuinely
+    /// is; any variant that actually delivers returns `false`.
     pub fn send_user_message(
         self: Arc<Self>,
         app: &AppHandle,
@@ -1180,9 +1180,10 @@ impl Supervisor {
         };
 
         let delivery = decide_delivery(busy, mode, tool_gated, queue_nonempty);
-        // Returns whether the message was genuinely held for a later boundary.
-        // Every delivering path returns `false`; only a still-busy `Enqueue`
-        // returns `true`.
+        // Whether the message is genuinely held for a later boundary. A path
+        // that delivers now returns `false`; a still-busy `Enqueue` returns
+        // `true`; a flush whose delivery failed and re-queued the follow-ups
+        // also returns `true` (they await the next retry boundary).
         let queued = match delivery {
             Delivery::DeliverNow => {
                 deliver_as_turn(&self, app, agent_id, &msg)?;
@@ -1190,8 +1191,7 @@ impl Supervisor {
             }
             Delivery::FlushNow => {
                 self.message_queue.lock().enqueue(agent_id, msg);
-                flush_queued(&self, app, agent_id)?;
-                false
+                flush_queued(&self, app, agent_id)?
             }
             Delivery::WriteLive => {
                 if let Err(e) = self.inject_live(agent_id, &msg) {
@@ -1203,9 +1203,10 @@ impl Supervisor {
                     // user message (CQ3-A).
                     tracing::warn!(error = %e, agent_id, "live inject failed; delivering as a new turn");
                     self.message_queue.lock().enqueue(agent_id, msg);
-                    flush_queued(&self, app, agent_id)?;
+                    flush_queued(&self, app, agent_id)?
+                } else {
+                    false
                 }
-                false
             }
             Delivery::Enqueue => {
                 self.message_queue.lock().enqueue(agent_id, msg);
@@ -1216,12 +1217,7 @@ impl Supervisor {
                 // message sit until the user types again. `flush_queued` drains
                 // under the queue lock, so if the drain did win the race this is
                 // a harmless no-op — never a double send.
-                if self.is_busy(agent_id) {
-                    true
-                } else {
-                    flush_queued(&self, app, agent_id)?;
-                    false
-                }
+                self.is_busy(agent_id) || flush_queued(&self, app, agent_id)?
             }
         };
         Ok(queued)
@@ -2592,10 +2588,15 @@ fn deliver_as_turn(
 /// as the next turn. No-op if the queue is empty. Persists a single
 /// `session_user_turns` row (the coalesced message's `turn_id`), so the matcher
 /// stays 1→1 with the one transcript record the turn produces.
-fn flush_queued(sup: &Arc<Supervisor>, app: &AppHandle, agent_id: &str) -> Result<()> {
+///
+/// Returns `true` only when delivery failed and the follow-ups were re-queued
+/// (still held for a later boundary); `false` when they were delivered as a
+/// turn or the queue was already empty (drained elsewhere). Callers reporting a
+/// "queued" state to the frontend key off this so the badge tracks reality.
+fn flush_queued(sup: &Arc<Supervisor>, app: &AppHandle, agent_id: &str) -> Result<bool> {
     let count = sup.message_queue.lock().len(agent_id);
     let Some(coalesced) = sup.message_queue.lock().drain_coalesced(agent_id) else {
-        return Ok(());
+        return Ok(false);
     };
     if count > 1 {
         tracing::debug!(agent_id, count, "flushing coalesced follow-up messages as one turn");
@@ -2606,8 +2607,9 @@ fn flush_queued(sup: &Arc<Supervisor>, app: &AppHandle, agent_id: &str) -> Resul
         // post-respawn flush retries. Re-queue at the front to preserve order.
         tracing::warn!(error = %e, agent_id, "flush delivery failed; re-queueing follow-ups");
         sup.message_queue.lock().requeue_front(agent_id, coalesced);
+        return Ok(true);
     }
-    Ok(())
+    Ok(false)
 }
 
 /// At a turn-end Idle transition, flush any queued follow-up messages as the

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -408,6 +408,15 @@ impl Supervisor {
         self.statuses.lock().get(agent_id).cloned()
     }
 
+    /// Whether the agent is mid-turn (spawning or running), i.e. a new message
+    /// can't start a fresh turn right now.
+    fn is_busy(&self, agent_id: &str) -> bool {
+        matches!(
+            self.live_status(agent_id),
+            Some(AgentStatus::Spawning | AgentStatus::Running)
+        )
+    }
+
     /// The status to report for an agent: the live in-memory value when
     /// present, otherwise the DB-derived at-rest status on the record.
     fn effective_status(&self, agent_id: &str, record: &AgentRecord) -> AgentStatus {
@@ -1155,10 +1164,7 @@ impl Supervisor {
         thinking: Option<&str>,
     ) -> Result<bool> {
         let mode = injection_mode(&self.workspace.agent(agent_id)?.provider);
-        let busy = matches!(
-            self.live_status(agent_id),
-            Some(AgentStatus::Spawning | AgentStatus::Running)
-        );
+        let busy = self.is_busy(agent_id);
         let tool_gated = self
             .agents
             .lock()
@@ -1174,11 +1180,18 @@ impl Supervisor {
         };
 
         let delivery = decide_delivery(busy, mode, tool_gated, queue_nonempty);
-        match delivery {
-            Delivery::DeliverNow => deliver_as_turn(&self, app, agent_id, &msg)?,
+        // Returns whether the message was genuinely held for a later boundary.
+        // Every delivering path returns `false`; only a still-busy `Enqueue`
+        // returns `true`.
+        let queued = match delivery {
+            Delivery::DeliverNow => {
+                deliver_as_turn(&self, app, agent_id, &msg)?;
+                false
+            }
             Delivery::FlushNow => {
                 self.message_queue.lock().enqueue(agent_id, msg);
                 flush_queued(&self, app, agent_id)?;
+                false
             }
             Delivery::WriteLive => {
                 if let Err(e) = self.inject_live(agent_id, &msg) {
@@ -1192,12 +1205,26 @@ impl Supervisor {
                     self.message_queue.lock().enqueue(agent_id, msg);
                     flush_queued(&self, app, agent_id)?;
                 }
+                false
             }
-            Delivery::Enqueue => self.message_queue.lock().enqueue(agent_id, msg),
-        }
-        // Only `Enqueue` holds the message back; every other path delivered it
-        // now (WriteLive's fallback still delivers as a fresh turn).
-        Ok(matches!(delivery, Delivery::Enqueue))
+            Delivery::Enqueue => {
+                self.message_queue.lock().enqueue(agent_id, msg);
+                // Same TOCTOU as WriteLive's fallback (CQ3-B): the turn may
+                // have ended between the busy check above and this enqueue, so
+                // the turn-end Idle drain already ran against an empty queue.
+                // If the agent is no longer busy, flush now rather than let the
+                // message sit until the user types again. `flush_queued` drains
+                // under the queue lock, so if the drain did win the race this is
+                // a harmless no-op — never a double send.
+                if self.is_busy(agent_id) {
+                    true
+                } else {
+                    flush_queued(&self, app, agent_id)?;
+                    false
+                }
+            }
+        };
+        Ok(queued)
     }
 
     /// Inject a message into the running turn over the managed agent's open


### PR DESCRIPTION
## Problem

A follow-up message can strand in the queue. `send_user_message` snapshots
`busy` at the top, but the `Enqueue` arm acts on it later. If the turn's Idle
transition fires in that TOCTOU window, `drain_message_queue` sees an empty
queue and returns — then the bare `enqueue` deposits the message with nothing
left to drain it. It sits until the user next types.

The `enqueue` and the drain's `is_empty` check both take the `message_queue`
lock, so the race is real and unrecovered. The `WriteLive` arm already patches
exactly this (the "CQ3-A" fallback); the `Enqueue` arm did not.

## Fix

Mirror the `WriteLive` fallback in the `Enqueue` arm (labeled **CQ3-B**): after
enqueueing, re-check `is_busy`; if the agent is no longer busy, `flush_queued`
now instead of leaving the message stranded. `flush_queued` drains under the
queue lock, so if the turn-end drain won the race this is a harmless no-op —
never a double send.

Supporting changes:
- Extract `is_busy()` to DRY the busy check (now used at two sites).
- Restructure the `match` to yield the returned "held" flag explicitly, so a
  message flushed via the re-check correctly returns `false` (delivered now)
  rather than `true` (queued) — keeping the frontend's "queued" badge honest.

## Testing

Not compiler-verified in this environment: the sandbox blocks the crates.io
fetch for `tauri-plugin-notification` (added by the recent native-notifications
merge, absent from the local cargo cache). The change is a small, type-directed
edit mirroring reviewed code. No supervisor-level integration test was added —
the sibling CQ3-A fix has none, and exercising this path needs a full
`Supervisor` harness that doesn't exist here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)