### PR TITLE
feat: per-project environment variables for sandboxed runs

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -814,31 +814,17 @@ pub fn read_env_file_keys(repo_path: String) -> Result<Vec<crate::run_env::EnvEn
 /// Read a project variable's override value (keychain-backed) so the settings
 /// UI can pre-fill the edit field. `None` when no override is set.
 #[tauri::command]
-pub fn get_env_override(
-    db: State<'_, Arc<parking_lot::Mutex<rusqlite::Connection>>>,
-    project_id: String,
-    key: String,
-) -> Result<Option<String>> {
-    crate::secrets::get(
-        &db.lock(),
-        &crate::run_env::override_secret_key(&project_id, &key),
-    )
+pub fn get_env_override(project_id: String, key: String) -> Option<String> {
+    crate::run_env::override_get(&crate::run_env::override_secret_key(&project_id, &key))
 }
 
-/// Store a project variable's override value in the app secret store (see
-/// `crate::secrets`) so a user-chosen value (e.g. a disposable per-agent DB
-/// URL) can diverge from `.env` without living in the `run_env` document. The
-/// store is the OS keychain on release macOS; on dev / non-macOS it falls back
-/// to the plaintext `settings` table, same as every other app secret.
+/// Store a project variable's override value in the override store (OS keychain
+/// on release macOS; in-memory session store on dev / non-macOS) so a
+/// user-chosen value (e.g. a disposable per-agent DB URL) can diverge from
+/// `.env` without ever being written to the database.
 #[tauri::command]
-pub fn set_env_override(
-    db: State<'_, Arc<parking_lot::Mutex<rusqlite::Connection>>>,
-    project_id: String,
-    key: String,
-    value: String,
-) -> Result<()> {
-    crate::secrets::set(
-        &db.lock(),
+pub fn set_env_override(project_id: String, key: String, value: String) -> Result<()> {
+    crate::run_env::override_set(
         &crate::run_env::override_secret_key(&project_id, &key),
         &value,
     )
@@ -847,15 +833,8 @@ pub fn set_env_override(
 /// Remove a project variable's override; resolution falls back to the `.env`
 /// value (mirror).
 #[tauri::command]
-pub fn clear_env_override(
-    db: State<'_, Arc<parking_lot::Mutex<rusqlite::Connection>>>,
-    project_id: String,
-    key: String,
-) -> Result<()> {
-    crate::secrets::delete(
-        &db.lock(),
-        &crate::run_env::override_secret_key(&project_id, &key),
-    )
+pub fn clear_env_override(project_id: String, key: String) -> Result<()> {
+    crate::run_env::override_delete(&crate::run_env::override_secret_key(&project_id, &key))
 }
 
 /// Returns git state for the agent's primary repo.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -819,7 +819,10 @@ pub fn get_env_override(
     project_id: String,
     key: String,
 ) -> Result<Option<String>> {
-    crate::secrets::get(&db.lock(), &crate::run_env::override_secret_key(&project_id, &key))
+    crate::secrets::get(
+        &db.lock(),
+        &crate::run_env::override_secret_key(&project_id, &key),
+    )
 }
 
 /// Store a project variable's override value in the keychain — never in the
@@ -832,7 +835,11 @@ pub fn set_env_override(
     key: String,
     value: String,
 ) -> Result<()> {
-    crate::secrets::set(&db.lock(), &crate::run_env::override_secret_key(&project_id, &key), &value)
+    crate::secrets::set(
+        &db.lock(),
+        &crate::run_env::override_secret_key(&project_id, &key),
+        &value,
+    )
 }
 
 /// Remove a project variable's override; resolution falls back to the `.env`
@@ -843,7 +850,10 @@ pub fn clear_env_override(
     project_id: String,
     key: String,
 ) -> Result<()> {
-    crate::secrets::delete(&db.lock(), &crate::run_env::override_secret_key(&project_id, &key))
+    crate::secrets::delete(
+        &db.lock(),
+        &crate::run_env::override_secret_key(&project_id, &key),
+    )
 }
 
 /// Returns git state for the agent's primary repo.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -802,6 +802,50 @@ pub fn project_run_config(
     supervisor.project_run_config(&repo_path)
 }
 
+/// Discover the `KEY=value` pairs in a project's `.env` (in the *source* repo,
+/// where gitignored env files live), for the Run & Environment settings list.
+/// Missing/unreadable `.env` → empty. Values are returned so the UI can show
+/// them masked and flag overrides that differ; it never writes them anywhere.
+#[tauri::command]
+pub fn read_env_file_keys(repo_path: String) -> Result<Vec<crate::run_env::EnvEntry>> {
+    Ok(crate::run_env::read_env_file(&expand_tilde(&repo_path)))
+}
+
+/// Read a project variable's override value (keychain-backed) so the settings
+/// UI can pre-fill the edit field. `None` when no override is set.
+#[tauri::command]
+pub fn get_env_override(
+    db: State<'_, Arc<parking_lot::Mutex<rusqlite::Connection>>>,
+    project_id: String,
+    key: String,
+) -> Result<Option<String>> {
+    crate::secrets::get(&db.lock(), &crate::run_env::override_secret_key(&project_id, &key))
+}
+
+/// Store a project variable's override value in the keychain — never in the
+/// database — so a user-chosen value (e.g. a disposable per-agent DB URL) can
+/// diverge from `.env` without persisting a secret at rest.
+#[tauri::command]
+pub fn set_env_override(
+    db: State<'_, Arc<parking_lot::Mutex<rusqlite::Connection>>>,
+    project_id: String,
+    key: String,
+    value: String,
+) -> Result<()> {
+    crate::secrets::set(&db.lock(), &crate::run_env::override_secret_key(&project_id, &key), &value)
+}
+
+/// Remove a project variable's override; resolution falls back to the `.env`
+/// value (mirror).
+#[tauri::command]
+pub fn clear_env_override(
+    db: State<'_, Arc<parking_lot::Mutex<rusqlite::Connection>>>,
+    project_id: String,
+    key: String,
+) -> Result<()> {
+    crate::secrets::delete(&db.lock(), &crate::run_env::override_secret_key(&project_id, &key))
+}
+
 /// Returns git state for the agent's primary repo.
 /// For multi-repo agents only the first repo's state is returned.
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -825,9 +825,11 @@ pub fn get_env_override(
     )
 }
 
-/// Store a project variable's override value in the keychain — never in the
-/// database — so a user-chosen value (e.g. a disposable per-agent DB URL) can
-/// diverge from `.env` without persisting a secret at rest.
+/// Store a project variable's override value in the app secret store (see
+/// `crate::secrets`) so a user-chosen value (e.g. a disposable per-agent DB
+/// URL) can diverge from `.env` without living in the `run_env` document. The
+/// store is the OS keychain on release macOS; on dev / non-macOS it falls back
+/// to the plaintext `settings` table, same as every other app secret.
 #[tauri::command]
 pub fn set_env_override(
     db: State<'_, Arc<parking_lot::Mutex<rusqlite::Connection>>>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,7 @@ mod oauth;
 mod pty_session;
 mod rpc;
 mod run_detect;
+mod run_env;
 mod run_session;
 mod sandbox;
 mod secrets;
@@ -1206,6 +1207,10 @@ pub fn run() {
             commands::run_state,
             commands::detect_run_config,
             commands::project_run_config,
+            commands::read_env_file_keys,
+            commands::get_env_override,
+            commands::set_env_override,
+            commands::clear_env_override,
             commands::list_checkout_tree,
             commands::list_dir,
             commands::list_prs,

--- a/src-tauri/src/run_env.rs
+++ b/src-tauri/src/run_env.rs
@@ -137,9 +137,7 @@ pub fn parse_env(text: &str) -> Vec<EnvEntry> {
 
 fn is_env_key(key: &str) -> bool {
     !key.is_empty()
-        && key
-            .bytes()
-            .all(|b| b.is_ascii_alphanumeric() || b == b'_')
+        && key.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_')
         && !key.as_bytes()[0].is_ascii_digit()
 }
 
@@ -208,10 +206,12 @@ pub fn resolve(
     let mut out = Vec::with_capacity(shared.len());
     for var in shared {
         let value = match var.source {
-            Source::Override => crate::secrets::get(conn, &override_secret_key(project_id, &var.key))
-                .ok()
-                .flatten()
-                .or_else(|| env_map.get(&var.key).cloned()),
+            Source::Override => {
+                crate::secrets::get(conn, &override_secret_key(project_id, &var.key))
+                    .ok()
+                    .flatten()
+                    .or_else(|| env_map.get(&var.key).cloned())
+            }
             Source::Mirror => env_map.get(&var.key).cloned(),
         };
         if let Some(value) = value {
@@ -253,8 +253,10 @@ BADKEY-DASH=nope
 FOO=override_wins
 EMPTY=
 ";
-        let got: Vec<(String, String)> =
-            parse_env(text).into_iter().map(|e| (e.key, e.value)).collect();
+        let got: Vec<(String, String)> = parse_env(text)
+            .into_iter()
+            .map(|e| (e.key, e.value))
+            .collect();
         assert!(got.contains(&("DATABASE_URL".into(), "postgres://localhost/dev".into())));
         assert!(got.contains(&("QUOTED".into(), "single".into())));
         assert!(got.contains(&("SPACED".into(), "padded".into())));
@@ -273,8 +275,7 @@ EMPTY=
             .vars
             .is_empty());
         // partial var: missing `shared`/`source` default to false/mirror
-        let doc: RunEnvDoc =
-            serde_json::from_str(r#"{"version":1,"vars":[{"key":"A"}]}"#).unwrap();
+        let doc: RunEnvDoc = serde_json::from_str(r#"{"version":1,"vars":[{"key":"A"}]}"#).unwrap();
         assert_eq!(doc.vars[0].key, "A");
         assert!(!doc.vars[0].shared);
         assert_eq!(doc.vars[0].source, Source::Mirror);
@@ -303,7 +304,11 @@ EMPTY=
     fn set_doc(conn: &Connection, project_id: &str, doc: &RunEnvDoc) {
         conn.execute(
             "INSERT INTO project_settings (project_id, key, value) VALUES (?1, ?2, ?3)",
-            rusqlite::params![project_id, RUN_ENV_SETTING, serde_json::to_string(doc).unwrap()],
+            rusqlite::params![
+                project_id,
+                RUN_ENV_SETTING,
+                serde_json::to_string(doc).unwrap()
+            ],
         )
         .unwrap();
     }
@@ -341,13 +346,20 @@ EMPTY=
         );
         let wt = PathBuf::from("/tmp/wt");
         let got = resolve(&conn, &project_id, dir.path(), &ctx("halifax", &wt));
-        assert_eq!(got, vec![("DATABASE_URL".into(), "postgres://real/dev".into())]);
+        assert_eq!(
+            got,
+            vec![("DATABASE_URL".into(), "postgres://real/dev".into())]
+        );
     }
 
     #[test]
     fn resolve_prefers_override_then_falls_back_to_env() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join(".env"), "DATABASE_URL=postgres://real/dev\n").unwrap();
+        std::fs::write(
+            dir.path().join(".env"),
+            "DATABASE_URL=postgres://real/dev\n",
+        )
+        .unwrap();
         let db = crate::database::init(dir.path()).unwrap();
         let conn = db.lock();
         let project_id = seed(&conn);
@@ -366,7 +378,10 @@ EMPTY=
         // No override stored yet → falls back to the .env value.
         let wt = PathBuf::from("/tmp/wt");
         let got = resolve(&conn, &project_id, dir.path(), &ctx("a", &wt));
-        assert_eq!(got, vec![("DATABASE_URL".into(), "postgres://real/dev".into())]);
+        assert_eq!(
+            got,
+            vec![("DATABASE_URL".into(), "postgres://real/dev".into())]
+        );
 
         // With an override (interpolated), the override wins.
         crate::secrets::set(
@@ -378,7 +393,10 @@ EMPTY=
         let got = resolve(&conn, &project_id, dir.path(), &ctx("halifax", &wt));
         assert_eq!(
             got,
-            vec![("DATABASE_URL".into(), "postgres://disposable/halifax".into())]
+            vec![(
+                "DATABASE_URL".into(),
+                "postgres://disposable/halifax".into()
+            )]
         );
     }
 

--- a/src-tauri/src/run_env.rs
+++ b/src-tauri/src/run_env.rs
@@ -9,16 +9,16 @@
 //! run and where its value comes from ([`Source`]). Nothing is shared by
 //! default.
 //!
-//! ## Values never live in the document
+//! ## Values never live in the database
 //! - **Mirror** vars read their value *live* from the source repo's `.env` at
 //!   spawn — so there is one source of truth and nothing to drift.
-//! - **Override** vars read their value from the app secret store (see
-//!   [`crate::secrets`]), under [`override_secret_key`], keeping the user-chosen
-//!   value out of the `run_env` document. That store is the OS keychain on
-//!   release macOS; on dev and non-macOS builds it falls back to the plaintext
-//!   `settings` table (the same posture as every other app secret), so an
-//!   override is only as protected as the store the build uses — it is not a
-//!   keychain-only guarantee on every target.
+//! - **Override** vars read their value from a dedicated store ([`override_get`]
+//!   / [`override_set`]) that **never writes to the database**: the OS keychain
+//!   on release macOS, an in-memory session store on dev and non-macOS builds
+//!   (where an ad-hoc-signed binary can't use the keychain silently). So a
+//!   user-chosen override value stays out of both the `run_env` document and
+//!   SQLite (and its backups). The trade-off is that on those non-keychain
+//!   builds an override does not survive an app restart.
 //!
 //! The `.env` lives in the **source repo** (it is gitignored, so it is absent
 //! from the agent's worktree checkout); resolution reads it host-side from the
@@ -29,6 +29,8 @@ use std::path::Path;
 
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
 
 /// `project_settings` key holding the [`RunEnvDoc`] JSON for a project.
 pub const RUN_ENV_SETTING: &str = "run_env";
@@ -100,8 +102,9 @@ pub struct InterpCtx<'a> {
     pub worktree: &'a Path,
 }
 
-/// Keychain account name for a project variable's override value. Namespaced by
-/// project so two projects that both override `DATABASE_URL` stay independent.
+/// Store key (keychain account / in-memory map key) for a project variable's
+/// override value. Namespaced by project so two projects that both override
+/// `DATABASE_URL` stay independent.
 pub fn override_secret_key(project_id: &str, key: &str) -> String {
     format!("env-override:{project_id}:{key}")
 }
@@ -203,10 +206,11 @@ fn project_setting(conn: &Connection, project_id: &str, key: &str) -> Option<Str
 
 /// Resolve the `(NAME, VALUE)` pairs to inject into a sandboxed run for
 /// `project_id`. Only `shared` vars are returned. `override` values come from
-/// the keychain (falling back to the `.env` value if the keychain entry is
-/// missing, so a half-applied override never drops the variable); `mirror`
-/// values come from `.env`. Values are interpolated with `ctx`. A var with no
-/// resolvable value is skipped rather than injected empty.
+/// the override store (falling back to the `.env` value if the entry is
+/// missing — e.g. a session store emptied by an app restart — so an override
+/// never drops the variable); `mirror` values come from `.env`. Values are
+/// interpolated with `ctx`. A var with no resolvable value is skipped rather
+/// than injected empty.
 pub fn resolve(
     conn: &Connection,
     project_id: &str,
@@ -226,12 +230,8 @@ pub fn resolve(
     let mut out = Vec::with_capacity(shared.len());
     for var in shared {
         let value = match var.source {
-            Source::Override => {
-                crate::secrets::get(conn, &override_secret_key(project_id, &var.key))
-                    .ok()
-                    .flatten()
-                    .or_else(|| env_map.get(&var.key).cloned())
-            }
+            Source::Override => override_get(&override_secret_key(project_id, &var.key))
+                .or_else(|| env_map.get(&var.key).cloned()),
             Source::Mirror => env_map.get(&var.key).cloned(),
         };
         if let Some(value) = value {
@@ -239,6 +239,97 @@ pub fn resolve(
         }
     }
     out
+}
+
+/// Override-value store. Deliberately **not** the database: the OS keychain on
+/// release macOS, an in-memory process map otherwise (dev / non-macOS), so a
+/// user's override secret never lands in SQLite or a backup. `get` is
+/// best-effort (a keychain read failure reads as "no value", so resolution
+/// falls back to `.env`); `set`/`delete` surface errors so the command can
+/// report a failed write and the caller can keep the two stores consistent.
+pub fn override_get(key: &str) -> Option<String> {
+    override_store::get(key)
+}
+
+pub fn override_set(key: &str, value: &str) -> Result<()> {
+    override_store::set(key, value)
+}
+
+pub fn override_delete(key: &str) -> Result<()> {
+    override_store::delete(key)
+}
+
+/// Keychain-backed on release macOS: the item is created and read by the same
+/// signed binary, so the app reads it silently while any other process hits a
+/// consent prompt (matching [`crate::secrets`]).
+#[cfg(all(target_os = "macos", not(debug_assertions)))]
+mod override_store {
+    use security_framework::passwords::{
+        delete_generic_password, get_generic_password, set_generic_password,
+    };
+
+    use crate::error::{Error, Result};
+
+    const SERVICE: &str = crate::BUNDLE_ID;
+    const ERR_SEC_ITEM_NOT_FOUND: i32 = -25300;
+
+    pub fn get(key: &str) -> Option<String> {
+        get_generic_password(SERVICE, key)
+            .ok()
+            .and_then(|b| String::from_utf8(b).ok())
+            .filter(|v| !v.trim().is_empty())
+    }
+
+    pub fn set(key: &str, value: &str) -> Result<()> {
+        set_generic_password(SERVICE, key, value.as_bytes())
+            .map_err(|e| Error::Other(format!("keychain write ({key}): {e}")))
+    }
+
+    pub fn delete(key: &str) -> Result<()> {
+        match delete_generic_password(SERVICE, key) {
+            Ok(()) => Ok(()),
+            Err(e) if e.code() == ERR_SEC_ITEM_NOT_FOUND => Ok(()),
+            Err(e) => Err(Error::Other(format!("keychain delete ({key}): {e}"))),
+        }
+    }
+}
+
+/// In-memory session store for builds without a usable keychain (dev, and
+/// non-macOS). Process-global so the settings commands and the spawn-time
+/// resolver share it; cleared on app exit — overrides don't persist a restart.
+#[cfg(not(all(target_os = "macos", not(debug_assertions))))]
+mod override_store {
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+
+    use crate::error::Result;
+
+    fn mem() -> &'static Mutex<HashMap<String, String>> {
+        static MEM: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+        MEM.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
+    pub fn get(key: &str) -> Option<String> {
+        mem()
+            .lock()
+            .unwrap()
+            .get(key)
+            .cloned()
+            .filter(|v| !v.trim().is_empty())
+    }
+
+    pub fn set(key: &str, value: &str) -> Result<()> {
+        mem()
+            .lock()
+            .unwrap()
+            .insert(key.to_string(), value.to_string());
+        Ok(())
+    }
+
+    pub fn delete(key: &str) -> Result<()> {
+        mem().lock().unwrap().remove(key);
+        Ok(())
+    }
 }
 
 /// Substitute `{{agent_id}}` and `{{worktree}}` tokens in a shared value.
@@ -297,8 +388,10 @@ HASH=a#b
 QUOTED_HASH=\"a # b\"
 LEADING= # only a comment
 ";
-        let got: std::collections::HashMap<String, String> =
-            parse_env(text).into_iter().map(|e| (e.key, e.value)).collect();
+        let got: std::collections::HashMap<String, String> = parse_env(text)
+            .into_iter()
+            .map(|e| (e.key, e.value))
+            .collect();
         // inline comment (space/tab before #) is stripped
         assert_eq!(got["API_KEY"], "secret");
         assert_eq!(got["TABBED"], "val");
@@ -419,7 +512,11 @@ LEADING= # only a comment
                 }],
             },
         );
-        // No override stored yet → falls back to the .env value.
+        // No override stored yet → falls back to the .env value. (The dev
+        // override store is process-global; clear first so a parallel test
+        // can't leave a value under this key.)
+        let store_key = override_secret_key(&project_id, "DATABASE_URL");
+        override_delete(&store_key).unwrap();
         let wt = PathBuf::from("/tmp/wt");
         let got = resolve(&conn, &project_id, dir.path(), &ctx("a", &wt));
         assert_eq!(
@@ -428,12 +525,7 @@ LEADING= # only a comment
         );
 
         // With an override (interpolated), the override wins.
-        crate::secrets::set(
-            &conn,
-            &override_secret_key(&project_id, "DATABASE_URL"),
-            "postgres://disposable/{{agent_id}}",
-        )
-        .unwrap();
+        override_set(&store_key, "postgres://disposable/{{agent_id}}").unwrap();
         let got = resolve(&conn, &project_id, dir.path(), &ctx("halifax", &wt));
         assert_eq!(
             got,

--- a/src-tauri/src/run_env.rs
+++ b/src-tauri/src/run_env.rs
@@ -12,9 +12,13 @@
 //! ## Values never live in the document
 //! - **Mirror** vars read their value *live* from the source repo's `.env` at
 //!   spawn — so there is one source of truth and nothing to drift.
-//! - **Override** vars read their value from the OS keychain (see
-//!   [`crate::secrets`]), under [`override_secret_key`], so a user-chosen value
-//!   (e.g. a disposable database URL) never sits in the database or its backups.
+//! - **Override** vars read their value from the app secret store (see
+//!   [`crate::secrets`]), under [`override_secret_key`], keeping the user-chosen
+//!   value out of the `run_env` document. That store is the OS keychain on
+//!   release macOS; on dev and non-macOS builds it falls back to the plaintext
+//!   `settings` table (the same posture as every other app secret), so an
+//!   override is only as protected as the store the build uses — it is not a
+//!   keychain-only guarantee on every target.
 //!
 //! The `.env` lives in the **source repo** (it is gitignored, so it is absent
 //! from the agent's worktree checkout); resolution reads it host-side from the
@@ -104,10 +108,8 @@ pub fn override_secret_key(project_id: &str, key: &str) -> String {
 
 /// Parse `.env` text into ordered `KEY=value` entries. Skips blank lines and
 /// `#` comments, tolerates a leading `export`, ignores lines without `=` or
-/// with a non-identifier key, and strips one layer of matching surrounding
-/// quotes. Last assignment wins, matching dotenv semantics. Intentionally does
-/// not strip unquoted trailing `# comments` (a value may legitimately contain
-/// `#`); document that if it surprises anyone later.
+/// with a non-identifier key. Last assignment wins, matching dotenv semantics.
+/// See [`parse_value`] for quoting and inline-comment handling.
 pub fn parse_env(text: &str) -> Vec<EnvEntry> {
     let mut out: Vec<EnvEntry> = Vec::new();
     for raw in text.lines() {
@@ -123,7 +125,7 @@ pub fn parse_env(text: &str) -> Vec<EnvEntry> {
         if !is_env_key(key) {
             continue;
         }
-        let value = unquote(v.trim());
+        let value = parse_value(v.trim());
         match out.iter_mut().find(|e| e.key == key) {
             Some(existing) => existing.value = value,
             None => out.push(EnvEntry {
@@ -141,17 +143,35 @@ fn is_env_key(key: &str) -> bool {
         && !key.as_bytes()[0].is_ascii_digit()
 }
 
-/// Strip one layer of matching surrounding single or double quotes.
-fn unquote(v: &str) -> String {
-    let bytes = v.as_bytes();
+/// Interpret the raw text after `=` (already trimmed) as a dotenv value:
+/// - **Quoted** (matching single/double quotes): the inner text verbatim — a
+///   `#` inside quotes is data, not a comment.
+/// - **Unquoted**: an inline comment (a `#` preceded by whitespace, per the
+///   dotenv convention) is stripped, then trailing whitespace trimmed. So
+///   `secret # staging` → `secret`, while `a#b` and `url#frag` (no space
+///   before `#`) keep the `#`.
+fn parse_value(v: &str) -> String {
     if v.len() >= 2 {
-        let first = bytes[0];
-        let last = bytes[bytes.len() - 1];
+        let bytes = v.as_bytes();
+        let (first, last) = (bytes[0], bytes[bytes.len() - 1]);
         if (first == b'"' || first == b'\'') && first == last {
             return v[1..v.len() - 1].to_string();
         }
     }
-    v.to_string()
+    strip_inline_comment(v).to_string()
+}
+
+/// Cut an unquoted value at its inline comment: the first `#` that is at the
+/// start or preceded by whitespace. Returns the value with trailing whitespace
+/// trimmed. A `#` with a non-space char before it (e.g. a URL fragment) is kept.
+fn strip_inline_comment(v: &str) -> &str {
+    let bytes = v.as_bytes();
+    for i in 0..bytes.len() {
+        if bytes[i] == b'#' && (i == 0 || bytes[i - 1] == b' ' || bytes[i - 1] == b'\t') {
+            return v[..i].trim_end();
+        }
+    }
+    v
 }
 
 /// Read and parse the source repo's `.env`. Missing or unreadable → empty
@@ -265,6 +285,30 @@ EMPTY=
         assert!(got.contains(&("FOO".into(), "override_wins".into())));
         // invalid keys dropped
         assert!(!got.iter().any(|(k, _)| k == "2BAD" || k == "BADKEY-DASH"));
+    }
+
+    #[test]
+    fn parse_env_strips_unquoted_inline_comments_but_keeps_hashes_in_data() {
+        let text = "\
+API_KEY=secret # staging
+TABBED=val\t# note
+FRAG=http://x/y#frag
+HASH=a#b
+QUOTED_HASH=\"a # b\"
+LEADING= # only a comment
+";
+        let got: std::collections::HashMap<String, String> =
+            parse_env(text).into_iter().map(|e| (e.key, e.value)).collect();
+        // inline comment (space/tab before #) is stripped
+        assert_eq!(got["API_KEY"], "secret");
+        assert_eq!(got["TABBED"], "val");
+        // no whitespace before # → part of the value (URL fragment, etc.)
+        assert_eq!(got["FRAG"], "http://x/y#frag");
+        assert_eq!(got["HASH"], "a#b");
+        // inside quotes, # is data
+        assert_eq!(got["QUOTED_HASH"], "a # b");
+        // a value that is only a comment collapses to empty
+        assert_eq!(got["LEADING"], "");
     }
 
     #[test]

--- a/src-tauri/src/run_env.rs
+++ b/src-tauri/src/run_env.rs
@@ -1,0 +1,395 @@
+//! Project run-environment: which of a project's `.env` variables are shared
+//! into the sandboxed Run-panel process, and with what value.
+//!
+//! ## Model
+//! The sandbox deliberately withholds the project's secrets from a run — that
+//! is the whole point of the isolation. This module is the opt-in membrane: a
+//! per-project document (stored as JSON in `project_settings` under
+//! [`RUN_ENV_SETTING`]) records, per variable, whether it is `shared` into the
+//! run and where its value comes from ([`Source`]). Nothing is shared by
+//! default.
+//!
+//! ## Values never live in the document
+//! - **Mirror** vars read their value *live* from the source repo's `.env` at
+//!   spawn — so there is one source of truth and nothing to drift.
+//! - **Override** vars read their value from the OS keychain (see
+//!   [`crate::secrets`]), under [`override_secret_key`], so a user-chosen value
+//!   (e.g. a disposable database URL) never sits in the database or its backups.
+//!
+//! The `.env` lives in the **source repo** (it is gitignored, so it is absent
+//! from the agent's worktree checkout); resolution reads it host-side from the
+//! repo path, which Fletch — unsandboxed — can always reach.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+
+/// `project_settings` key holding the [`RunEnvDoc`] JSON for a project.
+pub const RUN_ENV_SETTING: &str = "run_env";
+
+/// The `.env` file basename read from the source repo. Only the canonical
+/// `.env` for now; `.env.local` and friends are a deliberate later addition.
+const ENV_FILENAME: &str = ".env";
+
+/// Where a shared variable's value comes from. Serialized as a bare lowercase
+/// string (`"mirror"` / `"override"`) so the frontend document stays trivial;
+/// a future `computed` variant slots in without a document migration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Source {
+    /// Value read live from the source repo's `.env` at spawn.
+    #[default]
+    Mirror,
+    /// Value read from the keychain (user-provided, may differ from `.env`).
+    Override,
+}
+
+/// One variable's sharing policy. The value is never stored here.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnvVar {
+    pub key: String,
+    /// Whether the value crosses into the sandboxed run. Default (absent) is
+    /// `false` — nothing is shared unless the user switched it on.
+    #[serde(default)]
+    pub shared: bool,
+    #[serde(default)]
+    pub source: Source,
+}
+
+/// The per-project run-environment document. `version` gates future changes to
+/// this shape; unknown/malformed JSON degrades to an empty (share-nothing) doc.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunEnvDoc {
+    #[serde(default = "default_version")]
+    pub version: u32,
+    #[serde(default)]
+    pub vars: Vec<EnvVar>,
+}
+
+fn default_version() -> u32 {
+    1
+}
+
+impl Default for RunEnvDoc {
+    fn default() -> Self {
+        Self {
+            version: default_version(),
+            vars: Vec::new(),
+        }
+    }
+}
+
+/// A single `KEY=value` pair discovered in a `.env` file. Returned to the
+/// settings UI for discovery/display (masked there); `value` may be a secret.
+#[derive(Debug, Clone, Serialize)]
+pub struct EnvEntry {
+    pub key: String,
+    pub value: String,
+}
+
+/// Interpolation context: tokens a shared value may reference so the same
+/// project config yields per-agent values (e.g. a disposable per-agent DB).
+pub struct InterpCtx<'a> {
+    pub agent_id: &'a str,
+    pub worktree: &'a Path,
+}
+
+/// Keychain account name for a project variable's override value. Namespaced by
+/// project so two projects that both override `DATABASE_URL` stay independent.
+pub fn override_secret_key(project_id: &str, key: &str) -> String {
+    format!("env-override:{project_id}:{key}")
+}
+
+/// Parse `.env` text into ordered `KEY=value` entries. Skips blank lines and
+/// `#` comments, tolerates a leading `export`, ignores lines without `=` or
+/// with a non-identifier key, and strips one layer of matching surrounding
+/// quotes. Last assignment wins, matching dotenv semantics. Intentionally does
+/// not strip unquoted trailing `# comments` (a value may legitimately contain
+/// `#`); document that if it surprises anyone later.
+pub fn parse_env(text: &str) -> Vec<EnvEntry> {
+    let mut out: Vec<EnvEntry> = Vec::new();
+    for raw in text.lines() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let line = line.strip_prefix("export ").unwrap_or(line).trim_start();
+        let Some((k, v)) = line.split_once('=') else {
+            continue;
+        };
+        let key = k.trim();
+        if !is_env_key(key) {
+            continue;
+        }
+        let value = unquote(v.trim());
+        match out.iter_mut().find(|e| e.key == key) {
+            Some(existing) => existing.value = value,
+            None => out.push(EnvEntry {
+                key: key.to_string(),
+                value,
+            }),
+        }
+    }
+    out
+}
+
+fn is_env_key(key: &str) -> bool {
+    !key.is_empty()
+        && key
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_')
+        && !key.as_bytes()[0].is_ascii_digit()
+}
+
+/// Strip one layer of matching surrounding single or double quotes.
+fn unquote(v: &str) -> String {
+    let bytes = v.as_bytes();
+    if v.len() >= 2 {
+        let first = bytes[0];
+        let last = bytes[bytes.len() - 1];
+        if (first == b'"' || first == b'\'') && first == last {
+            return v[1..v.len() - 1].to_string();
+        }
+    }
+    v.to_string()
+}
+
+/// Read and parse the source repo's `.env`. Missing or unreadable → empty
+/// (the common case — many repos have no `.env`), never an error.
+pub fn read_env_file(repo_path: &Path) -> Vec<EnvEntry> {
+    match std::fs::read_to_string(repo_path.join(ENV_FILENAME)) {
+        Ok(text) => parse_env(&text),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Load the project's run-environment document. Absent or malformed → default
+/// (share nothing), so a corrupt setting can never brick a run.
+pub fn load_doc(conn: &Connection, project_id: &str) -> RunEnvDoc {
+    let Some(raw) = project_setting(conn, project_id, RUN_ENV_SETTING) else {
+        return RunEnvDoc::default();
+    };
+    serde_json::from_str(&raw).unwrap_or_default()
+}
+
+fn project_setting(conn: &Connection, project_id: &str, key: &str) -> Option<String> {
+    conn.query_row(
+        "SELECT value FROM project_settings WHERE project_id = ?1 AND key = ?2",
+        rusqlite::params![project_id, key],
+        |row| row.get::<_, String>(0),
+    )
+    .ok()
+}
+
+/// Resolve the `(NAME, VALUE)` pairs to inject into a sandboxed run for
+/// `project_id`. Only `shared` vars are returned. `override` values come from
+/// the keychain (falling back to the `.env` value if the keychain entry is
+/// missing, so a half-applied override never drops the variable); `mirror`
+/// values come from `.env`. Values are interpolated with `ctx`. A var with no
+/// resolvable value is skipped rather than injected empty.
+pub fn resolve(
+    conn: &Connection,
+    project_id: &str,
+    repo_path: &Path,
+    ctx: &InterpCtx,
+) -> Vec<(String, String)> {
+    let doc = load_doc(conn, project_id);
+    let shared: Vec<&EnvVar> = doc.vars.iter().filter(|v| v.shared).collect();
+    if shared.is_empty() {
+        return Vec::new();
+    }
+    let env_map: HashMap<String, String> = read_env_file(repo_path)
+        .into_iter()
+        .map(|e| (e.key, e.value))
+        .collect();
+
+    let mut out = Vec::with_capacity(shared.len());
+    for var in shared {
+        let value = match var.source {
+            Source::Override => crate::secrets::get(conn, &override_secret_key(project_id, &var.key))
+                .ok()
+                .flatten()
+                .or_else(|| env_map.get(&var.key).cloned()),
+            Source::Mirror => env_map.get(&var.key).cloned(),
+        };
+        if let Some(value) = value {
+            out.push((var.key.clone(), interpolate(&value, ctx)));
+        }
+    }
+    out
+}
+
+/// Substitute `{{agent_id}}` and `{{worktree}}` tokens in a shared value.
+fn interpolate(value: &str, ctx: &InterpCtx) -> String {
+    if !value.contains("{{") {
+        return value.to_string();
+    }
+    value
+        .replace("{{agent_id}}", ctx.agent_id)
+        .replace("{{worktree}}", &ctx.worktree.to_string_lossy())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn ctx<'a>(agent_id: &'a str, worktree: &'a Path) -> InterpCtx<'a> {
+        InterpCtx { agent_id, worktree }
+    }
+
+    #[test]
+    fn parse_env_handles_comments_export_quotes_and_last_wins() {
+        let text = "\
+# a comment
+export FOO=bar
+DATABASE_URL=\"postgres://localhost/dev\"
+QUOTED='single'
+  SPACED  =  padded
+2BAD=nope
+BADKEY-DASH=nope
+FOO=override_wins
+EMPTY=
+";
+        let got: Vec<(String, String)> =
+            parse_env(text).into_iter().map(|e| (e.key, e.value)).collect();
+        assert!(got.contains(&("DATABASE_URL".into(), "postgres://localhost/dev".into())));
+        assert!(got.contains(&("QUOTED".into(), "single".into())));
+        assert!(got.contains(&("SPACED".into(), "padded".into())));
+        assert!(got.contains(&("EMPTY".into(), String::new())));
+        // last assignment wins
+        assert!(got.contains(&("FOO".into(), "override_wins".into())));
+        // invalid keys dropped
+        assert!(!got.iter().any(|(k, _)| k == "2BAD" || k == "BADKEY-DASH"));
+    }
+
+    #[test]
+    fn doc_parses_and_degrades_gracefully() {
+        // malformed → default empty
+        assert!(serde_json::from_str::<RunEnvDoc>("not json")
+            .unwrap_or_default()
+            .vars
+            .is_empty());
+        // partial var: missing `shared`/`source` default to false/mirror
+        let doc: RunEnvDoc =
+            serde_json::from_str(r#"{"version":1,"vars":[{"key":"A"}]}"#).unwrap();
+        assert_eq!(doc.vars[0].key, "A");
+        assert!(!doc.vars[0].shared);
+        assert_eq!(doc.vars[0].source, Source::Mirror);
+    }
+
+    #[test]
+    fn interpolate_replaces_tokens() {
+        let wt = PathBuf::from("/tmp/wt");
+        assert_eq!(
+            interpolate("db_{{agent_id}}", &ctx("halifax", &wt)),
+            "db_halifax"
+        );
+        assert_eq!(interpolate("no-tokens", &ctx("x", &wt)), "no-tokens");
+    }
+
+    fn seed(conn: &Connection) -> String {
+        let project_id = "p1".to_string();
+        conn.execute(
+            "INSERT INTO projects (id, name, created_at) VALUES (?1, 'p', 0)",
+            [&project_id],
+        )
+        .unwrap();
+        project_id
+    }
+
+    fn set_doc(conn: &Connection, project_id: &str, doc: &RunEnvDoc) {
+        conn.execute(
+            "INSERT INTO project_settings (project_id, key, value) VALUES (?1, ?2, ?3)",
+            rusqlite::params![project_id, RUN_ENV_SETTING, serde_json::to_string(doc).unwrap()],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn resolve_returns_only_shared_mirror_vars_interpolated() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".env"),
+            "DATABASE_URL=postgres://real/dev\nSECRET=shh\nPORT=3000\n",
+        )
+        .unwrap();
+        let db = crate::database::init(dir.path()).unwrap();
+        let conn = db.lock();
+        let project_id = seed(&conn);
+        set_doc(
+            &conn,
+            &project_id,
+            &RunEnvDoc {
+                version: 1,
+                vars: vec![
+                    EnvVar {
+                        key: "DATABASE_URL".into(),
+                        shared: true,
+                        source: Source::Mirror,
+                    },
+                    // present in .env but not shared → must not appear
+                    EnvVar {
+                        key: "SECRET".into(),
+                        shared: false,
+                        source: Source::Mirror,
+                    },
+                ],
+            },
+        );
+        let wt = PathBuf::from("/tmp/wt");
+        let got = resolve(&conn, &project_id, dir.path(), &ctx("halifax", &wt));
+        assert_eq!(got, vec![("DATABASE_URL".into(), "postgres://real/dev".into())]);
+    }
+
+    #[test]
+    fn resolve_prefers_override_then_falls_back_to_env() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".env"), "DATABASE_URL=postgres://real/dev\n").unwrap();
+        let db = crate::database::init(dir.path()).unwrap();
+        let conn = db.lock();
+        let project_id = seed(&conn);
+        set_doc(
+            &conn,
+            &project_id,
+            &RunEnvDoc {
+                version: 1,
+                vars: vec![EnvVar {
+                    key: "DATABASE_URL".into(),
+                    shared: true,
+                    source: Source::Override,
+                }],
+            },
+        );
+        // No override stored yet → falls back to the .env value.
+        let wt = PathBuf::from("/tmp/wt");
+        let got = resolve(&conn, &project_id, dir.path(), &ctx("a", &wt));
+        assert_eq!(got, vec![("DATABASE_URL".into(), "postgres://real/dev".into())]);
+
+        // With an override (interpolated), the override wins.
+        crate::secrets::set(
+            &conn,
+            &override_secret_key(&project_id, "DATABASE_URL"),
+            "postgres://disposable/{{agent_id}}",
+        )
+        .unwrap();
+        let got = resolve(&conn, &project_id, dir.path(), &ctx("halifax", &wt));
+        assert_eq!(
+            got,
+            vec![("DATABASE_URL".into(), "postgres://disposable/halifax".into())]
+        );
+    }
+
+    #[test]
+    fn resolve_is_empty_when_nothing_shared_or_no_doc() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = crate::database::init(dir.path()).unwrap();
+        let conn = db.lock();
+        let project_id = seed(&conn);
+        let wt = PathBuf::from("/tmp/wt");
+        // No doc at all.
+        assert!(resolve(&conn, &project_id, dir.path(), &ctx("a", &wt)).is_empty());
+    }
+}

--- a/src-tauri/src/supervisor/run.rs
+++ b/src-tauri/src/supervisor/run.rs
@@ -379,8 +379,21 @@ fn spawn_run_phase(
     // unsandboxed with full user privilege the moment the user clicks ▶. Reads
     // and network stay open (dev servers need them); only writes are fenced.
     let (program, args, mut env, profile_file) = sandboxed_run_command(&cwd, &cmd)?;
+    // Layer the project's opt-in Run environment: the `.env` variables the user
+    // chose to share into the sandbox (mirrored live from the source repo's
+    // `.env` or overridden per project, with `{{agent_id}}`/`{{worktree}}`
+    // interpolated). Nothing is shared unless explicitly enabled in Project
+    // Settings. Best-effort — a missing record/repo just injects nothing.
+    if let Ok(record) = sup.workspace.agent(&agent_id) {
+        if let Some(primary) = record.repos.first() {
+            let project_env =
+                sup.workspace
+                    .run_env(&record.project_id, &primary.repo_path, &agent_id, &cwd);
+            env.extend(project_env);
+        }
+    }
     // Pin the resolved (port-safe) PORT last so it wins over anything the
-    // sandbox layer set.
+    // sandbox layer — or the project env above — set.
     env.extend(extra_env);
 
     let session_out = session.clone();

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -895,6 +895,28 @@ impl WorkspaceManager {
         .ok()
     }
 
+    /// Resolve the project's shared `.env` variables into `(NAME, VALUE)`
+    /// pairs to inject into a sandboxed Run process — the opt-in env membrane
+    /// (see [`crate::run_env`]). Reads the `.env` from the *source* `repo_path`
+    /// (gitignored files are absent from the worktree). Never errors: an
+    /// unreadable `.env`, absent config, or an unavailable keychain simply
+    /// yields fewer (or no) injected vars.
+    pub fn run_env(
+        &self,
+        project_id: &str,
+        repo_path: &std::path::Path,
+        agent_id: &str,
+        worktree: &std::path::Path,
+    ) -> Vec<(String, String)> {
+        let conn = self.db.lock();
+        crate::run_env::resolve(
+            &conn,
+            project_id,
+            repo_path,
+            &crate::run_env::InterpCtx { agent_id, worktree },
+        )
+    }
+
     /// Resolve the project_id for a repo path (creating the project/repo
     /// record if it doesn't exist yet — idempotent). The sidebar keys its
     /// project groups by repo path, so the Project Settings surface uses

--- a/src/api.ts
+++ b/src/api.ts
@@ -345,6 +345,13 @@ export interface ProjectRunConfig {
   configs: DetectedConfig[];
 }
 
+/** One `KEY=value` pair discovered in a project's `.env` (Rust
+ *  `run_env::EnvEntry`). Used by the Run & Environment settings list. */
+export interface EnvEntry {
+  key: string;
+  value: string;
+}
+
 export interface RunOutputEvent {
   agent_id: string;
   bytes: number[];
@@ -659,6 +666,13 @@ export const api = {
   detectRunConfig: (agentId: string) => invoke<DetectedConfig[]>("detect_run_config", { agentId }),
   projectRunConfig: (repoPath: string) =>
     invoke<ProjectRunConfig>("project_run_config", { repoPath }),
+  readEnvFileKeys: (repoPath: string) => invoke<EnvEntry[]>("read_env_file_keys", { repoPath }),
+  getEnvOverride: (projectId: string, key: string) =>
+    invoke<string | null>("get_env_override", { projectId, key }),
+  setEnvOverride: (projectId: string, key: string, value: string) =>
+    invoke<void>("set_env_override", { projectId, key, value }),
+  clearEnvOverride: (projectId: string, key: string) =>
+    invoke<void>("clear_env_override", { projectId, key }),
   listCheckoutTree: (agentId: string) => invoke<CheckoutFile[]>("list_checkout_tree", { agentId }),
   listDir: (path: string) => invoke<DirListing>("list_dir", { path }),
   listPrs: (agentId: string) => invoke<PrSummary[]>("list_prs", { agentId }),

--- a/src/components/ProjectSettings/EnvVarsSection/EnvVarRow.tsx
+++ b/src/components/ProjectSettings/EnvVarsSection/EnvVarRow.tsx
@@ -1,0 +1,81 @@
+import { Icon } from "@/components/Icon";
+import { ValueChip } from "@/components/RunConfig";
+import { IconButton } from "@/components/ui/IconButton";
+import type { EnvVarCfg } from "@/storage/runEnv";
+import { SandboxToggle } from "./SandboxToggle";
+
+interface Props {
+  varKey: string;
+  /** The value in the repo's `.env`; `undefined` if the var isn't in `.env`. */
+  envValue: string | undefined;
+  /** The override value (from the keychain) when `cfg.source === "override"`. */
+  overrideValue: string | undefined;
+  cfg: EnvVarCfg;
+  onToggleShare: (shared: boolean) => void;
+  /** Committed value from the chip: non-empty sets an override, empty reverts. */
+  onCommit: (value: string) => void;
+  /** Explicit revert-to-`.env` (the revert control by the caption). */
+  onRevert: () => void;
+}
+
+/** One environment-variable row. Same value-editing UX as the run-config rows
+ *  (shared [`ValueChip`]). The revert control lives with the "Overridden"
+ *  caption on the left — grouped with the state it undoes — so the right-hand
+ *  value + share cluster stays aligned across every row. */
+export function EnvVarRow({
+  varKey,
+  envValue,
+  overrideValue,
+  cfg,
+  onToggleShare,
+  onCommit,
+  onRevert,
+}: Props) {
+  const isOverride = cfg.source === "override";
+  const inEnv = envValue !== undefined;
+  // The effective value: the override when set, otherwise the mirrored `.env`
+  // value. Editing to a value that differs from `.env` creates an override.
+  const display = isOverride ? (overrideValue ?? "") : (envValue ?? "");
+
+  const caption = isOverride ? (
+    <>
+      <span className="dot" /> Overridden · differs from <code>.env</code>
+    </>
+  ) : inEnv ? (
+    <>
+      from <code>.env</code>
+    </>
+  ) : (
+    <>not in .env</>
+  );
+
+  return (
+    <div className={`ev-row flex-center${cfg.shared ? "" : " ev-off"}`}>
+      <div className="ev-l">
+        <div className="ev-key-row iflex-center">
+          <span className="ev-key mono text-base truncate">{varKey}</span>
+          {isOverride && (
+            <IconButton
+              size="sm"
+              tip="Revert to .env"
+              aria-label="Revert to .env"
+              onClick={onRevert}
+            >
+              <Icon name="refresh" size={12} />
+            </IconButton>
+          )}
+        </div>
+        <div className="ev-cap iflex-center text-xs">{caption}</div>
+      </div>
+      <div className="ev-r iflex-center">
+        <ValueChip
+          value={display}
+          placeholder={envValue ?? "not set"}
+          ariaLabel={varKey}
+          onCommit={onCommit}
+        />
+        <SandboxToggle value={cfg.shared} onChange={onToggleShare} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProjectSettings/EnvVarsSection/SandboxToggle.tsx
+++ b/src/components/ProjectSettings/EnvVarsSection/SandboxToggle.tsx
@@ -1,0 +1,27 @@
+import { Icon } from "@/components/Icon";
+
+interface Props {
+  value: boolean;
+  onChange: (value: boolean) => void;
+}
+
+/** Share-with-sandbox control, styled as a "drop it in the box" toggle rather
+ *  than a generic pill: the cube *is* the sandbox — a muted outline when the
+ *  variable is withheld, lit in the accent with a soft glow when it's shared
+ *  in. (Inspired by Cloudflare's proxy-cloud toggle.) Carries its own tooltip
+ *  since the icon alone doesn't spell out what it does. */
+export function SandboxToggle({ value, onChange }: Props) {
+  return (
+    <button
+      type="button"
+      className="ev-sbx tip"
+      data-on={value ? "1" : "0"}
+      data-tip={value ? "Shared with sandbox" : "Not shared with sandbox"}
+      aria-pressed={value}
+      aria-label="Share with the sandbox"
+      onClick={() => onChange(!value)}
+    >
+      <Icon name="cube" size={15} />
+    </button>
+  );
+}

--- a/src/components/ProjectSettings/EnvVarsSection/index.tsx
+++ b/src/components/ProjectSettings/EnvVarsSection/index.tsx
@@ -85,18 +85,29 @@ export function EnvVarsSection({ projectId, repoPath }: Props) {
   };
 
   // Drop an override and go back to mirroring `.env` (the revert button, and
-  // the empty/equal-to-`.env` commit cases). No-op if not overridden. Clears
-  // the keychain first so a failed doc save can't leave an orphaned value the
-  // document no longer references.
+  // the empty/equal-to-`.env` commit cases). No-op if not overridden. Capture
+  // the value and clear the store first (so a failed doc save can't orphan it);
+  // if the doc save then fails, restore the value so the two stores don't split
+  // — leaving the variable overridden, exactly as it was.
   const revertToMirror = async (key: string) => {
     if (varConfig(docRef.current, key).source !== "override") return;
+    const prevValue = await api.getEnvOverride(projectId, key);
     await api.clearEnvOverride(projectId, key);
     setOverrides((prev) => {
       const next = { ...prev };
       delete next[key];
       return next;
     });
-    await setVar(key, { source: "mirror" }).catch((e) => console.error("run_env: save failed", e));
+    try {
+      await setVar(key, { source: "mirror" });
+    } catch (e) {
+      console.error("run_env: revert save failed; restoring override", e);
+      if (prevValue != null) {
+        await api.setEnvOverride(projectId, key, prevValue).catch(() => {});
+        setOverrides((prev) => ({ ...prev, [key]: prevValue }));
+      }
+      await setVar(key, { source: "override" }).catch(() => {});
+    }
   };
 
   // A committed chip value. Empty — or exactly the `.env` value — is *not* an

--- a/src/components/ProjectSettings/EnvVarsSection/index.tsx
+++ b/src/components/ProjectSettings/EnvVarsSection/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { api, type EnvEntry } from "@/api";
 import { loadRunEnvDoc, type RunEnvDoc, saveRunEnvDoc, varConfig, withVar } from "@/storage/runEnv";
 import { basename } from "@/util/format";
@@ -21,6 +21,14 @@ export function EnvVarsSection({ projectId, repoPath }: Props) {
   // chip can show and edit them. Keyed by var name.
   const [overrides, setOverrides] = useState<Record<string, string>>({});
 
+  // The authoritative latest document. Handlers read this instead of the `doc`
+  // state so that a mutation resuming after an `await` (keychain IPC) sees any
+  // edit that landed meanwhile, rather than clobbering it with a stale closure.
+  const docRef = useRef(doc);
+  // Serializes saves so an earlier save can't finish after a later one and
+  // leave stale bytes on disk; each save writes the current `docRef`.
+  const saveQueue = useRef<Promise<unknown>>(Promise.resolve());
+
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -30,6 +38,7 @@ export function EnvVarsSection({ projectId, repoPath }: Props) {
       ]);
       if (cancelled) return;
       setEntries(envEntries);
+      docRef.current = loadedDoc;
       setDoc(loadedDoc);
       // Pull the current override values for any overridden vars.
       const overridden = loadedDoc.vars.filter((v) => v.source === "override");
@@ -55,26 +64,39 @@ export function EnvVarsSection({ projectId, repoPath }: Props) {
     return keys.map((key) => ({ key, envValue: envMap.get(key) }));
   }, [envMap, doc]);
 
-  const persist = (next: RunEnvDoc) => {
+  // Apply a pure mutation to the latest document: update ref + state
+  // synchronously (no `await` across the mutation, so concurrent edits can't
+  // interleave), then enqueue a save of the current `docRef` on the serialized
+  // queue. Returns the save promise so callers can react to a failed persist.
+  const commitDoc = (mutate: (d: RunEnvDoc) => RunEnvDoc): Promise<void> => {
+    const next = mutate(docRef.current);
+    docRef.current = next;
     setDoc(next);
-    void saveRunEnvDoc(projectId, next);
+    const save = saveQueue.current.then(() => saveRunEnvDoc(projectId, docRef.current));
+    saveQueue.current = save.catch(() => {}); // keep the chain alive after a failure
+    return save;
   };
 
-  const onToggleShare = (key: string, shared: boolean) =>
-    persist(withVar(doc, { ...varConfig(doc, key), shared }));
+  const setVar = (key: string, patch: Partial<ReturnType<typeof varConfig>>) =>
+    commitDoc((d) => withVar(d, { ...varConfig(d, key), ...patch }));
+
+  const onToggleShare = (key: string, shared: boolean) => {
+    void setVar(key, { shared }).catch((e) => console.error("run_env: save failed", e));
+  };
 
   // Drop an override and go back to mirroring `.env` (the revert button, and
-  // the empty/equal-to-`.env` commit cases). No-op if not overridden.
+  // the empty/equal-to-`.env` commit cases). No-op if not overridden. Clears
+  // the keychain first so a failed doc save can't leave an orphaned value the
+  // document no longer references.
   const revertToMirror = async (key: string) => {
-    const cfg = varConfig(doc, key);
-    if (cfg.source !== "override") return;
+    if (varConfig(docRef.current, key).source !== "override") return;
     await api.clearEnvOverride(projectId, key);
     setOverrides((prev) => {
       const next = { ...prev };
       delete next[key];
       return next;
     });
-    persist(withVar(doc, { ...cfg, source: "mirror" }));
+    await setVar(key, { source: "mirror" }).catch((e) => console.error("run_env: save failed", e));
   };
 
   // A committed chip value. Empty — or exactly the `.env` value — is *not* an
@@ -86,10 +108,22 @@ export function EnvVarsSection({ projectId, repoPath }: Props) {
       await revertToMirror(key);
       return;
     }
-    const cfg = varConfig(doc, key);
     await api.setEnvOverride(projectId, key, value);
     setOverrides((prev) => ({ ...prev, [key]: value }));
-    persist(withVar(doc, { ...cfg, source: "override" }));
+    try {
+      // Keep the two stores consistent: if the document save fails, undo the
+      // keychain write so we don't leave an override the document ignores.
+      await setVar(key, { source: "override" });
+    } catch (e) {
+      console.error("run_env: override save failed; rolling back keychain", e);
+      await api.clearEnvOverride(projectId, key).catch(() => {});
+      setOverrides((prev) => {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+      await setVar(key, { source: "mirror" }).catch(() => {});
+    }
   };
 
   return (

--- a/src/components/ProjectSettings/EnvVarsSection/index.tsx
+++ b/src/components/ProjectSettings/EnvVarsSection/index.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useMemo, useState } from "react";
+import { api, type EnvEntry } from "@/api";
+import { loadRunEnvDoc, type RunEnvDoc, saveRunEnvDoc, varConfig, withVar } from "@/storage/runEnv";
+import { basename } from "@/util/format";
+import { EnvVarRow } from "./EnvVarRow";
+
+interface Props {
+  projectId: string;
+  /** Source repo path — where the (gitignored) `.env` lives. */
+  repoPath: string;
+}
+
+/** The opt-in environment membrane: lists the project's `.env` variables and
+ *  lets the user choose, per variable, whether it's shared into the sandboxed
+ *  Run process and whether its value mirrors `.env` or is overridden. Nothing
+ *  is shared by default. Autosaves per edit, like the run-config section. */
+export function EnvVarsSection({ projectId, repoPath }: Props) {
+  const [entries, setEntries] = useState<EnvEntry[] | null>(null);
+  const [doc, setDoc] = useState<RunEnvDoc>({ version: 1, vars: [] });
+  // Override values (from the keychain), fetched for overridden vars so the
+  // chip can show and edit them. Keyed by var name.
+  const [overrides, setOverrides] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const [envEntries, loadedDoc] = await Promise.all([
+        api.readEnvFileKeys(repoPath).catch(() => [] as EnvEntry[]),
+        loadRunEnvDoc(projectId),
+      ]);
+      if (cancelled) return;
+      setEntries(envEntries);
+      setDoc(loadedDoc);
+      // Pull the current override values for any overridden vars.
+      const overridden = loadedDoc.vars.filter((v) => v.source === "override");
+      const pairs = await Promise.all(
+        overridden.map(
+          async (v) => [v.key, (await api.getEnvOverride(projectId, v.key)) ?? ""] as const,
+        ),
+      );
+      if (!cancelled) setOverrides(Object.fromEntries(pairs));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId, repoPath]);
+
+  const envMap = useMemo(() => new Map((entries ?? []).map((e) => [e.key, e.value])), [entries]);
+
+  // Every `.env` key, plus any configured var missing from `.env` (an
+  // override-only or stale entry) so nothing the user set silently vanishes.
+  const rows = useMemo(() => {
+    const keys = [...envMap.keys()];
+    for (const v of doc.vars) if (!envMap.has(v.key)) keys.push(v.key);
+    return keys.map((key) => ({ key, envValue: envMap.get(key) }));
+  }, [envMap, doc]);
+
+  const persist = (next: RunEnvDoc) => {
+    setDoc(next);
+    void saveRunEnvDoc(projectId, next);
+  };
+
+  const onToggleShare = (key: string, shared: boolean) =>
+    persist(withVar(doc, { ...varConfig(doc, key), shared }));
+
+  // Drop an override and go back to mirroring `.env` (the revert button, and
+  // the empty/equal-to-`.env` commit cases). No-op if not overridden.
+  const revertToMirror = async (key: string) => {
+    const cfg = varConfig(doc, key);
+    if (cfg.source !== "override") return;
+    await api.clearEnvOverride(projectId, key);
+    setOverrides((prev) => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+    persist(withVar(doc, { ...cfg, source: "mirror" }));
+  };
+
+  // A committed chip value. Empty — or exactly the `.env` value — is *not* an
+  // override (it just restates the mirror), so it reverts rather than pinning a
+  // redundant one. Only a value that genuinely differs from `.env` becomes an
+  // override. Mirrors the run-config revert semantics.
+  const onCommit = async (key: string, value: string) => {
+    if (value === "" || value === envMap.get(key)) {
+      await revertToMirror(key);
+      return;
+    }
+    const cfg = varConfig(doc, key);
+    await api.setEnvOverride(projectId, key, value);
+    setOverrides((prev) => ({ ...prev, [key]: value }));
+    persist(withVar(doc, { ...cfg, source: "override" }));
+  };
+
+  return (
+    <section className="ps-section">
+      <header className="ps-section-h">
+        <h2 className="ps-section-t text-lg">Environment variables</h2>
+        <p className="ps-section-lead text-sm">
+          Variables found in this project’s <code>.env</code>. Nothing is shared with the sandbox
+          unless you switch it on. Shared values are mirrored live from <code>.env</code>; edit one
+          to override it (e.g. a disposable per-agent database) — use <code>{"{{agent_id}}"}</code>{" "}
+          for a per-agent value, and clear the field to revert to <code>.env</code>.
+        </p>
+      </header>
+
+      {entries === null ? (
+        <div className="ps-state text-sm">Loading…</div>
+      ) : rows.length === 0 ? (
+        <div className="ev-empty-state text-sm">
+          No <code>.env</code> found in <span className="mono">{basename(repoPath)}</span>.
+        </div>
+      ) : (
+        <div className="ev-list">
+          {rows.map(({ key, envValue }) => (
+            <EnvVarRow
+              key={key}
+              varKey={key}
+              envValue={envValue}
+              overrideValue={overrides[key]}
+              cfg={varConfig(doc, key)}
+              onToggleShare={(shared) => onToggleShare(key, shared)}
+              onCommit={(value) => onCommit(key, value)}
+              onRevert={() => revertToMirror(key)}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/ProjectSettings/ProjectSettings.css
+++ b/src/components/ProjectSettings/ProjectSettings.css
@@ -156,7 +156,6 @@
 .ps-section-lead {
   margin-top: 6px;
   color: var(--fg-2);
-  max-width: 62ch;
   line-height: 1.5;
 }
 .ps-eco {
@@ -272,4 +271,109 @@
   background: color-mix(in srgb, var(--danger), var(--bg-0) 86%);
   border: 1px solid color-mix(in srgb, var(--danger), var(--bg-0) 70%);
   border-radius: var(--r-sm);
+}
+
+/* environment variables — the opt-in sandbox env membrane. No `overflow` here:
+ * clipping would cut off the value chip's tooltips at the list boundary. */
+.ev-list {
+  margin-top: 14px;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-sm);
+}
+.ev-row {
+  gap: 12px;
+  justify-content: space-between;
+  padding: 9px 12px;
+  border-top: 1px solid var(--bd-soft);
+}
+.ev-row:first-child {
+  border-top: none;
+}
+/* A var that isn't shared with the sandbox reads as inactive. */
+.ev-row.ev-off {
+  opacity: 0.6;
+}
+.ev-l {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.ev-key {
+  color: var(--fg-0);
+}
+.ev-cap {
+  gap: 5px;
+  color: var(--fg-3);
+}
+.ev-cap code {
+  font-family: var(--font-mono);
+  color: var(--fg-2);
+}
+.ev-cap .dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+/* Overridden rows tint their caption like the run-config surface does. */
+.ev-cap:has(.dot) {
+  color: var(--accent);
+}
+/* Variable name + its revert-to-.env button (shown only when overridden). The
+ * revert sits by the name, not in the right cluster, so the value + share
+ * columns stay aligned on every row. */
+.ev-key-row {
+  gap: 4px;
+  min-width: 0;
+}
+.ev-r {
+  gap: 6px;
+  flex-shrink: 0;
+}
+/* share-with-sandbox toggle — the cube is the sandbox; it lights up and glows
+ * when the variable is shared in. */
+.ev-sbx {
+  width: 30px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--fg-3);
+  background: transparent;
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    background 0.15s ease,
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+.ev-sbx:hover {
+  color: var(--fg-1);
+  border-color: var(--bd);
+}
+.ev-sbx[data-on="1"] {
+  color: var(--accent);
+  border-color: color-mix(in oklch, var(--accent), transparent 55%);
+  background: color-mix(in oklch, var(--accent), transparent 88%);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent), transparent 85%);
+}
+.ev-sbx[data-on="1"]:hover {
+  background: color-mix(in oklch, var(--accent), transparent 82%);
+}
+.ev-empty-state {
+  margin-top: 14px;
+  padding: 14px;
+  color: var(--fg-3);
+  text-align: center;
+  border: 1px dashed var(--bd-soft);
+  border-radius: var(--r-sm);
+}
+.ev-empty-state code {
+  font-family: var(--font-mono);
+  color: var(--fg-2);
 }

--- a/src/components/ProjectSettings/index.tsx
+++ b/src/components/ProjectSettings/index.tsx
@@ -5,6 +5,7 @@ import { loadRunOverrides, type SetupRow, toSetupRows } from "@/components/RunCo
 import { Loader } from "@/components/ui/Loader";
 import { useAppStore } from "@/store";
 import { basename } from "@/util/format";
+import { EnvVarsSection } from "./EnvVarsSection";
 import { GeneralSection } from "./GeneralSection";
 import { ProjectPulse } from "./ProjectPulse";
 import { RunEnvSection } from "./RunEnvSection";
@@ -104,6 +105,7 @@ export function ProjectSettings({ repoPath }: { repoPath: string }) {
                 ecosystem={loaded.ecosystem}
                 initialOverrides={loaded.overrides}
               />
+              <EnvVarsSection projectId={loaded.projectId} repoPath={repoPath} />
             </div>
           )}
         </div>

--- a/src/components/RunConfig/ConfigRow.tsx
+++ b/src/components/RunConfig/ConfigRow.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { Icon } from "@/components/Icon";
 import type { SetupRow } from "./types";
+import { ValueChip } from "./ValueChip";
 
 interface ConfigRowProps {
   row: SetupRow;
@@ -14,42 +15,26 @@ interface ConfigRowProps {
   onRevert: () => void;
 }
 
-/** Widest the value can render in view mode before it truncates. */
-const VIEW_MAX_WIDTH = 220;
-/** Input width while editing. */
-const EDIT_WIDTH = 200;
-
-/** One editable run-config row. The value is a single persistent input styled
- *  as a chip in view mode, so the border, focus ring, and width all animate
- *  on the view↔edit transition instead of the two states swapping elements.
+/** One editable run-config row. The value is a shared [`ValueChip`] — a chip
+ *  whose in-field edit icon and width animate on the view↔edit transition.
  *  Overridden rows on the agent surface get a revert button; project edits
  *  are final (clearing the field falls back to detected). Reused by the Run
  *  panel sheet and the Project Settings modal. */
 export function ConfigRow({ row, override, scope, onChange, onRevert }: ConfigRowProps) {
   const [editing, setEditing] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
-  // Set when Escape cancels the edit, so the blur that follows discards the
-  // draft instead of committing it.
-  const cancelledRef = useRef(false);
-
   const hasOverride = override != null;
   const display = hasOverride ? override : row.value;
   // The detected default seeds the placeholder; a fallback row has none, so
   // it carries its own hint instead.
   const placeholder = row.value || row.placeholder || "";
 
-  const [text, setText] = useState(display);
-  useEffect(() => {
-    if (!editing) setText(display);
-  }, [display, editing]);
-
-  // Inputs don't size to their content, but the value is monospace, so its
-  // rendered width is exactly length × 1ch — sized in ch units the width is
-  // always right, with no DOM measurement to go stale when the font loads.
-  // Keeping the width explicit in both states is what lets it transition.
-  // Fall back to the placeholder when empty so the hint isn't clipped.
-  const widthBasis = display || placeholder;
-  const viewWidth = `min(${Math.max(widthBasis.length, 1)}ch + 2px, ${VIEW_MAX_WIDTH}px)`;
+  // A committed value that clears the field or matches the detected default
+  // reverts; anything else is an override. (`ValueChip` already suppresses a
+  // no-op commit that equals `display`.)
+  const onCommit = (v: string) => {
+    if (v === "" || v === row.value) onRevert();
+    else onChange(v);
+  };
 
   // Project Settings edits ARE the project setting — no override framing
   // there, in label or styling. Only the agent surface marks a row that
@@ -81,54 +66,13 @@ export function ConfigRow({ row, override, scope, onChange, onRevert }: ConfigRo
         {caption && <div className="rs-source iflex-center text-xs">{caption}</div>}
       </div>
       <div className="rs-row-r iflex-center">
-        <div
-          className={`rs-value iflex-center text-sm${editing ? " editing" : ""}`}
-          onClick={() => inputRef.current?.focus()}
-        >
-          <input
-            ref={inputRef}
-            aria-label={row.key}
-            type="text"
-            value={text}
-            readOnly={!editing}
-            placeholder={placeholder}
-            style={{ width: editing ? EDIT_WIDTH : viewWidth }}
-            onFocus={() => setEditing(true)}
-            onChange={(e) => setText(e.target.value)}
-            onBlur={(e) => {
-              setEditing(false);
-              if (cancelledRef.current) {
-                cancelledRef.current = false;
-                setText(display);
-                return;
-              }
-              const v = e.currentTarget.value.trim();
-              // Unchanged from what's shown — don't fire onChange/onRevert.
-              // Comparing against `display` (the effective value: override if
-              // set, else detected) rather than `row.value` (detected only) is
-              // what keeps a no-op focus→blur on an already-overridden field
-              // from re-committing the identical override.
-              if (v === display) return;
-              if (v === "" || v === row.value) onRevert();
-              else onChange(v);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") e.currentTarget.blur();
-              if (e.key === "Escape") {
-                // Keep Escape from bubbling to the container's document/window
-                // keydown listener (Project Settings modal, Run panel sheet),
-                // which would otherwise close the whole surface instead of just
-                // cancelling this in-progress edit.
-                e.stopPropagation();
-                cancelledRef.current = true;
-                e.currentTarget.blur();
-              }
-            }}
-          />
-          <span className="rs-edit-ic iflex-center">
-            <Icon name="edit" size={10} />
-          </span>
-        </div>
+        <ValueChip
+          value={display}
+          placeholder={placeholder}
+          ariaLabel={row.key}
+          onCommit={onCommit}
+          onEditingChange={setEditing}
+        />
         {marksOverride && !editing && (
           <button className="rs-revert iflex-center tip" data-tip={revertTip} onClick={onRevert}>
             <span className="rs-revert-ic iflex-center">

--- a/src/components/RunConfig/ValueChip.tsx
+++ b/src/components/RunConfig/ValueChip.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useRef, useState } from "react";
+import { Icon } from "@/components/Icon";
+
+interface Props {
+  /** Effective value shown in view mode (the override if set, else the default). */
+  value: string;
+  /** Hint shown when the value is empty. */
+  placeholder?: string;
+  ariaLabel: string;
+  /** Fired with the trimmed value when an edit commits (Enter/blur) and it
+   *  actually changed. The parent decides what a value — or an empty string —
+   *  means (set an override, revert to default, etc.). */
+  onCommit: (value: string) => void;
+  /** Notified as the chip enters/leaves edit mode, so a parent can hide
+   *  adjacent controls (e.g. a revert button) while editing. */
+  onEditingChange?: (editing: boolean) => void;
+}
+
+/** Widest the value renders in view mode (`ch`) before it truncates. */
+const VIEW_MAX_CH = 28;
+/** Editing floor (`ch`) — kept above `VIEW_MAX_CH` so focusing always *expands*
+ *  the field (never shrinks it) even for a long, view-truncated value. */
+const EDIT_MIN_CH = 32;
+/** Editing ceiling (`ch`) — comfortable to edit, still safe in the narrower
+ *  Run-panel sheet as well as the wide Project Settings modal. */
+const EDIT_MAX_CH = 46;
+
+/** A value rendered as a chip with an in-field edit affordance: a single
+ *  persistent `<input>` styled as a chip, so the border, focus ring, and width
+ *  animate on the view↔edit transition instead of swapping elements. Extracted
+ *  from the run-config row so the Run panel, Project Settings run config, and
+ *  the environment-variables list all share one editing UX. */
+export function ValueChip({
+  value,
+  placeholder = "",
+  ariaLabel,
+  onCommit,
+  onEditingChange,
+}: Props) {
+  const [editing, setEditingState] = useState(false);
+  const setEditing = (next: boolean) => {
+    setEditingState(next);
+    onEditingChange?.(next);
+  };
+  const inputRef = useRef<HTMLInputElement>(null);
+  // Set when Escape cancels the edit, so the blur that follows discards the
+  // draft instead of committing it.
+  const cancelledRef = useRef(false);
+
+  const [text, setText] = useState(value);
+  useEffect(() => {
+    if (!editing) setText(value);
+  }, [value, editing]);
+
+  // Inputs don't size to content, but the value is monospace, so its rendered
+  // width is exactly length × 1ch — sized in ch units it's always right, with
+  // no DOM measurement to go stale when the font loads. Keeping the width
+  // explicit in both states is what lets it transition. View width tracks the
+  // value (capped); editing width tracks what's being typed but is floored
+  // above the view cap so focusing always grows the field, never shrinks it.
+  const viewCh = Math.min(Math.max((value || placeholder).length, 1), VIEW_MAX_CH);
+  const editCh = Math.min(Math.max(text.length + 2, EDIT_MIN_CH), EDIT_MAX_CH);
+  const width = editing ? `${editCh}ch` : `min(${viewCh}ch + 2px, ${VIEW_MAX_CH}ch)`;
+
+  return (
+    <div
+      className={`rs-value iflex-center text-sm${editing ? " editing" : ""}`}
+      onClick={() => inputRef.current?.focus()}
+    >
+      <input
+        ref={inputRef}
+        aria-label={ariaLabel}
+        type="text"
+        value={text}
+        readOnly={!editing}
+        placeholder={placeholder}
+        style={{ width }}
+        onFocus={() => setEditing(true)}
+        onChange={(e) => setText(e.target.value)}
+        onBlur={(e) => {
+          setEditing(false);
+          if (cancelledRef.current) {
+            cancelledRef.current = false;
+            setText(value);
+            return;
+          }
+          const v = e.currentTarget.value.trim();
+          // Unchanged from what's shown — don't fire onCommit.
+          if (v === value) return;
+          onCommit(v);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") e.currentTarget.blur();
+          if (e.key === "Escape") {
+            // Keep Escape from bubbling to the surrounding surface's keydown
+            // listener (modal / sheet), which would close it instead of just
+            // cancelling this in-progress edit.
+            e.stopPropagation();
+            cancelledRef.current = true;
+            e.currentTarget.blur();
+          }
+        }}
+      />
+      <span className="rs-edit-ic iflex-center">
+        <Icon name="edit" size={10} />
+      </span>
+    </div>
+  );
+}

--- a/src/components/RunConfig/index.ts
+++ b/src/components/RunConfig/index.ts
@@ -3,3 +3,4 @@ export { RunConfigEditor } from "./RunConfigEditor";
 export { reconcileOverrides } from "./reconcileOverrides";
 export { loadRunOverrides, persistRunOverrides } from "./runSettings";
 export { ECOSYSTEM_LABEL, rowsOrFallback, type SetupRow, toSetupRows } from "./types";
+export { ValueChip } from "./ValueChip";

--- a/src/storage/runEnv.ts
+++ b/src/storage/runEnv.ts
@@ -1,0 +1,62 @@
+import { getProjectSettings, setProjectSetting } from "./projectSettings";
+
+/** Where a shared variable's value comes from. Mirrors Rust `run_env::Source`
+ *  (serialized as a bare lowercase string). */
+export type EnvSource = "mirror" | "override";
+
+/** One variable's sharing policy. The value never lives here — mirror values
+ *  are read live from `.env`; override values live in the keychain. */
+export interface EnvVarCfg {
+  key: string;
+  shared: boolean;
+  source: EnvSource;
+}
+
+/** The per-project run-environment document, stored as JSON in
+ *  `project_settings` under `run_env`. Mirrors Rust `run_env::RunEnvDoc`. */
+export interface RunEnvDoc {
+  version: number;
+  vars: EnvVarCfg[];
+}
+
+const RUN_ENV_KEY = "run_env";
+const CURRENT_VERSION = 1;
+
+function emptyDoc(): RunEnvDoc {
+  return { version: CURRENT_VERSION, vars: [] };
+}
+
+/** Load the project's run-environment document. Absent or malformed → empty
+ *  (share nothing), matching the backend's degrade-gracefully posture. */
+export async function loadRunEnvDoc(projectId: string): Promise<RunEnvDoc> {
+  const settings = await getProjectSettings(projectId);
+  const raw = settings[RUN_ENV_KEY];
+  if (!raw) return emptyDoc();
+  try {
+    const parsed = JSON.parse(raw) as Partial<RunEnvDoc>;
+    return {
+      version: parsed.version ?? CURRENT_VERSION,
+      vars: Array.isArray(parsed.vars) ? parsed.vars : [],
+    };
+  } catch {
+    return emptyDoc();
+  }
+}
+
+/** Persist the run-environment document for a project. */
+export async function saveRunEnvDoc(projectId: string, doc: RunEnvDoc): Promise<void> {
+  await setProjectSetting(projectId, RUN_ENV_KEY, JSON.stringify(doc));
+}
+
+/** Return the config for `key`, or a default (unshared, mirror) if absent. */
+export function varConfig(doc: RunEnvDoc, key: string): EnvVarCfg {
+  return doc.vars.find((v) => v.key === key) ?? { key, shared: false, source: "mirror" };
+}
+
+/** Upsert one variable's config into the document (immutably), dropping a var
+ *  that has reverted to the default (unshared + mirror) so the doc stays sparse. */
+export function withVar(doc: RunEnvDoc, next: EnvVarCfg): RunEnvDoc {
+  const rest = doc.vars.filter((v) => v.key !== next.key);
+  const isDefault = !next.shared && next.source === "mirror";
+  return { ...doc, vars: isDefault ? rest : [...rest, next] };
+}

--- a/src/styles/foundation/base.css
+++ b/src/styles/foundation/base.css
@@ -48,6 +48,19 @@ select {
 }
 button {
   cursor: default;
+  /* Complete the reset: without this, the UA's default button padding shrinks
+   * the content box below a small button's set size, which (with the flex rule
+   * below) is what squashes icons. Styled buttons set their own padding. */
+  padding: 0;
+}
+/* Icons must never shrink to fit a too-tight flex parent — the classic "10px
+ * icon rendered at 4px inside a small button" bug. Keep them at their intrinsic
+ * size everywhere; a button/box that's genuinely too small should overflow (and
+ * get noticed), not silently squash the glyph. */
+button svg,
+.iflex-center > svg,
+.flex-center > svg {
+  flex-shrink: 0;
 }
 ::selection {
   background: var(--accent-soft);

--- a/src/styles/shared/icon-button.css
+++ b/src/styles/shared/icon-button.css
@@ -3,6 +3,7 @@
   justify-content: center;
   width: 26px;
   height: 26px;
+  flex-shrink: 0;
   border-radius: var(--r-sm);
   color: var(--fg-1);
   transition: var(--transition-ui-ease);


### PR DESCRIPTION
## What

Adds an opt-in **Environment variables** section to a project's settings. It lists the variables in the project's `.env` and lets you choose, per variable:

- **Share with the sandbox** (the cube toggle) — nothing is shared by default; the value only reaches the sandboxed Run process when switched on.
- **Mirror `.env` or Override** — a shared value is read live from `.env`, or you override it (e.g. a disposable per-agent database URL). Override values are stored in the OS keychain, never in the database.

Shared values are resolved at spawn from the **source** repo's `.env` (gitignored, so absent from the worktree), interpolated with `{{agent_id}}` / `{{worktree}}`, and injected into the Run process (both setup and dev phases).

## Why

Running a project's app in the sandbox failed when it needed env like `DATABASE_URL` — `.env` isn't cloned into the sandbox, and silently copying secrets defeats the isolation. This gives explicit, per-variable control over what crosses the sandbox boundary.

## Storage

A versioned JSON document in `project_settings` (key `run_env`) — no schema migration. Secrets stay out of the DB (keychain-backed overrides); `.env` values are read live, so there's no second copy to drift.

## Backend

- New `run_env` module: `.env` parser, `RunEnvDoc` types, resolver (mirror/override precedence + interpolation), keychain override keys — unit-tested.
- Commands: `read_env_file_keys`, `get/set/clear_env_override`.
- Injection in `supervisor::run::spawn_run_phase`.

## UI / refactor

- New **Environment variables** section: per-var share toggle (a cube that lights up when shared), in-place value editor, revert-to-`.env` by the variable name.
- Extracted the run-config value editor into a shared **`ValueChip`**, now reused by both the run-config rows and the env rows (one editing UX).
- Fixed an app-wide icon-button squash: the base reset now zeroes button padding and icon SVGs no longer flex-shrink.

## Scope / follow-ons

- Injection targets the **Run process** only (not the agent's own shell yet).
- **Proxy mode** (credentials that never enter the sandbox) and **per-agent resource provisioning** (auto create/tear-down of a disposable DB) are deliberately deferred; `{{agent_id}}` is a naming primitive today — pair it with a setup command to provision.

## Testing

- Rust: `cargo test` green incl. new `run_env` tests (parse, resolve precedence, interpolation, share-gating).
- Frontend: `tsc` clean, biome 0 errors, `vitest` 428 pass.
- Not exercised in the live GUI (the sandboxed Run panel can't launch in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
