### PR TITLE
feat(workflows): comms router — report/ask/notify + human Q&A (S10)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1153,6 +1153,7 @@ pub fn run() {
             workflow::scheduler::wf_resume,
             workflow::scheduler::wf_retry,
             workflow::scheduler::wf_approve,
+            workflow::comms::wf_answer,
             workflow::definition::wf_def_save,
             workflow::definition::wf_def_list,
             workflow::definition::wf_def_delete,

--- a/src-tauri/src/supervisor/disposition.rs
+++ b/src-tauri/src/supervisor/disposition.rs
@@ -256,6 +256,7 @@ impl Supervisor {
         self.activities.lock().remove(agent_id);
         self.statuses.lock().remove(agent_id);
         self.native_inputs.lock().remove(agent_id);
+        self.rpc_dispatchers.lock().remove(agent_id);
         // Clear the in-memory queue and its durable mirror under one hold of
         // the queue lock. Dropping the mirror stops an archived agent's queue
         // from rehydrating on the next launch (discard also cascades via the FK

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -556,8 +556,9 @@ impl Supervisor {
         // wf_ask / wf_notify, §10); everything else still falls through to the
         // git dispatcher. Plain agents keep the git dispatcher unchanged.
         let rpc_dispatcher: Arc<dyn rpc::RpcDispatcher> = match &record.owner_run_id {
-            Some(_) => Arc::new(crate::workflow::comms::WorkflowCommsDispatcher::new(
+            Some(run_id) => Arc::new(crate::workflow::comms::WorkflowCommsDispatcher::new(
                 app.clone(),
+                run_id.clone(),
                 agent_id.to_string(),
                 git_dispatcher,
             )),

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -551,7 +551,18 @@ impl Supervisor {
             .parent_branch
             .clone()
             .unwrap_or_else(|| "main".to_string());
-        let rpc_dispatcher = Arc::new(rpc::git::GitDispatcher::new(cwd.clone(), base_branch));
+        let git_dispatcher = rpc::git::GitDispatcher::new(cwd.clone(), base_branch);
+        // A run-owned step agent also gets the workflow comms ops (wf_report /
+        // wf_ask / wf_notify, §10); everything else still falls through to the
+        // git dispatcher. Plain agents keep the git dispatcher unchanged.
+        let rpc_dispatcher: Arc<dyn rpc::RpcDispatcher> = match &record.owner_run_id {
+            Some(_) => Arc::new(crate::workflow::comms::WorkflowCommsDispatcher::new(
+                app.clone(),
+                agent_id.to_string(),
+                git_dispatcher,
+            )),
+            None => Arc::new(git_dispatcher),
+        };
 
         // Claude only writes a session file once the first turn lands.
         // If task is still empty (no first user message has ever been

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -645,6 +645,13 @@ impl Supervisor {
 
         spawn_turn_watchdog(self.clone(), app.clone(), agent_id_str.clone(), my_gen);
 
+        // Register the dispatcher so the mailbox can also be drained on demand
+        // (`settle_agent_rpc`), not only on the watcher's tick. Overwrites any
+        // prior generation's entry.
+        self.rpc_dispatchers
+            .lock()
+            .insert(agent_id_str.clone(), rpc_dispatcher.clone());
+
         // Watch this agent's RPC mailbox for the life of this generation,
         // executing allowlisted ops and writing responses back.
         spawn_rpc_watcher(

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -91,6 +91,12 @@ pub struct Supervisor {
     /// never persisted (see `session_sync`). Behind an `Arc` so the fire-and-
     /// forget sync task can hold it without borrowing `self`.
     pub sync_health: Arc<Mutex<HashMap<String, session_sync::SyncHealth>>>,
+    /// Per-agent RPC dispatchers, so the mailbox can be drained on demand
+    /// (`settle_agent_rpc`) in addition to the polling watcher — the scheduler
+    /// drains a step agent's mailbox at turn end so a `wf_ask` is dispatched
+    /// before it acts on the gate (§10.4). Overwritten on each (re)spawn; removed
+    /// on teardown.
+    pub rpc_dispatchers: Mutex<HashMap<String, Arc<dyn crate::rpc::RpcDispatcher>>>,
     /// Fan-out of every runtime status transition (see [`StatusEvent`]). Held
     /// as the sender; subscribers call [`Supervisor::subscribe_status`]. The
     /// supervisor never reads it, so a dropped-receiver `send` error is ignored.
@@ -112,11 +118,29 @@ impl Supervisor {
             message_queue: Mutex::new(MessageQueue::new()),
             interrupted: Mutex::new(HashSet::new()),
             sync_health: Arc::new(Mutex::new(HashMap::new())),
+            rpc_dispatchers: Mutex::new(HashMap::new()),
             // Capacity is generous: a lagging subscriber gets `Lagged` and
             // re-reads `status_of`, so overflow degrades to a resync, never a
             // lost terminal state. 1024 covers bursts across many live agents.
             status_tx: broadcast::channel(1024).0,
         }
+    }
+
+    /// Drain `agent_id`'s RPC mailbox once, synchronously, dispatching any
+    /// requests it has already written (e.g. a `wf_ask` from the turn that just
+    /// ended) before the caller acts on that turn's result. The per-agent watcher
+    /// also processes on its tick; `process_pending` is idempotent and
+    /// in-flight-guarded, so the two never double-dispatch. A no-op for an agent
+    /// with no registered dispatcher.
+    pub async fn settle_agent_rpc(self: &Arc<Self>, app: &tauri::AppHandle, agent_id: &str) {
+        let dispatcher = self.rpc_dispatchers.lock().get(agent_id).cloned();
+        let Some(dispatcher) = dispatcher else {
+            return;
+        };
+        let Ok(rpc_dir) = crate::rpc::mailbox_dir(agent_id) else {
+            return;
+        };
+        rpc_watch::process_agent_rpc_once(self, app, agent_id, dispatcher.as_ref(), &rpc_dir).await;
     }
 
     /// Subscribe to runtime status transitions across all agents. To avoid a

--- a/src-tauri/src/supervisor/rpc_watch.rs
+++ b/src-tauri/src/supervisor/rpc_watch.rs
@@ -40,12 +40,29 @@ pub(super) fn spawn_rpc_watcher(
                 return;
             }
 
-            let events = rpc::process_pending(&rpc_dir, dispatcher.as_ref()).await;
-            for event in events {
-                handle_rpc_event(&sup, &app, &agent_id, event);
-            }
+            process_agent_rpc_once(&sup, &app, &agent_id, dispatcher.as_ref(), &rpc_dir).await;
         }
     });
+}
+
+/// Process every request currently pending in `agent_id`'s mailbox once, applying
+/// the resulting git/PR events. Shared by the polling watcher and the scheduler's
+/// synchronous drain (`Supervisor::settle_agent_rpc`): `process_pending` is
+/// idempotent and in-flight-guarded, so a concurrent tick and drain never
+/// double-dispatch. A request the agent wrote during its turn (e.g. a `wf_ask`)
+/// is therefore dispatched — and its message persisted — deterministically before
+/// the scheduler acts on that turn's gate outcome (§10.4).
+pub(super) async fn process_agent_rpc_once(
+    sup: &Arc<Supervisor>,
+    app: &AppHandle,
+    agent_id: &str,
+    dispatcher: &dyn rpc::RpcDispatcher,
+    rpc_dir: &std::path::Path,
+) {
+    let events = rpc::process_pending(rpc_dir, dispatcher).await;
+    for event in events {
+        handle_rpc_event(sup, app, agent_id, event);
+    }
 }
 
 fn handle_rpc_event(sup: &Supervisor, app: &AppHandle, agent_id: &str, event: rpc::RpcEvent) {

--- a/src-tauri/src/workflow/attempt.rs
+++ b/src-tauri/src/workflow/attempt.rs
@@ -85,6 +85,13 @@ pub struct AttemptParams {
     /// can be stopped; no spawn-race leak) and during the ready/turn waits. The
     /// linear path passes a never-set flag.
     pub cancel: Arc<AtomicBool>,
+    /// Raised by the comms router when this step has an unanswered `wf_ask`
+    /// routed to the human (spec §10.4). Checked at each turn end: while set, the
+    /// gate is **not** evaluated — the run pauses `question` instead of gating on
+    /// the wrong turn. Shared with the run's [`RunHandle`] so the router (running
+    /// in the RPC watcher task) and this attempt observe the same flag. Defaults
+    /// to a never-set flag for runs without comms and for `MockDriver` tests.
+    pub pending_ask: Arc<AtomicBool>,
 }
 
 /// The terminal outcome of an attempt (maps onto the §6.2 attempt states).
@@ -97,6 +104,11 @@ pub enum AttemptOutcome {
     Blocked { reason: String },
     /// Approval gate → run pauses `approval`; a human resolves via `wf_approve`.
     AwaitingApproval,
+    /// The step raised a `wf_ask` routed to the human and the gate is deferred
+    /// (spec §10.4): the run pauses `question` without gating; the scheduler
+    /// stops the agent and, on `wf_answer`, resumes with a fresh attempt that
+    /// carries the answer.
+    AwaitingAnswer,
     /// Spawn/turn-start timeout, agent error, or an exhausted stall → the
     /// scheduler applies the retry policy (spec §6.5).
     Error { error: String },
@@ -166,6 +178,7 @@ pub async fn run_attempt(
         deadlines,
         reprompt_on_block,
         cancel,
+        pending_ask,
     } = params;
 
     let fork_base = spawn_req.fork_base.clone();
@@ -307,6 +320,20 @@ pub async fn run_attempt(
         // Enforcement point: at every turn end (spec §11.2).
         if let Some(which) = ledger.exceeded(eff, super::now_ms()) {
             return budget_exceeded_run(agent_id, worktree, which, events);
+        }
+
+        // Pending-ask deferral (spec §6.3 step 5, §10.4): if the step raised a
+        // `wf_ask` routed to the human during this turn, the gate is not
+        // evaluated — the run pauses `question` and the answer arrives on a
+        // fresh attempt. Checked before gating so a turn that both asks and
+        // writes a done-verdict still defers.
+        if pending_ask.load(Ordering::SeqCst) {
+            return AttemptRun {
+                agent_id: Some(agent_id),
+                worktree: Some(worktree),
+                outcome: AttemptOutcome::AwaitingAnswer,
+                events,
+            };
         }
 
         // Gate — pure evaluation over freshly gathered facts (spec §6.3 step 6).
@@ -676,6 +703,7 @@ mod tests {
             deadlines,
             reprompt_on_block: true,
             cancel: Arc::new(AtomicBool::new(false)),
+            pending_ask: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -740,6 +768,34 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    async fn pending_ask_defers_the_gate() {
+        // The step wrote a done-verdict during its turn, but it also raised a
+        // wf_ask routed to the human (pending_ask set). The gate must NOT fire;
+        // the attempt returns AwaitingAnswer so the run pauses `question`
+        // (spec §6.3 step 5, §10.4).
+        let bb = tempfile::tempdir().unwrap();
+        let d = MockDriver::new();
+        d.set_ready_on_spawn(true);
+        d.set_turn_behavior(TurnBehavior::Complete);
+        let step_dir = blackboard::step_dir(bb.path(), "plan").unwrap();
+        d.set_complete_verdict(step_dir, r#"{"result":"done","summary":"ok"}"#);
+
+        let mut p = params(Gate::Verdict, bb.path().to_path_buf(), fast());
+        p.pending_ask = Arc::new(AtomicBool::new(true));
+        let run = run(d.as_ref(), &NeverTests, p).await;
+        assert!(
+            matches!(run.outcome, AttemptOutcome::AwaitingAnswer),
+            "{:?}",
+            run.outcome
+        );
+        // The gate was never evaluated while the ask was pending.
+        assert!(
+            !types_present(&run.events, event_type::GATE_EVALUATED),
+            "gate must not be evaluated with a pending ask"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn spawn_timeout_when_never_ready() {
         let bb = tempfile::tempdir().unwrap();
         let d = MockDriver::new();
@@ -785,7 +841,7 @@ mod tests {
         d.set_ready_on_spawn(true);
         let mut p = params(Gate::Verdict, bb.path().to_path_buf(), fast());
         p.cancel = Arc::new(AtomicBool::new(true)); // already cancelled at entry
-        let run = run(d.as_ref(), p).await;
+        let run = run(d.as_ref(), &NeverTests, p).await;
         assert!(
             matches!(run.outcome, AttemptOutcome::Canceled),
             "{:?}",

--- a/src-tauri/src/workflow/comms.rs
+++ b/src-tauri/src/workflow/comms.rs
@@ -186,6 +186,24 @@ pub(super) fn take_pending_deliveries(
     msgs
 }
 
+/// Does this attempt have a `wf_ask` still awaiting a human answer? The
+/// persisted message is the source of truth (spec §8.4 "event-sourced truth"):
+/// the in-memory pending-ask poke is best-effort and can be missed if the RPC
+/// op races the driver's wind-down, so the scheduler consults this before acting
+/// on a turn's gate outcome — a queued ask always pauses the run `question`
+/// rather than letting the gate be acted on (§10.4).
+pub(super) fn has_unanswered_ask(conn: &Connection, step_exec_id: &str) -> bool {
+    conn.query_row(
+        "SELECT 1 FROM wf_message
+         WHERE from_step_exec_id = ?1 AND kind = 'ask' AND status = 'queued' LIMIT 1",
+        [step_exec_id],
+        |_| Ok(()),
+    )
+    .optional()
+    .unwrap_or(None)
+    .is_some()
+}
+
 // ───────────────────────────── sender resolution ────────────────────────────
 
 /// The run/step context of the agent that issued a comms op.
@@ -226,36 +244,55 @@ fn step_caps(spec: &Spec, step_id: &str) -> Option<Vec<CommsCap>> {
     walk(&spec.workflow, step_id).map(<[CommsCap]>::to_vec)
 }
 
-/// Resolve the live step attempt behind a run-owned agent's mailbox. Errors if
-/// the agent has no attempt, its attempt is terminal (not live), or its step is
-/// missing from the launch snapshot.
-fn resolve_sender(conn: &Connection, agent_id: &str) -> Result<Sender> {
-    let (step_exec_id, run_id, step_id, status) = conn
-        .query_row(
-            "SELECT id, run_id, step_id, status FROM wf_step_exec
-             WHERE agent_id = ?1 ORDER BY rowid DESC LIMIT 1",
-            [agent_id],
-            |r| {
+/// Resolve the live step attempt behind a run-owned agent's mailbox. Keyed by
+/// `run_id` (which the dispatcher captures from the agent's `owner_run_id` at
+/// spawn) rather than `agent_id`: the scheduler only stamps `wf_step_exec.
+/// agent_id` *after* the turn completes, so during the turn — exactly when a
+/// comms op fires — that column is still NULL and an agent-id lookup would miss.
+/// When the row is already linked to `agent_id` (a future/parallel case) that
+/// row is preferred; otherwise the run's single in-flight attempt is used, and
+/// concurrent in-flight attempts (parallel comms, unsupported in v1) are an
+/// explicit error rather than a silent misattribution.
+fn resolve_sender(conn: &Connection, run_id: &str, agent_id: &str) -> Result<Sender> {
+    let live: Vec<(String, String, Option<String>)> = conn
+        .prepare(
+            "SELECT id, step_id, agent_id FROM wf_step_exec
+             WHERE run_id = ?1 AND status IN ('spawning','running','gating')
+             ORDER BY rowid DESC",
+        )
+        .and_then(|mut s| {
+            s.query_map([run_id], |r| {
                 Ok((
                     r.get::<_, String>(0)?,
                     r.get::<_, String>(1)?,
-                    r.get::<_, String>(2)?,
-                    r.get::<_, String>(3)?,
+                    r.get::<_, Option<String>>(2)?,
                 ))
-            },
-        )
-        .optional()
-        .map_err(|e| Error::Other(e.to_string()))?
-        .ok_or_else(|| Error::Other("no workflow step for this agent".into()))?;
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()
+        })
+        .map_err(|e| Error::Other(e.to_string()))?;
 
-    if !matches!(status.as_str(), "spawning" | "running" | "gating") {
-        return Err(Error::Other("this step's attempt is no longer live".into()));
-    }
+    let (step_exec_id, step_id) =
+        if let Some((id, step, _)) = live.iter().find(|(_, _, a)| a.as_deref() == Some(agent_id)) {
+            (id.clone(), step.clone())
+        } else {
+            match live.as_slice() {
+                [] => return Err(Error::Other("no live step for this run".into())),
+                [(id, step, _)] => (id.clone(), step.clone()),
+                _ => {
+                    return Err(Error::Other(
+                        "cannot attribute a comms op among concurrent steps \
+                     (parallel comms is not supported yet)"
+                            .into(),
+                    ))
+                }
+            }
+        };
 
     let spec_json: String = conn
         .query_row(
             "SELECT spec_json FROM wf_run WHERE id = ?1",
-            [&run_id],
+            [run_id],
             |r| r.get(0),
         )
         .map_err(|e| Error::Other(e.to_string()))?;
@@ -264,7 +301,7 @@ fn resolve_sender(conn: &Connection, agent_id: &str) -> Result<Sender> {
         .ok_or_else(|| Error::Other(format!("step '{step_id}' not found in run spec")))?;
 
     Ok(Sender {
-        run_id,
+        run_id: run_id.to_string(),
         step_exec_id,
         step_id,
         caps,
@@ -289,11 +326,12 @@ fn route(
     conn: &Connection,
     app: Option<&AppHandle>,
     id: &str,
+    run_id: &str,
     agent_id: &str,
     op: &str,
     args: &Value,
 ) -> (Response, Poke) {
-    let sender = match resolve_sender(conn, agent_id) {
+    let sender = match resolve_sender(conn, run_id, agent_id) {
         Ok(s) => s,
         Err(e) => return (Response::err(id, e.to_string()), Poke::None),
     };
@@ -476,6 +514,7 @@ impl WorkflowService {
     pub(super) fn handle_comms_op(
         &self,
         id: &str,
+        run_id: &str,
         agent_id: &str,
         op: &str,
         args: &Value,
@@ -485,7 +524,7 @@ impl WorkflowService {
         // DB lock's work).
         let (resp, poke) = {
             let conn = self.db.lock();
-            route(&conn, Some(&self.app), id, agent_id, op, args)
+            route(&conn, Some(&self.app), id, run_id, agent_id, op, args)
         };
         if let Poke::AskQueued { run_id } = poke {
             // Raise the run's pending-ask flag so the in-flight attempt defers its
@@ -572,13 +611,22 @@ fn new_msg_id() -> String {
 /// `supervisor::lifecycle` when an agent has an `owner_run_id`.
 pub struct WorkflowCommsDispatcher {
     app: AppHandle,
+    /// The run that owns this agent (its `owner_run_id`), captured at spawn. Comms
+    /// ops resolve the sender by run — `wf_step_exec.agent_id` is stamped only
+    /// after the turn, so it can't key resolution during the turn.
+    run_id: String,
     agent_id: String,
     git: GitDispatcher,
 }
 
 impl WorkflowCommsDispatcher {
-    pub fn new(app: AppHandle, agent_id: String, git: GitDispatcher) -> Self {
-        Self { app, agent_id, git }
+    pub fn new(app: AppHandle, run_id: String, agent_id: String, git: GitDispatcher) -> Self {
+        Self {
+            app,
+            run_id,
+            agent_id,
+            git,
+        }
     }
 }
 
@@ -592,7 +640,10 @@ impl RpcDispatcher for WorkflowCommsDispatcher {
         Box::pin(async move {
             if is_comms_op(op) {
                 match self.app.try_state::<Arc<WorkflowService>>() {
-                    Some(svc) => svc.inner().handle_comms_op(id, &self.agent_id, op, args),
+                    Some(svc) => {
+                        svc.inner()
+                            .handle_comms_op(id, &self.run_id, &self.agent_id, op, args)
+                    }
                     None => (
                         Response::err(id, "workflow service unavailable"),
                         Vec::new(),
@@ -755,6 +806,7 @@ mod tests {
             &conn,
             None,
             "req-1",
+            "run",
             "agent-1",
             "wf_report",
             &json!({ "status": "progress", "note": "halfway" }),
@@ -790,6 +842,7 @@ mod tests {
             &conn,
             None,
             "req-1",
+            "run",
             "agent-1",
             "wf_report",
             &json!({ "note": "x" }),
@@ -816,6 +869,7 @@ mod tests {
             &conn,
             None,
             "req-1",
+            "run",
             "agent-1",
             "wf_ask",
             &json!({ "question": "which db?" }),
@@ -841,6 +895,7 @@ mod tests {
             &conn,
             None,
             "req-1",
+            "run",
             "agent-1",
             "wf_ask",
             &json!({ "question": "   " }),
@@ -858,6 +913,7 @@ mod tests {
             &conn,
             None,
             "req-1",
+            "run",
             "agent-1",
             "wf_ask",
             &json!({ "question": "which db?" }),
@@ -905,5 +961,84 @@ mod tests {
         .unwrap();
         let err = deliver_answer(&conn, None, &run, "nope", "x");
         assert!(err.is_err());
+    }
+
+    #[test]
+    fn resolves_sender_before_agent_id_is_stamped() {
+        // The scheduler stamps `wf_step_exec.agent_id` only after the turn ends,
+        // but comms ops fire *during* the turn. Resolution must work off the
+        // run's live attempt while that column is still NULL — otherwise every
+        // mid-turn wf_ask/wf_report would fail with "no workflow step".
+        let (conn, _run, exec) = seed(vec![CommsCap::Ask]);
+        conn.execute(
+            "UPDATE wf_step_exec SET agent_id = NULL WHERE id = ?1",
+            [&exec],
+        )
+        .unwrap();
+        let (resp, poke) = route(
+            &conn,
+            None,
+            "req-1",
+            "run",
+            "agent-1",
+            "wf_ask",
+            &json!({ "question": "which db?" }),
+        );
+        assert!(
+            resp.ok,
+            "must resolve by run while agent_id is NULL: {resp:?}"
+        );
+        assert!(matches!(poke, Poke::AskQueued { .. }));
+    }
+
+    #[test]
+    fn concurrent_live_attempts_are_not_misattributed() {
+        // Parallel comms is unsupported in v1: with two in-flight attempts and no
+        // agent_id link yet, the router refuses rather than guess a sender.
+        let (conn, _run, _exec) = seed(vec![CommsCap::Ask]);
+        conn.execute(
+            "UPDATE wf_step_exec SET agent_id = NULL WHERE id = 'exec-1'",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO wf_step_exec (id,run_id,step_id,attempt,iteration,status,gate_mode)
+             VALUES ('exec-2','run','s1',1,0,'running','verdict')",
+            [],
+        )
+        .unwrap();
+        let (resp, _poke) = route(
+            &conn,
+            None,
+            "req-1",
+            "run",
+            "agent-1",
+            "wf_ask",
+            &json!({ "question": "q" }),
+        );
+        assert!(!resp.ok);
+        assert!(resp.error.unwrap().contains("concurrent"));
+    }
+
+    #[test]
+    fn has_unanswered_ask_tracks_queued_then_answered() {
+        let (conn, run, exec) = seed(vec![CommsCap::Ask]);
+        assert!(!has_unanswered_ask(&conn, &exec), "no ask yet");
+        let (resp, _) = route(
+            &conn,
+            None,
+            "req-1",
+            "run",
+            "agent-1",
+            "wf_ask",
+            &json!({ "question": "q" }),
+        );
+        let ask_id = resp.stdout.unwrap();
+        assert!(has_unanswered_ask(&conn, &exec), "queued ask is pending");
+        deliver_answer(&conn, None, &run, &ask_id, "yes").unwrap();
+        assert!(
+            !has_unanswered_ask(&conn, &exec),
+            "answered ask is no longer pending"
+        );
     }
 }

--- a/src-tauri/src/workflow/comms.rs
+++ b/src-tauri/src/workflow/comms.rs
@@ -443,10 +443,27 @@ fn route_ask(
 fn deliver_answer(
     conn: &Connection,
     app: Option<&AppHandle>,
+    project_id: &str,
     run_id: &str,
     message_id: &str,
     body: &str,
 ) -> Result<()> {
+    // Scope the answer to the caller's project (mirrors `wf_list_runs`): the run
+    // must belong to `project_id`. Not a cross-user boundary — this is a
+    // single-user desktop app — but it keeps a confused frontend from answering a
+    // run outside the project context it's operating in.
+    let proj: Option<String> = conn
+        .query_row(
+            "SELECT project_id FROM wf_run WHERE id = ?1",
+            [run_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(|e| Error::Other(e.to_string()))?;
+    if proj.as_deref() != Some(project_id) {
+        return Err(Error::Other("run not found in this project".into()));
+    }
+
     let (status, reason) = scheduler::run_status(conn, run_id)?;
     if status != "paused" || reason.as_deref() != Some("question") {
         return Err(Error::Other(format!(
@@ -539,10 +556,16 @@ impl WorkflowService {
     /// Deliver a human's answer to a paused `question` run and resume it
     /// (`wf_answer`, spec §13). The scheduler folds the answer into the fresh
     /// attempt's prompt on resume.
-    pub(super) fn answer(&self, run_id: &str, message_id: &str, body: &str) -> Result<()> {
+    pub(super) fn answer(
+        &self,
+        project_id: &str,
+        run_id: &str,
+        message_id: &str,
+        body: &str,
+    ) -> Result<()> {
         {
             let conn = self.db.lock();
-            deliver_answer(&conn, Some(&self.app), run_id, message_id, body)?;
+            deliver_answer(&conn, Some(&self.app), project_id, run_id, message_id, body)?;
         }
         // Resume: the drive loop starts a fresh attempt for the asking step (the
         // asking attempt was abandoned at the pause).
@@ -663,13 +686,14 @@ type Svc<'a> = tauri::State<'a, Arc<WorkflowService>>;
 /// Answer a paused `question` and resume the run (spec §13, §10.4).
 #[tauri::command]
 pub async fn wf_answer(
+    project_id: String,
     run_id: String,
     message_id: String,
     body: String,
     service: Svc<'_>,
 ) -> std::result::Result<(), String> {
     service
-        .answer(&run_id, &message_id, &body)
+        .answer(&project_id, &run_id, &message_id, &body)
         .map_err(|e| e.to_string())
 }
 
@@ -921,7 +945,7 @@ mod tests {
         let ask_id = resp.stdout.clone().unwrap();
 
         // The human answers.
-        deliver_answer(&conn, None, &run, &ask_id, "Postgres").unwrap();
+        deliver_answer(&conn, None, "p", &run, &ask_id, "Postgres").unwrap();
 
         // The ask is answered; a queued answer targets the asking attempt.
         let ask_status: String = conn
@@ -959,8 +983,33 @@ mod tests {
             [],
         )
         .unwrap();
-        let err = deliver_answer(&conn, None, &run, "nope", "x");
+        let err = deliver_answer(&conn, None, "p", &run, "nope", "x");
         assert!(err.is_err());
+    }
+
+    #[test]
+    fn answer_rejects_a_run_outside_the_project() {
+        let (conn, run, _exec) = seed(vec![CommsCap::Ask]);
+        let (resp, _) = route(
+            &conn,
+            None,
+            "req-1",
+            "run",
+            "agent-1",
+            "wf_ask",
+            &json!({ "question": "q" }),
+        );
+        let ask_id = resp.stdout.unwrap();
+        // The run belongs to project "p"; a caller scoped to another project
+        // cannot answer it, and nothing is enqueued.
+        let err = deliver_answer(&conn, None, "other", &run, &ask_id, "x");
+        assert!(err.is_err(), "answer must be scoped to the run's project");
+        assert_eq!(
+            count(&conn, "SELECT COUNT(*) FROM wf_message WHERE kind='answer'"),
+            0
+        );
+        // The correct project succeeds.
+        deliver_answer(&conn, None, "p", &run, &ask_id, "x").unwrap();
     }
 
     #[test]
@@ -1065,7 +1114,7 @@ mod tests {
         );
         let ask_id = resp.stdout.unwrap();
         assert!(has_unanswered_ask(&conn, &exec), "queued ask is pending");
-        deliver_answer(&conn, None, &run, &ask_id, "yes").unwrap();
+        deliver_answer(&conn, None, "p", &run, &ask_id, "yes").unwrap();
         assert!(
             !has_unanswered_ask(&conn, &exec),
             "answered ask is no longer pending"

--- a/src-tauri/src/workflow/comms.rs
+++ b/src-tauri/src/workflow/comms.rs
@@ -1,0 +1,909 @@
+//! The comms router (TECH_SPEC §10.1, §10.4): host-brokered messaging between a
+//! step agent and the workflow. Step agents call the `wf_report` / `wf_ask` /
+//! `wf_notify` RPC ops through their private mailbox; this module validates each
+//! against the step's declared caps, persists it to `wf_message`, journals it,
+//! and — for a `wf_ask` with no orchestrator (v1) — signals the run to pause for
+//! the human.
+//!
+//! **The engine is the only prompter (§10.4).** The router never sends a prompt
+//! or touches the message queue directly. It appends to the recipient's inbox
+//! (`wf_message`) and pokes the run's driver; the scheduler is the sole prompter,
+//! folding pending inbox messages into one engine-composed prompt
+//! ([`compose_delivery`]) at a turn boundary. That keeps turn accounting
+//! deterministic and gate evaluation on the right turn.
+//!
+//! The routing/persistence/journaling core is written as free functions taking
+//! `Option<&AppHandle>` (mirroring the scheduler's testable seam), so the whole
+//! matrix is exercised against a temp DB with no live app. [`WorkflowService`]
+//! adds only the two things that need the live registry: poking the driver on an
+//! ask, and resuming the run on `wf_answer`.
+//!
+//! Scope (S10): `report` / `ask` / `notify` + human Q&A. The orchestrator role
+//! (`decide` / `compose`, auto-forwarding lifecycle events, routing `ask` to an
+//! orchestrator) lands in S11; until then an `ask` with no orchestrator routes to
+//! the human, which is the complete, useful v1 behavior.
+
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use rusqlite::{params, Connection, OptionalExtension};
+use serde_json::{json, Value};
+use tauri::{AppHandle, Manager};
+
+use crate::error::{Error, Result};
+use crate::rpc::git::GitDispatcher;
+use crate::rpc::{Response, RpcDispatcher, RpcEvent, RpcFuture};
+
+use super::now_ms;
+use super::scheduler::{self, WorkflowService};
+use super::spec::{Block, CommsCap, Spec};
+use super::types::{event_type, Message, MessageKind};
+
+// ───────────────────────────── caps matrix (pure) ───────────────────────────
+
+/// The cap an RPC op requires, if it is a comms op (spec §10.1).
+pub(super) fn cap_for_op(op: &str) -> Option<CommsCap> {
+    match op {
+        "wf_report" => Some(CommsCap::Report),
+        "wf_ask" => Some(CommsCap::Ask),
+        "wf_notify" => Some(CommsCap::Notify),
+        _ => None,
+    }
+}
+
+/// Is `op` one this router owns? (Everything else falls through to git.)
+pub(super) fn is_comms_op(op: &str) -> bool {
+    cap_for_op(op).is_some()
+}
+
+/// Human-readable verb for a rejection message.
+fn op_verb(op: &str) -> &'static str {
+    match op {
+        "wf_report" => "report",
+        "wf_ask" => "ask",
+        "wf_notify" => "notify",
+        _ => "use that op",
+    }
+}
+
+/// Validate a comms op against a step's declared caps (spec §10.1). A step with
+/// `notify` never exists (spec validation forbids it), so `wf_notify` from a step
+/// is always rejected here — the deterministic engine, not the agent, is the
+/// authority.
+pub(super) fn check_cap(op: &str, caps: &[CommsCap]) -> std::result::Result<(), String> {
+    match cap_for_op(op) {
+        None => Err(format!("unknown comms op: {op}")),
+        Some(cap) if caps.contains(&cap) => Ok(()),
+        Some(_) => Err(format!(
+            "this step is not permitted to {} (declare `{}` in its comms caps)",
+            op_verb(op),
+            op_verb(op)
+        )),
+    }
+}
+
+// ───────────────────────────── delivery (pure) ──────────────────────────────
+
+/// Compose the single engine-owned prompt preamble that carries messages
+/// delivered to a step while it waited (spec §10.4). Many messages coalesce into
+/// one preamble, so one turn covers all of them.
+pub(super) fn compose_delivery(msgs: &[Message]) -> String {
+    let mut s = String::from(
+        "## Messages from the workflow\n\n\
+         While this step was waiting, the workflow delivered the following. \
+         Read them, then continue your work.\n\n",
+    );
+    for m in msgs {
+        match m.kind {
+            MessageKind::Answer => {
+                let text = body_str(&m.body, "text");
+                s.push_str(&format!("- **Answer to your question:** {text}\n"));
+            }
+            MessageKind::Notify => {
+                let text = body_str(&m.body, "message");
+                s.push_str(&format!("- **Notice:** {text}\n"));
+            }
+            // Only answer/notify are ever queued *for* a step; other kinds are
+            // outbound. Ignore defensively rather than render an empty bullet.
+            _ => {}
+        }
+    }
+    s
+}
+
+fn body_str<'a>(body: &'a Value, key: &str) -> &'a str {
+    body.get(key).and_then(|v| v.as_str()).unwrap_or("")
+}
+
+// ───────────────────────────── persistence ──────────────────────────────────
+
+#[allow(clippy::too_many_arguments)]
+fn insert_message(
+    conn: &Connection,
+    id: &str,
+    run_id: &str,
+    from: Option<&str>,
+    to: Option<&str>,
+    kind: &str,
+    body: &Value,
+    status: &str,
+    delivered: bool,
+) -> rusqlite::Result<()> {
+    let now = now_ms();
+    conn.execute(
+        "INSERT INTO wf_message
+           (id, run_id, from_step_exec_id, to_step_exec_id, kind, body_json, status,
+            created_at, delivered_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        params![
+            id,
+            run_id,
+            from,
+            to,
+            kind,
+            body.to_string(),
+            status,
+            now,
+            if delivered { Some(now) } else { None },
+        ],
+    )?;
+    Ok(())
+}
+
+/// Read (and mark delivered) every message queued for delivery to `step_id`'s
+/// attempts — a human's `wf_answer`, later an orchestrator notify. Joins through
+/// the recipient step-exec so an answer addressed to an earlier (now abandoned)
+/// attempt still reaches the step's fresh attempt. Marking them `delivered` here
+/// makes the fold idempotent across a step's attempts (spec §10.4).
+pub(super) fn take_pending_deliveries(
+    conn: &Connection,
+    run_id: &str,
+    step_id: &str,
+) -> Vec<Message> {
+    let msgs: Vec<Message> = conn
+        .prepare(
+            "SELECT m.* FROM wf_message m
+               JOIN wf_step_exec e ON m.to_step_exec_id = e.id
+             WHERE e.run_id = ?1 AND e.step_id = ?2
+               AND m.status = 'queued' AND m.kind IN ('answer', 'notify')
+             ORDER BY m.created_at, m.rowid",
+        )
+        .and_then(|mut stmt| {
+            stmt.query_map(params![run_id, step_id], Message::from_row)?
+                .collect::<rusqlite::Result<Vec<_>>>()
+        })
+        .unwrap_or_default();
+
+    if !msgs.is_empty() {
+        let now = now_ms();
+        for m in &msgs {
+            let _ = conn.execute(
+                "UPDATE wf_message SET status = 'delivered', delivered_at = ?1 WHERE id = ?2",
+                params![now, m.id],
+            );
+        }
+    }
+    msgs
+}
+
+// ───────────────────────────── sender resolution ────────────────────────────
+
+/// The run/step context of the agent that issued a comms op.
+struct Sender {
+    run_id: String,
+    step_exec_id: String,
+    step_id: String,
+    caps: Vec<CommsCap>,
+}
+
+/// Find a `Step` anywhere in a block tree, so a sender's caps resolve regardless
+/// of where the step sits (top level, loop body, parallel/orchestrate children).
+fn step_caps(spec: &Spec, step_id: &str) -> Option<Vec<CommsCap>> {
+    fn walk<'a>(blocks: &'a [Block], id: &str) -> Option<&'a [CommsCap]> {
+        for b in blocks {
+            match b {
+                Block::Step(s) if s.id == id => return Some(&s.comms),
+                Block::Step(_) => {}
+                Block::Loop(l) => {
+                    if let Some(c) = walk(&l.body, id) {
+                        return Some(c);
+                    }
+                }
+                Block::Parallel(p) => {
+                    if let Some(s) = p.steps.iter().find(|s| s.id == id) {
+                        return Some(&s.comms);
+                    }
+                }
+                Block::Orchestrate(o) => {
+                    if let Some(s) = o.body.iter().find(|s| s.id == id) {
+                        return Some(&s.comms);
+                    }
+                }
+            }
+        }
+        None
+    }
+    walk(&spec.workflow, step_id).map(<[CommsCap]>::to_vec)
+}
+
+/// Resolve the live step attempt behind a run-owned agent's mailbox. Errors if
+/// the agent has no attempt, its attempt is terminal (not live), or its step is
+/// missing from the launch snapshot.
+fn resolve_sender(conn: &Connection, agent_id: &str) -> Result<Sender> {
+    let (step_exec_id, run_id, step_id, status) = conn
+        .query_row(
+            "SELECT id, run_id, step_id, status FROM wf_step_exec
+             WHERE agent_id = ?1 ORDER BY rowid DESC LIMIT 1",
+            [agent_id],
+            |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, String>(3)?,
+                ))
+            },
+        )
+        .optional()
+        .map_err(|e| Error::Other(e.to_string()))?
+        .ok_or_else(|| Error::Other("no workflow step for this agent".into()))?;
+
+    if !matches!(status.as_str(), "spawning" | "running" | "gating") {
+        return Err(Error::Other("this step's attempt is no longer live".into()));
+    }
+
+    let spec_json: String = conn
+        .query_row(
+            "SELECT spec_json FROM wf_run WHERE id = ?1",
+            [&run_id],
+            |r| r.get(0),
+        )
+        .map_err(|e| Error::Other(e.to_string()))?;
+    let spec: Spec = serde_json::from_str(&spec_json).map_err(|e| Error::Other(e.to_string()))?;
+    let caps = step_caps(&spec, &step_id)
+        .ok_or_else(|| Error::Other(format!("step '{step_id}' not found in run spec")))?;
+
+    Ok(Sender {
+        run_id,
+        step_exec_id,
+        step_id,
+        caps,
+    })
+}
+
+// ───────────────────────────── routing core (testable) ──────────────────────
+
+/// What the router decided a comms op needs the caller to do next.
+enum Poke {
+    /// Nothing beyond the response (report / rejection).
+    None,
+    /// A `wf_ask` to the human was queued for `run_id`: raise its pending-ask
+    /// flag so the attempt pauses `question` at turn end (§10.4).
+    AskQueued { run_id: String },
+}
+
+/// The validated, persisted, journaled handling of one comms op. Free of the run
+/// registry and `AppHandle` so it is unit-testable; the caller performs the
+/// `Poke`. `app` is `None` under test.
+fn route(
+    conn: &Connection,
+    app: Option<&AppHandle>,
+    id: &str,
+    agent_id: &str,
+    op: &str,
+    args: &Value,
+) -> (Response, Poke) {
+    let sender = match resolve_sender(conn, agent_id) {
+        Ok(s) => s,
+        Err(e) => return (Response::err(id, e.to_string()), Poke::None),
+    };
+    if let Err(e) = check_cap(op, &sender.caps) {
+        // Journaled, never a silent drop (§10.1): the timeline shows the denied
+        // attempt.
+        journal_denied(conn, app, &sender, op, &e);
+        return (Response::err(id, e), Poke::None);
+    }
+
+    match op {
+        "wf_report" => (route_report(conn, app, &sender, id, args), Poke::None),
+        "wf_ask" => route_ask(conn, app, &sender, id, args),
+        // `wf_notify` is orchestrator-only; check_cap already rejected it for a
+        // step. Reachable only if a future block granted the cap — refuse until
+        // S11 wires orchestrator delivery.
+        "wf_notify" => (
+            Response::err(id, "notify is not available in this workflow yet"),
+            Poke::None,
+        ),
+        other => (
+            Response::err(id, format!("unknown op: {other}")),
+            Poke::None,
+        ),
+    }
+}
+
+fn route_report(
+    conn: &Connection,
+    app: Option<&AppHandle>,
+    sender: &Sender,
+    id: &str,
+    args: &Value,
+) -> Response {
+    let note = args.get("note").and_then(|v| v.as_str()).unwrap_or("");
+    let status = args
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("progress");
+    if !matches!(status, "progress" | "done") {
+        return Response::err(id, "wf_report `status` must be \"progress\" or \"done\"");
+    }
+    let body = json!({ "status": status, "note": note });
+    let msg_id = new_msg_id();
+    // No orchestrator in v1: a report is recorded on the timeline and otherwise a
+    // no-op (it never replaces the verdict). Marked delivered — nothing to route.
+    if let Err(e) = insert_message(
+        conn,
+        &msg_id,
+        &sender.run_id,
+        Some(&sender.step_exec_id),
+        None,
+        "report",
+        &body,
+        "delivered",
+        true,
+    ) {
+        return Response::err(id, e.to_string());
+    }
+    journal_routed(conn, app, sender, &msg_id, "report", None);
+    Response::ok(id, 0, msg_id, String::new())
+}
+
+fn route_ask(
+    conn: &Connection,
+    app: Option<&AppHandle>,
+    sender: &Sender,
+    id: &str,
+    args: &Value,
+) -> (Response, Poke) {
+    let question = args.get("question").and_then(|v| v.as_str()).unwrap_or("");
+    if question.trim().is_empty() {
+        return (
+            Response::err(id, "wf_ask requires a non-empty `question`"),
+            Poke::None,
+        );
+    }
+    let mut body = json!({ "question": question });
+    if let Some(options) = args.get("options") {
+        body["options"] = options.clone();
+    }
+    let msg_id = new_msg_id();
+    // Routed to the human (no orchestrator in v1): to_step_exec_id = NULL.
+    if let Err(e) = insert_message(
+        conn,
+        &msg_id,
+        &sender.run_id,
+        Some(&sender.step_exec_id),
+        None,
+        "ask",
+        &body,
+        "queued",
+        false,
+    ) {
+        return (Response::err(id, e.to_string()), Poke::None);
+    }
+    journal_routed(conn, app, sender, &msg_id, "ask", None);
+    (
+        Response::ok(id, 0, msg_id, String::new()),
+        Poke::AskQueued {
+            run_id: sender.run_id.clone(),
+        },
+    )
+}
+
+/// Persist a human's answer to a paused `question` run and journal it. Does not
+/// resume — the caller (`WorkflowService::answer`) does that. `app` is `None`
+/// under test.
+fn deliver_answer(
+    conn: &Connection,
+    app: Option<&AppHandle>,
+    run_id: &str,
+    message_id: &str,
+    body: &str,
+) -> Result<()> {
+    let (status, reason) = scheduler::run_status(conn, run_id)?;
+    if status != "paused" || reason.as_deref() != Some("question") {
+        return Err(Error::Other(format!(
+            "run is not awaiting an answer (status: {status})"
+        )));
+    }
+
+    let (asking_exec, ask_status) = conn
+        .query_row(
+            "SELECT from_step_exec_id, status FROM wf_message
+             WHERE id = ?1 AND run_id = ?2 AND kind = 'ask'",
+            params![message_id, run_id],
+            |r| Ok((r.get::<_, Option<String>>(0)?, r.get::<_, String>(1)?)),
+        )
+        .optional()
+        .map_err(|e| Error::Other(e.to_string()))?
+        .ok_or_else(|| Error::Other("no such question on this run".into()))?;
+    if ask_status != "queued" {
+        return Err(Error::Other("that question was already answered".into()));
+    }
+
+    let ans_id = new_msg_id();
+    let ans_body = json!({ "text": body });
+    insert_message(
+        conn,
+        &ans_id,
+        run_id,
+        None, // from the human
+        asking_exec.as_deref(),
+        "answer",
+        &ans_body,
+        "queued",
+        false,
+    )
+    .map_err(|e| Error::Other(e.to_string()))?;
+    conn.execute(
+        "UPDATE wf_message SET status = 'answered' WHERE id = ?1",
+        [message_id],
+    )
+    .map_err(|e| Error::Other(e.to_string()))?;
+
+    scheduler::journal_event(
+        conn,
+        app,
+        run_id,
+        event_type::MESSAGE_ROUTED,
+        asking_exec.as_deref(),
+        &json!({
+            "message_id": ans_id,
+            "kind": "answer",
+            "from": Value::Null,
+            "to": asking_exec,
+        }),
+    );
+    Ok(())
+}
+
+// ───────────────────────────── service glue ─────────────────────────────────
+
+impl WorkflowService {
+    /// Handle one `wf_report` / `wf_ask` / `wf_notify` op from a step agent
+    /// (§10.4). Synchronous: validate + persist + journal under the DB lock, then
+    /// perform the resulting poke. No prompt is sent here — that is the
+    /// scheduler's job.
+    pub(super) fn handle_comms_op(
+        &self,
+        id: &str,
+        agent_id: &str,
+        op: &str,
+        args: &Value,
+    ) -> (Response, Vec<RpcEvent>) {
+        // Validate + persist + journal under the DB lock, dropping it before we
+        // touch the run registry (lock discipline: never a map lock across the
+        // DB lock's work).
+        let (resp, poke) = {
+            let conn = self.db.lock();
+            route(&conn, Some(&self.app), id, agent_id, op, args)
+        };
+        if let Poke::AskQueued { run_id } = poke {
+            // Raise the run's pending-ask flag so the in-flight attempt defers its
+            // gate and the run pauses `question` at turn end (§10.4).
+            if let Some(flag) = self.runs.lock().get(&run_id).map(|h| h.pending_ask.clone()) {
+                flag.store(true, Ordering::SeqCst);
+            }
+        }
+        (resp, Vec::new())
+    }
+
+    /// Deliver a human's answer to a paused `question` run and resume it
+    /// (`wf_answer`, spec §13). The scheduler folds the answer into the fresh
+    /// attempt's prompt on resume.
+    pub(super) fn answer(&self, run_id: &str, message_id: &str, body: &str) -> Result<()> {
+        {
+            let conn = self.db.lock();
+            deliver_answer(&conn, Some(&self.app), run_id, message_id, body)?;
+        }
+        // Resume: the drive loop starts a fresh attempt for the asking step (the
+        // asking attempt was abandoned at the pause).
+        self.spawn_drive(run_id.to_string());
+        Ok(())
+    }
+}
+
+// ───────────────────────────── journaling ───────────────────────────────────
+
+fn journal_routed(
+    conn: &Connection,
+    app: Option<&AppHandle>,
+    sender: &Sender,
+    message_id: &str,
+    kind: &str,
+    to: Option<&str>,
+) {
+    scheduler::journal_event(
+        conn,
+        app,
+        &sender.run_id,
+        event_type::MESSAGE_ROUTED,
+        Some(&sender.step_exec_id),
+        &json!({
+            "message_id": message_id,
+            "kind": kind,
+            "from": sender.step_exec_id,
+            "to": to,
+        }),
+    );
+}
+
+fn journal_denied(
+    conn: &Connection,
+    app: Option<&AppHandle>,
+    sender: &Sender,
+    op: &str,
+    reason: &str,
+) {
+    scheduler::journal_event(
+        conn,
+        app,
+        &sender.run_id,
+        event_type::MESSAGE_ROUTED,
+        Some(&sender.step_exec_id),
+        &json!({
+            "kind": "denied",
+            "op": op,
+            "from": sender.step_exec_id,
+            "reason": reason,
+        }),
+    );
+}
+
+fn new_msg_id() -> String {
+    format!("msg-{}", uuid::Uuid::new_v4())
+}
+
+// ───────────────────────────── RPC dispatcher ───────────────────────────────
+
+/// The RPC dispatcher for a **run-owned** step agent (spec §10). Comms ops
+/// (`wf_*`) route to the [`WorkflowService`]; everything else (git, echo, ping)
+/// falls through to the standard [`GitDispatcher`], so a step agent keeps the
+/// same local-git surface as any other agent. Constructed in
+/// `supervisor::lifecycle` when an agent has an `owner_run_id`.
+pub struct WorkflowCommsDispatcher {
+    app: AppHandle,
+    agent_id: String,
+    git: GitDispatcher,
+}
+
+impl WorkflowCommsDispatcher {
+    pub fn new(app: AppHandle, agent_id: String, git: GitDispatcher) -> Self {
+        Self { app, agent_id, git }
+    }
+}
+
+impl RpcDispatcher for WorkflowCommsDispatcher {
+    fn dispatch<'a>(
+        &'a self,
+        id: &'a str,
+        op: &'a str,
+        args: &'a Value,
+    ) -> RpcFuture<'a, (Response, Vec<RpcEvent>)> {
+        Box::pin(async move {
+            if is_comms_op(op) {
+                match self.app.try_state::<Arc<WorkflowService>>() {
+                    Some(svc) => svc.inner().handle_comms_op(id, &self.agent_id, op, args),
+                    None => (
+                        Response::err(id, "workflow service unavailable"),
+                        Vec::new(),
+                    ),
+                }
+            } else {
+                self.git.dispatch(id, op, args).await
+            }
+        })
+    }
+}
+
+// ───────────────────────────── command (§13) ────────────────────────────────
+
+type Svc<'a> = tauri::State<'a, Arc<WorkflowService>>;
+
+/// Answer a paused `question` and resume the run (spec §13, §10.4).
+#[tauri::command]
+pub async fn wf_answer(
+    run_id: String,
+    message_id: String,
+    body: String,
+    service: Svc<'_>,
+) -> std::result::Result<(), String> {
+    service
+        .answer(&run_id, &message_id, &body)
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workflow::spec::{AgentSpec, Gate, Step};
+    use crate::workflow::types::{MessageKind, MessageStatus};
+    use std::collections::BTreeMap;
+
+    // ── caps matrix (spec §10.1) ──────────────────────────────────────────
+
+    #[test]
+    fn cap_for_op_maps_the_three_comms_ops() {
+        assert_eq!(cap_for_op("wf_report"), Some(CommsCap::Report));
+        assert_eq!(cap_for_op("wf_ask"), Some(CommsCap::Ask));
+        assert_eq!(cap_for_op("wf_notify"), Some(CommsCap::Notify));
+        assert_eq!(cap_for_op("git_push"), None);
+        assert!(!is_comms_op("git_push"));
+        assert!(is_comms_op("wf_ask"));
+    }
+
+    #[test]
+    fn check_cap_matrix() {
+        assert!(check_cap("wf_report", &[CommsCap::Report]).is_ok());
+        assert!(check_cap("wf_report", &[CommsCap::Ask]).is_err());
+        assert!(check_cap("wf_ask", &[CommsCap::Ask]).is_ok());
+        assert!(check_cap("wf_ask", &[]).is_err());
+        // notify is never grantable to a step, so it's always rejected here.
+        assert!(check_cap("wf_notify", &[CommsCap::Report, CommsCap::Ask]).is_err());
+        assert!(check_cap("wf_notify", &[CommsCap::Notify]).is_ok());
+        assert!(check_cap("rm_rf", &[CommsCap::Report]).is_err());
+    }
+
+    // ── delivery coalescing (spec §10.4) ──────────────────────────────────
+
+    fn msg(kind: MessageKind, body: Value) -> Message {
+        Message {
+            id: "m".into(),
+            run_id: "r".into(),
+            from_step_exec_id: None,
+            to_step_exec_id: Some("e".into()),
+            kind,
+            body,
+            status: MessageStatus::Queued,
+            created_at: 0,
+            delivered_at: None,
+        }
+    }
+
+    #[test]
+    fn compose_delivery_coalesces_many_messages_into_one_preamble() {
+        let msgs = vec![
+            msg(MessageKind::Answer, json!({ "text": "use Postgres" })),
+            msg(MessageKind::Notify, json!({ "message": "slice B landed" })),
+        ];
+        let p = compose_delivery(&msgs);
+        assert_eq!(p.matches("## Messages from the workflow").count(), 1);
+        assert!(p.contains("use Postgres"));
+        assert!(p.contains("slice B landed"));
+    }
+
+    #[test]
+    fn compose_delivery_renders_answer_body() {
+        let p = compose_delivery(&[msg(MessageKind::Answer, json!({ "text": "yes, ship it" }))]);
+        assert!(p.contains("Answer to your question:"));
+        assert!(p.contains("yes, ship it"));
+    }
+
+    // ── routing over a temp DB (spec §10.1, §10.4) ────────────────────────
+
+    /// A DB with one paused run, one live step attempt, and a spec whose single
+    /// step declares `caps`. Returns (db, run_id, step_exec_id).
+    fn seed(caps: Vec<CommsCap>) -> (Connection, String, String) {
+        let td = tempfile::tempdir().unwrap();
+        let db = crate::database::init(td.path()).unwrap();
+        // Keep the tempdir alive for the connection's lifetime by leaking it —
+        // acceptable in a unit test.
+        std::mem::forget(td);
+        let conn = Arc::try_unwrap(db).ok().unwrap().into_inner();
+
+        let mut agents = BTreeMap::new();
+        agents.insert(
+            "a".to_string(),
+            AgentSpec {
+                base: "claude".into(),
+                model: None,
+                instructions: None,
+                skills: vec![],
+                custom_agent: None,
+            },
+        );
+        let spec = Spec {
+            version: 1,
+            name: "demo".into(),
+            description: None,
+            budgets: None,
+            agents,
+            workflow: vec![Block::Step(Step {
+                id: "s1".into(),
+                agent: "a".into(),
+                goal: "g".into(),
+                gate: Gate::Verdict,
+                budgets: None,
+                comms: caps,
+            })],
+            finalize: None,
+        };
+        let spec_json = serde_json::to_string(&spec).unwrap();
+        conn.execute(
+            "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,branch,
+                base_sha,status,paused_reason,budgets_json,spent_json,created_at,updated_at)
+             VALUES ('run','demo',?1,'t','p','/repo','/rd','wf/x','sha','paused','question','{}','{}',0,0)",
+            [spec_json],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO wf_step_exec (id,run_id,step_id,attempt,iteration,status,gate_mode,agent_id)
+             VALUES ('exec-1','run','s1',1,0,'running','verdict','agent-1')",
+            [],
+        )
+        .unwrap();
+        (conn, "run".to_string(), "exec-1".to_string())
+    }
+
+    fn count(conn: &Connection, sql: &str) -> i64 {
+        conn.query_row(sql, [], |r| r.get(0)).unwrap()
+    }
+
+    #[test]
+    fn report_persists_and_journals() {
+        let (conn, _run, exec) = seed(vec![CommsCap::Report]);
+        let (resp, poke) = route(
+            &conn,
+            None,
+            "req-1",
+            "agent-1",
+            "wf_report",
+            &json!({ "status": "progress", "note": "halfway" }),
+        );
+        assert!(resp.ok, "{resp:?}");
+        assert!(matches!(poke, Poke::None));
+        assert_eq!(
+            count(&conn, "SELECT COUNT(*) FROM wf_message WHERE kind='report'"),
+            1
+        );
+        // Journaled as message_routed against the sending attempt.
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM wf_event WHERE type='message_routed'"
+            ),
+            1
+        );
+        let se: String = conn
+            .query_row(
+                "SELECT step_exec_id FROM wf_event WHERE type='message_routed'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(se, exec);
+    }
+
+    #[test]
+    fn report_without_cap_is_rejected_and_journaled_denied() {
+        let (conn, _run, _exec) = seed(vec![]); // no caps
+        let (resp, poke) = route(
+            &conn,
+            None,
+            "req-1",
+            "agent-1",
+            "wf_report",
+            &json!({ "note": "x" }),
+        );
+        assert!(!resp.ok);
+        assert!(matches!(poke, Poke::None));
+        // No message persisted, but the denial is journaled — never silent.
+        assert_eq!(count(&conn, "SELECT COUNT(*) FROM wf_message"), 0);
+        let denied: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM wf_event WHERE type='message_routed'
+                 AND json_extract(payload_json,'$.kind')='denied'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(denied, 1);
+    }
+
+    #[test]
+    fn ask_queues_message_and_reports_poke() {
+        let (conn, run, _exec) = seed(vec![CommsCap::Ask]);
+        let (resp, poke) = route(
+            &conn,
+            None,
+            "req-1",
+            "agent-1",
+            "wf_ask",
+            &json!({ "question": "which db?" }),
+        );
+        assert!(resp.ok);
+        match poke {
+            Poke::AskQueued { run_id } => assert_eq!(run_id, run),
+            Poke::None => panic!("ask should request a poke"),
+        }
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM wf_message WHERE kind='ask' AND status='queued'"
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn empty_question_is_rejected() {
+        let (conn, _run, _exec) = seed(vec![CommsCap::Ask]);
+        let (resp, poke) = route(
+            &conn,
+            None,
+            "req-1",
+            "agent-1",
+            "wf_ask",
+            &json!({ "question": "   " }),
+        );
+        assert!(!resp.ok);
+        assert!(matches!(poke, Poke::None));
+        assert_eq!(count(&conn, "SELECT COUNT(*) FROM wf_message"), 0);
+    }
+
+    #[test]
+    fn answer_queues_reply_and_marks_ask_answered() {
+        let (conn, run, exec) = seed(vec![CommsCap::Ask]);
+        // The step asked a question.
+        let (resp, _poke) = route(
+            &conn,
+            None,
+            "req-1",
+            "agent-1",
+            "wf_ask",
+            &json!({ "question": "which db?" }),
+        );
+        let ask_id = resp.stdout.clone().unwrap();
+
+        // The human answers.
+        deliver_answer(&conn, None, &run, &ask_id, "Postgres").unwrap();
+
+        // The ask is answered; a queued answer targets the asking attempt.
+        let ask_status: String = conn
+            .query_row(
+                "SELECT status FROM wf_message WHERE id=?1",
+                [&ask_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(ask_status, "answered");
+        let (to, status): (String, String) = conn
+            .query_row(
+                "SELECT to_step_exec_id, status FROM wf_message WHERE kind='answer'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(to, exec);
+        assert_eq!(status, "queued");
+
+        // The queued answer is picked up for the step and coalesced.
+        let pending = take_pending_deliveries(&conn, &run, "s1");
+        assert_eq!(pending.len(), 1);
+        assert!(compose_delivery(&pending).contains("Postgres"));
+        // …and marked delivered, so it isn't folded twice.
+        assert!(take_pending_deliveries(&conn, &run, "s1").is_empty());
+    }
+
+    #[test]
+    fn answer_rejects_when_run_not_awaiting() {
+        let (conn, run, _exec) = seed(vec![CommsCap::Ask]);
+        // No ask outstanding, and we'll flip the run to running.
+        conn.execute(
+            "UPDATE wf_run SET status='running', paused_reason=NULL WHERE id='run'",
+            [],
+        )
+        .unwrap();
+        let err = deliver_answer(&conn, None, &run, "nope", "x");
+        assert!(err.is_err());
+    }
+}

--- a/src-tauri/src/workflow/comms.rs
+++ b/src-tauri/src/workflow/comms.rs
@@ -1021,6 +1021,36 @@ mod tests {
     }
 
     #[test]
+    fn ask_is_rejected_once_the_exec_has_committed() {
+        // The other half of the commit-point serialization (§10.4): if the
+        // scheduler finalized the attempt first (its exec is terminal), a late
+        // ask from that turn is rejected — never queued against a completed step,
+        // so the run can't be left advanced with an orphan question.
+        let (conn, _run, exec) = seed(vec![CommsCap::Ask]);
+        conn.execute(
+            "UPDATE wf_step_exec SET status = 'done' WHERE id = ?1",
+            [&exec],
+        )
+        .unwrap();
+        let (resp, poke) = route(
+            &conn,
+            None,
+            "req-1",
+            "run",
+            "agent-1",
+            "wf_ask",
+            &json!({ "question": "q" }),
+        );
+        assert!(!resp.ok, "ask on a committed exec must be rejected");
+        assert!(matches!(poke, Poke::None));
+        assert_eq!(
+            count(&conn, "SELECT COUNT(*) FROM wf_message"),
+            0,
+            "no orphan ask is queued"
+        );
+    }
+
+    #[test]
     fn has_unanswered_ask_tracks_queued_then_answered() {
         let (conn, run, exec) = seed(vec![CommsCap::Ask]);
         assert!(!has_unanswered_ask(&conn, &exec), "no ask yet");

--- a/src-tauri/src/workflow/driver.rs
+++ b/src-tauri/src/workflow/driver.rs
@@ -89,6 +89,15 @@ pub trait AgentDriver: Send + Sync {
     fn last_activity(&self, agent_id: &str) -> Option<i64>;
     /// Per-turn usage if the provider exposes it (else `None`).
     fn turn_usage(&self, agent_id: &str) -> Option<TurnUsage>;
+    /// Synchronously drain any RPC requests the agent has already written but
+    /// whose per-agent watcher hasn't dispatched yet — so a `wf_ask` issued
+    /// during the just-finished turn is persisted before the scheduler acts on
+    /// that turn's gate (§10.4). The default is a no-op: only the real
+    /// supervisor-backed driver has a mailbox; `MockDriver` and the test stubs
+    /// signal comms directly.
+    fn settle_rpc<'a>(&'a self, _agent_id: &'a str) -> BoxFuture<'a, ()> {
+        Box::pin(async {})
+    }
 }
 
 /// The production driver: a thin adapter over the agent [`Supervisor`].
@@ -220,6 +229,12 @@ impl AgentDriver for SupervisorDriver {
             }
         }
         any.then_some(total)
+    }
+
+    fn settle_rpc<'a>(&'a self, agent_id: &'a str) -> BoxFuture<'a, ()> {
+        Box::pin(async move {
+            self.sup.settle_agent_rpc(&self.app, agent_id).await;
+        })
     }
 }
 

--- a/src-tauri/src/workflow/mod.rs
+++ b/src-tauri/src/workflow/mod.rs
@@ -17,6 +17,7 @@
 pub mod attempt;
 pub mod blackboard;
 pub mod budget;
+pub mod comms;
 pub mod definition;
 pub mod driver;
 pub mod gates;

--- a/src-tauri/src/workflow/prompts.rs
+++ b/src-tauri/src/workflow/prompts.rs
@@ -1,13 +1,13 @@
 //! Step protocol prompt assembly (spec §8.5). Pure string building: given the
-//! run task, the step goal, position, gate, and turn budget, produce the prompt
-//! the scheduler sends to a step agent. The comms section (§8.5 item 6) is
-//! deliberately omitted — it arrives with the comms router in S10; a step with
-//! declared caps gets those instructions appended there.
+//! run task, the step goal, position, gate, turn budget, and declared comms
+//! caps, produce the prompt the scheduler sends to a step agent. A step with
+//! `report`/`ask` caps gets the comms section (§8.5 item 6) appended, describing
+//! how to call the `wf_*` RPC ops through the mailbox.
 //!
 //! Everything here is deterministic and side-effect free so the exact text is
 //! unit-testable and stable across runs.
 
-use super::spec::Gate;
+use super::spec::{CommsCap, Gate};
 
 /// Where a step sits in the run, for the "step N of M, iteration i of max"
 /// context line (spec §8.5 item 3).
@@ -43,6 +43,9 @@ pub struct StepPromptCtx<'a> {
     pub gate: &'a Gate,
     /// The per-attempt turn budget, when one applies (§8.5 item 7).
     pub turns_per_attempt: Option<i64>,
+    /// The step's declared comms caps (§8.5 item 6). The comms section is
+    /// appended only when this is non-empty.
+    pub comms: &'a [CommsCap],
 }
 
 /// The full step prompt for a fresh attempt (spec §8.5).
@@ -71,12 +74,56 @@ pub fn step_prompt(ctx: &StepPromptCtx) -> String {
     s.push_str(&gate_statement(ctx.gate));
     s.push_str("\n\n");
 
+    if let Some(comms) = comms_section(ctx.comms) {
+        s.push_str(&comms);
+        s.push('\n');
+    }
+
     if let Some(budget) = budget_notice(ctx.turns_per_attempt) {
         s.push_str(&budget);
         s.push('\n');
     }
 
     s
+}
+
+/// The comms section (spec §8.5 item 6): how to talk to the host through the RPC
+/// mailbox, mirroring the git-actions playbook style. Only the ops the step is
+/// permitted to call are described. `None` when the step has no caps.
+fn comms_section(caps: &[CommsCap]) -> Option<String> {
+    let can_report = caps.contains(&CommsCap::Report);
+    let can_ask = caps.contains(&CommsCap::Ask);
+    if !can_report && !can_ask {
+        return None;
+    }
+
+    let mut s = String::new();
+    s.push_str("## Talking to the workflow\n\n");
+    s.push_str(
+        "You can send structured messages to the workflow host through your RPC \
+         mailbox (the same `$FLETCH_RPC_DIR` request/response channel the git \
+         actions use): write `requests/<id>.json` with an `op` and `args`, then \
+         read `responses/<id>.json`.\n\n",
+    );
+    if can_report {
+        s.push_str(
+            "- **Report progress** — `op: \"wf_report\"`, \
+             `args: { \"status\": \"progress\" | \"done\", \"note\": \"…\" }`. \
+             Use it to surface a milestone or your final status; it never ends \
+             your turn or replaces `verdict.json`.\n",
+        );
+    }
+    if can_ask {
+        s.push_str(
+            "- **Ask a question** — `op: \"wf_ask\"`, \
+             `args: { \"question\": \"…\", \"options\": [\"…\"] }` (options \
+             optional). Call it when you are genuinely blocked on a decision only \
+             a human can make, **then end your turn**: the workflow pauses, and \
+             you are re-prompted with the answer on your next turn. Don't ask \
+             about anything you can decide yourself.\n",
+        );
+    }
+    Some(s)
 }
 
 /// The re-prompt sent when the gate is unmet but the attempt still has turns
@@ -206,6 +253,7 @@ mod tests {
             },
             gate,
             turns_per_attempt: Some(3),
+            comms: &[],
         }
     }
 
@@ -245,12 +293,38 @@ mod tests {
     }
 
     #[test]
-    fn no_comms_section_in_v1_prompt() {
+    fn no_comms_section_without_caps() {
         let gate = Gate::Verdict;
         let p = step_prompt(&ctx(&gate, "task", "goal"));
-        // Comms instructions (wf_report/wf_ask) are S10; they must not leak in.
+        // A step with no declared caps gets no comms instructions.
         assert!(!p.contains("wf_report"));
         assert!(!p.contains("wf_ask"));
+        assert!(!p.contains("Talking to the workflow"));
+    }
+
+    #[test]
+    fn comms_section_lists_only_declared_caps() {
+        let gate = Gate::Verdict;
+        // Ask only.
+        let mut c = ctx(&gate, "task", "goal");
+        c.comms = &[CommsCap::Ask];
+        let p = step_prompt(&c);
+        assert!(p.contains("Talking to the workflow"));
+        assert!(p.contains("wf_ask"));
+        assert!(!p.contains("wf_report"), "report not declared: {p}");
+
+        // Report only.
+        let mut c = ctx(&gate, "task", "goal");
+        c.comms = &[CommsCap::Report];
+        let p = step_prompt(&c);
+        assert!(p.contains("wf_report"));
+        assert!(!p.contains("wf_ask"), "ask not declared: {p}");
+
+        // Both.
+        let mut c = ctx(&gate, "task", "goal");
+        c.comms = &[CommsCap::Report, CommsCap::Ask];
+        let p = step_prompt(&c);
+        assert!(p.contains("wf_report") && p.contains("wf_ask"));
     }
 
     #[test]

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -748,9 +748,20 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
                     let ferry = ferry_step(ctx, run_id, &exec_id, &msg, &wt, &run_repo).await;
                     match ferry {
                         Ok(head) => {
-                            {
-                                let conn = ctx.db.lock();
-                                finish_step_exec(&conn, &exec_id, "done", Some(&head));
+                            // Atomic commit point: a `wf_ask` can be routed while
+                            // `ferry` runs (the drain + pre-check above see only
+                            // the state before it), so re-check under the same lock
+                            // that finalizes `done` (§10.4). See
+                            // `commit_done_unless_ask`.
+                            let committed = commit_done_unless_ask(&ctx.db.lock(), &exec_id, &head);
+                            if !committed {
+                                // A late ask landed during the ferry. The boundary
+                                // commit is inert (never referenced as a `done`
+                                // ref); pause `question` and let `wf_answer` resume
+                                // with a fresh attempt.
+                                pause_question(ctx, run_id, &exec_id, result.agent_id.as_deref())
+                                    .await;
+                                return Ok(());
                             }
                             if let Some(agent_id) = &result.agent_id {
                                 let _ = ctx.driver.archive(agent_id).await;
@@ -841,43 +852,9 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
                 }
                 AttemptOutcome::AwaitingAnswer => {
                     // The step asked the human a question (§10.4). No gate, no
-                    // ferry: abandon this attempt (a fresh one runs on
-                    // `wf_answer`), stop the agent — pausing stops processes
-                    // (§6.5) and a human answer can be a long way off — and pause
-                    // `question`. The cursor is left where it is so the fresh
-                    // attempt re-runs this same step with the answer folded in.
-                    {
-                        let conn = ctx.db.lock();
-                        finish_step_exec(&conn, &exec_id, "abandoned", None);
-                    }
-                    if let Some(agent_id) = &result.agent_id {
-                        let _ = ctx.driver.stop(agent_id).await;
-                    }
-                    let conn = ctx.db.lock();
-                    journal_event(
-                        &conn,
-                        ctx.app.as_ref(),
-                        run_id,
-                        event_type::ATTEMPT_ABANDONED,
-                        Some(&exec_id),
-                        &json!({ "cause": "question" }),
-                    );
-                    journal_event(
-                        &conn,
-                        ctx.app.as_ref(),
-                        run_id,
-                        event_type::RUN_PAUSED,
-                        Some(&exec_id),
-                        &json!({ "reason": "question" }),
-                    );
-                    set_status(
-                        &conn,
-                        ctx.app.as_ref(),
-                        run_id,
-                        "paused",
-                        Some("question"),
-                        None,
-                    );
+                    // ferry, no advance — pause `question`; the cursor is left in
+                    // place so a fresh attempt re-runs this step with the answer.
+                    pause_question(ctx, run_id, &exec_id, result.agent_id.as_deref()).await;
                     return Ok(());
                 }
                 AttemptOutcome::Blocked { reason } => {
@@ -1030,6 +1007,65 @@ async fn ferry_step(
     let refname = gitops::pin_step_ref(worktree, exec_id).await?;
     gitops::ferry(worktree, run_repo, &refname).await?;
     Ok(bc.head)
+}
+
+/// The atomic commit point for a `done` attempt (§10.4). In ONE DB-lock hold,
+/// re-check for a late human `wf_ask` and either finalize the attempt `done`
+/// (returning `true`) or leave it uncommitted (`false`) so the caller pauses
+/// `question`. This is the load-bearing serialization: the comms router inserts
+/// an ask under this same connection mutex, and only after confirming the sender
+/// exec is still live — so this section and that insert can't interleave. Either
+/// the ask is committed before this runs (we observe it and don't finalize), or
+/// we finalize `done` first (and the router then rejects the late ask, whose
+/// exec is no longer live). No ordering can both queue an ask and advance the
+/// run — closing the window the mailbox drain alone leaves open during `ferry`.
+fn commit_done_unless_ask(conn: &Connection, exec_id: &str, head: &str) -> bool {
+    if super::comms::has_unanswered_ask(conn, exec_id) {
+        false
+    } else {
+        finish_step_exec(conn, exec_id, "done", Some(head));
+        true
+    }
+}
+
+/// Pause a run `question` for an outstanding human ask: abandon the current
+/// attempt (a fresh one runs on `wf_answer`), stop its agent — a human answer can
+/// be a long way off and pausing stops processes (§6.5) — and journal the pause.
+/// The cursor is left in place so the resumed attempt re-runs the same step with
+/// the answer folded in.
+async fn pause_question(ctx: &RunCtx, run_id: &str, exec_id: &str, agent_id: Option<&str>) {
+    {
+        let conn = ctx.db.lock();
+        finish_step_exec(&conn, exec_id, "abandoned", None);
+    }
+    if let Some(a) = agent_id {
+        let _ = ctx.driver.stop(a).await;
+    }
+    let conn = ctx.db.lock();
+    journal_event(
+        &conn,
+        ctx.app.as_ref(),
+        run_id,
+        event_type::ATTEMPT_ABANDONED,
+        Some(exec_id),
+        &json!({ "cause": "question" }),
+    );
+    journal_event(
+        &conn,
+        ctx.app.as_ref(),
+        run_id,
+        event_type::RUN_PAUSED,
+        Some(exec_id),
+        &json!({ "reason": "question" }),
+    );
+    set_status(
+        &conn,
+        ctx.app.as_ref(),
+        run_id,
+        "paused",
+        Some("question"),
+        None,
+    );
 }
 
 async fn finalize_run(
@@ -3206,6 +3242,67 @@ mod tests {
         assert!(check_resumable(&conn, "r-ques", "resume").is_err());
         assert!(check_resumable(&conn, "r-budg", "resume").is_ok());
         assert!(check_resumable(&conn, "r-blk", "retry").is_ok());
+    }
+
+    #[test]
+    fn commit_done_unless_ask_ties_the_gate_to_the_ask_check() {
+        // The atomic commit point (§10.4): finalize `done` only when no ask is
+        // queued for the exec; a pending ask blocks the commit so the caller can
+        // pause `question` instead of advancing.
+        let tmp = tempfile::tempdir().unwrap();
+        let db = crate::database::init(tmp.path()).unwrap();
+        let conn = db.lock();
+        conn.execute(
+            "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,branch,
+                base_sha,status,budgets_json,spent_json,created_at,updated_at)
+             VALUES ('r','n','{}','t','p','/r','/d','wf/x','sha','running','{}','{}',0,0)",
+            [],
+        )
+        .unwrap();
+        let mk_exec = |id: &str| {
+            conn.execute(
+                "INSERT INTO wf_step_exec (id,run_id,step_id,attempt,iteration,status,gate_mode)
+                 VALUES (?1,'r','s',1,0,'running','verdict')",
+                [id],
+            )
+            .unwrap();
+        };
+
+        // No ask → commits `done` with the ferried head.
+        mk_exec("e-clean");
+        assert!(commit_done_unless_ask(&conn, "e-clean", "sha1"));
+        let (status, head): (String, Option<String>) = conn
+            .query_row(
+                "SELECT status, head_end FROM wf_step_exec WHERE id='e-clean'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "done");
+        assert_eq!(head.as_deref(), Some("sha1"));
+
+        // A queued ask against the exec → does NOT commit; the exec stays live so
+        // the caller pauses `question`.
+        mk_exec("e-ask");
+        conn.execute(
+            "INSERT INTO wf_message (id,run_id,from_step_exec_id,to_step_exec_id,kind,
+                body_json,status,created_at)
+             VALUES ('m1','r','e-ask',NULL,'ask','{}','queued',0)",
+            [],
+        )
+        .unwrap();
+        assert!(!commit_done_unless_ask(&conn, "e-ask", "sha2"));
+        let status: String = conn
+            .query_row(
+                "SELECT status FROM wf_step_exec WHERE id='e-ask'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            status, "running",
+            "must not finalize while an ask is pending"
+        );
     }
 
     // ───────────────────────── parallel stages (S8) ─────────────────────────

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -38,15 +38,15 @@ type Db = Arc<Mutex<Connection>>;
 
 /// App-state singleton: the active-run registry plus launch / control.
 pub struct WorkflowService {
-    db: Db,
+    pub(super) db: Db,
     driver: Arc<dyn AgentDriver>,
-    app: AppHandle,
+    pub(super) app: AppHandle,
     /// Active-run registry. Behind an `Arc` so a drive task can remove its own
     /// entry on exit without borrowing the service.
-    runs: Arc<Mutex<HashMap<String, RunHandle>>>,
+    pub(super) runs: Arc<Mutex<HashMap<String, RunHandle>>>,
 }
 
-struct RunHandle {
+pub(super) struct RunHandle {
     cancel: Arc<AtomicBool>,
     /// Set when a spawn request arrives while this driver is winding down (its
     /// paused status already written, registry entry not yet removed). The
@@ -54,6 +54,11 @@ struct RunHandle {
     /// request — an approve that raced the wind-down would otherwise leave the
     /// run paused forever with nothing left to approve.
     respawn: Arc<AtomicBool>,
+    /// Raised by the comms router (§10.4) when a live step raises a `wf_ask`
+    /// routed to the human: the running attempt observes it at turn end and
+    /// returns `AwaitingAnswer`, so the run pauses `question` without gating.
+    /// Shared with that run's in-flight attempt (`AttemptParams::pending_ask`).
+    pub(super) pending_ask: Arc<AtomicBool>,
 }
 
 impl WorkflowService {
@@ -264,7 +269,7 @@ impl WorkflowService {
         Ok(())
     }
 
-    fn spawn_drive(&self, run_id: String) {
+    pub(super) fn spawn_drive(&self, run_id: String) {
         spawn_drive_task(
             self.db.clone(),
             self.driver.clone(),
@@ -300,6 +305,7 @@ fn spawn_drive_task(
 ) {
     let cancel = Arc::new(AtomicBool::new(false));
     let respawn = Arc::new(AtomicBool::new(false));
+    let pending_ask = Arc::new(AtomicBool::new(false));
     {
         let mut m = runs.lock();
         if let Some(existing) = m.get(&run_id) {
@@ -311,6 +317,7 @@ fn spawn_drive_task(
             RunHandle {
                 cancel: cancel.clone(),
                 respawn: respawn.clone(),
+                pending_ask: pending_ask.clone(),
             },
         );
     }
@@ -320,6 +327,7 @@ fn spawn_drive_task(
         driver: driver.clone(),
         app: Some(app.clone()),
         cancel,
+        pending_ask,
         deadlines: Deadlines::default(),
     };
     let id = run_id.clone();
@@ -365,6 +373,9 @@ struct RunCtx {
     /// skipped.
     app: Option<AppHandle>,
     cancel: Arc<AtomicBool>,
+    /// The run's pending-ask flag (§10.4), shared with the [`RunHandle`] so the
+    /// comms router can raise it; threaded into each attempt.
+    pending_ask: Arc<AtomicBool>,
     deadlines: Deadlines,
 }
 
@@ -523,6 +534,8 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
                 &last_ref,
                 &eff,
                 &mut ledger,
+                &test_override,
+                &setup_override,
             )
             .await?
             {
@@ -608,10 +621,25 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
                     },
                     gate: &step.gate,
                     turns_per_attempt: step.budgets.as_ref().and_then(|b| b.turns_per_attempt),
+                    comms: &step.comms,
                 };
-                match &last_failure {
+                let base = match &last_failure {
                     Some(f) => prompts::retry_prompt(f, &ctx_prompt),
                     None => prompts::step_prompt(&ctx_prompt),
+                };
+                // Fold any messages queued for this step while it was paused
+                // (a human's `wf_answer`, later an orchestrator notify) into
+                // this one prompt — coalesced, so many messages cost one turn
+                // (§10.4). Marking them delivered here means later attempts of
+                // the same step don't re-fold them.
+                let delivered = {
+                    let conn = ctx.db.lock();
+                    super::comms::take_pending_deliveries(&conn, run_id, &step.id)
+                };
+                if delivered.is_empty() {
+                    base
+                } else {
+                    format!("{}\n\n{}", super::comms::compose_delivery(&delivered), base)
                 }
             };
 
@@ -645,6 +673,7 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
                 // Linear steps are never cancelled mid-attempt (only parallel
                 // losers are, §6.6), so this flag is never set.
                 cancel: Arc::new(AtomicBool::new(false)),
+                pending_ask: ctx.pending_ask.clone(),
             };
 
             let started = super::now_ms();
@@ -781,6 +810,47 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
                         run_id,
                         "paused",
                         Some("approval"),
+                        None,
+                    );
+                    return Ok(());
+                }
+                AttemptOutcome::AwaitingAnswer => {
+                    // The step asked the human a question (§10.4). No gate, no
+                    // ferry: abandon this attempt (a fresh one runs on
+                    // `wf_answer`), stop the agent — pausing stops processes
+                    // (§6.5) and a human answer can be a long way off — and pause
+                    // `question`. The cursor is left where it is so the fresh
+                    // attempt re-runs this same step with the answer folded in.
+                    {
+                        let conn = ctx.db.lock();
+                        finish_step_exec(&conn, &exec_id, "abandoned", None);
+                    }
+                    if let Some(agent_id) = &result.agent_id {
+                        let _ = ctx.driver.stop(agent_id).await;
+                    }
+                    let conn = ctx.db.lock();
+                    journal_event(
+                        &conn,
+                        ctx.app.as_ref(),
+                        run_id,
+                        event_type::ATTEMPT_ABANDONED,
+                        Some(&exec_id),
+                        &json!({ "cause": "question" }),
+                    );
+                    journal_event(
+                        &conn,
+                        ctx.app.as_ref(),
+                        run_id,
+                        event_type::RUN_PAUSED,
+                        Some(&exec_id),
+                        &json!({ "reason": "question" }),
+                    );
+                    set_status(
+                        &conn,
+                        ctx.app.as_ref(),
+                        run_id,
+                        "paused",
+                        Some("question"),
                         None,
                     );
                     return Ok(());
@@ -1082,6 +1152,12 @@ struct ChildCtx {
     run_repo: PathBuf,
     block_index: usize,
     block_count: usize,
+    /// Project test/setup command overrides (spec §9.4), resolved once for the
+    /// run and cloned per child so a `tests`-gated child resolves its command the
+    /// same way a linear step does. The child builds its own `SandboxTestRunner`
+    /// (honoring its own `tests_timeout_secs`) in [`drive_child`].
+    test_override: Option<String>,
+    setup_override: Option<String>,
     /// Set by the stage to wind this child down (loser cancellation, §6.6).
     stage_cancel: Arc<AtomicBool>,
 }
@@ -1131,6 +1207,8 @@ async fn run_parallel_stage(
     fork_base: &str,
     eff: &EffectiveBudgets,
     ledger: &mut Ledger,
+    test_override: &Option<String>,
+    setup_override: &Option<String>,
 ) -> Result<StageFlow> {
     // Enforcement point: before spawning the stage (§11.2). Pause at the block
     // boundary if the run budget is already spent, spawning nothing.
@@ -1207,6 +1285,8 @@ async fn run_parallel_stage(
             run_repo: run_repo.to_path_buf(),
             block_index,
             block_count,
+            test_override: test_override.clone(),
+            setup_override: setup_override.clone(),
             stage_cancel: stage_cancel.clone(),
         });
     }
@@ -1341,6 +1421,26 @@ async fn drive_child(c: ChildCtx, stage_entry_sha: Option<String>) -> ChildResul
         ledger,
     };
 
+    // Tests-gate runner for this child, honoring its own `tests_timeout_secs`
+    // and the run's project overrides (spec §9.4) — parity with the linear path.
+    // Only a `tests`-gated child consults it; construction fails only if HOME is
+    // unavailable, which fails the child rather than silently skipping the gate.
+    let test_runner = match super::tests_gate::SandboxTestRunner::new(
+        c.test_override.clone(),
+        c.setup_override.clone(),
+        step_eff.tests_timeout_secs.max(1) as u64,
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            return done(
+                ChildOutcome::Failure {
+                    reason: format!("could not initialize the tests runner: {e}"),
+                },
+                child_ledger,
+            )
+        }
+    };
+
     let mut attempt_no = next_attempt_no(&c.db.lock(), &c.run_id, &c.step.id);
     let mut last_failure: Option<String> = None;
 
@@ -1374,6 +1474,7 @@ async fn drive_child(c: ChildCtx, stage_entry_sha: Option<String>) -> ChildResul
                 },
                 gate: &c.step.gate,
                 turns_per_attempt: c.step.budgets.as_ref().and_then(|b| b.turns_per_attempt),
+                comms: &c.step.comms,
             };
             match &last_failure {
                 Some(f) => prompts::retry_prompt(f, &ctx_prompt),
@@ -1399,11 +1500,21 @@ async fn drive_child(c: ChildCtx, stage_entry_sha: Option<String>) -> ChildResul
             deadlines: deadlines.clone(),
             reprompt_on_block: true,
             cancel: c.stage_cancel.clone(),
+            // Parallel children have no human-ask deferral wired yet (comms is a
+            // linear-run concern in S10); a never-set flag preserves existing
+            // behavior until orchestrator routing lands (S11).
+            pending_ask: Arc::new(AtomicBool::new(false)),
         };
 
         let started = super::now_ms();
-        let result =
-            attempt::run_attempt(c.driver.as_ref(), params, &mut child_ledger, &step_eff).await;
+        let result = attempt::run_attempt(
+            c.driver.as_ref(),
+            &test_runner,
+            params,
+            &mut child_ledger,
+            &step_eff,
+        )
+        .await;
 
         // Journal the attempt's events + stamp its agent id (linear-path parity).
         {
@@ -1532,6 +1643,24 @@ async fn drive_child(c: ChildCtx, stage_entry_sha: Option<String>) -> ChildResul
                     child_ledger,
                 );
             }
+            AttemptOutcome::AwaitingAnswer => {
+                // A parallel child never sets `pending_ask` (human Q&A is a
+                // linear-run concern in S10, §10.4), so this is unreachable in
+                // practice — fail with a clear cause rather than hang the stage.
+                {
+                    let conn = c.db.lock();
+                    finish_step_exec(&conn, &exec_id, "error", None);
+                }
+                if let Some(agent_id) = &result.agent_id {
+                    let _ = c.driver.archive(agent_id).await;
+                }
+                return done(
+                    ChildOutcome::Failure {
+                        reason: "human questions are not supported inside a parallel stage".into(),
+                    },
+                    child_ledger,
+                );
+            }
         }
     }
 }
@@ -1610,7 +1739,7 @@ fn check_resumable(conn: &Connection, run_id: &str, action: &str) -> Result<()> 
     Ok(())
 }
 
-fn run_status(conn: &Connection, run_id: &str) -> Result<(String, Option<String>)> {
+pub(super) fn run_status(conn: &Connection, run_id: &str) -> Result<(String, Option<String>)> {
     conn.query_row(
         "SELECT status, paused_reason FROM wf_run WHERE id = ?1",
         [run_id],
@@ -1682,7 +1811,7 @@ fn set_status(
 }
 
 /// Append a journal event and emit `wf:event` (when an app handle is present).
-fn journal_event(
+pub(super) fn journal_event(
     conn: &Connection,
     app: Option<&AppHandle>,
     run_id: &str,
@@ -2183,6 +2312,7 @@ mod tests {
             driver,
             app: None,
             cancel: Arc::new(AtomicBool::new(false)),
+            pending_ask: Arc::new(AtomicBool::new(false)),
             deadlines: Deadlines::default(),
         };
         drive_run(&ctx, run_id).await;
@@ -2307,6 +2437,7 @@ mod tests {
             driver: StubDriver::new(ws, true),
             app: None,
             cancel: Arc::new(AtomicBool::new(true)), // pre-canceled
+            pending_ask: Arc::new(AtomicBool::new(false)),
             deadlines: Deadlines::default(),
         };
         drive_run(&ctx, "run-cancel").await;
@@ -2331,6 +2462,7 @@ mod tests {
             driver: StubDriver::new(ws, true),
             app: None,
             cancel: Arc::new(AtomicBool::new(false)),
+            pending_ask: Arc::new(AtomicBool::new(false)),
             deadlines: Deadlines::default(),
         };
         drive_run(&ctx, "run-term").await;
@@ -2358,6 +2490,7 @@ mod tests {
             driver: StubDriver::new(ws, false),
             app: None,
             cancel: Arc::new(AtomicBool::new(false)),
+            pending_ask: Arc::new(AtomicBool::new(false)),
             deadlines: Deadlines::default(),
         };
         drive_run(&ctx, "run-blocked").await;
@@ -2371,6 +2504,218 @@ mod tests {
             .unwrap();
         assert_eq!(status, "paused");
         assert_eq!(reason.as_deref(), Some("blocked_gate"));
+    }
+
+    /// A stub whose "agent" raises the run's pending-ask flag on its very first
+    /// turn (standing in for a `wf_ask` routed to the human) and commits on every
+    /// later turn. It shares the run's `pending_ask` Arc and records every prompt
+    /// it is sent, so the test can prove the deferral, the pause, and the
+    /// answer-fold on resume.
+    struct AskStub {
+        root: PathBuf,
+        pending_ask: Arc<AtomicBool>,
+        tx: broadcast::Sender<StatusEvent>,
+        state: parking_lot::Mutex<AskStubState>,
+    }
+    #[derive(Default)]
+    struct AskStubState {
+        statuses: HashMap<String, AgentStatus>,
+        worktrees: HashMap<String, PathBuf>,
+        spawns: usize,
+        turns: usize,
+        prompts: Vec<String>,
+    }
+    impl AskStub {
+        fn new(root: PathBuf, pending_ask: Arc<AtomicBool>) -> Arc<Self> {
+            Arc::new(Self {
+                root,
+                pending_ask,
+                tx: broadcast::channel(256).0,
+                state: parking_lot::Mutex::new(AskStubState::default()),
+            })
+        }
+        fn set(&self, id: &str, s: AgentStatus) {
+            self.state.lock().statuses.insert(id.to_string(), s.clone());
+            let _ = self.tx.send(StatusEvent {
+                agent_id: id.to_string(),
+                status: s,
+            });
+        }
+    }
+    impl AgentDriver for AskStub {
+        fn spawn(
+            &self,
+            req: SpawnReq,
+        ) -> super::super::driver::BoxFuture<'_, Result<super::super::driver::SpawnedAgent>>
+        {
+            Box::pin(async move {
+                let id = {
+                    let mut st = self.state.lock();
+                    st.spawns += 1;
+                    format!("ask-{}", st.spawns)
+                };
+                let dest = self.root.join(&id);
+                let base_ref = req.fork_base.clone().unwrap();
+                let spec = crate::sandbox::provision::CheckoutSpec {
+                    source_repo: &req.repo_path,
+                    base_ref: &base_ref,
+                    dest: &dest,
+                };
+                crate::sandbox::provision::provision_forking_run_repo(
+                    &spec,
+                    req.run_repo.as_ref().unwrap(),
+                )
+                .await?;
+                sh(&dest, &["config", "user.email", "t@t.t"]);
+                sh(&dest, &["config", "user.name", "t"]);
+                self.state.lock().worktrees.insert(id.clone(), dest.clone());
+                self.set(&id, AgentStatus::Idle);
+                Ok(super::super::driver::SpawnedAgent {
+                    agent_id: id,
+                    worktree: dest,
+                })
+            })
+        }
+        fn status(&self, id: &str) -> Option<AgentStatus> {
+            self.state.lock().statuses.get(id).cloned()
+        }
+        fn subscribe(&self) -> broadcast::Receiver<StatusEvent> {
+            self.tx.subscribe()
+        }
+        fn send_message<'a>(
+            &'a self,
+            id: &'a str,
+            text: String,
+        ) -> super::super::driver::BoxFuture<'a, Result<()>> {
+            Box::pin(async move {
+                let (turn, wt) = {
+                    let mut st = self.state.lock();
+                    st.turns += 1;
+                    st.prompts.push(text);
+                    (st.turns, st.worktrees.get(id).cloned().unwrap())
+                };
+                self.set(id, AgentStatus::Running);
+                if turn == 1 {
+                    // First turn: ask the human (defer the gate) — no commit.
+                    self.pending_ask.store(true, Ordering::SeqCst);
+                } else {
+                    // Later turns: do the work so the commit gate is met.
+                    std::fs::write(wt.join(format!("{id}.txt")), "work").unwrap();
+                    sh(&wt, &["add", "-A"]);
+                    sh(&wt, &["commit", "-qm", "work"]);
+                }
+                self.set(id, AgentStatus::Idle);
+                Ok(())
+            })
+        }
+        fn stop<'a>(&'a self, _id: &'a str) -> super::super::driver::BoxFuture<'a, Result<()>> {
+            Box::pin(async { Ok(()) })
+        }
+        fn archive<'a>(&'a self, _id: &'a str) -> super::super::driver::BoxFuture<'a, Result<()>> {
+            Box::pin(async { Ok(()) })
+        }
+        fn last_activity(&self, _id: &str) -> Option<i64> {
+            None
+        }
+        fn turn_usage(&self, _id: &str) -> Option<super::super::driver::TurnUsage> {
+            None
+        }
+    }
+
+    #[tokio::test]
+    async fn ask_pauses_question_then_answer_resumes_to_done() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (db, ws) = scaffold_one_step(tmp.path(), "run-ask", "wf/ask-1");
+        let pending_ask = Arc::new(AtomicBool::new(false));
+        let driver = AskStub::new(ws, pending_ask.clone());
+        let ctx = RunCtx {
+            db: db.clone(),
+            driver: driver.clone(),
+            app: None,
+            cancel: Arc::new(AtomicBool::new(false)),
+            pending_ask: pending_ask.clone(),
+            deadlines: Deadlines::default(),
+        };
+
+        // ── First drive: the step asks; the run pauses `question`. ──
+        drive_run(&ctx, "run-ask").await;
+        let (status, reason): (String, Option<String>) = db
+            .lock()
+            .query_row(
+                "SELECT status, paused_reason FROM wf_run WHERE id='run-ask'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "paused");
+        assert_eq!(reason.as_deref(), Some("question"));
+
+        // The asking attempt was abandoned, and its gate was never evaluated
+        // (deferred, §10.4).
+        let (exec_id, exec_status): (String, String) = db
+            .lock()
+            .query_row(
+                "SELECT id, status FROM wf_step_exec WHERE run_id='run-ask' ORDER BY rowid LIMIT 1",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(exec_status, "abandoned");
+        let gates: i64 = db
+            .lock()
+            .query_row(
+                "SELECT COUNT(*) FROM wf_event WHERE run_id='run-ask' AND type='gate_evaluated'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            gates, 0,
+            "gate must not be evaluated while an ask is pending"
+        );
+
+        // ── The human answers (queued for the asking step) and the flag clears,
+        // mimicking the fresh RunHandle a real resume creates. ──
+        db.lock()
+            .execute(
+                "INSERT INTO wf_message (id, run_id, from_step_exec_id, to_step_exec_id, kind,
+                    body_json, status, created_at)
+                 VALUES ('ans-1','run-ask',NULL,?1,'answer',?2,'queued',0)",
+                rusqlite::params![exec_id, r#"{"text":"use Postgres"}"#],
+            )
+            .unwrap();
+        pending_ask.store(false, Ordering::SeqCst);
+
+        // ── Resume: a fresh attempt runs, the answer is folded into its prompt,
+        // and the run completes. ──
+        drive_run(&ctx, "run-ask").await;
+        let status: String = db
+            .lock()
+            .query_row("SELECT status FROM wf_run WHERE id='run-ask'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(status, "done");
+
+        // The answer reached the agent, coalesced into the resumed attempt's
+        // single prompt.
+        let prompts = driver.state.lock().prompts.clone();
+        assert_eq!(prompts.len(), 2, "one ask turn + one resumed turn");
+        assert!(
+            prompts[1].contains("use Postgres"),
+            "answer folded into resumed prompt: {}",
+            prompts[1]
+        );
+        // The queued answer was marked delivered (not re-folded).
+        let undelivered: i64 = db
+            .lock()
+            .query_row(
+                "SELECT COUNT(*) FROM wf_message WHERE id='ans-1' AND status='queued'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(undelivered, 0, "answer should be marked delivered");
     }
 
     #[tokio::test]
@@ -2392,6 +2737,7 @@ mod tests {
             driver: StubDriver::new(ws, true),
             app: None,
             cancel: Arc::new(AtomicBool::new(false)),
+            pending_ask: Arc::new(AtomicBool::new(false)),
             deadlines: Deadlines::default(),
         };
         drive_run(&ctx, "run-resume").await;
@@ -2514,6 +2860,7 @@ mod tests {
             driver: StubDriver::new(ws, true),
             app: None,
             cancel: Arc::new(AtomicBool::new(false)),
+            pending_ask: Arc::new(AtomicBool::new(false)),
             deadlines: Deadlines::default(),
         };
         drive_run(&ctx, "run-b0").await;
@@ -2552,6 +2899,7 @@ mod tests {
             driver: StubDriver::new(ws, true),
             app: None,
             cancel: Arc::new(AtomicBool::new(false)),
+            pending_ask: Arc::new(AtomicBool::new(false)),
             deadlines: Deadlines::default(),
         };
         drive_run(&ctx, "run-b1").await;
@@ -2898,6 +3246,7 @@ mod tests {
             driver,
             app: None,
             cancel: Arc::new(AtomicBool::new(false)),
+            pending_ask: Arc::new(AtomicBool::new(false)),
             deadlines: Deadlines::default(),
         }
     }

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -711,14 +711,25 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
                 persist_spent(&conn, run_id, &ledger);
             }
 
-            // Authoritative pending-ask backstop (§10.4): the in-memory
-            // `pending_ask` poke is best-effort — it can be missed if the RPC op
-            // raced this driver's wind-down or landed just after the turn-end
-            // check — so the *persisted* ask is the source of truth. If this
-            // attempt raised a `wf_ask` still awaiting a human answer, pause
-            // `question` regardless of the gate outcome; the gate's result is
-            // never acted on (no ferry, no advance) while an answer is
-            // outstanding. `AwaitingAnswer` from the fast path lands here too.
+            // Drain the agent's RPC mailbox now, before deciding what to do with
+            // the turn: a `wf_ask` the agent wrote during the turn may still be
+            // sitting undispatched (the per-agent watcher polls on a tick). This
+            // dispatches and persists it deterministically, closing the window
+            // where the run could act on the gate while a question is in flight
+            // (§10.4). The agent is idle here (its turn ended), so nothing new
+            // arrives after this drain.
+            if let Some(agent_id) = &result.agent_id {
+                ctx.driver.settle_rpc(agent_id).await;
+            }
+
+            // Authoritative pending-ask backstop (§10.4): with the mailbox drained
+            // above, the *persisted* ask is the source of truth — more reliable
+            // than the best-effort in-memory poke (which can be missed if the RPC
+            // op raced this driver's wind-down). If this attempt raised a `wf_ask`
+            // still awaiting a human answer, pause `question` regardless of the
+            // gate outcome; the gate's result is never acted on (no ferry, no
+            // advance) while an answer is outstanding. `AwaitingAnswer` from the
+            // fast path lands here too.
             let outcome = if super::comms::has_unanswered_ask(&ctx.db.lock(), &exec_id) {
                 AttemptOutcome::AwaitingAnswer
             } else {
@@ -2541,6 +2552,10 @@ mod tests {
         /// exercises the scheduler's DB backstop: the ask is persisted but the
         /// poke is "missed", and the run must still pause `question`.
         set_flag: bool,
+        /// When set, the ask isn't persisted during the turn — it only becomes
+        /// visible when `settle_rpc` drains the mailbox. Proves the scheduler
+        /// drains *before* the backstop check (§10.4).
+        persist_in_settle: bool,
         tx: broadcast::Sender<StatusEvent>,
         state: parking_lot::Mutex<AskStubState>,
     }
@@ -2551,6 +2566,7 @@ mod tests {
         spawns: usize,
         turns: usize,
         prompts: Vec<String>,
+        ask_persisted: bool,
     }
     impl AskStub {
         fn new(
@@ -2559,6 +2575,7 @@ mod tests {
             run_id: &str,
             pending_ask: Arc<AtomicBool>,
             set_flag: bool,
+            persist_in_settle: bool,
         ) -> Arc<Self> {
             Arc::new(Self {
                 root,
@@ -2566,9 +2583,37 @@ mod tests {
                 run_id: run_id.to_string(),
                 pending_ask,
                 set_flag,
+                persist_in_settle,
                 tx: broadcast::channel(256).0,
                 state: parking_lot::Mutex::new(AskStubState::default()),
             })
+        }
+        /// Persist a queued ask against the run's live attempt (agent_id is still
+        /// NULL mid-turn, so resolution is by run) — exactly as the router does.
+        fn persist_ask(&self) {
+            let mut st = self.state.lock();
+            if st.ask_persisted {
+                return;
+            }
+            st.ask_persisted = true;
+            let conn = self.db.lock();
+            let exec: String = conn
+                .query_row(
+                    "SELECT id FROM wf_step_exec WHERE run_id = ?1
+                     AND status IN ('spawning','running','gating')
+                     ORDER BY rowid DESC LIMIT 1",
+                    [&self.run_id],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            conn.execute(
+                "INSERT INTO wf_message (id, run_id, from_step_exec_id, to_step_exec_id,
+                    kind, body_json, status, created_at)
+                 VALUES ('ask-msg-1', ?1, ?2, NULL, 'ask', '{\"question\":\"which db?\"}',
+                    'queued', 0)",
+                rusqlite::params![self.run_id, exec],
+            )
+            .unwrap();
         }
         fn set(&self, id: &str, s: AgentStatus) {
             self.state.lock().statuses.insert(id.to_string(), s.clone());
@@ -2633,31 +2678,14 @@ mod tests {
                 self.set(id, AgentStatus::Running);
                 if turn == 1 {
                     // First turn: ask the human (defer the gate) — no commit.
-                    // Persist a real queued ask against the run's live attempt,
-                    // exactly as the router does (agent_id is still NULL here, so
-                    // resolution is by run). The poke is raised only when
-                    // `set_flag`; otherwise the scheduler's DB backstop must catch
-                    // the queued ask.
-                    let conn = self.db.lock();
-                    let exec: String = conn
-                        .query_row(
-                            "SELECT id FROM wf_step_exec WHERE run_id = ?1
-                             AND status IN ('spawning','running','gating')
-                             ORDER BY rowid DESC LIMIT 1",
-                            [&self.run_id],
-                            |r| r.get(0),
-                        )
-                        .unwrap();
-                    conn.execute(
-                        "INSERT INTO wf_message (id, run_id, from_step_exec_id, to_step_exec_id,
-                            kind, body_json, status, created_at)
-                         VALUES (?1, ?2, ?3, NULL, 'ask', '{\"question\":\"which db?\"}', 'queued', 0)",
-                        rusqlite::params![format!("ask-msg-{turn}"), self.run_id, exec],
-                    )
-                    .unwrap();
-                    drop(conn);
-                    if self.set_flag {
-                        self.pending_ask.store(true, Ordering::SeqCst);
+                    // Unless the ask is deferred to `settle_rpc` (mailbox-drain
+                    // test), persist it now and raise the poke only when
+                    // `set_flag`; otherwise the DB backstop must catch it.
+                    if !self.persist_in_settle {
+                        self.persist_ask();
+                        if self.set_flag {
+                            self.pending_ask.store(true, Ordering::SeqCst);
+                        }
                     }
                 } else {
                     // Later turns: do the work so the commit gate is met.
@@ -2667,6 +2695,15 @@ mod tests {
                 }
                 self.set(id, AgentStatus::Idle);
                 Ok(())
+            })
+        }
+        fn settle_rpc<'a>(&'a self, _id: &'a str) -> super::super::driver::BoxFuture<'a, ()> {
+            Box::pin(async move {
+                // Models the real drain: a wf_ask the agent wrote during the turn
+                // is only dispatched (persisted) when the mailbox is settled.
+                if self.persist_in_settle {
+                    self.persist_ask();
+                }
             })
         }
         fn stop<'a>(&'a self, _id: &'a str) -> super::super::driver::BoxFuture<'a, Result<()>> {
@@ -2688,7 +2725,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let (db, ws) = scaffold_one_step(tmp.path(), "run-ask", "wf/ask-1");
         let pending_ask = Arc::new(AtomicBool::new(false));
-        let driver = AskStub::new(ws, db.clone(), "run-ask", pending_ask.clone(), true);
+        let driver = AskStub::new(ws, db.clone(), "run-ask", pending_ask.clone(), true, false);
         let ctx = RunCtx {
             db: db.clone(),
             driver: driver.clone(),
@@ -2789,7 +2826,14 @@ mod tests {
         let (db, ws) = scaffold_one_step(tmp.path(), "run-ask2", "wf/ask2-1");
         let pending_ask = Arc::new(AtomicBool::new(false));
         // set_flag = false → the ask is persisted, but the flag is never raised.
-        let driver = AskStub::new(ws, db.clone(), "run-ask2", pending_ask.clone(), false);
+        let driver = AskStub::new(
+            ws,
+            db.clone(),
+            "run-ask2",
+            pending_ask.clone(),
+            false,
+            false,
+        );
         let ctx = RunCtx {
             db: db.clone(),
             driver,
@@ -2825,6 +2869,45 @@ mod tests {
             )
             .unwrap();
         assert_eq!(commits, 0, "no ferry while an answer is outstanding");
+    }
+
+    #[tokio::test]
+    async fn mailbox_drain_surfaces_a_late_ask_before_the_check() {
+        // The tightest race: the agent wrote a wf_ask during its turn, but it is
+        // still undispatched when the turn ends — it only becomes persisted when
+        // the scheduler drains the mailbox (settle_rpc). If the scheduler checked
+        // for a pending ask *without* draining first, it would miss it and act on
+        // the gate. persist_in_settle models exactly that ordering.
+        let tmp = tempfile::tempdir().unwrap();
+        let (db, ws) = scaffold_one_step(tmp.path(), "run-ask3", "wf/ask3-1");
+        let pending_ask = Arc::new(AtomicBool::new(false));
+        // No in-turn persist, no flag — the ask surfaces only via settle_rpc.
+        let driver = AskStub::new(ws, db.clone(), "run-ask3", pending_ask.clone(), false, true);
+        let ctx = RunCtx {
+            db: db.clone(),
+            driver,
+            app: None,
+            cancel: Arc::new(AtomicBool::new(false)),
+            pending_ask,
+            deadlines: Deadlines::default(),
+        };
+
+        drive_run(&ctx, "run-ask3").await;
+
+        let (status, reason): (String, Option<String>) = db
+            .lock()
+            .query_row(
+                "SELECT status, paused_reason FROM wf_run WHERE id='run-ask3'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "paused");
+        assert_eq!(
+            reason.as_deref(),
+            Some("question"),
+            "draining the mailbox before the check must surface the late ask"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -711,7 +711,21 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
                 persist_spent(&conn, run_id, &ledger);
             }
 
-            match result.outcome {
+            // Authoritative pending-ask backstop (§10.4): the in-memory
+            // `pending_ask` poke is best-effort — it can be missed if the RPC op
+            // raced this driver's wind-down or landed just after the turn-end
+            // check — so the *persisted* ask is the source of truth. If this
+            // attempt raised a `wf_ask` still awaiting a human answer, pause
+            // `question` regardless of the gate outcome; the gate's result is
+            // never acted on (no ferry, no advance) while an answer is
+            // outstanding. `AwaitingAnswer` from the fast path lands here too.
+            let outcome = if super::comms::has_unanswered_ask(&ctx.db.lock(), &exec_id) {
+                AttemptOutcome::AwaitingAnswer
+            } else {
+                result.outcome
+            };
+
+            match outcome {
                 AttemptOutcome::Done { .. } => {
                     let wt = result
                         .worktree
@@ -1723,9 +1737,11 @@ fn slugify(name: &str) -> String {
 }
 
 /// The resume/retry guard: only a `paused(blocked_gate|stalled|budget_exceeded)`
-/// run may be re-driven. A terminal run must not restart, and a
-/// `paused(approval)` run must go through `wf_approve`. Callers run this before
-/// any state mutation so a rejected resume changes nothing.
+/// run may be re-driven. A terminal run must not restart; a `paused(approval)`
+/// run must go through `wf_approve`; and a `paused(question)` run must go through
+/// `wf_answer` — resuming it without an answer would re-prompt the step with no
+/// human response (§10.4). Callers run this before any state mutation so a
+/// rejected resume changes nothing.
 fn check_resumable(conn: &Connection, run_id: &str, action: &str) -> Result<()> {
     let (status, reason) = run_status(conn, run_id)?;
     if status != "paused" {
@@ -1734,6 +1750,11 @@ fn check_resumable(conn: &Connection, run_id: &str, action: &str) -> Result<()> 
     if reason.as_deref() == Some("approval") {
         return Err(Error::Other(
             "run is awaiting approval — use wf_approve (or wf_cancel)".into(),
+        ));
+    }
+    if reason.as_deref() == Some("question") {
+        return Err(Error::Other(
+            "run is awaiting an answer — use wf_answer (or wf_cancel)".into(),
         ));
     }
     Ok(())
@@ -2513,7 +2534,13 @@ mod tests {
     /// answer-fold on resume.
     struct AskStub {
         root: PathBuf,
+        db: Db,
+        run_id: String,
         pending_ask: Arc<AtomicBool>,
+        /// Whether turn 1 also raises the in-memory flag (fast path). `false`
+        /// exercises the scheduler's DB backstop: the ask is persisted but the
+        /// poke is "missed", and the run must still pause `question`.
+        set_flag: bool,
         tx: broadcast::Sender<StatusEvent>,
         state: parking_lot::Mutex<AskStubState>,
     }
@@ -2526,10 +2553,19 @@ mod tests {
         prompts: Vec<String>,
     }
     impl AskStub {
-        fn new(root: PathBuf, pending_ask: Arc<AtomicBool>) -> Arc<Self> {
+        fn new(
+            root: PathBuf,
+            db: Db,
+            run_id: &str,
+            pending_ask: Arc<AtomicBool>,
+            set_flag: bool,
+        ) -> Arc<Self> {
             Arc::new(Self {
                 root,
+                db,
+                run_id: run_id.to_string(),
                 pending_ask,
+                set_flag,
                 tx: broadcast::channel(256).0,
                 state: parking_lot::Mutex::new(AskStubState::default()),
             })
@@ -2597,7 +2633,32 @@ mod tests {
                 self.set(id, AgentStatus::Running);
                 if turn == 1 {
                     // First turn: ask the human (defer the gate) — no commit.
-                    self.pending_ask.store(true, Ordering::SeqCst);
+                    // Persist a real queued ask against the run's live attempt,
+                    // exactly as the router does (agent_id is still NULL here, so
+                    // resolution is by run). The poke is raised only when
+                    // `set_flag`; otherwise the scheduler's DB backstop must catch
+                    // the queued ask.
+                    let conn = self.db.lock();
+                    let exec: String = conn
+                        .query_row(
+                            "SELECT id FROM wf_step_exec WHERE run_id = ?1
+                             AND status IN ('spawning','running','gating')
+                             ORDER BY rowid DESC LIMIT 1",
+                            [&self.run_id],
+                            |r| r.get(0),
+                        )
+                        .unwrap();
+                    conn.execute(
+                        "INSERT INTO wf_message (id, run_id, from_step_exec_id, to_step_exec_id,
+                            kind, body_json, status, created_at)
+                         VALUES (?1, ?2, ?3, NULL, 'ask', '{\"question\":\"which db?\"}', 'queued', 0)",
+                        rusqlite::params![format!("ask-msg-{turn}"), self.run_id, exec],
+                    )
+                    .unwrap();
+                    drop(conn);
+                    if self.set_flag {
+                        self.pending_ask.store(true, Ordering::SeqCst);
+                    }
                 } else {
                     // Later turns: do the work so the commit gate is met.
                     std::fs::write(wt.join(format!("{id}.txt")), "work").unwrap();
@@ -2627,7 +2688,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let (db, ws) = scaffold_one_step(tmp.path(), "run-ask", "wf/ask-1");
         let pending_ask = Arc::new(AtomicBool::new(false));
-        let driver = AskStub::new(ws, pending_ask.clone());
+        let driver = AskStub::new(ws, db.clone(), "run-ask", pending_ask.clone(), true);
         let ctx = RunCtx {
             db: db.clone(),
             driver: driver.clone(),
@@ -2716,6 +2777,54 @@ mod tests {
             )
             .unwrap();
         assert_eq!(undelivered, 0, "answer should be marked delivered");
+    }
+
+    #[tokio::test]
+    async fn queued_ask_backstop_pauses_even_when_poke_is_missed() {
+        // The in-memory pending-ask poke can be lost (the RPC op races the
+        // driver's wind-down). The persisted ask is authoritative: even with the
+        // flag never set, the scheduler must pause `question` rather than act on
+        // the gate outcome (§10.4).
+        let tmp = tempfile::tempdir().unwrap();
+        let (db, ws) = scaffold_one_step(tmp.path(), "run-ask2", "wf/ask2-1");
+        let pending_ask = Arc::new(AtomicBool::new(false));
+        // set_flag = false → the ask is persisted, but the flag is never raised.
+        let driver = AskStub::new(ws, db.clone(), "run-ask2", pending_ask.clone(), false);
+        let ctx = RunCtx {
+            db: db.clone(),
+            driver,
+            app: None,
+            cancel: Arc::new(AtomicBool::new(false)),
+            pending_ask,
+            deadlines: Deadlines::default(),
+        };
+
+        drive_run(&ctx, "run-ask2").await;
+
+        let (status, reason): (String, Option<String>) = db
+            .lock()
+            .query_row(
+                "SELECT status, paused_reason FROM wf_run WHERE id='run-ask2'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "paused");
+        assert_eq!(
+            reason.as_deref(),
+            Some("question"),
+            "the persisted ask must pause the run even though the poke was missed"
+        );
+        // No boundary commit was ferried — the gate outcome was not acted on.
+        let commits: i64 = db
+            .lock()
+            .query_row(
+                "SELECT COUNT(*) FROM wf_event WHERE run_id='run-ask2' AND type='boundary_commit'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(commits, 0, "no ferry while an answer is outstanding");
     }
 
     #[tokio::test]
@@ -3002,12 +3111,16 @@ mod tests {
         };
         insert("r-done", "done", None);
         insert("r-appr", "paused", Some("approval"));
+        insert("r-ques", "paused", Some("question"));
         insert("r-budg", "paused", Some("budget_exceeded"));
         insert("r-blk", "paused", Some("blocked_gate"));
 
         let conn = db.lock();
         assert!(check_resumable(&conn, "r-done", "resume").is_err());
         assert!(check_resumable(&conn, "r-appr", "resume").is_err());
+        // A question-paused run must go through `wf_answer`, not a bare resume —
+        // otherwise the step re-runs with no human response folded in (§10.4).
+        assert!(check_resumable(&conn, "r-ques", "resume").is_err());
         assert!(check_resumable(&conn, "r-budg", "resume").is_ok());
         assert!(check_resumable(&conn, "r-blk", "retry").is_ok());
     }


### PR DESCRIPTION
Implements **S10 — Comms router** from `docs/workflows/SLICES.md` (TECH_SPEC §10.1 minus decide/compose, §10.4). Deps S1 + S4, both merged.

## What it does
Host-brokered messaging between sandboxed step agents and the workflow: agents call `wf_report` / `wf_ask` / `wf_notify` through their RPC mailbox; the engine validates against declared caps, persists to `wf_message`, journals, and — for a `wf_ask` with no orchestrator (v1) — pauses the run for the human.

## Changes
- **New `workflow/comms.rs`** — pure caps matrix, the first `wf_message` writer + `message_routed` journaling, `WorkflowCommsDispatcher` (agent-scoped; falls through to `GitDispatcher` for git/echo/ping), a coalescing delivery composer, and the `wf_answer` command. Routing/persistence/journaling are free functions over `Option<&AppHandle>` so the matrix is unit-tested against a temp DB.
- **Engine-owned delivery (§10.4)** — the router never prompts; it appends to the attempt inbox and pokes the run's driver via a shared pending-ask flag. The scheduler stays the only prompter, folding pending inbox messages into one engine-composed prompt (many messages → one turn).
- **Pending-ask gate deferral (§6.3 step 5)** — `attempt.rs` gains `pending_ask` + an `AwaitingAnswer` outcome; the gate is not evaluated while an ask is pending. A human ask → `paused(question)` + stop the agent; `wf_answer` resumes with a fresh attempt carrying the answer.
- **`prompts.rs`** — §8.5 item 6 comms section, gated on declared caps.
- **`lifecycle.rs`** — run-owned agents (`owner_run_id` set) get the comms dispatcher; **`lib.rs`** registers `wf_answer`.

## Model
Per the chosen design: a `wf_ask` routed to the human pauses `question` and stops the agent (a human pause can last days); `wf_answer` resumes with a fresh attempt whose prompt folds in the answer.

## Tests / checks
- Caps + routing matrix; report persistence + denial journaling; coalesced one-turn delivery.
- End-to-end: `wf_ask` → `paused(question)` (attempt abandoned, **gate provably not evaluated**) → `wf_answer` → resume → `done`, with the answer folded into the resumed attempt's single prompt.
- 104 workflow tests (was 97); full lib suite **697 passed / 10 ignored**; clippy clean; rustfmt applied.

## Out of scope (per slice graph)
- The `paused(question)` banner + answer affordance in the UI → **F2**.
- Orchestrator routing of `ask`/`report` and `notify` delivery → **S11**. Until then `ask`→human is the complete, useful v1 behavior (as the spec states).

🤖 Generated with [Claude Code](https://claude.com/claude-code)