### PR TITLE
fix(composer): expand textarea to restored draft height on mount

### DIFF
--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -235,6 +235,15 @@ export function Composer({
     if (autoFocus) ta.current?.focus();
   }, [autoFocus]);
 
+  // On mount (including the remount a view switch causes) the restored draft
+  // text is in place but the textarea still renders at its single-row height,
+  // since `grow` only runs on edits. Resize once so a multi-line draft is
+  // expanded to fit its content (up to the max height).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: run once on mount
+  useEffect(() => {
+    if (ta.current) grow(ta.current);
+  }, []);
+
   // Mirror the draft into the store on every edit so it survives the remount
   // that view switches cause. Sending clears `text`, which clears the entry.
   useEffect(() => {


### PR DESCRIPTION
## Problem

When you write a long draft in the composer (new-agent screen or an existing conversation), switch to another workspace, then come back, the content is persisted but the composer collapses to 1–2 lines instead of showing the full draft.

## Root cause

Switching workspaces remounts the Composer (its subtree is keyed by agent/draft id). On remount the draft text is correctly restored via the `useState` initializer, but the textarea height is never recomputed — `grow()` only ran on `onChange`, seed injection, and caret placement, never on mount. So a multi-line draft rendered at its single-row `min-height` until the user typed again.

## Fix

Added a run-once mount effect in `src/components/Composer/index.tsx` that calls the existing `grow()` helper on the textarea, expanding it to fit the restored content up to the 240px max. Reuses the existing clamp, so max-lines behavior is preserved.

## Testing

Dependencies aren't installed in this worktree, so `biome`/`tsc` couldn't be run here. Manual check: type a long draft, switch workspaces and back — the composer should render expanded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)