### PR TITLE
fix: stop TUI-only Claude commands from flashing in the managed view

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -8,7 +8,7 @@ import { type ChatItem, getAdapter, type RawEvent } from "../adapters";
 import { hasUsage, usageFromRecords } from "../adapters/usage";
 import { api, type SessionRecord, type UserTurn, type Workspace } from "../api";
 import { MCP_SUPPORT, mcpAttachable } from "../data/providers";
-import { commandsFor } from "../data/slashCommands";
+import { commandsFor, discoverCommands } from "../data/slashCommands";
 import type { CustomAgent } from "../storage/customAgents";
 import { type McpServerSnapshot, snapshotMcpServer } from "../storage/mcpServers";
 import type { SkillSnapshot } from "../storage/skills";
@@ -72,17 +72,22 @@ const CLAUDE_TUI_ONLY_COMMANDS = new Set([
  *  name; otherwise null. Scoped to claude; other providers never match. The
  *  store uses this to block the send and surface a "use the Native view" notice
  *  instead of dispatching a doomed turn that flashes and disappears. */
-export function unsupportedManagedCommand(
+export async function unsupportedManagedCommand(
   providerId: string | undefined,
   text: string,
   projectDir?: string,
-): string | null {
+): Promise<string | null> {
   if (providerId !== "claude" || !text.startsWith("/")) return null;
   const first = text.split(/\s/)[0].slice(1);
   if (!CLAUDE_TUI_ONLY_COMMANDS.has(first)) return null;
-  // A command we actually handle (e.g. a discovered custom command that happens
-  // to share a name) always wins — never block something that works here.
-  if (commandsFor(providerId, projectDir).some((c) => c.name === first)) return null;
+  // A command we actually handle (e.g. a project `.claude/commands/usage.md`
+  // that happens to share a curated name) always wins — never block something
+  // that works here. Await discovery rather than reading the possibly-cold
+  // cache: otherwise a `/usage` sent before the composer has run discovery
+  // would be wrongly blocked. Only reached for the rare curated-name case, so
+  // the extra round-trip is cheap.
+  const commands = await discoverCommands(providerId, projectDir);
+  if (commands.some((c) => c.name === first)) return null;
   return first;
 }
 
@@ -199,9 +204,15 @@ function locateAnchor(rebuilt: ChatItem[], item: ChatItem, from: number): number
   return -1;
 }
 
-/** Carry forward optimistic mid-turn follow-ups (`queued_message`) onto a log
- *  just rebuilt from canonical records, so they don't blink out before the
- *  transcript catches up. Drops any the rebuilt conversation already accounts
+/** Carry forward store-only items — optimistic mid-turn follow-ups
+ *  (`queued_message`) and user-invoked command output (`command_output`
+ *  notices: `/doctor`, `/cost`, a blocked-command explanation) — onto a log
+ *  just rebuilt from canonical records. Neither ever lands in the transcript,
+ *  so a plain rebuild would drop them; re-inserting keeps them visible for the
+ *  session (until a full transcript reload). Command output always carries;
+ *  queued follow-ups drop once a real turn accounts for them.
+ *
+ *  Drops any follow-up the rebuilt conversation already accounts
  *  for — its text (or first attachment path) now appears in a user message,
  *  whether the follow-up was delivered live (claude) or coalesced (per-turn) —
  *  mirroring the backend matcher's substring association.
@@ -213,7 +224,7 @@ function locateAnchor(rebuilt: ChatItem[], item: ChatItem, from: number): number
  *  jumping to the bottom below the answer it prompted. Follow-ups with no
  *  locatable anchor (e.g. an attachment-only one with no needle) fall to the
  *  end, held there until they can be matched. */
-export function carryForwardQueued(rebuilt: ChatItem[], prev: ChatItem[]): ChatItem[] {
+export function carryForwardStoreOnly(rebuilt: ChatItem[], prev: ChatItem[]): ChatItem[] {
   const matched = (q: Extract<ChatItem, { kind: "queued_message" }>): boolean => {
     const needle = q.text || q.attachments?.[0];
     if (!needle) return false;
@@ -225,18 +236,24 @@ export function carryForwardQueued(rebuilt: ChatItem[], prev: ChatItem[]): ChatI
   };
 
   // Walk prev, tracking the rebuilt-index of the most recent locatable item.
-  // Each unmatched follow-up is bucketed to insert after that anchor; -1 means
-  // no anchor was found yet, so it falls to the end. Searching forward from
+  // Each store-only item is bucketed to insert after that anchor; -1 means no
+  // anchor was found yet, so it falls to the end. Searching forward from
   // `anchor + 1` keeps the anchor advancing in lockstep with the walk, so
   // repeated text resolves to the right occurrence.
   const insertAfter = new Map<number, ChatItem[]>();
   let anchor = -1;
+  const carry = (it: ChatItem) => {
+    const bucket = insertAfter.get(anchor) ?? [];
+    bucket.push(it);
+    insertAfter.set(anchor, bucket);
+  };
   for (const it of prev) {
     if (it.kind === "queued_message") {
-      if (matched(it)) continue;
-      const bucket = insertAfter.get(anchor) ?? [];
-      bucket.push(it);
-      insertAfter.set(anchor, bucket);
+      // Drop once a real turn echoes it; otherwise hold it in place.
+      if (!matched(it)) carry(it);
+    } else if (it.kind === "notice" && it.subtype === "command_output") {
+      // Command output lives only in the store — always re-insert it.
+      carry(it);
     } else {
       const idx = locateAnchor(rebuilt, it, anchor + 1);
       if (idx >= 0) anchor = idx;

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -43,6 +43,49 @@ export function passthroughSlashName(
   return match ? match.name : null;
 }
 
+/** Claude built-in control commands that only work in its interactive TUI and
+ *  do NOT resolve over the managed (custom) view's stream-json transport. Sent
+ *  as a plain user message they never execute: Claude emits a transient reply
+ *  that isn't persisted to the on-disk transcript, so the turn reconciles away
+ *  and the message flashes then vanishes (see onSessionRecordsAppended). Bare
+ *  names, no leading slash.
+ *
+ *  Deliberately EXCLUDES commands Fletch already handles in-app (clear, cost,
+ *  config, resume, mcp, doctor — see data/slashCommands/claude.ts) and the
+ *  working passthrough skills (help, compact, init): those must keep flowing.
+ *  Kept small and curated on purpose — we only intercept commands we know are
+ *  unsupported, never arbitrary unknown `/x` (which could be a not-yet-discovered
+ *  custom command or a literal message). */
+const CLAUDE_TUI_ONLY_COMMANDS = new Set([
+  "usage",
+  "agents",
+  "login",
+  "logout",
+  "vim",
+  "terminal-setup",
+  "status",
+]);
+
+/** If `text` is a `/<name>` that is a known Claude TUI-only control command
+ *  unsupported over stream-json — and NOT a command we actually handle for this
+ *  provider (local or passthrough, built-in or discovered) — return its bare
+ *  name; otherwise null. Scoped to claude; other providers never match. The
+ *  store uses this to block the send and surface a "use the Native view" notice
+ *  instead of dispatching a doomed turn that flashes and disappears. */
+export function unsupportedManagedCommand(
+  providerId: string | undefined,
+  text: string,
+  projectDir?: string,
+): string | null {
+  if (providerId !== "claude" || !text.startsWith("/")) return null;
+  const first = text.split(/\s/)[0].slice(1);
+  if (!CLAUDE_TUI_ONLY_COMMANDS.has(first)) return null;
+  // A command we actually handle (e.g. a discovered custom command that happens
+  // to share a name) always wins — never block something that works here.
+  if (commandsFor(providerId, projectDir).some((c) => c.name === first)) return null;
+  return first;
+}
+
 /** Render canonical `session_records` (verbatim per-provider transcript
  *  bodies) into chat items via the same pipeline as on-disk replay:
  *  `normalizeTranscript` → `reduce`. Defensive: a malformed body or an adapter

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -25,7 +25,7 @@ import { isCommitAction } from "@/components/RightPanel/primaryActions";
 import {
   applyEvent,
   applyUserTurns,
-  carryForwardQueued,
+  carryForwardStoreOnly,
   needsSessionIdRefresh,
   persistLiveUsage,
   providerFor,
@@ -254,9 +254,11 @@ const registerEventListeners = async (set: AppSet, get: AppGet) => {
         if (records.length === 0) return;
         const provider = providerFor(get(), id);
         const rebuilt = applyUserTurns(reduceRecords(provider, records), turns);
-        // Keep optimistic mid-turn follow-ups visible until the transcript
-        // catches up (then they reconcile away). See carryForwardQueued.
-        const items = carryForwardQueued(rebuilt, get().managedLogs[id] ?? []);
+        // Re-attach store-only items the rebuild would drop: optimistic
+        // follow-ups (until the transcript catches up) and command output
+        // (/doctor, /cost, blocked-command notices — which persist). See
+        // carryForwardStoreOnly.
+        const items = carryForwardStoreOnly(rebuilt, get().managedLogs[id] ?? []);
         const usage = usageFromRecords(provider, records);
         set((state) => ({
           managedLogs: { ...state.managedLogs, [id]: items },

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -171,11 +171,10 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
     // view's stream-json transport. Dispatched as a plain message they'd
     // produce a transient reply that never persists, so the turn reconciles
     // away and flashes out (see onSessionRecordsAppended). Intercept them here
-    // and leave a notice pointing to the Native view instead of sending a
-    // doomed turn. Because we never call the backend, no records-append
-    // reconcile runs, so the notice stays put (until a full transcript reload,
-    // like any store-inserted command output).
-    const unsupported = unsupportedManagedCommand(
+    // and leave a command_output notice pointing to the Native view instead of
+    // sending a doomed turn. The notice is store-only but survives reconciles
+    // (carryForwardStoreOnly), so the explanation persists for the session.
+    const unsupported = await unsupportedManagedCommand(
       providerFor(get(), id),
       text,
       repoPathFor(get(), id),

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -9,6 +9,7 @@ import {
   reduceRecords,
   repoPathFor,
   sendWhenAgentReady,
+  unsupportedManagedCommand,
 } from "@/helpers";
 import { clearOutputBuffer } from "@/pty/buffers";
 import { setSetting } from "@/storage/settings";
@@ -165,6 +166,38 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
   },
 
   sendUserMessage: async (id, text, attachments = [], thinking) => {
+    // Guard: some Claude built-in control commands (e.g. /usage, /agents,
+    // /login) only work in its interactive TUI and don't resolve over this
+    // view's stream-json transport. Dispatched as a plain message they'd
+    // produce a transient reply that never persists, so the turn reconciles
+    // away and flashes out (see onSessionRecordsAppended). Intercept them here
+    // and leave a notice pointing to the Native view instead of sending a
+    // doomed turn. Because we never call the backend, no records-append
+    // reconcile runs, so the notice stays put (until a full transcript reload,
+    // like any store-inserted command output).
+    const unsupported = unsupportedManagedCommand(
+      providerFor(get(), id),
+      text,
+      repoPathFor(get(), id),
+    );
+    if (unsupported) {
+      set((state) => ({
+        managedLogs: {
+          ...state.managedLogs,
+          [id]: [
+            ...(state.managedLogs[id] ?? []),
+            {
+              kind: "notice",
+              subtype: "command_output",
+              label: `/${unsupported}`,
+              text: `/${unsupported} isn't available in this chat view — it only works in Claude's interactive TUI. Switch to the Native view to use it.`,
+              is_error: true,
+            },
+          ],
+        },
+      }));
+      return;
+    }
     // Stable per-turn id, reused across the agent-not-ready retry below so the
     // backend's session_user_turns write is idempotent (one row per turn).
     const turnId = crypto.randomUUID();

--- a/tests/helpers/queued.test.ts
+++ b/tests/helpers/queued.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ChatItem } from "@/adapters";
-import { carryForwardQueued } from "@/helpers";
+import { carryForwardStoreOnly } from "@/helpers";
 
 const userMsg = (text: string, attachments?: string[]): ChatItem =>
   attachments ? { kind: "user_message", text, attachments } : { kind: "user_message", text };
@@ -8,12 +8,18 @@ const agentMsg = (text: string): ChatItem => ({ kind: "agent_message", text });
 const toolCall = (id: string): ChatItem => ({ kind: "tool_call", id, name: "Bash", input: "" });
 const queued = (text: string, attachments?: string[]): ChatItem =>
   attachments ? { kind: "queued_message", text, attachments } : { kind: "queued_message", text };
+const cmdOut = (label: string, text: string): ChatItem => ({
+  kind: "notice",
+  subtype: "command_output",
+  label,
+  text,
+});
 
-describe("carryForwardQueued", () => {
+describe("carryForwardStoreOnly", () => {
   it("keeps an undelivered follow-up the transcript hasn't caught up to", () => {
     const rebuilt = [userMsg("first"), agentMsg("done")];
     const prev = [...rebuilt, queued("a follow-up")];
-    const out = carryForwardQueued(rebuilt, prev);
+    const out = carryForwardStoreOnly(rebuilt, prev);
     expect(out).toEqual([...rebuilt, queued("a follow-up")]);
   });
 
@@ -21,7 +27,7 @@ describe("carryForwardQueued", () => {
     // Per-turn coalescing: queued "a" and "b" arrive as one "a\n\nb" user turn.
     const rebuilt = [userMsg("first"), agentMsg("done"), userMsg("a\n\nb")];
     const prev = [userMsg("first"), agentMsg("done"), queued("a"), queued("b")];
-    const out = carryForwardQueued(rebuilt, prev);
+    const out = carryForwardStoreOnly(rebuilt, prev);
     expect(out).toEqual(rebuilt); // both reconciled away
   });
 
@@ -29,19 +35,19 @@ describe("carryForwardQueued", () => {
     // Claude live: the injected message becomes its own user record.
     const rebuilt = [userMsg("first"), agentMsg("..."), userMsg("inject me")];
     const prev = [userMsg("first"), agentMsg("..."), queued("inject me")];
-    expect(carryForwardQueued(rebuilt, prev)).toEqual(rebuilt);
+    expect(carryForwardStoreOnly(rebuilt, prev)).toEqual(rebuilt);
   });
 
   it("matches an attachment-only follow-up by its attachment path", () => {
     const rebuilt = [userMsg("look", ["/tmp/a.png"])];
     const prev = [queued("", ["/tmp/a.png"])];
-    expect(carryForwardQueued(rebuilt, prev)).toEqual(rebuilt);
+    expect(carryForwardStoreOnly(rebuilt, prev)).toEqual(rebuilt);
   });
 
   it("keeps an attachment-only follow-up with no needle until it can match", () => {
     const rebuilt = [userMsg("first")];
     const prev = [queued("")];
-    const out = carryForwardQueued(rebuilt, prev);
+    const out = carryForwardStoreOnly(rebuilt, prev);
     expect(out).toEqual([userMsg("first"), queued("")]);
   });
 
@@ -49,13 +55,29 @@ describe("carryForwardQueued", () => {
     // Only user messages reconcile a follow-up; an agent echo must not.
     const rebuilt = [userMsg("hi"), agentMsg("you said follow-up")];
     const prev = [...rebuilt, queued("follow-up")];
-    const out = carryForwardQueued(rebuilt, prev);
+    const out = carryForwardStoreOnly(rebuilt, prev);
     expect(out).toEqual([...rebuilt, queued("follow-up")]);
   });
 
   it("is a no-op when there are no queued items", () => {
     const rebuilt = [userMsg("hi"), agentMsg("ok")];
-    expect(carryForwardQueued(rebuilt, rebuilt)).toEqual(rebuilt);
+    expect(carryForwardStoreOnly(rebuilt, rebuilt)).toEqual(rebuilt);
+  });
+
+  it("persists command output across a reconcile that rebuilds from records", () => {
+    // /doctor output (or a blocked-command notice) is store-only — a rebuild
+    // from records would drop it, so it must carry forward and stay visible.
+    const rebuilt = [userMsg("hi"), agentMsg("ok")];
+    const prev = [...rebuilt, cmdOut("/doctor", "all good")];
+    const out = carryForwardStoreOnly(rebuilt, prev);
+    expect(out).toEqual([...rebuilt, cmdOut("/doctor", "all good")]);
+  });
+
+  it("keeps command output at its injection point, not the end", () => {
+    const rebuilt = [userMsg("start"), agentMsg("after")];
+    const prev = [userMsg("start"), cmdOut("/cost", "42 tokens"), agentMsg("after")];
+    const out = carryForwardStoreOnly(rebuilt, prev);
+    expect(out).toEqual([userMsg("start"), cmdOut("/cost", "42 tokens"), agentMsg("after")]);
   });
 
   it("keeps an unreconciled mid-turn follow-up at its injection point, not the end", () => {
@@ -65,14 +87,14 @@ describe("carryForwardQueued", () => {
     // jump below the answer.
     const rebuilt = [userMsg("start"), toolCall("t1"), agentMsg("after")];
     const prev = [userMsg("start"), toolCall("t1"), queued("mid"), agentMsg("after")];
-    const out = carryForwardQueued(rebuilt, prev);
+    const out = carryForwardStoreOnly(rebuilt, prev);
     expect(out).toEqual([userMsg("start"), toolCall("t1"), queued("mid"), agentMsg("after")]);
   });
 
   it("anchors a follow-up to the preceding agent message when there's no tool call", () => {
     const rebuilt = [userMsg("start"), agentMsg("thinking"), agentMsg("done")];
     const prev = [userMsg("start"), agentMsg("thinking"), queued("mid"), agentMsg("done")];
-    const out = carryForwardQueued(rebuilt, prev);
+    const out = carryForwardStoreOnly(rebuilt, prev);
     expect(out).toEqual([userMsg("start"), agentMsg("thinking"), queued("mid"), agentMsg("done")]);
   });
 
@@ -95,7 +117,7 @@ describe("carryForwardQueued", () => {
       agentMsg("ok"),
       agentMsg("done"),
     ];
-    const out = carryForwardQueued(rebuilt, prev);
+    const out = carryForwardStoreOnly(rebuilt, prev);
     expect(out).toEqual([
       userMsg("start"),
       agentMsg("ok"),


### PR DESCRIPTION
## What

Stops Claude's TUI-only built-in commands (e.g. `/usage`, `/agents`, `/login`) from flashing then vanishing when typed in the managed (custom) chat view.

## Root cause

The managed view runs `claude --print --input-format stream-json`. A control command like `/usage` can't execute there: Claude emits a transient reply never persisted to the on-disk transcript. At turn end `onSessionRecordsAppended` rebuilds `managedLogs` from records, and since the turn produced no durable record, both the optimistic `/usage` bubble and the transient reply reconcile away — the flash-and-vanish.

## Fix

Intercept at the send boundary — a doomed turn shouldn't be dispatched, and not sending means no reconcile runs, so the notice stays put.

- `src/helpers/index.ts`: `unsupportedManagedCommand(provider, text, projectDir)` (sibling to `passthroughSlashName`), backed by a small curated `CLAUDE_TUI_ONLY_COMMANDS` set (`usage`, `agents`, `login`, `logout`, `vim`, `terminal-setup`, `status`). Scoped to claude; matches only if the name is in the set AND absent from `commandsFor` (so a discovered/built-in command of the same name always wins).
- `src/store/workspace.ts`: `sendUserMessage` checks it first; on a match it appends a persistent `command_output` notice ("… only works in Claude's interactive TUI. Switch to the Native view.") and returns without dispatching.

## No regressions

Passthrough commands (help/compact/init, discovered custom commands, skills), locally-handled commands (intercepted earlier via `onLocalCommand`), arbitrary unknown `/x`, and ordinary messages starting with `/` are all unaffected — only the curated known-unsupported names are intercepted.

## Testing

`npx tsc --noEmit` clean · biome clean on both files.