### PR TITLE
fix(timer): roll minutes into an hours field past 60m

### DIFF
--- a/src/components/Workspace/RunTimer.tsx
+++ b/src/components/Workspace/RunTimer.tsx
@@ -7,11 +7,16 @@ import { Icon } from "@/components/Icon";
 import { CopyButton } from "@/components/ui/CopyButton";
 
 /** Whole seconds under a minute; `{m}m {ss}s` (zero-padded seconds) at a
- *  minute or more. Never a leading `0m`, never decimals or an hours field. */
+ *  minute or more; `{h}h {mm}m {ss}s` at an hour or more. Never a leading
+ *  `0h`/`0m`, never decimals. */
 export function fmtDur(sec: number): string {
   sec = Math.max(0, Math.floor(sec));
-  const m = Math.floor(sec / 60);
+  const h = Math.floor(sec / 3600);
+  const m = Math.floor((sec % 3600) / 60);
   const s = sec % 60;
+  if (h > 0) {
+    return `${h}h ${String(m).padStart(2, "0")}m ${String(s).padStart(2, "0")}s`;
+  }
   return m === 0 ? `${s}s` : `${m}m ${String(s).padStart(2, "0")}s`;
 }
 

--- a/tests/components/Workspace/RunTimer.test.ts
+++ b/tests/components/Workspace/RunTimer.test.ts
@@ -12,6 +12,13 @@ describe("fmtDur", () => {
     expect(fmtDur(227)).toBe("3m 47s");
   });
 
+  it("rolls minutes into an hours field at an hour or more", () => {
+    expect(fmtDur(3600)).toBe("1h 00m 00s");
+    expect(fmtDur(3661)).toBe("1h 01m 01s");
+    expect(fmtDur(5312)).toBe("1h 28m 32s"); // was "88m 32s"
+    expect(fmtDur(7272)).toBe("2h 01m 12s"); // was "121m 12s"
+  });
+
   it("floors fractional seconds and clamps negatives to 0s", () => {
     expect(fmtDur(8.9)).toBe("8s");
     expect(fmtDur(-5)).toBe("0s");


### PR DESCRIPTION
## Problem

The chat run timer's `fmtDur` only ever split elapsed seconds into minutes and seconds, never rolling minutes into hours. Long turns rendered as `88m 32s` or `121m 12s` instead of `1h 28m 32s` / `2h 01m 12s`.

## Fix

Add an hours field: at an hour or more, `fmtDur` returns `{h}h {mm}m {ss}s` with zero-padded minutes and seconds. Sub-hour (`3m 47s`) and sub-minute (`8s`) formats, negative clamping, and fractional flooring are unchanged.

## Tests

Added cases in `RunTimer.test.ts` covering the hour boundary and both reported examples (`5312s` → `1h 28m 32s`, `7272s` → `2h 01m 12s`). All `fmtDur` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)