### PR TITLE
feat(docker): keep agent images fresh with TTL, version parity, and GC

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -813,6 +813,30 @@ pub fn run() {
                 });
             }
 
+            // Seed the docker version-refresh loop guard (mirror of the
+            // `docker_version_refresh_guard` setting — private bookkeeping,
+            // not user-facing) and wire its write-back, so a host CLI pinned
+            // away from the registry's latest triggers at most one
+            // version-parity rebuild ever, not one per app run. Same mirror
+            // idiom as the launch knobs above; the guard is consulted and
+            // recorded on spawn/background threads that have no DB handle.
+            {
+                let seeded: std::collections::HashMap<String, String> =
+                    database::get_setting(&db.lock(), sandbox::docker::VERSION_GUARD_SETTING)
+                        .and_then(|s| serde_json::from_str(&s).ok())
+                        .unwrap_or_default();
+                let guard_db = db.clone();
+                sandbox::docker::init_version_refresh_guard(seeded, move |attempted| {
+                    if let Ok(json) = serde_json::to_string(attempted) {
+                        let _ = database::set_setting(
+                            &guard_db.lock(),
+                            sandbox::docker::VERSION_GUARD_SETTING,
+                            &json,
+                        );
+                    }
+                });
+            }
+
             // Seed the in-process container auth token (mirror of the
             // `claude_container_token` setting, same pattern as the GitHub
             // token below) so the docker auth chain — resolved at spawn time

--- a/src-tauri/src/sandbox/docker/cleanup.rs
+++ b/src-tauri/src/sandbox/docker/cleanup.rs
@@ -271,6 +271,13 @@ fn list_images(args: &[&str]) -> Result<Vec<ImageRow>> {
 /// image inside `known_repos` is removed (the legacy path — the repo names are
 /// Fletch-owned by construction). Current tags and the `docker_image` override
 /// are always kept.
+///
+/// Within Fletch's repos, only tags Fletch itself could have written are
+/// removal candidates: the content-addressed shape (12 lowercase hex chars —
+/// see `image::tag_for`) or no tag at all (a dangling rebuild predecessor).
+/// A human-shaped tag like `fletch-agent:backup` — whether the user tagged
+/// our labeled image or built their own into our namespace — is theirs to
+/// keep: a tag a human wrote is the human's call.
 fn image_removal_refs(
     labeled: &[ImageRow],
     legacy: &[ImageRow],
@@ -305,6 +312,9 @@ fn image_removal_refs(
         if !row.untagged() && !known_repos.contains(row.repo.as_str()) {
             continue; // labeled but re-tagged under a user name: never touch
         }
+        if !row.untagged() && !is_content_addressed_tag(&row.tag) {
+            continue; // human-written tag in our repo: their tag, their call
+        }
         if protected(row) {
             continue;
         }
@@ -317,12 +327,22 @@ fn image_removal_refs(
         if row.untagged() || !known_repos.contains(row.repo.as_str()) {
             continue;
         }
+        if !is_content_addressed_tag(&row.tag) {
+            continue; // user image built into our namespace: never touch
+        }
         if protected(row) {
             continue;
         }
         push(row);
     }
     refs
+}
+
+/// Whether a tag has the shape Fletch's content addressing writes — exactly
+/// 12 lowercase hex chars (`image::tag_for`'s `sha256[..12]`). Anything else
+/// in a Fletch repo was written by a human and is never a removal candidate.
+fn is_content_addressed_tag(tag: &str) -> bool {
+    tag.len() == 12 && tag.bytes().all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
 }
 
 #[cfg(test)]
@@ -393,29 +413,34 @@ mod tests {
     /// stale → remove; the `docker_image` override → keep in every spelling.
     #[test]
     fn image_gc_selection() {
-        let current_tags: HashSet<String> = ["fletch-agent:currentaaaaa".to_string()].into();
+        let current_tags: HashSet<String> = ["fletch-agent:cafe00000000".to_string()].into();
         let known_repos: HashSet<&'static str> = ["fletch-agent", "fletch-agent-codex"].into();
 
         let labeled = vec![
             // Old hash under a Fletch repo: superseded by a Dockerfile revision.
-            row("aaa", "fletch-agent", "0ldhash00000"),
+            row("aaa", "fletch-agent", "0dab1e000000"),
             // The current tag: what launches use today.
-            row("bbb", "fletch-agent", "currentaaaaa"),
+            row("bbb", "fletch-agent", "cafe00000000"),
             // Untagged leftover of a TTL rebuild: removable only by id.
             row("ccc", "<none>", "<none>"),
             // Labeled but re-tagged under a user's name: their tag, kept.
             row("ddd", "mybackup", "keep"),
             // The override, hypothetically labeled (shouldn't happen): kept.
             row("eee", "ghcr.io/me/custom", "1"),
+            // Labeled but human-tagged inside our repo (`docker tag` of our
+            // image): their tag, kept.
+            row("hhh", "fletch-agent", "backup"),
         ];
         let legacy = vec![
             // Pre-label image in a Fletch-owned repo: removable by name.
-            row("fff", "fletch-agent-codex", "pre1abe10000"),
+            row("fff", "fletch-agent-codex", "badc0debadc0"),
             // Current tag also shows up in the repo-scoped listing: kept.
-            row("bbb", "fletch-agent", "currentaaaaa"),
+            row("bbb", "fletch-agent", "cafe00000000"),
             // Selection must be safe even if a listing misbehaves: an
             // unlabeled non-fletch row is never removed.
             row("ggg", "someones-image", "latest"),
+            // A user's own image built into our namespace: human tag, kept.
+            row("iii", "fletch-agent", "backup"),
         ];
 
         let refs = image_removal_refs(
@@ -428,11 +453,26 @@ mod tests {
         assert_eq!(
             refs,
             vec![
-                "fletch-agent:0ldhash00000".to_string(),
+                "fletch-agent:0dab1e000000".to_string(),
                 "ccc".to_string(),
-                "fletch-agent-codex:pre1abe10000".to_string(),
+                "fletch-agent-codex:badc0debadc0".to_string(),
             ],
         );
+    }
+
+    /// Only tags Fletch's content addressing could have written count as
+    /// removal candidates — exactly 12 lowercase hex chars.
+    #[test]
+    fn content_addressed_tag_shape() {
+        assert!(is_content_addressed_tag("0123abcdef01"));
+        assert!(is_content_addressed_tag("000000000000"));
+        // Human-shaped tags, wrong length, uppercase: all kept.
+        assert!(!is_content_addressed_tag("backup"));
+        assert!(!is_content_addressed_tag("latest"));
+        assert!(!is_content_addressed_tag("0123ABCDEF01"));
+        assert!(!is_content_addressed_tag("0123abcdef0"));
+        assert!(!is_content_addressed_tag("0123abcdef012"));
+        assert!(!is_content_addressed_tag(""));
     }
 
     /// Override matching is defensive across spellings: exact `repo:tag`,
@@ -442,19 +482,35 @@ mod tests {
         let current_tags = HashSet::new();
         let known_repos: HashSet<&'static str> = ["fletch-agent"].into();
         // Hypothetical worst case: the user's override lives *inside* a
-        // Fletch repo (they tagged their own image over our name).
+        // Fletch repo under a content-addressed-looking tag (anything
+        // human-shaped is already kept by the tag-shape guard).
         let labeled = vec![
-            row("aaa", "fletch-agent", "latest"),
-            row("bbb", "fletch-agent", "stale0000000"),
+            row("aaa", "fletch-agent", "aaaaaaaaaaaa"),
+            row("bbb", "fletch-agent", "bbbbbbbbbbbb"),
         ];
 
-        // Bare-repo override protects the `:latest` row only.
-        let refs = image_removal_refs(&labeled, &[], &current_tags, &known_repos, Some("fletch-agent"));
-        assert_eq!(refs, vec!["fletch-agent:stale0000000".to_string()]);
+        // Exact repo:tag override protects that row only.
+        let refs = image_removal_refs(
+            &labeled,
+            &[],
+            &current_tags,
+            &known_repos,
+            Some("fletch-agent:aaaaaaaaaaaa"),
+        );
+        assert_eq!(refs, vec!["fletch-agent:bbbbbbbbbbbb".to_string()]);
 
         // Id override protects by id.
         let refs = image_removal_refs(&labeled, &[], &current_tags, &known_repos, Some("bbb"));
-        assert_eq!(refs, vec!["fletch-agent:latest".to_string()]);
+        assert_eq!(refs, vec!["fletch-agent:aaaaaaaaaaaa".to_string()]);
+
+        // A bare-repo override reads as `:latest` — and a `:latest` row in our
+        // repo is kept by the tag-shape guard even before the override check,
+        // with or without the override present.
+        let with_latest = vec![row("lll", "fletch-agent", "latest")];
+        for ov in [Some("fletch-agent"), None] {
+            assert!(image_removal_refs(&with_latest, &[], &current_tags, &known_repos, ov)
+                .is_empty());
+        }
 
         // Blank override protects nothing (same as None).
         let refs = image_removal_refs(&labeled, &[], &current_tags, &known_repos, Some("  "));

--- a/src-tauri/src/sandbox/docker/cleanup.rs
+++ b/src-tauri/src/sandbox/docker/cleanup.rs
@@ -1,4 +1,4 @@
-//! Container labels and the dead-instance orphan sweep.
+//! Container labels, the dead-instance orphan sweep, and the stale-image GC.
 //!
 //! Every container Fletch launches carries `fletch.host-pid=<pid>` (which app
 //! instance owns it) and `fletch.agent-id=<id>` (which agent it runs). If the
@@ -6,12 +6,19 @@
 //! running; the next startup sweeps them by the same pid-liveness rule the
 //! nested-root sweeps use (`sandbox/seatbelt.rs`): remove only containers
 //! whose owning pid is gone, never a live side-by-side instance's.
+//!
+//! Images get the same treatment with one rule ([`sweep_stale_images`]): an
+//! image Fletch built (attributed by the `fletch.agent` label — see
+//! [`image::AGENT_IMAGE_LABEL`]) that is not one of the current expected tags
+//! is removed. That covers old-hash tags left by Dockerfile revisions and
+//! untagged leftovers from TTL rebuilds. Anything we can't attribute survives.
 
+use std::collections::HashSet;
 use std::time::Duration;
 
 use crate::error::{Error, Result};
 
-use super::cli;
+use super::{cli, engine, image, DockerProvider};
 
 /// Label carrying the owning Fletch instance's pid.
 pub const HOST_PID_LABEL: &str = "fletch.host-pid";
@@ -119,6 +126,205 @@ fn parse_inspect_line(line: &str) -> Option<(String, Option<i32>)> {
     Some((id.to_string(), pid))
 }
 
+/// `docker images` line format for the image GC listings. Untagged (dangling)
+/// images print `<none>` for repository and tag.
+const IMAGES_FORMAT: &str = "{{.ID}} {{.Repository}} {{.Tag}}";
+
+/// One `docker images` row: a (repo:tag, image id) pair — the same image id
+/// appears in multiple rows when it carries multiple tags, which is exactly
+/// what the GC wants: it untags Fletch's name and leaves any other name alone.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ImageRow {
+    id: String,
+    repo: String,
+    tag: String,
+}
+
+impl ImageRow {
+    /// Whether this row is a dangling image (`<none>:<none>`) — removable only
+    /// by id.
+    fn untagged(&self) -> bool {
+        self.repo == "<none>" || self.tag == "<none>"
+    }
+
+    /// The `repo:tag` name of a tagged row.
+    fn named(&self) -> String {
+        format!("{}:{}", self.repo, self.tag)
+    }
+
+    /// What to hand `docker rmi`: the name for tagged rows (untag just ours),
+    /// the id for dangling ones (the only handle they have).
+    fn removal_ref(&self) -> String {
+        if self.untagged() {
+            self.id.clone()
+        } else {
+            self.named()
+        }
+    }
+}
+
+/// One [`IMAGES_FORMAT`] line → an [`ImageRow`]; `None` on malformed lines
+/// (skipped — under-reclaim bias, same as the container sweep).
+fn parse_images_line(line: &str) -> Option<ImageRow> {
+    let mut parts = line.split_whitespace();
+    let row = ImageRow {
+        id: parts.next()?.to_string(),
+        repo: parts.next()?.to_string(),
+        tag: parts.next()?.to_string(),
+    };
+    Some(row)
+}
+
+/// Remove superseded Fletch agent images. One rule: an image carrying the
+/// `fletch.agent` label that is not one of the current expected tags (the set
+/// of `image_tag(provider)` across all providers) is removed — old-hash tags
+/// from Dockerfile revisions and untagged leftovers from TTL rebuilds alike.
+///
+/// Legacy path: images built before the label existed can only be attributed
+/// by name — a non-current tag under one of Fletch's own repos (`fletch-agent`,
+/// `fletch-agent-codex`, …; Fletch-owned by construction) is removed too. This
+/// arm becomes dead weight once pre-label installs age out and can then be
+/// deleted.
+///
+/// Never touched: current tags, the user's `docker_image` override (excluded
+/// defensively even though it can't carry the label), any unlabeled image
+/// outside Fletch's repos, and images in use by a container — `docker rmi`
+/// runs WITHOUT `-f`, so an in-use image fails removal, which is expected and
+/// logged at debug. Returns the number of images actually removed; callers
+/// treat all failures as non-fatal.
+pub fn sweep_stale_images() -> Result<usize> {
+    let current_tags: HashSet<String> =
+        DockerProvider::ALL.iter().map(|p| image::image_tag(*p)).collect();
+    let known_repos: HashSet<&'static str> =
+        DockerProvider::ALL.iter().map(|p| image::image_repo(*p)).collect();
+    let override_image = engine::image_override();
+
+    let labeled = list_images(&[
+        "images",
+        "--filter",
+        &format!("label={}", image::AGENT_IMAGE_LABEL),
+        "--format",
+        IMAGES_FORMAT,
+    ])?;
+    // Legacy pre-label images: list each Fletch-owned repo by name. (A repo
+    // argument to `docker images` matches only that exact repo.)
+    let mut legacy = Vec::new();
+    for repo in &known_repos {
+        legacy.extend(list_images(&["images", repo, "--format", IMAGES_FORMAT])?);
+    }
+
+    let refs = image_removal_refs(
+        &labeled,
+        &legacy,
+        &current_tags,
+        &known_repos,
+        override_image.as_deref(),
+    );
+    if refs.is_empty() {
+        return Ok(0);
+    }
+
+    tracing::info!(count = refs.len(), "removing superseded fletch agent images");
+    let mut removed = 0;
+    for image_ref in &refs {
+        // One rmi per image (not batched): a single in-use image must not
+        // taint the exit status the others report. No `-f` — an image backing
+        // a running container stays, by design.
+        let out = cli::run_docker(&["rmi", image_ref], REMOVE_TIMEOUT)?;
+        if out.status.success() {
+            removed += 1;
+        } else {
+            tracing::debug!(
+                target: "fletch::docker",
+                image = %image_ref,
+                stderr = %String::from_utf8_lossy(&out.stderr).trim(),
+                "stale image not removed (expected when a container still uses it)",
+            );
+        }
+    }
+    Ok(removed)
+}
+
+/// Run one `docker images` listing and parse its rows.
+fn list_images(args: &[&str]) -> Result<Vec<ImageRow>> {
+    let out = cli::run_docker(args, QUERY_TIMEOUT)?;
+    if !out.status.success() {
+        return Err(Error::Other(format!(
+            "docker images failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim(),
+        )));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(parse_images_line)
+        .collect())
+}
+
+/// The GC's selection rule, pure (inputs are pre-fetched listings, fixed in
+/// tests). `labeled` holds every image carrying the `fletch.agent` label;
+/// `legacy` holds the tagged contents of Fletch's own repos (pre-label
+/// installs). Returns deduplicated `docker rmi` refs.
+///
+/// The label is the authority, with one belt-and-braces exception each way:
+/// a *labeled* image tagged outside `known_repos` is kept (a user re-tagged
+/// our image under their own name — their tag, their call), and an *unlabeled*
+/// image inside `known_repos` is removed (the legacy path — the repo names are
+/// Fletch-owned by construction). Current tags and the `docker_image` override
+/// are always kept.
+fn image_removal_refs(
+    labeled: &[ImageRow],
+    legacy: &[ImageRow],
+    current_tags: &HashSet<String>,
+    known_repos: &HashSet<&'static str>,
+    override_image: Option<&str>,
+) -> Vec<String> {
+    let override_image = override_image.map(str::trim).filter(|s| !s.is_empty());
+    // A row that must survive no matter which listing produced it. The
+    // override comparison is defensive by design: match its exact `repo:tag`,
+    // its bare-repo spelling (docker reads `foo` as `foo:latest`), or the
+    // image id (all listings print the same short id).
+    let protected = |row: &ImageRow| {
+        if !row.untagged() && current_tags.contains(&row.named()) {
+            return true;
+        }
+        let Some(ov) = override_image else { return false };
+        ov == row.id
+            || (!row.untagged() && (ov == row.named() || (row.tag == "latest" && ov == row.repo)))
+    };
+
+    let mut seen = HashSet::new();
+    let mut refs = Vec::new();
+    let mut push = |row: &ImageRow| {
+        let r = row.removal_ref();
+        if seen.insert(r.clone()) {
+            refs.push(r);
+        }
+    };
+
+    for row in labeled {
+        if !row.untagged() && !known_repos.contains(row.repo.as_str()) {
+            continue; // labeled but re-tagged under a user name: never touch
+        }
+        if protected(row) {
+            continue;
+        }
+        push(row);
+    }
+    for row in legacy {
+        // The repo filter is load-bearing for the "unlabeled non-fletch →
+        // keep" property even though the listing is already repo-scoped:
+        // selection must be safe regardless of what the listing fed it.
+        if row.untagged() || !known_repos.contains(row.repo.as_str()) {
+            continue;
+        }
+        if protected(row) {
+            continue;
+        }
+        push(row);
+    }
+    refs
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -156,6 +362,156 @@ mod tests {
         let stdout = "aaa 100\nbbb 200\nccc \nddd bogus\n";
         let orphans = orphaned_ids(stdout, |pid| pid == 100);
         assert_eq!(orphans, vec!["bbb".to_string()]);
+    }
+
+    fn row(id: &str, repo: &str, tag: &str) -> ImageRow {
+        ImageRow {
+            id: id.into(),
+            repo: repo.into(),
+            tag: tag.into(),
+        }
+    }
+
+    #[test]
+    fn images_line_parsing() {
+        assert_eq!(
+            parse_images_line("abc123def456 fletch-agent 0011aabbccdd"),
+            Some(row("abc123def456", "fletch-agent", "0011aabbccdd")),
+        );
+        // Dangling images print `<none>` placeholders.
+        assert_eq!(
+            parse_images_line("abc123def456 <none> <none>"),
+            Some(row("abc123def456", "<none>", "<none>")),
+        );
+        assert_eq!(parse_images_line("abc123def456 fletch-agent"), None);
+        assert_eq!(parse_images_line(""), None);
+    }
+
+    /// The GC's one rule plus its fences, on fixed listings: labeled + stale
+    /// → remove; labeled + current → keep; labeled outside Fletch's repos
+    /// (user re-tag) → keep; unlabeled non-fletch → keep; legacy fletch-repo
+    /// stale → remove; the `docker_image` override → keep in every spelling.
+    #[test]
+    fn image_gc_selection() {
+        let current_tags: HashSet<String> = ["fletch-agent:currentaaaaa".to_string()].into();
+        let known_repos: HashSet<&'static str> = ["fletch-agent", "fletch-agent-codex"].into();
+
+        let labeled = vec![
+            // Old hash under a Fletch repo: superseded by a Dockerfile revision.
+            row("aaa", "fletch-agent", "0ldhash00000"),
+            // The current tag: what launches use today.
+            row("bbb", "fletch-agent", "currentaaaaa"),
+            // Untagged leftover of a TTL rebuild: removable only by id.
+            row("ccc", "<none>", "<none>"),
+            // Labeled but re-tagged under a user's name: their tag, kept.
+            row("ddd", "mybackup", "keep"),
+            // The override, hypothetically labeled (shouldn't happen): kept.
+            row("eee", "ghcr.io/me/custom", "1"),
+        ];
+        let legacy = vec![
+            // Pre-label image in a Fletch-owned repo: removable by name.
+            row("fff", "fletch-agent-codex", "pre1abe10000"),
+            // Current tag also shows up in the repo-scoped listing: kept.
+            row("bbb", "fletch-agent", "currentaaaaa"),
+            // Selection must be safe even if a listing misbehaves: an
+            // unlabeled non-fletch row is never removed.
+            row("ggg", "someones-image", "latest"),
+        ];
+
+        let refs = image_removal_refs(
+            &labeled,
+            &legacy,
+            &current_tags,
+            &known_repos,
+            Some("ghcr.io/me/custom:1"),
+        );
+        assert_eq!(
+            refs,
+            vec![
+                "fletch-agent:0ldhash00000".to_string(),
+                "ccc".to_string(),
+                "fletch-agent-codex:pre1abe10000".to_string(),
+            ],
+        );
+    }
+
+    /// Override matching is defensive across spellings: exact `repo:tag`,
+    /// bare repo (docker's implicit `:latest`), and image id all protect.
+    #[test]
+    fn image_gc_override_spellings() {
+        let current_tags = HashSet::new();
+        let known_repos: HashSet<&'static str> = ["fletch-agent"].into();
+        // Hypothetical worst case: the user's override lives *inside* a
+        // Fletch repo (they tagged their own image over our name).
+        let labeled = vec![
+            row("aaa", "fletch-agent", "latest"),
+            row("bbb", "fletch-agent", "stale0000000"),
+        ];
+
+        // Bare-repo override protects the `:latest` row only.
+        let refs = image_removal_refs(&labeled, &[], &current_tags, &known_repos, Some("fletch-agent"));
+        assert_eq!(refs, vec!["fletch-agent:stale0000000".to_string()]);
+
+        // Id override protects by id.
+        let refs = image_removal_refs(&labeled, &[], &current_tags, &known_repos, Some("bbb"));
+        assert_eq!(refs, vec!["fletch-agent:latest".to_string()]);
+
+        // Blank override protects nothing (same as None).
+        let refs = image_removal_refs(&labeled, &[], &current_tags, &known_repos, Some("  "));
+        assert_eq!(refs.len(), 2);
+
+        // Overlapping listings dedupe to one removal ref.
+        let refs = image_removal_refs(&labeled, &labeled, &current_tags, &known_repos, None);
+        assert_eq!(refs.len(), 2);
+    }
+
+    /// Integration: a labeled image under a Fletch repo with a non-current tag
+    /// is swept; an unlabeled image outside Fletch's repos survives.
+    /// `FLETCH_DOCKER_TESTS=1 cargo test -- --ignored`
+    #[test]
+    #[ignore = "requires Docker; opt in via FLETCH_DOCKER_TESTS=1"]
+    fn sweeps_stale_labeled_images_only() {
+        if !crate::sandbox::docker::docker_tests_enabled() {
+            return;
+        }
+        let build = |dockerfile: &str, tag: &str| {
+            let ctx = tempfile::tempdir().unwrap();
+            std::fs::write(ctx.path().join("Dockerfile"), dockerfile).unwrap();
+            let out = cli::run_docker(
+                &["build", "-t", tag, &ctx.path().to_string_lossy()],
+                Duration::from_secs(120),
+            )
+            .unwrap();
+            assert!(
+                out.status.success(),
+                "docker build failed: {}",
+                String::from_utf8_lossy(&out.stderr),
+            );
+        };
+        // A labeled image under Fletch's repo with a tag no provider owns —
+        // exactly what a superseded image looks like.
+        let stale_tag = "fletch-agent:000000000000";
+        build(
+            &format!("FROM busybox\nLABEL {}=claude\n", image::AGENT_IMAGE_LABEL),
+            stale_tag,
+        );
+        // An unlabeled image outside Fletch's repos: must survive.
+        let bystander = "fletch-gc-test-bystander:keep";
+        build("FROM busybox\nENV FLETCH_GC_TEST=1\n", bystander);
+
+        let removed = sweep_stale_images().unwrap();
+        assert!(removed >= 1, "the stale labeled image should be swept");
+
+        let exists = |tag: &str| {
+            cli::run_docker(&["image", "inspect", tag], Duration::from_secs(10))
+                .unwrap()
+                .status
+                .success()
+        };
+        assert!(!exists(stale_tag), "stale labeled image must be gone");
+        assert!(exists(bystander), "unlabeled non-fletch image must survive");
+
+        let _ = cli::run_docker(&["rmi", "-f", bystander], Duration::from_secs(30));
     }
 
     /// Integration: a container labeled with a dead pid is swept; one labeled

--- a/src-tauri/src/sandbox/docker/cleanup.rs
+++ b/src-tauri/src/sandbox/docker/cleanup.rs
@@ -180,15 +180,16 @@ fn parse_images_line(line: &str) -> Option<ImageRow> {
 /// of `image_tag(provider)` across all providers) is removed — old-hash tags
 /// from Dockerfile revisions and untagged leftovers from TTL rebuilds alike.
 ///
-/// Legacy path: images built before the label existed can only be attributed
-/// by name — a non-current tag under one of Fletch's own repos (`fletch-agent`,
-/// `fletch-agent-codex`, …; Fletch-owned by construction) is removed too. This
-/// arm becomes dead weight once pre-label installs age out and can then be
-/// deleted.
+/// Legacy path: images built before the label existed carry no ownership
+/// proof, so they are removed only on an exact [`LEGACY_TAGS`] match — the
+/// closed list of tags pre-label Fletch actually shipped. Neither namespace
+/// nor tag shape is trusted on its own: a user image in a Fletch repo, even
+/// under a hex tag, never matches. This arm becomes dead weight once
+/// pre-label installs age out and can then be deleted along with the list.
 ///
 /// Never touched: current tags, the user's `docker_image` override (excluded
 /// defensively even though it can't carry the label), any unlabeled image
-/// outside Fletch's repos, and images in use by a container — `docker rmi`
+/// not on the legacy list, and images in use by a container — `docker rmi`
 /// runs WITHOUT `-f`, so an in-use image fails removal, which is expected and
 /// logged at debug. Returns the number of images actually removed; callers
 /// treat all failures as non-fatal.
@@ -268,16 +269,17 @@ fn list_images(args: &[&str]) -> Result<Vec<ImageRow>> {
 /// The label is the authority, with one belt-and-braces exception each way:
 /// a *labeled* image tagged outside `known_repos` is kept (a user re-tagged
 /// our image under their own name — their tag, their call), and an *unlabeled*
-/// image inside `known_repos` is removed (the legacy path — the repo names are
-/// Fletch-owned by construction). Current tags and the `docker_image` override
-/// are always kept.
+/// image is removed only on an exact [`LEGACY_TAGS`] match (the closed list of
+/// tags pre-label Fletch actually shipped — shape or namespace alone is never
+/// an ownership signal for unlabeled images). Current tags and the
+/// `docker_image` override are always kept.
 ///
-/// Within Fletch's repos, only tags Fletch itself could have written are
-/// removal candidates: the content-addressed shape (12 lowercase hex chars —
-/// see `image::tag_for`) or no tag at all (a dangling rebuild predecessor).
-/// A human-shaped tag like `fletch-agent:backup` — whether the user tagged
-/// our labeled image or built their own into our namespace — is theirs to
-/// keep: a tag a human wrote is the human's call.
+/// Within Fletch's repos, a labeled image is a removal candidate only under a
+/// tag Fletch itself could have written: the content-addressed shape (12
+/// lowercase hex chars — see `image::tag_for`) or no tag at all (a dangling
+/// rebuild predecessor). A human-shaped tag like `fletch-agent:backup` —
+/// a user's `docker tag` of our image — is theirs to keep: a tag a human
+/// wrote is the human's call.
 fn image_removal_refs(
     labeled: &[ImageRow],
     legacy: &[ImageRow],
@@ -321,14 +323,12 @@ fn image_removal_refs(
         push(row);
     }
     for row in legacy {
-        // The repo filter is load-bearing for the "unlabeled non-fletch →
-        // keep" property even though the listing is already repo-scoped:
-        // selection must be safe regardless of what the listing fed it.
-        if row.untagged() || !known_repos.contains(row.repo.as_str()) {
+        // Exact match only: an unlabeled image carries no ownership proof, so
+        // the only safe removal signal is a tag we know Fletch shipped. A
+        // user's own image in our namespace — even under a hex/git-SHA-shaped
+        // tag like `fletch-agent:deadbeefcafe` — never matches.
+        if row.untagged() || !LEGACY_TAGS.contains(&row.named().as_str()) {
             continue;
-        }
-        if !is_content_addressed_tag(&row.tag) {
-            continue; // user image built into our namespace: never touch
         }
         if protected(row) {
             continue;
@@ -344,6 +344,23 @@ fn image_removal_refs(
 fn is_content_addressed_tag(tag: &str) -> bool {
     tag.len() == 12 && tag.bytes().all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
 }
+
+/// Every tag pre-label Fletch ever shipped — the exact, closed set of images
+/// the legacy GC arm may remove. Each is `tag_for(repo, dockerfile,
+/// entrypoint)` recomputed from the embedded constants at the named git
+/// commit (the hash input is `sha256(dockerfile ++ entrypoint)[..12]`); the
+/// claude entry was additionally confirmed against a real pre-label install.
+/// The label era starts with the commit introducing this list, so it never
+/// grows — once pre-label installs have aged out, this arm and list can be
+/// deleted wholesale.
+const LEGACY_TAGS: &[&str] = &[
+    "fletch-agent:1ea320e4ab55",          // claude, unchanged pre-label era (at 3870598)
+    "fletch-agent-codex:fa189de85caf",    // codex, #367..3870598
+    "fletch-agent-opencode:87523a7118a0", // opencode, #368..3870598
+    "fletch-agent-pi:54ab6c418d9c",       // pi, #368..3870598
+    "fletch-agent-cursor:2d8ee8975d0d",   // cursor, #369 before the --version build check (3557367)
+    "fletch-agent-cursor:b84044879c26",   // cursor, #369 after it (b77d973..3870598)
+];
 
 #[cfg(test)]
 mod tests {
@@ -432,8 +449,8 @@ mod tests {
             row("hhh", "fletch-agent", "backup"),
         ];
         let legacy = vec![
-            // Pre-label image in a Fletch-owned repo: removable by name.
-            row("fff", "fletch-agent-codex", "badc0debadc0"),
+            // Genuine pre-label image: exact LEGACY_TAGS match, removable.
+            row("fff", "fletch-agent-codex", "fa189de85caf"),
             // Current tag also shows up in the repo-scoped listing: kept.
             row("bbb", "fletch-agent", "cafe00000000"),
             // Selection must be safe even if a listing misbehaves: an
@@ -441,6 +458,9 @@ mod tests {
             row("ggg", "someones-image", "latest"),
             // A user's own image built into our namespace: human tag, kept.
             row("iii", "fletch-agent", "backup"),
+            // A user's own image under a hex/git-SHA-shaped tag in our
+            // namespace: shape is not ownership — kept (exact-match only).
+            row("jjj", "fletch-agent", "deadbeefcafe"),
         ];
 
         let refs = image_removal_refs(
@@ -455,9 +475,24 @@ mod tests {
             vec![
                 "fletch-agent:0dab1e000000".to_string(),
                 "ccc".to_string(),
-                "fletch-agent-codex:badc0debadc0".to_string(),
+                "fletch-agent-codex:fa189de85caf".to_string(),
             ],
         );
+    }
+
+    /// The legacy allowlist stays well-formed: every entry names a repo the
+    /// current binary owns, under a content-addressed tag shape. (The hash
+    /// values themselves are frozen history — recomputed from the embedded
+    /// constants at the commits named on each entry.)
+    #[test]
+    fn legacy_tags_are_fletch_shaped() {
+        let known_repos: HashSet<&'static str> =
+            DockerProvider::ALL.iter().map(|p| image::image_repo(*p)).collect();
+        for entry in LEGACY_TAGS {
+            let (repo, tag) = entry.split_once(':').expect("legacy entry must be repo:tag");
+            assert!(known_repos.contains(repo), "unknown legacy repo: {repo}");
+            assert!(is_content_addressed_tag(tag), "malformed legacy tag: {tag}");
+        }
     }
 
     /// Only tags Fletch's content addressing could have written count as

--- a/src-tauri/src/sandbox/docker/engine.rs
+++ b/src-tauri/src/sandbox/docker/engine.rs
@@ -145,6 +145,90 @@ pub fn set_launch_settings(settings: LaunchSettings) {
     *LAUNCH_SETTINGS.write() = settings;
 }
 
+/// Settings key persisting the version-refresh loop guard: a JSON object of
+/// `provider id → "host_version@image_tag"`, recording the last host/image
+/// pairing a version-mismatch rebuild *succeeded* for. Not a user-facing
+/// setting — private bookkeeping that must survive restarts: in the guarded
+/// case (host CLI pinned away from the registry's latest, so the mismatch
+/// persists even after a successful rebuild) an in-memory guard would decay
+/// into one full `--no-cache` rebuild on every app run. One pair per provider
+/// suffices — any change to either side legitimately warrants one fresh
+/// attempt.
+pub const VERSION_GUARD_SETTING: &str = "docker_version_refresh_guard";
+
+/// Writes the guard map back to its settings row (installed by
+/// [`init_version_refresh_guard`]).
+type VersionGuardPersist = Box<dyn Fn(&std::collections::HashMap<String, String>) + Send + Sync>;
+
+/// The version-refresh loop guard, mirrored in-process like
+/// [`LAUNCH_SETTINGS`] (the image code that consults it runs on spawn paths
+/// and background threads with no DB handle). Seeded and wired to a persister
+/// at startup by [`init_version_refresh_guard`]; until then (tests, headless)
+/// it's empty and unpersisted, and recording still guards the current
+/// process run.
+struct VersionGuard {
+    /// provider id → `"host_version@image_tag"` last successfully rebuilt for.
+    attempted: std::collections::HashMap<String, String>,
+    /// Writes the whole map back to the settings row.
+    persist: Option<VersionGuardPersist>,
+}
+
+static VERSION_GUARD: RwLock<Option<VersionGuard>> = RwLock::new(None);
+
+/// Install the loop-guard state: `attempted` as loaded from
+/// [`VERSION_GUARD_SETTING`], `persist` writing it back. The app wires this
+/// to a `database::set_setting` closure at startup — the same mirror idiom as
+/// [`set_launch_settings`] and `progress::set_build_sink`.
+pub fn init_version_refresh_guard(
+    attempted: std::collections::HashMap<String, String>,
+    persist: impl Fn(&std::collections::HashMap<String, String>) + Send + Sync + 'static,
+) {
+    *VERSION_GUARD.write() = Some(VersionGuard {
+        attempted,
+        persist: Some(Box::new(persist)),
+    });
+}
+
+/// Whether a version-mismatch rebuild already succeeded for exactly this
+/// `pair` (`"host_version@image_tag"`). If so the trigger is inert: the
+/// mismatch survived a rebuild, so it isn't rebuildable-away (pinned host).
+pub(super) fn version_refresh_attempted(provider_id: &str, pair: &str) -> bool {
+    VERSION_GUARD
+        .read()
+        .as_ref()
+        .is_some_and(|g| g.attempted.get(provider_id).map(String::as_str) == Some(pair))
+}
+
+/// Record (and persist, when wired) that a version-mismatch rebuild succeeded
+/// for `pair`. Called from the background rebuild thread on success only —
+/// failures must retry on a later run, exactly like TTL rebuild failures.
+pub(super) fn record_version_refresh(provider_id: &str, pair: String) {
+    let mut guard = VERSION_GUARD.write();
+    let state = guard.get_or_insert_with(|| VersionGuard {
+        attempted: std::collections::HashMap::new(),
+        persist: None,
+    });
+    state.attempted.insert(provider_id.to_string(), pair);
+    if let Some(persist) = &state.persist {
+        persist(&state.attempted);
+    }
+}
+
+/// The current `docker_image` override, trimmed, `None` when unset/blank —
+/// read by the image GC (`cleanup::sweep_stale_images`) to defensively exclude
+/// the user's image from removal. Structurally it should never be a candidate
+/// (Fletch never builds it, so it carries no `fletch.agent` label and lives
+/// outside Fletch's repos), but a lifecycle we don't own gets a second fence.
+pub(super) fn image_override() -> Option<String> {
+    LAUNCH_SETTINGS
+        .read()
+        .image_override
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
 /// The `SandboxEngine` implementation for Docker. Obtain it via
 /// [`DockerEngine::shared`]: launches embed an `Arc` of the engine in their
 /// [`KillHandle`], and sharing one instance also shares the once-per-app-run
@@ -174,7 +258,13 @@ impl DockerEngine {
 
     /// The image to launch `provider` from, resolving (and building, if the
     /// embedded image is missing) at most once per app run per (provider,
-    /// override) pair.
+    /// override) pair. Resolution also runs the background freshness checks
+    /// (TTL + host/container version parity — see `image::resolve_image`),
+    /// so their cadence is once per app run too. The host version comes from
+    /// the existing memoized probe (`agent::cached_provider_version` — at
+    /// most one `--version` subprocess per provider per run, shared with
+    /// ingest); a machine with no host CLI yields `None` and the version
+    /// trigger is simply inert, leaving the TTL as the backstop.
     fn resolve_image_cached(
         &self,
         provider: DockerProvider,
@@ -185,11 +275,24 @@ impl DockerEngine {
         if let Some(tag) = cache.get(&key) {
             return Ok(tag.clone());
         }
+        // Skip the host probe entirely on the override path: the user's image
+        // is never inspected or refreshed, so there is nothing to compare.
+        let host_cli_version = if override_image.map(str::trim).filter(|s| !s.is_empty()).is_none()
+        {
+            crate::agent::cached_provider_version(provider.id())
+        } else {
+            None
+        };
         // Per-line build output goes to the log; the UI build toast is driven
         // separately by the `progress` sink inside `image::ensure_image`.
         let on_progress = |line: &str| tracing::info!(target: "fletch::docker_build", "{line}");
-        let tag = image::resolve_image(provider, override_image, &on_progress)
-            .map_err(|e| Error::Other(format!("preparing the Docker sandbox image failed: {e}")))?;
+        let tag = image::resolve_image(
+            provider,
+            override_image,
+            host_cli_version.as_deref(),
+            &on_progress,
+        )
+        .map_err(|e| Error::Other(format!("preparing the Docker sandbox image failed: {e}")))?;
         cache.insert(key, tag.clone());
         Ok(tag)
     }
@@ -1293,6 +1396,48 @@ fn describe_exit_code(code: i32) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The version-refresh loop guard: exact-pair matching, per-provider
+    /// isolation, persistence callback on record, and safe recording before
+    /// `init` is ever called. Touches the process-wide `VERSION_GUARD`
+    /// static — the only test that does, so no serialization needed (the
+    /// same shared-global contract as `progress`'s sink test).
+    #[test]
+    fn version_refresh_guard_round_trip() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        // Pre-init (headless/tests): nothing attempted, recording is safe and
+        // guards the current process even without a persister.
+        assert!(!version_refresh_attempted("claude", "v1@fletch-agent:aaa"));
+        record_version_refresh("claude", "v1@fletch-agent:aaa".into());
+        assert!(version_refresh_attempted("claude", "v1@fletch-agent:aaa"));
+
+        // Init replaces state wholesale (the app seeds from the settings row).
+        let persisted = Arc::new(AtomicUsize::new(0));
+        let count = persisted.clone();
+        init_version_refresh_guard(
+            [("codex".to_string(), "v2@fletch-agent-codex:bbb".to_string())].into(),
+            move |map| {
+                count.store(map.len(), Ordering::SeqCst);
+            },
+        );
+        assert!(version_refresh_attempted("codex", "v2@fletch-agent-codex:bbb"));
+        // Exact pair only: a new host version or a new tag re-arms the trigger.
+        assert!(!version_refresh_attempted("codex", "v3@fletch-agent-codex:bbb"));
+        assert!(!version_refresh_attempted("codex", "v2@fletch-agent-codex:ccc"));
+        // Per-provider isolation.
+        assert!(!version_refresh_attempted("claude", "v2@fletch-agent-codex:bbb"));
+
+        // Recording persists the whole map through the installed callback,
+        // and one pair per provider suffices (newer replaces older).
+        record_version_refresh("claude", "v9@fletch-agent:ddd".into());
+        assert_eq!(persisted.load(Ordering::SeqCst), 2, "persister sees both providers");
+        record_version_refresh("claude", "v10@fletch-agent:ddd".into());
+        assert!(version_refresh_attempted("claude", "v10@fletch-agent:ddd"));
+        assert!(!version_refresh_attempted("claude", "v9@fletch-agent:ddd"));
+        assert_eq!(persisted.load(Ordering::SeqCst), 2, "replaced, not accumulated");
+    }
 
     /// The per-agent claude transcript dir every claude spec shares.
     const CLAUDE_PROJECTS_SRC: &str = "/Users/u/.fletch/worktrees/orkney/.fletch-claude-projects";

--- a/src-tauri/src/sandbox/docker/image.rs
+++ b/src-tauri/src/sandbox/docker/image.rs
@@ -4,10 +4,25 @@
 //! The Dockerfile and entrypoint are compiled into the binary and each image's
 //! tag is derived from its content (`<repo>:<sha256[..12]>`, e.g.
 //! `fletch-agent:…` for claude, `fletch-agent-codex:…` for codex), so shipping a
-//! change to either automatically produces a new tag — the stale image is simply
+//! change to either automatically produces a new tag — the stale image is
 //! never referenced again and the next spawn rebuilds. No version bookkeeping,
 //! no manual invalidation. Provider images share their base layers (identical
 //! `FROM` + apt step), so a second provider costs only its own install layer.
+//!
+//! Content addressing alone would freeze the *packages inside* an image
+//! forever, though: every image installs "latest at build time" (npm installs,
+//! cursor's installer), so a stable Dockerfile means a user's containerized CLI
+//! never updates while the host CLI does. [`IMAGE_MAX_AGE`] fixes that with a
+//! TTL: at resolution, an existing image older than the TTL is served for the
+//! current launch and rebuilt under the same tag in the background
+//! (stale-while-revalidate — see [`refresh_in_background_if_needed`]). A
+//! host/container CLI version mismatch triggers the same background rebuild
+//! even inside the TTL window — a user who just updated their host CLI
+//! expects container parity — while the TTL remains the backstop for
+//! Docker-only users with no host CLI to compare against. Every
+//! embedded image also carries [`AGENT_IMAGE_LABEL`] so superseded images (old
+//! hashes after a Dockerfile revision, untagged leftovers after a TTL rebuild)
+//! can be garbage-collected — see `cleanup::sweep_stale_images`.
 //!
 //! Users can bypass all of this with the `docker_image` settings key (see
 //! [`resolve_image`]): a user-supplied image is used verbatim — never built,
@@ -38,6 +53,7 @@ pub const DOCKERFILE: &str = r#"FROM node:22-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git curl ca-certificates ripgrep jq procps \
  && rm -rf /var/lib/apt/lists/*
+LABEL fletch.agent=claude
 RUN npm install -g @anthropic-ai/claude-code
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
@@ -68,6 +84,7 @@ pub const CODEX_DOCKERFILE: &str = r#"FROM node:22-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git curl ca-certificates ripgrep jq procps \
  && rm -rf /var/lib/apt/lists/*
+LABEL fletch.agent=codex
 RUN npm install -g @openai/codex
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
@@ -95,6 +112,7 @@ pub const OPENCODE_DOCKERFILE: &str = r#"FROM node:22-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git curl ca-certificates ripgrep jq procps \
  && rm -rf /var/lib/apt/lists/*
+LABEL fletch.agent=opencode
 RUN npm install -g opencode-ai
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
@@ -120,6 +138,7 @@ pub const PI_DOCKERFILE: &str = r#"FROM node:22-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git curl ca-certificates ripgrep jq procps \
  && rm -rf /var/lib/apt/lists/*
+LABEL fletch.agent=pi
 RUN npm install -g @earendil-works/pi-coding-agent
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
@@ -158,6 +177,7 @@ pub const CURSOR_DOCKERFILE: &str = r#"FROM node:22-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git curl ca-certificates ripgrep jq procps \
  && rm -rf /var/lib/apt/lists/*
+LABEL fletch.agent=cursor
 RUN curl -fsSL https://cursor.com/install | bash \
  && ln -s /root/.local/bin/cursor-agent /usr/local/bin/cursor-agent \
  && cursor-agent --version
@@ -177,10 +197,27 @@ mkdir -p "$HOME"
 exec "$@"
 "#;
 
+/// Label key baked into every embedded agent image (`LABEL
+/// fletch.agent=<provider>` in the Dockerfiles above). It is the image GC's
+/// authority: only images carrying it — or, transitionally, pre-label images
+/// in a Fletch-owned repo — are ever candidates for removal (see
+/// `cleanup::sweep_stale_images`). The user's `docker_image` override never
+/// gets the label (it is never built by us), so it can't be attributed to
+/// Fletch and is structurally safe from the GC.
+pub const AGENT_IMAGE_LABEL: &str = "fletch.agent";
+
+/// Dogma: **an agent image is never older than a week.** The images install
+/// "latest at build time" (npm installs, cursor's installer), so their
+/// contents freeze at build; this TTL bounds that freeze. An image past the
+/// TTL still serves the current launch — freshness is a background concern,
+/// never a launch blocker — and is rebuilt under the same tag off-thread
+/// (see [`refresh_in_background_if_stale`]). Deliberately not a setting.
+pub const IMAGE_MAX_AGE: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+
 /// The image build inputs for a provider: repo name plus the Dockerfile and
-/// entrypoint whose combined content addresses the tag. Claude returns the
-/// original constants under the original repo name, so its tag is byte-for-byte
-/// unchanged and existing users never rebuild; new providers get their own repo.
+/// entrypoint whose combined content addresses the tag. Every spec's Dockerfile
+/// carries `LABEL fletch.agent=<provider>` so the image GC can attribute it
+/// (enforced by a test); each provider gets its own repo.
 struct ImageSpec {
     repo: &'static str,
     dockerfile: &'static str,
@@ -234,6 +271,15 @@ pub fn image_tag(provider: DockerProvider) -> String {
     tag_for(spec.repo, spec.dockerfile, spec.entrypoint)
 }
 
+/// The repo (image name without tag) of a provider's embedded image. With
+/// [`image_tag`] this is the GC's vocabulary of Fletch-owned names: the repos
+/// are chosen by this module and are not meaningful outside Fletch, so a
+/// non-current tag under one of them is attributable to us even on legacy
+/// images built before [`AGENT_IMAGE_LABEL`] existed.
+pub fn image_repo(provider: DockerProvider) -> &'static str {
+    image_spec(provider).repo
+}
+
 /// `<repo>:<sha256(dockerfile + entrypoint)[..12]>` — 12 hex chars, the same
 /// abbreviation depth docker itself uses for short ids. The hash covers only the
 /// dockerfile+entrypoint content (not the repo), so claude's tail is unchanged
@@ -249,13 +295,17 @@ fn tag_for(repo: &str, dockerfile: &str, entrypoint: &str) -> String {
 }
 
 /// The image to launch containers from, honoring the `docker_image` settings
-/// key: a non-empty override is returned verbatim (no build, no inspect —
-/// the user owns that image's lifecycle); otherwise the embedded image is
-/// built if missing and its tag returned. Callers read the settings key and
-/// pass it in — this module stays DB-free.
+/// key: a non-empty override is returned verbatim (no build, no inspect, no
+/// TTL, no version check — the user owns that image's lifecycle); otherwise
+/// the embedded image is built if missing, refreshed in the background if
+/// older than [`IMAGE_MAX_AGE`] or version-divergent from the host CLI, and
+/// its tag returned. Callers read the settings key and probe the host CLI
+/// (`host_cli_version` — see `agent::cached_provider_version`) and pass both
+/// in — this module stays DB-free and host-probe-free.
 pub fn resolve_image(
     provider: DockerProvider,
     override_image: Option<&str>,
+    host_cli_version: Option<&str>,
     on_progress: Progress,
 ) -> Result<String> {
     if let Some(image) = override_image.map(str::trim).filter(|s| !s.is_empty()) {
@@ -271,17 +321,39 @@ pub fn resolve_image(
         return Ok(image.to_string());
     }
     let tag = image_tag(provider);
-    ensure_image(provider, &tag, on_progress)?;
+    let already_existed = ensure_image(provider, &tag, on_progress)?;
+    if already_existed {
+        // A just-built image is fresh by construction (it installed today's
+        // latest — if the host still differs, a rebuild can't fix that); a
+        // pre-existing one may have passed the TTL or drifted from the host
+        // CLI. Stale-while-revalidate: this launch still uses the existing
+        // tag, the refresh (if any) happens off-thread.
+        refresh_in_background_if_needed(provider, &tag, host_cli_version);
+    }
     Ok(tag)
 }
 
+/// Serializes every image build process-wide — foreground first-builds and
+/// background TTL rebuilds alike. Concurrent spawns during a cold start would
+/// otherwise race docker into building the same image N times, and a TTL
+/// rebuild must never interleave with a foreground build of the same tag.
+static BUILD_LOCK: Mutex<()> = Mutex::new(());
+
 /// Make sure `provider`'s image `tag` exists locally, building its embedded
-/// Dockerfile under that tag if it doesn't. Builds are serialized process-wide:
-/// concurrent spawns during a cold start would otherwise race docker into
-/// building the same image N times.
-pub fn ensure_image(provider: DockerProvider, tag: &str, on_progress: Progress) -> Result<()> {
+/// Dockerfile under that tag if it doesn't. Returns whether the image already
+/// existed (`true`) or was built just now (`false`) — the caller uses that to
+/// skip the TTL check on a fresh build.
+pub fn ensure_image(provider: DockerProvider, tag: &str, on_progress: Progress) -> Result<bool> {
     let spec = image_spec(provider);
-    ensure_image_with(spec.dockerfile, spec.entrypoint, tag, on_progress)
+    let already_existed = ensure_image_with(spec.dockerfile, spec.entrypoint, tag, on_progress)?;
+    if !already_existed {
+        // Post-build version probe, off-thread: warms the image-version cache
+        // for the mismatch trigger without delaying (or ever failing) the
+        // launch that just waited out the build.
+        let tag = tag.to_string();
+        std::thread::spawn(move || cache_image_version_post_build(provider, &tag));
+    }
+    Ok(already_existed)
 }
 
 /// [`ensure_image`] with explicit content — split out so the integration
@@ -292,19 +364,54 @@ fn ensure_image_with(
     entrypoint: &str,
     tag: &str,
     on_progress: Progress,
-) -> Result<()> {
-    static BUILD_LOCK: Mutex<()> = Mutex::new(());
-
+) -> Result<bool> {
     if image_exists(tag)? {
-        return Ok(());
+        return Ok(true);
     }
     let _guard = BUILD_LOCK.lock().unwrap();
     // Re-check under the lock: a concurrent spawn may have just built it.
     if image_exists(tag)? {
-        return Ok(());
+        return Ok(true);
     }
 
     tracing::info!(tag, "building agent docker image");
+    // Broadcast the build lifecycle to the UI. `Started`/`Finished`/`Failed`
+    // fire only here, where a foreground build actually runs (a cached image
+    // returns above without emitting), so the toast appears only for builds
+    // the user is actually waiting on. Each output line is forwarded alongside
+    // the caller's own sink so the tracing forwarder / test counter keep
+    // working unchanged.
+    progress::emit(BuildEvent::Started);
+    let forward = |line: &str| {
+        on_progress(line);
+        progress::emit(BuildEvent::Line {
+            line: line.to_string(),
+        });
+    };
+    let result = run_build(dockerfile, entrypoint, tag, false, &forward);
+    match &result {
+        Ok(()) => progress::emit(BuildEvent::Finished),
+        Err(e) => progress::emit(BuildEvent::Failed {
+            error: e.to_string(),
+        }),
+    }
+    result?;
+    tracing::info!(tag, "agent docker image built");
+    Ok(false)
+}
+
+/// Write the two-file build context and run `docker build -t tag`, streaming
+/// output to `on_line`. Shared by the foreground first-build
+/// ([`ensure_image_with`], `no_cache: false`) and the background refresh
+/// rebuild ([`rebuild_image`], `no_cache: true`); callers hold [`BUILD_LOCK`]
+/// and own their event/progress policy.
+fn run_build(
+    dockerfile: &str,
+    entrypoint: &str,
+    tag: &str,
+    no_cache: bool,
+    on_line: Progress,
+) -> Result<()> {
     // Build from a throwaway context dir holding exactly the two files —
     // nothing from the host repo can leak into the image.
     let ctx = tempfile::tempdir()?;
@@ -321,40 +428,311 @@ fn ensure_image_with(
         std::fs::set_permissions(&entrypoint_path, std::fs::Permissions::from_mode(0o755))?;
     }
 
-    let args = build_args(tag, ctx.path());
+    let args = build_args(tag, ctx.path(), no_cache);
     let args: Vec<&str> = args.iter().map(String::as_str).collect();
-    // Broadcast the build lifecycle to the UI. `Started`/`Finished`/`Failed`
-    // fire only here, where a build actually runs (a cached image returns above
-    // without emitting), so the toast appears only for real builds. Each output
-    // line is forwarded alongside the caller's own sink so the tracing
-    // forwarder / test counter keep working unchanged.
-    progress::emit(BuildEvent::Started);
-    let forward = |line: &str| {
-        on_progress(line);
-        progress::emit(BuildEvent::Line {
-            line: line.to_string(),
-        });
-    };
-    let result = cli::run_docker_streaming(&args, BUILD_TIMEOUT, &forward);
-    match &result {
-        Ok(()) => progress::emit(BuildEvent::Finished),
-        Err(e) => progress::emit(BuildEvent::Failed {
-            error: e.to_string(),
-        }),
-    }
-    result?;
-    tracing::info!(tag, "agent docker image built");
-    Ok(())
+    cli::run_docker_streaming(&args, BUILD_TIMEOUT, on_line)
 }
 
-/// `docker build` argv for `tag` from context `ctx`.
-fn build_args(tag: &str, ctx: &Path) -> Vec<String> {
-    vec![
-        "build".into(),
-        "-t".into(),
-        tag.into(),
-        ctx.to_string_lossy().into_owned(),
-    ]
+/// `docker build` argv for `tag` from context `ctx`. `--pull` on every build,
+/// first build and refresh rebuild alike: the images exist to capture "latest
+/// at build time", and a months-old locally cached `node:22-slim` would
+/// silently defeat that (docker's layer cache keys on the base image it has,
+/// not on what the registry currently serves). It adds no new failure mode —
+/// every agent build already needs the network for its install step (npm
+/// installs / cursor's curl installer), so "registry unreachable" fails the
+/// build either way, and the refresh path treats that as non-fatal.
+///
+/// `--no-cache` on refresh rebuilds only: `--pull` alone re-fetches the base,
+/// but the install `RUN` layer is keyed on its instruction text and would be
+/// served from cache whenever the base digest hasn't moved — a rebuild that
+/// changes nothing, silently defeating both the TTL and the version-mismatch
+/// trigger. First builds keep the cache: a brand-new image has nothing stale
+/// to bust, and cross-provider base-layer sharing on cold starts is worth
+/// keeping.
+fn build_args(tag: &str, ctx: &Path, no_cache: bool) -> Vec<String> {
+    let mut args: Vec<String> = vec!["build".into(), "--pull".into()];
+    if no_cache {
+        args.push("--no-cache".into());
+    }
+    args.extend(["-t".into(), tag.into(), ctx.to_string_lossy().into_owned()]);
+    args
+}
+
+/// TTL verdict for an image's `.Created` timestamp against [`IMAGE_MAX_AGE`].
+/// Pure — `now` is injected so tests use fixed instants. `Unknown` (an
+/// unparseable timestamp) is deliberately its own state: the caller treats it
+/// as fresh, because rebuilding on unparseable metadata would rebuild on
+/// *every* resolution forever (the rebuilt image's metadata would presumably
+/// parse no better if the daemon's format changed under us).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Freshness {
+    Fresh,
+    Stale,
+    Unknown,
+}
+
+/// Classify a raw `docker image inspect --format {{.Created}}` value (RFC3339,
+/// e.g. `2026-07-01T12:00:00.000000000Z`).
+fn classify_freshness(created_raw: &str, now: chrono::DateTime<chrono::Utc>) -> Freshness {
+    let Ok(created) = chrono::DateTime::parse_from_rfc3339(created_raw.trim()) else {
+        return Freshness::Unknown;
+    };
+    // A negative age (clock skew, image "from the future") compares below any
+    // positive TTL and lands on Fresh — the right bias for bad clocks.
+    let max_age = chrono::Duration::from_std(IMAGE_MAX_AGE).expect("TTL fits chrono::Duration");
+    if now.signed_duration_since(created) > max_age {
+        Freshness::Stale
+    } else {
+        Freshness::Fresh
+    }
+}
+
+/// Why a background refresh rebuild was kicked — log attribution, plus the
+/// version trigger's loop-guard bookkeeping on success.
+enum RefreshReason {
+    /// The image's build date passed [`IMAGE_MAX_AGE`].
+    Ttl,
+    /// The host CLI's probed version differs from the container image's;
+    /// `guard_pair` is the `host@tag` pair recorded (persistently, on rebuild
+    /// success) so the same combination is never retried — see
+    /// `engine::record_version_refresh`.
+    VersionMismatch { guard_pair: String },
+}
+
+/// Decide whether an existing image needs a background rebuild — TTL first,
+/// then host/container version parity — and kick it if so. Returns
+/// immediately either way. Freshness is never a launch concern: inspect
+/// failures, unparseable timestamps, missing versions, and rebuild failures
+/// all leave the existing image serving launches. Logged, never propagated.
+/// The rebuild is silent for the UI (log lines only): the build toast
+/// presents a blocking first-run build ("this can take a few minutes"),
+/// which is the wrong message for a refresh the user never waits on, and its
+/// failure state demands a dismissal the user shouldn't be bothered with.
+///
+/// The version trigger fires even when the image is TTL-fresh — a user who
+/// just updated their host CLI expects container parity. It compares with
+/// plain inequality (no semver ordering) and is inert whenever a side is
+/// missing: no host CLI installed, or the container probe failed (the TTL
+/// still covers those). Cadence for both triggers is once per app run
+/// (`DockerEngine::resolve_image_cached` caches resolution).
+fn refresh_in_background_if_needed(
+    provider: DockerProvider,
+    tag: &str,
+    host_cli_version: Option<&str>,
+) {
+    // One inspect serves both triggers: build date for the TTL, image id to
+    // key the container-version cache.
+    let (image_id, created_raw) = match cli::run_docker(
+        &["image", "inspect", "--format", "{{.Id}} {{.Created}}", tag],
+        INSPECT_TIMEOUT,
+    ) {
+        Ok(out) if out.status.success() => {
+            let text = String::from_utf8_lossy(&out.stdout);
+            let mut parts = text.split_whitespace().map(str::to_string);
+            match (parts.next(), parts.next()) {
+                (Some(id), Some(created)) => (id, created),
+                // Malformed inspect output: same treatment as a failed
+                // inspect below.
+                _ => return,
+            }
+        }
+        // The image resolved a moment ago; a metadata miss now is not worth
+        // failing a launch or rebuilding over. Next app run re-checks.
+        Ok(_) | Err(_) => return,
+    };
+
+    match classify_freshness(&created_raw, chrono::Utc::now()) {
+        Freshness::Stale => {
+            tracing::info!(
+                target: "fletch::docker",
+                tag,
+                created = %created_raw,
+                "agent image is older than IMAGE_MAX_AGE; rebuilding in the background",
+            );
+            spawn_refresh_rebuild(provider, tag.to_string(), RefreshReason::Ttl);
+            return;
+        }
+        Freshness::Unknown => {
+            // Once per app run in practice: resolution is cached per run
+            // (`DockerEngine::resolve_image_cached`), so this can't spam.
+            tracing::warn!(
+                target: "fletch::docker",
+                tag,
+                created = %created_raw,
+                "unparseable image build date; treating the image as fresh",
+            );
+        }
+        Freshness::Fresh => {}
+    }
+
+    // TTL-fresh: check version parity. Ordered so the docker-run probe only
+    // happens when there's a host version to compare and the pair hasn't
+    // already been tried (the pure decision below re-validates everything).
+    let Some(host) = host_cli_version else { return };
+    let guard_pair = format!("{host}@{tag}");
+    if super::engine::version_refresh_attempted(provider.id(), &guard_pair) {
+        return;
+    }
+    let container = image_cli_version(provider, tag, &image_id);
+    if !version_refresh_wanted(Some(host), container.as_deref(), false) {
+        return;
+    }
+    tracing::info!(
+        target: "fletch::docker",
+        tag,
+        host,
+        container = %container.as_deref().unwrap_or_default(),
+        "host CLI version differs from container image; rebuilding in the background",
+    );
+    spawn_refresh_rebuild(provider, tag.to_string(), RefreshReason::VersionMismatch { guard_pair });
+}
+
+/// Pure core of the version-mismatch trigger: refresh only when both sides
+/// are known, differ (plain `!=` — deliberately no semver ordering: "newer"
+/// is not computable across five vendors' formats, and parity is the actual
+/// goal), and this pairing hasn't already been attempted (rebuilding can't
+/// fix a host that's simply pinned away from the registry's latest).
+fn version_refresh_wanted(
+    host: Option<&str>,
+    container: Option<&str>,
+    already_attempted: bool,
+) -> bool {
+    match (host, container) {
+        (Some(h), Some(c)) => !already_attempted && h != c,
+        _ => false,
+    }
+}
+
+/// Kick the background stale-while-revalidate rebuild shared by both refresh
+/// triggers: rebuild the same tag, then (on success) record the version
+/// trigger's loop guard, re-probe the fresh image's CLI version, and reap the
+/// just-untagged predecessor. On failure, warn and keep serving the old image.
+fn spawn_refresh_rebuild(provider: DockerProvider, tag: String, reason: RefreshReason) {
+    std::thread::spawn(move || match rebuild_image(provider, &tag) {
+        Ok(()) => {
+            tracing::info!(target: "fletch::docker", tag, "agent image refreshed");
+            if let RefreshReason::VersionMismatch { guard_pair } = reason {
+                // Recorded on success only: a transient build failure should
+                // retry next run, but a *successful* rebuild that still
+                // mismatches (host pinned away from latest) must never loop.
+                super::engine::record_version_refresh(provider.id(), guard_pair);
+            }
+            cache_image_version_post_build(provider, &tag);
+            // Docker retagged atomically; the predecessor is now untagged.
+            // Reap it (and anything else stale) right away.
+            match super::cleanup::sweep_stale_images() {
+                Ok(0) => {}
+                Ok(n) => tracing::info!(
+                    target: "fletch::docker",
+                    removed = n,
+                    "swept superseded agent images after refresh",
+                ),
+                Err(e) => tracing::debug!(
+                    target: "fletch::docker",
+                    error = %e,
+                    "post-refresh image sweep failed",
+                ),
+            }
+        }
+        Err(e) => tracing::warn!(
+            target: "fletch::docker",
+            tag,
+            error = %e,
+            "background image refresh failed; keeping the existing image",
+        ),
+    });
+}
+
+/// Rebuild `provider`'s image under the same `tag`, unconditionally (no
+/// exists-check — the point is to replace an image that exists). Serialized on
+/// [`BUILD_LOCK`] with foreground builds; `--pull --no-cache` (see
+/// [`build_args`]) so neither a stale base nor a cached install layer can
+/// defeat the refresh. On success docker retags in place and the old image
+/// becomes untagged; on failure the old tag is untouched and keeps serving
+/// launches.
+fn rebuild_image(provider: DockerProvider, tag: &str) -> Result<()> {
+    let spec = image_spec(provider);
+    let _guard = BUILD_LOCK.lock().unwrap();
+    let on_line = |line: &str| tracing::info!(target: "fletch::docker_build", "{line}");
+    run_build(spec.dockerfile, spec.entrypoint, tag, true, &on_line)
+}
+
+/// One-shot in-container version probes are a container start + a node CLI's
+/// `--version` — seconds normally, and this bound only reaps a wedged daemon.
+const VERSION_PROBE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The provider CLI's version inside image `tag`, memoized by `image_id` for
+/// this app run. In-memory by choice: persistence would buy one skipped
+/// `docker run` per provider per app run — not worth a storage surface, and
+/// a restart-time re-probe also self-heals if a probe ever cached garbage.
+/// A failed probe caches nothing and returns `None` — the version trigger
+/// stays inert for that image (the TTL still covers it) and the next app run
+/// retries.
+fn image_cli_version(provider: DockerProvider, tag: &str, image_id: &str) -> Option<String> {
+    static CACHE: std::sync::OnceLock<Mutex<std::collections::HashMap<String, String>>> =
+        std::sync::OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(std::collections::HashMap::new()));
+    if let Some(v) = cache.lock().unwrap().get(image_id) {
+        return Some(v.clone());
+    }
+    let version = probe_image_cli_version(provider, tag)?;
+    cache.lock().unwrap().insert(image_id.to_string(), version.clone());
+    Some(version)
+}
+
+/// Run `docker run --rm <tag> <bin> --version` — no mounts, no agent
+/// scaffolding; the image's entrypoint just `exec`s the argv — and extract
+/// the version with the same parser the host probe uses
+/// (`agent::parse_semver`), so the two sides compare like-for-like. The
+/// `fletch.host-pid` label is stamped on so that if the CLI probe is killed
+/// at timeout while the daemon keeps the container alive, the next startup's
+/// orphan sweep can still attribute and reap it.
+fn probe_image_cli_version(provider: DockerProvider, tag: &str) -> Option<String> {
+    let pid_label = super::cleanup::host_pid_label();
+    let out = cli::run_docker(
+        &["run", "--rm", "--label", &pid_label, tag, provider.image_bin(), "--version"],
+        VERSION_PROBE_TIMEOUT,
+    )
+    .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = if !out.stdout.is_empty() {
+        String::from_utf8_lossy(&out.stdout)
+    } else {
+        String::from_utf8_lossy(&out.stderr)
+    };
+    crate::agent::parse_semver(&text)
+}
+
+/// After a successful build (foreground and background): probe the fresh
+/// image's CLI version and warm the [`image_cli_version`] cache so the
+/// mismatch trigger has a container side to compare. Best-effort — a failed
+/// probe logs at debug and the trigger stays inert for this image; it never
+/// fails or delays the build that preceded it.
+fn cache_image_version_post_build(provider: DockerProvider, tag: &str) {
+    let image_id = match cli::run_docker(
+        &["image", "inspect", "--format", "{{.Id}}", tag],
+        INSPECT_TIMEOUT,
+    ) {
+        Ok(out) if out.status.success() => {
+            String::from_utf8_lossy(&out.stdout).trim().to_string()
+        }
+        Ok(_) | Err(_) => return,
+    };
+    match image_cli_version(provider, tag, &image_id) {
+        Some(version) => tracing::info!(
+            target: "fletch::docker",
+            tag,
+            version,
+            "container CLI version probed after build",
+        ),
+        None => tracing::debug!(
+            target: "fletch::docker",
+            tag,
+            "post-build container CLI version probe failed; version trigger stays inert for this image",
+        ),
+    }
 }
 
 /// Whether `tag` exists locally. A non-zero `image inspect` exit is the
@@ -390,16 +768,21 @@ mod tests {
         );
     }
 
-    /// Acceptance guard: claude's image must not change. Its repo name stays
-    /// `fletch-agent` and its Dockerfile/entrypoint bytes are frozen, so its
-    /// content-addressed tag is byte-for-byte what shipped — existing users must
-    /// never be forced to rebuild by this PR. If this fails, claude's image
-    /// content changed and every user pays a cold rebuild.
+    /// Golden guard: claude's image content is pinned byte-for-byte so an
+    /// *accidental* edit can't silently move the content-addressed tag and
+    /// force every user through a cold rebuild. Deliberate changes update the
+    /// frozen bytes here and record why:
+    ///
+    /// - image-lifecycle PR: added `LABEL fletch.agent=claude` so the image GC
+    ///   can attribute Fletch's images by label instead of guessing from
+    ///   names. One planned rehash → one rebuild for every user on update,
+    ///   accepted (and the GC reaps the superseded image).
     #[test]
     fn claude_image_is_unchanged() {
-        // Frozen bytes (do not "fix" to match a changed constant — update the
-        // constant back instead).
-        const FROZEN_DOCKERFILE: &str = "FROM node:22-slim\nRUN apt-get update && apt-get install -y --no-install-recommends \\\n    git curl ca-certificates ripgrep jq procps \\\n && rm -rf /var/lib/apt/lists/*\nRUN npm install -g @anthropic-ai/claude-code\nCOPY entrypoint.sh /entrypoint.sh\nRUN chmod +x /entrypoint.sh\nENTRYPOINT [\"/entrypoint.sh\"]\n";
+        // Frozen bytes (do not "fix" to match an accidentally changed constant
+        // — update the constant back instead; deliberate changes update these
+        // bytes and the doc comment above).
+        const FROZEN_DOCKERFILE: &str = "FROM node:22-slim\nRUN apt-get update && apt-get install -y --no-install-recommends \\\n    git curl ca-certificates ripgrep jq procps \\\n && rm -rf /var/lib/apt/lists/*\nLABEL fletch.agent=claude\nRUN npm install -g @anthropic-ai/claude-code\nCOPY entrypoint.sh /entrypoint.sh\nRUN chmod +x /entrypoint.sh\nENTRYPOINT [\"/entrypoint.sh\"]\n";
         const FROZEN_ENTRYPOINT: &str = "#!/bin/sh\nset -e\nmkdir -p \"$HOME\"\nif [ ! -f \"$HOME/.claude.json\" ]; then\n  printf '{\"hasCompletedOnboarding\": true}\\n' > \"$HOME/.claude.json\"\nfi\nexec \"$@\"\n";
         assert_eq!(DOCKERFILE, FROZEN_DOCKERFILE, "claude Dockerfile changed");
         assert_eq!(ENTRYPOINT_SH, FROZEN_ENTRYPOINT, "claude entrypoint changed");
@@ -416,10 +799,13 @@ mod tests {
 
         // Base layers shared: the FROM line and the apt install line are
         // byte-identical, so Docker reuses those layers across both images.
-        let base: Vec<&str> = DOCKERFILE.lines().take_while(|l| !l.starts_with("RUN npm")).collect();
-        let codex_base: Vec<&str> =
-            CODEX_DOCKERFILE.lines().take_while(|l| !l.starts_with("RUN npm")).collect();
-        assert_eq!(base, codex_base, "base layers must match for cache reuse");
+        // (The per-provider `LABEL fletch.agent=…` sits after the base and is
+        // deliberately excluded — it differs by construction.)
+        assert_eq!(
+            base_layers(DOCKERFILE),
+            base_layers(CODEX_DOCKERFILE),
+            "base layers must match for cache reuse"
+        );
         // Provider-specific install step differs.
         assert!(CODEX_DOCKERFILE.contains("@openai/codex"));
         assert!(!CODEX_DOCKERFILE.contains("claude-code"));
@@ -501,9 +887,106 @@ mod tests {
 
     #[test]
     fn build_argv_shape() {
+        // `--pull` on every build, `--no-cache` on refresh rebuilds only: see
+        // the `build_args` doc — neither a stale cached base nor a cached
+        // install layer may defeat the freshness the rebuilds exist for.
         assert_eq!(
-            build_args("fletch-agent:abc123def456", Path::new("/tmp/ctx")),
-            vec!["build", "-t", "fletch-agent:abc123def456", "/tmp/ctx"],
+            build_args("fletch-agent:abc123def456", Path::new("/tmp/ctx"), false),
+            vec!["build", "--pull", "-t", "fletch-agent:abc123def456", "/tmp/ctx"],
+        );
+        assert_eq!(
+            build_args("fletch-agent:abc123def456", Path::new("/tmp/ctx"), true),
+            vec!["build", "--pull", "--no-cache", "-t", "fletch-agent:abc123def456", "/tmp/ctx"],
+        );
+    }
+
+    /// Every provider's Dockerfile carries `LABEL fletch.agent=<provider id>`
+    /// — the GC's attribution authority. The value must round-trip through
+    /// `DockerProvider::from_id` so label values and provider ids can't drift.
+    #[test]
+    fn every_dockerfile_carries_the_agent_label() {
+        for provider in DockerProvider::ALL {
+            let dockerfile = image_spec(provider).dockerfile;
+            let value = dockerfile
+                .lines()
+                .find_map(|l| l.strip_prefix(&format!("LABEL {AGENT_IMAGE_LABEL}=")))
+                .unwrap_or_else(|| panic!("{provider:?} Dockerfile is missing the fletch.agent label"));
+            assert_eq!(
+                DockerProvider::from_id(value.trim()),
+                Some(provider),
+                "{provider:?} label value must be its provider id",
+            );
+            // `id()` is `from_id`'s inverse — the version trigger keys the
+            // host probe and loop guard on it, so drift would silently
+            // disable (or cross-wire) the trigger.
+            assert_eq!(provider.id(), value.trim());
+            assert_eq!(DockerProvider::from_id(provider.id()), Some(provider));
+        }
+    }
+
+    /// The version-mismatch trigger's pure core: refresh only on a known,
+    /// unequal, not-yet-attempted pairing. Plain `!=`, no semver ordering.
+    #[test]
+    fn version_refresh_decision() {
+        // Mismatch → refresh.
+        assert!(version_refresh_wanted(Some("v2.0.1"), Some("v2.0.0"), false));
+        // Direction doesn't matter (no ordering): host older also fires once.
+        assert!(version_refresh_wanted(Some("v1.0.0"), Some("v2.0.0"), false));
+        // Match → fresh.
+        assert!(!version_refresh_wanted(Some("v2.0.0"), Some("v2.0.0"), false));
+        // No host CLI (not installed / probe failed) → inert.
+        assert!(!version_refresh_wanted(None, Some("v2.0.0"), false));
+        // Container version unknown (post-build probe failed) → inert.
+        assert!(!version_refresh_wanted(Some("v2.0.0"), None, false));
+        assert!(!version_refresh_wanted(None, None, false));
+        // Already-attempted pairing → inert (pinned host must not loop).
+        assert!(!version_refresh_wanted(Some("v2.0.1"), Some("v2.0.0"), true));
+    }
+
+    /// The TTL decision's pure core, with fixed instants: inside the window →
+    /// fresh, past it → stale, unparseable → unknown (treated as fresh by the
+    /// caller — never rebuild-loop on bad metadata), and a future timestamp
+    /// (clock skew) → fresh.
+    #[test]
+    fn freshness_classification() {
+        use chrono::{TimeZone, Utc};
+        let now = Utc.with_ymd_and_hms(2026, 7, 8, 12, 0, 0).unwrap();
+
+        // Docker's actual format: RFC3339 with nanoseconds and Z.
+        assert_eq!(
+            classify_freshness("2026-07-07T12:00:00.123456789Z", now),
+            Freshness::Fresh,
+            "one day old is fresh",
+        );
+        assert_eq!(
+            classify_freshness("2026-07-01T12:00:00Z", now),
+            Freshness::Fresh,
+            "exactly the TTL boundary is still fresh (strictly-older rebuilds)",
+        );
+        assert_eq!(
+            classify_freshness("2026-07-01T11:59:59Z", now),
+            Freshness::Stale,
+            "past the TTL is stale",
+        );
+        assert_eq!(
+            classify_freshness("2026-01-01T00:00:00Z", now),
+            Freshness::Stale,
+            "months old is stale",
+        );
+        assert_eq!(
+            classify_freshness("2026-08-01T00:00:00Z", now),
+            Freshness::Fresh,
+            "a future build date (clock skew) is fresh, not stale",
+        );
+        assert_eq!(
+            classify_freshness("not-a-timestamp", now),
+            Freshness::Unknown,
+        );
+        assert_eq!(classify_freshness("", now), Freshness::Unknown);
+        // Whitespace from the CLI pipe is tolerated.
+        assert_eq!(
+            classify_freshness("  2026-07-07T12:00:00Z\n", now),
+            Freshness::Fresh,
         );
     }
 
@@ -514,9 +997,15 @@ mod tests {
         let called = std::sync::atomic::AtomicBool::new(false);
         let progress = |_: &str| called.store(true, std::sync::atomic::Ordering::SeqCst);
 
-        let image =
-            resolve_image(DockerProvider::Claude, Some("  ghcr.io/me/custom:1  "), &progress)
-                .unwrap();
+        // A host version is passed to prove the override path ignores it too:
+        // the user's image is never inspected, so there's nothing to compare.
+        let image = resolve_image(
+            DockerProvider::Claude,
+            Some("  ghcr.io/me/custom:1  "),
+            Some("v9.9.9"),
+            &progress,
+        )
+        .unwrap();
         assert_eq!(
             image, "ghcr.io/me/custom:1",
             "override is trimmed and used verbatim"
@@ -557,7 +1046,8 @@ mod tests {
         let progress = |_: &str| {
             lines.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         };
-        ensure_image_with(dockerfile, ENTRYPOINT_SH, &tag, &progress).unwrap();
+        let existed = ensure_image_with(dockerfile, ENTRYPOINT_SH, &tag, &progress).unwrap();
+        assert!(!existed, "first call must report a fresh build");
         assert!(
             image_exists(&tag).unwrap(),
             "image should exist after build"
@@ -569,11 +1059,51 @@ mod tests {
 
         // Second call: image present, no build, no progress.
         lines.store(0, std::sync::atomic::Ordering::SeqCst);
-        ensure_image_with(dockerfile, ENTRYPOINT_SH, &tag, &progress).unwrap();
+        let existed = ensure_image_with(dockerfile, ENTRYPOINT_SH, &tag, &progress).unwrap();
+        assert!(existed, "second call must report the cached image");
         assert_eq!(
             lines.load(std::sync::atomic::Ordering::SeqCst),
             0,
             "an existing image must not rebuild",
+        );
+
+        let _ = cli::run_docker(&["rmi", "-f", &tag], Duration::from_secs(30));
+    }
+
+    /// Integration: the in-container version probe runs `<image_bin>
+    /// --version` through the image's entrypoint-less argv path and extracts
+    /// the version with the host probe's parser — a fake `claude` script in a
+    /// busybox image must come back as `v9.9.9`, and the result must be
+    /// memoized by image id.
+    /// `FLETCH_DOCKER_TESTS=1 cargo test -- --ignored`
+    #[test]
+    #[ignore = "requires Docker; opt in via FLETCH_DOCKER_TESTS=1"]
+    fn probes_container_cli_version() {
+        if !crate::sandbox::docker::docker_tests_enabled() {
+            return;
+        }
+        let dockerfile = "FROM busybox\nRUN printf '#!/bin/sh\\necho 9.9.9\\n' > /bin/claude && chmod +x /bin/claude\n";
+        let tag = tag_for("fletch-agent", dockerfile, "");
+        let _ = cli::run_docker(&["rmi", "-f", &tag], Duration::from_secs(30));
+        ensure_image_with(dockerfile, "", &tag, &|_| {}).unwrap();
+
+        assert_eq!(
+            probe_image_cli_version(DockerProvider::Claude, &tag).as_deref(),
+            Some("v9.9.9"),
+            "container probe must parse the CLI's --version output",
+        );
+        // The cached path returns the same answer without another docker run
+        // (indirectly observable: it works even against a bogus tag once the
+        // id is cached).
+        assert_eq!(
+            image_cli_version(DockerProvider::Claude, &tag, "test-id-123").as_deref(),
+            Some("v9.9.9"),
+        );
+        assert_eq!(
+            image_cli_version(DockerProvider::Claude, "no-such-image:zzz", "test-id-123")
+                .as_deref(),
+            Some("v9.9.9"),
+            "second lookup for the same image id must hit the cache",
         );
 
         let _ = cli::run_docker(&["rmi", "-f", &tag], Duration::from_secs(30));

--- a/src-tauri/src/sandbox/docker/mod.rs
+++ b/src-tauri/src/sandbox/docker/mod.rs
@@ -13,7 +13,8 @@
 //!   the app on a wedged daemon.
 //! - [`probe`] — cached daemon availability for UI polling.
 //! - [`image`] — the embedded agent Dockerfile and content-addressed builds.
-//! - [`cleanup`] — container labels and the dead-instance orphan sweep.
+//! - [`cleanup`] — container labels, the dead-instance orphan sweep, and the
+//!   stale agent-image GC.
 //! - [`engine`] — `DockerEngine`, the `SandboxEngine` implementation
 //!   (one `docker run --rm --init` container per agent process).
 
@@ -27,7 +28,8 @@ mod probe;
 mod progress;
 
 pub use engine::{
-    set_launch_settings, DockerEngine, LaunchSettings, CPUS_SETTING, IMAGE_SETTING, MEMORY_SETTING,
+    init_version_refresh_guard, set_launch_settings, DockerEngine, LaunchSettings, CPUS_SETTING,
+    IMAGE_SETTING, MEMORY_SETTING, VERSION_GUARD_SETTING,
 };
 pub use probe::{availability, DockerAvailability};
 pub use progress::set_build_sink;
@@ -57,6 +59,19 @@ pub enum DockerProvider {
 }
 
 impl DockerProvider {
+    /// Every docker-supported provider. The image GC derives "the current
+    /// expected images" from this list, so a variant missing here would make
+    /// the GC treat that provider's live image as stale — when adding a
+    /// variant, extend this list (the exhaustive `match` in `image::image_spec`
+    /// will already force you into that file).
+    pub const ALL: [Self; 5] = [
+        Self::Claude,
+        Self::Codex,
+        Self::Opencode,
+        Self::Pi,
+        Self::Cursor,
+    ];
+
     /// Map a provider id (as stamped on `AgentRecord.provider` / used by the
     /// frontend) to its Docker support, or `None` when the provider has no
     /// container support yet — the launch gate turns `None` into the
@@ -69,6 +84,21 @@ impl DockerProvider {
             "pi" => Some(Self::Pi),
             "cursor" => Some(Self::Cursor),
             _ => None,
+        }
+    }
+
+    /// The provider id string — [`from_id`](Self::from_id)'s inverse
+    /// (round-trip enforced by a test in [`image`]). Used where a variant must
+    /// key string-indexed state shared with the rest of the app, e.g. the host
+    /// version probe (`agent::cached_provider_version`) and the persisted
+    /// version-refresh loop guard (see `engine`).
+    pub fn id(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::Opencode => "opencode",
+            Self::Pi => "pi",
+            Self::Cursor => "cursor",
         }
     }
 
@@ -90,10 +120,12 @@ impl DockerProvider {
 }
 
 /// Best-effort reclamation of containers left behind by dead Fletch
-/// instances, for app startup (`lib.rs`, next to the nested-root sweeps).
-/// Runs on its own thread and probes the daemon first, so startup never
-/// waits on Docker — not even for the 2s probe timeout — and a machine
-/// without Docker skips the sweep entirely.
+/// instances — and of superseded agent images — for app startup (`lib.rs`,
+/// next to the nested-root sweeps). Runs on its own thread and probes the
+/// daemon first, so startup never waits on Docker — not even for the 2s probe
+/// timeout — and a machine without Docker skips both sweeps entirely. The
+/// image sweep runs second: a removed orphan container can unpin the stale
+/// image it was running. Both sweeps are non-fatal by construction.
 pub fn sweep_orphans_at_startup() {
     std::thread::spawn(|| {
         if !matches!(probe::availability(), DockerAvailability::Available { .. }) {
@@ -103,6 +135,11 @@ pub fn sweep_orphans_at_startup() {
             Ok(0) => {}
             Ok(n) => tracing::info!(removed = n, "swept orphaned fletch containers"),
             Err(e) => tracing::warn!(error = %e, "docker orphan sweep failed"),
+        }
+        match cleanup::sweep_stale_images() {
+            Ok(0) => {}
+            Ok(n) => tracing::info!(removed = n, "swept stale fletch agent images"),
+            Err(e) => tracing::warn!(error = %e, "docker image sweep failed"),
         }
     });
 }


### PR DESCRIPTION
## Summary

Follow-up to the Docker multi-provider series (#367/#368/#369). Content-addressed image tags solved *Dockerfile* drift but froze the packages *inside* an image forever: every image installs latest-at-build, so a user's containerized CLI never updated while their host CLI did — and superseded images were never removed. This PR adds an image lifecycle: images refresh themselves and clean up after themselves, and freshness can never block or fail a launch.

## The three mechanisms

**TTL — "an agent image is never older than a week."** At resolution, an existing image older than `IMAGE_MAX_AGE` (7 days) is served for the current launch and rebuilt under the same tag in a background thread (stale-while-revalidate, serialized on the shared `BUILD_LOCK`). Rebuild failure keeps the old image serving with a warning — a dead registry can't break launches. Unparseable/future `Created` timestamps count as fresh (no rebuild loops on odd metadata).

**Version parity ("a user who just updated their host CLI expects container parity").** After each successful build, a one-shot `docker run --rm <tag> <bin> --version` captures the container's CLI version (fire-and-forget; never delays a launch; parsed with the same extractor as the existing host probe). When the host CLI's memoized probe differs — plain `!=`, zero semver parsing — the same background rebuild fires even inside the TTL window. Inert when either side is unknown (Docker-only users with no host CLI fall back to the TTL). A persisted `(host_version, image_tag)` guard, recorded on success only, prevents rebuild loops when a pinned host trails the registry: one wasted rebuild worst case.

**GC — one rule.** Every Dockerfile now carries `LABEL fletch.agent=<provider>`; any labeled image that isn't a current expected tag is removed, at startup (after the container orphan sweep) and after each successful rebuild. `docker rmi` without `-f`; in-use failures are expected and non-fatal. Legacy pre-label images are matched by Fletch's own repo names (documented transitional arm, removable later). Current tags, the `docker_image` override (matched by repo:tag / bare-repo / id), labeled-but-user-retagged images, and all non-fletch images always survive.

## Build-flag decisions

- `--pull` on **all** builds: a months-old cached `node:22-slim` would silently defeat the TTL, and agent builds already need the network for their install step.
- `--no-cache` on **refresh rebuilds only**: without it, an unchanged base digest makes Docker serve the install layer from cache, producing a byte-identical image — both triggers would silently no-op and the version trigger would loop. First builds keep the cache (cross-provider base-layer sharing on cold start).

## Costs accepted deliberately

- The LABEL changes every Dockerfile's hash → **all users rebuild all five images once** on update. Claude's golden test records the new frozen bytes and the reasoning.
- Refresh rebuilds are full builds and forfeit base-layer sharing until GC'd.
- The loop guard persists in one non-user-facing settings row (`docker_version_refresh_guard`) — without it, a lagging host would trigger a full wasted rebuild per app restart.
- Background rebuilds are **silent** (log lines only): the build toast's copy/UX assumes a blocking first-run build the user is waiting on. Foreground builds emit BuildEvents exactly as before. Zero frontend changes; launch argv untouched.

## Verification

- `cargo check` / `cargo clippy --all-targets` (zero new warnings) / `cargo test`: **503 passed, 0 failed**. New pure-core tests: freshness classification (fresh/boundary/stale/unparseable/future), GC selection (labeled-stale/labeled-current/user-retag/unlabeled-non-fletch/legacy/override spellings/dedupe), version-trigger decision (mismatch/match/no-host/attempted-pair/container-unknown), guard round-trip + persistence callback.
- **Docker e2e** (daemon 29.5.3): all gated tests pass — GC sweeps a synthetic stale labeled image while sparing unlabeled ones, `fletch.agent` label verified on a real fresh build, post-build version probe verified through the real `docker run` path. All artifacts cleaned.

## Notes for reviewers

- Boundary semantics: exactly-7-days-old counts as fresh (strictly-older rebuilds) — trivially flippable.
- Digest-pinned overrides (`repo@sha256:…`) aren't name-matched by the GC's override fence; still structurally safe (unlabeled, non-fletch repo).
- The rebuild thread is detached: app exit mid-rebuild abandons a build; worst case is a dangling image the next sweep reaps.
- Startup image GC runs whenever Docker is reachable, even if seatbelt is the selected engine (mirrors the container sweep).
- Follow-ups tracked: remove the legacy repo-name GC arm once pre-label installs age out; `TODO(per-provider-override)` for the global `docker_image` setting; antigravity Docker support blocked on upstream (no non-interactive auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)