### PR TITLE
feat(composer): dynamic per-model reasoning levels

### DIFF
--- a/src-tauri/src/model_catalog.rs
+++ b/src-tauri/src/model_catalog.rs
@@ -34,6 +34,15 @@ pub struct DiscoveredModel {
     pub context_window: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<bool>,
+    /// The reasoning-effort levels this model supports, in the CLI's own order
+    /// (e.g. codex `["low","medium","high","xhigh","max","ultra"]`). Present only
+    /// when the CLI reports them; the frontend uses it to build a per-model
+    /// thinking picker instead of a hardcoded provider list.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_levels: Option<Vec<String>>,
+    /// The model's own default reasoning level, when the CLI reports one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_reasoning: Option<String>,
 }
 
 impl DiscoveredModel {
@@ -43,6 +52,8 @@ impl DiscoveredModel {
             name: None,
             context_window: None,
             reasoning: None,
+            reasoning_levels: None,
+            default_reasoning: None,
         }
     }
 }
@@ -194,15 +205,27 @@ fn parse_codex_cache(root: &Value) -> Vec<DiscoveredModel> {
                 .and_then(|v| v.as_str())
                 .map(str::to_string);
             let context_window = m.get("context_window").and_then(|v| v.as_u64());
-            let reasoning = m
+            let reasoning_levels = m
                 .get("supported_reasoning_levels")
                 .and_then(|v| v.as_array())
-                .map(|a| !a.is_empty());
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|e| e.get("effort").and_then(|v| v.as_str()))
+                        .map(str::to_string)
+                        .collect::<Vec<_>>()
+                });
+            let reasoning = reasoning_levels.as_ref().map(|l| !l.is_empty());
+            let default_reasoning = m
+                .get("default_reasoning_level")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
             Some(DiscoveredModel {
                 id,
                 name,
                 context_window,
                 reasoning,
+                reasoning_levels,
+                default_reasoning,
             })
         })
         .collect()
@@ -222,6 +245,8 @@ fn parse_pi_table(text: &str) -> Vec<DiscoveredModel> {
                 name: None,
                 context_window: parse_size(f[2]),
                 reasoning: Some(f[4].eq_ignore_ascii_case("yes")),
+                reasoning_levels: None,
+                default_reasoning: None,
             })
         })
         .collect()
@@ -242,6 +267,8 @@ fn parse_cursor_models(text: &str) -> Vec<DiscoveredModel> {
                 name: Some(name.trim().to_string()),
                 context_window: None,
                 reasoning: None,
+                reasoning_levels: None,
+                default_reasoning: None,
             })
         })
         .collect()
@@ -280,7 +307,7 @@ mod tests {
     fn parses_codex_cache_and_skips_hidden() {
         let v = json!({"models": [
             {"slug": "gpt-5.5", "display_name": "GPT-5.5", "visibility": "list",
-             "context_window": 372000,
+             "context_window": 372000, "default_reasoning_level": "high",
              "supported_reasoning_levels": [{"effort": "low"}, {"effort": "high"}]},
             {"slug": "codex-auto-review", "display_name": "Review", "visibility": "hide",
              "supported_reasoning_levels": [{"effort": "low"}]},
@@ -291,6 +318,11 @@ mod tests {
         assert_eq!(got[0].name.as_deref(), Some("GPT-5.5"));
         assert_eq!(got[0].context_window, Some(372_000));
         assert_eq!(got[0].reasoning, Some(true));
+        assert_eq!(
+            got[0].reasoning_levels.as_deref(),
+            Some(["low".to_string(), "high".to_string()].as_slice())
+        );
+        assert_eq!(got[0].default_reasoning.as_deref(), Some("high"));
     }
 
     #[test]

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { DirListing, PrSummary } from "@/api";
 import { Icon } from "@/components/Icon";
 import { Chip } from "@/components/ui/Chip";
-import { lookupModel } from "@/data/modelCatalog";
+import { lookupModel, lookupModelInList } from "@/data/modelCatalog";
 import {
   PROVIDER_DETAIL,
   type ThinkingLevel,
@@ -101,18 +101,21 @@ interface Props {
   usage?: AgentUsage;
 }
 
-/** The effective thinking level for a provider/model. A stored per-provider
- *  preference wins, but only when the current model still supports it — so
- *  switching to a model that lacks that level (e.g. a stale "low" carried onto a
- *  richer model) falls through to the model's own default rather than sending an
- *  unsupported value. Order: stored (if supported) → model default → provider
- *  default → highest available. */
+/** The effective thinking level for a provider/model. Every candidate — the
+ *  caller's `preferred` value (e.g. a custom agent's saved effort), a stored
+ *  per-provider preference, the model default — is used only when the current
+ *  model actually supports it, so switching to a model that lacks that level
+ *  (e.g. a stale "low", or a custom agent's effort a new model doesn't offer)
+ *  falls through rather than sending an unsupported value. Order: preferred →
+ *  stored → model default → provider default → highest available. */
 function resolveThinking(
   providerId: string,
   levels: ThinkingLevel[],
   modelDefault?: string,
+  preferred?: string,
 ): string | undefined {
   const supports = (v: string | undefined) => !!v && levels.some((l) => l.value === v);
+  if (supports(preferred)) return preferred;
   const stored = localStorage.getItem(`thinkingBudget.${providerId}`);
   if (supports(stored ?? undefined)) return stored ?? undefined;
   const d = PROVIDER_DETAIL[providerId as keyof typeof PROVIDER_DETAIL];
@@ -148,6 +151,7 @@ export function Composer({
 }: Props) {
   const features = useAppStore((s) => s.features);
   const modelCatalog = useAppStore((s) => s.modelCatalog);
+  const modelsByAgent = useAppStore((s) => s.modelsByAgent);
   const customAgents = useAppStore((s) => s.customAgents);
   const sandboxEngine = useAppStore((s) => s.sandboxEngine);
 
@@ -158,7 +162,15 @@ export function Composer({
   const [provider, setProvider] = useState(defaultProvider);
   const [model, setModel] = useState<string | undefined>(defaultModel);
   const [customAgentId, setCustomAgentId] = useState<string | undefined>(defaultCustomAgentId);
-  const activeMeta = lookupModel(modelCatalog, existingSession ? (activeModel ?? model) : model);
+  // Resolve the model within the SELECTED provider's list first: a model id
+  // shared across agents keeps only the first-discovered entry in the global
+  // `byId` view, which may belong to another provider and omit this provider's
+  // per-model metadata (e.g. codex's reasoning levels). Fall back to `byId` for
+  // ids the provider list doesn't carry (unknown/new models).
+  const activeModelId = existingSession ? (activeModel ?? model) : model;
+  const activeMeta =
+    lookupModelInList(modelsByAgent[provider], activeModelId) ??
+    lookupModel(modelCatalog, activeModelId);
   const modelSupportsThinking = activeMeta ? activeMeta.reasoning : true;
 
   const detail = PROVIDER_DETAIL[provider as keyof typeof PROVIDER_DETAIL];
@@ -196,16 +208,19 @@ export function Composer({
   customAgentsRef.current = customAgents;
 
   // When switching providers or models, restore the last-used level (validated
-  // against the new model's supported levels) — unless a custom agent is
-  // selected with its own reasoning budget, which takes precedence (runs after
-  // the provider change a custom pick triggers, so it wins). `thinkingLevels` is
-  // memoized, so this fires on genuine provider/model/custom-agent changes, not
-  // when the agent list mutates.
+  // against the new model's supported levels) — a custom agent's own reasoning
+  // budget takes precedence, but only when the current model supports it, so it
+  // can't send an unsupported value after a model switch (it's passed as the
+  // `preferred` candidate, which resolveThinking validates before every other
+  // fallback). `thinkingLevels` is memoized, so this fires on genuine
+  // provider/model/custom-agent changes, not when the agent list mutates.
   useEffect(() => {
     const custom = customAgentId
       ? customAgentsRef.current.find((a) => a.id === customAgentId)
       : undefined;
-    setThinkingValue(custom?.effort || resolveThinking(provider, thinkingLevels, modelReasoning));
+    setThinkingValue(
+      resolveThinking(provider, thinkingLevels, modelReasoning, custom?.effort ?? undefined),
+    );
   }, [provider, customAgentId, thinkingLevels, modelReasoning]);
 
   // Shared input core (textarea + `/`·`@`·`#` autocomplete + attachments +

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -1,9 +1,13 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { DirListing, PrSummary } from "@/api";
 import { Icon } from "@/components/Icon";
 import { Chip } from "@/components/ui/Chip";
 import { lookupModel } from "@/data/modelCatalog";
-import { PROVIDER_DETAIL } from "@/data/providerDetail";
+import {
+  PROVIDER_DETAIL,
+  type ThinkingLevel,
+  thinkingLevelsFromModel,
+} from "@/data/providerDetail";
 import { DEFAULT_PROVIDER_ID, isDockerSupported, providerLabel } from "@/data/providers";
 import type { LocalCommandAction } from "@/data/slashCommands";
 import type { AgentUsage } from "@/store";
@@ -97,12 +101,24 @@ interface Props {
   usage?: AgentUsage;
 }
 
-function resolveThinking(providerId: string): string | undefined {
-  const d = PROVIDER_DETAIL[providerId as keyof typeof PROVIDER_DETAIL];
-  const levels = d?.thinkingLevels ?? [];
+/** The effective thinking level for a provider/model. A stored per-provider
+ *  preference wins, but only when the current model still supports it — so
+ *  switching to a model that lacks that level (e.g. a stale "low" carried onto a
+ *  richer model) falls through to the model's own default rather than sending an
+ *  unsupported value. Order: stored (if supported) → model default → provider
+ *  default → highest available. */
+function resolveThinking(
+  providerId: string,
+  levels: ThinkingLevel[],
+  modelDefault?: string,
+): string | undefined {
+  const supports = (v: string | undefined) => !!v && levels.some((l) => l.value === v);
   const stored = localStorage.getItem(`thinkingBudget.${providerId}`);
-  if (stored && levels.some((l) => l.value === stored)) return stored;
-  return d?.defaultLevel ?? levels.at(-1)?.value;
+  if (supports(stored ?? undefined)) return stored ?? undefined;
+  const d = PROVIDER_DETAIL[providerId as keyof typeof PROVIDER_DETAIL];
+  if (supports(modelDefault)) return modelDefault;
+  if (supports(d?.defaultLevel)) return d?.defaultLevel;
+  return levels.at(-1)?.value;
 }
 
 export function Composer({
@@ -146,7 +162,19 @@ export function Composer({
   const modelSupportsThinking = activeMeta ? activeMeta.reasoning : true;
 
   const detail = PROVIDER_DETAIL[provider as keyof typeof PROVIDER_DETAIL];
-  const thinkingLevels = detail?.thinkingLevels ?? [];
+  // Prefer the levels the model itself reports (per-model, e.g. codex exposing
+  // low→ultra for a given model), falling back to the provider's static list for
+  // CLIs that don't report a per-model set. `modelReasoning` is the model's own
+  // default level, used to seed the picker. Both inputs are stable references
+  // (catalog entry / module const), so the memo — and the effect that depends on
+  // it — recompute only on genuine model/provider changes, not every render.
+  const modelReasoning = activeMeta?.defaultReasoning;
+  const modelReasoningLevels = activeMeta?.reasoningLevels;
+  const providerLevels = detail?.thinkingLevels;
+  const thinkingLevels = useMemo<ThinkingLevel[]>(() => {
+    const modelLevels = thinkingLevelsFromModel(modelReasoningLevels);
+    return modelLevels.length > 0 ? modelLevels : (providerLevels ?? []);
+  }, [modelReasoningLevels, providerLevels]);
 
   // A new-agent draft can still hold a docker-unsupported provider chosen
   // before the sandbox engine was switched to Docker. Block the send here —
@@ -158,7 +186,7 @@ export function Composer({
     !existingSession && sandboxEngine === "docker" && !isDockerSupported(provider);
 
   const [thinkingValue, setThinkingValue] = useState<string | undefined>(() =>
-    resolveThinking(defaultProvider),
+    resolveThinking(defaultProvider, thinkingLevels, modelReasoning),
   );
 
   // Latest custom agents, read via a ref inside the effect below so that
@@ -167,17 +195,18 @@ export function Composer({
   const customAgentsRef = useRef(customAgents);
   customAgentsRef.current = customAgents;
 
-  // When switching providers, restore the last-used level for that provider —
-  // unless a custom agent is selected with its own reasoning budget, which
-  // takes precedence (runs after the provider change a custom pick triggers,
-  // so it wins). Fires only on genuine provider/custom-agent *selection*
-  // changes, not when the agent list mutates.
+  // When switching providers or models, restore the last-used level (validated
+  // against the new model's supported levels) — unless a custom agent is
+  // selected with its own reasoning budget, which takes precedence (runs after
+  // the provider change a custom pick triggers, so it wins). `thinkingLevels` is
+  // memoized, so this fires on genuine provider/model/custom-agent changes, not
+  // when the agent list mutates.
   useEffect(() => {
     const custom = customAgentId
       ? customAgentsRef.current.find((a) => a.id === customAgentId)
       : undefined;
-    setThinkingValue(custom?.effort || resolveThinking(provider));
-  }, [provider, customAgentId]);
+    setThinkingValue(custom?.effort || resolveThinking(provider, thinkingLevels, modelReasoning));
+  }, [provider, customAgentId, thinkingLevels, modelReasoning]);
 
   // Shared input core (textarea + `/`·`@`·`#` autocomplete + attachments +
   // draft/seed). `onEnter` sends via a ref so the callback can reference the

--- a/src/data/modelCatalog/build.ts
+++ b/src/data/modelCatalog/build.ts
@@ -328,6 +328,10 @@ function metaFor(d: DiscoveredModel, index: ModelsDevIndex): ModelMeta {
     name: dev?.name ?? d.name ?? d.id,
     contextWindow: dev?.contextWindow || d.contextWindow || 0,
     reasoning: dev?.reasoning ?? d.reasoning ?? false,
+    // Reasoning levels/default come only from the CLI — models.dev doesn't carry
+    // them — so pass the discovered values straight through when present.
+    ...(d.reasoningLevels?.length ? { reasoningLevels: d.reasoningLevels } : {}),
+    ...(d.defaultReasoning ? { defaultReasoning: d.defaultReasoning } : {}),
     ...(dev?.family ? { family: dev.family } : {}),
     ...(dev?.releaseDate ? { releaseDate: dev.releaseDate } : {}),
   };

--- a/src/data/modelCatalog/index.ts
+++ b/src/data/modelCatalog/index.ts
@@ -11,7 +11,7 @@ import { buildCatalog } from "./build";
 import { fetchModelsDevIndex } from "./modelsDev";
 import type { UnifiedCatalog } from "./types";
 
-export { lookupModel } from "./normalize";
+export { lookupModel, lookupModelInList } from "./normalize";
 export type { ModelMeta, SlimCatalog } from "./types";
 
 const CACHE_KEY = "modelCatalog.cache.v14";

--- a/src/data/modelCatalog/index.ts
+++ b/src/data/modelCatalog/index.ts
@@ -14,7 +14,7 @@ import type { UnifiedCatalog } from "./types";
 export { lookupModel } from "./normalize";
 export type { ModelMeta, SlimCatalog } from "./types";
 
-const CACHE_KEY = "modelCatalog.cache.v13";
+const CACHE_KEY = "modelCatalog.cache.v14";
 const TTL_MS = 60 * 60 * 1000; // 1h
 
 const EMPTY: UnifiedCatalog = { byId: {}, byAgent: {} };

--- a/src/data/modelCatalog/normalize.ts
+++ b/src/data/modelCatalog/normalize.ts
@@ -53,3 +53,20 @@ export function lookupModel(
   }
   return undefined;
 }
+
+/** Look up a model within one provider's list, using the same id-candidate
+ *  matching as `lookupModel`. Prefer this over the global `byId` view when the
+ *  caller knows the provider: a model id shared across agents keeps only the
+ *  first-discovered entry in `byId`, which may belong to another provider and
+ *  lack this provider's metadata (e.g. codex's per-model reasoning levels). */
+export function lookupModelInList(
+  models: ModelMeta[] | undefined,
+  rawId: string | undefined,
+): ModelMeta | undefined {
+  if (!models || !rawId) return undefined;
+  for (const key of modelIdCandidates(rawId)) {
+    const hit = models.find((m) => m.id === key);
+    if (hit) return hit;
+  }
+  return undefined;
+}

--- a/src/data/modelCatalog/types.ts
+++ b/src/data/modelCatalog/types.ts
@@ -16,6 +16,13 @@ export interface ModelMeta {
   contextWindow: number;
   /** Whether the model supports reasoning / extended thinking. */
   reasoning: boolean;
+  /** Reasoning-effort levels the model supports, in the CLI's own order (e.g.
+   *  codex ["low","medium","high","xhigh","max","ultra"]). Present only when the
+   *  CLI reports them; drives a per-model thinking picker instead of a hardcoded
+   *  provider list. */
+  reasoningLevels?: string[];
+  /** The model's own default reasoning level, when the CLI reports one. */
+  defaultReasoning?: string;
   /** Model family from models.dev (e.g. "claude-opus", "claude-fable"), when
    *  known. Used to group/curate a provider's lineage without hardcoding names. */
   family?: string;
@@ -30,6 +37,8 @@ export interface DiscoveredModel {
   name?: string;
   contextWindow?: number;
   reasoning?: boolean;
+  reasoningLevels?: string[];
+  defaultReasoning?: string;
 }
 
 /** An agent and the models it supports. `providerHint` is set for agents with

--- a/src/data/providerDetail.ts
+++ b/src/data/providerDetail.ts
@@ -142,3 +142,28 @@ export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
     ],
   },
 };
+
+/** Display labels for known effort values, so model-reported levels (which come
+ *  as raw strings like "xhigh"/"ultra") render consistently with the static
+ *  provider lists. Unknown values fall back to a capitalized form. */
+const EFFORT_LABELS: Record<string, string> = {
+  off: "Off",
+  minimal: "Low",
+  low: "Low",
+  medium: "Med",
+  high: "High",
+  xhigh: "xHigh",
+  max: "Max",
+  ultra: "Ultra",
+};
+
+/** Label for a raw effort value (e.g. "xhigh" → "xHigh"). */
+export function effortLabel(value: string): string {
+  return EFFORT_LABELS[value] ?? value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+/** Turn a model's raw reasoning-effort values into labeled thinking levels,
+ *  preserving the CLI's order. Empty input yields an empty list. */
+export function thinkingLevelsFromModel(values: string[] | undefined): ThinkingLevel[] {
+  return (values ?? []).map((value) => ({ label: effortLabel(value), value }));
+}

--- a/tests/data/modelCatalog/modelCatalog.test.ts
+++ b/tests/data/modelCatalog/modelCatalog.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { buildCatalog, capPerGroup, dedupeBest } from "@/data/modelCatalog/build";
 import { indexModelsDev } from "@/data/modelCatalog/modelsDev";
-import { lookupModel, modelIdCandidates } from "@/data/modelCatalog/normalize";
+import { lookupModel, lookupModelInList, modelIdCandidates } from "@/data/modelCatalog/normalize";
 import type { AgentModels, ModelMeta, SlimCatalog } from "@/data/modelCatalog/types";
 
 const API = {
@@ -618,6 +618,48 @@ describe("lookupModel", () => {
   it("returns undefined for unknown or empty ids", () => {
     expect(lookupModel(catalog, "made-up")).toBeUndefined();
     expect(lookupModel(catalog, undefined)).toBeUndefined();
+  });
+});
+
+describe("lookupModelInList", () => {
+  // Two providers report the same id; only codex carries reasoning levels. The
+  // global byId view keeps whichever was discovered first, so a provider-scoped
+  // lookup must find codex's richer entry when codex is the selected provider.
+  const codexEntry: ModelMeta = {
+    id: "gpt-5.6-sol",
+    name: "GPT-5.6-Sol",
+    contextWindow: 272_000,
+    reasoning: true,
+    reasoningLevels: ["low", "high", "max"],
+    defaultReasoning: "low",
+  };
+  const opencodeEntry: ModelMeta = {
+    id: "gpt-5.6-sol",
+    name: "GPT-5.6-Sol",
+    contextWindow: 272_000,
+    reasoning: true,
+  };
+
+  it("finds the provider's own entry, including per-model reasoning metadata", () => {
+    const hit = lookupModelInList([codexEntry], "gpt-5.6-sol");
+    expect(hit?.reasoningLevels).toEqual(["low", "high", "max"]);
+    expect(hit?.defaultReasoning).toBe("low");
+  });
+
+  it("matches id candidates (provider prefix / date suffix)", () => {
+    expect(lookupModelInList([codexEntry], "openai/gpt-5.6-sol")?.name).toBe("GPT-5.6-Sol");
+  });
+
+  it("does not return another provider's leaner entry", () => {
+    // opencode's entry lacks reasoning levels; scoping to it must not surface
+    // codex's, so callers can fall back to their default.
+    expect(lookupModelInList([opencodeEntry], "gpt-5.6-sol")?.reasoningLevels).toBeUndefined();
+  });
+
+  it("returns undefined for empty/unknown input", () => {
+    expect(lookupModelInList(undefined, "gpt-5.6-sol")).toBeUndefined();
+    expect(lookupModelInList([codexEntry], undefined)).toBeUndefined();
+    expect(lookupModelInList([codexEntry], "made-up")).toBeUndefined();
   });
 });
 

--- a/tests/data/modelCatalog/modelCatalog.test.ts
+++ b/tests/data/modelCatalog/modelCatalog.test.ts
@@ -297,6 +297,41 @@ describe("buildCatalog", () => {
     expect(cat.byAgent.codex).toHaveLength(1);
   });
 
+  it("passes through a model's reasoning levels and default (CLI-only metadata)", () => {
+    const agents: AgentModels[] = [
+      {
+        agent: "codex",
+        models: [
+          {
+            id: "gpt-5.5",
+            reasoning: true,
+            reasoningLevels: ["low", "medium", "high", "xhigh", "max", "ultra"],
+            defaultReasoning: "low",
+          },
+        ],
+      },
+    ];
+    const cat = buildCatalog(agents, idx);
+    expect(cat.byId["gpt-5.5"].reasoningLevels).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+      "ultra",
+    ]);
+    expect(cat.byId["gpt-5.5"].defaultReasoning).toBe("low");
+  });
+
+  it("omits reasoning levels when the CLI reports none", () => {
+    const agents: AgentModels[] = [
+      { agent: "codex", models: [{ id: "gpt-5.5", reasoning: true }] },
+    ];
+    const cat = buildCatalog(agents, idx);
+    expect(cat.byId["gpt-5.5"].reasoningLevels).toBeUndefined();
+    expect(cat.byId["gpt-5.5"].defaultReasoning).toBeUndefined();
+  });
+
   it("offers no selectable models for Antigravity (agy ignores model selection)", () => {
     // Discovery contributes no hint and no models for antigravity, so the
     // picker shows it as a fixed-model agent rather than offering Gemini ids

--- a/tests/data/modelCatalog/refresh.test.ts
+++ b/tests/data/modelCatalog/refresh.test.ts
@@ -15,7 +15,7 @@ vi.mock("@/data/modelCatalog/modelsDev", () => ({
   fetchModelsDevIndex: mocks.fetchModelsDevIndex,
 }));
 
-const CACHE_KEY = "modelCatalog.cache.v13";
+const CACHE_KEY = "modelCatalog.cache.v14";
 
 const storage = new Map<string, string>();
 


### PR DESCRIPTION
## Summary

The thinking-effort picker hardcoded a Low/Med/High list per provider, so codex models were capped at "high" — even though models like **gpt-5.6-sol** support `xhigh`/`max`/`ultra`. codex already reports the full set in `~/.codex/models_cache.json` (`supported_reasoning_levels` + `default_reasoning_level`), but the catalog collapsed it to a boolean and threw the rest away.

This makes the reasoning levels **dynamic and per-model**: the picker now offers whatever the selected model actually supports, defaulting to the model's own default level.

## Changes

- **`model_catalog.rs`** — `DiscoveredModel` gains `reasoning_levels` + `default_reasoning`; `parse_codex_cache` extracts the effort strings and the model's default level instead of just a supports-reasoning bool.
- **catalog types / `build.ts`** — `ModelMeta` carries both fields; `metaFor` passes the CLI-reported values through (models.dev has no reasoning metadata, so the CLI is authoritative).
- **`index.ts`** — cache key bumped `v13` → `v14` so existing caches rebuild with the new fields.
- **`providerDetail.ts`** — shared `effortLabel()` + `thinkingLevelsFromModel()` with a reusable `EFFORT_LABELS` map so raw values (`xhigh`/`ultra`) render nicely.
- **`Composer/index.tsx`** — the picker prefers the model's reported levels, falling back to the provider's static list for CLIs that don't report a per-model set (claude/pi/cursor/opencode unchanged). `resolveThinking` validates the stored per-provider preference against the current model and drops to the model default when unsupported — **fixing a stale-value bug** where a level set on one model silently carried onto another.

The backend arg builder (`-c reasoning_effort="..."`) already passes any string verbatim, so no invocation change was needed.

## Behavior notes

- A fresh session defaults to the model's own `default_reasoning_level` (e.g. gpt-5.6-sol → `low`); bumping the chip sticks per-provider.
- claude keeps its session-level `--effort` spawn flag and static list.

## Testing

- `tsc --noEmit` clean, `biome check` clean
- Rust catalog tests pass (6)
- Full frontend suite passes (434, incl. 2 new tests for the passthrough + empty case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)