### PR TITLE
Add project deletion controls

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -17,7 +17,8 @@ use crate::new_project;
 use crate::run_session::RunStateSnapshot;
 use crate::supervisor::{SpawnRequest, Supervisor};
 use crate::workspace::{
-    repo_checkout_path, AgentRecord, AgentView, DiffStats, TrackedRepo, Workspace,
+    repo_checkout_path, AgentRecord, AgentView, DiffStats, ProjectDeleteResult, TrackedRepo,
+    Workspace,
 };
 
 #[tauri::command]
@@ -187,9 +188,14 @@ pub fn rename_project(
 #[tauri::command]
 pub async fn delete_project(
     supervisor: State<'_, Arc<Supervisor>>,
+    workflows: State<'_, Arc<crate::workflow::scheduler::WorkflowService>>,
     project_id: String,
-) -> Result<Workspace> {
-    supervisor.inner().clone().delete_project(&project_id).await
+) -> Result<ProjectDeleteResult> {
+    supervisor
+        .inner()
+        .clone()
+        .delete_project(workflows.inner(), &project_id)
+        .await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -182,6 +182,24 @@ pub fn rename_project(
     supervisor.rename_project(&project_id, &name)
 }
 
+/// Delete a project and all of its workspaces, including non-archived ones.
+/// The supervisor refuses while any project agent is actively running.
+#[tauri::command]
+pub async fn delete_project(
+    supervisor: State<'_, Arc<Supervisor>>,
+    project_id: String,
+) -> Result<Workspace> {
+    supervisor.inner().clone().delete_project(&project_id).await
+}
+
+#[tauri::command]
+pub fn project_has_running_agents(
+    supervisor: State<'_, Arc<Supervisor>>,
+    project_id: String,
+) -> bool {
+    supervisor.project_has_running_agents(&project_id)
+}
+
 /// Repoint a pinned repo at a folder the user has moved on disk. Validates the
 /// destination is a git repo; existing agents' worktrees are not relinked.
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1156,6 +1156,8 @@ pub fn run() {
             commands::add_workspace_repo,
             commands::remove_workspace_repo,
             commands::rename_project,
+            commands::delete_project,
+            commands::project_has_running_agents,
             commands::relocate_repo,
             commands::gh_status,
             commands::gh_repo_list,

--- a/src-tauri/src/supervisor/disposition.rs
+++ b/src-tauri/src/supervisor/disposition.rs
@@ -9,8 +9,8 @@ use crate::error::{Error, Result};
 use crate::git;
 use crate::sandbox::provision::{self, CheckoutSpec, WorkspaceMode};
 use crate::workspace::{
-    agent_parent_dir, repo_checkout_path, AgentStatus, ArchiveMetadata, ArchivedRepoSnapshot,
-    DiffStats, TrackedRepo,
+    agent_parent_dir, repo_checkout_path, AgentRecord, AgentStatus, ArchiveMetadata,
+    ArchivedRepoSnapshot, DiffStats, TrackedRepo,
 };
 
 use super::events::emit_workspace_changed;
@@ -95,6 +95,7 @@ impl Supervisor {
     /// metadata, transition to Spawning so the supervisor's start path
     /// attaches to the existing claude session.
     pub async fn restore_agent(self: Arc<Self>, app: AppHandle, agent_id: &str) -> Result<()> {
+        let _lifecycle_guard = self.agent_lifecycle.lock().await;
         let record = self.workspace.agent(agent_id)?;
         let archive = record
             .archive
@@ -239,6 +240,24 @@ impl Supervisor {
 
         self.workspace.remove_agent(agent_id)?;
         Ok(())
+    }
+
+    /// Detach every idle project agent without deleting its durable row. The
+    /// project FK cascade is the single DB commit point; separating runtime
+    /// detachment from row deletion prevents per-agent partial commits.
+    pub(super) fn detach_project_agents(&self, agents: &[AgentRecord]) {
+        for agent in agents {
+            self.detach_runtime(&agent.id);
+        }
+    }
+
+    /// Best-effort physical cleanup after the project row has committed. At
+    /// this point no user-visible project can be left half-deleted; failures
+    /// are logged by the shared checkout teardown helper as orphan cleanup.
+    pub(super) async fn teardown_project_checkouts(&self, agents: &[AgentRecord]) {
+        for agent in agents {
+            teardown_agent_checkouts(&agent.id, &agent.repos, "project delete").await;
+        }
     }
 
     /// Detach an agent's live runtime: shut down its process and drop its

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -1010,6 +1010,11 @@ impl Supervisor {
     /// (see `transition_active`). This is what keeps the "swap binary → keep
     /// going" flow working for an agent that's busy at swap time.
     pub(super) async fn respawn_agent_for_bin(self: &Arc<Self>, app: &AppHandle, agent_id: &str) {
+        // Keep the complete idle -> teardown -> Spawning -> restarted
+        // transition mutually exclusive with project deletion. The deletion
+        // marker is installed before that path waits for this lifecycle lock,
+        // so a respawn that won the lock but lost the marker race also stops.
+        let _lifecycle_guard = self.agent_lifecycle.lock().await;
         let record = match self.workspace.agent(agent_id) {
             Ok(r) => r,
             Err(_) => {
@@ -1017,6 +1022,10 @@ impl Supervisor {
                 return;
             }
         };
+        if self.deleting_projects.lock().contains(&record.project_id) {
+            self.respawn_pending.lock().remove(agent_id);
+            return;
+        }
         // Atomic idle-check + remove. `busy` distinguishes "left running" from
         // "already gone" when no agent is taken.
         let mut busy = false;

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -204,6 +204,7 @@ impl Supervisor {
         app: AppHandle,
         req: SpawnRequest,
     ) -> Result<AgentRecord> {
+        let _lifecycle_guard = self.agent_lifecycle.lock().await;
         let SpawnRequest {
             view,
             repo_path,
@@ -867,6 +868,7 @@ impl Supervisor {
     }
 
     pub async fn resume_agent(self: Arc<Self>, app: AppHandle, agent_id: &str) -> Result<()> {
+        let _lifecycle_guard = self.agent_lifecycle.lock().await;
         let record = self.workspace.agent(agent_id)?;
         if self.agents.lock().contains_key(agent_id) {
             return Ok(());
@@ -892,6 +894,11 @@ impl Supervisor {
         agent_id: &str,
         bytes: &[u8],
     ) -> Result<()> {
+        let project_id = self.workspace.agent(agent_id)?.project_id;
+        let deletion_guard = self.deleting_projects.lock();
+        if deletion_guard.contains(&project_id) {
+            return Err(Error::Other("project deletion is in progress".into()));
+        }
         self.live_agent(agent_id)?.write_pty(bytes)?;
         let submitted = self
             .native_inputs
@@ -903,6 +910,7 @@ impl Supervisor {
             mark_user_turn_started(&self, app, agent_id, None);
             on_first_user_message(self.clone(), app.clone(), agent_id.to_string(), submitted);
         }
+        drop(deletion_guard);
         Ok(())
     }
 
@@ -916,6 +924,7 @@ impl Supervisor {
         agent_id: &str,
         new_view: AgentView,
     ) -> Result<()> {
+        let _lifecycle_guard = self.agent_lifecycle.lock().await;
         let record = self.workspace.agent(agent_id)?;
         if record.view == new_view {
             return Ok(());

--- a/src-tauri/src/supervisor/messaging.rs
+++ b/src-tauri/src/supervisor/messaging.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use tauri::{AppHandle, Manager};
 
 use crate::agent::injection_mode;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::managed_session::ToolUseBehavior;
 use crate::message_queue::{decide_delivery, Delivery, PendingMsg};
 use crate::workspace::AgentStatus;
@@ -284,6 +284,11 @@ fn deliver_as_turn(
     agent_id: &str,
     msg: &PendingMsg,
 ) -> Result<()> {
+    let project_id = sup.workspace.agent(agent_id)?.project_id;
+    let deletion_guard = sup.deleting_projects.lock();
+    if deletion_guard.contains(&project_id) {
+        return Err(Error::Other("project deletion is in progress".into()));
+    }
     sup.deliver_user_message(
         agent_id,
         &msg.turn_id,
@@ -298,6 +303,7 @@ fn deliver_as_turn(
         agent_id.to_string(),
         msg.text.clone(),
     );
+    drop(deletion_guard);
     Ok(())
 }
 

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -29,7 +29,9 @@ use crate::message_queue::MessageQueue;
 use crate::native_input::NativeInputTracker;
 use crate::pty_session::PtySession;
 use crate::run_session::RunSession;
-use crate::workspace::{AgentRecord, AgentStatus, ClosedTurn, Workspace, WorkspaceManager};
+use crate::workspace::{
+    AgentRecord, AgentStatus, ClosedTurn, ProjectDeleteResult, Workspace, WorkspaceManager,
+};
 
 use events::emit_status;
 use messaging::{drain_message_queue, drain_pending_bin_respawn};
@@ -73,6 +75,12 @@ pub struct Supervisor {
     /// Per-agent run-panel processes (dev server + setup). Reused
     /// across start/stop cycles so the log buffer survives.
     pub runs: Mutex<HashMap<String, Arc<RunSession>>>,
+    /// Serializes agent creation/resume/view-switch/restore against project
+    /// deletion. A status snapshot alone cannot close the startup race.
+    pub(super) agent_lifecycle: tokio::sync::Mutex<()>,
+    /// Project ids currently being deleted. Fresh turns check and transition
+    /// to Running while holding this lock, closing the idle-to-running race.
+    pub(super) deleting_projects: Mutex<HashSet<String>>,
     /// Agent ids whose binary-path change couldn't be applied immediately
     /// because the agent was mid-turn. Drained at the next turn-end Idle
     /// transition (see `transition_active`), which respawns them onto the
@@ -116,6 +124,8 @@ impl Supervisor {
             native_inputs: Mutex::new(HashMap::new()),
             shells: Mutex::new(HashMap::new()),
             runs: Mutex::new(HashMap::new()),
+            agent_lifecycle: tokio::sync::Mutex::new(()),
+            deleting_projects: Mutex::new(HashSet::new()),
             respawn_pending: Mutex::new(HashSet::new()),
             message_queue: Mutex::new(MessageQueue::new()),
             interrupted: Mutex::new(HashSet::new()),
@@ -431,18 +441,66 @@ impl Supervisor {
             })
     }
 
-    pub async fn delete_project(self: Arc<Self>, project_id: &str) -> Result<Workspace> {
+    pub async fn delete_project(
+        self: Arc<Self>,
+        workflows: &crate::workflow::scheduler::WorkflowService,
+        project_id: &str,
+    ) -> Result<ProjectDeleteResult> {
+        if !self.deleting_projects.lock().insert(project_id.to_string()) {
+            return Err(Error::Other(
+                "project deletion is already in progress".into(),
+            ));
+        }
+        let result = self
+            .clone()
+            .delete_project_inner(workflows, project_id)
+            .await;
+        self.deleting_projects.lock().remove(project_id);
+        result
+    }
+
+    async fn delete_project_inner(
+        self: Arc<Self>,
+        workflows: &crate::workflow::scheduler::WorkflowService,
+        project_id: &str,
+    ) -> Result<ProjectDeleteResult> {
+        // Lock workflow creation/deletion first, then agent startup. Workflow
+        // launch releases its lock before its background driver can spawn, and
+        // the persisted pending run makes this preflight reject the deletion.
+        let _workflow_guard = workflows.lifecycle.lock().await;
+        let _agent_guard = self.agent_lifecycle.lock().await;
         let agents = self.workspace.agents_for_project(project_id);
-        if self.project_has_running_agents(project_id) {
+        if agents.iter().any(|agent| {
+            matches!(
+                self.effective_status(&agent.id, agent),
+                AgentStatus::Spawning | AgentStatus::Running
+            )
+        }) {
             return Err(Error::Other(
                 "cannot delete a project while one of its agents is running".into(),
             ));
         }
 
-        for agent in agents {
-            self.clone().discard_agent(&agent.id).await?;
-        }
-        self.workspace.delete_project(project_id)
+        let deleted_agent_ids = agents.iter().map(|agent| agent.id.clone()).collect();
+        let deleted_run_ids = workflows
+            .delete_project_runs_locked(&self, project_id)
+            .await?;
+
+        // Workflow deletion removes its owned agents through the normal path.
+        // Snapshot the remaining project agents, detach their idle runtimes,
+        // then commit every remaining row deletion in one FK-cascaded project
+        // transaction. If the DB commit fails, records and checkouts remain;
+        // detached idle agents can resume lazily.
+        let remaining = self.workspace.agents_for_project(project_id);
+        self.detach_project_agents(&remaining);
+        self.workspace.delete_project(project_id)?;
+        self.teardown_project_checkouts(&remaining).await;
+
+        Ok(ProjectDeleteResult {
+            workspace: self.current_workspace().expect("workspace initialized"),
+            deleted_agent_ids,
+            deleted_run_ids,
+        })
     }
 
     pub fn relocate_repo(&self, old_path: PathBuf, new_path: PathBuf) -> Result<Workspace> {
@@ -689,8 +747,8 @@ mod tests {
         assert_eq!(sup.live_status("yosemite"), Some(AgentStatus::Running));
     }
 
-    #[tokio::test]
-    async fn delete_project_rejects_running_agent() {
+    #[test]
+    fn project_running_check_detects_running_agent() {
         let sup = Arc::new(test_supervisor());
         let dir = tempfile::tempdir().unwrap();
         let repo = dir.path().join("repo");
@@ -723,10 +781,7 @@ mod tests {
             .lock()
             .insert(record.id.clone(), AgentStatus::Running);
 
-        let err = sup.clone().delete_project(&project_id).await.unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("while one of its agents is running"));
+        assert!(sup.project_has_running_agents(&project_id));
         assert_eq!(sup.current_workspace().unwrap().projects.len(), 1);
         assert_eq!(sup.current_workspace().unwrap().agents.len(), 1);
     }

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -417,6 +417,34 @@ impl Supervisor {
         self.workspace.rename_project(project_id, name)
     }
 
+    /// Delete a project and all of its agents. Busy agents are rejected before
+    /// any teardown begins; idle/stopped/archived agents are safe to discard.
+    pub fn project_has_running_agents(&self, project_id: &str) -> bool {
+        self.workspace
+            .agents_for_project(project_id)
+            .iter()
+            .any(|agent| {
+                matches!(
+                    self.effective_status(&agent.id, agent),
+                    AgentStatus::Spawning | AgentStatus::Running
+                )
+            })
+    }
+
+    pub async fn delete_project(self: Arc<Self>, project_id: &str) -> Result<Workspace> {
+        let agents = self.workspace.agents_for_project(project_id);
+        if self.project_has_running_agents(project_id) {
+            return Err(Error::Other(
+                "cannot delete a project while one of its agents is running".into(),
+            ));
+        }
+
+        for agent in agents {
+            self.clone().discard_agent(&agent.id).await?;
+        }
+        self.workspace.delete_project(project_id)
+    }
+
     pub fn relocate_repo(&self, old_path: PathBuf, new_path: PathBuf) -> Result<Workspace> {
         self.workspace.relocate_repo(&old_path, &new_path)
     }
@@ -659,5 +687,47 @@ mod tests {
             .lock()
             .insert("yosemite".to_string(), AgentStatus::Running);
         assert_eq!(sup.live_status("yosemite"), Some(AgentStatus::Running));
+    }
+
+    #[tokio::test]
+    async fn delete_project_rejects_running_agent() {
+        let sup = Arc::new(test_supervisor());
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        std::fs::create_dir_all(repo.join(".git")).unwrap();
+        sup.workspace.add_workspace_repo(repo.clone()).unwrap();
+        let project_id = sup.current_workspace().unwrap().projects[0]
+            .project_id
+            .clone();
+        let tracked = TrackedRepo {
+            repo_path: repo,
+            subdir: "repo".into(),
+            branch: None,
+            parent_branch: None,
+            base_sha: None,
+            pr_number: None,
+            pr_url: None,
+            pr_title: None,
+            pr_state: None,
+        };
+        let mut record = new_agent_record(
+            "yosemite".into(),
+            "agent".into(),
+            "claude".into(),
+            tracked,
+            "task".into(),
+            AgentView::Custom,
+        );
+        sup.workspace.add_agent(&mut record).unwrap();
+        sup.statuses
+            .lock()
+            .insert(record.id.clone(), AgentStatus::Running);
+
+        let err = sup.clone().delete_project(&project_id).await.unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("while one of its agents is running"));
+        assert_eq!(sup.current_workspace().unwrap().projects.len(), 1);
+        assert_eq!(sup.current_workspace().unwrap().agents.len(), 1);
     }
 }

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -482,19 +482,21 @@ impl Supervisor {
         }
 
         let deleted_agent_ids = agents.iter().map(|agent| agent.id.clone()).collect();
-        let deleted_run_ids = workflows
-            .delete_project_runs_locked(&self, project_id)
-            .await?;
+        let run_cleanup = workflows.prepare_project_runs_locked(project_id)?;
+        let deleted_run_ids = run_cleanup.run_ids().to_vec();
 
-        // Workflow deletion removes its owned agents through the normal path.
-        // Snapshot the remaining project agents, detach their idle runtimes,
-        // then commit every remaining row deletion in one FK-cascaded project
-        // transaction. If the DB commit fails, records and checkouts remain;
-        // detached idle agents can resume lazily.
-        let remaining = self.workspace.agents_for_project(project_id);
-        self.detach_project_agents(&remaining);
-        self.workspace.delete_project(project_id)?;
-        self.teardown_project_checkouts(&remaining).await;
+        // Detach every idle runtime, but keep all durable rows and checkouts
+        // until the single project + workflow-run transaction commits. A DB
+        // failure restores every staged run directory; detached agents can
+        // resume lazily, leaving the project fully intact rather than partly
+        // deleted. Physical checkout removal is best-effort after commit.
+        self.detach_project_agents(&agents);
+        if let Err(error) = self.workspace.delete_project(project_id, &deleted_run_ids) {
+            run_cleanup.restore();
+            return Err(error);
+        }
+        workflows.finish_project_runs(run_cleanup);
+        self.teardown_project_checkouts(&agents).await;
 
         Ok(ProjectDeleteResult {
             workspace: self.current_workspace().expect("workspace initialized"),

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -49,6 +49,10 @@ pub struct WorkflowService {
     /// Active-run registry. Behind an `Arc` so a drive task can remove its own
     /// entry on exit without borrowing the service.
     pub(super) runs: Arc<Mutex<HashMap<String, RunHandle>>>,
+    /// Serializes workflow creation/deletion. Project deletion holds this from
+    /// its run preflight through the project commit, so no new run can appear
+    /// between cleanup and deletion.
+    pub(crate) lifecycle: tokio::sync::Mutex<()>,
 }
 
 pub(super) struct RunHandle {
@@ -73,6 +77,7 @@ impl WorkflowService {
             driver,
             app,
             runs: Arc::new(Mutex::new(HashMap::new())),
+            lifecycle: tokio::sync::Mutex::new(()),
         }
     }
 
@@ -94,6 +99,7 @@ impl WorkflowService {
         // same form a chat message delivers them, scoped to the first agent.
         attachments: Vec<String>,
     ) -> Result<String> {
+        let _lifecycle_guard = self.lifecycle.lock().await;
         let run_id = format!("run-{}", uuid::Uuid::new_v4());
         let repo = PathBuf::from(&repo_path);
 
@@ -229,6 +235,11 @@ impl WorkflowService {
     /// surviving child), sibling subtrees still get cleaned, and every failure
     /// is aggregated into one error that says deleting again finishes the job.
     pub async fn delete_run(&self, supervisor: &Arc<Supervisor>, run_id: &str) -> Result<()> {
+        let _lifecycle_guard = self.lifecycle.lock().await;
+        self.delete_run_locked(supervisor, run_id).await
+    }
+
+    async fn delete_run_locked(&self, supervisor: &Arc<Supervisor>, run_id: &str) -> Result<()> {
         let order = {
             let conn = self.db.lock();
             let mut order = Vec::new();
@@ -258,6 +269,52 @@ impl WorkflowService {
              parents) is untouched — delete again to finish.",
             errors.join("; ")
         )))
+    }
+
+    /// Delete every workflow tree owned by a project through the same guarded
+    /// lifecycle path as `wf_delete_run`. The caller holds `lifecycle` across
+    /// this cleanup and the eventual project-row commit.
+    pub(crate) async fn delete_project_runs_locked(
+        &self,
+        supervisor: &Arc<Supervisor>,
+        project_id: &str,
+    ) -> Result<Vec<String>> {
+        let (roots, all_ids) = {
+            let conn = self.db.lock();
+            let roots = conn
+                .prepare("SELECT id FROM wf_run WHERE project_id = ?1 AND parent_run_id IS NULL")?
+                .query_map([project_id], |row| row.get::<_, String>(0))?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            let mut all_ids = Vec::new();
+            for root in &roots {
+                run_tree_post_order(&conn, root, &mut all_ids);
+            }
+            check_deletable(&conn, &all_ids)?;
+            (roots, all_ids)
+        };
+
+        // Match delete_run's winding-down guard, but check the whole project
+        // before touching any tree so rejection is side-effect free.
+        {
+            let runs = self.runs.lock();
+            if let Some(id) = all_ids.iter().find(|id| runs.contains_key(id.as_str())) {
+                return Err(Error::Other(format!(
+                    "run {id} is still winding down — try again in a moment"
+                )));
+            }
+        }
+
+        let mut errors = Vec::new();
+        for root in roots {
+            self.delete_tree(supervisor, &root, &mut errors).await;
+        }
+        if !errors.is_empty() {
+            return Err(Error::Other(format!(
+                "project workflow deletion incomplete: {}. Delete the project again to finish.",
+                errors.join("; ")
+            )));
+        }
+        Ok(all_ids)
     }
 
     /// Delete `run_id`'s subtree, children first. Returns whether the whole

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -70,6 +70,47 @@ pub(super) struct RunHandle {
     pub(super) pending_ask: Arc<AtomicBool>,
 }
 
+/// Filesystem half of an atomic project deletion. Run directories are renamed
+/// aside before the database transaction; they can therefore be restored if
+/// the transaction fails, or swept after it commits. Startup recovery handles
+/// the same two states if the app exits between either boundary.
+pub(crate) struct ProjectRunCleanup {
+    run_ids: Vec<String>,
+    staged_dirs: Vec<StagedRunDir>,
+    finalized: bool,
+}
+
+impl ProjectRunCleanup {
+    pub(crate) fn run_ids(&self) -> &[String] {
+        &self.run_ids
+    }
+
+    pub(crate) fn restore(mut self) {
+        restore_staged_run_dirs(&self.staged_dirs);
+        self.finalized = true;
+    }
+
+    fn finish(mut self, app: &AppHandle) {
+        // The DB commit has happened; never let Drop restore directories for
+        // rows that no longer exist. Failed removals are startup-recoverable.
+        self.finalized = true;
+        for dir in &self.staged_dirs {
+            dir.remove_staged();
+        }
+        for run_id in &self.run_ids {
+            journal::emit_run_deleted(app, run_id);
+        }
+    }
+}
+
+impl Drop for ProjectRunCleanup {
+    fn drop(&mut self) {
+        if !self.finalized {
+            restore_staged_run_dirs(&self.staged_dirs);
+        }
+    }
+}
+
 impl WorkflowService {
     pub fn new(db: Db, driver: Arc<dyn AgentDriver>, app: AppHandle) -> Self {
         Self {
@@ -271,26 +312,21 @@ impl WorkflowService {
         )))
     }
 
-    /// Delete every workflow tree owned by a project through the same guarded
-    /// lifecycle path as `wf_delete_run`. The caller holds `lifecycle` across
-    /// this cleanup and the eventual project-row commit.
-    pub(crate) async fn delete_project_runs_locked(
+    /// Preflight and stage every workflow run owned by a project. The caller
+    /// holds `lifecycle` through the subsequent project/run DB transaction, so
+    /// the checked set cannot change before that single commit point.
+    pub(crate) fn prepare_project_runs_locked(
         &self,
-        supervisor: &Arc<Supervisor>,
         project_id: &str,
-    ) -> Result<Vec<String>> {
-        let (roots, all_ids) = {
+    ) -> Result<ProjectRunCleanup> {
+        let all_ids = {
             let conn = self.db.lock();
-            let roots = conn
-                .prepare("SELECT id FROM wf_run WHERE project_id = ?1 AND parent_run_id IS NULL")?
+            let all_ids = conn
+                .prepare("SELECT id FROM wf_run WHERE project_id = ?1 ORDER BY created_at, id")?
                 .query_map([project_id], |row| row.get::<_, String>(0))?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
-            let mut all_ids = Vec::new();
-            for root in &roots {
-                run_tree_post_order(&conn, root, &mut all_ids);
-            }
             check_deletable(&conn, &all_ids)?;
-            (roots, all_ids)
+            all_ids
         };
 
         // Match delete_run's winding-down guard, but check the whole project
@@ -304,17 +340,16 @@ impl WorkflowService {
             }
         }
 
-        let mut errors = Vec::new();
-        for root in roots {
-            self.delete_tree(supervisor, &root, &mut errors).await;
-        }
-        if !errors.is_empty() {
-            return Err(Error::Other(format!(
-                "project workflow deletion incomplete: {}. Delete the project again to finish.",
-                errors.join("; ")
-            )));
-        }
-        Ok(all_ids)
+        let staged_dirs = stage_run_dirs(&all_ids)?;
+        Ok(ProjectRunCleanup {
+            run_ids: all_ids,
+            staged_dirs,
+            finalized: false,
+        })
+    }
+
+    pub(crate) fn finish_project_runs(&self, cleanup: ProjectRunCleanup) {
+        cleanup.finish(&self.app);
     }
 
     /// Delete `run_id`'s subtree, children first. Returns whether the whole
@@ -5795,6 +5830,96 @@ fn delete_run_data(conn: &Connection, run_id: &str) -> Result<()> {
     delete_run_data_at(conn, run_id, &blackboard::run_dir(run_id)?)
 }
 
+#[derive(Debug)]
+struct StagedRunDir {
+    live: PathBuf,
+    staged: PathBuf,
+    exists: bool,
+}
+
+impl StagedRunDir {
+    fn stage(run_id: &str, live: PathBuf) -> Result<Self> {
+        let staged = live.with_file_name(format!(
+            "{}.deleting",
+            live.file_name().and_then(|n| n.to_str()).unwrap_or(run_id)
+        ));
+        let exists = match std::fs::rename(&live, &staged) {
+            Ok(()) => true,
+            // No live dir: never provisioned, already cleaned, or a prior
+            // crash left the staged form for startup/retry recovery.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => staged.exists(),
+            Err(e) => {
+                return Err(Error::Other(format!(
+                    "cannot stage run dir for {run_id}: {e}"
+                )))
+            }
+        };
+        Ok(Self {
+            live,
+            staged,
+            exists,
+        })
+    }
+
+    fn restore(&self) {
+        if self.exists {
+            if let Err(error) = std::fs::rename(&self.staged, &self.live) {
+                tracing::warn!(
+                    error = %error,
+                    staged = %self.staged.display(),
+                    "restore staged run directory failed; startup recovery will retry"
+                );
+            }
+        }
+    }
+
+    fn remove_staged(&self) {
+        if self.exists {
+            if let Err(error) = std::fs::remove_dir_all(&self.staged) {
+                tracing::warn!(
+                    error = %error,
+                    staged = %self.staged.display(),
+                    "remove committed staged run directory failed; startup recovery will retry"
+                );
+            }
+        }
+    }
+}
+
+fn restore_staged_run_dirs(staged: &[StagedRunDir]) {
+    for dir in staged.iter().rev() {
+        dir.restore();
+    }
+}
+
+fn stage_run_dirs(run_ids: &[String]) -> Result<Vec<StagedRunDir>> {
+    stage_run_dirs_at(run_ids, blackboard::run_dir)
+}
+
+fn stage_run_dirs_at<F>(run_ids: &[String], resolve: F) -> Result<Vec<StagedRunDir>>
+where
+    F: Fn(&str) -> Result<PathBuf>,
+{
+    let mut staged = Vec::with_capacity(run_ids.len());
+    for run_id in run_ids {
+        let live = match resolve(run_id) {
+            Ok(path) => path,
+            Err(error) => {
+                restore_staged_run_dirs(&staged);
+                return Err(error);
+            }
+        };
+        match StagedRunDir::stage(run_id, live) {
+            Ok(dir) => staged.push(dir),
+            Err(error) => {
+                restore_staged_run_dirs(&staged);
+                return Err(error);
+            }
+        }
+    }
+    Ok(staged)
+}
+
 /// Discard every id, pressing on past a failure instead of bailing on the first
 /// (the review blocker): one wedged agent must not strand the run's other
 /// workspaces. Returns whether *all* discards succeeded — the caller keeps the
@@ -5836,31 +5961,12 @@ where
 /// startup would also sweep). A missing dir is fine — a retried partial delete
 /// or a cleaned disk.
 fn delete_run_data_at(conn: &Connection, run_id: &str, dir: &Path) -> Result<()> {
-    let staged = dir.with_file_name(format!(
-        "{}.deleting",
-        dir.file_name().and_then(|n| n.to_str()).unwrap_or(run_id)
-    ));
-    let dir_staged = match std::fs::rename(dir, &staged) {
-        Ok(()) => true,
-        // No live dir: never provisioned, a cleaned disk, or a previous
-        // attempt that crashed between this rename and the row delete — in
-        // that last case the staged dir survives and is swept below.
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => staged.exists(),
-        Err(e) => {
-            return Err(Error::Other(format!(
-                "cannot stage run dir for {run_id}: {e}"
-            )))
-        }
-    };
+    let staged = StagedRunDir::stage(run_id, dir.to_path_buf())?;
     if let Err(e) = conn.execute("DELETE FROM wf_run WHERE id = ?1", [run_id]) {
-        if dir_staged {
-            let _ = std::fs::rename(&staged, dir);
-        }
+        staged.restore();
         return Err(Error::Other(e.to_string()));
     }
-    if dir_staged {
-        let _ = std::fs::remove_dir_all(&staged);
-    }
+    staged.remove_staged();
     Ok(())
 }
 
@@ -7388,6 +7494,33 @@ mod tests {
         let all = discard_all(&ids, "r", &mut errors, |_| async { Ok(()) }).await;
         assert!(all);
         assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn staging_multiple_run_dirs_restores_earlier_dirs_on_later_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let runs = tmp.path().join("runs");
+        let first = runs.join("r-first");
+        let second = runs.join("r-second");
+        std::fs::create_dir_all(&first).unwrap();
+        std::fs::write(first.join("marker"), "first").unwrap();
+        std::fs::create_dir_all(&second).unwrap();
+        std::fs::write(second.join("marker"), "second").unwrap();
+
+        // Make the second staging rename fail after the first has succeeded.
+        let second_staged = runs.join("r-second.deleting");
+        std::fs::create_dir_all(&second_staged).unwrap();
+        std::fs::write(second_staged.join("collision"), "occupied").unwrap();
+
+        let ids = vec!["r-first".to_string(), "r-second".to_string()];
+        let error = stage_run_dirs_at(&ids, |id| Ok(runs.join(id))).unwrap_err();
+        assert!(error.to_string().contains("cannot stage run dir"));
+        assert!(first.join("marker").exists(), "first dir restored intact");
+        assert!(second.join("marker").exists(), "failed dir remains intact");
+        assert!(
+            !runs.join("r-first.deleting").exists(),
+            "earlier staged dir is not stranded"
+        );
     }
 
     #[test]

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -227,6 +227,13 @@ pub struct Workspace {
     pub agents: Vec<AgentRecord>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct ProjectDeleteResult {
+    pub workspace: Workspace,
+    pub deleted_agent_ids: Vec<String>,
+    pub deleted_run_ids: Vec<String>,
+}
+
 /// A pinned repo joined with its owning project, so the frontend can show a
 /// custom name (independent of the folder basename) and address the project
 /// for rename / relocate without a second round-trip.
@@ -512,21 +519,18 @@ impl WorkspaceManager {
         Ok(self.current().expect("workspace initialized"))
     }
 
-    /// Delete the project row after its agent runtimes/checkouts have been
-    /// torn down by the supervisor. Foreign keys cascade through repos,
-    /// workspaces, sessions, transcripts, and project settings. Workflow runs
-    /// reference projects by id without an FK, so remove those explicitly.
-    pub fn delete_project(&self, project_id: &str) -> Result<Workspace> {
+    /// Atomically delete a project after workflow and runtime lifecycle cleanup
+    /// has been coordinated by the supervisor. Foreign keys cascade through
+    /// repos, workspaces, sessions, transcripts, and project settings.
+    pub fn delete_project(&self, project_id: &str) -> Result<()> {
         let mut conn = self.db.lock();
         let tx = conn.transaction()?;
-        tx.execute("DELETE FROM wf_run WHERE project_id = ?1", [project_id])?;
         let changed = tx.execute("DELETE FROM projects WHERE id = ?1", [project_id])?;
         if changed == 0 {
             return Err(Error::Other(format!("project not found: {project_id}")));
         }
         tx.commit()?;
-        drop(conn);
-        Ok(self.current().expect("workspace initialized"))
+        Ok(())
     }
 
     /// Repoint a pinned repo at a new location on disk. The user has already
@@ -2627,7 +2631,8 @@ mod tests {
             )
             .unwrap();
 
-        let ws = wm.delete_project(&pid).unwrap();
+        wm.delete_project(&pid).unwrap();
+        let ws = wm.current().unwrap();
         assert!(ws.projects.is_empty());
         assert!(ws.repos.is_empty());
         assert!(ws.agents.is_empty());

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -519,12 +519,29 @@ impl WorkspaceManager {
         Ok(self.current().expect("workspace initialized"))
     }
 
-    /// Atomically delete a project after workflow and runtime lifecycle cleanup
-    /// has been coordinated by the supervisor. Foreign keys cascade through
-    /// repos, workspaces, sessions, transcripts, and project settings.
-    pub fn delete_project(&self, project_id: &str) -> Result<()> {
+    /// Atomically delete a project and its workflow runs after filesystem and
+    /// runtime cleanup has been staged by the supervisor. Workflow runs do not
+    /// have a project FK, so they share this transaction explicitly; every
+    /// other project-owned row is removed by foreign-key cascade.
+    pub fn delete_project(&self, project_id: &str, expected_run_ids: &[String]) -> Result<()> {
         let mut conn = self.db.lock();
         let tx = conn.transaction()?;
+        let actual_run_ids = {
+            let mut stmt =
+                tx.prepare("SELECT id FROM wf_run WHERE project_id = ?1 ORDER BY created_at, id")?;
+            let ids = stmt
+                .query_map([project_id], |row| row.get::<_, String>(0))?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            ids
+        };
+        if actual_run_ids != expected_run_ids {
+            return Err(Error::Other(format!(
+                "project workflow set changed during deletion: expected {}, found {}",
+                expected_run_ids.len(),
+                actual_run_ids.len()
+            )));
+        }
+        tx.execute("DELETE FROM wf_run WHERE project_id = ?1", [project_id])?;
         let changed = tx.execute("DELETE FROM projects WHERE id = ?1", [project_id])?;
         if changed == 0 {
             return Err(Error::Other(format!("project not found: {project_id}")));
@@ -2630,8 +2647,16 @@ mod tests {
                 [&pid],
             )
             .unwrap();
+        db.lock()
+            .execute(
+                "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,branch,
+                    base_sha,status,budgets_json,spent_json,created_at,updated_at)
+                 VALUES ('r1','n','{}','t',?1,'/r','/d','wf/x','sha','done','{}','{}',0,0)",
+                [&pid],
+            )
+            .unwrap();
 
-        wm.delete_project(&pid).unwrap();
+        wm.delete_project(&pid, &["r1".to_string()]).unwrap();
         let ws = wm.current().unwrap();
         assert!(ws.projects.is_empty());
         assert!(ws.repos.is_empty());
@@ -2645,6 +2670,56 @@ mod tests {
             )
             .unwrap();
         assert_eq!(setting_count, 0);
+        let run_count: i64 = db
+            .lock()
+            .query_row("SELECT COUNT(*) FROM wf_run WHERE id = 'r1'", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(run_count, 0, "workflow rows share the project commit");
+    }
+
+    #[test]
+    fn delete_project_rolls_back_when_the_workflow_set_changed() {
+        let db = test_db();
+        let td = tempfile::tempdir().unwrap();
+        let repo = init_repo(td.path());
+        let wm = WorkspaceManager::new(db.clone());
+        wm.add_workspace_repo(repo.clone()).unwrap();
+        let pid = wm.current().unwrap().projects[0].project_id.clone();
+
+        let mut rec = new_agent_record(
+            "yosemite".into(),
+            "agent".into(),
+            "claude".into(),
+            mk_repo(repo.to_str().unwrap()),
+            "task".into(),
+            AgentView::Custom,
+        );
+        wm.add_agent(&mut rec).unwrap();
+        db.lock()
+            .execute(
+                "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,branch,
+                    base_sha,status,budgets_json,spent_json,created_at,updated_at)
+                 VALUES ('r1','n','{}','t',?1,'/r','/d','wf/x','sha','done','{}','{}',0,0)",
+                [&pid],
+            )
+            .unwrap();
+
+        let error = wm.delete_project(&pid, &[]).unwrap_err();
+        assert!(error.to_string().contains("workflow set changed"));
+        let ws = wm.current().unwrap();
+        assert_eq!(ws.projects.len(), 1, "project row is rolled back");
+        assert_eq!(ws.agents.len(), 1, "agent cascade is rolled back");
+        let run_count: i64 = db
+            .lock()
+            .query_row(
+                "SELECT COUNT(*) FROM wf_run WHERE project_id = ?1",
+                [&pid],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(run_count, 1, "workflow row is rolled back");
     }
 
     #[test]

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -429,6 +429,13 @@ impl WorkspaceManager {
         Self::query_agents_for_run(&conn, run_id)
     }
 
+    /// Every agent owned by a project, including workflow-owned and archived
+    /// agents that are omitted from the normal sidebar snapshot.
+    pub fn agents_for_project(&self, project_id: &str) -> Vec<AgentRecord> {
+        let conn = self.db.lock();
+        Self::query_agents_for_project(&conn, project_id)
+    }
+
     /// Append a repo to the sidebar's pinned list. Idempotent — adding
     /// a path that's already pinned is a no-op (returns Ok).
     pub fn add_workspace_repo(&self, repo_path: PathBuf) -> Result<Workspace> {
@@ -501,6 +508,23 @@ impl WorkspaceManager {
         if changed == 0 {
             return Err(Error::Other(format!("project not found: {project_id}")));
         }
+        drop(conn);
+        Ok(self.current().expect("workspace initialized"))
+    }
+
+    /// Delete the project row after its agent runtimes/checkouts have been
+    /// torn down by the supervisor. Foreign keys cascade through repos,
+    /// workspaces, sessions, transcripts, and project settings. Workflow runs
+    /// reference projects by id without an FK, so remove those explicitly.
+    pub fn delete_project(&self, project_id: &str) -> Result<Workspace> {
+        let mut conn = self.db.lock();
+        let tx = conn.transaction()?;
+        tx.execute("DELETE FROM wf_run WHERE project_id = ?1", [project_id])?;
+        let changed = tx.execute("DELETE FROM projects WHERE id = ?1", [project_id])?;
+        if changed == 0 {
+            return Err(Error::Other(format!("project not found: {project_id}")));
+        }
+        tx.commit()?;
         drop(conn);
         Ok(self.current().expect("workspace initialized"))
     }
@@ -1640,6 +1664,23 @@ impl WorkspaceManager {
             .collect()
     }
 
+    fn query_agents_for_project(conn: &Connection, project_id: &str) -> Vec<AgentRecord> {
+        let mut stmt = match conn.prepare(&format!(
+            "{AGENT_SELECT} WHERE w.project_id = ?1 ORDER BY w.created_at"
+        )) {
+            Ok(s) => s,
+            Err(_) => return Vec::new(),
+        };
+
+        stmt.query_map([project_id], Self::map_agent_row)
+            .ok()
+            .map(|rows| rows.filter_map(|r| r.ok()).collect::<Vec<_>>())
+            .unwrap_or_default()
+            .into_iter()
+            .map(|row| Self::build_agent_record(conn, row))
+            .collect()
+    }
+
     fn query_tracked_repos(conn: &Connection, agent_id: &str) -> Vec<TrackedRepo> {
         let mut stmt = match conn.prepare(
             "SELECT r.path, w.subdir, w.branch, w.parent_branch, w.base_sha, w.pr_number,
@@ -2559,6 +2600,46 @@ mod tests {
 
         let err = wm.rename_project(&pid, "   ").unwrap_err();
         assert!(err.to_string().contains("cannot be empty"));
+    }
+
+    #[test]
+    fn delete_project_cascades_non_archived_agents_and_settings() {
+        let db = test_db();
+        let td = tempfile::tempdir().unwrap();
+        let repo = init_repo(td.path());
+        let wm = WorkspaceManager::new(db.clone());
+        wm.add_workspace_repo(repo.clone()).unwrap();
+        let pid = wm.current().unwrap().projects[0].project_id.clone();
+
+        let mut rec = new_agent_record(
+            "yosemite".into(),
+            "agent".into(),
+            "claude".into(),
+            mk_repo(repo.to_str().unwrap()),
+            "task".into(),
+            AgentView::Custom,
+        );
+        wm.add_agent(&mut rec).unwrap();
+        db.lock()
+            .execute(
+                "INSERT INTO project_settings (project_id, key, value) VALUES (?1, 'run.dev', 'npm run dev')",
+                [&pid],
+            )
+            .unwrap();
+
+        let ws = wm.delete_project(&pid).unwrap();
+        assert!(ws.projects.is_empty());
+        assert!(ws.repos.is_empty());
+        assert!(ws.agents.is_empty());
+        let setting_count: i64 = db
+            .lock()
+            .query_row(
+                "SELECT COUNT(*) FROM project_settings WHERE project_id = ?1",
+                [&pid],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(setting_count, 0);
     }
 
     #[test]

--- a/src/api.ts
+++ b/src/api.ts
@@ -511,6 +511,10 @@ export const api = {
   /** Set a project's custom display name (independent of its folder). */
   renameProject: (projectId: string, name: string) =>
     invoke<Workspace>("rename_project", { projectId, name }),
+  /** Delete a project and all of its agents/workspaces. Active agents block it. */
+  deleteProject: (projectId: string) => invoke<Workspace>("delete_project", { projectId }),
+  projectHasRunningAgents: (projectId: string) =>
+    invoke<boolean>("project_has_running_agents", { projectId }),
   /** Repoint a pinned repo at a moved folder. Rejects a non-git or
    *  already-pinned destination. */
   relocateRepo: (oldPath: string, newPath: string) =>

--- a/src/api.ts
+++ b/src/api.ts
@@ -109,6 +109,12 @@ export interface Workspace {
   agents: AgentRecord[];
 }
 
+export interface ProjectDeleteResult {
+  workspace: Workspace;
+  deleted_agent_ids: string[];
+  deleted_run_ids: string[];
+}
+
 export interface AgentOutputEvent {
   agent_id: string;
   /** Raw PTY bytes, base64-encoded over IPC. Decode with `decodeBase64`. */
@@ -512,7 +518,8 @@ export const api = {
   renameProject: (projectId: string, name: string) =>
     invoke<Workspace>("rename_project", { projectId, name }),
   /** Delete a project and all of its agents/workspaces. Active agents block it. */
-  deleteProject: (projectId: string) => invoke<Workspace>("delete_project", { projectId }),
+  deleteProject: (projectId: string) =>
+    invoke<ProjectDeleteResult>("delete_project", { projectId }),
   projectHasRunningAgents: (projectId: string) =>
     invoke<boolean>("project_has_running_agents", { projectId }),
   /** Repoint a pinned repo at a moved folder. Rejects a non-git or

--- a/src/components/ProjectSettings/DeleteSection.tsx
+++ b/src/components/ProjectSettings/DeleteSection.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from "react";
+import { api } from "@/api";
+import { Button } from "@/components/ui/Button";
+import { useAppStore } from "@/store";
+
+export function DeleteSection({
+  projectId,
+  projectName,
+}: {
+  projectId: string;
+  projectName: string;
+}) {
+  const agents = useAppStore((state) => state.workspace?.agents ?? []);
+  const deleteProject = useAppStore((state) => state.deleteProject);
+  const [confirming, setConfirming] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasBackendRunningAgent, setHasBackendRunningAgent] = useState<boolean | null>(null);
+  const hasVisibleRunningAgent = agents.some(
+    (agent) =>
+      agent.project_id === projectId && (agent.status === "running" || agent.status === "spawning"),
+  );
+  const checkingAgents = hasBackendRunningAgent === null && !hasVisibleRunningAgent;
+  const hasRunningAgent = hasVisibleRunningAgent || hasBackendRunningAgent === true;
+
+  useEffect(() => {
+    let cancelled = false;
+    const refresh = async () => {
+      try {
+        const running = await api.projectHasRunningAgents(projectId);
+        if (!cancelled) setHasBackendRunningAgent(running);
+      } catch {
+        // Fail closed. The delete command repeats the same guard, but keeping
+        // the button disabled avoids presenting an action we cannot validate.
+        if (!cancelled) setHasBackendRunningAgent(true);
+      }
+    };
+    void refresh();
+    const timer = window.setInterval(() => void refresh(), 1000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [projectId]);
+
+  const remove = async () => {
+    setDeleting(true);
+    setError(null);
+    try {
+      await deleteProject(projectId);
+    } catch (err) {
+      setError(String(err));
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <section className="ps-section ps-delete-section">
+      {confirming ? (
+        <div className="ps-delete-confirm" role="group" aria-label="Confirm project deletion">
+          <div className="ps-delete-confirm-copy">
+            <h3 className="ps-delete-confirm-title text-base">Delete {projectName}?</h3>
+            <div className="ps-delete-confirm-text text-sm">
+              This permanently deletes the project and all of its agents, workspaces, and history.
+              This action can&rsquo;t be undone.
+            </div>
+            {hasRunningAgent && (
+              <div className="ps-delete-note text-xs">
+                Stop running agents before deleting this project.
+              </div>
+            )}
+            {error && <div className="ps-delete-error text-xs">{error}</div>}
+          </div>
+          <div className="ps-delete-actions">
+            <Button
+              variant="ghost"
+              disabled={deleting}
+              onClick={() => {
+                setConfirming(false);
+                setError(null);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="outline"
+              danger
+              disabled={checkingAgents || hasRunningAgent || deleting}
+              onClick={() => void remove()}
+            >
+              {deleting ? "Deleting…" : "Confirm delete"}
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <header className="ps-section-h ps-delete-copy">
+            <h2 className="ps-section-t text-lg">Delete project</h2>
+            <p className="ps-section-lead text-sm">
+              Permanently delete {projectName} and all of its agents, workspaces, and history.
+            </p>
+            {hasRunningAgent && (
+              <div className="ps-delete-note text-xs">
+                Stop running agents before deleting this project.
+              </div>
+            )}
+            {error && <div className="ps-delete-error text-xs">{error}</div>}
+          </header>
+          <Button
+            variant="outline"
+            danger
+            disabled={checkingAgents || hasRunningAgent}
+            onClick={() => {
+              setConfirming(true);
+              setError(null);
+            }}
+            tip={
+              checkingAgents
+                ? "Checking agent status"
+                : hasRunningAgent
+                  ? "Stop running agents first"
+                  : undefined
+            }
+          >
+            Delete project
+          </Button>
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/components/ProjectSettings/ProjectSettings.css
+++ b/src/components/ProjectSettings/ProjectSettings.css
@@ -115,6 +115,60 @@
   padding: 24px 2px;
 }
 
+.ps-delete-section {
+  border-top: 1px solid var(--bd-soft);
+  padding-top: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+.ps-delete-copy {
+  min-width: 0;
+}
+.ps-delete-copy.ps-section-h {
+  margin-bottom: 0;
+}
+.ps-delete-note,
+.ps-delete-error {
+  margin-top: 8px;
+  color: var(--danger);
+}
+.ps-delete-section .btn-t {
+  flex-shrink: 0;
+}
+.ps-delete-confirm {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 8px 16px;
+  background: var(--bg-2);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-sm);
+}
+.ps-delete-confirm-copy {
+  min-width: 0;
+}
+.ps-delete-confirm-title {
+  margin-top: 0;
+  color: var(--fg-0);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.ps-delete-confirm-text {
+  margin-top: 6px;
+  color: var(--fg-2);
+  line-height: 1.5;
+}
+.ps-delete-actions {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 /* sections */
 .ps-section-h {
   margin-bottom: 16px;

--- a/src/components/ProjectSettings/index.tsx
+++ b/src/components/ProjectSettings/index.tsx
@@ -5,6 +5,7 @@ import { loadRunOverrides, type SetupRow, toSetupRows } from "@/components/RunCo
 import { Loader } from "@/components/ui/Loader";
 import { useAppStore } from "@/store";
 import { basename } from "@/util/format";
+import { DeleteSection } from "./DeleteSection";
 import { EnvVarsSection } from "./EnvVarsSection";
 import { GeneralSection } from "./GeneralSection";
 import { ProjectPulse } from "./ProjectPulse";
@@ -106,6 +107,7 @@ export function ProjectSettings({ repoPath }: { repoPath: string }) {
                 initialOverrides={loaded.overrides}
               />
               <EnvVarsSection projectId={loaded.projectId} repoPath={repoPath} />
+              <DeleteSection projectId={loaded.projectId} projectName={name} />
             </div>
           )}
         </div>

--- a/src/components/Sidebar/ProjectGroup.tsx
+++ b/src/components/Sidebar/ProjectGroup.tsx
@@ -1,4 +1,3 @@
-import { ask } from "@tauri-apps/plugin-dialog";
 import { useRef } from "react";
 import type { AgentRecord, WfRun } from "@/api";
 import { Icon } from "@/components/Icon";
@@ -18,8 +17,6 @@ interface Props {
   runs: WfRun[];
   /** Whether the user has expanded this group. */
   open: boolean;
-  /** Show the remove (×) button — only true when this is a pinned-but-empty group. */
-  removable: boolean;
   onToggle: () => void;
   /** Whether this group can be dragged to reorder (disabled while searching). */
   reorderable: boolean;
@@ -40,7 +37,6 @@ export function ProjectGroup({
   drafts,
   runs,
   open,
-  removable,
   onToggle,
   reorderable,
   dragging,
@@ -54,19 +50,9 @@ export function ProjectGroup({
   const selectDraft = useAppStore((s) => s.selectDraft);
   const selectRun = useAppStore((s) => s.selectRun);
   const createDraft = useAppStore((s) => s.createDraft);
-  const removeWorkspaceRepo = useAppStore((s) => s.removeWorkspaceRepo);
   const openProjectSettings = useAppStore((s) => s.openProjectSettings);
 
   const count = agents.length + drafts.length + runs.length;
-
-  async function onRemove(e: React.MouseEvent) {
-    e.stopPropagation();
-    const ok = await ask(`Remove "${label}" from the sidebar?`, {
-      title: "Remove repo",
-      kind: "info",
-    });
-    if (ok) await removeWorkspaceRepo(repoPath);
-  }
 
   function onAddAgent(e: React.MouseEvent) {
     e.stopPropagation();
@@ -90,7 +76,7 @@ export function ProjectGroup({
       <div
         className={`proj-h flex-center ${open ? "open" : ""} ${reorderable ? "reorderable" : ""}`}
         onPointerDown={(e) => {
-          // Left button only, and never from an action button (add/remove).
+          // Left button only, and never from an action button.
           if (!onReorderPointerDown || e.button !== 0) return;
           if ((e.target as HTMLElement).closest("button")) return;
           draggedRef.current = false;
@@ -128,17 +114,6 @@ export function ProjectGroup({
         >
           <Icon name="plus" size={11} />
         </button>
-        {removable && (
-          <button
-            className="padd padd-remove tip"
-            data-tip="Remove repo"
-            data-tip-down=""
-            onClick={onRemove}
-            aria-label="Remove repo"
-          >
-            <Icon name="close" />
-          </button>
-        )}
       </div>
 
       <div className={`agents ${open ? "" : "closed"}`}>

--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -194,29 +194,19 @@
   background: var(--accent-soft);
   color: var(--accent);
 }
-/* Settings gear and Remove are revealed only when the row is engaged, so they
- * don't compete with the label or shift the always-visible "add agent" button.
- * They sit at the trailing edge, so revealing them adds no layout shift. */
-.proj-h .padd-remove,
+/* The settings gear is revealed only when the row is engaged, so it doesn't
+ * compete with the label or shift the always-visible "add agent" button. */
 .proj-h .padd-settings {
   opacity: 0;
   pointer-events: none;
 }
-/* Gear is a normal action like "add", so it reveals at full strength to match
- * the + button. Remove stays subdued — it's destructive and rare. */
 .proj-h:hover .padd-settings {
   opacity: 1;
   pointer-events: auto;
 }
-.proj-h:hover .padd-remove {
-  opacity: 0.6;
-  pointer-events: auto;
-}
-/* Keyboard focus reveals them too — a focused button at opacity:0 would make
+/* Keyboard focus reveals it too — a focused button at opacity:0 would make
  * the focus ring vanish and hide the action from keyboard users. */
-.proj-h:hover .padd-remove:hover,
 .proj-h:hover .padd-settings:hover,
-.proj-h .padd-remove:focus-visible,
 .proj-h .padd-settings:focus-visible {
   opacity: 1;
   pointer-events: auto;

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -244,12 +244,6 @@ export function Sidebar() {
                   drafts={g.drafts}
                   runs={g.runs}
                   open={openMap[g.repoPath] ?? false}
-                  removable={
-                    g.pinned &&
-                    g.agents.length === 0 &&
-                    g.drafts.length === 0 &&
-                    g.runs.length === 0
-                  }
                   onToggle={() => setOpenMap((m) => ({ ...m, [g.repoPath]: !m[g.repoPath] }))}
                   reorderable={reorderable}
                   dragging={dragPath === g.repoPath}

--- a/src/store/repos.ts
+++ b/src/store/repos.ts
@@ -33,11 +33,8 @@ export const createReposSlice: SliceCreator<ReposSlice> = (set, get) => ({
   },
 
   deleteProject: async (projectId) => {
-    const deletedIds =
-      get()
-        .workspace?.agents.filter((agent) => agent.project_id === projectId)
-        .map((agent) => agent.id) ?? [];
-    const ws = await api.deleteProject(projectId);
+    const result = await api.deleteProject(projectId);
+    const deletedIds = result.deleted_agent_ids;
     for (const id of deletedIds) clearOutputBuffer(id);
     set((state) => {
       let patch = {};
@@ -45,10 +42,13 @@ export const createReposSlice: SliceCreator<ReposSlice> = (set, get) => ({
         patch = { ...patch, ...dropAgentEntries({ ...state, ...patch }, id) };
       return {
         ...patch,
-        workspace: ws,
+        workspace: result.workspace,
         selectedAgentId: deletedIds.includes(state.selectedAgentId ?? "")
           ? null
           : state.selectedAgentId,
+        selectedRunId: result.deleted_run_ids.includes(state.selectedRunId ?? "")
+          ? null
+          : state.selectedRunId,
         projectSettingsRepoPath: null,
       };
     });

--- a/src/store/repos.ts
+++ b/src/store/repos.ts
@@ -1,4 +1,6 @@
 import { api } from "@/api";
+import { dropAgentEntries } from "@/helpers";
+import { clearOutputBuffer } from "@/pty/buffers";
 import { remapProjectOrder } from "@/storage/projectOrder";
 import type { ReposSlice, SliceCreator } from "./types";
 
@@ -28,6 +30,28 @@ export const createReposSlice: SliceCreator<ReposSlice> = (set, get) => ({
     // Errors propagate to the modal for inline display.
     const ws = await api.renameProject(projectId, name);
     set({ workspace: ws });
+  },
+
+  deleteProject: async (projectId) => {
+    const deletedIds =
+      get()
+        .workspace?.agents.filter((agent) => agent.project_id === projectId)
+        .map((agent) => agent.id) ?? [];
+    const ws = await api.deleteProject(projectId);
+    for (const id of deletedIds) clearOutputBuffer(id);
+    set((state) => {
+      let patch = {};
+      for (const id of deletedIds)
+        patch = { ...patch, ...dropAgentEntries({ ...state, ...patch }, id) };
+      return {
+        ...patch,
+        workspace: ws,
+        selectedAgentId: deletedIds.includes(state.selectedAgentId ?? "")
+          ? null
+          : state.selectedAgentId,
+        projectSettingsRepoPath: null,
+      };
+    });
   },
 
   relocateProject: async (oldPath, newPath) => {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -189,6 +189,8 @@ export interface ReposSlice {
   // Settings modal can show the error inline rather than in the global banner.
   /** Set a project's custom display name (independent of its folder). */
   renameProject: (projectId: string, name: string) => Promise<void>;
+  /** Delete a project and all agents/workspaces belonging to it. */
+  deleteProject: (projectId: string) => Promise<void>;
   /** Repoint a pinned repo at a moved folder, migrating its sidebar order and
    *  the open settings modal to the new path. */
   relocateProject: (oldPath: string, newPath: string) => Promise<void>;


### PR DESCRIPTION
## Summary

- add a Project Settings danger section with explicit confirm/cancel deletion UI
- delete idle, stopped, archived, and workflow-owned project agents while blocking running or spawning agents
- remove the obsolete empty-project sidebar remove action while retaining add and settings controls

## Validation

- npm run check
- npm test -- --run (432 tests)
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml --lib delete_project