### PR TITLE
feat(workflows): blackboard + sandbox grants (S3)

### DIFF
--- a/docs/workflows/TECH_SPEC.md
+++ b/docs/workflows/TECH_SPEC.md
@@ -653,12 +653,20 @@ path handed to `SpawnReq`.
 ### 8.2 Sandbox grants
 
 - **Seatbelt:** one additional write-allow subpath per step agent:
-  `~/.fletch/runs/<run-id>/blackboard/`. Added in `sandbox/policy.rs` as a
-  run-scoped grant (same mechanism as the workspace grant).
+  `~/.fletch/runs/<run-id>/blackboard/`. Plumbed as an optional path on
+  `AgentLaunchCtx` and emitted directly in `seatbelt.rs`'s `build_profile`,
+  the same way the RPC mailbox grant is — *not* through `sandbox/policy.rs`.
+  The policy module is the source of truth for *static, home-relative*
+  provider/scratch dirs; it deliberately does not model dynamic per-run/
+  per-agent paths (its own doc-comment notes a passthrough grant "buys
+  nothing" through its dir-oriented API), which is why the mailbox — the
+  direct precedent for a per-agent out-of-checkout path — is a seatbelt-local
+  subpath. The blackboard follows that precedent.
 - **Docker:** bind-mount the blackboard directory read-write into the
-  container at a fixed path (`/workspace/.wf-blackboard`); the prompt tells
-  the agent the mount path. `WF_BLACKBOARD` env var carries the correct
-  path for both engines.
+  container **at its identical host path** (invariant 1 — path identity — the
+  same shape as the RPC mailbox mount), not a synthetic container path. The
+  `WF_BLACKBOARD` env var carries the path; because the mount is identical on
+  both engines, that value is the same under seatbelt and Docker.
 
 ### 8.3 Verdict schema
 

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -963,6 +963,7 @@ impl Agent {
             cwd: &spec.cwd,
             home: &home,
             interactive: true,
+            blackboard: None,
         };
         let LaunchPlan {
             program,
@@ -1052,6 +1053,7 @@ impl Agent {
             cwd: &spec.cwd,
             home: &home,
             interactive: true,
+            blackboard: None,
         };
         let LaunchPlan {
             program,
@@ -1113,6 +1115,7 @@ impl Agent {
             cwd: &spec.cwd,
             home: &home,
             interactive: false,
+            blackboard: None,
         };
         let LaunchPlan {
             program,
@@ -1255,6 +1258,7 @@ impl Agent {
             cwd: &spec.cwd,
             home: &home,
             interactive: false,
+            blackboard: None,
         };
         let LaunchPlan {
             program: launch_program,

--- a/src-tauri/src/sandbox/docker/engine.rs
+++ b/src-tauri/src/sandbox/docker/engine.rs
@@ -360,6 +360,17 @@ impl SandboxEngine for DockerEngine {
             ("TERM".into(), "xterm-256color".into()),
             ("COLORTERM".into(), "truecolor".into()),
         ];
+        // A workflow step agent's blackboard is bind-mounted at its identical
+        // host path (invariant 1, like the RPC mailbox), so `WF_BLACKBOARD` is
+        // the same host path under either engine. Pushed before the provider
+        // match sets `auth_start` so it forwards as a plain env var, not an
+        // auth var.
+        if let Some(board) = ctx.blackboard {
+            env.push((
+                crate::workflow::blackboard::WF_BLACKBOARD_ENV.into(),
+                board.to_string_lossy().into_owned(),
+            ));
+        }
 
         // Owned per-provider mount inputs, borrowed into a `ProviderMounts` when
         // the `RunSpec` is built below. Defaults describe "no config surface";
@@ -571,6 +582,7 @@ impl SandboxEngine for DockerEngine {
                 rpc_dir: ctx.rpc_dir,
                 home: ctx.home,
                 cwd: ctx.cwd,
+                blackboard: ctx.blackboard,
                 mounts,
                 borrowed_object_stores: &borrowed_object_stores,
                 memory: non_blank(settings.memory.as_deref()).unwrap_or(DEFAULT_MEMORY),
@@ -1091,6 +1103,10 @@ struct RunSpec<'a> {
     rpc_dir: &'a Path,
     home: &'a Path,
     cwd: &'a Path,
+    /// A workflow step agent's blackboard directory, bind-mounted read-write at
+    /// its identical host path and forwarded as `WF_BLACKBOARD`. `None` for
+    /// ordinary agents.
+    blackboard: Option<&'a Path>,
     /// The launching provider's config/data mounts + config-dir env forwards.
     mounts: ProviderMounts<'a>,
     /// Object stores borrowed via git alternates (a `--shared` clone),
@@ -1132,6 +1148,12 @@ fn run_args(spec: &RunSpec<'_>) -> Vec<String> {
         let path = path.to_string_lossy();
         args.push("-v".into());
         args.push(format!("{path}:{path}"));
+    }
+    // A workflow step agent's blackboard, bind-mounted read-write at its
+    // identical host path (invariant 1) so `$WF_BLACKBOARD` resolves the same
+    // in-container as on the host — the same shape as the RPC mailbox mount.
+    if let Some(board) = spec.blackboard {
+        push_rw_bind(&mut args, board);
     }
     // Object stores borrowed by a --shared clone, mounted read-only at their
     // identical host path so the alternates file resolves in-container with no
@@ -1185,6 +1207,9 @@ fn run_args(spec: &RunSpec<'_>) -> Vec<String> {
     // the value ever appearing in argv (invariant 3 for the auth vars). Auth
     // vars come from `spec.auth_vars` — the set the chain actually resolved.
     let mut forwarded: Vec<&str> = vec!["HOME", "FLETCH_RPC_DIR", "TERM", "COLORTERM"];
+    if spec.blackboard.is_some() {
+        forwarded.push(crate::workflow::blackboard::WF_BLACKBOARD_ENV);
+    }
     match &spec.mounts {
         ProviderMounts::Claude { config_dir, .. } => {
             if config_dir.is_some() {
@@ -1487,6 +1512,7 @@ mod tests {
             rpc_dir: Path::new("/Users/u/.fletch/rpc/orkney"),
             home: Path::new("/Users/u"),
             cwd: Path::new("/Users/u/.fletch/worktrees/orkney/repo"),
+            blackboard: None,
             mounts: claude_mounts(None, false, false),
             borrowed_object_stores: &[],
             memory: "4g",
@@ -1519,6 +1545,7 @@ mod tests {
             rpc_dir: Path::new("/Users/u/.fletch/rpc/orkney"),
             home: Path::new("/Users/u"),
             cwd: Path::new("/Users/u/.fletch/worktrees/orkney/repo"),
+            blackboard: None,
             mounts,
             borrowed_object_stores: &[],
             memory: "4g",
@@ -1575,6 +1602,39 @@ mod tests {
             values_of(&args, "-w"),
             vec!["/Users/u/.fletch/worktrees/orkney/repo"],
         );
+    }
+
+    #[test]
+    fn argv_mounts_blackboard_and_forwards_its_env_when_present() {
+        let board = Path::new("/Users/u/.fletch/runs/run-1/blackboard");
+        let mut spec = test_spec(false);
+        spec.blackboard = Some(board);
+        let args = run_args(&spec);
+
+        // Bound read-write at its identical host path (invariant 1), the same
+        // shape as the RPC mailbox mount.
+        assert!(
+            values_of(&args, "-v").contains(
+                &"/Users/u/.fletch/runs/run-1/blackboard:/Users/u/.fletch/runs/run-1/blackboard"
+            ),
+            "blackboard must be bind-mounted at its identical host path, got {:?}",
+            values_of(&args, "-v")
+        );
+        // Forwarded so the in-container agent finds the mount via `$WF_BLACKBOARD`.
+        assert!(
+            values_of(&args, "-e").contains(&"WF_BLACKBOARD"),
+            "WF_BLACKBOARD must be forwarded into the container"
+        );
+    }
+
+    #[test]
+    fn argv_omits_blackboard_for_ordinary_agents() {
+        let args = run_args(&test_spec(false));
+        assert!(
+            !args.iter().any(|a| a.contains("blackboard")),
+            "no blackboard mount for a non-workflow agent"
+        );
+        assert!(!values_of(&args, "-e").contains(&"WF_BLACKBOARD"));
     }
 
     /// Invariant 5: `~/.claude` is read-only so a prompt-injected agent cannot
@@ -2552,6 +2612,7 @@ mod tests {
             rpc_dir: &rpc,
             home: &home,
             cwd: &root,
+            blackboard: None,
             mounts: ProviderMounts::Claude {
                 config_dir: None,
                 credentials_rw: false,

--- a/src-tauri/src/sandbox/docker/engine.rs
+++ b/src-tauri/src/sandbox/docker/engine.rs
@@ -366,6 +366,18 @@ impl SandboxEngine for DockerEngine {
         // match sets `auth_start` so it forwards as a plain env var, not an
         // auth var.
         if let Some(board) = ctx.blackboard {
+            // Fail closed if the blackboard was not provisioned before launch:
+            // a bare `-v` on a missing source has Docker create it *root-owned*,
+            // leaving the host-side reader unable to read the agent's verdict/
+            // handoff files. Seatbelt already fails here (its `canonicalize`
+            // errors on a missing path); match that so an ordering bug in the
+            // scheduler surfaces instead of silently corrupting the mount.
+            if !board.is_dir() {
+                return Err(Error::Other(format!(
+                    "workflow blackboard not provisioned before launch: {}",
+                    board.display()
+                )));
+            }
             env.push((
                 crate::workflow::blackboard::WF_BLACKBOARD_ENV.into(),
                 board.to_string_lossy().into_owned(),

--- a/src-tauri/src/sandbox/engine.rs
+++ b/src-tauri/src/sandbox/engine.rs
@@ -43,6 +43,13 @@ pub struct AgentLaunchCtx<'a> {
     pub cwd: &'a Path,
     pub home: &'a Path,
     pub interactive: bool,
+    /// A workflow step agent's blackboard directory
+    /// (`~/.fletch/runs/<run-id>/blackboard/`), granted read-write into the
+    /// sandbox on top of the writable root: seatbelt adds it as a writable
+    /// subpath, Docker bind-mounts it at its identical host path. Both engines
+    /// export it as `WF_BLACKBOARD`. `None` for ordinary (non-workflow) agents,
+    /// which is every agent until the scheduler (S4) populates it at spawn.
+    pub blackboard: Option<&'a Path>,
 }
 
 /// A resource that must outlive the launched process. Parked on the session

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -56,6 +56,7 @@ impl SandboxEngine for SandboxExecEngine {
             ctx.rpc_dir,
             ctx.home,
             claude_config_dir.as_deref(),
+            ctx.blackboard,
         )?;
         let profile_file = profile_tempfile(&profile_text)?;
         let profile_path = profile_file
@@ -63,10 +64,20 @@ impl SandboxEngine for SandboxExecEngine {
             .to_str()
             .ok_or_else(|| Error::Other("profile path not utf-8".into()))?
             .to_string();
+        // A workflow step agent's blackboard is granted writable in the profile
+        // above; also point the agent at it via `WF_BLACKBOARD` (the same host
+        // path the sandbox sees — seatbelt shares the host filesystem).
+        let env = match ctx.blackboard {
+            Some(board) => vec![(
+                crate::workflow::blackboard::WF_BLACKBOARD_ENV.to_string(),
+                board.to_string_lossy().into_owned(),
+            )],
+            None => vec![],
+        };
         Ok(LaunchPlan {
             program: PathBuf::from(SANDBOX_EXEC),
             prefix_args: vec!["-f".into(), profile_path, agent_bin.to_string()],
-            env: vec![],
+            env,
             keepalive: Keepalive::Profile(profile_file),
             // sandbox-exec is a plain process wrapper — the session's own
             // process-group escalation tears everything down; the trait's
@@ -349,6 +360,7 @@ pub fn build_profile(
     rpc_dir: &Path,
     home: &Path,
     claude_config_dir: Option<&Path>,
+    blackboard: Option<&Path>,
 ) -> Result<String> {
     let writable_root = canonical(writable_root)?;
     let rpc_root = canonical(rpc_dir)?;
@@ -357,6 +369,18 @@ pub fn build_profile(
     let writable_root_s = sbpl_string(&writable_root.to_string_lossy());
     let rpc_root_s = sbpl_string(&rpc_root.to_string_lossy());
     let home_s = home.to_string_lossy();
+
+    // A workflow step agent's blackboard lives outside the checkout tree (under
+    // `~/.fletch/runs/`), so it needs its own writable subpath — the same shape
+    // as the rpc mailbox grant. Canonicalized so the SBPL path matches what the
+    // sandbox sees at write time; empty for non-workflow agents.
+    let blackboard_grant = match blackboard {
+        Some(board) => {
+            let board = canonical(board)?;
+            format!("\n  (subpath {})", sbpl_string(&board.to_string_lossy()))
+        }
+        None => String::new(),
+    };
 
     let claude_json = sbpl_string(&format!("{home_s}/.claude.json"));
 
@@ -434,7 +458,7 @@ pub fn build_profile(
 (deny file-write*)
 (allow file-write*
   (subpath {writable_root_s})
-  (subpath {rpc_root_s})
+  (subpath {rpc_root_s}){blackboard_grant}
   (subpath "/private/tmp")
   (subpath "/private/var/folders")
   (subpath "/private/var/tmp")
@@ -594,7 +618,7 @@ mod tests {
         std::fs::create_dir_all(&rpc).unwrap();
         std::fs::create_dir_all(&home).unwrap();
 
-        let profile = build_profile(&root, &rpc, &home, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
         let canonical_root = std::fs::canonicalize(&root).unwrap();
         let canonical_rpc = std::fs::canonicalize(&rpc).unwrap();
 
@@ -615,7 +639,7 @@ mod tests {
         // It grants the narrow replacements instead, and every provider dot-dir
         // and cache dir stays exactly as before.
         let (_td, root, rpc, home) = sandbox_dirs();
-        let profile = build_profile(&root, &rpc, &home, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
         let canonical_home = std::fs::canonicalize(&home).unwrap();
         let h = canonical_home.display();
 
@@ -736,7 +760,7 @@ mod tests {
         std::fs::create_dir_all(&target).unwrap();
         std::os::unix::fs::symlink(&target, home.join(".claude")).unwrap();
 
-        let profile = build_profile(&root, &rpc, &home, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
         let canonical_home = std::fs::canonicalize(&home).unwrap();
         assert!(
             !profile.contains(".local/bin"),
@@ -759,10 +783,41 @@ mod tests {
         let cfg = home.join(".local/bin/claude-cfg");
         std::fs::create_dir_all(&cfg).unwrap();
 
-        let profile = build_profile(&root, &rpc, &home, Some(cfg.as_path())).unwrap();
+        let profile = build_profile(&root, &rpc, &home, Some(cfg.as_path()), None).unwrap();
         assert!(
             !profile.contains(".local/bin"),
             "bin-resident CLAUDE_CONFIG_DIR must not appear on the allow-list"
+        );
+    }
+
+    #[test]
+    fn agent_profile_grants_blackboard_only_when_present_and_not_its_parent() {
+        let (td, root, rpc, home) = sandbox_dirs();
+        // A run blackboard living outside the checkout tree, like the mailbox.
+        let board = td.path().join("runs/run-1/blackboard");
+        std::fs::create_dir_all(&board).unwrap();
+        let canonical_board = std::fs::canonicalize(&board).unwrap();
+
+        // Absent by default: an ordinary (non-workflow) agent gets no grant.
+        let plain = build_profile(&root, &rpc, &home, None, None).unwrap();
+        assert!(
+            !plain.contains(&canonical_board.to_string_lossy().to_string()),
+            "no blackboard grant without a blackboard"
+        );
+
+        // Granted: the *exact* blackboard dir is a writable subpath.
+        let granted = build_profile(&root, &rpc, &home, None, Some(board.as_path())).unwrap();
+        assert!(
+            granted.contains(&format!("(subpath \"{}\")", canonical_board.display())),
+            "granted profile must allow writing inside the blackboard"
+        );
+        // …but not its parent — a process can't write *beside* the blackboard
+        // (a sibling run's dir stays unwritable). Mirrors the seatbelt
+        // acceptance: write inside the grant, not next to it.
+        let parent = canonical_board.parent().unwrap();
+        assert!(
+            !granted.contains(&format!("(subpath \"{}\")", parent.display())),
+            "the blackboard's parent must not be granted"
         );
     }
 
@@ -787,7 +842,7 @@ mod tests {
         let cfg = home.join(".claude-eve");
         std::fs::create_dir_all(&cfg).unwrap();
 
-        let profile = build_profile(&root, &rpc, &home, Some(cfg.as_path())).unwrap();
+        let profile = build_profile(&root, &rpc, &home, Some(cfg.as_path()), None).unwrap();
         // The emitted paths must be canonical (symlink-resolved) so they match
         // what the sandbox resolves at write time — e.g. on macOS the tempdir
         // lives under /var → /private/var.
@@ -852,7 +907,8 @@ mod tests {
         let (_td, root, rpc, home) = sandbox_dirs();
         let default_claude = std::fs::canonicalize(&home).unwrap().join(".claude");
 
-        let profile = build_profile(&root, &rpc, &home, Some(default_claude.as_path())).unwrap();
+        let profile =
+            build_profile(&root, &rpc, &home, Some(default_claude.as_path()), None).unwrap();
         for island in policy::claude_write_island_dirs(&default_claude) {
             let needle = format!("(subpath \"{}\")", island.display());
             assert_eq!(
@@ -879,7 +935,7 @@ mod tests {
         // credential file. `settings.json` (host hooks), `plugins/`, `CLAUDE.md`,
         // etc. must be covered by no grant.
         let (_td, root, rpc, home) = sandbox_dirs();
-        let profile = build_profile(&root, &rpc, &home, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
         let canonical_home = std::fs::canonicalize(&home).unwrap();
         let claude = canonical_home.join(".claude");
         let h = canonical_home.display();
@@ -945,7 +1001,7 @@ mod tests {
         // reads (exfiltration) and writes (forging state). The deny only bites if
         // it comes AFTER the write allow-list, since SBPL is last-match-wins.
         let (_td, root, rpc, home) = sandbox_dirs();
-        let profile = build_profile(&root, &rpc, &home, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
         let canonical_home = std::fs::canonicalize(&home).unwrap();
 
         let deny = format!(
@@ -970,7 +1026,7 @@ mod tests {
         // Agents never legitimately touch any Fletch data dir — no `dev`
         // exception (that carve-out is Run-profile-only).
         let (_td, root, rpc, home) = sandbox_dirs();
-        let profile = build_profile(&root, &rpc, &home, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
         let canonical_home = std::fs::canonicalize(&home).unwrap();
         let dev = format!(
             "{}/Library/Application Support/{}/dev",

--- a/src-tauri/src/workflow/blackboard.rs
+++ b/src-tauri/src/workflow/blackboard.rs
@@ -64,9 +64,32 @@ pub fn runs_root() -> Result<PathBuf> {
     Ok(home.join(".fletch").join("runs"))
 }
 
+/// Reject an id that is not a single safe path component. Run ids and step ids
+/// are joined onto host paths that become sandbox *write grants*, so a
+/// traversal component (`../other`) would place the grant outside the run
+/// directory or a step's lane, and `.` would alias a whole parent directory.
+/// Defense in depth: run ids are engine-generated and step ids are
+/// spec-validated (S2), but these path-deriving helpers must not trust them.
+fn validate_id(kind: &str, id: &str) -> Result<()> {
+    let unsafe_component = id.is_empty()
+        || id == "."
+        || id == ".."
+        || id.contains('/')
+        || id.contains('\\')
+        || id.contains('\0');
+    if unsafe_component {
+        return Err(Error::InvalidPath(format!(
+            "unsafe workflow {kind} id: {id:?}"
+        )));
+    }
+    Ok(())
+}
+
 /// `~/.fletch/runs/<run-id>/` — one run's host-owned directory (blackboard +,
-/// once S4 lands, the run repository and journal export).
+/// once S4 lands, the run repository and journal export). Errors if `run_id`
+/// is not a safe path component ([`validate_id`]).
 pub fn run_dir(run_id: &str) -> Result<PathBuf> {
+    validate_id("run", run_id)?;
     Ok(runs_root()?.join(run_id))
 }
 
@@ -83,9 +106,12 @@ pub fn export_dir(run_dir: &Path) -> PathBuf {
 }
 
 /// One step's blackboard subdirectory: `<blackboard>/<step-id>/`. A step owns
-/// this directory and `shared/`; it reads everything.
-pub fn step_dir(blackboard: &Path, step_id: &str) -> PathBuf {
-    blackboard.join(step_id)
+/// this directory and `shared/`; it reads everything. Errors if `step_id` is
+/// not a safe path component ([`validate_id`]) — otherwise a step id like
+/// `../other` would point outside the step's lane.
+pub fn step_dir(blackboard: &Path, step_id: &str) -> Result<PathBuf> {
+    validate_id("step", step_id)?;
+    Ok(blackboard.join(step_id))
 }
 
 /// Provision the run directory layout and write `task.md`, returning the
@@ -106,8 +132,12 @@ pub fn provision(run_dir: &Path, task_md: &str) -> Result<PathBuf> {
 }
 
 /// The structured completion signal an agent writes to
-/// `<step-id>/verdict.json` (spec §8.3).
+/// `<step-id>/verdict.json` (spec §8.3). `deny_unknown_fields` keeps the shape
+/// narrow: an unexpected key (a typo'd field name, a prompt-injected extra)
+/// makes the verdict `Malformed` rather than being silently dropped, and the
+/// re-prompt (§6.5) quotes the offending field back to the agent.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Verdict {
     pub result: VerdictResult,
     /// One-line handoff for the timeline and the next agent. Defaulted so a
@@ -207,7 +237,9 @@ pub fn scan_foreign_writes(
     own_step_id: &str,
     since: SystemTime,
 ) -> Result<Vec<PathBuf>> {
-    let own = blackboard.join(own_step_id);
+    // Validate through `step_dir` so a `.` / `..` step id can't alias the whole
+    // blackboard (marking every file "owned" and hiding all foreign writes).
+    let own = step_dir(blackboard, own_step_id)?;
     let shared = blackboard.join("shared");
     let mut out = Vec::new();
     collect_recent_files(blackboard, since, &mut |path| {
@@ -256,6 +288,42 @@ mod tests {
 
     fn tmp() -> tempfile::TempDir {
         tempfile::tempdir().expect("tempdir")
+    }
+
+    #[test]
+    fn run_dir_rejects_traversal_ids() {
+        for bad in ["../other", "a/b", "..", ".", "", "a\\b"] {
+            assert!(
+                run_dir(bad).is_err(),
+                "run id {bad:?} must be rejected as unsafe"
+            );
+        }
+        // A plain component resolves under the runs root.
+        assert!(run_dir("run-1").expect("safe id").ends_with("run-1"));
+    }
+
+    #[test]
+    fn step_dir_rejects_traversal_and_dot() {
+        let board = Path::new("/tmp/board");
+        for bad in ["../other-run", ".", "..", "a/b", ""] {
+            assert!(
+                step_dir(board, bad).is_err(),
+                "step id {bad:?} must be rejected as unsafe"
+            );
+        }
+        assert_eq!(
+            step_dir(board, "review").expect("safe id"),
+            board.join("review")
+        );
+    }
+
+    #[test]
+    fn scan_foreign_writes_rejects_unsafe_step_id() {
+        let dir = tmp();
+        let board = provision(dir.path(), "task").expect("provision");
+        // A `.` own-step-id would otherwise alias the whole board as owned.
+        assert!(scan_foreign_writes(&board, ".", SystemTime::UNIX_EPOCH).is_err());
+        assert!(scan_foreign_writes(&board, "../x", SystemTime::UNIX_EPOCH).is_err());
     }
 
     #[test]
@@ -334,6 +402,20 @@ mod tests {
         assert_eq!(v.result, VerdictResult::Done);
         assert_eq!(v.summary, "");
         assert!(v.detail.is_none());
+    }
+
+    #[test]
+    fn read_verdict_rejects_unknown_fields() {
+        let dir = tmp();
+        std::fs::write(
+            dir.path().join("verdict.json"),
+            r#"{"result":"done","summary":"ok","unexpected":"x"}"#,
+        )
+        .unwrap();
+        match read_verdict(dir.path()) {
+            Err(VerdictError::Malformed(msg)) => assert!(msg.contains("unexpected")),
+            other => panic!("expected malformed on unknown field, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src-tauri/src/workflow/blackboard.rs
+++ b/src-tauri/src/workflow/blackboard.rs
@@ -1,0 +1,416 @@
+//! The per-run **blackboard**: a host-owned directory shared read-write into
+//! every step agent's sandbox, plus the helpers that read and curate it.
+//!
+//! Layout (spec §8.1), rooted at `~/.fletch/runs/<run-id>/`:
+//!
+//! ```text
+//! ~/.fletch/runs/<run-id>/
+//!   blackboard/
+//!     task.md                 # engine-written: the run task + spec summary
+//!     <step-id>/handoff.md    # agent-written free-form notes for downstream
+//!     <step-id>/verdict.json  # agent-written structured completion signal
+//!     shared/                 # agent-written cross-agent scratch space
+//!   export/                   # reserved: journal.jsonl export (derived)
+//! ```
+//!
+//! This module owns four things: **provisioning** the directory and writing
+//! `task.md`; a **defensive `verdict.json` reader** that never panics and
+//! distinguishes missing from malformed (both are gate-unmet, but the
+//! re-prompt quotes the parse error); the **stale-verdict archival** helper
+//! that keeps a leftover verdict from a previous loop iteration or retry from
+//! satisfying a fresh gate (spec §8.3); and the **foreign-write scan** that
+//! lets the engine journal a note when a step wrote outside its own lane
+//! (spec §8.4 — prompt-enforced ownership, this is the detector).
+//!
+//! The sandbox *grant* that makes the blackboard writable from inside a step
+//! agent is plumbed separately through [`crate::sandbox`] (seatbelt subpath /
+//! Docker bind mount + the [`WF_BLACKBOARD_ENV`] env var); this module only
+//! computes the paths.
+
+// The provisioning / verdict / archival / scan helpers below are the S3→S4
+// seam: they are exercised by this module's unit tests but not yet called from
+// the engine, which lands in S4 (scheduler + attempt lifecycle). Remove this
+// allow when S4 wires them in.
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+
+/// Env var naming the blackboard directory inside a step agent's environment.
+/// Both sandbox engines set it to the path the agent should read/write (the
+/// same host path under either engine — Docker bind-mounts the blackboard at
+/// its identical host path, mirroring the RPC mailbox mount). The step-protocol
+/// prompt (S4) points the agent at `$WF_BLACKBOARD`.
+pub const WF_BLACKBOARD_ENV: &str = "WF_BLACKBOARD";
+
+/// Env var overriding the runs root (default `~/.fletch/runs`). Mirrors
+/// [`crate::workspace::WORKSPACES_ROOT_ENV`]: a nested Fletch launched as a Run
+/// process can't write the host's `~/.fletch`, so it is redirected. Set and
+/// non-empty to override.
+pub const RUNS_ROOT_ENV: &str = "FLETCH_RUNS_ROOT";
+
+/// Absolute path to the root holding every run's host-owned directory:
+/// `~/.fletch/runs/`. `$FLETCH_RUNS_ROOT` overrides it when set and non-empty.
+pub fn runs_root() -> Result<PathBuf> {
+    if let Some(root) = std::env::var_os(RUNS_ROOT_ENV).filter(|v| !v.is_empty()) {
+        return Ok(PathBuf::from(root));
+    }
+    let home =
+        dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
+    Ok(home.join(".fletch").join("runs"))
+}
+
+/// `~/.fletch/runs/<run-id>/` — one run's host-owned directory (blackboard +,
+/// once S4 lands, the run repository and journal export).
+pub fn run_dir(run_id: &str) -> Result<PathBuf> {
+    Ok(runs_root()?.join(run_id))
+}
+
+/// `<run-dir>/blackboard/` — the directory granted write access into each step
+/// agent's sandbox. This is the value handed to the sandbox layer and exported
+/// as [`WF_BLACKBOARD_ENV`].
+pub fn blackboard_dir(run_dir: &Path) -> PathBuf {
+    run_dir.join("blackboard")
+}
+
+/// `<run-dir>/export/` — reserved for a derived `journal.jsonl` export.
+pub fn export_dir(run_dir: &Path) -> PathBuf {
+    run_dir.join("export")
+}
+
+/// One step's blackboard subdirectory: `<blackboard>/<step-id>/`. A step owns
+/// this directory and `shared/`; it reads everything.
+pub fn step_dir(blackboard: &Path, step_id: &str) -> PathBuf {
+    blackboard.join(step_id)
+}
+
+/// Provision the run directory layout and write `task.md`, returning the
+/// blackboard path (the sandbox grant path). Idempotent: re-provisioning an
+/// existing run dir re-creates any missing subdirs and rewrites `task.md`, so
+/// resume after a restart is safe. Step subdirectories are created lazily by
+/// the agents themselves (they hold the write grant); only `shared/`, the
+/// blackboard root, and `export/` are provisioned here.
+///
+/// `task_md` is the full contents of `task.md` — the engine (S4) composes it
+/// from the run task and a spec summary; this module just persists it.
+pub fn provision(run_dir: &Path, task_md: &str) -> Result<PathBuf> {
+    let blackboard = blackboard_dir(run_dir);
+    std::fs::create_dir_all(blackboard.join("shared"))?;
+    std::fs::create_dir_all(export_dir(run_dir))?;
+    std::fs::write(blackboard.join("task.md"), task_md)?;
+    Ok(blackboard)
+}
+
+/// The structured completion signal an agent writes to
+/// `<step-id>/verdict.json` (spec §8.3).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Verdict {
+    pub result: VerdictResult,
+    /// One-line handoff for the timeline and the next agent. Defaulted so a
+    /// verdict carrying only `result` still parses — the gate reads `result`,
+    /// and a missing summary is a quality issue, not a malformed verdict.
+    #[serde(default)]
+    pub summary: String,
+    /// Optional; e.g. structured review feedback.
+    #[serde(default)]
+    pub detail: Option<String>,
+    /// Optional step-id to revise (loops only; must be inside the same loop).
+    #[serde(default)]
+    pub target: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum VerdictResult {
+    Done,
+    Revise,
+    Blocked,
+}
+
+/// Why reading a verdict did not yield a usable [`Verdict`]. Both variants mean
+/// "gate unmet"; they differ only in what the engine journals and re-prompts:
+/// a missing verdict is silent (the agent simply isn't done), a malformed one
+/// carries the parse error so the re-prompt can quote it back (spec §8.3, §6.5).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerdictError {
+    /// No `verdict.json` at the expected path.
+    Missing,
+    /// The file exists but could not be read or parsed into a [`Verdict`]. The
+    /// string is a human-readable cause suitable for a journal note and a
+    /// re-prompt.
+    Malformed(String),
+}
+
+/// Read and parse `<step-dir>/verdict.json` defensively. Never panics and never
+/// returns a generic error: a missing file is [`VerdictError::Missing`], any
+/// read or parse failure is [`VerdictError::Malformed`] with a cause. The
+/// caller treats both as an unmet gate (spec §8.3).
+pub fn read_verdict(step_dir: &Path) -> std::result::Result<Verdict, VerdictError> {
+    let path = step_dir.join("verdict.json");
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Err(VerdictError::Missing),
+        Err(e) => {
+            return Err(VerdictError::Malformed(format!(
+                "cannot read verdict.json: {e}"
+            )))
+        }
+    };
+    serde_json::from_slice::<Verdict>(&bytes)
+        .map_err(|e| VerdictError::Malformed(format!("invalid verdict.json: {e}")))
+}
+
+/// Move an existing `<step-dir>/verdict.json` aside before a fresh attempt's
+/// prompt is sent, so a leftover verdict from a previous iteration or retry
+/// cannot satisfy the new gate (spec §8.3, the loop/retry staleness bug class).
+/// The verdict is moved to `<step-dir>/history/attempt-<attempt>.iter-<iteration>.verdict.json`;
+/// the history files double as the loop's feedback trail. Returns the archive
+/// destination when a verdict was moved, or `None` when there was none (the
+/// common first-attempt case). The caller journals the move.
+///
+/// `attempt` and `iteration` label the verdict being archived — i.e. the
+/// attempt/iteration that *wrote* it, not the one about to run.
+pub fn archive_stale_verdict(
+    step_dir: &Path,
+    attempt: u32,
+    iteration: u32,
+) -> Result<Option<PathBuf>> {
+    let src = step_dir.join("verdict.json");
+    match src.symlink_metadata() {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(Error::Io(e)),
+    }
+    let history = step_dir.join("history");
+    std::fs::create_dir_all(&history)?;
+    let dest = history.join(format!("attempt-{attempt}.iter-{iteration}.verdict.json"));
+    std::fs::rename(&src, &dest)?;
+    Ok(Some(dest))
+}
+
+/// Files under `blackboard` modified strictly after `since` that the step with
+/// `own_step_id` does not own. A step owns its `<own_step_id>/` subtree and the
+/// shared `shared/` scratch space; everything else (other steps' dirs, the
+/// engine's `task.md`) is foreign. The engine runs this after a step's turn and
+/// journals a note if the result is non-empty (spec §8.4 — ownership is
+/// prompt-enforced in v1; this is the detector, not an enforcement gate). Paths
+/// are returned relative to `blackboard` for compact journaling.
+///
+/// Best-effort: unreadable entries and entries whose mtime can't be read are
+/// skipped rather than failing the scan (a missing mtime must not block a run).
+pub fn scan_foreign_writes(
+    blackboard: &Path,
+    own_step_id: &str,
+    since: SystemTime,
+) -> Result<Vec<PathBuf>> {
+    let own = blackboard.join(own_step_id);
+    let shared = blackboard.join("shared");
+    let mut out = Vec::new();
+    collect_recent_files(blackboard, since, &mut |path| {
+        if path.starts_with(&own) || path.starts_with(&shared) {
+            return;
+        }
+        if let Ok(rel) = path.strip_prefix(blackboard) {
+            out.push(rel.to_path_buf());
+        }
+    })?;
+    out.sort();
+    Ok(out)
+}
+
+/// Recurse `dir`, invoking `visit` for every regular file whose mtime is
+/// strictly after `since`. Directories themselves are traversed but never
+/// reported. Best-effort per the caller's contract: an unreadable directory or
+/// a metadata read failure skips that entry.
+fn collect_recent_files(dir: &Path, since: SystemTime, visit: &mut dyn FnMut(&Path)) -> Result<()> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(Error::Io(e)),
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(ft) = entry.file_type() else { continue };
+        if ft.is_dir() {
+            collect_recent_files(&path, since, visit)?;
+        } else if ft.is_file() {
+            let Ok(meta) = entry.metadata() else { continue };
+            let Ok(modified) = meta.modified() else {
+                continue;
+            };
+            if modified > since {
+                visit(&path);
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp() -> tempfile::TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+
+    #[test]
+    fn provision_creates_layout_and_writes_task() {
+        let dir = tmp();
+        let run = dir.path().join("run-1");
+        let board = provision(&run, "the task\n\nsummary").expect("provision");
+
+        assert_eq!(board, run.join("blackboard"));
+        assert!(board.is_dir());
+        assert!(board.join("shared").is_dir());
+        assert!(run.join("export").is_dir());
+        assert_eq!(
+            std::fs::read_to_string(board.join("task.md")).unwrap(),
+            "the task\n\nsummary"
+        );
+    }
+
+    #[test]
+    fn provision_is_idempotent_and_rewrites_task() {
+        let dir = tmp();
+        let run = dir.path().join("run-1");
+        provision(&run, "first").expect("provision");
+        // A step wrote a file; re-provisioning (resume) must not wipe it.
+        let board = run.join("blackboard");
+        std::fs::create_dir_all(board.join("plan")).unwrap();
+        std::fs::write(board.join("plan/handoff.md"), "notes").unwrap();
+
+        provision(&run, "second").expect("re-provision");
+        assert_eq!(
+            std::fs::read_to_string(board.join("task.md")).unwrap(),
+            "second"
+        );
+        assert_eq!(
+            std::fs::read_to_string(board.join("plan/handoff.md")).unwrap(),
+            "notes"
+        );
+    }
+
+    #[test]
+    fn read_verdict_missing_is_typed() {
+        let dir = tmp();
+        assert_eq!(read_verdict(dir.path()), Err(VerdictError::Missing));
+    }
+
+    #[test]
+    fn read_verdict_malformed_carries_cause() {
+        let dir = tmp();
+        std::fs::write(dir.path().join("verdict.json"), "{ not json").unwrap();
+        match read_verdict(dir.path()) {
+            Err(VerdictError::Malformed(msg)) => assert!(msg.contains("invalid verdict.json")),
+            other => panic!("expected malformed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_verdict_valid_parses_all_fields() {
+        let dir = tmp();
+        std::fs::write(
+            dir.path().join("verdict.json"),
+            r#"{"result":"revise","summary":"needs work","detail":"fix x","target":"review"}"#,
+        )
+        .unwrap();
+        let v = read_verdict(dir.path()).expect("valid verdict");
+        assert_eq!(v.result, VerdictResult::Revise);
+        assert_eq!(v.summary, "needs work");
+        assert_eq!(v.detail.as_deref(), Some("fix x"));
+        assert_eq!(v.target.as_deref(), Some("review"));
+    }
+
+    #[test]
+    fn read_verdict_accepts_result_only() {
+        let dir = tmp();
+        std::fs::write(dir.path().join("verdict.json"), r#"{"result":"done"}"#).unwrap();
+        let v = read_verdict(dir.path()).expect("result-only verdict");
+        assert_eq!(v.result, VerdictResult::Done);
+        assert_eq!(v.summary, "");
+        assert!(v.detail.is_none());
+    }
+
+    #[test]
+    fn read_verdict_rejects_unknown_result() {
+        let dir = tmp();
+        std::fs::write(dir.path().join("verdict.json"), r#"{"result":"maybe"}"#).unwrap();
+        assert!(matches!(
+            read_verdict(dir.path()),
+            Err(VerdictError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn archive_stale_verdict_moves_and_labels() {
+        let dir = tmp();
+        let step = dir.path();
+        std::fs::write(step.join("verdict.json"), r#"{"result":"revise"}"#).unwrap();
+
+        let dest = archive_stale_verdict(step, 1, 0).expect("archive").unwrap();
+        assert_eq!(
+            dest,
+            step.join("history").join("attempt-1.iter-0.verdict.json")
+        );
+        assert!(!step.join("verdict.json").exists());
+        assert!(dest.is_file());
+    }
+
+    #[test]
+    fn archive_stale_verdict_noop_when_absent() {
+        let dir = tmp();
+        assert_eq!(
+            archive_stale_verdict(dir.path(), 2, 3).expect("archive"),
+            None
+        );
+    }
+
+    #[test]
+    fn archived_verdict_does_not_satisfy_a_new_gate() {
+        // The staleness bug: a leftover done-verdict must not survive to the
+        // next iteration's gate. After archival, the step dir has no verdict.
+        let dir = tmp();
+        let step = dir.path();
+        std::fs::write(step.join("verdict.json"), r#"{"result":"done"}"#).unwrap();
+        archive_stale_verdict(step, 1, 0).expect("archive");
+        assert_eq!(read_verdict(step), Err(VerdictError::Missing));
+    }
+
+    #[test]
+    fn scan_foreign_writes_flags_other_lanes_only() {
+        let dir = tmp();
+        let board = provision(dir.path(), "task").expect("provision");
+        // A baseline in the past: everything created after counts as recent.
+        let since = SystemTime::UNIX_EPOCH;
+
+        std::fs::create_dir_all(board.join("plan")).unwrap();
+        std::fs::write(board.join("plan/handoff.md"), "own").unwrap();
+        std::fs::write(board.join("shared/scratch.txt"), "shared").unwrap();
+        std::fs::create_dir_all(board.join("other")).unwrap();
+        std::fs::write(board.join("other/verdict.json"), "foreign").unwrap();
+
+        let foreign = scan_foreign_writes(&board, "plan", since).expect("scan");
+        // Own lane and shared are exempt; task.md (engine-written, pre-`since`
+        // baseline aside it is foreign to every step) and the other step's file
+        // are flagged.
+        assert!(foreign.contains(&PathBuf::from("other/verdict.json")));
+        assert!(foreign.contains(&PathBuf::from("task.md")));
+        assert!(!foreign.iter().any(|p| p.starts_with("plan")));
+        assert!(!foreign.iter().any(|p| p.starts_with("shared")));
+    }
+
+    #[test]
+    fn scan_foreign_writes_respects_since_cutoff() {
+        let dir = tmp();
+        let board = provision(dir.path(), "task").expect("provision");
+        // Nothing modified after "now-ish" far in the future.
+        let future = SystemTime::now() + std::time::Duration::from_secs(3600);
+        let foreign = scan_foreign_writes(&board, "plan", future).expect("scan");
+        assert!(foreign.is_empty());
+    }
+}

--- a/src-tauri/src/workflow/mod.rs
+++ b/src-tauri/src/workflow/mod.rs
@@ -14,6 +14,7 @@
 //! The allow is removed once those callers land.
 #![allow(dead_code)]
 
+pub mod blackboard;
 pub mod definition;
 pub mod journal;
 pub mod spec;


### PR DESCRIPTION
Implements Workflows v1 slice **S3 — Blackboard + sandbox grants** (spec §8.1–8.4). See `docs/workflows/SLICES.md` and `docs/workflows/TECH_SPEC.md`.

## Scope

**`src-tauri/src/workflow/blackboard.rs`** (+ minimal `workflow/mod.rs`, `mod workflow;` in `lib.rs`)
- `provision(run_dir, task_md)` — creates `~/.fletch/runs/<id>/blackboard/{,shared}` + `export/`, writes `task.md`; idempotent so resume after a restart is safe.
- `read_verdict(step_dir)` — defensive reader returning a typed `VerdictError::{Missing, Malformed(cause)}`; never panics. Both are gate-unmet; they differ only in what the engine journals/re-prompts (§8.3, §6.5).
- `archive_stale_verdict(step_dir, attempt, iter)` — the §8.3 staleness fix: moves a leftover verdict to `history/attempt-<n>.iter-<i>.verdict.json` so an old verdict can't satisfy a fresh loop/retry gate. History files double as the loop feedback trail.
- `scan_foreign_writes(board, own_step_id, since)` — §8.4 mtime detector (own `<step-id>/` and `shared/` exempt).

**Sandbox grant plumbing**
- `AgentLaunchCtx.blackboard: Option<&Path>` — the S3→S4 seam. All 4 current call sites pass `None`; the scheduler (S4) populates it at spawn.
- Seatbelt: extra writable `(subpath …)` in `build_profile` + `WF_BLACKBOARD` on `LaunchPlan.env`.
- Docker: read-write bind mount + forwarded `-e WF_BLACKBOARD`.
- Verified `LaunchPlan.env` reaches the process in all three launch paths.

## Deviations from the spec (recorded in `TECH_SPEC.md §8.2`)
1. **Docker mounts at the blackboard's identical host path** (invariant 1), not the spec's synthetic `/workspace/.wf-blackboard` — this makes `WF_BLACKBOARD` the same value on both engines and matches the RPC mailbox mount.
2. **Seatbelt grant is emitted directly in `seatbelt.rs`** (like the RPC mailbox), not routed through `policy.rs`, which models only static home-relative dirs and documents that a passthrough grant "buys nothing" there.

## Out of scope (as specified)
Prompts (S4), per-path hard write enforcement (deferred, v2).

## Testing
- Seatbelt: grant present and **not its parent** (write inside the grant, not beside it).
- Verdict reader: missing / malformed / valid / result-only / unknown-result fixtures.
- Docker: mount at identical path + `WF_BLACKBOARD` forwarded; absent for ordinary agents.
- `provision` / `archive_stale_verdict` / `scan_foreign_writes` unit tests.
- `cargo test --lib` 604 passed, `cargo clippy --lib` and `cargo fmt --check` clean.

## Note for the S4 owner
`blackboard.rs` carries a `#![allow(dead_code)]` (the helpers are test-exercised but not yet engine-wired) — remove it when S4 wires them in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)