### PR TITLE
feat(workflows): orchestrator role + decisions (S11)

### DIFF
--- a/src-tauri/src/workflow/attempt.rs
+++ b/src-tauri/src/workflow/attempt.rs
@@ -67,6 +67,14 @@ impl Default for Deadlines {
 /// text is composed here from the gate reason.
 pub struct AttemptParams {
     pub spawn_req: SpawnReq,
+    /// An already-spawned agent to adopt instead of spawning one here (spec
+    /// §10.2). Orchestrate children (and any concurrent-stage attempt) spawn
+    /// their agent in the scheduler and stamp `wf_step_exec.agent_id` *before*
+    /// the turn, so a mid-turn `wf_ask`/`wf_report` resolves by agent id among
+    /// the concurrent siblings. When `Some`, `spawn_req` is used only for the
+    /// `attempt_spawned` journal payload. The linear/parallel-note paths leave
+    /// this `None` and let the attempt spawn.
+    pub pre_spawned: Option<crate::workflow::driver::SpawnedAgent>,
     /// The run's blackboard directory (`…/blackboard`).
     pub blackboard: PathBuf,
     /// The `wf_step_exec` row id — for the ledger's per-attempt turn rollup.
@@ -168,6 +176,7 @@ pub async fn run_attempt(
 ) -> AttemptRun {
     let AttemptParams {
         spawn_req,
+        pre_spawned,
         blackboard,
         exec_id,
         step_id,
@@ -184,19 +193,22 @@ pub async fn run_attempt(
     let fork_base = spawn_req.fork_base.clone();
     let mut events: Vec<AttemptEvent> = Vec::new();
 
-    // ── 1. Spawn ─────────────────────────────────────────────────────────
-    let spawned = match driver.spawn(spawn_req).await {
-        Ok(s) => s,
-        Err(e) => {
-            let error = format!("spawn failed: {e}");
-            events.push(ev(event_type::ATTEMPT_ERROR, json!({ "error": error })));
-            return AttemptRun {
-                agent_id: None,
-                worktree: None,
-                outcome: AttemptOutcome::Error { error },
-                events,
-            };
-        }
+    // ── 1. Spawn (or adopt a pre-spawned agent, §10.2) ───────────────────
+    let spawned = match pre_spawned {
+        Some(s) => s,
+        None => match driver.spawn(spawn_req).await {
+            Ok(s) => s,
+            Err(e) => {
+                let error = format!("spawn failed: {e}");
+                events.push(ev(event_type::ATTEMPT_ERROR, json!({ "error": error })));
+                return AttemptRun {
+                    agent_id: None,
+                    worktree: None,
+                    outcome: AttemptOutcome::Error { error },
+                    events,
+                };
+            }
+        },
     };
     let agent_id = spawned.agent_id.clone();
     let worktree = spawned.worktree.clone();
@@ -428,6 +440,69 @@ pub async fn run_attempt(
     }
 }
 
+/// The result of one orchestrator turn (spec §10.2). Unlike a step attempt, the
+/// orchestrator is a single long-lived agent prompted many times across a stage,
+/// so the scheduler drives it turn-by-turn rather than through `run_attempt`.
+pub(super) enum OrchTurn {
+    /// The turn completed (the orchestrator went idle). The caller settles the
+    /// RPC mailbox, executes any decisions, and decides whether to prompt again.
+    Ended,
+    /// The turn stalled past the nudge deadline (spec §11.3). The caller escalates
+    /// to the human (a stalled orchestrator must not hang the stage, §10.2).
+    Stalled,
+    /// The turn could not be driven (send failure, turn-start timeout, agent
+    /// error, supervisor stop). Carries a human-readable cause.
+    Error(String),
+}
+
+/// Drive one turn of an already-spawned, ready orchestrator agent (spec §10.2).
+/// Encapsulates the subscribe-before-send discipline (§6.3 step 4) and the stall
+/// watchdog (§11.3) so the orchestrator reuses the exact turn mechanics a step
+/// attempt uses. Returns the turn result plus the journalable events
+/// (`prompt_sent`, `turn_ended`, any `watchdog_stalled`); the caller charges the
+/// budget and appends the events to the run journal.
+pub(super) async fn drive_prompt_turn(
+    driver: &dyn AgentDriver,
+    agent_id: &str,
+    prompt: String,
+    prompt_kind: &'static str,
+    deadlines: &Deadlines,
+) -> (OrchTurn, Vec<AttemptEvent>) {
+    let mut events = Vec::new();
+    // Subscribe BEFORE sending so an arbitrarily fast Running→Idle flap is
+    // unlosable (spec §6.3 step 4) — the same discipline as `run_attempt`.
+    let mut rx = driver.subscribe();
+    let snapshot = driver.status(agent_id);
+    if let Err(e) = driver.send_message(agent_id, prompt).await {
+        let error = format!("send failed: {e}");
+        events.push(ev(event_type::ATTEMPT_ERROR, json!({ "error": error })));
+        return (OrchTurn::Error(error), events);
+    }
+    events.push(ev(event_type::PROMPT_SENT, json!({ "kind": prompt_kind })));
+
+    let turn = drive_turn(driver, agent_id, &mut rx, snapshot, deadlines, &mut events).await;
+    let result = match turn {
+        TurnEnd::Ended => {
+            events.push(ev(event_type::TURN_ENDED, json!({ "status": "idle" })));
+            OrchTurn::Ended
+        }
+        TurnEnd::Stalled => {
+            events.push(ev(event_type::TURN_ENDED, json!({ "status": "stalled" })));
+            OrchTurn::Stalled
+        }
+        TurnEnd::AgentErrored => {
+            events.push(ev(event_type::TURN_ENDED, json!({ "status": "error" })));
+            OrchTurn::Error("orchestrator errored mid-turn".into())
+        }
+        TurnEnd::TurnStartTimeout => OrchTurn::Error("turn_start_timeout".into()),
+        TurnEnd::Closed => OrchTurn::Error("supervisor stopped".into()),
+        // `drive_turn` only yields `Canceled` via `run_attempt`'s cancel select,
+        // never on its own — unreachable here (no cancel is raced).
+        TurnEnd::Canceled => OrchTurn::Error("orchestrator turn canceled".into()),
+    };
+    (result, events)
+}
+
 /// Stop the (still-live) agent and return an `Error` outcome. Errored/timed-out
 /// attempts must not leave a CLI process running; the scheduler's retry/abandon
 /// path (S4b) also stops agents, and `stop` is safe to call more than once.
@@ -505,6 +580,24 @@ enum Ready {
     Timeout,
     Closed,
     Canceled,
+}
+
+/// Wait for a freshly spawned orchestrator to reach `Idle` before its first
+/// prompt (spec §10.2) — the readiness step `run_attempt` does internally,
+/// exposed for the scheduler's bespoke orchestrator loop. `Err` carries the
+/// cause (`spawn_timeout` / agent error / supervisor stop).
+pub(super) async fn await_agent_ready(
+    driver: &dyn AgentDriver,
+    agent_id: &str,
+    timeout: Duration,
+) -> std::result::Result<(), String> {
+    match wait_ready(driver, agent_id, timeout).await {
+        Ready::Idle => Ok(()),
+        Ready::Errored => Err("agent error before ready".into()),
+        Ready::Timeout => Err("spawn_timeout".into()),
+        Ready::Closed => Err("supervisor stopped".into()),
+        Ready::Canceled => Err("canceled".into()),
+    }
 }
 
 /// Wait for the agent to reach `Idle` (ready to prompt), subscribing before
@@ -693,6 +786,7 @@ mod tests {
                 run_repo: None,
                 owner_run_id: "run-1".into(),
             },
+            pre_spawned: None,
             blackboard,
             exec_id: "exec-1".into(),
             step_id: "plan".into(),

--- a/src-tauri/src/workflow/comms.rs
+++ b/src-tauri/src/workflow/comms.rs
@@ -1085,38 +1085,6 @@ pub(super) fn forward_lifecycle(
     );
 }
 
-/// Queue a `notify` note for a child step (spec §10.2 `retry_child` guidance),
-/// targeting that step's latest attempt so a fresh attempt folds it in via
-/// [`take_pending_deliveries`]. A no-op when the step has no attempt yet.
-pub(super) fn queue_child_note(conn: &Connection, run_id: &str, step_id: &str, note: &str) {
-    if note.trim().is_empty() {
-        return;
-    }
-    let exec: Option<String> = conn
-        .query_row(
-            "SELECT id FROM wf_step_exec WHERE run_id = ?1 AND step_id = ?2
-             ORDER BY rowid DESC LIMIT 1",
-            params![run_id, step_id],
-            |r| r.get(0),
-        )
-        .optional()
-        .ok()
-        .flatten();
-    if let Some(exec) = exec {
-        let _ = insert_message(
-            conn,
-            &new_msg_id(),
-            run_id,
-            None,
-            Some(&exec),
-            "notify",
-            &json!({ "message": note }),
-            "queued",
-            false,
-        );
-    }
-}
-
 /// Queue an engine-authored `ask` to the human on the orchestrator's behalf
 /// (spec §10.4) — used when the orchestrator stalls and the engine escalates, so
 /// there is a concrete question `wf_answer` can resolve on resume.

--- a/src-tauri/src/workflow/comms.rs
+++ b/src-tauri/src/workflow/comms.rs
@@ -836,7 +836,7 @@ fn route_spawn_child(
         journal_spawn_denied(conn, app, sender, &e);
         return (Response::err(id, e), Poke::None);
     }
-    let spawned = spawn_child_count(conn, &sender.run_id, &sender.step_exec_id);
+    let spawned = spawn_child_count(conn, &sender.run_id, &sender.step_id);
     if spawned >= template.max as i64 {
         let e = format!(
             "spawn_child denied: already at the children.max of {} for this stage",
@@ -880,14 +880,19 @@ fn route_spawn_child(
     (Response::ok(id, 0, msg_id, String::new()), Poke::None)
 }
 
-/// How many `spawn_child` decisions this orchestrator has already had approved
-/// (status-agnostic, so consumed ones still count toward `children.max`).
-fn spawn_child_count(conn: &Connection, run_id: &str, orch_exec: &str) -> i64 {
+/// How many `spawn_child` decisions this orchestrate *stage* has already had
+/// approved. Counted across every orchestrator exec that shares the stage's
+/// `step_id` (`orchestrate-<n>`), so a resume — which starts a fresh orchestrator
+/// exec — cannot re-grant a whole `children.max` batch. Status-agnostic, so
+/// consumed decisions still count; counting persisted decisions (created
+/// synchronously under this lock) also keeps a burst within one turn race-free.
+fn spawn_child_count(conn: &Connection, run_id: &str, orch_step_id: &str) -> i64 {
     conn.query_row(
-        "SELECT COUNT(*) FROM wf_message
-         WHERE run_id = ?1 AND from_step_exec_id = ?2 AND kind = 'decision'
-           AND json_extract(body_json, '$.decision') = 'spawn_child'",
-        params![run_id, orch_exec],
+        "SELECT COUNT(*) FROM wf_message m
+           JOIN wf_step_exec e ON m.from_step_exec_id = e.id
+         WHERE m.run_id = ?1 AND e.step_id = ?2 AND m.kind = 'decision'
+           AND json_extract(m.body_json, '$.decision') = 'spawn_child'",
+        params![run_id, orch_step_id],
         |r| r.get(0),
     )
     .unwrap_or(0)
@@ -2259,5 +2264,48 @@ mod tests {
 
         let decisions = take_orchestrator_decisions(&conn, &run, &orch);
         assert_eq!(decisions, vec![Decision::StageDone]);
+    }
+
+    #[test]
+    fn spawn_limit_persists_across_resume() {
+        let (conn, _run, _orch, _child) = seed_orchestrate(); // children.max = 2
+        for i in 0..2 {
+            let (resp, _) = route(
+                &conn,
+                None,
+                &format!("s{i}"),
+                "run",
+                "orch-agent",
+                "wf_decide",
+                &json!({ "decision": "spawn_child", "agent": "coder", "goal": "slice" }),
+            );
+            assert!(resp.ok, "{resp:?}");
+        }
+        // Resume: the stage gets a fresh orchestrator exec (same `orchestrate-0`
+        // step id); the old one is no longer live.
+        conn.execute(
+            "UPDATE wf_step_exec SET status='abandoned' WHERE id='orch-exec'",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO wf_step_exec (id,run_id,step_id,attempt,iteration,status,gate_mode,agent_id)
+             VALUES ('orch-exec-2','run','orchestrate-0',2,0,'running','verdict','orch-agent-2')",
+            [],
+        )
+        .unwrap();
+        // The resumed orchestrator cannot re-grant a whole new batch — the count is
+        // stage-wide, not per-exec.
+        let (resp, _) = route(
+            &conn,
+            None,
+            "s3",
+            "run",
+            "orch-agent-2",
+            "wf_decide",
+            &json!({ "decision": "spawn_child", "agent": "coder", "goal": "one too many" }),
+        );
+        assert!(!resp.ok, "spawn limit must persist across resume: {resp:?}");
+        assert!(resp.error.unwrap().contains("children.max"));
     }
 }

--- a/src-tauri/src/workflow/comms.rs
+++ b/src-tauri/src/workflow/comms.rs
@@ -36,12 +36,20 @@ use crate::rpc::{Response, RpcDispatcher, RpcEvent, RpcFuture};
 
 use super::now_ms;
 use super::scheduler::{self, WorkflowService};
-use super::spec::{Block, CommsCap, Spec};
+use super::spec::{Block, CommsCap, Orchestrate, Spec};
 use super::types::{event_type, Message, MessageKind};
 
 // ───────────────────────────── caps matrix (pure) ───────────────────────────
 
-/// The cap an RPC op requires, if it is a comms op (spec §10.1).
+/// The step-exec `step_id` prefix of a stage-lived orchestrator (spec §10.2).
+/// `orchestrate-<block-index>`: the block has no id of its own, so the engine
+/// synthesizes a stable one from its position in the immutable spec. Children of
+/// an orchestrate stage resolve their caps from that block (below).
+pub(super) const ORCH_PREFIX: &str = "orchestrate-";
+
+/// The cap an RPC op requires, if it is a *cap-gated* comms op (spec §10.1).
+/// `wf_decide` / `wf_compose` are gated by the orchestrator *role* (not a cap),
+/// so they return `None` here and are checked separately in [`route`].
 pub(super) fn cap_for_op(op: &str) -> Option<CommsCap> {
     match op {
         "wf_report" => Some(CommsCap::Report),
@@ -51,9 +59,10 @@ pub(super) fn cap_for_op(op: &str) -> Option<CommsCap> {
     }
 }
 
-/// Is `op` one this router owns? (Everything else falls through to git.)
+/// Is `op` one this router owns? (Everything else falls through to git.) Includes
+/// the orchestrator-only `wf_decide` (spec §10.2), which has no cap.
 pub(super) fn is_comms_op(op: &str) -> bool {
-    cap_for_op(op).is_some()
+    cap_for_op(op).is_some() || op == "wf_decide"
 }
 
 /// Human-readable verb for a rejection message.
@@ -297,8 +306,7 @@ fn resolve_sender(conn: &Connection, run_id: &str, agent_id: &str) -> Result<Sen
         )
         .map_err(|e| Error::Other(e.to_string()))?;
     let spec: Spec = serde_json::from_str(&spec_json).map_err(|e| Error::Other(e.to_string()))?;
-    let caps = step_caps(&spec, &step_id)
-        .ok_or_else(|| Error::Other(format!("step '{step_id}' not found in run spec")))?;
+    let caps = resolve_caps(conn, &spec, run_id, &step_id)?;
 
     Ok(Sender {
         run_id: run_id.to_string(),
@@ -306,6 +314,64 @@ fn resolve_sender(conn: &Connection, run_id: &str, agent_id: &str) -> Result<Sen
         step_id,
         caps,
     })
+}
+
+/// The declared comms caps of the sender (spec §10.1, §10.2):
+/// - the **orchestrator** (its `step_id` starts with [`ORCH_PREFIX`]) gets every
+///   cap ("orchestrator gets all", §5.1);
+/// - a **child of the active orchestrate stage** takes the orchestrate block's
+///   `comms` (its children's caps) — this covers both static-body children and
+///   dynamically spawned ones, whose synthetic ids aren't in the spec;
+/// - any other step resolves its own declared caps from the block tree.
+fn resolve_caps(
+    conn: &Connection,
+    spec: &Spec,
+    run_id: &str,
+    step_id: &str,
+) -> Result<Vec<CommsCap>> {
+    if step_id.starts_with(ORCH_PREFIX) {
+        return Ok(vec![CommsCap::Report, CommsCap::Ask, CommsCap::Notify]);
+    }
+    if let Some((_, orch_step_id)) = live_orchestrator(conn, run_id) {
+        if let Some(orch) = orchestrate_block(spec, &orch_step_id) {
+            return Ok(orch.comms.clone());
+        }
+    }
+    step_caps(spec, step_id)
+        .ok_or_else(|| Error::Other(format!("step '{step_id}' not found in run spec")))
+}
+
+/// The live orchestrator's `(step_exec_id, step_id)` for a run, if a stage is
+/// active. At most one orchestrate stage runs at a time (nested orchestrate is
+/// forbidden, §5.2; sequential stages don't overlap), so a single live exec whose
+/// `step_id` starts with [`ORCH_PREFIX`] identifies it.
+pub(super) fn live_orchestrator(conn: &Connection, run_id: &str) -> Option<(String, String)> {
+    conn.query_row(
+        "SELECT id, step_id FROM wf_step_exec
+         WHERE run_id = ?1 AND status IN ('spawning','running','gating')
+           AND step_id LIKE 'orchestrate-%'
+         ORDER BY rowid DESC LIMIT 1",
+        [run_id],
+        |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)),
+    )
+    .optional()
+    .ok()
+    .flatten()
+}
+
+/// The `Orchestrate` block an orchestrator `step_id` (`orchestrate-<idx>`) refers
+/// to, by parsing the index and indexing the immutable top-level spec sequence.
+pub(super) fn orchestrate_block<'a>(spec: &'a Spec, orch_step_id: &str) -> Option<&'a Orchestrate> {
+    let idx: usize = orch_step_id.strip_prefix(ORCH_PREFIX)?.parse().ok()?;
+    match spec.workflow.get(idx)? {
+        Block::Orchestrate(o) => Some(o),
+        _ => None,
+    }
+}
+
+/// The synthetic `step_id` for the orchestrator of the top-level block at `index`.
+pub(super) fn orch_step_id(block_index: usize) -> String {
+    format!("{ORCH_PREFIX}{block_index}")
 }
 
 // ───────────────────────────── routing core (testable) ──────────────────────
@@ -335,6 +401,18 @@ fn route(
         Ok(s) => s,
         Err(e) => return (Response::err(id, e.to_string()), Poke::None),
     };
+
+    // `wf_decide` is gated by the orchestrator *role*, not a cap (spec §10.2):
+    // only the stage-lived orchestrator may issue decisions.
+    if op == "wf_decide" {
+        if !sender_is_orchestrator(&sender) {
+            let e = "wf_decide is available to the orchestrator only".to_string();
+            journal_denied(conn, app, &sender, op, &e);
+            return (Response::err(id, e), Poke::None);
+        }
+        return route_decide(conn, app, &sender, id, args);
+    }
+
     if let Err(e) = check_cap(op, &sender.caps) {
         // Journaled, never a silent drop (§10.1): the timeline shows the denied
         // attempt.
@@ -345,18 +423,20 @@ fn route(
     match op {
         "wf_report" => (route_report(conn, app, &sender, id, args), Poke::None),
         "wf_ask" => route_ask(conn, app, &sender, id, args),
-        // `wf_notify` is orchestrator-only; check_cap already rejected it for a
-        // step. Reachable only if a future block granted the cap — refuse until
-        // S11 wires orchestrator delivery.
-        "wf_notify" => (
-            Response::err(id, "notify is not available in this workflow yet"),
-            Poke::None,
-        ),
+        // `wf_notify` is orchestrator-only — `check_cap` already rejected it for a
+        // child (no step is granted `notify`, §5.2), so only the orchestrator
+        // reaches here.
+        "wf_notify" => (route_notify(conn, app, &sender, id, args), Poke::None),
         other => (
             Response::err(id, format!("unknown op: {other}")),
             Poke::None,
         ),
     }
+}
+
+/// Whether the sending attempt is the stage-lived orchestrator (spec §10.2).
+fn sender_is_orchestrator(sender: &Sender) -> bool {
+    sender.step_id.starts_with(ORCH_PREFIX)
 }
 
 fn route_report(
@@ -376,23 +456,39 @@ fn route_report(
     }
     let body = json!({ "status": status, "note": note });
     let msg_id = new_msg_id();
-    // No orchestrator in v1: a report is recorded on the timeline and otherwise a
-    // no-op (it never replaces the verdict). Marked delivered — nothing to route.
+    // Forwarded to the orchestrator when a stage is active (spec §10.1: "wf_report
+    // only adds color"); otherwise recorded on the timeline and delivered (a
+    // report never replaces the verdict). The orchestrator picks queued reports
+    // up at its next turn via `take_orchestrator_inbox`.
+    let orchestrator = child_orchestrator(conn, sender);
+    let (to, msg_status, delivered) = match &orchestrator {
+        Some((orch_exec, _)) => (Some(orch_exec.as_str()), "queued", false),
+        None => (None, "delivered", true),
+    };
     if let Err(e) = insert_message(
         conn,
         &msg_id,
         &sender.run_id,
         Some(&sender.step_exec_id),
-        None,
+        to,
         "report",
         &body,
-        "delivered",
-        true,
+        msg_status,
+        delivered,
     ) {
         return Response::err(id, e.to_string());
     }
-    journal_routed(conn, app, sender, &msg_id, "report", None);
+    journal_routed(conn, app, sender, &msg_id, "report", to);
     Response::ok(id, 0, msg_id, String::new())
+}
+
+/// The active orchestrator `(step_exec_id, step_id)` a *child* sender should route
+/// to — `None` when the sender is itself the orchestrator or no stage is active.
+fn child_orchestrator(conn: &Connection, sender: &Sender) -> Option<(String, String)> {
+    if sender_is_orchestrator(sender) {
+        return None;
+    }
+    live_orchestrator(conn, &sender.run_id)
 }
 
 fn route_ask(
@@ -414,13 +510,19 @@ fn route_ask(
         body["options"] = options.clone();
     }
     let msg_id = new_msg_id();
-    // Routed to the human (no orchestrator in v1): to_step_exec_id = NULL.
+    // A child's ask routes to the orchestrator when a stage is active (spec §10.1);
+    // otherwise (and for the orchestrator's own ask) it routes to the human, which
+    // pauses the run `question` (§10.4). Either way the ask stays `queued` — the
+    // sender's attempt sees an unanswered ask and defers its gate; it is marked
+    // `answered` when the orchestrator (or human) replies.
+    let orchestrator = child_orchestrator(conn, sender);
+    let to = orchestrator.as_ref().map(|(exec, _)| exec.as_str());
     if let Err(e) = insert_message(
         conn,
         &msg_id,
         &sender.run_id,
         Some(&sender.step_exec_id),
-        None,
+        to,
         "ask",
         &body,
         "queued",
@@ -428,13 +530,699 @@ fn route_ask(
     ) {
         return (Response::err(id, e.to_string()), Poke::None);
     }
-    journal_routed(conn, app, sender, &msg_id, "ask", None);
-    (
-        Response::ok(id, 0, msg_id, String::new()),
+    journal_routed(conn, app, sender, &msg_id, "ask", to);
+    // Routed to the orchestrator: the orchestrate loop polls its inbox, so no
+    // human pause. Routed to the human: raise the pending-ask flag so the run
+    // pauses `question` at turn end.
+    let poke = if orchestrator.is_some() {
+        Poke::None
+    } else {
         Poke::AskQueued {
             run_id: sender.run_id.clone(),
-        },
+        }
+    };
+    (Response::ok(id, 0, msg_id, String::new()), poke)
+}
+
+/// `wf_notify` (orchestrator only, spec §10.1): push a notice to one running child
+/// (`to: <step-id>`) or all of them (`to: "all-children"`). Each notice is queued
+/// to the child's live attempt; the child folds it into its next engine-composed
+/// prompt (§10.4). Best-effort — a notice to a child with no live attempt is a
+/// no-op, journaled with `to: null`.
+fn route_notify(
+    conn: &Connection,
+    app: Option<&AppHandle>,
+    sender: &Sender,
+    id: &str,
+    args: &Value,
+) -> Response {
+    let message = args.get("message").and_then(|v| v.as_str()).unwrap_or("");
+    if message.trim().is_empty() {
+        return Response::err(id, "wf_notify requires a non-empty `message`");
+    }
+    let to = args.get("to").and_then(|v| v.as_str()).unwrap_or("");
+    if to.trim().is_empty() {
+        return Response::err(
+            id,
+            "wf_notify requires `to` (a child step-id or \"all-children\")",
+        );
+    }
+    let recipients = live_children(
+        conn,
+        &sender.run_id,
+        if to == "all-children" { None } else { Some(to) },
+    );
+    if recipients.is_empty() {
+        journal_routed(conn, app, sender, &new_msg_id(), "notify", None);
+        return Response::ok(id, 0, String::new(), String::new());
+    }
+    let body = json!({ "message": message });
+    for child_exec in &recipients {
+        let msg_id = new_msg_id();
+        let _ = insert_message(
+            conn,
+            &msg_id,
+            &sender.run_id,
+            Some(&sender.step_exec_id),
+            Some(child_exec),
+            "notify",
+            &body,
+            "queued",
+            false,
+        );
+        journal_routed(conn, app, sender, &msg_id, "notify", Some(child_exec));
+    }
+    Response::ok(id, 0, String::new(), String::new())
+}
+
+/// Live (non-terminal) child attempts of the active orchestrate stage — every
+/// live step exec that is not the orchestrator, optionally filtered to one
+/// `step_id`. The recipients of `wf_notify`.
+fn live_children(conn: &Connection, run_id: &str, step_id: Option<&str>) -> Vec<String> {
+    let want = step_id.map(str::to_string);
+    conn.prepare(
+        "SELECT id, step_id FROM wf_step_exec
+         WHERE run_id = ?1 AND status IN ('spawning','running','gating')
+           AND step_id NOT LIKE 'orchestrate-%'
+         ORDER BY rowid",
     )
+    .and_then(|mut s| {
+        s.query_map([run_id], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+        })
+        .map(|it| {
+            it.filter_map(std::result::Result::ok)
+                .filter(|(_, sid)| want.as_deref().map(|w| w == sid).unwrap_or(true))
+                .map(|(id, _)| id)
+                .collect()
+        })
+    })
+    .unwrap_or_default()
+}
+
+// ───────────────────────────── decisions (§10.2) ────────────────────────────
+
+/// A decision the orchestrator issued that the *scheduler* must execute (spec
+/// §10.2). `answer` and `escalate` are completed in the router (a pure DB write /
+/// a human pause), so they are not represented here; these are the ones that need
+/// the driver + child JoinSet the orchestrate stage owns.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Decision {
+    /// Start another dynamic child (already validated ≤ `children.max`).
+    SpawnChild { agent: String, goal: String },
+    /// Drop a child that is no longer needed.
+    SkipChild { step_id: String, reason: String },
+    /// Ask a finished child to try again with guidance.
+    RetryChild { step_id: String, guidance: String },
+    /// End the stage now (early join, spec §6.6).
+    StageDone,
+}
+
+/// Handle a `wf_decide` op (spec §10.2). Validates the decision, journals it, and
+/// either completes it here (`answer` / `escalate`) or persists it as a queued
+/// `decision` message the orchestrate stage consumes via
+/// [`take_orchestrator_decisions`]. Invalid decisions (unknown step, over
+/// `children.max`, missing fields) return a structured error and are journaled —
+/// the deterministic engine, not the orchestrator, is the authority.
+fn route_decide(
+    conn: &Connection,
+    app: Option<&AppHandle>,
+    sender: &Sender,
+    id: &str,
+    args: &Value,
+) -> (Response, Poke) {
+    let decision = args.get("decision").and_then(|v| v.as_str()).unwrap_or("");
+    match decision {
+        "answer" => {
+            let message_id = args
+                .get("message_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let body = args.get("body").and_then(|v| v.as_str()).unwrap_or("");
+            if message_id.is_empty() || body.trim().is_empty() {
+                return (
+                    Response::err(
+                        id,
+                        "wf_decide answer requires `message_id` and a non-empty `body`",
+                    ),
+                    Poke::None,
+                );
+            }
+            match deliver_orchestrator_answer(conn, app, sender, message_id, body) {
+                Ok(()) => {
+                    journal_decision(
+                        conn,
+                        app,
+                        sender,
+                        &json!({ "decision": "answer", "message_id": message_id }),
+                    );
+                    (
+                        Response::ok(id, 0, String::new(), String::new()),
+                        Poke::None,
+                    )
+                }
+                Err(e) => (Response::err(id, e.to_string()), Poke::None),
+            }
+        }
+        "spawn_child" => route_spawn_child(conn, app, sender, id, args),
+        "skip_child" => {
+            let step_id = args.get("step_id").and_then(|v| v.as_str()).unwrap_or("");
+            if step_id.is_empty() {
+                return (
+                    Response::err(id, "wf_decide skip_child requires `step_id`"),
+                    Poke::None,
+                );
+            }
+            let reason = args
+                .get("reason")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            queue_decision(
+                conn,
+                app,
+                sender,
+                id,
+                json!({ "decision": "skip_child", "step_id": step_id, "reason": reason }),
+            )
+        }
+        "retry_child" => {
+            let step_id = args.get("step_id").and_then(|v| v.as_str()).unwrap_or("");
+            if step_id.is_empty() {
+                return (
+                    Response::err(id, "wf_decide retry_child requires `step_id`"),
+                    Poke::None,
+                );
+            }
+            let guidance = args
+                .get("guidance")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            queue_decision(
+                conn,
+                app,
+                sender,
+                id,
+                json!({ "decision": "retry_child", "step_id": step_id, "guidance": guidance }),
+            )
+        }
+        "stage_done" => queue_decision(conn, app, sender, id, json!({ "decision": "stage_done" })),
+        "escalate" => {
+            let question = args.get("question").and_then(|v| v.as_str()).unwrap_or("");
+            if question.trim().is_empty() {
+                return (
+                    Response::err(id, "wf_decide escalate requires a non-empty `question`"),
+                    Poke::None,
+                );
+            }
+            // Escalation is the orchestrator asking the human: queue an ask from
+            // the orchestrator (to = NULL) so the orchestrate loop's pending-ask
+            // backstop pauses the run `question`, and `wf_answer` delivers back to
+            // the orchestrator (§10.4).
+            let msg_id = new_msg_id();
+            if let Err(e) = insert_message(
+                conn,
+                &msg_id,
+                &sender.run_id,
+                Some(&sender.step_exec_id),
+                None,
+                "ask",
+                &json!({ "question": question }),
+                "queued",
+                false,
+            ) {
+                return (Response::err(id, e.to_string()), Poke::None);
+            }
+            journal_decision(conn, app, sender, &json!({ "decision": "escalate" }));
+            journal_routed(conn, app, sender, &msg_id, "ask", None);
+            (
+                Response::ok(id, 0, msg_id, String::new()),
+                Poke::AskQueued {
+                    run_id: sender.run_id.clone(),
+                },
+            )
+        }
+        other => (
+            Response::err(id, format!("unknown decision: {other}")),
+            Poke::None,
+        ),
+    }
+}
+
+/// Journal a decision and persist it as a queued `decision` message for the
+/// orchestrate stage to execute (spec §10.2).
+fn queue_decision(
+    conn: &Connection,
+    app: Option<&AppHandle>,
+    sender: &Sender,
+    id: &str,
+    body: Value,
+) -> (Response, Poke) {
+    let msg_id = new_msg_id();
+    if let Err(e) = insert_message(
+        conn,
+        &msg_id,
+        &sender.run_id,
+        Some(&sender.step_exec_id),
+        None,
+        "decision",
+        &body,
+        "queued",
+        false,
+    ) {
+        return (Response::err(id, e.to_string()), Poke::None);
+    }
+    journal_decision(conn, app, sender, &body);
+    (Response::ok(id, 0, msg_id, String::new()), Poke::None)
+}
+
+/// Validate + record a `spawn_child` decision (spec §10.2): the agent must be the
+/// block's `children` template agent and the count must stay within
+/// `children.max`. Over-max or template-less spawns are denied with a structured
+/// error and a `child_spawn_denied` journal entry.
+fn route_spawn_child(
+    conn: &Connection,
+    app: Option<&AppHandle>,
+    sender: &Sender,
+    id: &str,
+    args: &Value,
+) -> (Response, Poke) {
+    let goal = args.get("goal").and_then(|v| v.as_str()).unwrap_or("");
+    if goal.trim().is_empty() {
+        return (
+            Response::err(id, "wf_decide spawn_child requires a non-empty `goal`"),
+            Poke::None,
+        );
+    }
+    let Some(spec) = load_spec(conn, &sender.run_id) else {
+        return (Response::err(id, "run spec unavailable"), Poke::None);
+    };
+    let template = orchestrate_block(&spec, &sender.step_id).and_then(|o| o.children.clone());
+    let Some(template) = template else {
+        let e = "this stage has no dynamic-child template (spawn_child unavailable)".to_string();
+        journal_spawn_denied(conn, app, sender, &e);
+        return (Response::err(id, e), Poke::None);
+    };
+    let agent = args
+        .get("agent")
+        .and_then(|v| v.as_str())
+        .unwrap_or(&template.agent);
+    if agent != template.agent {
+        let e = format!(
+            "spawn_child agent must be the template's child agent '{}'",
+            template.agent
+        );
+        journal_spawn_denied(conn, app, sender, &e);
+        return (Response::err(id, e), Poke::None);
+    }
+    let spawned = spawn_child_count(conn, &sender.run_id, &sender.step_exec_id);
+    if spawned >= template.max as i64 {
+        let e = format!(
+            "spawn_child denied: already at the children.max of {} for this stage",
+            template.max
+        );
+        journal_spawn_denied(conn, app, sender, &e);
+        return (Response::err(id, e), Poke::None);
+    }
+    // Approved: journal the request + approval, then queue the decision for the
+    // orchestrate stage to actually spawn.
+    scheduler::journal_event(
+        conn,
+        app,
+        &sender.run_id,
+        event_type::CHILD_SPAWN_REQUESTED,
+        Some(&sender.step_exec_id),
+        &json!({ "agent": agent, "goal": goal }),
+    );
+    scheduler::journal_event(
+        conn,
+        app,
+        &sender.run_id,
+        event_type::CHILD_SPAWN_APPROVED,
+        Some(&sender.step_exec_id),
+        &json!({ "agent": agent }),
+    );
+    let msg_id = new_msg_id();
+    if let Err(e) = insert_message(
+        conn,
+        &msg_id,
+        &sender.run_id,
+        Some(&sender.step_exec_id),
+        None,
+        "decision",
+        &json!({ "decision": "spawn_child", "agent": agent, "goal": goal }),
+        "queued",
+        false,
+    ) {
+        return (Response::err(id, e.to_string()), Poke::None);
+    }
+    (Response::ok(id, 0, msg_id, String::new()), Poke::None)
+}
+
+/// How many `spawn_child` decisions this orchestrator has already had approved
+/// (status-agnostic, so consumed ones still count toward `children.max`).
+fn spawn_child_count(conn: &Connection, run_id: &str, orch_exec: &str) -> i64 {
+    conn.query_row(
+        "SELECT COUNT(*) FROM wf_message
+         WHERE run_id = ?1 AND from_step_exec_id = ?2 AND kind = 'decision'
+           AND json_extract(body_json, '$.decision') = 'spawn_child'",
+        params![run_id, orch_exec],
+        |r| r.get(0),
+    )
+    .unwrap_or(0)
+}
+
+/// Consume the queued `decision` messages the orchestrator issued (spec §10.2),
+/// marking them delivered. `answer` / `escalate` are already handled in the
+/// router, so only [`Decision`] variants the scheduler executes are returned.
+pub(super) fn take_orchestrator_decisions(
+    conn: &Connection,
+    run_id: &str,
+    orch_exec: &str,
+) -> Vec<Decision> {
+    let rows: Vec<(String, Value)> = conn
+        .prepare(
+            "SELECT id, body_json FROM wf_message
+             WHERE run_id = ?1 AND from_step_exec_id = ?2 AND kind = 'decision'
+               AND status = 'queued'
+             ORDER BY created_at, rowid",
+        )
+        .and_then(|mut s| {
+            s.query_map(params![run_id, orch_exec], |r| {
+                let body: String = r.get(1)?;
+                Ok((
+                    r.get::<_, String>(0)?,
+                    serde_json::from_str(&body).unwrap_or(Value::Null),
+                ))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()
+        })
+        .unwrap_or_default();
+
+    let mut out = Vec::new();
+    for (msg_id, body) in rows {
+        let _ = conn.execute(
+            "UPDATE wf_message SET status = 'delivered', delivered_at = ?1 WHERE id = ?2",
+            params![now_ms(), msg_id],
+        );
+        let d = body.get("decision").and_then(|v| v.as_str()).unwrap_or("");
+        let s = |k: &str| {
+            body.get(k)
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string()
+        };
+        match d {
+            "spawn_child" => out.push(Decision::SpawnChild {
+                agent: s("agent"),
+                goal: s("goal"),
+            }),
+            "skip_child" => out.push(Decision::SkipChild {
+                step_id: s("step_id"),
+                reason: s("reason"),
+            }),
+            "retry_child" => out.push(Decision::RetryChild {
+                step_id: s("step_id"),
+                guidance: s("guidance"),
+            }),
+            "stage_done" => out.push(Decision::StageDone),
+            _ => {}
+        }
+    }
+    out
+}
+
+/// One message queued for the orchestrator's attention, with the sending child's
+/// step id resolved for a readable prompt.
+pub(super) struct InboxItem {
+    pub from_step_id: String,
+    pub message: Message,
+}
+
+/// Take the messages queued for the orchestrator (children's `wf_report`s, their
+/// `wf_ask`s, and engine lifecycle notices) that it has not yet been shown, in
+/// order (spec §10.1). Marks each shown via `delivered_at` — an **ask stays
+/// `queued`** (its `status` is what `has_unanswered_ask` reads, so the child keeps
+/// deferring until the orchestrator answers), it is just not shown twice.
+pub(super) fn take_orchestrator_inbox(
+    conn: &Connection,
+    run_id: &str,
+    orch_exec: &str,
+) -> Vec<InboxItem> {
+    let items: Vec<InboxItem> = conn
+        .prepare(
+            "SELECT m.*, e.step_id FROM wf_message m
+               JOIN wf_step_exec e ON m.from_step_exec_id = e.id
+             WHERE m.run_id = ?1 AND m.to_step_exec_id = ?2
+               AND m.kind IN ('report', 'ask') AND m.delivered_at IS NULL
+             ORDER BY m.created_at, m.rowid",
+        )
+        .and_then(|mut stmt| {
+            stmt.query_map(params![run_id, orch_exec], |r| {
+                let from_step_id: String = r.get("step_id")?;
+                Ok(InboxItem {
+                    from_step_id,
+                    message: Message::from_row(r)?,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()
+        })
+        .unwrap_or_default();
+
+    let now = now_ms();
+    for item in &items {
+        let _ = conn.execute(
+            "UPDATE wf_message SET delivered_at = ?1 WHERE id = ?2",
+            params![now, item.message.id],
+        );
+    }
+    items
+}
+
+/// Compose the one engine-owned prompt preamble that hands the orchestrator its
+/// pending inbox (spec §10.1, §10.4). Asks carry their `message_id` so the
+/// orchestrator can answer them with `wf_decide`.
+pub(super) fn compose_orchestrator_inbox(items: &[InboxItem]) -> String {
+    let mut s = String::from(
+        "## Updates from your children\n\n\
+         Since your last turn, the following arrived. Act on them, then continue \
+         leading the stage.\n\n",
+    );
+    for item in items {
+        let m = &item.message;
+        let step = &item.from_step_id;
+        match m.kind {
+            MessageKind::Ask => {
+                let q = body_str(&m.body, "question");
+                s.push_str(&format!(
+                    "- **`{step}` asks** (answer with message_id `{}`): {q}\n",
+                    m.id
+                ));
+                if let Some(opts) = m.body.get("options").and_then(|v| v.as_array()) {
+                    let opts: Vec<String> = opts
+                        .iter()
+                        .filter_map(|o| o.as_str().map(str::to_string))
+                        .collect();
+                    if !opts.is_empty() {
+                        s.push_str(&format!("    options: {}\n", opts.join(", ")));
+                    }
+                }
+            }
+            MessageKind::Report => {
+                let note = body_str(&m.body, "note");
+                let status = body_str(&m.body, "status");
+                if m.body.get("lifecycle").and_then(|v| v.as_bool()) == Some(true) {
+                    s.push_str(&format!("- **`{step}` {status}** — {note}\n"));
+                } else if status == "done" {
+                    s.push_str(&format!("- **`{step}` reports done**: {note}\n"));
+                } else {
+                    s.push_str(&format!("- **`{step}` reports progress**: {note}\n"));
+                }
+            }
+            _ => {}
+        }
+    }
+    s
+}
+
+/// Auto-forward a child's terminal outcome to the orchestrator as a lifecycle
+/// report (spec §10.1: a child can never *forget* to report completion). Journaled
+/// as a routed message; picked up on the orchestrator's next turn.
+pub(super) fn forward_lifecycle(
+    conn: &Connection,
+    app: Option<&AppHandle>,
+    run_id: &str,
+    orch_exec: &str,
+    child_exec: &str,
+    status: &str,
+    note: &str,
+) {
+    let msg_id = new_msg_id();
+    let _ = insert_message(
+        conn,
+        &msg_id,
+        run_id,
+        Some(child_exec),
+        Some(orch_exec),
+        "report",
+        &json!({ "status": status, "note": note, "lifecycle": true }),
+        "queued",
+        false,
+    );
+    scheduler::journal_event(
+        conn,
+        app,
+        run_id,
+        event_type::MESSAGE_ROUTED,
+        Some(child_exec),
+        &json!({ "message_id": msg_id, "kind": "report", "from": child_exec, "to": orch_exec, "lifecycle": true }),
+    );
+}
+
+/// Queue a `notify` note for a child step (spec §10.2 `retry_child` guidance),
+/// targeting that step's latest attempt so a fresh attempt folds it in via
+/// [`take_pending_deliveries`]. A no-op when the step has no attempt yet.
+pub(super) fn queue_child_note(conn: &Connection, run_id: &str, step_id: &str, note: &str) {
+    if note.trim().is_empty() {
+        return;
+    }
+    let exec: Option<String> = conn
+        .query_row(
+            "SELECT id FROM wf_step_exec WHERE run_id = ?1 AND step_id = ?2
+             ORDER BY rowid DESC LIMIT 1",
+            params![run_id, step_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .ok()
+        .flatten();
+    if let Some(exec) = exec {
+        let _ = insert_message(
+            conn,
+            &new_msg_id(),
+            run_id,
+            None,
+            Some(&exec),
+            "notify",
+            &json!({ "message": note }),
+            "queued",
+            false,
+        );
+    }
+}
+
+/// Queue an engine-authored `ask` to the human on the orchestrator's behalf
+/// (spec §10.4) — used when the orchestrator stalls and the engine escalates, so
+/// there is a concrete question `wf_answer` can resolve on resume.
+pub(super) fn queue_engine_ask(conn: &Connection, run_id: &str, orch_exec: &str, question: &str) {
+    let _ = insert_message(
+        conn,
+        &new_msg_id(),
+        run_id,
+        Some(orch_exec),
+        None,
+        "ask",
+        &json!({ "question": question }),
+        "queued",
+        false,
+    );
+}
+
+/// Deliver the orchestrator's answer to a child's ask (spec §10.2). Marks the ask
+/// `answered` and queues an `answer` to the asking child, which folds it into its
+/// next prompt (§10.4). Rejects an answer to an ask not addressed to this
+/// orchestrator or already answered.
+fn deliver_orchestrator_answer(
+    conn: &Connection,
+    app: Option<&AppHandle>,
+    sender: &Sender,
+    message_id: &str,
+    body: &str,
+) -> Result<()> {
+    let (asking_exec, to_exec, status) = conn
+        .query_row(
+            "SELECT from_step_exec_id, to_step_exec_id, status FROM wf_message
+             WHERE id = ?1 AND run_id = ?2 AND kind = 'ask'",
+            params![message_id, sender.run_id],
+            |r| {
+                Ok((
+                    r.get::<_, Option<String>>(0)?,
+                    r.get::<_, Option<String>>(1)?,
+                    r.get::<_, String>(2)?,
+                ))
+            },
+        )
+        .optional()
+        .map_err(|e| Error::Other(e.to_string()))?
+        .ok_or_else(|| Error::Other("no such question on this run".into()))?;
+    if to_exec.as_deref() != Some(sender.step_exec_id.as_str()) {
+        return Err(Error::Other("that question was not routed to you".into()));
+    }
+    if status != "queued" {
+        return Err(Error::Other("that question was already answered".into()));
+    }
+    let ans_id = new_msg_id();
+    insert_message(
+        conn,
+        &ans_id,
+        &sender.run_id,
+        Some(&sender.step_exec_id),
+        asking_exec.as_deref(),
+        "answer",
+        &json!({ "text": body }),
+        "queued",
+        false,
+    )
+    .map_err(|e| Error::Other(e.to_string()))?;
+    conn.execute(
+        "UPDATE wf_message SET status = 'answered' WHERE id = ?1",
+        [message_id],
+    )
+    .map_err(|e| Error::Other(e.to_string()))?;
+    scheduler::journal_event(
+        conn,
+        app,
+        &sender.run_id,
+        event_type::MESSAGE_ROUTED,
+        asking_exec.as_deref(),
+        &json!({ "message_id": ans_id, "kind": "answer", "from": sender.step_exec_id, "to": asking_exec }),
+    );
+    Ok(())
+}
+
+fn journal_decision(conn: &Connection, app: Option<&AppHandle>, sender: &Sender, payload: &Value) {
+    scheduler::journal_event(
+        conn,
+        app,
+        &sender.run_id,
+        event_type::DECISION,
+        Some(&sender.step_exec_id),
+        payload,
+    );
+}
+
+fn journal_spawn_denied(conn: &Connection, app: Option<&AppHandle>, sender: &Sender, reason: &str) {
+    scheduler::journal_event(
+        conn,
+        app,
+        &sender.run_id,
+        event_type::CHILD_SPAWN_DENIED,
+        Some(&sender.step_exec_id),
+        &json!({ "reason": reason }),
+    );
+}
+
+/// Load a run's launch-frozen spec.
+fn load_spec(conn: &Connection, run_id: &str) -> Option<Spec> {
+    let spec_json: String = conn
+        .query_row(
+            "SELECT spec_json FROM wf_run WHERE id = ?1",
+            [run_id],
+            |r| r.get(0),
+        )
+        .ok()?;
+    serde_json::from_str(&spec_json).ok()
 }
 
 /// Persist a human's answer to a paused `question` run and journal it. Does not
@@ -700,7 +1488,9 @@ pub async fn wf_answer(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::workflow::spec::{AgentSpec, Gate, Step};
+    use crate::workflow::spec::{
+        AgentSpec, ChildTemplate, Gate, Integrate, Join, Orchestrate, Step,
+    };
     use crate::workflow::types::{MessageKind, MessageStatus};
     use std::collections::BTreeMap;
 
@@ -1119,5 +1909,355 @@ mod tests {
             !has_unanswered_ask(&conn, &exec),
             "answered ask is no longer pending"
         );
+    }
+
+    // ── orchestrator role + decisions (spec §10.2) ────────────────────────
+
+    /// A running orchestrate stage: an `orchestrate-0` block (agent `orch`,
+    /// dynamic `coder` children max 2, child caps `[report, ask]`), one live
+    /// orchestrator exec, and one live child exec. Returns (conn, run, orch_exec,
+    /// child_exec).
+    fn seed_orchestrate() -> (Connection, String, String, String) {
+        let td = tempfile::tempdir().unwrap();
+        let db = crate::database::init(td.path()).unwrap();
+        std::mem::forget(td);
+        let conn = Arc::try_unwrap(db).ok().unwrap().into_inner();
+
+        let mut agents = BTreeMap::new();
+        for a in ["orch", "coder"] {
+            agents.insert(
+                a.to_string(),
+                AgentSpec {
+                    base: "claude".into(),
+                    model: None,
+                    instructions: None,
+                    skills: vec![],
+                    custom_agent: None,
+                },
+            );
+        }
+        let spec = Spec {
+            version: 1,
+            name: "demo".into(),
+            description: None,
+            budgets: None,
+            agents,
+            workflow: vec![Block::Orchestrate(Orchestrate {
+                agent: "orch".into(),
+                goal: "lead".into(),
+                children: Some(ChildTemplate {
+                    agent: "coder".into(),
+                    max: 2,
+                }),
+                body: vec![],
+                join: Join::All,
+                integrate: Integrate::None,
+                comms: vec![CommsCap::Report, CommsCap::Ask],
+                compose: None,
+            })],
+            finalize: None,
+        };
+        let spec_json = serde_json::to_string(&spec).unwrap();
+        conn.execute(
+            "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,branch,
+                base_sha,status,budgets_json,spent_json,created_at,updated_at)
+             VALUES ('run','demo',?1,'t','p','/repo','/rd','wf/x','sha','running','{}','{}',0,0)",
+            [spec_json],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO wf_step_exec (id,run_id,step_id,attempt,iteration,status,gate_mode,agent_id)
+             VALUES ('orch-exec','run','orchestrate-0',1,0,'running','verdict','orch-agent')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO wf_step_exec (id,run_id,step_id,attempt,iteration,status,gate_mode,agent_id)
+             VALUES ('child-exec','run','child-1',1,0,'running','verdict','child-agent')",
+            [],
+        )
+        .unwrap();
+        (
+            conn,
+            "run".to_string(),
+            "orch-exec".to_string(),
+            "child-exec".to_string(),
+        )
+    }
+
+    #[test]
+    fn wf_decide_is_orchestrator_only() {
+        let (conn, _run, _orch, _child) = seed_orchestrate();
+        let (resp, poke) = route(
+            &conn,
+            None,
+            "r1",
+            "run",
+            "child-agent",
+            "wf_decide",
+            &json!({ "decision": "stage_done" }),
+        );
+        assert!(!resp.ok);
+        assert!(resp.error.unwrap().contains("orchestrator"));
+        assert!(matches!(poke, Poke::None));
+    }
+
+    #[test]
+    fn child_caps_come_from_the_orchestrate_block() {
+        let (conn, run, _orch, _child) = seed_orchestrate();
+        let spec = load_spec(&conn, &run).unwrap();
+        // Child inherits the block's [report, ask]; the orchestrator gets all.
+        let child_caps = resolve_caps(&conn, &spec, &run, "child-1").unwrap();
+        assert_eq!(child_caps, vec![CommsCap::Report, CommsCap::Ask]);
+        let orch_caps = resolve_caps(&conn, &spec, &run, "orchestrate-0").unwrap();
+        assert!(
+            orch_caps.contains(&CommsCap::Notify),
+            "orchestrator gets notify"
+        );
+    }
+
+    #[test]
+    fn child_ask_routes_to_the_orchestrator_not_the_human() {
+        let (conn, _run, orch, child) = seed_orchestrate();
+        let (resp, poke) = route(
+            &conn,
+            None,
+            "r1",
+            "run",
+            "child-agent",
+            "wf_ask",
+            &json!({ "question": "which db?" }),
+        );
+        assert!(resp.ok, "{resp:?}");
+        // No human pause — the orchestrator handles it.
+        assert!(
+            matches!(poke, Poke::None),
+            "child ask must not pause the run"
+        );
+        let to: String = conn
+            .query_row(
+                "SELECT to_step_exec_id FROM wf_message WHERE kind='ask'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(to, orch);
+        assert!(
+            has_unanswered_ask(&conn, &child),
+            "child defers until answered"
+        );
+    }
+
+    #[test]
+    fn orchestrator_answers_a_child_ask() {
+        let (conn, run, orch, child) = seed_orchestrate();
+        // The child asks.
+        let (resp, _) = route(
+            &conn,
+            None,
+            "r1",
+            "run",
+            "child-agent",
+            "wf_ask",
+            &json!({ "question": "which db?", "options": ["pg", "sqlite"] }),
+        );
+        let ask_id = resp.stdout.unwrap();
+
+        // The orchestrator sees it in its inbox with the message id to answer.
+        let inbox = take_orchestrator_inbox(&conn, &run, &orch);
+        assert_eq!(inbox.len(), 1);
+        assert_eq!(inbox[0].from_step_id, "child-1");
+        assert_eq!(inbox[0].message.id, ask_id);
+        assert!(compose_orchestrator_inbox(&inbox).contains(&ask_id));
+
+        // The orchestrator answers via wf_decide.
+        let (resp2, poke2) = route(
+            &conn,
+            None,
+            "r2",
+            "run",
+            "orch-agent",
+            "wf_decide",
+            &json!({ "decision": "answer", "message_id": ask_id, "body": "use Postgres" }),
+        );
+        assert!(resp2.ok, "{resp2:?}");
+        assert!(matches!(poke2, Poke::None));
+
+        // The child is no longer waiting; the answer is queued for its next turn.
+        assert!(!has_unanswered_ask(&conn, &child));
+        let pending = take_pending_deliveries(&conn, &run, "child-1");
+        assert_eq!(pending.len(), 1);
+        assert!(compose_delivery(&pending).contains("use Postgres"));
+
+        // The decision is journaled.
+        let decided: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM wf_event WHERE type='decision'
+                 AND json_extract(payload_json,'$.decision')='answer'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(decided, 1);
+    }
+
+    #[test]
+    fn spawn_child_is_bounded_by_children_max_and_denials_journal() {
+        let (conn, run, orch, _child) = seed_orchestrate(); // children.max = 2
+        for i in 0..2 {
+            let (resp, _) = route(
+                &conn,
+                None,
+                &format!("s{i}"),
+                "run",
+                "orch-agent",
+                "wf_decide",
+                &json!({ "decision": "spawn_child", "agent": "coder", "goal": "a slice" }),
+            );
+            assert!(resp.ok, "spawn {i} should be approved: {resp:?}");
+        }
+        // The third exceeds children.max → structured error + child_spawn_denied.
+        let (resp3, poke3) = route(
+            &conn,
+            None,
+            "s3",
+            "run",
+            "orch-agent",
+            "wf_decide",
+            &json!({ "decision": "spawn_child", "agent": "coder", "goal": "one too many" }),
+        );
+        assert!(!resp3.ok);
+        assert!(resp3.error.unwrap().contains("children.max"));
+        assert!(matches!(poke3, Poke::None));
+        let denied: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM wf_event WHERE type='child_spawn_denied'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(denied, 1);
+        let approved: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM wf_event WHERE type='child_spawn_approved'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(approved, 2);
+
+        // The two approvals are consumable by the scheduler as SpawnChild decisions.
+        let decisions = take_orchestrator_decisions(&conn, &run, &orch);
+        assert_eq!(decisions.len(), 2);
+        assert!(decisions
+            .iter()
+            .all(|d| matches!(d, Decision::SpawnChild { .. })));
+    }
+
+    #[test]
+    fn spawn_child_agent_must_match_the_template() {
+        let (conn, _run, _orch, _child) = seed_orchestrate();
+        let (resp, _) = route(
+            &conn,
+            None,
+            "s1",
+            "run",
+            "orch-agent",
+            "wf_decide",
+            &json!({ "decision": "spawn_child", "agent": "orch", "goal": "wrong agent" }),
+        );
+        assert!(!resp.ok);
+        assert!(resp.error.unwrap().contains("template's child agent"));
+    }
+
+    #[test]
+    fn notify_is_orchestrator_only_and_reaches_children() {
+        let (conn, run, _orch, _child) = seed_orchestrate();
+        // The orchestrator notifies the child.
+        let (resp, _) = route(
+            &conn,
+            None,
+            "n1",
+            "run",
+            "orch-agent",
+            "wf_notify",
+            &json!({ "to": "child-1", "message": "slice B landed" }),
+        );
+        assert!(resp.ok, "{resp:?}");
+        let pending = take_pending_deliveries(&conn, &run, "child-1");
+        assert_eq!(pending.len(), 1);
+        assert!(compose_delivery(&pending).contains("slice B landed"));
+
+        // A child cannot notify (its caps are [report, ask]).
+        let (resp2, _) = route(
+            &conn,
+            None,
+            "n2",
+            "run",
+            "child-agent",
+            "wf_notify",
+            &json!({ "to": "all-children", "message": "x" }),
+        );
+        assert!(!resp2.ok);
+    }
+
+    #[test]
+    fn lifecycle_is_auto_forwarded_to_the_orchestrator() {
+        let (conn, run, orch, child) = seed_orchestrate();
+        forward_lifecycle(
+            &conn,
+            None,
+            &run,
+            &orch,
+            &child,
+            "done",
+            "child `child-1` finished",
+        );
+        let inbox = take_orchestrator_inbox(&conn, &run, &orch);
+        assert_eq!(inbox.len(), 1);
+        assert_eq!(inbox[0].from_step_id, "child-1");
+        let rendered = compose_orchestrator_inbox(&inbox);
+        assert!(
+            rendered.contains("child-1") && rendered.contains("finished"),
+            "{rendered}"
+        );
+        // Shown once — not re-delivered on the next turn.
+        assert!(take_orchestrator_inbox(&conn, &run, &orch).is_empty());
+    }
+
+    #[test]
+    fn stage_done_and_escalate_decisions() {
+        let (conn, run, orch, _child) = seed_orchestrate();
+        // stage_done queues a consumable decision.
+        let (resp, _) = route(
+            &conn,
+            None,
+            "d1",
+            "run",
+            "orch-agent",
+            "wf_decide",
+            &json!({ "decision": "stage_done" }),
+        );
+        assert!(resp.ok, "{resp:?}");
+        // escalate queues an ask to the human and pauses the run.
+        let (resp2, poke2) = route(
+            &conn,
+            None,
+            "d2",
+            "run",
+            "orch-agent",
+            "wf_decide",
+            &json!({ "decision": "escalate", "question": "which framework?" }),
+        );
+        assert!(resp2.ok, "{resp2:?}");
+        assert!(
+            matches!(poke2, Poke::AskQueued { .. }),
+            "escalate pauses for the human"
+        );
+        // The escalation appears as an unanswered ask from the orchestrator.
+        assert!(has_unanswered_ask(&conn, &orch));
+
+        let decisions = take_orchestrator_decisions(&conn, &run, &orch);
+        assert_eq!(decisions, vec![Decision::StageDone]);
     }
 }

--- a/src-tauri/src/workflow/prompts.rs
+++ b/src-tauri/src/workflow/prompts.rs
@@ -126,6 +126,139 @@ fn comms_section(caps: &[CommsCap]) -> Option<String> {
     Some(s)
 }
 
+/// Everything the orchestrator prompt is assembled from (spec §10.2, §6.6). The
+/// orchestrator is a single agent that lives for the whole stage: it is prompted
+/// once here, again whenever a child asks it something or finishes, and a final
+/// time for its concluding verdict.
+#[derive(Debug, Clone)]
+pub struct OrchestratorPromptCtx<'a> {
+    pub run_task: &'a str,
+    /// The orchestrator's blackboard directory id (`orchestrate-<n>`).
+    pub orch_step_id: &'a str,
+    pub goal: &'a str,
+    pub position: Position,
+    /// Ids of static children that auto-start at stage entry (may be empty).
+    pub static_children: &'a [String],
+    /// The dynamic-child template: `(agent alias, max)` when the block declares
+    /// `children`; `None` when only static children exist.
+    pub dynamic: Option<(&'a str, u32)>,
+}
+
+/// The orchestrator's opening prompt (spec §10.2). Describes its supervisory
+/// role, the children it commands, and the `wf_decide` / `wf_notify` ops it drives
+/// them with — mirroring the step protocol's mailbox style (§8.5 item 6).
+pub fn orchestrator_prompt(ctx: &OrchestratorPromptCtx) -> String {
+    let mut s = String::new();
+    s.push_str("# Workflow orchestrator\n\n");
+    s.push_str(
+        "You lead a stage of an automated workflow. Child agents do the work; \
+         you assign it, answer their questions, and decide when the stage is \
+         done. The deterministic workflow engine validates and executes every \
+         decision you make — you advise, it acts.\n\n",
+    );
+
+    s.push_str("## The overall task\n\n");
+    s.push_str(ctx.run_task.trim());
+    s.push_str("\n\n");
+
+    s.push_str("## Your goal\n\n");
+    s.push_str(&position_line(&ctx.position));
+    s.push_str("\n\n");
+    s.push_str(ctx.goal.trim());
+    s.push_str("\n\n");
+
+    s.push_str("## Your children\n\n");
+    if ctx.static_children.is_empty() {
+        s.push_str("No children have started yet.");
+    } else {
+        s.push_str("These children start automatically now:\n");
+        for id in ctx.static_children {
+            s.push_str(&format!("- `{id}`\n"));
+        }
+    }
+    if let Some((agent, max)) = ctx.dynamic {
+        s.push_str(&format!(
+            "\nYou may spawn up to **{max}** additional `{agent}` children with \
+             `wf_decide` (`spawn_child`). Nothing spawns from this template on its \
+             own — you decide how many, if any.\n",
+        ));
+    }
+    s.push('\n');
+
+    s.push_str(&orchestrator_comms_section());
+    s.push('\n');
+
+    s.push_str(&blackboard_contract(ctx.orch_step_id));
+    s.push('\n');
+
+    s.push_str("## Ending the stage\n\n");
+    s.push_str(
+        "The stage ends when every child has finished **and** you have concluded. \
+         When the children are done, the workflow prompts you once more to write \
+         your `verdict.json` (`result` \"done\"). If the plan is already satisfied \
+         and remaining children are unnecessary, you may end early with \
+         `wf_decide` (`stage_done`).\n",
+    );
+    s
+}
+
+/// The concluding-verdict prompt (spec §6.6): sent once the join condition over
+/// all children is met, asking the orchestrator to write its verdict so the
+/// stage's gate (its own verdict) can be evaluated.
+pub fn orchestrator_conclude_prompt(orch_step_id: &str) -> String {
+    let mut s = String::new();
+    s.push_str("## All children are done\n\n");
+    s.push_str(
+        "Every child in this stage has reached a terminal state. Review their \
+         handoffs and verdicts on the blackboard, then conclude the stage: write \
+         your summary to your `handoff.md` and your completion signal to \
+         `verdict.json` with `result` \"done\". The stage does not advance until \
+         you do.\n\n",
+    );
+    s.push_str(&format!(
+        "Write `{orch_step_id}/verdict.json`:\n\n{}",
+        verdict_schema_block()
+    ));
+    s
+}
+
+/// The orchestrator's comms section: it holds every cap (spec §5.1 — "orchestrator
+/// gets all"), so it may answer/route with `wf_decide`, push notices to children
+/// with `wf_notify`, and escalate to the human. Mirrors the git-actions mailbox
+/// style used by the step protocol (§8.5 item 6).
+fn orchestrator_comms_section() -> String {
+    let mut s = String::new();
+    s.push_str("## Directing the workflow\n\n");
+    s.push_str(
+        "Send structured messages to the workflow host through your RPC mailbox \
+         (the same `$FLETCH_RPC_DIR` request/response channel the git actions \
+         use): write `requests/<id>.json` with an `op` and `args`, then read \
+         `responses/<id>.json`. Child questions and completion notices are \
+         delivered to you at the start of your turns.\n\n",
+    );
+    s.push_str(
+        "- **Decide** — `op: \"wf_decide\"`. One decision per call:\n\
+         \x20 - `{ \"decision\": \"answer\", \"message_id\": \"…\", \"body\": \"…\" }` — \
+         reply to a child's question (use the `message_id` from the delivered ask).\n\
+         \x20 - `{ \"decision\": \"spawn_child\", \"agent\": \"<alias>\", \"goal\": \"…\" }` — \
+         start another child (within your template's max).\n\
+         \x20 - `{ \"decision\": \"skip_child\", \"step_id\": \"…\", \"reason\": \"…\" }` — \
+         drop a child you no longer need.\n\
+         \x20 - `{ \"decision\": \"retry_child\", \"step_id\": \"…\", \"guidance\": \"…\" }` — \
+         ask a finished child to try again with guidance.\n\
+         \x20 - `{ \"decision\": \"stage_done\" }` — end the stage now (the plan is \
+         satisfied).\n\
+         \x20 - `{ \"decision\": \"escalate\", \"question\": \"…\" }` — hand a decision to \
+         the human; the run pauses until they answer.\n",
+    );
+    s.push_str(
+        "- **Notify** — `op: \"wf_notify\"`, \
+         `args: { \"to\": \"<step-id>\" | \"all-children\", \"message\": \"…\" }`. \
+         Push a notice to a running child (e.g. a sibling's slice landed).\n",
+    );
+    s
+}
+
 /// The re-prompt sent when the gate is unmet but the attempt still has turns
 /// left (spec §6.5) — quotes the gate reason and asks the agent to finish.
 pub fn reprompt(gate: &Gate, gate_reason: &str) -> String {
@@ -348,6 +481,44 @@ mod tests {
             failure_at < goal_at,
             "failure should precede the restated step"
         );
+    }
+
+    #[test]
+    fn orchestrator_prompt_lists_children_and_decisions() {
+        let statics = vec!["review".to_string()];
+        let p = orchestrator_prompt(&OrchestratorPromptCtx {
+            run_task: "Ship the feature",
+            orch_step_id: "orchestrate-1",
+            goal: "Assign slices and answer questions",
+            position: Position {
+                step_index: 1,
+                step_count: 3,
+                iteration: None,
+            },
+            static_children: &statics,
+            dynamic: Some(("coder", 3)),
+        });
+        assert!(p.contains("Ship the feature"));
+        assert!(p.contains("Assign slices"));
+        assert!(p.contains("`review`"), "static child listed: {p}");
+        assert!(
+            p.contains("up to **3**") && p.contains("`coder`"),
+            "dynamic template: {p}"
+        );
+        // The decision surface is described.
+        assert!(p.contains("wf_decide"));
+        assert!(p.contains("spawn_child") && p.contains("stage_done") && p.contains("escalate"));
+        assert!(p.contains("wf_notify"));
+        // Writes its own verdict to conclude.
+        assert!(p.contains("orchestrate-1/verdict.json"));
+    }
+
+    #[test]
+    fn conclude_prompt_asks_for_the_verdict() {
+        let p = orchestrator_conclude_prompt("orchestrate-0");
+        assert!(p.contains("All children are done"));
+        assert!(p.contains("orchestrate-0/verdict.json"));
+        assert!(p.contains("\"result\""));
     }
 
     #[test]

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -2302,6 +2302,27 @@ async fn run_orchestrate_stage(
     // keyed by step id — so `retry_child` can rebuild any child, not just the
     // static-body ones (spec §10.2).
     let mut child_specs: HashMap<String, Step> = HashMap::new();
+    // Rebuild the dynamic children of any prior drive into the registry from the
+    // persisted `spawn_child` decisions (which carry their agent + goal), so a
+    // resumed stage can still honor `retry_child` for `orchestrate-N::dyn-K`.
+    // Spawn order == index order, matching how ids were assigned originally.
+    for (i, (agent, goal)) in prior_spawn_decisions(&ctx.db.lock(), run_id, &orch_step_id)
+        .into_iter()
+        .enumerate()
+    {
+        let id = format!("{orch_step_id}::dyn-{i}");
+        child_specs.insert(
+            id.clone(),
+            Step {
+                id,
+                agent,
+                goal,
+                gate: Gate::Verdict,
+                budgets: None,
+                comms: orch.comms.clone(),
+            },
+        );
+    }
     // Seed the dynamic-child index from the DB so a resumed stage doesn't reuse an
     // id an earlier drive already created (ids stay unique across resume).
     let mut dyn_count = existing_dyn_child_count(&ctx.db.lock(), run_id, &orch_step_id);
@@ -3342,6 +3363,43 @@ fn cancel_all(child_cancels: &HashMap<String, Arc<AtomicBool>>) {
     for flag in child_cancels.values() {
         flag.store(true, Ordering::SeqCst);
     }
+}
+
+/// The `(agent, goal)` of each dynamic child the stage spawned in a prior drive,
+/// in spawn order (spec §10.2). Read from the persisted `spawn_child` decisions —
+/// joined across every orchestrator exec that shares the stage's `step_id` — so a
+/// resumed stage can rebuild those children into its registry and still honor
+/// `retry_child` for them. Spawn order matches the `dyn-<k>` index order.
+fn prior_spawn_decisions(
+    conn: &Connection,
+    run_id: &str,
+    orch_step_id: &str,
+) -> Vec<(String, String)> {
+    conn.prepare(
+        "SELECT m.body_json FROM wf_message m
+           JOIN wf_step_exec e ON m.from_step_exec_id = e.id
+         WHERE m.run_id = ?1 AND e.step_id = ?2 AND m.kind = 'decision'
+           AND json_extract(m.body_json, '$.decision') = 'spawn_child'
+         ORDER BY m.created_at, m.rowid",
+    )
+    .and_then(|mut s| {
+        s.query_map(rusqlite::params![run_id, orch_step_id], |r| {
+            r.get::<_, String>(0)
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()
+    })
+    .map(|bodies| {
+        bodies
+            .into_iter()
+            .filter_map(|b| {
+                let v: Value = serde_json::from_str(&b).ok()?;
+                let agent = v.get("agent")?.as_str()?.to_string();
+                let goal = v.get("goal")?.as_str()?.to_string();
+                Some((agent, goal))
+            })
+            .collect()
+    })
+    .unwrap_or_default()
 }
 
 /// The number of dynamic children an orchestrate stage has already created, from
@@ -7787,5 +7845,61 @@ mod tests {
             &child_gen,
         );
         assert!(matches!(outcomes.get("impl"), Some(ChildStatus::Success)));
+    }
+
+    #[test]
+    fn prior_spawn_decisions_rebuild_dynamic_children_in_order() {
+        // On resume, the dynamic children of a prior drive are rebuilt from their
+        // persisted spawn decisions (agent + goal), in spawn order, so retry_child
+        // can still target `orchestrate-0::dyn-K`.
+        let tmp = tempfile::tempdir().unwrap();
+        let db = crate::database::init(tmp.path()).unwrap();
+        let conn = db.lock();
+        conn.execute(
+            "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,branch,
+                base_sha,status,budgets_json,spent_json,created_at,updated_at)
+             VALUES ('r','n','{}','t','p','/r','/d','wf/x','sha','running','{}','{}',0,0)",
+            [],
+        )
+        .unwrap();
+        // A prior orchestrator exec for the stage.
+        conn.execute(
+            "INSERT INTO wf_step_exec (id,run_id,step_id,attempt,iteration,status,gate_mode,agent_id)
+             VALUES ('orch-old','r','orchestrate-0',1,0,'abandoned','verdict','a-old')",
+            [],
+        )
+        .unwrap();
+        // Two spawn decisions (ordered) + one unrelated decision that must be
+        // excluded.
+        let insert_msg = |id: &str, body: &str, ts: i64| {
+            conn.execute(
+                "INSERT INTO wf_message (id,run_id,from_step_exec_id,to_step_exec_id,kind,
+                    body_json,status,created_at)
+                 VALUES (?1,'r','orch-old',NULL,'decision',?2,'delivered',?3)",
+                rusqlite::params![id, body, ts],
+            )
+            .unwrap();
+        };
+        insert_msg(
+            "d0",
+            r#"{"decision":"spawn_child","agent":"coder","goal":"slice A"}"#,
+            1,
+        );
+        insert_msg(
+            "d1",
+            r#"{"decision":"spawn_child","agent":"coder","goal":"slice B"}"#,
+            2,
+        );
+        insert_msg("d2", r#"{"decision":"stage_done"}"#, 3);
+
+        let got = prior_spawn_decisions(&conn, "r", "orchestrate-0");
+        assert_eq!(
+            got,
+            vec![
+                ("coder".to_string(), "slice A".to_string()),
+                ("coder".to_string(), "slice B".to_string()),
+            ],
+            "spawn decisions rebuild in order, excluding non-spawn decisions"
+        );
     }
 }

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -1607,18 +1607,31 @@ async fn run_orchestrate_stage(
     }
 
     // ── Launch static body children, then drive the orchestrator's first turn. ──
-    let stage_cancel = Arc::new(AtomicBool::new(false));
     let mut set: JoinSet<OrchChildResult> = JoinSet::new();
-    let mut dyn_count = 0u32;
+    // Per-child cancel flags (keyed by step id) so `skip_child`/`retry_child` can
+    // wind down one child, and a join-`any` winner or a stage teardown can wind
+    // down all of them (§10.2, §6.6).
+    let mut child_cancels: HashMap<String, Arc<AtomicBool>> = HashMap::new();
+    // Seed the dynamic-child index from the DB so a resumed stage doesn't reuse an
+    // id an earlier drive already created (ids stay unique across resume).
+    let mut dyn_count = existing_dyn_child_count(&ctx.db.lock(), run_id, &orch_step_id);
     let mut outcomes: HashMap<String, ChildStatus> = HashMap::new();
 
     for step in &orch.body {
+        // Resume: a static child that already finished is not re-run — its work is
+        // durable (parity with the parallel stage, §12.3).
+        if child_already_done(&ctx.db.lock(), run_id, &step.id) {
+            outcomes.insert(step.id.clone(), ChildStatus::Success);
+            continue;
+        }
         let agent_spec = spec.agents.get(&step.agent).ok_or_else(|| {
             Error::Other(format!(
                 "orchestrate child '{}' references unknown agent '{}'",
                 step.id, step.agent
             ))
         })?;
+        let cancel = Arc::new(AtomicBool::new(false));
+        child_cancels.insert(step.id.clone(), cancel.clone());
         let c = build_orch_child_ctx(
             ctx,
             run_id,
@@ -1634,7 +1647,7 @@ async fn run_orchestrate_stage(
             eff,
             test_override,
             setup_override,
-            &stage_cancel,
+            cancel,
         );
         let entry = stage_entry_sha.clone();
         set.spawn(async move { drive_orch_child(c, entry).await });
@@ -1688,7 +1701,7 @@ async fn run_orchestrate_stage(
                 run_id,
                 &orch_exec,
                 &orch_agent_id,
-                &stage_cancel,
+                &child_cancels,
                 &mut set,
                 ledger,
                 other,
@@ -1706,7 +1719,7 @@ async fn run_orchestrate_stage(
 
     loop {
         if ctx.cancel.load(Ordering::SeqCst) {
-            drain_children(&stage_cancel, &mut set).await;
+            drain_children(&child_cancels, &mut set).await;
             cancel_run(ctx, run_id).await;
             return Ok(StageFlow::Stop);
         }
@@ -1714,7 +1727,7 @@ async fn run_orchestrate_stage(
         // Orchestrator escalated or asked the human on its last turn → pause
         // `question` (§10.2, §10.4). The backstop mirrors the linear path.
         if super::comms::has_unanswered_ask(&ctx.db.lock(), &orch_exec) {
-            drain_children(&stage_cancel, &mut set).await;
+            drain_children(&child_cancels, &mut set).await;
             pause_question(ctx, run_id, &orch_exec, Some(&orch_agent_id)).await;
             return Ok(StageFlow::Stop);
         }
@@ -1738,6 +1751,8 @@ async fn run_orchestrate_stage(
                             comms: orch.comms.clone(),
                         };
                         dyn_count += 1;
+                        let cancel = Arc::new(AtomicBool::new(false));
+                        child_cancels.insert(step.id.clone(), cancel.clone());
                         let c = build_orch_child_ctx(
                             ctx,
                             run_id,
@@ -1753,26 +1768,37 @@ async fn run_orchestrate_stage(
                             eff,
                             test_override,
                             setup_override,
-                            &stage_cancel,
+                            cancel,
                         );
                         let entry = stage_entry_sha.clone();
                         set.spawn(async move { drive_orch_child(c, entry).await });
                     }
                 }
                 super::comms::Decision::SkipChild { step_id, .. } => {
-                    // Satisfied, not failed. A still-running child's later outcome
-                    // is ignored (this entry wins the join decision).
+                    // Cancel the child's live task so it stops spending budget and
+                    // the stage can conclude without waiting on it, then record it
+                    // as satisfied for the join (§10.2).
+                    if let Some(flag) = child_cancels.get(&step_id) {
+                        flag.store(true, Ordering::SeqCst);
+                    }
                     outcomes.insert(step_id, ChildStatus::Skipped);
                 }
                 super::comms::Decision::RetryChild { step_id, guidance } => {
                     if let Some(orig) = orch.body.iter().find(|s| s.id == step_id).cloned() {
                         if let Some(agent_spec) = spec.agents.get(&orig.agent).cloned() {
+                            // Cancel the previous attempt's task so it can't race the
+                            // retry into the join outcome (§10.2).
+                            if let Some(flag) = child_cancels.get(&orig.id) {
+                                flag.store(true, Ordering::SeqCst);
+                            }
                             // Fold the guidance into the fresh attempt via a notice.
                             {
                                 let conn = ctx.db.lock();
                                 super::comms::queue_child_note(&conn, run_id, &orig.id, &guidance);
                             }
                             outcomes.remove(&orig.id);
+                            let cancel = Arc::new(AtomicBool::new(false));
+                            child_cancels.insert(orig.id.clone(), cancel.clone());
                             let step = orig.clone();
                             let c = build_orch_child_ctx(
                                 ctx,
@@ -1789,7 +1815,7 @@ async fn run_orchestrate_stage(
                                 eff,
                                 test_override,
                                 setup_override,
-                                &stage_cancel,
+                                cancel,
                             );
                             let entry = stage_entry_sha.clone();
                             set.spawn(async move { drive_orch_child(c, entry).await });
@@ -1812,7 +1838,7 @@ async fn run_orchestrate_stage(
                 ledger,
                 joined,
                 &mut outcomes,
-                &stage_cancel,
+                &child_cancels,
             );
         }
 
@@ -1822,7 +1848,7 @@ async fn run_orchestrate_stage(
                 ChildStatus::Failure(r) => Some(r.clone()),
                 _ => None,
             }) {
-                drain_children(&stage_cancel, &mut set).await;
+                drain_children(&child_cancels, &mut set).await;
                 let _ = ctx.driver.stop(&orch_agent_id).await;
                 let conn = ctx.db.lock();
                 finish_step_exec(&conn, &orch_exec, "error", None);
@@ -1900,7 +1926,7 @@ async fn run_orchestrate_stage(
                             run_id,
                             &orch_exec,
                             &orch_agent_id,
-                            &stage_cancel,
+                            &child_cancels,
                             &mut set,
                             ledger,
                             other,
@@ -1962,7 +1988,7 @@ async fn run_orchestrate_stage(
                             run_id,
                             &orch_exec,
                             &orch_agent_id,
-                            &stage_cancel,
+                            &child_cancels,
                             &mut set,
                             ledger,
                             other,
@@ -2024,7 +2050,7 @@ async fn run_orchestrate_stage(
                         run_id,
                         &orch_exec,
                         &orch_agent_id,
-                        &stage_cancel,
+                        &child_cancels,
                         &mut set,
                         ledger,
                         other,
@@ -2037,7 +2063,7 @@ async fn run_orchestrate_stage(
         // Bound the idle wait by the run wall-clock (§11.3 — "no wait without a
         // deadline"): a wedged stage pauses `budget_exceeded` rather than hanging.
         if let Some(which) = ledger.exceeded(eff, super::now_ms()) {
-            drain_children(&stage_cancel, &mut set).await;
+            drain_children(&child_cancels, &mut set).await;
             let _ = ctx.driver.stop(&orch_agent_id).await;
             {
                 let conn = ctx.db.lock();
@@ -2057,7 +2083,7 @@ async fn run_orchestrate_stage(
         tokio::select! {
             joined = set.join_next() => {
                 if let Some(j) = joined {
-                    handle_orch_child(ctx, run_id, &orch_exec, orch.join, ledger, j, &mut outcomes, &stage_cancel);
+                    handle_orch_child(ctx, run_id, &orch_exec, orch.join, ledger, j, &mut outcomes, &child_cancels);
                 }
             }
             _ = tokio::time::sleep(std::time::Duration::from_millis(200)) => {}
@@ -2065,7 +2091,7 @@ async fn run_orchestrate_stage(
     }
 
     // `stage_done`: wind the remaining children down and mark the stage done.
-    drain_children(&stage_cancel, &mut set).await;
+    drain_children(&child_cancels, &mut set).await;
     let _ = ctx.driver.archive(&orch_agent_id).await;
     let conn = ctx.db.lock();
     finish_step_exec(&conn, &orch_exec, "done", None);
@@ -2091,7 +2117,7 @@ fn build_orch_child_ctx(
     eff: &EffectiveBudgets,
     test_override: &Option<String>,
     setup_override: &Option<String>,
-    stage_cancel: &Arc<AtomicBool>,
+    cancel: Arc<AtomicBool>,
 ) -> ChildCtx {
     ChildCtx {
         db: ctx.db.clone(),
@@ -2111,7 +2137,7 @@ fn build_orch_child_ctx(
         block_count,
         test_override: test_override.clone(),
         setup_override: setup_override.clone(),
-        stage_cancel: stage_cancel.clone(),
+        stage_cancel: cancel,
     }
 }
 
@@ -2512,7 +2538,7 @@ fn handle_orch_child(
     ledger: &mut Ledger,
     joined: std::result::Result<OrchChildResult, tokio::task::JoinError>,
     outcomes: &mut HashMap<String, ChildStatus>,
-    stage_cancel: &Arc<AtomicBool>,
+    child_cancels: &HashMap<String, Arc<AtomicBool>>,
 ) {
     let res = match joined {
         Ok(r) => r,
@@ -2551,7 +2577,8 @@ fn handle_orch_child(
             // Don't overwrite a `skip` the orchestrator already recorded.
             outcomes.entry(res.step_id).or_insert(ChildStatus::Success);
             if matches!(join, Join::Any) {
-                stage_cancel.store(true, Ordering::SeqCst);
+                // First success wins → wind every remaining child down (§6.6).
+                cancel_all(child_cancels);
             }
         }
         ChildOutcome::Failure { reason } => {
@@ -2573,10 +2600,35 @@ fn handle_orch_child(
     persist_spent(&conn, run_id, ledger);
 }
 
-/// Wind down every remaining orchestrate child: raise the stage cancel and drain
-/// the set (each child stops its own agent and returns `Canceled`).
-async fn drain_children(stage_cancel: &Arc<AtomicBool>, set: &mut JoinSet<OrchChildResult>) {
-    stage_cancel.store(true, Ordering::SeqCst);
+/// Raise every child's cancel flag (a join-`any` winner or a stage teardown).
+fn cancel_all(child_cancels: &HashMap<String, Arc<AtomicBool>>) {
+    for flag in child_cancels.values() {
+        flag.store(true, Ordering::SeqCst);
+    }
+}
+
+/// The number of dynamic children an orchestrate stage has already created, from
+/// the DB — the next dynamic index, seeded so a resumed stage never reuses an id
+/// (§10.2). Dynamic child ids are `orchestrate-<n>::dyn-<k>`, `k` contiguous from
+/// 0, so the distinct count is the next `k`.
+fn existing_dyn_child_count(conn: &Connection, run_id: &str, orch_step_id: &str) -> u32 {
+    let pattern = format!("{orch_step_id}::dyn-%");
+    conn.query_row(
+        "SELECT COUNT(DISTINCT step_id) FROM wf_step_exec WHERE run_id = ?1 AND step_id LIKE ?2",
+        rusqlite::params![run_id, pattern],
+        |r| r.get::<_, i64>(0),
+    )
+    .map(|n| n.max(0) as u32)
+    .unwrap_or(0)
+}
+
+/// Wind down every remaining orchestrate child: cancel them all and drain the set
+/// (each child stops its own agent and returns `Canceled`).
+async fn drain_children(
+    child_cancels: &HashMap<String, Arc<AtomicBool>>,
+    set: &mut JoinSet<OrchChildResult>,
+) {
+    cancel_all(child_cancels);
     while set.join_next().await.is_some() {}
 }
 
@@ -2652,12 +2704,12 @@ async fn finish_orch_turn_failure(
     run_id: &str,
     orch_exec: &str,
     orch_agent_id: &str,
-    stage_cancel: &Arc<AtomicBool>,
+    child_cancels: &HashMap<String, Arc<AtomicBool>>,
     set: &mut JoinSet<OrchChildResult>,
     ledger: &mut Ledger,
     result: OrchStepResult,
 ) -> Result<StageFlow> {
-    drain_children(stage_cancel, set).await;
+    drain_children(child_cancels, set).await;
     match result {
         OrchStepResult::Stalled => {
             // A stalled orchestrator must not hang the stage — escalate to the
@@ -6159,5 +6211,74 @@ mod tests {
             "SELECT COUNT(*) FROM wf_event WHERE run_id='run-stall' AND type='watchdog_stalled'",
         );
         assert!(stalled >= 1, "the orchestrator stall was journaled");
+    }
+
+    #[tokio::test]
+    async fn resume_does_not_rerun_a_completed_static_child() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (db, ws, bb, _base) = scaffold_orchestrate(tmp.path(), "run-resume");
+        // Simulate a prior drive that paused before the orchestrator concluded: the
+        // static child already finished `done`.
+        db.lock()
+            .execute(
+                "INSERT INTO wf_step_exec (id,run_id,step_id,attempt,iteration,status,gate_mode,agent_id)
+                 VALUES ('impl-prior','run-resume','impl',1,0,'done','commit','prior-agent')",
+                [],
+            )
+            .unwrap();
+        let ctx = orch_ctx(db.clone(), OrchDriver::new(ws, bb, OrchMode::Conclude));
+        drive_run(&ctx, "run-resume").await;
+
+        assert_eq!(run_status_str(&db, "run-resume"), "done");
+        // The already-done child is not executed a second time (§12.3 parity).
+        assert_eq!(
+            count(
+                &db,
+                "SELECT COUNT(*) FROM wf_step_exec WHERE run_id='run-resume' AND step_id='impl'"
+            ),
+            1,
+            "the completed child must not re-run on resume"
+        );
+    }
+
+    #[test]
+    fn dyn_child_index_is_seeded_from_existing_execs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = crate::database::init(tmp.path()).unwrap();
+        let conn = db.lock();
+        conn.execute(
+            "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,branch,
+                base_sha,status,budgets_json,spent_json,created_at,updated_at)
+             VALUES ('r','n','{}','t','p','/r','/d','wf/x','sha','running','{}','{}',0,0)",
+            [],
+        )
+        .unwrap();
+        assert_eq!(existing_dyn_child_count(&conn, "r", "orchestrate-0"), 0);
+        for k in 0..2 {
+            conn.execute(
+                "INSERT INTO wf_step_exec (id,run_id,step_id,attempt,iteration,status,gate_mode)
+                 VALUES (?1,'r',?2,1,0,'done','verdict')",
+                rusqlite::params![format!("e{k}"), format!("orchestrate-0::dyn-{k}")],
+            )
+            .unwrap();
+        }
+        // A non-dynamic child and a different stage's children must not count.
+        conn.execute(
+            "INSERT INTO wf_step_exec (id,run_id,step_id,attempt,iteration,status,gate_mode)
+             VALUES ('x','r','impl',1,0,'done','commit')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO wf_step_exec (id,run_id,step_id,attempt,iteration,status,gate_mode)
+             VALUES ('y','r','orchestrate-1::dyn-0',1,0,'done','verdict')",
+            [],
+        )
+        .unwrap();
+        assert_eq!(
+            existing_dyn_child_count(&conn, "r", "orchestrate-0"),
+            2,
+            "the next dynamic index skips the two already created"
+        );
     }
 }

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -975,6 +975,11 @@ struct ChildCtx {
     /// message so the fresh attempt is guaranteed to carry it. `None` for the
     /// common case.
     extra_note: Option<String>,
+    /// The launch generation for this child's `step_id` (spec §10.2). `retry_child`
+    /// bumps it and spawns a replacement; the stage ignores results from any
+    /// superseded (lower-generation) attempt so a stale finish of the cancelled
+    /// task can't win the join. Always `0` outside an orchestrate stage.
+    generation: u64,
     /// Set by the stage to wind this child down (loser cancellation, §6.6).
     stage_cancel: Arc<AtomicBool>,
 }
@@ -1163,6 +1168,7 @@ async fn run_parallel_stage(
             setup_override: setup_override.clone(),
             integrate: par.integrate,
             extra_note: None,
+            generation: 0,
             stage_cancel: stage_cancel.clone(),
         });
     }
@@ -2115,6 +2121,9 @@ fn build_spawn_req(
 struct OrchChildResult {
     step_id: String,
     exec_id: String,
+    /// The launch generation of the attempt that produced this result — the stage
+    /// discards it if a later `retry_child` has superseded this generation.
+    generation: u64,
     outcome: ChildOutcome,
     ledger: Ledger,
 }
@@ -2285,6 +2294,10 @@ async fn run_orchestrate_stage(
     // wind down one child, and a join-`any` winner or a stage teardown can wind
     // down all of them (§10.2, §6.6).
     let mut child_cancels: HashMap<String, Arc<AtomicBool>> = HashMap::new();
+    // Per-step launch generation. `retry_child` bumps it and spawns a replacement;
+    // `handle_orch_child` discards any result whose generation is stale, so a
+    // cancelled old attempt that still finishes can't win the join (§10.2).
+    let mut child_gen: HashMap<String, u64> = HashMap::new();
     // Seed the dynamic-child index from the DB so a resumed stage doesn't reuse an
     // id an earlier drive already created (ids stay unique across resume).
     let mut dyn_count = existing_dyn_child_count(&ctx.db.lock(), run_id, &orch_step_id);
@@ -2305,6 +2318,7 @@ async fn run_orchestrate_stage(
         })?;
         let cancel = Arc::new(AtomicBool::new(false));
         child_cancels.insert(step.id.clone(), cancel.clone());
+        child_gen.insert(step.id.clone(), 0);
         let c = build_orch_child_ctx(
             ctx,
             run_id,
@@ -2321,6 +2335,7 @@ async fn run_orchestrate_stage(
             test_override,
             setup_override,
             None,
+            0,
             cancel,
         );
         let entry = stage_entry_sha.clone();
@@ -2427,6 +2442,7 @@ async fn run_orchestrate_stage(
                         dyn_count += 1;
                         let cancel = Arc::new(AtomicBool::new(false));
                         child_cancels.insert(step.id.clone(), cancel.clone());
+                        child_gen.insert(step.id.clone(), 0);
                         let c = build_orch_child_ctx(
                             ctx,
                             run_id,
@@ -2443,6 +2459,7 @@ async fn run_orchestrate_stage(
                             test_override,
                             setup_override,
                             None,
+                            0,
                             cancel,
                         );
                         let entry = stage_entry_sha.clone();
@@ -2469,6 +2486,10 @@ async fn run_orchestrate_stage(
                             outcomes.remove(&orig.id);
                             let cancel = Arc::new(AtomicBool::new(false));
                             child_cancels.insert(orig.id.clone(), cancel.clone());
+                            // Bump the generation so the cancelled attempt's result
+                            // (if it still finishes) is discarded by the join (§10.2).
+                            let gen = child_gen.get(&orig.id).copied().unwrap_or(0) + 1;
+                            child_gen.insert(orig.id.clone(), gen);
                             let step = orig.clone();
                             // Thread the guidance straight into the replacement
                             // child's first prompt (not a queued note) so the fresh
@@ -2495,6 +2516,7 @@ async fn run_orchestrate_stage(
                                 test_override,
                                 setup_override,
                                 note,
+                                gen,
                                 cancel,
                             );
                             let entry = stage_entry_sha.clone();
@@ -2519,6 +2541,7 @@ async fn run_orchestrate_stage(
                 joined,
                 &mut outcomes,
                 &child_cancels,
+                &child_gen,
             );
         }
 
@@ -2763,7 +2786,7 @@ async fn run_orchestrate_stage(
         tokio::select! {
             joined = set.join_next() => {
                 if let Some(j) = joined {
-                    handle_orch_child(ctx, run_id, &orch_exec, orch.join, ledger, j, &mut outcomes, &child_cancels);
+                    handle_orch_child(ctx, run_id, &orch_exec, orch.join, ledger, j, &mut outcomes, &child_cancels, &child_gen);
                 }
             }
             _ = tokio::time::sleep(std::time::Duration::from_millis(200)) => {}
@@ -2798,6 +2821,7 @@ fn build_orch_child_ctx(
     test_override: &Option<String>,
     setup_override: &Option<String>,
     extra_note: Option<String>,
+    generation: u64,
     cancel: Arc<AtomicBool>,
 ) -> ChildCtx {
     ChildCtx {
@@ -2822,6 +2846,7 @@ fn build_orch_child_ctx(
         // they never ferry — `drive_orch_child` always takes the none path.
         integrate: Integrate::None,
         extra_note,
+        generation,
         stage_cancel: cancel,
     }
 }
@@ -2838,10 +2863,12 @@ async fn drive_orch_child(c: ChildCtx, stage_entry_sha: Option<String>) -> OrchC
     let mut child_ledger = Ledger::default();
     let mut last_exec = String::new();
 
+    let generation = c.generation;
     let done =
         |step_id: String, exec_id: String, outcome: ChildOutcome, ledger: Ledger| OrchChildResult {
             step_id,
             exec_id,
+            generation,
             outcome,
             ledger,
         };
@@ -3231,6 +3258,7 @@ fn handle_orch_child(
     joined: std::result::Result<OrchChildResult, tokio::task::JoinError>,
     outcomes: &mut HashMap<String, ChildStatus>,
     child_cancels: &HashMap<String, Arc<AtomicBool>>,
+    child_gen: &HashMap<String, u64>,
 ) {
     let res = match joined {
         Ok(r) => r,
@@ -3243,7 +3271,15 @@ fn handle_orch_child(
             return;
         }
     };
+    // Its spend counts regardless, but a result from an attempt a later
+    // `retry_child` superseded must not touch the join outcome or wind losers
+    // down — otherwise the stale attempt could decide the stage (§10.2).
     fold_child_ledger(ledger, &res.ledger);
+    if child_gen.get(&res.step_id).copied().unwrap_or(0) != res.generation {
+        let conn = ctx.db.lock();
+        persist_spent(&conn, run_id, ledger);
+        return;
+    }
     let conn = ctx.db.lock();
     match res.outcome {
         ChildOutcome::Success { moved_head, head } => {
@@ -7661,5 +7697,86 @@ mod tests {
             bad, 0,
             "skip_child must cancel the child, not let it stall or finish"
         );
+    }
+
+    #[test]
+    fn stale_retry_result_is_discarded_by_generation() {
+        // A superseded attempt (older generation) that still finishes must not
+        // decide the join; only the current generation's result counts (§10.2).
+        let tmp = tempfile::tempdir().unwrap();
+        let db = crate::database::init(tmp.path()).unwrap();
+        db.lock()
+            .execute(
+                "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,branch,
+                    base_sha,status,budgets_json,spent_json,created_at,updated_at)
+                 VALUES ('r','n','{}','t','p','/r','/d','wf/x','sha','running','{}','{}',0,0)",
+                [],
+            )
+            .unwrap();
+        for id in ["orch-exec", "c-old", "c-new"] {
+            db.lock()
+                .execute(
+                    "INSERT INTO wf_step_exec (id,run_id,step_id,attempt,iteration,status,gate_mode)
+                     VALUES (?1,'r','impl',1,0,'abandoned','verdict')",
+                    [id],
+                )
+                .unwrap();
+        }
+        let ctx = RunCtx {
+            db: db.clone(),
+            driver: StubDriver::new(tmp.path().join("ws"), true),
+            app: None,
+            cancel: Arc::new(AtomicBool::new(false)),
+            pending_ask: Arc::new(AtomicBool::new(false)),
+            deadlines: Deadlines::default(),
+        };
+        let mut ledger = Ledger::default();
+        let mut outcomes: HashMap<String, ChildStatus> = HashMap::new();
+        let child_cancels: HashMap<String, Arc<AtomicBool>> = HashMap::new();
+        // Current generation for `impl` is 1 (a retry superseded generation 0).
+        let mut child_gen: HashMap<String, u64> = HashMap::new();
+        child_gen.insert("impl".to_string(), 1);
+
+        let result = |exec: &str, generation: u64| OrchChildResult {
+            step_id: "impl".to_string(),
+            exec_id: exec.to_string(),
+            generation,
+            outcome: ChildOutcome::Success {
+                moved_head: false,
+                head: None,
+            },
+            ledger: Ledger::default(),
+        };
+
+        // A stale (generation 0) success is ignored — records no join outcome.
+        handle_orch_child(
+            &ctx,
+            "r",
+            "orch-exec",
+            Join::Any,
+            &mut ledger,
+            Ok(result("c-old", 0)),
+            &mut outcomes,
+            &child_cancels,
+            &child_gen,
+        );
+        assert!(
+            !outcomes.contains_key("impl"),
+            "a superseded attempt must not decide the join"
+        );
+
+        // The current-generation result records the outcome.
+        handle_orch_child(
+            &ctx,
+            "r",
+            "orch-exec",
+            Join::Any,
+            &mut ledger,
+            Ok(result("c-new", 1)),
+            &mut outcomes,
+            &child_cancels,
+            &child_gen,
+        );
+        assert!(matches!(outcomes.get("impl"), Some(ChildStatus::Success)));
     }
 }

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -34,7 +34,9 @@ use super::driver::{AgentDriver, SpawnReq};
 use super::gitops;
 use super::journal;
 use super::prompts::{self, IterationPos, Position, StepPromptCtx};
-use super::spec::{AgentSpec, Block, Budgets, Gate, Integrate, Join, Loop, Parallel, Spec, Step};
+use super::spec::{
+    AgentSpec, Block, Budgets, Gate, Integrate, Join, Loop, Orchestrate, Parallel, Spec, Step,
+};
 use super::types::event_type;
 
 type Db = Arc<Mutex<Connection>>;
@@ -602,11 +604,31 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
                     BlockFlow::Halt => return Ok(()),
                 }
             }
-            // `ensure_executable` rejects orchestrate before any block runs.
-            Block::Orchestrate(_) => {
-                return Err(Error::Other(
-                    "orchestrate blocks are not supported yet (S11)".into(),
-                ))
+            Block::Orchestrate(orch) => {
+                match run_orchestrate_stage(
+                    ctx,
+                    run_id,
+                    &run,
+                    &spec,
+                    orch,
+                    index,
+                    blocks.len(),
+                    &blackboard,
+                    &repo,
+                    &run_repo,
+                    &last_ref,
+                    &eff,
+                    &mut ledger,
+                    &test_override,
+                    &setup_override,
+                )
+                .await?
+                {
+                    // `integrate: none` — the stage HEAD is its entry HEAD (§12.3),
+                    // so the line's fork source is unchanged; just advance.
+                    StageFlow::Advance => {}
+                    StageFlow::Stop => return Ok(()),
+                }
             }
         }
 
@@ -807,10 +829,15 @@ fn ensure_executable(blocks: &[Block]) -> Result<()> {
                     }
                 }
             }
-            Block::Orchestrate(_) => {
-                return Err(Error::Other(
-                    "orchestrate blocks are not supported yet (S11)".into(),
-                ))
+            Block::Orchestrate(o) => {
+                // S11 executes orchestrate stages with `integrate: none` (the
+                // orchestrator supervises note-producing children). `integrate:
+                // merge` reuses the code-merge machinery that arrives with S9.
+                if matches!(o.integrate, Integrate::Merge) {
+                    return Err(Error::Other(
+                        "orchestrate integrate: merge is not supported yet (S9)".into(),
+                    ));
+                }
             }
         }
     }
@@ -1207,6 +1234,7 @@ async fn drive_child(c: ChildCtx, stage_entry_sha: Option<String>) -> ChildResul
                 &c.run_repo,
                 &c.run_id,
             ),
+            pre_spawned: None,
             blackboard: c.blackboard.clone(),
             exec_id: exec_id.clone(),
             step_id: c.step.id.clone(),
@@ -1404,6 +1432,1290 @@ fn build_spawn_req(
         fork_base: Some(fork_base.to_string()),
         run_repo: Some(run_repo.to_path_buf()),
         owner_run_id: run_id.to_string(),
+    }
+}
+
+// ───────────────────────── orchestrate stages (§6.6, §10.2) ─────────────────
+
+/// An orchestrate child's terminal outcome plus the exec id (for lifecycle
+/// forwarding) — the orchestrate analogue of [`ChildResult`].
+struct OrchChildResult {
+    step_id: String,
+    exec_id: String,
+    outcome: ChildOutcome,
+    ledger: Ledger,
+}
+
+/// The stage-visible status of an orchestrate child, for the join decision.
+#[derive(Clone)]
+enum ChildStatus {
+    Success,
+    Failure(String),
+    /// The orchestrator dropped it with `skip_child` — satisfied, not a failure.
+    Skipped,
+}
+
+/// Result of waiting for the orchestrator to answer a child's ask (§10.4).
+enum AnswerWait {
+    Answered,
+    Timeout,
+    Canceled,
+}
+
+/// Outcome of driving one orchestrator turn (§10.2), mapping the turn result onto
+/// the stage's control flow.
+enum OrchStepResult {
+    Ok,
+    Stalled,
+    Error(String),
+    Budget(String),
+}
+
+/// Run an orchestrate stage (spec §6.6, §10.2): a stage-lived orchestrator agent
+/// supervises children with `integrate: none`. Static `body` children auto-start;
+/// the orchestrator may spawn dynamic children (bounded by `children.max`), answer
+/// their questions, notify them, and end the stage. The stage completes when the
+/// join over all children is met **and** the orchestrator writes its concluding
+/// `verdict.json`; `stage_done` ends it early. A stalled orchestrator escalates to
+/// the human (§10.2). Children run against their own ledgers, folded into the run
+/// ledger (§11.2).
+#[allow(clippy::too_many_arguments)]
+async fn run_orchestrate_stage(
+    ctx: &RunCtx,
+    run_id: &str,
+    run: &RunEssentials,
+    spec: &Spec,
+    orch: &Orchestrate,
+    block_index: usize,
+    block_count: usize,
+    blackboard: &Path,
+    repo: &Path,
+    run_repo: &Path,
+    fork_base: &str,
+    eff: &EffectiveBudgets,
+    ledger: &mut Ledger,
+    test_override: &Option<String>,
+    setup_override: &Option<String>,
+) -> Result<StageFlow> {
+    // Enforcement point: before spawning the stage (§11.2).
+    if let Some(which) = ledger.exceeded(eff, super::now_ms()) {
+        {
+            let conn = ctx.db.lock();
+            journal_event(
+                &conn,
+                ctx.app.as_ref(),
+                run_id,
+                event_type::BUDGET_EXCEEDED,
+                None,
+                &json!({ "which": which.as_str() }),
+            );
+        }
+        finish_budget_pause(ctx, run_id, None, ledger);
+        return Ok(StageFlow::Stop);
+    }
+
+    let orch_step_id = super::comms::orch_step_id(block_index);
+    // Resume: the orchestrator already concluded in a prior drive → stage done.
+    if child_already_done(&ctx.db.lock(), run_id, &orch_step_id) {
+        return Ok(StageFlow::Advance);
+    }
+
+    let stage_entry_sha = crate::git::rev_parse(run_repo, fork_base).await.ok();
+    let orch_step_eff = eff.for_step(None);
+    let orch_deadlines = deadlines_from(&ctx.deadlines, &orch_step_eff);
+
+    // ── Spawn the stage-lived orchestrator; stamp its agent id at spawn so its
+    //    mid-turn `wf_decide`/`wf_notify` resolve by agent id (§10.2). ──
+    let orch_agent = spec.agents.get(&orch.agent).ok_or_else(|| {
+        Error::Other(format!(
+            "orchestrate references unknown agent '{}'",
+            orch.agent
+        ))
+    })?;
+    let orch_exec = format!("exec-{}", uuid::Uuid::new_v4());
+    {
+        let conn = ctx.db.lock();
+        create_step_exec(&conn, &orch_exec, run_id, &orch_step_id, 1, 0, "verdict");
+    }
+    let spawned = match ctx
+        .driver
+        .spawn(build_spawn_req(
+            orch_agent, fork_base, repo, run_repo, run_id,
+        ))
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            let conn = ctx.db.lock();
+            finish_step_exec(&conn, &orch_exec, "error", None);
+            set_status(
+                &conn,
+                ctx.app.as_ref(),
+                run_id,
+                "failed",
+                None,
+                Some(&format!("orchestrator spawn failed: {e}")),
+            );
+            return Ok(StageFlow::Stop);
+        }
+    };
+    let orch_agent_id = spawned.agent_id.clone();
+    {
+        let conn = ctx.db.lock();
+        let _ = conn.execute(
+            "UPDATE wf_step_exec SET agent_id = ?1, status = 'running', started_at = ?2 WHERE id = ?3",
+            rusqlite::params![orch_agent_id, super::now_ms(), orch_exec],
+        );
+        journal_event(
+            &conn,
+            ctx.app.as_ref(),
+            run_id,
+            event_type::ATTEMPT_SPAWNED,
+            Some(&orch_exec),
+            &json!({ "agent_id": orch_agent_id, "fork_base": fork_base, "role": "orchestrator" }),
+        );
+    }
+    if let Err(e) = attempt::await_agent_ready(
+        ctx.driver.as_ref(),
+        &orch_agent_id,
+        orch_deadlines.spawn_timeout,
+    )
+    .await
+    {
+        let conn = ctx.db.lock();
+        finish_step_exec(&conn, &orch_exec, "error", None);
+        set_status(
+            &conn,
+            ctx.app.as_ref(),
+            run_id,
+            "failed",
+            None,
+            Some(&format!("orchestrator not ready: {e}")),
+        );
+        return Ok(StageFlow::Stop);
+    }
+    {
+        let conn = ctx.db.lock();
+        journal_event(
+            &conn,
+            ctx.app.as_ref(),
+            run_id,
+            event_type::ATTEMPT_READY,
+            Some(&orch_exec),
+            &json!({ "role": "orchestrator" }),
+        );
+    }
+
+    // ── Launch static body children, then drive the orchestrator's first turn. ──
+    let stage_cancel = Arc::new(AtomicBool::new(false));
+    let mut set: JoinSet<OrchChildResult> = JoinSet::new();
+    let mut dyn_count = 0u32;
+    let mut outcomes: HashMap<String, ChildStatus> = HashMap::new();
+
+    for step in &orch.body {
+        let agent_spec = spec.agents.get(&step.agent).ok_or_else(|| {
+            Error::Other(format!(
+                "orchestrate child '{}' references unknown agent '{}'",
+                step.id, step.agent
+            ))
+        })?;
+        let c = build_orch_child_ctx(
+            ctx,
+            run_id,
+            run,
+            agent_spec.clone(),
+            step.clone(),
+            block_index,
+            block_count,
+            blackboard,
+            repo,
+            run_repo,
+            fork_base,
+            eff,
+            test_override,
+            setup_override,
+            &stage_cancel,
+        );
+        let entry = stage_entry_sha.clone();
+        set.spawn(async move { drive_orch_child(c, entry).await });
+    }
+
+    let init_prompt = {
+        let static_children: Vec<String> = orch.body.iter().map(|s| s.id.clone()).collect();
+        let dynamic = orch.children.as_ref().map(|c| (c.agent.as_str(), c.max));
+        let base = prompts::orchestrator_prompt(&prompts::OrchestratorPromptCtx {
+            run_task: &run.task,
+            orch_step_id: &orch_step_id,
+            goal: &orch.goal,
+            position: Position {
+                step_index: block_index,
+                step_count: block_count,
+                iteration: None,
+            },
+            static_children: &static_children,
+            dynamic,
+        });
+        // On a resume after escalation, an answer for the orchestrator is folded in.
+        let delivered = {
+            let conn = ctx.db.lock();
+            super::comms::take_pending_deliveries(&conn, run_id, &orch_step_id)
+        };
+        if delivered.is_empty() {
+            base
+        } else {
+            format!("{}\n\n{}", super::comms::compose_delivery(&delivered), base)
+        }
+    };
+
+    match drive_orch_turn(
+        ctx,
+        run_id,
+        &orch_exec,
+        &orch_step_id,
+        &orch_agent_id,
+        init_prompt,
+        "step",
+        &orch_deadlines,
+        ledger,
+        eff,
+    )
+    .await
+    {
+        OrchStepResult::Ok => {}
+        other => {
+            return finish_orch_turn_failure(
+                ctx,
+                run_id,
+                &orch_exec,
+                &orch_agent_id,
+                &stage_cancel,
+                &mut set,
+                ledger,
+                other,
+            )
+            .await;
+        }
+    }
+
+    // ── The stage event loop (§6.6): alternate driving the orchestrator with
+    //    reaping children until the join is met and it concludes. ──
+    let mut concluded_early = false;
+    let mut conclude_sent = false;
+    let mut conclude_tries = 0u32;
+    const MAX_CONCLUDE_TRIES: u32 = 2;
+
+    loop {
+        if ctx.cancel.load(Ordering::SeqCst) {
+            drain_children(&stage_cancel, &mut set).await;
+            cancel_run(ctx, run_id).await;
+            return Ok(StageFlow::Stop);
+        }
+
+        // Orchestrator escalated or asked the human on its last turn → pause
+        // `question` (§10.2, §10.4). The backstop mirrors the linear path.
+        if super::comms::has_unanswered_ask(&ctx.db.lock(), &orch_exec) {
+            drain_children(&stage_cancel, &mut set).await;
+            pause_question(ctx, run_id, &orch_exec, Some(&orch_agent_id)).await;
+            return Ok(StageFlow::Stop);
+        }
+
+        // Execute the decisions the orchestrator issued last turn (§10.2).
+        let decisions = {
+            let conn = ctx.db.lock();
+            super::comms::take_orchestrator_decisions(&conn, run_id, &orch_exec)
+        };
+        for d in decisions {
+            match d {
+                super::comms::Decision::StageDone => concluded_early = true,
+                super::comms::Decision::SpawnChild { agent, goal } => {
+                    if let Some(agent_spec) = spec.agents.get(&agent).cloned() {
+                        let step = Step {
+                            id: format!("{orch_step_id}::dyn-{dyn_count}"),
+                            agent: agent.clone(),
+                            goal,
+                            gate: Gate::Verdict,
+                            budgets: None,
+                            comms: orch.comms.clone(),
+                        };
+                        dyn_count += 1;
+                        let c = build_orch_child_ctx(
+                            ctx,
+                            run_id,
+                            run,
+                            agent_spec,
+                            step,
+                            block_index,
+                            block_count,
+                            blackboard,
+                            repo,
+                            run_repo,
+                            fork_base,
+                            eff,
+                            test_override,
+                            setup_override,
+                            &stage_cancel,
+                        );
+                        let entry = stage_entry_sha.clone();
+                        set.spawn(async move { drive_orch_child(c, entry).await });
+                    }
+                }
+                super::comms::Decision::SkipChild { step_id, .. } => {
+                    // Satisfied, not failed. A still-running child's later outcome
+                    // is ignored (this entry wins the join decision).
+                    outcomes.insert(step_id, ChildStatus::Skipped);
+                }
+                super::comms::Decision::RetryChild { step_id, guidance } => {
+                    if let Some(orig) = orch.body.iter().find(|s| s.id == step_id).cloned() {
+                        if let Some(agent_spec) = spec.agents.get(&orig.agent).cloned() {
+                            // Fold the guidance into the fresh attempt via a notice.
+                            {
+                                let conn = ctx.db.lock();
+                                super::comms::queue_child_note(&conn, run_id, &orig.id, &guidance);
+                            }
+                            outcomes.remove(&orig.id);
+                            let step = orig.clone();
+                            let c = build_orch_child_ctx(
+                                ctx,
+                                run_id,
+                                run,
+                                agent_spec,
+                                step,
+                                block_index,
+                                block_count,
+                                blackboard,
+                                repo,
+                                run_repo,
+                                fork_base,
+                                eff,
+                                test_override,
+                                setup_override,
+                                &stage_cancel,
+                            );
+                            let entry = stage_entry_sha.clone();
+                            set.spawn(async move { drive_orch_child(c, entry).await });
+                        }
+                    }
+                }
+            }
+        }
+        if concluded_early {
+            break;
+        }
+
+        // Reap finished children without blocking (§11.2 fold + §10.1 forward).
+        while let Some(joined) = set.try_join_next() {
+            handle_orch_child(
+                ctx,
+                run_id,
+                &orch_exec,
+                orch.join,
+                ledger,
+                joined,
+                &mut outcomes,
+                &stage_cancel,
+            );
+        }
+
+        // join `all`: the first child failure fails the stage.
+        if matches!(orch.join, Join::All) {
+            if let Some(reason) = outcomes.values().find_map(|s| match s {
+                ChildStatus::Failure(r) => Some(r.clone()),
+                _ => None,
+            }) {
+                drain_children(&stage_cancel, &mut set).await;
+                let _ = ctx.driver.stop(&orch_agent_id).await;
+                let conn = ctx.db.lock();
+                finish_step_exec(&conn, &orch_exec, "error", None);
+                persist_spent(&conn, run_id, ledger);
+                set_status(
+                    &conn,
+                    ctx.app.as_ref(),
+                    run_id,
+                    "failed",
+                    None,
+                    Some(&format!("orchestrate stage failed: {reason}")),
+                );
+                return Ok(StageFlow::Stop);
+            }
+        }
+
+        if set.is_empty() {
+            // Every child is terminal. join `any` with no success and ≥1 failure
+            // fails the stage; otherwise the orchestrator concludes.
+            if matches!(orch.join, Join::Any)
+                && !outcomes.values().any(|s| matches!(s, ChildStatus::Success))
+                && outcomes
+                    .values()
+                    .any(|s| matches!(s, ChildStatus::Failure(_)))
+            {
+                let _ = ctx.driver.stop(&orch_agent_id).await;
+                let conn = ctx.db.lock();
+                finish_step_exec(&conn, &orch_exec, "error", None);
+                persist_spent(&conn, run_id, ledger);
+                set_status(
+                    &conn,
+                    ctx.app.as_ref(),
+                    run_id,
+                    "failed",
+                    None,
+                    Some("orchestrate stage failed: all children failed"),
+                );
+                return Ok(StageFlow::Stop);
+            }
+
+            if !conclude_sent {
+                let prompt = {
+                    let inbox = {
+                        let conn = ctx.db.lock();
+                        super::comms::take_orchestrator_inbox(&conn, run_id, &orch_exec)
+                    };
+                    let mut p = if inbox.is_empty() {
+                        String::new()
+                    } else {
+                        format!("{}\n\n", super::comms::compose_orchestrator_inbox(&inbox))
+                    };
+                    p.push_str(&prompts::orchestrator_conclude_prompt(&orch_step_id));
+                    p
+                };
+                conclude_sent = true;
+                conclude_tries += 1;
+                match drive_orch_turn(
+                    ctx,
+                    run_id,
+                    &orch_exec,
+                    &orch_step_id,
+                    &orch_agent_id,
+                    prompt,
+                    "reprompt",
+                    &orch_deadlines,
+                    ledger,
+                    eff,
+                )
+                .await
+                {
+                    OrchStepResult::Ok => continue,
+                    other => {
+                        return finish_orch_turn_failure(
+                            ctx,
+                            run_id,
+                            &orch_exec,
+                            &orch_agent_id,
+                            &stage_cancel,
+                            &mut set,
+                            ledger,
+                            other,
+                        )
+                        .await;
+                    }
+                }
+            }
+
+            // Read the orchestrator's concluding verdict — the stage gate (§6.6).
+            let step_dir = blackboard::step_dir(blackboard, &orch_step_id)?;
+            let verdict = blackboard::read_verdict(&step_dir);
+            let done = matches!(
+                &verdict,
+                Ok(v) if matches!(v.result, super::blackboard::VerdictResult::Done)
+            );
+            {
+                let conn = ctx.db.lock();
+                journal_event(
+                    &conn,
+                    ctx.app.as_ref(),
+                    run_id,
+                    event_type::GATE_EVALUATED,
+                    Some(&orch_exec),
+                    &json!({
+                        "mode": "verdict",
+                        "outcome": if done { "done" } else { "blocked" },
+                        "reason": if done { "orchestrator concluded" } else { "orchestrator has not concluded yet" },
+                    }),
+                );
+            }
+            if done {
+                let _ = ctx.driver.archive(&orch_agent_id).await;
+                let conn = ctx.db.lock();
+                finish_step_exec(&conn, &orch_exec, "done", None);
+                persist_spent(&conn, run_id, ledger);
+                return Ok(StageFlow::Advance);
+            }
+            if conclude_tries < MAX_CONCLUDE_TRIES {
+                conclude_tries += 1;
+                match drive_orch_turn(
+                    ctx,
+                    run_id,
+                    &orch_exec,
+                    &orch_step_id,
+                    &orch_agent_id,
+                    prompts::orchestrator_conclude_prompt(&orch_step_id),
+                    "reprompt",
+                    &orch_deadlines,
+                    ledger,
+                    eff,
+                )
+                .await
+                {
+                    OrchStepResult::Ok => continue,
+                    other => {
+                        return finish_orch_turn_failure(
+                            ctx,
+                            run_id,
+                            &orch_exec,
+                            &orch_agent_id,
+                            &stage_cancel,
+                            &mut set,
+                            ledger,
+                            other,
+                        )
+                        .await;
+                    }
+                }
+            }
+            // Could not conclude → pause `blocked_gate` for a human retry (§6.5).
+            let _ = ctx.driver.stop(&orch_agent_id).await;
+            let conn = ctx.db.lock();
+            finish_step_exec(&conn, &orch_exec, "blocked", None);
+            persist_spent(&conn, run_id, ledger);
+            journal_event(
+                &conn,
+                ctx.app.as_ref(),
+                run_id,
+                event_type::RUN_PAUSED,
+                Some(&orch_exec),
+                &json!({ "reason": "blocked_gate", "detail": "orchestrator did not conclude the stage" }),
+            );
+            set_status(
+                &conn,
+                ctx.app.as_ref(),
+                run_id,
+                "paused",
+                Some("blocked_gate"),
+                None,
+            );
+            return Ok(StageFlow::Stop);
+        }
+
+        // Children still running: prompt the orchestrator if it has inbox to act
+        // on, else wait for the next child event or a poll tick.
+        let inbox = {
+            let conn = ctx.db.lock();
+            super::comms::take_orchestrator_inbox(&conn, run_id, &orch_exec)
+        };
+        if !inbox.is_empty() {
+            let prompt = super::comms::compose_orchestrator_inbox(&inbox);
+            match drive_orch_turn(
+                ctx,
+                run_id,
+                &orch_exec,
+                &orch_step_id,
+                &orch_agent_id,
+                prompt,
+                "message",
+                &orch_deadlines,
+                ledger,
+                eff,
+            )
+            .await
+            {
+                OrchStepResult::Ok => continue,
+                other => {
+                    return finish_orch_turn_failure(
+                        ctx,
+                        run_id,
+                        &orch_exec,
+                        &orch_agent_id,
+                        &stage_cancel,
+                        &mut set,
+                        ledger,
+                        other,
+                    )
+                    .await;
+                }
+            }
+        }
+
+        // Bound the idle wait by the run wall-clock (§11.3 — "no wait without a
+        // deadline"): a wedged stage pauses `budget_exceeded` rather than hanging.
+        if let Some(which) = ledger.exceeded(eff, super::now_ms()) {
+            drain_children(&stage_cancel, &mut set).await;
+            let _ = ctx.driver.stop(&orch_agent_id).await;
+            {
+                let conn = ctx.db.lock();
+                finish_step_exec(&conn, &orch_exec, "abandoned", None);
+                journal_event(
+                    &conn,
+                    ctx.app.as_ref(),
+                    run_id,
+                    event_type::BUDGET_EXCEEDED,
+                    Some(&orch_exec),
+                    &json!({ "which": which.as_str() }),
+                );
+            }
+            finish_budget_pause(ctx, run_id, Some(&orch_exec), ledger);
+            return Ok(StageFlow::Stop);
+        }
+        tokio::select! {
+            joined = set.join_next() => {
+                if let Some(j) = joined {
+                    handle_orch_child(ctx, run_id, &orch_exec, orch.join, ledger, j, &mut outcomes, &stage_cancel);
+                }
+            }
+            _ = tokio::time::sleep(std::time::Duration::from_millis(200)) => {}
+        }
+    }
+
+    // `stage_done`: wind the remaining children down and mark the stage done.
+    drain_children(&stage_cancel, &mut set).await;
+    let _ = ctx.driver.archive(&orch_agent_id).await;
+    let conn = ctx.db.lock();
+    finish_step_exec(&conn, &orch_exec, "done", None);
+    persist_spent(&conn, run_id, ledger);
+    Ok(StageFlow::Advance)
+}
+
+/// Assemble one orchestrate child's owned [`ChildCtx`] (all fields cloned so the
+/// child task is `'static`).
+#[allow(clippy::too_many_arguments)]
+fn build_orch_child_ctx(
+    ctx: &RunCtx,
+    run_id: &str,
+    run: &RunEssentials,
+    agent_spec: AgentSpec,
+    step: Step,
+    block_index: usize,
+    block_count: usize,
+    blackboard: &Path,
+    repo: &Path,
+    run_repo: &Path,
+    fork_base: &str,
+    eff: &EffectiveBudgets,
+    test_override: &Option<String>,
+    setup_override: &Option<String>,
+    stage_cancel: &Arc<AtomicBool>,
+) -> ChildCtx {
+    ChildCtx {
+        db: ctx.db.clone(),
+        driver: ctx.driver.clone(),
+        app: ctx.app.clone(),
+        base_deadlines: ctx.deadlines.clone(),
+        eff: eff.clone(),
+        run_id: run_id.to_string(),
+        run_task: run.task.clone(),
+        step,
+        agent_spec,
+        fork_base: fork_base.to_string(),
+        blackboard: blackboard.to_path_buf(),
+        repo: repo.to_path_buf(),
+        run_repo: run_repo.to_path_buf(),
+        block_index,
+        block_count,
+        test_override: test_override.clone(),
+        setup_override: setup_override.clone(),
+        stage_cancel: stage_cancel.clone(),
+    }
+}
+
+/// Drive one orchestrate child (spec §6.6, §10.4). Like a parallel child it spawns,
+/// runs its turn, and gates under `integrate: none` — but it stamps its agent id
+/// at spawn (so a mid-turn `wf_ask` resolves to it), and when it raises a question
+/// routed to the orchestrator it parks for the answer and re-attempts with it
+/// folded in rather than failing.
+async fn drive_orch_child(c: ChildCtx, stage_entry_sha: Option<String>) -> OrchChildResult {
+    let step_eff = c.eff.for_step(c.step.budgets.as_ref());
+    let deadlines = deadlines_from(&c.base_deadlines, &step_eff);
+    let max_attempts = step_eff.max_attempts;
+    let mut child_ledger = Ledger::default();
+    let mut last_exec = String::new();
+
+    let done =
+        |step_id: String, exec_id: String, outcome: ChildOutcome, ledger: Ledger| OrchChildResult {
+            step_id,
+            exec_id,
+            outcome,
+            ledger,
+        };
+
+    let test_runner = match super::tests_gate::SandboxTestRunner::new(
+        c.test_override.clone(),
+        c.setup_override.clone(),
+        step_eff.tests_timeout_secs.max(1) as u64,
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            return done(
+                c.step.id.clone(),
+                last_exec,
+                ChildOutcome::Failure {
+                    reason: format!("could not initialize the tests runner: {e}"),
+                },
+                child_ledger,
+            )
+        }
+    };
+
+    let mut attempt_no = next_attempt_no(&c.db.lock(), &c.run_id, &c.step.id, 0);
+    let mut last_failure: Option<String> = None;
+
+    loop {
+        if c.stage_cancel.load(Ordering::SeqCst) {
+            return done(
+                c.step.id.clone(),
+                last_exec,
+                ChildOutcome::Canceled,
+                child_ledger,
+            );
+        }
+
+        let exec_id = format!("exec-{}", uuid::Uuid::new_v4());
+        last_exec = exec_id.clone();
+        {
+            let conn = c.db.lock();
+            create_step_exec(
+                &conn,
+                &exec_id,
+                &c.run_id,
+                &c.step.id,
+                attempt_no,
+                0,
+                gate_mode(&c.step.gate),
+            );
+        }
+
+        // Spawn and stamp the agent id BEFORE the turn (§10.2).
+        let spawned = match c
+            .driver
+            .spawn(build_spawn_req(
+                &c.agent_spec,
+                &c.fork_base,
+                &c.repo,
+                &c.run_repo,
+                &c.run_id,
+            ))
+            .await
+        {
+            Ok(s) => s,
+            Err(e) => {
+                let error = format!("spawn failed: {e}");
+                {
+                    let conn = c.db.lock();
+                    finish_step_exec(&conn, &exec_id, "error", None);
+                }
+                last_failure = Some(error.clone());
+                if attempt_no >= max_attempts {
+                    return done(
+                        c.step.id.clone(),
+                        last_exec,
+                        ChildOutcome::Failure { reason: error },
+                        child_ledger,
+                    );
+                }
+                attempt_no += 1;
+                continue;
+            }
+        };
+        let child_agent_id = spawned.agent_id.clone();
+        {
+            let conn = c.db.lock();
+            let _ = conn.execute(
+                "UPDATE wf_step_exec SET agent_id = ?1, started_at = ?2 WHERE id = ?3",
+                rusqlite::params![child_agent_id, super::now_ms(), exec_id],
+            );
+        }
+
+        let prompt = {
+            let ctx_prompt = StepPromptCtx {
+                run_task: &c.run_task,
+                step_id: &c.step.id,
+                step_goal: &c.step.goal,
+                position: Position {
+                    step_index: c.block_index,
+                    step_count: c.block_count,
+                    iteration: None,
+                },
+                gate: &c.step.gate,
+                turns_per_attempt: c.step.budgets.as_ref().and_then(|b| b.turns_per_attempt),
+                comms: &c.step.comms,
+            };
+            let base = match &last_failure {
+                Some(f) => prompts::retry_prompt(f, &ctx_prompt),
+                None => prompts::step_prompt(&ctx_prompt),
+            };
+            // Fold a delivered answer (to a prior ask) or a notify/guidance (§10.4).
+            let delivered = {
+                let conn = c.db.lock();
+                super::comms::take_pending_deliveries(&conn, &c.run_id, &c.step.id)
+            };
+            if delivered.is_empty() {
+                base
+            } else {
+                format!("{}\n\n{}", super::comms::compose_delivery(&delivered), base)
+            }
+        };
+
+        let params = AttemptParams {
+            spawn_req: build_spawn_req(
+                &c.agent_spec,
+                &c.fork_base,
+                &c.repo,
+                &c.run_repo,
+                &c.run_id,
+            ),
+            pre_spawned: Some(spawned),
+            blackboard: c.blackboard.clone(),
+            exec_id: exec_id.clone(),
+            step_id: c.step.id.clone(),
+            attempt: attempt_no as u32,
+            iteration: 0,
+            gate: c.step.gate.clone(),
+            prompt,
+            deadlines: deadlines.clone(),
+            reprompt_on_block: true,
+            cancel: c.stage_cancel.clone(),
+            pending_ask: Arc::new(AtomicBool::new(false)),
+        };
+
+        let started = super::now_ms();
+        let result = attempt::run_attempt(
+            c.driver.as_ref(),
+            &test_runner,
+            params,
+            &mut child_ledger,
+            &step_eff,
+        )
+        .await;
+        {
+            let conn = c.db.lock();
+            let _ = conn.execute(
+                "UPDATE wf_step_exec SET started_at = ?1 WHERE id = ?2 AND started_at IS NULL",
+                rusqlite::params![started, exec_id],
+            );
+            for e in &result.events {
+                journal_event(
+                    &conn,
+                    c.app.as_ref(),
+                    &c.run_id,
+                    e.event_type,
+                    Some(&exec_id),
+                    &e.payload,
+                );
+            }
+        }
+
+        // Drain the mailbox so a `wf_ask` from this turn is persisted (§10.4).
+        c.driver.settle_rpc(&child_agent_id).await;
+
+        // Asked the orchestrator? Park for the answer, then re-attempt (§10.4).
+        if super::comms::has_unanswered_ask(&c.db.lock(), &exec_id) {
+            {
+                let conn = c.db.lock();
+                let _ = conn.execute(
+                    "UPDATE wf_step_exec SET status = 'abandoned', ended_at = ?1 WHERE id = ?2",
+                    rusqlite::params![super::now_ms(), exec_id],
+                );
+                journal_event(
+                    &conn,
+                    c.app.as_ref(),
+                    &c.run_id,
+                    event_type::ATTEMPT_ABANDONED,
+                    Some(&exec_id),
+                    &json!({ "cause": "question" }),
+                );
+            }
+            let _ = c.driver.stop(&child_agent_id).await;
+            let _ = c.driver.archive(&child_agent_id).await;
+            match wait_for_answer(&c, &exec_id, &deadlines).await {
+                AnswerWait::Answered => {
+                    attempt_no += 1;
+                    continue;
+                }
+                AnswerWait::Canceled => {
+                    return done(
+                        c.step.id.clone(),
+                        last_exec,
+                        ChildOutcome::Canceled,
+                        child_ledger,
+                    )
+                }
+                AnswerWait::Timeout => {
+                    return done(
+                        c.step.id.clone(),
+                        last_exec,
+                        ChildOutcome::Failure {
+                            reason: "no answer from the orchestrator".into(),
+                        },
+                        child_ledger,
+                    )
+                }
+            }
+        }
+
+        match result.outcome {
+            AttemptOutcome::Done { .. } => {
+                let head = match &result.worktree {
+                    Some(wt) => gitops::head_sha(wt).await.ok(),
+                    None => None,
+                };
+                let moved_head = match (&head, &stage_entry_sha) {
+                    (Some(h), Some(entry)) => h != entry,
+                    _ => false,
+                };
+                {
+                    let conn = c.db.lock();
+                    finish_step_exec(&conn, &exec_id, "done", head.as_deref());
+                }
+                let _ = c.driver.archive(&child_agent_id).await;
+                return done(
+                    c.step.id.clone(),
+                    last_exec,
+                    ChildOutcome::Success { moved_head, head },
+                    child_ledger,
+                );
+            }
+            AttemptOutcome::Canceled => {
+                {
+                    let conn = c.db.lock();
+                    let _ = conn.execute(
+                        "UPDATE wf_step_exec SET status = 'abandoned', ended_at = ?1 WHERE id = ?2",
+                        rusqlite::params![super::now_ms(), exec_id],
+                    );
+                    journal_event(
+                        &conn,
+                        c.app.as_ref(),
+                        &c.run_id,
+                        event_type::ATTEMPT_ABANDONED,
+                        Some(&exec_id),
+                        &json!({ "cause": "canceled" }),
+                    );
+                }
+                let _ = c.driver.archive(&child_agent_id).await;
+                return done(
+                    c.step.id.clone(),
+                    last_exec,
+                    ChildOutcome::Canceled,
+                    child_ledger,
+                );
+            }
+            AttemptOutcome::Error { error } => {
+                {
+                    let conn = c.db.lock();
+                    finish_step_exec(&conn, &exec_id, "error", None);
+                }
+                last_failure = Some(error.clone());
+                if attempt_no >= max_attempts {
+                    return done(
+                        c.step.id.clone(),
+                        last_exec,
+                        ChildOutcome::Failure { reason: error },
+                        child_ledger,
+                    );
+                }
+                attempt_no += 1;
+            }
+            AttemptOutcome::Blocked { reason } => {
+                {
+                    let conn = c.db.lock();
+                    finish_step_exec(&conn, &exec_id, "blocked", None);
+                }
+                let _ = c.driver.stop(&child_agent_id).await;
+                let _ = c.driver.archive(&child_agent_id).await;
+                return done(
+                    c.step.id.clone(),
+                    last_exec,
+                    ChildOutcome::Failure {
+                        reason: format!("gate unmet: {reason}"),
+                    },
+                    child_ledger,
+                );
+            }
+            AttemptOutcome::BudgetExceeded { which } => {
+                {
+                    let conn = c.db.lock();
+                    finish_step_exec(&conn, &exec_id, "error", None);
+                }
+                let _ = c.driver.stop(&child_agent_id).await;
+                let _ = c.driver.archive(&child_agent_id).await;
+                return done(
+                    c.step.id.clone(),
+                    last_exec,
+                    ChildOutcome::Failure {
+                        reason: format!("budget_exceeded: {which}"),
+                    },
+                    child_ledger,
+                );
+            }
+            AttemptOutcome::AwaitingApproval => {
+                {
+                    let conn = c.db.lock();
+                    finish_step_exec(&conn, &exec_id, "error", None);
+                }
+                let _ = c.driver.archive(&child_agent_id).await;
+                return done(
+                    c.step.id.clone(),
+                    last_exec,
+                    ChildOutcome::Failure {
+                        reason: "approval gates are not supported inside an orchestrate stage"
+                            .into(),
+                    },
+                    child_ledger,
+                );
+            }
+            AttemptOutcome::AwaitingAnswer => {
+                // Children never set `pending_ask`; the `has_unanswered_ask` check
+                // above handles asks. Defensive.
+                {
+                    let conn = c.db.lock();
+                    finish_step_exec(&conn, &exec_id, "error", None);
+                }
+                let _ = c.driver.archive(&child_agent_id).await;
+                return done(
+                    c.step.id.clone(),
+                    last_exec,
+                    ChildOutcome::Failure {
+                        reason: "unexpected awaiting-answer state".into(),
+                    },
+                    child_ledger,
+                );
+            }
+        }
+    }
+}
+
+/// Poll for the orchestrator's answer to this child's ask, bounded by the child's
+/// stall timeout (§10.4 — no wait without a deadline). The persisted ask flips to
+/// `answered` when the orchestrator replies; the answer itself is folded into the
+/// next attempt's prompt.
+async fn wait_for_answer(c: &ChildCtx, exec_id: &str, d: &Deadlines) -> AnswerWait {
+    let deadline = tokio::time::Instant::now() + d.stall_timeout;
+    loop {
+        if c.stage_cancel.load(Ordering::SeqCst) {
+            return AnswerWait::Canceled;
+        }
+        if !super::comms::has_unanswered_ask(&c.db.lock(), exec_id) {
+            return AnswerWait::Answered;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return AnswerWait::Timeout;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+}
+
+/// Fold a reaped orchestrate child into the stage: sum its ledger, forward its
+/// terminal outcome to the orchestrator (§10.1), and record its join status. A
+/// join-`any` success winds the losers down.
+#[allow(clippy::too_many_arguments)]
+fn handle_orch_child(
+    ctx: &RunCtx,
+    run_id: &str,
+    orch_exec: &str,
+    join: Join,
+    ledger: &mut Ledger,
+    joined: std::result::Result<OrchChildResult, tokio::task::JoinError>,
+    outcomes: &mut HashMap<String, ChildStatus>,
+    stage_cancel: &Arc<AtomicBool>,
+) {
+    let res = match joined {
+        Ok(r) => r,
+        Err(e) => {
+            // A child task panicked — contain it as a failure (§6.1).
+            outcomes.insert(
+                format!("panicked-{}", outcomes.len()),
+                ChildStatus::Failure(format!("child task error: {e}")),
+            );
+            return;
+        }
+    };
+    fold_child_ledger(ledger, &res.ledger);
+    let conn = ctx.db.lock();
+    match res.outcome {
+        ChildOutcome::Success { moved_head, head } => {
+            if moved_head {
+                journal_event(
+                    &conn,
+                    ctx.app.as_ref(),
+                    run_id,
+                    event_type::INTEGRATE_SKIPPED,
+                    None,
+                    &json!({ "step_id": res.step_id, "sha": head }),
+                );
+            }
+            super::comms::forward_lifecycle(
+                &conn,
+                ctx.app.as_ref(),
+                run_id,
+                orch_exec,
+                &res.exec_id,
+                "done",
+                &format!("child `{}` finished", res.step_id),
+            );
+            // Don't overwrite a `skip` the orchestrator already recorded.
+            outcomes.entry(res.step_id).or_insert(ChildStatus::Success);
+            if matches!(join, Join::Any) {
+                stage_cancel.store(true, Ordering::SeqCst);
+            }
+        }
+        ChildOutcome::Failure { reason } => {
+            super::comms::forward_lifecycle(
+                &conn,
+                ctx.app.as_ref(),
+                run_id,
+                orch_exec,
+                &res.exec_id,
+                "error",
+                &format!("child `{}` failed: {reason}", res.step_id),
+            );
+            outcomes
+                .entry(res.step_id)
+                .or_insert(ChildStatus::Failure(reason));
+        }
+        ChildOutcome::Canceled => {}
+    }
+    persist_spent(&conn, run_id, ledger);
+}
+
+/// Wind down every remaining orchestrate child: raise the stage cancel and drain
+/// the set (each child stops its own agent and returns `Canceled`).
+async fn drain_children(stage_cancel: &Arc<AtomicBool>, set: &mut JoinSet<OrchChildResult>) {
+    stage_cancel.store(true, Ordering::SeqCst);
+    while set.join_next().await.is_some() {}
+}
+
+/// Drive one orchestrator turn and fold its budget in (§10.2, §11.2).
+#[allow(clippy::too_many_arguments)]
+async fn drive_orch_turn(
+    ctx: &RunCtx,
+    run_id: &str,
+    orch_exec: &str,
+    orch_step_id: &str,
+    orch_agent_id: &str,
+    prompt: String,
+    kind: &'static str,
+    deadlines: &Deadlines,
+    ledger: &mut Ledger,
+    eff: &EffectiveBudgets,
+) -> OrchStepResult {
+    if let Some(which) = ledger.exceeded(eff, super::now_ms()) {
+        return OrchStepResult::Budget(which.as_str().to_string());
+    }
+    let (turn, events) =
+        attempt::drive_prompt_turn(ctx.driver.as_ref(), orch_agent_id, prompt, kind, deadlines)
+            .await;
+    {
+        let conn = ctx.db.lock();
+        for e in &events {
+            journal_event(
+                &conn,
+                ctx.app.as_ref(),
+                run_id,
+                e.event_type,
+                Some(orch_exec),
+                &e.payload,
+            );
+        }
+    }
+    ledger.charge_turn(orch_step_id, orch_exec);
+    ledger.charge_tokens(
+        orch_agent_id,
+        orch_step_id,
+        ctx.driver.turn_usage(orch_agent_id),
+    );
+    {
+        let conn = ctx.db.lock();
+        journal_event(
+            &conn,
+            ctx.app.as_ref(),
+            run_id,
+            event_type::BUDGET_TICK,
+            None,
+            &json!({ "turns": ledger.turns, "tokens": ledger.tokens }),
+        );
+        ledger.checkpoint_wall(super::now_ms());
+        persist_spent(&conn, run_id, ledger);
+    }
+    match turn {
+        attempt::OrchTurn::Ended => {
+            if let Some(which) = ledger.exceeded(eff, super::now_ms()) {
+                return OrchStepResult::Budget(which.as_str().to_string());
+            }
+            OrchStepResult::Ok
+        }
+        attempt::OrchTurn::Stalled => OrchStepResult::Stalled,
+        attempt::OrchTurn::Error(e) => OrchStepResult::Error(e),
+    }
+}
+
+/// Handle a non-`Ok` orchestrator turn: wind the children down and pause/fail the
+/// run per the cause (§10.2). A stall escalates to the human (`question`).
+#[allow(clippy::too_many_arguments)]
+async fn finish_orch_turn_failure(
+    ctx: &RunCtx,
+    run_id: &str,
+    orch_exec: &str,
+    orch_agent_id: &str,
+    stage_cancel: &Arc<AtomicBool>,
+    set: &mut JoinSet<OrchChildResult>,
+    ledger: &mut Ledger,
+    result: OrchStepResult,
+) -> Result<StageFlow> {
+    drain_children(stage_cancel, set).await;
+    match result {
+        OrchStepResult::Stalled => {
+            // A stalled orchestrator must not hang the stage — escalate to the
+            // human (§10.2). `pause_question` abandons the exec, stops the agent,
+            // and pauses `question`; a `wf_answer` resumes and re-drives the stage.
+            {
+                let conn = ctx.db.lock();
+                journal_event(
+                    &conn,
+                    ctx.app.as_ref(),
+                    run_id,
+                    event_type::WATCHDOG_STALLED,
+                    Some(orch_exec),
+                    &json!({ "role": "orchestrator", "escalated": true }),
+                );
+            }
+            // Record an engine ask so the human sees why the run paused and can
+            // answer it (§10.4) — the orchestrator is unresponsive.
+            {
+                let conn = ctx.db.lock();
+                super::comms::queue_engine_ask(
+                    &conn,
+                    run_id,
+                    orch_exec,
+                    "The orchestrator stalled. Provide guidance to continue, or cancel the run.",
+                );
+            }
+            pause_question(ctx, run_id, orch_exec, Some(orch_agent_id)).await;
+            Ok(StageFlow::Stop)
+        }
+        OrchStepResult::Budget(_) => {
+            let _ = ctx.driver.stop(orch_agent_id).await;
+            {
+                let conn = ctx.db.lock();
+                let _ = conn.execute(
+                    "UPDATE wf_step_exec SET status = 'abandoned', ended_at = ?1 WHERE id = ?2",
+                    rusqlite::params![super::now_ms(), orch_exec],
+                );
+            }
+            finish_budget_pause(ctx, run_id, Some(orch_exec), ledger);
+            Ok(StageFlow::Stop)
+        }
+        OrchStepResult::Error(e) => {
+            let _ = ctx.driver.stop(orch_agent_id).await;
+            let conn = ctx.db.lock();
+            finish_step_exec(&conn, orch_exec, "error", None);
+            persist_spent(&conn, run_id, ledger);
+            set_status(
+                &conn,
+                ctx.app.as_ref(),
+                run_id,
+                "failed",
+                None,
+                Some(&format!("orchestrator error: {e}")),
+            );
+            Ok(StageFlow::Stop)
+        }
+        OrchStepResult::Ok => Ok(StageFlow::Advance),
     }
 }
 
@@ -1713,6 +3025,7 @@ async fn execute_step(
 
         let params = AttemptParams {
             spawn_req: build_spawn_req(agent_spec, fork_ref, env.repo, env.run_repo, run_id),
+            pre_spawned: None,
             blackboard: env.blackboard.to_path_buf(),
             exec_id: exec_id.clone(),
             step_id: step.id.clone(),
@@ -4497,5 +5810,354 @@ mod tests {
             1
         );
         assert_eq!(run_status_str(&db, "run-loop-skip"), "done");
+    }
+
+    // ─────────────────────── orchestrate stages (S11) ───────────────────────
+
+    #[derive(Clone, Copy, PartialEq)]
+    enum OrchMode {
+        /// Writes a `done` verdict on the concluding prompt.
+        Conclude,
+        /// Never writes a verdict — the stage should gate on it and pause.
+        NeverConclude,
+        /// Stalls its turn forever — the engine escalates to the human.
+        Stall,
+    }
+
+    /// A real-git stub for orchestrate stages (spec §10.2). Children commit (their
+    /// `commit` gate); the orchestrator writes its concluding `verdict.json` on the
+    /// conclude prompt, never writes one, or stalls — per [`OrchMode`]. Roles are
+    /// told apart by the prompt text the engine composes.
+    struct OrchDriver {
+        root: PathBuf,
+        blackboard: PathBuf,
+        mode: OrchMode,
+        tx: broadcast::Sender<StatusEvent>,
+        state: parking_lot::Mutex<StubState>,
+    }
+    impl OrchDriver {
+        fn new(root: PathBuf, blackboard: PathBuf, mode: OrchMode) -> Arc<Self> {
+            Arc::new(Self {
+                root,
+                blackboard,
+                mode,
+                tx: broadcast::channel(256).0,
+                state: parking_lot::Mutex::new(StubState::default()),
+            })
+        }
+        fn set(&self, id: &str, s: AgentStatus) {
+            self.state.lock().statuses.insert(id.to_string(), s.clone());
+            let _ = self.tx.send(StatusEvent {
+                agent_id: id.to_string(),
+                status: s,
+            });
+        }
+    }
+    impl AgentDriver for OrchDriver {
+        fn spawn(
+            &self,
+            req: SpawnReq,
+        ) -> super::super::driver::BoxFuture<'_, Result<super::super::driver::SpawnedAgent>>
+        {
+            Box::pin(async move {
+                let id = {
+                    let mut st = self.state.lock();
+                    st.count += 1;
+                    format!("o-{}", st.count)
+                };
+                let dest = self.root.join(&id);
+                let base_ref = req.fork_base.clone().unwrap();
+                let spec = crate::sandbox::provision::CheckoutSpec {
+                    source_repo: &req.repo_path,
+                    base_ref: &base_ref,
+                    dest: &dest,
+                };
+                crate::sandbox::provision::provision_forking_run_repo(
+                    &spec,
+                    req.run_repo.as_ref().unwrap(),
+                )
+                .await?;
+                self.state.lock().worktrees.insert(id.clone(), dest.clone());
+                self.set(&id, AgentStatus::Idle);
+                Ok(super::super::driver::SpawnedAgent {
+                    agent_id: id,
+                    worktree: dest,
+                })
+            })
+        }
+        fn status(&self, id: &str) -> Option<AgentStatus> {
+            self.state.lock().statuses.get(id).cloned()
+        }
+        fn subscribe(&self) -> broadcast::Receiver<StatusEvent> {
+            self.tx.subscribe()
+        }
+        fn send_message<'a>(
+            &'a self,
+            id: &'a str,
+            text: String,
+        ) -> super::super::driver::BoxFuture<'a, Result<()>> {
+            Box::pin(async move {
+                let is_orch = text.contains("Workflow orchestrator")
+                    || text.contains("All children are done")
+                    || text.contains("Updates from your children");
+                let is_nudge = text.contains("gone quiet");
+                self.set(id, AgentStatus::Running);
+                if is_nudge {
+                    // Keep the (stalling) turn running so the watchdog escalates.
+                    return Ok(());
+                }
+                if is_orch {
+                    match self.mode {
+                        OrchMode::Stall => return Ok(()), // never goes Idle → stall
+                        OrchMode::Conclude => {
+                            if text.contains("All children are done") {
+                                let dir = self.blackboard.join("orchestrate-0");
+                                std::fs::create_dir_all(&dir).unwrap();
+                                std::fs::write(
+                                    dir.join("verdict.json"),
+                                    r#"{"result":"done","summary":"concluded"}"#,
+                                )
+                                .unwrap();
+                            }
+                        }
+                        OrchMode::NeverConclude => {}
+                    }
+                    self.set(id, AgentStatus::Idle);
+                } else {
+                    // A child: satisfy its `commit` gate.
+                    let wt = self.state.lock().worktrees.get(id).cloned().unwrap();
+                    sh(&wt, &["config", "user.email", "t@t.t"]);
+                    sh(&wt, &["config", "user.name", "t"]);
+                    std::fs::write(wt.join(format!("{id}.txt")), "work").unwrap();
+                    sh(&wt, &["add", "-A"]);
+                    sh(&wt, &["commit", "-qm", "child work"]);
+                    self.set(id, AgentStatus::Idle);
+                }
+                Ok(())
+            })
+        }
+        fn stop<'a>(&'a self, _id: &'a str) -> super::super::driver::BoxFuture<'a, Result<()>> {
+            Box::pin(async { Ok(()) })
+        }
+        fn archive<'a>(&'a self, _id: &'a str) -> super::super::driver::BoxFuture<'a, Result<()>> {
+            Box::pin(async { Ok(()) })
+        }
+        fn last_activity(&self, _id: &str) -> Option<i64> {
+            None
+        }
+        fn turn_usage(&self, _id: &str) -> Option<super::super::driver::TurnUsage> {
+            None
+        }
+    }
+
+    /// A run whose whole workflow is one orchestrate block (agent `orch`) with a
+    /// single static, commit-gated child `impl`. Returns the db, the workspace
+    /// root, the blackboard dir, and the base SHA.
+    fn scaffold_orchestrate(tmp: &Path, run_id: &str) -> (Db, PathBuf, PathBuf, String) {
+        let source = tmp.join("source");
+        std::fs::create_dir_all(&source).unwrap();
+        sh(&source, &["init", "-q", "-b", "main"]);
+        sh(&source, &["config", "user.email", "t@t.t"]);
+        sh(&source, &["config", "user.name", "t"]);
+        std::fs::write(source.join("README"), "base").unwrap();
+        sh(&source, &["add", "-A"]);
+        sh(&source, &["commit", "-qm", "base"]);
+        let base_sha = {
+            let o = Sh::new("git")
+                .current_dir(&source)
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .unwrap();
+            String::from_utf8_lossy(&o.stdout).trim().to_string()
+        };
+        let run_dir = tmp.join("rundir");
+        let blackboard = blackboard::blackboard_dir(&run_dir);
+        std::fs::create_dir_all(&blackboard).unwrap();
+
+        let mut agents = BTreeMap::new();
+        for a in ["orch", "coder"] {
+            agents.insert(
+                a.to_string(),
+                super::super::spec::AgentSpec {
+                    base: "codex".to_string(),
+                    model: None,
+                    instructions: None,
+                    skills: vec![],
+                    custom_agent: None,
+                },
+            );
+        }
+        let child = Step {
+            id: "impl".to_string(),
+            agent: "coder".to_string(),
+            goal: "implement the slice".to_string(),
+            gate: Gate::Commit,
+            budgets: None,
+            comms: vec![],
+        };
+        let spec = Spec {
+            version: 1,
+            name: "orch".to_string(),
+            description: None,
+            // Short stall/nudge so the stall test escalates in ~2s of real time
+            // (no `start_paused` — the real-git provisioning needs the IO reactor).
+            // Harmless to the non-stalling tests: their turns end before any tick.
+            budgets: Some(Budgets {
+                turns: None,
+                tokens: None,
+                wall_clock_mins: None,
+                turns_per_attempt: None,
+                max_attempts: None,
+                spawn_timeout_secs: None,
+                turn_start_timeout_secs: None,
+                stall_timeout_secs: Some(1),
+                nudge_timeout_secs: Some(1),
+                tests_timeout_secs: None,
+            }),
+            agents,
+            workflow: vec![Block::Orchestrate(Orchestrate {
+                agent: "orch".to_string(),
+                goal: "lead the stage".to_string(),
+                children: None,
+                body: vec![child],
+                join: Join::All,
+                integrate: Integrate::None,
+                comms: vec![],
+                compose: None,
+            })],
+            finalize: None,
+        };
+        let spec_json = serde_json::to_string(&spec).unwrap();
+        // Freeze the effective budgets from the spec so the short stall/nudge
+        // actually take effect (a bare '{}' would deserialize to the defaults).
+        let budgets_json = serde_json::to_string(&EffectiveBudgets::resolve(&spec)).unwrap();
+        let db = crate::database::init(tmp).unwrap();
+        db.lock()
+            .execute(
+                "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,branch,
+                    base_sha,status,budgets_json,spent_json,created_at,updated_at)
+                 VALUES (?1,'orch',?2,'t','p',?3,?4,'wf/orch-x',?5,'pending',?6,'{}',0,0)",
+                rusqlite::params![
+                    run_id,
+                    spec_json,
+                    source.to_string_lossy(),
+                    run_dir.to_string_lossy(),
+                    base_sha,
+                    budgets_json,
+                ],
+            )
+            .unwrap();
+        (db, tmp.join("ws"), blackboard, base_sha)
+    }
+
+    fn orch_ctx(db: Db, driver: Arc<OrchDriver>) -> RunCtx {
+        RunCtx {
+            db,
+            driver,
+            app: None,
+            cancel: Arc::new(AtomicBool::new(false)),
+            pending_ask: Arc::new(AtomicBool::new(false)),
+            // Tick the stall watchdog fast so the stall test resolves quickly.
+            deadlines: Deadlines {
+                watchdog_tick: std::time::Duration::from_millis(100),
+                ..Deadlines::default()
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn orchestrate_concludes_after_children_and_reaches_done() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (db, ws, bb, _base) = scaffold_orchestrate(tmp.path(), "run-orch");
+        let ctx = orch_ctx(db.clone(), OrchDriver::new(ws, bb, OrchMode::Conclude));
+        drive_run(&ctx, "run-orch").await;
+
+        assert_eq!(run_status_str(&db, "run-orch"), "done");
+        // The child ran, and the orchestrator concluded — both terminal `done`.
+        assert_eq!(
+            count(
+                &db,
+                "SELECT COUNT(*) FROM wf_step_exec WHERE run_id='run-orch' \
+                 AND step_id='impl' AND status='done'"
+            ),
+            1,
+            "the child completed"
+        );
+        assert_eq!(
+            count(
+                &db,
+                "SELECT COUNT(*) FROM wf_step_exec WHERE run_id='run-orch' \
+                 AND step_id='orchestrate-0' AND status='done'"
+            ),
+            1,
+            "the orchestrator concluded"
+        );
+        // The stage gate is the orchestrator's own verdict.
+        let concluded = count(
+            &db,
+            "SELECT COUNT(*) FROM wf_event WHERE run_id='run-orch' AND type='gate_evaluated' \
+             AND json_extract(payload_json,'$.outcome')='done' \
+             AND step_exec_id IN (SELECT id FROM wf_step_exec WHERE step_id='orchestrate-0')",
+        );
+        assert!(
+            concluded >= 1,
+            "orchestrator's concluding verdict gated the stage"
+        );
+    }
+
+    #[tokio::test]
+    async fn orchestrate_pauses_blocked_when_the_orchestrator_never_concludes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (db, ws, bb, _base) = scaffold_orchestrate(tmp.path(), "run-nc");
+        let ctx = orch_ctx(db.clone(), OrchDriver::new(ws, bb, OrchMode::NeverConclude));
+        drive_run(&ctx, "run-nc").await;
+
+        // The child finished, but the stage does NOT complete without the
+        // orchestrator's concluding verdict — it pauses `blocked_gate` (§6.6).
+        let (status, reason): (String, Option<String>) = db
+            .lock()
+            .query_row(
+                "SELECT status, paused_reason FROM wf_run WHERE id='run-nc'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "paused");
+        assert_eq!(reason.as_deref(), Some("blocked_gate"));
+        assert_eq!(
+            count(
+                &db,
+                "SELECT COUNT(*) FROM wf_step_exec WHERE run_id='run-nc' \
+                 AND step_id='impl' AND status='done'"
+            ),
+            1,
+            "the child still ran to completion"
+        );
+    }
+
+    #[tokio::test]
+    async fn orchestrator_stall_escalates_to_the_human() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (db, ws, bb, _base) = scaffold_orchestrate(tmp.path(), "run-stall");
+        let ctx = orch_ctx(db.clone(), OrchDriver::new(ws, bb, OrchMode::Stall));
+        drive_run(&ctx, "run-stall").await;
+
+        // A stalled orchestrator does not hang the stage — the engine escalates to
+        // the human, pausing the run `question` (§10.2).
+        let (status, reason, error): (String, Option<String>, Option<String>) = db
+            .lock()
+            .query_row(
+                "SELECT status, paused_reason, error FROM wf_run WHERE id='run-stall'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "paused", "run error: {error:?}");
+        assert_eq!(reason.as_deref(), Some("question"));
+        let stalled = count(
+            &db,
+            "SELECT COUNT(*) FROM wf_event WHERE run_id='run-stall' AND type='watchdog_stalled'",
+        );
+        assert!(stalled >= 1, "the orchestrator stall was journaled");
     }
 }

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -970,6 +970,11 @@ struct ChildCtx {
     /// pin, and ferry their work into the run repo (like a linear step) so the
     /// stage can merge their refs; `None` children leave code on their fork.
     integrate: Integrate,
+    /// An orchestrator note folded into the child's *first* prompt (spec §10.2 —
+    /// `retry_child` guidance). Threaded directly rather than via a queued
+    /// message so the fresh attempt is guaranteed to carry it. `None` for the
+    /// common case.
+    extra_note: Option<String>,
     /// Set by the stage to wind this child down (loser cancellation, §6.6).
     stage_cancel: Arc<AtomicBool>,
 }
@@ -1157,6 +1162,7 @@ async fn run_parallel_stage(
             test_override: test_override.clone(),
             setup_override: setup_override.clone(),
             integrate: par.integrate,
+            extra_note: None,
             stage_cancel: stage_cancel.clone(),
         });
     }
@@ -2314,6 +2320,7 @@ async fn run_orchestrate_stage(
             eff,
             test_override,
             setup_override,
+            None,
             cancel,
         );
         let entry = stage_entry_sha.clone();
@@ -2435,6 +2442,7 @@ async fn run_orchestrate_stage(
                             eff,
                             test_override,
                             setup_override,
+                            None,
                             cancel,
                         );
                         let entry = stage_entry_sha.clone();
@@ -2458,15 +2466,19 @@ async fn run_orchestrate_stage(
                             if let Some(flag) = child_cancels.get(&orig.id) {
                                 flag.store(true, Ordering::SeqCst);
                             }
-                            // Fold the guidance into the fresh attempt via a notice.
-                            {
-                                let conn = ctx.db.lock();
-                                super::comms::queue_child_note(&conn, run_id, &orig.id, &guidance);
-                            }
                             outcomes.remove(&orig.id);
                             let cancel = Arc::new(AtomicBool::new(false));
                             child_cancels.insert(orig.id.clone(), cancel.clone());
                             let step = orig.clone();
+                            // Thread the guidance straight into the replacement
+                            // child's first prompt (not a queued note) so the fresh
+                            // attempt is guaranteed to carry it (spec §10.2).
+                            let note = (!guidance.trim().is_empty()).then(|| {
+                                format!(
+                                    "The orchestrator asked you to try this step again \
+                                     with this guidance:\n\n{guidance}"
+                                )
+                            });
                             let c = build_orch_child_ctx(
                                 ctx,
                                 run_id,
@@ -2482,6 +2494,7 @@ async fn run_orchestrate_stage(
                                 eff,
                                 test_override,
                                 setup_override,
+                                note,
                                 cancel,
                             );
                             let entry = stage_entry_sha.clone();
@@ -2784,6 +2797,7 @@ fn build_orch_child_ctx(
     eff: &EffectiveBudgets,
     test_override: &Option<String>,
     setup_override: &Option<String>,
+    extra_note: Option<String>,
     cancel: Arc<AtomicBool>,
 ) -> ChildCtx {
     ChildCtx {
@@ -2807,6 +2821,7 @@ fn build_orch_child_ctx(
         // Orchestrate children are note-producing in v1 (`integrate: none`), so
         // they never ferry — `drive_orch_child` always takes the none path.
         integrate: Integrate::None,
+        extra_note,
         stage_cancel: cancel,
     }
 }
@@ -2851,6 +2866,9 @@ async fn drive_orch_child(c: ChildCtx, stage_entry_sha: Option<String>) -> OrchC
 
     let mut attempt_no = next_attempt_no(&c.db.lock(), &c.run_id, &c.step.id, 0);
     let mut last_failure: Option<String> = None;
+    // Orchestrator guidance (`retry_child`, §10.2) folded into the first prompt
+    // only, then consumed so later attempts don't repeat it.
+    let mut extra_note = c.extra_note.clone();
 
     loop {
         if c.stage_cancel.load(Ordering::SeqCst) {
@@ -2932,11 +2950,15 @@ async fn drive_orch_child(c: ChildCtx, stage_entry_sha: Option<String>) -> OrchC
                 turns_per_attempt: c.step.budgets.as_ref().and_then(|b| b.turns_per_attempt),
                 comms: &c.step.comms,
             };
-            let base = match &last_failure {
+            let mut base = match &last_failure {
                 Some(f) => prompts::retry_prompt(f, &ctx_prompt),
                 None => prompts::step_prompt(&ctx_prompt),
             };
-            // Fold a delivered answer (to a prior ask) or a notify/guidance (§10.4).
+            // Orchestrator retry guidance leads the first prompt (§10.2).
+            if let Some(note) = extra_note.take() {
+                base = format!("{note}\n\n{base}");
+            }
+            // Fold a delivered answer (to a prior ask) or a notify (§10.4).
             let delivered = {
                 let conn = c.db.lock();
                 super::comms::take_pending_deliveries(&conn, &c.run_id, &c.step.id)
@@ -7142,6 +7164,10 @@ mod tests {
         root: PathBuf,
         blackboard: PathBuf,
         mode: OrchMode,
+        /// When set, a `wf_decide` body the orchestrator "issues" on its first turn
+        /// (persisted as a queued decision the way the router would), plus the DB
+        /// and run id needed to write it. Lets a test script skip/retry decisions.
+        first_decision: Option<(Db, String, serde_json::Value)>,
         tx: broadcast::Sender<StatusEvent>,
         state: parking_lot::Mutex<StubState>,
     }
@@ -7151,6 +7177,24 @@ mod tests {
                 root,
                 blackboard,
                 mode,
+                first_decision: None,
+                tx: broadcast::channel(256).0,
+                state: parking_lot::Mutex::new(StubState::default()),
+            })
+        }
+        fn new_scripted(
+            root: PathBuf,
+            blackboard: PathBuf,
+            mode: OrchMode,
+            db: Db,
+            run_id: &str,
+            decision: serde_json::Value,
+        ) -> Arc<Self> {
+            Arc::new(Self {
+                root,
+                blackboard,
+                mode,
+                first_decision: Some((db, run_id.to_string(), decision)),
                 tx: broadcast::channel(256).0,
                 state: parking_lot::Mutex::new(StubState::default()),
             })
@@ -7161,6 +7205,36 @@ mod tests {
                 agent_id: id.to_string(),
                 status: s,
             });
+        }
+        /// Persist `decision` as a queued `decision` message from the orchestrator
+        /// exec — exactly what `route_decide` does when the orchestrator calls
+        /// `wf_decide` (its exec is resolved by `agent_id`, stamped at spawn).
+        fn inject_decision(&self, orch_agent_id: &str) {
+            let Some((db, run_id, body)) = &self.first_decision else {
+                return;
+            };
+            let conn = db.lock();
+            let exec: Option<String> = conn
+                .query_row(
+                    "SELECT id FROM wf_step_exec WHERE run_id = ?1 AND agent_id = ?2",
+                    rusqlite::params![run_id, orch_agent_id],
+                    |r| r.get(0),
+                )
+                .ok();
+            if let Some(exec) = exec {
+                conn.execute(
+                    "INSERT INTO wf_message (id, run_id, from_step_exec_id, to_step_exec_id,
+                        kind, body_json, status, created_at)
+                     VALUES (?1, ?2, ?3, NULL, 'decision', ?4, 'queued', 0)",
+                    rusqlite::params![
+                        format!("dec-{}", uuid::Uuid::new_v4()),
+                        run_id,
+                        exec,
+                        body.to_string(),
+                    ],
+                )
+                .unwrap();
+            }
         }
     }
     impl AgentDriver for OrchDriver {
@@ -7207,7 +7281,8 @@ mod tests {
             text: String,
         ) -> super::super::driver::BoxFuture<'a, Result<()>> {
             Box::pin(async move {
-                let is_orch = text.contains("Workflow orchestrator")
+                let is_initial = text.contains("Workflow orchestrator");
+                let is_orch = is_initial
                     || text.contains("All children are done")
                     || text.contains("Updates from your children");
                 let is_nudge = text.contains("gone quiet");
@@ -7217,6 +7292,10 @@ mod tests {
                     return Ok(());
                 }
                 if is_orch {
+                    // Issue any scripted decision on the opening turn.
+                    if is_initial {
+                        self.inject_decision(id);
+                    }
                     match self.mode {
                         OrchMode::Stall => return Ok(()), // never goes Idle → stall
                         OrchMode::Conclude => {
@@ -7233,6 +7312,10 @@ mod tests {
                         OrchMode::NeverConclude => {}
                     }
                     self.set(id, AgentStatus::Idle);
+                } else if text.contains("HANGCHILD") {
+                    // A child that never finishes its turn — only a cancel (e.g.
+                    // `skip_child`) can wind it down.
+                    return Ok(());
                 } else {
                     // A child: satisfy its `commit` gate.
                     let wt = self.state.lock().worktrees.get(id).cloned().unwrap();
@@ -7261,9 +7344,14 @@ mod tests {
     }
 
     /// A run whose whole workflow is one orchestrate block (agent `orch`) with a
-    /// single static, commit-gated child `impl`. Returns the db, the workspace
-    /// root, the blackboard dir, and the base SHA.
-    fn scaffold_orchestrate(tmp: &Path, run_id: &str) -> (Db, PathBuf, PathBuf, String) {
+    /// single static, commit-gated child `impl` whose goal is `child_goal` (use
+    /// `HANGCHILD` for a child that never finishes its turn). Returns the db, the
+    /// workspace root, the blackboard dir, and the base SHA.
+    fn scaffold_orchestrate(
+        tmp: &Path,
+        run_id: &str,
+        child_goal: &str,
+    ) -> (Db, PathBuf, PathBuf, String) {
         let source = tmp.join("source");
         std::fs::create_dir_all(&source).unwrap();
         sh(&source, &["init", "-q", "-b", "main"]);
@@ -7300,7 +7388,7 @@ mod tests {
         let child = Step {
             id: "impl".to_string(),
             agent: "coder".to_string(),
-            goal: "implement the slice".to_string(),
+            goal: child_goal.to_string(),
             gate: Gate::Commit,
             budgets: None,
             comms: vec![],
@@ -7378,7 +7466,8 @@ mod tests {
     #[tokio::test]
     async fn orchestrate_concludes_after_children_and_reaches_done() {
         let tmp = tempfile::tempdir().unwrap();
-        let (db, ws, bb, _base) = scaffold_orchestrate(tmp.path(), "run-orch");
+        let (db, ws, bb, _base) =
+            scaffold_orchestrate(tmp.path(), "run-orch", "implement the slice");
         let ctx = orch_ctx(db.clone(), OrchDriver::new(ws, bb, OrchMode::Conclude));
         drive_run(&ctx, "run-orch").await;
 
@@ -7418,7 +7507,7 @@ mod tests {
     #[tokio::test]
     async fn orchestrate_pauses_blocked_when_the_orchestrator_never_concludes() {
         let tmp = tempfile::tempdir().unwrap();
-        let (db, ws, bb, _base) = scaffold_orchestrate(tmp.path(), "run-nc");
+        let (db, ws, bb, _base) = scaffold_orchestrate(tmp.path(), "run-nc", "implement the slice");
         let ctx = orch_ctx(db.clone(), OrchDriver::new(ws, bb, OrchMode::NeverConclude));
         drive_run(&ctx, "run-nc").await;
 
@@ -7448,7 +7537,8 @@ mod tests {
     #[tokio::test]
     async fn orchestrator_stall_escalates_to_the_human() {
         let tmp = tempfile::tempdir().unwrap();
-        let (db, ws, bb, _base) = scaffold_orchestrate(tmp.path(), "run-stall");
+        let (db, ws, bb, _base) =
+            scaffold_orchestrate(tmp.path(), "run-stall", "implement the slice");
         let ctx = orch_ctx(db.clone(), OrchDriver::new(ws, bb, OrchMode::Stall));
         drive_run(&ctx, "run-stall").await;
 
@@ -7474,7 +7564,8 @@ mod tests {
     #[tokio::test]
     async fn resume_does_not_rerun_a_completed_static_child() {
         let tmp = tempfile::tempdir().unwrap();
-        let (db, ws, bb, _base) = scaffold_orchestrate(tmp.path(), "run-resume");
+        let (db, ws, bb, _base) =
+            scaffold_orchestrate(tmp.path(), "run-resume", "implement the slice");
         // Simulate a prior drive that paused before the orchestrator concluded: the
         // static child already finished `done`.
         db.lock()
@@ -7537,6 +7628,38 @@ mod tests {
             existing_dyn_child_count(&conn, "r", "orchestrate-0"),
             2,
             "the next dynamic index skips the two already created"
+        );
+    }
+
+    #[tokio::test]
+    async fn skip_child_cancels_the_child_so_the_stage_can_conclude() {
+        let tmp = tempfile::tempdir().unwrap();
+        // The child hangs its turn — only a cancel ends it. On its opening turn the
+        // orchestrator issues `skip_child`; the engine must cancel that child (not
+        // let it stall out) so the stage concludes on the orchestrator's verdict.
+        let (db, ws, bb, _base) =
+            scaffold_orchestrate(tmp.path(), "run-skip", "implement HANGCHILD");
+        let driver = OrchDriver::new_scripted(
+            ws,
+            bb,
+            OrchMode::Conclude,
+            db.clone(),
+            "run-skip",
+            serde_json::json!({ "decision": "skip_child", "step_id": "impl", "reason": "unneeded" }),
+        );
+        drive_run(&orch_ctx(db.clone(), driver), "run-skip").await;
+
+        assert_eq!(run_status_str(&db, "run-skip"), "done");
+        // The child was cancelled (abandoned), not left to stall out (`error`) or
+        // to complete (`done`).
+        let bad = count(
+            &db,
+            "SELECT COUNT(*) FROM wf_step_exec WHERE run_id='run-skip' AND step_id='impl' \
+             AND status IN ('error','done')",
+        );
+        assert_eq!(
+            bad, 0,
+            "skip_child must cancel the child, not let it stall or finish"
         );
     }
 }

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -2298,6 +2298,10 @@ async fn run_orchestrate_stage(
     // `handle_orch_child` discards any result whose generation is stale, so a
     // cancelled old attempt that still finishes can't win the join (§10.2).
     let mut child_gen: HashMap<String, u64> = HashMap::new();
+    // The `Step` each child (static *or* dynamically spawned) was launched from,
+    // keyed by step id — so `retry_child` can rebuild any child, not just the
+    // static-body ones (spec §10.2).
+    let mut child_specs: HashMap<String, Step> = HashMap::new();
     // Seed the dynamic-child index from the DB so a resumed stage doesn't reuse an
     // id an earlier drive already created (ids stay unique across resume).
     let mut dyn_count = existing_dyn_child_count(&ctx.db.lock(), run_id, &orch_step_id);
@@ -2319,6 +2323,7 @@ async fn run_orchestrate_stage(
         let cancel = Arc::new(AtomicBool::new(false));
         child_cancels.insert(step.id.clone(), cancel.clone());
         child_gen.insert(step.id.clone(), 0);
+        child_specs.insert(step.id.clone(), step.clone());
         let c = build_orch_child_ctx(
             ctx,
             run_id,
@@ -2443,6 +2448,7 @@ async fn run_orchestrate_stage(
                         let cancel = Arc::new(AtomicBool::new(false));
                         child_cancels.insert(step.id.clone(), cancel.clone());
                         child_gen.insert(step.id.clone(), 0);
+                        child_specs.insert(step.id.clone(), step.clone());
                         let c = build_orch_child_ctx(
                             ctx,
                             run_id,
@@ -2476,7 +2482,10 @@ async fn run_orchestrate_stage(
                     outcomes.insert(step_id, ChildStatus::Skipped);
                 }
                 super::comms::Decision::RetryChild { step_id, guidance } => {
-                    if let Some(orig) = orch.body.iter().find(|s| s.id == step_id).cloned() {
+                    // Resolve from the live child registry, so a *dynamic* child
+                    // (`orchestrate-N::dyn-K`, absent from `orch.body`) can be
+                    // retried too, not just static-body children (§10.2).
+                    if let Some(orig) = child_specs.get(&step_id).cloned() {
                         if let Some(agent_spec) = spec.agents.get(&orig.agent).cloned() {
                             // Cancel the previous attempt's task so it can't race the
                             // retry into the join outcome (§10.2).

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -2302,19 +2302,20 @@ async fn run_orchestrate_stage(
     // keyed by step id — so `retry_child` can rebuild any child, not just the
     // static-body ones (spec §10.2).
     let mut child_specs: HashMap<String, Step> = HashMap::new();
+    // The join outcome recorded for each child; restored from prior drives below.
+    let mut outcomes: HashMap<String, ChildStatus> = HashMap::new();
     // Rebuild the dynamic children of any prior drive into the registry from the
     // persisted `spawn_child` decisions (which carry their agent + goal), so a
     // resumed stage can still honor `retry_child` for `orchestrate-N::dyn-K`.
     // Spawn order == index order, matching how ids were assigned originally.
-    for (i, (agent, goal)) in prior_spawn_decisions(&ctx.db.lock(), run_id, &orch_step_id)
-        .into_iter()
-        .enumerate()
-    {
+    // Bind first so the DB guard drops before the loop — the body re-locks it.
+    let prior_dynamic = prior_spawn_decisions(&ctx.db.lock(), run_id, &orch_step_id);
+    for (i, (agent, goal)) in prior_dynamic.into_iter().enumerate() {
         let id = format!("{orch_step_id}::dyn-{i}");
         child_specs.insert(
             id.clone(),
             Step {
-                id,
+                id: id.clone(),
                 agent,
                 goal,
                 gate: Gate::Verdict,
@@ -2322,18 +2323,28 @@ async fn run_orchestrate_stage(
                 comms: orch.comms.clone(),
             },
         );
+        // Restore a prior dynamic child's terminal join outcome so the resumed
+        // stage doesn't decide the join without it (dynamic children aren't
+        // auto-relaunched — the orchestrator re-drives them via retry_child).
+        if let Some(status) = latest_exec_status(&ctx.db.lock(), run_id, &id) {
+            if let Some(restored) = restored_child_status(&status) {
+                outcomes.insert(id, restored);
+            }
+        }
     }
     // Seed the dynamic-child index from the DB so a resumed stage doesn't reuse an
     // id an earlier drive already created (ids stay unique across resume).
     let mut dyn_count = existing_dyn_child_count(&ctx.db.lock(), run_id, &orch_step_id);
-    let mut outcomes: HashMap<String, ChildStatus> = HashMap::new();
 
     for step in &orch.body {
-        // Resume: a static child that already finished is not re-run — its work is
-        // durable (parity with the parallel stage, §12.3).
-        if child_already_done(&ctx.db.lock(), run_id, &step.id) {
-            outcomes.insert(step.id.clone(), ChildStatus::Success);
-            continue;
+        // Resume: a static child that terminally finished in a prior drive keeps
+        // its join outcome and is not re-run (§6.6, §12.3); an in-flight one
+        // (abandoned by the resume) or one that never ran is launched fresh.
+        if let Some(status) = latest_exec_status(&ctx.db.lock(), run_id, &step.id) {
+            if let Some(restored) = restored_child_status(&status) {
+                outcomes.insert(step.id.clone(), restored);
+                continue;
+            }
         }
         let agent_spec = spec.agents.get(&step.agent).ok_or_else(|| {
             Error::Other(format!(
@@ -4542,6 +4553,35 @@ fn done_exec_with_ended_at(
 /// in an earlier, interrupted drive — resume must not re-run it, §12.3 / S8).
 fn child_already_done(conn: &Connection, run_id: &str, step_id: &str) -> bool {
     latest_done_exec_for_step(conn, run_id, step_id).is_some()
+}
+
+/// The status of a step's most recent attempt, if any — the resume signal for an
+/// orchestrate child. Distinguishes a terminally-finished child (whose join
+/// outcome must be restored, not recomputed) from an in-flight one.
+fn latest_exec_status(conn: &Connection, run_id: &str, step_id: &str) -> Option<String> {
+    conn.query_row(
+        "SELECT status FROM wf_step_exec
+         WHERE run_id = ?1 AND step_id = ?2
+         ORDER BY rowid DESC LIMIT 1",
+        rusqlite::params![run_id, step_id],
+        |r| r.get(0),
+    )
+    .optional()
+    .ok()
+    .flatten()
+}
+
+/// Map a child's most-recent exec status to the join outcome to restore on resume
+/// (spec §6.6): a terminally-finished child keeps its result; an in-flight one
+/// (`abandoned` by the resume, or none) returns `None` so the caller re-runs or
+/// leaves it to the orchestrator. Prevents a resumed stage from deciding the join
+/// on incomplete child outcomes.
+fn restored_child_status(exec_status: &str) -> Option<ChildStatus> {
+    match exec_status {
+        "done" => Some(ChildStatus::Success),
+        "error" | "blocked" => Some(ChildStatus::Failure("failed in a previous drive".into())),
+        _ => None,
+    }
 }
 
 /// Recompute the line's fork source at resume: the last **top-level `step`**
@@ -7901,5 +7941,76 @@ mod tests {
             ],
             "spawn decisions rebuild in order, excluding non-spawn decisions"
         );
+    }
+
+    #[test]
+    fn restored_child_status_maps_only_terminal_execs() {
+        assert!(matches!(
+            restored_child_status("done"),
+            Some(ChildStatus::Success)
+        ));
+        assert!(matches!(
+            restored_child_status("error"),
+            Some(ChildStatus::Failure(_))
+        ));
+        assert!(matches!(
+            restored_child_status("blocked"),
+            Some(ChildStatus::Failure(_))
+        ));
+        // In-flight / superseded attempts are not a restorable join outcome.
+        assert!(restored_child_status("abandoned").is_none());
+        assert!(restored_child_status("running").is_none());
+    }
+
+    #[tokio::test]
+    async fn resume_restores_a_failed_dynamic_childs_join_outcome() {
+        // A dynamic child that failed in a prior drive must still count in the
+        // join on resume — otherwise a join:all stage could wrongly conclude
+        // `done` from incomplete outcomes.
+        let tmp = tempfile::tempdir().unwrap();
+        let (db, ws, bb, _base) =
+            scaffold_orchestrate(tmp.path(), "run-djoin", "implement the slice");
+        // Simulate a prior drive: the orchestrator spawned dyn-0, which failed.
+        db.lock()
+            .execute(
+                "INSERT INTO wf_step_exec (id,run_id,step_id,attempt,iteration,status,gate_mode,agent_id)
+                 VALUES ('orch-old','run-djoin','orchestrate-0',1,0,'abandoned','verdict','a-old')",
+                [],
+            )
+            .unwrap();
+        db.lock()
+            .execute(
+                "INSERT INTO wf_message (id,run_id,from_step_exec_id,to_step_exec_id,kind,
+                    body_json,status,created_at)
+                 VALUES ('sp0','run-djoin','orch-old',NULL,'decision',
+                    '{\"decision\":\"spawn_child\",\"agent\":\"coder\",\"goal\":\"slice\"}',
+                    'delivered',1)",
+                [],
+            )
+            .unwrap();
+        db.lock()
+            .execute(
+                "INSERT INTO wf_step_exec (id,run_id,step_id,attempt,iteration,status,gate_mode)
+                 VALUES ('dyn0','run-djoin','orchestrate-0::dyn-0',1,0,'error','verdict')",
+                [],
+            )
+            .unwrap();
+
+        let ctx = orch_ctx(db.clone(), OrchDriver::new(ws, bb, OrchMode::Conclude));
+        drive_run(&ctx, "run-djoin").await;
+
+        let (status, err): (String, Option<String>) = db
+            .lock()
+            .query_row(
+                "SELECT status, error FROM wf_run WHERE id='run-djoin'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            status, "failed",
+            "the restored dynamic-child failure must decide the join:all stage"
+        );
+        assert!(err.unwrap_or_default().contains("orchestrate stage failed"));
     }
 }


### PR DESCRIPTION
Implements **S11 — Orchestrator role + decisions** (TECH_SPEC §10.2 and orchestrate execution in §6.6), on top of the merged S8 (parallel blocks) and S10 (comms router). Base: `feat/workflows-rebase`.

## Scope
- **Orchestrate-stage execution** (`scheduler.rs`): a stage-lived orchestrator agent supervises children under `integrate: none`. Its `wf_step_exec` agent id is stamped at spawn so mid-turn `wf_decide`/`wf_notify` resolve among concurrent siblings. Static `body` children auto-spawn at stage entry; the `children` template authorizes dynamic `spawn_child` only (bounded by `children.max`). The stage completes when the join over all children is met **and** the orchestrator writes its concluding `verdict.json` (the stage gate); `wf_decide {stage_done}` ends it early. A stalled orchestrator escalates to the human (`paused(question)`), never hangs the stage.
- **Decisions & comms** (`comms.rs`): concurrent-attempt sender resolution by agent id; a child's `wf_ask` routes to a live orchestrator instead of the human; `wf_notify` delivers to children; `wf_decide` variants (`answer`, `retry_child`, `skip_child`, `spawn_child`, `stage_done`, `escalate`) with validation, journaling, and structured denials (over-max `spawn_child` → `child_spawn_denied`); engine lifecycle events auto-forwarded to the orchestrator.
- **Prompts** (`prompts.rs`): orchestrator opening prompt + concluding-verdict prompt.
- **Attempt** (`attempt.rs`): `pre_spawned` agent adoption + a reusable `drive_prompt_turn` for the orchestrator's multi-turn loop.

No frontend changes: the Run Monitor (F2) already renders the `decision` / `child_spawn_*` / `subrun_*` journal events, and all event types pre-existed in `types.rs`.

## Tests
MockDriver / temp-DB coverage (spec §16): orchestrator answers a child's ask; over-max `spawn_child` returns a structured error and journals `child_spawn_denied`; the stage does not complete before the orchestrator's concluding verdict; orchestrator stall → human escalation; the comms decide/notify/caps matrix. `cargo test --lib` → 769 passed, 0 failed; clippy clean; rustfmt applied.

## Deferred until S9 merges (S9 is not yet in the base)
- `orchestrate` with `integrate: merge` — gated with a clear error, mirroring parallel-merge.
- Conflict decision routing (mode b).

**Known v1 limitation:** orchestrate-stage resume re-drives the stage (dynamic children don't survive a pause); not required by the S11 acceptance set, and re-running note-producing children under `integrate: none` is harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)