### PR TITLE
fix(spawn): fork agent worktree from the selected base branch

### DIFF
--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -83,10 +83,11 @@ pub struct SpawnRequest {
     pub instructions: Option<String>,
     /// Custom agent identity; `None` for a plain built-in spawn.
     pub custom_agent_id: Option<String>,
-    /// Explicit fork point (a commit-ish). When set — e.g. a workflow step
-    /// forking from the previous step's HEAD — the worktree is cut from this
-    /// commit instead of the parent branch's remote fork-point. `None` keeps the
-    /// default behavior.
+    /// Base the worktree forks from, which also becomes the agent's recorded
+    /// parent branch (PR base / ahead-behind). The new-agent screen passes the
+    /// chosen base branch here; a workflow step instead passes the previous
+    /// step's HEAD (a commit-ish). `None` falls back to the repo's current
+    /// branch.
     pub fork_base: Option<String>,
 }
 
@@ -132,9 +133,14 @@ impl Supervisor {
         };
         let name = agent_id.clone();
 
-        // Parent_branch captured per-repo; primary's parent is the
-        // branch the user was on when they hit Spawn.
-        let parent_branch = git::current_branch(&repo_path).await.ok().flatten();
+        // The agent's parent branch — the base its worktree forks from and the
+        // ref it later targets for PRs / ahead-behind. The base the user chose
+        // on the new-agent screen (`fork_base`) wins; absent a choice, fall back
+        // to the branch the repo was on when the user hit Spawn.
+        let parent_branch = match &fork_base {
+            Some(base) if !base.trim().is_empty() => Some(base.clone()),
+            _ => git::current_branch(&repo_path).await.ok().flatten(),
+        };
         let subdir = allocate_repo_subdir(&repo_path, &[]);
         // Cloned for the background fork task — `parent_branch`/`subdir` are
         // moved into `primary` below.
@@ -192,17 +198,19 @@ impl Supervisor {
                 return;
             }
 
-            // Fork point: an explicit base (a workflow step forking from the
-            // previous step's HEAD) wins; otherwise fork from the freshest remote
-            // state of the parent branch so the agent never starts on stale local
-            // refs. Best-effort: offline, no remote, or a local-only branch all
-            // fall back to local HEAD.
-            let base = match &fork_base {
-                Some(sha) => Some(sha.clone()),
-                None => match &parent_for_fork {
-                    Some(b) => git::fetch_fork_point(&repo_path, b).await,
-                    None => None,
+            // Fork point: prefer the freshest remote state of the parent branch
+            // (the user's chosen base, or the repo's current branch) so the agent
+            // never starts on stale local refs. Best-effort — if the remote is
+            // unavailable (offline, no remote, a local-only branch, or a workflow
+            // commit-ish), use the ref directly when it resolves, otherwise fall
+            // through to HEAD so an unresolvable base degrades instead of failing
+            // the spawn.
+            let base = match &parent_for_fork {
+                Some(b) => match git::fetch_fork_point(&repo_path, b).await {
+                    Some(remote) => Some(remote),
+                    None => git::rev_parse(&repo_path, b).await.ok().map(|_| b.clone()),
                 },
+                None => None,
             };
             if let Err(e) =
                 git::worktree_add_detached(&repo_path, &primary_worktree, base.as_deref()).await

--- a/src/api.ts
+++ b/src/api.ts
@@ -404,8 +404,10 @@ export const api = {
     model?: string,
     instructions?: string,
     customAgentId?: string,
-    /** Explicit fork point (commit-ish). A workflow step passes the previous
-     *  step's HEAD here so its worktree continues that work. */
+    /** Base the worktree forks from and the agent's recorded parent branch
+     *  (PR base / ahead-behind). The new-agent screen passes the chosen base
+     *  branch; a workflow step instead passes the previous step's HEAD
+     *  (commit-ish) so its worktree continues that work. */
     forkBase?: string,
   ) =>
     invoke<AgentRecord>("spawn_agent", {

--- a/src/store/drafts.ts
+++ b/src/store/drafts.ts
@@ -183,6 +183,10 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
         model,
         instructions,
         custom?.id,
+        // The base branch the user picked on the new-agent screen. The backend
+        // forks the worktree from it and records it as the agent's parent
+        // branch (PR base / ahead-behind).
+        draft.base,
       );
       const fresh = await api.getWorkspace();
       set((state) => {


### PR DESCRIPTION
## Problem

Changing the **base branch** on the new-agent screen had no effect. `draft.base` was captured in UI state and rendered in the `BranchPicker`, but `spawnFromDraft` never passed it to `api.spawnAgent` — only 8 of 9 args were supplied, leaving the `forkBase` channel `null`. The backend therefore always forked the worktree from the repo's **currently checked-out** branch, regardless of the selection.

## Fix

- **`src/store/drafts.ts`** — pass `draft.base` as the `forkBase` arg on spawn.
- **`src-tauri/src/supervisor/lifecycle.rs`** — `fork_base` now overrides `parent_branch`, so the selection drives both:
  - the **fork point** of the worktree/sandbox, and
  - the agent's recorded **parent branch** (PR base + ahead/behind), consumed at `commands.rs:550/564/750`.
- The fork point resolves via **freshest remote (`origin/<branch>`) → local ref → `HEAD`**, so an unresolvable base (e.g. the hardcoded `main` default in a repo without `main`) degrades gracefully instead of failing the spawn. Workflow commit-ish bases still resolve directly via `rev-parse`.
- Doc comments on `SpawnRequest.fork_base` and `api.spawnAgent` updated.

## Behavior change

Both sandbox engines (seatbelt + docker) share the same `provision::provision` call, so both now honor the selected base. Note the picker still defaults to `main`; the worktree now genuinely forks from the displayed base rather than silently from the current branch.

## Testing

- `cargo check` passes.
- Frontend change is a type-safe positional arg matching the existing optional `forkBase?: string` param (no local `tsc` in the Fletch worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)