### PR TITLE
feat(fork): carry code — build a fork on a workspace's unmerged work

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -312,6 +312,8 @@ pub async fn spawn_agent(
             // and are never run-owned; the scheduler sets both for a step spawn.
             run_repo: None,
             owner_run_id: None,
+            // Carrying another workspace's working tree is a fork-only path.
+            carry_from: None,
         },
     )
     .await

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -476,6 +476,99 @@ pub async fn commit_all(repo: &Path, message: &str) -> Result<()> {
     Ok(())
 }
 
+/// Capture `checkout`'s current working tree — tracked modifications plus
+/// untracked, non-ignored files, and deletions — into a commit object WITHOUT
+/// touching the checkout's real index, HEAD, or working tree, and return its
+/// sha. Used by fork "carry code": the snapshot is created in the *source*
+/// checkout's object store (so a live agent is left undisturbed) and later
+/// fetched into the fork by [`carry_worktree`]. The snapshot's parent is the
+/// source's HEAD, so it records the full state (committed + uncommitted).
+pub async fn snapshot_worktree(checkout: &Path) -> Result<String> {
+    // A throwaway index so `add -A` never stages into the live agent's index.
+    let tmp = tempfile::Builder::new()
+        .prefix("fletch-fork-index-")
+        .tempfile()
+        .map_err(Error::from)?;
+    let index_env = vec![(
+        "GIT_INDEX_FILE".to_string(),
+        tmp.path().display().to_string(),
+    )];
+
+    // Seed the temp index from HEAD, then stage every working-tree change
+    // (adds/mods/dels, honoring .gitignore) into it — the snapshot tree.
+    let stage_env = merge_git_env(&[&index_env, &no_hooks_env()]);
+    run_git_env(
+        checkout,
+        &["read-tree", "HEAD"],
+        &stage_env,
+        "fork snapshot read-tree",
+    )
+    .await?;
+    run_git_env(checkout, &["add", "-A"], &stage_env, "fork snapshot add").await?;
+    let tree = run_git_env(
+        checkout,
+        &["write-tree"],
+        &stage_env,
+        "fork snapshot write-tree",
+    )
+    .await?;
+    let tree = String::from_utf8_lossy(&tree.stdout).trim().to_string();
+
+    // commit-tree writes no hooks but needs an identity, same fallback as commit.
+    let commit_env = merge_git_env(&[&index_env, &identity_env(checkout).await, &no_hooks_env()]);
+    let commit = run_git_env(
+        checkout,
+        &[
+            "commit-tree",
+            &tree,
+            "-p",
+            "HEAD",
+            "-m",
+            "fletch: fork snapshot",
+        ],
+        &commit_env,
+        "fork snapshot commit-tree",
+    )
+    .await?;
+    Ok(String::from_utf8_lossy(&commit.stdout).trim().to_string())
+}
+
+/// Point `dest`'s working tree at `snapshot` (fetched from the `source`
+/// checkout) while keeping `dest`'s HEAD on `base` — so the carried work shows
+/// as uncommitted changes against the fork's base, mirroring the parent's own
+/// diff. Used by fork "carry code" after `dest` is provisioned clean at `base`.
+pub async fn carry_worktree(dest: &Path, source: &Path, snapshot: &str, base: &str) -> Result<()> {
+    let source_str = source
+        .to_str()
+        .ok_or_else(|| Error::InvalidPath(source.display().to_string()))?;
+    // Bring the snapshot commit + its reachable objects into the fork's store.
+    run_git(
+        dest,
+        &["fetch", "--no-tags", source_str, snapshot],
+        "carry fetch",
+    )
+    .await?;
+    // Materialize the snapshot exactly (adds/mods/dels), then move HEAD + index
+    // back to base, leaving the working tree — so the delta reads as unstaged
+    // working-tree changes, exactly like the parent's uncommitted state.
+    let env = no_hooks_env();
+    run_git_env(
+        dest,
+        &["reset", "--hard", snapshot],
+        &env,
+        "carry reset --hard",
+    )
+    .await?;
+    run_git_env(
+        dest,
+        &["reset", "--mixed", base],
+        &env,
+        "carry reset --mixed",
+    )
+    .await?;
+    Ok(())
+}
+
 pub async fn worktree_remove(repo: &Path, worktree_path: &Path, force: bool) -> Result<()> {
     let mut args = vec!["worktree", "remove"];
     if force {
@@ -738,6 +831,57 @@ mod tests {
         // And the commit actually landed.
         let log = run_git(repo, &["log", "--oneline"], "log").await.unwrap();
         assert!(String::from_utf8_lossy(&log.stdout).contains("first"));
+    }
+
+    #[tokio::test]
+    async fn snapshot_and_carry_reproduce_working_tree_at_base() {
+        // Parent checkout: a base commit (with a .gitignore), then uncommitted
+        // work covering every case — modify, delete, add, and an ignored file.
+        let td = tempfile::tempdir().unwrap();
+        let src = td.path().join("src");
+        std::fs::create_dir(&src).unwrap();
+        init_repo(&src).await.unwrap();
+        config(&src, "user.email", "t@example.com").await;
+        config(&src, "user.name", "Tester").await;
+        std::fs::write(src.join(".gitignore"), b"ignored.txt\n").unwrap();
+        std::fs::write(src.join("keep.txt"), b"base").unwrap();
+        std::fs::write(src.join("drop.txt"), b"remove me").unwrap();
+        commit_all(&src, "base").await.unwrap();
+        let base = rev_parse(&src, "HEAD").await.unwrap();
+
+        std::fs::write(src.join("keep.txt"), b"modified").unwrap();
+        std::fs::remove_file(src.join("drop.txt")).unwrap();
+        std::fs::write(src.join("new.txt"), b"added").unwrap();
+        std::fs::write(src.join("ignored.txt"), b"secret").unwrap();
+
+        let snap = snapshot_worktree(&src).await.unwrap();
+        // No side effects on the live checkout: HEAD is untouched.
+        assert_eq!(rev_parse(&src, "HEAD").await.unwrap(), base);
+
+        // Fork checkout: a clone sitting at base, like a freshly-provisioned one.
+        let dst = td.path().join("dst");
+        let clone = Command::new("git")
+            .args(["clone", "-q", src.to_str().unwrap(), dst.to_str().unwrap()])
+            .output()
+            .await
+            .unwrap();
+        assert!(clone.status.success());
+
+        carry_worktree(&dst, &src, &snap, &base).await.unwrap();
+
+        // Working tree now mirrors the parent's: mod/add applied, deletion gone,
+        // ignored file never carried.
+        assert_eq!(std::fs::read(dst.join("keep.txt")).unwrap(), b"modified");
+        assert_eq!(std::fs::read(dst.join("new.txt")).unwrap(), b"added");
+        assert!(!dst.join("drop.txt").exists());
+        assert!(!dst.join("ignored.txt").exists());
+        // HEAD stays at base — the carried work reads as uncommitted changes.
+        assert_eq!(rev_parse(&dst, "HEAD").await.unwrap(), base);
+        let status = run_git(&dst, &["status", "--porcelain"], "status").await.unwrap();
+        assert!(
+            !String::from_utf8_lossy(&status.stdout).trim().is_empty(),
+            "carried changes should show as uncommitted"
+        );
     }
 
     #[test]

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -877,7 +877,9 @@ mod tests {
         assert!(!dst.join("ignored.txt").exists());
         // HEAD stays at base — the carried work reads as uncommitted changes.
         assert_eq!(rev_parse(&dst, "HEAD").await.unwrap(), base);
-        let status = run_git(&dst, &["status", "--porcelain"], "status").await.unwrap();
+        let status = run_git(&dst, &["status", "--porcelain"], "status")
+            .await
+            .unwrap();
         assert!(
             !String::from_utf8_lossy(&status.stdout).trim().is_empty(),
             "carried changes should show as uncommitted"

--- a/src-tauri/src/git_state.rs
+++ b/src-tauri/src/git_state.rs
@@ -222,9 +222,23 @@ async fn untracked_additions(checkout_path: &Path, rel: &str) -> u32 {
     }
 }
 
+/// Build a git command for this module's state queries with `GIT_OPTIONAL_LOCKS`
+/// disabled. Every invocation in `git_state` is read-only, but `git status` /
+/// `git diff HEAD` still take `.git/index.lock` for an *opportunistic* stat-cache
+/// refresh — which races a concurrent Fletch write on the same checkout (e.g. a
+/// fork's carry-code `reset`, or a user git-action) and fails with "Unable to
+/// create '.git/index.lock': File exists". `GIT_OPTIONAL_LOCKS=0` tells git to
+/// skip that refresh (the same knob editors/IDEs use); the only cost is a
+/// slightly staler stat cache, rebuilt by the next writing command.
+fn read_command(checkout_path: &Path) -> tokio::process::Command {
+    let mut cmd = crate::git_dist::command(checkout_path);
+    cmd.env("GIT_OPTIONAL_LOCKS", "0");
+    cmd
+}
+
 /// HEAD commit SHA, or `None` when it can't be read.
 async fn query_head_sha(checkout_path: &Path) -> Option<String> {
-    let out = crate::git_dist::command(checkout_path)
+    let out = read_command(checkout_path)
         .args(["rev-parse", "HEAD"])
         .output()
         .await
@@ -239,7 +253,7 @@ async fn query_head_sha(checkout_path: &Path) -> Option<String> {
 /// The `origin` remote: whether one exists at all, and its GitHub web base
 /// (`None` when missing or not a github.com remote).
 async fn query_origin(checkout_path: &Path) -> (bool, Option<String>) {
-    let out = match crate::git_dist::command(checkout_path)
+    let out = match read_command(checkout_path)
         .args(["remote", "get-url", "origin"])
         .output()
         .await
@@ -287,7 +301,7 @@ pub(crate) fn github_web_url(remote: &str) -> Option<String> {
 /// there is no upstream configured (branch never pushed), so the caller can
 /// fall back appropriately.
 async fn query_unpushed(checkout_path: &Path) -> Option<u32> {
-    let out = crate::git_dist::command(checkout_path)
+    let out = read_command(checkout_path)
         .args(["rev-list", "--count", "@{upstream}..HEAD"])
         .output()
         .await
@@ -321,7 +335,7 @@ async fn query_ahead_behind(checkout_path: &Path, parent_branch: &str) -> (u32, 
 /// `git rev-list --left-right --count HEAD...<base>`, or `None` when the base
 /// doesn't resolve — so the caller can try an alternate ref spelling.
 async fn rev_list_counts(checkout_path: &Path, base: &str) -> Option<(u32, u32)> {
-    let out = crate::git_dist::command(checkout_path)
+    let out = read_command(checkout_path)
         .args([
             "rev-list",
             "--left-right",
@@ -339,7 +353,7 @@ async fn rev_list_counts(checkout_path: &Path, base: &str) -> Option<(u32, u32)>
 }
 
 async fn run_status(checkout_path: &Path) -> Result<String> {
-    let out = crate::git_dist::command(checkout_path)
+    let out = read_command(checkout_path)
         // `-uall` lists each file inside an untracked directory individually
         // (the default collapses them into one `dir/` entry, which can't be
         // diffed or counted per-file).
@@ -354,7 +368,7 @@ async fn run_status(checkout_path: &Path) -> Result<String> {
 }
 
 async fn run_numstat(checkout_path: &Path) -> Result<String> {
-    let out = crate::git_dist::command(checkout_path)
+    let out = read_command(checkout_path)
         .args(["diff", "--numstat", "HEAD"])
         .output()
         .await?;

--- a/src-tauri/src/supervisor/fork.rs
+++ b/src-tauri/src/supervisor/fork.rs
@@ -64,6 +64,9 @@ const FORK_CONTEXT_CLOSE: &str = "<!-- /fletch:forked-conversation-context -->";
 pub enum ForkCode {
     /// A fresh worktree from the parent's base branch — no uncommitted work.
     Clean,
+    /// The parent's current working tree (incl. uncommitted work) overlaid onto
+    /// the fresh checkout — "build on unmerged work".
+    Carry,
 }
 
 /// How much of the parent conversation the fork carries. Drives the record
@@ -134,10 +137,17 @@ impl Supervisor {
             None => (!base_brief.is_empty()).then_some(base_brief),
         };
 
-        // Code: reuse the normal spawn/provision path. `Clean` forks the parent's
-        // own base branch, so the fork starts where the parent did.
-        let fork_base = match code {
-            ForkCode::Clean => primary.parent_branch.clone(),
+        // Code: reuse the normal spawn/provision path. Both modes fork the
+        // parent's own base branch (so the fork starts where the parent did);
+        // `Carry` additionally overlays the parent's current working tree after
+        // provisioning, so its uncommitted work reads as the fork's diff.
+        let fork_base = primary.parent_branch.clone();
+        let carry_from = match code {
+            ForkCode::Clean => None,
+            ForkCode::Carry => Some(crate::workspace::repo_checkout_path(
+                parent_id,
+                &primary.subdir,
+            )?),
         };
 
         let req = SpawnRequest {
@@ -154,6 +164,7 @@ impl Supervisor {
             fork_base,
             run_repo: None,
             owner_run_id: None,
+            carry_from,
         };
         let child = self.clone().spawn_agent(app, req).await?;
 
@@ -541,7 +552,9 @@ mod tests {
         let upto: ForkContext =
             serde_json::from_value(json!({"kind": "up_to_message", "prompt": 3})).unwrap();
         assert_eq!(upto, ForkContext::UpToMessage { prompt: 3 });
-        let code: ForkCode = serde_json::from_value(json!("clean")).unwrap();
-        assert_eq!(code, ForkCode::Clean);
+        let clean: ForkCode = serde_json::from_value(json!("clean")).unwrap();
+        assert_eq!(clean, ForkCode::Clean);
+        let carry: ForkCode = serde_json::from_value(json!("carry")).unwrap();
+        assert_eq!(carry, ForkCode::Carry);
     }
 }

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -187,6 +187,11 @@ pub struct SpawnRequest {
     /// normal sidebar and cleaned up by `wf_delete_run`. `None` for a normal
     /// user spawn.
     pub owner_run_id: Option<String>,
+    /// Fork "carry code": another workspace's primary checkout whose current
+    /// working tree (incl. uncommitted work) is overlaid onto this fresh
+    /// checkout after provisioning, so the fork starts from that workspace's
+    /// state. `None` for a normal spawn or a clean fork.
+    pub carry_from: Option<PathBuf>,
 }
 
 impl Supervisor {
@@ -209,6 +214,7 @@ impl Supervisor {
             fork_base,
             run_repo,
             owner_run_id,
+            carry_from,
         } = req;
         if !repo_path.join(".git").exists() {
             return Err(Error::InvalidPath(format!(
@@ -261,6 +267,9 @@ impl Supervisor {
         let subdir_for_fork = subdir.clone();
         // A workflow step forks from its `fork_base` ref in this run repo.
         let run_repo_for_task = run_repo.clone();
+        // Fork "carry code": the source checkout whose working tree is overlaid
+        // onto the fresh checkout once it's provisioned.
+        let carry_from_task = carry_from.clone();
 
         let primary = TrackedRepo {
             repo_path: repo_path.clone(),
@@ -390,10 +399,40 @@ impl Supervisor {
             // Record the fork point so diffs measure against the exact starting
             // commit rather than a branch name that can drift. Non-fatal: a
             // missing base_sha just falls back to the parent branch name.
-            if let Ok(sha) = git::rev_parse(&primary_checkout, "HEAD").await {
+            let base_sha = git::rev_parse(&primary_checkout, "HEAD").await.ok();
+            if let Some(sha) = &base_sha {
                 let _ = sup
                     .workspace
-                    .set_repo_base_sha(&id_for_task, &subdir_for_fork, &sha);
+                    .set_repo_base_sha(&id_for_task, &subdir_for_fork, sha);
+            }
+
+            // Fork "carry code": overlay the source workspace's current working
+            // tree onto the fresh checkout, so the fork starts from that
+            // workspace's uncommitted work. Fatal on failure — the user asked to
+            // carry, so silently producing a clean fork would drop their changes.
+            // Tears down like the start_process failure path below (a workflow
+            // step never carries, so this is always a non-run clone).
+            if let Some(src) = &carry_from_task {
+                let carried = match &base_sha {
+                    Some(base) => match git::snapshot_worktree(src).await {
+                        Ok(snap) => git::carry_worktree(&primary_checkout, src, &snap, base).await,
+                        Err(e) => Err(e),
+                    },
+                    None => Err(Error::Other(
+                        "cannot carry working tree without a base commit".into(),
+                    )),
+                };
+                if let Err(e) = carried {
+                    let teardown_spec = CheckoutSpec {
+                        source_repo: &repo_path,
+                        base_ref: "HEAD",
+                        dest: &primary_checkout,
+                    };
+                    let _ = provision::teardown(workspace_mode, &teardown_spec).await;
+                    let _ = tokio::fs::remove_dir_all(&parent_dir).await;
+                    fail_spawn(&sup, &app_for_task, &id_for_task, e.to_string());
+                    return;
+                }
             }
 
             tokio::time::sleep(Duration::from_millis(350)).await;

--- a/src-tauri/src/workflow/driver.rs
+++ b/src-tauri/src/workflow/driver.rs
@@ -148,6 +148,7 @@ impl AgentDriver for SupervisorDriver {
                         fork_base,
                         run_repo,
                         owner_run_id: Some(owner_run_id),
+                        carry_from: None,
                     },
                 )
                 .await?;

--- a/src/api.ts
+++ b/src/api.ts
@@ -10,10 +10,11 @@ export type AgentStatus = "spawning" | "running" | "idle" | "stopped" | "error";
 
 export type AgentView = "custom" | "native";
 
-/** What a forked workspace's worktree starts from. Only `clean` (fork the
- *  parent's base branch) is wired today; `carry` (bring the parent's current
- *  working tree) ships in a follow-up slice. Mirrors the backend `ForkCode`. */
-export type ForkCode = "clean";
+/** What a forked workspace's worktree starts from. `clean` forks the parent's
+ *  base branch; `carry` overlays the parent's current working tree (incl.
+ *  uncommitted work) so the fork builds on unmerged work. Mirrors the backend
+ *  `ForkCode`. */
+export type ForkCode = "clean" | "carry";
 
 /** How much of the parent conversation a fork carries. Mirrors the backend
  *  `ForkContext`. Summarized context ships in a follow-up slice. */

--- a/src/components/Workspace/Chat.css
+++ b/src/components/Workspace/Chat.css
@@ -94,17 +94,20 @@
   margin-left: auto;
   color: var(--fg-2);
 }
-/* The fork affordance sits at the far right of the seam. `margin-left: auto`
-   pushes it right when it's the only trailing action; when the copy button is
-   also present that one takes the free space and the fork sits just after it. */
-.turn-meta .turn-fork {
+/* The fork affordance sits at the far right of the seam. Its menu wrapper takes
+   the `margin-left: auto`, so it pushes right when it's the only trailing action
+   and sits just after the copy button when both are present. */
+.turn-meta .fork-menu {
   margin-left: auto;
+}
+.turn-meta .turn-fork {
   color: var(--fg-2);
 }
 /* With copy present, its `margin-left: auto` already pushes the whole action
-   group right — reset the fork's so a second auto doesn't split the free space
-   (which would strand the copy button mid-row). The 7px flex gap spaces them. */
-.turn-meta .turn-copy + .turn-fork {
+   group right — reset the fork menu's so a second auto doesn't split the free
+   space (which would strand the copy button mid-row). The 7px flex gap spaces
+   them. */
+.turn-meta .turn-copy + .fork-menu {
   margin-left: 0;
 }
 /* The fork button is the rightmost footer action, so its centered tooltip
@@ -117,6 +120,27 @@
   left: auto;
   right: 0;
   transform: none;
+}
+
+/* Fork menu: a branch button that opens a small option list. The scrim is a
+   full-viewport click-catcher for outside-dismiss; the menu is positioned just
+   under the trigger's right edge. */
+.fork-menu {
+  position: relative;
+  display: inline-flex;
+}
+.fork-menu-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 199;
+}
+.fork-menu-dd {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  z-index: 200;
+  white-space: nowrap;
 }
 
 /* The fixed 22px .btn-i.xs box clamps the copy glyph, so size the button to its

--- a/src/components/Workspace/Chat.css
+++ b/src/components/Workspace/Chat.css
@@ -123,8 +123,9 @@
 }
 
 /* Fork menu: a branch button that opens a small option list. The scrim is a
-   full-viewport click-catcher for outside-dismiss; the menu is positioned just
-   under the trigger's right edge. */
+   full-viewport click-catcher for outside-dismiss; the menu anchors to the
+   trigger's right edge and opens down by default, flipping up (`.up`) when the
+   footer sits too close to the composer for the list to fit below. */
 .fork-menu {
   position: relative;
   display: inline-flex;
@@ -136,11 +137,17 @@
 }
 .fork-menu-dd {
   position: absolute;
-  top: 100%;
   right: 0;
-  margin-top: 4px;
   z-index: 200;
   white-space: nowrap;
+}
+.fork-menu-dd.down {
+  top: 100%;
+  margin-top: 4px;
+}
+.fork-menu-dd.up {
+  bottom: 100%;
+  margin-bottom: 4px;
 }
 
 /* The fixed 22px .btn-i.xs box clamps the copy glyph, so size the button to its

--- a/src/components/Workspace/ForkButton.tsx
+++ b/src/components/Workspace/ForkButton.tsx
@@ -1,40 +1,23 @@
-import { useState } from "react";
-import { Icon } from "@/components/Icon";
-import { IconButton } from "@/components/ui/IconButton";
-import { useAppStore } from "@/store";
+import { ForkMenu, type ForkOption } from "./ForkMenu";
 
-/** "Fork from here" affordance under an ended turn. Creates a new workspace
- *  seeded with a clean worktree (from the parent's base branch) and the
- *  conversation carried up to this turn, then opens it. The token-slicing /
- *  branch-a-direction entry point.
- *
- *  Code is `clean` this slice (carrying the parent's working tree is a follow-up
- *  and will turn this into a small menu); context is fixed to "up to here" since
- *  that's what forking *from a turn* means. */
+/** "Fork from here" affordance under an ended turn: forks a new workspace
+ *  carrying the conversation up to this turn, with a choice of clean vs. current
+ *  code. The token-slicing / branch-a-direction entry point. */
 export function ForkButton({ agentId, upToPrompt }: { agentId: string; upToPrompt: number }) {
-  const forkAgent = useAppStore((s) => s.forkAgent);
-  const [forking, setForking] = useState(false);
-
-  const onFork = async () => {
-    if (forking) return;
-    setForking(true);
-    try {
-      await forkAgent(agentId, "clean", { kind: "up_to_message", prompt: upToPrompt });
-    } finally {
-      setForking(false);
-    }
-  };
-
-  return (
-    <IconButton
-      size="xs"
-      tip="Fork to new workspace"
-      className="turn-fork"
-      onClick={onFork}
-      disabled={forking}
-      aria-label="Fork to new workspace"
-    >
-      <Icon name="split" size={12} />
-    </IconButton>
-  );
+  const context = { kind: "up_to_message", prompt: upToPrompt } as const;
+  const options: ForkOption[] = [
+    {
+      key: "clean",
+      label: "Fork here · clean worktree",
+      code: "clean",
+      context,
+    },
+    {
+      key: "carry",
+      label: "Fork here · with current code",
+      code: "carry",
+      context,
+    },
+  ];
+  return <ForkMenu agentId={agentId} options={options} tip="Fork to new workspace" compact />;
 }

--- a/src/components/Workspace/ForkMenu.tsx
+++ b/src/components/Workspace/ForkMenu.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import type { ForkCode, ForkContext } from "@/api";
 import { Icon } from "@/components/Icon";
 import { DropdownItem, DropdownMenu } from "@/components/ui/Dropdown";
@@ -11,6 +11,19 @@ export interface ForkOption {
   label: string;
   code: ForkCode;
   context: ForkContext;
+}
+
+/** Bottom edge the menu must fit within: the nearest scrolling ancestor (which
+ *  clips absolutely-positioned descendants — e.g. the chat's `overflow-y: auto`
+ *  scroller, below which the composer sits), clamped to the viewport. */
+function clipBottom(el: HTMLElement): number {
+  for (let node = el.parentElement; node; node = node.parentElement) {
+    const overflowY = getComputedStyle(node).overflowY;
+    if (overflowY === "auto" || overflowY === "scroll") {
+      return Math.min(node.getBoundingClientRect().bottom, window.innerHeight);
+    }
+  }
+  return window.innerHeight;
 }
 
 /** A split-icon button that opens a small menu of fork options and runs the
@@ -31,6 +44,25 @@ export function ForkMenu({
   const forkAgent = useAppStore((s) => s.forkAgent);
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
+  // Open down unless the trigger sits too close to the clip edge for the list
+  // to fit below — then flip up. Measured after render, before paint.
+  const [placement, setPlacement] = useState<"down" | "up">("down");
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    const wrap = wrapRef.current;
+    const menu = menuRef.current;
+    if (!wrap || !menu) return;
+    const trigger = wrap.getBoundingClientRect();
+    const menuHeight = menu.offsetHeight;
+    const spaceBelow = clipBottom(wrap) - trigger.bottom;
+    const spaceAbove = trigger.top;
+    // Flip up only when it doesn't fit below *and* there's more room above, so a
+    // cramped-both-ways menu still opens down (its natural, expected direction).
+    setPlacement(spaceBelow < menuHeight + 8 && spaceAbove > spaceBelow ? "up" : "down");
+  }, [open]);
 
   const run = async (opt: ForkOption) => {
     setOpen(false);
@@ -43,7 +75,7 @@ export function ForkMenu({
   };
 
   return (
-    <div className="fork-menu">
+    <div className="fork-menu" ref={wrapRef}>
       <IconButton
         size={compact ? "xs" : undefined}
         tip={tip}
@@ -58,7 +90,7 @@ export function ForkMenu({
         <>
           {/* Full-viewport scrim: any outside click dismisses the menu. */}
           <div className="fork-menu-scrim" onClick={() => setOpen(false)} />
-          <DropdownMenu className="fork-menu-dd">
+          <DropdownMenu ref={menuRef} className={`fork-menu-dd ${placement}`}>
             {options.map((opt) => (
               <DropdownItem key={opt.key} as="button" onClick={() => run(opt)}>
                 <span className="di-l">{opt.label}</span>

--- a/src/components/Workspace/ForkMenu.tsx
+++ b/src/components/Workspace/ForkMenu.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import type { ForkCode, ForkContext } from "@/api";
+import { Icon } from "@/components/Icon";
+import { DropdownItem, DropdownMenu } from "@/components/ui/Dropdown";
+import { IconButton } from "@/components/ui/IconButton";
+import { useAppStore } from "@/store";
+
+/** One entry in a fork menu: a label plus the Code × Context it forks with. */
+export interface ForkOption {
+  key: string;
+  label: string;
+  code: ForkCode;
+  context: ForkContext;
+}
+
+/** A split-icon button that opens a small menu of fork options and runs the
+ *  chosen one (creating + opening the new workspace via the store). Shared by
+ *  the turn-seam and workspace-header entry points, which differ only in their
+ *  option list and `compact` sizing. */
+export function ForkMenu({
+  agentId,
+  options,
+  tip,
+  compact = false,
+}: {
+  agentId: string;
+  options: ForkOption[];
+  tip: string;
+  compact?: boolean;
+}) {
+  const forkAgent = useAppStore((s) => s.forkAgent);
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const run = async (opt: ForkOption) => {
+    setOpen(false);
+    setBusy(true);
+    try {
+      await forkAgent(agentId, opt.code, opt.context);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="fork-menu">
+      <IconButton
+        size={compact ? "xs" : undefined}
+        tip={tip}
+        className="turn-fork"
+        aria-label={tip}
+        disabled={busy}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <Icon name="split" size={compact ? 12 : undefined} />
+      </IconButton>
+      {open && (
+        <>
+          {/* Full-viewport scrim: any outside click dismisses the menu. */}
+          <div className="fork-menu-scrim" onClick={() => setOpen(false)} />
+          <DropdownMenu className="fork-menu-dd">
+            {options.map((opt) => (
+              <DropdownItem key={opt.key} as="button" onClick={() => run(opt)}>
+                <span className="di-l">{opt.label}</span>
+              </DropdownItem>
+            ))}
+          </DropdownMenu>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/Workspace/WorkspaceHeader.tsx
+++ b/src/components/Workspace/WorkspaceHeader.tsx
@@ -1,11 +1,36 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import type { AgentRecord, AgentStatus, DiffStats } from "@/api";
 import { Icon } from "@/components/Icon";
 import { IconButton } from "@/components/ui/IconButton";
 import { useAppStore } from "@/store";
 import { formatAge } from "@/util/format";
 import { useMinuteClock } from "@/util/hooks";
+import { ForkMenu, type ForkOption } from "./ForkMenu";
 import { ViewToggle } from "./ViewToggle";
+
+/** Workspace-level fork options — the "start a new thread of work" entry point,
+ *  spanning both axes (git-action turns aside, there's no single message to
+ *  anchor on here, so context is whole-conversation or none). */
+const HEADER_FORK_OPTIONS: ForkOption[] = [
+  {
+    key: "full-clean",
+    label: "Full history · clean worktree",
+    code: "clean",
+    context: { kind: "full" },
+  },
+  {
+    key: "full-carry",
+    label: "Full history · with current code",
+    code: "carry",
+    context: { kind: "full" },
+  },
+  {
+    key: "fresh-carry",
+    label: "Fresh chat · with current code",
+    code: "carry",
+    context: { kind: "none" },
+  },
+];
 
 /** Header strip above the workspace body. Houses the left-sidebar
  *  toggle, the agent task + meta line, the Custom/Native view
@@ -25,8 +50,6 @@ export function WorkspaceHeader({ agent }: Props) {
   const rightCollapsed = useAppStore((s) => s.rightCollapsed);
   const toggleLeft = useAppStore((s) => s.toggleLeft);
   const toggleRight = useAppStore((s) => s.toggleRight);
-  const forkAgent = useAppStore((s) => s.forkAgent);
-  const [forking, setForking] = useState(false);
   const now = useMinuteClock();
   // Use shortstats (5s app-wide poll) rather than full git state, since
   // the header shows shortstats regardless of which right-rail tab is
@@ -94,22 +117,11 @@ export function WorkspaceHeader({ agent }: Props) {
         />
       )}
 
-      <IconButton
+      <ForkMenu
+        agentId={agent.id}
+        options={HEADER_FORK_OPTIONS}
         tip="Fork this workspace and conversation"
-        aria-label="Fork this workspace"
-        disabled={forking}
-        onClick={async () => {
-          if (forking) return;
-          setForking(true);
-          try {
-            await forkAgent(agent.id, "clean", { kind: "full" });
-          } finally {
-            setForking(false);
-          }
-        }}
-      >
-        <Icon name="split" />
-      </IconButton>
+      />
 
       <IconButton
         active={!rightCollapsed}

--- a/src/styles/shared/dropdown.css
+++ b/src/styles/shared/dropdown.css
@@ -2,6 +2,10 @@
 .dd {
   position: absolute;
   min-width: 220px;
+  /* A menu is its own surface — never inherit a mono/other face from whatever
+     context it's anchored in (e.g. the mono `.turn-meta` seam). `.di-m` still
+     opts back into mono explicitly. */
+  font-family: var(--font-sans);
   background: var(--bg-2);
   border: 1px solid var(--bd);
   border-radius: var(--r-md);


### PR DESCRIPTION
Stacked on #433 (base: `feat/fork-conversation`).

## What

Adds the **Code axis's second value** — `ForkCode::Carry`: a fork can start from the parent workspace's **current working tree, including uncommitted changes**, so you can build on unmerged work without merging first. (Clean-from-base was the first slice; this completes the Code axis. Summary context is the remaining slice.)

## How (git-native, zero side effects on the live agent)

- **`git::snapshot_worktree`** captures the source checkout's tree — tracked modifications, untracked non-ignored files, and deletions, honoring `.gitignore` — into a commit object using a **throwaway index** (`GIT_INDEX_FILE`). The live agent's real index, HEAD, and working tree are never touched.
- **`git::carry_worktree`** fetches that snapshot into the freshly-provisioned fork, `reset --hard`s to it (exact tree, incl. deletions), then `reset --mixed` back to base — so the carried work shows as **uncommitted changes against the fork's base**, mirroring the parent's own diff.
- Wired through a new `SpawnRequest.carry_from`, run right after provisioning in the spawn task. Carry failure **fails the spawn** (with teardown) rather than silently producing a clean fork, since carry was explicit.

## UI

Both entry points now open a small **fork menu** (new shared `ForkMenu` popover) to choose the Code:
- **Turn seam:** *Fork here · clean worktree* / *· with current code* (context = up to that message).
- **Header:** *Full history · clean* / *· with current code* / *Fresh chat · with current code* — the "build on top with a fresh conversation" combo.

## Testing

- Backend: `cargo check` clean; **13 fork unit tests** + a dedicated **`snapshot_and_carry` git test** proving the mechanism end-to-end — add/modify/delete applied, `.gitignore` respected, local fetch-by-sha works, HEAD stays at base, carried work reads as uncommitted.
- Frontend: `tsc` clean, biome clean, **412/412 vitest pass**.
- Not yet driven end-to-end in the live Tauri app.

## Files

Backend: `git.rs`, `supervisor/{fork,lifecycle}.rs`, `commands.rs`, `workflow/driver.rs`. Frontend: `ForkMenu.tsx` (new), `ForkButton.tsx`, `WorkspaceHeader.tsx`, `api.ts`, `Chat.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)