### PR TITLE
fix(sandbox): reject stale credentials file + actionable managed-spawn errors

### DIFF
--- a/src-tauri/src/managed_session.rs
+++ b/src-tauri/src/managed_session.rs
@@ -95,6 +95,25 @@ impl ManagedSession {
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
 
+        // `Command::spawn` reports a missing program and a missing working
+        // directory identically as ENOENT ("No such file or directory (os
+        // error 2)"), which is impossible to act on. Check both up front and
+        // name the broken precondition instead. For docker agents `cwd` is the
+        // freshly-cloned workspace, so a missing one means provisioning didn't
+        // leave it where the launch expects — not a docker problem at all.
+        if spec.program.is_absolute() && !spec.program.exists() {
+            return Err(Error::Other(format!(
+                "managed spawn: program not found at {}",
+                spec.program.display()
+            )));
+        }
+        if !spec.cwd.exists() {
+            return Err(Error::Other(format!(
+                "managed spawn: working directory does not exist: {}",
+                spec.cwd.display()
+            )));
+        }
+
         let mut child = cmd
             .spawn()
             .map_err(|e| Error::Other(format!("managed spawn: {e}")))?;

--- a/src-tauri/src/sandbox/docker/auth.rs
+++ b/src-tauri/src/sandbox/docker/auth.rs
@@ -16,8 +16,11 @@
 //!    `CLAUDE_CODE_OAUTH_TOKEN` → forward those (plus `ANTHROPIC_BASE_URL` /
 //!    `ANTHROPIC_AUTH_TOKEN` for proxy setups, which ride along but don't
 //!    constitute a hit on their own).
-//! 3. `<home>/.claude/.credentials.json` exists → nothing to inject: the
-//!    `~/.claude` bind mount carries it, and refresh writes land on the host.
+//! 3. `<home>/.claude/.credentials.json` holds a usable OAuth token (non-empty
+//!    access token, non-placeholder `expiresAt`) → nothing to inject: the
+//!    `~/.claude` bind mount carries it, and refresh writes land on the host. A
+//!    stale placeholder (macOS Keychain logins leave `"expiresAt": 0` on disk)
+//!    does *not* count — see [`credentials_file_usable`].
 //! 4. Nothing → [`ContainerAuth::Unavailable`]; the spawn path fails fast and
 //!    the UI shows the "Connect Claude for containers" call-to-action.
 //!
@@ -123,13 +126,40 @@ impl fmt::Debug for ContainerAuth {
 /// call: the login-shell env is loaded (a shell runs) if nothing earlier
 /// populated `bin_resolve`'s cache.
 pub fn resolve() -> ContainerAuth {
-    let credentials_file =
-        dirs::home_dir().is_some_and(|home| home.join(".claude/.credentials.json").exists());
+    let credentials_file = dirs::home_dir().is_some_and(|home| {
+        credentials_file_usable(std::fs::read(home.join(".claude/.credentials.json")).ok().as_deref())
+    });
     resolve_from(
         stored_token(),
         bin_resolve::login_shell_env(),
         credentials_file,
     )
+}
+
+/// Whether `~/.claude/.credentials.json` carries an OAuth credential the
+/// container can actually authenticate with. Mere existence is *not* enough:
+/// on a macOS host the live token lives in the Keychain and the on-disk file is
+/// commonly a stale placeholder (`"expiresAt": 0`) — counting that as a hit
+/// boots the container straight into "Not logged in · Please run /login", which
+/// it can't recover from (no interactive login inside the sandbox).
+///
+/// A file counts only when it holds a non-empty `claudeAiOauth.accessToken` and
+/// a positive `expiresAt`. We deliberately do *not* require `expiresAt` to be
+/// in the future: an expired-but-refreshable token is the documented refresh
+/// flow (the container refreshes and the write lands on the mounted file), so
+/// rejecting it would break working Linux-host setups. The `expiresAt <= 0`
+/// (or missing/empty-token) placeholder is the only shape we reject.
+fn credentials_file_usable(contents: Option<&[u8]>) -> bool {
+    let Some(bytes) = contents else { return false };
+    let Ok(json) = serde_json::from_slice::<serde_json::Value>(bytes) else {
+        return false;
+    };
+    let oauth = &json["claudeAiOauth"];
+    let has_access = oauth["accessToken"]
+        .as_str()
+        .is_some_and(|t| !t.trim().is_empty());
+    let expires_ok = oauth["expiresAt"].as_i64().is_some_and(|e| e > 0);
+    has_access && expires_ok
 }
 
 /// The chain itself, pure over its inputs so tests can exercise the ordering
@@ -300,6 +330,36 @@ mod tests {
         let (env, source) = resolved(resolve_from(None, None, true));
         assert_eq!(source, AuthSource::CredentialsFile);
         assert!(env.is_empty());
+    }
+
+    #[test]
+    fn credentials_file_usable_accepts_a_real_oauth_token() {
+        assert!(credentials_file_usable(Some(
+            br#"{"claudeAiOauth":{"accessToken":"sk-ant-oat-x","refreshToken":"r","expiresAt":1893456000000}}"#
+        )));
+        // Expired-but-nonzero is still usable: the container can refresh via the
+        // mounted file (the documented refresh flow), so we must not reject it.
+        assert!(credentials_file_usable(Some(
+            br#"{"claudeAiOauth":{"accessToken":"sk-ant-oat-x","refreshToken":"r","expiresAt":1}}"#
+        )));
+    }
+
+    #[test]
+    fn credentials_file_usable_rejects_stale_and_malformed() {
+        // The reported macOS bug: a Keychain login leaves a placeholder on disk.
+        assert!(!credentials_file_usable(Some(
+            br#"{"claudeAiOauth":{"accessToken":"sk-ant-oat-x","refreshToken":"r","expiresAt":0}}"#
+        )));
+        // Empty access token, missing expiry, wrong shape, unparseable, absent.
+        assert!(!credentials_file_usable(Some(
+            br#"{"claudeAiOauth":{"accessToken":"","expiresAt":1893456000000}}"#
+        )));
+        assert!(!credentials_file_usable(Some(
+            br#"{"claudeAiOauth":{"accessToken":"sk-ant-oat-x"}}"#
+        )));
+        assert!(!credentials_file_usable(Some(br#"{"somethingElse":true}"#)));
+        assert!(!credentials_file_usable(Some(b"not json")));
+        assert!(!credentials_file_usable(None));
     }
 
     #[test]


### PR DESCRIPTION
Two Docker-sandbox fixes layered on the D1 auth chain (#345, already merged). Rebased onto current `sandboxing` — the diff is now just the two files below.

## 1. Reject a stale credentials file (fixes "Not logged in" on macOS)

`auth::resolve`'s credentials-file step counted the file as a valid credential if it merely **existed**. On a macOS host the live token lives in the **Keychain**; the on-disk `~/.claude/.credentials.json` is a stale placeholder (`"expiresAt": 0`). So a Keychain login resolved to `CredentialsFile`, injected nothing, and the container booted into **"Not logged in · Please run /login"** (which it can't recover from — no interactive login in the sandbox).

Now the file counts only when it holds a non-empty `claudeAiOauth.accessToken` **and** a positive `expiresAt`. Expired-but-nonzero tokens are still accepted (the documented in-container refresh flow — the container refreshes and the write lands on the mounted file), so Linux-host setups don't regress. Only the `expiresAt <= 0` / empty-token / malformed placeholder is rejected → falls through to `Unavailable` → fail-fast with the setup-token CTA.

## 2. Actionable managed-spawn errors

`Command::spawn` reports a missing program and a missing working directory identically as `ENOENT` ("os error 2"). `ManagedSession::spawn` now preflights both and names the broken one. For docker agents a missing `cwd` is the freshly-cloned workspace, so this points at provisioning rather than docker — useful for the intermittent docker-workspace spawn failure.

## Testing

- `cargo test --lib sandbox::docker` — 39 passed (new `credentials_file_usable` coverage: real token, expired-but-refreshable, `expiresAt:0` placeholder, empty token, missing expiry, wrong shape, unparseable, absent).
- `cargo test --lib managed_session` — 5 passed.
- `cargo build` + `cargo clippy --lib` clean (no new warnings in touched files).

## Note

The credentials-file validation doesn't help a macOS Keychain user directly (their on-disk file is stale) — it routes them to the **stored setup-token** path: `claude setup-token`, paste into Settings, restart.

> Scope note: an earlier revision of this branch re-implemented the D1 launch-path wiring, but that already landed in #345; this branch now contains only the two incremental fixes above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)