### PR TITLE
feat(agents): skills library and MCP tool servers for custom agents

### DIFF
--- a/src-tauri/migrations/0017_skills_and_mcp_servers.sql
+++ b/src-tauri/migrations/0017_skills_and_mcp_servers.sql
@@ -1,0 +1,40 @@
+-- Skills: shared library of named instruction documents. A custom agent
+-- references skills by id; at spawn the selected skills are snapshotted onto
+-- the session (by value) and materialized as files the agent reads on demand,
+-- so editing/deleting a skill never changes a running or resumed session.
+CREATE TABLE skills (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',   -- one-liner shown in the skill index
+    body        TEXT NOT NULL DEFAULT '',   -- markdown, materialized at spawn
+    created_at  INTEGER NOT NULL,
+    updated_at  INTEGER NOT NULL
+);
+
+-- MCP servers: shared registry of tool servers a custom agent can attach.
+-- `command`/`env` describe a stdio server; `url`/`headers` an http one.
+-- `env` and `headers` are stored as the user typed them (KEY=VALUE /
+-- "Name: value" lines) and parsed at spawn when the snapshot is built.
+CREATE TABLE mcp_servers (
+    id         TEXT PRIMARY KEY,
+    name       TEXT NOT NULL,
+    transport  TEXT NOT NULL DEFAULT 'stdio',  -- 'stdio' | 'http'
+    command    TEXT NOT NULL DEFAULT '',       -- full command line, whitespace-split at spawn
+    env        TEXT NOT NULL DEFAULT '',       -- KEY=VALUE per line
+    url        TEXT NOT NULL DEFAULT '',
+    headers    TEXT NOT NULL DEFAULT '',       -- "Name: value" per line
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+
+-- A custom agent's assigned skills/servers, as JSON id arrays. Ids are
+-- resolved against the library tables at spawn; a dangling id (deleted skill)
+-- resolves to nothing.
+ALTER TABLE custom_agents ADD COLUMN skill_ids TEXT NOT NULL DEFAULT '[]';
+ALTER TABLE custom_agents ADD COLUMN mcp_server_ids TEXT NOT NULL DEFAULT '[]';
+
+-- Per-session snapshots (JSON arrays of resolved skills/servers), mirroring how
+-- `sessions.instructions` snapshots the custom agent's brief: the session keeps
+-- re-injecting exactly what it was spawned with. NULL = none attached.
+ALTER TABLE sessions ADD COLUMN skills TEXT;
+ALTER TABLE sessions ADD COLUMN mcp_servers TEXT;

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -72,8 +72,13 @@ pub struct PerTurnSpec {
     pub model: Option<String>,
     /// A custom agent's standing instructions, snapshotted on the session and
     /// injected into every turn (appended after Fletch's global system prompt).
+    /// Includes the materialized skill index when the session has skills.
     /// `None` for a plain built-in spawn.
     pub instructions: Option<String>,
+    /// The session's MCP-server snapshot, delivered by providers with a
+    /// descriptor-level `mcp_args` builder (codex). Empty for plain spawns and
+    /// ignored by providers without MCP support.
+    pub mcp_servers: Vec<crate::agent_profile::McpServerSnapshot>,
     /// The agent's RPC mailbox dir, exposed to the child as `FLETCH_RPC_DIR`.
     pub rpc_dir: PathBuf,
     /// Sandbox engine stamped on the agent's record at creation and reused on
@@ -98,11 +103,18 @@ pub struct TurnArgs<'a> {
     pub model: Option<&'a str>,
     /// A custom agent's standing brief, injected into the turn.
     pub extra: Option<&'a str>,
+    /// Provider-specific MCP override args, prebuilt once per session by the
+    /// descriptor's `mcp_args` (codex `-c mcp_servers.*`). Empty otherwise.
+    pub mcp_args: &'a [String],
 }
 
 /// Builds the native (PTY) view launch args from
-/// `(session [None = fresh], model, custom_instructions)`.
-type PtyArgsBuilder = fn(Option<&str>, Option<&str>, Option<&str>) -> Vec<String>;
+/// `(session [None = fresh], model, custom_instructions, mcp_args)`.
+type PtyArgsBuilder = fn(Option<&str>, Option<&str>, Option<&str>, &[String]) -> Vec<String>;
+
+/// Builds a provider's MCP-delivery args from the session's server snapshot
+/// (e.g. codex `-c mcp_servers.*` overrides).
+type McpArgsBuilder = fn(&[crate::agent_profile::McpServerSnapshot]) -> Vec<String>;
 
 /// Everything that varies between per-turn agents. The runner lifecycle —
 /// one fresh process per turn via `ExecSession` — is identical for all of
@@ -120,8 +132,14 @@ pub struct PerTurnDescriptor {
     /// Builds the CLI args for one turn from the turn's [`TurnArgs`].
     build_args: fn(&TurnArgs) -> Vec<String>,
     /// Builds the args to launch this agent's interactive TUI in the native
-    /// (PTY) view: `(session [None = fresh], model, custom_instructions)`.
+    /// (PTY) view: `(session [None = fresh], model, custom_instructions,
+    /// mcp_args)`.
     pty_args: PtyArgsBuilder,
+    /// Builds this provider's MCP-delivery args from the session's snapshot
+    /// (e.g. codex `-c mcp_servers.*` overrides), applied to both the per-turn
+    /// and native-PTY launches. `None` = provider has no MCP config surface we
+    /// can drive; the snapshot is ignored (the editor UI says so up front).
+    mcp_args: Option<McpArgsBuilder>,
     /// Extracts the agent-assigned session id from a turn's events. The
     /// event-based agents are thin wrappers over `gated_session_id` (same shape,
     /// different gates). No-op for `plaintext` agents (they emit no events — see
@@ -271,6 +289,7 @@ const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         label: "Codex",
         build_args: codex_build_args,
         pty_args: codex_pty_args,
+        mcp_args: Some(crate::agent_profile::codex_mcp_args),
         session_id: codex_session_id,
         activity: || Box::new(ManagedActivity::codex()),
         native_view: true,
@@ -288,6 +307,7 @@ const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         label: "Cursor",
         build_args: cursor_build_args,
         pty_args: cursor_pty_args,
+        mcp_args: None,
         session_id: cursor_session_id,
         // Cursor emits Claude-shaped stream-json incl. a `result` turn-end,
         // so it reuses the Claude managed detector.
@@ -307,6 +327,7 @@ const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         label: "OpenCode",
         build_args: opencode_build_args,
         pty_args: opencode_pty_args,
+        mcp_args: None,
         session_id: opencode_session_id,
         activity: || Box::new(ManagedActivity::opencode()),
         native_view: true,
@@ -324,6 +345,7 @@ const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         label: "Pi",
         build_args: pi_build_args,
         pty_args: pi_pty_args,
+        mcp_args: None,
         session_id: pi_session_id,
         activity: || Box::new(ManagedActivity::pi()),
         native_view: true,
@@ -344,6 +366,7 @@ const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         label: "Antigravity",
         build_args: antigravity_build_args,
         pty_args: antigravity_pty_args,
+        mcp_args: None,
         // agy emits no JSON events; its session id is read from the filesystem.
         session_id: |_| None,
         // No event stream to detect turn-end from — the turn's process exit ends
@@ -749,6 +772,7 @@ fn antigravity_pty_args(
     session_id: Option<&str>,
     _model: Option<&str>,
     _extra: Option<&str>,
+    _mcp_args: &[String],
 ) -> Vec<String> {
     // Native view: launch agy's interactive TUI (NOT `--print`, the
     // non-interactive turn runner), resuming the conversation by id.
@@ -889,8 +913,16 @@ pub struct SpawnSpec<'a> {
     /// Session-level model override. `None` keeps the provider CLI default.
     pub model: Option<&'a str>,
     /// A custom agent's standing instructions, injected after Fletch's global
-    /// system prompt on every spawn/resume. `None` for a plain built-in spawn.
+    /// system prompt on every spawn/resume. Includes the materialized skill
+    /// index when the session has skills. `None` for a plain built-in spawn.
     pub instructions: Option<&'a str>,
+    /// The session's MCP-server snapshot, consumed by per-turn providers with
+    /// a descriptor `mcp_args` builder when this spec launches their native
+    /// TUI. Claude ignores it (it takes `mcp_config` instead).
+    pub mcp_servers: &'a [crate::agent_profile::McpServerSnapshot],
+    /// Claude's generated MCP config file, passed as
+    /// `--mcp-config <path> --strict-mcp-config`. `None` = no servers attached.
+    pub mcp_config: Option<&'a Path>,
     /// The agent's RPC mailbox dir, exposed to the child as `FLETCH_RPC_DIR`.
     pub rpc_dir: PathBuf,
     pub cols: u16,
@@ -1000,7 +1032,14 @@ impl Agent {
         } else {
             Some(spec.session_id)
         };
-        let agent_args = (desc.pty_args)(session, spec.model, spec.instructions);
+        // Provider MCP overrides (codex `-c mcp_servers.*`), rebuilt from the
+        // session's snapshot so the TUI resumes with the same tool set the
+        // Custom-view turns had.
+        let mcp_args = desc
+            .mcp_args
+            .map(|build| build(spec.mcp_servers))
+            .unwrap_or_default();
+        let agent_args = (desc.pty_args)(session, spec.model, spec.instructions, &mcp_args);
 
         // Unified sandbox: run the agent's TUI under the sandbox engine (the
         // agent's own sandbox is disabled in its arg builder), so per-turn
@@ -1143,11 +1182,16 @@ impl Agent {
             engine.as_ref(),
             &home,
         )?);
-        // A custom agent's standing brief is constant for the session, so bind
-        // it into the per-turn args builder once here rather than threading it
-        // through every turn. `ExecSession` keeps calling a 4-arg builder.
+        // A custom agent's standing brief and MCP overrides are constant for
+        // the session, so bind them into the per-turn args builder once here
+        // rather than threading them through every turn. `ExecSession` keeps
+        // calling a 4-arg builder.
         let build_args = desc.build_args;
         let extra = spec.instructions.clone();
+        let mcp_args = desc
+            .mcp_args
+            .map(|build| build(&spec.mcp_servers))
+            .unwrap_or_default();
         Self::spawn_exec(
             desc.id,
             program,
@@ -1159,6 +1203,7 @@ impl Agent {
                     thinking,
                     model,
                     extra: extra.as_deref(),
+                    mcp_args: &mcp_args,
                 })
             },
             desc.session_id,
@@ -1378,6 +1423,7 @@ fn prepare_pty_args(spec: &SpawnSpec<'_>) -> Vec<String> {
     args.extend(effort_args(spec.effort));
     args.extend(model_args(spec.model));
     args.extend(instructions::append_system_prompt_args(spec.instructions));
+    args.extend(mcp_config_args(spec.mcp_config));
 
     if spec.fresh {
         args.push("--session-id".into());
@@ -1388,6 +1434,20 @@ fn prepare_pty_args(spec: &SpawnSpec<'_>) -> Vec<String> {
     }
 
     args
+}
+
+/// Claude's MCP flags for a generated config file: `--strict-mcp-config` makes
+/// the snapshot-derived file the *only* MCP source, so on-disk user/project MCP
+/// config never rides along with an agent Fletch spawns.
+fn mcp_config_args(config: Option<&Path>) -> Vec<String> {
+    match config {
+        Some(path) => vec![
+            "--mcp-config".into(),
+            path.to_string_lossy().into_owned(),
+            "--strict-mcp-config".into(),
+        ],
+        None => Vec::new(),
+    }
 }
 
 fn prepare_managed_args(spec: &SpawnSpec<'_>) -> Vec<String> {
@@ -1418,6 +1478,7 @@ fn prepare_managed_args(spec: &SpawnSpec<'_>) -> Vec<String> {
     args.extend(effort_args(spec.effort));
     args.extend(model_args(spec.model));
     args.extend(instructions::append_system_prompt_args(spec.instructions));
+    args.extend(mcp_config_args(spec.mcp_config));
 
     if spec.fresh {
         args.push("--session-id".into());
@@ -1473,6 +1534,7 @@ fn codex_build_args(turn: &TurnArgs) -> Vec<String> {
         thinking,
         model,
         extra,
+        mcp_args,
     } = turn;
     let mut args: Vec<String> = vec!["exec".into()];
     push_opt(&mut args, "resume", session_id);
@@ -1488,6 +1550,10 @@ fn codex_build_args(turn: &TurnArgs) -> Vec<String> {
     }
     args.extend(model_args(model));
     args.extend(instructions::codex_config_args(extra));
+    // The session's MCP servers as `-c mcp_servers.*` overrides (see
+    // `agent_profile::codex_mcp_args`), re-passed every turn like the rest of
+    // the config since `codex exec` reads config per invocation.
+    args.extend_from_slice(mcp_args);
     args.push(prompt.to_string());
     args
 }
@@ -1573,6 +1639,7 @@ fn opencode_build_args(turn: &TurnArgs) -> Vec<String> {
         thinking,
         model,
         extra,
+        ..
     } = turn;
     let mut args: Vec<String> = vec![
         "run".into(),
@@ -1615,6 +1682,7 @@ fn pi_build_args(turn: &TurnArgs) -> Vec<String> {
         thinking,
         model,
         extra,
+        ..
     } = turn;
     let mut args: Vec<String> = vec!["-p".into(), "--mode".into(), "json".into()];
     args.extend(model_args(model));
@@ -1649,10 +1717,12 @@ fn codex_pty_args(
     session_id: Option<&str>,
     model: Option<&str>,
     extra: Option<&str>,
+    mcp_args: &[String],
 ) -> Vec<String> {
     let mut args: Vec<String> = vec!["--dangerously-bypass-approvals-and-sandbox".into()];
     args.extend(model_args(model));
     args.extend(instructions::codex_config_args(extra));
+    args.extend_from_slice(mcp_args);
     push_opt(&mut args, "resume", session_id);
     args
 }
@@ -1665,6 +1735,7 @@ fn cursor_pty_args(
     session_id: Option<&str>,
     model: Option<&str>,
     _extra: Option<&str>,
+    _mcp_args: &[String],
 ) -> Vec<String> {
     let mut args: Vec<String> = vec!["--force".into()];
     args.extend(model_args(model));
@@ -1682,6 +1753,7 @@ fn opencode_pty_args(
     session_id: Option<&str>,
     model: Option<&str>,
     _extra: Option<&str>,
+    _mcp_args: &[String],
 ) -> Vec<String> {
     let mut args: Vec<String> = Vec::new();
     args.extend(model_args(model));
@@ -1692,7 +1764,12 @@ fn opencode_pty_args(
 /// Pi: bare `pi` launches the interactive TUI (tools auto-run there).
 /// `--session <id>` resumes — same flag the Custom-view runner uses, since the
 /// versions we target (0.74.x) lack `--session-id`.
-fn pi_pty_args(session_id: Option<&str>, model: Option<&str>, extra: Option<&str>) -> Vec<String> {
+fn pi_pty_args(
+    session_id: Option<&str>,
+    model: Option<&str>,
+    extra: Option<&str>,
+    _mcp_args: &[String],
+) -> Vec<String> {
     let mut args: Vec<String> = instructions::append_system_prompt_args(extra);
     args.extend(model_args(model));
     push_opt(&mut args, "--session", session_id);
@@ -2184,11 +2261,11 @@ mod tests {
     fn codex_pty_args_launch_tui_fresh_and_resume() {
         // Fresh: bypass approvals/sandbox so the TUI runs unattended; no
         // `exec`/`resume` subcommand means the interactive CLI.
-        let fresh = codex_pty_args(None, None, None);
+        let fresh = codex_pty_args(None, None, None, &[]);
         assert!(fresh.contains(&"--dangerously-bypass-approvals-and-sandbox".to_string()));
         assert!(!fresh.iter().any(|a| a == "resume"));
         // Resume: `resume <id>` continues the prior interactive session.
-        let resume = codex_pty_args(Some("abc123"), None, None);
+        let resume = codex_pty_args(Some("abc123"), None, None, &[]);
         assert!(resume.contains(&"--dangerously-bypass-approvals-and-sandbox".to_string()));
         let pos = resume
             .iter()
@@ -2199,10 +2276,10 @@ mod tests {
 
     #[test]
     fn cursor_pty_args_force_and_resume() {
-        let fresh = cursor_pty_args(None, None, None);
+        let fresh = cursor_pty_args(None, None, None, &[]);
         assert!(fresh.contains(&"--force".to_string()));
         assert!(!fresh.iter().any(|a| a == "--resume"));
-        let resume = cursor_pty_args(Some("chat-1"), None, None);
+        let resume = cursor_pty_args(Some("chat-1"), None, None, &[]);
         assert!(resume.contains(&"--force".to_string()));
         let pos = resume
             .iter()
@@ -2216,11 +2293,11 @@ mod tests {
         // Fresh: bare `opencode` launches the TUI. It must NOT carry
         // `--dangerously-skip-permissions` — that's a `run`-only flag, and
         // the default (TUI) command prints help and exits when given it.
-        let fresh = opencode_pty_args(None, None, None);
+        let fresh = opencode_pty_args(None, None, None, &[]);
         assert!(!fresh.iter().any(|a| a == "--dangerously-skip-permissions"));
         assert!(fresh.is_empty());
         // Resume: `--session <id>` continues the prior session.
-        let resume = opencode_pty_args(Some("ses_9"), None, None);
+        let resume = opencode_pty_args(Some("ses_9"), None, None, &[]);
         assert!(!resume.iter().any(|a| a == "--dangerously-skip-permissions"));
         let pos = resume
             .iter()
@@ -2233,13 +2310,13 @@ mod tests {
     fn pi_pty_args_bare_tui_and_session() {
         // Fresh: bare `pi` launches the interactive TUI; tools auto-run there.
         // (May carry injected --append-system-prompt args, but never a resume.)
-        let fresh = pi_pty_args(None, None, None);
+        let fresh = pi_pty_args(None, None, None, &[]);
         assert!(
             !fresh.iter().any(|a| a == "--session"),
             "fresh TUI has no resume flag"
         );
         // Resume uses `--session <id>` (target pi 0.74.x lacks `--session-id`).
-        let resume = pi_pty_args(Some("u-7"), None, None);
+        let resume = pi_pty_args(Some("u-7"), None, None, &[]);
         let pos = resume
             .iter()
             .position(|a| a == "--session")
@@ -2252,7 +2329,7 @@ mod tests {
         // Native view is wired for every per-turn agent, so each descriptor
         // must carry a TUI arg-builder. Fresh launch never references resume.
         for d in PER_TURN_AGENTS {
-            let fresh = (d.pty_args)(None, None, None);
+            let fresh = (d.pty_args)(None, None, None, &[]);
             assert!(
                 !fresh
                     .iter()

--- a/src-tauri/src/agent_profile.rs
+++ b/src-tauri/src/agent_profile.rs
@@ -101,6 +101,39 @@ fn dedupe(base: &str, used: &mut Vec<String>, sep: char) -> String {
     candidate
 }
 
+/// Ensure `dir` is a real directory, replacing an agent-planted symlink (or
+/// stray file) at that path. The profile dir sits under the agent-writable
+/// root but is written by the *host* on every spawn; without this check a
+/// prompt-injected agent could swap `.fletch-profile` for a symlink between
+/// spawns and redirect the host's writes anywhere the user can write. Checked
+/// per component we own (profile root, skills dir) since `create_dir_all`
+/// happily follows an existing symlink.
+fn ensure_real_dir(dir: &Path) -> Result<()> {
+    if let Ok(meta) = std::fs::symlink_metadata(dir) {
+        if meta.file_type().is_symlink() || !meta.is_dir() {
+            std::fs::remove_file(dir)
+                .map_err(|e| Error::Other(format!("failed to clear profile path: {e}")))?;
+        }
+    }
+    std::fs::create_dir_all(dir)
+        .map_err(|e| Error::Other(format!("failed to create profile dir: {e}")))
+}
+
+/// Write a profile artifact, refusing to follow a symlink at the target path
+/// (`fs::write` would): an agent-planted link is removed so the content lands
+/// at the literal path. The agent process is not running while the host
+/// materializes the profile, so there is no live race with this check.
+fn write_profile_file(path: &Path, contents: &str) -> Result<()> {
+    if let Ok(meta) = std::fs::symlink_metadata(path) {
+        if meta.file_type().is_symlink() {
+            std::fs::remove_file(path)
+                .map_err(|e| Error::Other(format!("failed to clear profile path: {e}")))?;
+        }
+    }
+    std::fs::write(path, contents)
+        .map_err(|e| Error::Other(format!("failed to write profile file: {e}")))
+}
+
 /// Filesystem-safe slug for a skill file name: lowercased, runs of
 /// non-alphanumerics collapsed to `-`. Falls back to `skill` for names with no
 /// usable characters; callers dedupe collisions positionally.
@@ -133,8 +166,8 @@ pub fn materialize_skills(skills: &[SkillSnapshot], sandbox_root: &Path) -> Resu
         return Ok(None);
     }
     let dir = skills_dir(sandbox_root);
-    std::fs::create_dir_all(&dir)
-        .map_err(|e| Error::Other(format!("failed to create skills dir: {e}")))?;
+    ensure_real_dir(&profile_dir(sandbox_root))?;
+    ensure_real_dir(&dir)?;
 
     let mut index = String::from(
         "## Skills\n\nThe following skill documents are available. When your task matches one, \
@@ -144,8 +177,7 @@ pub fn materialize_skills(skills: &[SkillSnapshot], sandbox_root: &Path) -> Resu
     for skill in skills {
         let file = dedupe(&slug(&skill.name), &mut used, '-');
         let path = dir.join(format!("{file}.md"));
-        std::fs::write(&path, &skill.body)
-            .map_err(|e| Error::Other(format!("failed to write skill file: {e}")))?;
+        write_profile_file(&path, &skill.body)?;
         let desc = skill.description.trim();
         if desc.is_empty() {
             index.push_str(&format!("- {} — {}\n", skill.name, path.display()));
@@ -218,13 +250,11 @@ pub fn write_claude_mcp_config(
     }
     let config = serde_json::json!({ "mcpServers": serde_json::Value::Object(map) });
     let dir = profile_dir(sandbox_root);
-    std::fs::create_dir_all(&dir)
-        .map_err(|e| Error::Other(format!("failed to create profile dir: {e}")))?;
+    ensure_real_dir(&dir)?;
     let path = dir.join("mcp-servers.json");
     let body = serde_json::to_string_pretty(&config)
         .map_err(|e| Error::Other(format!("failed to encode MCP config: {e}")))?;
-    std::fs::write(&path, body)
-        .map_err(|e| Error::Other(format!("failed to write MCP config: {e}")))?;
+    write_profile_file(&path, &body)?;
     Ok(Some(path))
 }
 
@@ -410,6 +440,48 @@ mod tests {
         // The http server contributes nothing.
         assert_eq!(args.len(), 6);
         assert!(codex_mcp_args(&[]).is_empty());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn symlinked_profile_dir_is_replaced_not_followed() {
+        // An agent-planted symlink at `.fletch-profile` (or a skill file) must
+        // never redirect the host's writes outside the profile dir.
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink(outside.path(), dir.path().join(PROFILE_DIR)).unwrap();
+
+        let skills = vec![skill("Deploy", "", "steps")];
+        materialize_skills(&skills, dir.path()).unwrap().unwrap();
+
+        // The link was replaced by a real dir; nothing landed outside.
+        let profile = dir.path().join(PROFILE_DIR);
+        assert!(!std::fs::symlink_metadata(&profile)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert!(profile.join("skills/deploy.md").exists());
+        assert_eq!(std::fs::read_dir(outside.path()).unwrap().count(), 0);
+
+        // Same for a symlinked artifact file inside a real profile dir.
+        let target = outside.path().join("victim");
+        std::fs::write(&target, "before").unwrap();
+        let cfg = profile.join("mcp-servers.json");
+        std::os::unix::fs::symlink(&target, &cfg).unwrap();
+        let servers = vec![McpServerSnapshot {
+            name: "GitHub".into(),
+            transport: "stdio".into(),
+            command: "npx".into(),
+            ..Default::default()
+        }];
+        write_claude_mcp_config(&servers, dir.path())
+            .unwrap()
+            .unwrap();
+        assert!(!std::fs::symlink_metadata(&cfg)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "before");
     }
 
     #[test]

--- a/src-tauri/src/agent_profile.rs
+++ b/src-tauri/src/agent_profile.rs
@@ -119,13 +119,19 @@ fn ensure_real_dir(dir: &Path) -> Result<()> {
         .map_err(|e| Error::Other(format!("failed to create profile dir: {e}")))
 }
 
-/// Write a profile artifact, refusing to follow a symlink at the target path
-/// (`fs::write` would): an agent-planted link is removed so the content lands
-/// at the literal path. The agent process is not running while the host
-/// materializes the profile, so there is no live race with this check.
+/// Write a profile artifact, clearing whatever an agent left at the target
+/// path first: a symlink would be *followed* by `fs::write` (redirecting the
+/// host's write), and a directory would fail it with "is a directory",
+/// blocking every later respawn. These are host-owned paths — anything at
+/// them that isn't our regular file is replaced. The agent process is not
+/// running while the host materializes the profile, so there is no live race
+/// with this check.
 fn write_profile_file(path: &Path, contents: &str) -> Result<()> {
     if let Ok(meta) = std::fs::symlink_metadata(path) {
-        if meta.file_type().is_symlink() {
+        if meta.is_dir() {
+            std::fs::remove_dir_all(path)
+                .map_err(|e| Error::Other(format!("failed to clear profile path: {e}")))?;
+        } else if meta.file_type().is_symlink() {
             std::fs::remove_file(path)
                 .map_err(|e| Error::Other(format!("failed to clear profile path: {e}")))?;
         }
@@ -482,6 +488,32 @@ mod tests {
             .file_type()
             .is_symlink());
         assert_eq!(std::fs::read_to_string(&target).unwrap(), "before");
+    }
+
+    #[test]
+    fn directory_artifacts_are_replaced_before_write() {
+        // An agent-created *directory* at a host-owned artifact path (e.g.
+        // `mkdir .fletch-profile/mcp-servers.json`) must not wedge later
+        // respawns with "is a directory" — it's cleared and rewritten.
+        let dir = tempfile::tempdir().unwrap();
+        let profile = dir.path().join(PROFILE_DIR);
+        std::fs::create_dir_all(profile.join("skills/deploy.md")).unwrap();
+        std::fs::create_dir_all(profile.join("mcp-servers.json/nested")).unwrap();
+
+        let skills = vec![skill("Deploy", "", "steps")];
+        materialize_skills(&skills, dir.path()).unwrap().unwrap();
+        assert!(profile.join("skills/deploy.md").is_file());
+
+        let servers = vec![McpServerSnapshot {
+            name: "GitHub".into(),
+            transport: "stdio".into(),
+            command: "npx".into(),
+            ..Default::default()
+        }];
+        let path = write_claude_mcp_config(&servers, dir.path())
+            .unwrap()
+            .unwrap();
+        assert!(path.is_file());
     }
 
     #[test]

--- a/src-tauri/src/agent_profile.rs
+++ b/src-tauri/src/agent_profile.rs
@@ -1,0 +1,421 @@
+//! Custom-agent profile: the skills and MCP servers snapshotted onto a session
+//! at spawn, and how they reach the agent process.
+//!
+//! **Skills** are provider-neutral: every selected skill is materialized as a
+//! markdown file under the agent's writable root
+//! (`<sandbox_root>/.fletch-profile/skills/` — a reserved name a repo checkout
+//! can never claim, see [`PROFILE_DIR`]),
+//! and a compact index (name + description + path) is appended to the session's
+//! instruction text — riding the same per-provider delivery `instructions.rs`
+//! already implements. The agent reads a skill file when the task matches
+//! (progressive disclosure), so the per-turn token cost is one line per skill.
+//! The writable root is bind-mounted at its host path under docker (path
+//! identity), so the index paths are valid in both sandbox engines.
+//!
+//! **MCP servers** are delivered per provider:
+//! - claude — a generated config file passed via `--mcp-config` +
+//!   `--strict-mcp-config` (our snapshot is the *only* MCP source, so on-disk
+//!   user/project MCP config can't ride along).
+//! - codex — `-c mcp_servers.<key>.…` TOML config overrides (stdio only).
+//! - cursor/opencode/pi/antigravity — unsupported; the editor UI says so and
+//!   the snapshot is simply not consumed.
+//!
+//! Both snapshots live on the session row (like `sessions.instructions`), so a
+//! running or resumed session keeps the exact profile it spawned with even if
+//! the library entries are later edited or deleted.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+use crate::instructions::toml_basic_string;
+
+/// One skill resolved by value at spawn: a named instruction document the
+/// agent loads on demand.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct SkillSnapshot {
+    pub name: String,
+    /// One-liner shown in the skill index so the agent knows when to read it.
+    #[serde(default)]
+    pub description: String,
+    /// Markdown body, written verbatim to the materialized file.
+    #[serde(default)]
+    pub body: String,
+}
+
+/// One MCP server resolved by value at spawn. `command`/`args`/`env` describe a
+/// stdio server; `url`/`headers` an http one.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct McpServerSnapshot {
+    pub name: String,
+    /// `"stdio"` or `"http"`.
+    #[serde(default)]
+    pub transport: String,
+    #[serde(default)]
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub env: Vec<(String, String)>,
+    #[serde(default)]
+    pub url: String,
+    #[serde(default)]
+    pub headers: Vec<(String, String)>,
+}
+
+impl McpServerSnapshot {
+    fn is_stdio(&self) -> bool {
+        self.transport != "http"
+    }
+}
+
+/// Reserved directory name for Fletch-generated profile artifacts (skill files,
+/// MCP config) under the agent's writable root. Repo checkouts live as siblings
+/// directly under that root, so the name must be one `allocate_repo_subdir`
+/// can never hand to a checkout — it treats this constant as taken.
+pub const PROFILE_DIR: &str = ".fletch-profile";
+
+/// Root for this session's profile artifacts, under the agent's writable root
+/// so both sandbox engines can read them at the same path.
+fn profile_dir(sandbox_root: &Path) -> PathBuf {
+    sandbox_root.join(PROFILE_DIR)
+}
+
+/// Directory the skill files are materialized into.
+fn skills_dir(sandbox_root: &Path) -> PathBuf {
+    profile_dir(sandbox_root).join("skills")
+}
+
+/// Dedupe `base` against `used` by suffixing `<sep>2`, `<sep>3`, … until free,
+/// recording and returning the winner. Shared by the skill-file, claude-config,
+/// and codex-key namers so every profile artifact dedupes the same way.
+fn dedupe(base: &str, used: &mut Vec<String>, sep: char) -> String {
+    let mut candidate = base.to_string();
+    let mut n = 1;
+    while used.iter().any(|u| u == &candidate) {
+        n += 1;
+        candidate = format!("{base}{sep}{n}");
+    }
+    used.push(candidate.clone());
+    candidate
+}
+
+/// Filesystem-safe slug for a skill file name: lowercased, runs of
+/// non-alphanumerics collapsed to `-`. Falls back to `skill` for names with no
+/// usable characters; callers dedupe collisions positionally.
+fn slug(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    let mut dash = false;
+    for c in name.chars() {
+        if c.is_ascii_alphanumeric() {
+            out.push(c.to_ascii_lowercase());
+            dash = false;
+        } else if !dash && !out.is_empty() {
+            out.push('-');
+            dash = true;
+        }
+    }
+    let out = out.trim_end_matches('-').to_string();
+    if out.is_empty() {
+        "skill".into()
+    } else {
+        out
+    }
+}
+
+/// Materialize `skills` under `<sandbox_root>/skills/` and return the index
+/// block to append to the session's instructions. `None` when there are no
+/// skills (no dir is created). Rewritten on every spawn/resume so the files
+/// always match the session's snapshot, even after the checkout is recreated.
+pub fn materialize_skills(skills: &[SkillSnapshot], sandbox_root: &Path) -> Result<Option<String>> {
+    if skills.is_empty() {
+        return Ok(None);
+    }
+    let dir = skills_dir(sandbox_root);
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| Error::Other(format!("failed to create skills dir: {e}")))?;
+
+    let mut index = String::from(
+        "## Skills\n\nThe following skill documents are available. When your task matches one, \
+         read the file before proceeding:\n",
+    );
+    let mut used: Vec<String> = Vec::new();
+    for skill in skills {
+        let file = dedupe(&slug(&skill.name), &mut used, '-');
+        let path = dir.join(format!("{file}.md"));
+        std::fs::write(&path, &skill.body)
+            .map_err(|e| Error::Other(format!("failed to write skill file: {e}")))?;
+        let desc = skill.description.trim();
+        if desc.is_empty() {
+            index.push_str(&format!("- {} — {}\n", skill.name, path.display()));
+        } else {
+            index.push_str(&format!(
+                "- {} — {} — {}\n",
+                skill.name,
+                desc,
+                path.display()
+            ));
+        }
+    }
+    Ok(Some(index.trim_end().to_string()))
+}
+
+/// The session's effective instruction suffix: the custom agent's standing
+/// brief plus the materialized skill index. `None` when both are absent —
+/// which keeps every `instructions.rs` helper a no-op, exactly like today.
+pub fn effective_instructions(
+    brief: Option<&str>,
+    skills: &[SkillSnapshot],
+    sandbox_root: &Path,
+) -> Result<Option<String>> {
+    let index = materialize_skills(skills, sandbox_root)?;
+    let brief = brief.map(str::trim).filter(|s| !s.is_empty());
+    Ok(match (brief, index) {
+        (Some(b), Some(i)) => Some(format!("{b}\n\n{i}")),
+        (Some(b), None) => Some(b.to_string()),
+        (None, Some(i)) => Some(i),
+        (None, None) => None,
+    })
+}
+
+/// Write claude's MCP config (`{"mcpServers": {…}}`) under the writable root
+/// and return its path for `--mcp-config`. `None` when no servers are attached.
+/// Generated from the session's snapshot on every spawn — never read from
+/// agent-writable or user-level config, and paired with `--strict-mcp-config`
+/// at the arg builder so this file is the only MCP source claude loads.
+pub fn write_claude_mcp_config(
+    servers: &[McpServerSnapshot],
+    sandbox_root: &Path,
+) -> Result<Option<PathBuf>> {
+    if servers.is_empty() {
+        return Ok(None);
+    }
+    let mut map = serde_json::Map::new();
+    let mut used: Vec<String> = Vec::new();
+    for s in servers {
+        let key = dedupe(&slug(&s.name), &mut used, '-');
+        let to_map = |pairs: &[(String, String)]| {
+            pairs
+                .iter()
+                .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+                .collect::<serde_json::Map<_, _>>()
+        };
+        let entry = if s.is_stdio() {
+            serde_json::json!({
+                "command": s.command,
+                "args": s.args,
+                "env": to_map(&s.env),
+            })
+        } else {
+            serde_json::json!({
+                "type": "http",
+                "url": s.url,
+                "headers": to_map(&s.headers),
+            })
+        };
+        map.insert(key, entry);
+    }
+    let config = serde_json::json!({ "mcpServers": serde_json::Value::Object(map) });
+    let dir = profile_dir(sandbox_root);
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| Error::Other(format!("failed to create profile dir: {e}")))?;
+    let path = dir.join("mcp-servers.json");
+    let body = serde_json::to_string_pretty(&config)
+        .map_err(|e| Error::Other(format!("failed to encode MCP config: {e}")))?;
+    std::fs::write(&path, body)
+        .map_err(|e| Error::Other(format!("failed to write MCP config: {e}")))?;
+    Ok(Some(path))
+}
+
+/// Codex `-c mcp_servers.<key>.…` TOML overrides for the snapshot's stdio
+/// servers (codex config has no first-class http transport we can target via
+/// `-c`, so http entries are skipped). Empty when nothing applies.
+pub fn codex_mcp_args(servers: &[McpServerSnapshot]) -> Vec<String> {
+    let mut args: Vec<String> = Vec::new();
+    let mut used: Vec<String> = Vec::new();
+    for s in servers.iter().filter(|s| s.is_stdio()) {
+        let key = dedupe(&slug(&s.name).replace('-', "_"), &mut used, '_');
+        let mut push = |suffix: &str, value: String| {
+            args.push("-c".into());
+            args.push(format!("mcp_servers.{key}.{suffix}={value}"));
+        };
+        push("command", toml_basic_string(&s.command));
+        if !s.args.is_empty() {
+            let items: Vec<String> = s.args.iter().map(|a| toml_basic_string(a)).collect();
+            push("args", format!("[{}]", items.join(",")));
+        }
+        if !s.env.is_empty() {
+            let items: Vec<String> = s
+                .env
+                .iter()
+                .map(|(k, v)| format!("{} = {}", toml_basic_string(k), toml_basic_string(v)))
+                .collect();
+            push("env", format!("{{{}}}", items.join(", ")));
+        }
+    }
+    args
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn skill(name: &str, desc: &str, body: &str) -> SkillSnapshot {
+        SkillSnapshot {
+            name: name.into(),
+            description: desc.into(),
+            body: body.into(),
+        }
+    }
+
+    #[test]
+    fn no_skills_is_a_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(materialize_skills(&[], dir.path()).unwrap(), None);
+        assert!(!dir.path().join(PROFILE_DIR).exists());
+    }
+
+    #[test]
+    fn skills_materialize_and_index_points_at_them() {
+        let dir = tempfile::tempdir().unwrap();
+        let skills = vec![
+            skill("Code Review", "how we review PRs", "# Review\nBe thorough."),
+            skill("Code Review", "", "dupe name"),
+        ];
+        let index = materialize_skills(&skills, dir.path()).unwrap().unwrap();
+
+        let first = dir.path().join(".fletch-profile/skills/code-review.md");
+        let second = dir.path().join(".fletch-profile/skills/code-review-2.md");
+        assert_eq!(
+            std::fs::read_to_string(&first).unwrap(),
+            "# Review\nBe thorough."
+        );
+        assert_eq!(std::fs::read_to_string(&second).unwrap(), "dupe name");
+        assert!(index.contains("## Skills"));
+        assert!(index.contains("how we review PRs"));
+        assert!(index.contains(&first.display().to_string()));
+        assert!(index.contains(&second.display().to_string()));
+    }
+
+    #[test]
+    fn effective_instructions_compose_brief_and_index() {
+        let dir = tempfile::tempdir().unwrap();
+        let skills = vec![skill("Deploy", "cutting a release", "steps")];
+
+        // Brief only.
+        let brief_only = effective_instructions(Some("Be terse."), &[], dir.path()).unwrap();
+        assert_eq!(brief_only.as_deref(), Some("Be terse."));
+
+        // Both: brief first, index after.
+        let both = effective_instructions(Some("Be terse."), &skills, dir.path())
+            .unwrap()
+            .unwrap();
+        assert!(both.starts_with("Be terse.\n\n## Skills"));
+
+        // Neither → None, so instructions.rs helpers stay no-ops.
+        assert_eq!(effective_instructions(None, &[], dir.path()).unwrap(), None);
+        assert_eq!(
+            effective_instructions(Some("  "), &[], dir.path()).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn claude_mcp_config_covers_stdio_and_http() {
+        let dir = tempfile::tempdir().unwrap();
+        let servers = vec![
+            McpServerSnapshot {
+                name: "GitHub".into(),
+                transport: "stdio".into(),
+                command: "npx".into(),
+                args: vec!["-y".into(), "gh-mcp".into()],
+                env: vec![("TOKEN".into(), "t".into())],
+                ..Default::default()
+            },
+            McpServerSnapshot {
+                name: "Docs".into(),
+                transport: "http".into(),
+                url: "https://mcp.example.com".into(),
+                headers: vec![("Authorization".into(), "Bearer x".into())],
+                ..Default::default()
+            },
+        ];
+        let path = write_claude_mcp_config(&servers, dir.path())
+            .unwrap()
+            .unwrap();
+        let json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(json["mcpServers"]["github"]["command"], "npx");
+        assert_eq!(json["mcpServers"]["github"]["args"][1], "gh-mcp");
+        assert_eq!(json["mcpServers"]["github"]["env"]["TOKEN"], "t");
+        assert_eq!(json["mcpServers"]["docs"]["type"], "http");
+        assert_eq!(json["mcpServers"]["docs"]["url"], "https://mcp.example.com");
+        assert_eq!(
+            json["mcpServers"]["docs"]["headers"]["Authorization"],
+            "Bearer x"
+        );
+
+        assert_eq!(write_claude_mcp_config(&[], dir.path()).unwrap(), None);
+    }
+
+    #[test]
+    fn claude_mcp_config_keys_never_collide() {
+        // Dedupe must roll forward past *existing* keys: with servers named
+        // x-3, x, x the third dedupes to x-2 (not x-3, which would silently
+        // overwrite the first entry).
+        let dir = tempfile::tempdir().unwrap();
+        let mk = |name: &str| McpServerSnapshot {
+            name: name.into(),
+            transport: "stdio".into(),
+            command: "cmd".into(),
+            ..Default::default()
+        };
+        let servers = vec![mk("x-3"), mk("x"), mk("x")];
+        let path = write_claude_mcp_config(&servers, dir.path())
+            .unwrap()
+            .unwrap();
+        let json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let keys: Vec<&String> = json["mcpServers"].as_object().unwrap().keys().collect();
+        assert_eq!(keys.len(), 3, "no server may be silently dropped");
+        assert!(json["mcpServers"]["x-3"].is_object());
+        assert!(json["mcpServers"]["x"].is_object());
+        assert!(json["mcpServers"]["x-2"].is_object());
+    }
+
+    #[test]
+    fn codex_args_are_toml_overrides_for_stdio_servers_only() {
+        let servers = vec![
+            McpServerSnapshot {
+                name: "My GitHub".into(),
+                transport: "stdio".into(),
+                command: "npx".into(),
+                args: vec!["-y".into()],
+                env: vec![("A".into(), "b\"c".into())],
+                ..Default::default()
+            },
+            McpServerSnapshot {
+                name: "Docs".into(),
+                transport: "http".into(),
+                url: "https://mcp.example.com".into(),
+                ..Default::default()
+            },
+        ];
+        let args = codex_mcp_args(&servers);
+        assert_eq!(args[0], "-c");
+        assert_eq!(args[1], r#"mcp_servers.my_github.command="npx""#);
+        assert_eq!(args[3], r#"mcp_servers.my_github.args=["-y"]"#);
+        assert_eq!(args[5], r#"mcp_servers.my_github.env={"A" = "b\"c"}"#);
+        // The http server contributes nothing.
+        assert_eq!(args.len(), 6);
+        assert!(codex_mcp_args(&[]).is_empty());
+    }
+
+    #[test]
+    fn slugs_are_filesystem_safe() {
+        assert_eq!(slug("Code Review!!"), "code-review");
+        assert_eq!(slug("  émigré  "), "migr");
+        assert_eq!(slug("!!!"), "skill");
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -281,6 +281,8 @@ pub async fn spawn_agent(
     model: Option<String>,
     instructions: Option<String>,
     custom_agent_id: Option<String>,
+    skills: Option<Vec<crate::agent_profile::SkillSnapshot>>,
+    mcp_servers: Option<Vec<crate::agent_profile::McpServerSnapshot>>,
     fork_base: Option<String>,
 ) -> Result<AgentRecord> {
     let sup = supervisor.inner().clone();
@@ -295,6 +297,8 @@ pub async fn spawn_agent(
             model,
             instructions,
             custom_agent_id,
+            skills: skills.unwrap_or_default(),
+            mcp_servers: mcp_servers.unwrap_or_default(),
             fork_base,
         },
     )

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -142,6 +142,7 @@ const MIGRATIONS: &[&str] = &[
     include_str!("../migrations/0014_pr_times_and_usage_daily.sql"),
     include_str!("../migrations/0015_worktree_pr_snapshot.sql"),
     include_str!("../migrations/0016_pending_messages.sql"),
+    include_str!("../migrations/0017_skills_and_mcp_servers.sql"),
 ];
 
 fn get_migrations() -> Migrations<'static> {

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -111,8 +111,9 @@ pub fn prepend_to_prompt(prompt: &str, session_id: Option<&str>, extra: Option<&
 }
 
 /// Encode `s` as a TOML basic string (double-quoted, with escapes), so it can
-/// be passed as the value half of a `-c key=value` config override.
-fn toml_basic_string(s: &str) -> String {
+/// be passed as the value half of a `-c key=value` config override. Also used
+/// by `agent_profile` for codex `mcp_servers.*` overrides.
+pub(crate) fn toml_basic_string(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 2);
     out.push('"');
     for c in s.chars() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod activity;
 mod agent;
 mod agent_install;
+mod agent_profile;
 mod bin_resolve;
 mod child_io;
 mod commands;

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -163,6 +163,10 @@ pub struct SpawnRequest {
     pub instructions: Option<String>,
     /// Custom agent identity; `None` for a plain built-in spawn.
     pub custom_agent_id: Option<String>,
+    /// Custom agent's skills, snapshotted by value (see `agent_profile`).
+    pub skills: Vec<crate::agent_profile::SkillSnapshot>,
+    /// Custom agent's MCP servers, snapshotted by value (see `agent_profile`).
+    pub mcp_servers: Vec<crate::agent_profile::McpServerSnapshot>,
     /// Base the checkout forks from, which also becomes the agent's recorded
     /// parent branch (PR base / ahead-behind). The new-agent screen passes the
     /// chosen base branch here; a workflow step instead passes the previous
@@ -186,6 +190,8 @@ impl Supervisor {
             model,
             instructions,
             custom_agent_id,
+            skills,
+            mcp_servers,
             fork_base,
         } = req;
         if !repo_path.join(".git").exists() {
@@ -268,6 +274,10 @@ impl Supervisor {
         // built-in spawn. The brief is re-injected on every spawn/resume.
         record.instructions = instructions;
         record.custom_agent_id = custom_agent_id;
+        // Skill/MCP snapshots, persisted like the brief so every process spawn
+        // (fresh, view-switch, resume) re-materializes the same profile.
+        record.skills = skills;
+        record.mcp_servers = mcp_servers;
         // Stamp the sandbox engine at creation: the agent keeps this engine
         // for life (respawn, view-switch, restore), so a later settings change
         // never re-engines it — see `spawn_agent_process`, which reuses the
@@ -599,6 +609,26 @@ impl Supervisor {
         // respawn), not just fresh spawns: only claude runs under docker.
         ensure_engine_supports_provider(engine, &record.provider)?;
 
+        // Materialize the session's skill snapshot under the writable root and
+        // fold its index into the injected instructions. Recomputed on every
+        // launch path so the files always exist (e.g. after a checkout is
+        // recreated) and always match the snapshot. `None` when the session has
+        // neither a brief nor skills — the pre-profile behavior.
+        let instructions = crate::agent_profile::effective_instructions(
+            record.instructions.as_deref(),
+            &record.skills,
+            &sandbox_root,
+        )?;
+        // Claude's generated MCP config, regenerated from the snapshot each
+        // launch and passed via `--mcp-config` + `--strict-mcp-config`. Other
+        // providers take their MCP delivery from the spec's snapshot instead
+        // (codex `-c` overrides); see `agent_profile`.
+        let mcp_config = if record.provider == "claude" {
+            crate::agent_profile::write_claude_mcp_config(&record.mcp_servers, &sandbox_root)?
+        } else {
+            None
+        };
+
         if per_turn {
             match record.view {
                 // Native view: launch the agent's interactive TUI in a PTY,
@@ -621,7 +651,9 @@ impl Supervisor {
                         // not at spawn.
                         effort: None,
                         model: record.model.as_deref(),
-                        instructions: record.instructions.as_deref(),
+                        instructions: instructions.as_deref(),
+                        mcp_servers: &record.mcp_servers,
+                        mcp_config: None,
                         rpc_dir,
                         cols: 120,
                         rows: 32,
@@ -647,7 +679,8 @@ impl Supervisor {
                         sandbox_root,
                         session_id,
                         model: record.model.clone(),
-                        instructions: record.instructions.clone(),
+                        instructions: instructions.clone(),
+                        mcp_servers: record.mcp_servers.clone(),
                         rpc_dir,
                         engine,
                     },
@@ -671,7 +704,9 @@ impl Supervisor {
                 // re-applies on every spawn (fresh, view-switch, resume).
                 effort: record.effort.as_deref(),
                 model: record.model.as_deref(),
-                instructions: record.instructions.as_deref(),
+                instructions: instructions.as_deref(),
+                mcp_servers: &record.mcp_servers,
+                mcp_config: mcp_config.as_deref(),
                 rpc_dir,
                 cols: 120,
                 rows: 32,

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -171,6 +171,16 @@ pub struct AgentRecord {
     /// name/color in the sidebar. `None` for a plain built-in spawn.
     #[serde(default)]
     pub custom_agent_id: Option<String>,
+    /// Skills snapshotted at spawn (by value, like `instructions`): materialized
+    /// as files under the agent's writable root on every process spawn, with an
+    /// index appended to the injected instructions. Empty for plain spawns.
+    #[serde(default)]
+    pub skills: Vec<crate::agent_profile::SkillSnapshot>,
+    /// MCP servers snapshotted at spawn (by value): regenerated into provider
+    /// config (claude `--mcp-config`, codex `-c mcp_servers.*`) on every process
+    /// spawn. Empty for plain spawns.
+    #[serde(default)]
+    pub mcp_servers: Vec<crate::agent_profile::McpServerSnapshot>,
     /// Sandbox engine stamped at creation (an `EngineKind::as_setting`
     /// spelling) and reused on every process spawn, so a settings change never
     /// re-engines an existing agent. `None` = created before engine selection
@@ -332,6 +342,7 @@ const AGENT_SELECT: &str = "SELECT w.id, w.project_id, w.name, w.task, w.created
             w.stopped_at, w.archived_at,
             s.provider, s.view, s.provider_session_id, s.last_error,
             s.effort, s.model, s.instructions, s.custom_agent_id,
+            s.skills, s.mcp_servers,
             w.sandbox_engine
      FROM workspaces w
      LEFT JOIN sessions s ON s.workspace_id = w.id";
@@ -353,6 +364,8 @@ type AgentRow = (
     Option<String>, // s.model
     Option<String>, // s.instructions
     Option<String>, // s.custom_agent_id
+    Option<String>, // s.skills (JSON array of SkillSnapshot)
+    Option<String>, // s.mcp_servers (JSON array of McpServerSnapshot)
     Option<String>, // w.sandbox_engine
 );
 
@@ -595,8 +608,8 @@ impl WorkspaceManager {
         // not persisted — it derives from the workspace/session dispositions.
         let session_id = uuid::Uuid::new_v4().to_string();
         tx.execute(
-            "INSERT INTO sessions (id, workspace_id, provider, view, provider_session_id, last_error, effort, model, instructions, custom_agent_id, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            "INSERT INTO sessions (id, workspace_id, provider, view, provider_session_id, last_error, effort, model, instructions, custom_agent_id, skills, mcp_servers, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
             rusqlite::params![
                 session_id,
                 record.id,
@@ -608,6 +621,8 @@ impl WorkspaceManager {
                 record.model,
                 record.instructions,
                 record.custom_agent_id,
+                encode_json_vec(&record.skills),
+                encode_json_vec(&record.mcp_servers),
                 created_millis,
             ],
         )?;
@@ -1741,7 +1756,7 @@ impl WorkspaceManager {
     }
 
     /// Map a row from an [`AGENT_SELECT`] query into the raw column tuple.
-    /// Shared by `query_all_agents` and `load_agent` so the 16-column layout
+    /// Shared by `query_all_agents` and `load_agent` so the 18-column layout
     /// is decoded in exactly one place.
     fn map_agent_row(row: &rusqlite::Row) -> rusqlite::Result<AgentRow> {
         Ok((
@@ -1761,6 +1776,8 @@ impl WorkspaceManager {
             row.get(13)?,
             row.get(14)?,
             row.get(15)?,
+            row.get(16)?,
+            row.get(17)?,
         ))
     }
 
@@ -1784,6 +1801,8 @@ impl WorkspaceManager {
             model,
             instructions,
             custom_agent_id,
+            skills_json,
+            mcp_servers_json,
             sandbox_engine,
         ) = row;
 
@@ -1820,12 +1839,32 @@ impl WorkspaceManager {
             model,
             instructions,
             custom_agent_id,
+            skills: decode_json_vec(skills_json.as_deref()),
+            mcp_servers: decode_json_vec(mcp_servers_json.as_deref()),
             sandbox_engine,
             created_at: millis_to_iso(created_millis),
             last_error,
             archive,
         }
     }
+}
+
+/// Decode a nullable JSON-array session column into a Vec, treating NULL,
+/// blank, or malformed JSON as empty — a snapshot that can't be read shouldn't
+/// keep the whole workspace from loading.
+fn decode_json_vec<T: serde::de::DeserializeOwned>(json: Option<&str>) -> Vec<T> {
+    json.filter(|s| !s.trim().is_empty())
+        .and_then(|s| serde_json::from_str(s).ok())
+        .unwrap_or_default()
+}
+
+/// Encode a snapshot Vec for its session column: `None` (SQL NULL) when empty,
+/// so plain built-in spawns keep NULL columns like they do for `instructions`.
+fn encode_json_vec<T: serde::Serialize>(items: &[T]) -> Option<String> {
+    if items.is_empty() {
+        return None;
+    }
+    serde_json::to_string(items).ok()
 }
 
 /// Per-turn agents run one process per turn, assign their own session id
@@ -1870,6 +1909,8 @@ pub fn new_agent_record(
         model: None,
         instructions: None,
         custom_agent_id: None,
+        skills: Vec::new(),
+        mcp_servers: Vec::new(),
         // Stamped by the spawn path (`supervisor::lifecycle::spawn_agent`)
         // from the live setting — callers building records directly (tests)
         // default to the pre-selection NULL, which spawns under sandbox-exec.
@@ -1889,7 +1930,11 @@ pub fn allocate_repo_subdir(repo_path: &Path, used: &[String]) -> String {
         .and_then(|n| n.to_str())
         .unwrap_or("repo")
         .to_string();
-    if !used.iter().any(|u| u == &base) {
+    // `.fletch-profile` is reserved for Fletch-generated per-agent artifacts
+    // (skill files, MCP config — see `agent_profile::PROFILE_DIR`); a repo with
+    // that basename gets a numbered subdir instead of colliding with it.
+    let reserved = base == crate::agent_profile::PROFILE_DIR;
+    if !reserved && !used.iter().any(|u| u == &base) {
         return base;
     }
     let mut n = 2;
@@ -2535,6 +2580,58 @@ mod tests {
         let plain_loaded = wm.agent(&plain_id).unwrap();
         assert_eq!(plain_loaded.instructions, None);
         assert_eq!(plain_loaded.custom_agent_id, None);
+    }
+
+    #[test]
+    fn skill_and_mcp_snapshots_round_trip() {
+        use crate::agent_profile::{McpServerSnapshot, SkillSnapshot};
+
+        let db = test_db();
+        let wm = WorkspaceManager::new(db.clone());
+        seed_repo(&db, "/r");
+
+        let mut rec = new_agent_record(
+            "rainier".into(),
+            "a".into(),
+            "claude".into(),
+            mk_repo("/r"),
+            "task".into(),
+            AgentView::Custom,
+        );
+        let id = rec.id.clone();
+        rec.skills = vec![SkillSnapshot {
+            name: "Code Review".into(),
+            description: "how we review".into(),
+            body: "# Review\nBe thorough.".into(),
+        }];
+        rec.mcp_servers = vec![McpServerSnapshot {
+            name: "GitHub".into(),
+            transport: "stdio".into(),
+            command: "npx".into(),
+            args: vec!["-y".into(), "gh-mcp".into()],
+            env: vec![("TOKEN".into(), "t".into())],
+            ..Default::default()
+        }];
+        wm.add_agent(&mut rec).unwrap();
+
+        let loaded = wm.agent(&id).unwrap();
+        assert_eq!(loaded.skills, rec.skills);
+        assert_eq!(loaded.mcp_servers, rec.mcp_servers);
+
+        // A plain spawn keeps both columns NULL → empty vecs.
+        let mut plain = new_agent_record(
+            "hood".into(),
+            "b".into(),
+            "claude".into(),
+            mk_repo("/r"),
+            "task".into(),
+            AgentView::Custom,
+        );
+        let plain_id = plain.id.clone();
+        wm.add_agent(&mut plain).unwrap();
+        let plain_loaded = wm.agent(&plain_id).unwrap();
+        assert!(plain_loaded.skills.is_empty());
+        assert!(plain_loaded.mcp_servers.is_empty());
     }
 
     #[test]

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,7 +1,9 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import type { AgentModels } from "./data/modelCatalog/types";
+import type { McpServerSnapshot } from "./storage/mcpServers";
 import type { SandboxEngine } from "./storage/preferences";
+import type { SkillSnapshot } from "./storage/skills";
 
 export type AgentStatus = "spawning" | "running" | "idle" | "stopped" | "error";
 
@@ -508,6 +510,11 @@ export const api = {
      *  branch; a workflow step instead passes the previous step's HEAD
      *  (commit-ish) so its checkout continues that work. */
     forkBase?: string,
+    /** A custom agent's skills, resolved by value at spawn (snapshotted onto
+     *  the session like `instructions`). */
+    skills?: SkillSnapshot[],
+    /** A custom agent's MCP servers, resolved by value at spawn. */
+    mcpServers?: McpServerSnapshot[],
   ) =>
     invoke<AgentRecord>("spawn_agent", {
       view,
@@ -518,6 +525,8 @@ export const api = {
       model: model ?? null,
       instructions: instructions ?? null,
       customAgentId: customAgentId ?? null,
+      skills: skills ?? null,
+      mcpServers: mcpServers ?? null,
       forkBase: forkBase ?? null,
     }),
   writeToAgent: (agentId: string, data: string) =>

--- a/src/components/SettingsScreen/CustomAgents/AgentEditor.tsx
+++ b/src/components/SettingsScreen/CustomAgents/AgentEditor.tsx
@@ -9,7 +9,7 @@ import type { NewCustomAgent } from "@/storage/customAgents";
 import { useAppStore } from "@/store";
 import { AssignPicker } from "./AssignPicker";
 import { Mono } from "./Mono";
-import { CA_HUES, INJECTION_HINT, MCP_HINT, MCP_SUPPORT } from "./shared";
+import { CA_HUES, INJECTION_HINT, MCP_HINT, MCP_SUPPORT, mcpAttachable } from "./shared";
 
 /** Mutable editor form state. `model`/`effort` use "" as the "provider default"
  *  sentinel so the <select> has a concrete value; converted to null on save. */
@@ -78,6 +78,17 @@ export function AgentEditor({
 
   const canSave = form.name.trim().length > 0;
 
+  const mcpSupport = MCP_SUPPORT[form.base] ?? "none";
+
+  /** A saved id must be one the selected base can deliver: switching base
+   *  (e.g. Claude → Codex with an HTTP server attached) must not persist
+   *  assignments the spawn path would silently drop. Ids without a library row
+   *  pass through — the delete path already detaches those. */
+  const deliverable = (id: string) => {
+    const server = mcpServers.find((s) => s.id === id);
+    return !server || mcpAttachable(mcpSupport, server.transport);
+  };
+
   const submit = () => {
     if (!canSave) return;
     onSave({
@@ -89,11 +100,9 @@ export function AgentEditor({
       effort: form.effort || null,
       instructions: form.instructions,
       skillIds: form.skillIds,
-      mcpServerIds: form.mcpServerIds,
+      mcpServerIds: form.mcpServerIds.filter(deliverable),
     });
   };
-
-  const mcpSupport = MCP_SUPPORT[form.base] ?? "none";
 
   return (
     <div className="set-pane">
@@ -225,8 +234,7 @@ export function AgentEditor({
           </label>
           <AssignPicker
             items={mcpServers.map((s) => {
-              const unattachable =
-                mcpSupport === "none" || (mcpSupport === "stdio" && s.transport === "http");
+              const unattachable = !mcpAttachable(mcpSupport, s.transport);
               const target = s.transport === "http" ? s.url : s.command;
               return {
                 id: s.id,

--- a/src/components/SettingsScreen/CustomAgents/AgentEditor.tsx
+++ b/src/components/SettingsScreen/CustomAgents/AgentEditor.tsx
@@ -4,7 +4,7 @@ import { ProviderIcon } from "@/components/ProviderIcon";
 import { SetSeg } from "@/components/SettingsScreen/primitives";
 import { Button } from "@/components/ui/Button";
 import { Select } from "@/components/ui/Select";
-import { MCP_SUPPORT, PROVIDERS, mcpAttachable } from "@/data/providers";
+import { MCP_SUPPORT, mcpAttachable, PROVIDERS } from "@/data/providers";
 import type { NewCustomAgent } from "@/storage/customAgents";
 import { useAppStore } from "@/store";
 import { AssignPicker } from "./AssignPicker";

--- a/src/components/SettingsScreen/CustomAgents/AgentEditor.tsx
+++ b/src/components/SettingsScreen/CustomAgents/AgentEditor.tsx
@@ -4,12 +4,12 @@ import { ProviderIcon } from "@/components/ProviderIcon";
 import { SetSeg } from "@/components/SettingsScreen/primitives";
 import { Button } from "@/components/ui/Button";
 import { Select } from "@/components/ui/Select";
-import { PROVIDERS } from "@/data/providers";
+import { MCP_SUPPORT, PROVIDERS, mcpAttachable } from "@/data/providers";
 import type { NewCustomAgent } from "@/storage/customAgents";
 import { useAppStore } from "@/store";
 import { AssignPicker } from "./AssignPicker";
 import { Mono } from "./Mono";
-import { CA_HUES, INJECTION_HINT, MCP_HINT, MCP_SUPPORT, mcpAttachable } from "./shared";
+import { CA_HUES, INJECTION_HINT, MCP_HINT } from "./shared";
 
 /** Mutable editor form state. `model`/`effort` use "" as the "provider default"
  *  sentinel so the <select> has a concrete value; converted to null on save. */

--- a/src/components/SettingsScreen/CustomAgents/AgentEditor.tsx
+++ b/src/components/SettingsScreen/CustomAgents/AgentEditor.tsx
@@ -9,7 +9,7 @@ import type { NewCustomAgent } from "@/storage/customAgents";
 import { useAppStore } from "@/store";
 import { AssignPicker } from "./AssignPicker";
 import { Mono } from "./Mono";
-import { CA_HUES, INJECTION_HINT, MCP_SUPPORTED_BASES } from "./shared";
+import { CA_HUES, INJECTION_HINT, MCP_HINT, MCP_SUPPORT } from "./shared";
 
 /** Mutable editor form state. `model`/`effort` use "" as the "provider default"
  *  sentinel so the <select> has a concrete value; converted to null on save. */
@@ -93,7 +93,7 @@ export function AgentEditor({
     });
   };
 
-  const mcpSupported = MCP_SUPPORTED_BASES.has(form.base);
+  const mcpSupport = MCP_SUPPORT[form.base] ?? "none";
 
   return (
     <div className="set-pane">
@@ -221,18 +221,23 @@ export function AgentEditor({
         <div className="set-field ca-field">
           <label className="set-field-label text-sm">
             Tools (MCP)
-            <span className="ca-field-hint">
-              {mcpSupported
-                ? "MCP servers attached when this agent runs"
-                : "Not supported by this base — the agent will run without attached tools"}
-            </span>
+            <span className="ca-field-hint">{MCP_HINT[mcpSupport]}</span>
           </label>
           <AssignPicker
-            items={mcpServers.map((s) => ({
-              id: s.id,
-              name: s.name,
-              detail: s.transport === "http" ? s.url : s.command,
-            }))}
+            items={mcpServers.map((s) => {
+              const unattachable =
+                mcpSupport === "none" || (mcpSupport === "stdio" && s.transport === "http");
+              const target = s.transport === "http" ? s.url : s.command;
+              return {
+                id: s.id,
+                name: s.name,
+                detail:
+                  unattachable && mcpSupport === "stdio"
+                    ? `${target} — HTTP servers aren't supported by this base`
+                    : target,
+                disabled: unattachable,
+              };
+            })}
             selected={form.mcpServerIds}
             onChange={(mcpServerIds) => set({ mcpServerIds })}
             emptyHint="No MCP servers yet — add them under Settings → Tools."

--- a/src/components/SettingsScreen/CustomAgents/AgentEditor.tsx
+++ b/src/components/SettingsScreen/CustomAgents/AgentEditor.tsx
@@ -7,8 +7,9 @@ import { Select } from "@/components/ui/Select";
 import { PROVIDERS } from "@/data/providers";
 import type { NewCustomAgent } from "@/storage/customAgents";
 import { useAppStore } from "@/store";
+import { AssignPicker } from "./AssignPicker";
 import { Mono } from "./Mono";
-import { CA_HUES, INJECTION_HINT } from "./shared";
+import { CA_HUES, INJECTION_HINT, MCP_SUPPORTED_BASES } from "./shared";
 
 /** Mutable editor form state. `model`/`effort` use "" as the "provider default"
  *  sentinel so the <select> has a concrete value; converted to null on save. */
@@ -20,6 +21,8 @@ interface Form {
   model: string;
   effort: string;
   instructions: string;
+  skillIds: string[];
+  mcpServerIds: string[];
 }
 
 const EFFORTS = [
@@ -42,6 +45,8 @@ export function AgentEditor({
 }) {
   const modelsByAgent = useAppStore((s) => s.modelsByAgent);
   const providerFlags = useAppStore((s) => s.providerFlags);
+  const skills = useAppStore((s) => s.skills);
+  const mcpServers = useAppStore((s) => s.mcpServers);
 
   const [form, setForm] = useState<Form>({
     name: initial.name,
@@ -51,6 +56,8 @@ export function AgentEditor({
     model: initial.model ?? "",
     effort: initial.effort ?? "",
     instructions: initial.instructions,
+    skillIds: initial.skillIds,
+    mcpServerIds: initial.mcpServerIds,
   });
 
   const set = (patch: Partial<Form>) => setForm((f) => ({ ...f, ...patch }));
@@ -81,8 +88,12 @@ export function AgentEditor({
       model: form.model || null,
       effort: form.effort || null,
       instructions: form.instructions,
+      skillIds: form.skillIds,
+      mcpServerIds: form.mcpServerIds,
     });
   };
+
+  const mcpSupported = MCP_SUPPORTED_BASES.has(form.base);
 
   return (
     <div className="set-pane">
@@ -187,6 +198,44 @@ export function AgentEditor({
             value={form.instructions}
             placeholder="Describe this agent's role, how it should work, and what it should hand off…"
             onChange={(e) => set({ instructions: e.target.value })}
+          />
+        </div>
+
+        {/* skills */}
+        <div className="set-field ca-field">
+          <label className="set-field-label text-sm">
+            Skills
+            <span className="ca-field-hint">
+              Instruction documents this agent loads on demand — works on every base
+            </span>
+          </label>
+          <AssignPicker
+            items={skills.map((s) => ({ id: s.id, name: s.name, detail: s.description }))}
+            selected={form.skillIds}
+            onChange={(skillIds) => set({ skillIds })}
+            emptyHint="No skills yet — create them under Settings → Skills."
+          />
+        </div>
+
+        {/* tools (MCP servers) */}
+        <div className="set-field ca-field">
+          <label className="set-field-label text-sm">
+            Tools (MCP)
+            <span className="ca-field-hint">
+              {mcpSupported
+                ? "MCP servers attached when this agent runs"
+                : "Not supported by this base — the agent will run without attached tools"}
+            </span>
+          </label>
+          <AssignPicker
+            items={mcpServers.map((s) => ({
+              id: s.id,
+              name: s.name,
+              detail: s.transport === "http" ? s.url : s.command,
+            }))}
+            selected={form.mcpServerIds}
+            onChange={(mcpServerIds) => set({ mcpServerIds })}
+            emptyHint="No MCP servers yet — add them under Settings → Tools."
           />
         </div>
 

--- a/src/components/SettingsScreen/CustomAgents/AgentList.tsx
+++ b/src/components/SettingsScreen/CustomAgents/AgentList.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
 import { Icon } from "@/components/Icon";
+import { ArmedDeleteButton, useArmedDelete } from "@/components/SettingsScreen/LibraryList";
 import { SetHead } from "@/components/SettingsScreen/primitives";
 import { Button } from "@/components/ui/Button";
 import { IconButton } from "@/components/ui/IconButton";
@@ -22,15 +22,7 @@ export function AgentList({
   onDelete: (a: CustomAgent) => void;
 }) {
   const modelsByAgent = useAppStore((s) => s.modelsByAgent);
-  // Two-click delete confirm (matches the FileContextMenu "Confirm Delete?"
-  // idiom): the first trash click arms the row, the second deletes. Auto-disarms
-  // after a few seconds so a stray click never leaves a row stuck in danger.
-  const [armedDeleteId, setArmedDeleteId] = useState<string | null>(null);
-  useEffect(() => {
-    if (!armedDeleteId) return;
-    const t = setTimeout(() => setArmedDeleteId(null), 3000);
-    return () => clearTimeout(t);
-  }, [armedDeleteId]);
+  const { armedId, fire } = useArmedDelete();
 
   const modelLabel = (a: CustomAgent): string => {
     if (!a.model) return "Default model";
@@ -111,23 +103,10 @@ export function AgentList({
                   >
                     <Icon name="edit" />
                   </IconButton>
-                  <IconButton
-                    size="sm"
-                    className={armedDeleteId === a.id ? "danger" : undefined}
-                    tipDown
-                    tip={armedDeleteId === a.id ? "Click again to delete" : "Delete"}
-                    aria-label={armedDeleteId === a.id ? "Confirm delete" : "Delete"}
-                    onClick={() => {
-                      if (armedDeleteId === a.id) {
-                        onDelete(a);
-                        setArmedDeleteId(null);
-                      } else {
-                        setArmedDeleteId(a.id);
-                      }
-                    }}
-                  >
-                    <Icon name={armedDeleteId === a.id ? "check" : "trash"} />
-                  </IconButton>
+                  <ArmedDeleteButton
+                    armed={armedId === a.id}
+                    onClick={() => fire(a.id, () => onDelete(a))}
+                  />
                 </div>
               </div>
             );

--- a/src/components/SettingsScreen/CustomAgents/AssignPicker.tsx
+++ b/src/components/SettingsScreen/CustomAgents/AssignPicker.tsx
@@ -2,14 +2,17 @@ import { SetToggle } from "@/components/SettingsScreen/primitives";
 
 /** A toggle-list for assigning shared library items (skills, MCP servers) to a
  *  custom agent. Selection is an ordered id array: toggling on appends, so the
- *  spawn snapshot preserves the order items were assigned in. */
+ *  spawn snapshot preserves the order items were assigned in. A `disabled`
+ *  item can't be toggled ON (the base can't deliver it — see `MCP_SUPPORT`),
+ *  but an already-selected one can still be toggled OFF so stale assignments
+ *  are cleanable after a base switch. */
 export function AssignPicker({
   items,
   selected,
   onChange,
   emptyHint,
 }: {
-  items: { id: string; name: string; detail?: string }[];
+  items: { id: string; name: string; detail?: string; disabled?: boolean }[];
   selected: string[];
   onChange: (next: string[]) => void;
   emptyHint: string;
@@ -23,17 +26,24 @@ export function AssignPicker({
 
   return (
     <div className="set-rows">
-      {items.map((item) => (
-        <div key={item.id} className="set-row flex-center">
-          <div className="set-row-l">
-            <div className="set-row-t text-base">{item.name}</div>
-            {item.detail && <div className="set-row-s text-sm truncate">{item.detail}</div>}
+      {items.map((item) => {
+        const on = selected.includes(item.id);
+        return (
+          <div
+            key={item.id}
+            className="set-row flex-center"
+            style={item.disabled ? { opacity: 0.55 } : undefined}
+          >
+            <div className="set-row-l">
+              <div className="set-row-t text-base">{item.name}</div>
+              {item.detail && <div className="set-row-s text-sm truncate">{item.detail}</div>}
+            </div>
+            <div className="set-row-c flex-center">
+              <SetToggle on={on} disabled={item.disabled && !on} onClick={() => toggle(item.id)} />
+            </div>
           </div>
-          <div className="set-row-c flex-center">
-            <SetToggle on={selected.includes(item.id)} onClick={() => toggle(item.id)} />
-          </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/src/components/SettingsScreen/CustomAgents/AssignPicker.tsx
+++ b/src/components/SettingsScreen/CustomAgents/AssignPicker.tsx
@@ -1,0 +1,39 @@
+import { SetToggle } from "@/components/SettingsScreen/primitives";
+
+/** A toggle-list for assigning shared library items (skills, MCP servers) to a
+ *  custom agent. Selection is an ordered id array: toggling on appends, so the
+ *  spawn snapshot preserves the order items were assigned in. */
+export function AssignPicker({
+  items,
+  selected,
+  onChange,
+  emptyHint,
+}: {
+  items: { id: string; name: string; detail?: string }[];
+  selected: string[];
+  onChange: (next: string[]) => void;
+  emptyHint: string;
+}) {
+  if (items.length === 0) {
+    return <div className="ca-field-hint text-sm">{emptyHint}</div>;
+  }
+
+  const toggle = (id: string) =>
+    onChange(selected.includes(id) ? selected.filter((x) => x !== id) : [...selected, id]);
+
+  return (
+    <div className="set-rows">
+      {items.map((item) => (
+        <div key={item.id} className="set-row flex-center">
+          <div className="set-row-l">
+            <div className="set-row-t text-base">{item.name}</div>
+            {item.detail && <div className="set-row-s text-sm truncate">{item.detail}</div>}
+          </div>
+          <div className="set-row-c flex-center">
+            <SetToggle on={selected.includes(item.id)} onClick={() => toggle(item.id)} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/SettingsScreen/CustomAgents/index.tsx
+++ b/src/components/SettingsScreen/CustomAgents/index.tsx
@@ -21,6 +21,8 @@ function blankAgent(seed: number): NewCustomAgent {
     model: null,
     effort: null,
     instructions: "",
+    skillIds: [],
+    mcpServerIds: [],
   };
 }
 

--- a/src/components/SettingsScreen/CustomAgents/shared.ts
+++ b/src/components/SettingsScreen/CustomAgents/shared.ts
@@ -27,3 +27,10 @@ export const INJECTION_HINT: Record<string, string> = {
   antigravity: "prepended to the first message",
   pi: "--append-system-prompt",
 };
+
+/** Which base providers can attach MCP servers — mirrors the backend delivery
+ *  in `agent_profile.rs` (claude `--mcp-config`, codex `-c mcp_servers.*`).
+ *  Skills need no such map: the materialize-and-index mechanism works on every
+ *  base. Surfaced in the editor so attaching tools to an unsupported base is
+ *  honest about being a no-op. */
+export const MCP_SUPPORTED_BASES: ReadonlySet<string> = new Set(["claude", "codex"]);

--- a/src/components/SettingsScreen/CustomAgents/shared.ts
+++ b/src/components/SettingsScreen/CustomAgents/shared.ts
@@ -28,9 +28,22 @@ export const INJECTION_HINT: Record<string, string> = {
   pi: "--append-system-prompt",
 };
 
-/** Which base providers can attach MCP servers — mirrors the backend delivery
- *  in `agent_profile.rs` (claude `--mcp-config`, codex `-c mcp_servers.*`).
+/** Which MCP transports each base provider can attach — mirrors the backend
+ *  delivery in `agent_profile.rs`: claude takes stdio + http via
+ *  `--mcp-config`, codex only stdio via `-c mcp_servers.*` (its `-c` config
+ *  has no http transport), and the rest have no MCP surface we can drive.
  *  Skills need no such map: the materialize-and-index mechanism works on every
- *  base. Surfaced in the editor so attaching tools to an unsupported base is
- *  honest about being a no-op. */
-export const MCP_SUPPORTED_BASES: ReadonlySet<string> = new Set(["claude", "codex"]);
+ *  base. Surfaced in the editor so unattachable servers are disabled up front
+ *  instead of being silently ignored at spawn. */
+export type McpSupport = "all" | "stdio" | "none";
+export const MCP_SUPPORT: Record<string, McpSupport> = {
+  claude: "all",
+  codex: "stdio",
+};
+
+/** Editor hint line for the Tools section, by the base's MCP support level. */
+export const MCP_HINT: Record<McpSupport, string> = {
+  all: "MCP servers attached when this agent runs",
+  stdio: "MCP servers attached when this agent runs — command (stdio) servers only",
+  none: "Not supported by this base — the agent will run without attached tools",
+};

--- a/src/components/SettingsScreen/CustomAgents/shared.ts
+++ b/src/components/SettingsScreen/CustomAgents/shared.ts
@@ -1,6 +1,6 @@
 // Shared helpers + constants for the Custom Agents settings pane.
 
-import type { McpTransport } from "@/storage/mcpServers";
+import type { McpSupport } from "@/data/providers";
 
 /** Preset hues for the monogram tile (evenly spread around the wheel). */
 export const CA_HUES = [265, 150, 25, 215, 320, 95, 175, 50] as const;
@@ -30,27 +30,10 @@ export const INJECTION_HINT: Record<string, string> = {
   pi: "--append-system-prompt",
 };
 
-/** Which MCP transports each base provider can attach — mirrors the backend
- *  delivery in `agent_profile.rs`: claude takes stdio + http via
- *  `--mcp-config`, codex only stdio via `-c mcp_servers.*` (its `-c` config
- *  has no http transport), and the rest have no MCP surface we can drive.
- *  Skills need no such map: the materialize-and-index mechanism works on every
- *  base. Surfaced in the editor so unattachable servers are disabled up front
- *  instead of being silently ignored at spawn. */
-export type McpSupport = "all" | "stdio" | "none";
-export const MCP_SUPPORT: Record<string, McpSupport> = {
-  claude: "all",
-  codex: "stdio",
-};
-
-/** Whether a base with `support` can actually deliver a server of `transport`
- *  at spawn. The single rule behind both the editor's disabled rows and the
- *  save-path filter, so the two can't drift. */
-export function mcpAttachable(support: McpSupport, transport: McpTransport): boolean {
-  return support === "all" || (support === "stdio" && transport !== "http");
-}
-
-/** Editor hint line for the Tools section, by the base's MCP support level. */
+/** Editor hint line for the Tools section, by the base's MCP support level
+ *  (see `MCP_SUPPORT`/`mcpAttachable` in data/providers.ts — capability data
+ *  lives there so the spawn path can apply the same rule). Skills need no such
+ *  map: the materialize-and-index mechanism works on every base. */
 export const MCP_HINT: Record<McpSupport, string> = {
   all: "MCP servers attached when this agent runs",
   stdio: "MCP servers attached when this agent runs — command (stdio) servers only",

--- a/src/components/SettingsScreen/CustomAgents/shared.ts
+++ b/src/components/SettingsScreen/CustomAgents/shared.ts
@@ -1,5 +1,7 @@
 // Shared helpers + constants for the Custom Agents settings pane.
 
+import type { McpTransport } from "@/storage/mcpServers";
+
 /** Preset hues for the monogram tile (evenly spread around the wheel). */
 export const CA_HUES = [265, 150, 25, 215, 320, 95, 175, 50] as const;
 
@@ -40,6 +42,13 @@ export const MCP_SUPPORT: Record<string, McpSupport> = {
   claude: "all",
   codex: "stdio",
 };
+
+/** Whether a base with `support` can actually deliver a server of `transport`
+ *  at spawn. The single rule behind both the editor's disabled rows and the
+ *  save-path filter, so the two can't drift. */
+export function mcpAttachable(support: McpSupport, transport: McpTransport): boolean {
+  return support === "all" || (support === "stdio" && transport !== "http");
+}
 
 /** Editor hint line for the Tools section, by the base's MCP support level. */
 export const MCP_HINT: Record<McpSupport, string> = {

--- a/src/components/SettingsScreen/LibraryList.tsx
+++ b/src/components/SettingsScreen/LibraryList.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useState } from "react";
+import { Icon, type IconName } from "@/components/Icon";
+import { SetHead } from "@/components/SettingsScreen/primitives";
+import { Button } from "@/components/ui/Button";
+import { IconButton } from "@/components/ui/IconButton";
+
+// Shared scaffolding for the settings "library" panes (custom agents, skills,
+// MCP servers): the two-click delete idiom, its trash/confirm button, and a
+// generic head + card-list pane for libraries without bespoke row chrome.
+
+/** Two-click delete confirm (matches the FileContextMenu "Confirm Delete?"
+ *  idiom): the first trash click arms the row, the second fires. Auto-disarms
+ *  after a few seconds so a stray click never leaves a row stuck in danger. */
+export function useArmedDelete(): {
+  armedId: string | null;
+  /** Arm `id`, or run `del` if it's already armed. */
+  fire: (id: string, del: () => void) => void;
+} {
+  const [armedId, setArmedId] = useState<string | null>(null);
+  useEffect(() => {
+    if (!armedId) return;
+    const t = setTimeout(() => setArmedId(null), 3000);
+    return () => clearTimeout(t);
+  }, [armedId]);
+  const fire = (id: string, del: () => void) => {
+    if (armedId === id) {
+      del();
+      setArmedId(null);
+    } else {
+      setArmedId(id);
+    }
+  };
+  return { armedId, fire };
+}
+
+/** The armed-delete row action: trash when idle, check-in-danger when armed. */
+export function ArmedDeleteButton({ armed, onClick }: { armed: boolean; onClick: () => void }) {
+  return (
+    <IconButton
+      size="sm"
+      className={armed ? "danger" : undefined}
+      tipDown
+      tip={armed ? "Click again to delete" : "Delete"}
+      aria-label={armed ? "Confirm delete" : "Delete"}
+      onClick={onClick}
+    >
+      <Icon name={armed ? "check" : "trash"} />
+    </IconButton>
+  );
+}
+
+/** A settings pane listing a shared library: head + new action, an empty-state
+ *  CTA, and one card per item (icon, name, badge, description, edit/delete).
+ *  Rows without bespoke chrome (monogram tiles, extra actions) render through
+ *  this; the custom-agent list keeps its own markup and shares the delete
+ *  idiom via {@link useArmedDelete}. */
+export function LibraryList<T extends { id: string }>({
+  eyebrow,
+  title,
+  desc,
+  newLabel,
+  emptyLabel,
+  icon,
+  items,
+  row,
+  onNew,
+  onEdit,
+  onDelete,
+}: {
+  eyebrow: string;
+  title: string;
+  desc: string;
+  newLabel: string;
+  emptyLabel: string;
+  icon: IconName;
+  items: T[];
+  /** Card copy for one item: its display name, the small badge next to it
+   *  (e.g. "2 agents"), and the one-line description under it. */
+  row: (item: T) => { name: string; badge: string; desc: string };
+  onNew: () => void;
+  onEdit: (item: T) => void;
+  onDelete: (item: T) => void;
+}) {
+  const { armedId, fire } = useArmedDelete();
+
+  return (
+    <div className="set-pane">
+      <SetHead
+        eyebrow={eyebrow}
+        title={title}
+        desc={desc}
+        actions={
+          <Button variant="primary" onClick={onNew}>
+            <Icon name="plus" size={13} /> {newLabel}
+          </Button>
+        }
+      />
+
+      {items.length === 0 ? (
+        <button className="ca-empty flex-center text-base" onClick={onNew}>
+          <span className="ca-empty-ic iflex-center">
+            <Icon name="plus" />
+          </span>
+          <span>{emptyLabel}</span>
+        </button>
+      ) : (
+        <div className="ca-list">
+          {items.map((item) => {
+            const r = row(item);
+            return (
+              <div
+                key={item.id}
+                className="ca-card flex-center"
+                role="button"
+                tabIndex={0}
+                onClick={() => onEdit(item)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onEdit(item);
+                  }
+                }}
+              >
+                <span className="ca-empty-ic iflex-center">
+                  <Icon name={icon} size={16} />
+                </span>
+                <div className="ca-id">
+                  <div className="ca-name flex-center text-base">
+                    {r.name}
+                    <span className="ca-base iflex-center text-xs">{r.badge}</span>
+                  </div>
+                  <div className="ca-desc truncate text-sm">{r.desc}</div>
+                </div>
+                <div className="ca-acts flex-center" onClick={(e) => e.stopPropagation()}>
+                  <IconButton
+                    size="sm"
+                    tipDown
+                    tip="Edit"
+                    aria-label="Edit"
+                    onClick={() => onEdit(item)}
+                  >
+                    <Icon name="edit" />
+                  </IconButton>
+                  <ArmedDeleteButton
+                    armed={armedId === item.id}
+                    onClick={() => fire(item.id, () => onDelete(item))}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SettingsScreen/McpServers/ServerEditor.tsx
+++ b/src/components/SettingsScreen/McpServers/ServerEditor.tsx
@@ -1,0 +1,145 @@
+import { useState } from "react";
+import { Icon } from "@/components/Icon";
+import { SetSeg } from "@/components/SettingsScreen/primitives";
+import { Button } from "@/components/ui/Button";
+import type { McpTransport, NewMcpServer } from "@/storage/mcpServers";
+
+const TRANSPORTS: { value: McpTransport; label: string }[] = [
+  { value: "stdio", label: "Command" },
+  { value: "http", label: "HTTP" },
+];
+
+export function ServerEditor({
+  initial,
+  isNew,
+  onCancel,
+  onSave,
+}: {
+  initial: NewMcpServer;
+  isNew: boolean;
+  onCancel: () => void;
+  onSave: (values: NewMcpServer) => void;
+}) {
+  const [form, setForm] = useState<NewMcpServer>({
+    name: initial.name,
+    transport: initial.transport,
+    command: initial.command,
+    env: initial.env,
+    url: initial.url,
+    headers: initial.headers,
+  });
+
+  const set = (patch: Partial<NewMcpServer>) => setForm((f) => ({ ...f, ...patch }));
+
+  const canSave =
+    form.name.trim().length > 0 &&
+    (form.transport === "stdio" ? form.command.trim().length > 0 : form.url.trim().length > 0);
+
+  const submit = () => {
+    if (!canSave) return;
+    onSave({
+      name: form.name.trim(),
+      transport: form.transport,
+      command: form.command.trim(),
+      env: form.env,
+      url: form.url.trim(),
+      headers: form.headers,
+    });
+  };
+
+  return (
+    <div className="set-pane">
+      <div className="ca-editor">
+        <button className="ca-ed-back iflex-center text-sm" onClick={onCancel}>
+          <Icon name="chevL" size={13} /> All servers
+        </button>
+
+        <div className="ca-ed-head flex-center">
+          <input
+            className="ca-ed-name text-xl"
+            placeholder="Name this server…"
+            value={form.name}
+            autoFocus
+            onChange={(e) => set({ name: e.target.value })}
+          />
+        </div>
+
+        <div className="set-field ca-field">
+          <label className="set-field-label text-sm">Transport</label>
+          <SetSeg
+            value={form.transport}
+            options={TRANSPORTS}
+            onChange={(v) => set({ transport: v })}
+          />
+        </div>
+
+        {form.transport === "stdio" ? (
+          <>
+            <div className="set-field ca-field">
+              <label className="set-field-label text-sm">
+                Command <span className="ca-req">*</span>
+                <span className="ca-field-hint">
+                  Full command line, split on spaces (quoting isn't supported)
+                </span>
+              </label>
+              <input
+                className="set-text text-base mono"
+                placeholder="npx -y @modelcontextprotocol/server-github"
+                value={form.command}
+                onChange={(e) => set({ command: e.target.value })}
+              />
+            </div>
+            <div className="set-field ca-field">
+              <label className="set-field-label text-sm">
+                Environment
+                <span className="ca-field-hint">KEY=VALUE, one per line</span>
+              </label>
+              <textarea
+                className="set-text ca-textarea text-base mono"
+                value={form.env}
+                placeholder={"GITHUB_TOKEN=ghp_…"}
+                onChange={(e) => set({ env: e.target.value })}
+              />
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="set-field ca-field">
+              <label className="set-field-label text-sm">
+                URL <span className="ca-req">*</span>
+              </label>
+              <input
+                className="set-text text-base mono"
+                placeholder="https://mcp.example.com/mcp"
+                value={form.url}
+                onChange={(e) => set({ url: e.target.value })}
+              />
+            </div>
+            <div className="set-field ca-field">
+              <label className="set-field-label text-sm">
+                Headers
+                <span className="ca-field-hint">Name: value, one per line</span>
+              </label>
+              <textarea
+                className="set-text ca-textarea text-base mono"
+                value={form.headers}
+                placeholder={"Authorization: Bearer …"}
+                onChange={(e) => set({ headers: e.target.value })}
+              />
+            </div>
+          </>
+        )}
+
+        <div className="ca-ed-foot flex-center">
+          <span className="ca-grow" />
+          <Button variant="ghost" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button variant="primary" disabled={!canSave} onClick={submit}>
+            <Icon name="check" size={13} /> {isNew ? "Add server" : "Save changes"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SettingsScreen/McpServers/index.tsx
+++ b/src/components/SettingsScreen/McpServers/index.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import { LibraryList } from "@/components/SettingsScreen/LibraryList";
+import type { McpServer, NewMcpServer } from "@/storage/mcpServers";
+import { useAppStore } from "@/store";
+import { ServerEditor } from "./ServerEditor";
+
+// Tools (MCP servers) settings pane: a list ⇄ editor switch over the shared
+// server registry. Custom agents attach servers by id; at spawn the selection
+// is snapshotted onto the session and delivered to providers that support MCP
+// (claude, codex). All mutations go through the store slice.
+
+function blankServer(): NewMcpServer {
+  return { name: "", transport: "stdio", command: "", env: "", url: "", headers: "" };
+}
+
+type EditTarget =
+  | { mode: "new"; initial: NewMcpServer }
+  | { mode: "edit"; id: string; initial: NewMcpServer };
+
+export function McpServersPane() {
+  const servers = useAppStore((s) => s.mcpServers);
+  const customAgents = useAppStore((s) => s.customAgents);
+  const createMcpServer = useAppStore((s) => s.createMcpServer);
+  const updateMcpServer = useAppStore((s) => s.updateMcpServer);
+  const deleteMcpServer = useAppStore((s) => s.deleteMcpServer);
+  const setLastError = useAppStore((s) => s.setLastError);
+
+  const [editing, setEditing] = useState<EditTarget | null>(null);
+
+  const startNew = () => setEditing({ mode: "new", initial: blankServer() });
+  const startEdit = (s: McpServer) => setEditing({ mode: "edit", id: s.id, initial: s });
+
+  /** How many agents attach a server — shown in the list. */
+  const usedBy = (id: string) => customAgents.filter((a) => a.mcpServerIds.includes(id)).length;
+
+  const save = async (values: NewMcpServer) => {
+    try {
+      if (editing?.mode === "edit") {
+        await updateMcpServer(editing.id, values);
+      } else {
+        await createMcpServer(values);
+      }
+      setEditing(null);
+    } catch (e) {
+      setLastError(`Failed to save MCP server: ${e}`);
+    }
+  };
+
+  const remove = async (s: McpServer) => {
+    try {
+      await deleteMcpServer(s.id);
+    } catch (e) {
+      setLastError(`Failed to delete MCP server: ${e}`);
+    }
+  };
+
+  if (editing) {
+    return (
+      <ServerEditor
+        initial={editing.initial}
+        isNew={editing.mode === "new"}
+        onCancel={() => setEditing(null)}
+        onSave={save}
+      />
+    );
+  }
+
+  return (
+    <LibraryList
+      eyebrow="Settings · Tools"
+      title="Tools (MCP)"
+      desc="MCP servers your custom agents can attach as tools. Supported by Claude Code and Codex bases; other bases run without them. Running sessions keep the configuration they spawned with."
+      newLabel="New server"
+      emptyLabel="Add your first MCP server"
+      icon="zap"
+      items={servers}
+      row={(s) => {
+        const count = usedBy(s.id);
+        return {
+          name: s.name,
+          badge: `${s.transport} · ${count === 1 ? "1 agent" : `${count} agents`}`,
+          desc: (s.transport === "http" ? s.url : s.command) || "Not configured.",
+        };
+      }}
+      onNew={startNew}
+      onEdit={startEdit}
+      onDelete={remove}
+    />
+  );
+}

--- a/src/components/SettingsScreen/Skills/SkillEditor.tsx
+++ b/src/components/SettingsScreen/Skills/SkillEditor.tsx
@@ -1,0 +1,95 @@
+import { useState } from "react";
+import { Icon } from "@/components/Icon";
+import { Button } from "@/components/ui/Button";
+import type { NewSkill } from "@/storage/skills";
+
+export function SkillEditor({
+  initial,
+  isNew,
+  onCancel,
+  onSave,
+}: {
+  initial: NewSkill;
+  isNew: boolean;
+  onCancel: () => void;
+  onSave: (values: NewSkill) => void;
+}) {
+  const [form, setForm] = useState<NewSkill>({
+    name: initial.name,
+    description: initial.description,
+    body: initial.body,
+  });
+
+  const set = (patch: Partial<NewSkill>) => setForm((f) => ({ ...f, ...patch }));
+  const canSave = form.name.trim().length > 0;
+
+  const submit = () => {
+    if (!canSave) return;
+    onSave({
+      name: form.name.trim(),
+      description: form.description.trim(),
+      body: form.body,
+    });
+  };
+
+  return (
+    <div className="set-pane">
+      <div className="ca-editor">
+        <button className="ca-ed-back iflex-center text-sm" onClick={onCancel}>
+          <Icon name="chevL" size={13} /> All skills
+        </button>
+
+        <div className="ca-ed-head flex-center">
+          <input
+            className="ca-ed-name text-xl"
+            placeholder="Name this skill…"
+            value={form.name}
+            autoFocus
+            onChange={(e) => set({ name: e.target.value })}
+          />
+        </div>
+
+        <div className="set-field ca-field">
+          <label className="set-field-label text-sm">
+            Description
+            <span className="ca-field-hint">
+              One line telling the agent when this skill applies — it's all the agent sees until it
+              opens the document
+            </span>
+          </label>
+          <input
+            className="set-text text-base"
+            placeholder="e.g. How we review pull requests"
+            value={form.description}
+            onChange={(e) => set({ description: e.target.value })}
+          />
+        </div>
+
+        <div className="set-field ca-field">
+          <label className="set-field-label text-sm">
+            Document
+            <span className="ca-field-hint">
+              Markdown, given to the agent as a file it reads when the task matches
+            </span>
+          </label>
+          <textarea
+            className="set-text ca-textarea text-base"
+            value={form.body}
+            placeholder="Write the instructions, steps, or reference material for this skill…"
+            onChange={(e) => set({ body: e.target.value })}
+          />
+        </div>
+
+        <div className="ca-ed-foot flex-center">
+          <span className="ca-grow" />
+          <Button variant="ghost" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button variant="primary" disabled={!canSave} onClick={submit}>
+            <Icon name="check" size={13} /> {isNew ? "Create skill" : "Save changes"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SettingsScreen/Skills/index.tsx
+++ b/src/components/SettingsScreen/Skills/index.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+import { LibraryList } from "@/components/SettingsScreen/LibraryList";
+import type { NewSkill, Skill } from "@/storage/skills";
+import { useAppStore } from "@/store";
+import { SkillEditor } from "./SkillEditor";
+
+// Skills settings pane: a list ⇄ editor switch over the shared skills library.
+// Skills are named instruction documents custom agents attach; at spawn they're
+// snapshotted onto the session and materialized as files the agent reads on
+// demand. All mutations go through the store slice, which writes to the db and
+// keeps the list in sync.
+
+function blankSkill(): NewSkill {
+  return { name: "", description: "", body: "" };
+}
+
+type EditTarget =
+  | { mode: "new"; initial: NewSkill }
+  | { mode: "edit"; id: string; initial: NewSkill };
+
+export function SkillsPane() {
+  const skills = useAppStore((s) => s.skills);
+  const customAgents = useAppStore((s) => s.customAgents);
+  const createSkill = useAppStore((s) => s.createSkill);
+  const updateSkill = useAppStore((s) => s.updateSkill);
+  const deleteSkill = useAppStore((s) => s.deleteSkill);
+  const setLastError = useAppStore((s) => s.setLastError);
+
+  const [editing, setEditing] = useState<EditTarget | null>(null);
+
+  const startNew = () => setEditing({ mode: "new", initial: blankSkill() });
+  const startEdit = (s: Skill) => setEditing({ mode: "edit", id: s.id, initial: s });
+
+  /** How many agents carry a skill — shown in the list so it's obvious a
+   *  library edit reaches every one of them (future sessions only). */
+  const usedBy = (id: string) => customAgents.filter((a) => a.skillIds.includes(id)).length;
+
+  const save = async (values: NewSkill) => {
+    try {
+      if (editing?.mode === "edit") {
+        await updateSkill(editing.id, values);
+      } else {
+        await createSkill(values);
+      }
+      setEditing(null);
+    } catch (e) {
+      setLastError(`Failed to save skill: ${e}`);
+    }
+  };
+
+  const remove = async (s: Skill) => {
+    try {
+      await deleteSkill(s.id);
+    } catch (e) {
+      setLastError(`Failed to delete skill: ${e}`);
+    }
+  };
+
+  if (editing) {
+    return (
+      <SkillEditor
+        initial={editing.initial}
+        isNew={editing.mode === "new"}
+        onCancel={() => setEditing(null)}
+        onSave={save}
+      />
+    );
+  }
+
+  return (
+    <LibraryList
+      eyebrow="Settings · Skills"
+      title="Skills"
+      desc="Named instruction documents your custom agents load on demand. Assign skills to agents in their editor; running sessions keep the version they spawned with."
+      newLabel="New skill"
+      emptyLabel="Create your first skill"
+      icon="notebookPen"
+      items={skills}
+      row={(s) => {
+        const count = usedBy(s.id);
+        return {
+          name: s.name,
+          badge: count === 1 ? "1 agent" : `${count} agents`,
+          desc: s.description || s.body || "Empty skill.",
+        };
+      }}
+      onNew={startNew}
+      onEdit={startEdit}
+      onDelete={remove}
+    />
+  );
+}

--- a/src/components/SettingsScreen/index.tsx
+++ b/src/components/SettingsScreen/index.tsx
@@ -7,7 +7,9 @@ import { AccountPane } from "./AccountPane";
 import { CustomAgentsPane } from "./CustomAgents";
 import { ExperimentalPane } from "./ExperimentalPane";
 import { GeneralPane } from "./GeneralPane";
+import { McpServersPane } from "./McpServers";
 import { ProvidersPane } from "./ProvidersPane";
+import { SkillsPane } from "./Skills";
 
 // Lazily loaded behind `import.meta.env.DEV`. In production the ternary's dead
 // branch — including the dynamic import() — is dropped by Rollup, so the
@@ -25,6 +27,8 @@ const NAV: NavItem[] = [
   { id: "general", label: "General", icon: "settings", order: 20 },
   { id: "providers", label: "Providers", icon: "cube", order: 30 },
   { id: "agents", label: "Custom agents", icon: "bot", order: 40 },
+  { id: "skills", label: "Skills", icon: "notebookPen", order: 42 },
+  { id: "tools", label: "Tools", icon: "zap", order: 44 },
   { id: "experimental", label: "Experimental", icon: "flask", order: 50 },
   // Dev-only: omitted entirely from production builds.
   ...(DeveloperPane
@@ -72,6 +76,8 @@ export function SettingsScreen() {
           {section === "account" && <AccountPane />}
           {section === "providers" && <ProvidersPane />}
           {section === "agents" && <CustomAgentsPane />}
+          {section === "skills" && <SkillsPane />}
+          {section === "tools" && <McpServersPane />}
           {section === "experimental" && <ExperimentalPane />}
           {section === "developer" && DeveloperPane && (
             <Suspense fallback={null}>

--- a/src/components/SettingsScreen/primitives.tsx
+++ b/src/components/SettingsScreen/primitives.tsx
@@ -77,7 +77,15 @@ export function SetRow({
   );
 }
 
-export function SetToggle({ on, onClick }: { on: boolean; onClick: () => void }) {
+export function SetToggle({
+  on,
+  onClick,
+  disabled,
+}: {
+  on: boolean;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
   return (
     <button
       type="button"
@@ -85,6 +93,8 @@ export function SetToggle({ on, onClick }: { on: boolean; onClick: () => void })
       data-on={on ? "1" : "0"}
       role="switch"
       aria-checked={on}
+      disabled={disabled}
+      style={disabled ? { opacity: 0.4, cursor: "not-allowed" } : undefined}
       onClick={onClick}
     >
       <i />

--- a/src/data/providers.ts
+++ b/src/data/providers.ts
@@ -50,6 +50,25 @@ export function isDockerSupported(id: string | null | undefined): boolean {
   return !!PROVIDERS.find((p) => p.id === id)?.dockerSupported;
 }
 
+/** Which MCP transports each provider can attach — mirrors the backend
+ *  delivery in `agent_profile.rs`: claude takes stdio + http via
+ *  `--mcp-config`, codex only stdio via `-c mcp_servers.*` (its `-c` config
+ *  has no http transport), and the rest have no MCP surface we can drive.
+ *  Unknown ids are treated as unsupported. */
+export type McpSupport = "all" | "stdio" | "none";
+export const MCP_SUPPORT: Record<string, McpSupport> = {
+  claude: "all",
+  codex: "stdio",
+};
+
+/** Whether a provider with `support` can actually deliver an MCP server of
+ *  `transport` at spawn. The single rule behind the agent editor's disabled
+ *  rows, its save-path filter, and the spawn snapshot in `store/drafts.ts`,
+ *  so the three can't drift. */
+export function mcpAttachable(support: McpSupport, transport: "stdio" | "http"): boolean {
+  return support === "all" || (support === "stdio" && transport !== "http");
+}
+
 /** URL for a provider/agent's brand icon on the website CDN. Icons live at
  *  /agents/<slug>.svg (slug === provider id), so a rebrand only needs the SVG
  *  re-uploaded — no app release. The webview's disk cache serves it offline

--- a/src/storage/customAgents.ts
+++ b/src/storage/customAgents.ts
@@ -21,6 +21,12 @@ export interface CustomAgent {
   effort: string | null;
   /** The standing system-prompt-level brief injected when this agent runs. */
   instructions: string;
+  /** Ids of the library skills (see storage/skills.ts) this agent carries.
+   *  Resolved by value at spawn; dangling ids resolve to nothing. */
+  skillIds: string[];
+  /** Ids of the registry MCP servers (see storage/mcpServers.ts) this agent
+   *  attaches. Resolved by value at spawn; dangling ids resolve to nothing. */
+  mcpServerIds: string[];
   created_at: number;
   updated_at: number;
 }
@@ -31,6 +37,41 @@ export type NewCustomAgent = Omit<CustomAgent, "id" | "created_at" | "updated_at
 
 const TABLE = "custom_agents";
 
+/** The raw table row: id arrays live in JSON TEXT columns (`skill_ids`,
+ *  `mcp_server_ids`), converted to/from the typed arrays at this boundary. */
+type CustomAgentRow = Omit<CustomAgent, "skillIds" | "mcpServerIds"> & {
+  skill_ids: string;
+  mcp_server_ids: string;
+};
+
+function fromRow(row: CustomAgentRow): CustomAgent {
+  const { skill_ids, mcp_server_ids, ...rest } = row;
+  return {
+    ...rest,
+    skillIds: parseIdArray(skill_ids),
+    mcpServerIds: parseIdArray(mcp_server_ids),
+  };
+}
+
+function toRow(agent: CustomAgent): CustomAgentRow {
+  const { skillIds, mcpServerIds, ...rest } = agent;
+  return {
+    ...rest,
+    skill_ids: JSON.stringify(skillIds),
+    mcp_server_ids: JSON.stringify(mcpServerIds),
+  };
+}
+
+/** Parse a JSON id-array column, treating malformed content as empty. */
+function parseIdArray(json: string): string[] {
+  try {
+    const parsed = JSON.parse(json);
+    return Array.isArray(parsed) ? parsed.filter((v) => typeof v === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
 /** Generate a stable, collision-resistant id for a new custom agent. */
 function newId(): string {
   return `ca-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -38,23 +79,24 @@ function newId(): string {
 
 /** All custom agents, newest-edited first. */
 export async function listCustomAgents(): Promise<CustomAgent[]> {
-  return dbSelect<CustomAgent>(TABLE, {
+  const rows = await dbSelect<CustomAgentRow>(TABLE, {
     orderBy: "updated_at",
     orderDirection: "desc",
   });
+  return rows.map(fromRow);
 }
 
 /** Insert a new custom agent and return the persisted row. */
 export async function createCustomAgent(agent: NewCustomAgent): Promise<CustomAgent> {
   const now = Date.now();
-  const row: CustomAgent = {
+  const next: CustomAgent = {
     ...agent,
     id: newId(),
     created_at: now,
     updated_at: now,
   };
-  await dbInsert(TABLE, row as unknown as Record<string, unknown>);
-  return row;
+  await dbInsert(TABLE, toRow(next) as unknown as Record<string, unknown>);
+  return next;
 }
 
 /** Patch an existing custom agent (bumping `updated_at`) and return the merged
@@ -64,7 +106,7 @@ export async function updateCustomAgent(
   patch: Partial<NewCustomAgent>,
 ): Promise<CustomAgent> {
   const next: CustomAgent = { ...current, ...patch, updated_at: Date.now() };
-  const { id, created_at, ...writable } = next;
+  const { id, created_at, ...writable } = toRow(next);
   void id;
   void created_at;
   await dbUpdate(TABLE, { id: current.id }, writable as unknown as Record<string, unknown>);

--- a/src/storage/mcpServers.ts
+++ b/src/storage/mcpServers.ts
@@ -1,0 +1,127 @@
+import { dbDelete, dbInsert, dbSelect, dbUpdate } from "./db";
+
+// MCP servers: a shared registry of tool servers custom agents can attach
+// (custom_agents.mcp_server_ids). `command`/`env` describe a stdio server,
+// `url`/`headers` an http one; env and headers are stored as the user typed
+// them (KEY=VALUE / "Name: value" lines) and parsed only when the spawn
+// snapshot is built (see snapshotMcpServer). Persisted in `mcp_servers`.
+
+export type McpTransport = "stdio" | "http";
+
+export interface McpServer {
+  id: string;
+  name: string;
+  transport: McpTransport;
+  /** Full command line for a stdio server, whitespace-split at spawn
+   *  (e.g. "npx -y @modelcontextprotocol/server-github"). */
+  command: string;
+  /** KEY=VALUE per line, passed as the stdio server's environment. */
+  env: string;
+  /** Endpoint for an http server. */
+  url: string;
+  /** "Name: value" per line, sent as http request headers. */
+  headers: string;
+  created_at: number;
+  updated_at: number;
+}
+
+/** A new server before it's persisted: everything except the db-managed id and
+ *  timestamps. */
+export type NewMcpServer = Omit<McpServer, "id" | "created_at" | "updated_at">;
+
+/** The by-value form sent to the backend at spawn and snapshotted onto the
+ *  session — mirrors `agent_profile::McpServerSnapshot`. */
+export interface McpServerSnapshot {
+  name: string;
+  transport: McpTransport;
+  command: string;
+  args: string[];
+  env: [string, string][];
+  url: string;
+  headers: [string, string][];
+}
+
+const TABLE = "mcp_servers";
+
+/** Generate a stable, collision-resistant id for a new server. */
+function newId(): string {
+  return `mcp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/** All servers, newest-edited first. */
+export async function listMcpServers(): Promise<McpServer[]> {
+  return dbSelect<McpServer>(TABLE, {
+    orderBy: "updated_at",
+    orderDirection: "desc",
+  });
+}
+
+/** Insert a new server and return the persisted row. */
+export async function createMcpServer(server: NewMcpServer): Promise<McpServer> {
+  const now = Date.now();
+  const row: McpServer = { ...server, id: newId(), created_at: now, updated_at: now };
+  await dbInsert(TABLE, row as unknown as Record<string, unknown>);
+  return row;
+}
+
+/** Patch an existing server (bumping `updated_at`) and return the merged row so
+ *  callers can update local state without a re-read. */
+export async function updateMcpServer(
+  current: McpServer,
+  patch: Partial<NewMcpServer>,
+): Promise<McpServer> {
+  const next: McpServer = { ...current, ...patch, updated_at: Date.now() };
+  const { id, created_at, ...writable } = next;
+  void id;
+  void created_at;
+  await dbUpdate(TABLE, { id: current.id }, writable as unknown as Record<string, unknown>);
+  return next;
+}
+
+export async function deleteMcpServer(id: string): Promise<void> {
+  await dbDelete(TABLE, { id });
+}
+
+/** Parse `KEY=VALUE` lines into pairs, skipping blanks and lines without `=`.
+ *  Values may contain `=` (split on the first one). */
+export function parseKeyValueLines(text: string): [string, string][] {
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && line.includes("="))
+    .map((line): [string, string] => {
+      const eq = line.indexOf("=");
+      return [line.slice(0, eq).trim(), line.slice(eq + 1).trim()];
+    })
+    .filter(([k]) => k.length > 0);
+}
+
+/** Parse `Name: value` header lines into pairs, skipping blanks and lines
+ *  without `:`. */
+export function parseHeaderLines(text: string): [string, string][] {
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && line.includes(":"))
+    .map((line): [string, string] => {
+      const colon = line.indexOf(":");
+      return [line.slice(0, colon).trim(), line.slice(colon + 1).trim()];
+    })
+    .filter(([k]) => k.length > 0);
+}
+
+/** Resolve a registry row into the by-value snapshot sent at spawn: the command
+ *  line is whitespace-split into command + args (no shell quoting — document
+ *  args with spaces as unsupported), env/header lines are parsed into pairs. */
+export function snapshotMcpServer(server: McpServer): McpServerSnapshot {
+  const tokens = server.command.trim().split(/\s+/).filter(Boolean);
+  return {
+    name: server.name,
+    transport: server.transport,
+    command: tokens[0] ?? "",
+    args: tokens.slice(1),
+    env: parseKeyValueLines(server.env),
+    url: server.url.trim(),
+    headers: parseHeaderLines(server.headers),
+  };
+}

--- a/src/storage/preferences.ts
+++ b/src/storage/preferences.ts
@@ -15,6 +15,8 @@ export type SettingsSection =
   | "account"
   | "providers"
   | "agents"
+  | "skills"
+  | "tools"
   | "experimental"
   | "developer";
 

--- a/src/storage/skills.ts
+++ b/src/storage/skills.ts
@@ -1,0 +1,65 @@
+import { dbDelete, dbInsert, dbSelect, dbUpdate } from "./db";
+
+// Skills: a shared library of named instruction documents. Custom agents
+// reference skills by id (custom_agents.skill_ids); at spawn the selected
+// skills are snapshotted by value onto the session and materialized as files
+// the agent reads on demand, so editing or deleting a library skill never
+// changes a running or resumed session. Persisted in the `skills` table.
+
+export interface Skill {
+  id: string;
+  name: string;
+  /** One-liner shown in the skill index injected into the agent, so it knows
+   *  when to read the document. */
+  description: string;
+  /** Markdown body, materialized verbatim as the skill file at spawn. */
+  body: string;
+  created_at: number;
+  updated_at: number;
+}
+
+/** A new skill before it's persisted: everything except the db-managed id and
+ *  timestamps. */
+export type NewSkill = Omit<Skill, "id" | "created_at" | "updated_at">;
+
+/** The by-value form sent to the backend at spawn and snapshotted onto the
+ *  session — mirrors `agent_profile::SkillSnapshot`. */
+export type SkillSnapshot = Pick<Skill, "name" | "description" | "body">;
+
+const TABLE = "skills";
+
+/** Generate a stable, collision-resistant id for a new skill. */
+function newId(): string {
+  return `sk-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/** All skills, newest-edited first. */
+export async function listSkills(): Promise<Skill[]> {
+  return dbSelect<Skill>(TABLE, {
+    orderBy: "updated_at",
+    orderDirection: "desc",
+  });
+}
+
+/** Insert a new skill and return the persisted row. */
+export async function createSkill(skill: NewSkill): Promise<Skill> {
+  const now = Date.now();
+  const row: Skill = { ...skill, id: newId(), created_at: now, updated_at: now };
+  await dbInsert(TABLE, row as unknown as Record<string, unknown>);
+  return row;
+}
+
+/** Patch an existing skill (bumping `updated_at`) and return the merged row so
+ *  callers can update local state without a re-read. */
+export async function updateSkill(current: Skill, patch: Partial<NewSkill>): Promise<Skill> {
+  const next: Skill = { ...current, ...patch, updated_at: Date.now() };
+  const { id, created_at, ...writable } = next;
+  void id;
+  void created_at;
+  await dbUpdate(TABLE, { id: current.id }, writable as unknown as Record<string, unknown>);
+  return next;
+}
+
+export async function deleteSkill(id: string): Promise<void> {
+  await dbDelete(TABLE, { id });
+}

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -502,6 +502,10 @@ export const createAppSlice: SliceCreator<AppSlice> = (set, get) => ({
     // Load custom agent presets (async, non-blocking). Empty until loaded — the
     // composer picker and settings pane just show the built-ins meanwhile.
     void get().loadCustomAgents();
+    // Load the shared skills library and MCP server registry (async,
+    // non-blocking) — consumed by the agent editor and resolved at spawn.
+    void get().loadSkills();
+    void get().loadMcpServers();
     // Probe the GitHub connection once (async, non-blocking) so push/PR/clone
     // affordances know whether to act or prompt to connect.
     void get().refreshGithub();

--- a/src/store/customAgents.ts
+++ b/src/store/customAgents.ts
@@ -6,7 +6,7 @@ import {
   listCustomAgents,
   type NewCustomAgent,
 } from "@/storage/customAgents";
-import type { CustomAgentsSlice, SliceCreator } from "./types";
+import type { AppState, CustomAgentsSlice, SliceCreator } from "./types";
 
 // Store slice for custom agents. The list mirrors the `custom_agents` table and
 // is loaded once on init; every mutation writes through to the db and updates
@@ -55,5 +55,20 @@ export const createCustomAgentsSlice: SliceCreator<CustomAgentsSlice> = (set, ge
     return get().createCustomAgent(copy);
   },
 });
+
+/** Remove a deleted library id (skill / MCP server) from every custom agent
+ *  that references it, so the editor never shows — and the spawn path never
+ *  resolves — a dangling id. Shared by the skills and MCP-server slices. */
+export async function detachIdFromAgents(
+  state: Pick<AppState, "customAgents" | "updateCustomAgent">,
+  field: "skillIds" | "mcpServerIds",
+  id: string,
+): Promise<void> {
+  for (const agent of state.customAgents.filter((a) => a[field].includes(id))) {
+    await state.updateCustomAgent(agent.id, {
+      [field]: agent[field].filter((x) => x !== id),
+    });
+  }
+}
 
 export type { CustomAgent };

--- a/src/store/drafts.ts
+++ b/src/store/drafts.ts
@@ -1,6 +1,7 @@
 import { api } from "@/api";
 import { DEFAULT_PROVIDER_ID, PROVIDERS } from "@/data/providers";
 import { sendWhenAgentReady, usedNames } from "@/helpers";
+import { snapshotMcpServer } from "@/storage/mcpServers";
 import { setSetting } from "@/storage/settings";
 import type { AppState, DraftsSlice, SliceCreator } from "./types";
 
@@ -171,6 +172,18 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
         ? get().customAgents.find((a) => a.id === customAgentId)
         : undefined;
       const instructions = custom?.instructions?.trim() ? custom.instructions : undefined;
+      // Resolve the agent's skill/MCP assignments to by-value snapshots, in the
+      // agent's assignment order. Dangling ids (deleted library entries) drop
+      // out. Snapshotted like the brief: later library edits never touch this
+      // session.
+      const skills = (custom?.skillIds ?? [])
+        .map((sid) => get().skills.find((s) => s.id === sid))
+        .filter((s) => s !== undefined)
+        .map(({ name, description, body }) => ({ name, description, body }));
+      const mcpServers = (custom?.mcpServerIds ?? [])
+        .map((sid) => get().mcpServers.find((s) => s.id === sid))
+        .filter((s) => s !== undefined)
+        .map(snapshotMcpServer);
       // `thinking` carries the composer's effort selection. For claude it's a
       // session-level spawn flag (--effort), applied here; per-turn agents
       // ignore it at spawn and take it per-turn via sendUserMessage below.
@@ -187,6 +200,8 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
         // forks the checkout from it and records it as the agent's parent
         // branch (PR base / ahead-behind).
         draft.base,
+        skills.length > 0 ? skills : undefined,
+        mcpServers.length > 0 ? mcpServers : undefined,
       );
       const fresh = await api.getWorkspace();
       set((state) => {

--- a/src/store/drafts.ts
+++ b/src/store/drafts.ts
@@ -1,5 +1,5 @@
 import { api } from "@/api";
-import { DEFAULT_PROVIDER_ID, MCP_SUPPORT, PROVIDERS, mcpAttachable } from "@/data/providers";
+import { DEFAULT_PROVIDER_ID, MCP_SUPPORT, mcpAttachable, PROVIDERS } from "@/data/providers";
 import { sendWhenAgentReady, usedNames } from "@/helpers";
 import { snapshotMcpServer } from "@/storage/mcpServers";
 import { setSetting } from "@/storage/settings";

--- a/src/store/drafts.ts
+++ b/src/store/drafts.ts
@@ -1,5 +1,5 @@
 import { api } from "@/api";
-import { DEFAULT_PROVIDER_ID, PROVIDERS } from "@/data/providers";
+import { DEFAULT_PROVIDER_ID, MCP_SUPPORT, PROVIDERS, mcpAttachable } from "@/data/providers";
 import { sendWhenAgentReady, usedNames } from "@/helpers";
 import { snapshotMcpServer } from "@/storage/mcpServers";
 import { setSetting } from "@/storage/settings";
@@ -180,9 +180,15 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
         .map((sid) => get().skills.find((s) => s.id === sid))
         .filter((s) => s !== undefined)
         .map(({ name, description, body }) => ({ name, description, body }));
+      // Undeliverable servers (e.g. an HTTP server on a codex base, saved
+      // before the base switch) drop here too, not just in the editor: the
+      // snapshot must contain exactly what the provider can run, so the
+      // backend never carries assignments it silently ignores.
+      const mcpSupport = MCP_SUPPORT[provider] ?? "none";
       const mcpServers = (custom?.mcpServerIds ?? [])
         .map((sid) => get().mcpServers.find((s) => s.id === sid))
         .filter((s) => s !== undefined)
+        .filter((s) => mcpAttachable(mcpSupport, s.transport))
         .map(snapshotMcpServer);
       // `thinking` carries the composer's effort selection. For claude it's a
       // session-level spawn flag (--effort), applied here; per-turn agents

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -7,9 +7,11 @@ import { createComposerSlice } from "./composer";
 import { createCustomAgentsSlice } from "./customAgents";
 import { createDraftsSlice } from "./drafts";
 import { createGitSlice } from "./git";
+import { createMcpServersSlice } from "./mcpServers";
 import { createProvidersSlice } from "./providers";
 import { createReposSlice } from "./repos";
 import { createSandboxSlice } from "./sandbox";
+import { createSkillsSlice } from "./skills";
 import type { AppState } from "./types";
 import { createUiSlice } from "./ui";
 import { createWorkspaceSlice } from "./workspace";
@@ -28,6 +30,8 @@ export const useAppStore = create<AppState>()((...a) => ({
   ...createAppearanceSlice(...a),
   ...createProvidersSlice(...a),
   ...createCustomAgentsSlice(...a),
+  ...createSkillsSlice(...a),
+  ...createMcpServersSlice(...a),
   ...createSandboxSlice(...a),
 }));
 

--- a/src/store/mcpServers.ts
+++ b/src/store/mcpServers.ts
@@ -1,0 +1,48 @@
+import {
+  createMcpServer as dbCreate,
+  deleteMcpServer as dbDelete,
+  updateMcpServer as dbUpdate,
+  listMcpServers,
+  type McpServer,
+  type NewMcpServer,
+} from "@/storage/mcpServers";
+import { detachIdFromAgents } from "./customAgents";
+import type { McpServersSlice, SliceCreator } from "./types";
+
+// Store slice for the shared MCP server registry. Mirrors the `mcp_servers`
+// table (loaded once on init); every mutation writes through to the db and
+// updates the in-memory list so the settings pane and agent editor stay in
+// sync.
+
+export const createMcpServersSlice: SliceCreator<McpServersSlice> = (set, get) => ({
+  mcpServers: [],
+
+  loadMcpServers: async () => {
+    const mcpServers = await listMcpServers();
+    set({ mcpServers });
+  },
+
+  createMcpServer: async (server) => {
+    const created = await dbCreate(server);
+    set((s) => ({ mcpServers: [created, ...s.mcpServers] }));
+    return created;
+  },
+
+  updateMcpServer: async (id, patch) => {
+    const current = get().mcpServers.find((s) => s.id === id);
+    if (!current) return null;
+    const next = await dbUpdate(current, patch);
+    // Re-sort by updated_at desc so the just-edited server floats to the top,
+    // matching the load order.
+    set((s) => ({ mcpServers: [next, ...s.mcpServers.filter((x) => x.id !== id)] }));
+    return next;
+  },
+
+  deleteMcpServer: async (id) => {
+    await dbDelete(id);
+    set((s) => ({ mcpServers: s.mcpServers.filter((x) => x.id !== id) }));
+    await detachIdFromAgents(get(), "mcpServerIds", id);
+  },
+});
+
+export type { McpServer, NewMcpServer };

--- a/src/store/skills.ts
+++ b/src/store/skills.ts
@@ -1,0 +1,47 @@
+import {
+  createSkill as dbCreate,
+  deleteSkill as dbDelete,
+  updateSkill as dbUpdate,
+  listSkills,
+  type NewSkill,
+  type Skill,
+} from "@/storage/skills";
+import { detachIdFromAgents } from "./customAgents";
+import type { SkillsSlice, SliceCreator } from "./types";
+
+// Store slice for the shared skills library. Mirrors the `skills` table
+// (loaded once on init); every mutation writes through to the db and updates
+// the in-memory list so the settings pane and agent editor stay in sync.
+
+export const createSkillsSlice: SliceCreator<SkillsSlice> = (set, get) => ({
+  skills: [],
+
+  loadSkills: async () => {
+    const skills = await listSkills();
+    set({ skills });
+  },
+
+  createSkill: async (skill) => {
+    const created = await dbCreate(skill);
+    set((s) => ({ skills: [created, ...s.skills] }));
+    return created;
+  },
+
+  updateSkill: async (id, patch) => {
+    const current = get().skills.find((s) => s.id === id);
+    if (!current) return null;
+    const next = await dbUpdate(current, patch);
+    // Re-sort by updated_at desc so the just-edited skill floats to the top,
+    // matching the load order.
+    set((s) => ({ skills: [next, ...s.skills.filter((x) => x.id !== id)] }));
+    return next;
+  },
+
+  deleteSkill: async (id) => {
+    await dbDelete(id);
+    set((s) => ({ skills: s.skills.filter((x) => x.id !== id) }));
+    await detachIdFromAgents(get(), "skillIds", id);
+  },
+});
+
+export type { NewSkill, Skill };

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -20,6 +20,7 @@ import type { GitCommitAction } from "@/components/RightPanel/primaryActions";
 import type { ModelMeta, SlimCatalog } from "@/data/modelCatalog";
 import type { AccountProfile } from "@/storage/accounts";
 import type { CustomAgent, NewCustomAgent } from "@/storage/customAgents";
+import type { McpServer, NewMcpServer } from "@/storage/mcpServers";
 import type {
   Density,
   FeatureFlags,
@@ -29,6 +30,7 @@ import type {
   ThemeMode,
   WorkspaceView,
 } from "@/storage/preferences";
+import type { NewSkill, Skill } from "@/storage/skills";
 import type { DraftAgent } from "./drafts";
 
 /** A degraded transcript-ingest state stored per agent (the `healthy` status is
@@ -552,6 +554,34 @@ export interface CustomAgentsSlice {
   duplicateCustomAgent: (id: string) => Promise<CustomAgent | null>;
 }
 
+export interface SkillsSlice {
+  /** Shared skills library, mirrored from the `skills` table and ordered
+   *  newest-edited first. Loaded once on init. */
+  skills: Skill[];
+
+  loadSkills: () => Promise<void>;
+  createSkill: (skill: NewSkill) => Promise<Skill>;
+  /** Patch an existing skill; resolves to the merged row, or null if the id is
+   *  unknown. */
+  updateSkill: (id: string, patch: Partial<NewSkill>) => Promise<Skill | null>;
+  /** Delete a skill and detach its id from every custom agent. */
+  deleteSkill: (id: string) => Promise<void>;
+}
+
+export interface McpServersSlice {
+  /** Shared MCP server registry, mirrored from the `mcp_servers` table and
+   *  ordered newest-edited first. Loaded once on init. */
+  mcpServers: McpServer[];
+
+  loadMcpServers: () => Promise<void>;
+  createMcpServer: (server: NewMcpServer) => Promise<McpServer>;
+  /** Patch an existing server; resolves to the merged row, or null if the id is
+   *  unknown. */
+  updateMcpServer: (id: string, patch: Partial<NewMcpServer>) => Promise<McpServer | null>;
+  /** Delete a server and detach its id from every custom agent. */
+  deleteMcpServer: (id: string) => Promise<void>;
+}
+
 export type AppState = AppSlice &
   WorkspaceSlice &
   ReposSlice &
@@ -563,6 +593,8 @@ export type AppState = AppSlice &
   AppearanceSlice &
   ProvidersSlice &
   CustomAgentsSlice &
+  SkillsSlice &
+  McpServersSlice &
   SandboxSlice;
 
 export type SliceCreator<T> = StateCreator<AppState, [], [], T>;

--- a/tests/storage/customAgents.test.ts
+++ b/tests/storage/customAgents.test.ts
@@ -30,7 +30,12 @@ const NEW = {
   model: "gpt-5.2-codex",
   effort: "high",
   instructions: "Be terse.",
+  skillIds: ["sk-1", "sk-2"],
+  mcpServerIds: ["mcp-1"],
 };
+
+/** NEW without the id arrays — the scalar columns written verbatim. */
+const { skillIds: _sk, mcpServerIds: _mcp, ...NEW_SCALARS } = NEW;
 
 describe("customAgents storage", () => {
   beforeEach(() => {
@@ -45,9 +50,18 @@ describe("customAgents storage", () => {
     expect(agent.created_at).toBe(agent.updated_at);
     expect(agent.created_at).toBe(Date.now());
 
-    const [table, row] = dbInsert.mock.calls[0] as unknown as [string, CustomAgent];
+    const [table, row] = dbInsert.mock.calls[0] as unknown as [string, Record<string, unknown>];
     expect(table).toBe("custom_agents");
-    expect(row).toMatchObject({ ...NEW, id: agent.id });
+    // The id arrays are written as JSON TEXT columns (`skill_ids`,
+    // `mcp_server_ids`), not as the typed fields.
+    expect(row).toMatchObject({
+      ...NEW_SCALARS,
+      id: agent.id,
+      skill_ids: JSON.stringify(NEW.skillIds),
+      mcp_server_ids: JSON.stringify(NEW.mcpServerIds),
+    });
+    expect(row).not.toHaveProperty("skillIds");
+    expect(row).not.toHaveProperty("mcpServerIds");
   });
 
   it("bumps updated_at and never writes the id/created_at columns on update", async () => {


### PR DESCRIPTION
## What

Custom agents become first-party citizens: beyond the standing brief, an agent can now carry **skills** (shared library of named instruction documents) and **tools** (shared registry of MCP servers), assigned in the agent editor and injected into every session it spawns.

## How

**Skills — provider-neutral by design.** At spawn the selected skills are snapshotted by value onto the session and materialized as markdown files under a reserved `<sandbox_root>/.fletch-profile/skills/` dir; a compact index (name + description + path) rides the existing per-provider instruction channels (`--append-system-prompt`, codex `developer_instructions`, first-turn prompt-prepend). The agent reads a skill file when the task matches — progressive disclosure, ~1 line of context per skill, works on all six bases.

**MCP servers — per-provider delivery with an honest capability matrix.**
- **claude**: config generated from the session snapshot, passed via `--mcp-config` + `--strict-mcp-config` (our snapshot is the *only* MCP source — on-disk user/project config can't ride along)
- **codex**: `-c mcp_servers.*` TOML overrides (stdio servers)
- **cursor / opencode / pi / antigravity**: unsupported for now; the editor says so up front

**Snapshot semantics** mirror `sessions.instructions`: both snapshots persist on the session row, and files/config are re-materialized on every process spawn (fresh, resume, view switch), so editing or deleting a library entry never changes a running or resumed session.

## Changes

- **Migration 0016**: `skills` + `mcp_servers` tables, `custom_agents.skill_ids`/`mcp_server_ids` JSON columns, `sessions.skills`/`mcp_servers` snapshot columns
- **`agent_profile.rs`** (new): skill materialization + index, claude MCP config writer, codex `-c` builder, shared slug-dedupe helper
- **Spawn plumbing**: snapshots flow drafts → `spawnAgent` → `SpawnRequest` → session record → `SpawnSpec`/`PerTurnSpec`; MCP delivery is a per-provider `mcp_args` hook on `PerTurnDescriptor` (adding a provider stays one table row)
- **Settings UI**: new Skills and Tools panes built on a shared `LibraryList` component (also adopted by the custom-agent list's delete idiom); agent editor gains skill/tool assignment pickers with per-base capability hints
- **Safety**: profile artifacts live under a reserved `.fletch-profile/` name that `allocate_repo_subdir` can never hand to a repo checkout; MCP config is always generated host-side from the DB, never read from agent-writable files

## Testing

- `cargo test`: 572 passed (includes new round-trip, materialization, config-shape, and key-collision tests)
- `vitest`: 374 passed; `tsc --noEmit` clean
- Reviewed via /code-review (high): 2 correctness findings + 3 cleanups found and fixed in this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)