### PR TITLE
feat(sandbox): settings-driven engine selection with per-agent stickiness (slice C1)

### DIFF
--- a/src-tauri/migrations/0013_workspace_sandbox_engine.sql
+++ b/src-tauri/migrations/0013_workspace_sandbox_engine.sql
@@ -1,0 +1,6 @@
+-- Sandbox engine the agent was stamped with at first spawn ("sandbox-exec" |
+-- "docker"). Reused on every subsequent process spawn (respawn, view-switch,
+-- restore), so a later settings change never re-engines an existing agent.
+-- NULL for agents created before engine selection existed — they always ran
+-- (and keep running) under sandbox-exec.
+ALTER TABLE workspaces ADD COLUMN sandbox_engine TEXT;

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -27,7 +27,7 @@ use crate::instructions;
 use crate::managed_session::{ManagedExit, ManagedSession, ManagedSpawn, ToolUseBehavior};
 use crate::pty_session::{PtyExit, PtySession, PtySpawn};
 use crate::sandbox;
-use crate::sandbox::{AgentLaunchCtx, Keepalive, LaunchPlan};
+use crate::sandbox::{AgentLaunchCtx, EngineKind, Keepalive, LaunchPlan};
 
 pub enum Agent {
     Pty(PtyAgent),
@@ -77,6 +77,10 @@ pub struct PerTurnSpec {
     pub instructions: Option<String>,
     /// The agent's RPC mailbox dir, exposed to the child as `FLETCH_RPC_DIR`.
     pub rpc_dir: PathBuf,
+    /// Sandbox engine stamped on the agent's record at creation and reused on
+    /// every subsequent spawn, so a settings change never re-engines an
+    /// existing agent (see `supervisor::lifecycle`).
+    pub engine: EngineKind,
 }
 
 /// The per-turn inputs a `*_build_args` builder turns into CLI argv. Bundled
@@ -782,6 +786,10 @@ pub struct SpawnSpec<'a> {
     pub rpc_dir: PathBuf,
     pub cols: u16,
     pub rows: u16,
+    /// Sandbox engine stamped on the agent's record at creation and reused on
+    /// every subsequent spawn (fresh, view-switch, resume), so a settings
+    /// change never re-engines an existing agent (see `supervisor::lifecycle`).
+    pub engine: EngineKind,
 }
 
 /// The environment Fletch injects into every agent child: the absolute path to
@@ -819,7 +827,7 @@ impl Agent {
             env: launch_env,
             keepalive,
             kill,
-        } = sandbox::current_engine().launch_agent(&ctx, &claude)?;
+        } = sandbox::engine_for(spec.engine).launch_agent(&ctx, &claude)?;
         let mut args = prefix_args;
         args.extend(agent_args);
         let mut env = launch_env;
@@ -897,7 +905,7 @@ impl Agent {
             env: launch_env,
             keepalive,
             kill,
-        } = sandbox::current_engine().launch_agent(&ctx, &bin)?;
+        } = sandbox::engine_for(spec.engine).launch_agent(&ctx, &bin)?;
         let mut args = prefix_args;
         args.extend(agent_args);
         let mut env = launch_env;
@@ -956,7 +964,7 @@ impl Agent {
             env: launch_env,
             keepalive,
             kill,
-        } = sandbox::current_engine().launch_agent(&ctx, &claude)?;
+        } = sandbox::engine_for(spec.engine).launch_agent(&ctx, &claude)?;
         let mut args = prefix_args;
         args.extend(agent_args);
         let mut env = launch_env;
@@ -1070,7 +1078,7 @@ impl Agent {
             env: launch_env,
             keepalive,
             kill,
-        } = sandbox::current_engine().launch_agent(&ctx, agent_bin)?;
+        } = sandbox::engine_for(spec.engine).launch_agent(&ctx, agent_bin)?;
         let mut env = launch_env;
         env.extend(rpc_env(&spec.rpc_dir));
 

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -102,6 +102,7 @@ const MIGRATIONS: &[&str] = &[
     include_str!("../migrations/0010_worktree_pr_number.sql"),
     include_str!("../migrations/0011_custom_agents.sql"),
     include_str!("../migrations/0012_user_turn_timing.sql"),
+    include_str!("../migrations/0013_workspace_sandbox_engine.sql"),
 ];
 
 fn get_migrations() -> Migrations<'static> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -387,6 +387,60 @@ fn track_app_opened() {
     telemetry::track("app_opened", json!({}));
 }
 
+/// The persisted sandbox engine selection (`"sandbox-exec"` | `"docker"`).
+/// Reads the in-memory mirror seeded at startup and kept in sync by
+/// `set_sandbox_engine`, so no DB handle is needed.
+#[tauri::command]
+fn get_sandbox_engine() -> String {
+    sandbox::selected_engine_kind().as_setting().to_string()
+}
+
+/// Change the sandbox engine stamped onto *new* agents. Docker is validated
+/// against a live daemon probe before being accepted, so a success here means
+/// the choice is actionable. Persists to `settings` and updates the in-memory
+/// mirror — like `set_agent_bin_override` keeps the DB and process state in
+/// sync. Existing agents are unaffected: each keeps the engine stamped on its
+/// record at creation.
+#[tauri::command]
+async fn set_sandbox_engine(
+    engine: String,
+    state: tauri::State<'_, DbState>,
+) -> Result<(), String> {
+    let kind = sandbox::EngineKind::from_setting(&engine)
+        .ok_or_else(|| format!("unknown sandbox engine: {engine}"))?;
+    if kind == sandbox::EngineKind::Docker {
+        // `spawn_blocking`: the probe can block up to its 2s timeout.
+        let probe = tauri::async_runtime::spawn_blocking(sandbox::docker_availability)
+            .await
+            .map_err(|e| e.to_string())?;
+        match probe {
+            sandbox::DockerAvailability::Available { .. } => {}
+            sandbox::DockerAvailability::NotInstalled => {
+                return Err("Docker is not installed — install Docker Desktop first.".into())
+            }
+            sandbox::DockerAvailability::DaemonDown => {
+                return Err("Docker isn't running — start Docker Desktop first.".into())
+            }
+        }
+    }
+    {
+        let conn = state.lock();
+        database::set_setting(&conn, sandbox::ENGINE_SETTING, kind.as_setting())
+            .map_err(|e| e.to_string())?;
+    }
+    sandbox::set_selected_engine_kind(kind);
+    Ok(())
+}
+
+/// Probe the local Docker installation for the settings UI. Async +
+/// `spawn_blocking` because the probe can block up to its 2s timeout.
+#[tauri::command]
+async fn probe_docker_engine() -> Result<sandbox::DockerAvailability, String> {
+    tauri::async_runtime::spawn_blocking(sandbox::docker_availability)
+        .await
+        .map_err(|e| e.to_string())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Error/crash reporting. The DSN is baked in at build time via
@@ -463,6 +517,17 @@ pub fn run() {
             // resolution (deep in spawn/probe paths, with no DB handle) can
             // honor user-set custom paths without touching the DB each time.
             bin_resolve::set_agent_overrides(database::load_agent_bin_overrides(&db.lock()));
+
+            // Seed the in-memory sandbox engine selection (mirror of the
+            // `sandbox_engine` setting) so spawn-time engine resolution —
+            // deep in agent code with no DB handle — honors the user's
+            // choice. Missing/unknown values keep the sandbox-exec default.
+            if let Some(kind) = database::get_setting(&db.lock(), sandbox::ENGINE_SETTING)
+                .as_deref()
+                .and_then(sandbox::EngineKind::from_setting)
+            {
+                sandbox::set_selected_engine_kind(kind);
+            }
 
             // Unified git resolution: point the portable-install root at app
             // data, wire the fallback commit identity to the signed-in
@@ -588,6 +653,9 @@ pub fn run() {
             set_agent_bin_override,
             set_telemetry_enabled,
             track_app_opened,
+            get_sandbox_engine,
+            set_sandbox_engine,
+            probe_docker_engine,
             oauth::oauth_device_login,
             commands::get_workspace,
             commands::get_agent_diff_stats,

--- a/src-tauri/src/sandbox/docker_probe.rs
+++ b/src-tauri/src/sandbox/docker_probe.rs
@@ -1,0 +1,153 @@
+//! Temporary Docker availability probe for engine selection (slice C1).
+//!
+//! Replaced by `sandbox/docker/probe.rs` when slice B2 wires the engines
+//! together with the full `sandbox/docker/` module (which owns caching, the
+//! CLI locator, and the real `DockerEngine`). Kept in its own file so that
+//! swap deletes this file without touching the rest of `sandbox/`.
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use crate::bin_resolve;
+use crate::error::{Error, Result};
+
+use super::engine::{AgentLaunchCtx, EngineKind, LaunchPlan, SandboxEngine};
+
+/// How long the daemon gets to answer `docker version` before we call it
+/// down. Un-timed, the CLI blocks for ~30s when Docker Desktop is installed
+/// but stopped — far too long for spawn paths and UI polling.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Result of probing the local Docker installation. Serializes to the wire
+/// shape the settings UI consumes: `{ "status": "...", "version"?: "..." }`.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(tag = "status", rename_all = "kebab-case")]
+pub enum DockerAvailability {
+    /// Daemon reachable; `version` is the server version it reported.
+    Available { version: String },
+    /// No docker binary found on this machine.
+    NotInstalled,
+    /// Binary present but the daemon didn't answer (not running, or hung
+    /// past the probe timeout).
+    DaemonDown,
+}
+
+/// Probe Docker: resolve the CLI (PATH / login-shell PATH / common install
+/// dirs, same as agent binaries), then ask the daemon for its server version
+/// under a hard timeout.
+pub fn availability() -> DockerAvailability {
+    let Some(home) = dirs::home_dir() else {
+        return DockerAvailability::NotInstalled;
+    };
+    let Some(docker) = bin_resolve::resolve_bin("docker", &home) else {
+        return DockerAvailability::NotInstalled;
+    };
+    let mut child = match Command::new(&docker)
+        .args(["version", "--format", "{{.Server.Version}}"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(child) => child,
+        // The binary resolved but won't exec — treat as not installed rather
+        // than daemon-down: there is nothing to "start".
+        Err(_) => return DockerAvailability::NotInstalled,
+    };
+
+    let deadline = Instant::now() + PROBE_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                // Output is a single short version line, so reading after exit
+                // can't deadlock on a full pipe.
+                let mut out = String::new();
+                if let Some(stdout) = child.stdout.as_mut() {
+                    let _ = stdout.read_to_string(&mut out);
+                }
+                let version = out.trim();
+                return if status.success() && !version.is_empty() {
+                    DockerAvailability::Available {
+                        version: version.to_string(),
+                    }
+                } else {
+                    // CLI present but no server answered.
+                    DockerAvailability::DaemonDown
+                };
+            }
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            // Timed out (or the child handle broke): reap and report down.
+            _ => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return DockerAvailability::DaemonDown;
+            }
+        }
+    }
+}
+
+/// Stand-in for the Docker engine until slice B2 lands its launch path.
+/// Selecting docker is availability-gated in settings, but no engine exists
+/// yet, so a docker-stamped agent that reaches launch gets a clear error
+/// instead of a silent seatbelt downgrade. The setting (and the agent's
+/// stamped engine) persist — B2 makes both spawn for real.
+pub struct DockerEngineStub;
+
+impl SandboxEngine for DockerEngineStub {
+    fn kind(&self) -> EngineKind {
+        EngineKind::Docker
+    }
+
+    fn launch_agent(&self, _ctx: &AgentLaunchCtx, _agent_bin: &str) -> Result<LaunchPlan> {
+        Err(Error::Other(
+            "Docker engine not implemented yet — switch the sandbox engine back to sandbox-exec in Settings › General".into(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+
+    #[test]
+    fn availability_serializes_to_the_wire_shape() {
+        let available = DockerAvailability::Available {
+            version: "27.3.1".into(),
+        };
+        assert_eq!(
+            serde_json::to_value(available).unwrap(),
+            serde_json::json!({ "status": "available", "version": "27.3.1" })
+        );
+        assert_eq!(
+            serde_json::to_value(DockerAvailability::NotInstalled).unwrap(),
+            serde_json::json!({ "status": "not-installed" })
+        );
+        assert_eq!(
+            serde_json::to_value(DockerAvailability::DaemonDown).unwrap(),
+            serde_json::json!({ "status": "daemon-down" })
+        );
+    }
+
+    #[test]
+    fn stub_engine_refuses_to_launch() {
+        let ctx = AgentLaunchCtx {
+            agent_id: "test-agent",
+            writable_root: Path::new("/tmp/agent"),
+            rpc_dir: Path::new("/tmp/rpc"),
+            cwd: Path::new("/tmp/agent/repo"),
+            home: Path::new("/tmp/home"),
+            interactive: false,
+        };
+        // `match` rather than `expect_err`: `LaunchPlan` isn't `Debug`.
+        let err = match DockerEngineStub.launch_agent(&ctx, "claude") {
+            Ok(_) => panic!("stub must not launch"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("not implemented yet"));
+    }
+}

--- a/src-tauri/src/sandbox/engine.rs
+++ b/src-tauri/src/sandbox/engine.rs
@@ -3,11 +3,32 @@ use std::sync::Arc;
 
 use crate::error::Result;
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EngineKind {
     SandboxExec,
     Docker,
+}
+
+impl EngineKind {
+    /// The `sandbox_engine` settings-value spelling for this kind. Shared with
+    /// the frontend's `SandboxEngine` type, so both sides agree on the wire
+    /// strings.
+    pub fn as_setting(self) -> &'static str {
+        match self {
+            Self::SandboxExec => "sandbox-exec",
+            Self::Docker => "docker",
+        }
+    }
+
+    /// Parse a `sandbox_engine` settings value. `None` for unknown values so
+    /// callers pick their own fallback (spawn paths default to seatbelt).
+    pub fn from_setting(value: &str) -> Option<Self> {
+        match value {
+            "sandbox-exec" => Some(Self::SandboxExec),
+            "docker" => Some(Self::Docker),
+            _ => None,
+        }
+    }
 }
 
 #[allow(dead_code)]
@@ -109,5 +130,23 @@ pub trait SandboxEngine: Send + Sync {
     /// (Docker); the default defers to the session's own child handle.
     fn is_alive(&self, _plan: &KillPlan) -> bool {
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EngineKind;
+
+    #[test]
+    fn engine_kind_setting_round_trips() {
+        for kind in [EngineKind::SandboxExec, EngineKind::Docker] {
+            assert_eq!(EngineKind::from_setting(kind.as_setting()), Some(kind));
+        }
+    }
+
+    #[test]
+    fn engine_kind_rejects_unknown_setting_values() {
+        assert_eq!(EngineKind::from_setting("podman"), None);
+        assert_eq!(EngineKind::from_setting(""), None);
     }
 }

--- a/src-tauri/src/sandbox/mod.rs
+++ b/src-tauri/src/sandbox/mod.rs
@@ -1,19 +1,74 @@
+mod docker_probe;
 mod engine;
 mod seatbelt;
 
 use std::sync::{Arc, OnceLock};
 
-pub use engine::{AgentLaunchCtx, Keepalive, KillHandle, LaunchPlan, SandboxEngine};
+use parking_lot::RwLock;
+
+pub use docker_probe::{availability as docker_availability, DockerAvailability};
+pub use engine::{AgentLaunchCtx, EngineKind, Keepalive, KillHandle, LaunchPlan, SandboxEngine};
 pub use seatbelt::{
     build_run_profile, cleanup_nested_rpc_roots, cleanup_nested_worktrees_roots, nested_rpc_root,
     nested_worktrees_root, profile_tempfile, SANDBOX_EXEC,
 };
 
-/// The engine used for agent launches. Hardcoded to seatbelt until slice C1
-/// makes it setting-driven; resolved once so every launch in a process run
-/// shares the same instance. Teardown never consults this — sessions carry a
-/// `KillHandle` bound to the engine that launched them.
+/// The `settings` key holding the user's engine choice; values are
+/// [`EngineKind::as_setting`] spellings, default `sandbox-exec`.
+pub const ENGINE_SETTING: &str = "sandbox_engine";
+
+/// The user's engine selection, mirrored from the `sandbox_engine` setting so
+/// spawn paths (deep in agent code, no DB handle) can read it. Seeded at
+/// startup (`lib.rs setup`) and updated by the `set_sandbox_engine` command.
+/// Teardown never consults this — sessions carry a `KillHandle` bound to the
+/// engine that launched them.
+static SELECTED_ENGINE: RwLock<EngineKind> = RwLock::new(EngineKind::SandboxExec);
+
+pub fn set_selected_engine_kind(kind: EngineKind) {
+    *SELECTED_ENGINE.write() = kind;
+}
+
+/// The engine a *new* agent would be stamped with right now. Existing agents
+/// keep the kind stamped on their record at creation (see
+/// `supervisor::lifecycle::spawn_agent`), so a settings change never
+/// re-engines them.
+pub fn selected_engine_kind() -> EngineKind {
+    *SELECTED_ENGINE.read()
+}
+
+/// Resolve the engine for an agent stamped with `kind`, availability-checked
+/// at spawn time: docker falls back to seatbelt with a warning when the
+/// daemon is unreachable, so the agent still runs — sandboxed, just not
+/// containerized. When docker *is* reachable this returns the pre-B2 stub,
+/// whose `launch_agent` fails with a clear "not implemented yet" error.
+pub fn engine_for(kind: EngineKind) -> Arc<dyn SandboxEngine> {
+    match kind {
+        EngineKind::SandboxExec => seatbelt_engine(),
+        EngineKind::Docker => match docker_probe::availability() {
+            DockerAvailability::Available { .. } => Arc::new(docker_probe::DockerEngineStub),
+            status => {
+                tracing::warn!(
+                    ?status,
+                    "docker engine selected but unavailable; falling back to sandbox-exec"
+                );
+                seatbelt_engine()
+            }
+        },
+    }
+}
+
+/// The engine matching the current setting — what a launch would use absent a
+/// per-agent stamp. Launch paths resolve through `engine_for` with the kind
+/// stamped on the agent's record instead; this stays for callers with no
+/// record in hand (none today — B2's non-agent surfaces use it).
+#[allow(dead_code)]
 pub fn current_engine() -> Arc<dyn SandboxEngine> {
+    engine_for(selected_engine_kind())
+}
+
+/// The seatbelt engine, shared process-wide: it is stateless, and per-launch
+/// state (profile tempfile) lives on the `LaunchPlan`.
+fn seatbelt_engine() -> Arc<dyn SandboxEngine> {
     static ENGINE: OnceLock<Arc<dyn SandboxEngine>> = OnceLock::new();
     ENGINE
         .get_or_init(|| Arc::new(seatbelt::SandboxExecEngine))

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -12,6 +12,7 @@ use crate::agent::{capabilities, per_turn_descriptor, Agent, PerTurnSpec, SpawnS
 use crate::error::{Error, Result};
 use crate::git;
 use crate::rpc;
+use crate::sandbox::{self, EngineKind};
 use crate::workspace::{
     agent_parent_dir, allocate_repo_subdir, is_per_turn_provider, new_agent_record,
     repo_worktree_path, AgentRecord, AgentStatus, AgentView, TrackedRepo,
@@ -168,6 +169,11 @@ impl Supervisor {
         // built-in spawn. The brief is re-injected on every spawn/resume.
         record.instructions = instructions;
         record.custom_agent_id = custom_agent_id;
+        // Stamp the sandbox engine at creation: the agent keeps this engine
+        // for life (respawn, view-switch, restore), so a later settings change
+        // never re-engines it — see `spawn_agent_process`, which reuses the
+        // stored value instead of the live setting.
+        record.sandbox_engine = Some(sandbox::selected_engine_kind().as_setting().to_string());
         let parent_dir = agent_parent_dir(&agent_id)?;
         let primary_worktree = repo_worktree_path(&agent_id, &subdir)?;
 
@@ -432,6 +438,15 @@ impl Supervisor {
         } = launch;
         let agent_id_str = agent_id.to_string();
 
+        // The engine stamped at creation. Records from before engine selection
+        // existed (NULL) always ran under sandbox-exec, so that stays their
+        // permanent kind — never re-derive from the live setting here.
+        let engine = record
+            .sandbox_engine
+            .as_deref()
+            .and_then(EngineKind::from_setting)
+            .unwrap_or(EngineKind::SandboxExec);
+
         if per_turn {
             match record.view {
                 // Native view: launch the agent's interactive TUI in a PTY,
@@ -458,6 +473,7 @@ impl Supervisor {
                         rpc_dir,
                         cols: 120,
                         rows: 32,
+                        engine,
                     };
                     spawn_pty_per_turn_agent(
                         spec,
@@ -481,6 +497,7 @@ impl Supervisor {
                         model: record.model.clone(),
                         instructions: record.instructions.clone(),
                         rpc_dir,
+                        engine,
                     },
                     app.clone(),
                     agent_id_str.clone(),
@@ -506,6 +523,7 @@ impl Supervisor {
                 rpc_dir,
                 cols: 120,
                 rows: 32,
+                engine,
             };
             match record.view {
                 AgentView::Native => spawn_pty_agent(

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -165,6 +165,12 @@ pub struct AgentRecord {
     /// name/color in the sidebar. `None` for a plain built-in spawn.
     #[serde(default)]
     pub custom_agent_id: Option<String>,
+    /// Sandbox engine stamped at creation (an `EngineKind::as_setting`
+    /// spelling) and reused on every process spawn, so a settings change never
+    /// re-engines an existing agent. `None` = created before engine selection
+    /// existed — such agents always ran (and keep running) under sandbox-exec.
+    #[serde(default)]
+    pub sandbox_engine: Option<String>,
     pub created_at: String,
     #[serde(default)]
     pub last_error: Option<String>,
@@ -304,7 +310,8 @@ pub struct WorkspaceManager {
 const AGENT_SELECT: &str = "SELECT w.id, w.project_id, w.name, w.task, w.created_at,
             w.stopped_at, w.archived_at,
             s.provider, s.view, s.provider_session_id, s.last_error,
-            s.effort, s.model, s.instructions, s.custom_agent_id
+            s.effort, s.model, s.instructions, s.custom_agent_id,
+            w.sandbox_engine
      FROM workspaces w
      LEFT JOIN sessions s ON s.workspace_id = w.id";
 
@@ -325,6 +332,7 @@ type AgentRow = (
     Option<String>, // s.model
     Option<String>, // s.instructions
     Option<String>, // s.custom_agent_id
+    Option<String>, // w.sandbox_engine
 );
 
 impl WorkspaceManager {
@@ -468,14 +476,15 @@ impl WorkspaceManager {
 
         // The workspace is the durable work-area (identity + task metadata).
         tx.execute(
-            "INSERT INTO workspaces (id, project_id, name, task, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5)",
+            "INSERT INTO workspaces (id, project_id, name, task, created_at, sandbox_engine)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             rusqlite::params![
                 record.id,
                 project_id,
                 record.name,
                 record.task,
                 created_millis,
+                record.sandbox_engine,
             ],
         )?;
 
@@ -1404,7 +1413,7 @@ impl WorkspaceManager {
     }
 
     /// Map a row from an [`AGENT_SELECT`] query into the raw column tuple.
-    /// Shared by `query_all_agents` and `load_agent` so the 15-column layout
+    /// Shared by `query_all_agents` and `load_agent` so the 16-column layout
     /// is decoded in exactly one place.
     fn map_agent_row(row: &rusqlite::Row) -> rusqlite::Result<AgentRow> {
         Ok((
@@ -1423,6 +1432,7 @@ impl WorkspaceManager {
             row.get(12)?,
             row.get(13)?,
             row.get(14)?,
+            row.get(15)?,
         ))
     }
 
@@ -1446,6 +1456,7 @@ impl WorkspaceManager {
             model,
             instructions,
             custom_agent_id,
+            sandbox_engine,
         ) = row;
 
         let is_archived = archived_millis.is_some();
@@ -1481,6 +1492,7 @@ impl WorkspaceManager {
             model,
             instructions,
             custom_agent_id,
+            sandbox_engine,
             created_at: millis_to_iso(created_millis),
             last_error,
             archive,
@@ -1530,6 +1542,10 @@ pub fn new_agent_record(
         model: None,
         instructions: None,
         custom_agent_id: None,
+        // Stamped by the spawn path (`supervisor::lifecycle::spawn_agent`)
+        // from the live setting — callers building records directly (tests)
+        // default to the pre-selection NULL, which spawns under sandbox-exec.
+        sandbox_engine: None,
         created_at: Utc::now().to_rfc3339(),
         last_error: None,
         archive: None,
@@ -1721,6 +1737,44 @@ mod tests {
         let dolomites = cur.agents.iter().find(|a| a.id == "dolomites").unwrap();
         assert_eq!(yosemite.status, AgentStatus::Idle);
         assert_eq!(dolomites.status, AgentStatus::Stopped);
+    }
+
+    #[test]
+    fn sandbox_engine_stamp_round_trips() {
+        let db = test_db();
+        seed_repo(&db, "/r");
+        seed_repo(&db, "/r2");
+        let wm = WorkspaceManager::new(db);
+
+        // A stamped engine persists verbatim and comes back on load — the
+        // stickiness contract: spawn paths reuse this, never the live setting.
+        let mut stamped = new_agent_record(
+            "yosemite".into(),
+            "a".into(),
+            "claude".into(),
+            mk_repo("/r"),
+            "t".into(),
+            AgentView::Custom,
+        );
+        stamped.sandbox_engine = Some("docker".into());
+        wm.add_agent(&mut stamped).unwrap();
+        assert_eq!(
+            wm.agent("yosemite").unwrap().sandbox_engine.as_deref(),
+            Some("docker")
+        );
+
+        // An unstamped record (pre-selection agents) stays NULL, which spawn
+        // paths treat as sandbox-exec.
+        let mut legacy = new_agent_record(
+            "dolomites".into(),
+            "b".into(),
+            "claude".into(),
+            mk_repo("/r2"),
+            "t".into(),
+            AgentView::Custom,
+        );
+        wm.add_agent(&mut legacy).unwrap();
+        assert_eq!(wm.agent("dolomites").unwrap().sandbox_engine, None);
     }
 
     #[test]

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import type { AgentModels } from "./data/modelCatalog/types";
+import type { SandboxEngine } from "./storage/preferences";
 
 export type AgentStatus = "spawning" | "running" | "idle" | "stopped" | "error";
 
@@ -62,6 +63,10 @@ export interface AgentRecord {
   /** The custom agent this session was spawned from (null for a built-in
    *  spawn). Used to show the custom agent's name/color in the sidebar. */
   custom_agent_id?: string | null;
+  /** Sandbox engine stamped at creation ("sandbox-exec" | "docker") and kept
+   *  for the agent's life — a settings change never re-engines it. Null for
+   *  agents created before engine selection existed (they run sandbox-exec). */
+  sandbox_engine?: string | null;
 }
 
 export interface Workspace {
@@ -349,6 +354,13 @@ export interface GhRepoSummary {
   updated_at: string;
 }
 
+/** Result of probing the local Docker installation (Settings › General).
+ *  `version` is the daemon's server version, present only when available. */
+export interface DockerProbe {
+  status: "available" | "not-installed" | "daemon-down";
+  version?: string;
+}
+
 /** An editor or terminal detected on the user's machine (title-bar launcher). */
 export interface DetectedEditor {
   id: string;
@@ -370,6 +382,12 @@ export const api = {
   // Emit the deferred first `app_opened` once onboarding completes — i.e. after
   // the data-sharing disclosure has been shown. See `track_app_opened` (Rust).
   trackAppOpened: () => invoke<void>("track_app_opened"),
+  // Sandbox engine selection. The setting is backend-owned (snake_case
+  // `sandbox_engine`, written by `set_sandbox_engine` — which validates docker
+  // against a live daemon probe and refuses when it's unreachable).
+  getSandboxEngine: () => invoke<SandboxEngine>("get_sandbox_engine"),
+  setSandboxEngine: (engine: SandboxEngine) => invoke<void>("set_sandbox_engine", { engine }),
+  probeDockerEngine: () => invoke<DockerProbe>("probe_docker_engine"),
   getAgentDiffStats: (agentId: string) => invoke<DiffStats>("get_agent_diff_stats", { agentId }),
   addWorkspaceRepo: (repoPath: string) => invoke<Workspace>("add_workspace_repo", { repoPath }),
   removeWorkspaceRepo: (repoPath: string) =>

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -52,9 +52,14 @@ export function GeneralPane() {
   const dockerProbe = useAppStore((s) => s.dockerProbe);
   const refreshDockerProbe = useAppStore((s) => s.refreshDockerProbe);
 
-  // Probe Docker on open so the engine option reflects the live daemon state.
+  // Probe Docker on open — and again whenever the window regains focus — so the
+  // engine option reflects the live daemon state, including when the user starts
+  // Docker Desktop (as the disabled-option hint suggests) while the pane is open.
   useEffect(() => {
     void refreshDockerProbe();
+    const onFocus = () => void refreshDockerProbe();
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
   }, [refreshDockerProbe]);
 
   // Three states for the docker option: enabled when the daemon answered the

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -1,7 +1,9 @@
+import { useEffect } from "react";
 import { Icon } from "@/components/Icon";
 import { Button } from "@/components/ui/Button";
+import { Select } from "@/components/ui/Select";
 import { ACCENTS } from "@/data/providers";
-import type { Density, ThemeMode } from "@/storage/preferences";
+import type { Density, SandboxEngine, ThemeMode } from "@/storage/preferences";
 import { useAppStore } from "@/store";
 import { type FeatureItem, SetGroup, SetHead, SetRow, SetSeg, SetToggle } from "./primitives";
 
@@ -45,6 +47,25 @@ export function GeneralPane() {
   const telemetryEnabled = useAppStore((s) => s.telemetryEnabled);
   const setTelemetryEnabled = useAppStore((s) => s.setTelemetryEnabled);
   const revealLogs = useAppStore((s) => s.revealLogs);
+  const sandboxEngine = useAppStore((s) => s.sandboxEngine);
+  const setSandboxEngine = useAppStore((s) => s.setSandboxEngine);
+  const dockerProbe = useAppStore((s) => s.dockerProbe);
+  const refreshDockerProbe = useAppStore((s) => s.refreshDockerProbe);
+
+  // Probe Docker on open so the engine option reflects the live daemon state.
+  useEffect(() => {
+    void refreshDockerProbe();
+  }, [refreshDockerProbe]);
+
+  // Three states for the docker option: enabled when the daemon answered the
+  // probe; otherwise disabled with a hint saying how to fix it. `null` (probe
+  // still in flight) gates off too — never offer an engine we can't confirm.
+  const dockerAvailable = dockerProbe?.status === "available";
+  const dockerHint = dockerAvailable
+    ? dockerProbe?.version && `v${dockerProbe.version}`
+    : dockerProbe?.status === "daemon-down"
+      ? "Start Docker Desktop"
+      : "Install Docker Desktop";
 
   const FeatureRow = ({ item }: { item: FeatureItem }) => (
     <SetRow title={item.title} sub={item.sub}>
@@ -127,6 +148,28 @@ export function GeneralPane() {
           sub="Show a desktop notification when an agent finishes a turn or needs your input while you're looking elsewhere."
         >
           <SetToggle on={notifyEnabled} onClick={() => setNotifyEnabled(!notifyEnabled)} />
+        </SetRow>
+      </SetGroup>
+
+      <SetGroup label="Sandbox">
+        <SetRow
+          title="Engine"
+          sub="Applies to newly created agents; existing agents keep the engine they started with. Docker agents run in a Linux container: builds and tests run on Linux, not macOS. Only Claude Code is available in containers for now."
+        >
+          <Select<SandboxEngine>
+            value={sandboxEngine}
+            ariaLabel="Sandbox engine"
+            options={[
+              { value: "sandbox-exec", label: "Seatbelt (sandbox-exec)" },
+              {
+                value: "docker",
+                label: "Docker",
+                hint: dockerHint || undefined,
+                disabled: !dockerAvailable,
+              },
+            ]}
+            onChange={(v) => void setSandboxEngine(v)}
+          />
         </SetRow>
       </SetGroup>
 

--- a/src/components/SettingsScreen/SettingsScreen.css
+++ b/src/components/SettingsScreen/SettingsScreen.css
@@ -216,6 +216,11 @@
   flex-shrink: 0;
   gap: 8px;
 }
+/* Dropdowns used as row controls (e.g. the sandbox engine select) need an
+   explicit width — as a flex item the select would shrink-wrap its label. */
+.set-row-c .ui-select {
+  width: 240px;
+}
 
 /* premium toggle */
 .set-toggle {

--- a/src/components/ui/Select.css
+++ b/src/components/ui/Select.css
@@ -73,3 +73,10 @@
   background: var(--hover);
   box-shadow: inset 0 0 0 1px var(--accent-line);
 }
+/* Per-option disabled state (SelectOption.disabled): visible with its hint
+   explaining why, but not hoverable/selectable. */
+.ui-select-dd .dd-item:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  background: none;
+}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -10,6 +10,10 @@ export interface SelectOption<T extends string> {
   /** Optional leading visual (e.g. a provider icon) shown before the label,
    *  in both the trigger and the option row. */
   icon?: ReactNode;
+  /** Disable just this option: shown (with its hint explaining why) but not
+   *  selectable. Distinct from the component-level `disabled`, which locks
+   *  the whole control. */
+  disabled?: boolean;
 }
 
 interface Props<T extends string> {
@@ -108,6 +112,8 @@ export function Select<T extends string>({
                 type="button"
                 role="option"
                 aria-selected={o.value === value}
+                aria-disabled={o.disabled}
+                disabled={o.disabled}
                 className={`dd-item flex-center ${o.value === value ? "active" : ""}`}
                 onClick={() => pick(o.value)}
               >

--- a/src/storage/preferences.ts
+++ b/src/storage/preferences.ts
@@ -156,6 +156,23 @@ export function parsePaneWidth(raw: string | undefined, fallback: number): numbe
   return Math.min(MAX_PANE_WIDTH, Math.max(MIN_PANE_WIDTH, n));
 }
 
+// ---- Sandbox engine ------------------------------------------------------------
+
+/** Isolation engine new agents are stamped with. Mirrors the backend's
+ *  `EngineKind::as_setting` spellings (`sandbox/engine.rs`), so both sides
+ *  agree on the wire strings. */
+export type SandboxEngine = "sandbox-exec" | "docker";
+
+export const DEFAULT_SANDBOX_ENGINE: SandboxEngine = "sandbox-exec";
+
+/** Parse the `sandbox_engine` setting. The key is backend-owned (snake_case,
+ *  written by the `set_sandbox_engine` Rust command — never via a frontend
+ *  `setSetting`, same posture as `telemetry_enabled`). Unknown/missing values
+ *  fall back to the seatbelt default, matching the backend's parser. */
+export function parseSandboxEngine(raw: string | undefined): SandboxEngine {
+  return raw === "docker" ? "docker" : DEFAULT_SANDBOX_ENGINE;
+}
+
 // ---- Provider binary path overrides ------------------------------------------
 
 /** Settings-key prefix for per-agent custom binary paths. Must match the

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -40,6 +40,7 @@ import {
   parsePaneWidth,
   parseProviderFlags,
   parseProviderPathOverrides,
+  parseSandboxEngine,
   type ThemeMode,
   type WorkspaceView,
 } from "@/storage/preferences";
@@ -124,6 +125,9 @@ const hydrateSettings = async (set: AppSet) => {
       // switch a caller to `setSetting("telemetryEnabled", …)`: that's a
       // different key and the toggle would silently stop working.
       telemetryEnabled: s.telemetry_enabled !== "false",
+      // Backend-owned like telemetry_enabled (snake_case, written by the
+      // `set_sandbox_engine` Rust command) — read it, never setSetting it.
+      sandboxEngine: parseSandboxEngine(s.sandbox_engine),
       // Auto-open the welcome tour for new users (no completion flag yet).
       onboardingOpen: s.onboardingComplete !== "true",
       // Panel layout — restore the user's last splitter widths and collapse state.

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -9,6 +9,7 @@ import { createDraftsSlice } from "./drafts";
 import { createGitSlice } from "./git";
 import { createProvidersSlice } from "./providers";
 import { createReposSlice } from "./repos";
+import { createSandboxSlice } from "./sandbox";
 import type { AppState } from "./types";
 import { createUiSlice } from "./ui";
 import { createWorkspaceSlice } from "./workspace";
@@ -27,6 +28,7 @@ export const useAppStore = create<AppState>()((...a) => ({
   ...createAppearanceSlice(...a),
   ...createProvidersSlice(...a),
   ...createCustomAgentsSlice(...a),
+  ...createSandboxSlice(...a),
 }));
 
 export type { ChatItem } from "@/adapters";

--- a/src/store/sandbox.ts
+++ b/src/store/sandbox.ts
@@ -1,0 +1,33 @@
+import { api } from "@/api";
+import { DEFAULT_SANDBOX_ENGINE } from "@/storage/preferences";
+import type { SandboxSlice, SliceCreator } from "./types";
+
+export const createSandboxSlice: SliceCreator<SandboxSlice> = (set, get) => ({
+  sandboxEngine: DEFAULT_SANDBOX_ENGINE,
+  dockerProbe: null,
+
+  setSandboxEngine: async (engine) => {
+    const prev = get().sandboxEngine;
+    // Optimistic: the backend validates docker against a live daemon probe
+    // and can refuse (probe raced a daemon shutdown) — revert so the UI never
+    // shows an engine that didn't persist.
+    set({ sandboxEngine: engine });
+    try {
+      // The backend command persists the `sandbox_engine` setting AND updates
+      // its in-memory spawn-path mirror, so we don't also call setSetting here
+      // (same posture as `setTelemetryEnabled`).
+      await api.setSandboxEngine(engine);
+    } catch (e) {
+      set({ sandboxEngine: prev, lastError: String(e) });
+    }
+  },
+  refreshDockerProbe: async () => {
+    try {
+      set({ dockerProbe: await api.probeDockerEngine() });
+    } catch {
+      // A failed probe means we can't confirm docker — treat as not installed
+      // so the option gates off rather than dangling enabled.
+      set({ dockerProbe: { status: "not-installed" } });
+    }
+  },
+});

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -4,6 +4,7 @@ import type { AgentUsage } from "@/adapters/usage";
 import type {
   AgentRecord,
   AgentView,
+  DockerProbe,
   GhStatus,
   GitState,
   PrChecks,
@@ -21,6 +22,7 @@ import type { CustomAgent, NewCustomAgent } from "@/storage/customAgents";
 import type {
   Density,
   FeatureFlags,
+  SandboxEngine,
   SettingsIntent,
   SettingsSection,
   ThemeMode,
@@ -349,6 +351,20 @@ export interface AccountSlice {
   setTelemetryEnabled: (enabled: boolean) => void;
 }
 
+export interface SandboxSlice {
+  /** Engine new agents are stamped with. Mirrors the backend-owned
+   *  `sandbox_engine` setting; existing agents keep their stamped engine. */
+  sandboxEngine: SandboxEngine;
+  /** Latest Docker availability probe; `null` until the first probe lands. */
+  dockerProbe: DockerProbe | null;
+
+  /** Persist a new engine choice via the backend, which validates docker
+   *  against a live daemon probe — reverts the store on refusal. */
+  setSandboxEngine: (engine: SandboxEngine) => Promise<void>;
+  /** Re-probe Docker availability into `dockerProbe` (settings pane open). */
+  refreshDockerProbe: () => Promise<void>;
+}
+
 export interface AppearanceSlice {
   // ── appearance & feature flags ────────────────────────────────────────────
   theme: ThemeMode;
@@ -475,6 +491,7 @@ export type AppState = AppSlice &
   AccountSlice &
   AppearanceSlice &
   ProvidersSlice &
-  CustomAgentsSlice;
+  CustomAgentsSlice &
+  SandboxSlice;
 
 export type SliceCreator<T> = StateCreator<AppState, [], [], T>;


### PR DESCRIPTION
Implements Slice C1 of `docs/sandboxing.md`: user-visible sandbox engine choice, availability-gated, resolved at spawn time and sticky per agent.

**Backend**
- `sandbox_engine` setting (`"sandbox-exec"` default | `"docker"`) mirrored into a process-global so spawn paths need no DB handle; seeded at startup.
- New commands: `get_sandbox_engine`, `set_sandbox_engine` (validates docker against a live daemon probe before accepting), `probe_docker_engine` → `{status: "available"|"not-installed"|"daemon-down", version?}`.
- Temporary `sandbox/docker_probe.rs` (`docker version --format '{{.Server.Version}}'`, 2s hard timeout, `bin_resolve` CLI resolution) — replaced by `sandbox/docker/probe.rs` when B2 lands. Includes the pre-B2 `DockerEngineStub` whose launch fails with a clear "Docker engine not implemented yet" error; the setting itself persists.
- `sandbox::engine_for(kind)` resolves the launch engine with seatbelt fallback + `tracing::warn!` when docker is selected but unavailable. Teardown is untouched: sessions keep their launch-time-bound `KillHandle`; no kill path consults the setting.
- Stickiness: migration `0013` adds `sandbox_engine TEXT` to `workspaces`; `spawn_agent` stamps the live selection at creation and every spawn path (fresh/resume/view-switch/respawn/restore) reuses the stored value via `SpawnSpec`/`PerTurnSpec`. NULL (pre-migration) rows always mean sandbox-exec.

**Frontend**
- Typed `SandboxEngine` accessor in `storage/preferences.ts`; new `SandboxSlice` (engine + docker probe state, optimistic set with revert on backend refusal).
- Settings › General "Sandbox" group: engine select with three states — seatbelt always; docker enabled when the probe says available (version hint); docker disabled with an Install/Start Docker Desktop hint — plus the container caveat copy from the spec. `SelectOption` gained per-option `disabled`.

## Test plan
- `cargo test` — 369 passed, 0 failed (5 new: EngineKind parse round-trip, probe wire-shape serialization, stub refusal, sandbox_engine persistence round-trip incl. legacy NULL).
- `bun run check` (tsc) verified passing; biome clean on touched files.
- Manual: three UI states with Docker Desktop absent/stopped/running; setting + per-agent engine survive restart; flipping the setting never affects a live agent; docker-selected spawn errors clearly while seatbelt agents keep working.

Merge note: shares one-line touchpoints (`lib.rs`, `sandbox/mod.rs`) with #338 (B1) — whichever lands second needs a trivial update-branch.

Part of the swappable sandbox-engine effort; see `docs/sandboxing.md` slice graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)