### PR TITLE
feat(workflows): budgets ledger + enforcement (S5)

### DIFF
--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -141,6 +141,16 @@ impl Supervisor {
         self.workspace.last_activity(agent_id)
     }
 
+    /// This agent's canonical session records (seq order) — the raw provider
+    /// bodies as ingested. The workflow budget ledger reads token `usage` out of
+    /// them (spec §11.2); a read error degrades to an empty slice (tokens then
+    /// go uncounted, exactly as for a provider that exposes no usage).
+    pub fn read_session_records(&self, agent_id: &str) -> Vec<crate::workspace::SessionRecord> {
+        self.workspace
+            .read_session_records(agent_id)
+            .unwrap_or_default()
+    }
+
     /// Invalidate this agent's current spawn generation. Any gen-guarded
     /// background task (turn watchdog, RPC watcher) and any late process-exit
     /// handler captured the old number, so after this bump they see

--- a/src-tauri/src/workflow/attempt.rs
+++ b/src-tauri/src/workflow/attempt.rs
@@ -27,6 +27,7 @@ use crate::workspace::AgentStatus;
 // are already buffered by the time it reads them.
 
 use super::blackboard::{self, Verdict, VerdictError};
+use super::budget::{BudgetLimit, EffectiveBudgets, Ledger};
 use super::driver::{AgentDriver, SpawnReq};
 use super::gates::{self, GateInputs, GateOutcome};
 use super::prompts;
@@ -65,6 +66,8 @@ pub struct AttemptParams {
     pub spawn_req: SpawnReq,
     /// The run's blackboard directory (`…/blackboard`).
     pub blackboard: PathBuf,
+    /// The `wf_step_exec` row id — for the ledger's per-attempt turn rollup.
+    pub exec_id: String,
     pub step_id: String,
     pub attempt: u32,
     pub iteration: u32,
@@ -88,6 +91,10 @@ pub enum AttemptOutcome {
     /// Spawn/turn-start timeout, agent error, or an exhausted stall → the
     /// scheduler applies the retry policy (spec §6.5).
     Error { error: String },
+    /// A run-level budget cap was reached at an enforcement point (spec §11.2) →
+    /// the scheduler pauses the run `budget_exceeded`. `which` is `turns` /
+    /// `tokens` / `wall_clock`.
+    BudgetExceeded { which: String },
 }
 
 /// One journalable event the attempt produced, in order. The scheduler attaches
@@ -119,10 +126,22 @@ fn ev(event_type: &'static str, payload: Value) -> AttemptEvent {
 }
 
 /// Drive one step attempt to a terminal outcome (spec §6.3 steps 1–6).
-pub async fn run_attempt(driver: &dyn AgentDriver, params: AttemptParams) -> AttemptRun {
+///
+/// `ledger` / `eff` carry budget enforcement (spec §11.2): the attempt checks
+/// `ledger.exceeded()` before each prompt send and charges one turn (plus any
+/// token usage) at each turn end, bailing with [`AttemptOutcome::BudgetExceeded`]
+/// the moment a run-level cap is reached. The scheduler owns the pre-spawn check
+/// and persistence of the mutated ledger.
+pub async fn run_attempt(
+    driver: &dyn AgentDriver,
+    params: AttemptParams,
+    ledger: &mut Ledger,
+    eff: &EffectiveBudgets,
+) -> AttemptRun {
     let AttemptParams {
         spawn_req,
         blackboard,
+        exec_id,
         step_id,
         attempt,
         iteration,
@@ -188,6 +207,13 @@ pub async fn run_attempt(driver: &dyn AgentDriver, params: AttemptParams) -> Att
     let mut reprompts_left: u32 = if reprompt_on_block { 1 } else { 0 };
 
     loop {
+        // Enforcement point: before every prompt/message send (spec §11.2). A run
+        // that has spent its turn / token / wall-clock budget pauses now rather
+        // than driving another turn.
+        if let Some(which) = ledger.exceeded(eff, super::now_ms()) {
+            return budget_exceeded_run(agent_id, worktree, which, events);
+        }
+
         // Subscribe BEFORE sending so an arbitrarily fast Running→Idle flap is
         // unlosable (spec §6.3 step 4). Snapshot, archive any stale verdict,
         // then send — in that order.
@@ -238,6 +264,19 @@ pub async fn run_attempt(driver: &dyn AgentDriver, params: AttemptParams) -> Att
             TurnEnd::Closed => {
                 return terminal_error(driver, &agent_id, "supervisor stopped", events).await
             }
+        }
+
+        // Turn complete: count it (the universal unit, spec §11.2) and charge any
+        // token usage the provider reported, then journal the ledger tick.
+        ledger.charge_turn(&step_id, &exec_id);
+        ledger.charge_tokens(&agent_id, &step_id, driver.turn_usage(&agent_id));
+        events.push(ev(
+            event_type::BUDGET_TICK,
+            json!({ "turns": ledger.turns, "tokens": ledger.tokens }),
+        ));
+        // Enforcement point: at every turn end (spec §11.2).
+        if let Some(which) = ledger.exceeded(eff, super::now_ms()) {
+            return budget_exceeded_run(agent_id, worktree, which, events);
         }
 
         // Gate — pure evaluation over freshly gathered facts (spec §6.3 step 6).
@@ -326,6 +365,29 @@ async fn terminal_error(
         worktree: None,
         outcome: AttemptOutcome::Error {
             error: error.to_string(),
+        },
+        events,
+    }
+}
+
+/// Build the `BudgetExceeded` result. The agent is left alive and idle — the
+/// scheduler stops it as part of pausing the run (spec §6.5 "pausing stops
+/// processes"), mirroring how a `Blocked` attempt is handled.
+fn budget_exceeded_run(
+    agent_id: String,
+    worktree: PathBuf,
+    which: BudgetLimit,
+    mut events: Vec<AttemptEvent>,
+) -> AttemptRun {
+    events.push(ev(
+        event_type::BUDGET_EXCEEDED,
+        json!({ "which": which.as_str() }),
+    ));
+    AttemptRun {
+        agent_id: Some(agent_id),
+        worktree: Some(worktree),
+        outcome: AttemptOutcome::BudgetExceeded {
+            which: which.as_str().to_string(),
         },
         events,
     }
@@ -490,7 +552,7 @@ fn outcome_label(outcome: &GateOutcome) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::workflow::driver::{MockDriver, TurnBehavior};
+    use crate::workflow::driver::{MockDriver, TurnBehavior, TurnUsage};
 
     fn params(gate: Gate, blackboard: PathBuf, deadlines: Deadlines) -> AttemptParams {
         AttemptParams {
@@ -507,6 +569,7 @@ mod tests {
                 owner_run_id: "run-1".into(),
             },
             blackboard,
+            exec_id: "exec-1".into(),
             step_id: "plan".into(),
             attempt: 1,
             iteration: 0,
@@ -515,6 +578,13 @@ mod tests {
             deadlines,
             reprompt_on_block: true,
         }
+    }
+
+    /// Run an attempt with an effectively unbounded budget — the default for the
+    /// lifecycle tests that don't exercise enforcement.
+    async fn run(driver: &dyn AgentDriver, params: AttemptParams) -> AttemptRun {
+        let mut ledger = Ledger::default();
+        run_attempt(driver, params, &mut ledger, &EffectiveBudgets::default()).await
     }
 
     fn fast() -> Deadlines {
@@ -541,7 +611,7 @@ mod tests {
         let step_dir = blackboard::step_dir(bb.path(), "plan").unwrap();
         d.set_complete_verdict(step_dir, r#"{"result":"done","summary":"ok"}"#);
 
-        let run = run_attempt(
+        let run = run(
             d.as_ref(),
             params(Gate::Verdict, bb.path().to_path_buf(), fast()),
         )
@@ -563,7 +633,7 @@ mod tests {
         let bb = tempfile::tempdir().unwrap();
         let d = MockDriver::new();
         // ready_on_spawn stays false → agent parks in Spawning forever.
-        let run = run_attempt(
+        let run = run(
             d.as_ref(),
             params(Gate::Verdict, bb.path().to_path_buf(), fast()),
         )
@@ -580,7 +650,7 @@ mod tests {
         let d = MockDriver::new();
         d.set_ready_on_spawn(true);
         d.set_turn_behavior(TurnBehavior::Silent); // prompt lands, no turn
-        let run = run_attempt(
+        let run = run(
             d.as_ref(),
             params(Gate::Verdict, bb.path().to_path_buf(), fast()),
         )
@@ -604,7 +674,7 @@ mod tests {
         let step_dir = blackboard::step_dir(bb.path(), "plan").unwrap();
         d.set_complete_verdict(step_dir, r#"{"result":"done","summary":"flap"}"#);
 
-        let run = run_attempt(
+        let run = run(
             d.as_ref(),
             params(Gate::Verdict, bb.path().to_path_buf(), fast()),
         )
@@ -622,7 +692,7 @@ mod tests {
         let d = MockDriver::new();
         d.set_ready_on_spawn(true);
         d.set_turn_behavior(TurnBehavior::RunningOnly); // turn starts, never ends
-        let run = run_attempt(
+        let run = run(
             d.as_ref(),
             params(Gate::Verdict, bb.path().to_path_buf(), fast()),
         )
@@ -648,7 +718,7 @@ mod tests {
         let d = MockDriver::new();
         d.set_ready_on_spawn(true);
         d.set_turn_behavior(TurnBehavior::ErrorOut);
-        let run = run_attempt(
+        let run = run(
             d.as_ref(),
             params(Gate::Verdict, bb.path().to_path_buf(), fast()),
         )
@@ -665,7 +735,7 @@ mod tests {
         let bb = tempfile::tempdir().unwrap();
         let d = MockDriver::new();
         d.fail_next_spawn("no repo");
-        let run = run_attempt(
+        let run = run(
             d.as_ref(),
             params(Gate::Verdict, bb.path().to_path_buf(), fast()),
         )
@@ -684,7 +754,7 @@ mod tests {
         let step_dir = blackboard::step_dir(bb.path(), "plan").unwrap();
         d.set_complete_verdict(step_dir, r#"{"result":"revise","summary":"more work"}"#);
 
-        let run = run_attempt(
+        let run = run(
             d.as_ref(),
             params(Gate::Verdict, bb.path().to_path_buf(), fast()),
         )
@@ -709,7 +779,7 @@ mod tests {
         let d = MockDriver::new();
         d.set_ready_on_spawn(true);
         d.set_turn_behavior(TurnBehavior::Complete);
-        let run = run_attempt(
+        let run = run(
             d.as_ref(),
             params(Gate::Approval, bb.path().to_path_buf(), fast()),
         )
@@ -738,7 +808,7 @@ mod tests {
         let d = MockDriver::new();
         d.set_ready_on_spawn(true);
         d.set_turn_behavior(TurnBehavior::Complete); // completes but writes no verdict
-        let run = run_attempt(
+        let run = run(
             d.as_ref(),
             params(Gate::Verdict, bb.path().to_path_buf(), fast()),
         )
@@ -754,5 +824,99 @@ mod tests {
             .iter()
             .any(|e| e.event_type == event_type::PROMPT_SENT
                 && e.payload.get("stale_verdict_archived").is_some()));
+    }
+
+    // ── budget enforcement (spec §11.2) ──────────────────────────────────────
+
+    #[tokio::test(start_paused = true)]
+    async fn turn_budget_pauses_at_turn_end() {
+        let bb = tempfile::tempdir().unwrap();
+        let d = MockDriver::new();
+        d.set_ready_on_spawn(true);
+        // A "revise" verdict would normally trigger the re-prompt, but the turn
+        // budget of 1 stops the attempt at the first turn end instead.
+        d.set_turn_behavior(TurnBehavior::Complete);
+        let step_dir = blackboard::step_dir(bb.path(), "plan").unwrap();
+        d.set_complete_verdict(step_dir, r#"{"result":"revise","summary":"more"}"#);
+
+        let mut ledger = Ledger::default();
+        let eff = EffectiveBudgets {
+            turns: 1,
+            ..Default::default()
+        };
+        let run =
+            run_attempt(d.as_ref(), params(Gate::Verdict, bb.path().to_path_buf(), fast()), &mut ledger, &eff)
+                .await;
+        match run.outcome {
+            AttemptOutcome::BudgetExceeded { which } => assert_eq!(which, "turns"),
+            other => panic!("expected BudgetExceeded(turns), got {other:?}"),
+        }
+        assert_eq!(ledger.turns, 1, "the completed turn was counted");
+        // The turn ran (so it's charged) but the gate was never reached.
+        assert!(types_present(&run.events, event_type::TURN_ENDED));
+        assert!(types_present(&run.events, event_type::BUDGET_TICK));
+        assert!(!types_present(&run.events, event_type::GATE_EVALUATED));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn token_budget_pauses_at_turn_end() {
+        let bb = tempfile::tempdir().unwrap();
+        let d = MockDriver::new();
+        d.set_ready_on_spawn(true);
+        d.set_turn_behavior(TurnBehavior::Complete);
+        // The first spawned agent is deterministically "mock-agent-1"; give it a
+        // cumulative usage above the cap so the turn-end charge trips tokens.
+        d.set_usage(
+            "mock-agent-1",
+            TurnUsage {
+                input_tokens: 400,
+                output_tokens: 200,
+            },
+        );
+
+        let mut ledger = Ledger::default();
+        let eff = EffectiveBudgets {
+            turns: 100,
+            tokens: Some(500),
+            ..Default::default()
+        };
+        let run =
+            run_attempt(d.as_ref(), params(Gate::Verdict, bb.path().to_path_buf(), fast()), &mut ledger, &eff)
+                .await;
+        match run.outcome {
+            AttemptOutcome::BudgetExceeded { which } => assert_eq!(which, "tokens"),
+            other => panic!("expected BudgetExceeded(tokens), got {other:?}"),
+        }
+        assert_eq!(ledger.tokens, 600);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn exhausted_budget_pauses_before_any_send() {
+        // Models a resume where the ledger is already at the cap: the pre-send
+        // enforcement point fires before the first prompt is ever sent.
+        let bb = tempfile::tempdir().unwrap();
+        let d = MockDriver::new();
+        d.set_ready_on_spawn(true);
+        d.set_turn_behavior(TurnBehavior::Complete);
+
+        let mut ledger = Ledger::default();
+        ledger.charge_turn("plan", "prev");
+        ledger.charge_turn("plan", "prev");
+        let eff = EffectiveBudgets {
+            turns: 2,
+            ..Default::default()
+        };
+        let run =
+            run_attempt(d.as_ref(), params(Gate::Verdict, bb.path().to_path_buf(), fast()), &mut ledger, &eff)
+                .await;
+        assert!(
+            matches!(run.outcome, AttemptOutcome::BudgetExceeded { .. }),
+            "{:?}",
+            run.outcome
+        );
+        // Spawned + ready, but no prompt was sent and no turn ran.
+        assert!(types_present(&run.events, event_type::ATTEMPT_READY));
+        assert!(!types_present(&run.events, event_type::PROMPT_SENT));
+        assert!(d.sent_messages().is_empty());
     }
 }

--- a/src-tauri/src/workflow/attempt.rs
+++ b/src-tauri/src/workflow/attempt.rs
@@ -844,9 +844,13 @@ mod tests {
             turns: 1,
             ..Default::default()
         };
-        let run =
-            run_attempt(d.as_ref(), params(Gate::Verdict, bb.path().to_path_buf(), fast()), &mut ledger, &eff)
-                .await;
+        let run = run_attempt(
+            d.as_ref(),
+            params(Gate::Verdict, bb.path().to_path_buf(), fast()),
+            &mut ledger,
+            &eff,
+        )
+        .await;
         match run.outcome {
             AttemptOutcome::BudgetExceeded { which } => assert_eq!(which, "turns"),
             other => panic!("expected BudgetExceeded(turns), got {other:?}"),
@@ -880,9 +884,13 @@ mod tests {
             tokens: Some(500),
             ..Default::default()
         };
-        let run =
-            run_attempt(d.as_ref(), params(Gate::Verdict, bb.path().to_path_buf(), fast()), &mut ledger, &eff)
-                .await;
+        let run = run_attempt(
+            d.as_ref(),
+            params(Gate::Verdict, bb.path().to_path_buf(), fast()),
+            &mut ledger,
+            &eff,
+        )
+        .await;
         match run.outcome {
             AttemptOutcome::BudgetExceeded { which } => assert_eq!(which, "tokens"),
             other => panic!("expected BudgetExceeded(tokens), got {other:?}"),
@@ -906,9 +914,13 @@ mod tests {
             turns: 2,
             ..Default::default()
         };
-        let run =
-            run_attempt(d.as_ref(), params(Gate::Verdict, bb.path().to_path_buf(), fast()), &mut ledger, &eff)
-                .await;
+        let run = run_attempt(
+            d.as_ref(),
+            params(Gate::Verdict, bb.path().to_path_buf(), fast()),
+            &mut ledger,
+            &eff,
+        )
+        .await;
         assert!(
             matches!(run.outcome, AttemptOutcome::BudgetExceeded { .. }),
             "{:?}",

--- a/src-tauri/src/workflow/budget.rs
+++ b/src-tauri/src/workflow/budget.rs
@@ -267,7 +267,10 @@ impl Ledger {
     /// provider exposes no usage), so the delta is what this turn added.
     pub fn charge_tokens(&mut self, agent_id: &str, step_id: &str, usage: Option<TurnUsage>) {
         let cumulative = usage.map(|u| u.input_tokens + u.output_tokens).unwrap_or(0);
-        let seen = self.agent_tokens_seen.entry(agent_id.to_string()).or_insert(0);
+        let seen = self
+            .agent_tokens_seen
+            .entry(agent_id.to_string())
+            .or_insert(0);
         // Deltas only; guard against a non-monotonic report (never negative).
         let delta = cumulative.saturating_sub(*seen);
         *seen = cumulative;
@@ -411,8 +414,22 @@ mod tests {
     fn token_charges_are_per_turn_deltas() {
         let mut l = Ledger::default();
         // Cumulative session usage grows across turns; the ledger charges deltas.
-        l.charge_tokens("a", "s", Some(TurnUsage { input_tokens: 100, output_tokens: 0 }));
-        l.charge_tokens("a", "s", Some(TurnUsage { input_tokens: 250, output_tokens: 0 }));
+        l.charge_tokens(
+            "a",
+            "s",
+            Some(TurnUsage {
+                input_tokens: 100,
+                output_tokens: 0,
+            }),
+        );
+        l.charge_tokens(
+            "a",
+            "s",
+            Some(TurnUsage {
+                input_tokens: 250,
+                output_tokens: 0,
+            }),
+        );
         assert_eq!(l.tokens, 250, "delta 100 then 150");
         assert_eq!(l.steps["s"].tokens, 250);
     }
@@ -489,7 +506,14 @@ mod tests {
     fn ledger_json_round_trips_persisted_fields() {
         let mut l = Ledger::default();
         l.charge_turn("s", "e1");
-        l.charge_tokens("a", "s", Some(TurnUsage { input_tokens: 5, output_tokens: 5 }));
+        l.charge_tokens(
+            "a",
+            "s",
+            Some(TurnUsage {
+                input_tokens: 5,
+                output_tokens: 5,
+            }),
+        );
         l.wall_ms = 1234;
         let restored = Ledger::from_json(&l.to_json());
         assert_eq!(restored.turns, 1);

--- a/src-tauri/src/workflow/budget.rs
+++ b/src-tauri/src/workflow/budget.rs
@@ -1,0 +1,502 @@
+//! The run budget ledger and enforcement (spec §11.1–11.2).
+//!
+//! Turns are the universal unit — every provider is turn- and wall-clock-bounded.
+//! Tokens are enforced only where the provider's session records expose usage
+//! (§11.2 guardrail): the driver sums `usage` out of ingested record bodies and
+//! this ledger charges the per-turn delta. A provider that emits no usage reports
+//! `None`, its token count never grows, and only turn/clock budgets bite.
+//!
+//! Two concerns live here, kept apart:
+//!   * [`EffectiveBudgets`] — the launch-frozen caps (`§11.1 defaults ∪ spec`,
+//!     spec wins). Serialized into `wf_run.budgets_json`; `wf_resume`'s budget
+//!     patch bumps the three run-level caps in place.
+//!   * [`Ledger`] — the running spend (`wf_run.spent_json`). Its run-level totals
+//!     drive enforcement; per-step / per-attempt rollups are for the timeline.
+//!
+//! Enforcement is a pure predicate ([`Ledger::exceeded`]); the scheduler and the
+//! attempt lifecycle call it at the three §11.2 points (before spawn, before each
+//! prompt send, at each turn end) and pause the run on a hit.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use super::driver::TurnUsage;
+use super::spec::{Budgets, Spec};
+
+// ───────────────────────────── §11.1 defaults ───────────────────────────────
+
+/// Run-level turn cap when the spec sets none (§11.1).
+const DEFAULT_TURNS: i64 = 100;
+/// Run-level wall-clock cap, minutes (§11.1).
+const DEFAULT_WALL_CLOCK_MINS: i64 = 480;
+/// Per-step turn cap (§11.1).
+const DEFAULT_TURNS_PER_ATTEMPT: i64 = 10;
+/// Per-step retry cap (§11.1) — autonomous retries only.
+const DEFAULT_MAX_ATTEMPTS: i64 = 2;
+const DEFAULT_SPAWN_TIMEOUT_SECS: i64 = 180;
+const DEFAULT_TURN_START_TIMEOUT_SECS: i64 = 120;
+const DEFAULT_STALL_TIMEOUT_SECS: i64 = 600;
+const DEFAULT_NUDGE_TIMEOUT_SECS: i64 = 300;
+const DEFAULT_TESTS_TIMEOUT_SECS: i64 = 900;
+
+/// The launch-frozen budget set: every §11.1 field resolved to a concrete value
+/// (tokens stays optional — unlimited unless opted in). Produced once at launch
+/// by merging the spec's run-level budgets over the defaults, then persisted to
+/// `budgets_json` as the immutable-except-by-patch source of truth.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct EffectiveBudgets {
+    // Run-scoped — the three caps that pause the run when exceeded.
+    pub turns: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tokens: Option<i64>,
+    pub wall_clock_mins: i64,
+    // Step-scoped — per-attempt caps and the attempt timeouts. A step's own
+    // `budgets` override these (resolved at attempt time via [`Self::for_step`]).
+    pub turns_per_attempt: i64,
+    pub max_attempts: i64,
+    pub spawn_timeout_secs: i64,
+    pub turn_start_timeout_secs: i64,
+    pub stall_timeout_secs: i64,
+    pub nudge_timeout_secs: i64,
+    pub tests_timeout_secs: i64,
+}
+
+impl Default for EffectiveBudgets {
+    fn default() -> Self {
+        Self {
+            turns: DEFAULT_TURNS,
+            tokens: None,
+            wall_clock_mins: DEFAULT_WALL_CLOCK_MINS,
+            turns_per_attempt: DEFAULT_TURNS_PER_ATTEMPT,
+            max_attempts: DEFAULT_MAX_ATTEMPTS,
+            spawn_timeout_secs: DEFAULT_SPAWN_TIMEOUT_SECS,
+            turn_start_timeout_secs: DEFAULT_TURN_START_TIMEOUT_SECS,
+            stall_timeout_secs: DEFAULT_STALL_TIMEOUT_SECS,
+            nudge_timeout_secs: DEFAULT_NUDGE_TIMEOUT_SECS,
+            tests_timeout_secs: DEFAULT_TESTS_TIMEOUT_SECS,
+        }
+    }
+}
+
+impl EffectiveBudgets {
+    /// `§11.1 defaults ∪ spec.budgets`, spec winning on any set field. Frozen at
+    /// launch (spec §11.1). A `tokens` of `None` in the spec leaves tokens
+    /// unlimited; any other field falls back to its default.
+    pub fn resolve(spec: &Spec) -> Self {
+        let mut eff = Self::default();
+        if let Some(b) = &spec.budgets {
+            eff.overlay(b);
+        }
+        eff
+    }
+
+    /// The effective budgets for one step: the run-level frozen set with the
+    /// step's own `budgets` overlaid (spec §11.1: "step values override run
+    /// values"). Only the step-scoped fields differ; the run caps are unchanged.
+    pub fn for_step(&self, step_budgets: Option<&Budgets>) -> Self {
+        let mut eff = self.clone();
+        if let Some(b) = step_budgets {
+            eff.overlay(b);
+        }
+        eff
+    }
+
+    /// Overlay any set field of `b` onto `self`. Positivity is already enforced
+    /// by `spec::validate`, so values are trusted here.
+    fn overlay(&mut self, b: &Budgets) {
+        if let Some(v) = b.turns {
+            self.turns = v;
+        }
+        if b.tokens.is_some() {
+            self.tokens = b.tokens;
+        }
+        if let Some(v) = b.wall_clock_mins {
+            self.wall_clock_mins = v;
+        }
+        if let Some(v) = b.turns_per_attempt {
+            self.turns_per_attempt = v;
+        }
+        if let Some(v) = b.max_attempts {
+            self.max_attempts = v;
+        }
+        if let Some(v) = b.spawn_timeout_secs {
+            self.spawn_timeout_secs = v;
+        }
+        if let Some(v) = b.turn_start_timeout_secs {
+            self.turn_start_timeout_secs = v;
+        }
+        if let Some(v) = b.stall_timeout_secs {
+            self.stall_timeout_secs = v;
+        }
+        if let Some(v) = b.nudge_timeout_secs {
+            self.nudge_timeout_secs = v;
+        }
+        if let Some(v) = b.tests_timeout_secs {
+            self.tests_timeout_secs = v;
+        }
+    }
+
+    /// Apply a resume-time budget patch (§13): add the patch's set run-level
+    /// caps to the current ones ("resume with +N turns / +N tokens / +N minutes").
+    /// Only the three run-scoped caps are patchable; other fields are ignored.
+    /// Additive so the UI's "+N" reads literally; a patched `tokens` lifts an
+    /// unlimited budget only if it was already limited (adding to "unlimited" is
+    /// a no-op, which is the intended semantics).
+    pub fn apply_patch(&mut self, patch: &Budgets) {
+        if let Some(v) = patch.turns {
+            self.turns += v;
+        }
+        if let (Some(cur), Some(v)) = (self.tokens, patch.tokens) {
+            self.tokens = Some(cur + v);
+        }
+        if let Some(v) = patch.wall_clock_mins {
+            self.wall_clock_mins += v;
+        }
+    }
+}
+
+// ───────────────────────────── which limit ──────────────────────────────────
+
+/// Which run-level cap a check tripped — the `which` in `budget_exceeded`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BudgetLimit {
+    Turns,
+    Tokens,
+    WallClock,
+}
+
+impl BudgetLimit {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Turns => "turns",
+            Self::Tokens => "tokens",
+            Self::WallClock => "wall_clock",
+        }
+    }
+}
+
+// ───────────────────────────── the ledger ───────────────────────────────────
+
+/// Per-step spend, for the timeline rollup (§16 "attempt/step/run rollup").
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct StepSpend {
+    pub turns: i64,
+    #[serde(default)]
+    pub tokens: i64,
+}
+
+/// The running spend of one run (`wf_run.spent_json`). Run-level totals
+/// (`turns`, `tokens`, `wall_ms`) drive enforcement; the per-step / per-attempt
+/// maps are rollups for the Run Monitor.
+///
+/// Wall-clock is stored as *accumulated active driving time* (`wall_ms`) rather
+/// than a launch timestamp so a run paused for days doesn't blow its clock the
+/// instant it resumes: each drive stamps a transient start with [`Self::start_drive`]
+/// and folds the elapsed time back in with [`Self::checkpoint_wall`].
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Ledger {
+    pub turns: i64,
+    #[serde(default)]
+    pub tokens: i64,
+    /// Accumulated active wall-clock across all drives, milliseconds.
+    #[serde(default)]
+    pub wall_ms: i64,
+    #[serde(default)]
+    pub steps: HashMap<String, StepSpend>,
+    #[serde(default)]
+    pub attempts: HashMap<String, i64>,
+
+    /// Transient (never serialized): the current drive's start, set by
+    /// [`Self::start_drive`]. `wall_ms` already holds prior drives' time.
+    #[serde(skip)]
+    drive_start_ms: Option<i64>,
+    /// Transient (never serialized): last cumulative token total seen per agent,
+    /// so token charges are deltas. Fresh agents start at 0; resume abandons
+    /// non-terminal attempts and re-spawns, so no double-count survives a restart.
+    #[serde(skip)]
+    agent_tokens_seen: HashMap<String, u64>,
+}
+
+impl Ledger {
+    /// Load the ledger from a persisted `spent_json` value; a missing / malformed
+    /// snapshot starts an empty ledger (a fresh run persists `{}`).
+    pub fn from_json(spent: &Value) -> Self {
+        serde_json::from_value(spent.clone()).unwrap_or_default()
+    }
+
+    pub fn to_json(&self) -> Value {
+        serde_json::to_value(self).unwrap_or_else(|_| json!({}))
+    }
+
+    /// Begin a drive: stamp the wall-clock start (folded back in on checkpoint).
+    pub fn start_drive(&mut self, now_ms: i64) {
+        self.drive_start_ms = Some(now_ms);
+    }
+
+    /// Fold this drive's elapsed active time into `wall_ms` and restamp the start,
+    /// so repeated checkpoints within one drive don't double-count. Called before
+    /// any wall-clock check and before persisting on pause / exit.
+    pub fn checkpoint_wall(&mut self, now_ms: i64) {
+        if let Some(start) = self.drive_start_ms {
+            self.wall_ms += (now_ms - start).max(0);
+            self.drive_start_ms = Some(now_ms);
+        }
+    }
+
+    /// Elapsed active wall-clock (ms) including the in-flight drive segment.
+    fn wall_ms_now(&self, now_ms: i64) -> i64 {
+        let live = self
+            .drive_start_ms
+            .map(|s| (now_ms - s).max(0))
+            .unwrap_or(0);
+        self.wall_ms + live
+    }
+
+    /// Count one completed turn against the run and the given step / attempt.
+    pub fn charge_turn(&mut self, step_id: &str, exec_id: &str) {
+        self.turns += 1;
+        self.steps.entry(step_id.to_string()).or_default().turns += 1;
+        *self.attempts.entry(exec_id.to_string()).or_default() += 1;
+    }
+
+    /// Charge the token delta for `agent_id`'s latest turn against the run and the
+    /// step. `cumulative` is the provider's running session total (0 when the
+    /// provider exposes no usage), so the delta is what this turn added.
+    pub fn charge_tokens(&mut self, agent_id: &str, step_id: &str, usage: Option<TurnUsage>) {
+        let cumulative = usage.map(|u| u.input_tokens + u.output_tokens).unwrap_or(0);
+        let seen = self.agent_tokens_seen.entry(agent_id.to_string()).or_insert(0);
+        // Deltas only; guard against a non-monotonic report (never negative).
+        let delta = cumulative.saturating_sub(*seen);
+        *seen = cumulative;
+        if delta == 0 {
+            return;
+        }
+        let delta = delta as i64;
+        self.tokens += delta;
+        self.steps.entry(step_id.to_string()).or_default().tokens += delta;
+    }
+
+    /// The first run-level cap this ledger has reached, if any (§11.2). Checked at
+    /// each enforcement point; `Some` pauses the run. `>=` because a cap of N
+    /// permits N units of spend — reaching N means the next unit would exceed.
+    pub fn exceeded(&self, eff: &EffectiveBudgets, now_ms: i64) -> Option<BudgetLimit> {
+        if self.turns >= eff.turns {
+            return Some(BudgetLimit::Turns);
+        }
+        if let Some(cap) = eff.tokens {
+            if self.tokens >= cap {
+                return Some(BudgetLimit::Tokens);
+            }
+        }
+        if self.wall_ms_now(now_ms) >= eff.wall_clock_mins.saturating_mul(60_000) {
+            return Some(BudgetLimit::WallClock);
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn budgets(turns: Option<i64>, tokens: Option<i64>, wall: Option<i64>) -> Budgets {
+        Budgets {
+            turns,
+            tokens,
+            wall_clock_mins: wall,
+            turns_per_attempt: None,
+            max_attempts: None,
+            spawn_timeout_secs: None,
+            turn_start_timeout_secs: None,
+            stall_timeout_secs: None,
+            nudge_timeout_secs: None,
+            tests_timeout_secs: None,
+        }
+    }
+
+    fn spec_with(budgets: Option<Budgets>) -> Spec {
+        Spec {
+            version: 1,
+            name: "t".into(),
+            description: None,
+            budgets,
+            agents: Default::default(),
+            workflow: vec![],
+            finalize: None,
+        }
+    }
+
+    #[test]
+    fn resolve_uses_defaults_when_spec_is_silent() {
+        let eff = EffectiveBudgets::resolve(&spec_with(None));
+        assert_eq!(eff.turns, DEFAULT_TURNS);
+        assert_eq!(eff.tokens, None);
+        assert_eq!(eff.wall_clock_mins, DEFAULT_WALL_CLOCK_MINS);
+        assert_eq!(eff.turns_per_attempt, DEFAULT_TURNS_PER_ATTEMPT);
+        assert_eq!(eff.max_attempts, DEFAULT_MAX_ATTEMPTS);
+    }
+
+    #[test]
+    fn spec_overrides_defaults_field_by_field() {
+        let eff = EffectiveBudgets::resolve(&spec_with(Some(budgets(
+            Some(12),
+            Some(500_000),
+            None, // wall_clock left to the default
+        ))));
+        assert_eq!(eff.turns, 12);
+        assert_eq!(eff.tokens, Some(500_000));
+        assert_eq!(eff.wall_clock_mins, DEFAULT_WALL_CLOCK_MINS);
+    }
+
+    #[test]
+    fn step_budgets_override_run_level() {
+        let run = EffectiveBudgets::resolve(&spec_with(Some(budgets(Some(50), None, None))));
+        let mut sb = budgets(None, None, None);
+        sb.turns_per_attempt = Some(3);
+        let step = run.for_step(Some(&sb));
+        assert_eq!(step.turns_per_attempt, 3);
+        // Run-level caps are inherited unchanged.
+        assert_eq!(step.turns, 50);
+    }
+
+    #[test]
+    fn exceeded_reports_turns_first() {
+        let eff = EffectiveBudgets {
+            turns: 2,
+            tokens: Some(100),
+            wall_clock_mins: 10,
+            ..Default::default()
+        };
+        let mut l = Ledger::default();
+        assert_eq!(l.exceeded(&eff, 0), None);
+        l.charge_turn("s", "e1");
+        assert_eq!(l.exceeded(&eff, 0), None, "1 of 2 turns — ok");
+        l.charge_turn("s", "e2");
+        assert_eq!(
+            l.exceeded(&eff, 0),
+            Some(BudgetLimit::Turns),
+            "reached the cap"
+        );
+    }
+
+    #[test]
+    fn tokens_enforced_only_when_capped() {
+        let uncapped = EffectiveBudgets {
+            turns: 1000,
+            tokens: None,
+            ..Default::default()
+        };
+        let capped = EffectiveBudgets {
+            tokens: Some(1000),
+            ..uncapped.clone()
+        };
+        let mut l = Ledger::default();
+        l.charge_tokens(
+            "a",
+            "s",
+            Some(TurnUsage {
+                input_tokens: 800,
+                output_tokens: 400,
+            }),
+        );
+        assert_eq!(l.tokens, 1200);
+        assert_eq!(l.exceeded(&uncapped, 0), None, "no token cap → never trips");
+        assert_eq!(l.exceeded(&capped, 0), Some(BudgetLimit::Tokens));
+    }
+
+    #[test]
+    fn token_charges_are_per_turn_deltas() {
+        let mut l = Ledger::default();
+        // Cumulative session usage grows across turns; the ledger charges deltas.
+        l.charge_tokens("a", "s", Some(TurnUsage { input_tokens: 100, output_tokens: 0 }));
+        l.charge_tokens("a", "s", Some(TurnUsage { input_tokens: 250, output_tokens: 0 }));
+        assert_eq!(l.tokens, 250, "delta 100 then 150");
+        assert_eq!(l.steps["s"].tokens, 250);
+    }
+
+    #[test]
+    fn no_usage_never_charges_tokens() {
+        let mut l = Ledger::default();
+        l.charge_tokens("a", "s", None);
+        l.charge_tokens("a", "s", None);
+        assert_eq!(l.tokens, 0);
+    }
+
+    #[test]
+    fn rollup_tracks_step_and_attempt() {
+        let mut l = Ledger::default();
+        l.charge_turn("plan", "e1");
+        l.charge_turn("plan", "e1");
+        l.charge_turn("build", "e2");
+        assert_eq!(l.turns, 3, "run total");
+        assert_eq!(l.steps["plan"].turns, 2);
+        assert_eq!(l.steps["build"].turns, 1);
+        assert_eq!(l.attempts["e1"], 2);
+        assert_eq!(l.attempts["e2"], 1);
+    }
+
+    #[test]
+    fn wall_clock_accumulates_active_time_across_drives() {
+        let eff = EffectiveBudgets {
+            wall_clock_mins: 1, // 60_000 ms
+            turns: 1000,
+            ..Default::default()
+        };
+        let mut l = Ledger::default();
+        l.start_drive(0);
+        assert_eq!(l.exceeded(&eff, 30_000), None, "30s of 60s");
+        // Pause after 40s of active time.
+        l.checkpoint_wall(40_000);
+        assert_eq!(l.wall_ms, 40_000);
+        // Resume much later (pause time doesn't count): a fresh drive start.
+        l.start_drive(1_000_000);
+        assert_eq!(l.exceeded(&eff, 1_010_000), None, "40s + 10s = 50s < 60s");
+        assert_eq!(
+            l.exceeded(&eff, 1_030_000),
+            Some(BudgetLimit::WallClock),
+            "40s + 30s = 70s > 60s"
+        );
+    }
+
+    #[test]
+    fn patch_adds_to_run_caps() {
+        let mut eff = EffectiveBudgets {
+            turns: 10,
+            tokens: Some(1000),
+            wall_clock_mins: 60,
+            ..Default::default()
+        };
+        eff.apply_patch(&budgets(Some(5), Some(500), Some(30)));
+        assert_eq!(eff.turns, 15);
+        assert_eq!(eff.tokens, Some(1500));
+        assert_eq!(eff.wall_clock_mins, 90);
+    }
+
+    #[test]
+    fn patch_on_unlimited_tokens_is_a_noop() {
+        let mut eff = EffectiveBudgets {
+            tokens: None,
+            ..Default::default()
+        };
+        eff.apply_patch(&budgets(None, Some(500), None));
+        assert_eq!(eff.tokens, None, "adding to unlimited stays unlimited");
+    }
+
+    #[test]
+    fn ledger_json_round_trips_persisted_fields() {
+        let mut l = Ledger::default();
+        l.charge_turn("s", "e1");
+        l.charge_tokens("a", "s", Some(TurnUsage { input_tokens: 5, output_tokens: 5 }));
+        l.wall_ms = 1234;
+        let restored = Ledger::from_json(&l.to_json());
+        assert_eq!(restored.turns, 1);
+        assert_eq!(restored.tokens, 10);
+        assert_eq!(restored.wall_ms, 1234);
+        assert_eq!(restored.steps["s"].turns, 1);
+        // Transient fields do not survive serialization.
+        assert!(restored.agent_tokens_seen.is_empty());
+    }
+}

--- a/src-tauri/src/workflow/budget.rs
+++ b/src-tauri/src/workflow/budget.rs
@@ -95,17 +95,43 @@ impl EffectiveBudgets {
 
     /// The effective budgets for one step: the run-level frozen set with the
     /// step's own `budgets` overlaid (spec §11.1: "step values override run
-    /// values"). Only the step-scoped fields differ; the run caps are unchanged.
+    /// values"). **Only the step/attempt-scoped fields** (`turns_per_attempt`,
+    /// `max_attempts`, the timeouts) are overridable here. The run-scoped caps
+    /// (`turns` / `tokens` / `wall_clock_mins`) stay frozen at the run level —
+    /// `exceeded` reads them run-wide, so a step must not be able to widen or
+    /// tighten the run's budget for itself.
     pub fn for_step(&self, step_budgets: Option<&Budgets>) -> Self {
         let mut eff = self.clone();
         if let Some(b) = step_budgets {
-            eff.overlay(b);
+            if let Some(v) = b.turns_per_attempt {
+                eff.turns_per_attempt = v;
+            }
+            if let Some(v) = b.max_attempts {
+                eff.max_attempts = v;
+            }
+            if let Some(v) = b.spawn_timeout_secs {
+                eff.spawn_timeout_secs = v;
+            }
+            if let Some(v) = b.turn_start_timeout_secs {
+                eff.turn_start_timeout_secs = v;
+            }
+            if let Some(v) = b.stall_timeout_secs {
+                eff.stall_timeout_secs = v;
+            }
+            if let Some(v) = b.nudge_timeout_secs {
+                eff.nudge_timeout_secs = v;
+            }
+            if let Some(v) = b.tests_timeout_secs {
+                eff.tests_timeout_secs = v;
+            }
         }
         eff
     }
 
-    /// Overlay any set field of `b` onto `self`. Positivity is already enforced
-    /// by `spec::validate`, so values are trusted here.
+    /// Overlay any set field of `b` onto `self` — used only for the run-level
+    /// resolve, where the spec's run budgets may set both the run caps and the
+    /// step-scoped defaults. Positivity is already enforced by `spec::validate`,
+    /// so values are trusted here.
     fn overlay(&mut self, b: &Budgets) {
         if let Some(v) = b.turns {
             self.turns = v;
@@ -363,6 +389,18 @@ mod tests {
         assert_eq!(step.turns_per_attempt, 3);
         // Run-level caps are inherited unchanged.
         assert_eq!(step.turns, 50);
+    }
+
+    #[test]
+    fn step_budgets_cannot_move_run_caps() {
+        // The run-scoped caps drive run-wide enforcement; a step's budgets must
+        // not widen or tighten them, even if the step sets turns/tokens/wall.
+        let run =
+            EffectiveBudgets::resolve(&spec_with(Some(budgets(Some(50), Some(1000), Some(60)))));
+        let step = run.for_step(Some(&budgets(Some(5), Some(10), Some(1))));
+        assert_eq!(step.turns, 50, "run turn cap frozen");
+        assert_eq!(step.tokens, Some(1000), "run token cap frozen");
+        assert_eq!(step.wall_clock_mins, 60, "run wall-clock cap frozen");
     }
 
     #[test]

--- a/src-tauri/src/workflow/driver.rs
+++ b/src-tauri/src/workflow/driver.rs
@@ -340,10 +340,7 @@ impl MockDriver {
     /// Set the cumulative token usage `turn_usage` reports for an agent (the
     /// budget ledger's token input).
     pub(crate) fn set_usage(&self, agent_id: &str, usage: TurnUsage) {
-        self.state
-            .lock()
-            .usage
-            .insert(agent_id.to_string(), usage);
+        self.state.lock().usage.insert(agent_id.to_string(), usage);
     }
 
     pub(crate) fn set_worktree(&self, path: PathBuf) {
@@ -483,7 +480,10 @@ mod tests {
         });
         assert_eq!(
             usage_from_body(&body),
-            Some(TurnUsage { input_tokens: 150, output_tokens: 30 })
+            Some(TurnUsage {
+                input_tokens: 150,
+                output_tokens: 30
+            })
         );
     }
 
@@ -494,7 +494,10 @@ mod tests {
         }}});
         assert_eq!(
             usage_from_body(&body),
-            Some(TurnUsage { input_tokens: 80, output_tokens: 20 })
+            Some(TurnUsage {
+                input_tokens: 80,
+                output_tokens: 20
+            })
         );
     }
 

--- a/src-tauri/src/workflow/driver.rs
+++ b/src-tauri/src/workflow/driver.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use serde_json::Value;
 use tauri::AppHandle;
 use tokio::sync::broadcast;
 
@@ -58,9 +59,12 @@ pub struct SpawnedAgent {
     pub worktree: PathBuf,
 }
 
-/// Per-turn token usage, when the provider's transcript exposes it. The budget
-/// *ledger* that consumes this is S5; `SupervisorDriver` returns `None` in S4
-/// (turn counting is the universal unit the linear engine needs).
+/// Cumulative token usage for an agent's current session, when the provider's
+/// records expose it. The budget ledger charges the per-turn *delta* between
+/// successive reads (§11.2), so returning the running session total — not one
+/// turn's slice — is what lets it account correctly across a multi-turn attempt.
+/// Providers that expose no usage report `None`, and only turn/clock budgets
+/// then apply.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TurnUsage {
     pub input_tokens: u64,
@@ -198,11 +202,52 @@ impl AgentDriver for SupervisorDriver {
         self.sup.last_activity(agent_id)
     }
 
-    fn turn_usage(&self, _agent_id: &str) -> Option<TurnUsage> {
-        // Token extraction is the budget ledger's job (S5). Turn counting — the
-        // universal unit — needs nothing from here.
-        None
+    fn turn_usage(&self, agent_id: &str) -> Option<TurnUsage> {
+        // Sum the `usage` reported across the agent's session records — the
+        // cumulative session total (§11.2). Best-effort by design: we read only
+        // fields the provider already wrote into the record body and build no
+        // per-provider parser (SLICES.md guardrail). A provider that reports no
+        // usage yields `None`, so tokens stay uncounted and turn/clock budgets
+        // bound the run instead.
+        let records = self.sup.read_session_records(agent_id);
+        let mut total = TurnUsage::default();
+        let mut any = false;
+        for rec in &records {
+            if let Some(u) = usage_from_body(&rec.body) {
+                total.input_tokens += u.input_tokens;
+                total.output_tokens += u.output_tokens;
+                any = true;
+            }
+        }
+        any.then_some(total)
     }
+}
+
+/// Pull a `usage` object out of a canonical record body and read the token
+/// counts under whatever standard names the provider used. Covers the shapes
+/// Fletch's providers actually emit — `usage` at the record top level or nested
+/// under `message` (Claude `result`), with Anthropic (`input_tokens` +
+/// `cache_*_input_tokens` / `output_tokens`) or OpenAI (`prompt_tokens` /
+/// `completion_tokens`) field names. Returns `None` when no usage is present.
+fn usage_from_body(body: &Value) -> Option<TurnUsage> {
+    let usage = body
+        .get("usage")
+        .or_else(|| body.pointer("/message/usage"))?;
+    let field = |k: &str| usage.get(k).and_then(Value::as_u64);
+    let input = field("input_tokens")
+        .or_else(|| field("prompt_tokens"))
+        .map(|n| {
+            n + field("cache_creation_input_tokens").unwrap_or(0)
+                + field("cache_read_input_tokens").unwrap_or(0)
+        });
+    let output = field("output_tokens").or_else(|| field("completion_tokens"));
+    if input.is_none() && output.is_none() {
+        return None;
+    }
+    Some(TurnUsage {
+        input_tokens: input.unwrap_or(0),
+        output_tokens: output.unwrap_or(0),
+    })
 }
 
 /// What a `MockDriver` does to the agent's status when a prompt is sent —
@@ -290,6 +335,15 @@ impl MockDriver {
             .lock()
             .activity
             .insert(agent_id.to_string(), ts_ms);
+    }
+
+    /// Set the cumulative token usage `turn_usage` reports for an agent (the
+    /// budget ledger's token input).
+    pub(crate) fn set_usage(&self, agent_id: &str, usage: TurnUsage) {
+        self.state
+            .lock()
+            .usage
+            .insert(agent_id.to_string(), usage);
     }
 
     pub(crate) fn set_worktree(&self, path: PathBuf) {
@@ -419,6 +473,37 @@ impl AgentDriver for MockDriver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn usage_from_body_reads_anthropic_shape_with_cache() {
+        let body = json!({
+            "type": "result",
+            "usage": { "input_tokens": 100, "cache_read_input_tokens": 50, "output_tokens": 30 }
+        });
+        assert_eq!(
+            usage_from_body(&body),
+            Some(TurnUsage { input_tokens: 150, output_tokens: 30 })
+        );
+    }
+
+    #[test]
+    fn usage_from_body_reads_openai_shape_and_nested() {
+        let body = json!({ "message": { "usage": {
+            "prompt_tokens": 80, "completion_tokens": 20
+        }}});
+        assert_eq!(
+            usage_from_body(&body),
+            Some(TurnUsage { input_tokens: 80, output_tokens: 20 })
+        );
+    }
+
+    #[test]
+    fn usage_from_body_none_when_absent_or_empty() {
+        assert_eq!(usage_from_body(&json!({ "type": "turn.completed" })), None);
+        // An empty `usage` object carries no token fields → no usage.
+        assert_eq!(usage_from_body(&json!({ "usage": {} })), None);
+    }
 
     #[tokio::test]
     async fn mock_spawn_starts_spawning_and_broadcasts() {

--- a/src-tauri/src/workflow/mod.rs
+++ b/src-tauri/src/workflow/mod.rs
@@ -16,6 +16,7 @@
 
 pub mod attempt;
 pub mod blackboard;
+pub mod budget;
 pub mod definition;
 pub mod driver;
 pub mod gates;

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -184,8 +184,7 @@ impl WorkflowService {
             let mut eff: EffectiveBudgets = serde_json::from_str(&budgets_json)
                 .map_err(|e| Error::Other(format!("bad budgets_json: {e}")))?;
             eff.apply_patch(&patch);
-            let patched =
-                serde_json::to_string(&eff).map_err(|e| Error::Other(e.to_string()))?;
+            let patched = serde_json::to_string(&eff).map_err(|e| Error::Other(e.to_string()))?;
             conn.execute(
                 "UPDATE wf_run SET budgets_json = ?1, updated_at = ?2 WHERE id = ?3",
                 rusqlite::params![patched, super::now_ms(), run_id],
@@ -1833,8 +1832,7 @@ mod tests {
         // with a budget patch (simulating `wf_resume(budget_patch)`) lifts the
         // cap and the run drives to done from the paused position.
         let tmp = tempfile::tempdir().unwrap();
-        let (db, ws) =
-            scaffold_steps(tmp.path(), "run-b1", "wf/b1", &["s1", "s2"], &eff_json(1));
+        let (db, ws) = scaffold_steps(tmp.path(), "run-b1", "wf/b1", &["s1", "s2"], &eff_json(1));
         let ctx = RunCtx {
             db: db.clone(),
             driver: StubDriver::new(ws, true),
@@ -1877,9 +1875,11 @@ mod tests {
         {
             let conn = db.lock();
             let bj: String = conn
-                .query_row("SELECT budgets_json FROM wf_run WHERE id='run-b1'", [], |r| {
-                    r.get(0)
-                })
+                .query_row(
+                    "SELECT budgets_json FROM wf_run WHERE id='run-b1'",
+                    [],
+                    |r| r.get(0),
+                )
                 .unwrap();
             let mut e: EffectiveBudgets = serde_json::from_str(&bj).unwrap();
             e.apply_patch(&Budgets {

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -172,26 +172,34 @@ impl WorkflowService {
     /// lifts the tripped cap is what lets a `budget_exceeded` run make progress;
     /// resuming without one simply re-pauses at the same cap.
     pub fn resume(&self, run_id: &str, budget_patch: Option<Budgets>) -> Result<()> {
-        if let Some(patch) = budget_patch {
+        {
             let conn = self.db.lock();
-            let budgets_json: String = conn
-                .query_row(
-                    "SELECT budgets_json FROM wf_run WHERE id = ?1",
-                    [run_id],
-                    |r| r.get(0),
+            // Validate resumability BEFORE touching the budget — a rejected
+            // resume (terminal or approval-paused run) must not mutate the
+            // otherwise-immutable `budgets_json`.
+            check_resumable(&conn, run_id, "resume")?;
+            if let Some(patch) = budget_patch {
+                let budgets_json: String = conn
+                    .query_row(
+                        "SELECT budgets_json FROM wf_run WHERE id = ?1",
+                        [run_id],
+                        |r| r.get(0),
+                    )
+                    .map_err(|e| Error::Other(format!("run {run_id} not found: {e}")))?;
+                let mut eff: EffectiveBudgets = serde_json::from_str(&budgets_json)
+                    .map_err(|e| Error::Other(format!("bad budgets_json: {e}")))?;
+                eff.apply_patch(&patch);
+                let patched =
+                    serde_json::to_string(&eff).map_err(|e| Error::Other(e.to_string()))?;
+                conn.execute(
+                    "UPDATE wf_run SET budgets_json = ?1, updated_at = ?2 WHERE id = ?3",
+                    rusqlite::params![patched, super::now_ms(), run_id],
                 )
-                .map_err(|e| Error::Other(format!("run {run_id} not found: {e}")))?;
-            let mut eff: EffectiveBudgets = serde_json::from_str(&budgets_json)
-                .map_err(|e| Error::Other(format!("bad budgets_json: {e}")))?;
-            eff.apply_patch(&patch);
-            let patched = serde_json::to_string(&eff).map_err(|e| Error::Other(e.to_string()))?;
-            conn.execute(
-                "UPDATE wf_run SET budgets_json = ?1, updated_at = ?2 WHERE id = ?3",
-                rusqlite::params![patched, super::now_ms(), run_id],
-            )
-            .map_err(|e| Error::Other(e.to_string()))?;
+                .map_err(|e| Error::Other(e.to_string()))?;
+            }
         }
-        self.resume_paused(run_id, "resume")
+        self.spawn_drive(run_id.to_string());
+        Ok(())
     }
 
     /// User-initiated retry after `paused(blocked_gate|stalled)` — same as
@@ -208,15 +216,7 @@ impl WorkflowService {
     fn resume_paused(&self, run_id: &str, action: &str) -> Result<()> {
         {
             let conn = self.db.lock();
-            let (status, reason) = run_status(&conn, run_id)?;
-            if status != "paused" {
-                return Err(Error::Other(format!("cannot {action} a {status} run")));
-            }
-            if reason.as_deref() == Some("approval") {
-                return Err(Error::Other(
-                    "run is awaiting approval — use wf_approve (or wf_cancel)".into(),
-                ));
-            }
+            check_resumable(&conn, run_id, action)?;
         }
         self.spawn_drive(run_id.to_string());
         Ok(())
@@ -936,6 +936,23 @@ fn slugify(name: &str) -> String {
     } else {
         s.chars().take(40).collect()
     }
+}
+
+/// The resume/retry guard: only a `paused(blocked_gate|stalled|budget_exceeded)`
+/// run may be re-driven. A terminal run must not restart, and a
+/// `paused(approval)` run must go through `wf_approve`. Callers run this before
+/// any state mutation so a rejected resume changes nothing.
+fn check_resumable(conn: &Connection, run_id: &str, action: &str) -> Result<()> {
+    let (status, reason) = run_status(conn, run_id)?;
+    if status != "paused" {
+        return Err(Error::Other(format!("cannot {action} a {status} run")));
+    }
+    if reason.as_deref() == Some("approval") {
+        return Err(Error::Other(
+            "run is awaiting approval — use wf_approve (or wf_cancel)".into(),
+        ));
+    }
+    Ok(())
 }
 
 fn run_status(conn: &Connection, run_id: &str) -> Result<(String, Option<String>)> {
@@ -1918,5 +1935,35 @@ mod tests {
             )
             .unwrap();
         assert_eq!(done, 2, "both steps completed after the patch");
+    }
+
+    #[test]
+    fn check_resumable_gates_resume_and_retry() {
+        // The guard runs before `resume` applies any budget patch, so a rejected
+        // resume leaves state untouched. Terminal and approval-paused runs are
+        // rejected; resumable pauses pass.
+        let tmp = tempfile::tempdir().unwrap();
+        let db = crate::database::init(tmp.path()).unwrap();
+        let insert = |id: &str, status: &str, reason: Option<&str>| {
+            db.lock()
+                .execute(
+                    "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,
+                        branch,base_sha,status,paused_reason,budgets_json,spent_json,
+                        created_at,updated_at)
+                     VALUES (?1,'n','{}','t','p','/r','/d','wf/x','sha',?2,?3,'{}','{}',0,0)",
+                    rusqlite::params![id, status, reason],
+                )
+                .unwrap();
+        };
+        insert("r-done", "done", None);
+        insert("r-appr", "paused", Some("approval"));
+        insert("r-budg", "paused", Some("budget_exceeded"));
+        insert("r-blk", "paused", Some("blocked_gate"));
+
+        let conn = db.lock();
+        assert!(check_resumable(&conn, "r-done", "resume").is_err());
+        assert!(check_resumable(&conn, "r-appr", "resume").is_err());
+        assert!(check_resumable(&conn, "r-budg", "resume").is_ok());
+        assert!(check_resumable(&conn, "r-blk", "retry").is_ok());
     }
 }

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -25,18 +25,15 @@ use crate::error::{Error, Result};
 
 use super::attempt::{self, AttemptOutcome, AttemptParams, Deadlines};
 use super::blackboard;
+use super::budget::{EffectiveBudgets, Ledger};
 use super::driver::{AgentDriver, SpawnReq};
 use super::gitops;
 use super::journal;
 use super::prompts::{self, Position, StepPromptCtx};
-use super::spec::{Block, Gate, Spec, Step};
+use super::spec::{Block, Budgets, Gate, Spec, Step};
 use super::types::event_type;
 
 type Db = Arc<Mutex<Connection>>;
-
-/// Default `max_attempts` per step (spec §11.1). Autonomous retries only; a
-/// user-initiated `wf_retry` always grants one beyond this.
-const DEFAULT_MAX_ATTEMPTS: i64 = 2;
 
 /// App-state singleton: the active-run registry plus launch / control.
 pub struct WorkflowService {
@@ -100,11 +97,10 @@ impl WorkflowService {
 
         let branch = format!("wf/{}-{}", slugify(&spec.name), &run_id[run_id.len() - 8..]);
         let spec_json = serde_json::to_string(&spec).map_err(|e| Error::Other(e.to_string()))?;
-        let budgets_json = spec
-            .budgets
-            .as_ref()
-            .and_then(|b| serde_json::to_string(b).ok())
-            .unwrap_or_else(|| "{}".to_string());
+        // Freeze the effective budgets (§11.1 defaults ∪ spec) at launch — the
+        // immutable-except-by-resume-patch source of truth for enforcement (§11.2).
+        let budgets_json = serde_json::to_string(&EffectiveBudgets::resolve(&spec))
+            .map_err(|e| Error::Other(e.to_string()))?;
 
         let now = super::now_ms();
         {
@@ -170,9 +166,32 @@ impl WorkflowService {
         Ok(())
     }
 
-    /// Resume a paused run (`wf_resume`): re-drive from the cursor. A fresh
-    /// attempt is started for a blocked/stalled step by the drive loop.
-    pub fn resume(&self, run_id: &str) -> Result<()> {
+    /// Resume a paused run (`wf_resume`): optionally raise the budget (§11.2,
+    /// §13), then re-drive from the cursor. A fresh attempt is started for a
+    /// blocked / stalled / budget-exceeded step by the drive loop. A patch that
+    /// lifts the tripped cap is what lets a `budget_exceeded` run make progress;
+    /// resuming without one simply re-pauses at the same cap.
+    pub fn resume(&self, run_id: &str, budget_patch: Option<Budgets>) -> Result<()> {
+        if let Some(patch) = budget_patch {
+            let conn = self.db.lock();
+            let budgets_json: String = conn
+                .query_row(
+                    "SELECT budgets_json FROM wf_run WHERE id = ?1",
+                    [run_id],
+                    |r| r.get(0),
+                )
+                .map_err(|e| Error::Other(format!("run {run_id} not found: {e}")))?;
+            let mut eff: EffectiveBudgets = serde_json::from_str(&budgets_json)
+                .map_err(|e| Error::Other(format!("bad budgets_json: {e}")))?;
+            eff.apply_patch(&patch);
+            let patched =
+                serde_json::to_string(&eff).map_err(|e| Error::Other(e.to_string()))?;
+            conn.execute(
+                "UPDATE wf_run SET budgets_json = ?1, updated_at = ?2 WHERE id = ?3",
+                rusqlite::params![patched, super::now_ms(), run_id],
+            )
+            .map_err(|e| Error::Other(e.to_string()))?;
+        }
         self.resume_paused(run_id, "resume")
     }
 
@@ -183,10 +202,10 @@ impl WorkflowService {
         self.resume_paused(run_id, "retry")
     }
 
-    /// Shared resume/retry guard: only a `paused(blocked_gate|stalled)` run may
-    /// be re-driven. A terminal run must not restart, and a `paused(approval)`
-    /// run must go through `wf_approve` — re-driving it would start a fresh
-    /// attempt for a step whose result is already ferried.
+    /// Shared resume/retry guard: only a `paused(blocked_gate|stalled|
+    /// budget_exceeded)` run may be re-driven. A terminal run must not restart,
+    /// and a `paused(approval)` run must go through `wf_approve` — re-driving it
+    /// would start a fresh attempt for a step whose result is already ferried.
     fn resume_paused(&self, run_id: &str, action: &str) -> Result<()> {
         {
             let conn = self.db.lock();
@@ -358,6 +377,8 @@ struct RunEssentials {
     branch: String,
     base_sha: String,
     status: String,
+    budgets_json: String,
+    spent_json: String,
 }
 
 /// Drive one run to a terminal or paused state. Any error bubbling out marks the
@@ -416,6 +437,16 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
     // Resume: abandon any attempt left non-terminal by a prior driver (§6.4).
     abandon_stale_attempts(ctx, run_id).await;
 
+    // Budget ledger + frozen caps (§11). `budgets_json` is the launch-frozen
+    // effective set; `spent_json` the running ledger (carried across resumes).
+    // `start_drive` stamps the wall-clock so pause time between drives isn't
+    // charged (§11.3).
+    let eff: EffectiveBudgets = serde_json::from_str(&run.budgets_json)
+        .unwrap_or_else(|_| EffectiveBudgets::resolve(&spec));
+    let spent_val: Value = serde_json::from_str(&run.spent_json).unwrap_or_else(|_| json!({}));
+    let mut ledger = Ledger::from_json(&spent_val);
+    ledger.start_drive(super::now_ms());
+
     let mut index = get_cursor_index(&ctx.db.lock(), run_id) as usize;
     // The fork source for the next step: the last done step's ref, else base_sha.
     let mut last_ref =
@@ -450,16 +481,34 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
                 step.id, step.agent
             ))
         })?;
-        let max_attempts = step
-            .budgets
-            .as_ref()
-            .and_then(|b| b.max_attempts)
-            .unwrap_or(DEFAULT_MAX_ATTEMPTS);
+        // Step-effective budgets: run-level frozen caps with this step's own
+        // `budgets` overlaid (§11.1). Feeds the attempt timeouts and retry cap.
+        let step_eff = eff.for_step(step.budgets.as_ref());
+        let max_attempts = step_eff.max_attempts;
+        let deadlines = deadlines_from(&ctx.deadlines, &step_eff);
 
         let mut attempt_no = next_attempt_no(&ctx.db.lock(), run_id, &step.id);
         let mut last_failure: Option<String> = None;
 
         loop {
+            // Enforcement point: before every spawn (§11.2). No attempt row is
+            // created — the run pauses at the block boundary.
+            if let Some(which) = ledger.exceeded(&step_eff, super::now_ms()) {
+                {
+                    let conn = ctx.db.lock();
+                    journal_event(
+                        &conn,
+                        ctx.app.as_ref(),
+                        run_id,
+                        event_type::BUDGET_EXCEEDED,
+                        None,
+                        &json!({ "which": which.as_str() }),
+                    );
+                }
+                finish_budget_pause(ctx, run_id, None, &mut ledger);
+                return Ok(());
+            }
+
             let exec_id = format!("exec-{}", uuid::Uuid::new_v4());
             {
                 let conn = ctx.db.lock();
@@ -511,17 +560,19 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
                     owner_run_id: run_id.to_string(),
                 },
                 blackboard: blackboard.clone(),
+                exec_id: exec_id.clone(),
                 step_id: step.id.clone(),
                 attempt: attempt_no as u32,
                 iteration: 0,
                 gate: step.gate.clone(),
                 prompt,
-                deadlines: ctx.deadlines.clone(),
+                deadlines: deadlines.clone(),
                 reprompt_on_block: true,
             };
 
             let started = super::now_ms();
-            let result = attempt::run_attempt(ctx.driver.as_ref(), params).await;
+            let result =
+                attempt::run_attempt(ctx.driver.as_ref(), params, &mut ledger, &step_eff).await;
             // Journal the attempt's events and stamp its agent id.
             {
                 let conn = ctx.db.lock();
@@ -541,6 +592,11 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
                         &e.payload,
                     );
                 }
+                // Persist the ledger this attempt spent (turns/tokens charged in
+                // `run_attempt`), folding in the drive's active wall-clock so a
+                // resume reads a current spend snapshot (§11.2).
+                ledger.checkpoint_wall(super::now_ms());
+                persist_spent(&conn, run_id, &ledger);
             }
 
             match result.outcome {
@@ -694,6 +750,32 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
                         return Ok(());
                     }
                     attempt_no += 1;
+                }
+                AttemptOutcome::BudgetExceeded { .. } => {
+                    // A run-level cap was hit mid-attempt (§11.2). The attempt
+                    // already journaled `budget_exceeded`; finish its bookkeeping
+                    // — stop the agent, abandon the incomplete attempt — and pause.
+                    // Resume-with-patch (§13) starts a fresh attempt for this step.
+                    if let Some(agent_id) = &result.agent_id {
+                        let _ = ctx.driver.stop(agent_id).await;
+                    }
+                    {
+                        let conn = ctx.db.lock();
+                        let _ = conn.execute(
+                            "UPDATE wf_step_exec SET status = 'abandoned', ended_at = ?1 WHERE id = ?2",
+                            rusqlite::params![super::now_ms(), exec_id],
+                        );
+                        journal_event(
+                            &conn,
+                            ctx.app.as_ref(),
+                            run_id,
+                            event_type::ATTEMPT_ABANDONED,
+                            Some(&exec_id),
+                            &json!({ "cause": "budget_exceeded" }),
+                        );
+                    }
+                    finish_budget_pause(ctx, run_id, Some(&exec_id), &mut ledger);
+                    return Ok(());
                 }
             }
         }
@@ -868,7 +950,9 @@ fn run_status(conn: &Connection, run_id: &str) -> Result<(String, Option<String>
 
 fn load_run(conn: &Connection, run_id: &str) -> Result<RunEssentials> {
     conn.query_row(
-        "SELECT spec_json, task, repo_path, run_dir, branch, base_sha, status FROM wf_run WHERE id = ?1",
+        "SELECT spec_json, task, repo_path, run_dir, branch, base_sha, status,
+                budgets_json, spent_json
+         FROM wf_run WHERE id = ?1",
         [run_id],
         |r| {
             Ok(RunEssentials {
@@ -879,6 +963,8 @@ fn load_run(conn: &Connection, run_id: &str) -> Result<RunEssentials> {
                 branch: r.get(4)?,
                 base_sha: r.get(5)?,
                 status: r.get(6)?,
+                budgets_json: r.get(7)?,
+                spent_json: r.get(8)?,
             })
         },
     )
@@ -986,6 +1072,53 @@ fn set_cursor_index(conn: &Connection, run_id: &str, index: i64) {
     );
 }
 
+/// Persist the run's ledger snapshot to `spent_json` (§11.2).
+fn persist_spent(conn: &Connection, run_id: &str, ledger: &Ledger) {
+    let _ = conn.execute(
+        "UPDATE wf_run SET spent_json = ?1, updated_at = ?2 WHERE id = ?3",
+        rusqlite::params![ledger.to_json().to_string(), super::now_ms(), run_id],
+    );
+}
+
+/// Pause a run `budget_exceeded` (§11.2): fold in the drive's active wall-clock,
+/// persist the ledger, journal `run_paused`, and set the row. The caller has
+/// already journaled the `budget_exceeded` event (from the attempt's events or
+/// the pre-spawn check) and settled any live agent.
+fn finish_budget_pause(ctx: &RunCtx, run_id: &str, exec_id: Option<&str>, ledger: &mut Ledger) {
+    ledger.checkpoint_wall(super::now_ms());
+    let conn = ctx.db.lock();
+    persist_spent(&conn, run_id, ledger);
+    journal_event(
+        &conn,
+        ctx.app.as_ref(),
+        run_id,
+        event_type::RUN_PAUSED,
+        exec_id,
+        &json!({ "reason": "budget_exceeded" }),
+    );
+    set_status(
+        &conn,
+        ctx.app.as_ref(),
+        run_id,
+        "paused",
+        Some("budget_exceeded"),
+        None,
+    );
+}
+
+/// Attempt deadlines resolved from the step-effective budgets (§11.1). The
+/// watchdog cadence comes from `base` — it is not a budget field.
+fn deadlines_from(base: &Deadlines, eff: &EffectiveBudgets) -> Deadlines {
+    let secs = |n: i64| std::time::Duration::from_secs(n.max(0) as u64);
+    Deadlines {
+        spawn_timeout: secs(eff.spawn_timeout_secs),
+        turn_start_timeout: secs(eff.turn_start_timeout_secs),
+        stall_timeout: secs(eff.stall_timeout_secs),
+        nudge_timeout: secs(eff.nudge_timeout_secs),
+        watchdog_tick: base.watchdog_tick,
+    }
+}
+
 /// The exec id of the most recent `done` step (the fork source for the next).
 fn latest_done_exec(conn: &Connection, run_id: &str) -> Option<String> {
     conn.query_row(
@@ -1087,10 +1220,17 @@ pub async fn wf_cancel(run_id: String, service: Svc<'_>) -> std::result::Result<
     service.cancel(&run_id).await.map_err(|e| e.to_string())
 }
 
-/// Resume a paused run (no budget patch yet — S5).
+/// Resume a paused run (§13), optionally raising the budget with a patch
+/// ("+N turns / +N tokens / +N minutes") for a `budget_exceeded` pause.
 #[tauri::command]
-pub async fn wf_resume(run_id: String, service: Svc<'_>) -> std::result::Result<(), String> {
-    service.resume(&run_id).map_err(|e| e.to_string())
+pub async fn wf_resume(
+    run_id: String,
+    budget_patch: Option<Budgets>,
+    service: Svc<'_>,
+) -> std::result::Result<(), String> {
+    service
+        .resume(&run_id, budget_patch)
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -1570,5 +1710,213 @@ mod tests {
             })
             .unwrap();
         assert_eq!(status, "done");
+    }
+
+    // ── budgets (spec §11.2) ─────────────────────────────────────────────────
+
+    /// Scaffold a commit-gated linear run of `step_ids`, no finalize, with an
+    /// explicit `budgets_json`. Mirrors `scaffold_one_step` but parametric.
+    fn scaffold_steps(
+        tmp: &Path,
+        run_id: &str,
+        branch: &str,
+        step_ids: &[&str],
+        budgets_json: &str,
+    ) -> (Db, PathBuf) {
+        let source = tmp.join("source");
+        std::fs::create_dir_all(&source).unwrap();
+        sh(&source, &["init", "-q", "-b", "main"]);
+        sh(&source, &["config", "user.email", "t@t.t"]);
+        sh(&source, &["config", "user.name", "t"]);
+        std::fs::write(source.join("README"), "base").unwrap();
+        sh(&source, &["add", "-A"]);
+        sh(&source, &["commit", "-qm", "base"]);
+        let base_sha = {
+            let o = Sh::new("git")
+                .current_dir(&source)
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .unwrap();
+            String::from_utf8_lossy(&o.stdout).trim().to_string()
+        };
+        let run_dir = tmp.join("rundir");
+        std::fs::create_dir_all(blackboard::blackboard_dir(&run_dir)).unwrap();
+        let mut agents = BTreeMap::new();
+        agents.insert(
+            "coder".to_string(),
+            super::super::spec::AgentSpec {
+                base: "codex".to_string(),
+                model: None,
+                instructions: None,
+                skills: vec![],
+                custom_agent: None,
+            },
+        );
+        let spec = Spec {
+            version: 1,
+            name: "demo".to_string(),
+            description: None,
+            budgets: None,
+            agents,
+            workflow: step_ids.iter().map(|id| Block::Step(step(id))).collect(),
+            finalize: None,
+        };
+        let spec_json = serde_json::to_string(&spec).unwrap();
+        let db = crate::database::init(tmp).unwrap();
+        db.lock()
+            .execute(
+                "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,branch,
+                    base_sha,status,budgets_json,spent_json,created_at,updated_at)
+                 VALUES (?1,'demo',?2,'t','p',?3,?4,?5,?6,'pending',?7,'{}',0,0)",
+                rusqlite::params![
+                    run_id,
+                    spec_json,
+                    source.to_string_lossy(),
+                    run_dir.to_string_lossy(),
+                    branch,
+                    base_sha,
+                    budgets_json,
+                ],
+            )
+            .unwrap();
+        (db, tmp.join("ws"))
+    }
+
+    fn eff_json(turns: i64) -> String {
+        serde_json::to_string(&EffectiveBudgets {
+            turns,
+            ..Default::default()
+        })
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn zero_turn_budget_pauses_before_any_spawn() {
+        // Enforcement point: before every spawn (§11.2). A run with no turn
+        // budget pauses at the block boundary, having spawned nothing.
+        let tmp = tempfile::tempdir().unwrap();
+        let (db, ws) = scaffold_steps(tmp.path(), "run-b0", "wf/b0", &["only"], &eff_json(0));
+        let ctx = RunCtx {
+            db: db.clone(),
+            driver: StubDriver::new(ws, true),
+            app: None,
+            cancel: Arc::new(AtomicBool::new(false)),
+            deadlines: Deadlines::default(),
+        };
+        drive_run(&ctx, "run-b0").await;
+
+        let (status, reason): (String, Option<String>) = db
+            .lock()
+            .query_row(
+                "SELECT status, paused_reason FROM wf_run WHERE id='run-b0'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "paused");
+        assert_eq!(reason.as_deref(), Some("budget_exceeded"));
+        let execs: i64 = db
+            .lock()
+            .query_row(
+                "SELECT COUNT(*) FROM wf_step_exec WHERE run_id='run-b0'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(execs, 0, "no attempt was spawned");
+    }
+
+    #[tokio::test]
+    async fn budget_exceeded_pauses_then_resume_with_patch_completes() {
+        // A turn budget of 1 lets step 1's turn run and be counted, then trips
+        // the turn-end enforcement point and pauses the two-step run. A resume
+        // with a budget patch (simulating `wf_resume(budget_patch)`) lifts the
+        // cap and the run drives to done from the paused position.
+        let tmp = tempfile::tempdir().unwrap();
+        let (db, ws) =
+            scaffold_steps(tmp.path(), "run-b1", "wf/b1", &["s1", "s2"], &eff_json(1));
+        let ctx = RunCtx {
+            db: db.clone(),
+            driver: StubDriver::new(ws, true),
+            app: None,
+            cancel: Arc::new(AtomicBool::new(false)),
+            deadlines: Deadlines::default(),
+        };
+        drive_run(&ctx, "run-b1").await;
+
+        // Paused for budget, one turn spent, a budget_exceeded event journaled.
+        let (status, reason): (String, Option<String>) = db
+            .lock()
+            .query_row(
+                "SELECT status, paused_reason FROM wf_run WHERE id='run-b1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "paused");
+        assert_eq!(reason.as_deref(), Some("budget_exceeded"));
+        let spent: String = db
+            .lock()
+            .query_row("SELECT spent_json FROM wf_run WHERE id='run-b1'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        let ledger = Ledger::from_json(&serde_json::from_str(&spent).unwrap());
+        assert_eq!(ledger.turns, 1, "one turn charged before the pause");
+        let exceeded: i64 = db
+            .lock()
+            .query_row(
+                "SELECT COUNT(*) FROM wf_event WHERE run_id='run-b1' AND type=?1",
+                [event_type::BUDGET_EXCEEDED],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(exceeded, 1, "budget_exceeded journaled");
+
+        // Resume with +10 turns (what `wf_resume`'s patch does), then re-drive.
+        {
+            let conn = db.lock();
+            let bj: String = conn
+                .query_row("SELECT budgets_json FROM wf_run WHERE id='run-b1'", [], |r| {
+                    r.get(0)
+                })
+                .unwrap();
+            let mut e: EffectiveBudgets = serde_json::from_str(&bj).unwrap();
+            e.apply_patch(&Budgets {
+                turns: Some(10),
+                tokens: None,
+                wall_clock_mins: None,
+                turns_per_attempt: None,
+                max_attempts: None,
+                spawn_timeout_secs: None,
+                turn_start_timeout_secs: None,
+                stall_timeout_secs: None,
+                nudge_timeout_secs: None,
+                tests_timeout_secs: None,
+            });
+            conn.execute(
+                "UPDATE wf_run SET budgets_json=?1 WHERE id='run-b1'",
+                [serde_json::to_string(&e).unwrap()],
+            )
+            .unwrap();
+        }
+        drive_run(&ctx, "run-b1").await;
+
+        let status: String = db
+            .lock()
+            .query_row("SELECT status FROM wf_run WHERE id='run-b1'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(status, "done", "resume-with-patch drove the run to done");
+        let done: i64 = db
+            .lock()
+            .query_row(
+                "SELECT COUNT(*) FROM wf_step_exec WHERE run_id='run-b1' AND status='done'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(done, 2, "both steps completed after the patch");
     }
 }


### PR DESCRIPTION
Implements **S5 — Budgets ledger + enforcement** (SLICES.md Wave 2), per TECH_SPEC **§11.1–11.2** and resume-with-budget-patch **§13**. Base: `feat/workflows-rebase`. Backend-only; the budget meter / raise-budget UI is F2's scope.

## What lands

**`workflow/budget.rs` (new)**
- `EffectiveBudgets` — §11.1 defaults ∪ spec (spec wins, field-by-field), frozen into `budgets_json` at launch; `for_step()` overlays step budgets over run caps; `apply_patch()` adds the resume-time `+N turns/tokens/minutes`.
- `Ledger` — turn/token spend with **attempt/step/run rollup**; token charges are per-turn deltas off the provider's cumulative report; wall-clock stored as *accumulated active time* so a run paused for days doesn't blow its clock on resume. `exceeded()` is the pure enforcement predicate (`turns|tokens|wall_clock`).

**Enforcement at the three §11.2 points**
- `scheduler.rs`: freeze budgets at launch; check **before every spawn**; persist `spent_json` + checkpoint wall-clock per attempt; on `BudgetExceeded` abandon the incomplete attempt, journal `run_paused`, pause `budget_exceeded`. Also wires the frozen per-attempt timeouts into `Deadlines` and `max_attempts` from the resolved budgets. `wf_resume(budget_patch)` patches the caps and re-drives.
- `attempt.rs`: check **before every prompt send** and **at every turn end**; charge the turn + token delta, emit `budget_tick`; new `AttemptOutcome::BudgetExceeded`.

**Token extraction (guardrail-respecting)**
- `SupervisorDriver::turn_usage` sums the `usage` object out of session-record bodies best-effort (Anthropic / OpenAI shapes, top-level or `message.usage`). No per-provider parser — a provider that exposes no usage yields `None`, so tokens stay uncounted and turn/clock budgets bound the run. Adds `Supervisor::read_session_records` passthrough.

## Tests (acceptance §16)
- Ledger math incl. attempt/step/run rollup, delta charging, no-usage-never-charges, wall-clock across drives, patch math, JSON round-trip.
- MockDriver run pauses at **each enforcement point**: pre-spawn (`zero_turn_budget`), pre-send (`exhausted_budget`), turn-end (`turn_budget` / `token_budget`).
- Resume-with-patch continues from the paused position to `done`.

`cargo test` green (704 passed), clippy clean.

## Deliberate scope calls
- Budget defaults stay hardcoded to the §11.1 table — no preferences plumbing (out of S5 acceptance; "robust, not over-engineered").
- Per-attempt timeouts are now sourced from the launch-frozen budgets (the natural home for "merge frozen at launch"); defaults are unchanged from S4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)