### PR TITLE
refactor: remove Auto-edit feature flag

### DIFF
--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -371,12 +371,6 @@ export function Composer({
               <span>{thinkingLevels.find((l) => l.value === thinkingValue)?.label ?? ""}</span>
             </Chip>
           ))}
-        {features.autoEdit && (
-          <Chip tip="Auto-approve writes">
-            <Icon name="check" size={11} />
-            <span>Auto-edit</span>
-          </Chip>
-        )}
         <Chip tip="Attach" onClick={browse}>
           <Icon name="attach" size={11} />
         </Chip>

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -29,7 +29,6 @@ const FEATURE_GROUPS: { label: string; items: FeatureItem[] }[] = [
     label: "Composer",
     items: [
       { key: "thinkingBudget", title: "Thinking budget", sub: "Low / medium / high cap" },
-      { key: "autoEdit", title: "Auto-edit", sub: "Skip approval for write tools" },
       { key: "tokenUsage", title: "Token usage", sub: "Context window % meter in the composer" },
     ],
   },

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -23,11 +23,6 @@ const COMPOSER: FeatureItem[] = [
     sub: "Show a low / medium / high reasoning cap in the composer.",
   },
   {
-    key: "autoEdit",
-    title: "Auto-edit",
-    sub: "Let agents apply write tools without per-tool approval.",
-  },
-  {
     key: "tokenUsage",
     title: "Token usage",
     sub: "Show the context-window % meter in the composer.",

--- a/src/storage/preferences.ts
+++ b/src/storage/preferences.ts
@@ -28,7 +28,6 @@ export interface FeatureFlags {
   run: boolean;
   terminal: boolean;
   thinkingBudget: boolean;
-  autoEdit: boolean;
   /** Show the context-window usage meter in the composer foot. */
   tokenUsage: boolean;
   /** Experimental: expose the Custom/Native view switcher so agents can be
@@ -43,7 +42,6 @@ export const DEFAULT_FEATURES: FeatureFlags = {
   run: false,
   terminal: false,
   thinkingBudget: true,
-  autoEdit: false,
   tokenUsage: true,
   nativeView: false,
 };
@@ -57,6 +55,8 @@ export function parseFeatures(raw: string | undefined): FeatureFlags {
       diff?: boolean;
       // removed in this version; its presence marks a pre-migration blob
       statusBar?: boolean;
+      // removed feature; drop any stored value on read
+      autoEdit?: boolean;
     };
     // The old "Files" and "Diff" tabs were merged into the Code panel; honor a
     // saved preference for either when migrating an existing settings blob.
@@ -70,10 +70,17 @@ export function parseFeatures(raw: string | undefined): FeatureFlags {
     // Drop its stored `tokenUsage` so the new default (meter on, matching the
     // old always-visible behavior) applies; honor the value for newer blobs.
     const preMigration = saved.statusBar !== undefined;
-    const { files: _files, diff: _diff, statusBar: _statusBar, ...rest } = saved;
+    const {
+      files: _files,
+      diff: _diff,
+      statusBar: _statusBar,
+      autoEdit: _autoEdit,
+      ...rest
+    } = saved;
     void _files;
     void _diff;
     void _statusBar;
+    void _autoEdit;
     if (preMigration) delete rest.tokenUsage;
     return {
       ...DEFAULT_FEATURES,


### PR DESCRIPTION
## Summary

Removes the **Auto-edit** feature flag end-to-end. It was a client-only flag with no backend effect — the agent's permission mode in `agent.rs` never read it — so it only appeared in two settings surfaces and rendered a decorative chip in the composer.

## Changes
- **Settings/index.tsx** — drop the `autoEdit` entry from the quick-settings pop-over's Composer group.
- **SettingsScreen/GeneralPane.tsx** — drop the `autoEdit` entry from the full-screen General pane.
- **Composer/index.tsx** — remove the "Auto-edit" chip.
- **storage/preferences.ts** — remove `autoEdit` from the `FeatureFlags` interface and `DEFAULT_FEATURES`; `parseFeatures` now strips any persisted `autoEdit` on read, matching the existing `statusBar`/`files`/`diff` migration pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)