### PR TITLE
refactor(composer): share one input core across agent + workflow composers

### DIFF
--- a/src/components/Composer/ComposerFrame.tsx
+++ b/src/components/Composer/ComposerFrame.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from "react";
+import { Icon } from "@/components/Icon";
+import { AttachmentList } from "./AttachmentList";
+import { AutocompleteMenu } from "./autocomplete/AutocompleteMenu";
+import type { ComposerInput } from "./useComposerInput";
+
+interface Props {
+  /** The shared input core from [`useComposerInput`]. */
+  input: ComposerInput;
+  placeholder?: string;
+  disabled?: boolean;
+  /** Floor for visible input lines (the box still grows with content). */
+  minRows?: number;
+  /** Optional content pinned above the textarea (e.g. a workflow flow strip). */
+  top?: ReactNode;
+  /** The footer row — pickers/chips + the send button, supplied by the caller. */
+  foot: ReactNode;
+}
+
+/** The shared composer chrome: the `.composer` shell, drop overlay, autocomplete
+ *  menu, staged-attachment list, and the `<textarea>` — wired to a
+ *  [`useComposerInput`] core. Callers supply only the footer (and an optional
+ *  `top` slot), so the agent and workflow composers render an identical input
+ *  with their own controls + submit. */
+export function ComposerFrame({ input, placeholder, disabled, minRows = 1, top, foot }: Props) {
+  return (
+    <div className={`composer${input.isDropTarget ? " is-drop-target" : ""}`}>
+      {input.isDropTarget && (
+        <div className="composer-drop-overlay flex-center text-sm">
+          <Icon name="upload" size={20} />
+          <span>Drop files to attach</span>
+        </div>
+      )}
+      {input.autocomplete.menu && <AutocompleteMenu {...input.autocomplete.menu} />}
+      {top}
+      {input.attachments.length > 0 && (
+        <AttachmentList paths={input.attachments} onRemove={input.removePath} />
+      )}
+      <textarea
+        ref={input.ta}
+        className="composer-input text-base"
+        placeholder={placeholder}
+        value={input.text}
+        rows={minRows}
+        // Floor at `minRows` lines; mirrors .composer-input's line-height (1.55)
+        // and vertical padding (12+8px), so grow() can't shrink it below this.
+        style={minRows > 1 ? { minHeight: `calc(${minRows} * 1.55em + 20px)` } : undefined}
+        disabled={disabled}
+        {...input.textareaHandlers}
+      />
+      <div className="composer-foot flex-center">{foot}</div>
+    </div>
+  );
+}

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -1,4 +1,3 @@
-import { open } from "@tauri-apps/plugin-dialog";
 import { useEffect, useRef, useState } from "react";
 import type { DirListing, PrSummary } from "@/api";
 import { Icon } from "@/components/Icon";
@@ -9,16 +8,10 @@ import { DEFAULT_PROVIDER_ID, isDockerSupported, providerLabel } from "@/data/pr
 import type { LocalCommandAction } from "@/data/slashCommands";
 import type { AgentUsage } from "@/store";
 import { useAppStore } from "@/store";
-import { AttachmentList } from "./AttachmentList";
-import { AutocompleteMenu } from "./autocomplete/AutocompleteMenu";
-import { useCommandSource } from "./autocomplete/sources/commands";
-import { useFileSource } from "./autocomplete/sources/files";
-import { usePrSource } from "./autocomplete/sources/prs";
-import { triggerQueryAt } from "./autocomplete/triggers";
-import { useAutocomplete } from "./autocomplete/useAutocomplete";
+import { ComposerFrame } from "./ComposerFrame";
 import { ModelPicker } from "./ModelPicker";
 import { UsageMeter } from "./UsageMeter";
-import { useFileDrop } from "./useFileDrop";
+import { useComposerInput } from "./useComposerInput";
 
 interface Props {
   /** Initial provider id — defaults to claude. */
@@ -139,7 +132,6 @@ export function Composer({
 }: Props) {
   const features = useAppStore((s) => s.features);
   const modelCatalog = useAppStore((s) => s.modelCatalog);
-  const setComposerDraft = useAppStore((s) => s.setComposerDraft);
   const customAgents = useAppStore((s) => s.customAgents);
   const sandboxEngine = useAppStore((s) => s.sandboxEngine);
 
@@ -147,19 +139,11 @@ export function Composer({
   // When the model is unknown (a new session before the first turn, or one the
   // catalog doesn't list) we keep the picker — better to show a no-op control
   // than to wrongly hide a real one.
-  // Restore any unsent text for this target. Read once at mount via getState
-  // (not a subscription) so persisting on each keystroke doesn't re-render us;
-  // switching targets remounts the Composer, which re-runs this initializer.
-  const [text, setText] = useState(() =>
-    draftKey ? (useAppStore.getState().composerDrafts[draftKey] ?? "") : "",
-  );
   const [provider, setProvider] = useState(defaultProvider);
   const [model, setModel] = useState<string | undefined>(defaultModel);
   const [customAgentId, setCustomAgentId] = useState<string | undefined>(defaultCustomAgentId);
   const activeMeta = lookupModel(modelCatalog, existingSession ? (activeModel ?? model) : model);
   const modelSupportsThinking = activeMeta ? activeMeta.reasoning : true;
-
-  const [attachments, setAttachments] = useState<string[]>([]);
 
   const detail = PROVIDER_DETAIL[provider as keyof typeof PROVIDER_DETAIL];
   const thinkingLevels = detail?.thinkingLevels ?? [];
@@ -194,101 +178,32 @@ export function Composer({
       : undefined;
     setThinkingValue(custom?.effort || resolveThinking(provider));
   }, [provider, customAgentId]);
-  // Caret offset, tracked so triggers can be detected at the cursor (not just
-  // at the start of the text).
-  const [caret, setCaret] = useState(0);
-  const ta = useRef<HTMLTextAreaElement>(null);
 
-  function addPaths(paths: string[]) {
-    setAttachments((cur) => {
-      const next = [...cur];
-      for (const p of paths) if (!next.includes(p)) next.push(p);
-      return next;
-    });
-  }
-
-  const isDropTarget = useFileDrop(addPaths);
-
-  async function browse() {
-    const sel = await open({ multiple: true });
-    if (!sel) return;
-    addPaths(Array.isArray(sel) ? sel : [sel]);
-  }
-
-  // Autocompletions share one menu + keyboard mechanics (useAutocomplete);
-  // each source owns its data and what picking a row does. Triggers are
-  // mutually exclusive at a given caret, so only one menu is ever open.
-  const fileSource = useFileSource({
-    query: triggerQueryAt(text, caret, "@")?.query ?? null,
-    mentionSource,
-    listDir,
-    addPaths,
-  });
-  const prSource = usePrSource({
-    query: triggerQueryAt(text, caret, "#")?.query ?? null,
-    listPrs,
-  });
-  const commandSource = useCommandSource({
-    query: triggerQueryAt(text, caret, "/", true)?.query ?? null,
+  // Shared input core (textarea + `/`·`@`·`#` autocomplete + attachments +
+  // draft/seed). `onEnter` sends via a ref so the callback can reference the
+  // `input` and `send` defined just below (they depend on `input` in turn).
+  const submitRef = useRef<() => void>(() => {});
+  const input = useComposerInput({
     provider,
     projectDir,
     onLocalCommand,
+    mentionSource,
+    listDir,
+    listPrs,
+    draftKey,
+    autoFocus,
+    seed,
+    onSeedConsumed,
+    onEnter: () => submitRef.current(),
   });
-  const autocomplete = useAutocomplete({
-    sources: [commandSource, fileSource, prSource],
-    text,
-    caret,
-    setText,
-    setCaret,
-    focusAt: placeCaret,
-  });
 
-  useEffect(() => {
-    if (autoFocus) ta.current?.focus();
-  }, [autoFocus]);
-
-  // On mount (including the remount a view switch causes) the restored draft
-  // text is in place but the textarea still renders at its single-row height,
-  // since `grow` only runs on edits. Resize once so a multi-line draft is
-  // expanded to fit its content (up to the max height).
-  // biome-ignore lint/correctness/useExhaustiveDependencies: run once on mount
-  useEffect(() => {
-    if (ta.current) grow(ta.current);
-  }, []);
-
-  // Mirror the draft into the store on every edit so it survives the remount
-  // that view switches cause. Sending clears `text`, which clears the entry.
-  useEffect(() => {
-    if (draftKey) setComposerDraft(draftKey, text);
-  }, [draftKey, text, setComposerDraft]);
-
-  // Apply an externally-supplied seed: append to the current draft (with a
-  // blank-line separator), focus, resize, and notify the parent to clear it.
-  useEffect(() => {
-    if (!seed) return;
-    setText((cur) => {
-      const next = cur.trim() ? `${cur}\n\n${seed}` : seed;
-      requestAnimationFrame(() => {
-        const el = ta.current;
-        if (!el) return;
-        el.focus();
-        grow(el);
-        const end = next.length;
-        el.setSelectionRange(end, end);
-        setCaret(end);
-      });
-      return next;
-    });
-    onSeedConsumed?.();
-  }, [seed, onSeedConsumed]);
-
-  function grow(el: HTMLTextAreaElement) {
-    el.style.height = "auto";
-    el.style.height = `${Math.min(el.scrollHeight, 240)}px`;
-  }
+  const hasContent = input.text.trim().length > 0 || input.attachments.length > 0;
+  // Busy + empty → Stop; busy + typed (or idle) → Send. So a mid-turn
+  // follow-up sends with Enter, and an empty composer still stops the turn.
+  const showStop = stopping && !hasContent;
+  const sendDisabled = showStop ? !onStop : disabled || !hasContent || dockerBlocked;
 
   function send() {
-    const trimmed = text.trim();
     // While the agent works, an empty composer's primary action is Stop; once
     // the user types, it becomes Send so the message can be queued/injected
     // mid-turn (the agent keeps running — see store.sendUserMessage).
@@ -296,142 +211,97 @@ export function Composer({
       onStop?.();
       return;
     }
-    if ((!trimmed && attachments.length === 0) || disabled || dockerBlocked) return;
-    onSend({ text: trimmed, provider, model, thinking: thinkingValue, customAgentId, attachments });
-    setText("");
-    setAttachments([]);
-    if (ta.current) ta.current.style.height = "auto";
-  }
-
-  function stop() {
-    if (!showStop) return;
-    onStop?.();
-  }
-
-  function placeCaret(pos: number) {
-    requestAnimationFrame(() => {
-      const el = ta.current;
-      if (!el) return;
-      el.focus();
-      el.setSelectionRange(pos, pos);
-      grow(el);
+    const trimmed = input.text.trim();
+    if ((!trimmed && input.attachments.length === 0) || disabled || dockerBlocked) return;
+    onSend({
+      text: trimmed,
+      provider,
+      model,
+      thinking: thinkingValue,
+      customAgentId,
+      attachments: input.attachments,
     });
+    input.clear();
   }
-
-  const hasContent = text.trim().length > 0 || attachments.length > 0;
-  // Busy + empty → Stop; busy + typed (or idle) → Send. So a mid-turn
-  // follow-up sends with Enter, and an empty composer still stops the turn.
-  const showStop = stopping && !hasContent;
-  const sendDisabled = showStop ? !onStop : disabled || !hasContent || dockerBlocked;
+  submitRef.current = send;
 
   return (
-    <div className={`composer${isDropTarget ? " is-drop-target" : ""}`}>
-      {isDropTarget && (
-        <div className="composer-drop-overlay flex-center text-sm">
-          <Icon name="upload" size={20} />
-          <span>Drop files to attach</span>
-        </div>
-      )}
-      {autocomplete.menu && <AutocompleteMenu {...autocomplete.menu} />}
-      {attachments.length > 0 && (
-        <AttachmentList
-          paths={attachments}
-          onRemove={(p) => setAttachments((cur) => cur.filter((x) => x !== p))}
-        />
-      )}
-      <textarea
-        ref={ta}
-        className="composer-input text-base"
-        placeholder={placeholder || "Message agent · /commands · @ to attach · # for PRs"}
-        value={text}
-        rows={minRows}
-        // Floor at `minRows` lines; mirrors .composer-input's line-height (1.55)
-        // and vertical padding (12+8px), so grow() can't shrink it below this.
-        style={minRows > 1 ? { minHeight: `calc(${minRows} * 1.55em + 20px)` } : undefined}
-        disabled={disabled}
-        onChange={(e) => {
-          setText(e.target.value);
-          setCaret(e.target.selectionStart ?? e.target.value.length);
-          grow(e.target);
-        }}
-        onSelect={(e) => setCaret(e.currentTarget.selectionStart ?? 0)}
-        onKeyDown={(e) => {
-          if (autocomplete.onKeyDown(e)) return;
-          if (e.key === "Enter" && !e.shiftKey) {
-            e.preventDefault();
-            send();
-          }
-        }}
-      />
-      <div className="composer-foot flex-center">
-        <ModelPicker
-          provider={provider}
-          model={model}
-          customAgentId={customAgentId}
-          locked={existingSession}
-          onChange={(nextProvider, nextModel, nextCustomAgentId) => {
-            // Effort follows from the selection via the effect above (a custom
-            // agent's reasoning budget, else the per-provider default).
-            setProvider(nextProvider);
-            setModel(nextModel);
-            setCustomAgentId(nextCustomAgentId);
-            onChangeSelection?.(nextProvider, nextModel, nextCustomAgentId);
-          }}
-        />
-        {features.thinkingBudget &&
-          thinkingLevels.length > 0 &&
-          modelSupportsThinking &&
-          (existingSession && detail?.effortAtSpawn ? (
-            initialThinking && (
-              <Chip tip="Thinking effort — fixed at spawn" disabled>
+    <ComposerFrame
+      input={input}
+      placeholder={placeholder || "Message agent · /commands · @ to attach · # for PRs"}
+      disabled={disabled}
+      minRows={minRows}
+      foot={
+        <>
+          <ModelPicker
+            provider={provider}
+            model={model}
+            customAgentId={customAgentId}
+            locked={existingSession}
+            onChange={(nextProvider, nextModel, nextCustomAgentId) => {
+              // Effort follows from the selection via the effect above (a custom
+              // agent's reasoning budget, else the per-provider default).
+              setProvider(nextProvider);
+              setModel(nextModel);
+              setCustomAgentId(nextCustomAgentId);
+              onChangeSelection?.(nextProvider, nextModel, nextCustomAgentId);
+            }}
+          />
+          {features.thinkingBudget &&
+            thinkingLevels.length > 0 &&
+            modelSupportsThinking &&
+            (existingSession && detail?.effortAtSpawn ? (
+              initialThinking && (
+                <Chip tip="Thinking effort — fixed at spawn" disabled>
+                  <Icon name="sparkle" size={11} />
+                  <span>
+                    {thinkingLevels.find((l) => l.value === initialThinking)?.label ??
+                      initialThinking}
+                  </span>
+                </Chip>
+              )
+            ) : (
+              <Chip
+                tip="Thinking budget"
+                onClick={() => {
+                  const idx = thinkingLevels.findIndex((l) => l.value === thinkingValue);
+                  const next = thinkingLevels[(idx + 1) % thinkingLevels.length];
+                  setThinkingValue(next.value);
+                  localStorage.setItem(`thinkingBudget.${provider}`, next.value);
+                }}
+              >
                 <Icon name="sparkle" size={11} />
-                <span>
-                  {thinkingLevels.find((l) => l.value === initialThinking)?.label ??
-                    initialThinking}
-                </span>
+                <span>{thinkingLevels.find((l) => l.value === thinkingValue)?.label ?? ""}</span>
               </Chip>
-            )
-          ) : (
-            <Chip
-              tip="Thinking budget"
-              onClick={() => {
-                const idx = thinkingLevels.findIndex((l) => l.value === thinkingValue);
-                const next = thinkingLevels[(idx + 1) % thinkingLevels.length];
-                setThinkingValue(next.value);
-                localStorage.setItem(`thinkingBudget.${provider}`, next.value);
-              }}
-            >
-              <Icon name="sparkle" size={11} />
-              <span>{thinkingLevels.find((l) => l.value === thinkingValue)?.label ?? ""}</span>
-            </Chip>
-          ))}
-        <Chip tip="Attach" onClick={browse}>
-          <Icon name="attach" size={11} />
-        </Chip>
-        <span style={{ flex: 1 }} />
-        {features.tokenUsage && usage && usage.contextTokens > 0 && <UsageMeter usage={usage} />}
-        {/* A disabled <button> swallows hover in the WebView, so the reason
-         *  rides a wrapper span that stays hover-capable (same pattern as the
-         *  ModelPicker's disabled rows). */}
-        <span
-          className={dockerBlocked ? "tip" : undefined}
-          data-tip={
-            dockerBlocked
-              ? `${providerLabel(provider)} isn't available in Docker sandboxes yet — switch to Claude to send`
-              : undefined
-          }
-        >
-          <button
-            type="button"
-            className={`send flex-center ${showStop ? "is-stop" : ""}`}
-            disabled={sendDisabled}
-            onClick={showStop ? stop : send}
-            aria-label={showStop ? "Stop" : "Send"}
+            ))}
+          <Chip tip="Attach" onClick={input.browse}>
+            <Icon name="attach" size={11} />
+          </Chip>
+          <span style={{ flex: 1 }} />
+          {features.tokenUsage && usage && usage.contextTokens > 0 && <UsageMeter usage={usage} />}
+          {/* A disabled <button> swallows hover in the WebView, so the reason
+           *  rides a wrapper span that stays hover-capable (same pattern as the
+           *  ModelPicker's disabled rows). */}
+          <span
+            className={dockerBlocked ? "tip" : undefined}
+            data-tip={
+              dockerBlocked
+                ? `${providerLabel(provider)} isn't available in Docker sandboxes yet — switch to Claude to send`
+                : undefined
+            }
           >
-            <Icon name={showStop ? "stop" : "arrowUp"} size={13} />
-          </button>
-        </span>
-      </div>
-    </div>
+            <button
+              type="button"
+              className={`send flex-center ${showStop ? "is-stop" : ""}`}
+              disabled={sendDisabled}
+              onClick={showStop ? () => onStop?.() : send}
+              aria-label={showStop ? "Stop" : "Send"}
+            >
+              <Icon name={showStop ? "stop" : "arrowUp"} size={13} />
+            </button>
+          </span>
+        </>
+      }
+    />
   );
 }

--- a/src/components/Composer/useComposerInput.ts
+++ b/src/components/Composer/useComposerInput.ts
@@ -1,0 +1,200 @@
+import { open } from "@tauri-apps/plugin-dialog";
+import { useEffect, useRef, useState } from "react";
+import type { DirListing, PrSummary } from "@/api";
+import type { LocalCommandAction } from "@/data/slashCommands";
+import { useAppStore } from "@/store";
+import { useCommandSource } from "./autocomplete/sources/commands";
+import { useFileSource } from "./autocomplete/sources/files";
+import { usePrSource } from "./autocomplete/sources/prs";
+import { triggerQueryAt } from "./autocomplete/triggers";
+import { useAutocomplete } from "./autocomplete/useAutocomplete";
+import { useFileDrop } from "./useFileDrop";
+
+/** Max grown height of the input, in px, before it scrolls internally. */
+const MAX_HEIGHT = 240;
+
+export interface ComposerInputConfig {
+  /** Provider id driving the `/` slash-command source (claude has commands;
+   *  other providers use an empty adapter). */
+  provider: string;
+  /** Project root for discovering project-level slash commands. */
+  projectDir?: string;
+  onLocalCommand?: (action: LocalCommandAction) => void;
+  /** Candidate file paths for the `@` mention search. Omit to disable `@`. */
+  mentionSource?: () => Promise<string[]>;
+  /** Lists a directory so `@~/…` completes real filesystem paths. */
+  listDir?: (path: string) => Promise<DirListing>;
+  /** Lists the repo's open PRs for the `#` mention. Omit to disable `#`. */
+  listPrs?: () => Promise<PrSummary[]>;
+  /** Persists unsent text across the remounts a view switch causes. */
+  draftKey?: string;
+  autoFocus?: boolean;
+  /** Text injected from elsewhere; appended to the draft, then consumed. */
+  seed?: string;
+  onSeedConsumed?: () => void;
+  /** Fired on Enter without Shift, after the autocomplete menu declines it. */
+  onEnter: () => void;
+}
+
+/** The reusable composer input core: the textarea's text/caret/attachment
+ *  state, the shared `/`·`@`·`#` autocomplete, drag-drop + browse attach,
+ *  draft persistence, and seed injection. Both the agent [`Composer`] and the
+ *  workflow composer build their own footer + submit on top of this, so the
+ *  input behaves identically everywhere. */
+export function useComposerInput(cfg: ComposerInputConfig) {
+  const { draftKey, autoFocus, seed, onSeedConsumed, onEnter } = cfg;
+  const setComposerDraft = useAppStore((s) => s.setComposerDraft);
+
+  // Read the restored draft once at mount via getState (not a subscription) so
+  // persisting on each keystroke doesn't re-render; a view switch remounts us
+  // and re-runs this initializer.
+  const [text, setText] = useState(() =>
+    draftKey ? (useAppStore.getState().composerDrafts[draftKey] ?? "") : "",
+  );
+  // Caret offset, tracked so triggers can be detected at the cursor.
+  const [caret, setCaret] = useState(0);
+  const [attachments, setAttachments] = useState<string[]>([]);
+  const ta = useRef<HTMLTextAreaElement>(null);
+
+  function grow(el: HTMLTextAreaElement) {
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, MAX_HEIGHT)}px`;
+  }
+
+  function placeCaret(pos: number) {
+    requestAnimationFrame(() => {
+      const el = ta.current;
+      if (!el) return;
+      el.focus();
+      el.setSelectionRange(pos, pos);
+      grow(el);
+    });
+  }
+
+  function addPaths(paths: string[]) {
+    setAttachments((cur) => {
+      const next = [...cur];
+      for (const p of paths) if (!next.includes(p)) next.push(p);
+      return next;
+    });
+  }
+
+  function removePath(path: string) {
+    setAttachments((cur) => cur.filter((x) => x !== path));
+  }
+
+  const isDropTarget = useFileDrop(addPaths);
+
+  async function browse() {
+    const sel = await open({ multiple: true });
+    if (!sel) return;
+    addPaths(Array.isArray(sel) ? sel : [sel]);
+  }
+
+  // Autocompletions share one menu + keyboard mechanics (useAutocomplete);
+  // each source owns its data and what picking a row does. Triggers are
+  // mutually exclusive at a given caret, so only one menu is ever open.
+  const fileSource = useFileSource({
+    query: triggerQueryAt(text, caret, "@")?.query ?? null,
+    mentionSource: cfg.mentionSource,
+    listDir: cfg.listDir,
+    addPaths,
+  });
+  const prSource = usePrSource({
+    query: triggerQueryAt(text, caret, "#")?.query ?? null,
+    listPrs: cfg.listPrs,
+  });
+  const commandSource = useCommandSource({
+    query: triggerQueryAt(text, caret, "/", true)?.query ?? null,
+    provider: cfg.provider,
+    projectDir: cfg.projectDir,
+    onLocalCommand: cfg.onLocalCommand,
+  });
+  const autocomplete = useAutocomplete({
+    sources: [commandSource, fileSource, prSource],
+    text,
+    caret,
+    setText,
+    setCaret,
+    focusAt: placeCaret,
+  });
+
+  useEffect(() => {
+    if (autoFocus) ta.current?.focus();
+  }, [autoFocus]);
+
+  // On mount (including the remount a view switch causes) a restored multi-line
+  // draft renders at single-row height until grow() runs on an edit; resize once
+  // so it fits its content.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: run once on mount
+  useEffect(() => {
+    if (ta.current) grow(ta.current);
+  }, []);
+
+  // Mirror the draft into the store on every edit so it survives the remount a
+  // view switch causes. Clearing `text` on send clears the entry.
+  useEffect(() => {
+    if (draftKey) setComposerDraft(draftKey, text);
+  }, [draftKey, text, setComposerDraft]);
+
+  // Apply an externally-supplied seed: append to the current draft (blank-line
+  // separated), focus, resize, and notify the parent to clear it.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: runs only when a new seed arrives, not on grow identity
+  useEffect(() => {
+    if (!seed) return;
+    setText((cur) => {
+      const next = cur.trim() ? `${cur}\n\n${seed}` : seed;
+      requestAnimationFrame(() => {
+        const el = ta.current;
+        if (!el) return;
+        el.focus();
+        grow(el);
+        const end = next.length;
+        el.setSelectionRange(end, end);
+        setCaret(end);
+      });
+      return next;
+    });
+    onSeedConsumed?.();
+  }, [seed, onSeedConsumed]);
+
+  /** Reset after a successful send/launch: clear text + attachments and shrink. */
+  function clear() {
+    setText("");
+    setAttachments([]);
+    if (ta.current) ta.current.style.height = "auto";
+  }
+
+  return {
+    text,
+    setText,
+    caret,
+    attachments,
+    addPaths,
+    removePath,
+    ta,
+    autocomplete,
+    isDropTarget,
+    browse,
+    clear,
+    /** Spread onto the `<textarea>` — Enter-to-submit defers to the menu first. */
+    textareaHandlers: {
+      onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        setText(e.target.value);
+        setCaret(e.target.selectionStart ?? e.target.value.length);
+        grow(e.target);
+      },
+      onSelect: (e: React.SyntheticEvent<HTMLTextAreaElement>) =>
+        setCaret(e.currentTarget.selectionStart ?? 0),
+      onKeyDown: (e: React.KeyboardEvent) => {
+        if (autocomplete.onKeyDown(e)) return;
+        if (e.key === "Enter" && !e.shiftKey) {
+          e.preventDefault();
+          onEnter();
+        }
+      },
+    },
+  };
+}
+
+export type ComposerInput = ReturnType<typeof useComposerInput>;

--- a/src/workflows/run/WorkflowComposer.tsx
+++ b/src/workflows/run/WorkflowComposer.tsx
@@ -1,16 +1,22 @@
 // run/WorkflowComposer.tsx — the "Workflow" composer block. It renders ONLY the
 // prompt box (the host's new-agent page provides the identity, headings, and
 // project/branch pickers around it, identical to the agent screen). It reuses
-// the agent composer's shell classes (.composer / .composer-input /
-// .composer-foot / .model-chip / .send) so the two look the same.
+// the agent composer's shared input core (ComposerFrame + useComposerInput), so
+// slash commands, @-file mentions, and #-PR mentions behave identically here;
+// only the footer (a workflow picker instead of a model picker) and the submit
+// (wf_launch instead of a chat send) differ.
 //
 // Launch goes through the v1 scheduler: `wf_launch` takes the definition's spec
-// snapshot and returns the run id, which the monitor (RunView) then observes.
+// snapshot (plus any @-staged attachments) and returns the run id, which the
+// monitor (RunView) then observes.
 
 import { type CSSProperties, Fragment, useRef, useState } from "react";
 import { api } from "../../api";
+import { ComposerFrame } from "../../components/Composer/ComposerFrame";
+import { useComposerInput } from "../../components/Composer/useComposerInput";
 import { Icon } from "../../components/Icon";
 import { Chip } from "../../components/ui/Chip";
+import { DEFAULT_PROVIDER_ID } from "../../data/providers";
 import { useAppStore } from "../../store";
 import { AgentAvatar } from "../builder/AgentAvatar";
 import { resolveAlias } from "../shared";
@@ -48,36 +54,50 @@ export function WorkflowComposer({ repoPath, baseBranch }: ComposerContext) {
 
   const { definitions, loading } = useDefinitions();
   const [defId, setDefId] = useState("");
-  const [task, setTask] = useState("");
   const [busy, setBusy] = useState(false);
-  const ta = useRef<HTMLTextAreaElement>(null);
 
   // Default to the first definition once they load.
   const def = definitions.find((d) => d.id === defId) ?? definitions[0];
   const steps = flattenSteps(def?.spec ?? null);
-  const canLaunch = !!def && !!task.trim() && !busy;
-
-  const grow = (el: HTMLTextAreaElement) => {
-    el.style.height = "auto";
-    el.style.height = `${Math.min(el.scrollHeight, 240)}px`;
-  };
 
   const resolve = (alias: string) =>
     resolveAlias(def?.spec.agents, alias, customAgents, modelsByAgent);
 
+  // Slash commands are provider-specific; a workflow has many agents, so drive
+  // the `/` source off the first step's resolved provider (fallback: claude).
+  const slashProvider =
+    (steps[0] && resolve(steps[0].agentAlias)?.providerId) || DEFAULT_PROVIDER_ID;
+
+  // Fire the launch via a ref so `onEnter` can reference `launch` (defined below,
+  // since it reads the input's text/attachments).
+  const submitRef = useRef<() => void>(() => {});
+  const input = useComposerInput({
+    provider: slashProvider,
+    // Repo-path-keyed mention sources (no agent/checkout exists pre-launch).
+    projectDir: repoPath,
+    mentionSource: () => api.listRepoTree(repoPath),
+    listDir: api.listDir,
+    listPrs: () => api.listRepoPrs(repoPath),
+    autoFocus: true,
+    onEnter: () => submitRef.current(),
+  });
+
+  const canLaunch = !!def && !!input.text.trim() && !busy;
+
   const launch = async () => {
-    if (!def || !task.trim() || busy) return;
+    if (!def || !input.text.trim() || busy) return;
     setBusy(true);
     try {
       // project_id is resolved authoritatively from repo_path by the backend
       // (wf_launch), so the launcher doesn't guess it from the workspace snapshot.
       const runId = await api.wfLaunch(
         def.spec,
-        task.trim(),
+        input.text.trim(),
         "",
         repoPath,
         def.id,
         baseBranch || undefined,
+        input.attachments,
       );
       selectRun(runId);
     } catch (e) {
@@ -85,6 +105,7 @@ export function WorkflowComposer({ repoPath, baseBranch }: ComposerContext) {
       setBusy(false);
     }
   };
+  submitRef.current = () => void launch();
 
   if (loading) {
     return (
@@ -103,68 +124,56 @@ export function WorkflowComposer({ repoPath, baseBranch }: ComposerContext) {
   }
 
   return (
-    <div className="composer">
-      {/* The selected flow's step chain, built into the top of the prompt box so
-          it reads as "this task launches this flow" — not a detached strip. */}
-      {def && (
-        <div className="cmp-flow-strip">
-          <span className="cf-tag">
-            <Icon name="combine" size={11} /> {def.name}
-          </span>
-          {steps.map((s, i) => {
-            const a = resolve(s.agentAlias);
-            return (
-              <Fragment key={s.id}>
-                {i > 0 && <Icon name="arrowR" size={11} className="cf-arr" />}
-                {a ? (
-                  <AgentAvatar
-                    custom={a.custom}
-                    slug={a.providerId}
-                    short={a.short}
-                    hue={a.hue}
-                    size={20}
-                  />
-                ) : (
-                  <span className="cf-q">?</span>
-                )}
-              </Fragment>
-            );
-          })}
-          <span className="cf-note">each step runs its own agent</span>
-        </div>
-      )}
-      <textarea
-        ref={ta}
-        className="composer-input"
-        rows={1}
-        autoFocus
-        placeholder="Describe the task for the workflow. ↵ to launch."
-        value={task}
-        onChange={(e) => {
-          setTask(e.target.value);
-          grow(e.target);
-        }}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" && !e.shiftKey) {
-            e.preventDefault();
-            void launch();
-          }
-        }}
-      />
-      <div className="composer-foot">
-        <WorkflowSelect definitions={definitions} selected={def} onPick={setDefId} />
-        <span style={{ flex: 1 }} />
-        <button
-          type="button"
-          className="send"
-          disabled={!canLaunch}
-          onClick={() => void launch()}
-          aria-label="Launch run"
-        >
-          <Icon name={busy ? "refresh" : "arrowUp"} size={13} />
-        </button>
-      </div>
-    </div>
+    <ComposerFrame
+      input={input}
+      placeholder="Describe the task for the workflow. · /commands · @ to attach · # for PRs"
+      top={
+        // The selected flow's step chain, built into the top of the prompt box so
+        // it reads as "this task launches this flow" — not a detached strip.
+        def && (
+          <div className="cmp-flow-strip">
+            <span className="cf-tag">
+              <Icon name="combine" size={11} /> {def.name}
+            </span>
+            {steps.map((s, i) => {
+              const a = resolve(s.agentAlias);
+              return (
+                <Fragment key={s.id}>
+                  {i > 0 && <Icon name="arrowR" size={11} className="cf-arr" />}
+                  {a ? (
+                    <AgentAvatar
+                      custom={a.custom}
+                      slug={a.providerId}
+                      short={a.short}
+                      hue={a.hue}
+                      size={20}
+                    />
+                  ) : (
+                    <span className="cf-q">?</span>
+                  )}
+                </Fragment>
+              );
+            })}
+            <span className="cf-note">each step runs its own agent</span>
+          </div>
+        )
+      }
+      foot={
+        <>
+          <WorkflowSelect definitions={definitions} selected={def} onPick={setDefId} />
+          <span style={{ flex: 1 }} />
+          <button
+            type="button"
+            className="send"
+            disabled={!canLaunch}
+            onClick={() => void launch()}
+            aria-label="Launch run"
+          >
+            <Icon name={busy ? "refresh" : "arrowUp"} size={13} />
+          </button>
+        </>
+      }
+    />
   );
 }
 


### PR DESCRIPTION
## What & why

The chat/draft **agent** composer and the **workflow** composer were separate components — the workflow prompt box was a hand-rolled `<textarea>` with no slash commands or mentions. This is **PR B2**: it extracts the reusable input core so both render the same textarea + `/`·`@`·`#` autocomplete, each supplying only its own footer and submit. WorkflowComposer gains full parity.

## Changes

- **`useComposerInput.ts`** (new) — reusable input core: text/caret/attachment state, the shared command/file/PR autocomplete, drag-drop + browse attach, draft persistence, seed injection, and the textarea handlers (Enter-to-submit deferring to the menu). No provider/model coupling.
- **`ComposerFrame.tsx`** (new) — the `.composer` shell (drop overlay, autocomplete menu, attachment list, textarea) with a `top` slot and a `foot` slot.
- **`Composer/index.tsx`** — refactored onto hook + frame; same `Props`, same behavior. **Chat and the new-workspace draft composer are unchanged.**
- **`WorkflowComposer.tsx`** — rebuilt on the shared core: it now supports slash commands + `@`/`#` mentions. Mentions source from `repoPath` (`listRepoTree`/`listRepoPrs`/`listDir`); the `/` provider resolves from the first step's agent (fallback `claude`); staged `@` attachments flow into `wf_launch`'s attachment channel.

## Verification

- `tsc --noEmit` ✓
- `biome check` (changed files) — clean ✓
- `vitest run` — 432 passed ✓
- `cargo check` (merged backend) ✓

## ⚠️ Stacked PR

This branch **merges** the two prerequisite branches it depends on, so this PR's diff against `main` currently includes their changes too. Merge these first, then this diff shrinks to just the composer refactor:

1. `feat/draft-composer-mentions` — repo-path mention APIs (`listRepoTree`/`listRepoPrs`) the workflow `@`/`#` sources need.
2. `feat/workflow-attachments` — the `wf_launch` attachment channel the workflow `@` attachments feed.

## Minor behavior note

The workflow composer's autofocus now runs via the hook's mount effect rather than a DOM attribute — identical in practice (workflow definitions are normally already loaded when the box mounts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)