### PR TITLE
feat(sandbox): container auth chain — stored token, shell env, credentials file (slice D1)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -441,6 +441,58 @@ async fn probe_docker_engine() -> Result<sandbox::DockerAvailability, String> {
         .map_err(|e| e.to_string())
 }
 
+/// Which step of the container auth chain would supply Anthropic credentials
+/// to a docker agent right now — the settings UI status row. Async +
+/// `spawn_blocking` because the first resolution may load the login-shell env
+/// (runs a shell).
+#[tauri::command]
+async fn get_container_auth_status(
+) -> Result<sandbox::docker::auth::ContainerAuthStatus, String> {
+    tauri::async_runtime::spawn_blocking(sandbox::docker::auth::status)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Store a pasted `claude setup-token` for containerized agents under the
+/// `claude_container_token` setting — plaintext in sqlite, the same posture
+/// as `github_token`. Trims; rejects empty; unexpected shapes are accepted
+/// with a warning (which, like every log line here, never includes the token
+/// itself). Persists and then updates the in-process mirror, like
+/// `set_sandbox_engine` and `github::set_token`.
+#[tauri::command]
+async fn set_container_auth_token(
+    token: String,
+    state: tauri::State<'_, DbState>,
+) -> Result<(), String> {
+    let (token, recognized) = sandbox::docker::auth::normalize_token(&token)?;
+    if !recognized {
+        tracing::warn!(
+            "container auth token doesn't look like a `claude setup-token` value \
+             (sk-ant-oat…); storing it anyway"
+        );
+    }
+    {
+        let conn = state.lock();
+        database::set_setting(&conn, sandbox::docker::auth::TOKEN_SETTING, &token)
+            .map_err(|e| e.to_string())?;
+    }
+    sandbox::docker::auth::set_stored_token(Some(token));
+    Ok(())
+}
+
+/// Drop the stored container token (blank the setting + clear the mirror,
+/// mirroring `github_disconnect`). Later chain steps take over, if any.
+#[tauri::command]
+async fn clear_container_auth_token(state: tauri::State<'_, DbState>) -> Result<(), String> {
+    {
+        let conn = state.lock();
+        database::set_setting(&conn, sandbox::docker::auth::TOKEN_SETTING, "")
+            .map_err(|e| e.to_string())?;
+    }
+    sandbox::docker::auth::set_stored_token(None);
+    Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Error/crash reporting. The DSN is baked in at build time via
@@ -528,6 +580,15 @@ pub fn run() {
             {
                 sandbox::set_selected_engine_kind(kind);
             }
+
+            // Seed the in-process container auth token (mirror of the
+            // `claude_container_token` setting, same pattern as the GitHub
+            // token below) so the docker auth chain — resolved at spawn time
+            // with no DB handle — sees a token pasted in a previous run.
+            sandbox::docker::auth::set_stored_token(database::get_setting(
+                &db.lock(),
+                sandbox::docker::auth::TOKEN_SETTING,
+            ));
 
             // Unified git resolution: point the portable-install root at app
             // data, wire the fallback commit identity to the signed-in
@@ -659,6 +720,9 @@ pub fn run() {
             get_sandbox_engine,
             set_sandbox_engine,
             probe_docker_engine,
+            get_container_auth_status,
+            set_container_auth_token,
+            clear_container_auth_token,
             oauth::oauth_device_login,
             commands::get_workspace,
             commands::get_agent_diff_stats,

--- a/src-tauri/src/sandbox/docker/auth.rs
+++ b/src-tauri/src/sandbox/docker/auth.rs
@@ -1,0 +1,340 @@
+//! Anthropic auth for containerized agents (slice D1).
+//!
+//! Host claude logins usually live in the macOS Keychain, which doesn't exist
+//! inside a container, and Fletch itself injects no credentials — so docker
+//! agents need auth resolved explicitly. [`resolve`] walks a first-hit-wins
+//! chain and returns the env vars to set on the *docker CLI process*; the
+//! launch path (B2) forwards them with bare `-e VAR` flags, so token values
+//! never appear in argv (invariant 3). They must never appear in logs either:
+//! [`ContainerAuth`] redacts values in its `Debug` output, and nothing in this
+//! module traces a token.
+//!
+//! The chain:
+//! 1. A `claude setup-token` value pasted into settings
+//!    ([`TOKEN_SETTING`]) → `CLAUDE_CODE_OAUTH_TOKEN`.
+//! 2. The login-shell env exports `ANTHROPIC_API_KEY` or
+//!    `CLAUDE_CODE_OAUTH_TOKEN` → forward those (plus `ANTHROPIC_BASE_URL` /
+//!    `ANTHROPIC_AUTH_TOKEN` for proxy setups, which ride along but don't
+//!    constitute a hit on their own).
+//! 3. `<home>/.claude/.credentials.json` exists → nothing to inject: the
+//!    `~/.claude` bind mount carries it, and refresh writes land on the host.
+//! 4. Nothing → [`ContainerAuth::Unavailable`]; the spawn path fails fast and
+//!    the UI shows the "Connect Claude for containers" call-to-action.
+//!
+//! Seatbelt agents never see any of this — they keep the user's own login.
+
+use std::collections::HashMap;
+use std::fmt;
+
+use parking_lot::RwLock;
+
+use crate::bin_resolve;
+
+/// `settings` key holding the user-pasted `claude setup-token` value.
+/// Plaintext in sqlite — the same posture as `github::TOKEN_SETTING`
+/// (consistency over novelty; a keychain migration would move both).
+pub const TOKEN_SETTING: &str = "claude_container_token";
+
+/// Env var claude reads a setup-token (OAuth) credential from.
+const OAUTH_TOKEN_VAR: &str = "CLAUDE_CODE_OAUTH_TOKEN";
+
+/// Shell vars that constitute a chain hit on their own.
+const SHELL_KEY_VARS: [&str; 2] = ["ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"];
+
+/// Everything forwarded from the login shell once one of [`SHELL_KEY_VARS`]
+/// is present; the extra two support proxy/gateway setups.
+const SHELL_AUTH_VARS: [&str; 4] = [
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_AUTH_TOKEN",
+];
+
+/// Expected prefix of a `claude setup-token` credential. Other shapes are
+/// accepted with a warning — the format isn't a contract we own.
+const SETUP_TOKEN_PREFIX: &str = "sk-ant-oat";
+
+/// The stored token, cached in-process. Seeded from the DB at startup and
+/// updated by the `set_container_auth_token` / `clear_container_auth_token`
+/// commands, so [`resolve`] — called deep in spawn paths with no DB handle —
+/// never touches the DB. Same pattern as `github::set_token`.
+static STORED_TOKEN: RwLock<Option<String>> = RwLock::new(None);
+
+/// Replace the in-process stored token. Callers that change the *persisted*
+/// token write the DB and then call this; blank counts as none.
+pub fn set_stored_token(token: Option<String>) {
+    *STORED_TOKEN.write() = sanitize(token);
+}
+
+fn stored_token() -> Option<String> {
+    STORED_TOKEN.read().clone()
+}
+
+/// Blank-to-none normalization for the mirror: a cleared setting is stored as
+/// `""` (like `github_disconnect`), which must not count as a token.
+fn sanitize(token: Option<String>) -> Option<String> {
+    token
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+}
+
+/// Which chain step supplied the credentials.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthSource {
+    /// The pasted setup-token from settings.
+    StoredToken,
+    /// Auth vars exported by the user's login shell.
+    ShellEnv,
+    /// `~/.claude/.credentials.json` — carried by the `~/.claude` mount, so
+    /// there is nothing to inject.
+    CredentialsFile,
+}
+
+/// Outcome of the resolution chain: the env to set on the docker CLI process
+/// (forwarded into the container via bare `-e VAR`), or nothing usable.
+pub enum ContainerAuth {
+    Resolved {
+        env: Vec<(String, String)>,
+        source: AuthSource,
+    },
+    Unavailable,
+}
+
+/// Manual impl so a stray `{:?}` in a log line can never leak a token: env
+/// entries print their var *names* only.
+impl fmt::Debug for ContainerAuth {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Resolved { env, source } => f
+                .debug_struct("Resolved")
+                .field("source", source)
+                .field(
+                    "env",
+                    &env.iter().map(|(k, _)| k.as_str()).collect::<Vec<_>>(),
+                )
+                .finish(),
+            Self::Unavailable => write!(f, "Unavailable"),
+        }
+    }
+}
+
+/// Walk the auth chain (first hit wins). Called by the docker launch path at
+/// spawn time and, via [`status`], by the settings UI. May block on the first
+/// call: the login-shell env is loaded (a shell runs) if nothing earlier
+/// populated `bin_resolve`'s cache.
+pub fn resolve() -> ContainerAuth {
+    let credentials_file =
+        dirs::home_dir().is_some_and(|home| home.join(".claude/.credentials.json").exists());
+    resolve_from(
+        stored_token(),
+        bin_resolve::login_shell_env(),
+        credentials_file,
+    )
+}
+
+/// The chain itself, pure over its inputs so tests can exercise the ordering
+/// without touching process globals or the filesystem.
+fn resolve_from(
+    stored: Option<String>,
+    shell_env: Option<&HashMap<String, String>>,
+    credentials_file: bool,
+) -> ContainerAuth {
+    if let Some(token) = stored {
+        return ContainerAuth::Resolved {
+            env: vec![(OAUTH_TOKEN_VAR.to_string(), token)],
+            source: AuthSource::StoredToken,
+        };
+    }
+    if let Some(env) = shell_env {
+        let set = |var: &str| env.get(var).map(String::as_str).map(str::trim);
+        if SHELL_KEY_VARS
+            .iter()
+            .any(|var| set(var).is_some_and(|v| !v.is_empty()))
+        {
+            let forwarded = SHELL_AUTH_VARS
+                .iter()
+                .filter(|var| set(var).is_some_and(|v| !v.is_empty()))
+                .map(|var| (var.to_string(), env[*var].clone()))
+                .collect();
+            return ContainerAuth::Resolved {
+                env: forwarded,
+                source: AuthSource::ShellEnv,
+            };
+        }
+    }
+    if credentials_file {
+        return ContainerAuth::Resolved {
+            env: Vec::new(),
+            source: AuthSource::CredentialsFile,
+        };
+    }
+    ContainerAuth::Unavailable
+}
+
+/// Wire shape of the `get_container_auth_status` command — [`resolve`]'s
+/// outcome for the settings status row. Serializes like `DockerAvailability`:
+/// `{ "status": "stored-token" | "shell-env" | "credentials-file" | "none" }`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(tag = "status", rename_all = "kebab-case")]
+pub enum ContainerAuthStatus {
+    StoredToken,
+    ShellEnv,
+    CredentialsFile,
+    None,
+}
+
+/// Which chain step is active right now (settings UI polling).
+pub fn status() -> ContainerAuthStatus {
+    match resolve() {
+        ContainerAuth::Resolved { source, .. } => match source {
+            AuthSource::StoredToken => ContainerAuthStatus::StoredToken,
+            AuthSource::ShellEnv => ContainerAuthStatus::ShellEnv,
+            AuthSource::CredentialsFile => ContainerAuthStatus::CredentialsFile,
+        },
+        ContainerAuth::Unavailable => ContainerAuthStatus::None,
+    }
+}
+
+/// Normalize a pasted token for storage: trimmed, non-empty, plus whether it
+/// matches the expected setup-token shape (callers warn-but-accept on a
+/// mismatch). The error string never contains the input.
+pub fn normalize_token(raw: &str) -> Result<(String, bool), String> {
+    let token = raw.trim();
+    if token.is_empty() {
+        return Err("Token is empty — run `claude setup-token` and paste its output.".into());
+    }
+    Ok((token.to_string(), token.starts_with(SETUP_TOKEN_PREFIX)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn shell_env(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    fn resolved(auth: ContainerAuth) -> (Vec<(String, String)>, AuthSource) {
+        match auth {
+            ContainerAuth::Resolved { env, source } => (env, source),
+            ContainerAuth::Unavailable => panic!("expected Resolved"),
+        }
+    }
+
+    #[test]
+    fn stored_token_beats_shell_env_and_credentials_file() {
+        let shell = shell_env(&[("ANTHROPIC_API_KEY", "sk-ant-api-key")]);
+        let auth = resolve_from(Some("sk-ant-oat-stored".into()), Some(&shell), true);
+        let (env, source) = resolved(auth);
+        assert_eq!(source, AuthSource::StoredToken);
+        assert_eq!(
+            env,
+            vec![(
+                "CLAUDE_CODE_OAUTH_TOKEN".to_string(),
+                "sk-ant-oat-stored".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn shell_env_beats_credentials_file_and_forwards_proxy_vars() {
+        let shell = shell_env(&[
+            ("ANTHROPIC_API_KEY", "sk-ant-api-key"),
+            ("ANTHROPIC_BASE_URL", "https://proxy.example.com"),
+            ("PATH", "/usr/bin"),
+        ]);
+        let (env, source) = resolved(resolve_from(None, Some(&shell), true));
+        assert_eq!(source, AuthSource::ShellEnv);
+        let mut keys: Vec<_> = env.iter().map(|(k, _)| k.as_str()).collect();
+        keys.sort_unstable();
+        assert_eq!(keys, ["ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"]);
+    }
+
+    #[test]
+    fn proxy_vars_alone_are_not_a_hit() {
+        // BASE_URL without a key var must fall through — it can't authenticate.
+        let shell = shell_env(&[("ANTHROPIC_BASE_URL", "https://proxy.example.com")]);
+        let (env, source) = resolved(resolve_from(None, Some(&shell), true));
+        assert_eq!(source, AuthSource::CredentialsFile);
+        assert!(env.is_empty());
+    }
+
+    #[test]
+    fn blank_shell_values_are_ignored() {
+        let shell = shell_env(&[("ANTHROPIC_API_KEY", "  ")]);
+        assert!(matches!(
+            resolve_from(None, Some(&shell), false),
+            ContainerAuth::Unavailable
+        ));
+    }
+
+    #[test]
+    fn credentials_file_resolves_with_empty_env() {
+        // The ~/.claude mount carries the file; nothing to inject.
+        let (env, source) = resolved(resolve_from(None, None, true));
+        assert_eq!(source, AuthSource::CredentialsFile);
+        assert!(env.is_empty());
+    }
+
+    #[test]
+    fn nothing_resolves_to_unavailable() {
+        assert!(matches!(
+            resolve_from(None, None, false),
+            ContainerAuth::Unavailable
+        ));
+        assert!(matches!(
+            resolve_from(None, Some(&shell_env(&[("PATH", "/usr/bin")])), false),
+            ContainerAuth::Unavailable
+        ));
+    }
+
+    #[test]
+    fn debug_output_redacts_token_values() {
+        let auth = resolve_from(Some("sk-ant-oat-SECRET-VALUE".into()), None, false);
+        let printed = format!("{auth:?}");
+        assert!(printed.contains("CLAUDE_CODE_OAUTH_TOKEN"), "{printed}");
+        assert!(printed.contains("StoredToken"), "{printed}");
+        assert!(!printed.contains("SECRET"), "token leaked: {printed}");
+    }
+
+    #[test]
+    fn sanitize_drops_blank_and_trims() {
+        assert_eq!(sanitize(None), None);
+        assert_eq!(sanitize(Some("".into())), None);
+        assert_eq!(sanitize(Some("   ".into())), None);
+        assert_eq!(sanitize(Some(" tok ".into())), Some("tok".into()));
+    }
+
+    #[test]
+    fn normalize_token_rejects_empty_and_flags_shape() {
+        assert!(normalize_token("").is_err());
+        assert!(normalize_token("  \n ").is_err());
+        assert_eq!(
+            normalize_token(" sk-ant-oat01-abc \n"),
+            Ok(("sk-ant-oat01-abc".to_string(), true))
+        );
+        // Unknown shapes are accepted but flagged so the command can warn.
+        assert_eq!(
+            normalize_token("some-proxy-token"),
+            Ok(("some-proxy-token".to_string(), false))
+        );
+    }
+
+    #[test]
+    fn status_serializes_to_the_wire_shape() {
+        for (status, wire) in [
+            (ContainerAuthStatus::StoredToken, "stored-token"),
+            (ContainerAuthStatus::ShellEnv, "shell-env"),
+            (ContainerAuthStatus::CredentialsFile, "credentials-file"),
+            (ContainerAuthStatus::None, "none"),
+        ] {
+            assert_eq!(
+                serde_json::to_value(status).unwrap(),
+                serde_json::json!({ "status": wire })
+            );
+        }
+    }
+}

--- a/src-tauri/src/sandbox/docker/mod.rs
+++ b/src-tauri/src/sandbox/docker/mod.rs
@@ -16,6 +16,7 @@
 //! - [`image`] — the embedded agent Dockerfile and content-addressed builds.
 //! - [`cleanup`] — container labels and the dead-instance orphan sweep.
 
+pub mod auth;
 mod cleanup;
 mod cli;
 // Everything in `image` is consumed by the B2 launch path; within B1 only its

--- a/src/api.ts
+++ b/src/api.ts
@@ -361,6 +361,13 @@ export interface DockerProbe {
   version?: string;
 }
 
+/** Which step of the container auth chain (pasted token → shell env →
+ *  claude credentials file) would supply Anthropic credentials to a docker
+ *  agent right now (Settings › General › Sandbox status row). */
+export interface ContainerAuthStatus {
+  status: "stored-token" | "shell-env" | "credentials-file" | "none";
+}
+
 /** An editor or terminal detected on the user's machine (title-bar launcher). */
 export interface DetectedEditor {
   id: string;
@@ -388,6 +395,13 @@ export const api = {
   getSandboxEngine: () => invoke<SandboxEngine>("get_sandbox_engine"),
   setSandboxEngine: (engine: SandboxEngine) => invoke<void>("set_sandbox_engine", { engine }),
   probeDockerEngine: () => invoke<DockerProbe>("probe_docker_engine"),
+  // Anthropic auth for containerized agents. Docker-only: seatbelt agents keep
+  // the user's own claude login. The token setting is backend-owned
+  // (`claude_container_token`, written by the set/clear commands below — never
+  // via a frontend `setSetting`).
+  getContainerAuthStatus: () => invoke<ContainerAuthStatus>("get_container_auth_status"),
+  setContainerAuthToken: (token: string) => invoke<void>("set_container_auth_token", { token }),
+  clearContainerAuthToken: () => invoke<void>("clear_container_auth_token"),
   getAgentDiffStats: (agentId: string) => invoke<DiffStats>("get_agent_diff_stats", { agentId }),
   addWorkspaceRepo: (repoPath: string) => invoke<Workspace>("add_workspace_repo", { repoPath }),
   removeWorkspaceRepo: (repoPath: string) =>

--- a/src/components/SettingsScreen/ContainerAuth.tsx
+++ b/src/components/SettingsScreen/ContainerAuth.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useState } from "react";
+import { Icon } from "@/components/Icon";
+import { Button } from "@/components/ui/Button";
+import { CopyButton } from "@/components/ui/CopyButton";
+import { Scrim } from "@/components/ui/Scrim";
+import { useAppStore } from "@/store";
+import { SetRow } from "./primitives";
+
+/** Human labels for each container-auth chain step (see the backend chain in
+ *  `sandbox/docker/auth.rs` — first hit wins, so exactly one is active). */
+const STATUS_LABELS: Record<string, string> = {
+  "stored-token": "Using pasted token",
+  "shell-env": "Using API key from shell profile",
+  "credentials-file": "Using claude credentials file",
+  none: "Not connected",
+};
+
+const SETUP_COMMAND = "claude setup-token";
+
+/** Settings › General › Sandbox: how containerized agents authenticate to
+ *  Anthropic. Shows which chain step is active and opens the setup-token
+ *  modal — the path for Keychain-only claude logins, which containers can't
+ *  see. Docker-only: seatbelt agents keep the user's own login. */
+export function ContainerAuth() {
+  const containerAuth = useAppStore((s) => s.containerAuth);
+  const refreshContainerAuth = useAppStore((s) => s.refreshContainerAuth);
+  const [modalOpen, setModalOpen] = useState(false);
+
+  // Resolve on mount so the row isn't stale; cheap after the first call (the
+  // login-shell env is cached process-wide backend-side).
+  useEffect(() => {
+    void refreshContainerAuth();
+  }, [refreshContainerAuth]);
+
+  const status = containerAuth?.status;
+  const connected = !!status && status !== "none";
+
+  return (
+    <>
+      <SetRow
+        title="Claude auth for containers"
+        sub="Docker agents can't see your Keychain login, so they need an API key from your shell profile or a pasted setup-token. Seatbelt agents keep using your own login."
+      >
+        <span className={`set-cauth-status text-sm ${connected ? "connected" : ""}`}>
+          {status ? STATUS_LABELS[status] : "Checking…"}
+        </span>
+        <Button
+          variant={status === "none" ? "primary" : "outline"}
+          onClick={() => setModalOpen(true)}
+        >
+          {status === "none" ? "Connect Claude" : "Manage"}
+        </Button>
+      </SetRow>
+      {modalOpen && <ContainerAuthModal onClose={() => setModalOpen(false)} />}
+    </>
+  );
+}
+
+/** "Connect Claude for containers" modal: copyable `claude setup-token`
+ *  command + paste field. Reuses the GitHub connect modal's chrome (`ghc-*`,
+ *  see components/GithubConnect) — same compact centered dialog. */
+function ContainerAuthModal({ onClose }: { onClose: () => void }) {
+  const status = useAppStore((s) => s.containerAuth?.status);
+  const setContainerAuthToken = useAppStore((s) => s.setContainerAuthToken);
+  const clearContainerAuthToken = useAppStore((s) => s.clearContainerAuthToken);
+  const [token, setToken] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const save = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await setContainerAuthToken(token);
+      onClose();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const clear = async () => {
+    setBusy(true);
+    await clearContainerAuthToken();
+    setBusy(false);
+    onClose();
+  };
+
+  return (
+    <>
+      <Scrim onClose={onClose} zIndex={400} />
+      <div className="ghc-modal" role="dialog" aria-modal="true">
+        <div className="ghc-h flex-center text-base">
+          <Icon name="cube" size={15} />
+          <span>Connect Claude for containers</span>
+          <button className="ghc-close flex-center" aria-label="Close" onClick={onClose}>
+            <Icon name="close" size={14} />
+          </button>
+        </div>
+
+        <div className="ghc-body">
+          <div className="ghc-lede text-sm">
+            Run <span className="mono">{SETUP_COMMAND}</span> in your terminal and paste the token
+            here.
+          </div>
+          <div className="set-cauth-cmd flex-center">
+            <span className="mono text-sm">{SETUP_COMMAND}</span>
+            <CopyButton text={SETUP_COMMAND} />
+          </div>
+          <input
+            className="set-cauth-input mono text-sm"
+            type="password"
+            placeholder="sk-ant-oat…"
+            value={token}
+            autoFocus
+            onChange={(e) => {
+              setToken(e.target.value);
+              setError(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && token.trim() && !busy) void save();
+            }}
+          />
+          {error && <div className="ghc-err text-sm">{error}</div>}
+          <div className="ghc-actions flex-center">
+            <Button variant="primary" disabled={busy || !token.trim()} onClick={() => void save()}>
+              Save token
+            </Button>
+            {status === "stored-token" && (
+              <Button variant="outline" disabled={busy} onClick={() => void clear()}>
+                Clear token
+              </Button>
+            )}
+            <Button variant="outline" onClick={onClose}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -5,6 +5,7 @@ import { Select } from "@/components/ui/Select";
 import { ACCENTS } from "@/data/providers";
 import type { Density, SandboxEngine, ThemeMode } from "@/storage/preferences";
 import { useAppStore } from "@/store";
+import { ContainerAuth } from "./ContainerAuth";
 import { type FeatureItem, SetGroup, SetHead, SetRow, SetSeg, SetToggle } from "./primitives";
 
 const SIDE_PANELS: FeatureItem[] = [
@@ -176,6 +177,7 @@ export function GeneralPane() {
             onChange={(v) => void setSandboxEngine(v)}
           />
         </SetRow>
+        <ContainerAuth />
       </SetGroup>
 
       <SetGroup label="Diagnostics" last>

--- a/src/components/SettingsScreen/SettingsScreen.css
+++ b/src/components/SettingsScreen/SettingsScreen.css
@@ -455,6 +455,38 @@
   color: var(--fg-2);
 }
 
+/* ── CONTAINER AUTH (Sandbox › Claude auth) ──────────────────────────── */
+.set-cauth-status {
+  color: var(--fg-2);
+  white-space: nowrap;
+}
+.set-cauth-status.connected {
+  color: var(--fg-1);
+}
+/* Modal internals; the dialog chrome reuses `.ghc-*` (GithubConnect.css). */
+.set-cauth-cmd {
+  gap: 6px;
+  padding: 4px 6px 4px 12px;
+  background: var(--bg-1);
+  border: 1px solid var(--bd);
+  border-radius: var(--r-sm);
+  color: var(--fg-1);
+}
+.set-cauth-input {
+  width: 100%;
+  height: 28px;
+  padding: 0 10px;
+  color: var(--fg-0);
+  background: var(--bg-1);
+  border: 1px solid var(--bd);
+  border-radius: var(--r-sm);
+  outline: none;
+  transition: border-color 0.12s;
+}
+.set-cauth-input:focus {
+  border-color: var(--accent);
+}
+
 /* ── PROVIDERS ───────────────────────────────────────────────────────── */
 .set-checked {
   color: var(--fg-3);

--- a/src/store/sandbox.ts
+++ b/src/store/sandbox.ts
@@ -30,4 +30,29 @@ export const createSandboxSlice: SliceCreator<SandboxSlice> = (set, get) => ({
       set({ dockerProbe: { status: "not-installed" } });
     }
   },
+
+  containerAuth: null,
+  refreshContainerAuth: async () => {
+    try {
+      set({ containerAuth: await api.getContainerAuthStatus() });
+    } catch {
+      // A failed resolution means we can't confirm any credentials — show the
+      // "Not connected" state (with its connect CTA) rather than a stale one.
+      set({ containerAuth: { status: "none" } });
+    }
+  },
+  setContainerAuthToken: async (token) => {
+    // No try/catch: the connect modal surfaces the rejection (empty token)
+    // inline next to the paste field, so the error must propagate.
+    await api.setContainerAuthToken(token);
+    await get().refreshContainerAuth();
+  },
+  clearContainerAuthToken: async () => {
+    try {
+      await api.clearContainerAuthToken();
+    } catch (e) {
+      set({ lastError: String(e) });
+    }
+    await get().refreshContainerAuth();
+  },
 });

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -4,6 +4,7 @@ import type { AgentUsage } from "@/adapters/usage";
 import type {
   AgentRecord,
   AgentView,
+  ContainerAuthStatus,
   DockerProbe,
   GhStatus,
   GitState,
@@ -357,12 +358,24 @@ export interface SandboxSlice {
   sandboxEngine: SandboxEngine;
   /** Latest Docker availability probe; `null` until the first probe lands. */
   dockerProbe: DockerProbe | null;
+  /** Which container auth chain step is active (Anthropic credentials for
+   *  docker agents); `null` until the first refresh lands. */
+  containerAuth: ContainerAuthStatus | null;
 
   /** Persist a new engine choice via the backend, which validates docker
    *  against a live daemon probe — reverts the store on refusal. */
   setSandboxEngine: (engine: SandboxEngine) => Promise<void>;
   /** Re-probe Docker availability into `dockerProbe` (settings pane open). */
   refreshDockerProbe: () => Promise<void>;
+  /** Re-resolve the container auth chain into `containerAuth`. */
+  refreshContainerAuth: () => Promise<void>;
+  /** Persist a pasted `claude setup-token` for containers, then refresh the
+   *  status. Throws on backend refusal (empty token) so the connect modal
+   *  can show the error inline. */
+  setContainerAuthToken: (token: string) => Promise<void>;
+  /** Drop the stored container token, then refresh the status (a later chain
+   *  step — shell env / credentials file — may take over). */
+  clearContainerAuthToken: () => Promise<void>;
 }
 
 export interface AppearanceSlice {


### PR DESCRIPTION
Implements slice D1 of the sandbox engine plan (`docs/sandboxing.md`): how containerized agents authenticate to Anthropic, since the host Keychain doesn't exist inside a container.

**Backend**
- `sandbox/docker/auth.rs`: first-hit-wins chain — (1) Fletch-stored `claude setup-token` (`claude_container_token` setting) → `CLAUDE_CODE_OAUTH_TOKEN`; (2) login-shell `ANTHROPIC_API_KEY`/`CLAUDE_CODE_OAUTH_TOKEN` (forwarding `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN` for proxy setups); (3) `~/.claude/.credentials.json` present → resolved with empty env (the `~/.claude` mount carries it); (4) unavailable. Returns env to set on the docker CLI process for bare `-e VAR` forwarding — token values never enter argv (invariant 3) and are redacted from `Debug` output.
- Commands `get_container_auth_status` / `set_container_auth_token` (trims, rejects empty, warns-but-accepts non-`sk-ant-oat` shapes) / `clear_container_auth_token`. Token stored plaintext-in-sqlite, same posture as `github_token`, with an in-process mirror seeded at startup.

**Frontend**
- Settings › General › Sandbox: status row showing the active chain step ("Using pasted token" / "Using API key from shell profile" / "Using claude credentials file" / "Not connected") + "Connect Claude for containers" modal (run `claude setup-token`, paste, save/clear), following the GitHub connect modal chrome. Store slice + typed api accessors mirror C1's patterns.

**Integration note:** B2's interim `interim_container_auth_env()` is intentionally untouched; swapping it for `sandbox::docker::auth::resolve()` in the docker launch path happens as a follow-up commit once both slices merge.

## Test plan
- 10 new unit tests: chain ordering (stored > shell > credentials > unavailable), proxy-vars-alone-not-a-hit, blank-value handling, Debug redaction, token normalization, wire shapes.
- `cargo test` 409 green, `cargo build` zero warnings, `tsc --noEmit` clean, biome clean on touched files, vitest 344 passed.
- Manual (post-B2): real `claude setup-token` round trip; `ps` inspection for token absence during a docker spawn.

Part of the swappable sandbox-engine effort; see `docs/sandboxing.md` slice graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)