### PR TITLE
feat(docker): support Codex agents in Docker sandboxes

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -819,11 +819,12 @@ impl Agent {
         let home =
             dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
         let engine = sandbox::engine_for(spec.engine)?;
-        let claude = claude_bin_for(engine.as_ref(), &home)?;
+        let claude = agent_bin_for("claude", "claude", "Claude Code", engine.as_ref(), &home)?;
         let agent_args = prepare_pty_args(&spec);
 
         let ctx = AgentLaunchCtx {
             agent_id: spec.agent_id,
+            provider: "claude",
             writable_root: &spec.sandbox_root,
             rpc_dir: &spec.rpc_dir,
             cwd: &spec.cwd,
@@ -889,7 +890,10 @@ impl Agent {
             .ok_or_else(|| Error::Other(format!("no per-turn descriptor for `{provider}`")))?;
         let home =
             dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
-        let bin = resolve_agent_bin(desc.id, desc.bin, desc.label, &home)?;
+        let engine = sandbox::engine_for(spec.engine)?;
+        // Under docker this is the provider's in-image bin (`codex`); under
+        // seatbelt the host-resolved path — same decision claude makes.
+        let bin = agent_bin_for(desc.id, desc.bin, desc.label, engine.as_ref(), &home)?;
         let session = if spec.fresh {
             None
         } else {
@@ -902,6 +906,7 @@ impl Agent {
         // agents are confined exactly like claude.
         let ctx = AgentLaunchCtx {
             agent_id: spec.agent_id,
+            provider,
             writable_root: &spec.sandbox_root,
             rpc_dir: &spec.rpc_dir,
             cwd: &spec.cwd,
@@ -914,7 +919,7 @@ impl Agent {
             env: launch_env,
             keepalive,
             kill,
-        } = sandbox::engine_for(spec.engine)?.launch_agent(&ctx, &bin)?;
+        } = engine.launch_agent(&ctx, &bin)?;
         let mut args = prefix_args;
         args.extend(agent_args);
         let mut env = launch_env;
@@ -957,11 +962,12 @@ impl Agent {
         let home =
             dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
         let engine = sandbox::engine_for(spec.engine)?;
-        let claude = claude_bin_for(engine.as_ref(), &home)?;
+        let claude = agent_bin_for("claude", "claude", "Claude Code", engine.as_ref(), &home)?;
         let agent_args = prepare_managed_args(&spec);
 
         let ctx = AgentLaunchCtx {
             agent_id: spec.agent_id,
+            provider: "claude",
             writable_root: &spec.sandbox_root,
             rpc_dir: &spec.rpc_dir,
             cwd: &spec.cwd,
@@ -1025,13 +1031,19 @@ impl Agent {
     {
         let home = dirs::home_dir()
             .ok_or_else(|| Error::Other("HOME directory not available".into()))?;
-        let program = PathBuf::from(resolve_agent_bin(desc.id, desc.bin, desc.label, &home)?);
+        // Under docker this resolves to the provider's in-image bin (`codex`);
+        // under seatbelt the host path — same decision claude makes. Resolved
+        // here (not in `spawn_exec`) since the agent bin is provider-specific.
+        let engine = sandbox::engine_for(spec.engine)?;
+        let program =
+            PathBuf::from(agent_bin_for(desc.id, desc.bin, desc.label, engine.as_ref(), &home)?);
         // A custom agent's standing brief is constant for the session, so bind
         // it into the per-turn args builder once here rather than threading it
         // through every turn. `ExecSession` keeps calling a 4-arg builder.
         let build_args = desc.build_args;
         let extra = spec.instructions.clone();
         Self::spawn_exec(
+            desc.id,
             program,
             spec,
             move |prompt, session_id, thinking, model| {
@@ -1054,6 +1066,7 @@ impl Agent {
     /// failed turn that never emits an in-band turn-end still leaves the
     /// agent promptly.
     fn spawn_exec<A, I, F, G, H>(
+        provider: &str,
         program: PathBuf,
         spec: PerTurnSpec,
         build_args: A,
@@ -1076,6 +1089,7 @@ impl Agent {
 
         let ctx = AgentLaunchCtx {
             agent_id: &spec.agent_id,
+            provider,
             writable_root: &spec.sandbox_root,
             rpc_dir: &spec.rpc_dir,
             cwd: &spec.cwd,
@@ -1288,22 +1302,31 @@ fn prepare_managed_args(spec: &SpawnSpec<'_>) -> Vec<String> {
     args
 }
 
-fn resolve_claude(home: &Path) -> Result<String> {
-    resolve_agent_bin("claude", "claude", "Claude Code", home)
-}
-
-/// The claude binary handed to `launch_agent`, decided by the *resolved*
-/// engine's kind: under docker it's the in-image name `claude` (the image
-/// carries its own install; a resolved host path would be meaningless — or
-/// missing — inside the container), under seatbelt the host-resolved
-/// absolute path as always. Keyed off the resolved engine rather than the
-/// stamped setting; a docker-stamped agent whose daemon is down never reaches
-/// here — `sandbox::engine_for` fails the spawn instead of degrading to
+/// The agent binary handed to `launch_agent`, decided by the *resolved*
+/// engine's kind: under docker it's the provider's in-image command name
+/// (`claude` / `codex` — the image carries its own install; a resolved host path
+/// would be meaningless, or missing, inside the container), under seatbelt the
+/// host-resolved absolute path as always. Keyed off the resolved engine rather
+/// than the stamped setting; a docker-stamped agent whose daemon is down never
+/// reaches here — `sandbox::engine_for` fails the spawn instead of degrading to
 /// seatbelt — so the resolved engine always matches the launch boundary.
-fn claude_bin_for(engine: &dyn SandboxEngine, home: &Path) -> Result<String> {
+///
+/// Docker reaches here only for a provider `DockerProvider::from_id` accepts
+/// (the `supervisor::lifecycle` gate ran first), so the `None` arm is defensive.
+fn agent_bin_for(
+    provider: &str,
+    bin: &str,
+    label: &str,
+    engine: &dyn SandboxEngine,
+    home: &Path,
+) -> Result<String> {
     match engine.kind() {
-        EngineKind::Docker => Ok("claude".to_string()),
-        EngineKind::SandboxExec => resolve_claude(home),
+        EngineKind::Docker => sandbox::docker::DockerProvider::from_id(provider)
+            .map(|p| p.image_bin().to_string())
+            .ok_or_else(|| {
+                Error::Other(format!("{label} isn't available in Docker sandboxes yet"))
+            }),
+        EngineKind::SandboxExec => resolve_agent_bin(provider, bin, label, home),
     }
 }
 

--- a/src-tauri/src/sandbox/docker/engine.rs
+++ b/src-tauri/src/sandbox/docker/engine.rs
@@ -312,14 +312,8 @@ impl SandboxEngine for DockerEngine {
                 // Codex's config dir is bind-mounted read-write: auth.json token
                 // refresh and the session rollout files it writes both need to
                 // persist, and writing rollouts at the same host path keeps the
-                // host-side transcript reader (`find_codex_rollouts`) working. If
-                // it doesn't exist the user has never logged in on the host, so
-                // there'd be nothing to authenticate with — fail fast with a
-                // clear pointer rather than mounting an empty dir.
+                // host-side transcript reader (`find_codex_rollouts`) working.
                 let dir = codex_home_dir(ctx.home);
-                if !dir.is_dir() {
-                    return Err(Error::Other(NO_CODEX_CONFIG_MSG.to_string()));
-                }
                 // Forward CODEX_HOME only when it points somewhere other than the
                 // default `~/.codex` the container already resolves via HOME —
                 // mirrors `nondefault_claude_config_dir`.
@@ -329,7 +323,11 @@ impl SandboxEngine for DockerEngine {
                 }
 
                 auth_start = env.len();
-                apply_codex_auth(&mut env, &dir)?;
+                prepare_codex_launch(
+                    &mut env,
+                    &dir,
+                    std::env::var("OPENAI_API_KEY").ok().as_deref(),
+                )?;
                 codex_config_dir = Some(dir);
             }
         }
@@ -432,13 +430,8 @@ fn apply_container_auth(env: &mut Vec<(String, String)>, auth: ContainerAuth) ->
     }
 }
 
-/// Launch-blocking message when codex's config dir doesn't exist on the host:
-/// there's no login to carry in, so authentication would be impossible.
-const NO_CODEX_CONFIG_MSG: &str =
-    "No Codex config for containers — run `codex` on the host and sign in first (this creates ~/.codex).";
-
-/// Launch-blocking message when codex's config dir exists but carries no usable
-/// credential (no `auth.json`) and `OPENAI_API_KEY` is unset. Mirrors
+/// Launch-blocking message when codex has no usable credential: no
+/// `auth.json` in its config dir and `OPENAI_API_KEY` unset. Mirrors
 /// [`NO_CONTAINER_AUTH_MSG`]'s fail-fast: an unauthenticated container boots
 /// straight into a login prompt it can't answer inside the sandbox.
 const NO_CODEX_AUTH_MSG: &str =
@@ -464,19 +457,27 @@ fn codex_home_is_nondefault(home: &Path) -> bool {
     }
 }
 
-/// Fold codex's container auth into the docker CLI's process env. Codex's
+/// Fold codex's container auth into the docker CLI's process env, then make
+/// sure the config dir exists so the read-write bind has a host source. Codex's
 /// primary credential is the mounted `~/.codex/auth.json` (the read-write mount
 /// carries it and token refresh persists to the host); an `OPENAI_API_KEY` in
 /// the app's process env is forwarded when set (by bare `-e`, so its value never
-/// touches argv — invariant 3). Fails the launch when neither is present, so an
-/// unauthenticated container never boots into an unanswerable login prompt.
+/// touches argv — invariant 3). Either alone suffices: a key-only user may
+/// never have run codex on the host, so the dir is created rather than
+/// required — mounting a fresh dir keeps session rollouts landing where
+/// `find_codex_rollouts` reads them. Fails the launch when neither credential
+/// is present (before touching the filesystem), so an unauthenticated
+/// container never boots into an unanswerable login prompt.
 ///
 /// Unlike claude, no ANTHROPIC_*/CLAUDE_* var is injected: codex authenticates
 /// against OpenAI, and forwarding those would be dead weight at best.
-fn apply_codex_auth(env: &mut Vec<(String, String)>, config_dir: &Path) -> Result<()> {
-    let api_key = std::env::var("OPENAI_API_KEY").ok();
+fn prepare_codex_launch(
+    env: &mut Vec<(String, String)>,
+    config_dir: &Path,
+    api_key: Option<&str>,
+) -> Result<()> {
     let auth_file = config_dir.join("auth.json").is_file();
-    let resolved = codex_auth_env(api_key.as_deref(), auth_file)?;
+    let resolved = codex_auth_env(api_key, auth_file)?;
     // Booleans only — never a token value.
     tracing::info!(
         target: "fletch::docker",
@@ -485,10 +486,16 @@ fn apply_codex_auth(env: &mut Vec<(String, String)>, config_dir: &Path) -> Resul
         "codex container auth resolved"
     );
     env.extend(resolved);
+    std::fs::create_dir_all(config_dir).map_err(|e| {
+        Error::Other(format!(
+            "Couldn't create Codex config dir {}: {e}",
+            config_dir.display()
+        ))
+    })?;
     Ok(())
 }
 
-/// Pure core of [`apply_codex_auth`]: the auth env to forward given the process
+/// Pure core of [`prepare_codex_launch`]: the auth env to forward given the process
 /// `OPENAI_API_KEY` (if any) and whether `auth.json` exists on the mount. A
 /// non-blank key is forwarded (trimmed); the mounted `auth.json` carries auth on
 /// its own with nothing to inject. Neither present → the launch-blocking error.
@@ -1584,6 +1591,29 @@ mod tests {
         let err = codex_auth_env(None, false).unwrap_err().to_string();
         assert_eq!(err, NO_CODEX_AUTH_MSG);
         assert!(codex_auth_env(Some("  "), false).is_err());
+    }
+
+    /// Regression: a key-only user (`OPENAI_API_KEY` set, never ran codex on
+    /// the host) must launch — the missing config dir is created for the RW
+    /// mount, not treated as "no way to authenticate". With no credential at
+    /// all the launch still fails, and before touching the filesystem.
+    #[test]
+    fn codex_key_only_launch_creates_missing_config_dir() {
+        let td = tempfile::tempdir().unwrap();
+
+        let dir = td.path().join(".codex");
+        let mut env = Vec::new();
+        prepare_codex_launch(&mut env, &dir, Some("sk-openai")).unwrap();
+        assert!(dir.is_dir(), "config dir must exist for the RW bind mount");
+        assert_eq!(
+            env,
+            vec![("OPENAI_API_KEY".to_string(), "sk-openai".to_string())],
+        );
+
+        let no_auth = td.path().join(".codex-no-auth");
+        let err = prepare_codex_launch(&mut Vec::new(), &no_auth, None).unwrap_err();
+        assert_eq!(err.to_string(), NO_CODEX_AUTH_MSG);
+        assert!(!no_auth.exists(), "auth failure must not create the dir");
     }
 
     /// Integration: a real `docker run` round-trip through the exact argv the

--- a/src-tauri/src/sandbox/docker/engine.rs
+++ b/src-tauri/src/sandbox/docker/engine.rs
@@ -67,7 +67,7 @@ use crate::sandbox::engine::{
 use crate::sandbox::seatbelt::resolve_existing_prefix;
 
 use super::auth::{self, ContainerAuth};
-use super::{cleanup, cli, image};
+use super::{cleanup, cli, image, DockerProvider};
 
 /// Settings key overriding the container image (see [`image::resolve_image`]).
 pub const IMAGE_SETTING: &str = "docker_image";
@@ -150,11 +150,12 @@ pub fn set_launch_settings(settings: LaunchSettings) {
 /// [`KillHandle`], and sharing one instance also shares the once-per-app-run
 /// image resolution cache.
 pub struct DockerEngine {
-    /// The image resolved for this app run, keyed by the override value it
-    /// was resolved under so a (future) mid-run settings change re-resolves.
-    /// Only successes are cached — a failed build retries on the next spawn
-    /// (the user may have started Docker or fixed their network since).
-    resolved_image: Mutex<Option<(Option<String>, String)>>,
+    /// Images resolved for this app run, keyed by `(provider, override)` so each
+    /// provider's per-provider image is resolved (and built) at most once, and a
+    /// (future) mid-run settings change re-resolves. Only successes are cached —
+    /// a failed build retries on the next spawn (the user may have started Docker
+    /// or fixed their network since).
+    resolved_image: Mutex<std::collections::HashMap<(DockerProvider, Option<String>), String>>,
 }
 
 impl DockerEngine {
@@ -165,27 +166,31 @@ impl DockerEngine {
         ENGINE
             .get_or_init(|| {
                 Arc::new(DockerEngine {
-                    resolved_image: Mutex::new(None),
+                    resolved_image: Mutex::new(std::collections::HashMap::new()),
                 })
             })
             .clone()
     }
 
-    /// The image to launch from, resolving (and building, if the embedded
-    /// image is missing) at most once per app run per override value.
-    fn resolve_image_cached(&self, override_image: Option<&str>) -> Result<String> {
+    /// The image to launch `provider` from, resolving (and building, if the
+    /// embedded image is missing) at most once per app run per (provider,
+    /// override) pair.
+    fn resolve_image_cached(
+        &self,
+        provider: DockerProvider,
+        override_image: Option<&str>,
+    ) -> Result<String> {
+        let key = (provider, override_image.map(str::to_string));
         let mut cache = self.resolved_image.lock().unwrap();
-        if let Some((cached_override, tag)) = cache.as_ref() {
-            if cached_override.as_deref() == override_image {
-                return Ok(tag.clone());
-            }
+        if let Some(tag) = cache.get(&key) {
+            return Ok(tag.clone());
         }
         // Per-line build output goes to the log; the UI build toast is driven
         // separately by the `progress` sink inside `image::ensure_image`.
         let on_progress = |line: &str| tracing::info!(target: "fletch::docker_build", "{line}");
-        let tag = image::resolve_image(override_image, &on_progress)
+        let tag = image::resolve_image(provider, override_image, &on_progress)
             .map_err(|e| Error::Other(format!("preparing the Docker sandbox image failed: {e}")))?;
-        *cache = Some((override_image.map(str::to_string), tag.clone()));
+        cache.insert(key, tag.clone());
         Ok(tag)
     }
 }
@@ -195,72 +200,39 @@ impl SandboxEngine for DockerEngine {
         EngineKind::Docker
     }
 
-    /// Claude-only despite the agent-agnostic `agent_bin` parameter: the mounts,
-    /// `~/.claude` overlays, `projects/` transcript bind, and auth chain are all
-    /// claude-shaped. `supervisor::lifecycle::ensure_engine_supports_provider`
-    /// gates docker launches to `provider == "claude"`, so a non-claude
-    /// `agent_bin` never reaches here; a future per-turn-under-docker provider
-    /// would need its own config handling rather than inheriting claude's.
+    /// Launch a container for `ctx.provider`. The provider-agnostic scaffolding —
+    /// the writable-root and RPC mailbox mounts, borrowed git object stores, the
+    /// `--rm --init` shape, naming, and teardown — is shared; the per-provider
+    /// image, config-dir mount, and auth are selected by matching on
+    /// [`DockerProvider`]. `agent_bin` is the in-image command name the caller
+    /// already resolved for the docker boundary (`claude` / `codex`).
+    /// `ensure_engine_supports_provider` gates this to a supported provider, so
+    /// the `from_id` failure below is defensive only.
     fn launch_agent(&self, ctx: &AgentLaunchCtx, agent_bin: &str) -> Result<LaunchPlan> {
+        let provider = DockerProvider::from_id(ctx.provider).ok_or_else(|| {
+            Error::Other(format!(
+                "Docker sandbox has no support for provider `{}`",
+                ctx.provider
+            ))
+        })?;
         let docker = cli::docker_bin()
             .ok_or_else(|| Error::Other("docker binary not found — is Docker installed?".into()))?;
         let settings = LAUNCH_SETTINGS.read().clone();
-        let image = self.resolve_image_cached(settings.image_override.as_deref())?;
+        let image = self.resolve_image_cached(provider, settings.image_override.as_deref())?;
         let name = container_name(ctx.agent_id);
-        let claude_config_dir = nondefault_claude_config_dir(ctx.home);
-
-        // Make sure the mount sources exist before we hand them to `-v`. If a
-        // source can't be created (a file already sits at the path, a read-only
-        // or missing parent, permissions), mounting it anyway would let Docker
-        // recreate it root-owned or fail the bind opaquely — either way claude
-        // loses access to its auth/config. Fail the launch with the path
-        // instead of pressing on with a bad mount.
-        let claude_dir = ctx.home.join(".claude");
-        prepare_config_mount_dir(&claude_dir)?;
-        if let Some(dir) = &claude_config_dir {
-            prepare_config_mount_dir(dir)?;
-        }
-
-        // Per-agent host dir backing claude's `projects/` (session transcripts).
-        // Bind-mounted read-write over the read-only config dir's `projects/`
-        // (see [`push_claude_config_mount`]) so `--resume` survives container
-        // recreation without exposing the shared `~/.claude/projects` — other
-        // agents' transcripts and global memory stay unreachable (invariant 5).
-        // Lives under the agent's writable root, so archive teardown's `rm -rf`
-        // of that root reclaims it with no separate cleanup. Created before
-        // `docker run` so Docker binds an existing source instead of
-        // materializing it root-owned.
-        let projects_src = ctx
-            .writable_root
-            .join(crate::transcripts::DOCKER_CLAUDE_PROJECTS_DIRNAME);
-        std::fs::create_dir_all(&projects_src).map_err(|e| {
-            Error::Other(format!(
-                "preparing Docker sandbox projects mount {} failed: {e}",
-                projects_src.display()
-            ))
-        })?;
 
         // Object stores every checkout under the agent's writable root borrows
         // via git alternates (a --shared clone). Scanned across all tracked
         // repos, not just the primary `cwd`: a multi-repo agent has one shared
         // clone per repo, each borrowing its own source's objects. Mounted
         // read-only so in-container git reads borrowed history; empty for old
-        // full-copy clones or worktrees (no mount).
+        // full-copy clones or worktrees (no mount). Docker forces Clone-mode
+        // workspaces for every provider, so this is provider-agnostic.
         let borrowed_object_stores = borrowed_object_stores(ctx.writable_root);
-
-        // The read-only config mounts get a writable `.credentials.json` overlay
-        // only when the file already exists: a bare `-v` on a missing source
-        // makes Docker create a root-owned *directory* there, which would break
-        // claude's later attempt to write the real file.
-        let claude_credentials_rw = claude_dir.join(CREDENTIALS_FILE).is_file();
-        let config_dir_credentials_rw = claude_config_dir
-            .as_deref()
-            .is_some_and(|dir| dir.join(CREDENTIALS_FILE).is_file());
 
         // Env set on the docker CLI process; forwarded into the container by the
         // bare `-e NAME` flags `run_args` emits (values never touch argv —
-        // invariant 3). The auth chain appends its resolved vars last, so only
-        // what it actually picked is forwarded.
+        // invariant 3). Config-dir + auth vars are appended per provider below.
         let mut env: Vec<(String, String)> = vec![
             ("HOME".into(), ctx.home.to_string_lossy().into_owned()),
             (
@@ -270,23 +242,107 @@ impl SandboxEngine for DockerEngine {
             ("TERM".into(), "xterm-256color".into()),
             ("COLORTERM".into(), "truecolor".into()),
         ];
-        if let Some(dir) = &claude_config_dir {
-            env.push((
-                "CLAUDE_CONFIG_DIR".into(),
-                dir.to_string_lossy().into_owned(),
-            ));
-        }
-        let auth_start = env.len();
-        apply_container_auth(&mut env, auth::resolve())?;
 
-        // Forward exactly the resolved auth var names (the tail
-        // `apply_container_auth` appended). Scoped so the borrow of `env` ends
-        // before it moves into the plan below.
+        // Per-provider config-dir mount inputs for `RunSpec`. Defaults describe
+        // "no config surface"; the matched arm fills in what its provider needs.
+        let mut claude_config_dir: Option<PathBuf> = None;
+        let mut claude_credentials_rw = false;
+        let mut config_dir_credentials_rw = false;
+        let mut projects_src: Option<PathBuf> = None;
+        let mut codex_config_dir: Option<PathBuf> = None;
+        let mut forward_codex_home = false;
+
+        // The config-dir env (CLAUDE_CONFIG_DIR / CODEX_HOME) is pushed before
+        // this mark so only the *auth* tail is forwarded as auth vars.
+        let auth_start;
+        match provider {
+            DockerProvider::Claude => {
+                let cfg = nondefault_claude_config_dir(ctx.home);
+
+                // Make sure the mount sources exist before we hand them to `-v`.
+                // If a source can't be created (a file already sits at the path,
+                // a read-only or missing parent, permissions), mounting it anyway
+                // would let Docker recreate it root-owned or fail the bind
+                // opaquely — either way claude loses access to its auth/config.
+                // Fail the launch with the path instead of a bad mount.
+                let claude_dir = ctx.home.join(".claude");
+                prepare_config_mount_dir(&claude_dir)?;
+                if let Some(dir) = &cfg {
+                    prepare_config_mount_dir(dir)?;
+                }
+
+                // Per-agent host dir backing claude's `projects/` (session
+                // transcripts). Bind-mounted read-write over the read-only config
+                // dir's `projects/` (see [`push_claude_config_mount`]) so
+                // `--resume` survives container recreation without exposing the
+                // shared `~/.claude/projects` — other agents' transcripts and
+                // global memory stay unreachable (invariant 5). Lives under the
+                // agent's writable root, so archive teardown's `rm -rf` reclaims
+                // it with no separate cleanup. Created before `docker run` so
+                // Docker binds an existing source instead of materializing it
+                // root-owned.
+                let ps = ctx
+                    .writable_root
+                    .join(crate::transcripts::DOCKER_CLAUDE_PROJECTS_DIRNAME);
+                std::fs::create_dir_all(&ps).map_err(|e| {
+                    Error::Other(format!(
+                        "preparing Docker sandbox projects mount {} failed: {e}",
+                        ps.display()
+                    ))
+                })?;
+
+                // The read-only config mounts get a writable `.credentials.json`
+                // overlay only when the file already exists: a bare `-v` on a
+                // missing source makes Docker create a root-owned *directory*
+                // there, which would break claude's later write of the real file.
+                claude_credentials_rw = claude_dir.join(CREDENTIALS_FILE).is_file();
+                config_dir_credentials_rw = cfg
+                    .as_deref()
+                    .is_some_and(|dir| dir.join(CREDENTIALS_FILE).is_file());
+                if let Some(dir) = &cfg {
+                    env.push(("CLAUDE_CONFIG_DIR".into(), dir.to_string_lossy().into_owned()));
+                }
+                claude_config_dir = cfg;
+                projects_src = Some(ps);
+
+                auth_start = env.len();
+                apply_container_auth(&mut env, auth::resolve())?;
+            }
+            DockerProvider::Codex => {
+                // Codex's config dir is bind-mounted read-write: auth.json token
+                // refresh and the session rollout files it writes both need to
+                // persist, and writing rollouts at the same host path keeps the
+                // host-side transcript reader (`find_codex_rollouts`) working. If
+                // it doesn't exist the user has never logged in on the host, so
+                // there'd be nothing to authenticate with — fail fast with a
+                // clear pointer rather than mounting an empty dir.
+                let dir = codex_home_dir(ctx.home);
+                if !dir.is_dir() {
+                    return Err(Error::Other(NO_CODEX_CONFIG_MSG.to_string()));
+                }
+                // Forward CODEX_HOME only when it points somewhere other than the
+                // default `~/.codex` the container already resolves via HOME —
+                // mirrors `nondefault_claude_config_dir`.
+                forward_codex_home = codex_home_is_nondefault(ctx.home);
+                if forward_codex_home {
+                    env.push(("CODEX_HOME".into(), dir.to_string_lossy().into_owned()));
+                }
+
+                auth_start = env.len();
+                apply_codex_auth(&mut env, &dir)?;
+                codex_config_dir = Some(dir);
+            }
+        }
+
+        // Forward exactly the resolved auth var names (the tail appended after
+        // `auth_start`). Scoped so the borrow of `env` ends before it moves into
+        // the plan below.
         let prefix_args = {
             let auth_vars: Vec<&str> =
                 env[auth_start..].iter().map(|(k, _)| k.as_str()).collect();
             run_args(&RunSpec {
                 interactive: ctx.interactive,
+                provider,
                 name: &name,
                 agent_id: ctx.agent_id,
                 writable_root: ctx.writable_root,
@@ -297,7 +353,9 @@ impl SandboxEngine for DockerEngine {
                 borrowed_object_stores: &borrowed_object_stores,
                 claude_credentials_rw,
                 config_dir_credentials_rw,
-                projects_src: &projects_src,
+                projects_src: projects_src.as_deref(),
+                codex_config_dir: codex_config_dir.as_deref(),
+                forward_codex_home,
                 memory: non_blank(settings.memory.as_deref()).unwrap_or(DEFAULT_MEMORY),
                 cpus: non_blank(settings.cpus.as_deref()).unwrap_or(DEFAULT_CPUS),
                 image: &image,
@@ -372,6 +430,77 @@ fn apply_container_auth(env: &mut Vec<(String, String)>, auth: ContainerAuth) ->
         }
         ContainerAuth::Unavailable => Err(Error::Other(NO_CONTAINER_AUTH_MSG.to_string())),
     }
+}
+
+/// Launch-blocking message when codex's config dir doesn't exist on the host:
+/// there's no login to carry in, so authentication would be impossible.
+const NO_CODEX_CONFIG_MSG: &str =
+    "No Codex config for containers — run `codex` on the host and sign in first (this creates ~/.codex).";
+
+/// Launch-blocking message when codex's config dir exists but carries no usable
+/// credential (no `auth.json`) and `OPENAI_API_KEY` is unset. Mirrors
+/// [`NO_CONTAINER_AUTH_MSG`]'s fail-fast: an unauthenticated container boots
+/// straight into a login prompt it can't answer inside the sandbox.
+const NO_CODEX_AUTH_MSG: &str =
+    "No Codex credentials for containers — sign in with `codex` on the host (writes ~/.codex/auth.json) or set OPENAI_API_KEY.";
+
+/// Codex's config dir: `$CODEX_HOME` if set, else `~/.codex`. This is both the
+/// dir bind-mounted read-write and where `transcripts::find_codex_rollouts`
+/// reads transcripts, so the two must agree — mirror its resolution.
+fn codex_home_dir(home: &Path) -> PathBuf {
+    std::env::var_os("CODEX_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home.join(".codex"))
+}
+
+/// Whether `$CODEX_HOME` is set to a dir other than the default `~/.codex`
+/// (which the container already resolves via `HOME`). Only a non-default value
+/// is forwarded, mirroring [`nondefault_claude_config_dir`]; both sides go
+/// through [`resolve_existing_prefix`] so a symlink can't read as non-default.
+fn codex_home_is_nondefault(home: &Path) -> bool {
+    match std::env::var_os("CODEX_HOME") {
+        Some(v) => resolve_existing_prefix(&PathBuf::from(v)) != resolve_existing_prefix(&home.join(".codex")),
+        None => false,
+    }
+}
+
+/// Fold codex's container auth into the docker CLI's process env. Codex's
+/// primary credential is the mounted `~/.codex/auth.json` (the read-write mount
+/// carries it and token refresh persists to the host); an `OPENAI_API_KEY` in
+/// the app's process env is forwarded when set (by bare `-e`, so its value never
+/// touches argv — invariant 3). Fails the launch when neither is present, so an
+/// unauthenticated container never boots into an unanswerable login prompt.
+///
+/// Unlike claude, no ANTHROPIC_*/CLAUDE_* var is injected: codex authenticates
+/// against OpenAI, and forwarding those would be dead weight at best.
+fn apply_codex_auth(env: &mut Vec<(String, String)>, config_dir: &Path) -> Result<()> {
+    let api_key = std::env::var("OPENAI_API_KEY").ok();
+    let auth_file = config_dir.join("auth.json").is_file();
+    let resolved = codex_auth_env(api_key.as_deref(), auth_file)?;
+    // Booleans only — never a token value.
+    tracing::info!(
+        target: "fletch::docker",
+        auth_file,
+        api_key = !resolved.is_empty(),
+        "codex container auth resolved"
+    );
+    env.extend(resolved);
+    Ok(())
+}
+
+/// Pure core of [`apply_codex_auth`]: the auth env to forward given the process
+/// `OPENAI_API_KEY` (if any) and whether `auth.json` exists on the mount. A
+/// non-blank key is forwarded (trimmed); the mounted `auth.json` carries auth on
+/// its own with nothing to inject. Neither present → the launch-blocking error.
+fn codex_auth_env(api_key: Option<&str>, auth_file: bool) -> Result<Vec<(String, String)>> {
+    let api_key = api_key.map(str::trim).filter(|k| !k.is_empty());
+    if let Some(key) = api_key {
+        return Ok(vec![("OPENAI_API_KEY".to_string(), key.to_string())]);
+    }
+    if auth_file {
+        return Ok(Vec::new());
+    }
+    Err(Error::Other(NO_CODEX_AUTH_MSG.to_string()))
 }
 
 /// `Some(v)` only when `v` is present and non-blank — settings rows can hold
@@ -474,6 +603,11 @@ fn borrowed_object_stores(writable_root: &Path) -> Vec<PathBuf> {
 /// shape unit-testable without a daemon.
 struct RunSpec<'a> {
     interactive: bool,
+    /// Which provider is launching — selects the config-dir mount + config-dir
+    /// env below. The `claude_*` fields apply only to [`DockerProvider::Claude`]
+    /// and `codex_config_dir`/`forward_codex_home` only to
+    /// [`DockerProvider::Codex`]; the other provider's fields are inert.
+    provider: DockerProvider,
     name: &'a str,
     agent_id: &'a str,
     writable_root: &'a Path,
@@ -494,8 +628,17 @@ struct RunSpec<'a> {
     /// Per-agent host dir bind-mounted read-write over each config dir's
     /// `projects/` so claude's session transcript persists across container
     /// recreation (resume) while the shared `~/.claude` stays read-only. Lives
-    /// under `writable_root`; see [`push_claude_config_mount`].
-    projects_src: &'a Path,
+    /// under `writable_root`; see [`push_claude_config_mount`]. `Some` for the
+    /// claude provider, `None` for codex (which persists transcripts via its own
+    /// read-write `~/.codex` mount).
+    projects_src: Option<&'a Path>,
+    /// Codex's config dir (`$CODEX_HOME` or `~/.codex`), bind-mounted
+    /// **read-write** at its identical host path so auth-token refresh and
+    /// session rollout writes persist to the host. `Some` only for codex.
+    codex_config_dir: Option<&'a Path>,
+    /// Forward `CODEX_HOME` into the container (a non-default `$CODEX_HOME`);
+    /// only meaningful for codex.
+    forward_codex_home: bool,
     memory: &'a str,
     cpus: &'a str,
     image: &'a str,
@@ -543,19 +686,39 @@ fn run_args(spec: &RunSpec<'_>) -> Vec<String> {
         args.push("-v".into());
         args.push(format!("{path}:{path}:ro"));
     }
-    push_claude_config_mount(
-        &mut args,
-        &spec.home.join(".claude"),
-        spec.claude_credentials_rw,
-        spec.projects_src,
-    );
-    if let Some(dir) = spec.claude_config_dir {
-        push_claude_config_mount(
-            &mut args,
-            dir,
-            spec.config_dir_credentials_rw,
-            spec.projects_src,
-        );
+    // Provider config-dir mount(s), layered after the workspace/mailbox/object
+    // stores. Claude gets the read-only-except-carve-outs treatment; codex gets
+    // a single read-write bind (see the field docs on `RunSpec`).
+    match spec.provider {
+        DockerProvider::Claude => {
+            // Claude always supplies a `projects_src`; the launch path builds it.
+            let projects_src = spec
+                .projects_src
+                .expect("claude launch must supply a projects_src");
+            push_claude_config_mount(
+                &mut args,
+                &spec.home.join(".claude"),
+                spec.claude_credentials_rw,
+                projects_src,
+            );
+            if let Some(dir) = spec.claude_config_dir {
+                push_claude_config_mount(
+                    &mut args,
+                    dir,
+                    spec.config_dir_credentials_rw,
+                    projects_src,
+                );
+            }
+        }
+        DockerProvider::Codex => {
+            if let Some(dir) = spec.codex_config_dir {
+                let path = dir.to_string_lossy();
+                args.push("-v".into());
+                // Read-write (no `:ro`): codex refreshes auth.json in place and
+                // writes session rollouts here, both of which must reach the host.
+                args.push(format!("{path}:{path}"));
+            }
+        }
     }
     args.push("-w".into());
     args.push(spec.cwd.to_string_lossy().into_owned());
@@ -563,8 +726,17 @@ fn run_args(spec: &RunSpec<'_>) -> Vec<String> {
     // the value ever appearing in argv (invariant 3 for the auth vars). Auth
     // vars come from `spec.auth_vars` — the set the chain actually resolved.
     let mut forwarded: Vec<&str> = vec!["HOME", "FLETCH_RPC_DIR", "TERM", "COLORTERM"];
-    if spec.claude_config_dir.is_some() {
-        forwarded.push("CLAUDE_CONFIG_DIR");
+    match spec.provider {
+        DockerProvider::Claude => {
+            if spec.claude_config_dir.is_some() {
+                forwarded.push("CLAUDE_CONFIG_DIR");
+            }
+        }
+        DockerProvider::Codex => {
+            if spec.forward_codex_home {
+                forwarded.push("CODEX_HOME");
+            }
+        }
     }
     forwarded.extend(spec.auth_vars.iter().copied());
     for var in forwarded {
@@ -718,15 +890,19 @@ fn container_gone_within(name: &str, budget: Duration) -> bool {
 
 /// User-readable meanings for the docker CLI's reserved exit codes; other
 /// codes are the contained agent's own and pass through unmapped. `docker run`
-/// relays the agent's own exit status, so a `claude` that starts fine and later
+/// relays the agent's own exit status, so an agent that starts fine and later
 /// exits 125/126/127 is indistinguishable from a launcher/image failure — the
 /// messages name the likely Docker-layer cause but flag the agent-exit
 /// possibility so they don't mislead when the container did launch.
+///
+/// Provider-neutral: the teardown plan carries only the container name, and the
+/// sandbox image now varies per provider, so these speak of "the agent binary"
+/// rather than naming `claude`.
 fn describe_exit_code(code: i32) -> Option<String> {
     let msg = match code {
         125 => "Exit 125: Docker could not start the sandbox container — the daemon reported an error (or the agent itself exited 125). Is Docker Desktop still running?",
-        126 => "Exit 126: the agent binary in the sandbox image is present but not runnable (or the agent itself exited 126). If you set a custom docker_image, check its `claude`.",
-        127 => "Exit 127: no `claude` on the sandbox image's PATH (or the agent itself exited 127). A custom docker_image must include Claude Code.",
+        126 => "Exit 126: the agent binary in the sandbox image is present but not runnable (or the agent itself exited 126). If you set a custom docker_image, check its agent CLI.",
+        127 => "Exit 127: no agent binary on the sandbox image's PATH (or the agent itself exited 127). A custom docker_image must include the launching agent's CLI.",
         _ => return None,
     };
     Some(msg.to_string())
@@ -739,6 +915,7 @@ mod tests {
     fn test_spec<'a>(interactive: bool) -> RunSpec<'a> {
         RunSpec {
             interactive,
+            provider: DockerProvider::Claude,
             name: "fletch-orkney-deadbeef",
             agent_id: "orkney",
             writable_root: Path::new("/Users/u/.fletch/worktrees/orkney"),
@@ -749,7 +926,11 @@ mod tests {
             borrowed_object_stores: &[],
             claude_credentials_rw: false,
             config_dir_credentials_rw: false,
-            projects_src: Path::new("/Users/u/.fletch/worktrees/orkney/.fletch-claude-projects"),
+            projects_src: Some(Path::new(
+                "/Users/u/.fletch/worktrees/orkney/.fletch-claude-projects",
+            )),
+            codex_config_dir: None,
+            forward_codex_home: false,
             memory: "4g",
             cpus: "2",
             image: "fletch-agent:abc123def456",
@@ -760,6 +941,33 @@ mod tests {
                 "ANTHROPIC_BASE_URL",
                 "ANTHROPIC_AUTH_TOKEN",
             ],
+        }
+    }
+
+    /// A codex `RunSpec`: no claude config surface, a read-write `~/.codex`
+    /// mount, `OPENAI_API_KEY` as the forwarded auth var, and the codex image.
+    fn codex_spec<'a>() -> RunSpec<'a> {
+        RunSpec {
+            interactive: false,
+            provider: DockerProvider::Codex,
+            name: "fletch-orkney-deadbeef",
+            agent_id: "orkney",
+            writable_root: Path::new("/Users/u/.fletch/worktrees/orkney"),
+            rpc_dir: Path::new("/Users/u/.fletch/rpc/orkney"),
+            home: Path::new("/Users/u"),
+            cwd: Path::new("/Users/u/.fletch/worktrees/orkney/repo"),
+            claude_config_dir: None,
+            borrowed_object_stores: &[],
+            claude_credentials_rw: false,
+            config_dir_credentials_rw: false,
+            projects_src: None,
+            codex_config_dir: Some(Path::new("/Users/u/.codex")),
+            forward_codex_home: false,
+            memory: "4g",
+            cpus: "2",
+            image: "fletch-agent-codex:abc123def456",
+            agent_bin: "codex",
+            auth_vars: &["OPENAI_API_KEY"],
         }
     }
 
@@ -954,6 +1162,68 @@ mod tests {
                 "/Users/u/.fletch/worktrees/orkney/.fletch-claude-projects:/Users/u/.claude/projects",
             ],
         );
+    }
+
+    /// Codex mounts its config dir read-write (auth refresh + rollout writes
+    /// must reach the host) and launches the codex image + `codex` bin. There's
+    /// no `~/.claude` read-only mount, no tmpfs overlay, and no `projects/`
+    /// transcript bind — codex persists transcripts through this same RW mount.
+    #[test]
+    fn argv_codex_mounts_config_dir_read_write() {
+        let args = run_args(&codex_spec());
+        assert_eq!(
+            values_of(&args, "-v"),
+            vec![
+                "/Users/u/.fletch/worktrees/orkney:/Users/u/.fletch/worktrees/orkney",
+                "/Users/u/.fletch/rpc/orkney:/Users/u/.fletch/rpc/orkney",
+                // ~/.codex read-write: no `:ro` suffix.
+                "/Users/u/.codex:/Users/u/.codex",
+            ],
+        );
+        // No claude-shaped surfaces leak into a codex launch.
+        assert!(
+            !args.iter().any(|a| a.contains("/.claude")),
+            "codex must not mount any ~/.claude path"
+        );
+        assert!(
+            values_of(&args, "--tmpfs").is_empty(),
+            "codex has no tmpfs overlays"
+        );
+        assert!(
+            !args.iter().any(|a| a.contains("fletch-claude-projects")),
+            "codex has no projects/ transcript bind"
+        );
+        // Codex image + in-image bin, last (the prefix_args contract).
+        assert_eq!(args[args.len() - 2], "fletch-agent-codex:abc123def456");
+        assert_eq!(args[args.len() - 1], "codex");
+    }
+
+    /// Codex forwards `OPENAI_API_KEY` by bare name (invariant 3) and, unlike
+    /// claude, no `CLAUDE_CONFIG_DIR`/Anthropic vars. `CODEX_HOME` forwards only
+    /// for a non-default `$CODEX_HOME`.
+    #[test]
+    fn argv_codex_forwards_openai_key_and_optional_codex_home() {
+        let args = run_args(&codex_spec());
+        let forwarded = values_of(&args, "-e");
+        assert!(forwarded.contains(&"OPENAI_API_KEY"), "missing bare -e OPENAI_API_KEY");
+        assert!(forwarded.contains(&"HOME"));
+        assert!(!forwarded.contains(&"CLAUDE_CONFIG_DIR"));
+        assert!(!forwarded.contains(&"ANTHROPIC_API_KEY"));
+        // Default ~/.codex: CODEX_HOME is not forwarded (the mount + HOME cover it).
+        assert!(!forwarded.contains(&"CODEX_HOME"), "default CODEX_HOME must not forward");
+
+        // A non-default $CODEX_HOME is forwarded so in-container codex reads it.
+        let mut spec = codex_spec();
+        spec.forward_codex_home = true;
+        assert!(values_of(&run_args(&spec), "-e").contains(&"CODEX_HOME"));
+
+        // No token value anywhere in argv.
+        for arg in &args {
+            assert!(
+                !arg.contains('=') || arg.starts_with("fletch."),
+                "argv token `{arg}` carries a value — only label tokens may",
+            );
+        }
     }
 
     #[test]
@@ -1185,7 +1455,7 @@ mod tests {
         let missing = describe_exit_code(127).unwrap();
         assert!(daemon.contains("daemon"), "{daemon}");
         assert!(not_exec.contains("not runnable"), "{not_exec}");
-        assert!(missing.contains("no `claude`"), "{missing}");
+        assert!(missing.contains("no agent binary"), "{missing}");
         let distinct: std::collections::HashSet<_> = [&daemon, &not_exec, &missing].into();
         assert_eq!(distinct.len(), 3);
         // Each hedges: docker relays the agent's own status, so these codes can
@@ -1292,6 +1562,30 @@ mod tests {
         assert!(env.is_empty(), "a failed resolution must add no env");
     }
 
+    /// Codex auth: a non-blank `OPENAI_API_KEY` is forwarded (trimmed); a bare
+    /// `auth.json` resolves with nothing to inject (the mount carries it); a
+    /// blank key falls back to the file; neither present fails the launch.
+    #[test]
+    fn codex_auth_env_resolves_key_file_or_fails() {
+        // API key wins and is trimmed.
+        assert_eq!(
+            codex_auth_env(Some(" sk-openai \n"), false).unwrap(),
+            vec![("OPENAI_API_KEY".to_string(), "sk-openai".to_string())],
+        );
+        // Key alongside a file still forwards the key.
+        assert_eq!(
+            codex_auth_env(Some("sk-openai"), true).unwrap(),
+            vec![("OPENAI_API_KEY".to_string(), "sk-openai".to_string())],
+        );
+        // No key but a mounted auth.json: nothing to inject, but resolves.
+        assert!(codex_auth_env(None, true).unwrap().is_empty());
+        assert!(codex_auth_env(Some("   "), true).unwrap().is_empty());
+        // Neither: fail-fast with the settings pointer.
+        let err = codex_auth_env(None, false).unwrap_err().to_string();
+        assert_eq!(err, NO_CODEX_AUTH_MSG);
+        assert!(codex_auth_env(Some("  "), false).is_err());
+    }
+
     /// Integration: a real `docker run` round-trip through the exact argv the
     /// engine builds — busybox standing in for the agent image, `echo` for
     /// the agent binary. `FLETCH_DOCKER_TESTS=1 cargo test -- --ignored`
@@ -1317,6 +1611,7 @@ mod tests {
         let name = container_name("b2-int-test");
         let args = run_args(&RunSpec {
             interactive: false,
+            provider: DockerProvider::Claude,
             name: &name,
             agent_id: "b2-int-test",
             writable_root: &root,
@@ -1327,7 +1622,9 @@ mod tests {
             borrowed_object_stores: &[],
             claude_credentials_rw: false,
             config_dir_credentials_rw: false,
-            projects_src: &projects_src,
+            projects_src: Some(&projects_src),
+            codex_config_dir: None,
+            forward_codex_home: false,
             memory: "256m",
             cpus: "1",
             image: "busybox",

--- a/src-tauri/src/sandbox/docker/image.rs
+++ b/src-tauri/src/sandbox/docker/image.rs
@@ -1,14 +1,18 @@
-//! The embedded agent image: what containers run, built on demand.
+//! The embedded agent images: what containers run, built on demand, one image
+//! per supported provider (see [`DockerProvider`]).
 //!
-//! The Dockerfile and entrypoint are compiled into the binary and the image
-//! tag is derived from their content (`fletch-agent:<sha256[..12]>`), so
-//! shipping a change to either automatically produces a new tag — the stale
-//! image is simply never referenced again and the next spawn rebuilds. No
-//! version bookkeeping, no manual invalidation.
+//! The Dockerfile and entrypoint are compiled into the binary and each image's
+//! tag is derived from its content (`<repo>:<sha256[..12]>`, e.g.
+//! `fletch-agent:…` for claude, `fletch-agent-codex:…` for codex), so shipping a
+//! change to either automatically produces a new tag — the stale image is simply
+//! never referenced again and the next spawn rebuilds. No version bookkeeping,
+//! no manual invalidation. Provider images share their base layers (identical
+//! `FROM` + apt step), so a second provider costs only its own install layer.
 //!
 //! Users can bypass all of this with the `docker_image` settings key (see
 //! [`resolve_image`]): a user-supplied image is used verbatim — never built,
-//! never inspected — and must have `claude` on PATH and git installed.
+//! never inspected — and must have the launching provider's CLI on PATH and git
+//! installed. The override is global (applies to whichever provider launches).
 
 use std::path::Path;
 use std::sync::Mutex;
@@ -18,6 +22,7 @@ use crate::error::Result;
 
 use super::cli;
 use super::progress::{self, BuildEvent};
+use super::DockerProvider;
 
 /// Progress sink for image builds: called once per docker output line. Callers
 /// pass a tracing forwarder to log build output, or `&|_| {}` to ignore it.
@@ -53,6 +58,61 @@ fi
 exec "$@"
 "#;
 
+/// Codex's image. Shares [`DOCKERFILE`]'s base byte-for-byte — same `FROM
+/// node:22-slim` and the same apt line — so Docker's layer cache is reused
+/// across the two images; only the provider install step differs
+/// (`@openai/codex` instead of `@anthropic-ai/claude-code`). Codex authenticates
+/// from the read-write `~/.codex` mount (auth.json) and/or `OPENAI_API_KEY`, so
+/// the image carries no provider config of its own.
+pub const CODEX_DOCKERFILE: &str = r#"FROM node:22-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl ca-certificates ripgrep jq procps \
+ && rm -rf /var/lib/apt/lists/*
+RUN npm install -g @openai/codex
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+"#;
+
+/// Codex's PID-1 shim: create `HOME` and exec, nothing more. Unlike claude,
+/// codex needs no onboarding seed — `codex exec` runs non-interactively with
+/// `--skip-git-repo-check` and `approval_policy="never"` (see
+/// `agent::codex_build_args`), and its credentials come from the mounted
+/// `~/.codex/auth.json` rather than a config file we'd seed here.
+pub const CODEX_ENTRYPOINT_SH: &str = r#"#!/bin/sh
+set -e
+mkdir -p "$HOME"
+exec "$@"
+"#;
+
+/// The image build inputs for a provider: repo name plus the Dockerfile and
+/// entrypoint whose combined content addresses the tag. Claude returns the
+/// original constants under the original repo name, so its tag is byte-for-byte
+/// unchanged and existing users never rebuild; new providers get their own repo.
+struct ImageSpec {
+    repo: &'static str,
+    dockerfile: &'static str,
+    entrypoint: &'static str,
+}
+
+/// Per-provider image inputs. Claude's spec is the pre-existing embedded image
+/// verbatim (see the byte-identity guard in tests); codex gets its own repo and
+/// install step, sharing claude's base layers.
+fn image_spec(provider: DockerProvider) -> ImageSpec {
+    match provider {
+        DockerProvider::Claude => ImageSpec {
+            repo: "fletch-agent",
+            dockerfile: DOCKERFILE,
+            entrypoint: ENTRYPOINT_SH,
+        },
+        DockerProvider::Codex => ImageSpec {
+            repo: "fletch-agent-codex",
+            dockerfile: CODEX_DOCKERFILE,
+            entrypoint: CODEX_ENTRYPOINT_SH,
+        },
+    }
+}
+
 /// Builds are slow (base image pull + apt + npm) but bounded: past this we
 /// assume a wedged daemon or dead network and fail the spawn with a clear
 /// error rather than letting it hang indefinitely.
@@ -61,21 +121,24 @@ const BUILD_TIMEOUT: Duration = Duration::from_secs(600);
 /// Quick metadata lookups (`docker image inspect`).
 const INSPECT_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// The content-addressed tag for the embedded image.
-pub fn image_tag() -> String {
-    tag_for(DOCKERFILE, ENTRYPOINT_SH)
+/// The content-addressed tag for a provider's embedded image.
+pub fn image_tag(provider: DockerProvider) -> String {
+    let spec = image_spec(provider);
+    tag_for(spec.repo, spec.dockerfile, spec.entrypoint)
 }
 
-/// `fletch-agent:<sha256(dockerfile + entrypoint)[..12]>` — 12 hex chars, the
-/// same abbreviation depth docker itself uses for short ids.
-fn tag_for(dockerfile: &str, entrypoint: &str) -> String {
+/// `<repo>:<sha256(dockerfile + entrypoint)[..12]>` — 12 hex chars, the same
+/// abbreviation depth docker itself uses for short ids. The hash covers only the
+/// dockerfile+entrypoint content (not the repo), so claude's tail is unchanged
+/// from before the repo argument existed as long as its content is.
+fn tag_for(repo: &str, dockerfile: &str, entrypoint: &str) -> String {
     use sha2::Digest;
     let mut hasher = sha2::Sha256::new();
     hasher.update(dockerfile.as_bytes());
     hasher.update(entrypoint.as_bytes());
     let digest = hasher.finalize();
     let hex: String = digest.iter().map(|b| format!("{b:02x}")).collect();
-    format!("fletch-agent:{}", &hex[..12])
+    format!("{repo}:{}", &hex[..12])
 }
 
 /// The image to launch containers from, honoring the `docker_image` settings
@@ -83,25 +146,35 @@ fn tag_for(dockerfile: &str, entrypoint: &str) -> String {
 /// the user owns that image's lifecycle); otherwise the embedded image is
 /// built if missing and its tag returned. Callers read the settings key and
 /// pass it in — this module stays DB-free.
-pub fn resolve_image(override_image: Option<&str>, on_progress: Progress) -> Result<String> {
+pub fn resolve_image(
+    provider: DockerProvider,
+    override_image: Option<&str>,
+    on_progress: Progress,
+) -> Result<String> {
     if let Some(image) = override_image.map(str::trim).filter(|s| !s.is_empty()) {
+        // The override is global and applies verbatim to whichever provider
+        // launches (it must carry that provider's CLI + git on PATH).
+        // TODO(per-provider-override): a future per-provider image setting would
+        // key this on `provider`; today one override serves all.
         tracing::info!(
             image,
+            ?provider,
             "using user-supplied docker image (docker_image setting)"
         );
         return Ok(image.to_string());
     }
-    let tag = image_tag();
-    ensure_image(&tag, on_progress)?;
+    let tag = image_tag(provider);
+    ensure_image(provider, &tag, on_progress)?;
     Ok(tag)
 }
 
-/// Make sure `tag` exists locally, building the embedded Dockerfile under
-/// that tag if it doesn't. Builds are serialized process-wide: concurrent
-/// spawns during a cold start would otherwise race docker into building the
-/// same image N times.
-pub fn ensure_image(tag: &str, on_progress: Progress) -> Result<()> {
-    ensure_image_with(DOCKERFILE, ENTRYPOINT_SH, tag, on_progress)
+/// Make sure `provider`'s image `tag` exists locally, building its embedded
+/// Dockerfile under that tag if it doesn't. Builds are serialized process-wide:
+/// concurrent spawns during a cold start would otherwise race docker into
+/// building the same image N times.
+pub fn ensure_image(provider: DockerProvider, tag: &str, on_progress: Progress) -> Result<()> {
+    let spec = image_spec(provider);
+    ensure_image_with(spec.dockerfile, spec.entrypoint, tag, on_progress)
 }
 
 /// [`ensure_image`] with explicit content — split out so the integration
@@ -192,16 +265,57 @@ mod tests {
 
     #[test]
     fn tag_is_content_addressed() {
-        let tag = tag_for("FROM a\n", "#!/bin/sh\n");
+        let tag = tag_for("fletch-agent", "FROM a\n", "#!/bin/sh\n");
         let (repo, hash) = tag.split_once(':').unwrap();
         assert_eq!(repo, "fletch-agent");
         assert_eq!(hash.len(), 12);
         assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
 
         // Deterministic, and any content change moves the tag.
-        assert_eq!(tag, tag_for("FROM a\n", "#!/bin/sh\n"));
-        assert_ne!(tag, tag_for("FROM b\n", "#!/bin/sh\n"));
-        assert_ne!(tag, tag_for("FROM a\n", "#!/bin/bash\n"));
+        assert_eq!(tag, tag_for("fletch-agent", "FROM a\n", "#!/bin/sh\n"));
+        assert_ne!(tag, tag_for("fletch-agent", "FROM b\n", "#!/bin/sh\n"));
+        assert_ne!(tag, tag_for("fletch-agent", "FROM a\n", "#!/bin/bash\n"));
+        // The repo is a prefix, not part of the hash: a different repo with the
+        // same content shares the tail (so a repo rename can't force a rebuild).
+        assert_eq!(
+            tag_for("fletch-agent", "FROM a\n", "#!/bin/sh\n").split_once(':').unwrap().1,
+            tag_for("other", "FROM a\n", "#!/bin/sh\n").split_once(':').unwrap().1,
+        );
+    }
+
+    /// Acceptance guard: claude's image must not change. Its repo name stays
+    /// `fletch-agent` and its Dockerfile/entrypoint bytes are frozen, so its
+    /// content-addressed tag is byte-for-byte what shipped — existing users must
+    /// never be forced to rebuild by this PR. If this fails, claude's image
+    /// content changed and every user pays a cold rebuild.
+    #[test]
+    fn claude_image_is_unchanged() {
+        // Frozen bytes (do not "fix" to match a changed constant — update the
+        // constant back instead).
+        const FROZEN_DOCKERFILE: &str = "FROM node:22-slim\nRUN apt-get update && apt-get install -y --no-install-recommends \\\n    git curl ca-certificates ripgrep jq procps \\\n && rm -rf /var/lib/apt/lists/*\nRUN npm install -g @anthropic-ai/claude-code\nCOPY entrypoint.sh /entrypoint.sh\nRUN chmod +x /entrypoint.sh\nENTRYPOINT [\"/entrypoint.sh\"]\n";
+        const FROZEN_ENTRYPOINT: &str = "#!/bin/sh\nset -e\nmkdir -p \"$HOME\"\nif [ ! -f \"$HOME/.claude.json\" ]; then\n  printf '{\"hasCompletedOnboarding\": true}\\n' > \"$HOME/.claude.json\"\nfi\nexec \"$@\"\n";
+        assert_eq!(DOCKERFILE, FROZEN_DOCKERFILE, "claude Dockerfile changed");
+        assert_eq!(ENTRYPOINT_SH, FROZEN_ENTRYPOINT, "claude entrypoint changed");
+        assert!(image_tag(DockerProvider::Claude).starts_with("fletch-agent:"));
+    }
+
+    /// Codex gets its own repo and a distinct tag, and shares claude's base
+    /// layers (identical `FROM` + apt line) so the cache is reused.
+    #[test]
+    fn codex_image_is_distinct_and_shares_base() {
+        let codex = image_tag(DockerProvider::Codex);
+        assert!(codex.starts_with("fletch-agent-codex:"), "{codex}");
+        assert_ne!(codex, image_tag(DockerProvider::Claude));
+
+        // Base layers shared: the FROM line and the apt install line are
+        // byte-identical, so Docker reuses those layers across both images.
+        let base: Vec<&str> = DOCKERFILE.lines().take_while(|l| !l.starts_with("RUN npm")).collect();
+        let codex_base: Vec<&str> =
+            CODEX_DOCKERFILE.lines().take_while(|l| !l.starts_with("RUN npm")).collect();
+        assert_eq!(base, codex_base, "base layers must match for cache reuse");
+        // Provider-specific install step differs.
+        assert!(CODEX_DOCKERFILE.contains("@openai/codex"));
+        assert!(!CODEX_DOCKERFILE.contains("claude-code"));
     }
 
     #[test]
@@ -219,7 +333,9 @@ mod tests {
         let called = std::sync::atomic::AtomicBool::new(false);
         let progress = |_: &str| called.store(true, std::sync::atomic::Ordering::SeqCst);
 
-        let image = resolve_image(Some("  ghcr.io/me/custom:1  "), &progress).unwrap();
+        let image =
+            resolve_image(DockerProvider::Claude, Some("  ghcr.io/me/custom:1  "), &progress)
+                .unwrap();
         assert_eq!(
             image, "ghcr.io/me/custom:1",
             "override is trimmed and used verbatim"
@@ -238,7 +354,7 @@ mod tests {
             .map(str::trim)
             .filter(|s| !s.is_empty())
             .is_none());
-        assert!(image_tag().starts_with("fletch-agent:"));
+        assert!(image_tag(DockerProvider::Claude).starts_with("fletch-agent:"));
     }
 
     /// Integration: builds a tiny image (busybox base) through the real
@@ -252,7 +368,7 @@ mod tests {
         }
         let dockerfile =
             "FROM busybox\nCOPY entrypoint.sh /entrypoint.sh\nENTRYPOINT [\"/entrypoint.sh\"]\n";
-        let tag = tag_for(dockerfile, ENTRYPOINT_SH);
+        let tag = tag_for("fletch-agent", dockerfile, ENTRYPOINT_SH);
         // Start clean so the build path actually runs.
         let _ = cli::run_docker(&["rmi", "-f", &tag], Duration::from_secs(30));
 

--- a/src-tauri/src/sandbox/docker/mod.rs
+++ b/src-tauri/src/sandbox/docker/mod.rs
@@ -32,6 +32,50 @@ pub use engine::{
 pub use probe::{availability, DockerAvailability};
 pub use progress::set_build_sink;
 
+/// A provider Fletch can run inside a Docker sandbox. This is the single
+/// capability gate the rest of the app consults instead of string-matching
+/// `provider == "claude"`: [`supervisor::lifecycle::ensure_engine_supports_provider`]
+/// refuses anything [`from_id`](DockerProvider::from_id) doesn't recognize, and
+/// the launch path ([`engine`]) branches on the variant for the provider-specific
+/// image ([`image`]), config-dir mount, and auth. Everything else about a
+/// container (workspace / RPC / object-store mounts, naming, teardown) is
+/// provider-agnostic.
+///
+/// Seatbelt runs six providers; Docker is being brought up one at a time as each
+/// gets its image + config-mount + auth wired here — claude and codex so far.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DockerProvider {
+    Claude,
+    Codex,
+}
+
+impl DockerProvider {
+    /// Map a provider id (as stamped on `AgentRecord.provider` / used by the
+    /// frontend) to its Docker support, or `None` when the provider has no
+    /// container support yet — the launch gate turns `None` into the
+    /// user-facing "isn't available in Docker sandboxes yet" refusal.
+    pub fn from_id(provider: &str) -> Option<Self> {
+        match provider {
+            "claude" => Some(Self::Claude),
+            "codex" => Some(Self::Codex),
+            _ => None,
+        }
+    }
+
+    /// The command name on the image's PATH — what this provider's npm package
+    /// installs as its executable. Handed to `launch_agent` as the in-image
+    /// `agent_bin` (a host-resolved absolute path would be meaningless inside
+    /// the container). Matches the provider's `bin` field for both supported
+    /// providers today, but named explicitly so it stays an image fact, not a
+    /// coincidence.
+    pub fn image_bin(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+        }
+    }
+}
+
 /// Best-effort reclamation of containers left behind by dead Fletch
 /// instances, for app startup (`lib.rs`, next to the nested-root sweeps).
 /// Runs on its own thread and probes the daemon first, so startup never

--- a/src-tauri/src/sandbox/engine.rs
+++ b/src-tauri/src/sandbox/engine.rs
@@ -33,6 +33,11 @@ impl EngineKind {
 
 pub struct AgentLaunchCtx<'a> {
     pub agent_id: &'a str,
+    /// The provider launching (`AgentRecord.provider`). Seatbelt ignores it —
+    /// its profile is provider-agnostic — while the Docker engine branches on it
+    /// for the per-provider image, config-dir mount, and auth (see
+    /// [`sandbox::docker::DockerProvider`]).
+    pub provider: &'a str,
     pub writable_root: &'a Path,
     pub rpc_dir: &'a Path,
     pub cwd: &'a Path,

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -85,12 +85,15 @@ pub(super) fn effective_workspace_mode(engine: EngineKind, setting: Option<&str>
     }
 }
 
-/// Only claude runs in Docker sandboxes in v1 (the embedded image ships
-/// claude alone; per-turn CLIs haven't been ported). Checked before every
-/// spawn — fresh spawns and, via `spawn_agent_process`, resume/view-switch —
-/// so a docker-stamped record can never launch an unsupported provider.
+/// Which providers run in Docker sandboxes: those with a wired-up container
+/// image + config-mount + auth (see [`sandbox::docker::DockerProvider`]) — claude
+/// and codex so far, brought up one at a time as the rest are ported. Checked
+/// before every spawn — fresh spawns and, via `spawn_agent_process`,
+/// resume/view-switch — so a docker-stamped record can never launch an
+/// unsupported provider. Consults the capability lookup rather than string-
+/// matching a single provider id.
 fn ensure_engine_supports_provider(engine: EngineKind, provider: &str) -> Result<()> {
-    if engine == EngineKind::Docker && provider != "claude" {
+    if engine == EngineKind::Docker && sandbox::docker::DockerProvider::from_id(provider).is_none() {
         let label = per_turn_descriptor(provider)
             .map(|d| d.label())
             .unwrap_or(provider);
@@ -1220,11 +1223,18 @@ mod tests {
     }
 
     #[test]
-    fn docker_refuses_every_provider_but_claude() {
-        assert!(ensure_engine_supports_provider(EngineKind::Docker, "claude").is_ok());
-        for provider in ["codex", "cursor", "opencode", "pi", "antigravity"] {
+    fn docker_supports_claude_and_codex_but_refuses_the_rest() {
+        // Both wired-up providers launch under docker.
+        for provider in ["claude", "codex"] {
+            assert!(
+                ensure_engine_supports_provider(EngineKind::Docker, provider).is_ok(),
+                "{provider} should be docker-supported",
+            );
+        }
+        // The still-unported per-turn agents refuse with the stable copy.
+        for provider in ["cursor", "opencode", "pi", "antigravity"] {
             let err = ensure_engine_supports_provider(EngineKind::Docker, provider)
-                .expect_err("per-turn providers must refuse under docker");
+                .expect_err("unported providers must refuse under docker");
             assert!(
                 err.to_string()
                     .ends_with("isn't available in Docker sandboxes yet"),
@@ -1232,8 +1242,8 @@ mod tests {
             );
         }
         // The copy uses the human-facing product name, not the provider id.
-        let err = ensure_engine_supports_provider(EngineKind::Docker, "codex").unwrap_err();
-        assert!(err.to_string().starts_with("Codex "), "{err}");
+        let err = ensure_engine_supports_provider(EngineKind::Docker, "cursor").unwrap_err();
+        assert!(err.to_string().starts_with("Cursor "), "{err}");
 
         // Seatbelt is unaffected.
         for provider in ["claude", "codex", "cursor"] {

--- a/src/components/Composer/ModelPicker.tsx
+++ b/src/components/Composer/ModelPicker.tsx
@@ -4,7 +4,7 @@ import { ProviderIcon } from "@/components/ProviderIcon";
 import { Mono } from "@/components/SettingsScreen/CustomAgents/Mono";
 import { Chip } from "@/components/ui/Chip";
 import { Scrim } from "@/components/ui/Scrim";
-import { PROVIDERS, providerLabel } from "@/data/providers";
+import { isDockerSupported, PROVIDERS, providerLabel } from "@/data/providers";
 import { useAppStore } from "@/store";
 
 interface Props {
@@ -184,8 +184,9 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
                 // never disables an agent the user really has.
                 const installed = !providersProbed || !!providerPaths[p.id];
                 const missing = providersProbed && !installed;
-                // Non-Claude agents can't run under Docker yet (see dockerOnly).
-                const dockerBlocked = dockerOnly && p.id !== "claude";
+                // Providers without container support can't run under Docker yet
+                // (see dockerOnly + isDockerSupported).
+                const dockerBlocked = dockerOnly && !isDockerSupported(p.id);
                 const disabled = !installed || dockerBlocked;
                 // Why disabled — dockerBlocked wins over missing (a non-Claude
                 // agent under Docker is blocked regardless of install state).
@@ -200,8 +201,8 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
                     type="button"
                     // aria-disabled, not the native `disabled` attr: a disabled
                     // <button> swallows hover/pointer events in the WebView, so
-                    // its tooltip never shows and the user is left with only
-                    // "Docker: Claude only" and no reason. aria-disabled keeps
+                    // its tooltip never shows and the user is left with only the
+                    // "Not in Docker yet" chip and no reason. aria-disabled keeps
                     // the row hover-capable; the guarded handlers below keep it
                     // inert. The tooltip is the CSS `.tip`/`data-tip` one
                     // (shows on :hover), used only for the disabled explanation.
@@ -220,7 +221,7 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
                     <span className="model-agent-name truncate text-base">{p.label}</span>
                     <span className="model-agent-ver text-xs">
                       {dockerBlocked
-                        ? "Docker: Claude only"
+                        ? "Not in Docker yet"
                         : missing
                           ? "Not installed"
                           : providerVersions[p.id]}
@@ -238,7 +239,7 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
                 selectableCustom.map((a) => {
                   const active = a.id === customAgentId;
                   // A custom agent inherits its base provider's docker support.
-                  const dockerBlocked = dockerOnly && a.base !== "claude";
+                  const dockerBlocked = dockerOnly && !isDockerSupported(a.base);
                   return (
                     <button
                       key={a.id}

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -5,7 +5,7 @@ import { Icon } from "@/components/Icon";
 import { Chip } from "@/components/ui/Chip";
 import { lookupModel } from "@/data/modelCatalog";
 import { PROVIDER_DETAIL } from "@/data/providerDetail";
-import { DEFAULT_PROVIDER_ID, providerLabel } from "@/data/providers";
+import { DEFAULT_PROVIDER_ID, isDockerSupported, providerLabel } from "@/data/providers";
 import type { AgentUsage } from "@/store";
 import { useAppStore } from "@/store";
 import { AttachmentList } from "./AttachmentList";
@@ -153,13 +153,14 @@ export function Composer({
   const detail = PROVIDER_DETAIL[provider as keyof typeof PROVIDER_DETAIL];
   const thinkingLevels = detail?.thinkingLevels ?? [];
 
-  // A new-agent draft can still hold a non-Claude provider chosen before the
-  // sandbox engine was switched to Docker. Only Claude runs in Docker today, so
-  // block the send here — otherwise the stale selection reaches spawnAgent and
-  // fails in the backend. `provider` mirrors a custom agent's base, so this
-  // covers custom agents too. Existing sessions already spawned with their
-  // engine and keep a locked picker, so they're exempt.
-  const dockerBlocked = !existingSession && sandboxEngine === "docker" && provider !== "claude";
+  // A new-agent draft can still hold a docker-unsupported provider chosen
+  // before the sandbox engine was switched to Docker. Block the send here —
+  // otherwise the stale selection reaches spawnAgent and fails in the backend.
+  // `provider` mirrors a custom agent's base, so this covers custom agents too.
+  // Existing sessions already spawned with their engine and keep a locked
+  // picker, so they're exempt.
+  const dockerBlocked =
+    !existingSession && sandboxEngine === "docker" && !isDockerSupported(provider);
 
   const [thinkingValue, setThinkingValue] = useState<string | undefined>(() =>
     resolveThinking(defaultProvider),

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -177,7 +177,7 @@ export function GeneralPane() {
       <SetGroup label="Sandbox">
         <SetRow
           title="Engine"
-          sub="Applies to newly created agents; existing agents keep the engine they started with. Docker agents run in a Linux container: builds and tests run on Linux, not macOS. Only Claude Code is available in containers for now."
+          sub="Applies to newly created agents; existing agents keep the engine they started with. Docker agents run in a Linux container: builds and tests run on Linux, not macOS. Only Claude Code and Codex are available in containers for now."
         >
           <Select<SandboxEngine>
             value={sandboxEngine}

--- a/src/data/providers.ts
+++ b/src/data/providers.ts
@@ -19,14 +19,20 @@ export interface Provider {
   /** Agent manages its own model and ignores a per-session selection, so the
    *  picker offers no model choice (e.g. antigravity's `agy --print` runner). */
   fixedModel?: boolean;
+  /** Runs inside a Docker sandbox: the backend has this provider's container
+   *  image, config mount, and auth wired (see `sandbox::docker::DockerProvider`).
+   *  Providers without it are seatbelt-only for now and the picker blocks them
+   *  when the Docker engine is selected. Mirror the backend capability when a
+   *  new provider is ported. */
+  dockerSupported?: boolean;
 }
 
 // Versions and per-account status are never hardcoded here: the backend probes
 // real versions into the store (`providerVersions`, see refreshProviderVersions),
 // and honest, non-user-specific model routing lives in PROVIDER_DETAIL.
 export const PROVIDERS: Provider[] = [
-  { id: "claude", label: "Claude Code", short: "CC", hue: 28 },
-  { id: "codex", label: "Codex", short: "CX", hue: 145 },
+  { id: "claude", label: "Claude Code", short: "CC", hue: 28, dockerSupported: true },
+  { id: "codex", label: "Codex", short: "CX", hue: 145, dockerSupported: true },
   { id: "cursor", label: "Cursor Agent", short: "CR", hue: 215 },
   { id: "antigravity", label: "Antigravity", short: "AG", hue: 260, fixedModel: true },
   { id: "opencode", label: "OpenCode", short: "OC", hue: 195 },
@@ -34,6 +40,15 @@ export const PROVIDERS: Provider[] = [
 ];
 
 export const DEFAULT_PROVIDER_ID = "claude";
+
+/** Whether a provider (or a custom agent's base provider) can run under the
+ *  Docker sandbox engine. Mirrors the backend's
+ *  `ensure_engine_supports_provider` gate so the picker and the spawn path agree
+ *  on which providers are container-ready. Unknown ids are treated as
+ *  unsupported. */
+export function isDockerSupported(id: string | null | undefined): boolean {
+  return !!PROVIDERS.find((p) => p.id === id)?.dockerSupported;
+}
 
 /** URL for a provider/agent's brand icon on the website CDN. Icons live at
  *  /agents/<slug>.svg (slug === provider id), so a rebrand only needs the SVG


### PR DESCRIPTION
## Summary

Generalizes the Docker sandbox engine's claude-specific plumbing behind a per-provider capability gate and enables **Codex** as the second provider supported in Docker sandboxes. Cursor, OpenCode, Pi, and Antigravity keep the existing "isn't available in Docker sandboxes yet" error; seatbelt behavior is completely untouched.

## Changes

- **Capability gate**: new `DockerProvider` enum in `sandbox/docker/mod.rs` — the single lookup consulted by `ensure_engine_supports_provider`, bin selection, image resolution, and the launch path.
- **Per-provider images** (`image.rs`): Dockerfile/entrypoint become a per-provider `ImageSpec`. Codex's image shares claude's `node:22-slim` base layers and adds `npm install -g @openai/codex` with a minimal entrypoint. Claude's Dockerfile bytes and content-addressed tag are **frozen and guarded by a golden test**, so existing users don't rebuild.
- **Launch path** (`engine.rs`): provider-keyed image cache; codex mounts `$CODEX_HOME`/`~/.codex` read-write (auth.json token refresh + session rollouts land at the same host path, so the existing transcript reader keeps working), forwards `OPENAI_API_KEY`, and fails fast with a clear message when neither `auth.json` nor the key is present. Claude's argv path is byte-for-byte unchanged.
- **Bin selection** (`agent.rs`): `claude_bin_for` generalized to `agent_bin_for` — in-image bin name under Docker, host-resolved path under seatbelt.
- **Frontend**: `dockerSupported` capability flag in `providers.ts`; Composer picker and settings copy no longer hard-code claude ("Docker: Claude only" → "Not in Docker yet").

## Verification

- `cargo check`, `cargo clippy` (no new warnings), `cargo test`: **483 passed**
- `tsc`, biome, `npm test`: **352 passed**
- New unit tests: frozen claude image hash, codex image distinctness/base sharing, codex argv mounts + env forwarding, codex auth resolution, provider gate accepts claude+codex and refuses the rest
- End-to-end: built the codex image from the embedded constants against a live daemon — `codex` v0.142.5 lands on PATH

## Notes for reviewers

- The global `docker_image` override still applies verbatim to whichever provider launches (unchanged behavior, TODO noted). The hidden ExperimentalPane help text still says "must have Claude Code on PATH".
- `OPENAI_API_KEY` is read from the app process env only (not the login-shell probe claude's auth chain uses) — a user exporting it only in shell rc with no `auth.json` would fail; easy follow-up if it bites.
- Follow-up PRs will add opencode/pi (file-based auth, same pattern) then cursor/antigravity pending auth investigation; at 4+ providers the additive `RunSpec` fields should be refactored into an enum-of-directives shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)