### PR TITLE
feat(agents): multi-repo workspaces — checkout every project repo at spawn

### DIFF
--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -52,6 +52,47 @@ pub fn text() -> String {
     combined
 }
 
+/// Per-agent workspace-layout note for multi-repo projects, composed ahead of
+/// any custom brief by the spawn path. `None` for single-repo agents, so the
+/// common case injects nothing extra. Lists each sibling checkout by its
+/// directory name (with the repo's project label when one is set) and points
+/// at the `args.repo` selector the git RPC ops accept.
+pub fn multi_repo_workspace_note(repos: &[crate::workspace::TrackedRepo]) -> Option<String> {
+    if repos.len() < 2 {
+        return None;
+    }
+    let mut lines = String::new();
+    for (i, r) in repos.iter().enumerate() {
+        let basename = r
+            .repo_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default();
+        let name = r.label.as_deref().unwrap_or(basename);
+        let marker = if i == 0 {
+            " (your starting checkout)"
+        } else {
+            ""
+        };
+        if name.is_empty() || name == r.subdir {
+            lines.push_str(&format!("- `{}/`{}\n", r.subdir, marker));
+        } else {
+            lines.push_str(&format!("- `{}/` — {}{}\n", r.subdir, name, marker));
+        }
+    }
+    Some(format!(
+        "## Workspace layout: multiple repositories\n\n\
+         This project spans {} repositories; this workspace holds a sibling checkout of each \
+         under the workspace root:\n\n{lines}\n\
+         Work across whichever checkouts the task requires (e.g. `cd ../{}`), committing per \
+         repository with plain git. The host git ops (`git_push`, `open_pr`, `git_fetch`, \
+         `git_status`) target your starting repository by default — pass `\"repo\": \
+         \"<checkout dir name>\"` inside `args` to run one against a sibling checkout instead.",
+        repos.len(),
+        repos[1].subdir,
+    ))
+}
+
 /// The global instruction text plus an optional per-session suffix (a custom
 /// agent's standing brief). The suffix is appended *after* the global block so
 /// project/global guidance composes with the agent's role rather than replacing
@@ -209,6 +250,43 @@ mod tests {
             append_system_prompt_args(Some("   ")),
             append_system_prompt_args(None)
         );
+    }
+
+    #[test]
+    fn multi_repo_note_lists_checkouts_and_labels() {
+        use crate::workspace::TrackedRepo;
+        fn repo(subdir: &str, path: &str, label: Option<&str>) -> TrackedRepo {
+            TrackedRepo {
+                repo_path: std::path::PathBuf::from(path),
+                subdir: subdir.into(),
+                branch: None,
+                parent_branch: None,
+                base_sha: None,
+                pr_number: None,
+                pr_url: None,
+                pr_title: None,
+                pr_state: None,
+                label: label.map(str::to_string),
+            }
+        }
+
+        // Single repo (the common case): no note at all.
+        assert_eq!(
+            multi_repo_workspace_note(&[repo("app", "/src/app", None)]),
+            None
+        );
+
+        let note = multi_repo_workspace_note(&[
+            repo("frontend", "/src/frontend", None),
+            repo("backend", "/src/backend", Some("Gateway")),
+        ])
+        .unwrap();
+        assert!(note.contains("`frontend/`"), "note: {note}");
+        assert!(note.contains("(your starting checkout)"), "note: {note}");
+        assert!(note.contains("`backend/` — Gateway"), "note: {note}");
+        assert!(note.contains("args"), "must point at args.repo: {note}");
+        // No redundant "frontend — frontend" suffix when label == subdir.
+        assert!(!note.contains("frontend/` — frontend"), "note: {note}");
     }
 
     #[test]

--- a/src-tauri/src/instructions/rpc_protocol.md
+++ b/src-tauri/src/instructions/rpc_protocol.md
@@ -63,3 +63,9 @@ actions that need host-held GitHub credentials — `git_push`, `open_pr`, and
 `git_fetch` (local git you run directly; see the git-actions playbooks). The
 dispatcher also exposes `echo` as a simple round-trip check. Future app features
 can define their own ops on top of the same mailbox.
+
+In a multi-repo workspace (sibling repository checkouts under the workspace
+root), every git op accepts an optional `args.repo` — the sibling checkout's
+directory name — and defaults to your starting repository when absent. Commit
+in each repo with plain local git; use `args.repo` only for the host-brokered
+ops above, e.g. `{"op":"git_push","args":{"repo":"backend","branch":"feat/x"}}`.

--- a/src-tauri/src/rpc/git.rs
+++ b/src-tauri/src/rpc/git.rs
@@ -42,12 +42,26 @@ fn is_signalable_action(action: &str) -> bool {
     matches!(action, "git_commit" | "git_update_branch")
 }
 
+/// The checkout an op resolved to: the subdir identifies the tracked repo in
+/// emitted events so the supervisor records branch/PR state on the *targeted*
+/// repo, never blindly on the primary. `None` only for dispatchers built
+/// without `with_repos` (tests, legacy call sites) — consumers then fall back
+/// to the primary, matching the single-repo behavior.
+struct Target {
+    subdir: Option<String>,
+    cwd: PathBuf,
+    base_branch: String,
+}
+
 #[derive(Clone)]
 pub struct GitDispatcher {
     /// Default checkout (the agent's primary repo) — used when an op carries
     /// no `args.repo`, which keeps single-repo agents byte-identical.
     cwd: PathBuf,
     base_branch: String,
+    /// The default checkout's subdir, resolved from `repos` by matching `cwd`.
+    /// Stamped into events for defaulted ops.
+    default_subdir: Option<String>,
     /// Sibling checkouts by subdir (directory name under the workspace root),
     /// each with its own base branch. Includes the primary. Empty for
     /// dispatchers built without `with_repos` (tests, old call sites) — then
@@ -60,6 +74,7 @@ impl GitDispatcher {
         Self {
             cwd,
             base_branch,
+            default_subdir: None,
             repos: std::collections::HashMap::new(),
         }
     }
@@ -71,6 +86,11 @@ impl GitDispatcher {
             .into_iter()
             .map(|(subdir, cwd, base)| (subdir, (cwd, base)))
             .collect();
+        self.default_subdir = self
+            .repos
+            .iter()
+            .find(|(_, (cwd, _))| *cwd == self.cwd)
+            .map(|(subdir, _)| subdir.clone());
         self
     }
 
@@ -78,16 +98,24 @@ impl GitDispatcher {
     /// present, the primary checkout otherwise. An unknown repo is an error
     /// response listing the tracked names, so a typo can't silently operate on
     /// the wrong repo.
-    fn target(&self, id: &str, args: &Value) -> std::result::Result<(PathBuf, String), Response> {
+    fn target(&self, id: &str, args: &Value) -> std::result::Result<Target, Response> {
         let requested = args
             .get("repo")
             .and_then(|v| v.as_str())
             .map(str::trim)
             .filter(|s| !s.is_empty());
         match requested {
-            None => Ok((self.cwd.clone(), self.base_branch.clone())),
+            None => Ok(Target {
+                subdir: self.default_subdir.clone(),
+                cwd: self.cwd.clone(),
+                base_branch: self.base_branch.clone(),
+            }),
             Some(name) => match self.repos.get(name) {
-                Some((cwd, base)) => Ok((cwd.clone(), base.clone())),
+                Some((cwd, base)) => Ok(Target {
+                    subdir: Some(name.to_string()),
+                    cwd: cwd.clone(),
+                    base_branch: base.clone(),
+                }),
                 None => {
                     let mut known: Vec<&str> = self.repos.keys().map(String::as_str).collect();
                     known.sort_unstable();
@@ -102,6 +130,15 @@ impl GitDispatcher {
             },
         }
     }
+}
+
+/// Build an event payload carrying the resolved repo (when known), so the
+/// supervisor can attribute branch/PR state to the targeted checkout.
+fn with_repo(mut payload: Value, subdir: &Option<String>) -> Value {
+    if let Some(s) = subdir {
+        payload["repo"] = json!(s);
+    }
+    payload
 }
 
 impl RpcDispatcher for GitDispatcher {
@@ -134,8 +171,9 @@ impl GitDispatcher {
                 Vec::new(),
             ),
             "git_status" => match self.target(id, args) {
-                Ok((cwd, _)) => (
-                    run_git_command(id, &cwd, &["status", "--porcelain=v1", "--branch"], &[]).await,
+                Ok(t) => (
+                    run_git_command(id, &t.cwd, &["status", "--porcelain=v1", "--branch"], &[])
+                        .await,
                     Vec::new(),
                 ),
                 Err(resp) => (resp, Vec::new()),
@@ -186,7 +224,7 @@ impl GitDispatcher {
     }
 
     async fn open_pr(&self, id: &str, args: &Value) -> (Response, Vec<RpcEvent>) {
-        let (cwd, base_branch) = match self.target(id, args) {
+        let t = match self.target(id, args) {
             Ok(t) => t,
             Err(resp) => return (resp, Vec::new()),
         };
@@ -194,7 +232,7 @@ impl GitDispatcher {
         let body = args.get("body").and_then(|v| v.as_str()).unwrap_or("");
         let requested = arg_branch(args);
 
-        let current = match crate::git::current_branch(&cwd).await {
+        let current = match crate::git::current_branch(&t.cwd).await {
             Ok(b) => b,
             Err(e) => return (Response::err(id, format!("open_pr: {e}")), Vec::new()),
         };
@@ -203,11 +241,11 @@ impl GitDispatcher {
         let branch = match (current, requested) {
             (Some(cur), None) => cur,
             (Some(cur), Some(req)) if req == cur => cur,
-            (Some(_), Some(req)) => match materialize_branch(&cwd, &req).await {
+            (Some(_), Some(req)) => match materialize_branch(&t.cwd, &req).await {
                 Ok(name) => {
                     effects.push(RpcEvent::named(
                         EVENT_BRANCH_CREATED,
-                        json!({ "branch": name }),
+                        with_repo(json!({ "branch": name }), &t.subdir),
                     ));
                     name
                 }
@@ -215,11 +253,11 @@ impl GitDispatcher {
             },
             (None, req) => {
                 let desired = req.unwrap_or_else(|| fallback_branch(title));
-                match materialize_branch(&cwd, &desired).await {
+                match materialize_branch(&t.cwd, &desired).await {
                     Ok(name) => {
                         effects.push(RpcEvent::named(
                             EVENT_BRANCH_CREATED,
-                            json!({ "branch": name }),
+                            with_repo(json!({ "branch": name }), &t.subdir),
                         ));
                         name
                     }
@@ -228,18 +266,18 @@ impl GitDispatcher {
             }
         };
 
-        if let Err(e) = crate::git::push(&cwd, &branch, false).await {
+        if let Err(e) = crate::git::push(&t.cwd, &branch, false).await {
             return (
                 Response::err(id, format!("open_pr push failed: {e}")),
                 effects,
             );
         }
-        match crate::github::pr_create(&cwd, title, body, &base_branch).await {
+        match crate::github::pr_create(&t.cwd, title, body, &t.base_branch).await {
             Ok(pr) => {
                 crate::telemetry::track("pr_opened", json!({ "source": "agent_rpc" }));
                 effects.push(RpcEvent::named(
                     EVENT_PR_OPENED,
-                    json!({ "number": pr.number }),
+                    with_repo(json!({ "number": pr.number }), &t.subdir),
                 ));
                 (Response::ok(id, 0, pr.url, String::new()), effects)
             }
@@ -248,10 +286,11 @@ impl GitDispatcher {
     }
 
     async fn git_push(&self, id: &str, args: &Value) -> (Response, Vec<RpcEvent>) {
-        let (cwd, _) = match self.target(id, args) {
+        let t = match self.target(id, args) {
             Ok(t) => t,
             Err(resp) => return (resp, Vec::new()),
         };
+        let cwd = t.cwd;
         let current = match crate::git::current_branch(&cwd).await {
             Ok(b) => b,
             Err(e) => return (Response::err(id, format!("git_push: {e}")), Vec::new()),
@@ -265,7 +304,7 @@ impl GitDispatcher {
                     Ok(name) => {
                         effects.push(RpcEvent::named(
                             EVENT_BRANCH_CREATED,
-                            json!({ "branch": name }),
+                            with_repo(json!({ "branch": name }), &t.subdir),
                         ));
                         name
                     }
@@ -302,13 +341,14 @@ impl GitDispatcher {
     /// absent, the spawn parent branch is used. Hooks are disabled on this
     /// host-side invocation for the same reason as push (agent-writable `.git`).
     async fn git_fetch(&self, id: &str, args: &Value) -> Response {
-        let (cwd, base_branch) = match self.target(id, args) {
+        let t = match self.target(id, args) {
             Ok(t) => t,
             Err(resp) => return resp,
         };
+        let cwd = t.cwd;
         let branch = match arg_branch_named(args, "ref") {
             Some(r) => r,
-            None => base_branch,
+            None => t.base_branch,
         };
         if branch.starts_with('-') {
             return Response::err(
@@ -879,6 +919,63 @@ mod tests {
         assert!(
             !resp.stdout.as_deref().unwrap_or_default().contains("x.txt"),
             "the default target must remain the primary checkout: {resp:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn branch_events_carry_the_targeted_repo() {
+        let td = tempfile::tempdir().unwrap();
+        let a = td.path().join("a");
+        let b = td.path().join("b");
+        for repo in [&a, &b] {
+            std::fs::create_dir_all(repo).unwrap();
+            run_git(repo, &["init", "-q", "-b", "main"]);
+            run_git(repo, &["config", "user.email", "t@example.com"]);
+            run_git(repo, &["config", "user.name", "Tester"]);
+            std::fs::write(repo.join("f.txt"), b"x").unwrap();
+            run_git(repo, &["add", "-A"]);
+            run_git(repo, &["commit", "-q", "-m", "init"]);
+            run_git(repo, &["checkout", "-q", "--detach"]);
+        }
+
+        let disp = GitDispatcher::new(a.clone(), "main".into()).with_repos(vec![
+            ("a".into(), a.clone(), "main".into()),
+            ("b".into(), b.clone(), "main".into()),
+        ]);
+
+        // Targeting the sibling: the branch event must name `b`, so the
+        // supervisor records the branch on b's worktree row, not the primary's.
+        // (The push itself fails — no remote — but the branch was materialized
+        // and its event emitted before the push attempt.)
+        let (_resp, fx) = disp
+            .dispatch_inner(
+                "p1",
+                "git_push",
+                &json!({"repo": "b", "branch": "feat/backend"}),
+            )
+            .await;
+        assert!(
+            fx.iter().any(|e| matches!(
+                e,
+                RpcEvent::Named { name, payload }
+                    if name == EVENT_BRANCH_CREATED
+                        && payload["branch"] == "feat/backend"
+                        && payload["repo"] == "b"
+            )),
+            "branch event must carry the targeted repo, got: {fx:?}"
+        );
+
+        // Defaulted op: the event carries the primary's subdir.
+        let (_resp, fx) = disp
+            .dispatch_inner("p2", "git_push", &json!({"branch": "feat/front"}))
+            .await;
+        assert!(
+            fx.iter().any(|e| matches!(
+                e,
+                RpcEvent::Named { name, payload }
+                    if name == EVENT_BRANCH_CREATED && payload["repo"] == "a"
+            )),
+            "defaulted op must attribute to the primary subdir, got: {fx:?}"
         );
     }
 

--- a/src-tauri/src/rpc/git.rs
+++ b/src-tauri/src/rpc/git.rs
@@ -44,13 +44,63 @@ fn is_signalable_action(action: &str) -> bool {
 
 #[derive(Clone)]
 pub struct GitDispatcher {
+    /// Default checkout (the agent's primary repo) — used when an op carries
+    /// no `args.repo`, which keeps single-repo agents byte-identical.
     cwd: PathBuf,
     base_branch: String,
+    /// Sibling checkouts by subdir (directory name under the workspace root),
+    /// each with its own base branch. Includes the primary. Empty for
+    /// dispatchers built without `with_repos` (tests, old call sites) — then
+    /// `args.repo` is rejected as unknown.
+    repos: std::collections::HashMap<String, (PathBuf, String)>,
 }
 
 impl GitDispatcher {
     pub fn new(cwd: PathBuf, base_branch: String) -> Self {
-        Self { cwd, base_branch }
+        Self {
+            cwd,
+            base_branch,
+            repos: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Register the agent's tracked checkouts as `(subdir, cwd, base_branch)`
+    /// so ops can be pointed at any of them via `args.repo`.
+    pub fn with_repos(mut self, repos: Vec<(String, PathBuf, String)>) -> Self {
+        self.repos = repos
+            .into_iter()
+            .map(|(subdir, cwd, base)| (subdir, (cwd, base)))
+            .collect();
+        self
+    }
+
+    /// Resolve the checkout an op targets: `args.repo` (a tracked subdir) when
+    /// present, the primary checkout otherwise. An unknown repo is an error
+    /// response listing the tracked names, so a typo can't silently operate on
+    /// the wrong repo.
+    fn target(&self, id: &str, args: &Value) -> std::result::Result<(PathBuf, String), Response> {
+        let requested = args
+            .get("repo")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+        match requested {
+            None => Ok((self.cwd.clone(), self.base_branch.clone())),
+            Some(name) => match self.repos.get(name) {
+                Some((cwd, base)) => Ok((cwd.clone(), base.clone())),
+                None => {
+                    let mut known: Vec<&str> = self.repos.keys().map(String::as_str).collect();
+                    known.sort_unstable();
+                    Err(Response::err(
+                        id,
+                        format!(
+                            "unknown repo {name:?}; tracked checkouts: {}",
+                            known.join(", ")
+                        ),
+                    ))
+                }
+            },
+        }
     }
 }
 
@@ -83,16 +133,13 @@ impl GitDispatcher {
                 Response::ok(id, 0, "pong".to_string(), String::new()),
                 Vec::new(),
             ),
-            "git_status" => (
-                run_git_command(
-                    id,
-                    &self.cwd,
-                    &["status", "--porcelain=v1", "--branch"],
-                    &[],
-                )
-                .await,
-                Vec::new(),
-            ),
+            "git_status" => match self.target(id, args) {
+                Ok((cwd, _)) => (
+                    run_git_command(id, &cwd, &["status", "--porcelain=v1", "--branch"], &[]).await,
+                    Vec::new(),
+                ),
+                Err(resp) => (resp, Vec::new()),
+            },
             other => (
                 Response::err(id, format!("unknown op: {other}")),
                 Vec::new(),
@@ -139,11 +186,15 @@ impl GitDispatcher {
     }
 
     async fn open_pr(&self, id: &str, args: &Value) -> (Response, Vec<RpcEvent>) {
+        let (cwd, base_branch) = match self.target(id, args) {
+            Ok(t) => t,
+            Err(resp) => return (resp, Vec::new()),
+        };
         let title = args.get("title").and_then(|v| v.as_str()).unwrap_or("");
         let body = args.get("body").and_then(|v| v.as_str()).unwrap_or("");
         let requested = arg_branch(args);
 
-        let current = match crate::git::current_branch(&self.cwd).await {
+        let current = match crate::git::current_branch(&cwd).await {
             Ok(b) => b,
             Err(e) => return (Response::err(id, format!("open_pr: {e}")), Vec::new()),
         };
@@ -152,7 +203,7 @@ impl GitDispatcher {
         let branch = match (current, requested) {
             (Some(cur), None) => cur,
             (Some(cur), Some(req)) if req == cur => cur,
-            (Some(_), Some(req)) => match materialize_branch(&self.cwd, &req).await {
+            (Some(_), Some(req)) => match materialize_branch(&cwd, &req).await {
                 Ok(name) => {
                     effects.push(RpcEvent::named(
                         EVENT_BRANCH_CREATED,
@@ -164,7 +215,7 @@ impl GitDispatcher {
             },
             (None, req) => {
                 let desired = req.unwrap_or_else(|| fallback_branch(title));
-                match materialize_branch(&self.cwd, &desired).await {
+                match materialize_branch(&cwd, &desired).await {
                     Ok(name) => {
                         effects.push(RpcEvent::named(
                             EVENT_BRANCH_CREATED,
@@ -177,13 +228,13 @@ impl GitDispatcher {
             }
         };
 
-        if let Err(e) = crate::git::push(&self.cwd, &branch, false).await {
+        if let Err(e) = crate::git::push(&cwd, &branch, false).await {
             return (
                 Response::err(id, format!("open_pr push failed: {e}")),
                 effects,
             );
         }
-        match crate::github::pr_create(&self.cwd, title, body, &self.base_branch).await {
+        match crate::github::pr_create(&cwd, title, body, &base_branch).await {
             Ok(pr) => {
                 crate::telemetry::track("pr_opened", json!({ "source": "agent_rpc" }));
                 effects.push(RpcEvent::named(
@@ -197,7 +248,11 @@ impl GitDispatcher {
     }
 
     async fn git_push(&self, id: &str, args: &Value) -> (Response, Vec<RpcEvent>) {
-        let current = match crate::git::current_branch(&self.cwd).await {
+        let (cwd, _) = match self.target(id, args) {
+            Ok(t) => t,
+            Err(resp) => return (resp, Vec::new()),
+        };
+        let current = match crate::git::current_branch(&cwd).await {
             Ok(b) => b,
             Err(e) => return (Response::err(id, format!("git_push: {e}")), Vec::new()),
         };
@@ -206,7 +261,7 @@ impl GitDispatcher {
         let branch = match current {
             Some(cur) => cur,
             None => match arg_branch(args) {
-                Some(req) => match materialize_branch(&self.cwd, &req).await {
+                Some(req) => match materialize_branch(&cwd, &req).await {
                     Ok(name) => {
                         effects.push(RpcEvent::named(
                             EVENT_BRANCH_CREATED,
@@ -232,7 +287,7 @@ impl GitDispatcher {
         // history (e.g. after the agent rebased its branch). Lease-based so a
         // stale local view can't clobber remote work it hasn't seen.
         let force = arg_bool(args, "force");
-        match crate::git::push(&self.cwd, &branch, force).await {
+        match crate::git::push(&cwd, &branch, force).await {
             Ok(summary) => (Response::ok(id, 0, summary, String::new()), effects),
             Err(e) => (Response::err(id, e.to_string()), effects),
         }
@@ -247,9 +302,13 @@ impl GitDispatcher {
     /// absent, the spawn parent branch is used. Hooks are disabled on this
     /// host-side invocation for the same reason as push (agent-writable `.git`).
     async fn git_fetch(&self, id: &str, args: &Value) -> Response {
+        let (cwd, base_branch) = match self.target(id, args) {
+            Ok(t) => t,
+            Err(resp) => return resp,
+        };
         let branch = match arg_branch_named(args, "ref") {
             Some(r) => r,
-            None => self.base_branch.clone(),
+            None => base_branch,
         };
         if branch.starts_with('-') {
             return Response::err(
@@ -261,7 +320,7 @@ impl GitDispatcher {
             &crate::github::git_auth_env(),
             &crate::git::no_hooks_env(),
         ]);
-        let resp = run_git_command(id, &self.cwd, &["fetch", "origin", &branch], &auth).await;
+        let resp = run_git_command(id, &cwd, &["fetch", "origin", &branch], &auth).await;
         // `run_git_command` reports `ok: true` for any git that *ran*, carrying a
         // non-zero result only in `exit_code`. For fetch that's a trap: a missing
         // ref or a transient remote failure would leave `origin/<branch>` stale
@@ -787,6 +846,62 @@ mod tests {
             String::from_utf8_lossy(&b_head.stdout).trim(),
             "remote main must be untouched after the refused force push"
         );
+    }
+
+    #[tokio::test]
+    async fn repo_arg_targets_sibling_checkout() {
+        let td = tempfile::tempdir().unwrap();
+        let a = td.path().join("a");
+        let b = td.path().join("b");
+        for repo in [&a, &b] {
+            std::fs::create_dir_all(repo).unwrap();
+            run_git(repo, &["init", "-q", "-b", "main"]);
+        }
+        // A dirty file only in `b`, so the two checkouts are distinguishable.
+        std::fs::write(b.join("x.txt"), b"x").unwrap();
+
+        let disp = GitDispatcher::new(a.clone(), "main".into()).with_repos(vec![
+            ("a".into(), a.clone(), "main".into()),
+            ("b".into(), b.clone(), "main".into()),
+        ]);
+
+        let (resp, _fx) = disp
+            .dispatch_inner("s1", "git_status", &json!({"repo": "b"}))
+            .await;
+        assert_eq!(resp.exit_code, Some(0), "status in b: {resp:?}");
+        assert!(
+            resp.stdout.as_deref().unwrap_or_default().contains("x.txt"),
+            "targeting `b` must see its dirty file: {resp:?}"
+        );
+
+        // No `repo` arg → the primary checkout, exactly as before.
+        let (resp, _fx) = disp.dispatch_inner("s2", "git_status", &Value::Null).await;
+        assert!(
+            !resp.stdout.as_deref().unwrap_or_default().contains("x.txt"),
+            "the default target must remain the primary checkout: {resp:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_repo_arg_is_rejected_with_tracked_names() {
+        let td = tempfile::tempdir().unwrap();
+        let a = td.path().join("a");
+        std::fs::create_dir_all(&a).unwrap();
+        run_git(&a, &["init", "-q", "-b", "main"]);
+
+        let disp = GitDispatcher::new(a.clone(), "main".into()).with_repos(vec![(
+            "a".into(),
+            a.clone(),
+            "main".into(),
+        )]);
+        let (resp, fx) = disp
+            .dispatch_inner("p", "git_push", &json!({"repo": "nope"}))
+            .await;
+        assert!(!resp.ok, "an unknown repo must be rejected: {resp:?}");
+        let err = resp.error.as_deref().unwrap_or_default();
+        assert!(err.contains("unknown repo"), "got: {err}");
+        assert!(err.contains('a'), "should list tracked checkouts: {err}");
+        assert!(fx.is_empty(), "a rejected op must emit nothing: {fx:?}");
     }
 
     #[test]

--- a/src-tauri/src/supervisor/disposition.rs
+++ b/src-tauri/src/supervisor/disposition.rs
@@ -203,6 +203,7 @@ impl Supervisor {
                 pr_url: None,
                 pr_title: None,
                 pr_state: None,
+                label: None,
             });
         }
 

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -242,6 +242,7 @@ impl Supervisor {
             pr_url: None,
             pr_title: None,
             pr_state: None,
+            label: None,
         };
 
         let mut record = new_agent_record(
@@ -295,6 +296,7 @@ impl Supervisor {
         let sup = self.clone();
         let app_for_task = app.clone();
         let id_for_task = agent_id.clone();
+        let project_id_for_task = record.project_id.clone();
         tauri::async_runtime::spawn(async move {
             if let Err(e) = tokio::fs::create_dir_all(&parent_dir).await {
                 fail_spawn(&sup, &app_for_task, &id_for_task, e.to_string());
@@ -384,6 +386,34 @@ impl Supervisor {
                 }
             }
 
+            // Multi-repo project: fork a checkout of every *other* repo of the
+            // project too, so the agent works across all of them from turn one
+            // (untouched repos are just clean clones). Runs before
+            // start_process so the Docker engine's mounts and the git RPC
+            // dispatcher see the full repo set. Workflow step agents stay
+            // single-repo — a run targets one repo (see `wf_launch`).
+            if run_repo_for_task.is_none() {
+                for source in sup.workspace.project_repo_paths(&project_id_for_task) {
+                    if source == repo_path {
+                        continue;
+                    }
+                    if let Err(e) = sup
+                        .attach_repo_checkout(&app_for_task, &id_for_task, source.clone(), false)
+                        .await
+                    {
+                        let _ = provision::teardown(&primary_checkout).await;
+                        let _ = tokio::fs::remove_dir_all(&parent_dir).await;
+                        fail_spawn(
+                            &sup,
+                            &app_for_task,
+                            &id_for_task,
+                            format!("checkout of {} failed: {e}", source.display()),
+                        );
+                        return;
+                    }
+                }
+            }
+
             tokio::time::sleep(Duration::from_millis(350)).await;
 
             if let Err(e) = sup.start_process(&app_for_task, &id_for_task, true).await {
@@ -405,6 +435,32 @@ impl Supervisor {
         app: AppHandle,
         agent_id: &str,
         repo_path: PathBuf,
+    ) -> Result<TrackedRepo> {
+        // A repo added to a *live* agent can't get a new bind mount: the Docker
+        // container's mounts are fixed at `docker run`, so a `--shared` clone's
+        // borrowed object store would be unreachable in-container. Provision it
+        // self-contained (full object copy, no alternates) so it needs no mount
+        // and in-container git works immediately. Seatbelt has no container and
+        // uses the normal (`--shared`) clone path. A later restore relaunches
+        // the container and re-provisions via `--shared` + mount.
+        let record = self.workspace.agent(agent_id)?;
+        let self_contained = stamped_engine(&record) == EngineKind::Docker;
+        self.attach_repo_checkout(&app, agent_id, repo_path, self_contained)
+            .await
+    }
+
+    /// Shared core of "give this agent a checkout of another repo": validate,
+    /// allocate a sibling subdir, fork a checkout, and append the TrackedRepo.
+    /// `self_contained` selects a full object copy over a `--shared` clone —
+    /// required only when the checkout appears after a Docker container's
+    /// mounts are fixed (see `add_repo_to_agent`); spawn-time secondaries run
+    /// before the container exists, so they always use shared clones.
+    async fn attach_repo_checkout(
+        self: &Arc<Self>,
+        app: &AppHandle,
+        agent_id: &str,
+        repo_path: PathBuf,
+        self_contained: bool,
     ) -> Result<TrackedRepo> {
         if !repo_path.join(".git").exists() {
             return Err(Error::InvalidPath(format!(
@@ -432,20 +488,12 @@ impl Supervisor {
             Some(b) => git::fetch_fork_point(&repo_path, b).await,
             None => None,
         };
-        let engine = stamped_engine(&record);
         let spec = CheckoutSpec {
             source_repo: &repo_path,
             base_ref: base.as_deref().unwrap_or("HEAD"),
             dest: &checkout,
         };
-        // A repo added to a *live* agent can't get a new bind mount: the Docker
-        // container's mounts are fixed at `docker run`, so a `--shared` clone's
-        // borrowed object store would be unreachable in-container. Provision it
-        // self-contained (full object copy, no alternates) so it needs no mount
-        // and in-container git works immediately. Seatbelt has no container and
-        // uses the normal (`--shared`) clone path. A later restore relaunches
-        // the container and re-provisions via `--shared` + mount.
-        if engine == EngineKind::Docker {
+        if self_contained {
             provision::provision_self_contained(&spec).await?;
         } else {
             provision::provision(&spec).await?;
@@ -462,9 +510,10 @@ impl Supervisor {
             pr_url: None,
             pr_title: None,
             pr_state: None,
+            label: None,
         };
         self.workspace.append_tracked_repo(agent_id, repo.clone())?;
-        emit_repo_added(&app, agent_id, repo.clone());
+        emit_repo_added(app, agent_id, repo.clone());
 
         // No branch is created here — the new repo's checkout stays detached
         // until its first push, when the agent names its branch (same as the
@@ -517,7 +566,20 @@ impl Supervisor {
             .parent_branch
             .clone()
             .unwrap_or_else(|| "main".to_string());
-        let git_dispatcher = rpc::git::GitDispatcher::new(cwd.clone(), base_branch);
+        // Every tracked checkout is addressable by its subdir via `args.repo`;
+        // the primary stays the default when the arg is absent, so single-repo
+        // agents (and old prompts) behave exactly as before.
+        let mut repo_targets = Vec::new();
+        for r in &record.repos {
+            let checkout = repo_checkout_path(agent_id, &r.subdir)?;
+            let base = r
+                .parent_branch
+                .clone()
+                .unwrap_or_else(|| "main".to_string());
+            repo_targets.push((r.subdir.clone(), checkout, base));
+        }
+        let git_dispatcher =
+            rpc::git::GitDispatcher::new(cwd.clone(), base_branch).with_repos(repo_targets);
         // A run-owned step agent also gets the workflow comms ops (wf_report /
         // wf_ask / wf_notify, §10); everything else still falls through to the
         // git dispatcher. Plain agents keep the git dispatcher unchanged.
@@ -664,8 +726,17 @@ impl Supervisor {
         // launch path so the files always exist (e.g. after a checkout is
         // recreated) and always match the snapshot. `None` when the session has
         // neither a brief nor skills — the pre-profile behavior.
+        // Multi-repo workspaces get a layout note composed ahead of the custom
+        // brief, so the agent knows about its sibling checkouts from turn one.
+        // Recomputed every launch, like the rest of the instruction layers.
+        let workspace_note = crate::instructions::multi_repo_workspace_note(&record.repos);
+        let brief = match (workspace_note, record.instructions.as_deref()) {
+            (Some(note), Some(brief)) => Some(format!("{note}\n\n{brief}")),
+            (Some(note), None) => Some(note),
+            (None, brief) => brief.map(str::to_string),
+        };
         let instructions = crate::agent_profile::effective_instructions(
-            record.instructions.as_deref(),
+            brief.as_deref(),
             record.forked_context.as_deref(),
             &record.skills,
             &sandbox_root,

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -727,6 +727,7 @@ mod tests {
                 pr_url: None,
                 pr_title: None,
                 pr_state: None,
+                label: None,
             },
             String::new(),
             AgentView::Custom,
@@ -797,6 +798,7 @@ mod tests {
             pr_url: None,
             pr_title: None,
             pr_state: None,
+            label: None,
         };
         let mut record = new_agent_record(
             "yosemite".into(),

--- a/src-tauri/src/supervisor/rpc_watch.rs
+++ b/src-tauri/src/supervisor/rpc_watch.rs
@@ -66,6 +66,34 @@ pub(super) async fn process_agent_rpc_once(
 }
 
 fn handle_rpc_event(sup: &Supervisor, app: &AppHandle, agent_id: &str, event: rpc::RpcEvent) {
+    // The subdir of the checkout a branch/PR event belongs to: the dispatcher
+    // stamps the targeted repo into the payload (`args.repo` routing), so a PR
+    // opened in a sibling checkout lands on that repo's worktree row. Events
+    // without the field (legacy dispatchers, tests) keep the old primary-repo
+    // behavior — correct for single-repo agents, where primary is all there is.
+    fn event_subdir<'a>(
+        record: &'a crate::workspace::AgentRecord,
+        payload: &serde_json::Value,
+    ) -> Option<&'a str> {
+        match payload.get("repo").and_then(|v| v.as_str()) {
+            Some(requested) => {
+                let known = record
+                    .repos
+                    .iter()
+                    .find(|r| r.subdir == requested)
+                    .map(|r| r.subdir.as_str());
+                if known.is_none() {
+                    tracing::warn!(
+                        repo = %requested,
+                        "git event names an untracked repo; dropping instead of misattributing"
+                    );
+                }
+                known
+            }
+            None => record.repos.first().map(|r| r.subdir.as_str()),
+        }
+    }
+
     match event {
         rpc::RpcEvent::Named { name, payload } if name == rpc::git::EVENT_BRANCH_CREATED => {
             let Some(branch) = payload.get("branch").and_then(|v| v.as_str()) else {
@@ -77,11 +105,8 @@ fn handle_rpc_event(sup: &Supervisor, app: &AppHandle, agent_id: &str, event: rp
                 return;
             };
             if let Ok(record) = sup.workspace.agent(agent_id) {
-                if let Some(repo) = record.repos.first() {
-                    if let Err(e) = sup
-                        .workspace
-                        .set_repo_branch(agent_id, &repo.subdir, branch)
-                    {
+                if let Some(subdir) = event_subdir(&record, &payload) {
+                    if let Err(e) = sup.workspace.set_repo_branch(agent_id, subdir, branch) {
                         tracing::warn!(
                             error = %e,
                             agent_id = %agent_id,
@@ -89,7 +114,7 @@ fn handle_rpc_event(sup: &Supervisor, app: &AppHandle, agent_id: &str, event: rp
                             "git_push/open_pr: failed to persist branch name"
                         );
                     } else {
-                        emit_branch(app, agent_id, &repo.subdir, branch);
+                        emit_branch(app, agent_id, subdir, branch);
                     }
                 }
             }
@@ -104,10 +129,10 @@ fn handle_rpc_event(sup: &Supervisor, app: &AppHandle, agent_id: &str, event: rp
                 return;
             };
             if let Ok(record) = sup.workspace.agent(agent_id) {
-                if let Some(repo) = record.repos.first() {
+                if let Some(subdir) = event_subdir(&record, &payload) {
                     if let Err(e) =
                         sup.workspace
-                            .set_repo_pr_number(agent_id, &repo.subdir, number as i64)
+                            .set_repo_pr_number(agent_id, subdir, number as i64)
                     {
                         tracing::warn!(
                             error = %e,

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -1050,6 +1050,7 @@ mod tests {
             pr_url: Some("https://github.com/o/r/pull/42".into()),
             pr_title: Some("feat: x".into()),
             pr_state: Some("merged".into()),
+            label: None,
         }
     }
 

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -79,6 +79,12 @@ pub struct TrackedRepo {
     pub pr_title: Option<String>,
     #[serde(default)]
     pub pr_state: Option<String>,
+    /// The repo's display label within its project ("Frontend", "Gateway"),
+    /// denormalized from `repos.label` when the record is read from the DB
+    /// (constructors set `None`; `query_tracked_repos` fills it). `None` falls
+    /// back to the folder basename in the UI and in agent-facing notes.
+    #[serde(default)]
+    pub label: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -1872,6 +1878,25 @@ impl WorkspaceManager {
         .unwrap_or_default()
     }
 
+    /// All repo paths attached to a project, in creation order (the first is
+    /// the primary). Used at spawn to provision one checkout per project repo.
+    pub fn project_repo_paths(&self, project_id: &str) -> Vec<PathBuf> {
+        let conn = self.db.lock();
+        let mut stmt = match conn
+            .prepare("SELECT path FROM repos WHERE project_id = ?1 ORDER BY created_at")
+        {
+            Ok(s) => s,
+            Err(_) => return Vec::new(),
+        };
+        stmt.query_map([project_id], |row| {
+            let p: String = row.get(0)?;
+            Ok(PathBuf::from(p))
+        })
+        .ok()
+        .map(|rows| rows.filter_map(|r| r.ok()).collect())
+        .unwrap_or_default()
+    }
+
     fn query_all_repo_paths(conn: &Connection) -> Vec<PathBuf> {
         let mut stmt = conn
             .prepare("SELECT path FROM repos ORDER BY created_at")
@@ -1947,7 +1972,7 @@ impl WorkspaceManager {
     fn query_tracked_repos(conn: &Connection, agent_id: &str) -> Vec<TrackedRepo> {
         let mut stmt = match conn.prepare(
             "SELECT r.path, w.subdir, w.branch, w.parent_branch, w.base_sha, w.pr_number,
-                    w.pr_url, w.pr_title, w.pr_state
+                    w.pr_url, w.pr_title, w.pr_state, r.label
              FROM worktrees w
              JOIN repos r ON r.id = w.repo_id
              WHERE w.workspace_id = ?1
@@ -1967,6 +1992,7 @@ impl WorkspaceManager {
             let pr_url: Option<String> = row.get(6)?;
             let pr_title: Option<String> = row.get(7)?;
             let pr_state: Option<String> = row.get(8)?;
+            let label: Option<String> = row.get(9)?;
             Ok(TrackedRepo {
                 repo_path: PathBuf::from(path),
                 subdir,
@@ -1977,6 +2003,7 @@ impl WorkspaceManager {
                 pr_url,
                 pr_title,
                 pr_state,
+                label,
             })
         })
         .ok()
@@ -2567,6 +2594,7 @@ mod tests {
             pr_url: None,
             pr_title: None,
             pr_state: None,
+            label: None,
         }
     }
 
@@ -3656,6 +3684,7 @@ mod tests {
             pr_url: None,
             pr_title: None,
             pr_state: None,
+            label: None,
         }];
         wm.restore_agent(&id, restored).unwrap();
         let a = wm.agent(&id).unwrap();
@@ -3724,6 +3753,7 @@ mod tests {
                 pr_url: None,
                 pr_title: None,
                 pr_state: None,
+                label: None,
             },
             "task".into(),
             AgentView::Custom,

--- a/src/api.ts
+++ b/src/api.ts
@@ -35,6 +35,9 @@ export interface TrackedRepo {
   pr_url?: string | null;
   pr_title?: string | null;
   pr_state?: string | null;
+  /** The repo's display label within its project ("Frontend"); null falls
+   *  back to the folder basename. Denormalized from the repos table. */
+  label?: string | null;
 }
 
 export interface DiffStats {

--- a/src/components/Workspace/EmptyWorkspace.tsx
+++ b/src/components/Workspace/EmptyWorkspace.tsx
@@ -31,6 +31,13 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
     }
     return [...seen.values()];
   }, [projectRefs]);
+  // How many repos the drafted project spans — a multi-repo project gets a
+  // checkout of each at spawn, and the sub-copy should say so.
+  const repoCount = useMemo(() => {
+    const projectId = projectRefs.find((r) => r.path === draft.repoPath)?.project_id;
+    if (!projectId) return 1;
+    return projectRefs.filter((r) => r.project_id === projectId).length;
+  }, [projectRefs, draft.repoPath]);
   const toggleLeft = useAppStore((s) => s.toggleLeft);
   const leftCollapsed = useAppStore((s) => s.leftCollapsed);
   const runLocalCommand = useAppStore((s) => s.runLocalCommand);
@@ -121,7 +128,9 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
             <>
               <h1 className="empty-title text-5xl">What should be the first task?</h1>
               <p className="empty-sub text-base">
-                A checkout and sandbox will be created at{" "}
+                {repoCount > 1
+                  ? `Checkouts of all ${repoCount} repositories and a sandbox will be created at `
+                  : "A checkout and sandbox will be created at "}
                 <span style={{ fontFamily: "var(--font-mono)", color: "var(--fg-1)" }}>
                   ~/.fletch/workspaces/{draft.name}
                 </span>


### PR DESCRIPTION
## What

Second slice of multi-repo projects (stacked on #458). Spawning an agent on a multi-repo project now forks a checkout of **every** repo in the project, tells the agent about the workspace layout, and lets it push / open PRs on any of them through the host RPC. The user never picks repos: all of a project's repos are cloned, untouched ones simply stay clean.

## Changes

**Spawn (`supervisor/lifecycle.rs`)**
- After the primary checkout is provisioned, each remaining project repo is attached via the same core `add_repo_to_agent` uses (extracted as `attach_repo_checkout`). Spawn-time secondaries always use `--shared` clones — the Docker container doesn't exist yet, so its mounts and borrowed object stores still cover them; the self-contained copy remains only for repos added to a *live* Docker agent. A failed secondary checkout fails the spawn cleanly (teardown + error naming the repo).
- Workflow step agents stay single-repo — a run targets one repo by design.

**Agent context (`instructions.rs`)**
- New `multi_repo_workspace_note`: lists each sibling checkout by directory name with its project label ("`backend/` — Gateway"), marks the starting checkout, and points at the `args.repo` selector. Composed ahead of the custom brief on every launch; single-repo agents inject nothing extra.

**Git RPC (`rpc/git.rs`)**
- `GitDispatcher` now carries every tracked checkout keyed by subdir. `git_push`, `open_pr`, `git_fetch`, and `git_status` accept an optional `args.repo` and default to the primary checkout — existing prompts and single-repo agents behave byte-identically. Unknown names are rejected with the tracked list, so a typo can't operate on the wrong repo. `rpc_protocol.md` documents the arg.

**Plumbing**
- `TrackedRepo` gains a `label` field, denormalized from `repos.label` when records are read (used by the note now, by the per-repo git panel in PR 3).
- New-agent screen copy says "Checkouts of all N repositories…" for multi-repo projects.

## Compatibility

Single-repo projects: the secondary loop finds nothing, the note is `None`, the dispatcher map has one entry, and every op without `args.repo` targets the primary — behavior is unchanged end to end.

## Testing

- New tests: `args.repo` targets a sibling checkout / unknown repo rejected with tracked names (`rpc/git.rs`), workspace-note formatting incl. label fallback and single-repo suppression (`instructions.rs`).
- Full suites: cargo 887 passed, tsc clean, biome clean, 447 vitest passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)