### PR TITLE
feat(run-config): agent-scoped run overrides and cleaner settings framing

### DIFF
--- a/src-tauri/migrations/0014_pr_times_and_usage_daily.sql
+++ b/src-tauri/migrations/0014_pr_times_and_usage_daily.sql
@@ -1,0 +1,31 @@
+-- PR lifecycle timestamps + daily token-usage snapshots, both feeding the
+-- Project Pulse stats block (and any future per-project analytics).
+--
+-- pr_opened_at / pr_merged_at are ms-epoch values taken from GitHub's own
+-- createdAt/mergedAt on the PR, stamped whenever a PR-state fetch sees them
+-- (see `record_pr_times`). GitHub is the source of truth, so a PR that merged
+-- while the app was closed still gets its real merge time on the next fetch.
+-- NULL = not yet observed.
+ALTER TABLE worktrees ADD COLUMN pr_opened_at INTEGER;
+ALTER TABLE worktrees ADD COLUMN pr_merged_at INTEGER;
+
+-- One row per (workspace, local day): a snapshot of the session's CUMULATIVE
+-- token totals as of the last fold that day (see `recordUsageSnapshot` in the
+-- frontend, which upserts whenever usage is re-folded from session_records).
+-- Cumulative snapshots — not per-day deltas — because some providers (codex)
+-- only report running totals; a day's spend is the difference between
+-- consecutive snapshots. `project_id` is denormalized for cheap per-project
+-- range queries.
+CREATE TABLE usage_daily (
+    workspace_id       TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    project_id         TEXT NOT NULL,
+    day                TEXT NOT NULL,             -- local date, YYYY-MM-DD
+    input_tokens       INTEGER NOT NULL DEFAULT 0,
+    output_tokens      INTEGER NOT NULL DEFAULT 0,
+    cache_read_tokens  INTEGER NOT NULL DEFAULT 0,
+    cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+    cost_usd           REAL NOT NULL DEFAULT 0,   -- 0 when the provider reports no cost
+    updated_at         INTEGER NOT NULL,
+    PRIMARY KEY (workspace_id, day)
+);
+CREATE INDEX idx_usage_daily_project ON usage_daily(project_id, day);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -625,7 +625,14 @@ pub async fn get_pr_state(
     if repo.branch.is_none() {
         return Ok(None);
     }
-    gh::pr_view(&checkout).await
+    let state = gh::pr_view(&checkout).await?;
+    // Accrue PR history: stamp GitHub's open/merge times when reported.
+    if let Some(pr) = &state {
+        let _ = supervisor
+            .workspace
+            .set_repo_pr_times(&agent_id, &repo.subdir, pr.opened_at, pr.merged_at);
+    }
+    Ok(state)
 }
 
 /// List the open PRs for the agent's repo, for the composer's "#" mention
@@ -864,16 +871,23 @@ pub async fn refresh_all_pr_states(
         let Some(number) = repo.pr_number else { continue };
         let Ok(checkout) = repo_checkout_path(&agent.id, &repo.subdir) else { continue };
         let agent_id = agent.id.clone();
+        let subdir = repo.subdir.clone();
         set.spawn(async move {
             let state = gh::pr_view_number(&checkout, number as u32)
                 .await
                 .unwrap_or(None);
-            (agent_id, state)
+            (agent_id, subdir, state)
         });
     }
     let mut out = std::collections::HashMap::new();
     while let Some(res) = set.join_next().await {
-        if let Ok((id, state)) = res {
+        if let Ok((id, subdir, state)) = res {
+            // Accrue PR history: stamp GitHub's open/merge times when reported.
+            if let Some(pr) = &state {
+                let _ = supervisor
+                    .workspace
+                    .set_repo_pr_times(&id, &subdir, pr.opened_at, pr.merged_at);
+            }
             out.insert(id, state);
         }
     }

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -9,7 +9,7 @@ use crate::error::{Error, Result};
 
 const ALLOWED_TABLES: &[&str] = &[
     "accounts", "custom_agents", "project_settings", "projects", "repos",
-    "sessions", "settings", "workspaces", "worktrees",
+    "sessions", "settings", "usage_daily", "workspaces", "worktrees",
 ];
 
 /// Base name of the on-disk SQLite database within the app data dir. Neutral
@@ -123,6 +123,7 @@ const MIGRATIONS: &[&str] = &[
     include_str!("../migrations/0011_custom_agents.sql"),
     include_str!("../migrations/0012_user_turn_timing.sql"),
     include_str!("../migrations/0013_workspace_sandbox_engine.sql"),
+    include_str!("../migrations/0014_pr_times_and_usage_daily.sql"),
 ];
 
 fn get_migrations() -> Migrations<'static> {

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -43,6 +43,13 @@ pub struct PrState {
     pub state: PrStatus,
     pub title: String,
     pub mergeable: bool,
+    /// GitHub's createdAt / mergedAt as ms-epoch, when reported. Stamped onto
+    /// `worktrees.pr_opened_at/pr_merged_at` by every PR-state fetch path so
+    /// per-day PR history accrues locally (see `record_pr_times`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub opened_at: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merged_at: Option<i64>,
 }
 
 /// Lightweight PR summary for the composer's "#" mention autocomplete —
@@ -247,7 +254,15 @@ fn branch_pr_nodes(data: &Value) -> Vec<Value> {
 // PR state
 // ---------------------------------------------------------------------------
 
-const PR_STATE_FIELDS: &str = "number url title mergeable";
+const PR_STATE_FIELDS: &str = "number url title mergeable createdAt mergedAt";
+
+/// GitHub ISO-8601 timestamp → ms epoch. None for absent/null/unparseable.
+fn gh_time_ms(node: &Value, field: &str) -> Option<i64> {
+    let iso = node[field].as_str()?;
+    chrono::DateTime::parse_from_rfc3339(iso)
+        .ok()
+        .map(|t| t.timestamp_millis())
+}
 
 fn parse_pr_state(node: &Value) -> PrState {
     PrState {
@@ -261,6 +276,8 @@ fn parse_pr_state(node: &Value) -> PrState {
         title: node["title"].as_str().unwrap_or_default().to_string(),
         mergeable: node["state"].as_str() == Some("OPEN")
             && node["mergeable"].as_str() == Some("MERGEABLE"),
+        opened_at: gh_time_ms(node, "createdAt"),
+        merged_at: gh_time_ms(node, "mergedAt"),
     }
 }
 

--- a/src-tauri/src/supervisor/run.rs
+++ b/src-tauri/src/supervisor/run.rs
@@ -32,7 +32,7 @@ impl Supervisor {
             .ok_or_else(|| Error::Other("agent has no repos".into()))?;
         let cwd = repo_checkout_path(agent_id, &primary.subdir)?;
 
-        let (setup_cmd, run_cmd) = self.read_run_commands(&record.project_id, &cwd);
+        let (setup_cmd, run_cmd) = self.read_run_commands(agent_id, &record.project_id, &cwd);
         let setup_done = self.workspace.is_setup_completed(agent_id)?;
 
         let session = {
@@ -113,11 +113,17 @@ impl Supervisor {
     }
 
     /// Read the setup + run commands for an agent. The detector provides
-    /// the baseline (same values the panel shows), and any persisted
-    /// `run.install` / `run.dev` overrides in project_settings take
-    /// precedence. One detector feeds both the panel and the runner, so
-    /// there is no hardcoded default to keep in sync.
-    fn read_run_commands(&self, project_id: &str, checkout: &Path) -> (String, String) {
+    /// the baseline (same values the panel shows); the project's `run.*`
+    /// settings layer on top, and the agent's `run.agent.<id>.*` overrides
+    /// (edited in the Run panel sheet) take final precedence. One detector
+    /// feeds both the panel and the runner, so there is no hardcoded
+    /// default to keep in sync.
+    fn read_run_commands(
+        &self,
+        agent_id: &str,
+        project_id: &str,
+        checkout: &Path,
+    ) -> (String, String) {
         let configs = crate::run_detect::detect_all(checkout);
         let detected = |id: &str| -> String {
             configs
@@ -131,13 +137,18 @@ impl Supervisor {
         if project_id.is_empty() {
             return (install_default, dev_default);
         }
+        let resolve = |key: &str, default: String| -> String {
+            self.workspace
+                .project_setting(project_id, &format!("run.agent.{agent_id}.{key}"))
+                .or_else(|| {
+                    self.workspace
+                        .project_setting(project_id, &format!("run.{key}"))
+                })
+                .unwrap_or(default)
+        };
         (
-            self.workspace
-                .project_setting(project_id, "run.install")
-                .unwrap_or(install_default),
-            self.workspace
-                .project_setting(project_id, "run.dev")
-                .unwrap_or(dev_default),
+            resolve("install", install_default),
+            resolve("dev", dev_default),
         )
     }
 

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -115,6 +115,15 @@ impl Supervisor {
                     _ => None,
                 }
             };
+            // Accrue PR history: stamp GitHub's own open/merge times whenever
+            // a fetch reports them (feeds per-day PR stats).
+            if let Some(pr) = &state {
+                if let Err(e) =
+                    workspace.set_repo_pr_times(&agent_id, &subdir, pr.opened_at, pr.merged_at)
+                {
+                    tracing::warn!(error = %e, agent_id, "failed to stamp PR times");
+                }
+            }
             emit_pr_state(&app, &agent_id, state);
         });
     }

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -689,6 +689,32 @@ impl WorkspaceManager {
         Ok(())
     }
 
+    /// Stamp the PR's GitHub-reported open/merge times onto a tracked repo,
+    /// identified by subdir. Called from every PR-state fetch path; GitHub is
+    /// the source of truth, so values overwrite (COALESCE keeps an existing
+    /// stamp when a fetch reports none). NULL until first observed — a PR
+    /// merged while the app was closed still gets its real merge time on the
+    /// next fetch.
+    pub fn set_repo_pr_times(
+        &self,
+        agent_id: &str,
+        subdir: &str,
+        opened_at: Option<i64>,
+        merged_at: Option<i64>,
+    ) -> Result<()> {
+        if opened_at.is_none() && merged_at.is_none() {
+            return Ok(());
+        }
+        let conn = self.db.lock();
+        conn.execute(
+            "UPDATE worktrees SET pr_opened_at = COALESCE(?1, pr_opened_at),
+                                  pr_merged_at = COALESCE(?2, pr_merged_at)
+             WHERE workspace_id = ?3 AND subdir = ?4",
+            rusqlite::params![opened_at, merged_at, agent_id, subdir],
+        )?;
+        Ok(())
+    }
+
     pub fn append_tracked_repo(&self, agent_id: &str, repo: TrackedRepo) -> Result<()> {
         let conn = self.db.lock();
         Self::insert_worktree(&conn, agent_id, &repo)?;

--- a/src/app.css
+++ b/src/app.css
@@ -35,6 +35,7 @@
 @import "./styles/shared/terminal.css";
 @import "./components/History/History.css";
 @import "./components/ProjectSettings/ProjectSettings.css";
+@import "./components/Stats/Stats.css";
 @import "./components/RightPanel/FilePanel/FilePanel.css";
 @import "./components/SettingsScreen/SettingsScreen.css";
 @import "./styles/shared/error-boundary.css";

--- a/src/components/ProjectSettings/ProjectPulse.tsx
+++ b/src/components/ProjectSettings/ProjectPulse.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useState } from "react";
+import {
+  ActivityHeatmap,
+  CountUp,
+  computeStreak,
+  formatHeatDay,
+  Stat,
+} from "@/components/Stats";
+import { formatCost, formatTokens } from "@/util/format";
+import {
+  loadPulseActivity,
+  loadPulseTotals,
+  loadPulseUsage,
+  type PulseActivity,
+  type PulseTotals,
+  type PulseUsage,
+} from "./pulseData";
+
+const WEEKS = 52;
+// One extra week of margin past the grid so the oldest column is never short.
+const HORIZON_MS = (WEEKS + 1) * 7 * 86_400_000;
+
+/** The "Project Pulse" block atop Project Settings: a year of daily activity
+ *  on the accent heat ramp, a streak counter, and lifetime hero numbers.
+ *  Turn/agent/PR series load in one round of fast indexed queries; the token
+ *  total folds every session's records, so it streams in behind a shimmer. */
+export function ProjectPulse({ projectId }: { projectId: string }) {
+  const [activity, setActivity] = useState<PulseActivity | null>(null);
+  const [totals, setTotals] = useState<PulseTotals | null>(null);
+  const [usage, setUsage] = useState<PulseUsage | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setActivity(null);
+    setTotals(null);
+    setUsage(null);
+    const now = Date.now();
+    loadPulseActivity(projectId, now - HORIZON_MS)
+      .then((a) => !cancelled && setActivity(a))
+      .catch((err) => console.error("pulse activity failed", err));
+    loadPulseTotals(projectId, now)
+      .then((t) => !cancelled && setTotals(t))
+      .catch((err) => console.error("pulse totals failed", err));
+    loadPulseUsage(projectId)
+      .then((u) => !cancelled && setUsage(u))
+      .catch((err) => {
+        console.error("pulse usage failed", err);
+        if (!cancelled) setUsage({ tokens: 0, costUsd: 0 });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+
+  const turns = activity?.turns ?? {};
+  const streak = activity ? computeStreak(turns, Date.now()) : 0;
+
+  // Date + at most two metrics — more reads as clutter. Turns lead (they're
+  // the cell's intensity); PRs beat agents for the second slot because
+  // they're the rarer, more notable signal.
+  const tooltipFor = (day: string, count: number) => {
+    const parts: string[] = [];
+    if (count > 0) parts.push(`${count} turn${count === 1 ? "" : "s"}`);
+    const prs = activity?.prs[day] ?? 0;
+    if (prs > 0) parts.push(`${prs} PR${prs === 1 ? "" : "s"}`);
+    const agents = activity?.agents[day] ?? 0;
+    if (agents > 0) parts.push(`${agents} agent${agents === 1 ? "" : "s"}`);
+    if (parts.length === 0) parts.push("no activity");
+    return `${formatHeatDay(day)} · ${parts.slice(0, 2).join(" · ")}`;
+  };
+
+  return (
+    <section className="ps-section">
+      {activity ? (
+        <ActivityHeatmap
+          counts={turns}
+          weeks={WEEKS}
+          tooltipFor={tooltipFor}
+          footer={
+            streak > 1 && (
+              <div className="pulse-streak iflex-center">
+                <span className="pulse-streak-dot" />
+                {streak}-day streak
+              </div>
+            )
+          }
+        />
+      ) : (
+        <div className="pulse-skeleton" />
+      )}
+
+      <div className="stat-row text-sm">
+        <Stat
+          label="agents"
+          loading={!totals}
+          tip={
+            totals && totals.agents7d > 0 ? `${totals.agents7d} in the last 7 days` : undefined
+          }
+        >
+          {totals && <CountUp value={totals.agents} />}
+        </Stat>
+        <span className="stat-sep" />
+        <Stat
+          label="PRs"
+          loading={!totals}
+          tip={totals && totals.prsMerged > 0 ? `${totals.prsMerged} merged` : undefined}
+        >
+          {totals && <CountUp value={totals.prsOpened} />}
+        </Stat>
+        <span className="stat-sep" />
+        <Stat label="lines" loading={!totals}>
+          {totals && (
+            <>
+              <span className="stat-add">
+                +<CountUp value={totals.additions} />
+              </span>
+              <span className="stat-del">
+                −<CountUp value={totals.deletions} />
+              </span>
+            </>
+          )}
+        </Stat>
+        <span className="stat-sep" />
+        <Stat
+          label="tokens"
+          loading={!usage}
+          tip={usage && usage.costUsd > 0 ? `≈ ${formatCost(usage.costUsd)}` : undefined}
+        >
+          {usage && <CountUp value={usage.tokens} format={formatTokens} />}
+        </Stat>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ProjectSettings/ProjectPulse.tsx
+++ b/src/components/ProjectSettings/ProjectPulse.tsx
@@ -1,11 +1,5 @@
 import { useEffect, useState } from "react";
-import {
-  ActivityHeatmap,
-  CountUp,
-  computeStreak,
-  formatHeatDay,
-  Stat,
-} from "@/components/Stats";
+import { ActivityHeatmap, CountUp, computeStreak, formatHeatDay, Stat } from "@/components/Stats";
 import { formatCost, formatTokens } from "@/util/format";
 import {
   loadPulseActivity,
@@ -93,9 +87,7 @@ export function ProjectPulse({ projectId }: { projectId: string }) {
         <Stat
           label="agents"
           loading={!totals}
-          tip={
-            totals && totals.agents7d > 0 ? `${totals.agents7d} in the last 7 days` : undefined
-          }
+          tip={totals && totals.agents7d > 0 ? `${totals.agents7d} in the last 7 days` : undefined}
         >
           {totals && <CountUp value={totals.agents} />}
         </Stat>

--- a/src/components/ProjectSettings/ProjectSettings.css
+++ b/src/components/ProjectSettings/ProjectSettings.css
@@ -119,6 +119,35 @@
 .ps-section-h {
   margin-bottom: 16px;
 }
+/* ── Project Pulse (activity block) ── */
+.pulse-streak {
+  gap: 6px;
+  color: var(--fg-2);
+}
+.pulse-streak-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 6px color-mix(in oklch, var(--accent), transparent 40%);
+}
+.ps-section .heat {
+  margin-bottom: 24px;
+}
+.pulse-skeleton {
+  height: 128px;
+  margin-bottom: 24px;
+  border-radius: var(--r-sm);
+  background: linear-gradient(90deg, var(--bg-2) 25%, var(--bg-3) 50%, var(--bg-2) 75%);
+  background-size: 200% 100%;
+  animation: stat-shimmer 1.2s linear infinite;
+  opacity: 0.5;
+}
+@media (prefers-reduced-motion: reduce) {
+  .pulse-skeleton {
+    animation: none;
+  }
+}
 .ps-section-t {
   font-weight: 600;
   color: var(--fg-0);

--- a/src/components/ProjectSettings/ProjectSettings.css
+++ b/src/components/ProjectSettings/ProjectSettings.css
@@ -142,10 +142,6 @@
   border: 1px solid var(--bd-soft);
   border-radius: 3px;
 }
-.ps-eco-count b {
-  color: var(--fg-0);
-}
-
 /* general section — name + location */
 .ps-field {
   margin-top: 18px;

--- a/src/components/ProjectSettings/RunEnvSection.tsx
+++ b/src/components/ProjectSettings/RunEnvSection.tsx
@@ -35,15 +35,14 @@ export function RunEnvSection({ projectId, rows, ecosystem, initialOverrides }: 
     commit(next);
   };
 
-  const overrideCount = Object.keys(overrides).length;
-
   return (
     <section className="ps-section">
       <header className="ps-section-h">
         <h2 className="ps-section-t text-lg">Run &amp; environment</h2>
         <p className="ps-section-lead text-sm">
-          Defaults every agent in this project inherits. Detected from the repo; edit a value to
-          override it. Individual runs can still override these from the Run panel.
+          The run configuration every agent in this project inherits. Values are detected from the
+          repo as defaults; edit one to make it the project setting. Individual agents can still
+          override these from the Run panel.
         </p>
       </header>
 
@@ -61,14 +60,14 @@ export function RunEnvSection({ projectId, rows, ecosystem, initialOverrides }: 
             ) : (
               <>No ecosystem detected — edit values below</>
             )}
-            {overrideCount > 0 && (
-              <span className="ps-eco-count">
-                {" · "}
-                <b>{overrideCount}</b> override{overrideCount === 1 ? "" : "s"}
-              </span>
-            )}
           </div>
-          <RunConfigEditor rows={rows} draft={overrides} onChange={onChange} onRevert={onRevert} />
+          <RunConfigEditor
+            rows={rows}
+            draft={overrides}
+            scope="project"
+            onChange={onChange}
+            onRevert={onRevert}
+          />
         </>
       )}
     </section>

--- a/src/components/ProjectSettings/index.tsx
+++ b/src/components/ProjectSettings/index.tsx
@@ -6,6 +6,7 @@ import { Loader } from "@/components/ui/Loader";
 import { useAppStore } from "@/store";
 import { basename } from "@/util/format";
 import { GeneralSection } from "./GeneralSection";
+import { ProjectPulse } from "./ProjectPulse";
 import { RunEnvSection } from "./RunEnvSection";
 
 interface Loaded {
@@ -95,6 +96,7 @@ export function ProjectSettings({ repoPath }: { repoPath: string }) {
             </div>
           ) : (
             <div className="ps-sections">
+              <ProjectPulse projectId={loaded.projectId} />
               <GeneralSection projectId={loaded.projectId} currentName={name} repoPath={repoPath} />
               <RunEnvSection
                 projectId={loaded.projectId}

--- a/src/components/ProjectSettings/pulseData.ts
+++ b/src/components/ProjectSettings/pulseData.ts
@@ -1,0 +1,141 @@
+import { hasUsage, usageFromRecords } from "@/adapters/usage";
+import { api } from "@/api";
+import { dbQuery } from "@/storage/db";
+import { recordUsageSnapshot } from "@/storage/usageDaily";
+
+// Data layer for the Project Pulse block. Everything here reads what the app
+// already persists (session_user_turns, workspaces, worktrees) via SELECT-only
+// raw queries; nothing is recorded on open except the opportunistic usage
+// snapshots seeded by `loadPulseUsage`.
+
+/** Per-local-day counts feeding the heatmap and its tooltip. */
+export interface PulseActivity {
+  /** User turns sent to agents of this project — the heatmap intensity. */
+  turns: Record<string, number>;
+  /** Agents launched. */
+  agents: Record<string, number>;
+  /** PRs opened (only days observed since PR-time stamping shipped). */
+  prs: Record<string, number>;
+}
+
+export interface PulseTotals {
+  agents: number;
+  agents7d: number;
+  prsOpened: number;
+  prsMerged: number;
+  additions: number;
+  deletions: number;
+}
+
+export interface PulseUsage {
+  /** Input + output tokens across every session of the project. */
+  tokens: number;
+  /** Summed cost; 0 when no provider in the project reports cost. */
+  costUsd: number;
+}
+
+const DAY_MS = 86_400_000;
+
+const toDayMap = (rows: Array<{ day: string; n: number }>): Record<string, number> => {
+  const out: Record<string, number> = {};
+  for (const r of rows) if (r.day) out[r.day] = r.n;
+  return out;
+};
+
+/** The three per-day series, bucketed by the user's local calendar. */
+export async function loadPulseActivity(
+  projectId: string,
+  sinceMs: number,
+): Promise<PulseActivity> {
+  const [turns, agents, prs] = await Promise.all([
+    dbQuery<{ day: string; n: number }>(
+      `SELECT date(t.created_at/1000, 'unixepoch', 'localtime') AS day, COUNT(*) AS n
+       FROM session_user_turns t
+       JOIN sessions s ON s.id = t.session_id
+       JOIN workspaces w ON w.id = s.workspace_id
+       WHERE w.project_id = ? AND t.created_at >= ?
+       GROUP BY day`,
+      [projectId, sinceMs],
+    ),
+    dbQuery<{ day: string; n: number }>(
+      `SELECT date(created_at/1000, 'unixepoch', 'localtime') AS day, COUNT(*) AS n
+       FROM workspaces WHERE project_id = ? AND created_at >= ?
+       GROUP BY day`,
+      [projectId, sinceMs],
+    ),
+    dbQuery<{ day: string; n: number }>(
+      `SELECT date(wt.pr_opened_at/1000, 'unixepoch', 'localtime') AS day, COUNT(*) AS n
+       FROM worktrees wt JOIN workspaces w ON w.id = wt.workspace_id
+       WHERE w.project_id = ? AND wt.pr_opened_at >= ?
+       GROUP BY day`,
+      [projectId, sinceMs],
+    ),
+  ]);
+  return { turns: toDayMap(turns), agents: toDayMap(agents), prs: toDayMap(prs) };
+}
+
+/** Lifetime headline numbers for the tile row. */
+export async function loadPulseTotals(projectId: string, nowMs: number): Promise<PulseTotals> {
+  const weekAgo = nowMs - 7 * DAY_MS;
+  const [agentRows, repoRows] = await Promise.all([
+    dbQuery<{ n: number; recent: number }>(
+      `SELECT COUNT(*) AS n,
+              COALESCE(SUM(CASE WHEN created_at >= ? THEN 1 ELSE 0 END), 0) AS recent
+       FROM workspaces WHERE project_id = ?`,
+      [weekAgo, projectId],
+    ),
+    dbQuery<{ prs: number; merged: number; adds: number; dels: number }>(
+      `SELECT COUNT(wt.pr_number) AS prs,
+              COALESCE(SUM(CASE WHEN wt.pr_merged_at IS NOT NULL THEN 1 ELSE 0 END), 0) AS merged,
+              COALESCE(SUM(wt.diff_additions), 0) AS adds,
+              COALESCE(SUM(wt.diff_deletions), 0) AS dels
+       FROM worktrees wt JOIN workspaces w ON w.id = wt.workspace_id
+       WHERE w.project_id = ?`,
+      [projectId],
+    ),
+  ]);
+  return {
+    agents: agentRows[0]?.n ?? 0,
+    agents7d: agentRows[0]?.recent ?? 0,
+    prsOpened: repoRows[0]?.prs ?? 0,
+    prsMerged: repoRows[0]?.merged ?? 0,
+    additions: repoRows[0]?.adds ?? 0,
+    deletions: repoRows[0]?.dels ?? 0,
+  };
+}
+
+/** Fold every session of the project into a token/cost total. Reads each
+ *  agent's transcript records, so it runs lazily behind the tile shimmer;
+ *  folded totals are also snapshotted into usage_daily, seeding per-day
+ *  history for the whole project. Per-agent failures are skipped — the total
+ *  is best-effort over what's readable. */
+export async function loadPulseUsage(projectId: string): Promise<PulseUsage> {
+  const rows = await dbQuery<{ id: string; provider: string | null }>(
+    `SELECT w.id AS id,
+            (SELECT s.provider FROM sessions s WHERE s.workspace_id = w.id
+             ORDER BY s.created_at DESC LIMIT 1) AS provider
+     FROM workspaces w WHERE w.project_id = ?`,
+    [projectId],
+  );
+  let tokens = 0;
+  let costUsd = 0;
+  const CHUNK = 4;
+  for (let i = 0; i < rows.length; i += CHUNK) {
+    await Promise.all(
+      rows.slice(i, i + CHUNK).map(async (r) => {
+        try {
+          const records = await api.readSessionRecords(r.id);
+          if (records.length === 0) return;
+          const usage = usageFromRecords(r.provider ?? undefined, records);
+          if (!hasUsage(usage)) return;
+          tokens += usage.inputTokens + usage.outputTokens;
+          costUsd += usage.costUsd;
+          recordUsageSnapshot(r.id, projectId, usage);
+        } catch {
+          // Unreadable session (e.g. cleaned-up archive) — skip, don't abort.
+        }
+      }),
+    );
+  }
+  return { tokens, costUsd };
+}

--- a/src/components/RightPanel/RunPanel.css
+++ b/src/components/RightPanel/RunPanel.css
@@ -387,9 +387,11 @@
   gap: 6px;
   flex-shrink: 0;
 }
+/* The value chip is one persistent box around a naked input, so the border,
+ * focus ring, background, and width (set inline on the input) can all
+ * transition between the view and edit states. */
 .rs-value {
   gap: 6px;
-  max-width: 220px;
   height: 28px;
   padding: 0 9px;
   background: var(--bg-0);
@@ -399,34 +401,45 @@
   color: var(--fg-0);
   cursor: text;
   transition:
-    border-color 0.1s,
-    background 0.1s;
+    border-color 0.15s ease,
+    background 0.15s ease,
+    box-shadow 0.15s ease,
+    gap 0.15s ease;
 }
 .rs-value:hover {
   border-color: var(--bd);
   background: var(--bg-2);
 }
-.rs-value .rsv-text {
-  max-width: 180px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.rs-value.editing {
+  gap: 0;
+  background: var(--bg-0);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent), transparent 85%);
 }
-.rs-value svg {
+.rs-value input {
+  min-width: 0;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  outline: none;
+  font: inherit;
+  color: inherit;
+  text-overflow: ellipsis;
+  transition: width 0.15s ease;
+}
+.rs-value .rs-edit-ic {
+  width: 10px;
   color: var(--fg-3);
   flex-shrink: 0;
+  overflow: hidden;
+  justify-content: flex-start;
+  transition:
+    width 0.15s ease,
+    opacity 0.15s ease;
 }
-.rs-input {
-  width: 220px;
-  height: 28px;
-  padding: 0 9px;
-  background: var(--bg-0);
-  border: 1px solid var(--accent);
-  outline: none;
-  border-radius: var(--r-sm);
-  font-family: var(--font-mono);
-  color: var(--fg-0);
-  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent), transparent 85%);
+.rs-value.editing .rs-edit-ic {
+  width: 0;
+  opacity: 0;
 }
 .rs-revert {
   width: 22px;

--- a/src/components/RightPanel/RunPanel.tsx
+++ b/src/components/RightPanel/RunPanel.tsx
@@ -13,9 +13,9 @@ import { RunSettingsSheet } from "./RunSettingsSheet";
 
 // Detected run config replaces the old hardcoded defaults. The backend
 // (`detect_run_config`) returns rows per ecosystem; the panel shows the
-// highest-confidence one. The `run.*` overrides in project_settings — the
-// per-project defaults, also editable from Project settings — layer on top
-// of these detected values.
+// highest-confidence one. Two settings layers sit on top: the project's
+// `run.*` settings (edited in Project Settings), then this agent's
+// `run.agent.<id>.*` overrides (edited here in the sheet).
 
 // Strip ANSI escape sequences before rendering. v1 keeps log rendering
 // dead-simple (plain text with pre-wrap); colorization can come later.
@@ -43,6 +43,7 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
   const [lastError, setLastError] = useState<string | null>(null);
   const [log, setLog] = useState<string>("");
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [projectValues, setProjectValues] = useState<Record<string, string>>({});
   const [overrides, setOverrides] = useState<Record<string, string>>({});
   const [rows, setRows] = useState<SetupRow[]>([]);
   const [ecosystem, setEcosystem] = useState<string | null>(null);
@@ -52,22 +53,27 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
   // time we re-subscribe (agent switch).
   const decoderRef = useRef<TextDecoder | null>(null);
 
-  // Load persisted command overrides for this project. Re-loads when
-  // the selected agent (and thus project) changes.
+  // Load the project's run settings (the base every agent inherits) and this
+  // agent's overrides on top of them. Re-loads on agent switch.
   useEffect(() => {
     let cancelled = false;
     if (!agent.project_id) {
+      setProjectValues({});
       setOverrides({});
       return;
     }
     loadRunOverrides(agent.project_id).then((loaded) => {
+      if (cancelled) return;
+      setProjectValues(loaded);
+    });
+    loadRunOverrides(agent.project_id, agent.id).then((loaded) => {
       if (cancelled) return;
       setOverrides(loaded);
     });
     return () => {
       cancelled = true;
     };
-  }, [agent.project_id]);
+  }, [agent.project_id, agent.id]);
 
   // Detect the run config for this agent's checkout. Re-runs on agent
   // switch. The highest-confidence ecosystem fills the table; an empty
@@ -161,8 +167,17 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
     el.scrollTop = el.scrollHeight;
   }, [log]);
 
+  // What each row inherits: the project setting when one exists, else the
+  // detected value. Agent-level overrides compare against these, so a value
+  // matching the project setting never reads as an override.
+  const effectiveRows = rows.map((r) =>
+    projectValues[r.id] != null
+      ? { ...r, value: projectValues[r.id], origin: "project" as const }
+      : r,
+  );
+
   const fieldValue = (id: string) => {
-    const row = rows.find((r) => r.id === id);
+    const row = effectiveRows.find((r) => r.id === id);
     return overrides[id] ?? row?.value ?? "";
   };
 
@@ -187,13 +202,14 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
   };
 
   const onApply = (next: Record<string, string>) => {
-    // Reconcile the draft against the detected rows: keep only real
+    // Reconcile the draft against the inherited values: keep only real
     // overrides, and prune keys (including stale ones whose row no longer
     // exists after an ecosystem change) from the DB so the override
-    // indicator can't get stuck lit.
-    const { cleaned, toSet, toDelete } = reconcileOverrides(rows, overrides, next);
+    // indicator can't get stuck lit. Persisted under this agent's scope —
+    // the project setting is only edited from Project Settings.
+    const { cleaned, toSet, toDelete } = reconcileOverrides(effectiveRows, overrides, next);
     if (agent.project_id) {
-      persistRunOverrides(agent.project_id, toSet, toDelete);
+      persistRunOverrides(agent.project_id, toSet, toDelete, agent.id);
     }
 
     setOverrides(cleaned);
@@ -260,7 +276,7 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
       {/* ── Settings sheet ── */}
       {settingsOpen && (
         <RunSettingsSheet
-          rows={rows}
+          rows={effectiveRows}
           overrides={overrides}
           ecosystem={ecosystem}
           onClose={() => setSettingsOpen(false)}

--- a/src/components/RightPanel/RunSettingsSheet.tsx
+++ b/src/components/RightPanel/RunSettingsSheet.tsx
@@ -68,14 +68,20 @@ export function RunSettingsSheet({ rows, overrides, ecosystem, onClose, onApply 
 
         {/* Body */}
         <div className="run-sheet-body">
-          <RunConfigEditor rows={rows} draft={draft} onChange={setRow} onRevert={revert} />
+          <RunConfigEditor
+            rows={rows}
+            draft={draft}
+            scope="agent"
+            onChange={setRow}
+            onRevert={revert}
+          />
         </div>
 
         {/* Footer */}
         <div className="run-sheet-f flex-center">
           <div className="rsf-status truncate text-sm">
             {changed.length === 0 ? (
-              <span style={{ color: "var(--fg-3)" }}>No overrides — using detected values</span>
+              <span style={{ color: "var(--fg-3)" }}>No overrides — using project settings</span>
             ) : (
               <span>
                 <b style={{ color: "var(--fg-0)" }}>{changed.length}</b>

--- a/src/components/RunConfig/ConfigRow.tsx
+++ b/src/components/RunConfig/ConfigRow.tsx
@@ -5,54 +5,99 @@ import type { SetupRow } from "./types";
 interface ConfigRowProps {
   row: SetupRow;
   override: string | undefined;
+  /** Which surface the row is rendered on. Project Settings edits ARE the
+   *  project setting — an edited row carries no special label or styling.
+   *  The Run panel layers per-agent values on top of the project's, so an
+   *  edited row there is marked as overriding the project setting. */
+  scope: "project" | "agent";
   onChange: (v: string) => void;
   onRevert: () => void;
 }
 
-/** One editable run-config row: shows the detected value as a placeholder,
- *  click-to-edit, revert-to-detected, and an override indicator. Reused by
- *  the Run panel sheet and the Project Settings modal. */
-export function ConfigRow({ row, override, onChange, onRevert }: ConfigRowProps) {
+/** Widest the value can render in view mode before it truncates. */
+const VIEW_MAX_WIDTH = 220;
+/** Input width while editing. */
+const EDIT_WIDTH = 200;
+
+/** One editable run-config row. The value is a single persistent input styled
+ *  as a chip in view mode, so the border, focus ring, and width all animate
+ *  on the view↔edit transition instead of the two states swapping elements.
+ *  Overridden rows on the agent surface get a revert button; project edits
+ *  are final (clearing the field falls back to detected). Reused by the Run
+ *  panel sheet and the Project Settings modal. */
+export function ConfigRow({ row, override, scope, onChange, onRevert }: ConfigRowProps) {
   const [editing, setEditing] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (editing) inputRef.current?.focus();
-  }, [editing]);
+  // Set when Escape cancels the edit, so the blur that follows discards the
+  // draft instead of committing it.
+  const cancelledRef = useRef(false);
 
   const hasOverride = override != null;
   const display = hasOverride ? override : row.value;
 
+  const [text, setText] = useState(display);
+  useEffect(() => {
+    if (!editing) setText(display);
+  }, [display, editing]);
+
+  // Inputs don't size to their content, but the value is monospace, so its
+  // rendered width is exactly length × 1ch — sized in ch units the width is
+  // always right, with no DOM measurement to go stale when the font loads.
+  // Keeping the width explicit in both states is what lets it transition.
+  const viewWidth = `min(${Math.max(display.length, 1)}ch + 2px, ${VIEW_MAX_WIDTH}px)`;
+
+  // Project Settings edits ARE the project setting — no override framing
+  // there, in label or styling. Only the agent surface marks a row that
+  // deviates from what the project says.
+  const fromProject = row.origin === "project";
+  const marksOverride = hasOverride && scope === "agent";
+  const overrideLabel = fromProject ? "Overrides project setting" : "Overrides project default";
+  const revertTip = fromProject ? "Revert to project setting" : "Revert to detected";
+
+  const caption = marksOverride ? (
+    <>
+      <span className="dot" />
+      {overrideLabel}
+    </>
+  ) : hasOverride ? null : fromProject ? (
+    <>Project setting</>
+  ) : (
+    <>
+      Detected · <code>{row.source}</code>
+    </>
+  );
+
   return (
-    <div className={`rs-row flex-center${hasOverride ? " overridden" : ""}`}>
+    <div className={`rs-row flex-center${marksOverride ? " overridden" : ""}`}>
       <div className="rs-row-l">
         <div className="rs-label text-base">{row.key}</div>
-        <div className="rs-source iflex-center text-xs">
-          {hasOverride ? (
-            <>
-              <span className="dot" />
-              Manual override
-            </>
-          ) : (
-            <>
-              Detected · <code>{row.source}</code>
-            </>
-          )}
-        </div>
+        {caption && <div className="rs-source iflex-center text-xs">{caption}</div>}
       </div>
       <div className="rs-row-r iflex-center">
-        {editing ? (
+        <div
+          className={`rs-value iflex-center text-sm${editing ? " editing" : ""}`}
+          onClick={() => inputRef.current?.focus()}
+        >
           <input
             ref={inputRef}
-            className="rs-input text-sm"
+            aria-label={row.key}
             type="text"
-            defaultValue={display}
+            value={text}
+            readOnly={!editing}
             placeholder={row.value}
+            style={{ width: editing ? EDIT_WIDTH : viewWidth }}
+            onFocus={() => setEditing(true)}
+            onChange={(e) => setText(e.target.value)}
             onBlur={(e) => {
-              const v = e.target.value.trim();
+              setEditing(false);
+              if (cancelledRef.current) {
+                cancelledRef.current = false;
+                setText(display);
+                return;
+              }
+              const v = e.currentTarget.value.trim();
               if (v === "" || v === row.value) onRevert();
               else onChange(v);
-              setEditing(false);
             }}
             onKeyDown={(e) => {
               if (e.key === "Enter") e.currentTarget.blur();
@@ -62,23 +107,17 @@ export function ConfigRow({ row, override, onChange, onRevert }: ConfigRowProps)
                 // which would otherwise close the whole surface instead of just
                 // cancelling this in-progress edit.
                 e.stopPropagation();
-                e.currentTarget.value = display;
+                cancelledRef.current = true;
                 e.currentTarget.blur();
               }
             }}
           />
-        ) : (
-          <button className="rs-value iflex-center text-sm" onClick={() => setEditing(true)}>
-            <span className="rsv-text">{display}</span>
+          <span className="rs-edit-ic iflex-center">
             <Icon name="edit" size={10} />
-          </button>
-        )}
-        {hasOverride && !editing && (
-          <button
-            className="rs-revert iflex-center tip"
-            data-tip="Revert to detected"
-            onClick={onRevert}
-          >
+          </span>
+        </div>
+        {marksOverride && !editing && (
+          <button className="rs-revert iflex-center tip" data-tip={revertTip} onClick={onRevert}>
             <span className="rs-revert-ic iflex-center">
               <Icon name="refresh" size={11} />
             </span>

--- a/src/components/RunConfig/ConfigRow.tsx
+++ b/src/components/RunConfig/ConfigRow.tsx
@@ -96,6 +96,12 @@ export function ConfigRow({ row, override, scope, onChange, onRevert }: ConfigRo
                 return;
               }
               const v = e.currentTarget.value.trim();
+              // Unchanged from what's shown — don't fire onChange/onRevert.
+              // Comparing against `display` (the effective value: override if
+              // set, else detected) rather than `row.value` (detected only) is
+              // what keeps a no-op focus→blur on an already-overridden field
+              // from re-committing the identical override.
+              if (v === display) return;
               if (v === "" || v === row.value) onRevert();
               else onChange(v);
             }}

--- a/src/components/RunConfig/RunConfigEditor.tsx
+++ b/src/components/RunConfig/RunConfigEditor.tsx
@@ -5,14 +5,16 @@ interface Props {
   rows: SetupRow[];
   /** Current override draft, keyed by row id. */
   draft: Record<string, string>;
+  /** Which surface is editing — see ConfigRow. */
+  scope: "project" | "agent";
   onChange: (id: string, value: string) => void;
   onRevert: (id: string) => void;
 }
 
-/** Renders detected run-config rows grouped by section, each editable as an
- *  override. Pure presentation — draft state is owned by the caller. Reused by
- *  the Run panel sheet and Project Settings. */
-export function RunConfigEditor({ rows, draft, onChange, onRevert }: Props) {
+/** Renders detected run-config rows grouped by section, each editable. Pure
+ *  presentation — draft state is owned by the caller. Reused by the Run
+ *  panel sheet and Project Settings. */
+export function RunConfigEditor({ rows, draft, scope, onChange, onRevert }: Props) {
   const groups = Array.from(new Set(rows.map((r) => r.group)));
 
   return (
@@ -28,6 +30,7 @@ export function RunConfigEditor({ rows, draft, onChange, onRevert }: Props) {
                   key={r.id}
                   row={r}
                   override={draft[r.id]}
+                  scope={scope}
                   onChange={(v) => onChange(r.id, v)}
                   onRevert={() => onRevert(r.id)}
                 />

--- a/src/components/RunConfig/runSettings.ts
+++ b/src/components/RunConfig/runSettings.ts
@@ -4,36 +4,53 @@ import {
   setProjectSetting,
 } from "@/storage/projectSettings";
 
-// Run-config overrides live in `project_settings` under a `run.` prefix so
-// the table can hold other panels' per-project data without colliding.
+// Run-config values live in `project_settings` under a `run.` prefix so the
+// table can hold other panels' per-project data without colliding. Two
+// scopes share the table:
+//   run.<rowId>                 — the project setting (Project Settings page)
+//   run.agent.<agentId>.<rowId> — a per-agent override layered on top of it
+//                                 (Run panel sheet)
+// The backend resolves the same two keys (agent first) in `read_run_commands`.
 const RUN_KEY_PREFIX = "run.";
-const runKey = (id: string) => `${RUN_KEY_PREFIX}${id}`;
+const AGENT_SCOPE_PREFIX = "run.agent.";
+const runKey = (id: string, agentId?: string) =>
+  agentId ? `${AGENT_SCOPE_PREFIX}${agentId}.${id}` : `${RUN_KEY_PREFIX}${id}`;
 
-/** Load the persisted run-config overrides for a project, stripped of the
- *  `run.` prefix so keys match detected-row ids. */
-export async function loadRunOverrides(projectId: string): Promise<Record<string, string>> {
+/** Load the persisted run-config values for a project — or, when `agentId`
+ *  is given, the per-agent overrides — stripped of their prefix so keys
+ *  match detected-row ids. */
+export async function loadRunOverrides(
+  projectId: string,
+  agentId?: string,
+): Promise<Record<string, string>> {
   const all = await getProjectSettings(projectId);
+  const prefix = agentId ? `${AGENT_SCOPE_PREFIX}${agentId}.` : RUN_KEY_PREFIX;
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(all)) {
-    if (k.startsWith(RUN_KEY_PREFIX)) out[k.slice(RUN_KEY_PREFIX.length)] = v;
+    if (!k.startsWith(prefix)) continue;
+    // Project scope must not slurp up agent-scoped keys.
+    if (!agentId && k.startsWith(AGENT_SCOPE_PREFIX)) continue;
+    out[k.slice(prefix.length)] = v;
   }
   return out;
 }
 
-/** Persist reconciled run-config overrides: upsert the set, delete the rest.
+/** Persist reconciled run-config values: upsert the set, delete the rest.
+ *  Pass `agentId` to write the per-agent scope instead of the project's.
  *  Failures are logged, not thrown, so one bad key can't abort the batch. */
 export function persistRunOverrides(
   projectId: string,
   toSet: Array<{ id: string; value: string }>,
   toDelete: string[],
+  agentId?: string,
 ): void {
   for (const { id, value } of toSet) {
-    setProjectSetting(projectId, runKey(id), value).catch((err) =>
+    setProjectSetting(projectId, runKey(id, agentId), value).catch((err) =>
       console.error("setProjectSetting failed", err),
     );
   }
   for (const id of toDelete) {
-    deleteProjectSetting(projectId, runKey(id)).catch((err) =>
+    deleteProjectSetting(projectId, runKey(id, agentId)).catch((err) =>
       console.error("deleteProjectSetting failed", err),
     );
   }

--- a/src/components/RunConfig/types.ts
+++ b/src/components/RunConfig/types.ts
@@ -9,6 +9,11 @@ export interface SetupRow {
   key: string;
   value: string; // inferred / default
   source: string; // e.g. "scripts.dev", "vite.config.ts"
+  /** Where `value` comes from: repo detection (default) or an explicit
+   *  project setting layered on top. The Run panel maps project settings
+   *  onto detected rows so agent-level edits compare against the value the
+   *  agent actually inherits. */
+  origin?: "detected" | "project";
 }
 
 /** Backend group key → display label. Consumed only by `toSetupRows`. */

--- a/src/components/Stats/ActivityHeatmap.tsx
+++ b/src/components/Stats/ActivityHeatmap.tsx
@@ -1,0 +1,105 @@
+import { type ReactNode, useMemo, useState } from "react";
+import { localDay } from "@/util/format";
+import { buildHeatmapWeeks, heatLevel, monthLabels } from "./heatmap";
+
+interface Props {
+  /** Activity count per local day (YYYY-MM-DD). Missing days are 0. */
+  counts: Record<string, number>;
+  /** Grid width in weeks. 52 = one year, GitHub-style. */
+  weeks?: number;
+  /** Right edge of the grid; defaults to now. Injectable for tests. */
+  endMs?: number;
+  /** Tooltip / aria text for a day — the exact-value readout that keeps the
+   *  chart legible without relying on color alone. */
+  tooltipFor: (day: string, count: number) => string;
+  /** Optional slot on the footer row, opposite the Less/More legend
+   *  (e.g. a streak chip). */
+  footer?: ReactNode;
+}
+
+interface Tip {
+  x: number;
+  y: number;
+  text: string;
+}
+
+/** GitHub-style contribution grid on the app's accent ramp. One cell per
+ *  local day, columns are Monday-first weeks, intensity scales to the
+ *  busiest day in range. Hover any cell for the exact counts. */
+export function ActivityHeatmap({ counts, weeks = 52, endMs, tooltipFor, footer }: Props) {
+  const end = endMs ?? Date.now();
+  const grid = useMemo(() => buildHeatmapWeeks(end, weeks, counts), [end, weeks, counts]);
+  const months = useMemo(() => monthLabels(grid), [grid]);
+  const max = useMemo(
+    () => grid.reduce((m, col) => col.reduce((n, c) => Math.max(n, c.count), m), 0),
+    [grid],
+  );
+  const today = localDay(end);
+  const [tip, setTip] = useState<Tip | null>(null);
+
+  return (
+    <div className="heat">
+      <div className="heat-months text-xs" aria-hidden="true">
+        {months.map((label, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length positional slots
+          <span key={i} className="heat-mlabel">
+            {label}
+          </span>
+        ))}
+      </div>
+      <div className="heat-body">
+        <div className="heat-daylabels text-xs" aria-hidden="true">
+          <span>Mon</span>
+          <span>Wed</span>
+          <span>Fri</span>
+        </div>
+        <div className="heat-grid" role="img" aria-label="Daily activity for the past year">
+          {grid.map((col) => (
+            <div key={col[0].day} className="heat-col">
+              {col.map((cell) =>
+                cell.inRange ? (
+                  <div
+                    key={cell.day}
+                    className={`heat-cell${cell.day === today ? " today" : ""}`}
+                    data-level={heatLevel(cell.count, max)}
+                    aria-label={tooltipFor(cell.day, cell.count)}
+                    onMouseEnter={(e) => {
+                      const r = e.currentTarget.getBoundingClientRect();
+                      setTip({
+                        x: r.left + r.width / 2,
+                        y: r.bottom + 6,
+                        text: tooltipFor(cell.day, cell.count),
+                      });
+                    }}
+                    onMouseLeave={() => setTip(null)}
+                  />
+                ) : (
+                  <div key={cell.day} className="heat-cell out" />
+                ),
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="heat-foot">
+        <div className="heat-foot-l text-xs">{footer}</div>
+        <div className="heat-legend text-xs" aria-hidden="true">
+          Less
+          {[0, 1, 2, 3, 4].map((l) => (
+            <span key={l} className="heat-cell" data-level={l} />
+          ))}
+          More
+        </div>
+      </div>
+      {tip && (
+        <div
+          className="heat-tip mono text-xs"
+          style={{ left: tip.x, top: tip.y }}
+          role="presentation"
+        >
+          {tip.text}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Stats/Stat.tsx
+++ b/src/components/Stats/Stat.tsx
@@ -1,0 +1,65 @@
+import { type ReactNode, useEffect, useRef, useState } from "react";
+
+/** Animate a number from its previous value to `target` with an ease-out
+ *  ramp. Renders the final value immediately under prefers-reduced-motion. */
+export function useCountUp(target: number, durationMs = 700): number {
+  const [value, setValue] = useState(0);
+  const fromRef = useRef(0);
+
+  useEffect(() => {
+    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) {
+      fromRef.current = target;
+      setValue(target);
+      return;
+    }
+    const from = fromRef.current;
+    fromRef.current = target;
+    if (from === target) return;
+    let raf = 0;
+    const t0 = performance.now();
+    const tick = (now: number) => {
+      const p = Math.min(1, (now - t0) / durationMs);
+      const eased = 1 - (1 - p) ** 3;
+      setValue(Math.round(from + (target - from) * eased));
+      if (p < 1) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [target, durationMs]);
+
+  return value;
+}
+
+/** A counting-up number. `format` defaults to locale grouping. */
+export function CountUp({
+  value,
+  format = (n) => n.toLocaleString(),
+}: {
+  value: number;
+  format?: (n: number) => string;
+}) {
+  return <>{format(useCountUp(value))}</>;
+}
+
+interface StatProps {
+  /** Short unit label rendered after the value ("agents", "PRs", "tokens"). */
+  label: string;
+  /** Hover detail (e.g. "9 merged") via the app's data-tip tooltip. */
+  tip?: string;
+  /** Shimmer placeholder over the value while it computes. */
+  loading?: boolean;
+  /** The value — typically a CountUp (or several, for +/− pairs). */
+  children?: ReactNode;
+}
+
+/** One inline value–label pair of a compact stat strip. Detail beyond the
+ *  headline number lives in the hover tooltip, keeping the row one text
+ *  line tall. */
+export function Stat({ label, tip, loading, children }: StatProps) {
+  return (
+    <div className={`stat iflex-center${tip ? " tip" : ""}`} data-tip={tip}>
+      <span className="stat-v mono">{loading ? <span className="stat-shimmer" /> : children}</span>
+      <span className="stat-l">{label}</span>
+    </div>
+  );
+}

--- a/src/components/Stats/Stats.css
+++ b/src/components/Stats/Stats.css
@@ -1,0 +1,204 @@
+/* ── Stats primitives: activity heatmap + stat tiles ─────────────────────
+ * The heat ramp is a sequential scale mixed from the live --accent into
+ * --bg-2, so it recolors with the user's palette and theme for free. Mixed
+ * in oklab, not oklch: oklch would rotate hue from the accent toward the
+ * background's (near-gray but hued) angle, tinting low levels purple.
+ * Mix stops (35/56/78/100%) were validated for monotonic lightness and
+ * adjacent-step CVD separation (ΔE ≥ 13) on both themes' surfaces; exact
+ * values are always available via tooltip/aria, never color alone. */
+
+.heat {
+  --heat-cell: 10px;
+  --heat-gap: 3px;
+  --heat-1: color-mix(in oklab, var(--accent) 35%, var(--bg-2));
+  --heat-2: color-mix(in oklab, var(--accent) 56%, var(--bg-2));
+  --heat-3: color-mix(in oklab, var(--accent) 78%, var(--bg-2));
+  --heat-4: var(--accent);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* Columns flex to fill the container width, so the grid's right edge is
+ * flush with the legend below it; --heat-cell is the fixed row height and
+ * the minimum column width. The months row mirrors the same flex layout so
+ * labels stay over their columns. */
+.heat-months {
+  display: flex;
+  gap: var(--heat-gap);
+  margin-left: 30px; /* day-label gutter */
+  color: var(--fg-3);
+  height: 14px;
+}
+.heat-mlabel {
+  flex: 1 1 var(--heat-cell);
+  min-width: 0;
+  white-space: nowrap;
+  overflow: visible;
+}
+
+.heat-body {
+  display: flex;
+  gap: 6px;
+}
+.heat-daylabels {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 0 0 1px;
+  width: 24px;
+  color: var(--fg-3);
+  line-height: 1;
+}
+.heat-daylabels span {
+  height: var(--heat-cell);
+  display: flex;
+  align-items: center;
+}
+
+.heat-grid {
+  display: flex;
+  gap: var(--heat-gap);
+  flex: 1;
+  min-width: 0;
+}
+.heat-col {
+  display: flex;
+  flex-direction: column;
+  gap: var(--heat-gap);
+  flex: 1 1 var(--heat-cell);
+  min-width: 0;
+}
+.heat-cell {
+  width: var(--heat-cell);
+  height: var(--heat-cell);
+  border-radius: 2px;
+  background: var(--bg-2);
+  box-shadow: inset 0 0 0 1px var(--bd-soft);
+  transition: transform 0.08s var(--ease);
+}
+.heat-col .heat-cell {
+  width: auto; /* stretch to the flexed column */
+}
+.heat-cell[data-level="1"] {
+  background: var(--heat-1);
+  box-shadow: none;
+}
+.heat-cell[data-level="2"] {
+  background: var(--heat-2);
+  box-shadow: none;
+}
+.heat-cell[data-level="3"] {
+  background: var(--heat-3);
+  box-shadow: none;
+}
+.heat-cell[data-level="4"] {
+  background: var(--heat-4);
+  box-shadow: none;
+}
+.heat-grid .heat-cell:hover {
+  transform: scale(1.25);
+}
+.heat-cell.today {
+  box-shadow:
+    0 0 0 1px var(--bg-1),
+    0 0 0 2px var(--accent);
+}
+.heat-cell.out {
+  visibility: hidden;
+}
+
+.heat-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 12px;
+}
+.heat-foot-l {
+  color: var(--fg-2);
+}
+.heat-legend {
+  display: flex;
+  align-items: center;
+  gap: var(--heat-gap);
+  justify-content: flex-end;
+  color: var(--fg-3);
+}
+.heat-legend .heat-cell {
+  cursor: default;
+}
+.heat-legend :first-child {
+  margin-right: 3px;
+}
+
+/* Fixed-position so the modal's scroll container can't clip it. */
+.heat-tip {
+  position: fixed;
+  transform: translateX(-50%);
+  z-index: var(--z-popover);
+  padding: 4px 8px;
+  background: var(--bg-3);
+  border: 1px solid var(--bd-strong);
+  border-radius: var(--r-sm);
+  color: var(--fg-0);
+  white-space: nowrap;
+  pointer-events: none;
+  box-shadow: var(--shadow-2);
+}
+
+/* ── Stat strip: one text line of value–label pairs, detail on hover ── */
+.stat-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+.stat {
+  gap: 6px;
+}
+.stat-sep {
+  width: 1px;
+  height: 12px;
+  background: var(--bd-soft);
+}
+.stat-v {
+  color: var(--fg-0);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  font-variant-numeric: tabular-nums;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+}
+.stat-l {
+  color: var(--fg-3);
+}
+.stat-add {
+  color: var(--success);
+}
+.stat-del {
+  color: var(--danger);
+}
+
+.stat-shimmer {
+  display: inline-block;
+  width: 36px;
+  height: 12px;
+  border-radius: var(--r-xs);
+  background: linear-gradient(90deg, var(--bg-2) 25%, var(--bg-3) 50%, var(--bg-2) 75%);
+  background-size: 200% 100%;
+  animation: stat-shimmer 1.2s linear infinite;
+}
+@keyframes stat-shimmer {
+  to {
+    background-position: -200% 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .stat-shimmer {
+    animation: none;
+  }
+  .heat-grid .heat-cell:hover {
+    transform: none;
+  }
+}

--- a/src/components/Stats/heatmap.ts
+++ b/src/components/Stats/heatmap.ts
@@ -1,0 +1,93 @@
+import { localDay } from "@/util/format";
+
+// Pure math behind the activity heatmap: grid construction, month labels,
+// intensity levels, and the streak counter. Kept free of React/DOM so it's
+// unit-testable and reusable by any surface that wants a contribution graph.
+
+export interface HeatCell {
+  /** Local date key, YYYY-MM-DD. */
+  day: string;
+  count: number;
+  /** False for days after `endMs` (the tail of the current week) — rendered
+   *  as invisible placeholders so the last column keeps its shape. */
+  inRange: boolean;
+}
+
+const DAY_MS = 86_400_000;
+
+/** Monday-first weekday index (Mon=0 … Sun=6). */
+const mondayIdx = (d: Date) => (d.getDay() + 6) % 7;
+
+/** Noon of the given day — stepping whole days from noon never crosses a DST
+ *  boundary into the wrong date. */
+const atNoon = (ms: number): number => {
+  const d = new Date(ms);
+  d.setHours(12, 0, 0, 0);
+  return d.getTime();
+};
+
+/** Build a Monday-first week grid ending at the week containing `endMs`:
+ *  `weeks` columns × 7 rows, oldest week first. */
+export function buildHeatmapWeeks(
+  endMs: number,
+  weeks: number,
+  counts: Record<string, number>,
+): HeatCell[][] {
+  const end = atNoon(endMs);
+  const start = end - (mondayIdx(new Date(end)) + (weeks - 1) * 7) * DAY_MS;
+  const grid: HeatCell[][] = [];
+  for (let w = 0; w < weeks; w++) {
+    const col: HeatCell[] = [];
+    for (let d = 0; d < 7; d++) {
+      const t = start + (w * 7 + d) * DAY_MS;
+      const day = localDay(t);
+      col.push({ day, count: counts[day] ?? 0, inRange: t <= end });
+    }
+    grid.push(col);
+  }
+  return grid;
+}
+
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+/** One label slot per week column: the month name where a column starts a new
+ *  month, null elsewhere. The first column is only labeled when it starts at
+ *  a month boundary, so a mid-month left edge isn't mislabeled. */
+export function monthLabels(grid: HeatCell[][]): (string | null)[] {
+  let prev = -1;
+  return grid.map((col, i) => {
+    const month = Number(col[0].day.slice(5, 7)) - 1;
+    const label = i === 0 ? Number(col[0].day.slice(8, 10)) <= 7 : month !== prev;
+    prev = month;
+    return label ? (MONTHS[month] ?? null) : null;
+  });
+}
+
+/** Map a count onto the 0–4 intensity scale, scaled to the busiest day. */
+export function heatLevel(count: number, max: number): 0 | 1 | 2 | 3 | 4 {
+  if (count <= 0 || max <= 0) return 0;
+  return Math.min(4, Math.max(1, Math.ceil((count / max) * 4))) as 1 | 2 | 3 | 4;
+}
+
+/** Consecutive active days ending today. Today with no activity yet doesn't
+ *  break the streak (the day isn't over) — it just doesn't count. */
+export function computeStreak(counts: Record<string, number>, todayMs: number): number {
+  let t = atNoon(todayMs);
+  if (!counts[localDay(t)]) t -= DAY_MS;
+  let streak = 0;
+  while ((counts[localDay(t)] ?? 0) > 0) {
+    streak++;
+    t -= DAY_MS;
+  }
+  return streak;
+}
+
+/** "Tue, Jul 8" for a YYYY-MM-DD key, in the user's locale. */
+export function formatHeatDay(day: string): string {
+  const d = new Date(
+    Number(day.slice(0, 4)),
+    Number(day.slice(5, 7)) - 1,
+    Number(day.slice(8, 10)),
+  );
+  return d.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" });
+}

--- a/src/components/Stats/index.ts
+++ b/src/components/Stats/index.ts
@@ -1,0 +1,3 @@
+export { ActivityHeatmap } from "./ActivityHeatmap";
+export { buildHeatmapWeeks, computeStreak, formatHeatDay, heatLevel, monthLabels } from "./heatmap";
+export { CountUp, Stat, useCountUp } from "./Stat";

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -8,6 +8,7 @@ import { type ChatItem, getAdapter, type RawEvent } from "../adapters";
 import { hasUsage, usageFromRecords } from "../adapters/usage";
 import { api, type SessionRecord, type UserTurn, type Workspace } from "../api";
 import { commandsFor } from "../data/slashCommands";
+import { recordUsageSnapshot } from "../storage/usageDaily";
 import type { AppState, DraftAgent } from "../store";
 
 export function providerFor(state: AppState, agentId: string): string | undefined {
@@ -271,6 +272,8 @@ export async function persistLiveUsage(
     const usage = usageFromRecords(provider, records);
     if (hasUsage(usage)) {
       set({ usage: { ...get().usage, [agentId]: usage } });
+      const projectId = get().workspace?.agents.find((a) => a.id === agentId)?.project_id;
+      recordUsageSnapshot(agentId, projectId, usage);
     }
   } catch {
     // Non-critical: the next records refresh or restart re-folds it.

--- a/src/storage/usageDaily.ts
+++ b/src/storage/usageDaily.ts
@@ -1,0 +1,53 @@
+import type { AgentUsage } from "@/adapters/usage";
+import { localDay } from "@/util/format";
+import { dbUpsert } from "./db";
+
+// Daily token-usage snapshots (usage_daily table): one row per (workspace,
+// local day) holding the session's CUMULATIVE totals as of the last fold that
+// day. Cumulative — not per-day deltas — because some providers (codex) only
+// report running totals; a day's spend is the difference between consecutive
+// snapshots. Written opportunistically from every place usage is re-folded
+// from session_records, so history accrues as the app is used.
+
+// Last written fingerprint per workspace, so re-folds that didn't change the
+// totals (the common refresh case) never touch the DB.
+const lastWritten = new Map<string, string>();
+
+/** Upsert today's cumulative usage snapshot for a workspace. Fire-and-forget:
+ *  failures are logged, never thrown — stats are best-effort by design. No-op
+ *  when the project is unknown or the totals haven't changed since the last
+ *  write this session. */
+export function recordUsageSnapshot(
+  workspaceId: string,
+  projectId: string | undefined,
+  usage: AgentUsage,
+): void {
+  if (!workspaceId || !projectId) return;
+  const now = Date.now();
+  const day = localDay(now);
+  const fingerprint = [
+    day,
+    usage.inputTokens,
+    usage.outputTokens,
+    usage.cacheReadTokens,
+    usage.cacheWriteTokens,
+    usage.costUsd,
+  ].join("|");
+  if (lastWritten.get(workspaceId) === fingerprint) return;
+  lastWritten.set(workspaceId, fingerprint);
+  dbUpsert(
+    "usage_daily",
+    {
+      workspace_id: workspaceId,
+      project_id: projectId,
+      day,
+      input_tokens: usage.inputTokens,
+      output_tokens: usage.outputTokens,
+      cache_read_tokens: usage.cacheReadTokens,
+      cache_write_tokens: usage.cacheWriteTokens,
+      cost_usd: usage.costUsd,
+      updated_at: now,
+    },
+    "workspace_id,day",
+  ).catch((err) => console.error("usage snapshot failed", err));
+}

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -33,7 +33,6 @@ import {
 import { pushAgentOutput, pushShellOutput } from "@/pty/buffers";
 import { decodeBase64 } from "@/pty/decode";
 import { getOrCreateAccount, toProfile } from "@/storage/accounts";
-import { recordUsageSnapshot } from "@/storage/usageDaily";
 import {
   DEFAULT_LEFT_WIDTH,
   DEFAULT_RIGHT_WIDTH,
@@ -48,6 +47,7 @@ import {
   type WorkspaceView,
 } from "@/storage/preferences";
 import { getAllSettings } from "@/storage/settings";
+import { recordUsageSnapshot } from "@/storage/usageDaily";
 import { checkForUpdate } from "@/util/autoUpdate";
 import { notify } from "@/util/notify";
 import { playAgentDone } from "@/util/sound";

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -32,6 +32,7 @@ import {
 import { pushAgentOutput, pushShellOutput } from "@/pty/buffers";
 import { decodeBase64 } from "@/pty/decode";
 import { getOrCreateAccount, toProfile } from "@/storage/accounts";
+import { recordUsageSnapshot } from "@/storage/usageDaily";
 import {
   DEFAULT_LEFT_WIDTH,
   DEFAULT_RIGHT_WIDTH,
@@ -263,6 +264,10 @@ const registerEventListeners = async (set: AppSet, get: AppGet) => {
           // live, so an empty records result must not wipe it.
           usage: hasUsage(usage) ? { ...state.usage, [id]: usage } : state.usage,
         }));
+        if (hasUsage(usage)) {
+          const projectId = get().workspace?.agents.find((a) => a.id === id)?.project_id;
+          recordUsageSnapshot(id, projectId, usage);
+        }
         // The first turn captures the agent's session id in the DB; pull it
         // into the live workspace so the Native toggle unblocks without a
         // reload. Only when still missing locally — avoids per-turn re-fetch.

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -11,6 +11,7 @@ import {
 } from "@/helpers";
 import { clearOutputBuffer } from "@/pty/buffers";
 import { setSetting } from "@/storage/settings";
+import { recordUsageSnapshot } from "@/storage/usageDaily";
 import { interruptedAgents } from "./interrupted";
 import type { AppState, SliceCreator, WorkspaceSlice } from "./types";
 
@@ -369,6 +370,10 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
       const turns = await api.readUserTurns(id);
       const items = applyUserTurns(reduceRecords(provider, records), turns);
       const usage = usageFromRecords(provider, records);
+      if (hasUsage(usage)) {
+        const projectId = get().workspace?.agents.find((a) => a.id === id)?.project_id;
+        recordUsageSnapshot(id, projectId, usage);
+      }
       set((state) => {
         // Nothing stored but a live turn is already rendering — don't clobber it.
         if (items.length === 0 && (state.managedLogs[id]?.length ?? 0) > 0) {

--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -44,6 +44,15 @@ export function accountInitials(first: string, last: string, email = ""): string
   return e ? e.toUpperCase() : "?";
 }
 
+/** Local calendar date key (YYYY-MM-DD) — matches SQLite's
+ *  `date(…, 'localtime')`, so frontend-derived days join cleanly against
+ *  SQL-bucketed ones. */
+export function localDay(ms: number): string {
+  const d = new Date(ms);
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+}
+
 export function formatTokens(n: number): string {
   if (n < 1_000) return `${n}`;
   if (n < 1_000_000) return `${(n / 1_000).toFixed(n < 10_000 ? 1 : 0)}k`;

--- a/tests/components/RunConfig/runSettings.test.ts
+++ b/tests/components/RunConfig/runSettings.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Back the projectSettings layer with an in-memory map so the two run-config
+// scopes (project `run.<id>`, agent `run.agent.<agentId>.<id>`) can be
+// exercised without a real Tauri backend.
+let stored: Record<string, string> = {};
+
+vi.mock("@/storage/projectSettings", () => ({
+  getProjectSettings: async () => ({ ...stored }),
+  setProjectSetting: async (_p: string, key: string, value: string) => {
+    stored[key] = value;
+  },
+  deleteProjectSetting: async (_p: string, key: string) => {
+    delete stored[key];
+  },
+}));
+
+import { loadRunOverrides, persistRunOverrides } from "@/components/RunConfig";
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe("run settings scoping", () => {
+  beforeEach(() => {
+    stored = {};
+  });
+
+  it("loads project-scope values without slurping agent-scoped keys", async () => {
+    stored = {
+      "run.dev": "npm run dev",
+      "run.agent.a1.dev": "npm run dev -- --port 4000",
+      "other.key": "ignored",
+    };
+    await expect(loadRunOverrides("p1")).resolves.toEqual({ dev: "npm run dev" });
+  });
+
+  it("loads only the requested agent's overrides", async () => {
+    stored = {
+      "run.dev": "npm run dev",
+      "run.agent.a1.dev": "bun dev",
+      "run.agent.a1.port": "4000",
+      "run.agent.a2.dev": "yarn dev",
+    };
+    await expect(loadRunOverrides("p1", "a1")).resolves.toEqual({ dev: "bun dev", port: "4000" });
+    await expect(loadRunOverrides("p1", "a2")).resolves.toEqual({ dev: "yarn dev" });
+  });
+
+  it("persists to the project scope by default and the agent scope when given", async () => {
+    persistRunOverrides("p1", [{ id: "dev", value: "bun dev" }], []);
+    persistRunOverrides("p1", [{ id: "port", value: "4000" }], [], "a1");
+    await flush();
+    expect(stored).toEqual({ "run.dev": "bun dev", "run.agent.a1.port": "4000" });
+  });
+
+  it("deletes from the matching scope only", async () => {
+    stored = { "run.dev": "bun dev", "run.agent.a1.dev": "yarn dev" };
+    persistRunOverrides("p1", [], ["dev"], "a1");
+    await flush();
+    expect(stored).toEqual({ "run.dev": "bun dev" });
+    persistRunOverrides("p1", [], ["dev"]);
+    await flush();
+    expect(stored).toEqual({});
+  });
+});

--- a/tests/components/Stats/heatmap.test.ts
+++ b/tests/components/Stats/heatmap.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { buildHeatmapWeeks, computeStreak, heatLevel, monthLabels } from "@/components/Stats";
+import { localDay } from "@/util/format";
+
+// A fixed reference point: Wed 2026-07-08, noon local.
+const WED = new Date(2026, 6, 8, 12).getTime();
+const DAY = 86_400_000;
+
+describe("buildHeatmapWeeks", () => {
+  it("builds weeks × 7 Monday-first columns ending in the current week", () => {
+    const grid = buildHeatmapWeeks(WED, 4, {});
+    expect(grid).toHaveLength(4);
+    for (const col of grid) expect(col).toHaveLength(7);
+    // Last column starts the Monday of the reference week…
+    expect(grid[3][0].day).toBe("2026-07-06");
+    // …and the first column starts three Mondays earlier.
+    expect(grid[0][0].day).toBe("2026-06-15");
+  });
+
+  it("marks days after the reference point as out of range", () => {
+    const grid = buildHeatmapWeeks(WED, 2, {});
+    const last = grid[1];
+    // Mon Jul 6 … Wed Jul 8 are real; Thu Jul 9 … Sun Jul 12 are padding.
+    expect(last.map((c) => c.inRange)).toEqual([true, true, true, false, false, false, false]);
+  });
+
+  it("attaches counts by day key, defaulting to zero", () => {
+    const grid = buildHeatmapWeeks(WED, 1, { "2026-07-07": 5 });
+    expect(grid[0][1]).toMatchObject({ day: "2026-07-07", count: 5 });
+    expect(grid[0][0].count).toBe(0);
+  });
+});
+
+describe("monthLabels", () => {
+  it("labels columns that enter a new month, plus a first column near a boundary", () => {
+    // 6 weeks ending Jul 8: columns start Jun 1, 8, 15, 22, 29, Jul 6.
+    const labels = monthLabels(buildHeatmapWeeks(WED, 6, {}));
+    expect(labels).toEqual(["Jun", null, null, null, null, "Jul"]);
+  });
+
+  it("suppresses a mid-month label on the left edge", () => {
+    const labels = monthLabels(buildHeatmapWeeks(WED, 4, {}));
+    expect(labels).toEqual([null, null, null, "Jul"]);
+  });
+});
+
+describe("heatLevel", () => {
+  it("maps zero to level 0 and scales the rest to the max", () => {
+    expect(heatLevel(0, 8)).toBe(0);
+    expect(heatLevel(1, 8)).toBe(1);
+    expect(heatLevel(4, 8)).toBe(2);
+    expect(heatLevel(8, 8)).toBe(4);
+  });
+
+  it("never exceeds 4 and floors nonzero counts at 1", () => {
+    expect(heatLevel(100, 8)).toBe(4);
+    expect(heatLevel(1, 1000)).toBe(1);
+  });
+});
+
+describe("computeStreak", () => {
+  const days = (offsets: number[]) =>
+    Object.fromEntries(offsets.map((o) => [localDay(WED - o * DAY), 1]));
+
+  it("counts consecutive active days ending today", () => {
+    expect(computeStreak(days([0, 1, 2]), WED)).toBe(3);
+  });
+
+  it("doesn't break the streak when today has no activity yet", () => {
+    expect(computeStreak(days([1, 2, 3]), WED)).toBe(3);
+  });
+
+  it("stops at the first gap", () => {
+    expect(computeStreak(days([0, 1, 3, 4]), WED)).toBe(2);
+    expect(computeStreak(days([2, 3]), WED)).toBe(0);
+  });
+
+  it("is zero with no activity at all", () => {
+    expect(computeStreak({}, WED)).toBe(0);
+  });
+});

--- a/tests/storage/usageDaily.test.ts
+++ b/tests/storage/usageDaily.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const upserts: Array<{ table: string; data: Record<string, unknown>; conflict: string }> = [];
+
+vi.mock("@/storage/db", () => ({
+  dbUpsert: async (table: string, data: Record<string, unknown>, conflict: string) => {
+    upserts.push({ table, data, conflict });
+    return "ok";
+  },
+}));
+
+import { EMPTY_USAGE } from "@/adapters/usage";
+import { recordUsageSnapshot } from "@/storage/usageDaily";
+import { localDay } from "@/util/format";
+
+const usage = (input: number, output: number, cost = 0) => ({
+  ...EMPTY_USAGE,
+  inputTokens: input,
+  outputTokens: output,
+  costUsd: cost,
+});
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe("recordUsageSnapshot", () => {
+  beforeEach(() => {
+    upserts.length = 0;
+  });
+
+  it("upserts today's cumulative snapshot keyed by workspace and day", async () => {
+    recordUsageSnapshot("ws1", "p1", usage(100, 50, 0.25));
+    await flush();
+    expect(upserts).toHaveLength(1);
+    expect(upserts[0].table).toBe("usage_daily");
+    expect(upserts[0].conflict).toBe("workspace_id,day");
+    expect(upserts[0].data).toMatchObject({
+      workspace_id: "ws1",
+      project_id: "p1",
+      day: localDay(Date.now()),
+      input_tokens: 100,
+      output_tokens: 50,
+      cost_usd: 0.25,
+    });
+  });
+
+  it("skips a re-fold with unchanged totals, writes again when they grow", async () => {
+    recordUsageSnapshot("ws2", "p1", usage(100, 50));
+    recordUsageSnapshot("ws2", "p1", usage(100, 50));
+    recordUsageSnapshot("ws2", "p1", usage(120, 60));
+    await flush();
+    expect(upserts).toHaveLength(2);
+    expect(upserts[1].data).toMatchObject({ input_tokens: 120, output_tokens: 60 });
+  });
+
+  it("is a no-op without a project id", async () => {
+    recordUsageSnapshot("ws3", undefined, usage(10, 5));
+    await flush();
+    expect(upserts).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What

Reframes how run configuration is edited across the two surfaces and adds a real per-agent override layer.

### Project Settings — Run & environment
- Editing a value simply makes it the project setting: no more "Manual override" label, no accent/override styling, no "N overrides" counter, and no revert button. Detected values remain as pre-filled defaults with their "Detected · source" caption; clearing an edited field falls back to the detected value.

### Run panel (per agent)
- The sheet now layers **per-agent overrides** on top of the project's effective values (project setting when set, else detected), stored as `run.agent.<agentId>.<key>` in `project_settings`.
- Rows inherited from a project setting are captioned "Project setting"; an agent-level edit is marked "Overrides project setting" (or "Overrides project default"), with a matching revert action.
- The runner resolves commands agent override → project setting → detected (`read_run_commands`), so what runs matches what the panel shows. Existing `run.*` values keep working unchanged as project settings.

### UI polish
- The value chip is now one persistent input instead of a button/input swap, so the view↔edit transition animates border, focus ring, icon, and width. Width is sized in `ch` units (monospace-exact) rather than DOM measurement, fixing mis-truncation like `bun inst…`.

## Tests
- New `tests/components/RunConfig/runSettings.test.ts` covering key scoping: project loads don't slurp agent keys; per-agent load/persist/delete hit the right scope.
- Full suite green: 356 tests, tsc, biome, cargo check.

## Notes
- Deleting an agent leaves its `run.agent.<id>.*` rows behind (harmless; cleanup on agent deletion is a possible follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)