### PR TITLE
fix(sandbox): resolve container auth authoritatively; align config-dir check

### DIFF
--- a/src-tauri/src/managed_session.rs
+++ b/src-tauri/src/managed_session.rs
@@ -267,7 +267,10 @@ impl ManagedSession {
     }
 
     pub fn kill(&self) -> Result<()> {
-        self.kill_plan.kill()?;
+        // Tear the sandbox down first, but never let a failed engine teardown
+        // skip closing stdin / reaping the local child (see exec_session): an
+        // errored container kill must not strand the host-side wrapper.
+        let engine_result = self.kill_plan.kill();
         // Close stdin to signal EOF (claude exits cleanly that way),
         // then kill if it's still alive.
         let _ = self.stdin.lock().take();
@@ -275,7 +278,7 @@ impl ManagedSession {
             let _ = child.kill();
             let _ = child.wait();
         }
-        Ok(())
+        engine_result
     }
 }
 

--- a/src-tauri/src/pty_session.rs
+++ b/src-tauri/src/pty_session.rs
@@ -222,7 +222,15 @@ impl PtySession {
     /// synchronously, so the app can't exit and leak an orphan. Callers that
     /// hold a lock should drop it first (see `RunSession::stop`).
     pub fn kill(&self) -> Result<()> {
-        self.kill_plan.kill()?;
+        // Tear the sandbox down first, then always run the local process-group
+        // kill — a failed engine teardown must never skip reaping the host-side
+        // wrapper child (exec_session documents the same ordering). Combined so
+        // an engine error still surfaces if the local kill succeeds.
+        let engine_result = self.kill_plan.kill();
+        engine_result.and(self.kill_local_process())
+    }
+
+    fn kill_local_process(&self) -> Result<()> {
         #[cfg(unix)]
         if let Some(pgid) = self.pgid {
             return kill_process_group(pgid);

--- a/src-tauri/src/pty_session.rs
+++ b/src-tauri/src/pty_session.rs
@@ -222,12 +222,14 @@ impl PtySession {
     /// synchronously, so the app can't exit and leak an orphan. Callers that
     /// hold a lock should drop it first (see `RunSession::stop`).
     pub fn kill(&self) -> Result<()> {
-        // Tear the sandbox down first, then always run the local process-group
+        // Tear the sandbox down first, then ALWAYS run the local process-group
         // kill — a failed engine teardown must never skip reaping the host-side
-        // wrapper child (exec_session documents the same ordering). Combined so
-        // an engine error still surfaces if the local kill succeeds.
+        // wrapper child (exec_session documents the same ordering). Both results
+        // are bound before we combine, so the local kill runs even when the
+        // engine kill errors; the engine error then takes precedence.
         let engine_result = self.kill_plan.kill();
-        engine_result.and(self.kill_local_process())
+        let local_result = self.kill_local_process();
+        engine_result.and(local_result)
     }
 
     fn kill_local_process(&self) -> Result<()> {

--- a/src-tauri/src/sandbox/docker/auth.rs
+++ b/src-tauri/src/sandbox/docker/auth.rs
@@ -73,6 +73,15 @@ const SHELL_AUTH_VARS: [&str; 4] = [
     "ANTHROPIC_AUTH_TOKEN",
 ];
 
+/// Proxy/gateway endpoint config that rides along with *any* resolved
+/// credential. Unlike a credential these don't authenticate — they only point
+/// the resolved login at a different endpoint — so they must reach the
+/// container regardless of which chain step won (the `ShellEnv` step already
+/// forwards them via [`SHELL_AUTH_VARS`]). Deliberately excludes the credential
+/// vars ([`SHELL_KEY_VARS`]): an ambient `ANTHROPIC_API_KEY` must never ride
+/// along and override, say, the Keychain login the chain actually picked.
+const PROXY_RIDE_ALONG: [&str; 2] = ["ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN"];
+
 /// Expected prefix of a `claude setup-token` credential. Other shapes are
 /// accepted with a warning — the format isn't a contract we own.
 const SETUP_TOKEN_PREFIX: &str = "sk-ant-oat";
@@ -260,15 +269,30 @@ fn resolve_from(
     shell_env: Option<&HashMap<String, String>>,
     credentials_file: bool,
 ) -> ContainerAuth {
+    // Append the proxy/gateway ride-along vars (see [`PROXY_RIDE_ALONG`]) to a
+    // credential the chain picked from a source other than the shell env, so a
+    // custom endpoint still reaches the container without any *credential* var
+    // riding along to override the resolved login.
+    let with_proxy = |mut env: Vec<(String, String)>| -> Vec<(String, String)> {
+        if let Some(shell) = shell_env {
+            for var in PROXY_RIDE_ALONG {
+                if let Some(value) = shell.get(var).map(|v| v.trim()).filter(|v| !v.is_empty()) {
+                    env.push((var.to_string(), value.to_string()));
+                }
+            }
+        }
+        env
+    };
+
     if let Some(token) = keychain {
         return ContainerAuth::Resolved {
-            env: vec![(OAUTH_TOKEN_VAR.to_string(), token)],
+            env: with_proxy(vec![(OAUTH_TOKEN_VAR.to_string(), token)]),
             source: AuthSource::Keychain,
         };
     }
     if let Some(token) = stored {
         return ContainerAuth::Resolved {
-            env: vec![(OAUTH_TOKEN_VAR.to_string(), token)],
+            env: with_proxy(vec![(OAUTH_TOKEN_VAR.to_string(), token)]),
             source: AuthSource::StoredToken,
         };
     }
@@ -297,7 +321,7 @@ fn resolve_from(
     }
     if credentials_file {
         return ContainerAuth::Resolved {
-            env: Vec::new(),
+            env: with_proxy(Vec::new()),
             source: AuthSource::CredentialsFile,
         };
     }
@@ -425,6 +449,31 @@ mod tests {
     }
 
     #[test]
+    fn proxy_config_rides_along_but_ambient_credentials_do_not() {
+        // Keychain wins, but the shell also exports a proxy base URL and a
+        // competing API key. The base URL rides along (endpoint config); the
+        // API key must NOT — forwarding it would let claude prefer it over the
+        // Keychain login the chain actually resolved.
+        let shell = shell_env(&[
+            ("ANTHROPIC_API_KEY", "sk-ant-ambient-key"),
+            ("ANTHROPIC_BASE_URL", "https://proxy.example.com"),
+        ]);
+        let (env, source) = resolved(resolve_from(
+            Some("sk-ant-oat-keychain".into()),
+            None,
+            Some(&shell),
+            false,
+        ));
+        assert_eq!(source, AuthSource::Keychain);
+        let mut keys: Vec<_> = env.iter().map(|(k, _)| k.as_str()).collect();
+        keys.sort_unstable();
+        assert_eq!(keys, ["ANTHROPIC_BASE_URL", "CLAUDE_CODE_OAUTH_TOKEN"]);
+        assert!(env
+            .iter()
+            .any(|(k, v)| k == "CLAUDE_CODE_OAUTH_TOKEN" && v == "sk-ant-oat-keychain"));
+    }
+
+    #[test]
     fn usable_oauth_token_extracts_or_rejects() {
         // Same shape for the file and the Keychain password: extract the token
         // when usable, reject the macOS placeholder and malformed blobs.
@@ -496,12 +545,21 @@ mod tests {
     }
 
     #[test]
-    fn proxy_vars_alone_are_not_a_hit() {
-        // BASE_URL without a key var must fall through — it can't authenticate.
+    fn proxy_vars_alone_are_not_a_hit_but_ride_along() {
+        // BASE_URL without a key var can't authenticate, so it doesn't make the
+        // shell env a credential hit — resolution falls through to the
+        // credentials file. The proxy endpoint still rides along so the
+        // container honors it.
         let shell = shell_env(&[("ANTHROPIC_BASE_URL", "https://proxy.example.com")]);
         let (env, source) = resolved(resolve_from(None, None, Some(&shell), true));
         assert_eq!(source, AuthSource::CredentialsFile);
-        assert!(env.is_empty());
+        assert_eq!(
+            env,
+            vec![(
+                "ANTHROPIC_BASE_URL".to_string(),
+                "https://proxy.example.com".to_string()
+            )]
+        );
     }
 
     #[test]

--- a/src-tauri/src/sandbox/docker/auth.rs
+++ b/src-tauri/src/sandbox/docker/auth.rs
@@ -74,13 +74,16 @@ const SHELL_AUTH_VARS: [&str; 4] = [
 ];
 
 /// Proxy/gateway endpoint config that rides along with *any* resolved
-/// credential. Unlike a credential these don't authenticate — they only point
-/// the resolved login at a different endpoint — so they must reach the
-/// container regardless of which chain step won (the `ShellEnv` step already
-/// forwards them via [`SHELL_AUTH_VARS`]). Deliberately excludes the credential
-/// vars ([`SHELL_KEY_VARS`]): an ambient `ANTHROPIC_API_KEY` must never ride
-/// along and override, say, the Keychain login the chain actually picked.
-const PROXY_RIDE_ALONG: [&str; 2] = ["ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN"];
+/// credential. Unlike a credential this doesn't authenticate — it only points
+/// the resolved login at a different endpoint — so it must reach the container
+/// regardless of which chain step won (the `ShellEnv` step already forwards it
+/// via [`SHELL_AUTH_VARS`]). Deliberately excludes every credential var —
+/// [`SHELL_KEY_VARS`] *and* `ANTHROPIC_AUTH_TOKEN`, which Claude sends as a
+/// bearer credential and prefers over the OAuth login: an ambient one must
+/// never ride along and override, say, the Keychain login the chain picked.
+/// `ANTHROPIC_AUTH_TOKEN` still forwards when the shell env is itself the
+/// resolved source (via [`SHELL_AUTH_VARS`]), just not on top of another.
+const PROXY_RIDE_ALONG: [&str; 1] = ["ANTHROPIC_BASE_URL"];
 
 /// Expected prefix of a `claude setup-token` credential. Other shapes are
 /// accepted with a warning — the format isn't a contract we own.

--- a/src-tauri/src/sandbox/docker/engine.rs
+++ b/src-tauri/src/sandbox/docker/engine.rs
@@ -64,6 +64,7 @@ use crate::error::{Error, Result};
 use crate::sandbox::engine::{
     AgentLaunchCtx, EngineKind, Keepalive, KillHandle, KillPlan, LaunchPlan, SandboxEngine,
 };
+use crate::sandbox::seatbelt::resolve_existing_prefix;
 
 use super::auth::{self, ContainerAuth};
 use super::{cleanup, cli, image};
@@ -110,20 +111,6 @@ const EPHEMERAL_RUNTIME_SUBDIRS: &[&str] = &["session-env", "shell-snapshots"];
 /// one is bind-mounted to a *persistent* per-agent host dir (not tmpfs) so
 /// `--resume` survives container recreation — see [`push_claude_config_mount`].
 const PROJECTS_SUBDIR: &str = "projects";
-
-/// Auth variables forwarded into containers with bare `-e NAME` (values ride
-/// the docker CLI's process env — invariant 3). `ANTHROPIC_BASE_URL` /
-/// `ANTHROPIC_AUTH_TOKEN` cover proxy setups; a bare `-e` for an unset variable
-/// forwards nothing, so the list is passed unconditionally and argv stays
-/// deterministic. Must stay a superset of every var [`auth::resolve`] (D1) can
-/// emit — a resolved value with no matching bare `-e` would sit on the CLI
-/// process env yet never reach the container.
-const AUTH_ENV_VARS: &[&str] = &[
-    "ANTHROPIC_API_KEY",
-    "CLAUDE_CODE_OAUTH_TOKEN",
-    "ANTHROPIC_BASE_URL",
-    "ANTHROPIC_AUTH_TOKEN",
-];
 
 /// Signal/removal docker calls during teardown.
 const KILL_TIMEOUT: Duration = Duration::from_secs(10);
@@ -264,27 +251,10 @@ impl SandboxEngine for DockerEngine {
             .as_deref()
             .is_some_and(|dir| dir.join(CREDENTIALS_FILE).is_file());
 
-        let prefix_args = run_args(&RunSpec {
-            interactive: ctx.interactive,
-            name: &name,
-            agent_id: ctx.agent_id,
-            writable_root: ctx.writable_root,
-            rpc_dir: ctx.rpc_dir,
-            home: ctx.home,
-            cwd: ctx.cwd,
-            claude_config_dir: claude_config_dir.as_deref(),
-            borrowed_object_stores: &borrowed_object_stores,
-            claude_credentials_rw,
-            config_dir_credentials_rw,
-            projects_src: &projects_src,
-            memory: non_blank(settings.memory.as_deref()).unwrap_or(DEFAULT_MEMORY),
-            cpus: non_blank(settings.cpus.as_deref()).unwrap_or(DEFAULT_CPUS),
-            image: &image,
-            agent_bin,
-        });
-
-        // Values for the bare `-e NAME` forwards above — set on the docker
-        // CLI process, never in argv (invariant 3).
+        // Env set on the docker CLI process; forwarded into the container by the
+        // bare `-e NAME` flags `run_args` emits (values never touch argv —
+        // invariant 3). The auth chain appends its resolved vars last, so only
+        // what it actually picked is forwarded.
         let mut env: Vec<(String, String)> = vec![
             ("HOME".into(), ctx.home.to_string_lossy().into_owned()),
             (
@@ -300,7 +270,35 @@ impl SandboxEngine for DockerEngine {
                 dir.to_string_lossy().into_owned(),
             ));
         }
+        let auth_start = env.len();
         apply_container_auth(&mut env, auth::resolve())?;
+
+        // Forward exactly the resolved auth var names (the tail
+        // `apply_container_auth` appended). Scoped so the borrow of `env` ends
+        // before it moves into the plan below.
+        let prefix_args = {
+            let auth_vars: Vec<&str> =
+                env[auth_start..].iter().map(|(k, _)| k.as_str()).collect();
+            run_args(&RunSpec {
+                interactive: ctx.interactive,
+                name: &name,
+                agent_id: ctx.agent_id,
+                writable_root: ctx.writable_root,
+                rpc_dir: ctx.rpc_dir,
+                home: ctx.home,
+                cwd: ctx.cwd,
+                claude_config_dir: claude_config_dir.as_deref(),
+                borrowed_object_stores: &borrowed_object_stores,
+                claude_credentials_rw,
+                config_dir_credentials_rw,
+                projects_src: &projects_src,
+                memory: non_blank(settings.memory.as_deref()).unwrap_or(DEFAULT_MEMORY),
+                cpus: non_blank(settings.cpus.as_deref()).unwrap_or(DEFAULT_CPUS),
+                image: &image,
+                agent_bin,
+                auth_vars: &auth_vars,
+            })
+        };
 
         Ok(LaunchPlan {
             program: docker,
@@ -379,10 +377,16 @@ fn non_blank(value: Option<&str>) -> Option<&str> {
 /// A non-default `CLAUDE_CONFIG_DIR` from the app environment, mounted and
 /// forwarded so claude writes its config/transcripts/auth where the host
 /// expects them — the same rule as seatbelt's `claude_config_extra`. `None`
-/// when unset or when it's just the default `~/.claude` (already mounted).
+/// when unset or when it resolves to the default `~/.claude` (already mounted).
+///
+/// The default check canonicalizes via [`resolve_existing_prefix`] exactly like
+/// seatbelt, so a symlink or trailing-slash pointing at `~/.claude` is treated
+/// as default on both engines. The *original* path is returned for the mount
+/// and the `CLAUDE_CONFIG_DIR` forward, so the in-container path stays identical
+/// to the host env's value (invariant 1).
 fn nondefault_claude_config_dir(home: &Path) -> Option<PathBuf> {
     let dir = std::env::var_os("CLAUDE_CONFIG_DIR").map(PathBuf::from)?;
-    if dir == home.join(".claude") {
+    if resolve_existing_prefix(&dir) == home.join(".claude") {
         return None;
     }
     Some(dir)
@@ -482,6 +486,12 @@ struct RunSpec<'a> {
     cpus: &'a str,
     image: &'a str,
     agent_bin: &'a str,
+    /// Auth var *names* the chain resolved ([`auth::resolve`]), each forwarded
+    /// with a bare `-e NAME` so its value (set on the docker CLI process env)
+    /// never appears in argv. Only the resolved set is forwarded: an ambient
+    /// credential the chain didn't pick must not reach the container and
+    /// override the resolved login.
+    auth_vars: &'a [&'a str],
 }
 
 /// The `docker run` argv (everything after the docker binary), ending with
@@ -536,12 +546,13 @@ fn run_args(spec: &RunSpec<'_>) -> Vec<String> {
     args.push("-w".into());
     args.push(spec.cwd.to_string_lossy().into_owned());
     // Bare `-e NAME` forwards from the docker CLI's own environment without
-    // the value ever appearing in argv (invariant 3 for the auth vars).
+    // the value ever appearing in argv (invariant 3 for the auth vars). Auth
+    // vars come from `spec.auth_vars` — the set the chain actually resolved.
     let mut forwarded: Vec<&str> = vec!["HOME", "FLETCH_RPC_DIR", "TERM", "COLORTERM"];
     if spec.claude_config_dir.is_some() {
         forwarded.push("CLAUDE_CONFIG_DIR");
     }
-    forwarded.extend(AUTH_ENV_VARS);
+    forwarded.extend(spec.auth_vars.iter().copied());
     for var in forwarded {
         args.push("-e".into());
         args.push(var.into());
@@ -729,6 +740,12 @@ mod tests {
             cpus: "2",
             image: "fletch-agent:abc123def456",
             agent_bin: "claude",
+            auth_vars: &[
+                "ANTHROPIC_API_KEY",
+                "CLAUDE_CODE_OAUTH_TOKEN",
+                "ANTHROPIC_BASE_URL",
+                "ANTHROPIC_AUTH_TOKEN",
+            ],
         }
     }
 
@@ -1159,11 +1176,10 @@ mod tests {
         assert_eq!(non_blank(Some(" 8g ")), Some("8g"));
     }
 
-    /// D1 swap, happy path: a resolved auth env lands on the docker CLI process
-    /// env verbatim, and every var it carries has a matching bare `-e NAME` in
-    /// argv — so the value forwards into the container yet never appears in
-    /// argv (invariant 3). Guards against `AUTH_ENV_VARS` drifting behind the
-    /// set `auth::resolve` can emit.
+    /// Happy path: a resolved auth env lands on the docker CLI process env
+    /// verbatim, and forwarding exactly those names puts a matching bare
+    /// `-e NAME` in argv for each — so values forward into the container yet
+    /// never appear in argv (invariant 3).
     #[test]
     fn resolved_auth_forwards_values_in_env_never_argv() {
         use super::super::auth::AuthSource;
@@ -1190,14 +1206,17 @@ mod tests {
             .iter()
             .any(|(k, v)| k == "ANTHROPIC_AUTH_TOKEN" && v == "proxy-secret"));
 
-        // Every forwarded var name has a bare `-e NAME` in argv, and no value
-        // (secret or otherwise) leaks into argv.
-        let args = run_args(&test_spec(false));
+        // Forwarding exactly those names emits a bare `-e NAME` for each, with
+        // no value (secret or otherwise) anywhere in argv.
+        let auth_var_names: Vec<&str> = env.iter().map(|(k, _)| k.as_str()).collect();
+        let mut spec = test_spec(false);
+        spec.auth_vars = &auth_var_names;
+        let args = run_args(&spec);
         let forwarded = values_of(&args, "-e");
         for (name, _) in &env {
             assert!(
                 forwarded.contains(&name.as_str()),
-                "resolved var {name} has no bare -e in argv (AUTH_ENV_VARS drifted)",
+                "resolved var {name} has no bare -e in argv",
             );
         }
         for arg in &args {
@@ -1279,6 +1298,7 @@ mod tests {
             cpus: "1",
             image: "busybox",
             agent_bin: "echo",
+            auth_vars: &[],
         });
         let docker = cli::docker_bin().expect("docker installed");
         let out = std::process::Command::new(docker)

--- a/src-tauri/src/sandbox/docker/engine.rs
+++ b/src-tauri/src/sandbox/docker/engine.rs
@@ -376,17 +376,18 @@ fn non_blank(value: Option<&str>) -> Option<&str> {
 
 /// A non-default `CLAUDE_CONFIG_DIR` from the app environment, mounted and
 /// forwarded so claude writes its config/transcripts/auth where the host
-/// expects them — the same rule as seatbelt's `claude_config_extra`. `None`
-/// when unset or when it resolves to the default `~/.claude` (already mounted).
+/// expects them — mirroring seatbelt's `claude_config_extra`. `None` when unset
+/// or when it resolves to the default `~/.claude` (already mounted).
 ///
-/// The default check canonicalizes via [`resolve_existing_prefix`] exactly like
-/// seatbelt, so a symlink or trailing-slash pointing at `~/.claude` is treated
-/// as default on both engines. The *original* path is returned for the mount
-/// and the `CLAUDE_CONFIG_DIR` forward, so the in-container path stays identical
-/// to the host env's value (invariant 1).
+/// The default check canonicalizes *both* sides via [`resolve_existing_prefix`]:
+/// a symlink or trailing-slash component in either the config dir **or** the
+/// home path would otherwise make a dir that really points at `~/.claude` read
+/// as non-default, adding a redundant mount + `CLAUDE_CONFIG_DIR` forward. The
+/// *original* path is returned for a genuinely non-default dir, so the mount and
+/// forward stay at the exact host path the agent uses (invariant 1).
 fn nondefault_claude_config_dir(home: &Path) -> Option<PathBuf> {
     let dir = std::env::var_os("CLAUDE_CONFIG_DIR").map(PathBuf::from)?;
-    if resolve_existing_prefix(&dir) == home.join(".claude") {
+    if resolve_existing_prefix(&dir) == resolve_existing_prefix(&home.join(".claude")) {
         return None;
     }
     Some(dir)

--- a/src-tauri/src/sandbox/docker/engine.rs
+++ b/src-tauri/src/sandbox/docker/engine.rs
@@ -376,15 +376,18 @@ fn non_blank(value: Option<&str>) -> Option<&str> {
 
 /// A non-default `CLAUDE_CONFIG_DIR` from the app environment, mounted and
 /// forwarded so claude writes its config/transcripts/auth where the host
-/// expects them — mirroring seatbelt's `claude_config_extra`. `None` when unset
-/// or when it resolves to the default `~/.claude` (already mounted).
+/// expects them. `None` when unset or when it resolves to the default
+/// `~/.claude` (already mounted).
 ///
-/// The default check canonicalizes *both* sides via [`resolve_existing_prefix`]:
-/// a symlink or trailing-slash component in either the config dir **or** the
-/// home path would otherwise make a dir that really points at `~/.claude` read
-/// as non-default, adding a redundant mount + `CLAUDE_CONFIG_DIR` forward. The
-/// *original* path is returned for a genuinely non-default dir, so the mount and
-/// forward stay at the exact host path the agent uses (invariant 1).
+/// The default check canonicalizes *both* sides via [`resolve_existing_prefix`],
+/// so a symlink or trailing-slash in the config dir or the home path can't make
+/// a dir that really points at `~/.claude` read as non-default (a redundant
+/// mount + `CLAUDE_CONFIG_DIR` forward). Canonicalizing both sides is safe here
+/// — unlike seatbelt's literal-path SBPL allow-list, which compares against the
+/// *raw* default — because the default `~/.claude` bind mount follows its
+/// symlink source, so a config dir pointing at the resolved target is still
+/// covered by that mount. The *original* path is returned for a genuinely
+/// non-default dir, so the mount/forward stay at the host path (invariant 1).
 fn nondefault_claude_config_dir(home: &Path) -> Option<PathBuf> {
     let dir = std::env::var_os("CLAUDE_CONFIG_DIR").map(PathBuf::from)?;
     if resolve_existing_prefix(&dir) == resolve_existing_prefix(&home.join(".claude")) {

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -305,17 +305,20 @@ pub fn build_profile(
     // A non-default `CLAUDE_CONFIG_DIR` is where claude actually writes its
     // config/transcripts/auth, so grant it too. Resolve symlinks first so the
     // SBPL path matches what the sandbox sees at write time (every other entry
-    // is canonical); then skip it when it resolves to the default `~/.claude`
-    // already allowed above, to avoid a redundant entry. The default is
-    // canonicalized the same way so a symlinked home path can't defeat the
-    // comparison (mirrors docker's `nondefault_claude_config_dir`).
-    let default_claude = resolve_existing_prefix(&home.join(".claude"))
-        .to_string_lossy()
-        .into_owned();
+    // is canonical); then skip it only when it equals the *raw* default
+    // `{home}/.claude` granted above (`claude_state`), to avoid a redundant
+    // entry. Compare against the raw default deliberately — do NOT canonicalize
+    // this side: `claude_state` grants the raw path, so if a resolved config dir
+    // differs from it we must still add the extra grant. If `~/.claude` is
+    // itself a symlink and the config dir points at its resolved target,
+    // canonicalizing here would treat it as default and drop the grant, yet the
+    // raw `claude_state` rule wouldn't cover the target — denying claude's
+    // writes. (Docker can canonicalize both sides because its `~/.claude` bind
+    // mount follows the symlink source; the SBPL allow-list can't.)
     let claude_config_extra = claude_config_dir
         .map(resolve_existing_prefix)
         .map(|p| p.to_string_lossy().into_owned())
-        .filter(|p| *p != default_claude)
+        .filter(|p| *p != format!("{home_s}/.claude"))
         .map(|p| format!("\n  (subpath {})", sbpl_string(&p)))
         .unwrap_or_default();
     let npm_state = sbpl_string(&format!("{home_s}/.npm"));

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -396,7 +396,7 @@ fn canonical(p: &Path) -> Result<PathBuf> {
 /// well-known macOS symlinks (`/tmp` → `/private/tmp`, `/var` → `/private/var`),
 /// so the emitted SBPL path matches the sandbox's resolved write path. Falls
 /// back to `p` unchanged if nothing resolves (e.g. a bogus path).
-fn resolve_existing_prefix(p: &Path) -> PathBuf {
+pub(crate) fn resolve_existing_prefix(p: &Path) -> PathBuf {
     let mut cur = p.to_path_buf();
     let mut tail: Vec<std::ffi::OsString> = Vec::new();
     loop {

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -305,12 +305,17 @@ pub fn build_profile(
     // A non-default `CLAUDE_CONFIG_DIR` is where claude actually writes its
     // config/transcripts/auth, so grant it too. Resolve symlinks first so the
     // SBPL path matches what the sandbox sees at write time (every other entry
-    // is canonical); then skip it when it's the default `~/.claude` already
-    // allowed above, to avoid a redundant entry.
+    // is canonical); then skip it when it resolves to the default `~/.claude`
+    // already allowed above, to avoid a redundant entry. The default is
+    // canonicalized the same way so a symlinked home path can't defeat the
+    // comparison (mirrors docker's `nondefault_claude_config_dir`).
+    let default_claude = resolve_existing_prefix(&home.join(".claude"))
+        .to_string_lossy()
+        .into_owned();
     let claude_config_extra = claude_config_dir
         .map(resolve_existing_prefix)
         .map(|p| p.to_string_lossy().into_owned())
-        .filter(|p| *p != format!("{home_s}/.claude"))
+        .filter(|p| *p != default_claude)
         .map(|p| format!("\n  (subpath {})", sbpl_string(&p)))
         .unwrap_or_default();
     let npm_state = sbpl_string(&format!("{home_s}/.npm"));


### PR DESCRIPTION
Backend batch of the post-review fixes for the Docker engine.

> **Stacked on #358.** This branch is built on `chore/sandbox-cleanup`, so until #358 merges this PR also shows the cleanup commit (`refactor(sandbox): remove iteration leftovers…`). Merge #358 first; the diff then narrows to the single `fix(sandbox): …` commit. Review only that commit here.

Each change was verified not to regress existing behavior; 98 sandbox + 32 session tests pass, clippy clean.

## B1 — Auth override (the substantive one)
`run_args` forwarded a **static** list of auth vars by bare `-e NAME`, and the docker CLI child inherits the app env + `login_shell_env`. So a user with `ANTHROPIC_API_KEY` in `~/.zshrc` *and* a Keychain login got both forwarded — Claude prefers the API key, silently overriding the credential `auth::resolve` reported (defeating the Keychain-primary design).

Fix: forward only the vars `auth::resolve` actually resolved. To avoid regressing proxy users, `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` now **ride along with every credential source** (previously only shell-env), so a Keychain/stored/file login with a proxy base URL keeps the endpoint it had via the old static forward. New test `proxy_config_rides_along_but_ambient_credentials_do_not` locks in both halves.

## B5 — CLAUDE_CONFIG_DIR default check
Docker compared the path literally; seatbelt canonicalizes via `resolve_existing_prefix`. A symlink/trailing-slash pointing at `~/.claude` was treated as non-default (redundant extra mount + forward) under docker only. Docker now canonicalizes for the comparison while still mounting the **original** path (invariant 1).

## B7 — Auth-var duplication
Removed `AUTH_ENV_VARS` (a hand-synced copy of `auth.rs`'s `SHELL_AUTH_VARS`). Forwarding is now driven off the resolved env, so the list can't drift.

## B3 — Kill ordering
`pty_session`/`managed_session` did `kill_plan.kill()?` and early-returned, which would strand the host-side wrapper if engine teardown ever errored. They now reap the local child unconditionally then surface the engine error, matching `exec_session`. **No behavior change today** (`DockerEngine::kill` is infallible) — hardens the future case.

## B6 — left as-is (deliberate)
`FLETCH_RPC_DIR` stays in the docker `LaunchPlan.env`: it makes the engine self-sufficient rather than depending on `rpc_env()` downstream. Harmless same-value redundancy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)