### PR TITLE
feat(verify): engine-owned verification as a reusable primitive

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -888,6 +888,53 @@ pub fn run_state(
     Ok(supervisor.run_state(&agent_id))
 }
 
+/// Default wall-clock budget for an ad-hoc verification run's checks, matching
+/// the workflow tests gate's `DEFAULT_TESTS_TIMEOUT_SECS` (15 min). Ad-hoc
+/// checkouts have no step budget to draw from.
+const VERIFY_TIMEOUT_SECS: u64 = 900;
+
+/// Run the project's deterministic checks — install → test → lint — in an
+/// agent's checkout and return a [`crate::verify::VerificationReport`]. Resolves
+/// the target repo via `subdir` (primary when `None`) and layers the project's
+/// `run.test` / `run.install` / `run.lint` overrides over detection, the same
+/// layering the workflow tests gate uses.
+#[tauri::command]
+pub async fn run_verification(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+    subdir: Option<String>,
+) -> Result<crate::verify::VerificationReport> {
+    let (_repo, checkout) = agent_repo_checkout(&supervisor, &agent_id, subdir.as_deref())?;
+    // Project-scoped command overrides (mirrors the tests gate's `run.test` /
+    // `run.install`, plus `run.lint`). Empty project_id → detection only.
+    let project_id = supervisor
+        .workspace
+        .agent(&agent_id)
+        .map(|r| r.project_id)
+        .unwrap_or_default();
+    let setting = |key: &str| -> Option<String> {
+        if project_id.is_empty() {
+            None
+        } else {
+            supervisor.workspace.project_setting(&project_id, key)
+        }
+    };
+    let verifier = crate::verify::Verifier::new(
+        setting("run.test"),
+        setting("run.install"),
+        setting("run.lint"),
+        VERIFY_TIMEOUT_SECS,
+    )?;
+    let report = verifier.verify(&checkout).await;
+    tracing::info!(
+        agent_id = %agent_id,
+        passed = report.passed(),
+        checks = report.checks.len(),
+        "ran ad-hoc verification"
+    );
+    Ok(report)
+}
+
 /// Detect the run configuration for an agent's primary repo, ranked by
 /// confidence. The panel renders the first entry and layers persisted
 /// overrides on top.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,6 +33,7 @@ mod slash_commands;
 mod supervisor;
 mod telemetry;
 mod transcripts;
+mod verify;
 mod workflow;
 mod workspace;
 
@@ -1212,6 +1213,7 @@ pub fn run() {
             commands::run_stop,
             commands::run_state,
             commands::detect_run_config,
+            commands::run_verification,
             commands::project_run_config,
             commands::read_env_file_keys,
             commands::get_env_override,

--- a/src-tauri/src/run_detect/mod.rs
+++ b/src-tauri/src/run_detect/mod.rs
@@ -10,8 +10,10 @@
 //!
 //! The rows map onto the panel's hybrid schema: the core rows
 //! (`version`, `install`, `dev`, `test`, `build`) are attempted for every
-//! ecosystem; the optional rows (`port`, `env`) are emitted only when
-//! detected. Rows a detector can't fill are simply omitted.
+//! ecosystem; the optional rows (`lint`, `port`, `env`) are emitted only when
+//! detected — `lint` when a conventional linter hook exists (a `lint` npm
+//! script, or a declared linter dependency). Rows a detector can't fill are
+//! simply omitted.
 
 use serde::Serialize;
 use std::path::Path;
@@ -35,7 +37,8 @@ pub enum RowGroup {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct DetectedRow {
     /// Stable id matching the panel's override-key scheme
-    /// (`version` | `install` | `dev` | `test` | `build` | `port` | `env`).
+    /// (`version` | `install` | `dev` | `test` | `build` | `lint` | `port` |
+    /// `env`).
     pub id: String,
     pub group: RowGroup,
     /// Human label, e.g. "Node version", "Toolchain".

--- a/src-tauri/src/run_detect/node.rs
+++ b/src-tauri/src/run_detect/node.rs
@@ -113,6 +113,18 @@ impl RunDetector for NodeDetector {
                 "package.json · scripts.test",
             ));
         }
+        // lint: a conventional `lint` script. `run` is used (not the bare
+        // `{pm} lint`) so the command is valid for npm too, which reserves only
+        // a handful of script shortcuts.
+        if script("lint").is_some() {
+            rows.push(DetectedRow::new(
+                "lint",
+                RowGroup::Scripts,
+                "Lint",
+                format!("{pm} run lint"),
+                "package.json · scripts.lint",
+            ));
+        }
 
         // port (optional): scan the resolved dev command + framework deps.
         let deps = dependency_names(&pkg);
@@ -233,6 +245,29 @@ mod tests {
         assert_eq!(val(&cfg, "dev"), "pnpm dev");
         assert_eq!(val(&cfg, "build"), "pnpm build");
         assert_eq!(val(&cfg, "test"), "pnpm test");
+    }
+
+    #[test]
+    fn lint_script_becomes_run_lint() {
+        // `run` keeps the command valid for npm, which has no `npm lint` alias.
+        let cfg = detect(&[("package.json", r#"{"scripts":{"lint":"eslint ."}}"#)]).unwrap();
+        assert_eq!(val(&cfg, "lint"), "npm run lint");
+    }
+
+    #[test]
+    fn lint_script_uses_package_manager() {
+        let cfg = detect(&[(
+            "package.json",
+            r#"{"packageManager":"pnpm@9","scripts":{"lint":"biome check"}}"#,
+        )])
+        .unwrap();
+        assert_eq!(val(&cfg, "lint"), "pnpm run lint");
+    }
+
+    #[test]
+    fn missing_lint_script_omits_lint_row() {
+        let cfg = detect(&[("package.json", r#"{"scripts":{"test":"vitest"}}"#)]).unwrap();
+        assert!(cfg.rows.iter().all(|r| r.id != "lint"));
     }
 
     #[test]

--- a/src-tauri/src/run_detect/python.rs
+++ b/src-tauri/src/run_detect/python.rs
@@ -115,6 +115,19 @@ impl RunDetector for PythonDetector {
             ));
         }
 
+        // lint: only when a linter is a declared dependency (conservative —
+        // no inventing a command the project may not have). Ruff's canonical
+        // invocation is unambiguous.
+        if has_dep("ruff") {
+            rows.push(DetectedRow::new(
+                "lint",
+                RowGroup::Scripts,
+                "Lint",
+                "ruff check .",
+                "ruff dependency",
+            ));
+        }
+
         Some(DetectedConfig {
             ecosystem: "python".to_string(),
             confidence,
@@ -210,6 +223,18 @@ mod tests {
     fn pytest_test_row() {
         let cfg = detect(&[("requirements.txt", "pytest\n")]).unwrap();
         assert_eq!(val(&cfg, "test"), "pytest");
+    }
+
+    #[test]
+    fn ruff_dependency_yields_lint_row() {
+        let cfg = detect(&[("requirements.txt", "ruff\n")]).unwrap();
+        assert_eq!(val(&cfg, "lint"), "ruff check .");
+    }
+
+    #[test]
+    fn no_linter_dependency_omits_lint_row() {
+        let cfg = detect(&[("requirements.txt", "requests\n")]).unwrap();
+        assert!(cfg.rows.iter().all(|r| r.id != "lint"));
     }
 
     #[test]

--- a/src-tauri/src/run_detect/python.rs
+++ b/src-tauri/src/run_detect/python.rs
@@ -116,12 +116,14 @@ impl RunDetector for PythonDetector {
         }
 
         // lint: only when Ruff is a declared *dependency* (conservative — no
-        // inventing a command the project may not have installed). We match the
-        // declared package *name*, not a raw substring, so a comment (`# ruff`),
-        // a config table (`[tool.ruff]`), or an unrelated package (`ruffus`,
-        // `ruff-lsp`) never triggers it — otherwise verification would run
-        // `ruff check .` and fail where the executable isn't on PATH.
-        if declares_package(&deps_text, "ruff") {
+        // inventing a command the project may not have installed). Detection is
+        // section-aware (see `declares_package`), so a comment (`# ruff`), a
+        // config table (`[tool.ruff]`), a script/task table
+        // (`[tool.poe.tasks]`), a `[project]` `description`, or an unrelated
+        // package (`ruffus`, `ruff-lsp`) never triggers it — otherwise
+        // verification would run `ruff check .` and fail where Ruff isn't
+        // installed.
+        if declares_package(checkout, "ruff") {
             rows.push(DetectedRow::new(
                 "lint",
                 RowGroup::Scripts,
@@ -139,31 +141,170 @@ impl RunDetector for PythonDetector {
     }
 }
 
-/// Whether `deps_text` (the combined, lowercased dependency manifests) declares
-/// a dependency on package `name` (lowercase). Matches the leading PEP 508
-/// package *token* of a requirement rather than a raw substring, across the
-/// shapes Python manifests use:
+/// Whether the project declares a runtime/dev dependency on package `name`
+/// (lowercase), reading each manifest with awareness of its format.
 ///
-/// * requirements.txt lines — `ruff`, `ruff==0.4`, `ruff[extra]`, `ruff>=0.1; …`;
-/// * quoted specs in a PEP 621 / Poetry `dependencies` array — `"ruff>=0.1"`;
-/// * the `ruff = "…"` key form of a Poetry / Pipfile dependency table.
+/// A raw substring or even a bare per-line token isn't enough: a `[tool.ruff]`
+/// config table, a `[tool.poe.tasks]` / `[tool.pdm.scripts]` entry like
+/// `lint = "ruff check ."`, or a `[project]` `description = "ruff helpers"` all
+/// mention Ruff without installing it, and running `ruff check .` would then
+/// fail where the executable isn't on PATH. So detection is *contextual*:
 ///
-/// Blank lines, comments (`# …`), and TOML section headers (`[tool.ruff]`) never
-/// count, and an unrelated package whose name merely contains `name`
-/// (`ruffus`, `sruff`, `ruff-lsp`) is rejected because the whole token must
-/// match.
-fn declares_package(deps_text: &str, name: &str) -> bool {
-    deps_text.lines().any(|line| {
+/// * `requirements.txt` — the whole file is dependency context; the leading
+///   PEP 508 package token of each non-comment, non-option line is the package.
+/// * TOML (`pyproject.toml`, `Pipfile`) — a conservative line scanner tracks the
+///   current `[section]` and only evaluates candidates inside known dependency
+///   contexts (see [`toml_declares`]); everywhere else there are no candidates.
+///
+/// Package names match by whole token, so an unrelated package containing `name`
+/// (`ruffus`, `sruff`, `ruff-lsp`) never counts.
+fn declares_package(checkout: &Path, name: &str) -> bool {
+    let in_requirements = read_trimmed(checkout, "requirements.txt")
+        .is_some_and(|t| requirements_declare(&t.to_lowercase(), name));
+    in_requirements
+        || ["pyproject.toml", "Pipfile"].iter().any(|f| {
+            read_trimmed(checkout, f).is_some_and(|t| toml_declares(&t.to_lowercase(), name))
+        })
+}
+
+/// requirements.txt: the whole file is dependency context. Each non-blank line
+/// that isn't a comment or an option flag (`-r other.txt`, `-e .`, `--hash …`)
+/// begins with the package name.
+fn requirements_declare(text: &str, name: &str) -> bool {
+    text.lines().any(|line| {
         let line = line.trim();
-        if line.is_empty() || line.starts_with('#') || line.starts_with('[') {
+        if line.is_empty() || line.starts_with('#') || line.starts_with('-') {
             return false;
         }
-        // Candidates: the bare line (requirements.txt / TOML key form) plus every
-        // quoted string on it (array elements / table values).
-        std::iter::once(line)
-            .chain(quoted_substrings(line))
-            .any(|cand| leading_package_token(cand) == name)
+        leading_package_token(line) == name
     })
+}
+
+/// A TOML section's relevance to dependency detection.
+enum SectionKind {
+    /// Every `key = "…"` line names a package (the key is the package):
+    /// Poetry dependency tables, Pipfile `[packages]` / `[dev-packages]`.
+    KeyDeps,
+    /// Every key's *value* is an array of PEP 508 specs (the key is a group
+    /// name): `[project.optional-dependencies]`, `[dependency-groups]`, pdm/uv
+    /// dependency-group tables.
+    ArrayTable,
+    /// Mixed section where only specific keys open a dependency array
+    /// (`[project]` → `dependencies`, `[tool.uv]` → `*-dependencies`).
+    Mixed,
+    /// No dependency candidates (config, scripts, metadata, …).
+    None,
+}
+
+/// TOML dependency detection: a conservative line scanner (no TOML parser) that
+/// tracks the current `[section]` and an open multi-line dependency array, and
+/// only treats a line as a dependency candidate inside a known dependency
+/// context. See [`SectionKind`].
+fn toml_declares(text: &str, name: &str) -> bool {
+    let mut section = String::new();
+    // Inside an open `dependencies = [ … ]` array spanning multiple lines.
+    let mut in_dep_array = false;
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some(header) = line.strip_prefix('[') {
+            // `[section]` / `[[array.of.tables]]`, tolerant of a trailing comment.
+            let end = header.find(']').unwrap_or(header.len());
+            section = header[..end].trim_start_matches('[').trim().to_string();
+            in_dep_array = false;
+            continue;
+        }
+        // Continuation lines of an open multi-line dependency array.
+        if in_dep_array {
+            if quoted_has_package(line, name) {
+                return true;
+            }
+            if line.contains(']') {
+                in_dep_array = false;
+            }
+            continue;
+        }
+        match section_kind(&section) {
+            SectionKind::KeyDeps => {
+                if leading_package_token(line) == name {
+                    return true;
+                }
+            }
+            SectionKind::ArrayTable => {
+                let value = line.split_once('=').map_or(line, |(_, rhs)| rhs);
+                if eval_array_value(value, name, &mut in_dep_array) {
+                    return true;
+                }
+            }
+            SectionKind::Mixed => {
+                if let Some((key, rhs)) = line.split_once('=') {
+                    if is_dep_key(&section, key.trim())
+                        && eval_array_value(rhs, name, &mut in_dep_array)
+                    {
+                        return true;
+                    }
+                }
+            }
+            SectionKind::None => {}
+        }
+    }
+    false
+}
+
+/// Classify a (lowercased) TOML section header for dependency detection.
+fn section_kind(section: &str) -> SectionKind {
+    match section {
+        "project" | "tool.uv" => SectionKind::Mixed,
+        "project.optional-dependencies"
+        | "dependency-groups"
+        | "tool.uv.dependency-groups"
+        | "tool.pdm.dev-dependencies" => SectionKind::ArrayTable,
+        "packages"
+        | "dev-packages"
+        | "tool.poetry.dependencies"
+        | "tool.poetry.dev-dependencies" => SectionKind::KeyDeps,
+        // `[tool.poetry.group.<name>.dependencies]` (incl. dev groups).
+        s if s.starts_with("tool.poetry.group.") && s.ends_with(".dependencies") => {
+            SectionKind::KeyDeps
+        }
+        _ => SectionKind::None,
+    }
+}
+
+/// Whether a key opens a dependency array inside a [`SectionKind::Mixed`]
+/// section — the only keys there whose value is a list of specs.
+fn is_dep_key(section: &str, key: &str) -> bool {
+    match section {
+        "project" => key == "dependencies",
+        "tool.uv" => matches!(
+            key,
+            "dev-dependencies" | "constraint-dependencies" | "override-dependencies"
+        ),
+        _ => false,
+    }
+}
+
+/// Evaluate a dependency-array `value` (the RHS of `key = …`), which may be a
+/// single-line array or the start of a multi-line one. Returns whether a quoted
+/// spec's package token matches `name`; sets `in_dep_array` when the `[` is left
+/// open past this line so continuation lines are scanned.
+fn eval_array_value(value: &str, name: &str, in_dep_array: &mut bool) -> bool {
+    if quoted_has_package(value, name) {
+        return true;
+    }
+    if value.contains('[') && !value.contains(']') {
+        *in_dep_array = true;
+    }
+    false
+}
+
+/// Whether any `"…"`-quoted spec in `s` has `name` as its leading package token.
+fn quoted_has_package(s: &str, name: &str) -> bool {
+    quoted_substrings(s)
+        .iter()
+        .any(|q| leading_package_token(q) == name)
 }
 
 /// The leading PEP 508 package name of `spec`: the run of name characters
@@ -312,6 +453,65 @@ mod tests {
         )])
         .unwrap();
         assert_eq!(val(&cfg, "lint"), "ruff check .");
+    }
+
+    #[test]
+    fn ruff_pep621_multiline_array_yields_lint_row() {
+        let cfg = detect(&[(
+            "pyproject.toml",
+            "[project]\nname = \"x\"\ndependencies = [\n    \"requests\",\n    \"ruff>=0.4\",\n]\n",
+        )])
+        .unwrap();
+        assert_eq!(val(&cfg, "lint"), "ruff check .");
+    }
+
+    #[test]
+    fn ruff_poetry_group_dependency_yields_lint_row() {
+        let cfg = detect(&[(
+            "pyproject.toml",
+            "[tool.poetry.group.dev.dependencies]\nruff = \"^0.4\"\n",
+        )])
+        .unwrap();
+        assert_eq!(val(&cfg, "lint"), "ruff check .");
+    }
+
+    #[test]
+    fn ruff_pipfile_dev_packages_yields_lint_row() {
+        let cfg = detect(&[("Pipfile", "[dev-packages]\nruff = \"*\"\n")]).unwrap();
+        assert_eq!(val(&cfg, "lint"), "ruff check .");
+    }
+
+    #[test]
+    fn ruff_project_description_omits_lint_row() {
+        // A `[project]` metadata key that merely mentions Ruff is not a dep.
+        let cfg = detect(&[(
+            "pyproject.toml",
+            "[project]\nname = \"x\"\ndescription = \"ruff helpers for X\"\n",
+        )])
+        .unwrap();
+        assert!(cfg.rows.iter().all(|r| r.id != "lint"));
+    }
+
+    #[test]
+    fn ruff_task_table_omits_lint_row() {
+        // A task/script table invoking Ruff doesn't install it.
+        let cfg = detect(&[(
+            "pyproject.toml",
+            "[project]\nname = \"x\"\n\n[tool.poe.tasks]\nlint = \"ruff check .\"\n",
+        )])
+        .unwrap();
+        assert!(cfg.rows.iter().all(|r| r.id != "lint"));
+    }
+
+    #[test]
+    fn ruff_key_in_non_dependency_section_omits_lint_row() {
+        // A bare `ruff = "..."` outside a dependency table is not a dependency.
+        let cfg = detect(&[(
+            "pyproject.toml",
+            "[project]\nname = \"x\"\n\n[tool.something]\nruff = \"*\"\n",
+        )])
+        .unwrap();
+        assert!(cfg.rows.iter().all(|r| r.id != "lint"));
     }
 
     #[test]

--- a/src-tauri/src/run_detect/python.rs
+++ b/src-tauri/src/run_detect/python.rs
@@ -115,10 +115,16 @@ impl RunDetector for PythonDetector {
             ));
         }
 
-        // lint: only when a linter is a declared dependency (conservative —
-        // no inventing a command the project may not have). Ruff's canonical
-        // invocation is unambiguous.
-        if has_dep("ruff") {
+        // lint: only when Ruff is a declared *dependency* (conservative — no
+        // inventing a command the project may not have installed). A bare
+        // `[tool.ruff]` config table means the project is configured for Ruff
+        // but doesn't itself install the executable, so a line that is a TOML
+        // section header is not treated as a dependency — otherwise verification
+        // would run `ruff check .` and fail where Ruff isn't on PATH.
+        let ruff_dependency = deps_text
+            .lines()
+            .any(|l| l.contains("ruff") && !l.trim_start().starts_with('['));
+        if ruff_dependency {
             rows.push(DetectedRow::new(
                 "lint",
                 RowGroup::Scripts,
@@ -229,6 +235,28 @@ mod tests {
     fn ruff_dependency_yields_lint_row() {
         let cfg = detect(&[("requirements.txt", "ruff\n")]).unwrap();
         assert_eq!(val(&cfg, "lint"), "ruff check .");
+    }
+
+    #[test]
+    fn ruff_poetry_dependency_yields_lint_row() {
+        let cfg = detect(&[(
+            "pyproject.toml",
+            "[tool.poetry.dependencies]\nruff = \"^0.4\"\n",
+        )])
+        .unwrap();
+        assert_eq!(val(&cfg, "lint"), "ruff check .");
+    }
+
+    #[test]
+    fn ruff_config_section_alone_omits_lint_row() {
+        // `[tool.ruff]` configures Ruff but doesn't install it; verification
+        // must not assume the executable is present.
+        let cfg = detect(&[(
+            "pyproject.toml",
+            "[project]\nname = \"x\"\n\n[tool.ruff]\nline-length = 100\n",
+        )])
+        .unwrap();
+        assert!(cfg.rows.iter().all(|r| r.id != "lint"));
     }
 
     #[test]

--- a/src-tauri/src/run_detect/python.rs
+++ b/src-tauri/src/run_detect/python.rs
@@ -116,15 +116,12 @@ impl RunDetector for PythonDetector {
         }
 
         // lint: only when Ruff is a declared *dependency* (conservative — no
-        // inventing a command the project may not have installed). A bare
-        // `[tool.ruff]` config table means the project is configured for Ruff
-        // but doesn't itself install the executable, so a line that is a TOML
-        // section header is not treated as a dependency — otherwise verification
-        // would run `ruff check .` and fail where Ruff isn't on PATH.
-        let ruff_dependency = deps_text
-            .lines()
-            .any(|l| l.contains("ruff") && !l.trim_start().starts_with('['));
-        if ruff_dependency {
+        // inventing a command the project may not have installed). We match the
+        // declared package *name*, not a raw substring, so a comment (`# ruff`),
+        // a config table (`[tool.ruff]`), or an unrelated package (`ruffus`,
+        // `ruff-lsp`) never triggers it — otherwise verification would run
+        // `ruff check .` and fail where the executable isn't on PATH.
+        if declares_package(&deps_text, "ruff") {
             rows.push(DetectedRow::new(
                 "lint",
                 RowGroup::Scripts,
@@ -140,6 +137,64 @@ impl RunDetector for PythonDetector {
             rows,
         })
     }
+}
+
+/// Whether `deps_text` (the combined, lowercased dependency manifests) declares
+/// a dependency on package `name` (lowercase). Matches the leading PEP 508
+/// package *token* of a requirement rather than a raw substring, across the
+/// shapes Python manifests use:
+///
+/// * requirements.txt lines — `ruff`, `ruff==0.4`, `ruff[extra]`, `ruff>=0.1; …`;
+/// * quoted specs in a PEP 621 / Poetry `dependencies` array — `"ruff>=0.1"`;
+/// * the `ruff = "…"` key form of a Poetry / Pipfile dependency table.
+///
+/// Blank lines, comments (`# …`), and TOML section headers (`[tool.ruff]`) never
+/// count, and an unrelated package whose name merely contains `name`
+/// (`ruffus`, `sruff`, `ruff-lsp`) is rejected because the whole token must
+/// match.
+fn declares_package(deps_text: &str, name: &str) -> bool {
+    deps_text.lines().any(|line| {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with('[') {
+            return false;
+        }
+        // Candidates: the bare line (requirements.txt / TOML key form) plus every
+        // quoted string on it (array elements / table values).
+        std::iter::once(line)
+            .chain(quoted_substrings(line))
+            .any(|cand| leading_package_token(cand) == name)
+    })
+}
+
+/// The leading PEP 508 package name of `spec`: the run of name characters
+/// (`a-z0-9._-`) at its start, before any version / extras / marker punctuation
+/// or a `key =`-style separator.
+fn leading_package_token(spec: &str) -> &str {
+    let spec = spec.trim();
+    let end = spec
+        .find(|c: char| !(c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_')))
+        .unwrap_or(spec.len());
+    &spec[..end]
+}
+
+/// Every `"…"` / `'…'`-quoted substring in `line` (its inner text), so quoted
+/// dependency specs are inspected without their surrounding array/table syntax.
+fn quoted_substrings(line: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    for quote in ['"', '\''] {
+        let mut rest = line;
+        while let Some(open) = rest.find(quote) {
+            let after = &rest[open + 1..];
+            match after.find(quote) {
+                Some(close) => {
+                    out.push(&after[..close]);
+                    rest = &after[close + 1..];
+                }
+                None => break,
+            }
+        }
+    }
+    out
 }
 
 /// Extract `requires-python = "..."` from pyproject.toml text.
@@ -238,6 +293,28 @@ mod tests {
     }
 
     #[test]
+    fn ruff_pinned_spec_yields_lint_row() {
+        let cfg = detect(&[("requirements.txt", "ruff==0.4.9\n")]).unwrap();
+        assert_eq!(val(&cfg, "lint"), "ruff check .");
+    }
+
+    #[test]
+    fn ruff_extras_spec_yields_lint_row() {
+        let cfg = detect(&[("requirements.txt", "ruff[extra]>=0.1\n")]).unwrap();
+        assert_eq!(val(&cfg, "lint"), "ruff check .");
+    }
+
+    #[test]
+    fn ruff_pep621_array_spec_yields_lint_row() {
+        let cfg = detect(&[(
+            "pyproject.toml",
+            "[project]\ndependencies = [\"requests\", \"ruff>=0.1\"]\n",
+        )])
+        .unwrap();
+        assert_eq!(val(&cfg, "lint"), "ruff check .");
+    }
+
+    #[test]
     fn ruff_poetry_dependency_yields_lint_row() {
         let cfg = detect(&[(
             "pyproject.toml",
@@ -256,6 +333,21 @@ mod tests {
             "[project]\nname = \"x\"\n\n[tool.ruff]\nline-length = 100\n",
         )])
         .unwrap();
+        assert!(cfg.rows.iter().all(|r| r.id != "lint"));
+    }
+
+    #[test]
+    fn ruff_comment_mention_omits_lint_row() {
+        // A commented-out / aspirational mention is not a declared dependency.
+        let cfg = detect(&[("requirements.txt", "requests\n# TODO: add ruff later\n")]).unwrap();
+        assert!(cfg.rows.iter().all(|r| r.id != "lint"));
+    }
+
+    #[test]
+    fn ruff_substring_package_omits_lint_row() {
+        // `ruffus` / `sruff` merely contain the substring; the whole package
+        // token must match, so neither yields a Ruff lint row.
+        let cfg = detect(&[("requirements.txt", "ruffus==2.8\nsruff\n")]).unwrap();
         assert!(cfg.rows.iter().all(|r| r.id != "lint"));
     }
 

--- a/src-tauri/src/run_detect/ruby.rs
+++ b/src-tauri/src/run_detect/ruby.rs
@@ -81,6 +81,19 @@ impl RunDetector for RubyDetector {
             "convention",
         ));
 
+        // lint: only when RuboCop is a declared gem (conservative — no inventing
+        // a command the project may not have). Its canonical invocation is
+        // unambiguous.
+        if has_gem("rubocop") {
+            rows.push(DetectedRow::new(
+                "lint",
+                RowGroup::Scripts,
+                "Lint",
+                "bundle exec rubocop",
+                "rubocop gem",
+            ));
+        }
+
         // port (optional): Rails conventional dev port.
         if is_rails {
             rows.push(DetectedRow::new(
@@ -151,6 +164,18 @@ mod tests {
     fn default_test_is_rake() {
         let cfg = detect(&[("Gemfile", "gem 'rails'\n")]).unwrap();
         assert_eq!(val(&cfg, "test"), "bundle exec rake test");
+    }
+
+    #[test]
+    fn rubocop_gem_yields_lint_row() {
+        let cfg = detect(&[("Gemfile", "gem 'rubocop'\n")]).unwrap();
+        assert_eq!(val(&cfg, "lint"), "bundle exec rubocop");
+    }
+
+    #[test]
+    fn no_rubocop_omits_lint_row() {
+        let cfg = detect(&[("Gemfile", "gem 'rails'\n")]).unwrap();
+        assert!(cfg.rows.iter().all(|r| r.id != "lint"));
     }
 
     #[test]

--- a/src-tauri/src/verify.rs
+++ b/src-tauri/src/verify.rs
@@ -1,0 +1,719 @@
+//! Engine-owned deterministic verification — a reusable primitive.
+//!
+//! Verification runs a project's own checks (`install` → `test` → `lint`) in a
+//! checkout, each bounded and sandboxed under the Run-panel seatbelt profile,
+//! and reports a [`VerificationReport`]: one [`CheckResult`] per check with its
+//! outcome, timing, and output tail. It is the shared core behind two callers:
+//!
+//! * the workflow `tests` gate (spec §9.4), via the thin
+//!   [`crate::workflow::tests_gate`] adapter, which asks for a *tests-only*
+//!   report and maps it back to a `TestsOutcome`; and
+//! * ad-hoc agent checkouts, via the `run_verification` Tauri command, which
+//!   surfaces the full report (lint included) to the UI.
+//!
+//! Invariants worth preserving:
+//! * **Setup once per worktree.** The `install` command runs at most once per
+//!   worktree per [`Verifier`] (spec §9.4); the workflow scheduler holds one
+//!   `Verifier` across an attempt's gate evaluations, so a re-prompt does not
+//!   re-install. A fresh `Verifier` (as the Tauri command builds) always
+//!   installs once.
+//! * **Same ecosystem for install + test.** Detected commands come from the
+//!   highest-confidence config that actually defines a `test` row, and its
+//!   `install` pairs with it — so a mixed repo whose primary ecosystem has no
+//!   test script still runs a sibling's tests rather than degrading. `lint` is
+//!   resolved independently (its own highest-confidence config with a `lint`
+//!   row) so an ad-hoc lint check works even where no test command exists.
+//! * **Project overrides win.** A non-empty `run.test` / `run.install` /
+//!   `run.lint` override beats detection, same layering as the tests gate.
+//! * **Graceful degrade off-macOS.** The seatbelt profile needs `sandbox-exec`;
+//!   where it's absent every check is `Skipped` rather than run unsandboxed.
+//!
+//! The resolution and bounded-runner helpers are pure of any Tauri/DB state, so
+//! they are unit-tested directly with plain shell commands (green / red /
+//! timeout / unrunnable) and fixture directories — no sandbox required.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+use tokio::io::AsyncReadExt;
+use tokio::process::Command;
+use tokio::time::timeout;
+
+use crate::error::{Error, Result};
+
+/// Lines of output kept from a check's run for the report, the journal, and the
+/// re-prompt (spec §9.4 keeps the last 100).
+const OUTPUT_TAIL_LINES: usize = 100;
+
+/// The result of running the project's checks in a checkout. Serde-serialized
+/// (snake_case, matching the frontend's other IPC payloads) for the
+/// `run_verification` command.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct VerificationReport {
+    pub checks: Vec<CheckResult>,
+}
+
+impl VerificationReport {
+    /// Whether verification is clean: no check failed, timed out, or was blocked
+    /// by a failed setup. `Skipped` (no command resolved) counts as clean —
+    /// there was nothing to run, not a failure.
+    pub fn passed(&self) -> bool {
+        self.checks.iter().all(|c| {
+            matches!(
+                c.outcome,
+                CheckOutcome::Passed | CheckOutcome::Skipped
+            )
+        })
+    }
+
+    /// The check with the given `name` (`"install"` | `"test"` | `"lint"`).
+    pub fn check(&self, name: &str) -> Option<&CheckResult> {
+        self.checks.iter().find(|c| c.name == name)
+    }
+}
+
+/// One check's outcome inside a [`VerificationReport`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CheckResult {
+    /// Stable check id: `"install"` | `"test"` | `"lint"`.
+    pub name: String,
+    /// The command that ran (or would have), e.g. `"npm test"`. Empty when the
+    /// check was skipped for lack of a resolvable command.
+    pub command: String,
+    pub outcome: CheckOutcome,
+    /// Wall-clock duration of the command, 0 when it didn't run.
+    pub duration_ms: u64,
+    /// Last [`OUTPUT_TAIL_LINES`] lines of combined stdout+stderr (empty on
+    /// success or when nothing ran).
+    pub tail: Vec<String>,
+}
+
+/// The terminal shape of a single check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckOutcome {
+    /// The command exited 0.
+    Passed,
+    /// The command exited non-zero (or could not be launched).
+    Failed,
+    /// The command exceeded the timeout and was terminated.
+    TimedOut,
+    /// A prerequisite setup/install command failed, so this check never ran.
+    SetupFailed,
+    /// No command could be resolved for this check (nothing to run).
+    Skipped,
+}
+
+/// The reusable verification primitive. Holds the resolved project overrides,
+/// the seatbelt profile inputs, and the per-worktree setup-done cache. Cheap to
+/// construct; one instance may verify several worktrees.
+pub struct Verifier {
+    /// Project override for the test command (`run.test`); wins over detection.
+    test_override: Option<String>,
+    /// Project override for the setup command (`run.install`); wins over detection.
+    setup_override: Option<String>,
+    /// Project override for the lint command (`run.lint`); wins over detection.
+    lint_override: Option<String>,
+    home: PathBuf,
+    timeout: Duration,
+    /// Worktrees whose setup command has already succeeded — setup runs once per
+    /// worktree (spec §9.4).
+    setup_done: Mutex<HashSet<PathBuf>>,
+}
+
+impl Verifier {
+    pub fn new(
+        test_override: Option<String>,
+        setup_override: Option<String>,
+        lint_override: Option<String>,
+        timeout_secs: u64,
+    ) -> Result<Self> {
+        let home =
+            dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
+        Ok(Self {
+            test_override,
+            setup_override,
+            lint_override,
+            home,
+            timeout: Duration::from_secs(timeout_secs),
+            setup_done: Mutex::new(HashSet::new()),
+        })
+    }
+
+    /// Run the full suite — `install` (once) → `test` → `lint` — and report every
+    /// check. Used by the ad-hoc `run_verification` command.
+    pub async fn verify(&self, worktree: &Path) -> VerificationReport {
+        self.run(worktree, /* include_lint = */ true).await
+    }
+
+    /// Run only `install` (once) → `test`, for the workflow tests gate, which has
+    /// no use for a lint result and must stay byte-identical to its prior shape.
+    pub async fn verify_tests_only(&self, worktree: &Path) -> VerificationReport {
+        self.run(worktree, /* include_lint = */ false).await
+    }
+
+    async fn run(&self, worktree: &Path, include_lint: bool) -> VerificationReport {
+        // The checks run under the Run-panel seatbelt profile, which needs macOS
+        // `sandbox-exec`. Where it isn't present we can't safely run a
+        // repo-derived command, so skip every check rather than run unsandboxed
+        // (the tests gate then degrades to the verdict gate — spec §9.4).
+        if !sandbox_available() {
+            tracing::warn!(
+                "verify: `{}` unavailable on this host; skipping checks",
+                crate::sandbox::SANDBOX_EXEC
+            );
+            let mut checks = vec![skipped("test", "")];
+            if include_lint {
+                checks.push(skipped("lint", ""));
+            }
+            return VerificationReport { checks };
+        }
+
+        let resolved = resolve(
+            worktree,
+            &self.test_override,
+            &self.setup_override,
+            &self.lint_override,
+        );
+
+        // Nothing to verify: no test and (for the full suite) no lint. Report the
+        // requested checks as skipped so the shape is stable; the tests-gate
+        // mapping turns a skipped test into `NoCommand`.
+        let will_run = resolved.test.is_some() || (include_lint && resolved.lint.is_some());
+        if !will_run {
+            let mut checks = vec![skipped("test", "")];
+            if include_lint {
+                checks.push(skipped("lint", ""));
+            }
+            return VerificationReport { checks };
+        }
+
+        let mut checks = Vec::new();
+
+        // Setup once per worktree, a distinct failure from a failing check.
+        let mut setup_failed = false;
+        if let Some(setup) = &resolved.install {
+            let already = self.setup_done.lock().unwrap().contains(worktree);
+            if already {
+                checks.push(passed_cached("install", setup));
+            } else {
+                let (outcome, duration_ms, tail) =
+                    self.run_check(worktree, "install", setup).await;
+                if matches!(outcome, CheckOutcome::Passed) {
+                    self.setup_done
+                        .lock()
+                        .unwrap()
+                        .insert(worktree.to_path_buf());
+                } else {
+                    setup_failed = true;
+                }
+                checks.push(CheckResult {
+                    name: "install".to_string(),
+                    command: setup.clone(),
+                    outcome,
+                    duration_ms,
+                    tail,
+                });
+            }
+        }
+
+        // test, then (optionally) lint — each skipped when unresolved, or marked
+        // `SetupFailed` when the install above failed so they never ran.
+        let mut order: Vec<(&str, &Option<String>)> = vec![("test", &resolved.test)];
+        if include_lint {
+            order.push(("lint", &resolved.lint));
+        }
+        for (name, cmd) in order {
+            match cmd {
+                None => checks.push(skipped(name, "")),
+                Some(cmd) if setup_failed => checks.push(CheckResult {
+                    name: name.to_string(),
+                    command: cmd.clone(),
+                    outcome: CheckOutcome::SetupFailed,
+                    duration_ms: 0,
+                    tail: Vec::new(),
+                }),
+                Some(cmd) => {
+                    let (outcome, duration_ms, tail) = self.run_check(worktree, name, cmd).await;
+                    checks.push(CheckResult {
+                        name: name.to_string(),
+                        command: cmd.clone(),
+                        outcome,
+                        duration_ms,
+                        tail,
+                    });
+                }
+            }
+        }
+
+        VerificationReport { checks }
+    }
+
+    /// Run one check's command, mapping the bounded result to a [`CheckOutcome`]
+    /// plus its duration and output tail. `what` labels the synthetic timeout
+    /// note (`"setup command"` for install, `"test command"`, `"lint command"`).
+    async fn run_check(
+        &self,
+        worktree: &Path,
+        name: &str,
+        cmd: &str,
+    ) -> (CheckOutcome, u64, Vec<String>) {
+        let started = Instant::now();
+        let bounded = self.run_sandboxed(worktree, cmd).await;
+        let duration_ms = started.elapsed().as_millis() as u64;
+        let outcome_tail = match bounded {
+            Bounded::Exited { success: true, .. } => (CheckOutcome::Passed, Vec::new()),
+            Bounded::Exited {
+                success: false,
+                tail,
+            } => (CheckOutcome::Failed, tail),
+            Bounded::TimedOut => (CheckOutcome::TimedOut, vec![self.timeout_note(name)]),
+            Bounded::Unrunnable(e) => (CheckOutcome::Failed, vec![e]),
+        };
+        (outcome_tail.0, duration_ms, outcome_tail.1)
+    }
+
+    /// The synthetic tail line for a timed-out check. Preserves the exact wording
+    /// the tests gate has always journaled: `install` → "setup command …".
+    fn timeout_note(&self, name: &str) -> String {
+        let what = match name {
+            "install" => "setup command",
+            "lint" => "lint command",
+            _ => "test command",
+        };
+        format!(
+            "{what} exceeded the {}s limit and was terminated",
+            self.timeout.as_secs()
+        )
+    }
+
+    /// Build the `sandbox-exec -f <profile> <shell> -lic <cmd>` invocation under
+    /// the Run-panel profile (writable root = the checkout). The profile tempfile
+    /// is returned so it outlives the child's `exec`; the caller keeps it alive
+    /// until the process has finished.
+    fn sandbox_command(
+        &self,
+        worktree: &Path,
+        cmd: &str,
+    ) -> Result<(PathBuf, Vec<String>, tempfile::NamedTempFile)> {
+        // Grant the target's git *common dir* (as the Run panel does) so commands
+        // that touch git — e.g. `git worktree add` — work in a linked worktree
+        // checkout, whose common dir lives outside `worktree`. For a plain
+        // `--shared` clone this is `<worktree>/.git`, already writable, so the
+        // grant is harmless.
+        let extra_writable: Vec<PathBuf> =
+            crate::supervisor::run::run_target_git_common_dir(worktree)
+                .into_iter()
+                .collect();
+        let profile_text =
+            crate::sandbox::build_run_profile(worktree, &self.home, &extra_writable)?;
+        let profile_file = crate::sandbox::profile_tempfile(&profile_text)?;
+        let profile_path = profile_file
+            .path()
+            .to_str()
+            .ok_or_else(|| Error::Other("profile path not utf-8".into()))?
+            .to_string();
+        let shell = crate::run_session::user_shell();
+        let shell_str = shell
+            .to_str()
+            .ok_or_else(|| Error::Other("shell path not utf-8".into()))?
+            .to_string();
+        let mut args = vec!["-f".to_string(), profile_path, shell_str];
+        args.extend(crate::run_session::shell_args(cmd));
+        Ok((
+            PathBuf::from(crate::sandbox::SANDBOX_EXEC),
+            args,
+            profile_file,
+        ))
+    }
+
+    async fn run_sandboxed(&self, worktree: &Path, cmd: &str) -> Bounded {
+        let (program, args, _profile) = match self.sandbox_command(worktree, cmd) {
+            Ok(t) => t,
+            Err(e) => return Bounded::Unrunnable(format!("could not build sandbox profile: {e}")),
+        };
+        // `_profile` must outlive the child's `exec`; it drops at the end of this
+        // fn, after `run_bounded` has awaited the process to completion.
+        run_bounded(&program, &args, worktree, self.timeout).await
+    }
+}
+
+/// A `Skipped` check with no command resolved.
+fn skipped(name: &str, command: &str) -> CheckResult {
+    CheckResult {
+        name: name.to_string(),
+        command: command.to_string(),
+        outcome: CheckOutcome::Skipped,
+        duration_ms: 0,
+        tail: Vec::new(),
+    }
+}
+
+/// A `Passed` install check that was already satisfied earlier this worktree
+/// (setup-once): no work done this call, so 0 duration and no tail.
+fn passed_cached(name: &str, command: &str) -> CheckResult {
+    CheckResult {
+        name: name.to_string(),
+        command: command.to_string(),
+        outcome: CheckOutcome::Passed,
+        duration_ms: 0,
+        tail: Vec::new(),
+    }
+}
+
+/// The install / test / lint commands resolved for a worktree. Any may be
+/// `None` (no override, nothing detected).
+struct Resolved {
+    install: Option<String>,
+    test: Option<String>,
+    lint: Option<String>,
+}
+
+/// Resolve the install, test, and lint commands for `worktree`: a non-empty
+/// override wins, else the detected command (spec §9.4).
+///
+/// Detected `test` + `install` are taken from a single ecosystem: the
+/// highest-confidence config that actually defines a `test` row (`detect_all` is
+/// confidence-sorted). This keeps `test` and `install` from the same ecosystem
+/// and lets a lower-ranked detector supply the test command when the top one has
+/// none. `lint` is resolved independently — its own highest-confidence config
+/// with a `lint` row — so an ad-hoc lint check works even where no test exists.
+fn resolve(
+    worktree: &Path,
+    test_override: &Option<String>,
+    setup_override: &Option<String>,
+    lint_override: &Option<String>,
+) -> Resolved {
+    let configs = crate::run_detect::detect_all(worktree);
+    let row = |c: &crate::run_detect::DetectedConfig, id: &str| -> Option<String> {
+        c.rows.iter().find(|r| r.id == id).map(|r| r.value.clone())
+    };
+    // The ecosystem we take detected test/install from. Its `install` pairs with
+    // its `test`; for an override test with no detected test config, setup falls
+    // back to the highest-confidence config.
+    let test_config = configs.iter().find(|c| row(c, "test").is_some());
+    let setup_config = test_config.or_else(|| configs.first());
+
+    let test = nonempty(test_override.clone()).or_else(|| {
+        test_config
+            .and_then(|c| row(c, "test"))
+            .and_then(some_nonempty)
+    });
+    let install = nonempty(setup_override.clone()).or_else(|| {
+        setup_config
+            .and_then(|c| row(c, "install"))
+            .and_then(some_nonempty)
+    });
+    let lint = nonempty(lint_override.clone()).or_else(|| {
+        configs
+            .iter()
+            .find_map(|c| row(c, "lint"))
+            .and_then(some_nonempty)
+    });
+    Resolved {
+        install,
+        test,
+        lint,
+    }
+}
+
+/// Whether the seatbelt sandbox binary the checks run under is present (macOS).
+fn sandbox_available() -> bool {
+    Path::new(crate::sandbox::SANDBOX_EXEC).exists()
+}
+
+/// `Some(trimmed)` when the value is present and non-blank, else `None`.
+fn nonempty(v: Option<String>) -> Option<String> {
+    v.and_then(some_nonempty)
+}
+
+fn some_nonempty(s: String) -> Option<String> {
+    let t = s.trim();
+    (!t.is_empty()).then(|| t.to_string())
+}
+
+/// The bounded outcome of running one command.
+enum Bounded {
+    /// The process exited; `success` is exit status 0. `tail` is its output tail.
+    Exited { success: bool, tail: Vec<String> },
+    /// The process did not finish within the deadline (killed).
+    TimedOut,
+    /// The command could not be launched at all.
+    Unrunnable(String),
+}
+
+/// Run `program args` in `cwd`, capturing combined stdout+stderr, bounded by
+/// `deadline`. On timeout the child is killed (`kill_on_drop`) and `TimedOut` is
+/// returned. Pure of any workflow/Tauri state so it is directly unit-testable.
+async fn run_bounded(program: &Path, args: &[String], cwd: &Path, deadline: Duration) -> Bounded {
+    let mut command = Command::new(program);
+    command
+        .args(args)
+        .current_dir(cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+
+    let mut child = match command.spawn() {
+        Ok(c) => c,
+        Err(e) => return Bounded::Unrunnable(format!("could not launch command: {e}")),
+    };
+    let mut stdout = child.stdout.take().expect("piped stdout");
+    let mut stderr = child.stderr.take().expect("piped stderr");
+
+    // Read both pipes concurrently (so a full pipe buffer can't deadlock the
+    // child) and reap it. `read_to_end` completes when the process closes its
+    // fds, i.e. at exit.
+    let collect = async {
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let _ = tokio::join!(stdout.read_to_end(&mut out), stderr.read_to_end(&mut err));
+        let status = child.wait().await;
+        (status, out, err)
+    };
+
+    match timeout(deadline, collect).await {
+        Ok((status, mut out, err)) => {
+            out.extend_from_slice(&err);
+            let tail = tail_lines(&String::from_utf8_lossy(&out), OUTPUT_TAIL_LINES);
+            match status {
+                Ok(s) => Bounded::Exited {
+                    success: s.success(),
+                    tail,
+                },
+                Err(e) => Bounded::Unrunnable(format!("command errored: {e}")),
+            }
+        }
+        // `collect` drops here; `child` drops at fn end → killed via kill_on_drop.
+        Err(_elapsed) => Bounded::TimedOut,
+    }
+}
+
+/// The last `n` lines of `text`, as owned strings.
+fn tail_lines(text: &str, n: usize) -> Vec<String> {
+    let lines: Vec<&str> = text.lines().collect();
+    let start = lines.len().saturating_sub(n);
+    lines[start..].iter().map(|s| s.to_string()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(dir: &Path, name: &str, contents: &str) {
+        std::fs::write(dir.join(name), contents).unwrap();
+    }
+
+    // ── resolution ────────────────────────────────────────────────────────
+
+    #[test]
+    fn resolve_prefers_override_over_detection() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "package.json",
+            r#"{"scripts":{"test":"vitest"}}"#,
+        );
+        let r = resolve(
+            dir.path(),
+            &Some("cargo test --all".into()),
+            &Some("cargo fetch".into()),
+            &None,
+        );
+        assert_eq!(r.test.as_deref(), Some("cargo test --all"));
+        assert_eq!(r.install.as_deref(), Some("cargo fetch"));
+    }
+
+    #[test]
+    fn resolve_detects_test_and_install_commands() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "package.json",
+            r#"{"scripts":{"test":"vitest"}}"#,
+        );
+        let r = resolve(dir.path(), &None, &None, &None);
+        assert_eq!(r.test.as_deref(), Some("npm test"));
+        assert_eq!(r.install.as_deref(), Some("npm install"));
+    }
+
+    #[test]
+    fn resolve_detects_lint_command() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "package.json",
+            r#"{"scripts":{"test":"vitest","lint":"eslint ."}}"#,
+        );
+        let r = resolve(dir.path(), &None, &None, &None);
+        assert_eq!(r.lint.as_deref(), Some("npm run lint"));
+    }
+
+    #[test]
+    fn resolve_lint_override_wins() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "package.json", r#"{"scripts":{"lint":"eslint"}}"#);
+        let r = resolve(dir.path(), &None, &None, &Some("biome check".into()));
+        assert_eq!(r.lint.as_deref(), Some("biome check"));
+    }
+
+    #[test]
+    fn resolve_no_lint_row_is_none() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "package.json", r#"{"scripts":{"test":"vitest"}}"#);
+        let r = resolve(dir.path(), &None, &None, &None);
+        assert!(r.lint.is_none());
+    }
+
+    #[test]
+    fn resolve_uses_lower_ranked_config_when_top_has_no_test() {
+        // Node (lockfile → 90, ranks first) has no `test` script, but Go (also
+        // 90, ranked after node) always defines one. Verification must run Go's
+        // tests rather than skip, paired with Go's install.
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "package.json", "{}");
+        write(dir.path(), "pnpm-lock.yaml", "");
+        write(dir.path(), "go.mod", "module example.com/x\n\ngo 1.22\n");
+        write(dir.path(), "go.sum", "");
+        let r = resolve(dir.path(), &None, &None, &None);
+        assert_eq!(r.test.as_deref(), Some("go test ./..."));
+        assert_eq!(r.install.as_deref(), Some("go mod download"));
+    }
+
+    #[test]
+    fn resolve_none_when_no_command_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let r = resolve(dir.path(), &None, &None, &None);
+        assert!(r.test.is_none());
+        assert!(r.install.is_none());
+        assert!(r.lint.is_none());
+    }
+
+    #[test]
+    fn resolve_blank_override_is_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        let r = resolve(dir.path(), &Some("   ".into()), &None, &None);
+        assert!(r.test.is_none());
+    }
+
+    // ── report helpers ──────────────────────────────────────────────────────
+
+    #[test]
+    fn passed_ignores_skipped_but_fails_on_failure() {
+        let clean = VerificationReport {
+            checks: vec![skipped("test", ""), skipped("lint", "")],
+        };
+        assert!(clean.passed());
+
+        let failed = VerificationReport {
+            checks: vec![CheckResult {
+                name: "test".into(),
+                command: "x".into(),
+                outcome: CheckOutcome::Failed,
+                duration_ms: 1,
+                tail: vec!["boom".into()],
+            }],
+        };
+        assert!(!failed.passed());
+    }
+
+    #[test]
+    fn check_outcome_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&CheckOutcome::TimedOut).unwrap(),
+            "\"timed_out\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CheckOutcome::SetupFailed).unwrap(),
+            "\"setup_failed\""
+        );
+    }
+
+    // ── bounded runner ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn run_bounded_reports_success() {
+        let cwd = tempfile::tempdir().unwrap();
+        let b = run_bounded(
+            Path::new("/bin/sh"),
+            &["-c".into(), "echo ok; exit 0".into()],
+            cwd.path(),
+            Duration::from_secs(10),
+        )
+        .await;
+        match b {
+            Bounded::Exited { success, tail } => {
+                assert!(success);
+                assert!(tail.iter().any(|l| l.contains("ok")), "tail: {tail:?}");
+            }
+            _ => panic!("expected Exited"),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_bounded_captures_failure_tail() {
+        let cwd = tempfile::tempdir().unwrap();
+        let b = run_bounded(
+            Path::new("/bin/sh"),
+            &["-c".into(), "echo boom 1>&2; exit 3".into()],
+            cwd.path(),
+            Duration::from_secs(10),
+        )
+        .await;
+        match b {
+            Bounded::Exited { success, tail } => {
+                assert!(!success);
+                assert!(tail.iter().any(|l| l.contains("boom")), "tail: {tail:?}");
+            }
+            _ => panic!("expected Exited"),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_bounded_times_out() {
+        let cwd = tempfile::tempdir().unwrap();
+        let b = run_bounded(
+            Path::new("/bin/sh"),
+            &["-c".into(), "sleep 30".into()],
+            cwd.path(),
+            Duration::from_millis(150),
+        )
+        .await;
+        assert!(matches!(b, Bounded::TimedOut));
+    }
+
+    #[tokio::test]
+    async fn run_bounded_reports_unrunnable() {
+        let cwd = tempfile::tempdir().unwrap();
+        let b = run_bounded(
+            Path::new("/nonexistent/definitely/not/here"),
+            &[],
+            cwd.path(),
+            Duration::from_secs(5),
+        )
+        .await;
+        assert!(matches!(b, Bounded::Unrunnable(_)));
+    }
+
+    #[test]
+    fn tail_lines_keeps_last_n() {
+        let text = (1..=250)
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let tail = tail_lines(&text, 100);
+        assert_eq!(tail.len(), 100);
+        assert_eq!(tail.first().map(String::as_str), Some("151"));
+        assert_eq!(tail.last().map(String::as_str), Some("250"));
+    }
+
+    #[test]
+    fn tail_lines_shorter_than_n_is_whole() {
+        assert_eq!(tail_lines("a\nb", 100), vec!["a".to_string(), "b".to_string()]);
+    }
+}

--- a/src-tauri/src/verify.rs
+++ b/src-tauri/src/verify.rs
@@ -62,12 +62,9 @@ impl VerificationReport {
     /// by a failed setup. `Skipped` (no command resolved) counts as clean —
     /// there was nothing to run, not a failure.
     pub fn passed(&self) -> bool {
-        self.checks.iter().all(|c| {
-            matches!(
-                c.outcome,
-                CheckOutcome::Passed | CheckOutcome::Skipped
-            )
-        })
+        self.checks
+            .iter()
+            .all(|c| matches!(c.outcome, CheckOutcome::Passed | CheckOutcome::Skipped))
     }
 
     /// The check with the given `name` (`"install"` | `"test"` | `"lint"`).
@@ -201,8 +198,7 @@ impl Verifier {
             if already {
                 checks.push(passed_cached("install", setup));
             } else {
-                let (outcome, duration_ms, tail) =
-                    self.run_check(worktree, "install", setup).await;
+                let (outcome, duration_ms, tail) = self.run_check(worktree, "install", setup).await;
                 if matches!(outcome, CheckOutcome::Passed) {
                     self.setup_done
                         .lock()
@@ -557,7 +553,11 @@ mod tests {
     #[test]
     fn resolve_lint_override_wins() {
         let dir = tempfile::tempdir().unwrap();
-        write(dir.path(), "package.json", r#"{"scripts":{"lint":"eslint"}}"#);
+        write(
+            dir.path(),
+            "package.json",
+            r#"{"scripts":{"lint":"eslint"}}"#,
+        );
         let r = resolve(dir.path(), &None, &None, &Some("biome check".into()));
         assert_eq!(r.lint.as_deref(), Some("biome check"));
     }
@@ -565,7 +565,11 @@ mod tests {
     #[test]
     fn resolve_no_lint_row_is_none() {
         let dir = tempfile::tempdir().unwrap();
-        write(dir.path(), "package.json", r#"{"scripts":{"test":"vitest"}}"#);
+        write(
+            dir.path(),
+            "package.json",
+            r#"{"scripts":{"test":"vitest"}}"#,
+        );
         let r = resolve(dir.path(), &None, &None, &None);
         assert!(r.lint.is_none());
     }
@@ -714,6 +718,9 @@ mod tests {
 
     #[test]
     fn tail_lines_shorter_than_n_is_whole() {
-        assert_eq!(tail_lines("a\nb", 100), vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(
+            tail_lines("a\nb", 100),
+            vec!["a".to_string(), "b".to_string()]
+        );
     }
 }

--- a/src-tauri/src/workflow/tests_gate.rs
+++ b/src-tauri/src/workflow/tests_gate.rs
@@ -95,8 +95,12 @@ fn map_tests_outcome(report: &VerificationReport) -> TestsOutcome {
     match report.check("test") {
         Some(t) => match t.outcome {
             CheckOutcome::Passed => TestsOutcome::Passed,
-            CheckOutcome::Failed => TestsOutcome::Failed { tail: join(&t.tail) },
-            CheckOutcome::TimedOut => TestsOutcome::TimedOut { tail: join(&t.tail) },
+            CheckOutcome::Failed => TestsOutcome::Failed {
+                tail: join(&t.tail),
+            },
+            CheckOutcome::TimedOut => TestsOutcome::TimedOut {
+                tail: join(&t.tail),
+            },
             // Install was clean above, so a `SetupFailed` test here can only mean
             // an unresolved prerequisite; treat conservatively as no command.
             CheckOutcome::SetupFailed | CheckOutcome::Skipped => TestsOutcome::NoCommand,
@@ -166,7 +170,11 @@ mod tests {
     fn install_timeout_maps_to_setup_failed() {
         let report = VerificationReport {
             checks: vec![
-                check("install", CheckOutcome::TimedOut, &["setup command exceeded"]),
+                check(
+                    "install",
+                    CheckOutcome::TimedOut,
+                    &["setup command exceeded"],
+                ),
                 check("test", CheckOutcome::SetupFailed, &[]),
             ],
         };

--- a/src-tauri/src/workflow/tests_gate.rs
+++ b/src-tauri/src/workflow/tests_gate.rs
@@ -1,33 +1,27 @@
-//! Tests-gate execution (spec §9.4). The `tests` gate resolves the project's
-//! test command (project override > `run_detect`), runs it — after a one-time
-//! setup/install command — bounded and sandboxed inside the step worktree under
-//! the Run-panel seatbelt profile, and reports a [`gates::TestsOutcome`] that the
-//! pure `gates::evaluate` turns into done/blocked. No test command resolvable →
-//! [`TestsOutcome::NoCommand`], and the gate degrades to `verdict` (§9.4).
+//! Tests-gate execution (spec §9.4) — a thin adapter over [`crate::verify`].
 //!
-//! Execution lives behind the [`TestRunner`] trait so `attempt.rs` stays
-//! unit-testable with a scripted mock — the same seam `AgentDriver` provides.
-//! The pure resolution and output-tail helpers are tested directly, and the
-//! bounded runner is exercised with plain shell commands (green / red / timeout
-//! / unrunnable) so the fast tests need no sandbox.
+//! The `tests` gate runs the project's install + test commands, bounded and
+//! sandboxed in the step worktree, and reports a [`gates::TestsOutcome`] the
+//! pure `gates::evaluate` turns into done/blocked. The actual running (command
+//! resolution, seatbelt sandboxing, output-tail bounding, setup-once caching) is
+//! the shared [`crate::verify::Verifier`] primitive; this module only:
+//!
+//! * exposes the [`TestRunner`] trait so `attempt.rs` stays unit-testable with a
+//!   scripted mock (the same seam `AgentDriver` provides), and
+//! * maps a *tests-only* [`crate::verify::VerificationReport`] back to the
+//!   `TestsOutcome` the gate has always spoken.
+//!
+//! No test command resolvable → [`TestsOutcome::NoCommand`], and the gate
+//! degrades to `verdict` (§9.4). Off-macOS (no `sandbox-exec`) degrades the same
+//! way rather than running a repo-derived command unsandboxed.
 
-use std::collections::HashSet;
-use std::path::{Path, PathBuf};
-use std::process::Stdio;
-use std::sync::Mutex;
+use std::path::Path;
 
-use tokio::io::AsyncReadExt;
-use tokio::process::Command;
-use tokio::time::{timeout, Duration};
-
-use crate::error::{Error, Result};
+use crate::error::Result;
+use crate::verify::{CheckOutcome, VerificationReport, Verifier};
 
 use super::driver::BoxFuture;
 use super::gates::TestsOutcome;
-
-/// Lines of output kept from a failed / timed-out run for the journal and the
-/// re-prompt (spec §9.4 keeps the last 100).
-const OUTPUT_TAIL_LINES: usize = 100;
 
 /// Resolves and runs the `tests` gate. Behind a trait so the attempt lifecycle
 /// is unit-testable with a scripted mock (`AgentDriver`'s pattern).
@@ -36,20 +30,11 @@ pub trait TestRunner: Send + Sync {
     fn run_tests<'a>(&'a self, worktree: &'a Path) -> BoxFuture<'a, TestsOutcome>;
 }
 
-/// The production runner: resolves the command via `run_detect` (project
-/// overrides winning), runs the setup command once per workspace, then runs the
-/// test command — each `sandbox-exec`-wrapped under the Run-panel profile.
+/// The production runner: a [`Verifier`] configured with the project's
+/// `run.test` / `run.install` overrides, whose tests-only report is mapped back
+/// to a [`TestsOutcome`].
 pub struct SandboxTestRunner {
-    /// Project override for the test command (`run.test`); wins over detection.
-    test_override: Option<String>,
-    /// Project override for the setup command (`run.install`); wins over detection.
-    setup_override: Option<String>,
-    home: PathBuf,
-    timeout: Duration,
-    /// Worktrees whose setup command has already succeeded — setup runs once per
-    /// workspace (spec §9.4). A fresh clone has no deps, but by gate time the
-    /// step agent has usually installed them, so this is normally a fast no-op.
-    setup_done: Mutex<HashSet<PathBuf>>,
+    verifier: Verifier,
 }
 
 impl SandboxTestRunner {
@@ -58,65 +43,9 @@ impl SandboxTestRunner {
         setup_override: Option<String>,
         timeout_secs: u64,
     ) -> Result<Self> {
-        let home =
-            dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
-        Ok(Self {
-            test_override,
-            setup_override,
-            home,
-            timeout: Duration::from_secs(timeout_secs),
-            setup_done: Mutex::new(HashSet::new()),
-        })
-    }
-
-    /// Build the `sandbox-exec -f <profile> <shell> -lic <cmd>` invocation under
-    /// the Run-panel profile (writable root = the step worktree). The profile
-    /// tempfile is returned so it outlives the child's `exec`; the caller keeps
-    /// it alive until the process has finished.
-    fn sandbox_command(
-        &self,
-        worktree: &Path,
-        cmd: &str,
-    ) -> Result<(PathBuf, Vec<String>, tempfile::NamedTempFile)> {
-        // Grant the target's git *common dir* (as the Run panel does) so test
-        // commands that touch git — e.g. `git worktree add` — work in a linked
-        // worktree checkout, whose common dir lives outside `worktree`. For a
-        // plain `--shared` clone this is `<worktree>/.git`, already writable, so
-        // the grant is harmless.
-        let extra_writable: Vec<PathBuf> =
-            crate::supervisor::run::run_target_git_common_dir(worktree)
-                .into_iter()
-                .collect();
-        let profile_text =
-            crate::sandbox::build_run_profile(worktree, &self.home, &extra_writable)?;
-        let profile_file = crate::sandbox::profile_tempfile(&profile_text)?;
-        let profile_path = profile_file
-            .path()
-            .to_str()
-            .ok_or_else(|| Error::Other("profile path not utf-8".into()))?
-            .to_string();
-        let shell = crate::run_session::user_shell();
-        let shell_str = shell
-            .to_str()
-            .ok_or_else(|| Error::Other("shell path not utf-8".into()))?
-            .to_string();
-        let mut args = vec!["-f".to_string(), profile_path, shell_str];
-        args.extend(crate::run_session::shell_args(cmd));
-        Ok((
-            PathBuf::from(crate::sandbox::SANDBOX_EXEC),
-            args,
-            profile_file,
-        ))
-    }
-
-    async fn run_sandboxed(&self, worktree: &Path, cmd: &str) -> Bounded {
-        let (program, args, _profile) = match self.sandbox_command(worktree, cmd) {
-            Ok(t) => t,
-            Err(e) => return Bounded::Unrunnable(format!("could not build sandbox profile: {e}")),
-        };
-        // `_profile` must outlive the child's `exec`; it drops at the end of this
-        // fn, after `run_bounded` has awaited the process to completion.
-        run_bounded(&program, &args, worktree, self.timeout).await
+        // The tests gate never lints; `lint_override` is `None`.
+        let verifier = Verifier::new(test_override, setup_override, None, timeout_secs)?;
+        Ok(Self { verifier })
     }
 }
 
@@ -134,102 +63,10 @@ impl TestRunner for SandboxTestRunner {
                 );
                 return TestsOutcome::NoCommand;
             }
-            let Some(resolved) = resolve(worktree, &self.test_override, &self.setup_override)
-            else {
-                return TestsOutcome::NoCommand;
-            };
-
-            // Setup once per workspace, distinct failure from failing tests.
-            if let Some(setup) = &resolved.setup {
-                let already = self.setup_done.lock().unwrap().contains(worktree);
-                if !already {
-                    match self.run_sandboxed(worktree, setup).await {
-                        Bounded::Exited { success: true, .. } => {
-                            self.setup_done
-                                .lock()
-                                .unwrap()
-                                .insert(worktree.to_path_buf());
-                        }
-                        Bounded::Exited {
-                            success: false,
-                            tail,
-                        } => return TestsOutcome::SetupFailed { tail },
-                        Bounded::TimedOut => {
-                            return TestsOutcome::SetupFailed {
-                                tail: self.timeout_note("setup command"),
-                            }
-                        }
-                        Bounded::Unrunnable(e) => return TestsOutcome::SetupFailed { tail: e },
-                    }
-                }
-            }
-
-            match self.run_sandboxed(worktree, &resolved.test).await {
-                Bounded::Exited { success: true, .. } => TestsOutcome::Passed,
-                Bounded::Exited {
-                    success: false,
-                    tail,
-                } => TestsOutcome::Failed { tail },
-                Bounded::TimedOut => TestsOutcome::TimedOut {
-                    tail: self.timeout_note("test command"),
-                },
-                Bounded::Unrunnable(e) => TestsOutcome::Failed { tail: e },
-            }
+            let report = self.verifier.verify_tests_only(worktree).await;
+            map_tests_outcome(&report)
         })
     }
-}
-
-impl SandboxTestRunner {
-    fn timeout_note(&self, what: &str) -> String {
-        format!(
-            "{what} exceeded the {}s limit and was terminated",
-            self.timeout.as_secs()
-        )
-    }
-}
-
-/// The test + setup commands resolved for a worktree.
-struct Resolved {
-    test: String,
-    setup: Option<String>,
-}
-
-/// Resolve the test and setup commands for `worktree`: a non-empty override
-/// wins, else the detected commands (spec §9.4). `None` when no test command can
-/// be found (→ degrade to verdict).
-///
-/// Detected commands are taken from a single ecosystem: the highest-confidence
-/// config that actually defines a `test` row (`detect_all` is confidence-sorted).
-/// This keeps `test` and `install` from the same ecosystem and lets a
-/// lower-ranked detector supply the test command when the top one has none — a
-/// mixed repo whose primary ecosystem has no test script no longer degrades to
-/// the verdict gate while a sibling ecosystem's tests go unrun.
-fn resolve(
-    worktree: &Path,
-    test_override: &Option<String>,
-    setup_override: &Option<String>,
-) -> Option<Resolved> {
-    let configs = crate::run_detect::detect_all(worktree);
-    let row = |c: &crate::run_detect::DetectedConfig, id: &str| -> Option<String> {
-        c.rows.iter().find(|r| r.id == id).map(|r| r.value.clone())
-    };
-    // The ecosystem we take detected commands from. Its `install` pairs with its
-    // `test`; for an override test with no detected test config, setup falls back
-    // to the highest-confidence config.
-    let test_config = configs.iter().find(|c| row(c, "test").is_some());
-    let setup_config = test_config.or_else(|| configs.first());
-
-    let test = nonempty(test_override.clone()).or_else(|| {
-        test_config
-            .and_then(|c| row(c, "test"))
-            .and_then(some_nonempty)
-    })?;
-    let setup = nonempty(setup_override.clone()).or_else(|| {
-        setup_config
-            .and_then(|c| row(c, "install"))
-            .and_then(some_nonempty)
-    });
-    Some(Resolved { test, setup })
 }
 
 /// Whether the seatbelt sandbox binary the tests gate runs under is present
@@ -238,227 +75,126 @@ fn sandbox_available() -> bool {
     Path::new(crate::sandbox::SANDBOX_EXEC).exists()
 }
 
-/// `Some(trimmed)` when the value is present and non-blank, else `None`.
-fn nonempty(v: Option<String>) -> Option<String> {
-    v.and_then(some_nonempty)
-}
-
-fn some_nonempty(s: String) -> Option<String> {
-    let t = s.trim();
-    (!t.is_empty()).then(|| t.to_string())
-}
-
-/// The bounded outcome of running one command.
-enum Bounded {
-    /// The process exited; `success` is exit status 0. `tail` is its output tail.
-    Exited { success: bool, tail: String },
-    /// The process did not finish within the deadline (killed).
-    TimedOut,
-    /// The command could not be launched at all.
-    Unrunnable(String),
-}
-
-/// Run `program args` in `cwd`, capturing combined stdout+stderr, bounded by
-/// `deadline`. On timeout the child is killed (`kill_on_drop`) and `TimedOut` is
-/// returned. Pure of any workflow state so it is directly unit-testable.
-async fn run_bounded(program: &Path, args: &[String], cwd: &Path, deadline: Duration) -> Bounded {
-    let mut command = Command::new(program);
-    command
-        .args(args)
-        .current_dir(cwd)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true);
-
-    let mut child = match command.spawn() {
-        Ok(c) => c,
-        Err(e) => return Bounded::Unrunnable(format!("could not launch command: {e}")),
-    };
-    let mut stdout = child.stdout.take().expect("piped stdout");
-    let mut stderr = child.stderr.take().expect("piped stderr");
-
-    // Read both pipes concurrently (so a full pipe buffer can't deadlock the
-    // child) and reap it. `read_to_end` completes when the process closes its
-    // fds, i.e. at exit.
-    let collect = async {
-        let mut out = Vec::new();
-        let mut err = Vec::new();
-        let _ = tokio::join!(stdout.read_to_end(&mut out), stderr.read_to_end(&mut err));
-        let status = child.wait().await;
-        (status, out, err)
-    };
-
-    match timeout(deadline, collect).await {
-        Ok((status, mut out, err)) => {
-            out.extend_from_slice(&err);
-            let tail = tail_lines(&String::from_utf8_lossy(&out), OUTPUT_TAIL_LINES);
-            match status {
-                Ok(s) => Bounded::Exited {
-                    success: s.success(),
-                    tail,
-                },
-                Err(e) => Bounded::Unrunnable(format!("command errored: {e}")),
-            }
+/// Map a tests-only [`VerificationReport`] back to the gate's [`TestsOutcome`].
+///
+/// A failed / timed-out / unrunnable install blocks the tests before they run —
+/// a distinct cause (`SetupFailed`) from failing tests (spec §9.4). Otherwise
+/// the `test` check drives the outcome: a `Skipped` test (nothing resolved)
+/// degrades to `NoCommand` → the verdict gate.
+fn map_tests_outcome(report: &VerificationReport) -> TestsOutcome {
+    if let Some(install) = report.check("install") {
+        if matches!(
+            install.outcome,
+            CheckOutcome::Failed | CheckOutcome::TimedOut | CheckOutcome::SetupFailed
+        ) {
+            return TestsOutcome::SetupFailed {
+                tail: join(&install.tail),
+            };
         }
-        // `collect` drops here; `child` drops at fn end → killed via kill_on_drop.
-        Err(_elapsed) => Bounded::TimedOut,
+    }
+    match report.check("test") {
+        Some(t) => match t.outcome {
+            CheckOutcome::Passed => TestsOutcome::Passed,
+            CheckOutcome::Failed => TestsOutcome::Failed { tail: join(&t.tail) },
+            CheckOutcome::TimedOut => TestsOutcome::TimedOut { tail: join(&t.tail) },
+            // Install was clean above, so a `SetupFailed` test here can only mean
+            // an unresolved prerequisite; treat conservatively as no command.
+            CheckOutcome::SetupFailed | CheckOutcome::Skipped => TestsOutcome::NoCommand,
+        },
+        None => TestsOutcome::NoCommand,
     }
 }
 
-/// The last `n` lines of `text`, joined with `\n`.
-fn tail_lines(text: &str, n: usize) -> String {
-    let lines: Vec<&str> = text.lines().collect();
-    let start = lines.len().saturating_sub(n);
-    lines[start..].join("\n")
+/// Join an output tail back into the newline-delimited string the gate reason
+/// and journal payload carry.
+fn join(tail: &[String]) -> String {
+    tail.join("\n")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::verify::CheckResult;
 
-    fn write(dir: &Path, name: &str, contents: &str) {
-        std::fs::write(dir.join(name), contents).unwrap();
-    }
-
-    #[test]
-    fn resolve_prefers_override_over_detection() {
-        let dir = tempfile::tempdir().unwrap();
-        write(
-            dir.path(),
-            "package.json",
-            r#"{"scripts":{"test":"vitest"}}"#,
-        );
-        let r = resolve(
-            dir.path(),
-            &Some("cargo test --all".into()),
-            &Some("cargo fetch".into()),
-        )
-        .unwrap();
-        assert_eq!(r.test, "cargo test --all");
-        assert_eq!(r.setup.as_deref(), Some("cargo fetch"));
-    }
-
-    #[test]
-    fn resolve_detects_test_and_install_commands() {
-        let dir = tempfile::tempdir().unwrap();
-        write(
-            dir.path(),
-            "package.json",
-            r#"{"scripts":{"test":"vitest"}}"#,
-        );
-        let r = resolve(dir.path(), &None, &None).unwrap();
-        assert_eq!(r.test, "npm test");
-        assert_eq!(r.setup.as_deref(), Some("npm install"));
-    }
-
-    #[test]
-    fn resolve_uses_lower_ranked_config_when_top_has_no_test() {
-        // Node (lockfile → confidence 90, ranks first) has no `test` script, but
-        // Go (also 90, ranked after node) always defines one. The gate must run
-        // Go's tests rather than degrade, and pair them with Go's install.
-        let dir = tempfile::tempdir().unwrap();
-        write(dir.path(), "package.json", "{}");
-        write(dir.path(), "pnpm-lock.yaml", "");
-        write(dir.path(), "go.mod", "module example.com/x\n\ngo 1.22\n");
-        write(dir.path(), "go.sum", "");
-        let r = resolve(dir.path(), &None, &None).unwrap();
-        assert_eq!(r.test, "go test ./...");
-        assert_eq!(r.setup.as_deref(), Some("go mod download"));
-    }
-
-    #[test]
-    fn resolve_none_when_no_command_found() {
-        let dir = tempfile::tempdir().unwrap();
-        // No manifest, no override → nothing to run → degrade to verdict.
-        assert!(resolve(dir.path(), &None, &None).is_none());
-    }
-
-    #[test]
-    fn resolve_blank_override_is_ignored() {
-        let dir = tempfile::tempdir().unwrap();
-        assert!(resolve(dir.path(), &Some("   ".into()), &None).is_none());
-    }
-
-    #[tokio::test]
-    async fn run_bounded_reports_success() {
-        let cwd = tempfile::tempdir().unwrap();
-        let b = run_bounded(
-            Path::new("/bin/sh"),
-            &["-c".into(), "echo ok; exit 0".into()],
-            cwd.path(),
-            Duration::from_secs(10),
-        )
-        .await;
-        match b {
-            Bounded::Exited { success, tail } => {
-                assert!(success);
-                assert!(tail.contains("ok"), "tail: {tail}");
-            }
-            _ => panic!("expected Exited"),
+    fn check(name: &str, outcome: CheckOutcome, tail: &[&str]) -> CheckResult {
+        CheckResult {
+            name: name.to_string(),
+            command: "x".to_string(),
+            outcome,
+            duration_ms: 1,
+            tail: tail.iter().map(|s| s.to_string()).collect(),
         }
     }
 
-    #[tokio::test]
-    async fn run_bounded_captures_failure_tail() {
-        let cwd = tempfile::tempdir().unwrap();
-        let b = run_bounded(
-            Path::new("/bin/sh"),
-            &["-c".into(), "echo boom 1>&2; exit 3".into()],
-            cwd.path(),
-            Duration::from_secs(10),
-        )
-        .await;
-        match b {
-            Bounded::Exited { success, tail } => {
-                assert!(!success);
-                assert!(tail.contains("boom"), "tail: {tail}");
-            }
-            _ => panic!("expected Exited"),
+    #[test]
+    fn maps_passing_tests() {
+        let report = VerificationReport {
+            checks: vec![
+                check("install", CheckOutcome::Passed, &[]),
+                check("test", CheckOutcome::Passed, &[]),
+            ],
+        };
+        assert_eq!(map_tests_outcome(&report), TestsOutcome::Passed);
+    }
+
+    #[test]
+    fn maps_failing_tests_with_tail() {
+        let report = VerificationReport {
+            checks: vec![check("test", CheckOutcome::Failed, &["FAIL", "  x adds"])],
+        };
+        match map_tests_outcome(&report) {
+            TestsOutcome::Failed { tail } => assert!(tail.contains("adds"), "tail: {tail}"),
+            other => panic!("expected Failed, got {other:?}"),
         }
     }
 
-    #[tokio::test]
-    async fn run_bounded_times_out() {
-        let cwd = tempfile::tempdir().unwrap();
-        let b = run_bounded(
-            Path::new("/bin/sh"),
-            &["-c".into(), "sleep 30".into()],
-            cwd.path(),
-            Duration::from_millis(150),
-        )
-        .await;
-        assert!(matches!(b, Bounded::TimedOut));
-    }
-
-    #[tokio::test]
-    async fn run_bounded_reports_unrunnable() {
-        let cwd = tempfile::tempdir().unwrap();
-        let b = run_bounded(
-            Path::new("/nonexistent/definitely/not/here"),
-            &[],
-            cwd.path(),
-            Duration::from_secs(5),
-        )
-        .await;
-        assert!(matches!(b, Bounded::Unrunnable(_)));
+    #[test]
+    fn install_failure_maps_to_setup_failed() {
+        let report = VerificationReport {
+            checks: vec![
+                check("install", CheckOutcome::Failed, &["npm ERR!"]),
+                check("test", CheckOutcome::SetupFailed, &[]),
+            ],
+        };
+        match map_tests_outcome(&report) {
+            TestsOutcome::SetupFailed { tail } => assert!(tail.contains("npm ERR!")),
+            other => panic!("expected SetupFailed, got {other:?}"),
+        }
     }
 
     #[test]
-    fn tail_lines_keeps_last_n() {
-        let text = (1..=250)
-            .map(|i| i.to_string())
-            .collect::<Vec<_>>()
-            .join("\n");
-        let tail = tail_lines(&text, 100);
-        let lines: Vec<&str> = tail.lines().collect();
-        assert_eq!(lines.len(), 100);
-        assert_eq!(lines.first(), Some(&"151"));
-        assert_eq!(lines.last(), Some(&"250"));
+    fn install_timeout_maps_to_setup_failed() {
+        let report = VerificationReport {
+            checks: vec![
+                check("install", CheckOutcome::TimedOut, &["setup command exceeded"]),
+                check("test", CheckOutcome::SetupFailed, &[]),
+            ],
+        };
+        assert!(matches!(
+            map_tests_outcome(&report),
+            TestsOutcome::SetupFailed { .. }
+        ));
     }
 
     #[test]
-    fn tail_lines_shorter_than_n_is_whole() {
-        assert_eq!(tail_lines("a\nb", 100), "a\nb");
+    fn test_timeout_maps_to_timed_out() {
+        let report = VerificationReport {
+            checks: vec![
+                check("install", CheckOutcome::Passed, &[]),
+                check("test", CheckOutcome::TimedOut, &["test command exceeded"]),
+            ],
+        };
+        assert!(matches!(
+            map_tests_outcome(&report),
+            TestsOutcome::TimedOut { .. }
+        ));
+    }
+
+    #[test]
+    fn skipped_test_degrades_to_no_command() {
+        let report = VerificationReport {
+            checks: vec![check("test", CheckOutcome::Skipped, &[])],
+        };
+        assert_eq!(map_tests_outcome(&report), TestsOutcome::NoCommand);
     }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -354,7 +354,7 @@ export interface RunStateSnapshot {
 
 /** A single detected run-config row (see Rust `run_detect::DetectedRow`). */
 export interface DetectedRow {
-  /** "version" | "install" | "dev" | "test" | "build" | "port" | "env" */
+  /** "version" | "install" | "dev" | "test" | "build" | "lint" | "port" | "env" */
   id: string;
   group: "environment" | "scripts" | "server";
   key: string;
@@ -367,6 +367,30 @@ export interface DetectedConfig {
   ecosystem: string;
   confidence: number;
   rows: DetectedRow[];
+}
+
+/** One check's terminal outcome in a verification run (Rust
+ *  `verify::CheckOutcome`). `skipped` = no command resolved (nothing to run);
+ *  `setup_failed` = a prerequisite install failed so the check never ran. */
+export type CheckOutcome = "passed" | "failed" | "timed_out" | "setup_failed" | "skipped";
+
+/** One check's result inside a verification run (Rust `verify::CheckResult`). */
+export interface CheckResult {
+  /** "install" | "test" | "lint" */
+  name: string;
+  /** The command that ran (or would have); "" when skipped. */
+  command: string;
+  outcome: CheckOutcome;
+  /** Wall-clock duration in ms; 0 when the check didn't run. */
+  duration_ms: number;
+  /** Last ~100 lines of combined stdout+stderr; empty on success/skip. */
+  tail: string[];
+}
+
+/** The result of running a project's deterministic checks in a checkout
+ *  (Rust `verify::VerificationReport`). */
+export interface VerificationReport {
+  checks: CheckResult[];
 }
 
 /** Project-scoped run config resolved from a repo path: the detected configs
@@ -724,6 +748,11 @@ export const api = {
   runStop: (agentId: string) => invoke<void>("run_stop", { agentId }),
   runState: (agentId: string) => invoke<RunStateSnapshot>("run_state", { agentId }),
   detectRunConfig: (agentId: string) => invoke<DetectedConfig[]>("detect_run_config", { agentId }),
+  /** Run the project's deterministic checks (install → test → lint) in an
+   *  agent's checkout. `subdir` targets a specific tracked repo (primary when
+   *  omitted). */
+  runVerification: (agentId: string, subdir?: string) =>
+    invoke<VerificationReport>("run_verification", { agentId, subdir: subdir ?? null }),
   projectRunConfig: (repoPath: string) =>
     invoke<ProjectRunConfig>("project_run_config", { repoPath }),
   readEnvFileKeys: (repoPath: string) => invoke<EnvEntry[]>("read_env_file_keys", { repoPath }),

--- a/src/components/RunConfig/types.ts
+++ b/src/components/RunConfig/types.ts
@@ -36,6 +36,7 @@ const FALLBACK_ROWS: readonly SetupRow[] = [
   row("install", "environment", "Install", "Command to install dependencies"),
   row("dev", "scripts", "Dev", "Command to start the dev server"),
   row("test", "scripts", "Test", "Command to run the tests"),
+  row("lint", "scripts", "Lint", "Command to lint the project"),
   row("build", "scripts", "Build", "Command to build the project"),
   row("port", "server", "Port", "e.g. 3000"),
 ];


### PR DESCRIPTION
## Summary

Generalizes deterministic verification from the workflow-only tests gate into a reusable, engine-owned primitive — groundwork for evidence-based gates and the fleet review queue.

- **New top-level `verify.rs`**: `VerificationReport { checks: Vec<CheckResult> }` running install → test → lint in the same seatbelt profile as the Run panel, with project `run.*` overrides, setup-once-per-worktree, bounded timeouts and 100-line output tails. Zero `workflow` dependency.
- **`tests_gate.rs` becomes a thin adapter** over the new module. The `TestRunner` trait seam, all three scheduler construction sites, and exact `TestsOutcome` semantics (incl. timeout-note wording and NoCommand→verdict degrade) are unchanged — zero behavior change for `Gate::Tests`.
- **Lint detection** added conservatively to `run_detect`: node `package.json` lint script, python `ruff`, ruby `rubocop`. Rust/Go deliberately skipped (no manifest-declared signal).
- **`run_verification(agent_id, subdir)` Tauri command** + typed `api.ts` binding, so ad-hoc agent checkouts can be verified deterministically. No UI in this PR.

## Testing

- `cargo check` clean; `cargo test --lib`: verify 16, run_detect 74, workflow::gates 12, workflow::tests_gate 6, workflow::attempt 18 — all pass
- `tsc --noEmit` and biome clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)