### PR TITLE
feat(sidebar): drag-to-reorder projects with localStorage persistence

### DIFF
--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -28,6 +28,7 @@ import {
   GitCommitHorizontal,
   GitMerge,
   GitPullRequest,
+  GripVertical,
   Hand,
   History,
   Inbox,
@@ -150,6 +151,7 @@ const ICON_COMPONENTS = {
   zap: Zap,
   clock: Clock,
   hand: Hand,
+  grip: GripVertical,
 } satisfies Record<string, ComponentType<IconComponentProps>>;
 
 // Originally rendered with fill="currentColor". Setting fill on the root SVG

--- a/src/components/Sidebar/ProjectGroup.tsx
+++ b/src/components/Sidebar/ProjectGroup.tsx
@@ -1,4 +1,5 @@
 import { ask } from "@tauri-apps/plugin-dialog";
+import { useRef } from "react";
 import type { AgentRecord } from "@/api";
 import { Icon } from "@/components/Icon";
 import type { DraftAgent } from "@/store";
@@ -70,14 +71,30 @@ export function ProjectGroup({
 
   const dropClass = dropIndicator ? `drop-${dropIndicator}` : "";
 
+  // A native drag that ends on the header dispatches a trailing `click` in some
+  // browsers, which would toggle the group open/closed after a reorder. Track
+  // whether the current interaction turned into a drag (set on dragstart, reset
+  // when a fresh press begins) and swallow that phantom click.
+  const draggedRef = useRef(false);
+
   return (
     <div className={`proj ${dragging ? "dragging" : ""} ${dropClass}`}>
       <div
         className={`proj-h flex-center ${open ? "open" : ""} ${reorderable ? "reorderable" : ""}`}
-        onClick={onToggle}
+        onMouseDown={() => {
+          draggedRef.current = false;
+        }}
+        onClick={() => {
+          if (draggedRef.current) {
+            draggedRef.current = false;
+            return;
+          }
+          onToggle();
+        }}
         title={repoPath}
         draggable={reorderable}
         onDragStart={(e) => {
+          draggedRef.current = true;
           // Marks the drag as a move; the payload itself is tracked in React state.
           e.dataTransfer.effectAllowed = "move";
           e.dataTransfer.setData("text/plain", repoPath);

--- a/src/components/Sidebar/ProjectGroup.tsx
+++ b/src/components/Sidebar/ProjectGroup.tsx
@@ -17,6 +17,16 @@ interface Props {
   /** Show the remove (×) button — only true when this is a pinned-but-empty group. */
   removable: boolean;
   onToggle: () => void;
+  /** Whether this group can be dragged to reorder (disabled while searching). */
+  reorderable: boolean;
+  /** This group is the one currently being dragged. */
+  dragging: boolean;
+  /** Show a drop line above ("before") or below ("after") this group, or none. */
+  dropIndicator: "before" | "after" | null;
+  onDragStart: () => void;
+  onDragEnterGroup: () => void;
+  onDropGroup: () => void;
+  onDragEndGroup: () => void;
 }
 
 export function ProjectGroup({
@@ -27,6 +37,13 @@ export function ProjectGroup({
   open,
   removable,
   onToggle,
+  reorderable,
+  dragging,
+  dropIndicator,
+  onDragStart,
+  onDragEnterGroup,
+  onDropGroup,
+  onDragEndGroup,
 }: Props) {
   const selectedAgentId = useAppStore((s) => s.selectedAgentId);
   const activeDraftId = useAppStore((s) => s.activeDraftId);
@@ -51,13 +68,41 @@ export function ProjectGroup({
     createDraft(repoPath);
   }
 
+  const dropClass = dropIndicator ? `drop-${dropIndicator}` : "";
+
   return (
-    <div className="proj">
+    <div className={`proj ${dragging ? "dragging" : ""} ${dropClass}`}>
       <div
-        className={`proj-h flex-center ${open ? "open" : ""}`}
+        className={`proj-h flex-center ${open ? "open" : ""} ${reorderable ? "reorderable" : ""}`}
         onClick={onToggle}
         title={repoPath}
+        draggable={reorderable}
+        onDragStart={(e) => {
+          // Marks the drag as a move; the payload itself is tracked in React state.
+          e.dataTransfer.effectAllowed = "move";
+          e.dataTransfer.setData("text/plain", repoPath);
+          onDragStart();
+        }}
+        onDragEnter={reorderable ? onDragEnterGroup : undefined}
+        onDragOver={
+          reorderable
+            ? (e) => {
+                e.preventDefault();
+                e.dataTransfer.dropEffect = "move";
+              }
+            : undefined
+        }
+        onDrop={
+          reorderable
+            ? (e) => {
+                e.preventDefault();
+                onDropGroup();
+              }
+            : undefined
+        }
+        onDragEnd={reorderable ? onDragEndGroup : undefined}
       >
+        {reorderable && <Icon name="grip" size={12} className="pgrip" />}
         <Icon name="chevR" size={10} className="chev" />
         <span className="pname">{label}</span>
         <span className="pcount">{count}</span>

--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -75,6 +75,29 @@
 
 .proj {
   margin-bottom: 16px;
+  position: relative;
+}
+/* Dim the group while it's being dragged to a new position. */
+.proj.dragging {
+  opacity: 0.4;
+}
+/* Insertion line shown on the group under the drag pointer. */
+.proj.drop-before::before,
+.proj.drop-after::after {
+  content: "";
+  position: absolute;
+  left: 6px;
+  right: 6px;
+  height: 2px;
+  border-radius: 1px;
+  background: var(--accent);
+  pointer-events: none;
+}
+.proj.drop-before::before {
+  top: -8px;
+}
+.proj.drop-after::after {
+  bottom: -8px;
 }
 .proj-h {
   gap: 6px;
@@ -91,6 +114,26 @@
 }
 .proj-h:hover {
   background: var(--hover);
+}
+.proj-h.reorderable {
+  cursor: grab;
+}
+.proj-h.reorderable:active {
+  cursor: grabbing;
+}
+/* Drag affordance: a muted grip that firms up on hover. Fixed-width slot so
+ * showing it doesn't shift the project name. */
+.proj-h .pgrip {
+  flex-shrink: 0;
+  width: 12px;
+  height: 12px;
+  margin-left: -4px;
+  color: var(--fg-3);
+  opacity: 0.35;
+  transition: opacity 0.1s;
+}
+.proj-h:hover .pgrip {
+  opacity: 0.9;
 }
 .proj-h .chev {
   width: 10px;

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -9,6 +9,7 @@ import { NewProjectPopover } from "./NewProjectPopover";
 import { ProjectGroup } from "./ProjectGroup";
 import { SidebarFooter } from "./SidebarFooter";
 import { SidebarHeader } from "./SidebarHeader";
+import { useProjectReorder } from "./useProjectReorder";
 
 interface RepoGroup {
   repoPath: string;
@@ -75,6 +76,12 @@ export function Sidebar() {
   const [openMap, setOpenMap] = useState<Record<string, boolean>>({});
   const [npOpen, setNpOpen] = useState(false);
   const [npMode, setNpMode] = useState<NewProjectMode | null>(null);
+  // Transient drag state for reordering: the group being dragged and the one
+  // currently hovered as a drop target.
+  const [dragPath, setDragPath] = useState<string | null>(null);
+  const [overPath, setOverPath] = useState<string | null>(null);
+
+  const { sortPaths, reorder } = useProjectReorder();
 
   const liveAgents = useMemo(
     () =>
@@ -84,11 +91,26 @@ export function Sidebar() {
         .sort((a, b) => (a.created_at < b.created_at ? 1 : -1)),
     [workspace?.agents],
   );
-  const groups = useMemo(
-    () => groupByRepo(workspace?.repos ?? [], liveAgents, drafts),
-    [workspace?.repos, liveAgents, drafts],
-  );
+  const groups = useMemo(() => {
+    const built = groupByRepo(workspace?.repos ?? [], liveAgents, drafts);
+    const order = sortPaths(built.map((g) => g.repoPath));
+    const byPath = new Map(built.map((g) => [g.repoPath, g]));
+    return order.map((p) => byPath.get(p)).filter((g): g is RepoGroup => g !== undefined);
+  }, [workspace?.repos, liveAgents, drafts, sortPaths]);
   const filtered = useMemo(() => applySearch(groups, query), [groups, query]);
+
+  // Reordering is only meaningful over the full, unfiltered list.
+  const reorderable = !query.trim();
+  const orderedPaths = useMemo(() => groups.map((g) => g.repoPath), [groups]);
+
+  function endDrag() {
+    setDragPath(null);
+    setOverPath(null);
+  }
+  function onDrop(target: string) {
+    if (dragPath) reorder(orderedPaths, dragPath, target);
+    endDrag();
+  }
 
   // Auto-expand a project when its agent or draft is selected.
   useEffect(() => {
@@ -125,18 +147,32 @@ export function Sidebar() {
               <div>{query ? "Try a different search." : "Add a repo to get started."}</div>
             </div>
           ) : (
-            filtered.map((g) => (
-              <ProjectGroup
-                key={g.repoPath}
-                label={basename(g.repoPath)}
-                repoPath={g.repoPath}
-                agents={g.agents}
-                drafts={g.drafts}
-                open={openMap[g.repoPath] ?? false}
-                removable={g.pinned && g.agents.length === 0 && g.drafts.length === 0}
-                onToggle={() => setOpenMap((m) => ({ ...m, [g.repoPath]: !m[g.repoPath] }))}
-              />
-            ))
+            filtered.map((g) => {
+              const isOver = reorderable && overPath === g.repoPath && dragPath !== g.repoPath;
+              const dropAfter =
+                isOver &&
+                dragPath != null &&
+                orderedPaths.indexOf(dragPath) < orderedPaths.indexOf(g.repoPath);
+              return (
+                <ProjectGroup
+                  key={g.repoPath}
+                  label={basename(g.repoPath)}
+                  repoPath={g.repoPath}
+                  agents={g.agents}
+                  drafts={g.drafts}
+                  open={openMap[g.repoPath] ?? false}
+                  removable={g.pinned && g.agents.length === 0 && g.drafts.length === 0}
+                  onToggle={() => setOpenMap((m) => ({ ...m, [g.repoPath]: !m[g.repoPath] }))}
+                  reorderable={reorderable}
+                  dragging={dragPath === g.repoPath}
+                  dropIndicator={isOver ? (dropAfter ? "after" : "before") : null}
+                  onDragStart={() => setDragPath(g.repoPath)}
+                  onDragEnterGroup={() => setOverPath(g.repoPath)}
+                  onDropGroup={() => onDrop(g.repoPath)}
+                  onDragEndGroup={endDrag}
+                />
+              );
+            })
           )}
         </div>
       </div>

--- a/src/components/Sidebar/useProjectReorder.ts
+++ b/src/components/Sidebar/useProjectReorder.ts
@@ -1,0 +1,27 @@
+import { useCallback, useState } from "react";
+import {
+  loadProjectOrder,
+  moveInOrder,
+  saveProjectOrder,
+  sortByOrder,
+} from "@/storage/projectOrder";
+
+/** Manual, localStorage-persisted ordering for sidebar project groups.
+ *
+ *  `sortPaths` orders a set of repo paths by the saved order; paths absent from
+ *  it keep their natural order and sort last, so newly-added projects append at
+ *  the bottom. `reorder` moves one path relative to another and persists the
+ *  resulting full order. */
+export function useProjectReorder() {
+  const [order, setOrder] = useState<string[]>(loadProjectOrder);
+
+  const sortPaths = useCallback((paths: string[]) => sortByOrder(paths, order), [order]);
+
+  const reorder = useCallback((visiblePaths: string[], from: string, to: string) => {
+    const next = moveInOrder(visiblePaths, from, to);
+    setOrder(next);
+    saveProjectOrder(next);
+  }, []);
+
+  return { sortPaths, reorder };
+}

--- a/src/storage/projectOrder.ts
+++ b/src/storage/projectOrder.ts
@@ -1,0 +1,61 @@
+// Client-side persistence for the user's manual sidebar project ordering.
+// Stored in localStorage (not the Tauri settings db) so reordering needs no
+// backend migration — it's a purely cosmetic, per-machine preference keyed by
+// repo path. Matches the app's `q2:` localStorage key convention.
+
+const PROJECT_ORDER_KEY = "q2:projectOrder";
+
+/** Read the saved repo-path order. Returns [] on a missing or corrupt value. */
+export function loadProjectOrder(): string[] {
+  try {
+    const raw = localStorage.getItem(PROJECT_ORDER_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((p): p is string => typeof p === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Persist the repo-path order. Write failures (private mode / quota) are ignored. */
+export function saveProjectOrder(order: string[]): void {
+  try {
+    localStorage.setItem(PROJECT_ORDER_KEY, JSON.stringify(order));
+  } catch {
+    // best-effort — ordering is non-critical cosmetic state
+  }
+}
+
+/** Order `paths` by their index in the saved `order`. Paths absent from `order`
+ *  keep their incoming relative order and sort after all known paths, so a
+ *  newly-added project appears at the bottom rather than jumping to the top. */
+export function sortByOrder(paths: string[], order: string[]): string[] {
+  const rank = new Map(order.map((p, i) => [p, i]));
+  return paths
+    .map((p, i) => ({ p, i }))
+    .sort((a, b) => {
+      const ra = rank.get(a.p);
+      const rb = rank.get(b.p);
+      if (ra === undefined && rb === undefined) return a.i - b.i;
+      if (ra === undefined) return 1;
+      if (rb === undefined) return -1;
+      return ra - rb;
+    })
+    .map((x) => x.p);
+}
+
+/** Move `from` to `to`'s position within the already-ordered `visiblePaths`,
+ *  returning the new full order. Dragging downward (from before to) drops after
+ *  the target; dragging upward drops before it. Returns the input unchanged if
+ *  either path is missing or they're identical. */
+export function moveInOrder(visiblePaths: string[], from: string, to: string): string[] {
+  if (from === to) return visiblePaths;
+  const fromIdx = visiblePaths.indexOf(from);
+  const toIdx = visiblePaths.indexOf(to);
+  if (fromIdx < 0 || toIdx < 0) return visiblePaths;
+  const next = visiblePaths.filter((p) => p !== from);
+  const targetIdx = next.indexOf(to);
+  const insertAt = fromIdx < toIdx ? targetIdx + 1 : targetIdx;
+  next.splice(insertAt, 0, from);
+  return next;
+}

--- a/tests/storage/projectOrder.test.ts
+++ b/tests/storage/projectOrder.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { moveInOrder, sortByOrder } from "@/storage/projectOrder";
+
+describe("sortByOrder", () => {
+  it("orders paths by their index in the saved order", () => {
+    expect(sortByOrder(["/a", "/b", "/c"], ["/c", "/a", "/b"])).toEqual(["/c", "/a", "/b"]);
+  });
+
+  it("appends paths missing from the saved order, keeping their natural order", () => {
+    // /b and /c are known; /new and /new2 are unseen and sort last, in order.
+    expect(sortByOrder(["/new", "/b", "/new2", "/c"], ["/c", "/b"])).toEqual([
+      "/c",
+      "/b",
+      "/new",
+      "/new2",
+    ]);
+  });
+
+  it("falls back to natural order when nothing is saved", () => {
+    expect(sortByOrder(["/a", "/b"], [])).toEqual(["/a", "/b"]);
+  });
+
+  it("ignores saved paths that no longer exist", () => {
+    expect(sortByOrder(["/a", "/b"], ["/gone", "/b", "/a"])).toEqual(["/b", "/a"]);
+  });
+});
+
+describe("moveInOrder", () => {
+  it("drops after the target when dragging downward", () => {
+    expect(moveInOrder(["/a", "/b", "/c", "/d"], "/a", "/c")).toEqual(["/b", "/c", "/a", "/d"]);
+  });
+
+  it("drops before the target when dragging upward", () => {
+    expect(moveInOrder(["/a", "/b", "/c", "/d"], "/d", "/b")).toEqual(["/a", "/d", "/b", "/c"]);
+  });
+
+  it("is a no-op when source and target are the same", () => {
+    expect(moveInOrder(["/a", "/b"], "/a", "/a")).toEqual(["/a", "/b"]);
+  });
+
+  it("returns the input unchanged when a path is missing", () => {
+    expect(moveInOrder(["/a", "/b"], "/x", "/b")).toEqual(["/a", "/b"]);
+  });
+});


### PR DESCRIPTION
Adds subtle, intuitive drag-to-reorder for projects in the sidebar. Project order is persisted in `localStorage` (key `q2:projectOrder`) so it survives restarts without a DB migration.

## UX
- Each project header shows a muted grip handle on the left that firms up on hover, plus a grab cursor.
- Dragging a project shows a thin accent-colored insertion line where it will land (above when dragging up, below when dragging down); the dragged row dims while in flight.
- New projects append at the bottom rather than disturbing the saved arrangement.
- Reordering is disabled while searching (the list is filtered, so it would not be meaningful).

## Implementation
- `src/storage/projectOrder.ts` — `load/saveProjectOrder` plus pure helpers `sortByOrder` and `moveInOrder`.
- `src/components/Sidebar/useProjectReorder.ts` — thin hook wiring the helpers to React state + persistence.
- `src/components/Sidebar/index.tsx` — applies saved order, holds transient drag state, computes drop indicator.
- `src/components/Sidebar/ProjectGroup.tsx` — native HTML5 drag handlers + grip handle.
- `src/components/Sidebar/Sidebar.css` — grip, grab cursor, dragging dim, drop-line styles.
- `src/components/Icon.tsx` — added the `grip` icon.
- `tests/storage/projectOrder.test.ts` — 8 unit tests for the ordering/move semantics.

Uses native HTML5 drag-and-drop (no new dependency).

## Verification
- `tsc --noEmit` clean, `biome check` clean on changed files, `vite build` succeeds.
- Test suite: 344 existing + 8 new tests pass.

## Note
Order is per-machine (localStorage), so it does not sync across devices — the intended trade-off to avoid a DB migration for now. Easy to promote to the Tauri settings store later if syncing is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)