### PR TITLE
feat(workflows): dynamic composition — wf_compose (S12)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ dist/
 .vite/
 .tmp/
 
+# Local bun install cache/tmp (sandbox workaround; never committed)
+.bun-cache/
+.bun-tmp/
+
 # Rust / Tauri
 src-tauri/target/
 src-tauri/gen/

--- a/src-tauri/src/workflow/budget.rs
+++ b/src-tauri/src/workflow/budget.rs
@@ -235,6 +235,17 @@ pub struct Ledger {
     #[serde(default)]
     pub attempts: HashMap<String, i64>,
 
+    /// Turns/tokens reserved by live composed sub-runs (spec §10.3): the parent
+    /// carves a budget slice out for each sub-run, so that capacity is unavailable
+    /// to the parent's own work while the sub-run runs. `exceeded` counts reserved
+    /// against the caps; when a sub-run finishes, the parent releases its
+    /// reservation and folds the sub-run's *actual* spend in — never both, so a
+    /// slice is never double-counted.
+    #[serde(default)]
+    pub reserved_turns: i64,
+    #[serde(default)]
+    pub reserved_tokens: i64,
+
     /// Transient (never serialized): the current drive's start, set by
     /// [`Self::start_drive`]. `wall_ms` already holds prior drives' time.
     #[serde(skip)]
@@ -311,12 +322,14 @@ impl Ledger {
     /// The first run-level cap this ledger has reached, if any (§11.2). Checked at
     /// each enforcement point; `Some` pauses the run. `>=` because a cap of N
     /// permits N units of spend — reaching N means the next unit would exceed.
+    /// Reserved sub-run capacity (§10.3) counts against the caps: the parent must
+    /// not spend budget it has already promised to a live sub-run.
     pub fn exceeded(&self, eff: &EffectiveBudgets, now_ms: i64) -> Option<BudgetLimit> {
-        if self.turns >= eff.turns {
+        if self.turns + self.reserved_turns >= eff.turns {
             return Some(BudgetLimit::Turns);
         }
         if let Some(cap) = eff.tokens {
-            if self.tokens >= cap {
+            if self.tokens + self.reserved_tokens >= cap {
                 return Some(BudgetLimit::Tokens);
             }
         }
@@ -324,6 +337,38 @@ impl Ledger {
             return Some(BudgetLimit::WallClock);
         }
         None
+    }
+
+    /// Turns still spendable under `eff` after committed spend and live reservations
+    /// (spec §10.3 budget-fit check). Never negative.
+    pub fn remaining_turns(&self, eff: &EffectiveBudgets) -> i64 {
+        (eff.turns - self.turns - self.reserved_turns).max(0)
+    }
+
+    /// Tokens still spendable, or `None` when the run has no token cap (so a token
+    /// reservation is unbounded and never rejected on token grounds).
+    pub fn remaining_tokens(&self, eff: &EffectiveBudgets) -> Option<i64> {
+        eff.tokens
+            .map(|cap| (cap - self.tokens - self.reserved_tokens).max(0))
+    }
+
+    /// Reserve a sub-run's budget slice out of the parent ledger (§10.3). The slice
+    /// is held until the sub-run finishes and [`Self::release_reservation`] returns
+    /// it. Caller has already checked it fits via [`Self::remaining_turns`] /
+    /// [`Self::remaining_tokens`].
+    pub fn reserve(&mut self, turns: i64, tokens: i64) {
+        self.reserved_turns += turns;
+        self.reserved_tokens += tokens;
+    }
+
+    /// Release a finished sub-run's reservation (§10.3), floored at zero so a
+    /// double release or a mismatched slice can never drive the reservation
+    /// negative. Pair with [`fold_child_ledger`](super::scheduler) which adds the
+    /// sub-run's *actual* spend — the two together replace a reservation with real
+    /// consumption.
+    pub fn release_reservation(&mut self, turns: i64, tokens: i64) {
+        self.reserved_turns = (self.reserved_turns - turns).max(0);
+        self.reserved_tokens = (self.reserved_tokens - tokens).max(0);
     }
 }
 
@@ -541,6 +586,72 @@ mod tests {
     }
 
     #[test]
+    fn reservation_counts_against_caps_and_remaining() {
+        let eff = EffectiveBudgets {
+            turns: 100,
+            tokens: Some(1_000_000),
+            wall_clock_mins: 480,
+            ..Default::default()
+        };
+        let mut l = Ledger::default();
+        l.charge_turn("orch", "e1"); // 1 turn spent
+        l.reserve(30, 500_000); // sub-run slice reserved
+        assert_eq!(l.remaining_turns(&eff), 69, "100 - 1 spent - 30 reserved");
+        // charge_turn spends no tokens, so only the reservation is deducted.
+        assert_eq!(l.remaining_tokens(&eff), Some(500_000));
+        // The reservation bites even though the parent itself has spent almost
+        // nothing: it must not hand out capacity it already promised.
+        let tight = EffectiveBudgets {
+            turns: 31,
+            ..eff.clone()
+        };
+        assert_eq!(
+            l.exceeded(&tight, 0),
+            Some(BudgetLimit::Turns),
+            "1 spent + 30 reserved >= 31"
+        );
+    }
+
+    #[test]
+    fn release_then_fold_replaces_reservation_with_actual_spend() {
+        let mut parent = Ledger::default();
+        parent.reserve(30, 500_000);
+        assert_eq!(parent.reserved_turns, 30);
+        // Sub-run actually spent 12 turns; release the slice and fold real spend.
+        let mut sub = Ledger::default();
+        for i in 0..12 {
+            sub.charge_turn("s", &format!("e{i}"));
+        }
+        parent.release_reservation(30, 500_000);
+        parent.turns += sub.turns; // mirrors fold_child_ledger
+        assert_eq!(parent.reserved_turns, 0, "reservation released");
+        assert_eq!(
+            parent.turns, 12,
+            "only actual spend counts, never the slice"
+        );
+        assert_eq!(parent.reserved_tokens, 0);
+    }
+
+    #[test]
+    fn release_is_floored_at_zero() {
+        let mut l = Ledger::default();
+        l.reserve(5, 0);
+        l.release_reservation(10, 100); // over-release
+        assert_eq!(l.reserved_turns, 0);
+        assert_eq!(l.reserved_tokens, 0);
+    }
+
+    #[test]
+    fn remaining_tokens_none_when_uncapped() {
+        let eff = EffectiveBudgets {
+            tokens: None,
+            ..Default::default()
+        };
+        let l = Ledger::default();
+        assert_eq!(l.remaining_tokens(&eff), None);
+    }
+
+    #[test]
     fn ledger_json_round_trips_persisted_fields() {
         let mut l = Ledger::default();
         l.charge_turn("s", "e1");
@@ -553,11 +664,16 @@ mod tests {
             }),
         );
         l.wall_ms = 1234;
+        l.reserve(7, 900);
         let restored = Ledger::from_json(&l.to_json());
         assert_eq!(restored.turns, 1);
         assert_eq!(restored.tokens, 10);
         assert_eq!(restored.wall_ms, 1234);
         assert_eq!(restored.steps["s"].turns, 1);
+        // Live reservations survive a pause/resume so the resumed parent still
+        // accounts for a sub-run in flight.
+        assert_eq!(restored.reserved_turns, 7);
+        assert_eq!(restored.reserved_tokens, 900);
         // Transient fields do not survive serialization.
         assert!(restored.agent_tokens_seen.is_empty());
     }

--- a/src-tauri/src/workflow/comms.rs
+++ b/src-tauri/src/workflow/comms.rs
@@ -34,9 +34,12 @@ use crate::error::{Error, Result};
 use crate::rpc::git::GitDispatcher;
 use crate::rpc::{Response, RpcDispatcher, RpcEvent, RpcFuture};
 
+use std::collections::BTreeMap;
+
+use super::budget::{EffectiveBudgets, Ledger};
 use super::now_ms;
 use super::scheduler::{self, WorkflowService};
-use super::spec::{Block, CommsCap, Orchestrate, Spec};
+use super::spec::{self, AgentSpec, Block, Budgets, CommsCap, Integrate, Orchestrate, Spec};
 use super::types::{event_type, Message, MessageKind};
 
 // ───────────────────────────── caps matrix (pure) ───────────────────────────
@@ -60,9 +63,10 @@ pub(super) fn cap_for_op(op: &str) -> Option<CommsCap> {
 }
 
 /// Is `op` one this router owns? (Everything else falls through to git.) Includes
-/// the orchestrator-only `wf_decide` (spec §10.2), which has no cap.
+/// the orchestrator-only `wf_decide` (spec §10.2) and `wf_compose` (spec §10.3),
+/// which are gated by role, not a cap.
 pub(super) fn is_comms_op(op: &str) -> bool {
-    cap_for_op(op).is_some() || op == "wf_decide"
+    cap_for_op(op).is_some() || op == "wf_decide" || op == "wf_compose"
 }
 
 /// Human-readable verb for a rejection message.
@@ -413,6 +417,17 @@ fn route(
         return route_decide(conn, app, &sender, id, args);
     }
 
+    // `wf_compose` is likewise orchestrator-only (spec §10.3) and additionally
+    // requires the stage to have `compose` enabled — checked in `route_compose`.
+    if op == "wf_compose" {
+        if !sender_is_orchestrator(&sender) {
+            let e = "wf_compose is available to the orchestrator only".to_string();
+            journal_denied(conn, app, &sender, op, &e);
+            return (Response::err(id, e), Poke::None);
+        }
+        return route_compose(conn, app, &sender, id, args);
+    }
+
     if let Err(e) = check_cap(op, &sender.caps) {
         // Journaled, never a silent drop (§10.1): the timeline shows the denied
         // attempt.
@@ -626,7 +641,10 @@ fn live_children(conn: &Connection, run_id: &str, step_id: Option<&str>) -> Vec<
 /// §10.2). `answer` and `escalate` are completed in the router (a pure DB write /
 /// a human pause), so they are not represented here; these are the ones that need
 /// the driver + child JoinSet the orchestrate stage owns.
-#[derive(Debug, Clone, PartialEq, Eq)]
+// `Eq` is intentionally omitted: `Compose` carries a `Vec<Block>` fragment, and
+// `Block` is only `PartialEq` (specs aren't totally comparable). `PartialEq` is
+// all the tests need.
+#[derive(Debug, Clone, PartialEq)]
 pub(super) enum Decision {
     /// Start another dynamic child (already validated ≤ `children.max`).
     SpawnChild { agent: String, goal: String },
@@ -636,6 +654,42 @@ pub(super) enum Decision {
     RetryChild { step_id: String, guidance: String },
     /// End the stage now (early join, spec §6.6).
     StageDone,
+    /// Launch a validated composed sub-run (spec §10.3). The plan is fully
+    /// validated (fragment, depth, caps, budget-fit) in [`route_compose`]; the
+    /// scheduler only creates and drives it.
+    Compose(Box<ComposePlan>),
+}
+
+/// Which commit a composed sub-run forks from (spec §10.3).
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(super) enum ComposeBase {
+    /// The orchestrate stage's entry HEAD (the parent's current line).
+    ParentHead,
+    /// The run's original base commit.
+    RunBase,
+}
+
+/// A validated `wf_compose` request (spec §10.3), normalized into the fields the
+/// scheduler needs to create and drive the sub-run. Serialized into the queued
+/// `decision` message so a resume rebuilds it exactly.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub(super) struct ComposePlan {
+    pub task: String,
+    pub fragment: Vec<Block>,
+    /// Sub-run agent map; `None` inherits the parent's agents (spec §10.3).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agents: Option<BTreeMap<String, AgentSpec>>,
+    /// Reserved run-level turn slice (required, §10.3).
+    pub turns: i64,
+    /// Reserved run-level token slice, if the parent run has a token cap.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tokens: Option<i64>,
+    pub integrate: Integrate,
+    pub base: ComposeBase,
+    /// The orchestrate stage this sub-run belongs to (its top-level block index),
+    /// so it integrates at that stage's join.
+    pub block_index: usize,
 }
 
 /// Handle a `wf_decide` op (spec §10.2). Validates the decision, journals it, and
@@ -880,6 +934,450 @@ fn route_spawn_child(
     (Response::ok(id, 0, msg_id, String::new()), Poke::None)
 }
 
+/// Validate + record a `wf_compose` request (spec §10.3). Runs the fragment
+/// through the full [`spec::validate`], enforces the depth cap, the caps-escalation
+/// rules (§15), `max_sub_runs`, and the budget-fit check, then queues a
+/// [`Decision::Compose`] the orchestrate stage executes. Every rejection is a
+/// structured error plus a `compose_denied` journal entry — the deterministic
+/// engine is the authority, never the orchestrator.
+fn route_compose(
+    conn: &Connection,
+    app: Option<&AppHandle>,
+    sender: &Sender,
+    id: &str,
+    args: &Value,
+) -> (Response, Poke) {
+    let deny = |conn: &Connection, msg: String| -> (Response, Poke) {
+        journal_compose_denied(conn, app, sender, &msg);
+        (Response::err(id, msg), Poke::None)
+    };
+
+    // The stage must be an orchestrate block with `compose` enabled.
+    let Some(spec) = load_spec(conn, &sender.run_id) else {
+        return (Response::err(id, "run spec unavailable"), Poke::None);
+    };
+    let Some(orch) = orchestrate_block(&spec, &sender.step_id) else {
+        return deny(
+            conn,
+            "wf_compose is only valid within an orchestrate stage".into(),
+        );
+    };
+    let Some(limits) = orch.compose.clone() else {
+        return deny(
+            conn,
+            "dynamic composition is not enabled for this stage".into(),
+        );
+    };
+    let allowed_caps = orch.comms.clone();
+
+    // ── Parse the request (spec §10.3). ──
+    let task = args
+        .get("task")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    if task.is_empty() {
+        return deny(conn, "wf_compose requires a non-empty `task`".into());
+    }
+    let Some(frag_val) = args.get("fragment") else {
+        return deny(conn, "wf_compose requires a `fragment` block list".into());
+    };
+    let fragment: Vec<Block> = match serde_json::from_value(frag_val.clone()) {
+        Ok(f) => f,
+        Err(e) => {
+            return deny(
+                conn,
+                format!("wf_compose `fragment` is not a valid block list: {e}"),
+            )
+        }
+    };
+    let agents: Option<BTreeMap<String, AgentSpec>> = match args.get("agents") {
+        Some(v) if !v.is_null() => match serde_json::from_value(v.clone()) {
+            Ok(a) => Some(a),
+            Err(e) => {
+                return deny(
+                    conn,
+                    format!("wf_compose `agents` is not a valid agent map: {e}"),
+                )
+            }
+        },
+        _ => None,
+    };
+    let Some(budgets) = args.get("budgets") else {
+        return deny(
+            conn,
+            "wf_compose requires `budgets` with a `turns` slice (§10.3)".into(),
+        );
+    };
+    let turns = budgets.get("turns").and_then(|v| v.as_i64()).unwrap_or(0);
+    if turns <= 0 {
+        return deny(
+            conn,
+            "wf_compose `budgets.turns` must be a positive number".into(),
+        );
+    }
+    let req_tokens = budgets
+        .get("tokens")
+        .and_then(|v| v.as_i64())
+        .filter(|t| *t > 0);
+    let integrate = match args
+        .get("integrate")
+        .and_then(|v| v.as_str())
+        .unwrap_or("none")
+    {
+        "none" => Integrate::None,
+        "merge" => Integrate::Merge,
+        other => {
+            return deny(
+                conn,
+                format!("wf_compose `integrate` must be \"none\" or \"merge\", got \"{other}\""),
+            )
+        }
+    };
+    let base =
+        match args
+            .get("base")
+            .and_then(|v| v.as_str())
+            .unwrap_or("parent-head")
+        {
+            "parent-head" => ComposeBase::ParentHead,
+            "run-base" => ComposeBase::RunBase,
+            other => return deny(
+                conn,
+                format!(
+                    "wf_compose `base` must be \"parent-head\" or \"run-base\", got \"{other}\""
+                ),
+            ),
+        };
+
+    // ── Validate the fragment with the full spec.rs rules (§5.2), by wrapping it
+    //    in a synthetic Spec that also carries the reserved budget slice. ──
+    let eff_agents = agents.clone().unwrap_or_else(|| spec.agents.clone());
+    let sub_spec = Spec {
+        version: spec.version,
+        name: format!("{} — composed", spec.name),
+        description: None,
+        budgets: Some(Budgets {
+            turns: Some(turns),
+            tokens: req_tokens,
+            ..Budgets::default()
+        }),
+        agents: eff_agents,
+        workflow: fragment.clone(),
+        finalize: None,
+    };
+    if let Err(errs) = spec::validate(&sub_spec) {
+        return deny(
+            conn,
+            format!("wf_compose fragment is invalid: {}", errs.join("; ")),
+        );
+    }
+
+    // ── Depth (spec §10.3): parent depth + 1 ≤ max_depth, absolute cap 2. ──
+    let new_depth = run_depth(conn, &sender.run_id) + 1;
+    let max_depth = (limits.max_depth as i64).min(2);
+    if new_depth > max_depth {
+        return deny(
+            conn,
+            format!(
+                "wf_compose denied: composition depth {new_depth} exceeds the limit of {max_depth}"
+            ),
+        );
+    }
+
+    // ── Caps escalation (spec §15): the fragment can't grant caps broader than
+    //    this stage's children caps, and can't enable compose at max depth. ──
+    if let Some(msg) = caps_escalation(&fragment, &allowed_caps, new_depth >= max_depth) {
+        return deny(conn, msg);
+    }
+
+    // ── max_sub_runs: already-launched sub-runs + queued compose requests. ──
+    let launched = subrun_count(conn, &sender.run_id);
+    let queued = pending_compose_count(conn, &sender.run_id, &sender.step_id);
+    if launched + queued >= limits.max_sub_runs as i64 {
+        return deny(
+            conn,
+            format!(
+                "wf_compose denied: already at the max_sub_runs of {} for this stage",
+                limits.max_sub_runs
+            ),
+        );
+    }
+
+    // ── Budget-fit (spec §10.3): the slice must fit the parent's remaining budget,
+    //    net of slices already reserved by queued (not-yet-launched) composes. ──
+    let (eff, ledger) = load_budget(conn, &sender.run_id);
+    let (pending_turns, pending_tokens) =
+        pending_compose_reservations(conn, &sender.run_id, &sender.step_id);
+    let avail_turns = ledger.remaining_turns(&eff) - pending_turns;
+    if turns > avail_turns {
+        return deny(
+            conn,
+            format!(
+                "wf_compose denied: requested {turns} turns but only {} remain in the run budget",
+                avail_turns.max(0)
+            ),
+        );
+    }
+    if let (Some(cap_left), Some(req)) = (ledger.remaining_tokens(&eff), req_tokens) {
+        let avail = cap_left - pending_tokens;
+        if req > avail {
+            return deny(
+                conn,
+                format!(
+                    "wf_compose denied: requested {req} tokens but only {} remain in the run budget",
+                    avail.max(0)
+                ),
+            );
+        }
+    }
+
+    // ── Approved: journal the request and queue the plan for the stage loop. ──
+    let block_index = orch_index(&sender.step_id).unwrap_or(0);
+    let plan = ComposePlan {
+        task,
+        fragment,
+        agents,
+        turns,
+        tokens: req_tokens,
+        integrate,
+        base,
+        block_index,
+    };
+    scheduler::journal_event(
+        conn,
+        app,
+        &sender.run_id,
+        event_type::COMPOSE_REQUESTED,
+        Some(&sender.step_exec_id),
+        &json!({
+            "turns": turns,
+            "tokens": req_tokens,
+            "integrate": if matches!(integrate, Integrate::Merge) { "merge" } else { "none" },
+            "depth": new_depth,
+        }),
+    );
+    let msg_id = new_msg_id();
+    let body = json!({ "decision": "compose", "plan": plan });
+    if let Err(e) = insert_message(
+        conn,
+        &msg_id,
+        &sender.run_id,
+        Some(&sender.step_exec_id),
+        None,
+        "decision",
+        &body,
+        "queued",
+        false,
+    ) {
+        return (Response::err(id, e.to_string()), Poke::None);
+    }
+    (Response::ok(id, 0, msg_id, String::new()), Poke::None)
+}
+
+/// The composition depth of a run: 0 for a top-level run, +1 per `parent_run_id`
+/// hop (spec §10.3). Bounded by the absolute depth cap, so the walk is short.
+fn run_depth(conn: &Connection, run_id: &str) -> i64 {
+    let mut depth = 0i64;
+    let mut cur = run_id.to_string();
+    // The absolute cap is 2, so a valid chain is ≤ 3 rows; the guard bounds a
+    // corrupt self-referential chain regardless.
+    for _ in 0..8 {
+        let parent: Option<String> = conn
+            .query_row(
+                "SELECT parent_run_id FROM wf_run WHERE id = ?1",
+                [&cur],
+                |r| r.get(0),
+            )
+            .optional()
+            .ok()
+            .flatten();
+        match parent {
+            Some(p) => {
+                depth += 1;
+                cur = p;
+            }
+            None => break,
+        }
+    }
+    depth
+}
+
+/// Sub-runs already created under `parent_run_id` (any status): they count toward
+/// `max_sub_runs` for the life of the run, like `children.max` bounds spawns.
+fn subrun_count(conn: &Connection, parent_run_id: &str) -> i64 {
+    conn.query_row(
+        "SELECT COUNT(*) FROM wf_run WHERE parent_run_id = ?1",
+        [parent_run_id],
+        |r| r.get(0),
+    )
+    .unwrap_or(0)
+}
+
+/// Queued (not-yet-launched) `compose` decisions for this orchestrate stage —
+/// counted like [`spawn_child_count`] so a burst within one turn stays within
+/// `max_sub_runs` before the stage loop has drained any of them.
+fn pending_compose_count(conn: &Connection, run_id: &str, orch_step_id: &str) -> i64 {
+    conn.query_row(
+        "SELECT COUNT(*) FROM wf_message m
+           JOIN wf_step_exec e ON m.from_step_exec_id = e.id
+         WHERE m.run_id = ?1 AND e.step_id = ?2 AND m.kind = 'decision' AND m.status = 'queued'
+           AND json_extract(m.body_json, '$.decision') = 'compose'",
+        params![run_id, orch_step_id],
+        |r| r.get(0),
+    )
+    .unwrap_or(0)
+}
+
+/// The turn/token slices of queued (not-yet-launched) composes for this stage, so
+/// the budget-fit check accounts for reservations the stage loop hasn't applied to
+/// the ledger yet (§10.3). Launched sub-runs' reservations are already in the
+/// ledger's `reserved_*`, so they are not re-counted here.
+fn pending_compose_reservations(conn: &Connection, run_id: &str, orch_step_id: &str) -> (i64, i64) {
+    conn.prepare(
+        "SELECT m.body_json FROM wf_message m
+           JOIN wf_step_exec e ON m.from_step_exec_id = e.id
+         WHERE m.run_id = ?1 AND e.step_id = ?2 AND m.kind = 'decision' AND m.status = 'queued'
+           AND json_extract(m.body_json, '$.decision') = 'compose'",
+    )
+    .and_then(|mut s| {
+        s.query_map(params![run_id, orch_step_id], |r| r.get::<_, String>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()
+    })
+    .map(|bodies| {
+        bodies.into_iter().fold((0i64, 0i64), |(t, k), b| {
+            let plan = serde_json::from_str::<Value>(&b)
+                .ok()
+                .and_then(|v| v.get("plan").cloned());
+            let turns = plan
+                .as_ref()
+                .and_then(|p| p.get("turns"))
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0);
+            let tokens = plan
+                .as_ref()
+                .and_then(|p| p.get("tokens"))
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0);
+            (t + turns, k + tokens)
+        })
+    })
+    .unwrap_or((0, 0))
+}
+
+/// The parent run's frozen budgets and current ledger, for the compose fit-check.
+fn load_budget(conn: &Connection, run_id: &str) -> (EffectiveBudgets, Ledger) {
+    let (budgets_json, spent_json): (String, String) = conn
+        .query_row(
+            "SELECT budgets_json, spent_json FROM wf_run WHERE id = ?1",
+            [run_id],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap_or_else(|_| ("{}".into(), "{}".into()));
+    let eff: EffectiveBudgets = serde_json::from_str(&budgets_json).unwrap_or_default();
+    let spent: Value = serde_json::from_str(&spent_json).unwrap_or_else(|_| json!({}));
+    (eff, Ledger::from_json(&spent))
+}
+
+/// Reject a fragment that would broaden comms caps beyond the parent block's
+/// children caps, or enable `compose` at the maximum depth (spec §15). Returns the
+/// first violation message, or `None` if the fragment is within bounds.
+fn caps_escalation(fragment: &[Block], allowed: &[CommsCap], at_max_depth: bool) -> Option<String> {
+    fn broader(caps: &[CommsCap], allowed: &[CommsCap]) -> Option<CommsCap> {
+        caps.iter().find(|c| !allowed.contains(c)).copied()
+    }
+    fn cap_name(c: CommsCap) -> &'static str {
+        match c {
+            CommsCap::Report => "report",
+            CommsCap::Ask => "ask",
+            CommsCap::Notify => "notify",
+        }
+    }
+    for block in fragment {
+        match block {
+            Block::Step(s) => {
+                if let Some(c) = broader(&s.comms, allowed) {
+                    return Some(format!(
+                        "wf_compose denied: fragment step '{}' declares comms cap '{}' \
+                         broader than the stage grants",
+                        s.id,
+                        cap_name(c)
+                    ));
+                }
+            }
+            Block::Parallel(p) => {
+                for s in &p.steps {
+                    if let Some(c) = broader(&s.comms, allowed) {
+                        return Some(format!(
+                            "wf_compose denied: fragment step '{}' declares comms cap '{}' \
+                             broader than the stage grants",
+                            s.id,
+                            cap_name(c)
+                        ));
+                    }
+                }
+            }
+            Block::Loop(l) => {
+                if let Some(m) = caps_escalation(&l.body, allowed, at_max_depth) {
+                    return Some(m);
+                }
+            }
+            Block::Orchestrate(o) => {
+                if let Some(c) = broader(&o.comms, allowed) {
+                    return Some(format!(
+                        "wf_compose denied: fragment orchestrate '{}' grants children comms \
+                         cap '{}' broader than the stage grants",
+                        o.agent,
+                        cap_name(c)
+                    ));
+                }
+                if at_max_depth && o.compose.is_some() {
+                    return Some(format!(
+                        "wf_compose denied: fragment orchestrate '{}' enables composition at \
+                         the maximum depth",
+                        o.agent
+                    ));
+                }
+                for s in &o.body {
+                    if let Some(c) = broader(&s.comms, allowed) {
+                        return Some(format!(
+                            "wf_compose denied: fragment step '{}' declares comms cap '{}' \
+                             broader than the stage grants",
+                            s.id,
+                            cap_name(c)
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// The top-level block index an orchestrator `step_id` (`orchestrate-<idx>`) refers
+/// to.
+fn orch_index(orch_step_id: &str) -> Option<usize> {
+    orch_step_id.strip_prefix(ORCH_PREFIX)?.parse().ok()
+}
+
+/// Journal a `wf_compose` rejection (spec §10.3): never a silent drop.
+fn journal_compose_denied(
+    conn: &Connection,
+    app: Option<&AppHandle>,
+    sender: &Sender,
+    reason: &str,
+) {
+    scheduler::journal_event(
+        conn,
+        app,
+        &sender.run_id,
+        event_type::COMPOSE_DENIED,
+        Some(&sender.step_exec_id),
+        &json!({ "reason": reason }),
+    );
+}
+
 /// How many `spawn_child` decisions this orchestrate *stage* has already had
 /// approved. Counted across every orchestrator exec that shares the stage's
 /// `step_id` (`orchestrate-<n>`), so a resume — which starts a fresh orchestrator
@@ -952,6 +1450,15 @@ pub(super) fn take_orchestrator_decisions(
                 guidance: s("guidance"),
             }),
             "stage_done" => out.push(Decision::StageDone),
+            "compose" => {
+                if let Some(plan) = body
+                    .get("plan")
+                    .cloned()
+                    .and_then(|p| serde_json::from_value::<ComposePlan>(p).ok())
+                {
+                    out.push(Decision::Compose(Box::new(plan)));
+                }
+            }
             _ => {}
         }
     }
@@ -1082,6 +1589,43 @@ pub(super) fn forward_lifecycle(
         event_type::MESSAGE_ROUTED,
         Some(child_exec),
         &json!({ "message_id": msg_id, "kind": "report", "from": child_exec, "to": orch_exec, "lifecycle": true }),
+    );
+}
+
+/// Auto-forward a composed sub-run's terminal outcome to the orchestrator (spec
+/// §10.3: "the orchestrator receives subrun_launched / subrun_finished messages").
+/// Delivered as a lifecycle report the orchestrator reads on its next turn.
+/// Attributed to the orchestrator's own exec so it resolves through the inbox
+/// join (a sub-run has no step exec in the parent run); the note names the
+/// sub-run.
+pub(super) fn forward_subrun_finished(
+    conn: &Connection,
+    app: Option<&AppHandle>,
+    run_id: &str,
+    orch_exec: &str,
+    sub_run_id: &str,
+    status: &str,
+) {
+    let msg_id = new_msg_id();
+    let note = format!("sub-run `{sub_run_id}` finished ({status})");
+    let _ = insert_message(
+        conn,
+        &msg_id,
+        run_id,
+        Some(orch_exec),
+        Some(orch_exec),
+        "report",
+        &json!({ "status": status, "note": note, "lifecycle": true, "sub_run_id": sub_run_id }),
+        "queued",
+        false,
+    );
+    scheduler::journal_event(
+        conn,
+        app,
+        run_id,
+        event_type::MESSAGE_ROUTED,
+        Some(orch_exec),
+        &json!({ "message_id": msg_id, "kind": "report", "from": orch_exec, "to": orch_exec, "lifecycle": true, "sub_run_id": sub_run_id }),
     );
 }
 
@@ -1462,7 +2006,7 @@ pub async fn wf_answer(
 mod tests {
     use super::*;
     use crate::workflow::spec::{
-        AgentSpec, ChildTemplate, Gate, Integrate, Join, Orchestrate, Step,
+        AgentSpec, ChildTemplate, ComposeLimits, Gate, Integrate, Join, Orchestrate, Step,
     };
     use crate::workflow::types::{MessageKind, MessageStatus};
     use std::collections::BTreeMap;
@@ -2275,5 +2819,309 @@ mod tests {
         );
         assert!(!resp.ok, "spawn limit must persist across resume: {resp:?}");
         assert!(resp.error.unwrap().contains("children.max"));
+    }
+
+    // ── dynamic composition, wf_compose (spec §10.3) ──────────────────────
+
+    /// A running orchestrate stage with `compose` enabled. `comms` are the stage's
+    /// children caps; `turns` seeds the run budget; `parent` sets `parent_run_id`
+    /// (drives the depth check). Returns (conn, orch_exec).
+    fn seed_compose(
+        limits: Option<ComposeLimits>,
+        comms: Vec<CommsCap>,
+        turns: i64,
+        parent: Option<&str>,
+    ) -> (Connection, String) {
+        let td = tempfile::tempdir().unwrap();
+        let db = crate::database::init(td.path()).unwrap();
+        std::mem::forget(td);
+        let conn = Arc::try_unwrap(db).ok().unwrap().into_inner();
+
+        let mut agents = BTreeMap::new();
+        for a in ["orch", "coder"] {
+            agents.insert(
+                a.to_string(),
+                AgentSpec {
+                    base: "claude".into(),
+                    model: None,
+                    instructions: None,
+                    skills: vec![],
+                    custom_agent: None,
+                },
+            );
+        }
+        let spec = Spec {
+            version: 1,
+            name: "demo".into(),
+            description: None,
+            budgets: None,
+            agents,
+            workflow: vec![Block::Orchestrate(Orchestrate {
+                agent: "orch".into(),
+                goal: "lead".into(),
+                children: Some(ChildTemplate {
+                    agent: "coder".into(),
+                    max: 2,
+                }),
+                body: vec![],
+                join: Join::All,
+                integrate: Integrate::Merge,
+                comms,
+                compose: limits,
+            })],
+            finalize: None,
+        };
+        let spec_json = serde_json::to_string(&spec).unwrap();
+        let budgets_json = serde_json::to_string(&crate::workflow::budget::EffectiveBudgets {
+            turns,
+            ..Default::default()
+        })
+        .unwrap();
+        // Satisfy the parent_run_id FK when the run is itself a sub-run.
+        if let Some(p) = parent {
+            conn.execute(
+                "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,branch,
+                    base_sha,status,budgets_json,spent_json,created_at,updated_at)
+                 VALUES (?1,'p','{}','t','p','/repo','/rd','wf/p','sha','running','{}','{}',0,0)",
+                [p],
+            )
+            .unwrap();
+        }
+        conn.execute(
+            "INSERT INTO wf_run (id,parent_run_id,name,spec_json,task,project_id,repo_path,run_dir,
+                branch,base_sha,status,budgets_json,spent_json,created_at,updated_at)
+             VALUES ('run',?1,'demo',?2,'t','p','/repo','/rd','wf/x','sha','running',?3,'{}',0,0)",
+            rusqlite::params![parent, spec_json, budgets_json],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO wf_step_exec (id,run_id,step_id,attempt,iteration,status,gate_mode,agent_id)
+             VALUES ('orch-exec','run','orchestrate-0',1,0,'running','verdict','orch-agent')",
+            [],
+        )
+        .unwrap();
+        (conn, "orch-exec".to_string())
+    }
+
+    /// A minimal one-step fragment whose step declares `caps` and uses `agent`.
+    fn fragment(caps: Vec<&str>, agent: &str) -> Value {
+        json!([{ "step": { "id": "impl", "agent": agent, "goal": "do it", "comms": caps } }])
+    }
+
+    fn compose_args(fragment: Value, turns: i64) -> Value {
+        json!({
+            "task": "a composed slice",
+            "fragment": fragment,
+            "budgets": { "turns": turns },
+            "integrate": "merge",
+            "base": "parent-head",
+        })
+    }
+
+    fn compose(conn: &Connection, agent_id: &str, args: &Value) -> Response {
+        route(conn, None, "c1", "run", agent_id, "wf_compose", args).0
+    }
+
+    #[test]
+    fn wf_compose_is_orchestrator_only() {
+        let (conn, _orch) = seed_compose(
+            Some(ComposeLimits {
+                max_sub_runs: 2,
+                max_depth: 2,
+            }),
+            vec![CommsCap::Report],
+            100,
+            None,
+        );
+        // Add a non-orchestrator child exec and send as it. (Its step id must not
+        // start with the orchestrate prefix, which marks the orchestrator role.)
+        conn.execute(
+            "INSERT INTO wf_step_exec (id,run_id,step_id,attempt,iteration,status,gate_mode,agent_id)
+             VALUES ('child-exec','run','child-1',1,0,'running','verdict','child-agent')",
+            [],
+        )
+        .unwrap();
+        let resp = compose(
+            &conn,
+            "child-agent",
+            &compose_args(fragment(vec![], "coder"), 10),
+        );
+        assert!(!resp.ok);
+        assert!(resp.error.unwrap().contains("orchestrator only"));
+    }
+
+    #[test]
+    fn wf_compose_denied_when_composition_disabled() {
+        let (conn, _orch) = seed_compose(None, vec![CommsCap::Report], 100, None);
+        let resp = compose(
+            &conn,
+            "orch-agent",
+            &compose_args(fragment(vec![], "coder"), 10),
+        );
+        assert!(!resp.ok);
+        assert!(resp.error.unwrap().contains("not enabled"));
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM wf_event WHERE type='compose_denied'"
+            ),
+            1,
+            "a rejection is always journaled"
+        );
+    }
+
+    #[test]
+    fn wf_compose_valid_request_queues_a_decision() {
+        let (conn, _orch) = seed_compose(
+            Some(ComposeLimits {
+                max_sub_runs: 2,
+                max_depth: 2,
+            }),
+            vec![CommsCap::Report, CommsCap::Ask],
+            100,
+            None,
+        );
+        let resp = compose(
+            &conn,
+            "orch-agent",
+            &compose_args(fragment(vec!["report"], "coder"), 30),
+        );
+        assert!(resp.ok, "valid compose should be accepted: {resp:?}");
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM wf_message WHERE kind='decision'
+                   AND json_extract(body_json,'$.decision')='compose' AND status='queued'"
+            ),
+            1
+        );
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM wf_event WHERE type='compose_requested'"
+            ),
+            1
+        );
+        // The scheduler decodes it into a typed Compose decision.
+        let decisions = take_orchestrator_decisions(&conn, "run", "orch-exec");
+        assert_eq!(decisions.len(), 1);
+        assert!(matches!(decisions[0], Decision::Compose(_)));
+    }
+
+    #[test]
+    fn wf_compose_rejects_over_budget() {
+        // Run turn cap is 20; a 50-turn slice can't fit.
+        let (conn, _orch) = seed_compose(
+            Some(ComposeLimits {
+                max_sub_runs: 2,
+                max_depth: 2,
+            }),
+            vec![CommsCap::Report],
+            20,
+            None,
+        );
+        let resp = compose(
+            &conn,
+            "orch-agent",
+            &compose_args(fragment(vec![], "coder"), 50),
+        );
+        assert!(!resp.ok);
+        assert!(resp.error.unwrap().contains("remain in the run budget"));
+    }
+
+    #[test]
+    fn wf_compose_rejects_over_depth() {
+        // The run is itself a sub-run (parent set → depth 1); with max_depth 1 a
+        // further sub-run would be depth 2.
+        let (conn, _orch) = seed_compose(
+            Some(ComposeLimits {
+                max_sub_runs: 2,
+                max_depth: 1,
+            }),
+            vec![CommsCap::Report],
+            100,
+            Some("parent-run"),
+        );
+        let resp = compose(
+            &conn,
+            "orch-agent",
+            &compose_args(fragment(vec![], "coder"), 10),
+        );
+        assert!(!resp.ok);
+        assert!(resp.error.unwrap().contains("depth"));
+    }
+
+    #[test]
+    fn wf_compose_rejects_caps_escalation() {
+        // Stage grants children only `report`; a fragment step wanting `ask` is a
+        // privilege escalation (spec §15).
+        let (conn, _orch) = seed_compose(
+            Some(ComposeLimits {
+                max_sub_runs: 2,
+                max_depth: 2,
+            }),
+            vec![CommsCap::Report],
+            100,
+            None,
+        );
+        let resp = compose(
+            &conn,
+            "orch-agent",
+            &compose_args(fragment(vec!["ask"], "coder"), 10),
+        );
+        assert!(!resp.ok);
+        assert!(resp
+            .error
+            .unwrap()
+            .contains("broader than the stage grants"));
+    }
+
+    #[test]
+    fn wf_compose_rejects_invalid_fragment() {
+        let (conn, _orch) = seed_compose(
+            Some(ComposeLimits {
+                max_sub_runs: 2,
+                max_depth: 2,
+            }),
+            vec![CommsCap::Report],
+            100,
+            None,
+        );
+        // References an agent that isn't in the (inherited) agent map.
+        let resp = compose(
+            &conn,
+            "orch-agent",
+            &compose_args(fragment(vec![], "nonexistent"), 10),
+        );
+        assert!(!resp.ok);
+        assert!(resp.error.unwrap().contains("fragment is invalid"));
+    }
+
+    #[test]
+    fn wf_compose_rejects_over_max_sub_runs() {
+        let (conn, _orch) = seed_compose(
+            Some(ComposeLimits {
+                max_sub_runs: 1,
+                max_depth: 2,
+            }),
+            vec![CommsCap::Report],
+            100,
+            None,
+        );
+        // One sub-run already exists for this parent.
+        conn.execute(
+            "INSERT INTO wf_run (id,parent_run_id,name,spec_json,task,project_id,repo_path,run_dir,
+                branch,base_sha,status,budgets_json,spent_json,created_at,updated_at)
+             VALUES ('sub-1','run','s','{}','t','p','/repo','/rd','wf/s','sha','running','{}','{}',0,0)",
+            [],
+        )
+        .unwrap();
+        let resp = compose(
+            &conn,
+            "orch-agent",
+            &compose_args(fragment(vec![], "coder"), 10),
+        );
+        assert!(!resp.ok);
+        assert!(resp.error.unwrap().contains("max_sub_runs"));
     }
 }

--- a/src-tauri/src/workflow/comms.rs
+++ b/src-tauri/src/workflow/comms.rs
@@ -1035,21 +1035,22 @@ fn route_compose(
             )
         }
     };
-    let base =
-        match args
-            .get("base")
-            .and_then(|v| v.as_str())
-            .unwrap_or("parent-head")
-        {
-            "parent-head" => ComposeBase::ParentHead,
-            "run-base" => ComposeBase::RunBase,
-            other => return deny(
+    let base = match args
+        .get("base")
+        .and_then(|v| v.as_str())
+        .unwrap_or("parent-head")
+    {
+        "parent-head" => ComposeBase::ParentHead,
+        "run-base" => ComposeBase::RunBase,
+        other => {
+            return deny(
                 conn,
                 format!(
                     "wf_compose `base` must be \"parent-head\" or \"run-base\", got \"{other}\""
                 ),
-            ),
-        };
+            )
+        }
+    };
 
     // ── Validate the fragment with the full spec.rs rules (§5.2), by wrapping it
     //    in a synthetic Spec that also carries the reserved budget slice. ──

--- a/src-tauri/src/workflow/gitops.rs
+++ b/src-tauri/src/workflow/gitops.rs
@@ -159,6 +159,35 @@ pub async fn ferry(step_checkout: &Path, run_repo: &Path, refname: &str) -> Resu
     Ok(())
 }
 
+/// The ref a composed sub-run's final commit is pinned as in the *parent's* run
+/// repo after ferrying (spec §10.3). Distinct per sub-run so concurrent sub-runs
+/// integrating into the same parent never collide.
+pub fn subrun_ref(sub_run_id: &str) -> String {
+    format!("refs/wf/subruns/{sub_run_id}")
+}
+
+/// Ferry a ref from one run repo into another under a *different* destination name
+/// (spec §10.3 integrate-at-join): the sub-run's final ref lives in its own run
+/// repo; the parent fetches it as [`subrun_ref`] so it can be merged like any
+/// child ref. Both repos are `--shared` clones of the same source, so only the
+/// sub-run's new objects transfer — explicit refs, no `allowAnySHA1InWant`.
+pub async fn ferry_ref_as(
+    from_repo: &Path,
+    into_repo: &Path,
+    src_ref: &str,
+    dest_ref: &str,
+) -> Result<()> {
+    let from = path_str(from_repo)?;
+    let refspec = format!("{src_ref}:{dest_ref}");
+    git::run_git(
+        into_repo,
+        &["fetch", &from, &refspec],
+        "ferry sub-run ref into parent run repo",
+    )
+    .await?;
+    Ok(())
+}
+
 /// The result of finalizing a run.
 pub struct FinalizeOutcome {
     pub pushed: bool,

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -161,8 +161,20 @@ impl WorkflowService {
     }
 
     /// Cancel a run: flag it, stop the live attempt's agent, and (if no driver
-    /// is live) mark it canceled directly.
+    /// is live) mark it canceled directly. Cancelling a parent cascades to its
+    /// composed sub-runs (spec §6.1, §10.3) — depth-first so the whole tree winds
+    /// down.
     pub async fn cancel(&self, run_id: &str) -> Result<()> {
+        // Cascade to sub-runs first, so a child can't outlive a parent that has
+        // already been marked canceled.
+        let children = {
+            let conn = self.db.lock();
+            child_run_ids(&conn, run_id)
+        };
+        for child in children {
+            Box::pin(self.cancel(&child)).await?;
+        }
+
         let handle = self.runs.lock().get(run_id).map(|h| h.cancel.clone());
         match handle {
             Some(cancel) => cancel.store(true, Ordering::SeqCst),
@@ -374,6 +386,7 @@ fn spawn_drive_task(
         cancel,
         pending_ask,
         deadlines: Deadlines::default(),
+        runs: Some(runs.clone()),
     };
     let id = run_id.clone();
     let join = tauri::async_runtime::spawn(async move {
@@ -422,6 +435,11 @@ struct RunCtx {
     /// comms router can raise it; threaded into each attempt.
     pending_ask: Arc<AtomicBool>,
     deadlines: Deadlines,
+    /// The active-run registry (spec §6.1, §10.3), so an orchestrate stage can
+    /// launch a composed sub-run's own driver task and register it for the
+    /// cancel-cascade. `None` under test — sub-runs are driven detached and the
+    /// stage tracks them by polling `wf_run.status`.
+    runs: Option<Arc<Mutex<HashMap<String, RunHandle>>>>,
 }
 
 /// The `wf_run` columns the walker reads.
@@ -660,12 +678,14 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
                     &mut ledger,
                     &test_override,
                     &setup_override,
+                    &mut cursor,
                 )
                 .await?
                 {
-                    // Orchestrate is `integrate: none` in v1 — the stage HEAD is its
-                    // entry HEAD (§12.3), so `line` is always `None` and the fork
-                    // source is unchanged. Handled uniformly with the parallel arm.
+                    // With no composed `integrate: merge` sub-run the stage HEAD is
+                    // its entry HEAD (§12.3) and `line` is `None`; a merged sub-run
+                    // advances the line onto the integrated result (§10.3), handled
+                    // uniformly with the parallel arm.
                     StageFlow::Advance { line } => {
                         if let Some((head_ref, exec_id)) = line {
                             last_ref = head_ref;
@@ -2178,7 +2198,36 @@ async fn run_orchestrate_stage(
     ledger: &mut Ledger,
     test_override: &Option<String>,
     setup_override: &Option<String>,
+    cursor: &mut Cursor,
 ) -> Result<StageFlow> {
+    // Resume: a sub-run integration paused mid-merge or on a conflict (§10.3,
+    // §12.3). The sub-runs already ran and ferried; continue merging / apply the
+    // recorded resolution rather than re-driving the orchestrator.
+    if cursor
+        .merge
+        .as_ref()
+        .is_some_and(|m| m.block_index == block_index)
+    {
+        return resume_subrun_merge(
+            ctx,
+            run_id,
+            run,
+            spec,
+            orch,
+            block_index,
+            block_count,
+            blackboard,
+            repo,
+            run_repo,
+            eff,
+            ledger,
+            test_override,
+            setup_override,
+            cursor,
+        )
+        .await;
+    }
+
     // Enforcement point: before spawning the stage (§11.2).
     if let Some(which) = ledger.exceeded(eff, super::now_ms()) {
         {
@@ -2336,6 +2385,18 @@ async fn run_orchestrate_stage(
     // id an earlier drive already created (ids stay unique across resume).
     let mut dyn_count = existing_dyn_child_count(&ctx.db.lock(), run_id, &orch_step_id);
 
+    // Composed sub-runs of this stage (spec §10.3), keyed by sub-run id. Rebuilt
+    // from the DB on resume so a restarted stage keeps tracking sub-runs launched
+    // by a prior drive (and re-drives any left `pending`/`running`).
+    let mut sub_runs: HashMap<String, SubRunState> =
+        rebuild_sub_runs(&ctx.db.lock(), run_id, block_index);
+    for (sub_id, st) in &sub_runs {
+        if st.terminal.is_none() {
+            // A live sub-run abandoned by the restart: re-drive its own task.
+            spawn_subrun(ctx, sub_id.clone());
+        }
+    }
+
     for step in &orch.body {
         // Resume: a static child that terminally finished in a prior drive keeps
         // its join outcome and is not re-run (§6.6, §12.3); an in-flight one
@@ -2446,6 +2507,7 @@ async fn run_orchestrate_stage(
     loop {
         if ctx.cancel.load(Ordering::SeqCst) {
             drain_children(&child_cancels, &mut set).await;
+            cancel_sub_runs(ctx, &sub_runs).await;
             cancel_run(ctx, run_id).await;
             return Ok(StageFlow::Stop);
         }
@@ -2454,6 +2516,7 @@ async fn run_orchestrate_stage(
         // `question` (§10.2, §10.4). The backstop mirrors the linear path.
         if super::comms::has_unanswered_ask(&ctx.db.lock(), &orch_exec) {
             drain_children(&child_cancels, &mut set).await;
+            cancel_sub_runs(ctx, &sub_runs).await;
             pause_question(ctx, run_id, &orch_exec, Some(&orch_agent_id)).await;
             return Ok(StageFlow::Stop);
         }
@@ -2466,6 +2529,58 @@ async fn run_orchestrate_stage(
         for d in decisions {
             match d {
                 super::comms::Decision::StageDone => concluded_early = true,
+                super::comms::Decision::Compose(plan) => {
+                    // Launch the validated sub-run's own driver (spec §10.3),
+                    // reserve its budget slice out of the parent ledger, and track
+                    // it for the join. A provisioning failure is journaled and the
+                    // slice is not reserved — the stage keeps running.
+                    match launch_subrun(ctx, run, run_id, run_repo, fork_base, &plan).await {
+                        Ok(sub_id) => {
+                            ledger.reserve(plan.turns, plan.tokens.unwrap_or(0));
+                            {
+                                let conn = ctx.db.lock();
+                                persist_spent(&conn, run_id, ledger);
+                                journal_event(
+                                    &conn,
+                                    ctx.app.as_ref(),
+                                    run_id,
+                                    event_type::SUBRUN_LAUNCHED,
+                                    Some(&orch_exec),
+                                    // The extra fields let a resumed stage rebuild
+                                    // its sub-run tracking without a side table.
+                                    &json!({
+                                        "sub_run_id": sub_id,
+                                        "block_index": block_index,
+                                        "integrate": if matches!(plan.integrate, Integrate::Merge) { "merge" } else { "none" },
+                                        "reserved_turns": plan.turns,
+                                        "reserved_tokens": plan.tokens.unwrap_or(0),
+                                    }),
+                                );
+                            }
+                            sub_runs.insert(
+                                sub_id.clone(),
+                                SubRunState {
+                                    integrate: plan.integrate,
+                                    reserved_turns: plan.turns,
+                                    reserved_tokens: plan.tokens.unwrap_or(0),
+                                    terminal: None,
+                                },
+                            );
+                            spawn_subrun(ctx, sub_id);
+                        }
+                        Err(e) => {
+                            let conn = ctx.db.lock();
+                            journal_event(
+                                &conn,
+                                ctx.app.as_ref(),
+                                run_id,
+                                event_type::COMPOSE_DENIED,
+                                Some(&orch_exec),
+                                &json!({ "reason": format!("sub-run launch failed: {e}") }),
+                            );
+                        }
+                    }
+                }
                 super::comms::Decision::SpawnChild { agent, goal } => {
                     if let Some(agent_spec) = spec.agents.get(&agent).cloned() {
                         let step = Step {
@@ -2586,6 +2701,18 @@ async fn run_orchestrate_stage(
             );
         }
 
+        // Reap finished sub-runs (spec §10.3): reconcile each one's reserved slice
+        // against its actual spend, forward its outcome to the orchestrator, and
+        // record its join status alongside the children's.
+        reap_sub_runs(
+            ctx,
+            run_id,
+            &orch_exec,
+            ledger,
+            &mut sub_runs,
+            &mut outcomes,
+        );
+
         // join `all`: the first child failure fails the stage.
         if matches!(orch.join, Join::All) {
             if let Some(reason) = outcomes.values().find_map(|s| match s {
@@ -2593,6 +2720,7 @@ async fn run_orchestrate_stage(
                 _ => None,
             }) {
                 drain_children(&child_cancels, &mut set).await;
+                cancel_sub_runs(ctx, &sub_runs).await;
                 let _ = ctx.driver.stop(&orch_agent_id).await;
                 let conn = ctx.db.lock();
                 finish_step_exec(&conn, &orch_exec, "error", None);
@@ -2609,7 +2737,9 @@ async fn run_orchestrate_stage(
             }
         }
 
-        if set.is_empty() {
+        // The join is met only when every child *and* every composed sub-run
+        // (spec §6.6, §10.3) is terminal.
+        if set.is_empty() && sub_runs.values().all(|s| s.terminal.is_some()) {
             // Every child is terminal. join `any` with no success and ≥1 failure
             // fails the stage; otherwise the orchestrator concludes.
             if matches!(orch.join, Join::Any)
@@ -2704,10 +2834,26 @@ async fn run_orchestrate_stage(
             }
             if done {
                 let _ = ctx.driver.archive(&orch_agent_id).await;
-                let conn = ctx.db.lock();
-                finish_step_exec(&conn, &orch_exec, "done", None);
-                persist_spent(&conn, run_id, ledger);
-                return Ok(StageFlow::Advance { line: None });
+                {
+                    let conn = ctx.db.lock();
+                    finish_step_exec(&conn, &orch_exec, "done", None);
+                    persist_spent(&conn, run_id, ledger);
+                }
+                // Integrate composed sub-runs at the join (spec §10.3): merge each
+                // `integrate: merge` sub-run's ferried ref into the stage line. No
+                // merge sub-runs → the stage HEAD is its entry HEAD (`line: None`).
+                return begin_subrun_merge(
+                    ctx,
+                    run_id,
+                    run,
+                    spec,
+                    block_index,
+                    run_repo,
+                    fork_base,
+                    &sub_runs,
+                    cursor,
+                )
+                .await;
             }
             if conclude_tries < MAX_CONCLUDE_TRIES {
                 conclude_tries += 1;
@@ -2808,6 +2954,7 @@ async fn run_orchestrate_stage(
         // deadline"): a wedged stage pauses `budget_exceeded` rather than hanging.
         if let Some(which) = ledger.exceeded(eff, super::now_ms()) {
             drain_children(&child_cancels, &mut set).await;
+            cancel_sub_runs(ctx, &sub_runs).await;
             let _ = ctx.driver.stop(&orch_agent_id).await;
             {
                 let conn = ctx.db.lock();
@@ -2824,23 +2971,639 @@ async fn run_orchestrate_stage(
             finish_budget_pause(ctx, run_id, Some(&orch_exec), ledger);
             return Ok(StageFlow::Stop);
         }
-        tokio::select! {
-            joined = set.join_next() => {
-                if let Some(j) = joined {
-                    handle_orch_child(ctx, run_id, &orch_exec, orch.join, ledger, j, &mut outcomes, &child_cancels, &child_gen);
+        // Wait for the next event. With children still live, race a child join
+        // against a poll tick; with only sub-runs left (an empty `JoinSet` yields
+        // `None` immediately, which would busy-spin), just poll their status.
+        if set.is_empty() {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        } else {
+            tokio::select! {
+                joined = set.join_next() => {
+                    if let Some(j) = joined {
+                        handle_orch_child(ctx, run_id, &orch_exec, orch.join, ledger, j, &mut outcomes, &child_cancels, &child_gen);
+                    }
                 }
+                _ = tokio::time::sleep(std::time::Duration::from_millis(200)) => {}
             }
-            _ = tokio::time::sleep(std::time::Duration::from_millis(200)) => {}
         }
     }
 
-    // `stage_done`: wind the remaining children down and mark the stage done.
+    // `stage_done`: wind the remaining children and sub-runs down and mark the
+    // stage done. Composed sub-runs are canceled (not integrated) on an early
+    // `stage_done` — the orchestrator chose to end without waiting for them.
     drain_children(&child_cancels, &mut set).await;
+    cancel_sub_runs(ctx, &sub_runs).await;
     let _ = ctx.driver.archive(&orch_agent_id).await;
     let conn = ctx.db.lock();
     finish_step_exec(&conn, &orch_exec, "done", None);
     persist_spent(&conn, run_id, ledger);
     Ok(StageFlow::Advance { line: None })
+}
+
+// ───────────────────────── composed sub-runs (§10.3) ────────────────────────
+
+/// A composed sub-run tracked by its parent orchestrate stage.
+struct SubRunState {
+    integrate: Integrate,
+    /// The reserved budget slice, released and reconciled when the sub-run ends.
+    reserved_turns: i64,
+    reserved_tokens: i64,
+    /// `None` while the sub-run is live; its join outcome once terminal.
+    terminal: Option<ChildStatus>,
+}
+
+/// Create and provision a composed sub-run (spec §10.3): a synthetic spec from the
+/// validated fragment, the fork base resolved from the parent, its own run dir +
+/// run repo, and a `wf_run` row with `parent_run_id`. Returns the new sub-run id;
+/// the caller reserves the budget slice, spawns the driver, and tracks it.
+async fn launch_subrun(
+    ctx: &RunCtx,
+    parent: &RunEssentials,
+    parent_run_id: &str,
+    parent_run_repo: &Path,
+    fork_base: &str,
+    plan: &super::comms::ComposePlan,
+) -> Result<String> {
+    let sub_run_id = format!("run-{}", uuid::Uuid::new_v4());
+    let parent_spec: Spec =
+        serde_json::from_str(&parent.spec_json).map_err(|e| Error::Other(e.to_string()))?;
+    let agents = plan
+        .agents
+        .clone()
+        .unwrap_or_else(|| parent_spec.agents.clone());
+    let sub_spec = Spec {
+        version: parent_spec.version,
+        name: format!("{} — sub-run", parent_spec.name),
+        description: None,
+        budgets: Some(Budgets {
+            turns: Some(plan.turns),
+            tokens: plan.tokens,
+            ..Default::default()
+        }),
+        agents,
+        workflow: plan.fragment.clone(),
+        // A sub-run integrates at the parent's join; it never pushes/PRs itself.
+        finalize: None,
+    };
+    let spec_json = serde_json::to_string(&sub_spec).map_err(|e| Error::Other(e.to_string()))?;
+    let budgets_json = serde_json::to_string(&EffectiveBudgets::resolve(&sub_spec))
+        .map_err(|e| Error::Other(e.to_string()))?;
+
+    let run_dir = blackboard::run_dir(&sub_run_id)?;
+    let task_md = format!("# {}\n\n{}\n", sub_spec.name, plan.task);
+    blackboard::provision(&run_dir, &task_md)?;
+    let repo = PathBuf::from(&parent.repo_path);
+    let sub_run_repo = gitops::provision_run_repo(&repo, &run_dir).await?;
+
+    // Resolve the fork base (§10.3). `run-base` is the parent's original base (a
+    // source commit, already in the sub-run's clone). `parent-head` is the stage's
+    // current line — a workflow commit that lives only in the parent run repo, so
+    // ferry its ref in before the sub-run's step 1 provisions from it.
+    let base_sha = match plan.base {
+        super::comms::ComposeBase::RunBase => parent.base_sha.clone(),
+        super::comms::ComposeBase::ParentHead => fork_base.to_string(),
+    };
+    if base_sha.starts_with("refs/") {
+        gitops::ferry_ref_as(parent_run_repo, &sub_run_repo, &base_sha, &base_sha).await?;
+    }
+
+    let branch = format!(
+        "wf/{}-{}",
+        slugify(&sub_spec.name),
+        &sub_run_id[sub_run_id.len() - 8..]
+    );
+    let now = super::now_ms();
+    {
+        let conn = ctx.db.lock();
+        conn.execute(
+            "INSERT INTO wf_run (id, definition_id, parent_run_id, name, spec_json, task,
+                 project_id, repo_path, run_dir, branch, base_sha, status, budgets_json,
+                 spent_json, created_at, updated_at)
+             VALUES (?1, NULL, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 'pending', ?11, '{}', ?12, ?12)",
+            rusqlite::params![
+                sub_run_id,
+                parent_run_id,
+                sub_spec.name,
+                spec_json,
+                plan.task,
+                parent.project_id,
+                parent.repo_path,
+                run_dir.to_string_lossy(),
+                branch,
+                base_sha,
+                budgets_json,
+                now,
+            ],
+        )
+        .map_err(|e| Error::Other(e.to_string()))?;
+    }
+    Ok(sub_run_id)
+}
+
+/// Spawn (or, on resume, re-spawn) a composed sub-run's own driver task (spec
+/// §6.1, §10.3). In production the sub-run is registered in the run registry so
+/// the cancel-cascade reaches it and at most one driver runs; under test (`runs`
+/// = `None`) it is driven detached and the stage tracks it by polling
+/// `wf_run.status`.
+fn spawn_subrun(ctx: &RunCtx, sub_run_id: String) {
+    let cancel = Arc::new(AtomicBool::new(false));
+    let pending_ask = Arc::new(AtomicBool::new(false));
+    if let Some(runs) = &ctx.runs {
+        let mut m = runs.lock();
+        if m.contains_key(&sub_run_id) {
+            return;
+        }
+        m.insert(
+            sub_run_id.clone(),
+            RunHandle {
+                cancel: cancel.clone(),
+                respawn: Arc::new(AtomicBool::new(false)),
+                pending_ask: pending_ask.clone(),
+            },
+        );
+    }
+    let child = RunCtx {
+        db: ctx.db.clone(),
+        driver: ctx.driver.clone(),
+        app: ctx.app.clone(),
+        cancel,
+        pending_ask,
+        deadlines: ctx.deadlines.clone(),
+        runs: ctx.runs.clone(),
+    };
+    let runs = ctx.runs.clone();
+    let id = sub_run_id.clone();
+    tokio::spawn(async move {
+        drive_run(&child, &id).await;
+        // Drop the registry entry on exit so the cancel-cascade and any list see
+        // the sub-run's driver as gone.
+        if let Some(runs) = &runs {
+            runs.lock().remove(&id);
+        }
+    });
+}
+
+/// The join status of a sub-run from its `wf_run.status`, or `None` while it is
+/// still `pending`/`running`/`paused`.
+fn subrun_terminal_status(conn: &Connection, sub_run_id: &str) -> Option<ChildStatus> {
+    let status: Option<String> = conn
+        .query_row(
+            "SELECT status FROM wf_run WHERE id = ?1",
+            [sub_run_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .ok()
+        .flatten();
+    match status.as_deref() {
+        Some("done") => Some(ChildStatus::Success),
+        Some("failed") => Some(ChildStatus::Failure("sub-run failed".into())),
+        Some("canceled") => Some(ChildStatus::Skipped),
+        _ => None,
+    }
+}
+
+/// Rebuild an orchestrate stage's sub-run tracking from the journal on resume
+/// (spec §10.3): each `subrun_launched` event for this stage carries the sub-run
+/// id, integrate mode, and reserved slice. A sub-run already terminal in the DB is
+/// marked so (not reaped or reconciled again); a live one is left `None` for the
+/// stage to re-drive and await.
+fn rebuild_sub_runs(
+    conn: &Connection,
+    run_id: &str,
+    block_index: usize,
+) -> HashMap<String, SubRunState> {
+    let mut out = HashMap::new();
+    let rows: Vec<String> = conn
+        .prepare(
+            "SELECT payload_json FROM wf_event
+             WHERE run_id = ?1 AND type = ?2
+               AND json_extract(payload_json, '$.block_index') = ?3
+             ORDER BY seq",
+        )
+        .and_then(|mut s| {
+            s.query_map(
+                rusqlite::params![run_id, event_type::SUBRUN_LAUNCHED, block_index as i64],
+                |r| r.get::<_, String>(0),
+            )?
+            .collect::<rusqlite::Result<Vec<_>>>()
+        })
+        .unwrap_or_default();
+    for body in rows {
+        let Ok(v) = serde_json::from_str::<Value>(&body) else {
+            continue;
+        };
+        let Some(sub_id) = v.get("sub_run_id").and_then(|x| x.as_str()) else {
+            continue;
+        };
+        let integrate = if v.get("integrate").and_then(|x| x.as_str()) == Some("merge") {
+            Integrate::Merge
+        } else {
+            Integrate::None
+        };
+        out.insert(
+            sub_id.to_string(),
+            SubRunState {
+                integrate,
+                reserved_turns: v
+                    .get("reserved_turns")
+                    .and_then(|x| x.as_i64())
+                    .unwrap_or(0),
+                reserved_tokens: v
+                    .get("reserved_tokens")
+                    .and_then(|x| x.as_i64())
+                    .unwrap_or(0),
+                terminal: subrun_terminal_status(conn, sub_id),
+            },
+        );
+    }
+    out
+}
+
+/// The sub-run's persisted ledger (its actual spend), for reconciliation.
+fn subrun_ledger(conn: &Connection, sub_run_id: &str) -> Option<Ledger> {
+    let spent: String = conn
+        .query_row(
+            "SELECT spent_json FROM wf_run WHERE id = ?1",
+            [sub_run_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .ok()
+        .flatten()?;
+    let val: Value = serde_json::from_str(&spent).unwrap_or_else(|_| json!({}));
+    Some(Ledger::from_json(&val))
+}
+
+/// Reconcile any sub-runs that reached a terminal state since the last poll (spec
+/// §10.3): release each one's reserved slice, fold its actual spend into the
+/// parent ledger (so a slice is replaced by real consumption, never both),
+/// journal `subrun_finished`, forward the outcome to the orchestrator, and record
+/// its join status alongside the children's.
+fn reap_sub_runs(
+    ctx: &RunCtx,
+    run_id: &str,
+    orch_exec: &str,
+    ledger: &mut Ledger,
+    sub_runs: &mut HashMap<String, SubRunState>,
+    outcomes: &mut HashMap<String, ChildStatus>,
+) {
+    let conn = ctx.db.lock();
+    for (sub_id, st) in sub_runs.iter_mut() {
+        if st.terminal.is_some() {
+            continue;
+        }
+        let Some(status) = subrun_terminal_status(&conn, sub_id) else {
+            continue;
+        };
+        ledger.release_reservation(st.reserved_turns, st.reserved_tokens);
+        if let Some(sub_ledger) = subrun_ledger(&conn, sub_id) {
+            fold_child_ledger(ledger, &sub_ledger);
+        }
+        persist_spent(&conn, run_id, ledger);
+        let status_str = match &status {
+            ChildStatus::Success => "done",
+            ChildStatus::Failure(_) => "failed",
+            ChildStatus::Skipped => "canceled",
+        };
+        journal_event(
+            &conn,
+            ctx.app.as_ref(),
+            run_id,
+            event_type::SUBRUN_FINISHED,
+            Some(orch_exec),
+            &json!({ "sub_run_id": sub_id, "status": status_str }),
+        );
+        super::comms::forward_subrun_finished(
+            &conn,
+            ctx.app.as_ref(),
+            run_id,
+            orch_exec,
+            sub_id,
+            status_str,
+        );
+        outcomes.insert(sub_id.clone(), status.clone());
+        st.terminal = Some(status);
+    }
+}
+
+/// Cancel every live composed sub-run of a stage (spec §10.3): flag a registered
+/// driver so it winds itself down, else (under test) stop its agents and mark it
+/// canceled directly.
+async fn cancel_sub_runs(ctx: &RunCtx, sub_runs: &HashMap<String, SubRunState>) {
+    for (sub_id, st) in sub_runs {
+        if st.terminal.is_none() {
+            cancel_run_by_id(ctx, sub_id).await;
+        }
+    }
+}
+
+/// Cancel one sub-run by id: prefer flagging its live driver (which stops its
+/// agents and marks it canceled), else mark it directly.
+async fn cancel_run_by_id(ctx: &RunCtx, run_id: &str) {
+    if let Some(runs) = &ctx.runs {
+        if let Some(flag) = runs.lock().get(run_id).map(|h| h.cancel.clone()) {
+            flag.store(true, Ordering::SeqCst);
+            return;
+        }
+    }
+    let agents = live_step_agents(&ctx.db.lock(), run_id);
+    for a in agents {
+        let _ = ctx.driver.stop(&a).await;
+    }
+    let conn = ctx.db.lock();
+    set_status(&conn, ctx.app.as_ref(), run_id, "canceled", None, None);
+}
+
+/// The sub-run's final line `(ref, exec_id)` — the commit its integration merges.
+/// `None` when the sub-run produced no commit (nothing to integrate).
+fn subrun_final_line(ctx: &RunCtx, sub_run_id: &str) -> Option<(String, String)> {
+    let conn = ctx.db.lock();
+    let (spec_json, base_sha): (String, String) = conn
+        .query_row(
+            "SELECT spec_json, base_sha FROM wf_run WHERE id = ?1",
+            [sub_run_id],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .optional()
+        .ok()
+        .flatten()?;
+    let spec: Spec = serde_json::from_str(&spec_json).ok()?;
+    let (line_ref, exec) = resume_line_state(
+        &conn,
+        sub_run_id,
+        &spec.workflow,
+        spec.workflow.len(),
+        &base_sha,
+    );
+    exec.map(|e| (line_ref, e))
+}
+
+/// Integrate composed `integrate: merge` sub-runs at the orchestrate join (spec
+/// §10.3): ferry each successful sub-run's final ref into the parent run repo (in
+/// launch order), then merge them via the shared merge machinery (§12.3) — a clean
+/// run advances the stage line onto the integrated result; a conflict pauses
+/// `conflict`. No merge sub-runs → the stage line is unchanged (`line: None`).
+#[allow(clippy::too_many_arguments)]
+async fn begin_subrun_merge(
+    ctx: &RunCtx,
+    run_id: &str,
+    run: &RunEssentials,
+    spec: &Spec,
+    block_index: usize,
+    run_repo: &Path,
+    fork_base: &str,
+    sub_runs: &HashMap<String, SubRunState>,
+    cursor: &mut Cursor,
+) -> Result<StageFlow> {
+    // Launch order, so merges are deterministic (child order = spec order §12.3).
+    let ordered: Vec<String> = {
+        let conn = ctx.db.lock();
+        conn.prepare("SELECT id FROM wf_run WHERE parent_run_id = ?1 ORDER BY created_at, rowid")
+            .and_then(|mut s| {
+                s.query_map([run_id], |r| r.get::<_, String>(0))?
+                    .collect::<rusqlite::Result<Vec<_>>>()
+            })
+            .unwrap_or_default()
+    };
+    let mut winners: Vec<(String, String)> = Vec::new();
+    for sub_id in ordered {
+        let Some(st) = sub_runs.get(&sub_id) else {
+            continue;
+        };
+        if !matches!(st.integrate, Integrate::Merge)
+            || !matches!(st.terminal, Some(ChildStatus::Success))
+        {
+            continue;
+        }
+        let Some((src_ref, _)) = subrun_final_line(ctx, &sub_id) else {
+            continue; // produced no commit
+        };
+        let sub_run_dir: String = {
+            let conn = ctx.db.lock();
+            conn.query_row("SELECT run_dir FROM wf_run WHERE id = ?1", [&sub_id], |r| {
+                r.get(0)
+            })
+            .map_err(|e| Error::Other(e.to_string()))?
+        };
+        let sub_run_repo = gitops::run_repo_path(&PathBuf::from(sub_run_dir));
+        let dest = gitops::subrun_ref(&sub_id);
+        gitops::ferry_ref_as(&sub_run_repo, run_repo, &src_ref, &dest).await?;
+        winners.push((sub_id.clone(), dest));
+    }
+    if winners.is_empty() {
+        return Ok(StageFlow::Advance { line: None });
+    }
+    let run_dir = PathBuf::from(&run.run_dir);
+    let int_wt = gitops::integration_worktree_path(&run_dir, block_index);
+    let base = crate::git::rev_parse(run_repo, fork_base).await?;
+    gitops::setup_integration_worktree(run_repo, &int_wt, &base).await?;
+    {
+        let conn = ctx.db.lock();
+        journal_event(
+            &conn,
+            ctx.app.as_ref(),
+            run_id,
+            event_type::MERGE_STARTED,
+            None,
+            &json!({ "count": winners.len(), "kind": "subrun" }),
+        );
+    }
+    drive_merges(
+        ctx,
+        run_id,
+        &spec.name,
+        block_index,
+        run_repo,
+        &int_wt,
+        winners,
+        cursor,
+    )
+    .await
+}
+
+/// Resume a sub-run integration paused mid-merge or on a conflict (spec §10.3,
+/// §12.3). Mirrors [`resume_merge_stage`] but the refs are already ferried and the
+/// mode-(a) resolver is the orchestrate stage's own agent (there is no `parallel`
+/// child list to resolve one from).
+#[allow(clippy::too_many_arguments)]
+async fn resume_subrun_merge(
+    ctx: &RunCtx,
+    run_id: &str,
+    run: &RunEssentials,
+    spec: &Spec,
+    orch: &Orchestrate,
+    block_index: usize,
+    block_count: usize,
+    blackboard: &Path,
+    repo: &Path,
+    run_repo: &Path,
+    eff: &EffectiveBudgets,
+    ledger: &mut Ledger,
+    test_override: &Option<String>,
+    setup_override: &Option<String>,
+    cursor: &mut Cursor,
+) -> Result<StageFlow> {
+    let ms = cursor
+        .merge
+        .clone()
+        .ok_or_else(|| Error::Other("resume_subrun_merge without merge cursor".into()))?;
+    let run_dir = PathBuf::from(&run.run_dir);
+    let int_wt = gitops::integration_worktree_path(&run_dir, block_index);
+
+    let Some(ci) = ms.conflict.clone() else {
+        // Interrupted mid-clean-merge — continue with what remains.
+        return drive_merges(
+            ctx,
+            run_id,
+            &spec.name,
+            block_index,
+            run_repo,
+            &int_wt,
+            ms.remaining,
+            cursor,
+        )
+        .await;
+    };
+    // A conflict awaiting the user's choice must not be silently re-driven.
+    let Some(resolution) = ci.resolution.clone() else {
+        let conn = ctx.db.lock();
+        set_status(
+            &conn,
+            ctx.app.as_ref(),
+            run_id,
+            "paused",
+            Some("conflict"),
+            None,
+        );
+        return Ok(StageFlow::Stop);
+    };
+
+    let new_acc: String = match resolution.as_str() {
+        // (c) The human committed a resolution in the integration worktree.
+        "human" => {
+            let head = crate::git::rev_parse(&int_wt, "HEAD").await?;
+            let snapshot = crate::git::rev_parse(run_repo, &ci.conflict_ref).await.ok();
+            let clean = gitops::is_worktree_clean(&int_wt).await.unwrap_or(false);
+            let uncommitted = !clean || snapshot.as_deref() == Some(head.as_str());
+            let markers =
+                gitops::resolution_retains_markers(&int_wt, &ci.conflict_ref, &ci.files).await;
+            if uncommitted || markers {
+                let detail = if uncommitted {
+                    "resolve the conflicts and commit in the integration worktree before continuing"
+                } else {
+                    "the committed resolution still contains conflict markers — remove them, commit, and continue"
+                };
+                if let Some(c) = cursor.merge.as_mut().and_then(|m| m.conflict.as_mut()) {
+                    c.resolution = None;
+                }
+                let conn = ctx.db.lock();
+                set_cursor(&conn, run_id, cursor);
+                journal_event(
+                    &conn,
+                    ctx.app.as_ref(),
+                    run_id,
+                    event_type::RUN_PAUSED,
+                    None,
+                    &json!({ "reason": "conflict", "detail": detail }),
+                );
+                set_status(
+                    &conn,
+                    ctx.app.as_ref(),
+                    run_id,
+                    "paused",
+                    Some("conflict"),
+                    None,
+                );
+                return Ok(StageFlow::Stop);
+            }
+            head
+        }
+        // (a) Spawn a conflict-resolution step, forked from the pinned snapshot,
+        // run by the orchestrate stage's own agent.
+        "agent" => {
+            let agent_spec = spec.agents.get(&orch.agent).ok_or_else(|| {
+                Error::Other(format!(
+                    "conflict resolver references unknown agent '{}'",
+                    orch.agent
+                ))
+            })?;
+            let resolve_step = Step {
+                id: format!("__resolve_{block_index}"),
+                agent: orch.agent.clone(),
+                goal: format!(
+                    "A merge of composed sub-run work produced conflicts in: {}. \
+                     Open each file, remove every conflict marker \
+                     (<<<<<<<, =======, >>>>>>>), reconcile both sides so the \
+                     result is coherent, and commit the resolution.",
+                    ci.files.join(", ")
+                ),
+                gate: Gate::Commit,
+                budgets: None,
+                comms: vec![],
+            };
+            let env = StepEnv {
+                repo,
+                run_repo,
+                blackboard,
+                eff,
+                test_override,
+                setup_override,
+                run_task: &run.task,
+                spec_name: &spec.name,
+            };
+            let position = Position {
+                step_index: block_index,
+                step_count: block_count,
+                iteration: None,
+            };
+            match execute_step(
+                ctx,
+                run_id,
+                &env,
+                &resolve_step,
+                agent_spec,
+                position,
+                0,
+                &ci.conflict_ref,
+                false,
+                ledger,
+            )
+            .await?
+            {
+                StepFlow::Done { head_ref, .. } => {
+                    crate::git::rev_parse(run_repo, &head_ref).await?
+                }
+                StepFlow::Halt => return Ok(StageFlow::Stop),
+                StepFlow::LoopContinue => unreachable!("resolution step is never a loop until"),
+            }
+        }
+        other => {
+            return Err(Error::Other(format!(
+                "unknown conflict resolution mode '{other}'"
+            )))
+        }
+    };
+
+    gitops::setup_integration_worktree(run_repo, &int_wt, &new_acc).await?;
+    gitops::pin_ref(&int_wt, &gitops::merge_acc_ref(block_index)).await?;
+    cursor.merge = Some(MergeCursor {
+        block_index,
+        remaining: ms.remaining.clone(),
+        conflict: None,
+    });
+    set_cursor(&ctx.db.lock(), run_id, cursor);
+    drive_merges(
+        ctx,
+        run_id,
+        &spec.name,
+        block_index,
+        run_repo,
+        &int_wt,
+        ms.remaining,
+        cursor,
+    )
+    .await
 }
 
 /// Assemble one orchestrate child's owned [`ChildCtx`] (all fields cloned so the
@@ -4617,6 +5380,16 @@ fn resume_line_state(
     (base_sha.to_string(), None)
 }
 
+/// The ids of a run's composed sub-runs (spec §10.3), for the cancel-cascade.
+fn child_run_ids(conn: &Connection, parent_run_id: &str) -> Vec<String> {
+    conn.prepare("SELECT id FROM wf_run WHERE parent_run_id = ?1")
+        .and_then(|mut s| {
+            s.query_map([parent_run_id], |r| r.get::<_, String>(0))?
+                .collect::<rusqlite::Result<Vec<_>>>()
+        })
+        .unwrap_or_default()
+}
+
 /// Live (spawned, non-terminal) step agents for a run — stopped on cancel/pause.
 fn live_step_agents(conn: &Connection, run_id: &str) -> Vec<String> {
     conn.prepare(
@@ -4977,6 +5750,7 @@ mod tests {
             cancel: Arc::new(AtomicBool::new(false)),
             pending_ask: Arc::new(AtomicBool::new(false)),
             deadlines: Deadlines::default(),
+            runs: None,
         };
         drive_run(&ctx, run_id).await;
 
@@ -5102,6 +5876,7 @@ mod tests {
             cancel: Arc::new(AtomicBool::new(true)), // pre-canceled
             pending_ask: Arc::new(AtomicBool::new(false)),
             deadlines: Deadlines::default(),
+            runs: None,
         };
         drive_run(&ctx, "run-cancel").await;
         let status: String = db
@@ -5127,6 +5902,7 @@ mod tests {
             cancel: Arc::new(AtomicBool::new(false)),
             pending_ask: Arc::new(AtomicBool::new(false)),
             deadlines: Deadlines::default(),
+            runs: None,
         };
         drive_run(&ctx, "run-term").await;
         let (status, execs): (String, i64) = db
@@ -5155,6 +5931,7 @@ mod tests {
             cancel: Arc::new(AtomicBool::new(false)),
             pending_ask: Arc::new(AtomicBool::new(false)),
             deadlines: Deadlines::default(),
+            runs: None,
         };
         drive_run(&ctx, "run-blocked").await;
         let (status, reason): (String, Option<String>) = db
@@ -5364,6 +6141,7 @@ mod tests {
             cancel: Arc::new(AtomicBool::new(false)),
             pending_ask: pending_ask.clone(),
             deadlines: Deadlines::default(),
+            runs: None,
         };
 
         // ── First drive: the step asks; the run pauses `question`. ──
@@ -5472,6 +6250,7 @@ mod tests {
             cancel: Arc::new(AtomicBool::new(false)),
             pending_ask,
             deadlines: Deadlines::default(),
+            runs: None,
         };
 
         drive_run(&ctx, "run-ask2").await;
@@ -5521,6 +6300,7 @@ mod tests {
             cancel: Arc::new(AtomicBool::new(false)),
             pending_ask,
             deadlines: Deadlines::default(),
+            runs: None,
         };
 
         drive_run(&ctx, "run-ask3").await;
@@ -5562,6 +6342,7 @@ mod tests {
             cancel: Arc::new(AtomicBool::new(false)),
             pending_ask: Arc::new(AtomicBool::new(false)),
             deadlines: Deadlines::default(),
+            runs: None,
         };
         drive_run(&ctx, "run-resume").await;
 
@@ -5685,6 +6466,7 @@ mod tests {
             cancel: Arc::new(AtomicBool::new(false)),
             pending_ask: Arc::new(AtomicBool::new(false)),
             deadlines: Deadlines::default(),
+            runs: None,
         };
         drive_run(&ctx, "run-b0").await;
 
@@ -5724,6 +6506,7 @@ mod tests {
             cancel: Arc::new(AtomicBool::new(false)),
             pending_ask: Arc::new(AtomicBool::new(false)),
             deadlines: Deadlines::default(),
+            runs: None,
         };
         drive_run(&ctx, "run-b1").await;
 
@@ -6178,6 +6961,7 @@ mod tests {
             cancel: Arc::new(AtomicBool::new(false)),
             pending_ask: Arc::new(AtomicBool::new(false)),
             deadlines: Deadlines::default(),
+            runs: None,
         }
     }
 
@@ -7043,6 +7827,7 @@ mod tests {
             cancel: Arc::new(AtomicBool::new(false)),
             pending_ask: Arc::new(AtomicBool::new(false)),
             deadlines: Deadlines::default(),
+            runs: None,
         }
     }
 
@@ -7603,6 +8388,7 @@ mod tests {
                 watchdog_tick: std::time::Duration::from_millis(100),
                 ..Deadlines::default()
             },
+            runs: None,
         }
     }
 
@@ -7836,6 +8622,7 @@ mod tests {
             cancel: Arc::new(AtomicBool::new(false)),
             pending_ask: Arc::new(AtomicBool::new(false)),
             deadlines: Deadlines::default(),
+            runs: None,
         };
         let mut ledger = Ledger::default();
         let mut outcomes: HashMap<String, ChildStatus> = HashMap::new();
@@ -8012,5 +8799,264 @@ mod tests {
             "the restored dynamic-child failure must decide the join:all stage"
         );
         assert!(err.unwrap_or_default().contains("orchestrate stage failed"));
+    }
+
+    // ───────────────────────── dynamic composition (S12, §10.3) ─────────────
+
+    #[test]
+    fn child_run_ids_lists_only_direct_sub_runs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = crate::database::init(tmp.path()).unwrap();
+        let conn = db.lock();
+        for (id, parent) in [
+            ("p", None),
+            ("c1", Some("p")),
+            ("c2", Some("p")),
+            ("other", None),
+        ] {
+            conn.execute(
+                "INSERT INTO wf_run (id,parent_run_id,name,spec_json,task,project_id,repo_path,
+                    run_dir,branch,base_sha,status,budgets_json,spent_json,created_at,updated_at)
+                 VALUES (?1,?2,'n','{}','t','p','/r','/rd','wf/x','s','running','{}','{}',0,0)",
+                rusqlite::params![id, parent],
+            )
+            .unwrap();
+        }
+        let mut kids = child_run_ids(&conn, "p");
+        kids.sort();
+        assert_eq!(kids, vec!["c1".to_string(), "c2".to_string()]);
+        assert!(child_run_ids(&conn, "other").is_empty());
+    }
+
+    #[test]
+    fn rebuild_sub_runs_reconstructs_tracking_from_the_journal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = crate::database::init(tmp.path()).unwrap();
+        let conn = db.lock();
+        conn.execute(
+            "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,branch,
+                base_sha,status,budgets_json,spent_json,created_at,updated_at)
+             VALUES ('run','n','{}','t','p','/r','/rd','wf/x','s','running','{}','{}',0,0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO wf_run (id,parent_run_id,name,spec_json,task,project_id,repo_path,run_dir,
+                branch,base_sha,status,budgets_json,spent_json,created_at,updated_at)
+             VALUES ('sub','run','n','{}','t','p','/r','/rd','wf/s','s','done','{}','{}',0,0)",
+            [],
+        )
+        .unwrap();
+        journal_event(
+            &conn,
+            None,
+            "run",
+            event_type::SUBRUN_LAUNCHED,
+            Some("orch-exec"),
+            &json!({
+                "sub_run_id": "sub",
+                "block_index": 0,
+                "integrate": "merge",
+                "reserved_turns": 30,
+                "reserved_tokens": 500,
+            }),
+        );
+        let map = rebuild_sub_runs(&conn, "run", 0);
+        let st = map.get("sub").expect("sub-run rebuilt");
+        assert!(matches!(st.integrate, Integrate::Merge));
+        assert_eq!(st.reserved_turns, 30);
+        assert_eq!(st.reserved_tokens, 500);
+        assert!(
+            matches!(st.terminal, Some(ChildStatus::Success)),
+            "a `done` sub-run is terminal so it is not reaped again"
+        );
+        // A different stage's rebuild sees nothing.
+        assert!(rebuild_sub_runs(&conn, "run", 1).is_empty());
+    }
+
+    #[test]
+    fn subrun_terminal_status_maps_run_status() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = crate::database::init(tmp.path()).unwrap();
+        let conn = db.lock();
+        for (id, status) in [
+            ("d", "done"),
+            ("f", "failed"),
+            ("c", "canceled"),
+            ("r", "running"),
+        ] {
+            conn.execute(
+                "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,branch,
+                    base_sha,status,budgets_json,spent_json,created_at,updated_at)
+                 VALUES (?1,'n','{}','t','p','/r','/rd','wf/x','s',?2,'{}','{}',0,0)",
+                rusqlite::params![id, status],
+            )
+            .unwrap();
+        }
+        assert!(matches!(
+            subrun_terminal_status(&conn, "d"),
+            Some(ChildStatus::Success)
+        ));
+        assert!(matches!(
+            subrun_terminal_status(&conn, "f"),
+            Some(ChildStatus::Failure(_))
+        ));
+        assert!(matches!(
+            subrun_terminal_status(&conn, "c"),
+            Some(ChildStatus::Skipped)
+        ));
+        assert!(subrun_terminal_status(&conn, "r").is_none());
+    }
+
+    /// A run whose whole workflow is one orchestrate block with `compose` enabled
+    /// and no static children. The orchestrator's scripted first decision is a
+    /// `wf_compose` (a one-step, commit-gated fragment). Returns (db, ws, bb).
+    fn scaffold_compose(tmp: &Path, run_id: &str) -> (Db, PathBuf, PathBuf) {
+        let source = tmp.join("source");
+        std::fs::create_dir_all(&source).unwrap();
+        sh(&source, &["init", "-q", "-b", "main"]);
+        sh(&source, &["config", "user.email", "t@t.t"]);
+        sh(&source, &["config", "user.name", "t"]);
+        std::fs::write(source.join("README"), "base").unwrap();
+        sh(&source, &["add", "-A"]);
+        sh(&source, &["commit", "-qm", "base"]);
+        let base_sha = {
+            let o = Sh::new("git")
+                .current_dir(&source)
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .unwrap();
+            String::from_utf8_lossy(&o.stdout).trim().to_string()
+        };
+        let run_dir = tmp.join("rundir");
+        let blackboard = blackboard::blackboard_dir(&run_dir);
+        std::fs::create_dir_all(&blackboard).unwrap();
+
+        let mut agents = BTreeMap::new();
+        for a in ["orch", "coder"] {
+            agents.insert(
+                a.to_string(),
+                super::super::spec::AgentSpec {
+                    base: "codex".to_string(),
+                    model: None,
+                    instructions: None,
+                    skills: vec![],
+                    custom_agent: None,
+                },
+            );
+        }
+        let spec = Spec {
+            version: 1,
+            name: "compose".to_string(),
+            description: None,
+            budgets: None,
+            agents,
+            workflow: vec![Block::Orchestrate(Orchestrate {
+                agent: "orch".to_string(),
+                goal: "lead".to_string(),
+                children: None,
+                body: vec![],
+                join: Join::All,
+                integrate: Integrate::None,
+                comms: vec![],
+                compose: Some(super::super::spec::ComposeLimits {
+                    max_sub_runs: 2,
+                    max_depth: 2,
+                }),
+            })],
+            finalize: None,
+        };
+        let spec_json = serde_json::to_string(&spec).unwrap();
+        let db = crate::database::init(tmp).unwrap();
+        db.lock()
+            .execute(
+                "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,branch,
+                    base_sha,status,budgets_json,spent_json,created_at,updated_at)
+                 VALUES (?1,'compose',?2,'t','p',?3,?4,'wf/compose-x',?5,'pending','{}','{}',0,0)",
+                rusqlite::params![
+                    run_id,
+                    spec_json,
+                    source.to_string_lossy(),
+                    run_dir.to_string_lossy(),
+                    base_sha,
+                ],
+            )
+            .unwrap();
+        (db, tmp.join("ws"), blackboard)
+    }
+
+    #[tokio::test]
+    async fn composed_sub_run_runs_to_done_and_merges_at_the_join() {
+        let tmp = tempfile::tempdir().unwrap();
+        // The sub-run provisions its own run dir under the runs root; point it at
+        // the (writable) tempdir. This is the only test that launches a sub-run,
+        // so the process-global override doesn't race other tests.
+        std::env::set_var("FLETCH_RUNS_ROOT", tmp.path().join("runs"));
+        let (db, ws, bb) = scaffold_compose(tmp.path(), "run-compose");
+        // The orchestrator composes a one-step, commit-gated sub-run that merges.
+        let decision = json!({
+            "decision": "compose",
+            "plan": {
+                "task": "implement the composed slice",
+                "fragment": [{
+                    "step": {
+                        "id": "impl",
+                        "agent": "coder",
+                        "goal": "write code",
+                        "gate": { "type": "commit" }
+                    }
+                }],
+                "turns": 20,
+                "integrate": "merge",
+                "base": "parent-head",
+                "block_index": 0
+            }
+        });
+        let driver = OrchDriver::new_scripted(
+            ws,
+            bb,
+            OrchMode::Conclude,
+            db.clone(),
+            "run-compose",
+            decision,
+        );
+        let ctx = orch_ctx(db.clone(), driver);
+        drive_run(&ctx, "run-compose").await;
+
+        assert_eq!(
+            run_status_str(&db, "run-compose"),
+            "done",
+            "the composed sub-run drove the parent to done"
+        );
+        assert_eq!(
+            count(
+                &db,
+                "SELECT COUNT(*) FROM wf_run WHERE parent_run_id='run-compose'"
+            ),
+            1,
+            "exactly one sub-run was created"
+        );
+        assert_eq!(
+            count(
+                &db,
+                "SELECT COUNT(*) FROM wf_run WHERE parent_run_id='run-compose' AND status='done'"
+            ),
+            1,
+            "the sub-run ran to done"
+        );
+        assert!(
+            count(
+                &db,
+                "SELECT COUNT(*) FROM wf_event WHERE run_id='run-compose' AND type='subrun_finished'"
+            ) >= 1,
+            "the sub-run's completion was journaled"
+        );
+        assert!(
+            count(
+                &db,
+                "SELECT COUNT(*) FROM wf_event WHERE run_id='run-compose' AND type='merge_done'"
+            ) >= 1,
+            "the sub-run merged at the join"
+        );
     }
 }

--- a/src-tauri/src/workflow/spec.rs
+++ b/src-tauri/src/workflow/spec.rs
@@ -212,7 +212,7 @@ pub struct Finalize {
 /// §11.1. All optional — a missing field falls back to the app default at
 /// launch. Signed so a negative value parses and is caught by validation with a
 /// precise message rather than failing deserialization opaquely.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct Budgets {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub turns: Option<i64>,

--- a/src-tauri/src/workflow/types.rs
+++ b/src-tauri/src/workflow/types.rs
@@ -140,6 +140,12 @@ pub mod event_type {
     pub const CHILD_SPAWN_REQUESTED: &str = "child_spawn_requested";
     pub const CHILD_SPAWN_APPROVED: &str = "child_spawn_approved";
     pub const CHILD_SPAWN_DENIED: &str = "child_spawn_denied";
+    /// An orchestrator `wf_compose` passed validation and a sub-run was authorized
+    /// (spec §10.3). The `subrun_launched` event follows once its driver starts.
+    pub const COMPOSE_REQUESTED: &str = "compose_requested";
+    /// A `wf_compose` was rejected — invalid fragment, over-depth, over-budget, or
+    /// a caps escalation (spec §10.3, §15). Carries the human-readable reason.
+    pub const COMPOSE_DENIED: &str = "compose_denied";
     pub const SUBRUN_LAUNCHED: &str = "subrun_launched";
     pub const SUBRUN_FINISHED: &str = "subrun_finished";
     /// A parallel/orchestrate stage with `integrate: none` finished; a child's

--- a/src/components/Sidebar/ProjectGroup.tsx
+++ b/src/components/Sidebar/ProjectGroup.tsx
@@ -160,14 +160,28 @@ export function ProjectGroup({
             onClick={() => selectAgent(a.id)}
           />
         ))}
-        {runs.map((run) => (
-          <RunRow
-            key={run.id}
-            run={run}
-            selected={selectedRunId === run.id}
-            onSelect={() => selectRun(run.id)}
-          />
-        ))}
+        {runs
+          .filter((run) => !run.parent_run_id)
+          .flatMap((run) => [
+            <RunRow
+              key={run.id}
+              run={run}
+              selected={selectedRunId === run.id}
+              onSelect={() => selectRun(run.id)}
+            />,
+            // Composed sub-runs (§10.3) render nested under their parent.
+            ...runs
+              .filter((sub) => sub.parent_run_id === run.id)
+              .map((sub) => (
+                <RunRow
+                  key={sub.id}
+                  run={sub}
+                  nested
+                  selected={selectedRunId === sub.id}
+                  onSelect={() => selectRun(sub.id)}
+                />
+              )),
+          ])}
       </div>
     </div>
   );

--- a/src/workflows/run/RunRow.tsx
+++ b/src/workflows/run/RunRow.tsx
@@ -19,10 +19,13 @@ export function RunRow({
   run,
   selected,
   onSelect,
+  nested = false,
 }: {
   run: WfRun;
   selected: boolean;
   onSelect: () => void;
+  /** A composed sub-run (§10.3), rendered indented under its parent run. */
+  nested?: boolean;
 }) {
   const customAgents = useAppStore((s) => s.customAgents);
   const modelsByAgent = useAppStore((s) => s.modelsByAgent);
@@ -61,7 +64,7 @@ export function RunRow({
 
   return (
     <div
-      className={`agent ${selected ? "active" : ""}`}
+      className={`agent ${selected ? "active" : ""} ${nested ? "run-nested" : ""}`}
       role="button"
       tabIndex={0}
       aria-current={selected ? "page" : undefined}

--- a/src/workflows/run/RunView/index.tsx
+++ b/src/workflows/run/RunView/index.tsx
@@ -16,6 +16,7 @@ import { useAppStore } from "../../../store";
 import { resolveAgent } from "../../shared";
 import type { Spec } from "../../spec";
 import { runChip } from "../status";
+import { useRuns } from "../useRuns";
 import { AttemptRail } from "./AttemptRail";
 import { BudgetMeter } from "./BudgetMeter";
 import { flattenSteps } from "./flatten";
@@ -28,6 +29,15 @@ export function RunView({ id }: { id: string }) {
   const modelsByAgent = useAppStore((s) => s.modelsByAgent);
   const toggleLeft = useAppStore((s) => s.toggleLeft);
   const leftCollapsed = useAppStore((s) => s.leftCollapsed);
+  const selectRun = useAppStore((s) => s.selectRun);
+
+  // Composed sub-runs (§10.3) nest under this run in the monitor; each links to
+  // its own RunView. Sourced from the live run list, filtered to our children.
+  const allRuns = useRuns();
+  const subRuns = useMemo(
+    () => allRuns.filter((r) => r.parent_run_id === id),
+    [allRuns, id],
+  );
 
   // Run-owned step agents come from the run (they're hidden from the workspace
   // snapshot); the monitor renders each attempt's chat from these records.
@@ -171,6 +181,28 @@ export function RunView({ id }: { id: string }) {
         </div>
 
         <div className="wf-run-side">
+          {subRuns.length > 0 && (
+            <div className="wf-subruns">
+              <div className="wf-side-head">Sub-runs</div>
+              {subRuns.map((sr) => {
+                const c = runChip(sr.status);
+                return (
+                  <button
+                    key={sr.id}
+                    type="button"
+                    className="wf-subrun-row"
+                    onClick={() => selectRun(sr.id)}
+                  >
+                    <span className="wf-srow-dot" style={{ background: c.tone }} />
+                    <span className="wf-subrun-name">{sr.name}</span>
+                    <span className="wf-subrun-status" style={{ color: c.tone }}>
+                      {c.label}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
           <div className="wf-side-head">Timeline</div>
           <Timeline events={events} />
         </div>

--- a/src/workflows/run/RunView/index.tsx
+++ b/src/workflows/run/RunView/index.tsx
@@ -34,10 +34,7 @@ export function RunView({ id }: { id: string }) {
   // Composed sub-runs (§10.3) nest under this run in the monitor; each links to
   // its own RunView. Sourced from the live run list, filtered to our children.
   const allRuns = useRuns();
-  const subRuns = useMemo(
-    () => allRuns.filter((r) => r.parent_run_id === id),
-    [allRuns, id],
-  );
+  const subRuns = useMemo(() => allRuns.filter((r) => r.parent_run_id === id), [allRuns, id]);
 
   // Run-owned step agents come from the run (they're hidden from the workspace
   // snapshot); the monitor renders each attempt's chat from these records.

--- a/src/workflows/workflows.css
+++ b/src/workflows/workflows.css
@@ -781,6 +781,48 @@
   flex-shrink: 0;
 }
 
+/* A composed sub-run (§10.3) sits indented under its parent run in the sidebar,
+   with a faint guide rail so the nesting reads at a glance. */
+.agent.run-nested {
+  margin-left: 14px;
+  border-left: 1px solid var(--bd-soft);
+  padding-left: 6px;
+}
+
+/* Run monitor: the sub-runs section above the timeline (§10.3, §14.2). */
+.wf-subruns {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 12px;
+}
+.wf-subrun-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px;
+  border: none;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--fg-1);
+  text-align: left;
+  cursor: pointer;
+  font-size: 12px;
+}
+.wf-subrun-row:hover {
+  background: var(--hover);
+}
+.wf-subrun-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wf-subrun-status {
+  font-size: 11px;
+  flex-shrink: 0;
+}
+
 /* Workflow tile (composer selector chip) + status dot (run monitor rail). The
    sidebar run row otherwise reuses the agent-row classes (.agent/.ag-*). */
 .wf-srow-tile {


### PR DESCRIPTION
Implements **S12 — Dynamic composition (`wf_compose`)** from the workflows v1 spec (TECH_SPEC §10.3), on top of the merged Wave 3 (S9 + S11). Depends on S11 (orchestrator role) and S2 (spec/validation).

## What this adds

An orchestrator agent can compose bounded sub-workflows at runtime. The deterministic engine validates and executes; the LLM only advises.

### Backend
- **`comms.rs`** — `wf_compose` RPC op, gated by the orchestrator *role* (like `wf_decide`). Synchronous, structured-error validation: fragment via the full `spec::validate`, depth (`parent+1 ≤ max_depth`, absolute cap 2), caps-escalation (§15), `max_sub_runs`, and a budget-fit check. Every rejection also journals `compose_denied`. On success it queues a typed `Decision::Compose`.
- **`budget.rs`** — sub-run budget **reservation**: `reserved_turns`/`reserved_tokens` count against the run caps in `exceeded`, and are released + reconciled against the sub-run's *actual* spend on completion (a slice is never double-counted). Faithful to §10.3's "reserved from the parent ledger."
- **`scheduler.rs`** — sub-run creation (`parent_run_id`, synthetic spec from the fragment, its own run dir/repo + driver task), fork-base resolution (`parent-head`/`run-base`) with a ref ferry for parent-head workflow commits, orchestrate-join tracking + reconciliation, **integrate-at-join** reusing the S9 merge/conflict machinery (clean merge advances the stage line; conflict pauses `conflict`), resume rebuild from the journal, and **cancel-cascade** (canceling a parent cancels its sub-runs).
- **`gitops.rs`** — `ferry_ref_as` / `subrun_ref` to move a sub-run's final ref into the parent run repo for integration.

### Frontend (§14.2)
- Sidebar: sub-runs render **nested** under their parent run.
- Run Monitor: a **Sub-runs** section linking to each child's `RunView`.

## Tests
- Budget reservation math (reserve → release/reconcile, caps accounting, persistence).
- The `wf_compose` validation/rejection matrix — orchestrator-only, compose-disabled, over-budget, over-depth, caps-escalation, invalid fragment, over-`max_sub_runs` — each a structured error + `compose_denied`.
- Sub-run tracking: journal rebuild on resume, status mapping, cancel-cascade query.
- A stub-agent **e2e**: a composed sub-run runs to `done` and merges at the join.

`cargo test` (212 workflow tests), `cargo clippy`, `cargo fmt`, and `tsc --noEmit` are green. Frontend `biome`/`vitest` could not run in this sandbox (dependency install is blocked); the TS changes are typecheck-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)