### PR TITLE
docs(isolation): canonical isolation doc, site checklist, and terminology sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Fletch ships two isolation engines. The guarantee is the same under both: an age
 
 Under both engines, workspaces are full shared-object clones, so an agent's writable `.git` lives entirely inside its sandbox; your repo's `.git` is never writable by an agent. Pushes and PR creation run host-side through a brokered RPC: credentials never enter the sandbox, but these ops currently run without a confirmation prompt, so an agent can publish code under your identity. Choose tasks and repos accordingly.
 
-The code is canonical: [`sandbox/seatbelt.rs`](src-tauri/src/sandbox/seatbelt.rs), [`sandbox/docker/`](src-tauri/src/sandbox/docker), and [`sandbox/provision.rs`](src-tauri/src/sandbox/provision.rs), with the full write-up in the [docs](https://fletch.sh/docs).
+The full write-up is [`docs/isolation.md`](docs/isolation.md) — the canonical, code-accurate account of both engines, the clone model, and the honest threat model. The code is canonical too: [`sandbox/seatbelt.rs`](src-tauri/src/sandbox/seatbelt.rs), [`sandbox/docker/`](src-tauri/src/sandbox/docker), and [`sandbox/provision.rs`](src-tauri/src/sandbox/provision.rs).
 
 ## Documentation
 

--- a/docs/isolation-site-checklist.md
+++ b/docs/isolation-site-checklist.md
@@ -1,0 +1,110 @@
+# Isolation site-correction checklist
+
+The external site and marketing surfaces (**fletch.sh**, its `/docs`, and
+`llms.txt`) live outside this repository, so this repo can't edit them. This
+checklist enumerates the claims those surfaces must align to. The canonical
+source is [`docs/isolation.md`](./isolation.md) in this repo; if the site
+disagrees with the code, the code wins and the site is stale.
+
+Each item is phrased as **"the site must say X; if it says Y, it's stale"** so a
+person or agent with site access can execute it mechanically. Prior analysis
+found `llms.txt` describing isolation as a **"worktree"** — treat that as the
+**primary known error** and hunt every instance of it first.
+
+## How to execute
+
+1. Grep the site content (pages, MDX, `llms.txt`, meta descriptions, OG copy)
+   for: `worktree`, `work tree`, `No Docker`, `no containers`, `VM`, `virtual
+   machine`, `network`, `credential`, `token`.
+2. For each hit, apply the matching item below.
+3. Verify nothing else claims an isolation model Fletch doesn't implement (e.g.
+   "runs in a VM", "fully sandboxed reads", "confirms before pushing").
+
+## The claims the site must align to
+
+### 1. Terminology: clone, not worktree (primary known error)
+
+- **Must say:** each agent works in an isolated **clone** of your repo (a
+  self-contained git checkout with its own writable `.git`); the on-disk root is
+  `~/.fletch/workspaces/<id>/`.
+- **Stale if it says:** each agent gets a **git worktree**; Fletch uses linked
+  worktrees; the path is `~/.fletch/worktrees/<name>/`.
+- **Why:** provisioning is `git clone` (`--shared` normally, `--no-hardlinks`
+  for repos added to a live Docker container). Linked worktrees are explicitly
+  rejected — see `docs/isolation.md`, "Why not linked git worktrees."
+
+### 2. Two isolation engines, no third mode, no fallback
+
+- **Must say:** Fletch ships **two** isolation engines — macOS **Seatbelt**
+  (default) and **Docker** (opt-in). Docker is optional, not required. If Docker
+  is selected but unavailable, spawning **fails closed** — it does not silently
+  fall back to seatbelt.
+- **Stale if it says:** "No Docker, no containers" as a blanket statement;
+  Docker is required; there is only one sandbox; an unavailable engine degrades
+  gracefully to another.
+- **Why:** `EngineKind { SandboxExec, Docker }`; `engine_for` hard-errors on an
+  unavailable Docker daemon.
+
+### 3. Not a VM (both engines)
+
+- **Must say:** neither engine is a virtual machine. Seatbelt is OS-level
+  **write confinement** for a process that runs as your user; Docker is
+  **per-agent live-process containment** (and runs as root in v1). No VM is
+  required to run Fletch.
+- **Stale if it says:** agents run in a VM; the sandbox is a full virtualization
+  boundary; it defeats a determined attacker.
+- **Why:** `sandbox/seatbelt.rs` (write-only confinement, `allow default`);
+  `sandbox/docker/engine.rs` (threat-model note: containment, not a trust
+  boundary; root in v1).
+
+### 4. Network is open (honesty item)
+
+- **Must say:** under **both** engines the **network is open**. Seatbelt leaves
+  it open; the Docker launch sets no network restriction. Treat agents as
+  network-capable.
+- **Stale if it says:** agents are network-isolated; the sandbox blocks network
+  access; egress is restricted.
+- **Why:** seatbelt `(allow default)`; the Docker run has no `--network` flag,
+  so the container uses the default bridge.
+
+### 5. Reads are open under seatbelt
+
+- **Must say:** the default (seatbelt) engine confines **writes**, not reads —
+  an agent can read anything you can. Docker additionally restricts reads to
+  what is mounted.
+- **Stale if it says:** the default sandbox prevents agents from reading your
+  files; reads are sandboxed under seatbelt.
+- **Why:** `sandbox/seatbelt.rs` — the profile only denies `file-write*` (plus a
+  read+write deny on Fletch's own data dir); everything else is readable via
+  `allow default`.
+
+### 6. Your source repo's `.git` is never writable
+
+- **Must say:** an agent can never write your repository's `.git`. It works in a
+  clone with its own `.git`; under Docker your source `.git` is never mounted,
+  and the borrowed object store it does mount is **read-only**.
+- **Stale if it says:** agents share your repo's git store writably; worktrees
+  share the origin `.git`.
+- **Why:** `sandbox/provision.rs`; `sandbox/docker/engine.rs` (object store
+  mounted `:ro`, source `.git` never mounted).
+
+### 7. Credential brokering, with the no-confirmation caveat
+
+- **Must say:** GitHub credentials **never enter the sandbox**. Pushes and PRs
+  are **brokered host-side** through an RPC mailbox. State this candidly: those
+  publication ops (`git_push`, `open_pr`) currently run **without a confirmation
+  prompt**, so an agent can push or open a PR under your identity without asking
+  — choose tasks and repos accordingly.
+- **Stale if it says:** agents hold your GitHub token; the sandbox has network
+  credentials; **or** that Fletch asks for confirmation before every push/PR
+  (it does not, today — don't overclaim safety).
+- **Why:** `rpc/git.rs` — host-side broker; no prompt gate on the mutating ops.
+
+## Consistency check
+
+After edits, the site's isolation story must match, in one voice:
+**clone (not worktree) + two engines (seatbelt default, docker opt-in, fail
+closed) + not a VM + network open under both + reads open under seatbelt +
+source `.git` never writable + credentials brokered host-side but push/PR
+unprompted.** If any surface tells a different story, it is stale.
+</content>

--- a/docs/isolation.md
+++ b/docs/isolation.md
@@ -1,0 +1,217 @@
+# Isolation
+
+Isolation is the feature Fletch is built around: you can run many agents on real
+code and trust that none of them can damage your repository, your machine, or
+each other's work. This document is the canonical description of how that
+isolation works. It is the source of truth — the README summarizes it, the
+website should track it, and the code implements it. Where a claim is
+load-bearing, the authoritative file is named.
+
+## The model in one paragraph
+
+Every agent works in its own **clone** of your repository — a self-contained
+git checkout with its own real, writable `.git` — and runs under an **OS-level
+sandbox that blocks writes outside that clone**. The clone is why an agent can
+commit, branch, and merge freely without ever touching your working copy; the
+sandbox is why a misbehaving or prompt-injected agent can't write anywhere else
+on disk. Together they protect your source repository's `.git` (never writable
+by an agent), everything on your filesystem outside the agent's workspace, and
+Fletch's own state. They deliberately do **not** restrict what an agent can
+*read* (under the default engine) or the network it can reach — Fletch confines
+writes, it does not virtualize the machine. Isolation is a containment boundary
+for live agent processes, not a claim to defeat a determined attacker.
+
+## The two engines
+
+Fletch ships exactly two isolation engines, chosen in Settings. There is no
+third mode and no silent fallback between them (`sandbox/engine.rs`,
+`sandbox/mod.rs`).
+
+- **Seatbelt (default).** Each agent is launched under a per-agent macOS
+  `sandbox-exec` profile. The profile is write-confinement only: it starts from
+  `(allow default)`, denies all writes, then re-allows a specific set of paths
+  (last-match-wins SBPL). **Reads and network stay open.** The agent runs as
+  *you* — same user, same read access, same network — so this is write
+  protection, not a virtual machine (`sandbox/seatbelt.rs`).
+- **Docker (opt-in).** Each agent process runs in its own
+  `docker run --rm --init` container, one container per agent, agent ≈ PID 1.
+  The container sees only what Fletch bind-mounts into it, so the rest of your
+  filesystem is unreachable *even for reads*. It is truer isolation, at the cost
+  of requiring Docker and some startup latency (`sandbox/docker/`).
+
+An agent is stamped with its engine at creation and keeps it for life; changing
+the setting only affects agents spawned afterward (`sandbox/mod.rs`). A
+Docker-stamped agent whose daemon is unreachable is a **hard error** — Fletch
+fails closed rather than quietly launching outside the container boundary the
+user selected (`sandbox/mod.rs`, `engine_for`).
+
+### What the seatbelt profile allows
+
+Writes are permitted only to: the agent's workspace root, its private RPC
+mailbox, the optional workflow blackboard, the standard scratch/state locations
+(`/private/tmp`, `/private/var/folders`, `/private/var/tmp`), each provider's
+own on-disk state dirs (so the agent CLI can persist transcripts, config, and
+refreshed auth), and `~/.claude.json`. Fletch's own application-data directory
+(`fletch.db` — transcripts and settings) is explicitly denied **both read and
+write**, so a confined agent can neither exfiltrate nor forge app state
+(`sandbox/seatbelt.rs`).
+
+### What the Docker container mounts
+
+Only the agent's writable root and its RPC mailbox are mounted read-write, at
+their identical host paths. The provider's config/data dirs are mounted per
+provider (Claude's `~/.claude` is read-only except its `.credentials.json` and a
+per-agent transcripts dir; the others are read-write). Crucially, the source
+repo's `.git` is **never** mounted; only its borrowed git object store is
+mounted, and only **read-only** (`sandbox/docker/engine.rs`). There is **no
+`--network` flag** anywhere in the launch, so the container uses Docker's default
+bridge — the network is open. Containers run as root in v1 (a documented
+limitation), which is another reason the container is treated as live-process
+containment, not a trust boundary.
+
+## The isolation matrix
+
+Provisioning has two clone strategies, and the engine plus *when* the repo joins
+the agent decides which one runs (`sandbox/provision.rs`, `clone_base`).
+
+| Engine | When the repo is added | Clone strategy | Why |
+| --- | --- | --- | --- |
+| Seatbelt | Always | `git clone --shared` | Same filesystem as the source; borrowed objects are reachable directly, no mount involved, so the cheap shared clone always works. |
+| Docker | Present when the container starts (the primary repo, and any repo already tracked at launch) | `git clone --shared` | The borrowed object store is bind-mounted **read-only** at its identical host path when the container launches, so in-container git can read history while writes fail with `Read-only file system`. |
+| Docker | Added to an **already-running** container | `git clone --no-hardlinks` | A running container's bind mounts are fixed at `docker run`; a `--shared` clone's borrowed store could never be mounted, so in-container git would fail on missing objects. A self-contained full copy needs no extra mount. |
+
+`git clone --shared` borrows the source's object store through
+`.git/objects/info/alternates` and copies **no** objects, so spawning an agent
+costs kilobytes and milliseconds instead of a full history copy. New objects
+(the agent's commits and fetches) land in the clone's own store; reads of
+existing history fall through to the borrowed one. Borrowed objects are only
+ever *referenced*, never written, and under Docker the store is mounted
+read-only — so a container can't reach back through the alternates link to
+mutate the source (`sandbox/provision.rs`). `git clone --no-hardlinks` makes a
+full, self-contained copy with no alternates and no shared inodes.
+
+After either clone, three fixups run (`sandbox/provision.rs`):
+
+- **Origin is rewritten** to the source repo's *real* remote, so push/PR/fetch
+  behave as they would from a normal checkout. If the source has no remote, the
+  clone's implicit local-path `origin` is *removed* — otherwise a push could
+  silently create branches and objects inside your source repo.
+- **Delegation git hooks** (`post-commit`, `post-merge`) are installed into the
+  clone so the agent's own native git commits and merges signal the UI. They are
+  installed only in the clone; host-side git runs with hooks disabled, so they
+  never fire on the host.
+- **A git identity is frozen** into the clone's own config, so in-container git
+  (which can't see your global gitconfig) can commit without failing on "Please
+  tell me who you are."
+
+## What an agent can and cannot do
+
+Stated plainly, because the trust anchor earns trust by naming its limits.
+
+**An agent CAN:**
+
+- **Read your disk — under seatbelt.** The seatbelt profile confines writes, not
+  reads; the agent runs as your user and can read anything you can. Under Docker
+  it can read only what is mounted into the container.
+- **Open network connections — under both engines.** Neither engine restricts
+  the network. Seatbelt's `(allow default)` leaves it open; the Docker launch
+  sets no `--network` flag, so the container gets the default bridge. Treat every
+  agent as network-capable.
+
+**An agent CANNOT:**
+
+- **Write outside its workspace.** Both engines deny it: seatbelt by policy,
+  Docker by mounting nothing else writable.
+- **Touch your source repo's `.git`.** The agent works in a clone with its own
+  `.git`; your repository's `.git` is never writable by an agent, and under
+  Docker it is never mounted at all.
+- **Hold your GitHub credentials.** Pushes and PR creation never run inside the
+  sandbox. They are brokered: the agent writes a request to its RPC mailbox, and
+  Fletch runs the operation **host-side**, where the credentials live
+  (`rpc/git.rs`, ops `git_push`, `open_pr`, `git_fetch`). Credentials never enter
+  the sandbox.
+
+**The one caveat to state loudly:** the brokered `git_push` and `open_pr` ops
+currently run **without a confirmation prompt** (`rpc/git.rs`). An agent that
+decides to push a branch or open a PR can do so under your GitHub identity
+without asking first. Credentials stay out of the sandbox, but publication is
+not gated. Choose the tasks and repositories you point agents at accordingly.
+(The README states this same caveat; keep the two in sync.)
+
+## Why not linked git worktrees
+
+A natural-seeming alternative to cloning is `git worktree add` — a second
+working tree that shares the origin repository's object store and ref database.
+Fletch rejects it, for two reasons (`sandbox/provision.rs`):
+
+1. **It's incompatible with the Docker engine.** A linked worktree's `.git` is a
+   *file* that points at the origin repo's `.git/worktrees/<name>` by absolute
+   path. Containerizing such a checkout would require bind-mounting your real
+   `.git` into the container — and a writable `.git/hooks` there is a host escape
+   (the next `git` command you run on the host would execute agent-authored hook
+   code). The source `.git` must never enter an agent's sandbox writable.
+2. **Agents need a real, writable `.git`.** Local git mutations (commit, merge,
+   conflict resolution) now run as native git *inside* the sandbox, which
+   requires a genuine writable object store and config. A clone has one; a linked
+   worktree borrows the origin's, which is exactly what must stay out of reach.
+
+Both engines therefore converge on the same shape: a self-contained clone.
+
+## Why not a VM
+
+Neither engine is a virtual machine, and Fletch does not claim to be one.
+
+- **Seatbelt** is a write-confinement profile applied to a process that still
+  runs as *you*, on your kernel, with your read access and your network. It stops
+  writes; it does not virtualize anything.
+- **Docker** is live-process containment: it isolates the filesystem an agent can
+  see and write, but the network is open, and in v1 containers run as root, so
+  in-container privilege isolation is not relied upon.
+
+The real review gate that keeps agent output off your main branch is not the
+sandbox at all — it's the clone-plus-PR flow with you in the loop: nothing merges
+without your review.
+
+## Terminology
+
+Fletch uses precise words for these concepts. Please use them consistently.
+
+- **Workspace** — the agent's isolated area on disk (`~/.fletch/workspaces/<id>/`),
+  containing its clone (or one clone per repo, for a multi-repo agent). This is
+  the user-facing word for "where the agent works."
+- **Clone** — the isolation *mechanism*: each workspace is a `git clone` of your
+  repository, never a linked worktree. When you need one word for how Fletch
+  isolates an agent, it is "clone."
+- **Git worktrees are not the isolation mechanism.** Fletch does not use
+  `git worktree add` to isolate agents (see [Why not linked git worktrees](#why-not-linked-git-worktrees)).
+  Two internal uses of the word "worktree" survive and are *not* user-facing
+  terminology for isolation:
+  - The **`worktrees` database table** is legacy-internal naming: one row per
+    repo checkout in a workspace (`database.rs`). Renaming the table is churn we
+    haven't taken on; it does not mean agents use git worktrees.
+  - The **workflow merge stage** does use a genuine linked worktree — but of an
+    internal, disposable *run repository* under `~/.fletch/runs/`, purely to
+    integrate parallel step results (`workflow/gitops.rs`). It never touches your
+    source repository, and it is unrelated to how agents are isolated.
+
+The historical spelling `~/.fletch/worktrees/` for the on-disk root was renamed
+to `~/.fletch/workspaces/`; a one-time migration handles existing installs
+(`workspace.rs`).
+
+## Authoritative code
+
+The code is canonical. When this document and the code disagree, the code wins —
+and this document should be corrected.
+
+- `src-tauri/src/sandbox/seatbelt.rs` — the macOS `sandbox-exec` profile: the
+  deny-writes-then-re-allow model, the writable set, and the app-data deny.
+- `src-tauri/src/sandbox/docker/` — the Docker engine: per-agent
+  `docker run --rm --init`, the identical-host-path mounts, the read-only
+  borrowed object store, and the invariants that keep the source `.git` and your
+  credentials out of the container.
+- `src-tauri/src/sandbox/provision.rs` — how a workspace comes into existence:
+  the two clone strategies, origin rewrite, hook install, and identity seeding.
+- `src-tauri/src/rpc/git.rs` — the host-side broker for `git_push`, `open_pr`,
+  and `git_fetch`, including the (currently unprompted) publication ops.
+</content>
+</invoke>

--- a/src/components/Workspace/ForkButton.tsx
+++ b/src/components/Workspace/ForkButton.tsx
@@ -8,7 +8,7 @@ export function ForkButton({ agentId, upToPrompt }: { agentId: string; upToPromp
   const options: ForkOption[] = [
     {
       key: "clean",
-      label: "Fork here · clean worktree",
+      label: "Fork here · clean workspace",
       code: "clean",
       context,
     },

--- a/src/components/Workspace/WorkspaceHeader.tsx
+++ b/src/components/Workspace/WorkspaceHeader.tsx
@@ -14,7 +14,7 @@ import { ViewToggle } from "./ViewToggle";
 const HEADER_FORK_OPTIONS: ForkOption[] = [
   {
     key: "full-clean",
-    label: "Full history · clean worktree",
+    label: "Full history · clean workspace",
     code: "clean",
     context: { kind: "full" },
   },

--- a/src/workflows/data.ts
+++ b/src/workflows/data.ts
@@ -42,7 +42,7 @@ export const GATE_MODES: GateModeDef[] = [
     label: "Tests pass",
     short: "tests",
     icon: "flask",
-    note: "Runs the project's test command in the step worktree; done only when it exits 0.",
+    note: "Runs the project's test command in the step's checkout; done only when it exits 0.",
   },
   {
     id: "approval",


### PR DESCRIPTION
## Summary

One canonical isolation story — the trust anchor gets exactly one description, verified claim-by-claim against the code.

- **`docs/isolation.md`** (new, canonical): the model in one paragraph; the two engines (seatbelt default / Docker opt-in, fail-closed, engine-stamped-for-life); the isolation matrix ({seatbelt, docker} × {`clone --shared`, `clone --no-hardlinks`}); honest can/cannot threat model (reads open under seatbelt, network open under both engines, source `.git` never writable, credentials brokered host-side — including the no-confirmation-prompt caveat on push/PR); why not linked worktrees; why not a VM; terminology.
- **`docs/isolation-site-checklist.md`** (new): seven "must say X / stale if Y" items for correcting the external fletch.sh docs/marketing site (which this repo can't edit), with the `llms.txt` "worktree" claim flagged as the primary known error, plus a grep-driven execution recipe.
- **README**: isolation write-up pointer now goes to the in-repo canonical doc.
- **User-facing "worktree" string sweep**: fixed 3 (fork menu labels ×2, workflow gate note). Left the workflow "integration worktree" pause text as-is — that stage genuinely runs `git worktree add` on an internal disposable run repo, so the wording is accurate. All internal identifiers/DB names untouched (churn, not user-facing).

## Testing

- `bun run check` (tsc --noEmit) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)