### PR TITLE
fix(rpc): idempotent mailbox processing + poll-only watcher guarantee (slice B3)

### DIFF
--- a/src-tauri/src/rpc.rs
+++ b/src-tauri/src/rpc.rs
@@ -243,9 +243,14 @@ async fn handle_request_file(
 
     let (resp, effects) = dispatcher.dispatch(stem, &req.op, &req.args).await;
 
+    // The op has now run and may have had side effects (e.g. a git push). Even
+    // if writing the response fails, we must remove the request file so the
+    // next poll tick can't re-acquire and re-dispatch it — a lost response (the
+    // caller times out waiting) is strictly safer than executing a
+    // side-effectful op twice. The request stays only if the process crashes
+    // before this point, which preserves at-least-once for un-dispatched ops.
     if let Err(e) = write_response_atomic(responses, stem, &resp) {
-        tracing::warn!(error = %e, id = %stem, "rpc: write response failed");
-        return effects;
+        tracing::error!(error = %e, id = %stem, "rpc: write response failed after dispatch; dropping request to avoid re-execution");
     }
 
     remove_request_file(path);
@@ -560,6 +565,49 @@ mod tests {
         let body = std::fs::read_to_string(rpc_dir.join("responses/req-7.json")).unwrap();
         let v: Value = serde_json::from_str(&body).unwrap();
         assert_eq!(v["ok"], true);
+    }
+
+    /// A response-write failure *after* dispatch must not leave the request
+    /// eligible for a second dispatch: the op already ran (possibly with side
+    /// effects like a git push), so the request file is dropped even though no
+    /// response was written. A later tick then finds nothing to re-execute.
+    #[tokio::test]
+    async fn write_failure_after_dispatch_does_not_redispatch() {
+        let td = tempfile::tempdir().unwrap();
+        let rpc_dir = td.path().join(".fletch-rpc");
+        ensure_mailbox(&rpc_dir).unwrap();
+        write_request(
+            &rpc_dir.join("requests"),
+            "req-8.json",
+            r#"{"id":"req-8","op":"ping"}"#,
+        );
+
+        // Force write_response_atomic to fail deterministically: it writes to
+        // `responses/req-8.json.tmp` first, so a directory in that spot makes
+        // the write error out on every platform.
+        std::fs::create_dir(rpc_dir.join("responses/req-8.json.tmp")).unwrap();
+
+        let dispatcher = CountingDispatcher(std::sync::atomic::AtomicUsize::new(0));
+        process_pending(&rpc_dir, &dispatcher).await;
+
+        assert_eq!(
+            dispatcher.0.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the op runs once"
+        );
+        assert!(
+            !rpc_dir.join("requests/req-8.json").exists(),
+            "request must be removed even when the response write fails"
+        );
+        assert!(!rpc_dir.join("responses/req-8.json").exists());
+
+        // A subsequent tick must not re-run the (side-effectful) op.
+        process_pending(&rpc_dir, &dispatcher).await;
+        assert_eq!(
+            dispatcher.0.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "a write failure must not cause the op to run a second time"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/rpc.rs
+++ b/src-tauri/src/rpc.rs
@@ -187,8 +187,23 @@ async fn handle_request_file(
         return Vec::new();
     }
 
+    // A response for this id already exists: a previous tick answered the
+    // request but failed to remove its file, or two triggers raced on the same
+    // scan. Never re-dispatch — ops can have side effects (e.g. a git push).
+    // Just finish the cleanup.
+    if responses.join(format!("{stem}.json")).exists() {
+        remove_request_file(path);
+        return Vec::new();
+    }
+
     let raw = match std::fs::read(path) {
         Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // A concurrent trigger consumed the file between the directory
+            // scan and this read — already handled, nothing to do.
+            tracing::debug!(file = %path.display(), "rpc: request vanished before read");
+            return Vec::new();
+        }
         Err(e) => {
             tracing::warn!(error = %e, file = %path.display(), "rpc: read request failed");
             return Vec::new();
@@ -202,7 +217,7 @@ async fn handle_request_file(
                 tracing::warn!(error = %e, file = %path.display(), "rpc: malformed request, answering with error");
                 let resp = Response::err(stem, format!("malformed request JSON: {e}"));
                 if write_response_atomic(responses, stem, &resp).is_ok() {
-                    let _ = std::fs::remove_file(path);
+                    remove_request_file(path);
                 }
             } else {
                 tracing::debug!(error = %e, file = %path.display(), "rpc: unparseable request (will retry)");
@@ -218,11 +233,19 @@ async fn handle_request_file(
         return effects;
     }
 
-    if let Err(e) = std::fs::remove_file(path) {
-        tracing::warn!(error = %e, file = %path.display(), "rpc: remove request failed");
-    }
+    remove_request_file(path);
 
     effects
+}
+
+/// Delete a handled request file. NotFound is a no-op — a concurrent trigger
+/// beat us to the cleanup, which is fine now that the request is answered.
+fn remove_request_file(path: &Path) {
+    if let Err(e) = std::fs::remove_file(path) {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            tracing::warn!(error = %e, file = %path.display(), "rpc: remove request failed");
+        }
+    }
 }
 
 fn write_response_atomic(responses: &Path, key: &str, resp: &Response) -> Result<()> {
@@ -257,6 +280,27 @@ mod tests {
     }
 
     struct MockDispatcher;
+
+    /// Like `MockDispatcher`, but counts dispatch calls so tests can assert an
+    /// already-answered request is never re-executed.
+    struct CountingDispatcher(std::sync::atomic::AtomicUsize);
+
+    impl RpcDispatcher for CountingDispatcher {
+        fn dispatch<'a>(
+            &'a self,
+            id: &'a str,
+            _op: &'a str,
+            _args: &'a Value,
+        ) -> RpcFuture<'a, (Response, Vec<RpcEvent>)> {
+            self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Box::pin(async move {
+                (
+                    Response::ok(id, 0, "pong".to_string(), String::new()),
+                    Vec::new(),
+                )
+            })
+        }
+    }
 
     impl RpcDispatcher for MockDispatcher {
         fn dispatch<'a>(
@@ -365,5 +409,92 @@ mod tests {
 
         assert!(rpc_dir.join("requests/req-3.json").exists());
         assert!(!rpc_dir.join("responses/req-3.json").exists());
+    }
+
+    #[tokio::test]
+    async fn request_with_existing_response_is_not_redispatched() {
+        let td = tempfile::tempdir().unwrap();
+        let rpc_dir = td.path().join(".fletch-rpc");
+        ensure_mailbox(&rpc_dir).unwrap();
+
+        // A previous tick answered req-4 but its request file lingered
+        // (remove failed or two triggers raced on the same scan).
+        std::fs::write(
+            rpc_dir.join("responses/req-4.json"),
+            r#"{"id":"req-4","ok":true,"exit_code":0,"stdout":"first","stderr":""}"#,
+        )
+        .unwrap();
+        write_request(
+            &rpc_dir.join("requests"),
+            "req-4.json",
+            r#"{"id":"req-4","op":"ping"}"#,
+        );
+
+        let dispatcher = CountingDispatcher(std::sync::atomic::AtomicUsize::new(0));
+        process_pending(&rpc_dir, &dispatcher).await;
+
+        assert_eq!(
+            dispatcher.0.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "an already-answered request must never be re-dispatched"
+        );
+        assert!(!rpc_dir.join("requests/req-4.json").exists());
+        let body = std::fs::read_to_string(rpc_dir.join("responses/req-4.json")).unwrap();
+        let v: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["stdout"], "first", "original response must be preserved");
+    }
+
+    #[tokio::test]
+    async fn concurrently_deleted_request_is_tolerated() {
+        let td = tempfile::tempdir().unwrap();
+        let rpc_dir = td.path().join(".fletch-rpc");
+        ensure_mailbox(&rpc_dir).unwrap();
+
+        // The file vanished between the directory scan and the read.
+        let gone = rpc_dir.join("requests/req-5.json");
+        let effects = handle_request_file(&gone, &rpc_dir.join("responses"), &MockDispatcher).await;
+
+        assert!(effects.is_empty());
+        assert!(!rpc_dir.join("responses/req-5.json").exists());
+    }
+
+    /// B3 acceptance: with no FS-event mechanism anywhere (this transport has
+    /// none — the watcher is a bare interval tick), a dropped request file is
+    /// answered within 1s by the poll path alone. The tick here mirrors the
+    /// spec's 500ms fallback; production polls even faster (`RPC_TICK`).
+    #[tokio::test]
+    async fn poll_tick_answers_request_within_a_second_without_fs_events() {
+        let td = tempfile::tempdir().unwrap();
+        let rpc_dir = td.path().join(".fletch-rpc");
+        ensure_mailbox(&rpc_dir).unwrap();
+
+        let dir = rpc_dir.clone();
+        let poller = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                process_pending(&dir, &MockDispatcher).await;
+            }
+        });
+
+        write_request(
+            &rpc_dir.join("requests"),
+            "req-6.json",
+            r#"{"id":"req-6","op":"ping"}"#,
+        );
+
+        let response = rpc_dir.join("responses/req-6.json");
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        while !response.exists() && std::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        poller.abort();
+
+        assert!(
+            response.exists(),
+            "poll fallback did not answer the request within 1s"
+        );
+        let v: Value = serde_json::from_str(&std::fs::read_to_string(response).unwrap()).unwrap();
+        assert_eq!(v["ok"], true);
+        assert!(!rpc_dir.join("requests/req-6.json").exists());
     }
 }

--- a/src-tauri/src/rpc.rs
+++ b/src-tauri/src/rpc.rs
@@ -4,11 +4,14 @@
 //! handling, and the dispatcher trait. Feature-specific behavior lives behind
 //! dispatchers such as `rpc::git::GitDispatcher`.
 
+use std::collections::HashSet;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
+use std::sync::OnceLock;
 use std::time::{Duration, SystemTime};
 
+use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -187,6 +190,18 @@ async fn handle_request_file(
         return Vec::new();
     }
 
+    // Claim the request for this trigger. The response-file check below only
+    // covers *answered* requests; without the claim, two concurrent triggers
+    // (an overlapping watcher generation still draining a slow op, or a future
+    // FS-event trigger racing the poll tick) could both scan the request
+    // before either writes its response and dispatch it twice. In-memory is
+    // enough: every trigger for a mailbox lives in this process, and after a
+    // crash the request file survives for the next start to retry.
+    let Some(_claim) = InFlightClaim::acquire(path) else {
+        tracing::debug!(file = %path.display(), "rpc: request already in flight, skipping");
+        return Vec::new();
+    };
+
     // A response for this id already exists: a previous tick answered the
     // request but failed to remove its file, or two triggers raced on the same
     // scan. Never re-dispatch — ops can have side effects (e.g. a git push).
@@ -236,6 +251,33 @@ async fn handle_request_file(
     remove_request_file(path);
 
     effects
+}
+
+/// Request files currently being processed somewhere in this process. Guards
+/// the dispatch of side-effectful ops against concurrent triggers; see the
+/// claim site in `handle_request_file`.
+fn in_flight() -> &'static Mutex<HashSet<PathBuf>> {
+    static IN_FLIGHT: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
+    IN_FLIGHT.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// RAII entry in `in_flight()`: released on drop, so every early return in
+/// `handle_request_file` unclaims automatically.
+struct InFlightClaim(PathBuf);
+
+impl InFlightClaim {
+    fn acquire(path: &Path) -> Option<Self> {
+        in_flight()
+            .lock()
+            .insert(path.to_path_buf())
+            .then(|| Self(path.to_path_buf()))
+    }
+}
+
+impl Drop for InFlightClaim {
+    fn drop(&mut self) {
+        in_flight().lock().remove(&self.0);
+    }
 }
 
 /// Delete a handled request file. NotFound is a no-op — a concurrent trigger
@@ -294,6 +336,31 @@ mod tests {
         ) -> RpcFuture<'a, (Response, Vec<RpcEvent>)> {
             self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Box::pin(async move {
+                (
+                    Response::ok(id, 0, "pong".to_string(), String::new()),
+                    Vec::new(),
+                )
+            })
+        }
+    }
+
+    /// Counts dispatch entries and then parks until the test hands it a
+    /// permit, so a test can hold a request in flight deterministically.
+    struct BlockingDispatcher {
+        calls: std::sync::atomic::AtomicUsize,
+        release: tokio::sync::Semaphore,
+    }
+
+    impl RpcDispatcher for BlockingDispatcher {
+        fn dispatch<'a>(
+            &'a self,
+            id: &'a str,
+            _op: &'a str,
+            _args: &'a Value,
+        ) -> RpcFuture<'a, (Response, Vec<RpcEvent>)> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Box::pin(async move {
+                let _permit = self.release.acquire().await.unwrap();
                 (
                     Response::ok(id, 0, "pong".to_string(), String::new()),
                     Vec::new(),
@@ -442,6 +509,57 @@ mod tests {
         let body = std::fs::read_to_string(rpc_dir.join("responses/req-4.json")).unwrap();
         let v: Value = serde_json::from_str(&body).unwrap();
         assert_eq!(v["stdout"], "first", "original response must be preserved");
+    }
+
+    /// A request that is being dispatched (no response written yet) must not
+    /// be dispatched again by a concurrent trigger — e.g. an old watcher
+    /// generation still draining a slow `git_push` while the respawned
+    /// generation starts ticking, or an FS-event trigger racing the poll tick.
+    #[tokio::test]
+    async fn in_flight_request_is_not_redispatched_by_a_concurrent_trigger() {
+        let td = tempfile::tempdir().unwrap();
+        let rpc_dir = td.path().join(".fletch-rpc");
+        ensure_mailbox(&rpc_dir).unwrap();
+        write_request(
+            &rpc_dir.join("requests"),
+            "req-7.json",
+            r#"{"id":"req-7","op":"ping"}"#,
+        );
+
+        let dispatcher = std::sync::Arc::new(BlockingDispatcher {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            release: tokio::sync::Semaphore::new(0),
+        });
+
+        let dir = rpc_dir.clone();
+        let d = dispatcher.clone();
+        let first = tokio::spawn(async move { process_pending(&dir, d.as_ref()).await });
+
+        // Wait until the first trigger is inside dispatch: claim held, no
+        // response written yet — exactly the window the exists() check misses.
+        while dispatcher.calls.load(std::sync::atomic::Ordering::SeqCst) == 0 {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        // A second trigger scans the same request mid-flight.
+        process_pending(&rpc_dir, dispatcher.as_ref()).await;
+        assert_eq!(
+            dispatcher.calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "an in-flight request must not be re-dispatched"
+        );
+
+        dispatcher.release.add_permits(1);
+        first.await.unwrap();
+
+        assert_eq!(
+            dispatcher.calls.load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
+        assert!(!rpc_dir.join("requests/req-7.json").exists());
+        let body = std::fs::read_to_string(rpc_dir.join("responses/req-7.json")).unwrap();
+        let v: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["ok"], true);
     }
 
     #[tokio::test]

--- a/src-tauri/src/supervisor/rpc_watch.rs
+++ b/src-tauri/src/supervisor/rpc_watch.rs
@@ -18,7 +18,11 @@ const RPC_TICK: Duration = Duration::from_millis(100);
 /// tick, execute any pending requests and write responses. Gen-guarded like
 /// `spawn_turn_watchdog`, so it exits cleanly when the agent is respawned or
 /// torn down (no explicit handle to track). Polling (no `notify` crate) mirrors
-/// the transcript-sync style already used elsewhere.
+/// the transcript-sync style already used elsewhere — and is load-bearing for
+/// sandbox engines beyond seatbelt: container-originated writes over VirtioFS
+/// don't reliably produce FSEvents, so this watcher must never be converted to
+/// an FS-event trigger without keeping an interval fallback (`process_pending`
+/// is idempotent, so extra triggers are safe).
 pub(super) fn spawn_rpc_watcher(
     sup: Arc<Supervisor>,
     app: AppHandle,


### PR DESCRIPTION
Slice B3 of the sandbox engine plan (`docs/sandboxing.md`): the host-side RPC mailbox watcher must not depend on FS events, because container-originated writes over VirtioFS don't reliably produce FSEvents (needed for the upcoming Docker engine).

The watcher (`supervisor/rpc_watch.rs`) is already a pure 100ms interval poll — stronger than the spec's 500ms fallback tick — so no new timer is added; instead its doc comment now states that polling is load-bearing and must never be replaced by an FS-event-only trigger. The idempotency audit required by the spec found and fixed a **double-dispatch bug** in `rpc::handle_request_file`: a request whose response was written but whose file removal failed would be re-dispatched on the next tick, re-executing side-effectful ops (e.g. `git_push`). Processing now skips (and cleans up) any request that already has a response file, and tolerates a concurrently-deleted request quietly (NotFound on read/remove is a benign race, not a warning).

## Test plan
- `request_with_existing_response_is_not_redispatched` — counting dispatcher asserts zero dispatches when a response already exists; original response preserved, lingering request removed.
- `concurrently_deleted_request_is_tolerated` — request path vanishing between scan and read yields no effects and no response.
- `poll_tick_answers_request_within_a_second_without_fs_events` — B3 acceptance: a bare 500ms interval tick (no FS-event mechanism anywhere) answers a dropped request file within 1s.
- `cargo build` zero warnings; `cargo test` 367 passed, 0 failed, 3 ignored.

Part of the swappable sandbox-engine effort; see `docs/sandboxing.md` slice graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)