### PR TITLE
fix(sandbox): claude config-dir RO-with-islands for seatbelt

### DIFF
--- a/src-tauri/src/sandbox/docker/engine.rs
+++ b/src-tauri/src/sandbox/docker/engine.rs
@@ -66,6 +66,7 @@ use crate::sandbox::engine::{
 };
 use crate::sandbox::policy::{
     codex_home_dir, opencode_config_dir, opencode_data_dir, resolve_existing_prefix,
+    CLAUDE_CREDENTIALS_FILE, CLAUDE_EPHEMERAL_RUNTIME_SUBDIRS, CLAUDE_PROJECTS_SUBDIR,
 };
 
 use super::auth::{self, ContainerAuth};
@@ -85,7 +86,9 @@ const DEFAULT_CPUS: &str = "2";
 /// bind-mounted read-only: claude's OAuth refresh rewrites the rotated token
 /// here, and the `CredentialsFile` auth chain (see [`super::auth`]) needs that
 /// write to land on the host. Mounted read-write on top of the read-only dir.
-const CREDENTIALS_FILE: &str = ".credentials.json";
+/// The name is shared with seatbelt via [`CLAUDE_CREDENTIALS_FILE`] so
+/// the two engines can't drift.
+const CREDENTIALS_FILE: &str = CLAUDE_CREDENTIALS_FILE;
 
 /// Subdirs of a claude config dir that Claude Code creates and writes *afresh
 /// every session* — the per-session env store (`mkdir session-env/<id>` at
@@ -106,13 +109,18 @@ const CREDENTIALS_FILE: &str = ".credentials.json";
 /// best-effort (a failed write logs and continues), so it needs no overlay —
 /// while making it writable would reopen exactly the injection surface this
 /// design closes.
-const EPHEMERAL_RUNTIME_SUBDIRS: &[&str] = &["session-env", "shell-snapshots"];
+///
+/// Shared with seatbelt via [`CLAUDE_EPHEMERAL_RUNTIME_SUBDIRS`] (which
+/// grants the real dirs as writable islands) so the two engines can't drift.
+const EPHEMERAL_RUNTIME_SUBDIRS: &[&str] = CLAUDE_EPHEMERAL_RUNTIME_SUBDIRS;
 
 /// Claude's session-transcript subdir within a config dir (`<config-dir>/
 /// projects/<slug>/<uuid>.jsonl`). Unlike [`EPHEMERAL_RUNTIME_SUBDIRS`], this
 /// one is bind-mounted to a *persistent* per-agent host dir (not tmpfs) so
 /// `--resume` survives container recreation — see [`push_claude_config_mount`].
-const PROJECTS_SUBDIR: &str = "projects";
+/// Shared with seatbelt via [`CLAUDE_PROJECTS_SUBDIR`] so the two
+/// engines can't drift.
+const PROJECTS_SUBDIR: &str = CLAUDE_PROJECTS_SUBDIR;
 
 /// Signal/removal docker calls during teardown.
 const KILL_TIMEOUT: Duration = Duration::from_secs(10);

--- a/src-tauri/src/sandbox/policy.rs
+++ b/src-tauri/src/sandbox/policy.rs
@@ -42,6 +42,19 @@
 //!    poison `~/.config/git` (`core.hooksPath`), `~/.config/fish`,
 //!    `~/.config/gh` (aliases carry shell commands), etc.
 //!
+//! Claude's config dir gets a third treatment that is really invariant 2
+//! applied to `~/.claude` itself. `~/.claude` *is* a config root — its
+//! `settings.json` defines hooks Claude Code runs **on the host**, and it holds
+//! `plugins/`/`skills/`/`commands/`/`agents/`, `CLAUDE.md`, and MCP config — so
+//! granting it whole was exactly the config-poisoning surface invariant 2 closes
+//! for `~/.config`. So claude's grant is no longer the config-dir *root* but a
+//! set of **writable islands** beneath it ([`claude_write_island_dirs`] + the
+//! [`CLAUDE_CREDENTIALS_FILE`] file): claude-regenerated, non-executable,
+//! non-config state only. This mirrors Docker's invariant 5 (`~/.claude` mounted
+//! read-only with writable exceptions layered on); the shared island-name
+//! constants ([`CLAUDE_PROJECTS_SUBDIR`], [`CLAUDE_EPHEMERAL_RUNTIME_SUBDIRS`],
+//! [`CLAUDE_CREDENTIALS_FILE`]) are the same ones the docker engine mounts.
+//!
 //! One piece of claude's persistence surface is deliberately *not* modeled
 //! here: the top-level `~/.claude.json` state **file**. It's a single file, not
 //! a dir, and threading a file-literal grant through this dir-oriented API buys
@@ -58,6 +71,77 @@ use std::path::{Path, PathBuf};
 /// is the authority for the seatbelt side.
 const STATE_DIR_PROVIDERS: &[&str] = &["claude", "codex", "cursor", "gemini", "pi", "opencode"];
 
+/// The one **file** under a claude config dir that stays writable when the dir
+/// is otherwise read-only: claude's OAuth refresh rewrites the rotated token
+/// here, and the host-side `CredentialsFile` auth chain needs that write to
+/// land on the host. Docker remounts it read-write over the read-only config
+/// dir; seatbelt grants it as a file rule (see the seatbelt caller). Shared so
+/// the two engines can't drift on the name.
+pub const CLAUDE_CREDENTIALS_FILE: &str = ".credentials.json";
+
+/// Claude's session-transcript subdir (`<config-dir>/projects/<slug>/*.jsonl`).
+/// Docker binds it to a persistent per-agent host dir so `--resume` survives
+/// container recreation; seatbelt grants the real one as an island (see the
+/// residual note on [`claude_write_island_dirs`]). Shared so the two engines
+/// agree on the name.
+pub const CLAUDE_PROJECTS_SUBDIR: &str = "projects";
+
+/// Subdirs claude creates and writes *afresh every session*: the per-session
+/// env store (`session-env/<id>`) and the shell-environment snapshot the Bash
+/// tool sources (`shell-snapshots`). Docker overlays each with an ephemeral
+/// tmpfs (claude otherwise `mkdir`s them under the read-only config dir and
+/// fails `EROFS`); seatbelt grants the real ones as islands. Shared so the two
+/// engines agree on the names.
+pub const CLAUDE_EPHEMERAL_RUNTIME_SUBDIRS: &[&str] = &["session-env", "shell-snapshots"];
+
+/// Extra pure-state subdirs seatbelt grants writable that docker leaves
+/// read-only. Docker leaves *everything* but the credential file, the projects
+/// bind, and the tmpfs overlays read-only, and claude's writes there are
+/// best-effort (a failed write logs and continues). Seatbelt shares the host
+/// filesystem, so these writes actually land on the real `~/.claude` and are
+/// worth allowing — but only for claude-regenerated, non-executable, non-config
+/// state that can neither run code on the host nor steer a later host session:
+/// per-session todo lists, the feature-flag/analytics cache, file edit-history
+/// (undo state), and diagnostic logs. Anything that could influence a later
+/// session's trust/behavior (`backups/` of `~/.claude.json`, `plans/`,
+/// `sessions/`, `cache/`, `paste-cache/`) or execute (`downloads/` of the
+/// claude binary, `chrome/`, `daemon/`) is deliberately NOT here — deny by
+/// default (fail-closed) is the correct treatment for those.
+const CLAUDE_SEATBELT_STATE_SUBDIRS: &[&str] = &["todos", "statsig", "file-history", "debug"];
+
+/// The writable **islands** beneath a claude config `config_dir` — the write
+/// grant that replaces the old whole-`~/.claude` grant (config-poisoning
+/// narrowing; see the module doc). Each is claude-regenerated, non-executable,
+/// non-config *state*: session transcripts, per-session runtime scaffolding, and
+/// the pure-state dirs above. Everything else under the config dir
+/// (`settings.json` → host hooks, `plugins`/`skills`/`commands`/`agents`,
+/// `CLAUDE.md`, MCP config, …) stays deny-by-default, so a prompt-injected agent
+/// can't plant a host-executed hook or a config a later HOST session trusts.
+///
+/// The credential *file* ([`CLAUDE_CREDENTIALS_FILE`]) is intentionally NOT
+/// here: it's a file needing a regex rule (atomic temp-file writes), which the
+/// seatbelt caller emits separately.
+///
+/// Two DELIBERATE residuals, left writable here and flagged for later hardening
+/// rather than fixed now:
+///
+/// 1. **`projects/` stays writable.** Docker redirects it to a per-agent host
+///    dir so the shared `~/.claude/projects` (other agents' transcripts, global
+///    memory) is unreachable; seatbelt can't redirect without env surgery, and
+///    the app's host-side transcript reader tails the real dir. Residual: an
+///    agent can write a `projects/<slug>/memory` entry a later session trusts.
+/// 2. **`~/.claude.json` stays a writable literal** (emitted by the seatbelt
+///    caller, not here — it's outside the config dir). Claude requires it (state
+///    writes every session), yet it carries per-project trust/settings. Both are
+///    candidates for later hardening.
+pub fn claude_write_island_dirs(config_dir: &Path) -> Vec<PathBuf> {
+    std::iter::once(CLAUDE_PROJECTS_SUBDIR)
+        .chain(CLAUDE_EPHEMERAL_RUNTIME_SUBDIRS.iter().copied())
+        .chain(CLAUDE_SEATBELT_STATE_SUBDIRS.iter().copied())
+        .map(|s| config_dir.join(s))
+        .collect()
+}
+
 /// Class-1 host-persistence dirs a single `provider` must write on the host:
 /// its session store, auth, and config. Docker mounts exactly these read-write
 /// at their host paths; the seatbelt profile folds them in provider-agnostically
@@ -65,9 +149,12 @@ const STATE_DIR_PROVIDERS: &[&str] = &["claude", "codex", "cursor", "gemini", "p
 /// list — Docker already gates on a known [`super::docker::DockerProvider`], and
 /// the seatbelt side only ever passes ids from [`STATE_DIR_PROVIDERS`].
 ///
-/// Note the omissions this policy makes on purpose: claude's grant is its
-/// config *dir* only — the top-level `~/.claude.json` file stays a
-/// seatbelt-local literal (see the module doc), and a non-default
+/// Note the omissions this policy makes on purpose: claude's grant is NOT its
+/// config-dir root (that root holds host-executed hooks / plugins / MCP config
+/// — see the module doc) but the writable **islands** beneath it
+/// ([`claude_write_island_dirs`]); the top-level `~/.claude.json` file and the
+/// [`CLAUDE_CREDENTIALS_FILE`] file both stay seatbelt-local literals (a file,
+/// not a dir, so the dir-oriented API doesn't model them), and a non-default
 /// `CLAUDE_CONFIG_DIR` is likewise handled by the seatbelt caller, which needs
 /// its own symlink-resolution to keep the emitted SBPL path matching the
 /// sandbox's resolved write path. Codex's and opencode's env relocations
@@ -75,7 +162,10 @@ const STATE_DIR_PROVIDERS: &[&str] = &["claude", "codex", "cursor", "gemini", "p
 /// need the same dir, with no engine-specific handling on top.
 pub fn provider_state_dirs(provider: &str, home: &Path) -> Vec<PathBuf> {
     match provider {
-        "claude" => vec![home.join(".claude")],
+        // Not the `~/.claude` root — only its writable islands (config-poisoning
+        // narrowing, module doc). The credential *file* is added separately by
+        // the seatbelt caller (it needs a regex rule, not a `(subpath …)`).
+        "claude" => claude_write_island_dirs(&home.join(".claude")),
         // Codex's state dir moves with `$CODEX_HOME`. The old blanket
         // `~/.config` agent grant incidentally covered e.g.
         // `CODEX_HOME=$HOME/.config/codex`; with the narrowing, this
@@ -307,11 +397,50 @@ mod tests {
         }
     }
 
+    /// The claude write islands are exactly the config-poisoning narrowing: each
+    /// is a subdir *beneath* a config dir, never the config-dir root itself, and
+    /// never a bin dir — the same invariants, applied to `~/.claude`.
+    #[test]
+    fn claude_islands_are_subdirs_never_the_config_root_or_bin() {
+        let config_dir = Path::new("/Users/u/.claude");
+        let islands = claude_write_island_dirs(config_dir);
+
+        // The exact set (order-independent): the shared projects/ephemeral
+        // names plus the seatbelt-only pure-state subdirs.
+        let expected: Vec<PathBuf> = std::iter::once(CLAUDE_PROJECTS_SUBDIR)
+            .chain(CLAUDE_EPHEMERAL_RUNTIME_SUBDIRS.iter().copied())
+            .chain(CLAUDE_SEATBELT_STATE_SUBDIRS.iter().copied())
+            .map(|s| config_dir.join(s))
+            .collect();
+        assert_eq!(islands, expected);
+        // The credential *file* is not an island dir (it's a file rule).
+        assert!(!islands.iter().any(|p| p.ends_with(CLAUDE_CREDENTIALS_FILE)));
+
+        for island in &islands {
+            assert!(
+                island.starts_with(config_dir) && *island != config_dir,
+                "{} must be a strict subdir of the config root, never the root",
+                island.display()
+            );
+            assert!(!bin_resident(island), "{} must not be bin-resident", island.display());
+            assert_ne!(island.file_name(), Some(OsStr::new("bin")));
+        }
+    }
+
     /// Class-1 per-provider content, and the union's dedup + coverage.
     #[test]
     fn provider_state_dirs_cover_each_provider() {
         let home = Path::new("/Users/u");
-        assert_eq!(provider_state_dirs("claude", home), vec![home.join(".claude")]);
+        // Claude's entry is no longer the `~/.claude` root — it's the writable
+        // islands beneath it (config-poisoning narrowing).
+        assert_eq!(
+            provider_state_dirs("claude", home),
+            claude_write_island_dirs(&home.join(".claude"))
+        );
+        assert!(
+            !provider_state_dirs("claude", home).contains(&home.join(".claude")),
+            "claude must not grant its config-dir root"
+        );
         // Codex: env-dependent (`$CODEX_HOME`), so assert identity with the
         // canonical resolver — same treatment as opencode below; the
         // resolution itself is covered by the `codex_home_from` test.
@@ -333,8 +462,12 @@ mod tests {
 
         // The union carries every provider's dirs and is deduped.
         let all = all_provider_state_dirs(home);
+        // Claude contributes its islands to the union (not the `~/.claude` root).
+        assert!(!all.contains(&home.join(".claude")), "union must not carry the ~/.claude root");
+        for island in claude_write_island_dirs(&home.join(".claude")) {
+            assert!(all.contains(&island), "union missing claude island {}", island.display());
+        }
         for expected in [
-            home.join(".claude"),
             codex_home_dir(home),
             home.join(".cursor"),
             home.join(".gemini"),

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -527,6 +527,15 @@ fn sbpl_string(s: &str) -> String {
 /// regex-escaped ([`sbpl_regex_escape`]) before interpolation — `sbpl_string`
 /// only escapes for string literals, and a home dir can contain regex
 /// metacharacters (`.`, `+`, `(`, …) that would otherwise change the match.
+///
+/// The pattern is emitted as a *string* argument — `(regex "…")` via
+/// [`sbpl_string`] — never as a raw `#"…"` regex literal: raw literals have no
+/// reliable in-literal quote escaping, so a `"` in the dir path would terminate
+/// the literal early and let the path's remainder parse as profile text
+/// (policy injection via path contents) or fail the profile outright. The
+/// string form composes correctly: `sbpl_string` doubles the regex escapes'
+/// backslashes and escapes any quote, and the Scheme string reader undoes
+/// exactly that before the regex engine sees the pattern.
 fn claude_credentials_rules(config_dir: &Path) -> Vec<String> {
     let resolved = policy::resolve_existing_prefix(config_dir);
     let mut out: Vec<String> = Vec::new();
@@ -539,7 +548,7 @@ fn claude_credentials_rules(config_dir: &Path) -> Vec<String> {
             sbpl_regex_escape(&dir.to_string_lossy()),
             sbpl_regex_escape(policy::CLAUDE_CREDENTIALS_FILE),
         );
-        let line = format!("  (regex #\"{re}\")");
+        let line = format!("  (regex {})", sbpl_string(&re));
         if !out.contains(&line) {
             out.push(line);
         }
@@ -789,15 +798,41 @@ mod tests {
                 island.display()
             );
         }
-        // The credential file gets its anchored regex rule under the custom dir.
-        // The dir portion is regex-escaped (tempdir paths carry `.`), matching
-        // how the profile emits it.
+        // The credential file gets its anchored regex rule under the custom
+        // dir — asserted via the emitter itself; its exact escaping is covered
+        // by `credentials_rules_escape_quotes_via_string_literals`.
+        for rule in claude_credentials_rules(&canonical_cfg) {
+            assert!(
+                profile.contains(rule.trim_start()),
+                "custom config dir should grant the .credentials.json rule {rule}"
+            );
+        }
+    }
+
+    #[test]
+    fn credentials_rules_escape_quotes_via_string_literals() {
+        // A `"` in the config-dir path must not terminate the SBPL token: raw
+        // `#"…"` regex literals have no in-literal quote escaping, so a quoted
+        // path would end the literal early and let the path's remainder parse
+        // as profile text (policy injection) or fail the profile. The rule is
+        // therefore emitted as a *string* argument, where `sbpl_string`
+        // escaping applies.
+        let rules = claude_credentials_rules(Path::new("/Users/we\"ird/.claude"));
+        assert_eq!(rules.len(), 1, "raw == resolved for a nonexistent path");
+        let rule = &rules[0];
         assert!(
-            profile.contains(&format!(
-                "(regex #\"^{}/\\.credentials\\.json.*$\")",
-                sbpl_regex_escape(&canonical_cfg.to_string_lossy())
-            )),
-            "custom config dir should grant the .credentials.json regex rule"
+            !rule.contains("#\""),
+            "raw regex literal must not be used: {rule}"
+        );
+        assert!(
+            rule.contains(r#"we\"ird"#),
+            "quote in path must be string-escaped: {rule}"
+        );
+        // The regex escapes ride the string escaping doubled: `\\.` in profile
+        // text reads back as `\.` for the regex engine.
+        assert!(
+            rule.contains(r#"\\.credentials\\.json"#),
+            "regex escapes must be double-escaped in the string form: {rule}"
         );
     }
 
@@ -820,15 +855,13 @@ mod tests {
             );
         }
         // The default credential regex likewise appears exactly once.
-        let creds = format!(
-            "(regex #\"^{}/\\.credentials\\.json.*$\")",
-            sbpl_regex_escape(&default_claude.to_string_lossy())
-        );
-        assert_eq!(
-            profile.matches(&creds).count(),
-            1,
-            "default .credentials.json regex should appear exactly once"
-        );
+        for rule in claude_credentials_rules(&default_claude) {
+            assert_eq!(
+                profile.matches(rule.trim_start()).count(),
+                1,
+                "default .credentials.json rule should appear exactly once: {rule}"
+            );
+        }
     }
 
     #[test]
@@ -857,15 +890,15 @@ mod tests {
                 island.display()
             );
         }
-        // The credential file's anchored regex rule is present (dir portion
-        // regex-escaped to match the emitted form).
-        assert!(
-            profile.contains(&format!(
-                "(regex #\"^{}/\\.credentials\\.json.*$\")",
-                sbpl_regex_escape(&claude.to_string_lossy())
-            )),
-            "agent profile should grant the ~/.claude/.credentials.json regex rule"
-        );
+        // The credential file's anchored regex rule is present — asserted via
+        // the emitter; its exact escaping is covered by
+        // `credentials_rules_escape_quotes_via_string_literals`.
+        for rule in claude_credentials_rules(&claude) {
+            assert!(
+                profile.contains(rule.trim_start()),
+                "agent profile should grant the credentials rule {rule}"
+            );
+        }
 
         // (c) The config-poisoning entries are covered by NO grant. Since (a)
         // holds (no root subpath) and each island is a distinct named subdir,

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -359,21 +359,35 @@ pub fn build_profile(
     let home_s = home.to_string_lossy();
 
     let claude_json = sbpl_string(&format!("{home_s}/.claude.json"));
+
+    // Claude's config dir is NOT granted whole (its `settings.json` defines
+    // host-executed hooks, and it holds `plugins`/`skills`/`CLAUDE.md`/MCP
+    // config — the config-poisoning surface Docker's invariant 5 closes). Only
+    // the writable *islands* beneath it ([`policy::claude_write_island_dirs`])
+    // plus the `.credentials.json` file are granted. The default `~/.claude`
+    // islands flow through the policy state-dir list (`policy_dirs` below); its
+    // credential file needs a *regex* rule (atomic temp-file writes), emitted
+    // here.
+    let claude_default_dir = home.join(".claude");
+    let claude_credentials = claude_credentials_rules(&claude_default_dir).join("\n");
+
     // A non-default `CLAUDE_CONFIG_DIR` is where claude actually writes its
-    // config/transcripts/auth, so grant it too. Resolve symlinks first so the
-    // SBPL path matches what the sandbox sees at write time (every other entry
-    // is canonical); then skip it only when it equals the default `{home}/.claude`
-    // (which the policy state-dir list grants below), to avoid a redundant entry.
-    // `home` is already canonical, but the policy's `.claude` leaf is NOT
-    // symlink-resolved — the state-dir grant is that literal path — so compare
-    // against it un-resolved. If `~/.claude` is itself a symlink and the config
-    // dir points at its resolved target, resolving the leaf here too would treat
-    // it as default and drop the grant, yet the literal state-dir rule wouldn't
-    // cover the target, denying claude's writes. (Docker can resolve both sides
-    // because its `~/.claude` bind mount follows the symlink source; the SBPL
-    // allow-list can't.) The `~/.claude.json` top-level state *file* stays a
-    // seatbelt-local literal grant: it's a file, not a dir, so the dir-oriented
-    // policy API doesn't model it (see the policy module doc).
+    // config/transcripts/auth, so grant the same islands + credential file
+    // relative to *that* dir. Resolve symlinks first so the SBPL paths match
+    // what the sandbox sees at write time (every other entry is canonical);
+    // then skip it only when the resolved dir equals the default `{home}/.claude`
+    // (whose islands the policy state-dir list already grants below), to avoid
+    // redundant entries. `home` is already canonical, but the policy's `.claude`
+    // leaf is NOT symlink-resolved — the state-dir grant builds islands under
+    // that literal path — so compare against it un-resolved. If `~/.claude` is
+    // itself a symlink and the config dir points at its resolved target,
+    // resolving the leaf here too would treat it as default and drop the grant,
+    // yet the literal state-dir rule's islands wouldn't cover the target,
+    // denying claude's writes. (Docker can resolve both sides because its
+    // `~/.claude` bind mount follows the symlink source; the SBPL allow-list
+    // can't.) The `~/.claude.json` top-level state *file* stays a seatbelt-local
+    // literal grant: it's a file, not a dir, so the dir-oriented policy API
+    // doesn't model it (see the policy module doc).
     let claude_config_extra = claude_config_dir
         // A bin-resident relocation (`CLAUDE_CONFIG_DIR=$HOME/.local/bin/…`)
         // would put an agent-writable subtree on the user's PATH — the same
@@ -381,13 +395,20 @@ pub fn build_profile(
         // fail-closed: claude's config writes are denied, never a hijack).
         .filter(|p| !policy::bin_resident(p))
         .map(policy::resolve_existing_prefix)
-        .map(|p| p.to_string_lossy().into_owned())
-        .filter(|p| *p != format!("{home_s}/.claude"))
-        .map(|p| format!("\n  (subpath {})", sbpl_string(&p)))
+        .filter(|resolved| resolved.to_string_lossy() != claude_default_dir.to_string_lossy())
+        .map(|resolved| {
+            // Islands flow through `subpath_grants` (bin_resident filter +
+            // resolved forms) like every other grant; the credential file gets
+            // its own regex rule.
+            let mut lines = subpath_grants(policy::claude_write_island_dirs(&resolved));
+            lines.extend(claude_credentials_rules(&resolved));
+            format!("\n{}", lines.join("\n"))
+        })
         .unwrap_or_default();
     // The write allow-list is the engine-independent policy, not a list local to
-    // this file: every provider's host-persistence dirs (`~/.claude`, `~/.codex`,
-    // `~/.cursor`, `~/.gemini`, `~/.pi`, opencode's XDG data+config subdirs) plus
+    // this file: every provider's host-persistence dirs (claude's config-dir
+    // *islands* — see above, NOT the `~/.claude` root — `~/.codex`, `~/.cursor`,
+    // `~/.gemini`, `~/.pi`, opencode's XDG data+config subdirs) plus
     // the host-scratch cache/data dirs (`~/.npm`, `~/.cache`, `~/.local/share`,
     // `~/.local/state`, `~/Library/Caches`, `~/Library/Application Support`).
     // Crucially this is *not* the old blanket `~/.local`/`~/.config` grant: the
@@ -417,7 +438,8 @@ pub fn build_profile(
   (subpath "/private/tmp")
   (subpath "/private/var/folders")
   (subpath "/private/var/tmp")
-  (literal {claude_json}){claude_config_extra}
+  (literal {claude_json})
+{claude_credentials}{claude_config_extra}
 {policy_dirs})
 
 {deny_app_data}
@@ -482,6 +504,66 @@ pub fn profile_tempfile(text: &str) -> Result<tempfile::NamedTempFile> {
 fn sbpl_string(s: &str) -> String {
     let escaped = s.replace('\\', "\\\\").replace('"', "\\\"");
     format!("\"{escaped}\"")
+}
+
+/// SBPL `file-write*` filter clauses for a claude config dir's
+/// `.credentials.json` — the one file under the config dir that must stay
+/// writable (claude's OAuth refresh persists the rotated token here). Emitted as
+/// filters for the enclosing `(allow file-write* …)` block, alongside the island
+/// `(subpath …)` grants.
+///
+/// It's a *regex*, not a `(literal …)`: claude rewrites the file atomically via
+/// the `write-file-atomic` pattern — write a sibling temp file (`<path>.<pid>
+/// <rand>`) in the same dir, then `rename` it over the target — so a literal on
+/// the final name alone would deny the temp write and break the refresh. The
+/// anchored `^<dir>/\.credentials\.json.*$` matches the target *and* its
+/// atomic-temp siblings (both share the `.credentials.json` prefix) while
+/// granting nothing else under the config dir.
+///
+/// Emitted in the dir's literal form and — when different — its symlink-resolved
+/// form (the sandbox checks resolved write paths), same as [`subpath_grants`]; a
+/// bin-resident form is dropped (invariant 1) so a config dir symlinked into a
+/// PATH bin dir can't smuggle a writable on-PATH file. The dir path is
+/// regex-escaped ([`sbpl_regex_escape`]) before interpolation — `sbpl_string`
+/// only escapes for string literals, and a home dir can contain regex
+/// metacharacters (`.`, `+`, `(`, …) that would otherwise change the match.
+fn claude_credentials_rules(config_dir: &Path) -> Vec<String> {
+    let resolved = policy::resolve_existing_prefix(config_dir);
+    let mut out: Vec<String> = Vec::new();
+    for dir in [config_dir.to_path_buf(), resolved] {
+        if policy::bin_resident(&dir) {
+            continue;
+        }
+        let re = format!(
+            "^{}/{}.*$",
+            sbpl_regex_escape(&dir.to_string_lossy()),
+            sbpl_regex_escape(policy::CLAUDE_CREDENTIALS_FILE),
+        );
+        let line = format!("  (regex #\"{re}\")");
+        if !out.contains(&line) {
+            out.push(line);
+        }
+    }
+    out
+}
+
+/// Backslash-escape the regex metacharacters in `s` so it can be embedded as a
+/// literal fragment inside an SBPL `#"…"` regex. The set covers the POSIX/ERE
+/// metacharacters SBPL's regex engine recognizes; `/` is not special and is left
+/// as-is. Distinct from [`sbpl_string`], which escapes for *string* literals
+/// (only `"`/`\`) and would leave a `.` in a path matching any character.
+fn sbpl_regex_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 8);
+    for c in s.chars() {
+        if matches!(
+            c,
+            '\\' | '^' | '$' | '.' | '|' | '?' | '*' | '+' | '(' | ')' | '[' | ']' | '{' | '}'
+        ) {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
 }
 
 fn canonical(p: &Path) -> Result<PathBuf> {
@@ -565,8 +647,10 @@ mod tests {
             "agent profile should grant the codex home dir"
         );
         // Everything else unchanged: provider dot-dirs, caches, macOS-native.
+        // (`.claude` is deliberately NOT here — its root is no longer granted;
+        // see `agent_profile_grants_claude_islands_not_the_config_root`.)
         for dir in [
-            ".claude", ".cursor", ".gemini", ".pi", ".npm", ".cache",
+            ".cursor", ".gemini", ".pi", ".npm", ".cache",
             "Library/Caches", "Library/Application Support",
         ] {
             assert!(
@@ -677,35 +761,135 @@ mod tests {
     }
 
     #[test]
-    fn profile_grants_custom_claude_config_dir() {
+    fn profile_grants_custom_claude_config_dir_islands_not_the_root() {
         // Regression: a sandboxed agent running with CLAUDE_CONFIG_DIR outside
-        // ~/.claude couldn't write its config/transcripts/auth, because only
-        // ~/.claude was on the allow-list.
+        // ~/.claude couldn't write its config/transcripts/auth. It gets the same
+        // writable *islands* (not the config-dir root — config-poisoning
+        // narrowing) plus the credential file, relative to the custom dir.
         let (_td, root, rpc, home) = sandbox_dirs();
         let cfg = home.join(".claude-eve");
         std::fs::create_dir_all(&cfg).unwrap();
 
         let profile = build_profile(&root, &rpc, &home, Some(cfg.as_path())).unwrap();
-        // The emitted path must be canonical (symlink-resolved) so it matches
+        // The emitted paths must be canonical (symlink-resolved) so they match
         // what the sandbox resolves at write time — e.g. on macOS the tempdir
         // lives under /var → /private/var.
         let canonical_cfg = std::fs::canonicalize(&cfg).unwrap();
-        assert!(profile.contains(&format!("(subpath \"{}\")", canonical_cfg.display())));
+
+        // The config-dir ROOT is never granted.
+        assert!(
+            !profile.contains(&format!("(subpath \"{}\")", canonical_cfg.display())),
+            "the custom config-dir root must not be granted, only its islands"
+        );
+        // Every island under the custom dir is granted.
+        for island in policy::claude_write_island_dirs(&canonical_cfg) {
+            assert!(
+                profile.contains(&format!("(subpath \"{}\")", island.display())),
+                "custom config dir should grant island {}",
+                island.display()
+            );
+        }
+        // The credential file gets its anchored regex rule under the custom dir.
+        // The dir portion is regex-escaped (tempdir paths carry `.`), matching
+        // how the profile emits it.
+        assert!(
+            profile.contains(&format!(
+                "(regex #\"^{}/\\.credentials\\.json.*$\")",
+                sbpl_regex_escape(&canonical_cfg.to_string_lossy())
+            )),
+            "custom config dir should grant the .credentials.json regex rule"
+        );
     }
 
     #[test]
-    fn profile_does_not_duplicate_default_config_dir() {
+    fn profile_does_not_duplicate_default_config_dir_islands() {
         // CLAUDE_CONFIG_DIR explicitly set to the default ~/.claude must not add
-        // a second, redundant allow entry.
+        // second, redundant island entries (the default islands come through the
+        // policy list already).
         let (_td, root, rpc, home) = sandbox_dirs();
         let default_claude = std::fs::canonicalize(&home).unwrap().join(".claude");
 
         let profile = build_profile(&root, &rpc, &home, Some(default_claude.as_path())).unwrap();
-        let needle = format!("(subpath \"{}\")", default_claude.display());
+        for island in policy::claude_write_island_dirs(&default_claude) {
+            let needle = format!("(subpath \"{}\")", island.display());
+            assert_eq!(
+                profile.matches(&needle).count(),
+                1,
+                "default island {} should appear exactly once",
+                island.display()
+            );
+        }
+        // The default credential regex likewise appears exactly once.
+        let creds = format!(
+            "(regex #\"^{}/\\.credentials\\.json.*$\")",
+            sbpl_regex_escape(&default_claude.to_string_lossy())
+        );
         assert_eq!(
-            profile.matches(&needle).count(),
+            profile.matches(&creds).count(),
             1,
-            "default ~/.claude should appear exactly once"
+            "default .credentials.json regex should appear exactly once"
+        );
+    }
+
+    #[test]
+    fn agent_profile_grants_claude_islands_not_the_config_root() {
+        // The security fix (config-poisoning narrowing): the default ~/.claude
+        // config-dir ROOT must NOT be granted, only its writable islands and the
+        // credential file. `settings.json` (host hooks), `plugins/`, `CLAUDE.md`,
+        // etc. must be covered by no grant.
+        let (_td, root, rpc, home) = sandbox_dirs();
+        let profile = build_profile(&root, &rpc, &home, None).unwrap();
+        let canonical_home = std::fs::canonicalize(&home).unwrap();
+        let claude = canonical_home.join(".claude");
+        let h = canonical_home.display();
+
+        // (a) No `(subpath ".../.claude")` root grant.
+        assert!(
+            !profile.contains(&format!("(subpath \"{}\")", claude.display())),
+            "the ~/.claude config-dir root must not be granted"
+        );
+
+        // (b) Every island present.
+        for island in policy::claude_write_island_dirs(&claude) {
+            assert!(
+                profile.contains(&format!("(subpath \"{}\")", island.display())),
+                "agent profile should grant claude island {}",
+                island.display()
+            );
+        }
+        // The credential file's anchored regex rule is present (dir portion
+        // regex-escaped to match the emitted form).
+        assert!(
+            profile.contains(&format!(
+                "(regex #\"^{}/\\.credentials\\.json.*$\")",
+                sbpl_regex_escape(&claude.to_string_lossy())
+            )),
+            "agent profile should grant the ~/.claude/.credentials.json regex rule"
+        );
+
+        // (c) The config-poisoning entries are covered by NO grant. Since (a)
+        // holds (no root subpath) and each island is a distinct named subdir,
+        // a substring check for these paths suffices.
+        for denied in [
+            ".claude/settings.json",
+            ".claude/settings.local.json",
+            ".claude/plugins",
+            ".claude/skills",
+            ".claude/commands",
+            ".claude/agents",
+            ".claude/hooks",
+            ".claude/CLAUDE.md",
+            ".claude/keybindings.json",
+        ] {
+            assert!(
+                !profile.contains(&format!("{h}/{denied}")),
+                "config-poisoning path {denied} must not be covered by any grant"
+            );
+        }
+        // (d) The `~/.claude.json` top-level state file literal stays.
+        assert!(
+            profile.contains(&format!("(literal \"{h}/.claude.json\")")),
+            "the ~/.claude.json literal grant must remain"
         );
     }
 


### PR DESCRIPTION
## Problem

Follow-up to #398 (agreed there as "Option 2"). The seatbelt agent profile still granted the **whole claude config dir**, leaving the highest-value config-poisoning target open: an agent could write `~/.claude/settings.json` — whose hooks execute **unsandboxed on the host** the next time the user runs claude manually — plus `plugins/`, `skills/`, `commands/`, `agents/`, `CLAUDE.md`, and MCP config. The Docker engine already closes this (its invariant 5: `~/.claude` mounted read-only with writable exceptions).

## Fix

Seatbelt's translation is simpler than Docker's: the profile is deny-write-by-default, so we just **stop granting the config-dir root** and allow only writable islands beneath it — claude-regenerated, non-executable, non-config state, enumerated against a real `~/.claude`:

- `projects/` (transcripts), `session-env/`, `shell-snapshots/` (per-session scaffolding), `todos/`, `statsig/`, `file-history/`, `debug/`
- `.credentials.json` via an **anchored regex** (dir regex-escaped): claude rewrites it atomically through a temp sibling sharing the `.credentials.json` prefix, which a bare literal would deny and break OAuth refresh.

Everything else under the config dir is now denied — including `settings.json`, `plugins/`, `skills/`, `CLAUDE.md`, MCP/policy config, `downloads/` (holds claude **binaries**), `chrome/`, `daemon/`, and `backups/`. Unknown entries fail closed by construction.

The same islands apply to a custom `CLAUDE_CONFIG_DIR`, preserving the existing bin-residency rejection, symlink resolution, and skip-when-default dedup. The island list lives in `sandbox::policy` as shared constants; Docker's `CREDENTIALS_FILE` / `EPHEMERAL_RUNTIME_SUBDIRS` / `PROJECTS_SUBDIR` now alias them (pure refactor — mounts byte-identical, docker tests unmodified). Island grants flow through `subpath_grants`, so the bin-residency and symlink-resolution protections from #398's review rounds apply automatically.

## Documented residuals (deliberate, future hardening candidates)

1. `projects/` stays writable: the app's host-side transcript reader tails the real dir (Docker redirects it per-agent; seatbelt can't without env surgery). An agent can still write `projects/<slug>/memory` entries a later session trusts.
2. `~/.claude.json` stays a writable literal: claude requires it every session, though it carries per-project trust settings.

## Testing

- Full lib suite: **563 passed, 0 failed** — repeated under a clean env and under `CLAUDE_CONFIG_DIR=/tmp/claude-x CODEX_HOME=/tmp/codex XDG_CONFIG_HOME=/home/runner/.config XDG_DATA_HOME=$HOME/.local/bin`.
- New tests: no config-dir root grant (default + custom dir), all islands granted (default + custom dir), `settings.json`/`plugins`/`CLAUDE.md` uncovered, credentials regex present and escaped, policy island guard (strict subdirs, never the root, never bin-resident); docker tests untouched.

## Manual validation (host, outside a sandbox)

Stream denials in one terminal:
```
log stream --style syslog --predicate 'sender == "Sandbox" AND eventMessage CONTAINS "deny" AND eventMessage CONTAINS ".claude"'
```
Then under an agent profile (`sandbox-exec -f <profile>.sb /bin/sh`):
`echo x > ~/.claude/settings.json`, `echo x > ~/.claude/CLAUDE.md`, `mkdir -p ~/.claude/plugins/evil` → all **denied**; writes under `~/.claude/projects/`, `~/.claude/todos/`, and to `~/.claude/.credentials.json` (and a `.credentials.json.tmp*` sibling) → all **succeed**. Also confirm a real claude session still refreshes its token and `--resume` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)