### PR TITLE
feat(workflows): tests gate (S6)

### DIFF
--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -5,7 +5,7 @@ mod events;
 mod lifecycle;
 mod messaging;
 mod rpc_watch;
-mod run;
+pub(crate) mod run;
 mod session_sync;
 mod shell;
 

--- a/src-tauri/src/supervisor/run.rs
+++ b/src-tauri/src/supervisor/run.rs
@@ -493,7 +493,10 @@ fn sandboxed_run_command(cwd: &Path, cmd: &str) -> Result<SandboxedRunCommand> {
 /// check anyway). Runs synchronously — the profile is assembled off the async
 /// runtime — via the app's resolved git binary (portable-git fallback),
 /// matching every other git call.
-fn run_target_git_common_dir(cwd: &Path) -> Option<PathBuf> {
+///
+/// Shared with the workflows tests gate (`workflow::tests_gate`), which runs the
+/// project's tests under this same Run profile and needs the identical grant.
+pub(crate) fn run_target_git_common_dir(cwd: &Path) -> Option<PathBuf> {
     let out = crate::git_dist::std_command(cwd)
         // Resolve strictly from `cwd`. `std_command` inherits the outer app's
         // environment, and an ambient GIT_DIR / GIT_WORK_TREE / GIT_COMMON_DIR

--- a/src-tauri/src/workflow/attempt.rs
+++ b/src-tauri/src/workflow/attempt.rs
@@ -29,9 +29,10 @@ use crate::workspace::AgentStatus;
 use super::blackboard::{self, Verdict, VerdictError};
 use super::budget::{BudgetLimit, EffectiveBudgets, Ledger};
 use super::driver::{AgentDriver, SpawnReq};
-use super::gates::{self, GateInputs, GateOutcome};
+use super::gates::{self, GateInputs, GateOutcome, TestsOutcome};
 use super::prompts;
 use super::spec::Gate;
+use super::tests_gate::TestRunner;
 use super::types::event_type;
 
 /// The deadlines and watchdog cadence for one attempt (spec §11.1). The
@@ -127,6 +128,9 @@ fn ev(event_type: &'static str, payload: Value) -> AttemptEvent {
 
 /// Drive one step attempt to a terminal outcome (spec §6.3 steps 1–6).
 ///
+/// `test_runner` is only consulted for a `tests` gate (spec §9.4); every other
+/// gate ignores it, so callers with no test-capable gate can pass any impl.
+///
 /// `ledger` / `eff` carry budget enforcement (spec §11.2): the attempt checks
 /// `ledger.exceeded()` before each prompt send and charges one turn (plus any
 /// token usage) at each turn end, bailing with [`AttemptOutcome::BudgetExceeded`]
@@ -134,6 +138,7 @@ fn ev(event_type: &'static str, payload: Value) -> AttemptEvent {
 /// and persistence of the mutated ledger.
 pub async fn run_attempt(
     driver: &dyn AgentDriver,
+    test_runner: &dyn TestRunner,
     params: AttemptParams,
     ledger: &mut Ledger,
     eff: &EffectiveBudgets,
@@ -294,6 +299,13 @@ pub async fn run_attempt(
             Gate::Artifact { path } => artifact_exists(&spawned.worktree, path),
             _ => false,
         };
+        // Tests gate (spec §9.4): resolve + run the project's tests in the step
+        // worktree now, then let the pure gate turn the outcome into done/blocked.
+        let tests = if matches!(gate, Gate::Tests) {
+            Some(test_runner.run_tests(&spawned.worktree).await)
+        } else {
+            None
+        };
         let inputs = GateInputs {
             verdict: verdict.as_ref(),
             verdict_error: verdict_error.as_deref(),
@@ -301,16 +313,31 @@ pub async fn run_attempt(
             head_end: head_end.as_deref(),
             artifact_present,
             approved: false,
+            tests: tests.as_ref(),
         };
         let result = gates::evaluate(&gate, &inputs);
-        events.push(ev(
-            event_type::GATE_EVALUATED,
-            json!({
-                "mode": gate_mode(&gate),
-                "outcome": outcome_label(&result.outcome),
-                "reason": result.reason,
-            }),
-        ));
+        let mut gate_payload = json!({
+            "mode": gate_mode(&gate),
+            "outcome": outcome_label(&result.outcome),
+            "reason": result.reason,
+        });
+        // Attach the tests-gate specifics for the timeline (spec §9.4): the
+        // output tail on a red/timeout/setup-failed run, or a degrade warning
+        // when no test command resolved and the gate fell back to verdict.
+        match &tests {
+            Some(
+                TestsOutcome::Failed { tail }
+                | TestsOutcome::TimedOut { tail }
+                | TestsOutcome::SetupFailed { tail },
+            ) if !tail.trim().is_empty() => {
+                gate_payload["output_tail"] = json!(tail);
+            }
+            Some(TestsOutcome::NoCommand) => {
+                gate_payload["tests_degraded"] = json!(true);
+            }
+            _ => {}
+        }
+        events.push(ev(event_type::GATE_EVALUATED, gate_payload));
 
         match result.outcome {
             GateOutcome::Done => {
@@ -552,7 +579,24 @@ fn outcome_label(outcome: &GateOutcome) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::workflow::driver::{MockDriver, TurnBehavior, TurnUsage};
+    use crate::workflow::driver::{BoxFuture, MockDriver, TurnBehavior, TurnUsage};
+
+    /// A runner for the non-tests gates, which must never invoke it.
+    struct NeverTests;
+    impl TestRunner for NeverTests {
+        fn run_tests<'a>(&'a self, _worktree: &'a Path) -> BoxFuture<'a, TestsOutcome> {
+            Box::pin(async { panic!("run_tests must not be called for a non-tests gate") })
+        }
+    }
+
+    /// A runner that returns a fixed outcome — drives the `tests` gate cases.
+    struct ScriptedTests(TestsOutcome);
+    impl TestRunner for ScriptedTests {
+        fn run_tests<'a>(&'a self, _worktree: &'a Path) -> BoxFuture<'a, TestsOutcome> {
+            let outcome = self.0.clone();
+            Box::pin(async move { outcome })
+        }
+    }
 
     fn params(gate: Gate, blackboard: PathBuf, deadlines: Deadlines) -> AttemptParams {
         AttemptParams {
@@ -582,9 +626,20 @@ mod tests {
 
     /// Run an attempt with an effectively unbounded budget — the default for the
     /// lifecycle tests that don't exercise enforcement.
-    async fn run(driver: &dyn AgentDriver, params: AttemptParams) -> AttemptRun {
+    async fn run(
+        driver: &dyn AgentDriver,
+        test_runner: &dyn TestRunner,
+        params: AttemptParams,
+    ) -> AttemptRun {
         let mut ledger = Ledger::default();
-        run_attempt(driver, params, &mut ledger, &EffectiveBudgets::default()).await
+        run_attempt(
+            driver,
+            test_runner,
+            params,
+            &mut ledger,
+            &EffectiveBudgets::default(),
+        )
+        .await
     }
 
     fn fast() -> Deadlines {
@@ -613,6 +668,7 @@ mod tests {
 
         let run = run(
             d.as_ref(),
+            &NeverTests,
             params(Gate::Verdict, bb.path().to_path_buf(), fast()),
         )
         .await;
@@ -635,6 +691,7 @@ mod tests {
         // ready_on_spawn stays false → agent parks in Spawning forever.
         let run = run(
             d.as_ref(),
+            &NeverTests,
             params(Gate::Verdict, bb.path().to_path_buf(), fast()),
         )
         .await;
@@ -652,6 +709,7 @@ mod tests {
         d.set_turn_behavior(TurnBehavior::Silent); // prompt lands, no turn
         let run = run(
             d.as_ref(),
+            &NeverTests,
             params(Gate::Verdict, bb.path().to_path_buf(), fast()),
         )
         .await;
@@ -676,6 +734,7 @@ mod tests {
 
         let run = run(
             d.as_ref(),
+            &NeverTests,
             params(Gate::Verdict, bb.path().to_path_buf(), fast()),
         )
         .await;
@@ -694,6 +753,7 @@ mod tests {
         d.set_turn_behavior(TurnBehavior::RunningOnly); // turn starts, never ends
         let run = run(
             d.as_ref(),
+            &NeverTests,
             params(Gate::Verdict, bb.path().to_path_buf(), fast()),
         )
         .await;
@@ -720,6 +780,7 @@ mod tests {
         d.set_turn_behavior(TurnBehavior::ErrorOut);
         let run = run(
             d.as_ref(),
+            &NeverTests,
             params(Gate::Verdict, bb.path().to_path_buf(), fast()),
         )
         .await;
@@ -737,6 +798,7 @@ mod tests {
         d.fail_next_spawn("no repo");
         let run = run(
             d.as_ref(),
+            &NeverTests,
             params(Gate::Verdict, bb.path().to_path_buf(), fast()),
         )
         .await;
@@ -756,6 +818,7 @@ mod tests {
 
         let run = run(
             d.as_ref(),
+            &NeverTests,
             params(Gate::Verdict, bb.path().to_path_buf(), fast()),
         )
         .await;
@@ -781,6 +844,7 @@ mod tests {
         d.set_turn_behavior(TurnBehavior::Complete);
         let run = run(
             d.as_ref(),
+            &NeverTests,
             params(Gate::Approval, bb.path().to_path_buf(), fast()),
         )
         .await;
@@ -810,6 +874,7 @@ mod tests {
         d.set_turn_behavior(TurnBehavior::Complete); // completes but writes no verdict
         let run = run(
             d.as_ref(),
+            &NeverTests,
             params(Gate::Verdict, bb.path().to_path_buf(), fast()),
         )
         .await;
@@ -846,6 +911,7 @@ mod tests {
         };
         let run = run_attempt(
             d.as_ref(),
+            &NeverTests,
             params(Gate::Verdict, bb.path().to_path_buf(), fast()),
             &mut ledger,
             &eff,
@@ -886,6 +952,7 @@ mod tests {
         };
         let run = run_attempt(
             d.as_ref(),
+            &NeverTests,
             params(Gate::Verdict, bb.path().to_path_buf(), fast()),
             &mut ledger,
             &eff,
@@ -916,6 +983,7 @@ mod tests {
         };
         let run = run_attempt(
             d.as_ref(),
+            &NeverTests,
             params(Gate::Verdict, bb.path().to_path_buf(), fast()),
             &mut ledger,
             &eff,
@@ -930,5 +998,92 @@ mod tests {
         assert!(types_present(&run.events, event_type::ATTEMPT_READY));
         assert!(!types_present(&run.events, event_type::PROMPT_SENT));
         assert!(d.sent_messages().is_empty());
+    }
+
+    // ── tests gate (spec §9.4) ────────────────────────────────────────────────
+
+    #[tokio::test(start_paused = true)]
+    async fn tests_gate_passes_when_the_runner_reports_green() {
+        let bb = tempfile::tempdir().unwrap();
+        let d = MockDriver::new();
+        d.set_ready_on_spawn(true);
+        d.set_turn_behavior(TurnBehavior::Complete);
+        let run = run(
+            d.as_ref(),
+            &ScriptedTests(TestsOutcome::Passed),
+            params(Gate::Tests, bb.path().to_path_buf(), fast()),
+        )
+        .await;
+        assert!(
+            matches!(run.outcome, AttemptOutcome::Done { .. }),
+            "{:?}",
+            run.outcome
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn tests_gate_red_run_reprompts_with_output_tail() {
+        let bb = tempfile::tempdir().unwrap();
+        let d = MockDriver::new();
+        d.set_ready_on_spawn(true);
+        d.set_turn_behavior(TurnBehavior::Complete);
+        let tail = "FAIL src/math.test.ts\n  ✕ adds (3 failing tests)";
+        let run = run(
+            d.as_ref(),
+            &ScriptedTests(TestsOutcome::Failed { tail: tail.into() }),
+            params(Gate::Tests, bb.path().to_path_buf(), fast()),
+        )
+        .await;
+        assert!(
+            matches!(run.outcome, AttemptOutcome::Blocked { .. }),
+            "{:?}",
+            run.outcome
+        );
+        // The re-prompt after the red run quotes the output tail (spec §9.4).
+        let reprompt_has_tail = d
+            .sent_messages()
+            .into_iter()
+            .any(|(_, t)| t.contains("3 failing tests"));
+        assert!(
+            reprompt_has_tail,
+            "re-prompt should include the output tail"
+        );
+        // And the gate_evaluated events carry the tail for the timeline.
+        assert!(run
+            .events
+            .iter()
+            .any(|e| e.event_type == event_type::GATE_EVALUATED
+                && e.payload
+                    .get("output_tail")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|s| s.contains("3 failing tests"))));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn tests_gate_no_command_degrades_to_verdict() {
+        // With no resolvable test command the gate falls back to the verdict:
+        // a done verdict completes the step, and the degrade is journaled.
+        let bb = tempfile::tempdir().unwrap();
+        let step_dir = blackboard::step_dir(bb.path(), "plan").unwrap();
+        let d = MockDriver::new();
+        d.set_ready_on_spawn(true);
+        d.set_turn_behavior(TurnBehavior::Complete);
+        d.set_complete_verdict(step_dir, r#"{"result":"done","summary":"ok"}"#);
+        let run = run(
+            d.as_ref(),
+            &ScriptedTests(TestsOutcome::NoCommand),
+            params(Gate::Tests, bb.path().to_path_buf(), fast()),
+        )
+        .await;
+        assert!(
+            matches!(run.outcome, AttemptOutcome::Done { .. }),
+            "{:?}",
+            run.outcome
+        );
+        assert!(run
+            .events
+            .iter()
+            .any(|e| e.event_type == event_type::GATE_EVALUATED
+                && e.payload.get("tests_degraded").and_then(|v| v.as_bool()) == Some(true)));
     }
 }

--- a/src-tauri/src/workflow/gates.rs
+++ b/src-tauri/src/workflow/gates.rs
@@ -4,10 +4,11 @@
 //! verdict, and artifact existence, then asks this module for the verdict so
 //! the decision is trivially unit-testable and journalable.
 //!
-//! S4 implements four gates — `verdict`, `commit`, `artifact`, `approval`. The
-//! `tests` gate (spec §9.4) lands in S6; until then spec validation rejects
-//! definitions that declare it, and this module blocks it rather than let a
-//! step complete a `tests` gate without any test having run.
+//! S4 implemented four gates — `verdict`, `commit`, `artifact`, `approval`.
+//! S6 adds the `tests` gate (spec §9.4): the caller (`workflow::tests_gate`)
+//! resolves and runs the project's test command bounded in the step worktree,
+//! then hands the [`TestsOutcome`] in as a fact — execution stays out of this
+//! pure module. When no test command resolves the gate degrades to `verdict`.
 
 use super::blackboard::{Verdict, VerdictResult};
 use super::spec::Gate;
@@ -51,6 +52,26 @@ impl GateResult {
     }
 }
 
+/// The result of running the project's tests for the `tests` gate (spec §9.4).
+/// Produced by `workflow::tests_gate` (which does the I/O) and handed to
+/// [`evaluate`] as a fact so gate evaluation stays pure and unit-testable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TestsOutcome {
+    /// The test command exited 0.
+    Passed,
+    /// The test command exited non-zero. `tail` is the last lines of output
+    /// (spec §9.4), quoted into the `gate_evaluated` payload and the re-prompt.
+    Failed { tail: String },
+    /// The test command did not finish within `tests_timeout_secs`.
+    TimedOut { tail: String },
+    /// The project's setup/install command failed, so tests never ran — a
+    /// distinct cause from failing tests (spec §9.4).
+    SetupFailed { tail: String },
+    /// No test command could be resolved (no override, nothing detected). The
+    /// gate degrades to `verdict` with a journaled warning (spec §9.4).
+    NoCommand,
+}
+
 /// Facts the caller gathers before asking for a gate decision. Everything here
 /// is already-resolved data — this module performs no I/O.
 #[derive(Debug, Default, Clone)]
@@ -71,6 +92,10 @@ pub struct GateInputs<'a> {
     /// evaluation → `AwaitingApproval`; the `wf_approve` path re-evaluates with
     /// `true`.
     pub approved: bool,
+    /// The result of running the project's tests (the `tests` gate only). `None`
+    /// for every other gate; a `tests` gate with `NoCommand` degrades to the
+    /// verdict facts above (spec §9.4).
+    pub tests: Option<&'a TestsOutcome>,
 }
 
 /// Evaluate `gate` against `inputs`. Pure and total — no panics, no I/O.
@@ -80,12 +105,7 @@ pub fn evaluate(gate: &Gate, inputs: &GateInputs) -> GateResult {
         Gate::Commit => evaluate_commit(inputs),
         Gate::Artifact { path } => evaluate_artifact(path, inputs),
         Gate::Approval => evaluate_approval(inputs),
-        // Tests gate arrives in S6. Spec validation already rejects it; block
-        // here too so nothing can complete a `tests` gate without tests running.
-        Gate::Tests => GateResult::blocked(
-            "tests gate is not implemented yet — no test command was run; use the \
-             `verdict` gate until test execution lands (S6)",
-        ),
+        Gate::Tests => evaluate_tests(inputs),
     }
 }
 
@@ -139,6 +159,38 @@ fn evaluate_approval(inputs: &GateInputs) -> GateResult {
             outcome: GateOutcome::AwaitingApproval,
             reason: "waiting for human approval".to_string(),
         }
+    }
+}
+
+fn evaluate_tests(inputs: &GateInputs) -> GateResult {
+    match inputs.tests {
+        Some(TestsOutcome::Passed) => GateResult::done("project tests passed"),
+        Some(TestsOutcome::Failed { tail }) => {
+            GateResult::blocked(with_tail("project tests failed", tail))
+        }
+        Some(TestsOutcome::TimedOut { tail }) => {
+            GateResult::blocked(with_tail("project tests timed out before finishing", tail))
+        }
+        Some(TestsOutcome::SetupFailed { tail }) => GateResult::blocked(with_tail(
+            "project setup command failed (tests not run)",
+            tail,
+        )),
+        // No test command resolvable → degrade to the verdict gate (spec §9.4).
+        // `attempt.rs` journals the degrade warning; here we just read the
+        // verdict facts the caller always gathers.
+        Some(TestsOutcome::NoCommand) | None => evaluate_verdict(inputs),
+    }
+}
+
+/// Compose a gate reason from a headline plus an optional output tail. The tail
+/// rides in the reason so it reaches both the `gate_evaluated` journal event and
+/// the re-prompt (spec §9.4) through the existing blocked-reason plumbing.
+fn with_tail(headline: &str, tail: &str) -> String {
+    let tail = tail.trim_end();
+    if tail.is_empty() {
+        headline.to_string()
+    } else {
+        format!("{headline}:\n{tail}")
     }
 }
 
@@ -294,16 +346,86 @@ mod tests {
     }
 
     #[test]
-    fn tests_gate_blocks_even_with_done_verdict() {
-        let v = verdict(VerdictResult::Done, "ok");
+    fn tests_gate_passes_when_tests_pass() {
+        let outcome = TestsOutcome::Passed;
         let r = evaluate(
             &Gate::Tests,
             &GateInputs {
-                verdict: Some(&v),
+                tests: Some(&outcome),
+                ..Default::default()
+            },
+        );
+        assert_eq!(r.outcome, GateOutcome::Done);
+    }
+
+    #[test]
+    fn tests_gate_blocks_with_output_tail_on_failure() {
+        let outcome = TestsOutcome::Failed {
+            tail: "FAIL src/foo.test.ts\n  ✕ adds numbers".into(),
+        };
+        let r = evaluate(
+            &Gate::Tests,
+            &GateInputs {
+                tests: Some(&outcome),
                 ..Default::default()
             },
         );
         assert_eq!(r.outcome, GateOutcome::Blocked);
-        assert!(r.reason.contains("not implemented"), "reason: {}", r.reason);
+        assert!(r.reason.contains("adds numbers"), "reason: {}", r.reason);
+    }
+
+    #[test]
+    fn tests_gate_distinguishes_timeout_and_setup_failure() {
+        let timed = TestsOutcome::TimedOut {
+            tail: String::new(),
+        };
+        let r = evaluate(
+            &Gate::Tests,
+            &GateInputs {
+                tests: Some(&timed),
+                ..Default::default()
+            },
+        );
+        assert_eq!(r.outcome, GateOutcome::Blocked);
+        assert!(r.reason.contains("timed out"), "reason: {}", r.reason);
+
+        let setup = TestsOutcome::SetupFailed {
+            tail: "npm ERR! missing script: build".into(),
+        };
+        let r = evaluate(
+            &Gate::Tests,
+            &GateInputs {
+                tests: Some(&setup),
+                ..Default::default()
+            },
+        );
+        assert_eq!(r.outcome, GateOutcome::Blocked);
+        assert!(r.reason.contains("setup"), "reason: {}", r.reason);
+    }
+
+    #[test]
+    fn tests_gate_no_command_degrades_to_verdict() {
+        let none = TestsOutcome::NoCommand;
+        // With a done verdict present the degraded gate passes …
+        let v = verdict(VerdictResult::Done, "ok");
+        let r = evaluate(
+            &Gate::Tests,
+            &GateInputs {
+                tests: Some(&none),
+                verdict: Some(&v),
+                ..Default::default()
+            },
+        );
+        assert_eq!(r.outcome, GateOutcome::Done);
+
+        // … and without one it blocks exactly like a verdict gate.
+        let r = evaluate(
+            &Gate::Tests,
+            &GateInputs {
+                tests: Some(&none),
+                ..Default::default()
+            },
+        );
+        assert_eq!(r.outcome, GateOutcome::Blocked);
     }
 }

--- a/src-tauri/src/workflow/mod.rs
+++ b/src-tauri/src/workflow/mod.rs
@@ -25,6 +25,7 @@ pub mod journal;
 pub mod prompts;
 pub mod scheduler;
 pub mod spec;
+pub mod tests_gate;
 pub mod types;
 pub mod yaml;
 

--- a/src-tauri/src/workflow/prompts.rs
+++ b/src-tauri/src/workflow/prompts.rs
@@ -172,11 +172,9 @@ fn gate_statement(gate: &Gate) -> String {
              `verdict.json`. A human will review and approve before the workflow \
              continues."
             .to_string(),
-        // Tests gate lands in S6. Spec validation rejects definitions that
-        // declare it and gate evaluation blocks it, so this arm is unreachable
-        // in a validated run — kept only so the match stays total.
-        Gate::Tests => "The `tests` gate is not implemented yet and cannot pass. Write \
-             `verdict.json` describing your work; the run will pause blocked."
+        Gate::Tests => "You are done when the project's test suite passes. The workflow runs \
+             the project's tests for you after your turn; make them green. Still write \
+             `verdict.json` and handoff notes so the next step has your summary."
             .to_string(),
     }
 }
@@ -242,6 +240,8 @@ mod tests {
         })
         .contains("X.md"));
         assert!(gate_statement(&Gate::Approval).contains("human"));
+        let tests = gate_statement(&Gate::Tests);
+        assert!(tests.contains("test suite passes"), "{tests}");
     }
 
     #[test]

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -653,13 +653,18 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
                         Err(e) => {
                             last_failure = Some(format!("ferry failed: {e}"));
                             // The attempt reached `done`, so its agent is idle but
-                            // still alive. Marking the exec `error` hides it from
-                            // `live_step_agents` (which only sees in-flight execs),
-                            // so stop+archive it here — otherwise the CLI process
-                            // leaks past the retry/fail and its chat is orphaned.
+                            // still alive, and marking the exec `error` hides it
+                            // from `live_step_agents` (which only sees in-flight
+                            // execs). Stop it here — the same cleanup every other
+                            // errored attempt gets (`terminal_error`,
+                            // `abandon_stale_attempts`) — so the CLI process can't
+                            // leak past the retry/fail. Deliberately not archived:
+                            // `archive` rejects a not-yet-stopped agent (a race),
+                            // and the chat stays replayable by `agent_id` anyway
+                            // (run agents are hidden from the sidebar via
+                            // `owner_run_id`, not by archiving).
                             if let Some(agent_id) = &result.agent_id {
                                 let _ = ctx.driver.stop(agent_id).await;
-                                let _ = ctx.driver.archive(agent_id).await;
                             }
                             let give_up = attempt_no >= max_attempts;
                             {

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -371,6 +371,7 @@ struct RunCtx {
 struct RunEssentials {
     spec_json: String,
     task: String,
+    project_id: String,
     repo_path: String,
     run_dir: String,
     branch: String,
@@ -413,6 +414,18 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
 
     // Run repo may need re-provisioning after a restart (idempotent).
     gitops::provision_run_repo(&repo, &run_dir).await?;
+
+    // Tests gate (spec §9.4): resolve the project's test/setup command overrides
+    // once and build the runner shared across every step's attempts. Detection
+    // itself runs per step worktree at gate time.
+    let test_runner = {
+        let conn = ctx.db.lock();
+        super::tests_gate::SandboxTestRunner::new(
+            project_setting(&conn, &run.project_id, "run.test"),
+            project_setting(&conn, &run.project_id, "run.install"),
+            super::tests_gate::DEFAULT_TESTS_TIMEOUT_SECS,
+        )?
+    };
 
     let first_time = run.status == "pending";
     {
@@ -570,8 +583,14 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
             };
 
             let started = super::now_ms();
-            let result =
-                attempt::run_attempt(ctx.driver.as_ref(), params, &mut ledger, &step_eff).await;
+            let result = attempt::run_attempt(
+                ctx.driver.as_ref(),
+                &test_runner,
+                params,
+                &mut ledger,
+                &step_eff,
+            )
+            .await;
             // Journal the attempt's events and stamp its agent id.
             {
                 let conn = ctx.db.lock();
@@ -964,9 +983,23 @@ fn run_status(conn: &Connection, run_id: &str) -> Result<(String, Option<String>
     .map_err(|e| Error::Other(format!("run {run_id} not found: {e}")))
 }
 
+/// Read a project setting value, `None` when unset, blank, or the table is
+/// absent. Used to resolve the tests-gate command overrides (spec §9.4), which
+/// mirror the Run panel's `run.test` / `run.install` keys.
+fn project_setting(conn: &Connection, project_id: &str, key: &str) -> Option<String> {
+    conn.query_row(
+        "SELECT value FROM project_settings WHERE project_id = ?1 AND key = ?2",
+        rusqlite::params![project_id, key],
+        |r| r.get::<_, String>(0),
+    )
+    .ok()
+    .map(|s| s.trim().to_string())
+    .filter(|s| !s.is_empty())
+}
+
 fn load_run(conn: &Connection, run_id: &str) -> Result<RunEssentials> {
     conn.query_row(
-        "SELECT spec_json, task, repo_path, run_dir, branch, base_sha, status,
+        "SELECT spec_json, task, project_id, repo_path, run_dir, branch, base_sha, status,
                 budgets_json, spent_json
          FROM wf_run WHERE id = ?1",
         [run_id],
@@ -974,13 +1007,14 @@ fn load_run(conn: &Connection, run_id: &str) -> Result<RunEssentials> {
             Ok(RunEssentials {
                 spec_json: r.get(0)?,
                 task: r.get(1)?,
-                repo_path: r.get(2)?,
-                run_dir: r.get(3)?,
-                branch: r.get(4)?,
-                base_sha: r.get(5)?,
-                status: r.get(6)?,
-                budgets_json: r.get(7)?,
-                spent_json: r.get(8)?,
+                project_id: r.get(2)?,
+                repo_path: r.get(3)?,
+                run_dir: r.get(4)?,
+                branch: r.get(5)?,
+                base_sha: r.get(6)?,
+                status: r.get(7)?,
+                budgets_json: r.get(8)?,
+                spent_json: r.get(9)?,
             })
         },
     )

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -416,15 +416,15 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
     gitops::provision_run_repo(&repo, &run_dir).await?;
 
     // Tests gate (spec §9.4): resolve the project's test/setup command overrides
-    // once and build the runner shared across every step's attempts. Detection
-    // itself runs per step worktree at gate time.
-    let test_runner = {
+    // once (they are project-scoped). The runner is built per step below so it
+    // honors the step's effective `tests_timeout_secs`; detection runs per step
+    // worktree at gate time.
+    let (test_override, setup_override) = {
         let conn = ctx.db.lock();
-        super::tests_gate::SandboxTestRunner::new(
+        (
             project_setting(&conn, &run.project_id, "run.test"),
             project_setting(&conn, &run.project_id, "run.install"),
-            super::tests_gate::DEFAULT_TESTS_TIMEOUT_SECS,
-        )?
+        )
     };
 
     let first_time = run.status == "pending";
@@ -498,6 +498,14 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
         let step_eff = eff.for_step(step.budgets.as_ref());
         let max_attempts = step_eff.max_attempts;
         let deadlines = deadlines_from(&ctx.deadlines, &step_eff);
+        // Tests-gate runner for this step, honoring its effective
+        // `tests_timeout_secs` (spec §9.4, §11.1). Only the `tests` gate consults
+        // it; a fresh runner per step means setup runs once per step workspace.
+        let test_runner = super::tests_gate::SandboxTestRunner::new(
+            test_override.clone(),
+            setup_override.clone(),
+            step_eff.tests_timeout_secs.max(1) as u64,
+        )?;
 
         let mut attempt_no = next_attempt_no(&ctx.db.lock(), run_id, &step.id);
         let mut last_failure: Option<String> = None;
@@ -644,17 +652,31 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
                         }
                         Err(e) => {
                             last_failure = Some(format!("ferry failed: {e}"));
-                            let conn = ctx.db.lock();
-                            finish_step_exec(&conn, &exec_id, "error", None);
-                            if attempt_no >= max_attempts {
-                                set_status(
-                                    &conn,
-                                    ctx.app.as_ref(),
-                                    run_id,
-                                    "failed",
-                                    None,
-                                    Some(&format!("ferry failed: {e}")),
-                                );
+                            // The attempt reached `done`, so its agent is idle but
+                            // still alive. Marking the exec `error` hides it from
+                            // `live_step_agents` (which only sees in-flight execs),
+                            // so stop+archive it here — otherwise the CLI process
+                            // leaks past the retry/fail and its chat is orphaned.
+                            if let Some(agent_id) = &result.agent_id {
+                                let _ = ctx.driver.stop(agent_id).await;
+                                let _ = ctx.driver.archive(agent_id).await;
+                            }
+                            let give_up = attempt_no >= max_attempts;
+                            {
+                                let conn = ctx.db.lock();
+                                finish_step_exec(&conn, &exec_id, "error", None);
+                                if give_up {
+                                    set_status(
+                                        &conn,
+                                        ctx.app.as_ref(),
+                                        run_id,
+                                        "failed",
+                                        None,
+                                        Some(&format!("ferry failed: {e}")),
+                                    );
+                                }
+                            }
+                            if give_up {
                                 return Ok(());
                             }
                         }

--- a/src-tauri/src/workflow/spec.rs
+++ b/src-tauri/src/workflow/spec.rs
@@ -406,16 +406,6 @@ fn check_step(
     if let Gate::Artifact { path } = &step.gate {
         check_artifact_path(&step.id, path, errors);
     }
-    // The `tests` gate (spec §9.4) is not implemented until S6. Reject it at
-    // validation so a definition can't launch a step whose gate would either
-    // never pass or falsely pass without running any tests.
-    if matches!(step.gate, Gate::Tests) {
-        errors.push(format!(
-            "step '{}' declares gate 'tests', which is not implemented yet — \
-             use 'verdict' until test execution lands (S6)",
-            step.id
-        ));
-    }
     if let Some(b) = &step.budgets {
         check_budgets(&format!("step '{}'", step.id), b, errors);
     }
@@ -712,14 +702,13 @@ mod tests {
     }
 
     #[test]
-    fn tests_gate_rejected_until_implemented() {
+    fn tests_gate_is_accepted() {
+        // The `tests` gate (spec §9.4) is implemented in S6 — a step may declare it.
         let mut s = minimal();
         if let Block::Step(step) = &mut s.workflow[0] {
             step.gate = Gate::Tests;
         }
-        assert!(errors(&s)
-            .iter()
-            .any(|e| e.contains("'tests'") && e.contains("not implemented")));
+        assert!(validate(&s).is_ok(), "{:?}", errors(&s));
     }
 
     #[test]

--- a/src-tauri/src/workflow/tests_gate.rs
+++ b/src-tauri/src/workflow/tests_gate.rs
@@ -29,9 +29,6 @@ use super::gates::TestsOutcome;
 /// re-prompt (spec §9.4 keeps the last 100).
 const OUTPUT_TAIL_LINES: usize = 100;
 
-/// Default bound on a single test (or setup) run (spec §11.1 `tests_timeout_secs`).
-pub const DEFAULT_TESTS_TIMEOUT_SECS: u64 = 900;
-
 /// Resolves and runs the `tests` gate. Behind a trait so the attempt lifecycle
 /// is unit-testable with a scripted mock (`AgentDriver`'s pattern).
 pub trait TestRunner: Send + Sync {
@@ -81,7 +78,17 @@ impl SandboxTestRunner {
         worktree: &Path,
         cmd: &str,
     ) -> Result<(PathBuf, Vec<String>, tempfile::NamedTempFile)> {
-        let profile_text = crate::sandbox::build_run_profile(worktree, &self.home, &[])?;
+        // Grant the target's git *common dir* (as the Run panel does) so test
+        // commands that touch git — e.g. `git worktree add` — work in a linked
+        // worktree checkout, whose common dir lives outside `worktree`. For a
+        // plain `--shared` clone this is `<worktree>/.git`, already writable, so
+        // the grant is harmless.
+        let extra_writable: Vec<PathBuf> =
+            crate::supervisor::run::run_target_git_common_dir(worktree)
+                .into_iter()
+                .collect();
+        let profile_text =
+            crate::sandbox::build_run_profile(worktree, &self.home, &extra_writable)?;
         let profile_file = crate::sandbox::profile_tempfile(&profile_text)?;
         let profile_path = profile_file
             .path()
@@ -116,6 +123,17 @@ impl SandboxTestRunner {
 impl TestRunner for SandboxTestRunner {
     fn run_tests<'a>(&'a self, worktree: &'a Path) -> BoxFuture<'a, TestsOutcome> {
         Box::pin(async move {
+            // The gate runs under the Run-panel seatbelt profile, which needs
+            // macOS `sandbox-exec`. Where it isn't present we can't safely run a
+            // repo-derived command, so degrade to the verdict gate (spec §9.4)
+            // rather than fail the step for the wrong reason.
+            if !sandbox_available() {
+                tracing::warn!(
+                    "tests gate: `{}` unavailable on this host; degrading to the verdict gate",
+                    crate::sandbox::SANDBOX_EXEC
+                );
+                return TestsOutcome::NoCommand;
+            }
             let Some(resolved) = resolve(worktree, &self.test_override, &self.setup_override)
             else {
                 return TestsOutcome::NoCommand;
@@ -177,25 +195,47 @@ struct Resolved {
 }
 
 /// Resolve the test and setup commands for `worktree`: a non-empty override
-/// wins, else the highest-confidence detected config's `test` / `install` rows
-/// (spec §9.4). `None` when no test command can be found (→ degrade to verdict).
+/// wins, else the detected commands (spec §9.4). `None` when no test command can
+/// be found (→ degrade to verdict).
+///
+/// Detected commands are taken from a single ecosystem: the highest-confidence
+/// config that actually defines a `test` row (`detect_all` is confidence-sorted).
+/// This keeps `test` and `install` from the same ecosystem and lets a
+/// lower-ranked detector supply the test command when the top one has none — a
+/// mixed repo whose primary ecosystem has no test script no longer degrades to
+/// the verdict gate while a sibling ecosystem's tests go unrun.
 fn resolve(
     worktree: &Path,
     test_override: &Option<String>,
     setup_override: &Option<String>,
 ) -> Option<Resolved> {
     let configs = crate::run_detect::detect_all(worktree);
-    let detected = |id: &str| -> Option<String> {
-        configs
-            .first()
-            .and_then(|c| c.rows.iter().find(|r| r.id == id))
-            .map(|r| r.value.clone())
+    let row = |c: &crate::run_detect::DetectedConfig, id: &str| -> Option<String> {
+        c.rows.iter().find(|r| r.id == id).map(|r| r.value.clone())
     };
-    let test =
-        nonempty(test_override.clone()).or_else(|| detected("test").and_then(some_nonempty))?;
-    let setup =
-        nonempty(setup_override.clone()).or_else(|| detected("install").and_then(some_nonempty));
+    // The ecosystem we take detected commands from. Its `install` pairs with its
+    // `test`; for an override test with no detected test config, setup falls back
+    // to the highest-confidence config.
+    let test_config = configs.iter().find(|c| row(c, "test").is_some());
+    let setup_config = test_config.or_else(|| configs.first());
+
+    let test = nonempty(test_override.clone()).or_else(|| {
+        test_config
+            .and_then(|c| row(c, "test"))
+            .and_then(some_nonempty)
+    })?;
+    let setup = nonempty(setup_override.clone()).or_else(|| {
+        setup_config
+            .and_then(|c| row(c, "install"))
+            .and_then(some_nonempty)
+    });
     Some(Resolved { test, setup })
+}
+
+/// Whether the seatbelt sandbox binary the tests gate runs under is present
+/// (macOS). Elsewhere the gate degrades to the verdict gate rather than fail.
+fn sandbox_available() -> bool {
+    Path::new(crate::sandbox::SANDBOX_EXEC).exists()
 }
 
 /// `Some(trimmed)` when the value is present and non-blank, else `None`.
@@ -310,6 +350,21 @@ mod tests {
         let r = resolve(dir.path(), &None, &None).unwrap();
         assert_eq!(r.test, "npm test");
         assert_eq!(r.setup.as_deref(), Some("npm install"));
+    }
+
+    #[test]
+    fn resolve_uses_lower_ranked_config_when_top_has_no_test() {
+        // Node (lockfile → confidence 90, ranks first) has no `test` script, but
+        // Go (also 90, ranked after node) always defines one. The gate must run
+        // Go's tests rather than degrade, and pair them with Go's install.
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "package.json", "{}");
+        write(dir.path(), "pnpm-lock.yaml", "");
+        write(dir.path(), "go.mod", "module example.com/x\n\ngo 1.22\n");
+        write(dir.path(), "go.sum", "");
+        let r = resolve(dir.path(), &None, &None).unwrap();
+        assert_eq!(r.test, "go test ./...");
+        assert_eq!(r.setup.as_deref(), Some("go mod download"));
     }
 
     #[test]

--- a/src-tauri/src/workflow/tests_gate.rs
+++ b/src-tauri/src/workflow/tests_gate.rs
@@ -1,0 +1,409 @@
+//! Tests-gate execution (spec §9.4). The `tests` gate resolves the project's
+//! test command (project override > `run_detect`), runs it — after a one-time
+//! setup/install command — bounded and sandboxed inside the step worktree under
+//! the Run-panel seatbelt profile, and reports a [`gates::TestsOutcome`] that the
+//! pure `gates::evaluate` turns into done/blocked. No test command resolvable →
+//! [`TestsOutcome::NoCommand`], and the gate degrades to `verdict` (§9.4).
+//!
+//! Execution lives behind the [`TestRunner`] trait so `attempt.rs` stays
+//! unit-testable with a scripted mock — the same seam `AgentDriver` provides.
+//! The pure resolution and output-tail helpers are tested directly, and the
+//! bounded runner is exercised with plain shell commands (green / red / timeout
+//! / unrunnable) so the fast tests need no sandbox.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Mutex;
+
+use tokio::io::AsyncReadExt;
+use tokio::process::Command;
+use tokio::time::{timeout, Duration};
+
+use crate::error::{Error, Result};
+
+use super::driver::BoxFuture;
+use super::gates::TestsOutcome;
+
+/// Lines of output kept from a failed / timed-out run for the journal and the
+/// re-prompt (spec §9.4 keeps the last 100).
+const OUTPUT_TAIL_LINES: usize = 100;
+
+/// Default bound on a single test (or setup) run (spec §11.1 `tests_timeout_secs`).
+pub const DEFAULT_TESTS_TIMEOUT_SECS: u64 = 900;
+
+/// Resolves and runs the `tests` gate. Behind a trait so the attempt lifecycle
+/// is unit-testable with a scripted mock (`AgentDriver`'s pattern).
+pub trait TestRunner: Send + Sync {
+    /// Resolve and run the project's tests in `worktree`, returning the outcome.
+    fn run_tests<'a>(&'a self, worktree: &'a Path) -> BoxFuture<'a, TestsOutcome>;
+}
+
+/// The production runner: resolves the command via `run_detect` (project
+/// overrides winning), runs the setup command once per workspace, then runs the
+/// test command — each `sandbox-exec`-wrapped under the Run-panel profile.
+pub struct SandboxTestRunner {
+    /// Project override for the test command (`run.test`); wins over detection.
+    test_override: Option<String>,
+    /// Project override for the setup command (`run.install`); wins over detection.
+    setup_override: Option<String>,
+    home: PathBuf,
+    timeout: Duration,
+    /// Worktrees whose setup command has already succeeded — setup runs once per
+    /// workspace (spec §9.4). A fresh clone has no deps, but by gate time the
+    /// step agent has usually installed them, so this is normally a fast no-op.
+    setup_done: Mutex<HashSet<PathBuf>>,
+}
+
+impl SandboxTestRunner {
+    pub fn new(
+        test_override: Option<String>,
+        setup_override: Option<String>,
+        timeout_secs: u64,
+    ) -> Result<Self> {
+        let home =
+            dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
+        Ok(Self {
+            test_override,
+            setup_override,
+            home,
+            timeout: Duration::from_secs(timeout_secs),
+            setup_done: Mutex::new(HashSet::new()),
+        })
+    }
+
+    /// Build the `sandbox-exec -f <profile> <shell> -lic <cmd>` invocation under
+    /// the Run-panel profile (writable root = the step worktree). The profile
+    /// tempfile is returned so it outlives the child's `exec`; the caller keeps
+    /// it alive until the process has finished.
+    fn sandbox_command(
+        &self,
+        worktree: &Path,
+        cmd: &str,
+    ) -> Result<(PathBuf, Vec<String>, tempfile::NamedTempFile)> {
+        let profile_text = crate::sandbox::build_run_profile(worktree, &self.home, &[])?;
+        let profile_file = crate::sandbox::profile_tempfile(&profile_text)?;
+        let profile_path = profile_file
+            .path()
+            .to_str()
+            .ok_or_else(|| Error::Other("profile path not utf-8".into()))?
+            .to_string();
+        let shell = crate::run_session::user_shell();
+        let shell_str = shell
+            .to_str()
+            .ok_or_else(|| Error::Other("shell path not utf-8".into()))?
+            .to_string();
+        let mut args = vec!["-f".to_string(), profile_path, shell_str];
+        args.extend(crate::run_session::shell_args(cmd));
+        Ok((
+            PathBuf::from(crate::sandbox::SANDBOX_EXEC),
+            args,
+            profile_file,
+        ))
+    }
+
+    async fn run_sandboxed(&self, worktree: &Path, cmd: &str) -> Bounded {
+        let (program, args, _profile) = match self.sandbox_command(worktree, cmd) {
+            Ok(t) => t,
+            Err(e) => return Bounded::Unrunnable(format!("could not build sandbox profile: {e}")),
+        };
+        // `_profile` must outlive the child's `exec`; it drops at the end of this
+        // fn, after `run_bounded` has awaited the process to completion.
+        run_bounded(&program, &args, worktree, self.timeout).await
+    }
+}
+
+impl TestRunner for SandboxTestRunner {
+    fn run_tests<'a>(&'a self, worktree: &'a Path) -> BoxFuture<'a, TestsOutcome> {
+        Box::pin(async move {
+            let Some(resolved) = resolve(worktree, &self.test_override, &self.setup_override)
+            else {
+                return TestsOutcome::NoCommand;
+            };
+
+            // Setup once per workspace, distinct failure from failing tests.
+            if let Some(setup) = &resolved.setup {
+                let already = self.setup_done.lock().unwrap().contains(worktree);
+                if !already {
+                    match self.run_sandboxed(worktree, setup).await {
+                        Bounded::Exited { success: true, .. } => {
+                            self.setup_done
+                                .lock()
+                                .unwrap()
+                                .insert(worktree.to_path_buf());
+                        }
+                        Bounded::Exited {
+                            success: false,
+                            tail,
+                        } => return TestsOutcome::SetupFailed { tail },
+                        Bounded::TimedOut => {
+                            return TestsOutcome::SetupFailed {
+                                tail: self.timeout_note("setup command"),
+                            }
+                        }
+                        Bounded::Unrunnable(e) => return TestsOutcome::SetupFailed { tail: e },
+                    }
+                }
+            }
+
+            match self.run_sandboxed(worktree, &resolved.test).await {
+                Bounded::Exited { success: true, .. } => TestsOutcome::Passed,
+                Bounded::Exited {
+                    success: false,
+                    tail,
+                } => TestsOutcome::Failed { tail },
+                Bounded::TimedOut => TestsOutcome::TimedOut {
+                    tail: self.timeout_note("test command"),
+                },
+                Bounded::Unrunnable(e) => TestsOutcome::Failed { tail: e },
+            }
+        })
+    }
+}
+
+impl SandboxTestRunner {
+    fn timeout_note(&self, what: &str) -> String {
+        format!(
+            "{what} exceeded the {}s limit and was terminated",
+            self.timeout.as_secs()
+        )
+    }
+}
+
+/// The test + setup commands resolved for a worktree.
+struct Resolved {
+    test: String,
+    setup: Option<String>,
+}
+
+/// Resolve the test and setup commands for `worktree`: a non-empty override
+/// wins, else the highest-confidence detected config's `test` / `install` rows
+/// (spec §9.4). `None` when no test command can be found (→ degrade to verdict).
+fn resolve(
+    worktree: &Path,
+    test_override: &Option<String>,
+    setup_override: &Option<String>,
+) -> Option<Resolved> {
+    let configs = crate::run_detect::detect_all(worktree);
+    let detected = |id: &str| -> Option<String> {
+        configs
+            .first()
+            .and_then(|c| c.rows.iter().find(|r| r.id == id))
+            .map(|r| r.value.clone())
+    };
+    let test =
+        nonempty(test_override.clone()).or_else(|| detected("test").and_then(some_nonempty))?;
+    let setup =
+        nonempty(setup_override.clone()).or_else(|| detected("install").and_then(some_nonempty));
+    Some(Resolved { test, setup })
+}
+
+/// `Some(trimmed)` when the value is present and non-blank, else `None`.
+fn nonempty(v: Option<String>) -> Option<String> {
+    v.and_then(some_nonempty)
+}
+
+fn some_nonempty(s: String) -> Option<String> {
+    let t = s.trim();
+    (!t.is_empty()).then(|| t.to_string())
+}
+
+/// The bounded outcome of running one command.
+enum Bounded {
+    /// The process exited; `success` is exit status 0. `tail` is its output tail.
+    Exited { success: bool, tail: String },
+    /// The process did not finish within the deadline (killed).
+    TimedOut,
+    /// The command could not be launched at all.
+    Unrunnable(String),
+}
+
+/// Run `program args` in `cwd`, capturing combined stdout+stderr, bounded by
+/// `deadline`. On timeout the child is killed (`kill_on_drop`) and `TimedOut` is
+/// returned. Pure of any workflow state so it is directly unit-testable.
+async fn run_bounded(program: &Path, args: &[String], cwd: &Path, deadline: Duration) -> Bounded {
+    let mut command = Command::new(program);
+    command
+        .args(args)
+        .current_dir(cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+
+    let mut child = match command.spawn() {
+        Ok(c) => c,
+        Err(e) => return Bounded::Unrunnable(format!("could not launch command: {e}")),
+    };
+    let mut stdout = child.stdout.take().expect("piped stdout");
+    let mut stderr = child.stderr.take().expect("piped stderr");
+
+    // Read both pipes concurrently (so a full pipe buffer can't deadlock the
+    // child) and reap it. `read_to_end` completes when the process closes its
+    // fds, i.e. at exit.
+    let collect = async {
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let _ = tokio::join!(stdout.read_to_end(&mut out), stderr.read_to_end(&mut err));
+        let status = child.wait().await;
+        (status, out, err)
+    };
+
+    match timeout(deadline, collect).await {
+        Ok((status, mut out, err)) => {
+            out.extend_from_slice(&err);
+            let tail = tail_lines(&String::from_utf8_lossy(&out), OUTPUT_TAIL_LINES);
+            match status {
+                Ok(s) => Bounded::Exited {
+                    success: s.success(),
+                    tail,
+                },
+                Err(e) => Bounded::Unrunnable(format!("command errored: {e}")),
+            }
+        }
+        // `collect` drops here; `child` drops at fn end → killed via kill_on_drop.
+        Err(_elapsed) => Bounded::TimedOut,
+    }
+}
+
+/// The last `n` lines of `text`, joined with `\n`.
+fn tail_lines(text: &str, n: usize) -> String {
+    let lines: Vec<&str> = text.lines().collect();
+    let start = lines.len().saturating_sub(n);
+    lines[start..].join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(dir: &Path, name: &str, contents: &str) {
+        std::fs::write(dir.join(name), contents).unwrap();
+    }
+
+    #[test]
+    fn resolve_prefers_override_over_detection() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "package.json",
+            r#"{"scripts":{"test":"vitest"}}"#,
+        );
+        let r = resolve(
+            dir.path(),
+            &Some("cargo test --all".into()),
+            &Some("cargo fetch".into()),
+        )
+        .unwrap();
+        assert_eq!(r.test, "cargo test --all");
+        assert_eq!(r.setup.as_deref(), Some("cargo fetch"));
+    }
+
+    #[test]
+    fn resolve_detects_test_and_install_commands() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "package.json",
+            r#"{"scripts":{"test":"vitest"}}"#,
+        );
+        let r = resolve(dir.path(), &None, &None).unwrap();
+        assert_eq!(r.test, "npm test");
+        assert_eq!(r.setup.as_deref(), Some("npm install"));
+    }
+
+    #[test]
+    fn resolve_none_when_no_command_found() {
+        let dir = tempfile::tempdir().unwrap();
+        // No manifest, no override → nothing to run → degrade to verdict.
+        assert!(resolve(dir.path(), &None, &None).is_none());
+    }
+
+    #[test]
+    fn resolve_blank_override_is_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(resolve(dir.path(), &Some("   ".into()), &None).is_none());
+    }
+
+    #[tokio::test]
+    async fn run_bounded_reports_success() {
+        let cwd = tempfile::tempdir().unwrap();
+        let b = run_bounded(
+            Path::new("/bin/sh"),
+            &["-c".into(), "echo ok; exit 0".into()],
+            cwd.path(),
+            Duration::from_secs(10),
+        )
+        .await;
+        match b {
+            Bounded::Exited { success, tail } => {
+                assert!(success);
+                assert!(tail.contains("ok"), "tail: {tail}");
+            }
+            _ => panic!("expected Exited"),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_bounded_captures_failure_tail() {
+        let cwd = tempfile::tempdir().unwrap();
+        let b = run_bounded(
+            Path::new("/bin/sh"),
+            &["-c".into(), "echo boom 1>&2; exit 3".into()],
+            cwd.path(),
+            Duration::from_secs(10),
+        )
+        .await;
+        match b {
+            Bounded::Exited { success, tail } => {
+                assert!(!success);
+                assert!(tail.contains("boom"), "tail: {tail}");
+            }
+            _ => panic!("expected Exited"),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_bounded_times_out() {
+        let cwd = tempfile::tempdir().unwrap();
+        let b = run_bounded(
+            Path::new("/bin/sh"),
+            &["-c".into(), "sleep 30".into()],
+            cwd.path(),
+            Duration::from_millis(150),
+        )
+        .await;
+        assert!(matches!(b, Bounded::TimedOut));
+    }
+
+    #[tokio::test]
+    async fn run_bounded_reports_unrunnable() {
+        let cwd = tempfile::tempdir().unwrap();
+        let b = run_bounded(
+            Path::new("/nonexistent/definitely/not/here"),
+            &[],
+            cwd.path(),
+            Duration::from_secs(5),
+        )
+        .await;
+        assert!(matches!(b, Bounded::Unrunnable(_)));
+    }
+
+    #[test]
+    fn tail_lines_keeps_last_n() {
+        let text = (1..=250)
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let tail = tail_lines(&text, 100);
+        let lines: Vec<&str> = tail.lines().collect();
+        assert_eq!(lines.len(), 100);
+        assert_eq!(lines.first(), Some(&"151"));
+        assert_eq!(lines.last(), Some(&"250"));
+    }
+
+    #[test]
+    fn tail_lines_shorter_than_n_is_whole() {
+        assert_eq!(tail_lines("a\nb", 100), "a\nb");
+    }
+}


### PR DESCRIPTION
## S6 — Tests gate

Implements the `tests` gate (spec §9.4), the last unimplemented gate from S4. Depends on S4 (merged into `feat/workflows-rebase`).

### What it does
At gate-evaluation time for a `tests`-gated step, the engine:
1. **Resolves** the test command — project `run.test` override wins, else `run_detect`'s detected `test` row (and `run.install`/detected `install` for setup).
2. Runs the **setup/install** command once per workspace (distinct `SetupFailed` cause, not conflated with failing tests).
3. Runs the **tests** bounded (`tests_timeout_secs`, default 900) and `sandbox-exec`-wrapped in the step worktree under the **Run-panel profile** — the same sandboxing the Run panel uses.
4. Maps the result to the gate: exit 0 → done; non-zero/timeout/setup-failure → blocked, with the **last 100 lines** of output attached to `gate_evaluated` and quoted into the re-prompt.
5. **No test command resolvable → degrades to the `verdict` gate** with a `tests_degraded` journal flag (§9.4).

### Design
- `gates::evaluate` stays **pure**: execution lives in the new `workflow/tests_gate.rs` behind a `TestRunner` trait (mirroring the `AgentDriver` seam), and hands a `TestsOutcome` fact into `GateInputs`.
- The `gate_evaluated` payload gains additive fields (`output_tail`, `tests_degraded`) — no command-surface or frontend change; F2 renders them later.
- Removes the S4 stubs that rejected `gate: tests` at validation and blocked it at evaluation.

### Tests (spec §16)
- Runner: green / red (tail captured) / timeout / unrunnable, plus command resolution (override > detection > none) and the tail helper.
- Gate mapping matrix incl. degrade-to-verdict.
- Attempt-level: green → done; **red run re-prompts with the output tail**; no-command degrades to verdict.

`cargo test` (workflow, 107 passing) + `cargo clippy` clean; `cargo fmt` applied. Backend-only, so `bun run test` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)