### PR TITLE
feat(docker): support Cursor agents in Docker sandboxes

### DIFF
--- a/src-tauri/src/sandbox/docker/engine.rs
+++ b/src-tauri/src/sandbox/docker/engine.rs
@@ -257,6 +257,7 @@ impl SandboxEngine for DockerEngine {
         let mut forward_xdg_data_home = false;
         let mut forward_xdg_config_home = false;
         let mut pi_data: Option<PathBuf> = None;
+        let mut cursor_data: Option<PathBuf> = None;
 
         // The config-dir env (CLAUDE_CONFIG_DIR / CODEX_HOME / XDG_*) is pushed
         // before this mark so only the *auth* tail is forwarded as auth vars.
@@ -382,6 +383,20 @@ impl SandboxEngine for DockerEngine {
                 prepare_pi_launch(&mut env, &data, api_keys)?;
                 pi_data = Some(data);
             }
+            DockerProvider::Cursor => {
+                // `~/.cursor` is bound read-write at its identical host path so
+                // cursor's session transcripts land where the host reader
+                // (`agent::cursor_locate`) tails them. It carries no credential
+                // (the login token is keychain-bound); auth is CURSOR_API_KEY only.
+                let data = ctx.home.join(".cursor");
+                auth_start = env.len();
+                prepare_cursor_launch(
+                    &mut env,
+                    &data,
+                    std::env::var("CURSOR_API_KEY").ok().as_deref(),
+                )?;
+                cursor_data = Some(data);
+            }
         }
 
         // Forward exactly the resolved auth var names (the tail appended after
@@ -420,6 +435,11 @@ impl SandboxEngine for DockerEngine {
                     data_dir: pi_data
                         .as_deref()
                         .expect("pi launch must supply a data_dir"),
+                },
+                DockerProvider::Cursor => ProviderMounts::Cursor {
+                    data_dir: cursor_data
+                        .as_deref()
+                        .expect("cursor launch must supply a data_dir"),
                 },
             };
             run_args(&RunSpec {
@@ -525,6 +545,15 @@ const NO_OPENCODE_AUTH_MSG: &str =
 /// `~/.pi/agent/auth.json` on its mount and no known provider API key set.
 const NO_PI_AUTH_MSG: &str =
     "No Pi credentials for containers — sign in with `pi` on the host (writes ~/.pi/agent/auth.json) or set a provider API key (e.g. ANTHROPIC_API_KEY or OPENAI_API_KEY).";
+
+/// Launch-blocking message when cursor has no usable credential. Unlike the other
+/// providers there is no mount-based fallback: `cursor-agent login` stores its
+/// access/refresh tokens in the host OS keychain (macOS "Cursor Safe Storage"),
+/// which a Linux container can't read, and `~/.cursor` carries only identity
+/// metadata — not a bearer token. So `CURSOR_API_KEY` is the sole container
+/// credential; fail fast (before touching the filesystem) when it's unset.
+const NO_CURSOR_AUTH_MSG: &str =
+    "No Cursor credentials for containers — set CURSOR_API_KEY (create one at cursor.com/dashboard). `cursor-agent login` stores its token in the host keychain, which containers can't read.";
 
 /// Provider API-key env vars the multi-provider CLIs (opencode, pi) read to
 /// authenticate. Whichever are set in the app's process env are forwarded by bare
@@ -748,6 +777,50 @@ fn prepare_pi_launch(
     Ok(())
 }
 
+/// Fold cursor's container auth into the docker CLI's process env, then make sure
+/// `~/.cursor` exists so the read-write bind has a host source. Cursor is a
+/// single-provider CLI, so — like codex — no cross-provider key set applies;
+/// unlike every other provider, though, its credential can't ride the mount:
+/// `cursor-agent login` writes its tokens to the host OS keychain (see
+/// [`NO_CURSOR_AUTH_MSG`]), so `CURSOR_API_KEY` (forwarded by bare `-e` — invariant
+/// 3) is the only container credential. The `~/.cursor` mount still matters: it's
+/// where cursor writes session transcripts (`agent::cursor_locate` reads them at
+/// the identical host path), so the dir is created for the bind even though it
+/// carries no auth. Fails the launch when `CURSOR_API_KEY` is unset, before
+/// touching the filesystem. Only a boolean is logged, never the key.
+fn prepare_cursor_launch(
+    env: &mut Vec<(String, String)>,
+    config_dir: &Path,
+    api_key: Option<&str>,
+) -> Result<()> {
+    let resolved = cursor_auth_env(api_key)?;
+    tracing::info!(
+        target: "fletch::docker",
+        api_key = !resolved.is_empty(),
+        "cursor container auth resolved"
+    );
+    env.extend(resolved);
+    std::fs::create_dir_all(config_dir).map_err(|e| {
+        Error::Other(format!(
+            "Couldn't create Cursor config dir {}: {e}",
+            config_dir.display()
+        ))
+    })?;
+    Ok(())
+}
+
+/// Pure core of [`prepare_cursor_launch`]: the auth env to forward given the
+/// process `CURSOR_API_KEY`. A non-blank key is forwarded (trimmed); anything
+/// else — unset or blank — is the launch-blocking error, because cursor's login
+/// token lives in the host keychain and can't reach the container by any other
+/// path (see [`NO_CURSOR_AUTH_MSG`]).
+fn cursor_auth_env(api_key: Option<&str>) -> Result<Vec<(String, String)>> {
+    match api_key.map(str::trim).filter(|k| !k.is_empty()) {
+        Some(key) => Ok(vec![("CURSOR_API_KEY".to_string(), key.to_string())]),
+        None => Err(Error::Other(NO_CURSOR_AUTH_MSG.to_string())),
+    }
+}
+
 /// `Some(v)` only when `v` is present and non-blank — settings rows can hold
 /// empty strings, which must fall back to defaults.
 fn non_blank(value: Option<&str>) -> Option<&str> {
@@ -896,6 +969,11 @@ enum ProviderMounts<'a> {
     /// `agent/settings.json`, and the `agent/sessions/` transcripts the host
     /// reader tails at the identical path.
     Pi { data_dir: &'a Path },
+    /// Cursor: `~/.cursor` bind-mounted **read-write** — it holds the
+    /// `projects/<slug>/agent-transcripts/` session logs the host reader tails at
+    /// the identical path. Carries no credential (cursor's login token is
+    /// keychain-bound); auth is the forwarded `CURSOR_API_KEY` only.
+    Cursor { data_dir: &'a Path },
 }
 
 /// Everything [`run_args`] needs, bundled so the builder is pure and the argv
@@ -994,6 +1072,7 @@ fn run_args(spec: &RunSpec<'_>) -> Vec<String> {
             }
         }
         ProviderMounts::Pi { data_dir } => push_rw_bind(&mut args, data_dir),
+        ProviderMounts::Cursor { data_dir } => push_rw_bind(&mut args, data_dir),
     }
     args.push("-w".into());
     args.push(spec.cwd.to_string_lossy().into_owned());
@@ -1025,6 +1104,9 @@ fn run_args(spec: &RunSpec<'_>) -> Vec<String> {
             }
         }
         ProviderMounts::Pi { .. } => {}
+        // Cursor forwards no config-dir env; its sole auth var (CURSOR_API_KEY)
+        // rides `spec.auth_vars` like every other resolved credential.
+        ProviderMounts::Cursor { .. } => {}
     }
     forwarded.extend(spec.auth_vars.iter().copied());
     for var in forwarded {
@@ -1577,6 +1659,17 @@ mod tests {
         )
     }
 
+    fn cursor_spec<'a>() -> RunSpec<'a> {
+        rw_config_spec(
+            ProviderMounts::Cursor {
+                data_dir: Path::new("/Users/u/.cursor"),
+            },
+            "fletch-agent-cursor:abc123def456",
+            "cursor-agent",
+            &["CURSOR_API_KEY"],
+        )
+    }
+
     /// Assert no claude/codex config surface leaks into another provider's argv:
     /// no `~/.claude` mount, no tmpfs overlay, no `projects/` transcript bind, and
     /// no `~/.codex` mount. Shared by the opencode and pi mount tests.
@@ -1665,6 +1758,36 @@ mod tests {
         }
         assert_eq!(args[args.len() - 2], "fletch-agent-pi:abc123def456");
         assert_eq!(args[args.len() - 1], "pi");
+    }
+
+    /// Cursor mounts `~/.cursor` read-write (session transcripts must reach the
+    /// host) and launches the cursor image + `cursor-agent` bin; no claude/codex
+    /// surface, and its sole auth var rides by bare name only (invariant 3).
+    #[test]
+    fn argv_cursor_mounts_dot_cursor_read_write() {
+        let args = run_args(&cursor_spec());
+        assert_eq!(
+            values_of(&args, "-v"),
+            vec![
+                "/Users/u/.fletch/worktrees/orkney:/Users/u/.fletch/worktrees/orkney",
+                "/Users/u/.fletch/rpc/orkney:/Users/u/.fletch/rpc/orkney",
+                "/Users/u/.cursor:/Users/u/.cursor",
+            ],
+        );
+        assert_no_claude_or_codex_surface(&args);
+        let forwarded = values_of(&args, "-e");
+        assert!(forwarded.contains(&"CURSOR_API_KEY"), "missing bare -e CURSOR_API_KEY");
+        assert!(!forwarded.contains(&"CLAUDE_CONFIG_DIR"));
+        assert!(!forwarded.contains(&"CODEX_HOME"));
+        // No token value in argv, only the label token may carry an `=`.
+        for arg in &args {
+            assert!(
+                !arg.contains('=') || arg.starts_with("fletch."),
+                "argv token `{arg}` carries a value",
+            );
+        }
+        assert_eq!(args[args.len() - 2], "fletch-agent-cursor:abc123def456");
+        assert_eq!(args[args.len() - 1], "cursor-agent");
     }
 
     #[test]
@@ -2146,6 +2269,41 @@ mod tests {
         let err = prepare_pi_launch(&mut Vec::new(), &none, Vec::new()).unwrap_err();
         assert_eq!(err.to_string(), NO_PI_AUTH_MSG);
         assert!(!none.exists(), "auth failure must not create the dir");
+    }
+
+    /// Cursor auth: a non-blank `CURSOR_API_KEY` is forwarded (trimmed); anything
+    /// else fails the launch. Unlike the other providers there is *no* mount
+    /// fallback — the keychain-bound login token can't reach a container — so a
+    /// missing/blank key is the only outcome besides a forwarded key.
+    #[test]
+    fn cursor_auth_env_forwards_key_or_fails() {
+        assert_eq!(
+            cursor_auth_env(Some(" cur-key \n")).unwrap(),
+            vec![("CURSOR_API_KEY".to_string(), "cur-key".to_string())],
+        );
+        // No mount fallback: unset and blank both fail with the settings pointer.
+        assert_eq!(cursor_auth_env(None).unwrap_err().to_string(), NO_CURSOR_AUTH_MSG);
+        assert_eq!(cursor_auth_env(Some("   ")).unwrap_err().to_string(), NO_CURSOR_AUTH_MSG);
+    }
+
+    /// Regression (mirrors the codex key-only case): a cursor user with
+    /// `CURSOR_API_KEY` set launches — the missing `~/.cursor` is created for the
+    /// RW transcript bind. With no key the launch fails, before touching disk
+    /// (there is no mounted-credential path for cursor to fall back to).
+    #[test]
+    fn cursor_key_only_launch_creates_missing_config_dir() {
+        let td = tempfile::tempdir().unwrap();
+
+        let dir = td.path().join(".cursor");
+        let mut env = Vec::new();
+        prepare_cursor_launch(&mut env, &dir, Some("cur-key")).unwrap();
+        assert!(dir.is_dir(), "~/.cursor must exist for the RW bind mount");
+        assert_eq!(env, vec![("CURSOR_API_KEY".to_string(), "cur-key".to_string())]);
+
+        let no_auth = td.path().join(".cursor-no-auth");
+        let err = prepare_cursor_launch(&mut Vec::new(), &no_auth, None).unwrap_err();
+        assert_eq!(err.to_string(), NO_CURSOR_AUTH_MSG);
+        assert!(!no_auth.exists(), "auth failure must not create the dir");
     }
 
     /// Integration: a real `docker run` round-trip through the exact argv the

--- a/src-tauri/src/sandbox/docker/image.rs
+++ b/src-tauri/src/sandbox/docker/image.rs
@@ -136,6 +136,43 @@ mkdir -p "$HOME"
 exec "$@"
 "#;
 
+/// Cursor's image. Shares [`DOCKERFILE`]'s base byte-for-byte (same `FROM
+/// node:22-slim` and apt line) for layer-cache reuse; only the install step
+/// differs. Unlike the other providers, cursor-agent ships not as an npm package
+/// but via its official installer (`https://cursor.com/install`), which detects
+/// `linux/arm64` and downloads a self-contained bundle (its own node runtime +
+/// per-arch native modules) into `~/.local`; we symlink its `cursor-agent`
+/// launcher onto PATH so the in-image `agent_bin` resolves. The installer pins
+/// whatever version its script currently references — no worse than the `latest`
+/// npm installs the other images use: the Dockerfile *text* is constant so the
+/// content-addressed tag is stable, while a re-pull may fetch a newer bundle
+/// (contents drift under a stable tag — an accepted, documented tradeoff shared
+/// with every `npm install -g <pkg>` here). Cursor authenticates in-container from
+/// a forwarded `CURSOR_API_KEY` (see [`super::engine`]): `cursor-agent login`
+/// stores its tokens in the host OS keychain, which a container can't read, so the
+/// image carries no provider config of its own.
+pub const CURSOR_DOCKERFILE: &str = r#"FROM node:22-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl ca-certificates ripgrep jq procps \
+ && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://cursor.com/install | bash \
+ && ln -s /root/.local/bin/cursor-agent /usr/local/bin/cursor-agent
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+"#;
+
+/// Cursor's PID-1 shim: create `HOME` and exec. `cursor-agent -p --output-format
+/// stream-json --force --trust` (see `agent::cursor_build_args`) runs one turn
+/// non-interactively; credentials arrive as the forwarded `CURSOR_API_KEY` env
+/// var and its transcripts land on the read-write `~/.cursor` mount, so nothing is
+/// seeded here.
+pub const CURSOR_ENTRYPOINT_SH: &str = r#"#!/bin/sh
+set -e
+mkdir -p "$HOME"
+exec "$@"
+"#;
+
 /// The image build inputs for a provider: repo name plus the Dockerfile and
 /// entrypoint whose combined content addresses the tag. Claude returns the
 /// original constants under the original repo name, so its tag is byte-for-byte
@@ -170,6 +207,11 @@ fn image_spec(provider: DockerProvider) -> ImageSpec {
             repo: "fletch-agent-pi",
             dockerfile: PI_DOCKERFILE,
             entrypoint: PI_ENTRYPOINT_SH,
+        },
+        DockerProvider::Cursor => ImageSpec {
+            repo: "fletch-agent-cursor",
+            dockerfile: CURSOR_DOCKERFILE,
+            entrypoint: CURSOR_ENTRYPOINT_SH,
         },
     }
 }
@@ -379,10 +421,20 @@ mod tests {
         assert!(!CODEX_DOCKERFILE.contains("claude-code"));
     }
 
-    /// The base layers (everything before the `RUN npm install` line) that every
-    /// provider image must share byte-for-byte so Docker's layer cache is reused.
+    /// The base layers (`FROM` + the shared apt step, through the apt-list
+    /// cleanup) that every provider image must share byte-for-byte so Docker's
+    /// layer cache is reused. Stops at the apt cleanup rather than the install
+    /// `RUN` so it's install-agnostic — npm-installed providers and cursor's
+    /// curl-installer image both compare equal on the base.
     fn base_layers(dockerfile: &str) -> Vec<&str> {
-        dockerfile.lines().take_while(|l| !l.starts_with("RUN npm")).collect()
+        let mut out = Vec::new();
+        for line in dockerfile.lines() {
+            out.push(line);
+            if line.contains("rm -rf /var/lib/apt/lists") {
+                break;
+            }
+        }
+        out
     }
 
     /// OpenCode and Pi each get their own repo + distinct tag, share claude's base
@@ -410,6 +462,37 @@ mod tests {
 
         // The two new tags are distinct from each other, too.
         assert_ne!(image_tag(DockerProvider::Opencode), image_tag(DockerProvider::Pi));
+    }
+
+    /// Cursor gets its own repo + distinct tag and shares claude's base layers
+    /// (cache reuse) even though it installs via the official curl installer
+    /// rather than npm — the base-sharing invariant is install-agnostic. No other
+    /// provider's package leaks into the image.
+    #[test]
+    fn cursor_image_is_distinct_and_shares_base() {
+        let cursor = image_tag(DockerProvider::Cursor);
+        assert!(cursor.starts_with("fletch-agent-cursor:"), "{cursor}");
+        for other in [
+            DockerProvider::Claude,
+            DockerProvider::Codex,
+            DockerProvider::Opencode,
+            DockerProvider::Pi,
+        ] {
+            assert_ne!(cursor, image_tag(other), "cursor tag collides with {other:?}");
+        }
+        // Base (FROM + apt) byte-identical despite the curl-installer install step.
+        assert_eq!(
+            base_layers(CURSOR_DOCKERFILE),
+            base_layers(DOCKERFILE),
+            "base layers must match for cache reuse",
+        );
+        // Installs cursor-agent via its official installer; no other provider's pkg.
+        assert!(CURSOR_DOCKERFILE.contains("cursor.com/install"));
+        assert!(CURSOR_DOCKERFILE.contains("cursor-agent"));
+        assert!(!CURSOR_DOCKERFILE.contains("claude-code"));
+        assert!(!CURSOR_DOCKERFILE.contains("@openai/codex"));
+        assert!(!CURSOR_DOCKERFILE.contains("opencode-ai"));
+        assert!(!CURSOR_DOCKERFILE.contains("pi-coding-agent"));
     }
 
     #[test]

--- a/src-tauri/src/sandbox/docker/image.rs
+++ b/src-tauri/src/sandbox/docker/image.rs
@@ -142,7 +142,10 @@ exec "$@"
 /// but via its official installer (`https://cursor.com/install`), which detects
 /// `linux/arm64` and downloads a self-contained bundle (its own node runtime +
 /// per-arch native modules) into `~/.local`; we symlink its `cursor-agent`
-/// launcher onto PATH so the in-image `agent_bin` resolves. The installer pins
+/// launcher onto PATH so the in-image `agent_bin` resolves, then run
+/// `--version` so a build fails loudly if the installer ever relocates the
+/// binary — `ln -s` happily creates a dangling link, and without the check
+/// that drift would only surface as exit-127 launches. The installer pins
 /// whatever version its script currently references — no worse than the `latest`
 /// npm installs the other images use: the Dockerfile *text* is constant so the
 /// content-addressed tag is stable, while a re-pull may fetch a newer bundle
@@ -156,7 +159,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git curl ca-certificates ripgrep jq procps \
  && rm -rf /var/lib/apt/lists/*
 RUN curl -fsSL https://cursor.com/install | bash \
- && ln -s /root/.local/bin/cursor-agent /usr/local/bin/cursor-agent
+ && ln -s /root/.local/bin/cursor-agent /usr/local/bin/cursor-agent \
+ && cursor-agent --version
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/src-tauri/src/sandbox/docker/mod.rs
+++ b/src-tauri/src/sandbox/docker/mod.rs
@@ -42,14 +42,18 @@ pub use progress::set_build_sink;
 /// provider-agnostic.
 ///
 /// Seatbelt runs six providers; Docker is being brought up one at a time as each
-/// gets its image + config-mount + auth wired here — claude, codex, opencode, and
-/// pi so far (cursor and antigravity are still gated).
+/// gets its image + config-mount + auth wired here — claude, codex, opencode, pi,
+/// and cursor so far. antigravity remains gated: its CLI (`agy`) has no
+/// non-interactive credential path — auth is browser OAuth with its tokens in the
+/// host keychain and no API-key env fallback (maintainer-confirmed), so a fresh
+/// container cannot authenticate. See `ensure_engine_supports_provider`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DockerProvider {
     Claude,
     Codex,
     Opencode,
     Pi,
+    Cursor,
 }
 
 impl DockerProvider {
@@ -63,6 +67,7 @@ impl DockerProvider {
             "codex" => Some(Self::Codex),
             "opencode" => Some(Self::Opencode),
             "pi" => Some(Self::Pi),
+            "cursor" => Some(Self::Cursor),
             _ => None,
         }
     }
@@ -79,6 +84,7 @@ impl DockerProvider {
             Self::Codex => "codex",
             Self::Opencode => "opencode",
             Self::Pi => "pi",
+            Self::Cursor => "cursor-agent",
         }
     }
 }

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -87,8 +87,9 @@ pub(super) fn effective_workspace_mode(engine: EngineKind, setting: Option<&str>
 
 /// Which providers run in Docker sandboxes: those with a wired-up container
 /// image + config-mount + auth (see [`sandbox::docker::DockerProvider`]) — claude,
-/// codex, opencode, and pi so far (cursor and antigravity are still gated),
-/// brought up as the rest are ported. Checked
+/// codex, opencode, pi, and cursor so far. antigravity stays gated: its CLI has no
+/// non-interactive credential path (browser-OAuth only, tokens in the host
+/// keychain, no API-key env fallback), so a container can't authenticate. Checked
 /// before every spawn — fresh spawns and, via `spawn_agent_process`,
 /// resume/view-switch — so a docker-stamped record can never launch an
 /// unsupported provider. Consults the capability lookup rather than string-
@@ -1226,28 +1227,25 @@ mod tests {
     #[test]
     fn docker_supports_wired_providers_but_refuses_the_rest() {
         // All wired-up providers launch under docker.
-        for provider in ["claude", "codex", "opencode", "pi"] {
+        for provider in ["claude", "codex", "opencode", "pi", "cursor"] {
             assert!(
                 ensure_engine_supports_provider(EngineKind::Docker, provider).is_ok(),
                 "{provider} should be docker-supported",
             );
         }
-        // The still-unported per-turn agents refuse with the stable copy.
-        for provider in ["cursor", "antigravity"] {
-            let err = ensure_engine_supports_provider(EngineKind::Docker, provider)
-                .expect_err("unported providers must refuse under docker");
-            assert!(
-                err.to_string()
-                    .ends_with("isn't available in Docker sandboxes yet"),
-                "unexpected refusal copy: {err}",
-            );
-        }
+        // antigravity is the last still-gated provider — no container auth path.
+        let err = ensure_engine_supports_provider(EngineKind::Docker, "antigravity")
+            .expect_err("antigravity must refuse under docker");
+        assert!(
+            err.to_string()
+                .ends_with("isn't available in Docker sandboxes yet"),
+            "unexpected refusal copy: {err}",
+        );
         // The copy uses the human-facing product name, not the provider id.
-        let err = ensure_engine_supports_provider(EngineKind::Docker, "cursor").unwrap_err();
-        assert!(err.to_string().starts_with("Cursor "), "{err}");
+        assert!(err.to_string().starts_with("Antigravity "), "{err}");
 
         // Seatbelt is unaffected.
-        for provider in ["claude", "codex", "cursor"] {
+        for provider in ["claude", "codex", "cursor", "antigravity"] {
             assert!(ensure_engine_supports_provider(EngineKind::SandboxExec, provider).is_ok());
         }
     }

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -177,7 +177,7 @@ export function GeneralPane() {
       <SetGroup label="Sandbox">
         <SetRow
           title="Engine"
-          sub="Applies to newly created agents; existing agents keep the engine they started with. Docker agents run in a Linux container: builds and tests run on Linux, not macOS. Claude Code, Codex, OpenCode, and Pi are available in containers for now; other agents stay on Seatbelt."
+          sub="Applies to newly created agents; existing agents keep the engine they started with. Docker agents run in a Linux container: builds and tests run on Linux, not macOS. Claude Code, Codex, OpenCode, Pi, and Cursor Agent are available in containers for now; Antigravity stays on Seatbelt."
         >
           <Select<SandboxEngine>
             value={sandboxEngine}

--- a/src/data/providers.ts
+++ b/src/data/providers.ts
@@ -33,7 +33,7 @@ export interface Provider {
 export const PROVIDERS: Provider[] = [
   { id: "claude", label: "Claude Code", short: "CC", hue: 28, dockerSupported: true },
   { id: "codex", label: "Codex", short: "CX", hue: 145, dockerSupported: true },
-  { id: "cursor", label: "Cursor Agent", short: "CR", hue: 215 },
+  { id: "cursor", label: "Cursor Agent", short: "CR", hue: 215, dockerSupported: true },
   { id: "antigravity", label: "Antigravity", short: "AG", hue: 260, fixedModel: true },
   { id: "opencode", label: "OpenCode", short: "OC", hue: 195, dockerSupported: true },
   { id: "pi", label: "Pi", short: "PI", hue: 320, dockerSupported: true },


### PR DESCRIPTION
## Summary

Final slice of the Docker multi-provider series (follows #367, #368): enables **Cursor** in Docker sandboxes, bringing coverage to **5 of 6 providers**. **Antigravity stays Seatbelt-only** with a documented upstream blocker. Claude/codex/opencode/pi Docker behavior is byte-identical; seatbelt untouched.

## Cursor

- **Image**: `cursor-agent` has no npm package — the official `https://cursor.com/install` script is used in the Dockerfile (detects linux/arm64, pulls a self-contained bundle with its own node + native modules). Same content-drift class as the npm-latest installs in the other images; documented in the dockerfile constant. Image shares the `node:22-slim` base layers.
- **Auth**: on macOS, `cursor-agent login` stores tokens in the **Keychain** ("Cursor Safe Storage"), not `~/.cursor` — so there is no credential file to mount. Container auth is **`CURSOR_API_KEY` only** (forwarded by bare `-e`, value never in argv), directly analogous to claude's Keychain-OAuth situation. No key set → fail-fast with a clear message. Deliberately no mounted-credential fallback: `~/.cursor`'s presence isn't a credential signal on macOS and would wrongly pass the gate for logged-in-but-keyless users; a file fallback can be added if Fletch ever supports Linux hosts.
- **Mounts**: `~/.cursor` bind-mounted read-write at the identical host path so session transcripts land where the host-side reader (`cursor_locate`) already looks.
- **Verified empirically**: real linux/arm64 image build (`cursor-agent 2026.07.01-41b2de7` on PATH), first run non-interactive through the real entrypoint with Fletch's exact argv — a bogus key returns a clean "API key is invalid", no prompt, no hang.

## Antigravity — blocked upstream, stays gated

Install is not the blocker (Google publishes a linux/arm64 installer). **`agy` has no non-interactive auth**: browser OAuth only, machine-bound token, no `--api-key` / `GEMINI_API_KEY` / env fallback — maintainer-confirmed as unsupported in the CLI's issue #78. A fresh container cannot authenticate, so it keeps the "isn't available in Docker sandboxes yet" error and the settings copy calls it out as Seatbelt-only. When upstream ships key-based auth, the integration is mechanical on the established pattern.

## Verification

- `cargo check`, `cargo clippy --all-targets` (0 new warnings), `cargo test`: **496 passed** (new: cursor argv/mount test, auth-env pure core, key-only-launch regression; gate test now 5 accepted / 1 refused)
- `tsc`, lint, `npm test`: **352 passed**
- Docker e2e: exact final Dockerfile built on linux/arm64; test images removed

## Series follow-ups

- `TODO(per-provider-override)` in `image.rs` — one global `docker_image` override still serves all providers.
- Watch antigravity issue #78; revisit when non-interactive auth lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)