### PR TITLE
fix(workflows): builder agent selection, chip centering, and dropdown/tooltip clipping

### DIFF
--- a/src/workflows/builder/AgentAvatar.tsx
+++ b/src/workflows/builder/AgentAvatar.tsx
@@ -35,7 +35,7 @@ export function AgentAvatar({
     ["--ph" as string]: "oklch(.65 .13 var(--ph-h))",
   };
   return (
-    <span className="chip-mono" style={style}>
+    <span className="chip-mono iflex-center" style={style}>
       {short}
     </span>
   );

--- a/src/workflows/builder/WorkflowBuilder.tsx
+++ b/src/workflows/builder/WorkflowBuilder.tsx
@@ -58,7 +58,14 @@ export function WorkflowBuilder({
 
   const ctx: BuilderCtx = useMemo(
     () => ({
-      resolve: (id) => resolveAgent(id, agents, modelsByAgent),
+      resolve: (id) => {
+        if (!id) return null;
+        // `id` is an alias into `state.agents`; resolve it to the underlying
+        // custom-agent id or base provider before rendering. (Base-provider
+        // aliases happen to equal the provider id, but custom ones don't.)
+        const spec = state.agents[id];
+        return resolveAgent(spec?.custom_agent ?? spec?.base ?? id, agents, modelsByAgent);
+      },
       errorsFor: (nid) => validation.byNode[nid],
       patchStep: (nid, patch) => setState((s) => patchStep(s, nid, patch)),
       patchBlock: (nid, patch) => setState((s) => patchBlock(s, nid, patch)),
@@ -70,7 +77,7 @@ export function WorkflowBuilder({
       openGate: (nid, e) => setPop({ type: "gate", nid, rect: rectFrom(e) }),
       openBudgets: (target, e) => setPop({ type: "budgets", target, rect: rectFrom(e) }),
     }),
-    [agents, modelsByAgent, validation],
+    [agents, modelsByAgent, validation, state.agents],
   );
 
   const runBudgetLabel = state.budgets?.turns ? `${state.budgets.turns} turns` : "budgets";

--- a/src/workflows/builder/WorkflowBuilder.tsx
+++ b/src/workflows/builder/WorkflowBuilder.tsx
@@ -3,7 +3,7 @@
 // edit or open a popover. Validation from `model.ts` renders inline and gates
 // the save. Persistence is the caller's job (Save hands back the editor state).
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Icon } from "../../components/Icon";
 import type { ModelMeta } from "../../data/modelCatalog/types";
 import type { CustomAgent } from "../../storage/customAgents";
@@ -53,6 +53,21 @@ export function WorkflowBuilder({
   const [state, setState] = useState<EditorState>(initial);
   const [pop, setPop] = useState<Pop | null>(null);
   const closePop = () => setPop(null);
+
+  // Every popover is fixed-positioned from a rect captured at open time, which
+  // goes stale once the canvas scrolls or the window resizes. Dismiss on either
+  // so the popover can never float away from its trigger. Capture-phase catches
+  // scrolls in the horizontal canvas scroller (scroll events don't bubble).
+  useEffect(() => {
+    if (!pop) return;
+    const close = () => setPop(null);
+    window.addEventListener("scroll", close, true);
+    window.addEventListener("resize", close);
+    return () => {
+      window.removeEventListener("scroll", close, true);
+      window.removeEventListener("resize", close);
+    };
+  }, [pop]);
 
   const validation = useMemo(() => validateEditor(state), [state]);
 

--- a/src/workflows/builder/blocks/BlockSequence.tsx
+++ b/src/workflows/builder/blocks/BlockSequence.tsx
@@ -52,7 +52,9 @@ export function BlockSequence({
   seqNid: NodeId | null;
   ctx: BuilderCtx;
 }) {
-  const [menu, setMenu] = useState(false);
+  // The menu is fixed-positioned from the button's rect so it escapes the
+  // canvas's overflow clip (same trick as the builder's other popovers).
+  const [menu, setMenu] = useState<{ top: number; left: number } | null>(null);
   const canRemove = blocks.length > 1 || seqNid !== null;
   // A non-null seqNid means this is a loop body, and the engine executes loop
   // bodies of plain steps only (spec §6.6) — don't offer containers there.
@@ -70,7 +72,13 @@ export function BlockSequence({
       {blocks.length > 0 && <Connector />}
 
       <div className="wb-addwrap">
-        <button className="wb-add" onClick={() => setMenu((m) => !m)}>
+        <button
+          className="wb-add"
+          onClick={(e) => {
+            const r = e.currentTarget.getBoundingClientRect();
+            setMenu((m) => (m ? null : { top: r.bottom, left: r.left }));
+          }}
+        >
           <span className="wb-add-ic">
             <Icon name="plus" />
           </span>
@@ -80,16 +88,19 @@ export function BlockSequence({
           <>
             <div
               style={{ position: "fixed", inset: 0, zIndex: 55 }}
-              onClick={() => setMenu(false)}
+              onClick={() => setMenu(null)}
             />
-            <div className="dd wb-add-menu">
+            <div
+              className="dd wb-add-menu"
+              style={{ position: "fixed", top: menu.top, left: menu.left }}
+            >
               {blockTypes.map((t) => (
                 <div
                   key={t.id}
                   className="dd-item"
                   onClick={() => {
                     ctx.addBlock(seqNid, t.id);
-                    setMenu(false);
+                    setMenu(null);
                   }}
                   style={{ alignItems: "flex-start", flexDirection: "column", gap: 2 }}
                 >

--- a/src/workflows/builder/blocks/BlockSequence.tsx
+++ b/src/workflows/builder/blocks/BlockSequence.tsx
@@ -2,7 +2,7 @@
 // and an "add block" menu. Used at the top level and (recursively) for loop
 // bodies, so it takes its owning sequence's nid (`null` = top level).
 
-import { Fragment, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import { Icon } from "../../../components/Icon";
 import { BLOCK_TYPES } from "../../data";
 import type { BuilderCtx } from "../ctx";
@@ -55,6 +55,21 @@ export function BlockSequence({
   // The menu is fixed-positioned from the button's rect so it escapes the
   // canvas's overflow clip (same trick as the builder's other popovers).
   const [menu, setMenu] = useState<{ top: number; left: number } | null>(null);
+
+  // The captured rect goes stale if the canvas scrolls or the window resizes
+  // (the trigger moves, the fixed menu doesn't). Dismiss on either — the
+  // conventional behavior for a transient dropdown. Capture-phase catches
+  // scrolls inside the horizontal canvas scroller, which don't bubble.
+  useEffect(() => {
+    if (!menu) return;
+    const close = () => setMenu(null);
+    window.addEventListener("scroll", close, true);
+    window.addEventListener("resize", close);
+    return () => {
+      window.removeEventListener("scroll", close, true);
+      window.removeEventListener("resize", close);
+    };
+  }, [menu]);
   const canRemove = blocks.length > 1 || seqNid !== null;
   // A non-null seqNid means this is a loop body, and the engine executes loop
   // bodies of plain steps only (spec §6.6) — don't offer containers there.

--- a/src/workflows/workflows.css
+++ b/src/workflows/workflows.css
@@ -1330,7 +1330,10 @@
   align-items: stretch;
 }
 .wb-canvas > .wb-seq {
-  padding: 44px 24px 26px;
+  /* A horizontal scroller clips vertically too, so the vertical padding doubles
+     as breathing room that keeps `data-tip-down` tooltips inside the scrollport
+     instead of being cut off at the card edges. */
+  padding: 44px 24px 44px;
   overflow-x: auto;
 }
 .wb-loop-body .wb-seq {


### PR DESCRIPTION
## Summary

Fixes three issues in the Settings → Workflows builder UI.

### 1. Custom agents couldn't be selected
`ctx.resolve(step.agent)` passed the **alias** (e.g. `my-reviewer`) directly to `resolveAgent`, which only resolves a custom-agent id or a provider id. Base providers worked by coincidence (`slugify("claude") === "claude"` equals the provider id), but custom-agent aliases matched nothing → `resolveAgent` returned `null` → the pick registered in state but rendered as "Choose agent", so clicking appeared to do nothing. Every other caller (`RunView`, `WorkflowComposer`, `WorkflowList`) already maps the alias through the spec; `ctx.resolve` was the outlier. It now resolves the alias via `state.agents` (`spec.custom_agent ?? spec.base`).

### 2. Custom-agent chip text stuck in the top-left corner
`.chip-mono` sets `justify-content: center` but no `display: flex`. `ProviderIcon` supplies that through the `iflex-center` utility; `AgentAvatar`'s custom `<span>` did not. Added `iflex-center` so the monogram centers like the brand-icon chips.

### 3. Dropdowns and tooltips clipped by the step wrapper
`.wb-canvas > .wb-seq` is a horizontal scroller (`overflow-x: auto`), which forces vertical clipping. The fixed popovers (agent/gate/budgets) already escape, but the absolute-positioned "Add block" menu and the CSS `.tip` tooltips were cut off. The Add-block menu is now `position: fixed` (positioned from the button rect, same pattern as the other popovers), and the scrollport's bottom padding was increased so `data-tip-down` tooltips stay visible.

## Testing
- `tsc --noEmit` — clean
- `biome check` on touched files — clean
- `vitest run src/workflows` — 33 tests pass

UI/CSS changes were not exercised in the running Tauri app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)