### PR TITLE
refactor(titlebar): drop leftover project color swatch

### DIFF
--- a/src/components/TitleBar/WorkspaceStatus/Capsule.tsx
+++ b/src/components/TitleBar/WorkspaceStatus/Capsule.tsx
@@ -12,12 +12,11 @@ import { useCapsuleData } from "./useCapsuleData";
 interface Props {
   agent: AgentRecord;
   projectName: string;
-  projectHue?: number;
 }
 
 /** The full hoverable capsule for the active agent: status dot + project/agent
  *  names + git badge (+ checks), with the details popover on hover/focus. */
-export function Capsule({ agent, projectName, projectHue }: Props) {
+export function Capsule({ agent, projectName }: Props) {
   const pending = useAppStore((s) => s.pendingToolUse[agent.id]);
   const rightCollapsed = useAppStore((s) => s.rightCollapsed);
   const toggleRight = useAppStore((s) => s.toggleRight);
@@ -41,9 +40,6 @@ export function Capsule({ agent, projectName, projectHue }: Props) {
       <div className="ws-cap" tabIndex={0}>
         <span className="ws-ctx">
           <StatusDot status={status} />
-          {projectHue != null && (
-            <span className="ws-swatch" style={{ background: `oklch(0.5 0.08 ${projectHue})` }} />
-          )}
           <span className="ws-proj-name">{projectName}</span>
           <span className="ws-slash">/</span>
           <span className="ws-agent-name">{agent.name}</span>

--- a/src/components/TitleBar/WorkspaceStatus/WorkspaceStatus.css
+++ b/src/components/TitleBar/WorkspaceStatus/WorkspaceStatus.css
@@ -39,12 +39,6 @@
   gap: 7px;
   min-width: 0;
 }
-.ws-swatch {
-  width: 8px;
-  height: 8px;
-  border-radius: 2.5px;
-  flex-shrink: 0;
-}
 .ws-proj-name {
   font-size: 12px;
   color: var(--fg-2);

--- a/src/components/TitleBar/WorkspaceStatus/index.tsx
+++ b/src/components/TitleBar/WorkspaceStatus/index.tsx
@@ -22,9 +22,7 @@ export function WorkspaceStatus() {
   const agent = selectedId ? workspace?.agents.find((a) => a.id === selectedId) : null;
   if (agent) {
     const repoPath = agent.repos[0]?.repo_path;
-    return (
-      <Capsule agent={agent} projectName={repoPath ? basename(repoPath) : agent.name} />
-    );
+    return <Capsule agent={agent} projectName={repoPath ? basename(repoPath) : agent.name} />;
   }
 
   return <HomeSummary />;

--- a/src/components/TitleBar/WorkspaceStatus/index.tsx
+++ b/src/components/TitleBar/WorkspaceStatus/index.tsx
@@ -1,5 +1,5 @@
 import { useAppStore } from "@/store";
-import { basename, hueFromString } from "@/util/format";
+import { basename } from "@/util/format";
 import { Capsule } from "./Capsule";
 import { StatusDot } from "./StatusDot";
 
@@ -23,11 +23,7 @@ export function WorkspaceStatus() {
   if (agent) {
     const repoPath = agent.repos[0]?.repo_path;
     return (
-      <Capsule
-        agent={agent}
-        projectName={repoPath ? basename(repoPath) : agent.name}
-        projectHue={repoPath ? hueFromString(repoPath) : undefined}
-      />
+      <Capsule agent={agent} projectName={repoPath ? basename(repoPath) : agent.name} />
     );
   }
 

--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -16,14 +16,6 @@ export function joinPath(dir: string, name: string): string {
   return dir ? `${dir}/${name}` : name;
 }
 
-/** Stable hue (0–360) derived from a string — used to color a project
- *  swatch consistently across reloads. */
-export function hueFromString(s: string): number {
-  let h = 0;
-  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
-  return h % 360;
-}
-
 export function firstLine(s: string, max = 56): string {
   const idx = s.indexOf("\n");
   const head = idx === -1 ? s : s.slice(0, idx);


### PR DESCRIPTION
## What

Removes the small colored square (`ws-swatch`) rendered between the status dot and the project name in the titlebar capsule.

## Why

The swatch was leftover code. When the titlebar switched to using the status dot as the sole project indicator, the color square was never removed, so both were showing next to the project name — one indicator too many.

## Changes

- `Capsule.tsx` — remove the swatch `<span>` and the `projectHue` prop
- `WorkspaceStatus/index.tsx` — stop passing `projectHue`; drop the `hueFromString` import
- `WorkspaceStatus.css` — remove the `.ws-swatch` rule
- `util/format.ts` — remove the now-unused `hueFromString` helper

The capsule now shows: **status dot → project name / agent name**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)