### PR TITLE
feat(projects): multi-repo projects — grouping, settings, per-repo labels

### DIFF
--- a/src-tauri/migrations/0022_repo_label.sql
+++ b/src-tauri/migrations/0022_repo_label.sql
@@ -1,0 +1,4 @@
+-- Per-repo display label for multi-repo projects ("Frontend", "Gateway", …).
+-- NULL falls back to the folder basename in the UI. Independent of the
+-- project's own name, which labels the whole group.
+ALTER TABLE repos ADD COLUMN label TEXT;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -172,9 +172,11 @@ pub fn remove_workspace_repo(
     supervisor.remove_workspace_repo(PathBuf::from(repo_path))
 }
 
-/// Attach a repo to an existing project (multi-repo projects). A non-git
-/// folder is initialized first, mirroring `add_workspace_repo`, so any local
-/// folder can join a project.
+/// Attach a repo to an existing project (multi-repo projects). Two phases,
+/// deliberately ordered so a doomed attach can never mutate the picked
+/// folder: the DB attach validates the project and commits first, and only
+/// then is a non-git folder initialized (mirroring `add_workspace_repo`).
+/// If that filesystem step fails, the DB attach is rolled back precisely.
 #[tauri::command]
 pub async fn attach_repo_to_project(
     supervisor: State<'_, Arc<Supervisor>>,
@@ -182,15 +184,16 @@ pub async fn attach_repo_to_project(
     repo_path: String,
 ) -> Result<Workspace> {
     let sup = supervisor.inner().clone();
-    // Validate the target project before ensure_git_repo touches the picked
-    // folder: a stale settings modal (project deleted meanwhile) must fail
-    // cleanly, not leave a freshly initialized `.git` behind.
-    if !sup.project_exists(&project_id) {
-        return Err(Error::Other(format!("project not found: {project_id}")));
-    }
     let path = PathBuf::from(repo_path);
-    new_project::ensure_git_repo(&path).await?;
-    sup.attach_repo_to_project(&project_id, path)
+    let outcome = sup.attach_repo_to_project(&project_id, &path)?;
+    if let Err(e) = new_project::ensure_git_repo(&path).await {
+        // Roll back the row(s) the DB phase wrote; best-effort — it re-applies
+        // keys we wrote moments ago on a local connection, so a failure here
+        // means the DB itself is gone, and the init error is the one to show.
+        let _ = sup.undo_attach(&outcome);
+        return Err(e);
+    }
+    Ok(sup.workspace.current().expect("workspace initialized"))
 }
 
 /// Detach a repo from a project. Rejects the project's last repo and any repo

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -172,6 +172,32 @@ pub fn remove_workspace_repo(
     supervisor.remove_workspace_repo(PathBuf::from(repo_path))
 }
 
+/// Attach a repo to an existing project (multi-repo projects). A non-git
+/// folder is initialized first, mirroring `add_workspace_repo`, so any local
+/// folder can join a project.
+#[tauri::command]
+pub async fn attach_repo_to_project(
+    supervisor: State<'_, Arc<Supervisor>>,
+    project_id: String,
+    repo_path: String,
+) -> Result<Workspace> {
+    let sup = supervisor.inner().clone();
+    let path = PathBuf::from(repo_path);
+    new_project::ensure_git_repo(&path).await?;
+    sup.attach_repo_to_project(&project_id, path)
+}
+
+/// Detach a repo from a project. Rejects the project's last repo and any repo
+/// still referenced by an agent checkout (live or archived).
+#[tauri::command]
+pub fn detach_repo_from_project(
+    supervisor: State<'_, Arc<Supervisor>>,
+    project_id: String,
+    repo_path: String,
+) -> Result<Workspace> {
+    supervisor.detach_repo_from_project(&project_id, PathBuf::from(repo_path))
+}
+
 /// Rename a project — a custom display label independent of its folder name.
 /// The sidebar and Project Settings header show this instead of the basename.
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -198,6 +198,17 @@ pub fn detach_repo_from_project(
     supervisor.detach_repo_from_project(&project_id, PathBuf::from(repo_path))
 }
 
+/// Set a repo's display label within its project ("Frontend", "Gateway").
+/// Blank clears back to the folder-basename fallback.
+#[tauri::command]
+pub fn set_repo_label(
+    supervisor: State<'_, Arc<Supervisor>>,
+    repo_path: String,
+    label: String,
+) -> Result<Workspace> {
+    supervisor.set_repo_label(PathBuf::from(repo_path), &label)
+}
+
 /// Rename a project — a custom display label independent of its folder name.
 /// The sidebar and Project Settings header show this instead of the basename.
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -182,6 +182,12 @@ pub async fn attach_repo_to_project(
     repo_path: String,
 ) -> Result<Workspace> {
     let sup = supervisor.inner().clone();
+    // Validate the target project before ensure_git_repo touches the picked
+    // folder: a stale settings modal (project deleted meanwhile) must fail
+    // cleanly, not leave a freshly initialized `.git` behind.
+    if !sup.project_exists(&project_id) {
+        return Err(Error::Other(format!("project not found: {project_id}")));
+    }
     let path = PathBuf::from(repo_path);
     new_project::ensure_git_repo(&path).await?;
     sup.attach_repo_to_project(&project_id, path)

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -147,6 +147,7 @@ const MIGRATIONS: &[&str] = &[
     include_str!("../migrations/0019_workflows_v1.sql"),
     include_str!("../migrations/0020_workflow_base_branch.sql"),
     include_str!("../migrations/0021_session_forked_context.sql"),
+    include_str!("../migrations/0022_repo_label.sql"),
 ];
 
 fn get_migrations() -> Migrations<'static> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1155,6 +1155,8 @@ pub fn run() {
             commands::get_agent_diff_stats,
             commands::add_workspace_repo,
             commands::remove_workspace_repo,
+            commands::attach_repo_to_project,
+            commands::detach_repo_from_project,
             commands::rename_project,
             commands::delete_project,
             commands::project_has_running_agents,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1157,6 +1157,7 @@ pub fn run() {
             commands::remove_workspace_repo,
             commands::attach_repo_to_project,
             commands::detach_repo_from_project,
+            commands::set_repo_label,
             commands::rename_project,
             commands::delete_project,
             commands::project_has_running_agents,

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -440,6 +440,10 @@ impl Supervisor {
             .detach_repo_from_project(project_id, &repo_path)
     }
 
+    pub fn set_repo_label(&self, repo_path: PathBuf, label: &str) -> Result<Workspace> {
+        self.workspace.set_repo_label(&repo_path, label)
+    }
+
     pub fn rename_project(&self, project_id: &str, name: &str) -> Result<Workspace> {
         self.workspace.rename_project(project_id, name)
     }

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -423,6 +423,10 @@ impl Supervisor {
         self.workspace.remove_workspace_repo(&repo_path)
     }
 
+    pub fn project_exists(&self, project_id: &str) -> bool {
+        self.workspace.project_exists(project_id)
+    }
+
     pub fn attach_repo_to_project(
         &self,
         project_id: &str,

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -423,6 +423,23 @@ impl Supervisor {
         self.workspace.remove_workspace_repo(&repo_path)
     }
 
+    pub fn attach_repo_to_project(
+        &self,
+        project_id: &str,
+        repo_path: PathBuf,
+    ) -> Result<Workspace> {
+        self.workspace.attach_repo_to_project(project_id, repo_path)
+    }
+
+    pub fn detach_repo_from_project(
+        &self,
+        project_id: &str,
+        repo_path: PathBuf,
+    ) -> Result<Workspace> {
+        self.workspace
+            .detach_repo_from_project(project_id, &repo_path)
+    }
+
     pub fn rename_project(&self, project_id: &str, name: &str) -> Result<Workspace> {
         self.workspace.rename_project(project_id, name)
     }

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -423,16 +423,19 @@ impl Supervisor {
         self.workspace.remove_workspace_repo(&repo_path)
     }
 
-    pub fn project_exists(&self, project_id: &str) -> bool {
-        self.workspace.project_exists(project_id)
-    }
-
+    /// DB phase of an attach (validates + commits, no filesystem access).
+    /// The command layer mutates the folder only after this succeeds and
+    /// calls [`Self::undo_attach`] if that later step fails.
     pub fn attach_repo_to_project(
         &self,
         project_id: &str,
-        repo_path: PathBuf,
-    ) -> Result<Workspace> {
+        repo_path: &std::path::Path,
+    ) -> Result<crate::workspace::AttachOutcome> {
         self.workspace.attach_repo_to_project(project_id, repo_path)
+    }
+
+    pub fn undo_attach(&self, outcome: &crate::workspace::AttachOutcome) -> Result<()> {
+        self.workspace.undo_attach(outcome)
     }
 
     pub fn detach_repo_from_project(

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -247,6 +247,33 @@ pub struct ProjectRef {
     pub label: Option<String>,
 }
 
+/// What the DB phase of an attach changed, so the command layer can undo it
+/// precisely if the follow-up filesystem step (`ensure_git_repo`) fails. The
+/// filesystem is only mutated after the DB phase commits — see
+/// `commands::attach_repo_to_project`.
+#[derive(Debug, Clone)]
+pub enum AttachOutcome {
+    /// The path already belonged to the target project — nothing changed.
+    AlreadyAttached,
+    /// A fresh repos row was inserted.
+    Inserted { repo_id: String },
+    /// An existing pinned repo was moved out of an empty source project.
+    Moved {
+        repo_id: String,
+        source_project_id: String,
+        /// Set when the emptied source project row was dropped; kept so undo
+        /// can re-create it verbatim.
+        dropped_source: Option<DroppedProject>,
+    },
+}
+
+/// Fields of a project row dropped during an attach-move, for undo.
+#[derive(Debug, Clone)]
+pub struct DroppedProject {
+    pub name: String,
+    pub created_at: i64,
+}
+
 // ── Helpers ────────────────────────────────────────────────────────────────
 
 /// Runtime status is not stored. Derive it from durable dispositions plus
@@ -494,21 +521,6 @@ impl WorkspaceManager {
         Ok(self.current().expect("workspace initialized"))
     }
 
-    /// Whether a project row exists. The attach command checks this *before*
-    /// `ensure_git_repo` can initialize the picked folder, so a stale settings
-    /// modal can't leave a fresh `.git` on disk as the side effect of an
-    /// attach that was doomed to fail.
-    pub fn project_exists(&self, project_id: &str) -> bool {
-        let conn = self.db.lock();
-        conn.query_row(
-            "SELECT COUNT(*) FROM projects WHERE id = ?1",
-            [project_id],
-            |row| row.get::<_, i64>(0),
-        )
-        .map(|c| c > 0)
-        .unwrap_or(false)
-    }
-
     /// Attach a repo to an existing project, making it a multi-repo project.
     /// An unpinned path is inserted under the target project; a path already
     /// attached to the target is a no-op. A path pinned as its own project is
@@ -516,22 +528,23 @@ impl WorkspaceManager {
     /// runs) — its emptied project row is then removed. A path belonging to a
     /// project with history is rejected: moving it would strand that project's
     /// agents under a project the repo no longer belongs to.
+    ///
+    /// This is the DB phase only, one atomic transaction, and it runs *before*
+    /// any filesystem mutation: the command layer initializes a non-git folder
+    /// only after this commits, and calls [`Self::undo_attach`] with the
+    /// returned outcome if that on-disk step fails. Ordering is the point — a
+    /// doomed attach (stale modal, deleted project) must never touch the
+    /// picked folder.
     pub fn attach_repo_to_project(
         &self,
         project_id: &str,
-        repo_path: PathBuf,
-    ) -> Result<Workspace> {
-        if !repo_path.join(".git").exists() {
-            return Err(Error::InvalidPath(format!(
-                "not a git repository: {}",
-                repo_path.display()
-            )));
-        }
-
-        let conn = self.db.lock();
+        repo_path: &Path,
+    ) -> Result<AttachOutcome> {
+        let mut conn = self.db.lock();
+        let tx = conn.transaction()?;
         let path_str = repo_path.to_string_lossy().to_string();
 
-        let target_exists: bool = conn
+        let target_exists: bool = tx
             .query_row(
                 "SELECT COUNT(*) FROM projects WHERE id = ?1",
                 [project_id],
@@ -542,7 +555,7 @@ impl WorkspaceManager {
             return Err(Error::Other(format!("project not found: {project_id}")));
         }
 
-        let existing: Option<(String, String)> = conn
+        let existing: Option<(String, String)> = tx
             .query_row(
                 "SELECT id, project_id FROM repos WHERE path = ?1",
                 [&path_str],
@@ -550,24 +563,25 @@ impl WorkspaceManager {
             )
             .ok();
 
-        match existing {
+        let outcome = match existing {
             None => {
                 let repo_id = uuid::Uuid::new_v4().to_string();
-                conn.execute(
+                tx.execute(
                     "INSERT INTO repos (id, project_id, path, created_at) VALUES (?1, ?2, ?3, ?4)",
                     rusqlite::params![repo_id, project_id, path_str, now_millis()],
                 )?;
+                AttachOutcome::Inserted { repo_id }
             }
-            Some((_, ref pid)) if pid == project_id => {} // already attached
-            Some((_, source_pid)) => {
-                let in_use: i64 = conn.query_row(
+            Some((_, ref pid)) if pid == project_id => AttachOutcome::AlreadyAttached,
+            Some((repo_id, source_pid)) => {
+                let in_use: i64 = tx.query_row(
                     "SELECT (SELECT COUNT(*) FROM workspaces WHERE project_id = ?1)
                           + (SELECT COUNT(*) FROM wf_run WHERE project_id = ?1)",
                     [&source_pid],
                     |row| row.get(0),
                 )?;
                 if in_use > 0 {
-                    let source_name: String = conn
+                    let source_name: String = tx
                         .query_row(
                             "SELECT name FROM projects WHERE id = ?1",
                             [&source_pid],
@@ -579,25 +593,72 @@ impl WorkspaceManager {
                          workflow runs. Delete those first, or attach a different repo."
                     )));
                 }
-                conn.execute(
-                    "UPDATE repos SET project_id = ?1 WHERE path = ?2",
-                    rusqlite::params![project_id, path_str],
+                tx.execute(
+                    "UPDATE repos SET project_id = ?1 WHERE id = ?2",
+                    rusqlite::params![project_id, repo_id],
                 )?;
                 // The source project is empty and now repo-less — drop the row
-                // so it doesn't linger as an invisible orphan.
-                let repos_left: i64 = conn.query_row(
+                // so it doesn't linger as an invisible orphan. Keep its fields
+                // so undo can restore it verbatim.
+                let repos_left: i64 = tx.query_row(
                     "SELECT COUNT(*) FROM repos WHERE project_id = ?1",
                     [&source_pid],
                     |row| row.get(0),
                 )?;
-                if repos_left == 0 {
-                    conn.execute("DELETE FROM projects WHERE id = ?1", [&source_pid])?;
+                let dropped_source = if repos_left == 0 {
+                    let (name, created_at): (String, i64) = tx.query_row(
+                        "SELECT name, created_at FROM projects WHERE id = ?1",
+                        [&source_pid],
+                        |row| Ok((row.get(0)?, row.get(1)?)),
+                    )?;
+                    tx.execute("DELETE FROM projects WHERE id = ?1", [&source_pid])?;
+                    Some(DroppedProject { name, created_at })
+                } else {
+                    None
+                };
+                AttachOutcome::Moved {
+                    repo_id,
+                    source_project_id: source_pid,
+                    dropped_source,
                 }
             }
-        }
+        };
 
-        drop(conn);
-        Ok(self.current().expect("workspace initialized"))
+        tx.commit()?;
+        Ok(outcome)
+    }
+
+    /// Undo the DB phase of an attach after the follow-up filesystem step
+    /// failed. Restores exactly what [`Self::attach_repo_to_project`] changed
+    /// moments earlier: a fresh row is deleted, a moved row is pointed back at
+    /// its source project, and a dropped source project row is re-created.
+    pub fn undo_attach(&self, outcome: &AttachOutcome) -> Result<()> {
+        let mut conn = self.db.lock();
+        let tx = conn.transaction()?;
+        match outcome {
+            AttachOutcome::AlreadyAttached => {}
+            AttachOutcome::Inserted { repo_id } => {
+                tx.execute("DELETE FROM repos WHERE id = ?1", [repo_id])?;
+            }
+            AttachOutcome::Moved {
+                repo_id,
+                source_project_id,
+                dropped_source,
+            } => {
+                if let Some(p) = dropped_source {
+                    tx.execute(
+                        "INSERT OR IGNORE INTO projects (id, name, created_at) VALUES (?1, ?2, ?3)",
+                        rusqlite::params![source_project_id, p.name, p.created_at],
+                    )?;
+                }
+                tx.execute(
+                    "UPDATE repos SET project_id = ?1 WHERE id = ?2",
+                    rusqlite::params![source_project_id, repo_id],
+                )?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
     }
 
     /// Detach a repo from a project. Guarded twice: the last repo can't be
@@ -2990,7 +3051,9 @@ mod tests {
         let cur = wm.current().unwrap();
         let project_id = cur.projects[0].project_id.clone();
 
-        let cur = wm.attach_repo_to_project(&project_id, b.clone()).unwrap();
+        let outcome = wm.attach_repo_to_project(&project_id, &b).unwrap();
+        assert!(matches!(outcome, AttachOutcome::Inserted { .. }));
+        let cur = wm.current().unwrap();
         assert_eq!(cur.repos.len(), 2);
         assert!(
             cur.projects.iter().all(|p| p.project_id == project_id),
@@ -2998,8 +3061,16 @@ mod tests {
         );
 
         // Re-attaching the same path is a no-op, not an error.
-        let cur = wm.attach_repo_to_project(&project_id, b).unwrap();
-        assert_eq!(cur.repos.len(), 2);
+        let outcome = wm.attach_repo_to_project(&project_id, &b).unwrap();
+        assert!(matches!(outcome, AttachOutcome::AlreadyAttached));
+        assert_eq!(wm.current().unwrap().repos.len(), 2);
+
+        // Undoing an insert removes exactly the inserted row.
+        let outcome = wm
+            .attach_repo_to_project(&project_id, &td.path().join("c"))
+            .unwrap();
+        wm.undo_attach(&outcome).unwrap();
+        assert_eq!(wm.current().unwrap().repos.len(), 2);
     }
 
     #[test]
@@ -3032,13 +3103,39 @@ mod tests {
 
         // `b` has no agents/runs, so it folds into `a`'s project and its own
         // now-empty project row is removed.
-        let cur = wm.attach_repo_to_project(&pid_a, b).unwrap();
+        let outcome = wm.attach_repo_to_project(&pid_a, &b).unwrap();
+        let cur = wm.current().unwrap();
         assert!(cur.projects.iter().all(|p| p.project_id == pid_a));
         let count: i64 = db
             .lock()
             .query_row("SELECT COUNT(*) FROM projects", [], |r| r.get(0))
             .unwrap();
         assert_eq!(count, 1, "emptied source project row dropped");
+
+        // Undoing the move restores the repo's source project — including the
+        // dropped project row, verbatim.
+        assert!(matches!(
+            outcome,
+            AttachOutcome::Moved {
+                dropped_source: Some(_),
+                ..
+            }
+        ));
+        wm.undo_attach(&outcome).unwrap();
+        let cur = wm.current().unwrap();
+        assert_eq!(
+            cur.projects
+                .iter()
+                .find(|p| p.path == b)
+                .unwrap()
+                .project_id,
+            pid_b
+        );
+        let count: i64 = db
+            .lock()
+            .query_row("SELECT COUNT(*) FROM projects", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 2, "dropped source project row restored");
     }
 
     #[test]
@@ -3071,8 +3168,27 @@ mod tests {
         );
         wm.add_agent(&mut rec).unwrap();
 
-        let err = wm.attach_repo_to_project(&pid_a, b).unwrap_err();
+        let err = wm.attach_repo_to_project(&pid_a, &b).unwrap_err();
         assert!(err.to_string().contains("agents or workflow runs"));
+
+        // A rejected attach must not have changed anything (transaction
+        // rolled back): `b` still belongs to its own project.
+        let cur = wm.current().unwrap();
+        assert_ne!(
+            cur.projects
+                .iter()
+                .find(|p| p.path == b)
+                .unwrap()
+                .project_id,
+            pid_a
+        );
+
+        // Attaching to a project that no longer exists fails without a row.
+        let err = wm
+            .attach_repo_to_project("gone", &td.path().join("c"))
+            .unwrap_err();
+        assert!(err.to_string().contains("project not found"));
+        assert_eq!(wm.current().unwrap().repos.len(), 2);
     }
 
     #[test]
@@ -3092,12 +3208,12 @@ mod tests {
         assert!(err.to_string().contains("at least one repository"));
 
         // A freshly attached, unused repo detaches cleanly.
-        wm.attach_repo_to_project(&project_id, b.clone()).unwrap();
+        wm.attach_repo_to_project(&project_id, &b).unwrap();
         let cur = wm.detach_repo_from_project(&project_id, &b).unwrap();
         assert_eq!(cur.repos.len(), 1);
 
         // A repo with an agent checkout is protected from the FK cascade.
-        wm.attach_repo_to_project(&project_id, b.clone()).unwrap();
+        wm.attach_repo_to_project(&project_id, &b).unwrap();
         let mut rec = new_agent_record(
             "dolomites".into(),
             "a".into(),

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -494,6 +494,21 @@ impl WorkspaceManager {
         Ok(self.current().expect("workspace initialized"))
     }
 
+    /// Whether a project row exists. The attach command checks this *before*
+    /// `ensure_git_repo` can initialize the picked folder, so a stale settings
+    /// modal can't leave a fresh `.git` on disk as the side effect of an
+    /// attach that was doomed to fail.
+    pub fn project_exists(&self, project_id: &str) -> bool {
+        let conn = self.db.lock();
+        conn.query_row(
+            "SELECT COUNT(*) FROM projects WHERE id = ?1",
+            [project_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .map(|c| c > 0)
+        .unwrap_or(false)
+    }
+
     /// Attach a repo to an existing project, making it a multi-repo project.
     /// An unpinned path is inserted under the target project; a path already
     /// attached to the target is a no-op. A path pinned as its own project is

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -242,6 +242,9 @@ pub struct ProjectRef {
     pub path: PathBuf,
     pub name: String,
     pub project_id: String,
+    /// Per-repo display label ("Frontend", "Gateway"); `None` falls back to
+    /// the folder basename. Distinct from `name`, which labels the project.
+    pub label: Option<String>,
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -632,6 +635,29 @@ impl WorkspaceManager {
         }
 
         conn.execute("DELETE FROM repos WHERE id = ?1", [&repo_id])?;
+        drop(conn);
+        Ok(self.current().expect("workspace initialized"))
+    }
+
+    /// Set a repo's display label ("Frontend", "Gateway"), independent of its
+    /// folder name. A blank label clears back to the basename fallback.
+    pub fn set_repo_label(&self, repo_path: &Path, label: &str) -> Result<Workspace> {
+        let trimmed = label.trim();
+        let value: Option<&str> = if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        };
+
+        let conn = self.db.lock();
+        let path_str = repo_path.to_string_lossy().to_string();
+        let changed = conn.execute(
+            "UPDATE repos SET label = ?1 WHERE path = ?2",
+            rusqlite::params![value, path_str],
+        )?;
+        if changed == 0 {
+            return Err(Error::Other(format!("repo not found: {path_str}")));
+        }
         drop(conn);
         Ok(self.current().expect("workspace initialized"))
     }
@@ -1739,7 +1765,7 @@ impl WorkspaceManager {
     /// than the repo silently vanishing from the sidebar.
     fn query_project_refs(conn: &Connection) -> Vec<ProjectRef> {
         let mut stmt = match conn.prepare(
-            "SELECT r.path, p.name, p.id
+            "SELECT r.path, p.name, p.id, r.label
              FROM repos r LEFT JOIN projects p ON p.id = r.project_id
              ORDER BY r.created_at",
         ) {
@@ -1750,6 +1776,7 @@ impl WorkspaceManager {
             let path: String = row.get(0)?;
             let name: Option<String> = row.get(1)?;
             let project_id: Option<String> = row.get(2)?;
+            let label: Option<String> = row.get(3)?;
             let name = name.unwrap_or_else(|| {
                 Path::new(&path)
                     .file_name()
@@ -1761,6 +1788,7 @@ impl WorkspaceManager {
                 path: PathBuf::from(path),
                 name,
                 project_id: project_id.unwrap_or_default(),
+                label,
             })
         })
         .ok()
@@ -3066,6 +3094,25 @@ mod tests {
         wm.add_agent(&mut rec).unwrap();
         let err = wm.detach_repo_from_project(&project_id, &b).unwrap_err();
         assert!(err.to_string().contains("used by existing agents"));
+    }
+
+    #[test]
+    fn repo_label_round_trip_and_clear() {
+        let db = test_db();
+        let td = tempfile::tempdir().unwrap();
+        let repo = init_repo(td.path());
+        let wm = WorkspaceManager::new(db);
+        wm.add_workspace_repo(repo.clone()).unwrap();
+
+        let cur = wm.set_repo_label(&repo, "  Frontend  ").unwrap();
+        assert_eq!(cur.projects[0].label.as_deref(), Some("Frontend"));
+
+        // Blank clears back to the basename fallback (label = None).
+        let cur = wm.set_repo_label(&repo, "   ").unwrap();
+        assert_eq!(cur.projects[0].label, None);
+
+        let err = wm.set_repo_label(&td.path().join("nope"), "x").unwrap_err();
+        assert!(err.to_string().contains("repo not found"));
     }
 
     #[test]

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -491,6 +491,151 @@ impl WorkspaceManager {
         Ok(self.current().expect("workspace initialized"))
     }
 
+    /// Attach a repo to an existing project, making it a multi-repo project.
+    /// An unpinned path is inserted under the target project; a path already
+    /// attached to the target is a no-op. A path pinned as its own project is
+    /// *moved* here only when that project is empty (no agents, no workflow
+    /// runs) — its emptied project row is then removed. A path belonging to a
+    /// project with history is rejected: moving it would strand that project's
+    /// agents under a project the repo no longer belongs to.
+    pub fn attach_repo_to_project(
+        &self,
+        project_id: &str,
+        repo_path: PathBuf,
+    ) -> Result<Workspace> {
+        if !repo_path.join(".git").exists() {
+            return Err(Error::InvalidPath(format!(
+                "not a git repository: {}",
+                repo_path.display()
+            )));
+        }
+
+        let conn = self.db.lock();
+        let path_str = repo_path.to_string_lossy().to_string();
+
+        let target_exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) FROM projects WHERE id = ?1",
+                [project_id],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|c| c > 0)?;
+        if !target_exists {
+            return Err(Error::Other(format!("project not found: {project_id}")));
+        }
+
+        let existing: Option<(String, String)> = conn
+            .query_row(
+                "SELECT id, project_id FROM repos WHERE path = ?1",
+                [&path_str],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .ok();
+
+        match existing {
+            None => {
+                let repo_id = uuid::Uuid::new_v4().to_string();
+                conn.execute(
+                    "INSERT INTO repos (id, project_id, path, created_at) VALUES (?1, ?2, ?3, ?4)",
+                    rusqlite::params![repo_id, project_id, path_str, now_millis()],
+                )?;
+            }
+            Some((_, ref pid)) if pid == project_id => {} // already attached
+            Some((_, source_pid)) => {
+                let in_use: i64 = conn.query_row(
+                    "SELECT (SELECT COUNT(*) FROM workspaces WHERE project_id = ?1)
+                          + (SELECT COUNT(*) FROM wf_run WHERE project_id = ?1)",
+                    [&source_pid],
+                    |row| row.get(0),
+                )?;
+                if in_use > 0 {
+                    let source_name: String = conn
+                        .query_row(
+                            "SELECT name FROM projects WHERE id = ?1",
+                            [&source_pid],
+                            |row| row.get(0),
+                        )
+                        .unwrap_or_else(|_| "another project".into());
+                    return Err(Error::Other(format!(
+                        "{path_str} belongs to project \"{source_name}\", which has agents or \
+                         workflow runs. Delete those first, or attach a different repo."
+                    )));
+                }
+                conn.execute(
+                    "UPDATE repos SET project_id = ?1 WHERE path = ?2",
+                    rusqlite::params![project_id, path_str],
+                )?;
+                // The source project is empty and now repo-less — drop the row
+                // so it doesn't linger as an invisible orphan.
+                let repos_left: i64 = conn.query_row(
+                    "SELECT COUNT(*) FROM repos WHERE project_id = ?1",
+                    [&source_pid],
+                    |row| row.get(0),
+                )?;
+                if repos_left == 0 {
+                    conn.execute("DELETE FROM projects WHERE id = ?1", [&source_pid])?;
+                }
+            }
+        }
+
+        drop(conn);
+        Ok(self.current().expect("workspace initialized"))
+    }
+
+    /// Detach a repo from a project. Guarded twice: the last repo can't be
+    /// detached (delete the project instead), and a repo referenced by any
+    /// agent checkout — live or archived — can't be detached, because the
+    /// `worktrees.repo_id` FK cascade would silently destroy that agent's
+    /// tracked branches, PRs, and archive snapshots.
+    pub fn detach_repo_from_project(
+        &self,
+        project_id: &str,
+        repo_path: &Path,
+    ) -> Result<Workspace> {
+        let conn = self.db.lock();
+        let path_str = repo_path.to_string_lossy().to_string();
+
+        let (repo_id, actual_pid): (String, String) = conn
+            .query_row(
+                "SELECT id, project_id FROM repos WHERE path = ?1",
+                [&path_str],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .map_err(|_| Error::Other(format!("repo not found: {path_str}")))?;
+        if actual_pid != project_id {
+            return Err(Error::Other(format!(
+                "{path_str} does not belong to project {project_id}"
+            )));
+        }
+
+        let repo_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM repos WHERE project_id = ?1",
+            [project_id],
+            |row| row.get(0),
+        )?;
+        if repo_count <= 1 {
+            return Err(Error::Other(
+                "a project needs at least one repository — delete the project instead".into(),
+            ));
+        }
+
+        let checkouts: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM worktrees WHERE repo_id = ?1",
+            [&repo_id],
+            |row| row.get(0),
+        )?;
+        if checkouts > 0 {
+            return Err(Error::Other(format!(
+                "{path_str} is used by existing agents (including archived ones). \
+                 Delete those agents before detaching it."
+            )));
+        }
+
+        conn.execute("DELETE FROM repos WHERE id = ?1", [&repo_id])?;
+        drop(conn);
+        Ok(self.current().expect("workspace initialized"))
+    }
+
     /// Set a project's display name, decoupled from its folder basename. The
     /// name is trimmed; an empty name is rejected so a project always has a
     /// label. Does not touch the repo path or anything on disk.
@@ -2787,6 +2932,140 @@ mod tests {
         // may reference a now-deleted repo — that's fine, the sidebar
         // union logic handles it).
         assert_eq!(cur.agents.len(), 1);
+    }
+
+    #[test]
+    fn attach_repo_creates_multi_repo_project() {
+        let db = test_db();
+        let td = tempfile::tempdir().unwrap();
+        let a = init_repo(td.path());
+        let b = td.path().join("b");
+        std::fs::create_dir_all(b.join(".git")).unwrap();
+
+        let wm = WorkspaceManager::new(db);
+        wm.add_workspace_repo(a.clone()).unwrap();
+        let cur = wm.current().unwrap();
+        let project_id = cur.projects[0].project_id.clone();
+
+        let cur = wm.attach_repo_to_project(&project_id, b.clone()).unwrap();
+        assert_eq!(cur.repos.len(), 2);
+        assert!(
+            cur.projects.iter().all(|p| p.project_id == project_id),
+            "both repos share the project"
+        );
+
+        // Re-attaching the same path is a no-op, not an error.
+        let cur = wm.attach_repo_to_project(&project_id, b).unwrap();
+        assert_eq!(cur.repos.len(), 2);
+    }
+
+    #[test]
+    fn attach_repo_moves_empty_project_and_drops_it() {
+        let db = test_db();
+        let td = tempfile::tempdir().unwrap();
+        let a = init_repo(td.path());
+        let b = td.path().join("b");
+        std::fs::create_dir_all(b.join(".git")).unwrap();
+
+        let wm = WorkspaceManager::new(db.clone());
+        wm.add_workspace_repo(a.clone()).unwrap();
+        wm.add_workspace_repo(b.clone()).unwrap();
+        let cur = wm.current().unwrap();
+        let pid_a = cur
+            .projects
+            .iter()
+            .find(|p| p.path == a)
+            .unwrap()
+            .project_id
+            .clone();
+        let pid_b = cur
+            .projects
+            .iter()
+            .find(|p| p.path == b)
+            .unwrap()
+            .project_id
+            .clone();
+        assert_ne!(pid_a, pid_b);
+
+        // `b` has no agents/runs, so it folds into `a`'s project and its own
+        // now-empty project row is removed.
+        let cur = wm.attach_repo_to_project(&pid_a, b).unwrap();
+        assert!(cur.projects.iter().all(|p| p.project_id == pid_a));
+        let count: i64 = db
+            .lock()
+            .query_row("SELECT COUNT(*) FROM projects", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1, "emptied source project row dropped");
+    }
+
+    #[test]
+    fn attach_repo_refuses_project_with_agents() {
+        let db = test_db();
+        let td = tempfile::tempdir().unwrap();
+        let a = init_repo(td.path());
+        let b = td.path().join("b");
+        std::fs::create_dir_all(b.join(".git")).unwrap();
+
+        let wm = WorkspaceManager::new(db);
+        wm.add_workspace_repo(a.clone()).unwrap();
+        wm.add_workspace_repo(b.clone()).unwrap();
+        let cur = wm.current().unwrap();
+        let pid_a = cur
+            .projects
+            .iter()
+            .find(|p| p.path == a)
+            .unwrap()
+            .project_id
+            .clone();
+
+        let mut rec = new_agent_record(
+            "yosemite".into(),
+            "a".into(),
+            "claude".into(),
+            mk_repo(b.to_str().unwrap()),
+            "".into(),
+            AgentView::Custom,
+        );
+        wm.add_agent(&mut rec).unwrap();
+
+        let err = wm.attach_repo_to_project(&pid_a, b).unwrap_err();
+        assert!(err.to_string().contains("agents or workflow runs"));
+    }
+
+    #[test]
+    fn detach_repo_guards() {
+        let db = test_db();
+        let td = tempfile::tempdir().unwrap();
+        let a = init_repo(td.path());
+        let b = td.path().join("b");
+        std::fs::create_dir_all(b.join(".git")).unwrap();
+
+        let wm = WorkspaceManager::new(db);
+        wm.add_workspace_repo(a.clone()).unwrap();
+        let project_id = wm.current().unwrap().projects[0].project_id.clone();
+
+        // Last repo can't be detached.
+        let err = wm.detach_repo_from_project(&project_id, &a).unwrap_err();
+        assert!(err.to_string().contains("at least one repository"));
+
+        // A freshly attached, unused repo detaches cleanly.
+        wm.attach_repo_to_project(&project_id, b.clone()).unwrap();
+        let cur = wm.detach_repo_from_project(&project_id, &b).unwrap();
+        assert_eq!(cur.repos.len(), 1);
+
+        // A repo with an agent checkout is protected from the FK cascade.
+        wm.attach_repo_to_project(&project_id, b.clone()).unwrap();
+        let mut rec = new_agent_record(
+            "dolomites".into(),
+            "a".into(),
+            "claude".into(),
+            mk_repo(b.to_str().unwrap()),
+            "".into(),
+            AgentView::Custom,
+        );
+        wm.add_agent(&mut rec).unwrap();
+        let err = wm.detach_repo_from_project(&project_id, &b).unwrap_err();
+        assert!(err.to_string().contains("used by existing agents"));
     }
 
     #[test]

--- a/src/api.ts
+++ b/src/api.ts
@@ -92,13 +92,16 @@ export interface AgentRecord {
   sandbox_engine?: string | null;
 }
 
-/** A pinned repo joined with its owning project. `name` is the user-editable
- *  display label (defaults to the folder basename, survives rename/relocate);
- *  `project_id` addresses the project for rename/relocate + per-project settings. */
+/** A pinned repo joined with its owning project. `name` is the project's
+ *  user-editable display name (defaults to the folder basename, survives
+ *  rename/relocate); `project_id` addresses the project for rename/relocate +
+ *  per-project settings. `label` names this repo within a multi-repo project
+ *  ("Frontend", "Gateway"); null falls back to the folder basename. */
 export interface ProjectRef {
   path: string;
   name: string;
   project_id: string;
+  label: string | null;
 }
 
 export interface Workspace {
@@ -521,6 +524,10 @@ export const api = {
    *  referenced by agent checkouts (live or archived). */
   detachRepoFromProject: (projectId: string, repoPath: string) =>
     invoke<Workspace>("detach_repo_from_project", { projectId, repoPath }),
+  /** Set a repo's display label within its project. Blank clears back to the
+   *  folder-basename fallback. */
+  setRepoLabel: (repoPath: string, label: string) =>
+    invoke<Workspace>("set_repo_label", { repoPath, label }),
   /** Set a project's custom display name (independent of its folder). */
   renameProject: (projectId: string, name: string) =>
     invoke<Workspace>("rename_project", { projectId, name }),

--- a/src/api.ts
+++ b/src/api.ts
@@ -514,6 +514,13 @@ export const api = {
   addWorkspaceRepo: (repoPath: string) => invoke<Workspace>("add_workspace_repo", { repoPath }),
   removeWorkspaceRepo: (repoPath: string) =>
     invoke<Workspace>("remove_workspace_repo", { repoPath }),
+  /** Attach a repo to an existing project (multi-repo projects). */
+  attachRepoToProject: (projectId: string, repoPath: string) =>
+    invoke<Workspace>("attach_repo_to_project", { projectId, repoPath }),
+  /** Detach a repo from a project. Rejects the last repo and repos still
+   *  referenced by agent checkouts (live or archived). */
+  detachRepoFromProject: (projectId: string, repoPath: string) =>
+    invoke<Workspace>("detach_repo_from_project", { projectId, repoPath }),
   /** Set a project's custom display name (independent of its folder). */
   renameProject: (projectId: string, name: string) =>
     invoke<Workspace>("rename_project", { projectId, name }),

--- a/src/components/Composer/ProjectPicker.tsx
+++ b/src/components/Composer/ProjectPicker.tsx
@@ -4,25 +4,36 @@ import { DropdownItem, DropdownMenu, DropdownSection } from "@/components/ui/Dro
 import { Scrim } from "@/components/ui/Scrim";
 import { basename } from "@/util/format";
 
+export interface ProjectOption {
+  /** The project's primary repo path — what a draft/spawn targets. */
+  path: string;
+  /** Project display name. */
+  label: string;
+}
+
 interface Props {
-  /** Currently selected repo path. */
+  /** Currently selected repo path (a project's primary repo). */
   value: string;
-  /** Available repo paths (sidebar projects). */
-  repos: string[];
+  /** One option per project. */
+  projects: ProjectOption[];
   onChange: (repoPath: string) => void;
 }
 
 /** Project picker for the new-agent draft screen. Mirrors BranchPicker's
  *  dropdown, but rendered as an `empty-meta` pill so it sits inline with the
  *  branch/reroll pills below the composer. */
-export function ProjectPicker({ value, repos, onChange }: Props) {
+export function ProjectPicker({ value, projects, onChange }: Props) {
   const [open, setOpen] = useState(false);
+
+  // A stale draft can point at a repo that's no longer a project's primary
+  // (e.g. it was attached into another project); fall back to its basename.
+  const selectedLabel = projects.find((p) => p.path === value)?.label ?? basename(value);
 
   return (
     <span style={{ position: "relative" }}>
       <span className="pill is-action" onClick={() => setOpen((v) => !v)}>
         <Icon name="folder" />
-        <span className="v">{basename(value)}</span>
+        <span className="v">{selectedLabel}</span>
         <Icon name="chevD" size={9} />
       </span>
 
@@ -34,19 +45,19 @@ export function ProjectPicker({ value, repos, onChange }: Props) {
           >
             <DropdownSection>Projects</DropdownSection>
             <div style={{ maxHeight: 272, overflowY: "auto" }}>
-              {repos.map((r) => (
+              {projects.map((p) => (
                 <DropdownItem
-                  key={r}
-                  active={r === value}
+                  key={p.path}
+                  active={p.path === value}
                   style={{ padding: "7px 9px" }}
-                  title={r}
+                  title={p.path}
                   onClick={() => {
-                    onChange(r);
+                    onChange(p.path);
                     setOpen(false);
                   }}
                 >
                   <Icon name="folder" size={14} />
-                  <span className="di-l">{basename(r)}</span>
+                  <span className="di-l">{p.label}</span>
                 </DropdownItem>
               ))}
             </div>

--- a/src/components/ProjectSettings/GeneralSection.tsx
+++ b/src/components/ProjectSettings/GeneralSection.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useAppStore } from "@/store";
+import { RepositoriesField } from "./RepositoriesField";
 
 interface Props {
   projectId: string;
@@ -7,8 +8,9 @@ interface Props {
   currentName: string;
 }
 
-/** Project identity: a custom display name, independent of any folder name.
- *  Where the project lives on disk is per-repo — see RepositoriesSection. */
+/** Project identity: a custom display name (independent of any folder name)
+ *  and the repositories the project is made of. The project has no location
+ *  of its own — each repo row carries its own path. */
 export function GeneralSection({ projectId, currentName }: Props) {
   const renameProject = useAppStore((s) => s.renameProject);
 
@@ -39,7 +41,9 @@ export function GeneralSection({ projectId, currentName }: Props) {
     <section className="ps-section">
       <header className="ps-section-h">
         <h2 className="ps-section-t text-lg">General</h2>
-        <p className="ps-section-lead text-sm">The project&rsquo;s display name.</p>
+        <p className="ps-section-lead text-sm">
+          The project&rsquo;s display name and the repositories it&rsquo;s made of.
+        </p>
       </header>
 
       <div className="ps-field">
@@ -78,6 +82,8 @@ export function GeneralSection({ projectId, currentName }: Props) {
         </div>
         <p className="ps-hint text-xs">Shown in the sidebar. Independent of the folder name.</p>
       </div>
+
+      <RepositoriesField projectId={projectId} />
 
       {error && <div className="ps-error text-sm">{error}</div>}
     </section>

--- a/src/components/ProjectSettings/GeneralSection.tsx
+++ b/src/components/ProjectSettings/GeneralSection.tsx
@@ -1,26 +1,19 @@
-import { open } from "@tauri-apps/plugin-dialog";
 import { useState } from "react";
-import { Icon } from "@/components/Icon";
 import { useAppStore } from "@/store";
 
 interface Props {
   projectId: string;
   /** Current display name (from the store), used as the edit baseline. */
   currentName: string;
-  /** The repo's location on disk — the group's stable id. */
-  repoPath: string;
 }
 
-/** Project identity: a custom display name (independent of the folder) and the
- *  on-disk location. Renaming only relabels the project; changing the location
- *  repoints Fletch at a folder the user has already moved. */
-export function GeneralSection({ projectId, currentName, repoPath }: Props) {
+/** Project identity: a custom display name, independent of any folder name.
+ *  Where the project lives on disk is per-repo — see RepositoriesSection. */
+export function GeneralSection({ projectId, currentName }: Props) {
   const renameProject = useAppStore((s) => s.renameProject);
-  const relocateProject = useAppStore((s) => s.relocateProject);
 
   const [name, setName] = useState(currentName);
   const [saving, setSaving] = useState(false);
-  const [relocating, setRelocating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const trimmed = name.trim();
@@ -42,32 +35,11 @@ export function GeneralSection({ projectId, currentName, repoPath }: Props) {
     }
   }
 
-  async function changeLocation() {
-    if (relocating) return;
-    const picked = await open({
-      directory: true,
-      multiple: false,
-      title: "Select the project's new location",
-    });
-    if (typeof picked !== "string" || picked === repoPath) return;
-    setRelocating(true);
-    setError(null);
-    try {
-      await relocateProject(repoPath, picked);
-    } catch (e) {
-      setError(String(e));
-    } finally {
-      setRelocating(false);
-    }
-  }
-
   return (
     <section className="ps-section">
       <header className="ps-section-h">
         <h2 className="ps-section-t text-lg">General</h2>
-        <p className="ps-section-lead text-sm">
-          The project&rsquo;s display name and where Fletch looks for it on disk.
-        </p>
+        <p className="ps-section-lead text-sm">The project&rsquo;s display name.</p>
       </header>
 
       <div className="ps-field">
@@ -105,24 +77,6 @@ export function GeneralSection({ projectId, currentName, repoPath }: Props) {
           </button>
         </div>
         <p className="ps-hint text-xs">Shown in the sidebar. Independent of the folder name.</p>
-      </div>
-
-      <div className="ps-field">
-        <label className="ps-label text-sm">Location</label>
-        <button
-          type="button"
-          className="ps-path-row flex-center"
-          disabled={relocating}
-          onClick={() => void changeLocation()}
-        >
-          <Icon name="folder" size={14} />
-          <span className="ps-path-val mono text-base truncate">{repoPath}</span>
-          <span className="ps-path-change text-sm">{relocating ? "Moving…" : "Change…"}</span>
-        </button>
-        <p className="ps-hint text-xs">
-          Moved the folder? Point Fletch at its new location. Running agents keep their existing
-          worktrees — only new agents use the new path.
-        </p>
       </div>
 
       {error && <div className="ps-error text-sm">{error}</div>}

--- a/src/components/ProjectSettings/ProjectSettings.css
+++ b/src/components/ProjectSettings/ProjectSettings.css
@@ -327,6 +327,58 @@
   border-radius: var(--r-sm);
 }
 
+/* repositories — the repos attached to this project */
+.ps-repo-list {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-sm);
+}
+.ps-repo-row {
+  gap: 9px;
+  padding: 8px 11px;
+  border-top: 1px solid var(--bd-soft);
+  color: var(--fg-1);
+}
+.ps-repo-row:first-child {
+  border-top: none;
+}
+.ps-repo-path {
+  flex: 1;
+  min-width: 0;
+  color: var(--fg-2);
+}
+.ps-repo-primary {
+  flex-shrink: 0;
+  padding: 1px 7px;
+  color: var(--fg-3);
+  border: 1px solid var(--bd-soft);
+  border-radius: 999px;
+}
+.ps-repo-x {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  justify-content: center;
+  border-radius: var(--r-sm);
+  background: transparent;
+  border: 0;
+  color: var(--fg-3);
+  transition:
+    background 0.1s,
+    color 0.1s;
+}
+.ps-repo-x:hover:not(:disabled) {
+  background: var(--hover);
+  color: var(--danger);
+}
+.ps-repo-x:disabled {
+  opacity: 0.45;
+}
+.ps-repo-add {
+  margin-top: 10px;
+}
+
 /* environment variables — the opt-in sandbox env membrane. No `overflow` here:
  * clipping would cut off the value chip's tooltips at the list boundary. */
 .ev-list {

--- a/src/components/ProjectSettings/ProjectSettings.css
+++ b/src/components/ProjectSettings/ProjectSettings.css
@@ -335,7 +335,7 @@
   border-radius: var(--r-sm);
 }
 .ps-repo-row {
-  gap: 9px;
+  gap: 10px;
   padding: 8px 11px;
   border-top: 1px solid var(--bd-soft);
   color: var(--fg-1);
@@ -343,10 +343,45 @@
 .ps-repo-row:first-child {
   border-top: none;
 }
-.ps-repo-path {
+.ps-repo-main {
   flex: 1;
   min-width: 0;
-  color: var(--fg-2);
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.ps-repo-toprow {
+  gap: 7px;
+}
+/* Editable per-repo label: reads as text until hovered/focused. */
+.ps-repo-label {
+  min-width: 0;
+  max-width: 240px;
+  padding: 1px 5px;
+  margin-left: -5px;
+  color: var(--fg-0);
+  font-weight: 500;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  transition:
+    border-color 0.1s,
+    background 0.1s;
+}
+.ps-repo-label::placeholder {
+  color: var(--fg-1);
+  font-weight: 500;
+}
+.ps-repo-label:hover {
+  border-color: var(--bd-soft);
+}
+.ps-repo-label:focus {
+  outline: none;
+  border-color: var(--accent);
+  background: var(--bg-1);
+}
+.ps-repo-path {
+  color: var(--fg-3);
 }
 .ps-repo-primary {
   flex-shrink: 0;
@@ -354,6 +389,22 @@
   color: var(--fg-3);
   border: 1px solid var(--bd-soft);
   border-radius: 999px;
+}
+.ps-repo-act {
+  flex-shrink: 0;
+  padding: 2px 6px;
+  color: var(--accent);
+  font-weight: 500;
+  background: transparent;
+  border: 0;
+  border-radius: var(--r-sm);
+  transition: background 0.1s;
+}
+.ps-repo-act:hover:not(:disabled) {
+  background: var(--hover);
+}
+.ps-repo-act:disabled {
+  opacity: 0.45;
 }
 .ps-repo-x {
   flex-shrink: 0;

--- a/src/components/ProjectSettings/RepositoriesField.tsx
+++ b/src/components/ProjectSettings/RepositoriesField.tsx
@@ -69,6 +69,7 @@ export function RepositoriesField({ projectId }: { projectId: string }) {
             busy={busy}
             onRelocate={() => void onRelocate(r.path)}
             onDetach={() => void run(() => detachRepoFromProject(projectId, r.path))}
+            onError={setError}
           />
         ))}
       </div>
@@ -96,6 +97,7 @@ function RepoRow({
   busy,
   onRelocate,
   onDetach,
+  onError,
 }: {
   repo: ProjectRef;
   primary: boolean;
@@ -103,6 +105,9 @@ function RepoRow({
   busy: boolean;
   onRelocate: () => void;
   onDetach: () => void;
+  /** Surface a failed save in the field's shared error slot (null clears it) —
+   *  a reverted input alone would read as the label silently vanishing. */
+  onError: (msg: string | null) => void;
 }) {
   const setRepoLabel = useAppStore((s) => s.setRepoLabel);
   const saved = repo.label ?? "";
@@ -115,8 +120,10 @@ function RepoRow({
       // The store round-trips the trimmed value (or "" when cleared); mirror it
       // so the field matches what was persisted.
       setLabel(label.trim());
-    } catch {
-      setLabel(saved); // revert on failure; section-level errors cover the rest
+      onError(null);
+    } catch (e) {
+      setLabel(saved);
+      onError(String(e));
     }
   }
 

--- a/src/components/ProjectSettings/RepositoriesField.tsx
+++ b/src/components/ProjectSettings/RepositoriesField.tsx
@@ -5,12 +5,13 @@ import { Icon } from "@/components/Icon";
 import { useAppStore } from "@/store";
 import { basename } from "@/util/format";
 
-/** Where the project lives on disk. Each repo row carries its own path,
- *  relocate action, and an optional label ("Frontend", "Gateway") that names
- *  it inside the project. One repo is the common case; attaching more turns
- *  the project multi-repo, grouped under a single sidebar entry. The project
- *  itself has no location — repos can live anywhere. */
-export function RepositoriesSection({ projectId }: { projectId: string }) {
+/** The repositories field of the General section: where the project lives on
+ *  disk. Each repo row carries its own path, relocate action, and an optional
+ *  label ("Frontend", "Gateway") that names it inside the project. One repo is
+ *  the common case; attaching more turns the project multi-repo, grouped under
+ *  a single sidebar entry. The project itself has no location — repos can live
+ *  anywhere. */
+export function RepositoriesField({ projectId }: { projectId: string }) {
   const projects = useAppStore((s) => s.workspace?.projects);
   const attachRepoToProject = useAppStore((s) => s.attachRepoToProject);
   const detachRepoFromProject = useAppStore((s) => s.detachRepoFromProject);
@@ -55,14 +56,8 @@ export function RepositoriesSection({ projectId }: { projectId: string }) {
   }
 
   return (
-    <section className="ps-section">
-      <header className="ps-section-h">
-        <h2 className="ps-section-t text-lg">Repositories</h2>
-        <p className="ps-section-lead text-sm">
-          Where this project lives on disk. Attach more repositories to group a frontend, a backend,
-          and more under one project — they can live anywhere on your machine.
-        </p>
-      </header>
+    <div className="ps-field">
+      <span className="ps-label text-sm">Repositories</span>
 
       <div className="ps-repo-list">
         {repos.map((r, i) => (
@@ -82,12 +77,13 @@ export function RepositoriesSection({ projectId }: { projectId: string }) {
         Attach repository…
       </button>
       <p className="ps-hint text-xs">
-        Labels name each repository inside the project. New agents currently start in the primary
-        repository. Detaching and relocating never touch the folder on disk.
+        Attach more repositories to group a frontend, a backend, and more under one project — they
+        can live anywhere on disk. Labels name each repository inside the project; new agents
+        currently start in the primary one. Detaching and relocating never touch the folder on disk.
       </p>
 
       {error && <div className="ps-error text-sm">{error}</div>}
-    </section>
+    </div>
   );
 }
 

--- a/src/components/ProjectSettings/RepositoriesSection.tsx
+++ b/src/components/ProjectSettings/RepositoriesSection.tsx
@@ -1,0 +1,102 @@
+import { open } from "@tauri-apps/plugin-dialog";
+import { useState } from "react";
+import { Icon } from "@/components/Icon";
+import { useAppStore } from "@/store";
+
+/** The repositories attached to this project. One repo is the common case;
+ *  attaching more turns it into a multi-repo project grouped under a single
+ *  sidebar entry. The first (primary) repo is where new agents start. */
+export function RepositoriesSection({ projectId }: { projectId: string }) {
+  const projects = useAppStore((s) => s.workspace?.projects);
+  const attachRepoToProject = useAppStore((s) => s.attachRepoToProject);
+  const detachRepoFromProject = useAppStore((s) => s.detachRepoFromProject);
+  const [adding, setAdding] = useState(false);
+  const [busyPath, setBusyPath] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const repos = (projects ?? []).filter((p) => p.project_id === projectId).map((p) => p.path);
+
+  async function onAttach() {
+    if (adding) return;
+    const picked = await open({
+      directory: true,
+      multiple: false,
+      title: "Select a git repository to attach",
+    });
+    if (typeof picked !== "string") return;
+    setAdding(true);
+    setError(null);
+    try {
+      await attachRepoToProject(projectId, picked);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setAdding(false);
+    }
+  }
+
+  async function onDetach(path: string) {
+    if (busyPath) return;
+    setBusyPath(path);
+    setError(null);
+    try {
+      await detachRepoFromProject(projectId, path);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusyPath(null);
+    }
+  }
+
+  return (
+    <section className="ps-section">
+      <header className="ps-section-h">
+        <h2 className="ps-section-t text-lg">Repositories</h2>
+        <p className="ps-section-lead text-sm">
+          The repositories that make up this project. Attach more to group several repos — a
+          frontend, a backend — under one project.
+        </p>
+      </header>
+
+      <div className="ps-repo-list">
+        {repos.map((path, i) => (
+          <div key={path} className="ps-repo-row flex-center">
+            <Icon name="folder" size={14} />
+            <span className="ps-repo-path mono text-sm truncate" title={path}>
+              {path}
+            </span>
+            {i === 0 && repos.length > 1 && (
+              <span className="ps-repo-primary text-xs">primary</span>
+            )}
+            {repos.length > 1 && (
+              <button
+                className="ps-repo-x iflex-center tip"
+                data-tip="Detach from project"
+                aria-label={`Detach ${path}`}
+                disabled={busyPath !== null}
+                onClick={() => void onDetach(path)}
+              >
+                <Icon name="close" size={12} />
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        className="ps-btn ps-repo-add"
+        disabled={adding}
+        onClick={() => void onAttach()}
+      >
+        {adding ? "Attaching…" : "Attach repository…"}
+      </button>
+      <p className="ps-hint text-xs">
+        New agents currently start in the primary repository. Detaching never touches the folder on
+        disk.
+      </p>
+
+      {error && <div className="ps-error text-sm">{error}</div>}
+    </section>
+  );
+}

--- a/src/components/ProjectSettings/RepositoriesSection.tsx
+++ b/src/components/ProjectSettings/RepositoriesSection.tsx
@@ -1,51 +1,57 @@
 import { open } from "@tauri-apps/plugin-dialog";
 import { useState } from "react";
+import type { ProjectRef } from "@/api";
 import { Icon } from "@/components/Icon";
 import { useAppStore } from "@/store";
+import { basename } from "@/util/format";
 
-/** The repositories attached to this project. One repo is the common case;
- *  attaching more turns it into a multi-repo project grouped under a single
- *  sidebar entry. The first (primary) repo is where new agents start. */
+/** Where the project lives on disk. Each repo row carries its own path,
+ *  relocate action, and an optional label ("Frontend", "Gateway") that names
+ *  it inside the project. One repo is the common case; attaching more turns
+ *  the project multi-repo, grouped under a single sidebar entry. The project
+ *  itself has no location — repos can live anywhere. */
 export function RepositoriesSection({ projectId }: { projectId: string }) {
   const projects = useAppStore((s) => s.workspace?.projects);
   const attachRepoToProject = useAppStore((s) => s.attachRepoToProject);
   const detachRepoFromProject = useAppStore((s) => s.detachRepoFromProject);
-  const [adding, setAdding] = useState(false);
-  const [busyPath, setBusyPath] = useState<string | null>(null);
+  const relocateProject = useAppStore((s) => s.relocateProject);
+  const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const repos = (projects ?? []).filter((p) => p.project_id === projectId).map((p) => p.path);
+  const repos = (projects ?? []).filter((p) => p.project_id === projectId);
+  const multi = repos.length > 1;
+
+  async function run(fn: () => Promise<void>) {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await fn();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
 
   async function onAttach() {
-    if (adding) return;
     const picked = await open({
       directory: true,
       multiple: false,
       title: "Select a git repository to attach",
     });
     if (typeof picked !== "string") return;
-    setAdding(true);
-    setError(null);
-    try {
-      await attachRepoToProject(projectId, picked);
-    } catch (e) {
-      setError(String(e));
-    } finally {
-      setAdding(false);
-    }
+    await run(() => attachRepoToProject(projectId, picked));
   }
 
-  async function onDetach(path: string) {
-    if (busyPath) return;
-    setBusyPath(path);
-    setError(null);
-    try {
-      await detachRepoFromProject(projectId, path);
-    } catch (e) {
-      setError(String(e));
-    } finally {
-      setBusyPath(null);
-    }
+  async function onRelocate(path: string) {
+    const picked = await open({
+      directory: true,
+      multiple: false,
+      title: "Select the repository's new location",
+    });
+    if (typeof picked !== "string" || picked === path) return;
+    await run(() => relocateProject(path, picked));
   }
 
   return (
@@ -53,50 +59,117 @@ export function RepositoriesSection({ projectId }: { projectId: string }) {
       <header className="ps-section-h">
         <h2 className="ps-section-t text-lg">Repositories</h2>
         <p className="ps-section-lead text-sm">
-          The repositories that make up this project. Attach more to group several repos — a
-          frontend, a backend — under one project.
+          Where this project lives on disk. Attach more repositories to group a frontend, a backend,
+          and more under one project — they can live anywhere on your machine.
         </p>
       </header>
 
       <div className="ps-repo-list">
-        {repos.map((path, i) => (
-          <div key={path} className="ps-repo-row flex-center">
-            <Icon name="folder" size={14} />
-            <span className="ps-repo-path mono text-sm truncate" title={path}>
-              {path}
-            </span>
-            {i === 0 && repos.length > 1 && (
-              <span className="ps-repo-primary text-xs">primary</span>
-            )}
-            {repos.length > 1 && (
-              <button
-                className="ps-repo-x iflex-center tip"
-                data-tip="Detach from project"
-                aria-label={`Detach ${path}`}
-                disabled={busyPath !== null}
-                onClick={() => void onDetach(path)}
-              >
-                <Icon name="close" size={12} />
-              </button>
-            )}
-          </div>
+        {repos.map((r, i) => (
+          <RepoRow
+            key={r.path}
+            repo={r}
+            primary={i === 0 && multi}
+            detachable={multi}
+            busy={busy}
+            onRelocate={() => void onRelocate(r.path)}
+            onDetach={() => void run(() => detachRepoFromProject(projectId, r.path))}
+          />
         ))}
       </div>
 
-      <button
-        type="button"
-        className="ps-btn ps-repo-add"
-        disabled={adding}
-        onClick={() => void onAttach()}
-      >
-        {adding ? "Attaching…" : "Attach repository…"}
+      <button type="button" className="ps-btn ps-repo-add" disabled={busy} onClick={onAttach}>
+        Attach repository…
       </button>
       <p className="ps-hint text-xs">
-        New agents currently start in the primary repository. Detaching never touches the folder on
-        disk.
+        Labels name each repository inside the project. New agents currently start in the primary
+        repository. Detaching and relocating never touch the folder on disk.
       </p>
 
       {error && <div className="ps-error text-sm">{error}</div>}
     </section>
+  );
+}
+
+/** One attached repo: an editable label over the on-disk path, plus relocate
+ *  and (for multi-repo projects) detach actions. */
+function RepoRow({
+  repo,
+  primary,
+  detachable,
+  busy,
+  onRelocate,
+  onDetach,
+}: {
+  repo: ProjectRef;
+  primary: boolean;
+  detachable: boolean;
+  busy: boolean;
+  onRelocate: () => void;
+  onDetach: () => void;
+}) {
+  const setRepoLabel = useAppStore((s) => s.setRepoLabel);
+  const saved = repo.label ?? "";
+  const [label, setLabel] = useState(saved);
+
+  async function saveLabel() {
+    if (label.trim() === saved) return;
+    try {
+      await setRepoLabel(repo.path, label);
+      // The store round-trips the trimmed value (or "" when cleared); mirror it
+      // so the field matches what was persisted.
+      setLabel(label.trim());
+    } catch {
+      setLabel(saved); // revert on failure; section-level errors cover the rest
+    }
+  }
+
+  return (
+    <div className="ps-repo-row flex-center">
+      <Icon name="folder" size={14} />
+      <div className="ps-repo-main">
+        <div className="ps-repo-toprow flex-center">
+          <input
+            className="ps-repo-label text-sm"
+            value={label}
+            placeholder={basename(repo.path)}
+            spellCheck={false}
+            autoComplete="off"
+            aria-label={`Label for ${repo.path}`}
+            onChange={(e) => setLabel(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                (e.target as HTMLInputElement).blur();
+              } else if (e.key === "Escape") {
+                e.stopPropagation();
+                setLabel(saved);
+                (e.target as HTMLInputElement).blur();
+              }
+            }}
+            onBlur={() => void saveLabel()}
+          />
+          {primary && <span className="ps-repo-primary text-xs">primary</span>}
+        </div>
+        <div className="ps-repo-path mono text-xs truncate" title={repo.path}>
+          {repo.path}
+        </div>
+      </div>
+      <button type="button" className="ps-repo-act text-sm" disabled={busy} onClick={onRelocate}>
+        Change…
+      </button>
+      {detachable && (
+        <button
+          type="button"
+          className="ps-repo-x iflex-center tip"
+          data-tip="Detach from project"
+          aria-label={`Detach ${repo.path}`}
+          disabled={busy}
+          onClick={onDetach}
+        >
+          <Icon name="close" size={12} />
+        </button>
+      )}
+    </div>
   );
 }

--- a/src/components/ProjectSettings/index.tsx
+++ b/src/components/ProjectSettings/index.tsx
@@ -9,7 +9,6 @@ import { DeleteSection } from "./DeleteSection";
 import { EnvVarsSection } from "./EnvVarsSection";
 import { GeneralSection } from "./GeneralSection";
 import { ProjectPulse } from "./ProjectPulse";
-import { RepositoriesSection } from "./RepositoriesSection";
 import { RunEnvSection } from "./RunEnvSection";
 
 interface Loaded {
@@ -108,7 +107,6 @@ export function ProjectSettings({ repoPath }: { repoPath: string }) {
             <div className="ps-sections">
               <ProjectPulse projectId={loaded.projectId} />
               <GeneralSection projectId={loaded.projectId} currentName={name} />
-              <RepositoriesSection projectId={loaded.projectId} />
               <RunEnvSection
                 projectId={loaded.projectId}
                 rows={loaded.rows}

--- a/src/components/ProjectSettings/index.tsx
+++ b/src/components/ProjectSettings/index.tsx
@@ -9,6 +9,7 @@ import { DeleteSection } from "./DeleteSection";
 import { EnvVarsSection } from "./EnvVarsSection";
 import { GeneralSection } from "./GeneralSection";
 import { ProjectPulse } from "./ProjectPulse";
+import { RepositoriesSection } from "./RepositoriesSection";
 import { RunEnvSection } from "./RunEnvSection";
 
 interface Loaded {
@@ -100,6 +101,7 @@ export function ProjectSettings({ repoPath }: { repoPath: string }) {
             <div className="ps-sections">
               <ProjectPulse projectId={loaded.projectId} />
               <GeneralSection projectId={loaded.projectId} currentName={name} repoPath={repoPath} />
+              <RepositoriesSection projectId={loaded.projectId} />
               <RunEnvSection
                 projectId={loaded.projectId}
                 rows={loaded.rows}

--- a/src/components/ProjectSettings/index.tsx
+++ b/src/components/ProjectSettings/index.tsx
@@ -31,6 +31,11 @@ export function ProjectSettings({ repoPath }: { repoPath: string }) {
 
   // Custom display name for this repo, falling back to the folder basename.
   const name = projects?.find((p) => p.path === repoPath)?.name ?? basename(repoPath);
+  // The project's repos (known once the project_id resolves). A single-repo
+  // project reads as "the repo at this path"; multi-repo has no single
+  // location, so the header shows the repo count instead.
+  const projectRepoCount =
+    loaded == null ? 1 : (projects?.filter((p) => p.project_id === loaded.projectId).length ?? 1);
 
   // Resolve project_id + detected run config for the repo, then load the
   // persisted overrides. Both must be ready before the editor mounts so the
@@ -83,7 +88,9 @@ export function ProjectSettings({ repoPath }: { repoPath: string }) {
         <div className="ps-head">
           <div className="ps-id">
             <div className="ps-title text-lg truncate">{name}</div>
-            <div className="ps-path mono text-xs truncate">{repoPath}</div>
+            <div className="ps-path mono text-xs truncate">
+              {projectRepoCount > 1 ? `${projectRepoCount} repositories` : repoPath}
+            </div>
           </div>
           <button className="ps-x iflex-center" onClick={close} aria-label="Close">
             <Icon name="close" size={13} />
@@ -100,7 +107,7 @@ export function ProjectSettings({ repoPath }: { repoPath: string }) {
           ) : (
             <div className="ps-sections">
               <ProjectPulse projectId={loaded.projectId} />
-              <GeneralSection projectId={loaded.projectId} currentName={name} repoPath={repoPath} />
+              <GeneralSection projectId={loaded.projectId} currentName={name} />
               <RepositoriesSection projectId={loaded.projectId} />
               <RunEnvSection
                 projectId={loaded.projectId}

--- a/src/components/Sidebar/ProjectGroup.tsx
+++ b/src/components/Sidebar/ProjectGroup.tsx
@@ -7,10 +7,14 @@ import { RunRow } from "@/workflows/run/RunRow";
 import { AgentRow } from "./AgentRow";
 
 interface Props {
-  /** Display name (basename of repo path). */
+  /** Project display name. */
   label: string;
-  /** Full repo path — used as the group's stable id. */
+  /** The project's primary repo path — the drag handle id and the target for
+   *  new drafts and the settings modal. */
   repoPath: string;
+  /** All repos attached to the project (equals [repoPath] for single-repo
+   *  projects) — shown in the header tooltip. */
+  repoPaths: string[];
   agents: AgentRecord[];
   drafts: DraftAgent[];
   /** Workflow runs grouped under this repo. */
@@ -33,6 +37,7 @@ interface Props {
 export function ProjectGroup({
   label,
   repoPath,
+  repoPaths,
   agents,
   drafts,
   runs,
@@ -91,7 +96,7 @@ export function ProjectGroup({
           }
           onToggle();
         }}
-        title={repoPath}
+        title={repoPaths.join("\n")}
       >
         <Icon name="chevR" size={10} className="chev" />
         <span className="pname">{label}</span>

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { AgentRecord, WfRun } from "@/api";
+import type { AgentRecord, ProjectRef, WfRun } from "@/api";
 import { Icon } from "@/components/Icon";
 import { NewProject, type NewProjectMode } from "@/components/NewProject";
 import type { DraftAgent } from "@/store";
@@ -12,48 +12,88 @@ import { SidebarFooter } from "./SidebarFooter";
 import { SidebarHeader } from "./SidebarHeader";
 import { useProjectReorder } from "./useProjectReorder";
 
-interface RepoGroup {
-  repoPath: string;
+interface ProjectGroupData {
+  /** Stable group id: the project_id, or the repo path for repos that aren't
+   *  pinned (an agent whose repo was removed from the sidebar). */
+  key: string;
+  /** Project display name (folder basename fallback for unpinned repos). */
+  label: string;
+  /** All repos attached to the project, in creation order. */
+  repoPaths: string[];
+  /** The project's first repo — the drag/order key, draft target, and
+   *  settings key, so single-repo projects behave exactly as before. */
+  primaryPath: string;
   agents: AgentRecord[];
   drafts: DraftAgent[];
   runs: WfRun[];
   pinned: boolean;
 }
 
-/** Build groups from (a) pinned repos, (b) any repo referenced by an
- *  existing agent, (c) any repo referenced by a draft, (d) any workflow run. */
-function groupByRepo(
-  pinned: string[],
+/** Build one group per project from (a) pinned repos (each carries its
+ *  project via ProjectRef; a multi-repo project folds into one group),
+ *  (b) any repo referenced by an existing agent, draft, or workflow run —
+ *  those resolve to their project's group, or a path-keyed fallback group
+ *  when the repo isn't pinned. */
+function groupByProject(
+  refs: readonly ProjectRef[],
   agents: readonly AgentRecord[],
   drafts: readonly DraftAgent[],
   runs: readonly WfRun[],
-): RepoGroup[] {
-  const map = new Map<string, RepoGroup>();
-  const ensure = (p: string, pinnedFlag = false): RepoGroup => {
-    let g = map.get(p);
+): ProjectGroupData[] {
+  const groups = new Map<string, ProjectGroupData>();
+  const byPath = new Map<string, ProjectGroupData>();
+  for (const ref of refs) {
+    const key = ref.project_id || ref.path;
+    let g = groups.get(key);
     if (!g) {
-      g = { repoPath: p, agents: [], drafts: [], runs: [], pinned: pinnedFlag };
-      map.set(p, g);
+      g = {
+        key,
+        label: ref.name,
+        repoPaths: [],
+        primaryPath: ref.path,
+        agents: [],
+        drafts: [],
+        runs: [],
+        pinned: true,
+      };
+      groups.set(key, g);
+    }
+    g.repoPaths.push(ref.path);
+    byPath.set(ref.path, g);
+  }
+  const ensure = (p: string): ProjectGroupData => {
+    let g = byPath.get(p);
+    if (!g) {
+      g = {
+        key: p,
+        label: basename(p),
+        repoPaths: [p],
+        primaryPath: p,
+        agents: [],
+        drafts: [],
+        runs: [],
+        pinned: false,
+      };
+      groups.set(p, g);
+      byPath.set(p, g);
     }
     return g;
   };
-  for (const p of pinned) ensure(p, true);
   for (const a of agents) {
     const primary = a.repos[0]?.repo_path;
     if (primary) ensure(primary).agents.push(a);
   }
   for (const d of drafts) ensure(d.repoPath).drafts.push(d);
   for (const r of runs) ensure(r.repo_path).runs.push(r);
-  return Array.from(map.values());
+  return Array.from(groups.values());
 }
 
-function applySearch(
-  groups: RepoGroup[],
-  q: string,
-  labelOf: (path: string) => string,
-): RepoGroup[] {
+function applySearch(groups: ProjectGroupData[], q: string): ProjectGroupData[] {
   if (!q.trim()) return groups;
   const needle = q.toLowerCase();
+  const groupMatches = (g: ProjectGroupData) =>
+    g.label.toLowerCase().includes(needle) ||
+    g.repoPaths.some((p) => basename(p).toLowerCase().includes(needle));
   return groups
     .map((g) => ({
       ...g,
@@ -64,15 +104,11 @@ function applySearch(
           a.repos[0]?.branch?.toLowerCase().includes(needle),
       ),
       drafts: g.drafts.filter((d) => d.name.toLowerCase().includes(needle)),
-      // Run rows render their own body; keep them when the repo matches.
-      runs: labelOf(g.repoPath).toLowerCase().includes(needle) ? g.runs : [],
+      // Run rows render their own body; keep them when the project matches.
+      runs: groupMatches(g) ? g.runs : [],
     }))
     .filter(
-      (g) =>
-        g.agents.length > 0 ||
-        g.drafts.length > 0 ||
-        g.runs.length > 0 ||
-        labelOf(g.repoPath).toLowerCase().includes(needle),
+      (g) => g.agents.length > 0 || g.drafts.length > 0 || g.runs.length > 0 || groupMatches(g),
     );
 }
 
@@ -117,22 +153,18 @@ export function Sidebar() {
   );
   const runs = useRuns();
   const groups = useMemo(() => {
-    const built = groupByRepo(workspace?.repos ?? [], liveAgents, drafts, runs);
-    const order = sortPaths(built.map((g) => g.repoPath));
-    const byPath = new Map(built.map((g) => [g.repoPath, g]));
-    return order.map((p) => byPath.get(p)).filter((g): g is RepoGroup => g !== undefined);
-  }, [workspace?.repos, liveAgents, drafts, runs, sortPaths]);
-  // Custom display name per pinned repo. Groups derived only from an agent's
-  // repo (never pinned) have no entry and fall back to the folder basename.
-  const labelOf = useMemo(() => {
-    const byPath = new Map((workspace?.projects ?? []).map((p) => [p.path, p.name]));
-    return (path: string) => byPath.get(path) ?? basename(path);
-  }, [workspace?.projects]);
-  const filtered = useMemo(() => applySearch(groups, query, labelOf), [groups, query, labelOf]);
+    const built = groupByProject(workspace?.projects ?? [], liveAgents, drafts, runs);
+    // Manual ordering is keyed by each project's primary repo path, so orders
+    // saved before multi-repo grouping keep working unchanged.
+    const order = sortPaths(built.map((g) => g.primaryPath));
+    const byPath = new Map(built.map((g) => [g.primaryPath, g]));
+    return order.map((p) => byPath.get(p)).filter((g): g is ProjectGroupData => g !== undefined);
+  }, [workspace?.projects, liveAgents, drafts, runs, sortPaths]);
+  const filtered = useMemo(() => applySearch(groups, query), [groups, query]);
 
   // Reordering is only meaningful over the full, unfiltered list.
   const reorderable = !query.trim();
-  const orderedPaths = useMemo(() => groups.map((g) => g.repoPath), [groups]);
+  const orderedPaths = useMemo(() => groups.map((g) => g.primaryPath), [groups]);
 
   // Begin a pointer-driven reorder. `markDragged` lets the group swallow the
   // trailing click so a real drag doesn't also toggle it open/closed. The order
@@ -198,11 +230,11 @@ export function Sidebar() {
     setOpenMap((prev) => {
       const next = { ...prev };
       for (const g of groups) {
-        if (g.agents.some((a) => a.id === selectedAgentId)) next[g.repoPath] = true;
-        if (g.drafts.some((d) => d.id === activeDraftId)) next[g.repoPath] = true;
-        if (g.runs.some((r) => r.id === selectedRunId)) next[g.repoPath] = true;
-        if (!(g.repoPath in next)) {
-          next[g.repoPath] = g.agents.length > 0 || g.drafts.length > 0 || g.runs.length > 0;
+        if (g.agents.some((a) => a.id === selectedAgentId)) next[g.key] = true;
+        if (g.drafts.some((d) => d.id === activeDraftId)) next[g.key] = true;
+        if (g.runs.some((r) => r.id === selectedRunId)) next[g.key] = true;
+        if (!(g.key in next)) {
+          next[g.key] = g.agents.length > 0 || g.drafts.length > 0 || g.runs.length > 0;
         }
       }
       return next;
@@ -230,27 +262,29 @@ export function Sidebar() {
             </div>
           ) : (
             filtered.map((g) => {
-              const isOver = reorderable && overPath === g.repoPath && dragPath !== g.repoPath;
+              const isOver =
+                reorderable && overPath === g.primaryPath && dragPath !== g.primaryPath;
               const dropAfter =
                 isOver &&
                 dragPath != null &&
-                orderedPaths.indexOf(dragPath) < orderedPaths.indexOf(g.repoPath);
+                orderedPaths.indexOf(dragPath) < orderedPaths.indexOf(g.primaryPath);
               return (
                 <ProjectGroup
-                  key={g.repoPath}
-                  label={labelOf(g.repoPath)}
-                  repoPath={g.repoPath}
+                  key={g.key}
+                  label={g.label}
+                  repoPath={g.primaryPath}
+                  repoPaths={g.repoPaths}
                   agents={g.agents}
                   drafts={g.drafts}
                   runs={g.runs}
-                  open={openMap[g.repoPath] ?? false}
-                  onToggle={() => setOpenMap((m) => ({ ...m, [g.repoPath]: !m[g.repoPath] }))}
+                  open={openMap[g.key] ?? false}
+                  onToggle={() => setOpenMap((m) => ({ ...m, [g.key]: !m[g.key] }))}
                   reorderable={reorderable}
-                  dragging={dragPath === g.repoPath}
+                  dragging={dragPath === g.primaryPath}
                   dropIndicator={isOver ? (dropAfter ? "after" : "before") : null}
                   onReorderPointerDown={
                     reorderable
-                      ? (e, markDragged) => startReorder(g.repoPath, e, markDragged)
+                      ? (e, markDragged) => startReorder(g.primaryPath, e, markDragged)
                       : undefined
                   }
                 />

--- a/src/components/Workspace/EmptyWorkspace.tsx
+++ b/src/components/Workspace/EmptyWorkspace.tsx
@@ -1,8 +1,8 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { api } from "@/api";
 import { Composer } from "@/components/Composer";
 import { BranchPicker } from "@/components/Composer/BranchPicker";
-import { ProjectPicker } from "@/components/Composer/ProjectPicker";
+import { type ProjectOption, ProjectPicker } from "@/components/Composer/ProjectPicker";
 import { Icon, LandmarkGlyph } from "@/components/Icon";
 import { IconButton } from "@/components/ui/IconButton";
 import type { DraftAgent } from "@/store";
@@ -20,7 +20,17 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
   const updateDraft = useAppStore((s) => s.updateDraft);
   const setNewDraftSelection = useAppStore((s) => s.setNewDraftSelection);
   const setLastRepoPath = useAppStore((s) => s.setLastRepoPath);
-  const repos = useAppStore((s) => s.workspace?.repos ?? []);
+  const projectRefs = useAppStore((s) => s.workspace?.projects ?? []);
+  // One picker entry per project: a multi-repo project shows once, valued at
+  // its primary (first) repo, which is where the agent spawns.
+  const projectOptions = useMemo(() => {
+    const seen = new Map<string, ProjectOption>();
+    for (const ref of projectRefs) {
+      const key = ref.project_id || ref.path;
+      if (!seen.has(key)) seen.set(key, { path: ref.path, label: ref.name });
+    }
+    return [...seen.values()];
+  }, [projectRefs]);
   const toggleLeft = useAppStore((s) => s.toggleLeft);
   const leftCollapsed = useAppStore((s) => s.leftCollapsed);
   const runLocalCommand = useAppStore((s) => s.runLocalCommand);
@@ -164,7 +174,7 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
             <div className="empty-meta flex-center">
               <ProjectPicker
                 value={draft.repoPath}
-                repos={repos}
+                projects={projectOptions}
                 onChange={(repoPath) => {
                   // Switching projects: the previously chosen base branch may not
                   // exist in the new repo, so reset to main.

--- a/src/store/repos.ts
+++ b/src/store/repos.ts
@@ -37,6 +37,11 @@ export const createReposSlice: SliceCreator<ReposSlice> = (set, get) => ({
     set({ workspace: ws });
   },
 
+  setRepoLabel: async (path, label) => {
+    const ws = await api.setRepoLabel(path, label);
+    set({ workspace: ws });
+  },
+
   renameProject: async (projectId, name) => {
     // Errors propagate to the modal for inline display.
     const ws = await api.renameProject(projectId, name);

--- a/src/store/repos.ts
+++ b/src/store/repos.ts
@@ -26,6 +26,17 @@ export const createReposSlice: SliceCreator<ReposSlice> = (set, get) => ({
     }
   },
 
+  attachRepoToProject: async (projectId, path) => {
+    // Errors propagate to the Repositories section for inline display.
+    const ws = await api.attachRepoToProject(projectId, path);
+    set({ workspace: ws });
+  },
+
+  detachRepoFromProject: async (projectId, path) => {
+    const ws = await api.detachRepoFromProject(projectId, path);
+    set({ workspace: ws });
+  },
+
   renameProject: async (projectId, name) => {
     // Errors propagate to the modal for inline display.
     const ws = await api.renameProject(projectId, name);

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -191,6 +191,8 @@ export interface ReposSlice {
   attachRepoToProject: (projectId: string, path: string) => Promise<void>;
   /** Detach a repo from a project (guarded backend-side). */
   detachRepoFromProject: (projectId: string, path: string) => Promise<void>;
+  /** Set a repo's display label; blank clears to the basename fallback. */
+  setRepoLabel: (path: string, label: string) => Promise<void>;
   // Rename/relocate resolve on success and throw on failure, so the Project
   // Settings modal can show the error inline rather than in the global banner.
   /** Set a project's custom display name (independent of its folder). */

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -185,6 +185,12 @@ export interface WorkspaceSlice {
 export interface ReposSlice {
   addWorkspaceRepo: (path: string) => Promise<void>;
   removeWorkspaceRepo: (path: string) => Promise<void>;
+  // Attach/detach resolve on success and throw on failure, so the Project
+  // Settings Repositories section can show the error inline.
+  /** Attach a repo to an existing project (multi-repo projects). */
+  attachRepoToProject: (projectId: string, path: string) => Promise<void>;
+  /** Detach a repo from a project (guarded backend-side). */
+  detachRepoFromProject: (projectId: string, path: string) => Promise<void>;
   // Rename/relocate resolve on success and throw on failure, so the Project
   // Settings modal can show the error inline rather than in the global banner.
   /** Set a project's custom display name (independent of its folder). */


### PR DESCRIPTION
## What

First slice of multi-repo projects: a project can now hold several repositories, grouped as a single sidebar entry and configured from Project Settings. Agents still spawn on the primary (first) repo — multi-repo checkouts (PR 2) and the per-repo git surface (PR 3) land separately.

## Why

A project was coupled 1:1 to a git repo, which made it impossible to represent a product made of several repos (frontend, backend, ai-assistant). The schema already allowed N repos per project (`repos.project_id`); this PR removes the places that manufactured the 1:1 coupling.

## Changes

**Backend**
- `attach_repo_to_project`: attaches any git folder to an existing project. A folder already pinned as its own *empty* project (no agents, no workflow runs) is moved in and the emptied project row dropped; a project with history is rejected rather than stranding its agents.
- `detach_repo_from_project`, guarded twice: the last repo can't be detached (delete the project instead), and a repo referenced by any worktree row — live or archived — is refused, because the `worktrees.repo_id` FK cascade would silently destroy that agent's tracked branches/PRs/archive snapshots.
- `set_repo_label` + nullable `repos.label` (migration 0022): per-repo display labels ("Frontend", "Gateway"), surfaced on `ProjectRef`; blank clears to the folder-basename fallback.

**Frontend**
- Sidebar groups by `project_id` instead of repo path. Manual ordering and drag keys stay on the primary repo path, so saved orders and single-repo behavior are unchanged; unpinned agent repos keep their path-keyed fallback group.
- Project Settings: General section now holds the project name plus a Repositories field — per-repo rows with editable label, path, Change… (relocate) and detach, plus Attach repository. The standalone Location field is gone: a project has no location of its own, repos can live anywhere on disk. The modal header shows the repo count once a project has several.
- New-agent ProjectPicker dedupes to one entry per project, showing the project display name.

## Compatibility

Single-repo projects are unchanged: same rows in the DB (no data migration beyond the additive `label` column), same sidebar rendering, same spawn flow, and the Repositories field shows one row whose path is the project's location — the same information the old Location field carried.

## Testing

- 5 new backend tests: attach (fresh / no-op / merge-empty-project / refuse-with-agents), detach guards (last repo, worktree references, clean detach), label round-trip/trim/clear/not-found.
- Full suites: cargo 883 passed (one pre-existing port-binding test is flaky under parallel runs and passes in isolation), tsc clean, biome clean, 447 vitest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)