### PR TITLE
fix: move OAuth tokens to the macOS Keychain and wall off the app data dir from agents

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1192,6 +1192,7 @@ dependencies = [
  "rfd",
  "rusqlite",
  "rusqlite_migration",
+ "security-framework",
  "sentry",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -64,6 +64,13 @@ tar = "0.4"
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-window-state = "2"
 
+# App-held secrets (secrets.rs): release builds keep the GitHub / container
+# tokens in the login Keychain via the in-process API — the same signed binary
+# creates and reads the items, so access is silent. Already in the dep tree
+# transitively; pinned to the lockfile's major.
+[target.'cfg(target_os = "macos")'.dependencies]
+security-framework = "3"
+
 [dev-dependencies]
 tempfile = "3"
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -261,7 +261,7 @@ pub async fn publish_agent(
 /// Drop the stored GitHub token — the app returns to local-only mode.
 #[tauri::command]
 pub fn github_disconnect(db: State<'_, Arc<parking_lot::Mutex<rusqlite::Connection>>>) -> Result<()> {
-    crate::database::set_setting(&db.lock(), gh::TOKEN_SETTING, "")?;
+    crate::secrets::delete(&db.lock(), gh::TOKEN_SETTING)?;
     gh::set_token(None);
     Ok(())
 }

--- a/src-tauri/src/github/client.rs
+++ b/src-tauri/src/github/client.rs
@@ -4,10 +4,10 @@
 //! everything here is transport.
 //!
 //! The token comes from the app's own OAuth device flow (`repo` scope) and is
-//! stored in the `settings` table — plaintext for now, the same bar as the
-//! `gh` CLI's hosts.yml, isolated behind `set_token`/`token` so a move to the
-//! OS keychain later touches only the storage call sites. The token must
-//! never appear in logs, telemetry, or error strings.
+//! persisted via `crate::secrets` — the OS keychain on release macOS builds,
+//! the `settings` table in dev — isolated behind `set_token`/`token` so the
+//! storage backend never leaks into API code. The token must never appear in
+//! logs, telemetry, or error strings.
 
 use std::sync::{OnceLock, RwLock};
 use std::time::{Duration, Instant};
@@ -17,7 +17,8 @@ use serde_json::{json, Value};
 
 use crate::error::{Error, Result};
 
-/// `settings` key holding the GitHub access token.
+/// `crate::secrets` key holding the GitHub access token (keychain account
+/// name on release macOS; `settings` key in the dev fallback).
 pub const TOKEN_SETTING: &str = "github_token";
 
 const API_BASE: &str = "https://api.github.com";

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -749,6 +749,39 @@ async fn set_docker_launch_settings(
     Ok(())
 }
 
+/// How long the startup secret seed keeps retrying an unavailable store
+/// (10 × 30s ≈ 5 min) — generous for the realistic case, a login-item launch
+/// racing the keychain unlock, without polling forever.
+const SECRET_SEED_RETRIES: u32 = 10;
+const SECRET_SEED_RETRY_SECS: u64 = 30;
+
+/// Seed an in-process secret mirror from the store at startup. A definitive
+/// answer (present or absent) applies immediately; an *unavailable* store
+/// (`Err` — e.g. the keychain is locked) must not read as signed-out, so it
+/// retries in the background and applies on the first definitive answer.
+/// `apply` is a plain fn: both mirrors (`github::set_token`,
+/// `docker::auth::set_stored_token`) have that shape.
+fn seed_secret_mirror(db: &DbState, key: &'static str, apply: fn(Option<String>)) {
+    match secrets::get(&db.lock(), key) {
+        Ok(value) => apply(value),
+        Err(e) => {
+            tracing::warn!(key, error = %e, "secret store unavailable at startup; retrying");
+            let db = db.clone();
+            tauri::async_runtime::spawn(async move {
+                for _ in 0..SECRET_SEED_RETRIES {
+                    tokio::time::sleep(std::time::Duration::from_secs(SECRET_SEED_RETRY_SECS))
+                        .await;
+                    if let Ok(value) = secrets::get(&db.lock(), key) {
+                        apply(value);
+                        return;
+                    }
+                }
+                tracing::warn!(key, "secret store still unavailable; giving up until restart");
+            });
+        }
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Error/crash reporting. The DSN is baked in at build time via
@@ -878,10 +911,11 @@ pub fn run() {
             // `claude_container_token` secret, same pattern as the GitHub
             // token below) so the docker auth chain — resolved at spawn time
             // with no DB handle — sees a token pasted in a previous run.
-            sandbox::docker::auth::set_stored_token(secrets::get(
-                &db.lock(),
+            seed_secret_mirror(
+                &db,
                 sandbox::docker::auth::TOKEN_SETTING,
-            ));
+                sandbox::docker::auth::set_stored_token,
+            );
 
             // Unified git resolution: point the portable-install root at app
             // data, wire the fallback commit identity to the signed-in
@@ -891,7 +925,7 @@ pub fn run() {
             git_dist::init(data_dir.join("git-dist"));
             // Seed the in-process GitHub token so API calls and git network
             // auth work without a DB handle (updated on sign-in).
-            github::set_token(secrets::get(&db.lock(), github::TOKEN_SETTING));
+            seed_secret_mirror(&db, github::TOKEN_SETTING, github::set_token);
             {
                 let db = db.clone();
                 git_dist::set_identity_source(Box::new(move || {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -749,17 +749,19 @@ async fn set_docker_launch_settings(
     Ok(())
 }
 
-/// How long the startup secret seed keeps retrying an unavailable store
-/// (10 × 30s ≈ 5 min) — generous for the realistic case, a login-item launch
-/// racing the keychain unlock, without polling forever.
-const SECRET_SEED_RETRIES: u32 = 10;
-const SECRET_SEED_RETRY_SECS: u64 = 30;
+/// Startup seed retry pacing for an unavailable secret store: start at 30s
+/// (the realistic case — a login-item launch racing the keychain unlock —
+/// resolves quickly) and back off to a slow probe that never gives up. An
+/// unavailable store must stay distinct from "no token" for the app's whole
+/// lifetime, not just a startup window: a saved login must never read as
+/// signed-out only because the keychain stayed locked past some deadline.
+const SECRET_SEED_RETRY_START: std::time::Duration = std::time::Duration::from_secs(30);
+const SECRET_SEED_RETRY_CAP: std::time::Duration = std::time::Duration::from_secs(300);
 
 /// Seed an in-process secret mirror from the store at startup. A definitive
 /// answer (present or absent) applies immediately; an *unavailable* store
-/// (`Err` — e.g. the keychain is locked) must not read as signed-out, so it
-/// retries in the background and applies on the first definitive answer.
-/// `apply` is a plain fn: both mirrors (`github::set_token`,
+/// (`Err` — e.g. the keychain is locked) retries in the background until it
+/// gets one. `apply` is a plain fn: both mirrors (`github::set_token`,
 /// `docker::auth::set_stored_token`) have that shape.
 fn seed_secret_mirror(db: &DbState, key: &'static str, apply: fn(Option<String>)) {
     match secrets::get(&db.lock(), key) {
@@ -768,15 +770,19 @@ fn seed_secret_mirror(db: &DbState, key: &'static str, apply: fn(Option<String>)
             tracing::warn!(key, error = %e, "secret store unavailable at startup; retrying");
             let db = db.clone();
             tauri::async_runtime::spawn(async move {
-                for _ in 0..SECRET_SEED_RETRIES {
-                    tokio::time::sleep(std::time::Duration::from_secs(SECRET_SEED_RETRY_SECS))
-                        .await;
-                    if let Ok(value) = secrets::get(&db.lock(), key) {
-                        apply(value);
-                        return;
+                let mut delay = SECRET_SEED_RETRY_START;
+                loop {
+                    tokio::time::sleep(delay).await;
+                    match secrets::get(&db.lock(), key) {
+                        // Only a real value is applied: the mirror already
+                        // defaults to empty, and a sign-in/paste may have set
+                        // it directly while we waited — a late None could only
+                        // clobber that fresher token, never fix anything.
+                        Ok(Some(value)) => return apply(Some(value)),
+                        Ok(None) => return,
+                        Err(_) => delay = (delay * 2).min(SECRET_SEED_RETRY_CAP),
                     }
                 }
-                tracing::warn!(key, "secret store still unavailable; giving up until restart");
             });
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,6 +25,7 @@ mod rpc;
 mod run_detect;
 mod run_session;
 mod sandbox;
+mod secrets;
 mod supervisor;
 mod telemetry;
 mod transcripts;
@@ -543,11 +544,11 @@ async fn get_container_auth_status(
 }
 
 /// Store a pasted `claude setup-token` for containerized agents under the
-/// `claude_container_token` setting — plaintext in sqlite, the same posture
-/// as `github_token`. Trims; rejects empty; unexpected shapes are accepted
-/// with a warning (which, like every log line here, never includes the token
-/// itself). Persists and then updates the in-process mirror, like
-/// `set_sandbox_engine` and `github::set_token`.
+/// `claude_container_token` secret — the OS keychain on release macOS builds
+/// (see `secrets`), the same posture as `github_token`. Trims; rejects empty;
+/// unexpected shapes are accepted with a warning (which, like every log line
+/// here, never includes the token itself). Persists and then updates the
+/// in-process mirror, like `set_sandbox_engine` and `github::set_token`.
 #[tauri::command]
 async fn set_container_auth_token(
     token: String,
@@ -559,8 +560,8 @@ async fn set_container_auth_token(
 /// Persist-then-mirror core shared by the paste command
 /// ([`set_container_auth_token`]) and the automated capture flow
 /// ([`connect_claude_container_auth`]): normalize + shape-check (warning, never
-/// logging the token, on an unrecognized shape), write the
-/// `claude_container_token` setting, then update the in-process mirror the
+/// logging the token, on an unrecognized shape), store the
+/// `claude_container_token` secret, then update the in-process mirror the
 /// spawn path reads — so a change applies to the next docker spawn without a
 /// restart. Same shape as `github::set_token`.
 fn store_container_token(db: &DbState, raw_token: &str) -> Result<(), String> {
@@ -573,7 +574,7 @@ fn store_container_token(db: &DbState, raw_token: &str) -> Result<(), String> {
     }
     {
         let conn = db.lock();
-        database::set_setting(&conn, sandbox::docker::auth::TOKEN_SETTING, &token)
+        secrets::set(&conn, sandbox::docker::auth::TOKEN_SETTING, &token)
             .map_err(|e| e.to_string())?;
     }
     sandbox::docker::auth::set_stored_token(Some(token));
@@ -688,14 +689,13 @@ async fn cancel_claude_container_auth(
     Ok(())
 }
 
-/// Drop the stored container token (blank the setting + clear the mirror,
+/// Drop the stored container token (delete the secret + clear the mirror,
 /// mirroring `github_disconnect`). Later chain steps take over, if any.
 #[tauri::command]
 async fn clear_container_auth_token(state: tauri::State<'_, DbState>) -> Result<(), String> {
     {
         let conn = state.lock();
-        database::set_setting(&conn, sandbox::docker::auth::TOKEN_SETTING, "")
-            .map_err(|e| e.to_string())?;
+        secrets::delete(&conn, sandbox::docker::auth::TOKEN_SETTING).map_err(|e| e.to_string())?;
     }
     sandbox::docker::auth::set_stored_token(None);
     Ok(())
@@ -874,11 +874,11 @@ pub fn run() {
                 });
             }
 
-            // Seed the in-process container auth token (mirror of the
-            // `claude_container_token` setting, same pattern as the GitHub
+            // Seed the in-process container auth token (mirror of the stored
+            // `claude_container_token` secret, same pattern as the GitHub
             // token below) so the docker auth chain — resolved at spawn time
             // with no DB handle — sees a token pasted in a previous run.
-            sandbox::docker::auth::set_stored_token(database::get_setting(
+            sandbox::docker::auth::set_stored_token(secrets::get(
                 &db.lock(),
                 sandbox::docker::auth::TOKEN_SETTING,
             ));
@@ -891,7 +891,7 @@ pub fn run() {
             git_dist::init(data_dir.join("git-dist"));
             // Seed the in-process GitHub token so API calls and git network
             // auth work without a DB handle (updated on sign-in).
-            github::set_token(database::get_setting(&db.lock(), github::TOKEN_SETTING));
+            github::set_token(secrets::get(&db.lock(), github::TOKEN_SETTING));
             {
                 let db = db.clone();
                 git_dist::set_identity_source(Box::new(move || {

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -2,9 +2,9 @@
 //! are both supported.
 //!
 //! Google is identity-only: its token reads the profile once, then drops.
-//! GitHub requests the `repo` scope and its token is persisted (settings
-//! table + the in-process registry) — it powers the GitHub API client and
-//! git's https auth, replacing the `gh` CLI dependency.
+//! GitHub requests the `repo` scope and its token is persisted (the app's
+//! secret store + the in-process registry) — it powers the GitHub API client
+//! and git's https auth, replacing the `gh` CLI dependency.
 
 use serde::Serialize;
 use std::time::{Duration, Instant};
@@ -315,7 +315,7 @@ pub async fn oauth_device_login(
     // (the in-process registry still has it until quit), but say so loudly.
     if provider == "github" {
         if let Err(e) =
-            crate::database::set_setting(&db.lock(), crate::github::TOKEN_SETTING, &access_token)
+            crate::secrets::set(&db.lock(), crate::github::TOKEN_SETTING, &access_token)
         {
             tracing::warn!(error = %e, "failed to persist GitHub token");
         }

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -311,14 +311,14 @@ pub async fn oauth_device_login(
     };
 
     // Persist the GitHub token — it authenticates the API client and git's
-    // https transport from now on. A failed write isn't fatal to sign-in
-    // (the in-process registry still has it until quit), but say so loudly.
+    // https transport from now on. A failed write fails the sign-in: the
+    // store is the Keychain on release macOS, which can refuse writes (e.g.
+    // locked keychain), and proceeding would look signed in until quit, then
+    // silently sign out on next launch. Same posture as
+    // `store_container_token`; the mirror is only set once storage succeeded.
     if provider == "github" {
-        if let Err(e) =
-            crate::secrets::set(&db.lock(), crate::github::TOKEN_SETTING, &access_token)
-        {
-            tracing::warn!(error = %e, "failed to persist GitHub token");
-        }
+        crate::secrets::set(&db.lock(), crate::github::TOKEN_SETTING, &access_token)
+            .map_err(|e| format!("couldn't save your GitHub login: {e}"))?;
         crate::github::set_token(Some(access_token.clone()));
     }
 

--- a/src-tauri/src/sandbox/docker/auth.rs
+++ b/src-tauri/src/sandbox/docker/auth.rs
@@ -20,9 +20,10 @@
 //!    re-login (e.g. after hitting a rate limit) takes effect immediately. Only
 //!    a usable token counts (see [`usable_oauth_token`]); no Keychain / no login
 //!    (Linux, CI) falls through. See [`keychain_token`].
-//! 2. A `claude setup-token` value captured into settings ([`TOKEN_SETTING`],
-//!    auto-populated by [`super::setup_token`]) → `CLAUDE_CODE_OAUTH_TOKEN`. The
-//!    fallback for hosts without a readable Keychain login.
+//! 2. A `claude setup-token` value captured into the app's secret store
+//!    ([`TOKEN_SETTING`], auto-populated by [`super::setup_token`]) →
+//!    `CLAUDE_CODE_OAUTH_TOKEN`. The fallback for hosts without a readable
+//!    Keychain login.
 //! 3. The app's process env or the login-shell probe exports a credential —
 //!    `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, or `ANTHROPIC_AUTH_TOKEN`
 //!    (a custom-gateway bearer) → forward it plus `ANTHROPIC_BASE_URL` (the
@@ -52,9 +53,9 @@ use parking_lot::RwLock;
 
 use crate::bin_resolve;
 
-/// `settings` key holding the user-pasted `claude setup-token` value.
-/// Plaintext in sqlite — the same posture as `github::TOKEN_SETTING`
-/// (consistency over novelty; a keychain migration would move both).
+/// `crate::secrets` key holding the user-pasted `claude setup-token` value —
+/// the OS keychain on release macOS builds, the same posture as
+/// `github::TOKEN_SETTING`.
 pub const TOKEN_SETTING: &str = "claude_container_token";
 
 /// Env var claude reads a setup-token (OAuth) credential from.

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -21,6 +21,14 @@
 //! latter. The agent CLIs' own sandboxes are disabled (e.g. codex runs
 //! `danger-full-access`) so the two don't fight, leaving `sandbox-exec` as the
 //! sole boundary.
+//!
+//! One region is carved back *out* of the broad `Application Support` grant:
+//! the app's own data dir (`~/Library/Application Support/<BUNDLE_ID>`, holding
+//! `fletch.db` — transcripts, settings). Both reads (exfiltration) and writes
+//! (forging state) are denied there, so a prompt-injected agent can't touch
+//! app state even though its parent is writable. The Run profile keeps the same
+//! deny but re-allows the `dev` subdir, so a nested *dev* Fletch launched from
+//! the Run panel can still open its own database.
 
 use std::path::{Path, PathBuf};
 
@@ -89,6 +97,28 @@ fn standard_state_dirs(home_s: &str) -> Vec<String> {
     .iter()
     .map(|d| sbpl_string(&format!("{home_s}/{d}")))
     .collect()
+}
+
+/// SBPL rule carving the app's own data dir back *out* of the broad
+/// `Application Support` write grant — and out of `allow default` for reads.
+/// `fletch.db` (agent transcripts, settings) lives here, so no confined process
+/// should read it (exfiltration) or write it (forging state). Emitted as a
+/// single multi-operation deny (verified to parse) and MUST follow the
+/// `(allow file-write* …)` block: SBPL is last-match-wins, so a later deny
+/// overrides the earlier read/write grants. `BUNDLE_ID` must match the folder
+/// macOS derives from `tauri.conf.json`'s `identifier`.
+fn deny_app_data_dir(home_s: &str) -> String {
+    let app_data = sbpl_string(&format!(
+        "{home_s}/Library/Application Support/{}",
+        crate::BUNDLE_ID
+    ));
+    format!(
+        ";; The app's own data dir (fletch.db: transcripts, settings) must be opaque\n\
+         ;; to confined processes: deny reads (exfiltration) and writes (forging\n\
+         ;; state), even though the broad Application Support grant above covers its\n\
+         ;; parent. Last-match-wins, so this must come after the allow block.\n\
+         (deny file-read* file-write* (subpath {app_data}))"
+    )
 }
 
 /// Toolchain state dirs the Run panel additionally grants so real project
@@ -165,6 +195,12 @@ pub fn build_run_profile(
         .collect::<Vec<_>>()
         .join("\n  ");
 
+    let deny_app_data = deny_app_data_dir(&home_s);
+    let app_data_dev = sbpl_string(&format!(
+        "{home_s}/Library/Application Support/{}/dev",
+        crate::BUNDLE_ID
+    ));
+
     Ok(format!(
         r#"(version 1)
 (allow default)
@@ -173,6 +209,14 @@ pub fn build_run_profile(
 (deny file-write*)
 (allow file-write*
   {writable_block})
+
+{deny_app_data}
+;; Exception: a nested *dev* Fletch launched from the Run panel stores its data
+;; under `<data dir>/dev` (see lib.rs setup) and must open its own database, so
+;; re-allow just that subtree (last-match-wins). A Run-panel process can thus
+;; touch the dev instance's state — acceptable because it's dev-only and the Run
+;; panel already runs arbitrary project code the developer chose to run.
+(allow file-read* file-write* (subpath {app_data_dev}))
 
 {DEVICE_WRITE_RULES}
 "#
@@ -340,6 +384,10 @@ pub fn build_profile(
     let gemini_state = sbpl_string(&format!("{home_s}/.gemini"));
     let pi_state = sbpl_string(&format!("{home_s}/.pi"));
 
+    // No `dev` exception here (unlike the Run profile): agents never legitimately
+    // touch any Fletch data dir, dev or otherwise.
+    let deny_app_data = deny_app_data_dir(&home_s);
+
     Ok(format!(
         r#"(version 1)
 (allow default)
@@ -364,6 +412,8 @@ pub fn build_profile(
   (subpath {cursor_state})
   (subpath {gemini_state})
   (subpath {pi_state}))
+
+{deny_app_data}
 
 {DEVICE_WRITE_RULES}
 "#
@@ -526,6 +576,90 @@ mod tests {
     #[test]
     fn escapes_quotes_in_paths() {
         assert_eq!(sbpl_string(r#"/path/with"quote"#), r#""/path/with\"quote""#);
+    }
+
+    #[test]
+    fn agent_profile_denies_app_data_dir_after_allow_block() {
+        // The app's own data dir (fletch.db) must be opaque to agents: deny both
+        // reads (exfiltration) and writes (forging state). The deny only bites if
+        // it comes AFTER the write allow-list, since SBPL is last-match-wins.
+        let (_td, root, rpc, home) = sandbox_dirs();
+        let profile = build_profile(&root, &rpc, &home, None).unwrap();
+        let canonical_home = std::fs::canonicalize(&home).unwrap();
+
+        let deny = format!(
+            "(deny file-read* file-write* (subpath \"{}/Library/Application Support/{}\"))",
+            canonical_home.display(),
+            crate::BUNDLE_ID
+        );
+        assert!(
+            profile.contains(&deny),
+            "agent profile must deny read+write on its own data dir: missing {deny}"
+        );
+        let allow_at = profile.find("(allow file-write*").unwrap();
+        let deny_at = profile.find(&deny).unwrap();
+        assert!(
+            deny_at > allow_at,
+            "the app-data deny must come after the allow block to override it"
+        );
+    }
+
+    #[test]
+    fn agent_profile_does_not_reallow_dev_data_dir() {
+        // Agents never legitimately touch any Fletch data dir — no `dev`
+        // exception (that carve-out is Run-profile-only).
+        let (_td, root, rpc, home) = sandbox_dirs();
+        let profile = build_profile(&root, &rpc, &home, None).unwrap();
+        let canonical_home = std::fs::canonicalize(&home).unwrap();
+        let dev = format!(
+            "{}/Library/Application Support/{}/dev",
+            canonical_home.display(),
+            crate::BUNDLE_ID
+        );
+        assert!(
+            !profile.contains(&dev),
+            "agent profile must not re-allow the dev data subdir"
+        );
+    }
+
+    #[test]
+    fn run_profile_denies_app_data_but_reallows_dev_subdir() {
+        // The Run profile carries the same app-data deny, but re-allows the `dev`
+        // subtree AFTER it (last-match-wins) so a nested dev Fletch can open its
+        // own database.
+        let td = tempfile::tempdir().unwrap();
+        let checkout = td.path().join("repo-checkout");
+        let home = td.path().join("home");
+        std::fs::create_dir_all(&checkout).unwrap();
+        std::fs::create_dir_all(&home).unwrap();
+
+        let profile = build_run_profile(&checkout, &home, &[]).unwrap();
+        let canonical_home = std::fs::canonicalize(&home).unwrap();
+
+        let deny = format!(
+            "(deny file-read* file-write* (subpath \"{}/Library/Application Support/{}\"))",
+            canonical_home.display(),
+            crate::BUNDLE_ID
+        );
+        let dev_allow = format!(
+            "(allow file-read* file-write* (subpath \"{}/Library/Application Support/{}/dev\"))",
+            canonical_home.display(),
+            crate::BUNDLE_ID
+        );
+        assert!(
+            profile.contains(&deny),
+            "run profile must deny the app data dir"
+        );
+        assert!(
+            profile.contains(&dev_allow),
+            "run profile must re-allow the dev subdir: missing {dev_allow}"
+        );
+        let deny_at = profile.find(&deny).unwrap();
+        let dev_at = profile.find(&dev_allow).unwrap();
+        assert!(
+            dev_at > deny_at,
+            "the dev re-allow must come after the deny to take effect"
+        );
     }
 
     #[test]

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -1,0 +1,147 @@
+//! App-held secrets (the GitHub OAuth token, the claude container token).
+//!
+//! Release macOS builds store secrets in the login Keychain through the
+//! in-process Security.framework API: the item is created and read by the
+//! same signed binary, so the app's own access is silent (no prompt, no
+//! password), while any *other* process — including a sandboxed agent, whose
+//! seatbelt profile leaves file reads open — hits a visible macOS consent
+//! dialog instead of reading silently. Dev builds (and non-macOS targets)
+//! fall back to the plaintext `settings` table: an ad-hoc-signed dev binary
+//! changes code identity on every rebuild, which would otherwise re-prompt
+//! each run. Values that reached the settings table under the pre-keychain
+//! scheme are migrated (and the plaintext scrubbed) on first read.
+//!
+//! Secrets read or written here must never appear in logs, telemetry, or
+//! error strings — the `github::client` invariant, enforced at the store too.
+
+use rusqlite::Connection;
+
+use crate::error::Result;
+
+pub use store::{delete, get, set};
+
+/// Keychain-backed store (release macOS). The setting key doubles as the
+/// keychain account name; the service is the app bundle id.
+#[cfg(all(target_os = "macos", not(debug_assertions)))]
+mod store {
+    use security_framework::passwords::{
+        delete_generic_password, get_generic_password, set_generic_password,
+    };
+
+    use super::*;
+    use crate::database;
+    use crate::error::Error;
+
+    const SERVICE: &str = crate::BUNDLE_ID;
+
+    pub fn get(conn: &Connection, key: &str) -> Option<String> {
+        if let Ok(bytes) = get_generic_password(SERVICE, key) {
+            return String::from_utf8(bytes)
+                .ok()
+                .filter(|v| !v.trim().is_empty());
+        }
+        // Not in the keychain: migrate the legacy plaintext `settings` row a
+        // pre-keychain build left behind, then scrub it. On a keychain write
+        // failure keep the settings copy — the token still works, and the
+        // move retries on the next read.
+        let legacy = database::get_setting(conn, key).filter(|v| !v.trim().is_empty())?;
+        match set(conn, key, &legacy) {
+            Ok(()) => scrub_setting(conn, key),
+            Err(e) => tracing::warn!(key, error = %e, "keychain migration failed"),
+        }
+        Some(legacy)
+    }
+
+    pub fn set(_conn: &Connection, key: &str, value: &str) -> Result<()> {
+        set_generic_password(SERVICE, key, value.as_bytes())
+            .map_err(|e| Error::Other(format!("keychain write ({key}): {e}")))
+    }
+
+    pub fn delete(conn: &Connection, key: &str) -> Result<()> {
+        // Deleting an absent secret is a no-op, not an error.
+        let _ = delete_generic_password(SERVICE, key);
+        // Scrub any plaintext row a failed migration could have left behind.
+        if database::get_setting(conn, key).is_some_and(|v| !v.is_empty()) {
+            scrub_setting(conn, key);
+        }
+        Ok(())
+    }
+
+    /// Blank the legacy `settings` row and scrub the old plaintext from the
+    /// database *file*: a plain UPDATE leaves the value recoverable on freed
+    /// pages and in the WAL, so zero freed content (`secure_delete`), rewrite
+    /// the main file (VACUUM), and drain the WAL (checkpoint TRUNCATE).
+    /// Best-effort — the secret is already safe in the keychain, so a scrub
+    /// failure warns rather than blocking the caller.
+    fn scrub_setting(conn: &Connection, key: &str) {
+        let scrub = || -> Result<()> {
+            conn.pragma_update(None, "secure_delete", "ON")?;
+            database::set_setting(conn, key, "")?;
+            conn.execute_batch("VACUUM")?;
+            conn.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |_| Ok(()))?;
+            Ok(())
+        };
+        if let Err(e) = scrub() {
+            tracing::warn!(key, error = %e, "failed to scrub legacy plaintext setting");
+        }
+    }
+}
+
+/// `settings`-table store (dev builds and non-macOS): the pre-keychain
+/// plaintext posture, kept where keychain ACLs can't work — an ad-hoc-signed
+/// dev binary changes identity every rebuild and would prompt each run.
+#[cfg(not(all(target_os = "macos", not(debug_assertions))))]
+mod store {
+    use super::*;
+    use crate::database;
+
+    pub fn get(conn: &Connection, key: &str) -> Option<String> {
+        database::get_setting(conn, key).filter(|v| !v.trim().is_empty())
+    }
+
+    pub fn set(conn: &Connection, key: &str, value: &str) -> Result<()> {
+        database::set_setting(conn, key, value)
+    }
+
+    pub fn delete(conn: &Connection, key: &str) -> Result<()> {
+        database::set_setting(conn, key, "")
+    }
+}
+
+// Tests build with `debug_assertions`, so they exercise the settings-table
+// store — the keychain store is thin glue over Security.framework that can't
+// run headless (no login keychain in CI).
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_db() -> (
+        tempfile::TempDir,
+        std::sync::Arc<parking_lot::Mutex<Connection>>,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let db = crate::database::init(dir.path()).unwrap();
+        (dir, db)
+    }
+
+    #[test]
+    fn roundtrip_set_get_delete() {
+        let (_dir, db) = test_db();
+        let conn = db.lock();
+        assert_eq!(get(&conn, "github_token"), None);
+        set(&conn, "github_token", "tok123").unwrap();
+        assert_eq!(get(&conn, "github_token").as_deref(), Some("tok123"));
+        delete(&conn, "github_token").unwrap();
+        assert_eq!(get(&conn, "github_token"), None);
+    }
+
+    /// A cleared secret persists as a blank row (dev store) — blank must read
+    /// back as "no secret", matching `github::set_token`'s blank handling.
+    #[test]
+    fn blank_value_reads_as_none() {
+        let (_dir, db) = test_db();
+        let conn = db.lock();
+        set(&conn, "claude_container_token", "  ").unwrap();
+        assert_eq!(get(&conn, "claude_container_token"), None);
+    }
+}

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -34,11 +34,27 @@ mod store {
 
     const SERVICE: &str = crate::BUNDLE_ID;
 
+    /// `errSecItemNotFound` — the one read/delete failure that means "no such
+    /// secret". Every other code (locked keychain, interaction not allowed)
+    /// means the secret may exist but the keychain is unavailable right now,
+    /// and must not be treated as absence.
+    const ERR_SEC_ITEM_NOT_FOUND: i32 = -25300;
+
     pub fn get(conn: &Connection, key: &str) -> Option<String> {
-        if let Ok(bytes) = get_generic_password(SERVICE, key) {
-            return String::from_utf8(bytes)
-                .ok()
-                .filter(|v| !v.trim().is_empty());
+        match get_generic_password(SERVICE, key) {
+            Ok(bytes) => {
+                return String::from_utf8(bytes)
+                    .ok()
+                    .filter(|v| !v.trim().is_empty())
+            }
+            // Unavailable ≠ absent: say so (never silently look signed out),
+            // then still consult the legacy row below — a pre-migration value
+            // keeps the session working, and nothing is scrubbed unless the
+            // keychain write succeeds.
+            Err(e) if e.code() != ERR_SEC_ITEM_NOT_FOUND => {
+                tracing::warn!(key, code = e.code(), "keychain read failed");
+            }
+            Err(_) => {}
         }
         // Not in the keychain: migrate the legacy plaintext `settings` row a
         // pre-keychain build left behind, then scrub it. On a keychain write
@@ -58,8 +74,16 @@ mod store {
     }
 
     pub fn delete(conn: &Connection, key: &str) -> Result<()> {
-        // Deleting an absent secret is a no-op, not an error.
-        let _ = delete_generic_password(SERVICE, key);
+        match delete_generic_password(SERVICE, key) {
+            // Deleting an absent secret is a no-op, not an error.
+            Ok(()) => {}
+            Err(e) if e.code() == ERR_SEC_ITEM_NOT_FOUND => {}
+            // Any other failure must fail the disconnect: swallowing it would
+            // clear only the in-process mirror, and the surviving keychain
+            // item would re-seed the token on next launch — a "disconnected"
+            // account that signs itself back in.
+            Err(e) => return Err(Error::Other(format!("keychain delete ({key}): {e}"))),
+        }
         // Scrub any plaintext row a failed migration could have left behind.
         if database::get_setting(conn, key).is_some_and(|v| !v.is_empty()) {
             scrub_setting(conn, key);

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -71,10 +71,17 @@ mod store {
         }
         // Definitively absent from the keychain: migrate the legacy row,
         // then scrub it. On a keychain write failure keep the settings copy —
-        // the token still works, and the move retries on the next read.
+        // the token still works, and the move retries on the next read. A
+        // failed scrub is non-fatal *here* (the keychain copy is in place and
+        // the value must still be returned); `delete` is where a surviving
+        // row is load-bearing.
         let Some(legacy) = legacy else { return Ok(None) };
         match set(conn, key, &legacy) {
-            Ok(()) => scrub_setting(conn, key),
+            Ok(()) => {
+                if let Err(e) = scrub_setting(conn, key) {
+                    tracing::warn!(key, error = %e, "failed to blank migrated plaintext row");
+                }
+            }
             Err(e) => tracing::warn!(key, error = %e, "keychain migration failed"),
         }
         Ok(Some(legacy))
@@ -96,30 +103,39 @@ mod store {
             // account that signs itself back in.
             Err(e) => return Err(Error::Other(format!("keychain delete ({key}): {e}"))),
         }
-        // Scrub any plaintext row a failed migration could have left behind.
+        // Blank any plaintext row a failed migration could have left behind —
+        // and fail the disconnect if that blank fails: a surviving row would
+        // be re-migrated into the keychain on the next read, resurrecting the
+        // "deleted" secret.
         if database::get_setting(conn, key).is_some_and(|v| !v.is_empty()) {
-            scrub_setting(conn, key);
+            scrub_setting(conn, key)?;
         }
         Ok(())
     }
 
-    /// Blank the legacy `settings` row and scrub the old plaintext from the
+    /// Blank the legacy `settings` row, then scrub the old plaintext from the
     /// database *file*: a plain UPDATE leaves the value recoverable on freed
     /// pages and in the WAL, so zero freed content (`secure_delete`), rewrite
     /// the main file (VACUUM), and drain the WAL (checkpoint TRUNCATE).
-    /// Best-effort — the secret is already safe in the keychain, so a scrub
-    /// failure warns rather than blocking the caller.
-    fn scrub_setting(conn: &Connection, key: &str) {
-        let scrub = || -> Result<()> {
-            conn.pragma_update(None, "secure_delete", "ON")?;
-            database::set_setting(conn, key, "")?;
+    /// The row blank is the load-bearing step — a surviving value is a live
+    /// secret `get` would re-migrate — so its failure propagates; the file
+    /// scrub guards against forensic *remnants* and stays best-effort.
+    fn scrub_setting(conn: &Connection, key: &str) -> Result<()> {
+        // Armed before the overwrite so the freed page content is zeroed;
+        // only weakens the file scrub if it fails, so best-effort.
+        if let Err(e) = conn.pragma_update(None, "secure_delete", "ON") {
+            tracing::warn!(key, error = %e, "failed to enable secure_delete");
+        }
+        database::set_setting(conn, key, "")?;
+        let file_scrub = || -> Result<()> {
             conn.execute_batch("VACUUM")?;
             conn.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |_| Ok(()))?;
             Ok(())
         };
-        if let Err(e) = scrub() {
-            tracing::warn!(key, error = %e, "failed to scrub legacy plaintext setting");
+        if let Err(e) = file_scrub() {
+            tracing::warn!(key, error = %e, "failed to scrub plaintext remnants from db file");
         }
+        Ok(())
     }
 }
 

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -11,6 +11,10 @@
 //! each run. Values that reached the settings table under the pre-keychain
 //! scheme are migrated (and the plaintext scrubbed) on first read.
 //!
+//! `get` keeps a missing secret (`Ok(None)`) distinct from an unavailable
+//! store (`Err` — e.g. a locked keychain): a saved login that can't be read
+//! right now must surface as a retryable failure, never as signed-out.
+//!
 //! Secrets read or written here must never appear in logs, telemetry, or
 //! error strings — the `github::client` invariant, enforced at the store too.
 
@@ -40,32 +44,40 @@ mod store {
     /// and must not be treated as absence.
     const ERR_SEC_ITEM_NOT_FOUND: i32 = -25300;
 
-    pub fn get(conn: &Connection, key: &str) -> Option<String> {
-        match get_generic_password(SERVICE, key) {
+    pub fn get(conn: &Connection, key: &str) -> Result<Option<String>> {
+        let err = match get_generic_password(SERVICE, key) {
             Ok(bytes) => {
-                return String::from_utf8(bytes)
+                return Ok(String::from_utf8(bytes)
                     .ok()
-                    .filter(|v| !v.trim().is_empty())
+                    .filter(|v| !v.trim().is_empty()))
             }
-            // Unavailable ≠ absent: say so (never silently look signed out),
-            // then still consult the legacy row below — a pre-migration value
-            // keeps the session working, and nothing is scrubbed unless the
-            // keychain write succeeds.
-            Err(e) if e.code() != ERR_SEC_ITEM_NOT_FOUND => {
-                tracing::warn!(key, code = e.code(), "keychain read failed");
-            }
-            Err(_) => {}
+            Err(e) => e,
+        };
+        // The legacy plaintext `settings` row a pre-keychain build left
+        // behind — consulted both for migration and as the working copy
+        // while the keychain is unavailable.
+        let legacy = database::get_setting(conn, key).filter(|v| !v.trim().is_empty());
+        if err.code() != ERR_SEC_ITEM_NOT_FOUND {
+            // Unavailable ≠ absent (locked keychain, interaction not
+            // allowed): a migrated secret may exist but can't be read right
+            // now. A still-unmigrated legacy value keeps the session working
+            // (no migration attempt — the keychain write would fail too);
+            // otherwise surface the failure so callers retry instead of
+            // treating the account as signed out.
+            return match legacy {
+                Some(v) => Ok(Some(v)),
+                None => Err(Error::Other(format!("keychain read ({key}): {err}"))),
+            };
         }
-        // Not in the keychain: migrate the legacy plaintext `settings` row a
-        // pre-keychain build left behind, then scrub it. On a keychain write
-        // failure keep the settings copy — the token still works, and the
-        // move retries on the next read.
-        let legacy = database::get_setting(conn, key).filter(|v| !v.trim().is_empty())?;
+        // Definitively absent from the keychain: migrate the legacy row,
+        // then scrub it. On a keychain write failure keep the settings copy —
+        // the token still works, and the move retries on the next read.
+        let Some(legacy) = legacy else { return Ok(None) };
         match set(conn, key, &legacy) {
             Ok(()) => scrub_setting(conn, key),
             Err(e) => tracing::warn!(key, error = %e, "keychain migration failed"),
         }
-        Some(legacy)
+        Ok(Some(legacy))
     }
 
     pub fn set(_conn: &Connection, key: &str, value: &str) -> Result<()> {
@@ -119,8 +131,8 @@ mod store {
     use super::*;
     use crate::database;
 
-    pub fn get(conn: &Connection, key: &str) -> Option<String> {
-        database::get_setting(conn, key).filter(|v| !v.trim().is_empty())
+    pub fn get(conn: &Connection, key: &str) -> Result<Option<String>> {
+        Ok(database::get_setting(conn, key).filter(|v| !v.trim().is_empty()))
     }
 
     pub fn set(conn: &Connection, key: &str, value: &str) -> Result<()> {
@@ -152,20 +164,21 @@ mod tests {
     fn roundtrip_set_get_delete() {
         let (_dir, db) = test_db();
         let conn = db.lock();
-        assert_eq!(get(&conn, "github_token"), None);
+        assert_eq!(get(&conn, "github_token").unwrap(), None);
         set(&conn, "github_token", "tok123").unwrap();
-        assert_eq!(get(&conn, "github_token").as_deref(), Some("tok123"));
+        assert_eq!(get(&conn, "github_token").unwrap().as_deref(), Some("tok123"));
         delete(&conn, "github_token").unwrap();
-        assert_eq!(get(&conn, "github_token"), None);
+        assert_eq!(get(&conn, "github_token").unwrap(), None);
     }
 
     /// A cleared secret persists as a blank row (dev store) — blank must read
-    /// back as "no secret", matching `github::set_token`'s blank handling.
+    /// back as "no secret" (`Ok(None)`, not an error), matching
+    /// `github::set_token`'s blank handling.
     #[test]
     fn blank_value_reads_as_none() {
         let (_dir, db) = test_db();
         let conn = db.lock();
         set(&conn, "claude_container_token", "  ").unwrap();
-        assert_eq!(get(&conn, "claude_container_token"), None);
+        assert_eq!(get(&conn, "claude_container_token").unwrap(), None);
     }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -439,9 +439,9 @@ export const api = {
   setSandboxEngine: (engine: SandboxEngine) => invoke<void>("set_sandbox_engine", { engine }),
   probeDockerEngine: () => invoke<DockerProbe>("probe_docker_engine"),
   // Anthropic auth for containerized agents. Docker-only: seatbelt agents keep
-  // the user's own claude login. The token setting is backend-owned
-  // (`claude_container_token`, written by the set/clear commands below — never
-  // via a frontend `setSetting`).
+  // the user's own claude login. The token is backend-owned
+  // (`claude_container_token` in the backend secret store, written by the
+  // set/clear commands below — never via a frontend `setSetting`).
   getContainerAuthStatus: () => invoke<ContainerAuthStatus>("get_container_auth_status"),
   setContainerAuthToken: (token: string) => invoke<void>("set_container_auth_token", { token }),
   clearContainerAuthToken: () => invoke<void>("clear_container_auth_token"),


### PR DESCRIPTION
Closes audit finding M1: the GitHub OAuth token (`repo` scope) sat plaintext in the `settings` table of `fletch.db`, inside a directory the agent sandbox grants write access to — a prompt-injected agent could read the token and exfiltrate it, or rewrite the DB (forge other agents' transcripts, corrupt app state). Two complementary fixes:

## 1. Sandbox: deny read+write on the app's own data dir (`seatbelt.rs`)

`~/Library/Application Support/com.fletch.desktop` is carved back out of the broad Application Support grant with a `(deny file-read* file-write* …)` appended after the allow block (SBPL is last-match-wins). Agents can no longer read fletch.db (exfiltration) or write it (transcript forging) — this also protects the dev-build plaintext fallback below. The Run profile keeps the same deny but re-allows the `dev` subdir so a nested dev Fletch launched from the Run panel can still open its own database (dev-only tradeoff, documented in the profile).

## 2. Secrets: Keychain storage for both app-held tokens (`secrets.rs`)

`github_token` and `claude_container_token` now live in the login Keychain on release macOS builds, via the in-process Security.framework API. The same signed binary creates and reads the items, so the app's access is silent — no prompt, no password, and updates keep access (same Developer ID). Any *other* process trying to read them triggers a visible macOS consent dialog. Dev builds (and non-macOS targets) fall back to the existing settings-table storage, because an ad-hoc-signed dev binary changes code identity on every rebuild and would re-prompt each run; the sandbox deny above still shields that path.

Existing users migrate transparently: on first read the legacy settings value moves to the Keychain and the plaintext is scrubbed from the DB file (`secure_delete` + `VACUUM` + WAL truncate — a plain UPDATE leaves the value recoverable on freed pages and in the WAL). If the Keychain write fails, the settings copy is kept and the move retries next launch. All persistence flows through the new `secrets::get/set/delete` seam; the in-process token mirrors (`github::set_token`, docker auth) are unchanged.

## Verification

- `cargo check` (debug) and `cargo check --release` — both cfg backends compile
- `cargo test --lib`: 544 passed (5 new: secrets roundtrip/blank-handling, seatbelt deny presence + ordering + dev-exception scoping)
- Generated SBPL validated with `sandbox-exec` (multi-operation deny parses)
- Remaining manual check: on a signed release build, sign in and confirm the token lands in Keychain Access and the settings row is scrubbed

🤖 Generated with [Claude Code](https://claude.com/claude-code)