### PR TITLE
chore: release 0.7.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fletch",
   "private": true,
-  "version": "0.7.9",
+  "version": "0.7.10",
   "license": "AGPL-3.0-only",
   "author": "Alex Chaplinsky and fwdai.org",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "fletch"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fletch"
-version = "0.7.9"
+version = "0.7.10"
 description = "Spawn coding agents in isolated sandboxes"
 authors = ["Alex Chaplinsky", "fwdai.org"]
 license = "AGPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Fletch",
   "mainBinaryName": "Fletch",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "identifier": "com.fletch.desktop",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
This branch contains the current `main...HEAD` work, including:
- version bump to 0.7.10 across package.json, Tauri metadata, Cargo.toml, and Cargo.lock
- slash-command discovery and composer integration
- per-project run environment variables
- settings/model refresh updates and related UI cleanup
- supporting tests and small UI fixes