### PR TITLE
feat(settings): gate native turn-end notifications behind a toggle

### DIFF
--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -45,6 +45,8 @@ export function GeneralPane() {
   const setFeature = useAppStore((s) => s.setFeature);
   const soundEnabled = useAppStore((s) => s.soundEnabled);
   const setSoundEnabled = useAppStore((s) => s.setSoundEnabled);
+  const notifyEnabled = useAppStore((s) => s.notifyEnabled);
+  const setNotifyEnabled = useAppStore((s) => s.setNotifyEnabled);
   const telemetryEnabled = useAppStore((s) => s.telemetryEnabled);
   const setTelemetryEnabled = useAppStore((s) => s.setTelemetryEnabled);
   const revealLogs = useAppStore((s) => s.revealLogs);
@@ -121,9 +123,15 @@ export function GeneralPane() {
       <SetGroup label="Notifications">
         <SetRow
           title="Sound"
-          sub="Play a chime when an agent finishes a turn or needs your input while you're looking elsewhere. Native notifications fire either way."
+          sub="Play a chime when an agent finishes a turn or needs your input while you're looking elsewhere."
         >
           <SetToggle on={soundEnabled} onClick={() => setSoundEnabled(!soundEnabled)} />
+        </SetRow>
+        <SetRow
+          title="Native notifications"
+          sub="Show a desktop notification when an agent finishes a turn or needs your input while you're looking elsewhere."
+        >
+          <SetToggle on={notifyEnabled} onClick={() => setNotifyEnabled(!notifyEnabled)} />
         </SetRow>
       </SetGroup>
 

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -62,12 +62,12 @@ const watchingChat = (get: AppGet, agentId: string) =>
 const agentName = (get: AppGet, agentId: string) =>
   get().workspace?.agents.find((a) => a.id === agentId)?.name ?? "Agent";
 
-// Signal an out-of-app event for an agent the user isn't watching: a native
-// notification always, plus the chime unless it's been muted in settings.
+// Signal an out-of-app event for an agent the user isn't watching: a chime and
+// a native notification, each unless muted in settings.
 const signalAway = (get: AppGet, agentId: string, title: string) => {
   if (watchingChat(get, agentId)) return;
   if (get().soundEnabled) playAgentDone();
-  notify(title, agentName(get, agentId));
+  if (get().notifyEnabled) notify(title, agentName(get, agentId));
 };
 
 type AgentPatch = Partial<AgentRecord> | ((a: AgentRecord) => Partial<AgentRecord>);
@@ -106,6 +106,8 @@ const hydrateSettings = async (set: AppSet) => {
       features: parseFeatures(s.features),
       // Opt-out chime: only an explicit "false" mutes it.
       soundEnabled: s.soundEnabled !== "false",
+      // Opt-out native notifications: only an explicit "false" disables them.
+      notifyEnabled: s.notifyEnabled !== "false",
       providerFlags: parseProviderFlags(s.providers),
       providerPathOverrides: parseProviderPathOverrides(s),
       newDraftProvider,

--- a/src/store/appearance.ts
+++ b/src/store/appearance.ts
@@ -14,6 +14,7 @@ export const createAppearanceSlice: SliceCreator<AppearanceSlice> = (set) => ({
   density: "comfortable" as Density,
   features: DEFAULT_FEATURES,
   soundEnabled: true,
+  notifyEnabled: true,
   viewMode: "custom" as WorkspaceView,
 
   // ── appearance ──────────────────────────────────────────────────────────────
@@ -42,6 +43,10 @@ export const createAppearanceSlice: SliceCreator<AppearanceSlice> = (set) => ({
   setSoundEnabled: (on) => {
     set({ soundEnabled: on });
     setSetting("soundEnabled", String(on));
+  },
+  setNotifyEnabled: (on) => {
+    set({ notifyEnabled: on });
+    setSetting("notifyEnabled", String(on));
   },
   setViewMode: (v) => {
     set({ viewMode: v });

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -337,8 +337,11 @@ export interface AppearanceSlice {
   density: Density;
   features: FeatureFlags;
   /** Play the chime when an agent turn finishes or needs input while you're
-   *  not watching that chat. Native notifications fire regardless. Opt-out. */
+   *  not watching that chat. Opt-out. */
   soundEnabled: boolean;
+  /** Send a native OS notification when an agent turn finishes or needs input
+   *  while you're not watching that chat. Opt-out. */
+  notifyEnabled: boolean;
   /** View mode preference for the workspace pane. Persisted; falls
    *  back to the agent's own `view` field for native vs. custom
    *  switching. */
@@ -351,6 +354,7 @@ export interface AppearanceSlice {
   setDensity: (d: Density) => void;
   setFeature: <K extends keyof FeatureFlags>(k: K, v: FeatureFlags[K]) => void;
   setSoundEnabled: (on: boolean) => void;
+  setNotifyEnabled: (on: boolean) => void;
   setViewMode: (v: WorkspaceView) => void;
 }
 


### PR DESCRIPTION
## What

Makes native OS notifications on turn end configurable, gated behind a new setting with a toggle in **Settings → General → Notifications**.

Previously native notifications fired on every away-signal ("Turn complete" / "Needs your input") unconditionally — only the chime respected a setting. Now both are independently toggleable.

## Changes

- Add `notifyEnabled` boolean to the appearance slice, mirroring `soundEnabled` (opt-out — defaults on, so existing behavior is unchanged until toggled off).
- Gate the `notify()` call in `signalAway` on `notifyEnabled`; this single choke point covers both trigger sites.
- Persist via `setSetting("notifyEnabled", …)` and hydrate with the `!== "false"` opt-out pattern.
- Add a "Native notifications" toggle row in the General pane's Notifications section, and drop the now-stale "Native notifications fire either way" copy from the Sound row.

## Notes

- Frontend-only (TS/React) change.
- Could not run a real typecheck in this worktree (no `node_modules`); worth running `npm run check` before merge. Edits mirror the existing `soundEnabled` wiring exactly.