### PR TITLE
fix(workflows): close the five pre-merge review blockers

### DIFF
--- a/docs/workflows/TECH_SPEC.md
+++ b/docs/workflows/TECH_SPEC.md
@@ -615,6 +615,9 @@ re-run" in place.
 
 `run_launched, run_resumed, run_paused {reason}, run_done, run_failed
 {error}, run_canceled, attempt_spawned {agent_id, fork_base},
+skills_missing {skills[]} / mcp_servers_missing {mcp_servers[]} /
+custom_agent_missing {custom_agent} (a spawn resolved less than the
+definition requested — deleted library rows; warn-don't-fail),
 attempt_ready, prompt_sent {kind: step|nudge|reprompt|message},
 turn_ended {status, usage?}, gate_evaluated {mode, inputs, verdict, reason},
 boundary_commit {sha}, attempt_abandoned {cause}, attempt_error {error},

--- a/docs/workflows/TECH_SPEC.md
+++ b/docs/workflows/TECH_SPEC.md
@@ -371,6 +371,10 @@ pub struct Finalize { pub push: bool, pub open_pr: bool, pub pr_base: Option<Str
 Rejected at save/import/launch time with precise messages:
 
 - duplicate/missing step ids; `agent` keys that don't resolve
+- step ids wearing an engine-reserved shape — prefix `orchestrate-` or
+  `__`, or containing `::` — since comms role checks and routing key off
+  those shapes (a composed fragment naming a step `orchestrate-…` would
+  otherwise acquire the orchestrator's caps and decision surface, §15)
 - `loop.until.step` not in the loop body; `loop.max` < 1
 - `loop.until.step` whose gate is not `verdict` (the exit condition reads
   the verdict; a `tests`/`commit`-gated judge would conflate "gate unmet"
@@ -1038,7 +1042,10 @@ file-drop → `wf_def_import_yaml` → `ImportReport` mapping dialog
   caps broader than its parent block's, and can't enable `compose` itself
   at max depth.
 - Push stays constrained to the `wf/` namespace; finalize PR base is
-  validated as an existing branch name.
+  validated as an existing branch name. Run-owned step agents cannot push
+  at all: the workflow RPC dispatcher denies `git_push`/`open_pr` outright
+  (only `git_fetch` falls through to the git broker) — the engine's
+  finalize is the sole publish path for a run.
 - Step prompts never embed host credentials; RPC ops remain the only
   credentialed surface (unchanged from the agent playbooks).
 

--- a/src-tauri/src/workflow/attempt.rs
+++ b/src-tauri/src/workflow/attempt.rs
@@ -545,7 +545,7 @@ async fn terminal_canceled(
 /// Resolve once `flag` is set. Polls on a short cadence so a cancelled child
 /// reacts promptly under real time and deterministically under a paused test
 /// clock (an idle runtime auto-advances to the next pending timer).
-async fn wait_cancelled(flag: &AtomicBool) {
+pub(super) async fn wait_cancelled(flag: &AtomicBool) {
     while !flag.load(Ordering::SeqCst) {
         tokio::time::sleep(Duration::from_millis(50)).await;
     }

--- a/src-tauri/src/workflow/comms.rs
+++ b/src-tauri/src/workflow/comms.rs
@@ -69,6 +69,12 @@ pub(super) fn is_comms_op(op: &str) -> bool {
     cap_for_op(op).is_some() || op == "wf_decide" || op == "wf_compose"
 }
 
+/// Credentialed publish ops a run-owned agent must never reach (§15): the
+/// engine's `wf/`-guarded finalize is the only push path for workflow runs.
+pub(super) fn is_publish_op(op: &str) -> bool {
+    matches!(op, "git_push" | "open_pr")
+}
+
 /// Human-readable verb for a rejection message.
 fn op_verb(op: &str) -> &'static str {
     match op {
@@ -1978,6 +1984,21 @@ impl RpcDispatcher for WorkflowCommsDispatcher {
                         Vec::new(),
                     ),
                 }
+            } else if is_publish_op(op) {
+                // §15: run-owned step agents never publish. The engine's
+                // finalize is the only push path (and it is `wf/`-namespace
+                // guarded); the plain GitDispatcher would push any branch or
+                // open a PR with the host's credentials, so deny these
+                // outright rather than fall through. `git_fetch` stays
+                // available for base refreshes.
+                (
+                    Response::err(
+                        id,
+                        "workflow step agents cannot push or open PRs; the run \
+                         publishes its wf/ branch when it finalizes",
+                    ),
+                    Vec::new(),
+                )
             } else {
                 self.git.dispatch(id, op, args).await
             }
@@ -2013,6 +2034,18 @@ mod tests {
     use std::collections::BTreeMap;
 
     // ── caps matrix (spec §10.1) ──────────────────────────────────────────
+
+    #[test]
+    fn publish_ops_are_denied_for_run_owned_agents() {
+        // §15: the dispatcher short-circuits these before the GitDispatcher
+        // fallthrough — a step agent can never push or open a PR with host
+        // credentials. `git_fetch` (and unknown ops) still fall through.
+        assert!(is_publish_op("git_push"));
+        assert!(is_publish_op("open_pr"));
+        assert!(!is_publish_op("git_fetch"));
+        assert!(!is_publish_op("wf_report"));
+        assert!(!is_publish_op("echo"));
+    }
 
     #[test]
     fn cap_for_op_maps_the_three_comms_ops() {

--- a/src-tauri/src/workflow/definition.rs
+++ b/src-tauri/src/workflow/definition.rs
@@ -275,8 +275,10 @@ fn mcp_attachable(support: &str, transport: &str) -> bool {
 /// and servers by id, plus the spec's `skills` names resolved against the
 /// library, filtered to what the provider can deliver. Snapshots are by value
 /// (the same semantics as the draft spawn path), so later library edits never
-/// touch a spawned step. Dangling ids and unknown names drop out silently —
-/// the import already warned about them.
+/// touch a spawned step. A skill that no longer resolves (deleted since the
+/// definition was saved) is returned in the third element so the caller can
+/// journal a warning — the step still spawns, matching import's
+/// warn-don't-fail policy.
 pub(super) fn resolve_step_deliverables(
     conn: &Connection,
     custom_agent_id: Option<&str>,
@@ -285,9 +287,11 @@ pub(super) fn resolve_step_deliverables(
 ) -> (
     Vec<crate::agent_profile::SkillSnapshot>,
     Vec<crate::agent_profile::McpServerSnapshot>,
+    Vec<String>,
 ) {
     let mut skills: Vec<crate::agent_profile::SkillSnapshot> = Vec::new();
     let mut mcp: Vec<crate::agent_profile::McpServerSnapshot> = Vec::new();
+    let mut missing_skills: Vec<String> = Vec::new();
 
     let assigned: (Vec<String>, Vec<String>) = custom_agent_id
         .and_then(|id| {
@@ -311,17 +315,23 @@ pub(super) fn resolve_step_deliverables(
     // Custom-agent skills by id (assignment order), then spec names on top,
     // deduped by name.
     for skill_id in &assigned.0 {
-        if let Ok(Some(s)) = skill_row(conn, "id", skill_id) {
-            if !skills.iter().any(|k| k.name == s.name) {
-                skills.push(s);
+        match skill_row(conn, "id", skill_id) {
+            Ok(Some(s)) => {
+                if !skills.iter().any(|k| k.name == s.name) {
+                    skills.push(s);
+                }
             }
+            _ => missing_skills.push(skill_id.clone()),
         }
     }
     for name in skill_names {
-        if let Ok(Some(s)) = skill_row(conn, "name", name) {
-            if !skills.iter().any(|k| k.name == s.name) {
-                skills.push(s);
+        match skill_row(conn, "name", name) {
+            Ok(Some(s)) => {
+                if !skills.iter().any(|k| k.name == s.name) {
+                    skills.push(s);
+                }
             }
+            _ => missing_skills.push(name.clone()),
         }
     }
 
@@ -333,7 +343,7 @@ pub(super) fn resolve_step_deliverables(
             }
         }
     }
-    (skills, mcp)
+    (skills, mcp, missing_skills)
 }
 
 fn skill_row(
@@ -567,16 +577,17 @@ mod tests {
     #[test]
     fn deliverables_resolve_custom_agent_ids_plus_spec_names() {
         let conn = library_db();
-        let (skills, mcp) = resolve_step_deliverables(
+        let (skills, mcp, missing) = resolve_step_deliverables(
             &conn,
             Some("ca1"),
             &["tests-first".into(), "code-review".into(), "unknown".into()],
             "claude",
         );
         // ca1's sk1 first (assignment order), then the spec name that isn't a
-        // duplicate; the dangling id and unknown name drop silently.
+        // duplicate; the dangling id and unknown name are reported as missing.
         let names: Vec<&str> = skills.iter().map(|s| s.name.as_str()).collect();
         assert_eq!(names, vec!["code-review", "tests-first"]);
+        assert_eq!(missing, vec!["dangling", "unknown"]);
         assert_eq!(skills[0].body, "# Review");
         // claude supports all transports: both servers, parsed.
         assert_eq!(mcp.len(), 2);
@@ -593,20 +604,21 @@ mod tests {
     #[test]
     fn deliverables_filter_http_servers_for_stdio_only_providers() {
         let conn = library_db();
-        let (_, mcp) = resolve_step_deliverables(&conn, Some("ca1"), &[], "codex");
+        let (_, mcp, _) = resolve_step_deliverables(&conn, Some("ca1"), &[], "codex");
         assert_eq!(mcp.len(), 1, "codex delivers stdio only");
         assert_eq!(mcp[0].name, "gh");
-        let (_, none) = resolve_step_deliverables(&conn, Some("ca1"), &[], "cursor");
+        let (_, none, _) = resolve_step_deliverables(&conn, Some("ca1"), &[], "cursor");
         assert!(none.is_empty(), "providers without MCP support get none");
     }
 
     #[test]
     fn deliverables_without_custom_agent_resolve_names_only() {
         let conn = library_db();
-        let (skills, mcp) =
+        let (skills, mcp, missing) =
             resolve_step_deliverables(&conn, None, &["code-review".into()], "claude");
         assert_eq!(skills.len(), 1);
         assert_eq!(skills[0].name, "code-review");
+        assert!(missing.is_empty(), "everything requested resolved");
         assert!(mcp.is_empty(), "MCP comes only via a custom agent (§5.1)");
     }
 }

--- a/src-tauri/src/workflow/definition.rs
+++ b/src-tauri/src/workflow/definition.rs
@@ -254,6 +254,149 @@ fn resolve_skill_names(conn: &Connection, skill_ids_json: &str) -> Result<Vec<St
     Ok(names)
 }
 
+// ───────────────────────── spawn deliverables (§3.2) ─────────────────────────
+
+/// Which MCP transports a provider can deliver at spawn — mirrors the app's
+/// `MCP_SUPPORT` map in `src/data/providers.ts`; the two must not drift.
+fn mcp_support(provider: &str) -> &'static str {
+    match provider {
+        "claude" => "all",
+        "codex" => "stdio",
+        _ => "none",
+    }
+}
+
+fn mcp_attachable(support: &str, transport: &str) -> bool {
+    support == "all" || (support == "stdio" && transport != "http")
+}
+
+/// Resolve a step's skill/MCP deliverables at spawn (§3.2) — the Rust twin of
+/// the app's `snapshotAgentDeliverables`: the custom agent's assigned skills
+/// and servers by id, plus the spec's `skills` names resolved against the
+/// library, filtered to what the provider can deliver. Snapshots are by value
+/// (the same semantics as the draft spawn path), so later library edits never
+/// touch a spawned step. Dangling ids and unknown names drop out silently —
+/// the import already warned about them.
+pub(super) fn resolve_step_deliverables(
+    conn: &Connection,
+    custom_agent_id: Option<&str>,
+    skill_names: &[String],
+    provider: &str,
+) -> (
+    Vec<crate::agent_profile::SkillSnapshot>,
+    Vec<crate::agent_profile::McpServerSnapshot>,
+) {
+    let mut skills: Vec<crate::agent_profile::SkillSnapshot> = Vec::new();
+    let mut mcp: Vec<crate::agent_profile::McpServerSnapshot> = Vec::new();
+
+    let assigned: (Vec<String>, Vec<String>) = custom_agent_id
+        .and_then(|id| {
+            conn.query_row(
+                "SELECT skill_ids, mcp_server_ids FROM custom_agents WHERE id = ?1",
+                [id],
+                |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)),
+            )
+            .optional()
+            .ok()
+            .flatten()
+        })
+        .map(|(s, m)| {
+            (
+                serde_json::from_str(&s).unwrap_or_default(),
+                serde_json::from_str(&m).unwrap_or_default(),
+            )
+        })
+        .unwrap_or_default();
+
+    // Custom-agent skills by id (assignment order), then spec names on top,
+    // deduped by name.
+    for skill_id in &assigned.0 {
+        if let Ok(Some(s)) = skill_row(conn, "id", skill_id) {
+            if !skills.iter().any(|k| k.name == s.name) {
+                skills.push(s);
+            }
+        }
+    }
+    for name in skill_names {
+        if let Ok(Some(s)) = skill_row(conn, "name", name) {
+            if !skills.iter().any(|k| k.name == s.name) {
+                skills.push(s);
+            }
+        }
+    }
+
+    let support = mcp_support(provider);
+    for server_id in &assigned.1 {
+        if let Ok(Some(snap)) = mcp_snapshot_row(conn, server_id) {
+            if mcp_attachable(support, &snap.transport) {
+                mcp.push(snap);
+            }
+        }
+    }
+    (skills, mcp)
+}
+
+fn skill_row(
+    conn: &Connection,
+    column: &str,
+    value: &str,
+) -> Result<Option<crate::agent_profile::SkillSnapshot>, rusqlite::Error> {
+    // `column` is a compile-time literal ("id" | "name"), never user input.
+    let sql = format!("SELECT name, description, body FROM skills WHERE {column} = ?1 LIMIT 1");
+    conn.query_row(&sql, [value], |r| {
+        Ok(crate::agent_profile::SkillSnapshot {
+            name: r.get(0)?,
+            description: r.get(1)?,
+            body: r.get(2)?,
+        })
+    })
+    .optional()
+}
+
+/// Resolve a registry row into the by-value spawn snapshot — the Rust twin of
+/// `snapshotMcpServer` in `src/storage/mcpServers.ts`: the command line is
+/// whitespace-split into command + args, env/header lines are parsed into
+/// pairs (KEY=VALUE / "Name: value", blanks and malformed lines skipped).
+fn mcp_snapshot_row(
+    conn: &Connection,
+    server_id: &str,
+) -> Result<Option<crate::agent_profile::McpServerSnapshot>, rusqlite::Error> {
+    conn.query_row(
+        "SELECT name, transport, command, env, url, headers FROM mcp_servers WHERE id = ?1",
+        [server_id],
+        |r| {
+            let command_line: String = r.get(2)?;
+            let env_text: String = r.get(3)?;
+            let headers_text: String = r.get(5)?;
+            let mut tokens = command_line.split_whitespace().map(str::to_string);
+            Ok(crate::agent_profile::McpServerSnapshot {
+                name: r.get(0)?,
+                transport: r.get(1)?,
+                command: tokens.next().unwrap_or_default(),
+                args: tokens.collect(),
+                env: parse_pair_lines(&env_text, '='),
+                url: r.get::<_, String>(4)?.trim().to_string(),
+                headers: parse_pair_lines(&headers_text, ':'),
+            })
+        },
+    )
+    .optional()
+}
+
+fn parse_pair_lines(text: &str, sep: char) -> Vec<(String, String)> {
+    text.lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            let (k, v) = line.split_once(sep)?;
+            let k = k.trim();
+            if k.is_empty() {
+                return None;
+            }
+            Some((k.to_string(), v.trim().to_string()))
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -384,5 +527,86 @@ mod tests {
         // Local id cleared; the alias keeps its original base.
         assert!(spec.agents["coder"].custom_agent.is_none());
         assert_eq!(spec.agents["coder"].base, "claude");
+    }
+
+    // ───────────────────── spawn deliverables (§3.2) ─────────────────────────
+
+    /// A library DB with the columns `resolve_step_deliverables` reads.
+    fn library_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE skills (
+                id TEXT PRIMARY KEY, name TEXT NOT NULL,
+                description TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT ''
+             );
+             CREATE TABLE mcp_servers (
+                id TEXT PRIMARY KEY, name TEXT NOT NULL,
+                transport TEXT NOT NULL DEFAULT 'stdio',
+                command TEXT NOT NULL DEFAULT '', env TEXT NOT NULL DEFAULT '',
+                url TEXT NOT NULL DEFAULT '', headers TEXT NOT NULL DEFAULT ''
+             );
+             CREATE TABLE custom_agents (
+                id TEXT PRIMARY KEY,
+                skill_ids TEXT NOT NULL DEFAULT '[]',
+                mcp_server_ids TEXT NOT NULL DEFAULT '[]'
+             );
+             INSERT INTO skills VALUES
+                ('sk1', 'code-review', 'review well', '# Review'),
+                ('sk2', 'tests-first', 'tests first', '# Tests');
+             INSERT INTO mcp_servers VALUES
+                ('m1', 'gh', 'stdio', 'npx -y gh-mcp',
+                 'TOKEN=t' || char(10) || 'BAD-LINE', '', ''),
+                ('m2', 'web', 'http', '', '', ' https://mcp.example ', 'X-Key: abc');
+             INSERT INTO custom_agents VALUES
+                ('ca1', '[\"sk1\",\"dangling\"]', '[\"m1\",\"m2\",\"gone\"]');",
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn deliverables_resolve_custom_agent_ids_plus_spec_names() {
+        let conn = library_db();
+        let (skills, mcp) = resolve_step_deliverables(
+            &conn,
+            Some("ca1"),
+            &["tests-first".into(), "code-review".into(), "unknown".into()],
+            "claude",
+        );
+        // ca1's sk1 first (assignment order), then the spec name that isn't a
+        // duplicate; the dangling id and unknown name drop silently.
+        let names: Vec<&str> = skills.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["code-review", "tests-first"]);
+        assert_eq!(skills[0].body, "# Review");
+        // claude supports all transports: both servers, parsed.
+        assert_eq!(mcp.len(), 2);
+        assert_eq!(mcp[0].command, "npx");
+        assert_eq!(mcp[0].args, vec!["-y", "gh-mcp"]);
+        assert_eq!(mcp[0].env, vec![("TOKEN".to_string(), "t".to_string())]);
+        assert_eq!(mcp[1].url, "https://mcp.example");
+        assert_eq!(
+            mcp[1].headers,
+            vec![("X-Key".to_string(), "abc".to_string())]
+        );
+    }
+
+    #[test]
+    fn deliverables_filter_http_servers_for_stdio_only_providers() {
+        let conn = library_db();
+        let (_, mcp) = resolve_step_deliverables(&conn, Some("ca1"), &[], "codex");
+        assert_eq!(mcp.len(), 1, "codex delivers stdio only");
+        assert_eq!(mcp[0].name, "gh");
+        let (_, none) = resolve_step_deliverables(&conn, Some("ca1"), &[], "cursor");
+        assert!(none.is_empty(), "providers without MCP support get none");
+    }
+
+    #[test]
+    fn deliverables_without_custom_agent_resolve_names_only() {
+        let conn = library_db();
+        let (skills, mcp) =
+            resolve_step_deliverables(&conn, None, &["code-review".into()], "claude");
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].name, "code-review");
+        assert!(mcp.is_empty(), "MCP comes only via a custom agent (§5.1)");
     }
 }

--- a/src-tauri/src/workflow/definition.rs
+++ b/src-tauri/src/workflow/definition.rs
@@ -270,47 +270,64 @@ fn mcp_attachable(support: &str, transport: &str) -> bool {
     support == "all" || (support == "stdio" && transport != "http")
 }
 
+/// What [`resolve_step_deliverables`] found for a step at spawn: the by-value
+/// snapshots to deliver, plus everything the definition requested that no
+/// longer resolves — the caller journals those as warnings (warn-don't-fail,
+/// the same policy as import).
+pub(super) struct StepDeliverables {
+    pub skills: Vec<crate::agent_profile::SkillSnapshot>,
+    pub mcp_servers: Vec<crate::agent_profile::McpServerSnapshot>,
+    /// Skill names/ids the definition requested that no longer resolve
+    /// (deleted since the save).
+    pub missing_skills: Vec<String>,
+    /// The step's `custom_agent` id when its row no longer resolves — the step
+    /// spawns without that agent's skills and MCP servers.
+    pub missing_custom_agent: Option<String>,
+}
+
 /// Resolve a step's skill/MCP deliverables at spawn (§3.2) — the Rust twin of
 /// the app's `snapshotAgentDeliverables`: the custom agent's assigned skills
 /// and servers by id, plus the spec's `skills` names resolved against the
 /// library, filtered to what the provider can deliver. Snapshots are by value
 /// (the same semantics as the draft spawn path), so later library edits never
-/// touch a spawned step. A skill that no longer resolves (deleted since the
-/// definition was saved) is returned in the third element so the caller can
-/// journal a warning — the step still spawns, matching import's
-/// warn-don't-fail policy.
+/// touch a spawned step. Anything that no longer resolves — a skill, or the
+/// custom agent itself — is reported on [`StepDeliverables`] so the caller can
+/// journal a warning; the step still spawns.
 pub(super) fn resolve_step_deliverables(
     conn: &Connection,
     custom_agent_id: Option<&str>,
     skill_names: &[String],
     provider: &str,
-) -> (
-    Vec<crate::agent_profile::SkillSnapshot>,
-    Vec<crate::agent_profile::McpServerSnapshot>,
-    Vec<String>,
-) {
+) -> StepDeliverables {
     let mut skills: Vec<crate::agent_profile::SkillSnapshot> = Vec::new();
     let mut mcp: Vec<crate::agent_profile::McpServerSnapshot> = Vec::new();
     let mut missing_skills: Vec<String> = Vec::new();
+    let mut missing_custom_agent: Option<String> = None;
 
-    let assigned: (Vec<String>, Vec<String>) = custom_agent_id
-        .and_then(|id| {
-            conn.query_row(
-                "SELECT skill_ids, mcp_server_ids FROM custom_agents WHERE id = ?1",
-                [id],
-                |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)),
-            )
-            .optional()
-            .ok()
-            .flatten()
-        })
-        .map(|(s, m)| {
-            (
-                serde_json::from_str(&s).unwrap_or_default(),
-                serde_json::from_str(&m).unwrap_or_default(),
-            )
-        })
-        .unwrap_or_default();
+    let assigned: (Vec<String>, Vec<String>) = match custom_agent_id {
+        None => Default::default(),
+        Some(id) => {
+            let row = conn
+                .query_row(
+                    "SELECT skill_ids, mcp_server_ids FROM custom_agents WHERE id = ?1",
+                    [id],
+                    |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)),
+                )
+                .optional()
+                .ok()
+                .flatten();
+            match row {
+                Some((s, m)) => (
+                    serde_json::from_str(&s).unwrap_or_default(),
+                    serde_json::from_str(&m).unwrap_or_default(),
+                ),
+                None => {
+                    missing_custom_agent = Some(id.to_string());
+                    Default::default()
+                }
+            }
+        }
+    };
 
     // Custom-agent skills by id (assignment order), then spec names on top,
     // deduped by name.
@@ -343,7 +360,12 @@ pub(super) fn resolve_step_deliverables(
             }
         }
     }
-    (skills, mcp, missing_skills)
+    StepDeliverables {
+        skills,
+        mcp_servers: mcp,
+        missing_skills,
+        missing_custom_agent,
+    }
 }
 
 fn skill_row(
@@ -577,7 +599,7 @@ mod tests {
     #[test]
     fn deliverables_resolve_custom_agent_ids_plus_spec_names() {
         let conn = library_db();
-        let (skills, mcp, missing) = resolve_step_deliverables(
+        let d = resolve_step_deliverables(
             &conn,
             Some("ca1"),
             &["tests-first".into(), "code-review".into(), "unknown".into()],
@@ -585,9 +607,11 @@ mod tests {
         );
         // ca1's sk1 first (assignment order), then the spec name that isn't a
         // duplicate; the dangling id and unknown name are reported as missing.
-        let names: Vec<&str> = skills.iter().map(|s| s.name.as_str()).collect();
+        let names: Vec<&str> = d.skills.iter().map(|s| s.name.as_str()).collect();
         assert_eq!(names, vec!["code-review", "tests-first"]);
-        assert_eq!(missing, vec!["dangling", "unknown"]);
+        assert_eq!(d.missing_skills, vec!["dangling", "unknown"]);
+        assert!(d.missing_custom_agent.is_none());
+        let (skills, mcp) = (d.skills, d.mcp_servers);
         assert_eq!(skills[0].body, "# Review");
         // claude supports all transports: both servers, parsed.
         assert_eq!(mcp.len(), 2);
@@ -604,21 +628,35 @@ mod tests {
     #[test]
     fn deliverables_filter_http_servers_for_stdio_only_providers() {
         let conn = library_db();
-        let (_, mcp, _) = resolve_step_deliverables(&conn, Some("ca1"), &[], "codex");
+        let mcp = resolve_step_deliverables(&conn, Some("ca1"), &[], "codex").mcp_servers;
         assert_eq!(mcp.len(), 1, "codex delivers stdio only");
         assert_eq!(mcp[0].name, "gh");
-        let (_, none, _) = resolve_step_deliverables(&conn, Some("ca1"), &[], "cursor");
+        let none = resolve_step_deliverables(&conn, Some("ca1"), &[], "cursor").mcp_servers;
         assert!(none.is_empty(), "providers without MCP support get none");
     }
 
     #[test]
     fn deliverables_without_custom_agent_resolve_names_only() {
         let conn = library_db();
-        let (skills, mcp, missing) =
-            resolve_step_deliverables(&conn, None, &["code-review".into()], "claude");
-        assert_eq!(skills.len(), 1);
-        assert_eq!(skills[0].name, "code-review");
-        assert!(missing.is_empty(), "everything requested resolved");
-        assert!(mcp.is_empty(), "MCP comes only via a custom agent (§5.1)");
+        let d = resolve_step_deliverables(&conn, None, &["code-review".into()], "claude");
+        assert_eq!(d.skills.len(), 1);
+        assert_eq!(d.skills[0].name, "code-review");
+        assert!(d.missing_skills.is_empty(), "everything requested resolved");
+        assert!(d.missing_custom_agent.is_none());
+        assert!(
+            d.mcp_servers.is_empty(),
+            "MCP comes only via a custom agent (§5.1)"
+        );
+    }
+
+    #[test]
+    fn deliverables_report_a_deleted_custom_agent() {
+        let conn = library_db();
+        let d = resolve_step_deliverables(&conn, Some("gone"), &["code-review".into()], "claude");
+        assert_eq!(d.missing_custom_agent.as_deref(), Some("gone"));
+        // Spec-named skills still resolve; only the agent's assignments are lost.
+        assert_eq!(d.skills.len(), 1);
+        assert!(d.mcp_servers.is_empty());
+        assert!(d.missing_skills.is_empty());
     }
 }

--- a/src-tauri/src/workflow/definition.rs
+++ b/src-tauri/src/workflow/definition.rs
@@ -278,11 +278,14 @@ pub(super) struct StepDeliverables {
     pub skills: Vec<crate::agent_profile::SkillSnapshot>,
     pub mcp_servers: Vec<crate::agent_profile::McpServerSnapshot>,
     /// Skill names/ids the definition requested that no longer resolve
-    /// (deleted since the save).
+    /// (deleted since the save) — or a descriptive entry when the custom
+    /// agent's `skill_ids` column itself is unreadable.
     pub missing_skills: Vec<String>,
     /// MCP server ids the custom agent assigned that no longer resolve
-    /// (deleted since the save). Provider-filtered transports are *not*
-    /// listed — that gating is by design and mirrors the agent editor.
+    /// (deleted since the save) — or a descriptive entry when the agent's
+    /// `mcp_server_ids` column itself is unreadable. Provider-filtered
+    /// transports are *not* listed — that gating is by design and mirrors
+    /// the agent editor.
     pub missing_mcp_servers: Vec<String>,
     /// The step's `custom_agent` id when its row no longer resolves — the step
     /// spawns without that agent's skills and MCP servers.
@@ -322,10 +325,32 @@ pub(super) fn resolve_step_deliverables(
                 .ok()
                 .flatten();
             match row {
-                Some((s, m)) => (
-                    serde_json::from_str(&s).unwrap_or_default(),
-                    serde_json::from_str(&m).unwrap_or_default(),
-                ),
+                // A malformed assignment column must not collapse to "nothing
+                // requested" — that would skip every missing-deliverable check
+                // below and lose the agent's capabilities with no warning. The
+                // parse failure lands in the respective missing list as a
+                // descriptive entry, so the usual event fires and the timeline
+                // says exactly what was unreadable.
+                Some((s, m)) => {
+                    let skill_ids = match serde_json::from_str(&s) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            missing_skills
+                                .push(format!("custom agent '{id}' skill_ids unreadable: {e}"));
+                            Vec::new()
+                        }
+                    };
+                    let server_ids = match serde_json::from_str(&m) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            missing_mcp_servers.push(format!(
+                                "custom agent '{id}' mcp_server_ids unreadable: {e}"
+                            ));
+                            Vec::new()
+                        }
+                    };
+                    (skill_ids, server_ids)
+                }
                 None => {
                     missing_custom_agent = Some(id.to_string());
                     Default::default()
@@ -602,7 +627,8 @@ mod tests {
                  'TOKEN=t' || char(10) || 'BAD-LINE', '', ''),
                 ('m2', 'web', 'http', '', '', ' https://mcp.example ', 'X-Key: abc');
              INSERT INTO custom_agents VALUES
-                ('ca1', '[\"sk1\",\"dangling\"]', '[\"m1\",\"m2\",\"gone\"]');",
+                ('ca1', '[\"sk1\",\"dangling\"]', '[\"m1\",\"m2\",\"gone\"]'),
+                ('ca-corrupt', 'not-json', '{\"nope\"');",
         )
         .unwrap();
         conn
@@ -680,5 +706,27 @@ mod tests {
         // The agent row itself is the missing thing — its unknowable server
         // assignments are not double-reported.
         assert!(d.missing_mcp_servers.is_empty());
+    }
+
+    #[test]
+    fn deliverables_report_unreadable_assignment_columns() {
+        let conn = library_db();
+        // The row exists but both assignment columns are malformed JSON: this
+        // must warn per class, not collapse to "nothing requested".
+        let d = resolve_step_deliverables(&conn, Some("ca-corrupt"), &[], "claude");
+        assert!(d.missing_custom_agent.is_none(), "the row itself resolves");
+        assert_eq!(d.missing_skills.len(), 1);
+        assert!(
+            d.missing_skills[0].contains("'ca-corrupt' skill_ids unreadable"),
+            "{:?}",
+            d.missing_skills
+        );
+        assert_eq!(d.missing_mcp_servers.len(), 1);
+        assert!(
+            d.missing_mcp_servers[0].contains("'ca-corrupt' mcp_server_ids unreadable"),
+            "{:?}",
+            d.missing_mcp_servers
+        );
+        assert!(d.skills.is_empty() && d.mcp_servers.is_empty());
     }
 }

--- a/src-tauri/src/workflow/definition.rs
+++ b/src-tauri/src/workflow/definition.rs
@@ -280,6 +280,10 @@ pub(super) struct StepDeliverables {
     /// Skill names/ids the definition requested that no longer resolve
     /// (deleted since the save).
     pub missing_skills: Vec<String>,
+    /// MCP server ids the custom agent assigned that no longer resolve
+    /// (deleted since the save). Provider-filtered transports are *not*
+    /// listed — that gating is by design and mirrors the agent editor.
+    pub missing_mcp_servers: Vec<String>,
     /// The step's `custom_agent` id when its row no longer resolves — the step
     /// spawns without that agent's skills and MCP servers.
     pub missing_custom_agent: Option<String>,
@@ -302,6 +306,7 @@ pub(super) fn resolve_step_deliverables(
     let mut skills: Vec<crate::agent_profile::SkillSnapshot> = Vec::new();
     let mut mcp: Vec<crate::agent_profile::McpServerSnapshot> = Vec::new();
     let mut missing_skills: Vec<String> = Vec::new();
+    let mut missing_mcp_servers: Vec<String> = Vec::new();
     let mut missing_custom_agent: Option<String> = None;
 
     let assigned: (Vec<String>, Vec<String>) = match custom_agent_id {
@@ -354,16 +359,23 @@ pub(super) fn resolve_step_deliverables(
 
     let support = mcp_support(provider);
     for server_id in &assigned.1 {
-        if let Ok(Some(snap)) = mcp_snapshot_row(conn, server_id) {
-            if mcp_attachable(support, &snap.transport) {
-                mcp.push(snap);
+        match mcp_snapshot_row(conn, server_id) {
+            Ok(Some(snap)) => {
+                if mcp_attachable(support, &snap.transport) {
+                    mcp.push(snap);
+                }
             }
+            // A dangling id (server deleted since the agent was saved) is a
+            // real capability loss — report it; a transport the provider can't
+            // run is filtered above by design and stays silent.
+            _ => missing_mcp_servers.push(server_id.clone()),
         }
     }
     StepDeliverables {
         skills,
         mcp_servers: mcp,
         missing_skills,
+        missing_mcp_servers,
         missing_custom_agent,
     }
 }
@@ -610,6 +622,9 @@ mod tests {
         let names: Vec<&str> = d.skills.iter().map(|s| s.name.as_str()).collect();
         assert_eq!(names, vec!["code-review", "tests-first"]);
         assert_eq!(d.missing_skills, vec!["dangling", "unknown"]);
+        // ca1's deleted server id is reported — a saved agent must never lose
+        // part of its requested capability snapshot silently.
+        assert_eq!(d.missing_mcp_servers, vec!["gone"]);
         assert!(d.missing_custom_agent.is_none());
         let (skills, mcp) = (d.skills, d.mcp_servers);
         assert_eq!(skills[0].body, "# Review");
@@ -628,9 +643,12 @@ mod tests {
     #[test]
     fn deliverables_filter_http_servers_for_stdio_only_providers() {
         let conn = library_db();
-        let mcp = resolve_step_deliverables(&conn, Some("ca1"), &[], "codex").mcp_servers;
-        assert_eq!(mcp.len(), 1, "codex delivers stdio only");
-        assert_eq!(mcp[0].name, "gh");
+        let d = resolve_step_deliverables(&conn, Some("ca1"), &[], "codex");
+        assert_eq!(d.mcp_servers.len(), 1, "codex delivers stdio only");
+        assert_eq!(d.mcp_servers[0].name, "gh");
+        // The provider-filtered http server ('m2') is by-design gating, never a
+        // missing warning; only the genuinely deleted id is reported.
+        assert_eq!(d.missing_mcp_servers, vec!["gone"]);
         let none = resolve_step_deliverables(&conn, Some("ca1"), &[], "cursor").mcp_servers;
         assert!(none.is_empty(), "providers without MCP support get none");
     }
@@ -642,6 +660,7 @@ mod tests {
         assert_eq!(d.skills.len(), 1);
         assert_eq!(d.skills[0].name, "code-review");
         assert!(d.missing_skills.is_empty(), "everything requested resolved");
+        assert!(d.missing_mcp_servers.is_empty());
         assert!(d.missing_custom_agent.is_none());
         assert!(
             d.mcp_servers.is_empty(),
@@ -658,5 +677,8 @@ mod tests {
         assert_eq!(d.skills.len(), 1);
         assert!(d.mcp_servers.is_empty());
         assert!(d.missing_skills.is_empty());
+        // The agent row itself is the missing thing — its unknowable server
+        // assignments are not double-reported.
+        assert!(d.missing_mcp_servers.is_empty());
     }
 }

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -1212,7 +1212,24 @@ async fn run_parallel_stage(
     // from timestamps so a same-millisecond raced sibling can't be mistaken for it.
     let mut any_winner: Option<String> = None;
 
-    while let Some(joined) = set.join_next().await {
+    let run_cancel = ctx.cancel.clone();
+    loop {
+        // Race the join against a run-level cancel (§6.5): a user cancel must
+        // wind the whole stage down promptly, not after every child ran to its
+        // natural terminal. Setting `stage_cancel` stops new launches and trips
+        // the in-flight children's own cancel races; the loop keeps draining so
+        // their teardown (abandon + archive) completes.
+        let joined = tokio::select! {
+            biased;
+            _ = attempt::wait_cancelled(&run_cancel), if !stage_cancel.load(Ordering::SeqCst) => {
+                stage_cancel.store(true, Ordering::SeqCst);
+                continue;
+            }
+            j = set.join_next() => match j {
+                Some(j) => j,
+                None => break,
+            },
+        };
         let res = match joined {
             Ok(r) => r,
             Err(e) => {
@@ -1272,6 +1289,23 @@ async fn run_parallel_stage(
         let conn = ctx.db.lock();
         ledger.checkpoint_wall(super::now_ms());
         persist_spent(&conn, run_id, ledger);
+    }
+
+    // A run-level cancel supersedes join evaluation (§6.5): the children were
+    // wound down above; write the terminal status now — like the drive loop's
+    // between-blocks check, nothing after a Stop will.
+    if run_cancel.load(Ordering::SeqCst) {
+        let conn = ctx.db.lock();
+        journal_event(
+            &conn,
+            ctx.app.as_ref(),
+            run_id,
+            event_type::RUN_CANCELED,
+            None,
+            &json!({}),
+        );
+        set_status(&conn, ctx.app.as_ref(), run_id, "canceled", None, None);
+        return Ok(StageFlow::Stop);
     }
 
     match par.join {
@@ -1860,13 +1894,17 @@ async fn drive_child(c: ChildCtx, stage_entry_sha: Option<String>) -> ChildResul
         };
 
         let params = AttemptParams {
-            spawn_req: build_spawn_req(
-                &c.agent_spec,
-                &c.fork_base,
-                &c.repo,
-                &c.run_repo,
-                &c.run_id,
-            ),
+            spawn_req: {
+                let conn = c.db.lock();
+                build_spawn_req(
+                    &conn,
+                    &c.agent_spec,
+                    &c.fork_base,
+                    &c.repo,
+                    &c.run_repo,
+                    &c.run_id,
+                )
+            },
             pre_spawned: None,
             blackboard: c.blackboard.clone(),
             exec_id: exec_id.clone(),
@@ -2109,25 +2147,34 @@ async fn drive_child(c: ChildCtx, stage_entry_sha: Option<String>) -> ChildResul
     }
 }
 
-/// Assemble a [`SpawnReq`] for a step / parallel-child agent. Resolving the
-/// spec's skill / MCP names to snapshots is a documented S4b follow-up; the
-/// engine spawns with provider + brief for now (the blackboard write-grant is
-/// derived from `owner_run_id` at spawn).
+/// Assemble a [`SpawnReq`] for a step / parallel-child agent. The step's
+/// skill/MCP deliverables are resolved to by-value snapshots here — at spawn
+/// (§3.2), the same semantics as the draft spawn path — so a custom-agent step
+/// carries its skills and deliverable MCP servers, and later library edits
+/// never touch a spawned step. The blackboard write-grant is derived from
+/// `owner_run_id` at spawn.
 fn build_spawn_req(
+    conn: &Connection,
     agent_spec: &AgentSpec,
     fork_base: &str,
     repo: &Path,
     run_repo: &Path,
     run_id: &str,
 ) -> SpawnReq {
+    let (skills, mcp_servers) = super::definition::resolve_step_deliverables(
+        conn,
+        agent_spec.custom_agent.as_deref(),
+        &agent_spec.skills,
+        &agent_spec.base,
+    );
     SpawnReq {
         repo_path: repo.to_path_buf(),
         provider: agent_spec.base.clone(),
         model: agent_spec.model.clone(),
         instructions: agent_spec.instructions.clone(),
         custom_agent_id: agent_spec.custom_agent.clone(),
-        skills: vec![],
-        mcp_servers: vec![],
+        skills,
+        mcp_servers,
         fork_base: Some(fork_base.to_string()),
         run_repo: Some(run_repo.to_path_buf()),
         owner_run_id: run_id.to_string(),
@@ -2268,13 +2315,11 @@ async fn run_orchestrate_stage(
         let conn = ctx.db.lock();
         create_step_exec(&conn, &orch_exec, run_id, &orch_step_id, 1, 0, "verdict");
     }
-    let spawned = match ctx
-        .driver
-        .spawn(build_spawn_req(
-            orch_agent, fork_base, repo, run_repo, run_id,
-        ))
-        .await
-    {
+    let orch_req = {
+        let conn = ctx.db.lock();
+        build_spawn_req(&conn, orch_agent, fork_base, repo, run_repo, run_id)
+    };
+    let spawned = match ctx.driver.spawn(orch_req).await {
         Ok(s) => s,
         Err(e) => {
             let conn = ctx.db.lock();
@@ -3727,17 +3772,18 @@ async fn drive_orch_child(c: ChildCtx, stage_entry_sha: Option<String>) -> OrchC
         }
 
         // Spawn and stamp the agent id BEFORE the turn (§10.2).
-        let spawned = match c
-            .driver
-            .spawn(build_spawn_req(
+        let child_req = {
+            let conn = c.db.lock();
+            build_spawn_req(
+                &conn,
                 &c.agent_spec,
                 &c.fork_base,
                 &c.repo,
                 &c.run_repo,
                 &c.run_id,
-            ))
-            .await
-        {
+            )
+        };
+        let spawned = match c.driver.spawn(child_req).await {
             Ok(s) => s,
             Err(e) => {
                 let error = format!("spawn failed: {e}");
@@ -3802,13 +3848,17 @@ async fn drive_orch_child(c: ChildCtx, stage_entry_sha: Option<String>) -> OrchC
         };
 
         let params = AttemptParams {
-            spawn_req: build_spawn_req(
-                &c.agent_spec,
-                &c.fork_base,
-                &c.repo,
-                &c.run_repo,
-                &c.run_id,
-            ),
+            spawn_req: {
+                let conn = c.db.lock();
+                build_spawn_req(
+                    &conn,
+                    &c.agent_spec,
+                    &c.fork_base,
+                    &c.repo,
+                    &c.run_repo,
+                    &c.run_id,
+                )
+            },
             pre_spawned: Some(spawned),
             blackboard: c.blackboard.clone(),
             exec_id: exec_id.clone(),
@@ -4645,7 +4695,10 @@ async fn execute_step(
         };
 
         let params = AttemptParams {
-            spawn_req: build_spawn_req(agent_spec, fork_ref, env.repo, env.run_repo, run_id),
+            spawn_req: {
+                let conn = ctx.db.lock();
+                build_spawn_req(&conn, agent_spec, fork_ref, env.repo, env.run_repo, run_id)
+            },
             pre_spawned: None,
             blackboard: env.blackboard.to_path_buf(),
             exec_id: exec_id.clone(),
@@ -4658,9 +4711,10 @@ async fn execute_step(
             // A loop's `until` step must not be re-prompted on "revise": that is
             // a legitimate turn end, not an unmet gate to nag about (§6.6).
             reprompt_on_block: !is_until,
-            // Linear/loop steps are never cancelled mid-attempt (only parallel
-            // losers are, §6.6), so this flag is never set.
-            cancel: Arc::new(AtomicBool::new(false)),
+            // The run's cancel flag (§6.5): `WorkflowService::cancel` sets it and
+            // the attempt's cancel checkpoints/races observe it, so a cancel
+            // lands mid-spawn or mid-turn instead of after the block finishes.
+            cancel: ctx.cancel.clone(),
             // Shared with the run's `RunHandle` so the comms router and this
             // attempt observe the same pending-ask flag (§10.4).
             pending_ask: ctx.pending_ask.clone(),
@@ -4920,14 +4974,39 @@ async fn execute_step(
                 return Ok(StepFlow::Halt);
             }
             AttemptOutcome::Canceled => {
-                // Linear/loop steps never pass a live cancel flag, so this is
-                // unreachable in practice; handle it defensively as an abandonment
-                // (the agent is already stopped by `run_attempt`).
-                let conn = ctx.db.lock();
-                let _ = conn.execute(
-                    "UPDATE wf_step_exec SET status = 'abandoned', ended_at = ?1 WHERE id = ?2",
-                    rusqlite::params![super::now_ms(), exec_id],
-                );
+                // The run was cancelled mid-attempt (§6.5). `run_attempt` already
+                // stopped the agent; abandon the row, archive the chat, and
+                // complete the cancel here — the drive loop's between-blocks
+                // check never runs again after a Halt, so the terminal status
+                // must be written now. Lock scoped so the guard drops before
+                // the archive await.
+                {
+                    let conn = ctx.db.lock();
+                    let _ = conn.execute(
+                        "UPDATE wf_step_exec SET status = 'abandoned', ended_at = ?1 WHERE id = ?2",
+                        rusqlite::params![super::now_ms(), exec_id],
+                    );
+                    journal_event(
+                        &conn,
+                        ctx.app.as_ref(),
+                        run_id,
+                        event_type::ATTEMPT_ABANDONED,
+                        Some(&exec_id),
+                        &json!({ "cause": "canceled" }),
+                    );
+                    journal_event(
+                        &conn,
+                        ctx.app.as_ref(),
+                        run_id,
+                        event_type::RUN_CANCELED,
+                        None,
+                        &json!({}),
+                    );
+                    set_status(&conn, ctx.app.as_ref(), run_id, "canceled", None, None);
+                }
+                if let Some(agent_id) = &result.agent_id {
+                    let _ = ctx.driver.archive(agent_id).await;
+                }
                 return Ok(StepFlow::Halt);
             }
         }
@@ -5374,10 +5453,65 @@ fn resume_line_state(
                     return (gitops::step_ref(&exec_id), Some(exec_id));
                 }
             }
+            // A completed loop advances the line to its most recent `done` body
+            // step across iterations and retries (§6.6). Without this arm a
+            // resume past the loop refetches an earlier block's ref (or the run
+            // base) and every commit the loop ferried silently drops off the
+            // branch — and a finalize-on-resume skips the push entirely.
+            Block::Loop(l) => {
+                let ids: Vec<String> = l
+                    .body
+                    .iter()
+                    .filter_map(|b| match b {
+                        Block::Step(s) => Some(s.id.clone()),
+                        _ => None,
+                    })
+                    .collect();
+                if let Some(exec_id) = latest_done_exec_for_steps(conn, run_id, &ids) {
+                    return (gitops::step_ref(&exec_id), Some(exec_id));
+                }
+            }
+            // An orchestrate stage advances the line only when a composed
+            // sub-run merged (§10.3) — recorded via the same synthetic
+            // `__merge_<i>` exec as a parallel merge stage. `integrate: none`
+            // children never move it.
+            Block::Orchestrate(_) => {
+                if let Some(exec_id) = latest_done_exec_for_step(conn, run_id, &merge_step_id(i)) {
+                    return (gitops::step_ref(&exec_id), Some(exec_id));
+                }
+            }
             _ => {}
         }
     }
     (base_sha.to_string(), None)
+}
+
+/// The most recent `done` exec among a set of step ids (a loop's body): the
+/// line's tip after a completed loop. `rowid DESC` picks the latest completion
+/// across iterations and retries, exactly like [`latest_done_exec_for_step`].
+fn latest_done_exec_for_steps(
+    conn: &Connection,
+    run_id: &str,
+    step_ids: &[String],
+) -> Option<String> {
+    if step_ids.is_empty() {
+        return None;
+    }
+    let placeholders = vec!["?"; step_ids.len()].join(",");
+    let sql = format!(
+        "SELECT id FROM wf_step_exec
+         WHERE run_id = ? AND status = 'done' AND step_id IN ({placeholders})
+         ORDER BY rowid DESC LIMIT 1"
+    );
+    let mut params: Vec<&dyn rusqlite::ToSql> = Vec::with_capacity(step_ids.len() + 1);
+    params.push(&run_id);
+    for s in step_ids {
+        params.push(s);
+    }
+    conn.query_row(&sql, params.as_slice(), |r| r.get(0))
+        .optional()
+        .ok()
+        .flatten()
 }
 
 /// The ids of a run's composed sub-runs (spec §10.3), for the cancel-cascade.
@@ -9058,5 +9192,282 @@ mod tests {
             ) >= 1,
             "the sub-run merged at the join"
         );
+    }
+
+    // ───────────────── run-level cancel mid-attempt / mid-stage (§6.5) ─────────
+
+    /// A driver whose turns never end: `send_message` flips the agent to
+    /// `Running` and returns, but `Idle` never follows — the attempt sits in its
+    /// turn until something (the cancel race) ends it. Models the H2 scenario:
+    /// a user cancel landing while work is in flight.
+    struct HoldDriver {
+        root: PathBuf,
+        tx: broadcast::Sender<StatusEvent>,
+        state: parking_lot::Mutex<StubState>,
+        turns_started: std::sync::atomic::AtomicUsize,
+        stopped: parking_lot::Mutex<Vec<String>>,
+    }
+    impl HoldDriver {
+        fn new(root: PathBuf) -> Arc<Self> {
+            Arc::new(Self {
+                root,
+                tx: broadcast::channel(256).0,
+                state: parking_lot::Mutex::new(StubState::default()),
+                turns_started: std::sync::atomic::AtomicUsize::new(0),
+                stopped: parking_lot::Mutex::new(Vec::new()),
+            })
+        }
+        fn set(&self, id: &str, s: AgentStatus) {
+            self.state.lock().statuses.insert(id.to_string(), s.clone());
+            let _ = self.tx.send(StatusEvent {
+                agent_id: id.to_string(),
+                status: s,
+            });
+        }
+    }
+    impl AgentDriver for HoldDriver {
+        fn spawn(
+            &self,
+            req: SpawnReq,
+        ) -> super::super::driver::BoxFuture<'_, Result<super::super::driver::SpawnedAgent>>
+        {
+            Box::pin(async move {
+                let id = {
+                    let mut st = self.state.lock();
+                    st.count += 1;
+                    format!("hold-{}", st.count)
+                };
+                let dest = self.root.join(&id);
+                let base_ref = req.fork_base.clone().unwrap();
+                let spec = crate::sandbox::provision::CheckoutSpec {
+                    source_repo: &req.repo_path,
+                    base_ref: &base_ref,
+                    dest: &dest,
+                };
+                crate::sandbox::provision::provision_forking_run_repo(
+                    &spec,
+                    req.run_repo.as_ref().unwrap(),
+                )
+                .await?;
+                self.state.lock().worktrees.insert(id.clone(), dest.clone());
+                self.set(&id, AgentStatus::Idle);
+                Ok(super::super::driver::SpawnedAgent {
+                    agent_id: id,
+                    worktree: dest,
+                })
+            })
+        }
+        fn status(&self, id: &str) -> Option<AgentStatus> {
+            self.state.lock().statuses.get(id).cloned()
+        }
+        fn subscribe(&self) -> broadcast::Receiver<StatusEvent> {
+            self.tx.subscribe()
+        }
+        fn send_message<'a>(
+            &'a self,
+            id: &'a str,
+            _text: String,
+        ) -> super::super::driver::BoxFuture<'a, Result<()>> {
+            Box::pin(async move {
+                self.set(id, AgentStatus::Running);
+                self.turns_started
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(()) // Idle never arrives — the turn hangs until cancelled.
+            })
+        }
+        fn stop<'a>(&'a self, id: &'a str) -> super::super::driver::BoxFuture<'a, Result<()>> {
+            self.stopped.lock().push(id.to_string());
+            Box::pin(async { Ok(()) })
+        }
+        fn archive<'a>(&'a self, _id: &'a str) -> super::super::driver::BoxFuture<'a, Result<()>> {
+            Box::pin(async { Ok(()) })
+        }
+        fn last_activity(&self, _id: &str) -> Option<i64> {
+            // "Recent activity" forever, so the stall watchdog never fires and
+            // the cancel race is the only thing that can end the turn.
+            Some(crate::workflow::now_ms())
+        }
+        fn turn_usage(&self, _id: &str) -> Option<super::super::driver::TurnUsage> {
+            None
+        }
+    }
+
+    /// Wait (bounded) until `n` turns have started on the driver.
+    async fn await_turns(driver: &HoldDriver, n: usize) {
+        for _ in 0..400 {
+            if driver
+                .turns_started
+                .load(std::sync::atomic::Ordering::SeqCst)
+                >= n
+            {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        panic!("driver never reached {n} started turn(s)");
+    }
+
+    #[tokio::test]
+    async fn cancel_mid_turn_stops_the_attempt_and_cancels_the_run() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (db, ws) = scaffold_one_step(tmp.path(), "run-midcancel", "wf/mc-1");
+        let driver = HoldDriver::new(ws);
+        let cancel = Arc::new(AtomicBool::new(false));
+        let ctx = RunCtx {
+            db: db.clone(),
+            driver: driver.clone(),
+            app: None,
+            cancel: cancel.clone(),
+            pending_ask: Arc::new(AtomicBool::new(false)),
+            deadlines: Deadlines::default(),
+            runs: None,
+        };
+        let drive = tokio::spawn(async move { drive_run(&ctx, "run-midcancel").await });
+        await_turns(&driver, 1).await;
+        cancel.store(true, Ordering::SeqCst); // user cancel lands mid-turn
+        drive.await.unwrap();
+
+        assert_eq!(run_status_str(&db, "run-midcancel"), "canceled");
+        assert_eq!(
+            count_children(&db, "run-midcancel", "abandoned"),
+            1,
+            "the in-flight attempt was abandoned, not left running"
+        );
+        assert!(
+            !driver.stopped.lock().is_empty(),
+            "the live agent process was stopped"
+        );
+        assert!(
+            count(
+                &db,
+                "SELECT COUNT(*) FROM wf_event WHERE run_id='run-midcancel' AND type='run_canceled'"
+            ) >= 1,
+            "the cancel was journaled"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_mid_parallel_stage_winds_children_down_and_cancels_the_run() {
+        let tmp = tempfile::tempdir().unwrap();
+        let children = vec![cstep("a", ""), cstep("b", "")];
+        let (db, ws, _base) = scaffold_parallel(tmp.path(), "run-pcancel", Join::All, &children);
+        let driver = HoldDriver::new(ws);
+        let cancel = Arc::new(AtomicBool::new(false));
+        let ctx = RunCtx {
+            db: db.clone(),
+            driver: driver.clone(),
+            app: None,
+            cancel: cancel.clone(),
+            pending_ask: Arc::new(AtomicBool::new(false)),
+            deadlines: Deadlines::default(),
+            runs: None,
+        };
+        let drive = tokio::spawn(async move { drive_run(&ctx, "run-pcancel").await });
+        await_turns(&driver, 2).await; // both children mid-turn
+        cancel.store(true, Ordering::SeqCst);
+        drive.await.unwrap();
+
+        assert_eq!(run_status_str(&db, "run-pcancel"), "canceled");
+        assert_eq!(
+            count_children(&db, "run-pcancel", "abandoned"),
+            2,
+            "both in-flight children were abandoned"
+        );
+        assert_eq!(
+            count_children(&db, "run-pcancel", "running"),
+            0,
+            "no child was left running"
+        );
+    }
+
+    // ───────────── resume line state across loop / orchestrate blocks (H1) ─────
+
+    fn done_exec(conn: &Connection, id: &str, run_id: &str, step_id: &str, iter: i64) {
+        create_step_exec(conn, id, run_id, step_id, 1, iter, "verdict");
+        finish_step_exec(conn, id, "done", Some("head-sha"));
+    }
+
+    fn loop_block(body_ids: &[&str], until: &str) -> Block {
+        Block::Loop(super::super::spec::Loop {
+            max: 3,
+            until: super::super::spec::Until {
+                step: until.to_string(),
+                verdict: Default::default(),
+            },
+            body: body_ids
+                .iter()
+                .map(|id| Block::Step(cstep(id, "")))
+                .collect(),
+        })
+    }
+
+    #[tokio::test]
+    async fn resume_line_state_advances_past_a_completed_loop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (db, _ws) = scaffold_one_step(tmp.path(), "run-loopresume", "wf/lr-1");
+        let blocks = vec![
+            loop_block(&["review", "fix"], "review"),
+            Block::Step(cstep("ship", "")),
+        ];
+        {
+            let conn = db.lock();
+            // Two iterations: review/fix (iter 0), then the closing review (iter 1).
+            done_exec(&conn, "exec-r0", "run-loopresume", "review", 0);
+            done_exec(&conn, "exec-f0", "run-loopresume", "fix", 0);
+            done_exec(&conn, "exec-r1", "run-loopresume", "review", 1);
+        }
+        let conn = db.lock();
+        // Cursor past the loop (at `ship`): the line must be the loop's last
+        // done body exec — not the run base (the H1 silent-work-loss bug).
+        let (line_ref, exec) = resume_line_state(&conn, "run-loopresume", &blocks, 1, "base-sha");
+        assert_eq!(exec.as_deref(), Some("exec-r1"));
+        assert_eq!(line_ref, gitops::step_ref("exec-r1"));
+    }
+
+    #[tokio::test]
+    async fn resume_line_state_uses_an_orchestrate_stages_merge_exec() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (db, _ws) = scaffold_one_step(tmp.path(), "run-orchresume", "wf/or-1");
+        let orch = Block::Orchestrate(super::super::spec::Orchestrate {
+            agent: "coder".to_string(),
+            goal: "coordinate".to_string(),
+            children: None,
+            body: vec![],
+            join: Join::All,
+            integrate: Integrate::None,
+            comms: vec![],
+            compose: None,
+        });
+        let blocks = vec![orch, Block::Step(cstep("ship", ""))];
+        {
+            let conn = db.lock();
+            // A composed sub-run merged at the join → synthetic `__merge_0` exec.
+            done_exec(&conn, "exec-m0", "run-orchresume", &merge_step_id(0), 0);
+        }
+        let conn = db.lock();
+        let (line_ref, exec) = resume_line_state(&conn, "run-orchresume", &blocks, 1, "base-sha");
+        assert_eq!(exec.as_deref(), Some("exec-m0"));
+        assert_eq!(line_ref, gitops::step_ref("exec-m0"));
+    }
+
+    #[tokio::test]
+    async fn resume_line_state_falls_back_to_base_for_an_unmerged_orchestrate() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (db, _ws) = scaffold_one_step(tmp.path(), "run-orchnone", "wf/on-1");
+        let orch = Block::Orchestrate(super::super::spec::Orchestrate {
+            agent: "coder".to_string(),
+            goal: "coordinate".to_string(),
+            children: None,
+            body: vec![],
+            join: Join::All,
+            integrate: Integrate::None,
+            comms: vec![],
+            compose: None,
+        });
+        let blocks = vec![orch, Block::Step(cstep("ship", ""))];
+        let conn = db.lock();
+        let (line_ref, exec) = resume_line_state(&conn, "run-orchnone", &blocks, 1, "base-sha");
+        assert_eq!(exec, None);
+        assert_eq!(line_ref, "base-sha");
     }
 }

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -2155,7 +2155,8 @@ async fn drive_child(c: ChildCtx, stage_entry_sha: Option<String>) -> ChildResul
 /// carries its skills and deliverable MCP servers, and later library edits
 /// never touch a spawned step. Anything the definition requested that no
 /// longer resolves — skills, or the custom agent itself — is journaled as a
-/// `skills_missing` / `custom_agent_missing` warning against `warn_exec_id`;
+/// `skills_missing` / `mcp_servers_missing` / `custom_agent_missing` warning
+/// against `warn_exec_id`;
 /// the step still spawns. Pass `warn_exec_id: None` when the req describes an
 /// already-spawned agent (`pre_spawned`) whose spawn call warned already. The
 /// blackboard write-grant is derived from `owner_run_id` at spawn.
@@ -2195,6 +2196,16 @@ fn build_spawn_req(
                 event_type::SKILLS_MISSING,
                 Some(exec_id),
                 &json!({ "skills": deliverables.missing_skills }),
+            );
+        }
+        if !deliverables.missing_mcp_servers.is_empty() {
+            journal_event(
+                conn,
+                app,
+                run_id,
+                event_type::MCP_SERVERS_MISSING,
+                Some(exec_id),
+                &json!({ "mcp_servers": deliverables.missing_mcp_servers }),
             );
         }
     }

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -1898,11 +1898,13 @@ async fn drive_child(c: ChildCtx, stage_entry_sha: Option<String>) -> ChildResul
                 let conn = c.db.lock();
                 build_spawn_req(
                     &conn,
+                    c.app.as_ref(),
                     &c.agent_spec,
                     &c.fork_base,
                     &c.repo,
                     &c.run_repo,
                     &c.run_id,
+                    Some(&exec_id),
                 )
             },
             pre_spawned: None,
@@ -2151,22 +2153,38 @@ async fn drive_child(c: ChildCtx, stage_entry_sha: Option<String>) -> ChildResul
 /// skill/MCP deliverables are resolved to by-value snapshots here — at spawn
 /// (§3.2), the same semantics as the draft spawn path — so a custom-agent step
 /// carries its skills and deliverable MCP servers, and later library edits
-/// never touch a spawned step. The blackboard write-grant is derived from
-/// `owner_run_id` at spawn.
+/// never touch a spawned step. Skills the definition requested that no longer
+/// resolve (deleted since the save) are journaled as a `skills_missing`
+/// warning against `warn_exec_id`; the step still spawns. Pass
+/// `warn_exec_id: None` when the req describes an already-spawned agent
+/// (`pre_spawned`) whose spawn call warned already. The blackboard write-grant
+/// is derived from `owner_run_id` at spawn.
 fn build_spawn_req(
     conn: &Connection,
+    app: Option<&AppHandle>,
     agent_spec: &AgentSpec,
     fork_base: &str,
     repo: &Path,
     run_repo: &Path,
     run_id: &str,
+    warn_exec_id: Option<&str>,
 ) -> SpawnReq {
-    let (skills, mcp_servers) = super::definition::resolve_step_deliverables(
+    let (skills, mcp_servers, missing_skills) = super::definition::resolve_step_deliverables(
         conn,
         agent_spec.custom_agent.as_deref(),
         &agent_spec.skills,
         &agent_spec.base,
     );
+    if let Some(exec_id) = warn_exec_id.filter(|_| !missing_skills.is_empty()) {
+        journal_event(
+            conn,
+            app,
+            run_id,
+            event_type::SKILLS_MISSING,
+            Some(exec_id),
+            &json!({ "skills": missing_skills }),
+        );
+    }
     SpawnReq {
         repo_path: repo.to_path_buf(),
         provider: agent_spec.base.clone(),
@@ -2317,7 +2335,16 @@ async fn run_orchestrate_stage(
     }
     let orch_req = {
         let conn = ctx.db.lock();
-        build_spawn_req(&conn, orch_agent, fork_base, repo, run_repo, run_id)
+        build_spawn_req(
+            &conn,
+            ctx.app.as_ref(),
+            orch_agent,
+            fork_base,
+            repo,
+            run_repo,
+            run_id,
+            Some(&orch_exec),
+        )
     };
     let spawned = match ctx.driver.spawn(orch_req).await {
         Ok(s) => s,
@@ -3776,11 +3803,13 @@ async fn drive_orch_child(c: ChildCtx, stage_entry_sha: Option<String>) -> OrchC
             let conn = c.db.lock();
             build_spawn_req(
                 &conn,
+                c.app.as_ref(),
                 &c.agent_spec,
                 &c.fork_base,
                 &c.repo,
                 &c.run_repo,
                 &c.run_id,
+                Some(&exec_id),
             )
         };
         let spawned = match c.driver.spawn(child_req).await {
@@ -3852,11 +3881,14 @@ async fn drive_orch_child(c: ChildCtx, stage_entry_sha: Option<String>) -> OrchC
                 let conn = c.db.lock();
                 build_spawn_req(
                     &conn,
+                    c.app.as_ref(),
                     &c.agent_spec,
                     &c.fork_base,
                     &c.repo,
                     &c.run_repo,
                     &c.run_id,
+                    // The agent is pre-spawned above — that call warned already.
+                    None,
                 )
             },
             pre_spawned: Some(spawned),
@@ -4697,7 +4729,16 @@ async fn execute_step(
         let params = AttemptParams {
             spawn_req: {
                 let conn = ctx.db.lock();
-                build_spawn_req(&conn, agent_spec, fork_ref, env.repo, env.run_repo, run_id)
+                build_spawn_req(
+                    &conn,
+                    ctx.app.as_ref(),
+                    agent_spec,
+                    fork_ref,
+                    env.repo,
+                    env.run_repo,
+                    run_id,
+                    Some(&exec_id),
+                )
             },
             pre_spawned: None,
             blackboard: env.blackboard.to_path_buf(),

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -2153,12 +2153,13 @@ async fn drive_child(c: ChildCtx, stage_entry_sha: Option<String>) -> ChildResul
 /// skill/MCP deliverables are resolved to by-value snapshots here — at spawn
 /// (§3.2), the same semantics as the draft spawn path — so a custom-agent step
 /// carries its skills and deliverable MCP servers, and later library edits
-/// never touch a spawned step. Skills the definition requested that no longer
-/// resolve (deleted since the save) are journaled as a `skills_missing`
-/// warning against `warn_exec_id`; the step still spawns. Pass
-/// `warn_exec_id: None` when the req describes an already-spawned agent
-/// (`pre_spawned`) whose spawn call warned already. The blackboard write-grant
-/// is derived from `owner_run_id` at spawn.
+/// never touch a spawned step. Anything the definition requested that no
+/// longer resolves — skills, or the custom agent itself — is journaled as a
+/// `skills_missing` / `custom_agent_missing` warning against `warn_exec_id`;
+/// the step still spawns. Pass `warn_exec_id: None` when the req describes an
+/// already-spawned agent (`pre_spawned`) whose spawn call warned already. The
+/// blackboard write-grant is derived from `owner_run_id` at spawn.
+#[allow(clippy::too_many_arguments)]
 fn build_spawn_req(
     conn: &Connection,
     app: Option<&AppHandle>,
@@ -2169,21 +2170,33 @@ fn build_spawn_req(
     run_id: &str,
     warn_exec_id: Option<&str>,
 ) -> SpawnReq {
-    let (skills, mcp_servers, missing_skills) = super::definition::resolve_step_deliverables(
+    let deliverables = super::definition::resolve_step_deliverables(
         conn,
         agent_spec.custom_agent.as_deref(),
         &agent_spec.skills,
         &agent_spec.base,
     );
-    if let Some(exec_id) = warn_exec_id.filter(|_| !missing_skills.is_empty()) {
-        journal_event(
-            conn,
-            app,
-            run_id,
-            event_type::SKILLS_MISSING,
-            Some(exec_id),
-            &json!({ "skills": missing_skills }),
-        );
+    if let Some(exec_id) = warn_exec_id {
+        if let Some(ca_id) = &deliverables.missing_custom_agent {
+            journal_event(
+                conn,
+                app,
+                run_id,
+                event_type::CUSTOM_AGENT_MISSING,
+                Some(exec_id),
+                &json!({ "custom_agent": ca_id }),
+            );
+        }
+        if !deliverables.missing_skills.is_empty() {
+            journal_event(
+                conn,
+                app,
+                run_id,
+                event_type::SKILLS_MISSING,
+                Some(exec_id),
+                &json!({ "skills": deliverables.missing_skills }),
+            );
+        }
     }
     SpawnReq {
         repo_path: repo.to_path_buf(),
@@ -2191,8 +2204,8 @@ fn build_spawn_req(
         model: agent_spec.model.clone(),
         instructions: agent_spec.instructions.clone(),
         custom_agent_id: agent_spec.custom_agent.clone(),
-        skills,
-        mcp_servers,
+        skills: deliverables.skills,
+        mcp_servers: deliverables.mcp_servers,
         fork_base: Some(fork_base.to_string()),
         run_repo: Some(run_repo.to_path_buf()),
         owner_run_id: run_id.to_string(),

--- a/src-tauri/src/workflow/spec.rs
+++ b/src-tauri/src/workflow/spec.rs
@@ -401,6 +401,19 @@ fn check_step(
         errors.push("step id must not be empty".into());
     } else if seen_ids.insert(step.id.clone(), ()).is_some() {
         errors.push(format!("duplicate step id '{}'", step.id));
+    } else if step.id.starts_with("orchestrate-")
+        || step.id.starts_with("__")
+        || step.id.contains("::")
+    {
+        // Reserved for engine-synthesized execs (`orchestrate-<block>`,
+        // `__merge_<i>`, `__resolve_<i>`, `<id>::dyn-<n>`): comms role checks
+        // and routing key off these shapes, so a user-authored step must never
+        // wear them — a composed fragment naming a step `orchestrate-…` would
+        // otherwise acquire the orchestrator's caps and decision surface (§15).
+        errors.push(format!(
+            "step id '{}' uses a reserved pattern (prefix 'orchestrate-' or '__', or '::')",
+            step.id
+        ));
     }
     check_agent_ref(&format!("step '{}'", step.id), &step.agent, spec, errors);
     if let Gate::Artifact { path } = &step.gate {
@@ -519,6 +532,39 @@ mod tests {
     #[test]
     fn minimal_spec_is_valid() {
         assert!(validate(&minimal()).is_ok());
+    }
+
+    #[test]
+    fn reserved_step_ids_are_rejected() {
+        // Engine-synthesized exec shapes (§15): a user step wearing one would
+        // spoof the orchestrator role or collide with merge/resolve/dyn execs.
+        for bad in [
+            "orchestrate-0",
+            "orchestrate-anything",
+            "__merge_1",
+            "__x",
+            "impl::dyn-2",
+        ] {
+            let mut s = minimal();
+            if let Block::Step(step) = &mut s.workflow[0] {
+                step.id = bad.to_string();
+            }
+            assert!(
+                errors(&s).iter().any(|e| e.contains("reserved")),
+                "expected reserved-id rejection for '{bad}'"
+            );
+        }
+        // Legit ids that merely *contain* the words stay valid.
+        for ok in ["orchestrated-rollout", "my__step", "review"] {
+            let mut s = minimal();
+            if let Block::Step(step) = &mut s.workflow[0] {
+                step.id = ok.to_string();
+            }
+            assert!(
+                !errors(&s).iter().any(|e| e.contains("reserved")),
+                "'{ok}' must not be rejected"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/workflow/types.rs
+++ b/src-tauri/src/workflow/types.rs
@@ -128,6 +128,11 @@ pub mod event_type {
     /// Carries the unresolved names/ids; the step still runs (warn-don't-fail,
     /// the same policy as import).
     pub const SKILLS_MISSING: &str = "skills_missing";
+    /// A step spawned without MCP servers its custom agent assigned — the
+    /// server rows no longer resolve (deleted since the save). Carries the
+    /// unresolved ids; the step still runs. Provider-filtered transports are
+    /// not reported (by-design gating, mirrors the agent editor).
+    pub const MCP_SERVERS_MISSING: &str = "mcp_servers_missing";
     /// A step's `custom_agent` no longer resolves (deleted since the save) —
     /// the step spawned without that agent's skills and MCP servers. Carries
     /// the unresolved id; the step still runs.

--- a/src-tauri/src/workflow/types.rs
+++ b/src-tauri/src/workflow/types.rs
@@ -123,6 +123,11 @@ pub mod event_type {
     pub const RUN_FAILED: &str = "run_failed";
     pub const RUN_CANCELED: &str = "run_canceled";
     pub const ATTEMPT_SPAWNED: &str = "attempt_spawned";
+    /// A step spawned without skills its definition requested — they no longer
+    /// resolve against the local library (deleted since the save/import).
+    /// Carries the unresolved names/ids; the step still runs (warn-don't-fail,
+    /// the same policy as import).
+    pub const SKILLS_MISSING: &str = "skills_missing";
     pub const ATTEMPT_READY: &str = "attempt_ready";
     pub const PROMPT_SENT: &str = "prompt_sent";
     pub const TURN_ENDED: &str = "turn_ended";

--- a/src-tauri/src/workflow/types.rs
+++ b/src-tauri/src/workflow/types.rs
@@ -128,6 +128,10 @@ pub mod event_type {
     /// Carries the unresolved names/ids; the step still runs (warn-don't-fail,
     /// the same policy as import).
     pub const SKILLS_MISSING: &str = "skills_missing";
+    /// A step's `custom_agent` no longer resolves (deleted since the save) —
+    /// the step spawned without that agent's skills and MCP servers. Carries
+    /// the unresolved id; the step still runs.
+    pub const CUSTOM_AGENT_MISSING: &str = "custom_agent_missing";
     pub const ATTEMPT_READY: &str = "attempt_ready";
     pub const PROMPT_SENT: &str = "prompt_sent";
     pub const TURN_ENDED: &str = "turn_ended";

--- a/src/workflows/run/eventSummary.test.ts
+++ b/src/workflows/run/eventSummary.test.ts
@@ -83,6 +83,12 @@ describe("summarizeEvent", () => {
     expect(summarizeEvent(ev(1, "boundary_commit", {})).title).toBe("Committed ");
   });
 
+  it("lists the unresolved skills a step spawned without", () => {
+    const warn = summarizeEvent(ev(1, "skills_missing", { skills: ["code-review", "sk-gone"] }));
+    expect(warn.title).toBe("Started without missing skills");
+    expect(warn.detail).toBe("code-review, sk-gone");
+  });
+
   it("shows finalize PR success and failure distinctly", () => {
     const ok = summarizeEvent(ev(1, "finalize_pr", { url: "https://example/pr/1" }));
     expect(ok.title).toBe("Pull request opened");

--- a/src/workflows/run/eventSummary.test.ts
+++ b/src/workflows/run/eventSummary.test.ts
@@ -89,6 +89,12 @@ describe("summarizeEvent", () => {
     expect(warn.detail).toBe("code-review, sk-gone");
   });
 
+  it("lists the unresolved MCP servers a step spawned without", () => {
+    const warn = summarizeEvent(ev(1, "mcp_servers_missing", { mcp_servers: ["m-gone"] }));
+    expect(warn.title).toBe("Started without missing MCP servers");
+    expect(warn.detail).toBe("m-gone");
+  });
+
   it("warns when a step's custom agent no longer exists", () => {
     const warn = summarizeEvent(ev(1, "custom_agent_missing", { custom_agent: "ca-gone" }));
     expect(warn.title).toContain("Custom agent no longer exists");

--- a/src/workflows/run/eventSummary.test.ts
+++ b/src/workflows/run/eventSummary.test.ts
@@ -89,6 +89,12 @@ describe("summarizeEvent", () => {
     expect(warn.detail).toBe("code-review, sk-gone");
   });
 
+  it("warns when a step's custom agent no longer exists", () => {
+    const warn = summarizeEvent(ev(1, "custom_agent_missing", { custom_agent: "ca-gone" }));
+    expect(warn.title).toContain("Custom agent no longer exists");
+    expect(warn.detail).toBe("ca-gone");
+  });
+
   it("shows finalize PR success and failure distinctly", () => {
     const ok = summarizeEvent(ev(1, "finalize_pr", { url: "https://example/pr/1" }));
     expect(ok.title).toBe("Pull request opened");

--- a/src/workflows/run/eventSummary.ts
+++ b/src/workflows/run/eventSummary.ts
@@ -78,6 +78,13 @@ export function summarizeEvent(ev: WfEvent): EventSummary {
         title: "Started without missing skills",
         detail: strList(p, "skills"),
       };
+    case "custom_agent_missing":
+      return {
+        icon: "minus",
+        tone: AMBER,
+        title: "Custom agent no longer exists — started without its skills and MCP servers",
+        detail: str(p, "custom_agent"),
+      };
     case "attempt_ready":
       return { icon: "dot", tone: MUTED, title: "Agent ready" };
     case "prompt_sent": {

--- a/src/workflows/run/eventSummary.ts
+++ b/src/workflows/run/eventSummary.ts
@@ -71,6 +71,13 @@ export function summarizeEvent(ev: WfEvent): EventSummary {
 
     case "attempt_spawned":
       return { icon: "bot", tone: MUTED, title: "Agent spawned" };
+    case "skills_missing":
+      return {
+        icon: "minus",
+        tone: AMBER,
+        title: "Started without missing skills",
+        detail: strList(p, "skills"),
+      };
     case "attempt_ready":
       return { icon: "dot", tone: MUTED, title: "Agent ready" };
     case "prompt_sent": {
@@ -160,7 +167,7 @@ export function summarizeEvent(ev: WfEvent): EventSummary {
     case "merge_started":
       return { icon: "merge", tone: ACCENT, title: "Merging children" };
     case "merge_conflict":
-      return { icon: "close", tone: DANGER, title: "Merge conflict", detail: fileList(p) };
+      return { icon: "close", tone: DANGER, title: "Merge conflict", detail: strList(p, "files") };
     case "merge_done":
       return { icon: "merge", tone: GREEN, title: `Merged ${short(str(p, "sha"))}` };
 
@@ -181,12 +188,12 @@ export function summarizeEvent(ev: WfEvent): EventSummary {
   }
 }
 
-/** A `merge_conflict` payload's `files` array rendered as a short detail line. */
-function fileList(payload: unknown): string | undefined {
-  if (payload && typeof payload === "object" && "files" in payload) {
-    const files = (payload as { files: unknown }).files;
-    if (Array.isArray(files) && files.length > 0) {
-      return files.filter((f) => typeof f === "string").join(", ");
+/** A payload's string-array field rendered as a short detail line. */
+function strList(payload: unknown, key: string): string | undefined {
+  if (payload && typeof payload === "object" && key in payload) {
+    const items = (payload as Record<string, unknown>)[key];
+    if (Array.isArray(items) && items.length > 0) {
+      return items.filter((f) => typeof f === "string").join(", ");
     }
   }
   return undefined;

--- a/src/workflows/run/eventSummary.ts
+++ b/src/workflows/run/eventSummary.ts
@@ -78,6 +78,13 @@ export function summarizeEvent(ev: WfEvent): EventSummary {
         title: "Started without missing skills",
         detail: strList(p, "skills"),
       };
+    case "mcp_servers_missing":
+      return {
+        icon: "minus",
+        tone: AMBER,
+        title: "Started without missing MCP servers",
+        detail: strList(p, "mcp_servers"),
+      };
     case "custom_agent_missing":
       return {
         icon: "minus",


### PR DESCRIPTION
Closes the five merge blockers from the workflows-v1 pre-merge review, in one pass:

1. **Resume work-loss (H1/F1)** — `resume_line_state` now has `Loop` and `Orchestrate` arms: a resume past a completed loop forks from the loop's most recent done body exec (across iterations/retries), and an orchestrate stage with a merged compose sub-run resumes from its synthetic `__merge_<i>` exec. Previously both fell through to an earlier block or the run base, silently dropping ferried commits from the branch and the final push.
2. **Credentialed publish escape (F2)** — the workflow RPC dispatcher no longer falls `git_push`/`open_pr` through to the plain git broker: run-owned step agents are denied outright (with a clear error), keeping the engine's `wf/`-guarded finalize as the sole publish path. `git_fetch` still falls through.
3. **Skills/MCP silently dropped (H3)** — `build_spawn_req` now resolves deliverables at spawn via `resolve_step_deliverables` (custom-agent skill/server ids + spec skill names, MCP transports gated per provider, mirroring `snapshotAgentDeliverables`), restoring the by-value snapshot semantics of ddb1b43 that the Rust engine had dropped.
4. **Cancel not honored mid-flight (H2)** — linear/loop attempts now receive the run's cancel flag (the attempt's existing cancel races end the turn), the `Canceled` arm completes the cancel (abandon + journal + status + archive), and the parallel join loop races the cancel flag, winds children down via `stage_cancel`, and writes the terminal status after draining.
5. **Orchestrator-role spoofing (F3)** — spec validation reserves engine-synthesized step-id shapes (prefix `orchestrate-`/`__`, or containing `::`), so a composed fragment can no longer name a step `orchestrate-…` to acquire the orchestrator's caps and decision surface.

TECH_SPEC.md §5.2 and §15 amended in-PR per the deviation rule. New tests: mid-turn and mid-parallel cancel (HoldDriver), resume-past-loop / orchestrate-merge / unmerged-orchestrate line state, reserved-id validation, publish-op denial, and three deliverables-resolution suites. Full gate green: cargo test 815 passed / 0 failed, clippy `-D warnings` clean (CI invocation), rustfmt applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)