### PR TITLE
feat(run): port safety — fall back to next free port on conflict

### DIFF
--- a/src-tauri/src/run_detect/mod.rs
+++ b/src-tauri/src/run_detect/mod.rs
@@ -18,7 +18,7 @@ use std::path::Path;
 
 mod go;
 mod node;
-mod port;
+pub(crate) mod port;
 mod python;
 mod ruby;
 mod rust;

--- a/src-tauri/src/run_detect/port.rs
+++ b/src-tauri/src/run_detect/port.rs
@@ -16,6 +16,16 @@ pub fn detect_port(dev_cmd: &str, deps: &[String]) -> Option<(u16, String)> {
 /// forms: `--port 3001`, `--port=3001`, `-p 3001`, `PORT=3001`, `:3001`.
 fn explicit_port(cmd: &str) -> Option<u16> {
     let tokens: Vec<&str> = cmd.split_whitespace().collect();
+    find_port_token(&tokens).map(|(_, port)| port)
+}
+
+/// Locate the first explicit port token in `tokens`, returning the index of
+/// the token that carries the numeric value and the parsed port. For the
+/// space-separated forms (`--port N`, `-p N`) that's the *value* token
+/// (`i + 1`), not the flag; for the fused forms (`--port=N`, `:N`) it's the
+/// token itself. Shared by [`explicit_port`] and [`rewrite_explicit_port`] so
+/// the recognized forms never drift.
+fn find_port_token(tokens: &[&str]) -> Option<(usize, u16)> {
     for (i, tok) in tokens.iter().enumerate() {
         // --port=N / -p=N / PORT=N
         if let Some(rest) = tok
@@ -24,20 +34,65 @@ fn explicit_port(cmd: &str) -> Option<u16> {
             .or_else(|| tok.strip_prefix("PORT="))
         {
             if let Ok(p) = rest.parse() {
-                return Some(p);
+                return Some((i, p));
             }
         }
         // --port N / -p N (value in the next token)
         if (*tok == "--port" || *tok == "-p") && i + 1 < tokens.len() {
             if let Ok(p) = tokens[i + 1].parse() {
-                return Some(p);
+                return Some((i + 1, p));
             }
         }
         // bare :N (e.g. "serve :8080")
         if let Some(rest) = tok.strip_prefix(':') {
             if let Ok(p) = rest.parse() {
-                return Some(p);
+                return Some((i, p));
             }
+        }
+    }
+    None
+}
+
+/// Rewrite the first explicit port token in `cmd` to `new_port`, preserving the
+/// token's form (`--port=N`, `-p N`, `:N`, `PORT=N`, …). Returns `None` when
+/// `cmd` has no explicit port token — the caller then relies on the `PORT` env
+/// var alone. Tokens are rejoined on single spaces, which is fine for the
+/// simple dev commands detection targets.
+pub fn rewrite_explicit_port(cmd: &str, new_port: u16) -> Option<String> {
+    let mut tokens: Vec<String> = cmd.split_whitespace().map(|s| s.to_string()).collect();
+    let refs: Vec<&str> = tokens.iter().map(|s| s.as_str()).collect();
+    let (idx, _) = find_port_token(&refs)?;
+    let tok = &tokens[idx];
+    // Rebuild the value token in its original form. The value token is either a
+    // bare number (space-separated form) or `<prefix>=<n>` / `:<n>`.
+    let rewritten = if let Some(prefix) = tok
+        .strip_prefix("--port=")
+        .map(|_| "--port=")
+        .or_else(|| tok.strip_prefix("-p=").map(|_| "-p="))
+        .or_else(|| tok.strip_prefix("PORT=").map(|_| "PORT="))
+    {
+        format!("{prefix}{new_port}")
+    } else if tok.starts_with(':') {
+        format!(":{new_port}")
+    } else {
+        // Space-separated form: the token is the bare number.
+        new_port.to_string()
+    };
+    tokens[idx] = rewritten;
+    Some(tokens.join(" "))
+}
+
+/// Find the first free TCP port at or after `start`, scanning `start`,
+/// `start + 1`, … up to and including `start + cap`. "Free" means we can bind
+/// `127.0.0.1:<port>` right now (the listener is dropped immediately, releasing
+/// it for the dev server to claim). Returns `None` if every port in the range
+/// is taken. Binding-to-test is the standard technique; there is no lighter
+/// primitive that also honors the "your port, then +1, +2, …" order.
+pub fn find_free_port(start: u16, cap: u16) -> Option<u16> {
+    for offset in 0..=cap {
+        let port = start.checked_add(offset)?;
+        if std::net::TcpListener::bind(("127.0.0.1", port)).is_ok() {
+            return Some(port);
         }
     }
     None
@@ -129,5 +184,76 @@ mod tests {
     #[test]
     fn empty_is_none() {
         assert!(detect_port("", &[]).is_none());
+    }
+
+    // ── rewrite_explicit_port ──────────────────────────────────────────────
+
+    #[test]
+    fn rewrite_space_separated() {
+        assert_eq!(
+            rewrite_explicit_port("vite --port 3000", 3001).unwrap(),
+            "vite --port 3001"
+        );
+    }
+
+    #[test]
+    fn rewrite_short_flag() {
+        assert_eq!(
+            rewrite_explicit_port("next dev -p 3000", 3005).unwrap(),
+            "next dev -p 3005"
+        );
+    }
+
+    #[test]
+    fn rewrite_equals_form() {
+        assert_eq!(
+            rewrite_explicit_port("vite --port=3000", 3002).unwrap(),
+            "vite --port=3002"
+        );
+    }
+
+    #[test]
+    fn rewrite_env_assignment() {
+        assert_eq!(
+            rewrite_explicit_port("PORT=3000 node server.js", 3003).unwrap(),
+            "PORT=3003 node server.js"
+        );
+    }
+
+    #[test]
+    fn rewrite_colon_form() {
+        assert_eq!(
+            rewrite_explicit_port("serve :8080", 8081).unwrap(),
+            "serve :8081"
+        );
+    }
+
+    #[test]
+    fn rewrite_none_when_no_token() {
+        assert!(rewrite_explicit_port("pnpm dev", 3001).is_none());
+    }
+
+    // ── find_free_port ─────────────────────────────────────────────────────
+
+    #[test]
+    fn free_port_returns_start_when_open() {
+        // Bind an ephemeral port to learn a definitely-free number, release it,
+        // then confirm the finder returns it as the start.
+        let probe = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = probe.local_addr().unwrap().port();
+        drop(probe);
+        assert_eq!(find_free_port(port, 30), Some(port));
+    }
+
+    #[test]
+    fn free_port_skips_occupied() {
+        // Hold a listener open on `port`, so the finder must skip to `port + 1`.
+        let held = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = held.local_addr().unwrap().port();
+        // Guard against the (rare) chance port+1 is also busy on the test host.
+        assert!(port < u16::MAX);
+        let found = find_free_port(port, 30).unwrap();
+        assert_ne!(found, port);
+        assert!(found > port);
     }
 }

--- a/src-tauri/src/supervisor/events.rs
+++ b/src-tauri/src/supervisor/events.rs
@@ -297,6 +297,27 @@ pub(super) fn emit_run_state(
     );
 }
 
+#[derive(Clone, serde::Serialize)]
+struct RunPortPayload {
+    agent_id: String,
+    port: u16,
+}
+
+/// The port the dev server is actually being launched on — emitted just before
+/// the Run panel's dev phase spawns. May differ from the configured port when
+/// port-safety bumped it to the next free one; the frontend uses this to render
+/// the correct `localhost:<port>` link and sidebar indicator.
+pub(super) fn emit_run_port(app: &AppHandle, agent_id: &str, port: u16) {
+    emit(
+        app,
+        "run:port",
+        RunPortPayload {
+            agent_id: agent_id.to_string(),
+            port,
+        },
+    );
+}
+
 /// Structural workspace change (archive/restore) — the frontend reloads the
 /// whole workspace on this signal rather than patching from finer events.
 pub(super) fn emit_workspace_changed(app: &AppHandle) {

--- a/src-tauri/src/supervisor/run.rs
+++ b/src-tauri/src/supervisor/run.rs
@@ -35,7 +35,8 @@ impl Supervisor {
             .ok_or_else(|| Error::Other("agent has no repos".into()))?;
         let cwd = repo_checkout_path(agent_id, &primary.subdir)?;
 
-        let (setup_cmd, run_cmd) = self.read_run_commands(&record.project_id, &cwd);
+        let (setup_cmd, run_cmd, intended_port) =
+            self.read_run_config(&record.project_id, &cwd);
         let setup_done = self.workspace.is_setup_completed(agent_id)?;
 
         let session = {
@@ -58,9 +59,10 @@ impl Supervisor {
         // Secure a free port for the dev phase *before* flipping the session
         // active, so a "no free port" failure surfaces cleanly without leaving
         // the button stuck. Setup runs unchanged; its chained run is prepared
-        // later, in handle_run_phase_exit, closer to its own spawn.
+        // later, in handle_run_phase_exit, closer to its own spawn — the
+        // intended port rides along so that pass reuses this detection.
         let prepared = if plan.first_phase == RunPhase::Running {
-            match self.prepare_run(&record.project_id, &cwd, &plan.first_cmd) {
+            match prepare_run(&plan.first_cmd, intended_port) {
                 Ok(p) => p,
                 Err(e) => {
                     let msg = format!("Failed to start command: {e}");
@@ -73,10 +75,13 @@ impl Supervisor {
         };
 
         let gen = session.begin_phase(plan.first_phase);
-        emit_run_state(&app, agent_id, plan.first_phase, None);
+        // Emit the resolved port *before* the state flips to running, so the
+        // store already holds the correct port when the UI reacts to
+        // `run:state` — otherwise the link/label briefly shows the old port.
         if let Some(port) = prepared.port {
             emit_run_port(&app, agent_id, port);
         }
+        emit_run_state(&app, agent_id, plan.first_phase, None);
         write_header(&app, agent_id, &session, &prepared.cmd);
         if let Some(note) = &prepared.note {
             write_note(&app, agent_id, &session, note);
@@ -93,7 +98,7 @@ impl Supervisor {
             session.clone(),
             gen,
             cwd,
-            record.project_id.clone(),
+            intended_port,
             plan.first_phase,
             prepared.cmd,
             prepared.extra_env,
@@ -140,90 +145,41 @@ impl Supervisor {
         }
     }
 
-    /// Read the setup + run commands for an agent. The detector provides
-    /// the baseline (same values the panel shows), and any persisted
-    /// `run.install` / `run.dev` overrides in project_settings take
-    /// precedence. One detector feeds both the panel and the runner, so
-    /// there is no hardcoded default to keep in sync.
-    fn read_run_commands(&self, project_id: &str, checkout: &Path) -> (String, String) {
+    /// Read the setup + run commands and the intended dev-server port for an
+    /// agent, from a single detection pass. The detector provides the baseline
+    /// (same values the panel shows), and any persisted `run.install` /
+    /// `run.dev` / `run.port` overrides in project_settings take precedence. One
+    /// detector feeds both the panel and the runner, so there is no hardcoded
+    /// default to keep in sync. The port is `None` when none can be inferred
+    /// (e.g. a plain script) — port safety is then a no-op.
+    fn read_run_config(&self, project_id: &str, checkout: &Path) -> (String, String, Option<u16>) {
         let configs = crate::run_detect::detect_all(checkout);
-        let detected = |id: &str| -> String {
+        let detected = |id: &str| -> Option<String> {
             configs
                 .first()
                 .and_then(|c| c.rows.iter().find(|r| r.id == id))
                 .map(|r| r.value.clone())
-                .unwrap_or_default()
         };
-        let install_default = detected("install");
-        let dev_default = detected("dev");
-        if project_id.is_empty() {
-            return (install_default, dev_default);
-        }
-        (
-            self.workspace
-                .project_setting(project_id, "run.install")
-                .unwrap_or(install_default),
-            self.workspace
-                .project_setting(project_id, "run.dev")
-                .unwrap_or(dev_default),
-        )
-    }
+        let install_default = detected("install").unwrap_or_default();
+        let dev_default = detected("dev").unwrap_or_default();
+        let port_default = detected("port");
 
-    /// Resolve the intended dev-server port the same way the panel does:
-    /// the detected `port` row, overridden by the `run.port` project setting
-    /// when present. `None` when no port can be inferred (e.g. a plain script
-    /// or an ecosystem with no port concept) — port safety is then a no-op.
-    fn read_run_port(&self, project_id: &str, checkout: &Path) -> Option<u16> {
-        let configs = crate::run_detect::detect_all(checkout);
-        let detected = configs
-            .first()
-            .and_then(|c| c.rows.iter().find(|r| r.id == "port"))
-            .map(|r| r.value.clone());
-        let raw = if project_id.is_empty() {
-            detected
+        let (install, dev, port_raw) = if project_id.is_empty() {
+            (install_default, dev_default, port_default)
         } else {
-            self.workspace
-                .project_setting(project_id, "run.port")
-                .or(detected)
+            (
+                self.workspace
+                    .project_setting(project_id, "run.install")
+                    .unwrap_or(install_default),
+                self.workspace
+                    .project_setting(project_id, "run.dev")
+                    .unwrap_or(dev_default),
+                self.workspace
+                    .project_setting(project_id, "run.port")
+                    .or(port_default),
+            )
         };
-        raw.and_then(|s| s.trim().parse::<u16>().ok())
-    }
-
-    /// Prepare a dev command for spawn with port safety: find a free port at or
-    /// after the configured one (scanning up to [`PORT_SCAN_CAP`] past it) and
-    /// force the dev server onto it — via a `PORT` env var and, when the command
-    /// carries an explicit port token, by rewriting that token too. When the
-    /// configured port is already free the command is unchanged (only `PORT` is
-    /// pinned). Returns a passthrough when no port is inferred, and errors when
-    /// every port in range is taken.
-    fn prepare_run(&self, project_id: &str, cwd: &Path, run_cmd: &str) -> Result<PreparedRun> {
-        let Some(intended) = self.read_run_port(project_id, cwd) else {
-            return Ok(PreparedRun::passthrough(run_cmd.to_string()));
-        };
-        let chosen = crate::run_detect::port::find_free_port(intended, PORT_SCAN_CAP)
-            .ok_or_else(|| {
-                Error::Other(format!(
-                    "No free port available in {}\u{2013}{}",
-                    intended,
-                    intended.saturating_add(PORT_SCAN_CAP)
-                ))
-            })?;
-
-        let mut cmd = run_cmd.to_string();
-        let mut note = None;
-        if chosen != intended {
-            if let Some(rewritten) = crate::run_detect::port::rewrite_explicit_port(run_cmd, chosen)
-            {
-                cmd = rewritten;
-            }
-            note = Some(format!("Port {intended} in use — using {chosen}"));
-        }
-        Ok(PreparedRun {
-            cmd,
-            extra_env: vec![("PORT".to_string(), chosen.to_string())],
-            note,
-            port: Some(chosen),
-        })
+        (install, dev, port_raw.and_then(|s| s.trim().parse::<u16>().ok()))
     }
 
     /// Detect the run configuration for an agent's primary repo,
@@ -311,6 +267,45 @@ impl PreparedRun {
     }
 }
 
+/// Prepare a dev command for spawn with port safety: given the already-resolved
+/// `intended` port (see [`Supervisor::read_run_config`]), find a free port at or
+/// after it (scanning up to [`PORT_SCAN_CAP`] past it) and force the dev server
+/// onto it — via a `PORT` env var and, when the command carries an explicit port
+/// token, by rewriting that token too. When the intended port is already free
+/// the command is unchanged (only `PORT` is pinned). Returns a passthrough when
+/// no port was inferred, and errors when every port in range is taken.
+///
+/// The free-port probe runs here, right before spawn, rather than at click time:
+/// setup/install can take minutes, so a port checked earlier may be gone by the
+/// time the dev server actually binds.
+fn prepare_run(run_cmd: &str, intended: Option<u16>) -> Result<PreparedRun> {
+    let Some(intended) = intended else {
+        return Ok(PreparedRun::passthrough(run_cmd.to_string()));
+    };
+    let chosen = crate::run_detect::port::find_free_port(intended, PORT_SCAN_CAP).ok_or_else(|| {
+        Error::Other(format!(
+            "No free port available in {}\u{2013}{}",
+            intended,
+            intended.saturating_add(PORT_SCAN_CAP)
+        ))
+    })?;
+
+    let mut cmd = run_cmd.to_string();
+    let mut note = None;
+    if chosen != intended {
+        if let Some(rewritten) = crate::run_detect::port::rewrite_explicit_port(run_cmd, chosen) {
+            cmd = rewritten;
+        }
+        note = Some(format!("Port {intended} in use — using {chosen}"));
+    }
+    Ok(PreparedRun {
+        cmd,
+        extra_env: vec![("PORT".to_string(), chosen.to_string())],
+        note,
+        port: Some(chosen),
+    })
+}
+
 /// The phases to spawn for a single `run_start`, derived from the
 /// resolved commands and whether setup has already completed.
 #[derive(Debug)]
@@ -359,7 +354,7 @@ fn spawn_run_phase(
     session: Arc<RunSession>,
     gen: u64,
     cwd: std::path::PathBuf,
-    project_id: String,
+    chain_port: Option<u16>,
     phase: RunPhase,
     cmd: String,
     extra_env: Vec<(String, String)>,
@@ -402,7 +397,7 @@ fn spawn_run_phase(
                 session_exit.clone(),
                 gen,
                 cwd_exit.clone(),
-                project_id.clone(),
+                chain_port,
                 phase,
                 exit,
                 chain_run_cmd.clone(),
@@ -523,7 +518,7 @@ fn handle_run_phase_exit(
     session: Arc<RunSession>,
     gen: u64,
     cwd: std::path::PathBuf,
-    project_id: String,
+    chain_port: Option<u16>,
     phase: RunPhase,
     exit: crate::pty_session::PtyExit,
     chain_run_cmd: Option<String>,
@@ -547,8 +542,9 @@ fn handle_run_phase_exit(
         }
         if let Some(run_cmd) = chain_run_cmd {
             // Secure a free port now — install may have run for minutes, so the
-            // port could have been taken since the click.
-            let prepared = match sup.prepare_run(&project_id, &cwd, &run_cmd) {
+            // port could have been taken since the click. The intended port was
+            // resolved at run_start and threaded here, so no re-detection.
+            let prepared = match prepare_run(&run_cmd, chain_port) {
                 Ok(p) => p,
                 Err(e) => {
                     let msg = format!("Failed to start run command: {e}");
@@ -558,10 +554,12 @@ fn handle_run_phase_exit(
                 }
             };
             session.transition_phase(RunPhase::Running);
-            emit_run_state(&app, &agent_id, RunPhase::Running, None);
+            // Emit the resolved port before the running state so the store holds
+            // it before the UI reacts (see run_start for the same ordering).
             if let Some(port) = prepared.port {
                 emit_run_port(&app, &agent_id, port);
             }
+            emit_run_state(&app, &agent_id, RunPhase::Running, None);
             write_header(&app, &agent_id, &session, &prepared.cmd);
             if let Some(note) = &prepared.note {
                 write_note(&app, &agent_id, &session, note);
@@ -573,7 +571,7 @@ fn handle_run_phase_exit(
                 session.clone(),
                 gen,
                 cwd,
-                project_id.clone(),
+                None,
                 RunPhase::Running,
                 prepared.cmd,
                 prepared.extra_env,

--- a/src-tauri/src/supervisor/run.rs
+++ b/src-tauri/src/supervisor/run.rs
@@ -9,8 +9,11 @@ use crate::error::{Error, Result};
 use crate::run_session::{self, shell_args, user_shell, RunPhase, RunSession, RunStateSnapshot};
 use crate::workspace::repo_checkout_path;
 
-use super::events::{emit_run_output, emit_run_state};
+use super::events::{emit_run_output, emit_run_port, emit_run_state};
 use super::Supervisor;
+
+/// How far past the configured port to scan for a free one before giving up.
+const PORT_SCAN_CAP: u16 = 30;
 
 impl Supervisor {
     /// Start the Run-panel process for an agent.
@@ -52,9 +55,32 @@ impl Supervisor {
             return Ok(());
         };
 
+        // Secure a free port for the dev phase *before* flipping the session
+        // active, so a "no free port" failure surfaces cleanly without leaving
+        // the button stuck. Setup runs unchanged; its chained run is prepared
+        // later, in handle_run_phase_exit, closer to its own spawn.
+        let prepared = if plan.first_phase == RunPhase::Running {
+            match self.prepare_run(&record.project_id, &cwd, &plan.first_cmd) {
+                Ok(p) => p,
+                Err(e) => {
+                    let msg = format!("Failed to start command: {e}");
+                    emit_run_state(&app, agent_id, RunPhase::Stopped, Some(msg));
+                    return Err(e);
+                }
+            }
+        } else {
+            PreparedRun::passthrough(plan.first_cmd.clone())
+        };
+
         let gen = session.begin_phase(plan.first_phase);
         emit_run_state(&app, agent_id, plan.first_phase, None);
-        write_header(&app, agent_id, &session, &plan.first_cmd);
+        if let Some(port) = prepared.port {
+            emit_run_port(&app, agent_id, port);
+        }
+        write_header(&app, agent_id, &session, &prepared.cmd);
+        if let Some(note) = &prepared.note {
+            write_note(&app, agent_id, &session, note);
+        }
 
         // begin_phase already flipped the session active. If the spawn fails we
         // must reset to Stopped — otherwise is_active() stays true and every
@@ -67,8 +93,10 @@ impl Supervisor {
             session.clone(),
             gen,
             cwd,
+            record.project_id.clone(),
             plan.first_phase,
-            plan.first_cmd,
+            prepared.cmd,
+            prepared.extra_env,
             plan.chained_run_cmd,
         ) {
             let msg = format!("Failed to start command: {e}");
@@ -141,6 +169,63 @@ impl Supervisor {
         )
     }
 
+    /// Resolve the intended dev-server port the same way the panel does:
+    /// the detected `port` row, overridden by the `run.port` project setting
+    /// when present. `None` when no port can be inferred (e.g. a plain script
+    /// or an ecosystem with no port concept) — port safety is then a no-op.
+    fn read_run_port(&self, project_id: &str, checkout: &Path) -> Option<u16> {
+        let configs = crate::run_detect::detect_all(checkout);
+        let detected = configs
+            .first()
+            .and_then(|c| c.rows.iter().find(|r| r.id == "port"))
+            .map(|r| r.value.clone());
+        let raw = if project_id.is_empty() {
+            detected
+        } else {
+            self.workspace
+                .project_setting(project_id, "run.port")
+                .or(detected)
+        };
+        raw.and_then(|s| s.trim().parse::<u16>().ok())
+    }
+
+    /// Prepare a dev command for spawn with port safety: find a free port at or
+    /// after the configured one (scanning up to [`PORT_SCAN_CAP`] past it) and
+    /// force the dev server onto it — via a `PORT` env var and, when the command
+    /// carries an explicit port token, by rewriting that token too. When the
+    /// configured port is already free the command is unchanged (only `PORT` is
+    /// pinned). Returns a passthrough when no port is inferred, and errors when
+    /// every port in range is taken.
+    fn prepare_run(&self, project_id: &str, cwd: &Path, run_cmd: &str) -> Result<PreparedRun> {
+        let Some(intended) = self.read_run_port(project_id, cwd) else {
+            return Ok(PreparedRun::passthrough(run_cmd.to_string()));
+        };
+        let chosen = crate::run_detect::port::find_free_port(intended, PORT_SCAN_CAP)
+            .ok_or_else(|| {
+                Error::Other(format!(
+                    "No free port available in {}\u{2013}{}",
+                    intended,
+                    intended.saturating_add(PORT_SCAN_CAP)
+                ))
+            })?;
+
+        let mut cmd = run_cmd.to_string();
+        let mut note = None;
+        if chosen != intended {
+            if let Some(rewritten) = crate::run_detect::port::rewrite_explicit_port(run_cmd, chosen)
+            {
+                cmd = rewritten;
+            }
+            note = Some(format!("Port {intended} in use — using {chosen}"));
+        }
+        Ok(PreparedRun {
+            cmd,
+            extra_env: vec![("PORT".to_string(), chosen.to_string())],
+            note,
+            port: Some(chosen),
+        })
+    }
+
     /// Detect the run configuration for an agent's primary repo,
     /// ranked by confidence. The panel renders the first (highest
     /// confidence) entry; the rest are returned for future
@@ -194,6 +279,38 @@ fn write_header(app: &AppHandle, agent_id: &str, session: &Arc<RunSession>, cmd:
     emit_run_output(app, agent_id, bytes);
 }
 
+/// Inject a port-safety note (e.g. "Port 3000 in use — using 3001") into the
+/// log so the user understands why the dev server bound a different port.
+fn write_note(app: &AppHandle, agent_id: &str, session: &Arc<RunSession>, note: &str) {
+    let line = format!("\x1b[2m{note}\x1b[0m\r\n");
+    let bytes = line.into_bytes();
+    session.append_log(&bytes);
+    emit_run_output(app, agent_id, bytes);
+}
+
+/// A dev command prepared for spawn: the (possibly port-rewritten) command,
+/// extra env vars to inject (the pinned `PORT`), an optional user-facing note
+/// when the port was bumped, and the actual port to advertise to the UI.
+struct PreparedRun {
+    cmd: String,
+    extra_env: Vec<(String, String)>,
+    note: Option<String>,
+    port: Option<u16>,
+}
+
+impl PreparedRun {
+    /// A no-op preparation: run the command as-is, no port injection. Used for
+    /// the setup phase and for commands with no inferable port.
+    fn passthrough(cmd: String) -> Self {
+        Self {
+            cmd,
+            extra_env: Vec::new(),
+            note: None,
+            port: None,
+        }
+    }
+}
+
 /// The phases to spawn for a single `run_start`, derived from the
 /// resolved commands and whether setup has already completed.
 #[derive(Debug)]
@@ -234,6 +351,7 @@ fn plan_run_phases(setup_done: bool, setup_cmd: &str, run_cmd: &str) -> Option<R
 /// and the exit handler that chains setup→run or transitions to
 /// Stopped on natural exit. Out-of-band stops are handled via the
 /// generation check.
+#[allow(clippy::too_many_arguments)]
 fn spawn_run_phase(
     sup: Arc<Supervisor>,
     app: AppHandle,
@@ -241,8 +359,10 @@ fn spawn_run_phase(
     session: Arc<RunSession>,
     gen: u64,
     cwd: std::path::PathBuf,
+    project_id: String,
     phase: RunPhase,
     cmd: String,
+    extra_env: Vec<(String, String)>,
     chain_run_cmd: Option<String>,
 ) -> Result<()> {
     // Confine the run command to the checkout + toolchain caches. The command
@@ -250,7 +370,10 @@ fn spawn_run_phase(
     // config), so a malicious agent could otherwise plant a script that runs
     // unsandboxed with full user privilege the moment the user clicks ▶. Reads
     // and network stay open (dev servers need them); only writes are fenced.
-    let (program, args, env, profile_file) = sandboxed_run_command(&cwd, &cmd)?;
+    let (program, args, mut env, profile_file) = sandboxed_run_command(&cwd, &cmd)?;
+    // Pin the resolved (port-safe) PORT last so it wins over anything the
+    // sandbox layer set.
+    env.extend(extra_env);
 
     let session_out = session.clone();
     let app_out = app.clone();
@@ -278,9 +401,10 @@ fn spawn_run_phase(
                 id_exit.clone(),
                 session_exit.clone(),
                 gen,
+                cwd_exit.clone(),
+                project_id.clone(),
                 phase,
                 exit,
-                cwd_exit.clone(),
                 chain_run_cmd.clone(),
             );
         },
@@ -391,15 +515,17 @@ fn run_target_git_common_dir(cwd: &Path) -> Option<PathBuf> {
     std::fs::canonicalize(&abs).ok()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn handle_run_phase_exit(
     sup: Arc<Supervisor>,
     app: AppHandle,
     agent_id: String,
     session: Arc<RunSession>,
     gen: u64,
+    cwd: std::path::PathBuf,
+    project_id: String,
     phase: RunPhase,
     exit: crate::pty_session::PtyExit,
-    cwd: std::path::PathBuf,
     chain_run_cmd: Option<String>,
 ) {
     // If the user clicked Stop (or started a fresh run), our
@@ -420,9 +546,26 @@ fn handle_run_phase_exit(
             tracing::warn!(error = %e, agent_id = %agent_id, "mark_setup_completed failed");
         }
         if let Some(run_cmd) = chain_run_cmd {
+            // Secure a free port now — install may have run for minutes, so the
+            // port could have been taken since the click.
+            let prepared = match sup.prepare_run(&project_id, &cwd, &run_cmd) {
+                Ok(p) => p,
+                Err(e) => {
+                    let msg = format!("Failed to start run command: {e}");
+                    session.mark_stopped(Some(msg.clone()));
+                    emit_run_state(&app, &agent_id, RunPhase::Stopped, Some(msg));
+                    return;
+                }
+            };
             session.transition_phase(RunPhase::Running);
             emit_run_state(&app, &agent_id, RunPhase::Running, None);
-            write_header(&app, &agent_id, &session, &run_cmd);
+            if let Some(port) = prepared.port {
+                emit_run_port(&app, &agent_id, port);
+            }
+            write_header(&app, &agent_id, &session, &prepared.cmd);
+            if let Some(note) = &prepared.note {
+                write_note(&app, &agent_id, &session, note);
+            }
             if let Err(e) = spawn_run_phase(
                 sup,
                 app.clone(),
@@ -430,8 +573,10 @@ fn handle_run_phase_exit(
                 session.clone(),
                 gen,
                 cwd,
+                project_id.clone(),
                 RunPhase::Running,
-                run_cmd,
+                prepared.cmd,
+                prepared.extra_env,
                 None,
             ) {
                 let msg = format!("Failed to start run command: {e}");

--- a/src/api.ts
+++ b/src/api.ts
@@ -333,6 +333,14 @@ export interface RunStateEvent {
   last_error: string | null;
 }
 
+/** The port the dev server is actually launching on — emitted just before the
+ *  run phase spawns. May differ from the configured port when port-safety
+ *  bumped it to the next free one. */
+export interface RunPortEvent {
+  agent_id: string;
+  port: number;
+}
+
 export interface ProviderProbe {
   id: string;
   version: string | null;
@@ -734,6 +742,10 @@ export function onRunOutput(cb: (e: RunOutputEvent) => void): Promise<UnlistenFn
 
 export function onRunState(cb: (e: RunStateEvent) => void): Promise<UnlistenFn> {
   return listen<RunStateEvent>("run:state", (event) => cb(event.payload));
+}
+
+export function onRunPort(cb: (e: RunPortEvent) => void): Promise<UnlistenFn> {
+  return listen<RunPortEvent>("run:port", (event) => cb(event.payload));
 }
 
 /** Fires per line (and at start/finish/failure) while the embedded docker agent

--- a/src/components/RightPanel/RunPanel.tsx
+++ b/src/components/RightPanel/RunPanel.tsx
@@ -171,12 +171,19 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
   const isActive = phase === "setup" || phase === "running";
   const linkLive = phase === "running";
 
-  // Publish the resolved port to the store so the sidebar's running indicator
-  // can show `:port`. The port isn't on the `run:state` event, so the panel —
-  // which already resolves detected value + overrides — is the source.
+  // While running, the backend owns the port (it may have bumped the configured
+  // one to the next free port and emits the real value via `run:port`). Prefer
+  // that store value for the link/label; fall back to the locally resolved
+  // (configured) port when idle.
+  const storePort = useAppStore((s) => s.runPorts[agent.id]);
+  const displayPort = storePort ?? port;
+
+  // Seed the store with the configured port so the sidebar indicator can show
+  // `:port` before a run starts — but only while idle, so we never clobber the
+  // backend's authoritative (possibly bumped) port during an active run.
   useEffect(() => {
-    if (port) setRunPort(agent.id, port);
-  }, [agent.id, port, setRunPort]);
+    if (port && !isActive) setRunPort(agent.id, port);
+  }, [agent.id, port, isActive, setRunPort]);
 
   const onPlay = () => {
     if (isActive) {
@@ -222,7 +229,7 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
         </div>
 
         <a
-          href={`http://localhost:${port}`}
+          href={`http://localhost:${displayPort}`}
           target="_blank"
           rel="noreferrer"
           className={`run-link text-xs${linkLive ? "" : " disabled"}`}
@@ -231,7 +238,7 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
           }}
         >
           <span className="colon">:</span>
-          <span className="port">{port}</span>
+          <span className="port">{displayPort}</span>
           <Icon name="external" size={10} />
         </a>
 

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -13,6 +13,7 @@ import {
   onAgentView,
   onDockerBuildProgress,
   onPrStateChanged,
+  onRunPort,
   onRunState,
   onSessionRecordsAppended,
   onShellOutput,
@@ -380,6 +381,13 @@ const registerEventListeners = async (set: AppSet, get: AppGet) => {
   // dot lit from another tab — this always-on listener owns `runPhases`.
   await onRunState((e) => {
     set((s) => ({ runPhases: { ...s.runPhases, [e.agent_id]: e.phase } }));
+  });
+
+  // The actual (possibly port-safety-bumped) port the dev server bound. Owns
+  // `runPorts` so the sidebar indicator and Run pane link reflect the real port
+  // even after a bump, and survive the RunPanel unmounting on a tab switch.
+  await onRunPort((e) => {
+    set((s) => ({ runPorts: { ...s.runPorts, [e.agent_id]: String(e.port) } }));
   });
 
   // Docker image-build progress (first docker spawn). Drives the build toast:


### PR DESCRIPTION
## What & why

When a user clicked ▶ in the Run pane, the dev server could fail if its configured port was already taken. Fletch now detects a busy port and falls back to the next free one (`+1`, `+2`, … up to `+30`) instead of failing.

**Key discovery that shaped this work:** the port shown in the Run pane was *display-only* — detected purely to render the `http://localhost:<port>` link and **never passed to the dev server**. So port safety required both finding a free port *and* actively forcing the dev server onto it.

## How

Resolution happens **immediately before the dev phase spawns** (both the direct-run and after-setup-chained paths), keeping the free-port check close to the actual bind even when install runs for minutes.

**Backend (Rust)**
- `run_detect/port.rs`: `find_free_port(start, cap)` (std `TcpListener::bind` loop — no new dependency) and `rewrite_explicit_port(cmd, port)`. Token scanning is shared with `explicit_port` so the recognized forms never drift. +6 unit tests.
- `supervisor/run.rs`: `read_run_port` (detected `port` row + `run.port` override, matching the UI) and `prepare_run`, which finds a free port, pins it via a `PORT` env var, rewrites an explicit `--port/-p/:N/PORT=` token when present, logs a `Port 3000 in use — using 3001` note, and errors cleanly when the whole range is taken.
- `supervisor/events.rs`: new `run:port` event carrying the actual bound port.

**Frontend**
- `api.ts` `onRunPort`/`RunPortEvent`; `store/app.ts` always-on listener owns the real port; `RunPanel.tsx` link/label show the actual port when running (sidebar already reads the store).

## Decisions
- Injection: `PORT` env var **and** token rewrite (covers explicit-port commands universally + PORT-respecting frameworks like Next/CRA/Remix/Nuxt).
- Iteration cap: **30**.

## Boundaries (as designed)
- A bare `vite`/`ng serve` on its framework default (no token, ignores `PORT`) isn't forced — but those frameworks already auto-pick a free port.
- Small TOCTOU window between check and the server's bind, minimized by checking just before spawn.

## Verification
- ✅ `cargo test` — 18 port tests + 6 `supervisor::run` tests pass; crate compiles clean
- ✅ Frontend `tsc --noEmit` and `biome check` clean
- ⏳ Interactive GUI click-through (occupy a port, click ▶, watch it bind the next one) not run headlessly

🤖 Generated with [Claude Code](https://claude.com/claude-code)