### PR TITLE
refactor(sandbox): remove iteration leftovers and stale slice comments

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -49,8 +49,8 @@ pub fn reveal_logs() -> Result<()> {
 }
 
 /// Launch Docker Desktop — the "Start Docker Desktop" action on a docker
-/// agent's daemon-down error state (slice C2). macOS-only, like the rest of the
-/// sandbox feature (`open -a Docker`); other platforms error so the UI can
+/// agent's daemon-down error state. macOS-only, like the rest of the sandbox
+/// feature (`open -a Docker`); other platforms error so the UI can
 /// report it rather than silently no-op. The daemon then takes a few seconds to
 /// answer, which the settings pane's probe-retry loop already covers.
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -793,7 +793,7 @@ pub fn run() {
                 }));
             }
 
-            // Forward docker image-build progress to the UI (slice C2). The
+            // Forward docker image-build progress to the UI. The
             // build runs deep in the spawn path (no AppHandle there), so it
             // emits through a process-wide sink installed here — mirroring the
             // git-dist emitter above. Rare (first docker spawn per image), so a

--- a/src-tauri/src/rpc.rs
+++ b/src-tauri/src/rpc.rs
@@ -624,10 +624,10 @@ mod tests {
         assert!(!rpc_dir.join("responses/req-5.json").exists());
     }
 
-    /// B3 acceptance: with no FS-event mechanism anywhere (this transport has
-    /// none — the watcher is a bare interval tick), a dropped request file is
-    /// answered within 1s by the poll path alone. The tick here mirrors the
-    /// spec's 500ms fallback; production polls even faster (`RPC_TICK`).
+    /// With no FS-event mechanism anywhere (this transport has none — the
+    /// watcher is a bare interval tick), a dropped request file is answered
+    /// within 1s by the poll path alone. The tick here mirrors the 500ms
+    /// fallback; production polls even faster (`RPC_TICK`).
     #[tokio::test]
     async fn poll_tick_answers_request_within_a_second_without_fs_events() {
         let td = tempfile::tempdir().unwrap();

--- a/src-tauri/src/sandbox/docker/auth.rs
+++ b/src-tauri/src/sandbox/docker/auth.rs
@@ -1,10 +1,10 @@
-//! Anthropic auth for containerized agents (slice D1).
+//! Anthropic auth for containerized agents.
 //!
 //! Host claude logins usually live in the macOS Keychain, which doesn't exist
 //! inside a container, and Fletch itself injects no credentials — so docker
 //! agents need auth resolved explicitly. [`resolve`] walks a first-hit-wins
 //! chain and returns the env vars to set on the *docker CLI process*; the
-//! launch path (B2) forwards them with bare `-e VAR` flags, so token values
+//! launch path forwards them with bare `-e VAR` flags, so token values
 //! never appear in argv (invariant 3). They must never appear in logs either:
 //! [`ContainerAuth`] redacts values in its `Debug` output, and nothing in this
 //! module traces a token.
@@ -306,7 +306,7 @@ fn resolve_from(
 
 /// Wire shape of the `get_container_auth_status` command — [`resolve`]'s
 /// outcome for the settings status row. Serializes like `DockerAvailability`:
-/// `{ "status": "stored-token" | "shell-env" | "credentials-file" | "none" }`.
+/// `{ "status": "keychain" | "stored-token" | "shell-env" | "credentials-file" | "none" }`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(tag = "status", rename_all = "kebab-case")]
 pub enum ContainerAuthStatus {

--- a/src-tauri/src/sandbox/docker/cleanup.rs
+++ b/src-tauri/src/sandbox/docker/cleanup.rs
@@ -1,9 +1,8 @@
 //! Container labels and the dead-instance orphan sweep.
 //!
-//! Invariant 4 of the sandbox plan: no orphaned containers. Every container
-//! Fletch launches carries `fletch.host-pid=<pid>` (which app instance owns
-//! it) and `fletch.agent-id=<id>` (which agent it runs). If the app dies
-//! without cleanup — crash, force-quit, SIGKILL — its containers keep
+//! Every container Fletch launches carries `fletch.host-pid=<pid>` (which app
+//! instance owns it) and `fletch.agent-id=<id>` (which agent it runs). If the
+//! app dies without cleanup — crash, force-quit, SIGKILL — its containers keep
 //! running; the next startup sweeps them by the same pid-liveness rule the
 //! nested-root sweeps use (`sandbox/seatbelt.rs`): remove only containers
 //! whose owning pid is gone, never a live side-by-side instance's.
@@ -19,17 +18,14 @@ pub const HOST_PID_LABEL: &str = "fletch.host-pid";
 
 /// Label carrying the agent id a container runs (attribution/debugging; the
 /// sweep keys on [`HOST_PID_LABEL`] alone).
-#[allow(dead_code)] // slice B2 stamps it on `docker run`
 pub const AGENT_ID_LABEL: &str = "fletch.agent-id";
 
-/// `fletch.host-pid=<our pid>` — the value B2 passes to `docker run --label`.
-#[allow(dead_code)] // slice B2 is the consumer
+/// `fletch.host-pid=<our pid>` — the `--label` value stamped on `docker run`.
 pub fn host_pid_label() -> String {
     format!("{HOST_PID_LABEL}={}", std::process::id())
 }
 
-/// `fletch.agent-id=<agent_id>` — sibling of [`host_pid_label`] for B2's argv.
-#[allow(dead_code)] // slice B2 is the consumer
+/// `fletch.agent-id=<agent_id>` — sibling of [`host_pid_label`].
 pub fn agent_id_label(agent_id: &str) -> String {
     format!("{AGENT_ID_LABEL}={agent_id}")
 }

--- a/src-tauri/src/sandbox/docker/cli.rs
+++ b/src-tauri/src/sandbox/docker/cli.rs
@@ -42,9 +42,8 @@ pub(super) fn run_docker(args: &[&str], timeout: Duration) -> Result<Output> {
 
 /// Run `docker <args>` streaming every output line (stdout and stderr) to
 /// `on_line` as it appears — the shape `docker build` needs so image-build
-/// progress can reach the UI (slice C2). Fails on non-zero exit with the
-/// last output lines in the message, or on `timeout` expiry.
-#[allow(dead_code)] // reached via `image`, whose consumer is slice B2
+/// progress can reach the UI. Fails on non-zero exit with the last output
+/// lines in the message, or on `timeout` expiry.
 pub(super) fn run_docker_streaming(
     args: &[&str],
     timeout: Duration,
@@ -89,7 +88,6 @@ pub(super) fn run_docker_streaming(
 
 /// Forward each line of `reader` to `on_line`, retaining a bounded tail for
 /// error reporting.
-#[allow(dead_code)] // reached via `image`, whose consumer is slice B2
 fn forward_lines(
     reader: impl std::io::Read,
     on_line: &(dyn Fn(&str) + Send + Sync),

--- a/src-tauri/src/sandbox/docker/engine.rs
+++ b/src-tauri/src/sandbox/docker/engine.rs
@@ -1,9 +1,8 @@
 //! The Docker sandbox engine: one container per agent process, agent ≈ PID 1.
 //!
-//! Launch shape (fixed in the sandbox plan, slice B2): every agent process is
-//! its own `docker run --rm --init` — no long-lived container + `docker exec`,
-//! whose kill/exit-code semantics are broken. The plan invariants this file
-//! carries:
+//! Launch shape: every agent process is its own `docker run --rm --init` — no
+//! long-lived container + `docker exec`, whose kill/exit-code semantics are
+//! broken. The invariants this file carries:
 //!
 //! - **Path identity (invariant 1).** The three mounts — the agent's writable
 //!   root, its RPC mailbox, and `~/.claude` — are bind-mounted at their exact
@@ -136,8 +135,8 @@ const TERM_GRACE: Duration = Duration::from_millis(500);
 
 /// Launch knobs read from the `settings` table, mirrored in-process (the spawn
 /// path has no DB handle — same pattern as `sandbox::set_selected_engine_kind`).
-/// Seeded at startup in `lib.rs setup`; slice C2 adds the settings UI whose
-/// set-commands will keep the mirror in sync mid-run.
+/// Seeded at startup in `lib.rs setup` and kept in sync by the settings
+/// set-commands.
 #[derive(Clone, Default)]
 pub struct LaunchSettings {
     /// `docker_image` — a non-empty value is used verbatim, skipping the
@@ -194,7 +193,8 @@ impl DockerEngine {
                 return Ok(tag.clone());
             }
         }
-        // Build progress goes to the log until slice C2 wires it to UI events.
+        // Per-line build output goes to the log; the UI build toast is driven
+        // separately by the `progress` sink inside `image::ensure_image`.
         let on_progress = |line: &str| tracing::info!(target: "fletch::docker_build", "{line}");
         let tag = image::resolve_image(override_image, &on_progress)
             .map_err(|e| Error::Other(format!("preparing the Docker sandbox image failed: {e}")))?;
@@ -320,9 +320,7 @@ impl SandboxEngine for DockerEngine {
     /// exit), and an error here would abort the caller's local process-group
     /// teardown of the docker CLI child.
     fn kill(&self, plan: &KillPlan) -> Result<()> {
-        let KillPlan::Container { name } = plan else {
-            return Ok(());
-        };
+        let KillPlan::Container { name } = plan;
         match cli::run_docker(&["kill", "-s", "TERM", name], KILL_TIMEOUT) {
             Ok(out) if out.status.success() => {
                 if !container_gone_within(name, TERM_GRACE) {
@@ -340,26 +338,14 @@ impl SandboxEngine for DockerEngine {
         Ok(())
     }
 
-    /// Containers die independently of the host (daemon stop, OOM kill), so
-    /// liveness asks the daemon rather than the local CLI child. Any failure
-    /// to answer — container gone, daemon down, timeout — reads as dead: the
-    /// user's remedy is the same, and this is the health surface the UI polls
-    /// (slice C2).
-    fn is_alive(&self, plan: &KillPlan) -> bool {
-        let KillPlan::Container { name } = plan else {
-            return true;
-        };
-        container_running(name)
-    }
-
     fn describe_exit(&self, _plan: &KillPlan, code: i32) -> Option<String> {
         describe_exit_code(code)
     }
 }
 
-/// Launch-blocking message when the container auth chain (D1) resolves nothing.
-/// Kept as one stable, matchable string so slice C2 can turn it into a Settings
-/// call-to-action; the wording tells the user exactly what to do.
+/// Launch-blocking message when the container auth chain resolves nothing.
+/// Kept as one stable, matchable string the frontend keys its Settings
+/// call-to-action on; the wording tells the user exactly what to do.
 const NO_CONTAINER_AUTH_MSG: &str = "No Anthropic credentials for containers — open Settings → General → Sandbox and connect Claude for containers (claude setup-token).";
 
 /// Fold the D1 auth-chain outcome ([`auth::resolve`]) into the docker CLI's
@@ -1313,7 +1299,7 @@ mod tests {
         );
     }
 
-    /// Integration: kill/is_alive against a live container.
+    /// Integration: kill and liveness against a live container.
     /// `FLETCH_DOCKER_TESTS=1 cargo test -- --ignored`
     #[test]
     #[ignore = "requires Docker; opt in via FLETCH_DOCKER_TESTS=1"]
@@ -1337,8 +1323,8 @@ mod tests {
 
         let engine = DockerEngine::shared();
         let plan = KillPlan::Container { name: name.clone() };
-        assert!(engine.is_alive(&plan), "fresh container should be running");
+        assert!(container_running(&name), "fresh container should be running");
         engine.kill(&plan).unwrap();
-        assert!(!engine.is_alive(&plan), "killed container reads as dead");
+        assert!(!container_running(&name), "killed container reads as dead");
     }
 }

--- a/src-tauri/src/sandbox/docker/image.rs
+++ b/src-tauri/src/sandbox/docker/image.rs
@@ -19,9 +19,8 @@ use crate::error::Result;
 use super::cli;
 use super::progress::{self, BuildEvent};
 
-/// Progress sink for image builds: called once per docker output line.
-/// Slice C2 wires this to UI events; until then callers pass `&|_| {}` or a
-/// tracing forwarder.
+/// Progress sink for image builds: called once per docker output line. Callers
+/// pass a tracing forwarder to log build output, or `&|_| {}` to ignore it.
 pub type Progress<'a> = &'a (dyn Fn(&str) + Send + Sync);
 
 /// The agent container image. Debian-slim keeps apt available for the tools
@@ -43,9 +42,8 @@ ENTRYPOINT ["/entrypoint.sh"]
 /// PID-1 shim. The container gets `HOME=<host home>` (a path that does not
 /// exist in the image), so the entrypoint creates it and seeds the minimal
 /// `~/.claude.json` claude needs to skip interactive onboarding. Seeding is
-/// conditional and the file is container-ephemeral by design — see slice B2:
-/// bind-mounting the real `~/.claude.json` would break on claude's atomic
-/// rename-replace writes.
+/// conditional and the file is container-ephemeral by design: bind-mounting the
+/// real `~/.claude.json` would break on claude's atomic rename-replace writes.
 pub const ENTRYPOINT_SH: &str = r#"#!/bin/sh
 set -e
 mkdir -p "$HOME"
@@ -145,11 +143,11 @@ fn ensure_image_with(
 
     let args = build_args(tag, ctx.path());
     let args: Vec<&str> = args.iter().map(String::as_str).collect();
-    // Broadcast the build lifecycle to the UI (slice C2). `Started`/`Finished`/
-    // `Failed` fire only here, where a build actually runs (a cached image
-    // returns above without emitting), so the toast appears only for real
-    // builds. Each output line is forwarded alongside the caller's own sink so
-    // the tracing forwarder / test counter keep working unchanged.
+    // Broadcast the build lifecycle to the UI. `Started`/`Finished`/`Failed`
+    // fire only here, where a build actually runs (a cached image returns above
+    // without emitting), so the toast appears only for real builds. Each output
+    // line is forwarded alongside the caller's own sink so the tracing
+    // forwarder / test counter keep working unchanged.
     progress::emit(BuildEvent::Started);
     let forward = |line: &str| {
         on_progress(line);

--- a/src-tauri/src/sandbox/docker/mod.rs
+++ b/src-tauri/src/sandbox/docker/mod.rs
@@ -26,24 +26,11 @@ mod image;
 mod probe;
 mod progress;
 
-// Label plumbing for slice C2's surfacing needs; unused until then.
-#[allow(unused_imports)]
-pub use cleanup::{agent_id_label, host_pid_label, sweep_orphans, AGENT_ID_LABEL, HOST_PID_LABEL};
 pub use engine::{
     set_launch_settings, DockerEngine, LaunchSettings, CPUS_SETTING, IMAGE_SETTING, MEMORY_SETTING,
 };
-// Build progress plumbing: `image` emits per-line/lifecycle events through
-// `progress`, which the app forwards to a Tauri event (slice C2). The image
-// re-exports stay for the integration tests / callers that pass a raw sink.
-#[allow(unused_imports)]
-pub use image::{ensure_image, image_tag, resolve_image, Progress};
 pub use probe::{availability, DockerAvailability};
 pub use progress::set_build_sink;
-// `BuildEvent` is the sink's payload type; re-exported for API symmetry (the
-// app installs the sink via a closure whose param type is inferred, so it's
-// never named in-crate).
-#[allow(unused_imports)]
-pub use progress::BuildEvent;
 
 /// Best-effort reclamation of containers left behind by dead Fletch
 /// instances, for app startup (`lib.rs`, next to the nested-root sweeps).

--- a/src-tauri/src/sandbox/docker/probe.rs
+++ b/src-tauri/src/sandbox/docker/probe.rs
@@ -1,8 +1,8 @@
 //! Daemon availability probe, cached for UI polling.
 //!
-//! The settings pane (slice C1) polls this to enable/disable the Docker
-//! engine option, and spawn paths (B2) gate on it — so it must be cheap to
-//! call repeatedly and must never hang: the underlying `docker version` call
+//! The settings pane polls this to enable/disable the Docker engine option,
+//! and spawn paths gate on it — so it must be cheap to call repeatedly and
+//! must never hang: the underlying `docker version` call
 //! is bounded at 2s, and results are cached for 5s so a polling UI costs at
 //! most one daemon round-trip per window.
 

--- a/src-tauri/src/sandbox/docker/progress.rs
+++ b/src-tauri/src/sandbox/docker/progress.rs
@@ -1,4 +1,4 @@
-//! Image-build progress broadcast (slice C2).
+//! Image-build progress broadcast to the UI.
 //!
 //! The embedded agent image is built on the first docker spawn (see
 //! [`super::image::ensure_image`]) — a potentially minutes-long `docker build`

--- a/src-tauri/src/sandbox/engine.rs
+++ b/src-tauri/src/sandbox/engine.rs
@@ -31,7 +31,6 @@ impl EngineKind {
     }
 }
 
-#[allow(dead_code)]
 pub struct AgentLaunchCtx<'a> {
     pub agent_id: &'a str,
     pub writable_root: &'a Path,
@@ -54,19 +53,16 @@ pub enum Keepalive {
 }
 
 /// Engine-specific data describing how to tear down what was launched.
-#[allow(dead_code)]
 #[derive(Clone)]
 pub enum KillPlan {
-    ProcessGroup,
     Container { name: String },
 }
 
 /// Teardown handle bound at launch time. Sessions call [`KillHandle::kill`]
 /// before their own process-group escalation and never inspect the variant —
 /// adding an engine requires no session changes. The engine that produced the
-/// plan is captured here, NOT looked up at kill time: once engine selection is
-/// setting-driven (slice C1), a session must be torn down by the engine that
-/// launched it, regardless of what the setting says now.
+/// plan is captured here, not looked up at kill time, so a session is always
+/// torn down by the engine that launched it regardless of the current setting.
 #[derive(Clone)]
 pub enum KillHandle {
     /// The session's own child-handle / process-group termination is the whole
@@ -87,19 +83,6 @@ impl KillHandle {
         match self {
             Self::ProcessGroup => Ok(()),
             Self::Engine { engine, plan } => engine.kill(plan),
-        }
-    }
-
-    /// Whether the sandboxed process is still running, as far as the engine
-    /// can tell. `ProcessGroup` children can't outlive the session's own child
-    /// handle, so the session's view is authoritative and this returns true.
-    /// Docker containers can die independently of the host process (daemon
-    /// stop, OOM kill), which is what this exists to surface — see slice B2.
-    #[allow(dead_code)]
-    pub fn is_alive(&self) -> bool {
-        match self {
-            Self::ProcessGroup => true,
-            Self::Engine { engine, plan } => engine.is_alive(plan),
         }
     }
 
@@ -136,13 +119,6 @@ pub trait SandboxEngine: Send + Sync {
     /// child kill is sufficient.
     fn kill(&self, _plan: &KillPlan) -> Result<()> {
         Ok(())
-    }
-
-    /// Whether the sandboxed process behind `plan` is still running. Override
-    /// where the sandbox can outlive or die independently of the local child
-    /// (Docker); the default defers to the session's own child handle.
-    fn is_alive(&self, _plan: &KillPlan) -> bool {
-        true
     }
 
     /// A user-readable meaning for the launcher's exit `code`, if this engine

--- a/src-tauri/src/sandbox/mod.rs
+++ b/src-tauri/src/sandbox/mod.rs
@@ -64,15 +64,6 @@ pub fn engine_for(kind: EngineKind) -> Result<Arc<dyn SandboxEngine>> {
     }
 }
 
-/// The engine matching the current setting — what a launch would use absent a
-/// per-agent stamp. Launch paths resolve through `engine_for` with the kind
-/// stamped on the agent's record instead; this stays for callers with no
-/// record in hand (none today — B2's non-agent surfaces use it).
-#[allow(dead_code)]
-pub fn current_engine() -> Result<Arc<dyn SandboxEngine>> {
-    engine_for(selected_engine_kind())
-}
-
 /// The seatbelt engine, shared process-wide: it is stateless, and per-launch
 /// state (profile tempfile) lives on the `LaunchPlan`.
 fn seatbelt_engine() -> Arc<dyn SandboxEngine> {

--- a/src-tauri/src/sandbox/provision.rs
+++ b/src-tauri/src/sandbox/provision.rs
@@ -1,9 +1,9 @@
 //! Workspace provisioning: how an agent's checkout comes into existence.
 //!
-//! Two modes. `Worktree` is the historical behavior — a linked `git worktree`
-//! whose `.git` file points back into the origin repo. `Clone` is a
-//! self-contained checkout with its own real, writable `.git`, required by the
-//! Docker engine: a linked worktree's `.git` file references the origin repo's
+//! Two modes. `Worktree` is a linked `git worktree` whose `.git` file points
+//! back into the origin repo. `Clone` is a self-contained checkout with its own
+//! real, writable `.git`, required by the Docker engine: a linked worktree's
+//! `.git` file references the origin repo's
 //! `.git/worktrees/<name>` by absolute path, so containerizing it would mean
 //! mounting the user's real `.git` — a sandbox escape (a writable `.git/hooks`
 //! executes on the host the next time the user runs git).
@@ -22,18 +22,19 @@
 //! The source object store must therefore remain present for the clone's
 //! lifetime — Fletch owns the source repo lifecycle, so this holds.
 //!
-//! The mode is selected by the `workspace_mode` settings key (dev flag, not
-//! exposed in UI — set via sqlite for testing) so the clone path can be
-//! exercised under seatbelt before the Docker engine exists.
+//! The effective mode is chosen per agent at spawn time (see
+//! `supervisor::lifecycle::effective_workspace_mode`): Docker always uses
+//! `Clone`; seatbelt uses `Clone` too unless the `workspace_mode` dev flag
+//! (set via sqlite, not exposed in UI) opts back into linked worktrees.
 
 use std::path::Path;
 
 use crate::error::{Error, Result};
 use crate::git;
 
-/// Settings-table key selecting the provisioning mode: `"worktree"` (default)
-/// or `"clone"`. Read at spawn time; slice B2 forces `Clone` whenever the
-/// engine is Docker regardless of this key.
+/// Settings-table key overriding the provisioning mode under seatbelt:
+/// `"worktree"` or `"clone"`. Docker always uses `Clone` regardless of this
+/// key; see `supervisor::lifecycle::effective_workspace_mode`.
 pub const WORKSPACE_MODE_SETTING: &str = "workspace_mode";
 
 /// How an agent workspace is materialized from its source repo.
@@ -47,7 +48,7 @@ pub enum WorkspaceMode {
 }
 
 /// What to check out where. `base_ref` is any commit-ish; pass `"HEAD"` for
-/// "the source repo's current HEAD" (the legacy no-base behavior).
+/// "the source repo's current HEAD" (the no-base behavior).
 pub struct CheckoutSpec<'a> {
     /// The user's real repo root.
     pub source_repo: &'a Path,

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -44,35 +44,29 @@ pub(super) fn stamped_engine(record: &AgentRecord) -> EngineKind {
 ///
 /// Docker forces `Clone` regardless of the `workspace_mode` dev flag: a linked
 /// worktree's `.git` file points into the user's real repo, and a container
-/// must never be able to reach that (sandbox plan invariant 2).
+/// must never be able to reach that (invariant 2).
 ///
-/// Seatbelt now also defaults to `Clone` — both engines converge on one
+/// Seatbelt also defaults to `Clone` — both engines converge on one
 /// self-contained-checkout model, made cheap by `git clone --shared` (objects
 /// borrowed via alternates, not copied). An explicit `workspace_mode=worktree`
-/// still opts back into the historical linked-worktree model.
+/// still opts back into the linked-worktree model.
 ///
-/// Changed restore semantics under seatbelt — but only for work that lives
-/// *solely* in a clone. Restore re-provisions each repo at its archived tip;
-/// provisioning refetches from `origin` only when that tip isn't already in the
-/// source repo's object store (see `provision_on_branch`).
+/// Restore re-provisions each repo at its archived tip. Provisioning refetches
+/// from `origin` only when that tip isn't already reachable in the source
+/// repo's object store (see `provision_on_branch`); when it is, restore borrows
+/// it back via alternates and checks out offline, no remote branch needed (see
+/// the `provision.rs` restore tests).
 ///
-/// - A clone-native agent writes new commits into its *own* `.git/objects`;
-///   archive teardown `rm -rf`s the clone, so unpushed commits are gone and
-///   restore can only recover what was pushed. This is the accepted cost of
-///   Clone mode — the reason the `workspace_mode=worktree` opt-out remains.
-/// - A pre-existing agent archived under the old Worktree default kept its
-///   commits in the *source* repo's object store (a worktree shares it), so
-///   even though teardown deleted the worktree branch, the tip object survives.
-///   Clone-mode restore borrows it back via alternates and checks it out
-///   offline — no remote branch needed (see the `provision.rs` restore tests).
-///   It only becomes unrecoverable once the source repo gc-prunes the
-///   now-unreachable object, which would have broken worktree-mode restore just
-///   the same. So the flip does not regress restore of legacy archives.
+/// A clone-native agent writes new commits into its *own* `.git/objects`, and
+/// archive teardown `rm -rf`s the clone — so commits that never reached
+/// `origin` or the source store are gone, and restore can only recover what
+/// did. This is the accepted cost of Clone mode, and the reason the
+/// `workspace_mode=worktree` opt-out remains.
 pub(super) fn effective_workspace_mode(engine: EngineKind, setting: Option<&str>) -> WorkspaceMode {
     match engine {
         EngineKind::Docker => WorkspaceMode::Clone,
-        // Explicit opt-out to the historical linked-worktree model; everything
-        // else — unset (the new default) or "clone" — resolves to Clone.
+        // Explicit opt-out to the linked-worktree model; everything else —
+        // unset or "clone" — resolves to Clone.
         EngineKind::SandboxExec => match setting {
             Some("worktree") => WorkspaceMode::Worktree,
             Some("clone") | None => WorkspaceMode::Clone,


### PR DESCRIPTION
Cleanup pass over the sandbox engine layer now that all plan slices (A1–D1) have landed and the plan doc has been removed. **No behavior change** — clippy is back to the 21 pre-existing warnings (0 new), and all 97 sandbox unit tests pass.

## Dead code removed
- `current_engine()` — zero callers.
- The unused `is_alive` surface — `KillHandle::is_alive`, the `SandboxEngine::is_alive` trait method, and the `DockerEngine` impl. Nothing ever polled it (container-death is surfaced via exit codes); the integration test now checks `container_running` directly.
- The never-constructed `KillPlan::ProcessGroup` variant.
- The three dead re-export blocks in `docker/mod.rs` (`cleanup`/`image`/`progress` items nothing imported through the module).
- Stale `#[allow(dead_code)]` / `#[allow(unused_imports)]` on items that are actually used now (cleanup label helpers, cli streaming helpers, `AgentLaunchCtx`).

## Comments cleaned
- Stripped every sandbox-plan slice reference (`slice B2/C1/C2/D1`, "B3 acceptance") and change-history narration ("the flip", "old Worktree default", "before the Docker engine exists", "legacy archives", "until slice C2 wires it").
- Kept the invariant/rationale comments that guard against future breakage (invariant 1–5 notes, `--shared`/RO-mount reasoning, the atomic-rename note).

## Contradictions fixed
- `provision.rs` `workspace_mode` docs now state Clone is the default for **both** engines and point at `effective_workspace_mode`.
- The container-auth status wire-shape doc now lists `keychain` (added by the Keychain-primary commit).

Worktree support is intentionally left in place — its detection/teardown path is still load-bearing for existing on-disk worktree agents; a full removal is a separate scoped migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)