### PR TITLE
feat(sidebar): simplify project header into a clean list label

### DIFF
--- a/src/components/Sidebar/ProjectGroup.tsx
+++ b/src/components/Sidebar/ProjectGroup.tsx
@@ -95,7 +95,6 @@ export function ProjectGroup({
         }}
         title={repoPath}
       >
-        {reorderable && <Icon name="grip" size={12} className="pgrip" />}
         <Icon name="chevR" size={10} className="chev" />
         <span className="pname">{label}</span>
         <span className="pcount">{count}</span>
@@ -110,7 +109,7 @@ export function ProjectGroup({
         </button>
         {removable && (
           <button
-            className="padd tip"
+            className="padd padd-remove tip"
             data-tip="Remove repo"
             data-tip-down=""
             onClick={onRemove}

--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -101,7 +101,9 @@
 }
 .proj-h {
   gap: 6px;
-  padding: 0 8px;
+  /* name column aligned to the agents' 13px text rail; chevron lives in the
+   * gutter (absolute, like .ag-rail), so the header reads as the list's label */
+  padding: 0 8px 0 13px;
   height: 28px;
   border-radius: var(--r-sm);
   font-size: var(--fs-xs);
@@ -116,35 +118,32 @@
 .proj-h:hover {
   background: var(--hover);
 }
+/* The whole header is the drag target — cursor:grab is the only reorder
+ * affordance (no grip glyph, so the name keeps the gutter's left rail). */
 .proj-h.reorderable {
   cursor: grab;
 }
 .proj-h.reorderable:active {
   cursor: grabbing;
 }
-/* Drag affordance: a muted grip that firms up on hover. Fixed-width slot so
- * showing it doesn't shift the project name. */
-.proj-h .pgrip {
-  flex-shrink: 0;
-  width: 12px;
-  height: 12px;
-  margin-left: -4px;
-  color: var(--fg-3);
-  opacity: 0.35;
-  transition: opacity 0.1s;
-}
-.proj-h:hover .pgrip {
-  opacity: 0.9;
-}
 .proj-h .chev {
+  position: absolute;
+  left: 1px;
+  top: 50%;
   width: 10px;
   height: 10px;
   color: var(--fg-3);
-  transition: transform 0.15s var(--ease);
-  flex-shrink: 0;
+  opacity: 0.55;
+  transform: translateY(-50%);
+  transition:
+    transform 0.15s var(--ease),
+    opacity 0.1s;
+}
+.proj-h:hover .chev {
+  opacity: 0.9;
 }
 .proj-h.open .chev {
-  transform: rotate(90deg);
+  transform: translateY(-50%) rotate(90deg);
 }
 .proj-h .pname {
   flex: 0 1 auto;
@@ -166,6 +165,9 @@
   content: "·";
   margin-right: 4px;
 }
+/* Ghost affordance: always visible so "add an agent" is discoverable without
+ * hovering, but borderless + muted so it never competes with the label. It
+ * earns the accent fill only on hover. */
 .proj-h .padd {
   width: 22px;
   height: 22px;
@@ -173,13 +175,28 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: var(--fg-2);
-  background: var(--bd-soft);
+  color: var(--fg-3);
+  background: transparent;
+  opacity: 0.6;
   transition: var(--transition-ui);
 }
 .proj-h .padd:hover {
   background: var(--accent-soft);
   color: var(--accent);
+  opacity: 1;
+}
+/* Remove (empty projects only) is destructive and rare — hidden until the row
+ * is engaged. */
+.proj-h .padd-remove {
+  opacity: 0;
+  pointer-events: none;
+}
+.proj-h:hover .padd-remove {
+  opacity: 0.6;
+  pointer-events: auto;
+}
+.proj-h:hover .padd-remove:hover {
+  opacity: 1;
 }
 .proj-h .padd[aria-label="New agent"] svg {
   width: 15px;

--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -195,8 +195,12 @@
   opacity: 0.6;
   pointer-events: auto;
 }
-.proj-h:hover .padd-remove:hover {
+/* Keyboard focus reveals it too — a focused button at opacity:0 would make the
+ * focus ring vanish and hide the action from keyboard users. */
+.proj-h:hover .padd-remove:hover,
+.proj-h .padd-remove:focus-visible {
   opacity: 1;
+  pointer-events: auto;
 }
 .proj-h .padd[aria-label="New agent"] svg {
   width: 15px;


### PR DESCRIPTION
## Summary

Cleans up the sidebar project rows so each project header reads as a **label for its list of agents**, while keeping every existing capability (expand/collapse, add agent, drag-to-reorder, remove empty project).

## Changes

- **Name aligned to the agent column.** The project name now sits on the same 13px text rail as the agent names below it, and the expand chevron moves into the gutter (absolutely positioned, like the agent status rail). The header now visually belongs to the list it heads.
- **Drag grip removed.** The whole header was already the drag target, so the grip glyph was redundant noise. `cursor: grab` on hover is the reorder affordance, and the name reclaims the left rail.
- **"New agent" (+) is now a ghost button.** Always visible so adding an agent stays discoverable without hovering (⌘N still works too), but borderless and muted at rest — it earns the accent fill only on hover, so it no longer competes with the label.
- **Remove (×) is hover-revealed.** Only shown for empty pinned projects, and now hidden until the row is engaged — it's destructive and rare, so it stays out of the resting view.

Resting state goes from a crowded `⠿ ⌄ NAME · 3 [+]` to a calm `⌄ NAME · 3 +` with the name column-aligned to its agents.

## Files

- `src/components/Sidebar/ProjectGroup.tsx` — drop grip icon, tag remove button
- `src/components/Sidebar/Sidebar.css` — regrid header to the agent gutter/column, ghost `+`, hover-reveal `×`

## Testing

CSS + markup only; no behavior/logic changes. Worth an eyeball in-app to confirm the chevron/name alignment lands on the agent rail.