### PR TITLE
fix(claude): render task-notification events as quiet system notices

### DIFF
--- a/src/adapters/claude/sanitize.ts
+++ b/src/adapters/claude/sanitize.ts
@@ -33,18 +33,21 @@ const COMPACT_PREAMBLE_RE = /^This session is being continued from a previous co
 // guard in reduce.ts and would otherwise render its raw XML as a user bubble.
 // Detect it by the wrapper tag — present on both the live wire and the persisted
 // transcript, unlike origin which the CLI reshapes between the two — and surface
-// only the human-readable <summary> as a quiet background_task notice.
-const TASK_NOTIFICATION_RE = /^\s*<task-notification>([\s\S]*)<\/task-notification>\s*$/;
+// only the human-readable <summary> as a quiet background_task notice. Stripped
+// inline (global, like the other wrappers) so a notification riding alongside
+// real user text doesn't leak its raw XML into the bubble.
+const TASK_NOTIFICATION_RE = /<task-notification>([\s\S]*?)<\/task-notification>/g;
 const TASK_SUMMARY_RE = /<summary>([\s\S]*?)<\/summary>/;
 const TASK_STATUS_RE = /<status>([\s\S]*?)<\/status>/;
 
-function parseTaskNotification(raw: string): NoticeItem | null {
-  const match = raw.match(TASK_NOTIFICATION_RE);
-  if (!match) return null;
-  const body = match[1];
+function taskNotificationNotice(body: string): NoticeItem | null {
   const summary = body.match(TASK_SUMMARY_RE)?.[1]?.trim();
   const status = body.match(TASK_STATUS_RE)?.[1]?.trim() ?? "";
-  const text = summary || `Background task ${status || "update"}`;
+  // A contentless notification (no summary and no status) carries nothing worth
+  // showing — drop it like an empty system-reminder rather than emitting a
+  // misleading "Background task update" line.
+  if (!summary && !status) return null;
+  const text = summary || `Background task ${status}`;
   // Anything other than a clean completion (e.g. "stopped", a nonzero exit)
   // flags the dot red; the summary text already spells out the detail.
   const isError = status !== "" && status !== "completed" && status !== "success";
@@ -69,13 +72,16 @@ export function sanitizeUserText(raw: string): SanitizeResult {
     };
   }
 
-  const taskNotice = parseTaskNotification(raw);
-  if (taskNotice) {
-    return { text: "", notices: [taskNotice] };
-  }
+  // Background-task notifications → background_task notices. Stripped inline so
+  // surrounding user text survives; contentless ones drop to nothing.
+  let text = raw.replace(TASK_NOTIFICATION_RE, (_match, body: string) => {
+    const notice = taskNotificationNotice(body);
+    if (notice) notices.push(notice);
+    return "";
+  });
 
   // Slash-command name → one notice per invocation. Strip the tag.
-  let text = raw.replace(COMMAND_NAME_RE, (_match, body: string) => {
+  text = text.replace(COMMAND_NAME_RE, (_match, body: string) => {
     const name = body.trim();
     if (name) {
       notices.push({

--- a/src/adapters/claude/sanitize.ts
+++ b/src/adapters/claude/sanitize.ts
@@ -27,6 +27,32 @@ const SYSTEM_REMINDER_RE = /<system-reminder>([\s\S]*?)<\/system-reminder>/g;
 // type it. Convert to a compact_summary notice instead.
 const COMPACT_PREAMBLE_RE = /^This session is being continued from a previous conversation/;
 
+// When a background Task/Bash finishes, the harness re-invokes the agent with
+// a `<task-notification>` user-role event (origin.kind === "task-notification").
+// It carries neither isMeta nor isSynthetic, so it isn't caught by the injected
+// guard in reduce.ts and would otherwise render its raw XML as a user bubble.
+// Detect it by the wrapper tag — present on both the live wire and the persisted
+// transcript, unlike origin which the CLI reshapes between the two — and surface
+// only the human-readable <summary> as a quiet background_task notice.
+const TASK_NOTIFICATION_RE = /^\s*<task-notification>([\s\S]*)<\/task-notification>\s*$/;
+const TASK_SUMMARY_RE = /<summary>([\s\S]*?)<\/summary>/;
+const TASK_STATUS_RE = /<status>([\s\S]*?)<\/status>/;
+
+function parseTaskNotification(raw: string): NoticeItem | null {
+  const match = raw.match(TASK_NOTIFICATION_RE);
+  if (!match) return null;
+  const body = match[1];
+  const summary = body.match(TASK_SUMMARY_RE)?.[1]?.trim();
+  const status = body.match(TASK_STATUS_RE)?.[1]?.trim() ?? "";
+  const text = summary || `Background task ${status || "update"}`;
+  // Anything other than a clean completion (e.g. "stopped", a nonzero exit)
+  // flags the dot red; the summary text already spells out the detail.
+  const isError = status !== "" && status !== "completed" && status !== "success";
+  return isError
+    ? { kind: "notice", subtype: "background_task", text, is_error: true }
+    : { kind: "notice", subtype: "background_task", text };
+}
+
 // Cursor (which reuses this sanitizer) wraps every user turn in its own
 // envelope: a `<timestamp>` line followed by the query inside `<user_query>`.
 // Neither is user-authored. Claude never emits these, so it's a no-op there.
@@ -41,6 +67,11 @@ export function sanitizeUserText(raw: string): SanitizeResult {
       text: "",
       notices: [{ kind: "notice", subtype: "compact_summary", text: "Conversation compacted" }],
     };
+  }
+
+  const taskNotice = parseTaskNotification(raw);
+  if (taskNotice) {
+    return { text: "", notices: [taskNotice] };
   }
 
   // Slash-command name → one notice per invocation. Strip the tag.

--- a/src/adapters/shared/default-policy.ts
+++ b/src/adapters/shared/default-policy.ts
@@ -8,6 +8,7 @@ export const DEFAULT_POLICY: DisplayPolicy = {
   "notice:turn_end": "hide",
   "notice:hook_output": "hide",
   "notice:info": "show",
+  "notice:background_task": "show",
   "notice:reasoning": "show",
   "notice:slash_command": "show",
   "notice:error": "show",

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -80,7 +80,8 @@ export type NoticeSubtype =
   | "reasoning"
   | "slash_command"
   | "compact_summary"
-  | "hook_output";
+  | "hook_output"
+  | "background_task";
 
 export type RawEvent = Record<string, unknown> & { type?: string };
 

--- a/src/components/Workspace/Chat.css
+++ b/src/components/Workspace/Chat.css
@@ -617,3 +617,39 @@
   margin-bottom: 4px;
   font-weight: 500;
 }
+
+/* A background-task notification, rendered as a single quiet system line
+   (status dot · label · summary) rather than a user bubble. Kept dim and
+   compact so a run of completed background tasks reads as chrome. */
+.m-sysbit {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 3px 18px;
+  font-size: var(--fs-xs);
+  line-height: var(--lh-snug);
+  color: var(--fg-3);
+}
+.m-sysbit__dot {
+  flex: none;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  align-self: center;
+  background: var(--success);
+}
+.m-sysbit.is-error .m-sysbit__dot {
+  background: var(--danger);
+}
+.m-sysbit__label {
+  flex: none;
+  font-family: var(--font-mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 500;
+  color: var(--fg-3);
+}
+.m-sysbit__text {
+  color: var(--fg-2);
+  white-space: pre-wrap;
+}

--- a/src/components/Workspace/messages/MessageItem.tsx
+++ b/src/components/Workspace/messages/MessageItem.tsx
@@ -246,6 +246,19 @@ function NoticeView({ item }: { item: Extract<ChatItem, { kind: "notice" }> }) {
       </div>
     );
   }
+  if (item.subtype === "background_task") {
+    // A quiet under-the-hood system line: a status dot + label + the harness's
+    // one-line summary. Deliberately not a bubble and not italic reasoning — it
+    // reads as chrome, so a stream of completed background tasks doesn't clutter
+    // the conversation.
+    return (
+      <div className={item.is_error ? "m-sysbit is-error" : "m-sysbit"}>
+        <span className="m-sysbit__dot" aria-hidden />
+        <span className="m-sysbit__label">background task</span>
+        <span className="m-sysbit__text">{item.text}</span>
+      </div>
+    );
+  }
   if (item.subtype === "compact_summary") {
     return (
       <div className="m-reasoning" style={{ fontStyle: "italic" }}>

--- a/tests/adapters/claude/sanitize.test.ts
+++ b/tests/adapters/claude/sanitize.test.ts
@@ -123,6 +123,33 @@ describe("sanitizeUserText", () => {
     ]);
   });
 
+  it("strips a task-notification inline while preserving surrounding user text", () => {
+    const raw = [
+      "Please review this once done.",
+      "<task-notification>",
+      "<status>completed</status>",
+      '<summary>Background command "lint" completed (exit code 0)</summary>',
+      "</task-notification>",
+      "Thanks!",
+    ].join("\n");
+    const out = sanitizeUserText(raw);
+    expect(out.text).toBe("Please review this once done.\n\nThanks!");
+    expect(out.notices).toEqual([
+      {
+        kind: "notice",
+        subtype: "background_task",
+        text: 'Background command "lint" completed (exit code 0)',
+      },
+    ]);
+  });
+
+  it("drops a contentless task-notification without emitting a notice", () => {
+    const raw = "<task-notification>   </task-notification>";
+    const out = sanitizeUserText(raw);
+    expect(out.text).toBe("");
+    expect(out.notices).toEqual([]);
+  });
+
   it("drops empty system-reminders without emitting notices", () => {
     const raw = "<system-reminder>   </system-reminder>";
     const out = sanitizeUserText(raw);

--- a/tests/adapters/claude/sanitize.test.ts
+++ b/tests/adapters/claude/sanitize.test.ts
@@ -74,6 +74,55 @@ describe("sanitizeUserText", () => {
     ]);
   });
 
+  it("converts a completed task-notification into a quiet background_task notice", () => {
+    const raw = [
+      "<task-notification>",
+      "<task-id>b99pbi1zk</task-id>",
+      "<tool-use-id>toolu_016T57Qykc1mPnzTRBxUM6eL</tool-use-id>",
+      "<output-file>/tmp/tasks/b99pbi1zk.output</output-file>",
+      "<status>completed</status>",
+      '<summary>Background command "Run typecheck" completed (exit code 0)</summary>',
+      "</task-notification>",
+    ].join("\n");
+    const out = sanitizeUserText(raw);
+    expect(out.text).toBe("");
+    expect(out.notices).toEqual([
+      {
+        kind: "notice",
+        subtype: "background_task",
+        text: 'Background command "Run typecheck" completed (exit code 0)',
+      },
+    ]);
+  });
+
+  it("flags a non-completed task-notification as an error", () => {
+    const raw = [
+      "<task-notification>",
+      "<task-id>bqlybe1oq</task-id>",
+      "<status>stopped</status>",
+      "<summary>No completion record was found for this task</summary>",
+      "</task-notification>",
+    ].join("\n");
+    const out = sanitizeUserText(raw);
+    expect(out.text).toBe("");
+    expect(out.notices).toEqual([
+      {
+        kind: "notice",
+        subtype: "background_task",
+        text: "No completion record was found for this task",
+        is_error: true,
+      },
+    ]);
+  });
+
+  it("falls back to the status when a task-notification has no summary", () => {
+    const raw = "<task-notification>\n<status>completed</status>\n</task-notification>";
+    const out = sanitizeUserText(raw);
+    expect(out.notices).toEqual([
+      { kind: "notice", subtype: "background_task", text: "Background task completed" },
+    ]);
+  });
+
   it("drops empty system-reminders without emitting notices", () => {
     const raw = "<system-reminder>   </system-reminder>";
     const out = sanitizeUserText(raw);


### PR DESCRIPTION
## Problem

When a background `Task`/`Bash` finishes, the Claude CLI re-invokes the agent with a `<task-notification>` user-role event. These events carry neither `isMeta` nor `isSynthetic`, so they slipped the injected-event guard in `reduce.ts` and rendered their raw XML as a **user message bubble** in the chat — cluttering the timeline with internal harness plumbing.

## Fix

- **`sanitize.ts`** — detect the `<task-notification>…</task-notification>` wrapper and convert it to a new `background_task` notice carrying only the human-readable `<summary>`. Non-completed statuses (e.g. `stopped`) flag `is_error`. Detection keys off the wrapper tag rather than `origin.kind`, because the tag is present on both the live wire and the persisted transcript, whereas `origin` is reshaped between them (same wire-vs-transcript divergence already documented for `isMeta`/`isSynthetic`) — so this works both live and on replay.
- **`types.ts` / `default-policy.ts`** — add the `background_task` notice subtype, shown by default.
- **`MessageItem.tsx` + `Chat.css`** — render it as a quiet, single-line "system bit": a small status dot (green `--success`, red `--danger` on failure) · a mono `BACKGROUND TASK` overline · the summary. Deliberately not a bubble and not italic reasoning, so a run of completed tasks reads as chrome.

## Testing

- Added 3 sanitize tests (completed / stopped-as-error / summary-less fallback).
- Full suite: 377 passed; `tsc --noEmit` clean; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)