### PR TITLE
fix(sandbox): container auth honors custom CLAUDE_CONFIG_DIR; review nits

### DIFF
--- a/src-tauri/src/sandbox/docker/auth.rs
+++ b/src-tauri/src/sandbox/docker/auth.rs
@@ -41,7 +41,9 @@
 //! Seatbelt agents never see any of this — they keep the user's own login.
 
 use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::fmt;
+use std::path::{Path, PathBuf};
 
 use parking_lot::RwLock;
 
@@ -156,14 +158,32 @@ impl fmt::Debug for ContainerAuth {
     }
 }
 
+/// The config dir whose `.credentials.json` claude reads: the explicit
+/// `CLAUDE_CONFIG_DIR` if set, else `~/.claude`. Pure over its inputs so the
+/// resolution is unit-testable without touching process env or `$HOME`.
+fn credentials_config_dir(config_dir_env: Option<&OsStr>, home: Option<&Path>) -> Option<PathBuf> {
+    config_dir_env
+        .map(PathBuf::from)
+        .or_else(|| home.map(|h| h.join(".claude")))
+}
+
 /// Walk the auth chain (first hit wins). Called by the docker launch path at
 /// spawn time and, via [`status`], by the settings UI. May block on the first
 /// call: the login-shell env is loaded (a shell runs) if nothing earlier
 /// populated `bin_resolve`'s cache.
 pub fn resolve() -> ContainerAuth {
     let keychain = keychain_token();
-    let credentials_file = dirs::home_dir().is_some_and(|home| {
-        credentials_file_usable(std::fs::read(home.join(".claude/.credentials.json")).ok().as_deref())
+    // Check the config dir claude will actually read from — the explicit
+    // `CLAUDE_CONFIG_DIR` if set, else `~/.claude` — which is also the dir the
+    // engine mounts (see `nondefault_claude_config_dir`). Hardcoding `~/.claude`
+    // would refuse a container whose only credential is a `.credentials.json`
+    // living in a custom config dir.
+    let credentials_file = credentials_config_dir(
+        std::env::var_os("CLAUDE_CONFIG_DIR").as_deref(),
+        dirs::home_dir().as_deref(),
+    )
+    .is_some_and(|dir| {
+        credentials_file_usable(std::fs::read(dir.join(".credentials.json")).ok().as_deref())
     });
     let process_env: HashMap<String, String> = SHELL_AUTH_VARS
         .iter()
@@ -572,6 +592,24 @@ mod tests {
             resolve_from(None, None, Some(&shell), false),
             ContainerAuth::Unavailable
         ));
+    }
+
+    #[test]
+    fn credentials_config_dir_honors_claude_config_dir() {
+        let home = Path::new("/Users/u");
+        // Unset → the default `~/.claude`.
+        assert_eq!(
+            credentials_config_dir(None, Some(home)),
+            Some(PathBuf::from("/Users/u/.claude"))
+        );
+        // A custom `CLAUDE_CONFIG_DIR` is used verbatim — this is the dir claude
+        // reads its `.credentials.json` from and the one the engine mounts.
+        assert_eq!(
+            credentials_config_dir(Some(OsStr::new("/cfg/eve")), Some(home)),
+            Some(PathBuf::from("/cfg/eve"))
+        );
+        // No env and no home → nothing to check.
+        assert_eq!(credentials_config_dir(None, None), None);
     }
 
     #[test]

--- a/src-tauri/src/sandbox/docker/engine.rs
+++ b/src-tauri/src/sandbox/docker/engine.rs
@@ -396,10 +396,14 @@ fn non_blank(value: Option<&str>) -> Option<&str> {
 /// non-default dir, so the mount/forward stay at the host path (invariant 1).
 fn nondefault_claude_config_dir(home: &Path) -> Option<PathBuf> {
     let dir = std::env::var_os("CLAUDE_CONFIG_DIR").map(PathBuf::from)?;
-    if resolve_existing_prefix(&dir) == resolve_existing_prefix(&home.join(".claude")) {
-        return None;
-    }
-    Some(dir)
+    (!config_dir_is_default(&dir, home)).then_some(dir)
+}
+
+/// Whether `dir` resolves to the default `~/.claude`. Both sides go through
+/// [`resolve_existing_prefix`] — see [`nondefault_claude_config_dir`] for why.
+/// Pure over its inputs so the comparison rule is directly testable.
+fn config_dir_is_default(dir: &Path, home: &Path) -> bool {
+    resolve_existing_prefix(dir) == resolve_existing_prefix(&home.join(".claude"))
 }
 
 /// Every object store borrowed via git alternates by any checkout under the
@@ -1132,11 +1136,31 @@ mod tests {
     }
 
     #[test]
-    fn nondefault_config_dir_rules_match_seatbelt() {
-        // Pure check of the comparison rule (the env var itself is process
-        // state; tests must not mutate it).
-        let home = Path::new("/Users/u");
-        assert_eq!(home.join(".claude"), Path::new("/Users/u/.claude"));
+    fn config_dir_is_default_canonicalizes_both_sides() {
+        let td = tempfile::tempdir().unwrap();
+        let home = td.path();
+        let default = home.join(".claude");
+        std::fs::create_dir_all(&default).unwrap();
+
+        // The literal default, and its trailing-slash spelling, are default.
+        assert!(config_dir_is_default(&default, home));
+        assert!(config_dir_is_default(&home.join(".claude/"), home));
+        // A genuinely different dir is not.
+        assert!(!config_dir_is_default(&home.join(".claude-eve"), home));
+
+        // A symlink that resolves to the default is treated as default — the
+        // both-sides canonicalization this test exists to prove. (On macOS the
+        // tempdir itself lives under a `/var`→`/private/var` symlink, so the
+        // home side is exercised too.)
+        #[cfg(unix)]
+        {
+            let link = home.join("link-to-claude");
+            std::os::unix::fs::symlink(&default, &link).unwrap();
+            assert!(
+                config_dir_is_default(&link, home),
+                "a symlink resolving to ~/.claude must read as default"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/sandbox/engine.rs
+++ b/src-tauri/src/sandbox/engine.rs
@@ -79,6 +79,13 @@ pub enum KillHandle {
 impl KillHandle {
     /// Engine-side teardown. Callers still run their local child kill after
     /// this — for containers the local child is just the attached CLI.
+    ///
+    /// Note the `Result` is only the *engine* teardown's outcome. Sessions run
+    /// their local child/process-group kill unconditionally regardless of it,
+    /// but each combines the two differently: `pty_session` surfaces a local
+    /// kill failure too, while `managed`/`exec` treat the local child as
+    /// best-effort and return this engine result alone. So a caller can't read a
+    /// uniform meaning from `kill()`'s `Result` across the spawn shapes.
     pub fn kill(&self) -> Result<()> {
         match self {
             Self::ProcessGroup => Ok(()),

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -55,7 +55,7 @@ impl SandboxEngine for SandboxExecEngine {
             keepalive: Keepalive::Profile(profile_file),
             // sandbox-exec is a plain process wrapper — the session's own
             // process-group escalation tears everything down; the trait's
-            // default no-op kill/is_alive apply.
+            // default no-op `kill` applies.
             kill: KillHandle::ProcessGroup,
         })
     }
@@ -305,16 +305,15 @@ pub fn build_profile(
     // A non-default `CLAUDE_CONFIG_DIR` is where claude actually writes its
     // config/transcripts/auth, so grant it too. Resolve symlinks first so the
     // SBPL path matches what the sandbox sees at write time (every other entry
-    // is canonical); then skip it only when it equals the *raw* default
-    // `{home}/.claude` granted above (`claude_state`), to avoid a redundant
-    // entry. Compare against the raw default deliberately — do NOT canonicalize
-    // this side: `claude_state` grants the raw path, so if a resolved config dir
-    // differs from it we must still add the extra grant. If `~/.claude` is
-    // itself a symlink and the config dir points at its resolved target,
-    // canonicalizing here would treat it as default and drop the grant, yet the
-    // raw `claude_state` rule wouldn't cover the target — denying claude's
-    // writes. (Docker can canonicalize both sides because its `~/.claude` bind
-    // mount follows the symlink source; the SBPL allow-list can't.)
+    // is canonical); then skip it only when it equals the default `{home}/.claude`
+    // granted above (`claude_state`), to avoid a redundant entry. `home` is
+    // already canonical, but the `.claude` leaf is NOT symlink-resolved —
+    // `claude_state` grants that literal path — so compare against it un-resolved.
+    // If `~/.claude` is itself a symlink and the config dir points at its
+    // resolved target, resolving the leaf here too would treat it as default and
+    // drop the grant, yet the literal `claude_state` rule wouldn't cover the
+    // target, denying claude's writes. (Docker can resolve both sides because its
+    // `~/.claude` bind mount follows the symlink source; the SBPL allow-list can't.)
     let claude_config_extra = claude_config_dir
         .map(resolve_existing_prefix)
         .map(|p| p.to_string_lossy().into_owned())

--- a/src-tauri/src/supervisor/disposition.rs
+++ b/src-tauri/src/supervisor/disposition.rs
@@ -418,3 +418,36 @@ async fn teardown_agent_worktrees(agent_id: &str, repos: &[TrackedRepo], op: &st
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn git(repo: &Path, args: &[&str]) {
+        let out = std::process::Command::new("git")
+            .current_dir(repo)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    #[tokio::test]
+    async fn source_has_origin_reflects_the_remote() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path();
+        git(repo, &["init", "-q", "-b", "main"]);
+        // A fresh repo has no `origin` — a clone-mode tip that's gone from the
+        // object store here is genuinely unrecoverable, so the restore
+        // pre-flight must reject it rather than fail later inside `fetch_branch`.
+        assert!(!source_has_origin(repo).await);
+        // Adding a remote flips it.
+        git(repo, &["remote", "add", "origin", "https://example.com/x.git"]);
+        assert!(source_has_origin(repo).await);
+    }
+}


### PR DESCRIPTION
Round-2 review fixes. Off `sandboxing` (all prior sandbox PRs merged), so the diff is just these five files. `cargo test` (99 sandbox + 20 supervisor) and clippy pass.

## Correctness — container auth ignored a custom `CLAUDE_CONFIG_DIR`
`auth::resolve()`'s credentials-file step hardcoded `~/.claude/.credentials.json`, but the engine mounts (and claude reads from) `$CLAUDE_CONFIG_DIR` when it's set. So a host whose **only** credential is a `.credentials.json` in a custom config dir — no Keychain login, no shell creds — was refused with the "not connected" CTA even though the mounted dir would authenticate. Now checks the dir claude actually reads from (`CLAUDE_CONFIG_DIR` or `~/.claude`), via a pure, unit-tested `credentials_config_dir` helper.

## Docs
- Dropped the stale `is_alive` reference in seatbelt's kill comment (that trait method was removed in the cleanup pass).
- Tightened the seatbelt config-dir comment — `home` is already canonicalized, so only the `.claude` leaf is literal (the old "raw default" wording overstated it, and this line has flip-flopped before).
- Added a note on `KillHandle::kill` that its `Result` is the engine teardown's alone and is combined differently per spawn shape (pty surfaces local failures; managed/exec treat the local child as best-effort).

## Tests
- Replaced the mis-named `nondefault_config_dir_rules_match_seatbelt` (which asserted nothing about the actual rule) with `config_dir_is_default_canonicalizes_both_sides` — extracts a pure `config_dir_is_default` helper and exercises the both-sides comparison, including a symlink that resolves to the default.
- Added `source_has_origin_reflects_the_remote` covering the clone-mode restore pre-flight.

## Not included (your call)
The `ANTHROPIC_AUTH_TOKEN` gateway-auth coherence gap (docker refuses gateway-bearer-only setups that seatbelt accepts; and a gateway `BASE_URL`+`AUTH_TOKEN` forwards only the URL) is held pending your decision on whether gateway-only is a supported docker configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)