### PR TITLE
feat(sandbox): automate claude setup-token capture for container auth

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -464,7 +464,18 @@ async fn set_container_auth_token(
     token: String,
     state: tauri::State<'_, DbState>,
 ) -> Result<(), String> {
-    let (token, recognized) = sandbox::docker::auth::normalize_token(&token)?;
+    store_container_token(&state, &token)
+}
+
+/// Persist-then-mirror core shared by the paste command
+/// ([`set_container_auth_token`]) and the automated capture flow
+/// ([`connect_claude_container_auth`]): normalize + shape-check (warning, never
+/// logging the token, on an unrecognized shape), write the
+/// `claude_container_token` setting, then update the in-process mirror the
+/// spawn path reads — so a change applies to the next docker spawn without a
+/// restart. Same shape as `github::set_token`.
+fn store_container_token(db: &DbState, raw_token: &str) -> Result<(), String> {
+    let (token, recognized) = sandbox::docker::auth::normalize_token(raw_token)?;
     if !recognized {
         tracing::warn!(
             "container auth token doesn't look like a `claude setup-token` value \
@@ -472,11 +483,112 @@ async fn set_container_auth_token(
         );
     }
     {
-        let conn = state.lock();
+        let conn = db.lock();
         database::set_setting(&conn, sandbox::docker::auth::TOKEN_SETTING, &token)
             .map_err(|e| e.to_string())?;
     }
     sandbox::docker::auth::set_stored_token(Some(token));
+    Ok(())
+}
+
+/// A `claude setup-token` capture in flight, held so the code-submit and cancel
+/// commands can reach its live PTY. At most one runs at a time; dropping the
+/// stored session kills the PTY (see [`sandbox::docker::setup_token`]).
+type ClaudeSetupState = Mutex<Option<sandbox::docker::setup_token::ClaudeSetup>>;
+
+/// Drive `claude setup-token` on the user's behalf: spawn it under a PTY, emit
+/// the consent URL and the auth-code prompt to the UI (`claude-setup:url` /
+/// `claude-setup:awaiting-code`), and — once the user completes browser consent
+/// and submits the code via [`submit_claude_setup_code`] — capture the emitted
+/// token and store it through the shared [`store_container_token`] path (no
+/// paste, no restart). Resolves when the token is stored; errors on timeout,
+/// cancel, a missing `claude` CLI, or an exit with no token. The token never
+/// reaches the frontend or the logs.
+#[tauri::command]
+async fn connect_claude_container_auth(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, DbState>,
+    setup: tauri::State<'_, ClaudeSetupState>,
+) -> Result<(), String> {
+    use tauri::Emitter;
+
+    let home = dirs::home_dir().ok_or("Could not determine your home directory.")?;
+    let bin = bin_resolve::resolve_bin("claude", &home).ok_or(
+        "Couldn't find the `claude` CLI on your PATH. Install Claude Code, then try again.",
+    )?;
+
+    if setup.lock().is_some() {
+        return Err("A Claude connection is already in progress.".into());
+    }
+
+    let (tx, rx) = std::sync::mpsc::channel::<crate::error::Result<String>>();
+    let emit_handle = app.clone();
+    let emit: Arc<dyn Fn(sandbox::docker::setup_token::SetupEvent) + Send + Sync> =
+        Arc::new(move |event| {
+            use sandbox::docker::setup_token::SetupEvent;
+            match event {
+                SetupEvent::Url(url) => {
+                    let _ = emit_handle.emit("claude-setup:url", url);
+                }
+                SetupEvent::AwaitingCode => {
+                    let _ = emit_handle.emit("claude-setup:awaiting-code", ());
+                }
+            }
+        });
+
+    let session = sandbox::docker::setup_token::ClaudeSetup::start(
+        std::path::Path::new(&bin),
+        &std::env::temp_dir(),
+        emit,
+        tx,
+    )
+    .map_err(|e| e.to_string())?;
+    *setup.lock() = Some(session);
+
+    // Wait off the async runtime: the user drives a browser consent in between,
+    // so the ceiling is generous. Blank the slot on any outcome — dropping the
+    // session kills the PTY (success, error, or timeout alike).
+    let outcome = tauri::async_runtime::spawn_blocking(move || {
+        rx.recv_timeout(std::time::Duration::from_secs(300))
+    })
+    .await
+    .map_err(|e| e.to_string())?;
+    let _ = setup.lock().take();
+
+    match outcome {
+        Ok(Ok(token)) => store_container_token(&state, &token),
+        Ok(Err(e)) => Err(e.to_string()),
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => Err(
+            "Timed out waiting for the token. Re-run and complete the browser sign-in.".into(),
+        ),
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            Err("Claude setup ended unexpectedly.".into())
+        }
+    }
+}
+
+/// Feed the user's auth code to the live `claude setup-token` PTY started by
+/// [`connect_claude_container_auth`].
+#[tauri::command]
+async fn submit_claude_setup_code(
+    code: String,
+    setup: tauri::State<'_, ClaudeSetupState>,
+) -> Result<(), String> {
+    let guard = setup.lock();
+    match guard.as_ref() {
+        Some(session) => session.submit_code(&code).map_err(|e| e.to_string()),
+        None => Err("No Claude connection is in progress.".into()),
+    }
+}
+
+/// Abandon an in-flight [`connect_claude_container_auth`]: drop the session
+/// (killing the PTY), which makes the waiting connect command return an error
+/// the frontend ignores via its run-id guard.
+#[tauri::command]
+async fn cancel_claude_container_auth(
+    setup: tauri::State<'_, ClaudeSetupState>,
+) -> Result<(), String> {
+    setup.lock().take();
     Ok(())
 }
 
@@ -737,6 +849,9 @@ pub fn run() {
             let workspace = Arc::new(WorkspaceManager::new(db));
             let supervisor = Arc::new(Supervisor::new(workspace));
             app.manage(supervisor.clone());
+            // At most one `claude setup-token` capture runs at a time; the
+            // code-submit / cancel commands reach it through this slot.
+            app.manage(ClaudeSetupState::default());
 
             // Reclaim nested-Fletch RPC mailbox and worktree roots left in the
             // temp dir by dead instances (dogfooding runs). Live instances'
@@ -797,6 +912,9 @@ pub fn run() {
             get_container_auth_status,
             set_container_auth_token,
             clear_container_auth_token,
+            connect_claude_container_auth,
+            submit_claude_setup_code,
+            cancel_claude_container_auth,
             set_docker_launch_settings,
             oauth::oauth_device_login,
             commands::get_workspace,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -517,10 +517,6 @@ async fn connect_claude_container_auth(
         "Couldn't find the `claude` CLI on your PATH. Install Claude Code, then try again.",
     )?;
 
-    if setup.lock().is_some() {
-        return Err("A Claude connection is already in progress.".into());
-    }
-
     let (tx, rx) = std::sync::mpsc::channel::<crate::error::Result<String>>();
     let emit_handle = app.clone();
     let emit: Arc<dyn Fn(sandbox::docker::setup_token::SetupEvent) + Send + Sync> =
@@ -536,14 +532,25 @@ async fn connect_claude_container_auth(
             }
         });
 
-    let session = sandbox::docker::setup_token::ClaudeSetup::start(
-        std::path::Path::new(&bin),
-        &std::env::temp_dir(),
-        emit,
-        tx,
-    )
-    .map_err(|e| e.to_string())?;
-    *setup.lock() = Some(session);
+    // Claim the single-flight slot atomically with the spawn: checking and
+    // storing under one lock hold closes the check→store window a concurrent
+    // connect (double "already in progress") or cancel (sees an empty slot,
+    // no-ops, then this PTY publishes and runs uncancelled until timeout) would
+    // otherwise slip through. `start` is a quick spawn and holds no `.await`.
+    {
+        let mut slot = setup.lock();
+        if slot.is_some() {
+            return Err("A Claude connection is already in progress.".into());
+        }
+        let session = sandbox::docker::setup_token::ClaudeSetup::start(
+            std::path::Path::new(&bin),
+            &std::env::temp_dir(),
+            emit,
+            tx,
+        )
+        .map_err(|e| e.to_string())?;
+        *slot = Some(session);
+    }
 
     // Wait off the async runtime: the user drives a browser consent in between,
     // so the ceiling is generous. Blank the slot on any outcome — dropping the

--- a/src-tauri/src/sandbox/docker/mod.rs
+++ b/src-tauri/src/sandbox/docker/mod.rs
@@ -18,6 +18,7 @@
 //!   (one `docker run --rm --init` container per agent process).
 
 pub mod auth;
+pub mod setup_token;
 mod cleanup;
 mod cli;
 mod engine;

--- a/src-tauri/src/sandbox/docker/setup_token.rs
+++ b/src-tauri/src/sandbox/docker/setup_token.rs
@@ -26,10 +26,17 @@ use std::sync::mpsc::Sender;
 
 use parking_lot::Mutex;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use crate::error::Result;
 use crate::pty_session::{PtyExit, PtySession, PtySpawn};
 use crate::sandbox::KillHandle;
+
+/// How long `on_exit` waits for the output pipeline to drain the final bytes
+/// (the token line) after the child exits, before concluding no token arrived.
+/// The reader → coalescer flushes within one ~16ms frame of EOF, so this is
+/// generous; it only ever elapses on a genuine no-token exit (error / cancel).
+const EXIT_DRAIN_GRACE: Duration = Duration::from_secs(1);
 
 /// PTY width. Wide enough that the ~250-char consent URL and the token both fit
 /// on one line — narrow terminals wrap them mid-value (see module docs).
@@ -122,19 +129,37 @@ impl ClaudeSetup {
         let on_exit = {
             let parse = parse.clone();
             move |exit: PtyExit| {
-                let mut p = parse.lock();
-                let Some(tx) = p.tx.take() else {
-                    return; // token already delivered — normal success path
-                };
-                // EOF means no more bytes, so a lenient final scan is safe.
-                let outcome = match extract_setup_token(&p.raw) {
-                    Some(token) => Ok(token),
-                    None => Err(crate::error::Error::Other(format!(
-                        "Claude exited before returning a token ({}).",
-                        exit.message
-                    ))),
-                };
-                let _ = tx.send(outcome);
+                // `wait()` (this thread) races the reader → coalescer → on_output
+                // pipeline: on a fast token-then-exit, the final bytes may not be
+                // in `p.raw` yet. So don't conclude "no token" immediately — poll
+                // for a grace window, bailing the moment either the output path
+                // resolves (tx taken) or the token lands in the drained buffer.
+                let deadline = Instant::now() + EXIT_DRAIN_GRACE;
+                loop {
+                    {
+                        let mut p = parse.lock();
+                        if p.tx.is_none() {
+                            return; // output path already delivered the token
+                        }
+                        // EOF means no more bytes, so a lenient scan is safe.
+                        if let Some(token) = extract_setup_token(&p.raw) {
+                            if let Some(tx) = p.tx.take() {
+                                let _ = tx.send(Ok(token));
+                            }
+                            return;
+                        }
+                        if Instant::now() >= deadline {
+                            if let Some(tx) = p.tx.take() {
+                                let _ = tx.send(Err(crate::error::Error::Other(format!(
+                                    "Claude exited before returning a token ({}).",
+                                    exit.message
+                                ))));
+                            }
+                            return;
+                        }
+                    }
+                    std::thread::sleep(Duration::from_millis(20));
+                }
             }
         };
 

--- a/src-tauri/src/sandbox/docker/setup_token.rs
+++ b/src-tauri/src/sandbox/docker/setup_token.rs
@@ -1,0 +1,405 @@
+//! Automated `claude setup-token` capture (the auto path for [`super::auth`]).
+//!
+//! Manually running `claude setup-token` and pasting the `sk-ant-oat…` output
+//! into settings is the main "it doesn't just work" gap for docker agents. This
+//! module drives that flow for the user: it spawns `claude setup-token` under a
+//! PTY, surfaces the consent URL, relays the CLI's auth-code prompt to the UI,
+//! writes the code the user pastes back, and captures the emitted token — no
+//! copy-paste. The token is stored via the exact same persist-then-mirror path
+//! the paste command uses (see `store_container_token` in `lib.rs`).
+//!
+//! `claude` is an Ink (React) TUI, so its output is a stream of ANSI escapes and
+//! cursor moves, redrawn frame-by-frame — not clean line-oriented stdout. Two
+//! consequences shape the parsing here:
+//!   * We [`strip_ansi`] before scanning, and match on collapsed content
+//!     (spacing between words is drawn with cursor-column escapes, not spaces).
+//!   * We run the PTY at a deliberately **wide** width so the long consent URL
+//!     and the long token each render on a single unbroken line, instead of
+//!     wrapping mid-value where a regex/scan would tear them.
+//!
+//! Token discipline (invariant shared with [`super::auth`]): nothing here logs
+//! the raw PTY buffer or the token. The captured stream lives only in memory and
+//! dies with the session.
+
+use std::path::Path;
+use std::sync::mpsc::Sender;
+
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+use crate::error::Result;
+use crate::pty_session::{PtyExit, PtySession, PtySpawn};
+use crate::sandbox::KillHandle;
+
+/// PTY width. Wide enough that the ~250-char consent URL and the token both fit
+/// on one line — narrow terminals wrap them mid-value (see module docs).
+const PTY_COLS: u16 = 400;
+const PTY_ROWS: u16 = 50;
+
+/// Prefix every Anthropic secret shares; the setup-token's `sk-ant-oat…` is one
+/// shape of it. We anchor extraction here (rather than the stricter `sk-ant-oat`)
+/// so a future prefix variant is still captured — [`super::auth::normalize_token`]
+/// then decides whether it's the *recognized* shape or a warn-but-store one.
+const TOKEN_ANCHOR: &str = "sk-ant-";
+
+/// Lifecycle signals the driver hands up to the UI layer.
+pub enum SetupEvent {
+    /// The consent URL `claude` printed. Surfaced so the user can open it if the
+    /// CLI's own browser-open didn't fire (we do *not* auto-open — `claude`
+    /// already tries, and a second open would spawn a duplicate tab).
+    Url(String),
+    /// `claude` is now blocked on its "Paste code here" stdin prompt.
+    AwaitingCode,
+}
+
+/// Mutable state shared between the PTY's output and exit callbacks.
+struct Parse {
+    /// Everything read from the PTY so far (raw, with ANSI). Scanned on each
+    /// chunk; never logged.
+    raw: String,
+    url_sent: bool,
+    prompt_sent: bool,
+    /// Delivers the final outcome exactly once. `take`-n on the first of: token
+    /// captured (output path) or process exit (exit path); `None` thereafter.
+    tx: Option<Sender<Result<String>>>,
+}
+
+/// A live `claude setup-token` PTY session. Held in Tauri managed state so the
+/// code-submit and cancel commands can reach it; dropping it kills the PTY.
+pub struct ClaudeSetup {
+    pty: PtySession,
+}
+
+impl ClaudeSetup {
+    /// Spawn `claude setup-token` under a wide PTY and wire parsing.
+    ///
+    /// `emit` receives [`SetupEvent`]s as they're detected. `tx` receives the
+    /// final `Ok(token)` / `Err(reason)` exactly once. Both callbacks run on the
+    /// PTY's own threads.
+    pub fn start(
+        claude_bin: &Path,
+        cwd: &Path,
+        emit: Arc<dyn Fn(SetupEvent) + Send + Sync>,
+        tx: Sender<Result<String>>,
+    ) -> Result<Self> {
+        let parse = Arc::new(Mutex::new(Parse {
+            raw: String::new(),
+            url_sent: false,
+            prompt_sent: false,
+            tx: Some(tx),
+        }));
+
+        let on_output = {
+            let parse = parse.clone();
+            move |bytes: Vec<u8>| {
+                let mut p = parse.lock();
+                if p.tx.is_none() {
+                    return; // already resolved — ignore trailing frames
+                }
+                p.raw.push_str(&String::from_utf8_lossy(&bytes));
+
+                // Token wins: once it's present (and terminated, so we don't
+                // capture a still-streaming prefix) we're done.
+                if let Some(token) = extract_streaming_token(&p.raw) {
+                    if let Some(tx) = p.tx.take() {
+                        let _ = tx.send(Ok(token));
+                    }
+                    return;
+                }
+                if !p.url_sent {
+                    if let Some(url) = find_consent_url(&p.raw) {
+                        p.url_sent = true;
+                        emit(SetupEvent::Url(url));
+                    }
+                }
+                if !p.prompt_sent && awaiting_code(&p.raw) {
+                    p.prompt_sent = true;
+                    emit(SetupEvent::AwaitingCode);
+                }
+            }
+        };
+
+        let on_exit = {
+            let parse = parse.clone();
+            move |exit: PtyExit| {
+                let mut p = parse.lock();
+                let Some(tx) = p.tx.take() else {
+                    return; // token already delivered — normal success path
+                };
+                // EOF means no more bytes, so a lenient final scan is safe.
+                let outcome = match extract_setup_token(&p.raw) {
+                    Some(token) => Ok(token),
+                    None => Err(crate::error::Error::Other(format!(
+                        "Claude exited before returning a token ({}).",
+                        exit.message
+                    ))),
+                };
+                let _ = tx.send(outcome);
+            }
+        };
+
+        let args = ["setup-token".to_string()];
+        let pty = PtySession::spawn(
+            PtySpawn {
+                program: claude_bin,
+                args: &args,
+                cwd,
+                env: &[],
+                cols: PTY_COLS,
+                rows: PTY_ROWS,
+                kill_plan: KillHandle::ProcessGroup,
+            },
+            on_output,
+            on_exit,
+        )?;
+        Ok(Self { pty })
+    }
+
+    /// Write the user's auth code to the CLI's stdin prompt (trailing CR submits
+    /// it, as if typed at the terminal).
+    pub fn submit_code(&self, code: &str) -> Result<()> {
+        let mut line = code.trim().to_string();
+        line.push('\r');
+        self.pty.write(line.as_bytes())
+    }
+}
+
+/// Strip ANSI/VT control sequences (CSI, OSC, and two-byte escapes), preserving
+/// the surrounding UTF-8 bytes intact. Escape sequences are pure ASCII, so we
+/// can drop them at the byte level without splitting a multibyte char.
+pub fn strip_ansi(input: &str) -> String {
+    let b = input.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(b.len());
+    let mut i = 0;
+    while i < b.len() {
+        if b[i] == 0x1b {
+            i += 1;
+            let Some(&kind) = b.get(i) else { break };
+            match kind {
+                b'[' => {
+                    // CSI: params/intermediates until a final byte in @..~.
+                    i += 1;
+                    while i < b.len() && !(0x40..=0x7e).contains(&b[i]) {
+                        i += 1;
+                    }
+                    if i < b.len() {
+                        i += 1;
+                    }
+                }
+                b']' => {
+                    // OSC: until BEL, or ST (ESC \).
+                    i += 1;
+                    while i < b.len() && b[i] != 0x07 {
+                        if b[i] == 0x1b && b.get(i + 1) == Some(&b'\\') {
+                            i += 1;
+                            break;
+                        }
+                        i += 1;
+                    }
+                    if i < b.len() {
+                        i += 1; // consume the BEL / the `\` of ST
+                    }
+                }
+                // Two-byte escape (e.g. ESC 7 save-cursor, ESC = keypad mode).
+                _ => i += 1,
+            }
+        } else {
+            out.push(b[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn is_token_byte(c: u8) -> bool {
+    c.is_ascii_alphanumeric() || c == b'-' || c == b'_'
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Locate the setup token in (possibly ANSI-laden) `output`. Anchored on
+/// `sk-ant-`; returns the full token run, or `None` if there's no run past the
+/// bare anchor. When `require_terminated`, a run reaching the very end of the
+/// buffer is treated as still-streaming and rejected (see [`extract_streaming_token`]).
+fn find_token(output: &str, require_terminated: bool) -> Option<String> {
+    let s = strip_ansi(output);
+    let bytes = s.as_bytes();
+    let anchor = TOKEN_ANCHOR.as_bytes();
+    let mut from = 0;
+    while let Some(rel) = find_subslice(&bytes[from..], anchor) {
+        let start = from + rel;
+        let mut end = start + anchor.len();
+        while end < bytes.len() && is_token_byte(bytes[end]) {
+            end += 1;
+        }
+        if end > start + anchor.len() {
+            // A run that ends exactly at the buffer edge may still be arriving.
+            if require_terminated && end == bytes.len() {
+                return None;
+            }
+            return Some(s[start..end].to_string());
+        }
+        from = start + anchor.len();
+    }
+    None
+}
+
+/// Extract a complete token from finished output (process EOF, or a test/paste
+/// buffer). Lenient: accepts a token even if it runs to the end of the input.
+pub fn extract_setup_token(output: &str) -> Option<String> {
+    find_token(output, false)
+}
+
+/// Like [`extract_setup_token`] but for a *streaming* buffer: returns `None` if
+/// the token runs to the very end of `output`, since more bytes may still be
+/// coming and we'd otherwise capture a truncated prefix. The caller retries on
+/// the next chunk once a terminating byte (newline, box border, …) lands.
+pub fn extract_streaming_token(output: &str) -> Option<String> {
+    find_token(output, true)
+}
+
+/// Extract the consent URL `claude` prints (the `oauth/authorize` link). Returns
+/// the first `https://` run pointing at claude/oauth; `None` if none present.
+pub fn find_consent_url(output: &str) -> Option<String> {
+    let s = strip_ansi(output);
+    let bytes = s.as_bytes();
+    let needle = b"https://";
+    let mut from = 0;
+    while let Some(rel) = find_subslice(&bytes[from..], needle) {
+        let start = from + rel;
+        let mut end = start;
+        while end < bytes.len() {
+            let c = bytes[end];
+            if c.is_ascii_whitespace() || c == b'"' || c == b'\'' || c == 0x07 {
+                break;
+            }
+            end += 1;
+        }
+        let url = s[start..end]
+            .trim_end_matches(['.', ',', ')'])
+            .to_string();
+        if url.contains("oauth") || url.contains("claude.") || url.contains("anthropic.") {
+            return Some(url);
+        }
+        from = end.max(start + needle.len());
+    }
+    None
+}
+
+/// Whether the CLI is now sitting on its auth-code stdin prompt. The prompt
+/// ("Paste code here if prompted >") is drawn with cursor-column escapes, so
+/// after stripping ANSI the words collapse together — we match the collapsed
+/// form to stay robust to that spacing and to line wrapping.
+pub fn awaiting_code(output: &str) -> bool {
+    let collapsed: String = strip_ansi(output).split_whitespace().collect();
+    collapsed.contains("Pastecode")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox::docker::auth::normalize_token;
+
+    #[test]
+    fn strip_ansi_removes_csi_osc_and_two_byte_escapes() {
+        // ESC7 / ESC8 (two-byte), a CSI cursor move, and an OSC title with BEL.
+        let raw = "\x1b7\x1b[9GWelcome\x1b]0;title\x07 to\x1b[0m Claude";
+        assert_eq!(strip_ansi(raw), "Welcome to Claude");
+    }
+
+    #[test]
+    fn strip_ansi_preserves_multibyte_content() {
+        // Braille/block spinner glyphs must survive byte-level escape stripping.
+        assert_eq!(strip_ansi("\x1b[2K✳ ░█▓"), "✳ ░█▓");
+    }
+
+    #[test]
+    fn extract_token_from_a_clean_line() {
+        let out = "Your token:\nsk-ant-oat01-Abc_123-XYZ\nDone.\n";
+        assert_eq!(
+            extract_setup_token(out).as_deref(),
+            Some("sk-ant-oat01-Abc_123-XYZ")
+        );
+    }
+
+    #[test]
+    fn extract_token_from_a_noisy_ink_line() {
+        // The token embedded amid cursor moves and a redraw, as Ink emits it.
+        let out = "\x1b[2G\x1b[1mToken\x1b[7Gsk-ant-oat01-tok_EN-42\x1b[0m\r\n\x1b[?25h";
+        assert_eq!(
+            extract_setup_token(out).as_deref(),
+            Some("sk-ant-oat01-tok_EN-42")
+        );
+    }
+
+    #[test]
+    fn extract_token_returns_none_on_unrelated_output() {
+        // The consent URL / spinner frames carry no token.
+        let out = "\x1b[2G· Opening browser\nhttps://claude.com/cai/oauth/authorize?code=true&state=abc\n";
+        assert_eq!(extract_setup_token(out), None);
+    }
+
+    #[test]
+    fn unexpected_shape_is_extracted_but_flagged_unrecognized() {
+        // A non-`sk-ant-oat` shape (still `sk-ant-`) is captured; normalize_token
+        // then flags it so the store path warns-but-stores (auth.rs behavior).
+        let out = "token: sk-ant-api03-notanoauth\n";
+        let token = extract_setup_token(out).expect("anchored on sk-ant-");
+        assert_eq!(token, "sk-ant-api03-notanoauth");
+        let (normalized, recognized) = normalize_token(&token).unwrap();
+        assert_eq!(normalized, "sk-ant-api03-notanoauth");
+        assert!(!recognized, "sk-ant-api… is not the recognized oat shape");
+    }
+
+    #[test]
+    fn recognized_shape_passes_normalize() {
+        let token = extract_setup_token("sk-ant-oat01-Good_Tok-9\n").unwrap();
+        let (_, recognized) = normalize_token(&token).unwrap();
+        assert!(recognized);
+    }
+
+    #[test]
+    fn streaming_token_waits_for_a_terminator() {
+        // Mid-stream: the run reaches the buffer edge, so hold off.
+        assert_eq!(extract_streaming_token("...sk-ant-oat01-partial"), None);
+        // Next chunk adds a terminating byte → now safe to capture.
+        assert_eq!(
+            extract_streaming_token("...sk-ant-oat01-partialX\n").as_deref(),
+            Some("sk-ant-oat01-partialX")
+        );
+    }
+
+    #[test]
+    fn bare_anchor_is_not_a_token() {
+        assert_eq!(extract_setup_token("sk-ant- and nothing else"), None);
+    }
+
+    #[test]
+    fn find_consent_url_reconstructs_the_authorize_link() {
+        // Wide-PTY output: the URL is one unbroken line after ANSI strip.
+        let out = "\x1b[2GBrowser didn't open?\r\nhttps://claude.com/cai/oauth/authorize?code=true&client_id=abc&scope=user%3Ainference&state=xyz\r\n\x1b[2GPaste code here >";
+        assert_eq!(
+            find_consent_url(out).as_deref(),
+            Some("https://claude.com/cai/oauth/authorize?code=true&client_id=abc&scope=user%3Ainference&state=xyz")
+        );
+    }
+
+    #[test]
+    fn find_consent_url_ignores_non_oauth_urls() {
+        assert_eq!(find_consent_url("see https://example.com/docs for help"), None);
+    }
+
+    #[test]
+    fn awaiting_code_detects_the_collapsed_prompt() {
+        // As emitted by Ink (column-positioned words → no spaces after strip).
+        assert!(awaiting_code("\x1b[2GPaste\x1b[8Gcode\x1b[13Ghere\x1b[18Gif\x1b[21Gprompted\x1b[30G>"));
+        // Also robust to normal spacing / wrapping.
+        assert!(awaiting_code("Paste code here if prompted >"));
+        assert!(!awaiting_code("Opening browser to sign in…"));
+    }
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -412,6 +412,13 @@ export const api = {
   getContainerAuthStatus: () => invoke<ContainerAuthStatus>("get_container_auth_status"),
   setContainerAuthToken: (token: string) => invoke<void>("set_container_auth_token", { token }),
   clearContainerAuthToken: () => invoke<void>("clear_container_auth_token"),
+  // Automated `claude setup-token` capture: drives the CLI under a PTY,
+  // surfaces the consent URL + auth-code prompt as `claude-setup:url` /
+  // `claude-setup:awaiting-code` events, and resolves once the token is stored.
+  // The token itself never crosses this boundary. See `useClaudeSetup`.
+  connectClaudeContainerAuth: () => invoke<void>("connect_claude_container_auth"),
+  submitClaudeSetupCode: (code: string) => invoke<void>("submit_claude_setup_code", { code }),
+  cancelClaudeContainerAuth: () => invoke<void>("cancel_claude_container_auth"),
   // Advanced docker launch knobs (image override + resource limits). Backend-
   // owned settings (`docker_image` / `docker_memory` / `docker_cpus`): the
   // command persists all three AND updates the spawn-path mirror. Blank clears

--- a/src/components/SettingsScreen/ContainerAuth.tsx
+++ b/src/components/SettingsScreen/ContainerAuth.tsx
@@ -1,15 +1,17 @@
+import { open as openExternal } from "@tauri-apps/plugin-shell";
 import { useEffect, useState } from "react";
 import { Icon } from "@/components/Icon";
 import { Button } from "@/components/ui/Button";
 import { CopyButton } from "@/components/ui/CopyButton";
 import { Scrim } from "@/components/ui/Scrim";
 import { useAppStore } from "@/store";
+import { useClaudeSetup } from "@/util/useClaudeSetup";
 import { SetRow } from "./primitives";
 
 /** Human labels for each container-auth chain step (see the backend chain in
  *  `sandbox/docker/auth.rs` — first hit wins, so exactly one is active). */
 const STATUS_LABELS: Record<string, string> = {
-  "stored-token": "Using pasted token",
+  "stored-token": "Using stored token",
   "shell-env": "Using API key from shell profile",
   "credentials-file": "Using claude credentials file",
   none: "Not connected",
@@ -18,9 +20,9 @@ const STATUS_LABELS: Record<string, string> = {
 const SETUP_COMMAND = "claude setup-token";
 
 /** Settings › General › Sandbox: how containerized agents authenticate to
- *  Anthropic. Shows which chain step is active and opens the setup-token
- *  modal — the path for Keychain-only claude logins, which containers can't
- *  see. Docker-only: seatbelt agents keep the user's own login. */
+ *  Anthropic. Shows which chain step is active and opens the connect modal —
+ *  the path for Keychain-only claude logins, which containers can't see.
+ *  Docker-only: seatbelt agents keep the user's own login. */
 export function ContainerAuth() {
   const containerAuth = useAppStore((s) => s.containerAuth);
   const refreshContainerAuth = useAppStore((s) => s.refreshContainerAuth);
@@ -39,7 +41,7 @@ export function ContainerAuth() {
     <>
       <SetRow
         title="Claude auth for containers"
-        sub="Docker agents can't see your Keychain login, so they need an API key from your shell profile or a pasted setup-token. Seatbelt agents keep using your own login."
+        sub="Docker agents can't see your Keychain login, so they need an API key from your shell profile or a setup-token. Seatbelt agents keep using your own login."
       >
         <span className={`set-cauth-status text-sm ${connected ? "connected" : ""}`}>
           {status ? STATUS_LABELS[status] : "Checking…"}
@@ -56,13 +58,179 @@ export function ContainerAuth() {
   );
 }
 
-/** "Connect Claude for containers" modal: copyable `claude setup-token`
- *  command + paste field. Reuses the GitHub connect modal's chrome (`ghc-*`,
- *  see components/GithubConnect) — same compact centered dialog. */
+/** "Connect Claude for containers" modal. The primary path is automated: it
+ *  runs `claude setup-token` for the user (backend PTY flow via `useClaudeSetup`
+ *  — surfaces the consent URL, collects the auth code, captures + stores the
+ *  token). A manual paste field remains as a fallback (e.g. the `claude` CLI
+ *  isn't on PATH). Reuses the GitHub connect modal's chrome (`ghc-*`). */
 function ContainerAuthModal({ onClose }: { onClose: () => void }) {
   const status = useAppStore((s) => s.containerAuth?.status);
-  const setContainerAuthToken = useAppStore((s) => s.setContainerAuthToken);
   const clearContainerAuthToken = useAppStore((s) => s.clearContainerAuthToken);
+  // On success the hook refreshes the status row, then closes the modal.
+  const { phase, url, error, connect, submit, cancel } = useClaudeSetup(onClose);
+  const [manual, setManual] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  // Closing mid-flow cancels the backend PTY (no-op when idle).
+  const close = () => {
+    cancel();
+    onClose();
+  };
+
+  const clear = async () => {
+    setBusy(true);
+    await clearContainerAuthToken();
+    setBusy(false);
+    onClose();
+  };
+
+  return (
+    <>
+      <Scrim onClose={close} zIndex={400} />
+      <div className="ghc-modal" role="dialog" aria-modal="true">
+        <div className="ghc-h flex-center text-base">
+          <Icon name="cube" size={15} />
+          <span>Connect Claude for containers</span>
+          <button className="ghc-close flex-center" aria-label="Close" onClick={close}>
+            <Icon name="close" size={14} />
+          </button>
+        </div>
+
+        <div className="ghc-body">
+          {manual ? (
+            <ManualPaste onClose={onClose} onBack={() => setManual(false)} />
+          ) : (
+            <AutoConnect phase={phase} url={url} error={error} connect={connect} submit={submit} />
+          )}
+
+          <div className="ghc-actions flex-center">
+            {!manual && phase === "idle" && (
+              <Button variant="ghost" onClick={() => setManual(true)}>
+                Paste a token manually
+              </Button>
+            )}
+            {status === "stored-token" && (
+              <Button variant="outline" disabled={busy} onClick={() => void clear()}>
+                Clear token
+              </Button>
+            )}
+            <Button variant="outline" onClick={close}>
+              {phase === "success" ? "Done" : "Cancel"}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+/** The automated flow, rendered by phase. */
+function AutoConnect({
+  phase,
+  url,
+  error,
+  connect,
+  submit,
+}: {
+  phase: ReturnType<typeof useClaudeSetup>["phase"];
+  url: string | null;
+  error: string | null;
+  connect: () => void;
+  submit: (code: string) => void;
+}) {
+  const [code, setCode] = useState("");
+
+  const urlRow = url && (
+    <div className="set-cauth-cmd flex-center">
+      <span className="set-cauth-url mono text-sm" title={url}>
+        {url}
+      </span>
+      <CopyButton text={url} />
+      <Button variant="outline" onClick={() => void openExternal(url).catch(() => {})}>
+        Open
+      </Button>
+    </div>
+  );
+
+  if (phase === "idle") {
+    return (
+      <>
+        <div className="ghc-lede text-sm">
+          Connect your Claude account so containerized agents can authenticate. This opens your
+          browser once to sign in — no copy-paste.
+        </div>
+        <div className="ghc-actions flex-center">
+          <Button variant="primary" onClick={connect}>
+            Connect Claude
+          </Button>
+        </div>
+      </>
+    );
+  }
+
+  if (phase === "awaiting-code") {
+    return (
+      <>
+        <div className="ghc-lede text-sm">
+          Finish signing in, then paste the code from your browser here.
+        </div>
+        {urlRow}
+        <input
+          className="set-cauth-input mono text-sm"
+          type="text"
+          placeholder="Paste code here"
+          value={code}
+          autoFocus
+          onChange={(e) => setCode(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && code.trim()) submit(code);
+          }}
+        />
+        <div className="ghc-actions flex-center">
+          <Button variant="primary" disabled={!code.trim()} onClick={() => submit(code)}>
+            Submit code
+          </Button>
+        </div>
+      </>
+    );
+  }
+
+  if (phase === "success") {
+    return (
+      <div className="ghc-lede flex-center text-sm">
+        <Icon name="check" size={14} />
+        <span>Connected. Containers can now authenticate to Claude.</span>
+      </div>
+    );
+  }
+
+  if (phase === "error") {
+    return (
+      <>
+        <div className="ghc-err text-sm">{error ?? "Something went wrong."}</div>
+        <div className="ghc-actions flex-center">
+          <Button variant="primary" onClick={connect}>
+            Try again
+          </Button>
+        </div>
+      </>
+    );
+  }
+
+  // connecting | verifying
+  return (
+    <>
+      <div className="set-cauth-note text-sm">
+        {phase === "verifying" ? "Verifying your code…" : "Opening your browser to sign in…"}
+      </div>
+      {urlRow}
+    </>
+  );
+}
+
+/** Fallback: run `claude setup-token` yourself and paste the result. */
+function ManualPaste({ onClose, onBack }: { onClose: () => void; onBack: () => void }) {
+  const setContainerAuthToken = useAppStore((s) => s.setContainerAuthToken);
   const [token, setToken] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -80,63 +248,37 @@ function ContainerAuthModal({ onClose }: { onClose: () => void }) {
     }
   };
 
-  const clear = async () => {
-    setBusy(true);
-    await clearContainerAuthToken();
-    setBusy(false);
-    onClose();
-  };
-
   return (
     <>
-      <Scrim onClose={onClose} zIndex={400} />
-      <div className="ghc-modal" role="dialog" aria-modal="true">
-        <div className="ghc-h flex-center text-base">
-          <Icon name="cube" size={15} />
-          <span>Connect Claude for containers</span>
-          <button className="ghc-close flex-center" aria-label="Close" onClick={onClose}>
-            <Icon name="close" size={14} />
-          </button>
-        </div>
-
-        <div className="ghc-body">
-          <div className="ghc-lede text-sm">
-            Run <span className="mono">{SETUP_COMMAND}</span> in your terminal and paste the token
-            here.
-          </div>
-          <div className="set-cauth-cmd flex-center">
-            <span className="mono text-sm">{SETUP_COMMAND}</span>
-            <CopyButton text={SETUP_COMMAND} />
-          </div>
-          <input
-            className="set-cauth-input mono text-sm"
-            type="password"
-            placeholder="sk-ant-oat…"
-            value={token}
-            autoFocus
-            onChange={(e) => {
-              setToken(e.target.value);
-              setError(null);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && token.trim() && !busy) void save();
-            }}
-          />
-          {error && <div className="ghc-err text-sm">{error}</div>}
-          <div className="ghc-actions flex-center">
-            <Button variant="primary" disabled={busy || !token.trim()} onClick={() => void save()}>
-              Save token
-            </Button>
-            {status === "stored-token" && (
-              <Button variant="outline" disabled={busy} onClick={() => void clear()}>
-                Clear token
-              </Button>
-            )}
-            <Button variant="outline" onClick={onClose}>
-              Cancel
-            </Button>
-          </div>
-        </div>
+      <div className="ghc-lede text-sm">
+        Run <span className="mono">{SETUP_COMMAND}</span> in your terminal and paste the token here.
+      </div>
+      <div className="set-cauth-cmd flex-center">
+        <span className="mono text-sm">{SETUP_COMMAND}</span>
+        <CopyButton text={SETUP_COMMAND} />
+      </div>
+      <input
+        className="set-cauth-input mono text-sm"
+        type="password"
+        placeholder="sk-ant-oat…"
+        value={token}
+        autoFocus
+        onChange={(e) => {
+          setToken(e.target.value);
+          setError(null);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && token.trim() && !busy) void save();
+        }}
+      />
+      {error && <div className="ghc-err text-sm">{error}</div>}
+      <div className="ghc-actions flex-center">
+        <Button variant="primary" disabled={busy || !token.trim()} onClick={() => void save()}>
+          Save token
+        </Button>
+        <Button variant="ghost" onClick={onBack}>
+          Back
+        </Button>
       </div>
     </>
   );

--- a/src/components/SettingsScreen/SettingsScreen.css
+++ b/src/components/SettingsScreen/SettingsScreen.css
@@ -486,6 +486,21 @@
 .set-cauth-input:focus {
   border-color: var(--accent);
 }
+/* Consent URL surfaced during the automated flow (fallback to the CLI's own
+   browser-open); mono + single-line with the tail elided so a ~250-char URL
+   doesn't blow out the dialog. The recognizable `https://claude.com/…` head
+   stays visible; Copy/Open carry the full value. */
+.set-cauth-url {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* Muted per-phase status line ("Opening your browser…", "Verifying…"). */
+.set-cauth-note {
+  color: var(--fg-2);
+}
 
 /* ── PROVIDERS ───────────────────────────────────────────────────────── */
 .set-checked {

--- a/src/util/useClaudeSetup.ts
+++ b/src/util/useClaudeSetup.ts
@@ -1,0 +1,99 @@
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { useCallback, useRef, useState } from "react";
+import { api } from "@/api";
+import { useAppStore } from "@/store";
+
+/** Where the automated `claude setup-token` flow is:
+ *  - `idle`         — not started
+ *  - `connecting`   — CLI launched; waiting on the consent URL / sign-in
+ *  - `awaiting-code`— CLI is prompting for the auth code; show the input
+ *  - `verifying`    — code submitted; waiting for the token to be captured
+ *  - `success`      — token captured + stored
+ *  - `error`        — the flow failed (see `error`) */
+export type ClaudeSetupPhase =
+  | "idle"
+  | "connecting"
+  | "awaiting-code"
+  | "verifying"
+  | "success"
+  | "error";
+
+/** Drives the automated `claude setup-token` capture end to end (the analogue
+ *  of `useGithubConnect` for container auth): start the backend PTY flow, relay
+ *  its consent URL and auth-code prompt to the UI, submit the code the user
+ *  pastes back, then refresh the container-auth status on success.
+ *
+ *  A monotonic run id drops late results from a superseded/cancelled attempt:
+ *  the backend PTY keeps running until it exits or is cancelled, but its outcome
+ *  no longer touches the UI once a newer attempt (or a cancel) has started. */
+export function useClaudeSetup(onConnected?: () => void) {
+  const refreshContainerAuth = useAppStore((s) => s.refreshContainerAuth);
+
+  const [phase, setPhase] = useState<ClaudeSetupPhase>("idle");
+  const [url, setUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const runRef = useRef(0);
+  const onConnectedRef = useRef(onConnected);
+  onConnectedRef.current = onConnected;
+
+  const connect = useCallback(async () => {
+    const runId = ++runRef.current;
+    const stale = () => runRef.current !== runId;
+    setPhase("connecting");
+    setUrl(null);
+    setError(null);
+    // Default no-ops so `finally` can always call them; listen() lives inside
+    // the try so an IPC failure surfaces as an error instead of throwing.
+    let unlistenUrl: UnlistenFn = () => {};
+    let unlistenCode: UnlistenFn = () => {};
+    try {
+      // Surface the consent URL as a fallback — the CLI already opens the
+      // browser itself, so we show (not auto-open) it to avoid a duplicate tab.
+      unlistenUrl = await listen<string>("claude-setup:url", (e) => {
+        if (stale()) return;
+        setUrl(e.payload);
+      });
+      unlistenCode = await listen("claude-setup:awaiting-code", () => {
+        if (stale()) return;
+        setPhase("awaiting-code");
+      });
+      await api.connectClaudeContainerAuth();
+      if (stale()) return;
+      await refreshContainerAuth();
+      if (stale()) return;
+      setPhase("success");
+      onConnectedRef.current?.();
+    } catch (err) {
+      if (stale()) return;
+      setError(String(err));
+      setPhase("error");
+    } finally {
+      unlistenUrl();
+      unlistenCode();
+    }
+  }, [refreshContainerAuth]);
+
+  /** Send the auth code the user pasted to the waiting CLI; flips back to a
+   *  verifying state until the connect call resolves (success) or rejects. */
+  const submit = useCallback(async (code: string) => {
+    try {
+      await api.submitClaudeSetupCode(code);
+      setPhase("verifying");
+    } catch (err) {
+      setError(String(err));
+      setPhase("error");
+    }
+  }, []);
+
+  /** Abandon the current attempt: invalidate its run id, tell the backend to
+   *  kill the PTY, and reset to idle. Its now-superseded outcome is ignored. */
+  const cancel = useCallback(() => {
+    runRef.current++;
+    void api.cancelClaudeContainerAuth().catch(() => {});
+    setPhase("idle");
+    setUrl(null);
+    setError(null);
+  }, []);
+
+  return { phase, url, error, connect, submit, cancel };
+}


### PR DESCRIPTION
## Why

Docker agents can't see the host macOS Keychain login, so they need Anthropic credentials resolved explicitly. The only "connect" path so far was running `claude setup-token` by hand and pasting the `sk-ant-oat…` token into settings — the main "it doesn't just work" gap for containers. This automates it: click **Connect Claude**, complete a one-time browser consent, and the token is captured and stored (no paste, no restart).

## How

`claude setup-token` is an interactive Ink TUI — it opens a browser for consent, then prompts on the CLI for an auth code before printing the token — so this is a PTY-driven subprocess, not stdout capture.

**Backend**
- New `sandbox/docker/setup_token.rs`: spawns `claude setup-token` under a **wide (400-col) PTY** (reusing `PtySession`), strips ANSI, and scans for the consent URL, the auth-code prompt, and the token. The wide PTY keeps the long URL and token on single unbroken lines (Ink wraps mid-value at normal width); a terminator guard avoids capturing a still-streaming token prefix. Never logs the buffer or the token.
- `lib.rs`: factored `set_container_auth_token`'s persist-then-mirror core into `store_container_token`, shared with the automated path. Added commands:
  - `connect_claude_container_auth` — drives the flow, emits `claude-setup:url` / `claude-setup:awaiting-code`, 5-min timeout, single-flight, clear "claude not on PATH" error.
  - `submit_claude_setup_code` — writes the code to the live PTY.
  - `cancel_claude_container_auth` — drops the session (kills the PTY).
- Token validated via the existing `auth::normalize_token` and stored through the same path as the paste command (unexpected shapes are warn-but-stored).

**Frontend**
- `useClaudeSetup` hook (mirrors `useGithubConnect`): relays URL + prompt, submits the code, refreshes status on success, run-id guard + cancel.
- `ContainerAuth` modal: automated "Connect Claude" is now primary (surfaces the URL as a Copy/Open fallback — no auto-open, since the CLI already opens the browser — collects the code, shows success). Manual paste kept as a fallback (e.g. `claude` off PATH). `api.ts` + CSS wired.

## Testing

- 12 new unit tests over the parsers: valid `sk-ant-oat…`, noisy Ink lines, no-token output, an unexpected `sk-ant-api…` shape (extracted but flagged → warn-but-store), streaming terminator guard, plus URL and prompt detection.
- `cargo test` green (439 passed).
- Live-verified the consent-URL and auth-code-prompt detection against the real `claude setup-token` CLI. The final token-capture leg needs a real Anthropic consent (the manual E2E step).

> Note: `tsc` wasn't run (no `node_modules` in the Fletch worktree — a known false-green trap); frontend is Biome-clean + type-reviewed. Worth a `pnpm check` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)