### PR TITLE
feat(git-panel): per-repo git surface for multi-repo agents

### DIFF
--- a/docs/multi-repo-followups.md
+++ b/docs/multi-repo-followups.md
@@ -1,0 +1,270 @@
+# Multi-repo projects — follow-up work
+
+Hand-off document for the work remaining after the multi-repo stack:
+
+- **PR #458** `feat/multi-repo-projects` — projects hold N repos; Repositories
+  field in project settings (attach/detach/relocate, per-repo labels); sidebar
+  groups by project.
+- **PR #459** `feat/multi-repo-spawn` — spawn forks a checkout of every project
+  repo; agents get a workspace-layout note; host git RPC ops accept `args.repo`;
+  branch/PR events carry the targeted repo.
+- **PR #460** `feat/multi-repo-git-panel` — panel commands take an optional
+  `subdir`; Git panel renders per-repo sections with progressive disclosure;
+  delegations are repo-scoped.
+
+Read this primer first; each task below is self-contained after it.
+
+## Architecture primer (state as of PR #460)
+
+**Data model.** A project is `projects(id, name)` — no path. Repos hang off it:
+`repos(id, project_id, path UNIQUE, label)`. An agent (a `workspaces` row) has
+one `worktrees` row per checkout: `worktrees(workspace_id, repo_id, subdir,
+branch, parent_branch, base_sha, pr_number, pr_url, pr_title, pr_state, …)`.
+In memory that's `AgentRecord.repos: Vec<TrackedRepo>` — always non-empty,
+`repos[0]` is the **primary** (the repo the user spawned against). A repo
+within an agent is addressed by its `subdir` — the checkout's directory name
+under `~/.fletch/workspaces/<agent-id>/`. `TrackedRepo.label` is denormalized
+from `repos.label` at query time (`query_tracked_repos`,
+`src-tauri/src/workspace.rs`).
+
+**The primary-default convention.** Every per-agent surface takes an optional
+repo scope and defaults to the primary, so single-repo behavior is
+byte-identical everywhere:
+
+- Backend panel commands: `subdir: Option<String>` resolved by
+  `agent_repo_checkout(_opt)` (`src-tauri/src/commands.rs`, near the other
+  `fn primary_*` helpers).
+- PR resolution: `resolve_pr_state(workspace, agent_id, subdir: Option<&str>)`
+  (`src-tauri/src/supervisor/session_sync.rs`).
+- Agent-facing RPC (`git_push` / `open_pr` / `git_fetch` / `git_status`):
+  optional `args.repo` = subdir (`src-tauri/src/rpc/git.rs`, `GitDispatcher`,
+  built per-spawn in `supervisor/lifecycle.rs::start_process`). Emitted
+  `git.branch_created` / `git.pr_opened` events carry `repo`; the consumer
+  (`supervisor/rpc_watch.rs`) persists branch/PR onto the matching worktree
+  row, falling back to primary when the field is absent.
+- Frontend store: `gitKey(agentId, subdir?)` in `src/store/git.ts` —
+  `subdir ? `${agentId}::${subdir}` : agentId`. The **plain agent id is the
+  primary's key** and is the only key the app-wide write paths use (bulk
+  polls, `pr:state_changed` reducer in `src/store/app.ts`, sidebar badges,
+  `src/util/prState.ts`). Only the Git panel's per-repo fetches use suffixed
+  keys.
+- Git panel: `GitPanel` (`src/components/RightPanel/GitPanel/index.tsx`)
+  orchestrates `GitRepoSection` per repo. A repo renders a section when
+  "active" (changed files ∨ branch ∨ PR ∨ pinned by an in-flight delegation).
+  Single-repo agents early-return the bare section — pixel-identical to the
+  old panel. Delegations (`GitDelegation` in
+  `src/components/RightPanel/delegation.ts`) carry `subdir?`; the matching
+  section's `useDelegationLifecycle` owns the lifecycle.
+
+**Non-negotiable invariants for all follow-ups:**
+
+1. Single-repo projects/agents must stay byte-identical (no visual or
+   behavioral diff). The pattern that achieves this everywhere: optional scope
+   param, primary default, plain-agent-id store keys for the primary.
+2. Never attribute one repo's git/PR state to another. When adding a repo
+   dimension to a currently agent-keyed path, either thread the subdir or
+   leave the path primary-only — no silent `repos[0]` when a scope exists.
+3. Workflow step agents are single-repo by design (`wf_run.repo_path`); don't
+   accidentally multi-repo them (spawn skips secondaries when
+   `run_repo_for_task.is_some()` — keep that).
+
+Verification baseline: `cargo test --lib` (src-tauri; ~890 tests),
+`bun run check`, `bun run lint` (0 errors / ~72 legacy warnings),
+`bun run test` (447). In sandboxed environments set `TMPDIR=$PWD/.tmp` for bun.
+
+---
+
+## 1. Sidebar PR badge fan-out  ·  priority: high  ·  size: M
+
+**Problem.** The app-wide PR polls and every badge read only the primary:
+`refresh_all_pr_states` / `refresh_all_pr_checks`
+(`src-tauri/src/commands.rs`) and `resolve_all_pr_states`
+(`supervisor/session_sync.rs`) iterate `agent.repos.first()`; the frontend
+maps `prStates[agentId]` / `prChecks[agentId]` hold one entry per agent;
+`src/util/prState.ts` falls back to `repos[0]`. A multi-repo agent whose only
+PR is on a secondary repo shows no sidebar badge at all (the panel is
+correct; the badge isn't).
+
+**Sketch.**
+- Backend: change the pending-set builders in `resolve_all_pr_states` and
+  `refresh_all_pr_checks` to iterate all `agent.repos` (each entry already
+  tracks `subdir`; `Pending { agent_id, subdir, … }` exists). Return maps
+  keyed `agent_id -> Vec<{subdir, state}>` or flat `"{agent_id}::{subdir}"`
+  string keys — pick ONE and mirror `gitKey` exactly (`::` separator; primary
+  entry keyed by plain agent id to preserve every existing consumer).
+  Preserve the omit-on-unknown contract (absent ≠ null) per the doc comments
+  on both commands.
+- Frontend: the poll reducers (`refreshAllPrStates` / `refreshAllPrChecks` in
+  `src/store/git.ts`) merge the returned keys as-is — if the backend keys by
+  `gitKey`, no reducer change is needed beyond accepting extra keys.
+- Badge UI (`src/components/Sidebar/AgentRow.tsx` + `src/util/prState.ts`):
+  aggregate across the agent's repos. Suggested rendering: keep the single PR
+  pill when exactly one repo has a PR (whatever repo it's on — this fixes the
+  main bug); with >1, show `N PRs` with the *worst* status tint (any failing
+  checks → failing; any open → open; all merged → merged). Keep
+  `prState.ts`'s snapshot-fallback policy per repo (`prSnapshot(repo)` works
+  on any TrackedRepo).
+
+**Acceptance.**
+- Agent with PR only on secondary repo → sidebar badge shows it.
+- Two PRs → aggregate pill; tint follows worst status; opening the agent
+  shows the matching panel sections.
+- Single-repo agents: unchanged badge, unchanged poll payload size (one entry).
+- No per-agent `gh` fan-out: the batched GraphQL query grows by repo count,
+  not by extra round trips (both batch fns already alias per-lookup).
+
+**Pitfalls.** The one-PR-per-agent shape is asserted in comments
+(`commands.rs` "multi-repo PR tracking is out of scope here" — delete those);
+`session_sync.rs` has `pr_opened_at/pr_merged_at` timestamps persisted per
+worktree via `persist_pr_snapshot` — already per-repo, don't duplicate.
+Delegation attribution (`markGitDelegationSawOp` path) keys off
+`agent:git-action` events, not prStates — untouched.
+
+## 2. "One task → N PRs" presented as a unit  ·  priority: high  ·  size: M
+
+**Problem.** Each panel section shows its own PR, but nothing communicates
+"this task produced 3 related PRs": no cross-links in PR bodies, no suggested
+merge order, no combined status.
+
+**Sketch.**
+- Cross-linking at creation: when `open_pr` (RPC, `src-tauri/src/rpc/git.rs`)
+  or `create_pr` (panel command) runs for an agent that already has other
+  bound PRs, append a generated trailer to the body:
+  `---\nPart of a multi-repo change in <project name>: fwdai/frontend#12,
+  fwdai/backend#34`. Backfill the older PRs' bodies via a
+  best-effort `gh pr edit`-equivalent (there's a GitHub client in
+  `src-tauri/src/github/mod.rs`; add `pr_update_body(checkout, number, body)`
+  if missing). Idempotency: mark the trailer with an HTML comment sentinel
+  (`<!-- fletch:pr-set -->`) and replace between sentinels rather than append.
+- Panel summary strip: in `MultiRepoGitPanel`, when ≥2 sections have PRs,
+  render a slim strip above the sections: `2 PRs · 1 green · 1 checks running`
+  with each PR number linking out. Data is already in the store under
+  `gitKey` keys.
+- Merge order: keep it lightweight — a static hint derived from repo order
+  (primary last?) is guesswork; better to let the user merge from each
+  section and skip ordering logic entirely in v1. Do NOT build cross-repo
+  merge gating yet.
+
+**Acceptance.** Opening 2nd PR of an agent updates both bodies with the set
+trailer exactly once (re-running doesn't duplicate); panel shows the summary
+strip; single-PR agents see no trailer and no strip.
+
+**Pitfalls.** Body edits race the agent's own `open_pr` body — sentinel
+replacement, never string-append. `pr_create` returns `PrState` without body;
+fetch before edit. Respect the rate-limit backoff guard
+(`gh::client::is_backing_off()`).
+
+## 3. Code tab (file tree + editor) multi-repo  ·  priority: medium  ·  size: M
+
+**Problem.** `list_checkout_tree`, `read/write/create/copy_checkout_file`
+(`src-tauri/src/commands.rs`, helper `primary_checkout`) operate on the
+primary checkout only. A multi-repo agent's secondary-repo edits are
+invisible in the Code tab (`src/components/RightPanel/FilePanel/index.tsx`).
+
+**Sketch (choose A; B listed for completeness).**
+- **A — repo-prefixed virtual root (recommended):** for `repos.len() > 1`,
+  `list_checkout_tree` returns paths prefixed `"<subdir>/…"` (walk each
+  checkout, prefix, concat; per-repo git status vs each repo's own
+  `diff_base`). File read/write commands split the first path segment against
+  the agent's subdirs to pick the checkout, falling back to primary-relative
+  for single-repo (exact current behavior). Frontend FilePanel needs little:
+  the tree component already nests by `/`; top-level folders become the repos.
+  Diff view: per-file diff fetch must use the same subdir resolution.
+- **B — repo selector dropdown in the panel:** smaller backend change
+  (`subdir` param like the git commands) but adds a UI mode switch; rejected
+  by the product direction (obscure the plumbing; one tree).
+
+**Acceptance.** Multi-repo agent: tree shows one top-level folder per repo
+with per-repo status badges; opening/editing/creating a file in a secondary
+repo works; single-repo agents see today's un-prefixed tree.
+
+**Pitfalls.** Path-splitting must not treat a real top-level directory named
+like a subdir in the *single*-repo case (gate all prefix logic on
+`repos.len() > 1`). `write_checkout_file` safety checks (path traversal
+guards) must run against the resolved checkout root.
+
+## 4. Per-repo base branch at spawn  ·  priority: low  ·  size: S
+
+**Problem.** The new-agent BranchPicker sets the base for the primary only;
+secondaries fork from their repo's current branch
+(`attach_repo_checkout` in `supervisor/lifecycle.rs` uses
+`git::current_branch(&repo_path)`).
+
+**Sketch.** Add a nullable `default_base` column to `repos` (migration 0023,
+mirror 0022_repo_label.sql), editable in the Repositories field rows
+(`src/components/ProjectSettings/RepositoriesField.tsx`) as a small branch
+input/picker. `attach_repo_checkout` prefers `default_base` when set. The
+spawn-time picker continues to govern the primary.
+
+**Acceptance.** Set backend default base = `develop` → new agents' backend
+checkout forks from `develop` (verify `parent_branch` on the worktree row);
+unset → current behavior.
+
+## 5. Secondary push → PR state latency  ·  priority: low  ·  size: S
+
+**Problem.** After a push on a secondary repo, `push_agent` fires
+`fetch_and_emit_pr_state(app, agent_id)` (primary-scoped) and the
+`pr:state_changed` event is agent-keyed, so the secondary section's PR card
+updates only on its 5s poll.
+
+**Sketch.** Thread subdir: `fetch_and_emit_pr_state(app, agent_id, subdir)`
+(`session_sync.rs` — it already calls `resolve_pr_state(…, None)`; pass the
+subdir through) and extend the `pr:state_changed` payload with optional
+`subdir`. Frontend reducer (`src/store/app.ts`, search `pr:state_changed`)
+writes under `gitKey(agent_id, subdir)`. RPC-side `EVENT_PR_OPENED` handling
+in `rpc_watch.rs` calls `fetch_and_emit_pr_state` — pass the event's repo.
+Old events without the field keep the plain key (primary) — same
+compatibility dance as the branch events.
+
+**Acceptance.** Agent opens PR on secondary via RPC → that section's card
+flips to "PR open" within ~1s (event path), not 5s (poll).
+
+## 6. `publish_agent` repo-awareness  ·  priority: low  ·  size: S
+
+**Problem.** "Publish to GitHub" (local-only repo, no origin) publishes the
+primary (`commands.rs::publish_agent`). A secondary section with
+`has_origin: false` shows the publish action but would publish the wrong
+repo.
+
+**Sketch.** Add `subdir: Option<String>` like the other panel commands; the
+frontend `useGitActions` "publish" case passes `ctx.subdir` (it already has
+it). Check the backend impl for primary assumptions (it publishes from the
+*source repo root*, not the checkout — resolve the source repo through the
+agent's TrackedRepo by subdir).
+
+**Acceptance.** Local-only secondary repo publishes itself; primary flow
+unchanged.
+
+## 7. Multi-repo workflows  ·  priority: parked  ·  size: L — design first
+
+`wf_run` has `repo_path` + `base_branch` baked into schema (migration 0019 /
+0020) and every step provisions from that one repo
+(`workflow/scheduler.rs::wf_launch`, `provision_forking_run_repo` call sites).
+Options when demand appears: (a) run-level repo set with per-step primary,
+(b) per-step repo scope in workflow YAML (`src/workflows/spec.ts` `Step`),
+(c) keep runs single-repo and compose one run per repo. Don't start without a
+design doc; the scheduler's step hand-off (refs `refs/wf/steps/<prev>`) is
+single-repo throughout, and finalize (`Finalize { push, open_pr, pr_base }`)
+assumes one PR target. Free-form agents already cover multi-repo tasks — this
+is the deliberate v1 boundary.
+
+## 8. Merging projects that have history  ·  priority: parked  ·  size: M
+
+`attach_repo_to_project` (`workspace.rs`) moves a repo out of its old project
+only when that project is empty; a project with agents/workflow runs is
+rejected with an explanatory error. Lifting that means re-pointing
+`workspaces.project_id` and `wf_run.project_id` for the moved repo's agents —
+but agents can have checkouts of *multiple* repos, so "which project owns the
+agent" becomes ambiguous the moment projects merge. Needs a decision (likely:
+move all agents whose primary repo is the moved repo; refuse if any agent
+spans both projects), plus extending `AttachOutcome`/`undo_attach` to cover
+the re-pointing rollback. Don't attempt as a drive-by.
+
+---
+
+## Suggested sequencing
+
+1 + 2 together ("multi-repo review surface" — they share the PR fan-out
+plumbing), then 3, then 5 + 6 as a small cleanup pair, 4 when someone asks,
+7/8 on demand with design first. Base each PR on the multi-repo stack (or
+main once #458–#460 land).

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -599,14 +599,15 @@ pub async fn add_repo_to_agent(
         .await
 }
 
-/// Push the primary repo's current branch to origin.
+/// Push the targeted repo's current branch to origin (primary by default).
 #[tauri::command]
 pub async fn push_agent(
     supervisor: State<'_, Arc<Supervisor>>,
     app: AppHandle,
     agent_id: String,
+    subdir: Option<String>,
 ) -> Result<String> {
-    let (repo, checkout) = primary_repo_checkout(&supervisor, &agent_id)?;
+    let (repo, checkout) = agent_repo_checkout(&supervisor, &agent_id, subdir.as_deref())?;
     let branch = repo_branch(&repo)?.to_string();
     let summary = git::push(&checkout, &branch, false).await?;
     // After successful push, fetch PR state in background
@@ -620,8 +621,9 @@ pub async fn commit_agent(
     supervisor: State<'_, Arc<Supervisor>>,
     agent_id: String,
     message: String,
+    subdir: Option<String>,
 ) -> Result<()> {
-    let (_repo, checkout) = primary_repo_checkout(&supervisor, &agent_id)?;
+    let (_repo, checkout) = agent_repo_checkout(&supervisor, &agent_id, subdir.as_deref())?;
     git::commit(&checkout, &message).await
 }
 
@@ -630,15 +632,20 @@ pub async fn commit_agent(
 pub async fn discard_agent_changes(
     supervisor: State<'_, Arc<Supervisor>>,
     agent_id: String,
+    subdir: Option<String>,
 ) -> Result<()> {
-    let (_repo, checkout) = primary_repo_checkout(&supervisor, &agent_id)?;
+    let (_repo, checkout) = agent_repo_checkout(&supervisor, &agent_id, subdir.as_deref())?;
     git::discard_all(&checkout).await
 }
 
 /// Stash all working-tree changes including untracked files.
 #[tauri::command]
-pub async fn stash_agent(supervisor: State<'_, Arc<Supervisor>>, agent_id: String) -> Result<()> {
-    let (_repo, checkout) = primary_repo_checkout(&supervisor, &agent_id)?;
+pub async fn stash_agent(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+    subdir: Option<String>,
+) -> Result<()> {
+    let (_repo, checkout) = agent_repo_checkout(&supervisor, &agent_id, subdir.as_deref())?;
     git::stash_push(&checkout).await
 }
 
@@ -647,8 +654,9 @@ pub async fn stash_agent(supervisor: State<'_, Arc<Supervisor>>, agent_id: Strin
 pub async fn abort_merge_agent(
     supervisor: State<'_, Arc<Supervisor>>,
     agent_id: String,
+    subdir: Option<String>,
 ) -> Result<()> {
-    let (_repo, checkout) = primary_repo_checkout(&supervisor, &agent_id)?;
+    let (_repo, checkout) = agent_repo_checkout(&supervisor, &agent_id, subdir.as_deref())?;
     git::merge_abort(&checkout).await
 }
 
@@ -666,24 +674,33 @@ pub async fn list_repo_branches(repo_path: String) -> Result<Vec<String>> {
 pub async fn delete_branch_agent(
     supervisor: State<'_, Arc<Supervisor>>,
     agent_id: String,
+    subdir: Option<String>,
 ) -> Result<()> {
-    let repo = primary_repo(&supervisor, &agent_id)?;
+    let (repo, _checkout) = agent_repo_checkout(&supervisor, &agent_id, subdir.as_deref())?;
     let branch = repo_branch(&repo)?;
     git::branch_delete(&repo.repo_path, branch).await
 }
 
-/// Pull latest into the primary repo's checkout.
+/// Pull latest into the targeted repo's checkout (primary by default).
 #[tauri::command]
-pub async fn pull_agent(supervisor: State<'_, Arc<Supervisor>>, agent_id: String) -> Result<()> {
-    let (_repo, checkout) = primary_repo_checkout(&supervisor, &agent_id)?;
+pub async fn pull_agent(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+    subdir: Option<String>,
+) -> Result<()> {
+    let (_repo, checkout) = agent_repo_checkout(&supervisor, &agent_id, subdir.as_deref())?;
     git::pull(&checkout).await
 }
 
 /// Rebase the agent's branch onto its parent (base) branch. Used by the
 /// clean-state panel action to catch up when the base has advanced.
 #[tauri::command]
-pub async fn rebase_agent(supervisor: State<'_, Arc<Supervisor>>, agent_id: String) -> Result<()> {
-    let (repo, checkout) = primary_repo_checkout(&supervisor, &agent_id)?;
+pub async fn rebase_agent(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+    subdir: Option<String>,
+) -> Result<()> {
+    let (repo, checkout) = agent_repo_checkout(&supervisor, &agent_id, subdir.as_deref())?;
     let base = repo.parent_branch.as_deref().unwrap_or("main");
     git::rebase_onto(&checkout, base).await
 }
@@ -696,8 +713,9 @@ pub async fn create_pr(
     agent_id: String,
     title: String,
     body: String,
+    subdir: Option<String>,
 ) -> Result<PrState> {
-    let (repo, checkout) = primary_repo_checkout(&supervisor, &agent_id)?;
+    let (repo, checkout) = agent_repo_checkout(&supervisor, &agent_id, subdir.as_deref())?;
     let base = repo.parent_branch.as_deref().unwrap_or("main");
     let pr = gh::pr_create(&checkout, &title, &body, base).await?;
     crate::telemetry::track("pr_opened", serde_json::json!({ "source": "manual" }));
@@ -709,10 +727,14 @@ pub async fn create_pr(
     Ok(pr)
 }
 
-/// Merge the open PR for the agent's current branch.
+/// Merge the open PR for the targeted repo's current branch.
 #[tauri::command]
-pub async fn merge_pr(supervisor: State<'_, Arc<Supervisor>>, agent_id: String) -> Result<()> {
-    let (_repo, checkout) = primary_repo_checkout(&supervisor, &agent_id)?;
+pub async fn merge_pr(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+    subdir: Option<String>,
+) -> Result<()> {
+    let (_repo, checkout) = agent_repo_checkout(&supervisor, &agent_id, subdir.as_deref())?;
     gh::pr_merge(&checkout).await
 }
 
@@ -725,9 +747,10 @@ pub async fn merge_pr(supervisor: State<'_, Arc<Supervisor>>, agent_id: String) 
 pub async fn get_pr_state(
     supervisor: State<'_, Arc<Supervisor>>,
     agent_id: String,
+    subdir: Option<String>,
 ) -> Result<Option<PrState>> {
     Ok(
-        crate::supervisor::resolve_pr_state(&supervisor.workspace, &agent_id)
+        crate::supervisor::resolve_pr_state(&supervisor.workspace, &agent_id, subdir.as_deref())
             .await
             .map(|(pr, _bound)| pr),
     )
@@ -760,8 +783,11 @@ pub async fn list_repo_prs(repo_path: String) -> Result<Vec<gh::PrSummary>> {
 pub async fn get_pr_checks(
     supervisor: State<'_, Arc<Supervisor>>,
     agent_id: String,
+    subdir: Option<String>,
 ) -> Result<Option<gh::PrChecks>> {
-    let Some((repo, checkout)) = primary_repo_checkout_opt(&supervisor, &agent_id)? else {
+    let Some((repo, checkout)) =
+        agent_repo_checkout_opt(&supervisor, &agent_id, subdir.as_deref())?
+    else {
         return Ok(None);
     };
     if repo.branch.is_none() {
@@ -777,8 +803,11 @@ pub async fn get_pr_checks(
 pub async fn get_pr_comments(
     supervisor: State<'_, Arc<Supervisor>>,
     agent_id: String,
+    subdir: Option<String>,
 ) -> Result<Option<gh::PrComments>> {
-    let Some((repo, checkout)) = primary_repo_checkout_opt(&supervisor, &agent_id)? else {
+    let Some((repo, checkout)) =
+        agent_repo_checkout_opt(&supervisor, &agent_id, subdir.as_deref())?
+    else {
         return Ok(None);
     };
     if repo.branch.is_none() {
@@ -916,14 +945,17 @@ pub fn clear_env_override(project_id: String, key: String) -> Result<()> {
     crate::run_env::override_delete(&crate::run_env::override_secret_key(&project_id, &key))
 }
 
-/// Returns git state for the agent's primary repo.
-/// For multi-repo agents only the first repo's state is returned.
+/// Returns git state for one of the agent's checkouts — the repo whose
+/// `subdir` matches, or the primary when none is given.
 #[tauri::command]
 pub async fn get_git_state(
     supervisor: State<'_, Arc<Supervisor>>,
     agent_id: String,
+    subdir: Option<String>,
 ) -> Result<Option<GitState>> {
-    let Some((repo, checkout)) = primary_repo_checkout_opt(&supervisor, &agent_id)? else {
+    let Some((repo, checkout)) =
+        agent_repo_checkout_opt(&supervisor, &agent_id, subdir.as_deref())?
+    else {
         return Ok(None);
     };
     let parent = repo.parent_branch.as_deref().unwrap_or("main");
@@ -957,19 +989,28 @@ pub async fn get_all_shortstats(
         if agent.archive.is_some() {
             continue;
         }
-        let Some(repo) = agent.repos.first() else {
-            continue;
-        };
-        let Ok(checkout) = repo_checkout_path(&agent.id, &repo.subdir) else {
-            continue;
-        };
-        let agent_id = agent.id.clone();
-        set.spawn(async move { (agent_id, git_state::shortstats(&checkout).await) });
+        // One shortstat per checkout; a multi-repo agent's badge shows the
+        // sum across all of its repos (matching the archive metadata, which
+        // also aggregates). Single-repo agents behave exactly as before.
+        for repo in &agent.repos {
+            let Ok(checkout) = repo_checkout_path(&agent.id, &repo.subdir) else {
+                continue;
+            };
+            let agent_id = agent.id.clone();
+            set.spawn(async move { (agent_id, git_state::shortstats(&checkout).await) });
+        }
     }
-    let mut out = std::collections::HashMap::new();
+    let mut out: std::collections::HashMap<String, ShortStats> = std::collections::HashMap::new();
     while let Some(res) = set.join_next().await {
         if let Ok((id, stats)) = res {
-            out.insert(id, stats);
+            let entry = out.entry(id).or_insert(ShortStats {
+                additions: 0,
+                deletions: 0,
+                file_count: 0,
+            });
+            entry.additions += stats.additions;
+            entry.deletions += stats.deletions;
+            entry.file_count += stats.file_count;
         }
     }
     Ok(out)
@@ -1202,17 +1243,43 @@ fn primary_repo_checkout(
     Ok((repo, checkout))
 }
 
+/// The tracked repo a panel command targets: the one whose `subdir` matches,
+/// or the primary when no subdir is given — which keeps every single-repo
+/// caller (and old frontends that don't pass the arg) byte-identical.
+fn agent_repo_checkout(
+    supervisor: &Supervisor,
+    agent_id: &str,
+    subdir: Option<&str>,
+) -> Result<(TrackedRepo, PathBuf)> {
+    let Some(s) = subdir else {
+        return primary_repo_checkout(supervisor, agent_id);
+    };
+    let record = supervisor.workspace.agent(agent_id)?;
+    let repo = record
+        .repos
+        .into_iter()
+        .find(|r| r.subdir == s)
+        .ok_or_else(|| Error::Other(format!("agent has no tracked repo {s:?}")))?;
+    let checkout = repo_checkout_path(agent_id, &repo.subdir)?;
+    Ok((repo, checkout))
+}
+
 /// Best-effort variant for read-only lookups (git / PR state): returns `None`
 /// instead of an error when the agent or its repo can't be resolved, so callers
 /// can degrade gracefully rather than surfacing a failure.
-fn primary_repo_checkout_opt(
+fn agent_repo_checkout_opt(
     supervisor: &Supervisor,
     agent_id: &str,
+    subdir: Option<&str>,
 ) -> Result<Option<(TrackedRepo, PathBuf)>> {
     let Ok(record) = supervisor.workspace.agent(agent_id) else {
         return Ok(None);
     };
-    let Some(repo) = record.repos.into_iter().next() else {
+    let repo = match subdir {
+        None => record.repos.into_iter().next(),
+        Some(s) => record.repos.into_iter().find(|r| r.subdir == s),
+    };
+    let Some(repo) = repo else {
         return Ok(None);
     };
     let checkout = repo_checkout_path(agent_id, &repo.subdir)?;

--- a/src-tauri/src/instructions/git_actions.md
+++ b/src-tauri/src/instructions/git_actions.md
@@ -6,6 +6,12 @@ When the user clicks a git action in the app, the app sends a one-line request o
 
 Treat it exactly like a user request and follow the matching playbook below — nothing more, nothing less. Keep your reply brief: one line on what you did (plus the PR URL when you opened one).
 
+In a multi-repo workspace a trigger may carry `repo="<dir>"` — the sibling
+checkout the action targets. Run the playbook **in that checkout** (`cd` into
+`../<dir>` for the local git steps) and pass the same value as `args.repo` on
+every host RPC op you use (`git_push`, `open_pr`, `git_fetch`). No `repo`
+param means your starting (primary) checkout, as always.
+
 **Local git is yours to run directly.** Your workspace is a real checkout with a writable `.git`, so run plain git for local work: `git status`, `git add`, `git commit`, `git merge`, and conflict resolution all work in-place. What Fletch runs *for* you are the actions that need your GitHub credentials — and those stay on the host, never in your sandbox. So for anything that talks to the remote, use the file-RPC ops:
 
 - **`git_push`** — push the current branch to `origin`. Pass `args.force=true` to push a rewritten history (e.g. after a rebase); it uses `--force-with-lease`, which rewrites the remote branch but refuses if the remote has moved in a way you haven't seen.

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -87,7 +87,7 @@ impl Supervisor {
             // Only bound PRs are emitted app-wide: an unbound merged/closed PR
             // discovered on a recycled branch name is focused-panel display
             // (`get_pr_state`), not this agent's state.
-            let state = resolve_pr_state(&workspace, &agent_id)
+            let state = resolve_pr_state(&workspace, &agent_id, None)
                 .await
                 .and_then(|(pr, bound)| bound.then_some(pr));
             emit_pr_state(&app, &agent_id, state);
@@ -149,9 +149,15 @@ pub(crate) fn persist_pr_snapshot(
 pub(crate) async fn resolve_pr_state(
     workspace: &WorkspaceManager,
     agent_id: &str,
+    subdir: Option<&str>,
 ) -> Option<(PrState, bool)> {
     let record = workspace.agent(agent_id).ok()?;
-    let repo = record.repos.first()?;
+    let repo = match subdir {
+        // A specific checkout (the multi-repo panel's per-repo sections).
+        Some(s) => record.repos.iter().find(|r| r.subdir == s)?,
+        // Default: the primary — the app-wide badge/poll shape.
+        None => record.repos.first()?,
+    };
     // No branch yet → nothing pushed, so no PR to find or bind.
     repo.branch.as_ref()?;
     let checkout = repo_checkout_path(agent_id, &repo.subdir).ok()?;

--- a/src/api.ts
+++ b/src/api.ts
@@ -681,26 +681,39 @@ export const api = {
   addRepoToAgent: (agentId: string, repoPath: string) =>
     invoke<TrackedRepo>("add_repo_to_agent", { agentId, repoPath }),
   allocateDraftName: (used: string[]) => invoke<string>("allocate_draft_name", { used }),
-  getGitState: (agentId: string) => invoke<GitState | null>("get_git_state", { agentId }),
+  // Git/PR commands below take an optional `subdir` (a checkout's directory
+  // name from `TrackedRepo.subdir`) to target one repo of a multi-repo agent.
+  // Omitted/undefined serializes to None = the agent's primary (first) repo.
+  getGitState: (agentId: string, subdir?: string) =>
+    invoke<GitState | null>("get_git_state", { agentId, subdir }),
   getAllShortstats: () => invoke<Record<string, ShortStats>>("get_all_shortstats"),
-  getPrState: (agentId: string) => invoke<PrState | null>("get_pr_state", { agentId }),
+  getPrState: (agentId: string, subdir?: string) =>
+    invoke<PrState | null>("get_pr_state", { agentId, subdir }),
   refreshAllPrStates: () => invoke<Record<string, PrState | null>>("refresh_all_pr_states"),
   refreshAllPrChecks: () => invoke<Record<string, PrChecks | null>>("refresh_all_pr_checks"),
-  getPrChecks: (agentId: string) => invoke<PrChecks | null>("get_pr_checks", { agentId }),
-  getPrComments: (agentId: string) => invoke<PrComments | null>("get_pr_comments", { agentId }),
-  pushAgent: (agentId: string) => invoke<string>("push_agent", { agentId }),
-  pullAgent: (agentId: string) => invoke<void>("pull_agent", { agentId }),
-  rebaseAgent: (agentId: string) => invoke<void>("rebase_agent", { agentId }),
-  commitAgent: (agentId: string, message: string) =>
-    invoke<void>("commit_agent", { agentId, message }),
-  discardAgentChanges: (agentId: string) => invoke<void>("discard_agent_changes", { agentId }),
-  stashAgent: (agentId: string) => invoke<void>("stash_agent", { agentId }),
-  abortMergeAgent: (agentId: string) => invoke<void>("abort_merge_agent", { agentId }),
-  deleteBranchAgent: (agentId: string) => invoke<void>("delete_branch_agent", { agentId }),
+  getPrChecks: (agentId: string, subdir?: string) =>
+    invoke<PrChecks | null>("get_pr_checks", { agentId, subdir }),
+  getPrComments: (agentId: string, subdir?: string) =>
+    invoke<PrComments | null>("get_pr_comments", { agentId, subdir }),
+  pushAgent: (agentId: string, subdir?: string) =>
+    invoke<string>("push_agent", { agentId, subdir }),
+  pullAgent: (agentId: string, subdir?: string) => invoke<void>("pull_agent", { agentId, subdir }),
+  rebaseAgent: (agentId: string, subdir?: string) =>
+    invoke<void>("rebase_agent", { agentId, subdir }),
+  commitAgent: (agentId: string, message: string, subdir?: string) =>
+    invoke<void>("commit_agent", { agentId, message, subdir }),
+  discardAgentChanges: (agentId: string, subdir?: string) =>
+    invoke<void>("discard_agent_changes", { agentId, subdir }),
+  stashAgent: (agentId: string, subdir?: string) =>
+    invoke<void>("stash_agent", { agentId, subdir }),
+  abortMergeAgent: (agentId: string, subdir?: string) =>
+    invoke<void>("abort_merge_agent", { agentId, subdir }),
+  deleteBranchAgent: (agentId: string, subdir?: string) =>
+    invoke<void>("delete_branch_agent", { agentId, subdir }),
   listRepoBranches: (repoPath: string) => invoke<string[]>("list_repo_branches", { repoPath }),
-  createPr: (agentId: string, title: string, body: string) =>
-    invoke<PrState>("create_pr", { agentId, title, body }),
-  mergePr: (agentId: string) => invoke<void>("merge_pr", { agentId }),
+  createPr: (agentId: string, title: string, body: string, subdir?: string) =>
+    invoke<PrState>("create_pr", { agentId, title, body, subdir }),
+  mergePr: (agentId: string, subdir?: string) => invoke<void>("merge_pr", { agentId, subdir }),
   openAgentShell: (agentId: string) => invoke<void>("open_agent_shell", { agentId }),
   closeAgentShell: (agentId: string) => invoke<void>("close_agent_shell", { agentId }),
   writeToShell: (agentId: string, data: string) =>

--- a/src/components/RightPanel/GitPanel/GitPanel.css
+++ b/src/components/RightPanel/GitPanel/GitPanel.css
@@ -1019,3 +1019,33 @@
   background: transparent;
   color: var(--fg-1);
 }
+
+/* ── multi-repo: one section per active repo, slim repo-name headers ──
+   Single-repo agents never render these — their lone GitRepoSection keeps the
+   classic .git-wrap layout untouched. Sections split the panel height evenly;
+   each keeps its own scrollable body and pinned footer. */
+.git-multi {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.git-repo-sect {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.git-repo-sect + .git-repo-sect {
+  border-top: 2px solid var(--bd);
+}
+.git-repo-name {
+  flex-shrink: 0;
+  padding: 5px 14px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--bd-soft);
+}

--- a/src/components/RightPanel/GitPanel/GitRepoSection.tsx
+++ b/src/components/RightPanel/GitPanel/GitRepoSection.tsx
@@ -1,0 +1,216 @@
+import { useEffect, useState } from "react";
+import type { AgentRecord, TrackedRepo } from "@/api";
+import { delegationLabel } from "@/components/RightPanel/delegation";
+import { useAppStore } from "@/store";
+import { ActionBar } from "./ActionBar";
+import { ChangesList } from "./ChangesList";
+import { CommitComposer } from "./CommitComposer";
+import { ClosedPRCard, ConflictCard, PRCard } from "./cards";
+import { EmptyState } from "./EmptyState";
+import { useActionBarModel } from "./hooks/useActionBarModel";
+import { useCommitDraft } from "./hooks/useCommitDraft";
+import { useDelegationLifecycle } from "./hooks/useDelegationLifecycle";
+import { useGitActions } from "./hooks/useGitActions";
+import { useGitPanelData } from "./hooks/useGitPanelData";
+import { useTransientFeedback } from "./hooks/useTransientFeedback";
+import { StatusHeader } from "./StatusHeader";
+
+/** One repo's worth of git panel: the full header / body / footer stack,
+ *  scoped to a single checkout of the agent. For a single-repo agent this IS
+ *  the whole panel. `subdir` is undefined for the agent's primary repo (index
+ *  0) — that section reads/writes the plain agent-keyed store entries that
+ *  live events and bulk polls update — and the checkout's directory name for
+ *  secondaries, which read/write under `gitKey(agentId, subdir)`.
+ *
+ *  The component is a thin orchestrator: live reads + polling live in
+ *  `useGitPanelData`, the commit draft in `useCommitDraft`, busy/notice in
+ *  `useTransientFeedback`, the agent-handoff lifecycle in
+ *  `useDelegationLifecycle`, the dispatch table in `useGitActions`, and the
+ *  split-button model in `useActionBarModel`. */
+export function GitRepoSection({
+  agent,
+  repo,
+  subdir,
+}: {
+  agent: AgentRecord;
+  repo: TrackedRepo | undefined;
+  subdir?: string;
+}) {
+  const {
+    gitState,
+    prState,
+    checks,
+    comments,
+    mergeState,
+    prOpen,
+    panelState,
+    fetchGitState,
+    fetchPrState,
+    fetchPrChecks,
+  } = useGitPanelData(agent.id, repo, subdir);
+
+  const { busy, runBusy, notice, showNotice } = useTransientFeedback(agent.id);
+  const { override, msg, setMsg, commitRef, customActive, openOverride, revertOverride } =
+    useCommitDraft(agent.id, panelState);
+
+  // Delegations are agent-keyed and watched against the primary repo's state;
+  // secondary sections only read the delegation for display.
+  const delegation = useDelegationLifecycle({
+    agentId: agent.id,
+    agentStatus: agent.status,
+    gitState,
+    prState,
+    checks,
+    showNotice,
+    fetchPrChecks,
+    enabled: subdir === undefined,
+  });
+
+  // Selected file in the changes list — kept valid across polls (fall back to
+  // the first file when the selection disappears).
+  const [selected, setSelected] = useState<string | null>(null);
+  useEffect(() => {
+    setSelected((prev) => {
+      const paths = gitState?.files.map((f) => f.path) ?? [];
+      if (prev && paths.includes(prev)) return prev;
+      return paths[0] ?? null;
+    });
+  }, [gitState]);
+
+  const githubConnected = useAppStore((s) => s.github?.authenticated ?? false);
+  const hasOrigin = gitState?.has_origin ?? true;
+
+  const branch = gitState?.branch || repo?.branch || "(no branch yet)";
+  const base = gitState?.parent_branch || repo?.parent_branch || "main";
+  // The checkout is detached until its first push; a branch is only born from
+  // an agent that names it. So a direct (agent-bypassed) action that needs a
+  // branch — push, open PR — can't run yet: it routes through the agent
+  // instead, which picks a conventional name and creates the branch.
+  const hasBranch = Boolean(gitState?.branch || repo?.branch);
+
+  const { runAction, addCommentToChat } = useGitActions({
+    agentId: agent.id,
+    subdir,
+    base,
+    hasBranch,
+    customActive,
+    msg,
+    checks,
+    prUrl: prState?.url,
+    githubConnected,
+    hasOrigin,
+    runBusy,
+    showNotice,
+    openOverride,
+    revertOverride,
+    fetchPrState,
+  });
+
+  const { primary, items, effectiveKey, tone, mainDisabled, onSelectAction } = useActionBarModel({
+    agentId: agent.id,
+    panelState,
+    gitState,
+    prState,
+    checks,
+    mergeState,
+    prOpen,
+    base,
+    customActive,
+    delegationActive: delegation != null,
+    githubConnected,
+  });
+
+  // Pushed state: link the commit count out to GitHub — a single commit when
+  // only one is ahead, otherwise the base..branch compare (commit list + full
+  // diff). Gated on nothing being unpushed, so the tip is on origin and the
+  // link can't 404. Needs the origin web base (github.com remotes only).
+  const webBase = gitState?.remote_url ?? null;
+  const aheadCount = gitState?.ahead ?? 0;
+  const unpushed = gitState?.unpushed ?? 0;
+  const pushedLink: string | null =
+    webBase && unpushed === 0 && aheadCount > 0
+      ? aheadCount === 1 && gitState?.head_sha
+        ? `${webBase}/commit/${gitState.head_sha}`
+        : `${webBase}/compare/${base}...${branch}`
+      : null;
+
+  // Show the changes list only when there are uncommitted files to display.
+  // The commit composer yields while the agent holds a delegation.
+  const showFiles = panelState === "changes" || panelState === "conflicts";
+  const showCommit = panelState === "changes" && !delegation;
+
+  return (
+    <div className="git-wrap">
+      {/* ── color-coded status header: the at-a-glance state signal ── */}
+      <StatusHeader
+        state={panelState}
+        branch={branch}
+        base={base}
+        git={gitState}
+        pr={prState}
+        mergeState={mergeState}
+        checksFailed={checks?.failed ?? 0}
+      />
+
+      {/* ── scrollable body: the changes are the focus ── */}
+      <div className={`git-body ${busy ? "busy" : ""}`}>
+        {panelState === "pr-open" && prState && (
+          <PRCard
+            pr={prState}
+            base={base}
+            checks={checks}
+            comments={comments}
+            onAddToChat={addCommentToChat}
+          />
+        )}
+        {panelState === "pr-closed" && prState && <ClosedPRCard pr={prState} />}
+        {panelState === "conflicts" && gitState && <ConflictCard files={gitState.files} />}
+
+        {showFiles && (
+          <ChangesList
+            files={gitState?.files ?? []}
+            selected={selected}
+            onSelect={setSelected}
+            onRefresh={() => void fetchGitState(agent.id)}
+          />
+        )}
+
+        <EmptyState state={panelState} base={base} />
+      </div>
+
+      {/* ── pinned footer: commit message + status + action ── */}
+      <div className="git-foot">
+        {showCommit && (
+          <CommitComposer
+            writing={override}
+            msg={msg}
+            setMsg={setMsg}
+            textareaRef={commitRef}
+            onOpen={openOverride}
+            onRevert={revertOverride}
+            onSubmit={() => runAction(effectiveKey)}
+          />
+        )}
+
+        <ActionBar
+          statusKind={primary.statusKind}
+          statusLabel={primary.statusLabel}
+          statusExtra={primary.statusExtra}
+          busy={busy}
+          delegationLabel={delegation ? delegationLabel(delegation.kind) : null}
+          notice={notice}
+          panelState={panelState}
+          pushedLink={pushedLink}
+          aheadCount={aheadCount}
+          prUrl={prState?.url}
+          items={items}
+          selectedKey={effectiveKey}
+          tone={tone}
+          mainDisabled={mainDisabled}
+          onSelect={onSelectAction}
+          onRun={() => runAction(effectiveKey)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/RightPanel/GitPanel/GitRepoSection.tsx
+++ b/src/components/RightPanel/GitPanel/GitRepoSection.tsx
@@ -53,8 +53,9 @@ export function GitRepoSection({
   const { override, msg, setMsg, commitRef, customActive, openOverride, revertOverride } =
     useCommitDraft(agent.id, panelState);
 
-  // Delegations are agent-keyed and watched against the primary repo's state;
-  // secondary sections only read the delegation for display.
+  // Delegations are agent-keyed but repo-scoped: the section whose scope
+  // matches the delegation's target watches its lifecycle against THIS repo's
+  // state; other sections only read it for display.
   const delegation = useDelegationLifecycle({
     agentId: agent.id,
     agentStatus: agent.status,
@@ -63,7 +64,7 @@ export function GitRepoSection({
     checks,
     showNotice,
     fetchPrChecks,
-    enabled: subdir === undefined,
+    subdir,
   });
 
   // Selected file in the changes list — kept valid across polls (fall back to

--- a/src/components/RightPanel/GitPanel/hooks/useDelegationLifecycle.ts
+++ b/src/components/RightPanel/GitPanel/hooks/useDelegationLifecycle.ts
@@ -14,10 +14,11 @@ import { useAppStore } from "@/store";
  *  agent only reads as "gave up" after our own turn ran or the grace window
  *  passed. Returns the active delegation (or undefined) for the render.
  *
- *  Delegations are agent-keyed and watched against the PRIMARY repo's state
- *  only — secondary sections of a multi-repo panel pass `enabled: false` so
- *  exactly one lifecycle effect runs per agent (they still get the delegation
- *  back for display, e.g. to yield the commit composer). */
+ *  Delegations are agent-keyed but scoped to one repo (`delegation.subdir`).
+ *  Only the section whose scope matches watches the lifecycle — its git/PR
+ *  state is the one the delegation's target transition happens in — so
+ *  exactly one lifecycle effect runs per delegation. Every section still gets
+ *  the delegation back for display (e.g. to yield the commit composer). */
 export function useDelegationLifecycle({
   agentId,
   agentStatus,
@@ -26,7 +27,7 @@ export function useDelegationLifecycle({
   checks,
   showNotice,
   fetchPrChecks,
-  enabled = true,
+  subdir,
 }: {
   agentId: string;
   agentStatus: AgentRecord["status"];
@@ -35,7 +36,8 @@ export function useDelegationLifecycle({
   checks: PrChecks | null;
   showNotice: (m: string) => void;
   fetchPrChecks: (agentId: string) => unknown;
-  enabled?: boolean;
+  /** This section's repo scope; undefined = the primary repo. */
+  subdir?: string;
 }) {
   const delegation = useAppStore((s) => s.gitDelegations[agentId]);
   const markGitDelegationRunning = useAppStore((s) => s.markGitDelegationRunning);
@@ -43,7 +45,7 @@ export function useDelegationLifecycle({
   const clearGitDelegation = useAppStore((s) => s.clearGitDelegation);
 
   useEffect(() => {
-    if (!enabled || !delegation) return;
+    if (!delegation || delegation.subdir !== subdir) return;
     const resolved = delegationResolved(delegation.kind, gitState, prState, checks);
     switch (delegationStep(delegation, agentStatus, resolved, Date.now())) {
       case "resolve":
@@ -71,7 +73,7 @@ export function useDelegationLifecycle({
         break;
     }
   }, [
-    enabled,
+    subdir,
     delegation,
     agentId,
     agentStatus,

--- a/src/components/RightPanel/GitPanel/hooks/useDelegationLifecycle.ts
+++ b/src/components/RightPanel/GitPanel/hooks/useDelegationLifecycle.ts
@@ -12,7 +12,12 @@ import { useAppStore } from "@/store";
  *  decision is pure (`delegationStep`) and handles the tricky cases — a trigger
  *  queued behind a pre-existing turn must wait that turn out, and a settled
  *  agent only reads as "gave up" after our own turn ran or the grace window
- *  passed. Returns the active delegation (or undefined) for the render. */
+ *  passed. Returns the active delegation (or undefined) for the render.
+ *
+ *  Delegations are agent-keyed and watched against the PRIMARY repo's state
+ *  only — secondary sections of a multi-repo panel pass `enabled: false` so
+ *  exactly one lifecycle effect runs per agent (they still get the delegation
+ *  back for display, e.g. to yield the commit composer). */
 export function useDelegationLifecycle({
   agentId,
   agentStatus,
@@ -21,6 +26,7 @@ export function useDelegationLifecycle({
   checks,
   showNotice,
   fetchPrChecks,
+  enabled = true,
 }: {
   agentId: string;
   agentStatus: AgentRecord["status"];
@@ -29,6 +35,7 @@ export function useDelegationLifecycle({
   checks: PrChecks | null;
   showNotice: (m: string) => void;
   fetchPrChecks: (agentId: string) => unknown;
+  enabled?: boolean;
 }) {
   const delegation = useAppStore((s) => s.gitDelegations[agentId]);
   const markGitDelegationRunning = useAppStore((s) => s.markGitDelegationRunning);
@@ -36,7 +43,7 @@ export function useDelegationLifecycle({
   const clearGitDelegation = useAppStore((s) => s.clearGitDelegation);
 
   useEffect(() => {
-    if (!delegation) return;
+    if (!enabled || !delegation) return;
     const resolved = delegationResolved(delegation.kind, gitState, prState, checks);
     switch (delegationStep(delegation, agentStatus, resolved, Date.now())) {
       case "resolve":
@@ -64,6 +71,7 @@ export function useDelegationLifecycle({
         break;
     }
   }, [
+    enabled,
     delegation,
     agentId,
     agentStatus,

--- a/src/components/RightPanel/GitPanel/hooks/useGitActions.ts
+++ b/src/components/RightPanel/GitPanel/hooks/useGitActions.ts
@@ -21,6 +21,9 @@ const NEEDS_GITHUB = new Set([
 
 interface GitActionsCtx {
   agentId: string;
+  /** Target repo of a multi-repo agent (a checkout's `TrackedRepo.subdir`).
+   *  Undefined = the primary repo — byte-identical to the old behavior. */
+  subdir?: string;
   base: string;
   hasBranch: boolean;
   customActive: boolean;
@@ -45,6 +48,7 @@ interface GitActionsCtx {
 export function useGitActions(ctx: GitActionsCtx) {
   const {
     agentId,
+    subdir,
     base,
     hasBranch,
     customActive,
@@ -159,7 +163,7 @@ export function useGitActions(ctx: GitActionsCtx) {
           return;
         }
         void runBusy("Committing…", async () => {
-          const ok = await commitChanges(agentId, msg.trim());
+          const ok = await commitChanges(agentId, msg.trim(), subdir);
           if (ok) revertOverride();
         });
         break;
@@ -172,7 +176,7 @@ export function useGitActions(ctx: GitActionsCtx) {
         // HEAD), then let the agent name the branch and write the PR.
         if (!hasBranch) {
           void runBusy("Committing…", async () => {
-            const ok = await commitChanges(agentId, msg.trim());
+            const ok = await commitChanges(agentId, msg.trim(), subdir);
             if (ok) {
               revertOverride();
               delegate("open-pr", appActionMessage("open-pr", { base }));
@@ -181,7 +185,7 @@ export function useGitActions(ctx: GitActionsCtx) {
           break;
         }
         void runBusy("Committing & opening PR…", async () => {
-          const ok = await commitAndOpenPr(agentId, msg.trim());
+          const ok = await commitAndOpenPr(agentId, msg.trim(), subdir);
           if (ok) revertOverride();
         });
         break;
@@ -193,7 +197,7 @@ export function useGitActions(ctx: GitActionsCtx) {
           break;
         }
         void runBusy("Opening PR…", async () => {
-          const pr = await createPr(agentId, "", "");
+          const pr = await createPr(agentId, "", "", subdir);
           // If creation failed (e.g. a PR already exists), the local prState
           // was stale — re-fetch so the panel corrects itself.
           if (!pr) await fetchPrState(agentId);
@@ -203,7 +207,7 @@ export function useGitActions(ctx: GitActionsCtx) {
         if (prUrl) void open(prUrl);
         break;
       case "merge":
-        void runBusy("Merging…", () => mergePr(agentId));
+        void runBusy("Merging…", () => mergePr(agentId, subdir));
         break;
       case "archive":
         void runBusy("Archiving…", () => archive(agentId));
@@ -216,32 +220,32 @@ export function useGitActions(ctx: GitActionsCtx) {
           break;
         }
         void runBusy("Pushing…", async () => {
-          const r = await pushAgent(agentId);
+          const r = await pushAgent(agentId, subdir);
           if (r)
             showNotice(r === "up-to-date" ? "Already up to date with origin" : "Pushed to origin");
         });
         break;
       case "pull":
         void runBusy("Pulling…", async () => {
-          if (await pullAgent(agentId)) showNotice("Pulled latest changes");
+          if (await pullAgent(agentId, subdir)) showNotice("Pulled latest changes");
         });
         break;
       case "rebase":
         void runBusy("Rebasing…", async () => {
-          if (await rebaseAgent(agentId)) showNotice(`Rebased onto ${base}`);
+          if (await rebaseAgent(agentId, subdir)) showNotice(`Rebased onto ${base}`);
         });
         break;
       case "stash":
-        void runBusy("Stashing…", () => stashChanges(agentId));
+        void runBusy("Stashing…", () => stashChanges(agentId, subdir));
         break;
       case "discard":
-        void runBusy("Discarding…", () => discardChanges(agentId));
+        void runBusy("Discarding…", () => discardChanges(agentId, subdir));
         break;
       case "abort":
-        void runBusy("Aborting…", () => abortMerge(agentId));
+        void runBusy("Aborting…", () => abortMerge(agentId, subdir));
         break;
       case "delete-branch":
-        void runBusy("Deleting branch…", () => deleteBranch(agentId));
+        void runBusy("Deleting branch…", () => deleteBranch(agentId, subdir));
         break;
       // "loading" is a non-actionable placeholder.
       default:

--- a/src/components/RightPanel/GitPanel/hooks/useGitActions.ts
+++ b/src/components/RightPanel/GitPanel/hooks/useGitActions.ts
@@ -83,12 +83,22 @@ export function useGitActions(ctx: GitActionsCtx) {
 
   // Hand control to the coding agent: it writes the judgment part (message /
   // description / conflict edits) and executes the mutation through the app's
-  // file RPC. The panel tracks the delegation until the matching transition.
+  // file RPC. The panel tracks the delegation until the matching transition —
+  // scoped to this section's repo, so this section's watcher owns it.
   const delegate = useCallback(
     (kind: GitDelegationKind, prompt: string) => {
-      delegateGitAction(agentId, kind, prompt);
+      delegateGitAction(agentId, kind, prompt, subdir);
     },
-    [agentId, delegateGitAction],
+    [agentId, subdir, delegateGitAction],
+  );
+
+  // Trigger builder scoped to this section's repo: a secondary section adds
+  // `repo="<subdir>"` so the agent works in that sibling checkout (and passes
+  // `args.repo` on the host git ops — see git_actions.md).
+  const trigger = useCallback(
+    (name: string, params?: Record<string, string>) =>
+      appActionMessage(name, subdir ? { ...params, repo: subdir } : params),
+    [subdir],
   );
 
   // "→ chat" on a review comment: drop the formatted comment into this agent's
@@ -131,29 +141,29 @@ export function useGitActions(ctx: GitActionsCtx) {
       // lives in the agent's injected instructions (git_actions.md), keeping
       // the chat free of boilerplate. Params carry only dynamic context.
       case "agent-commit-pr":
-        delegate("commit-pr", appActionMessage("commit-pr", { base }));
+        delegate("commit-pr", trigger("commit-pr", { base }));
         break;
       case "agent-commit":
-        delegate("commit", appActionMessage("commit"));
+        delegate("commit", trigger("commit"));
         break;
       case "agent-commit-push":
-        delegate("commit-push", appActionMessage("commit-push"));
+        delegate("commit-push", trigger("commit-push"));
         break;
       case "agent-open-pr":
-        delegate("open-pr", appActionMessage("open-pr", { base }));
+        delegate("open-pr", trigger("open-pr", { base }));
         break;
       case "agent-resolve":
-        delegate("resolve", appActionMessage("resolve-conflicts"));
+        delegate("resolve", trigger("resolve-conflicts"));
         break;
       case "agent-update-branch":
         // PR can't merge cleanly with the base (the base advanced). This is NOT
         // a local in-progress merge — the agent must sync the base in first.
-        delegate("update-branch", appActionMessage("update-branch", { base }));
+        delegate("update-branch", trigger("update-branch", { base }));
         break;
       case "agent-fix":
         delegate(
           "fix-checks",
-          appActionMessage("fix-checks", { failing: (checks?.required_failing ?? []).join(", ") }),
+          trigger("fix-checks", { failing: (checks?.required_failing ?? []).join(", ") }),
         );
         break;
       // ── direct, agent bypassed (user typed their own message) ──
@@ -179,7 +189,7 @@ export function useGitActions(ctx: GitActionsCtx) {
             const ok = await commitChanges(agentId, msg.trim(), subdir);
             if (ok) {
               revertOverride();
-              delegate("open-pr", appActionMessage("open-pr", { base }));
+              delegate("open-pr", trigger("open-pr", { base }));
             }
           });
           break;
@@ -193,7 +203,7 @@ export function useGitActions(ctx: GitActionsCtx) {
         // Needs a branch — hand to the agent to name + create one if there
         // isn't one yet; otherwise the direct gh --fill PR.
         if (!hasBranch) {
-          delegate("open-pr", appActionMessage("open-pr", { base }));
+          delegate("open-pr", trigger("open-pr", { base }));
           break;
         }
         void runBusy("Opening PR…", async () => {
@@ -216,7 +226,7 @@ export function useGitActions(ctx: GitActionsCtx) {
         // Direct git push needs a branch; with none yet, the agent names and
         // creates one, then pushes.
         if (!hasBranch) {
-          delegate("push", appActionMessage("push"));
+          delegate("push", trigger("push"));
           break;
         }
         void runBusy("Pushing…", async () => {

--- a/src/components/RightPanel/GitPanel/hooks/useGitPanelData.ts
+++ b/src/components/RightPanel/GitPanel/hooks/useGitPanelData.ts
@@ -23,8 +23,9 @@ export function useGitPanelData(agentId: string, repo?: TrackedRepo, subdir?: st
   const gitState = useAppStore((s) => s.gitStates[key] ?? null);
   // PR state with the database-snapshot fallback (same policy as usePrState,
   // scoped to this section's repo): live store value wins; the last persisted
-  // snapshot fills in when live state is absent or null.
-  const livePr = useAppStore((s) => s.prStates[key] ?? null);
+  // snapshot fills in only when live state was never fetched (absent key).
+  // Keep `undefined` distinct from `null` here — see the fallback below.
+  const livePr = useAppStore((s) => s.prStates[key]);
   // A scoped (secondary) section must NEVER fall back to the primary repo for
   // its snapshot — that would leak the primary's persisted PR number/title
   // into this repo's card until the scoped fetch lands. Its snapshot comes
@@ -34,7 +35,14 @@ export function useGitPanelData(agentId: string, repo?: TrackedRepo, subdir?: st
       ? (repo ?? s.workspace?.agents.find((a) => a.id === agentId)?.repos[0])
       : repo,
   );
-  const prState = useMemo(() => livePr ?? prSnapshot(snapshotRepo), [livePr, snapshotRepo]);
+  // A present key — including a confirmed `null` (fetch returned no PR) — is
+  // authoritative and wins. Only an absent key (undefined = never fetched)
+  // falls back to the persisted snapshot, so a scoped fetch that confirmed no
+  // PR clears the card instead of rendering this repo's stale snapshot.
+  const prState = useMemo(
+    () => (livePr !== undefined ? livePr : prSnapshot(snapshotRepo)),
+    [livePr, snapshotRepo],
+  );
 
   const fetchGitStateStore = useAppStore((s) => s.fetchGitState);
   const fetchPrStateStore = useAppStore((s) => s.fetchPrState);

--- a/src/components/RightPanel/GitPanel/hooks/useGitPanelData.ts
+++ b/src/components/RightPanel/GitPanel/hooks/useGitPanelData.ts
@@ -25,8 +25,14 @@ export function useGitPanelData(agentId: string, repo?: TrackedRepo, subdir?: st
   // scoped to this section's repo): live store value wins; the last persisted
   // snapshot fills in when live state is absent or null.
   const livePr = useAppStore((s) => s.prStates[key] ?? null);
-  const snapshotRepo = useAppStore(
-    (s) => repo ?? s.workspace?.agents.find((a) => a.id === agentId)?.repos[0],
+  // A scoped (secondary) section must NEVER fall back to the primary repo for
+  // its snapshot — that would leak the primary's persisted PR number/title
+  // into this repo's card until the scoped fetch lands. Its snapshot comes
+  // from its own TrackedRepo or nowhere.
+  const snapshotRepo = useAppStore((s) =>
+    subdir === undefined
+      ? (repo ?? s.workspace?.agents.find((a) => a.id === agentId)?.repos[0])
+      : repo,
   );
   const prState = useMemo(() => livePr ?? prSnapshot(snapshotRepo), [livePr, snapshotRepo]);
 

--- a/src/components/RightPanel/GitPanel/hooks/useGitPanelData.ts
+++ b/src/components/RightPanel/GitPanel/hooks/useGitPanelData.ts
@@ -1,25 +1,60 @@
-import { useCallback } from "react";
-import type { MergeState } from "@/api";
+import { useCallback, useMemo } from "react";
+import type { MergeState, TrackedRepo } from "@/api";
 import { deriveState } from "@/components/RightPanel/primaryActions";
 import { useAppStore } from "@/store";
+import { gitKey } from "@/store/git";
 import { usePoll } from "@/util/hooks";
-import { usePrState } from "@/util/prState";
+import { prSnapshot } from "@/util/prState";
 
 /** All the live git/PR reads the panel renders from, plus the polling that
  *  keeps them fresh while the panel is mounted:
  *  - git state at 1s,
  *  - PR state at 5s (so a merge/close/mergeable flip on GitHub shows up),
  *  - the heavier checks + review comments at 5s, only while a PR is open.
- *  usePoll fires immediately, so the first read of each still lands on mount. */
-export function useGitPanelData(agentId: string) {
-  const gitState = useAppStore((s) => s.gitStates[agentId] ?? null);
-  const prState = usePrState(agentId);
-  const fetchGitState = useAppStore((s) => s.fetchGitState);
-  const fetchPrState = useAppStore((s) => s.fetchPrState);
-  const prChecksEntry = useAppStore((s) => s.prChecks[agentId]);
-  const fetchPrChecks = useAppStore((s) => s.fetchPrChecks);
-  const prCommentsEntry = useAppStore((s) => s.prComments[agentId]);
-  const fetchPrComments = useAppStore((s) => s.fetchPrComments);
+ *  usePoll fires immediately, so the first read of each still lands on mount.
+ *
+ *  `repo`/`subdir` scope the hook to one repo of a multi-repo agent: `subdir`
+ *  undefined = the primary repo, read/written under the plain agent key (the
+ *  one live events and bulk polls update); a secondary repo reads/writes under
+ *  `gitKey(agentId, subdir)`. The returned fetchers are pre-bound to the
+ *  scope's subdir, so callers keep passing just the agent id. */
+export function useGitPanelData(agentId: string, repo?: TrackedRepo, subdir?: string) {
+  const key = gitKey(agentId, subdir);
+  const gitState = useAppStore((s) => s.gitStates[key] ?? null);
+  // PR state with the database-snapshot fallback (same policy as usePrState,
+  // scoped to this section's repo): live store value wins; the last persisted
+  // snapshot fills in when live state is absent or null.
+  const livePr = useAppStore((s) => s.prStates[key] ?? null);
+  const snapshotRepo = useAppStore(
+    (s) => repo ?? s.workspace?.agents.find((a) => a.id === agentId)?.repos[0],
+  );
+  const prState = useMemo(() => livePr ?? prSnapshot(snapshotRepo), [livePr, snapshotRepo]);
+
+  const fetchGitStateStore = useAppStore((s) => s.fetchGitState);
+  const fetchPrStateStore = useAppStore((s) => s.fetchPrState);
+  const prChecksEntry = useAppStore((s) => s.prChecks[key]);
+  const fetchPrChecksStore = useAppStore((s) => s.fetchPrChecks);
+  const prCommentsEntry = useAppStore((s) => s.prComments[key]);
+  const fetchPrCommentsStore = useAppStore((s) => s.fetchPrComments);
+
+  // Subdir-bound fetchers, so every consumer (polls, actions, delegation
+  // refresh) hits this section's repo without re-threading the scope.
+  const fetchGitState = useCallback(
+    (id: string) => fetchGitStateStore(id, subdir),
+    [fetchGitStateStore, subdir],
+  );
+  const fetchPrState = useCallback(
+    (id: string) => fetchPrStateStore(id, subdir),
+    [fetchPrStateStore, subdir],
+  );
+  const fetchPrChecks = useCallback(
+    (id: string) => fetchPrChecksStore(id, subdir),
+    [fetchPrChecksStore, subdir],
+  );
+  const fetchPrComments = useCallback(
+    (id: string) => fetchPrCommentsStore(id, subdir),
+    [fetchPrCommentsStore, subdir],
+  );
 
   const pollGitState = useCallback(() => fetchGitState(agentId), [agentId, fetchGitState]);
   usePoll(pollGitState, 1000, [pollGitState]);

--- a/src/components/RightPanel/GitPanel/index.tsx
+++ b/src/components/RightPanel/GitPanel/index.tsx
@@ -19,8 +19,17 @@ const scopesFor = (agent: AgentRecord): RepoScope[] =>
   agent.repos.map((repo, i) => ({ repo, subdir: i === 0 ? undefined : repo.subdir }));
 
 /** A repo earns its own section once it has anything git-worthy to show:
- *  uncommitted changes, a named branch, or a bound PR. */
-const repoActive = (scope: RepoScope, gitStates: Record<string, GitState>, agentId: string) =>
+ *  uncommitted changes, a named branch, or a bound PR. A repo targeted by the
+ *  agent's in-flight delegation is pinned active regardless — its section owns
+ *  the lifecycle watcher, so it must not unmount mid-delegation (e.g. when a
+ *  commit empties the file list before the branch materializes). */
+const repoActive = (
+  scope: RepoScope,
+  gitStates: Record<string, GitState>,
+  agentId: string,
+  delegatedSubdir: string | null | undefined,
+) =>
+  (delegatedSubdir !== null && scope.subdir === delegatedSubdir) ||
   (gitStates[gitKey(agentId, scope.subdir)]?.files.length ?? 0) > 0 ||
   Boolean(scope.repo.branch) ||
   scope.repo.pr_number != null;
@@ -40,9 +49,16 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
 function MultiRepoGitPanel({ agent }: { agent: AgentRecord }) {
   const fetchGitState = useAppStore((s) => s.fetchGitState);
   const gitStates = useAppStore((s) => s.gitStates);
+  // The repo scope of the agent's in-flight delegation, if any: `null` when
+  // there is no delegation (pins nothing), `undefined` when it targets the
+  // primary. Distinct sentinel needed because `undefined` is a real scope.
+  const delegatedSubdir = useAppStore((s) => {
+    const d = s.gitDelegations[agent.id];
+    return d ? d.subdir : null;
+  });
 
   const scopes = scopesFor(agent);
-  const active = scopes.filter((sc) => repoActive(sc, gitStates, agent.id));
+  const active = scopes.filter((sc) => repoActive(sc, gitStates, agent.id, delegatedSubdir));
   // Nothing active yet → the primary repo's section (today's empty state),
   // with no section header.
   const sections = active.length > 0 ? active : [scopes[0]];

--- a/src/components/RightPanel/GitPanel/index.tsx
+++ b/src/components/RightPanel/GitPanel/index.tsx
@@ -1,204 +1,83 @@
-import { useEffect, useState } from "react";
-import type { AgentRecord } from "@/api";
-import { delegationLabel } from "@/components/RightPanel/delegation";
+import { useCallback, useEffect, useRef } from "react";
+import type { AgentRecord, GitState, TrackedRepo } from "@/api";
 import { useAppStore } from "@/store";
-import { ActionBar } from "./ActionBar";
-import { ChangesList } from "./ChangesList";
-import { CommitComposer } from "./CommitComposer";
-import { ClosedPRCard, ConflictCard, PRCard } from "./cards";
-import { EmptyState } from "./EmptyState";
-import { useActionBarModel } from "./hooks/useActionBarModel";
-import { useCommitDraft } from "./hooks/useCommitDraft";
-import { useDelegationLifecycle } from "./hooks/useDelegationLifecycle";
-import { useGitActions } from "./hooks/useGitActions";
-import { useGitPanelData } from "./hooks/useGitPanelData";
-import { useTransientFeedback } from "./hooks/useTransientFeedback";
-import { StatusHeader } from "./StatusHeader";
+import { gitKey } from "@/store/git";
+import { basename } from "@/util/format";
+import { usePoll } from "@/util/hooks";
+import { GitRepoSection } from "./GitRepoSection";
+
+/** A repo of the agent plus the scope its section reads/writes under:
+ *  `subdir` is undefined for the primary repo (index 0 — plain agent-keyed
+ *  state, shared with live events and bulk polls) and the checkout's
+ *  directory name for secondaries. */
+interface RepoScope {
+  repo: TrackedRepo;
+  subdir?: string;
+}
+
+const scopesFor = (agent: AgentRecord): RepoScope[] =>
+  agent.repos.map((repo, i) => ({ repo, subdir: i === 0 ? undefined : repo.subdir }));
+
+/** A repo earns its own section once it has anything git-worthy to show:
+ *  uncommitted changes, a named branch, or a bound PR. */
+const repoActive = (scope: RepoScope, gitStates: Record<string, GitState>, agentId: string) =>
+  (gitStates[gitKey(agentId, scope.subdir)]?.files.length ?? 0) > 0 ||
+  Boolean(scope.repo.branch) ||
+  scope.repo.pr_number != null;
 
 /** State-aware git panel driven by live git state from the Tauri backend.
- *  Layout: a color-coded status header (the at-a-glance state signal), a
- *  scrollable body (the changes / PR card — the focus), and a pinned footer
- *  holding the commit message plus a responsive action bar (status left,
- *  split-button right; stacks full-width on a narrow panel via a container
- *  query). The panel is feature-flagged in settings.
- *
- *  The component is a thin orchestrator: live reads + polling live in
- *  `useGitPanelData`, the commit draft in `useCommitDraft`, busy/notice in
- *  `useTransientFeedback`, the agent-handoff lifecycle in
- *  `useDelegationLifecycle`, the dispatch table in `useGitActions`, and the
- *  split-button model in `useActionBarModel`. */
+ *  Single-repo agents render one `GitRepoSection` — exactly the panel as it
+ *  always was. Multi-repo agents render one section per ACTIVE repo (changes,
+ *  branch, or PR), each under a slim repo-name header; when nothing is active
+ *  yet, just the primary repo's section (its empty state) without a header. */
 export function GitPanel({ agent }: { agent: AgentRecord }) {
-  const {
-    gitState,
-    prState,
-    checks,
-    comments,
-    mergeState,
-    prOpen,
-    panelState,
-    fetchGitState,
-    fetchPrState,
-    fetchPrChecks,
-  } = useGitPanelData(agent.id);
+  if (agent.repos.length <= 1) {
+    return <GitRepoSection agent={agent} repo={agent.repos[0]} />;
+  }
+  return <MultiRepoGitPanel agent={agent} />;
+}
 
-  const { busy, runBusy, notice, showNotice } = useTransientFeedback(agent.id);
-  const { override, msg, setMsg, commitRef, customActive, openOverride, revertOverride } =
-    useCommitDraft(agent.id, panelState);
+function MultiRepoGitPanel({ agent }: { agent: AgentRecord }) {
+  const fetchGitState = useAppStore((s) => s.fetchGitState);
+  const gitStates = useAppStore((s) => s.gitStates);
 
-  const delegation = useDelegationLifecycle({
-    agentId: agent.id,
-    agentStatus: agent.status,
-    gitState,
-    prState,
-    checks,
-    showNotice,
-    fetchPrChecks,
-  });
+  const scopes = scopesFor(agent);
+  const active = scopes.filter((sc) => repoActive(sc, gitStates, agent.id));
+  // Nothing active yet → the primary repo's section (today's empty state),
+  // with no section header.
+  const sections = active.length > 0 ? active : [scopes[0]];
 
-  // Selected file in the changes list — kept valid across polls (fall back to
-  // the first file when the selection disappears).
-  const [selected, setSelected] = useState<string | null>(null);
+  // On mount / agent change, fetch git state for EVERY repo so "active" can be
+  // computed — rendered sections then keep their own 1s poll going.
+  const repos = agent.repos;
   useEffect(() => {
-    setSelected((prev) => {
-      const paths = gitState?.files.map((f) => f.path) ?? [];
-      if (prev && paths.includes(prev)) return prev;
-      return paths[0] ?? null;
-    });
-  }, [gitState]);
+    repos.forEach((repo, i) => void fetchGitState(agent.id, i === 0 ? undefined : repo.subdir));
+  }, [agent.id, repos, fetchGitState]);
 
-  const githubConnected = useAppStore((s) => s.github?.authenticated ?? false);
-  const hasOrigin = gitState?.has_origin ?? true;
-
-  const branch = gitState?.branch || agent.repos[0]?.branch || "(no branch yet)";
-  const base = gitState?.parent_branch || agent.repos[0]?.parent_branch || "main";
-  // The checkout is detached until its first push; a branch is only born from
-  // an agent that names it. So a direct (agent-bypassed) action that needs a
-  // branch — push, open PR — can't run yet: it routes through the agent
-  // instead, which picks a conventional name and creates the branch.
-  const hasBranch = Boolean(gitState?.branch || agent.repos[0]?.branch);
-
-  const { runAction, addCommentToChat } = useGitActions({
-    agentId: agent.id,
-    base,
-    hasBranch,
-    customActive,
-    msg,
-    checks,
-    prUrl: prState?.url,
-    githubConnected,
-    hasOrigin,
-    runBusy,
-    showNotice,
-    openOverride,
-    revertOverride,
-    fetchPrState,
-  });
-
-  const { primary, items, effectiveKey, tone, mainDisabled, onSelectAction } = useActionBarModel({
-    agentId: agent.id,
-    panelState,
-    gitState,
-    prState,
-    checks,
-    mergeState,
-    prOpen,
-    base,
-    customActive,
-    delegationActive: delegation != null,
-    githubConnected,
-  });
-
-  // Pushed state: link the commit count out to GitHub — a single commit when
-  // only one is ahead, otherwise the base..branch compare (commit list + full
-  // diff). Gated on nothing being unpushed, so the tip is on origin and the
-  // link can't 404. Needs the origin web base (github.com remotes only).
-  const webBase = gitState?.remote_url ?? null;
-  const aheadCount = gitState?.ahead ?? 0;
-  const unpushed = gitState?.unpushed ?? 0;
-  const pushedLink: string | null =
-    webBase && unpushed === 0 && aheadCount > 0
-      ? aheadCount === 1 && gitState?.head_sha
-        ? `${webBase}/commit/${gitState.head_sha}`
-        : `${webBase}/compare/${base}...${branch}`
-      : null;
-
-  // Show the changes list only when there are uncommitted files to display.
-  // The commit composer yields while the agent holds a delegation.
-  const showFiles = panelState === "changes" || panelState === "conflicts";
-  const showCommit = panelState === "changes" && !delegation;
+  // Repos without a rendered section have no per-section poll, so sweep them
+  // on a slow cadence — an agent touching a dormant repo promotes it to a
+  // section within a tick. Read through a ref so the poll's identity is
+  // stable (the active set changes with every gitStates write).
+  const dormantRef = useRef<RepoScope[]>([]);
+  dormantRef.current =
+    active.length > 0 ? scopes.filter((sc) => !active.includes(sc)) : scopes.slice(1);
+  const pollDormant = useCallback(async () => {
+    await Promise.all(dormantRef.current.map((sc) => fetchGitState(agent.id, sc.subdir)));
+  }, [agent.id, fetchGitState]);
+  usePoll(pollDormant, 5000, [pollDormant]);
 
   return (
-    <div className="git-wrap">
-      {/* ── color-coded status header: the at-a-glance state signal ── */}
-      <StatusHeader
-        state={panelState}
-        branch={branch}
-        base={base}
-        git={gitState}
-        pr={prState}
-        mergeState={mergeState}
-        checksFailed={checks?.failed ?? 0}
-      />
-
-      {/* ── scrollable body: the changes are the focus ── */}
-      <div className={`git-body ${busy ? "busy" : ""}`}>
-        {panelState === "pr-open" && prState && (
-          <PRCard
-            pr={prState}
-            base={base}
-            checks={checks}
-            comments={comments}
-            onAddToChat={addCommentToChat}
-          />
-        )}
-        {panelState === "pr-closed" && prState && <ClosedPRCard pr={prState} />}
-        {panelState === "conflicts" && gitState && <ConflictCard files={gitState.files} />}
-
-        {showFiles && (
-          <ChangesList
-            files={gitState?.files ?? []}
-            selected={selected}
-            onSelect={setSelected}
-            onRefresh={() => void fetchGitState(agent.id)}
-          />
-        )}
-
-        <EmptyState state={panelState} base={base} />
-      </div>
-
-      {/* ── pinned footer: commit message + status + action ── */}
-      <div className="git-foot">
-        {showCommit && (
-          <CommitComposer
-            writing={override}
-            msg={msg}
-            setMsg={setMsg}
-            textareaRef={commitRef}
-            onOpen={openOverride}
-            onRevert={revertOverride}
-            onSubmit={() => runAction(effectiveKey)}
-          />
-        )}
-
-        <ActionBar
-          statusKind={primary.statusKind}
-          statusLabel={primary.statusLabel}
-          statusExtra={primary.statusExtra}
-          busy={busy}
-          delegationLabel={delegation ? delegationLabel(delegation.kind) : null}
-          notice={notice}
-          panelState={panelState}
-          pushedLink={pushedLink}
-          aheadCount={aheadCount}
-          prUrl={prState?.url}
-          items={items}
-          selectedKey={effectiveKey}
-          tone={tone}
-          mainDisabled={mainDisabled}
-          onSelect={onSelectAction}
-          onRun={() => runAction(effectiveKey)}
-        />
-      </div>
+    <div className="git-multi">
+      {sections.map((sc) => (
+        <section key={sc.repo.subdir} className="git-repo-sect">
+          {active.length > 0 && (
+            <div className="git-repo-name text-xs">
+              {sc.repo.label ?? basename(sc.repo.repo_path)}
+            </div>
+          )}
+          <GitRepoSection agent={agent} repo={sc.repo} subdir={sc.subdir} />
+        </section>
+      ))}
     </div>
   );
 }

--- a/src/components/RightPanel/delegation.ts
+++ b/src/components/RightPanel/delegation.ts
@@ -45,6 +45,12 @@ export interface GitDelegation {
    *  current turn) instead of running as its own. We wait for the agent to go
    *  idle, then deliver and drop `queued` (the delegated turn now runs alone). */
   queued: boolean;
+  /** Which checkout of a multi-repo agent the delegation targets: a
+   *  `TrackedRepo.subdir` for a secondary repo, undefined for the primary.
+   *  The matching panel section watches the lifecycle against ITS repo's
+   *  git/PR state; the trigger message carries the same scope as `repo="…"`
+   *  so the agent works in that sibling checkout. */
+  subdir?: string;
 }
 
 /** How long a settled agent may sit without `sawRunning` before the

--- a/src/store/git.ts
+++ b/src/store/git.ts
@@ -7,16 +7,26 @@ import type { GitSlice, SliceCreator } from "./types";
 type GitSet = Parameters<SliceCreator<GitSlice>>[0];
 type GitGet = Parameters<SliceCreator<GitSlice>>[1];
 
+/** Composite key for the per-repo git/PR maps (`gitStates`, `prStates`,
+ *  `prChecks`, `prComments`). The primary repo (no `subdir`) keeps the plain
+ *  agent id — the key every existing write path (background bulk polls, tauri
+ *  event reducers, sidebar badges) uses — so only secondary-repo fetches get
+ *  the suffixed form. */
+export function gitKey(agentId: string, subdir?: string): string {
+  return subdir ? `${agentId}::${subdir}` : agentId;
+}
+
 // Shared shape for the simple git mutations: run the backend call, refresh git
 // state on success, otherwise record the error and report failure.
 const runGitMutation = async (
   get: GitGet,
   agentId: string,
   fn: () => Promise<unknown>,
+  subdir?: string,
 ): Promise<boolean> => {
   try {
     await fn();
-    await get().fetchGitState(agentId);
+    await get().fetchGitState(agentId, subdir);
     return true;
   } catch (e) {
     get().setLastError(String(e));
@@ -33,14 +43,16 @@ const fetchPrAux = async <K extends "prChecks" | "prComments">(
   set: GitSet,
   agentId: string,
   key: K,
-  fetch: (agentId: string) => Promise<GitSlice[K][string]>,
+  fetch: (agentId: string, subdir?: string) => Promise<GitSlice[K][string]>,
+  subdir?: string,
 ): Promise<void> => {
+  const mapKey = gitKey(agentId, subdir);
   try {
-    const value = await fetch(agentId);
-    set((s) => ({ [key]: { ...s[key], [agentId]: value } }) as Partial<GitSlice>);
+    const value = await fetch(agentId, subdir);
+    set((s) => ({ [key]: { ...s[key], [mapKey]: value } }) as Partial<GitSlice>);
   } catch {
     set((s) =>
-      agentId in s[key] ? {} : ({ [key]: { ...s[key], [agentId]: null } } as Partial<GitSlice>),
+      mapKey in s[key] ? {} : ({ [key]: { ...s[key], [mapKey]: null } } as Partial<GitSlice>),
     );
   }
 };
@@ -54,11 +66,11 @@ export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
   gitDelegations: {},
   gitCommitAction: "agent-commit-pr" as GitCommitAction,
 
-  fetchGitState: async (agentId) => {
+  fetchGitState: async (agentId, subdir) => {
     try {
-      const state = await api.getGitState(agentId);
+      const state = await api.getGitState(agentId, subdir);
       if (state) {
-        set((s) => ({ gitStates: { ...s.gitStates, [agentId]: state } }));
+        set((s) => ({ gitStates: { ...s.gitStates, [gitKey(agentId, subdir)]: state } }));
       }
     } catch {
       // non-fatal — next poll tick will retry
@@ -77,13 +89,13 @@ export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
     }
   },
 
-  fetchPrState: async (agentId) => {
+  fetchPrState: async (agentId, subdir) => {
     try {
-      const state = await api.getPrState(agentId);
+      const state = await api.getPrState(agentId, subdir);
       // Always write (including null) to distinguish "confirmed: no PR" from
       // "not yet fetched" (absent key). Unlike fetchGitState which guards the
       // write, PR state being null is meaningful.
-      set((s) => ({ prStates: { ...s.prStates, [agentId]: state } }));
+      set((s) => ({ prStates: { ...s.prStates, [gitKey(agentId, subdir)]: state } }));
     } catch {
       // non-fatal
     }
@@ -116,9 +128,10 @@ export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
     }
   },
 
-  fetchPrChecks: (agentId) => fetchPrAux(set, agentId, "prChecks", api.getPrChecks),
+  fetchPrChecks: (agentId, subdir) => fetchPrAux(set, agentId, "prChecks", api.getPrChecks, subdir),
 
-  fetchPrComments: (agentId) => fetchPrAux(set, agentId, "prComments", api.getPrComments),
+  fetchPrComments: (agentId, subdir) =>
+    fetchPrAux(set, agentId, "prComments", api.getPrComments, subdir),
 
   delegateGitAction: (agentId, kind, prompt) => {
     // If the agent is already running, DON'T inject the trigger mid-turn: Claude
@@ -204,11 +217,11 @@ export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
     void setSetting("gitCommitAction", action);
   },
 
-  pushAgent: async (agentId) => {
+  pushAgent: async (agentId, subdir) => {
     try {
       // "up-to-date" | "pushed" — lets the UI confirm the outcome.
-      const summary = await api.pushAgent(agentId);
-      await get().fetchGitState(agentId);
+      const summary = await api.pushAgent(agentId, subdir);
+      await get().fetchGitState(agentId, subdir);
       // pr:state_changed event will update prStates automatically
       return summary;
     } catch (e) {
@@ -217,48 +230,50 @@ export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
     }
   },
 
-  pullAgent: (agentId) => runGitMutation(get, agentId, () => api.pullAgent(agentId)),
+  pullAgent: (agentId, subdir) =>
+    runGitMutation(get, agentId, () => api.pullAgent(agentId, subdir), subdir),
 
-  rebaseAgent: (agentId) => runGitMutation(get, agentId, () => api.rebaseAgent(agentId)),
+  rebaseAgent: (agentId, subdir) =>
+    runGitMutation(get, agentId, () => api.rebaseAgent(agentId, subdir), subdir),
 
-  commitChanges: (agentId, message) =>
-    runGitMutation(get, agentId, () => api.commitAgent(agentId, message)),
+  commitChanges: (agentId, message, subdir) =>
+    runGitMutation(get, agentId, () => api.commitAgent(agentId, message, subdir), subdir),
 
-  commitAndOpenPr: async (agentId, message) => {
+  commitAndOpenPr: async (agentId, message, subdir) => {
     try {
-      await api.commitAgent(agentId, message);
-      await api.pushAgent(agentId);
-      const pr = await api.createPr(agentId, "", "");
-      set((s) => ({ prStates: { ...s.prStates, [agentId]: pr } }));
-      await get().fetchGitState(agentId);
+      await api.commitAgent(agentId, message, subdir);
+      await api.pushAgent(agentId, subdir);
+      const pr = await api.createPr(agentId, "", "", subdir);
+      set((s) => ({ prStates: { ...s.prStates, [gitKey(agentId, subdir)]: pr } }));
+      await get().fetchGitState(agentId, subdir);
       return true;
     } catch (e) {
       set({ lastError: String(e) });
-      await get().fetchGitState(agentId);
+      await get().fetchGitState(agentId, subdir);
       return false;
     }
   },
 
-  stashChanges: async (agentId) => {
-    await runGitMutation(get, agentId, () => api.stashAgent(agentId));
+  stashChanges: async (agentId, subdir) => {
+    await runGitMutation(get, agentId, () => api.stashAgent(agentId, subdir), subdir);
   },
 
-  discardChanges: async (agentId) => {
-    await runGitMutation(get, agentId, () => api.discardAgentChanges(agentId));
+  discardChanges: async (agentId, subdir) => {
+    await runGitMutation(get, agentId, () => api.discardAgentChanges(agentId, subdir), subdir);
   },
 
-  abortMerge: async (agentId) => {
-    await runGitMutation(get, agentId, () => api.abortMergeAgent(agentId));
+  abortMerge: async (agentId, subdir) => {
+    await runGitMutation(get, agentId, () => api.abortMergeAgent(agentId, subdir), subdir);
   },
 
-  deleteBranch: async (agentId) => {
-    await runGitMutation(get, agentId, () => api.deleteBranchAgent(agentId));
+  deleteBranch: async (agentId, subdir) => {
+    await runGitMutation(get, agentId, () => api.deleteBranchAgent(agentId, subdir), subdir);
   },
 
-  createPr: async (agentId, title, body) => {
+  createPr: async (agentId, title, body, subdir) => {
     try {
-      const pr = await api.createPr(agentId, title, body);
-      set((s) => ({ prStates: { ...s.prStates, [agentId]: pr } }));
+      const pr = await api.createPr(agentId, title, body, subdir);
+      set((s) => ({ prStates: { ...s.prStates, [gitKey(agentId, subdir)]: pr } }));
       return pr;
     } catch (e) {
       set({ lastError: String(e) });
@@ -266,14 +281,14 @@ export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
     }
   },
 
-  mergePr: async (agentId) => {
+  mergePr: async (agentId, subdir) => {
     try {
-      await api.mergePr(agentId);
+      await api.mergePr(agentId, subdir);
       // Refresh immediately: no backend event fires on merge, and the panel
       // should transition to the merged state as soon as GitHub reports it
       // (with --auto + pending checks the PR can legitimately stay open).
-      await get().fetchPrState(agentId);
-      await get().fetchPrChecks(agentId);
+      await get().fetchPrState(agentId, subdir);
+      await get().fetchPrChecks(agentId, subdir);
     } catch (e) {
       set({ lastError: String(e) });
     }

--- a/src/store/git.ts
+++ b/src/store/git.ts
@@ -133,7 +133,7 @@ export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
   fetchPrComments: (agentId, subdir) =>
     fetchPrAux(set, agentId, "prComments", api.getPrComments, subdir),
 
-  delegateGitAction: (agentId, kind, prompt) => {
+  delegateGitAction: (agentId, kind, prompt, subdir) => {
     // If the agent is already running, DON'T inject the trigger mid-turn: Claude
     // coalesces a stdin message into the current turn (it wouldn't run as its
     // own turn), and the turn boundary isn't observable, so we couldn't tell our
@@ -152,6 +152,7 @@ export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
           sawRunning: false,
           sawGitOp: false,
           queued,
+          subdir,
         },
       },
     }));

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -269,7 +269,13 @@ export interface GitSlice {
   refreshAllPrChecks: () => Promise<void>;
   fetchPrChecks: (agentId: string, subdir?: string) => Promise<void>;
   fetchPrComments: (agentId: string, subdir?: string) => Promise<void>;
-  delegateGitAction: (agentId: string, kind: GitDelegationKind, prompt: string) => void;
+  delegateGitAction: (
+    agentId: string,
+    kind: GitDelegationKind,
+    prompt: string,
+    /** Target checkout of a multi-repo agent; undefined = primary. */
+    subdir?: string,
+  ) => void;
   markGitDelegationRunning: (agentId: string) => void;
   /** The agent ran a successful mutating git op `op` (backend
    *  `agent:git-action`). Sets the causal proof only if `op` matches the

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -219,8 +219,10 @@ export interface ReposSlice {
 }
 
 export interface GitSlice {
-  /** Full git state, keyed by agent_id — branch, ahead/behind, file list,
-   *  totals. Only populated for the focused agent (by GitPanel's 1s poll
+  /** Full git state — branch, ahead/behind, file list, totals. Keyed by
+   *  `gitKey(agentId, subdir?)` (store/git.ts): the plain agent_id addresses
+   *  the primary repo, `agentId::subdir` a secondary repo of a multi-repo
+   *  agent. Only populated for the focused agent (by GitPanel's 1s poll
    *  while it's mounted). For sidebar shortstats / right-rail badges of
    *  other agents, read from `gitShortstats` instead. */
   gitStates: Record<string, GitState>;
@@ -229,13 +231,17 @@ export interface GitSlice {
    *  poll — kept in its own map so the focused agent's richer `gitStates`
    *  entry isn't clobbered by a slower bulk reply. */
   gitShortstats: Record<string, ShortStats>;
-  /** PR state per agent, keyed by agent_id. Updated by the pr:state_changed watcher event. */
+  /** PR state, keyed by `gitKey(agentId, subdir?)` — plain agent_id for the
+   *  primary repo (updated by the pr:state_changed watcher event + bulk
+   *  polls), `agentId::subdir` for a secondary repo. */
   prStates: Record<string, PrState | null>;
-  /** Rich PR merge-gate + checks per agent. Absent key = not yet fetched;
-   *  `null` = confirmed unavailable (no PR / gh failure). */
+  /** Rich PR merge-gate + checks, keyed by `gitKey(agentId, subdir?)`. Absent
+   *  key = not yet fetched; `null` = confirmed unavailable (no PR / gh
+   *  failure). */
   prChecks: Record<string, PrChecks | null>;
-  /** Unresolved PR review comments per agent. Absent = not yet fetched;
-   *  `null` = confirmed unavailable (no PR / gh failure). */
+  /** Unresolved PR review comments, keyed by `gitKey(agentId, subdir?)`.
+   *  Absent = not yet fetched; `null` = confirmed unavailable (no PR / gh
+   *  failure). */
   prComments: Record<string, PrComments | null>;
   /** Active agent-delegated git action per agent (absent = none). Set when a
    *  panel action hands control to the agent; cleared by the panel when the
@@ -245,12 +251,14 @@ export interface GitSlice {
    *  across workspaces, persisted in settings until the user picks another. */
   gitCommitAction: GitCommitAction;
 
-  /** Fetch full git state for one agent (used by the focused panel's poll). */
-  fetchGitState: (agentId: string) => Promise<void>;
+  /** Fetch full git state for one agent (used by the focused panel's poll).
+   *  `subdir` targets a secondary repo of a multi-repo agent (stored under
+   *  `gitKey(agentId, subdir)`); omitted = the primary repo, plain key. */
+  fetchGitState: (agentId: string, subdir?: string) => Promise<void>;
   /** Fetch compact shortstats for every live agent in one round-trip
    *  (used by the app-wide background poll). */
   fetchAllShortstats: () => Promise<void>;
-  fetchPrState: (agentId: string) => Promise<void>;
+  fetchPrState: (agentId: string, subdir?: string) => Promise<void>;
   /** Refresh PR state for every agent with a known PR in one round-trip
    *  (used by the app-wide background poll). Backend emits `pr:state_changed`
    *  per agent, so the sidebar badge updates without opening the Git panel. */
@@ -259,8 +267,8 @@ export interface GitSlice {
    *  (used by the app-wide background poll) so the sidebar PR pill can tint
    *  pass/fail without opening the Git panel. */
   refreshAllPrChecks: () => Promise<void>;
-  fetchPrChecks: (agentId: string) => Promise<void>;
-  fetchPrComments: (agentId: string) => Promise<void>;
+  fetchPrChecks: (agentId: string, subdir?: string) => Promise<void>;
+  fetchPrComments: (agentId: string, subdir?: string) => Promise<void>;
   delegateGitAction: (agentId: string, kind: GitDelegationKind, prompt: string) => void;
   markGitDelegationRunning: (agentId: string) => void;
   /** The agent ran a successful mutating git op `op` (backend
@@ -273,22 +281,27 @@ export interface GitSlice {
   clearGitDelegation: (agentId: string) => void;
   setGitCommitAction: (action: GitCommitAction) => void;
   /** Resolves to "up-to-date" | "pushed" on success, null on error. */
-  pushAgent: (agentId: string) => Promise<string | null>;
+  pushAgent: (agentId: string, subdir?: string) => Promise<string | null>;
   /** Resolves true on success, false on error. */
-  pullAgent: (agentId: string) => Promise<boolean>;
+  pullAgent: (agentId: string, subdir?: string) => Promise<boolean>;
   /** Resolves true on success, false on error. */
-  rebaseAgent: (agentId: string) => Promise<boolean>;
-  commitChanges: (agentId: string, message: string) => Promise<boolean>;
+  rebaseAgent: (agentId: string, subdir?: string) => Promise<boolean>;
+  commitChanges: (agentId: string, message: string, subdir?: string) => Promise<boolean>;
   /** Commit all changes, push, and open a PR — the "Commit & open PR"
    *  primary CTA wired from the git panel. Returns false on any step
    *  failure so the UI can leave the textarea content in place. */
-  commitAndOpenPr: (agentId: string, message: string) => Promise<boolean>;
-  stashChanges: (agentId: string) => Promise<void>;
-  discardChanges: (agentId: string) => Promise<void>;
-  abortMerge: (agentId: string) => Promise<void>;
-  deleteBranch: (agentId: string) => Promise<void>;
-  createPr: (agentId: string, title: string, body: string) => Promise<PrState | null>;
-  mergePr: (agentId: string) => Promise<void>;
+  commitAndOpenPr: (agentId: string, message: string, subdir?: string) => Promise<boolean>;
+  stashChanges: (agentId: string, subdir?: string) => Promise<void>;
+  discardChanges: (agentId: string, subdir?: string) => Promise<void>;
+  abortMerge: (agentId: string, subdir?: string) => Promise<void>;
+  deleteBranch: (agentId: string, subdir?: string) => Promise<void>;
+  createPr: (
+    agentId: string,
+    title: string,
+    body: string,
+    subdir?: string,
+  ) => Promise<PrState | null>;
+  mergePr: (agentId: string, subdir?: string) => Promise<void>;
   /** Publish a local-only project (no origin) to GitHub, then refresh git
    *  state so the panel switches out of the no-origin affordances. Resolves
    *  the repo web URL on success, null on error. */


### PR DESCRIPTION
## What

Third slice of multi-repo projects (stacked on #459). The Git panel goes per-repo: a multi-repo agent's checkouts are reviewed, committed, pushed, and PR'd independently, presented with progressive disclosure — a repo only appears as a section once it has something git-worthy to show (uncommitted changes, a named branch, or a bound PR). One touched repo looks exactly like today's panel; three touched repos are three slim-headered sections. Single-repo agents render the identical pre-refactor panel, no visual change.

## Changes

**Backend (`commands.rs`, `session_sync.rs`)**
- Panel commands take an optional `subdir` resolved against the agent's tracked repos via new `agent_repo_checkout(_opt)` helpers, defaulting to the primary: `get_git_state`, `get_pr_state`, `get_pr_checks`, `get_pr_comments`, `push_agent`, `commit_agent`, `discard_agent_changes`, `stash_agent`, `abort_merge_agent`, `pull_agent`, `rebase_agent`, `create_pr`, `merge_pr`, `delete_branch_agent`. Old callers are byte-identical; an unknown subdir errors.
- `resolve_pr_state` gains a subdir parameter (panel sections resolve their own repo's PR with the same snapshot/fallback policy); `create_pr` already persisted per-subdir snapshots.
- `get_all_shortstats` sums additions/deletions/file counts across all of an agent's checkouts, so the sidebar badge reflects every repo (matching how archive metadata aggregates).

**Frontend**
- `api.ts`: the 14 wrappers gain a trailing `subdir?: string`.
- Store: `gitKey(agentId, subdir?)` — `subdir ? agentId::subdir : agentId`. The `gitStates`/`prStates`/`prChecks`/`prComments` maps key by it; the plain agent id remains the primary repo's key, so every existing write path (bulk polls, `pr:state_changed` reducer, sidebar badges, header) is untouched. Fetch and mutation actions gain optional `subdir`.
- `GitPanel` becomes an orchestrator over a new `GitRepoSection` (the former panel body verbatim, scoped by `{repo, subdir?}` — `subdir` undefined for the primary so it keeps the live-event data path). Active sections poll at the existing cadences; dormant repos are swept every 5s so a repo the agent just touched promotes itself to a section within a tick.

## Deliberately primary-only (follow-ups)

Sidebar PR badge and the batched PR polls (one badge per agent for now), delegation lifecycle tracking (a delegation dispatched from a secondary section resolves via the chat-review path rather than precise state-matching), `publish_agent`, and the Code-tab file tree.

## Testing

cargo 888 passed; tsc clean; biome 0 errors (72 pre-existing warnings); vitest 447 passed. Single-repo rendering verified unchanged by construction (early-return path renders the identical component tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)