### PR TITLE
fix(git): seed initial commit so commit-less repos are forkable

### DIFF
--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -771,6 +771,39 @@ mod tests {
         assert_eq!(first, rev_parse(repo, "HEAD").await.unwrap());
     }
 
+    /// Overlapping spawns against the same commit-less repo must seed exactly one
+    /// commit and none may fail. Without the internal lock the check-then-act
+    /// race lets multiple callers each commit (a stray empty "Initial commit") or
+    /// fail one on `.git/index.lock` contention.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn ensure_head_commit_concurrent_seeds_exactly_one_commit() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path().to_path_buf();
+        init_repo(&repo).await.unwrap();
+        config(&repo, "user.email", "t@example.com").await;
+        config(&repo, "user.name", "Tester").await;
+        assert!(rev_parse(&repo, "HEAD").await.is_err());
+
+        // Fire many concurrent calls at the unborn-HEAD repo at once.
+        let mut set = tokio::task::JoinSet::new();
+        for _ in 0..8 {
+            let r = repo.clone();
+            set.spawn(async move { ensure_head_commit(&r).await });
+        }
+        while let Some(joined) = set.join_next().await {
+            // No task panicked, and no call returned Err (no lock-contention
+            // failure surfaced to a spawn).
+            joined.unwrap().unwrap();
+        }
+
+        // Exactly one commit — no duplicate from a lost race.
+        let out = run_git(&repo, &["rev-list", "--count", "HEAD"], "rev-list")
+            .await
+            .unwrap();
+        let count = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        assert_eq!(count, "1", "expected exactly one commit, got {count}");
+    }
+
     #[tokio::test]
     async fn fetch_fork_point_without_remote_is_none() {
         // No `origin` configured → best-effort fetch fails and we fall back to
@@ -1124,13 +1157,34 @@ pub async fn commit_initial(repo: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Process-wide lock serializing the unborn-HEAD seed in `ensure_head_commit`.
+/// Contended only when a repo has no commits yet and two spawns race to seed it;
+/// the common HEAD-already-exists path never acquires it (see the double-check).
+static HEAD_SEED_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 /// Guarantee `repo` has a resolvable `HEAD` so a workspace can fork from it.
 /// A repo that's been `git init`'d but never committed has an unborn HEAD, and
 /// neither `git clone --shared` (the default workspace mode) nor `worktree add`
 /// can fork a repo without one — the fork fails and the agent never launches.
 /// Seed the repo's first commit in that case; no-op when HEAD already resolves.
 /// Idempotent, so it's safe to call on every provisioning.
+///
+/// Concurrency: the check (`rev_parse`) and the act (`commit_initial`) are
+/// guarded by a process-wide lock, with a double-check inside it. Without the
+/// lock two overlapping spawns against the same commit-less repo could both pass
+/// the check and each seed — leaving a stray empty "Initial commit", or failing
+/// one spawn on `.git/index.lock` contention. The lock is taken only once HEAD
+/// is confirmed unborn, so the common case stays lock-free. This serializes
+/// within one Fletch process; two separate processes seeding the same brand-new
+/// repo at the same instant still fall back to git's own index locking — a
+/// vanishingly small, self-limiting window that closes the moment a commit lands.
 pub async fn ensure_head_commit(repo: &Path) -> Result<()> {
+    if rev_parse(repo, "HEAD").await.is_ok() {
+        return Ok(());
+    }
+    // Unborn HEAD — serialize the seed so racing spawns don't double-commit.
+    let _guard = HEAD_SEED_LOCK.lock().await;
+    // A racer may have seeded HEAD while we waited for the lock; re-check.
     if rev_parse(repo, "HEAD").await.is_ok() {
         return Ok(());
     }

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -753,6 +753,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ensure_head_commit_seeds_unborn_head_and_is_idempotent() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path();
+        init_repo(repo).await.unwrap();
+        config(repo, "user.email", "t@example.com").await;
+        config(repo, "user.name", "Tester").await;
+
+        // Unborn HEAD: no commit yet.
+        assert!(rev_parse(repo, "HEAD").await.is_err());
+
+        ensure_head_commit(repo).await.unwrap();
+        let first = rev_parse(repo, "HEAD").await.unwrap();
+
+        // No-op on a repo that already has a HEAD — same commit, no error.
+        ensure_head_commit(repo).await.unwrap();
+        assert_eq!(first, rev_parse(repo, "HEAD").await.unwrap());
+    }
+
+    #[tokio::test]
     async fn fetch_fork_point_without_remote_is_none() {
         // No `origin` configured → best-effort fetch fails and we fall back to
         // local HEAD (None), never an error.
@@ -1103,6 +1122,19 @@ pub async fn commit_initial(repo: &Path) -> Result<()> {
         )));
     }
     Ok(())
+}
+
+/// Guarantee `repo` has a resolvable `HEAD` so a workspace can fork from it.
+/// A repo that's been `git init`'d but never committed has an unborn HEAD, and
+/// neither `git clone --shared` (the default workspace mode) nor `worktree add`
+/// can fork a repo without one — the fork fails and the agent never launches.
+/// Seed the repo's first commit in that case; no-op when HEAD already resolves.
+/// Idempotent, so it's safe to call on every provisioning.
+pub async fn ensure_head_commit(repo: &Path) -> Result<()> {
+    if rev_parse(repo, "HEAD").await.is_ok() {
+        return Ok(());
+    }
+    commit_initial(repo).await
 }
 
 /// Add a remote. Used when publishing a fresh local repo to GitHub.

--- a/src-tauri/src/new_project.rs
+++ b/src-tauri/src/new_project.rs
@@ -98,12 +98,16 @@ pub async fn clone(spec: &str, dest_parent: &Path) -> Result<PathBuf> {
 /// Ensure the folder at `path` is a git repository so agents can operate in
 /// worktrees, commit, and track history — the progressive-disclosure ramp for
 /// users who've never heard of git. A plain folder is initialized with an
-/// initial commit (worktrees can't fork a repo with no HEAD); a folder nested
-/// inside an existing repository is rejected with a pointer to the actual
+/// initial commit (a fork needs a HEAD); a repo that's already initialized but
+/// has no commits yet is given its first commit for the same reason; a folder
+/// nested inside an existing repository is rejected with a pointer to the actual
 /// root, since silently initializing a nested repo would split its history.
 pub async fn ensure_git_repo(path: &Path) -> Result<()> {
     if path.join(".git").exists() {
-        return Ok(());
+        // Already a repo — but forking a workspace needs a resolvable HEAD, and
+        // a folder that was `git init`'d but never committed has an unborn one.
+        // Seed the first commit so agents can fork it (no-op when HEAD exists).
+        return git::ensure_head_commit(path).await;
     }
     if let Some(root) = git_toplevel(path).await {
         return Err(Error::InvalidPath(format!(
@@ -246,6 +250,41 @@ mod tests {
         );
 
         ensure_git_repo(&dir).await.unwrap();
+    }
+
+    /// A folder that's already a git repo but has no commits yet (unborn HEAD)
+    /// must be given a first commit — otherwise the workspace clone/worktree
+    /// can't fork it and the agent fails to spawn. Early-returning on the mere
+    /// presence of `.git` (the original bug) leaves HEAD unborn.
+    #[tokio::test]
+    async fn ensure_git_repo_seeds_commit_for_initialized_but_empty_repo() {
+        let td = tempfile::tempdir().unwrap();
+        let dir = td.path().join("empty-repo");
+        std::fs::create_dir(&dir).unwrap();
+        assert!(std::process::Command::new("git")
+            .current_dir(&dir)
+            .args(["init", "-q"])
+            .status()
+            .unwrap()
+            .success());
+        // Precondition: initialized, but HEAD is unborn.
+        assert!(dir.join(".git").exists());
+        assert!(!head_resolves(&dir), "test setup: repo should have no commits");
+
+        ensure_git_repo(&dir).await.unwrap();
+
+        assert!(head_resolves(&dir), "adopted empty repo must gain a HEAD commit");
+        // Idempotent: a second adoption doesn't add another commit or error.
+        ensure_git_repo(&dir).await.unwrap();
+    }
+
+    fn head_resolves(dir: &Path) -> bool {
+        std::process::Command::new("git")
+            .current_dir(dir)
+            .args(["rev-parse", "--verify", "HEAD"])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
     }
 
     /// A folder nested inside an existing repository must be rejected with a

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -193,6 +193,12 @@ impl Supervisor {
                 repo_path.display()
             )));
         }
+        // Provisioning forks a workspace (a `--shared` clone by default) from
+        // this repo, which needs a resolvable HEAD. Adopting a folder normally
+        // seeds one, but a repo added while it had no commits — or before that
+        // guarantee existed — still has an unborn HEAD; seed it here so the fork
+        // can't fail with a missing working directory downstream.
+        git::ensure_head_commit(&repo_path).await?;
 
         // The engine this agent will be stamped with, resolved once so the
         // provider gate, the stamp, and the provisioning mode below all agree.
@@ -358,6 +364,9 @@ impl Supervisor {
                 repo_path.display()
             )));
         }
+        // Same forkability guarantee as the primary repo: a commit-less repo has
+        // an unborn HEAD that the workspace clone/worktree can't fork.
+        git::ensure_head_commit(&repo_path).await?;
         let record = self.workspace.agent(agent_id)?;
         if record.repos.iter().any(|r| r.repo_path == repo_path) {
             return Err(Error::Other(


### PR DESCRIPTION
## Problem

Creating an agent against a repo that had been `git init`'d but never committed failed with:

> `managed spawn: working directory does not exist: …`
> `Agent stopped unexpectedly — Spawn timed out after 15s — process did not become ready.`

Provisioning forks an agent workspace (a `git clone --shared` by default, a linked worktree under the `workspace_mode=worktree` dev flag) from the source repo, and both need a **resolvable HEAD**. A repo with no commits has an unborn HEAD, so the fork produced no working directory; the launch then hit the missing-cwd guard and the 15s readiness watchdog reported the agent as stopped.

The "just works under the hood" bootstrap already seeds a first commit when adopting a plain folder, but `ensure_git_repo` early-returned whenever `.git` existed — leaving an initialized-but-empty repo unforkable. It also only ran at add-project time, so repos added before the guarantee existed were never healed.

## Fix

Make "forkable" an idempotent invariant enforced at the point of use:

- **`git::ensure_head_commit`** (new): no-op when `HEAD` resolves, otherwise seed the first commit (reusing `commit_initial`'s `--allow-empty`).
- **`ensure_git_repo`**: calls it on the `.git`-exists branch, closing the "initialized but no commits" hole.
- **Both provisioning sites** (primary spawn + `add_repo_to_agent`): call it before forking the workspace, so a repo added while commit-less is healed at spawn — not just at add time.

Mode-agnostic: clone and worktree both require a HEAD.

## Tests

- `new_project`: new `.git`-exists-but-no-commits case (previously uncovered).
- `git`: `ensure_head_commit` seeds an unborn HEAD and is idempotent.

All `new_project`, `git`, `provision`, and `supervisor` lib tests pass.