### PR TITLE
feat(settings): add model refresh action

### DIFF
--- a/src/components/SettingsScreen/DeveloperPane.tsx
+++ b/src/components/SettingsScreen/DeveloperPane.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { Icon } from "@/components/Icon";
 import { Button } from "@/components/ui/Button";
-import { clearCachedCatalog } from "@/data/modelCatalog";
 import { useAppStore } from "@/store";
 import { SetGroup, SetHead, SetRow } from "./primitives";
 
@@ -17,9 +16,8 @@ export function DeveloperPane() {
   const handleRefreshModels = async () => {
     if (refreshingModels) return;
     setRefreshingModels(true);
-    clearCachedCatalog();
     try {
-      await refreshModelCatalog();
+      await refreshModelCatalog(true);
     } finally {
       setRefreshingModels(false);
     }

--- a/src/components/SettingsScreen/DeveloperPane.tsx
+++ b/src/components/SettingsScreen/DeveloperPane.tsx
@@ -56,7 +56,11 @@ export function DeveloperPane() {
           title="Refresh models"
           sub="Clear the cached catalog and re-run Codex discovery plus models.dev enrichment right now."
         >
-          <Button variant="outline" onClick={() => void handleRefreshModels()} disabled={refreshingModels}>
+          <Button
+            variant="outline"
+            onClick={() => void handleRefreshModels()}
+            disabled={refreshingModels}
+          >
             <Icon name="refresh" size={12} />
             {refreshingModels ? "Refreshing..." : "Refresh models"}
           </Button>

--- a/src/components/SettingsScreen/DeveloperPane.tsx
+++ b/src/components/SettingsScreen/DeveloperPane.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react";
 import { Icon } from "@/components/Icon";
 import { Button } from "@/components/ui/Button";
+import { clearCachedCatalog } from "@/data/modelCatalog";
 import { useAppStore } from "@/store";
 import { SetGroup, SetHead, SetRow } from "./primitives";
 
@@ -8,7 +10,20 @@ import { SetGroup, SetHead, SetRow } from "./primitives";
 export function DeveloperPane() {
   const openOnboarding = useAppStore((s) => s.openOnboarding);
   const closeSettingsScreen = useAppStore((s) => s.closeSettingsScreen);
+  const refreshModelCatalog = useAppStore((s) => s.refreshModelCatalog);
   const setUpdateReady = useAppStore((s) => s.setUpdateReady);
+  const [refreshingModels, setRefreshingModels] = useState(false);
+
+  const handleRefreshModels = async () => {
+    if (refreshingModels) return;
+    setRefreshingModels(true);
+    clearCachedCatalog();
+    try {
+      await refreshModelCatalog();
+    } finally {
+      setRefreshingModels(false);
+    }
+  };
 
   return (
     <div className="set-pane">
@@ -32,6 +47,18 @@ export function DeveloperPane() {
           >
             <Icon name="sparkle" size={12} />
             Replay tour
+          </Button>
+        </SetRow>
+      </SetGroup>
+
+      <SetGroup label="Models">
+        <SetRow
+          title="Refresh models"
+          sub="Clear the cached catalog and re-run Codex discovery plus models.dev enrichment right now."
+        >
+          <Button variant="outline" onClick={() => void handleRefreshModels()} disabled={refreshingModels}>
+            <Icon name="refresh" size={12} />
+            {refreshingModels ? "Refreshing..." : "Refresh models"}
           </Button>
         </SetRow>
       </SetGroup>

--- a/src/data/modelCatalog/index.ts
+++ b/src/data/modelCatalog/index.ts
@@ -24,6 +24,8 @@ interface CacheEnvelope {
   catalog: UnifiedCatalog;
 }
 
+let refreshInFlight: Promise<UnifiedCatalog | null> | null = null;
+
 function readCache(): CacheEnvelope | null {
   try {
     const raw = localStorage.getItem(CACHE_KEY);
@@ -34,15 +36,6 @@ function readCache(): CacheEnvelope | null {
     // Corrupt cache — treat as absent.
   }
   return null;
-}
-
-/** Drop the cached catalog so the next refresh rebuilds from live discovery. */
-export function clearCachedCatalog(): void {
-  try {
-    localStorage.removeItem(CACHE_KEY);
-  } catch {
-    // Storage unavailable — the next rebuild still updates in-memory state.
-  }
 }
 
 /** Best catalog available without rebuilding: the cached copy, or empty. Used to
@@ -74,4 +67,16 @@ export async function rebuildCatalog(): Promise<UnifiedCatalog | null> {
     // Storage unavailable — the in-memory result is still usable this session.
   }
   return catalog;
+}
+
+/** Refresh the catalog, deduping concurrent requests so only one rebuild runs.
+ *  `force=true` skips the TTL check and is used by the manual developer action. */
+export function refreshCatalog(force = false): Promise<UnifiedCatalog | null> {
+  if (refreshInFlight) return refreshInFlight;
+  if (!force && !isCatalogStale()) return Promise.resolve(loadCachedCatalog());
+
+  refreshInFlight = rebuildCatalog().finally(() => {
+    refreshInFlight = null;
+  });
+  return refreshInFlight;
 }

--- a/src/data/modelCatalog/index.ts
+++ b/src/data/modelCatalog/index.ts
@@ -36,6 +36,15 @@ function readCache(): CacheEnvelope | null {
   return null;
 }
 
+/** Drop the cached catalog so the next refresh rebuilds from live discovery. */
+export function clearCachedCatalog(): void {
+  try {
+    localStorage.removeItem(CACHE_KEY);
+  } catch {
+    // Storage unavailable — the next rebuild still updates in-memory state.
+  }
+}
+
 /** Best catalog available without rebuilding: the cached copy, or empty. Used to
  *  seed the store synchronously so lookups work on the first render. */
 export function loadCachedCatalog(): UnifiedCatalog {

--- a/src/data/modelCatalog/index.ts
+++ b/src/data/modelCatalog/index.ts
@@ -51,14 +51,14 @@ export function isCatalogStale(): boolean {
 }
 
 /** Rebuild the catalog from agent discovery + models.dev, and cache it. Returns
- *  null on failure (no agents and no models.dev) so the caller keeps the cache.
- *  A models.dev outage still yields a usable catalog from CLI-reported ids. */
+ *  null on any failure so the caller keeps the last good cache intact. */
 export async function rebuildCatalog(): Promise<UnifiedCatalog | null> {
   const [agents, index] = await Promise.all([
     api.discoverSupportedModels().catch(() => []),
     fetchModelsDevIndex(),
   ]);
-  const catalog = buildCatalog(agents, index ?? { byId: {}, byProvider: {} });
+  if (index === null) return null;
+  const catalog = buildCatalog(agents, index);
   if (Object.keys(catalog.byId).length === 0) return null;
   try {
     const env: CacheEnvelope = { builtAt: Date.now(), catalog };

--- a/src/store/providers.ts
+++ b/src/store/providers.ts
@@ -1,5 +1,5 @@
 import { api } from "@/api";
-import { isCatalogStale, loadCachedCatalog, rebuildCatalog } from "@/data/modelCatalog";
+import { loadCachedCatalog, refreshCatalog } from "@/data/modelCatalog";
 import { setSetting } from "@/storage/settings";
 import type { ProvidersSlice, SliceCreator } from "./types";
 
@@ -54,10 +54,8 @@ export const createProvidersSlice: SliceCreator<ProvidersSlice> = (set, get) => 
     });
     await get().refreshProviderVersions();
   },
-  refreshModelCatalog: async () => {
-    // Cache holds for 1h; the init seed already reflects it when fresh.
-    if (!isCatalogStale()) return;
-    const catalog = await rebuildCatalog();
+  refreshModelCatalog: async (force = false) => {
+    const catalog = await refreshCatalog(force);
     if (catalog) set({ modelCatalog: catalog.byId, modelsByAgent: catalog.byAgent });
   },
 });

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -515,8 +515,8 @@ export interface ProvidersSlice {
    *  override, updates local state, and re-probes so the version/path refresh. */
   setProviderPathOverride: (id: string, path: string | null) => Promise<void>;
   /** Rebuild the model catalog (agent discovery + models.dev) when the cache is
-   *  stale (24h). Runs once on init; non-fatal on failure (keeps cached data). */
-  refreshModelCatalog: () => Promise<void>;
+   *  stale (1h), or immediately when forced by the manual developer action. */
+  refreshModelCatalog: (force?: boolean) => Promise<void>;
 }
 
 export interface DraftsSlice {

--- a/tests/data/modelCatalog/refresh.test.ts
+++ b/tests/data/modelCatalog/refresh.test.ts
@@ -39,7 +39,7 @@ beforeEach(() => {
 });
 
 describe("refreshCatalog", () => {
-  it("keeps the last good cache when a refresh fails", async () => {
+  it("keeps the last good cache when models.dev fails after discovery succeeds", async () => {
     storage.set(
       CACHE_KEY,
       JSON.stringify({
@@ -57,7 +57,7 @@ describe("refreshCatalog", () => {
         },
       }),
     );
-    mocks.discoverSupportedModels.mockResolvedValue([]);
+    mocks.discoverSupportedModels.mockResolvedValue([{ agent: "codex", models: [] }]);
     mocks.fetchModelsDevIndex.mockResolvedValue(null);
 
     const { loadCachedCatalog, refreshCatalog } = await import("@/data/modelCatalog");

--- a/tests/data/modelCatalog/refresh.test.ts
+++ b/tests/data/modelCatalog/refresh.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  discoverSupportedModels: vi.fn(),
+  fetchModelsDevIndex: vi.fn(),
+}));
+
+vi.mock("@/api", () => ({
+  api: {
+    discoverSupportedModels: mocks.discoverSupportedModels,
+  },
+}));
+
+vi.mock("@/data/modelCatalog/modelsDev", () => ({
+  fetchModelsDevIndex: mocks.fetchModelsDevIndex,
+}));
+
+const CACHE_KEY = "modelCatalog.cache.v13";
+
+const storage = new Map<string, string>();
+
+beforeEach(() => {
+  storage.clear();
+  vi.resetModules();
+  mocks.discoverSupportedModels.mockReset();
+  mocks.fetchModelsDevIndex.mockReset();
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      storage.set(key, value);
+    },
+    removeItem: (key: string) => {
+      storage.delete(key);
+    },
+    clear: () => {
+      storage.clear();
+    },
+  });
+});
+
+describe("refreshCatalog", () => {
+  it("keeps the last good cache when a refresh fails", async () => {
+    storage.set(
+      CACHE_KEY,
+      JSON.stringify({
+        builtAt: 1,
+        catalog: {
+          byId: {
+            saved: {
+              id: "saved",
+              name: "Saved",
+              contextWindow: 1,
+              reasoning: false,
+            },
+          },
+          byAgent: {},
+        },
+      }),
+    );
+    mocks.discoverSupportedModels.mockResolvedValue([]);
+    mocks.fetchModelsDevIndex.mockResolvedValue(null);
+
+    const { loadCachedCatalog, refreshCatalog } = await import("@/data/modelCatalog");
+    const result = await refreshCatalog(true);
+
+    expect(result).toBeNull();
+    expect(loadCachedCatalog().byId.saved.id).toBe("saved");
+    expect(storage.get(CACHE_KEY)).toContain("saved");
+  });
+
+  it("dedupes concurrent refreshes so only one rebuild runs", async () => {
+    let resolveDiscover: (value: unknown) => void = () => {};
+    let resolveIndex: (value: unknown) => void = () => {};
+    const discover = new Promise((resolve) => {
+      resolveDiscover = resolve;
+    });
+    const index = new Promise((resolve) => {
+      resolveIndex = resolve;
+    });
+
+    mocks.discoverSupportedModels.mockReturnValue(discover);
+    mocks.fetchModelsDevIndex.mockReturnValue(index);
+
+    const { refreshCatalog } = await import("@/data/modelCatalog");
+    const first = refreshCatalog(true);
+    const second = refreshCatalog(true);
+
+    expect(first).toBe(second);
+    expect(mocks.discoverSupportedModels).toHaveBeenCalledTimes(1);
+    expect(mocks.fetchModelsDevIndex).toHaveBeenCalledTimes(1);
+
+    resolveDiscover([{ agent: "codex", models: [{ id: "gpt-5.5" }] }]);
+    resolveIndex({
+      byId: {
+        "gpt-5.5": {
+          id: "gpt-5.5",
+          name: "GPT-5.5",
+          contextWindow: 400_000,
+          reasoning: true,
+          releaseDate: "2025-12-11",
+        },
+      },
+      byProvider: {
+        openai: ["gpt-5.5"],
+      },
+    });
+
+    const result = await first;
+    expect(result?.byId["gpt-5.5"]?.name).toBe("GPT-5.5");
+    expect(storage.get(CACHE_KEY)).toContain("gpt-5.5");
+  });
+});


### PR DESCRIPTION
Add a Developer settings action that clears the cached model catalog and immediately rebuilds it from Codex discovery plus models.dev. This gives a manual way to refresh newly released models without waiting for the 1h cache TTL.\n\nAlso adds a small catalog helper to clear the localStorage-backed cache.