### PR TITLE
feat(composer): support @/# mentions in the new-workspace draft composer

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -674,6 +674,15 @@ pub async fn list_prs(
     gh::pr_list(&checkout, 50).await
 }
 
+/// List the open PRs for a repo by path, for the draft (new-workspace)
+/// composer's "#" mention autocomplete. Unlike `list_prs`, this needs no agent
+/// — a draft has no checkout yet — so it queries the base repo directly.
+/// Capped at 50 to match `list_prs`.
+#[tauri::command]
+pub async fn list_repo_prs(repo_path: String) -> Result<Vec<gh::PrSummary>> {
+    gh::pr_list(&expand_tilde(&repo_path), 50).await
+}
+
 /// Fetch the PR merge gate + per-check detail (spec §6). Best-effort: any
 /// failure (no PR, gh missing, API error) returns `None` and the panel falls
 /// back to `mergeable`-only behavior.
@@ -1203,6 +1212,16 @@ pub async fn list_checkout_tree(
             }
         })
         .collect())
+}
+
+/// List a repo's files by path (tracked + non-ignored untracked), for the
+/// draft (new-workspace) composer's "@" mention autocomplete. Unlike
+/// `list_checkout_tree`, this needs no agent — a draft has no checkout yet — so
+/// it reads the base repo directly and returns plain paths (no diff status,
+/// since there's no fork point to diff against).
+#[tauri::command]
+pub async fn list_repo_tree(repo_path: String) -> Result<Vec<String>> {
+    git::list_files(&expand_tilde(&repo_path)).await
 }
 
 /// Expand a leading `~` (or `~/…`) to the user's home directory. Any other

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1217,6 +1217,8 @@ pub fn run() {
             commands::discover_slash_commands,
             commands::run_claude_command,
             commands::list_prs,
+            commands::list_repo_prs,
+            commands::list_repo_tree,
             commands::read_checkout_file,
             commands::get_file_diff,
             commands::write_checkout_file,

--- a/src/api.ts
+++ b/src/api.ts
@@ -702,6 +702,10 @@ export const api = {
   runClaudeCommand: (agentId: string, args: string[]) =>
     invoke<ClaudeCommandOutput>("run_claude_command", { agentId, args }),
   listPrs: (agentId: string) => invoke<PrSummary[]>("list_prs", { agentId }),
+  // Draft (new-workspace) composer variants, keyed by repo path since a draft
+  // has no agent/checkout yet.
+  listRepoTree: (repoPath: string) => invoke<string[]>("list_repo_tree", { repoPath }),
+  listRepoPrs: (repoPath: string) => invoke<PrSummary[]>("list_repo_prs", { repoPath }),
   readCheckoutFile: (agentId: string, path: string) =>
     invoke<CheckoutFileContents>("read_checkout_file", { agentId, path }),
   getFileDiff: (agentId: string, path: string) =>

--- a/src/components/Workspace/EmptyWorkspace.tsx
+++ b/src/components/Workspace/EmptyWorkspace.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { api } from "@/api";
 import { Composer } from "@/components/Composer";
 import { BranchPicker } from "@/components/Composer/BranchPicker";
 import { ProjectPicker } from "@/components/Composer/ProjectPicker";
@@ -132,6 +133,9 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
                 defaultProvider={draft.provider}
                 projectDir={draft.repoPath}
                 onLocalCommand={(action) => runLocalCommand(action)}
+                mentionSource={() => api.listRepoTree(draft.repoPath)}
+                listDir={api.listDir}
+                listPrs={() => api.listRepoPrs(draft.repoPath)}
                 defaultModel={draft.model}
                 defaultCustomAgentId={draft.customAgentId}
                 onChangeSelection={(provider, model, customAgentId) => {

--- a/src/components/Workspace/EmptyWorkspace.tsx
+++ b/src/components/Workspace/EmptyWorkspace.tsx
@@ -128,6 +128,11 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
               />
             ) : (
               <Composer
+                // Remount when the target repo changes so the @/# mention
+                // sources drop the previous repo's cached files/PRs (they only
+                // refetch on menu-open, not on a repoPath change under a live
+                // composer) — otherwise a wrong-repo file/PR could be inserted.
+                key={draft.repoPath}
                 autoFocus
                 draftKey={draft.id}
                 defaultProvider={draft.provider}


### PR DESCRIPTION
## What & why

The new-workspace (draft) composer already shares the `Composer` component with the chat composer, but `@`-file and `#`-PR autocomplete were disabled there. Chat sources those from **agent-id-keyed** backend commands (`list_checkout_tree`, `list_prs`), and a draft has no agent or checkout yet — so the props were simply omitted. (Slash `/` commands already worked in drafts.)

This wires them up by adding **repo-path-keyed** equivalents.

## Changes

- **`src-tauri/src/commands.rs`** — `list_repo_tree(repo_path)` and `list_repo_prs(repo_path)`, thin wrappers over the existing `git::list_files` / `gh::pr_list` helpers (both already take a bare path).
- **`src-tauri/src/lib.rs`** — register both commands.
- **`src/api.ts`** — `listRepoTree` / `listRepoPrs` bindings.
- **`src/components/Workspace/EmptyWorkspace.tsx`** — pass `mentionSource` (→ `listRepoTree`), `listDir` (→ `api.listDir`), and `listPrs` (→ `listRepoPrs`) to the draft `<Composer>`.

## Result

In a fresh draft, `@` opens repo file search + filesystem-path navigation, `#` lists the repo's open PRs, and `/` continues to work — matching chat. Chat and Workflow mode are untouched.

## Verification

- `npx tsc --noEmit` — passes
- `cargo build` — passes
- `npx vitest run` — 432 passed, 0 failed
- `biome check` on changed files — clean

## Follow-up

A later PR will fold the separate `WorkflowComposer` (a hand-rolled textarea with no autocomplete) onto the shared `Composer` so Workflow mode gets the same slash/`@`/`#` support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)