### PR TITLE
feat: persist follow-up message queue across restarts

### DIFF
--- a/src-tauri/migrations/0016_pending_messages.sql
+++ b/src-tauri/migrations/0016_pending_messages.sql
@@ -1,0 +1,26 @@
+-- Durable mirror of the in-memory follow-up queue (see `message_queue.rs`).
+--
+-- Follow-ups the user sends while a turn is in flight are held in an in-memory
+-- per-agent VecDeque and, before this table, were lost if the app exited
+-- mid-turn. Each row is one queued message for the workspace's current session,
+-- written on enqueue and deleted once the coalesced batch is delivered as a turn
+-- (or the agent is archived/discarded). On startup the in-memory queue is
+-- rehydrated from here, so a follow-up survives a crash/restart and flushes on
+-- the user's next interaction.
+--
+-- Keyed to `session_id` (like `session_user_turns`), so the FK cascade drops the
+-- rows when the session — and, transitively, the workspace — is deleted.
+-- `attachments` is a JSON array of file paths; `thinking` is the optional
+-- thinking-effort tag that rides along to delivery.
+CREATE TABLE pending_messages (
+    id          INTEGER PRIMARY KEY,
+    session_id  TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    seq         INTEGER NOT NULL,          -- per-session monotonic enqueue order
+    turn_id     TEXT NOT NULL,             -- frontend-generated uuid for this message
+    text        TEXT NOT NULL,
+    attachments TEXT NOT NULL,             -- JSON array of attachment paths
+    thinking    TEXT,                      -- optional thinking-effort tag
+    created_at  INTEGER NOT NULL,
+    UNIQUE(session_id, seq)
+);
+CREATE INDEX idx_pending_messages_session ON pending_messages(session_id);

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -125,6 +125,7 @@ const MIGRATIONS: &[&str] = &[
     include_str!("../migrations/0013_workspace_sandbox_engine.sql"),
     include_str!("../migrations/0014_pr_times_and_usage_daily.sql"),
     include_str!("../migrations/0015_worktree_pr_snapshot.sql"),
+    include_str!("../migrations/0016_pending_messages.sql"),
 ];
 
 fn get_migrations() -> Migrations<'static> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1034,6 +1034,10 @@ pub fn run() {
             let workspace = Arc::new(WorkspaceManager::new(db));
             let supervisor = Arc::new(Supervisor::new(workspace));
             app.manage(supervisor.clone());
+            // Reload follow-ups that were queued behind an in-flight turn when a
+            // prior run exited, so a mid-turn message survives a restart. They
+            // rest in the queue and flush on the user's next send (no auto-spawn).
+            supervisor.rehydrate_pending_messages();
             // At most one `claude setup-token` capture runs at a time; the
             // code-submit / cancel commands reach it through this slot.
             app.manage(ClaudeSetupState::default());

--- a/src-tauri/src/message_queue.rs
+++ b/src-tauri/src/message_queue.rs
@@ -130,6 +130,17 @@ impl MessageQueue {
         self.by_agent.get(agent_id).map_or(0, VecDeque::len)
     }
 
+    /// The `turn_id`s currently queued for an agent, in FIFO order. Used by the
+    /// durable mirror: after a flush delivers, the supervisor deletes every
+    /// persisted row *except* these, so a follow-up that arrived during the
+    /// delivery window (still queued here) keeps its row (see
+    /// `WorkspaceManager::delete_pending_messages_except`).
+    pub fn turn_ids(&self, agent_id: &str) -> Vec<String> {
+        self.by_agent.get(agent_id).map_or_else(Vec::new, |q| {
+            q.iter().map(|m| m.turn_id.clone()).collect()
+        })
+    }
+
     /// Remove and return all queued messages for an agent, coalesced into a
     /// single [`PendingMsg`]. `None` if nothing was queued.
     pub fn drain_coalesced(&mut self, agent_id: &str) -> Option<PendingMsg> {
@@ -253,6 +264,18 @@ mod tests {
         assert_eq!(q.len("a"), 2);
         // isolation between agents
         assert!(q.is_empty("b"));
+    }
+
+    #[test]
+    fn turn_ids_lists_queued_in_fifo_order() {
+        let mut q = MessageQueue::new();
+        assert!(q.turn_ids("a").is_empty());
+        q.enqueue("a", msg("t1", "hi", &[], None));
+        q.enqueue("a", msg("t2", "there", &[], None));
+        assert_eq!(q.turn_ids("a"), vec!["t1".to_string(), "t2".to_string()]);
+        // Draining empties it; the persisted-row cleanup then keeps nothing.
+        q.drain_coalesced("a");
+        assert!(q.turn_ids("a").is_empty());
     }
 
     #[test]

--- a/src-tauri/src/supervisor/disposition.rs
+++ b/src-tauri/src/supervisor/disposition.rs
@@ -256,12 +256,22 @@ impl Supervisor {
         self.activities.lock().remove(agent_id);
         self.statuses.lock().remove(agent_id);
         self.native_inputs.lock().remove(agent_id);
-        self.message_queue.lock().clear(agent_id);
-        // Drop the durable mirror too, so an archived agent's queue can't be
-        // rehydrated on the next launch. (Discard also cascades via the FK when
-        // the workspace row is removed; this covers archive, which keeps it.)
-        if let Err(e) = self.workspace.clear_pending_messages(agent_id) {
-            tracing::warn!(error = %e, agent_id, "clear persisted pending follow-ups failed");
+        // Clear the in-memory queue and its durable mirror under one hold of
+        // the queue lock. Dropping the mirror stops an archived agent's queue
+        // from rehydrating on the next launch (discard also cascades via the FK
+        // when the workspace row is removed; this covers archive, which keeps
+        // it). Holding the lock across both clears means a concurrent
+        // `persist_and_enqueue` — which writes its row and queue entry under the
+        // same lock — is fully ordered before or after this teardown, so it
+        // can't slip a new row in between the two clears only to have it deleted
+        // with no in-memory entry left to deliver it. Lock order stays queue →
+        // db (see `messaging::Supervisor::persist_and_enqueue`).
+        {
+            let mut queue = self.message_queue.lock();
+            queue.clear(agent_id);
+            if let Err(e) = self.workspace.clear_pending_messages(agent_id) {
+                tracing::warn!(error = %e, agent_id, "clear persisted pending follow-ups failed");
+            }
         }
         self.interrupted.lock().remove(agent_id);
         self.shells.lock().remove(agent_id);

--- a/src-tauri/src/supervisor/disposition.rs
+++ b/src-tauri/src/supervisor/disposition.rs
@@ -257,6 +257,12 @@ impl Supervisor {
         self.statuses.lock().remove(agent_id);
         self.native_inputs.lock().remove(agent_id);
         self.message_queue.lock().clear(agent_id);
+        // Drop the durable mirror too, so an archived agent's queue can't be
+        // rehydrated on the next launch. (Discard also cascades via the FK when
+        // the workspace row is removed; this covers archive, which keeps it.)
+        if let Err(e) = self.workspace.clear_pending_messages(agent_id) {
+            tracing::warn!(error = %e, agent_id, "clear persisted pending follow-ups failed");
+        }
         self.interrupted.lock().remove(agent_id);
         self.shells.lock().remove(agent_id);
         if let Some(run) = self.runs.lock().remove(agent_id) {

--- a/src-tauri/src/supervisor/messaging.rs
+++ b/src-tauri/src/supervisor/messaging.rs
@@ -62,7 +62,7 @@ impl Supervisor {
                 false
             }
             Delivery::FlushNow => {
-                self.message_queue.lock().enqueue(agent_id, msg);
+                self.persist_and_enqueue(agent_id, msg);
                 flush_queued(&self, app, agent_id)?
             }
             Delivery::WriteLive => {
@@ -74,14 +74,14 @@ impl Supervisor {
                     // bare re-enqueue would strand the follow-up until the next
                     // user message (CQ3-A).
                     tracing::warn!(error = %e, agent_id, "live inject failed; delivering as a new turn");
-                    self.message_queue.lock().enqueue(agent_id, msg);
+                    self.persist_and_enqueue(agent_id, msg);
                     flush_queued(&self, app, agent_id)?
                 } else {
                     false
                 }
             }
             Delivery::Enqueue => {
-                self.message_queue.lock().enqueue(agent_id, msg);
+                self.persist_and_enqueue(agent_id, msg);
                 // Same TOCTOU as WriteLive's fallback (CQ3-B): the turn may
                 // have ended between the busy check above and this enqueue, so
                 // the turn-end Idle drain already ran against an empty queue.
@@ -167,6 +167,42 @@ impl Supervisor {
     ) -> Result<()> {
         let agent = self.live_agent(agent_id)?;
         agent.answer_tool_use(request_id, updated_input, behavior, message)
+    }
+
+    /// Enqueue a follow-up both in memory (the live queue) and in the durable
+    /// mirror, so it survives a crash/restart. The persist is best-effort: a DB
+    /// hiccup is logged but never blocks the in-memory delivery, which is the
+    /// hot path. The persisted row is dropped once the message is delivered
+    /// (see `flush_queued`) or the agent is torn down (see `detach_runtime`).
+    fn persist_and_enqueue(&self, agent_id: &str, msg: PendingMsg) {
+        if let Err(e) = self.workspace.enqueue_pending_message(agent_id, &msg) {
+            tracing::warn!(error = %e, agent_id, "persist queued follow-up failed");
+        }
+        self.message_queue.lock().enqueue(agent_id, msg);
+    }
+
+    /// Reload queued follow-ups persisted by a previous run into the live
+    /// in-memory queue. Called once at startup, before any send. Rehydrated
+    /// messages sit idle until the user's next interaction, which routes through
+    /// `Delivery::FlushNow` and delivers them coalesced (the existing
+    /// idle-with-leftovers path) — no process is auto-spawned here.
+    pub fn rehydrate_pending_messages(&self) {
+        let pending = match self.workspace.read_all_pending_messages() {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(error = %e, "rehydrate queued follow-ups failed");
+                return;
+            }
+        };
+        if pending.is_empty() {
+            return;
+        }
+        let count = pending.len();
+        let mut queue = self.message_queue.lock();
+        for (agent_id, msg) in pending {
+            queue.enqueue(&agent_id, msg);
+        }
+        tracing::info!(count, "rehydrated queued follow-up messages from a prior run");
     }
 }
 
@@ -277,9 +313,20 @@ pub(super) fn flush_queued(sup: &Arc<Supervisor>, app: &AppHandle, agent_id: &st
         // Delivery raced with teardown/respawn (e.g. AgentNotFound). Put the
         // follow-ups back rather than dropping them; a later boundary or the
         // post-respawn flush retries. Re-queue at the front to preserve order.
+        // The persisted rows are left intact (we only clear on success), so the
+        // retry — or a restart before it — still has them.
         tracing::warn!(error = %e, agent_id, "flush delivery failed; re-queueing follow-ups");
         sup.message_queue.lock().requeue_front(agent_id, coalesced);
         return Ok(true);
+    }
+    // Delivered as a turn (now durable in `session_user_turns`), so drop the
+    // pending rows we just delivered. Keep only what is still queued in memory
+    // — a follow-up that arrived during the delivery window — so it survives to
+    // its own flush. This also clears any rows coalesced away by a prior failed
+    // flush, leaving no orphans behind.
+    let keep = sup.message_queue.lock().turn_ids(agent_id);
+    if let Err(e) = sup.workspace.delete_pending_messages_except(agent_id, &keep) {
+        tracing::warn!(error = %e, agent_id, "clear delivered pending follow-ups failed");
     }
     Ok(false)
 }

--- a/src-tauri/src/supervisor/messaging.rs
+++ b/src-tauri/src/supervisor/messaging.rs
@@ -174,11 +174,21 @@ impl Supervisor {
     /// hiccup is logged but never blocks the in-memory delivery, which is the
     /// hot path. The persisted row is dropped once the message is delivered
     /// (see `flush_queued`) or the agent is torn down (see `detach_runtime`).
+    ///
+    /// The DB write and the in-memory enqueue are done under one hold of the
+    /// queue lock so they land as a unit. Otherwise a concurrent
+    /// `flush_queued` cleanup could observe the persisted row (written first)
+    /// but not yet the queue entry, and its delete-except-still-queued pass
+    /// would delete the row — losing the message on a restart before delivery.
+    /// Lock order is always queue → db (`WorkspaceManager` only ever takes the
+    /// db lock and never calls back into the queue), so nesting the db lock
+    /// under the queue lock here cannot deadlock.
     fn persist_and_enqueue(&self, agent_id: &str, msg: PendingMsg) {
+        let mut queue = self.message_queue.lock();
         if let Err(e) = self.workspace.enqueue_pending_message(agent_id, &msg) {
             tracing::warn!(error = %e, agent_id, "persist queued follow-up failed");
         }
-        self.message_queue.lock().enqueue(agent_id, msg);
+        queue.enqueue(agent_id, msg);
     }
 
     /// Reload queued follow-ups persisted by a previous run into the live
@@ -324,9 +334,19 @@ pub(super) fn flush_queued(sup: &Arc<Supervisor>, app: &AppHandle, agent_id: &st
     // — a follow-up that arrived during the delivery window — so it survives to
     // its own flush. This also clears any rows coalesced away by a prior failed
     // flush, leaving no orphans behind.
-    let keep = sup.message_queue.lock().turn_ids(agent_id);
-    if let Err(e) = sup.workspace.delete_pending_messages_except(agent_id, &keep) {
-        tracing::warn!(error = %e, agent_id, "clear delivered pending follow-ups failed");
+    //
+    // Snapshot `keep` and run the delete under a single hold of the queue lock,
+    // so a concurrent `persist_and_enqueue` (which writes its row and queue
+    // entry under the same lock) is fully ordered before or after this pass —
+    // never half-visible. Without the shared lock, a row written but not yet
+    // queued would be absent from `keep` and wrongly deleted. Lock order is
+    // queue → db throughout (see `persist_and_enqueue`), so this can't deadlock.
+    {
+        let queue = sup.message_queue.lock();
+        let keep = queue.turn_ids(agent_id);
+        if let Err(e) = sup.workspace.delete_pending_messages_except(agent_id, &keep) {
+            tracing::warn!(error = %e, agent_id, "clear delivered pending follow-ups failed");
+        }
     }
     Ok(false)
 }

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -1196,6 +1196,137 @@ impl WorkspaceManager {
             .collect()
     }
 
+    // ── Queued follow-up messages (pending_messages) ─────────────────────
+    // Durable mirror of the in-memory `MessageQueue` (see `message_queue`), so
+    // follow-ups enqueued behind an in-flight turn survive an app restart.
+    // Rows are written on enqueue and dropped once the coalesced batch is
+    // delivered (or the agent is torn down). Unlike `session_user_turns` these
+    // are *un-delivered* messages: once delivered they become a normal turn and
+    // their pending row is deleted.
+
+    /// Persist one queued follow-up for the workspace's current session, at the
+    /// next enqueue seq. Best-effort no-op (`Ok`) when the workspace has no
+    /// session yet — a follow-up is only ever queued behind a live turn, which
+    /// implies a session, so that case is defensive.
+    pub fn enqueue_pending_message(
+        &self,
+        workspace_id: &str,
+        msg: &crate::message_queue::PendingMsg,
+    ) -> Result<()> {
+        let conn = self.db.lock();
+        let Some(sid) = current_session_id(&conn, workspace_id) else {
+            return Ok(());
+        };
+        let attachments_json = serde_json::to_string(&msg.attachments)
+            .map_err(|e| Error::Other(format!("serialize attachments: {e}")))?;
+        let tx = conn.unchecked_transaction()?;
+        let seq: i64 = tx.query_row(
+            "SELECT COALESCE(MAX(seq), 0) + 1 FROM pending_messages WHERE session_id = ?1",
+            [&sid],
+            |r| r.get(0),
+        )?;
+        tx.execute(
+            "INSERT INTO pending_messages
+                (session_id, seq, turn_id, text, attachments, thinking, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            rusqlite::params![
+                sid,
+                seq,
+                msg.turn_id,
+                msg.text,
+                attachments_json,
+                msg.thinking,
+                now_millis()
+            ],
+        )?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Drop the persisted follow-ups for the workspace's current session that
+    /// were just delivered, keeping only the `keep` ids. Called after a flush:
+    /// `keep` is whatever is still queued in memory (a follow-up that arrived
+    /// during the delivery window), so its row survives while the delivered
+    /// batch — including any coalesced-away rows from a prior failed flush — is
+    /// cleared. `keep` empty ⇒ clear the whole session's queue.
+    pub fn delete_pending_messages_except(
+        &self,
+        workspace_id: &str,
+        keep: &[String],
+    ) -> Result<()> {
+        let conn = self.db.lock();
+        let Some(sid) = current_session_id(&conn, workspace_id) else {
+            return Ok(());
+        };
+        if keep.is_empty() {
+            conn.execute("DELETE FROM pending_messages WHERE session_id = ?1", [&sid])?;
+            return Ok(());
+        }
+        let placeholders = std::iter::repeat("?")
+            .take(keep.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "DELETE FROM pending_messages WHERE session_id = ? AND turn_id NOT IN ({placeholders})"
+        );
+        let mut binds: Vec<&str> = Vec::with_capacity(keep.len() + 1);
+        binds.push(sid.as_str());
+        binds.extend(keep.iter().map(String::as_str));
+        conn.execute(&sql, rusqlite::params_from_iter(binds))?;
+        Ok(())
+    }
+
+    /// Drop every persisted follow-up for the workspace's current session
+    /// (archive / discard teardown). Discard removes the workspace row and the
+    /// FK cascade handles it too; archive keeps the row, so this clears it.
+    pub fn clear_pending_messages(&self, workspace_id: &str) -> Result<()> {
+        let conn = self.db.lock();
+        let Some(sid) = current_session_id(&conn, workspace_id) else {
+            return Ok(());
+        };
+        conn.execute("DELETE FROM pending_messages WHERE session_id = ?1", [&sid])?;
+        Ok(())
+    }
+
+    /// Every persisted follow-up across all non-archived workspaces, for
+    /// rehydrating the in-memory queue at startup. Returns `(workspace_id,
+    /// PendingMsg)` pairs in per-workspace enqueue (seq) order. Archived
+    /// workspaces are excluded so a leftover row can never resurrect a queue for
+    /// an agent the user has put away.
+    pub fn read_all_pending_messages(
+        &self,
+    ) -> Result<Vec<(String, crate::message_queue::PendingMsg)>> {
+        let conn = self.db.lock();
+        let mut stmt = conn.prepare(
+            "SELECT s.workspace_id, p.turn_id, p.text, p.attachments, p.thinking
+             FROM pending_messages p
+             JOIN sessions s ON s.id = p.session_id
+             JOIN workspaces w ON w.id = s.workspace_id
+             WHERE w.archived_at IS NULL
+             ORDER BY s.workspace_id, p.seq ASC",
+        )?;
+        let rows: Vec<(String, String, String, String, Option<String>)> = stmt
+            .query_map([], |r| {
+                Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?))
+            })?
+            .collect::<std::result::Result<_, rusqlite::Error>>()?;
+        rows.into_iter()
+            .map(|(workspace_id, turn_id, text, attachments_text, thinking)| {
+                let attachments = serde_json::from_str(&attachments_text)
+                    .map_err(|e| Error::Other(format!("deserialize attachments: {e}")))?;
+                Ok((
+                    workspace_id,
+                    crate::message_queue::PendingMsg {
+                        turn_id,
+                        text,
+                        attachments,
+                        thinking,
+                    },
+                ))
+            })
+            .collect()
+    }
+
     /// Match pending (`native_id IS NULL`) user turns to their canonical
     /// `session_records` user-message rows and fill in `native_id`. Run at
     /// turn-end after transcript ingest. Matching: for each pending turn (seq
@@ -2046,6 +2177,99 @@ mod tests {
         let dolomites = cur.agents.iter().find(|a| a.id == "dolomites").unwrap();
         assert_eq!(yosemite.status, AgentStatus::Idle);
         assert_eq!(dolomites.status, AgentStatus::Stopped);
+    }
+
+    #[test]
+    fn pending_messages_round_trip_and_scoped_delete() {
+        use crate::message_queue::PendingMsg;
+        let db = test_db();
+        seed_repo(&db, "/r");
+        let wm = WorkspaceManager::new(db);
+        let mut rec = new_agent_record(
+            "yosemite".into(),
+            "a".into(),
+            "claude".into(),
+            mk_repo("/r"),
+            "task".into(),
+            AgentView::Custom,
+        );
+        wm.add_agent(&mut rec).unwrap();
+
+        let pm = |id: &str, text: &str| PendingMsg {
+            turn_id: id.into(),
+            text: text.into(),
+            attachments: vec![],
+            thinking: None,
+        };
+
+        // Enqueue three follow-ups; they read back for this workspace in seq order.
+        wm.enqueue_pending_message("yosemite", &pm("t1", "first")).unwrap();
+        wm.enqueue_pending_message("yosemite", &pm("t2", "second")).unwrap();
+        wm.enqueue_pending_message("yosemite", &pm("t3", "third")).unwrap();
+
+        let all = wm.read_all_pending_messages().unwrap();
+        let ids: Vec<_> = all
+            .iter()
+            .map(|(w, m)| (w.as_str(), m.turn_id.as_str()))
+            .collect();
+        assert_eq!(
+            ids,
+            vec![("yosemite", "t1"), ("yosemite", "t2"), ("yosemite", "t3")]
+        );
+
+        // A flush delivered t1/t2 while t3 arrived during the delivery window
+        // (still queued): delete-except-keep drops the delivered rows, keeps t3.
+        wm.delete_pending_messages_except("yosemite", &["t3".to_string()])
+            .unwrap();
+        let after = wm.read_all_pending_messages().unwrap();
+        assert_eq!(after.len(), 1);
+        assert_eq!(after[0].1.turn_id, "t3");
+
+        // Empty keep clears the rest (the normal full-drain flush).
+        wm.delete_pending_messages_except("yosemite", &[]).unwrap();
+        assert!(wm.read_all_pending_messages().unwrap().is_empty());
+
+        // clear wipes whatever remains (teardown path).
+        wm.enqueue_pending_message("yosemite", &pm("t4", "again")).unwrap();
+        wm.clear_pending_messages("yosemite").unwrap();
+        assert!(wm.read_all_pending_messages().unwrap().is_empty());
+    }
+
+    #[test]
+    fn pending_messages_excluded_for_archived_workspace() {
+        use crate::message_queue::PendingMsg;
+        let db = test_db();
+        seed_repo(&db, "/r");
+        let wm = WorkspaceManager::new(db.clone());
+        let mut rec = new_agent_record(
+            "yosemite".into(),
+            "a".into(),
+            "claude".into(),
+            mk_repo("/r"),
+            "task".into(),
+            AgentView::Custom,
+        );
+        wm.add_agent(&mut rec).unwrap();
+        wm.enqueue_pending_message(
+            "yosemite",
+            &PendingMsg {
+                turn_id: "t1".into(),
+                text: "hi".into(),
+                attachments: vec![],
+                thinking: None,
+            },
+        )
+        .unwrap();
+
+        // Archiving the workspace must hide its queued rows from rehydration, so
+        // a put-away agent never resurrects a queue on the next launch.
+        db.lock()
+            .execute(
+                "UPDATE workspaces SET archived_at = ?1 WHERE id = 'yosemite'",
+                [now_millis()],
+            )
+            .unwrap();
+        assert!(wm.read_all_pending_messages().unwrap().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Follow-up messages the user sends while an agent is mid-turn were held only in an in-memory per-agent queue (`MessageQueue`, a `HashMap<String, VecDeque<PendingMsg>>` on the `Supervisor`). They only became durable at *delivery* time (written to `session_user_turns`). A message sitting in the queue — `Delivery::Enqueue` for a busy per-turn agent, or claude paused on a tool gate — had **no row anywhere**, so an app exit/crash mid-turn dropped it silently. This is the message-queue half of the audit finding "no agent recovery on restart + in-memory queues dropped mid-turn."

## Approach

Keep the in-memory queue as the working copy (and hot path); add a durable write-through mirror in SQLite and rehydrate it on startup.

- **`pending_messages` table** (migration `0016`) — keyed to `session_id` with `ON DELETE CASCADE`, one row per queued `PendingMsg`.
- **`WorkspaceManager`** — `enqueue_pending_message`, `delete_pending_messages_except`, `clear_pending_messages`, `read_all_pending_messages` (excludes archived workspaces), mirroring the existing `session_user_turns` helpers.
- **`Supervisor::persist_and_enqueue`** — write-through at all three enqueue sites; the DB write is best-effort (logged, never blocks in-memory delivery).
- **`flush_queued`** — on successful delivery, clears persisted rows by *"everything except what is still queued in memory."* This is race-safe against a follow-up that arrives during the delivery window and also cleans up rows a prior failed flush coalesced away, so no orphan can be re-delivered after a crash. On failed delivery the rows are left intact for the retry (or a restart before it).
- **Startup** — `rehydrate_pending_messages()` reloads the queue in `lib.rs` setup. Messages rest until the user's next send, which delivers them coalesced via the existing `Delivery::FlushNow` path. No process is auto-spawned, consistent with the app's lazy-revival design.
- **Teardown** — archive/discard clears the durable rows (archive keeps the workspace row, so the FK cascade alone isn't enough).

## Tests

- New: `MessageQueue::turn_ids` FIFO test; `WorkspaceManager` round-trip + scoped-delete test; archived-workspace exclusion test.
- Pass: message_queue (16), supervisor (22), database (12), plus the new workspace tests. `cargo clippy` adds 0 new warnings.

## Known limitation (follow-up)

Rehydrated messages aren't yet shown in the UI as pending bubbles after a restart (`read_user_turns` only returns delivered turns). The data is preserved and delivers correctly; surfacing it visually fits with the planned interrupted-turn work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)