### PR TITLE
fix(sandbox): honor process-env auth for docker containers

### DIFF
--- a/src-tauri/src/sandbox/docker/auth.rs
+++ b/src-tauri/src/sandbox/docker/auth.rs
@@ -12,10 +12,13 @@
 //! The chain:
 //! 1. A `claude setup-token` value pasted into settings
 //!    ([`TOKEN_SETTING`]) → `CLAUDE_CODE_OAUTH_TOKEN`.
-//! 2. The login-shell env exports `ANTHROPIC_API_KEY` or
-//!    `CLAUDE_CODE_OAUTH_TOKEN` → forward those (plus `ANTHROPIC_BASE_URL` /
-//!    `ANTHROPIC_AUTH_TOKEN` for proxy setups, which ride along but don't
-//!    constitute a hit on their own).
+//! 2. The app's process env or the login-shell probe exports
+//!    `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` → forward those (plus
+//!    `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` for proxy setups, which ride
+//!    along but don't constitute a hit on their own). Both sources are consulted
+//!    (login-shell wins on collision) so a token in the launching terminal's
+//!    env works even when the `/bin/zsh -lc` probe can't see it — see
+//!    [`merge_auth_env`].
 //! 3. `<home>/.claude/.credentials.json` holds a usable OAuth token (non-empty
 //!    access token, non-placeholder `expiresAt`) → nothing to inject: the
 //!    `~/.claude` bind mount carries it, and refresh writes land on the host. A
@@ -86,7 +89,7 @@ fn sanitize(token: Option<String>) -> Option<String> {
 pub enum AuthSource {
     /// The pasted setup-token from settings.
     StoredToken,
-    /// Auth vars exported by the user's login shell.
+    /// Auth vars from the app's process env or the user's login shell.
     ShellEnv,
     /// `~/.claude/.credentials.json` — carried by the `~/.claude` mount, so
     /// there is nothing to inject.
@@ -129,11 +132,44 @@ pub fn resolve() -> ContainerAuth {
     let credentials_file = dirs::home_dir().is_some_and(|home| {
         credentials_file_usable(std::fs::read(home.join(".claude/.credentials.json")).ok().as_deref())
     });
-    resolve_from(
-        stored_token(),
-        bin_resolve::login_shell_env(),
-        credentials_file,
-    )
+    let process_env: HashMap<String, String> = SHELL_AUTH_VARS
+        .iter()
+        .filter_map(|var| std::env::var(var).ok().map(|v| (var.to_string(), v)))
+        .collect();
+    let env = merge_auth_env(&process_env, bin_resolve::login_shell_env());
+    resolve_from(stored_token(), env.as_ref(), credentials_file)
+}
+
+/// Fold the app's own process environment together with the login-shell probe
+/// into one auth view for the env chain step (login-shell wins on collision).
+///
+/// The docker CLI child inherits the app's process env, so a token exported in
+/// the terminal that launched Fletch — or on a bash-only host, where the
+/// `/bin/zsh -lc` probe in [`bin_resolve::login_shell_env`] can't see it — was
+/// always forwarded into the container by the bare `-e VAR` flags. Consulting
+/// only the login-shell probe here would make [`resolve`] report `Unavailable`
+/// for exactly that setup, and the fail-fast launch path would then abort a
+/// container that would otherwise have authenticated fine. Reading the process
+/// env too keeps that path working. `None` when neither source carries an auth
+/// var.
+fn merge_auth_env(
+    process_env: &HashMap<String, String>,
+    shell_env: Option<&HashMap<String, String>>,
+) -> Option<HashMap<String, String>> {
+    let mut merged = HashMap::new();
+    for var in SHELL_AUTH_VARS {
+        if let Some(v) = process_env.get(var) {
+            merged.insert(var.to_string(), v.clone());
+        }
+    }
+    if let Some(shell) = shell_env {
+        for var in SHELL_AUTH_VARS {
+            if let Some(v) = shell.get(var) {
+                merged.insert(var.to_string(), v.clone());
+            }
+        }
+    }
+    (!merged.is_empty()).then_some(merged)
 }
 
 /// Whether `~/.claude/.credentials.json` carries an OAuth credential the
@@ -258,6 +294,48 @@ mod tests {
             ContainerAuth::Resolved { env, source } => (env, source),
             ContainerAuth::Unavailable => panic!("expected Resolved"),
         }
+    }
+
+    #[test]
+    fn merge_auth_env_honors_process_env_and_prefers_shell() {
+        let process = shell_env(&[
+            ("ANTHROPIC_API_KEY", "proc-key"),
+            ("ANTHROPIC_BASE_URL", "https://proc-proxy"),
+        ]);
+        // Process env alone is honored.
+        let m = merge_auth_env(&process, None).unwrap();
+        assert_eq!(m.get("ANTHROPIC_API_KEY").unwrap(), "proc-key");
+        // Login-shell wins on collision; process-only vars still survive.
+        let shell = shell_env(&[("ANTHROPIC_API_KEY", "shell-key")]);
+        let m = merge_auth_env(&process, Some(&shell)).unwrap();
+        assert_eq!(m.get("ANTHROPIC_API_KEY").unwrap(), "shell-key");
+        assert_eq!(m.get("ANTHROPIC_BASE_URL").unwrap(), "https://proc-proxy");
+    }
+
+    #[test]
+    fn merge_auth_env_none_when_no_auth_vars() {
+        assert!(merge_auth_env(&HashMap::new(), None).is_none());
+        // Non-auth vars are ignored, so a shell with only PATH is not a source.
+        let junk = shell_env(&[("PATH", "/usr/bin")]);
+        assert!(merge_auth_env(&junk, Some(&junk)).is_none());
+    }
+
+    #[test]
+    fn process_env_token_resolves_instead_of_aborting() {
+        // The regression: a token in the app's process env but not the
+        // login-shell probe must resolve (not fall through to Unavailable and
+        // abort the launch). merge_auth_env feeds it into the env chain step.
+        let process = shell_env(&[("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat-proc")]);
+        let merged = merge_auth_env(&process, None);
+        let (env, source) = resolved(resolve_from(None, merged.as_ref(), false));
+        assert_eq!(source, AuthSource::ShellEnv);
+        assert_eq!(
+            env,
+            vec![(
+                "CLAUDE_CODE_OAUTH_TOKEN".to_string(),
+                "sk-ant-oat-proc".to_string()
+            )]
+        );
     }
 
     #[test]

--- a/src/components/SettingsScreen/ContainerAuth.tsx
+++ b/src/components/SettingsScreen/ContainerAuth.tsx
@@ -10,7 +10,7 @@ import { SetRow } from "./primitives";
  *  `sandbox/docker/auth.rs` — first hit wins, so exactly one is active). */
 const STATUS_LABELS: Record<string, string> = {
   "stored-token": "Using pasted token",
-  "shell-env": "Using API key from shell profile",
+  "shell-env": "Using API key from environment",
   "credentials-file": "Using claude credentials file",
   none: "Not connected",
 };
@@ -39,7 +39,7 @@ export function ContainerAuth() {
     <>
       <SetRow
         title="Claude auth for containers"
-        sub="Docker agents can't see your Keychain login, so they need an API key from your shell profile or a pasted setup-token. Seatbelt agents keep using your own login."
+        sub="Docker agents can't see your Keychain login, so they need an API key from your environment (shell profile or the launching terminal) or a pasted setup-token. Seatbelt agents keep using your own login."
       >
         <span className={`set-cauth-status text-sm ${connected ? "connected" : ""}`}>
           {status ? STATUS_LABELS[status] : "Checking…"}


### PR DESCRIPTION
Follow-up to #348, addressing the review comment "Process-Env Auth Is Blocked."

## Problem

`auth::resolve` reads credentials from the `/bin/zsh -lc` login-shell probe (`bin_resolve::login_shell_env`) but **not** the app's own process environment. The docker CLI child inherits the app process env (managed_session doesn't `env_clear`), so a token in the app env was always forwarded into the container by the bare `-e VAR` flags — this worked before the D1 chain.

But the D1 chain now **fails fast** on `Unavailable`. So when the app process has `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` (exported in the terminal that launched Fletch, or on a **bash-only host** the zsh probe can't see) and the login-shell probe doesn't surface it — and there's no stored token or valid credentials file — `resolve()` returns `Unavailable` and the launch aborts with "no Claude credentials," regressing a setup that previously authenticated fine.

## Fix

`resolve()` now merges the app's process env with the login-shell probe (login-shell wins on collision) before the env chain step, via a new pure `merge_auth_env` helper. A process-env token resolves through the existing `ShellEnv` step instead of aborting.

- No new `AuthSource` variant — process env and login-shell are the same category (an auth var the app can read). The settings copy changes from "shell profile" to "environment" to stay accurate for both.
- Login-shell still wins on collision, matching the runtime env layering (`apply_login_shell_env` overlays the inherited process env).

## Testing

- `cargo test --lib sandbox::docker::auth` — 16 passed, incl.:
  - `process_env_token_resolves_instead_of_aborting` — the exact regression.
  - `merge_auth_env_honors_process_env_and_prefers_shell` / `_none_when_no_auth_vars`.
- `cargo clippy --lib` — clean in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)