### PR TITLE
fix(sandbox-ui): surface unusable engine, reachable connect success, DRY docker fields

### DIFF
--- a/src/components/SettingsScreen/ContainerAuth.tsx
+++ b/src/components/SettingsScreen/ContainerAuth.tsx
@@ -67,8 +67,10 @@ export function ContainerAuth() {
 function ContainerAuthModal({ onClose }: { onClose: () => void }) {
   const status = useAppStore((s) => s.containerAuth?.status);
   const clearContainerAuthToken = useAppStore((s) => s.clearContainerAuthToken);
-  // On success the hook refreshes the status row, then closes the modal.
-  const { phase, url, error, connect, submit, cancel } = useClaudeSetup(onClose);
+  // No onConnected callback: the hook refreshes the status row itself, and we
+  // want the modal to stay open on success so its confirmation ("Connected…")
+  // and the "Done" button render. The user dismisses it.
+  const { phase, url, error, connect, submit, cancel } = useClaudeSetup();
   const [manual, setManual] = useState(false);
   const [busy, setBusy] = useState(false);
 

--- a/src/components/SettingsScreen/ExperimentalPane.tsx
+++ b/src/components/SettingsScreen/ExperimentalPane.tsx
@@ -40,6 +40,29 @@ export function ExperimentalPane() {
   );
 }
 
+/** The three Docker launch knobs, in display order. Each maps to a
+ *  backend-owned `docker_*` setting; `key` also indexes the draft/store state. */
+const DOCKER_FIELDS = [
+  {
+    key: "image",
+    title: "Container image",
+    sub: "Override the built-in agent image. Your image must have Claude Code (`claude`) on PATH and git installed. Leave blank to use Fletch's image (built on the first Docker run).",
+    placeholder: "fletch-agent (built-in)",
+  },
+  {
+    key: "memory",
+    title: "Memory limit",
+    sub: "Passed to `docker run --memory`. Blank uses the default (4g).",
+    placeholder: "4g",
+  },
+  {
+    key: "cpus",
+    title: "CPU limit",
+    sub: "Passed to `docker run --cpus`. Blank uses the default (2).",
+    placeholder: "2",
+  },
+] as const;
+
 /** Advanced Docker-sandbox launch knobs. These persist to the backend-owned
  *  `docker_image` / `docker_memory` / `docker_cpus` settings AND update the
  *  in-process spawn-path mirror, so a change applies to the next docker spawn
@@ -51,19 +74,21 @@ function DockerAdvanced() {
   const dockerCpus = useAppStore((s) => s.dockerCpus);
   const save = useAppStore((s) => s.saveDockerLaunchSettings);
 
+  const stored = { image: dockerImage, memory: dockerMemory, cpus: dockerCpus };
   // Local edit state, committed on blur/Enter so we don't persist per keystroke.
-  const [image, setImage] = useState(dockerImage);
-  const [memory, setMemory] = useState(dockerMemory);
-  const [cpus, setCpus] = useState(dockerCpus);
+  const [draft, setDraft] = useState(stored);
 
   // Reflect external changes (e.g. a revert on a failed save) back into the
-  // fields so they never drift from the store's source of truth.
-  useEffect(() => setImage(dockerImage), [dockerImage]);
-  useEffect(() => setMemory(dockerMemory), [dockerMemory]);
-  useEffect(() => setCpus(dockerCpus), [dockerCpus]);
+  // fields so they never drift from the store's source of truth. The three
+  // values only ever move together (via `save`), so one effect covers them.
+  useEffect(() => {
+    setDraft({ image: dockerImage, memory: dockerMemory, cpus: dockerCpus });
+  }, [dockerImage, dockerMemory, dockerCpus]);
 
   const commit = () => {
-    const [i, m, c] = [image.trim(), memory.trim(), cpus.trim()];
+    const i = draft.image.trim();
+    const m = draft.memory.trim();
+    const c = draft.cpus.trim();
     if (i === dockerImage && m === dockerMemory && c === dockerCpus) return;
     void save(i, m, c);
   };
@@ -74,45 +99,19 @@ function DockerAdvanced() {
 
   return (
     <SetGroup label="Docker sandbox" last>
-      <SetRow
-        title="Container image"
-        sub="Override the built-in agent image. Your image must have Claude Code (`claude`) on PATH and git installed. Leave blank to use Fletch's image (built on the first Docker run)."
-      >
-        <input
-          className="set-text text-base mono"
-          value={image}
-          placeholder="fletch-agent (built-in)"
-          spellCheck={false}
-          onChange={(e) => setImage(e.target.value)}
-          onBlur={commit}
-          onKeyDown={commitOnEnter}
-        />
-      </SetRow>
-      <SetRow
-        title="Memory limit"
-        sub="Passed to `docker run --memory`. Blank uses the default (4g)."
-      >
-        <input
-          className="set-text text-base mono"
-          value={memory}
-          placeholder="4g"
-          spellCheck={false}
-          onChange={(e) => setMemory(e.target.value)}
-          onBlur={commit}
-          onKeyDown={commitOnEnter}
-        />
-      </SetRow>
-      <SetRow title="CPU limit" sub="Passed to `docker run --cpus`. Blank uses the default (2).">
-        <input
-          className="set-text text-base mono"
-          value={cpus}
-          placeholder="2"
-          spellCheck={false}
-          onChange={(e) => setCpus(e.target.value)}
-          onBlur={commit}
-          onKeyDown={commitOnEnter}
-        />
-      </SetRow>
+      {DOCKER_FIELDS.map((f) => (
+        <SetRow key={f.key} title={f.title} sub={f.sub}>
+          <input
+            className="set-text text-base mono"
+            value={draft[f.key]}
+            placeholder={f.placeholder}
+            spellCheck={false}
+            onChange={(e) => setDraft((d) => ({ ...d, [f.key]: e.target.value }))}
+            onBlur={commit}
+            onKeyDown={commitOnEnter}
+          />
+        </SetRow>
+      ))}
     </SetGroup>
   );
 }

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -8,12 +8,14 @@ import { useAppStore } from "@/store";
 import { ContainerAuth } from "./ContainerAuth";
 import { type FeatureItem, SetGroup, SetHead, SetRow, SetSeg, SetToggle } from "./primitives";
 
-// Docker Desktop can take a few seconds to answer after it's launched, so a
-// focus/mount probe that comes back unavailable is retried every
-// PROBE_RETRY_INTERVAL_MS until the daemon answers or PROBE_RETRY_WINDOW_MS
-// elapses — long enough to cover a cold daemon start without polling forever.
-const PROBE_RETRY_INTERVAL_MS = 2_000;
-const PROBE_RETRY_WINDOW_MS = 20_000;
+// Docker Desktop can start or stop while this pane stays open, so we re-probe
+// on a steady interval (plus immediately on mount and on window focus) rather
+// than once. Polling both ways keeps the engine option AND the "selected but
+// unavailable" warning tracking the live daemon: a one-shot or stop-when-
+// available probe would latch a stale state and, e.g., leave the warning
+// hidden after the daemon stops. The backend caches each probe for a few
+// seconds, so a tight interval mostly hits that cache.
+const PROBE_INTERVAL_MS = 3_000;
 
 const SIDE_PANELS: FeatureItem[] = [
   { key: "git", title: "Git", sub: "Branch, file changes, and smart commit / push / PR actions." },
@@ -60,54 +62,20 @@ export function GeneralPane() {
   const dockerProbe = useAppStore((s) => s.dockerProbe);
   const refreshDockerProbe = useAppStore((s) => s.refreshDockerProbe);
 
-  // Probe Docker on open — and again whenever the window regains focus — so the
-  // engine option reflects the live daemon state, including when the user starts
-  // Docker Desktop (as the disabled-option hint suggests) while the pane is open.
-  //
-  // A focus event usually means the user just launched Docker Desktop from the
-  // hint, but the daemon can take several seconds to answer. A single probe
-  // would latch "daemon-down" and leave the option disabled until the next
-  // focus, so we keep re-probing on a short interval for a bounded window,
-  // stopping the moment the daemon answers.
   useEffect(() => {
     let cancelled = false;
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    // Resolver for the in-flight retry sleep, so cleanup (or a superseding run)
-    // can wake it immediately — clearing the timeout alone would leave poll()
-    // awaiting a Promise that never settles, stranding its closure until GC.
-    let wakeSleep: (() => void) | undefined;
-    // Bumped on each poll start so a fresh focus supersedes any in-flight loop
-    // instead of running several concurrent probe loops.
-    let runId = 0;
-
-    const wake = () => {
-      if (timer) clearTimeout(timer);
-      timer = undefined;
-      wakeSleep?.();
-      wakeSleep = undefined;
+    const probe = () => {
+      if (!cancelled) void refreshDockerProbe();
     };
-
-    const poll = async () => {
-      const myRun = ++runId;
-      wake(); // retire any sleep left by the run this one supersedes
-      const deadline = Date.now() + PROBE_RETRY_WINDOW_MS;
-      while (!cancelled && runId === myRun) {
-        const probe = await refreshDockerProbe();
-        if (cancelled || runId !== myRun) return;
-        if (probe.status === "available" || Date.now() >= deadline) return;
-        await new Promise<void>((resolve) => {
-          wakeSleep = resolve;
-          timer = setTimeout(resolve, PROBE_RETRY_INTERVAL_MS);
-        });
-      }
-    };
-
-    void poll();
-    const onFocus = () => void poll();
+    probe(); // immediately on mount
+    const timer = setInterval(probe, PROBE_INTERVAL_MS);
+    // Re-check right away when the window returns (e.g. the user just launched
+    // Docker Desktop from the hint) instead of waiting for the next tick.
+    const onFocus = () => probe();
     window.addEventListener("focus", onFocus);
     return () => {
       cancelled = true;
-      wake(); // resolve the pending sleep so poll() unwinds instead of hanging
+      clearInterval(timer);
       window.removeEventListener("focus", onFocus);
     };
   }, [refreshDockerProbe]);

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -226,6 +226,15 @@ export function GeneralPane() {
             onChange={(v) => void setSandboxEngine(v)}
           />
         </SetRow>
+        {sandboxEngine === "docker" && dockerProbe && !dockerAvailable && (
+          <div className="set-sandbox-warn">
+            Docker is selected but{" "}
+            {dockerProbe.status === "daemon-down" ? "the daemon isn't running" : "isn't installed"}.
+            New agents won't launch until it's available —{" "}
+            {dockerProbe.status === "daemon-down" ? "start" : "install"} Docker Desktop, or switch
+            back to Seatbelt.
+          </div>
+        )}
         <ContainerAuth />
       </SetGroup>
 

--- a/src/components/SettingsScreen/SettingsScreen.css
+++ b/src/components/SettingsScreen/SettingsScreen.css
@@ -501,6 +501,20 @@
 .set-cauth-note {
   color: var(--fg-2);
 }
+/* Inline warning when the selected engine can't be used right now (e.g. a
+   persisted Docker choice whose daemon is down): new agents would fail to
+   launch until it's resolved, so surface it rather than let the Select read as
+   active. Warn-tinted like the other inline banners. */
+.set-sandbox-warn {
+  margin-top: 10px;
+  padding: 8px 10px;
+  background: color-mix(in srgb, var(--warn), var(--bg-0) 86%);
+  border: 1px solid color-mix(in srgb, var(--warn), var(--bg-0) 68%);
+  border-radius: var(--r-md);
+  color: var(--fg-1);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-snug);
+}
 
 /* ── PROVIDERS ───────────────────────────────────────────────────────── */
 .set-checked {


### PR DESCRIPTION
Frontend batch of the post-review fixes. Independent of #358/#359 (no file overlap), based directly on `sandboxing`. `tsc --noEmit` and `biome check` pass.

## B2 — persisted-but-unavailable engine had no signal
`set_sandbox_engine` validates against the probe at set-time, but the choice persists. On a later launch with the daemon down, the Select restored `"docker"`, rendered the option `disabled`, but the **trigger still showed "Docker" as active** — so every new agent got stamped docker and failed at spawn, surfaced only as the crash banner.

GeneralPane now shows an inline warning when docker is selected but the *resolved* probe reports it unavailable (distinguishing "daemon isn't running" from "isn't installed"), gated on the probe having answered so it never flashes during the initial in-flight probe.

## B4 — connect-modal success confirmation was unreachable
`ContainerAuthModal` passed its `onClose` as `useClaudeSetup`'s `onConnected`, so on success the hook ran `setPhase("success")` and then immediately closed the modal — unmounting before the "Connected…" branch and the "Done" button label could render (both were effectively dead code). Dropped the callback: the hook already refreshes the status row itself, so the modal now stays open on success and the user dismisses it.

## B8 — DockerAdvanced field duplication
Three near-identical field blocks (3× `useState` + 3× sync `useEffect` + 3× input) collapsed to a single draft object + a `DOCKER_FIELDS` config array. Behavior-equivalent: the three settings only ever move together via `saveDockerLaunchSettings`, so one reflect-external-changes effect covers them.

Verification: type-check + lint (the panes have no test runner, per the project's own convention); the state/probe logic was traced by hand. A manual visual pass in-app is the remaining check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)