### PR TITLE
fix(sidebar): make project drag-to-reorder work in the Tauri webview

### DIFF
--- a/src/components/Sidebar/ProjectGroup.tsx
+++ b/src/components/Sidebar/ProjectGroup.tsx
@@ -24,10 +24,10 @@ interface Props {
   dragging: boolean;
   /** Show a drop line above ("before") or below ("after") this group, or none. */
   dropIndicator: "before" | "after" | null;
-  onDragStart: () => void;
-  onDragEnterGroup: () => void;
-  onDropGroup: () => void;
-  onDragEndGroup: () => void;
+  /** Start a pointer-driven reorder from this group's header. `markDragged` is
+   *  called once the pointer clears the drag threshold, so the group can swallow
+   *  the trailing click. Undefined when reordering is disabled (searching). */
+  onReorderPointerDown?: (e: React.PointerEvent, markDragged: () => void) => void;
 }
 
 export function ProjectGroup({
@@ -41,10 +41,7 @@ export function ProjectGroup({
   reorderable,
   dragging,
   dropIndicator,
-  onDragStart,
-  onDragEnterGroup,
-  onDropGroup,
-  onDragEndGroup,
+  onReorderPointerDown,
 }: Props) {
   const selectedAgentId = useAppStore((s) => s.selectedAgentId);
   const activeDraftId = useAppStore((s) => s.activeDraftId);
@@ -71,18 +68,23 @@ export function ProjectGroup({
 
   const dropClass = dropIndicator ? `drop-${dropIndicator}` : "";
 
-  // A native drag that ends on the header dispatches a trailing `click` in some
-  // browsers, which would toggle the group open/closed after a reorder. Track
-  // whether the current interaction turned into a drag (set on dragstart, reset
-  // when a fresh press begins) and swallow that phantom click.
+  // A pointer drag that ends on the header still dispatches a trailing `click`,
+  // which would toggle the group open/closed after a reorder. Track whether the
+  // current interaction turned into a drag and swallow that phantom click.
   const draggedRef = useRef(false);
 
   return (
-    <div className={`proj ${dragging ? "dragging" : ""} ${dropClass}`}>
+    <div className={`proj ${dragging ? "dragging" : ""} ${dropClass}`} data-repo-path={repoPath}>
       <div
         className={`proj-h flex-center ${open ? "open" : ""} ${reorderable ? "reorderable" : ""}`}
-        onMouseDown={() => {
+        onPointerDown={(e) => {
+          // Left button only, and never from an action button (add/remove).
+          if (!onReorderPointerDown || e.button !== 0) return;
+          if ((e.target as HTMLElement).closest("button")) return;
           draggedRef.current = false;
+          onReorderPointerDown(e, () => {
+            draggedRef.current = true;
+          });
         }}
         onClick={() => {
           if (draggedRef.current) {
@@ -92,32 +94,6 @@ export function ProjectGroup({
           onToggle();
         }}
         title={repoPath}
-        draggable={reorderable}
-        onDragStart={(e) => {
-          draggedRef.current = true;
-          // Marks the drag as a move; the payload itself is tracked in React state.
-          e.dataTransfer.effectAllowed = "move";
-          e.dataTransfer.setData("text/plain", repoPath);
-          onDragStart();
-        }}
-        onDragEnter={reorderable ? onDragEnterGroup : undefined}
-        onDragOver={
-          reorderable
-            ? (e) => {
-                e.preventDefault();
-                e.dataTransfer.dropEffect = "move";
-              }
-            : undefined
-        }
-        onDrop={
-          reorderable
-            ? (e) => {
-                e.preventDefault();
-                onDropGroup();
-              }
-            : undefined
-        }
-        onDragEnd={reorderable ? onDragEndGroup : undefined}
       >
         {reorderable && <Icon name="grip" size={12} className="pgrip" />}
         <Icon name="chevR" size={10} className="chev" />

--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -111,6 +111,7 @@
   color: var(--fg-2);
   transition: background 0.1s;
   position: relative;
+  user-select: none;
 }
 .proj-h:hover {
   background: var(--hover);

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { AgentRecord } from "@/api";
 import { Icon } from "@/components/Icon";
 import { NewProject, type NewProjectMode } from "@/components/NewProject";
@@ -77,9 +77,18 @@ export function Sidebar() {
   const [npOpen, setNpOpen] = useState(false);
   const [npMode, setNpMode] = useState<NewProjectMode | null>(null);
   // Transient drag state for reordering: the group being dragged and the one
-  // currently hovered as a drop target.
+  // currently hovered as a drop target. Driven by pointer events (not the HTML5
+  // drag-and-drop API, which Tauri's OS-level drag-drop handler swallows inside
+  // the macOS webview — that handler stays on for the composer's file drop).
   const [dragPath, setDragPath] = useState<string | null>(null);
   const [overPath, setOverPath] = useState<string | null>(null);
+  const dragInfo = useRef<{
+    path: string;
+    x: number;
+    y: number;
+    active: boolean;
+    over: string | null;
+  } | null>(null);
 
   const { sortPaths, reorder } = useProjectReorder();
 
@@ -103,13 +112,44 @@ export function Sidebar() {
   const reorderable = !query.trim();
   const orderedPaths = useMemo(() => groups.map((g) => g.repoPath), [groups]);
 
-  function endDrag() {
-    setDragPath(null);
-    setOverPath(null);
-  }
-  function onDrop(target: string) {
-    if (dragPath) reorder(orderedPaths, dragPath, target);
-    endDrag();
+  // Begin a pointer-driven reorder. `markDragged` lets the group swallow the
+  // trailing click so a real drag doesn't also toggle it open/closed. The order
+  // is captured up front — it doesn't change mid-drag.
+  function startReorder(path: string, e: React.PointerEvent, markDragged: () => void) {
+    const paths = orderedPaths;
+    dragInfo.current = { path, x: e.clientX, y: e.clientY, active: false, over: null };
+
+    const onMove = (ev: PointerEvent) => {
+      const info = dragInfo.current;
+      if (!info) return;
+      // Only promote to a drag once the pointer clears a small threshold, so a
+      // plain click still falls through to the toggle.
+      if (!info.active) {
+        if (Math.hypot(ev.clientX - info.x, ev.clientY - info.y) < 4) return;
+        info.active = true;
+        markDragged();
+        setDragPath(info.path);
+      }
+      const target = document
+        .elementFromPoint(ev.clientX, ev.clientY)
+        ?.closest<HTMLElement>("[data-repo-path]");
+      const over = target?.dataset.repoPath ?? null;
+      info.over = over;
+      setOverPath(over);
+    };
+    const onUp = () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      const info = dragInfo.current;
+      dragInfo.current = null;
+      if (info?.active && info.over && info.over !== info.path) {
+        reorder(paths, info.path, info.over);
+      }
+      setDragPath(null);
+      setOverPath(null);
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
   }
 
   // Auto-expand a project when its agent or draft is selected.
@@ -166,10 +206,11 @@ export function Sidebar() {
                   reorderable={reorderable}
                   dragging={dragPath === g.repoPath}
                   dropIndicator={isOver ? (dropAfter ? "after" : "before") : null}
-                  onDragStart={() => setDragPath(g.repoPath)}
-                  onDragEnterGroup={() => setOverPath(g.repoPath)}
-                  onDropGroup={() => onDrop(g.repoPath)}
-                  onDragEndGroup={endDrag}
+                  onReorderPointerDown={
+                    reorderable
+                      ? (e, markDragged) => startReorder(g.repoPath, e, markDragged)
+                      : undefined
+                  }
                 />
               );
             })

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -89,6 +89,10 @@ export function Sidebar() {
     active: boolean;
     over: string | null;
   } | null>(null);
+  // Tears down the in-flight drag's window listeners and resets state. Held in a
+  // ref so an interrupted drag (pointercancel, or the sidebar unmounting) can
+  // clean up too — not just a normal pointerup.
+  const dragCleanup = useRef<(() => void) | null>(null);
 
   const { sortPaths, reorder } = useProjectReorder();
 
@@ -137,20 +141,39 @@ export function Sidebar() {
       info.over = over;
       setOverPath(over);
     };
-    const onUp = () => {
+    // `commit` is true only for a clean pointerup; a cancel or unmount tears the
+    // drag down without reordering.
+    // `commit` is true only for a clean pointerup; a cancel, focus loss, or
+    // unmount tears the drag down without reordering.
+    const finish = (commit: boolean) => {
       window.removeEventListener("pointermove", onMove);
       window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onCancel);
+      window.removeEventListener("blur", onCancel);
+      dragCleanup.current = null;
       const info = dragInfo.current;
       dragInfo.current = null;
-      if (info?.active && info.over && info.over !== info.path) {
+      if (commit && info?.active && info.over && info.over !== info.path) {
         reorder(paths, info.path, info.over);
       }
       setDragPath(null);
       setOverPath(null);
     };
+    const onUp = () => finish(true);
+    const onCancel = () => finish(false);
+
+    dragCleanup.current = () => finish(false);
     window.addEventListener("pointermove", onMove);
     window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onCancel);
+    // The webview can drop the pointer stream on focus loss without a
+    // pointercancel; bail out so the drag can't get stuck.
+    window.addEventListener("blur", onCancel);
   }
+
+  // Safety net: if the sidebar unmounts mid-drag, tear down the window listeners
+  // so they don't leak past this component's life.
+  useEffect(() => () => dragCleanup.current?.(), []);
 
   // Auto-expand a project when its agent or draft is selected.
   useEffect(() => {


### PR DESCRIPTION
## Problem
Project drag-to-reorder in the sidebar was non-functional: you could pick up a project, but there was no drop indicator and it never landed where you dropped it.

## Root cause
Reordering used the native HTML5 drag-and-drop API. This is a Tauri v2 app, and on macOS (WKWebView) Tauri's OS-level drag-drop handler intercepts drop-target events (`dragenter`/`dragover`/`drop`) before they reach the page. The source-side `dragstart` still fires (hence the element visibly drags), but nothing downstream does — so `overPath` never sets (no indicator) and `drop` never fires (no landing).

That handler can't simply be disabled: `dragDropEnabled` must stay on for the composer's drag-a-file-to-attach feature (`useFileDrop.ts`, which subscribes to Tauri's `onDragDropEvent`).

## Fix
Drive reordering with **pointer events**, which are unaffected by the OS drag-drop handler, so both features coexist:
- 4px movement threshold separates a click (toggle) from a drag.
- `document.elementFromPoint` hit-tests the group under the pointer via a new `data-repo-path` attribute.
- `pointerup` commits the move, reusing the existing `moveInOrder`/`reorder` math and drop-indicator wiring (unchanged).
- The **whole group** (header + agent rows) is now a valid drop target, replacing the old header-only 28px zone.
- `user-select: none` on the header prevents text selection while dragging.

Also incidentally fixes the WebKit drag-source-mutation flakiness noted during diagnosis.

## Verification
- `tsc` typecheck — clean
- `biome check` on changed files — clean
- `vitest` — 352/352 pass (incl. reorder math)
- `bun run build` — succeeds

Automated live-drag testing isn't possible in the sandbox (can't drive an OS pointer-drag in the Tauri webview). Manual check recommended: grab a project header → confirm the insertion line, that the order sticks across restart, that a plain click still expands/collapses, and that file-drop into the composer still attaches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)