### PR TITLE
feat(sandbox): swap interim container auth for the D1 resolution chain

### DIFF
--- a/docs/sandboxing.md
+++ b/docs/sandboxing.md
@@ -467,7 +467,9 @@ kill: KillHandle::Engine { engine: <self>, plan: KillPlan::Container { name } }
   inspecting the handle's variant. Seatbelt inherits the `None` default.
 - The interim auth forward also passes `ANTHROPIC_BASE_URL` (bare `-e`, value
   on the CLI env) alongside `ANTHROPIC_API_KEY`/`CLAUDE_CODE_OAUTH_TOKEN`, so
-  proxy setups work pre-D1 — matching D1's documented chain.
+  proxy setups work pre-D1 — matching D1's documented chain. **Superseded:** D1
+  has landed, so the interim `login_shell_env` forward is gone; `launch_agent`
+  now calls `auth::resolve()` (see the D1 note below).
 - Clone-forcing for docker-stamped agents covers `restore_agent`
   (`disposition.rs`) and `add_repo_to_agent` in addition to `spawn_agent`,
   all through one helper (`lifecycle::effective_workspace_mode`) — the
@@ -534,6 +536,23 @@ exist in a container; the app currently injects nothing.
 fails with the CTA → paste token → agent completes a turn. With
 `ANTHROPIC_API_KEY` exported in `~/.zshrc` instead: works with no setup. Token
 absent from argv (`ps`) and from logs.
+
+**Implementation notes (D1, as landed — deviations from the text above):**
+- **B2 swap landed** (was flagged as a follow-up): `engine::launch_agent`'s
+  single interim call site now calls `sandbox::docker::auth::resolve()` and the
+  interim `login_shell_env` forward is deleted. `Resolved.env` is folded onto
+  the docker CLI process env by `apply_container_auth`; `run_args` still forwards
+  every auth var with a bare `-e NAME`, so values never touch argv (invariant 3).
+- `AUTH_ENV_VARS` (the bare-`-e` list in `engine.rs`) is kept a superset of what
+  `auth::resolve` can emit — `ANTHROPIC_AUTH_TOKEN` was added so a resolved
+  proxy token actually reaches the container rather than sitting unused on the
+  CLI env.
+- `Unavailable` fails the launch with a typed `Error::Other` carrying one stable
+  string (`NO_CONTAINER_AUTH_MSG`, "…open Settings → General → Sandbox and
+  connect Claude for containers (claude setup-token).") that C2 keys its CTA on.
+- Launch logs the winning `AuthSource` variant (never token content) via
+  `tracing::info!(?source)`; `ContainerAuth`'s `Debug` redacts env values as a
+  backstop.
 
 ---
 

--- a/src-tauri/src/sandbox/docker/engine.rs
+++ b/src-tauri/src/sandbox/docker/engine.rs
@@ -31,12 +31,12 @@ use std::time::{Duration, Instant};
 
 use parking_lot::RwLock;
 
-use crate::bin_resolve;
 use crate::error::{Error, Result};
 use crate::sandbox::engine::{
     AgentLaunchCtx, EngineKind, Keepalive, KillHandle, KillPlan, LaunchPlan, SandboxEngine,
 };
 
+use super::auth::{self, ContainerAuth};
 use super::{cleanup, cli, image};
 
 /// Settings key overriding the container image (see [`image::resolve_image`]).
@@ -50,13 +50,17 @@ const DEFAULT_MEMORY: &str = "4g";
 const DEFAULT_CPUS: &str = "2";
 
 /// Auth variables forwarded into containers with bare `-e NAME` (values ride
-/// the docker CLI's process env — invariant 3). `ANTHROPIC_BASE_URL` covers
-/// proxy setups; a bare `-e` for an unset variable forwards nothing, so the
-/// list is passed unconditionally and argv stays deterministic.
+/// the docker CLI's process env — invariant 3). `ANTHROPIC_BASE_URL` /
+/// `ANTHROPIC_AUTH_TOKEN` cover proxy setups; a bare `-e` for an unset variable
+/// forwards nothing, so the list is passed unconditionally and argv stays
+/// deterministic. Must stay a superset of every var [`auth::resolve`] (D1) can
+/// emit — a resolved value with no matching bare `-e` would sit on the CLI
+/// process env yet never reach the container.
 const AUTH_ENV_VARS: &[&str] = &[
     "ANTHROPIC_API_KEY",
     "CLAUDE_CODE_OAUTH_TOKEN",
     "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_AUTH_TOKEN",
 ];
 
 /// Signal/removal docker calls during teardown.
@@ -203,7 +207,7 @@ impl SandboxEngine for DockerEngine {
                 dir.to_string_lossy().into_owned(),
             ));
         }
-        env.extend(interim_container_auth_env());
+        apply_container_auth(&mut env, auth::resolve())?;
 
         Ok(LaunchPlan {
             program: docker,
@@ -260,19 +264,31 @@ impl SandboxEngine for DockerEngine {
     }
 }
 
-/// Interim container auth: forward Anthropic credentials from the user's
-/// login-shell environment when present, so `~/.zshrc` exporters work with no
-/// setup. Replaced by `sandbox::docker::auth::container_auth_env()` when
-/// slice D1 lands (Fletch-stored setup token + credential-file chain) — this
-/// is its single call site, so the swap is one line in `launch_agent`.
-fn interim_container_auth_env() -> Vec<(String, String)> {
-    let Some(shell_env) = bin_resolve::login_shell_env() else {
-        return Vec::new();
-    };
-    AUTH_ENV_VARS
-        .iter()
-        .filter_map(|var| shell_env.get(*var).map(|v| (var.to_string(), v.clone())))
-        .collect()
+/// Launch-blocking message when the container auth chain (D1) resolves nothing.
+/// Kept as one stable, matchable string so slice C2 can turn it into a Settings
+/// call-to-action; the wording tells the user exactly what to do.
+const NO_CONTAINER_AUTH_MSG: &str = "No Anthropic credentials for containers — open Settings → General → Sandbox and connect Claude for containers (claude setup-token).";
+
+/// Fold the D1 auth-chain outcome ([`auth::resolve`]) into the docker CLI's
+/// process env, from which [`run_args`]' bare `-e NAME` flags forward it into
+/// the container (invariant 3 — values never touch argv). An [`AuthSource`] is
+/// logged (the enum variant only, never a token value); [`ContainerAuth`]'s
+/// `Debug` redacts values so even `?source` cannot leak one. When the chain
+/// yields nothing the launch fails fast with [`NO_CONTAINER_AUTH_MSG`].
+///
+/// [`AuthSource`]: super::auth::AuthSource
+fn apply_container_auth(env: &mut Vec<(String, String)>, auth: ContainerAuth) -> Result<()> {
+    match auth {
+        ContainerAuth::Resolved {
+            env: auth_env,
+            source,
+        } => {
+            tracing::info!(target: "fletch::docker", ?source, "container auth resolved");
+            env.extend(auth_env);
+            Ok(())
+        }
+        ContainerAuth::Unavailable => Err(Error::Other(NO_CONTAINER_AUTH_MSG.to_string())),
+    }
 }
 
 /// `Some(v)` only when `v` is present and non-blank — settings rows can hold
@@ -527,6 +543,7 @@ mod tests {
             "ANTHROPIC_API_KEY",
             "CLAUDE_CODE_OAUTH_TOKEN",
             "ANTHROPIC_BASE_URL",
+            "ANTHROPIC_AUTH_TOKEN",
         ] {
             assert!(forwarded.contains(&var), "missing bare -e {var}");
         }
@@ -608,6 +625,86 @@ mod tests {
         assert_eq!(non_blank(Some("")), None);
         assert_eq!(non_blank(Some("  ")), None);
         assert_eq!(non_blank(Some(" 8g ")), Some("8g"));
+    }
+
+    /// D1 swap, happy path: a resolved auth env lands on the docker CLI process
+    /// env verbatim, and every var it carries has a matching bare `-e NAME` in
+    /// argv — so the value forwards into the container yet never appears in
+    /// argv (invariant 3). Guards against `AUTH_ENV_VARS` drifting behind the
+    /// set `auth::resolve` can emit.
+    #[test]
+    fn resolved_auth_forwards_values_in_env_never_argv() {
+        use super::super::auth::AuthSource;
+
+        let secret = "sk-ant-oat-SECRET-VALUE";
+        let resolved = ContainerAuth::Resolved {
+            env: vec![
+                ("CLAUDE_CODE_OAUTH_TOKEN".to_string(), secret.to_string()),
+                (
+                    "ANTHROPIC_AUTH_TOKEN".to_string(),
+                    "proxy-secret".to_string(),
+                ),
+            ],
+            source: AuthSource::StoredToken,
+        };
+        let mut env: Vec<(String, String)> = Vec::new();
+        apply_container_auth(&mut env, resolved).expect("resolved auth applies");
+
+        // Values ride the CLI process env.
+        assert!(env
+            .iter()
+            .any(|(k, v)| k == "CLAUDE_CODE_OAUTH_TOKEN" && v == secret));
+        assert!(env
+            .iter()
+            .any(|(k, v)| k == "ANTHROPIC_AUTH_TOKEN" && v == "proxy-secret"));
+
+        // Every forwarded var name has a bare `-e NAME` in argv, and no value
+        // (secret or otherwise) leaks into argv.
+        let args = run_args(&test_spec(false));
+        let forwarded = values_of(&args, "-e");
+        for (name, _) in &env {
+            assert!(
+                forwarded.contains(&name.as_str()),
+                "resolved var {name} has no bare -e in argv (AUTH_ENV_VARS drifted)",
+            );
+        }
+        for arg in &args {
+            assert!(!arg.contains(secret), "secret leaked into argv: {arg}");
+            assert!(!arg.contains("proxy-secret"), "proxy secret in argv: {arg}");
+        }
+    }
+
+    /// D1 swap, empty resolution (`CredentialsFile`): no env additions, no
+    /// error — the `~/.claude` mount carries the credential.
+    #[test]
+    fn resolved_auth_with_empty_env_is_a_noop() {
+        use super::super::auth::AuthSource;
+
+        let mut env: Vec<(String, String)> = Vec::new();
+        apply_container_auth(
+            &mut env,
+            ContainerAuth::Resolved {
+                env: Vec::new(),
+                source: AuthSource::CredentialsFile,
+            },
+        )
+        .expect("credentials-file resolves");
+        assert!(env.is_empty());
+    }
+
+    /// D1 swap, `Unavailable`: the launch fails fast with the settings pointer
+    /// C2 keys its call-to-action on. Asserts the stable substrings so the
+    /// wording can evolve without silently breaking the UI match.
+    #[test]
+    fn unavailable_auth_fails_launch_with_settings_pointer() {
+        let mut env: Vec<(String, String)> = Vec::new();
+        let err = apply_container_auth(&mut env, ContainerAuth::Unavailable)
+            .expect_err("Unavailable must block the launch");
+        let msg = err.to_string();
+        assert!(msg.contains("Settings"), "no settings pointer: {msg}");
+        assert!(msg.contains("setup-token"), "no setup-token hint: {msg}");
+        assert_eq!(msg, NO_CONTAINER_AUTH_MSG);
+        assert!(env.is_empty(), "a failed resolution must add no env");
     }
 
     /// Integration: a real `docker run` round-trip through the exact argv the


### PR DESCRIPTION
Replaces the interim login-shell credential passthrough in the Docker engine with slice D1's real auth chain — the follow-up promised in #343/#344.

- `engine::launch_agent` now calls `sandbox::docker::auth::resolve()` at its single former call site; the interim `interim_container_auth_env()` fn and its `bin_resolve` import are deleted.
- New pure helper `apply_container_auth` folds `ContainerAuth::Resolved.env` onto the docker CLI process env; `run_args` continues to forward each auth var by bare `-e NAME`, so token values never enter argv (invariant 3).
- `ContainerAuth::Unavailable` now fails the launch fast with a typed error carrying one stable, UI-matchable string pointing users to Settings → General → Sandbox / `claude setup-token` (C2 turns this into a CTA).
- `AUTH_ENV_VARS` gains `ANTHROPIC_AUTH_TOKEN` — the interim forward list omitted it, so a proxy token resolved by the chain would have sat on the CLI env without ever reaching the container. Documented as "must stay a superset of what `auth::resolve` can emit."
- Launch logs the winning `AuthSource` variant only (never token content).
- Docs: B2 interim-auth note marked superseded.

## Test plan
3 new engine unit tests: resolved env forwarded as bare `-e` names with values only on the process env, credentials-file (empty env) no-op, `Unavailable` → launch error with the settings pointer; plus `ANTHROPIC_AUTH_TOKEN` added to the existing argv-forwarding assertion. `cargo test` 423 passed, 0 failed; `cargo build` zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)