### PR TITLE
refactor(git): retire RPC commit/merge for native in-container git

### DIFF
--- a/src-tauri/src/editors.rs
+++ b/src-tauri/src/editors.rs
@@ -4,7 +4,7 @@
 //! — so the launcher only ever offers tools that are actually present.
 
 use serde::Serialize;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 
 use crate::bin_resolve;
@@ -28,7 +28,8 @@ struct KnownEditor {
     /// CLI launcher names to try on PATH, first match wins (e.g. `code`).
     clis: &'static [&'static str],
     /// macOS `.app` name (without the extension), used both to detect the app
-    /// and to launch it by name via LaunchServices.
+    /// and to launch it by name via LaunchServices. Only read on macOS.
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
     mac_app: Option<&'static str>,
 }
 
@@ -166,6 +167,7 @@ fn is_available(ed: &KnownEditor, home: Option<&Path>) -> bool {
 
 #[cfg(target_os = "macos")]
 fn mac_app_installed(ed: &KnownEditor, home: Option<&Path>) -> bool {
+    use std::path::PathBuf;
     let Some(app) = ed.mac_app else { return false };
     let bundle = format!("{app}.app");
     // Cover the GUI-app locations plus Utilities (where the system Terminal

--- a/src-tauri/src/instructions/git_actions.md
+++ b/src-tauri/src/instructions/git_actions.md
@@ -4,38 +4,44 @@ When the user clicks a git action in the app, the app sends a one-line request o
 
     [app-action] <name> key="value" ...
 
-Treat it exactly like a user request and follow the matching playbook below — nothing more, nothing less. Use the file-RPC ops (`git_commit`, `git_push`, `git_update_branch`, `open_pr`) for every git mutation; raw `git commit`/`push`/`merge` are blocked by your sandbox. Keep your reply brief: one line on what you did (plus the PR URL when you opened one).
+Treat it exactly like a user request and follow the matching playbook below — nothing more, nothing less. Keep your reply brief: one line on what you did (plus the PR URL when you opened one).
 
-Your worktree starts with no branch (detached HEAD) — that's expected. The branch is created the first time you push, and **you choose its name**: pass `args.branch` to `open_pr` (or `git_push`) with a short, conventional, descriptive name for the work — `fix/…`, `feat/…`, or `chore/…` (no `fletch/` prefix), e.g. `fix/login-crash`. Run `git status` if unsure whether you're already on a branch; once you are, omit `args.branch` and later pushes update that same branch.
+**Local git is yours to run directly.** Your workspace is a real checkout with a writable `.git`, so run plain git for local work: `git status`, `git add`, `git commit`, `git merge`, and conflict resolution all work in-place. What Fletch runs *for* you are the actions that need your GitHub credentials — and those stay on the host, never in your sandbox. So for anything that talks to the remote, use the file-RPC ops:
+
+- **`git_push`** — push the current branch to `origin`.
+- **`open_pr`** — push and open a pull request.
+- **`git_fetch`** — refresh a base branch from `origin` (for `update-branch`).
+
+Your worktree starts with no branch (detached HEAD) — that's expected. The branch is created the first time you push, and **you choose its name**: pass `args.branch` to `git_push` (or `open_pr`) with a short, conventional, descriptive name for the work — `fix/…`, `feat/…`, or `chore/…` (no `fletch/` prefix), e.g. `fix/login-crash`. Run `git status` if unsure whether you're already on a branch; once you are, omit `args.branch` and later pushes update that same branch.
 
 ### commit
 
-Review the uncommitted changes (`git status`, `git diff HEAD`), write a clear, conventional commit message, and commit by calling `git_commit`. Commit ONLY — do not push and do not open a pull request.
+Review the uncommitted changes (`git status`, `git diff HEAD`), write a clear, conventional commit message, and commit with plain git — `git add -A` then `git commit -m "…"`. Commit ONLY — do not push and do not open a pull request.
 
 ### commit-push
 
-Same as `commit`, then push by calling `git_push` — include `args.branch` (a conventional name like `fix/…`) if you don't have a branch yet. Do not open a pull request.
+Commit with plain git as in `commit`, then push by calling the `git_push` op — include `args.branch` (a conventional name like `fix/…`) if you don't have a branch yet. Do not open a pull request.
 
 ### commit-pr — params: `base`
 
-Same as `commit`, then write a concise PR title and description covering ALL changes versus the `base` branch, and open the PR by calling `open_pr` with that title and body — plus `args.branch` (your chosen conventional name) if you don't have a branch yet.
+Commit with plain git as in `commit`, then write a concise PR title and description covering ALL changes versus the `base` branch, and open the PR by calling the `open_pr` op with that title and body — plus `args.branch` (your chosen conventional name) if you don't have a branch yet.
 
 ### open-pr — params: `base`
 
-Everything is already committed. Review the work versus `base` (`git log <base>..HEAD`, `git diff <base>...HEAD`), write a concise, descriptive PR title and body, and open the PR by calling `open_pr` with them — plus `args.branch` (your chosen conventional name) if you don't have a branch yet.
+Everything is already committed. Review the work versus `base` (`git log <base>..HEAD`, `git diff <base>...HEAD`), write a concise, descriptive PR title and body, and open the PR by calling the `open_pr` op with them — plus `args.branch` (your chosen conventional name) if you don't have a branch yet.
 
 ### push
 
-Push your committed work by calling `git_push`. If you don't have a branch yet (detached HEAD), choose a conventional, descriptive name and pass it as `args.branch` (e.g. `fix/login-crash`); the branch is created at your current commit and pushed. Do not open a pull request.
+Push your committed work by calling the `git_push` op. If you don't have a branch yet (detached HEAD), choose a conventional, descriptive name and pass it as `args.branch` (e.g. `fix/login-crash`); the branch is created at your current commit and pushed. Do not open a pull request.
 
 ### resolve-conflicts
 
-Inspect each conflicted file in your worktree, reconcile both sides correctly, then complete the merge by calling `git_commit` with a short merge message — it stages everything for you.
+Inspect each conflicted file in your worktree, reconcile both sides correctly, then complete the merge with plain git — `git add -A` then `git commit` (an empty `-m` uses git's prepared merge message; a short summary is fine too).
 
 ### update-branch — params: `base`
 
-The pull request can't merge cleanly because `base` has advanced. Call `git_update_branch` to merge the latest base into this branch. If it reports conflicts, resolve the affected files, complete the merge with `git_commit`, then push with `git_push`. If it merges cleanly, just push with `git_push`.
+The pull request can't merge cleanly because `base` has advanced. First refresh the base by calling the `git_fetch` op with `args.ref="<base>"` (this uses the host's credentials to update `origin/<base>`). Then merge it natively: `git merge origin/<base>`. If it reports conflicts, resolve the affected files and complete the merge with `git commit`; if it merged cleanly, no commit is needed. Either way, finish by pushing with the `git_push` op.
 
 ### fix-checks — params: `failing` (check names)
 
-CI checks are failing on this branch's pull request. Investigate the failures, fix them, commit the fix with `git_commit`, and push with `git_push` so the checks re-run.
+CI checks are failing on this branch's pull request. Investigate the failures, fix them, commit the fix with plain git (`git add -A` && `git commit`), and push by calling the `git_push` op so the checks re-run.

--- a/src-tauri/src/instructions/rpc_protocol.md
+++ b/src-tauri/src/instructions/rpc_protocol.md
@@ -58,7 +58,8 @@ jq -n --arg id "$ID" --arg msg "$MSG" '{id:$id,op:"echo",args:{message:$msg}}' \
 mv "$FLETCH_RPC_DIR/requests/$ID.json.tmp" "$FLETCH_RPC_DIR/requests/$ID.json"
 ```
 
-The exact op names are feature-specific. Fletch currently uses this same
-transport for Git actions, and the Git dispatcher also exposes `echo` as a
-simple round-trip check. Future app features can define their own ops on top of
-the same mailbox.
+The exact op names are feature-specific. Fletch uses this transport for the git
+actions that need host-held GitHub credentials — `git_push`, `open_pr`, and
+`git_fetch` (local git you run directly; see the git-actions playbooks). The
+dispatcher also exposes `echo` as a simple round-trip check. Future app features
+can define their own ops on top of the same mailbox.

--- a/src-tauri/src/rpc/git.rs
+++ b/src-tauri/src/rpc/git.rs
@@ -248,7 +248,26 @@ impl GitDispatcher {
             &crate::github::git_auth_env(),
             &crate::git::no_hooks_env(),
         ]);
-        run_git_command(id, &self.cwd, &["fetch", "origin", &branch], &auth).await
+        let resp = run_git_command(id, &self.cwd, &["fetch", "origin", &branch], &auth).await;
+        // `run_git_command` reports `ok: true` for any git that *ran*, carrying a
+        // non-zero result only in `exit_code`. For fetch that's a trap: a missing
+        // ref or a transient remote failure would leave `origin/<branch>` stale
+        // while the agent merges it anyway. Convert a non-zero fetch into a hard
+        // error so the `update-branch` flow stops here instead of merging old
+        // state. A response that's already an error (spawn/timeout) passes through
+        // unchanged, keeping its original message.
+        if !resp.ok || resp.exit_code == Some(0) {
+            return resp;
+        }
+        let detail = resp
+            .stderr
+            .filter(|s| !s.trim().is_empty())
+            .or(resp.stdout)
+            .unwrap_or_default();
+        Response::err(
+            id,
+            format!("git_fetch: fetch origin {branch} failed: {}", detail.trim()),
+        )
     }
 }
 
@@ -444,10 +463,15 @@ mod tests {
         let (resp, effects) = disp
             .dispatch_inner("f1", "git_fetch", &json!({"ref": "main"}))
             .await;
-        // No origin remote → git exits non-zero, but the op itself ran and must
-        // NOT read as a completed mutation (fetch is not a mutating op).
-        assert!(resp.ok, "the op ran; the failure is in the exit code");
-        assert_ne!(resp.exit_code, Some(0));
+        // No origin remote → git exits non-zero. This must surface as a hard
+        // error, not an ok response, so the agent stops instead of merging a
+        // stale `origin/<base>`. And it's never a completed mutation.
+        assert!(!resp.ok, "a failed fetch must be an error response, got: {resp:?}");
+        assert!(
+            resp.error.as_deref().unwrap_or_default().contains("failed"),
+            "error should explain the fetch failed, got: {:?}",
+            resp.error
+        );
         assert!(!has_action_done(&effects, "git_fetch"));
     }
 

--- a/src-tauri/src/rpc/git.rs
+++ b/src-tauri/src/rpc/git.rs
@@ -22,11 +22,24 @@ pub const EVENT_PR_OPENED: &str = "git.pr_opened";
 /// (which can't tell agent work from a manual action or a pre-existing match).
 pub const EVENT_ACTION_DONE: &str = "git.action_done";
 
-/// Ops that change repo/PR state — the ones whose success means the agent did
-/// the delegated work. Read-only ops (status) and the test ops (echo/ping) are
-/// excluded so they never read as a completed delegation.
+/// Host-brokered ops that change remote state — the ones that must run on the
+/// host because they need GitHub credentials that never enter the sandbox, and
+/// whose success means the agent did the delegated work. Local mutations
+/// (commit, merge, conflict-resolve) now run as native in-container git and are
+/// *not* here — their delegation signal arrives out-of-band via the clone's
+/// `post-commit`/`post-merge` hooks (see `signal_git_action`). Read-only ops
+/// (status, fetch) and the test ops (echo/ping) are excluded so they never read
+/// as a completed delegation.
 fn is_mutating_op(op: &str) -> bool {
-    matches!(op, "git_commit" | "git_push" | "open_pr" | "git_update_branch")
+    matches!(op, "git_push" | "open_pr")
+}
+
+/// The local-git action names a delegation hook may report. Kept to a closed
+/// set so a compromised hook can't fabricate an arbitrary op string into the
+/// UI's delegation attribution. These mirror the op names the frontend's
+/// `gitActionProvesKind` still recognizes for backward compatibility.
+fn is_signalable_action(action: &str) -> bool {
+    matches!(action, "git_commit" | "git_update_branch")
 }
 
 #[derive(Clone)]
@@ -57,6 +70,14 @@ impl GitDispatcher {
         let (resp, mut effects) = match op {
             "open_pr" => self.open_pr(id, args).await,
             "git_push" => self.git_push(id, args).await,
+            // Credentialed fetch of the base branch for the native in-container
+            // merge in `update-branch`: the token stays host-side, so the agent
+            // can't fetch a private remote itself.
+            "git_fetch" => (self.git_fetch(id, args).await, Vec::new()),
+            // Out-of-band delegation signal from the clone's local git hooks
+            // (post-commit / post-merge). Not a mutation the host performs —
+            // it only relays that the agent's native git action ran.
+            "signal_git_action" => self.signal_git_action(id, args),
             "echo" => (self.echo(id, args).await, Vec::new()),
             "ping" => (Response::ok(id, 0, "pong".to_string(), String::new()), Vec::new()),
             "git_status" => (
@@ -69,8 +90,6 @@ impl GitDispatcher {
                 .await,
                 Vec::new(),
             ),
-            "git_commit" => (self.git_commit(id, args).await, Vec::new()),
-            "git_update_branch" => (self.git_update_branch(id).await, Vec::new()),
             other => (Response::err(id, format!("unknown op: {other}")), Vec::new()),
         };
         // A successful mutating op is ground truth that the agent performed the
@@ -93,15 +112,24 @@ impl GitDispatcher {
         Response::ok(id, 0, message.to_string(), String::new())
     }
 
-    async fn git_commit(&self, id: &str, args: &Value) -> Response {
-        let message = args.get("message").and_then(|v| v.as_str()).unwrap_or("");
-        if message.trim().is_empty() {
-            return Response::err(id, "git_commit requires a non-empty `message` arg");
+    /// Relay a native-git delegation signal from a clone-installed hook. The
+    /// hook can't emit an app event itself, so it pings this op; we translate it
+    /// into the same `EVENT_ACTION_DONE` a host-side mutation would emit, so the
+    /// UI attributes the agent's in-container commit/merge to its turn exactly as
+    /// before. Synchronous: no git runs, we only validate and emit.
+    fn signal_git_action(&self, id: &str, args: &Value) -> (Response, Vec<RpcEvent>) {
+        let action = args.get("action").and_then(|v| v.as_str()).unwrap_or("");
+        if !is_signalable_action(action) {
+            return (
+                Response::err(id, format!("signal_git_action: unknown action {action:?}")),
+                Vec::new(),
+            );
         }
-        match crate::git::commit_all(&self.cwd, message).await {
-            Ok(()) => Response::ok(id, 0, "committed".to_string(), String::new()),
-            Err(e) => Response::err(id, e.to_string()),
-        }
+        let effects = vec![RpcEvent::named(
+            EVENT_ACTION_DONE,
+            serde_json::json!({ "op": action }),
+        )];
+        (Response::ok(id, 0, String::new(), String::new()), effects)
     }
 
     async fn open_pr(&self, id: &str, args: &Value) -> (Response, Vec<RpcEvent>) {
@@ -200,30 +228,38 @@ impl GitDispatcher {
         }
     }
 
-    async fn git_update_branch(&self, id: &str) -> Response {
-        // Auth for the fetch, plus hook-disabling on both ops: the workspace is
-        // agent-writable, so a planted hook must not run on the host. `merge_git_env`
-        // reindexes so the auth and no-hooks `GIT_CONFIG_*` sets don't collide.
-        let no_hooks = crate::git::no_hooks_env();
-        let auth = crate::git::merge_git_env(&[&crate::github::git_auth_env(), &no_hooks]);
-        let fetch = run_git_command(id, &self.cwd, &["fetch", "origin", &self.base_branch], &auth)
-            .await;
-        if !fetch.ok || fetch.exit_code != Some(0) {
-            return fetch;
+    /// Fetch a base branch from `origin` with the host-held GitHub token, so the
+    /// agent can then run a native in-container `git merge origin/<base>` without
+    /// the token ever entering the sandbox. Read-only on the local repo (updates
+    /// only the `origin/<base>` remote-tracking ref); the merge, conflict
+    /// resolution, and merge commit are the agent's native git. `args.ref`
+    /// selects the branch (the `update-branch` playbook passes its `base`);
+    /// absent, the spawn parent branch is used. Hooks are disabled on this
+    /// host-side invocation for the same reason as push (agent-writable `.git`).
+    async fn git_fetch(&self, id: &str, args: &Value) -> Response {
+        let branch = match arg_branch_named(args, "ref") {
+            Some(r) => r,
+            None => self.base_branch.clone(),
+        };
+        if branch.starts_with('-') {
+            return Response::err(id, format!("git_fetch: refusing option-like ref {branch:?}"));
         }
-        // A clean merge creates a merge commit (needs an identity) and fires
-        // `post-merge` on the host (needs hooks disabled).
-        let env = crate::git::merge_git_env(&[
-            &crate::git::identity_env(&self.cwd).await,
-            &no_hooks,
+        let auth = crate::git::merge_git_env(&[
+            &crate::github::git_auth_env(),
+            &crate::git::no_hooks_env(),
         ]);
-        let target = format!("origin/{}", self.base_branch);
-        run_git_command(id, &self.cwd, &["merge", "--no-edit", &target], &env).await
+        run_git_command(id, &self.cwd, &["fetch", "origin", &branch], &auth).await
     }
 }
 
 fn arg_branch(args: &Value) -> Option<String> {
-    args.get("branch")
+    arg_branch_named(args, "branch")
+}
+
+/// Read a trimmed, non-empty string arg by key. Used for `branch` (push/PR) and
+/// `ref` (fetch).
+fn arg_branch_named(args: &Value, key: &str) -> Option<String> {
+    args.get(key)
         .and_then(|v| v.as_str())
         .map(str::trim)
         .filter(|s| !s.is_empty())
@@ -353,36 +389,81 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn git_commit_stages_and_commits_the_worktree() {
+    async fn signal_git_action_emits_action_done_for_known_actions() {
         let td = tempfile::tempdir().unwrap();
         let repo = td.path().join("repo");
         std::fs::create_dir_all(&repo).unwrap();
         run_git(&repo, &["init", "-q"]);
-        run_git(&repo, &["config", "user.email", "t@example.com"]);
-        run_git(&repo, &["config", "user.name", "Tester"]);
-        std::fs::write(repo.join("new.txt"), b"hello").unwrap();
 
         let rpc_dir = td.path().join("rpc");
         ensure_mailbox(&rpc_dir).unwrap();
         write_request(
             &rpc_dir.join("requests"),
-            "c1.json",
-            r#"{"id":"c1","op":"git_commit","args":{"message":"add new.txt"}}"#,
+            "s1.json",
+            r#"{"id":"s1","op":"signal_git_action","args":{"action":"git_commit"}}"#,
         );
 
         let dispatcher = dispatcher(&repo);
-        process_pending(&rpc_dir, &dispatcher).await;
+        let effects = process_pending(&rpc_dir, &dispatcher).await;
 
-        let body = std::fs::read_to_string(rpc_dir.join("responses/c1.json")).unwrap();
+        let body = std::fs::read_to_string(rpc_dir.join("responses/s1.json")).unwrap();
         let v: Value = serde_json::from_str(&body).unwrap();
         assert_eq!(v["ok"], true, "response: {body}");
+        assert!(
+            has_action_done(&effects, "git_commit"),
+            "a post-commit hook signal must relay an action-done, got: {effects:?}"
+        );
+    }
 
-        let log = std::process::Command::new("git")
-            .current_dir(&repo)
-            .args(["log", "--oneline"])
-            .output()
-            .unwrap();
-        assert!(String::from_utf8_lossy(&log.stdout).contains("add new.txt"));
+    #[tokio::test]
+    async fn signal_git_action_rejects_unknown_action() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        run_git(&repo, &["init", "-q"]);
+
+        let disp = dispatcher(&repo);
+        let (resp, effects) = disp
+            .dispatch_inner("s", "signal_git_action", &json!({"action": "rm -rf"}))
+            .await;
+        assert!(!resp.ok, "an unrecognized action must be rejected");
+        assert!(
+            effects.is_empty(),
+            "a rejected signal must emit nothing, got: {effects:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn git_fetch_without_remote_reports_error() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        run_git(&repo, &["init", "-q", "-b", "main"]);
+
+        let disp = dispatcher(&repo);
+        let (resp, effects) = disp
+            .dispatch_inner("f1", "git_fetch", &json!({"ref": "main"}))
+            .await;
+        // No origin remote → git exits non-zero, but the op itself ran and must
+        // NOT read as a completed mutation (fetch is not a mutating op).
+        assert!(resp.ok, "the op ran; the failure is in the exit code");
+        assert_ne!(resp.exit_code, Some(0));
+        assert!(!has_action_done(&effects, "git_fetch"));
+    }
+
+    #[tokio::test]
+    async fn git_fetch_refuses_option_like_ref() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        run_git(&repo, &["init", "-q", "-b", "main"]);
+
+        let disp = dispatcher(&repo);
+        let (resp, _fx) = disp
+            .dispatch_inner("f2", "git_fetch", &json!({"ref": "--upload-pack=evil"}))
+            .await;
+        assert!(!resp.ok);
+        assert!(resp.error.as_deref().unwrap_or_default().contains("option-like"));
     }
 
     #[tokio::test]
@@ -503,128 +584,6 @@ mod tests {
         assert_eq!(fallback_branch("!!!"), "chore/update");
     }
 
-    fn setup_origin_and_clone() -> (tempfile::TempDir, std::path::PathBuf) {
-        let td = tempfile::tempdir().unwrap();
-        let origin = td.path().join("origin.git");
-        std::fs::create_dir_all(&origin).unwrap();
-        run_git(&origin, &["init", "-q", "--bare", "-b", "main"]);
-
-        let work = td.path().join("work");
-        let out = std::process::Command::new("git")
-            .current_dir(td.path())
-            .args(["clone", "-q", origin.to_str().unwrap(), "work"])
-            .output()
-            .unwrap();
-        assert!(
-            out.status.success(),
-            "{}",
-            String::from_utf8_lossy(&out.stderr)
-        );
-        run_git(&work, &["config", "user.email", "t@example.com"]);
-        run_git(&work, &["config", "user.name", "Tester"]);
-        run_git(&work, &["checkout", "-q", "-b", "main"]);
-        std::fs::write(work.join("a.txt"), b"base\n").unwrap();
-        run_git(&work, &["add", "-A"]);
-        run_git(&work, &["commit", "-q", "-m", "init"]);
-        run_git(&work, &["push", "-q", "-u", "origin", "main"]);
-
-        run_git(&work, &["checkout", "-q", "-b", "feat"]);
-        std::fs::write(work.join("feat.txt"), b"feature\n").unwrap();
-        run_git(&work, &["add", "-A"]);
-        run_git(&work, &["commit", "-q", "-m", "feat work"]);
-        run_git(&work, &["checkout", "-q", "main"]);
-        std::fs::write(work.join("b.txt"), b"advance\n").unwrap();
-        run_git(&work, &["add", "-A"]);
-        run_git(&work, &["commit", "-q", "-m", "main advances"]);
-        run_git(&work, &["push", "-q", "origin", "main"]);
-        run_git(&work, &["checkout", "-q", "feat"]);
-        (td, work)
-    }
-
-    #[tokio::test]
-    async fn git_update_branch_merges_the_advanced_base() {
-        let (td, work) = setup_origin_and_clone();
-        let rpc_dir = td.path().join("rpc");
-        ensure_mailbox(&rpc_dir).unwrap();
-        write_request(
-            &rpc_dir.join("requests"),
-            "u1.json",
-            r#"{"id":"u1","op":"git_update_branch"}"#,
-        );
-
-        let dispatcher = dispatcher(&work);
-        process_pending(&rpc_dir, &dispatcher).await;
-
-        let body = std::fs::read_to_string(rpc_dir.join("responses/u1.json")).unwrap();
-        let v: Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(v["ok"], true, "response: {body}");
-        assert_eq!(v["exit_code"], 0, "response: {body}");
-        assert!(work.join("b.txt").exists());
-    }
-
-    #[tokio::test]
-    async fn git_update_branch_reports_conflicts_and_leaves_merge_open() {
-        let (td, work) = setup_origin_and_clone();
-        std::fs::write(work.join("a.txt"), b"feat version\n").unwrap();
-        run_git(&work, &["add", "-A"]);
-        run_git(&work, &["commit", "-q", "-m", "feat edits a"]);
-        run_git(&work, &["checkout", "-q", "main"]);
-        std::fs::write(work.join("a.txt"), b"main version\n").unwrap();
-        run_git(&work, &["add", "-A"]);
-        run_git(&work, &["commit", "-q", "-m", "main edits a"]);
-        run_git(&work, &["push", "-q", "origin", "main"]);
-        run_git(&work, &["checkout", "-q", "feat"]);
-
-        let rpc_dir = td.path().join("rpc");
-        ensure_mailbox(&rpc_dir).unwrap();
-        write_request(
-            &rpc_dir.join("requests"),
-            "u2.json",
-            r#"{"id":"u2","op":"git_update_branch"}"#,
-        );
-
-        let dispatcher = dispatcher(&work);
-        process_pending(&rpc_dir, &dispatcher).await;
-
-        let body = std::fs::read_to_string(rpc_dir.join("responses/u2.json")).unwrap();
-        let v: Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(v["ok"], true, "response: {body}");
-        assert_ne!(v["exit_code"], 0, "response: {body}");
-        assert!(v["stdout"].as_str().unwrap().contains("CONFLICT"));
-        let status = std::process::Command::new("git")
-            .current_dir(&work)
-            .args(["status", "--porcelain=v1"])
-            .output()
-            .unwrap();
-        assert!(String::from_utf8_lossy(&status.stdout).contains("UU a.txt"));
-    }
-
-    #[tokio::test]
-    async fn git_commit_rejects_empty_message() {
-        let td = tempfile::tempdir().unwrap();
-        let repo = td.path().join("repo");
-        std::fs::create_dir_all(&repo).unwrap();
-        run_git(&repo, &["init", "-q", "-b", "main"]);
-        run_git(&repo, &["config", "user.email", "t@example.com"]);
-        run_git(&repo, &["config", "user.name", "Tester"]);
-
-        let rpc_dir = td.path().join("rpc");
-        ensure_mailbox(&rpc_dir).unwrap();
-        write_request(
-            &rpc_dir.join("requests"),
-            "c2.json",
-            r#"{"id":"c2","op":"git_commit","args":{"message":"  "}}"#,
-        );
-
-        let dispatcher = dispatcher(&repo);
-        process_pending(&rpc_dir, &dispatcher).await;
-
-        let body = std::fs::read_to_string(rpc_dir.join("responses/c2.json")).unwrap();
-        let v: Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(v["ok"], false);
-        assert!(v["error"].as_str().unwrap().contains("message"));
-    }
-
     fn has_action_done(effects: &[RpcEvent], expect_op: &str) -> bool {
         effects.iter().any(|e| {
             let RpcEvent::Named { name, payload } = e;
@@ -633,32 +592,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn successful_mutating_op_emits_action_done() {
-        let td = tempfile::tempdir().unwrap();
-        let repo = td.path().join("repo");
-        std::fs::create_dir_all(&repo).unwrap();
-        run_git(&repo, &["init", "-q"]);
-        run_git(&repo, &["config", "user.email", "t@example.com"]);
-        run_git(&repo, &["config", "user.name", "Tester"]);
-        std::fs::write(repo.join("new.txt"), b"hello").unwrap();
-
-        let disp = dispatcher(&repo);
-        let (resp, effects) = disp
-            .dispatch_inner("c1", "git_commit", &json!({"message": "add new.txt"}))
-            .await;
-        assert!(resp.ok, "commit should succeed");
-        assert!(
-            has_action_done(&effects, "git_commit"),
-            "a successful git_commit must emit the action-done signal"
-        );
-    }
-
-    #[tokio::test]
     async fn read_only_and_failed_ops_emit_no_action_done() {
         let td = tempfile::tempdir().unwrap();
         let repo = td.path().join("repo");
         std::fs::create_dir_all(&repo).unwrap();
-        run_git(&repo, &["init", "-q"]);
+        run_git(&repo, &["init", "-q", "-b", "main"]);
+        run_git(&repo, &["config", "user.email", "t@example.com"]);
+        run_git(&repo, &["config", "user.name", "Tester"]);
+        std::fs::write(repo.join("a.txt"), b"x").unwrap();
+        run_git(&repo, &["add", "-A"]);
+        run_git(&repo, &["commit", "-q", "-m", "init"]);
         let disp = dispatcher(&repo);
 
         // Read-only op: never an action-done signal.
@@ -668,14 +611,13 @@ mod tests {
             "git_status is read-only and must not signal an action"
         );
 
-        // A failed mutating op (empty message) must NOT signal success.
-        let (resp, commit_fx) = disp
-            .dispatch_inner("c", "git_commit", &json!({"message": "   "}))
-            .await;
+        // A failed mutating op (push with no remote) must NOT signal success:
+        // `is_mutating_op` gates the emit on `resp.ok`.
+        let (resp, push_fx) = disp.dispatch_inner("p", "git_push", &Value::Null).await;
         assert!(!resp.ok);
         assert!(
-            !has_action_done(&commit_fx, "git_commit"),
-            "a failed git_commit must not signal an action"
+            !has_action_done(&push_fx, "git_push"),
+            "a failed git_push must not signal an action"
         );
     }
 }

--- a/src-tauri/src/sandbox/docker/image.rs
+++ b/src-tauri/src/sandbox/docker/image.rs
@@ -259,7 +259,9 @@ mod tests {
         let _ = cli::run_docker(&["rmi", "-f", &tag], Duration::from_secs(30));
 
         let lines = std::sync::atomic::AtomicUsize::new(0);
-        let progress = |_: &str| drop(lines.fetch_add(1, std::sync::atomic::Ordering::SeqCst));
+        let progress = |_: &str| {
+            lines.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        };
         ensure_image_with(dockerfile, ENTRYPOINT_SH, &tag, &progress).unwrap();
         assert!(
             image_exists(&tag).unwrap(),

--- a/src-tauri/src/sandbox/provision.rs
+++ b/src-tauri/src/sandbox/provision.rs
@@ -277,6 +277,7 @@ where
     let result = async {
         rewrite_origin(spec).await?;
         copy_local_identity(spec).await?;
+        install_delegation_hooks(spec.dest).await?;
         checkout(spec.dest.to_path_buf()).await
     }
     .await;
@@ -314,6 +315,78 @@ async fn rewrite_origin(spec: &CheckoutSpec<'_>) -> Result<()> {
         "remote set-url origin",
     )
     .await?;
+    Ok(())
+}
+
+/// Install Fletch's delegation-signal git hooks into the clone's `.git/hooks`.
+///
+/// With local git mutations (commit, merge, conflict-resolve) now running as
+/// native in-container git rather than host RPC ops, the old "a mutating RPC op
+/// succeeded" delegation signal is gone for those actions. These hooks restore
+/// it without teaching the agent anything: on the agent's own `git commit` /
+/// `git merge`, git runs the hook, which pings the RPC mailbox
+/// (`$FLETCH_RPC_DIR`, inherited from the triggering git process's env) so the
+/// host relays an `agent:git-action` event — exactly what the panel's
+/// delegation tracking consumes.
+///
+/// Contained by construction: host-side git (diff polling, push, PR, fetch)
+/// runs with `core.hooksPath=/dev/null` (`git::no_hooks_env`), so these hooks
+/// never fire on the host — only on the agent's sandboxed git, where any command
+/// they run is already inside the sandbox. The hook is best-effort and always
+/// exits 0, so a missing mailbox or a slow write can never fail the agent's
+/// commit. Installed only for clones (this is the clone-arm path); a linked
+/// worktree's hooks live in the user's real repo and must never be touched.
+async fn install_delegation_hooks(dest: &Path) -> Result<()> {
+    let hooks_dir = dest.join(".git/hooks");
+    // A fresh clone always has `.git/hooks`, but create it defensively so a
+    // future object-layout change can't silently drop the signal.
+    tokio::fs::create_dir_all(&hooks_dir).await?;
+    // post-commit fires on `git commit` (a plain commit, or the commit that
+    // completes a conflicted merge); post-merge fires on a clean `git merge`
+    // (fast-forward or merge commit). Between them they cover every native
+    // local mutation an agent playbook performs. The reported action name
+    // mirrors the legacy RPC op the frontend still maps to each delegation kind.
+    for (hook, action) in [
+        ("post-commit", "git_commit"),
+        ("post-merge", "git_update_branch"),
+    ] {
+        let path = hooks_dir.join(hook);
+        tokio::fs::write(&path, delegation_hook_script(action)).await?;
+        set_executable(&path).await?;
+    }
+    Ok(())
+}
+
+/// The body of a delegation hook reporting `action`. POSIX `sh`, no bashisms:
+/// runs in the container image's shell and macOS `/bin/sh` alike. Writes the
+/// mailbox request atomically (`.tmp` then `mv`) so the watcher never reads a
+/// half-written file, and swallows every error — the git op must not depend on
+/// the signal landing.
+fn delegation_hook_script(action: &str) -> String {
+    format!(
+        r#"#!/bin/sh
+# Fletch-managed: delegation signal. Pings the app RPC mailbox so the panel can
+# attribute this git action to the agent's turn. Best-effort; never blocks or
+# fails the git operation. Do not edit — reinstalled on provision.
+[ -n "$FLETCH_RPC_DIR" ] || exit 0
+reqdir="$FLETCH_RPC_DIR/requests"
+[ -d "$reqdir" ] || exit 0
+id="hook-$$-$(date +%s%N 2>/dev/null || date +%s)"
+tmp="$reqdir/$id.json.tmp"
+printf '{{"id":"%s","op":"signal_git_action","args":{{"action":"{action}"}}}}' "$id" > "$tmp" 2>/dev/null \
+  && mv "$tmp" "$reqdir/$id.json" 2>/dev/null
+exit 0
+"#
+    )
+}
+
+/// Mark a file user/group/other-executable (0755). The hooks must be executable
+/// or git silently ignores them.
+async fn set_executable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = tokio::fs::metadata(path).await?.permissions();
+    perms.set_mode(0o755);
+    tokio::fs::set_permissions(path, perms).await?;
     Ok(())
 }
 
@@ -514,6 +587,77 @@ mod tests {
         // The implicit local-path origin must be gone: a push from the clone
         // must never be able to write into the user's source repo.
         assert_eq!(run(&dest, &["remote"]), "");
+    }
+
+    #[tokio::test]
+    async fn clone_installs_executable_delegation_hooks() {
+        use std::os::unix::fs::PermissionsExt;
+        let td = tempfile::tempdir().unwrap();
+        let (repo, _first, head) = fixture_repo(td.path());
+        let dest = td.path().join("clone");
+        let spec = CheckoutSpec {
+            source_repo: &repo,
+            base_ref: &head,
+            dest: &dest,
+        };
+
+        provision(WorkspaceMode::Clone, &spec).await.unwrap();
+
+        for (hook, action) in [
+            ("post-commit", "git_commit"),
+            ("post-merge", "git_update_branch"),
+        ] {
+            let path = dest.join(".git/hooks").join(hook);
+            let body = std::fs::read_to_string(&path).unwrap_or_else(|_| panic!("{hook} missing"));
+            assert!(body.contains("signal_git_action"), "{hook} must ping the signal op");
+            assert!(
+                body.contains(&format!(r#""action":"{action}""#)),
+                "{hook} must report {action}"
+            );
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+            assert!(mode & 0o111 != 0, "{hook} must be executable, mode={mode:o}");
+        }
+    }
+
+    #[tokio::test]
+    async fn delegation_hook_fires_on_a_native_commit() {
+        // End-to-end: a plain in-repo `git commit` runs the installed hook,
+        // which writes a well-formed signal request into the mailbox dir.
+        let td = tempfile::tempdir().unwrap();
+        let (repo, _first, head) = fixture_repo(td.path());
+        let dest = td.path().join("clone");
+        let spec = CheckoutSpec {
+            source_repo: &repo,
+            base_ref: &head,
+            dest: &dest,
+        };
+        provision(WorkspaceMode::Clone, &spec).await.unwrap();
+        // Land on a branch so a commit is straightforward.
+        run(&dest, &["checkout", "-q", "-b", "work"]);
+
+        let mailbox = td.path().join("mbox");
+        let requests = mailbox.join("requests");
+        std::fs::create_dir_all(&requests).unwrap();
+        std::fs::write(dest.join("c.txt"), b"change").unwrap();
+        run(&dest, &["add", "-A"]);
+        // The hook reads $FLETCH_RPC_DIR from the committing process's env.
+        let out = std::process::Command::new("git")
+            .current_dir(&dest)
+            .env("FLETCH_RPC_DIR", &mailbox)
+            .args(["commit", "-q", "-m", "hooked"])
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "{}", String::from_utf8_lossy(&out.stderr));
+
+        let entries: Vec<_> = std::fs::read_dir(&requests)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+            .collect();
+        assert_eq!(entries.len(), 1, "exactly one signal request expected");
+        let body = std::fs::read_to_string(entries[0].path()).unwrap();
+        assert!(body.contains(r#""op":"signal_git_action""#), "body: {body}");
+        assert!(body.contains(r#""action":"git_commit""#), "body: {body}");
     }
 
     #[tokio::test]

--- a/src-tauri/src/sandbox/provision.rs
+++ b/src-tauri/src/sandbox/provision.rs
@@ -276,7 +276,7 @@ where
 {
     let result = async {
         rewrite_origin(spec).await?;
-        copy_local_identity(spec).await?;
+        seed_identity(spec).await?;
         install_delegation_hooks(spec.dest).await?;
         checkout(spec.dest.to_path_buf()).await
     }
@@ -390,26 +390,32 @@ async fn set_executable(path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Copy repo-local `user.name` / `user.email` into the clone. Global
-/// gitconfig already applies host-side; only per-repo identity would
-/// otherwise be lost (clones don't inherit the source's local config).
-async fn copy_local_identity(spec: &CheckoutSpec<'_>) -> Result<()> {
-    for key in ["user.name", "user.email"] {
-        // Exits 1 when unset — not an error, just nothing to copy.
-        let out = git::git_output(spec.source_repo, &["config", "--local", "--get", key]).await?;
-        if !out.status.success() {
-            continue;
-        }
-        let value = String::from_utf8_lossy(&out.stdout).trim().to_string();
-        if value.is_empty() {
-            continue;
-        }
-        git::run_git(
-            spec.dest,
-            &["config", key, &value],
-            &format!("config {key}"),
-        )
-        .await?;
+/// Seed the clone with a git identity it can commit under **without** the
+/// host's global gitconfig. A container can't see that file, so with local git
+/// mutations now running as native in-container `git commit`, a clone that
+/// inherited its identity only from the host's global config would die with
+/// git's "Please tell me who you are" — the retired host-side commit path used
+/// to paper over this via `git::identity_env`.
+///
+/// Write the *effective* identity the source repo resolves (`--get`, i.e.
+/// local ▸ global ▸ system — exactly what the host itself would author with)
+/// into the clone's own config, and fill any half the host can't resolve from
+/// the signed-in profile / neutral default. This is the same fallback
+/// `git::identity_env` applied, but persisted into the clone so in-container
+/// git sees it. Clones are ephemeral, so freezing the value here is harmless.
+async fn seed_identity(spec: &CheckoutSpec<'_>) -> Result<()> {
+    let (fallback_name, fallback_email) = crate::git_dist::fallback_identity();
+    for (key, fallback) in [("user.name", fallback_name), ("user.email", fallback_email)] {
+        // `--get` (no `--local`) is the effective value across every scope;
+        // empty or exit-1 means the host resolves nothing, so fall back.
+        let effective = git::git_output(spec.source_repo, &["config", "--get", key])
+            .await
+            .ok()
+            .filter(|out| out.status.success())
+            .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
+            .filter(|v| !v.is_empty());
+        let value = effective.unwrap_or(fallback);
+        git::run_git(spec.dest, &["config", key, &value], &format!("config {key}")).await?;
     }
     Ok(())
 }
@@ -677,6 +683,32 @@ mod tests {
             run(&dest, &["config", "--local", "user.email"]),
             "t@example.com"
         );
+    }
+
+    #[tokio::test]
+    async fn clone_seeds_identity_when_source_resolves_none_locally() {
+        let td = tempfile::tempdir().unwrap();
+        let (repo, _first, head) = fixture_repo(td.path());
+        // Drop the repo-local identity the fixture set: the source now resolves
+        // an identity only from ambient global/system config, or nothing —
+        // exactly the reviewer's "identity lives only in host global config,
+        // which the container can't see" case.
+        run(&repo, &["config", "--local", "--unset", "user.name"]);
+        run(&repo, &["config", "--local", "--unset", "user.email"]);
+        let dest = td.path().join("clone");
+        let spec = CheckoutSpec {
+            source_repo: &repo,
+            base_ref: &head,
+            dest: &dest,
+        };
+
+        provision(WorkspaceMode::Clone, &spec).await.unwrap();
+
+        // Whatever the host's ambient config, the clone must resolve a non-empty
+        // identity in its OWN config so a native in-container `git commit` never
+        // dies with "Please tell me who you are".
+        assert!(!run(&dest, &["config", "--local", "user.name"]).is_empty());
+        assert!(!run(&dest, &["config", "--local", "user.email"]).is_empty());
     }
 
     #[tokio::test]

--- a/src-tauri/src/sandbox/provision.rs
+++ b/src-tauri/src/sandbox/provision.rs
@@ -341,28 +341,37 @@ async fn install_delegation_hooks(dest: &Path) -> Result<()> {
     // A fresh clone always has `.git/hooks`, but create it defensively so a
     // future object-layout change can't silently drop the signal.
     tokio::fs::create_dir_all(&hooks_dir).await?;
-    // post-commit fires on `git commit` (a plain commit, or the commit that
-    // completes a conflicted merge); post-merge fires on a clean `git merge`
-    // (fast-forward or merge commit). Between them they cover every native
-    // local mutation an agent playbook performs. The reported action name
-    // mirrors the legacy RPC op the frontend still maps to each delegation kind.
-    for (hook, action) in [
-        ("post-commit", "git_commit"),
-        ("post-merge", "git_update_branch"),
-    ] {
-        let path = hooks_dir.join(hook);
-        tokio::fs::write(&path, delegation_hook_script(action)).await?;
-        set_executable(&path).await?;
-    }
+    // post-merge fires on a completed clean `git merge` (fast-forward or merge
+    // commit): the action is unambiguously a base merge.
+    let post_merge = hooks_dir.join("post-merge");
+    tokio::fs::write(&post_merge, delegation_hook_script(r#"action="git_update_branch""#)).await?;
+    set_executable(&post_merge).await?;
+    // post-commit fires on *every* plain `git commit` — including the commit
+    // that completes a *conflicted* merge, which never reaches post-merge. Those
+    // two cases must report different actions or an unrelated commit made during
+    // an `update-branch` delegation would falsely satisfy it. A merge-completion
+    // commit is a merge commit (it has a second parent, `HEAD^2`); a plain commit
+    // does not — so branch on that.
+    let post_commit = hooks_dir.join("post-commit");
+    let set_action = concat!(
+        "if git rev-parse -q --verify HEAD^2 >/dev/null 2>&1; then\n",
+        "  action=\"git_update_branch\"\n",
+        "else\n",
+        "  action=\"git_commit\"\n",
+        "fi",
+    );
+    tokio::fs::write(&post_commit, delegation_hook_script(set_action)).await?;
+    set_executable(&post_commit).await?;
     Ok(())
 }
 
-/// The body of a delegation hook reporting `action`. POSIX `sh`, no bashisms:
-/// runs in the container image's shell and macOS `/bin/sh` alike. Writes the
-/// mailbox request atomically (`.tmp` then `mv`) so the watcher never reads a
-/// half-written file, and swallows every error — the git op must not depend on
-/// the signal landing.
-fn delegation_hook_script(action: &str) -> String {
+/// The body of a delegation hook. `set_action` is a shell fragment that assigns
+/// the reported op to `$action` (a literal for post-merge, a merge-commit test
+/// for post-commit). POSIX `sh`, no bashisms: runs in the container image's
+/// shell and macOS `/bin/sh` alike. Writes the mailbox request atomically
+/// (`.tmp` then `mv`) so the watcher never reads a half-written file, and
+/// swallows every error — the git op must not depend on the signal landing.
+fn delegation_hook_script(set_action: &str) -> String {
     format!(
         r#"#!/bin/sh
 # Fletch-managed: delegation signal. Pings the app RPC mailbox so the panel can
@@ -371,9 +380,10 @@ fn delegation_hook_script(action: &str) -> String {
 [ -n "$FLETCH_RPC_DIR" ] || exit 0
 reqdir="$FLETCH_RPC_DIR/requests"
 [ -d "$reqdir" ] || exit 0
+{set_action}
 id="hook-$$-$(date +%s%N 2>/dev/null || date +%s)"
 tmp="$reqdir/$id.json.tmp"
-printf '{{"id":"%s","op":"signal_git_action","args":{{"action":"{action}"}}}}' "$id" > "$tmp" 2>/dev/null \
+printf '{{"id":"%s","op":"signal_git_action","args":{{"action":"%s"}}}}' "$id" "$action" > "$tmp" 2>/dev/null \
   && mv "$tmp" "$reqdir/$id.json" 2>/dev/null
 exit 0
 "#
@@ -609,20 +619,75 @@ mod tests {
 
         provision(WorkspaceMode::Clone, &spec).await.unwrap();
 
-        for (hook, action) in [
-            ("post-commit", "git_commit"),
-            ("post-merge", "git_update_branch"),
-        ] {
+        for hook in ["post-commit", "post-merge"] {
             let path = dest.join(".git/hooks").join(hook);
             let body = std::fs::read_to_string(&path).unwrap_or_else(|_| panic!("{hook} missing"));
             assert!(body.contains("signal_git_action"), "{hook} must ping the signal op");
-            assert!(
-                body.contains(&format!(r#""action":"{action}""#)),
-                "{hook} must report {action}"
-            );
             let mode = std::fs::metadata(&path).unwrap().permissions().mode();
             assert!(mode & 0o111 != 0, "{hook} must be executable, mode={mode:o}");
         }
+        // post-merge always reports a base merge; post-commit distinguishes a
+        // merge-completion commit (HEAD^2) from a plain one.
+        let post_merge = std::fs::read_to_string(dest.join(".git/hooks/post-merge")).unwrap();
+        assert!(post_merge.contains(r#"action="git_update_branch""#));
+        let post_commit = std::fs::read_to_string(dest.join(".git/hooks/post-commit")).unwrap();
+        assert!(post_commit.contains("HEAD^2"), "post-commit must test for a merge commit");
+        assert!(post_commit.contains(r#"action="git_update_branch""#));
+        assert!(post_commit.contains(r#"action="git_commit""#));
+    }
+
+    #[tokio::test]
+    async fn post_commit_hook_reports_merge_commit_as_update_branch() {
+        // The conflicted-merge path of `update-branch`: the completing commit is
+        // a merge commit (two parents), so post-commit must report a base merge
+        // rather than a plain commit — otherwise the delegation couldn't tell it
+        // apart from an unrelated commit.
+        let td = tempfile::tempdir().unwrap();
+        let (repo, _first, head) = fixture_repo(td.path());
+        let dest = td.path().join("clone");
+        let spec = CheckoutSpec {
+            source_repo: &repo,
+            base_ref: &head,
+            dest: &dest,
+        };
+        provision(WorkspaceMode::Clone, &spec).await.unwrap();
+
+        // Two branches that diverge on different files → a clean but non-ff
+        // merge. `--no-commit` stops before committing (so post-merge does not
+        // fire), leaving the merge for a manual `git commit` that post-commit
+        // sees as a two-parent merge commit.
+        run(&dest, &["checkout", "-q", "-b", "target"]);
+        std::fs::write(dest.join("t.txt"), b"t").unwrap();
+        run(&dest, &["add", "-A"]);
+        run(&dest, &["commit", "-q", "-m", "target edit"]);
+        run(&dest, &["checkout", "-q", "-b", "side", "HEAD~1"]);
+        std::fs::write(dest.join("s.txt"), b"s").unwrap();
+        run(&dest, &["add", "-A"]);
+        run(&dest, &["commit", "-q", "-m", "side edit"]);
+        run(&dest, &["checkout", "-q", "target"]);
+        run(&dest, &["merge", "--no-ff", "--no-commit", "side"]);
+
+        let mailbox = td.path().join("mbox");
+        std::fs::create_dir_all(mailbox.join("requests")).unwrap();
+        let out = std::process::Command::new("git")
+            .current_dir(&dest)
+            .env("FLETCH_RPC_DIR", &mailbox)
+            .args(["commit", "--no-edit"])
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "{}", String::from_utf8_lossy(&out.stderr));
+
+        let reqs: Vec<_> = std::fs::read_dir(mailbox.join("requests"))
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+            .collect();
+        assert_eq!(reqs.len(), 1, "exactly one signal expected");
+        let body = std::fs::read_to_string(reqs[0].path()).unwrap();
+        assert!(
+            body.contains(r#""action":"git_update_branch""#),
+            "a merge-completion commit must report a base merge, body: {body}"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/sandbox/provision.rs
+++ b/src-tauri/src/sandbox/provision.rs
@@ -46,23 +46,6 @@ pub enum WorkspaceMode {
     Clone,
 }
 
-impl WorkspaceMode {
-    /// Parse the `workspace_mode` setting. Anything other than an explicit
-    /// `"clone"` — including absent or unrecognized values — falls back to
-    /// `Worktree`, the historical default, so a typo'd dev flag can't change
-    /// behavior silently on top of a warning.
-    pub fn from_setting(value: Option<&str>) -> Self {
-        match value {
-            Some("clone") => WorkspaceMode::Clone,
-            Some("worktree") | None => WorkspaceMode::Worktree,
-            Some(other) => {
-                tracing::warn!(value = %other, "unrecognized workspace_mode setting; using worktree");
-                WorkspaceMode::Worktree
-            }
-        }
-    }
-}
-
 /// What to check out where. `base_ref` is any commit-ish; pass `"HEAD"` for
 /// "the source repo's current HEAD" (the legacy no-base behavior).
 pub struct CheckoutSpec<'a> {
@@ -498,23 +481,6 @@ mod tests {
         run(&repo, &["commit", "-q", "-m", "second"]);
         let head = run(&repo, &["rev-parse", "HEAD"]);
         (repo, first, head)
-    }
-
-    #[test]
-    fn mode_parses_setting_with_worktree_default() {
-        assert_eq!(WorkspaceMode::from_setting(None), WorkspaceMode::Worktree);
-        assert_eq!(
-            WorkspaceMode::from_setting(Some("worktree")),
-            WorkspaceMode::Worktree
-        );
-        assert_eq!(
-            WorkspaceMode::from_setting(Some("clone")),
-            WorkspaceMode::Clone
-        );
-        assert_eq!(
-            WorkspaceMode::from_setting(Some("docker?!")),
-            WorkspaceMode::Worktree
-        );
     }
 
     #[tokio::test]

--- a/src/components/RightPanel/delegation.ts
+++ b/src/components/RightPanel/delegation.ts
@@ -2,8 +2,11 @@ import type { AgentStatus, GitState, PrChecks, PrState } from "@/api";
 
 /** One agent-delegated git action: the user clicked a panel action whose
  *  judgment part (message, description, conflict edits) belongs to the
- *  coding agent; the agent executes the mutation through the app's file
- *  RPC (`git_commit` / `open_pr` / `git_update_branch` / `git_push`). */
+ *  coding agent. The agent runs local mutations (commit, merge, conflict
+ *  resolution) as plain in-sandbox git, and the credentialed remote actions
+ *  through the app's file RPC (`open_pr` / `git_push` / `git_fetch`). The
+ *  `agent:git-action` signal that confirms a local mutation arrives via the
+ *  clone's `post-commit` / `post-merge` hooks (see `gitActionProvesKind`). */
 export type GitDelegationKind =
   | "commit"
   | "commit-push"
@@ -105,7 +108,11 @@ export function gitActionProvesKind(kind: GitDelegationKind, op: string): boolea
     case "push":
       return op === "git_push";
     case "update-branch":
-      return op === "git_update_branch";
+      // A clean merge fires the clone's post-merge hook (`git_update_branch`);
+      // a conflicted merge is completed by a native `git commit`, firing
+      // post-commit (`git_commit`). Accept either — resolution still ANDs this
+      // with the merge-state snapshot, so listing both ops is safe.
+      return op === "git_update_branch" || op === "git_commit";
   }
 }
 

--- a/src/components/RightPanel/delegation.ts
+++ b/src/components/RightPanel/delegation.ts
@@ -96,8 +96,13 @@ export function delegationStep(
 export function gitActionProvesKind(kind: GitDelegationKind, op: string): boolean {
   switch (kind) {
     case "commit":
-    case "resolve":
       return op === "git_commit";
+    case "resolve":
+      // Completing a conflicted merge yields a merge commit, which post-commit
+      // reports as `git_update_branch`; a rebase/cherry-pick resolution is a
+      // plain commit (`git_commit`). Accept either — the snapshot (no conflicts
+      // left) gates actual completion.
+      return op === "git_commit" || op === "git_update_branch";
     case "commit-push":
     case "fix-checks":
       return op === "git_commit" || op === "git_push";
@@ -108,11 +113,12 @@ export function gitActionProvesKind(kind: GitDelegationKind, op: string): boolea
     case "push":
       return op === "git_push";
     case "update-branch":
-      // A clean merge fires the clone's post-merge hook (`git_update_branch`);
-      // a conflicted merge is completed by a native `git commit`, firing
-      // post-commit (`git_commit`). Accept either — resolution still ANDs this
-      // with the merge-state snapshot, so listing both ops is safe.
-      return op === "git_update_branch" || op === "git_commit";
+      // Proven only by an actual base merge: a clean merge fires the clone's
+      // post-merge hook, and a conflicted merge's completing commit is a merge
+      // commit that post-commit also reports as `git_update_branch`. A plain
+      // `git commit` reports `git_commit`, so an unrelated commit made during
+      // this delegation can't stand in for the merge.
+      return op === "git_update_branch";
   }
 }
 


### PR DESCRIPTION
## What & why

The RPC git layer is a bespoke protocol the agent has to be taught in prose (hand-assembling mailbox JSON, polling for responses). Under the clone workspace model — now the universal default for **both** Docker and seatbelt on `sandboxing` (`effective_workspace_mode`) — the workspace already has a real, writable `.git`, so `git commit`/`merge`/conflict-resolve work natively. The only things that genuinely need the host are (1) the GitHub credentials (must stay off the container) and (2) the delegation signal. Everything else was friction.

This slice moves local git to native and keeps only the credentialed remote actions host-side.

## Changes

**`GitDispatcher` (`rpc/git.rs`)**
- Removed `git_commit` and `git_update_branch` ops (and their `is_mutating_op` / dispatch entries). Commit and merge are native git now.
- Retained `git_push` and `open_pr` host-side — the **documented v1 fallback** for push: the token stays on the host, framed in the instructions as "the one action Fletch runs for you", not "git is blocked". (The credential broker remains the eventual target.)
- Added **`git_fetch`**: a host-side, credentialed `fetch origin <ref>` so the agent's native `git merge origin/<base>` in `update-branch` works against a **private** remote without the token entering the sandbox. `ref` is validated against option-like injection.
- Added **`signal_git_action`**: relays a native-git delegation signal (closed action set) into the existing `EVENT_ACTION_DONE` → `agent:git-action` pipeline.

**Delegation signal without agent cooperation (`sandbox/provision.rs`)**
- Provisioning installs executable `post-commit` / `post-merge` hooks into the **clone** that ping the RPC mailbox (`$FLETCH_RPC_DIR`, inherited from the committing git process). Host-side git runs with `core.hooksPath=/dev/null` (`git::no_hooks_env`), so these fire **only** on the agent's sandboxed git — contained by construction. Best-effort, always `exit 0`, so they never fail a commit. Installed on the clone path only (a linked worktree's hooks live in the user's real repo and must never be touched).

**Instructions**
- `git_actions.md`: playbooks rewritten to run plain git for commit/merge/resolve, and the RPC ops only for push/PR/fetch. Removed the false "raw git … blocked by your sandbox" claim. `[app-action]` trigger names unchanged.
- `rpc_protocol.md`: closing paragraph trimmed to the remaining real git ops.

**Frontend (`delegation.ts`)**
- `gitActionProvesKind("update-branch", …)` now accepts `git_commit` too: a clean merge fires post-merge (`git_update_branch`), a conflicted one is completed by a native commit firing post-commit (`git_commit`). Still ANDed with the merge-state snapshot.

## Prerequisites — verified
- **Hook neutralization on host-side git**: `commit_all`, `push`, `git_update_branch`'s old merge, and `worktree_add` all apply `no_hooks_env()`. ✅
- **Self-contained writable clone**: `provision.rs` Clone mode; Docker forces it, seatbelt defaults to it. ✅

## Known limitation (documented, not a regression of a supported path)
The legacy, non-UI `workspace_mode=worktree` opt-out under seatbelt writes commits into the source repo's `.git`, which the agent seatbelt profile (`build_profile`) does **not** grant — so native commit/merge don't work there and this mode loses agent-driven local git. It remains usable for its restore-testing purpose. The forward/default path (Clone) is unaffected.

## Acceptance criteria
- Native `git add`/`commit`/`merge`/resolve in-container; agent no longer told git is "blocked". ✅ (instructions + tests)
- `git push` works without the token in the container — retained as a host RPC (documented fallback); no token enters the sandbox. ✅
- `open_pr` unchanged; UI still gets the PR number. ✅
- Delegation lights up on agent commits (post-commit hook), merges (post-merge hook), pushes/PRs (retained RPC). ✅
- Removed ops gone from `GitDispatcher` / `is_mutating_op` / instructions; `instructions.rs` tests green. ✅
- `cargo test --manifest-path src-tauri/Cargo.toml` → **447 passed**. ✅

## Notes
- The frontend `delegation.ts` change is a type-trivial boolean-OR extension inside an already-exhaustive switch; `node_modules` isn't installed in this environment so `tsc` wasn't run, but the change cannot introduce a type error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)