### PR TITLE
feat: detect transcript layout drift and surface sync health

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -163,6 +163,31 @@ pub struct RawRecord {
     pub body: Value,
 }
 
+/// Counters a `locate`/`read` pass fills in as it walks a provider's transcript
+/// on disk. Purely observational — never an error, and a reader must still
+/// return every record that DID parse (partial drift must not lose good
+/// records). The turn-end sync classifies these into a health signal to tell a
+/// benign "nothing flushed yet" apart from a vendor moving/reshaping its files
+/// (see `supervisor::session_sync`).
+#[derive(Default, Debug, Clone)]
+pub struct ReadDiagnostics {
+    /// The provider's transcript root dir was found (for Claude, EITHER of its
+    /// two candidate roots counts). False means the CLI's home dir is gone —
+    /// a strong drift signal when the CLI just ran a turn.
+    pub root_exists: bool,
+    /// Located transcript artifacts (locate glob/suffix hits). For OpenCode this
+    /// also includes the part-blob files discovered during `read`.
+    pub files_matched: usize,
+    /// Non-blank JSONL lines (or JSON files) actually read. Blank lines are
+    /// normal and never counted, so `lines_seen > records_parsed` means real
+    /// parse failures — the fingerprint of a format change.
+    pub lines_seen: usize,
+    /// Records that parsed cleanly out of `lines_seen`.
+    pub records_parsed: usize,
+    /// I/O failures opening/reading a located artifact.
+    pub io_errors: usize,
+}
+
 /// Marks a reader whose transcript is a single append-only JSONL file, so it can
 /// be read incrementally from a byte offset (`read_jsonl_tail`) instead of fully
 /// re-parsed each turn. `id_field` is the per-line native-id field (matching the
@@ -176,9 +201,11 @@ pub struct JsonlTail {
 pub struct TranscriptReader {
     /// Ordered transcript artifact paths for a session (empty if none / not
     /// yet flushed). Multiple paths concatenate in order (resume can split).
-    pub locate: fn(session_id: &str, cwd: &Path) -> Vec<PathBuf>,
-    /// Parse located artifacts into ordered verbatim records.
-    pub read: fn(paths: &[PathBuf]) -> Vec<RawRecord>,
+    /// Records `root_exists` / `files_matched` into `diag` as it scans.
+    pub locate: fn(session_id: &str, cwd: &Path, diag: &mut ReadDiagnostics) -> Vec<PathBuf>,
+    /// Parse located artifacts into ordered verbatim records, recording
+    /// `lines_seen` / `records_parsed` / `io_errors` into `diag`.
+    pub read: fn(paths: &[PathBuf], diag: &mut ReadDiagnostics) -> Vec<RawRecord>,
     /// Set for single-file JSONL readers to enable incremental tail ingest.
     /// `None` for multi-file (codex) / blob-dir (opencode) readers, which fall
     /// back to a full read + idempotent batched insert.
@@ -377,17 +404,21 @@ pub fn read_jsonl_tail(
     start_index: usize,
     id_field: Option<&str>,
     consume_trailing: bool,
+    diag: &mut ReadDiagnostics,
 ) -> (Vec<RawRecord>, u64) {
     use std::io::{Read, Seek, SeekFrom};
 
     let Ok(mut file) = std::fs::File::open(path) else {
+        diag.io_errors += 1;
         return (Vec::new(), offset);
     };
     if file.seek(SeekFrom::Start(offset)).is_err() {
+        diag.io_errors += 1;
         return (Vec::new(), offset);
     }
     let mut buf = Vec::new();
     if file.read_to_end(&mut buf).is_err() {
+        diag.io_errors += 1;
         return (Vec::new(), offset);
     }
 
@@ -403,15 +434,29 @@ pub fn read_jsonl_tail(
     let mut idx = start_index;
     let mut consumed = complete_end;
 
+    // A blank line is normal padding, not content — only non-blank lines count
+    // toward `lines_seen`, so a non-blank line that fails to parse is what marks
+    // a format drift (`lines_seen > records_parsed`).
+    let count_line = |line: &[u8], diag: &mut ReadDiagnostics| {
+        let nonblank = std::str::from_utf8(line).map_or(true, |t| !t.trim().is_empty());
+        if nonblank {
+            diag.lines_seen += 1;
+        }
+    };
+
     for line in buf[..complete_end].split(|&b| b == b'\n') {
+        count_line(line, diag);
         if let Some(rec) = parse_jsonl_record(line, id_field, idx) {
+            diag.records_parsed += 1;
             out.push(rec);
             idx += 1;
         }
     }
 
     if consume_trailing {
+        count_line(&buf[complete_end..], diag);
         if let Some(rec) = parse_jsonl_record(&buf[complete_end..], id_field, idx) {
+            diag.records_parsed += 1;
             out.push(rec);
             // The trailing line parsed cleanly, so it was complete — consume to
             // EOF so we don't re-read it next time.
@@ -461,19 +506,23 @@ fn pi_session_slug(cwd: &Path) -> String {
     format!("-{}--", cwd.to_string_lossy().replace('/', "-"))
 }
 
-fn pi_locate(session_id: &str, cwd: &Path) -> Vec<PathBuf> {
+fn pi_locate(session_id: &str, cwd: &Path, diag: &mut ReadDiagnostics) -> Vec<PathBuf> {
     let Some(home) = dirs::home_dir() else {
         return Vec::new();
     };
-    let dir = home.join(".pi/agent/sessions").join(pi_session_slug(cwd));
+    let sessions = home.join(".pi/agent/sessions");
+    diag.root_exists = sessions.exists();
+    let dir = sessions.join(pi_session_slug(cwd));
     // Files are `<ts>_<session_id>.jsonl`.
-    jsonl_files_ending(&dir, &format!("_{session_id}.jsonl"))
+    let out = jsonl_files_ending(&dir, &format!("_{session_id}.jsonl"));
+    diag.files_matched += out.len();
+    out
 }
 
-fn pi_read(paths: &[PathBuf]) -> Vec<RawRecord> {
+fn pi_read(paths: &[PathBuf], diag: &mut ReadDiagnostics) -> Vec<RawRecord> {
     let values: Vec<Value> = paths
         .iter()
-        .flat_map(|p| crate::transcripts::read_jsonl_values(p).unwrap_or_default())
+        .flat_map(|p| crate::transcripts::read_jsonl_values(p, diag))
         .collect();
     // Pi's JSONL lines carry a stable `id`.
     records_with_id(values, Some("id"))
@@ -487,16 +536,16 @@ fn pi_read(paths: &[PathBuf]) -> Vec<RawRecord> {
 // per-agent transcript dir (derived from `cwd`). Content lines carry a top-level
 // `uuid`; metadata lines (mode/permission-mode/…) don't → positional fallback.
 
-fn claude_locate(session_id: &str, cwd: &Path) -> Vec<PathBuf> {
-    crate::transcripts::find_session_jsonl(session_id, cwd)
+fn claude_locate(session_id: &str, cwd: &Path, diag: &mut ReadDiagnostics) -> Vec<PathBuf> {
+    crate::transcripts::find_session_jsonl(session_id, cwd, diag)
         .into_iter()
         .collect()
 }
 
-fn claude_read(paths: &[PathBuf]) -> Vec<RawRecord> {
+fn claude_read(paths: &[PathBuf], diag: &mut ReadDiagnostics) -> Vec<RawRecord> {
     let values: Vec<Value> = paths
         .iter()
-        .flat_map(|p| crate::transcripts::read_jsonl_values(p).unwrap_or_default())
+        .flat_map(|p| crate::transcripts::read_jsonl_values(p, diag))
         .collect();
     records_with_id(values, Some("uuid"))
 }
@@ -513,14 +562,14 @@ static CLAUDE_TRANSCRIPT: TranscriptReader = TranscriptReader {
 // Codex writes `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<id>.jsonl`.
 // Lines are `{timestamp,type,payload}` dual-channel with no stable per-line id,
 // so records key positionally. The codex frontend adapter already normalizes.
-fn codex_locate(session_id: &str, _cwd: &Path) -> Vec<PathBuf> {
-    crate::transcripts::find_codex_rollouts(session_id)
+fn codex_locate(session_id: &str, _cwd: &Path, diag: &mut ReadDiagnostics) -> Vec<PathBuf> {
+    crate::transcripts::find_codex_rollouts(session_id, diag)
 }
 
-fn codex_read(paths: &[PathBuf]) -> Vec<RawRecord> {
+fn codex_read(paths: &[PathBuf], diag: &mut ReadDiagnostics) -> Vec<RawRecord> {
     let values: Vec<Value> = paths
         .iter()
-        .flat_map(|p| crate::transcripts::read_jsonl_values(p).unwrap_or_default())
+        .flat_map(|p| crate::transcripts::read_jsonl_values(p, diag))
         .collect();
     records_with_id(values, None)
 }
@@ -530,7 +579,7 @@ fn codex_read(paths: &[PathBuf]) -> Vec<RawRecord> {
 // The session-id dir is unique, so glob by it (like claude) rather than
 // reverse-engineering the undocumented slug. Lines have no per-line id →
 // positional keys.
-fn cursor_locate(session_id: &str, _cwd: &Path) -> Vec<PathBuf> {
+fn cursor_locate(session_id: &str, _cwd: &Path, diag: &mut ReadDiagnostics) -> Vec<PathBuf> {
     let Some(home) = dirs::home_dir() else {
         return Vec::new();
     };
@@ -538,6 +587,7 @@ fn cursor_locate(session_id: &str, _cwd: &Path) -> Vec<PathBuf> {
     let projects = home.join(".cursor").join("projects");
     let mut out = Vec::new();
     if let Ok(entries) = std::fs::read_dir(&projects) {
+        diag.root_exists = true;
         for entry in entries.flatten() {
             let path = entry.path().join(&rel);
             if path.exists() {
@@ -546,13 +596,14 @@ fn cursor_locate(session_id: &str, _cwd: &Path) -> Vec<PathBuf> {
         }
     }
     out.sort();
+    diag.files_matched += out.len();
     out
 }
 
-fn cursor_read(paths: &[PathBuf]) -> Vec<RawRecord> {
+fn cursor_read(paths: &[PathBuf], diag: &mut ReadDiagnostics) -> Vec<RawRecord> {
     let values: Vec<Value> = paths
         .iter()
-        .flat_map(|p| crate::transcripts::read_jsonl_values(p).unwrap_or_default())
+        .flat_map(|p| crate::transcripts::read_jsonl_values(p, diag))
         .collect();
     records_with_id(values, None)
 }
@@ -590,20 +641,35 @@ fn read_json_value(path: &Path) -> Option<Value> {
     serde_json::from_str(&std::fs::read_to_string(path).ok()?).ok()
 }
 
-fn opencode_locate(session_id: &str, _cwd: &Path) -> Vec<PathBuf> {
+fn opencode_locate(session_id: &str, _cwd: &Path, diag: &mut ReadDiagnostics) -> Vec<PathBuf> {
     let Some(root) = opencode_storage_root() else {
         return Vec::new();
     };
-    json_files_in(&root.join("message").join(session_id))
+    diag.root_exists = root.exists();
+    let out = json_files_in(&root.join("message").join(session_id));
+    diag.files_matched += out.len();
+    out
 }
 
-fn opencode_read(message_paths: &[PathBuf]) -> Vec<RawRecord> {
+fn opencode_read(message_paths: &[PathBuf], diag: &mut ReadDiagnostics) -> Vec<RawRecord> {
+    // Each blob is one JSON object (not a JSONL line): count it as one
+    // `lines_seen`, bump `io_errors` when unreadable/unparseable, and only
+    // `records_parsed` once we've confirmed its expected `id` shape — so an
+    // OpenCode format change (readable JSON, but the id moved) reads as drift.
+    let read_one = |path: &Path, diag: &mut ReadDiagnostics| -> Option<(String, Value)> {
+        diag.lines_seen += 1;
+        let Some(v) = read_json_value(path) else {
+            diag.io_errors += 1;
+            return None;
+        };
+        let id = v.get("id").and_then(|x| x.as_str())?.to_string();
+        diag.records_parsed += 1;
+        Some((id, v))
+    };
+
     let mut out = Vec::new();
     for msg_path in message_paths {
-        let Some(msg) = read_json_value(msg_path) else {
-            continue;
-        };
-        let Some(msg_id) = msg.get("id").and_then(|v| v.as_str()).map(str::to_string) else {
+        let Some((msg_id, msg)) = read_one(msg_path, diag) else {
             continue;
         };
         out.push(RawRecord {
@@ -621,13 +687,14 @@ fn opencode_read(message_paths: &[PathBuf]) -> Vec<RawRecord> {
             continue;
         };
         for pf in json_files_in(&part_dir) {
-            if let Some(part) = read_json_value(&pf) {
-                if let Some(pid) = part.get("id").and_then(|v| v.as_str()) {
-                    out.push(RawRecord {
-                        native_id: pid.to_string(),
-                        body: part,
-                    });
-                }
+            // Part blobs count toward files_matched too (locate only saw the
+            // message blobs).
+            diag.files_matched += 1;
+            if let Some((pid, part)) = read_one(&pf, diag) {
+                out.push(RawRecord {
+                    native_id: pid,
+                    body: part,
+                });
             }
         }
     }
@@ -692,10 +759,17 @@ fn antigravity_conv_id_from_map(json_text: &str, cwd: &str) -> Option<String> {
     map.get(cwd).and_then(|v| v.as_str()).map(str::to_string)
 }
 
-fn antigravity_locate(session_id: &str, cwd: &Path) -> Vec<PathBuf> {
+fn antigravity_locate(session_id: &str, cwd: &Path, diag: &mut ReadDiagnostics) -> Vec<PathBuf> {
     let Some(home) = dirs::home_dir() else {
         return Vec::new();
     };
+    // root_exists tracks the CLI's home dir, not the conv-id indirection: a
+    // missing/unparseable `last_conversations.json` or a missing cwd key leaves
+    // the CLI installed (root present) but the conversation unresolved, so it
+    // reads as `files_matched == 0` (ambiguous NoFiles), not NoRoot. Only the
+    // whole `~/.gemini/antigravity-cli` dir vanishing is a NoRoot drift signal.
+    let vendor_root = home.join(".gemini/antigravity-cli");
+    diag.root_exists = vendor_root.exists();
     // Prefer the captured id; fall back to the cwd→id map (e.g. the first turn,
     // before the id has been persisted).
     let id = if session_id.is_empty() {
@@ -706,21 +780,22 @@ fn antigravity_locate(session_id: &str, cwd: &Path) -> Vec<PathBuf> {
     } else {
         session_id.to_string()
     };
-    let path = home
-        .join(".gemini/antigravity-cli/brain")
+    let path = vendor_root
+        .join("brain")
         .join(&id)
         .join(".system_generated/logs/transcript_full.jsonl");
     if path.exists() {
+        diag.files_matched += 1;
         vec![path]
     } else {
         Vec::new()
     }
 }
 
-fn antigravity_read(paths: &[PathBuf]) -> Vec<RawRecord> {
+fn antigravity_read(paths: &[PathBuf], diag: &mut ReadDiagnostics) -> Vec<RawRecord> {
     paths
         .iter()
-        .flat_map(|p| crate::transcripts::read_jsonl_values(p).unwrap_or_default())
+        .flat_map(|p| crate::transcripts::read_jsonl_values(p, diag))
         .enumerate()
         .map(|(i, body)| {
             // `step_index` is a stable, monotonic per-conversation key.
@@ -1788,7 +1863,8 @@ mod tests {
             .unwrap();
         }
 
-        let (recs, off) = read_jsonl_tail(&path, 0, 0, Some("uuid"), false);
+        let (recs, off) =
+            read_jsonl_tail(&path, 0, 0, Some("uuid"), false, &mut ReadDiagnostics::default());
         assert_eq!(
             recs.iter()
                 .map(|r| r.native_id.as_str())
@@ -1811,7 +1887,8 @@ mod tests {
             .unwrap();
         }
 
-        let (recs2, _off2) = read_jsonl_tail(&path, off, 2, Some("uuid"), false);
+        let (recs2, _off2) =
+            read_jsonl_tail(&path, off, 2, Some("uuid"), false, &mut ReadDiagnostics::default());
         assert_eq!(
             recs2
                 .iter()
@@ -1833,7 +1910,7 @@ mod tests {
             write!(f, "{{\"type\":\"mode\"}}\n{{\"type\":\"summary\"}}\n").unwrap();
         }
         // Pretend 5 records were already ingested.
-        let (recs, _off) = read_jsonl_tail(&path, 0, 5, None, false);
+        let (recs, _off) = read_jsonl_tail(&path, 0, 5, None, false, &mut ReadDiagnostics::default());
         assert_eq!(
             recs.iter()
                 .map(|r| r.native_id.as_str())
@@ -1860,7 +1937,8 @@ mod tests {
         }
 
         // Exited writer: the unterminated final line is consumed, to EOF.
-        let (recs, off) = read_jsonl_tail(&path, 0, 0, Some("uuid"), true);
+        let (recs, off) =
+            read_jsonl_tail(&path, 0, 0, Some("uuid"), true, &mut ReadDiagnostics::default());
         assert_eq!(
             recs.iter()
                 .map(|r| r.native_id.as_str())
@@ -1874,7 +1952,8 @@ mod tests {
         );
 
         // Live writer (same bytes): the unterminated final line is held back.
-        let (held, _) = read_jsonl_tail(&path, 0, 0, Some("uuid"), false);
+        let (held, _) =
+            read_jsonl_tail(&path, 0, 0, Some("uuid"), false, &mut ReadDiagnostics::default());
         assert_eq!(
             held.iter()
                 .map(|r| r.native_id.as_str())
@@ -1888,7 +1967,8 @@ mod tests {
             let mut f = std::fs::File::create(&torn).unwrap();
             write!(f, "{{\"uuid\":\"a\",\"type\":\"user\"}}\n{{\"uuid\":\"x\",").unwrap();
         }
-        let (recs_torn, _) = read_jsonl_tail(&torn, 0, 0, Some("uuid"), true);
+        let (recs_torn, _) =
+            read_jsonl_tail(&torn, 0, 0, Some("uuid"), true, &mut ReadDiagnostics::default());
         assert_eq!(
             recs_torn
                 .iter()
@@ -1947,11 +2027,14 @@ mod tests {
             "{\"step_index\":0,\"type\":\"USER_INPUT\"}\n{\"step_index\":2,\"type\":\"PLANNER_RESPONSE\"}\n{\"type\":\"X\"}\n",
         )
         .unwrap();
-        let recs = antigravity_read(&[f]);
+        let mut diag = ReadDiagnostics::default();
+        let recs = antigravity_read(&[f], &mut diag);
         assert_eq!(recs.len(), 3);
         assert_eq!(recs[0].native_id, "step:0");
         assert_eq!(recs[1].native_id, "step:2");
         assert_eq!(recs[2].native_id, "ln:2"); // no step_index → positional
+        assert_eq!(diag.lines_seen, 3);
+        assert_eq!(diag.records_parsed, 3);
     }
 
     // agy's native (PTY/TUI) view is wired — it resumes the conversation the

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -1863,8 +1863,14 @@ mod tests {
             .unwrap();
         }
 
-        let (recs, off) =
-            read_jsonl_tail(&path, 0, 0, Some("uuid"), false, &mut ReadDiagnostics::default());
+        let (recs, off) = read_jsonl_tail(
+            &path,
+            0,
+            0,
+            Some("uuid"),
+            false,
+            &mut ReadDiagnostics::default(),
+        );
         assert_eq!(
             recs.iter()
                 .map(|r| r.native_id.as_str())
@@ -1887,8 +1893,14 @@ mod tests {
             .unwrap();
         }
 
-        let (recs2, _off2) =
-            read_jsonl_tail(&path, off, 2, Some("uuid"), false, &mut ReadDiagnostics::default());
+        let (recs2, _off2) = read_jsonl_tail(
+            &path,
+            off,
+            2,
+            Some("uuid"),
+            false,
+            &mut ReadDiagnostics::default(),
+        );
         assert_eq!(
             recs2
                 .iter()
@@ -1910,7 +1922,8 @@ mod tests {
             write!(f, "{{\"type\":\"mode\"}}\n{{\"type\":\"summary\"}}\n").unwrap();
         }
         // Pretend 5 records were already ingested.
-        let (recs, _off) = read_jsonl_tail(&path, 0, 5, None, false, &mut ReadDiagnostics::default());
+        let (recs, _off) =
+            read_jsonl_tail(&path, 0, 5, None, false, &mut ReadDiagnostics::default());
         assert_eq!(
             recs.iter()
                 .map(|r| r.native_id.as_str())
@@ -1937,8 +1950,14 @@ mod tests {
         }
 
         // Exited writer: the unterminated final line is consumed, to EOF.
-        let (recs, off) =
-            read_jsonl_tail(&path, 0, 0, Some("uuid"), true, &mut ReadDiagnostics::default());
+        let (recs, off) = read_jsonl_tail(
+            &path,
+            0,
+            0,
+            Some("uuid"),
+            true,
+            &mut ReadDiagnostics::default(),
+        );
         assert_eq!(
             recs.iter()
                 .map(|r| r.native_id.as_str())
@@ -1952,8 +1971,14 @@ mod tests {
         );
 
         // Live writer (same bytes): the unterminated final line is held back.
-        let (held, _) =
-            read_jsonl_tail(&path, 0, 0, Some("uuid"), false, &mut ReadDiagnostics::default());
+        let (held, _) = read_jsonl_tail(
+            &path,
+            0,
+            0,
+            Some("uuid"),
+            false,
+            &mut ReadDiagnostics::default(),
+        );
         assert_eq!(
             held.iter()
                 .map(|r| r.native_id.as_str())
@@ -1967,8 +1992,14 @@ mod tests {
             let mut f = std::fs::File::create(&torn).unwrap();
             write!(f, "{{\"uuid\":\"a\",\"type\":\"user\"}}\n{{\"uuid\":\"x\",").unwrap();
         }
-        let (recs_torn, _) =
-            read_jsonl_tail(&torn, 0, 0, Some("uuid"), true, &mut ReadDiagnostics::default());
+        let (recs_torn, _) = read_jsonl_tail(
+            &torn,
+            0,
+            0,
+            Some("uuid"),
+            true,
+            &mut ReadDiagnostics::default(),
+        );
         assert_eq!(
             recs_torn
                 .iter()

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -188,6 +188,20 @@ pub struct ReadDiagnostics {
     pub io_errors: usize,
 }
 
+impl ReadDiagnostics {
+    /// Fold another pass's counters into this one. The turn-end sync polls
+    /// repeatedly and classifies the turn as a whole, so counters accumulate
+    /// across passes — a clean settle read must not erase an earlier pass's
+    /// errors.
+    pub fn absorb(&mut self, other: &ReadDiagnostics) {
+        self.root_exists |= other.root_exists;
+        self.files_matched += other.files_matched;
+        self.lines_seen += other.lines_seen;
+        self.records_parsed += other.records_parsed;
+        self.io_errors += other.io_errors;
+    }
+}
+
 /// Marks a reader whose transcript is a single append-only JSONL file, so it can
 /// be read incrementally from a byte offset (`read_jsonl_tail`) instead of fully
 /// re-parsed each turn. `id_field` is the per-line native-id field (matching the

--- a/src-tauri/src/message_queue.rs
+++ b/src-tauri/src/message_queue.rs
@@ -136,9 +136,9 @@ impl MessageQueue {
     /// delivery window (still queued here) keeps its row (see
     /// `WorkspaceManager::delete_pending_messages_except`).
     pub fn turn_ids(&self, agent_id: &str) -> Vec<String> {
-        self.by_agent.get(agent_id).map_or_else(Vec::new, |q| {
-            q.iter().map(|m| m.turn_id.clone()).collect()
-        })
+        self.by_agent
+            .get(agent_id)
+            .map_or_else(Vec::new, |q| q.iter().map(|m| m.turn_id.clone()).collect())
     }
 
     /// Remove and return all queued messages for an agent, coalesced into a

--- a/src-tauri/src/supervisor/events.rs
+++ b/src-tauri/src/supervisor/events.rs
@@ -82,6 +82,40 @@ pub(super) fn emit_session_records_appended(app: &AppHandle, agent_id: &str) {
     );
 }
 
+#[derive(Clone, serde::Serialize)]
+struct SessionSyncHealthPayload {
+    agent_id: String,
+    provider: String,
+    /// `"healthy"` (clears a prior degraded state), `"no_root"`, or
+    /// `"format_drift"`. `NoFiles` is never emitted (log-only, ambiguous).
+    status: &'static str,
+    /// The current CLI version string (memoized `<bin> --version`) for the
+    /// log/message only — not a historical DB lookup. `None` if unprobed.
+    version: Option<String>,
+}
+
+/// The transcript-ingest health for an agent changed (drift detected, or a
+/// prior drift cleared). Emitted on status *change* only — see
+/// `session_sync::trigger_session_sync`.
+pub(super) fn emit_session_sync_health(
+    app: &AppHandle,
+    agent_id: &str,
+    provider: &str,
+    status: &'static str,
+    version: Option<String>,
+) {
+    emit(
+        app,
+        "session:sync-health",
+        SessionSyncHealthPayload {
+            agent_id: agent_id.to_string(),
+            provider: provider.to_string(),
+            status,
+            version,
+        },
+    );
+}
+
 /// Emitted when a turn flips to Running, carrying the backend's own start
 /// timestamp (the same value persisted as the turn's `started_at`). The live
 /// timer anchors to this rather than the event's client-receipt time, so it

--- a/src-tauri/src/supervisor/messaging.rs
+++ b/src-tauri/src/supervisor/messaging.rs
@@ -212,7 +212,10 @@ impl Supervisor {
         for (agent_id, msg) in pending {
             queue.enqueue(&agent_id, msg);
         }
-        tracing::info!(count, "rehydrated queued follow-up messages from a prior run");
+        tracing::info!(
+            count,
+            "rehydrated queued follow-up messages from a prior run"
+        );
     }
 }
 
@@ -344,7 +347,10 @@ pub(super) fn flush_queued(sup: &Arc<Supervisor>, app: &AppHandle, agent_id: &st
     {
         let queue = sup.message_queue.lock();
         let keep = queue.turn_ids(agent_id);
-        if let Err(e) = sup.workspace.delete_pending_messages_except(agent_id, &keep) {
+        if let Err(e) = sup
+            .workspace
+            .delete_pending_messages_except(agent_id, &keep)
+        {
             tracing::warn!(error = %e, agent_id, "clear delivered pending follow-ups failed");
         }
     }

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -71,6 +71,12 @@ pub struct Supervisor {
     /// flush distinguish a natural completion (flush queued follow-ups) from a
     /// stop (keep them queued, don't auto-send — see `drain_message_queue`).
     pub interrupted: Mutex<HashSet<String>>,
+    /// Last-emitted transcript-ingest health per agent, so `session:sync-health`
+    /// fires on *change* only (real drift would otherwise spam an event every
+    /// turn). Absent = healthy/never-degraded. In-memory only, event-driven —
+    /// never persisted (see `session_sync`). Behind an `Arc` so the fire-and-
+    /// forget sync task can hold it without borrowing `self`.
+    pub sync_health: Arc<Mutex<HashMap<String, session_sync::SyncHealth>>>,
 }
 
 impl Supervisor {
@@ -87,6 +93,7 @@ impl Supervisor {
             respawn_pending: Mutex::new(HashSet::new()),
             message_queue: Mutex::new(MessageQueue::new()),
             interrupted: Mutex::new(HashSet::new()),
+            sync_health: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -344,6 +344,9 @@ pub(crate) enum SyncHealth {
     /// Files matched and carried non-blank lines, yet none parsed — the vendor
     /// reshaped its format. The smoking gun, essentially zero false positives.
     FormatDrift,
+    /// Files matched but couldn't be opened or read (permissions, vanished
+    /// mid-read) and nothing parsed — ingestion failed just as surely as drift.
+    ReadError,
 }
 
 impl SyncHealth {
@@ -354,6 +357,7 @@ impl SyncHealth {
             SyncHealth::Healthy => Some("healthy"),
             SyncHealth::NoRoot => Some("no_root"),
             SyncHealth::FormatDrift => Some("format_drift"),
+            SyncHealth::ReadError => Some("read_error"),
             SyncHealth::NoFiles => None,
         }
     }
@@ -362,11 +366,12 @@ impl SyncHealth {
 /// Classify a completed poll's diagnostics into a health signal. Pure so it's
 /// unit-testable over hand-built counters.
 ///
-/// The `lines_seen == 0` fall-through to `Healthy` is deliberate: an
-/// incremental tail read of an already-ingested transcript reads no new bytes
-/// on the settle poll (`files_matched > 0`, `records_parsed == 0`,
-/// `lines_seen == 0`), which must NOT read as drift. Real drift always leaves
-/// non-blank lines that failed to parse (`lines_seen > 0`).
+/// The final fall-through to `Healthy` is deliberate: an incremental tail read
+/// of an already-ingested transcript reads no new bytes on the settle poll
+/// (`files_matched > 0`, `records_parsed == 0`, `lines_seen == 0`,
+/// `io_errors == 0`), which must NOT read as drift. Real drift always leaves
+/// non-blank lines that failed to parse (`lines_seen > 0`), and a matched file
+/// that couldn't be read at all leaves `io_errors > 0`.
 fn classify(diag: &crate::agent::ReadDiagnostics) -> SyncHealth {
     if diag.records_parsed > 0 {
         SyncHealth::Healthy
@@ -376,6 +381,8 @@ fn classify(diag: &crate::agent::ReadDiagnostics) -> SyncHealth {
         SyncHealth::NoFiles
     } else if diag.lines_seen > 0 {
         SyncHealth::FormatDrift
+    } else if diag.io_errors > 0 {
+        SyncHealth::ReadError
     } else {
         SyncHealth::Healthy
     }
@@ -758,6 +765,21 @@ mod tests {
             io_errors: 0,
         };
         assert_eq!(classify(&d), SyncHealth::FormatDrift);
+    }
+
+    #[test]
+    fn classify_read_error_when_matched_files_unreadable() {
+        // locate matched a transcript but every read failed (permissions,
+        // vanished mid-read): no lines were ever seen, so without the
+        // io_errors branch this would fall through to Healthy.
+        let d = ReadDiagnostics {
+            root_exists: true,
+            files_matched: 1,
+            lines_seen: 0,
+            records_parsed: 0,
+            io_errors: 1,
+        };
+        assert_eq!(classify(&d), SyncHealth::ReadError);
     }
 
     #[test]

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -494,6 +494,16 @@ fn report_sync_health(
             io_errors = diag.io_errors,
             "session sync ingested 0 records after retries",
         );
+    } else if diag.io_errors > 0 {
+        // Partial read: records flowed so this stays Healthy (no banner), but
+        // an unread tail shouldn't vanish without a trace.
+        tracing::warn!(
+            agent_id,
+            provider,
+            records_parsed = diag.records_parsed,
+            io_errors = diag.io_errors,
+            "session sync hit read errors after ingesting records — transcript tail may be missing",
+        );
     }
 
     let mut map = health_map.lock();
@@ -765,6 +775,22 @@ mod tests {
             io_errors: 0,
         };
         assert_eq!(classify(&d), SyncHealth::FormatDrift);
+    }
+
+    #[test]
+    fn classify_healthy_on_partial_read_with_records() {
+        // A read that fails partway after ingesting records stays Healthy (no
+        // banner — records flowed, and the next sync re-attempts the tail via
+        // the persisted offset / idempotent dedup); the partial loss is
+        // warn-logged instead.
+        let d = ReadDiagnostics {
+            root_exists: true,
+            files_matched: 1,
+            lines_seen: 3,
+            records_parsed: 3,
+            io_errors: 1,
+        };
+        assert_eq!(classify(&d), SyncHealth::Healthy);
     }
 
     #[test]

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -8,15 +8,18 @@ use crate::agent::per_turn_descriptor;
 use crate::github::{PrState, PrStatus};
 use crate::workspace::{repo_checkout_path, AgentRecord, AgentView, TrackedRepo, WorkspaceManager};
 
-use super::events::{emit_pr_state, emit_session_records_appended};
+use super::events::{emit_pr_state, emit_session_records_appended, emit_session_sync_health};
 use super::Supervisor;
+
+use parking_lot::Mutex;
+use std::collections::HashMap;
 
 impl Supervisor {
     /// Synchronously ingest the agent's transcript into session_records (used
     /// for lazy backfill when a session is opened with no records yet). `None`
     /// if the provider has no transcript reader.
     pub fn sync_session(&self, agent_id: &str) -> Option<usize> {
-        sync_session_records(&self.workspace, agent_id)
+        sync_session_records(&self.workspace, agent_id).map(|o| o.inserted)
     }
 
     /// Fire-and-forget transcript ingest at turn-end. Called from
@@ -34,6 +37,7 @@ impl Supervisor {
     ///   consecutive reads add nothing) before trusting the turn is fully on disk.
     pub fn trigger_session_sync(&self, app: AppHandle, agent_id: String) {
         let workspace = self.workspace.clone();
+        let health_map = self.sync_health.clone();
         let persistent = workspace
             .agent(&agent_id)
             .map(|r| is_persistent_runner(&r))
@@ -55,11 +59,15 @@ impl Supervisor {
             }
             if poll.should_emit() {
                 emit_session_records_appended(&app, &agent_id);
-            } else if poll.reader_ingested_nothing() {
-                tracing::warn!(
-                    agent_id,
-                    "session sync ingested 0 records after retries (transcript not found or unchanged)"
-                );
+            }
+            // Classify only now, after the retry loop is exhausted — earlier the
+            // transcript may just be mid-flush, which must never read as drift.
+            if let Some(diag) = poll.last_diagnostics() {
+                let provider = workspace
+                    .agent(&agent_id)
+                    .map(|r| r.provider)
+                    .unwrap_or_default();
+                report_sync_health(&app, &health_map, &agent_id, &provider, classify(diag), diag);
             }
         });
     }
@@ -313,10 +321,70 @@ enum PollControl {
     Stop,
 }
 
+/// One `sync_session_records` pass: how many new records it inserted plus the
+/// counters the locate/read collected. The count drives the poll's stop/settle
+/// logic; the diagnostics drive the post-exhaustion health classification.
+struct SyncOutcome {
+    inserted: usize,
+    diagnostics: crate::agent::ReadDiagnostics,
+}
+
+/// The turn-end ingest health for a reader-backed agent, derived purely from
+/// the last pass's [`ReadDiagnostics`](crate::agent::ReadDiagnostics).
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub(crate) enum SyncHealth {
+    /// Records parsed this turn — ingestion is working.
+    Healthy,
+    /// The CLI's transcript root dir is gone though it just ran a turn — a
+    /// strong drift signal.
+    NoRoot,
+    /// Root present, but no transcript files matched. Ambiguous (slow flush /
+    /// empty session), so this is logged, never surfaced to the UI.
+    NoFiles,
+    /// Files matched and carried non-blank lines, yet none parsed — the vendor
+    /// reshaped its format. The smoking gun, essentially zero false positives.
+    FormatDrift,
+}
+
+impl SyncHealth {
+    /// The wire status for `session:sync-health`. `None` for `NoFiles`, which is
+    /// never emitted.
+    fn wire(self) -> Option<&'static str> {
+        match self {
+            SyncHealth::Healthy => Some("healthy"),
+            SyncHealth::NoRoot => Some("no_root"),
+            SyncHealth::FormatDrift => Some("format_drift"),
+            SyncHealth::NoFiles => None,
+        }
+    }
+}
+
+/// Classify a completed poll's diagnostics into a health signal. Pure so it's
+/// unit-testable over hand-built counters.
+///
+/// The `lines_seen == 0` fall-through to `Healthy` is deliberate: an
+/// incremental tail read of an already-ingested transcript reads no new bytes
+/// on the settle poll (`files_matched > 0`, `records_parsed == 0`,
+/// `lines_seen == 0`), which must NOT read as drift. Real drift always leaves
+/// non-blank lines that failed to parse (`lines_seen > 0`).
+fn classify(diag: &crate::agent::ReadDiagnostics) -> SyncHealth {
+    if diag.records_parsed > 0 {
+        SyncHealth::Healthy
+    } else if !diag.root_exists {
+        SyncHealth::NoRoot
+    } else if diag.files_matched == 0 {
+        SyncHealth::NoFiles
+    } else if diag.lines_seen > 0 {
+        SyncHealth::FormatDrift
+    } else {
+        SyncHealth::Healthy
+    }
+}
+
 /// Decision logic for the turn-end transcript sync, split out from
 /// `trigger_session_sync` so it's unit-testable without timers or the
 /// filesystem. Fed each `sync_session_records` result (`None` = no reader,
-/// `Some(n)` = n new records this pass).
+/// `Some(outcome)` = the pass's record count + diagnostics).
 ///
 /// The stop condition depends on whether the runner persists:
 /// - **Non-persistent (per-turn, exited):** the file is complete, so stop at the
@@ -331,6 +399,9 @@ struct SyncPoll {
     had_reader: bool,
     inserted: usize,
     stable_polls: u32,
+    /// Diagnostics from the most recent reader pass, classified only after the
+    /// retry loop exhausts — never mid-poll, so flush lag can't false-positive.
+    last_diag: Option<crate::agent::ReadDiagnostics>,
 }
 
 impl SyncPoll {
@@ -340,36 +411,36 @@ impl SyncPoll {
             had_reader: false,
             inserted: 0,
             stable_polls: 0,
+            last_diag: None,
         }
     }
 
-    fn observe(&mut self, result: Option<usize>) -> PollControl {
-        match result {
-            None => PollControl::Stop, // no reader — nothing to wait for
-            Some(0) => {
-                self.had_reader = true;
-                if self.inserted == 0 {
-                    return PollControl::Continue; // not flushed yet — keep waiting
-                }
-                if !self.persistent {
-                    return PollControl::Stop; // exited → first batch was the whole turn
-                }
-                self.stable_polls += 1;
-                if self.stable_polls >= 2 {
-                    PollControl::Stop // file quiet for two polls → settled
-                } else {
-                    PollControl::Continue
-                }
+    fn observe(&mut self, result: Option<SyncOutcome>) -> PollControl {
+        let Some(SyncOutcome { inserted: n, diagnostics }) = result else {
+            return PollControl::Stop; // no reader — nothing to wait for
+        };
+        self.had_reader = true;
+        self.last_diag = Some(diagnostics);
+        if n == 0 {
+            if self.inserted == 0 {
+                return PollControl::Continue; // not flushed yet — keep waiting
             }
-            Some(n) => {
-                self.had_reader = true;
-                self.inserted += n;
-                self.stable_polls = 0; // new content → not settled
-                if self.persistent {
-                    PollControl::Continue
-                } else {
-                    PollControl::Stop // exited → the batch is complete
-                }
+            if !self.persistent {
+                return PollControl::Stop; // exited → first batch was the whole turn
+            }
+            self.stable_polls += 1;
+            if self.stable_polls >= 2 {
+                PollControl::Stop // file quiet for two polls → settled
+            } else {
+                PollControl::Continue
+            }
+        } else {
+            self.inserted += n;
+            self.stable_polls = 0; // new content → not settled
+            if self.persistent {
+                PollControl::Continue
+            } else {
+                PollControl::Stop // exited → the batch is complete
             }
         }
     }
@@ -378,25 +449,106 @@ impl SyncPoll {
         self.inserted > 0
     }
 
-    fn reader_ingested_nothing(&self) -> bool {
-        self.had_reader && self.inserted == 0
+    /// The health of the final pass — `None` when there was no reader (nothing
+    /// to classify). Test-only convenience; production classifies via
+    /// [`last_diagnostics`](Self::last_diagnostics) so it can log the counters.
+    #[cfg(test)]
+    fn health(&self) -> Option<SyncHealth> {
+        self.last_diag.as_ref().map(classify)
+    }
+
+    /// The final pass's diagnostics — `None` when there was no reader.
+    fn last_diagnostics(&self) -> Option<&crate::agent::ReadDiagnostics> {
+        self.last_diag.as_ref()
+    }
+}
+
+/// Log every degraded pass (with full counters) and emit `session:sync-health`
+/// on status *change* only — a persistent drift must not fire an event per
+/// turn. `Healthy` is emitted solely to clear a prior degraded state; `NoFiles`
+/// is logged but never emitted (ambiguous — slow flush or empty session).
+fn report_sync_health(
+    app: &AppHandle,
+    health_map: &Mutex<HashMap<String, SyncHealth>>,
+    agent_id: &str,
+    provider: &str,
+    health: SyncHealth,
+    diag: &crate::agent::ReadDiagnostics,
+) {
+    if !matches!(health, SyncHealth::Healthy) {
+        tracing::warn!(
+            agent_id,
+            provider,
+            ?health,
+            root_exists = diag.root_exists,
+            files_matched = diag.files_matched,
+            lines_seen = diag.lines_seen,
+            records_parsed = diag.records_parsed,
+            io_errors = diag.io_errors,
+            "session sync ingested 0 records after retries",
+        );
+    }
+
+    let mut map = health_map.lock();
+    match health {
+        // Ambiguous — logged above, but never emitted and never mutates state
+        // (so it can't clear a real degraded status either).
+        SyncHealth::NoFiles => {}
+        SyncHealth::Healthy => {
+            if map.remove(agent_id).is_some() {
+                // Clearing a previously-degraded status.
+                emit_session_sync_health(
+                    app,
+                    agent_id,
+                    provider,
+                    "healthy",
+                    crate::agent::cached_provider_version(provider),
+                );
+            }
+        }
+        degraded => {
+            if map.get(agent_id) != Some(&degraded) {
+                map.insert(agent_id.to_string(), degraded);
+                if let Some(status) = degraded.wire() {
+                    emit_session_sync_health(
+                        app,
+                        agent_id,
+                        provider,
+                        status,
+                        crate::agent::cached_provider_version(provider),
+                    );
+                }
+            }
+        }
     }
 }
 
 /// Ingest the agent's on-disk transcript into `session_records`, idempotent per
 /// `native_id`. `None` = no transcript reader for this provider (skip, don't
-/// retry); `Some(n)` = reader ran, `n` new records inserted (`0` = nothing yet:
-/// file not flushed, or its location/format changed).
-fn sync_session_records(workspace: &WorkspaceManager, agent_id: &str) -> Option<usize> {
+/// retry); `Some(outcome)` = reader ran, carrying the count of new records
+/// inserted (`0` = nothing yet: file not flushed, or its location/format
+/// changed) plus the `ReadDiagnostics` the locate/read pass collected so the
+/// caller can tell those two apart.
+fn sync_session_records(workspace: &WorkspaceManager, agent_id: &str) -> Option<SyncOutcome> {
     let record = workspace.agent(agent_id).ok()?;
     let reader = crate::agent::transcript_reader(&record.provider)?;
 
-    // A reader exists; from here any shortfall is "nothing yet" → Some(0).
+    // A reader exists but we couldn't even attempt a real read this pass (no
+    // repo / broken checkout / session id not captured yet). This is an
+    // internal / not-yet-ready state, never vendor drift, so report it as
+    // ambiguous (`root_exists`, no files → NoFiles, which is log-only) rather
+    // than letting the default all-false diagnostics read as NoRoot. Still
+    // `inserted == 0`, so the poll keeps retrying exactly as before.
+    let pending = || SyncOutcome {
+        inserted: 0,
+        diagnostics: crate::agent::ReadDiagnostics { root_exists: true, ..Default::default() },
+    };
+
     let Some(repo) = record.repos.first() else {
-        return Some(0);
+        return Some(pending());
     };
     let Ok(cwd) = repo_checkout_path(agent_id, &repo.subdir) else {
-        return Some(0);
+        return Some(pending());
     };
 
     // Resolve the session id. Event-stream agents have it on the record already;
@@ -413,12 +565,13 @@ fn sync_session_records(workspace: &WorkspaceManager, agent_id: &str) -> Option<
                     let _ = workspace.set_agent_session_id(agent_id, &id);
                     id
                 }
-                None => return Some(0),
+                None => return Some(pending()),
             }
         }
     };
 
-    let paths = (reader.locate)(&session_id, &cwd);
+    let mut diagnostics = crate::agent::ReadDiagnostics::default();
+    let paths = (reader.locate)(&session_id, &cwd, &mut diagnostics);
 
     // Version-frozen snapshot tag (memoized probe — at most one --version per
     // provider per process).
@@ -444,10 +597,11 @@ fn sync_session_records(workspace: &WorkspaceManager, agent_id: &str) -> Option<
                 start_index,
                 tail.id_field,
                 consume_trailing,
+                &mut diagnostics,
             );
             (recs, Some(next))
         }
-        _ => ((reader.read)(&paths), None),
+        _ => ((reader.read)(&paths, &mut diagnostics), None),
     };
 
     let batch: Vec<(&str, &serde_json::Value)> = records
@@ -482,12 +636,46 @@ fn sync_session_records(workspace: &WorkspaceManager, agent_id: &str) -> Option<
         tracing::warn!(error = %e, agent_id, "associate user turns failed");
     }
 
-    Some(inserted)
+    Some(SyncOutcome { inserted, diagnostics })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent::ReadDiagnostics;
+    use std::path::Path;
+
+    // Serialize the two env-var drift tests: they mutate process-global
+    // CODEX_HOME / CLAUDE_CONFIG_DIR, and cargo runs tests in parallel.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// A pass that ingested `n` records off a healthy transcript.
+    fn healthy(n: usize) -> Option<SyncOutcome> {
+        Some(SyncOutcome {
+            inserted: n,
+            diagnostics: ReadDiagnostics {
+                root_exists: true,
+                files_matched: 1,
+                lines_seen: n.max(1),
+                records_parsed: n.max(1),
+                io_errors: 0,
+            },
+        })
+    }
+
+    /// A pass that read a matched file but parsed nothing (format drift).
+    fn drifted() -> Option<SyncOutcome> {
+        Some(SyncOutcome {
+            inserted: 0,
+            diagnostics: ReadDiagnostics {
+                root_exists: true,
+                files_matched: 1,
+                lines_seen: 3,
+                records_parsed: 0,
+                io_errors: 0,
+            },
+        })
+    }
 
     // ── SyncPoll: per-turn stops on first batch; persistent waits for settle ──
 
@@ -496,8 +684,8 @@ mod tests {
         // A per-turn agent has exited, so the file is complete: the first batch
         // is the whole turn. Empty reads before it just ride out flush lag.
         let mut poll = SyncPoll::new(false);
-        assert_eq!(poll.observe(Some(0)), PollControl::Continue); // not flushed yet
-        assert_eq!(poll.observe(Some(6)), PollControl::Stop); // complete — done
+        assert_eq!(poll.observe(healthy(0)), PollControl::Continue); // not flushed yet
+        assert_eq!(poll.observe(healthy(6)), PollControl::Stop); // complete — done
         assert!(poll.should_emit());
     }
 
@@ -506,9 +694,9 @@ mod tests {
         // Claude keeps the file open; only stop once it's been quiet for two
         // consecutive reads after we started ingesting.
         let mut poll = SyncPoll::new(true);
-        assert_eq!(poll.observe(Some(5)), PollControl::Continue);
-        assert_eq!(poll.observe(Some(0)), PollControl::Continue); // quiet 1
-        assert_eq!(poll.observe(Some(0)), PollControl::Stop); // quiet 2 → settled
+        assert_eq!(poll.observe(healthy(5)), PollControl::Continue);
+        assert_eq!(poll.observe(healthy(0)), PollControl::Continue); // quiet 1
+        assert_eq!(poll.observe(healthy(0)), PollControl::Stop); // quiet 2 → settled
         assert!(poll.should_emit());
     }
 
@@ -518,11 +706,11 @@ mod tests {
         // final answer a phase later (an empty read in between). A new batch
         // resets the settle counter, so the answer is still ingested this turn.
         let mut poll = SyncPoll::new(true);
-        assert_eq!(poll.observe(Some(7)), PollControl::Continue);
-        assert_eq!(poll.observe(Some(0)), PollControl::Continue); // gap, quiet 1
-        assert_eq!(poll.observe(Some(2)), PollControl::Continue); // answer lands → reset
-        assert_eq!(poll.observe(Some(0)), PollControl::Continue); // quiet 1
-        assert_eq!(poll.observe(Some(0)), PollControl::Stop); // quiet 2 → settled
+        assert_eq!(poll.observe(healthy(7)), PollControl::Continue);
+        assert_eq!(poll.observe(healthy(0)), PollControl::Continue); // gap, quiet 1
+        assert_eq!(poll.observe(healthy(2)), PollControl::Continue); // answer lands → reset
+        assert_eq!(poll.observe(healthy(0)), PollControl::Continue); // quiet 1
+        assert_eq!(poll.observe(healthy(0)), PollControl::Stop); // quiet 2 → settled
         assert!(poll.should_emit());
     }
 
@@ -531,17 +719,189 @@ mod tests {
         let mut poll = SyncPoll::new(true);
         assert_eq!(poll.observe(None), PollControl::Stop);
         assert!(!poll.should_emit());
-        assert!(!poll.reader_ingested_nothing());
+        assert_eq!(poll.health(), None);
+    }
+
+    // ── classifier: the four states, over hand-built diagnostics ──
+
+    #[test]
+    fn classify_healthy_when_records_parsed() {
+        let d = ReadDiagnostics {
+            root_exists: true,
+            files_matched: 1,
+            lines_seen: 4,
+            records_parsed: 4,
+            io_errors: 0,
+        };
+        assert_eq!(classify(&d), SyncHealth::Healthy);
     }
 
     #[test]
-    fn sync_poll_reader_but_nothing_ingested_warns() {
+    fn classify_no_root_when_root_missing() {
+        let d = ReadDiagnostics { root_exists: false, ..Default::default() };
+        assert_eq!(classify(&d), SyncHealth::NoRoot);
+    }
+
+    #[test]
+    fn classify_no_files_when_root_present_but_no_matches() {
+        let d = ReadDiagnostics { root_exists: true, files_matched: 0, ..Default::default() };
+        assert_eq!(classify(&d), SyncHealth::NoFiles);
+    }
+
+    #[test]
+    fn classify_format_drift_when_lines_seen_but_none_parse() {
+        let d = ReadDiagnostics {
+            root_exists: true,
+            files_matched: 2,
+            lines_seen: 5,
+            records_parsed: 0,
+            io_errors: 0,
+        };
+        assert_eq!(classify(&d), SyncHealth::FormatDrift);
+    }
+
+    #[test]
+    fn classify_healthy_on_tail_settle_reading_no_new_bytes() {
+        // The false-positive guard: an already-ingested transcript tail-read at
+        // EOF matches a file but reads no new lines — must not read as drift.
+        let d = ReadDiagnostics {
+            root_exists: true,
+            files_matched: 1,
+            lines_seen: 0,
+            records_parsed: 0,
+            io_errors: 0,
+        };
+        assert_eq!(classify(&d), SyncHealth::Healthy);
+    }
+
+    // ── SyncPoll health: classification waits for retry exhaustion ──
+
+    #[test]
+    fn sync_poll_flush_lag_zero_then_records_is_healthy() {
+        // A zero→nonzero flush-lag sequence: early empty reads must not classify
+        // (that would false-positive a slow flush as drift). Only the final
+        // pass's diagnostics count, and it carried records → Healthy.
+        let mut poll = SyncPoll::new(false);
+        assert_eq!(poll.observe(healthy(0)), PollControl::Continue);
+        assert_eq!(poll.observe(healthy(4)), PollControl::Stop);
+        assert_eq!(poll.health(), Some(SyncHealth::Healthy));
+    }
+
+    #[test]
+    fn sync_poll_persistent_drift_classifies_after_exhaustion() {
+        // Claude never ingests anything: every pass matches the file but parses
+        // nothing. After the loop exhausts, the last diagnostics → FormatDrift.
         let mut poll = SyncPoll::new(true);
-        for _ in 0..5 {
-            assert_eq!(poll.observe(Some(0)), PollControl::Continue);
+        for _ in 0..8 {
+            assert_eq!(poll.observe(drifted()), PollControl::Continue);
         }
         assert!(!poll.should_emit());
-        assert!(poll.reader_ingested_nothing());
+        assert_eq!(poll.health(), Some(SyncHealth::FormatDrift));
+    }
+
+    // ── real-reader drift, via env-injectable roots ──
+    // These exercise the actual vendor readers through the public
+    // `transcript_reader` dispatch, so the diagnostics + classification are
+    // validated end-to-end (not just over hand-built counters).
+
+    /// Run a vendor reader against a session id / cwd and classify the result.
+    fn read_and_classify(provider: &str, session_id: &str, cwd: &Path) -> (SyncHealth, ReadDiagnostics) {
+        let reader = crate::agent::transcript_reader(provider).expect("reader");
+        let mut diag = ReadDiagnostics::default();
+        let paths = (reader.locate)(session_id, cwd, &mut diag);
+        let _ = (reader.read)(&paths, &mut diag);
+        (classify(&diag), diag)
+    }
+
+    #[test]
+    fn codex_reader_drift_states_via_codex_home() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("CODEX_HOME", home.path());
+        let cwd = home.path(); // codex ignores cwd
+        let day = home.path().join("sessions/2024/01/02");
+
+        // (a) missing root → NoRoot (no `sessions` dir yet).
+        let (h, d) = read_and_classify("codex", "sid-a", cwd);
+        assert_eq!(h, SyncHealth::NoRoot, "diag={d:?}");
+        assert!(!d.root_exists);
+
+        // (b) root present, no matching rollout → NoFiles.
+        std::fs::create_dir_all(&day).unwrap();
+        let (h, d) = read_and_classify("codex", "sid-b", cwd);
+        assert_eq!(h, SyncHealth::NoFiles, "diag={d:?}");
+        assert!(d.root_exists && d.files_matched == 0);
+
+        // (c) matching rollout of pure garbage → FormatDrift, zero records.
+        let garbage = day.join("rollout-20240102T0000-sid-c.jsonl");
+        std::fs::write(&garbage, b"not json\nalso not json\n").unwrap();
+        let (h, d) = read_and_classify("codex", "sid-c", cwd);
+        assert_eq!(h, SyncHealth::FormatDrift, "diag={d:?}");
+        assert_eq!(d.files_matched, 1);
+        assert_eq!(d.records_parsed, 0);
+        assert!(d.lines_seen >= 2);
+
+        // (d) mixed file: good lines still ingested, skips counted.
+        let mixed = day.join("rollout-20240102T0001-sid-d.jsonl");
+        std::fs::write(&mixed, b"{\"a\":1}\ngarbage\n{\"b\":2}\n").unwrap();
+        let reader = crate::agent::transcript_reader("codex").unwrap();
+        let mut diag = ReadDiagnostics::default();
+        let paths = (reader.locate)("sid-d", cwd, &mut diag);
+        let recs = (reader.read)(&paths, &mut diag);
+        assert_eq!(recs.len(), 2, "the two valid lines are still returned");
+        assert_eq!(diag.records_parsed, 2);
+        assert_eq!(diag.lines_seen, 3, "the garbage line was seen but not parsed");
+        assert_eq!(classify(&diag), SyncHealth::Healthy);
+
+        std::env::remove_var("CODEX_HOME");
+    }
+
+    #[test]
+    fn claude_reader_drift_states_via_config_dir() {
+        // NoRoot is not asserted here: Claude falls back to `~/.claude/projects`,
+        // which exists on many dev machines, so a missing CLAUDE_CONFIG_DIR alone
+        // can't guarantee `!root_exists`. NoRoot is covered by the codex reader
+        // test and the pure classifier test.
+        let _guard = ENV_LOCK.lock().unwrap();
+        let cfg = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap(); // no docker per-agent dir under it
+        std::env::set_var("CLAUDE_CONFIG_DIR", cfg.path());
+        let projects = cfg.path().join("projects");
+        let slug = projects.join("-tmp-slug");
+        std::fs::create_dir_all(&slug).unwrap();
+
+        // (b) root present, session file absent → NoFiles (random uuid can't
+        // collide with a real file in the ~/.claude fallback).
+        let sid_b = "11111111-1111-4111-8111-111111111111";
+        let (h, d) = read_and_classify("claude", sid_b, cwd.path());
+        assert_eq!(h, SyncHealth::NoFiles, "diag={d:?}");
+        assert!(d.root_exists && d.files_matched == 0);
+
+        // (c) session file of garbage → FormatDrift.
+        let sid_c = "22222222-2222-4222-8222-222222222222";
+        std::fs::write(slug.join(format!("{sid_c}.jsonl")), b"{oops\nnope\n").unwrap();
+        let (h, d) = read_and_classify("claude", sid_c, cwd.path());
+        assert_eq!(h, SyncHealth::FormatDrift, "diag={d:?}");
+        assert_eq!(d.files_matched, 1);
+        assert_eq!(d.records_parsed, 0);
+
+        // (d) mixed file: valid records still ingested.
+        let sid_d = "33333333-3333-4333-8333-333333333333";
+        std::fs::write(
+            slug.join(format!("{sid_d}.jsonl")),
+            b"{\"uuid\":\"x\",\"type\":\"user\"}\ntorn{\n{\"uuid\":\"y\"}\n",
+        )
+        .unwrap();
+        let reader = crate::agent::transcript_reader("claude").unwrap();
+        let mut diag = ReadDiagnostics::default();
+        let paths = (reader.locate)(sid_d, cwd.path(), &mut diag);
+        let recs = (reader.read)(&paths, &mut diag);
+        assert_eq!(recs.len(), 2);
+        assert_eq!(diag.records_parsed, 2);
+        assert_eq!(diag.lines_seen, 3);
+        assert_eq!(classify(&diag), SyncHealth::Healthy);
+
+        std::env::remove_var("CLAUDE_CONFIG_DIR");
     }
 
     fn snapshot_repo() -> TrackedRepo {

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -62,7 +62,7 @@ impl Supervisor {
             }
             // Classify only now, after the retry loop is exhausted — earlier the
             // transcript may just be mid-flush, which must never read as drift.
-            if let Some(diag) = poll.last_diagnostics() {
+            if let Some(diag) = poll.turn_diagnostics() {
                 let provider = workspace
                     .agent(&agent_id)
                     .map(|r| r.provider)
@@ -422,9 +422,11 @@ struct SyncPoll {
     had_reader: bool,
     inserted: usize,
     stable_polls: u32,
-    /// Diagnostics from the most recent reader pass, classified only after the
-    /// retry loop exhausts — never mid-poll, so flush lag can't false-positive.
-    last_diag: Option<crate::agent::ReadDiagnostics>,
+    /// Diagnostics accumulated across every reader pass this turn, classified
+    /// only after the retry loop exhausts — never mid-poll, so flush lag can't
+    /// false-positive. Accumulated (not last-pass) so a clean settle read can't
+    /// erase an earlier pass's read errors and misreport the turn as Healthy.
+    turn_diag: Option<crate::agent::ReadDiagnostics>,
 }
 
 impl SyncPoll {
@@ -434,7 +436,7 @@ impl SyncPoll {
             had_reader: false,
             inserted: 0,
             stable_polls: 0,
-            last_diag: None,
+            turn_diag: None,
         }
     }
 
@@ -447,7 +449,10 @@ impl SyncPoll {
             return PollControl::Stop; // no reader — nothing to wait for
         };
         self.had_reader = true;
-        self.last_diag = Some(diagnostics);
+        match &mut self.turn_diag {
+            Some(acc) => acc.absorb(&diagnostics),
+            None => self.turn_diag = Some(diagnostics),
+        }
         if n == 0 {
             if self.inserted == 0 {
                 return PollControl::Continue; // not flushed yet — keep waiting
@@ -476,17 +481,18 @@ impl SyncPoll {
         self.inserted > 0
     }
 
-    /// The health of the final pass — `None` when there was no reader (nothing
+    /// The health of the whole turn — `None` when there was no reader (nothing
     /// to classify). Test-only convenience; production classifies via
-    /// [`last_diagnostics`](Self::last_diagnostics) so it can log the counters.
+    /// [`turn_diagnostics`](Self::turn_diagnostics) so it can log the counters.
     #[cfg(test)]
     fn health(&self) -> Option<SyncHealth> {
-        self.last_diag.as_ref().map(classify)
+        self.turn_diag.as_ref().map(classify)
     }
 
-    /// The final pass's diagnostics — `None` when there was no reader.
-    fn last_diagnostics(&self) -> Option<&crate::agent::ReadDiagnostics> {
-        self.last_diag.as_ref()
+    /// Diagnostics accumulated over the turn's passes — `None` when there was
+    /// no reader.
+    fn turn_diagnostics(&self) -> Option<&crate::agent::ReadDiagnostics> {
+        self.turn_diag.as_ref()
     }
 }
 
@@ -863,8 +869,8 @@ mod tests {
     #[test]
     fn sync_poll_flush_lag_zero_then_records_is_healthy() {
         // A zero→nonzero flush-lag sequence: early empty reads must not classify
-        // (that would false-positive a slow flush as drift). Only the final
-        // pass's diagnostics count, and it carried records → Healthy.
+        // (that would false-positive a slow flush as drift). The turn's
+        // accumulated diagnostics carried records → Healthy.
         let mut poll = SyncPoll::new(false);
         assert_eq!(poll.observe(healthy(0)), PollControl::Continue);
         assert_eq!(poll.observe(healthy(4)), PollControl::Stop);
@@ -874,13 +880,52 @@ mod tests {
     #[test]
     fn sync_poll_persistent_drift_classifies_after_exhaustion() {
         // Claude never ingests anything: every pass matches the file but parses
-        // nothing. After the loop exhausts, the last diagnostics → FormatDrift.
+        // nothing. After the loop exhausts, the turn diagnostics → FormatDrift.
         let mut poll = SyncPoll::new(true);
         for _ in 0..8 {
             assert_eq!(poll.observe(drifted()), PollControl::Continue);
         }
         assert!(!poll.should_emit());
         assert_eq!(poll.health(), Some(SyncHealth::FormatDrift));
+    }
+
+    #[test]
+    fn sync_poll_settle_reads_do_not_erase_an_earlier_read_error() {
+        // Persistent agent: the first pass ingests records but also hits a read
+        // error, then the file goes quiet and clean settle reads follow. The
+        // turn must classify PartialRead — a last-pass-wins diagnostic would let
+        // the clean settle read report Healthy and clear a real degraded state.
+        let partial = || {
+            Some(SyncOutcome {
+                inserted: 5,
+                diagnostics: ReadDiagnostics {
+                    root_exists: true,
+                    files_matched: 1,
+                    lines_seen: 5,
+                    records_parsed: 5,
+                    io_errors: 1,
+                },
+            })
+        };
+        // A genuinely empty settle read: tail at EOF, nothing seen, no errors.
+        let quiet = || {
+            Some(SyncOutcome {
+                inserted: 0,
+                diagnostics: ReadDiagnostics {
+                    root_exists: true,
+                    files_matched: 1,
+                    lines_seen: 0,
+                    records_parsed: 0,
+                    io_errors: 0,
+                },
+            })
+        };
+        let mut poll = SyncPoll::new(true);
+        assert_eq!(poll.observe(partial()), PollControl::Continue);
+        assert_eq!(poll.observe(quiet()), PollControl::Continue); // quiet 1
+        assert_eq!(poll.observe(quiet()), PollControl::Stop); // quiet 2 → settled
+        assert!(poll.should_emit());
+        assert_eq!(poll.health(), Some(SyncHealth::PartialRead));
     }
 
     // ── real-reader drift, via env-injectable roots ──

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -354,23 +354,23 @@ pub(crate) enum SyncHealth {
     /// Files matched but couldn't be opened or read (permissions, vanished
     /// mid-read) and nothing parsed — ingestion failed just as surely as drift.
     ReadError,
-    /// Records parsed, but the same pass also hit a read failure — the tail of
-    /// the transcript may be missing. Logged, never emitted, and never mutates
-    /// health state: records did flow (so no new banner), but a pass that
-    /// failed partway must not clear a real degraded status either.
+    /// Records parsed, but the turn also hit a read failure — the tail of the
+    /// transcript may be missing. Degraded: the parsed records are kept, but
+    /// the read failure surfaces like any other ingest failure.
     PartialRead,
 }
 
 impl SyncHealth {
-    /// The wire status for `session:sync-health`. `None` for `NoFiles` and
-    /// `PartialRead`, which are never emitted.
+    /// The wire status for `session:sync-health`. `None` for `NoFiles`, which
+    /// is never emitted.
     fn wire(self) -> Option<&'static str> {
         match self {
             SyncHealth::Healthy => Some("healthy"),
             SyncHealth::NoRoot => Some("no_root"),
             SyncHealth::FormatDrift => Some("format_drift"),
             SyncHealth::ReadError => Some("read_error"),
-            SyncHealth::NoFiles | SyncHealth::PartialRead => None,
+            SyncHealth::PartialRead => Some("partial_read"),
+            SyncHealth::NoFiles => None,
         }
     }
 }
@@ -536,10 +536,9 @@ fn report_sync_health(
 
     let mut map = health_map.lock();
     match health {
-        // Ambiguous (NoFiles) or partial (PartialRead) — logged above, but
-        // never emitted and never mutates state (so neither can clear a real
-        // degraded status).
-        SyncHealth::NoFiles | SyncHealth::PartialRead => {}
+        // Ambiguous — logged above, but never emitted and never mutates state
+        // (so it can't clear a real degraded status either).
+        SyncHealth::NoFiles => {}
         SyncHealth::Healthy => {
             if map.remove(agent_id).is_some() {
                 // Clearing a previously-degraded status.

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -67,7 +67,14 @@ impl Supervisor {
                     .agent(&agent_id)
                     .map(|r| r.provider)
                     .unwrap_or_default();
-                report_sync_health(&app, &health_map, &agent_id, &provider, classify(diag), diag);
+                report_sync_health(
+                    &app,
+                    &health_map,
+                    &agent_id,
+                    &provider,
+                    classify(diag),
+                    diag,
+                );
             }
         });
     }
@@ -432,7 +439,11 @@ impl SyncPoll {
     }
 
     fn observe(&mut self, result: Option<SyncOutcome>) -> PollControl {
-        let Some(SyncOutcome { inserted: n, diagnostics }) = result else {
+        let Some(SyncOutcome {
+            inserted: n,
+            diagnostics,
+        }) = result
+        else {
             return PollControl::Stop; // no reader — nothing to wait for
         };
         self.had_reader = true;
@@ -570,7 +581,10 @@ fn sync_session_records(workspace: &WorkspaceManager, agent_id: &str) -> Option<
     // `inserted == 0`, so the poll keeps retrying exactly as before.
     let pending = || SyncOutcome {
         inserted: 0,
-        diagnostics: crate::agent::ReadDiagnostics { root_exists: true, ..Default::default() },
+        diagnostics: crate::agent::ReadDiagnostics {
+            root_exists: true,
+            ..Default::default()
+        },
     };
 
     let Some(repo) = record.repos.first() else {
@@ -665,7 +679,10 @@ fn sync_session_records(workspace: &WorkspaceManager, agent_id: &str) -> Option<
         tracing::warn!(error = %e, agent_id, "associate user turns failed");
     }
 
-    Some(SyncOutcome { inserted, diagnostics })
+    Some(SyncOutcome {
+        inserted,
+        diagnostics,
+    })
 }
 
 #[cfg(test)]
@@ -767,13 +784,20 @@ mod tests {
 
     #[test]
     fn classify_no_root_when_root_missing() {
-        let d = ReadDiagnostics { root_exists: false, ..Default::default() };
+        let d = ReadDiagnostics {
+            root_exists: false,
+            ..Default::default()
+        };
         assert_eq!(classify(&d), SyncHealth::NoRoot);
     }
 
     #[test]
     fn classify_no_files_when_root_present_but_no_matches() {
-        let d = ReadDiagnostics { root_exists: true, files_matched: 0, ..Default::default() };
+        let d = ReadDiagnostics {
+            root_exists: true,
+            files_matched: 0,
+            ..Default::default()
+        };
         assert_eq!(classify(&d), SyncHealth::NoFiles);
     }
 
@@ -865,7 +889,11 @@ mod tests {
     // validated end-to-end (not just over hand-built counters).
 
     /// Run a vendor reader against a session id / cwd and classify the result.
-    fn read_and_classify(provider: &str, session_id: &str, cwd: &Path) -> (SyncHealth, ReadDiagnostics) {
+    fn read_and_classify(
+        provider: &str,
+        session_id: &str,
+        cwd: &Path,
+    ) -> (SyncHealth, ReadDiagnostics) {
         let reader = crate::agent::transcript_reader(provider).expect("reader");
         let mut diag = ReadDiagnostics::default();
         let paths = (reader.locate)(session_id, cwd, &mut diag);
@@ -910,7 +938,10 @@ mod tests {
         let recs = (reader.read)(&paths, &mut diag);
         assert_eq!(recs.len(), 2, "the two valid lines are still returned");
         assert_eq!(diag.records_parsed, 2);
-        assert_eq!(diag.lines_seen, 3, "the garbage line was seen but not parsed");
+        assert_eq!(
+            diag.lines_seen, 3,
+            "the garbage line was seen but not parsed"
+        );
         assert_eq!(classify(&diag), SyncHealth::Healthy);
 
         std::env::remove_var("CODEX_HOME");

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -347,18 +347,23 @@ pub(crate) enum SyncHealth {
     /// Files matched but couldn't be opened or read (permissions, vanished
     /// mid-read) and nothing parsed — ingestion failed just as surely as drift.
     ReadError,
+    /// Records parsed, but the same pass also hit a read failure — the tail of
+    /// the transcript may be missing. Logged, never emitted, and never mutates
+    /// health state: records did flow (so no new banner), but a pass that
+    /// failed partway must not clear a real degraded status either.
+    PartialRead,
 }
 
 impl SyncHealth {
-    /// The wire status for `session:sync-health`. `None` for `NoFiles`, which is
-    /// never emitted.
+    /// The wire status for `session:sync-health`. `None` for `NoFiles` and
+    /// `PartialRead`, which are never emitted.
     fn wire(self) -> Option<&'static str> {
         match self {
             SyncHealth::Healthy => Some("healthy"),
             SyncHealth::NoRoot => Some("no_root"),
             SyncHealth::FormatDrift => Some("format_drift"),
             SyncHealth::ReadError => Some("read_error"),
-            SyncHealth::NoFiles => None,
+            SyncHealth::NoFiles | SyncHealth::PartialRead => None,
         }
     }
 }
@@ -374,7 +379,11 @@ impl SyncHealth {
 /// that couldn't be read at all leaves `io_errors > 0`.
 fn classify(diag: &crate::agent::ReadDiagnostics) -> SyncHealth {
     if diag.records_parsed > 0 {
-        SyncHealth::Healthy
+        if diag.io_errors > 0 {
+            SyncHealth::PartialRead
+        } else {
+            SyncHealth::Healthy
+        }
     } else if !diag.root_exists {
         SyncHealth::NoRoot
     } else if diag.files_matched == 0 {
@@ -482,35 +491,38 @@ fn report_sync_health(
     health: SyncHealth,
     diag: &crate::agent::ReadDiagnostics,
 ) {
-    if !matches!(health, SyncHealth::Healthy) {
-        tracing::warn!(
-            agent_id,
-            provider,
-            ?health,
-            root_exists = diag.root_exists,
-            files_matched = diag.files_matched,
-            lines_seen = diag.lines_seen,
-            records_parsed = diag.records_parsed,
-            io_errors = diag.io_errors,
-            "session sync ingested 0 records after retries",
-        );
-    } else if diag.io_errors > 0 {
-        // Partial read: records flowed so this stays Healthy (no banner), but
-        // an unread tail shouldn't vanish without a trace.
-        tracing::warn!(
-            agent_id,
-            provider,
-            records_parsed = diag.records_parsed,
-            io_errors = diag.io_errors,
-            "session sync hit read errors after ingesting records — transcript tail may be missing",
-        );
+    match health {
+        SyncHealth::Healthy => {}
+        SyncHealth::PartialRead => {
+            tracing::warn!(
+                agent_id,
+                provider,
+                records_parsed = diag.records_parsed,
+                io_errors = diag.io_errors,
+                "session sync hit read errors after ingesting records — transcript tail may be missing",
+            );
+        }
+        _ => {
+            tracing::warn!(
+                agent_id,
+                provider,
+                ?health,
+                root_exists = diag.root_exists,
+                files_matched = diag.files_matched,
+                lines_seen = diag.lines_seen,
+                records_parsed = diag.records_parsed,
+                io_errors = diag.io_errors,
+                "session sync ingested 0 records after retries",
+            );
+        }
     }
 
     let mut map = health_map.lock();
     match health {
-        // Ambiguous — logged above, but never emitted and never mutates state
-        // (so it can't clear a real degraded status either).
-        SyncHealth::NoFiles => {}
+        // Ambiguous (NoFiles) or partial (PartialRead) — logged above, but
+        // never emitted and never mutates state (so neither can clear a real
+        // degraded status).
+        SyncHealth::NoFiles | SyncHealth::PartialRead => {}
         SyncHealth::Healthy => {
             if map.remove(agent_id).is_some() {
                 // Clearing a previously-degraded status.
@@ -778,11 +790,11 @@ mod tests {
     }
 
     #[test]
-    fn classify_healthy_on_partial_read_with_records() {
-        // A read that fails partway after ingesting records stays Healthy (no
-        // banner — records flowed, and the next sync re-attempts the tail via
-        // the persisted offset / idempotent dedup); the partial loss is
-        // warn-logged instead.
+    fn classify_partial_read_when_records_and_read_failure() {
+        // A read that fails partway after ingesting records is PartialRead:
+        // records flowed (so no new banner — the next sync re-attempts the
+        // tail via the persisted offset / idempotent dedup), but the pass
+        // still failed, so it must not clear a prior degraded status either.
         let d = ReadDiagnostics {
             root_exists: true,
             files_matched: 1,
@@ -790,7 +802,7 @@ mod tests {
             records_parsed: 3,
             io_errors: 1,
         };
-        assert_eq!(classify(&d), SyncHealth::Healthy);
+        assert_eq!(classify(&d), SyncHealth::PartialRead);
     }
 
     #[test]

--- a/src-tauri/src/transcripts.rs
+++ b/src-tauri/src/transcripts.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 
 use serde_json::Value;
 
-use crate::error::{Error, Result};
+use crate::agent::ReadDiagnostics;
 
 /// Directory (under an agent's writable root) that the Docker sandbox binds
 /// over the container's read-only `<config-dir>/projects`, so claude's session
@@ -28,13 +28,17 @@ pub(crate) const DOCKER_CLAUDE_PROJECTS_DIRNAME: &str = ".fletch-claude-projects
 /// its parent is the writable root that holds it. Seatbelt agents have no such
 /// dir (it won't exist and is skipped), so the scan falls through to the
 /// standard `~/.claude` / `CLAUDE_CONFIG_DIR` candidates.
-pub(crate) fn find_session_jsonl(session_id: &str, cwd: &Path) -> Option<PathBuf> {
+pub(crate) fn find_session_jsonl(
+    session_id: &str,
+    cwd: &Path,
+    diag: &mut ReadDiagnostics,
+) -> Option<PathBuf> {
     let mut dirs: Vec<PathBuf> = Vec::new();
     if let Some(parent) = cwd.parent() {
         dirs.push(parent.join(DOCKER_CLAUDE_PROJECTS_DIRNAME));
     }
     dirs.extend(claude_projects_dirs());
-    find_session_jsonl_in(&dirs, session_id)
+    find_session_jsonl_in(&dirs, session_id, diag)
 }
 
 /// Candidate `projects` directories Claude may have written transcripts to.
@@ -75,15 +79,23 @@ fn projects_dirs_from(config_dir: Option<PathBuf>, home: Option<PathBuf>) -> Vec
 /// Scan the given `projects` dirs for `<session-id>.jsonl`, returning the first
 /// match. A missing/unreadable candidate dir is skipped, not fatal, so a later
 /// candidate is still searched.
-fn find_session_jsonl_in(projects_dirs: &[PathBuf], session_id: &str) -> Option<PathBuf> {
+fn find_session_jsonl_in(
+    projects_dirs: &[PathBuf],
+    session_id: &str,
+    diag: &mut ReadDiagnostics,
+) -> Option<PathBuf> {
     let filename = format!("{session_id}.jsonl");
     for projects in projects_dirs {
         let Ok(entries) = std::fs::read_dir(projects) else {
             continue;
         };
+        // A readable `projects` candidate is a live Claude root — Claude's home
+        // hasn't moved out from under us (either of its two roots counts).
+        diag.root_exists = true;
         for entry in entries.flatten() {
             let path = entry.path().join(&filename);
             if path.exists() {
+                diag.files_matched += 1;
                 return Some(path);
             }
         }
@@ -96,7 +108,7 @@ fn find_session_jsonl_in(projects_dirs: &[PathBuf], session_id: &str) -> Option<
 /// at `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<id>.jsonl` (CODEX_HOME
 /// defaults to `~/.codex`); the id suffix is the thread id we captured. Resume
 /// normally keeps one file per session, but returning all is correct if it splits.
-pub(crate) fn find_codex_rollouts(session_id: &str) -> Vec<PathBuf> {
+pub(crate) fn find_codex_rollouts(session_id: &str, diag: &mut ReadDiagnostics) -> Vec<PathBuf> {
     let Some(home) = std::env::var_os("CODEX_HOME")
         .map(PathBuf::from)
         .or_else(|| dirs::home_dir().map(|h| h.join(".codex")))
@@ -118,6 +130,7 @@ pub(crate) fn find_codex_rollouts(session_id: &str) -> Vec<PathBuf> {
             .collect()
     }
     let sessions = home.join("sessions");
+    diag.root_exists = sessions.exists();
     let mut out = Vec::new();
     for year in dirs_in(&sessions) {
         for month in dirs_in(&year) {
@@ -136,26 +149,34 @@ pub(crate) fn find_codex_rollouts(session_id: &str) -> Vec<PathBuf> {
         }
     }
     out.sort();
+    diag.files_matched += out.len();
     out
 }
 
-/// Read a JSONL file into a vec of parsed values, skipping blank or
-/// unparseable lines.
-pub(crate) fn read_jsonl_values(path: &Path) -> Result<Vec<Value>> {
+/// Read a JSONL file into a vec of parsed values, skipping blank lines. A
+/// non-blank line that fails to parse is counted (`lines_seen`) but not
+/// returned, so `lines_seen > records_parsed` surfaces a format drift instead
+/// of silently vanishing; an unreadable file bumps `io_errors`. Infallible by
+/// design — every value that DID parse is still returned.
+pub(crate) fn read_jsonl_values(path: &Path, diag: &mut ReadDiagnostics) -> Vec<Value> {
     use std::io::BufRead;
-    let file =
-        std::fs::File::open(path).map_err(|e| Error::Other(format!("open transcript: {e}")))?;
+    let Ok(file) = std::fs::File::open(path) else {
+        diag.io_errors += 1;
+        return Vec::new();
+    };
     let reader = std::io::BufReader::new(file);
     let mut out = Vec::new();
     for line in reader.lines().map_while(std::result::Result::ok) {
         if line.trim().is_empty() {
             continue;
         }
+        diag.lines_seen += 1;
         if let Ok(v) = serde_json::from_str::<Value>(&line) {
+            diag.records_parsed += 1;
             out.push(v);
         }
     }
-    Ok(out)
+    out
 }
 
 #[cfg(test)]
@@ -210,7 +231,7 @@ mod tests {
         let jsonl = slug.join(format!("{sid}.jsonl"));
         std::fs::write(&jsonl, b"{}\n").unwrap();
 
-        let found = find_session_jsonl_in(&[projects], sid);
+        let found = find_session_jsonl_in(&[projects], sid, &mut ReadDiagnostics::default());
         assert_eq!(found.as_deref(), Some(jsonl.as_path()));
     }
 
@@ -227,7 +248,8 @@ mod tests {
         std::fs::write(&jsonl, b"{}\n").unwrap();
 
         let missing = cfg.path().join("does-not-exist");
-        let found = find_session_jsonl_in(&[missing, projects], sid);
+        let found =
+            find_session_jsonl_in(&[missing, projects], sid, &mut ReadDiagnostics::default());
         assert_eq!(found.as_deref(), Some(jsonl.as_path()));
     }
 
@@ -250,7 +272,7 @@ mod tests {
         let jsonl = slug.join(format!("{sid}.jsonl"));
         std::fs::write(&jsonl, b"{}\n").unwrap();
 
-        let found = find_session_jsonl(sid, &cwd);
+        let found = find_session_jsonl(sid, &cwd, &mut ReadDiagnostics::default());
         assert_eq!(found.as_deref(), Some(jsonl.as_path()));
     }
 }

--- a/src-tauri/src/transcripts.rs
+++ b/src-tauri/src/transcripts.rs
@@ -156,8 +156,9 @@ pub(crate) fn find_codex_rollouts(session_id: &str, diag: &mut ReadDiagnostics) 
 /// Read a JSONL file into a vec of parsed values, skipping blank lines. A
 /// non-blank line that fails to parse is counted (`lines_seen`) but not
 /// returned, so `lines_seen > records_parsed` surfaces a format drift instead
-/// of silently vanishing; an unreadable file bumps `io_errors`. Infallible by
-/// design — every value that DID parse is still returned.
+/// of silently vanishing; an unreadable file — or a read that fails partway
+/// through, leaving an unread tail — bumps `io_errors`. Infallible by design —
+/// every value that DID parse is still returned.
 pub(crate) fn read_jsonl_values(path: &Path, diag: &mut ReadDiagnostics) -> Vec<Value> {
     use std::io::BufRead;
     let Ok(file) = std::fs::File::open(path) else {
@@ -166,7 +167,16 @@ pub(crate) fn read_jsonl_values(path: &Path, diag: &mut ReadDiagnostics) -> Vec<
     };
     let reader = std::io::BufReader::new(file);
     let mut out = Vec::new();
-    for line in reader.lines().map_while(std::result::Result::ok) {
+    for line in reader.lines() {
+        let line = match line {
+            Ok(line) => line,
+            Err(_) => {
+                // Mid-stream read failure: the rest of the file is unreadable,
+                // so record it rather than letting the tail look ingested.
+                diag.io_errors += 1;
+                break;
+            }
+        };
         if line.trim().is_empty() {
             continue;
         }
@@ -274,5 +284,21 @@ mod tests {
 
         let found = find_session_jsonl(sid, &cwd, &mut ReadDiagnostics::default());
         assert_eq!(found.as_deref(), Some(jsonl.as_path()));
+    }
+
+    // ── read_jsonl_values: I/O failure accounting ──────────────────────────────
+
+    #[test]
+    fn read_jsonl_values_counts_read_failure_after_successful_open() {
+        // A directory opens fine on Unix but the first read fails (EISDIR) —
+        // the mid-stream `Err` arm must bump `io_errors` instead of the old
+        // `map_while(Result::ok)` silently stopping.
+        let td = tempfile::tempdir().unwrap();
+        let mut diag = ReadDiagnostics::default();
+        let out = read_jsonl_values(td.path(), &mut diag);
+        assert!(out.is_empty());
+        assert_eq!(diag.io_errors, 1);
+        assert_eq!(diag.lines_seen, 0);
+        assert_eq!(diag.records_parsed, 0);
     }
 }

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -1315,19 +1315,21 @@ impl WorkspaceManager {
             })?
             .collect::<std::result::Result<_, rusqlite::Error>>()?;
         rows.into_iter()
-            .map(|(workspace_id, turn_id, text, attachments_text, thinking)| {
-                let attachments = serde_json::from_str(&attachments_text)
-                    .map_err(|e| Error::Other(format!("deserialize attachments: {e}")))?;
-                Ok((
-                    workspace_id,
-                    crate::message_queue::PendingMsg {
-                        turn_id,
-                        text,
-                        attachments,
-                        thinking,
-                    },
-                ))
-            })
+            .map(
+                |(workspace_id, turn_id, text, attachments_text, thinking)| {
+                    let attachments = serde_json::from_str(&attachments_text)
+                        .map_err(|e| Error::Other(format!("deserialize attachments: {e}")))?;
+                    Ok((
+                        workspace_id,
+                        crate::message_queue::PendingMsg {
+                            turn_id,
+                            text,
+                            attachments,
+                            thinking,
+                        },
+                    ))
+                },
+            )
             .collect()
     }
 
@@ -2220,9 +2222,12 @@ mod tests {
         };
 
         // Enqueue three follow-ups; they read back for this workspace in seq order.
-        wm.enqueue_pending_message("yosemite", &pm("t1", "first")).unwrap();
-        wm.enqueue_pending_message("yosemite", &pm("t2", "second")).unwrap();
-        wm.enqueue_pending_message("yosemite", &pm("t3", "third")).unwrap();
+        wm.enqueue_pending_message("yosemite", &pm("t1", "first"))
+            .unwrap();
+        wm.enqueue_pending_message("yosemite", &pm("t2", "second"))
+            .unwrap();
+        wm.enqueue_pending_message("yosemite", &pm("t3", "third"))
+            .unwrap();
 
         let all = wm.read_all_pending_messages().unwrap();
         let ids: Vec<_> = all
@@ -2247,7 +2252,8 @@ mod tests {
         assert!(wm.read_all_pending_messages().unwrap().is_empty());
 
         // clear wipes whatever remains (teardown path).
-        wm.enqueue_pending_message("yosemite", &pm("t4", "again")).unwrap();
+        wm.enqueue_pending_message("yosemite", &pm("t4", "again"))
+            .unwrap();
         wm.clear_pending_messages("yosemite").unwrap();
         assert!(wm.read_all_pending_messages().unwrap().is_empty());
     }

--- a/src/api.ts
+++ b/src/api.ts
@@ -723,9 +723,15 @@ export function onSessionRecordsAppended(
 
 /** Degraded transcript-ingest status: the vendor CLI's home dir is gone
  *  (`no_root`), its files no longer parse (`format_drift`), or matched files
- *  couldn't be read at all (`read_error`). `healthy` is only ever sent to
- *  clear a prior degraded status. */
-export type SyncHealthStatus = "healthy" | "no_root" | "format_drift" | "read_error";
+ *  couldn't be read at all (`read_error`) or only partially (`partial_read`,
+ *  records ingested but the tail may be missing). `healthy` is only ever sent
+ *  to clear a prior degraded status. */
+export type SyncHealthStatus =
+  | "healthy"
+  | "no_root"
+  | "format_drift"
+  | "read_error"
+  | "partial_read";
 
 export interface SessionSyncHealthEvent {
   agent_id: string;

--- a/src/api.ts
+++ b/src/api.ts
@@ -721,6 +721,25 @@ export function onSessionRecordsAppended(
   );
 }
 
+/** Degraded transcript-ingest status: the vendor CLI's home dir is gone
+ *  (`no_root`) or its files no longer parse (`format_drift`). `healthy` is only
+ *  ever sent to clear a prior degraded status. */
+export type SyncHealthStatus = "healthy" | "no_root" | "format_drift";
+
+export interface SessionSyncHealthEvent {
+  agent_id: string;
+  provider: string;
+  status: SyncHealthStatus;
+  /** Current CLI version (for display/logging only), or null if unprobed. */
+  version: string | null;
+}
+
+/** Fires when an agent's turn-end transcript ingest changes health — drift
+ *  detected, or a prior drift cleared. Emitted on change only. */
+export function onSessionSyncHealth(cb: (e: SessionSyncHealthEvent) => void): Promise<UnlistenFn> {
+  return listen<SessionSyncHealthEvent>("session:sync-health", (event) => cb(event.payload));
+}
+
 export interface TurnStartedEvent {
   agent_id: string;
   /** Backend epoch millis the turn began — the live-timer anchor. */

--- a/src/api.ts
+++ b/src/api.ts
@@ -722,9 +722,10 @@ export function onSessionRecordsAppended(
 }
 
 /** Degraded transcript-ingest status: the vendor CLI's home dir is gone
- *  (`no_root`) or its files no longer parse (`format_drift`). `healthy` is only
- *  ever sent to clear a prior degraded status. */
-export type SyncHealthStatus = "healthy" | "no_root" | "format_drift";
+ *  (`no_root`), its files no longer parse (`format_drift`), or matched files
+ *  couldn't be read at all (`read_error`). `healthy` is only ever sent to
+ *  clear a prior degraded status. */
+export type SyncHealthStatus = "healthy" | "no_root" | "format_drift" | "read_error";
 
 export interface SessionSyncHealthEvent {
   agent_id: string;

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -161,8 +161,9 @@ function CrashBanner({ agent }: { agent: AgentRecord }) {
 }
 
 /** Non-blocking notice that this session's on-disk transcript couldn't be read
- *  at turn-end — the vendor CLI moved its files (`no_root`) or reshaped them
- *  (`format_drift`), so newly-written history may not persist. Worded as
+ *  at turn-end — the vendor CLI moved its files (`no_root`), reshaped them
+ *  (`format_drift`), or they were unreadable (`read_error`), so
+ *  newly-written history may not persist. Worded as
  *  degraded, not broken: the app still renders the turn from its live-compiled
  *  stream. Only present while the store holds a degraded status for the agent
  *  (cleared by a `healthy` sync-health event). */

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -3,6 +3,7 @@ import type { AgentRecord } from "@/api";
 import { Icon } from "@/components/Icon";
 import { Button } from "@/components/ui/Button";
 import { IconButton } from "@/components/ui/IconButton";
+import { providerLabel } from "@/data/providers";
 import { EMPTY_AGENTS, useAppStore } from "@/store";
 import { ChatView } from "./ChatView";
 import { EmptyWorkspace } from "./EmptyWorkspace";
@@ -54,6 +55,7 @@ export function Workspace() {
     <div className="pane center fade-in" key={agent.id}>
       <WorkspaceHeader agent={agent} />
       {agent.status === "error" && <CrashBanner agent={agent} />}
+      <SyncHealthBanner agentId={agent.id} />
       {agent.view === "native" ? <NativeBody agent={agent} /> : <ChatView agent={agent} />}
     </div>
   );
@@ -154,6 +156,29 @@ function CrashBanner({ agent }: { agent: AgentRecord }) {
         <Icon name="play" size={12} />
         {resuming ? "Resuming…" : "Resume"}
       </Button>
+    </div>
+  );
+}
+
+/** Non-blocking notice that this session's on-disk transcript couldn't be read
+ *  at turn-end — the vendor CLI moved its files (`no_root`) or reshaped them
+ *  (`format_drift`), so newly-written history may not persist. Worded as
+ *  degraded, not broken: the app still renders the turn from its live-compiled
+ *  stream. Only present while the store holds a degraded status for the agent
+ *  (cleared by a `healthy` sync-health event). */
+function SyncHealthBanner({ agentId }: { agentId: string }) {
+  const health = useAppStore((s) => s.syncHealth[agentId]);
+  if (!health) return null;
+  const provider = providerLabel(health.provider);
+  return (
+    <div className="drift-banner flex-center" role="status">
+      <div className="crash-text">
+        <span className="drift-title">Couldn't read chat history</span>
+        <span className="crash-detail">
+          Fletch couldn't read this session's history from the {provider} CLI — new history for this
+          session may not be saved. The conversation you see is still up to date.
+        </span>
+      </div>
     </div>
   );
 }

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -162,22 +162,26 @@ function CrashBanner({ agent }: { agent: AgentRecord }) {
 
 /** Non-blocking notice that this session's on-disk transcript couldn't be read
  *  at turn-end — the vendor CLI moved its files (`no_root`), reshaped them
- *  (`format_drift`), or they were unreadable (`read_error`), so
- *  newly-written history may not persist. Worded as
- *  degraded, not broken: the app still renders the turn from its live-compiled
- *  stream. Only present while the store holds a degraded status for the agent
- *  (cleared by a `healthy` sync-health event). */
+ *  (`format_drift`), they were unreadable (`read_error`), or a read failed
+ *  partway so the tail may be missing (`partial_read`) — newly-written history
+ *  may not persist. Worded as degraded, not broken: the app still renders the
+ *  turn from its live-compiled stream. Only present while the store holds a
+ *  degraded status for the agent (cleared by a `healthy` sync-health event). */
 function SyncHealthBanner({ agentId }: { agentId: string }) {
   const health = useAppStore((s) => s.syncHealth[agentId]);
   if (!health) return null;
   const provider = providerLabel(health.provider);
+  const partial = health.status === "partial_read";
   return (
     <div className="drift-banner flex-center" role="status">
       <div className="crash-text">
-        <span className="drift-title">Couldn't read chat history</span>
+        <span className="drift-title">
+          {partial ? "Couldn't read some chat history" : "Couldn't read chat history"}
+        </span>
         <span className="crash-detail">
-          Fletch couldn't read this session's history from the {provider} CLI — new history for this
-          session may not be saved. The conversation you see is still up to date.
+          {partial
+            ? `Fletch could only read part of this session's history from the ${provider} CLI — some new history may not be saved. The conversation you see is still up to date.`
+            : `Fletch couldn't read this session's history from the ${provider} CLI — new history for this session may not be saved. The conversation you see is still up to date.`}
         </span>
       </div>
     </div>

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -16,6 +16,7 @@ import {
   onRunPort,
   onRunState,
   onSessionRecordsAppended,
+  onSessionSyncHealth,
   onShellOutput,
   onTurnStarted,
   onWorkspaceChanged,
@@ -280,6 +281,26 @@ const registerEventListeners = async (set: AppSet, get: AppGet) => {
         // Non-critical refresh; the next load picks up the records.
       }
     })();
+  });
+
+  // Transcript-ingest health changed for an agent. A degraded status
+  // (no_root / format_drift) is stored per-agent and surfaced as a
+  // non-blocking banner in the chat view; `healthy` clears it (deletes the
+  // key, mirroring how `unseenResults` treats an absent key as the good state).
+  await onSessionSyncHealth((e) => {
+    set((state) => {
+      const syncHealth = { ...state.syncHealth };
+      if (e.status === "healthy") {
+        delete syncHealth[e.agent_id];
+      } else {
+        syncHealth[e.agent_id] = {
+          status: e.status,
+          provider: e.provider,
+          version: e.version,
+        };
+      }
+      return { syncHealth };
+    });
   });
 
   await onAgentBranch((e) => {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -31,6 +31,15 @@ import type {
 } from "@/storage/preferences";
 import type { DraftAgent } from "./drafts";
 
+/** A degraded transcript-ingest state stored per agent (the `healthy` status is
+ *  never stored — it deletes the key). `provider`/`version` are for the banner
+ *  copy; `status` picks the message. */
+export interface SyncHealthInfo {
+  status: "no_root" | "format_drift";
+  provider: string;
+  version: string | null;
+}
+
 export interface AppSlice {
   busy: boolean;
   lastError: string | null;
@@ -96,6 +105,11 @@ export interface WorkspaceSlice {
    *  non-selected agent (covers research-only turns with no diff), cleared
    *  when the agent is selected. */
   unseenResults: Record<string, boolean>;
+  /** Degraded transcript-ingest health per agent, keyed by agent_id, from the
+   *  `session:sync-health` event. Absent = healthy (the common case): a `healthy`
+   *  event deletes the key. Present = the vendor CLI drifted, so the chat view
+   *  shows a non-blocking "couldn't read history" banner. In-memory only. */
+  syncHealth: Record<string, SyncHealthInfo>;
   /** Per-agent cumulative token usage (and latest context-window fill),
    *  folded from session_records at turn-end and on transcript load. Keyed by
    *  agent_id; absent until the agent's first turn lands. Empty for agents that

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -35,7 +35,7 @@ import type { DraftAgent } from "./drafts";
  *  never stored — it deletes the key). `provider`/`version` are for the banner
  *  copy; `status` picks the message. */
 export interface SyncHealthInfo {
-  status: "no_root" | "format_drift";
+  status: "no_root" | "format_drift" | "read_error";
   provider: string;
   version: string | null;
 }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -35,7 +35,7 @@ import type { DraftAgent } from "./drafts";
  *  never stored — it deletes the key). `provider`/`version` are for the banner
  *  copy; `status` picks the message. */
 export interface SyncHealthInfo {
-  status: "no_root" | "format_drift" | "read_error";
+  status: "no_root" | "format_drift" | "read_error" | "partial_read";
   provider: string;
   version: string | null;
 }

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -36,6 +36,7 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
   managedBusyLabel: {},
   switchInFlight: {},
   unseenResults: {},
+  syncHealth: {},
   usage: {},
   runPhases: {},
   runPorts: {},

--- a/src/styles/shared/banners.css
+++ b/src/styles/shared/banners.css
@@ -72,6 +72,23 @@
   flex-shrink: 0;
 }
 
+/* Inline per-agent transcript-drift notice under the workspace header. Same
+   layout as .crash-banner but a softer warn tint — history ingestion degraded,
+   not the agent crashing (the app still has its live-compiled fallback). */
+.drift-banner {
+  gap: 12px;
+  margin: 8px 12px 0;
+  padding: 8px 10px 8px 12px;
+  background: color-mix(in srgb, var(--warn), var(--bg-0) 86%);
+  border: 1px solid color-mix(in srgb, var(--warn), var(--bg-0) 70%);
+  border-radius: var(--r-md);
+  font-size: var(--fs-base);
+}
+.drift-title {
+  color: var(--warn);
+  font-weight: 600;
+}
+
 /* update-ready toast — bottom-right, offers restart now / skip */
 .update-toast {
   position: fixed;


### PR DESCRIPTION
## Summary

Transcript ingestion tracks six undocumented vendor CLI on-disk layouts (claude, codex, cursor-agent, opencode, pi, antigravity), and until now every failure mode collapsed into an empty read: a moved root dir, renamed files, or a reshaped JSON format all yielded zero records with only a `tracing::warn` — chat history silently stopped persisting with no user signal.

This PR makes the ingest pipeline report *which assumption broke* and surfaces a visible "couldn't read history" signal.

## Changes

**Backend**
- New `ReadDiagnostics` counters (`root_exists`, `files_matched`, `lines_seen`, `records_parsed`, `io_errors`) threaded through all six vendor `locate`/`read` paths and the shared JSONL helpers, replacing the silent `unwrap_or_default()`/skip sites. Readers stay infallible and still return every record that parsed — partial drift never drops good records.
- A pure `classify()` in `session_sync.rs` maps diagnostics to Healthy / NoRoot / NoFiles / FormatDrift, evaluated only after the sync retry loop exhausts so flush lag can never false-positive. FormatDrift additionally requires `lines_seen > 0`, since an incremental tail settle read legitimately parses nothing.
- New `session:sync-health` event emitted on status *change* only (a persistent drift doesn't fire per turn); `healthy` is emitted solely to clear a prior degraded state. NoFiles is ambiguous (slow flush / empty session) and stays log-only — the warn now includes full counters.

**Frontend**
- `onSessionSyncHealth` listener, per-agent `syncHealth` store entry (cleared on healthy), and an inline warn-tinted banner in the Workspace view following the existing `CrashBanner` idiom: "Couldn't read chat history from the <provider> CLI — history for this session may not persist."

## Non-goals (deliberate)

No layout-version numbers or fingerprinting, no auto-adapting parsers, no DB persistence of health state, no telemetry — this PR only makes the failure visible and precise.

## Testing

- Classifier unit tests for all four states.
- Real-reader drift tests against temp roots via `CODEX_HOME` (NoRoot / NoFiles / FormatDrift / mixed good+garbage lines) and `CLAUDE_CONFIG_DIR` (NoFiles / FormatDrift / mixed).
- SyncPoll tests confirming no degraded classification mid-poll during normal flush lag.
- `cargo test`: 547 passed. Frontend: 374 tests passed, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)