### PR TITLE
feat: inline GitHub connect modal + local-dev OAuth config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,20 @@
-# Local signing/notarization config for `scripts/release-local.sh`.
+# Local config for `scripts/release-local.sh` and for local dev builds
+# (the OAuth keys below are read at build time by src-tauri/build.rs).
 # Copy to `.env` and fill in. NEVER commit the real `.env` (it is gitignored).
 # In CI these same values come from GitHub repository secrets (see docs/RELEASING.md).
+
+# --- OAuth client keys (baked into the binary at compile time; see
+#     src-tauri/src/oauth.rs). Without these, "Connect GitHub" and Google
+#     sign-in report "not configured". ---
+# GitHub OAuth App client ID, with Device Flow enabled:
+#   https://github.com/settings/developers → New OAuth App → tick
+#   "Enable Device Flow". The client ID is NOT secret and no client secret is
+#   needed for the device flow. Requested scopes: repo read:user user:email.
+QUORUM_GITHUB_CLIENT_ID=""
+# Google OAuth "TV and Limited Input device" client (identity sign-in only).
+# Optional — leave empty to disable Google sign-in.
+QUORUM_GOOGLE_CLIENT_ID=""
+QUORUM_GOOGLE_CLIENT_SECRET=""
 
 # --- macOS code signing + notarization (Apple Developer ID) ---
 # The full identity string from `security find-identity -v -p codesigning`.

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,14 +1,62 @@
+// OAuth client keys are baked into the binary at compile time via `option_env!`
+// (see src-tauri/src/oauth.rs). CI supplies them as process env from repository
+// secrets (see .github/workflows/release.yml). For local dev they'd otherwise
+// be empty — making "Connect GitHub"/Google sign-in report "not configured" —
+// so we also load a repo-root `.env` here and forward these keys into the
+// compile. A value already present in the environment always wins, so CI is
+// unaffected and a developer can still override `.env` with a shell export.
+const CONFIG_KEYS: [&str; 3] = [
+    "QUORUM_GITHUB_CLIENT_ID",
+    "QUORUM_GOOGLE_CLIENT_ID",
+    "QUORUM_GOOGLE_CLIENT_SECRET",
+];
+
 fn main() {
-    // OAuth client keys are embedded at compile time via `option_env!`. Cargo
-    // doesn't track those env vars on its own, so declare them here — otherwise
+    // build.rs runs with the package dir (src-tauri/) as CWD; the shared local
+    // `.env` lives at the repo root, one level up.
+    let dotenv = std::path::Path::new("../.env");
+    if dotenv.exists() {
+        println!("cargo::rerun-if-changed=../.env");
+        if let Ok(contents) = std::fs::read_to_string(dotenv) {
+            for (key, value) in parse_env(&contents) {
+                if CONFIG_KEYS.contains(&key.as_str()) && std::env::var_os(&key).is_none() {
+                    println!("cargo::rustc-env={key}={value}");
+                }
+            }
+        }
+    }
+
+    // Cargo doesn't track these env vars on its own, so declare them — otherwise
     // a cached/incremental build could ship a stale or empty value.
-    for key in [
-        "QUORUM_GITHUB_CLIENT_ID",
-        "QUORUM_GOOGLE_CLIENT_ID",
-        "QUORUM_GOOGLE_CLIENT_SECRET",
-    ] {
+    for key in CONFIG_KEYS {
         println!("cargo::rerun-if-env-changed={key}");
     }
 
     tauri_build::build()
+}
+
+/// Minimal `.env` parser: `KEY=VALUE` lines, optional `export ` prefix and
+/// surrounding quotes; `#` comments and blank lines skipped. Only the plain
+/// scalar values we forward (client ids/secrets) matter — lines we can't parse
+/// are ignored rather than erroring the build.
+fn parse_env(contents: &str) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let line = line.strip_prefix("export ").unwrap_or(line);
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let value = value.trim();
+        let unquoted = value
+            .strip_prefix('"')
+            .and_then(|v| v.strip_suffix('"'))
+            .or_else(|| value.strip_prefix('\'').and_then(|v| v.strip_suffix('\'')))
+            .unwrap_or(value);
+        out.push((key.trim().to_string(), unquoted.to_string()));
+    }
+    out
 }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -15,8 +15,12 @@ fn main() {
     // build.rs runs with the package dir (src-tauri/) as CWD; the shared local
     // `.env` lives at the repo root, one level up.
     let dotenv = std::path::Path::new("../.env");
+    // Track the path unconditionally (even when absent), so *creating* `.env`
+    // later reruns this script — otherwise a direct `cargo`/rust-analyzer build
+    // could keep the old empty `option_env!` values until an unrelated input
+    // changes.
+    println!("cargo::rerun-if-changed=../.env");
     if dotenv.exists() {
-        println!("cargo::rerun-if-changed=../.env");
         if let Ok(contents) = std::fs::read_to_string(dotenv) {
             for (key, value) in parse_env(&contents) {
                 if CONFIG_KEYS.contains(&key.as_str()) && std::env::var_os(&key).is_none() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { GithubConnectModal } from "./components/GithubConnect";
 import { History } from "./components/History";
 import { Onboarding } from "./components/Onboarding";
 import { RightPanel } from "./components/RightPanel";
@@ -161,6 +162,7 @@ export function App() {
       {historyOpen && <History />}
       <Settings />
       {onboardingOpen && <Onboarding />}
+      <GithubConnectModal />
 
       {lastError && (
         <div className="error-banner" role="alert">

--- a/src/app.css
+++ b/src/app.css
@@ -29,6 +29,7 @@
 @import "./components/Workspace/Draft.css";
 @import "./components/Settings/Settings.css";
 @import "./components/NewProject/NewProject.css";
+@import "./components/GithubConnect/GithubConnect.css";
 @import "./styles/shared/banners.css";
 @import "./styles/foundation/scrollbar.css";
 @import "./styles/shared/terminal.css";

--- a/src/components/GithubConnect/GithubConnect.css
+++ b/src/components/GithubConnect/GithubConnect.css
@@ -1,0 +1,103 @@
+/* App-level GitHub connect modal (see components/GithubConnect/index.tsx).
+   Compact centered dialog matching the new-project modal's chrome. */
+.ghc-modal {
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 380px;
+  max-width: calc(100vw - 48px);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-2);
+  border: 1px solid var(--bd);
+  border-radius: var(--r-md);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.4);
+  z-index: 401;
+  animation: ghc-in 0.18s var(--ease);
+}
+@keyframes ghc-in {
+  from {
+    opacity: 0;
+    transform: translate(-50%, calc(-50% + 6px)) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+  }
+}
+.ghc-h {
+  gap: 8px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--bd);
+  font-weight: 600;
+  color: var(--fg-0);
+}
+.ghc-h svg {
+  color: var(--accent);
+}
+.ghc-h span {
+  flex: 1;
+}
+.ghc-close {
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: var(--r-sm);
+  color: var(--fg-2);
+}
+.ghc-close:hover {
+  background: var(--hover);
+  color: var(--fg-0);
+}
+
+.ghc-body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 20px 16px 22px;
+  text-align: center;
+}
+.ghc-lede {
+  gap: 8px;
+  color: var(--fg-2);
+  line-height: 1.45;
+}
+.ghc-title {
+  font-weight: 600;
+  color: var(--fg-0);
+}
+.ghc-code-row {
+  gap: 8px;
+}
+.ghc-code {
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: var(--fg-0);
+}
+.ghc-uri {
+  color: var(--fg-3);
+}
+.ghc-actions {
+  gap: 8px;
+  margin-top: 4px;
+}
+.ghc-err {
+  width: 100%;
+  color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--danger) 35%, transparent);
+  border-radius: var(--r-sm);
+  padding: 8px 10px;
+  line-height: 1.4;
+}
+.ghc-spin {
+  animation: ghc-spin 0.9s linear infinite;
+  color: var(--fg-2);
+}
+@keyframes ghc-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/GithubConnect/index.tsx
+++ b/src/components/GithubConnect/index.tsx
@@ -16,9 +16,14 @@ export function GithubConnectModal() {
   const close = useAppStore((s) => s.closeGithubConnect);
   const { connect, cancel, device, error, busy } = useGithubConnect(close);
 
-  // Kick off the flow as soon as the modal opens (once per open). `connect`
-  // itself guards against re-entry while busy, and the ref keeps a dev-mode
-  // double-mount from starting two attempts.
+  // Kick off the flow once per open. We deliberately depend on `open` alone and
+  // reach `connect` through a ref: `connect`'s identity changes on every `busy`
+  // transition, so listing it here would re-run the effect mid-flow (e.g. right
+  // after a failure clears `busy`) — the `started` guard would still hold, but
+  // it's cleaner not to fire at all. `started` (reset only when the modal
+  // closes) also stops a dev-mode double-invoke from starting two attempts.
+  const connectRef = useRef(connect);
+  connectRef.current = connect;
   const started = useRef(false);
   useEffect(() => {
     if (!open) {
@@ -27,8 +32,8 @@ export function GithubConnectModal() {
     }
     if (started.current) return;
     started.current = true;
-    void connect();
-  }, [open, connect]);
+    void connectRef.current();
+  }, [open]);
 
   if (!open) return null;
 

--- a/src/components/GithubConnect/index.tsx
+++ b/src/components/GithubConnect/index.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useRef } from "react";
+import { Icon } from "@/components/Icon";
+import { Button } from "@/components/ui/Button";
+import { CopyButton } from "@/components/ui/CopyButton";
+import { Scrim } from "@/components/ui/Scrim";
+import { useAppStore } from "@/store";
+import { useGithubConnect } from "@/util/useGithubConnect";
+
+/** App-level GitHub connect modal. Any "Connect GitHub" affordance opens it via
+ *  `openGithubConnect()` and the OAuth device flow starts immediately — one
+ *  click to begin, with the device code / any config error shown right here
+ *  instead of behind a detour into Settings. Mounted once at the app root;
+ *  renders nothing until opened. Closes itself on a successful connection. */
+export function GithubConnectModal() {
+  const open = useAppStore((s) => s.githubConnectOpen);
+  const close = useAppStore((s) => s.closeGithubConnect);
+  const { connect, cancel, device, error, busy } = useGithubConnect(close);
+
+  // Kick off the flow as soon as the modal opens (once per open). `connect`
+  // itself guards against re-entry while busy, and the ref keeps a dev-mode
+  // double-mount from starting two attempts.
+  const started = useRef(false);
+  useEffect(() => {
+    if (!open) {
+      started.current = false;
+      return;
+    }
+    if (started.current) return;
+    started.current = true;
+    void connect();
+  }, [open, connect]);
+
+  if (!open) return null;
+
+  const onClose = () => {
+    cancel();
+    close();
+  };
+
+  return (
+    <>
+      <Scrim onClose={onClose} zIndex={400} />
+      <div className="ghc-modal" role="dialog" aria-modal="true">
+        <div className="ghc-h flex-center text-base">
+          <Icon name="github" size={15} />
+          <span>Connect GitHub</span>
+          <button className="ghc-close flex-center" aria-label="Close" onClick={onClose}>
+            <Icon name="close" size={14} />
+          </button>
+        </div>
+
+        <div className="ghc-body">
+          {device ? (
+            <>
+              <div className="ghc-lede text-sm">
+                Finish signing in in the browser tab that just opened, then enter this code:
+              </div>
+              <div className="ghc-code-row flex-center">
+                <span className="ghc-code text-2xl">{device.userCode}</span>
+                <CopyButton text={device.userCode} />
+              </div>
+              <div className="ghc-uri mono text-sm">{device.verificationUri}</div>
+              <Button variant="outline" size="sm" onClick={onClose}>
+                Cancel
+              </Button>
+            </>
+          ) : error ? (
+            <>
+              <div className="ghc-title text-base">Couldn’t connect</div>
+              <div className="ghc-err text-sm">{error}</div>
+              <div className="ghc-actions flex-center">
+                <Button variant="primary" disabled={!!busy} onClick={() => void connect()}>
+                  Try again
+                </Button>
+                <Button variant="outline" onClick={onClose}>
+                  Close
+                </Button>
+              </div>
+            </>
+          ) : (
+            <div className="ghc-lede flex-center text-sm">
+              <Icon name="refresh" size={14} className="ghc-spin" />
+              Starting GitHub sign-in…
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/RightPanel/GitPanel/hooks/useGitActions.ts
+++ b/src/components/RightPanel/GitPanel/hooks/useGitActions.ts
@@ -75,7 +75,7 @@ export function useGitActions(ctx: GitActionsCtx) {
   const deleteBranch = useAppStore((s) => s.deleteBranch);
   const delegateGitAction = useAppStore((s) => s.delegateGitAction);
   const seedComposer = useAppStore((s) => s.seedComposer);
-  const openSettingsScreen = useAppStore((s) => s.openSettingsScreen);
+  const openGithubConnect = useAppStore((s) => s.openGithubConnect);
 
   // Hand control to the coding agent: it writes the judgment part (message /
   // description / conflict edits) and executes the mutation through the app's
@@ -109,9 +109,9 @@ export function useGitActions(ctx: GitActionsCtx) {
 
     switch (key) {
       case "connect-github":
-        // The device flow lives in Settings → Account; take the user there.
-        openSettingsScreen("account");
-        showNotice("Connect GitHub to push & open pull requests");
+        // Start the OAuth device flow right here (in the app-level modal), so a
+        // single click begins connecting instead of detouring through Settings.
+        openGithubConnect();
         break;
       case "publish":
       case "publish-public": {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -275,6 +275,11 @@ export interface UiSlice {
    *  by the target pane on mount (e.g. open the new-custom-agent editor
    *  straight from the composer's agent picker). */
   settingsIntent: SettingsIntent | null;
+  /** GitHub connect modal: a small app-level overlay that runs the OAuth
+   *  device flow inline, so any "Connect GitHub" affordance (e.g. the Git
+   *  panel) can start signing in on the first click instead of detouring
+   *  through Settings. */
+  githubConnectOpen: boolean;
   /** First-run onboarding overlay. `onboardingComplete` is persisted (DB
    *  settings); the overlay auto-opens for new users on init and is
    *  re-openable any time from Settings › General. */
@@ -302,6 +307,9 @@ export interface UiSlice {
   setSettingsSection: (section: SettingsSection) => void;
   /** Clear a consumed `settingsIntent` so it fires only once. */
   clearSettingsIntent: () => void;
+  /** Open / close the GitHub connect modal (the device flow starts on open). */
+  openGithubConnect: () => void;
+  closeGithubConnect: () => void;
   /** Open the onboarding overlay (e.g. "Replay tour" from Settings). */
   openOnboarding: () => void;
   /** Dismiss onboarding and mark it complete so it won't auto-open again. */

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -12,6 +12,7 @@ export const createUiSlice: SliceCreator<UiSlice> = (set, get) => ({
   settingsScreenOpen: false,
   settingsSection: "general" as SettingsSection,
   settingsIntent: null,
+  githubConnectOpen: false,
   onboardingOpen: false,
   onboardingComplete: false,
   historyOpen: false,
@@ -35,6 +36,8 @@ export const createUiSlice: SliceCreator<UiSlice> = (set, get) => ({
   closeSettingsScreen: () => set({ settingsScreenOpen: false }),
   setSettingsSection: (section) => set({ settingsSection: section }),
   clearSettingsIntent: () => set({ settingsIntent: null }),
+  openGithubConnect: () => set({ githubConnectOpen: true }),
+  closeGithubConnect: () => set({ githubConnectOpen: false }),
   openOnboarding: () => set({ onboardingOpen: true }),
   closeOnboarding: () => {
     const firstCompletion = !get().onboardingComplete;


### PR DESCRIPTION
## Problem

Connecting to GitHub to push/open PRs was broken in two ways:

1. **"GitHub is not configured"** — the device-flow needs `QUORUM_GITHUB_CLIENT_ID`, baked in at compile time via `option_env!` (`oauth.rs`). It was only ever supplied by CI secrets and was never documented, so any local/dev build compiled it empty and reported *"GitHub sign-in is not configured"*.
2. **Detour + hidden error** — the Git-panel "Connect GitHub" button routed to Settings → Account, requiring another click to start the flow and only then revealing the config error. Multiple clicks to surface the problem.

## Changes

**Config plumbing**
- `src-tauri/build.rs` loads the repo-root `.env` at build time and forwards `QUORUM_GITHUB_CLIENT_ID` / `QUORUM_GOOGLE_CLIENT_*` into the compile. A value already in the environment always wins, so CI (which supplies them as process env) is unaffected, and this also covers direct `cargo` / rust-analyzer builds.
- `.env.example` now documents the OAuth keys (GitHub OAuth App with Device Flow enabled; client ID is not secret, no client secret needed).

**Inline connect (UX)**
- New reusable `GithubConnectModal` (`src/components/GithubConnect/`), mounted once at the app root and driven by store state (`githubConnectOpen` + `openGithubConnect`/`closeGithubConnect` in the ui slice). It **auto-starts the OAuth device flow on open**, shows the user code + verification URL (browser opens automatically), surfaces any config/sign-in error **in place**, and closes on success.
- The Git-panel `connect-github` action (`useGitActions.ts`) now calls `openGithubConnect()` instead of `openSettingsScreen("account")` — one click begins connecting.

Existing Settings and New-Project connect surfaces are unchanged (they already run the flow inline); adopting this modal there to remove the small device-code-UI duplication is a possible follow-up.

## Setup

Add the client ID to a gitignored repo-root `.env`:

```
QUORUM_GITHUB_CLIENT_ID="Iv1.xxxxxxxx"
```

## Testing

- `.env` parser in `build.rs` verified standalone against quoted / `export` / comment / empty / malformed lines.
- Frontend `tsc`/`biome` not run in this worktree (no `node_modules`); prop shapes were checked manually. Recommend `bun run check && bun run lint` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)