### PR TITLE
feat(ui): surface Docker sandbox — badge, gating, build progress, error states, settings (slice C2)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -48,6 +48,26 @@ pub fn reveal_logs() -> Result<()> {
     Ok(())
 }
 
+/// Launch Docker Desktop — the "Start Docker Desktop" action on a docker
+/// agent's daemon-down error state (slice C2). macOS-only, like the rest of the
+/// sandbox feature (`open -a Docker`); other platforms error so the UI can
+/// report it rather than silently no-op. The daemon then takes a few seconds to
+/// answer, which the settings pane's probe-retry loop already covers.
+#[tauri::command]
+pub fn start_docker_desktop() -> Result<()> {
+    if cfg!(target_os = "macos") {
+        std::process::Command::new("open")
+            .args(["-a", "Docker"])
+            .spawn()
+            .map_err(|e| Error::Other(format!("open Docker Desktop: {e}")))?;
+        Ok(())
+    } else {
+        Err(Error::Other(
+            "Starting Docker Desktop from Fletch is only supported on macOS.".into(),
+        ))
+    }
+}
+
 /// The code editors installed on this machine, for the title-bar
 /// "Open in editor" launcher. Detected live (see `editors::detect`).
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -493,6 +493,46 @@ async fn clear_container_auth_token(state: tauri::State<'_, DbState>) -> Result<
     Ok(())
 }
 
+/// Persist the docker launch knobs (`docker_image` override + `docker_memory` /
+/// `docker_cpus` limits) and update the in-process mirror the spawn path reads,
+/// so a change applies to the next docker spawn without a restart. Blank values
+/// clear the setting (the launch path falls back to its defaults). Same
+/// persist-then-mirror shape as `set_sandbox_engine` — the mirror
+/// (`sandbox::docker::LaunchSettings`) is the whole struct, so all three are
+/// written together.
+#[tauri::command]
+async fn set_docker_launch_settings(
+    image: Option<String>,
+    memory: Option<String>,
+    cpus: Option<String>,
+    state: tauri::State<'_, DbState>,
+) -> Result<(), String> {
+    // Blank → None: a cleared field must not be stored as a launch override
+    // (an empty `--memory`/`--cpus` value or `docker_image` would break `docker
+    // run`), and the mirror treats blank as "use default" anyway.
+    let norm = |v: Option<String>| v.map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
+    let image = norm(image);
+    let memory = norm(memory);
+    let cpus = norm(cpus);
+    {
+        let conn = state.lock();
+        for (key, value) in [
+            (sandbox::docker::IMAGE_SETTING, &image),
+            (sandbox::docker::MEMORY_SETTING, &memory),
+            (sandbox::docker::CPUS_SETTING, &cpus),
+        ] {
+            database::set_setting(&conn, key, value.as_deref().unwrap_or(""))
+                .map_err(|e| e.to_string())?;
+        }
+    }
+    sandbox::docker::set_launch_settings(sandbox::docker::LaunchSettings {
+        image_override: image,
+        memory,
+        cpus,
+    });
+    Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Error/crash reporting. The DSN is baked in at build time via
@@ -626,6 +666,19 @@ pub fn run() {
                 }));
             }
 
+            // Forward docker image-build progress to the UI (slice C2). The
+            // build runs deep in the spawn path (no AppHandle there), so it
+            // emits through a process-wide sink installed here — mirroring the
+            // git-dist emitter above. Rare (first docker spawn per image), so a
+            // single toast fed by these events suffices.
+            {
+                use tauri::Emitter;
+                let handle = app.handle().clone();
+                sandbox::docker::set_build_sink(move |event| {
+                    let _ = handle.emit("docker:build-progress", event);
+                });
+            }
+
             // Anonymous product telemetry. Mint (or read) the install's random
             // distinct id, read the opt-out consent flag, and detect a version
             // change since the last launch — all from `settings`, before any
@@ -736,6 +789,7 @@ pub fn run() {
             get_container_auth_status,
             set_container_auth_token,
             clear_container_auth_token,
+            set_docker_launch_settings,
             oauth::oauth_device_login,
             commands::get_workspace,
             commands::get_agent_diff_stats,
@@ -806,6 +860,7 @@ pub fn run() {
             commands::validate_agent_bin,
             commands::discover_supported_models,
             commands::reveal_logs,
+            commands::start_docker_desktop,
             commands::detect_editors,
             commands::open_in_editor,
         ])

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -516,14 +516,22 @@ async fn set_docker_launch_settings(
     let cpus = norm(cpus);
     {
         let conn = state.lock();
+        // All three must land together. Written individually, a mid-loop
+        // failure (image commits, then memory errors) would leave a mixed
+        // config committed to the DB — one the UI never shows, since it reverts
+        // all three optimistically and we skip the mirror update on error, so a
+        // restart would silently hydrate the partial write. The transaction
+        // rolls back on any failure, keeping DB, mirror, and UI in sync.
+        let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
         for (key, value) in [
             (sandbox::docker::IMAGE_SETTING, &image),
             (sandbox::docker::MEMORY_SETTING, &memory),
             (sandbox::docker::CPUS_SETTING, &cpus),
         ] {
-            database::set_setting(&conn, key, value.as_deref().unwrap_or(""))
+            database::set_setting(&tx, key, value.as_deref().unwrap_or(""))
                 .map_err(|e| e.to_string())?;
         }
+        tx.commit().map_err(|e| e.to_string())?;
     }
     sandbox::docker::set_launch_settings(sandbox::docker::LaunchSettings {
         image_override: image,

--- a/src-tauri/src/sandbox/docker/image.rs
+++ b/src-tauri/src/sandbox/docker/image.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 use crate::error::Result;
 
 use super::cli;
+use super::progress::{self, BuildEvent};
 
 /// Progress sink for image builds: called once per docker output line.
 /// Slice C2 wires this to UI events; until then callers pass `&|_| {}` or a
@@ -144,7 +145,26 @@ fn ensure_image_with(
 
     let args = build_args(tag, ctx.path());
     let args: Vec<&str> = args.iter().map(String::as_str).collect();
-    cli::run_docker_streaming(&args, BUILD_TIMEOUT, on_progress)?;
+    // Broadcast the build lifecycle to the UI (slice C2). `Started`/`Finished`/
+    // `Failed` fire only here, where a build actually runs (a cached image
+    // returns above without emitting), so the toast appears only for real
+    // builds. Each output line is forwarded alongside the caller's own sink so
+    // the tracing forwarder / test counter keep working unchanged.
+    progress::emit(BuildEvent::Started);
+    let forward = |line: &str| {
+        on_progress(line);
+        progress::emit(BuildEvent::Line {
+            line: line.to_string(),
+        });
+    };
+    let result = cli::run_docker_streaming(&args, BUILD_TIMEOUT, &forward);
+    match &result {
+        Ok(()) => progress::emit(BuildEvent::Finished),
+        Err(e) => progress::emit(BuildEvent::Failed {
+            error: e.to_string(),
+        }),
+    }
+    result?;
     tracing::info!(tag, "agent docker image built");
     Ok(())
 }

--- a/src-tauri/src/sandbox/docker/mod.rs
+++ b/src-tauri/src/sandbox/docker/mod.rs
@@ -23,6 +23,7 @@ mod cli;
 mod engine;
 mod image;
 mod probe;
+mod progress;
 
 // Label plumbing for slice C2's surfacing needs; unused until then.
 #[allow(unused_imports)]
@@ -30,10 +31,18 @@ pub use cleanup::{agent_id_label, host_pid_label, sweep_orphans, AGENT_ID_LABEL,
 pub use engine::{
     set_launch_settings, DockerEngine, LaunchSettings, CPUS_SETTING, IMAGE_SETTING, MEMORY_SETTING,
 };
-// Build progress plumbing for slice C2's UI events; unused until then.
+// Build progress plumbing: `image` emits per-line/lifecycle events through
+// `progress`, which the app forwards to a Tauri event (slice C2). The image
+// re-exports stay for the integration tests / callers that pass a raw sink.
 #[allow(unused_imports)]
 pub use image::{ensure_image, image_tag, resolve_image, Progress};
 pub use probe::{availability, DockerAvailability};
+pub use progress::set_build_sink;
+// `BuildEvent` is the sink's payload type; re-exported for API symmetry (the
+// app installs the sink via a closure whose param type is inferred, so it's
+// never named in-crate).
+#[allow(unused_imports)]
+pub use progress::BuildEvent;
 
 /// Best-effort reclamation of containers left behind by dead Fletch
 /// instances, for app startup (`lib.rs`, next to the nested-root sweeps).

--- a/src-tauri/src/sandbox/docker/progress.rs
+++ b/src-tauri/src/sandbox/docker/progress.rs
@@ -1,0 +1,98 @@
+//! Image-build progress broadcast (slice C2).
+//!
+//! The embedded agent image is built on the first docker spawn (see
+//! [`super::image::ensure_image`]) — a potentially minutes-long `docker build`
+//! that blocks the spawn until it finishes. That work happens deep in the
+//! engine launch path, which has no `AppHandle`, so this module offers a
+//! process-wide sink the app installs once at startup ([`set_build_sink`]) to
+//! forward build events to the UI. Until a sink is installed (or in headless
+//! tests) emitting is a no-op, so the build path stays decoupled from Tauri —
+//! matching how `engine::set_launch_settings` mirrors settings without a DB
+//! handle.
+
+use parking_lot::RwLock;
+
+/// One image-build lifecycle event. Serializes tagged (`{ "phase": "line",
+/// "line": "…" }`) so the frontend can pattern-match a single event stream.
+#[derive(Clone, serde::Serialize)]
+#[serde(tag = "phase", rename_all = "kebab-case")]
+pub enum BuildEvent {
+    /// A build just started (image missing, `docker build` about to run).
+    Started,
+    /// One line of `docker build` output.
+    Line { line: String },
+    /// The build finished successfully.
+    Finished,
+    /// The build failed; `error` is the user-readable reason.
+    Failed { error: String },
+}
+
+type Sink = Box<dyn Fn(BuildEvent) + Send + Sync>;
+
+static SINK: RwLock<Option<Sink>> = RwLock::new(None);
+
+/// Install the process-wide progress sink (the app wires this to a Tauri event
+/// emitter at startup). Replaces any previous sink.
+pub fn set_build_sink(sink: impl Fn(BuildEvent) + Send + Sync + 'static) {
+    *SINK.write() = Some(Box::new(sink));
+}
+
+/// Forward a build event to the installed sink, if any. A no-op when none is
+/// installed, so the build machinery never depends on the app being wired up.
+pub(crate) fn emit(event: BuildEvent) {
+    if let Some(sink) = SINK.read().as_ref() {
+        sink(event);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    // Serializes with any other test touching the process-wide sink. This is the
+    // only such test today; the guard documents the shared-global contract.
+    #[test]
+    fn sink_receives_events_and_no_op_without_one() {
+        // No sink installed at first: emitting must not panic (the build path
+        // runs in headless tests with no app wired up).
+        emit(BuildEvent::Started);
+
+        let count = Arc::new(AtomicUsize::new(0));
+        let seen = count.clone();
+        set_build_sink(move |_| {
+            seen.fetch_add(1, Ordering::SeqCst);
+        });
+
+        emit(BuildEvent::Started);
+        emit(BuildEvent::Line {
+            line: "step 1/5".into(),
+        });
+        emit(BuildEvent::Finished);
+        assert_eq!(count.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn build_event_serializes_tagged() {
+        let json = serde_json::to_value(BuildEvent::Line {
+            line: "pulling base image".into(),
+        })
+        .unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({ "phase": "line", "line": "pulling base image" })
+        );
+        assert_eq!(
+            serde_json::to_value(BuildEvent::Started).unwrap(),
+            serde_json::json!({ "phase": "started" })
+        );
+        assert_eq!(
+            serde_json::to_value(BuildEvent::Failed {
+                error: "boom".into()
+            })
+            .unwrap(),
+            serde_json::json!({ "phase": "failed", "error": "boom" })
+        );
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { DockerBuildToast } from "./components/DockerBuildToast";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { GithubConnectModal } from "./components/GithubConnect";
 import { History } from "./components/History";
@@ -174,6 +175,7 @@ export function App() {
       )}
 
       <UpdateToast />
+      <DockerBuildToast />
     </div>
   );
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -368,6 +368,16 @@ export interface ContainerAuthStatus {
   status: "stored-token" | "shell-env" | "credentials-file" | "none";
 }
 
+/** One image-build lifecycle event from the `docker:build-progress` stream.
+ *  The embedded agent image is built on the first docker spawn (a slow
+ *  `docker build`); these feed the build toast. `line` is set only on `"line"`,
+ *  `error` only on `"failed"`. */
+export interface DockerBuildEvent {
+  phase: "started" | "line" | "finished" | "failed";
+  line?: string;
+  error?: string;
+}
+
 /** An editor or terminal detected on the user's machine (title-bar launcher). */
 export interface DetectedEditor {
   id: string;
@@ -402,6 +412,16 @@ export const api = {
   getContainerAuthStatus: () => invoke<ContainerAuthStatus>("get_container_auth_status"),
   setContainerAuthToken: (token: string) => invoke<void>("set_container_auth_token", { token }),
   clearContainerAuthToken: () => invoke<void>("clear_container_auth_token"),
+  // Advanced docker launch knobs (image override + resource limits). Backend-
+  // owned settings (`docker_image` / `docker_memory` / `docker_cpus`): the
+  // command persists all three AND updates the spawn-path mirror. Blank clears
+  // a field (falls back to the launch defaults). Never write these via a
+  // frontend `setSetting`.
+  setDockerLaunchSettings: (image: string | null, memory: string | null, cpus: string | null) =>
+    invoke<void>("set_docker_launch_settings", { image, memory, cpus }),
+  /** Launch Docker Desktop (the daemon-down error state's action). macOS-only;
+   *  rejects elsewhere. */
+  startDockerDesktop: () => invoke<void>("start_docker_desktop"),
   getAgentDiffStats: (agentId: string) => invoke<DiffStats>("get_agent_diff_stats", { agentId }),
   addWorkspaceRepo: (repoPath: string) => invoke<Workspace>("add_workspace_repo", { repoPath }),
   removeWorkspaceRepo: (repoPath: string) =>
@@ -678,4 +698,10 @@ export function onRunOutput(cb: (e: RunOutputEvent) => void): Promise<UnlistenFn
 
 export function onRunState(cb: (e: RunStateEvent) => void): Promise<UnlistenFn> {
   return listen<RunStateEvent>("run:state", (event) => cb(event.payload));
+}
+
+/** Fires per line (and at start/finish/failure) while the embedded docker agent
+ *  image builds on a cold first spawn — feeds the build progress toast. */
+export function onDockerBuildProgress(cb: (e: DockerBuildEvent) => void): Promise<UnlistenFn> {
+  return listen<DockerBuildEvent>("docker:build-progress", (event) => cb(event.payload));
 }

--- a/src/components/Composer/ModelPicker.css
+++ b/src/components/Composer/ModelPicker.css
@@ -58,15 +58,18 @@
   text-align: left;
   transition: background 0.12s var(--ease);
 }
-.model-agent-row:not(:disabled):hover,
+.model-agent-row:not(.is-disabled):hover,
 .model-agent-row.hot {
   background: var(--hover);
 }
 .model-agent-row.active {
   background: var(--selected);
 }
-.model-agent-row:disabled {
+/* .is-disabled, not :disabled — the row uses aria-disabled so it stays
+ * hover-capable and can surface its tooltip (see ModelPicker.tsx). */
+.model-agent-row.is-disabled {
   opacity: 0.42;
+  cursor: default;
 }
 .model-agent-name {
   flex: 1;
@@ -88,7 +91,7 @@
     color 0.16s,
     opacity 0.16s;
 }
-.model-agent-row:not(:disabled):hover > svg:last-child,
+.model-agent-row:not(.is-disabled):hover > svg:last-child,
 .model-agent-row.hot > svg:last-child {
   color: var(--accent);
   opacity: 1;

--- a/src/components/Composer/ModelPicker.tsx
+++ b/src/components/Composer/ModelPicker.tsx
@@ -187,20 +187,31 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
                 // Non-Claude agents can't run under Docker yet (see dockerOnly).
                 const dockerBlocked = dockerOnly && p.id !== "claude";
                 const disabled = !installed || dockerBlocked;
+                // Why disabled — dockerBlocked wins over missing (a non-Claude
+                // agent under Docker is blocked regardless of install state).
+                const disabledTip = dockerBlocked
+                  ? `${p.label} isn't available in Docker sandboxes yet`
+                  : "Not installed — see Settings › Providers";
                 const isSelected = p.id === provider && !customAgentId;
                 const isOpen = hovered === p.id;
                 return (
                   <button
                     key={p.id}
                     type="button"
-                    disabled={disabled}
-                    className={`model-agent-row flex-center ${isSelected ? "active" : ""} ${isOpen ? "hot" : ""}`}
+                    // aria-disabled, not the native `disabled` attr: a disabled
+                    // <button> swallows hover/pointer events in the WebView, so
+                    // its tooltip never shows and the user is left with only
+                    // "Docker: Claude only" and no reason. aria-disabled keeps
+                    // the row hover-capable; the guarded handlers below keep it
+                    // inert. The tooltip is the CSS `.tip`/`data-tip` one
+                    // (shows on :hover), used only for the disabled explanation.
+                    aria-disabled={disabled}
+                    className={`model-agent-row flex-center ${disabled ? "is-disabled tip" : ""} ${isSelected ? "active" : ""} ${isOpen ? "hot" : ""}`}
+                    data-tip={disabled ? disabledTip : undefined}
                     title={
-                      dockerBlocked
-                        ? `${p.label} isn't available in Docker sandboxes yet`
-                        : missing
-                          ? "Not installed — see Settings › Providers"
-                          : "Click to use the default model · hover to choose a model"
+                      disabled
+                        ? undefined
+                        : "Click to use the default model · hover to choose a model"
                     }
                     onMouseEnter={() => !disabled && setHovered(p.id)}
                     onClick={() => !disabled && pickModel(p.id, undefined)}

--- a/src/components/Composer/ModelPicker.tsx
+++ b/src/components/Composer/ModelPicker.tsx
@@ -39,6 +39,12 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
   const modelsByAgent = useAppStore((s) => s.modelsByAgent);
   const customAgents = useAppStore((s) => s.customAgents);
   const openSettingsScreen = useAppStore((s) => s.openSettingsScreen);
+  // New agents get the currently selected sandbox engine. Only Claude Code runs
+  // in Docker containers today, so under the docker engine every other coding
+  // agent (and any custom agent not based on Claude) is disabled — matching the
+  // backend spawn refusal in supervisor/lifecycle.rs.
+  const sandboxEngine = useAppStore((s) => s.sandboxEngine);
+  const dockerOnly = sandboxEngine === "docker";
 
   const selected = PROVIDERS.find((p) => p.id === provider) ?? PROVIDERS[0];
   const enabled = PROVIDERS.filter((p) => providerFlags[p.id] !== false);
@@ -178,28 +184,37 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
                 // never disables an agent the user really has.
                 const installed = !providersProbed || !!providerPaths[p.id];
                 const missing = providersProbed && !installed;
+                // Non-Claude agents can't run under Docker yet (see dockerOnly).
+                const dockerBlocked = dockerOnly && p.id !== "claude";
+                const disabled = !installed || dockerBlocked;
                 const isSelected = p.id === provider && !customAgentId;
                 const isOpen = hovered === p.id;
                 return (
                   <button
                     key={p.id}
                     type="button"
-                    disabled={!installed}
+                    disabled={disabled}
                     className={`model-agent-row flex-center ${isSelected ? "active" : ""} ${isOpen ? "hot" : ""}`}
                     title={
-                      missing
-                        ? "Not installed — see Settings › Providers"
-                        : "Click to use the default model · hover to choose a model"
+                      dockerBlocked
+                        ? `${p.label} isn't available in Docker sandboxes yet`
+                        : missing
+                          ? "Not installed — see Settings › Providers"
+                          : "Click to use the default model · hover to choose a model"
                     }
-                    onMouseEnter={() => installed && setHovered(p.id)}
-                    onClick={() => installed && pickModel(p.id, undefined)}
+                    onMouseEnter={() => !disabled && setHovered(p.id)}
+                    onClick={() => !disabled && pickModel(p.id, undefined)}
                   >
                     <ProviderIcon slug={p.id} short={p.short} hue={p.hue} size={26} />
                     <span className="model-agent-name truncate text-base">{p.label}</span>
                     <span className="model-agent-ver text-xs">
-                      {missing ? "Not installed" : providerVersions[p.id]}
+                      {dockerBlocked
+                        ? "Docker: Claude only"
+                        : missing
+                          ? "Not installed"
+                          : providerVersions[p.id]}
                     </span>
-                    {installed && <Icon name="chevR" size={12} />}
+                    {!disabled && <Icon name="chevR" size={12} />}
                   </button>
                 );
               })}
@@ -211,13 +226,21 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
               {selectableCustom.length > 0 ? (
                 selectableCustom.map((a) => {
                   const active = a.id === customAgentId;
+                  // A custom agent inherits its base provider's docker support.
+                  const dockerBlocked = dockerOnly && a.base !== "claude";
                   return (
                     <button
                       key={a.id}
                       type="button"
+                      disabled={dockerBlocked}
+                      title={
+                        dockerBlocked
+                          ? `${providerLabel(a.base)} isn't available in Docker sandboxes yet`
+                          : undefined
+                      }
                       className={`model-custom-row flex-center ${active ? "active" : ""}`}
                       onMouseEnter={() => setHovered(null)}
-                      onClick={() => pickCustom(a.id, a.base, a.model)}
+                      onClick={() => !dockerBlocked && pickCustom(a.id, a.base, a.model)}
                     >
                       <Mono name={a.name} hue={a.color} size={26} />
                       <span className="model-custom-text">

--- a/src/components/Composer/ModelPicker.tsx
+++ b/src/components/Composer/ModelPicker.tsx
@@ -243,13 +243,16 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
                     <button
                       key={a.id}
                       type="button"
-                      disabled={dockerBlocked}
-                      title={
+                      // Same reasoning as the provider rows above: aria-disabled
+                      // (not the native attr) keeps the row hover-capable so the
+                      // CSS .tip/data-tip refusal is reachable in the WebView.
+                      aria-disabled={dockerBlocked}
+                      data-tip={
                         dockerBlocked
                           ? `${providerLabel(a.base)} isn't available in Docker sandboxes yet`
                           : undefined
                       }
-                      className={`model-custom-row flex-center ${active ? "active" : ""}`}
+                      className={`model-custom-row flex-center ${dockerBlocked ? "is-disabled tip" : ""} ${active ? "active" : ""}`}
                       onMouseEnter={() => setHovered(null)}
                       onClick={() => !dockerBlocked && pickCustom(a.id, a.base, a.model)}
                     >

--- a/src/components/DockerBuildToast.tsx
+++ b/src/components/DockerBuildToast.tsx
@@ -1,0 +1,47 @@
+import { useAppStore } from "@/store";
+import { Icon } from "./Icon";
+import { Button } from "./ui/Button";
+
+/**
+ * Bottom-left toast for the embedded docker agent image build. The first docker
+ * spawn triggers a (potentially minutes-long) `docker build`; this surfaces its
+ * progress so the wait is legible, then clears itself when the build finishes.
+ * A failed build stays up with the reason and a dismiss. Renders nothing when no
+ * build is in flight. Fed by the `docker:build-progress` event (see store/app).
+ */
+export function DockerBuildToast() {
+  const build = useAppStore((s) => s.dockerBuild);
+  const dismiss = useAppStore((s) => s.dismissDockerBuild);
+
+  if (!build) return null;
+
+  const failed = build.status === "failed";
+
+  return (
+    <div className="update-toast docker-build-toast" role={failed ? "alert" : "status"}>
+      <Icon name={failed ? "close" : "cube"} />
+      <div className="update-toast-body">
+        <div className="update-toast-text">
+          <strong>
+            {failed ? "Sandbox image build failed" : "Building Docker sandbox image…"}
+          </strong>
+          <span>
+            {failed
+              ? (build.error ?? "The build did not complete.")
+              : "First container run — this can take a few minutes."}
+          </span>
+        </div>
+        {!failed && build.lastLine && (
+          <p className="update-toast-notes docker-build-line mono">{build.lastLine}</p>
+        )}
+        {failed && (
+          <div className="update-toast-actions">
+            <Button variant="ghost" onClick={dismiss}>
+              Dismiss
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/SettingsScreen/CustomAgents/CustomAgents.css
+++ b/src/components/SettingsScreen/CustomAgents/CustomAgents.css
@@ -228,11 +228,17 @@
   text-align: left;
   transition: background 0.12s var(--ease);
 }
-.model-custom-row:hover {
+.model-custom-row:not(.is-disabled):hover {
   background: var(--hover);
 }
 .model-custom-row.active {
   background: var(--selected);
+}
+/* .is-disabled, not :disabled — the row uses aria-disabled so it stays
+ * hover-capable and can surface its tooltip (see ModelPicker.tsx). */
+.model-custom-row.is-disabled {
+  opacity: 0.42;
+  cursor: default;
 }
 .model-custom-row > svg {
   margin-left: auto;

--- a/src/components/SettingsScreen/ExperimentalPane.tsx
+++ b/src/components/SettingsScreen/ExperimentalPane.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { useAppStore } from "@/store";
 import { type FeatureItem, SetGroup, SetHead, SetRow, SetToggle } from "./primitives";
 
@@ -23,7 +24,7 @@ export function ExperimentalPane() {
         desc="Early features we're still polishing. Expect rough edges — toggle them on to try them, off to go back to the stable path."
       />
 
-      <SetGroup label="Early features" last>
+      <SetGroup label="Early features">
         {EXPERIMENTS.map((it) => (
           <SetRow key={it.key} title={it.title} sub={it.sub}>
             <SetToggle
@@ -33,6 +34,85 @@ export function ExperimentalPane() {
           </SetRow>
         ))}
       </SetGroup>
+
+      <DockerAdvanced />
     </div>
+  );
+}
+
+/** Advanced Docker-sandbox launch knobs. These persist to the backend-owned
+ *  `docker_image` / `docker_memory` / `docker_cpus` settings AND update the
+ *  in-process spawn-path mirror, so a change applies to the next docker spawn
+ *  without a restart. Only relevant when the Docker engine is selected
+ *  (Settings › General › Sandbox); harmless otherwise. */
+function DockerAdvanced() {
+  const dockerImage = useAppStore((s) => s.dockerImage);
+  const dockerMemory = useAppStore((s) => s.dockerMemory);
+  const dockerCpus = useAppStore((s) => s.dockerCpus);
+  const save = useAppStore((s) => s.saveDockerLaunchSettings);
+
+  // Local edit state, committed on blur/Enter so we don't persist per keystroke.
+  const [image, setImage] = useState(dockerImage);
+  const [memory, setMemory] = useState(dockerMemory);
+  const [cpus, setCpus] = useState(dockerCpus);
+
+  // Reflect external changes (e.g. a revert on a failed save) back into the
+  // fields so they never drift from the store's source of truth.
+  useEffect(() => setImage(dockerImage), [dockerImage]);
+  useEffect(() => setMemory(dockerMemory), [dockerMemory]);
+  useEffect(() => setCpus(dockerCpus), [dockerCpus]);
+
+  const commit = () => {
+    const [i, m, c] = [image.trim(), memory.trim(), cpus.trim()];
+    if (i === dockerImage && m === dockerMemory && c === dockerCpus) return;
+    void save(i, m, c);
+  };
+
+  const commitOnEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") e.currentTarget.blur();
+  };
+
+  return (
+    <SetGroup label="Docker sandbox" last>
+      <SetRow
+        title="Container image"
+        sub="Override the built-in agent image. Your image must have Claude Code (`claude`) on PATH and git installed. Leave blank to use Fletch's image (built on the first Docker run)."
+      >
+        <input
+          className="set-text text-base mono"
+          value={image}
+          placeholder="fletch-agent (built-in)"
+          spellCheck={false}
+          onChange={(e) => setImage(e.target.value)}
+          onBlur={commit}
+          onKeyDown={commitOnEnter}
+        />
+      </SetRow>
+      <SetRow
+        title="Memory limit"
+        sub="Passed to `docker run --memory`. Blank uses the default (4g)."
+      >
+        <input
+          className="set-text text-base mono"
+          value={memory}
+          placeholder="4g"
+          spellCheck={false}
+          onChange={(e) => setMemory(e.target.value)}
+          onBlur={commit}
+          onKeyDown={commitOnEnter}
+        />
+      </SetRow>
+      <SetRow title="CPU limit" sub="Passed to `docker run --cpus`. Blank uses the default (2).">
+        <input
+          className="set-text text-base mono"
+          value={cpus}
+          placeholder="2"
+          spellCheck={false}
+          onChange={(e) => setCpus(e.target.value)}
+          onBlur={commit}
+          onKeyDown={commitOnEnter}
+        />
+      </SetRow>
+    </SetGroup>
   );
 }

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -5,6 +5,7 @@ import { Icon } from "@/components/Icon";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import { Mono } from "@/components/SettingsScreen/CustomAgents/Mono";
 import { Badge, type BadgeVariant } from "@/components/ui/Badge";
+import { EngineBadge } from "@/components/ui/EngineBadge";
 import { lookupModel } from "@/data/modelCatalog";
 import { providerChip, providerLabel } from "@/data/providers";
 import type { DraftAgent } from "@/store";
@@ -171,6 +172,7 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
             <ProviderIcon slug={agent.provider} {...providerChip(agent.provider)} size={14} />
           )}
         </span>
+        <EngineBadge engine={agent.sandbox_engine} />
         {runLive && (
           <span
             className="ag-run tip"

--- a/src/components/Workspace/WorkspaceHeader.tsx
+++ b/src/components/Workspace/WorkspaceHeader.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import type { AgentRecord, AgentStatus, DiffStats } from "@/api";
 import { Icon } from "@/components/Icon";
+import { EngineBadge } from "@/components/ui/EngineBadge";
 import { IconButton } from "@/components/ui/IconButton";
 import { useAppStore } from "@/store";
 import { formatAge } from "@/util/format";
@@ -66,6 +67,7 @@ export function WorkspaceHeader({ agent }: Props) {
         <div className="t-name">
           <StatusDot status={agent.status} />
           <span>{agent.name}</span>
+          <EngineBadge engine={agent.sandbox_engine} />
         </div>
         <div className="t-meta">
           {branch && <>{branch} · </>}

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -59,13 +59,52 @@ export function Workspace() {
   );
 }
 
+/** Classify a docker agent's crash reason so the banner can offer the right
+ *  recovery action. Keys off the backend's own error strings (engine exit-code
+ *  mapping + launch/build errors in sandbox/docker, and the D1 auth CTA):
+ *   - "docker-down": daemon stopped / not installed / build couldn't connect →
+ *     "Start Docker Desktop".
+ *   - "image":       a bad image (missing/broken `claude`, exit 126/127) →
+ *     point at the sandbox settings to fix `docker_image`.
+ *   - "auth":        no Anthropic credentials in the container → connect Claude.
+ *  Order matters: daemon-down is checked first (its message also mentions the
+ *  image). Returns null for non-docker crashes (the plain banner). */
+function dockerCrashKind(msg: string | null | undefined): "docker-down" | "image" | "auth" | null {
+  if (!msg) return null;
+  const m = msg.toLowerCase();
+  if (
+    m.includes("docker desktop") ||
+    m.includes("docker daemon") ||
+    m.includes("docker isn't running") ||
+    m.includes("docker binary not found") ||
+    m.includes("is docker installed") ||
+    m.includes("preparing the docker sandbox image failed")
+  ) {
+    return "docker-down";
+  }
+  if (
+    m.includes("connect claude for containers") ||
+    m.includes("setup-token") ||
+    m.includes("no anthropic credentials") ||
+    m.includes("not authenticated")
+  ) {
+    return "auth";
+  }
+  if (m.includes("docker_image") || m.includes("sandbox image")) return "image";
+  return null;
+}
+
 /** Shown when an agent's process exited with an error. Surfaces the crash
  *  reason (otherwise only a red dot in the sidebar) and a Resume action —
  *  both already captured on the record / available in the store, just never
  *  rendered. Sits under the header so the transcript leading up to the crash
- *  stays visible. */
+ *  stays visible. Docker crashes additionally get a targeted recovery action
+ *  (start the daemon / fix the image / connect Claude). */
 function CrashBanner({ agent }: { agent: AgentRecord }) {
   const resume = useAppStore((s) => s.resume);
+  const startDockerDesktop = useAppStore((s) => s.startDockerDesktop);
+  const openSettingsScreen = useAppStore((s) => s.openSettingsScreen);
+  const dockerKind = dockerCrashKind(agent.last_error);
   // Guard against a double-click firing two concurrent resumes: status stays
   // "error" until the backend's status event lands, so the banner (and button)
   // linger through that window. `resume` catches internally, so on success the
@@ -75,9 +114,35 @@ function CrashBanner({ agent }: { agent: AgentRecord }) {
   return (
     <div className="crash-banner flex-center" role="alert">
       <div className="crash-text">
-        <span className="crash-title">Agent stopped unexpectedly</span>
+        <span className="crash-title">
+          {dockerKind === "docker-down"
+            ? "Docker isn't available"
+            : dockerKind === "image"
+              ? "Sandbox image problem"
+              : dockerKind === "auth"
+                ? "Claude isn't connected for containers"
+                : "Agent stopped unexpectedly"}
+        </span>
         {agent.last_error && <span className="crash-detail">{agent.last_error}</span>}
       </div>
+      {dockerKind === "docker-down" && (
+        <Button variant="outline" onClick={() => void startDockerDesktop()}>
+          <Icon name="play" size={12} />
+          Start Docker Desktop
+        </Button>
+      )}
+      {dockerKind === "image" && (
+        <Button variant="outline" onClick={() => openSettingsScreen("experimental")}>
+          <Icon name="settings" size={12} />
+          Sandbox settings
+        </Button>
+      )}
+      {dockerKind === "auth" && (
+        <Button variant="outline" onClick={() => openSettingsScreen("general")}>
+          <Icon name="cube" size={12} />
+          Connect Claude for containers
+        </Button>
+      )}
       <Button
         variant="outline"
         disabled={resuming}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -4,6 +4,7 @@ export type BadgeVariant =
   | "neutral"
   | "new"
   | "err"
+  | "docker"
   | "pr-open"
   | "pr-merged"
   | "pr-closed"

--- a/src/components/ui/EngineBadge.tsx
+++ b/src/components/ui/EngineBadge.tsx
@@ -1,0 +1,14 @@
+import { Badge } from "./Badge";
+
+/** A small "Docker" chip shown on containerized agents (header + sidebar row).
+ *  Renders nothing for seatbelt agents (the default), so the sandbox engine is
+ *  only surfaced when it's the non-default one. `engine` is the agent's stamped
+ *  `sandbox_engine` value. */
+export function EngineBadge({ engine }: { engine?: string | null }) {
+  if (engine !== "docker") return null;
+  return (
+    <Badge variant="docker" tip="Runs in a Docker container (Linux)">
+      Docker
+    </Badge>
+  );
+}

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -11,6 +11,7 @@ import {
   onAgentStatus,
   onAgentTask,
   onAgentView,
+  onDockerBuildProgress,
   onPrStateChanged,
   onRunState,
   onSessionRecordsAppended,
@@ -128,6 +129,12 @@ const hydrateSettings = async (set: AppSet) => {
       // Backend-owned like telemetry_enabled (snake_case, written by the
       // `set_sandbox_engine` Rust command) — read it, never setSetting it.
       sandboxEngine: parseSandboxEngine(s.sandbox_engine),
+      // Advanced docker launch knobs — backend-owned (snake_case, written by
+      // `set_docker_launch_settings`), so read them here and never setSetting.
+      // Blank = unset (launch defaults apply).
+      dockerImage: s.docker_image || "",
+      dockerMemory: s.docker_memory || "",
+      dockerCpus: s.docker_cpus || "",
       // Auto-open the welcome tour for new users (no completion flag yet).
       onboardingOpen: s.onboardingComplete !== "true",
       // Panel layout — restore the user's last splitter widths and collapse state.
@@ -373,6 +380,27 @@ const registerEventListeners = async (set: AppSet, get: AppGet) => {
   // dot lit from another tab — this always-on listener owns `runPhases`.
   await onRunState((e) => {
     set((s) => ({ runPhases: { ...s.runPhases, [e.agent_id]: e.phase } }));
+  });
+
+  // Docker image-build progress (first docker spawn). Drives the build toast:
+  // started opens it, lines update the tail, finished clears it, failed keeps
+  // it up (with the reason) until the user dismisses.
+  await onDockerBuildProgress((e) => {
+    if (e.phase === "started") {
+      set({ dockerBuild: { status: "building", lastLine: null, error: null } });
+    } else if (e.phase === "line") {
+      set((s) =>
+        s.dockerBuild
+          ? { dockerBuild: { ...s.dockerBuild, lastLine: e.line ?? s.dockerBuild.lastLine } }
+          : {},
+      );
+    } else if (e.phase === "finished") {
+      set({ dockerBuild: null });
+    } else if (e.phase === "failed") {
+      set({
+        dockerBuild: { status: "failed", lastLine: null, error: e.error ?? "Image build failed" },
+      });
+    }
   });
 };
 

--- a/src/store/sandbox.ts
+++ b/src/store/sandbox.ts
@@ -5,6 +5,10 @@ import type { SandboxSlice, SliceCreator } from "./types";
 export const createSandboxSlice: SliceCreator<SandboxSlice> = (set, get) => ({
   sandboxEngine: DEFAULT_SANDBOX_ENGINE,
   dockerProbe: null,
+  dockerBuild: null,
+  dockerImage: "",
+  dockerMemory: "",
+  dockerCpus: "",
 
   setSandboxEngine: async (engine) => {
     const prev = get().sandboxEngine;
@@ -57,5 +61,30 @@ export const createSandboxSlice: SliceCreator<SandboxSlice> = (set, get) => ({
       set({ lastError: String(e) });
     }
     await get().refreshContainerAuth();
+  },
+
+  dismissDockerBuild: () => set({ dockerBuild: null }),
+
+  saveDockerLaunchSettings: async (image, memory, cpus) => {
+    const prev = {
+      dockerImage: get().dockerImage,
+      dockerMemory: get().dockerMemory,
+      dockerCpus: get().dockerCpus,
+    };
+    // Optimistic, reverted on backend refusal — same posture as setSandboxEngine.
+    set({ dockerImage: image, dockerMemory: memory, dockerCpus: cpus });
+    try {
+      await api.setDockerLaunchSettings(image || null, memory || null, cpus || null);
+    } catch (e) {
+      set({ ...prev, lastError: String(e) });
+    }
+  },
+
+  startDockerDesktop: async () => {
+    try {
+      await api.startDockerDesktop();
+    } catch (e) {
+      set({ lastError: String(e) });
+    }
   },
 });

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -352,6 +352,17 @@ export interface AccountSlice {
   setTelemetryEnabled: (enabled: boolean) => void;
 }
 
+/** Live state of the embedded docker image build (first docker spawn). `null`
+ *  when no build is in progress. `building` streams the latest output line;
+ *  `failed` stays up (with `error`) until dismissed. Success clears to `null`. */
+export interface DockerBuildProgress {
+  status: "building" | "failed";
+  /** Most recent `docker build` output line (building only). */
+  lastLine: string | null;
+  /** Failure reason (failed only). */
+  error: string | null;
+}
+
 export interface SandboxSlice {
   /** Engine new agents are stamped with. Mirrors the backend-owned
    *  `sandbox_engine` setting; existing agents keep their stamped engine. */
@@ -361,6 +372,15 @@ export interface SandboxSlice {
   /** Which container auth chain step is active (Anthropic credentials for
    *  docker agents); `null` until the first refresh lands. */
   containerAuth: ContainerAuthStatus | null;
+  /** Live image-build progress for the build toast; `null` = no build. */
+  dockerBuild: DockerBuildProgress | null;
+  /** Advanced docker launch knobs, mirrored from the backend-owned
+   *  `docker_image` / `docker_memory` / `docker_cpus` settings. Empty string =
+   *  unset (the launch path uses its defaults: 4g memory, 2 cpus, embedded
+   *  image). */
+  dockerImage: string;
+  dockerMemory: string;
+  dockerCpus: string;
 
   /** Persist a new engine choice via the backend, which validates docker
    *  against a live daemon probe — reverts the store on refusal. */
@@ -377,6 +397,15 @@ export interface SandboxSlice {
   /** Drop the stored container token, then refresh the status (a later chain
    *  step — shell env / credentials file — may take over). */
   clearContainerAuthToken: () => Promise<void>;
+  /** Dismiss the build toast (used after a failed build). */
+  dismissDockerBuild: () => void;
+  /** Persist the advanced docker launch knobs (image / memory / cpus) via the
+   *  backend, which writes the settings AND updates the spawn-path mirror.
+   *  Reverts the store on failure. */
+  saveDockerLaunchSettings: (image: string, memory: string, cpus: string) => Promise<void>;
+  /** Launch Docker Desktop (daemon-down error action); surfaces failures via
+   *  `lastError`. */
+  startDockerDesktop: () => Promise<void>;
 }
 
 export interface AppearanceSlice {

--- a/src/styles/shared/badge.css
+++ b/src/styles/shared/badge.css
@@ -50,6 +50,14 @@
   color: var(--accent);
   background: var(--accent-soft);
 }
+/* Docker engine chip — a small info-tinted "Docker" pill on containerized
+ * agents (sidebar row + workspace header). */
+.ag-badge.docker {
+  --badge-color: var(--info);
+  background: color-mix(in oklch, var(--badge-color), transparent 86%);
+  color: var(--badge-color);
+  text-transform: none;
+}
 
 .agent-sub {
   gap: 8px;

--- a/src/styles/shared/banners.css
+++ b/src/styles/shared/banners.css
@@ -166,3 +166,23 @@
   gap: 6px;
   justify-content: flex-end;
 }
+
+/* Docker image-build toast — reuses the update-toast chrome but anchors
+   bottom-left so it never overlaps a concurrent update toast (bottom-right). */
+.docker-build-toast {
+  right: auto;
+  left: 16px;
+  transform-origin: bottom left;
+}
+.docker-build-toast > svg {
+  color: var(--info);
+}
+/* The streamed build line: a single truncated row of docker output. */
+.docker-build-line {
+  max-height: 2.6em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--fg-3);
+  font-size: var(--fs-xs);
+}


### PR DESCRIPTION
Slice C2 makes the Docker sandbox legible in the UI, building on B2's launch path and C1's settings.

- **Engine badge**: docker-stamped agents show a "Docker" chip in the sidebar row and workspace header (shared `EngineBadge`, new `Badge` variant).
- **Provider gating**: in the new-agent picker, when the selected engine is Docker every non-Claude coding agent and non-Claude custom agent is disabled with a tooltip matching the backend refusal ("… isn't available in Docker sandboxes yet").
- **Image-build progress**: the first docker spawn's `docker build` streams via a process-wide sink (`sandbox::docker::progress`) → the `docker:build-progress` Tauri event → a build toast (bottom-left, clear of the update toast); the spawn proceeds when the build finishes. Emission lives in `image.rs`, only around real builds — cached images stay silent, and `engine.rs` is untouched (no conflict with #345).
- **Docker-down/error states**: the crash banner distinguishes daemon-down (→ "Start Docker Desktop" via `open -a Docker`, new `start_docker_desktop` command), image problems (→ Sandbox settings), and the auth-unavailable spawn error (→ "Connect Claude for containers").
- **Advanced settings**: `docker_image` / `docker_memory` / `docker_cpus` in the Experimental pane, backed by `set_docker_launch_settings` which persists to settings **and** updates the in-process `LaunchSettings` mirror (same persist-then-mirror shape as `set_sandbox_engine`). Fields commit on blur/Enter.

⚠️ **Merge-order note:** the crash banner's auth branch substring-matches the spawn-error string introduced in #345 — merge #345 first (or together) and verify the phrase match, since the two were authored concurrently in separate copies.

## Test plan
- `cargo build` 0 warnings; `cargo test` 422 passed (+2 new: progress sink/serialization).
- `bun run check` (tsc) + biome clean on all touched files.
- Manual eyeball with Docker Desktop (listed in slice doc): chip on docker agents, gated picker + tooltip, build toast stream/success/failure, all three crash-banner states, Experimental fields persisting and applying on next spawn.

Final planned slice of the swappable sandbox-engine effort; see `docs/sandboxing.md` slice graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)