### PR TITLE
fix(git): surface untracked files as green U with real diffs and line counts

### DIFF
--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -1330,25 +1330,59 @@ pub async fn file_changed_lines(
     base_ref: &str,
     path: &str,
 ) -> Result<(Vec<u32>, Vec<u32>)> {
-    let out = run_git(
-        checkout,
-        &["diff", "--no-color", "-U0", base_ref, "--", path],
-        &format!("diff -U0 {base_ref} -- {path}"),
-    )
-    .await?;
-    Ok(parse_changed_lines(&String::from_utf8_lossy(&out.stdout)))
+    let diff = file_diff_unified(checkout, base_ref, path, "-U0").await?;
+    Ok(parse_changed_lines(&diff))
 }
 
 /// Return the full unified diff of `path` versus `base_ref`, for the Code
 /// panel's live view. `-U3` gives three lines of surrounding context per hunk.
 pub async fn file_diff(checkout: &Path, base_ref: &str, path: &str) -> Result<String> {
+    file_diff_unified(checkout, base_ref, path, "-U3").await
+}
+
+/// Unified diff of `path` versus `base_ref` with the given `-U<n>` context
+/// flag. `git diff <ref>` only covers files in the index, so an untracked
+/// (agent-created, never `git add`ed) file diffs as empty; when that happens,
+/// re-diff it against /dev/null with `--no-index`, which renders the whole
+/// file as one added hunk.
+async fn file_diff_unified(
+    checkout: &Path,
+    base_ref: &str,
+    path: &str,
+    unified: &str,
+) -> Result<String> {
     let out = run_git(
         checkout,
-        &["diff", "--no-color", "-U3", base_ref, "--", path],
-        &format!("diff -U3 {base_ref} -- {path}"),
+        &["diff", "--no-color", unified, base_ref, "--", path],
+        &format!("diff {unified} {base_ref} -- {path}"),
     )
     .await?;
-    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+    if !out.stdout.is_empty() || is_tracked(checkout, path).await {
+        return Ok(String::from_utf8_lossy(&out.stdout).into_owned());
+    }
+    // `--no-index` exits 1 whenever the two sides differ, so accept 0 and 1.
+    let out = git_output(
+        checkout,
+        &["diff", "--no-color", unified, "--no-index", "--", "/dev/null", path],
+    )
+    .await?;
+    match out.status.code() {
+        Some(0) | Some(1) => Ok(String::from_utf8_lossy(&out.stdout).into_owned()),
+        _ => Err(Error::Git(format!(
+            "diff --no-index -- /dev/null {path} failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ))),
+    }
+}
+
+/// Whether `path` is in the index. `ls-files --error-unmatch` exits 0 for
+/// tracked paths; a spawn failure counts as tracked so callers fall back to
+/// the plain-diff result rather than a second diff that would also fail.
+async fn is_tracked(checkout: &Path, path: &str) -> bool {
+    git_output(checkout, &["ls-files", "--error-unmatch", "--", path])
+        .await
+        .map(|o| o.status.success())
+        .unwrap_or(true)
 }
 
 /// Parse `git diff -U0` output into (added, modified) new-file line numbers.

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -1363,17 +1363,25 @@ async fn file_diff_unified(
     // `--no-index` exits 1 whenever the two sides differ, so accept 0 and 1.
     let out = git_output(
         checkout,
-        &["diff", "--no-color", unified, "--no-index", "--", "/dev/null", path],
+        &["diff", "--no-color", unified, "--no-index", "--", NULL_DEVICE, path],
     )
     .await?;
     match out.status.code() {
         Some(0) | Some(1) => Ok(String::from_utf8_lossy(&out.stdout).into_owned()),
         _ => Err(Error::Git(format!(
-            "diff --no-index -- /dev/null {path} failed: {}",
+            "diff --no-index -- {path} failed: {}",
             String::from_utf8_lossy(&out.stderr).trim()
         ))),
     }
 }
+
+/// The null device handed to `diff --no-index` as the "before" side. The app
+/// ships macOS-only today, but name the Windows device explicitly rather than
+/// relying on Git-for-Windows' msys `/dev/null` emulation if that changes.
+#[cfg(windows)]
+const NULL_DEVICE: &str = "NUL";
+#[cfg(not(windows))]
+const NULL_DEVICE: &str = "/dev/null";
 
 /// Whether `path` is in the index. `ls-files --error-unmatch` exits 0 for
 /// tracked paths; a spawn failure counts as tracked so callers fall back to

--- a/src-tauri/src/git_state.rs
+++ b/src-tauri/src/git_state.rs
@@ -113,11 +113,15 @@ pub async fn query(checkout_path: &Path, parent_branch: &str) -> Result<GitState
         Err(_) => HashMap::new(),
     };
 
-    // Merge numstat into file list
+    // Merge numstat into file list. `git diff --numstat HEAD` only covers
+    // tracked files, so untracked (agent-created, never-added) ones fall back
+    // to a direct line count of their on-disk contents.
     for f in &mut files {
         if let Some(&(adds, dels)) = numstat.get(&f.path) {
             f.additions = adds;
             f.deletions = dels;
+        } else if matches!(f.kind, StatusKind::Untracked) {
+            f.additions = untracked_additions(checkout_path, &f.path).await;
         }
     }
 
@@ -153,15 +157,41 @@ pub async fn query(checkout_path: &Path, parent_branch: &str) -> Result<GitState
 /// agent, matching the badge's "no news is zero" contract.
 pub async fn shortstats(checkout_path: &Path) -> ShortStats {
     let (status, numstat) = tokio::join!(run_status(checkout_path), run_numstat(checkout_path));
-    let file_count = status.map(|o| parse_porcelain(&o).len() as u32).unwrap_or(0);
-    let (additions, deletions) = numstat
+    let files = status.map(|o| parse_porcelain(&o)).unwrap_or_default();
+    let file_count = files.len() as u32;
+    let (mut additions, deletions) = numstat
         .map(|o| {
             parse_numstat(&o)
                 .values()
                 .fold((0, 0), |(a, d), &(adds, dels)| (a + adds, d + dels))
         })
         .unwrap_or((0, 0));
+    // Numstat misses untracked files (see `query`); count their lines too.
+    for f in &files {
+        if matches!(f.kind, StatusKind::Untracked) {
+            additions += untracked_additions(checkout_path, &f.path).await;
+        }
+    }
     ShortStats { additions, deletions, file_count }
+}
+
+/// Additions for an untracked file: the line count of its on-disk contents —
+/// what `git diff --numstat` would report once the file is added. Binary,
+/// oversized, or unreadable files count 0, mirroring numstat's `-` markers.
+async fn untracked_additions(checkout_path: &Path, rel: &str) -> u32 {
+    const MAX_BYTES: u64 = 4 * 1024 * 1024;
+    let abs = checkout_path.join(rel);
+    let Ok(meta) = tokio::fs::metadata(&abs).await else { return 0 };
+    if !meta.is_file() || meta.len() > MAX_BYTES {
+        return 0;
+    }
+    let Ok(bytes) = tokio::fs::read(&abs).await else { return 0 };
+    if bytes.is_empty() || bytes.contains(&0) {
+        return 0;
+    }
+    let newlines = bytes.iter().filter(|&&b| b == b'\n').count() as u32;
+    // A final line without a trailing newline still counts as a line.
+    if bytes.ends_with(b"\n") { newlines } else { newlines + 1 }
 }
 
 /// HEAD commit SHA, or `None` when it can't be read.
@@ -277,7 +307,10 @@ async fn rev_list_counts(checkout_path: &Path, base: &str) -> Option<(u32, u32)>
 
 async fn run_status(checkout_path: &Path) -> Result<String> {
     let out = crate::git_dist::command(checkout_path)
-        .args(["status", "--porcelain=v1"])
+        // `-uall` lists each file inside an untracked directory individually
+        // (the default collapses them into one `dir/` entry, which can't be
+        // diffed or counted per-file).
+        .args(["status", "--porcelain=v1", "-uall"])
         .output()
         .await?;
     if !out.status.success() {

--- a/src-tauri/src/git_state.rs
+++ b/src-tauri/src/git_state.rs
@@ -115,13 +115,22 @@ pub async fn query(checkout_path: &Path, parent_branch: &str) -> Result<GitState
 
     // Merge numstat into file list. `git diff --numstat HEAD` only covers
     // tracked files, so untracked (agent-created, never-added) ones fall back
-    // to a direct line count of their on-disk contents.
-    for f in &mut files {
+    // to a direct line count of their on-disk contents, read concurrently so
+    // many new files don't serialize the poll.
+    let mut reads = tokio::task::JoinSet::new();
+    for (i, f) in files.iter_mut().enumerate() {
         if let Some(&(adds, dels)) = numstat.get(&f.path) {
             f.additions = adds;
             f.deletions = dels;
         } else if matches!(f.kind, StatusKind::Untracked) {
-            f.additions = untracked_additions(checkout_path, &f.path).await;
+            let root = checkout_path.to_path_buf();
+            let rel = f.path.clone();
+            reads.spawn(async move { (i, untracked_additions(&root, &rel).await) });
+        }
+    }
+    while let Some(res) = reads.join_next().await {
+        if let Ok((i, adds)) = res {
+            files[i].additions = adds;
         }
     }
 
@@ -166,11 +175,18 @@ pub async fn shortstats(checkout_path: &Path) -> ShortStats {
                 .fold((0, 0), |(a, d), &(adds, dels)| (a + adds, d + dels))
         })
         .unwrap_or((0, 0));
-    // Numstat misses untracked files (see `query`); count their lines too.
+    // Numstat misses untracked files (see `query`); count their lines too,
+    // concurrently, to keep this poll-path helper's latency flat.
+    let mut reads = tokio::task::JoinSet::new();
     for f in &files {
         if matches!(f.kind, StatusKind::Untracked) {
-            additions += untracked_additions(checkout_path, &f.path).await;
+            let root = checkout_path.to_path_buf();
+            let rel = f.path.clone();
+            reads.spawn(async move { untracked_additions(&root, &rel).await });
         }
+    }
+    while let Some(res) = reads.join_next().await {
+        additions += res.unwrap_or(0);
     }
     ShortStats { additions, deletions, file_count }
 }

--- a/src/components/RightPanel/Code/Code.css
+++ b/src/components/RightPanel/Code/Code.css
@@ -254,7 +254,8 @@
   background: color-mix(in oklch, var(--info), transparent 80%);
   color: var(--info);
 }
-.code-tab.status-a .ct-status {
+.code-tab.status-a .ct-status,
+.code-tab.status-u .ct-status {
   background: color-mix(in oklch, var(--success), transparent 80%);
   color: var(--success);
 }

--- a/src/components/RightPanel/Code/CodeLivePanel.tsx
+++ b/src/components/RightPanel/Code/CodeLivePanel.tsx
@@ -34,7 +34,7 @@ function statusLetter(kind: FileStatus["kind"]): string {
     case "renamed":
       return "R";
     case "untracked":
-      return "?";
+      return "U"; // new-but-unstaged file, shown green like VS Code
     case "conflicted":
       return "!";
     default:

--- a/src/components/RightPanel/GitPanel/ChangesList.tsx
+++ b/src/components/RightPanel/GitPanel/ChangesList.tsx
@@ -14,7 +14,7 @@ function kindLabel(kind: FileStatus["kind"]): string {
     case "renamed":
       return "R";
     case "untracked":
-      return "?";
+      return "U"; // new-but-unstaged file, shown green like VS Code
     case "conflicted":
       return "!";
     default:

--- a/src/components/RightPanel/GitPanel/GitPanel.css
+++ b/src/components/RightPanel/GitPanel/GitPanel.css
@@ -237,7 +237,7 @@
   color: var(--info);
 }
 .git-file .gs.untracked {
-  color: var(--fg-3);
+  color: var(--success);
 }
 .git-file .gs.conflicted {
   color: var(--danger);


### PR DESCRIPTION
## Problem

Files created by agents show up broken in the app's git surfaces:

- The Git panel marks them with a grey `?` badge and no `+N` line count
- The Code panel's Live view shows "Nothing to show — this change has no textual diff"
- Files inside a brand-new directory collapse into a single undiffable `dir/` row

Root cause: agent-created files are **untracked** (written but never `git add`-ed), and every consumer only handled tracked changes — `git diff <ref>` silently excludes untracked paths, so both the per-file diff and `--numstat` counts came back empty, and the UI styled the `untracked` kind as muted grey.

## Fix

**Backend**
- `file_diff` / `file_changed_lines` share a new helper: when the tracked diff is empty and `git ls-files --error-unmatch` says the path isn't in the index, re-diff against `/dev/null` with `git diff --no-index` (accepting exit code 1, which means "differs"), rendering the whole file as one added hunk. Fixes the Live view and the editor gutter.
- Untracked files missing from `--numstat` get additions from a direct line count of their contents (4 MiB cap, null-byte binary sniff, mirroring numstat's `-` markers) — applied in both `query` (per-file `+N`) and `shortstats` (app-wide badge). This also fixes Live-view refetching, which keys off the `+/-` signature and never fired for files stuck at 0:0.
- `git status` now runs with `-uall` so each file in a new directory gets its own row.

**Frontend**
- `untracked` maps to a green **U** (VS Code convention) in the Git panel changes list and the Code panel tabs; CSS updated accordingly. The backend kind stays distinct — the editor already folded it into "A".

## Testing

- Full Rust suite passes (539 tests), `tsc --noEmit` clean
- Verified the exact git command sequence in a scratch repo: empty tracked diff → `ls-files` exit 1 → well-formed `@@ -0,0 +1,3 @@` hunk from `--no-index`, which `parseUnifiedDiff` handles as-is; line-count logic matches numstat semantics (trailing partial line counts)

Known leftover: an untracked *empty* file still shows "Nothing to show" (no hunk exists) — matches VS Code behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)