### PR TITLE
feat(multi-repo): sidebar PR fan-out, PR-set cross-linking, multi-repo Code tab

### DIFF
--- a/docs/multi-repo-followups.md
+++ b/docs/multi-repo-followups.md
@@ -74,7 +74,7 @@ Verification baseline: `cargo test --lib` (src-tauri; ~890 tests),
 
 ---
 
-## 1. Sidebar PR badge fan-out  ·  priority: high  ·  size: M
+## 1. Sidebar PR badge fan-out  ·  ✅ done  ·  size: M
 
 **Problem.** The app-wide PR polls and every badge read only the primary:
 `refresh_all_pr_states` / `refresh_all_pr_checks`
@@ -120,7 +120,7 @@ worktree via `persist_pr_snapshot` — already per-repo, don't duplicate.
 Delegation attribution (`markGitDelegationSawOp` path) keys off
 `agent:git-action` events, not prStates — untouched.
 
-## 2. "One task → N PRs" presented as a unit  ·  priority: high  ·  size: M
+## 2. "One task → N PRs" presented as a unit  ·  ✅ done  ·  size: M
 
 **Problem.** Each panel section shows its own PR, but nothing communicates
 "this task produced 3 related PRs": no cross-links in PR bodies, no suggested
@@ -154,7 +154,7 @@ replacement, never string-append. `pr_create` returns `PrState` without body;
 fetch before edit. Respect the rate-limit backoff guard
 (`gh::client::is_backing_off()`).
 
-## 3. Code tab (file tree + editor) multi-repo  ·  priority: medium  ·  size: M
+## 3. Code tab (file tree + editor) multi-repo  ·  ✅ done  ·  size: M
 
 **Problem.** `list_checkout_tree`, `read/write/create/copy_checkout_file`
 (`src-tauri/src/commands.rs`, helper `primary_checkout`) operate on the

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -724,6 +724,12 @@ pub async fn create_pr(
     // the next idle/push poll re-binds it via guarded discovery once the PR
     // shows OPEN — but the helper logs it so the gap is observable, not silent.
     crate::supervisor::persist_pr_snapshot(&supervisor.workspace, &agent_id, &repo.subdir, &pr);
+    // If the agent now has PRs in two or more repos, cross-link the whole set
+    // in each PR's body (best-effort, off the command's critical path).
+    let workspace = supervisor.workspace.clone();
+    tauri::async_runtime::spawn(async move {
+        crate::supervisor::sync_pr_set_links(&workspace, &agent_id).await;
+    });
     Ok(pr)
 }
 
@@ -1016,10 +1022,14 @@ pub async fn get_all_shortstats(
     Ok(out)
 }
 
-/// App-wide background poll that refreshes PR state for every agent with a
-/// recorded PR, so the sidebar badge (and any open Git panel) reflects merges /
-/// closes / mergeability changes that happen on GitHub — without the user
-/// having to open the panel. Returns an `agent_id -> PrState | null` map.
+/// App-wide background poll that refreshes PR state for every repo with a
+/// recorded PR across every agent, so the sidebar badge (and any open Git
+/// panel) reflects merges / closes / mergeability changes that happen on
+/// GitHub — without the user having to open the panel. Returns a map keyed by
+/// the frontend's `gitKey` convention: the agent's primary repo under the
+/// plain agent id (what every existing consumer reads) and each secondary
+/// repo under `"{agent_id}::{subdir}"` — so a multi-repo agent's PR on a
+/// secondary repo reaches the sidebar too.
 ///
 /// Unlike the per-trigger `fetch_and_emit_pr_state` path (which emits an event),
 /// this returns the states directly so the caller folds them into the store
@@ -1027,21 +1037,17 @@ pub async fn get_all_shortstats(
 /// routing through `pr:state_changed` would drop results emitted before the
 /// store's listener finishes attaching during `init()`.
 ///
-/// Only agents with a known PR *number* are polled: discovery of a brand-new PR
+/// Only repos with a known PR *number* are polled: discovery of a brand-new PR
 /// still rides the existing turn-end / push / git-action triggers, so this poll
-/// never fans a `gh` call out to an agent that has no PR. Resolution goes
+/// never fans a `gh` call out to a repo that has no PR. Resolution goes
 /// through `resolve_all_pr_states`, which collapses every live lookup into a
-/// single batched GraphQL query rather than a per-agent fan-out: by number
+/// single batched GraphQL query rather than a per-repo fan-out: by number
 /// (never branch), served straight from the persisted snapshot for merged PRs
 /// (and closed ones except on the slow re-verify tick), and degrading to that
-/// snapshot when GitHub is unreachable or a rate-limit backoff is active. An
-/// agent that resolves to nothing is *omitted* from the map — not written as
+/// snapshot when GitHub is unreachable or a rate-limit backoff is active. A
+/// repo that resolves to nothing is *omitted* from the map — not written as
 /// null — so the frontend merge keeps its last-known badge instead of wiping it
 /// (same contract as `refresh_all_pr_checks`).
-///
-/// Each agent's *first* repo is used, matching the rest of the PR subsystem
-/// (`get_pr_state`, `fetch_and_emit_pr_state`) and the one-PR-per-agent shape of
-/// the store's `prStates` map; multi-repo PR tracking is out of scope here.
 #[tauri::command]
 pub async fn refresh_all_pr_states(
     supervisor: State<'_, Arc<Supervisor>>,
@@ -1065,15 +1071,16 @@ static PR_STATE_TICK: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU6
 /// Re-verify closed PRs live on every Nth `refresh_all_pr_states` tick.
 const CLOSED_REVERIFY_EVERY: u64 = 6;
 
-/// Refresh CI checks for every agent with an open PR, so the sidebar can tint
-/// each PR pill pass/fail without opening the Git panel. Mirror of
-/// `refresh_all_pr_states`: skips archived agents and any without a PR, and
-/// collapses the lookups into a single batched GraphQL query rather than a
-/// per-agent fan-out. Best-effort: only a resolved rollup lands in the map
-/// (including "no checks configured"); a not-found/partial-error alias, a
-/// whole-batch failure, or an active rate-limit backoff omits the agent, so the
-/// frontend's merge keeps its last-known tint instead of wiping it — matching
-/// `fetchPrAux`'s contract.
+/// Refresh CI checks for every repo with an open PR across every agent, so the
+/// sidebar can tint each PR pill pass/fail without opening the Git panel.
+/// Mirror of `refresh_all_pr_states`, including its key shape (`gitKey`: plain
+/// agent id for the primary repo, `"{agent_id}::{subdir}"` for secondaries):
+/// skips archived agents and any repo without a PR, and collapses the lookups
+/// into a single batched GraphQL query rather than a per-repo fan-out.
+/// Best-effort: only a resolved rollup lands in the map (including "no checks
+/// configured"); a not-found/partial-error alias, a whole-batch failure, or an
+/// active rate-limit backoff omits the repo, so the frontend's merge keeps its
+/// last-known tint instead of wiping it — matching `fetchPrAux`'s contract.
 #[tauri::command]
 pub async fn refresh_all_pr_checks(
     supervisor: State<'_, Arc<Supervisor>>,
@@ -1082,49 +1089,48 @@ pub async fn refresh_all_pr_checks(
         return Ok(Default::default());
     };
     // Paused for rate-limit backoff → return nothing so the frontend merge keeps
-    // every agent's last-known tint instead of wiping it.
+    // every repo's last-known tint instead of wiping it.
     if gh::client::is_backing_off() {
         return Ok(Default::default());
     }
 
-    // Gather one (agent, PR ref) per agent with a branch + PR number, resolving
+    // Gather one (key, PR ref) per repo with a branch + PR number, resolving
     // the slug via local git (the network cost is deferred to the single batched
-    // query below, not fanned out per agent).
-    let mut agent_ids: Vec<String> = Vec::new();
+    // query below, not fanned out per repo).
+    let mut keys: Vec<String> = Vec::new();
     let mut refs: Vec<gh::PrRef> = Vec::new();
     for agent in workspace.agents {
         if agent.archive.is_some() {
             continue;
         }
-        let Some(repo) = agent.repos.first() else {
-            continue;
-        };
-        let (Some(_branch), Some(number)) = (repo.branch.as_ref(), repo.pr_number) else {
-            continue;
-        };
-        let Ok(checkout) = repo_checkout_path(&agent.id, &repo.subdir) else {
-            continue;
-        };
-        let Some((owner, repo_name)) = gh::resolve_slug(&checkout, Some(&repo.repo_path)).await
-        else {
-            continue;
-        };
-        agent_ids.push(agent.id.clone());
-        refs.push(gh::PrRef {
-            owner,
-            repo: repo_name,
-            number: number as u32,
-        });
+        for (i, repo) in agent.repos.iter().enumerate() {
+            let (Some(_branch), Some(number)) = (repo.branch.as_ref(), repo.pr_number) else {
+                continue;
+            };
+            let Ok(checkout) = repo_checkout_path(&agent.id, &repo.subdir) else {
+                continue;
+            };
+            let Some((owner, repo_name)) = gh::resolve_slug(&checkout, Some(&repo.repo_path)).await
+            else {
+                continue;
+            };
+            keys.push(crate::supervisor::pr_map_key(&agent.id, &repo.subdir, i == 0));
+            refs.push(gh::PrRef {
+                owner,
+                repo: repo_name,
+                number: number as u32,
+            });
+        }
     }
 
     let mut out = std::collections::HashMap::new();
-    // A whole-batch failure leaves the map empty (all agents keep last-known);
+    // A whole-batch failure leaves the map empty (all repos keep last-known);
     // per-alias `None` (PR not found / partial error) is dropped for the same
     // reason. Only a resolved rollup — including "no checks" — is recorded.
     if let Ok(results) = gh::pr_checks_batch(&refs).await {
-        for (id, checks) in agent_ids.into_iter().zip(results) {
+        for (key, checks) in keys.into_iter().zip(results) {
             if let Some(checks) = checks {
-                out.insert(id, Some(checks));
+                out.insert(key, Some(checks));
             }
         }
     }
@@ -1302,23 +1308,63 @@ fn primary_checkout(supervisor: &Supervisor, agent_id: &str) -> Result<(PathBuf,
     Ok((checkout, parent))
 }
 
-/// List the agent's checkout files (tracked + untracked), each tagged with
-/// its git status vs the parent branch. This mirrors what's actually on disk
-/// — like a regular file explorer — so files the agent deleted are dropped
-/// rather than lingering as struck-through entries.
-#[tauri::command]
-pub async fn list_checkout_tree(
-    supervisor: State<'_, Arc<Supervisor>>,
-    agent_id: String,
-) -> Result<Vec<CheckoutFile>> {
-    let (checkout, parent) = primary_checkout(&supervisor, &agent_id)?;
+/// Split a repo-prefixed Code-tab path (`"<subdir>/<rel>"`) into its tracked
+/// repo and the checkout-relative remainder. Only ever called for multi-repo
+/// agents — a single-repo agent's paths are never prefixed (all prefix logic
+/// is gated on `repos.len() > 1`), so a real top-level directory that happens
+/// to share a repo's name can't be misrouted here.
+fn split_repo_path<'a>(repos: &'a [TrackedRepo], path: &str) -> Result<(&'a TrackedRepo, String)> {
+    let (first, rest) = path.split_once('/').unwrap_or((path, ""));
+    let repo = repos.iter().find(|r| r.subdir == first).ok_or_else(|| {
+        let known: Vec<&str> = repos.iter().map(|r| r.subdir.as_str()).collect();
+        Error::InvalidPath(format!(
+            "{path:?} must start with one of the agent's repo folders: {}",
+            known.join(", ")
+        ))
+    })?;
+    if rest.is_empty() {
+        return Err(Error::InvalidPath(format!(
+            "{path:?} names a repo folder itself, not a path inside it"
+        )));
+    }
+    Ok((repo, rest.to_string()))
+}
 
-    let state = git_state::query(&checkout, &parent).await.ok();
+/// Resolve a Code-tab path to the checkout it lives in: `(checkout root,
+/// parent ref, checkout-relative path)`. Single-repo agents use the primary
+/// checkout with the path unchanged — the exact legacy behavior. For a
+/// multi-repo agent every tree path is prefixed with the repo's `subdir`
+/// (see `list_checkout_tree`), so the first segment picks the checkout.
+fn checkout_scope_for_path(
+    supervisor: &Supervisor,
+    agent_id: &str,
+    path: &str,
+) -> Result<(PathBuf, String, String)> {
+    let record = supervisor.workspace.agent(agent_id)?;
+    if record.repos.len() <= 1 {
+        let (checkout, parent) = primary_checkout(supervisor, agent_id)?;
+        return Ok((checkout, parent, path.to_string()));
+    }
+    let (repo, rel) = split_repo_path(&record.repos, path)?;
+    let checkout = repo_checkout_path(agent_id, &repo.subdir)?;
+    let parent = diff_base(repo).unwrap_or_else(|| "main".to_string());
+    Ok((checkout, parent, rel))
+}
+
+/// One checkout's file list (tracked + untracked, deleted dropped), each
+/// tagged with its git status vs `parent`. `prefix` (a repo's subdir) is
+/// prepended to every path for multi-repo agents' virtual roots.
+async fn checkout_tree_files(
+    checkout: &Path,
+    parent: &str,
+    prefix: Option<&str>,
+) -> Vec<CheckoutFile> {
+    let state = git_state::query(checkout, parent).await.ok();
     let status_for = |path: &str| -> Option<&FileStatus> {
         state.as_ref()?.files.iter().find(|f| f.path == path)
     };
 
-    let mut paths: BTreeSet<String> = git::list_files(&checkout)
+    let mut paths: BTreeSet<String> = git::list_files(checkout)
         .await
         .unwrap_or_default()
         .into_iter()
@@ -1337,7 +1383,7 @@ pub async fn list_checkout_tree(
         }
     }
 
-    Ok(paths
+    paths
         .into_iter()
         .map(|path| {
             let st = status_for(&path);
@@ -1345,10 +1391,47 @@ pub async fn list_checkout_tree(
                 status: st.map(|f| status_code(&f.kind).to_string()),
                 additions: st.map(|f| f.additions).unwrap_or(0),
                 deletions: st.map(|f| f.deletions).unwrap_or(0),
-                path,
+                path: match prefix {
+                    Some(p) => format!("{p}/{path}"),
+                    None => path,
+                },
             }
         })
-        .collect())
+        .collect()
+}
+
+/// List the agent's checkout files (tracked + untracked), each tagged with
+/// its git status vs the parent branch. This mirrors what's actually on disk
+/// — like a regular file explorer — so files the agent deleted are dropped
+/// rather than lingering as struck-through entries.
+///
+/// Single-repo agents get today's un-prefixed listing of the primary checkout.
+/// A multi-repo agent gets one virtual root per repo: every path is prefixed
+/// with the checkout's `subdir`, each repo's status computed against its own
+/// fork point — the tree component nests on `/`, so the repos render as
+/// top-level folders. The file read/write commands resolve the same prefix
+/// back to the owning checkout (`checkout_scope_for_path`).
+#[tauri::command]
+pub async fn list_checkout_tree(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+) -> Result<Vec<CheckoutFile>> {
+    let record = supervisor.workspace.agent(&agent_id)?;
+    if record.repos.len() <= 1 {
+        let (checkout, parent) = primary_checkout(&supervisor, &agent_id)?;
+        return Ok(checkout_tree_files(&checkout, &parent, None).await);
+    }
+    let mut out = Vec::new();
+    for repo in &record.repos {
+        // One broken checkout shouldn't blank the whole tree — skip it and
+        // keep listing the others.
+        let Ok(checkout) = repo_checkout_path(&agent_id, &repo.subdir) else {
+            continue;
+        };
+        let parent = diff_base(repo).unwrap_or_else(|| "main".to_string());
+        out.extend(checkout_tree_files(&checkout, &parent, Some(&repo.subdir)).await);
+    }
+    Ok(out)
 }
 
 /// List a repo's files by path (tracked + non-ignored untracked), for the
@@ -1481,7 +1564,7 @@ pub async fn read_checkout_file(
     agent_id: String,
     path: String,
 ) -> Result<CheckoutFileContents> {
-    let (checkout, parent) = primary_checkout(&supervisor, &agent_id)?;
+    let (checkout, parent, path) = checkout_scope_for_path(&supervisor, &agent_id, &path)?;
     let abs = safe_join(&checkout, &path)?;
     let lang = lang_for(&path);
 
@@ -1549,7 +1632,7 @@ pub async fn get_file_diff(
     agent_id: String,
     path: String,
 ) -> Result<String> {
-    let (checkout, parent) = primary_checkout(&supervisor, &agent_id)?;
+    let (checkout, parent, path) = checkout_scope_for_path(&supervisor, &agent_id, &path)?;
     git::file_diff(&checkout, &parent, &path).await
 }
 
@@ -1561,7 +1644,7 @@ pub async fn write_checkout_file(
     path: String,
     contents: String,
 ) -> Result<()> {
-    let (checkout, _parent) = primary_checkout(&supervisor, &agent_id)?;
+    let (checkout, _parent, path) = checkout_scope_for_path(&supervisor, &agent_id, &path)?;
     let abs = safe_join(&checkout, &path)?;
     if let Some(dir) = abs.parent() {
         std::fs::create_dir_all(dir)?;
@@ -1587,6 +1670,9 @@ fn resolve_new_path(checkout: &Path, rel: &str) -> Result<PathBuf> {
 
 /// Rename/move a checkout path (file or directory). Refuses to clobber an
 /// existing destination so a rename can never silently overwrite a sibling.
+/// Source and destination resolve their repo scope independently, so a move
+/// between a multi-repo agent's checkouts (sibling directories on the same
+/// volume) works like any other rename.
 #[tauri::command]
 pub async fn rename_checkout_path(
     supervisor: State<'_, Arc<Supervisor>>,
@@ -1594,9 +1680,10 @@ pub async fn rename_checkout_path(
     from: String,
     to: String,
 ) -> Result<()> {
-    let (checkout, _parent) = primary_checkout(&supervisor, &agent_id)?;
-    let src = safe_join(&checkout, &from)?;
-    let dst = resolve_new_path(&checkout, &to)?;
+    let (checkout_from, _parent, from) = checkout_scope_for_path(&supervisor, &agent_id, &from)?;
+    let (checkout_to, _parent, to) = checkout_scope_for_path(&supervisor, &agent_id, &to)?;
+    let src = safe_join(&checkout_from, &from)?;
+    let dst = resolve_new_path(&checkout_to, &to)?;
     std::fs::rename(&src, &dst)?;
     Ok(())
 }
@@ -1610,7 +1697,7 @@ pub async fn delete_checkout_path(
     agent_id: String,
     path: String,
 ) -> Result<()> {
-    let (checkout, _parent) = primary_checkout(&supervisor, &agent_id)?;
+    let (checkout, _parent, path) = checkout_scope_for_path(&supervisor, &agent_id, &path)?;
     let abs = safe_join(&checkout, &path)?;
     if abs.is_dir() {
         std::fs::remove_dir_all(&abs)?;
@@ -1628,7 +1715,7 @@ pub async fn create_checkout_file(
     agent_id: String,
     path: String,
 ) -> Result<()> {
-    let (checkout, _parent) = primary_checkout(&supervisor, &agent_id)?;
+    let (checkout, _parent, path) = checkout_scope_for_path(&supervisor, &agent_id, &path)?;
     let abs = resolve_new_path(&checkout, &path)?;
     std::fs::write(&abs, "")?;
     Ok(())
@@ -1641,7 +1728,7 @@ pub async fn create_checkout_dir(
     agent_id: String,
     path: String,
 ) -> Result<()> {
-    let (checkout, _parent) = primary_checkout(&supervisor, &agent_id)?;
+    let (checkout, _parent, path) = checkout_scope_for_path(&supervisor, &agent_id, &path)?;
     let abs = resolve_new_path(&checkout, &path)?;
     std::fs::create_dir_all(&abs)?;
     Ok(())
@@ -1656,9 +1743,10 @@ pub async fn copy_checkout_file(
     from: String,
     to: String,
 ) -> Result<()> {
-    let (checkout, _parent) = primary_checkout(&supervisor, &agent_id)?;
-    let src = safe_join(&checkout, &from)?;
-    let dst = resolve_new_path(&checkout, &to)?;
+    let (checkout_from, _parent, from) = checkout_scope_for_path(&supervisor, &agent_id, &from)?;
+    let (checkout_to, _parent, to) = checkout_scope_for_path(&supervisor, &agent_id, &to)?;
+    let src = safe_join(&checkout_from, &from)?;
+    let dst = resolve_new_path(&checkout_to, &to)?;
     std::fs::copy(&src, &dst)?;
     Ok(())
 }
@@ -1736,6 +1824,53 @@ pub async fn validate_agent_bin(path: String) -> BinValidation {
 #[tauri::command]
 pub async fn discover_supported_models() -> Vec<crate::model_catalog::AgentModels> {
     crate::model_catalog::discover_supported_models().await
+}
+
+#[cfg(test)]
+mod split_repo_path_tests {
+    use super::split_repo_path;
+    use crate::workspace::TrackedRepo;
+
+    fn repo(subdir: &str) -> TrackedRepo {
+        TrackedRepo {
+            repo_path: std::path::PathBuf::from(format!("/src/{subdir}")),
+            subdir: subdir.into(),
+            branch: None,
+            parent_branch: None,
+            base_sha: None,
+            pr_number: None,
+            pr_url: None,
+            pr_title: None,
+            pr_state: None,
+            label: None,
+        }
+    }
+
+    #[test]
+    fn routes_first_segment_to_the_matching_repo() {
+        let repos = [repo("frontend"), repo("backend")];
+        let (r, rel) = split_repo_path(&repos, "backend/src/main.rs").unwrap();
+        assert_eq!(r.subdir, "backend");
+        assert_eq!(rel, "src/main.rs");
+    }
+
+    #[test]
+    fn rejects_unknown_prefix_listing_tracked_folders() {
+        let repos = [repo("frontend"), repo("backend")];
+        let err = split_repo_path(&repos, "shared/util.ts").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("frontend"), "should list tracked folders: {msg}");
+        assert!(msg.contains("backend"), "should list tracked folders: {msg}");
+    }
+
+    #[test]
+    fn rejects_a_bare_repo_root() {
+        // "frontend" alone names the checkout itself — never a file operation
+        // target (renaming/deleting a repo root must not be possible).
+        let repos = [repo("frontend"), repo("backend")];
+        assert!(split_repo_path(&repos, "frontend").is_err());
+        assert!(split_repo_path(&repos, "frontend/").is_err());
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1114,7 +1114,11 @@ pub async fn refresh_all_pr_checks(
             else {
                 continue;
             };
-            keys.push(crate::supervisor::pr_map_key(&agent.id, &repo.subdir, i == 0));
+            keys.push(crate::supervisor::pr_map_key(
+                &agent.id,
+                &repo.subdir,
+                i == 0,
+            ));
             refs.push(gh::PrRef {
                 owner,
                 repo: repo_name,
@@ -1859,8 +1863,14 @@ mod split_repo_path_tests {
         let repos = [repo("frontend"), repo("backend")];
         let err = split_repo_path(&repos, "shared/util.ts").unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("frontend"), "should list tracked folders: {msg}");
-        assert!(msg.contains("backend"), "should list tracked folders: {msg}");
+        assert!(
+            msg.contains("frontend"),
+            "should list tracked folders: {msg}"
+        );
+        assert!(
+            msg.contains("backend"),
+            "should list tracked folders: {msg}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -393,6 +393,66 @@ pub async fn pr_view_number(
     Ok(Some(parse_pr_state(node)))
 }
 
+/// Fetch a PR's current body text by number. `Ok(None)` when the PR can't be
+/// found (or no token / non-GitHub origin). Same slug resolution as
+/// [`pr_view_number`] — the source repo backs up a broken checkout.
+pub(crate) async fn pr_body(
+    checkout: &Path,
+    source_repo: Option<&Path>,
+    number: u32,
+) -> Result<Option<String>> {
+    let Some((owner, repo)) = resolve_slug(checkout, source_repo).await else {
+        return Ok(None);
+    };
+    let query = r#"query($owner:String!,$repo:String!,$number:Int!){
+  repository(owner:$owner,name:$repo){ pullRequest(number:$number){ body } }
+}"#;
+    let Some(data) = graphql_opt(
+        query,
+        json!({ "owner": owner, "repo": repo, "number": number }),
+    )
+    .await?
+    else {
+        return Ok(None);
+    };
+    let node = &data["repository"]["pullRequest"];
+    if node.is_null() {
+        return Ok(None);
+    }
+    Ok(Some(node["body"].as_str().unwrap_or_default().to_string()))
+}
+
+/// Overwrite a PR's body by number (REST PATCH). Used by the multi-repo
+/// PR-set cross-linker; callers are expected to have fetched the current body
+/// via [`pr_body`] and edited it (sentinel replacement, never blind append).
+pub(crate) async fn pr_update_body(
+    checkout: &Path,
+    source_repo: Option<&Path>,
+    number: u32,
+    body: &str,
+) -> Result<()> {
+    let Some((owner, repo)) = resolve_slug(checkout, source_repo).await else {
+        return Err(Error::Gh(
+            "this repository's `origin` remote is not a GitHub repository".into(),
+        ));
+    };
+    let client = client::Client::new()?;
+    let (status, resp) = client
+        .rest(
+            reqwest::Method::PATCH,
+            &format!("/repos/{owner}/{repo}/pulls/{number}"),
+            Some(&json!({ "body": body })),
+        )
+        .await?;
+    if !status.is_success() {
+        return Err(Error::Gh(format!(
+            "pr body update failed: {}",
+            detailed_rest_error(&resp)
+        )));
+    }
+    Ok(())
+}
+
 /// List open PRs for the repo at `checkout` (newest first), for the
 /// composer's "#" mention autocomplete. Empty when not connected.
 pub async fn pr_list(checkout: &Path, limit: u32) -> Result<Vec<PrSummary>> {

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -5,16 +5,16 @@ mod events;
 mod fork;
 mod lifecycle;
 mod messaging;
+mod pr_set;
 mod rpc_watch;
 pub(crate) mod run;
-mod pr_set;
 mod session_sync;
 mod shell;
 
 pub use fork::{ForkCode, ForkContext};
 pub use lifecycle::SpawnRequest;
-pub use run::ProjectRunConfig;
 pub(crate) use pr_set::sync_pr_set_links;
+pub use run::ProjectRunConfig;
 pub(crate) use session_sync::{
     persist_pr_snapshot, pr_map_key, resolve_all_pr_states, resolve_pr_state,
 };

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -7,13 +7,17 @@ mod lifecycle;
 mod messaging;
 mod rpc_watch;
 pub(crate) mod run;
+mod pr_set;
 mod session_sync;
 mod shell;
 
 pub use fork::{ForkCode, ForkContext};
 pub use lifecycle::SpawnRequest;
 pub use run::ProjectRunConfig;
-pub(crate) use session_sync::{persist_pr_snapshot, resolve_all_pr_states, resolve_pr_state};
+pub(crate) use pr_set::sync_pr_set_links;
+pub(crate) use session_sync::{
+    persist_pr_snapshot, pr_map_key, resolve_all_pr_states, resolve_pr_state,
+};
 
 use parking_lot::Mutex;
 use std::collections::{HashMap, HashSet};

--- a/src-tauri/src/supervisor/pr_set.rs
+++ b/src-tauri/src/supervisor/pr_set.rs
@@ -116,7 +116,8 @@ pub(crate) async fn sync_pr_set_links(workspace: &WorkspaceManager, agent_id: &s
         if updated == body {
             continue;
         }
-        if let Err(e) = crate::github::pr_update_body(checkout, Some(source), *number, &updated).await
+        if let Err(e) =
+            crate::github::pr_update_body(checkout, Some(source), *number, &updated).await
         {
             tracing::warn!(error = %e, pr = %pr_ref, "pr-set: body update failed");
         }
@@ -148,7 +149,10 @@ mod tests {
         assert_eq!(second.matches(PR_SET_END).count(), 1);
         assert!(second.starts_with("Adds the login flow."));
         assert!(second.contains("o/c#3"));
-        assert!(!second.contains("set: o/a#1, o/b#2\n"), "old block must be gone");
+        assert!(
+            !second.contains("set: o/a#1, o/b#2\n"),
+            "old block must be gone"
+        );
         // Same trailer again → byte-identical (the sync skips the PATCH).
         let third = apply_pr_set_trailer(&second, "---\nset: o/a#1, o/b#2, o/c#3");
         assert_eq!(second, third);
@@ -169,7 +173,10 @@ mod tests {
     #[test]
     fn trailer_is_the_whole_body_when_body_is_empty() {
         let out = apply_pr_set_trailer("", "content");
-        assert_eq!(out, "<!-- fletch:pr-set -->\ncontent\n<!-- /fletch:pr-set -->");
+        assert_eq!(
+            out,
+            "<!-- fletch:pr-set -->\ncontent\n<!-- /fletch:pr-set -->"
+        );
         // Whitespace-only bodies count as empty (no leading blank lines).
         let out = apply_pr_set_trailer("  \n", "content");
         assert!(out.starts_with(PR_SET_START));

--- a/src-tauri/src/supervisor/pr_set.rs
+++ b/src-tauri/src/supervisor/pr_set.rs
@@ -1,0 +1,190 @@
+//! Multi-repo PR-set cross-linking: when one agent's task produces PRs in
+//! more than one repo, stamp each PR's body with a trailer linking the whole
+//! set ("Part of a multi-repo change in <project>: owner/frontend#12,
+//! owner/backend#34"), so a reviewer landing on any one PR can find the rest.
+//!
+//! The trailer is wrapped in HTML-comment sentinels and *replaced* between
+//! them on every sync — never string-appended — so re-running (a third PR
+//! opening, a retried sync) can't duplicate it, and it composes safely with
+//! bodies the agent wrote itself. Everything here is best-effort: a body edit
+//! is decoration, so failures are logged, never surfaced.
+
+use crate::workspace::{repo_checkout_path, WorkspaceManager};
+
+/// Sentinels marking the generated trailer inside a PR body. Content between
+/// them is owned by Fletch and replaced wholesale on every sync.
+const PR_SET_START: &str = "<!-- fletch:pr-set -->";
+const PR_SET_END: &str = "<!-- /fletch:pr-set -->";
+
+/// Replace the sentinel-marked trailer block in `body` (or append one when
+/// absent). Pure — the sync's only string surgery, so it's unit-tested hard.
+fn apply_pr_set_trailer(body: &str, trailer: &str) -> String {
+    let block = format!("{PR_SET_START}\n{trailer}\n{PR_SET_END}");
+    if let (Some(start), Some(end)) = (body.find(PR_SET_START), body.rfind(PR_SET_END)) {
+        // Replace everything from the first start sentinel through the last
+        // end sentinel, so even a mangled body (duplicated blocks from an
+        // older bug, an agent quoting the block) converges to one clean block.
+        if end >= start {
+            let mut out = String::with_capacity(body.len() + block.len());
+            out.push_str(&body[..start]);
+            out.push_str(&block);
+            out.push_str(&body[end + PR_SET_END.len()..]);
+            return out;
+        }
+    }
+    if body.trim().is_empty() {
+        block
+    } else {
+        format!("{}\n\n{}", body.trim_end(), block)
+    }
+}
+
+/// The trailer's human-facing content: an `---` rule plus one line naming the
+/// project and every PR in the set as `owner/repo#N` (GitHub auto-links these
+/// across repos).
+fn pr_set_trailer(project_name: Option<&str>, refs: &[String]) -> String {
+    let list = refs.join(", ");
+    match project_name {
+        Some(name) => format!("---\nPart of a multi-repo change in {name}: {list}"),
+        None => format!("---\nPart of a multi-repo change: {list}"),
+    }
+}
+
+/// Sync the PR-set trailer across every PR bound to this agent. No-op unless
+/// the agent has PRs in **two or more** repos — single-PR agents never get a
+/// trailer. Called after any path that binds a new PR (panel `create_pr`, the
+/// agent's `open_pr` RPC); each call rewrites the full set, which is what
+/// backfills the older PRs' bodies when the second PR appears.
+///
+/// Best-effort throughout: an unresolvable slug drops that repo from the set,
+/// a fetch/update failure is logged and skipped, and an active rate-limit
+/// backoff skips the whole sync (the next PR-binding event retries it).
+pub(crate) async fn sync_pr_set_links(workspace: &WorkspaceManager, agent_id: &str) {
+    if crate::github::client::is_backing_off() {
+        return;
+    }
+    let Ok(record) = workspace.agent(agent_id) else {
+        return;
+    };
+
+    // Every bound PR of the agent, as (checkout, source repo, number, ref).
+    let mut prs = Vec::new();
+    for repo in &record.repos {
+        let Some(number) = repo.pr_number else {
+            continue;
+        };
+        let Ok(checkout) = repo_checkout_path(agent_id, &repo.subdir) else {
+            continue;
+        };
+        let Some((owner, name)) =
+            crate::github::resolve_slug(&checkout, Some(&repo.repo_path)).await
+        else {
+            continue;
+        };
+        prs.push((
+            checkout,
+            repo.repo_path.clone(),
+            number as u32,
+            format!("{owner}/{name}#{number}"),
+        ));
+    }
+    if prs.len() < 2 {
+        return;
+    }
+
+    let project_name = workspace.current().and_then(|ws| {
+        ws.projects
+            .iter()
+            .find(|p| p.project_id == record.project_id)
+            .map(|p| p.name.clone())
+    });
+    let refs: Vec<String> = prs.iter().map(|(_, _, _, r)| r.clone()).collect();
+    let trailer = pr_set_trailer(project_name.as_deref(), &refs);
+
+    for (checkout, source, number, pr_ref) in &prs {
+        let body = match crate::github::pr_body(checkout, Some(source), *number).await {
+            Ok(Some(body)) => body,
+            Ok(None) => continue,
+            Err(e) => {
+                tracing::warn!(error = %e, pr = %pr_ref, "pr-set: body fetch failed");
+                continue;
+            }
+        };
+        let updated = apply_pr_set_trailer(&body, &trailer);
+        // Idempotency backstop: an unchanged body (the set didn't grow) costs
+        // no write — the common case for every PR but the newest.
+        if updated == body {
+            continue;
+        }
+        if let Err(e) = crate::github::pr_update_body(checkout, Some(source), *number, &updated).await
+        {
+            tracing::warn!(error = %e, pr = %pr_ref, "pr-set: body update failed");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trailer_appends_to_a_body_without_one() {
+        let body = "Adds the login flow.";
+        let out = apply_pr_set_trailer(body, "---\nPart of a multi-repo change in X: o/a#1, o/b#2");
+        assert_eq!(
+            out,
+            "Adds the login flow.\n\n<!-- fletch:pr-set -->\n---\nPart of a multi-repo change in X: o/a#1, o/b#2\n<!-- /fletch:pr-set -->"
+        );
+    }
+
+    #[test]
+    fn trailer_replaces_between_sentinels_never_duplicates() {
+        let body = "Adds the login flow.";
+        let first = apply_pr_set_trailer(body, "---\nset: o/a#1, o/b#2");
+        // The set grew — re-applying must swap the block in place, keeping the
+        // prose above it and producing exactly one sentinel pair.
+        let second = apply_pr_set_trailer(&first, "---\nset: o/a#1, o/b#2, o/c#3");
+        assert_eq!(second.matches(PR_SET_START).count(), 1);
+        assert_eq!(second.matches(PR_SET_END).count(), 1);
+        assert!(second.starts_with("Adds the login flow."));
+        assert!(second.contains("o/c#3"));
+        assert!(!second.contains("set: o/a#1, o/b#2\n"), "old block must be gone");
+        // Same trailer again → byte-identical (the sync skips the PATCH).
+        let third = apply_pr_set_trailer(&second, "---\nset: o/a#1, o/b#2, o/c#3");
+        assert_eq!(second, third);
+    }
+
+    #[test]
+    fn trailer_preserves_text_after_the_block() {
+        // The agent (or a human) edited below the trailer — replacement must
+        // keep that text, not truncate the body at the block.
+        let body = "intro\n\n<!-- fletch:pr-set -->\nold\n<!-- /fletch:pr-set -->\n\noutro";
+        let out = apply_pr_set_trailer(body, "new");
+        assert_eq!(
+            out,
+            "intro\n\n<!-- fletch:pr-set -->\nnew\n<!-- /fletch:pr-set -->\n\noutro"
+        );
+    }
+
+    #[test]
+    fn trailer_is_the_whole_body_when_body_is_empty() {
+        let out = apply_pr_set_trailer("", "content");
+        assert_eq!(out, "<!-- fletch:pr-set -->\ncontent\n<!-- /fletch:pr-set -->");
+        // Whitespace-only bodies count as empty (no leading blank lines).
+        let out = apply_pr_set_trailer("  \n", "content");
+        assert!(out.starts_with(PR_SET_START));
+    }
+
+    #[test]
+    fn trailer_content_names_project_and_set() {
+        let refs = vec!["o/frontend#12".to_string(), "o/backend#34".to_string()];
+        assert_eq!(
+            pr_set_trailer(Some("Acme"), &refs),
+            "---\nPart of a multi-repo change in Acme: o/frontend#12, o/backend#34"
+        );
+        assert_eq!(
+            pr_set_trailer(None, &refs),
+            "---\nPart of a multi-repo change: o/frontend#12, o/backend#34"
+        );
+    }
+}

--- a/src-tauri/src/supervisor/rpc_watch.rs
+++ b/src-tauri/src/supervisor/rpc_watch.rs
@@ -144,6 +144,13 @@ fn handle_rpc_event(sup: &Supervisor, app: &AppHandle, agent_id: &str, event: rp
                 }
             }
             sup.fetch_and_emit_pr_state(app.clone(), agent_id.to_string());
+            // The agent may now hold PRs in two or more repos — cross-link the
+            // set in each PR's body (best-effort, in the background).
+            let workspace = sup.workspace.clone();
+            let id = agent_id.to_string();
+            tauri::async_runtime::spawn(async move {
+                super::sync_pr_set_links(&workspace, &id).await;
+            });
         }
         rpc::RpcEvent::Named { name, payload } if name == rpc::git::EVENT_ACTION_DONE => {
             // Authoritative "the agent performed a git mutation this

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -191,10 +191,24 @@ pub(crate) async fn resolve_pr_state(
     }
 }
 
-/// Resolve PR state for *every* bound agent in one batched round-trip — the
-/// app-wide poll behind `refresh_all_pr_states`. Same per-agent policy as
-/// [`resolve_pr_state`], but the live lookups are collapsed into a single
-/// aliased GraphQL query instead of a per-agent fan-out:
+/// Store key for one repo's PR state in the app-wide maps, mirroring the
+/// frontend's `gitKey` (`src/store/git.ts`): the primary repo keeps the plain
+/// agent id — the key every existing consumer (sidebar badge, title bar,
+/// `pr:state_changed` reducer) reads — and secondaries get
+/// `"{agent_id}::{subdir}"`, the same suffixed form the Git panel's per-repo
+/// fetches use.
+pub(crate) fn pr_map_key(agent_id: &str, subdir: &str, primary: bool) -> String {
+    if primary {
+        agent_id.to_string()
+    } else {
+        format!("{agent_id}::{subdir}")
+    }
+}
+
+/// Resolve PR state for *every* bound repo of every agent in one batched
+/// round-trip — the app-wide poll behind `refresh_all_pr_states`. Same
+/// per-repo policy as [`resolve_pr_state`], but the live lookups are collapsed
+/// into a single aliased GraphQL query instead of a per-agent fan-out:
 ///
 /// - **Merged** PRs are served from the persisted snapshot (terminal — never
 ///   re-fetched).
@@ -205,8 +219,11 @@ pub(crate) async fn resolve_pr_state(
 ///
 /// A paused backoff, an unresolvable slug, a not-found alias, or a whole-batch
 /// failure all degrade to the last persisted snapshot rather than wiping the
-/// badge. Agents that resolve to nothing are omitted from the map (never
-/// written as absent state), matching the command's contract.
+/// badge. Repos that resolve to nothing are omitted from the map (never
+/// written as absent state), matching the command's contract. Keys follow
+/// [`pr_map_key`]: plain agent id for the primary, `"{agent_id}::{subdir}"`
+/// for secondaries — so single-repo agents produce exactly one plain-keyed
+/// entry, byte-identical to before.
 pub(crate) async fn resolve_all_pr_states(
     workspace: &WorkspaceManager,
     reverify_closed: bool,
@@ -221,10 +238,11 @@ pub(crate) async fn resolve_all_pr_states(
     // Paused → touch no network; every bound PR renders from its snapshot.
     let paused = client::is_backing_off();
 
-    // A network-bound agent: what to fetch, plus the snapshot to fall back to.
+    // A network-bound repo: what to fetch, plus the snapshot to fall back to.
     struct Pending {
         agent_id: String,
         subdir: String,
+        key: String,
         snapshot: Option<PrState>,
         pr_ref: PrRef,
     }
@@ -234,50 +252,51 @@ pub(crate) async fn resolve_all_pr_states(
         if agent.archive.is_some() {
             continue;
         }
-        let Some(repo) = agent.repos.first() else {
-            continue;
-        };
-        // No branch → nothing pushed; no number → discovery isn't this poll's job.
-        if repo.branch.is_none() {
-            continue;
-        }
-        let Some(number) = repo.pr_number else {
-            continue;
-        };
-        let snapshot = pr_snapshot(repo);
-
-        let terminal = repo.pr_state.as_deref() == Some(PrStatus::Merged.as_str());
-        let closed = repo.pr_state.as_deref() == Some(PrStatus::Closed.as_str());
-        // Merged never re-fetches; closed only on the slow re-verify tick.
-        let fetch = !paused && !terminal && (!closed || reverify_closed);
-        if !fetch {
-            if let Some(snap) = snapshot {
-                out.insert(agent.id.clone(), snap);
+        for (i, repo) in agent.repos.iter().enumerate() {
+            let key = pr_map_key(&agent.id, &repo.subdir, i == 0);
+            // No branch → nothing pushed; no number → discovery isn't this poll's job.
+            if repo.branch.is_none() {
+                continue;
             }
-            continue;
-        }
+            let Some(number) = repo.pr_number else {
+                continue;
+            };
+            let snapshot = pr_snapshot(repo);
 
-        // Resolve the slug now (local git); the network cost is deferred to the
-        // one batched query below. A broken checkout / non-GitHub origin can't
-        // be fetched — hold the snapshot instead.
-        let slug = match repo_checkout_path(&agent.id, &repo.subdir) {
-            Ok(checkout) => crate::github::resolve_slug(&checkout, Some(&repo.repo_path)).await,
-            Err(_) => None,
-        };
-        match slug {
-            Some((owner, repo_name)) => pending.push(Pending {
-                agent_id: agent.id.clone(),
-                subdir: repo.subdir.clone(),
-                snapshot,
-                pr_ref: PrRef {
-                    owner,
-                    repo: repo_name,
-                    number: number as u32,
-                },
-            }),
-            None => {
+            let terminal = repo.pr_state.as_deref() == Some(PrStatus::Merged.as_str());
+            let closed = repo.pr_state.as_deref() == Some(PrStatus::Closed.as_str());
+            // Merged never re-fetches; closed only on the slow re-verify tick.
+            let fetch = !paused && !terminal && (!closed || reverify_closed);
+            if !fetch {
                 if let Some(snap) = snapshot {
-                    out.insert(agent.id.clone(), snap);
+                    out.insert(key, snap);
+                }
+                continue;
+            }
+
+            // Resolve the slug now (local git); the network cost is deferred to the
+            // one batched query below. A broken checkout / non-GitHub origin can't
+            // be fetched — hold the snapshot instead.
+            let slug = match repo_checkout_path(&agent.id, &repo.subdir) {
+                Ok(checkout) => crate::github::resolve_slug(&checkout, Some(&repo.repo_path)).await,
+                Err(_) => None,
+            };
+            match slug {
+                Some((owner, repo_name)) => pending.push(Pending {
+                    agent_id: agent.id.clone(),
+                    subdir: repo.subdir.clone(),
+                    key,
+                    snapshot,
+                    pr_ref: PrRef {
+                        owner,
+                        repo: repo_name,
+                        number: number as u32,
+                    },
+                }),
+                None => {
+                    if let Some(snap) = snapshot {
+                        out.insert(key, snap);
+                    }
                 }
             }
         }
@@ -294,22 +313,22 @@ pub(crate) async fn resolve_all_pr_states(
                 match res {
                     Some(pr) => {
                         persist_pr_snapshot(workspace, &p.agent_id, &p.subdir, &pr);
-                        out.insert(p.agent_id, pr);
+                        out.insert(p.key, pr);
                     }
                     // Not found this round / partial error — keep last-known.
                     None => {
                         if let Some(snap) = p.snapshot {
-                            out.insert(p.agent_id, snap);
+                            out.insert(p.key, snap);
                         }
                     }
                 }
             }
         }
-        // Whole-batch failure — degrade every bound agent to its snapshot.
+        // Whole-batch failure — degrade every bound repo to its snapshot.
         Err(_) => {
             for p in pending {
                 if let Some(snap) = p.snapshot {
-                    out.insert(p.agent_id, snap);
+                    out.insert(p.key, snap);
                 }
             }
         }
@@ -1058,6 +1077,15 @@ mod tests {
             pr_state: Some("merged".into()),
             label: None,
         }
+    }
+
+    /// The app-wide poll keys mirror the frontend's `gitKey`: the primary repo
+    /// keeps the plain agent id (so every existing consumer is untouched) and
+    /// secondaries get the `::`-suffixed form the Git panel already reads.
+    #[test]
+    fn pr_map_key_mirrors_frontend_git_key() {
+        assert_eq!(pr_map_key("ag-1", "frontend", true), "ag-1");
+        assert_eq!(pr_map_key("ag-1", "backend", false), "ag-1::backend");
     }
 
     /// The persisted columns rebuild into a renderable PrState.

--- a/src/api.ts
+++ b/src/api.ts
@@ -211,7 +211,10 @@ export interface GitState {
 
 /** One file in the checkout, as returned by `list_checkout_tree`.
  *  `status` is the single-letter git status vs the parent branch
- *  ("M" | "A" | "D" | "R"), or null when the file is unchanged. */
+ *  ("M" | "A" | "D" | "R"), or null when the file is unchanged.
+ *  Multi-repo agents get paths prefixed with the owning checkout's subdir
+ *  ("<subdir>/<rel>"); the file read/write commands resolve the same prefix
+ *  back, so the panel can pass these paths through unchanged. */
 export interface CheckoutFile {
   path: string;
   status: string | null;

--- a/src/components/RightPanel/FilePanel/index.tsx
+++ b/src/components/RightPanel/FilePanel/index.tsx
@@ -119,11 +119,23 @@ export function FilePanel({ agent, openPath, onOpenPath }: FilePanelProps) {
   // ── file operations ───────────────────────────────────────────────────
   const allPaths = useMemo(() => new Set(files.map((f) => f.path)), [files]);
 
+  // Multi-repo agents get one virtual top-level folder per repo (the backend
+  // prefixes every path with the checkout's subdir). Those folders are
+  // structural — you can create inside them, but never rename/delete/duplicate
+  // the checkout itself. Null for single-repo agents: no path is a repo root.
+  const repoRoots = useMemo(
+    () => (agent.repos.length > 1 ? new Set(agent.repos.map((r) => r.subdir)) : null),
+    [agent.repos],
+  );
+
   // Begin a create: open the target dir so the inline input is visible.
+  // Multi-repo: nothing can live at the virtual root (every path belongs to a
+  // repo), so a root-level create lands in the primary repo instead.
   const beginCreate = (mode: "newFile" | "newFolder", dir: string) => {
+    const target = dir === "" && repoRoots ? agent.repos[0].subdir : dir;
     setOpError(null);
-    if (dir) expand(dir);
-    setEdit({ mode, parentDir: dir });
+    if (target) expand(target);
+    setEdit({ mode, parentDir: target });
   };
 
   const cancelEdit = () => setEdit(null);
@@ -221,6 +233,20 @@ export function FilePanel({ agent, openPath, onOpenPath }: FilePanelProps) {
       { icon: "file", label: "New File…", onClick: () => beginCreate("newFile", target) },
       { icon: "folder", label: "New Folder…", onClick: () => beginCreate("newFolder", target) },
     ];
+    // A repo's virtual root folder: create into it and copy its path, but no
+    // rename/delete — the checkout itself isn't a file-tree operation target.
+    if (node.type === "dir" && repoRoots?.has(node.path)) {
+      return [
+        ...newItems,
+        "sep",
+        {
+          icon: "copy",
+          label: "Copy Path",
+          feedbackLabel: "Copied",
+          onClick: () => copyPath(node),
+        },
+      ];
+    }
     const common: ContextMenuEntry[] = [
       {
         icon: "edit",

--- a/src/components/RightPanel/GitPanel/GitPanel.css
+++ b/src/components/RightPanel/GitPanel/GitPanel.css
@@ -1049,3 +1049,31 @@
   background: var(--bg-1);
   border-bottom: 1px solid var(--bd-soft);
 }
+
+/* ── PR-set strip: "one task, N PRs" summary above the sections ──
+   Rendered only when ≥2 repos hold a PR; each chip links out to its PR. */
+.git-pr-set {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--bd-soft);
+}
+.git-pr-set-label {
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+}
+.git-pr-set-chip {
+  display: inline-flex;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+.git-pr-set-chip:hover .ag-badge {
+  filter: brightness(1.15);
+}

--- a/src/components/RightPanel/GitPanel/PrSetStrip.tsx
+++ b/src/components/RightPanel/GitPanel/PrSetStrip.tsx
@@ -1,0 +1,57 @@
+import { open } from "@tauri-apps/plugin-shell";
+import type { PrChecks, PrState, TrackedRepo } from "@/api";
+import { Icon } from "@/components/Icon";
+import { Badge, type BadgeVariant } from "@/components/ui/Badge";
+import { basename } from "@/util/format";
+
+/** One repo's PR for the strip: the panel section's own resolved state. */
+export interface PrSetEntry {
+  repo: TrackedRepo;
+  pr: PrState;
+  checks: PrChecks | null;
+}
+
+/** The status pill for one PR of the set: state first, refined by the CI
+ *  rollup while open (same tint semantics as the sidebar's PR pill). */
+function chipStatus(pr: PrState, checks: PrChecks | null): { variant: BadgeVariant; word: string } {
+  if (pr.state === "merged") return { variant: "pr-merged", word: "merged" };
+  if (pr.state === "closed") return { variant: "pr-closed", word: "closed" };
+  switch (checks?.rollup) {
+    case "passing":
+      return { variant: "pr-pass", word: "checks passing" };
+    case "failing":
+      return { variant: "pr-fail", word: "checks failing" };
+    case "pending":
+      return { variant: "pr-open", word: "checks running" };
+    default:
+      return { variant: "pr-open", word: "open" };
+  }
+}
+
+/** Slim summary strip above a multi-repo agent's panel sections when the task
+ *  produced PRs in two or more repos: "2 PRs" plus one linked pill per PR, so
+ *  the set reads as a unit and each PR is one click away. Rendered only by
+ *  `MultiRepoGitPanel` (never for single-repo agents). */
+export function PrSetStrip({ entries }: { entries: PrSetEntry[] }) {
+  return (
+    <div className="git-pr-set text-xs">
+      <span className="git-pr-set-label">{entries.length} PRs</span>
+      {entries.map(({ repo, pr, checks }) => {
+        const { variant, word } = chipStatus(pr, checks);
+        const label = repo.label ?? basename(repo.repo_path);
+        return (
+          <button
+            key={repo.subdir}
+            className="git-pr-set-chip"
+            onClick={() => pr.url && void open(pr.url)}
+            aria-label={`${label} PR #${pr.number} — ${word}`}
+          >
+            <Badge variant={variant} tip={`${label} · ${word}`}>
+              <Icon name={pr.state === "merged" ? "merge" : "pr"} size={10} />#{pr.number}
+            </Badge>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/RightPanel/GitPanel/index.tsx
+++ b/src/components/RightPanel/GitPanel/index.tsx
@@ -4,7 +4,9 @@ import { useAppStore } from "@/store";
 import { gitKey } from "@/store/git";
 import { basename } from "@/util/format";
 import { usePoll } from "@/util/hooks";
+import { prSnapshot } from "@/util/prState";
 import { GitRepoSection } from "./GitRepoSection";
+import { type PrSetEntry, PrSetStrip } from "./PrSetStrip";
 
 /** A repo of the agent plus the scope its section reads/writes under:
  *  `subdir` is undefined for the primary repo (index 0 — plain agent-keyed
@@ -49,6 +51,8 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
 function MultiRepoGitPanel({ agent }: { agent: AgentRecord }) {
   const fetchGitState = useAppStore((s) => s.fetchGitState);
   const gitStates = useAppStore((s) => s.gitStates);
+  const prStates = useAppStore((s) => s.prStates);
+  const prChecks = useAppStore((s) => s.prChecks);
   // The repo scope of the agent's in-flight delegation, if any: `null` when
   // there is no delegation (pins nothing), `undefined` when it targets the
   // primary. Distinct sentinel needed because `undefined` is a real scope.
@@ -62,6 +66,17 @@ function MultiRepoGitPanel({ agent }: { agent: AgentRecord }) {
   // Nothing active yet → the primary repo's section (today's empty state),
   // with no section header.
   const sections = active.length > 0 ? active : [scopes[0]];
+
+  // The task's PR set, one entry per repo with a PR — resolved with the same
+  // per-repo policy as each section (a present store key, even a confirmed
+  // null, is authoritative; only a never-fetched key falls back to the repo's
+  // own persisted snapshot), so the strip and the sections always agree.
+  const prSet: PrSetEntry[] = scopes.flatMap((sc) => {
+    const key = gitKey(agent.id, sc.subdir);
+    const live = prStates[key];
+    const pr = live !== undefined ? live : prSnapshot(sc.repo);
+    return pr ? [{ repo: sc.repo, pr, checks: prChecks[key] ?? null }] : [];
+  });
 
   // On mount / agent change, fetch git state for EVERY repo so "active" can be
   // computed — rendered sections then keep their own 1s poll going.
@@ -84,6 +99,8 @@ function MultiRepoGitPanel({ agent }: { agent: AgentRecord }) {
 
   return (
     <div className="git-multi">
+      {/* ≥2 PRs → the "one task, N PRs" strip presents the set as a unit. */}
+      {prSet.length >= 2 && <PrSetStrip entries={prSet} />}
       {sections.map((sc) => (
         <section key={sc.repo.subdir} className="git-repo-sect">
           {active.length > 0 && (

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -11,7 +11,7 @@ import type { DraftAgent } from "@/store";
 import { useAppStore } from "@/store";
 import { formatAge } from "@/util/format";
 import { useMinuteClock } from "@/util/hooks";
-import { usePrState } from "@/util/prState";
+import { type AgentPr, useAgentPrs } from "@/util/prState";
 import { type AgentStats, AgentStatsPopover } from "./AgentStatsPopover";
 
 /** The agent rows carry nested buttons (stop/archive/discard), so they can't be
@@ -52,13 +52,13 @@ export function AgentRow(props: Props) {
 
 function RealRow({ agent, active, onClick }: RealRowProps) {
   const usage = useAppStore((s) => s.usage[agent.id]);
-  // Live PR state with the persisted database snapshot as fallback, so a
-  // merged badge survives restarts, offline stretches, and broken checkouts.
-  const prState = usePrState(agent.id, agent.repos[0]);
-  // CI rollup for this agent's PR, fed by the app-wide refreshAllPrChecks poll
-  // (see App.tsx) — lets the PR pill tint pass/fail across every row, not just
-  // the focused one. Null until the first poll lands or when there's no PR.
-  const prChecks = useAppStore((s) => s.prChecks[agent.id] ?? null);
+  // Every PR across the agent's repos (live state with the persisted database
+  // snapshot as fallback, so a merged badge survives restarts, offline
+  // stretches, and broken checkouts), each with the CI rollup the app-wide
+  // refreshAllPrChecks poll recorded for it. Single-repo agents yield at most
+  // one entry — exactly the old primary-only read; a multi-repo agent whose
+  // only PR lives on a secondary repo still gets its badge.
+  const agentPrs = useAgentPrs(agent);
   const shortstats = useAppStore((s) => s.gitShortstats[agent.id]);
   const unseen = useAppStore((s) => s.unseenResults[agent.id] ?? false);
   // Dev-server state for this checkout — orthogonal to the agent's turn status,
@@ -124,15 +124,17 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
     agent.status === "idle" || agent.status === "stopped" || agent.status === "error";
 
   // The status rail doubles as the left spine: colored for live/terminal
-  // states, a merged PR claims purple, everything else is a faint grey.
-  // A pending question outranks the plain running green — amber says "you".
+  // states, a merged PR claims purple (every PR of the set, for multi-repo),
+  // everything else is a faint grey. A pending question outranks the plain
+  // running green — amber says "you".
+  const allMerged = agentPrs.length > 0 && agentPrs.every((e) => e.pr.state === "merged");
   const railClass = awaiting
     ? "wait"
     : working
       ? "run"
       : agent.status === "error"
         ? "err"
-        : prState?.state === "merged"
+        : allMerged
           ? "merged"
           : "idle";
 
@@ -231,8 +233,10 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
       </div>
       <div className="agent-sub flex-center">
         <span className="a-task">{taskOrBranch}</span>
-        {prState ? (
-          <PrBadge pr={prState} checks={prChecks} />
+        {agentPrs.length === 1 ? (
+          <PrBadge pr={agentPrs[0].pr} checks={agentPrs[0].checks} />
+        ) : agentPrs.length > 1 ? (
+          <MultiPrBadge prs={agentPrs} />
         ) : hasChanges ? (
           <DiffStat stats={shortstats} />
         ) : null}
@@ -329,6 +333,53 @@ function PrBadge({ pr, checks }: { pr: PrState; checks: PrChecks | null }) {
       PR
     </Badge>
   );
+}
+
+/** Aggregate pill for a multi-repo agent with PRs on several repos: `N PRs`,
+ *  tinted by the worst status across the set — any open PR with failing checks
+ *  → red; any open PR still pending/unchecked → the neutral open blue; all
+ *  open PRs passing → green; no open PRs → closed grey over merged purple.
+ *  The tooltip itemizes each PR so the pill stays glanceable. */
+function MultiPrBadge({ prs }: { prs: AgentPr[] }) {
+  const open = prs.filter((e) => e.pr.state === "open");
+  let variant: BadgeVariant;
+  let icon: "pr" | "merge" = "pr";
+  if (open.length > 0) {
+    const tints = open.map((e) => ciTint(e.checks).variant);
+    variant = tints.includes("pr-fail")
+      ? "pr-fail"
+      : tints.includes("pr-open")
+        ? "pr-open"
+        : "pr-pass";
+  } else if (prs.some((e) => e.pr.state === "closed")) {
+    variant = "pr-closed";
+  } else {
+    variant = "pr-merged";
+    icon = "merge";
+  }
+  const tip = prs.map((e) => `#${e.pr.number} ${prStatusWord(e)}`).join(" · ");
+  return (
+    <Badge variant={variant} tip={tip}>
+      <Icon name={icon} size={10} />
+      {prs.length} PRs
+    </Badge>
+  );
+}
+
+/** One PR's status for the aggregate tooltip: its state, refined by the CI
+ *  rollup while open. */
+function prStatusWord({ pr, checks }: AgentPr): string {
+  if (pr.state !== "open") return pr.state;
+  switch (checks?.rollup) {
+    case "passing":
+      return "open, checks passing";
+    case "failing":
+      return "open, checks failing";
+    case "pending":
+      return "open, checks running";
+    default:
+      return "open";
+  }
 }
 
 /** Map an open PR's CI rollup to a pill variant + tooltip suffix. Pending and

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -423,6 +423,16 @@ export function usedNames(workspace: Workspace | null, drafts: DraftAgent[]): Se
   return used;
 }
 
+/** Drop an agent's entries from a repo-scoped map: the plain `id` key (the
+ *  primary repo) plus any `id::subdir` composite keys a multi-repo agent's
+ *  per-repo fetches and bulk polls wrote (see `gitKey` in store/git). */
+function dropScopedEntries<T>(map: Record<string, T>, id: string): Record<string, T> {
+  const prefix = `${id}::`;
+  return Object.fromEntries(
+    Object.entries(map).filter(([key]) => key !== id && !key.startsWith(prefix)),
+  );
+}
+
 /** Strip an agent's entries from every ephemeral per-agent map, returning just
  *  the pruned maps as a state patch (the caller layers on workspace /
  *  selectedAgentId). Shared by discard and archive — dropping these is safe
@@ -434,11 +444,13 @@ export function dropAgentEntries(state: AppState, id: string): Partial<AppState>
   const { [id]: _busy, ...managedBusy } = state.managedBusy;
   const { [id]: _started, ...turnStartedAt } = state.turnStartedAt;
   const { [id]: _usage, ...usage } = state.usage;
-  const { [id]: _git, ...gitStates } = state.gitStates;
+  // The git/PR maps are repo-scoped: a multi-repo agent also holds
+  // `id::subdir` keys, which must not outlive it.
+  const gitStates = dropScopedEntries(state.gitStates, id);
+  const prStates = dropScopedEntries(state.prStates, id);
+  const prChecks = dropScopedEntries(state.prChecks, id);
+  const prComments = dropScopedEntries(state.prComments, id);
   const { [id]: _short, ...gitShortstats } = state.gitShortstats;
-  const { [id]: _pr, ...prStates } = state.prStates;
-  const { [id]: _checks, ...prChecks } = state.prChecks;
-  const { [id]: _comments, ...prComments } = state.prComments;
   const { [id]: _seed, ...composerSeeds } = state.composerSeeds;
   const { [id]: _draft, ...composerDrafts } = state.composerDrafts;
   const { [id]: _delegation, ...gitDelegations } = state.gitDelegations;

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -259,13 +259,15 @@ export interface GitSlice {
    *  (used by the app-wide background poll). */
   fetchAllShortstats: () => Promise<void>;
   fetchPrState: (agentId: string, subdir?: string) => Promise<void>;
-  /** Refresh PR state for every agent with a known PR in one round-trip
-   *  (used by the app-wide background poll). Backend emits `pr:state_changed`
-   *  per agent, so the sidebar badge updates without opening the Git panel. */
+  /** Refresh PR state for every repo with a known PR across every agent in
+   *  one round-trip (used by the app-wide background poll). The reply is
+   *  keyed by `gitKey`, so a multi-repo agent's secondary-repo PRs land in
+   *  the store too and the sidebar badge updates without opening the panel. */
   refreshAllPrStates: () => Promise<void>;
-  /** Refresh CI checks for every agent with an open PR in one round-trip
-   *  (used by the app-wide background poll) so the sidebar PR pill can tint
-   *  pass/fail without opening the Git panel. */
+  /** Refresh CI checks for every repo with an open PR in one round-trip
+   *  (used by the app-wide background poll, keyed by `gitKey` like
+   *  `refreshAllPrStates`) so the sidebar PR pill can tint pass/fail without
+   *  opening the Git panel. */
   refreshAllPrChecks: () => Promise<void>;
   fetchPrChecks: (agentId: string, subdir?: string) => Promise<void>;
   fetchPrComments: (agentId: string, subdir?: string) => Promise<void>;

--- a/src/util/prState.ts
+++ b/src/util/prState.ts
@@ -5,8 +5,10 @@
 // already confirmed (especially a merged one) never renders as "no PR".
 
 import { useMemo } from "react";
-import type { PrState, PrStatus, TrackedRepo } from "@/api";
+import { useShallow } from "zustand/react/shallow";
+import type { AgentRecord, PrChecks, PrState, PrStatus, TrackedRepo } from "@/api";
 import { useAppStore } from "@/store";
+import { gitKey } from "@/store/git";
 
 const PR_STATUSES: readonly PrStatus[] = ["open", "merged", "closed"];
 
@@ -39,4 +41,32 @@ export function usePrState(agentId: string, repo?: TrackedRepo): PrState | null 
     (s) => repo ?? s.workspace?.agents.find((a) => a.id === agentId)?.repos[0],
   );
   return useMemo(() => live ?? prSnapshot(found), [live, found]);
+}
+
+/** One repo's PR within an agent's set, with its CI rollup (null until the
+ *  app-wide checks poll lands or when there's no rollup). */
+export interface AgentPr {
+  pr: PrState;
+  checks: PrChecks | null;
+  repo: TrackedRepo;
+}
+
+/** Every PR across an agent's repos, in repo order (primary first). Each repo
+ *  reads its own store entry — plain agent id for the primary, the suffixed
+ *  `gitKey` for secondaries, both fed by the app-wide bulk polls — with the
+ *  same live-else-snapshot fallback as `usePrState`, applied per repo (a
+ *  secondary never inherits the primary's snapshot). Repos without a PR drop
+ *  out, so a single-repo agent yields exactly the `usePrState` result. */
+export function useAgentPrs(agent: AgentRecord): AgentPr[] {
+  const keys = agent.repos.map((r, i) => gitKey(agent.id, i === 0 ? undefined : r.subdir));
+  const live = useAppStore(useShallow((s) => keys.map((k) => s.prStates[k] ?? null)));
+  const checks = useAppStore(useShallow((s) => keys.map((k) => s.prChecks[k] ?? null)));
+  return useMemo(
+    () =>
+      agent.repos.flatMap((repo, i) => {
+        const pr = live[i] ?? prSnapshot(repo);
+        return pr ? [{ pr, checks: checks[i], repo }] : [];
+      }),
+    [agent.repos, live, checks],
+  );
 }

--- a/src/util/prState.ts
+++ b/src/util/prState.ts
@@ -53,18 +53,22 @@ export interface AgentPr {
 
 /** Every PR across an agent's repos, in repo order (primary first). Each repo
  *  reads its own store entry — plain agent id for the primary, the suffixed
- *  `gitKey` for secondaries, both fed by the app-wide bulk polls — with the
- *  same live-else-snapshot fallback as `usePrState`, applied per repo (a
- *  secondary never inherits the primary's snapshot). Repos without a PR drop
- *  out, so a single-repo agent yields exactly the `usePrState` result. */
+ *  `gitKey` for secondaries, both fed by the app-wide bulk polls — resolved
+ *  with the same per-repo policy as the panel sections and the PR-set strip:
+ *  a present key, even a confirmed `null` (a fetch that found no PR), is
+ *  authoritative; only a never-fetched key (absent = `undefined`) falls back
+ *  to that repo's own persisted snapshot (a secondary never inherits the
+ *  primary's). Repos without a PR drop out. */
 export function useAgentPrs(agent: AgentRecord): AgentPr[] {
   const keys = agent.repos.map((r, i) => gitKey(agent.id, i === 0 ? undefined : r.subdir));
-  const live = useAppStore(useShallow((s) => keys.map((k) => s.prStates[k] ?? null)));
+  const live = useAppStore(
+    useShallow((s) => keys.map((k) => (k in s.prStates ? s.prStates[k] : undefined))),
+  );
   const checks = useAppStore(useShallow((s) => keys.map((k) => s.prChecks[k] ?? null)));
   return useMemo(
     () =>
       agent.repos.flatMap((repo, i) => {
-        const pr = live[i] ?? prSnapshot(repo);
+        const pr = live[i] !== undefined ? live[i] : prSnapshot(repo);
         return pr ? [{ pr, checks: checks[i], repo }] : [];
       }),
     [agent.repos, live, checks],


### PR DESCRIPTION
Implements the high- and medium-priority follow-ups (items 1–3) from `docs/multi-repo-followups.md`, as one PR since they share the PR fan-out plumbing.

## 1. Sidebar PR badge fan-out (high)

- `resolve_all_pr_states` / `refresh_all_pr_checks` now iterate **every** tracked repo of every agent, returning maps keyed by the frontend's `gitKey` convention: plain agent id for the primary (so every existing consumer is untouched), `agent_id::subdir` for secondaries. The batched GraphQL queries grow by repo count — no extra round trips.
- New `useAgentPrs(agent)` hook aggregates live-state-else-snapshot per repo. The sidebar row shows the single PR pill whenever exactly one repo has a PR — **fixing the bug where an agent whose only PR is on a secondary repo showed no badge** — and an `N PRs` pill with worst-status tint (failing > open/pending > passing; closed > merged) with an itemized tooltip when there are several. The purple "merged" rail now requires the whole set to be merged.
- `dropAgentEntries` also prunes `id::subdir` composite keys so a discarded/archived multi-repo agent leaves nothing behind.

## 2. "One task → N PRs" presented as a unit (high)

- New `supervisor/pr_set.rs`: when an agent holds bound PRs in ≥2 repos, every PR body gets a trailer — `Part of a multi-repo change in <project>: owner/frontend#12, owner/backend#34` — wrapped in `<!-- fletch:pr-set -->` sentinels and **replaced between sentinels, never appended**, so re-runs converge and text the agent wrote above/below the block survives. Unchanged bodies skip the PATCH. Runs best-effort in the background after both PR-creation paths (panel `create_pr`, agent `open_pr` RPC), which is also what backfills the first PR's body when the second appears. Respects the rate-limit backoff gate.
- New `gh::pr_body` / `gh::pr_update_body` (GraphQL fetch + REST PATCH) back this.
- The multi-repo Git panel renders a slim **PR-set strip** above the sections when ≥2 repos hold a PR: `N PRs` plus one linked, status-tinted chip per PR (repo label + checks state in the tooltip), resolved with the same per-repo policy the sections use.
- Merge-order gating deliberately skipped per the doc (v1 boundary).

## 3. Code tab multi-repo (medium — option A, repo-prefixed virtual root)

- `list_checkout_tree` for a multi-repo agent walks each checkout and prefixes paths with the repo's `subdir`, computing each repo's git status against **its own** fork point; the tree component already nests on `/`, so repos appear as top-level folders with the existing changed-count badges. One broken checkout skips rather than blanking the tree.
- All file commands (`read/write/create/copy/rename/delete`, `get_file_diff`) resolve the first path segment back to the owning checkout via `checkout_scope_for_path`; unknown prefixes error listing the tracked folders, and path-traversal checks run against the resolved checkout root. Rename/copy resolve source and destination independently.
- Repo-root folders are structural in the UI: context menu offers New File/Folder + Copy Path only (no rename/delete/duplicate), and the toolbar's root-level create lands in the primary repo (nothing can live at the virtual root).
- Every prefix branch is gated on `repos.len() > 1` — single-repo agents keep today's un-prefixed tree and behavior byte-identical, and a real top-level directory named like a subdir can't be misrouted.

## Invariants

- Single-repo projects/agents byte-identical everywhere (optional scope, primary default, plain-agent-id keys).
- No cross-repo attribution: every new path threads the subdir; snapshot fallbacks are per-repo.
- Workflow step agents untouched.

## Verification

- `cargo test --lib`: **897 passed** (new: `pr_map_key` shape, `split_repo_path` routing/rejection, PR-set trailer idempotency/replacement/preservation)
- `bun run check`: clean · `bun run lint`: 0 errors / 72 legacy warnings · `bun run test`: **447 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)