### PR TITLE
feat(project-settings): rename projects and change their location

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -165,6 +165,28 @@ pub fn remove_workspace_repo(
     supervisor.remove_workspace_repo(PathBuf::from(repo_path))
 }
 
+/// Rename a project — a custom display label independent of its folder name.
+/// The sidebar and Project Settings header show this instead of the basename.
+#[tauri::command]
+pub fn rename_project(
+    supervisor: State<'_, Arc<Supervisor>>,
+    project_id: String,
+    name: String,
+) -> Result<Workspace> {
+    supervisor.rename_project(&project_id, &name)
+}
+
+/// Repoint a pinned repo at a folder the user has moved on disk. Validates the
+/// destination is a git repo; existing agents' worktrees are not relinked.
+#[tauri::command]
+pub fn relocate_repo(
+    supervisor: State<'_, Arc<Supervisor>>,
+    old_path: String,
+    new_path: String,
+) -> Result<Workspace> {
+    supervisor.relocate_repo(PathBuf::from(old_path), PathBuf::from(new_path))
+}
+
 /// Whether the app has a working GitHub connection — drives the New Project
 /// flow's gating (clone and create both need the API).
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1004,6 +1004,8 @@ pub fn run() {
             commands::get_agent_diff_stats,
             commands::add_workspace_repo,
             commands::remove_workspace_repo,
+            commands::rename_project,
+            commands::relocate_repo,
             commands::gh_status,
             commands::gh_repo_list,
             commands::clone_repo,

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -284,6 +284,14 @@ impl Supervisor {
     pub fn remove_workspace_repo(&self, repo_path: PathBuf) -> Result<Workspace> {
         self.workspace.remove_workspace_repo(&repo_path)
     }
+
+    pub fn rename_project(&self, project_id: &str, name: &str) -> Result<Workspace> {
+        self.workspace.rename_project(project_id, name)
+    }
+
+    pub fn relocate_repo(&self, old_path: PathBuf, new_path: PathBuf) -> Result<Workspace> {
+        self.workspace.relocate_repo(&old_path, &new_path)
+    }
 }
 
 fn transition_active(sup: &Supervisor, app: &AppHandle, agent_id: &str, new: AgentStatus) {

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -1280,12 +1280,14 @@ impl WorkspaceManager {
         Ok(())
     }
 
-    /// One `ProjectRef` per pinned repo (repo path joined with its project's
-    /// name + id), ordered like `query_all_repo_paths` so the two lists align.
+    /// One `ProjectRef` per repo, keyed by path (the frontend looks these up by
+    /// path, not by index). A LEFT JOIN keeps a repo even if its project row is
+    /// somehow missing — the name then falls back to the folder basename rather
+    /// than the repo silently vanishing from the sidebar.
     fn query_project_refs(conn: &Connection) -> Vec<ProjectRef> {
         let mut stmt = match conn.prepare(
             "SELECT r.path, p.name, p.id
-             FROM repos r JOIN projects p ON p.id = r.project_id
+             FROM repos r LEFT JOIN projects p ON p.id = r.project_id
              ORDER BY r.created_at",
         ) {
             Ok(s) => s,
@@ -1293,10 +1295,19 @@ impl WorkspaceManager {
         };
         stmt.query_map([], |row| {
             let path: String = row.get(0)?;
+            let name: Option<String> = row.get(1)?;
+            let project_id: Option<String> = row.get(2)?;
+            let name = name.unwrap_or_else(|| {
+                Path::new(&path)
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or(&path)
+                    .to_string()
+            });
             Ok(ProjectRef {
                 path: PathBuf::from(path),
-                name: row.get(1)?,
-                project_id: row.get(2)?,
+                name,
+                project_id: project_id.unwrap_or_default(),
             })
         })
         .ok()

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -492,8 +492,7 @@ impl WorkspaceManager {
                 [&new_str],
                 |row| row.get::<_, i64>(0),
             )
-            .map(|c| c > 0)
-            .unwrap_or(false);
+            .map(|c| c > 0)?;
         if taken {
             return Err(Error::Other(format!(
                 "a project is already pinned at {new_str}"

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -188,8 +188,23 @@ pub struct Workspace {
     /// these; the sidebar groups agents by primary repo.
     #[serde(default)]
     pub repos: Vec<PathBuf>,
+    /// Per-repo project metadata (custom display name + project id), parallel
+    /// to `repos`. The sidebar shows `name` — a user-editable label that
+    /// defaults to the folder basename but survives renames and relocations.
+    #[serde(default)]
+    pub projects: Vec<ProjectRef>,
     #[serde(default)]
     pub agents: Vec<AgentRecord>,
+}
+
+/// A pinned repo joined with its owning project, so the frontend can show a
+/// custom name (independent of the folder basename) and address the project
+/// for rename / relocate without a second round-trip.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectRef {
+    pub path: PathBuf,
+    pub name: String,
+    pub project_id: String,
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -358,10 +373,17 @@ impl WorkspaceManager {
         // Collect all unique repo paths.
         let repos = Self::query_all_repo_paths(&conn);
 
+        // Project metadata (custom name + id) for each pinned repo.
+        let projects = Self::query_project_refs(&conn);
+
         // Collect all agents.
         let agents = Self::query_all_agents(&conn);
 
-        Some(Workspace { repos, agents })
+        Some(Workspace {
+            repos,
+            projects,
+            agents,
+        })
     }
 
     /// Append a repo to the sidebar's pinned list. Idempotent — adding
@@ -415,6 +437,76 @@ impl WorkspaceManager {
         let conn = self.db.lock();
         let path_str = repo_path.to_string_lossy().to_string();
         conn.execute("DELETE FROM repos WHERE path = ?1", [&path_str])?;
+        drop(conn);
+        Ok(self.current().expect("workspace initialized"))
+    }
+
+    /// Set a project's display name, decoupled from its folder basename. The
+    /// name is trimmed; an empty name is rejected so a project always has a
+    /// label. Does not touch the repo path or anything on disk.
+    pub fn rename_project(&self, project_id: &str, name: &str) -> Result<Workspace> {
+        let trimmed = name.trim();
+        if trimmed.is_empty() {
+            return Err(Error::Other("project name cannot be empty".into()));
+        }
+
+        let conn = self.db.lock();
+        let changed = conn.execute(
+            "UPDATE projects SET name = ?1 WHERE id = ?2",
+            rusqlite::params![trimmed, project_id],
+        )?;
+        if changed == 0 {
+            return Err(Error::Other(format!("project not found: {project_id}")));
+        }
+        drop(conn);
+        Ok(self.current().expect("workspace initialized"))
+    }
+
+    /// Repoint a pinned repo at a new location on disk. The user has already
+    /// moved the folder; this only updates the stored reference so future
+    /// agents spawn from the right place. Validates the new path is a git repo
+    /// and isn't already pinned. Existing agents' worktrees are NOT relinked —
+    /// they were forked from the old location and keep pointing there.
+    pub fn relocate_repo(&self, old_path: &Path, new_path: &Path) -> Result<Workspace> {
+        if !new_path.join(".git").exists() {
+            return Err(Error::InvalidPath(format!(
+                "not a git repository: {}",
+                new_path.display()
+            )));
+        }
+
+        let conn = self.db.lock();
+        let old_str = old_path.to_string_lossy().to_string();
+        let new_str = new_path.to_string_lossy().to_string();
+
+        if old_str == new_str {
+            drop(conn);
+            return Ok(self.current().expect("workspace initialized"));
+        }
+
+        // `repos.path` is UNIQUE — refuse to collide with a repo already pinned
+        // at the destination rather than fail with an opaque constraint error.
+        let taken: bool = conn
+            .query_row(
+                "SELECT COUNT(*) FROM repos WHERE path = ?1",
+                [&new_str],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|c| c > 0)
+            .unwrap_or(false);
+        if taken {
+            return Err(Error::Other(format!(
+                "a project is already pinned at {new_str}"
+            )));
+        }
+
+        let changed = conn.execute(
+            "UPDATE repos SET path = ?1 WHERE path = ?2",
+            rusqlite::params![new_str, old_str],
+        )?;
+        if changed == 0 {
+            return Err(Error::Other(format!("repo not found: {old_str}")));
+        }
         drop(conn);
         Ok(self.current().expect("workspace initialized"))
     }
@@ -1188,6 +1280,30 @@ impl WorkspaceManager {
         Ok(())
     }
 
+    /// One `ProjectRef` per pinned repo (repo path joined with its project's
+    /// name + id), ordered like `query_all_repo_paths` so the two lists align.
+    fn query_project_refs(conn: &Connection) -> Vec<ProjectRef> {
+        let mut stmt = match conn.prepare(
+            "SELECT r.path, p.name, p.id
+             FROM repos r JOIN projects p ON p.id = r.project_id
+             ORDER BY r.created_at",
+        ) {
+            Ok(s) => s,
+            Err(_) => return Vec::new(),
+        };
+        stmt.query_map([], |row| {
+            let path: String = row.get(0)?;
+            Ok(ProjectRef {
+                path: PathBuf::from(path),
+                name: row.get(1)?,
+                project_id: row.get(2)?,
+            })
+        })
+        .ok()
+        .map(|rows| rows.filter_map(|r| r.ok()).collect())
+        .unwrap_or_default()
+    }
+
     fn query_all_repo_paths(conn: &Connection) -> Vec<PathBuf> {
         let mut stmt = conn
             .prepare("SELECT path FROM repos ORDER BY created_at")
@@ -1842,6 +1958,84 @@ mod tests {
         wm.add_workspace_repo(repo.clone()).unwrap();
         let cur = wm.current().unwrap();
         assert_eq!(cur.repos.iter().filter(|p| **p == repo).count(), 1);
+    }
+
+    #[test]
+    fn rename_project_updates_display_name() {
+        let db = test_db();
+        let td = tempfile::tempdir().unwrap();
+        let repo = init_repo(td.path());
+        let wm = WorkspaceManager::new(db);
+        wm.add_workspace_repo(repo.clone()).unwrap();
+
+        let pid = wm.current().unwrap().projects[0].project_id.clone();
+        let ws = wm.rename_project(&pid, "  My Project  ").unwrap();
+
+        // Name is trimmed and decoupled from the folder path, which is untouched.
+        assert_eq!(ws.projects[0].name, "My Project");
+        assert_eq!(ws.projects[0].path, repo);
+        assert!(ws.repos.contains(&repo));
+    }
+
+    #[test]
+    fn rename_project_rejects_empty_name() {
+        let db = test_db();
+        let td = tempfile::tempdir().unwrap();
+        let repo = init_repo(td.path());
+        let wm = WorkspaceManager::new(db);
+        wm.add_workspace_repo(repo).unwrap();
+        let pid = wm.current().unwrap().projects[0].project_id.clone();
+
+        let err = wm.rename_project(&pid, "   ").unwrap_err();
+        assert!(err.to_string().contains("cannot be empty"));
+    }
+
+    #[test]
+    fn relocate_repo_repoints_path() {
+        let db = test_db();
+        let td = tempfile::tempdir().unwrap();
+        let old = init_repo(td.path());
+        let new = td.path().join("moved");
+        std::fs::create_dir_all(new.join(".git")).unwrap();
+
+        let wm = WorkspaceManager::new(db);
+        wm.add_workspace_repo(old.clone()).unwrap();
+        let pid = wm.current().unwrap().projects[0].project_id.clone();
+
+        let ws = wm.relocate_repo(&old, &new).unwrap();
+        assert!(ws.repos.contains(&new));
+        assert!(!ws.repos.contains(&old));
+        // Same project — relocate keeps the id (and any per-project settings).
+        assert_eq!(ws.projects[0].project_id, pid);
+    }
+
+    #[test]
+    fn relocate_repo_rejects_non_git_dest() {
+        let db = test_db();
+        let td = tempfile::tempdir().unwrap();
+        let old = init_repo(td.path());
+        let wm = WorkspaceManager::new(db);
+        wm.add_workspace_repo(old.clone()).unwrap();
+
+        let err = wm.relocate_repo(&old, &td.path().join("nope")).unwrap_err();
+        assert!(err.to_string().contains("not a git repository"));
+    }
+
+    #[test]
+    fn relocate_repo_rejects_pinned_collision() {
+        let db = test_db();
+        let td = tempfile::tempdir().unwrap();
+        let a = init_repo(td.path());
+        let b = td.path().join("b");
+        std::fs::create_dir_all(b.join(".git")).unwrap();
+
+        let wm = WorkspaceManager::new(db);
+        wm.add_workspace_repo(a.clone()).unwrap();
+        wm.add_workspace_repo(b.clone()).unwrap();
+
+        // Moving `a` onto `b`'s already-pinned path is refused, not silently merged.
+        let err = wm.relocate_repo(&a, &b).unwrap_err();
+        assert!(err.to_string().contains("already pinned"));
     }
 
     #[test]

--- a/src/api.ts
+++ b/src/api.ts
@@ -69,9 +69,20 @@ export interface AgentRecord {
   sandbox_engine?: string | null;
 }
 
+/** A pinned repo joined with its owning project. `name` is the user-editable
+ *  display label (defaults to the folder basename, survives rename/relocate);
+ *  `project_id` addresses the project for rename/relocate + per-project settings. */
+export interface ProjectRef {
+  path: string;
+  name: string;
+  project_id: string;
+}
+
 export interface Workspace {
   /** Repos pinned in the sidebar. Empty on first launch. */
   repos: string[];
+  /** Per-repo project metadata, parallel to `repos`. */
+  projects: ProjectRef[];
   agents: AgentRecord[];
 }
 
@@ -440,6 +451,13 @@ export const api = {
   addWorkspaceRepo: (repoPath: string) => invoke<Workspace>("add_workspace_repo", { repoPath }),
   removeWorkspaceRepo: (repoPath: string) =>
     invoke<Workspace>("remove_workspace_repo", { repoPath }),
+  /** Set a project's custom display name (independent of its folder). */
+  renameProject: (projectId: string, name: string) =>
+    invoke<Workspace>("rename_project", { projectId, name }),
+  /** Repoint a pinned repo at a moved folder. Rejects a non-git or
+   *  already-pinned destination. */
+  relocateRepo: (oldPath: string, newPath: string) =>
+    invoke<Workspace>("relocate_repo", { oldPath, newPath }),
   ghStatus: () => invoke<GhStatus>("gh_status"),
   ghRepoList: () => invoke<GhRepoSummary[]>("gh_repo_list"),
   cloneRepo: (spec: string, destParent: string) =>

--- a/src/components/ProjectSettings/GeneralSection.tsx
+++ b/src/components/ProjectSettings/GeneralSection.tsx
@@ -1,0 +1,128 @@
+import { open } from "@tauri-apps/plugin-dialog";
+import { useState } from "react";
+import { Icon } from "@/components/Icon";
+import { useAppStore } from "@/store";
+
+interface Props {
+  projectId: string;
+  /** Current display name (from the store), used as the edit baseline. */
+  currentName: string;
+  /** The repo's location on disk — the group's stable id. */
+  repoPath: string;
+}
+
+/** Project identity: a custom display name (independent of the folder) and the
+ *  on-disk location. Renaming only relabels the project; changing the location
+ *  repoints Fletch at a folder the user has already moved. */
+export function GeneralSection({ projectId, currentName, repoPath }: Props) {
+  const renameProject = useAppStore((s) => s.renameProject);
+  const relocateProject = useAppStore((s) => s.relocateProject);
+
+  const [name, setName] = useState(currentName);
+  const [saving, setSaving] = useState(false);
+  const [relocating, setRelocating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const trimmed = name.trim();
+  const dirty = trimmed.length > 0 && trimmed !== currentName;
+
+  async function saveName() {
+    if (!dirty || saving) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await renameProject(projectId, trimmed);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function changeLocation() {
+    if (relocating) return;
+    const picked = await open({
+      directory: true,
+      multiple: false,
+      title: "Select the project's new location",
+    });
+    if (typeof picked !== "string" || picked === repoPath) return;
+    setRelocating(true);
+    setError(null);
+    try {
+      await relocateProject(repoPath, picked);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setRelocating(false);
+    }
+  }
+
+  return (
+    <section className="ps-section">
+      <header className="ps-section-h">
+        <h2 className="ps-section-t text-lg">General</h2>
+        <p className="ps-section-lead text-sm">
+          The project&rsquo;s display name and where Fletch looks for it on disk.
+        </p>
+      </header>
+
+      <div className="ps-field">
+        <label className="ps-label text-sm" htmlFor="ps-name">
+          Name
+        </label>
+        <div className="ps-name-row">
+          <input
+            id="ps-name"
+            className="ps-input text-base"
+            value={name}
+            spellCheck={false}
+            autoComplete="off"
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                void saveName();
+              } else if (e.key === "Escape") {
+                // Cancel the edit; don't let it bubble up and close the modal.
+                e.stopPropagation();
+                setName(currentName);
+                (e.target as HTMLInputElement).blur();
+              }
+            }}
+            onBlur={() => void saveName()}
+          />
+          <button
+            type="button"
+            className="ps-btn"
+            disabled={!dirty || saving}
+            onClick={() => void saveName()}
+          >
+            {saving ? "Saving…" : "Save"}
+          </button>
+        </div>
+        <p className="ps-hint text-xs">Shown in the sidebar. Independent of the folder name.</p>
+      </div>
+
+      <div className="ps-field">
+        <label className="ps-label text-sm">Location</label>
+        <button
+          type="button"
+          className="ps-path-row flex-center"
+          disabled={relocating}
+          onClick={() => void changeLocation()}
+        >
+          <Icon name="folder" size={14} />
+          <span className="ps-path-val mono text-base truncate">{repoPath}</span>
+          <span className="ps-path-change text-sm">{relocating ? "Moving…" : "Change…"}</span>
+        </button>
+        <p className="ps-hint text-xs">
+          Moved the folder? Point Fletch at its new location. Running agents keep their existing
+          worktrees — only new agents use the new path.
+        </p>
+      </div>
+
+      {error && <div className="ps-error text-sm">{error}</div>}
+    </section>
+  );
+}

--- a/src/components/ProjectSettings/GeneralSection.tsx
+++ b/src/components/ProjectSettings/GeneralSection.tsx
@@ -32,6 +32,9 @@ export function GeneralSection({ projectId, currentName, repoPath }: Props) {
     setError(null);
     try {
       await renameProject(projectId, trimmed);
+      // Reflect what was actually persisted (trimmed), so the field matches the
+      // sidebar instead of keeping the user's raw input with surrounding space.
+      setName(trimmed);
     } catch (e) {
       setError(String(e));
     } finally {

--- a/src/components/ProjectSettings/ProjectSettings.css
+++ b/src/components/ProjectSettings/ProjectSettings.css
@@ -145,3 +145,106 @@
 .ps-eco-count b {
   color: var(--fg-0);
 }
+
+/* general section — name + location */
+.ps-field {
+  margin-top: 18px;
+}
+.ps-field:first-of-type {
+  margin-top: 0;
+}
+.ps-label {
+  display: block;
+  margin-bottom: 7px;
+  color: var(--fg-1);
+  font-weight: 500;
+}
+.ps-name-row {
+  display: flex;
+  gap: 8px;
+}
+.ps-input {
+  flex: 1;
+  min-width: 0;
+  height: 34px;
+  padding: 0 11px;
+  color: var(--fg-0);
+  background: var(--bg-2);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-sm);
+  transition:
+    border-color 0.1s,
+    background 0.1s;
+}
+.ps-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  background: var(--bg-1);
+}
+.ps-btn {
+  flex-shrink: 0;
+  height: 34px;
+  padding: 0 16px;
+  color: var(--fg-0);
+  background: var(--bg-2);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-sm);
+  font-weight: 500;
+  transition:
+    background 0.1s,
+    border-color 0.1s,
+    opacity 0.1s;
+}
+.ps-btn:hover:not(:disabled) {
+  background: var(--hover);
+  border-color: var(--bd-strong);
+}
+.ps-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+.ps-path-row {
+  width: 100%;
+  gap: 9px;
+  height: 34px;
+  padding: 0 11px;
+  text-align: left;
+  color: var(--fg-1);
+  background: var(--bg-2);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-sm);
+  transition:
+    background 0.1s,
+    border-color 0.1s;
+}
+.ps-path-row:hover:not(:disabled) {
+  background: var(--hover);
+  border-color: var(--bd-strong);
+}
+.ps-path-row:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+.ps-path-val {
+  flex: 1;
+  min-width: 0;
+  color: var(--fg-2);
+}
+.ps-path-change {
+  flex-shrink: 0;
+  color: var(--accent);
+  font-weight: 500;
+}
+.ps-hint {
+  margin-top: 7px;
+  color: var(--fg-3);
+  line-height: 1.45;
+}
+.ps-error {
+  margin-top: 16px;
+  padding: 9px 12px;
+  color: var(--danger);
+  background: color-mix(in srgb, var(--danger), var(--bg-0) 86%);
+  border: 1px solid color-mix(in srgb, var(--danger), var(--bg-0) 70%);
+  border-radius: var(--r-sm);
+}

--- a/src/components/ProjectSettings/index.tsx
+++ b/src/components/ProjectSettings/index.tsx
@@ -5,6 +5,7 @@ import { loadRunOverrides, type SetupRow, toSetupRows } from "@/components/RunCo
 import { Loader } from "@/components/ui/Loader";
 import { useAppStore } from "@/store";
 import { basename } from "@/util/format";
+import { GeneralSection } from "./GeneralSection";
 import { RunEnvSection } from "./RunEnvSection";
 
 interface Loaded {
@@ -20,10 +21,12 @@ interface Loaded {
  *  sidebar's repo path; resolves the project_id and detected run config on open. */
 export function ProjectSettings({ repoPath }: { repoPath: string }) {
   const close = useAppStore((s) => s.closeProjectSettings);
+  const projects = useAppStore((s) => s.workspace?.projects);
   const [loaded, setLoaded] = useState<Loaded | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const name = basename(repoPath);
+  // Custom display name for this repo, falling back to the folder basename.
+  const name = projects?.find((p) => p.path === repoPath)?.name ?? basename(repoPath);
 
   // Resolve project_id + detected run config for the repo, then load the
   // persisted overrides. Both must be ready before the editor mounts so the
@@ -92,6 +95,7 @@ export function ProjectSettings({ repoPath }: { repoPath: string }) {
             </div>
           ) : (
             <div className="ps-sections">
+              <GeneralSection projectId={loaded.projectId} currentName={name} repoPath={repoPath} />
               <RunEnvSection
                 projectId={loaded.projectId}
                 rows={loaded.rows}

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -44,7 +44,11 @@ function groupByRepo(
   return Array.from(map.values());
 }
 
-function applySearch(groups: RepoGroup[], q: string): RepoGroup[] {
+function applySearch(
+  groups: RepoGroup[],
+  q: string,
+  labelOf: (path: string) => string,
+): RepoGroup[] {
   if (!q.trim()) return groups;
   const needle = q.toLowerCase();
   return groups
@@ -62,7 +66,7 @@ function applySearch(groups: RepoGroup[], q: string): RepoGroup[] {
       (g) =>
         g.agents.length > 0 ||
         g.drafts.length > 0 ||
-        basename(g.repoPath).toLowerCase().includes(needle),
+        labelOf(g.repoPath).toLowerCase().includes(needle),
     );
 }
 
@@ -110,7 +114,13 @@ export function Sidebar() {
     const byPath = new Map(built.map((g) => [g.repoPath, g]));
     return order.map((p) => byPath.get(p)).filter((g): g is RepoGroup => g !== undefined);
   }, [workspace?.repos, liveAgents, drafts, sortPaths]);
-  const filtered = useMemo(() => applySearch(groups, query), [groups, query]);
+  // Custom display name per pinned repo. Groups derived only from an agent's
+  // repo (never pinned) have no entry and fall back to the folder basename.
+  const labelOf = useMemo(() => {
+    const byPath = new Map((workspace?.projects ?? []).map((p) => [p.path, p.name]));
+    return (path: string) => byPath.get(path) ?? basename(path);
+  }, [workspace?.projects]);
+  const filtered = useMemo(() => applySearch(groups, query, labelOf), [groups, query, labelOf]);
 
   // Reordering is only meaningful over the full, unfiltered list.
   const reorderable = !query.trim();
@@ -219,7 +229,7 @@ export function Sidebar() {
               return (
                 <ProjectGroup
                   key={g.repoPath}
-                  label={basename(g.repoPath)}
+                  label={labelOf(g.repoPath)}
                   repoPath={g.repoPath}
                   agents={g.agents}
                   drafts={g.drafts}

--- a/src/storage/projectOrder.ts
+++ b/src/storage/projectOrder.ts
@@ -26,6 +26,15 @@ export function saveProjectOrder(order: string[]): void {
   }
 }
 
+/** Rewrite a path in the saved order after a relocate, so the project keeps its
+ *  manual position instead of dropping to the bottom under its new path. No-op
+ *  when the old path isn't in the saved order. */
+export function remapProjectOrder(oldPath: string, newPath: string): void {
+  const order = loadProjectOrder();
+  if (!order.includes(oldPath)) return;
+  saveProjectOrder(order.map((p) => (p === oldPath ? newPath : p)));
+}
+
 /** Order `paths` by their index in the saved `order`. Paths absent from `order`
  *  keep their incoming relative order and sort after all known paths, so a
  *  newly-added project appears at the bottom rather than jumping to the top. */

--- a/src/store/repos.ts
+++ b/src/store/repos.ts
@@ -1,7 +1,8 @@
 import { api } from "@/api";
+import { remapProjectOrder } from "@/storage/projectOrder";
 import type { ReposSlice, SliceCreator } from "./types";
 
-export const createReposSlice: SliceCreator<ReposSlice> = (set) => ({
+export const createReposSlice: SliceCreator<ReposSlice> = (set, get) => ({
   addWorkspaceRepo: async (path) => {
     set({ busy: true, lastError: null });
     try {
@@ -21,6 +22,21 @@ export const createReposSlice: SliceCreator<ReposSlice> = (set) => ({
     } catch (e) {
       set({ lastError: String(e) });
     }
+  },
+
+  renameProject: async (projectId, name) => {
+    // Errors propagate to the modal for inline display.
+    const ws = await api.renameProject(projectId, name);
+    set({ workspace: ws });
+  },
+
+  relocateProject: async (oldPath, newPath) => {
+    const ws = await api.relocateRepo(oldPath, newPath);
+    // Keep the project's manual sidebar position, and repoint the open settings
+    // modal (keyed by repo path) at the new location so it doesn't go stale.
+    remapProjectOrder(oldPath, newPath);
+    set({ workspace: ws });
+    if (get().projectSettingsRepoPath === oldPath) get().openProjectSettings(newPath);
   },
 
   revealLogs: async () => {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -154,6 +154,13 @@ export interface WorkspaceSlice {
 export interface ReposSlice {
   addWorkspaceRepo: (path: string) => Promise<void>;
   removeWorkspaceRepo: (path: string) => Promise<void>;
+  // Rename/relocate resolve on success and throw on failure, so the Project
+  // Settings modal can show the error inline rather than in the global banner.
+  /** Set a project's custom display name (independent of its folder). */
+  renameProject: (projectId: string, name: string) => Promise<void>;
+  /** Repoint a pinned repo at a moved folder, migrating its sidebar order and
+   *  the open settings modal to the new path. */
+  relocateProject: (oldPath: string, newPath: string) => Promise<void>;
   /** Open the log folder in the OS file manager; surfaces failures via
    *  `lastError` rather than swallowing them. */
   revealLogs: () => Promise<void>;


### PR DESCRIPTION
## What

Extends the existing Project Settings modal so a project's **name** and **path** are editable. Previously both were read-only.

### Rename
A custom display label, decoupled from the folder name. Stored in `projects.name`, surfaced to the sidebar (falls back to the folder basename when unset). Saves on Enter/blur.

### Change location
A "Change…" directory picker repoints a pinned repo at a folder the user has already moved on disk, so Fletch stops referencing the stale path. Validation:
- destination must be a git repo,
- destination must not already be pinned.

On relocate it also migrates the project's manual sidebar order and keeps the open settings modal pointed at the new path.

## How

**Backend (`src-tauri`)**
- `ProjectRef { path, name, project_id }` + `Workspace.projects`, populated in `current()` via a repos⋈projects join.
- `rename_project` / `relocate_repo` methods (with validation) + supervisor wrappers + Tauri commands + registration.
- 5 new unit tests (rename trims/rejects-empty; relocate repoints / rejects non-git / rejects pinned collision).

**Frontend**
- `api.ts`: `ProjectRef` type, `Workspace.projects`, `renameProject` / `relocateRepo`.
- `store/repos.ts` + `types.ts`: `renameProject` / `relocateProject` actions.
- `storage/projectOrder.ts`: `remapProjectOrder` helper.
- `Sidebar/index.tsx`: sidebar label resolves from the custom name.
- New `ProjectSettings/GeneralSection.tsx` (sibling to `RunEnvSection`) + modal wiring + CSS.

## Notes / scope
- **Existing agents' worktrees are not relinked** on relocate — they were forked from the old location and keep pointing there; only new agents use the new path. Surfaced as a hint in the UI.
- Kept minimal blast radius by *adding* `projects` alongside `repos` rather than reworking `repos: string[]` and its consumers.
- Pre-existing edge case left alone: two folders with the same basename share one project row, so renaming one would relabel both. Rare; noted for a follow-up.

## Verification
`cargo check`, `cargo test` (40 pass, incl. 5 new), `tsc`, `biome` (touched files clean), `vite build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)