### PR TITLE
fix(history): balance search popover header and footer spacing

### DIFF
--- a/src/components/History/History.css
+++ b/src/components/History/History.css
@@ -49,7 +49,7 @@
 
 /* search header */
 .hh {
-  padding: 18px 24px;
+  padding: 10px 24px;
   flex-shrink: 0;
   border-bottom: 1px solid var(--bd-soft);
 }
@@ -237,7 +237,7 @@
   flex-shrink: 0;
   border-top: 1px solid var(--bd-soft);
   gap: 16px;
-  padding: 8px 20px;
+  padding: 12px 24px;
   color: var(--fg-2);
 }
 .history-foot .kbd {


### PR DESCRIPTION
## Summary
The History search popover had a visually awkward vertical gap: the `Search sessions` header carried heavy vertical padding while the footer (meta hints) was cramped against its border.

## Changes
- Header `.hh`: vertical padding `18px → 10px` (height ~72px → ~56px)
- Footer `.history-foot`: padding `8px 20px → 12px 24px` for more breathing room, with horizontal padding now matching the header's 24px

🤖 Generated with [Claude Code](https://claude.com/claude-code)