### PR TITLE
refactor: remove non-functional Density setting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,6 @@ export function App() {
 
   const theme = useAppStore((s) => s.theme);
   const accent = useAppStore((s) => s.accent);
-  const density = useAppStore((s) => s.density);
 
   const leftCollapsed = useAppStore((s) => s.leftCollapsed);
   const rightCollapsed = useAppStore((s) => s.rightCollapsed);
@@ -104,10 +103,10 @@ export function App() {
     [refreshAllPrChecks, githubConnected, anyChecksPending, anyOpenPr],
   );
 
-  // Apply theme + density via html classes; accent via CSS vars.
+  // Apply theme via html class; accent via CSS vars.
   useEffect(() => {
-    document.documentElement.className = `theme-${theme} density-${density}`;
-  }, [theme, density]);
+    document.documentElement.className = `theme-${theme}`;
+  }, [theme]);
   useEffect(() => {
     const v = ACCENT_VALUES[accent] || ACCENT_VALUES.copper;
     const root = document.documentElement;

--- a/src/components/Settings/Segmented.tsx
+++ b/src/components/Settings/Segmented.tsx
@@ -1,4 +1,4 @@
-/** Segmented control used in the settings popover (theme, density). */
+/** Segmented control used in the settings popover (e.g. theme). */
 interface Props<T extends string> {
   value: T;
   options: { value: T; label: string }[];

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -3,7 +3,7 @@ import { IconButton } from "@/components/ui/IconButton";
 import { Scrim } from "@/components/ui/Scrim";
 import { PROVIDER_DETAIL } from "@/data/providerDetail";
 import { ACCENTS, PROVIDERS } from "@/data/providers";
-import type { Density, FeatureFlags, ThemeMode } from "@/storage/preferences";
+import type { FeatureFlags, ThemeMode } from "@/storage/preferences";
 import { useAppStore } from "@/store";
 import { Segmented } from "./Segmented";
 import { SettingsRow, SettingsSection } from "./SettingsRow";
@@ -55,8 +55,6 @@ function Popover({ onClose }: { onClose: () => void }) {
   const setTheme = useAppStore((s) => s.setTheme);
   const accent = useAppStore((s) => s.accent);
   const setAccent = useAppStore((s) => s.setAccent);
-  const density = useAppStore((s) => s.density);
-  const setDensity = useAppStore((s) => s.setDensity);
   const providerVersions = useAppStore((s) => s.providerVersions);
   const openSettingsScreen = useAppStore((s) => s.openSettingsScreen);
 
@@ -94,16 +92,6 @@ function Popover({ onClose }: { onClose: () => void }) {
               />
             ))}
           </div>
-        </SettingsRow>
-        <SettingsRow label="Density">
-          <Segmented<Density>
-            value={density}
-            options={[
-              { value: "comfortable", label: "Comfortable" },
-              { value: "compact", label: "Compact" },
-            ]}
-            onChange={setDensity}
-          />
         </SettingsRow>
       </SettingsSection>
 

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -3,7 +3,7 @@ import { Icon } from "@/components/Icon";
 import { Button } from "@/components/ui/Button";
 import { Select } from "@/components/ui/Select";
 import { ACCENTS } from "@/data/providers";
-import type { Density, SandboxEngine, ThemeMode } from "@/storage/preferences";
+import type { SandboxEngine, ThemeMode } from "@/storage/preferences";
 import { useAppStore } from "@/store";
 import { ContainerAuth } from "./ContainerAuth";
 import { type FeatureItem, SetGroup, SetHead, SetRow, SetSeg, SetToggle } from "./primitives";
@@ -46,8 +46,6 @@ export function GeneralPane() {
   const setTheme = useAppStore((s) => s.setTheme);
   const accent = useAppStore((s) => s.accent);
   const setAccent = useAppStore((s) => s.setAccent);
-  const density = useAppStore((s) => s.density);
-  const setDensity = useAppStore((s) => s.setDensity);
   const features = useAppStore((s) => s.features);
   const setFeature = useAppStore((s) => s.setFeature);
   const soundEnabled = useAppStore((s) => s.soundEnabled);
@@ -134,16 +132,6 @@ export function GeneralPane() {
               </button>
             ))}
           </div>
-        </SetRow>
-        <SetRow title="Density" sub="Compact tightens row heights across panels.">
-          <SetSeg<Density>
-            value={density}
-            options={[
-              { value: "comfortable", label: "Comfortable" },
-              { value: "compact", label: "Compact" },
-            ]}
-            onChange={setDensity}
-          />
         </SetRow>
       </SetGroup>
 

--- a/src/storage/preferences.ts
+++ b/src/storage/preferences.ts
@@ -8,7 +8,6 @@ import { DEFAULT_PROVIDER_ID } from "@/data/providers";
 // ---- Appearance & feature-flag types -----------------------------------------
 
 export type ThemeMode = "dark" | "light";
-export type Density = "comfortable" | "compact";
 export type WorkspaceView = "custom" | "native";
 export type SettingsSection =
   | "general"

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -37,7 +37,6 @@ import { getOrCreateAccount, toProfile } from "@/storage/accounts";
 import {
   DEFAULT_LEFT_WIDTH,
   DEFAULT_RIGHT_WIDTH,
-  type Density,
   parseFeatures,
   parseNewDraftSelection,
   parsePaneWidth,
@@ -107,7 +106,6 @@ const hydrateSettings = async (set: AppSet) => {
       theme: (s.theme as ThemeMode) || "dark",
       codeTheme: s.codeTheme || "quorum",
       accent: s.accent || "copper",
-      density: (s.density as Density) || "comfortable",
       features: parseFeatures(s.features),
       // Opt-out chime: only an explicit "false" mutes it.
       soundEnabled: s.soundEnabled !== "false",

--- a/src/store/appearance.ts
+++ b/src/store/appearance.ts
@@ -1,9 +1,4 @@
-import {
-  DEFAULT_FEATURES,
-  type Density,
-  type ThemeMode,
-  type WorkspaceView,
-} from "@/storage/preferences";
+import { DEFAULT_FEATURES, type ThemeMode, type WorkspaceView } from "@/storage/preferences";
 import { setSetting } from "@/storage/settings";
 import type { AppearanceSlice, SliceCreator } from "./types";
 
@@ -11,7 +6,6 @@ export const createAppearanceSlice: SliceCreator<AppearanceSlice> = (set) => ({
   theme: "dark" as ThemeMode,
   codeTheme: "quorum",
   accent: "copper",
-  density: "comfortable" as Density,
   features: DEFAULT_FEATURES,
   soundEnabled: true,
   notifyEnabled: true,
@@ -29,10 +23,6 @@ export const createAppearanceSlice: SliceCreator<AppearanceSlice> = (set) => ({
   setAccent: (a) => {
     set({ accent: a });
     setSetting("accent", a);
-  },
-  setDensity: (d) => {
-    set({ density: d });
-    setSetting("density", d);
   },
   setFeature: (k, v) =>
     set((s) => {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -24,7 +24,6 @@ import type { AccountProfile } from "@/storage/accounts";
 import type { CustomAgent, NewCustomAgent } from "@/storage/customAgents";
 import type { McpServer, NewMcpServer } from "@/storage/mcpServers";
 import type {
-  Density,
   FeatureFlags,
   SandboxEngine,
   SettingsIntent,
@@ -461,7 +460,6 @@ export interface AppearanceSlice {
    *  follows the app's light/dark mode. See data/codeThemes.ts. */
   codeTheme: string;
   accent: string;
-  density: Density;
   features: FeatureFlags;
   /** Play the chime when an agent turn finishes or needs input while you're
    *  not watching that chat. Opt-out. */
@@ -478,7 +476,6 @@ export interface AppearanceSlice {
   setTheme: (t: ThemeMode) => void;
   setCodeTheme: (id: string) => void;
   setAccent: (a: string) => void;
-  setDensity: (d: Density) => void;
   setFeature: <K extends keyof FeatureFlags>(k: K, v: FeatureFlags[K]) => void;
   setSoundEnabled: (on: boolean) => void;
   setNotifyEnabled: (on: boolean) => void;

--- a/src/styles/foundation/tokens.css
+++ b/src/styles/foundation/tokens.css
@@ -1,7 +1,6 @@
 /* Fletch — quiet & editorial. Ported from the Fletch v2 prototype.
  * Color tokens are OKLCH; theme via `.theme-dark` / `.theme-light` on <html>;
- * density via `.density-comfortable` / `.density-compact`; accent vars are
- * overridden at runtime by App.tsx based on the selected palette.
+ * accent vars are overridden at runtime by App.tsx based on the selected palette.
  */
 
 :root {
@@ -44,10 +43,6 @@
   --ease: cubic-bezier(0.3, 0.7, 0.4, 1);
   --transition-ui: background 0.12s, color 0.12s;
   --transition-ui-ease: background 0.12s var(--ease), color 0.12s var(--ease);
-
-  --dens-sm: 6px;
-  --dens-md: 10px;
-  --dens-lg: 16px;
 
   /* z-index scale */
   --z-titlebar: 20; /* title bar + chat-search overlay */
@@ -125,15 +120,4 @@
   --btn-fg-dark-alt: oklch(0.18 0.02 60);
   --btn-fg-light: oklch(0.98 0.005 60);
   color-scheme: light;
-}
-
-.density-comfortable {
-  --dens-sm: 6px;
-  --dens-md: 10px;
-  --dens-lg: 18px;
-}
-.density-compact {
-  --dens-sm: 4px;
-  --dens-md: 7px;
-  --dens-lg: 12px;
 }


### PR DESCRIPTION
## What & why

The **Density** control (Comfortable / Compact) in Quick Settings and the full settings screen did nothing. It was wired all the way through UI → store → DB persistence → an `<html>` class → three CSS variables (`--dens-sm/md/lg`), but **no selector ever consumed those variables**, so toggling it produced no visual change. The full-settings subtitle even promised behavior that didn't exist: *"Compact tightens row heights across panels."*

Rather than wire it up, we're removing it to make room for more useful controls.

## Changes

- **UI** — dropped the Density row from the Quick Settings popover (`Settings/index.tsx`) and the full settings screen (`SettingsScreen/GeneralPane.tsx`), including the misleading subtitle.
- **Store** — removed `density` state, `setDensity`, and type declarations (`store/appearance.ts`, `store/types.ts`); removed the hydrate-on-load line (`store/app.ts`).
- **Type** — deleted `export type Density` (`storage/preferences.ts`).
- **DOM** — `App.tsx` now sets `<html class="theme-${theme}">` only.
- **CSS** — removed the `.density-comfortable` / `.density-compact` blocks and dead `--dens-*` defaults; updated the header comment (`styles/foundation/tokens.css`).
- Fixed a stale comment in `Segmented.tsx`.

## Verification

- `tsc --noEmit` passes clean.
- All touched files lint clean under biome.

## Note

Existing users may have a leftover `density` row in the DB `settings` table. It's harmless orphaned data (nothing reads it now), so no migration was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)