### PR TITLE
feat(project-settings): per-project settings modal for run config

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -737,6 +737,17 @@ pub fn detect_run_config(
     supervisor.detect_run_config(&agent_id)
 }
 
+/// Detect the run configuration for a project by repo path (as the sidebar
+/// keys its groups), bundled with the resolved project_id. Powers the
+/// Project Settings surface, which can open for a repo that has no live agent.
+#[tauri::command]
+pub fn project_run_config(
+    supervisor: State<'_, Arc<Supervisor>>,
+    repo_path: String,
+) -> Result<crate::supervisor::ProjectRunConfig> {
+    supervisor.project_run_config(&repo_path)
+}
+
 /// Returns git state for the agent's primary repo.
 /// For multi-repo agents only the first repo's state is returned.
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1053,6 +1053,7 @@ pub fn run() {
             commands::run_stop,
             commands::run_state,
             commands::detect_run_config,
+            commands::project_run_config,
             commands::list_worktree_tree,
             commands::list_dir,
             commands::list_prs,

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -10,6 +10,7 @@ mod session_sync;
 mod shell;
 
 pub use lifecycle::SpawnRequest;
+pub use run::ProjectRunConfig;
 
 use parking_lot::Mutex;
 use std::collections::{HashMap, HashSet};

--- a/src-tauri/src/supervisor/run.rs
+++ b/src-tauri/src/supervisor/run.rs
@@ -157,6 +157,30 @@ impl Supervisor {
         let worktree = repo_worktree_path(agent_id, &primary.subdir)?;
         Ok(crate::run_detect::detect_all(&worktree))
     }
+
+    /// Detect the run configuration for a project, keyed by repo path
+    /// rather than an agent. The Project Settings surface is reachable
+    /// from the sidebar's repo groups — including pinned repos with no
+    /// live agent — so it can't resolve a worktree the way the Run panel
+    /// does. Detection runs against the repo checkout root, and the
+    /// resolved `project_id` is bundled in so the frontend can read and
+    /// write `project_settings` without a second round-trip.
+    pub fn project_run_config(&self, repo_path: &str) -> Result<ProjectRunConfig> {
+        let project_id = self.workspace.project_id_for_repo(repo_path)?;
+        let configs = crate::run_detect::detect_all(Path::new(repo_path));
+        Ok(ProjectRunConfig {
+            project_id,
+            configs,
+        })
+    }
+}
+
+/// Run configuration for a project resolved from a repo path: the detected
+/// configs plus the `project_id` they belong to. See [`Supervisor::project_run_config`].
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ProjectRunConfig {
+    pub project_id: String,
+    pub configs: Vec<crate::run_detect::DetectedConfig>,
 }
 
 /// Inject a "$ <cmd>" header line into the log so each phase has a

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -731,6 +731,16 @@ impl WorkspaceManager {
         .ok()
     }
 
+    /// Resolve the project_id for a repo path (creating the project/repo
+    /// record if it doesn't exist yet — idempotent). The sidebar keys its
+    /// project groups by repo path, so the Project Settings surface uses
+    /// this to reach the `project_settings` rows, which are keyed by
+    /// project_id.
+    pub fn project_id_for_repo(&self, repo_path: &str) -> Result<String> {
+        let conn = self.db.lock();
+        Self::project_id_for_repo_path(&conn, repo_path)
+    }
+
     /// Stamp the setup command as having succeeded. Idempotent.
     pub fn mark_setup_completed(&self, id: &str) -> Result<()> {
         let conn = self.db.lock();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { ErrorBoundary } from "./components/ErrorBoundary";
 import { GithubConnectModal } from "./components/GithubConnect";
 import { History } from "./components/History";
 import { Onboarding } from "./components/Onboarding";
+import { ProjectSettings } from "./components/ProjectSettings";
 import { RightPanel } from "./components/RightPanel";
 import { Settings } from "./components/Settings";
 import { SettingsScreen } from "./components/SettingsScreen";
@@ -47,6 +48,7 @@ export function App() {
   const historyOpen = useAppStore((s) => s.historyOpen);
   const settingsScreenOpen = useAppStore((s) => s.settingsScreenOpen);
   const onboardingOpen = useAppStore((s) => s.onboardingOpen);
+  const projectSettingsRepoPath = useAppStore((s) => s.projectSettingsRepoPath);
   // Count of agents that finished a turn while the user wasn't looking at them
   // (set on completion, cleared when the agent is opened). This is the same
   // signal behind the sidebar "new" dots — mirror it onto the app icon badge.
@@ -161,6 +163,7 @@ export function App() {
       </div>
 
       {historyOpen && <History />}
+      {projectSettingsRepoPath && <ProjectSettings repoPath={projectSettingsRepoPath} />}
       <Settings />
       {onboardingOpen && <Onboarding />}
       <GithubConnectModal />

--- a/src/api.ts
+++ b/src/api.ts
@@ -304,6 +304,13 @@ export interface DetectedConfig {
   rows: DetectedRow[];
 }
 
+/** Project-scoped run config resolved from a repo path: the detected configs
+ *  plus the project_id they belong to (see Rust `supervisor::ProjectRunConfig`). */
+export interface ProjectRunConfig {
+  project_id: string;
+  configs: DetectedConfig[];
+}
+
 export interface RunOutputEvent {
   agent_id: string;
   bytes: number[];
@@ -565,6 +572,8 @@ export const api = {
   runStop: (agentId: string) => invoke<void>("run_stop", { agentId }),
   runState: (agentId: string) => invoke<RunStateSnapshot>("run_state", { agentId }),
   detectRunConfig: (agentId: string) => invoke<DetectedConfig[]>("detect_run_config", { agentId }),
+  projectRunConfig: (repoPath: string) =>
+    invoke<ProjectRunConfig>("project_run_config", { repoPath }),
   listWorktreeTree: (agentId: string) => invoke<WorktreeFile[]>("list_worktree_tree", { agentId }),
   listDir: (path: string) => invoke<DirListing>("list_dir", { path }),
   listPrs: (agentId: string) => invoke<PrSummary[]>("list_prs", { agentId }),

--- a/src/app.css
+++ b/src/app.css
@@ -34,6 +34,7 @@
 @import "./styles/foundation/scrollbar.css";
 @import "./styles/shared/terminal.css";
 @import "./components/History/History.css";
+@import "./components/ProjectSettings/ProjectSettings.css";
 @import "./components/RightPanel/FilePanel/FilePanel.css";
 @import "./components/SettingsScreen/SettingsScreen.css";
 @import "./styles/shared/error-boundary.css";

--- a/src/components/ProjectSettings/ProjectSettings.css
+++ b/src/components/ProjectSettings/ProjectSettings.css
@@ -1,0 +1,147 @@
+/* ─── project settings modal ─────────────────────────────────────────
+ * Centered overlay, modeled on the History sheet (see History.css) for
+ * consistency with the app's existing full-screen modal. */
+.ps-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  -webkit-backdrop-filter: blur(2px);
+  backdrop-filter: blur(2px);
+  z-index: var(--z-overlay);
+  display: flex;
+  flex-direction: column;
+  animation: psOverlayIn 0.18s var(--ease);
+}
+.theme-light .ps-overlay {
+  background: rgba(40, 40, 40, 0.35);
+}
+@keyframes psOverlayIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.ps-modal {
+  margin: 36px auto;
+  width: min(1180px, calc(100vw - 64px));
+  /* Fixed full height so the modal fills the viewport regardless of how much
+   * content a section has — short sections leave the content area empty below
+   * rather than shrinking the modal. */
+  height: calc(100vh - 72px);
+  background: var(--bg-1);
+  border: 1px solid var(--bd-strong);
+  border-radius: var(--r-lg);
+  box-shadow: 0 36px 96px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+  animation: psModalIn 0.22s var(--ease);
+}
+.theme-light .ps-modal {
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.18);
+}
+@keyframes psModalIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.99);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* header — project identity */
+.ps-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 18px 20px 16px 24px;
+  border-bottom: 1px solid var(--bd-soft);
+  flex-shrink: 0;
+}
+.ps-id {
+  flex: 1;
+  min-width: 0;
+}
+.ps-title {
+  font-weight: 600;
+  color: var(--fg-0);
+  letter-spacing: -0.01em;
+}
+.ps-path {
+  margin-top: 3px;
+  color: var(--fg-3);
+}
+.ps-x {
+  flex-shrink: 0;
+  width: 26px;
+  height: 26px;
+  border-radius: var(--r-sm);
+  background: transparent;
+  border: 0;
+  color: var(--fg-3);
+  justify-content: center;
+  transition:
+    background 0.1s,
+    color 0.1s;
+}
+.ps-x:hover {
+  background: var(--hover);
+  color: var(--fg-0);
+}
+
+/* body — one scrollable page; sections stack in a centered column */
+.ps-content {
+  flex: 1;
+  min-width: 0;
+  overflow-y: auto;
+  padding: 28px 32px 44px;
+}
+.ps-sections {
+  max-width: 760px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+.ps-state {
+  gap: 8px;
+  color: var(--fg-3);
+  padding: 24px 2px;
+}
+
+/* sections */
+.ps-section-h {
+  margin-bottom: 16px;
+}
+.ps-section-t {
+  font-weight: 600;
+  color: var(--fg-0);
+  letter-spacing: -0.01em;
+}
+.ps-section-lead {
+  margin-top: 6px;
+  color: var(--fg-2);
+  max-width: 62ch;
+  line-height: 1.5;
+}
+.ps-eco {
+  color: var(--fg-3);
+  padding: 2px 2px 2px;
+}
+.ps-eco code {
+  font-family: var(--font-mono);
+  color: var(--fg-1);
+  padding: 0 4px;
+  background: var(--bg-2);
+  border: 1px solid var(--bd-soft);
+  border-radius: 3px;
+}
+.ps-eco-count b {
+  color: var(--fg-0);
+}

--- a/src/components/ProjectSettings/RunEnvSection.tsx
+++ b/src/components/ProjectSettings/RunEnvSection.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import {
+  ECOSYSTEM_LABEL,
+  persistRunOverrides,
+  RunConfigEditor,
+  reconcileOverrides,
+  type SetupRow,
+} from "@/components/RunConfig";
+
+interface Props {
+  projectId: string;
+  rows: SetupRow[];
+  ecosystem: string | null;
+  initialOverrides: Record<string, string>;
+}
+
+/** The run configuration every agent in the project inherits. Unlike the Run
+ *  panel sheet — which stages a draft and applies on restart — this edits the
+ *  project defaults directly, so changes autosave per row. */
+export function RunEnvSection({ projectId, rows, ecosystem, initialOverrides }: Props) {
+  const [overrides, setOverrides] = useState<Record<string, string>>(initialOverrides);
+
+  // Reconcile a single edit against the detected rows and persist it. Same
+  // logic the Run panel runs on Apply, just committed immediately.
+  const commit = (next: Record<string, string>) => {
+    const { cleaned, toSet, toDelete } = reconcileOverrides(rows, overrides, next);
+    persistRunOverrides(projectId, toSet, toDelete);
+    setOverrides(cleaned);
+  };
+
+  const onChange = (id: string, value: string) => commit({ ...overrides, [id]: value });
+  const onRevert = (id: string) => {
+    const next = { ...overrides };
+    delete next[id];
+    commit(next);
+  };
+
+  const overrideCount = Object.keys(overrides).length;
+
+  return (
+    <section className="ps-section">
+      <header className="ps-section-h">
+        <h2 className="ps-section-t text-lg">Run &amp; environment</h2>
+        <p className="ps-section-lead text-sm">
+          Defaults every agent in this project inherits. Detected from the repo; edit a value to
+          override it. Individual runs can still override these from the Run panel.
+        </p>
+      </header>
+
+      {rows.length === 0 ? (
+        <div className="ps-state text-sm">
+          No run configuration detected for this project — nothing to configure yet.
+        </div>
+      ) : (
+        <>
+          <div className="ps-eco text-xs">
+            {ecosystem ? (
+              <>
+                Detected · <code>{ECOSYSTEM_LABEL[ecosystem] ?? ecosystem}</code>
+              </>
+            ) : (
+              <>No ecosystem detected — edit values below</>
+            )}
+            {overrideCount > 0 && (
+              <span className="ps-eco-count">
+                {" · "}
+                <b>{overrideCount}</b> override{overrideCount === 1 ? "" : "s"}
+              </span>
+            )}
+          </div>
+          <RunConfigEditor rows={rows} draft={overrides} onChange={onChange} onRevert={onRevert} />
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/components/ProjectSettings/index.tsx
+++ b/src/components/ProjectSettings/index.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from "react";
+import { api } from "@/api";
+import { Icon } from "@/components/Icon";
+import { loadRunOverrides, type SetupRow, toSetupRows } from "@/components/RunConfig";
+import { Loader } from "@/components/ui/Loader";
+import { useAppStore } from "@/store";
+import { basename } from "@/util/format";
+import { RunEnvSection } from "./RunEnvSection";
+
+interface Loaded {
+  projectId: string;
+  rows: SetupRow[];
+  ecosystem: string | null;
+  overrides: Record<string, string>;
+}
+
+/** Project Settings modal. A centered overlay (mirrors the History sheet) for
+ *  editing per-project defaults — chiefly the run configuration every agent in
+ *  the project inherits. Sections stack in one scrollable page. Keyed by the
+ *  sidebar's repo path; resolves the project_id and detected run config on open. */
+export function ProjectSettings({ repoPath }: { repoPath: string }) {
+  const close = useAppStore((s) => s.closeProjectSettings);
+  const [loaded, setLoaded] = useState<Loaded | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const name = basename(repoPath);
+
+  // Resolve project_id + detected run config for the repo, then load the
+  // persisted overrides. Both must be ready before the editor mounts so the
+  // draft baseline is correct.
+  useEffect(() => {
+    let cancelled = false;
+    setLoaded(null);
+    setError(null);
+    (async () => {
+      try {
+        const { project_id, configs } = await api.projectRunConfig(repoPath);
+        const overrides = await loadRunOverrides(project_id);
+        if (cancelled) return;
+        const primary = configs[0];
+        setLoaded({
+          projectId: project_id,
+          rows: toSetupRows(primary?.rows ?? []),
+          ecosystem: primary?.ecosystem ?? null,
+          overrides,
+        });
+      } catch (err) {
+        if (cancelled) return;
+        console.error("projectRunConfig failed", err);
+        setError(String(err));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [repoPath]);
+
+  // Close on Escape.
+  useEffect(() => {
+    const h = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    document.addEventListener("keydown", h);
+    return () => document.removeEventListener("keydown", h);
+  }, [close]);
+
+  return (
+    <div className="ps-overlay" onClick={close}>
+      <div
+        className="ps-modal"
+        role="dialog"
+        aria-label="Project settings"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="ps-head">
+          <div className="ps-id">
+            <div className="ps-title text-lg truncate">{name}</div>
+            <div className="ps-path mono text-xs truncate">{repoPath}</div>
+          </div>
+          <button className="ps-x iflex-center" onClick={close} aria-label="Close">
+            <Icon name="close" size={13} />
+          </button>
+        </div>
+
+        <div className="ps-content">
+          {error ? (
+            <div className="ps-state text-sm">Couldn’t load project settings.</div>
+          ) : !loaded ? (
+            <div className="ps-state iflex-center text-sm">
+              <Loader variant="inherit" /> Loading…
+            </div>
+          ) : (
+            <div className="ps-sections">
+              <RunEnvSection
+                projectId={loaded.projectId}
+                rows={loaded.rows}
+                ecosystem={loaded.ecosystem}
+                initialOverrides={loaded.overrides}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProjectSettings/index.tsx
+++ b/src/components/ProjectSettings/index.tsx
@@ -69,6 +69,7 @@ export function ProjectSettings({ repoPath }: { repoPath: string }) {
       <div
         className="ps-modal"
         role="dialog"
+        aria-modal="true"
         aria-label="Project settings"
         onClick={(e) => e.stopPropagation()}
       >

--- a/src/components/RightPanel/RunPanel.tsx
+++ b/src/components/RightPanel/RunPanel.tsx
@@ -2,28 +2,20 @@ import { useEffect, useRef, useState } from "react";
 import { type AgentRecord, api, onRunOutput, onRunState } from "@/api";
 import { Icon } from "@/components/Icon";
 import {
-  deleteProjectSetting,
-  getProjectSettings,
-  setProjectSetting,
-} from "@/storage/projectSettings";
+  loadRunOverrides,
+  persistRunOverrides,
+  reconcileOverrides,
+  type SetupRow,
+  toSetupRows,
+} from "@/components/RunConfig";
 import { useAppStore } from "@/store";
-import { RunSettingsSheet, type SetupRow } from "./RunSettingsSheet";
-import { reconcileOverrides } from "./reconcileOverrides";
-
-// Settings keys are namespaced under `run.` so the project_settings
-// table can hold overrides from other panels without colliding.
-const RUN_KEY_PREFIX = "run.";
-const runKey = (id: string) => `${RUN_KEY_PREFIX}${id}`;
+import { RunSettingsSheet } from "./RunSettingsSheet";
 
 // Detected run config replaces the old hardcoded defaults. The backend
 // (`detect_run_config`) returns rows per ecosystem; the panel shows the
-// highest-confidence one. The `run.*` overrides in project_settings layer
-// on top of these detected values.
-const GROUP_LABEL: Record<string, string> = {
-  environment: "Environment",
-  scripts: "Scripts",
-  server: "Server",
-};
+// highest-confidence one. The `run.*` overrides in project_settings — the
+// per-project defaults, also editable from Project settings — layer on top
+// of these detected values.
 
 // Strip ANSI escape sequences before rendering. v1 keeps log rendering
 // dead-simple (plain text with pre-wrap); colorization can come later.
@@ -68,14 +60,8 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
       setOverrides({});
       return;
     }
-    getProjectSettings(agent.project_id).then((all) => {
+    loadRunOverrides(agent.project_id).then((loaded) => {
       if (cancelled) return;
-      const loaded: Record<string, string> = {};
-      for (const [k, v] of Object.entries(all)) {
-        if (k.startsWith(RUN_KEY_PREFIX)) {
-          loaded[k.slice(RUN_KEY_PREFIX.length)] = v;
-        }
-      }
       setOverrides(loaded);
     });
     return () => {
@@ -94,15 +80,7 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
         if (cancelled) return;
         const primary = configs[0];
         setEcosystem(primary?.ecosystem ?? null);
-        setRows(
-          (primary?.rows ?? []).map((r) => ({
-            id: r.id,
-            group: GROUP_LABEL[r.group] ?? r.group,
-            key: r.key,
-            value: r.value,
-            source: r.source,
-          })),
-        );
+        setRows(toSetupRows(primary?.rows ?? []));
       })
       .catch((err) => {
         if (cancelled) return;
@@ -214,18 +192,8 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
     // exists after an ecosystem change) from the DB so the override
     // indicator can't get stuck lit.
     const { cleaned, toSet, toDelete } = reconcileOverrides(rows, overrides, next);
-    const projectId = agent.project_id;
-    if (projectId) {
-      for (const { id, value } of toSet) {
-        setProjectSetting(projectId, runKey(id), value).catch((err) =>
-          console.error("setProjectSetting failed", err),
-        );
-      }
-      for (const id of toDelete) {
-        deleteProjectSetting(projectId, runKey(id)).catch((err) =>
-          console.error("deleteProjectSetting failed", err),
-        );
-      }
+    if (agent.project_id) {
+      persistRunOverrides(agent.project_id, toSet, toDelete);
     }
 
     setOverrides(cleaned);

--- a/src/components/RightPanel/RunSettingsSheet.tsx
+++ b/src/components/RightPanel/RunSettingsSheet.tsx
@@ -1,14 +1,7 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { Icon } from "@/components/Icon";
+import { ECOSYSTEM_LABEL, RunConfigEditor, type SetupRow } from "@/components/RunConfig";
 import { Button } from "@/components/ui/Button";
-
-export interface SetupRow {
-  id: string;
-  group: string;
-  key: string;
-  value: string; // inferred / default
-  source: string; // e.g. "scripts.dev", "vite.config.ts"
-}
 
 interface Props {
   rows: SetupRow[];
@@ -19,20 +12,9 @@ interface Props {
   onApply: (overrides: Record<string, string>) => void;
 }
 
-const ECOSYSTEM_LABEL: Record<string, string> = {
-  node: "Node",
-  python: "Python",
-  ruby: "Ruby",
-  rust: "Rust",
-  go: "Go",
-};
-
 export function RunSettingsSheet({ rows, overrides, ecosystem, onClose, onApply }: Props) {
   // Draft = working copy while the sheet is open; uncommitted until Apply.
   const [draft, setDraft] = useState<Record<string, string>>(overrides);
-
-  const groups = Array.from(new Set(rows.map((r) => r.group)));
-
   const setRow = (id: string, v: string | null) =>
     setDraft((d) => {
       const next = { ...d };
@@ -40,10 +22,9 @@ export function RunSettingsSheet({ rows, overrides, ecosystem, onClose, onApply 
       else next[id] = v;
       return next;
     });
-
   const revert = (id: string) => setRow(id, null);
-
-  // Rows whose draft differs from the inferred value
+  const reset = () => setDraft({});
+  // Rows whose draft differs from the detected value — the real overrides.
   const changed = rows.filter((r) => draft[r.id] != null && draft[r.id] !== r.value);
   const dirty =
     changed.length > 0 ||
@@ -87,24 +68,7 @@ export function RunSettingsSheet({ rows, overrides, ecosystem, onClose, onApply 
 
         {/* Body */}
         <div className="run-sheet-body">
-          {groups.map((g) => (
-            <div key={g} className="rs-group">
-              <div className="rs-group-h text-xs">{g}</div>
-              <div className="rs-group-rows">
-                {rows
-                  .filter((r) => r.group === g)
-                  .map((r) => (
-                    <ConfigRow
-                      key={r.id}
-                      row={r}
-                      override={draft[r.id]}
-                      onChange={(v) => setRow(r.id, v)}
-                      onRevert={() => revert(r.id)}
-                    />
-                  ))}
-              </div>
-            </div>
-          ))}
+          <RunConfigEditor rows={rows} draft={draft} onChange={setRow} onRevert={revert} />
         </div>
 
         {/* Footer */}
@@ -122,11 +86,7 @@ export function RunSettingsSheet({ rows, overrides, ecosystem, onClose, onApply 
             )}
           </div>
           <div className="rsf-actions">
-            <Button
-              variant="ghost"
-              onClick={() => setDraft({})}
-              disabled={Object.keys(draft).length === 0}
-            >
+            <Button variant="ghost" onClick={reset} disabled={Object.keys(draft).length === 0}>
               Reset all
             </Button>
 
@@ -138,86 +98,5 @@ export function RunSettingsSheet({ rows, overrides, ecosystem, onClose, onApply 
         </div>
       </div>
     </>
-  );
-}
-
-// ── Config row ───────────────────────────────────────────────────────────────
-
-interface ConfigRowProps {
-  row: SetupRow;
-  override: string | undefined;
-  onChange: (v: string) => void;
-  onRevert: () => void;
-}
-
-function ConfigRow({ row, override, onChange, onRevert }: ConfigRowProps) {
-  const [editing, setEditing] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (editing) inputRef.current?.focus();
-  }, [editing]);
-
-  const hasOverride = override != null;
-  const display = hasOverride ? override : row.value;
-
-  return (
-    <div className={`rs-row flex-center${hasOverride ? " overridden" : ""}`}>
-      <div className="rs-row-l">
-        <div className="rs-label text-base">{row.key}</div>
-        <div className="rs-source iflex-center text-xs">
-          {hasOverride ? (
-            <>
-              <span className="dot" />
-              Manual override
-            </>
-          ) : (
-            <>
-              Detected · <code>{row.source}</code>
-            </>
-          )}
-        </div>
-      </div>
-      <div className="rs-row-r iflex-center">
-        {editing ? (
-          <input
-            ref={inputRef}
-            className="rs-input text-sm"
-            type="text"
-            defaultValue={display}
-            placeholder={row.value}
-            onBlur={(e) => {
-              const v = e.target.value.trim();
-              if (v === "" || v === row.value) onRevert();
-              else onChange(v);
-              setEditing(false);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") e.currentTarget.blur();
-              if (e.key === "Escape") {
-                e.currentTarget.value = display;
-                e.currentTarget.blur();
-              }
-            }}
-          />
-        ) : (
-          <button className="rs-value iflex-center text-sm" onClick={() => setEditing(true)}>
-            <span className="rsv-text">{display}</span>
-            <Icon name="edit" size={10} />
-          </button>
-        )}
-        {hasOverride && !editing && (
-          <button
-            className="rs-revert iflex-center tip"
-            data-tip="Revert to detected"
-            onClick={onRevert}
-          >
-            <span className="rs-revert-ic iflex-center">
-              <Icon name="refresh" size={11} />
-            </span>
-          </button>
-        )}
-      </div>
-    </div>
   );
 }

--- a/src/components/RunConfig/ConfigRow.tsx
+++ b/src/components/RunConfig/ConfigRow.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef, useState } from "react";
+import { Icon } from "@/components/Icon";
+import type { SetupRow } from "./types";
+
+interface ConfigRowProps {
+  row: SetupRow;
+  override: string | undefined;
+  onChange: (v: string) => void;
+  onRevert: () => void;
+}
+
+/** One editable run-config row: shows the detected value as a placeholder,
+ *  click-to-edit, revert-to-detected, and an override indicator. Reused by
+ *  the Run panel sheet and the Project Settings modal. */
+export function ConfigRow({ row, override, onChange, onRevert }: ConfigRowProps) {
+  const [editing, setEditing] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing) inputRef.current?.focus();
+  }, [editing]);
+
+  const hasOverride = override != null;
+  const display = hasOverride ? override : row.value;
+
+  return (
+    <div className={`rs-row flex-center${hasOverride ? " overridden" : ""}`}>
+      <div className="rs-row-l">
+        <div className="rs-label text-base">{row.key}</div>
+        <div className="rs-source iflex-center text-xs">
+          {hasOverride ? (
+            <>
+              <span className="dot" />
+              Manual override
+            </>
+          ) : (
+            <>
+              Detected · <code>{row.source}</code>
+            </>
+          )}
+        </div>
+      </div>
+      <div className="rs-row-r iflex-center">
+        {editing ? (
+          <input
+            ref={inputRef}
+            className="rs-input text-sm"
+            type="text"
+            defaultValue={display}
+            placeholder={row.value}
+            onBlur={(e) => {
+              const v = e.target.value.trim();
+              if (v === "" || v === row.value) onRevert();
+              else onChange(v);
+              setEditing(false);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") e.currentTarget.blur();
+              if (e.key === "Escape") {
+                e.currentTarget.value = display;
+                e.currentTarget.blur();
+              }
+            }}
+          />
+        ) : (
+          <button className="rs-value iflex-center text-sm" onClick={() => setEditing(true)}>
+            <span className="rsv-text">{display}</span>
+            <Icon name="edit" size={10} />
+          </button>
+        )}
+        {hasOverride && !editing && (
+          <button
+            className="rs-revert iflex-center tip"
+            data-tip="Revert to detected"
+            onClick={onRevert}
+          >
+            <span className="rs-revert-ic iflex-center">
+              <Icon name="refresh" size={11} />
+            </span>
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/RunConfig/ConfigRow.tsx
+++ b/src/components/RunConfig/ConfigRow.tsx
@@ -57,6 +57,11 @@ export function ConfigRow({ row, override, onChange, onRevert }: ConfigRowProps)
             onKeyDown={(e) => {
               if (e.key === "Enter") e.currentTarget.blur();
               if (e.key === "Escape") {
+                // Keep Escape from bubbling to the container's document/window
+                // keydown listener (Project Settings modal, Run panel sheet),
+                // which would otherwise close the whole surface instead of just
+                // cancelling this in-progress edit.
+                e.stopPropagation();
                 e.currentTarget.value = display;
                 e.currentTarget.blur();
               }

--- a/src/components/RunConfig/RunConfigEditor.tsx
+++ b/src/components/RunConfig/RunConfigEditor.tsx
@@ -1,0 +1,40 @@
+import { ConfigRow } from "./ConfigRow";
+import type { SetupRow } from "./types";
+
+interface Props {
+  rows: SetupRow[];
+  /** Current override draft, keyed by row id. */
+  draft: Record<string, string>;
+  onChange: (id: string, value: string) => void;
+  onRevert: (id: string) => void;
+}
+
+/** Renders detected run-config rows grouped by section, each editable as an
+ *  override. Pure presentation — draft state is owned by the caller. Reused by
+ *  the Run panel sheet and Project Settings. */
+export function RunConfigEditor({ rows, draft, onChange, onRevert }: Props) {
+  const groups = Array.from(new Set(rows.map((r) => r.group)));
+
+  return (
+    <>
+      {groups.map((g) => (
+        <div key={g} className="rs-group">
+          <div className="rs-group-h text-xs">{g}</div>
+          <div className="rs-group-rows">
+            {rows
+              .filter((r) => r.group === g)
+              .map((r) => (
+                <ConfigRow
+                  key={r.id}
+                  row={r}
+                  override={draft[r.id]}
+                  onChange={(v) => onChange(r.id, v)}
+                  onRevert={() => onRevert(r.id)}
+                />
+              ))}
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}

--- a/src/components/RunConfig/index.ts
+++ b/src/components/RunConfig/index.ts
@@ -1,0 +1,4 @@
+export { RunConfigEditor } from "./RunConfigEditor";
+export { reconcileOverrides } from "./reconcileOverrides";
+export { loadRunOverrides, persistRunOverrides } from "./runSettings";
+export { ECOSYSTEM_LABEL, type SetupRow, toSetupRows } from "./types";

--- a/src/components/RunConfig/reconcileOverrides.ts
+++ b/src/components/RunConfig/reconcileOverrides.ts
@@ -1,4 +1,4 @@
-import type { SetupRow } from "./RunSettingsSheet";
+import type { SetupRow } from "./types";
 
 /** The outcome of reconciling a draft against the detected rows. */
 export interface OverrideReconciliation {

--- a/src/components/RunConfig/runSettings.ts
+++ b/src/components/RunConfig/runSettings.ts
@@ -1,0 +1,40 @@
+import {
+  deleteProjectSetting,
+  getProjectSettings,
+  setProjectSetting,
+} from "@/storage/projectSettings";
+
+// Run-config overrides live in `project_settings` under a `run.` prefix so
+// the table can hold other panels' per-project data without colliding.
+const RUN_KEY_PREFIX = "run.";
+const runKey = (id: string) => `${RUN_KEY_PREFIX}${id}`;
+
+/** Load the persisted run-config overrides for a project, stripped of the
+ *  `run.` prefix so keys match detected-row ids. */
+export async function loadRunOverrides(projectId: string): Promise<Record<string, string>> {
+  const all = await getProjectSettings(projectId);
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(all)) {
+    if (k.startsWith(RUN_KEY_PREFIX)) out[k.slice(RUN_KEY_PREFIX.length)] = v;
+  }
+  return out;
+}
+
+/** Persist reconciled run-config overrides: upsert the set, delete the rest.
+ *  Failures are logged, not thrown, so one bad key can't abort the batch. */
+export function persistRunOverrides(
+  projectId: string,
+  toSet: Array<{ id: string; value: string }>,
+  toDelete: string[],
+): void {
+  for (const { id, value } of toSet) {
+    setProjectSetting(projectId, runKey(id), value).catch((err) =>
+      console.error("setProjectSetting failed", err),
+    );
+  }
+  for (const id of toDelete) {
+    deleteProjectSetting(projectId, runKey(id)).catch((err) =>
+      console.error("deleteProjectSetting failed", err),
+    );
+  }
+}

--- a/src/components/RunConfig/types.ts
+++ b/src/components/RunConfig/types.ts
@@ -1,0 +1,40 @@
+import type { DetectedRow } from "@/api";
+
+/** A single run-config row as rendered by the editor: the detected value
+ *  (`value`) is the default/placeholder; a persisted override layers on top.
+ *  `group` holds the display label (already mapped from the backend key). */
+export interface SetupRow {
+  id: string;
+  group: string;
+  key: string;
+  value: string; // inferred / default
+  source: string; // e.g. "scripts.dev", "vite.config.ts"
+}
+
+/** Backend group key → display label. Consumed only by `toSetupRows`. */
+const GROUP_LABEL: Record<string, string> = {
+  environment: "Environment",
+  scripts: "Scripts",
+  server: "Server",
+};
+
+/** Ecosystem key → display label. */
+export const ECOSYSTEM_LABEL: Record<string, string> = {
+  node: "Node",
+  python: "Python",
+  ruby: "Ruby",
+  rust: "Rust",
+  go: "Go",
+};
+
+/** Map detected rows from the backend to the display rows the editor renders,
+ *  applying the group label. Shared by every surface that shows run config. */
+export function toSetupRows(rows: DetectedRow[]): SetupRow[] {
+  return rows.map((r) => ({
+    id: r.id,
+    group: GROUP_LABEL[r.group] ?? r.group,
+    key: r.key,
+    value: r.value,
+    source: r.source,
+  }));
+}

--- a/src/components/Sidebar/ProjectGroup.tsx
+++ b/src/components/Sidebar/ProjectGroup.tsx
@@ -49,6 +49,7 @@ export function ProjectGroup({
   const selectDraft = useAppStore((s) => s.selectDraft);
   const createDraft = useAppStore((s) => s.createDraft);
   const removeWorkspaceRepo = useAppStore((s) => s.removeWorkspaceRepo);
+  const openProjectSettings = useAppStore((s) => s.openProjectSettings);
 
   const count = agents.length + drafts.length;
 
@@ -64,6 +65,11 @@ export function ProjectGroup({
   function onAddAgent(e: React.MouseEvent) {
     e.stopPropagation();
     createDraft(repoPath);
+  }
+
+  function onOpenSettings(e: React.MouseEvent) {
+    e.stopPropagation();
+    openProjectSettings(repoPath);
   }
 
   const dropClass = dropIndicator ? `drop-${dropIndicator}` : "";
@@ -98,6 +104,15 @@ export function ProjectGroup({
         <Icon name="chevR" size={10} className="chev" />
         <span className="pname">{label}</span>
         <span className="pcount">{count}</span>
+        <button
+          className="padd padd-settings tip"
+          data-tip="Project settings"
+          data-tip-down=""
+          onClick={onOpenSettings}
+          aria-label="Project settings"
+        >
+          <Icon name="settings" size={14} />
+        </button>
         <button
           className="padd tip"
           data-tip="New agent  ⌘N"

--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -103,7 +103,7 @@
   gap: 6px;
   /* name column aligned to the agents' 13px text rail; chevron lives in the
    * gutter (absolute, like .ag-rail), so the header reads as the list's label */
-  padding: 0 8px 0 13px;
+  padding: 0 4px 0 13px;
   height: 28px;
   border-radius: var(--r-sm);
   font-size: var(--fs-xs);
@@ -165,9 +165,9 @@
   content: "·";
   margin-right: 4px;
 }
-/* Ghost affordance: always visible so "add an agent" is discoverable without
- * hovering, but borderless + muted so it never competes with the label. It
- * earns the accent fill only on hover. */
+/* Always visible so "add an agent" is discoverable without hovering;
+ * borderless so it doesn't compete with the label, earning the accent fill
+ * only on hover. */
 .proj-h .padd {
   width: 22px;
   height: 22px;
@@ -175,36 +175,51 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: var(--fg-3);
+  color: var(--fg-2);
   background: transparent;
-  opacity: 0.6;
   transition: var(--transition-ui);
 }
 .proj-h .padd:hover {
   background: var(--accent-soft);
   color: var(--accent);
-  opacity: 1;
 }
-/* Remove (empty projects only) is destructive and rare — hidden until the row
- * is engaged. */
-.proj-h .padd-remove {
+/* Settings gear and Remove are revealed only when the row is engaged, so they
+ * don't compete with the label or shift the always-visible "add agent" button.
+ * They sit at the trailing edge, so revealing them adds no layout shift. */
+.proj-h .padd-remove,
+.proj-h .padd-settings {
   opacity: 0;
   pointer-events: none;
+}
+/* Gear is a normal action like "add", so it reveals at full strength to match
+ * the + button. Remove stays subdued — it's destructive and rare. */
+.proj-h:hover .padd-settings {
+  opacity: 1;
+  pointer-events: auto;
 }
 .proj-h:hover .padd-remove {
   opacity: 0.6;
   pointer-events: auto;
 }
-/* Keyboard focus reveals it too — a focused button at opacity:0 would make the
- * focus ring vanish and hide the action from keyboard users. */
+/* Keyboard focus reveals them too — a focused button at opacity:0 would make
+ * the focus ring vanish and hide the action from keyboard users. */
 .proj-h:hover .padd-remove:hover,
-.proj-h .padd-remove:focus-visible {
+.proj-h:hover .padd-settings:hover,
+.proj-h .padd-remove:focus-visible,
+.proj-h .padd-settings:focus-visible {
   opacity: 1;
   pointer-events: auto;
 }
 .proj-h .padd[aria-label="New agent"] svg {
   width: 15px;
   height: 15px;
+  flex-shrink: 0;
+}
+/* Icon size is driven by CSS here (like the + above), so it doesn't depend on
+ * the size prop. Gear reads a touch larger than the +. */
+.proj-h .padd-settings svg {
+  width: 14px;
+  height: 14px;
   flex-shrink: 0;
 }
 .proj-h .padd.tip[data-tip]:hover::after {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -295,6 +295,10 @@ export interface UiSlice {
   /** When in history mode, the archived agent whose chat preview is
    *  being shown. `null` = list view. */
   selectedHistoryAgentId: string | null;
+  /** Project Settings modal: a centered overlay (History-style) for editing
+   *  per-project defaults. Keyed by the sidebar's repo path — the modal
+   *  resolves the project_id on open. Open iff non-null. */
+  projectSettingsRepoPath: string | null;
   leftCollapsed: boolean;
   rightCollapsed: boolean;
   leftWidth: number;
@@ -319,6 +323,9 @@ export interface UiSlice {
   closeOnboarding: () => void;
   toggleHistory: (open?: boolean) => void;
   selectHistoryAgent: (id: string | null) => void;
+  /** Open the Project Settings modal for a sidebar repo group. */
+  openProjectSettings: (repoPath: string) => void;
+  closeProjectSettings: () => void;
   toggleLeft: () => void;
   toggleRight: () => void;
   /** Live (in-memory) width update during a splitter drag. */

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -17,6 +17,7 @@ export const createUiSlice: SliceCreator<UiSlice> = (set, get) => ({
   onboardingComplete: false,
   historyOpen: false,
   selectedHistoryAgentId: null,
+  projectSettingsRepoPath: null,
   leftCollapsed: false,
   rightCollapsed: false,
   leftWidth: DEFAULT_LEFT_WIDTH,
@@ -56,6 +57,8 @@ export const createUiSlice: SliceCreator<UiSlice> = (set, get) => ({
       return next ? { historyOpen: true } : { historyOpen: false, selectedHistoryAgentId: null };
     }),
   selectHistoryAgent: (id) => set({ selectedHistoryAgentId: id }),
+  openProjectSettings: (repoPath) => set({ projectSettingsRepoPath: repoPath }),
+  closeProjectSettings: () => set({ projectSettingsRepoPath: null }),
   toggleLeft: () =>
     set((s) => {
       const leftCollapsed = !s.leftCollapsed;

--- a/tests/components/RunConfig/reconcileOverrides.test.ts
+++ b/tests/components/RunConfig/reconcileOverrides.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { SetupRow } from "@/components/RightPanel/RunSettingsSheet";
-import { reconcileOverrides } from "@/components/RightPanel/reconcileOverrides";
+import { reconcileOverrides, type SetupRow } from "@/components/RunConfig";
 
 const row = (id: string, value: string): SetupRow => ({
   id,


### PR DESCRIPTION
## Summary

Adds a **Project Settings** surface for editing per-project defaults — starting with the run configuration every agent in a project inherits.

- Opened from a hover-revealed **gear** on each sidebar project header.
- Centered, full-height overlay that mirrors the History modal (Esc / click-outside to close); sections stack in one scrollable page.
- **Run & environment** section: edit the detected run config (toolchain version, install/dev/build/test, port, env file). Edits autosave as project defaults into `project_settings`.

## Architecture

- Extracts the Run panel's detected-row editor into a shared `RunConfig/` module — `RunConfigEditor`, `reconcileOverrides`, and `project_settings` persistence helpers — reused by both the Run panel sheet and the new modal. Overrides continue to layer on the same detected values, so the Run panel is behaviorally unchanged.
- New Tauri command `project_run_config(repo_path)` resolves the `project_id` and detects run config from a repo path (not an agent worktree), so the modal works even for projects with no live agent.

## Sidebar tweaks

- Gear sits before the New-agent `+`, revealed on hover (no layout shift to `+`).
- Restored the `+`/gear buttons to a flat, full-strength look (`--fg-2`, full opacity) and tightened the project row's right padding.

## Testing

- `reconcileOverrides` unit tests moved to `tests/components/RunConfig/` — 7/7 pass.
- Full frontend suite 352/352 pass; `tsc` and `biome` clean; Rust `cargo check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)