### PR TITLE
fix(workflows): close review blockers 5, 6, and 8

### DIFF
--- a/docs/workflows/QA.md
+++ b/docs/workflows/QA.md
@@ -169,9 +169,10 @@ returning `{status:'ok'}` with a test."* Press Enter to launch.
 
 ## 9. Cleanup
 
-- ✅ **Delete run** (terminal runs only): the confirm dialog states chats will
-  be gone. Confirm → run-owned workspaces discarded, `~/.fletch/runs/<id>/`
-  removed, rows deleted. The run leaves the sidebar; its chats no longer open.
+- ✅ **Delete run** (terminal runs only): the run row's delete button arms on
+  the first click and its tooltip states chats will be gone. Click again →
+  run-owned workspaces discarded, `~/.fletch/runs/<id>/` removed, rows deleted
+  (sub-runs cascade). The run leaves the sidebar; its chats no longer open.
 
 ---
 

--- a/docs/workflows/TECH_SPEC.md
+++ b/docs/workflows/TECH_SPEC.md
@@ -1011,9 +1011,15 @@ run-owned step-agent workspaces (matched by `owner_run_id`) through the
 app path, delete `~/.fletch/runs/<run-id>/` (blackboard + run repo), and
 delete the run's rows (`wf_step_exec`/`wf_event`/`wf_message` cascade).
 The whole tree must be terminal — the guard runs before anything is
-touched. Chats of deleted runs are gone — the delete is a two-click
-armed button on the run row whose confirm state says so. A `wf:run-deleted`
-event drops the row from the sidebar. Until deletion, everything is
+touched. Tree deletion is best-effort per subtree: workspace discards and
+dir removals are irreversible, so a mid-tree failure cannot roll back —
+instead the failed run and all its ancestors stay fully intact (a run's
+rows are deleted last and are what a retry rediscovers its cleanup
+through), sibling subtrees still get cleaned, and the command returns one
+aggregated error stating that deleting again finishes the job. Chats of
+deleted runs are gone — the delete is a two-click armed button on the run
+row whose confirm state says so. A `wf:run-deleted` event drops each
+fully deleted row from the sidebar. Until deletion, everything is
 retained (open question #4 covers automatic GC policy later).
 
 `ImportReport` = parsed spec + per-agent resolution proposals + warnings

--- a/docs/workflows/TECH_SPEC.md
+++ b/docs/workflows/TECH_SPEC.md
@@ -382,6 +382,13 @@ Rejected at save/import/launch time with precise messages:
 - nested `orchestrate` inside `orchestrate` (depth is handled by sub-runs,
   not block nesting)
 - `parallel.steps` empty, or containing non-`Step` blocks (v1)
+- `loop` bodies containing non-`Step` blocks (v1 — the engine executes
+  plain-step bodies only; the builder's loop "add block" menu offers steps
+  only for the same reason)
+- `orchestrate` with `integrate: merge` (v1 — orchestrate stages run
+  `integrate: none` only; wiring the orchestrator over the parallel merge
+  machinery is a follow-up, and the builder doesn't offer `merge` on
+  orchestrate)
 - gate `artifact.path` absolute or containing `..`
 - budgets with zero/negative values
 - unknown `version`
@@ -419,7 +426,7 @@ workflow:
         When a slice a sibling depends on lands, notify that sibling.
       children: { agent: coder, max: 3 }
       join: all
-      integrate: merge
+      integrate: none
       comms: [report, ask]
       compose: { max_sub_runs: 2, max_depth: 2 }
 
@@ -605,7 +612,9 @@ re-run" in place.
   prompts the orchestrator once ("all children are terminal — write your
   verdict.json / issue final decisions"), and the stage's gate is the
   orchestrator's own verdict. An orchestrator may end the stage early with
-  `wf_decide {stage_done}`. Details in §10.
+  `wf_decide {stage_done}`. v1 runs orchestrate stages with
+  `integrate: none` only — `merge` is rejected at validation (§5.2).
+  Details in §10.
 
 ---
 
@@ -804,6 +813,10 @@ the authority.
 ### 10.3 Dynamic composition (`wf_compose`)
 
 Enabled per-orchestrate-block via `compose: { max_sub_runs, max_depth }`.
+When enabled, the orchestrator's opening prompt (`prompts.rs`) describes
+the op and its args alongside `wf_decide`/`wf_notify` — an orchestrator
+can only discover `wf_compose` there, so a stage without `compose` never
+mentions it.
 
 ```json
 {

--- a/docs/workflows/TECH_SPEC.md
+++ b/docs/workflows/TECH_SPEC.md
@@ -1005,11 +1005,16 @@ each attempt's preserved chat via the existing `ChatView` (§14.2). Read-only;
 implemented on the supervisor alongside `get_workspace` rather than on
 `WorkflowService`, since it is a workspace query.
 
-`wf_delete_run` cascades: discard all run-owned step-agent workspaces
-(matched by `owner_run_id`), delete `~/.fletch/runs/<run-id>/` (blackboard
-+ run repo), and delete the run's rows. Chats of deleted runs are gone —
-the confirm dialog says so. Until deletion, everything is retained (open
-question #4 covers automatic GC policy later).
+`wf_delete_run` cascades: composed sub-runs first (children-first — the
+`parent_run_id` FK deliberately has no cascade), then per run discard all
+run-owned step-agent workspaces (matched by `owner_run_id`) through the
+app path, delete `~/.fletch/runs/<run-id>/` (blackboard + run repo), and
+delete the run's rows (`wf_step_exec`/`wf_event`/`wf_message` cascade).
+The whole tree must be terminal — the guard runs before anything is
+touched. Chats of deleted runs are gone — the delete is a two-click
+armed button on the run row whose confirm state says so. A `wf:run-deleted`
+event drops the row from the sidebar. Until deletion, everything is
+retained (open question #4 covers automatic GC policy later).
 
 `ImportReport` = parsed spec + per-agent resolution proposals + warnings
 (missing skills, unknown providers).

--- a/docs/workflows/TECH_SPEC.md
+++ b/docs/workflows/TECH_SPEC.md
@@ -1020,7 +1020,9 @@ aggregated error stating that deleting again finishes the job. Within one
 run the row delete is the commit point: the run dir is staged aside with
 an atomic rename and renamed back if the row delete fails, so a surviving
 run row never points at a missing blackboard/run repo; the staged dir is
-removed only after the rows are gone. Chats of
+removed only after the rows are gone. An app exit inside that window is
+reconciled at the next startup (`resume_active_runs`): a staged dir whose
+row survives is renamed back, one whose row is gone is swept. Chats of
 deleted runs are gone — the delete is a two-click armed button on the run
 row whose confirm state says so. A `wf:run-deleted` event drops each
 fully deleted row from the sidebar. Until deletion, everything is

--- a/docs/workflows/TECH_SPEC.md
+++ b/docs/workflows/TECH_SPEC.md
@@ -1016,7 +1016,11 @@ dir removals are irreversible, so a mid-tree failure cannot roll back —
 instead the failed run and all its ancestors stay fully intact (a run's
 rows are deleted last and are what a retry rediscovers its cleanup
 through), sibling subtrees still get cleaned, and the command returns one
-aggregated error stating that deleting again finishes the job. Chats of
+aggregated error stating that deleting again finishes the job. Within one
+run the row delete is the commit point: the run dir is staged aside with
+an atomic rename and renamed back if the row delete fails, so a surviving
+run row never points at a missing blackboard/run repo; the staged dir is
+removed only after the rows are gone. Chats of
 deleted runs are gone — the delete is a two-click armed button on the run
 row whose confirm state says so. A `wf:run-deleted` event drops each
 fully deleted row from the sidebar. Until deletion, everything is

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1140,6 +1140,7 @@ pub fn run() {
             workflow::scheduler::wf_retry,
             workflow::scheduler::wf_approve,
             workflow::scheduler::wf_resolve_conflict,
+            workflow::scheduler::wf_delete_run,
             workflow::comms::wf_answer,
             workflow::definition::wf_def_save,
             workflow::definition::wf_def_list,

--- a/src-tauri/src/workflow/comms.rs
+++ b/src-tauri/src/workflow/comms.rs
@@ -2899,7 +2899,7 @@ mod tests {
                 }),
                 body: vec![],
                 join: Join::All,
-                integrate: Integrate::Merge,
+                integrate: Integrate::None,
                 comms,
                 compose: limits,
             })],

--- a/src-tauri/src/workflow/journal.rs
+++ b/src-tauri/src/workflow/journal.rs
@@ -101,6 +101,12 @@ pub fn emit_run(app: &AppHandle, run: &Run) {
     let _ = app.emit("wf:run", run);
 }
 
+/// Notify the frontend that a run's rows were deleted (`wf_delete_run`, §13),
+/// so the sidebar drops the row instead of upserting it.
+pub fn emit_run_deleted(app: &AppHandle, run_id: &str) {
+    let _ = app.emit("wf:run-deleted", run_id);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/workflow/prompts.rs
+++ b/src-tauri/src/workflow/prompts.rs
@@ -142,6 +142,9 @@ pub struct OrchestratorPromptCtx<'a> {
     /// The dynamic-child template: `(agent alias, max)` when the block declares
     /// `children`; `None` when only static children exist.
     pub dynamic: Option<(&'a str, u32)>,
+    /// `max_sub_runs` when the block enables dynamic composition (spec §10.3);
+    /// `None` leaves `wf_compose` out of the prompt entirely.
+    pub compose_max_sub_runs: Option<u32>,
 }
 
 /// The orchestrator's opening prompt (spec §10.2). Describes its supervisory
@@ -185,7 +188,7 @@ pub fn orchestrator_prompt(ctx: &OrchestratorPromptCtx) -> String {
     }
     s.push('\n');
 
-    s.push_str(&orchestrator_comms_section());
+    s.push_str(&orchestrator_comms_section(ctx.compose_max_sub_runs));
     s.push('\n');
 
     s.push_str(&blackboard_contract(ctx.orch_step_id));
@@ -224,9 +227,11 @@ pub fn orchestrator_conclude_prompt(orch_step_id: &str) -> String {
 
 /// The orchestrator's comms section: it holds every cap (spec §5.1 — "orchestrator
 /// gets all"), so it may answer/route with `wf_decide`, push notices to children
-/// with `wf_notify`, and escalate to the human. Mirrors the git-actions mailbox
-/// style used by the step protocol (§8.5 item 6).
-fn orchestrator_comms_section() -> String {
+/// with `wf_notify`, and escalate to the human. When the stage enables dynamic
+/// composition (spec §10.3), `wf_compose` is described too — an op the agent can
+/// only discover here. Mirrors the git-actions mailbox style used by the step
+/// protocol (§8.5 item 6).
+fn orchestrator_comms_section(compose_max_sub_runs: Option<u32>) -> String {
     let mut s = String::new();
     s.push_str("## Directing the workflow\n\n");
     s.push_str(
@@ -256,6 +261,23 @@ fn orchestrator_comms_section() -> String {
          `args: { \"to\": \"<step-id>\" | \"all-children\", \"message\": \"…\" }`. \
          Push a notice to a running child (e.g. a sibling's slice landed).\n",
     );
+    if let Some(max) = compose_max_sub_runs {
+        s.push_str(&format!(
+            "- **Compose a sub-workflow** — `op: \"wf_compose\"`, \
+             `args: {{ \"task\": \"…\", \"fragment\": [ {{ \"step\": {{ \"id\": \"…\", \
+             \"agent\": \"<alias>\", \"goal\": \"…\" }} }}, … ], \
+             \"budgets\": {{ \"turns\": <n> }}, \"integrate\": \"none\" | \"merge\", \
+             \"base\": \"parent-head\" | \"run-base\" }}`. \
+             When the work needs a multi-step pipeline rather than one more child, \
+             describe it as a fragment of workflow blocks and the engine runs it as \
+             a sub-run that joins this stage. `budgets.turns` reserves a slice of \
+             this run's remaining turn budget (required; `budgets.tokens` optional). \
+             `agents` is an optional agent map — omit it to reuse this run's agents. \
+             The engine validates the fragment and enforces the limits; you may \
+             launch at most **{max}** sub-run{s_} this stage.\n",
+            s_ = if max == 1 { "" } else { "s" },
+        ));
+    }
     s
 }
 
@@ -497,6 +519,7 @@ mod tests {
             },
             static_children: &statics,
             dynamic: Some(("coder", 3)),
+            compose_max_sub_runs: None,
         });
         assert!(p.contains("Ship the feature"));
         assert!(p.contains("Assign slices"));
@@ -509,8 +532,35 @@ mod tests {
         assert!(p.contains("wf_decide"));
         assert!(p.contains("spawn_child") && p.contains("stage_done") && p.contains("escalate"));
         assert!(p.contains("wf_notify"));
+        // Composition is disabled for this stage, so the op is never mentioned.
+        assert!(!p.contains("wf_compose"), "compose off ⇒ unadvertised: {p}");
         // Writes its own verdict to conclude.
         assert!(p.contains("orchestrate-1/verdict.json"));
+    }
+
+    #[test]
+    fn orchestrator_prompt_advertises_compose_only_when_enabled() {
+        let p = orchestrator_prompt(&OrchestratorPromptCtx {
+            run_task: "Ship the feature",
+            orch_step_id: "orchestrate-0",
+            goal: "Split and supervise",
+            position: Position {
+                step_index: 0,
+                step_count: 1,
+                iteration: None,
+            },
+            static_children: &[],
+            dynamic: None,
+            compose_max_sub_runs: Some(2),
+        });
+        assert!(p.contains("wf_compose"), "{p}");
+        // The contract's load-bearing pieces: fragment shape, required budget
+        // slice, integrate/base vocabulary, and the stage limit.
+        assert!(p.contains("\"fragment\""));
+        assert!(p.contains("\"budgets\""));
+        assert!(p.contains("\"turns\""));
+        assert!(p.contains("\"parent-head\"") && p.contains("\"run-base\""));
+        assert!(p.contains("at most **2** sub-runs"), "{p}");
     }
 
     #[test]

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -197,10 +197,15 @@ impl WorkflowService {
     /// `wf_message` cascade off `wf_run`). Chats of deleted runs are gone; the
     /// UI's confirm dialog says so. The whole tree is checked before anything
     /// is touched, so a rejected delete changes nothing.
+    ///
+    /// Deletion of the tree itself is best-effort per subtree: workspace
+    /// discards and dir removals are irreversible, so a mid-tree failure can't
+    /// roll back — instead a failed run keeps itself *and its ancestors* fully
+    /// intact (its `wf_run` row is what a retry rediscovers the cleanup
+    /// through, and the `parent_run_id` FK forbids deleting a parent under a
+    /// surviving child), sibling subtrees still get cleaned, and every failure
+    /// is aggregated into one error that says deleting again finishes the job.
     pub async fn delete_run(&self, supervisor: &Arc<Supervisor>, run_id: &str) -> Result<()> {
-        // Post-order (children before parents): `wf_run.parent_run_id` has no
-        // ON DELETE cascade, so a parent must never be deleted while a child
-        // row still points at it.
         let order = {
             let conn = self.db.lock();
             let mut order = Vec::new();
@@ -220,17 +225,61 @@ impl WorkflowService {
             }
         }
 
-        for id in &order {
-            for agent in supervisor.workspace.agents_for_run(id) {
-                supervisor.clone().discard_agent(&agent.id).await?;
-            }
-            {
-                let conn = self.db.lock();
-                delete_run_data(&conn, id)?;
-            }
-            journal::emit_run_deleted(&self.app, id);
+        let mut errors = Vec::new();
+        self.delete_tree(supervisor, run_id, &mut errors).await;
+        if errors.is_empty() {
+            return Ok(());
         }
-        Ok(())
+        Err(Error::Other(format!(
+            "run deletion incomplete: {}. Every run that failed (and its \
+             parents) is untouched — delete again to finish.",
+            errors.join("; ")
+        )))
+    }
+
+    /// Delete `run_id`'s subtree, children first. Returns whether the whole
+    /// subtree is gone; a failure is pushed onto `errors` and keeps this run's
+    /// rows (deleted last, so the run stays discoverable for a retry) and, via
+    /// the `false` return, every ancestor's.
+    async fn delete_tree(
+        &self,
+        supervisor: &Arc<Supervisor>,
+        run_id: &str,
+        errors: &mut Vec<String>,
+    ) -> bool {
+        let children = {
+            let conn = self.db.lock();
+            child_run_ids(&conn, run_id)
+        };
+        let mut children_deleted = true;
+        for child in children {
+            if !Box::pin(self.delete_tree(supervisor, &child, errors)).await {
+                children_deleted = false;
+            }
+        }
+        if !children_deleted {
+            // A surviving child row still points at this run (`parent_run_id`),
+            // and a half-gutted parent would strand the retry path — leave this
+            // run entirely alone.
+            return false;
+        }
+
+        for agent in supervisor.workspace.agents_for_run(run_id) {
+            if let Err(e) = supervisor.clone().discard_agent(&agent.id).await {
+                errors.push(format!("run {run_id}: discard agent {}: {e}", agent.id));
+                return false;
+            }
+        }
+        let deleted = {
+            let conn = self.db.lock();
+            delete_run_data(&conn, run_id)
+        };
+        if let Err(e) = deleted {
+            errors.push(format!("run {run_id}: {e}"));
+            return false;
+        }
+        journal::emit_run_deleted(&self.app, run_id);
+        true
     }
 
     /// Resume a paused run (`wf_resume`): optionally raise the budget (§11.2,

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -894,7 +894,9 @@ async fn finalize_run(
 /// Reject blocks the engine can't yet execute, up front, so a run fails with a
 /// clear cause before doing any work rather than part-way through. S8/S9 execute
 /// `step` and `parallel` (both `integrate: none` and `integrate: merge`); loop
-/// (S7) executes bodies of plain steps; orchestrate (S11) is not wired yet.
+/// (S7) executes bodies of plain steps; orchestrate (S11) runs `integrate: none`
+/// only. `spec::validate` rejects both unsupported shapes at save/import now, so
+/// this is a backstop for definitions persisted before that rule existed.
 fn ensure_executable(blocks: &[Block]) -> Result<()> {
     for b in blocks {
         match b {
@@ -2550,6 +2552,7 @@ async fn run_orchestrate_stage(
             },
             static_children: &static_children,
             dynamic,
+            compose_max_sub_runs: orch.compose.as_ref().map(|c| c.max_sub_runs),
         });
         // On a resume after escalation, an answer for the orchestrator is folded in.
         let delivered = {

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -144,8 +144,16 @@ impl WorkflowService {
     }
 
     /// Re-drive every run left `pending`/`running` at startup (spec §6.1); a
-    /// `paused` run waits for a user action. Best-effort per run.
+    /// `paused` run waits for a user action. Best-effort per run. Also
+    /// reconciles run dirs a crashed `wf_delete_run` left staged (§13), so a
+    /// surviving run is valid again before anyone opens it.
     pub fn resume_active_runs(&self) {
+        {
+            let conn = self.db.lock();
+            if let Ok(root) = blackboard::runs_root() {
+                recover_staged_run_dirs(&conn, &root);
+            }
+        }
         let ids: Vec<String> = {
             let conn = self.db.lock();
             conn.prepare("SELECT id FROM wf_run WHERE status IN ('pending','running')")
@@ -5721,11 +5729,13 @@ fn delete_run_data(conn: &Connection, run_id: &str) -> Result<()> {
 /// The row delete is the commit point: the dir is first staged aside with an
 /// atomic rename and renamed back if the row delete fails, so a run that
 /// survives the command is always openable — never a visible row whose
-/// blackboard and run repo are already gone. Only once the rows are gone is
-/// the staged dir actually removed (best-effort: at that point the run no
-/// longer exists to retry against, and a leftover `<id>.deleting` dir is
-/// invisible junk, which the next attempt would also sweep). A missing dir is
-/// fine — a retried partial delete or a cleaned disk.
+/// blackboard and run repo are already gone. An app exit inside that window
+/// can't rename back — [`recover_staged_run_dirs`] reconciles it at the next
+/// startup. Only once the rows are gone is the staged dir actually removed
+/// (best-effort: at that point the run no longer exists to retry against, and
+/// a leftover `<id>.deleting` dir is invisible junk, which the next attempt or
+/// startup would also sweep). A missing dir is fine — a retried partial delete
+/// or a cleaned disk.
 fn delete_run_data_at(conn: &Connection, run_id: &str, dir: &Path) -> Result<()> {
     let staged = dir.with_file_name(format!(
         "{}.deleting",
@@ -5753,6 +5763,40 @@ fn delete_run_data_at(conn: &Connection, run_id: &str, dir: &Path) -> Result<()>
         let _ = std::fs::remove_dir_all(&staged);
     }
     Ok(())
+}
+
+/// Startup reconciliation for `<id>.deleting` run dirs (§13): an app exit
+/// between `delete_run_data_at`'s staging rename and its row delete strands
+/// the staged dir with the run row still live — the exact broken state the
+/// staging exists to prevent, and one only a manual retry would otherwise
+/// clear. A staged dir whose row survives is renamed back (the run is fully
+/// openable again before anyone touches it); one whose row is gone is the
+/// tail of a completed delete and is swept. Best-effort throughout.
+fn recover_staged_run_dirs(conn: &Connection, runs_root: &Path) {
+    let Ok(entries) = std::fs::read_dir(runs_root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(run_id) = name.to_str().and_then(|n| n.strip_suffix(".deleting")) else {
+            continue;
+        };
+        let row_exists =
+            match conn.query_row("SELECT COUNT(*) FROM wf_run WHERE id = ?1", [run_id], |r| {
+                r.get::<_, i64>(0)
+            }) {
+                Ok(n) => n > 0,
+                // Can't tell — never destroy data on a failed lookup.
+                Err(_) => continue,
+            };
+        if row_exists {
+            // Restore. Renaming onto an existing non-empty dir fails, which is
+            // the safe outcome if a live dir somehow reappeared.
+            let _ = std::fs::rename(entry.path(), runs_root.join(run_id));
+        } else {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
 }
 
 /// Live (spawned, non-terminal) step agents for a run — stopped on cancel/pause.
@@ -7171,6 +7215,42 @@ mod tests {
             })
             .unwrap();
         assert_eq!(runs, 0);
+    }
+
+    #[test]
+    fn startup_recovery_reconciles_staged_run_dirs() {
+        // An app exit between the staging rename and the row delete strands a
+        // `<id>.deleting` dir. At the next startup: a staged dir whose run row
+        // survives is renamed back (the run is openable again without user
+        // action); one whose row is gone is swept; live dirs are untouched.
+        let tmp = tempfile::tempdir().unwrap();
+        let db = crate::database::init(tmp.path()).unwrap();
+        let conn = db.lock();
+        conn.execute(
+            "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,branch,
+                base_sha,status,budgets_json,spent_json,created_at,updated_at)
+             VALUES ('r-alive','n','{}','t','p','/r','/d','wf/x','sha','done','{}','{}',0,0)",
+            [],
+        )
+        .unwrap();
+        let root = tmp.path().join("runs");
+        std::fs::create_dir_all(root.join("r-alive.deleting")).unwrap();
+        std::fs::write(root.join("r-alive.deleting").join("marker"), "m").unwrap();
+        std::fs::create_dir_all(root.join("r-gone.deleting")).unwrap();
+        std::fs::create_dir_all(root.join("r-normal")).unwrap();
+
+        recover_staged_run_dirs(&conn, &root);
+
+        assert!(
+            root.join("r-alive").join("marker").exists(),
+            "surviving run's dir restored intact"
+        );
+        assert!(!root.join("r-alive.deleting").exists(), "staged name gone");
+        assert!(
+            !root.join("r-gone.deleting").exists(),
+            "completed delete's tail swept"
+        );
+        assert!(root.join("r-normal").exists(), "live dirs untouched");
     }
 
     #[test]

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -189,6 +189,50 @@ impl WorkflowService {
         Ok(())
     }
 
+    /// Delete a terminal run (`wf_delete_run`, spec §13): cascade over composed
+    /// sub-runs, discard every run-owned step-agent workspace (`owner_run_id`)
+    /// through the app path — a DB cascade would orphan checkouts and dangle
+    /// supervisor state (0019) — remove `~/.fletch/runs/<id>/` (blackboard +
+    /// run repo), and delete the run's rows (`wf_step_exec` / `wf_event` /
+    /// `wf_message` cascade off `wf_run`). Chats of deleted runs are gone; the
+    /// UI's confirm dialog says so. The whole tree is checked before anything
+    /// is touched, so a rejected delete changes nothing.
+    pub async fn delete_run(&self, supervisor: &Arc<Supervisor>, run_id: &str) -> Result<()> {
+        // Post-order (children before parents): `wf_run.parent_run_id` has no
+        // ON DELETE cascade, so a parent must never be deleted while a child
+        // row still points at it.
+        let order = {
+            let conn = self.db.lock();
+            let mut order = Vec::new();
+            run_tree_post_order(&conn, run_id, &mut order);
+            check_deletable(&conn, &order)?;
+            order
+        };
+        // A terminal run normally has no live driver, but a drive task can
+        // still be winding down (status written, registry entry not yet
+        // removed). Deleting its rows out from under it would race — reject.
+        {
+            let runs = self.runs.lock();
+            if let Some(id) = order.iter().find(|id| runs.contains_key(id.as_str())) {
+                return Err(Error::Other(format!(
+                    "run {id} is still winding down — try again in a moment"
+                )));
+            }
+        }
+
+        for id in &order {
+            for agent in supervisor.workspace.agents_for_run(id) {
+                supervisor.clone().discard_agent(&agent.id).await?;
+            }
+            {
+                let conn = self.db.lock();
+                delete_run_data(&conn, id)?;
+            }
+            journal::emit_run_deleted(&self.app, id);
+        }
+        Ok(())
+    }
+
     /// Resume a paused run (`wf_resume`): optionally raise the budget (§11.2,
     /// §13), then re-drive from the cursor. A fresh attempt is started for a
     /// blocked / stalled / budget-exceeded step by the drive loop. A patch that
@@ -5592,6 +5636,48 @@ fn child_run_ids(conn: &Connection, parent_run_id: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
+/// The run tree rooted at `run_id`, post-order — every child precedes its
+/// parent, so a delete walked in this order never dangles the `parent_run_id`
+/// FK (which deliberately has no cascade).
+fn run_tree_post_order(conn: &Connection, run_id: &str, out: &mut Vec<String>) {
+    for child in child_run_ids(conn, run_id) {
+        run_tree_post_order(conn, &child, out);
+    }
+    out.push(run_id.to_string());
+}
+
+/// The `wf_delete_run` guard (spec §13): every run in the tree must be terminal
+/// (`done` / `failed` / `canceled`). Checked before anything is deleted.
+fn check_deletable(conn: &Connection, run_ids: &[String]) -> Result<()> {
+    for id in run_ids {
+        let (status, _) = run_status(conn, id)?;
+        if !matches!(status.as_str(), "done" | "failed" | "canceled") {
+            return Err(Error::Other(format!(
+                "cannot delete a {status} run — cancel it first"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Delete one run's on-disk directory and its DB rows. The row delete cascades
+/// `wf_step_exec` / `wf_event` / `wf_message` (0019 + `PRAGMA foreign_keys`).
+/// A missing run dir is fine — a retried partial delete or a cleaned disk.
+fn delete_run_data(conn: &Connection, run_id: &str) -> Result<()> {
+    match std::fs::remove_dir_all(blackboard::run_dir(run_id)?) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(Error::Other(format!(
+                "cannot remove run dir for {run_id}: {e}"
+            )))
+        }
+    }
+    conn.execute("DELETE FROM wf_run WHERE id = ?1", [run_id])
+        .map_err(|e| Error::Other(e.to_string()))?;
+    Ok(())
+}
+
 /// Live (spawned, non-terminal) step agents for a run — stopped on cancel/pause.
 fn live_step_agents(conn: &Connection, run_id: &str) -> Vec<String> {
     conn.prepare(
@@ -5709,6 +5795,20 @@ pub async fn wf_retry(run_id: String, service: Svc<'_>) -> std::result::Result<(
 #[tauri::command]
 pub async fn wf_approve(run_id: String, service: Svc<'_>) -> std::result::Result<(), String> {
     service.approve(&run_id).map_err(|e| e.to_string())
+}
+
+/// Delete a terminal run and everything it owns (spec §13): run-owned step
+/// agents (and their chats), the run directory, and the run's rows.
+#[tauri::command]
+pub async fn wf_delete_run(
+    run_id: String,
+    service: Svc<'_>,
+    supervisor: tauri::State<'_, Arc<Supervisor>>,
+) -> std::result::Result<(), String> {
+    service
+        .delete_run(supervisor.inner(), &run_id)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 /// Resolve a merge conflict (§12.3): `mode` is `"agent"` or `"human"`.
@@ -6822,6 +6922,100 @@ mod tests {
         assert!(check_resumable(&conn, "r-ques", "resume").is_err());
         assert!(check_resumable(&conn, "r-budg", "resume").is_ok());
         assert!(check_resumable(&conn, "r-blk", "retry").is_ok());
+    }
+
+    #[test]
+    fn delete_guard_and_tree_order_protect_the_cascade() {
+        // `wf_delete_run` (§13): the tree is collected children-first (the
+        // `parent_run_id` FK has no cascade), and the guard rejects the whole
+        // delete while any run in the tree is non-terminal.
+        let tmp = tempfile::tempdir().unwrap();
+        let db = crate::database::init(tmp.path()).unwrap();
+        let insert = |id: &str, parent: Option<&str>, status: &str| {
+            db.lock()
+                .execute(
+                    "INSERT INTO wf_run (id,parent_run_id,name,spec_json,task,project_id,
+                        repo_path,run_dir,branch,base_sha,status,budgets_json,spent_json,
+                        created_at,updated_at)
+                     VALUES (?1,?2,'n','{}','t','p','/r','/d','wf/x','sha',?3,'{}','{}',0,0)",
+                    rusqlite::params![id, parent, status],
+                )
+                .unwrap();
+        };
+        insert("r-parent", None, "done");
+        insert("r-child", Some("r-parent"), "canceled");
+        insert("r-grandchild", Some("r-child"), "running");
+
+        let conn = db.lock();
+        let mut order = Vec::new();
+        run_tree_post_order(&conn, "r-parent", &mut order);
+        assert_eq!(order, vec!["r-grandchild", "r-child", "r-parent"]);
+
+        // One live descendant blocks the whole delete.
+        let err = check_deletable(&conn, &order).unwrap_err().to_string();
+        assert!(err.contains("cannot delete a running run"), "{err}");
+
+        conn.execute(
+            "UPDATE wf_run SET status='failed' WHERE id='r-grandchild'",
+            [],
+        )
+        .unwrap();
+        assert!(check_deletable(&conn, &order).is_ok());
+    }
+
+    #[test]
+    fn delete_run_data_cascades_the_runs_rows() {
+        // Deleting the `wf_run` row must take its journal, execs, and messages
+        // with it (0019 ON DELETE CASCADE + the connection's foreign_keys
+        // pragma), and tolerate an already-missing run directory.
+        let tmp = tempfile::tempdir().unwrap();
+        let db = crate::database::init(tmp.path()).unwrap();
+        let conn = db.lock();
+        conn.execute(
+            "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,branch,
+                base_sha,status,budgets_json,spent_json,created_at,updated_at)
+             VALUES ('r-del','n','{}','t','p','/r','/d','wf/x','sha','done','{}','{}',0,0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO wf_step_exec (id,run_id,step_id,attempt,iteration,status,gate_mode)
+             VALUES ('e1','r-del','s',1,0,'done','verdict')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO wf_event (run_id,seq,ts,type,payload_json)
+             VALUES ('r-del',1,0,'run_launched','{}')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO wf_message (id,run_id,kind,body_json,status,created_at)
+             VALUES ('m1','r-del','report','{}','delivered',0)",
+            [],
+        )
+        .unwrap();
+
+        delete_run_data(&conn, "r-del").expect("delete succeeds without a run dir on disk");
+
+        let count = |table: &str| -> i64 {
+            conn.query_row(
+                &format!("SELECT COUNT(*) FROM {table} WHERE run_id = 'r-del'"),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+        let runs: i64 = conn
+            .query_row("SELECT COUNT(*) FROM wf_run WHERE id='r-del'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(runs, 0);
+        assert_eq!(count("wf_step_exec"), 0, "execs cascade");
+        assert_eq!(count("wf_event"), 0, "journal cascades");
+        assert_eq!(count("wf_message"), 0, "messages cascade");
     }
 
     #[test]

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -5711,19 +5711,47 @@ fn check_deletable(conn: &Connection, run_ids: &[String]) -> Result<()> {
 
 /// Delete one run's on-disk directory and its DB rows. The row delete cascades
 /// `wf_step_exec` / `wf_event` / `wf_message` (0019 + `PRAGMA foreign_keys`).
-/// A missing run dir is fine — a retried partial delete or a cleaned disk.
 fn delete_run_data(conn: &Connection, run_id: &str) -> Result<()> {
-    match std::fs::remove_dir_all(blackboard::run_dir(run_id)?) {
-        Ok(()) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+    delete_run_data_at(conn, run_id, &blackboard::run_dir(run_id)?)
+}
+
+/// Inner form taking the resolved run dir, so tests can exercise the staging
+/// without the process-global `FLETCH_RUNS_ROOT` override.
+///
+/// The row delete is the commit point: the dir is first staged aside with an
+/// atomic rename and renamed back if the row delete fails, so a run that
+/// survives the command is always openable — never a visible row whose
+/// blackboard and run repo are already gone. Only once the rows are gone is
+/// the staged dir actually removed (best-effort: at that point the run no
+/// longer exists to retry against, and a leftover `<id>.deleting` dir is
+/// invisible junk, which the next attempt would also sweep). A missing dir is
+/// fine — a retried partial delete or a cleaned disk.
+fn delete_run_data_at(conn: &Connection, run_id: &str, dir: &Path) -> Result<()> {
+    let staged = dir.with_file_name(format!(
+        "{}.deleting",
+        dir.file_name().and_then(|n| n.to_str()).unwrap_or(run_id)
+    ));
+    let dir_staged = match std::fs::rename(dir, &staged) {
+        Ok(()) => true,
+        // No live dir: never provisioned, a cleaned disk, or a previous
+        // attempt that crashed between this rename and the row delete — in
+        // that last case the staged dir survives and is swept below.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => staged.exists(),
         Err(e) => {
             return Err(Error::Other(format!(
-                "cannot remove run dir for {run_id}: {e}"
+                "cannot stage run dir for {run_id}: {e}"
             )))
         }
+    };
+    if let Err(e) = conn.execute("DELETE FROM wf_run WHERE id = ?1", [run_id]) {
+        if dir_staged {
+            let _ = std::fs::rename(&staged, dir);
+        }
+        return Err(Error::Other(e.to_string()));
     }
-    conn.execute("DELETE FROM wf_run WHERE id = ?1", [run_id])
-        .map_err(|e| Error::Other(e.to_string()))?;
+    if dir_staged {
+        let _ = std::fs::remove_dir_all(&staged);
+    }
     Ok(())
 }
 
@@ -7046,7 +7074,12 @@ mod tests {
         )
         .unwrap();
 
-        delete_run_data(&conn, "r-del").expect("delete succeeds without a run dir on disk");
+        // A real run dir with content: it must be gone (not just staged) after.
+        let dir = tmp.path().join("runs").join("r-del");
+        std::fs::create_dir_all(dir.join("blackboard")).unwrap();
+        std::fs::write(dir.join("blackboard").join("task.md"), "t").unwrap();
+
+        delete_run_data_at(&conn, "r-del", &dir).expect("delete succeeds");
 
         let count = |table: &str| -> i64 {
             conn.query_row(
@@ -7065,6 +7098,79 @@ mod tests {
         assert_eq!(count("wf_step_exec"), 0, "execs cascade");
         assert_eq!(count("wf_event"), 0, "journal cascades");
         assert_eq!(count("wf_message"), 0, "messages cascade");
+        assert!(!dir.exists(), "run dir removed");
+        assert!(
+            !dir.with_file_name("r-del.deleting").exists(),
+            "no staged dir left behind"
+        );
+    }
+
+    #[test]
+    fn delete_run_data_restores_the_dir_when_the_row_delete_fails() {
+        // The row delete is the commit point: if it fails, the staged dir is
+        // renamed back so the surviving run row never points at missing state.
+        // The failure here is real — a child run's parent_run_id FK (no
+        // cascade) rejects deleting the parent row.
+        let tmp = tempfile::tempdir().unwrap();
+        let db = crate::database::init(tmp.path()).unwrap();
+        let conn = db.lock();
+        let insert = |id: &str, parent: Option<&str>| {
+            conn.execute(
+                "INSERT INTO wf_run (id,parent_run_id,name,spec_json,task,project_id,repo_path,
+                    run_dir,branch,base_sha,status,budgets_json,spent_json,created_at,updated_at)
+                 VALUES (?1,?2,'n','{}','t','p','/r','/d','wf/x','sha','done','{}','{}',0,0)",
+                rusqlite::params![id, parent],
+            )
+            .unwrap();
+        };
+        insert("r-parent", None);
+        insert("r-child", Some("r-parent"));
+        let dir = tmp.path().join("runs").join("r-parent");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("marker"), "m").unwrap();
+
+        let err = delete_run_data_at(&conn, "r-parent", &dir).unwrap_err();
+        assert!(err.to_string().contains("FOREIGN KEY"), "{err}");
+        assert!(dir.join("marker").exists(), "dir renamed back intact");
+        assert!(
+            !dir.with_file_name("r-parent.deleting").exists(),
+            "staged dir gone after restore"
+        );
+        let runs: i64 = conn
+            .query_row("SELECT COUNT(*) FROM wf_run WHERE id='r-parent'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(runs, 1, "row untouched");
+    }
+
+    #[test]
+    fn delete_run_data_sweeps_a_crashed_attempts_staged_dir() {
+        // A crash between the staging rename and the row delete leaves rows
+        // plus a `<id>.deleting` dir and no live dir; the retry must finish
+        // the job rather than orphan the staged dir.
+        let tmp = tempfile::tempdir().unwrap();
+        let db = crate::database::init(tmp.path()).unwrap();
+        let conn = db.lock();
+        conn.execute(
+            "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,branch,
+                base_sha,status,budgets_json,spent_json,created_at,updated_at)
+             VALUES ('r-crash','n','{}','t','p','/r','/d','wf/x','sha','done','{}','{}',0,0)",
+            [],
+        )
+        .unwrap();
+        let dir = tmp.path().join("runs").join("r-crash");
+        let staged = dir.with_file_name("r-crash.deleting");
+        std::fs::create_dir_all(&staged).unwrap();
+
+        delete_run_data_at(&conn, "r-crash", &dir).expect("retry completes");
+        assert!(!staged.exists(), "leftover staged dir swept");
+        let runs: i64 = conn
+            .query_row("SELECT COUNT(*) FROM wf_run WHERE id='r-crash'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(runs, 0);
     }
 
     #[test]

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -272,11 +272,27 @@ impl WorkflowService {
             return false;
         }
 
-        for agent in supervisor.workspace.agents_for_run(run_id) {
-            if let Err(e) = supervisor.clone().discard_agent(&agent.id).await {
-                errors.push(format!("run {run_id}: discard agent {}: {e}", agent.id));
-                return false;
-            }
+        // Discard every owned workspace before giving up, rather than bailing on
+        // the first failure: a single wedged agent must not strand the others,
+        // which would leave the surviving (kept-for-retry) run showing some
+        // agents already gone and others intact. A successful discard removes the
+        // workspace row, so `agents_for_run` no longer lists it — a re-delete
+        // only sees the ones that failed, and retries just those.
+        let agent_ids: Vec<String> = supervisor
+            .workspace
+            .agents_for_run(run_id)
+            .into_iter()
+            .map(|a| a.id)
+            .collect();
+        let all_discarded = discard_all(&agent_ids, run_id, errors, |id| {
+            let sup = supervisor.clone();
+            async move { sup.discard_agent(&id).await }
+        })
+        .await;
+        if !all_discarded {
+            // A workspace survives; keep this run's row (and, via `false`, its
+            // ancestors') so a re-delete rediscovers and finishes the cleanup.
+            return false;
         }
         let deleted = {
             let conn = self.db.lock();
@@ -5723,6 +5739,33 @@ fn delete_run_data(conn: &Connection, run_id: &str) -> Result<()> {
     delete_run_data_at(conn, run_id, &blackboard::run_dir(run_id)?)
 }
 
+/// Discard every id, pressing on past a failure instead of bailing on the first
+/// (the review blocker): one wedged agent must not strand the run's other
+/// workspaces. Returns whether *all* discards succeeded — the caller keeps the
+/// run row (for a re-delete) whenever any failed. A per-failure message lands in
+/// `errors`. Split out from [`WorkflowService::delete_tree`] so the policy is
+/// unit-testable without a real `Supervisor` (whose discards can't be made to
+/// fail on demand).
+async fn discard_all<F, Fut>(
+    ids: &[String],
+    run_id: &str,
+    errors: &mut Vec<String>,
+    discard: F,
+) -> bool
+where
+    F: Fn(String) -> Fut,
+    Fut: std::future::Future<Output = Result<()>>,
+{
+    let mut all = true;
+    for id in ids {
+        if let Err(e) = discard(id.clone()).await {
+            errors.push(format!("run {run_id}: discard agent {id}: {e}"));
+            all = false;
+        }
+    }
+    all
+}
+
 /// Inner form taking the resolved run dir, so tests can exercise the staging
 /// without the process-global `FLETCH_RUNS_ROOT` override.
 ///
@@ -7082,6 +7125,50 @@ mod tests {
         )
         .unwrap();
         assert!(check_deletable(&conn, &order).is_ok());
+    }
+
+    #[tokio::test]
+    async fn discard_all_presses_past_a_failure_and_reports_it() {
+        // The review blocker: a discard failing mid-loop must not strand the
+        // run's other workspaces. Every id is attempted; the surviving one is
+        // reported; the "all succeeded" result is false so the caller keeps the
+        // run row for a re-delete.
+        let ids = vec!["a1".to_string(), "a2".to_string(), "a3".to_string()];
+        let mut errors = Vec::new();
+        let attempted = std::sync::Mutex::new(Vec::new());
+        let all = discard_all(&ids, "r", &mut errors, |id| {
+            attempted.lock().unwrap().push(id.clone());
+            async move {
+                if id == "a2" {
+                    Err(Error::Other("wedged checkout".into()))
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .await;
+
+        assert!(!all, "a failed discard means not-all-discarded");
+        assert_eq!(
+            *attempted.lock().unwrap(),
+            vec!["a1", "a2", "a3"],
+            "every agent is attempted even after a1..a2 — the loop does not bail"
+        );
+        assert_eq!(errors.len(), 1, "only the failed discard is reported");
+        assert!(
+            errors[0].contains("a2") && errors[0].contains("wedged checkout"),
+            "the failure names the agent and cause: {}",
+            errors[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn discard_all_is_all_when_every_discard_succeeds() {
+        let ids = vec!["a1".to_string(), "a2".to_string()];
+        let mut errors = Vec::new();
+        let all = discard_all(&ids, "r", &mut errors, |_| async { Ok(()) }).await;
+        assert!(all);
+        assert!(errors.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/workflow/spec.rs
+++ b/src-tauri/src/workflow/spec.rs
@@ -323,6 +323,17 @@ fn walk_blocks(
             Block::Loop(lp) => check_loop(lp, spec, seen_ids, errors),
             Block::Orchestrate(orch) => {
                 check_agent_ref("orchestrate", &orch.agent, spec, errors);
+                if matches!(orch.integrate, Integrate::Merge) {
+                    // The engine runs orchestrate stages with `integrate: none`
+                    // only (§6.6); merge over the parallel-stage machinery is a
+                    // follow-up. Rejecting here keeps a definition that would
+                    // die at launch from ever persisting.
+                    errors.push(format!(
+                        "orchestrate '{}' integrate: merge is not supported yet — \
+                         use integrate: none",
+                        orch.agent
+                    ));
+                }
                 if orch.comms.contains(&CommsCap::Notify) {
                     // `comms` is the children's caps; children are steps, so
                     // `notify` (orchestrator-only, §5.1) is invalid here too.
@@ -371,6 +382,18 @@ fn check_loop(
 ) {
     if lp.max < 1 {
         errors.push("loop.max must be ≥ 1".into());
+    }
+    // The engine executes loop bodies of plain steps only (§6.6); nesting
+    // parallel/loop/orchestrate inside a body is a follow-up. Reject at
+    // validation so the shape never saves, rather than dying at launch.
+    for b in &lp.body {
+        if !matches!(b, Block::Step(_)) {
+            errors.push(
+                "loop body blocks must be steps — nested parallel/loop/orchestrate \
+                 inside a loop is not supported yet"
+                    .into(),
+            );
+        }
     }
     // The `until.step` must be a step *inside this loop's body*, and its gate
     // must be `verdict` — the exit reads that verdict, so a tests/commit gate
@@ -674,7 +697,7 @@ mod tests {
             }),
             body: vec![],
             join: Join::All,
-            integrate: Integrate::Merge,
+            integrate: Integrate::None,
             comms: vec![CommsCap::Report, CommsCap::Ask],
             compose: Some(ComposeLimits {
                 max_sub_runs: 2,
@@ -682,6 +705,66 @@ mod tests {
             }),
         })];
         assert!(validate(&s).is_ok(), "{:?}", errors(&s));
+    }
+
+    #[test]
+    fn orchestrate_integrate_merge_rejected() {
+        // The engine only runs orchestrate with `integrate: none` (§6.6) — the
+        // unsupported shape must fail validation, not die at launch.
+        let mut s = minimal();
+        s.workflow = vec![Block::Orchestrate(Orchestrate {
+            agent: "coder".into(),
+            goal: "lead".into(),
+            children: None,
+            body: vec![],
+            join: Join::All,
+            integrate: Integrate::Merge,
+            comms: vec![],
+            compose: None,
+        })];
+        assert!(errors(&s)
+            .iter()
+            .any(|e| e.contains("integrate: merge is not supported")));
+    }
+
+    #[test]
+    fn loop_with_nested_block_rejected() {
+        // Loop bodies are plain steps in v1 (§6.6) — a nested parallel must fail
+        // validation, not die at launch.
+        let mut s = minimal();
+        s.workflow = vec![Block::Loop(Loop {
+            max: 2,
+            until: Until {
+                step: "check".into(),
+                verdict: LoopVerdict::Done,
+            },
+            body: vec![
+                Block::Parallel(Parallel {
+                    join: Join::All,
+                    integrate: Integrate::None,
+                    max_concurrent: None,
+                    steps: vec![Step {
+                        id: "fan".into(),
+                        agent: "coder".into(),
+                        goal: "g".into(),
+                        gate: Gate::Verdict,
+                        budgets: None,
+                        comms: vec![],
+                    }],
+                }),
+                Block::Step(Step {
+                    id: "check".into(),
+                    agent: "coder".into(),
+                    goal: "g".into(),
+                    gate: Gate::Verdict,
+                    budgets: None,
+                    comms: vec![],
+                }),
+            ],
+        })];
+        assert!(errors(&s)
+            .iter()
+            .any(|e| e.contains("loop body blocks must be steps")));
     }
 
     #[test]

--- a/src-tauri/src/workflow/yaml.rs
+++ b/src-tauri/src/workflow/yaml.rs
@@ -428,7 +428,7 @@ workflow:
         When a slice a sibling depends on lands, notify that sibling.
       children: { agent: coder, max: 3 }
       join: all
-      integrate: merge
+      integrate: none
       comms: [report, ask]
       compose: { max_sub_runs: 2, max_depth: 2 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -701,6 +701,10 @@ export const api = {
    *  asking step and resumes. `messageId` is the pending `ask` message id. */
   wfAnswer: (projectId: string, runId: string, messageId: string, body: string) =>
     invoke<void>("wf_answer", { projectId, runId, messageId, body }),
+  /** Delete a terminal run and everything it owns (§13): its run-owned step
+   *  agents (and their chats), `~/.fletch/runs/<id>/`, and its rows. Cascades
+   *  over composed sub-runs; rejected while any run in the tree is active. */
+  wfDeleteRun: (runId: string) => invoke<void>("wf_delete_run", { runId }),
 
   // ── Workflows v1: definition storage (spec §13, `wf_def_*`) ──
   /** Validate and persist a workflow definition. Omit `id` to create; pass an
@@ -832,6 +836,12 @@ export function onWfEvent(cb: (e: WfEventEnvelope) => void): Promise<UnlistenFn>
 /** Fires whenever a run row changes; carries the full row. */
 export function onWfRun(cb: (e: WfRun) => void): Promise<UnlistenFn> {
   return listen<WfRun>("wf:run", (event) => cb(event.payload));
+}
+
+/** `wf:run-deleted` fires the deleted run's id after `wf_delete_run` removes its
+ *  rows, so the sidebar drops the row instead of upserting it. */
+export function onWfRunDeleted(cb: (runId: string) => void): Promise<UnlistenFn> {
+  return listen<string>("wf:run-deleted", (event) => cb(event.payload));
 }
 
 /** Payload of the `agent-install:state` event: progress of a one-click agent

--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -468,6 +468,13 @@
 .ag-act:active {
   background: var(--selected);
 }
+/* An armed destructive action (a run row's delete after the first click):
+ * stays red until the pointer leaves the row, so the confirming second click
+ * is visibly different from the first. */
+.ag-act.confirm-del,
+.ag-act.confirm-del:hover {
+  color: var(--danger);
+}
 .ag-act.tip[data-tip]:hover::after {
   left: auto;
   right: 0;

--- a/src/workflows/builder/blocks/BlockSequence.tsx
+++ b/src/workflows/builder/blocks/BlockSequence.tsx
@@ -54,6 +54,9 @@ export function BlockSequence({
 }) {
   const [menu, setMenu] = useState(false);
   const canRemove = blocks.length > 1 || seqNid !== null;
+  // A non-null seqNid means this is a loop body, and the engine executes loop
+  // bodies of plain steps only (spec §6.6) — don't offer containers there.
+  const blockTypes = seqNid === null ? BLOCK_TYPES : BLOCK_TYPES.filter((t) => t.id === "step");
 
   return (
     <div className="wb-seq">
@@ -80,7 +83,7 @@ export function BlockSequence({
               onClick={() => setMenu(false)}
             />
             <div className="dd wb-add-menu">
-              {BLOCK_TYPES.map((t) => (
+              {blockTypes.map((t) => (
                 <div
                   key={t.id}
                   className="dd-item"

--- a/src/workflows/builder/blocks/OrchestrateContainer.tsx
+++ b/src/workflows/builder/blocks/OrchestrateContainer.tsx
@@ -1,8 +1,8 @@
 // OrchestrateContainer.tsx — a lead agent coordinating children (spec §6.6/§10).
 // The orchestrator card sits above its static children; toggles expose the
-// dynamic-children template, comms caps, and dynamic-composition limits. This
-// renders now even though orchestrate *execution* lands in a later slice — it is
-// gated behind the same validation as everything else.
+// dynamic-children template, comms caps, and dynamic-composition limits. The
+// engine runs orchestrate stages with `integrate: none` only, so `merge` is not
+// offered (a legacy value renders disabled and validation flags it).
 
 import { Icon } from "../../../components/Icon";
 import { STEP_COMMS } from "../../data";
@@ -53,7 +53,14 @@ export function OrchestrateContainer({ block, ctx }: { block: EOrchestrate; ctx:
             }
           >
             <option value="none">none</option>
-            <option value="merge">merge</option>
+            {/* The engine runs orchestrate with integrate: none only (§6.6); a
+                legacy definition may still carry merge — render it so the value
+                is visible and switchable, but don't offer it. */}
+            {block.integrate === "merge" && (
+              <option value="merge" disabled>
+                merge (unsupported)
+              </option>
+            )}
           </select>
         </label>
         <span className="grow" />

--- a/src/workflows/builder/model.test.ts
+++ b/src/workflows/builder/model.test.ts
@@ -39,7 +39,7 @@ function canonicalSpec(): Spec {
           goal: "Assign one slice from PLAN.md per coder. Answer their questions.",
           children: { agent: "coder", max: 3 },
           join: "all",
-          integrate: "merge",
+          integrate: "none",
           comms: ["report", "ask"],
           compose: { max_sub_runs: 2, max_depth: 2 },
         },
@@ -187,6 +187,35 @@ describe("validation mirrors the load-bearing §5.2 rules", () => {
     const v = validateEditor(editor);
     expect(v.ok).toBe(false);
     if (loop) expect(v.byNode[loop.nid]?.some((m) => m.includes("max"))).toBe(true);
+  });
+
+  it("flags orchestrate integrate: merge as unsupported", () => {
+    const editor = fromDefinition(asDefinition(canonicalSpec()));
+    const orch = editor.blocks.find((b) => b.kind === "orchestrate");
+    if (orch?.kind === "orchestrate") orch.integrate = "merge";
+    const v = validateEditor(editor);
+    expect(v.ok).toBe(false);
+    if (orch) expect(v.byNode[orch.nid]?.some((m) => m.includes("not supported"))).toBe(true);
+  });
+
+  it("flags a non-step block inside a loop body", () => {
+    const editor = fromDefinition(asDefinition(canonicalSpec()));
+    const loop = editor.blocks.find((b) => b.kind === "loop");
+    if (loop?.kind === "loop") {
+      loop.body.push({
+        kind: "parallel",
+        nid: "n-par",
+        join: "all",
+        integrate: "none",
+        maxConcurrent: null,
+        steps: [],
+      });
+    }
+    const v = validateEditor(editor);
+    expect(v.ok).toBe(false);
+    if (loop) {
+      expect(v.byNode[loop.nid]?.some((m) => m.includes("must be steps"))).toBe(true);
+    }
   });
 
   it("rejects an absolute artifact path", () => {

--- a/src/workflows/builder/model.ts
+++ b/src/workflows/builder/model.ts
@@ -502,6 +502,9 @@ function validateBlocks(blocks: EBlock[], v: Validation, seen: Map<string, EStep
     } else if (b.kind === "loop") {
       const errs: string[] = [];
       if (b.max < 1) errs.push("max iterations must be ≥ 1");
+      if (b.body.some((x) => x.kind !== "step")) {
+        errs.push("loop body blocks must be steps — nesting isn't supported yet");
+      }
       const until = b.untilNid ? findStepByNid(b.body, b.untilNid) : null;
       if (!until) errs.push("choose which step's verdict ends the loop");
       else if (until.gate.type !== "verdict") {
@@ -512,6 +515,9 @@ function validateBlocks(blocks: EBlock[], v: Validation, seen: Map<string, EStep
     } else {
       const errs: string[] = [];
       if (!b.agent) errs.push("assign an orchestrator agent");
+      if (b.integrate === "merge") {
+        errs.push("integrate: merge is not supported yet — use none");
+      }
       if (b.children && b.children.max < 1) errs.push("children max must be ≥ 1");
       if (b.children && !b.children.agent) errs.push("choose the child agent");
       if (b.compose) {

--- a/src/workflows/data.ts
+++ b/src/workflows/data.ts
@@ -100,6 +100,6 @@ export const BLOCK_TYPES: BlockTypeDef[] = [
     id: "orchestrate",
     label: "Orchestrate",
     icon: "combine",
-    note: "A lead agent coordinates children (execution lands in a later release).",
+    note: "A lead agent assigns work to children and answers their questions.",
   },
 ];

--- a/src/workflows/run/RunRow.tsx
+++ b/src/workflows/run/RunRow.tsx
@@ -3,7 +3,7 @@
 // it as a run, a chip shows the flow's lead agent, a paused-reason badge names
 // why it's waiting, and it can be stopped the same way as an agent.
 
-import type { KeyboardEvent, MouseEvent } from "react";
+import { type KeyboardEvent, type MouseEvent, useState } from "react";
 import { api, type WfRun } from "../../api";
 import { Icon } from "../../components/Icon";
 import { useAppStore } from "../../store";
@@ -34,6 +34,12 @@ export function RunRow({
 
   const working = run.status === "running";
   const stoppable = run.status === "running" || run.status === "pending";
+  // Delete is the inverse gate (§13: terminal runs only). It is destructive and
+  // irreversible — the run's step-agent chats go with it — so it takes two
+  // clicks: the first arms the button and the tooltip states what is lost.
+  const deletable =
+    run.status === "done" || run.status === "failed" || run.status === "canceled";
+  const [confirmDelete, setConfirmDelete] = useState(false);
   // Same left-spine vocabulary as an agent row: live → accent, failed → danger,
   // everything else (pending/paused/done/canceled) → the faint idle grey.
   const railClass = working ? "run" : run.status === "failed" ? "err" : "idle";
@@ -62,6 +68,20 @@ export function RunRow({
     }
   };
 
+  const onDelete = async (e: MouseEvent) => {
+    e.stopPropagation();
+    if (!confirmDelete) {
+      setConfirmDelete(true);
+      return;
+    }
+    try {
+      await api.wfDeleteRun(run.id);
+    } catch (err) {
+      setLastError(`Failed to delete run: ${err}`);
+      setConfirmDelete(false);
+    }
+  };
+
   return (
     <div
       className={`agent ${selected ? "active" : ""} ${nested ? "run-nested" : ""}`}
@@ -77,6 +97,7 @@ export function RunRow({
           onSelect();
         }
       }}
+      onMouseLeave={() => setConfirmDelete(false)}
     >
       <span className={`ag-rail ${railClass}`} />
       <div className="agent-row">
@@ -112,6 +133,20 @@ export function RunRow({
                 aria-label="Stop"
               >
                 <Icon name="stop" size={11} />
+              </button>
+            )}
+            {deletable && (
+              <button
+                className={`ag-act tip ${confirmDelete ? "confirm-del" : ""}`}
+                data-tip={
+                  confirmDelete
+                    ? "Deletes this run's chats too — click again to confirm"
+                    : "Delete run"
+                }
+                onClick={(e) => void onDelete(e)}
+                aria-label="Delete run"
+              >
+                <Icon name="trash" size={11} />
               </button>
             )}
           </span>

--- a/src/workflows/run/RunRow.tsx
+++ b/src/workflows/run/RunRow.tsx
@@ -37,8 +37,7 @@ export function RunRow({
   // Delete is the inverse gate (§13: terminal runs only). It is destructive and
   // irreversible — the run's step-agent chats go with it — so it takes two
   // clicks: the first arms the button and the tooltip states what is lost.
-  const deletable =
-    run.status === "done" || run.status === "failed" || run.status === "canceled";
+  const deletable = run.status === "done" || run.status === "failed" || run.status === "canceled";
   const [confirmDelete, setConfirmDelete] = useState(false);
   // Same left-spine vocabulary as an agent row: live → accent, failed → danger,
   // everything else (pending/paused/done/canceled) → the faint idle grey.

--- a/src/workflows/run/useRuns.ts
+++ b/src/workflows/run/useRuns.ts
@@ -5,7 +5,7 @@
 // (`resume_active_runs` on startup), so this hook is a pure view.
 
 import { useEffect, useState } from "react";
-import { api, onWfRun, type WfRun } from "../../api";
+import { api, onWfRun, onWfRunDeleted, type WfRun } from "../../api";
 
 export function useRuns(): WfRun[] {
   const [runs, setRuns] = useState<WfRun[]>([]);
@@ -28,10 +28,14 @@ export function useRuns(): WfRun[] {
         return next;
       });
     });
+    const offDeleted = onWfRunDeleted((runId) => {
+      setRuns((prev) => prev.filter((r) => r.id !== runId));
+    });
 
     return () => {
       alive = false;
       void off.then((f) => f());
+      void offDeleted.then((f) => f());
     };
   }, []);
 


### PR DESCRIPTION
Closes the three remaining merge blockers from the workflows v1 implementation review, following up on #428.

## #6 — `wf_compose` was undiscoverable
The engine side (validation, budget reservation, sub-run launch) was fully built and tested, but no prompt ever mentioned the op. The orchestrator's opening prompt now describes `wf_compose` and its args contract (fragment shape, required `budgets.turns` slice, `integrate`/`base` vocabulary, the stage's `max_sub_runs` cap) — gated on the stage actually enabling composition, so a stage without `compose` never mentions it. TECH_SPEC §10.3 records the prompt as the op's discovery point.

## #5 — builder/engine expressiveness mismatch
`ensure_executable` rejected non-step loop bodies and `orchestrate integrate: merge` only at drive time, while `spec::validate` and the builder accepted them — a definition could save cleanly and die at launch, and the canonical §5.3 example itself carried the unrunnable `integrate: merge`. Both rules now live in `spec::validate` (save/import/launch) and are mirrored in the builder: the loop body's add-block menu offers steps only, orchestrate no longer offers `merge` (a legacy value renders disabled and is flagged inline), and the TS validator names both violations. `ensure_executable` stays as a backstop. Canonical fixtures (yaml.rs, model.test.ts, TECH_SPEC §5.3) move to `integrate: none`; §5.2/§6.6 record the v1 limits.

## #8 — `wf_delete_run` was missing entirely
Spec'd in §13 and QA §9 but never built — terminal runs, their run dirs, and their run-owned workspaces accumulated forever. `WorkflowService::delete_run` walks the run tree children-first (the `parent_run_id` FK deliberately has no cascade), guards that every run in the tree is terminal and has no winding-down driver before touching anything, then per run discards run-owned step-agent workspaces through the supervisor, removes `~/.fletch/runs/<id>/`, and deletes the `wf_run` row (execs/journal/messages cascade via 0019). A `wf:run-deleted` event drops the row from the sidebar. UI: terminal-only delete action on the run row — first click arms it and the tooltip states chats are lost, second click deletes; the monitor's existing "Run not found" state covers a deleted-while-open run.

## Tests
- Rust: 822 passed (new: compose-prompt gating, integrate-merge/loop-nesting validation, delete guard + tree order, row-cascade delete); clippy clean with the CI invocation.
- Frontend: 407 passed (new: TS validator mirrors for both #5 rules); tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)