### PR TITLE
fix(sandbox): address Greptile review on #347

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -818,7 +818,7 @@ impl Agent {
     {
         let home =
             dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
-        let engine = sandbox::engine_for(spec.engine);
+        let engine = sandbox::engine_for(spec.engine)?;
         let claude = claude_bin_for(engine.as_ref(), &home)?;
         let agent_args = prepare_pty_args(&spec);
 
@@ -914,7 +914,7 @@ impl Agent {
             env: launch_env,
             keepalive,
             kill,
-        } = sandbox::engine_for(spec.engine).launch_agent(&ctx, &bin)?;
+        } = sandbox::engine_for(spec.engine)?.launch_agent(&ctx, &bin)?;
         let mut args = prefix_args;
         args.extend(agent_args);
         let mut env = launch_env;
@@ -956,7 +956,7 @@ impl Agent {
     {
         let home =
             dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
-        let engine = sandbox::engine_for(spec.engine);
+        let engine = sandbox::engine_for(spec.engine)?;
         let claude = claude_bin_for(engine.as_ref(), &home)?;
         let agent_args = prepare_managed_args(&spec);
 
@@ -1088,7 +1088,7 @@ impl Agent {
             env: launch_env,
             keepalive,
             kill,
-        } = sandbox::engine_for(spec.engine).launch_agent(&ctx, agent_bin)?;
+        } = sandbox::engine_for(spec.engine)?.launch_agent(&ctx, agent_bin)?;
         let mut env = launch_env;
         env.extend(rpc_env(&spec.rpc_dir));
 
@@ -1297,8 +1297,9 @@ fn resolve_claude(home: &Path) -> Result<String> {
 /// carries its own install; a resolved host path would be meaningless — or
 /// missing — inside the container), under seatbelt the host-resolved
 /// absolute path as always. Keyed off the resolved engine rather than the
-/// stamped setting so a docker-stamped agent that fell back to seatbelt
-/// (daemon down, see `sandbox::engine_for`) still execs a real host binary.
+/// stamped setting; a docker-stamped agent whose daemon is down never reaches
+/// here — `sandbox::engine_for` fails the spawn instead of degrading to
+/// seatbelt — so the resolved engine always matches the launch boundary.
 fn claude_bin_for(engine: &dyn SandboxEngine, home: &Path) -> Result<String> {
     match engine.kind() {
         EngineKind::Docker => Ok("claude".to_string()),

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -27,6 +27,9 @@ pub enum Error {
     #[error("database schema is newer than this app version")]
     SchemaTooNew,
 
+    #[error("sandbox unavailable: {0}")]
+    SandboxUnavailable(String),
+
     #[error("{0}")]
     Other(String),
 }

--- a/src-tauri/src/exec_session.rs
+++ b/src-tauri/src/exec_session.rs
@@ -325,12 +325,16 @@ impl ExecSession {
     }
 
     pub fn kill(&self) -> Result<()> {
-        self.kill_plan.kill()?;
+        // Tear the engine down first, but never let a failed teardown strand the
+        // local wrapper process: reap the child unconditionally, then surface the
+        // engine error. Otherwise a Docker-backed session whose container kill
+        // errors would leave the host-side wrapper running.
+        let engine_result = self.kill_plan.kill();
         if let Some(mut child) = self.child.lock().take() {
             let _ = child.kill();
             let _ = child.wait();
         }
-        Ok(())
+        engine_result
     }
 }
 

--- a/src-tauri/src/sandbox/mod.rs
+++ b/src-tauri/src/sandbox/mod.rs
@@ -7,6 +7,8 @@ use std::sync::{Arc, OnceLock};
 
 use parking_lot::RwLock;
 
+use crate::error::{Error, Result};
+
 pub use docker::{availability as docker_availability, DockerAvailability};
 pub use engine::{AgentLaunchCtx, EngineKind, Keepalive, KillHandle, LaunchPlan, SandboxEngine};
 pub use seatbelt::{
@@ -38,21 +40,25 @@ pub fn selected_engine_kind() -> EngineKind {
 }
 
 /// Resolve the engine for an agent stamped with `kind`, availability-checked
-/// at spawn time: docker falls back to seatbelt with a warning when the
-/// daemon is unreachable, so the agent still runs — sandboxed, just not
-/// containerized. Callers pick the agent binary by the *returned* engine's
-/// `kind()`, not by `kind`, so the fallback resolves a real host binary.
-pub fn engine_for(kind: EngineKind) -> Arc<dyn SandboxEngine> {
+/// at spawn time. A docker-stamped agent whose daemon is unreachable is a hard
+/// error: silently falling back to seatbelt would launch the process *outside*
+/// the container boundary the user selected, while the record and UI keep
+/// showing Docker — an isolation downgrade the caller never sees. Fail closed
+/// instead so the spawn surfaces the unavailability rather than degrading.
+pub fn engine_for(kind: EngineKind) -> Result<Arc<dyn SandboxEngine>> {
     match kind {
-        EngineKind::SandboxExec => seatbelt_engine(),
+        EngineKind::SandboxExec => Ok(seatbelt_engine()),
         EngineKind::Docker => match docker::availability() {
-            DockerAvailability::Available { .. } => docker::DockerEngine::shared(),
+            DockerAvailability::Available { .. } => Ok(docker::DockerEngine::shared()),
             status => {
                 tracing::warn!(
                     ?status,
-                    "docker engine selected but unavailable; falling back to sandbox-exec"
+                    "docker engine selected but unavailable; refusing to launch outside the container boundary"
                 );
-                seatbelt_engine()
+                Err(Error::SandboxUnavailable(format!(
+                    "Docker sandbox is selected but unavailable ({status:?}); \
+                     start Docker or switch the sandbox engine before launching."
+                )))
             }
         },
     }
@@ -63,7 +69,7 @@ pub fn engine_for(kind: EngineKind) -> Arc<dyn SandboxEngine> {
 /// stamped on the agent's record instead; this stays for callers with no
 /// record in hand (none today — B2's non-agent surfaces use it).
 #[allow(dead_code)]
-pub fn current_engine() -> Arc<dyn SandboxEngine> {
+pub fn current_engine() -> Result<Arc<dyn SandboxEngine>> {
     engine_for(selected_engine_kind())
 }
 

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -5,7 +5,7 @@ import { Icon } from "@/components/Icon";
 import { Chip } from "@/components/ui/Chip";
 import { lookupModel } from "@/data/modelCatalog";
 import { PROVIDER_DETAIL } from "@/data/providerDetail";
-import { DEFAULT_PROVIDER_ID } from "@/data/providers";
+import { DEFAULT_PROVIDER_ID, providerLabel } from "@/data/providers";
 import type { AgentUsage } from "@/store";
 import { useAppStore } from "@/store";
 import { AttachmentList } from "./AttachmentList";
@@ -130,6 +130,7 @@ export function Composer({
   const modelCatalog = useAppStore((s) => s.modelCatalog);
   const setComposerDraft = useAppStore((s) => s.setComposerDraft);
   const customAgents = useAppStore((s) => s.customAgents);
+  const sandboxEngine = useAppStore((s) => s.sandboxEngine);
 
   // Hide the thinking-effort picker for a model the catalog knows can't reason.
   // When the model is unknown (a new session before the first turn, or one the
@@ -151,6 +152,14 @@ export function Composer({
 
   const detail = PROVIDER_DETAIL[provider as keyof typeof PROVIDER_DETAIL];
   const thinkingLevels = detail?.thinkingLevels ?? [];
+
+  // A new-agent draft can still hold a non-Claude provider chosen before the
+  // sandbox engine was switched to Docker. Only Claude runs in Docker today, so
+  // block the send here — otherwise the stale selection reaches spawnAgent and
+  // fails in the backend. `provider` mirrors a custom agent's base, so this
+  // covers custom agents too. Existing sessions already spawned with their
+  // engine and keep a locked picker, so they're exempt.
+  const dockerBlocked = !existingSession && sandboxEngine === "docker" && provider !== "claude";
 
   const [thinkingValue, setThinkingValue] = useState<string | undefined>(() =>
     resolveThinking(defaultProvider),
@@ -265,7 +274,7 @@ export function Composer({
       onStop?.();
       return;
     }
-    if ((!trimmed && attachments.length === 0) || disabled) return;
+    if ((!trimmed && attachments.length === 0) || disabled || dockerBlocked) return;
     onSend({ text: trimmed, provider, model, thinking: thinkingValue, customAgentId, attachments });
     setText("");
     setAttachments([]);
@@ -291,7 +300,7 @@ export function Composer({
   // Busy + empty → Stop; busy + typed (or idle) → Send. So a mid-turn
   // follow-up sends with Enter, and an empty composer still stops the turn.
   const showStop = stopping && !hasContent;
-  const sendDisabled = showStop ? !onStop : disabled || !hasContent;
+  const sendDisabled = showStop ? !onStop : disabled || !hasContent || dockerBlocked;
 
   return (
     <div className={`composer${isDropTarget ? " is-drop-target" : ""}`}>
@@ -376,15 +385,27 @@ export function Composer({
         </Chip>
         <span style={{ flex: 1 }} />
         {features.tokenUsage && usage && usage.contextTokens > 0 && <UsageMeter usage={usage} />}
-        <button
-          type="button"
-          className={`send flex-center ${showStop ? "is-stop" : ""}`}
-          disabled={sendDisabled}
-          onClick={showStop ? stop : send}
-          aria-label={showStop ? "Stop" : "Send"}
+        {/* A disabled <button> swallows hover in the WebView, so the reason
+         *  rides a wrapper span that stays hover-capable (same pattern as the
+         *  ModelPicker's disabled rows). */}
+        <span
+          className={dockerBlocked ? "tip" : undefined}
+          data-tip={
+            dockerBlocked
+              ? `${providerLabel(provider)} isn't available in Docker sandboxes yet — switch to Claude to send`
+              : undefined
+          }
         >
-          <Icon name={showStop ? "stop" : "arrowUp"} size={13} />
-        </button>
+          <button
+            type="button"
+            className={`send flex-center ${showStop ? "is-stop" : ""}`}
+            disabled={sendDisabled}
+            onClick={showStop ? stop : send}
+            aria-label={showStop ? "Stop" : "Send"}
+          >
+            <Icon name={showStop ? "stop" : "arrowUp"} size={13} />
+          </button>
+        </span>
       </div>
     </div>
   );


### PR DESCRIPTION
Addresses the three Greptile comments on #347. Targets the `sandboxing` branch so the fixes land on that PR's line once merged.

## Fixes

**P1 (security) — Docker selection failed open** · `sandbox/mod.rs`, `agent.rs`, `error.rs`
`engine_for` previously fell back to the seatbelt engine when a Docker-stamped agent started with the daemon down — launching the process *outside* the selected container boundary while the record/UI still showed Docker. It now returns `Result` and fails closed with a new `Error::SandboxUnavailable`; the four spawn call sites propagate the error with `?`.

**P2 — Engine kill blocked child cleanup** · `exec_session.rs`
`kill()` returned early on a `kill_plan.kill()` error, leaving the local wrapper process alive after a failed container teardown. It now reaps the local child unconditionally, then surfaces the engine error.

**P2 — Existing draft bypassed the picker gate** · `Composer/index.tsx`
A new-agent draft set to a non-Claude provider before switching the sandbox engine to Docker still reached `spawnAgent` and failed in the backend. The composer now blocks the send under the Docker engine (send disabled + guarded in `send()`, with a hover reason), mirroring the ModelPicker row gating.

## Verification
`cargo check` passes. Frontend change is type-consistent (no `node_modules` in this worktree to run `tsc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)