### PR TITLE
feat(project-settings): editable run config with fallback fields when nothing detected

### DIFF
--- a/src/components/ProjectSettings/RunEnvSection.tsx
+++ b/src/components/ProjectSettings/RunEnvSection.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
 import {
-  ECOSYSTEM_LABEL,
+  EcosystemBadge,
   persistRunOverrides,
   RunConfigEditor,
   reconcileOverrides,
+  rowsOrFallback,
   type SetupRow,
 } from "@/components/RunConfig";
 
@@ -17,7 +18,10 @@ interface Props {
 /** The run configuration every agent in the project inherits. Unlike the Run
  *  panel sheet — which stages a draft and applies on restart — this edits the
  *  project defaults directly, so changes autosave per row. */
-export function RunEnvSection({ projectId, rows, ecosystem, initialOverrides }: Props) {
+export function RunEnvSection({ projectId, rows: detected, ecosystem, initialOverrides }: Props) {
+  // Nothing detected still gets the empty fallback fields — a project with an
+  // unrecognized stack should be configurable, not hidden.
+  const rows = rowsOrFallback(detected);
   const [overrides, setOverrides] = useState<Record<string, string>>(initialOverrides);
 
   // Reconcile a single edit against the detected rows and persist it. Same
@@ -46,30 +50,16 @@ export function RunEnvSection({ projectId, rows, ecosystem, initialOverrides }: 
         </p>
       </header>
 
-      {rows.length === 0 ? (
-        <div className="ps-state text-sm">
-          No run configuration detected for this project — nothing to configure yet.
-        </div>
-      ) : (
-        <>
-          <div className="ps-eco text-xs">
-            {ecosystem ? (
-              <>
-                Detected · <code>{ECOSYSTEM_LABEL[ecosystem] ?? ecosystem}</code>
-              </>
-            ) : (
-              <>No ecosystem detected — edit values below</>
-            )}
-          </div>
-          <RunConfigEditor
-            rows={rows}
-            draft={overrides}
-            scope="project"
-            onChange={onChange}
-            onRevert={onRevert}
-          />
-        </>
-      )}
+      <div className="ps-eco text-xs">
+        <EcosystemBadge ecosystem={ecosystem} />
+      </div>
+      <RunConfigEditor
+        rows={rows}
+        draft={overrides}
+        scope="project"
+        onChange={onChange}
+        onRevert={onRevert}
+      />
     </section>
   );
 }

--- a/src/components/RightPanel/RunPanel.tsx
+++ b/src/components/RightPanel/RunPanel.tsx
@@ -5,6 +5,7 @@ import {
   loadRunOverrides,
   persistRunOverrides,
   reconcileOverrides,
+  rowsOrFallback,
   type SetupRow,
   toSetupRows,
 } from "@/components/RunConfig";
@@ -169,8 +170,10 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
 
   // What each row inherits: the project setting when one exists, else the
   // detected value. Agent-level overrides compare against these, so a value
-  // matching the project setting never reads as an override.
-  const effectiveRows = rows.map((r) =>
+  // matching the project setting never reads as an override. Falling back to
+  // the empty rows lets a project-configured command surface here even when
+  // the repo detected nothing.
+  const effectiveRows = rowsOrFallback(rows).map((r) =>
     projectValues[r.id] != null
       ? { ...r, value: projectValues[r.id], origin: "project" as const }
       : r,

--- a/src/components/RightPanel/RunSettingsSheet.tsx
+++ b/src/components/RightPanel/RunSettingsSheet.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Icon } from "@/components/Icon";
-import { ECOSYSTEM_LABEL, RunConfigEditor, type SetupRow } from "@/components/RunConfig";
+import { EcosystemBadge, RunConfigEditor, type SetupRow } from "@/components/RunConfig";
 import { Button } from "@/components/ui/Button";
 
 interface Props {
@@ -52,13 +52,7 @@ export function RunSettingsSheet({ rows, overrides, ecosystem, onClose, onApply 
           <div className="rsh-left">
             <div className="rsh-title text-base">Run configuration</div>
             <div className="rsh-sub text-sm">
-              {ecosystem ? (
-                <>
-                  Detected · <code>{ECOSYSTEM_LABEL[ecosystem] ?? ecosystem}</code>
-                </>
-              ) : (
-                <>No ecosystem detected — edit values below</>
-              )}
+              <EcosystemBadge ecosystem={ecosystem} />
             </div>
           </div>
           <button className="run-sheet-x iflex-center" onClick={onClose} aria-label="Close">

--- a/src/components/RunConfig/ConfigRow.tsx
+++ b/src/components/RunConfig/ConfigRow.tsx
@@ -34,6 +34,9 @@ export function ConfigRow({ row, override, scope, onChange, onRevert }: ConfigRo
 
   const hasOverride = override != null;
   const display = hasOverride ? override : row.value;
+  // The detected default seeds the placeholder; a fallback row has none, so
+  // it carries its own hint instead.
+  const placeholder = row.value || row.placeholder || "";
 
   const [text, setText] = useState(display);
   useEffect(() => {
@@ -44,7 +47,9 @@ export function ConfigRow({ row, override, scope, onChange, onRevert }: ConfigRo
   // rendered width is exactly length × 1ch — sized in ch units the width is
   // always right, with no DOM measurement to go stale when the font loads.
   // Keeping the width explicit in both states is what lets it transition.
-  const viewWidth = `min(${Math.max(display.length, 1)}ch + 2px, ${VIEW_MAX_WIDTH}px)`;
+  // Fall back to the placeholder when empty so the hint isn't clipped.
+  const widthBasis = display || placeholder;
+  const viewWidth = `min(${Math.max(widthBasis.length, 1)}ch + 2px, ${VIEW_MAX_WIDTH}px)`;
 
   // Project Settings edits ARE the project setting — no override framing
   // there, in label or styling. Only the agent surface marks a row that
@@ -61,10 +66,12 @@ export function ConfigRow({ row, override, scope, onChange, onRevert }: ConfigRo
     </>
   ) : hasOverride ? null : fromProject ? (
     <>Project setting</>
-  ) : (
+  ) : row.source ? (
     <>
       Detected · <code>{row.source}</code>
     </>
+  ) : (
+    <>Not set</>
   );
 
   return (
@@ -84,7 +91,7 @@ export function ConfigRow({ row, override, scope, onChange, onRevert }: ConfigRo
             type="text"
             value={text}
             readOnly={!editing}
-            placeholder={row.value}
+            placeholder={placeholder}
             style={{ width: editing ? EDIT_WIDTH : viewWidth }}
             onFocus={() => setEditing(true)}
             onChange={(e) => setText(e.target.value)}

--- a/src/components/RunConfig/EcosystemBadge.tsx
+++ b/src/components/RunConfig/EcosystemBadge.tsx
@@ -1,0 +1,16 @@
+import { ECOSYSTEM_LABEL } from "./types";
+
+/** The stack line shown atop every run-config surface. When detection
+ *  couldn't identify the ecosystem it reads "Unknown" — the fields below
+ *  stay editable either way, so the user can still configure the project. */
+export function EcosystemBadge({ ecosystem }: { ecosystem: string | null }) {
+  return ecosystem ? (
+    <>
+      Detected · <code>{ECOSYSTEM_LABEL[ecosystem] ?? ecosystem}</code>
+    </>
+  ) : (
+    <>
+      Stack · <code>Unknown</code>
+    </>
+  );
+}

--- a/src/components/RunConfig/index.ts
+++ b/src/components/RunConfig/index.ts
@@ -1,4 +1,5 @@
+export { EcosystemBadge } from "./EcosystemBadge";
 export { RunConfigEditor } from "./RunConfigEditor";
 export { reconcileOverrides } from "./reconcileOverrides";
 export { loadRunOverrides, persistRunOverrides } from "./runSettings";
-export { ECOSYSTEM_LABEL, type SetupRow, toSetupRows } from "./types";
+export { ECOSYSTEM_LABEL, rowsOrFallback, type SetupRow, toSetupRows } from "./types";

--- a/src/components/RunConfig/types.ts
+++ b/src/components/RunConfig/types.ts
@@ -32,11 +32,11 @@ const GROUP_LABEL: Record<string, string> = {
  *  up by `read_run_commands` at run time. Rendered empty (no default,
  *  `source: ""`) with a hint so the user can type their own command. */
 const FALLBACK_ROWS: readonly SetupRow[] = [
-  row("version", "environment", "Version", "e.g. 22.4.0"),
-  row("install", "environment", "Install", "e.g. npm install"),
-  row("dev", "scripts", "Dev", "e.g. npm run dev"),
-  row("test", "scripts", "Test", "e.g. npm test"),
-  row("build", "scripts", "Build", "e.g. npm run build"),
+  row("version", "environment", "Version", "Language / runtime version"),
+  row("install", "environment", "Install", "Command to install dependencies"),
+  row("dev", "scripts", "Dev", "Command to start the dev server"),
+  row("test", "scripts", "Test", "Command to run the tests"),
+  row("build", "scripts", "Build", "Command to build the project"),
   row("port", "server", "Port", "e.g. 3000"),
 ];
 

--- a/src/components/RunConfig/types.ts
+++ b/src/components/RunConfig/types.ts
@@ -9,6 +9,9 @@ export interface SetupRow {
   key: string;
   value: string; // inferred / default
   source: string; // e.g. "scripts.dev", "vite.config.ts"
+  /** Hint shown in the empty field when there's no detected value to
+   *  suggest — only the fallback rows carry one. */
+  placeholder?: string;
   /** Where `value` comes from: repo detection (default) or an explicit
    *  project setting layered on top. The Run panel maps project settings
    *  onto detected rows so agent-level edits compare against the value the
@@ -16,12 +19,37 @@ export interface SetupRow {
   origin?: "detected" | "project";
 }
 
-/** Backend group key → display label. Consumed only by `toSetupRows`. */
+/** Backend group key → display label. */
 const GROUP_LABEL: Record<string, string> = {
   environment: "Environment",
   scripts: "Scripts",
   server: "Server",
 };
+
+/** The fields every project can configure, even when the repo yields no
+ *  detection. Ids/groups mirror the backend schema so an entered value
+ *  persists under the same key a detector would have filled — and is picked
+ *  up by `read_run_commands` at run time. Rendered empty (no default,
+ *  `source: ""`) with a hint so the user can type their own command. */
+const FALLBACK_ROWS: readonly SetupRow[] = [
+  row("version", "environment", "Version", "e.g. 22.4.0"),
+  row("install", "environment", "Install", "e.g. npm install"),
+  row("dev", "scripts", "Dev", "e.g. npm run dev"),
+  row("test", "scripts", "Test", "e.g. npm test"),
+  row("build", "scripts", "Build", "e.g. npm run build"),
+  row("port", "server", "Port", "e.g. 3000"),
+];
+
+function row(id: string, group: string, key: string, placeholder: string): SetupRow {
+  return { id, group: GROUP_LABEL[group], key, value: "", source: "", placeholder };
+}
+
+/** Rows a surface should render: the detected ones when the repo yielded
+ *  any, else the empty fallback set so run config is always editable rather
+ *  than hidden behind a "nothing detected" state. */
+export function rowsOrFallback(rows: SetupRow[]): SetupRow[] {
+  return rows.length > 0 ? rows : [...FALLBACK_ROWS];
+}
 
 /** Ecosystem key → display label. */
 export const ECOSYSTEM_LABEL: Record<string, string> = {


### PR DESCRIPTION
## Summary

The Project Settings "Run & environment" section was hidden entirely whenever repo detection found no scripts (`rows.length === 0` → *"nothing to configure yet"*), leaving no way to configure a project with an unrecognized stack. It now always renders editable fields, and the stack shows **Unknown** when it can't be detected.

## Changes

- **`RunConfig/types.ts`** — add canonical `FALLBACK_ROWS` (version, install, dev, test, build, port) with empty values and placeholder hints, plus `rowsOrFallback(rows)`. Ids/groups mirror the backend schema so a value typed into a fallback field persists under the exact key a detector would have filled and is honored by `read_run_commands` at run time. Add optional `placeholder` to `SetupRow`.
- **`RunConfig/EcosystemBadge.tsx`** (new) — shared stack line: *"Detected · Node"* when known, *"Stack · Unknown"* otherwise. Dedupes logic that was copy-pasted across two surfaces.
- **`RunConfig/ConfigRow.tsx`** — empty fallback rows show their hint as placeholder (width sized so it isn't clipped) and a *"Not set"* caption instead of a bogus *"Detected · "* with an empty source.
- **`ProjectSettings/RunEnvSection.tsx`** — drop the whole-section hiding; always render the badge + editor via `rowsOrFallback`.
- **`RightPanel/RunSettingsSheet.tsx` & `RunPanel.tsx`** — adopt the shared badge and `rowsOrFallback` so a project-configured command for an undetected stack also surfaces in the agent's Run panel.

## Notes

- Reconciliation/persistence already keys off row ids, so entered values save and revert correctly against the fallback rows with no further changes.
- Kept the fallback set to the six standard fields; the optional `env` row is still added by detection when present but omitted from the empty state to avoid overreach.
- `tsc --noEmit` and biome pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)