### PR TITLE
feat(pr): persist PR state snapshots so UI survives broken checkouts

### DIFF
--- a/src-tauri/migrations/0015_worktree_pr_snapshot.sql
+++ b/src-tauri/migrations/0015_worktree_pr_snapshot.sql
@@ -1,0 +1,10 @@
+-- Last-known PR snapshot for a checkout's bound PR, alongside the existing
+-- pr_number / pr_opened_at / pr_merged_at. Stamped on every successful PR
+-- fetch, so the UI can render PR identity and terminal state (merged/closed)
+-- from the database alone — a broken checkout, a pruned worktree, network
+-- loss, or a fresh app start must never blank a badge GitHub already
+-- confirmed. NULL = no fetch has succeeded since the PR was bound.
+ALTER TABLE worktrees ADD COLUMN pr_url TEXT;
+ALTER TABLE worktrees ADD COLUMN pr_title TEXT;
+-- 'open' | 'merged' | 'closed' (serialized github::PrStatus)
+ALTER TABLE worktrees ADD COLUMN pr_state TEXT;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -586,19 +586,19 @@ pub async fn create_pr(
     let base = repo.parent_branch.as_deref().unwrap_or("main");
     let pr = gh::pr_create(&checkout, &title, &body, base).await?;
     crate::telemetry::track("pr_opened", serde_json::json!({ "source": "manual" }));
-    // Bind the PR to this agent by number so later lookups don't rely on the
-    // (recyclable) branch name. A failure here isn't fatal — the next idle/push
-    // poll re-binds it via guarded discovery once the PR shows OPEN — but log it
-    // so the gap is observable rather than silent.
+    // Bind the PR to this agent (number + state snapshot) so later lookups
+    // don't rely on the (recyclable) branch name. A failure here isn't fatal —
+    // the next idle/push poll re-binds it via guarded discovery once the PR
+    // shows OPEN — but log it so the gap is observable rather than silent.
     if let Err(e) = supervisor
         .workspace
-        .set_repo_pr_number(&agent_id, &repo.subdir, pr.number as i64)
+        .set_repo_pr_snapshot(&agent_id, &repo.subdir, &pr)
     {
         tracing::warn!(
             error = %e,
             agent_id = %agent_id,
             pr = pr.number,
-            "create_pr: failed to persist PR number"
+            "create_pr: failed to persist PR snapshot"
         );
     }
     Ok(pr)
@@ -614,25 +614,21 @@ pub async fn merge_pr(
     gh::pr_merge(&checkout).await
 }
 
-/// Fetch and return the current PR state for the agent's branch.
+/// Fetch and return the current PR state for the agent's primary repo: by
+/// bound number when one is recorded (with the persisted snapshot as the
+/// fallback when GitHub is unreachable), else discovered by branch. Unbound
+/// merged/closed PRs on a recycled branch are included here for panel
+/// display, though the app-wide paths never claim them as the agent's.
 #[tauri::command]
 pub async fn get_pr_state(
     supervisor: State<'_, Arc<Supervisor>>,
     agent_id: String,
 ) -> Result<Option<PrState>> {
-    let (repo, checkout) = primary_repo_checkout(&supervisor, &agent_id)?;
-    // Only fetch if the agent has a branch
-    if repo.branch.is_none() {
-        return Ok(None);
-    }
-    let state = gh::pr_view(&checkout).await?;
-    // Accrue PR history: stamp GitHub's open/merge times when reported.
-    if let Some(pr) = &state {
-        let _ = supervisor
-            .workspace
-            .set_repo_pr_times(&agent_id, &repo.subdir, pr.opened_at, pr.merged_at);
-    }
-    Ok(state)
+    Ok(
+        crate::supervisor::resolve_pr_state(&supervisor.workspace, &agent_id)
+            .await
+            .map(|(pr, _bound)| pr),
+    )
 }
 
 /// List the open PRs for the agent's repo, for the composer's "#" mention
@@ -845,9 +841,14 @@ pub async fn get_all_shortstats(
 ///
 /// Only agents with a known PR *number* are polled: discovery of a brand-new PR
 /// still rides the existing turn-end / push / git-action triggers, so this poll
-/// never fans a `gh` call out to an agent that has no PR. Lookup is by number
-/// (not branch), keeping PR identity bound to the agent. Like
-/// `get_all_shortstats`, queries run in parallel via a `JoinSet`.
+/// never fans a `gh` call out to an agent that has no PR. Resolution goes
+/// through `resolve_pr_state`: by number (never branch), served straight from
+/// the persisted snapshot for already-merged PRs, and degrading to that
+/// snapshot when GitHub is unreachable. An agent that resolves to nothing is
+/// *omitted* from the map — not written as null — so the frontend merge keeps
+/// its last-known badge instead of wiping it (same contract as
+/// `refresh_all_pr_checks`). Like `get_all_shortstats`, queries run in
+/// parallel via a `JoinSet`.
 ///
 /// Each agent's *first* repo is used, matching the rest of the PR subsystem
 /// (`get_pr_state`, `fetch_and_emit_pr_state`) and the one-PR-per-agent shape of
@@ -865,30 +866,22 @@ pub async fn refresh_all_pr_states(
             continue;
         }
         let Some(repo) = agent.repos.first() else { continue };
-        if repo.branch.is_none() {
+        if repo.pr_number.is_none() {
             continue;
         }
-        let Some(number) = repo.pr_number else { continue };
-        let Ok(checkout) = repo_checkout_path(&agent.id, &repo.subdir) else { continue };
+        let ws = supervisor.workspace.clone();
         let agent_id = agent.id.clone();
-        let subdir = repo.subdir.clone();
         set.spawn(async move {
-            let state = gh::pr_view_number(&checkout, number as u32)
-                .await
-                .unwrap_or(None);
-            (agent_id, subdir, state)
+            let state = crate::supervisor::resolve_pr_state(&ws, &agent_id).await;
+            (agent_id, state)
         });
     }
     let mut out = std::collections::HashMap::new();
     while let Some(res) = set.join_next().await {
-        if let Ok((id, subdir, state)) = res {
-            // Accrue PR history: stamp GitHub's open/merge times when reported.
-            if let Some(pr) = &state {
-                let _ = supervisor
-                    .workspace
-                    .set_repo_pr_times(&id, &subdir, pr.opened_at, pr.merged_at);
-            }
-            out.insert(id, state);
+        // Bound is a given here (every polled agent has a pr_number); a None
+        // resolve means the fetch failed with nothing persisted yet — skip it.
+        if let Ok((id, Some((pr, _bound)))) = res {
+            out.insert(id, Some(pr));
         }
     }
     Ok(out)

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -124,6 +124,7 @@ const MIGRATIONS: &[&str] = &[
     include_str!("../migrations/0012_user_turn_timing.sql"),
     include_str!("../migrations/0013_workspace_sandbox_engine.sql"),
     include_str!("../migrations/0014_pr_times_and_usage_daily.sql"),
+    include_str!("../migrations/0015_worktree_pr_snapshot.sql"),
 ];
 
 fn get_migrations() -> Migrations<'static> {

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -36,6 +36,28 @@ pub enum PrStatus {
     Closed,
 }
 
+impl PrStatus {
+    /// Stable lowercase form, matching the serde serialization. Used as the
+    /// on-disk value in `worktrees.pr_state`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PrStatus::Open => "open",
+            PrStatus::Merged => "merged",
+            PrStatus::Closed => "closed",
+        }
+    }
+
+    /// Inverse of [`as_str`](Self::as_str), for rows written by this app.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "open" => Some(PrStatus::Open),
+            "merged" => Some(PrStatus::Merged),
+            "closed" => Some(PrStatus::Closed),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct PrState {
     pub number: u32,
@@ -307,8 +329,24 @@ pub async fn pr_view(checkout: &Path) -> Result<Option<PrState>> {
 /// identity: once we've recorded a PR number for an agent we fetch by it, so a
 /// recycled workspace/branch name can't resolve to a different (e.g. a prior
 /// agent's merged) PR. `Ok(None)` when the PR can't be found.
-pub async fn pr_view_number(checkout: &Path, number: u32) -> Result<Option<PrState>> {
-    let Some((owner, repo)) = repo_ref(checkout).await else {
+///
+/// `owner/repo` resolves from the checkout's origin, falling back to
+/// `source_repo` (the repo the agent was spawned against — it shares the same
+/// origin) when the checkout is broken or gone. A checkout casualty — a moved
+/// root, a pruned linked worktree — must not sever a by-number lookup that
+/// never needed the checkout's git state in the first place.
+pub async fn pr_view_number(
+    checkout: &Path,
+    source_repo: Option<&Path>,
+    number: u32,
+) -> Result<Option<PrState>> {
+    let mut slug = repo_ref(checkout).await;
+    if slug.is_none() {
+        if let Some(source) = source_repo {
+            slug = repo_ref(source).await;
+        }
+    }
+    let Some((owner, repo)) = slug else {
         return Ok(None);
     };
     let query = format!(
@@ -629,7 +667,7 @@ pub async fn pr_create(checkout: &Path, title: &str, body: &str, base: &str) -> 
     // The create response carries no `mergeable` verdict yet (GitHub computes
     // it async) — fetch the same shape every other path returns.
     let number = resp["number"].as_u64().unwrap_or_default() as u32;
-    match pr_view_number(checkout, number).await? {
+    match pr_view_number(checkout, None, number).await? {
         Some(pr) => Ok(pr),
         None => Err(Error::Gh("PR was created but could not be fetched".into())),
     }
@@ -1082,7 +1120,7 @@ mod tests {
         if let Some(pr) = pr_view(&repo).await.unwrap() {
             assert!(pr.number > 0);
             assert!(pr.url.starts_with("https://github.com/"));
-            let by_number = pr_view_number(&repo, pr.number).await.unwrap().unwrap();
+            let by_number = pr_view_number(&repo, None, pr.number).await.unwrap().unwrap();
             assert_eq!(by_number.number, pr.number);
             let checks = pr_checks(&repo).await.unwrap();
             assert!(checks.is_some(), "checks must resolve for an existing PR");
@@ -1090,7 +1128,7 @@ mod tests {
         }
 
         // A PR number that can't exist maps to None, not an error.
-        assert!(pr_view_number(&repo, 999_999_999).await.unwrap().is_none());
+        assert!(pr_view_number(&repo, None, 999_999_999).await.unwrap().is_none());
 
         let prs = pr_list(&repo, 5).await.unwrap();
         assert!(prs.len() <= 5);

--- a/src-tauri/src/supervisor/disposition.rs
+++ b/src-tauri/src/supervisor/disposition.rs
@@ -203,8 +203,11 @@ impl Supervisor {
                 // placeholder to satisfy the struct.
                 base_sha: None,
                 // Likewise preserved in the worktrees row across restore;
-                // placeholder to satisfy the struct.
+                // placeholders to satisfy the struct.
                 pr_number: None,
+                pr_url: None,
+                pr_title: None,
+                pr_state: None,
             });
         }
 

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -244,6 +244,9 @@ impl Supervisor {
             parent_branch,
             base_sha: None,  // captured by the fork task once HEAD is known
             pr_number: None, // set when a PR is opened for this branch
+            pr_url: None,
+            pr_title: None,
+            pr_state: None,
         };
 
         let mut record = new_agent_record(
@@ -423,6 +426,9 @@ impl Supervisor {
             parent_branch,
             base_sha,
             pr_number: None,
+            pr_url: None,
+            pr_title: None,
+            pr_state: None,
         };
         self.workspace.append_tracked_repo(agent_id, repo.clone())?;
         emit_repo_added(&app, agent_id, repo.clone());

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -11,6 +11,7 @@ mod shell;
 
 pub use lifecycle::SpawnRequest;
 pub use run::ProjectRunConfig;
+pub(crate) use session_sync::resolve_pr_state;
 
 use parking_lot::Mutex;
 use std::collections::{HashMap, HashSet};
@@ -480,6 +481,9 @@ mod tests {
                 parent_branch: None,
                 base_sha: None,
                 pr_number: None,
+                pr_url: None,
+                pr_title: None,
+                pr_state: None,
             },
             String::new(),
             AgentView::Custom,

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -5,7 +5,8 @@ use std::time::Duration;
 use tauri::AppHandle;
 
 use crate::agent::per_turn_descriptor;
-use crate::workspace::{repo_checkout_path, AgentRecord, AgentView, WorkspaceManager};
+use crate::github::{PrState, PrStatus};
+use crate::workspace::{repo_checkout_path, AgentRecord, AgentView, TrackedRepo, WorkspaceManager};
 
 use super::events::{emit_pr_state, emit_session_records_appended};
 use super::Supervisor;
@@ -68,64 +69,99 @@ impl Supervisor {
     pub fn fetch_and_emit_pr_state(&self, app: AppHandle, agent_id: String) {
         let workspace = self.workspace.clone();
         tauri::async_runtime::spawn(async move {
-            let record = match workspace.agent(&agent_id) {
-                Ok(r) => r,
-                Err(_) => return,
-            };
-            let repo = match record.repos.first() {
-                Some(r) => r,
-                None => return,
-            };
-            // Only fetch if there's a branch (agent may still be on detached HEAD)
-            if repo.branch.is_none() {
-                return;
-            }
-            let subdir = repo.subdir.clone();
-            let checkout = match crate::workspace::repo_checkout_path(&agent_id, &subdir) {
-                Ok(p) => p,
-                Err(_) => return,
-            };
-            let state = if let Some(number) = repo.pr_number {
-                // Known PR: fetch by number, never by branch. This is what keeps
-                // PR identity bound to the agent rather than the recyclable
-                // branch name.
-                crate::github::pr_view_number(&checkout, number as u32)
-                    .await
-                    .unwrap_or(None)
-            } else {
-                // No PR recorded yet. Discover one created out-of-band (agent ran
-                // `gh pr create`, or it was opened on github.com), but only adopt
-                // it if it's OPEN — a stale merged/closed PR sitting on a recycled
-                // branch must not be claimed as this agent's. Once adopted we
-                // persist the number so all later lookups go by number.
-                match crate::github::pr_view(&checkout).await.unwrap_or(None) {
-                    Some(pr) if matches!(pr.state, crate::github::PrStatus::Open) => {
-                        if let Err(e) =
-                            workspace.set_repo_pr_number(&agent_id, &subdir, pr.number as i64)
-                        {
-                            tracing::warn!(
-                                error = %e,
-                                agent_id = %agent_id,
-                                pr = pr.number,
-                                "pr discovery: failed to persist PR number"
-                            );
-                        }
-                        Some(pr)
-                    }
-                    _ => None,
-                }
-            };
-            // Accrue PR history: stamp GitHub's own open/merge times whenever
-            // a fetch reports them (feeds per-day PR stats).
-            if let Some(pr) = &state {
-                if let Err(e) =
-                    workspace.set_repo_pr_times(&agent_id, &subdir, pr.opened_at, pr.merged_at)
-                {
-                    tracing::warn!(error = %e, agent_id, "failed to stamp PR times");
-                }
-            }
+            // Only bound PRs are emitted app-wide: an unbound merged/closed PR
+            // discovered on a recycled branch name is focused-panel display
+            // (`get_pr_state`), not this agent's state.
+            let state = resolve_pr_state(&workspace, &agent_id)
+                .await
+                .and_then(|(pr, bound)| bound.then_some(pr));
             emit_pr_state(&app, &agent_id, state);
         });
+    }
+}
+
+/// The last persisted state of a repo's bound PR, rebuilt from its database
+/// columns — what the UI shows when GitHub or the checkout is unavailable.
+/// `None` when no PR is bound or no fetch has ever succeeded (state column
+/// still NULL). `mergeable` isn't persisted and reads `false`; it only means
+/// anything while an open PR is being polled live.
+pub(crate) fn pr_snapshot(repo: &TrackedRepo) -> Option<PrState> {
+    let number = repo.pr_number?;
+    let state = PrStatus::parse(repo.pr_state.as_deref()?)?;
+    Some(PrState {
+        number: number as u32,
+        url: repo.pr_url.clone().unwrap_or_default(),
+        state,
+        title: repo.pr_title.clone().unwrap_or_default(),
+        mergeable: false,
+        opened_at: None,
+        merged_at: None,
+    })
+}
+
+/// Resolve the current PR state for an agent's primary repo, persisting what
+/// it learns. Returns the state plus whether that PR is *bound* to the agent
+/// by number. The single implementation behind the focused panel
+/// (`get_pr_state`), the app-wide poll (`refresh_all_pr_states`), and the
+/// per-trigger emit (`fetch_and_emit_pr_state`).
+///
+/// - **Bound PR** (`pr_number` recorded): a persisted `merged` state returns
+///   straight from the database — merges don't un-happen, so no network or
+///   git access is spent re-confirming them. Otherwise fetch by number
+///   (resolving owner/repo from the checkout, or from the source repo when
+///   the checkout is broken), persist the result, and on failure degrade to
+///   the last persisted snapshot — a failed fetch must never erase state
+///   GitHub already confirmed.
+/// - **No bound PR**: discover one by branch name. An OPEN PR is adopted
+///   (persisted, becoming bound); a merged/closed one is returned unbound —
+///   displayable, but never claimed as this agent's, so a recycled branch
+///   name can't inherit a prior agent's PR.
+pub(crate) async fn resolve_pr_state(
+    workspace: &WorkspaceManager,
+    agent_id: &str,
+) -> Option<(PrState, bool)> {
+    let record = workspace.agent(agent_id).ok()?;
+    let repo = record.repos.first()?;
+    // No branch yet → nothing pushed, so no PR to find or bind.
+    repo.branch.as_ref()?;
+    let checkout = repo_checkout_path(agent_id, &repo.subdir).ok()?;
+
+    if let Some(number) = repo.pr_number {
+        if repo.pr_state.as_deref() == Some(PrStatus::Merged.as_str()) {
+            return pr_snapshot(repo).map(|pr| (pr, true));
+        }
+        match crate::github::pr_view_number(&checkout, Some(&repo.repo_path), number as u32).await
+        {
+            Ok(Some(pr)) => {
+                if let Err(e) = workspace.set_repo_pr_snapshot(agent_id, &repo.subdir, &pr) {
+                    tracing::warn!(
+                        error = %e,
+                        agent_id,
+                        pr = pr.number,
+                        "failed to persist PR snapshot"
+                    );
+                }
+                Some((pr, true))
+            }
+            // Unreachable or not found — fall back to the last confirmed state.
+            _ => pr_snapshot(repo).map(|pr| (pr, true)),
+        }
+    } else {
+        match crate::github::pr_view(&checkout).await.unwrap_or(None) {
+            Some(pr) if matches!(pr.state, PrStatus::Open) => {
+                if let Err(e) = workspace.set_repo_pr_snapshot(agent_id, &repo.subdir, &pr) {
+                    tracing::warn!(
+                        error = %e,
+                        agent_id,
+                        pr = pr.number,
+                        "pr discovery: failed to persist PR snapshot"
+                    );
+                }
+                Some((pr, true))
+            }
+            Some(pr) => Some((pr, false)),
+            None => None,
+        }
     }
 }
 
@@ -375,5 +411,47 @@ mod tests {
         }
         assert!(!poll.should_emit());
         assert!(poll.reader_ingested_nothing());
+    }
+
+    fn snapshot_repo() -> TrackedRepo {
+        TrackedRepo {
+            repo_path: std::path::PathBuf::from("/r"),
+            subdir: "repo".into(),
+            branch: Some("feat/x".into()),
+            parent_branch: Some("main".into()),
+            base_sha: None,
+            pr_number: Some(42),
+            pr_url: Some("https://github.com/o/r/pull/42".into()),
+            pr_title: Some("feat: x".into()),
+            pr_state: Some("merged".into()),
+        }
+    }
+
+    /// The persisted columns rebuild into a renderable PrState.
+    #[test]
+    fn pr_snapshot_rebuilds_from_columns() {
+        let pr = pr_snapshot(&snapshot_repo()).expect("snapshot");
+        assert_eq!(pr.number, 42);
+        assert_eq!(pr.url, "https://github.com/o/r/pull/42");
+        assert_eq!(pr.title, "feat: x");
+        assert!(matches!(pr.state, PrStatus::Merged));
+        assert!(!pr.mergeable, "mergeable isn't persisted — must read false");
+    }
+
+    /// No bound number, no persisted state, or an unknown state string all
+    /// mean "no snapshot" — never a fabricated badge.
+    #[test]
+    fn pr_snapshot_requires_number_and_valid_state() {
+        let mut no_number = snapshot_repo();
+        no_number.pr_number = None;
+        assert!(pr_snapshot(&no_number).is_none());
+
+        let mut no_state = snapshot_repo();
+        no_state.pr_state = None;
+        assert!(pr_snapshot(&no_state).is_none());
+
+        let mut bad_state = snapshot_repo();
+        bad_state.pr_state = Some("weird".into());
+        assert!(pr_snapshot(&bad_state).is_none());
     }
 }

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -127,6 +127,11 @@ pub(crate) async fn resolve_pr_state(
     let checkout = repo_checkout_path(agent_id, &repo.subdir).ok()?;
 
     if let Some(number) = repo.pr_number {
+        // Merged is the one terminal state — it can't be undone, so it's
+        // served from the database with no network spent re-confirming it.
+        // Closed is deliberately NOT short-circuited: a closed PR can be
+        // reopened, so it stays on the live-fetch path (and keeps costing a
+        // poll per cycle) to catch that transition.
         if repo.pr_state.as_deref() == Some(PrStatus::Merged.as_str()) {
             return pr_snapshot(repo).map(|pr| (pr, true));
         }

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -73,6 +73,16 @@ pub struct TrackedRepo {
     /// `None` until a PR exists.
     #[serde(default)]
     pub pr_number: Option<i64>,
+    /// Last-known snapshot of the bound PR (url / title / open|merged|closed),
+    /// stamped by every successful PR fetch. This is what the UI falls back to
+    /// when GitHub can't be reached or the checkout is broken — database truth
+    /// outlives git state. `None` until a fetch has succeeded.
+    #[serde(default)]
+    pub pr_url: Option<String>,
+    #[serde(default)]
+    pub pr_title: Option<String>,
+    #[serde(default)]
+    pub pr_state: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -695,22 +705,33 @@ impl WorkspaceManager {
     /// stamp when a fetch reports none). NULL until first observed — a PR
     /// merged while the app was closed still gets its real merge time on the
     /// next fetch.
-    pub fn set_repo_pr_times(
+    /// Persist a successful PR fetch: identity (number), the display snapshot
+    /// (url / title / state), and GitHub's own lifecycle times. One write per
+    /// fetch keeps the database the durable source of truth the UI can render
+    /// from when GitHub or the checkout is unavailable. Times COALESCE so an
+    /// earlier-observed value is never erased by a payload that omits it.
+    pub fn set_repo_pr_snapshot(
         &self,
         agent_id: &str,
         subdir: &str,
-        opened_at: Option<i64>,
-        merged_at: Option<i64>,
+        pr: &crate::github::PrState,
     ) -> Result<()> {
-        if opened_at.is_none() && merged_at.is_none() {
-            return Ok(());
-        }
         let conn = self.db.lock();
         conn.execute(
-            "UPDATE worktrees SET pr_opened_at = COALESCE(?1, pr_opened_at),
-                                  pr_merged_at = COALESCE(?2, pr_merged_at)
-             WHERE workspace_id = ?3 AND subdir = ?4",
-            rusqlite::params![opened_at, merged_at, agent_id, subdir],
+            "UPDATE worktrees SET pr_number = ?1, pr_url = ?2, pr_title = ?3, pr_state = ?4,
+                                  pr_opened_at = COALESCE(?5, pr_opened_at),
+                                  pr_merged_at = COALESCE(?6, pr_merged_at)
+             WHERE workspace_id = ?7 AND subdir = ?8",
+            rusqlite::params![
+                pr.number as i64,
+                pr.url,
+                pr.title,
+                pr.state.as_str(),
+                pr.opened_at,
+                pr.merged_at,
+                agent_id,
+                subdir,
+            ],
         )?;
         Ok(())
     }
@@ -1373,7 +1394,8 @@ impl WorkspaceManager {
 
     fn query_tracked_repos(conn: &Connection, agent_id: &str) -> Vec<TrackedRepo> {
         let mut stmt = match conn.prepare(
-            "SELECT r.path, w.subdir, w.branch, w.parent_branch, w.base_sha, w.pr_number
+            "SELECT r.path, w.subdir, w.branch, w.parent_branch, w.base_sha, w.pr_number,
+                    w.pr_url, w.pr_title, w.pr_state
              FROM worktrees w
              JOIN repos r ON r.id = w.repo_id
              WHERE w.workspace_id = ?1
@@ -1390,6 +1412,9 @@ impl WorkspaceManager {
             let parent_branch: Option<String> = row.get(3)?;
             let base_sha: Option<String> = row.get(4)?;
             let pr_number: Option<i64> = row.get(5)?;
+            let pr_url: Option<String> = row.get(6)?;
+            let pr_title: Option<String> = row.get(7)?;
+            let pr_state: Option<String> = row.get(8)?;
             Ok(TrackedRepo {
                 repo_path: PathBuf::from(path),
                 subdir,
@@ -1397,6 +1422,9 @@ impl WorkspaceManager {
                 parent_branch,
                 base_sha,
                 pr_number,
+                pr_url,
+                pr_title,
+                pr_state,
             })
         })
         .ok()
@@ -1931,6 +1959,9 @@ mod tests {
             parent_branch: None,
             base_sha: None,
             pr_number: None,
+            pr_url: None,
+            pr_title: None,
+            pr_state: None,
         }
     }
 
@@ -2301,6 +2332,67 @@ mod tests {
         assert_eq!(wm.agent(&reused_id).unwrap().repos[0].pr_number, None);
     }
 
+    /// A successful PR fetch persists the full snapshot (number, url, title,
+    /// state, times) and it loads back on the repo record — the database copy
+    /// the UI falls back to when GitHub or the checkout is unavailable. A
+    /// later fetch that omits times must not erase the earlier-observed ones.
+    #[test]
+    fn pr_snapshot_persists_and_loads() {
+        let db = test_db();
+        let wm = WorkspaceManager::new(db.clone());
+        seed_repo(&db, "/r");
+
+        let mut rec = new_agent_record(
+            "denali".into(),
+            "a".into(),
+            "claude".into(),
+            mk_repo("/r"),
+            "task".into(),
+            AgentView::Custom,
+        );
+        let id = rec.id.clone();
+        wm.add_agent(&mut rec).unwrap();
+        let subdir = wm.agent(&id).unwrap().repos[0].subdir.clone();
+
+        let open = crate::github::PrState {
+            number: 42,
+            url: "https://github.com/o/r/pull/42".into(),
+            title: "feat: thing".into(),
+            state: crate::github::PrStatus::Open,
+            mergeable: true,
+            opened_at: Some(1_000),
+            merged_at: None,
+        };
+        wm.set_repo_pr_snapshot(&id, &subdir, &open).unwrap();
+        let repo = wm.agent(&id).unwrap().repos[0].clone();
+        assert_eq!(repo.pr_number, Some(42));
+        assert_eq!(repo.pr_url.as_deref(), Some("https://github.com/o/r/pull/42"));
+        assert_eq!(repo.pr_title.as_deref(), Some("feat: thing"));
+        assert_eq!(repo.pr_state.as_deref(), Some("open"));
+
+        // Merge lands; a payload without opened_at keeps the earlier value.
+        let merged = crate::github::PrState {
+            state: crate::github::PrStatus::Merged,
+            mergeable: false,
+            opened_at: None,
+            merged_at: Some(2_000),
+            ..open
+        };
+        wm.set_repo_pr_snapshot(&id, &subdir, &merged).unwrap();
+        let repo = wm.agent(&id).unwrap().repos[0].clone();
+        assert_eq!(repo.pr_state.as_deref(), Some("merged"));
+        let conn = db.lock();
+        let (opened, merged_at): (Option<i64>, Option<i64>) = conn
+            .query_row(
+                "SELECT pr_opened_at, pr_merged_at FROM worktrees WHERE workspace_id = ?1",
+                [&id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(opened, Some(1_000), "COALESCE must keep the earlier opened_at");
+        assert_eq!(merged_at, Some(2_000));
+    }
+
     #[test]
     fn agent_status_transitions() {
         let db = test_db();
@@ -2410,6 +2502,9 @@ mod tests {
             parent_branch: Some("main".into()),
             base_sha: None,
             pr_number: None,
+            pr_url: None,
+            pr_title: None,
+            pr_state: None,
         }];
         wm.restore_agent(&id, restored).unwrap();
         let a = wm.agent(&id).unwrap();
@@ -2475,6 +2570,9 @@ mod tests {
                 parent_branch: None,
                 base_sha: None,
                 pr_number: None,
+                pr_url: None,
+                pr_title: None,
+                pr_state: None,
             },
             "task".into(),
             AgentView::Custom,

--- a/src/api.ts
+++ b/src/api.ts
@@ -12,6 +12,13 @@ export interface TrackedRepo {
   subdir: string;
   branch?: string | null;
   parent_branch?: string | null;
+  /** Bound PR identity + last persisted snapshot (see prSnapshot in
+   *  util/prState.ts). Written by the backend on every successful PR fetch;
+   *  what the UI renders when GitHub or the checkout is unavailable. */
+  pr_number?: number | null;
+  pr_url?: string | null;
+  pr_title?: string | null;
+  pr_state?: string | null;
 }
 
 export interface DiffStats {

--- a/src/components/RightPanel/GitPanel/hooks/useGitPanelData.ts
+++ b/src/components/RightPanel/GitPanel/hooks/useGitPanelData.ts
@@ -3,6 +3,7 @@ import type { MergeState } from "@/api";
 import { deriveState } from "@/components/RightPanel/primaryActions";
 import { useAppStore } from "@/store";
 import { usePoll } from "@/util/hooks";
+import { usePrState } from "@/util/prState";
 
 /** All the live git/PR reads the panel renders from, plus the polling that
  *  keeps them fresh while the panel is mounted:
@@ -12,7 +13,7 @@ import { usePoll } from "@/util/hooks";
  *  usePoll fires immediately, so the first read of each still lands on mount. */
 export function useGitPanelData(agentId: string) {
   const gitState = useAppStore((s) => s.gitStates[agentId] ?? null);
-  const prState = useAppStore((s) => s.prStates[agentId] ?? null);
+  const prState = usePrState(agentId);
   const fetchGitState = useAppStore((s) => s.fetchGitState);
   const fetchPrState = useAppStore((s) => s.fetchPrState);
   const prChecksEntry = useAppStore((s) => s.prChecks[agentId]);

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -11,6 +11,7 @@ import type { DraftAgent } from "@/store";
 import { useAppStore } from "@/store";
 import { formatAge } from "@/util/format";
 import { useMinuteClock } from "@/util/hooks";
+import { usePrState } from "@/util/prState";
 import { type AgentStats, AgentStatsPopover } from "./AgentStatsPopover";
 
 /** The agent rows carry nested buttons (stop/archive/discard), so they can't be
@@ -51,7 +52,9 @@ export function AgentRow(props: Props) {
 
 function RealRow({ agent, active, onClick }: RealRowProps) {
   const usage = useAppStore((s) => s.usage[agent.id]);
-  const prState = useAppStore((s) => s.prStates[agent.id] ?? null);
+  // Live PR state with the persisted database snapshot as fallback, so a
+  // merged badge survives restarts, offline stretches, and broken checkouts.
+  const prState = usePrState(agent.id);
   // CI rollup for this agent's PR, fed by the app-wide refreshAllPrChecks poll
   // (see App.tsx) — lets the PR pill tint pass/fail across every row, not just
   // the focused one. Null until the first poll lands or when there's no PR.

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -54,7 +54,7 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
   const usage = useAppStore((s) => s.usage[agent.id]);
   // Live PR state with the persisted database snapshot as fallback, so a
   // merged badge survives restarts, offline stretches, and broken checkouts.
-  const prState = usePrState(agent.id);
+  const prState = usePrState(agent.id, agent.repos[0]);
   // CI rollup for this agent's PR, fed by the app-wide refreshAllPrChecks poll
   // (see App.tsx) — lets the PR pill tint pass/fail across every row, not just
   // the focused one. Null until the first poll lands or when there's no PR.

--- a/src/components/TitleBar/WorkspaceStatus/useCapsuleData.ts
+++ b/src/components/TitleBar/WorkspaceStatus/useCapsuleData.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { useAppStore } from "@/store";
 import { usePoll } from "@/util/hooks";
+import { usePrState } from "@/util/prState";
 
 /** Live git/PR reads for the title-bar capsule of the active agent.
  *
@@ -13,7 +14,7 @@ import { usePoll } from "@/util/hooks";
 export function useCapsuleData(agentId: string) {
   const shortstats = useAppStore((s) => s.gitShortstats[agentId] ?? null);
   const gitState = useAppStore((s) => s.gitStates[agentId] ?? null);
-  const prState = useAppStore((s) => s.prStates[agentId] ?? null);
+  const prState = usePrState(agentId);
   const checks = useAppStore((s) => s.prChecks[agentId] ?? null);
   const fetchGitState = useAppStore((s) => s.fetchGitState);
   const fetchPrChecks = useAppStore((s) => s.fetchPrChecks);

--- a/src/util/prState.ts
+++ b/src/util/prState.ts
@@ -1,0 +1,34 @@
+// PR state with a database fallback. Live state (the `prStates` store map,
+// fed by polls and pr:state_changed events) always wins; when it's absent or
+// null — fresh app start, GitHub unreachable, broken checkout — the last
+// snapshot the backend persisted on the repo record fills in, so a PR GitHub
+// already confirmed (especially a merged one) never renders as "no PR".
+
+import { useMemo } from "react";
+import type { PrState, PrStatus, TrackedRepo } from "@/api";
+import { useAppStore } from "@/store";
+
+const PR_STATUSES: readonly PrStatus[] = ["open", "merged", "closed"];
+
+/** Rebuild the last persisted PR state from a repo record's snapshot columns.
+ *  Null when no PR is bound or no fetch has ever succeeded. `mergeable` isn't
+ *  persisted and reads false — it only means anything while polling live. */
+export function prSnapshot(repo: TrackedRepo | undefined): PrState | null {
+  if (!repo || repo.pr_number == null || !repo.pr_state) return null;
+  if (!(PR_STATUSES as readonly string[]).includes(repo.pr_state)) return null;
+  return {
+    number: repo.pr_number,
+    url: repo.pr_url ?? "",
+    state: repo.pr_state as PrStatus,
+    title: repo.pr_title ?? "",
+    mergeable: false,
+  };
+}
+
+/** The PR state to render for an agent: live store value, else the database
+ *  snapshot from the agent's primary repo. */
+export function usePrState(agentId: string): PrState | null {
+  const live = useAppStore((s) => s.prStates[agentId] ?? null);
+  const repo = useAppStore((s) => s.workspace?.agents.find((a) => a.id === agentId)?.repos[0]);
+  return useMemo(() => live ?? prSnapshot(repo), [live, repo]);
+}

--- a/src/util/prState.ts
+++ b/src/util/prState.ts
@@ -26,9 +26,17 @@ export function prSnapshot(repo: TrackedRepo | undefined): PrState | null {
 }
 
 /** The PR state to render for an agent: live store value, else the database
- *  snapshot from the agent's primary repo. */
-export function usePrState(agentId: string): PrState | null {
+ *  snapshot from the agent's primary repo.
+ *
+ *  Callers that already hold the agent record (the sidebar mounts one row per
+ *  agent) should pass its primary repo — the selector then skips the O(n)
+ *  agents scan that would otherwise run in every mounted row on every store
+ *  update. Singleton consumers (title-bar capsule, Git panel) can omit it and
+ *  let the selector look the repo up. */
+export function usePrState(agentId: string, repo?: TrackedRepo): PrState | null {
   const live = useAppStore((s) => s.prStates[agentId] ?? null);
-  const repo = useAppStore((s) => s.workspace?.agents.find((a) => a.id === agentId)?.repos[0]);
-  return useMemo(() => live ?? prSnapshot(repo), [live, repo]);
+  const found = useAppStore(
+    (s) => repo ?? s.workspace?.agents.find((a) => a.id === agentId)?.repos[0],
+  );
+  return useMemo(() => live ?? prSnapshot(found), [live, found]);
 }

--- a/tests/util/prState.test.ts
+++ b/tests/util/prState.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import type { TrackedRepo } from "@/api";
+import { prSnapshot } from "@/util/prState";
+
+const repo = (overrides: Partial<TrackedRepo> = {}): TrackedRepo => ({
+  repo_path: "/r",
+  subdir: "repo",
+  branch: "feat/x",
+  parent_branch: "main",
+  pr_number: 42,
+  pr_url: "https://github.com/o/r/pull/42",
+  pr_title: "feat: x",
+  pr_state: "merged",
+  ...overrides,
+});
+
+describe("prSnapshot", () => {
+  it("rebuilds the persisted PR state from the repo record", () => {
+    expect(prSnapshot(repo())).toEqual({
+      number: 42,
+      url: "https://github.com/o/r/pull/42",
+      state: "merged",
+      title: "feat: x",
+      mergeable: false,
+    });
+  });
+
+  it("is null without a bound PR number or persisted state", () => {
+    expect(prSnapshot(undefined)).toBeNull();
+    expect(prSnapshot(repo({ pr_number: null }))).toBeNull();
+    expect(prSnapshot(repo({ pr_state: null }))).toBeNull();
+  });
+
+  it("rejects an unknown state string rather than fabricating a badge", () => {
+    expect(prSnapshot(repo({ pr_state: "weird" }))).toBeNull();
+  });
+
+  it("degrades missing url/title to empty strings", () => {
+    const pr = prSnapshot(repo({ pr_url: null, pr_title: null }));
+    expect(pr).toMatchObject({ number: 42, url: "", title: "" });
+  });
+});


### PR DESCRIPTION
## Problem

PR badges (sidebar) and the Git panel's merged state went blank for most agents after upgrading to v0.7.5 and cleaning up branches. Root cause chain:

1. PR *display* state was never persisted — every render required a live GitHub fetch, which resolved `owner/repo` by running `git remote get-url origin` **inside the agent's checkout**.
2. The v0.7.5 checkout-root rename (`~/.fletch/worktrees` → `~/.fletch/workspaces`) moved linked worktrees without repairing git's back-pointers; a later `git worktree prune` in the source repo deleted their admin dirs, so every git command in those checkouts fails.
3. `pr_view_number` then resolved `Ok(None)`, and `refresh_all_pr_states` wrote that `null` into the store — wiping badges the database already knew about (`pr_number` was recorded; PRs were confirmed merged).

## Fix — database is the durable source of truth

- **Migration 0015**: `worktrees` gains `pr_url` / `pr_title` / `pr_state`. `set_repo_pr_snapshot` stamps them (plus number and open/merge times) on every successful fetch, replacing `set_repo_pr_times`. Verified the migration applies cleanly against a copy of a live v14 database.
- **Checkout-independent lookups**: `pr_view_number` falls back to the source repo's origin when the checkout can't resolve one — by-number lookups never needed checkout git state.
- **One resolution path**: new `resolve_pr_state` backs the focused panel (`get_pr_state`), the app-wide poll (`refresh_all_pr_states`), and the per-trigger emit (`fetch_and_emit_pr_state`): fetch by bound number first, persist on success, degrade to the persisted snapshot on failure, and serve already-merged PRs straight from the database (merges don't un-happen — also stops re-polling every merged PR every 45s). Branch discovery still adopts only OPEN PRs, preserving the recycled-branch protection from #0010.
- **No more wipe-on-error**: `refresh_all_pr_states` omits failed agents instead of writing `null`, matching `refresh_all_pr_checks`' contract.
- **Frontend fallback**: new `usePrState` hook renders the live store value or, when absent, the repo record's persisted snapshot — sidebar rows, the title-bar capsule, and the Git panel now show merged state offline and on fresh starts.

## Testing

- `cargo test --lib`: 533 passed (new: snapshot persist/load round-trip incl. COALESCE on times; snapshot rebuild + rejection of unknown state strings)
- `vitest`: 374 passed (new: `prSnapshot` mapping/edge cases)
- `tsc` clean, `biome` no new warnings
- Dry-ran migration 0015 against a copy of the live database

Note: this deliberately does not repair already-broken checkouts (pruned worktree metadata / stranded legacy-root dirs) — with this change their PR state renders from the database again after one successful fetch, and recovery tooling can come separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)