### PR TITLE
fix: never hold the global agents lock across blocking child I/O

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,25 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+
+      # Guard the concurrency invariant this codebase relies on: a lock guard
+      # must never be held across a blocking wait / await (see the rule on
+      # Supervisor::agents — clone the Arc out and drop the lock before child
+      # I/O). Scoped to `await_holding_lock` (clean today) rather than
+      # `-D warnings` because of unrelated pre-existing clippy warnings.
+      # `significant_drop_tightening` was considered but fires on ~44 idiomatic
+      # guard-at-scope-end sites across the tree, too noisy to gate on.
+      - name: Clippy
+        run: >
+          cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --
+          -D clippy::await_holding_lock
 
       - name: Test
         run: cargo test --manifest-path src-tauri/Cargo.toml

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -1205,9 +1205,18 @@ impl Agent {
         }
     }
 
-    pub fn shutdown(self) -> Result<()> {
-        drop(self);
-        Ok(())
+    /// Tear the agent's child down explicitly via the session's `&self` kill
+    /// path, rather than deferring to `Drop`. Takes `&self` so it can run on an
+    /// `Arc<Agent>` clone at a map-removal site: the kill is exactly what
+    /// unblocks a stuck write (EPIPE), so it must not wait behind an in-flight
+    /// blocked write holding another `Arc` clone. Idempotent (each session's
+    /// `kill` is), and `Drop` still runs it as a last-`Arc`-drop safety net.
+    pub fn shutdown(&self) -> Result<()> {
+        match self {
+            Self::Pty(a) => a.pty.kill(),
+            Self::Managed(a) => a.session.kill(),
+            Self::PerTurn(a) => a.session.kill(),
+        }
     }
 }
 

--- a/src-tauri/src/managed_session.rs
+++ b/src-tauri/src/managed_session.rs
@@ -248,13 +248,12 @@ impl ManagedSession {
     }
 
     /// Send SIGINT to the child process to interrupt the current turn
-    /// without killing it. First releases any held permission prompts (denied),
-    /// so a turn paused on a question can unwind rather than hang.
+    /// without killing it. Signal *first*, then release any held permission
+    /// prompts (denied): the deny-writes unblock a turn paused on a question so
+    /// it can unwind rather than hang, but they go over stdin, which a wedged
+    /// writer (blocked on a full pipe) can be holding — signalling first means
+    /// such a wedge can't prevent the interrupt from reaching the child.
     pub fn interrupt(&self) {
-        let held: Vec<String> = self.pending.lock().drain().collect();
-        for rid in held {
-            let _ = write_line(&self.stdin, deny_response(&rid, "Interrupted by user"));
-        }
         #[cfg(unix)]
         {
             use nix::sys::signal::{kill, Signal};
@@ -264,20 +263,27 @@ impl ManagedSession {
                 let _ = kill(Pid::from_raw(id as i32), Signal::SIGINT);
             }
         }
+        let held: Vec<String> = self.pending.lock().drain().collect();
+        for rid in held {
+            let _ = write_line(&self.stdin, deny_response(&rid, "Interrupted by user"));
+        }
     }
 
     pub fn kill(&self) -> Result<()> {
         // Tear the sandbox down first, but never let a failed engine teardown
-        // skip closing stdin / reaping the local child (see exec_session): an
+        // skip reaping the local child / closing stdin (see exec_session): an
         // errored container kill must not strand the host-side wrapper.
         let engine_result = self.kill_plan.kill();
-        // Close stdin to signal EOF (claude exits cleanly that way),
-        // then kill if it's still alive.
-        let _ = self.stdin.lock().take();
+        // Kill+reap the child *before* touching stdin. A wedged writer holding
+        // the stdin mutex would otherwise stall teardown here — and the child
+        // kill is exactly what unblocks that writer (EPIPE). Closing stdin (the
+        // EOF that lets claude exit cleanly) is now only best-effort cleanup
+        // after the forced kill, so it can never gate the reap.
         if let Some(mut child) = self.child.lock().take() {
             let _ = child.kill();
             let _ = child.wait();
         }
+        let _ = self.stdin.lock().take();
         engine_result
     }
 }

--- a/src-tauri/src/supervisor/disposition.rs
+++ b/src-tauri/src/supervisor/disposition.rs
@@ -249,7 +249,8 @@ impl Supervisor {
         // process-exit handler before `shutdown()` triggers the latter, so the
         // exit can't re-emit `Idle` for the agent we're tearing down.
         self.bump_generation(agent_id);
-        if let Some(agent) = self.agents.lock().remove(agent_id) {
+        let taken = self.agents.lock().remove(agent_id);
+        if let Some(agent) = taken {
             let _ = agent.shutdown();
         }
         self.activities.lock().remove(agent_id);

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -517,7 +517,9 @@ impl Supervisor {
             },
         )?;
 
-        self.agents.lock().insert(agent_id_str.clone(), agent);
+        self.agents
+            .lock()
+            .insert(agent_id_str.clone(), Arc::new(agent));
 
         // Initial status is always Idle now — at process start there's
         // never an in-flight turn (we no longer pass a task as a spawn
@@ -530,7 +532,8 @@ impl Supervisor {
         let promoted = self.claim_spawn_outcome(app, &agent_id_str, AgentStatus::Idle, None);
         if !promoted && matches!(self.live_status(&agent_id_str), Some(AgentStatus::Error)) {
             self.bump_generation(&agent_id_str);
-            if let Some(agent) = self.agents.lock().remove(&agent_id_str) {
+            let taken = self.agents.lock().remove(&agent_id_str);
+            if let Some(agent) = taken {
                 let _ = agent.shutdown();
             }
             self.activities.lock().remove(&agent_id_str);
@@ -718,13 +721,7 @@ impl Supervisor {
         agent_id: &str,
         bytes: &[u8],
     ) -> Result<()> {
-        {
-            let agents = self.agents.lock();
-            let agent = agents
-                .get(agent_id)
-                .ok_or_else(|| Error::AgentNotFound(agent_id.to_string()))?;
-            agent.write_pty(bytes)?;
-        }
+        self.live_agent(agent_id)?.write_pty(bytes)?;
         let submitted = self
             .native_inputs
             .lock()
@@ -739,11 +736,7 @@ impl Supervisor {
     }
 
     pub fn resize_agent(&self, agent_id: &str, cols: u16, rows: u16) -> Result<()> {
-        let agents = self.agents.lock();
-        let agent = agents
-            .get(agent_id)
-            .ok_or_else(|| Error::AgentNotFound(agent_id.to_string()))?;
-        agent.resize(cols, rows)
+        self.live_agent(agent_id)?.resize(cols, rows)
     }
 
     pub async fn switch_view(
@@ -778,7 +771,8 @@ impl Supervisor {
             ));
         }
 
-        if let Some(agent) = self.agents.lock().remove(agent_id) {
+        let taken = self.agents.lock().remove(agent_id);
+        if let Some(agent) = taken {
             let _ = agent.shutdown();
         }
         self.activities.lock().remove(agent_id);
@@ -912,8 +906,10 @@ impl Supervisor {
         // Mark the stop so the turn-end Idle transition keeps the queue intact
         // instead of auto-flushing it (A2-A). Cleared when a new turn starts.
         self.interrupted.lock().insert(agent_id.to_string());
-        let agents = self.agents.lock();
-        if let Some(agent) = agents.get(agent_id) {
+        // Clone the handle out and interrupt with the `agents` lock released
+        // (interrupt writes deny responses over stdin, which can block). An
+        // agent not in the map is a silent no-op, as before.
+        if let Ok(agent) = self.live_agent(agent_id) {
             agent.interrupt();
         }
         Ok(())
@@ -1088,7 +1084,11 @@ fn spawn_per_turn_agent(
                 AgentStatus::Idle,
             );
         } else {
-            sup_for_exit.agents.lock().remove(&id_for_exit);
+            // Bind the removed handle so the `agents` guard drops before the
+            // (last-`Arc`) session teardown, keeping child kill/reap off the
+            // global lock.
+            let taken = sup_for_exit.agents.lock().remove(&id_for_exit);
+            drop(taken);
             sup_for_exit.activities.lock().remove(&id_for_exit);
             sup_for_exit.native_inputs.lock().remove(&id_for_exit);
             sup_for_exit.trigger_session_sync(app_for_exit.clone(), id_for_exit.clone());
@@ -1146,7 +1146,8 @@ pub(super) fn arm_spawn_timeout(sup: Arc<Supervisor>, app: AppHandle, agent_id: 
         // Invalidate any gen-guarded loop / exit handler from this spawn before
         // killing the process (same reason as `detach_runtime`).
         sup.bump_generation(&agent_id);
-        if let Some(agent) = sup.agents.lock().remove(&agent_id) {
+        let taken = sup.agents.lock().remove(&agent_id);
+        if let Some(agent) = taken {
             let _ = agent.shutdown();
         }
         sup.activities.lock().remove(&agent_id);
@@ -1181,7 +1182,10 @@ fn apply_exit_if_current(
     // and RPC watcher stop polling instead of spinning for the app's lifetime.
     sup.bump_generation(agent_id);
 
-    sup.agents.lock().remove(agent_id);
+    // Bind the removed handle so the `agents` guard drops before the
+    // (last-`Arc`) session teardown runs its child kill/reap off the lock.
+    let taken = sup.agents.lock().remove(agent_id);
+    drop(taken);
     sup.activities.lock().remove(agent_id);
     sup.native_inputs.lock().remove(agent_id);
 

--- a/src-tauri/src/supervisor/messaging.rs
+++ b/src-tauri/src/supervisor/messaging.rs
@@ -4,8 +4,8 @@
 use std::sync::Arc;
 use tauri::{AppHandle, Manager};
 
-use crate::agent::{injection_mode, Agent};
-use crate::error::{Error, Result};
+use crate::agent::injection_mode;
+use crate::error::Result;
 use crate::managed_session::ToolUseBehavior;
 use crate::message_queue::{decide_delivery, Delivery, PendingMsg};
 use crate::workspace::AgentStatus;
@@ -41,7 +41,7 @@ impl Supervisor {
             .agents
             .lock()
             .get(agent_id)
-            .is_some_and(Agent::is_tool_gated);
+            .is_some_and(|a| a.is_tool_gated());
         let queue_nonempty = !self.message_queue.lock().is_empty(agent_id);
 
         let msg = PendingMsg {
@@ -103,13 +103,14 @@ impl Supervisor {
     /// the message untouched so the caller can fall back without double-handling
     /// it.
     fn inject_live(&self, agent_id: &str, msg: &PendingMsg) -> Result<()> {
-        self.agents
-            .lock()
-            .get(agent_id)
-            .ok_or_else(|| Error::AgentNotFound(agent_id.to_string()))
-            .and_then(|a| {
-                a.send_user_message(&msg.text, &msg.attachments, msg.thinking.as_deref())
-            })?;
+        // `live_agent` yields `AgentNotFound` when the turn already ended; the
+        // send error then propagates untouched so the caller's fallback still
+        // fires. Both happen with the `agents` lock released (see `live_agent`).
+        self.live_agent(agent_id)?.send_user_message(
+            &msg.text,
+            &msg.attachments,
+            msg.thinking.as_deref(),
+        )?;
         if let Err(e) =
             self.workspace
                 .insert_user_turn(agent_id, &msg.turn_id, &msg.text, &msg.attachments)
@@ -149,10 +150,7 @@ impl Supervisor {
         {
             tracing::warn!(error = %e, agent_id, "persist outgoing user turn failed");
         }
-        let agents = self.agents.lock();
-        let agent = agents
-            .get(agent_id)
-            .ok_or_else(|| Error::AgentNotFound(agent_id.to_string()))?;
+        let agent = self.live_agent(agent_id)?;
         agent.send_user_message(text, attachments, thinking)?;
         Ok(())
     }
@@ -167,10 +165,7 @@ impl Supervisor {
         behavior: ToolUseBehavior,
         message: Option<String>,
     ) -> Result<()> {
-        let agents = self.agents.lock();
-        let agent = agents
-            .get(agent_id)
-            .ok_or_else(|| Error::AgentNotFound(agent_id.to_string()))?;
+        let agent = self.live_agent(agent_id)?;
         agent.answer_tool_use(request_id, updated_input, behavior, message)
     }
 }
@@ -355,6 +350,7 @@ pub(super) fn drain_pending_bin_respawn(sup: &Supervisor, app: &AppHandle, agent
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::Error;
     use crate::supervisor::tests::{record_with_status, test_supervisor};
 
     #[test]

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -21,7 +21,7 @@ use tauri::AppHandle;
 
 use crate::activity::Activity;
 use crate::agent::Agent;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::message_queue::MessageQueue;
 use crate::native_input::NativeInputTracker;
 use crate::pty_session::PtySession;
@@ -33,7 +33,16 @@ use messaging::{drain_message_queue, drain_pending_bin_respawn};
 
 pub struct Supervisor {
     pub workspace: Arc<WorkspaceManager>,
-    pub agents: Mutex<HashMap<String, Agent>>,
+    /// Live agent handles, keyed by agent id. INVARIANT: never hold this guard
+    /// across any call into an `Agent` that touches its child — stdin/PTY
+    /// writes, `interrupt`, `resize`, `shutdown`/`kill`. Those can block on a
+    /// child that stopped draining its pipe, and this is one global lock, so
+    /// blocking under it stalls every agent's I/O app-wide. Clone the `Arc` out
+    /// via `live_agent` (or bind the value out of a `remove`) and drop the lock
+    /// *first*; the sessions carry their own per-agent I/O mutexes, so the map
+    /// lock only needs to protect membership. The `Arc` lets a clone outlive the
+    /// guard so the actual I/O runs unlocked.
+    pub agents: Mutex<HashMap<String, Arc<Agent>>>,
     pub generations: Mutex<HashMap<String, u64>>,
     pub activities: Mutex<HashMap<String, Box<dyn Activity>>>,
     /// In-memory source of truth for live runtime status
@@ -93,6 +102,19 @@ impl Supervisor {
     fn bump_generation(&self, agent_id: &str) {
         let mut g = self.generations.lock();
         *g.entry(agent_id.to_string()).or_insert(0) += 1;
+    }
+
+    /// Clone the live agent's handle under a short-lived `agents` lock.
+    /// The only thing callers may do under the `agents` lock is this clone —
+    /// all child I/O (stdin writes, PTY writes, interrupt, shutdown) must
+    /// happen on the returned handle with the lock released (see the `agents`
+    /// field doc). Returns `AgentNotFound` when the agent isn't live.
+    pub(super) fn live_agent(&self, agent_id: &str) -> Result<Arc<Agent>> {
+        self.agents
+            .lock()
+            .get(agent_id)
+            .cloned()
+            .ok_or_else(|| Error::AgentNotFound(agent_id.to_string()))
     }
 
     /// Kill and reap every live child process the supervisor is tracking:


### PR DESCRIPTION
## Problem

`Supervisor.agents` is one global `Mutex<HashMap<String, Agent>>`, and several paths held that guard while doing blocking child I/O — stdin writes (`deliver_user_message`, `inject_live`, `answer_tool_use`), PTY writes/resize, `stop_agent`'s interrupt, and (via edition-2021 `if let` temporary scoping) even `shutdown()`'s child kill+`wait()` at removal sites. One agent whose stdin pipe fills — a child that stopped draining — would block every agent's send/interrupt/resize app-wide.

## Fix

Per-agent I/O synchronization already exists inside the sessions (`ManagedSession`/`PtySession` guard stdin/writer with their own mutexes), so the global lock only needs to protect map membership:

- Store `Arc<Agent>` in the map; a new `live_agent()` helper clones the handle under a short-lived lock, and all child I/O runs with the lock released. The invariant is documented on the `agents` field.
- All removal sites bind the agent out of `remove()` before teardown, so the guard drops first (the edition-2021 `if let` scrutinee temporary otherwise holds it for the whole block).
- `Agent::shutdown` now takes `&self` and calls each session's idempotent `kill()` explicitly, so teardown is never deferred behind an in-flight blocked write holding another `Arc` clone — the kill is exactly what unblocks that write (EPIPE). `Drop` impls remain as a last-reference safety net.
- `ManagedSession::kill` reaps the child *before* taking the stdin lock, and `interrupt` sends SIGINT *before* writing deny responses, so a wedged writer can't gate teardown or interruption.

Blast radius of a stuck pipe shrinks to that one agent. No happy-path behavior change: `AgentNotFound` semantics are preserved everywhere and per-agent write ordering is unchanged.

## CI

Adds a clippy step (`-D clippy::await_holding_lock`) to the `rust-test` job to guard the guard-across-blocking-wait class. Scoped to that lint rather than `-D warnings` because of 19 unrelated pre-existing warnings; `significant_drop_tightening` (nursery) was evaluated and skipped — it fires on ~44 idiomatic guard-at-scope-end sites (reasoning documented in the workflow comment).

## Verification

- `cargo build` clean; `cargo test`: 539 passed, 0 failed, 10 ignored.
- `cargo clippy --all-targets -- -D clippy::await_holding_lock` passes.
- Audited every remaining `agents.lock()` site: all do map-only work (membership checks, id snapshots, insert, the atomic idle-check+remove in `respawn_agent_for_bin`) under the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)