### PR TITLE
perf(pr): batch PR polls, back off on rate limits, adaptive cadence

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -589,18 +589,8 @@ pub async fn create_pr(
     // Bind the PR to this agent (number + state snapshot) so later lookups
     // don't rely on the (recyclable) branch name. A failure here isn't fatal —
     // the next idle/push poll re-binds it via guarded discovery once the PR
-    // shows OPEN — but log it so the gap is observable rather than silent.
-    if let Err(e) = supervisor
-        .workspace
-        .set_repo_pr_snapshot(&agent_id, &repo.subdir, &pr)
-    {
-        tracing::warn!(
-            error = %e,
-            agent_id = %agent_id,
-            pr = pr.number,
-            "create_pr: failed to persist PR snapshot"
-        );
-    }
+    // shows OPEN — but the helper logs it so the gap is observable, not silent.
+    crate::supervisor::persist_pr_snapshot(&supervisor.workspace, &agent_id, &repo.subdir, &pr);
     Ok(pr)
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -857,35 +857,23 @@ pub async fn get_all_shortstats(
 pub async fn refresh_all_pr_states(
     supervisor: State<'_, Arc<Supervisor>>,
 ) -> Result<std::collections::HashMap<String, Option<PrState>>> {
-    let Some(workspace) = supervisor.workspace.current() else {
-        return Ok(Default::default());
-    };
-    let mut set = tokio::task::JoinSet::new();
-    for agent in workspace.agents {
-        if agent.archive.is_some() {
-            continue;
-        }
-        let Some(repo) = agent.repos.first() else { continue };
-        if repo.pr_number.is_none() {
-            continue;
-        }
-        let ws = supervisor.workspace.clone();
-        let agent_id = agent.id.clone();
-        set.spawn(async move {
-            let state = crate::supervisor::resolve_pr_state(&ws, &agent_id).await;
-            (agent_id, state)
-        });
-    }
-    let mut out = std::collections::HashMap::new();
-    while let Some(res) = set.join_next().await {
-        // Bound is a given here (every polled agent has a pr_number); a None
-        // resolve means the fetch failed with nothing persisted yet — skip it.
-        if let Ok((id, Some((pr, _bound)))) = res {
-            out.insert(id, Some(pr));
-        }
-    }
-    Ok(out)
+    // Closed PRs are served from the DB snapshot most cycles and only re-verified
+    // live on every Nth tick (they can reopen) — cheap coverage of a rare event.
+    // Tick 0 (first poll after launch) re-verifies so freshly-adopted state is
+    // confirmed right away.
+    let tick = PR_STATE_TICK.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let reverify_closed = tick % CLOSED_REVERIFY_EVERY == 0;
+    let states = crate::supervisor::resolve_all_pr_states(&supervisor.workspace, reverify_closed).await;
+    // Only present states land in the map — an omitted agent keeps its
+    // last-known badge on the frontend merge (never wiped to null).
+    Ok(states.into_iter().map(|(id, pr)| (id, Some(pr))).collect())
 }
+
+/// Monotonic tick for `refresh_all_pr_states`, driving the slow closed-PR
+/// re-verify cadence.
+static PR_STATE_TICK: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+/// Re-verify closed PRs live on every Nth `refresh_all_pr_states` tick.
+const CLOSED_REVERIFY_EVERY: u64 = 6;
 
 /// Refresh CI checks for every agent with an open PR in one round-trip, so the
 /// sidebar can tint each PR pill pass/fail without opening the Git panel. Mirror
@@ -903,25 +891,43 @@ pub async fn refresh_all_pr_checks(
     let Some(workspace) = supervisor.workspace.current() else {
         return Ok(Default::default());
     };
-    let mut set = tokio::task::JoinSet::new();
+    // Paused for rate-limit backoff → return nothing so the frontend merge keeps
+    // every agent's last-known tint instead of wiping it.
+    if gh::client::is_backing_off() {
+        return Ok(Default::default());
+    }
+
+    // Gather one (agent, PR ref) per agent with a branch + PR number, resolving
+    // the slug via local git (the network cost is deferred to the single batched
+    // query below, not fanned out per agent).
+    let mut agent_ids: Vec<String> = Vec::new();
+    let mut refs: Vec<gh::PrRef> = Vec::new();
     for agent in workspace.agents {
         if agent.archive.is_some() {
             continue;
         }
         let Some(repo) = agent.repos.first() else { continue };
-        if repo.branch.is_none() || repo.pr_number.is_none() {
+        let (Some(_branch), Some(number)) = (repo.branch.as_ref(), repo.pr_number) else {
             continue;
-        }
+        };
         let Ok(checkout) = repo_checkout_path(&agent.id, &repo.subdir) else { continue };
-        let agent_id = agent.id.clone();
-        set.spawn(async move { (agent_id, gh::pr_checks(&checkout).await) });
+        let Some((owner, repo_name)) = gh::resolve_slug(&checkout, Some(&repo.repo_path)).await
+        else {
+            continue;
+        };
+        agent_ids.push(agent.id.clone());
+        refs.push(gh::PrRef { owner, repo: repo_name, number: number as u32 });
     }
+
     let mut out = std::collections::HashMap::new();
-    while let Some(res) = set.join_next().await {
-        // Record only definitive outcomes; drop errored agents so their prior
-        // value survives the frontend merge.
-        if let Ok((id, Ok(checks))) = res {
-            out.insert(id, checks);
+    // A whole-batch failure leaves the map empty (all agents keep last-known);
+    // per-alias `None` (PR not found / partial error) is dropped for the same
+    // reason. Only a resolved rollup — including "no checks" — is recorded.
+    if let Ok(results) = gh::pr_checks_batch(&refs).await {
+        for (id, checks) in agent_ids.into_iter().zip(results) {
+            if let Some(checks) = checks {
+                out.insert(id, Some(checks));
+            }
         }
     }
     Ok(out)

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -842,13 +842,14 @@ pub async fn get_all_shortstats(
 /// Only agents with a known PR *number* are polled: discovery of a brand-new PR
 /// still rides the existing turn-end / push / git-action triggers, so this poll
 /// never fans a `gh` call out to an agent that has no PR. Resolution goes
-/// through `resolve_pr_state`: by number (never branch), served straight from
-/// the persisted snapshot for already-merged PRs, and degrading to that
-/// snapshot when GitHub is unreachable. An agent that resolves to nothing is
-/// *omitted* from the map — not written as null — so the frontend merge keeps
-/// its last-known badge instead of wiping it (same contract as
-/// `refresh_all_pr_checks`). Like `get_all_shortstats`, queries run in
-/// parallel via a `JoinSet`.
+/// through `resolve_all_pr_states`, which collapses every live lookup into a
+/// single batched GraphQL query rather than a per-agent fan-out: by number
+/// (never branch), served straight from the persisted snapshot for merged PRs
+/// (and closed ones except on the slow re-verify tick), and degrading to that
+/// snapshot when GitHub is unreachable or a rate-limit backoff is active. An
+/// agent that resolves to nothing is *omitted* from the map — not written as
+/// null — so the frontend merge keeps its last-known badge instead of wiping it
+/// (same contract as `refresh_all_pr_checks`).
 ///
 /// Each agent's *first* repo is used, matching the rest of the PR subsystem
 /// (`get_pr_state`, `fetch_and_emit_pr_state`) and the one-PR-per-agent shape of
@@ -875,15 +876,15 @@ static PR_STATE_TICK: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU6
 /// Re-verify closed PRs live on every Nth `refresh_all_pr_states` tick.
 const CLOSED_REVERIFY_EVERY: u64 = 6;
 
-/// Refresh CI checks for every agent with an open PR in one round-trip, so the
-/// sidebar can tint each PR pill pass/fail without opening the Git panel. Mirror
-/// of `refresh_all_pr_states`: skips archived agents and any without a PR so we
-/// never fan a `gh` call out needlessly, and runs the per-agent `pr_checks`
-/// queries in parallel via a `JoinSet`. Best-effort per agent: only *definitive*
-/// results land in the map — `Ok(Some)` (checks) and `Ok(None)` (no PR / none
-/// configured). A transient `gh` failure (network, rate-limit, missing binary)
-/// is omitted entirely, so the frontend's merge keeps that agent's last-known
-/// tint instead of wiping it — matching `fetchPrAux`'s per-agent contract.
+/// Refresh CI checks for every agent with an open PR, so the sidebar can tint
+/// each PR pill pass/fail without opening the Git panel. Mirror of
+/// `refresh_all_pr_states`: skips archived agents and any without a PR, and
+/// collapses the lookups into a single batched GraphQL query rather than a
+/// per-agent fan-out. Best-effort: only a resolved rollup lands in the map
+/// (including "no checks configured"); a not-found/partial-error alias, a
+/// whole-batch failure, or an active rate-limit backoff omits the agent, so the
+/// frontend's merge keeps its last-known tint instead of wiping it — matching
+/// `fetchPrAux`'s contract.
 #[tauri::command]
 pub async fn refresh_all_pr_checks(
     supervisor: State<'_, Arc<Supervisor>>,

--- a/src-tauri/src/github/client.rs
+++ b/src-tauri/src/github/client.rs
@@ -328,8 +328,19 @@ mod tests {
         h
     }
 
+    /// Serializes the tests that mutate the process-global backoff registry, so
+    /// one test's arming can't race another's `clear_backoff()` → `assert!`
+    /// window under `cargo test`'s parallel threads (mirrors `test_token_lock`).
+    fn test_backoff_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<std::sync::Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+
     #[test]
     fn retry_after_arms_backoff() {
+        let _guard = test_backoff_lock();
         clear_backoff();
         assert!(!is_backing_off());
         observe_rate_limit(
@@ -343,6 +354,7 @@ mod tests {
 
     #[test]
     fn graphql_rate_limited_error_arms_backoff() {
+        let _guard = test_backoff_lock();
         clear_backoff();
         let body = json!({ "errors": [{ "type": "RATE_LIMITED", "message": "API rate limit exceeded" }] });
         observe_rate_limit(reqwest::StatusCode::OK, &headers(&[]), &body);
@@ -352,6 +364,7 @@ mod tests {
 
     #[test]
     fn healthy_response_does_not_arm_backoff() {
+        let _guard = test_backoff_lock();
         clear_backoff();
         observe_rate_limit(
             reqwest::StatusCode::OK,
@@ -363,6 +376,7 @@ mod tests {
 
     #[test]
     fn budget_floor_arms_backoff_only_when_low() {
+        let _guard = test_backoff_lock();
         clear_backoff();
         note_rate_budget(500, None);
         assert!(!is_backing_off(), "ample budget must not pause");

--- a/src-tauri/src/github/client.rs
+++ b/src-tauri/src/github/client.rs
@@ -10,7 +10,7 @@
 //! never appear in logs, telemetry, or error strings.
 
 use std::sync::{OnceLock, RwLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use base64::Engine;
 use serde_json::{json, Value};
@@ -43,6 +43,110 @@ pub fn set_token(token: Option<String>) {
 
 pub fn token() -> Option<String> {
     token_registry().read().unwrap().clone()
+}
+
+// ---------------------------------------------------------------------------
+// Rate-limit backoff
+//
+// GitHub enforces two ceilings the poll paths can trip: the primary hourly
+// points budget (5000 for authenticated GraphQL) and a *secondary* limit on
+// bursts/concurrency that answers with `403` + `Retry-After`. Rather than keep
+// hammering, we honor those signals with a single process-global "don't call
+// until" instant. Poll paths (`graphql_opt`, the batch fetchers) check
+// [`is_backing_off`] and serve the persisted PR snapshot instead; user-driven
+// mutations (create/merge) skip the gate so an explicit action still errors
+// loudly instead of silently no-op'ing.
+// ---------------------------------------------------------------------------
+
+/// GraphQL points remaining (of ~5000/hr) at or below which we stop polling
+/// until the window resets — a cushion so an in-flight batch can't overrun.
+const RATE_BUDGET_FLOOR: i64 = 50;
+/// Fallback pause when GitHub signals a secondary limit without a `Retry-After`.
+const DEFAULT_BACKOFF: Duration = Duration::from_secs(60);
+
+fn backoff_registry() -> &'static RwLock<Option<Instant>> {
+    static BACKOFF: OnceLock<RwLock<Option<Instant>>> = OnceLock::new();
+    BACKOFF.get_or_init(|| RwLock::new(None))
+}
+
+/// Pause API polling for `dur`. Extends an existing pause, never shortens it —
+/// two overlapping signals settle on the later deadline.
+fn set_backoff(dur: Duration) {
+    let until = Instant::now() + dur;
+    let mut w = backoff_registry().write().unwrap();
+    if w.map_or(true, |cur| until > cur) {
+        *w = Some(until);
+    }
+}
+
+/// True while a rate-limit pause is in effect. Poll paths short-circuit to the
+/// last persisted state instead of spending a request that would likely 403.
+pub fn is_backing_off() -> bool {
+    backoff_registry()
+        .read()
+        .unwrap()
+        .is_some_and(|until| Instant::now() < until)
+}
+
+/// Feed the queried GraphQL `rateLimit` budget back into the gate: when the
+/// remaining points fall to the floor, pause until the window resets
+/// (`reset_at_ms` is GitHub's `resetAt` as ms-epoch).
+pub fn note_rate_budget(remaining: i64, reset_at_ms: Option<i64>) {
+    if remaining > RATE_BUDGET_FLOOR {
+        return;
+    }
+    let dur = reset_at_ms
+        .and_then(|reset| {
+            let now = chrono::Utc::now().timestamp_millis();
+            (reset > now).then(|| Duration::from_millis((reset - now) as u64))
+        })
+        .unwrap_or(DEFAULT_BACKOFF);
+    set_backoff(dur);
+}
+
+/// Inspect a response for rate-limit signals and arm the backoff gate:
+/// a secondary-limit `403`/`429` (honoring `Retry-After`), a GraphQL
+/// `RATE_LIMITED` error, or an exhausted `x-ratelimit-remaining` header.
+fn observe_rate_limit(status: reqwest::StatusCode, headers: &reqwest::header::HeaderMap, body: &Value) {
+    let header_secs = |name: &str| {
+        headers
+            .get(name)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<i64>().ok())
+    };
+
+    // Secondary (burst/concurrency) limit: back off for Retry-After, or a
+    // conservative default when the header is absent.
+    if matches!(status.as_u16(), 403 | 429) {
+        let secs = header_secs("retry-after").filter(|s| *s > 0);
+        set_backoff(secs.map_or(DEFAULT_BACKOFF, |s| Duration::from_secs(s as u64)));
+        return;
+    }
+
+    // GraphQL reports its secondary limit as 200 + a RATE_LIMITED error.
+    let rate_limited_error = body
+        .get("errors")
+        .and_then(Value::as_array)
+        .is_some_and(|errs| {
+            errs.iter().any(|e| {
+                e.get("type").and_then(Value::as_str) == Some("RATE_LIMITED")
+                    || e.get("message")
+                        .and_then(Value::as_str)
+                        .is_some_and(|m| m.to_lowercase().contains("rate limit"))
+            })
+        });
+    if rate_limited_error {
+        set_backoff(DEFAULT_BACKOFF);
+        return;
+    }
+
+    // Primary budget exhausted: pause until the reset the header names.
+    if header_secs("x-ratelimit-remaining") == Some(0) {
+        let dur = header_secs("x-ratelimit-reset")
+            .map(|reset| Duration::from_secs((reset - chrono::Utc::now().timestamp()).max(1) as u64))
+            .unwrap_or(DEFAULT_BACKOFF);
+        set_backoff(dur);
+    }
 }
 
 /// Git-config env authenticating git's https transport to github.com with the
@@ -123,6 +227,19 @@ impl Client {
     /// server's messages — callers match on the text for expected cases
     /// (e.g. auto-merge's "clean status").
     pub async fn graphql(&self, query: &str, variables: Value) -> Result<Value> {
+        self.graphql_inner(query, variables, false).await
+    }
+
+    /// Like [`graphql`](Self::graphql) but tolerant of a partial `errors[]`:
+    /// returns whatever `data` came back even when some fields errored. For
+    /// *batched* queries, one inaccessible repo/PR must null just its own alias
+    /// (`data.aN == null`), not fail the whole round-trip and blank every other
+    /// agent's state.
+    pub async fn graphql_partial(&self, query: &str, variables: Value) -> Result<Value> {
+        self.graphql_inner(query, variables, true).await
+    }
+
+    async fn graphql_inner(&self, query: &str, variables: Value, allow_partial: bool) -> Result<Value> {
         let resp = self
             .request(reqwest::Method::POST, GRAPHQL_URL.to_string())
             .json(&json!({ "query": query, "variables": variables }))
@@ -130,7 +247,9 @@ impl Client {
             .await
             .map_err(request_error)?;
         let status = resp.status();
+        let headers = resp.headers().clone();
         let body = resp.json::<Value>().await.unwrap_or(Value::Null);
+        observe_rate_limit(status, &headers, &body);
         if status == reqwest::StatusCode::UNAUTHORIZED {
             return Err(Error::Gh(
                 "GitHub token is no longer valid — sign in with GitHub again".into(),
@@ -148,7 +267,13 @@ impl Client {
                     .iter()
                     .filter_map(|e| e.get("message").and_then(Value::as_str))
                     .collect();
-                return Err(Error::Gh(msgs.join("; ")));
+                // Partial mode keeps the good aliases; note the rest at debug
+                // (never at a level that could leak a token-bearing message).
+                if allow_partial && body.get("data").is_some_and(|d| !d.is_null()) {
+                    tracing::debug!(errors = %msgs.join("; "), "graphql partial errors");
+                } else {
+                    return Err(Error::Gh(msgs.join("; ")));
+                }
             }
         }
         Ok(body.get("data").cloned().unwrap_or(Value::Null))
@@ -181,9 +306,70 @@ pub(crate) fn test_token_lock() -> std::sync::MutexGuard<'static, ()> {
         .unwrap_or_else(|e| e.into_inner())
 }
 
+/// Clear the backoff gate. Tests only — keeps a rate-limit signal from one
+/// test leaking into the next (the registry is process-global).
+#[cfg(test)]
+pub(crate) fn clear_backoff() {
+    *backoff_registry().write().unwrap() = None;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn headers(pairs: &[(&str, &str)]) -> reqwest::header::HeaderMap {
+        let mut h = reqwest::header::HeaderMap::new();
+        for (k, v) in pairs {
+            h.insert(
+                reqwest::header::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                v.parse().unwrap(),
+            );
+        }
+        h
+    }
+
+    #[test]
+    fn retry_after_arms_backoff() {
+        clear_backoff();
+        assert!(!is_backing_off());
+        observe_rate_limit(
+            reqwest::StatusCode::FORBIDDEN,
+            &headers(&[("retry-after", "30")]),
+            &Value::Null,
+        );
+        assert!(is_backing_off(), "403 + Retry-After must pause polling");
+        clear_backoff();
+    }
+
+    #[test]
+    fn graphql_rate_limited_error_arms_backoff() {
+        clear_backoff();
+        let body = json!({ "errors": [{ "type": "RATE_LIMITED", "message": "API rate limit exceeded" }] });
+        observe_rate_limit(reqwest::StatusCode::OK, &headers(&[]), &body);
+        assert!(is_backing_off(), "GraphQL RATE_LIMITED must pause polling");
+        clear_backoff();
+    }
+
+    #[test]
+    fn healthy_response_does_not_arm_backoff() {
+        clear_backoff();
+        observe_rate_limit(
+            reqwest::StatusCode::OK,
+            &headers(&[("x-ratelimit-remaining", "4999")]),
+            &json!({ "data": {} }),
+        );
+        assert!(!is_backing_off(), "a normal response must not pause polling");
+    }
+
+    #[test]
+    fn budget_floor_arms_backoff_only_when_low() {
+        clear_backoff();
+        note_rate_budget(500, None);
+        assert!(!is_backing_off(), "ample budget must not pause");
+        note_rate_budget(1, None);
+        assert!(is_backing_off(), "budget at the floor must pause");
+        clear_backoff();
+    }
 
     /// The git auth header is the documented actions/checkout form: basic
     /// base64("x-access-token:<token>"), scoped to github.com https only.

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -650,6 +650,14 @@ async fn pr_batch<T>(
             let node = &data[format!("a{i}")]["pullRequest"];
             out.push((!node.is_null()).then(|| parse(node)));
         }
+        // A signal in this chunk's response — the budget crossing its floor, a
+        // Retry-After, or a RATE_LIMITED error — armed the gate. Stop before the
+        // next chunk spends the reserve, padding the unfetched refs with `None`
+        // so the result stays aligned 1:1 with `refs` (callers zip on that).
+        if client::is_backing_off() {
+            out.resize_with(refs.len(), || None);
+            break;
+        }
     }
     Ok(out)
 }

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -210,6 +210,20 @@ async fn require_repo_ref(checkout: &Path) -> Result<(String, String)> {
     })
 }
 
+/// Resolve `owner/repo` from the checkout's origin, falling back to the source
+/// repo when the checkout is broken or gone (they share an origin). `None` when
+/// neither resolves to a github.com remote. Shared by the by-number lookups
+/// (single and batched) that must survive a checkout casualty.
+pub(crate) async fn resolve_slug(checkout: &Path, source: Option<&Path>) -> Option<(String, String)> {
+    match repo_ref(checkout).await {
+        Some(slug) => Some(slug),
+        None => match source {
+            Some(src) => repo_ref(src).await,
+            None => None,
+        },
+    }
+}
+
 async fn require_current_branch(checkout: &Path, what: &str) -> Result<String> {
     crate::git::current_branch(checkout)
         .await?
@@ -245,6 +259,11 @@ fn pick_branch_pr(nodes: &[Value]) -> Option<&Value> {
 /// the same degradation the gh wrapper applied to its stderr ("could not
 /// resolve to a PullRequest", "...not found").
 async fn graphql_opt(query: &str, variables: Value) -> Result<Option<Value>> {
+    // A rate-limit pause is in effect — skip the request so callers degrade to
+    // the persisted snapshot instead of spending one that would likely 403.
+    if client::is_backing_off() {
+        return Ok(None);
+    }
     let client = match client::Client::new() {
         Ok(c) => c,
         // Read paths poll in the background; not being connected is a normal
@@ -340,13 +359,7 @@ pub async fn pr_view_number(
     source_repo: Option<&Path>,
     number: u32,
 ) -> Result<Option<PrState>> {
-    let mut slug = repo_ref(checkout).await;
-    if slug.is_none() {
-        if let Some(source) = source_repo {
-            slug = repo_ref(source).await;
-        }
-    }
-    let Some((owner, repo)) = slug else {
+    let Some((owner, repo)) = resolve_slug(checkout, source_repo).await else {
         return Ok(None);
     };
     let query = format!(
@@ -408,6 +421,27 @@ pub async fn pr_list(checkout: &Path, limit: u32) -> Result<Vec<PrSummary>> {
 // PR checks
 // ---------------------------------------------------------------------------
 
+/// GraphQL selection for the merge gate + per-check rollup on a PR node.
+/// `startedAt: createdAt` aliases StatusContext's field to the name the parser
+/// (shared with the CheckRun arm) expects. Reused by the branch lookup
+/// (`pr_checks`) and the by-number batch (`pr_checks_batch`).
+const PR_CHECKS_FIELDS: &str = r#"mergeStateStatus
+           commits(last:1){nodes{commit{statusCheckRollup{contexts(first:100){nodes{
+             __typename
+             ... on CheckRun { name status conclusion detailsUrl startedAt completedAt }
+             ... on StatusContext { context state targetUrl startedAt: createdAt }
+           }}}}}}"#;
+
+/// Extract [`PrChecks`] from a PR node carrying [`PR_CHECKS_FIELDS`].
+fn pr_checks_from_node(pr: &Value) -> PrChecks {
+    let merge_state = pr["mergeStateStatus"].as_str().unwrap_or("UNKNOWN").to_string();
+    let rollup = pr["commits"]["nodes"][0]["commit"]["statusCheckRollup"]["contexts"]["nodes"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    parse_pr_checks(&merge_state, &rollup)
+}
+
 /// Fetch the merge gate + per-check detail for the current branch's PR in one
 /// GraphQL call. `Ok(None)` when there is no PR; other failures surface as
 /// `Err` — the command layer treats both as "checks unavailable" and the
@@ -419,16 +453,7 @@ pub async fn pr_checks(checkout: &Path) -> Result<Option<PrChecks>> {
     let Some(branch) = crate::git::current_branch(checkout).await? else {
         return Ok(None);
     };
-    // `startedAt: createdAt` aliases StatusContext's field to the name the
-    // parser (shared with the CheckRun arm) expects.
-    let query = branch_prs_query(
-        r#"mergeStateStatus
-           commits(last:1){nodes{commit{statusCheckRollup{contexts(first:100){nodes{
-             __typename
-             ... on CheckRun { name status conclusion detailsUrl startedAt completedAt }
-             ... on StatusContext { context state targetUrl startedAt: createdAt }
-           }}}}}}"#,
-    );
+    let query = branch_prs_query(PR_CHECKS_FIELDS);
     let Some(data) = graphql_opt(
         &query,
         json!({ "owner": owner, "repo": repo, "branch": branch }),
@@ -441,12 +466,7 @@ pub async fn pr_checks(checkout: &Path) -> Result<Option<PrChecks>> {
     let Some(pr) = pick_branch_pr(&nodes) else {
         return Ok(None);
     };
-    let merge_state = pr["mergeStateStatus"].as_str().unwrap_or("UNKNOWN").to_string();
-    let rollup = pr["commits"]["nodes"][0]["commit"]["statusCheckRollup"]["contexts"]["nodes"]
-        .as_array()
-        .cloned()
-        .unwrap_or_default();
-    Ok(Some(parse_pr_checks(&merge_state, &rollup)))
+    Ok(Some(pr_checks_from_node(pr)))
 }
 
 /// Normalize the UPPERCASE rollup payload into the spec §6 shape. Pure — unit
@@ -544,6 +564,104 @@ fn parse_pr_checks(merge_state_status: &str, rollup: &[Value]) -> PrChecks {
         required_failing,
         runs,
     }
+}
+
+// ---------------------------------------------------------------------------
+// Batched multi-PR queries
+//
+// The app-wide polls (`refresh_all_pr_states`/`refresh_all_pr_checks`) used to
+// fan one GraphQL request out per agent, concurrently — the burst that trips
+// GitHub's secondary rate limit. Instead we collapse them into a single aliased
+// query (`a0: repository(...){pullRequest(number:…){…}} a1: …`), chunked, so N
+// agents cost ⌈N/50⌉ *sequential* requests rather than N concurrent ones.
+// ---------------------------------------------------------------------------
+
+/// One PR to look up by number in a batched query.
+#[derive(Debug, Clone)]
+pub(crate) struct PrRef {
+    pub owner: String,
+    pub repo: String,
+    pub number: u32,
+}
+
+/// Max PRs per batched request — each adds a top-level `repository` alias, so
+/// chunking keeps the query under GitHub's node/complexity limits.
+const BATCH_CHUNK: usize = 50;
+
+/// Build an aliased multi-PR query with a trailing `rateLimit` probe. Values
+/// ride in as variables (`$oN/$rN/$nN`) so nothing user-derived is interpolated
+/// into the query text.
+fn build_batch_query(chunk: &[PrRef], inner_fields: &str) -> (String, Value) {
+    let mut decls = Vec::with_capacity(chunk.len());
+    let mut aliases = Vec::with_capacity(chunk.len());
+    let mut vars = serde_json::Map::new();
+    for (i, r) in chunk.iter().enumerate() {
+        decls.push(format!("$o{i}:String!,$r{i}:String!,$n{i}:Int!"));
+        aliases.push(format!(
+            "a{i}:repository(owner:$o{i},name:$r{i}){{pullRequest(number:$n{i}){{{inner_fields}}}}}"
+        ));
+        vars.insert(format!("o{i}"), json!(r.owner));
+        vars.insert(format!("r{i}"), json!(r.repo));
+        vars.insert(format!("n{i}"), json!(r.number));
+    }
+    let query = format!(
+        "query({}){{{} rateLimit{{cost remaining resetAt}}}}",
+        decls.join(","),
+        aliases.join(" "),
+    );
+    (query, Value::Object(vars))
+}
+
+/// Feed the queried `rateLimit` budget into the client's backoff gate.
+fn note_budget(data: &Value) {
+    let rl = &data["rateLimit"];
+    if let Some(remaining) = rl["remaining"].as_i64() {
+        let reset = rl["resetAt"]
+            .as_str()
+            .and_then(|iso| chrono::DateTime::parse_from_rfc3339(iso).ok())
+            .map(|t| t.timestamp_millis());
+        client::note_rate_budget(remaining, reset);
+    }
+}
+
+/// Run `refs` through one or more batched queries, mapping each alias's
+/// `pullRequest` node with `parse`. Results align 1:1 with `refs`; a
+/// missing/inaccessible PR yields `None` for its slot (partial-error tolerant).
+/// `Ok(vec![])` for empty input; an active backoff short-circuits to all-`None`
+/// so callers fall back to the persisted snapshot without spending a request.
+async fn pr_batch<T>(
+    refs: &[PrRef],
+    inner_fields: &str,
+    parse: impl Fn(&Value) -> T,
+) -> Result<Vec<Option<T>>> {
+    if refs.is_empty() {
+        return Ok(Vec::new());
+    }
+    if client::is_backing_off() {
+        return Ok(refs.iter().map(|_| None).collect());
+    }
+    let client = client::Client::new()?;
+    let mut out = Vec::with_capacity(refs.len());
+    for chunk in refs.chunks(BATCH_CHUNK) {
+        let (query, vars) = build_batch_query(chunk, inner_fields);
+        let data = client.graphql_partial(&query, vars).await?;
+        note_budget(&data);
+        for i in 0..chunk.len() {
+            let node = &data[format!("a{i}")]["pullRequest"];
+            out.push((!node.is_null()).then(|| parse(node)));
+        }
+    }
+    Ok(out)
+}
+
+/// Fetch PR state for many PRs by number in one (chunked) round-trip.
+pub(crate) async fn pr_states_batch(refs: &[PrRef]) -> Result<Vec<Option<PrState>>> {
+    pr_batch(refs, &format!("state {PR_STATE_FIELDS}"), parse_pr_state).await
+}
+
+/// Fetch the merge gate + checks for many PRs by number in one round-trip.
+pub(crate) async fn pr_checks_batch(refs: &[PrRef]) -> Result<Vec<Option<PrChecks>>> {
+    pr_batch(refs, PR_CHECKS_FIELDS, pr_checks_from_node).await
 }
 
 // ---------------------------------------------------------------------------
@@ -918,6 +1036,24 @@ mod tests {
         let no_open = vec![pr_node("MERGED", 9, "UNKNOWN"), pr_node("CLOSED", 5, "UNKNOWN")];
         assert_eq!(pick_branch_pr(&no_open).unwrap()["number"].as_u64(), Some(9));
         assert!(pick_branch_pr(&[]).is_none());
+    }
+
+    #[test]
+    fn batch_query_builds_aliases_and_variables() {
+        let refs = vec![
+            PrRef { owner: "acme".into(), repo: "web".into(), number: 7 },
+            PrRef { owner: "acme".into(), repo: "api".into(), number: 12 },
+        ];
+        let (query, vars) = build_batch_query(&refs, "state number");
+        // One aliased repository/pullRequest per ref, values via variables.
+        assert!(query.contains("a0:repository(owner:$o0,name:$r0)"), "{query}");
+        assert!(query.contains("a1:repository(owner:$o1,name:$r1)"), "{query}");
+        assert!(query.contains("pullRequest(number:$n1)"), "{query}");
+        // The budget probe rides along on every batch.
+        assert!(query.contains("rateLimit"), "{query}");
+        assert_eq!(vars["o0"], json!("acme"));
+        assert_eq!(vars["r1"], json!("api"));
+        assert_eq!(vars["n1"], json!(12));
     }
 
     #[test]

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -11,7 +11,7 @@ mod shell;
 
 pub use lifecycle::SpawnRequest;
 pub use run::ProjectRunConfig;
-pub(crate) use session_sync::resolve_pr_state;
+pub(crate) use session_sync::{resolve_all_pr_states, resolve_pr_state};
 
 use parking_lot::Mutex;
 use std::collections::{HashMap, HashSet};

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -11,7 +11,7 @@ mod shell;
 
 pub use lifecycle::SpawnRequest;
 pub use run::ProjectRunConfig;
-pub(crate) use session_sync::{resolve_all_pr_states, resolve_pr_state};
+pub(crate) use session_sync::{persist_pr_snapshot, resolve_all_pr_states, resolve_pr_state};
 
 use parking_lot::Mutex;
 use std::collections::{HashMap, HashSet};

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -170,6 +170,131 @@ pub(crate) async fn resolve_pr_state(
     }
 }
 
+/// Resolve PR state for *every* bound agent in one batched round-trip — the
+/// app-wide poll behind `refresh_all_pr_states`. Same per-agent policy as
+/// [`resolve_pr_state`], but the live lookups are collapsed into a single
+/// aliased GraphQL query instead of a per-agent fan-out:
+///
+/// - **Merged** PRs are served from the persisted snapshot (terminal — never
+///   re-fetched).
+/// - **Closed** PRs are served from the snapshot too, *except* on the slow
+///   re-verify tick (`reverify_closed`), so a reopen is still eventually caught
+///   without paying a poll every cycle.
+/// - Everything else is fetched live by number and its snapshot refreshed.
+///
+/// A paused backoff, an unresolvable slug, a not-found alias, or a whole-batch
+/// failure all degrade to the last persisted snapshot rather than wiping the
+/// badge. Agents that resolve to nothing are omitted from the map (never
+/// written as absent state), matching the command's contract.
+pub(crate) async fn resolve_all_pr_states(
+    workspace: &WorkspaceManager,
+    reverify_closed: bool,
+) -> std::collections::HashMap<String, PrState> {
+    use crate::github::{client, PrRef};
+    use std::collections::HashMap;
+
+    let mut out: HashMap<String, PrState> = HashMap::new();
+    let Some(ws) = workspace.current() else {
+        return out;
+    };
+    // Paused → touch no network; every bound PR renders from its snapshot.
+    let paused = client::is_backing_off();
+
+    // A network-bound agent: what to fetch, plus the snapshot to fall back to.
+    struct Pending {
+        agent_id: String,
+        subdir: String,
+        snapshot: Option<PrState>,
+        pr_ref: PrRef,
+    }
+    let mut pending: Vec<Pending> = Vec::new();
+
+    for agent in ws.agents {
+        if agent.archive.is_some() {
+            continue;
+        }
+        let Some(repo) = agent.repos.first() else { continue };
+        // No branch → nothing pushed; no number → discovery isn't this poll's job.
+        if repo.branch.is_none() {
+            continue;
+        }
+        let Some(number) = repo.pr_number else { continue };
+        let snapshot = pr_snapshot(repo);
+
+        let terminal = repo.pr_state.as_deref() == Some(PrStatus::Merged.as_str());
+        let closed = repo.pr_state.as_deref() == Some(PrStatus::Closed.as_str());
+        // Merged never re-fetches; closed only on the slow re-verify tick.
+        let fetch = !paused && !terminal && (!closed || reverify_closed);
+        if !fetch {
+            if let Some(snap) = snapshot {
+                out.insert(agent.id.clone(), snap);
+            }
+            continue;
+        }
+
+        // Resolve the slug now (local git); the network cost is deferred to the
+        // one batched query below. A broken checkout / non-GitHub origin can't
+        // be fetched — hold the snapshot instead.
+        let slug = match repo_checkout_path(&agent.id, &repo.subdir) {
+            Ok(checkout) => crate::github::resolve_slug(&checkout, Some(&repo.repo_path)).await,
+            Err(_) => None,
+        };
+        match slug {
+            Some((owner, repo_name)) => pending.push(Pending {
+                agent_id: agent.id.clone(),
+                subdir: repo.subdir.clone(),
+                snapshot,
+                pr_ref: PrRef { owner, repo: repo_name, number: number as u32 },
+            }),
+            None => {
+                if let Some(snap) = snapshot {
+                    out.insert(agent.id.clone(), snap);
+                }
+            }
+        }
+    }
+
+    if pending.is_empty() {
+        return out;
+    }
+
+    let refs: Vec<PrRef> = pending.iter().map(|p| p.pr_ref.clone()).collect();
+    match crate::github::pr_states_batch(&refs).await {
+        Ok(results) => {
+            for (p, res) in pending.into_iter().zip(results) {
+                match res {
+                    Some(pr) => {
+                        if let Err(e) = workspace.set_repo_pr_snapshot(&p.agent_id, &p.subdir, &pr) {
+                            tracing::warn!(
+                                error = %e,
+                                agent_id = %p.agent_id,
+                                pr = pr.number,
+                                "failed to persist PR snapshot"
+                            );
+                        }
+                        out.insert(p.agent_id, pr);
+                    }
+                    // Not found this round / partial error — keep last-known.
+                    None => {
+                        if let Some(snap) = p.snapshot {
+                            out.insert(p.agent_id, snap);
+                        }
+                    }
+                }
+            }
+        }
+        // Whole-batch failure — degrade every bound agent to its snapshot.
+        Err(_) => {
+            for p in pending {
+                if let Some(snap) = p.snapshot {
+                    out.insert(p.agent_id, snap);
+                }
+            }
+        }
+    }
+    out
+}
+
 /// Does this agent keep its transcript file open across turns? Per-turn agents
 /// in the custom view *exit* at each turn-end, so the file is complete and
 /// quiescent the moment we sync. Everything else — claude, and any agent in the

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -99,6 +99,21 @@ pub(crate) fn pr_snapshot(repo: &TrackedRepo) -> Option<PrState> {
     })
 }
 
+/// Persist a freshly-fetched PR state to its repo's snapshot columns, logging
+/// (never propagating) a write failure. Every path that learns a PR's state —
+/// the single and batched polls and `create_pr` — funnels through here so the
+/// persistence contract lives in one place.
+pub(crate) fn persist_pr_snapshot(
+    workspace: &WorkspaceManager,
+    agent_id: &str,
+    subdir: &str,
+    pr: &PrState,
+) {
+    if let Err(e) = workspace.set_repo_pr_snapshot(agent_id, subdir, pr) {
+        tracing::warn!(error = %e, agent_id, pr = pr.number, "failed to persist PR snapshot");
+    }
+}
+
 /// Resolve the current PR state for an agent's primary repo, persisting what
 /// it learns. Returns the state plus whether that PR is *bound* to the agent
 /// by number. The single implementation behind the focused panel
@@ -138,14 +153,7 @@ pub(crate) async fn resolve_pr_state(
         match crate::github::pr_view_number(&checkout, Some(&repo.repo_path), number as u32).await
         {
             Ok(Some(pr)) => {
-                if let Err(e) = workspace.set_repo_pr_snapshot(agent_id, &repo.subdir, &pr) {
-                    tracing::warn!(
-                        error = %e,
-                        agent_id,
-                        pr = pr.number,
-                        "failed to persist PR snapshot"
-                    );
-                }
+                persist_pr_snapshot(workspace, agent_id, &repo.subdir, &pr);
                 Some((pr, true))
             }
             // Unreachable or not found — fall back to the last confirmed state.
@@ -154,14 +162,7 @@ pub(crate) async fn resolve_pr_state(
     } else {
         match crate::github::pr_view(&checkout).await.unwrap_or(None) {
             Some(pr) if matches!(pr.state, PrStatus::Open) => {
-                if let Err(e) = workspace.set_repo_pr_snapshot(agent_id, &repo.subdir, &pr) {
-                    tracing::warn!(
-                        error = %e,
-                        agent_id,
-                        pr = pr.number,
-                        "pr discovery: failed to persist PR snapshot"
-                    );
-                }
+                persist_pr_snapshot(workspace, agent_id, &repo.subdir, &pr);
                 Some((pr, true))
             }
             Some(pr) => Some((pr, false)),
@@ -264,14 +265,7 @@ pub(crate) async fn resolve_all_pr_states(
             for (p, res) in pending.into_iter().zip(results) {
                 match res {
                     Some(pr) => {
-                        if let Err(e) = workspace.set_repo_pr_snapshot(&p.agent_id, &p.subdir, &pr) {
-                            tracing::warn!(
-                                error = %e,
-                                agent_id = %p.agent_id,
-                                pr = pr.number,
-                                "failed to persist PR snapshot"
-                            );
-                        }
+                        persist_pr_snapshot(workspace, &p.agent_id, &p.subdir, &pr);
                         out.insert(p.agent_id, pr);
                     }
                     // Not found this round / partial error — keep last-known.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,13 @@ export function App() {
   // PR polls hit the GitHub API — skip them entirely in local-only mode
   // (no connection) so a GitHub-unaware user generates zero network chatter.
   const githubConnected = useAppStore((s) => s.github?.authenticated ?? false);
+  // Drive adaptive poll cadence: poll fast while there's something changing
+  // (an open PR, or checks still in flight) and back off hard once everything
+  // has settled, so an idle workspace of merged PRs stops hitting the API.
+  const anyOpenPr = useAppStore((s) => Object.values(s.prStates).some((p) => p?.state === "open"));
+  const anyChecksPending = useAppStore((s) =>
+    Object.values(s.prChecks).some((c) => c?.rollup === "pending"),
+  );
 
   const theme = useAppStore((s) => s.theme);
   const accent = useAppStore((s) => s.accent);
@@ -72,28 +79,29 @@ export function App() {
 
   // App-wide poll for remote PR state (open → merged / closed, mergeability)
   // so the sidebar PR badge tracks changes made on GitHub — a merge by a
-  // teammate, CI, or the web UI — without the user opening the Git panel. Each
-  // refresh is a `gh` network call, so this runs at a far gentler cadence than
-  // the local shortstats poll, and the backend only touches agents that
-  // actually have a PR.
+  // teammate, CI, or the web UI — without the user opening the Git panel. The
+  // whole sweep is now one batched `gh` call. Cadence adapts: 45s while any PR
+  // is open (a merge/close is worth catching quickly), backing off to 5min once
+  // every PR has settled — merged PRs answer from the local snapshot anyway, so
+  // the slow tick just watches for a rare reopen.
   usePoll(
     async () => {
       if (githubConnected) await refreshAllPrStates();
     },
-    45000,
-    [refreshAllPrStates, githubConnected],
+    anyOpenPr ? 45000 : 300000,
+    [refreshAllPrStates, githubConnected, anyOpenPr],
   );
 
   // App-wide poll for CI checks so each sidebar PR pill can be tinted pass/fail
-  // at a glance. One `gh` call per open PR, so this rides an even gentler
-  // cadence than PR state — checks flip over minutes, not seconds, and the
-  // focused Git panel keeps its own faster per-agent checks poll.
+  // at a glance — one batched `gh` call. Cadence follows the checks themselves:
+  // 60s while any are in flight, 2min while PRs are open but settled (still
+  // catches a fresh push kicking off new checks), and 5min once nothing is open.
   usePoll(
     async () => {
       if (githubConnected) await refreshAllPrChecks();
     },
-    60000,
-    [refreshAllPrChecks, githubConnected],
+    anyChecksPending ? 60000 : anyOpenPr ? 120000 : 300000,
+    [refreshAllPrChecks, githubConnected, anyChecksPending, anyOpenPr],
   );
 
   // Apply theme + density via html classes; accent via CSS vars.

--- a/src/components/RightPanel/GitPanel/hooks/useGitPanelData.ts
+++ b/src/components/RightPanel/GitPanel/hooks/useGitPanelData.ts
@@ -30,11 +30,16 @@ export function useGitPanelData(agentId: string) {
   const prOpen = prState?.state === "open";
   const pollChecks = useCallback(async () => {
     if (!prOpen) return;
-    // Checks + review comments share the slow cadence: both are heavier gh
-    // reads that only matter while a PR is open.
+    // Checks + review comments share a cadence: both are heavier gh reads that
+    // only matter while a PR is open.
     await Promise.all([fetchPrChecks(agentId), fetchPrComments(agentId)]);
   }, [agentId, prOpen, fetchPrChecks, fetchPrComments]);
-  usePoll(pollChecks, 5000, [pollChecks]);
+  // Adaptive: 5s while checks are still in flight (or not yet fetched), backing
+  // off to 15s once they've settled pass/fail — a settled PR rarely changes, and
+  // the app-wide poll still covers it. `undefined` (first fetch pending) counts
+  // as in-flight so the initial read lands promptly.
+  const checksSettled = prOpen && prChecksEntry != null && prChecksEntry.rollup !== "pending";
+  usePoll(pollChecks, checksSettled ? 15000 : 5000, [pollChecks, checksSettled]);
 
   const checks = prChecksEntry ?? null;
   const comments = prCommentsEntry ?? null;

--- a/src/store/git.ts
+++ b/src/store/git.ts
@@ -106,8 +106,9 @@ export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
   refreshAllPrChecks: async () => {
     try {
       // Merge (like refreshAllPrStates) so the focused panel's per-agent
-      // checks poll isn't clobbered between bulk ticks. Absent agents keep
-      // their last value; agents with a `null` reply record "no checks".
+      // checks poll isn't clobbered between bulk ticks. The batched reply only
+      // carries resolved rollups, so absent agents keep their last value rather
+      // than being wiped.
       const map = await api.refreshAllPrChecks();
       set((s) => ({ prChecks: { ...s.prChecks, ...map } }));
     } catch {


### PR DESCRIPTION
## Why

We were hitting GitHub API secondary rate limits when submitting PRs, despite low PR volume. Diagnosis: submitting a PR is cheap (~3 calls); the quota was burned by **background polling** that fanned one GraphQL request out **per agent, concurrently** (`tokio::JoinSet`) every 45s/60s. Concurrent bursts — not raw hourly volume — trip GitHub's secondary/concurrency limit.

## What

**1. Batch the GraphQL polls (the core fix)**
- New `PrRef` + `build_batch_query` build a single aliased query (`a0: repository(...){pullRequest(number:N){…}} a1: …`), chunked at 50/request, with a trailing `rateLimit` probe.
- `pr_states_batch` / `pr_checks_batch` collapse the per-agent fan-out into **⌈N/50⌉ sequential requests instead of N concurrent ones**.
- `resolve_all_pr_states` replaces the per-agent `JoinSet` in `refresh_all_pr_states`; `refresh_all_pr_checks` issues one batch. Frontend command contracts unchanged. Extracted `resolve_slug` / `PR_CHECKS_FIELDS` to share code.

**2. Rate-limit backoff**
- Process-global "don't call until" gate in the GitHub client, armed by `Retry-After` (403/429), GraphQL `RATE_LIMITED` errors, exhausted `x-ratelimit-remaining`, or the queried `rateLimit` budget nearing its floor.
- Poll paths serve the persisted DB snapshot while paused; user-initiated create/merge skip the gate so they still error loudly.

**3. Adaptive cadence**
- Closed PRs re-verify only on a slow tick (they can reopen); merged stays fully terminal (DB snapshot).
- Frontend poll intervals slow as PRs settle/close (45s→5min state, 60s→2min→5min checks, focused-panel checks 5s→15s) and speed back up when an open PR has in-flight checks.

## Notes
- `ETags` (originally requested) don't apply: all PR reads are GraphQL (needs `mergeStateStatus`/`statusCheckRollup`), which has no conditional-request/304 support. Pivoted to `rateLimit`-driven backoff for the same goal.
- During an active backoff, the focused Git panel's checks section shows "unavailable" until the pause clears; sidebar badges keep last-known state.

## Testing
- `cargo test` — 538 pass. New unit tests cover backoff arming (Retry-After / RATE_LIMITED / budget floor / healthy no-op) and the batch-query builder. Clippy clean on touched files; `tsc --noEmit` passes.
- Frontend `vitest`/`biome` full runs unavailable in this environment (missing dev deps); touched files are biome-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)