### PR TITLE
fix(spawn): resolve fork-point fallback to a SHA so agent spawn survives a failed base fetch

### DIFF
--- a/src-tauri/src/sandbox/provision.rs
+++ b/src-tauri/src/sandbox/provision.rs
@@ -529,6 +529,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn clone_provision_detaches_at_sha_of_non_checked_out_branch() {
+        // The spawn fork-point fallback resolves the base branch to a SHA
+        // (lifecycle.rs) precisely because a name can't work here: a clone's
+        // only local branch is the source's HEAD branch, so `checkout --detach
+        // <other-branch-name>` trips git's remote-DWIM (an implicit `-b`) and
+        // dies with "'--detach' cannot be used with '-b/-B/--orphan'". Model
+        // that spawn: source checked out on a side branch, base = the SHA of
+        // `main`'s tip.
+        let td = tempfile::tempdir().unwrap();
+        let (repo, _first, main_tip) = fixture_repo(td.path());
+        run(&repo, &["checkout", "-q", "-b", "side"]);
+        std::fs::write(repo.join("s.txt"), b"side").unwrap();
+        run(&repo, &["add", "-A"]);
+        run(&repo, &["commit", "-q", "-m", "side work"]);
+
+        let dest = td.path().join("clone");
+        let spec = CheckoutSpec {
+            source_repo: &repo,
+            base_ref: &main_tip,
+            dest: &dest,
+        };
+        provision(WorkspaceMode::Clone, &spec).await.unwrap();
+        assert_eq!(run(&dest, &["rev-parse", "HEAD"]), main_tip);
+        // Detached, not on a DWIM-created local branch.
+        let out = std::process::Command::new("git")
+            .current_dir(&dest)
+            .args(["symbolic-ref", "-q", "HEAD"])
+            .output()
+            .unwrap();
+        assert!(!out.status.success(), "clone HEAD should be detached");
+    }
+
+    #[tokio::test]
     async fn clone_rewrites_origin_to_source_remote() {
         let td = tempfile::tempdir().unwrap();
         let (repo, _first, head) = fixture_repo(td.path());

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -313,13 +313,17 @@ impl Supervisor {
             // (a symbolic `origin/<branch>` would resolve against the source's
             // stale local head inside the clone). Best-effort — if the remote is
             // unavailable (offline, no remote, a local-only branch, or a workflow
-            // commit-ish), use the ref directly when it resolves, otherwise fall
+            // commit-ish), resolve the ref to its local SHA, otherwise fall
             // through to HEAD so an unresolvable base degrades instead of failing
-            // the spawn.
+            // the spawn. The SHA (never the branch name) matters even in the
+            // fallback: a clone-mode workspace only has the source's HEAD branch
+            // as a local branch, so checking out any *other* branch by name
+            // trips git's remote-DWIM (an implicit `-b`), which is fatal
+            // combined with `--detach`.
             let base = match &parent_for_fork {
                 Some(b) => match git::fetch_fork_point(&repo_path, b).await {
                     Some(sha) => Some(sha),
-                    None => git::rev_parse(&repo_path, b).await.ok().map(|_| b.clone()),
+                    None => git::rev_parse(&repo_path, b).await.ok(),
                 },
                 None => None,
             };


### PR DESCRIPTION
## Problem

Spawning an agent based on `main` failed with:

```
git command failed: checkout --detach main failed: fatal: '--detach' cannot be used with '-b/-B/--orphan'
```

whenever (1) the spawn's best-effort `git fetch origin <base>` failed — offline, SSH-only origin auth, or ref-lock contention from two agents spawning concurrently — and (2) the source repo was checked out on a branch other than the base. The fallback passed the raw branch name as the clone's checkout base, but a `git clone --shared` workspace only has the source's HEAD branch as a local branch; checking out any other branch by name trips git's remote-DWIM (an implicit `-b`), which is fatal combined with `--detach`.

## Fix

Resolve the base ref to its local SHA in the fallback (`lifecycle.rs`) instead of keeping the branch name. A SHA resolves identically inside the clone via alternates, so the detached checkout can never DWIM. Completes 62edea4, which pinned the fetch-success path to a SHA but left the fallback on the branch name.

## Testing

- New regression test `clone_provision_detaches_at_sha_of_non_checked_out_branch` modeling the failing scenario (source on a side branch, base = SHA of `main`'s tip).
- `cargo build` clean; all provision (19) and supervisor (22) tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)