### PR TITLE
docs: reposition README around workflows, isolation, and control

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
   Fletch
 </h1>
 
-### Run a fleet of AI coding agents in parallel — each in its own sandbox and git worktree.
+### A new kind of IDE for agentic engineering.
 
-Claude Code, Codex, Cursor, OpenCode, and more — all on one repo, at the same time, without stepping on each other.
+Run Claude Code, Codex, Cursor, OpenCode and more in parallel, each in an isolated sandbox, chained into deterministic workflows that plan, build, review, and test.
 
 [![Download for macOS](https://img.shields.io/badge/Download%20for%20macOS-Apple%20Silicon%20%26%20Intel-111?style=for-the-badge&logo=apple)](https://fletch.sh)
 
@@ -15,31 +15,55 @@ Claude Code, Codex, Cursor, OpenCode, and more — all on one repo, at the same 
 ![Platform: macOS 13+](https://img.shields.io/badge/Platform-macOS%2013%2B-lightgrey.svg)
 ![Built with Tauri](https://img.shields.io/badge/Built%20with-Tauri%202-24C8DB.svg)
 
-<!-- Drop a short demo GIF here. Record one full loop: spawn an agent → it works → review the diff → commit/PR. Save it to docs/demo.gif. -->
-<img src="docs/fletch_control_room.jpg" alt="Fletch: spawning multiple AI coding agents in parallel, each in its own git worktree" width="820">
+<img src="docs/fletch_control_room.jpg" alt="Fletch: specialist AI coding agents running a deterministic workflow in parallel, each in its own sandboxed clone" width="820">
 
 </div>
 
+<!-- DEMO VIDEO: GitHub only renders an inline player for videos uploaded through
+     its own web UI. To embed the demo: edit this file on github.com and drag
+     fletch-demo-github.mp4 (in the repo root, untracked; <10 MB) onto the blank
+     line below this comment. GitHub uploads it and inserts a
+     github.com/user-attachments/... URL. Keep that URL on its own line, exactly
+     here (outside the <div> above, or the player won't render), then delete the
+     screenshot above. -->
+
 ---
 
-One coding agent at a time is a bottleneck. You wait, review, and repeat — serially. Fletch lets you run a dozen at once, each in its own git worktree and macOS sandbox, so they physically can't touch each other's files or the rest of your machine.
+Fletch is a native macOS app for engineers who use AI agents to build real software and want predictable results, not just more output. Running more agents stopped being the hard part a while ago. Trusting what they produce is the hard part now.
 
-Kick off five agents on five tasks. Watch each as a clean chat or its raw terminal. See edits land as live diffs. Commit, push, or open a PR — all from one window. Spawn another when you need more throughput; discard one — worktree and branch with it — in a click.
+Fletch is opinionated about how agent-written code should reach your main branch:
 
-## Why Fletch
+- **Agents don't get your checkout.** Each one works in an isolated clone of your repo, inside an OS-level sandbox that denies writes anywhere else. Your working copy is untouchable.
+- **Process beats prompting.** Repeatable work runs as a workflow (plan → build → review → test) where a step is done when a _verifiable condition_ holds: tests passed, a commit landed, you approved. Not when the agent says so.
+- **Nothing merges without you.** Live diffs, explicit approval gates, and your review sit between the agents and the merge.
 
-- **Actual parallelism.** Every agent gets its own git worktree and branch. Two agents editing the same file is impossible — they're on different checkouts of the same repo. No collisions, no locking, no waiting your turn.
-- **Sandboxed by default.** Each agent runs under a per-agent macOS `sandbox-exec` profile that blocks writes outside its worktree. It can't trash your repo, your other agents, or your machine.
-- **Your agents, your keys.** Fletch drives the CLIs you already installed and pay for — Claude Code, Codex, Cursor, OpenCode, Pi. No extra subscription, no model lock-in, no proxy.
-- **One cockpit per agent.** Normalized chat view of reasoning and tool calls, a native terminal for the raw TUI, live diffs as edits land, and an integrated Git/PR panel — plus optional Run and Terminal panels.
-- **From clone to PR without a shell.** Start a project from a GitHub repo or a fresh one, work it with agents, and ship the PR — never dropping to the command line.
-- **Fully local.** A native desktop app. Your code and transcripts stay on your machine; nothing routes through a Fletch server.
+If you want to fire off a dozen agents and merge whatever comes back, there are simpler tools. Fletch is for the part after the demo: shipping agent-written code you're willing to maintain.
 
-## Supported agents
+## What you get
 
-Fletch normalizes every agent's transcript into one consistent view — they all look and behave the same to you.
+**Real isolation.** Every agent gets its own full clone of your repo (shared git objects make spawning effectively free), sandboxed by macOS Seatbelt by default or by an opt-in Docker container per agent. Either way, an agent can't touch your repo, your machine, or another agent's work.
 
-| Agent                                                             | Status                      |
+**Deterministic workflows.** Define a pipeline once (architect, coder, reviewer, tester) and launch it on any task. Steps hand context forward, loops repeat _review → fix_ until a verdict says done, parallel blocks fan work out and join it back. Control flow belongs to the engine, not to an LLM: gates are checked, budgets (turns, iterations, wall-clock, tokens) are enforced, every pause names its cause, and runs survive an app restart. Workflows are shareable YAML.
+
+**Control.** Watch every agent as it works: a normalized chat of reasoning and tool calls (every harness looks the same), the raw terminal when you want it, live diffs as edits land. And sign off on what ships: approval gates in workflows, in-app file editing, and a full git/PR panel. Commit, push, open and merge PRs, and pull unresolved review comments straight into an agent's chat to fix. The reviewer in the loop is you.
+
+**Specialist agents.** Base harnesses are generalists. On top of them you define custom agents (a role, a model, a reasoning budget, standing instructions) and assign the right one to each workflow step: an _Architect_ pinned to your strongest model, a _Reviewer_ that refuses to pass unhandled errors.
+
+**Parallel by default.** Kick off as many agents as you like on one repo; isolation makes collisions structurally impossible. In this category that's the ante, not the pitch.
+
+**Local-first, your subscriptions.** Fletch drives the CLIs you already installed and pay for: no middleman keys, no markup, no proxy. Your code and transcripts stay on your machine; nothing routes through a Fletch server. Free and AGPL.
+
+## Quick start
+
+1. **[Download Fletch](https://fletch.sh)**: universal binary, signed, notarized, self-updating.
+2. Onboarding checks the three things you need (`git`, GitHub access, and at least one agent CLI) and can install any of them for you.
+3. Point Fletch at a repo and spawn an agent with a task, or define a workflow and launch it.
+
+Requires macOS 13+. No VM, no required containers: Docker is an optional isolation engine, not a prerequisite.
+
+## Supported harnesses
+
+| Harness                                                           | Status                      |
 | ----------------------------------------------------------------- | --------------------------- |
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code)     | ✅ Supported                |
 | [Codex](https://github.com/openai/codex)                          | ✅ Supported                |
@@ -48,73 +72,22 @@ Fletch normalizes every agent's transcript into one consistent view — they all
 | [Pi](https://pi.dev/)                                             | ✅ Supported                |
 | [Antigravity](https://antigravity.google/product/antigravity-cli) | ✅ Supported (experimental) |
 
-Install and authenticate the CLIs you want; Fletch detects them on your `PATH` and common install locations.
+Fletch detects installed CLIs automatically and normalizes their transcripts into one consistent view.
 
-## Download
+## Sandboxing
 
-**[Download Fletch for macOS →](https://fletch.sh)** — universal (Apple Silicon & Intel), signed, notarized, and self-updating.
+Fletch ships two isolation engines. The guarantee is the same under both: an agent's writes stay inside its own workspace. The trade-off is friction versus depth.
 
-**Requirements**
+- **Seatbelt (default).** Each agent runs under a per-agent macOS `sandbox-exec` profile that denies writes outside its workspace. Nothing to install, nothing to configure, no startup cost. But it's write protection, not a VM: the agent runs as your user, reads what you can read, and has network access.
+- **Docker (opt-in).** Switch the engine and each agent runs in its own container. Truer sandboxing: the agent sees only what's mounted into its container, so the rest of your filesystem isn't reachable even for reads. It requires Docker on your machine (and every harness except Antigravity supports it), and it's still not a silver bullet: the network is open, and a container is not a VM.
 
-- macOS 13+ (`sandbox-exec` is macOS-only)
-- At least one supported agent CLI (e.g. `claude`)
-- `git`, plus `gh` (GitHub CLI) for PR and project-creation features
+Under both engines, workspaces are full shared-object clones rather than linked worktrees, so an agent's writable `.git` lives entirely inside its sandbox; your repo's `.git` is never writable by an agent. Pushes and PR creation run host-side through a brokered RPC: credentials never enter the sandbox, but these ops currently run without a confirmation prompt, so an agent can publish code under your identity. Choose tasks and repos accordingly.
 
-No VM, no Docker, no containers.
+The code is canonical: [`sandbox/seatbelt.rs`](src-tauri/src/sandbox/seatbelt.rs), [`sandbox/docker/`](src-tauri/src/sandbox/docker), and [`sandbox/provision.rs`](src-tauri/src/sandbox/provision.rs), with the full write-up in the [docs](https://fletch.sh/docs).
 
-## How it works
+## Documentation
 
-1. **Point** Fletch at a local git repo.
-2. **Spawn** an agent with a task — Fletch creates an isolated per-agent workspace at `~/.fletch/workspaces/<id>/`, with the repo checked out in a subdir as a lightweight clone that shares your repo's git objects.
-3. **Run** the agent's CLI in that checkout under `sandbox-exec`, bridged through a local PTY.
-4. **Watch** output stream into a tab — switch between the normalized chat view and the raw terminal.
-5. **Review** edits as live diffs; browse and edit files directly.
-6. **Ship** — commit, push, open or merge a PR, or discard the agent and its workspace in one click.
-
-Every session is captured to a local SQLite store, so reopening it replays the full transcript.
-
-## Workflows
-
-Spawning agents one at a time is great for ad-hoc work. For a repeatable process — *plan, implement in parallel, review in a loop, ship* — Fletch has **workflows**: a definition you build once and launch on any task.
-
-A workflow is a tree of **blocks**:
-
-- **Step** — one sandboxed agent with a **goal** and a **gate** (the condition that means it's done: wrote a `verdict.json`, moved `HEAD`, produced an artifact, passed the project's tests, or got your approval).
-- **Parallel** — fan several agents out from the same point, with a join policy (`all` / `any`) and optional merge of their work.
-- **Loop** — repeat a body (e.g. `review → fix`) until a step's verdict says `done` or a max iteration count is hit.
-- **Orchestrate** — an orchestrator agent supervises child agents, answers their questions, and can dynamically compose bounded sub-workflows.
-
-The engine — not an LLM — owns control flow. It's built to be **robust and observable**:
-
-- **Filesystem handoffs.** Each run gets a per-run *blackboard* mounted read-write into every step's sandbox; steps leave notes and a structured verdict for the next agent.
-- **Host-brokered messaging.** Steps `report` / `ask` along edges you declare; questions with no orchestrator pause the run for *you* to answer.
-- **Bounded spend.** Turn, iteration, wall-clock, and (where the provider exposes it) token budgets are enforced. Exceeding one pauses the run — it never silently overspends or dies.
-- **No silent hangs.** Every wait has a deadline; every pause names its cause (approval, question, blocked gate, budget, conflict, stall) and offers its action in the monitor.
-- **Fully resumable.** Every engine decision is an append-only journal event; runs resume after an app restart, and each step attempt's chat is preserved and replayable forever.
-
-**Using it:** define a workflow in **Settings → Workflows** (or import a shareable YAML file); launch it on a task from a new workspace's **Workflow** tab; watch it in the run monitor — a live timeline, each attempt's chat, a budget meter, and banners for anything that needs you. Finalize pushes the run branch and opens a PR.
-
-## Isolation & security
-
-Each agent runs as **your user** under a per-agent `sandbox-exec` profile that denies writes by default, re-allowing only:
-
-- the agent's workspace root at `~/.fletch/workspaces/<id>/` (its per-repo checkouts live in subdirs) and its RPC mailbox at `~/.fletch/rpc/<id>/`
-- temp dirs: `/private/tmp`, `/private/var/tmp`, and `/private/var/folders`
-- per-user app state: `~/.claude` and `~/.claude.json` (plus `CLAUDE_CONFIG_DIR` when set), `~/.npm`, `~/.cache`, `~/.config`, `~/.local`, `~/Library/Caches`, and `~/Library/Application Support`
-- each per-turn agent's own on-disk state store: `~/.codex`, `~/.cursor`, `~/.gemini`, and `~/.pi`
-- the PTY and device files terminal programs need (`/dev/null`, `/dev/zero`, `/dev/tty*`, `/dev/ptmx`, `/dev/pts/*`)
-
-See [`src-tauri/src/sandbox/seatbelt.rs`](src-tauri/src/sandbox/seatbelt.rs) for the exact profile — the code is canonical. Run-panel processes (a project's setup/dev command) use a broader profile that additionally grants toolchain dirs like `~/.cargo`, `~/.rustup`, and `~/go` so real project builds succeed.
-
-This is a **write-protection sandbox, not a VM**: an agent can still read what your user can read and reach the network. It's "can't trash your repo or machine," not "air-gapped." Choose tasks accordingly.
-
-### Workspaces are clones, not worktrees
-
-Each workspace checkout is a `git clone --shared` of your repo, not a linked `git worktree`. A linked worktree's `.git` file points back inside your real repo's `.git` — agents would need write access there, and a writable `.git/hooks` means code execution on your host the next time you run git. With a shared clone, the agent's entire writable `.git` lives inside its sandboxed workspace: **your repo's `.git` is never writable by an agent**. The clone borrows your repo's object store instead of copying it, so spawning an agent costs kilobytes and milliseconds regardless of history size, and your repo stays pristine — no worktree entries, no "branch already checked out elsewhere" collisions, and discarding an agent just deletes its directory. The flip side of borrowing objects is that a workspace is tied to its source repo staying in place. See [`src-tauri/src/sandbox/provision.rs`](src-tauri/src/sandbox/provision.rs) for the full design.
-
-### Remote actions & credentials
-
-Agents can ask the host to run a small, fixed set of git operations on their behalf through an RPC broker: `git push`, PR creation (`open_pr`), and a credentialed `git fetch`. These run on the host with your GitHub credentials — and today they run **without a confirmation prompt**. The mitigation is narrow but real: the credentials never enter the sandbox (the ops are brokered host-side), and the broker accepts only that closed, small op set. The consequence is that an agent can publish code and open pull requests under your identity, so choose tasks and repos accordingly.
+Concepts, the workflow reference, and the isolation design live at **[fletch.sh/docs](https://fletch.sh/docs)**.
 
 ## Build from source
 
@@ -123,15 +96,13 @@ bun install
 bun tauri dev
 ```
 
-**Toolchain:** [Bun](https://bun.com) 1.3+ and a stable Rust toolchain. Frontend is React 18 + TypeScript + Zustand + xterm.js; backend is Rust via [Tauri 2](https://tauri.app).
+**Toolchain:** [Bun](https://bun.com) 1.3+ and a stable Rust toolchain. React 18 + TypeScript + Zustand + xterm.js frontend; Rust backend via [Tauri 2](https://tauri.app).
 
 ```
-src/                  React + TypeScript frontend (store, adapters, components)
-src-tauri/src/        Rust backend (supervisor, sessions, sandbox, git, gh)
+src/                  frontend (store, adapters, workflows, components)
+src-tauri/src/        backend (supervisor, sessions, sandbox, workflow engine, git, github)
 src-tauri/migrations/ SQLite schema
 ```
-
-Run the tests:
 
 ```bash
 bun run test                  # frontend (vitest)


### PR DESCRIPTION
Rewrites the README to match the new positioning: Fletch as the workbench for agentic engineering, not another parallel-fleet cockpit.

## What changed

- **New tagline and framing.** "The workbench for agentic engineering" replaces the fleet pitch; the opening states who the tool is for and its three opinions (agents don't get your checkout, process beats prompting, nothing merges without you).
- **"What you get" restructured**: real isolation first, then deterministic workflows, then a new **Control** item (monitoring surfaces + sign-off tools, absorbing the old cockpit item), specialist agents, parallelism as the ante, local-first.
- **New "Sandboxing" section** covering both engines honestly: Seatbelt (default, zero friction, write-protection only) and Docker (opt-in, deeper isolation, still not a silver bullet). Keeps the clones-not-worktrees guarantee and the unprompted-RPC disclosure.
- **Implementation detail moved out**: the sandbox path allow-list, clone design walkthrough, and workflow block reference are delegated to source links (`seatbelt.rs`, `docker/`, `provision.rs`) and fletch.sh/docs.
- **Stale facts fixed**: `gh` CLI is no longer listed as a requirement (backend no longer shells out to it), "No VM, no Docker, no containers" corrected (Docker is an optional engine), "worktree" removed from copy that contradicted the clone-based design.
- **Demo video prep**: hero comment now documents the GitHub user-attachments upload flow; a compressed <10 MB video is ready locally (untracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)