### PR TITLE
feat: one-click installs for portable git and agent CLIs

### DIFF
--- a/src-tauri/src/agent_install.rs
+++ b/src-tauri/src/agent_install.rs
@@ -36,7 +36,7 @@ pub fn install_command(id: &str) -> Option<&'static str> {
         match id {
             "claude" => Some("curl -fsSL https://claude.ai/install.sh | bash"),
             "codex" => Some("curl -fsSL https://chatgpt.com/codex/install.sh | sh"),
-            "cursor" => Some("curl https://cursor.com/install -fsS | bash"),
+            "cursor" => Some("curl -fsSL https://cursor.com/install | bash"),
             "opencode" => Some("curl -fsSL https://opencode.ai/install | bash"),
             _ => None,
         }
@@ -143,12 +143,16 @@ async fn run_streamed(
         child.stdout.take().map(|s| Box::new(s) as _),
         child.stderr.take().map(|s| Box::new(s) as _),
     ];
-    let mut readers = Vec::new();
+    // JoinSet, not detached spawns: when the caller's timeout cancels this
+    // future, dropping the set aborts the readers with it — otherwise they'd
+    // keep emitting "running" lines after the terminal "failed" event while
+    // the killed child's pipes drain.
+    let mut readers = tokio::task::JoinSet::new();
     for stream in streams.into_iter().flatten() {
         let id = id.to_string();
         let emit = emit.clone();
         let last_line = last_line.clone();
-        readers.push(tokio::spawn(async move {
+        readers.spawn(async move {
             let mut lines = BufReader::new(stream).lines();
             while let Ok(Some(line)) = lines.next_line().await {
                 let line = line.trim();
@@ -161,11 +165,9 @@ async fn run_streamed(
                 *last_line.lock().unwrap() = line.clone();
                 emit(json!({ "id": id, "phase": "running", "line": line }));
             }
-        }));
+        });
     }
-    for reader in readers {
-        let _ = reader.await;
-    }
+    while readers.join_next().await.is_some() {}
 
     let status = child
         .wait()

--- a/src-tauri/src/agent_install.rs
+++ b/src-tauri/src/agent_install.rs
@@ -1,0 +1,183 @@
+//! One-click installation of agent CLIs via their official native installer
+//! scripts (no Node/npm required — each ships a standalone binary).
+//!
+//! The commands are pinned here rather than passed from the renderer, so the
+//! UI can only ever trigger a known vendor installer. Each command mirrors
+//! the copy-paste string shown as the manual fallback in the UI
+//! (`src/data/providerDetail.ts`) — keep the two in sync.
+//!
+//! Installers drop binaries into the usual per-user dirs (`~/.local/bin`,
+//! `~/.codex/bin`, …), all of which `bin_resolve` already scans, so a
+//! post-install re-probe picks the new agent up with no extra wiring.
+
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+/// Ceiling on a single installer run. The scripts download ~50–150 MB and
+/// finish in well under a minute on a normal connection; this only exists so
+/// a hung curl doesn't hold the per-agent in-flight guard forever.
+const INSTALL_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+
+/// The pinned official installer for an agent on this platform, if one
+/// exists. Unix commands run through `bash -c`; Windows through PowerShell.
+/// Agents without a scripted installer (antigravity, pi — and cursor/opencode
+/// on Windows) return `None` and the UI falls back to their docs link.
+pub fn install_command(id: &str) -> Option<&'static str> {
+    if cfg!(windows) {
+        match id {
+            "claude" => Some("irm https://claude.ai/install.ps1 | iex"),
+            "codex" => Some("irm https://chatgpt.com/codex/install.ps1 | iex"),
+            _ => None,
+        }
+    } else {
+        match id {
+            "claude" => Some("curl -fsSL https://claude.ai/install.sh | bash"),
+            "codex" => Some("curl -fsSL https://chatgpt.com/codex/install.sh | sh"),
+            "cursor" => Some("curl https://cursor.com/install -fsS | bash"),
+            "opencode" => Some("curl -fsSL https://opencode.ai/install | bash"),
+            _ => None,
+        }
+    }
+}
+
+/// Agents with an installer currently running — a second click on the same
+/// tile (or the same agent from two windows) errors instead of racing two
+/// installers over the same install dir.
+fn in_flight() -> &'static Mutex<HashSet<String>> {
+    static SET: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    SET.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Removes the agent from the in-flight set on drop, so the error and timeout
+/// paths can't leak a stuck "already installing" state.
+struct InFlightGuard(String);
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        in_flight().lock().unwrap().remove(&self.0);
+    }
+}
+
+/// Run the pinned installer for `id`, streaming its output through `emit` as
+/// `agent-install:state` payloads: `{id, phase: "running", line}` per output
+/// line, then a final `{id, phase: "done"}` or `{id, phase: "failed", error}`.
+/// Resolves when the installer exits; the caller re-probes to confirm the
+/// binary actually appeared.
+pub async fn install(
+    id: String,
+    emit: impl Fn(Value) + Send + Sync + 'static,
+) -> Result<(), String> {
+    let cmd = install_command(&id)
+        .ok_or_else(|| format!("no scripted installer for `{id}` on this platform"))?;
+    if !in_flight().lock().unwrap().insert(id.clone()) {
+        return Err(format!("`{id}` installation is already in progress"));
+    }
+    let _guard = InFlightGuard(id.clone());
+    let emit: Arc<dyn Fn(Value) + Send + Sync> = Arc::new(emit);
+
+    emit(json!({ "id": id, "phase": "running", "line": format!("$ {cmd}") }));
+    tracing::info!(agent = %id, %cmd, "running agent installer");
+
+    let result = tokio::time::timeout(INSTALL_TIMEOUT, run_streamed(&id, cmd, emit.clone())).await;
+    match result {
+        Ok(Ok(())) => {
+            emit(json!({ "id": id, "phase": "done" }));
+            tracing::info!(agent = %id, "agent installer finished");
+            Ok(())
+        }
+        Ok(Err(e)) => {
+            tracing::warn!(agent = %id, error = %e, "agent installer failed");
+            emit(json!({ "id": id, "phase": "failed", "error": e.clone() }));
+            Err(e)
+        }
+        Err(_) => {
+            let e = "installer timed out".to_string();
+            tracing::warn!(agent = %id, "agent installer timed out");
+            emit(json!({ "id": id, "phase": "failed", "error": e.clone() }));
+            Err(e)
+        }
+    }
+}
+
+/// Spawn the installer and forward each output line to `emit`. stderr is
+/// read alongside stdout — installer scripts write progress to both — and
+/// the last non-empty line is kept for the error message when the exit
+/// status is non-zero (curl and the vendor scripts put the reason there).
+async fn run_streamed(
+    id: &str,
+    cmd: &str,
+    emit: Arc<dyn Fn(Value) + Send + Sync>,
+) -> Result<(), String> {
+    use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
+
+    let mut command = if cfg!(windows) {
+        let mut c = tokio::process::Command::new("powershell");
+        c.args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", cmd]);
+        c
+    } else {
+        let mut c = tokio::process::Command::new("bash");
+        c.args(["-c", cmd]);
+        c
+    };
+    // GUI processes inherit launchd's sparse env; the installers expect a
+    // normal user environment (PATH, HOME, proxy vars) to pick install dirs
+    // and update shell profiles.
+    if let Some(env) = crate::bin_resolve::login_shell_env() {
+        command.envs(env);
+    }
+    command
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true);
+
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("spawn installer: {e}"))?;
+
+    let last_line = Arc::new(Mutex::new(String::new()));
+    let streams: [Option<Box<dyn AsyncRead + Send + Unpin>>; 2] = [
+        child.stdout.take().map(|s| Box::new(s) as _),
+        child.stderr.take().map(|s| Box::new(s) as _),
+    ];
+    let mut readers = Vec::new();
+    for stream in streams.into_iter().flatten() {
+        let id = id.to_string();
+        let emit = emit.clone();
+        let last_line = last_line.clone();
+        readers.push(tokio::spawn(async move {
+            let mut lines = BufReader::new(stream).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let line = line.trim();
+                if line.is_empty() {
+                    continue;
+                }
+                // Installer output is untrusted length-wise (progress bars
+                // can be one huge line); cap what crosses the event bridge.
+                let line: String = line.chars().take(400).collect();
+                *last_line.lock().unwrap() = line.clone();
+                emit(json!({ "id": id, "phase": "running", "line": line }));
+            }
+        }));
+    }
+    for reader in readers {
+        let _ = reader.await;
+    }
+
+    let status = child
+        .wait()
+        .await
+        .map_err(|e| format!("wait installer: {e}"))?;
+    if status.success() {
+        return Ok(());
+    }
+    let last = last_line.lock().unwrap().clone();
+    Err(if last.is_empty() {
+        format!("installer exited with {status}")
+    } else {
+        format!("installer exited with {status}: {last}")
+    })
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1369,6 +1369,35 @@ pub async fn check_cli(name: String) -> ToolStatus {
         })
 }
 
+/// Manually (re)trigger portable-git resolution/installation. The startup
+/// bootstrap may have failed (offline first launch, blocked network) — this
+/// gives the readiness UI a retry that doesn't require an app restart. Emits
+/// the same `git-dist:state` events as the startup path, so existing
+/// listeners render its progress unchanged.
+#[tauri::command]
+pub async fn git_dist_install(app: AppHandle) -> Result<()> {
+    use tauri::Emitter;
+    crate::git_dist::resolve_or_install(move |payload| {
+        let _ = app.emit("git-dist:state", payload);
+    })
+    .await
+    .map_err(Error::Other)
+}
+
+/// Run the pinned official installer for an agent CLI (see `agent_install`),
+/// streaming progress via `agent-install:state` events. Resolves when the
+/// installer exits; the frontend re-probes providers afterwards to confirm
+/// the binary is now detectable.
+#[tauri::command]
+pub async fn install_agent(app: AppHandle, id: String) -> Result<()> {
+    use tauri::Emitter;
+    crate::agent_install::install(id, move |payload| {
+        let _ = app.emit("agent-install:state", payload);
+    })
+    .await
+    .map_err(Error::Other)
+}
+
 /// Validate a candidate custom agent binary path: is it an executable file,
 /// and what `--version` does it report? The providers settings UI calls this
 /// before saving a path override so it can show immediate inline feedback

--- a/src-tauri/src/git_dist.rs
+++ b/src-tauri/src/git_dist.rs
@@ -532,11 +532,33 @@ fn locate_dist_root(unpacked: &Path) -> Option<PathBuf> {
 /// the time the user reaches onboarding's readiness screen. `emit` receives
 /// JSON state payloads for the `git-dist:state` frontend event.
 pub async fn startup(emit: impl Fn(Value) + Send + Sync + 'static) {
+    let _ = resolve_or_install(emit).await;
+}
+
+/// Serializes install attempts: the startup bootstrap and a manual retry from
+/// the UI can overlap, and the loser must wait and then observe the winner's
+/// completed install (via `ensure_installed`'s idempotence) instead of
+/// downloading a second copy over it.
+fn install_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+/// Resolve, and when nothing usable exists, download + install the portable
+/// dist. Shared by the startup bootstrap and the `git_dist_install` command
+/// (the UI's retry after a failed bootstrap — offline first launch, blocked
+/// network), so both paths emit identical `git-dist:state` payloads and the
+/// frontend needs one listener. The returned error is also emitted as the
+/// `failed` phase.
+pub async fn resolve_or_install(
+    emit: impl Fn(Value) + Send + Sync + 'static,
+) -> Result<(), String> {
+    let _guard = install_lock().lock().await;
     emit(json!({ "phase": "checking" }));
     let resolved = tokio::task::spawn_blocking(resolve).await.ok().flatten();
     if let Some(bin) = resolved {
         emit(json!({ "phase": "ready", "source": bin.source.as_str() }));
-        return;
+        return Ok(());
     }
     emit(json!({ "phase": "downloading" }));
     let emit = Arc::new(emit);
@@ -550,10 +572,14 @@ pub async fn startup(emit: impl Fn(Value) + Send + Sync + 'static) {
     })
     .await;
     match result {
-        Ok(()) => emit(json!({ "phase": "ready", "source": "portable" })),
+        Ok(()) => {
+            emit(json!({ "phase": "ready", "source": "portable" }));
+            Ok(())
+        }
         Err(e) => {
             tracing::warn!(error = %e, "portable git install failed");
-            emit(json!({ "phase": "failed", "error": e }));
+            emit(json!({ "phase": "failed", "error": e.clone() }));
+            Err(e)
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod activity;
 mod agent;
+mod agent_install;
 mod bin_resolve;
 mod child_io;
 mod commands;
@@ -1111,6 +1112,8 @@ pub fn run() {
             commands::copy_checkout_file,
             commands::probe_provider_versions,
             commands::check_cli,
+            commands::git_dist_install,
+            commands::install_agent,
             commands::validate_agent_bin,
             commands::discover_supported_models,
             commands::reveal_logs,

--- a/src/api.ts
+++ b/src/api.ts
@@ -629,6 +629,14 @@ export const api = {
   probeProviderVersions: () => invoke<ProviderProbe[]>("probe_provider_versions"),
   /** Resolve a required non-agent CLI (e.g. "git") and probe its version. */
   checkCli: (name: string) => invoke<ToolStatus>("check_cli", { name }),
+  /** Manually (re)run portable-git resolution/installation — the retry for a
+   *  failed startup bootstrap. Progress arrives via `git-dist:state` events
+   *  (see useGitDist); rejects with the install error on failure. */
+  gitDistInstall: () => invoke<void>("git_dist_install"),
+  /** Run the pinned official installer for an agent CLI. Progress arrives via
+   *  `agent-install:state` events; resolves when the installer exits. Callers
+   *  re-probe providers afterwards to confirm detection. */
+  installAgent: (id: string) => invoke<void>("install_agent", { id }),
   /** Check a candidate custom binary path before saving it as an override. */
   validateAgentBin: (path: string) => invoke<BinValidation>("validate_agent_bin", { path }),
   /** Set (or clear, with a null/blank path) a per-agent custom binary path.
@@ -639,6 +647,20 @@ export const api = {
    *  The frontend enriches these against models.dev. */
   discoverSupportedModels: () => invoke<AgentModels[]>("discover_supported_models"),
 };
+
+/** Payload of the `agent-install:state` event: progress of a one-click agent
+ *  CLI install (`api.installAgent`). `line` carries installer output while
+ *  running; `error` is set on the final `failed` payload. */
+export interface AgentInstallEvent {
+  id: string;
+  phase: "running" | "done" | "failed";
+  line?: string;
+  error?: string;
+}
+
+export function onAgentInstallState(cb: (e: AgentInstallEvent) => void): Promise<UnlistenFn> {
+  return listen<AgentInstallEvent>("agent-install:state", (event) => cb(event.payload));
+}
 
 export function onAgentOutput(cb: (e: AgentOutputEvent) => void): Promise<UnlistenFn> {
   return listen<AgentOutputEvent>("agent:output", (event) => cb(event.payload));

--- a/src/components/Onboarding/OnboardingReadiness.tsx
+++ b/src/components/Onboarding/OnboardingReadiness.tsx
@@ -11,7 +11,7 @@ import { api, type GhStatus, type ToolStatus } from "@/api";
 import { Icon } from "@/components/Icon";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import { Button } from "@/components/ui/Button";
-import { PROVIDER_DETAIL } from "@/data/providerDetail";
+import { installCommand, PROVIDER_DETAIL } from "@/data/providerDetail";
 import { PROVIDERS } from "@/data/providers";
 import { useAppStore } from "@/store";
 import { useGitDist } from "@/util/useGitDist";
@@ -120,7 +120,7 @@ export function OnboardingReadiness() {
                       ? (providerVersions[p.id] ?? "installed")
                       : "not installed"
               }
-              fix={state === "bad" ? d.install : undefined}
+              fix={state === "bad" ? installCommand(p.id) : undefined}
               docs={d.docs}
             />
           );

--- a/src/components/ProviderReadiness/index.tsx
+++ b/src/components/ProviderReadiness/index.tsx
@@ -18,7 +18,7 @@ import { PROVIDER_DETAIL } from "@/data/providerDetail";
 import { PROVIDERS } from "@/data/providers";
 import { useAppStore } from "@/store";
 import { IS_MAC } from "@/util/platform";
-import { useGitDist } from "@/util/useGitDist";
+import { useGitInstall } from "@/util/useGitInstall";
 
 type RowState = "ok" | "warn" | "bad" | "checking";
 
@@ -122,27 +122,10 @@ export function ProviderReadiness() {
     recheck();
   }, [recheck]);
 
-  // While the app is downloading its portable git (no usable system git),
-  // show that instead of a false "not found"; re-check once it settles.
-  const gitDist = useGitDist(recheck);
-  const gitDownloading = !git?.installed && gitDist.phase === "downloading";
-  // The startup bootstrap's failure reason, shown until a retry succeeds.
-  const gitInstallError = !git?.installed && gitDist.phase === "failed" ? gitDist.error : undefined;
-
-  const [installingGit, setInstallingGit] = useState(false);
-  const installGit = useCallback(() => {
-    setInstallingGit(true);
-    // Progress + failure reason arrive via git-dist:state; the final recheck
-    // covers the case where the bootstrap already settled before mount (no
-    // further events) yet the retry succeeded.
-    void api
-      .gitDistInstall()
-      .catch(() => {})
-      .finally(() => {
-        setInstallingGit(false);
-        recheck();
-      });
-  }, [recheck]);
+  const { gitDownloading, gitInstallError, installingGit, installGit } = useGitInstall(
+    git,
+    recheck,
+  );
 
   // Skip agents the user has toggled off; the rest are all runnable.
   const agents = PROVIDERS.filter((p) => providerFlags[p.id] !== false);

--- a/src/components/ProviderReadiness/index.tsx
+++ b/src/components/ProviderReadiness/index.tsx
@@ -14,7 +14,7 @@ import { api, type GhStatus, type ToolStatus } from "@/api";
 import { Icon } from "@/components/Icon";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import { Button } from "@/components/ui/Button";
-import { PROVIDER_DETAIL } from "@/data/providerDetail";
+import { installCommand, PROVIDER_DETAIL } from "@/data/providerDetail";
 import { PROVIDERS } from "@/data/providers";
 import { useAppStore } from "@/store";
 import { IS_MAC } from "@/util/platform";
@@ -211,7 +211,7 @@ export function ProviderReadiness() {
             }
             // Only offer the install command when we know it's missing, not
             // when detection itself failed.
-            fix={state === "bad" ? d.install : undefined}
+            fix={state === "bad" ? installCommand(p.id) : undefined}
             docs={d.docs}
             hint={d.signIn}
           />

--- a/src/components/ProviderReadiness/index.tsx
+++ b/src/components/ProviderReadiness/index.tsx
@@ -17,6 +17,7 @@ import { Button } from "@/components/ui/Button";
 import { PROVIDER_DETAIL } from "@/data/providerDetail";
 import { PROVIDERS } from "@/data/providers";
 import { useAppStore } from "@/store";
+import { IS_MAC } from "@/util/platform";
 import { useGitDist } from "@/util/useGitDist";
 
 type RowState = "ok" | "warn" | "bad" | "checking";
@@ -45,6 +46,7 @@ function Row({
   name,
   state,
   statusText,
+  action,
   fix,
   docs,
   hint,
@@ -53,6 +55,9 @@ function Row({
   name: string;
   state: RowState;
   statusText: string;
+  /** In-app remediation (e.g. the Install Git button), shown before the
+   *  copy-paste fix. */
+  action?: ReactNode;
   /** Copy-paste command that resolves the issue (install or sign-in). */
   fix?: string;
   docs?: string;
@@ -69,8 +74,9 @@ function Row({
           <span className={`rdy-dot ${state}`} />
           <span className="rdy-status text-sm">{statusText}</span>
         </div>
-        {needsFix && (fix || docs) && (
+        {needsFix && (action || fix || docs) && (
           <div className="rdy-fix flex-center">
+            {action}
             {fix && <CopyCmd cmd={fix} />}
             {docs && (
               <button
@@ -120,6 +126,23 @@ export function ProviderReadiness() {
   // show that instead of a false "not found"; re-check once it settles.
   const gitDist = useGitDist(recheck);
   const gitDownloading = !git?.installed && gitDist.phase === "downloading";
+  // The startup bootstrap's failure reason, shown until a retry succeeds.
+  const gitInstallError = !git?.installed && gitDist.phase === "failed" ? gitDist.error : undefined;
+
+  const [installingGit, setInstallingGit] = useState(false);
+  const installGit = useCallback(() => {
+    setInstallingGit(true);
+    // Progress + failure reason arrive via git-dist:state; the final recheck
+    // covers the case where the bootstrap already settled before mount (no
+    // further events) yet the retry succeeded.
+    void api
+      .gitDistInstall()
+      .catch(() => {})
+      .finally(() => {
+        setInstallingGit(false);
+        recheck();
+      });
+  }, [recheck]);
 
   // Skip agents the user has toggled off; the rest are all runnable.
   const agents = PROVIDERS.filter((p) => providerFlags[p.id] !== false);
@@ -160,12 +183,21 @@ export function ProviderReadiness() {
                 ? git.source === "portable"
                   ? `${git.version ?? "Installed"} — bundled with Fletch`
                   : (git.version ?? "Installed")
-                : "Not found — required to run any agent"
+                : gitInstallError
+                  ? `Install failed — ${gitInstallError}`
+                  : "Not found — required to run any agent"
               : checking
                 ? "Checking…"
                 : "Couldn't check"
         }
-        fix={gitState === "bad" ? "xcode-select --install" : undefined}
+        action={
+          gitState === "bad" ? (
+            <Button variant="outline" onClick={installGit} disabled={installingGit}>
+              {installingGit ? "Installing…" : "Install Git"}
+            </Button>
+          ) : undefined
+        }
+        fix={gitState === "bad" && IS_MAC ? "xcode-select --install" : undefined}
         docs="https://git-scm.com/downloads"
       />
 

--- a/src/components/SettingsScreen/DevToolsStatus.tsx
+++ b/src/components/SettingsScreen/DevToolsStatus.tsx
@@ -4,7 +4,7 @@ import { api, type GhStatus, type ToolStatus } from "@/api";
 import { Icon } from "@/components/Icon";
 import { Button } from "@/components/ui/Button";
 import { IS_MAC } from "@/util/platform";
-import { useGitDist } from "@/util/useGitDist";
+import { useGitInstall } from "@/util/useGitInstall";
 
 type S = "ok" | "warn" | "bad" | "checking";
 
@@ -24,27 +24,10 @@ export function DevToolsStatus() {
     recheck();
   }, [recheck]);
 
-  // While the app is downloading its portable git (no usable system git),
-  // show that instead of a false "not found"; re-check once it settles.
-  const gitDist = useGitDist(recheck);
-  const gitDownloading = !git?.installed && gitDist.phase === "downloading";
-  // The startup bootstrap's failure reason, shown until a retry succeeds.
-  const gitInstallError = !git?.installed && gitDist.phase === "failed" ? gitDist.error : undefined;
-
-  const [installingGit, setInstallingGit] = useState(false);
-  const installGit = useCallback(() => {
-    setInstallingGit(true);
-    // Progress + failure reason arrive via git-dist:state; the final recheck
-    // covers the case where the bootstrap already settled before mount (no
-    // further events) yet the retry succeeded.
-    void api
-      .gitDistInstall()
-      .catch(() => {})
-      .finally(() => {
-        setInstallingGit(false);
-        recheck();
-      });
-  }, [recheck]);
+  const { gitDownloading, gitInstallError, installingGit, installGit } = useGitInstall(
+    git,
+    recheck,
+  );
 
   const gitState: S = gitDownloading
     ? "checking"

--- a/src/components/SettingsScreen/DevToolsStatus.tsx
+++ b/src/components/SettingsScreen/DevToolsStatus.tsx
@@ -3,6 +3,7 @@ import { type ReactNode, useCallback, useEffect, useState } from "react";
 import { api, type GhStatus, type ToolStatus } from "@/api";
 import { Icon } from "@/components/Icon";
 import { Button } from "@/components/ui/Button";
+import { IS_MAC } from "@/util/platform";
 import { useGitDist } from "@/util/useGitDist";
 
 type S = "ok" | "warn" | "bad" | "checking";
@@ -27,6 +28,23 @@ export function DevToolsStatus() {
   // show that instead of a false "not found"; re-check once it settles.
   const gitDist = useGitDist(recheck);
   const gitDownloading = !git?.installed && gitDist.phase === "downloading";
+  // The startup bootstrap's failure reason, shown until a retry succeeds.
+  const gitInstallError = !git?.installed && gitDist.phase === "failed" ? gitDist.error : undefined;
+
+  const [installingGit, setInstallingGit] = useState(false);
+  const installGit = useCallback(() => {
+    setInstallingGit(true);
+    // Progress + failure reason arrive via git-dist:state; the final recheck
+    // covers the case where the bootstrap already settled before mount (no
+    // further events) yet the retry succeeded.
+    void api
+      .gitDistInstall()
+      .catch(() => {})
+      .finally(() => {
+        setInstallingGit(false);
+        recheck();
+      });
+  }, [recheck]);
 
   const gitState: S = gitDownloading
     ? "checking"
@@ -53,12 +71,21 @@ export function DevToolsStatus() {
                 ? git.source === "portable"
                   ? `${git.version ?? "Installed"} — bundled with Fletch`
                   : (git.version ?? "Installed")
-                : "Not found — required to run any agent"
+                : gitInstallError
+                  ? `Install failed — ${gitInstallError}`
+                  : "Not found — required to run any agent"
               : checking
                 ? "Checking…"
                 : "Couldn't check"
         }
-        fix={gitState === "bad" ? "xcode-select --install" : undefined}
+        action={
+          gitState === "bad" ? (
+            <Button variant="outline" onClick={installGit} disabled={installingGit}>
+              {installingGit ? "Installing…" : "Install Git"}
+            </Button>
+          ) : undefined
+        }
+        fix={gitState === "bad" && IS_MAC ? "xcode-select --install" : undefined}
         docs="https://git-scm.com/downloads"
       />
       <ToolRow
@@ -91,6 +118,7 @@ function ToolRow({
   name,
   state,
   statusText,
+  action,
   fix,
   docs,
 }: {
@@ -98,6 +126,9 @@ function ToolRow({
   name: string;
   state: S;
   statusText: string;
+  /** In-app remediation (e.g. the Install Git button), shown before the
+   *  copy-paste fix. */
+  action?: ReactNode;
   fix?: string;
   docs?: string;
 }) {
@@ -111,8 +142,9 @@ function ToolRow({
           <span className={`rdy-dot ${state}`} />
           <span className="rdy-status">{statusText}</span>
         </div>
-        {needsFix && (fix || docs) && (
+        {needsFix && (action || fix || docs) && (
           <div className="rdy-fix flex-center">
+            {action}
             {fix && <CopyCmd cmd={fix} />}
             {docs && (
               <button

--- a/src/data/providerDetail.ts
+++ b/src/data/providerDetail.ts
@@ -84,7 +84,7 @@ export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
     path: "/Applications/Cursor.app/…/cursor-agent",
     models: "Composer · Auto",
     installed: true,
-    install: "curl https://cursor.com/install -fsS | bash",
+    install: "curl -fsSL https://cursor.com/install | bash",
     docs: "https://cursor.com",
     signIn: "Run `cursor-agent login` to sign in.",
     // Cursor encodes effort in model names — no standalone flag.

--- a/src/data/providerDetail.ts
+++ b/src/data/providerDetail.ts
@@ -5,6 +5,7 @@
 // `models` describes the tool's model routing (not user-specific).
 // `installed: false` keeps a provider out of the "Installed" list.
 
+import { IS_WINDOWS } from "@/util/platform";
 import type { ProviderId } from "./providers";
 
 export interface ThinkingLevel {
@@ -20,13 +21,17 @@ export interface ProviderDetail {
   models: string;
   /** Detected & configured on this machine — drives the "Installed" list. */
   installed: boolean;
-  /** Shell command to install the CLI, shown in the readiness check when the
-   *  binary isn't found — the official native installer (standalone binary,
-   *  no Node/npm), so it doubles as the manual copy-paste fallback for the
-   *  one-click install. Must mirror the pinned command the backend runs
-   *  (src-tauri/src/agent_install.rs). Omit when there's no reliable
-   *  one-liner — the UI falls back to the `docs` link. */
+  /** Shell command to install the CLI on macOS/Linux, shown in the readiness
+   *  check when the binary isn't found — the official native installer
+   *  (standalone binary, no Node/npm), so it doubles as the manual copy-paste
+   *  fallback for the one-click install. Omit when there's no reliable
+   *  one-liner — the UI falls back to the `docs` link. Consumers should read
+   *  these through `installCommand()`, which picks per platform; both fields
+   *  must mirror the pinned commands the backend runs
+   *  (src-tauri/src/agent_install.rs). */
   install?: string;
+  /** PowerShell equivalent of `install` for Windows, where one exists. */
+  installWindows?: string;
   /** Setup / docs URL — always offered as "learn more" and the fallback when
    *  there's no `install` command. */
   docs: string;
@@ -45,12 +50,22 @@ export interface ProviderDetail {
   effortAtSpawn?: boolean;
 }
 
+/** The install one-liner to show (and copy) on this platform, if one exists.
+ *  On Windows, agents without a PowerShell installer return undefined so the
+ *  UI falls back to the docs link instead of offering a bash command that
+ *  won't run. Mirrors the backend's platform pick (agent_install.rs). */
+export function installCommand(id: ProviderId): string | undefined {
+  const d = PROVIDER_DETAIL[id];
+  return IS_WINDOWS ? d.installWindows : d.install;
+}
+
 export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
   claude: {
     path: "/opt/homebrew/bin/claude",
     models: "Opus 4.7 · Sonnet 4.6 · Haiku 4",
     installed: true,
     install: "curl -fsSL https://claude.ai/install.sh | bash",
+    installWindows: "irm https://claude.ai/install.ps1 | iex",
     docs: "https://docs.anthropic.com/en/docs/claude-code",
     signIn: "Run `claude` once in a terminal to sign in.",
     // `claude --effort <level>` is a session-level spawn flag (not per-message):
@@ -71,6 +86,7 @@ export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
     models: "GPT-5.2-codex · o4-mini",
     installed: true,
     install: "curl -fsSL https://chatgpt.com/codex/install.sh | sh",
+    installWindows: "irm https://chatgpt.com/codex/install.ps1 | iex",
     docs: "https://github.com/openai/codex",
     signIn: "Run `codex` once in a terminal to sign in.",
     // `codex exec -c reasoning_effort="<value>"`

--- a/src/data/providerDetail.ts
+++ b/src/data/providerDetail.ts
@@ -20,8 +20,11 @@ export interface ProviderDetail {
   models: string;
   /** Detected & configured on this machine — drives the "Installed" list. */
   installed: boolean;
-  /** Copy-paste shell command to install the CLI, shown in the readiness
-   *  check when the binary isn't found. Omit when there's no reliable
+  /** Shell command to install the CLI, shown in the readiness check when the
+   *  binary isn't found — the official native installer (standalone binary,
+   *  no Node/npm), so it doubles as the manual copy-paste fallback for the
+   *  one-click install. Must mirror the pinned command the backend runs
+   *  (src-tauri/src/agent_install.rs). Omit when there's no reliable
    *  one-liner — the UI falls back to the `docs` link. */
   install?: string;
   /** Setup / docs URL — always offered as "learn more" and the fallback when
@@ -47,7 +50,7 @@ export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
     path: "/opt/homebrew/bin/claude",
     models: "Opus 4.7 · Sonnet 4.6 · Haiku 4",
     installed: true,
-    install: "npm install -g @anthropic-ai/claude-code",
+    install: "curl -fsSL https://claude.ai/install.sh | bash",
     docs: "https://docs.anthropic.com/en/docs/claude-code",
     signIn: "Run `claude` once in a terminal to sign in.",
     // `claude --effort <level>` is a session-level spawn flag (not per-message):
@@ -67,7 +70,7 @@ export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
     path: "~/.codex/bin/codex",
     models: "GPT-5.2-codex · o4-mini",
     installed: true,
-    install: "npm install -g @openai/codex",
+    install: "curl -fsSL https://chatgpt.com/codex/install.sh | sh",
     docs: "https://github.com/openai/codex",
     signIn: "Run `codex` once in a terminal to sign in.",
     // `codex exec -c reasoning_effort="<value>"`

--- a/src/util/platform.ts
+++ b/src/util/platform.ts
@@ -1,0 +1,4 @@
+/** Coarse renderer-side platform check. The Tauri WebView's user agent
+ *  carries the host OS, and this only gates cosmetic hints (e.g. the
+ *  macOS-only `xcode-select --install` suggestion) — never capability. */
+export const IS_MAC = navigator.userAgent.includes("Mac");

--- a/src/util/platform.ts
+++ b/src/util/platform.ts
@@ -1,4 +1,6 @@
-/** Coarse renderer-side platform check. The Tauri WebView's user agent
- *  carries the host OS, and this only gates cosmetic hints (e.g. the
- *  macOS-only `xcode-select --install` suggestion) — never capability. */
+/** Coarse renderer-side platform checks. The Tauri WebView's user agent
+ *  carries the host OS, and these only gate cosmetic hints (e.g. the
+ *  macOS-only `xcode-select --install` suggestion, or which install
+ *  one-liner to show) — never capability. */
 export const IS_MAC = navigator.userAgent.includes("Mac");
+export const IS_WINDOWS = navigator.userAgent.includes("Windows");

--- a/src/util/useGitInstall.ts
+++ b/src/util/useGitInstall.ts
@@ -1,0 +1,46 @@
+// Portable-git install state for readiness surfaces: the live bootstrap
+// phase (via useGitDist), the derived downloading/failed views, and the
+// manual install/retry action. Shared so every surface that shows a git row
+// resolves and retries identically.
+
+import { useCallback, useState } from "react";
+import { api, type ToolStatus } from "@/api";
+import { type GitDistState, useGitDist } from "./useGitDist";
+
+export interface GitInstall {
+  /** Live portable-git bootstrap state (download progress / failure). */
+  gitDist: GitDistState;
+  /** Portable git download in flight (startup bootstrap or manual retry). */
+  gitDownloading: boolean;
+  /** Why the last install attempt failed, until a retry succeeds. */
+  gitInstallError?: string;
+  installingGit: boolean;
+  installGit: () => void;
+}
+
+/** `git` is the caller's latest probe result; `recheck` re-runs its checks —
+ *  called when the bootstrap settles and after a manual install attempt. */
+export function useGitInstall(git: ToolStatus | null, recheck: () => void): GitInstall {
+  // While the app is downloading its portable git (no usable system git),
+  // callers show that instead of a false "not found"; re-check on settle.
+  const gitDist = useGitDist(recheck);
+  const gitDownloading = !git?.installed && gitDist.phase === "downloading";
+  const gitInstallError = !git?.installed && gitDist.phase === "failed" ? gitDist.error : undefined;
+
+  const [installingGit, setInstallingGit] = useState(false);
+  const installGit = useCallback(() => {
+    setInstallingGit(true);
+    // Progress + failure reason arrive via git-dist:state; the final recheck
+    // covers the case where the bootstrap already settled before mount (no
+    // further events) yet the retry succeeded.
+    void api
+      .gitDistInstall()
+      .catch(() => {})
+      .finally(() => {
+        setInstallingGit(false);
+        recheck();
+      });
+  }, [recheck]);
+
+  return { gitDist, gitDownloading, gitInstallError, installingGit, installGit };
+}


### PR DESCRIPTION
## What

Backend enablement for the onboarding redesign: both hard requirements (git, an agent CLI) become installable in-app, with no terminal and no app restart.

- **`git_dist_install` command** — exposes the portable-git `ensure_installed` path as a manual retry. The startup bootstrap stays the primary path; this covers the failure case (offline first launch, blocked network) that previously required restarting the app. Emits the same `git-dist:state` events, so existing listeners render progress unchanged. Serialized against the startup bootstrap via an install lock.
- **`agent_install` module + `install_agent` command** — runs the pinned official native installer for an agent CLI (claude, codex, cursor, opencode), streaming output via `agent-install:state` events. Commands are pinned backend-side so the renderer can only trigger known vendor installers. All are standalone-binary installers — no Node/npm dependency. Per-agent in-flight guard + 10-minute timeout.
- **`providerDetail.ts`** — claude/codex copy-paste commands switched from npm one-liners to the same native installers (kept in sync with the backend pins).
- **Readiness rows** (Settings › General dev tools, Settings › Providers) — gain an **Install Git** button wired to the new command, surface the bootstrap failure reason (previously captured but never shown), and only suggest `xcode-select --install` on macOS (it was shown on all platforms).

## Why

Onboarding is being rebuilt around three requirements (git installed, GitHub connected, ≥1 agent installed). This PR ships the capabilities that redesign needs; the onboarding UI itself lands in a follow-up PR.

## Testing

- `cargo check` clean; `cargo test git_dist` 5 passed.
- `tsc --noEmit` and biome clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)