### PR TITLE
feat(sandbox): docker primitives — probe, content-addressed image, orphan sweep (slice B1)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -544,6 +544,9 @@ pub fn run() {
             // untouched.
             crate::sandbox::cleanup_nested_rpc_roots();
             crate::sandbox::cleanup_nested_worktrees_roots();
+            // Same reclamation for docker containers left by dead instances —
+            // probe-gated and on its own thread, so startup never waits on it.
+            crate::sandbox::docker::sweep_orphans_at_startup();
 
             // Quitting normally goes through `RunEvent::ExitRequested` (below),
             // but a SIGINT (Ctrl-C under `tauri dev`) or SIGTERM (sent by the

--- a/src-tauri/src/sandbox/docker/cleanup.rs
+++ b/src-tauri/src/sandbox/docker/cleanup.rs
@@ -1,0 +1,210 @@
+//! Container labels and the dead-instance orphan sweep.
+//!
+//! Invariant 4 of the sandbox plan: no orphaned containers. Every container
+//! Fletch launches carries `fletch.host-pid=<pid>` (which app instance owns
+//! it) and `fletch.agent-id=<id>` (which agent it runs). If the app dies
+//! without cleanup — crash, force-quit, SIGKILL — its containers keep
+//! running; the next startup sweeps them by the same pid-liveness rule the
+//! nested-root sweeps use (`sandbox/seatbelt.rs`): remove only containers
+//! whose owning pid is gone, never a live side-by-side instance's.
+
+use std::time::Duration;
+
+use crate::error::{Error, Result};
+
+use super::cli;
+
+/// Label carrying the owning Fletch instance's pid.
+pub const HOST_PID_LABEL: &str = "fletch.host-pid";
+
+/// Label carrying the agent id a container runs (attribution/debugging; the
+/// sweep keys on [`HOST_PID_LABEL`] alone).
+#[allow(dead_code)] // slice B2 stamps it on `docker run`
+pub const AGENT_ID_LABEL: &str = "fletch.agent-id";
+
+/// `fletch.host-pid=<our pid>` — the value B2 passes to `docker run --label`.
+#[allow(dead_code)] // slice B2 is the consumer
+pub fn host_pid_label() -> String {
+    format!("{HOST_PID_LABEL}={}", std::process::id())
+}
+
+/// `fletch.agent-id=<agent_id>` — sibling of [`host_pid_label`] for B2's argv.
+#[allow(dead_code)] // slice B2 is the consumer
+pub fn agent_id_label(agent_id: &str) -> String {
+    format!("{AGENT_ID_LABEL}={agent_id}")
+}
+
+/// Listing/inspect are metadata-only; generous next to their usual
+/// milliseconds, so tripping one means the daemon is wedged.
+const QUERY_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// `docker rm -f` also kills a still-running container's process; give the
+/// batched removal room without letting a hung daemon pin the sweep thread.
+const REMOVE_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// `docker inspect` line format pairing each container id with its owning
+/// pid. `index` (rather than a direct field access) yields an empty string
+/// when the label is somehow absent, which parses to "no pid" and is skipped
+/// — under-reclaiming, never removing something we can't attribute.
+const INSPECT_FORMAT: &str = r#"{{.Id}} {{index .Config.Labels "fletch.host-pid"}}"#;
+
+/// Remove every fletch-labeled container whose owning host instance is dead.
+/// Returns the number removed. Callers gate on the probe and run this off
+/// the main thread — see `sweep_orphans_at_startup` in `docker/mod.rs`.
+pub fn sweep_orphans() -> Result<usize> {
+    let list = cli::run_docker(
+        &["ps", "-aq", "--filter", &format!("label={HOST_PID_LABEL}")],
+        QUERY_TIMEOUT,
+    )?;
+    if !list.status.success() {
+        return Err(Error::Other(format!(
+            "docker ps failed: {}",
+            String::from_utf8_lossy(&list.stderr).trim(),
+        )));
+    }
+    let ids: Vec<&str> = std::str::from_utf8(&list.stdout)
+        .unwrap_or_default()
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .collect();
+    if ids.is_empty() {
+        return Ok(0);
+    }
+
+    let mut inspect_args = vec!["inspect", "-f", INSPECT_FORMAT];
+    inspect_args.extend(&ids);
+    let inspected = cli::run_docker(&inspect_args, QUERY_TIMEOUT)?;
+    // Don't require a zero exit: inspect exits non-zero if ANY id vanished
+    // between ps and inspect (e.g. a `--rm` container finishing), but still
+    // prints the rows it found — those are the ones we act on.
+    let stdout = String::from_utf8_lossy(&inspected.stdout);
+    let orphans = orphaned_ids(&stdout, crate::sandbox::seatbelt::pid_alive);
+    if orphans.is_empty() {
+        return Ok(0);
+    }
+
+    tracing::info!(
+        count = orphans.len(),
+        "removing containers of dead fletch instances"
+    );
+    let mut rm_args = vec!["rm", "-f"];
+    rm_args.extend(orphans.iter().map(String::as_str));
+    let removed = cli::run_docker(&rm_args, REMOVE_TIMEOUT)?;
+    if !removed.status.success() {
+        return Err(Error::Other(format!(
+            "docker rm failed: {}",
+            String::from_utf8_lossy(&removed.stderr).trim(),
+        )));
+    }
+    Ok(orphans.len())
+}
+
+/// Parse [`INSPECT_FORMAT`] output and keep the ids whose owning pid is
+/// provably dead. A missing or unparsable pid means we can't attribute the
+/// container, so it is left alone (same under-reclaim bias as
+/// `cleanup_nested_state_roots_in`). Pure — the liveness probe is injected
+/// for unit tests.
+fn orphaned_ids(inspect_stdout: &str, alive: impl Fn(i32) -> bool) -> Vec<String> {
+    inspect_stdout
+        .lines()
+        .filter_map(parse_inspect_line)
+        .filter(|(_, pid)| pid.is_some_and(|p| !alive(p)))
+        .map(|(id, _)| id)
+        .collect()
+}
+
+/// One [`INSPECT_FORMAT`] line → `(container_id, owning_pid)`. The pid is
+/// `None` when the label was empty or not a number.
+fn parse_inspect_line(line: &str) -> Option<(String, Option<i32>)> {
+    let mut parts = line.split_whitespace();
+    let id = parts.next()?;
+    let pid = parts.next().and_then(|p| p.parse::<i32>().ok());
+    Some((id.to_string(), pid))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn label_argv_shapes() {
+        assert_eq!(
+            host_pid_label(),
+            format!("fletch.host-pid={}", std::process::id()),
+        );
+        assert_eq!(agent_id_label("agent-42"), "fletch.agent-id=agent-42");
+    }
+
+    #[test]
+    fn inspect_line_parsing() {
+        assert_eq!(
+            parse_inspect_line("abc123 4242"),
+            Some(("abc123".into(), Some(4242))),
+        );
+        // Missing label → `index` printed an empty string → no pid.
+        assert_eq!(parse_inspect_line("abc123 "), Some(("abc123".into(), None)));
+        assert_eq!(parse_inspect_line("abc123"), Some(("abc123".into(), None)));
+        // Garbage pid → no pid, not a parse crash.
+        assert_eq!(
+            parse_inspect_line("abc123 not-a-pid"),
+            Some(("abc123".into(), None)),
+        );
+        assert_eq!(parse_inspect_line(""), None);
+    }
+
+    /// The sweep's core rule: dead pid → remove; live pid → keep; and any
+    /// container we can't attribute to a pid is kept (under-reclaim bias).
+    #[test]
+    fn selects_only_provably_dead_owners() {
+        let stdout = "aaa 100\nbbb 200\nccc \nddd bogus\n";
+        let orphans = orphaned_ids(stdout, |pid| pid == 100);
+        assert_eq!(orphans, vec!["bbb".to_string()]);
+    }
+
+    /// Integration: a container labeled with a dead pid is swept; one labeled
+    /// with our own (live) pid survives.
+    /// `FLETCH_DOCKER_TESTS=1 cargo test -- --ignored`
+    #[test]
+    #[ignore = "requires Docker; opt in via FLETCH_DOCKER_TESTS=1"]
+    fn sweeps_dead_instance_containers_only() {
+        if !crate::sandbox::docker::docker_tests_enabled() {
+            return;
+        }
+        let run = |label: &str, name: &str| {
+            let out = cli::run_docker(
+                &[
+                    "run", "-d", "--label", label, "--name", name, "busybox", "sleep", "60",
+                ],
+                Duration::from_secs(60),
+            )
+            .unwrap();
+            assert!(
+                out.status.success(),
+                "docker run failed: {}",
+                String::from_utf8_lossy(&out.stderr),
+            );
+        };
+        // 99999998 exceeds macOS's pid range and can't be a live process.
+        let dead_name = format!("fletch-test-dead-{}", std::process::id());
+        let live_name = format!("fletch-test-live-{}", std::process::id());
+        run(&format!("{HOST_PID_LABEL}=99999998"), &dead_name);
+        run(&host_pid_label(), &live_name);
+
+        let removed = sweep_orphans().unwrap();
+        assert!(removed >= 1, "the dead-pid container should be swept");
+
+        let exists = |name: &str| {
+            let out = cli::run_docker(
+                &["ps", "-aq", "--filter", &format!("name={name}")],
+                Duration::from_secs(10),
+            )
+            .unwrap();
+            !String::from_utf8_lossy(&out.stdout).trim().is_empty()
+        };
+        assert!(!exists(&dead_name), "dead-instance container must be gone");
+        assert!(exists(&live_name), "live-instance container must survive");
+
+        let _ = cli::run_docker(&["rm", "-f", &live_name], Duration::from_secs(30));
+    }
+}

--- a/src-tauri/src/sandbox/docker/cli.rs
+++ b/src-tauri/src/sandbox/docker/cli.rs
@@ -1,0 +1,228 @@
+//! Locate the docker binary and run it with hard timeouts.
+//!
+//! Two rules every docker invocation in the app must follow, enforced by
+//! funneling them through this module:
+//!
+//! 1. **Resolve the binary like a GUI app.** Docker Desktop symlinks the CLI
+//!    into `/usr/local/bin`, which a Finder-launched Tauri app's PATH may not
+//!    include — `bin_resolve::resolve_bin` handles that (its common-dirs
+//!    fallback already covers `/usr/local/bin`).
+//! 2. **Bound every call.** A stopped Docker Desktop leaves a socket that
+//!    accepts connections and then hangs; an unbounded `docker` call would
+//!    wedge whatever thread issued it (UI polling, startup sweep). Callers
+//!    pass an explicit timeout and get a clear "timed out" error instead.
+
+use std::process::{Command, Output, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
+
+use crate::error::{Error, Result};
+
+/// Absolute path of the docker CLI, or `None` when it isn't installed.
+/// Resolved fresh on every call (the underlying login-shell env is cached, so
+/// this is just a stat walk): caching a `None` here would pin the probe to
+/// `NotInstalled` for the whole app run even after the user installs Docker,
+/// and the probe's own 5s cache already bounds the frequency.
+pub(super) fn docker_bin() -> Option<std::path::PathBuf> {
+    let home = dirs::home_dir()?;
+    crate::bin_resolve::resolve_bin("docker", &home).map(std::path::PathBuf::from)
+}
+
+/// Run `docker <args>` capturing stdout/stderr, failing after `timeout`.
+/// Returns the raw `Output` — callers inspect the exit status themselves,
+/// since several docker commands use non-zero exits as answers (e.g.
+/// `image inspect` on a missing image), not as errors.
+pub(super) fn run_docker(args: &[&str], timeout: Duration) -> Result<Output> {
+    let bin = docker_bin()
+        .ok_or_else(|| Error::Other("docker binary not found — is Docker installed?".into()))?;
+    let mut cmd = Command::new(bin);
+    cmd.args(args);
+    let what = format!("docker {}", args.first().copied().unwrap_or_default());
+    run_with_timeout(cmd, timeout, &what)
+}
+
+/// Run `docker <args>` streaming every output line (stdout and stderr) to
+/// `on_line` as it appears — the shape `docker build` needs so image-build
+/// progress can reach the UI (slice C2). Fails on non-zero exit with the
+/// last output lines in the message, or on `timeout` expiry.
+#[allow(dead_code)] // reached via `image`, whose consumer is slice B2
+pub(super) fn run_docker_streaming(
+    args: &[&str],
+    timeout: Duration,
+    on_line: &(dyn Fn(&str) + Send + Sync),
+) -> Result<()> {
+    let bin = docker_bin()
+        .ok_or_else(|| Error::Other("docker binary not found — is Docker installed?".into()))?;
+    let what = format!("docker {}", args.first().copied().unwrap_or_default());
+    let mut child = Command::new(bin)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let stdout = child.stdout.take().expect("stdout piped above");
+    let stderr = child.stderr.take().expect("stderr piped above");
+
+    // Keep a bounded tail of everything seen, so a failure message carries
+    // the actual docker error (which lands near the end of the stream)
+    // without buffering an entire multi-minute build log.
+    let tail = std::sync::Mutex::new(std::collections::VecDeque::<String>::new());
+
+    // Scoped threads: the readers borrow `on_line` and `tail`, and both
+    // pipes are drained continuously so the child can never block on a full
+    // pipe while we sit in the wait loop below.
+    let status = std::thread::scope(|scope| {
+        scope.spawn(|| forward_lines(stdout, on_line, &tail));
+        scope.spawn(|| forward_lines(stderr, on_line, &tail));
+        wait_with_deadline(&mut child, timeout, &what)
+    })?;
+
+    if !status.success() {
+        let tail = tail.lock().unwrap();
+        return Err(Error::Other(format!(
+            "{what} failed (exit {}):\n{}",
+            status.code().unwrap_or(-1),
+            tail.iter().cloned().collect::<Vec<_>>().join("\n"),
+        )));
+    }
+    Ok(())
+}
+
+/// Forward each line of `reader` to `on_line`, retaining a bounded tail for
+/// error reporting.
+#[allow(dead_code)] // reached via `image`, whose consumer is slice B2
+fn forward_lines(
+    reader: impl std::io::Read,
+    on_line: &(dyn Fn(&str) + Send + Sync),
+    tail: &std::sync::Mutex<std::collections::VecDeque<String>>,
+) {
+    use std::io::BufRead;
+    const TAIL_LINES: usize = 20;
+    for line in std::io::BufReader::new(reader).lines() {
+        let Ok(line) = line else { break };
+        on_line(&line);
+        let mut tail = tail.lock().unwrap();
+        if tail.len() == TAIL_LINES {
+            tail.pop_front();
+        }
+        tail.push_back(line);
+    }
+}
+
+/// Poll `child` until it exits or `timeout` passes; on expiry SIGKILL it so a
+/// hung docker CLI (daemon gone mid-call) doesn't outlive the error we return.
+#[allow(dead_code)] // reached via `image`, whose consumer is slice B2
+fn wait_with_deadline(
+    child: &mut std::process::Child,
+    timeout: Duration,
+    what: &str,
+) -> Result<std::process::ExitStatus> {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok(status);
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait(); // reap; readers see EOF and finish
+            return Err(timeout_error(what, timeout));
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Run any command to completion under `timeout`, capturing output. The child
+/// is reaped on a helper thread (`wait_with_output` drains the pipes, so a
+/// chatty child can't deadlock on a full pipe); on expiry we SIGKILL by pid —
+/// the helper thread then reaps the corpse and exits on its own.
+fn run_with_timeout(mut cmd: Command, timeout: Duration, what: &str) -> Result<Output> {
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let child = cmd.spawn()?;
+    let pid = child.id();
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(child.wait_with_output());
+    });
+    match rx.recv_timeout(timeout) {
+        Ok(out) => out.map_err(Error::from),
+        Err(_) => {
+            #[cfg(unix)]
+            {
+                use nix::sys::signal::{kill, Signal};
+                let _ = kill(nix::unistd::Pid::from_raw(pid as i32), Signal::SIGKILL);
+            }
+            Err(timeout_error(what, timeout))
+        }
+    }
+}
+
+fn timeout_error(what: &str, timeout: Duration) -> Error {
+    Error::Other(format!(
+        "{what} timed out after {:.0?} — is the Docker daemon responding?",
+        timeout,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The property every docker invocation relies on: a hung child comes
+    /// back as a bounded error, and the child is killed rather than orphaned.
+    #[test]
+    fn run_with_timeout_kills_hung_child() {
+        let mut cmd = Command::new("/bin/sleep");
+        cmd.arg("30");
+        let started = std::time::Instant::now();
+        let err = run_with_timeout(cmd, Duration::from_millis(200), "sleep")
+            .expect_err("a 30s sleep must trip a 200ms timeout");
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "timeout must not wait for the child's natural exit",
+        );
+        assert!(err.to_string().contains("timed out"), "got: {err}");
+    }
+
+    #[test]
+    fn run_with_timeout_captures_output_of_fast_child() {
+        let mut cmd = Command::new("/bin/echo");
+        cmd.arg("hello");
+        let out = run_with_timeout(cmd, Duration::from_secs(5), "echo").unwrap();
+        assert!(out.status.success());
+        assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "hello");
+    }
+
+    /// Streaming runs deliver lines to the callback and fail loudly (with the
+    /// output tail) on a non-zero exit — the contract `docker build` needs.
+    #[test]
+    fn streaming_forwards_lines_and_reports_failure_tail() {
+        let lines = std::sync::Mutex::new(Vec::new());
+        let on_line = |line: &str| lines.lock().unwrap().push(line.to_string());
+
+        // Use /bin/sh directly (not via docker) to exercise the machinery.
+        let mut child = Command::new("/bin/sh")
+            .args(["-c", "echo one; echo two >&2; exit 3"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let stdout = child.stdout.take().unwrap();
+        let stderr = child.stderr.take().unwrap();
+        let tail = std::sync::Mutex::new(std::collections::VecDeque::new());
+        let status = std::thread::scope(|scope| {
+            scope.spawn(|| forward_lines(stdout, &on_line, &tail));
+            scope.spawn(|| forward_lines(stderr, &on_line, &tail));
+            wait_with_deadline(&mut child, Duration::from_secs(5), "sh")
+        })
+        .unwrap();
+
+        assert_eq!(status.code(), Some(3));
+        let mut seen = lines.lock().unwrap().clone();
+        seen.sort();
+        assert_eq!(seen, vec!["one".to_string(), "two".to_string()]);
+        assert_eq!(tail.lock().unwrap().len(), 2);
+    }
+}

--- a/src-tauri/src/sandbox/docker/cli.rs
+++ b/src-tauri/src/sandbox/docker/cli.rs
@@ -13,7 +13,6 @@
 //!    pass an explicit timeout and get a clear "timed out" error instead.
 
 use std::process::{Command, Output, Stdio};
-use std::sync::mpsc;
 use std::time::Duration;
 
 use crate::error::{Error, Result};
@@ -109,9 +108,8 @@ fn forward_lines(
     }
 }
 
-/// Poll `child` until it exits or `timeout` passes; on expiry SIGKILL it so a
+/// Poll `child` until it exits or `timeout` passes; on expiry kill it so a
 /// hung docker CLI (daemon gone mid-call) doesn't outlive the error we return.
-#[allow(dead_code)] // reached via `image`, whose consumer is slice B2
 fn wait_with_deadline(
     child: &mut std::process::Child,
     timeout: Duration,
@@ -131,31 +129,35 @@ fn wait_with_deadline(
     }
 }
 
-/// Run any command to completion under `timeout`, capturing output. The child
-/// is reaped on a helper thread (`wait_with_output` drains the pipes, so a
-/// chatty child can't deadlock on a full pipe); on expiry we SIGKILL by pid —
-/// the helper thread then reaps the corpse and exits on its own.
+/// Run any command to completion under `timeout`, capturing output. Both
+/// pipes are drained on scoped threads (so a chatty child can't deadlock on
+/// a full pipe) while this thread keeps ownership of the `Child` and waits
+/// with a deadline — on expiry [`wait_with_deadline`] kills and reaps it on
+/// any platform, the pipes hit EOF, and the readers finish: nothing outlives
+/// the error we return.
 fn run_with_timeout(mut cmd: Command, timeout: Duration, what: &str) -> Result<Output> {
+    fn read_all(mut reader: impl std::io::Read) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let _ = reader.read_to_end(&mut buf);
+        buf
+    }
+
     cmd.stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    let child = cmd.spawn()?;
-    let pid = child.id();
-    let (tx, rx) = mpsc::channel();
-    std::thread::spawn(move || {
-        let _ = tx.send(child.wait_with_output());
-    });
-    match rx.recv_timeout(timeout) {
-        Ok(out) => out.map_err(Error::from),
-        Err(_) => {
-            #[cfg(unix)]
-            {
-                use nix::sys::signal::{kill, Signal};
-                let _ = kill(nix::unistd::Pid::from_raw(pid as i32), Signal::SIGKILL);
-            }
-            Err(timeout_error(what, timeout))
-        }
-    }
+    let mut child = cmd.spawn()?;
+    let stdout = child.stdout.take().expect("stdout piped above");
+    let stderr = child.stderr.take().expect("stderr piped above");
+    std::thread::scope(|scope| {
+        let stdout = scope.spawn(move || read_all(stdout));
+        let stderr = scope.spawn(move || read_all(stderr));
+        let status = wait_with_deadline(&mut child, timeout, what)?;
+        Ok(Output {
+            status,
+            stdout: stdout.join().expect("stdout reader panicked"),
+            stderr: stderr.join().expect("stderr reader panicked"),
+        })
+    })
 }
 
 fn timeout_error(what: &str, timeout: Duration) -> Error {

--- a/src-tauri/src/sandbox/docker/image.rs
+++ b/src-tauri/src/sandbox/docker/image.rs
@@ -1,0 +1,259 @@
+//! The embedded agent image: what containers run, built on demand.
+//!
+//! The Dockerfile and entrypoint are compiled into the binary and the image
+//! tag is derived from their content (`fletch-agent:<sha256[..12]>`), so
+//! shipping a change to either automatically produces a new tag — the stale
+//! image is simply never referenced again and the next spawn rebuilds. No
+//! version bookkeeping, no manual invalidation.
+//!
+//! Users can bypass all of this with the `docker_image` settings key (see
+//! [`resolve_image`]): a user-supplied image is used verbatim — never built,
+//! never inspected — and must have `claude` on PATH and git installed.
+
+use std::path::Path;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use crate::error::Result;
+
+use super::cli;
+
+/// Progress sink for image builds: called once per docker output line.
+/// Slice C2 wires this to UI events; until then callers pass `&|_| {}` or a
+/// tracing forwarder.
+pub type Progress<'a> = &'a (dyn Fn(&str) + Send + Sync);
+
+/// The agent container image. Debian-slim keeps apt available for the tools
+/// claude needs at runtime (`git`, `rg`, `jq`, `procps` for /proc-based
+/// process introspection) while staying small; node 22 is claude-code's
+/// supported runtime.
+pub const DOCKERFILE: &str = r#"FROM node:22-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl ca-certificates ripgrep jq procps \
+ && rm -rf /var/lib/apt/lists/*
+RUN npm install -g @anthropic-ai/claude-code
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+"#;
+
+/// PID-1 shim. The container gets `HOME=<host home>` (a path that does not
+/// exist in the image), so the entrypoint creates it and seeds the minimal
+/// `~/.claude.json` claude needs to skip interactive onboarding. Seeding is
+/// conditional and the file is container-ephemeral by design — see slice B2:
+/// bind-mounting the real `~/.claude.json` would break on claude's atomic
+/// rename-replace writes.
+pub const ENTRYPOINT_SH: &str = r#"#!/bin/sh
+set -e
+mkdir -p "$HOME"
+if [ ! -f "$HOME/.claude.json" ]; then
+  printf '{"hasCompletedOnboarding": true}\n' > "$HOME/.claude.json"
+fi
+exec "$@"
+"#;
+
+/// Builds are slow (base image pull + apt + npm) but bounded: past this we
+/// assume a wedged daemon or dead network and fail the spawn with a clear
+/// error rather than letting it hang indefinitely.
+const BUILD_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Quick metadata lookups (`docker image inspect`).
+const INSPECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The content-addressed tag for the embedded image.
+pub fn image_tag() -> String {
+    tag_for(DOCKERFILE, ENTRYPOINT_SH)
+}
+
+/// `fletch-agent:<sha256(dockerfile + entrypoint)[..12]>` — 12 hex chars, the
+/// same abbreviation depth docker itself uses for short ids.
+fn tag_for(dockerfile: &str, entrypoint: &str) -> String {
+    use sha2::Digest;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(dockerfile.as_bytes());
+    hasher.update(entrypoint.as_bytes());
+    let digest = hasher.finalize();
+    let hex: String = digest.iter().map(|b| format!("{b:02x}")).collect();
+    format!("fletch-agent:{}", &hex[..12])
+}
+
+/// The image to launch containers from, honoring the `docker_image` settings
+/// key: a non-empty override is returned verbatim (no build, no inspect —
+/// the user owns that image's lifecycle); otherwise the embedded image is
+/// built if missing and its tag returned. Callers read the settings key and
+/// pass it in — this module stays DB-free.
+pub fn resolve_image(override_image: Option<&str>, on_progress: Progress) -> Result<String> {
+    if let Some(image) = override_image.map(str::trim).filter(|s| !s.is_empty()) {
+        tracing::info!(
+            image,
+            "using user-supplied docker image (docker_image setting)"
+        );
+        return Ok(image.to_string());
+    }
+    let tag = image_tag();
+    ensure_image(&tag, on_progress)?;
+    Ok(tag)
+}
+
+/// Make sure `tag` exists locally, building the embedded Dockerfile under
+/// that tag if it doesn't. Builds are serialized process-wide: concurrent
+/// spawns during a cold start would otherwise race docker into building the
+/// same image N times.
+pub fn ensure_image(tag: &str, on_progress: Progress) -> Result<()> {
+    ensure_image_with(DOCKERFILE, ENTRYPOINT_SH, tag, on_progress)
+}
+
+/// [`ensure_image`] with explicit content — split out so the integration
+/// test can exercise the build machinery with a tiny Dockerfile instead of
+/// the full agent image.
+fn ensure_image_with(
+    dockerfile: &str,
+    entrypoint: &str,
+    tag: &str,
+    on_progress: Progress,
+) -> Result<()> {
+    static BUILD_LOCK: Mutex<()> = Mutex::new(());
+
+    if image_exists(tag)? {
+        return Ok(());
+    }
+    let _guard = BUILD_LOCK.lock().unwrap();
+    // Re-check under the lock: a concurrent spawn may have just built it.
+    if image_exists(tag)? {
+        return Ok(());
+    }
+
+    tracing::info!(tag, "building agent docker image");
+    // Build from a throwaway context dir holding exactly the two files —
+    // nothing from the host repo can leak into the image.
+    let ctx = tempfile::tempdir()?;
+    std::fs::write(ctx.path().join("Dockerfile"), dockerfile)?;
+    let entrypoint_path = ctx.path().join("entrypoint.sh");
+    std::fs::write(&entrypoint_path, entrypoint)?;
+    // COPY preserves the context file's mode; make sure a restrictive host
+    // umask can't produce a non-executable entrypoint.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&entrypoint_path, std::fs::Permissions::from_mode(0o755))?;
+    }
+
+    let args = build_args(tag, ctx.path());
+    let args: Vec<&str> = args.iter().map(String::as_str).collect();
+    cli::run_docker_streaming(&args, BUILD_TIMEOUT, on_progress)?;
+    tracing::info!(tag, "agent docker image built");
+    Ok(())
+}
+
+/// `docker build` argv for `tag` from context `ctx`.
+fn build_args(tag: &str, ctx: &Path) -> Vec<String> {
+    vec![
+        "build".into(),
+        "-t".into(),
+        tag.into(),
+        ctx.to_string_lossy().into_owned(),
+    ]
+}
+
+/// Whether `tag` exists locally. A non-zero `image inspect` exit is the
+/// documented "no such image" answer (it also covers a down daemon — the
+/// subsequent build then fails with docker's own connectivity error, which
+/// is the right message for that state).
+fn image_exists(tag: &str) -> Result<bool> {
+    let out = cli::run_docker(&["image", "inspect", tag], INSPECT_TIMEOUT)?;
+    Ok(out.status.success())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tag_is_content_addressed() {
+        let tag = tag_for("FROM a\n", "#!/bin/sh\n");
+        let (repo, hash) = tag.split_once(':').unwrap();
+        assert_eq!(repo, "fletch-agent");
+        assert_eq!(hash.len(), 12);
+        assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
+
+        // Deterministic, and any content change moves the tag.
+        assert_eq!(tag, tag_for("FROM a\n", "#!/bin/sh\n"));
+        assert_ne!(tag, tag_for("FROM b\n", "#!/bin/sh\n"));
+        assert_ne!(tag, tag_for("FROM a\n", "#!/bin/bash\n"));
+    }
+
+    #[test]
+    fn build_argv_shape() {
+        assert_eq!(
+            build_args("fletch-agent:abc123def456", Path::new("/tmp/ctx")),
+            vec!["build", "-t", "fletch-agent:abc123def456", "/tmp/ctx"],
+        );
+    }
+
+    /// The override path must not touch docker at all — it has to work (and
+    /// return instantly) on machines where docker isn't even installed.
+    #[test]
+    fn override_image_skips_build_entirely() {
+        let called = std::sync::atomic::AtomicBool::new(false);
+        let progress = |_: &str| called.store(true, std::sync::atomic::Ordering::SeqCst);
+
+        let image = resolve_image(Some("  ghcr.io/me/custom:1  "), &progress).unwrap();
+        assert_eq!(
+            image, "ghcr.io/me/custom:1",
+            "override is trimmed and used verbatim"
+        );
+        assert!(
+            !called.load(std::sync::atomic::Ordering::SeqCst),
+            "override path must never build",
+        );
+    }
+
+    #[test]
+    fn blank_override_falls_through_to_embedded_tag() {
+        // Blank means "not set" — but asserting the full resolve would hit
+        // docker; assert only the pure decision by checking the tag source.
+        assert!(Some("   ")
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .is_none());
+        assert!(image_tag().starts_with("fletch-agent:"));
+    }
+
+    /// Integration: builds a tiny image (busybox base) through the real
+    /// machinery, then verifies the second call is a cached no-op.
+    /// `FLETCH_DOCKER_TESTS=1 cargo test -- --ignored`
+    #[test]
+    #[ignore = "requires Docker; opt in via FLETCH_DOCKER_TESTS=1"]
+    fn builds_tiny_image_and_reuses_it() {
+        if !crate::sandbox::docker::docker_tests_enabled() {
+            return;
+        }
+        let dockerfile =
+            "FROM busybox\nCOPY entrypoint.sh /entrypoint.sh\nENTRYPOINT [\"/entrypoint.sh\"]\n";
+        let tag = tag_for(dockerfile, ENTRYPOINT_SH);
+        // Start clean so the build path actually runs.
+        let _ = cli::run_docker(&["rmi", "-f", &tag], Duration::from_secs(30));
+
+        let lines = std::sync::atomic::AtomicUsize::new(0);
+        let progress = |_: &str| drop(lines.fetch_add(1, std::sync::atomic::Ordering::SeqCst));
+        ensure_image_with(dockerfile, ENTRYPOINT_SH, &tag, &progress).unwrap();
+        assert!(
+            image_exists(&tag).unwrap(),
+            "image should exist after build"
+        );
+        assert!(
+            lines.load(std::sync::atomic::Ordering::SeqCst) > 0,
+            "build should have streamed progress lines",
+        );
+
+        // Second call: image present, no build, no progress.
+        lines.store(0, std::sync::atomic::Ordering::SeqCst);
+        ensure_image_with(dockerfile, ENTRYPOINT_SH, &tag, &progress).unwrap();
+        assert_eq!(
+            lines.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "an existing image must not rebuild",
+        );
+
+        let _ = cli::run_docker(&["rmi", "-f", &tag], Duration::from_secs(30));
+    }
+}

--- a/src-tauri/src/sandbox/docker/image.rs
+++ b/src-tauri/src/sandbox/docker/image.rs
@@ -26,13 +26,16 @@ pub type Progress<'a> = &'a (dyn Fn(&str) + Send + Sync);
 /// The agent container image. Debian-slim keeps apt available for the tools
 /// claude needs at runtime (`git`, `rg`, `jq`, `procps` for /proc-based
 /// process introspection) while staying small; node 22 is claude-code's
-/// supported runtime.
+/// supported runtime. The `chmod` guarantees the entrypoint is executable
+/// regardless of the mode `COPY` picked up from the build context (context
+/// files are written at build time on the host — see [`ensure_image`]).
 pub const DOCKERFILE: &str = r#"FROM node:22-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git curl ca-certificates ripgrep jq procps \
  && rm -rf /var/lib/apt/lists/*
 RUN npm install -g @anthropic-ai/claude-code
 COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 "#;
 
@@ -129,8 +132,10 @@ fn ensure_image_with(
     std::fs::write(ctx.path().join("Dockerfile"), dockerfile)?;
     let entrypoint_path = ctx.path().join("entrypoint.sh");
     std::fs::write(&entrypoint_path, entrypoint)?;
-    // COPY preserves the context file's mode; make sure a restrictive host
-    // umask can't produce a non-executable entrypoint.
+    // COPY preserves the context file's mode. The embedded Dockerfile's
+    // `RUN chmod +x` is what actually guarantees an executable entrypoint on
+    // every host; setting the mode here too just keeps the copied layer's
+    // metadata sane where the host supports it.
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;

--- a/src-tauri/src/sandbox/docker/mod.rs
+++ b/src-tauri/src/sandbox/docker/mod.rs
@@ -1,0 +1,60 @@
+//! Docker engine primitives: availability probing, the agent image, and
+//! orphaned-container cleanup.
+//!
+//! This module is deliberately independent of the spawn path — slice B2 wires
+//! `DockerEngine` (the `SandboxEngine` impl) on top of these pieces. Keeping
+//! the plumbing standalone means every function here must work when Docker is
+//! absent or the daemon is down: probing reports that state instead of
+//! erroring, and the startup sweep is probe-gated so an install-less machine
+//! never pays for a docker invocation.
+//!
+//! Layout:
+//! - [`cli`] — docker binary resolution + bounded-invocation helpers. Every
+//!   docker call in this module goes through it, so no invocation can hang
+//!   the app on a wedged daemon.
+//! - [`probe`] — cached daemon availability for UI polling.
+//! - [`image`] — the embedded agent Dockerfile and content-addressed builds.
+//! - [`cleanup`] — container labels and the dead-instance orphan sweep.
+
+mod cleanup;
+mod cli;
+// Everything in `image` is consumed by the B2 launch path; within B1 only its
+// tests exercise it, so the whole module is dead code until then.
+#[allow(dead_code)]
+mod image;
+mod probe;
+
+// Re-exported for slices B2 (engine launch path) and C1 (settings/UI probe);
+// unused within B1 itself, hence the allowances.
+#[allow(unused_imports)]
+pub use cleanup::{agent_id_label, host_pid_label, sweep_orphans, AGENT_ID_LABEL, HOST_PID_LABEL};
+#[allow(unused_imports)]
+pub use image::{ensure_image, image_tag, resolve_image, Progress};
+#[allow(unused_imports)]
+pub use probe::{availability, DockerAvailability};
+
+/// Best-effort reclamation of containers left behind by dead Fletch
+/// instances, for app startup (`lib.rs`, next to the nested-root sweeps).
+/// Runs on its own thread and probes the daemon first, so startup never
+/// waits on Docker — not even for the 2s probe timeout — and a machine
+/// without Docker skips the sweep entirely.
+pub fn sweep_orphans_at_startup() {
+    std::thread::spawn(|| {
+        if !matches!(probe::availability(), DockerAvailability::Available { .. }) {
+            return;
+        }
+        match cleanup::sweep_orphans() {
+            Ok(0) => {}
+            Ok(n) => tracing::info!(removed = n, "swept orphaned fletch containers"),
+            Err(e) => tracing::warn!(error = %e, "docker orphan sweep failed"),
+        }
+    });
+}
+
+/// Gate for the `#[ignore]`d integration tests: they touch a real Docker
+/// daemon, so they run only when explicitly opted in via
+/// `FLETCH_DOCKER_TESTS=1 cargo test -- --ignored`.
+#[cfg(test)]
+pub(crate) fn docker_tests_enabled() -> bool {
+    std::env::var("FLETCH_DOCKER_TESTS").as_deref() == Ok("1")
+}

--- a/src-tauri/src/sandbox/docker/probe.rs
+++ b/src-tauri/src/sandbox/docker/probe.rs
@@ -1,0 +1,120 @@
+//! Daemon availability probe, cached for UI polling.
+//!
+//! The settings pane (slice C1) polls this to enable/disable the Docker
+//! engine option, and spawn paths (B2) gate on it — so it must be cheap to
+//! call repeatedly and must never hang: the underlying `docker version` call
+//! is bounded at 2s, and results are cached for 5s so a polling UI costs at
+//! most one daemon round-trip per window.
+
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use super::cli;
+
+/// How long a probe result stays fresh. UI polling is expected at ~1s
+/// intervals; 5s keeps the daemon traffic negligible while still flipping
+/// the UI within a beat of Docker Desktop starting or stopping.
+const CACHE_TTL: Duration = Duration::from_secs(5);
+
+/// Hard cap on the `docker version` round-trip. A healthy daemon answers in
+/// milliseconds; anything slower is indistinguishable from down for our
+/// purposes, and 2s keeps a first uncached call from stalling its caller.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// The three states the UI distinguishes: usable now, fixable by starting
+/// Docker Desktop, or fixable only by installing it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DockerAvailability {
+    Available { server_version: String },
+    NotInstalled,
+    DaemonDown,
+}
+
+/// Current Docker availability, at most [`CACHE_TTL`] stale.
+///
+/// The cache lock is held across the probe itself — deliberate: concurrent
+/// callers during a daemon outage would otherwise each burn their own 2s
+/// timeout, and serializing them means followers get the fresh cached answer
+/// immediately.
+pub fn availability() -> DockerAvailability {
+    static CACHE: Mutex<Option<(Instant, DockerAvailability)>> = Mutex::new(None);
+    let mut cache = CACHE.lock().unwrap();
+    if let Some((at, cached)) = cache.as_ref() {
+        if at.elapsed() < CACHE_TTL {
+            return cached.clone();
+        }
+    }
+    let fresh = probe();
+    *cache = Some((Instant::now(), fresh.clone()));
+    fresh
+}
+
+/// One uncached probe: binary present? daemon answering?
+fn probe() -> DockerAvailability {
+    if cli::docker_bin().is_none() {
+        return DockerAvailability::NotInstalled;
+    }
+    // `docker version --format {{.Server.Version}}` exits non-zero (and prints
+    // to stderr) when the daemon is unreachable; a timeout means a socket that
+    // accepts but never answers — same user remedy, same classification.
+    match cli::run_docker(
+        &["version", "--format", "{{.Server.Version}}"],
+        PROBE_TIMEOUT,
+    ) {
+        Ok(out) if out.status.success() => {
+            classify_version_stdout(&String::from_utf8_lossy(&out.stdout))
+        }
+        _ => DockerAvailability::DaemonDown,
+    }
+}
+
+/// Map a successful `docker version` stdout to availability. Split out of
+/// [`probe`] so the parsing is unit-testable without a daemon.
+fn classify_version_stdout(stdout: &str) -> DockerAvailability {
+    let version = stdout.trim();
+    if version.is_empty() {
+        // Zero exit but no server version — treat as down rather than
+        // inventing an "unknown" state the UI would have to render.
+        DockerAvailability::DaemonDown
+    } else {
+        DockerAvailability::Available {
+            server_version: version.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_stdout_classification() {
+        assert_eq!(
+            classify_version_stdout("28.1.1\n"),
+            DockerAvailability::Available {
+                server_version: "28.1.1".into()
+            },
+        );
+        assert_eq!(
+            classify_version_stdout("  \n"),
+            DockerAvailability::DaemonDown,
+            "a zero exit without a server version is not a usable daemon",
+        );
+    }
+
+    /// Integration: needs Docker Desktop running.
+    /// `FLETCH_DOCKER_TESTS=1 cargo test -- --ignored`
+    #[test]
+    #[ignore = "requires Docker; opt in via FLETCH_DOCKER_TESTS=1"]
+    fn probe_reports_running_daemon() {
+        if !crate::sandbox::docker::docker_tests_enabled() {
+            return;
+        }
+        match availability() {
+            DockerAvailability::Available { server_version } => {
+                assert!(!server_version.is_empty());
+            }
+            other => panic!("expected a running daemon, probe said {other:?}"),
+        }
+    }
+}

--- a/src-tauri/src/sandbox/mod.rs
+++ b/src-tauri/src/sandbox/mod.rs
@@ -1,3 +1,4 @@
+pub mod docker;
 mod engine;
 mod seatbelt;
 

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -268,13 +268,15 @@ fn cleanup_nested_state_roots_in(base: &Path) {
 /// Whether a process with `pid` currently exists — a signal-0 `kill` probe.
 /// `Err` (ESRCH, or EPERM on a reused pid we don't own) is treated as gone,
 /// which only ever under-reclaims; a live Fletch we own always probes `Ok`.
+/// `pub(crate)` so the docker orphan sweep (`sandbox/docker/cleanup.rs`) can
+/// share the exact liveness semantics instead of duplicating them.
 #[cfg(unix)]
-fn pid_alive(pid: i32) -> bool {
+pub(crate) fn pid_alive(pid: i32) -> bool {
     nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None).is_ok()
 }
 
 #[cfg(not(unix))]
-fn pid_alive(_pid: i32) -> bool {
+pub(crate) fn pid_alive(_pid: i32) -> bool {
     true // can't probe — never reclaim
 }
 


### PR DESCRIPTION
Implements slice B1 of `docs/sandboxing.md`: standalone Docker plumbing under `src-tauri/src/sandbox/docker/`, no spawn wiring (that's B2).

- `cli.rs`: docker binary resolution via `bin_resolve::resolve_bin` (Docker Desktop's `/usr/local/bin` already covered); every invocation runs under an explicit timeout with kill-on-expiry, plus a line-streaming variant for build progress (C2 wires it to UI events).
- `probe.rs`: `availability() -> Available{server_version} | NotInstalled | DaemonDown`, 2s probe timeout, 5s cache for UI polling.
- `image.rs`: embedded Dockerfile (node:22-slim + git/curl/ca-certificates/ripgrep/jq/procps + `@anthropic-ai/claude-code`) and entrypoint; content-addressed tag `fletch-agent:<sha256(dockerfile+entrypoint)[..12]>`; `ensure_image` with process-wide build mutex + double-checked inspect; `resolve_image` honors the `docker_image` settings override (used verbatim, never built).
- `cleanup.rs`: `fletch.host-pid` / `fletch.agent-id` labels and `sweep_orphans()` — removes containers whose owning pid is dead, sharing `pid_alive` from `sandbox/seatbelt.rs` (now `pub(crate)`); under-reclaim bias for unattributable containers.
- Startup: `sweep_orphans_at_startup()` called from `lib.rs` next to the nested-root sweeps — probe-gated, own thread, never blocks startup. Edits to `lib.rs` / `sandbox/mod.rs` kept to a line each to ease merging with slice C1.

## Test plan
- `cargo build` — zero warnings; `cargo test` — 375 passed, 0 failed (11 new unit tests: tag derivation, label/inspect parsing, argv shapes, timeout-kill, streaming).
- `FLETCH_DOCKER_TESTS=1 cargo test -- --ignored` on a machine with Docker Desktop: probe, tiny-image build+reuse, labeled-container sweep (3 tests; verified they no-op green without the env). **Not run here — needs a machine with Docker.**

Part of the swappable sandbox-engine effort; see `docs/sandboxing.md` slice graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)