### PR TITLE
fix(agent): keep turn active while a subagent runs

### DIFF
--- a/src-tauri/src/activity.rs
+++ b/src-tauri/src/activity.rs
@@ -116,6 +116,21 @@ impl ManagedActivity {
 
 impl Activity for ManagedActivity {
     fn observe_event(&mut self, event: &Value) {
+        // Subagent (sidechain) events carry the spawning Task/Agent tool's id in
+        // a top-level `parent_tool_use_id`. They belong to a nested turn, not the
+        // main one: a subagent's `result` must not end the main turn, and its
+        // tool_use/tool_result pairs must not touch the main turn's outstanding
+        // set. Ignore them entirely here — the main agent's own Task tool call
+        // stays in `outstanding_tools` until its real `tool_result`, which keeps
+        // `turn_ended()` false while the subagent runs. (The frontend mirrors
+        // this via `parent_tool_use_id` routing in reduce.ts.)
+        if event
+            .get("parent_tool_use_id")
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| !s.is_empty())
+        {
+            return;
+        }
         self.last_event_at = Some(Instant::now());
         if (self.is_turn_end)(event) {
             self.explicit_turn_end = true;
@@ -261,6 +276,43 @@ mod tests {
         a.observe_event(&serde_json::json!({
             "type": "assistant",
             "message": {"content": [{"type": "tool_use", "id": "toolu_1"}]}
+        }));
+        a.observe_event(&serde_json::json!({"type": "result", "subtype": "success"}));
+        assert!(a.turn_ended());
+    }
+
+    #[test]
+    fn managed_ignores_subagent_sidechain_events() {
+        // The main agent spawns a subagent via a Task tool call.
+        let mut a = ManagedActivity::claude();
+        a.observe_event(&serde_json::json!({
+            "type": "assistant",
+            "message": {"content": [{"type": "tool_use", "id": "toolu_task", "name": "Task"}]}
+        }));
+        assert!(!a.turn_ended());
+
+        // The subagent runs, emitting its own tool cycle and finally a `result`,
+        // all tagged with the spawning tool's id. None of it must end the main
+        // turn or leak into the main outstanding-tool set.
+        a.observe_event(&serde_json::json!({
+            "type": "assistant",
+            "parent_tool_use_id": "toolu_task",
+            "message": {"content": [{"type": "tool_use", "id": "toolu_sub", "name": "Bash"}]}
+        }));
+        assert_eq!(a.outstanding_tools.len(), 1); // only the main Task call
+        a.observe_event(&serde_json::json!({
+            "type": "result",
+            "parent_tool_use_id": "toolu_task",
+            "subtype": "success"
+        }));
+        // Subagent's result must NOT end the main turn — the Task call is still
+        // outstanding.
+        assert!(!a.turn_ended());
+
+        // The main agent finally gets the Task tool_result, then ends its turn.
+        a.observe_event(&serde_json::json!({
+            "type": "user",
+            "message": {"content": [{"type": "tool_result", "tool_use_id": "toolu_task"}]}
         }));
         a.observe_event(&serde_json::json!({"type": "result", "subtype": "success"}));
         assert!(a.turn_ended());

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -286,6 +286,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
                     item={item}
                     provider={agent.provider}
                     agentId={agent.id}
+                    busy={liveBusy}
                     turnId={turnIds[i]}
                   />
                   {turnFooters[i] != null && <TurnFooter {...turnFooters[i]!} />}

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -238,6 +238,17 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
   // anchor is redundant.
   const turnPending = liveBusy && isTurnPending(items) && turns.length <= 1;
 
+  // Index where the currently-open turn begins (the last top-level user
+  // message). Only tools at/after it belong to the running turn, so only they
+  // may show a live spinner — a dangling tool_call left by an interrupted or
+  // reloaded earlier turn must not light up when a later turn sets `busy`.
+  const openTurnStart = useMemo(() => {
+    for (let i = items.length - 1; i >= 0; i -= 1) {
+      if (items[i].kind === "user_message") return i;
+    }
+    return 0;
+  }, [items]);
+
   // Live-timer anchor: the backend's turn-start timestamp (from `turn:started`,
   // the same value the footer's duration uses, so they never drift). On reload
   // mid-turn no event fired this session, so fall back to the open turn's
@@ -286,7 +297,7 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
                     item={item}
                     provider={agent.provider}
                     agentId={agent.id}
-                    busy={liveBusy}
+                    busy={liveBusy && i >= openTurnStart}
                     turnId={turnIds[i]}
                   />
                   {turnFooters[i] != null && <TurnFooter {...turnFooters[i]!} />}

--- a/src/components/Workspace/messages/MessageItem.tsx
+++ b/src/components/Workspace/messages/MessageItem.tsx
@@ -27,11 +27,16 @@ export const MessageItem = memo(function MessageItem({
   item,
   provider,
   agentId,
+  busy,
   turnId,
 }: {
   item: ViewItem;
   provider?: string;
   agentId?: string;
+  /** The agent is mid-turn. Lets a tool row still awaiting its result show a
+   *  live "running" spinner (and a subagent step count) rather than looking
+   *  settled. Cleared when the turn ends, so no spinner ever hangs. */
+  busy?: boolean;
   /** Ordinal of this user turn, used by ChatNav to locate the bubble in the
    *  DOM. Set only for top-level navigable user prompts. */
   turnId?: number;
@@ -81,17 +86,32 @@ export const MessageItem = memo(function MessageItem({
       }
       const presenter = getPresenter(item.call.name);
       const children = item.call.children ?? [];
+      // In flight: the agent is busy and this call has no result yet (a long
+      // Bash, or a subagent still working). Kept collapsed — the spinner plus a
+      // live subagent step count signal activity without expanding the row.
+      const running = Boolean(busy) && !item.result;
       return (
         <ToolRow
           name={item.call.name}
           icon={presenter.icon}
           isError={item.result?.is_error}
-          summary={presenter.summary(item.call, item.result)}
+          running={running}
+          summary={
+            <>
+              {presenter.summary(item.call, item.result)}
+              {running && <SubagentProgress items={children} />}
+            </>
+          }
           expanded={
             <>
               {presenter.expanded(item.call, item.result)}
               {children.length > 0 && (
-                <SubagentThread items={children} provider={provider} agentId={agentId} />
+                <SubagentThread
+                  items={children}
+                  provider={provider}
+                  agentId={agentId}
+                  busy={busy}
+                />
               )}
             </>
           }
@@ -156,6 +176,21 @@ function UserBubble({
   );
 }
 
+/** Live progress badge for a running tool call that has spawned a subagent.
+ *  Counts the subagent's meaningful steps so far (assistant messages + tool
+ *  calls) and shows a dim "· N steps" hint next to the collapsed row summary,
+ *  so activity is visible without expanding the thread. Renders nothing for
+ *  ordinary tool calls (no children) — those just get the spinner. */
+function SubagentProgress({ items }: { items: ChatItem[] }) {
+  const steps = items.filter((c) => c.kind === "tool_call" || c.kind === "agent_message").length;
+  if (steps === 0) return null;
+  return (
+    <span style={{ color: "var(--fg-3)", marginLeft: 8 }}>
+      · {steps} step{steps === 1 ? "" : "s"}
+    </span>
+  );
+}
+
 /** A subagent's threaded sub-conversation, rendered inside its spawning
  *  tool row's expanded body. Runs the children through the same
  *  policy → pairing → MessageItem pipeline as the main log (so tool calls
@@ -165,10 +200,12 @@ function SubagentThread({
   items,
   provider,
   agentId,
+  busy,
 }: {
   items: ChatItem[];
   provider?: string;
   agentId?: string;
+  busy?: boolean;
 }) {
   // Re-derive only when the children or provider change — not on every parent
   // re-render (e.g. a streaming token elsewhere in the main log).
@@ -186,7 +223,13 @@ function SubagentThread({
       }}
     >
       {rows.map((row, i) => (
-        <MessageItem key={rowKey(row, i)} item={row} provider={provider} agentId={agentId} />
+        <MessageItem
+          key={rowKey(row, i)}
+          item={row}
+          provider={provider}
+          agentId={agentId}
+          busy={busy}
+        />
       ))}
     </div>
   );

--- a/src/components/Workspace/messages/MessageItem.tsx
+++ b/src/components/Workspace/messages/MessageItem.tsx
@@ -33,9 +33,11 @@ export const MessageItem = memo(function MessageItem({
   item: ViewItem;
   provider?: string;
   agentId?: string;
-  /** The agent is mid-turn. Lets a tool row still awaiting its result show a
-   *  live "running" spinner (and a subagent step count) rather than looking
-   *  settled. Cleared when the turn ends, so no spinner ever hangs. */
+  /** This row's turn is live: the agent is mid-turn AND the row is part of the
+   *  currently-open turn (top-level) or of a still-running parent tool (nested
+   *  subagent). Lets a tool still awaiting its result show a "running" spinner
+   *  (and a subagent step count) rather than looking settled — while keeping
+   *  dangling tool_calls from interrupted/earlier turns quiet. */
   busy?: boolean;
   /** Ordinal of this user turn, used by ChatNav to locate the bubble in the
    *  DOM. Set only for top-level navigable user prompts. */
@@ -110,7 +112,7 @@ export const MessageItem = memo(function MessageItem({
                   items={children}
                   provider={provider}
                   agentId={agentId}
-                  busy={busy}
+                  busy={running}
                 />
               )}
             </>

--- a/src/components/Workspace/messages/ToolRow.tsx
+++ b/src/components/Workspace/messages/ToolRow.tsx
@@ -1,18 +1,24 @@
 import { type ReactNode, useState } from "react";
 import { Icon, type IconName } from "@/components/Icon";
+import { Loader } from "@/components/ui/Loader";
 
 /** Shared chrome for every tool presenter: icon, name, one-line summary,
- *  click-to-expand. Presenters supply the summary and expanded bodies. */
+ *  click-to-expand. Presenters supply the summary and expanded bodies.
+ *  `running` marks a tool call still in flight (no result yet, agent busy) —
+ *  e.g. a long Bash or a spawned subagent — so the row shows a live spinner
+ *  instead of looking identical to a settled one. */
 export function ToolRow({
   name,
   icon = "wrench",
   isError,
+  running,
   summary,
   expanded,
 }: {
   name: string;
   icon?: IconName;
   isError?: boolean;
+  running?: boolean;
   summary: ReactNode;
   expanded: ReactNode;
 }) {
@@ -31,6 +37,7 @@ export function ToolRow({
           {name}
         </span>
         <span className="t-arg">{summary}</span>
+        {running && <Loader variant="muted" size="sm" aria-label={`${name} running`} />}
         <span className="t-result">{open ? "▾" : "▸"}</span>
       </button>
       {open && <div style={{ padding: "8px 14px 12px" }}>{expanded}</div>}


### PR DESCRIPTION
## Problem

When the main agent spawns a subagent (Task/Agent tool), the chat showed the turn as **ended/idle** even though a background subagent was still running and would keep producing logs.

## Root cause

The app has two independent turn-end detectors that disagreed about subagents:

- **Frontend** (`reduce.ts`) already routes sidechain events (tagged with `parent_tool_use_id`) into the spawning tool's nested log, so a subagent's `result` never ended the main turn there.
- **Backend** (`activity.rs`) — the authoritative source driving the sidebar's idle status — fed *every* event to `observe_event` and treated any `type: "result"` as turn-end. A subagent's `result` therefore flipped the agent to Idle while the main agent was still blocked inside its Task tool call.

## Fix

**Backend (sidebar false-idle):** `observe_event` now early-returns on any event with a non-empty top-level `parent_tool_use_id`. Sidechain `result`/tool events no longer touch `explicit_turn_end` or `outstanding_tools`. The main agent's own Task tool call stays outstanding until its real `tool_result`, so the existing outstanding-tool guard keeps the turn "running" until the actual turn ends. Fixes Claude and Cursor (shared detector).

**Frontend (make it obvious in chat):**
- `ToolRow` gained a `running` state (spinner) — a tool with no result yet while the agent is busy now reads as active instead of settled. Clears when the turn ends, so no spinner hangs.
- A spawned subagent's row stays collapsed but shows a live `· N steps` badge counting its assistant messages + tool calls as they stream.
- `busy` is threaded from `ChatView` down through `MessageItem` into nested `SubagentThread`s.

## Testing

- New Rust test covers spawn → subagent-result → main-result; `cargo test` 15/15 activity tests pass.
- `bun run check` clean, `bun run test` 352/352 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)