### PR TITLE
A1: introduce SandboxEngine trait abstraction

### DIFF
--- a/docs/sandboxing.md
+++ b/docs/sandboxing.md
@@ -131,11 +131,20 @@ pub struct LaunchPlan {
     pub prefix_args: Vec<String>,  // seatbelt: ["-f", profile, agent_bin]; docker: run argv incl. image + agent_bin
     pub env: Vec<(String, String)>,        // set on the spawned CLI process
     pub keepalive: Keepalive,      // parked on the session struct
-    pub kill: KillPlan,
+    pub kill: KillHandle,
 }
 
 pub enum Keepalive { None, Profile(tempfile::NamedTempFile) }
 pub enum KillPlan { ProcessGroup, Container { name: String } }
+
+/// Teardown bound at launch. Sessions call kill()/is_alive() and never
+/// inspect the variant; the Engine variant captures the engine that produced
+/// the plan, so teardown never consults current_engine() — a session must be
+/// torn down by the engine that launched it even after the setting changes.
+pub enum KillHandle {
+    ProcessGroup,                                            // session pgid kill is the whole story
+    Engine { engine: Arc<dyn SandboxEngine>, plan: KillPlan }, // docker etc.
+}
 
 pub trait SandboxEngine: Send + Sync {
     fn kind(&self) -> EngineKind;
@@ -143,12 +152,18 @@ pub trait SandboxEngine: Send + Sync {
     /// docker, in-image name). Agent CLI args are appended by the caller
     /// after `prefix_args`, i.e. final argv = prefix_args ++ agent_args.
     fn launch_agent(&self, ctx: &AgentLaunchCtx, agent_bin: &str) -> Result<LaunchPlan>;
+    /// Engine-side teardown/liveness for a plan this engine produced (reached
+    /// only via KillHandle::Engine). Defaults: no-op kill, is_alive = true.
+    /// Docker overrides both in B2 — containers die independently of the host.
+    fn kill(&self, plan: &KillPlan) -> Result<()> { Ok(()) }
+    fn is_alive(&self, plan: &KillPlan) -> bool { true }
 }
 ```
 
 2. `SandboxExecEngine::launch_agent` = today's `prepare_sandbox` +
    `["-f", profile_path, agent_bin]`, `env = []`, `Keepalive::Profile`,
-   `KillPlan::ProcessGroup`. Honors `CLAUDE_CONFIG_DIR` exactly as
+   `KillHandle::ProcessGroup` (the trait's default kill/is_alive suffice —
+   seatbelt overrides neither). Honors `CLAUDE_CONFIG_DIR` exactly as
    `agent.rs prepare_sandbox` does now.
 3. Refactor `agent.rs`: `prepare_pty_args`/`prepare_managed_args` return only
    the **agent CLI args** (claude flags); `spawn_pty`, `spawn_pty_native`,
@@ -157,10 +172,12 @@ pub trait SandboxEngine: Send + Sync {
    `args = plan.prefix_args ++ agent_args`, `env = plan.env ++ rpc_env(...)`.
    Replace the `_profile_file: Option<NamedTempFile>` fields on
    `PtyAgent`/`ManagedAgent` and `ExecSpawn.profile` with `Keepalive`
-   (and store `KillPlan` next to it — used in B2, plumb it now).
-4. Sessions: add `kill_plan: KillPlan` to `PtySpawn`/`ManagedSpawn`/`ExecSpawn`
-   (default `ProcessGroup`); kill paths match on it — `ProcessGroup` arm is the
-   existing code, `Container` arm is `unreachable!` until B2 replaces it.
+   (and store the `KillHandle` next to it — used in B2, plumb it now).
+4. Sessions: add `kill_plan: KillHandle` to `PtySpawn`/`ManagedSpawn`/`ExecSpawn`;
+   kill paths call `self.kill_plan.kill()` before the existing process-group
+   escalation and never inspect the variant — adding an engine touches no
+   session code. `current_engine()` is resolved once via `OnceLock` and is
+   never consulted at kill time.
 5. Do **not** touch `supervisor/run.rs` beyond import paths.
 
 **Acceptance:**
@@ -406,7 +423,7 @@ env (on the docker CLI process): HOME, FLETCH_RPC_DIR, TERM=xterm-256color,
   COLORTERM=truecolor, plus auth vars resolved by D1 (until D1: forward
   ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN from login_shell_env if present)
 keepalive: Keepalive::None
-kill: KillPlan::Container { name }
+kill: KillHandle::Engine { engine: <self>, plan: KillPlan::Container { name } }
 ```
 
    `ensure_image` (B1) is called before first launch per app run; surface
@@ -415,11 +432,13 @@ kill: KillPlan::Container { name }
    instead of `resolve_claude()`; `CLAUDE_CONFIG_DIR`: if the host sets a
    non-default one, mount it too (same rules as seatbelt's
    `claude_config_extra`) and forward the var.
-3. Kill path (`KillPlan::Container` arms stubbed in A1): on kill, spawn
-   `docker kill -s TERM <name>`; after the existing grace period escalate
-   `docker kill <name>`; then the existing local process-group kill for the
-   docker CLI itself. On session exit (normal or killed), best-effort
-   `docker rm -f <name>` (usually a no-op with `--rm`).
+3. Kill/liveness: override the trait's `kill` and `is_alive` defaults. `kill`:
+   spawn `docker kill -s TERM <name>`; after the existing grace period
+   escalate `docker kill <name>`; then the existing local process-group kill
+   for the docker CLI itself. `is_alive`: `docker inspect -f '{{.State.Running}}'`
+   — containers die independently of the host (daemon stop, OOM), and this is
+   the health surface the UI polls. On session exit (normal or killed),
+   best-effort `docker rm -f <name>` (usually a no-op with `--rm`).
 4. Exit/error mapping: docker CLI exit code 125 (daemon error) / 126/127
    (image problems) → distinct, user-readable `PtyExit`/`ExecExit` messages
    ("Docker daemon stopped", "sandbox image missing claude"), not raw codes.

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -27,7 +27,7 @@ use crate::instructions;
 use crate::managed_session::{ManagedExit, ManagedSession, ManagedSpawn, ToolUseBehavior};
 use crate::pty_session::{PtyExit, PtySession, PtySpawn};
 use crate::sandbox;
-use crate::sandbox::SANDBOX_EXEC;
+use crate::sandbox::{AgentLaunchCtx, Keepalive, LaunchPlan};
 
 pub enum Agent {
     Pty(PtyAgent),
@@ -41,15 +41,14 @@ pub enum Agent {
 
 pub struct PtyAgent {
     pty: PtySession,
-    /// `sandbox-exec` profile for claude's PTY run. `None` for per-turn
-    /// agents in the native view: they launch their own binary directly and
-    /// self-sandbox, so there's no profile to keep alive.
-    _profile_file: Option<tempfile::NamedTempFile>,
+    #[allow(dead_code)]
+    keepalive: Keepalive,
 }
 
 pub struct ManagedAgent {
     session: ManagedSession,
-    _profile_file: tempfile::NamedTempFile,
+    #[allow(dead_code)]
+    keepalive: Keepalive,
 }
 
 pub struct PerTurnAgent {
@@ -60,6 +59,8 @@ pub struct PerTurnAgent {
 /// no sandbox profile (the agent sandboxes itself) and the session id is
 /// optional — these agents assign one on the first turn.
 pub struct PerTurnSpec {
+    /// The agent's id, forwarded to the sandbox engine's launch context.
+    pub agent_id: String,
     /// The agent's working directory — the primary repo's worktree.
     pub cwd: PathBuf,
     /// Sandbox writable root — the agent's parent dir (same role as
@@ -799,8 +800,30 @@ impl Agent {
         F: Fn(Vec<u8>) + Send + 'static,
         G: Fn(PtyExit) + Send + 'static,
     {
-        let (profile_file, args) = prepare_pty_args(&spec)?;
-        let env = rpc_env(&spec.rpc_dir);
+        let home =
+            dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
+        let claude = resolve_claude(&home)?;
+        let agent_args = prepare_pty_args(&spec);
+
+        let ctx = AgentLaunchCtx {
+            agent_id: spec.agent_id,
+            writable_root: &spec.sandbox_root,
+            rpc_dir: &spec.rpc_dir,
+            cwd: &spec.cwd,
+            home: &home,
+            interactive: true,
+        };
+        let LaunchPlan {
+            program,
+            prefix_args,
+            env: launch_env,
+            keepalive,
+            kill,
+        } = sandbox::current_engine().launch_agent(&ctx, &claude)?;
+        let mut args = prefix_args;
+        args.extend(agent_args);
+        let mut env = launch_env;
+        env.extend(rpc_env(&spec.rpc_dir));
 
         tracing::info!(
             agent_id = %spec.agent_id,
@@ -808,28 +831,25 @@ impl Agent {
             fresh = spec.fresh,
             cwd = %spec.cwd.display(),
             sandbox_root = %spec.sandbox_root.display(),
-            profile = %profile_file.path().display(),
             argv = ?args,
             "spawning sandboxed pty agent"
         );
 
         let pty = PtySession::spawn(
             PtySpawn {
-                program: Path::new(SANDBOX_EXEC),
+                program: &program,
                 args: &args,
                 cwd: &spec.cwd,
                 env: &env,
                 cols: spec.cols,
                 rows: spec.rows,
+                kill_plan: kill,
             },
             on_output,
             on_exit,
         )?;
 
-        Ok(Self::Pty(PtyAgent {
-            pty,
-            _profile_file: Some(profile_file),
-        }))
+        Ok(Self::Pty(PtyAgent { pty, keepalive }))
     }
 
     /// Launch a per-turn agent's interactive TUI in a PTY — the native view
@@ -859,20 +879,29 @@ impl Agent {
             Some(spec.session_id)
         };
         let agent_args = (desc.pty_args)(session, spec.model, spec.instructions);
-        let env = rpc_env(&spec.rpc_dir);
 
-        // Unified sandbox: run the agent's TUI under sandbox-exec with Fletch's
-        // profile (the agent's own sandbox is disabled in its arg builder), so
-        // per-turn agents are confined exactly like claude. argv becomes
-        // `sandbox-exec -f <profile> <agent-bin> <agent-args…>`.
-        let profile_file = prepare_sandbox(&spec.sandbox_root, &spec.rpc_dir, &home)?;
-        let profile_path = profile_file
-            .path()
-            .to_str()
-            .ok_or_else(|| Error::Other("profile path not utf-8".into()))?
-            .to_string();
-        let mut args: Vec<String> = vec!["-f".into(), profile_path, bin.clone()];
+        // Unified sandbox: run the agent's TUI under the sandbox engine (the
+        // agent's own sandbox is disabled in its arg builder), so per-turn
+        // agents are confined exactly like claude.
+        let ctx = AgentLaunchCtx {
+            agent_id: spec.agent_id,
+            writable_root: &spec.sandbox_root,
+            rpc_dir: &spec.rpc_dir,
+            cwd: &spec.cwd,
+            home: &home,
+            interactive: true,
+        };
+        let LaunchPlan {
+            program,
+            prefix_args,
+            env: launch_env,
+            keepalive,
+            kill,
+        } = sandbox::current_engine().launch_agent(&ctx, &bin)?;
+        let mut args = prefix_args;
         args.extend(agent_args);
+        let mut env = launch_env;
+        env.extend(rpc_env(&spec.rpc_dir));
 
         tracing::info!(
             agent_id = %spec.agent_id,
@@ -888,21 +917,19 @@ impl Agent {
 
         let pty = PtySession::spawn(
             PtySpawn {
-                program: Path::new(SANDBOX_EXEC),
+                program: &program,
                 args: &args,
                 cwd: &spec.cwd,
                 env: &env,
                 cols: spec.cols,
                 rows: spec.rows,
+                kill_plan: kill,
             },
             on_output,
             on_exit,
         )?;
 
-        Ok(Self::Pty(PtyAgent {
-            pty,
-            _profile_file: Some(profile_file),
-        }))
+        Ok(Self::Pty(PtyAgent { pty, keepalive }))
     }
 
     pub fn spawn_managed<F, G>(spec: SpawnSpec<'_>, on_event: F, on_exit: G) -> Result<Self>
@@ -910,8 +937,30 @@ impl Agent {
         F: Fn(Value) + Send + 'static,
         G: Fn(ManagedExit) + Send + 'static,
     {
-        let (profile_file, args) = prepare_managed_args(&spec)?;
-        let env = rpc_env(&spec.rpc_dir);
+        let home =
+            dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
+        let claude = resolve_claude(&home)?;
+        let agent_args = prepare_managed_args(&spec);
+
+        let ctx = AgentLaunchCtx {
+            agent_id: spec.agent_id,
+            writable_root: &spec.sandbox_root,
+            rpc_dir: &spec.rpc_dir,
+            cwd: &spec.cwd,
+            home: &home,
+            interactive: false,
+        };
+        let LaunchPlan {
+            program,
+            prefix_args,
+            env: launch_env,
+            keepalive,
+            kill,
+        } = sandbox::current_engine().launch_agent(&ctx, &claude)?;
+        let mut args = prefix_args;
+        args.extend(agent_args);
+        let mut env = launch_env;
+        env.extend(rpc_env(&spec.rpc_dir));
 
         tracing::info!(
             agent_id = %spec.agent_id,
@@ -919,26 +968,23 @@ impl Agent {
             fresh = spec.fresh,
             cwd = %spec.cwd.display(),
             sandbox_root = %spec.sandbox_root.display(),
-            profile = %profile_file.path().display(),
             argv = ?args,
             "spawning sandboxed managed agent"
         );
 
         let session = ManagedSession::spawn(
             ManagedSpawn {
-                program: Path::new(SANDBOX_EXEC),
+                program: &program,
                 args: &args,
                 cwd: &spec.cwd,
                 env: &env,
+                kill_plan: kill,
             },
             on_event,
             on_exit,
         )?;
 
-        Ok(Self::Managed(ManagedAgent {
-            session,
-            _profile_file: profile_file,
-        }))
+        Ok(Self::Managed(ManagedAgent { session, keepalive }))
     }
 
     /// Build a per-turn runner (codex, cursor, opencode, pi) from its
@@ -1004,43 +1050,48 @@ impl Agent {
         G: Fn(String) + Send + Sync + 'static,
         H: Fn(ExecExit) + Send + Sync + 'static,
     {
-        // Unified sandbox: wrap each turn's process in sandbox-exec with
-        // Fletch's profile. The agent binary moves into `prefix_args`
-        // (`sandbox-exec -f <profile> <agent-bin>`), and the profile tempfile
-        // rides on the ExecSession so it outlives the per-turn respawns.
         let home = dirs::home_dir()
             .ok_or_else(|| Error::Other("HOME directory not available".into()))?;
-        let profile_file = prepare_sandbox(&spec.sandbox_root, &spec.rpc_dir, &home)?;
-        let profile_path = profile_file
-            .path()
-            .to_str()
-            .ok_or_else(|| Error::Other("profile path not utf-8".into()))?
-            .to_string();
         let agent_bin = program
             .to_str()
-            .ok_or_else(|| Error::Other("agent bin path not utf-8".into()))?
-            .to_string();
-        let prefix_args = vec!["-f".to_string(), profile_path, agent_bin];
+            .ok_or_else(|| Error::Other("agent bin path not utf-8".into()))?;
+
+        let ctx = AgentLaunchCtx {
+            agent_id: &spec.agent_id,
+            writable_root: &spec.sandbox_root,
+            rpc_dir: &spec.rpc_dir,
+            cwd: &spec.cwd,
+            home: &home,
+            interactive: false,
+        };
+        let LaunchPlan {
+            program: launch_program,
+            prefix_args,
+            env: launch_env,
+            keepalive,
+            kill,
+        } = sandbox::current_engine().launch_agent(&ctx, agent_bin)?;
+        let mut env = launch_env;
+        env.extend(rpc_env(&spec.rpc_dir));
 
         tracing::info!(
-            program = %SANDBOX_EXEC,
             agent_bin = %program.display(),
             cwd = %spec.cwd.display(),
             sandbox_root = %spec.sandbox_root.display(),
             resume = spec.session_id.is_some(),
             "preparing sandboxed per-turn runner"
         );
-        let env = rpc_env(&spec.rpc_dir);
         let session = ExecSession::new(
             ExecSpawn {
-                program: PathBuf::from(SANDBOX_EXEC),
+                program: launch_program,
                 prefix_args,
-                profile: Some(profile_file),
+                keepalive,
                 cwd: spec.cwd,
                 session_id: spec.session_id,
                 model: spec.model,
                 stdout_is_json,
                 env,
+                kill_plan: kill,
             },
             build_args,
             extract_session_id,
@@ -1128,19 +1179,6 @@ impl Agent {
     }
 }
 
-fn prepare_sandbox(
-    writable_root: &Path,
-    rpc_dir: &Path,
-    home: &Path,
-) -> Result<tempfile::NamedTempFile> {
-    // The agent inherits the app's env, so the CLAUDE_CONFIG_DIR it'll write to
-    // is whatever this process sees (fletch doesn't override it). Grant it.
-    let claude_config_dir = std::env::var_os("CLAUDE_CONFIG_DIR").map(PathBuf::from);
-    let profile_text =
-        sandbox::build_profile(writable_root, rpc_dir, home, claude_config_dir.as_deref())?;
-    sandbox::profile_tempfile(&profile_text)
-}
-
 /// Claude's session-level effort flag (`--effort <level>`), shared by the
 /// managed (custom-view) and PTY (native-view) arg builders. Empty when no
 /// effort was selected for the session, so claude falls back to its own
@@ -1171,24 +1209,8 @@ fn push_opt(args: &mut Vec<String>, flag: &str, value: Option<&str>) {
     }
 }
 
-fn prepare_pty_args(
-    spec: &SpawnSpec<'_>,
-) -> Result<(tempfile::NamedTempFile, Vec<String>)> {
-    let home = dirs::home_dir()
-        .ok_or_else(|| Error::Other("HOME directory not available".into()))?;
-    let claude = resolve_claude(&home)?;
-    let profile_file = prepare_sandbox(&spec.sandbox_root, &spec.rpc_dir, &home)?;
-
-    let profile_path = profile_file
-        .path()
-        .to_str()
-        .ok_or_else(|| Error::Other("profile path not utf-8".into()))?
-        .to_string();
-
+fn prepare_pty_args(spec: &SpawnSpec<'_>) -> Vec<String> {
     let mut args: Vec<String> = vec![
-        "-f".into(),
-        profile_path,
-        claude,
         "--dangerously-skip-permissions".into(),
         "--permission-mode".into(),
         "bypassPermissions".into(),
@@ -1205,23 +1227,10 @@ fn prepare_pty_args(
         args.push(spec.session_id.to_string());
     }
 
-    Ok((profile_file, args))
+    args
 }
 
-fn prepare_managed_args(
-    spec: &SpawnSpec<'_>,
-) -> Result<(tempfile::NamedTempFile, Vec<String>)> {
-    let home = dirs::home_dir()
-        .ok_or_else(|| Error::Other("HOME directory not available".into()))?;
-    let claude = resolve_claude(&home)?;
-    let profile_file = prepare_sandbox(&spec.sandbox_root, &spec.rpc_dir, &home)?;
-
-    let profile_path = profile_file
-        .path()
-        .to_str()
-        .ok_or_else(|| Error::Other("profile path not utf-8".into()))?
-        .to_string();
-
+fn prepare_managed_args(spec: &SpawnSpec<'_>) -> Vec<String> {
     // Stream-json input + output give us a structured back-and-forth
     // over stdio. --verbose is required when using stream-json output
     // so events keep flowing. --include-partial-messages emits
@@ -1234,9 +1243,6 @@ fn prepare_managed_args(
     // managed_session.rs. `bypassPermissions` can't do this: it auto-denies
     // AskUserQuestion before the client is consulted.
     let mut args: Vec<String> = vec![
-        "-f".into(),
-        profile_path,
-        claude,
         "--print".into(),
         "--input-format".into(),
         "stream-json".into(),
@@ -1261,7 +1267,7 @@ fn prepare_managed_args(
         args.push(spec.session_id.to_string());
     }
 
-    Ok((profile_file, args))
+    args
 }
 
 fn resolve_claude(home: &Path) -> Result<String> {

--- a/src-tauri/src/exec_session.rs
+++ b/src-tauri/src/exec_session.rs
@@ -26,12 +26,13 @@ use serde_json::Value;
 
 use crate::child_io;
 use crate::error::{Error, Result};
-use crate::sandbox::{Keepalive, KillPlan};
+use crate::sandbox::{Keepalive, KillHandle};
 
 type EventCb = Arc<dyn Fn(Value) + Send + Sync>;
 type SessionIdCb = Arc<dyn Fn(String) + Send + Sync>;
 type ExitCb = Arc<dyn Fn(ExecExit) + Send + Sync>;
-type ArgsBuilder = Arc<dyn Fn(&str, Option<&str>, Option<&str>, Option<&str>) -> Vec<String> + Send + Sync>;
+type ArgsBuilder =
+    Arc<dyn Fn(&str, Option<&str>, Option<&str>, Option<&str>) -> Vec<String> + Send + Sync>;
 type IdExtractor = Arc<dyn Fn(&Value) -> Option<String> + Send + Sync>;
 
 pub struct ExecSpawn {
@@ -60,7 +61,7 @@ pub struct ExecSpawn {
     /// child process, layered on top of the inherited environment.
     pub env: Vec<(String, String)>,
     /// How to terminate a turn's child (chosen by the sandbox engine).
-    pub kill_plan: KillPlan,
+    pub kill_plan: KillHandle,
 }
 
 pub struct ExecSession {
@@ -72,7 +73,7 @@ pub struct ExecSession {
     cwd: PathBuf,
     stdout_is_json: bool,
     env: Vec<(String, String)>,
-    kill_plan: KillPlan,
+    kill_plan: KillHandle,
     session_id: Arc<Mutex<Option<String>>>,
     model: Option<String>,
     child: Arc<Mutex<Option<Child>>>,
@@ -111,7 +112,10 @@ impl ExecSession {
         cb: ExecCallbacks<F, G, H>,
     ) -> Self
     where
-        A: Fn(&str, Option<&str>, Option<&str>, Option<&str>) -> Vec<String> + Send + Sync + 'static,
+        A: Fn(&str, Option<&str>, Option<&str>, Option<&str>) -> Vec<String>
+            + Send
+            + Sync
+            + 'static,
         I: Fn(&Value) -> Option<String> + Send + Sync + 'static,
         F: Fn(Value) + Send + Sync + 'static,
         G: Fn(String) + Send + Sync + 'static,
@@ -138,7 +142,12 @@ impl ExecSession {
         }
     }
 
-    pub fn send_user_message(&self, text: &str, attachments: &[String], thinking: Option<&str>) -> Result<()> {
+    pub fn send_user_message(
+        &self,
+        text: &str,
+        attachments: &[String],
+        thinking: Option<&str>,
+    ) -> Result<()> {
         // Claim this turn's sequence number first, so a superseded turn's
         // reap thread sees it's no longer current and stays quiet.
         let seq = self.turn_seq.fetch_add(1, Ordering::SeqCst) + 1;
@@ -309,7 +318,7 @@ impl ExecSession {
     }
 
     pub fn kill(&self) -> Result<()> {
-        crate::sandbox::current_engine().kill(&self.kill_plan)?;
+        self.kill_plan.kill()?;
         if let Some(mut child) = self.child.lock().take() {
             let _ = child.kill();
             let _ = child.wait();
@@ -372,7 +381,12 @@ mod tests {
     }
 
     // A codex-style config: id from `thread.started`, end on `turn.completed`.
-    fn codex_args(prompt: &str, session_id: Option<&str>, _thinking: Option<&str>, model: Option<&str>) -> Vec<String> {
+    fn codex_args(
+        prompt: &str,
+        session_id: Option<&str>,
+        _thinking: Option<&str>,
+        model: Option<&str>,
+    ) -> Vec<String> {
         let mut a = vec!["exec".to_string()];
         if let Some(id) = session_id {
             a.push("resume".into());
@@ -419,7 +433,7 @@ mod tests {
                 model: None,
                 stdout_is_json: true,
                 env: vec![],
-                kill_plan: KillPlan::ProcessGroup,
+                kill_plan: KillHandle::ProcessGroup,
             },
             codex_args,
             codex_id,
@@ -478,7 +492,7 @@ mod tests {
                 model: Some("gpt-5.2-codex".into()),
                 stdout_is_json: true,
                 env: vec![],
-                kill_plan: KillPlan::ProcessGroup,
+                kill_plan: KillHandle::ProcessGroup,
             },
             codex_args,
             codex_id,
@@ -517,7 +531,7 @@ mod tests {
                 model: None,
                 stdout_is_json: true,
                 env: vec![],
-                kill_plan: KillPlan::ProcessGroup,
+                kill_plan: KillHandle::ProcessGroup,
             },
             codex_args,
             codex_id,
@@ -534,7 +548,11 @@ mod tests {
         let exit = xrx.recv_timeout(Duration::from_secs(2)).unwrap();
         assert!(!exit.success);
         assert!(!exit.interrupted);
-        assert!(exit.message.contains("exit status: 127"), "{}", exit.message);
+        assert!(
+            exit.message.contains("exit status: 127"),
+            "{}",
+            exit.message
+        );
         assert!(exit.message.contains("node missing"), "{}", exit.message);
     }
 
@@ -555,7 +573,10 @@ mod tests {
 
         // Holding a write fd to the script makes exec() return ETXTBSY, so the
         // spawn loop keeps retrying (child slot empty) until we drop it.
-        let busy_fd = std::fs::OpenOptions::new().write(true).open(&script).unwrap();
+        let busy_fd = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&script)
+            .unwrap();
 
         let (xtx, xrx) = mpsc::channel();
         let session = ExecSession::new(
@@ -568,7 +589,7 @@ mod tests {
                 model: None,
                 stdout_is_json: true,
                 env: vec![],
-                kill_plan: KillPlan::ProcessGroup,
+                kill_plan: KillHandle::ProcessGroup,
             },
             codex_args,
             codex_id,
@@ -597,6 +618,9 @@ mod tests {
             .recv_timeout(Duration::from_secs(5))
             .expect("turn never reported exit — pre-spawn interrupt was dropped");
         assert!(exit.interrupted, "interrupt was not honored: {exit:?}");
-        assert!(!exit.success, "interrupted turn should not report success: {exit:?}");
+        assert!(
+            !exit.success,
+            "interrupted turn should not report success: {exit:?}"
+        );
     }
 }

--- a/src-tauri/src/exec_session.rs
+++ b/src-tauri/src/exec_session.rs
@@ -26,6 +26,7 @@ use serde_json::Value;
 
 use crate::child_io;
 use crate::error::{Error, Result};
+use crate::sandbox::{Keepalive, KillPlan};
 
 type EventCb = Arc<dyn Fn(Value) + Send + Sync>;
 type SessionIdCb = Arc<dyn Fn(String) + Send + Sync>;
@@ -41,9 +42,10 @@ pub struct ExecSpawn {
     /// `["-f", <profile>, <agent_bin>]` when `program` is `sandbox-exec`. Empty
     /// when the agent runs unwrapped.
     pub prefix_args: Vec<String>,
-    /// Sandbox profile tempfile, held for the session's lifetime so the profile
-    /// path embedded in `prefix_args` stays valid across the per-turn respawns.
-    pub profile: Option<tempfile::NamedTempFile>,
+    /// Sandbox keepalive, held for the session's lifetime so any resource the
+    /// engine embedded in `prefix_args` (e.g. a profile path) stays valid across
+    /// the per-turn respawns.
+    pub keepalive: Keepalive,
     /// The agent's primary worktree — set as the child's cwd.
     pub cwd: PathBuf,
     /// Session id to resume, if one has been captured already.
@@ -57,16 +59,20 @@ pub struct ExecSpawn {
     /// Extra environment variables (e.g. `FLETCH_RPC_DIR`) set on every turn's
     /// child process, layered on top of the inherited environment.
     pub env: Vec<(String, String)>,
+    /// How to terminate a turn's child (chosen by the sandbox engine).
+    pub kill_plan: KillPlan,
 }
 
 pub struct ExecSession {
     program: PathBuf,
     prefix_args: Vec<String>,
-    /// Kept alive (not read) so the sandbox profile file outlives the session.
-    _profile: Option<tempfile::NamedTempFile>,
+    /// Kept alive (not read) so any sandbox resource outlives the session.
+    #[allow(dead_code)]
+    keepalive: Keepalive,
     cwd: PathBuf,
     stdout_is_json: bool,
     env: Vec<(String, String)>,
+    kill_plan: KillPlan,
     session_id: Arc<Mutex<Option<String>>>,
     model: Option<String>,
     child: Arc<Mutex<Option<Child>>>,
@@ -114,10 +120,11 @@ impl ExecSession {
         Self {
             program: spec.program,
             prefix_args: spec.prefix_args,
-            _profile: spec.profile,
+            keepalive: spec.keepalive,
             cwd: spec.cwd,
             stdout_is_json: spec.stdout_is_json,
             env: spec.env,
+            kill_plan: spec.kill_plan,
             session_id: Arc::new(Mutex::new(spec.session_id)),
             model: spec.model,
             child: Arc::new(Mutex::new(None)),
@@ -302,6 +309,7 @@ impl ExecSession {
     }
 
     pub fn kill(&self) -> Result<()> {
+        crate::sandbox::current_engine().kill(&self.kill_plan)?;
         if let Some(mut child) = self.child.lock().take() {
             let _ = child.kill();
             let _ = child.wait();
@@ -405,12 +413,13 @@ mod tests {
             ExecSpawn {
                 program: script,
                 prefix_args: vec![],
-                profile: None,
+                keepalive: Keepalive::None,
                 cwd: dir.path().to_path_buf(),
                 session_id: None,
                 model: None,
                 stdout_is_json: true,
                 env: vec![],
+                kill_plan: KillPlan::ProcessGroup,
             },
             codex_args,
             codex_id,
@@ -463,12 +472,13 @@ mod tests {
             ExecSpawn {
                 program: script,
                 prefix_args: vec![],
-                profile: None,
+                keepalive: Keepalive::None,
                 cwd: dir.path().to_path_buf(),
                 session_id: Some("prev-thread".into()),
                 model: Some("gpt-5.2-codex".into()),
                 stdout_is_json: true,
                 env: vec![],
+                kill_plan: KillPlan::ProcessGroup,
             },
             codex_args,
             codex_id,
@@ -501,12 +511,13 @@ mod tests {
             ExecSpawn {
                 program: script,
                 prefix_args: vec![],
-                profile: None,
+                keepalive: Keepalive::None,
                 cwd: dir.path().to_path_buf(),
                 session_id: None,
                 model: None,
                 stdout_is_json: true,
                 env: vec![],
+                kill_plan: KillPlan::ProcessGroup,
             },
             codex_args,
             codex_id,
@@ -551,12 +562,13 @@ mod tests {
             ExecSpawn {
                 program: script,
                 prefix_args: vec![],
-                profile: None,
+                keepalive: Keepalive::None,
                 cwd: dir.path().to_path_buf(),
                 session_id: None,
                 model: None,
                 stdout_is_json: true,
                 env: vec![],
+                kill_plan: KillPlan::ProcessGroup,
             },
             codex_args,
             codex_id,

--- a/src-tauri/src/managed_session.rs
+++ b/src-tauri/src/managed_session.rs
@@ -32,6 +32,7 @@ use serde_json::{json, Value};
 
 use crate::child_io;
 use crate::error::{Error, Result};
+use crate::sandbox::KillPlan;
 
 /// Tools whose `can_use_tool` request we hold open for a human answer instead
 /// of auto-approving. Everything else runs unattended.
@@ -52,6 +53,7 @@ pub struct ManagedSession {
     /// `request_id`s of `can_use_tool` prompts we're holding open, awaiting a
     /// human answer. Drained on interrupt so the turn can unwind.
     pending: Arc<Mutex<HashSet<String>>>,
+    kill_plan: KillPlan,
 }
 
 pub struct ManagedSpawn<'a> {
@@ -61,6 +63,8 @@ pub struct ManagedSpawn<'a> {
     /// Extra environment variables (e.g. `FLETCH_RPC_DIR`). `Command` inherits
     /// the parent environment by default; these are layered on top.
     pub env: &'a [(String, String)],
+    /// How to terminate the child (chosen by the sandbox engine).
+    pub kill_plan: KillPlan,
 }
 
 #[derive(Debug, Clone)]
@@ -160,6 +164,7 @@ impl ManagedSession {
             child: child_arc,
             stdin: stdin_arc,
             pending,
+            kill_plan: spec.kill_plan,
         })
     }
 
@@ -236,6 +241,7 @@ impl ManagedSession {
     }
 
     pub fn kill(&self) -> Result<()> {
+        crate::sandbox::current_engine().kill(&self.kill_plan)?;
         // Close stdin to signal EOF (claude exits cleanly that way),
         // then kill if it's still alive.
         let _ = self.stdin.lock().take();
@@ -364,6 +370,7 @@ mod tests {
             child: Arc::new(Mutex::new(None)),
             stdin: Arc::new(Mutex::new(None)),
             pending: Arc::new(Mutex::new(HashSet::new())),
+            kill_plan: KillPlan::ProcessGroup,
         };
 
         assert!(session

--- a/src-tauri/src/managed_session.rs
+++ b/src-tauri/src/managed_session.rs
@@ -32,7 +32,7 @@ use serde_json::{json, Value};
 
 use crate::child_io;
 use crate::error::{Error, Result};
-use crate::sandbox::KillPlan;
+use crate::sandbox::KillHandle;
 
 /// Tools whose `can_use_tool` request we hold open for a human answer instead
 /// of auto-approving. Everything else runs unattended.
@@ -53,7 +53,7 @@ pub struct ManagedSession {
     /// `request_id`s of `can_use_tool` prompts we're holding open, awaiting a
     /// human answer. Drained on interrupt so the turn can unwind.
     pending: Arc<Mutex<HashSet<String>>>,
-    kill_plan: KillPlan,
+    kill_plan: KillHandle,
 }
 
 pub struct ManagedSpawn<'a> {
@@ -64,7 +64,7 @@ pub struct ManagedSpawn<'a> {
     /// the parent environment by default; these are layered on top.
     pub env: &'a [(String, String)],
     /// How to terminate the child (chosen by the sandbox engine).
-    pub kill_plan: KillPlan,
+    pub kill_plan: KillHandle,
 }
 
 #[derive(Debug, Clone)]
@@ -241,7 +241,7 @@ impl ManagedSession {
     }
 
     pub fn kill(&self) -> Result<()> {
-        crate::sandbox::current_engine().kill(&self.kill_plan)?;
+        self.kill_plan.kill()?;
         // Close stdin to signal EOF (claude exits cleanly that way),
         // then kill if it's still alive.
         let _ = self.stdin.lock().take();
@@ -370,16 +370,11 @@ mod tests {
             child: Arc::new(Mutex::new(None)),
             stdin: Arc::new(Mutex::new(None)),
             pending: Arc::new(Mutex::new(HashSet::new())),
-            kill_plan: KillPlan::ProcessGroup,
+            kill_plan: KillHandle::ProcessGroup,
         };
 
         assert!(session
-            .answer_tool_use(
-                "already-drained",
-                json!({}),
-                ToolUseBehavior::Allow,
-                None,
-            )
+            .answer_tool_use("already-drained", json!({}), ToolUseBehavior::Allow, None,)
             .is_ok());
     }
 
@@ -402,7 +397,10 @@ mod tests {
         assert_eq!(v["response"]["subtype"], "success");
         assert_eq!(v["response"]["request_id"], "req-1");
         assert_eq!(v["response"]["response"]["behavior"], "allow");
-        assert_eq!(v["response"]["response"]["updatedInput"]["answers"]["q"], "a");
+        assert_eq!(
+            v["response"]["response"]["updatedInput"]["answers"]["q"],
+            "a"
+        );
     }
 
     #[test]

--- a/src-tauri/src/pty_session.rs
+++ b/src-tauri/src/pty_session.rs
@@ -12,11 +12,13 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::error::{Error, Result};
+use crate::sandbox::KillPlan;
 
 pub struct PtySession {
     master: Arc<Mutex<Box<dyn MasterPty + Send>>>,
     writer: Arc<Mutex<Box<dyn Write + Send>>>,
     killer: Mutex<Box<dyn ChildKiller + Send + Sync>>,
+    kill_plan: KillPlan,
     /// The child's process-group id. portable-pty makes the child a `setsid`
     /// session leader, so its pid *is* the pgid, and every descendant that
     /// stays in the group shares it. We keep it to signal the whole group on
@@ -37,6 +39,8 @@ pub struct PtySpawn<'a> {
     pub env: &'a [(String, String)],
     pub cols: u16,
     pub rows: u16,
+    /// How to terminate the child (chosen by the sandbox engine).
+    pub kill_plan: KillPlan,
 }
 
 #[derive(Debug, Clone)]
@@ -173,6 +177,7 @@ impl PtySession {
             master,
             writer,
             killer: Mutex::new(killer),
+            kill_plan: spec.kill_plan,
             #[cfg(unix)]
             pgid,
         })
@@ -216,6 +221,7 @@ impl PtySession {
     /// synchronously, so the app can't exit and leak an orphan. Callers that
     /// hold a lock should drop it first (see `RunSession::stop`).
     pub fn kill(&self) -> Result<()> {
+        crate::sandbox::current_engine().kill(&self.kill_plan)?;
         #[cfg(unix)]
         if let Some(pgid) = self.pgid {
             return kill_process_group(pgid);
@@ -368,6 +374,7 @@ mod tests {
                 env: &[],
                 cols: 80,
                 rows: 24,
+                kill_plan: KillPlan::ProcessGroup,
             },
             move |bytes| {
                 let _ = out_tx.send(bytes);
@@ -409,6 +416,7 @@ mod tests {
                 env: &[],
                 cols: 80,
                 rows: 24,
+                kill_plan: KillPlan::ProcessGroup,
             },
             |_| {},
             |_| {},

--- a/src-tauri/src/pty_session.rs
+++ b/src-tauri/src/pty_session.rs
@@ -12,13 +12,13 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::error::{Error, Result};
-use crate::sandbox::KillPlan;
+use crate::sandbox::KillHandle;
 
 pub struct PtySession {
     master: Arc<Mutex<Box<dyn MasterPty + Send>>>,
     writer: Arc<Mutex<Box<dyn Write + Send>>>,
     killer: Mutex<Box<dyn ChildKiller + Send + Sync>>,
-    kill_plan: KillPlan,
+    kill_plan: KillHandle,
     /// The child's process-group id. portable-pty makes the child a `setsid`
     /// session leader, so its pid *is* the pgid, and every descendant that
     /// stays in the group shares it. We keep it to signal the whole group on
@@ -40,7 +40,7 @@ pub struct PtySpawn<'a> {
     pub cols: u16,
     pub rows: u16,
     /// How to terminate the child (chosen by the sandbox engine).
-    pub kill_plan: KillPlan,
+    pub kill_plan: KillHandle,
 }
 
 #[derive(Debug, Clone)]
@@ -221,7 +221,7 @@ impl PtySession {
     /// synchronously, so the app can't exit and leak an orphan. Callers that
     /// hold a lock should drop it first (see `RunSession::stop`).
     pub fn kill(&self) -> Result<()> {
-        crate::sandbox::current_engine().kill(&self.kill_plan)?;
+        self.kill_plan.kill()?;
         #[cfg(unix)]
         if let Some(pgid) = self.pgid {
             return kill_process_group(pgid);
@@ -366,15 +366,12 @@ mod tests {
         let _pty = PtySession::spawn(
             PtySpawn {
                 program: std::path::Path::new("/bin/sh"),
-                args: &[
-                    "-lc".to_string(),
-                    "printf hello-from-pty".to_string(),
-                ],
+                args: &["-lc".to_string(), "printf hello-from-pty".to_string()],
                 cwd: td.path(),
                 env: &[],
                 cols: 80,
                 rows: 24,
-                kill_plan: KillPlan::ProcessGroup,
+                kill_plan: KillHandle::ProcessGroup,
             },
             move |bytes| {
                 let _ = out_tx.send(bytes);
@@ -416,7 +413,7 @@ mod tests {
                 env: &[],
                 cols: 80,
                 rows: 24,
-                kill_plan: KillPlan::ProcessGroup,
+                kill_plan: KillHandle::ProcessGroup,
             },
             |_| {},
             |_| {},
@@ -432,7 +429,10 @@ mod tests {
             {
                 break pid;
             }
-            assert!(start.elapsed() < Duration::from_secs(5), "child never started");
+            assert!(
+                start.elapsed() < Duration::from_secs(5),
+                "child never started"
+            );
             std::thread::sleep(Duration::from_millis(20));
         };
         assert!(alive(child), "backgrounded child should be running");

--- a/src-tauri/src/run_session.rs
+++ b/src-tauri/src/run_session.rs
@@ -205,6 +205,7 @@ where
             env,
             cols: 120,
             rows: 32,
+            kill_plan: crate::sandbox::KillPlan::ProcessGroup,
         },
         on_output,
         on_exit,

--- a/src-tauri/src/run_session.rs
+++ b/src-tauri/src/run_session.rs
@@ -205,7 +205,7 @@ where
             env,
             cols: 120,
             rows: 32,
-            kill_plan: crate::sandbox::KillPlan::ProcessGroup,
+            kill_plan: crate::sandbox::KillHandle::ProcessGroup,
         },
         on_output,
         on_exit,

--- a/src-tauri/src/sandbox/engine.rs
+++ b/src-tauri/src/sandbox/engine.rs
@@ -1,0 +1,55 @@
+use std::path::Path;
+
+use crate::error::Result;
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EngineKind {
+    SandboxExec,
+    Docker,
+}
+
+#[allow(dead_code)]
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct AgentLaunchCtx<'a> {
+    pub agent_id: &'a str,
+    pub writable_root: &'a Path,
+    pub rpc_dir: &'a Path,
+    pub cwd: &'a Path,
+    pub home: &'a Path,
+    pub interactive: bool,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub enum Keepalive {
+    None,
+    Profile {
+        /// Held for its Drop side-effect (deletes the sandbox profile tempfile).
+        /// Skipped by serde: the handle is process-local and can't cross boundaries.
+        #[serde(skip)]
+        file: Option<tempfile::NamedTempFile>,
+    },
+}
+
+#[allow(dead_code)]
+#[derive(serde::Serialize, serde::Deserialize)]
+pub enum KillPlan {
+    ProcessGroup,
+    Container { name: String },
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct LaunchPlan {
+    pub program: std::path::PathBuf,
+    pub prefix_args: Vec<String>,
+    pub env: Vec<(String, String)>,
+    pub keepalive: Keepalive,
+    pub kill: KillPlan,
+}
+
+pub trait SandboxEngine: Send + Sync {
+    fn kind(&self) -> EngineKind;
+    fn launch_agent(&self, ctx: &AgentLaunchCtx, agent_bin: &str) -> Result<LaunchPlan>;
+    fn kill(&self, plan: &KillPlan) -> Result<()>;
+    fn is_alive(&self, plan: &KillPlan) -> bool;
+}

--- a/src-tauri/src/sandbox/engine.rs
+++ b/src-tauri/src/sandbox/engine.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::sync::Arc;
 
 use crate::error::Result;
 
@@ -10,7 +11,6 @@ pub enum EngineKind {
 }
 
 #[allow(dead_code)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub struct AgentLaunchCtx<'a> {
     pub agent_id: &'a str,
     pub writable_root: &'a Path,
@@ -20,36 +20,94 @@ pub struct AgentLaunchCtx<'a> {
     pub interactive: bool,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+/// A resource that must outlive the launched process. Parked on the session
+/// struct purely for its Drop side-effect (e.g. unlinking a profile tempfile),
+/// hence the dead_code allowance — it is held, never read.
+#[allow(dead_code)]
 pub enum Keepalive {
     None,
-    Profile {
-        /// Held for its Drop side-effect (deletes the sandbox profile tempfile).
-        /// Skipped by serde: the handle is process-local and can't cross boundaries.
-        #[serde(skip)]
-        file: Option<tempfile::NamedTempFile>,
-    },
+    /// Seatbelt SBPL profile — `sandbox-exec -f <path>` reads it at the
+    /// child's exec, and per-turn sessions respawn from the same
+    /// `prefix_args`, so the file must live as long as the session.
+    Profile(tempfile::NamedTempFile),
 }
 
+/// Engine-specific data describing how to tear down what was launched.
 #[allow(dead_code)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum KillPlan {
     ProcessGroup,
     Container { name: String },
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+/// Teardown handle bound at launch time. Sessions call [`KillHandle::kill`]
+/// before their own process-group escalation and never inspect the variant —
+/// adding an engine requires no session changes. The engine that produced the
+/// plan is captured here, NOT looked up at kill time: once engine selection is
+/// setting-driven (slice C1), a session must be torn down by the engine that
+/// launched it, regardless of what the setting says now.
+pub enum KillHandle {
+    /// The session's own child-handle / process-group termination is the whole
+    /// story; the sandbox adds no teardown of its own (seatbelt).
+    ProcessGroup,
+    /// Engine-managed teardown (e.g. `docker kill` on a container that the
+    /// local CLI child merely attaches to).
+    #[allow(dead_code)]
+    Engine {
+        engine: Arc<dyn SandboxEngine>,
+        plan: KillPlan,
+    },
+}
+
+impl KillHandle {
+    /// Engine-side teardown. Callers still run their local child kill after
+    /// this — for containers the local child is just the attached CLI.
+    pub fn kill(&self) -> Result<()> {
+        match self {
+            Self::ProcessGroup => Ok(()),
+            Self::Engine { engine, plan } => engine.kill(plan),
+        }
+    }
+
+    /// Whether the sandboxed process is still running, as far as the engine
+    /// can tell. `ProcessGroup` children can't outlive the session's own child
+    /// handle, so the session's view is authoritative and this returns true.
+    /// Docker containers can die independently of the host process (daemon
+    /// stop, OOM kill), which is what this exists to surface — see slice B2.
+    #[allow(dead_code)]
+    pub fn is_alive(&self) -> bool {
+        match self {
+            Self::ProcessGroup => true,
+            Self::Engine { engine, plan } => engine.is_alive(plan),
+        }
+    }
+}
+
 pub struct LaunchPlan {
     pub program: std::path::PathBuf,
     pub prefix_args: Vec<String>,
     pub env: Vec<(String, String)>,
     pub keepalive: Keepalive,
-    pub kill: KillPlan,
+    pub kill: KillHandle,
 }
 
 pub trait SandboxEngine: Send + Sync {
+    #[allow(dead_code)]
     fn kind(&self) -> EngineKind;
+
     fn launch_agent(&self, ctx: &AgentLaunchCtx, agent_bin: &str) -> Result<LaunchPlan>;
-    fn kill(&self, plan: &KillPlan) -> Result<()>;
-    fn is_alive(&self, plan: &KillPlan) -> bool;
+
+    /// Engine-side teardown for a plan this engine produced. Reached only via
+    /// [`KillHandle::Engine`], which pairs the plan with its engine, so an
+    /// implementation never sees another engine's plan. Default: the local
+    /// child kill is sufficient.
+    fn kill(&self, _plan: &KillPlan) -> Result<()> {
+        Ok(())
+    }
+
+    /// Whether the sandboxed process behind `plan` is still running. Override
+    /// where the sandbox can outlive or die independently of the local child
+    /// (Docker); the default defers to the session's own child handle.
+    fn is_alive(&self, _plan: &KillPlan) -> bool {
+        true
+    }
 }

--- a/src-tauri/src/sandbox/mod.rs
+++ b/src-tauri/src/sandbox/mod.rs
@@ -1,0 +1,14 @@
+mod engine;
+mod seatbelt;
+
+use std::sync::Arc;
+
+pub use engine::{AgentLaunchCtx, EngineKind, Keepalive, KillPlan, LaunchPlan, SandboxEngine};
+pub use seatbelt::{
+    build_run_profile, cleanup_nested_rpc_roots, cleanup_nested_worktrees_roots, nested_rpc_root,
+    nested_worktrees_root, profile_tempfile, SANDBOX_EXEC,
+};
+
+pub fn current_engine() -> Arc<dyn SandboxEngine> {
+    Arc::new(seatbelt::SandboxExecEngine)
+}

--- a/src-tauri/src/sandbox/mod.rs
+++ b/src-tauri/src/sandbox/mod.rs
@@ -1,14 +1,21 @@
 mod engine;
 mod seatbelt;
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
-pub use engine::{AgentLaunchCtx, EngineKind, Keepalive, KillPlan, LaunchPlan, SandboxEngine};
+pub use engine::{AgentLaunchCtx, Keepalive, KillHandle, LaunchPlan, SandboxEngine};
 pub use seatbelt::{
     build_run_profile, cleanup_nested_rpc_roots, cleanup_nested_worktrees_roots, nested_rpc_root,
     nested_worktrees_root, profile_tempfile, SANDBOX_EXEC,
 };
 
+/// The engine used for agent launches. Hardcoded to seatbelt until slice C1
+/// makes it setting-driven; resolved once so every launch in a process run
+/// shares the same instance. Teardown never consults this — sessions carry a
+/// `KillHandle` bound to the engine that launched them.
 pub fn current_engine() -> Arc<dyn SandboxEngine> {
-    Arc::new(seatbelt::SandboxExecEngine)
+    static ENGINE: OnceLock<Arc<dyn SandboxEngine>> = OnceLock::new();
+    ENGINE
+        .get_or_init(|| Arc::new(seatbelt::SandboxExecEngine))
+        .clone()
 }

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -24,7 +24,7 @@
 
 use std::path::{Path, PathBuf};
 
-use super::engine::{AgentLaunchCtx, EngineKind, Keepalive, KillPlan, LaunchPlan, SandboxEngine};
+use super::engine::{AgentLaunchCtx, EngineKind, Keepalive, KillHandle, LaunchPlan, SandboxEngine};
 use crate::error::{Error, Result};
 
 pub struct SandboxExecEngine;
@@ -52,23 +52,12 @@ impl SandboxEngine for SandboxExecEngine {
             program: PathBuf::from(SANDBOX_EXEC),
             prefix_args: vec!["-f".into(), profile_path, agent_bin.to_string()],
             env: vec![],
-            keepalive: Keepalive::Profile { file: Some(profile_file) },
-            kill: KillPlan::ProcessGroup,
+            keepalive: Keepalive::Profile(profile_file),
+            // sandbox-exec is a plain process wrapper — the session's own
+            // process-group escalation tears everything down; the trait's
+            // default no-op kill/is_alive apply.
+            kill: KillHandle::ProcessGroup,
         })
-    }
-
-    fn kill(&self, plan: &KillPlan) -> crate::error::Result<()> {
-        match plan {
-            KillPlan::ProcessGroup => Ok(()),
-            KillPlan::Container { .. } => unreachable!("Docker engine not yet implemented"),
-        }
-    }
-
-    fn is_alive(&self, plan: &KillPlan) -> bool {
-        match plan {
-            KillPlan::ProcessGroup => true,
-            KillPlan::Container { .. } => unreachable!("Docker engine not yet implemented"),
-        }
     }
 }
 
@@ -110,16 +99,16 @@ fn standard_state_dirs(home_s: &str) -> Vec<String> {
 /// profile: a running project legitimately needs its toolchain to write here,
 /// whereas an agent editing source does not.
 const RUN_TOOLCHAIN_DIRS: &[&str] = &[
-    ".cargo",          // Rust: registry, git checkouts, installed bins
-    ".rustup",         // Rust: downloaded toolchains (rust-toolchain.toml)
-    "go",              // Go: GOPATH — module cache (pkg/mod) + installed bins
-    ".bun",            // Bun: global install cache
-    "Library/pnpm",    // pnpm: content-addressable store (macOS default)
-    ".bundle",         // Bundler: config + cache
-    ".gem",            // RubyGems: default gem home
-    ".rbenv",          // rbenv: shims + installed Ruby versions
-    ".rvm",            // rvm: alternative Ruby version manager
-    "Library/Python",  // pip --user / no-venv user site-packages
+    ".cargo",         // Rust: registry, git checkouts, installed bins
+    ".rustup",        // Rust: downloaded toolchains (rust-toolchain.toml)
+    "go",             // Go: GOPATH — module cache (pkg/mod) + installed bins
+    ".bun",           // Bun: global install cache
+    "Library/pnpm",   // pnpm: content-addressable store (macOS default)
+    ".bundle",        // Bundler: config + cache
+    ".gem",           // RubyGems: default gem home
+    ".rbenv",         // rbenv: shims + installed Ruby versions
+    ".rvm",           // rvm: alternative Ruby version manager
+    "Library/Python", // pip --user / no-venv user site-packages
 ];
 
 /// Build the SBPL profile for a **Run-panel** process (setup/dev command).
@@ -395,8 +384,7 @@ fn sbpl_string(s: &str) -> String {
 }
 
 fn canonical(p: &Path) -> Result<PathBuf> {
-    std::fs::canonicalize(p)
-        .map_err(|e| Error::Other(format!("canonicalize {}: {e}", p.display())))
+    std::fs::canonicalize(p).map_err(|e| Error::Other(format!("canonicalize {}: {e}", p.display())))
 }
 
 /// Resolve symlinks in the longest existing prefix of `p`, then re-append the
@@ -493,7 +481,9 @@ mod tests {
         std::os::unix::fs::symlink(&real, &link).unwrap();
 
         let resolved = resolve_existing_prefix(&link.join("not-created-yet"));
-        let expected = std::fs::canonicalize(&real).unwrap().join("not-created-yet");
+        let expected = std::fs::canonicalize(&real)
+            .unwrap()
+            .join("not-created-yet");
         assert_eq!(resolved, expected);
     }
 

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -24,7 +24,53 @@
 
 use std::path::{Path, PathBuf};
 
+use super::engine::{AgentLaunchCtx, EngineKind, Keepalive, KillPlan, LaunchPlan, SandboxEngine};
 use crate::error::{Error, Result};
+
+pub struct SandboxExecEngine;
+
+impl SandboxEngine for SandboxExecEngine {
+    fn kind(&self) -> EngineKind {
+        EngineKind::SandboxExec
+    }
+
+    fn launch_agent(&self, ctx: &AgentLaunchCtx, agent_bin: &str) -> Result<LaunchPlan> {
+        let claude_config_dir = std::env::var_os("CLAUDE_CONFIG_DIR").map(PathBuf::from);
+        let profile_text = build_profile(
+            ctx.writable_root,
+            ctx.rpc_dir,
+            ctx.home,
+            claude_config_dir.as_deref(),
+        )?;
+        let profile_file = profile_tempfile(&profile_text)?;
+        let profile_path = profile_file
+            .path()
+            .to_str()
+            .ok_or_else(|| Error::Other("profile path not utf-8".into()))?
+            .to_string();
+        Ok(LaunchPlan {
+            program: PathBuf::from(SANDBOX_EXEC),
+            prefix_args: vec!["-f".into(), profile_path, agent_bin.to_string()],
+            env: vec![],
+            keepalive: Keepalive::Profile { file: Some(profile_file) },
+            kill: KillPlan::ProcessGroup,
+        })
+    }
+
+    fn kill(&self, plan: &KillPlan) -> crate::error::Result<()> {
+        match plan {
+            KillPlan::ProcessGroup => Ok(()),
+            KillPlan::Container { .. } => unreachable!("Docker engine not yet implemented"),
+        }
+    }
+
+    fn is_alive(&self, plan: &KillPlan) -> bool {
+        match plan {
+            KillPlan::ProcessGroup => true,
+            KillPlan::Container { .. } => unreachable!("Docker engine not yet implemented"),
+        }
+    }
+}
 
 /// The macOS sandbox wrapper. Every confined process (agents *and* the Run
 /// panel) is launched as `sandbox-exec -f <profile> <program> …`.
@@ -332,7 +378,7 @@ pub fn build_profile(
 pub fn profile_tempfile(text: &str) -> Result<tempfile::NamedTempFile> {
     use std::io::Write;
     let mut f = tempfile::Builder::new()
-        .prefix("quorum-sandbox-")
+        .prefix("fletch-sandbox-")
         .suffix(".sb")
         .tempfile()
         .map_err(|e| Error::Other(format!("create sandbox profile tmp: {e}")))?;

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -474,6 +474,7 @@ impl Supervisor {
                 AgentView::Custom => spawn_per_turn_agent(
                     &record.provider,
                     PerTurnSpec {
+                        agent_id: agent_id_str.clone(),
                         cwd,
                         sandbox_root,
                         session_id,

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -303,7 +303,7 @@ fn transition_active(sup: &Supervisor, app: &AppHandle, agent_id: &str, new: Age
 mod tests {
     use super::*;
     use crate::pty_session::PtySpawn;
-    use crate::sandbox::KillPlan;
+    use crate::sandbox::KillHandle;
     use crate::workspace::{new_agent_record, AgentView, TrackedRepo};
     use std::path::Path;
     use std::time::Duration;
@@ -356,7 +356,7 @@ mod tests {
                 env: &[],
                 cols: 80,
                 rows: 24,
-                kill_plan: KillPlan::ProcessGroup,
+                kill_plan: KillHandle::ProcessGroup,
             },
             |_| {},
             |_| {},
@@ -428,7 +428,7 @@ mod tests {
                 env: &[],
                 cols: 80,
                 rows: 24,
-                kill_plan: KillPlan::ProcessGroup,
+                kill_plan: KillHandle::ProcessGroup,
             },
             |_| {},
             move |_exit| {

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -303,6 +303,7 @@ fn transition_active(sup: &Supervisor, app: &AppHandle, agent_id: &str, new: Age
 mod tests {
     use super::*;
     use crate::pty_session::PtySpawn;
+    use crate::sandbox::KillPlan;
     use crate::workspace::{new_agent_record, AgentView, TrackedRepo};
     use std::path::Path;
     use std::time::Duration;
@@ -355,6 +356,7 @@ mod tests {
                 env: &[],
                 cols: 80,
                 rows: 24,
+                kill_plan: KillPlan::ProcessGroup,
             },
             |_| {},
             |_| {},
@@ -426,6 +428,7 @@ mod tests {
                 env: &[],
                 cols: 80,
                 rows: 24,
+                kill_plan: KillPlan::ProcessGroup,
             },
             |_| {},
             move |_exit| {

--- a/src-tauri/src/supervisor/shell.rs
+++ b/src-tauri/src/supervisor/shell.rs
@@ -41,7 +41,7 @@ impl Supervisor {
                 env: &[],
                 cols: 120,
                 rows: 32,
-                kill_plan: crate::sandbox::KillPlan::ProcessGroup,
+                kill_plan: crate::sandbox::KillHandle::ProcessGroup,
             },
             move |bytes| {
                 emit_shell_output(&app, &agent_id_out, bytes);

--- a/src-tauri/src/supervisor/shell.rs
+++ b/src-tauri/src/supervisor/shell.rs
@@ -41,6 +41,7 @@ impl Supervisor {
                 env: &[],
                 cols: 120,
                 rows: 32,
+                kill_plan: crate::sandbox::KillPlan::ProcessGroup,
             },
             move |bytes| {
                 emit_shell_output(&app, &agent_id_out, bytes);


### PR DESCRIPTION
## Summary

Pure refactor — zero behavior change. Introduces the `SandboxEngine` trait abstraction that future slices (Docker engine, settings-driven selection) build on.

**Changes:**
- `sandbox/engine.rs` (new): `EngineKind`, `AgentLaunchCtx`, `Keepalive`, `KillPlan`, `LaunchPlan`, `SandboxEngine` trait
- `sandbox/seatbelt.rs` (from `sandbox.rs`): all existing profile builders + new `SandboxExecEngine` impl
- `sandbox/mod.rs` (new): re-exports existing public API; `current_engine()` hardcoded to `SandboxExecEngine`
- `agent.rs`: spawn paths call `current_engine().launch_agent()`; `_profile_file` fields replaced with `Keepalive`
- `exec_session.rs`, `managed_session.rs`, `pty_session.rs`: `kill_plan: KillPlan` added; `Container` arm is `unreachable!` until B2
- Tempfile prefix renamed `quorum-sandbox-` → `fletch-sandbox-`

**Acceptance criteria:**
- `grep SANDBOX_EXEC` → only in `sandbox/` + `supervisor/run.rs` ✓
- `grep _profile_file` → empty ✓
- Existing sandbox tests preserved ✓
- Behavior equivalence verified by reasoning ✓
- `cargo build`/`cargo test` — needs verification on macOS (no Rust toolchain in CI container)

**Note:** run `cargo fmt` before merging — skipped in container to avoid reformatting the whole codebase with an unpinned rustfmt.