### PR TITLE
fix(settings): retry docker probe after focus until daemon answers

### DIFF
--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -7,6 +7,13 @@ import type { Density, SandboxEngine, ThemeMode } from "@/storage/preferences";
 import { useAppStore } from "@/store";
 import { type FeatureItem, SetGroup, SetHead, SetRow, SetSeg, SetToggle } from "./primitives";
 
+// Docker Desktop can take a few seconds to answer after it's launched, so a
+// focus/mount probe that comes back unavailable is retried every
+// PROBE_RETRY_INTERVAL_MS until the daemon answers or PROBE_RETRY_WINDOW_MS
+// elapses — long enough to cover a cold daemon start without polling forever.
+const PROBE_RETRY_INTERVAL_MS = 2_000;
+const PROBE_RETRY_WINDOW_MS = 20_000;
+
 const SIDE_PANELS: FeatureItem[] = [
   { key: "git", title: "Git", sub: "Branch, file changes, and smart commit / push / PR actions." },
   {
@@ -55,11 +62,40 @@ export function GeneralPane() {
   // Probe Docker on open — and again whenever the window regains focus — so the
   // engine option reflects the live daemon state, including when the user starts
   // Docker Desktop (as the disabled-option hint suggests) while the pane is open.
+  //
+  // A focus event usually means the user just launched Docker Desktop from the
+  // hint, but the daemon can take several seconds to answer. A single probe
+  // would latch "daemon-down" and leave the option disabled until the next
+  // focus, so we keep re-probing on a short interval for a bounded window,
+  // stopping the moment the daemon answers.
   useEffect(() => {
-    void refreshDockerProbe();
-    const onFocus = () => void refreshDockerProbe();
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    // Bumped on each poll start so a fresh focus supersedes any in-flight loop
+    // instead of running several concurrent probe loops.
+    let runId = 0;
+
+    const poll = async () => {
+      const myRun = ++runId;
+      const deadline = Date.now() + PROBE_RETRY_WINDOW_MS;
+      while (!cancelled && runId === myRun) {
+        const probe = await refreshDockerProbe();
+        if (cancelled || runId !== myRun) return;
+        if (probe.status === "available" || Date.now() >= deadline) return;
+        await new Promise<void>((resolve) => {
+          timer = setTimeout(resolve, PROBE_RETRY_INTERVAL_MS);
+        });
+      }
+    };
+
+    void poll();
+    const onFocus = () => void poll();
     window.addEventListener("focus", onFocus);
-    return () => window.removeEventListener("focus", onFocus);
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      window.removeEventListener("focus", onFocus);
+    };
   }, [refreshDockerProbe]);
 
   // Three states for the docker option: enabled when the daemon answered the

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -71,18 +71,31 @@ export function GeneralPane() {
   useEffect(() => {
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
+    // Resolver for the in-flight retry sleep, so cleanup (or a superseding run)
+    // can wake it immediately — clearing the timeout alone would leave poll()
+    // awaiting a Promise that never settles, stranding its closure until GC.
+    let wakeSleep: (() => void) | undefined;
     // Bumped on each poll start so a fresh focus supersedes any in-flight loop
     // instead of running several concurrent probe loops.
     let runId = 0;
 
+    const wake = () => {
+      if (timer) clearTimeout(timer);
+      timer = undefined;
+      wakeSleep?.();
+      wakeSleep = undefined;
+    };
+
     const poll = async () => {
       const myRun = ++runId;
+      wake(); // retire any sleep left by the run this one supersedes
       const deadline = Date.now() + PROBE_RETRY_WINDOW_MS;
       while (!cancelled && runId === myRun) {
         const probe = await refreshDockerProbe();
         if (cancelled || runId !== myRun) return;
         if (probe.status === "available" || Date.now() >= deadline) return;
         await new Promise<void>((resolve) => {
+          wakeSleep = resolve;
           timer = setTimeout(resolve, PROBE_RETRY_INTERVAL_MS);
         });
       }
@@ -93,7 +106,7 @@ export function GeneralPane() {
     window.addEventListener("focus", onFocus);
     return () => {
       cancelled = true;
-      if (timer) clearTimeout(timer);
+      wake(); // resolve the pending sleep so poll() unwinds instead of hanging
       window.removeEventListener("focus", onFocus);
     };
   }, [refreshDockerProbe]);

--- a/src/store/sandbox.ts
+++ b/src/store/sandbox.ts
@@ -1,4 +1,4 @@
-import { api } from "@/api";
+import { api, type DockerProbe } from "@/api";
 import { DEFAULT_SANDBOX_ENGINE } from "@/storage/preferences";
 import type { SandboxSlice, SliceCreator } from "./types";
 
@@ -22,12 +22,15 @@ export const createSandboxSlice: SliceCreator<SandboxSlice> = (set, get) => ({
     }
   },
   refreshDockerProbe: async () => {
+    let probe: DockerProbe;
     try {
-      set({ dockerProbe: await api.probeDockerEngine() });
+      probe = await api.probeDockerEngine();
     } catch {
       // A failed probe means we can't confirm docker — treat as not installed
       // so the option gates off rather than dangling enabled.
-      set({ dockerProbe: { status: "not-installed" } });
+      probe = { status: "not-installed" };
     }
+    set({ dockerProbe: probe });
+    return probe;
   },
 });

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -361,8 +361,9 @@ export interface SandboxSlice {
   /** Persist a new engine choice via the backend, which validates docker
    *  against a live daemon probe — reverts the store on refusal. */
   setSandboxEngine: (engine: SandboxEngine) => Promise<void>;
-  /** Re-probe Docker availability into `dockerProbe` (settings pane open). */
-  refreshDockerProbe: () => Promise<void>;
+  /** Re-probe Docker availability into `dockerProbe` (settings pane open).
+   *  Returns the probe result so callers can poll until the daemon answers. */
+  refreshDockerProbe: () => Promise<DockerProbe>;
 }
 
 export interface AppearanceSlice {


### PR DESCRIPTION
Follow-up to #340 addressing Greptile's "Probe Can Stay Stale" review comment, which was pushed to that branch but landed after the merge and so isn't in `sandboxing`.

## Problem

The settings pane probed Docker exactly once per mount/focus. When a user launches Docker Desktop from the disabled-option hint ("Start Docker Desktop") and returns to the app, the daemon is usually still starting — so that single probe latches `daemon-down` and stops. When the daemon finishes coming up a few seconds later, nothing re-probes until the next focus event or a pane remount, leaving the Docker engine option disabled with a stale hint.

## Fix

After a mount/focus probe that isn't `available`, re-probe on a short interval (2s) for a bounded window (20s), stopping the moment the daemon answers. This models daemon startup directly and needs no extra focus event.

- `refreshDockerProbe` now returns its `DockerProbe` result so the poller can decide when to stop.
- Each poll run supersedes any in-flight loop (via a `runId` guard), so stacked focus events don't run concurrent probe loops.
- The effect cleans up its pending timer and focus listener on unmount.

## Verification

- `biome check` clean on the three touched files.
- `tsc` reports no new errors in touched files (two pre-existing missing-module errors in `notify.ts`/`vite.config.ts` are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)