### PR TITLE
fix(sandbox): narrow agent write grants via shared engine-independent policy

### DIFF
--- a/src-tauri/src/sandbox/docker/engine.rs
+++ b/src-tauri/src/sandbox/docker/engine.rs
@@ -64,7 +64,7 @@ use crate::error::{Error, Result};
 use crate::sandbox::engine::{
     AgentLaunchCtx, EngineKind, Keepalive, KillHandle, KillPlan, LaunchPlan, SandboxEngine,
 };
-use crate::sandbox::seatbelt::resolve_existing_prefix;
+use crate::sandbox::policy::{opencode_config_dir, opencode_data_dir, resolve_existing_prefix};
 
 use super::auth::{self, ContainerAuth};
 use super::{cleanup, cli, image, DockerProvider};
@@ -696,34 +696,18 @@ fn codex_home_is_nondefault(home: &Path) -> bool {
     }
 }
 
-/// OpenCode's data dir: `$XDG_DATA_HOME/opencode` if set, else
-/// `~/.local/share/opencode`. This is both the dir bind-mounted read-write and
-/// where `agent::opencode_locate` reads its session storage on the host, so the
-/// two must agree — mirror its resolution.
-fn opencode_data_dir(home: &Path) -> PathBuf {
-    xdg_base(home, "XDG_DATA_HOME", ".local/share").join("opencode")
-}
-
-/// OpenCode's config dir: `$XDG_CONFIG_HOME/opencode` if set, else
-/// `~/.config/opencode` (custom providers + plugin installs). Mounted only when
-/// it already exists (see the launch path).
-fn opencode_config_dir(home: &Path) -> PathBuf {
-    xdg_base(home, "XDG_CONFIG_HOME", ".config").join("opencode")
-}
-
-/// The XDG base dir named by `var` (`$var` if set non-blank, else
-/// `home/<default_rel>`). Shared by [`opencode_data_dir`]/[`opencode_config_dir`].
-fn xdg_base(home: &Path, var: &str, default_rel: &str) -> PathBuf {
-    std::env::var_os(var)
-        .filter(|v| !v.is_empty())
-        .map(PathBuf::from)
-        .unwrap_or_else(|| home.join(default_rel))
-}
+// OpenCode's data/config dir resolution (`opencode_data_dir`,
+// `opencode_config_dir`) and their shared `xdg_base` helper now live in
+// [`crate::sandbox::policy`] — they're class-1 host-persistence dirs both
+// engines share (Docker mounts them; seatbelt grants them), so the policy
+// module is their single source of truth. Imported at the top of this file.
 
 /// Whether `$var` points to an XDG base other than the default `home/<default_rel>`
 /// the container already resolves via `HOME`. Only a non-default base is forwarded,
 /// mirroring [`codex_home_is_nondefault`]; both sides canonicalize via
-/// [`resolve_existing_prefix`] so a symlink can't read as non-default.
+/// [`resolve_existing_prefix`] so a symlink can't read as non-default. This stays
+/// docker-local: it's launch-time env-forwarding logic (does the container need a
+/// `-e XDG_*`?), not a write-policy question.
 fn xdg_base_is_nondefault(var: &str, home: &Path, default_rel: &str) -> bool {
     match std::env::var_os(var) {
         Some(v) if !v.is_empty() => {

--- a/src-tauri/src/sandbox/docker/engine.rs
+++ b/src-tauri/src/sandbox/docker/engine.rs
@@ -64,7 +64,9 @@ use crate::error::{Error, Result};
 use crate::sandbox::engine::{
     AgentLaunchCtx, EngineKind, Keepalive, KillHandle, KillPlan, LaunchPlan, SandboxEngine,
 };
-use crate::sandbox::policy::{opencode_config_dir, opencode_data_dir, resolve_existing_prefix};
+use crate::sandbox::policy::{
+    codex_home_dir, opencode_config_dir, opencode_data_dir, resolve_existing_prefix,
+};
 
 use super::auth::{self, ContainerAuth};
 use super::{cleanup, cli, image, DockerProvider};
@@ -676,31 +678,28 @@ const MULTI_PROVIDER_API_KEY_ENV: &[&str] = &[
     "MISTRAL_API_KEY",
 ];
 
-/// Codex's config dir: `$CODEX_HOME` if set, else `~/.codex`. This is both the
-/// dir bind-mounted read-write and where `transcripts::find_codex_rollouts`
-/// reads transcripts, so the two must agree — mirror its resolution.
-fn codex_home_dir(home: &Path) -> PathBuf {
-    std::env::var_os("CODEX_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| home.join(".codex"))
-}
-
 /// Whether `$CODEX_HOME` is set to a dir other than the default `~/.codex`
 /// (which the container already resolves via `HOME`). Only a non-default value
 /// is forwarded, mirroring [`nondefault_claude_config_dir`]; both sides go
 /// through [`resolve_existing_prefix`] so a symlink can't read as non-default.
+/// Blank counts as unset, matching [`codex_home_dir`]'s resolution —
+/// forwarding a blank value the resolver ignored would desync the two.
 fn codex_home_is_nondefault(home: &Path) -> bool {
     match std::env::var_os("CODEX_HOME") {
-        Some(v) => resolve_existing_prefix(&PathBuf::from(v)) != resolve_existing_prefix(&home.join(".codex")),
-        None => false,
+        Some(v) if !v.is_empty() => {
+            resolve_existing_prefix(&PathBuf::from(v))
+                != resolve_existing_prefix(&home.join(".codex"))
+        }
+        _ => false,
     }
 }
 
-// OpenCode's data/config dir resolution (`opencode_data_dir`,
-// `opencode_config_dir`) and their shared `xdg_base` helper now live in
-// [`crate::sandbox::policy`] — they're class-1 host-persistence dirs both
-// engines share (Docker mounts them; seatbelt grants them), so the policy
-// module is their single source of truth. Imported at the top of this file.
+// Codex's `$CODEX_HOME` resolution (`codex_home_dir`) and opencode's data/
+// config dir resolution (`opencode_data_dir`, `opencode_config_dir`, their
+// shared `xdg_base`) now live in [`crate::sandbox::policy`] — they're class-1
+// host-persistence dirs both engines share (Docker mounts them; seatbelt
+// grants them), so the policy module is their single source of truth.
+// Imported at the top of this file.
 
 /// Whether `$var` points to an XDG base other than the default `home/<default_rel>`
 /// the container already resolves via `HOME`. Only a non-default base is forwarded,

--- a/src-tauri/src/sandbox/mod.rs
+++ b/src-tauri/src/sandbox/mod.rs
@@ -1,5 +1,6 @@
 pub mod docker;
 mod engine;
+pub mod policy;
 pub mod provision;
 mod seatbelt;
 

--- a/src-tauri/src/sandbox/policy.rs
+++ b/src-tauri/src/sandbox/policy.rs
@@ -1,0 +1,332 @@
+//! Engine-independent **write policy** for sandboxed agents: which host
+//! directories a coding agent is allowed to write. It's the single source of
+//! truth both sandbox engines consume — macOS seatbelt (SBPL `(subpath …)`
+//! rules) and Docker (`-v host:host` bind mounts) — instead of each engine
+//! hand-maintaining its own allow-list and drifting apart.
+//!
+//! The split is **policy vs mechanism**: this module answers *what* an agent
+//! may write; each engine decides *how* to enforce it. Grants fall into two
+//! classes:
+//!
+//! - **Host-persistence grants** (class 1 — [`provider_state_dirs`] /
+//!   [`all_provider_state_dirs`]): host dirs a provider must persist real state
+//!   to — its session store, auth, config. BOTH engines honor these (Docker as
+//!   read-write mounts, seatbelt as writable subpaths), because that state has
+//!   to land on the *host* to survive the process/container and be read back by
+//!   the host-side transcript/auth readers.
+//! - **Host-scratch grants** (class 2 — [`agent_scratch_dirs`]): caches and XDG
+//!   data/state dirs a toolchain needs writable *somewhere*, but not
+//!   necessarily on a host-visible path. Only engines that share the host
+//!   filesystem (seatbelt) consume these; Docker satisfies them with the
+//!   container's own writable filesystem and must NOT mount them back to the
+//!   host.
+//!
+//! Two invariants hold across every path any function here returns; the guard
+//! test `policy_grants_never_expose_bin_or_config_root` encodes them so a future
+//! provider or scratch dir can't silently regress the class:
+//!
+//! 1. **No PATH-resolved bin dir is ever agent-writable** (the `~/.local/bin`
+//!    class). Nothing returns `~/.local/bin`, anything under it, or any
+//!    component-final `bin` dir under home. Were one writable, a prompt-injected
+//!    agent could drop `~/.local/bin/git`, and the user's next *host* shell
+//!    command would run attacker code entirely outside the sandbox.
+//! 2. **No host config *root* is ever agent-writable** (the `~/.config` class).
+//!    Nothing returns bare `~/.config`. A provider gets specific config
+//!    *subdirs* (e.g. `~/.config/opencode`), never the root — so an agent can't
+//!    poison `~/.config/git` (`core.hooksPath`), `~/.config/fish`,
+//!    `~/.config/gh` (aliases carry shell commands), etc.
+//!
+//! One piece of claude's persistence surface is deliberately *not* modeled
+//! here: the top-level `~/.claude.json` state **file**. It's a single file, not
+//! a dir, and threading a file-literal grant through this dir-oriented API buys
+//! nothing, so the seatbelt caller keeps it as a local literal grant. Noted
+//! here so the whole persistence surface is documented in one place.
+
+use std::path::{Path, PathBuf};
+
+/// Every provider whose host-persistence dirs seatbelt's provider-agnostic
+/// profile grants — the enumeration [`all_provider_state_dirs`] folds over.
+/// A superset of Docker's supported providers (Docker has no `gemini` image
+/// yet, but the seatbelt agent still runs the gemini CLI and must let it
+/// persist `~/.gemini`), so this list, not [`super::docker::DockerProvider`],
+/// is the authority for the seatbelt side.
+const STATE_DIR_PROVIDERS: &[&str] = &["claude", "codex", "cursor", "gemini", "pi", "opencode"];
+
+/// Class-1 host-persistence dirs a single `provider` must write on the host:
+/// its session store, auth, and config. Docker mounts exactly these read-write
+/// at their host paths; the seatbelt profile folds them in provider-agnostically
+/// via [`all_provider_state_dirs`]. An unrecognized provider yields an empty
+/// list — Docker already gates on a known [`super::docker::DockerProvider`], and
+/// the seatbelt side only ever passes ids from [`STATE_DIR_PROVIDERS`].
+///
+/// Note the omissions this policy makes on purpose: claude's grant is its
+/// config *dir* only — the top-level `~/.claude.json` file stays a
+/// seatbelt-local literal (see the module doc), and a non-default
+/// `CLAUDE_CONFIG_DIR` is likewise handled by the seatbelt caller, which needs
+/// its own symlink-resolution to keep the emitted SBPL path matching the
+/// sandbox's resolved write path.
+pub fn provider_state_dirs(provider: &str, home: &Path) -> Vec<PathBuf> {
+    match provider {
+        "claude" => vec![home.join(".claude")],
+        "codex" => vec![home.join(".codex")],
+        "cursor" => vec![home.join(".cursor")],
+        "gemini" => vec![home.join(".gemini")],
+        "pi" => vec![home.join(".pi")],
+        // OpenCode keeps its session store / auth under an XDG *data* dir and
+        // its custom-provider/plugin config under an XDG *config* dir. The
+        // config dir is a specific `~/.config` subdir (invariant 2), never the
+        // root.
+        "opencode" => vec![opencode_data_dir(home), opencode_config_dir(home)],
+        _ => Vec::new(),
+    }
+}
+
+/// Class-1 union across every provider — for an engine whose confinement is
+/// built once, provider-agnostically (the seatbelt profile covers *all* agents
+/// with one profile, so it must grant every provider's state dirs). Deduped
+/// while preserving first-seen order so the emitted allow-list is stable.
+pub fn all_provider_state_dirs(home: &Path) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    for provider in STATE_DIR_PROVIDERS {
+        for dir in provider_state_dirs(provider, home) {
+            if !out.contains(&dir) {
+                out.push(dir);
+            }
+        }
+    }
+    out
+}
+
+/// Class-2 host-scratch dirs a host-FS-sharing engine (seatbelt) must
+/// additionally allow: package-manager caches and the XDG data/state +
+/// macOS-native cache/app-support dirs the agents' subprocess toolchains and
+/// macOS frameworks write to. A denied write here ranges from a harmless cache
+/// miss to a fatal auth-token or state write, so they're granted on the
+/// "per-user app state, not source/system" basis.
+///
+/// Crucially this is the narrow replacement for the old blanket `~/.local` and
+/// `~/.config` grants: `~/.local/share` + `~/.local/state` instead of all of
+/// `~/.local` (which contains `~/.local/bin`, a PATH dir — invariant 1), and
+/// *nothing* under `~/.config` (config poisoning — invariant 2; providers get
+/// their specific config subdirs via [`provider_state_dirs`] instead).
+///
+/// Docker does NOT consume these: a container has its own writable filesystem
+/// for scratch, and mounting these back would needlessly expose host state.
+pub fn agent_scratch_dirs(home: &Path) -> Vec<PathBuf> {
+    [
+        ".npm",                      // npm's package cache
+        ".cache",                    // XDG cache root
+        ".local/share",             // XDG data root — NOT ~/.local (holds ~/.local/bin)
+        ".local/state",             // XDG state root — NOT ~/.local (holds ~/.local/bin)
+        "Library/Caches",            // macOS-native cache root
+        "Library/Application Support", // macOS-native per-app state root
+    ]
+    .iter()
+    .map(|d| home.join(d))
+    .collect()
+}
+
+/// OpenCode's data dir: `$XDG_DATA_HOME/opencode` if set, else
+/// `~/.local/share/opencode`. This is both the dir Docker bind-mounts read-write
+/// and where `agent::opencode_locate` reads its session storage on the host, so
+/// the two must agree — this is the shared resolution.
+pub fn opencode_data_dir(home: &Path) -> PathBuf {
+    xdg_base(home, "XDG_DATA_HOME", ".local/share").join("opencode")
+}
+
+/// OpenCode's config dir: `$XDG_CONFIG_HOME/opencode` if set, else
+/// `~/.config/opencode` (custom providers + plugin installs). A specific
+/// `~/.config` subdir — never the root (invariant 2). Docker mounts it only
+/// when it already exists (see the docker launch path).
+pub fn opencode_config_dir(home: &Path) -> PathBuf {
+    xdg_base(home, "XDG_CONFIG_HOME", ".config").join("opencode")
+}
+
+/// The XDG base dir named by `var` (`$var` if set non-blank, else
+/// `home/<default_rel>`). Shared by [`opencode_data_dir`]/[`opencode_config_dir`].
+pub fn xdg_base(home: &Path, var: &str, default_rel: &str) -> PathBuf {
+    std::env::var_os(var)
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home.join(default_rel))
+}
+
+/// Resolve symlinks in the longest existing prefix of `p`, then re-append the
+/// not-yet-existing tail. `fs::canonicalize` alone can't be used because it
+/// requires the whole path to exist, but a config dir (e.g. `CLAUDE_CONFIG_DIR`)
+/// may point at a dir the CLI hasn't created yet. Resolving the existing prefix
+/// still collapses the well-known macOS symlinks (`/tmp` → `/private/tmp`,
+/// `/var` → `/private/var`), so the emitted SBPL path matches the sandbox's
+/// resolved write path. Falls back to `p` unchanged if nothing resolves (e.g. a
+/// bogus path).
+///
+/// Lives here — not in either engine — because both need it: seatbelt to emit a
+/// canonical SBPL allow entry for a non-default config dir, docker to compare a
+/// config/XDG dir against its default. It used to live in `seatbelt` and be
+/// imported *up* into `docker`, a cross-engine dependency pointing the wrong
+/// way; the shared policy module is its correct home.
+pub fn resolve_existing_prefix(p: &Path) -> PathBuf {
+    let mut cur = p.to_path_buf();
+    let mut tail: Vec<std::ffi::OsString> = Vec::new();
+    loop {
+        if let Ok(real) = std::fs::canonicalize(&cur) {
+            let mut out = real;
+            out.extend(tail.iter().rev());
+            return out;
+        }
+        match cur.file_name() {
+            Some(name) => tail.push(name.to_os_string()),
+            None => return p.to_path_buf(),
+        }
+        if !cur.pop() {
+            return p.to_path_buf();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+
+    /// The invariant guard — the whole reason this module centralizes the
+    /// allow-list. It encodes the *class* (not just today's instances): every
+    /// dir any grant function returns must be neither the `~/.local/bin`
+    /// PATH-hijack surface (invariant 1) nor a host config/local *root*
+    /// (invariant 2). A future provider or scratch dir that reintroduces either
+    /// fails here before it can reach a sandbox profile.
+    #[test]
+    fn policy_grants_never_expose_bin_or_config_root() {
+        let home = Path::new("/Users/u");
+        let mut dirs = all_provider_state_dirs(home);
+        dirs.extend(agent_scratch_dirs(home));
+
+        let local_bin = home.join(".local/bin");
+        let config_root = home.join(".config");
+        let local_root = home.join(".local");
+
+        for dir in &dirs {
+            // (i) never ~/.local/bin, nor anything nested under it.
+            assert!(
+                !dir.starts_with(&local_bin),
+                "{} exposes the PATH bin dir ~/.local/bin (invariant 1)",
+                dir.display()
+            );
+            // (ii) never the bare config/local roots.
+            assert_ne!(
+                *dir, config_root,
+                "the ~/.config root must never be granted (invariant 2)"
+            );
+            assert_ne!(
+                *dir, local_root,
+                "the ~/.local root must never be granted (invariant 1)"
+            );
+            // (iii) no component-final `bin` dir under home — the general
+            // PATH-hijack class, not just the ~/.local/bin instance.
+            assert_ne!(
+                dir.file_name(),
+                Some(OsStr::new("bin")),
+                "{} is a component-final bin dir — a PATH-hijack surface (invariant 1)",
+                dir.display()
+            );
+        }
+    }
+
+    /// Class-1 per-provider content, and the union's dedup + coverage.
+    #[test]
+    fn provider_state_dirs_cover_each_provider() {
+        let home = Path::new("/Users/u");
+        assert_eq!(provider_state_dirs("claude", home), vec![home.join(".claude")]);
+        assert_eq!(provider_state_dirs("codex", home), vec![home.join(".codex")]);
+        assert_eq!(provider_state_dirs("cursor", home), vec![home.join(".cursor")]);
+        assert_eq!(provider_state_dirs("gemini", home), vec![home.join(".gemini")]);
+        assert_eq!(provider_state_dirs("pi", home), vec![home.join(".pi")]);
+        // OpenCode: XDG data + config subdirs (default locations here).
+        assert_eq!(
+            provider_state_dirs("opencode", home),
+            vec![
+                home.join(".local/share/opencode"),
+                home.join(".config/opencode"),
+            ],
+        );
+        // Unknown provider → empty, never a panic.
+        assert!(provider_state_dirs("nope", home).is_empty());
+
+        // The union carries every provider's dirs and is deduped.
+        let all = all_provider_state_dirs(home);
+        for expected in [
+            home.join(".claude"),
+            home.join(".codex"),
+            home.join(".cursor"),
+            home.join(".gemini"),
+            home.join(".pi"),
+            home.join(".local/share/opencode"),
+            home.join(".config/opencode"),
+        ] {
+            assert!(all.contains(&expected), "union missing {}", expected.display());
+        }
+        let mut deduped = all.clone();
+        deduped.dedup();
+        assert_eq!(deduped.len(), all.len(), "union must be free of duplicates");
+    }
+
+    /// The only `~/.config` grant the policy ever emits is a specific subdir
+    /// (`opencode`), and the only `~/.local` grants are `share`/`state` — the
+    /// concrete narrowing this security fix is about.
+    #[test]
+    fn config_and_local_grants_are_narrow_subdirs() {
+        let home = Path::new("/Users/u");
+        let mut dirs = all_provider_state_dirs(home);
+        dirs.extend(agent_scratch_dirs(home));
+
+        let under_config: Vec<_> = dirs
+            .iter()
+            .filter(|d| d.starts_with(home.join(".config")))
+            .collect();
+        assert_eq!(
+            under_config,
+            vec![&home.join(".config/opencode")],
+            "the only ~/.config grant may be ~/.config/opencode"
+        );
+
+        let under_local: Vec<_> = dirs
+            .iter()
+            .filter(|d| d.starts_with(home.join(".local")))
+            .collect();
+        // `.local/share` (scratch), `.local/state` (scratch), and
+        // `.local/share/opencode` (opencode data) — all narrow, none is `.local`.
+        for d in &under_local {
+            assert_ne!(**d, home.join(".local"), "must never be the bare ~/.local");
+            assert!(d.starts_with(home.join(".local/share")) || d.starts_with(home.join(".local/state")));
+        }
+    }
+
+    #[test]
+    fn resolve_existing_prefix_resolves_symlinks_through_missing_leaf() {
+        // A config dir may point at a dir the CLI hasn't created yet, under a
+        // symlinked prefix (the /tmp → /private/tmp case). The existing prefix
+        // must be symlink-resolved and the missing leaf re-appended verbatim.
+        let td = tempfile::tempdir().unwrap();
+        let real = td.path().join("real");
+        std::fs::create_dir_all(&real).unwrap();
+        let link = td.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let resolved = resolve_existing_prefix(&link.join("not-created-yet"));
+        let expected = std::fs::canonicalize(&real)
+            .unwrap()
+            .join("not-created-yet");
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn resolve_existing_prefix_canonicalizes_an_existing_dir() {
+        let td = tempfile::tempdir().unwrap();
+        let dir = td.path().join("cfg");
+        std::fs::create_dir_all(&dir).unwrap();
+        assert_eq!(
+            resolve_existing_prefix(&dir),
+            std::fs::canonicalize(&dir).unwrap()
+        );
+    }
+}

--- a/src-tauri/src/sandbox/policy.rs
+++ b/src-tauri/src/sandbox/policy.rs
@@ -23,7 +23,13 @@
 //!
 //! Two invariants hold across every path any function here returns; the guard
 //! test `policy_grants_never_expose_bin_or_config_root` encodes them so a future
-//! provider or scratch dir can't silently regress the class:
+//! provider or scratch dir can't silently regress the class. For the
+//! env-relocatable dirs (`$CODEX_HOME`, `$XDG_*` — and `$CLAUDE_CONFIG_DIR`,
+//! resolved by the seatbelt caller) invariant 1 is additionally *enforced at
+//! resolution time*: [`env_state_dir`] rejects a value that sits inside a
+//! `bin`/`sbin` dir — checked on both the raw value and its symlink-resolved
+//! form — and falls back to the default, so the provider fails closed under
+//! that configuration instead of the profile granting a PATH dir:
 //!
 //! 1. **No PATH-resolved bin dir is ever agent-writable** (the `~/.local/bin`
 //!    class). Nothing returns `~/.local/bin`, anything under it, or any
@@ -163,10 +169,7 @@ pub fn codex_home_dir(home: &Path) -> PathBuf {
 /// a blank value verbatim, i.e. produced an empty mount source that failed
 /// the launch — falling back to the default is the strict improvement).
 fn codex_home_from(value: Option<std::ffi::OsString>, home: &Path) -> PathBuf {
-    value
-        .filter(|v| !v.is_empty())
-        .map(PathBuf::from)
-        .unwrap_or_else(|| home.join(".codex"))
+    env_state_dir(value, home.join(".codex"))
 }
 
 /// The XDG base dir named by `var` (`$var` if set non-blank, else
@@ -183,10 +186,44 @@ pub fn xdg_base(home: &Path, var: &str, default_rel: &str) -> PathBuf {
 /// value. A blank value counts as unset, matching the XDG spec's treatment of
 /// empty base-dir vars.
 fn xdg_base_from(value: Option<std::ffi::OsString>, home: &Path, default_rel: &str) -> PathBuf {
-    value
-        .filter(|v| !v.is_empty())
-        .map(PathBuf::from)
-        .unwrap_or_else(|| home.join(default_rel))
+    env_state_dir(value, home.join(default_rel))
+}
+
+/// Shared resolution for every env-relocatable state dir: use the env `value`
+/// unless it's absent, blank, or violates invariant 1. A value that sits
+/// inside a `bin`/`sbin` directory is REJECTED in favor of `default` — a grant
+/// there would put agent-writable files directly on the user's PATH (e.g.
+/// `XDG_DATA_HOME=$HOME/.local/bin` would grant `~/.local/bin/opencode`,
+/// letting an agent create an on-PATH executable named `opencode`; a
+/// bin-resident `$CODEX_HOME` would grant the whole bin dir). The check runs
+/// on the raw value AND its symlink-resolved form, so a link disguising a bin
+/// dir doesn't slip through. Rejection is fail-closed: under such a
+/// configuration the provider's writes are denied (it looks at the env var,
+/// we grant the default) — a visible breakage, never a hijack surface.
+fn env_state_dir(value: Option<std::ffi::OsString>, default: PathBuf) -> PathBuf {
+    let Some(v) = value.filter(|v| !v.is_empty()) else {
+        return default;
+    };
+    let raw = PathBuf::from(v);
+    if bin_resident(&raw) {
+        return default;
+    }
+    raw
+}
+
+/// Whether `p` — raw or symlink-resolved — has a `bin`/`sbin` path component,
+/// i.e. is or lives inside a PATH-style binaries dir (invariant 1's rejection
+/// predicate). Component equality, not substring: `~/binaries` is fine.
+/// `pub(crate)` for the seatbelt `CLAUDE_CONFIG_DIR` handling, which resolves
+/// its env value itself and must apply the same rejection.
+pub(crate) fn bin_resident(p: &Path) -> bool {
+    has_bin_component(p) || has_bin_component(&resolve_existing_prefix(p))
+}
+
+fn has_bin_component(p: &Path) -> bool {
+    use std::path::Component;
+    p.components()
+        .any(|c| matches!(c, Component::Normal(n) if n == "bin" || n == "sbin"))
 }
 
 /// Resolve symlinks in the longest existing prefix of `p`, then re-append the
@@ -386,6 +423,50 @@ mod tests {
         // Blank counts as unset — the old docker-local resolution took it
         // verbatim and produced an empty, launch-failing mount source.
         assert_eq!(codex_home_from(Some("".into()), home), home.join(".codex"));
+    }
+
+    /// Invariant 1 enforced at resolution time, not just asserted over the
+    /// defaults: an env relocation into a `bin`/`sbin` dir must be rejected,
+    /// or the profile would grant an agent-writable path directly on the
+    /// user's PATH (`XDG_DATA_HOME=$HOME/.local/bin` → a writable on-PATH
+    /// `opencode`; a bin-resident `$CODEX_HOME` → the whole bin dir).
+    #[test]
+    fn env_relocations_inside_bin_dirs_are_rejected() {
+        let home = Path::new("/Users/u");
+
+        assert_eq!(
+            xdg_base_from(Some("/Users/u/.local/bin".into()), home, ".local/share"),
+            home.join(".local/share"),
+            "XDG base inside ~/.local/bin must fall back to the default"
+        );
+        assert_eq!(
+            codex_home_from(Some("/Users/u/.local/bin/codex".into()), home),
+            home.join(".codex"),
+            "CODEX_HOME under a bin dir must fall back to the default"
+        );
+        // `sbin` is the same PATH-style class.
+        assert_eq!(
+            codex_home_from(Some("/usr/local/sbin/codex".into()), home),
+            home.join(".codex")
+        );
+        // Component equality, not substring: a dir merely *named like* bin is
+        // a legitimate relocation target.
+        assert_eq!(
+            codex_home_from(Some("/Users/u/binaries/codex".into()), home),
+            PathBuf::from("/Users/u/binaries/codex")
+        );
+
+        // A symlink disguising a bin dir resolves into one → still rejected.
+        let td = tempfile::tempdir().unwrap();
+        let bin = td.path().join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        let link = td.path().join("data");
+        std::os::unix::fs::symlink(&bin, &link).unwrap();
+        assert_eq!(
+            codex_home_from(Some(link.into_os_string()), home),
+            home.join(".codex"),
+            "a symlink resolving into a bin dir must be rejected too"
+        );
     }
 
     #[test]

--- a/src-tauri/src/sandbox/policy.rs
+++ b/src-tauri/src/sandbox/policy.rs
@@ -64,11 +64,17 @@ const STATE_DIR_PROVIDERS: &[&str] = &["claude", "codex", "cursor", "gemini", "p
 /// seatbelt-local literal (see the module doc), and a non-default
 /// `CLAUDE_CONFIG_DIR` is likewise handled by the seatbelt caller, which needs
 /// its own symlink-resolution to keep the emitted SBPL path matching the
-/// sandbox's resolved write path.
+/// sandbox's resolved write path. Codex's and opencode's env relocations
+/// (`$CODEX_HOME`, `$XDG_*`), by contrast, ARE resolved here — both engines
+/// need the same dir, with no engine-specific handling on top.
 pub fn provider_state_dirs(provider: &str, home: &Path) -> Vec<PathBuf> {
     match provider {
         "claude" => vec![home.join(".claude")],
-        "codex" => vec![home.join(".codex")],
+        // Codex's state dir moves with `$CODEX_HOME`. The old blanket
+        // `~/.config` agent grant incidentally covered e.g.
+        // `CODEX_HOME=$HOME/.config/codex`; with the narrowing, this
+        // env-resolved grant is what keeps that supported relocation writable.
+        "codex" => vec![codex_home_dir(home)],
         "cursor" => vec![home.join(".cursor")],
         "gemini" => vec![home.join(".gemini")],
         "pi" => vec![home.join(".pi")],
@@ -140,6 +146,27 @@ pub fn opencode_data_dir(home: &Path) -> PathBuf {
 /// when it already exists (see the docker launch path).
 pub fn opencode_config_dir(home: &Path) -> PathBuf {
     xdg_base(home, "XDG_CONFIG_HOME", ".config").join("opencode")
+}
+
+/// Codex's config dir: `$CODEX_HOME` if set non-blank, else `~/.codex`. This
+/// is both the dir Docker bind-mounts read-write and where
+/// `transcripts::find_codex_rollouts` reads transcripts on the host, so the
+/// two must agree — this is the shared resolution (it used to live in the
+/// docker engine, leaving seatbelt blind to the relocation).
+pub fn codex_home_dir(home: &Path) -> PathBuf {
+    codex_home_from(std::env::var_os("CODEX_HOME"), home)
+}
+
+/// Pure core of [`codex_home_dir`] — the same env-seam split as
+/// [`xdg_base_from`], for the same hermetic-test reason. Blank counts as
+/// unset, matching the XDG handling (the docker engine's old resolution took
+/// a blank value verbatim, i.e. produced an empty mount source that failed
+/// the launch — falling back to the default is the strict improvement).
+fn codex_home_from(value: Option<std::ffi::OsString>, home: &Path) -> PathBuf {
+    value
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home.join(".codex"))
 }
 
 /// The XDG base dir named by `var` (`$var` if set non-blank, else
@@ -248,7 +275,10 @@ mod tests {
     fn provider_state_dirs_cover_each_provider() {
         let home = Path::new("/Users/u");
         assert_eq!(provider_state_dirs("claude", home), vec![home.join(".claude")]);
-        assert_eq!(provider_state_dirs("codex", home), vec![home.join(".codex")]);
+        // Codex: env-dependent (`$CODEX_HOME`), so assert identity with the
+        // canonical resolver — same treatment as opencode below; the
+        // resolution itself is covered by the `codex_home_from` test.
+        assert_eq!(provider_state_dirs("codex", home), vec![codex_home_dir(home)]);
         assert_eq!(provider_state_dirs("cursor", home), vec![home.join(".cursor")]);
         assert_eq!(provider_state_dirs("gemini", home), vec![home.join(".gemini")]);
         assert_eq!(provider_state_dirs("pi", home), vec![home.join(".pi")]);
@@ -268,7 +298,7 @@ mod tests {
         let all = all_provider_state_dirs(home);
         for expected in [
             home.join(".claude"),
-            home.join(".codex"),
+            codex_home_dir(home),
             home.join(".cursor"),
             home.join(".gemini"),
             home.join(".pi"),
@@ -338,6 +368,24 @@ mod tests {
             xdg_base_from(Some("".into()), home, ".config"),
             home.join(".config")
         );
+    }
+
+    /// Same hermetic env-seam coverage for codex's `$CODEX_HOME` relocation —
+    /// the regression this guards: policy hardcoding `~/.codex` while docker
+    /// resolved the env var left a relocated codex home write-denied under
+    /// seatbelt (the old blanket `~/.config` grant had covered e.g.
+    /// `CODEX_HOME=$HOME/.config/codex`).
+    #[test]
+    fn codex_home_from_prefers_nonblank_value_else_default() {
+        let home = Path::new("/Users/u");
+        assert_eq!(
+            codex_home_from(Some("/Users/u/.config/codex".into()), home),
+            PathBuf::from("/Users/u/.config/codex")
+        );
+        assert_eq!(codex_home_from(None, home), home.join(".codex"));
+        // Blank counts as unset — the old docker-local resolution took it
+        // verbatim and produced an empty, launch-failing mount source.
+        assert_eq!(codex_home_from(Some("".into()), home), home.join(".codex"));
     }
 
     #[test]

--- a/src-tauri/src/sandbox/policy.rs
+++ b/src-tauri/src/sandbox/policy.rs
@@ -144,8 +144,19 @@ pub fn opencode_config_dir(home: &Path) -> PathBuf {
 
 /// The XDG base dir named by `var` (`$var` if set non-blank, else
 /// `home/<default_rel>`). Shared by [`opencode_data_dir`]/[`opencode_config_dir`].
+/// This thin wrapper is the env *seam*; the resolution itself is the pure
+/// [`xdg_base_from`], so it can be tested hermetically — CI runners export
+/// their own `XDG_*` vars, and mutating the process env in parallel tests
+/// races other tests that read it.
 pub fn xdg_base(home: &Path, var: &str, default_rel: &str) -> PathBuf {
-    std::env::var_os(var)
+    xdg_base_from(std::env::var_os(var), home, default_rel)
+}
+
+/// Pure core of [`xdg_base`]: resolve from an explicit (possibly absent) env
+/// value. A blank value counts as unset, matching the XDG spec's treatment of
+/// empty base-dir vars.
+fn xdg_base_from(value: Option<std::ffi::OsString>, home: &Path, default_rel: &str) -> PathBuf {
+    value
         .filter(|v| !v.is_empty())
         .map(PathBuf::from)
         .unwrap_or_else(|| home.join(default_rel))
@@ -241,13 +252,14 @@ mod tests {
         assert_eq!(provider_state_dirs("cursor", home), vec![home.join(".cursor")]);
         assert_eq!(provider_state_dirs("gemini", home), vec![home.join(".gemini")]);
         assert_eq!(provider_state_dirs("pi", home), vec![home.join(".pi")]);
-        // OpenCode: XDG data + config subdirs (default locations here).
+        // OpenCode: XDG data + config subdirs. The exact paths are
+        // env-dependent (`$XDG_DATA_HOME`/`$XDG_CONFIG_HOME` — CI runners
+        // export their own), so assert identity with the canonical resolvers;
+        // the resolution logic itself is covered hermetically by the
+        // `xdg_base_from` test below.
         assert_eq!(
             provider_state_dirs("opencode", home),
-            vec![
-                home.join(".local/share/opencode"),
-                home.join(".config/opencode"),
-            ],
+            vec![opencode_data_dir(home), opencode_config_dir(home)],
         );
         // Unknown provider → empty, never a panic.
         assert!(provider_state_dirs("nope", home).is_empty());
@@ -260,8 +272,8 @@ mod tests {
             home.join(".cursor"),
             home.join(".gemini"),
             home.join(".pi"),
-            home.join(".local/share/opencode"),
-            home.join(".config/opencode"),
+            opencode_data_dir(home),
+            opencode_config_dir(home),
         ] {
             assert!(all.contains(&expected), "union missing {}", expected.display());
         }
@@ -272,22 +284,26 @@ mod tests {
 
     /// The only `~/.config` grant the policy ever emits is a specific subdir
     /// (`opencode`), and the only `~/.local` grants are `share`/`state` — the
-    /// concrete narrowing this security fix is about.
+    /// concrete narrowing this security fix is about. Assertions are filtered
+    /// against the fake home, so a CI runner's own `$XDG_*` vars (which point
+    /// outside it, relocating opencode's dirs) can't perturb them.
     #[test]
     fn config_and_local_grants_are_narrow_subdirs() {
         let home = Path::new("/Users/u");
         let mut dirs = all_provider_state_dirs(home);
         dirs.extend(agent_scratch_dirs(home));
 
-        let under_config: Vec<_> = dirs
-            .iter()
-            .filter(|d| d.starts_with(home.join(".config")))
-            .collect();
-        assert_eq!(
-            under_config,
-            vec![&home.join(".config/opencode")],
-            "the only ~/.config grant may be ~/.config/opencode"
-        );
+        // Anything under ~/.config must be exactly opencode's default config
+        // subdir — never the root, never another subdir smuggled in outside
+        // the policy. (With a custom `$XDG_CONFIG_HOME` opencode's dir lives
+        // elsewhere and nothing under ~/.config is granted at all.)
+        for d in dirs.iter().filter(|d| d.starts_with(home.join(".config"))) {
+            assert_eq!(
+                *d,
+                home.join(".config/opencode"),
+                "the only ~/.config grant may be ~/.config/opencode"
+            );
+        }
 
         let under_local: Vec<_> = dirs
             .iter()
@@ -299,6 +315,29 @@ mod tests {
             assert_ne!(**d, home.join(".local"), "must never be the bare ~/.local");
             assert!(d.starts_with(home.join(".local/share")) || d.starts_with(home.join(".local/state")));
         }
+    }
+
+    /// Hermetic coverage of the XDG resolution [`xdg_base`] performs at its
+    /// env seam. The tests above deliberately never read the live env for
+    /// expected values — CI runners export their own `XDG_*` vars — and don't
+    /// mutate it either (parallel tests race on the process env), so the pure
+    /// core carries the resolution contract.
+    #[test]
+    fn xdg_base_from_prefers_nonblank_value_else_default() {
+        let home = Path::new("/Users/u");
+        assert_eq!(
+            xdg_base_from(Some("/custom/data".into()), home, ".local/share"),
+            PathBuf::from("/custom/data")
+        );
+        assert_eq!(
+            xdg_base_from(None, home, ".local/share"),
+            home.join(".local/share")
+        );
+        // Blank counts as unset, per the XDG spec.
+        assert_eq!(
+            xdg_base_from(Some("".into()), home, ".config"),
+            home.join(".config")
+        );
     }
 
     #[test]

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -375,6 +375,11 @@ pub fn build_profile(
     // seatbelt-local literal grant: it's a file, not a dir, so the dir-oriented
     // policy API doesn't model it (see the policy module doc).
     let claude_config_extra = claude_config_dir
+        // A bin-resident relocation (`CLAUDE_CONFIG_DIR=$HOME/.local/bin/…`)
+        // would put an agent-writable subtree on the user's PATH — the same
+        // rejection every env-relocated policy dir gets (invariant 1;
+        // fail-closed: claude's config writes are denied, never a hijack).
+        .filter(|p| !policy::bin_resident(p))
         .map(policy::resolve_existing_prefix)
         .map(|p| p.to_string_lossy().into_owned())
         .filter(|p| *p != format!("{home_s}/.claude"))
@@ -389,12 +394,12 @@ pub fn build_profile(
     // policy withholds every PATH-resolved bin dir (`~/.local/bin`) and config
     // root (`~/.config`), granting only `~/.local/share`+`~/.local/state` and the
     // specific `~/.config/opencode` — see the policy module's invariants.
-    let policy_dirs = policy::all_provider_state_dirs(&home)
-        .into_iter()
-        .chain(policy::agent_scratch_dirs(&home))
-        .map(|p| format!("  (subpath {})", sbpl_string(&p.to_string_lossy())))
-        .collect::<Vec<_>>()
-        .join("\n");
+    let policy_dirs = subpath_grants(
+        policy::all_provider_state_dirs(&home)
+            .into_iter()
+            .chain(policy::agent_scratch_dirs(&home)),
+    )
+    .join("\n");
 
     // No `dev` exception here (unlike the Run profile): agents never legitimately
     // touch any Fletch data dir, dev or otherwise.
@@ -420,6 +425,28 @@ pub fn build_profile(
 {DEVICE_WRITE_RULES}
 "#
     ))
+}
+
+/// SBPL `(subpath …)` grant lines for the policy dirs, each emitted in its
+/// literal form and — when different — its symlink-resolved form (deduped).
+/// The sandbox checks *resolved* write paths, so an env-relocated provider dir
+/// that passes through a symlink (`CODEX_HOME=/tmp/codex` → writes observed at
+/// `/private/tmp/codex`) is denied by the raw grant alone. The literal form is
+/// kept alongside: for the default home-relative dirs both forms are equal
+/// (home is canonical), and when a leaf like `~/.claude` is itself a symlink
+/// the literal path is what the `claude_config_extra` dedup compares against.
+fn subpath_grants(dirs: impl IntoIterator<Item = PathBuf>) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for dir in dirs {
+        let resolved = policy::resolve_existing_prefix(&dir);
+        for p in [dir, resolved] {
+            let line = format!("  (subpath {})", sbpl_string(&p.to_string_lossy()));
+            if !out.contains(&line) {
+                out.push(line);
+            }
+        }
+    }
+    out
 }
 
 /// Write an SBPL profile to a private `.sb` tempfile. `sandbox-exec -f <path>`
@@ -538,6 +565,48 @@ mod tests {
         assert!(
             profile.contains(&format!("(literal \"{h}/.claude.json\")")),
             "agent profile should keep the ~/.claude.json literal grant"
+        );
+    }
+
+    #[test]
+    fn subpath_grants_emit_resolved_form_for_symlinked_dirs() {
+        // The sandbox checks resolved write paths: an env-relocated dir behind
+        // a symlink (CODEX_HOME=/tmp/codex → /private/tmp/codex) must be
+        // granted in resolved form too, or its writes are denied.
+        let td = tempfile::tempdir().unwrap();
+        let real = td.path().join("real");
+        std::fs::create_dir_all(&real).unwrap();
+        let link = td.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let grants = subpath_grants([link.clone()]);
+        let canonical_real = std::fs::canonicalize(&real).unwrap();
+        assert!(
+            grants.contains(&format!("  (subpath \"{}\")", link.display())),
+            "literal form kept"
+        );
+        assert!(
+            grants.contains(&format!("  (subpath \"{}\")", canonical_real.display())),
+            "resolved form added"
+        );
+
+        // A dir that resolves to itself yields exactly one grant — no
+        // duplicate lines for the common (canonical) case.
+        assert_eq!(subpath_grants([canonical_real]).len(), 1);
+    }
+
+    #[test]
+    fn profile_rejects_bin_resident_claude_config_dir() {
+        // CLAUDE_CONFIG_DIR pointed into a PATH-style bin dir must not become
+        // a write grant (invariant 1) — claude fails closed instead.
+        let (_td, root, rpc, home) = sandbox_dirs();
+        let cfg = home.join(".local/bin/claude-cfg");
+        std::fs::create_dir_all(&cfg).unwrap();
+
+        let profile = build_profile(&root, &rpc, &home, Some(cfg.as_path())).unwrap();
+        assert!(
+            !profile.contains(".local/bin"),
+            "bin-resident CLAUDE_CONFIG_DIR must not appear on the allow-list"
         );
     }
 

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -518,9 +518,15 @@ mod tests {
             profile.contains(&format!("(subpath \"{}\")", opencode_config.display())),
             "agent profile should grant the narrow opencode config dir"
         );
+        // Codex's dir is env-relocatable too (`$CODEX_HOME`) — same treatment.
+        let codex_home = policy::codex_home_dir(&canonical_home);
+        assert!(
+            profile.contains(&format!("(subpath \"{}\")", codex_home.display())),
+            "agent profile should grant the codex home dir"
+        );
         // Everything else unchanged: provider dot-dirs, caches, macOS-native.
         for dir in [
-            ".claude", ".codex", ".cursor", ".gemini", ".pi", ".npm", ".cache",
+            ".claude", ".cursor", ".gemini", ".pi", ".npm", ".cache",
             "Library/Caches", "Library/Application Support",
         ] {
             assert!(

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -435,11 +435,24 @@ pub fn build_profile(
 /// kept alongside: for the default home-relative dirs both forms are equal
 /// (home is canonical), and when a leaf like `~/.claude` is itself a symlink
 /// the literal path is what the `claude_config_extra` dedup compares against.
+///
+/// Every candidate — literal and resolved — passes [`policy::bin_resident`]
+/// before it's emitted: a default dir whose leaf symlinks into a PATH-style
+/// bin dir (`~/.claude` → `~/.local/bin/claude`) must not have its resolved
+/// form granted, or writes through the symlink would land agent-controlled
+/// files on the user's PATH (invariant 1). Env-relocated dirs are already
+/// rejected at resolution time, but the default home-relative dirs never pass
+/// through that check, so it's re-applied here at the emission seam. Skipping
+/// is fail-closed: with the resolved form denied, the provider's writes
+/// through the symlink are refused rather than hijackable.
 fn subpath_grants(dirs: impl IntoIterator<Item = PathBuf>) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
     for dir in dirs {
         let resolved = policy::resolve_existing_prefix(&dir);
         for p in [dir, resolved] {
+            if policy::bin_resident(&p) {
+                continue;
+            }
             let line = format!("  (subpath {})", sbpl_string(&p.to_string_lossy()));
             if !out.contains(&line) {
                 out.push(line);
@@ -593,6 +606,48 @@ mod tests {
         // A dir that resolves to itself yields exactly one grant — no
         // duplicate lines for the common (canonical) case.
         assert_eq!(subpath_grants([canonical_real]).len(), 1);
+    }
+
+    #[test]
+    fn subpath_grants_never_emit_bin_resident_paths() {
+        // A default provider dir whose leaf symlinks into a PATH-style bin dir
+        // (~/.claude → ~/.local/bin/claude) must not have its resolved form
+        // emitted — that would grant an agent-writable subtree on the user's
+        // PATH through the symlink (invariant 1). Fail closed instead.
+        let td = tempfile::tempdir().unwrap();
+        let target = td.path().join(".local/bin/claude");
+        std::fs::create_dir_all(&target).unwrap();
+        let link = td.path().join(".claude");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let grants = subpath_grants([link]);
+        assert!(
+            grants.is_empty(),
+            "no grant may be emitted for a bin-resident dir, got: {grants:?}"
+        );
+    }
+
+    #[test]
+    fn profile_omits_provider_dirs_symlinked_into_bin() {
+        // End-to-end through build_profile: with ~/.claude symlinked into
+        // ~/.local/bin, neither the resolved bin subtree nor any other
+        // .local/bin path may appear on the allow-list, while the remaining
+        // provider dirs stay granted.
+        let (_td, root, rpc, home) = sandbox_dirs();
+        let target = home.join(".local/bin/claude");
+        std::fs::create_dir_all(&target).unwrap();
+        std::os::unix::fs::symlink(&target, home.join(".claude")).unwrap();
+
+        let profile = build_profile(&root, &rpc, &home, None).unwrap();
+        let canonical_home = std::fs::canonicalize(&home).unwrap();
+        assert!(
+            !profile.contains(".local/bin"),
+            "a symlinked ~/.claude must not smuggle a bin subtree onto the allow-list"
+        );
+        assert!(
+            profile.contains(&format!("(subpath \"{}/.cursor\")", canonical_home.display())),
+            "other provider dirs stay granted"
+        );
     }
 
     #[test]

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -503,13 +503,21 @@ mod tests {
             "no ~/.local/bin grant may appear"
         );
 
-        // Narrow replacements PRESENT.
-        for narrow in [".local/share", ".local/state", ".config/opencode"] {
+        // Narrow replacements PRESENT. The scratch dirs are fixed
+        // home-relative paths; opencode's config dir is env-dependent
+        // (`$XDG_CONFIG_HOME` — CI runners export their own), so assert it via
+        // the same policy resolution the profile builder uses.
+        for narrow in [".local/share", ".local/state"] {
             assert!(
                 profile.contains(&format!("(subpath \"{h}/{narrow}\")")),
                 "agent profile should grant the narrow {narrow}"
             );
         }
+        let opencode_config = policy::opencode_config_dir(&canonical_home);
+        assert!(
+            profile.contains(&format!("(subpath \"{}\")", opencode_config.display())),
+            "agent profile should grant the narrow opencode config dir"
+        );
         // Everything else unchanged: provider dot-dirs, caches, macOS-native.
         for dir in [
             ".claude", ".codex", ".cursor", ".gemini", ".pi", ".npm", ".cache",

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -13,14 +13,20 @@
 //! Because confinement is by *write* path (reads and network stay open via
 //! `allow default`), each agent that the wrapper covers must have its
 //! out-of-checkout write locations (session transcripts, config, auth refresh)
-//! on the allow-list below — otherwise it can't persist its own state. That
-//! covers the agents' own dot-dir stores plus the standard per-user
-//! cache/state dirs in both XDG (`~/.cache`, `~/.config`, `~/.local`) and
-//! macOS-native (`~/Library/Caches`, `~/Library/Application Support`) form,
-//! since the agents' subprocess toolchains and macOS frameworks write to the
-//! latter. The agent CLIs' own sandboxes are disabled (e.g. codex runs
-//! `danger-full-access`) so the two don't fight, leaving `sandbox-exec` as the
-//! sole boundary.
+//! on the allow-list below — otherwise it can't persist its own state. What
+//! goes on that list is *policy*, not a hand-maintained list local to this
+//! file: the agent profile's write allowance is exactly the engine-independent
+//! [`super::policy`] grants — every provider's host-persistence dirs
+//! ([`policy::all_provider_state_dirs`]) plus the host-scratch cache/data dirs a
+//! host-FS-sharing engine must additionally allow ([`policy::agent_scratch_dirs`],
+//! which cover XDG `~/.cache`/`~/.local/share`/`~/.local/state` and their
+//! macOS-native `~/Library/Caches`/`~/Library/Application Support` forms). Those
+//! grants deliberately never include a PATH-resolved bin dir (`~/.local/bin`) or
+//! a config *root* (`~/.config`) — see the policy module's invariants — which is
+//! why this profile grants `~/.local/share`+`~/.local/state` rather than all of
+//! `~/.local`, and only `~/.config/opencode` rather than all of `~/.config`. The
+//! agent CLIs' own sandboxes are disabled (e.g. codex runs `danger-full-access`)
+//! so the two don't fight, leaving `sandbox-exec` as the sole boundary.
 //!
 //! One region is carved back *out* of the broad `Application Support` grant:
 //! the app's own data dir (`~/Library/Application Support/<BUNDLE_ID>`, holding
@@ -33,6 +39,7 @@
 use std::path::{Path, PathBuf};
 
 use super::engine::{AgentLaunchCtx, EngineKind, Keepalive, KillHandle, LaunchPlan, SandboxEngine};
+use super::policy;
 use crate::error::{Error, Result};
 
 pub struct SandboxExecEngine;
@@ -82,23 +89,6 @@ const DEVICE_WRITE_RULES: &str = r#";; PTYs and basic device files are required 
   (regex #"^/dev/ptmx$")
   (regex #"^/dev/pts/[0-9]+$"))"#;
 
-/// Per-user cache/state dirs that both agents and Run processes must be able to
-/// write: package-manager caches and XDG + macOS-native app state. Returned as
-/// sbpl-quoted `subpath` argument strings (without the enclosing `(subpath …)`).
-fn standard_state_dirs(home_s: &str) -> Vec<String> {
-    [
-        ".npm",
-        ".cache",
-        ".config",
-        ".local",
-        "Library/Caches",
-        "Library/Application Support",
-    ]
-    .iter()
-    .map(|d| sbpl_string(&format!("{home_s}/{d}")))
-    .collect()
-}
-
 /// SBPL rule carving the app's own data dir back *out* of the broad
 /// `Application Support` write grant — and out of `allow default` for reads.
 /// `fletch.db` (agent transcripts, settings) lives here, so no confined process
@@ -121,13 +111,24 @@ fn deny_app_data_dir(home_s: &str) -> String {
     )
 }
 
-/// Toolchain state dirs the Run panel additionally grants so real project
-/// builds succeed. These hold package caches, downloaded toolchains, and —
-/// for some — PATH-resolved binaries (`~/.cargo/bin`, `~/go/bin`,
-/// `~/.rbenv/shims`). That last part is a residual hijack surface, which is
-/// why this superset is **Run-only** and deliberately kept off the agent
-/// profile: a running project legitimately needs its toolchain to write here,
-/// whereas an agent editing source does not.
+/// Toolchain + broad-state dirs the Run panel additionally grants so real
+/// project builds succeed. These hold package caches, downloaded toolchains,
+/// and — for some — PATH-resolved binaries (`~/.cargo/bin`, `~/go/bin`,
+/// `~/.rbenv/shims`, and everything under `~/.local/bin`). That last part is a
+/// residual hijack surface, which is why this superset is **Run-only** and
+/// deliberately kept off the agent profile: a running project legitimately
+/// needs its toolchain to write here, whereas an agent editing source does not.
+///
+/// The two broadest entries — the whole of `~/.config` and `~/.local` — are the
+/// ones the agent profile pointedly narrows (to `~/.config/opencode` and
+/// `~/.local/share`+`~/.local/state`; see [`super::policy`]). Run re-adds them
+/// whole because build steps write arbitrary config/state (`~/.config/<tool>`,
+/// `~/.local/bin` installs). Note the residual surface is reachable from an
+/// agent *indirectly*: an agent can edit e.g. a `package.json` script or a
+/// `Makefile` target that a later Run command executes, so Run's looseness can
+/// be triggered by agent-authored content. That's an accepted, documented
+/// trade-off — the Run panel runs project code the user chose to run, under a
+/// weaker boundary by design — not a hole in the agent profile.
 const RUN_TOOLCHAIN_DIRS: &[&str] = &[
     ".cargo",         // Rust: registry, git checkouts, installed bins
     ".rustup",        // Rust: downloaded toolchains (rust-toolchain.toml)
@@ -139,6 +140,8 @@ const RUN_TOOLCHAIN_DIRS: &[&str] = &[
     ".rbenv",         // rbenv: shims + installed Ruby versions
     ".rvm",           // rvm: alternative Ruby version manager
     "Library/Python", // pip --user / no-venv user site-packages
+    ".config",        // Run-only: whole config root (agent gets only subdirs)
+    ".local",         // Run-only: whole ~/.local incl. ~/.local/bin (agent gets share/state)
 ];
 
 /// Build the SBPL profile for a **Run-panel** process (setup/dev command).
@@ -178,7 +181,18 @@ pub fn build_run_profile(
         sbpl_string("/private/var/folders"),
         sbpl_string("/private/var/tmp"),
     ];
-    subpaths.extend(standard_state_dirs(&home_s));
+    // Host-scratch dirs (package/XDG/macOS caches) — the same class the agent
+    // profile grants, sourced from the shared policy so the two can't drift.
+    subpaths.extend(
+        policy::agent_scratch_dirs(&home)
+            .iter()
+            .map(|p| sbpl_string(&p.to_string_lossy())),
+    );
+    // Run-only toolchain + broad-state dirs, including the whole `~/.config`
+    // and `~/.local` the agent profile pointedly withholds (see the const's
+    // doc-comment). `~/.local` here supersets the scratch `~/.local/share`/
+    // `~/.local/state` above — a harmless redundancy that keeps Run's write set
+    // byte-for-byte what it was before the agent-profile narrowing.
     subpaths.extend(
         RUN_TOOLCHAIN_DIRS
             .iter()
@@ -344,45 +358,43 @@ pub fn build_profile(
     let rpc_root_s = sbpl_string(&rpc_root.to_string_lossy());
     let home_s = home.to_string_lossy();
 
-    let claude_state = sbpl_string(&format!("{home_s}/.claude"));
     let claude_json = sbpl_string(&format!("{home_s}/.claude.json"));
     // A non-default `CLAUDE_CONFIG_DIR` is where claude actually writes its
     // config/transcripts/auth, so grant it too. Resolve symlinks first so the
     // SBPL path matches what the sandbox sees at write time (every other entry
     // is canonical); then skip it only when it equals the default `{home}/.claude`
-    // granted above (`claude_state`), to avoid a redundant entry. `home` is
-    // already canonical, but the `.claude` leaf is NOT symlink-resolved —
-    // `claude_state` grants that literal path — so compare against it un-resolved.
-    // If `~/.claude` is itself a symlink and the config dir points at its
-    // resolved target, resolving the leaf here too would treat it as default and
-    // drop the grant, yet the literal `claude_state` rule wouldn't cover the
-    // target, denying claude's writes. (Docker can resolve both sides because its
-    // `~/.claude` bind mount follows the symlink source; the SBPL allow-list can't.)
+    // (which the policy state-dir list grants below), to avoid a redundant entry.
+    // `home` is already canonical, but the policy's `.claude` leaf is NOT
+    // symlink-resolved — the state-dir grant is that literal path — so compare
+    // against it un-resolved. If `~/.claude` is itself a symlink and the config
+    // dir points at its resolved target, resolving the leaf here too would treat
+    // it as default and drop the grant, yet the literal state-dir rule wouldn't
+    // cover the target, denying claude's writes. (Docker can resolve both sides
+    // because its `~/.claude` bind mount follows the symlink source; the SBPL
+    // allow-list can't.) The `~/.claude.json` top-level state *file* stays a
+    // seatbelt-local literal grant: it's a file, not a dir, so the dir-oriented
+    // policy API doesn't model it (see the policy module doc).
     let claude_config_extra = claude_config_dir
-        .map(resolve_existing_prefix)
+        .map(policy::resolve_existing_prefix)
         .map(|p| p.to_string_lossy().into_owned())
         .filter(|p| *p != format!("{home_s}/.claude"))
         .map(|p| format!("\n  (subpath {})", sbpl_string(&p)))
         .unwrap_or_default();
-    let npm_state = sbpl_string(&format!("{home_s}/.npm"));
-    let cache_state = sbpl_string(&format!("{home_s}/.cache"));
-    let config_state = sbpl_string(&format!("{home_s}/.config"));
-    let local_state = sbpl_string(&format!("{home_s}/.local"));
-    // macOS-native equivalents of the XDG cache/state dirs above. Native
-    // toolchains the agents invoke (node/npm tooling, git, language SDKs) and
-    // macOS framework caches (CFNetwork, fonts, per-bundle state) write here; a
-    // denied write ranges from a harmless cache miss to a fatal auth-token
-    // write, so allow them on the same "per-user app state, not source/system"
-    // basis as `~/.cache`/`~/.config`.
-    let library_caches = sbpl_string(&format!("{home_s}/Library/Caches"));
-    let library_app_support = sbpl_string(&format!("{home_s}/Library/Application Support"));
-    // Per-agent on-disk session stores (transcripts, config, auth) for the
-    // per-turn agents now covered by this profile. OpenCode's store lives under
-    // `~/.local/share/opencode`, already covered by `local_state`.
-    let codex_state = sbpl_string(&format!("{home_s}/.codex"));
-    let cursor_state = sbpl_string(&format!("{home_s}/.cursor"));
-    let gemini_state = sbpl_string(&format!("{home_s}/.gemini"));
-    let pi_state = sbpl_string(&format!("{home_s}/.pi"));
+    // The write allow-list is the engine-independent policy, not a list local to
+    // this file: every provider's host-persistence dirs (`~/.claude`, `~/.codex`,
+    // `~/.cursor`, `~/.gemini`, `~/.pi`, opencode's XDG data+config subdirs) plus
+    // the host-scratch cache/data dirs (`~/.npm`, `~/.cache`, `~/.local/share`,
+    // `~/.local/state`, `~/Library/Caches`, `~/Library/Application Support`).
+    // Crucially this is *not* the old blanket `~/.local`/`~/.config` grant: the
+    // policy withholds every PATH-resolved bin dir (`~/.local/bin`) and config
+    // root (`~/.config`), granting only `~/.local/share`+`~/.local/state` and the
+    // specific `~/.config/opencode` — see the policy module's invariants.
+    let policy_dirs = policy::all_provider_state_dirs(&home)
+        .into_iter()
+        .chain(policy::agent_scratch_dirs(&home))
+        .map(|p| format!("  (subpath {})", sbpl_string(&p.to_string_lossy())))
+        .collect::<Vec<_>>()
+        .join("\n");
 
     // No `dev` exception here (unlike the Run profile): agents never legitimately
     // touch any Fletch data dir, dev or otherwise.
@@ -400,18 +412,8 @@ pub fn build_profile(
   (subpath "/private/tmp")
   (subpath "/private/var/folders")
   (subpath "/private/var/tmp")
-  (subpath {claude_state})
   (literal {claude_json}){claude_config_extra}
-  (subpath {npm_state})
-  (subpath {cache_state})
-  (subpath {config_state})
-  (subpath {local_state})
-  (subpath {library_caches})
-  (subpath {library_app_support})
-  (subpath {codex_state})
-  (subpath {cursor_state})
-  (subpath {gemini_state})
-  (subpath {pi_state}))
+{policy_dirs})
 
 {deny_app_data}
 
@@ -446,32 +448,6 @@ fn canonical(p: &Path) -> Result<PathBuf> {
     std::fs::canonicalize(p).map_err(|e| Error::Other(format!("canonicalize {}: {e}", p.display())))
 }
 
-/// Resolve symlinks in the longest existing prefix of `p`, then re-append the
-/// not-yet-existing tail. `fs::canonicalize` alone can't be used because it
-/// requires the whole path to exist, but `CLAUDE_CONFIG_DIR` may point at a dir
-/// claude hasn't created yet. Resolving the existing prefix still collapses the
-/// well-known macOS symlinks (`/tmp` → `/private/tmp`, `/var` → `/private/var`),
-/// so the emitted SBPL path matches the sandbox's resolved write path. Falls
-/// back to `p` unchanged if nothing resolves (e.g. a bogus path).
-pub(crate) fn resolve_existing_prefix(p: &Path) -> PathBuf {
-    let mut cur = p.to_path_buf();
-    let mut tail: Vec<std::ffi::OsString> = Vec::new();
-    loop {
-        if let Ok(real) = std::fs::canonicalize(&cur) {
-            let mut out = real;
-            out.extend(tail.iter().rev());
-            return out;
-        }
-        match cur.file_name() {
-            Some(name) => tail.push(name.to_os_string()),
-            None => return p.to_path_buf(),
-        }
-        if !cur.pop() {
-            return p.to_path_buf();
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -500,6 +476,57 @@ mod tests {
         assert!(profile.contains("/Library/Application Support"));
     }
 
+    #[test]
+    fn agent_profile_narrows_local_and_config_away_from_bin_and_root() {
+        // The security fix: the agent profile must NOT grant blanket `~/.local`
+        // (it contains `~/.local/bin`, a PATH dir → host-command hijack) or
+        // blanket `~/.config` (config poisoning: git core.hooksPath, fish, gh).
+        // It grants the narrow replacements instead, and every provider dot-dir
+        // and cache dir stays exactly as before.
+        let (_td, root, rpc, home) = sandbox_dirs();
+        let profile = build_profile(&root, &rpc, &home, None).unwrap();
+        let canonical_home = std::fs::canonicalize(&home).unwrap();
+        let h = canonical_home.display();
+
+        // Blanket roots ABSENT (the whole point of the fix).
+        assert!(
+            !profile.contains(&format!("(subpath \"{h}/.local\")")),
+            "blanket ~/.local must not be on the agent allow-list"
+        );
+        assert!(
+            !profile.contains(&format!("(subpath \"{h}/.config\")")),
+            "blanket ~/.config must not be on the agent allow-list"
+        );
+        // No `~/.local/bin` grant may appear in any form.
+        assert!(
+            !profile.contains(&format!("{h}/.local/bin")),
+            "no ~/.local/bin grant may appear"
+        );
+
+        // Narrow replacements PRESENT.
+        for narrow in [".local/share", ".local/state", ".config/opencode"] {
+            assert!(
+                profile.contains(&format!("(subpath \"{h}/{narrow}\")")),
+                "agent profile should grant the narrow {narrow}"
+            );
+        }
+        // Everything else unchanged: provider dot-dirs, caches, macOS-native.
+        for dir in [
+            ".claude", ".codex", ".cursor", ".gemini", ".pi", ".npm", ".cache",
+            "Library/Caches", "Library/Application Support",
+        ] {
+            assert!(
+                profile.contains(&format!("(subpath \"{h}/{dir}\")")),
+                "agent profile should still grant {dir}"
+            );
+        }
+        // The `~/.claude.json` top-level state file stays a literal grant.
+        assert!(
+            profile.contains(&format!("(literal \"{h}/.claude.json\")")),
+            "agent profile should keep the ~/.claude.json literal grant"
+        );
+    }
+
     fn sandbox_dirs() -> (tempfile::TempDir, PathBuf, PathBuf, PathBuf) {
         let td = tempfile::tempdir().unwrap();
         let root = td.path().join("agent-parent");
@@ -526,35 +553,6 @@ mod tests {
         // lives under /var → /private/var.
         let canonical_cfg = std::fs::canonicalize(&cfg).unwrap();
         assert!(profile.contains(&format!("(subpath \"{}\")", canonical_cfg.display())));
-    }
-
-    #[test]
-    fn resolve_existing_prefix_resolves_symlinks_through_missing_leaf() {
-        // CLAUDE_CONFIG_DIR may point at a dir claude hasn't created yet, under
-        // a symlinked prefix (the /tmp → /private/tmp case). The existing prefix
-        // must be symlink-resolved and the missing leaf re-appended verbatim.
-        let td = tempfile::tempdir().unwrap();
-        let real = td.path().join("real");
-        std::fs::create_dir_all(&real).unwrap();
-        let link = td.path().join("link");
-        std::os::unix::fs::symlink(&real, &link).unwrap();
-
-        let resolved = resolve_existing_prefix(&link.join("not-created-yet"));
-        let expected = std::fs::canonicalize(&real)
-            .unwrap()
-            .join("not-created-yet");
-        assert_eq!(resolved, expected);
-    }
-
-    #[test]
-    fn resolve_existing_prefix_canonicalizes_an_existing_dir() {
-        let td = tempfile::tempdir().unwrap();
-        let dir = td.path().join("cfg");
-        std::fs::create_dir_all(&dir).unwrap();
-        assert_eq!(
-            resolve_existing_prefix(&dir),
-            std::fs::canonicalize(&dir).unwrap()
-        );
     }
 
     #[test]
@@ -679,8 +677,12 @@ mod tests {
         assert!(profile.contains("(deny file-write*)"));
         // The run command writes freely inside its checkout.
         assert!(profile.contains(&format!("\"{}\"", canonical_checkout.display())));
-        // Toolchain dirs the default detected commands need (cargo/go/pnpm/bundler).
-        for dir in [".cargo", "go", "Library/pnpm", ".bundle", ".rustup", ".bun"] {
+        // Toolchain dirs the default detected commands need (cargo/go/pnpm/bundler),
+        // plus the whole `~/.config` and `~/.local` the agent profile withholds —
+        // Run keeps the looser grant so arbitrary build steps succeed.
+        for dir in [
+            ".cargo", "go", "Library/pnpm", ".bundle", ".rustup", ".bun", ".config", ".local",
+        ] {
             let expected = format!("(subpath \"{}/{dir}\")", canonical_home.display());
             assert!(
                 profile.contains(&expected),


### PR DESCRIPTION
## Problem

Security audit finding: the seatbelt **agent** profile's write allow-list is too broad, and two grant classes enable host code-execution escape:

- Blanket `~/.local` includes `~/.local/bin` — a PATH dir. An agent can write `~/.local/bin/git`, and the user's next manual shell command runs attacker code **unsandboxed on the host**. The code itself flags PATH-bin dirs as a "residual hijack surface" for the Run profile, then granted all of `~/.local` to agents anyway.
- Blanket `~/.config` enables host config poisoning: `~/.config/git` (`core.hooksPath` → code exec on any host git operation), `~/.config/fish`, etc.

The Docker engine already handles this correctly (narrow per-provider mounts, never blanket roots) — seatbelt was the outlier, with each engine hand-maintaining its own list.

## Fix

Separate **policy** (what an agent may write on the host) from **mechanism** (SBPL subpaths vs bind mounts):

- **New `sandbox::policy`** — the single source of truth both engines consume. Two grant classes:
  - *Host-persistence grants*: per-provider state dirs (session store, auth, config) that must land on the host — Docker mounts them rw, seatbelt allows them as subpaths.
  - *Host-scratch grants*: caches/XDG data+state dirs a toolchain needs writable somewhere — only host-FS-sharing engines (seatbelt) consume these; Docker satisfies them with the container FS.
- **Seatbelt agent profile** (the security fix): `~/.local` → `~/.local/share` + `~/.local/state` (structurally excludes `~/.local/bin`); `~/.config` → only `~/.config/opencode` (opencode provider state). Everything else on the allow-list is byte-identical to before. `~/.config/gh` deliberately not re-added (gh aliases can carry shell commands — same poisoning class).
- **Guard test** encoding the invariants, not just today's instances: no grant may be a PATH-resolved bin dir or a config/local root, so a future provider or scratch dir can't silently regress the class.
- **Docker**: pure refactor — `opencode_data_dir`/`opencode_config_dir`/`xdg_base` and `resolve_existing_prefix` move into `policy` (also fixing the docker→seatbelt import that pointed the wrong way). Zero mount/behavior changes; existing docker tests pass unmodified.
- **Run profile**: behaviorally unchanged. `.local`/`.config` move into `RUN_TOOLCHAIN_DIRS`, whose doc-comment already documents the Run-only residual hijack surface — extended to note that Run's looseness is reachable indirectly via agent-edited build scripts.

## Testing

- Full lib suite: **543 passed, 0 failed**; `cargo check` clean.
- New tests: `policy_grants_never_expose_bin_or_config_root` (invariant guard), `agent_profile_narrows_local_and_config_away_from_bin_and_root` (emitted-profile assertions), per-provider policy coverage; run-profile tests assert `.local`/`.config` still granted there.

Follow-up (separate PR, agreed): RO-with-writable-islands treatment of `~/.claude` for seatbelt, mirroring Docker's invariant 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)