### PR TITLE
feat(agents): specialist bundles — settings-table fix, step effort, MCP export, starter pack

### DIFF
--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -10,11 +10,13 @@ use crate::error::{Error, Result};
 const ALLOWED_TABLES: &[&str] = &[
     "accounts",
     "custom_agents",
+    "mcp_servers",
     "project_settings",
     "projects",
     "repos",
     "sessions",
     "settings",
+    "skills",
     "usage_daily",
     "workspaces",
     "worktrees",
@@ -851,6 +853,50 @@ mod tests {
 
         let count = db_count(&conn, "workspaces", json!({})).unwrap();
         assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn skills_and_mcp_servers_crud_through_generic_layer() {
+        // The Settings panes CRUD these tables via the generic db_* commands
+        // (src/storage/skills.ts, mcpServers.ts). They must be allow-listed, or
+        // every insert/select/update/delete fails with "unknown table". This is
+        // the regression guard for that gate.
+        let db = test_db();
+        let conn = db.lock();
+
+        // `updated_at` is NOT NULL with no default; the storage layer supplies it
+        // (skills.ts / mcpServers.ts), so the test mirrors that.
+        let sk = db_insert(
+            &conn,
+            "skills",
+            json!({ "name": "code-review", "description": "review well", "body": "# Review",
+                    "updated_at": 0 }),
+        )
+        .unwrap();
+        let rows = db_select(&conn, "skills", json!({ "where": { "id": sk } })).unwrap();
+        assert_eq!(rows[0]["name"], "code-review");
+
+        let mcp = db_insert(
+            &conn,
+            "mcp_servers",
+            json!({ "name": "gh", "transport": "stdio", "command": "npx -y gh-mcp",
+                    "updated_at": 0 }),
+        )
+        .unwrap();
+        db_update(
+            &conn,
+            "mcp_servers",
+            json!({ "where": { "id": mcp } }),
+            json!({ "url": "https://mcp.example" }),
+        )
+        .unwrap();
+        let rows = db_select(&conn, "mcp_servers", json!({ "where": { "id": mcp } })).unwrap();
+        assert_eq!(rows[0]["url"], "https://mcp.example");
+
+        db_delete(&conn, "skills", json!({ "where": { "id": sk } })).unwrap();
+        db_delete(&conn, "mcp_servers", json!({ "where": { "id": mcp } })).unwrap();
+        assert_eq!(db_count(&conn, "skills", json!({})).unwrap(), 0);
+        assert_eq!(db_count(&conn, "mcp_servers", json!({})).unwrap(), 0);
     }
 
     #[test]

--- a/src-tauri/src/workflow/attempt.rs
+++ b/src-tauri/src/workflow/attempt.rs
@@ -791,6 +791,7 @@ mod tests {
                 repo_path: PathBuf::from("/r"),
                 provider: "claude".into(),
                 model: None,
+                effort: None,
                 instructions: None,
                 custom_agent_id: None,
                 skills: vec![],

--- a/src-tauri/src/workflow/comms.rs
+++ b/src-tauri/src/workflow/comms.rs
@@ -2178,8 +2178,10 @@ mod tests {
             AgentSpec {
                 base: "claude".into(),
                 model: None,
+                effort: None,
                 instructions: None,
                 skills: vec![],
+                mcp_servers: vec![],
                 custom_agent: None,
             },
         );
@@ -2537,8 +2539,10 @@ mod tests {
                 AgentSpec {
                     base: "claude".into(),
                     model: None,
+                    effort: None,
                     instructions: None,
                     skills: vec![],
+                    mcp_servers: vec![],
                     custom_agent: None,
                 },
             );
@@ -2984,8 +2988,10 @@ mod tests {
                 AgentSpec {
                     base: "claude".into(),
                     model: None,
+                    effort: None,
                     instructions: None,
                     skills: vec![],
+                    mcp_servers: vec![],
                     custom_agent: None,
                 },
             );

--- a/src-tauri/src/workflow/definition.rs
+++ b/src-tauri/src/workflow/definition.rs
@@ -164,10 +164,12 @@ pub async fn wf_def_import_yaml(
 
     let conn = db.lock();
     let local_skills = list_skill_names(&conn)?;
+    let local_mcp_servers = list_mcp_server_names(&conn)?;
     let local_agents = list_custom_agents(&conn)?;
     Ok(yaml::build_import_report(
         spec,
         &local_skills,
+        &local_mcp_servers,
         &local_agents,
     ))
 }
@@ -177,6 +179,17 @@ pub async fn wf_def_import_yaml(
 fn list_skill_names(conn: &Connection) -> Result<Vec<String>, String> {
     let mut stmt = conn
         .prepare("SELECT name FROM skills")
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([], |r| r.get::<_, String>(0))
+        .map_err(|e| e.to_string())?;
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|e| e.to_string())
+}
+
+fn list_mcp_server_names(conn: &Connection) -> Result<Vec<String>, String> {
+    let mut stmt = conn
+        .prepare("SELECT name FROM mcp_servers")
         .map_err(|e| e.to_string())?;
     let rows = stmt
         .query_map([], |r| r.get::<_, String>(0))
@@ -212,29 +225,91 @@ fn embed_custom_agents(conn: &Connection, spec: &mut Spec) -> Result<(), String>
         };
         let resolved = conn
             .query_row(
-                "SELECT base, model, instructions, skill_ids FROM custom_agents WHERE id = ?1",
+                "SELECT base, model, effort, instructions, skill_ids, mcp_server_ids \
+                 FROM custom_agents WHERE id = ?1",
                 [&ca_id],
                 |r| {
                     Ok((
                         r.get::<_, String>(0)?,
                         r.get::<_, Option<String>>(1)?,
-                        r.get::<_, String>(2)?,
+                        r.get::<_, Option<String>>(2)?,
                         r.get::<_, String>(3)?,
+                        r.get::<_, String>(4)?,
+                        r.get::<_, String>(5)?,
                     ))
                 },
             )
             .optional()
             .map_err(|e| e.to_string())?;
         agent.custom_agent = None;
-        let Some((base, model, instructions, skill_ids_json)) = resolved else {
+        let Some((base, model, effort, instructions, skill_ids_json, mcp_ids_json)) = resolved
+        else {
             continue; // dangling id: keep whatever the alias already carried
         };
         agent.base = base;
         agent.model = model.filter(|m| !m.is_empty());
+        agent.effort = effort.filter(|e| !e.is_empty());
         agent.instructions = Some(instructions).filter(|i| !i.is_empty());
         agent.skills = resolve_skill_names(conn, &skill_ids_json)?;
+        agent.mcp_servers = resolve_mcp_defs(conn, &mcp_ids_json)?;
     }
     Ok(())
+}
+
+/// Map a JSON array of MCP server ids (a custom agent's `mcp_server_ids`) to the
+/// portable [`McpServerDef`]s embedded in an export — env/header KEY NAMES only,
+/// never their secret values (spec §5.3). Ids that no longer resolve are
+/// dropped silently: this is the *export* side, so the only reader is the file,
+/// and a deleted server simply doesn't travel.
+fn resolve_mcp_defs(
+    conn: &Connection,
+    mcp_ids_json: &str,
+) -> Result<Vec<spec::McpServerDef>, String> {
+    let ids: Vec<String> = serde_json::from_str(mcp_ids_json).unwrap_or_default();
+    let mut defs = Vec::new();
+    for id in ids {
+        let row = conn
+            .query_row(
+                "SELECT name, transport, command, env, url, headers FROM mcp_servers WHERE id = ?1",
+                [&id],
+                |r| {
+                    Ok((
+                        r.get::<_, String>(0)?,
+                        r.get::<_, String>(1)?,
+                        r.get::<_, String>(2)?,
+                        r.get::<_, String>(3)?,
+                        r.get::<_, String>(4)?,
+                        r.get::<_, String>(5)?,
+                    ))
+                },
+            )
+            .optional()
+            .map_err(|e| e.to_string())?;
+        if let Some((name, transport, command, env, url, headers)) = row {
+            defs.push(spec::McpServerDef {
+                name,
+                transport,
+                command: command.trim().to_string(),
+                url: url.trim().to_string(),
+                env_keys: pair_keys(&env, '='),
+                header_keys: pair_keys(&headers, ':'),
+            });
+        }
+    }
+    Ok(defs)
+}
+
+/// The KEY names from `KEY=VALUE` / `Name: value` lines, values discarded. The
+/// export carries only the shape of an MCP server's secrets, never the secrets
+/// (spec §5.3).
+fn pair_keys(text: &str, sep: char) -> Vec<String> {
+    text.lines()
+        .filter_map(|line| {
+            let (k, _) = line.trim().split_once(sep)?;
+            let k = k.trim();
+            (!k.is_empty()).then(|| k.to_string())
+        })
+        .collect()
 }
 
 /// Map a JSON array of skill ids (a custom agent's `skill_ids`) to skill names,
@@ -277,6 +352,11 @@ fn mcp_attachable(support: &str, transport: &str) -> bool {
 pub(super) struct StepDeliverables {
     pub skills: Vec<crate::agent_profile::SkillSnapshot>,
     pub mcp_servers: Vec<crate::agent_profile::McpServerSnapshot>,
+    /// The linked custom agent's reasoning effort, when one resolves. The
+    /// scheduler applies it only as a fallback — an explicit `AgentSpec.effort`
+    /// override wins (§3.2). `None` when there's no custom agent, its row is
+    /// gone, or its effort column is null.
+    pub effort: Option<String>,
     /// Skill names/ids the definition requested that no longer resolve
     /// (deleted since the save) — or a descriptive entry when the custom
     /// agent's `skill_ids` column itself is unreadable.
@@ -304,6 +384,7 @@ pub(super) fn resolve_step_deliverables(
     conn: &Connection,
     custom_agent_id: Option<&str>,
     skill_names: &[String],
+    mcp_server_names: &[String],
     provider: &str,
 ) -> StepDeliverables {
     let mut skills: Vec<crate::agent_profile::SkillSnapshot> = Vec::new();
@@ -311,15 +392,22 @@ pub(super) fn resolve_step_deliverables(
     let mut missing_skills: Vec<String> = Vec::new();
     let mut missing_mcp_servers: Vec<String> = Vec::new();
     let mut missing_custom_agent: Option<String> = None;
+    let mut effort: Option<String> = None;
 
     let assigned: (Vec<String>, Vec<String>) = match custom_agent_id {
         None => Default::default(),
         Some(id) => {
             let row = conn
                 .query_row(
-                    "SELECT skill_ids, mcp_server_ids FROM custom_agents WHERE id = ?1",
+                    "SELECT skill_ids, mcp_server_ids, effort FROM custom_agents WHERE id = ?1",
                     [id],
-                    |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)),
+                    |r| {
+                        Ok((
+                            r.get::<_, String>(0)?,
+                            r.get::<_, String>(1)?,
+                            r.get::<_, Option<String>>(2)?,
+                        ))
+                    },
                 )
                 .optional()
                 .ok()
@@ -331,7 +419,8 @@ pub(super) fn resolve_step_deliverables(
                 // parse failure lands in the respective missing list as a
                 // descriptive entry, so the usual event fires and the timeline
                 // says exactly what was unreadable.
-                Some((s, m)) => {
+                Some((s, m, e)) => {
+                    effort = e.filter(|v| !v.is_empty());
                     let skill_ids = match serde_json::from_str(&s) {
                         Ok(v) => v,
                         Err(e) => {
@@ -384,9 +473,10 @@ pub(super) fn resolve_step_deliverables(
 
     let support = mcp_support(provider);
     for server_id in &assigned.1 {
-        match mcp_snapshot_row(conn, server_id) {
+        match mcp_snapshot_row(conn, "id", server_id) {
             Ok(Some(snap)) => {
-                if mcp_attachable(support, &snap.transport) {
+                if mcp_attachable(support, &snap.transport) && !mcp.iter().any(|m| m.name == snap.name)
+                {
                     mcp.push(snap);
                 }
             }
@@ -396,12 +486,29 @@ pub(super) fn resolve_step_deliverables(
             _ => missing_mcp_servers.push(server_id.clone()),
         }
     }
+    // Spec-level MCP servers (from an imported workflow's embedded defs) resolve
+    // by *name* against the local library — the same warn-don't-fail path skills
+    // take. A locally-built definition leaves `mcp_server_names` empty and gets
+    // its MCP via the custom-agent ids above; the name dedup keeps the two from
+    // double-attaching the same server.
+    for name in mcp_server_names {
+        match mcp_snapshot_row(conn, "name", name) {
+            Ok(Some(snap)) => {
+                if mcp_attachable(support, &snap.transport) && !mcp.iter().any(|m| m.name == snap.name)
+                {
+                    mcp.push(snap);
+                }
+            }
+            _ => missing_mcp_servers.push(name.clone()),
+        }
+    }
     StepDeliverables {
         skills,
         mcp_servers: mcp,
         missing_skills,
         missing_mcp_servers,
         missing_custom_agent,
+        effort,
     }
 }
 
@@ -428,11 +535,16 @@ fn skill_row(
 /// pairs (KEY=VALUE / "Name: value", blanks and malformed lines skipped).
 fn mcp_snapshot_row(
     conn: &Connection,
-    server_id: &str,
+    column: &str,
+    value: &str,
 ) -> Result<Option<crate::agent_profile::McpServerSnapshot>, rusqlite::Error> {
+    // `column` is a compile-time literal ("id" | "name"), never user input.
+    let sql = format!(
+        "SELECT name, transport, command, env, url, headers FROM mcp_servers WHERE {column} = ?1 LIMIT 1"
+    );
     conn.query_row(
-        "SELECT name, transport, command, env, url, headers FROM mcp_servers WHERE id = ?1",
-        [server_id],
+        &sql,
+        [value],
         |r| {
             let command_line: String = r.get(2)?;
             let env_text: String = r.get(3)?;
@@ -481,6 +593,11 @@ mod tests {
                created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
              CREATE TABLE skills (id TEXT PRIMARY KEY, name TEXT NOT NULL,
                description TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '',
+               created_at INTEGER NOT NULL DEFAULT 0, updated_at INTEGER NOT NULL DEFAULT 0);
+             CREATE TABLE mcp_servers (id TEXT PRIMARY KEY, name TEXT NOT NULL,
+               transport TEXT NOT NULL DEFAULT 'stdio', command TEXT NOT NULL DEFAULT '',
+               env TEXT NOT NULL DEFAULT '', url TEXT NOT NULL DEFAULT '',
+               headers TEXT NOT NULL DEFAULT '',
                created_at INTEGER NOT NULL DEFAULT 0, updated_at INTEGER NOT NULL DEFAULT 0);
              CREATE TABLE custom_agents (id TEXT PRIMARY KEY, name TEXT NOT NULL,
                description TEXT NOT NULL DEFAULT '', color INTEGER NOT NULL DEFAULT 0,
@@ -588,6 +705,49 @@ mod tests {
     }
 
     #[test]
+    fn export_embeds_mcp_defs_key_only_and_effort() {
+        let db = test_db();
+        {
+            let conn = db.lock();
+            conn.execute(
+                "INSERT INTO mcp_servers (id,name,transport,command,env,url,headers) \
+                 VALUES ('m1','gh','stdio','npx -y gh-mcp', \
+                         'TOKEN=supersecret' || char(10) || 'REGION=us', '', ''), \
+                        ('m2','web','http','','',' https://mcp.example ','X-Key: topsecret')",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO custom_agents (id,name,base,effort,mcp_server_ids) \
+                 VALUES ('ca-1','Reviewer','claude','high','[\"m1\",\"m2\"]')",
+                [],
+            )
+            .unwrap();
+        }
+        let mut spec = sample_spec();
+        spec.agents.get_mut("coder").unwrap().custom_agent = Some("ca-1".into());
+        embed_custom_agents(&db.lock(), &mut spec).unwrap();
+
+        let agent = &spec.agents["coder"];
+        assert_eq!(agent.effort.as_deref(), Some("high"));
+        assert_eq!(agent.mcp_servers.len(), 2);
+        let gh = &agent.mcp_servers[0];
+        assert_eq!(gh.name, "gh");
+        assert_eq!(gh.transport, "stdio");
+        assert_eq!(gh.command, "npx -y gh-mcp");
+        // Keys only — the secret values never travel.
+        assert_eq!(gh.env_keys, vec!["TOKEN".to_string(), "REGION".to_string()]);
+        let web = &agent.mcp_servers[1];
+        assert_eq!(web.url, "https://mcp.example");
+        assert_eq!(web.header_keys, vec!["X-Key".to_string()]);
+
+        let out = yaml::to_yaml(&spec).unwrap();
+        assert!(!out.contains("supersecret"), "env value leaked:\n{out}");
+        assert!(!out.contains("topsecret"), "header value leaked:\n{out}");
+        assert!(out.contains("TOKEN"), "env key should be present:\n{out}");
+    }
+
+    #[test]
     fn dangling_custom_agent_id_is_dropped_gracefully() {
         let db = test_db();
         let mut spec = sample_spec();
@@ -617,7 +777,8 @@ mod tests {
              CREATE TABLE custom_agents (
                 id TEXT PRIMARY KEY,
                 skill_ids TEXT NOT NULL DEFAULT '[]',
-                mcp_server_ids TEXT NOT NULL DEFAULT '[]'
+                mcp_server_ids TEXT NOT NULL DEFAULT '[]',
+                effort TEXT
              );
              INSERT INTO skills VALUES
                 ('sk1', 'code-review', 'review well', '# Review'),
@@ -627,8 +788,8 @@ mod tests {
                  'TOKEN=t' || char(10) || 'BAD-LINE', '', ''),
                 ('m2', 'web', 'http', '', '', ' https://mcp.example ', 'X-Key: abc');
              INSERT INTO custom_agents VALUES
-                ('ca1', '[\"sk1\",\"dangling\"]', '[\"m1\",\"m2\",\"gone\"]'),
-                ('ca-corrupt', 'not-json', '{\"nope\"');",
+                ('ca1', '[\"sk1\",\"dangling\"]', '[\"m1\",\"m2\",\"gone\"]', 'high'),
+                ('ca-corrupt', 'not-json', '{\"nope\"', NULL);",
         )
         .unwrap();
         conn
@@ -641,6 +802,7 @@ mod tests {
             &conn,
             Some("ca1"),
             &["tests-first".into(), "code-review".into(), "unknown".into()],
+            &[],
             "claude",
         );
         // ca1's sk1 first (assignment order), then the spec name that isn't a
@@ -648,6 +810,8 @@ mod tests {
         let names: Vec<&str> = d.skills.iter().map(|s| s.name.as_str()).collect();
         assert_eq!(names, vec!["code-review", "tests-first"]);
         assert_eq!(d.missing_skills, vec!["dangling", "unknown"]);
+        // ca1 carries effort 'high' — inherited by a step that doesn't override.
+        assert_eq!(d.effort.as_deref(), Some("high"));
         // ca1's deleted server id is reported — a saved agent must never lose
         // part of its requested capability snapshot silently.
         assert_eq!(d.missing_mcp_servers, vec!["gone"]);
@@ -669,35 +833,67 @@ mod tests {
     #[test]
     fn deliverables_filter_http_servers_for_stdio_only_providers() {
         let conn = library_db();
-        let d = resolve_step_deliverables(&conn, Some("ca1"), &[], "codex");
+        let d = resolve_step_deliverables(&conn, Some("ca1"), &[], &[], "codex");
         assert_eq!(d.mcp_servers.len(), 1, "codex delivers stdio only");
         assert_eq!(d.mcp_servers[0].name, "gh");
         // The provider-filtered http server ('m2') is by-design gating, never a
         // missing warning; only the genuinely deleted id is reported.
         assert_eq!(d.missing_mcp_servers, vec!["gone"]);
-        let none = resolve_step_deliverables(&conn, Some("ca1"), &[], "cursor").mcp_servers;
+        let none = resolve_step_deliverables(&conn, Some("ca1"), &[], &[], "cursor").mcp_servers;
         assert!(none.is_empty(), "providers without MCP support get none");
     }
 
     #[test]
     fn deliverables_without_custom_agent_resolve_names_only() {
         let conn = library_db();
-        let d = resolve_step_deliverables(&conn, None, &["code-review".into()], "claude");
+        let d = resolve_step_deliverables(&conn, None, &["code-review".into()], &[], "claude");
         assert_eq!(d.skills.len(), 1);
         assert_eq!(d.skills[0].name, "code-review");
         assert!(d.missing_skills.is_empty(), "everything requested resolved");
         assert!(d.missing_mcp_servers.is_empty());
         assert!(d.missing_custom_agent.is_none());
+        assert!(d.effort.is_none(), "no custom agent → no inherited effort");
         assert!(
             d.mcp_servers.is_empty(),
-            "MCP comes only via a custom agent (§5.1)"
+            "no custom agent and no spec-named MCP servers → none"
         );
+    }
+
+    #[test]
+    fn deliverables_resolve_spec_named_mcp_servers_against_library() {
+        // An imported workflow carries MCP by embedded def; at spawn the names
+        // resolve against the local library (the warn-don't-fail path skills
+        // take), with the local secret values — not the file's key-only shape.
+        let conn = library_db();
+        let d = resolve_step_deliverables(
+            &conn,
+            None,
+            &[],
+            &["gh".into(), "nonexistent".into()],
+            "claude",
+        );
+        assert_eq!(d.mcp_servers.len(), 1);
+        assert_eq!(d.mcp_servers[0].name, "gh");
+        assert_eq!(
+            d.mcp_servers[0].env,
+            vec![("TOKEN".to_string(), "t".to_string())]
+        );
+        assert_eq!(d.missing_mcp_servers, vec!["nonexistent"]);
+    }
+
+    #[test]
+    fn deliverables_dedupe_mcp_from_custom_agent_and_spec_name() {
+        // 'gh' comes via ca1's ids and again via the spec name — attach once.
+        let conn = library_db();
+        let d = resolve_step_deliverables(&conn, Some("ca1"), &[], &["gh".into()], "claude");
+        assert_eq!(d.mcp_servers.iter().filter(|m| m.name == "gh").count(), 1);
     }
 
     #[test]
     fn deliverables_report_a_deleted_custom_agent() {
         let conn = library_db();
-        let d = resolve_step_deliverables(&conn, Some("gone"), &["code-review".into()], "claude");
+        let d =
+            resolve_step_deliverables(&conn, Some("gone"), &["code-review".into()], &[], "claude");
         assert_eq!(d.missing_custom_agent.as_deref(), Some("gone"));
         // Spec-named skills still resolve; only the agent's assignments are lost.
         assert_eq!(d.skills.len(), 1);
@@ -713,7 +909,7 @@ mod tests {
         let conn = library_db();
         // The row exists but both assignment columns are malformed JSON: this
         // must warn per class, not collapse to "nothing requested".
-        let d = resolve_step_deliverables(&conn, Some("ca-corrupt"), &[], "claude");
+        let d = resolve_step_deliverables(&conn, Some("ca-corrupt"), &[], &[], "claude");
         assert!(d.missing_custom_agent.is_none(), "the row itself resolves");
         assert_eq!(d.missing_skills.len(), 1);
         assert!(

--- a/src-tauri/src/workflow/definition.rs
+++ b/src-tauri/src/workflow/definition.rs
@@ -381,6 +381,16 @@ pub(super) struct StepDeliverables {
     /// The step's `custom_agent` id when its row no longer resolves — the step
     /// spawns without that agent's skills and MCP servers.
     pub missing_custom_agent: Option<String>,
+    /// By-name skill references (from the spec) that matched more than one
+    /// library row. The step still ran against a deterministic pick (lowest
+    /// id); the caller journals these so the timeline names which same-named
+    /// skill was chosen. Ambiguity is only possible on the by-name path —
+    /// custom-agent skills resolve by unique id.
+    pub ambiguous_skills: Vec<String>,
+    /// By-name MCP server references (spec-level / imported) that matched more
+    /// than one library row — same warn-don't-fail treatment as
+    /// `ambiguous_skills`.
+    pub ambiguous_mcp_servers: Vec<String>,
 }
 
 /// Resolve a step's skill/MCP deliverables at spawn (§3.2) — the Rust twin of
@@ -402,6 +412,8 @@ pub(super) fn resolve_step_deliverables(
     let mut mcp: Vec<crate::agent_profile::McpServerSnapshot> = Vec::new();
     let mut missing_skills: Vec<String> = Vec::new();
     let mut missing_mcp_servers: Vec<String> = Vec::new();
+    let mut ambiguous_skills: Vec<String> = Vec::new();
+    let mut ambiguous_mcp_servers: Vec<String> = Vec::new();
     let mut missing_custom_agent: Option<String> = None;
     let mut effort: Option<String> = None;
     let mut model: Option<String> = None;
@@ -436,12 +448,13 @@ pub(super) fn resolve_step_deliverables(
                 // descriptive entry, so the usual event fires and the timeline
                 // says exactly what was unreadable.
                 Some((s, m, e, mdl, instr)) => {
-                    // Match `embed_custom_agents`' export semantics exactly so a
-                    // live step and an export+imported one resolve the same:
-                    // empty model/instructions collapse to `None` (CLI default).
-                    effort = e.filter(|v| !v.is_empty());
-                    model = mdl.filter(|v| !v.is_empty());
-                    instructions = Some(instr).filter(|v| !v.is_empty());
+                    // Collapse blank (incl. whitespace-only) values to `None` so
+                    // a live step and an export+imported one resolve the same and
+                    // neither spawns with an empty argument — the trim-based twin
+                    // of `scheduler::nonblank` on the AgentSpec-override side.
+                    effort = e.filter(|v| !v.trim().is_empty());
+                    model = mdl.filter(|v| !v.trim().is_empty());
+                    instructions = Some(instr).filter(|v| !v.trim().is_empty());
                     let skill_ids = match serde_json::from_str(&s) {
                         Ok(v) => v,
                         Err(e) => {
@@ -487,6 +500,9 @@ pub(super) fn resolve_step_deliverables(
                 if !skills.iter().any(|k| k.name == s.name) {
                     skills.push(s);
                 }
+                if count_by_name(conn, "skills", name) > 1 {
+                    ambiguous_skills.push(name.clone());
+                }
             }
             _ => missing_skills.push(name.clone()),
         }
@@ -521,6 +537,9 @@ pub(super) fn resolve_step_deliverables(
                 {
                     mcp.push(snap);
                 }
+                if count_by_name(conn, "mcp_servers", name) > 1 {
+                    ambiguous_mcp_servers.push(name.clone());
+                }
             }
             _ => missing_mcp_servers.push(name.clone()),
         }
@@ -531,6 +550,8 @@ pub(super) fn resolve_step_deliverables(
         missing_skills,
         missing_mcp_servers,
         missing_custom_agent,
+        ambiguous_skills,
+        ambiguous_mcp_servers,
         effort,
         model,
         instructions,
@@ -543,7 +564,12 @@ fn skill_row(
     value: &str,
 ) -> Result<Option<crate::agent_profile::SkillSnapshot>, rusqlite::Error> {
     // `column` is a compile-time literal ("id" | "name"), never user input.
-    let sql = format!("SELECT name, description, body FROM skills WHERE {column} = ?1 LIMIT 1");
+    // Names are not unique; `ORDER BY id` makes the pick deterministic (lowest
+    // id wins) so a duplicate-named lookup is stable rather than arbitrary. The
+    // caller flags the ambiguity via `count_by_name`.
+    let sql = format!(
+        "SELECT name, description, body FROM skills WHERE {column} = ?1 ORDER BY id LIMIT 1"
+    );
     conn.query_row(&sql, [value], |r| {
         Ok(crate::agent_profile::SkillSnapshot {
             name: r.get(0)?,
@@ -564,8 +590,11 @@ fn mcp_snapshot_row(
     value: &str,
 ) -> Result<Option<crate::agent_profile::McpServerSnapshot>, rusqlite::Error> {
     // `column` is a compile-time literal ("id" | "name"), never user input.
+    // `ORDER BY id` makes a duplicate-named pick deterministic (lowest id wins)
+    // rather than arbitrary; the caller flags the ambiguity via `count_by_name`.
     let sql = format!(
-        "SELECT name, transport, command, env, url, headers FROM mcp_servers WHERE {column} = ?1 LIMIT 1"
+        "SELECT name, transport, command, env, url, headers FROM mcp_servers \
+         WHERE {column} = ?1 ORDER BY id LIMIT 1"
     );
     conn.query_row(&sql, [value], |r| {
         let command_line: String = r.get(2)?;
@@ -583,6 +612,16 @@ fn mcp_snapshot_row(
         })
     })
     .optional()
+}
+
+/// How many library rows carry `name`. Used to flag a by-name resolution as
+/// ambiguous (>1 match) so the deterministic pick above is surfaced as a
+/// warning rather than a silent bind. `table` is a compile-time literal
+/// (`"skills"` | `"mcp_servers"`), never user input; a query error counts as 0
+/// (no false ambiguity warning).
+fn count_by_name(conn: &Connection, table: &str, name: &str) -> i64 {
+    let sql = format!("SELECT COUNT(*) FROM {table} WHERE name = ?1");
+    conn.query_row(&sql, [name], |r| r.get(0)).unwrap_or(0)
 }
 
 fn parse_pair_lines(text: &str, sep: char) -> Vec<(String, String)> {
@@ -919,6 +958,77 @@ mod tests {
         let conn = library_db();
         let d = resolve_step_deliverables(&conn, Some("ca1"), &[], &["gh".into()], "claude");
         assert_eq!(d.mcp_servers.iter().filter(|m| m.name == "gh").count(), 1);
+    }
+
+    /// An empty three-table library the ambiguity tests seed with duplicates.
+    fn blank_library() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE skills (id TEXT PRIMARY KEY, name TEXT NOT NULL,
+                description TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '');
+             CREATE TABLE mcp_servers (id TEXT PRIMARY KEY, name TEXT NOT NULL,
+                transport TEXT NOT NULL DEFAULT 'stdio', command TEXT NOT NULL DEFAULT '',
+                env TEXT NOT NULL DEFAULT '', url TEXT NOT NULL DEFAULT '',
+                headers TEXT NOT NULL DEFAULT '');
+             CREATE TABLE custom_agents (id TEXT PRIMARY KEY,
+                skill_ids TEXT NOT NULL DEFAULT '[]', mcp_server_ids TEXT NOT NULL DEFAULT '[]',
+                effort TEXT, model TEXT, instructions TEXT NOT NULL DEFAULT '');",
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn deliverables_flag_ambiguous_mcp_name_and_pick_lowest_id() {
+        // Two servers named 'gh': the by-name lookup must pick deterministically
+        // (lowest id 'm-a') and flag the ambiguity, never bind silently.
+        let conn = blank_library();
+        conn.execute_batch(
+            "INSERT INTO mcp_servers (id, name, command) VALUES
+                ('m-b', 'gh', 'cmd-b'), ('m-a', 'gh', 'cmd-a');",
+        )
+        .unwrap();
+        let d = resolve_step_deliverables(&conn, None, &[], &["gh".into()], "claude");
+        assert_eq!(d.mcp_servers.len(), 1);
+        assert_eq!(d.mcp_servers[0].command, "cmd-a", "lowest id wins");
+        assert_eq!(d.ambiguous_mcp_servers, vec!["gh"]);
+        assert!(d.missing_mcp_servers.is_empty());
+    }
+
+    #[test]
+    fn deliverables_flag_ambiguous_skill_name_but_not_unique_one() {
+        // 'review' is duplicated (ambiguous); 'lint' is unique (not flagged).
+        let conn = blank_library();
+        conn.execute_batch(
+            "INSERT INTO skills (id, name, body) VALUES
+                ('sk-b', 'review', '# B'), ('sk-a', 'review', '# A'),
+                ('sk-solo', 'lint', '# lint');",
+        )
+        .unwrap();
+        let d = resolve_step_deliverables(
+            &conn,
+            None,
+            &["review".into(), "lint".into()],
+            &[],
+            "claude",
+        );
+        let review = d.skills.iter().find(|s| s.name == "review").unwrap();
+        assert_eq!(review.body, "# A", "lowest id wins");
+        assert_eq!(d.ambiguous_skills, vec!["review"]);
+    }
+
+    #[test]
+    fn deliverables_unique_names_are_not_flagged_ambiguous() {
+        let conn = library_db(); // sk1/sk2 and m1/m2 all have unique names
+        let d = resolve_step_deliverables(
+            &conn,
+            None,
+            &["code-review".into()],
+            &["gh".into()],
+            "claude",
+        );
+        assert!(d.ambiguous_skills.is_empty());
+        assert!(d.ambiguous_mcp_servers.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/workflow/definition.rs
+++ b/src-tauri/src/workflow/definition.rs
@@ -357,6 +357,17 @@ pub(super) struct StepDeliverables {
     /// override wins (§3.2). `None` when there's no custom agent, its row is
     /// gone, or its effort column is null.
     pub effort: Option<String>,
+    /// The linked custom agent's model, applied as a fallback the same way as
+    /// `effort` — an explicit `AgentSpec.model` wins. This is what makes a live
+    /// custom-agent step spawn identically to the same alias after YAML
+    /// export+import (where `embed_custom_agents` inlines the model). `None`
+    /// when there's no custom agent, its row is gone, or its model is empty.
+    pub model: Option<String>,
+    /// The linked custom agent's standing instructions, applied as a fallback
+    /// like `model`/`effort`. Flows into the same `SpawnReq.instructions` slot
+    /// an inlined `AgentSpec.instructions` uses, so the composition into the
+    /// step prompt is identical either way (§3.2). `None` when absent/empty.
+    pub instructions: Option<String>,
     /// Skill names/ids the definition requested that no longer resolve
     /// (deleted since the save) — or a descriptive entry when the custom
     /// agent's `skill_ids` column itself is unreadable.
@@ -393,19 +404,24 @@ pub(super) fn resolve_step_deliverables(
     let mut missing_mcp_servers: Vec<String> = Vec::new();
     let mut missing_custom_agent: Option<String> = None;
     let mut effort: Option<String> = None;
+    let mut model: Option<String> = None;
+    let mut instructions: Option<String> = None;
 
     let assigned: (Vec<String>, Vec<String>) = match custom_agent_id {
         None => Default::default(),
         Some(id) => {
             let row = conn
                 .query_row(
-                    "SELECT skill_ids, mcp_server_ids, effort FROM custom_agents WHERE id = ?1",
+                    "SELECT skill_ids, mcp_server_ids, effort, model, instructions \
+                     FROM custom_agents WHERE id = ?1",
                     [id],
                     |r| {
                         Ok((
                             r.get::<_, String>(0)?,
                             r.get::<_, String>(1)?,
                             r.get::<_, Option<String>>(2)?,
+                            r.get::<_, Option<String>>(3)?,
+                            r.get::<_, String>(4)?,
                         ))
                     },
                 )
@@ -419,8 +435,13 @@ pub(super) fn resolve_step_deliverables(
                 // parse failure lands in the respective missing list as a
                 // descriptive entry, so the usual event fires and the timeline
                 // says exactly what was unreadable.
-                Some((s, m, e)) => {
+                Some((s, m, e, mdl, instr)) => {
+                    // Match `embed_custom_agents`' export semantics exactly so a
+                    // live step and an export+imported one resolve the same:
+                    // empty model/instructions collapse to `None` (CLI default).
                     effort = e.filter(|v| !v.is_empty());
+                    model = mdl.filter(|v| !v.is_empty());
+                    instructions = Some(instr).filter(|v| !v.is_empty());
                     let skill_ids = match serde_json::from_str(&s) {
                         Ok(v) => v,
                         Err(e) => {
@@ -475,7 +496,8 @@ pub(super) fn resolve_step_deliverables(
     for server_id in &assigned.1 {
         match mcp_snapshot_row(conn, "id", server_id) {
             Ok(Some(snap)) => {
-                if mcp_attachable(support, &snap.transport) && !mcp.iter().any(|m| m.name == snap.name)
+                if mcp_attachable(support, &snap.transport)
+                    && !mcp.iter().any(|m| m.name == snap.name)
                 {
                     mcp.push(snap);
                 }
@@ -494,7 +516,8 @@ pub(super) fn resolve_step_deliverables(
     for name in mcp_server_names {
         match mcp_snapshot_row(conn, "name", name) {
             Ok(Some(snap)) => {
-                if mcp_attachable(support, &snap.transport) && !mcp.iter().any(|m| m.name == snap.name)
+                if mcp_attachable(support, &snap.transport)
+                    && !mcp.iter().any(|m| m.name == snap.name)
                 {
                     mcp.push(snap);
                 }
@@ -509,6 +532,8 @@ pub(super) fn resolve_step_deliverables(
         missing_mcp_servers,
         missing_custom_agent,
         effort,
+        model,
+        instructions,
     }
 }
 
@@ -542,25 +567,21 @@ fn mcp_snapshot_row(
     let sql = format!(
         "SELECT name, transport, command, env, url, headers FROM mcp_servers WHERE {column} = ?1 LIMIT 1"
     );
-    conn.query_row(
-        &sql,
-        [value],
-        |r| {
-            let command_line: String = r.get(2)?;
-            let env_text: String = r.get(3)?;
-            let headers_text: String = r.get(5)?;
-            let mut tokens = command_line.split_whitespace().map(str::to_string);
-            Ok(crate::agent_profile::McpServerSnapshot {
-                name: r.get(0)?,
-                transport: r.get(1)?,
-                command: tokens.next().unwrap_or_default(),
-                args: tokens.collect(),
-                env: parse_pair_lines(&env_text, '='),
-                url: r.get::<_, String>(4)?.trim().to_string(),
-                headers: parse_pair_lines(&headers_text, ':'),
-            })
-        },
-    )
+    conn.query_row(&sql, [value], |r| {
+        let command_line: String = r.get(2)?;
+        let env_text: String = r.get(3)?;
+        let headers_text: String = r.get(5)?;
+        let mut tokens = command_line.split_whitespace().map(str::to_string);
+        Ok(crate::agent_profile::McpServerSnapshot {
+            name: r.get(0)?,
+            transport: r.get(1)?,
+            command: tokens.next().unwrap_or_default(),
+            args: tokens.collect(),
+            env: parse_pair_lines(&env_text, '='),
+            url: r.get::<_, String>(4)?.trim().to_string(),
+            headers: parse_pair_lines(&headers_text, ':'),
+        })
+    })
     .optional()
 }
 
@@ -778,7 +799,9 @@ mod tests {
                 id TEXT PRIMARY KEY,
                 skill_ids TEXT NOT NULL DEFAULT '[]',
                 mcp_server_ids TEXT NOT NULL DEFAULT '[]',
-                effort TEXT
+                effort TEXT,
+                model TEXT,
+                instructions TEXT NOT NULL DEFAULT ''
              );
              INSERT INTO skills VALUES
                 ('sk1', 'code-review', 'review well', '# Review'),
@@ -788,8 +811,8 @@ mod tests {
                  'TOKEN=t' || char(10) || 'BAD-LINE', '', ''),
                 ('m2', 'web', 'http', '', '', ' https://mcp.example ', 'X-Key: abc');
              INSERT INTO custom_agents VALUES
-                ('ca1', '[\"sk1\",\"dangling\"]', '[\"m1\",\"m2\",\"gone\"]', 'high'),
-                ('ca-corrupt', 'not-json', '{\"nope\"', NULL);",
+                ('ca1', '[\"sk1\",\"dangling\"]', '[\"m1\",\"m2\",\"gone\"]', 'high', 'opus', 'Be thorough.'),
+                ('ca-corrupt', 'not-json', '{\"nope\"', NULL, NULL, '');",
         )
         .unwrap();
         conn
@@ -810,8 +833,12 @@ mod tests {
         let names: Vec<&str> = d.skills.iter().map(|s| s.name.as_str()).collect();
         assert_eq!(names, vec!["code-review", "tests-first"]);
         assert_eq!(d.missing_skills, vec!["dangling", "unknown"]);
-        // ca1 carries effort 'high' — inherited by a step that doesn't override.
+        // ca1 carries effort 'high', model 'opus', and instructions — all
+        // inherited by a step that doesn't override them (the same fallback the
+        // export+import path bakes in by inlining them onto the AgentSpec).
         assert_eq!(d.effort.as_deref(), Some("high"));
+        assert_eq!(d.model.as_deref(), Some("opus"));
+        assert_eq!(d.instructions.as_deref(), Some("Be thorough."));
         // ca1's deleted server id is reported — a saved agent must never lose
         // part of its requested capability snapshot silently.
         assert_eq!(d.missing_mcp_servers, vec!["gone"]);
@@ -853,6 +880,11 @@ mod tests {
         assert!(d.missing_mcp_servers.is_empty());
         assert!(d.missing_custom_agent.is_none());
         assert!(d.effort.is_none(), "no custom agent → no inherited effort");
+        assert!(d.model.is_none(), "no custom agent → no inherited model");
+        assert!(
+            d.instructions.is_none(),
+            "no custom agent → no inherited instructions"
+        );
         assert!(
             d.mcp_servers.is_empty(),
             "no custom agent and no spec-named MCP servers → none"
@@ -902,6 +934,11 @@ mod tests {
         // The agent row itself is the missing thing — its unknowable server
         // assignments are not double-reported.
         assert!(d.missing_mcp_servers.is_empty());
+        // A dangling id inherits nothing: model/effort/instructions stay None so
+        // the step falls back to the AgentSpec's own (here, unset) values.
+        assert!(d.effort.is_none());
+        assert!(d.model.is_none());
+        assert!(d.instructions.is_none());
     }
 
     #[test]

--- a/src-tauri/src/workflow/driver.rs
+++ b/src-tauri/src/workflow/driver.rs
@@ -33,6 +33,10 @@ pub struct SpawnReq {
     /// Provider id (`claude` | `codex` | …).
     pub provider: String,
     pub model: Option<String>,
+    /// Session-level reasoning effort (claude `--effort`) for this step. Resolved
+    /// by the scheduler from the alias's `effort` override, falling back to the
+    /// linked custom agent's effort (§3.2); `None` uses the provider default.
+    pub effort: Option<String>,
     pub instructions: Option<String>,
     /// Local custom-agent id, when the step's agent alias maps to one.
     pub custom_agent_id: Option<String>,
@@ -119,6 +123,7 @@ impl AgentDriver for SupervisorDriver {
                 repo_path,
                 provider,
                 model,
+                effort,
                 instructions,
                 custom_agent_id,
                 skills,
@@ -139,7 +144,7 @@ impl AgentDriver for SupervisorDriver {
                         repo_path,
                         provider,
                         name: None,
-                        effort: None,
+                        effort,
                         model,
                         instructions,
                         // Workflow steps are not forks; no carried conversation.
@@ -515,6 +520,7 @@ mod tests {
                 repo_path: PathBuf::from("/r"),
                 provider: "claude".into(),
                 model: None,
+                effort: None,
                 instructions: None,
                 custom_agent_id: None,
                 skills: vec![],
@@ -542,6 +548,7 @@ mod tests {
                 repo_path: PathBuf::from("/r"),
                 provider: "claude".into(),
                 model: None,
+                effort: None,
                 instructions: None,
                 custom_agent_id: None,
                 skills: vec![],

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -2386,8 +2386,11 @@ fn build_spawn_req(
     run_id: &str,
     warn_exec_id: Option<&str>,
 ) -> SpawnReq {
-    let mcp_server_names: Vec<String> =
-        agent_spec.mcp_servers.iter().map(|d| d.name.clone()).collect();
+    let mcp_server_names: Vec<String> = agent_spec
+        .mcp_servers
+        .iter()
+        .map(|d| d.name.clone())
+        .collect();
     let deliverables = super::definition::resolve_step_deliverables(
         conn,
         agent_spec.custom_agent.as_deref(),
@@ -2430,12 +2433,18 @@ fn build_spawn_req(
     SpawnReq {
         repo_path: repo.to_path_buf(),
         provider: agent_spec.base.clone(),
-        model: agent_spec.model.clone(),
-        // The alias's explicit effort wins; otherwise inherit the linked custom
-        // agent's effort (§3.2). Resolved here rather than in the driver so the
-        // one place that reads the custom_agents row also owns the fallback.
+        // The alias's explicit model/effort/instructions win; otherwise inherit
+        // the linked custom agent's values (§3.2). Resolved here rather than in
+        // the driver so the one place that reads the custom_agents row owns the
+        // fallback — and so a live custom-agent step spawns identically to the
+        // same alias after YAML export+import (which inlines these onto the
+        // AgentSpec via `embed_custom_agents`).
+        model: agent_spec.model.clone().or(deliverables.model.clone()),
         effort: agent_spec.effort.clone().or(deliverables.effort.clone()),
-        instructions: agent_spec.instructions.clone(),
+        instructions: agent_spec
+            .instructions
+            .clone()
+            .or(deliverables.instructions.clone()),
         custom_agent_id: agent_spec.custom_agent.clone(),
         skills: deliverables.skills,
         mcp_servers: deliverables.mcp_servers,
@@ -6295,6 +6304,96 @@ mod tests {
             budgets: None,
             comms: vec![],
         }
+    }
+
+    /// A library DB with one custom agent carrying a model/effort/instructions,
+    /// for the `build_spawn_req` precedence checks below.
+    fn spawn_req_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE skills (id TEXT PRIMARY KEY, name TEXT NOT NULL,
+                description TEXT NOT NULL DEFAULT '', body TEXT NOT NULL DEFAULT '');
+             CREATE TABLE mcp_servers (id TEXT PRIMARY KEY, name TEXT NOT NULL,
+                transport TEXT NOT NULL DEFAULT 'stdio', command TEXT NOT NULL DEFAULT '',
+                env TEXT NOT NULL DEFAULT '', url TEXT NOT NULL DEFAULT '',
+                headers TEXT NOT NULL DEFAULT '');
+             CREATE TABLE custom_agents (id TEXT PRIMARY KEY,
+                skill_ids TEXT NOT NULL DEFAULT '[]', mcp_server_ids TEXT NOT NULL DEFAULT '[]',
+                effort TEXT, model TEXT, instructions TEXT NOT NULL DEFAULT '');
+             INSERT INTO custom_agents (id, effort, model, instructions)
+                VALUES ('ca1', 'high', 'opus', 'Be thorough.');",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn agent_spec(custom_agent: Option<&str>) -> super::super::spec::AgentSpec {
+        super::super::spec::AgentSpec {
+            base: "claude".into(),
+            model: None,
+            effort: None,
+            instructions: None,
+            skills: vec![],
+            mcp_servers: vec![],
+            custom_agent: custom_agent.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn build_spawn_req_inherits_custom_agent_model_effort_instructions() {
+        // The coherency bar: a live custom-agent-backed alias must spawn with the
+        // same model/effort/instructions the export+import path inlines onto the
+        // AgentSpec — sourced here from the custom_agents row as a fallback.
+        let conn = spawn_req_conn();
+        let dummy = Path::new("/tmp/repo");
+        let req = build_spawn_req(
+            &conn,
+            None,
+            &agent_spec(Some("ca1")),
+            "base",
+            dummy,
+            dummy,
+            "r",
+            None,
+        );
+        assert_eq!(req.model.as_deref(), Some("opus"));
+        assert_eq!(req.effort.as_deref(), Some("high"));
+        assert_eq!(req.instructions.as_deref(), Some("Be thorough."));
+    }
+
+    #[test]
+    fn build_spawn_req_explicit_alias_values_win_over_custom_agent() {
+        let conn = spawn_req_conn();
+        let mut spec = agent_spec(Some("ca1"));
+        spec.model = Some("sonnet".into());
+        spec.effort = Some("low".into());
+        spec.instructions = Some("Override brief.".into());
+        let dummy = Path::new("/tmp/repo");
+        let req = build_spawn_req(&conn, None, &spec, "base", dummy, dummy, "r", None);
+        assert_eq!(req.model.as_deref(), Some("sonnet"));
+        assert_eq!(req.effort.as_deref(), Some("low"));
+        assert_eq!(req.instructions.as_deref(), Some("Override brief."));
+    }
+
+    #[test]
+    fn build_spawn_req_dangling_custom_agent_inherits_nothing() {
+        // A deleted custom agent leaves the alias's own (here unset) values —
+        // unchanged behavior, never a resolution error.
+        let conn = spawn_req_conn();
+        let dummy = Path::new("/tmp/repo");
+        let req = build_spawn_req(
+            &conn,
+            None,
+            &agent_spec(Some("gone")),
+            "base",
+            dummy,
+            dummy,
+            "r",
+            None,
+        );
+        assert!(req.model.is_none());
+        assert!(req.effort.is_none());
+        assert!(req.instructions.is_none());
     }
 
     #[tokio::test]

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -2375,12 +2375,15 @@ async fn drive_child(c: ChildCtx, stage_entry_sha: Option<String>) -> ChildResul
 /// the step still spawns. Pass `warn_exec_id: None` when the req describes an
 /// already-spawned agent (`pre_spawned`) whose spawn call warned already. The
 /// blackboard write-grant is derived from `owner_run_id` at spawn.
-/// An explicit `AgentSpec` override, treating an empty string as unset so a
+/// An explicit `AgentSpec` override, treating a blank string as unset so a
 /// blank `model`/`effort`/`instructions` in a hand-authored or imported spec
 /// falls back to the linked custom agent's value instead of spawning with an
-/// empty argument (matches the custom-agent side's empty→None normalization).
+/// empty argument. The check is trim-based, so a whitespace-only value (`"   "`,
+/// reachable from hand-authored YAML) is also treated as unset; the original
+/// (untrimmed) value is returned when it has content. Matches the custom-agent
+/// side's normalization in `resolve_step_deliverables`.
 fn nonblank(value: &Option<String>) -> Option<String> {
-    value.clone().filter(|s| !s.is_empty())
+    value.clone().filter(|s| !s.trim().is_empty())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2435,6 +2438,29 @@ fn build_spawn_req(
                 event_type::MCP_SERVERS_MISSING,
                 Some(exec_id),
                 &json!({ "mcp_servers": deliverables.missing_mcp_servers }),
+            );
+        }
+        // A by-name match that hit multiple same-named rows: the step ran
+        // against a deterministic pick (lowest id), but say so — the user may
+        // have meant a different one (warn-don't-fail).
+        if !deliverables.ambiguous_skills.is_empty() {
+            journal_event(
+                conn,
+                app,
+                run_id,
+                event_type::SKILLS_AMBIGUOUS,
+                Some(exec_id),
+                &json!({ "skills": deliverables.ambiguous_skills }),
+            );
+        }
+        if !deliverables.ambiguous_mcp_servers.is_empty() {
+            journal_event(
+                conn,
+                app,
+                run_id,
+                event_type::MCP_SERVERS_AMBIGUOUS,
+                Some(exec_id),
+                &json!({ "mcp_servers": deliverables.ambiguous_mcp_servers }),
             );
         }
     }
@@ -6388,19 +6414,25 @@ mod tests {
 
     #[test]
     fn build_spawn_req_blank_explicit_values_fall_back_to_custom_agent() {
-        // A blank explicit override (`""`, e.g. from a hand-authored/imported
-        // YAML) must not block the custom agent's value or reach spawn as an
-        // empty argument — it's treated as unset.
+        // A blank explicit override — empty *or* whitespace-only (both reachable
+        // from hand-authored/imported YAML) — must not block the custom agent's
+        // value or reach spawn as an empty argument; it's treated as unset.
         let conn = spawn_req_conn();
-        let mut spec = agent_spec(Some("ca1"));
-        spec.model = Some(String::new());
-        spec.effort = Some(String::new());
-        spec.instructions = Some(String::new());
         let dummy = Path::new("/tmp/repo");
-        let req = build_spawn_req(&conn, None, &spec, "base", dummy, dummy, "r", None);
-        assert_eq!(req.model.as_deref(), Some("opus"));
-        assert_eq!(req.effort.as_deref(), Some("high"));
-        assert_eq!(req.instructions.as_deref(), Some("Be thorough."));
+        for blank in ["", "   ", "\t\n"] {
+            let mut spec = agent_spec(Some("ca1"));
+            spec.model = Some(blank.to_string());
+            spec.effort = Some(blank.to_string());
+            spec.instructions = Some(blank.to_string());
+            let req = build_spawn_req(&conn, None, &spec, "base", dummy, dummy, "r", None);
+            assert_eq!(req.model.as_deref(), Some("opus"), "blank {blank:?}");
+            assert_eq!(req.effort.as_deref(), Some("high"), "blank {blank:?}");
+            assert_eq!(
+                req.instructions.as_deref(),
+                Some("Be thorough."),
+                "blank {blank:?}"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -2375,6 +2375,14 @@ async fn drive_child(c: ChildCtx, stage_entry_sha: Option<String>) -> ChildResul
 /// the step still spawns. Pass `warn_exec_id: None` when the req describes an
 /// already-spawned agent (`pre_spawned`) whose spawn call warned already. The
 /// blackboard write-grant is derived from `owner_run_id` at spawn.
+/// An explicit `AgentSpec` override, treating an empty string as unset so a
+/// blank `model`/`effort`/`instructions` in a hand-authored or imported spec
+/// falls back to the linked custom agent's value instead of spawning with an
+/// empty argument (matches the custom-agent side's empty→None normalization).
+fn nonblank(value: &Option<String>) -> Option<String> {
+    value.clone().filter(|s| !s.is_empty())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn build_spawn_req(
     conn: &Connection,
@@ -2439,12 +2447,15 @@ fn build_spawn_req(
         // fallback — and so a live custom-agent step spawns identically to the
         // same alias after YAML export+import (which inlines these onto the
         // AgentSpec via `embed_custom_agents`).
-        model: agent_spec.model.clone().or(deliverables.model.clone()),
-        effort: agent_spec.effort.clone().or(deliverables.effort.clone()),
-        instructions: agent_spec
-            .instructions
-            .clone()
-            .or(deliverables.instructions.clone()),
+        //
+        // A *blank* explicit value (`""`, e.g. from a hand-authored/imported
+        // YAML) is treated as unset, so it falls through to the custom agent's
+        // value rather than spawning with an empty argument. This matches the
+        // empty→None normalization the custom-agent side already applies (see
+        // `resolve_step_deliverables` / `embed_custom_agents`).
+        model: nonblank(&agent_spec.model).or(deliverables.model.clone()),
+        effort: nonblank(&agent_spec.effort).or(deliverables.effort.clone()),
+        instructions: nonblank(&agent_spec.instructions).or(deliverables.instructions.clone()),
         custom_agent_id: agent_spec.custom_agent.clone(),
         skills: deliverables.skills,
         mcp_servers: deliverables.mcp_servers,
@@ -6373,6 +6384,23 @@ mod tests {
         assert_eq!(req.model.as_deref(), Some("sonnet"));
         assert_eq!(req.effort.as_deref(), Some("low"));
         assert_eq!(req.instructions.as_deref(), Some("Override brief."));
+    }
+
+    #[test]
+    fn build_spawn_req_blank_explicit_values_fall_back_to_custom_agent() {
+        // A blank explicit override (`""`, e.g. from a hand-authored/imported
+        // YAML) must not block the custom agent's value or reach spawn as an
+        // empty argument — it's treated as unset.
+        let conn = spawn_req_conn();
+        let mut spec = agent_spec(Some("ca1"));
+        spec.model = Some(String::new());
+        spec.effort = Some(String::new());
+        spec.instructions = Some(String::new());
+        let dummy = Path::new("/tmp/repo");
+        let req = build_spawn_req(&conn, None, &spec, "base", dummy, dummy, "r", None);
+        assert_eq!(req.model.as_deref(), Some("opus"));
+        assert_eq!(req.effort.as_deref(), Some("high"));
+        assert_eq!(req.instructions.as_deref(), Some("Be thorough."));
     }
 
     #[test]

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -2386,10 +2386,13 @@ fn build_spawn_req(
     run_id: &str,
     warn_exec_id: Option<&str>,
 ) -> SpawnReq {
+    let mcp_server_names: Vec<String> =
+        agent_spec.mcp_servers.iter().map(|d| d.name.clone()).collect();
     let deliverables = super::definition::resolve_step_deliverables(
         conn,
         agent_spec.custom_agent.as_deref(),
         &agent_spec.skills,
+        &mcp_server_names,
         &agent_spec.base,
     );
     if let Some(exec_id) = warn_exec_id {
@@ -2428,6 +2431,10 @@ fn build_spawn_req(
         repo_path: repo.to_path_buf(),
         provider: agent_spec.base.clone(),
         model: agent_spec.model.clone(),
+        // The alias's explicit effort wins; otherwise inherit the linked custom
+        // agent's effort (§3.2). Resolved here rather than in the driver so the
+        // one place that reads the custom_agents row also owns the fallback.
+        effort: agent_spec.effort.clone().or(deliverables.effort.clone()),
         instructions: agent_spec.instructions.clone(),
         custom_agent_id: agent_spec.custom_agent.clone(),
         skills: deliverables.skills,
@@ -6329,8 +6336,10 @@ mod tests {
             super::super::spec::AgentSpec {
                 base: "codex".to_string(),
                 model: None,
+                effort: None,
                 instructions: None,
                 skills: vec![],
+                mcp_servers: vec![],
                 custom_agent: None,
             },
         );
@@ -6459,8 +6468,10 @@ mod tests {
             super::super::spec::AgentSpec {
                 base: "codex".to_string(),
                 model: None,
+                effort: None,
                 instructions: None,
                 skills: vec![],
+                mcp_servers: vec![],
                 custom_agent: None,
             },
         );
@@ -7201,8 +7212,10 @@ mod tests {
             super::super::spec::AgentSpec {
                 base: "codex".to_string(),
                 model: None,
+                effort: None,
                 instructions: None,
                 skills: vec![],
+                mcp_servers: vec![],
                 custom_agent: None,
             },
         );
@@ -7985,8 +7998,10 @@ mod tests {
             super::super::spec::AgentSpec {
                 base: "codex".to_string(),
                 model: None,
+                effort: None,
                 instructions: None,
                 skills: vec![],
+                mcp_servers: vec![],
                 custom_agent: None,
             },
         );
@@ -8825,8 +8840,10 @@ mod tests {
             super::super::spec::AgentSpec {
                 base: "codex".to_string(),
                 model: None,
+                effort: None,
                 instructions: None,
                 skills: vec![],
+                mcp_servers: vec![],
                 custom_agent: None,
             },
         );
@@ -9377,8 +9394,10 @@ mod tests {
                 super::super::spec::AgentSpec {
                     base: "codex".to_string(),
                     model: None,
+                    effort: None,
                     instructions: None,
                     skills: vec![],
+                    mcp_servers: vec![],
                     custom_agent: None,
                 },
             );
@@ -10009,8 +10028,10 @@ mod tests {
                 super::super::spec::AgentSpec {
                     base: "codex".to_string(),
                     model: None,
+                    effort: None,
                     instructions: None,
                     skills: vec![],
+                    mcp_servers: vec![],
                     custom_agent: None,
                 },
             );

--- a/src-tauri/src/workflow/spec.rs
+++ b/src-tauri/src/workflow/spec.rs
@@ -53,12 +53,53 @@ pub struct AgentSpec {
     pub base: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+    /// Reasoning effort (`low`/`medium`/`high`), applied at step spawn the same
+    /// way a session's `--effort` is. `None` inherits the linked custom agent's
+    /// effort (if any), then the provider CLI default (spec §11 / §3.2). Left
+    /// free-form and unvalidated, exactly like `model`: an unknown value is the
+    /// provider's problem, not a spec violation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub skills: Vec<String>,
+    /// MCP servers this agent attaches, embedded *by definition* for portability
+    /// (spec §5.3). Skills travel as bare names (resolved against the importer's
+    /// library), but a shared file can't assume the importer already has an MCP
+    /// server, so its transport/command/url and env/header KEY NAMES travel with
+    /// the export. Secret values never leave this machine — the importer
+    /// recreates the server and supplies them. At spawn these resolve by `name`
+    /// against the local `mcp_servers` library (the warn-don't-fail path skills
+    /// use). Empty for a locally-built definition whose MCP comes via a linked
+    /// `custom_agent`; populated by export (`embed_custom_agents`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mcp_servers: Vec<McpServerDef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_agent: Option<String>,
+}
+
+/// An MCP server embedded in a shared workflow (spec §5.3): the `mcp_servers`
+/// registry row minus its local id/timestamps and minus every secret value —
+/// only env/header KEY NAMES are exported, so a leaked file can never carry a
+/// token. The importer reconciles by `name` against its local library and
+/// re-enters the values.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct McpServerDef {
+    pub name: String,
+    /// `stdio` | `http`. Left free-form for forward-compatibility.
+    pub transport: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub command: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub url: String,
+    /// Env var names only (no values — those are secrets). The importer supplies
+    /// values when recreating the server locally.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env_keys: Vec<String>,
+    /// HTTP header names only (no values — secrets, same policy as `env_keys`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub header_keys: Vec<String>,
 }
 
 /// A control-flow node (spec §5.1). Serialized externally tagged for JSON
@@ -525,8 +566,10 @@ mod tests {
             AgentSpec {
                 base: "claude".into(),
                 model: None,
+                effort: None,
                 instructions: None,
                 skills: vec![],
+                mcp_servers: vec![],
                 custom_agent: None,
             },
         );

--- a/src-tauri/src/workflow/types.rs
+++ b/src-tauri/src/workflow/types.rs
@@ -137,6 +137,17 @@ pub mod event_type {
     /// the step spawned without that agent's skills and MCP servers. Carries
     /// the unresolved id; the step still runs.
     pub const CUSTOM_AGENT_MISSING: &str = "custom_agent_missing";
+    /// A by-name skill reference matched more than one library row (names are
+    /// not unique). The step still runs against a deterministic pick (lowest
+    /// id); the event carries the ambiguous names so the timeline is honest
+    /// about which of several same-named skills was chosen.
+    pub const SKILLS_AMBIGUOUS: &str = "skills_ambiguous";
+    /// A by-name MCP server reference matched more than one library row (names
+    /// are not unique). The step still runs against a deterministic pick
+    /// (lowest id); the event carries the ambiguous names. Only the by-name
+    /// path (imported/spec-level servers) can be ambiguous — custom-agent
+    /// assignments resolve by unique id.
+    pub const MCP_SERVERS_AMBIGUOUS: &str = "mcp_servers_ambiguous";
     pub const ATTEMPT_READY: &str = "attempt_ready";
     pub const PROMPT_SENT: &str = "prompt_sent";
     pub const TURN_ENDED: &str = "turn_ended";

--- a/src-tauri/src/workflow/yaml.rs
+++ b/src-tauri/src/workflow/yaml.rs
@@ -294,6 +294,12 @@ pub fn build_import_report(
     let mut warnings = Vec::new();
     let mut agents = Vec::new();
 
+    // Library names aren't unique; a reference that matches more than one row is
+    // ambiguous — the spawn path binds a deterministic pick (lowest id), but the
+    // user may have meant a different one, so flag it here too (spec §5.3,
+    // warn-don't-fail — mirrors the `*_ambiguous` journal events at spawn).
+    let count = |list: &[String], name: &str| list.iter().filter(|s| s.as_str() == name).count();
+
     for (alias, agent) in spec.agents.iter_mut() {
         if !KNOWN_PROVIDERS.contains(&agent.base.as_str()) {
             warnings.push(format!(
@@ -304,6 +310,12 @@ pub fn build_import_report(
         let mut kept = Vec::new();
         for skill in std::mem::take(&mut agent.skills) {
             if local_skills.iter().any(|s| s == &skill) {
+                if count(local_skills, &skill) > 1 {
+                    warnings.push(format!(
+                        "agent '{alias}' references skill '{skill}', which matches multiple \
+                         skills in your library; the first (lowest id) will be used"
+                    ));
+                }
                 kept.push(skill);
             } else {
                 warnings.push(format!(
@@ -325,6 +337,12 @@ pub fn build_import_report(
                     "agent '{alias}' references MCP server '{}' (transport: {}), which isn't \
                      in your library; recreate it with its secret values to attach it",
                     server.name, server.transport
+                ));
+            } else if count(local_mcp_servers, &server.name) > 1 {
+                warnings.push(format!(
+                    "agent '{alias}' references MCP server '{}', which matches multiple servers \
+                     in your library; the first (lowest id) will be used",
+                    server.name
                 ));
             }
         }
@@ -543,6 +561,55 @@ finalize: { push: true, open_pr: true, pr_base: main }
         // With the server present locally, no warning.
         let quiet = build_import_report(spec, &["code-review".into()], &["gh".into()], &[]);
         assert!(!quiet.warnings.iter().any(|w| w.contains("MCP server 'gh'")));
+    }
+
+    #[test]
+    fn import_warns_on_ambiguous_duplicate_names() {
+        use super::super::spec::McpServerDef;
+        let mut spec = from_yaml(CANONICAL).unwrap();
+        // `reviewer` already references skill `code-review`; give `coder` an MCP
+        // server named `gh`.
+        spec.agents.get_mut("coder").unwrap().mcp_servers = vec![McpServerDef {
+            name: "gh".into(),
+            transport: "stdio".into(),
+            command: "npx -y gh-mcp".into(),
+            url: String::new(),
+            env_keys: vec![],
+            header_keys: vec![],
+        }];
+        // Two local skills named `code-review` and two servers named `gh`: both
+        // references resolve but are ambiguous → a "matches multiple" warning
+        // each, and nothing is dropped.
+        let report = build_import_report(
+            spec.clone(),
+            &["code-review".into(), "code-review".into()],
+            &["gh".into(), "gh".into()],
+            &[],
+        );
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|w| w.contains("skill 'code-review'") && w.contains("matches multiple")),
+            "{:?}",
+            report.warnings
+        );
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|w| w.contains("MCP server 'gh'") && w.contains("matches multiple")),
+            "{:?}",
+            report.warnings
+        );
+        assert_eq!(report.spec.agents["reviewer"].skills, vec!["code-review"]);
+
+        // Unique local names → no ambiguity warnings.
+        let quiet = build_import_report(spec, &["code-review".into()], &["gh".into()], &[]);
+        assert!(!quiet
+            .warnings
+            .iter()
+            .any(|w| w.contains("matches multiple")));
     }
 
     #[test]

--- a/src-tauri/src/workflow/yaml.rs
+++ b/src-tauri/src/workflow/yaml.rs
@@ -288,6 +288,7 @@ pub struct AgentResolution {
 pub fn build_import_report(
     mut spec: Spec,
     local_skills: &[String],
+    local_mcp_servers: &[String],
     local_agents: &[LocalAgent],
 ) -> ImportReport {
     let mut warnings = Vec::new();
@@ -312,6 +313,21 @@ pub fn build_import_report(
             }
         }
         agent.skills = kept;
+
+        // MCP servers reconcile by *name*, warn-don't-fail (spec §5.3). Unlike
+        // skills we keep the embedded def rather than drop it: it carries the
+        // transport/command/url and env/header key names the user needs to
+        // recreate the server locally (its secret values never travelled). Once
+        // a same-named server exists, the workflow attaches it at spawn.
+        for server in &agent.mcp_servers {
+            if !local_mcp_servers.iter().any(|s| s == &server.name) {
+                warnings.push(format!(
+                    "agent '{alias}' references MCP server '{}' (transport: {}), which isn't \
+                     in your library; recreate it with its secret values to attach it",
+                    server.name, server.transport
+                ));
+            }
+        }
 
         agents.push(AgentResolution {
             alias: alias.clone(),
@@ -484,6 +500,52 @@ finalize: { push: true, open_pr: true, pr_base: main }
     }
 
     #[test]
+    fn agent_effort_and_mcp_defs_round_trip() {
+        use super::super::spec::McpServerDef;
+        let mut spec = from_yaml(CANONICAL).unwrap();
+        let coder = spec.agents.get_mut("coder").unwrap();
+        coder.effort = Some("high".into());
+        coder.mcp_servers = vec![McpServerDef {
+            name: "gh".into(),
+            transport: "stdio".into(),
+            command: "npx -y gh-mcp".into(),
+            url: String::new(),
+            env_keys: vec!["TOKEN".into()],
+            header_keys: vec![],
+        }];
+        let yaml = to_yaml(&spec).unwrap();
+        assert!(yaml.contains("effort: high"), "{yaml}");
+        assert!(yaml.contains("env_keys"), "{yaml}");
+        let back = from_yaml(&yaml).unwrap();
+        assert_eq!(spec, back, "effort + mcp defs must round-trip");
+    }
+
+    #[test]
+    fn import_warns_on_mcp_server_not_in_library() {
+        use super::super::spec::McpServerDef;
+        let mut spec = from_yaml(CANONICAL).unwrap();
+        spec.agents.get_mut("coder").unwrap().mcp_servers = vec![McpServerDef {
+            name: "gh".into(),
+            transport: "stdio".into(),
+            command: "npx -y gh-mcp".into(),
+            url: String::new(),
+            env_keys: vec![],
+            header_keys: vec![],
+        }];
+        // No local MCP server named 'gh' → a warning, and the def is kept (not
+        // dropped like a missing skill).
+        let report = build_import_report(spec.clone(), &["code-review".into()], &[], &[]);
+        assert!(report
+            .warnings
+            .iter()
+            .any(|w| w.contains("MCP server 'gh'") && w.contains("isn't")));
+        assert_eq!(report.spec.agents["coder"].mcp_servers.len(), 1);
+        // With the server present locally, no warning.
+        let quiet = build_import_report(spec, &["code-review".into()], &["gh".into()], &[]);
+        assert!(!quiet.warnings.iter().any(|w| w.contains("MCP server 'gh'")));
+    }
+
+    #[test]
     fn nested_orchestrate_fails_to_parse() {
         // orchestrate.body children must be steps; a nested orchestrate map has
         // no `step:` key, so parsing rejects it (spec §5.2 nesting rule).
@@ -537,7 +599,7 @@ workflow:
     fn import_of_unknown_skill_warns_not_errors() {
         let spec = from_yaml(CANONICAL).unwrap();
         // No skills installed locally → `code-review` (on `reviewer`) is dropped.
-        let report = build_import_report(spec, &[], &[]);
+        let report = build_import_report(spec, &[], &[], &[]);
         assert!(report
             .warnings
             .iter()
@@ -554,7 +616,7 @@ workflow:
             id: "ca-1".into(),
             name: "planner".into(),
         }];
-        let report = build_import_report(spec, &["code-review".to_string()], &locals);
+        let report = build_import_report(spec, &["code-review".to_string()], &[], &locals);
         assert!(report.warnings.is_empty(), "{:?}", report.warnings);
         assert_eq!(
             report.spec.agents["reviewer"].skills,
@@ -578,7 +640,7 @@ workflow:
     goal: go
 "#;
         let spec = from_yaml(yaml).unwrap();
-        let report = build_import_report(spec, &[], &[]);
+        let report = build_import_report(spec, &[], &[], &[]);
         assert!(report
             .warnings
             .iter()

--- a/src/starterPack/index.ts
+++ b/src/starterPack/index.ts
@@ -1,0 +1,9 @@
+export type { InstallDeps, InstallResult } from "./install";
+export { installStarterPack } from "./install";
+export type { AgentPreset } from "./presets";
+export {
+  buildFeaturePipelineSpec,
+  STARTER_AGENTS,
+  STARTER_WORKFLOW_HUE,
+  STARTER_WORKFLOW_NAME,
+} from "./presets";

--- a/src/starterPack/install.test.ts
+++ b/src/starterPack/install.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CustomAgent, NewCustomAgent } from "@/storage/customAgents";
+import type { Definition, Spec } from "@/workflows/spec";
+import { installStarterPack } from "./install";
+import { STARTER_AGENTS, STARTER_WORKFLOW_NAME } from "./presets";
+
+function fakeAgent(name: string, id: string): CustomAgent {
+  return {
+    id,
+    name,
+    description: "",
+    color: 0,
+    base: "claude",
+    model: null,
+    effort: null,
+    instructions: "",
+    skillIds: [],
+    mcpServerIds: [],
+    created_at: 0,
+    updated_at: 0,
+  };
+}
+
+function deps(existingAgents: CustomAgent[], existingDefinitions: Definition[]) {
+  const saved: Spec[] = [];
+  let seq = 0;
+  const createAgent = vi.fn(async (a: NewCustomAgent) => fakeAgent(a.name, `new-${seq++}`));
+  const saveDefinition = vi.fn(async (spec: Spec) => {
+    saved.push(spec);
+  });
+  return {
+    d: { existingAgents, createAgent, existingDefinitions, saveDefinition },
+    saved,
+  };
+}
+
+describe("installStarterPack", () => {
+  it("seeds all four agents and the workflow on a clean library", async () => {
+    const { d, saved } = deps([], []);
+    const res = await installStarterPack(d);
+
+    expect(res.agentsCreated).toEqual(["Architect", "Coder", "Reviewer", "Tester"]);
+    expect(res.agentsSkipped).toEqual([]);
+    expect(res.workflowCreated).toBe(true);
+    expect(d.createAgent).toHaveBeenCalledTimes(4);
+
+    const spec = saved[0];
+    expect(spec.name).toBe(STARTER_WORKFLOW_NAME);
+    // Every alias is wired to a freshly created custom-agent id.
+    for (const alias of Object.values(spec.agents)) {
+      expect(alias.custom_agent).toMatch(/^new-\d+$/);
+    }
+    // Architect → implement → parallel[review, test] → ship.
+    expect(spec.workflow.length).toBe(4);
+    expect("parallel" in spec.workflow[2]).toBe(true);
+  });
+
+  it("is idempotent: reuses existing agents by name and skips an existing workflow", async () => {
+    const existingAgents = STARTER_AGENTS.map((a, i) => fakeAgent(a.preset.name, `old-${i}`));
+    const existingDef = {
+      id: "wf-1",
+      name: STARTER_WORKFLOW_NAME,
+      description: "",
+      hue: null,
+      spec: {} as Spec,
+      run_count: 0,
+      created_at: 0,
+      updated_at: 0,
+    } satisfies Definition;
+
+    const { d } = deps(existingAgents, [existingDef]);
+    const res = await installStarterPack(d);
+
+    expect(res.agentsCreated).toEqual([]);
+    expect(res.agentsSkipped).toEqual(["Architect", "Coder", "Reviewer", "Tester"]);
+    expect(res.workflowCreated).toBe(false);
+    expect(d.createAgent).not.toHaveBeenCalled();
+    expect(d.saveDefinition).not.toHaveBeenCalled();
+  });
+
+  it("wires the workflow to existing agent ids even when only the workflow is missing", async () => {
+    const existingAgents = STARTER_AGENTS.map((a, i) => fakeAgent(a.preset.name, `old-${i}`));
+    const { d, saved } = deps(existingAgents, []);
+    const res = await installStarterPack(d);
+
+    expect(res.agentsSkipped.length).toBe(4);
+    expect(res.workflowCreated).toBe(true);
+    const ids = Object.values(saved[0].agents).map((a) => a.custom_agent);
+    expect(ids).toEqual(["old-0", "old-1", "old-2", "old-3"]);
+  });
+});

--- a/src/starterPack/install.ts
+++ b/src/starterPack/install.ts
@@ -1,0 +1,63 @@
+// Starter pack installer — seeds the four specialist custom agents and the
+// "Feature pipeline" workflow. Idempotent: it matches existing items by name
+// and skips them, so re-installing never duplicates. Deliberately explicit
+// (invoked from a Settings affordance), never run silently on launch.
+
+import type { CustomAgent, NewCustomAgent } from "@/storage/customAgents";
+import type { Definition, Spec } from "@/workflows/spec";
+import {
+  buildFeaturePipelineSpec,
+  STARTER_AGENTS,
+  STARTER_WORKFLOW_HUE,
+  STARTER_WORKFLOW_NAME,
+} from "./presets";
+
+/** The library surface the installer needs — passed in so the flow stays
+ *  testable and decoupled from the store/api singletons. */
+export interface InstallDeps {
+  /** Current custom agents (for the by-name skip). */
+  existingAgents: CustomAgent[];
+  /** Persist one new custom agent, returning the created row (with its id). */
+  createAgent: (agent: NewCustomAgent) => Promise<CustomAgent>;
+  /** Current workflow definitions (for the by-name skip). */
+  existingDefinitions: Definition[];
+  /** Persist a workflow definition. */
+  saveDefinition: (spec: Spec, hue: number) => Promise<unknown>;
+}
+
+export interface InstallResult {
+  agentsCreated: string[];
+  agentsSkipped: string[];
+  workflowCreated: boolean;
+}
+
+/** Seed the starter pack. Creates any of the four specialists missing by name,
+ *  reuses those already present, then creates the "Feature pipeline" workflow
+ *  (wired to whichever agent ids resulted) unless a workflow of that name
+ *  already exists. */
+export async function installStarterPack(deps: InstallDeps): Promise<InstallResult> {
+  const agentsCreated: string[] = [];
+  const agentsSkipped: string[] = [];
+  const idByRole: Record<string, string> = {};
+
+  for (const { role, preset } of STARTER_AGENTS) {
+    const existing = deps.existingAgents.find((a) => a.name === preset.name);
+    if (existing) {
+      idByRole[role] = existing.id;
+      agentsSkipped.push(preset.name);
+      continue;
+    }
+    const created = await deps.createAgent(preset);
+    idByRole[role] = created.id;
+    agentsCreated.push(preset.name);
+  }
+
+  let workflowCreated = false;
+  const workflowExists = deps.existingDefinitions.some((d) => d.name === STARTER_WORKFLOW_NAME);
+  if (!workflowExists) {
+    await deps.saveDefinition(buildFeaturePipelineSpec(idByRole), STARTER_WORKFLOW_HUE);
+    workflowCreated = true;
+  }
+
+  return { agentsCreated, agentsSkipped, workflowCreated };
+}

--- a/src/starterPack/presets.ts
+++ b/src/starterPack/presets.ts
@@ -1,0 +1,181 @@
+// Starter pack presets — the four named specialists (Architect / Coder /
+// Reviewer / Tester) and the "Feature pipeline" workflow that composes them.
+//
+// This is data, not behavior: the install flow (see ./install.ts) seeds these
+// into the local library idempotently. Each agent is a base "claude" preset
+// with a distinct hue and a standing brief; the workflow references them by
+// their local custom-agent ids, resolved at install time.
+
+import type { NewCustomAgent } from "@/storage/customAgents";
+import type { Spec } from "@/workflows/spec";
+import { SPEC_VERSION } from "@/workflows/spec";
+
+/** A specialist preset: everything a `NewCustomAgent` needs, keyed by its
+ *  stable role so the workflow builder can wire aliases to the seeded ids. */
+export interface AgentPreset {
+  /** Stable role key and the agent's display name (they match on purpose). */
+  role: "Architect" | "Coder" | "Reviewer" | "Tester";
+  preset: NewCustomAgent;
+}
+
+const base = "claude";
+
+export const STARTER_AGENTS: AgentPreset[] = [
+  {
+    role: "Architect",
+    preset: {
+      name: "Architect",
+      description: "Plans work into small, testable slices",
+      color: 265,
+      base,
+      model: null,
+      effort: "high",
+      instructions: `You are a senior software architect. Turn a feature request into a concrete, low-risk plan — do not write the implementation.
+
+- Read the relevant code before proposing anything; ground the plan in what exists.
+- Break the work into small, independently testable slices, ordered by dependency.
+- Call out edge cases, data migrations, and backward-compatibility concerns explicitly.
+- Prefer the simplest design that solves the problem; note where complexity is deferred.
+- Reuse existing patterns and utilities instead of inventing new ones.
+- Write the plan to PLAN.md: a short summary, the slices in order, and the risks.
+- The plan is your only deliverable — do not change production code.`,
+      skillIds: [],
+      mcpServerIds: [],
+    },
+  },
+  {
+    role: "Coder",
+    preset: {
+      name: "Coder",
+      description: "Implements slices cleanly and commits",
+      color: 150,
+      base,
+      model: null,
+      effort: null,
+      instructions: `You are a careful implementation engineer. Take the plan and turn it into working, committed code.
+
+- Follow the repo's existing style, structure, and naming conventions.
+- Implement one slice at a time; keep each change focused and reviewable.
+- Reuse existing helpers and components; do not duplicate logic.
+- Add or update tests alongside the code you change.
+- Run the project's build/lint/tests before you consider a slice done.
+- Commit your work with a clear, conventional commit message.
+- If the plan is wrong or incomplete, fix the smallest thing needed and note it — don't gold-plate.`,
+      skillIds: [],
+      mcpServerIds: [],
+    },
+  },
+  {
+    role: "Reviewer",
+    preset: {
+      name: "Reviewer",
+      description: "Reviews the diff for correctness and risk",
+      color: 25,
+      base,
+      model: null,
+      effort: "high",
+      instructions: `You are a rigorous code reviewer. Review the full diff against the run's base branch.
+
+- Correctness first: logic errors, unhandled edge cases, race conditions, broken invariants.
+- Check security and data-safety, especially around input handling and persistence.
+- Flag missing or weak tests for the behavior that changed.
+- Note reuse and simplification opportunities, but keep them separate from blocking issues.
+- Be concrete: cite the file and line, and say what would falsify your concern.
+- Write verdict.json with result "done" when the change is sound, or "revise" with specific, actionable feedback.`,
+      skillIds: [],
+      mcpServerIds: [],
+    },
+  },
+  {
+    role: "Tester",
+    preset: {
+      name: "Tester",
+      description: "Exercises the change and runs the tests",
+      color: 215,
+      base,
+      model: null,
+      effort: null,
+      instructions: `You are a testing specialist. Verify the change actually does what it should — end to end, not just on paper.
+
+- Run the project's full test suite and report failures precisely.
+- Add tests for behavior that changed and for edge cases the author missed.
+- Where practical, exercise the real flow the change touches, not only unit tests.
+- Distinguish pre-existing failures from ones this change introduced.
+- Keep tests deterministic and fast; avoid flaky sleeps and network dependence.
+- The tests gate passes only when the project test command exits cleanly.`,
+      skillIds: [],
+      mcpServerIds: [],
+    },
+  },
+];
+
+/** The starter workflow's name — the idempotency key the installer matches on. */
+export const STARTER_WORKFLOW_NAME = "Feature pipeline";
+
+/** The hue used for the seeded workflow card. */
+export const STARTER_WORKFLOW_HUE = 265;
+
+/** Build the "Feature pipeline" spec, wiring each alias to the seeded custom
+ *  agent's local id (`idByRole`). Architect → Coder → Parallel[Reviewer,
+ *  Tester] → an approval-gated ship step, ending in push + open PR. */
+export function buildFeaturePipelineSpec(idByRole: Record<string, string>): Spec {
+  const alias = (role: string) => ({ base, custom_agent: idByRole[role] });
+  return {
+    version: SPEC_VERSION,
+    name: STARTER_WORKFLOW_NAME,
+    description: "Plan, implement, then review and test in parallel before an approved ship.",
+    agents: {
+      architect: alias("Architect"),
+      coder: alias("Coder"),
+      reviewer: alias("Reviewer"),
+      tester: alias("Tester"),
+    },
+    workflow: [
+      {
+        step: {
+          id: "plan",
+          agent: "architect",
+          goal: "Analyze the task and write PLAN.md describing small, independently testable slices in dependency order.",
+          gate: { type: "artifact", path: "PLAN.md" },
+        },
+      },
+      {
+        step: {
+          id: "implement",
+          agent: "coder",
+          goal: "Implement the slices from PLAN.md with tests, following the repo's conventions. Commit the work.",
+          gate: { type: "commit" },
+        },
+      },
+      {
+        parallel: {
+          join: "all",
+          integrate: "none",
+          steps: [
+            {
+              id: "review",
+              agent: "reviewer",
+              goal: "Review the full diff vs the run base. Write verdict.json with result done or revise plus concrete feedback.",
+              gate: { type: "verdict" },
+            },
+            {
+              id: "test",
+              agent: "tester",
+              goal: "Run the project's tests and add coverage for the change. The step passes only when tests are green.",
+              gate: { type: "tests" },
+            },
+          ],
+        },
+      },
+      {
+        step: {
+          id: "ship",
+          agent: "coder",
+          goal: "Address review and test feedback, then prepare the change for merge. Waits for human approval.",
+          gate: { type: "approval" },
+        },
+      },
+    ],
+    finalize: { push: true, open_pr: true },
+  };
+}

--- a/src/workflows/builder/WorkflowList.tsx
+++ b/src/workflows/builder/WorkflowList.tsx
@@ -95,6 +95,8 @@ export function WorkflowList({
   onDelete,
   onExport,
   onImport,
+  onInstallStarter,
+  installing,
 }: {
   definitions: Definition[];
   loading: boolean;
@@ -106,6 +108,9 @@ export function WorkflowList({
   onDelete: (id: string) => void;
   onExport: (d: Definition) => void;
   onImport: () => void;
+  /** Seed the specialist starter pack; `undefined` once it's already installed. */
+  onInstallStarter?: () => void;
+  installing?: boolean;
 }) {
   return (
     <div className="set-pane">
@@ -120,6 +125,12 @@ export function WorkflowList({
           {definitions.length} workflow{definitions.length === 1 ? "" : "s"}
         </span>
         <div className="wf-list-acts">
+          {onInstallStarter && (
+            <button className="btn-t" onClick={onInstallStarter} disabled={installing}>
+              <Icon name="sparkle" size={13} />{" "}
+              {installing ? "Installing…" : "Install starter pack"}
+            </button>
+          )}
           <button className="btn-t" onClick={onImport}>
             <Icon name="upload" size={13} /> Import
           </button>
@@ -178,12 +189,36 @@ export function WorkflowList({
           </div>
         )}
         {!loading && definitions.length === 0 && (
-          <button className="wb-add" style={{ width: "100%", minHeight: 120 }} onClick={onNew}>
-            <span className="wb-add-ic">
-              <Icon name="plus" />
-            </span>
-            <span className="wb-add-l">Create your first workflow</span>
-          </button>
+          <>
+            {onInstallStarter && (
+              <button
+                className="wf-card wf-starter-card"
+                onClick={onInstallStarter}
+                disabled={installing}
+              >
+                <div className="wf-card-h">
+                  <span className="wf-starter-ic">
+                    <Icon name="sparkle" />
+                  </span>
+                  <div style={{ flex: 1, minWidth: 0, textAlign: "left" }}>
+                    <div className="wf-name">
+                      {installing ? "Installing starter pack…" : "Install the starter pack"}
+                    </div>
+                    <div className="wf-desc">
+                      Seeds four specialist agents — Architect, Coder, Reviewer, Tester — and a
+                      ready-to-run Feature pipeline that chains them.
+                    </div>
+                  </div>
+                </div>
+              </button>
+            )}
+            <button className="wb-add" style={{ width: "100%", minHeight: 120 }} onClick={onNew}>
+              <span className="wb-add-ic">
+                <Icon name="plus" />
+              </span>
+              <span className="wb-add-l">Create your first workflow</span>
+            </button>
+          </>
         )}
       </div>
     </div>

--- a/src/workflows/builder/index.tsx
+++ b/src/workflows/builder/index.tsx
@@ -4,6 +4,7 @@
 
 import { useEffect, useState } from "react";
 import { api } from "../../api";
+import { installStarterPack, STARTER_WORKFLOW_NAME } from "../../starterPack";
 import { useAppStore } from "../../store";
 import type { Definition, ImportReport, Spec } from "../spec";
 import { ImportDialog } from "./ImportDialog";
@@ -16,11 +17,13 @@ type Editing = { state: EditorState; isNew: boolean };
 
 export function WorkflowsPane() {
   const agents = useAppStore((s) => s.customAgents);
+  const createCustomAgent = useAppStore((s) => s.createCustomAgent);
   const modelsByAgent = useAppStore((s) => s.modelsByAgent);
   const setLastError = useAppStore((s) => s.setLastError);
 
   const [definitions, setDefinitions] = useState<Definition[]>([]);
   const [loading, setLoading] = useState(true);
+  const [installing, setInstalling] = useState(false);
   const [editing, setEditing] = useState<Editing | null>(null);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -84,6 +87,27 @@ export function WorkflowsPane() {
     setSaveError(null);
     setEditing(next);
   };
+
+  // Seed the specialist bundle (four custom agents + the Feature pipeline
+  // workflow). Idempotent — re-running skips anything already present by name.
+  const installStarter = async () => {
+    setInstalling(true);
+    try {
+      await installStarterPack({
+        existingAgents: agents,
+        createAgent: createCustomAgent,
+        existingDefinitions: definitions,
+        saveDefinition: (spec, hue) => api.wfDefSave(spec, undefined, hue),
+      });
+      await reload();
+    } catch (e) {
+      setLastError(`Failed to install the starter pack: ${e}`);
+    } finally {
+      setInstalling(false);
+    }
+  };
+
+  const hasStarter = definitions.some((d) => d.name === STARTER_WORKFLOW_NAME);
 
   const exportDef = async (d: Definition) => {
     try {
@@ -149,6 +173,8 @@ export function WorkflowsPane() {
         onDelete={remove}
         onExport={exportDef}
         onImport={startImport}
+        onInstallStarter={hasStarter ? undefined : installStarter}
+        installing={installing}
       />
       {importReport && (
         <ImportDialog

--- a/src/workflows/spec.ts
+++ b/src/workflows/spec.ts
@@ -33,12 +33,34 @@ export interface Budgets {
   tests_timeout_secs?: number;
 }
 
+/** An MCP server embedded in a shared workflow (spec §5.3): the registry row
+ *  minus its local id/timestamps and minus every secret value — only env/header
+ *  KEY NAMES travel, so a shared file can never carry a token. The importer
+ *  reconciles by `name` against its local library and re-enters the values. */
+export interface McpServerDef {
+  name: string;
+  /** "stdio" | "http". */
+  transport: string;
+  command?: string;
+  url?: string;
+  /** Env var names only (values are secrets, never exported). */
+  env_keys?: string[];
+  /** HTTP header names only (values are secrets, never exported). */
+  header_keys?: string[];
+}
+
 /** A configured agent. `custom_agent` is a local id, never exported (spec §5.3). */
 export interface AgentSpec {
   base: ProviderBase;
   model?: string;
+  /** Reasoning effort (low/medium/high) applied at step spawn; inherits the
+   *  linked custom agent's effort when unset (spec §3.2). */
+  effort?: string;
   instructions?: string;
   skills?: string[];
+  /** MCP servers embedded by definition for portability; resolved by name
+   *  against the local library at spawn (spec §5.3). */
+  mcp_servers?: McpServerDef[];
   custom_agent?: string;
 }
 

--- a/src/workflows/workflows.css
+++ b/src/workflows/workflows.css
@@ -74,6 +74,28 @@
   border-color: var(--bd-strong);
   background: var(--hover);
 }
+/* Starter-pack empty-state card: a dashed, accent-tinted call to action. */
+.wf-starter-card {
+  width: 100%;
+  cursor: pointer;
+  border-style: dashed;
+  border-color: var(--bd-strong);
+}
+.wf-starter-card:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+.wf-starter-ic {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  flex: none;
+  border-radius: var(--r-md);
+  background: color-mix(in oklch, var(--accent) 16%, transparent);
+  color: var(--accent);
+}
 .wf-card-h {
   display: flex;
   align-items: flex-start;


### PR DESCRIPTION
## Summary

Tightens "specialist agent bundles" so named specialists are a durable, first-class composition — plus a real bug fix found along the way.

- **Fix: Skills/MCP settings panes were broken.** The `skills` and `mcp_servers` tables (migration 0017) were missing from `ALLOWED_TABLES`, so every generic-layer CRUD call was rejected as "unknown table". Added to the allowlist with a regression test.
- **`AgentSpec.effort`**: workflow steps can now carry reasoning effort (previously the driver hardcoded `None` for every step, even custom-agent-backed ones). Explicit alias effort wins, else it inherits the linked custom agent's effort. YAML round-trips.
- **MCP servers in YAML export/import**: `embed_custom_agents` previously dropped MCP assignments silently. Exports now embed transport/command/url plus env/header **key names only** — secret values never leave the machine. Import reconciles by name, warn-don't-fail; spawn resolves against the local library with real local values.
- **Starter pack**: installable from the Workflows pane (header button + empty-state card, idempotent by name) — four specialists (Architect, Coder, Reviewer, Tester) and a "Feature pipeline" workflow: plan[artifact] → implement[commit] → parallel[review[verdict], test[tests]] → ship[approval], finalize push+PR.

## Testing

- `cargo check --tests` clean; `cargo test` workflow+database: 265 passed
- `tsc --noEmit` clean; biome clean; vitest 450 passed (incl. 3 new installer tests)

## Notes

Pre-existing inconsistency flagged for follow-up (not addressed here): a custom agent's model/instructions are still not applied at live workflow spawn — only skills/MCP/effort/identity are — while the export path embeds them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)