### PR TITLE
feat(sandbox): workspace provisioning layer — worktree and clone modes (slice A2)

### DIFF
--- a/docs/sandboxing.md
+++ b/docs/sandboxing.md
@@ -234,8 +234,9 @@ pub fn teardown(mode: WorkspaceMode, spec: &CheckoutSpec) -> Result<()>;
      objects through shared inodes.
    - Rewrite `origin` to the real remote:
      `git -C <source_repo> remote get-url origin` → `git -C <dest> remote
-     set-url origin <url>` (skip if source has no `origin`; then keep the
-     local-path remote and note it in a log line).
+     set-url origin <url>` (if the source has no `origin`, remove the clone's
+     implicit local-path remote — keeping it would let `git push -u origin`
+     write branches into the user's source repo — and note it in a log line).
    - Copy `user.name`/`user.email` into the clone's local config if the source
      repo has repo-local identity (global gitconfig already applies host-side).
    - Teardown = `rm -rf dest` (it's self-contained).

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -60,7 +60,7 @@ const LOCAL_TIMEOUT: Duration = Duration::from_secs(120);
 /// `Output`; callers that inspect exit codes themselves (e.g. `show-ref`'s
 /// 0/1) use this and check `status`, while `run_git` layers the
 /// success-or-`Error::Git` check on top.
-async fn git_output(dir: &Path, args: &[&str]) -> Result<std::process::Output> {
+pub(crate) async fn git_output(dir: &Path, args: &[&str]) -> Result<std::process::Output> {
     git_output_env(dir, args, &[]).await
 }
 
@@ -93,7 +93,7 @@ async fn git_output_env(
 /// `Error::Git("<label> failed: <stderr>")` — `label` names the op for the
 /// message. Collapses the "spawn, check status, format stderr" trio repeated
 /// across this module into one call.
-async fn run_git(dir: &Path, args: &[&str], label: &str) -> Result<std::process::Output> {
+pub(crate) async fn run_git(dir: &Path, args: &[&str], label: &str) -> Result<std::process::Output> {
     let out = git_output(dir, args).await?;
     if !out.status.success() {
         return Err(Error::Git(format!(

--- a/src-tauri/src/git_state.rs
+++ b/src-tauri/src/git_state.rs
@@ -242,17 +242,37 @@ async fn query_unpushed(worktree_path: &Path) -> Option<u32> {
 }
 
 async fn query_ahead_behind(worktree_path: &Path, parent_branch: &str) -> (u32, u32) {
-    let out = crate::git_dist::command(worktree_path)
-        .args(["rev-list", "--left-right", "--count", &format!("HEAD...{parent_branch}")])
-        .output()
-        .await;
-    match out {
-        Ok(o) if o.status.success() => {
-            let s = String::from_utf8_lossy(&o.stdout);
-            parse_ahead_behind(s.trim())
-        }
-        _ => (0, 0),
+    if let Some(counts) = rev_list_counts(worktree_path, parent_branch).await {
+        return counts;
     }
+    // In a clone workspace (`workspace_mode = clone`) the parent branch may
+    // exist only as a remote-tracking ref: `git clone` creates a local branch
+    // for the source's HEAD alone, and bare branch names don't resolve
+    // through `refs/remotes/origin/`. Worktrees never hit this — they share
+    // the source repo's refs.
+    if !parent_branch.starts_with("origin/") {
+        if let Some(counts) =
+            rev_list_counts(worktree_path, &format!("origin/{parent_branch}")).await
+        {
+            return counts;
+        }
+    }
+    (0, 0)
+}
+
+/// `git rev-list --left-right --count HEAD...<base>`, or `None` when the base
+/// doesn't resolve — so the caller can try an alternate ref spelling.
+async fn rev_list_counts(worktree_path: &Path, base: &str) -> Option<(u32, u32)> {
+    let out = crate::git_dist::command(worktree_path)
+        .args(["rev-list", "--left-right", "--count", &format!("HEAD...{base}")])
+        .output()
+        .await
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout);
+    Some(parse_ahead_behind(s.trim()))
 }
 
 async fn run_status(worktree_path: &Path) -> Result<String> {
@@ -506,6 +526,51 @@ mod tests {
     #[test]
     fn ahead_behind_malformed() {
         assert_eq!(parse_ahead_behind("abc\txyz"), (0, 0));
+    }
+
+    // --- query_ahead_behind ---
+
+    #[tokio::test]
+    async fn ahead_behind_falls_back_to_remote_tracking_ref() {
+        // A clone workspace only gets a local branch for the source's HEAD,
+        // so a parent branch like `main` may resolve only as `origin/main`.
+        let td = tempfile::tempdir().unwrap();
+        let run = |dir: &Path, args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .current_dir(dir)
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {args:?}: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        let source = td.path().join("source");
+        std::fs::create_dir_all(&source).unwrap();
+        run(&source, &["init", "-q", "-b", "main"]);
+        run(&source, &["config", "user.email", "t@example.com"]);
+        run(&source, &["config", "user.name", "Tester"]);
+        std::fs::write(source.join("a.txt"), b"one").unwrap();
+        run(&source, &["add", "-A"]);
+        run(&source, &["commit", "-q", "-m", "first"]);
+        // `dev` stays at the first commit; `main` advances past it.
+        run(&source, &["branch", "dev"]);
+        std::fs::write(source.join("b.txt"), b"two").unwrap();
+        run(&source, &["add", "-A"]);
+        run(&source, &["commit", "-q", "-m", "second"]);
+        run(&source, &["checkout", "-q", "dev"]);
+
+        // Clone while `dev` is HEAD: the clone has no local `main`.
+        let clone = td.path().join("clone");
+        run(
+            td.path(),
+            &["clone", "-q", source.to_str().unwrap(), clone.to_str().unwrap()],
+        );
+
+        // Bare `main` fails in the clone; the fallback resolves origin/main.
+        assert_eq!(query_ahead_behind(&clone, "main").await, (0, 1));
     }
 
     // --- parse_porcelain ---

--- a/src-tauri/src/sandbox/mod.rs
+++ b/src-tauri/src/sandbox/mod.rs
@@ -1,4 +1,5 @@
 mod engine;
+pub mod provision;
 mod seatbelt;
 
 use std::sync::{Arc, OnceLock};

--- a/src-tauri/src/sandbox/provision.rs
+++ b/src-tauri/src/sandbox/provision.rs
@@ -91,12 +91,18 @@ pub async fn provision(mode: WorkspaceMode, spec: &CheckoutSpec<'_>) -> Result<(
 /// refs of the origin repo) and the worktree attached to it. Clone: the branch
 /// is created inside the clone; when `base_ref` isn't present in the source
 /// repo (the agent's commits lived only in the torn-down clone), it is fetched
-/// from `origin` via `branch` first — which is why restore of a clone
+/// from `origin` via `origin_branch` first — which is why restore of a clone
 /// workspace requires the branch to have been pushed.
+///
+/// `origin_branch` is the branch name as the remote knows it. It differs from
+/// `branch` when restore renamed to dodge a local collision (`feat` →
+/// `feat-restored`): the remote only has the original name, so fetching the
+/// renamed one would fail and make a pushed branch unrestorable.
 pub async fn provision_on_branch(
     mode: WorkspaceMode,
     spec: &CheckoutSpec<'_>,
     branch: &str,
+    origin_branch: &str,
 ) -> Result<()> {
     match mode {
         WorkspaceMode::Worktree => {
@@ -106,9 +112,10 @@ pub async fn provision_on_branch(
         WorkspaceMode::Clone => {
             clone_base(spec).await?;
             let branch = branch.to_string();
+            let origin_branch = origin_branch.to_string();
             finish_clone(spec, |dest| async move {
                 if !commit_present(&dest, spec.base_ref).await {
-                    fetch_branch(&dest, &branch).await?;
+                    fetch_branch(&dest, &origin_branch).await?;
                 }
                 git::run_git(
                     &dest,
@@ -224,15 +231,23 @@ where
 
 /// Point the clone's `origin` at the source repo's real remote so push/PR/
 /// fetch behave exactly as they would from a worktree. When the source has no
-/// `origin`, the clone keeps its local-path remote — push then fails the same
-/// way it would in the source repo, which is the honest behavior.
+/// `origin`, the clone's implicit local-path `origin` is *removed*: keeping it
+/// would let `git push -u origin <branch>` silently create branches and
+/// objects inside the user's source repo. With no remote at all, push fails
+/// cleanly — the same terminal state the source repo itself is in.
 async fn rewrite_origin(spec: &CheckoutSpec<'_>) -> Result<()> {
     let out = git::git_output(spec.source_repo, &["remote", "get-url", "origin"]).await?;
     if !out.status.success() {
         tracing::info!(
             source = %spec.source_repo.display(),
-            "source repo has no origin remote; clone keeps the local-path remote"
+            "source repo has no origin remote; removing the clone's local-path remote"
         );
+        git::run_git(
+            spec.dest,
+            &["remote", "remove", "origin"],
+            "remote remove origin",
+        )
+        .await?;
         return Ok(());
     }
     let url = String::from_utf8_lossy(&out.stdout).trim().to_string();
@@ -428,7 +443,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn clone_without_source_origin_keeps_local_path_remote() {
+    async fn clone_without_source_origin_removes_local_path_remote() {
         let td = tempfile::tempdir().unwrap();
         let (repo, _first, head) = fixture_repo(td.path());
         let dest = td.path().join("clone");
@@ -439,11 +454,9 @@ mod tests {
         };
 
         provision(WorkspaceMode::Clone, &spec).await.unwrap();
-        let origin = run(&dest, &["remote", "get-url", "origin"]);
-        assert!(
-            std::fs::canonicalize(&origin).unwrap() == std::fs::canonicalize(&repo).unwrap(),
-            "origin should still point at the source repo, got: {origin}"
-        );
+        // The implicit local-path origin must be gone: a push from the clone
+        // must never be able to write into the user's source repo.
+        assert_eq!(run(&dest, &["remote"]), "");
     }
 
     #[tokio::test]
@@ -531,9 +544,14 @@ mod tests {
             dest: &dest,
         };
 
-        provision_on_branch(WorkspaceMode::Worktree, &spec, "feat/restore")
-            .await
-            .unwrap();
+        provision_on_branch(
+            WorkspaceMode::Worktree,
+            &spec,
+            "feat/restore",
+            "feat/restore",
+        )
+        .await
+        .unwrap();
         assert_eq!(
             run(&dest, &["rev-parse", "--abbrev-ref", "HEAD"]),
             "feat/restore"
@@ -552,7 +570,7 @@ mod tests {
             dest: &dest,
         };
 
-        provision_on_branch(WorkspaceMode::Clone, &spec, "feat/restore")
+        provision_on_branch(WorkspaceMode::Clone, &spec, "feat/restore", "feat/restore")
             .await
             .unwrap();
         assert_eq!(
@@ -606,11 +624,29 @@ mod tests {
             base_ref: &tip,
             dest: &dest,
         };
-        provision_on_branch(WorkspaceMode::Clone, &spec, "feat")
+        provision_on_branch(WorkspaceMode::Clone, &spec, "feat", "feat")
             .await
             .unwrap();
         assert_eq!(run(&dest, &["rev-parse", "--abbrev-ref", "HEAD"]), "feat");
         assert_eq!(run(&dest, &["rev-parse", "HEAD"]), tip);
+
+        // Restore under a collision-renamed local branch: the fetch must still
+        // target the name the remote knows (`feat`), while the local branch is
+        // created under the renamed one.
+        let dest2 = td.path().join("clone2");
+        let spec2 = CheckoutSpec {
+            source_repo: &repo,
+            base_ref: &tip,
+            dest: &dest2,
+        };
+        provision_on_branch(WorkspaceMode::Clone, &spec2, "feat-restored", "feat")
+            .await
+            .unwrap();
+        assert_eq!(
+            run(&dest2, &["rev-parse", "--abbrev-ref", "HEAD"]),
+            "feat-restored"
+        );
+        assert_eq!(run(&dest2, &["rev-parse", "HEAD"]), tip);
     }
 
     #[tokio::test]

--- a/src-tauri/src/sandbox/provision.rs
+++ b/src-tauri/src/sandbox/provision.rs
@@ -1,0 +1,638 @@
+//! Workspace provisioning: how an agent's checkout comes into existence.
+//!
+//! Two modes. `Worktree` is the historical behavior — a linked `git worktree`
+//! whose `.git` file points back into the origin repo. `Clone` is a fully
+//! self-contained copy, required by the Docker engine: a linked worktree's
+//! `.git` file references the origin repo's `.git/worktrees/<name>` by
+//! absolute path, so containerizing it would mean mounting the user's real
+//! `.git` — a sandbox escape (a writable `.git/hooks` executes on the host
+//! the next time the user runs git). A clone needs zero extra mounts, and
+//! because it still lives at the normal host path, all host-side git (diff
+//! polling, RPC commit/push, archive/restore) operates on it unchanged.
+//!
+//! The mode is selected by the `workspace_mode` settings key (dev flag, not
+//! exposed in UI — set via sqlite for testing) so the clone path can be
+//! exercised under seatbelt before the Docker engine exists.
+
+use std::path::Path;
+
+use crate::error::{Error, Result};
+use crate::git;
+
+/// Settings-table key selecting the provisioning mode: `"worktree"` (default)
+/// or `"clone"`. Read at spawn time; slice B2 forces `Clone` whenever the
+/// engine is Docker regardless of this key.
+pub const WORKSPACE_MODE_SETTING: &str = "workspace_mode";
+
+/// How an agent workspace is materialized from its source repo.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspaceMode {
+    /// Linked `git worktree` sharing the source repo's object store.
+    Worktree,
+    /// Self-contained `git clone --no-hardlinks` (Docker-safe).
+    Clone,
+}
+
+impl WorkspaceMode {
+    /// Parse the `workspace_mode` setting. Anything other than an explicit
+    /// `"clone"` — including absent or unrecognized values — falls back to
+    /// `Worktree`, the historical default, so a typo'd dev flag can't change
+    /// behavior silently on top of a warning.
+    pub fn from_setting(value: Option<&str>) -> Self {
+        match value {
+            Some("clone") => WorkspaceMode::Clone,
+            Some("worktree") | None => WorkspaceMode::Worktree,
+            Some(other) => {
+                tracing::warn!(value = %other, "unrecognized workspace_mode setting; using worktree");
+                WorkspaceMode::Worktree
+            }
+        }
+    }
+}
+
+/// What to check out where. `base_ref` is any commit-ish; pass `"HEAD"` for
+/// "the source repo's current HEAD" (the legacy no-base behavior).
+pub struct CheckoutSpec<'a> {
+    /// The user's real repo root.
+    pub source_repo: &'a Path,
+    /// Commit-ish the workspace starts from, checked out detached.
+    pub base_ref: &'a str,
+    /// Workspace path (`workspace::repo_worktree_path(agent_id, subdir)`).
+    pub dest: &'a Path,
+}
+
+/// Create the workspace at `spec.dest`, detached at `spec.base_ref`.
+pub async fn provision(mode: WorkspaceMode, spec: &CheckoutSpec<'_>) -> Result<()> {
+    match mode {
+        WorkspaceMode::Worktree => {
+            git::worktree_add_detached(spec.source_repo, spec.dest, Some(spec.base_ref)).await
+        }
+        WorkspaceMode::Clone => {
+            clone_base(spec).await?;
+            finish_clone(spec, |dest| async move {
+                git::run_git(
+                    &dest,
+                    &["checkout", "--detach", spec.base_ref],
+                    &format!("checkout --detach {}", spec.base_ref),
+                )
+                .await?;
+                Ok(())
+            })
+            .await
+        }
+    }
+}
+
+/// Create the workspace checked out on a new local branch `branch` pointing at
+/// `spec.base_ref`. Restore path — the counterpart of [`provision`] for agents
+/// that had already materialized a branch.
+///
+/// Worktree: the branch is created in the source repo (worktree branches are
+/// refs of the origin repo) and the worktree attached to it. Clone: the branch
+/// is created inside the clone; when `base_ref` isn't present in the source
+/// repo (the agent's commits lived only in the torn-down clone), it is fetched
+/// from `origin` via `branch` first — which is why restore of a clone
+/// workspace requires the branch to have been pushed.
+pub async fn provision_on_branch(
+    mode: WorkspaceMode,
+    spec: &CheckoutSpec<'_>,
+    branch: &str,
+) -> Result<()> {
+    match mode {
+        WorkspaceMode::Worktree => {
+            git::branch_create_at(spec.source_repo, branch, spec.base_ref).await?;
+            git::worktree_add_branch(spec.source_repo, spec.dest, branch).await
+        }
+        WorkspaceMode::Clone => {
+            clone_base(spec).await?;
+            let branch = branch.to_string();
+            finish_clone(spec, |dest| async move {
+                if !commit_present(&dest, spec.base_ref).await {
+                    fetch_branch(&dest, &branch).await?;
+                }
+                git::run_git(
+                    &dest,
+                    &["checkout", "-b", &branch, spec.base_ref],
+                    &format!("checkout -b {branch}"),
+                )
+                .await?;
+                Ok(())
+            })
+            .await
+        }
+    }
+}
+
+/// Remove the workspace at `spec.dest`.
+pub async fn teardown(mode: WorkspaceMode, spec: &CheckoutSpec<'_>) -> Result<()> {
+    match mode {
+        WorkspaceMode::Worktree => {
+            // Prune first so a stale registration never blocks the remove;
+            // best-effort, like the pre-existing disposition sweep.
+            let _ = git::worktree_prune(spec.source_repo).await;
+            git::worktree_remove(spec.source_repo, spec.dest, true).await
+        }
+        // A clone is self-contained: nothing to unregister in the source repo.
+        WorkspaceMode::Clone => match tokio::fs::remove_dir_all(spec.dest).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(Error::Other(format!(
+                "remove clone workspace {}: {e}",
+                spec.dest.display()
+            ))),
+        },
+    }
+}
+
+/// Which mode produced the workspace on disk — a linked worktree has a `.git`
+/// *file* (pointer into the origin repo), a clone has a `.git` *directory*.
+/// `None` when the path holds neither (already gone, or never provisioned).
+/// Teardown callers use this instead of re-reading the settings key, so a
+/// dev-flag flip between spawn and archive can't tear down with the wrong arm.
+pub fn detect_mode(dest: &Path) -> Option<WorkspaceMode> {
+    let git_path = dest.join(".git");
+    let meta = std::fs::symlink_metadata(&git_path).ok()?;
+    if meta.is_dir() {
+        Some(WorkspaceMode::Clone)
+    } else {
+        Some(WorkspaceMode::Worktree)
+    }
+}
+
+/// `git clone --no-hardlinks` + origin rewrite + repo-local identity copy —
+/// the parts shared by both clone-arm entry points. Leaves HEAD wherever the
+/// clone put it; callers do their own checkout.
+async fn clone_base(spec: &CheckoutSpec<'_>) -> Result<()> {
+    let source = path_str(spec.source_repo)?;
+    let dest = path_str(spec.dest)?;
+
+    // A leftover directory at the target can only be an orphan from a crashed
+    // spawn: agent-id allocation refuses ids whose worktree dir physically
+    // exists (`occupied_worktree_dirs`), so no live workspace can be here.
+    // Clear it rather than letting `git clone` fail on a non-empty dir.
+    if spec.dest.exists() {
+        tracing::warn!(path = %spec.dest.display(), "clearing orphan dir at clone target");
+        tokio::fs::remove_dir_all(spec.dest).await?;
+    }
+
+    // `--no-hardlinks` is mandatory: hardlinked objects would let a container
+    // corrupt the source repo's objects through shared inodes.
+    // TODO(perf): no `--filter=blob:none` for large repos — local promisor
+    // remotes are fragile; full-clone cost is accepted in v1.
+    //
+    // No timeout: this is a local copy, but a large repo can legitimately
+    // take minutes (same reasoning as `new_project::clone`). `kill_on_drop`
+    // still reaps the child if the spawn task is aborted.
+    let out = crate::git_dist::command(spec.source_repo)
+        .args(["clone", "--no-hardlinks", &source, &dest])
+        .kill_on_drop(true)
+        .output()
+        .await?;
+    if !out.status.success() {
+        // Self-heal: a partial clone dir would make every retry fail with
+        // "already exists" (mirrors `new_project::clone`).
+        let _ = tokio::fs::remove_dir_all(spec.dest).await;
+        return Err(Error::Git(format!(
+            "clone --no-hardlinks failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
+/// Run the shared post-clone fixups, then the mode-specific checkout step.
+/// The origin rewrite must come first: the branch-restore checkout may need
+/// to `fetch origin`, which has to hit the real remote, not the source path.
+/// Any failure tears the half-built clone down so nothing orphaned blocks a
+/// retry (a clone is self-contained, so `rm -rf` is always safe here).
+async fn finish_clone<F, Fut>(spec: &CheckoutSpec<'_>, checkout: F) -> Result<()>
+where
+    F: FnOnce(std::path::PathBuf) -> Fut,
+    Fut: std::future::Future<Output = Result<()>>,
+{
+    let result = async {
+        rewrite_origin(spec).await?;
+        copy_local_identity(spec).await?;
+        checkout(spec.dest.to_path_buf()).await
+    }
+    .await;
+    if result.is_err() {
+        let _ = tokio::fs::remove_dir_all(spec.dest).await;
+    }
+    result
+}
+
+/// Point the clone's `origin` at the source repo's real remote so push/PR/
+/// fetch behave exactly as they would from a worktree. When the source has no
+/// `origin`, the clone keeps its local-path remote — push then fails the same
+/// way it would in the source repo, which is the honest behavior.
+async fn rewrite_origin(spec: &CheckoutSpec<'_>) -> Result<()> {
+    let out = git::git_output(spec.source_repo, &["remote", "get-url", "origin"]).await?;
+    if !out.status.success() {
+        tracing::info!(
+            source = %spec.source_repo.display(),
+            "source repo has no origin remote; clone keeps the local-path remote"
+        );
+        return Ok(());
+    }
+    let url = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    git::run_git(
+        spec.dest,
+        &["remote", "set-url", "origin", &url],
+        "remote set-url origin",
+    )
+    .await?;
+    Ok(())
+}
+
+/// Copy repo-local `user.name` / `user.email` into the clone. Global
+/// gitconfig already applies host-side; only per-repo identity would
+/// otherwise be lost (clones don't inherit the source's local config).
+async fn copy_local_identity(spec: &CheckoutSpec<'_>) -> Result<()> {
+    for key in ["user.name", "user.email"] {
+        // Exits 1 when unset — not an error, just nothing to copy.
+        let out = git::git_output(spec.source_repo, &["config", "--local", "--get", key]).await?;
+        if !out.status.success() {
+            continue;
+        }
+        let value = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if value.is_empty() {
+            continue;
+        }
+        git::run_git(
+            spec.dest,
+            &["config", key, &value],
+            &format!("config {key}"),
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+/// Does `commit` resolve to a commit already present in `repo`?
+async fn commit_present(repo: &Path, commit: &str) -> bool {
+    let spec = format!("{commit}^{{commit}}");
+    matches!(
+        git::git_output(repo, &["rev-parse", "--verify", "--quiet", &spec]).await,
+        Ok(out) if out.status.success()
+    )
+}
+
+/// `git fetch origin <branch>` with the GitHub token auth every other network
+/// op gets, bounded like push/pull so a dead connection surfaces finitely.
+async fn fetch_branch(repo: &Path, branch: &str) -> Result<()> {
+    let mut cmd = crate::git_dist::command(repo);
+    cmd.args(["fetch", "origin", branch]);
+    for (k, v) in crate::github::git_auth_env() {
+        cmd.env(k, v);
+    }
+    let out = git::output_timed(&mut cmd, "git fetch").await?;
+    if !out.status.success() {
+        return Err(Error::Git(format!(
+            "fetch origin {branch} failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
+fn path_str(path: &Path) -> Result<String> {
+    path.to_str()
+        .map(str::to_string)
+        .ok_or_else(|| Error::InvalidPath(path.display().to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn run(repo: &Path, args: &[&str]) -> String {
+        let out = std::process::Command::new("git")
+            .current_dir(repo)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    /// Init a source repo with two commits; returns (repo, first_sha, head_sha).
+    fn fixture_repo(dir: &Path) -> (PathBuf, String, String) {
+        let repo = dir.join("source");
+        std::fs::create_dir_all(&repo).unwrap();
+        run(&repo, &["init", "-q", "-b", "main"]);
+        run(&repo, &["config", "user.email", "t@example.com"]);
+        run(&repo, &["config", "user.name", "Tester"]);
+        std::fs::write(repo.join("a.txt"), b"one").unwrap();
+        run(&repo, &["add", "-A"]);
+        run(&repo, &["commit", "-q", "-m", "first"]);
+        let first = run(&repo, &["rev-parse", "HEAD"]);
+        std::fs::write(repo.join("b.txt"), b"two").unwrap();
+        run(&repo, &["add", "-A"]);
+        run(&repo, &["commit", "-q", "-m", "second"]);
+        let head = run(&repo, &["rev-parse", "HEAD"]);
+        (repo, first, head)
+    }
+
+    #[test]
+    fn mode_parses_setting_with_worktree_default() {
+        assert_eq!(WorkspaceMode::from_setting(None), WorkspaceMode::Worktree);
+        assert_eq!(
+            WorkspaceMode::from_setting(Some("worktree")),
+            WorkspaceMode::Worktree
+        );
+        assert_eq!(
+            WorkspaceMode::from_setting(Some("clone")),
+            WorkspaceMode::Clone
+        );
+        assert_eq!(
+            WorkspaceMode::from_setting(Some("docker?!")),
+            WorkspaceMode::Worktree
+        );
+    }
+
+    #[tokio::test]
+    async fn worktree_provision_detaches_at_base_and_teardown_removes() {
+        let td = tempfile::tempdir().unwrap();
+        let (repo, first, _head) = fixture_repo(td.path());
+        let dest = td.path().join("wt");
+        let spec = CheckoutSpec {
+            source_repo: &repo,
+            base_ref: &first,
+            dest: &dest,
+        };
+
+        provision(WorkspaceMode::Worktree, &spec).await.unwrap();
+        assert_eq!(run(&dest, &["rev-parse", "HEAD"]), first);
+        assert_eq!(detect_mode(&dest), Some(WorkspaceMode::Worktree));
+
+        teardown(WorkspaceMode::Worktree, &spec).await.unwrap();
+        assert!(!dest.exists());
+        // The registration is gone too — the same path is reusable.
+        assert!(!run(&repo, &["worktree", "list", "--porcelain"]).contains("wt"));
+    }
+
+    #[tokio::test]
+    async fn clone_provision_detaches_at_base_ref() {
+        let td = tempfile::tempdir().unwrap();
+        let (repo, first, _head) = fixture_repo(td.path());
+        let dest = td.path().join("clone");
+        let spec = CheckoutSpec {
+            source_repo: &repo,
+            base_ref: &first,
+            dest: &dest,
+        };
+
+        provision(WorkspaceMode::Clone, &spec).await.unwrap();
+        assert_eq!(run(&dest, &["rev-parse", "HEAD"]), first);
+        // Detached HEAD: symbolic-ref exits non-zero.
+        let out = std::process::Command::new("git")
+            .current_dir(&dest)
+            .args(["symbolic-ref", "-q", "HEAD"])
+            .output()
+            .unwrap();
+        assert!(!out.status.success(), "clone HEAD should be detached");
+        assert_eq!(detect_mode(&dest), Some(WorkspaceMode::Clone));
+    }
+
+    #[tokio::test]
+    async fn clone_rewrites_origin_to_source_remote() {
+        let td = tempfile::tempdir().unwrap();
+        let (repo, _first, head) = fixture_repo(td.path());
+        run(
+            &repo,
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/acme/widget.git",
+            ],
+        );
+        let dest = td.path().join("clone");
+        let spec = CheckoutSpec {
+            source_repo: &repo,
+            base_ref: &head,
+            dest: &dest,
+        };
+
+        provision(WorkspaceMode::Clone, &spec).await.unwrap();
+        assert_eq!(
+            run(&dest, &["remote", "get-url", "origin"]),
+            "https://github.com/acme/widget.git"
+        );
+    }
+
+    #[tokio::test]
+    async fn clone_without_source_origin_keeps_local_path_remote() {
+        let td = tempfile::tempdir().unwrap();
+        let (repo, _first, head) = fixture_repo(td.path());
+        let dest = td.path().join("clone");
+        let spec = CheckoutSpec {
+            source_repo: &repo,
+            base_ref: &head,
+            dest: &dest,
+        };
+
+        provision(WorkspaceMode::Clone, &spec).await.unwrap();
+        let origin = run(&dest, &["remote", "get-url", "origin"]);
+        assert!(
+            std::fs::canonicalize(&origin).unwrap() == std::fs::canonicalize(&repo).unwrap(),
+            "origin should still point at the source repo, got: {origin}"
+        );
+    }
+
+    #[tokio::test]
+    async fn clone_copies_repo_local_identity() {
+        let td = tempfile::tempdir().unwrap();
+        let (repo, _first, head) = fixture_repo(td.path());
+        let dest = td.path().join("clone");
+        let spec = CheckoutSpec {
+            source_repo: &repo,
+            base_ref: &head,
+            dest: &dest,
+        };
+
+        provision(WorkspaceMode::Clone, &spec).await.unwrap();
+        assert_eq!(run(&dest, &["config", "--local", "user.name"]), "Tester");
+        assert_eq!(
+            run(&dest, &["config", "--local", "user.email"]),
+            "t@example.com"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn clone_shares_no_hardlinks_with_source() {
+        use std::os::unix::fs::MetadataExt;
+
+        let td = tempfile::tempdir().unwrap();
+        let (repo, _first, head) = fixture_repo(td.path());
+        let dest = td.path().join("clone");
+        let spec = CheckoutSpec {
+            source_repo: &repo,
+            base_ref: &head,
+            dest: &dest,
+        };
+
+        provision(WorkspaceMode::Clone, &spec).await.unwrap();
+        let mut stack = vec![dest.join(".git").join("objects")];
+        let mut checked = 0usize;
+        while let Some(dir) = stack.pop() {
+            for entry in std::fs::read_dir(&dir).unwrap() {
+                let entry = entry.unwrap();
+                let meta = entry.metadata().unwrap();
+                if meta.is_dir() {
+                    stack.push(entry.path());
+                } else {
+                    checked += 1;
+                    assert_eq!(
+                        meta.nlink(),
+                        1,
+                        "hardlinked object: {}",
+                        entry.path().display()
+                    );
+                }
+            }
+        }
+        assert!(checked > 0, "expected object files to verify");
+    }
+
+    #[tokio::test]
+    async fn clone_teardown_removes_everything_and_is_idempotent() {
+        let td = tempfile::tempdir().unwrap();
+        let (repo, _first, head) = fixture_repo(td.path());
+        let dest = td.path().join("clone");
+        let spec = CheckoutSpec {
+            source_repo: &repo,
+            base_ref: &head,
+            dest: &dest,
+        };
+
+        provision(WorkspaceMode::Clone, &spec).await.unwrap();
+        teardown(WorkspaceMode::Clone, &spec).await.unwrap();
+        assert!(!dest.exists());
+        // Already gone — teardown converges rather than erroring.
+        teardown(WorkspaceMode::Clone, &spec).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn worktree_provision_on_branch_creates_branch_at_tip() {
+        let td = tempfile::tempdir().unwrap();
+        let (repo, first, _head) = fixture_repo(td.path());
+        let dest = td.path().join("wt");
+        let spec = CheckoutSpec {
+            source_repo: &repo,
+            base_ref: &first,
+            dest: &dest,
+        };
+
+        provision_on_branch(WorkspaceMode::Worktree, &spec, "feat/restore")
+            .await
+            .unwrap();
+        assert_eq!(
+            run(&dest, &["rev-parse", "--abbrev-ref", "HEAD"]),
+            "feat/restore"
+        );
+        assert_eq!(run(&dest, &["rev-parse", "HEAD"]), first);
+    }
+
+    #[tokio::test]
+    async fn clone_provision_on_branch_uses_local_commit_when_present() {
+        let td = tempfile::tempdir().unwrap();
+        let (repo, first, _head) = fixture_repo(td.path());
+        let dest = td.path().join("clone");
+        let spec = CheckoutSpec {
+            source_repo: &repo,
+            base_ref: &first,
+            dest: &dest,
+        };
+
+        provision_on_branch(WorkspaceMode::Clone, &spec, "feat/restore")
+            .await
+            .unwrap();
+        assert_eq!(
+            run(&dest, &["rev-parse", "--abbrev-ref", "HEAD"]),
+            "feat/restore"
+        );
+        assert_eq!(run(&dest, &["rev-parse", "HEAD"]), first);
+    }
+
+    #[tokio::test]
+    async fn clone_provision_on_branch_fetches_missing_tip_from_origin() {
+        // The agent's commits lived only in its clone (torn down at archive)
+        // and on the real remote. Model that: `origin` (bare) holds a `feat`
+        // branch the source repo never fetched.
+        let td = tempfile::tempdir().unwrap();
+        let (repo, _first, _head) = fixture_repo(td.path());
+        let origin = td.path().join("origin.git");
+        run(
+            td.path(),
+            &["init", "-q", "--bare", origin.to_str().unwrap()],
+        );
+        run(
+            &repo,
+            &["remote", "add", "origin", origin.to_str().unwrap()],
+        );
+        run(&repo, &["push", "-q", "origin", "main"]);
+
+        // A second worker pushes `feat` commits the source repo never sees.
+        let worker = td.path().join("worker");
+        run(
+            td.path(),
+            &[
+                "clone",
+                "-q",
+                origin.to_str().unwrap(),
+                worker.to_str().unwrap(),
+            ],
+        );
+        run(&worker, &["config", "user.email", "w@example.com"]);
+        run(&worker, &["config", "user.name", "Worker"]);
+        run(&worker, &["checkout", "-q", "-b", "feat"]);
+        std::fs::write(worker.join("feat.txt"), b"feature").unwrap();
+        run(&worker, &["add", "-A"]);
+        run(&worker, &["commit", "-q", "-m", "feat work"]);
+        run(&worker, &["push", "-q", "origin", "feat"]);
+        let tip = run(&worker, &["rev-parse", "HEAD"]);
+
+        let dest = td.path().join("clone");
+        let spec = CheckoutSpec {
+            source_repo: &repo,
+            base_ref: &tip,
+            dest: &dest,
+        };
+        provision_on_branch(WorkspaceMode::Clone, &spec, "feat")
+            .await
+            .unwrap();
+        assert_eq!(run(&dest, &["rev-parse", "--abbrev-ref", "HEAD"]), "feat");
+        assert_eq!(run(&dest, &["rev-parse", "HEAD"]), tip);
+    }
+
+    #[tokio::test]
+    async fn clone_recovers_orphan_dir_at_target() {
+        let td = tempfile::tempdir().unwrap();
+        let (repo, _first, head) = fixture_repo(td.path());
+        let dest = td.path().join("clone");
+        std::fs::create_dir_all(&dest).unwrap();
+        std::fs::write(dest.join("leftover.txt"), b"stale").unwrap();
+        let spec = CheckoutSpec {
+            source_repo: &repo,
+            base_ref: &head,
+            dest: &dest,
+        };
+
+        provision(WorkspaceMode::Clone, &spec).await.unwrap();
+        assert!(!dest.join("leftover.txt").exists());
+        assert!(dest.join("a.txt").exists());
+    }
+
+    #[test]
+    fn detect_mode_on_missing_path_is_none() {
+        assert_eq!(detect_mode(Path::new("/nonexistent/nope")), None);
+    }
+}

--- a/src-tauri/src/supervisor/disposition.rs
+++ b/src-tauri/src/supervisor/disposition.rs
@@ -361,7 +361,8 @@ async fn teardown_agent_worktrees(agent_id: &str, repos: &[TrackedRepo], op: &st
         // settings key: a dev-flag flip between spawn and teardown must not
         // run the wrong arm. A missing/empty dir defaults to the worktree
         // arm, whose prune+remove degrade to the pre-existing warnings.
-        let mode = provision::detect_mode(&worktree).unwrap_or(WorkspaceMode::Worktree);
+        let detected = provision::detect_mode(&worktree);
+        let mode = detected.unwrap_or(WorkspaceMode::Worktree);
         let spec = CheckoutSpec {
             source_repo: &repo.repo_path,
             base_ref: "HEAD", // unused by teardown
@@ -375,7 +376,14 @@ async fn teardown_agent_worktrees(agent_id: &str, repos: &[TrackedRepo], op: &st
         // in the source repo, so `branch -D` here would force-delete an
         // unrelated same-named branch in the user's source repo — losing the
         // pointer to their unpushed work.
-        if mode == WorkspaceMode::Worktree {
+        //
+        // Gate on the *positive* worktree detection, not `mode`: ambiguous
+        // disk state (`detect_mode` == `None` — the `.git` is already gone, as
+        // happens for a half-torn-down clone) falls back to the worktree arm
+        // for the harmless prune+remove, but must never reach `branch -D`. A
+        // torn-down clone would otherwise force-delete an unrelated same-named
+        // branch in the user's source repo.
+        if detected == Some(WorkspaceMode::Worktree) {
             if let Some(branch) = &repo.branch {
                 if let Err(e) = git::branch_delete(&repo.repo_path, branch).await {
                     tracing::warn!(%branch, error = %e, op, "branch delete failed");

--- a/src-tauri/src/supervisor/disposition.rs
+++ b/src-tauri/src/supervisor/disposition.rs
@@ -168,7 +168,11 @@ impl Supervisor {
                 // resolving name collisions with a -restored suffix.
                 Some(desired_name) => {
                     let chosen = choose_restore_branch_name(&snap.repo_path, desired_name).await;
-                    provision::provision_on_branch(workspace_mode, &spec, &chosen).await?;
+                    // `desired_name` rides along as the fetch source: when the
+                    // tip must be refetched (clone mode), the remote only
+                    // knows the original name, not the -restored rename.
+                    provision::provision_on_branch(workspace_mode, &spec, &chosen, desired_name)
+                        .await?;
                     Some(chosen)
                 }
                 // Branchless agent (never pushed) → restore detached at the
@@ -366,9 +370,16 @@ async fn teardown_agent_worktrees(agent_id: &str, repos: &[TrackedRepo], op: &st
         if let Err(e) = provision::teardown(mode, &spec).await {
             tracing::warn!(error = %e, subdir = %repo.subdir, op, "workspace teardown failed");
         }
-        if let Some(branch) = &repo.branch {
-            if let Err(e) = git::branch_delete(&repo.repo_path, branch).await {
-                tracing::warn!(%branch, error = %e, op, "branch delete failed");
+        // Only worktree-mode branches are refs of the source repo. A clone's
+        // branch lives inside the (now `rm -rf`'d) clone and was never created
+        // in the source repo, so `branch -D` here would force-delete an
+        // unrelated same-named branch in the user's source repo — losing the
+        // pointer to their unpushed work.
+        if mode == WorkspaceMode::Worktree {
+            if let Some(branch) = &repo.branch {
+                if let Err(e) = git::branch_delete(&repo.repo_path, branch).await {
+                    tracing::warn!(%branch, error = %e, op, "branch delete failed");
+                }
             }
         }
     }

--- a/src-tauri/src/supervisor/disposition.rs
+++ b/src-tauri/src/supervisor/disposition.rs
@@ -7,6 +7,7 @@ use tauri::AppHandle;
 
 use crate::error::{Error, Result};
 use crate::git;
+use crate::sandbox::provision::{self, CheckoutSpec, WorkspaceMode};
 use crate::workspace::{
     agent_parent_dir, repo_worktree_path, AgentStatus, ArchiveMetadata, ArchivedRepoSnapshot,
     DiffStats, TrackedRepo,
@@ -46,6 +47,32 @@ impl Supervisor {
         // shouldn't block archive, since the user's intent is "get rid of
         // this").
         let (snapshots, diff_stats) = capture_repo_snapshots(agent_id, &record.repos).await;
+
+        // A clone workspace's commits exist only inside the clone until they
+        // are pushed — teardown deletes unpushed ones for good (restore can
+        // refetch a pushed branch from origin, nothing else). Warn loudly so
+        // that data-loss case is diagnosable; archive itself stays
+        // best-effort by design.
+        for snap in &snapshots {
+            let Some(tip) = snap.branch_tip_sha.as_deref() else {
+                continue;
+            };
+            let Ok(wt) = repo_worktree_path(agent_id, &snap.subdir) else {
+                continue;
+            };
+            if provision::detect_mode(&wt) == Some(WorkspaceMode::Clone)
+                && git::rev_parse(&snap.repo_path, tip).await.is_err()
+            {
+                tracing::warn!(
+                    agent_id,
+                    subdir = %snap.subdir,
+                    tip,
+                    "archiving clone workspace whose tip isn't in the source repo; \
+                     restore will need the branch to have been pushed"
+                );
+            }
+        }
+
         teardown_agent_worktrees(agent_id, &record.repos, "archive").await;
 
         let archive = ArchiveMetadata {
@@ -79,9 +106,21 @@ impl Supervisor {
             ));
         }
 
-        // Pre-flight: every snapshot must have a tip SHA, and that SHA
-        // must still be reachable. We do this before any mutation so
-        // we don't leave a half-restored agent on failure.
+        // The provisioning mode is a dev flag until slice C1 stamps it per
+        // agent; restore re-reads it because the archived workspace left no
+        // on-disk trace to detect it from.
+        let workspace_mode = WorkspaceMode::from_setting(
+            self.workspace
+                .setting(provision::WORKSPACE_MODE_SETTING)
+                .as_deref(),
+        );
+
+        // Pre-flight: every snapshot must have a tip SHA, and that SHA must
+        // be recoverable. We do this before any mutation so we don't leave a
+        // half-restored agent on failure. A clone's commits live only in the
+        // (torn-down) clone and on the real remote once pushed, so under
+        // clone mode a tip that isn't in the source repo is still fine when
+        // a branch name exists — provisioning refetches it from origin.
         for snap in &archive.repos {
             let sha = snap.branch_tip_sha.as_deref().ok_or_else(|| {
                 Error::Other(format!(
@@ -89,13 +128,17 @@ impl Supervisor {
                     snap.subdir
                 ))
             })?;
-            git::rev_parse(&snap.repo_path, sha).await.map_err(|e| {
-                Error::Other(format!(
-                    "branch tip {} no longer reachable in {}: {e}",
-                    sha,
-                    snap.repo_path.display()
-                ))
-            })?;
+            if let Err(e) = git::rev_parse(&snap.repo_path, sha).await {
+                let fetchable =
+                    matches!(workspace_mode, WorkspaceMode::Clone) && snap.branch_name.is_some();
+                if !fetchable {
+                    return Err(Error::Other(format!(
+                        "branch tip {} no longer reachable in {}: {e}",
+                        sha,
+                        snap.repo_path.display()
+                    )));
+                }
+            }
         }
 
         // Ensure the agent parent dir exists.
@@ -115,19 +158,23 @@ impl Supervisor {
                     .map_err(|e| Error::Other(format!("create worktree parent: {e}")))?;
             }
 
+            let spec = CheckoutSpec {
+                source_repo: &snap.repo_path,
+                base_ref: tip_sha,
+                dest: &worktree,
+            };
             let branch = match &snap.branch_name {
                 // The agent had pushed a branch → recreate it at the tip,
                 // resolving name collisions with a -restored suffix.
                 Some(desired_name) => {
                     let chosen = choose_restore_branch_name(&snap.repo_path, desired_name).await;
-                    git::branch_create_at(&snap.repo_path, &chosen, tip_sha).await?;
-                    git::worktree_add_branch(&snap.repo_path, &worktree, &chosen).await?;
+                    provision::provision_on_branch(workspace_mode, &spec, &chosen).await?;
                     Some(chosen)
                 }
                 // Branchless agent (never pushed) → restore detached at the
                 // tip, ready to name its branch at the next push.
                 None => {
-                    git::worktree_add_detached(&snap.repo_path, &worktree, Some(tip_sha)).await?;
+                    provision::provision(workspace_mode, &spec).await?;
                     None
                 }
             };
@@ -217,9 +264,10 @@ async fn capture_repo_snapshots(
     let mut total_dels: u32 = 0;
 
     for repo in repos {
-        let branch_tip_sha = match repo_worktree_path(agent_id, &repo.subdir) {
-            Ok(wt) => git::rev_parse(&wt, "HEAD").await.ok(),
-            Err(_) => None,
+        let worktree = repo_worktree_path(agent_id, &repo.subdir).ok();
+        let branch_tip_sha = match &worktree {
+            Some(wt) => git::rev_parse(wt, "HEAD").await.ok(),
+            None => None,
         };
         // Prefer the immutable fork point; only fall back to resolving the
         // parent branch name (which may have drifted) for pre-migration
@@ -234,9 +282,12 @@ async fn capture_repo_snapshots(
 
         let mut adds = 0u32;
         let mut dels = 0u32;
-        if let (Some(from), Some(to)) = (&parent_branch_sha, &branch_tip_sha) {
+        // The diff runs inside the workspace, not the source repo: a clone's
+        // commits exist only in the clone's object store, while a worktree
+        // shares its store with the source — so the workspace resolves both.
+        if let (Some(wt), Some(from), Some(to)) = (&worktree, &parent_branch_sha, &branch_tip_sha) {
             if from != to {
-                if let Ok((a, d)) = git::diff_shortstat(&repo.repo_path, from, to).await {
+                if let Ok((a, d)) = git::diff_shortstat(wt, from, to).await {
                     adds = a;
                     dels = d;
                 }
@@ -302,9 +353,18 @@ async fn teardown_agent_worktrees(agent_id: &str, repos: &[TrackedRepo], op: &st
                 continue;
             }
         };
-        let _ = git::worktree_prune(&repo.repo_path).await;
-        if let Err(e) = git::worktree_remove(&repo.repo_path, &worktree, true).await {
-            tracing::warn!(error = %e, subdir = %repo.subdir, op, "worktree remove failed");
+        // Detect what actually sits on disk rather than re-reading the
+        // settings key: a dev-flag flip between spawn and teardown must not
+        // run the wrong arm. A missing/empty dir defaults to the worktree
+        // arm, whose prune+remove degrade to the pre-existing warnings.
+        let mode = provision::detect_mode(&worktree).unwrap_or(WorkspaceMode::Worktree);
+        let spec = CheckoutSpec {
+            source_repo: &repo.repo_path,
+            base_ref: "HEAD", // unused by teardown
+            dest: &worktree,
+        };
+        if let Err(e) = provision::teardown(mode, &spec).await {
+            tracing::warn!(error = %e, subdir = %repo.subdir, op, "workspace teardown failed");
         }
         if let Some(branch) = &repo.branch {
             if let Err(e) = git::branch_delete(&repo.repo_path, branch).await {

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -12,6 +12,7 @@ use crate::agent::{capabilities, per_turn_descriptor, Agent, PerTurnSpec, SpawnS
 use crate::error::{Error, Result};
 use crate::git;
 use crate::rpc;
+use crate::sandbox::provision::{self, CheckoutSpec, WorkspaceMode};
 use crate::workspace::{
     agent_parent_dir, allocate_repo_subdir, is_per_turn_provider, new_agent_record,
     repo_worktree_path, AgentRecord, AgentStatus, AgentView, TrackedRepo,
@@ -183,6 +184,15 @@ impl Supervisor {
         self.set_status(&app, &agent_id, AgentStatus::Spawning, None);
         arm_spawn_timeout(self.clone(), app.clone(), agent_id.clone());
 
+        // Workspace provisioning mode — a dev flag until slice C1 stamps the
+        // engine (and with it the mode) per agent. Read once, outside the
+        // spawn task, so the whole spawn uses one consistent mode.
+        let workspace_mode = WorkspaceMode::from_setting(
+            self.workspace
+                .setting(provision::WORKSPACE_MODE_SETTING)
+                .as_deref(),
+        );
+
         let sup = self.clone();
         let app_for_task = app.clone();
         let id_for_task = agent_id.clone();
@@ -204,9 +214,12 @@ impl Supervisor {
                     None => None,
                 },
             };
-            if let Err(e) =
-                git::worktree_add_detached(&repo_path, &primary_worktree, base.as_deref()).await
-            {
+            let spec = CheckoutSpec {
+                source_repo: &repo_path,
+                base_ref: base.as_deref().unwrap_or("HEAD"),
+                dest: &primary_worktree,
+            };
+            if let Err(e) = provision::provision(workspace_mode, &spec).await {
                 fail_spawn(&sup, &app_for_task, &id_for_task, e.to_string());
                 return;
             }
@@ -223,7 +236,7 @@ impl Supervisor {
             tokio::time::sleep(Duration::from_millis(350)).await;
 
             if let Err(e) = sup.start_process(&app_for_task, &id_for_task, true).await {
-                let _ = git::worktree_remove(&repo_path, &primary_worktree, true).await;
+                let _ = provision::teardown(workspace_mode, &spec).await;
                 let _ = tokio::fs::remove_dir_all(&parent_dir).await;
                 fail_spawn(&sup, &app_for_task, &id_for_task, e.to_string());
             }
@@ -265,7 +278,17 @@ impl Supervisor {
             Some(b) => git::fetch_fork_point(&repo_path, b).await,
             None => None,
         };
-        git::worktree_add_detached(&repo_path, &worktree, base.as_deref()).await?;
+        let workspace_mode = WorkspaceMode::from_setting(
+            self.workspace
+                .setting(provision::WORKSPACE_MODE_SETTING)
+                .as_deref(),
+        );
+        let spec = CheckoutSpec {
+            source_repo: &repo_path,
+            base_ref: base.as_deref().unwrap_or("HEAD"),
+            dest: &worktree,
+        };
+        provision::provision(workspace_mode, &spec).await?;
         let base_sha = git::rev_parse(&worktree, "HEAD").await.ok();
 
         let repo = TrackedRepo {

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -337,6 +337,13 @@ impl WorkspaceManager {
         Self { db }
     }
 
+    /// Read one key from the key-value `settings` table (`None` when unset).
+    /// Backend-side settings reads (e.g. the `workspace_mode` dev flag) go
+    /// through here so callers never need the raw connection.
+    pub fn setting(&self, key: &str) -> Option<String> {
+        crate::database::get_setting(&self.db.lock(), key)
+    }
+
     pub fn current(&self) -> Option<Workspace> {
         let conn = self.db.lock();
 


### PR DESCRIPTION
Implements slice A2 of the sandbox engine plan (`docs/sandboxing.md`): workspace creation becomes an engine-owned concern behind `sandbox/provision.rs`, with the clone-based provisioner the Docker engine will require — testable today under seatbelt via the `workspace_mode` dev flag (sqlite settings key, `worktree` default, not exposed in UI).

- New `sandbox/provision.rs`: `WorkspaceMode`, `CheckoutSpec`, `provision`, `provision_on_branch` (restore path), `teardown`, `detect_mode` (`.git` file = worktree, dir = clone — teardown dispatches on disk state so a dev-flag flip between spawn and teardown can't run the wrong arm).
- Worktree arm wraps the existing `worktree_add_detached`/`worktree_add_branch`/`remove`/`prune` calls; all supervisor call sites (spawn, add-repo, restore, archive/discard teardown, failed-spawn cleanup) now go through the API.
- Clone arm: `git clone --no-hardlinks` + `checkout --detach <base_ref>`, origin rewritten to the source's real remote (skipped with a log when none), repo-local `user.name`/`user.email` copied, teardown = `rm -rf`. `// TODO(perf)` left in place of `--filter=blob:none`.
- Host-side consumers fixed for clones: archive diff stats computed inside the workspace, `git_state` ahead/behind falls back to `origin/<parent>`, restore of a pushed clone branch refetches from origin, loud warn when archiving a clone with unpushed commits.

Known limitation (inherent to clone teardown = `rm -rf`): committed-but-never-pushed work in a clone workspace is unrecoverable after archive; restore fails cleanly at pre-flight. Flagged for follow-up (e.g. fetch the clone's HEAD into a hidden ref before teardown).

## Test plan
- `cargo build` zero warnings; `cargo test` 378 passed, 0 failed. 14 new tests: clone/worktree fixtures covering detached checkout at base ref, origin rewrite, identity copy, hardlink-free objects (nlink walk), idempotent teardown, branch restore incl. fetch-from-origin, orphan recovery, `git_state` fallback.
- **Pending manual pass** (A2 acceptance list): `workspace_mode=clone` full lifecycle under seatbelt — spawn, edit, `git_commit`/`git_push`/`open_pr`/`git_update_branch` with a conflict, archive, restore, diff panel rendering throughout.

Part of the swappable sandbox-engine effort; see `docs/sandboxing.md` slice graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)