### PR TITLE
feat: local-first projects with progressive GitHub disclosure

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -122,12 +122,19 @@ pub fn allocate_draft_name(used: Vec<String>) -> String {
     names::allocate(&reserved)
 }
 
+/// Pin a folder as a workspace project. A folder that isn't a git repository
+/// yet is initialized (with an initial commit) first, so users who've never
+/// heard of git can still point the app at any project folder and get working
+/// agents, worktrees, and history.
 #[tauri::command]
-pub fn add_workspace_repo(
+pub async fn add_workspace_repo(
     supervisor: State<'_, Arc<Supervisor>>,
     repo_path: String,
 ) -> Result<Workspace> {
-    supervisor.add_workspace_repo(PathBuf::from(repo_path))
+    let sup = supervisor.inner().clone();
+    let path = PathBuf::from(repo_path);
+    new_project::ensure_git_repo(&path).await?;
+    sup.add_workspace_repo(path)
 }
 
 #[tauri::command]
@@ -172,15 +179,49 @@ pub async fn create_repo(
     dest_parent: String,
     private: bool,
     description: Option<String>,
+    publish: Option<bool>,
 ) -> Result<Workspace> {
     let target = new_project::create(
         &name,
         Path::new(&dest_parent),
         private,
         description.as_deref(),
+        // Default true: an older frontend that doesn't pass the flag keeps
+        // the original create-and-publish behavior.
+        publish.unwrap_or(true),
     )
     .await?;
     supervisor.add_workspace_repo(target)
+}
+
+/// Publish a local-only project to GitHub: create the remote repo from the
+/// project's *root* (so its default branch — e.g. `main` — becomes the GitHub
+/// default, not the agent's working branch), wire `origin`, and push. The
+/// worktree shares the new remote, so the agent can push its branch afterward.
+/// The repo name is the project directory's basename. Returns the web URL.
+#[tauri::command]
+pub async fn publish_agent(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+    private: bool,
+) -> Result<String> {
+    let repo = primary_repo(&supervisor, &agent_id)?;
+    let name = repo
+        .repo_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| Error::InvalidPath("project folder has no name".into()))?
+        .to_string();
+    new_project::validate_new_name(&name)?;
+    gh::repo_create_and_push(&repo.repo_path, &name, private, None).await
+}
+
+/// Drop the stored GitHub token — the app returns to local-only mode.
+#[tauri::command]
+pub fn github_disconnect(db: State<'_, Arc<parking_lot::Mutex<rusqlite::Connection>>>) -> Result<()> {
+    crate::database::set_setting(&db.lock(), gh::TOKEN_SETTING, "")?;
+    gh::set_token(None);
+    Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -782,6 +782,27 @@ pub async fn merge_abort(worktree: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Stage everything and create the repo's first commit. `--allow-empty` so an
+/// empty folder still gets a HEAD — worktrees can't fork without one. Uses the
+/// identity fallback like every other commit-creating op.
+pub async fn commit_initial(repo: &Path) -> Result<()> {
+    run_git(repo, &["add", "-A"], "add -A").await?;
+    let env = identity_env(repo).await;
+    let out = git_output_env(
+        repo,
+        &["commit", "--allow-empty", "-m", "Initial commit"],
+        &env,
+    )
+    .await?;
+    if !out.status.success() {
+        return Err(Error::Git(format!(
+            "initial commit failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
 /// Add a remote. Used when publishing a fresh local repo to GitHub.
 pub async fn remote_add(worktree: &Path, name: &str, url: &str) -> Result<()> {
     run_git(worktree, &["remote", "add", name, url], &format!("remote add {name}")).await?;

--- a/src-tauri/src/git_state.rs
+++ b/src-tauri/src/git_state.rs
@@ -29,6 +29,9 @@ pub struct GitState {
     /// or `None` when origin is missing or isn't a github.com remote. Lets the
     /// UI link out to a commit / compare view. Stable across a branch's life.
     pub remote_url: Option<String>,
+    /// Whether an `origin` remote exists at all (GitHub or not). `false` means
+    /// a local-only repo — push/PR affordances are replaced by "publish".
+    pub has_origin: bool,
     /// HEAD commit SHA, used to build a single-commit link when exactly one
     /// commit is ahead. `None` on an empty repo / detached read failure.
     pub head_sha: Option<String>,
@@ -86,6 +89,7 @@ pub async fn query(worktree_path: &Path, parent_branch: &str) -> Result<GitState
                 additions: 0,
                 deletions: 0,
                 remote_url: None,
+                has_origin: false,
                 head_sha: None,
             });
         }
@@ -123,7 +127,7 @@ pub async fn query(worktree_path: &Path, parent_branch: &str) -> Result<GitState
     // 5. Link targets — the origin web base (for commit / compare links) and the
     //    HEAD sha (for a single-commit link). Both are cheap reads; failures are
     //    non-fatal (the UI just omits the link).
-    let remote_url = query_remote_web_url(worktree_path).await;
+    let (has_origin, remote_url) = query_origin(worktree_path).await;
     let head_sha = query_head_sha(worktree_path).await;
 
     Ok(GitState {
@@ -136,6 +140,7 @@ pub async fn query(worktree_path: &Path, parent_branch: &str) -> Result<GitState
         additions,
         deletions,
         remote_url,
+        has_origin,
         head_sha,
     })
 }
@@ -173,18 +178,21 @@ async fn query_head_sha(worktree_path: &Path) -> Option<String> {
     (!sha.is_empty()).then_some(sha)
 }
 
-/// The `origin` remote, normalized to a GitHub web base. `None` when there is no
-/// origin or it isn't a github.com remote.
-async fn query_remote_web_url(worktree_path: &Path) -> Option<String> {
-    let out = crate::git_dist::command(worktree_path)
+/// The `origin` remote: whether one exists at all, and its GitHub web base
+/// (`None` when missing or not a github.com remote).
+async fn query_origin(worktree_path: &Path) -> (bool, Option<String>) {
+    let out = match crate::git_dist::command(worktree_path)
         .args(["remote", "get-url", "origin"])
         .output()
         .await
-        .ok()?;
-    if !out.status.success() {
-        return None;
-    }
-    github_web_url(String::from_utf8_lossy(&out.stdout).trim())
+    {
+        Ok(out) if out.status.success() => out,
+        _ => return (false, None),
+    };
+    (
+        true,
+        github_web_url(String::from_utf8_lossy(&out.stdout).trim()),
+    )
 }
 
 /// Normalize a git remote URL to its GitHub web base (`https://github.com/

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -770,15 +770,16 @@ pub async fn repo_clone(spec: &str, target: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Create a GitHub repo from the existing git repo at `target` and push the
-/// initial commit. `target` must already be a git repo with at least one
-/// commit (see `new_project::create`).
+/// Create a GitHub repo from the existing git repo at `target` and push its
+/// current branch. `target` must already be a git repo with at least one
+/// commit. Serves both the New Project create flow and the git panel's
+/// "Publish to GitHub" for a local-only project. Returns the repo's web URL.
 pub async fn repo_create_and_push(
     target: &Path,
     name: &str,
     private: bool,
     description: Option<&str>,
-) -> Result<()> {
+) -> Result<String> {
     let client = client::Client::new()?;
     let mut body = json!({ "name": name, "private": private });
     if let Some(desc) = description.filter(|d| !d.is_empty()) {
@@ -801,7 +802,7 @@ pub async fn repo_create_and_push(
         .await?;
     let branch = require_current_branch(target, "publish").await?;
     crate::git::push(target, &branch).await?;
-    Ok(())
+    Ok(format!("https://github.com/{full_name}"))
 }
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -595,6 +595,8 @@ pub fn run() {
             commands::gh_repo_list,
             commands::clone_repo,
             commands::create_repo,
+            commands::publish_agent,
+            commands::github_disconnect,
             commands::spawn_agent,
             commands::write_to_agent,
             commands::send_user_message,

--- a/src-tauri/src/new_project.rs
+++ b/src-tauri/src/new_project.rs
@@ -95,13 +95,51 @@ pub async fn clone(spec: &str, dest_parent: &Path) -> Result<PathBuf> {
     Ok(target)
 }
 
-/// Create a new local repo at `dest_parent/<name>` (seeded with a README and an
-/// initial commit), publish it to GitHub, and return the local path.
+/// Ensure the folder at `path` is a git repository so agents can operate in
+/// worktrees, commit, and track history — the progressive-disclosure ramp for
+/// users who've never heard of git. A plain folder is initialized with an
+/// initial commit (worktrees can't fork a repo with no HEAD); a folder nested
+/// inside an existing repository is rejected with a pointer to the actual
+/// root, since silently initializing a nested repo would split its history.
+pub async fn ensure_git_repo(path: &Path) -> Result<()> {
+    if path.join(".git").exists() {
+        return Ok(());
+    }
+    if let Some(root) = git_toplevel(path).await {
+        return Err(Error::InvalidPath(format!(
+            "{} is inside the git repository at {root} — add that folder instead",
+            path.display(),
+        )));
+    }
+    git::init_repo(path).await?;
+    git::commit_initial(path).await
+}
+
+/// The repository root containing `path`, or `None` when `path` is not inside
+/// any git repository (the normal case for a folder we're about to init).
+async fn git_toplevel(path: &Path) -> Option<String> {
+    let out = crate::git_dist::command(path)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .await
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let root = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!root.is_empty()).then_some(root)
+}
+
+/// Create a new local repo at `dest_parent/<name>` (seeded with a README and
+/// an initial commit) and return the local path. With `publish` it is also
+/// created on GitHub and pushed; without (no GitHub connection yet) it stays
+/// local — the git panel offers "Publish to GitHub" later.
 pub async fn create(
     name: &str,
     dest_parent: &Path,
     private: bool,
     description: Option<&str>,
+    publish: bool,
 ) -> Result<PathBuf> {
     let name = name.trim();
     validate_new_name(name)?;
@@ -122,7 +160,9 @@ pub async fn create(
         std::fs::write(&readme, body)?;
 
         git::commit_all(&target, "Initial commit").await?;
-        gh::repo_create_and_push(&target, name, private, description).await?;
+        if publish {
+            gh::repo_create_and_push(&target, name, private, description).await?;
+        }
         Ok::<(), Error>(())
     }
     .await;
@@ -180,6 +220,57 @@ mod tests {
     fn name_rejects_illegal_chars() {
         // A spec whose tail contains spaces is not a legal repo name.
         assert!(repo_name_from_spec("owner/bad name").is_err());
+    }
+
+    /// The GitHub-unaware path: an empty non-repo folder becomes a repo WITH
+    /// a HEAD (worktrees can't fork without one), and adopting it again is a
+    /// no-op rather than an error.
+    #[tokio::test]
+    async fn ensure_git_repo_initializes_folder_and_is_idempotent() {
+        let td = tempfile::tempdir().unwrap();
+        let dir = td.path().join("my-notes");
+        std::fs::create_dir(&dir).unwrap();
+
+        ensure_git_repo(&dir).await.unwrap();
+
+        assert!(dir.join(".git").exists());
+        let head = std::process::Command::new("git")
+            .current_dir(&dir)
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .unwrap();
+        assert!(
+            head.status.success(),
+            "an adopted folder must have a HEAD commit: {}",
+            String::from_utf8_lossy(&head.stderr),
+        );
+
+        ensure_git_repo(&dir).await.unwrap();
+    }
+
+    /// A folder nested inside an existing repository must be rejected with a
+    /// pointer to the real root — silently initializing a nested repo would
+    /// split its history.
+    #[tokio::test]
+    async fn ensure_git_repo_rejects_folder_inside_existing_repo() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        assert!(std::process::Command::new("git")
+            .current_dir(&repo)
+            .args(["init", "-q"])
+            .status()
+            .unwrap()
+            .success());
+        let nested = repo.join("src");
+        std::fs::create_dir(&nested).unwrap();
+
+        let err = ensure_git_repo(&nested).await.unwrap_err().to_string();
+        assert!(
+            err.contains("inside the git repository"),
+            "unexpected error: {err}",
+        );
+        assert!(!nested.join(".git").exists());
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,9 @@ export function App() {
   const fetchAllShortstats = useAppStore((s) => s.fetchAllShortstats);
   const refreshAllPrStates = useAppStore((s) => s.refreshAllPrStates);
   const refreshAllPrChecks = useAppStore((s) => s.refreshAllPrChecks);
+  // PR polls hit the GitHub API — skip them entirely in local-only mode
+  // (no connection) so a GitHub-unaware user generates zero network chatter.
+  const githubConnected = useAppStore((s) => s.github?.authenticated ?? false);
 
   const theme = useAppStore((s) => s.theme);
   const accent = useAppStore((s) => s.accent);
@@ -69,13 +72,25 @@ export function App() {
   // refresh is a `gh` network call, so this runs at a far gentler cadence than
   // the local shortstats poll, and the backend only touches agents that
   // actually have a PR.
-  usePoll(refreshAllPrStates, 45000, [refreshAllPrStates]);
+  usePoll(
+    async () => {
+      if (githubConnected) await refreshAllPrStates();
+    },
+    45000,
+    [refreshAllPrStates, githubConnected],
+  );
 
   // App-wide poll for CI checks so each sidebar PR pill can be tinted pass/fail
   // at a glance. One `gh` call per open PR, so this rides an even gentler
   // cadence than PR state — checks flip over minutes, not seconds, and the
   // focused Git panel keeps its own faster per-agent checks poll.
-  usePoll(refreshAllPrChecks, 60000, [refreshAllPrChecks]);
+  usePoll(
+    async () => {
+      if (githubConnected) await refreshAllPrChecks();
+    },
+    60000,
+    [refreshAllPrChecks, githubConnected],
+  );
 
   // Apply theme + density via html classes; accent via CSS vars.
   useEffect(() => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -151,6 +151,9 @@ export interface GitState {
    *  when origin is missing / not a github.com remote. Lets the panel link to
    *  a commit or compare view. */
   remote_url?: string | null;
+  /** Whether an `origin` remote exists at all (GitHub or not). False = a
+   *  local-only repo: push/PR give way to "Publish to GitHub". */
+  has_origin: boolean;
   /** HEAD commit SHA, for a single-commit link when one commit is ahead. */
   head_sha?: string | null;
 }
@@ -375,13 +378,23 @@ export const api = {
   ghRepoList: () => invoke<GhRepoSummary[]>("gh_repo_list"),
   cloneRepo: (spec: string, destParent: string) =>
     invoke<Workspace>("clone_repo", { spec, destParent }),
-  createRepo: (name: string, destParent: string, isPrivate: boolean, description?: string) =>
+  createRepo: (
+    name: string,
+    destParent: string,
+    isPrivate: boolean,
+    description?: string,
+    publish?: boolean,
+  ) =>
     invoke<Workspace>("create_repo", {
       name,
       destParent,
       private: isPrivate,
       description: description ?? null,
+      publish: publish ?? true,
     }),
+  publishAgent: (agentId: string, isPrivate: boolean) =>
+    invoke<string>("publish_agent", { agentId, private: isPrivate }),
+  githubDisconnect: () => invoke<void>("github_disconnect"),
   spawnAgent: (
     view: AgentView,
     repoPath: string,

--- a/src/components/NewProject/CloneView.tsx
+++ b/src/components/NewProject/CloneView.tsx
@@ -3,7 +3,7 @@ import { Icon } from "@/components/Icon";
 import { useAppStore } from "@/store";
 import { parseRepoSpec } from "@/util/repoSpec";
 import { RepoList } from "./RepoList";
-import { DestRow, GhGate, type NewProjectShared } from "./shared";
+import { ConnectGitHub, DestRow, type NewProjectShared } from "./shared";
 
 /** Clone an existing GitHub repo — pick from the user's repos or paste a
  *  URL / owner-repo spec. */
@@ -17,7 +17,9 @@ export function CloneView({ shared, onDone }: { shared: NewProjectShared; onDone
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  if (gh && (!gh.installed || !gh.authenticated)) return <GhGate gh={gh} />;
+  // Cloning genuinely needs GitHub — prompt to connect in place. Once
+  // connected, `gh.authenticated` flips and this view renders the picker.
+  if (!gh?.authenticated) return <ConnectGitHub what="clone a repository" />;
 
   // The active spec is the pasted URL (when in paste mode) or the selected repo.
   const spec = pasteMode ? url.trim() : (selected ?? "");

--- a/src/components/NewProject/CreateView.tsx
+++ b/src/components/NewProject/CreateView.tsx
@@ -3,20 +3,21 @@ import { Icon } from "@/components/Icon";
 import { Segmented } from "@/components/Settings/Segmented";
 import { useAppStore } from "@/store";
 import { isValidRepoName } from "@/util/repoSpec";
-import { DestRow, GhGate, type NewProjectShared } from "./shared";
+import { DestRow, type NewProjectShared } from "./shared";
 
-/** Create a brand-new repo locally and publish it to GitHub. */
+/** Create a brand-new local repo. When GitHub is connected it's also published
+ *  (repo created + pushed); otherwise it stays local and the git panel offers
+ *  "Publish to GitHub" later — so a GitHub-unaware user is never blocked. */
 export function CreateView({ shared, onDone }: { shared: NewProjectShared; onDone: () => void }) {
   const createRepo = useAppStore((s) => s.createRepo);
   const { parent, pickParent, gh } = shared;
+  const connected = !!gh?.authenticated;
 
   const [name, setName] = useState("");
   const [visibility, setVisibility] = useState<"private" | "public">("private");
   const [description, setDescription] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  if (gh && (!gh.installed || !gh.authenticated)) return <GhGate gh={gh} />;
 
   const nameOk = isValidRepoName(name);
   const showNameError = name.trim().length > 0 && !nameOk;
@@ -32,6 +33,7 @@ export function CreateView({ shared, onDone }: { shared: NewProjectShared; onDon
         parent,
         visibility === "private",
         description.trim() || undefined,
+        connected,
       );
       onDone();
     } catch (e) {
@@ -55,17 +57,26 @@ export function CreateView({ shared, onDone }: { shared: NewProjectShared; onDon
         )}
       </div>
 
-      <div className="np-field">
-        <label>Visibility</label>
-        <Segmented
-          value={visibility}
-          onChange={setVisibility}
-          options={[
-            { value: "private", label: "Private" },
-            { value: "public", label: "Public" },
-          ]}
-        />
-      </div>
+      {connected ? (
+        <div className="np-field">
+          <label>Visibility</label>
+          <Segmented
+            value={visibility}
+            onChange={setVisibility}
+            options={[
+              { value: "private", label: "Private" },
+              { value: "public", label: "Public" },
+            ]}
+          />
+        </div>
+      ) : (
+        <div className="np-field">
+          <div className="np-hint text-sm">
+            Creating a local project. Connect GitHub later to publish it — you can keep working with
+            agents, commits, and history offline until then.
+          </div>
+        </div>
+      )}
 
       <div className="np-field">
         <label>
@@ -92,6 +103,8 @@ export function CreateView({ shared, onDone }: { shared: NewProjectShared; onDon
             <>
               <Icon name="refresh" size={13} /> Creating…
             </>
+          ) : connected ? (
+            "Create & publish"
           ) : (
             "Create project"
           )}

--- a/src/components/NewProject/NewProject.css
+++ b/src/components/NewProject/NewProject.css
@@ -344,3 +344,13 @@
   font-size: var(--fs-sm);
   color: var(--fg-0);
 }
+/* Device-flow user code shown while connecting from the New Project gate. */
+.np-gate-code {
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: var(--fg-0);
+  font-variant-numeric: tabular-nums;
+}
+.np-gate .np-primary {
+  margin-top: 8px;
+}

--- a/src/components/NewProject/shared.tsx
+++ b/src/components/NewProject/shared.tsx
@@ -1,5 +1,6 @@
 import type { GhStatus } from "@/api";
 import { Icon } from "@/components/Icon";
+import { useGithubConnect } from "@/util/useGithubConnect";
 
 /** Shared state passed from the modal shell to each view. */
 export interface NewProjectShared {
@@ -46,19 +47,56 @@ export function DestRow({
   );
 }
 
-/** Shown when the app has no GitHub connection — both flows need one.
- *  (`gh.installed` is always true now that GitHub goes through the API; the
- *  only gate left is authentication.) */
-export function GhGate(_props: { gh: GhStatus }) {
+/** Connect-GitHub prompt for a flow that genuinely needs it (cloning). Runs
+ *  the device flow inline: on success the store's `github` flips and the
+ *  parent view re-renders to the real form — no dialog reopen. */
+export function ConnectGitHub({ what }: { what: string }) {
+  const { connect, cancel, device, error, busy } = useGithubConnect();
   return (
     <div className="np-body">
       <div className="np-gate flex-center">
         <Icon name="github" size={22} />
-        <div className="np-gate-t text-base">Not connected to GitHub</div>
-        <div className="np-gate-s text-sm">
-          Sign in with GitHub from Settings → Account (or the onboarding tour), then reopen this
-          dialog.
-        </div>
+        {device ? (
+          <>
+            <div className="np-gate-t text-base">Finish signing in in your browser</div>
+            <div className="np-gate-code text-2xl">{device.userCode}</div>
+            <div className="np-gate-s text-sm">{device.verificationUri}</div>
+            <button className="np-link text-sm" onClick={cancel}>
+              Cancel
+            </button>
+          </>
+        ) : error ? (
+          <>
+            <div className="np-gate-t text-base">Sign-in failed</div>
+            <div className="np-gate-s text-sm">{error}</div>
+            <button className="np-primary flex-center text-base" onClick={() => void connect()}>
+              Try again
+            </button>
+          </>
+        ) : (
+          <>
+            <div className="np-gate-t text-base">Connect GitHub to {what}</div>
+            <div className="np-gate-s text-sm">
+              Fletch works fully offline for local projects. Connect GitHub when you want to clone,
+              push, or open pull requests.
+            </div>
+            <button
+              className="np-primary flex-center text-base"
+              disabled={!!busy}
+              onClick={() => void connect()}
+            >
+              {busy ? (
+                <>
+                  <Icon name="refresh" size={13} /> Connecting…
+                </>
+              ) : (
+                <>
+                  <Icon name="github" size={14} /> Connect GitHub
+                </>
+              )}
+            </button>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components/NewProject/useNewProject.ts
+++ b/src/components/NewProject/useNewProject.ts
@@ -1,34 +1,23 @@
 import { open } from "@tauri-apps/plugin-dialog";
 import { useCallback, useEffect, useState } from "react";
-import { api, type GhStatus } from "@/api";
+import { useAppStore } from "@/store";
 
 // The last parent folder a project was created in, pre-filled next time.
 const PARENT_KEY = "q2:newProjectParent";
 
 /** Shared state for the New Project modal: destination parent (remembered),
- *  the gh availability probe, and the directory picker. */
+ *  the shared GitHub connection state, and the directory picker. */
 export function useNewProject() {
   const [parent, setParentState] = useState<string>(() => localStorage.getItem(PARENT_KEY) ?? "");
-  const [gh, setGh] = useState<GhStatus | null>(null);
+  // The store's connection state, refreshed here on open so a sign-in from
+  // elsewhere (or since launch) is reflected; the ConnectGitHub flow updates
+  // the same store field, so the views react without a manual re-probe.
+  const gh = useAppStore((s) => s.github);
+  const refreshGithub = useAppStore((s) => s.refreshGithub);
 
   useEffect(() => {
-    let cancelled = false;
-    api
-      .ghStatus()
-      .then((s) => {
-        if (!cancelled) setGh(s);
-      })
-      .catch(() => {
-        // If the probe itself fails, treat gh as unavailable so the gate shows
-        // immediately rather than leaving the form live with a deferred error.
-        if (!cancelled) {
-          setGh({ installed: false, authenticated: false, login: null });
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+    void refreshGithub();
+  }, [refreshGithub]);
 
   const setParent = useCallback((p: string) => {
     setParentState(p);

--- a/src/components/Onboarding/index.tsx
+++ b/src/components/Onboarding/index.tsx
@@ -3,16 +3,13 @@
 // General. Ported from the design prototype (onboarding/app.jsx): ambient
 // stage, step sequence, cinematic transitions, progress rail, keyboard nav.
 
-import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
-import { open as openExternal } from "@tauri-apps/plugin-shell";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Icon } from "@/components/Icon";
-import { getOrCreateAccount, linkOAuthAccount, type OAuthProfile } from "@/storage/accounts";
 import { useAppStore } from "@/store";
+import { useGithubConnect } from "@/util/useGithubConnect";
 import { Ambient } from "./Ambient";
 import { BEATS } from "./beats";
-import { DeviceCode, type DeviceCodeInfo } from "./DeviceCode";
+import { DeviceCode } from "./DeviceCode";
 import { Beat, IgniteStep, WelcomeStep } from "./steps";
 import "./onboarding.css";
 
@@ -30,20 +27,10 @@ const RAIL_LEN = 4; // welcome..last beat (finale excluded)
 
 export function Onboarding() {
   const closeOnboarding = useAppStore((s) => s.closeOnboarding);
-  const refreshAccount = useAppStore((s) => s.refreshAccount);
 
   const [idx, setIdx] = useState(0);
   const [phase, setPhase] = useState<"in" | "out">("in");
   const [ready, setReady] = useState(false);
-  const [busy, setBusy] = useState<string | null>(null);
-
-  const [device, setDevice] = useState<DeviceCodeInfo | null>(null);
-  const [authError, setAuthError] = useState<string | null>(null);
-  // Monotonic id for the active sign-in. Bumping it (on cancel or a new
-  // attempt) invalidates any in-flight oauth_device_login so its late result
-  // is ignored — the backend poll keeps running until it expires, but its
-  // outcome no longer touches the UI or the DB.
-  const authRunRef = useRef(0);
 
   const step = STEPS[idx];
 
@@ -72,74 +59,16 @@ export function Onboarding() {
   const next = useCallback(() => go(idx + 1), [go, idx]);
   const back = useCallback(() => go(idx - 1), [go, idx]);
 
-  const onAuth = useCallback(
-    async (provider: string) => {
-      if (busy) return;
-      const runId = ++authRunRef.current;
-      const stale = () => authRunRef.current !== runId;
-      setBusy(provider);
-      setAuthError(null);
-      setDevice(null);
-      // Default to a no-op so the finally can always call it — listen() lives
-      // inside the try so an IPC failure is caught and surfaced, not thrown
-      // unhandled (which would strand the cancel-less loading panel).
-      let unlisten: () => void = () => {};
-      try {
-        // The backend emits the user code once the provider issues it; show it
-        // and open the verification page in the user's browser.
-        unlisten = await listen<{
-          provider: string;
-          user_code: string;
-          verification_uri: string;
-        }>("oauth:device-code", (e) => {
-          if (stale()) return;
-          setDevice({
-            provider: e.payload.provider,
-            userCode: e.payload.user_code,
-            verificationUri: e.payload.verification_uri,
-          });
-          void openExternal(e.payload.verification_uri).catch(() => {});
-        });
-        const profile = await invoke<OAuthProfile>("oauth_device_login", {
-          provider,
-        });
-        if (stale()) return; // cancelled or superseded — drop the result
-        const account = await getOrCreateAccount();
-        await linkOAuthAccount(account.id, profile);
-        await refreshAccount();
-        if (stale()) return;
-        // Keep the device panel visible through the transition-out — clearing
-        // `device`/`busy` here would flash the welcome buttons mid-fade. The
-        // step-change effect below tears them down once we've left welcome.
-        go(1);
-      } catch (err) {
-        if (stale()) return;
-        setAuthError(String(err));
-        setBusy(null);
-      } finally {
-        unlisten();
-      }
-    },
-    [busy, go, refreshAccount],
-  );
-
-  const cancelAuth = useCallback(() => {
-    authRunRef.current++; // invalidate any in-flight sign-in
-    setDevice(null);
-    setAuthError(null);
-    setBusy(null);
-  }, []);
-
-  // Once we leave the welcome step, tear down any auth/device state so the
-  // panel fades out cleanly and a later return to welcome shows the sign-in
-  // buttons, not a stale code panel.
-  useEffect(() => {
-    if (step.kind !== "welcome") {
-      setBusy(null);
-      setDevice(null);
-      setAuthError(null);
-    }
-  }, [step.kind]);
+  // Shared device-flow sign-in. On success advance off the welcome step; the
+  // hook persists the profile and refreshes the account + GitHub connection.
+  const {
+    connect,
+    cancel: cancelAuth,
+    device,
+    error: authError,
+    busy,
+  } = useGithubConnect(useCallback(() => go(1), [go]));
+  const onAuth = useCallback((provider: string) => void connect(provider), [connect]);
 
   // Finale handoff: just drop into the real app. Its empty state prompts the
   // user to add their first repo from the sidebar — no auto-picker.
@@ -172,8 +101,11 @@ export function Onboarding() {
 
   let content = null;
   if (step.kind === "welcome")
+    // The only way off welcome is a successful sign-in (go(1)), so during its
+    // fade-out (`phase === "out"`) keep the device panel up rather than
+    // flashing the sign-in buttons as the hook clears its state.
     content =
-      busy || device || authError ? (
+      busy || device || authError || phase === "out" ? (
         <DeviceCode info={device} error={authError} onCancel={cancelAuth} />
       ) : (
         <WelcomeStep onAuth={onAuth} busy={busy} />

--- a/src/components/RightPanel/GitPanel/hooks/useActionBarModel.ts
+++ b/src/components/RightPanel/GitPanel/hooks/useActionBarModel.ts
@@ -26,6 +26,7 @@ export function useActionBarModel(input: {
   base: string;
   customActive: boolean;
   delegationActive: boolean;
+  githubConnected: boolean;
 }) {
   const {
     agentId,
@@ -38,6 +39,7 @@ export function useActionBarModel(input: {
     base,
     customActive,
     delegationActive,
+    githubConnected,
   } = input;
 
   const gitCommitAction = useAppStore((s) => s.gitCommitAction);
@@ -59,6 +61,11 @@ export function useActionBarModel(input: {
     checksFailed: checks?.failed ?? 0,
     commitAction: gitCommitAction,
     prOpen,
+    githubConnected,
+    // A local-only repo (no origin) can't push/PR until published. GitState is
+    // null while loading — assume an origin then so the CTA doesn't flicker to
+    // "Publish" before the first read lands.
+    hasOrigin: gitState?.has_origin ?? true,
   };
   const primary = primaryFor(panelState, counts);
   const secondary = secondaryFor(panelState, counts);

--- a/src/components/RightPanel/GitPanel/hooks/useGitActions.ts
+++ b/src/components/RightPanel/GitPanel/hooks/useGitActions.ts
@@ -5,6 +5,20 @@ import { appActionMessage, type GitDelegationKind } from "@/components/RightPane
 import { formatCommentForChat } from "@/components/RightPanel/prComments";
 import { useAppStore } from "@/store";
 
+// Actions that push to / read from GitHub. In local/offline mode these are
+// intercepted in `runAction` and replaced with connect-or-publish, so none of
+// them reaches the backend only to fail. A compile-time constant — defined at
+// module scope so it isn't reallocated on every render.
+const NEEDS_GITHUB = new Set([
+  "agent-commit-push",
+  "agent-commit-pr",
+  "agent-open-pr",
+  "open-pr",
+  "commit-pr-direct",
+  "push",
+  "merge",
+]);
+
 interface GitActionsCtx {
   agentId: string;
   base: string;
@@ -84,19 +98,6 @@ export function useGitActions(ctx: GitActionsCtx) {
     [agentId, seedComposer, showNotice],
   );
 
-  // Actions that push to / read from GitHub. In local/offline mode these are
-  // intercepted below and replaced with connect-or-publish, so none of them
-  // reaches the backend only to fail.
-  const NEEDS_GITHUB = new Set([
-    "agent-commit-push",
-    "agent-commit-pr",
-    "agent-open-pr",
-    "open-pr",
-    "commit-pr-direct",
-    "push",
-    "merge",
-  ]);
-
   // Single dispatch table for every action a state can offer — the split
   // button's main click and its menu both route through here by key.
   function runAction(key: string) {
@@ -113,11 +114,14 @@ export function useGitActions(ctx: GitActionsCtx) {
         showNotice("Connect GitHub to push & open pull requests");
         break;
       case "publish":
+      case "publish-public": {
+        const isPrivate = key === "publish";
         void runBusy("Publishing to GitHub…", async () => {
-          const url = await publishAgent(agentId, true);
-          if (url) showNotice("Published to GitHub");
+          const url = await publishAgent(agentId, isPrivate);
+          if (url) showNotice(`Published ${isPrivate ? "private" : "public"} repo to GitHub`);
         });
         break;
+      }
       // ── delegated to the coding agent (agent mode) ──
       // Each click sends a short `[app-action]` trigger; the full playbook
       // lives in the agent's injected instructions (git_actions.md), keeping

--- a/src/components/RightPanel/GitPanel/hooks/useGitActions.ts
+++ b/src/components/RightPanel/GitPanel/hooks/useGitActions.ts
@@ -13,6 +13,10 @@ interface GitActionsCtx {
   msg: string;
   checks: PrChecks | null;
   prUrl: string | undefined;
+  /** GitHub connection + origin presence — gate push/PR actions to a connect
+   *  or publish prompt so nothing fails on click in local/offline mode. */
+  githubConnected: boolean;
+  hasOrigin: boolean;
   runBusy: (label: string, fn: () => Promise<unknown>) => Promise<unknown>;
   showNotice: (m: string) => void;
   openOverride: () => void;
@@ -33,6 +37,8 @@ export function useGitActions(ctx: GitActionsCtx) {
     msg,
     checks,
     prUrl,
+    githubConnected,
+    hasOrigin,
     runBusy,
     showNotice,
     openOverride,
@@ -45,6 +51,7 @@ export function useGitActions(ctx: GitActionsCtx) {
   const rebaseAgent = useAppStore((s) => s.rebaseAgent);
   const createPr = useAppStore((s) => s.createPr);
   const mergePr = useAppStore((s) => s.mergePr);
+  const publishAgent = useAppStore((s) => s.publishAgent);
   const archive = useAppStore((s) => s.archive);
   const commitChanges = useAppStore((s) => s.commitChanges);
   const commitAndOpenPr = useAppStore((s) => s.commitAndOpenPr);
@@ -54,6 +61,7 @@ export function useGitActions(ctx: GitActionsCtx) {
   const deleteBranch = useAppStore((s) => s.deleteBranch);
   const delegateGitAction = useAppStore((s) => s.delegateGitAction);
   const seedComposer = useAppStore((s) => s.seedComposer);
+  const openSettingsScreen = useAppStore((s) => s.openSettingsScreen);
 
   // Hand control to the coding agent: it writes the judgment part (message /
   // description / conflict edits) and executes the mutation through the app's
@@ -76,10 +84,40 @@ export function useGitActions(ctx: GitActionsCtx) {
     [agentId, seedComposer, showNotice],
   );
 
+  // Actions that push to / read from GitHub. In local/offline mode these are
+  // intercepted below and replaced with connect-or-publish, so none of them
+  // reaches the backend only to fail.
+  const NEEDS_GITHUB = new Set([
+    "agent-commit-push",
+    "agent-commit-pr",
+    "agent-open-pr",
+    "open-pr",
+    "commit-pr-direct",
+    "push",
+    "merge",
+  ]);
+
   // Single dispatch table for every action a state can offer — the split
   // button's main click and its menu both route through here by key.
   function runAction(key: string) {
+    // Backstop: if a GitHub action is somehow selected while offline (e.g. a
+    // sticky mode from when we were connected), route to the unblock path
+    // instead of dispatching a call that would error.
+    if (NEEDS_GITHUB.has(key) && !githubConnected) key = "connect-github";
+    else if (NEEDS_GITHUB.has(key) && !hasOrigin) key = "publish";
+
     switch (key) {
+      case "connect-github":
+        // The device flow lives in Settings → Account; take the user there.
+        openSettingsScreen("account");
+        showNotice("Connect GitHub to push & open pull requests");
+        break;
+      case "publish":
+        void runBusy("Publishing to GitHub…", async () => {
+          const url = await publishAgent(agentId, true);
+          if (url) showNotice("Published to GitHub");
+        });
+        break;
       // ── delegated to the coding agent (agent mode) ──
       // Each click sends a short `[app-action]` trigger; the full playbook
       // lives in the agent's injected instructions (git_actions.md), keeping

--- a/src/components/RightPanel/GitPanel/index.tsx
+++ b/src/components/RightPanel/GitPanel/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import type { AgentRecord } from "@/api";
 import { delegationLabel } from "@/components/RightPanel/delegation";
+import { useAppStore } from "@/store";
 import { ActionBar } from "./ActionBar";
 import { ChangesList } from "./ChangesList";
 import { CommitComposer } from "./CommitComposer";
@@ -65,6 +66,9 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
     });
   }, [gitState]);
 
+  const githubConnected = useAppStore((s) => s.github?.authenticated ?? false);
+  const hasOrigin = gitState?.has_origin ?? true;
+
   const branch = gitState?.branch || agent.repos[0]?.branch || "(no branch yet)";
   const base = gitState?.parent_branch || agent.repos[0]?.parent_branch || "main";
   // The worktree is detached until its first push; a branch is only born from
@@ -81,6 +85,8 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
     msg,
     checks,
     prUrl: prState?.url,
+    githubConnected,
+    hasOrigin,
     runBusy,
     showNotice,
     openOverride,
@@ -99,6 +105,7 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
     base,
     customActive,
     delegationActive: delegation != null,
+    githubConnected,
   });
 
   // Pushed state: link the commit count out to GitHub — a single commit when

--- a/src/components/RightPanel/primaryActions.ts
+++ b/src/components/RightPanel/primaryActions.ts
@@ -92,6 +92,47 @@ export interface ActionCounts {
   /** Changes state: a PR is already open for this branch — "open PR" is
    *  meaningless (push updates it) and Merge belongs in the menu. */
   prOpen?: boolean;
+  /** Whether GitHub is connected (a valid app token). When false, any
+   *  push/PR action is replaced by "Connect GitHub" — local work still runs. */
+  githubConnected?: boolean;
+  /** Whether the repo has an `origin` remote. When false (a local-only repo)
+   *  push/PR give way to "Publish to GitHub". */
+  hasOrigin?: boolean;
+}
+
+/** Does this commit mode need a GitHub remote (push / open PR)? Plain local
+ *  "Commit" does not, so it stays available with no connection. */
+function commitModeNeedsRemote(mode: GitCommitAction): boolean {
+  return mode === "agent-commit-push" || mode === "agent-commit-pr";
+}
+
+/** The action that unblocks GitHub for a repo that can't push yet: connect
+ *  first (no token), else publish (no origin remote). `null` when neither is
+ *  needed. Shared by the "changes"/"pushed"/"clean" states so the GitHub path
+ *  is always one honest, correctly-labelled click away. */
+export function githubUnblockAction(counts?: ActionCounts): PrimaryAction | null {
+  const { githubConnected = true, hasOrigin = true } = counts ?? {};
+  if (!githubConnected) {
+    return {
+      key: "connect-github",
+      label: "Connect GitHub",
+      icon: "github",
+      statusLabel: "connect GitHub to push & open PRs",
+      statusKind: "info",
+      tone: "ghost",
+    };
+  }
+  if (!hasOrigin) {
+    return {
+      key: "publish",
+      label: "Publish to GitHub",
+      icon: "github",
+      statusLabel: "local project — publish to push & open PRs",
+      statusKind: "info",
+      tone: "ghost",
+    };
+  }
+  return null;
 }
 
 /** Maps a git panel state to the panel's primary call-to-action.
@@ -137,6 +178,19 @@ export function primaryFor(state: GitPanelState, counts?: ActionCounts): Primary
       // updates the existing PR.
       const effective: GitCommitAction =
         prOpen && commitAction === "agent-commit-pr" ? "agent-commit-push" : commitAction;
+      // Offline / local-only: a push/PR mode can't run, so the primary becomes
+      // plain local Commit (still fully functional) and the GitHub path is
+      // offered in the menu — never a button that fails on click.
+      if (commitModeNeedsRemote(effective) && githubUnblockAction(counts)) {
+        return {
+          key: "agent-commit",
+          label: "Commit",
+          icon: "commit",
+          statusLabel: "Ready to commit",
+          statusKind: "warn",
+          statusExtra: `${files} ${files === 1 ? "file" : "files"}`,
+        };
+      }
       const common = {
         statusLabel: "Ready to commit",
         statusKind: "warn" as StatusKind,
@@ -151,7 +205,11 @@ export function primaryFor(state: GitPanelState, counts?: ActionCounts): Primary
           return { key: "agent-commit-pr", label: "Commit & open PR", icon: "pr", ...common };
       }
     }
-    case "pushed":
+    case "pushed": {
+      // Opening a PR needs GitHub — if the token was cleared since the push,
+      // offer Connect instead of a PR button that would fail.
+      const unblock = githubUnblockAction(counts);
+      if (unblock) return unblock;
       // The PR description is the agent's job by default (it has the full
       // context of the branch); the direct gh --fill PR stays in the menu.
       return {
@@ -162,6 +220,7 @@ export function primaryFor(state: GitPanelState, counts?: ActionCounts): Primary
           ahead === 1 ? "1 commit pushed, no PR yet" : `${ahead} commits pushed, no PR yet`,
         statusKind: "info",
       };
+    }
     case "pr-open": {
       // Gate semantics (which MergeState means what, in which tone) live in
       // describeMergeGate; here we only pick the action + status phrasing.
@@ -293,6 +352,12 @@ export function secondaryFor(state: GitPanelState, counts?: ActionCounts): Secon
     checksFailed = 0,
     prOpen = false,
   } = counts ?? {};
+  // In local/offline mode, offer the connect-or-publish action in the states
+  // where the user would reach for GitHub, so it's always one click away.
+  const unblock = githubUnblockAction(counts);
+  const unblockItem: SecondaryAction[] = unblock
+    ? [{ key: unblock.key, label: unblock.label, icon: unblock.icon }]
+    : [];
   // "Push more commits" only makes sense when there's something unpushed.
   const pushItem: SecondaryAction[] =
     unpushed > 0 ? [{ key: "push", label: "Push more commits", icon: "push" }] : [];
@@ -300,28 +365,41 @@ export function secondaryFor(state: GitPanelState, counts?: ActionCounts): Secon
     case "changes":
       // Override active → primary is direct "Commit"; offer a direct
       // "Commit & open PR" (your message + agent-written PR) as the alternate.
+      // Offline, the push/PR alternates give way to connect-or-publish.
       if (customActive) {
         return [
-          { key: "commit-pr-direct", label: "Commit & open PR", icon: "pr" },
-          { key: "push", label: "Push only", icon: "push" },
+          ...(unblock
+            ? unblockItem
+            : [
+                { key: "commit-pr-direct", label: "Commit & open PR", icon: "pr" as IconName },
+                { key: "push", label: "Push only", icon: "push" as IconName },
+              ]),
           { key: "stash", label: "Stash changes", icon: "inbox" },
           { key: "discard", label: "Discard all", icon: "trash" },
         ];
       }
       // Default (agent): every commit mode is a candidate — the panel drops
       // whichever is the sticky primary. With a PR open, "open PR" is
-      // meaningless (push updates it) and Merge joins the menu.
+      // meaningless (push updates it) and Merge joins the menu. Offline, the
+      // push/PR items give way to the single connect-or-publish action.
       return [
         { key: "agent-commit", label: "Commit", icon: "commit" },
-        { key: "agent-commit-push", label: "Commit & push", icon: "push" },
-        ...(prOpen
-          ? [{ key: "merge", label: "Merge PR without changes", icon: "merge" as IconName }]
-          : [{ key: "agent-commit-pr", label: "Commit & open PR", icon: "pr" as IconName }]),
-        { key: "push", label: "Push only", icon: "push" },
+        ...(unblock
+          ? unblockItem
+          : [
+              { key: "agent-commit-push", label: "Commit & push", icon: "push" as IconName },
+              ...(prOpen
+                ? [{ key: "merge", label: "Merge PR without changes", icon: "merge" as IconName }]
+                : [{ key: "agent-commit-pr", label: "Commit & open PR", icon: "pr" as IconName }]),
+              { key: "push", label: "Push only", icon: "push" as IconName },
+            ]),
         { key: "stash", label: "Stash changes", icon: "inbox" },
         { key: "discard", label: "Discard all", icon: "trash" },
       ];
     case "pushed":
+      // Offline, the PR/push items give way to connect-or-publish; the local
+      // Pull stays available either way.
+      if (unblock) return [...unblockItem, { key: "pull", label: "Pull", icon: "inbox" }];
       // Primary is the agent-written PR; the direct gh --fill PR stays one
       // click away for users who don't want to wait on the agent.
       return [

--- a/src/components/RightPanel/primaryActions.ts
+++ b/src/components/RightPanel/primaryActions.ts
@@ -354,10 +354,18 @@ export function secondaryFor(state: GitPanelState, counts?: ActionCounts): Secon
   } = counts ?? {};
   // In local/offline mode, offer the connect-or-publish action in the states
   // where the user would reach for GitHub, so it's always one click away.
+  // Publishing offers both visibilities: the primary/first item publishes
+  // private (the safe default, matching New Project), with a public variant
+  // right beneath it so users don't have to change it on GitHub afterward.
   const unblock = githubUnblockAction(counts);
-  const unblockItem: SecondaryAction[] = unblock
-    ? [{ key: unblock.key, label: unblock.label, icon: unblock.icon }]
-    : [];
+  const unblockItem: SecondaryAction[] = !unblock
+    ? []
+    : unblock.key === "publish"
+      ? [
+          { key: "publish", label: "Publish (private)", icon: "github" },
+          { key: "publish-public", label: "Publish (public)", icon: "github" },
+        ]
+      : [{ key: unblock.key, label: unblock.label, icon: unblock.icon }];
   // "Push more commits" only makes sense when there's something unpushed.
   const pushItem: SecondaryAction[] =
     unpushed > 0 ? [{ key: "push", label: "Push more commits", icon: "push" }] : [];

--- a/src/components/SettingsScreen/AccountPane.tsx
+++ b/src/components/SettingsScreen/AccountPane.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/Button";
 import { useAppStore } from "@/store";
 import { accountInitials } from "@/util/format";
 import { DevToolsStatus } from "./DevToolsStatus";
+import { GithubConnection } from "./GithubConnection";
 import { SetGroup, SetHead } from "./primitives";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -121,6 +122,10 @@ export function AccountPane() {
             </Button>
           </div>
         </div>
+      </SetGroup>
+
+      <SetGroup label="GitHub">
+        <GithubConnection />
       </SetGroup>
 
       <SetGroup label="Developer tools" last>

--- a/src/components/SettingsScreen/GithubConnection.tsx
+++ b/src/components/SettingsScreen/GithubConnection.tsx
@@ -1,0 +1,64 @@
+import { useEffect } from "react";
+import { Icon } from "@/components/Icon";
+import { Button } from "@/components/ui/Button";
+import { useAppStore } from "@/store";
+import { useGithubConnect } from "@/util/useGithubConnect";
+
+/** GitHub connection control for Settings → Account. Connecting runs the
+ *  device flow inline (the same one onboarding uses); disconnecting drops the
+ *  stored token and returns the app to local-only mode. */
+export function GithubConnection() {
+  const github = useAppStore((s) => s.github);
+  const refreshGithub = useAppStore((s) => s.refreshGithub);
+  const disconnectGithub = useAppStore((s) => s.disconnectGithub);
+  const { connect, cancel, device, error, busy } = useGithubConnect();
+
+  // Reflect the current connection on mount (and after a connect/disconnect
+  // elsewhere) so the row isn't stale.
+  useEffect(() => {
+    void refreshGithub();
+  }, [refreshGithub]);
+
+  if (device) {
+    return (
+      <div className="set-gh">
+        <div className="set-gh-lede text-sm">Finish signing in in your browser, then enter:</div>
+        <div className="set-gh-code text-2xl">{device.userCode}</div>
+        <div className="set-gh-uri mono text-sm">{device.verificationUri}</div>
+        <Button variant="outline" onClick={cancel}>
+          Cancel
+        </Button>
+      </div>
+    );
+  }
+
+  const connected = !!github?.authenticated;
+
+  return (
+    <div className="set-gh">
+      <div className="set-gh-row flex-center">
+        <Icon name="github" size={16} />
+        <span className="set-gh-status text-base">
+          {connected
+            ? `Connected${github?.login ? ` as ${github.login}` : ""}`
+            : "Not connected — local projects still work offline"}
+        </span>
+        {connected ? (
+          <Button variant="outline" onClick={() => void disconnectGithub()}>
+            Disconnect
+          </Button>
+        ) : (
+          <Button variant="primary" disabled={!!busy} onClick={() => void connect()}>
+            {busy ? "Connecting…" : "Connect GitHub"}
+          </Button>
+        )}
+      </div>
+      {error && <div className="set-gh-err text-sm">{error}</div>}
+      {connected && (
+        <div className="set-gh-hint text-sm">
+          Fletch uses this to clone, push, and open pull requests on your behalf.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SettingsScreen/SettingsScreen.css
+++ b/src/components/SettingsScreen/SettingsScreen.css
@@ -419,6 +419,37 @@
   pointer-events: none;
 }
 
+/* ── GITHUB CONNECTION ───────────────────────────────────────────────── */
+.set-gh {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.set-gh-row {
+  gap: 10px;
+}
+.set-gh-status {
+  flex: 1;
+  color: var(--fg-1);
+}
+.set-gh-hint,
+.set-gh-lede {
+  color: var(--fg-2);
+  line-height: var(--lh-normal);
+}
+.set-gh-err {
+  color: var(--danger);
+}
+.set-gh-code {
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: var(--fg-0);
+  font-variant-numeric: tabular-nums;
+}
+.set-gh-uri {
+  color: var(--fg-2);
+}
+
 /* ── PROVIDERS ───────────────────────────────────────────────────────── */
 .set-checked {
   color: var(--fg-3);

--- a/src/store/account.ts
+++ b/src/store/account.ts
@@ -37,10 +37,14 @@ export const createAccountSlice: SliceCreator<AccountSlice> = (set, get) => ({
   disconnectGithub: async () => {
     try {
       await api.githubDisconnect();
+      // Only reflect disconnected once the backend actually cleared the token.
+      // If the write failed the token is still stored, so leaving `github`
+      // as-is keeps the UI honest instead of showing a phantom disconnect
+      // that a later refresh silently reverses.
+      set({ github: { installed: true, authenticated: false, login: null } });
     } catch (e) {
       set({ lastError: String(e) });
     }
-    set({ github: { installed: true, authenticated: false, login: null } });
   },
   setTelemetryEnabled: (enabled) => {
     set({ telemetryEnabled: enabled });

--- a/src/store/account.ts
+++ b/src/store/account.ts
@@ -5,6 +5,7 @@ import type { AccountSlice, SliceCreator } from "./types";
 export const createAccountSlice: SliceCreator<AccountSlice> = (set, get) => ({
   account: null,
   telemetryEnabled: true,
+  github: null,
 
   saveAccount: async (patch) => {
     const current = get().account;
@@ -23,6 +24,23 @@ export const createAccountSlice: SliceCreator<AccountSlice> = (set, get) => ({
     } catch (e) {
       set({ lastError: String(e) });
     }
+  },
+  refreshGithub: async () => {
+    try {
+      set({ github: await api.ghStatus() });
+    } catch {
+      // A failed probe means we can't confirm a connection — treat as
+      // not-connected so gated UI shows "connect" rather than a spinner.
+      set({ github: { installed: true, authenticated: false, login: null } });
+    }
+  },
+  disconnectGithub: async () => {
+    try {
+      await api.githubDisconnect();
+    } catch (e) {
+      set({ lastError: String(e) });
+    }
+    set({ github: { installed: true, authenticated: false, login: null } });
   },
   setTelemetryEnabled: (enabled) => {
     set({ telemetryEnabled: enabled });

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -436,6 +436,9 @@ export const createAppSlice: SliceCreator<AppSlice> = (set, get) => ({
     // Load custom agent presets (async, non-blocking). Empty until loaded — the
     // composer picker and settings pane just show the built-ins meanwhile.
     void get().loadCustomAgents();
+    // Probe the GitHub connection once (async, non-blocking) so push/PR/clone
+    // affordances know whether to act or prompt to connect.
+    void get().refreshGithub();
 
     await registerEventListeners(set, get);
     setupResync(set);

--- a/src/store/git.ts
+++ b/src/store/git.ts
@@ -277,4 +277,17 @@ export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
       set({ lastError: String(e) });
     }
   },
+
+  publishAgent: async (agentId, isPrivate) => {
+    try {
+      const url = await api.publishAgent(agentId, isPrivate);
+      // Origin now exists — refresh so the panel drops the no-origin
+      // affordances and shows normal push/PR against the new remote.
+      await get().fetchGitState(agentId);
+      return url;
+    } catch (e) {
+      set({ lastError: String(e) });
+      return null;
+    }
+  },
 });

--- a/src/store/repos.ts
+++ b/src/store/repos.ts
@@ -38,8 +38,8 @@ export const createReposSlice: SliceCreator<ReposSlice> = (set) => ({
     set({ workspace: ws });
   },
 
-  createRepo: async (name, destParent, isPrivate, description) => {
-    const ws = await api.createRepo(name, destParent, isPrivate, description);
+  createRepo: async (name, destParent, isPrivate, description, publish) => {
+    const ws = await api.createRepo(name, destParent, isPrivate, description, publish);
     set({ workspace: ws });
   },
 });

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -4,6 +4,7 @@ import type { AgentUsage } from "@/adapters/usage";
 import type {
   AgentRecord,
   AgentView,
+  GhStatus,
   GitState,
   PrChecks,
   PrComments,
@@ -161,6 +162,8 @@ export interface ReposSlice {
     destParent: string,
     isPrivate: boolean,
     description?: string,
+    /** Also create + push to GitHub. False = local-only (no connection yet). */
+    publish?: boolean,
   ) => Promise<void>;
 }
 
@@ -235,6 +238,10 @@ export interface GitSlice {
   deleteBranch: (agentId: string) => Promise<void>;
   createPr: (agentId: string, title: string, body: string) => Promise<PrState | null>;
   mergePr: (agentId: string) => Promise<void>;
+  /** Publish a local-only project (no origin) to GitHub, then refresh git
+   *  state so the panel switches out of the no-origin affordances. Resolves
+   *  the repo web URL on success, null on error. */
+  publishAgent: (agentId: string, isPrivate: boolean) => Promise<string | null>;
 }
 
 export interface ComposerSlice {
@@ -318,11 +325,19 @@ export interface AccountSlice {
   account: AccountProfile | null;
   /** Anonymous usage telemetry consent. Opt-out: defaults on. */
   telemetryEnabled: boolean;
+  /** GitHub connection: null until the first probe, then the live status.
+   *  `authenticated` gates push/PR/clone affordances app-wide. */
+  github: GhStatus | null;
 
   saveAccount: (patch: Pick<AccountProfile, "firstName" | "lastName" | "email">) => Promise<void>;
   /** Re-read the local account row into the store — e.g. after an OAuth
    *  sign-in writes the provider profile to SQLite. */
   refreshAccount: () => Promise<void>;
+  /** Re-probe the GitHub connection into `github` (after sign-in/disconnect,
+   *  and once on init). */
+  refreshGithub: () => Promise<void>;
+  /** Drop the stored GitHub token and return to local-only mode. */
+  disconnectGithub: () => Promise<void>;
   setTelemetryEnabled: (enabled: boolean) => void;
 }
 

--- a/src/util/useGithubConnect.ts
+++ b/src/util/useGithubConnect.ts
@@ -1,0 +1,95 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { open as openExternal } from "@tauri-apps/plugin-shell";
+import { useCallback, useRef, useState } from "react";
+import { getOrCreateAccount, linkOAuthAccount, type OAuthProfile } from "@/storage/accounts";
+import { useAppStore } from "@/store";
+
+/** Info shown while a device-flow sign-in is pending: the user code to enter
+ *  at the provider's verification page (opened automatically in the browser). */
+export interface DeviceInfo {
+  provider: string;
+  userCode: string;
+  verificationUri: string;
+}
+
+/** Drives an OAuth device-flow sign-in end to end, shared by onboarding, the
+ *  New Project GitHub gate, and Settings. Owns the mechanics — emit the code,
+ *  open the browser, poll, then persist the profile and refresh the account +
+ *  GitHub connection — leaving each caller to render `device`/`error`/`busy`
+ *  however it likes and pass an `onConnected` for its own follow-up (e.g. an
+ *  onboarding step advance).
+ *
+ *  Late results from a superseded/cancelled attempt are dropped via a
+ *  monotonic run id: the backend keeps polling until the code expires, but its
+ *  outcome no longer touches the UI or the store. */
+export function useGithubConnect(onConnected?: () => void) {
+  const refreshAccount = useAppStore((s) => s.refreshAccount);
+  const refreshGithub = useAppStore((s) => s.refreshGithub);
+
+  const [device, setDevice] = useState<DeviceInfo | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const runRef = useRef(0);
+  const onConnectedRef = useRef(onConnected);
+  onConnectedRef.current = onConnected;
+
+  const connect = useCallback(
+    async (provider = "github") => {
+      if (busy) return;
+      const runId = ++runRef.current;
+      const stale = () => runRef.current !== runId;
+      setBusy(provider);
+      setError(null);
+      setDevice(null);
+      // Default no-op so `finally` can always call it; listen() lives inside
+      // the try so an IPC failure surfaces as an error instead of throwing.
+      let unlisten: UnlistenFn = () => {};
+      try {
+        unlisten = await listen<{
+          provider: string;
+          user_code: string;
+          verification_uri: string;
+        }>("oauth:device-code", (e) => {
+          if (stale()) return;
+          setDevice({
+            provider: e.payload.provider,
+            userCode: e.payload.user_code,
+            verificationUri: e.payload.verification_uri,
+          });
+          void openExternal(e.payload.verification_uri).catch(() => {});
+        });
+        const profile = await invoke<OAuthProfile>("oauth_device_login", { provider });
+        if (stale()) return;
+        const account = await getOrCreateAccount();
+        await linkOAuthAccount(account.id, profile);
+        await refreshAccount();
+        // GitHub sign-in also granted repo access + persisted a token; reflect
+        // the connection so gated affordances unlock immediately.
+        if (provider === "github") await refreshGithub();
+        if (stale()) return;
+        setBusy(null);
+        setDevice(null);
+        onConnectedRef.current?.();
+      } catch (err) {
+        if (stale()) return;
+        setError(String(err));
+        setBusy(null);
+      } finally {
+        unlisten();
+      }
+    },
+    [busy, refreshAccount, refreshGithub],
+  );
+
+  /** Abandon the current attempt: invalidate its run id and clear UI state.
+   *  The backend poll runs on until the code expires but is ignored. */
+  const cancel = useCallback(() => {
+    runRef.current++;
+    setDevice(null);
+    setError(null);
+    setBusy(null);
+  }, []);
+
+  return { connect, cancel, device, error, busy };
+}

--- a/tests/components/RightPanel/delegation.test.ts
+++ b/tests/components/RightPanel/delegation.test.ts
@@ -34,6 +34,7 @@ function git(over: Partial<GitState> = {}): GitState {
     files: [],
     additions: 0,
     deletions: 0,
+    has_origin: true,
     ...over,
   };
 }

--- a/tests/components/RightPanel/primaryActions.test.ts
+++ b/tests/components/RightPanel/primaryActions.test.ts
@@ -14,6 +14,7 @@ function git(over: Partial<GitState> = {}): GitState {
     files: [],
     additions: 0,
     deletions: 0,
+    has_origin: true,
     ...over,
   };
 }
@@ -68,6 +69,53 @@ describe("changes-state sticky commit action", () => {
     const openKeys = secondaryFor("changes", { files: 2, prOpen: true }).map((s) => s.key);
     expect(openKeys).toContain("merge");
     expect(openKeys).not.toContain("agent-commit-pr"); // meaningless with a PR open
+  });
+});
+
+describe("offline / local-only gating", () => {
+  it("keeps local Commit as the changes primary when not connected", () => {
+    // Even with the sticky mode set to push/PR, an unconnected repo commits
+    // locally rather than showing a button that would fail.
+    const p = primaryFor("changes", {
+      files: 2,
+      commitAction: "agent-commit-pr",
+      githubConnected: false,
+    });
+    expect(p.key).toBe("agent-commit");
+  });
+
+  it("does not downgrade the primary when the mode is plain local Commit", () => {
+    const p = primaryFor("changes", {
+      files: 2,
+      commitAction: "agent-commit",
+      githubConnected: false,
+    });
+    expect(p.key).toBe("agent-commit");
+  });
+
+  it("offers Connect GitHub in the changes menu when not connected", () => {
+    const keys = secondaryFor("changes", { files: 2, githubConnected: false }).map((s) => s.key);
+    expect(keys).toContain("connect-github");
+    expect(keys).not.toContain("agent-commit-push");
+    // Local actions remain reachable.
+    expect(keys).toContain("stash");
+    expect(keys).toContain("discard");
+  });
+
+  it("offers Publish when connected but the repo has no origin", () => {
+    const keys = secondaryFor("changes", {
+      files: 2,
+      githubConnected: true,
+      hasOrigin: false,
+    }).map((s) => s.key);
+    expect(keys).toContain("publish");
+    expect(keys).not.toContain("connect-github");
+  });
+
+  it("replaces the pushed-state Open PR primary with Connect when offline", () => {
+    expect(primaryFor("pushed", { ahead: 1, githubConnected: false }).key).toBe("connect-github");
+    // Connected with an origin, it's the normal PR action.
+    expect(primaryFor("pushed", { ahead: 1 }).key).toBe("agent-open-pr");
   });
 });
 

--- a/tests/components/RightPanel/primaryActions.test.ts
+++ b/tests/components/RightPanel/primaryActions.test.ts
@@ -102,13 +102,14 @@ describe("offline / local-only gating", () => {
     expect(keys).toContain("discard");
   });
 
-  it("offers Publish when connected but the repo has no origin", () => {
+  it("offers both Publish visibilities when connected but the repo has no origin", () => {
     const keys = secondaryFor("changes", {
       files: 2,
       githubConnected: true,
       hasOrigin: false,
     }).map((s) => s.key);
-    expect(keys).toContain("publish");
+    expect(keys).toContain("publish"); // private (default)
+    expect(keys).toContain("publish-public");
     expect(keys).not.toContain("connect-github");
   });
 


### PR DESCRIPTION
## Summary

Third and final PR of the "make git/GitHub work under the hood" series. GitHub-unaware users no longer hit walls — any folder works, agents operate locally, and GitHub is requested only when an action genuinely needs it (push, PR, clone).

- **Any folder just works**: `add_workspace_repo` auto-initializes a non-repo folder (`git init` + an `--allow-empty` initial commit so worktrees can fork). A folder *inside* an existing repo is rejected with a pointer to the real root instead of splitting history.
- **Create offline**: New Project → Create makes a local repo and only publishes to GitHub when connected; the view says so and the git panel offers "Publish to GitHub" later.
- **Connect in place**: Clone and onboarding sign-in share a new `useGithubConnect` hook (device flow), replacing the old "install gh / run `gh auth login`" gate. Onboarding's previously-inline flow now routes through the same hook.
- **Settings**: Account gains a GitHub connect/disconnect control; disconnect clears the token and returns to local-only mode.
- **Git panel never fails on click**: a local-only repo (no origin) offers "Publish to GitHub" (publishes the project *root*, so its default branch — not the agent's working branch — becomes the GitHub default); when not connected, push/PR actions become "Connect GitHub". Local commit/stash/discard always work.
- **Quiet when local**: `GitState` gains `has_origin`; PR polls skip entirely when not connected, so a local-only user generates zero GitHub traffic. Shared connection state lives in the account store slice, refreshed on init and after connect/disconnect.

## Verification

- All 362 backend + 344 frontend tests pass (new: auto-init initializes-with-HEAD and rejects-nested-repo; five offline action-model cases). tsc / biome / clippy clean on touched files.
- Drove the GitHub-unaware path with a git-less config end to end: plain folder → init → initial commit authored as `Fletch <fletch@localhost>` (no `.gitconfig`) → worktree forks OK → local-only (no origin).

## Not verified live (needs the running app / a real session)

- The Publish-to-GitHub button (`publish_agent`) and the in-app device-flow consent screen — both require driving the live UI and a browser.
- The connect→unlock re-render in the git panel is wired and unit-tested at the model level, but not exercised in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)