### PR TITLE
feat(workflows): gate evidence, reject flow, and ReviewSurface v0

### DIFF
--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -565,9 +565,72 @@ pub async fn checkout_diff_shortstat(checkout: &Path, base_ref: &str) -> Result<
     Ok(parse_shortstat(&line))
 }
 
+/// Per-file additions/deletions for `git diff --numstat <from>..<to>` in `repo`.
+/// Binary files (numstat prints `-`/`-`) report zero counts. Lists the files a
+/// ferried ref changed versus the run base for the review surface's file list.
+pub async fn diff_numstat(
+    repo: &Path,
+    from_sha: &str,
+    to_sha: &str,
+) -> Result<Vec<(String, u32, u32)>> {
+    let range = format!("{from_sha}..{to_sha}");
+    let out = run_git(repo, &["diff", "--numstat", &range], "diff --numstat").await?;
+    Ok(parse_numstat_lines(&String::from_utf8_lossy(&out.stdout)))
+}
+
+/// Parse `git diff --numstat` output into `(path, additions, deletions)` rows.
+/// Binary files print `-` for both counts; those become 0.
+fn parse_numstat_lines(text: &str) -> Vec<(String, u32, u32)> {
+    let mut files = Vec::new();
+    for line in text.lines() {
+        let mut parts = line.splitn(3, '\t');
+        if let (Some(a), Some(d), Some(path)) = (parts.next(), parts.next(), parts.next()) {
+            files.push((
+                path.to_string(),
+                a.parse::<u32>().unwrap_or(0),
+                d.parse::<u32>().unwrap_or(0),
+            ));
+        }
+    }
+    files
+}
+
+/// The unified diff of `from_sha..to_sha` in `repo`, optionally scoped to one
+/// `path` (`-U3`, matching the file-diff view's context). Both refs are objects
+/// in the same repo — for the review surface, the run repo where the ferried step
+/// ref and the run base both live — so no checkout is needed.
+pub async fn diff_refs(
+    repo: &Path,
+    from_sha: &str,
+    to_sha: &str,
+    path: Option<&str>,
+) -> Result<String> {
+    let range = format!("{from_sha}..{to_sha}");
+    let mut args = vec!["diff", "--no-color", "-U3", &range];
+    if let Some(p) = path {
+        args.push("--");
+        args.push(p);
+    }
+    let out = run_git(repo, &args, "diff -U3 range").await?;
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_numstat_lines_counts_and_binaries() {
+        let text = "12\t3\tsrc/a.rs\n-\t-\tassets/logo.png\n0\t5\tsrc/b.rs\n";
+        assert_eq!(
+            parse_numstat_lines(text),
+            vec![
+                ("src/a.rs".to_string(), 12, 3),
+                ("assets/logo.png".to_string(), 0, 0),
+                ("src/b.rs".to_string(), 0, 5),
+            ]
+        );
+    }
 
     #[test]
     fn parse_shortstat_typical() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1399,6 +1399,8 @@ pub fn run() {
             workflow::scheduler::wf_resume,
             workflow::scheduler::wf_retry,
             workflow::scheduler::wf_approve,
+            workflow::scheduler::wf_reject,
+            workflow::scheduler::wf_run_diff,
             workflow::scheduler::wf_resolve_conflict,
             workflow::scheduler::wf_delete_run,
             workflow::comms::wf_answer,

--- a/src-tauri/src/workflow/attempt.rs
+++ b/src-tauri/src/workflow/attempt.rs
@@ -378,7 +378,9 @@ pub async fn run_attempt(
         };
         // Tests gate (spec §9.4): resolve + run the project's tests in the step
         // worktree now, then let the pure gate turn the outcome into done/blocked.
-        let tests = if matches!(gate, Gate::Tests) {
+        // An `approval` gate with `require: [tests]` runs them too, so the human
+        // pause is unreachable while tests are red (spec §9).
+        let tests = if gate.requires_tests() {
             Some(test_runner.run_tests(&spawned.worktree).await)
         } else {
             None
@@ -751,7 +753,7 @@ fn gate_mode(gate: &Gate) -> &'static str {
         Gate::Commit => "commit",
         Gate::Artifact { .. } => "artifact",
         Gate::Tests => "tests",
-        Gate::Approval => "approval",
+        Gate::Approval { .. } => "approval",
     }
 }
 
@@ -1087,7 +1089,11 @@ mod tests {
         let run = run(
             d.as_ref(),
             &NeverTests,
-            params(Gate::Approval, bb.path().to_path_buf(), fast()),
+            params(
+                Gate::Approval { require: vec![] },
+                bb.path().to_path_buf(),
+                fast(),
+            ),
         )
         .await;
         assert!(

--- a/src-tauri/src/workflow/comms.rs
+++ b/src-tauri/src/workflow/comms.rs
@@ -1709,6 +1709,32 @@ pub(super) fn queue_engine_ask(conn: &Connection, run_id: &str, orch_exec: &str,
     );
 }
 
+/// Queue a human's approval-gate rejection as a delivery to the gated step, so
+/// its next attempt re-prompts with the reviewer's note folded into the prompt —
+/// the same coalesced-delivery path a `wf_answer` uses (spec §10.4). Addressed to
+/// the (now abandoned) approval exec by id; `take_pending_deliveries` joins on the
+/// step id, so it reaches the step's fresh attempt. Modeled as a `notify` so no
+/// new message kind is needed.
+pub(super) fn queue_rejection(conn: &Connection, run_id: &str, step_exec_id: &str, note: &str) {
+    let body = json!({
+        "message": format!(
+            "A human reviewed your work and requested changes before approving it:\n\n{note}\n\n\
+             Address this feedback, update the code, and complete the step again."
+        )
+    });
+    let _ = insert_message(
+        conn,
+        &new_msg_id(),
+        run_id,
+        None,
+        Some(step_exec_id),
+        "notify",
+        &body,
+        "queued",
+        false,
+    );
+}
+
 /// Queue an `answer` to the asking child, mark the originating `ask` `answered`,
 /// and journal the route (§10.4). Shared by the orchestrator (§10.2) and human
 /// (§14) answer paths, which differ only in their preconditions and in `from`

--- a/src-tauri/src/workflow/gates.rs
+++ b/src-tauri/src/workflow/gates.rs
@@ -155,12 +155,21 @@ fn evaluate_approval(require: &[Require], inputs: &GateInputs) -> GateResult {
     // `require: [tests]` (spec §9): the deterministic gate is evaluated first, so
     // the approval pause is unreachable while tests are red — a failing/timed-out/
     // setup-failed run blocks exactly like a `tests` gate, quoting the same reason
-    // (and output tail) so the re-prompt is identical. A green run, or one with no
-    // resolvable test command (the tests gate's degrade case), falls through to
-    // the human-approval decision — the engine never blocks on tests it can't run.
+    // (and output tail) so the re-prompt is identical. With no resolvable test
+    // command the tests gate degrades to the verdict (spec §9.4); mirror that when
+    // the step wrote one, so a "revise"/"blocked" verdict never reaches the human.
+    // A step with no verdict at all still falls through to approval — the approval
+    // gate never demands a verdict, and blocking on a missing file would strand
+    // the step in a re-prompt loop tests can't satisfy.
     if require.contains(&Require::Tests) {
         if let Some(reason) = tests_block_reason(inputs.tests) {
             return GateResult::blocked(reason);
+        }
+        if matches!(inputs.tests, Some(TestsOutcome::NoCommand)) && inputs.verdict.is_some() {
+            let degraded = evaluate_verdict(inputs);
+            if degraded.outcome == GateOutcome::Blocked {
+                return degraded;
+            }
         }
     }
     if inputs.approved {
@@ -411,6 +420,38 @@ mod tests {
                 "outcome {outcome:?} should await the human"
             );
         }
+    }
+
+    #[test]
+    fn approval_require_tests_degrades_to_verdict_on_no_command() {
+        // With no resolvable test command, `require: [tests]` mirrors the tests
+        // gate's degrade (spec §9.4): a blocking verdict never reaches the human.
+        let gate = Gate::Approval {
+            require: vec![Require::Tests],
+        };
+        let v = verdict(VerdictResult::Revise, "flaky assertion");
+        let r = evaluate(
+            &gate,
+            &GateInputs {
+                tests: Some(&TestsOutcome::NoCommand),
+                verdict: Some(&v),
+                ..Default::default()
+            },
+        );
+        assert_eq!(r.outcome, GateOutcome::Blocked);
+        assert!(r.reason.contains("flaky assertion"), "reason: {}", r.reason);
+
+        // A "done" verdict falls through to the human as usual.
+        let v = verdict(VerdictResult::Done, "shipped");
+        let r = evaluate(
+            &gate,
+            &GateInputs {
+                tests: Some(&TestsOutcome::NoCommand),
+                verdict: Some(&v),
+                ..Default::default()
+            },
+        );
+        assert_eq!(r.outcome, GateOutcome::AwaitingApproval);
     }
 
     #[test]

--- a/src-tauri/src/workflow/gates.rs
+++ b/src-tauri/src/workflow/gates.rs
@@ -11,7 +11,7 @@
 //! pure module. When no test command resolves the gate degrades to `verdict`.
 
 use super::blackboard::{Verdict, VerdictResult};
-use super::spec::Gate;
+use super::spec::{Gate, Require};
 
 /// The three terminal shapes a gate evaluation can take. Maps onto the step
 /// attempt's `gating → { done | blocked | awaiting_approval }` transition
@@ -104,7 +104,7 @@ pub fn evaluate(gate: &Gate, inputs: &GateInputs) -> GateResult {
         Gate::Verdict => evaluate_verdict(inputs),
         Gate::Commit => evaluate_commit(inputs),
         Gate::Artifact { path } => evaluate_artifact(path, inputs),
-        Gate::Approval => evaluate_approval(inputs),
+        Gate::Approval { require } => evaluate_approval(require, inputs),
         Gate::Tests => evaluate_tests(inputs),
     }
 }
@@ -151,7 +151,18 @@ fn evaluate_artifact(path: &str, inputs: &GateInputs) -> GateResult {
     }
 }
 
-fn evaluate_approval(inputs: &GateInputs) -> GateResult {
+fn evaluate_approval(require: &[Require], inputs: &GateInputs) -> GateResult {
+    // `require: [tests]` (spec §9): the deterministic gate is evaluated first, so
+    // the approval pause is unreachable while tests are red — a failing/timed-out/
+    // setup-failed run blocks exactly like a `tests` gate, quoting the same reason
+    // (and output tail) so the re-prompt is identical. A green run, or one with no
+    // resolvable test command (the tests gate's degrade case), falls through to
+    // the human-approval decision — the engine never blocks on tests it can't run.
+    if require.contains(&Require::Tests) {
+        if let Some(reason) = tests_block_reason(inputs.tests) {
+            return GateResult::blocked(reason);
+        }
+    }
     if inputs.approved {
         GateResult::done("approved by a human")
     } else {
@@ -163,22 +174,33 @@ fn evaluate_approval(inputs: &GateInputs) -> GateResult {
 }
 
 fn evaluate_tests(inputs: &GateInputs) -> GateResult {
+    if let Some(reason) = tests_block_reason(inputs.tests) {
+        return GateResult::blocked(reason);
+    }
     match inputs.tests {
         Some(TestsOutcome::Passed) => GateResult::done("project tests passed"),
-        Some(TestsOutcome::Failed { tail }) => {
-            GateResult::blocked(with_tail("project tests failed", tail))
-        }
+        // No test command resolvable → degrade to the verdict gate (spec §9.4).
+        // `attempt.rs` journals the degrade warning; here we just read the verdict
+        // facts the caller always gathers. (Failing outcomes are handled above.)
+        _ => evaluate_verdict(inputs),
+    }
+}
+
+/// The `Blocked` reason for a *failing* tests outcome (red / timed out / setup
+/// failed), or `None` when tests passed, weren't run, or resolved to no command.
+/// Shared by the `tests` gate and an `approval` gate's `require: [tests]` so both
+/// speak the identical failure reason and output tail (spec §9.4).
+fn tests_block_reason(tests: Option<&TestsOutcome>) -> Option<String> {
+    match tests {
+        Some(TestsOutcome::Failed { tail }) => Some(with_tail("project tests failed", tail)),
         Some(TestsOutcome::TimedOut { tail }) => {
-            GateResult::blocked(with_tail("project tests timed out before finishing", tail))
+            Some(with_tail("project tests timed out before finishing", tail))
         }
-        Some(TestsOutcome::SetupFailed { tail }) => GateResult::blocked(with_tail(
+        Some(TestsOutcome::SetupFailed { tail }) => Some(with_tail(
             "project setup command failed (tests not run)",
             tail,
         )),
-        // No test command resolvable → degrade to the verdict gate (spec §9.4).
-        // `attempt.rs` journals the degrade warning; here we just read the
-        // verdict facts the caller always gathers.
-        Some(TestsOutcome::NoCommand) | None => evaluate_verdict(inputs),
+        _ => None,
     }
 }
 
@@ -332,17 +354,63 @@ mod tests {
 
     #[test]
     fn approval_gate_awaits_then_passes() {
-        let waiting = evaluate(&Gate::Approval, &GateInputs::default());
+        let bare = Gate::Approval { require: vec![] };
+        let waiting = evaluate(&bare, &GateInputs::default());
         assert_eq!(waiting.outcome, GateOutcome::AwaitingApproval);
 
         let approved = evaluate(
-            &Gate::Approval,
+            &bare,
             &GateInputs {
                 approved: true,
                 ..Default::default()
             },
         );
         assert_eq!(approved.outcome, GateOutcome::Done);
+    }
+
+    #[test]
+    fn approval_require_tests_blocks_before_asking_a_human() {
+        // With `require: [tests]`, a red test run must block (and quote the tail)
+        // rather than reach the human-approval pause — the deterministic gate is
+        // evaluated first (spec §9).
+        let gate = Gate::Approval {
+            require: vec![Require::Tests],
+        };
+        let failed = TestsOutcome::Failed {
+            tail: "FAIL src/x.test.ts\n  ✕ adds".into(),
+        };
+        let r = evaluate(
+            &gate,
+            &GateInputs {
+                tests: Some(&failed),
+                ..Default::default()
+            },
+        );
+        assert_eq!(r.outcome, GateOutcome::Blocked);
+        assert!(r.reason.contains("adds"), "reason: {}", r.reason);
+    }
+
+    #[test]
+    fn approval_require_tests_awaits_human_once_green() {
+        // Passing tests (or no resolvable command) must fall through to the human
+        // pause — the engine never blocks on tests it can't or didn't fail to run.
+        let gate = Gate::Approval {
+            require: vec![Require::Tests],
+        };
+        for outcome in [TestsOutcome::Passed, TestsOutcome::NoCommand] {
+            let r = evaluate(
+                &gate,
+                &GateInputs {
+                    tests: Some(&outcome),
+                    ..Default::default()
+                },
+            );
+            assert_eq!(
+                r.outcome,
+                GateOutcome::AwaitingApproval,
+                "outcome {outcome:?} should await the human"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/workflow/prompts.rs
+++ b/src-tauri/src/workflow/prompts.rs
@@ -7,7 +7,7 @@
 //! Everything here is deterministic and side-effect free so the exact text is
 //! unit-testable and stable across runs.
 
-use super::spec::{CommsCap, Gate};
+use super::spec::{CommsCap, Gate, Require};
 
 /// Where a step sits in the run, for the "step N of M, iteration i of max"
 /// context line (spec §8.5 item 3).
@@ -388,8 +388,15 @@ fn gate_statement(gate: &Gate) -> String {
         Gate::Artifact { path } => {
             format!("You are done when the file `{path}` exists in the repository.")
         }
-        Gate::Approval => "When you believe the work is complete, write your handoff notes and \
-             `verdict.json`. A human will review and approve before the workflow \
+        Gate::Approval { require } if require.contains(&Require::Tests) => {
+            "When you believe the work is complete, write your handoff notes and \
+             `verdict.json`. The project's test suite must pass first — the workflow \
+             runs it after your turn; make it green. A human then reviews and approves \
+             before the workflow continues."
+                .to_string()
+        }
+        Gate::Approval { .. } => "When you believe the work is complete, write your handoff notes \
+             and `verdict.json`. A human will review and approve before the workflow \
              continues."
             .to_string(),
         Gate::Tests => "You are done when the project's test suite passes. The workflow runs \
@@ -476,9 +483,15 @@ mod tests {
             path: "X.md".into()
         })
         .contains("X.md"));
-        assert!(gate_statement(&Gate::Approval).contains("human"));
+        assert!(gate_statement(&Gate::Approval { require: vec![] }).contains("human"));
         let tests = gate_statement(&Gate::Tests);
         assert!(tests.contains("test suite passes"), "{tests}");
+        // An approval gate that requires tests reminds the agent about them too.
+        let approval_tests = gate_statement(&Gate::Approval {
+            require: vec![Require::Tests],
+        });
+        assert!(approval_tests.contains("test suite"), "{approval_tests}");
+        assert!(approval_tests.contains("human"), "{approval_tests}");
     }
 
     #[test]

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -517,6 +517,47 @@ impl WorkflowService {
         Ok(())
     }
 
+    /// Reject an `awaiting_approval` step (`wf_reject`, spec §9): journal the
+    /// human decision, then give the step one more attempt within budget — the
+    /// mirror of [`Self::approve`]. The rejected attempt is abandoned (its ferried
+    /// work discarded) and the reviewer's `note` is queued as a delivery so the
+    /// fresh attempt re-prompts with it (the same fold `wf_answer` uses, §10.4);
+    /// the cursor is left in place so the walker re-runs the step. When the run
+    /// budget is already spent there is no attempt to give — pause `blocked_gate`
+    /// carrying the note as detail, exactly like an exhausted blocked-gate retry
+    /// (§6.5).
+    pub fn reject(&self, run_id: &str, note: &str) -> Result<()> {
+        let re_drive = {
+            let conn = self.db.lock();
+            reject_apply(&conn, Some(&self.app), run_id, note)?
+        };
+        if re_drive {
+            self.spawn_drive(run_id.to_string());
+        }
+        Ok(())
+    }
+
+    /// Diff `from_sha..to_sha` in the run's own repository (`wf_run_diff`, spec
+    /// §9). Both refs are objects in `~/.fletch/runs/<id>/repo` — the ferried step
+    /// ref and the run base — so no working checkout is involved.
+    pub async fn run_diff(
+        &self,
+        run_id: &str,
+        from_sha: &str,
+        to_sha: &str,
+        path: Option<&str>,
+    ) -> Result<String> {
+        let run_dir: String = {
+            let conn = self.db.lock();
+            conn.query_row("SELECT run_dir FROM wf_run WHERE id = ?1", [run_id], |r| {
+                r.get(0)
+            })
+            .map_err(|e| Error::Other(format!("run {run_id} not found: {e}")))?
+        };
+        let run_repo = gitops::run_repo_path(Path::new(&run_dir));
+        crate::git::diff_refs(&run_repo, from_sha, to_sha, path).await
+    }
+
     /// Resolve a `paused(conflict)` run (`wf_resolve_conflict`, §12.3). `mode` is
     /// `"agent"` (spawn a conflict-resolution step forked from the snapshot) or
     /// `"human"` (the user resolved in the run repo's integration worktree). The
@@ -813,6 +854,7 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
         setup_override: &setup_override,
         run_task: &run.task,
         spec_name: &spec.name,
+        base_sha: &run.base_sha,
         launch_attachments: &launch_attachments,
     };
 
@@ -2016,6 +2058,7 @@ async fn resume_merge_stage(
                 setup_override,
                 run_task: &run.task,
                 spec_name: &spec.name,
+                base_sha: &run.base_sha,
                 // A parallel/orchestrate merge step is never the run entry.
                 launch_attachments: &[],
             };
@@ -3955,6 +3998,7 @@ async fn resume_subrun_merge(
                 setup_override,
                 run_task: &run.task,
                 spec_name: &spec.name,
+                base_sha: &run.base_sha,
                 // A parallel/orchestrate merge step is never the run entry.
                 launch_attachments: &[],
             };
@@ -4747,6 +4791,9 @@ struct StepEnv<'a> {
     setup_override: &'a Option<String>,
     run_task: &'a str,
     spec_name: &'a str,
+    /// The run's base commit — the fork point the ferried diff in an approval
+    /// gate's review evidence is taken against (spec §9).
+    base_sha: &'a str,
     /// The run's launch-time file attachments (durable, read-only). Rendered into
     /// the entry step's prompt only (see `execute_step`); empty for stages that
     /// can't be the run entry.
@@ -5187,15 +5234,22 @@ async fn execute_step(
                 // (§6.3 step 8, §9). The agent is archived; the run pauses until
                 // `wf_approve` promotes the attempt and resumes.
                 let msg = format!("wf({}): {} attempt {}", env.spec_name, step.id, attempt_no);
-                let head = ferry_step(
-                    ctx,
-                    run_id,
-                    &exec_id,
-                    &msg,
-                    result.worktree.as_ref().unwrap(),
-                    env.run_repo,
+                let worktree = result.worktree.as_ref().unwrap();
+                let head = ferry_step(ctx, run_id, &exec_id, &msg, worktree, env.run_repo).await?;
+                // Assemble the review evidence while the worktree is intact (spec
+                // §9): verification, the ferried diff vs the run base, budget
+                // spend, and the step's verdict — journaled so ReviewSurface can
+                // render it without re-deriving anything. No lock is held across
+                // the (async) verification + git work.
+                let evidence = assemble_gate_evidence(
+                    env,
+                    &step.id,
+                    worktree,
+                    &head,
+                    step_eff.tests_timeout_secs.max(1) as u64,
+                    ledger,
                 )
-                .await?;
+                .await;
                 {
                     let conn = ctx.db.lock();
                     finish_step_exec(&conn, &exec_id, "awaiting_approval", Some(&head));
@@ -5204,6 +5258,14 @@ async fn execute_step(
                     let _ = ctx.driver.archive(agent_id).await;
                 }
                 let conn = ctx.db.lock();
+                journal_event(
+                    &conn,
+                    ctx.app.as_ref(),
+                    run_id,
+                    event_type::GATE_EVIDENCE,
+                    Some(&exec_id),
+                    &evidence,
+                );
                 journal_event(
                     &conn,
                     ctx.app.as_ref(),
@@ -5347,13 +5409,75 @@ async fn execute_step(
     }
 }
 
+/// Assemble an `approval` gate's review evidence (spec §9), as the `gate_evidence`
+/// payload (snake_case, like every IPC payload): the verification report (the
+/// shared `Verifier` primitive run install→test→lint in the step worktree —
+/// all-`Skipped` when the project configures nothing or the host can't sandbox),
+/// the ferried diff versus the run base (shortstat + per-file numstat, both taken
+/// in the run repo where the ferried ref and the base commit live), budget spend
+/// versus cap, and the step's `verdict.json`. Best-effort: any piece that can't be
+/// gathered is omitted / `null` so evidence collection never blocks the pause.
+/// Holds no DB lock across its async verification + git work.
+async fn assemble_gate_evidence(
+    env: &StepEnv<'_>,
+    step_id: &str,
+    worktree: &Path,
+    head_sha: &str,
+    tests_timeout_secs: u64,
+    ledger: &Ledger,
+) -> Value {
+    // Reuse the engine-owned verifier. Lint resolves by detection (no project
+    // lint override is plumbed to the linear path); a HOME-less host yields no
+    // verifier, reported as `null` rather than a fake empty report.
+    let verification = match crate::verify::Verifier::new(
+        env.test_override.clone(),
+        env.setup_override.clone(),
+        None,
+        tests_timeout_secs,
+    ) {
+        Ok(v) => serde_json::to_value(v.verify(worktree).await).ok(),
+        Err(_) => None,
+    };
+
+    let (additions, deletions) = crate::git::diff_shortstat(env.run_repo, env.base_sha, head_sha)
+        .await
+        .unwrap_or((0, 0));
+    let files: Vec<Value> = crate::git::diff_numstat(env.run_repo, env.base_sha, head_sha)
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(path, a, d)| json!({ "path": path, "additions": a, "deletions": d }))
+        .collect();
+
+    let verdict = blackboard::step_dir(env.blackboard, step_id)
+        .ok()
+        .and_then(|dir| blackboard::read_verdict(&dir).ok())
+        .and_then(|v| serde_json::to_value(v).ok());
+
+    json!({
+        "base_sha": env.base_sha,
+        "head_sha": head_sha,
+        "verification": verification,
+        "diff": { "additions": additions, "deletions": deletions, "files": files },
+        "budget": {
+            "turns_spent": ledger.turns,
+            "turns_cap": env.eff.turns,
+            "tokens_spent": ledger.tokens,
+            "tokens_cap": env.eff.tokens,
+            "wall_ms_spent": ledger.wall_ms,
+            "wall_clock_cap_mins": env.eff.wall_clock_mins,
+        },
+        "verdict": verdict,
+    })
+}
+
 fn gate_mode(gate: &Gate) -> &'static str {
     match gate {
         Gate::Verdict => "verdict",
         Gate::Commit => "commit",
         Gate::Artifact { .. } => "artifact",
         Gate::Tests => "tests",
-        Gate::Approval => "approval",
+        Gate::Approval { .. } => "approval",
     }
 }
 
@@ -5406,6 +5530,80 @@ fn check_resumable(conn: &Connection, run_id: &str, action: &str) -> Result<()> 
         ));
     }
     Ok(())
+}
+
+/// The DB half of `wf_reject` (spec §9), factored out so it is unit-testable
+/// without the async re-drive. Validates the pause, journals the human decision,
+/// abandons the rejected attempt, and either (budget left) queues the reviewer's
+/// note as a delivery and returns `true` — telling the caller to re-drive — or
+/// (budget spent) pauses `blocked_gate` with the note as detail and returns
+/// `false`. Runs entirely under the caller's connection lock.
+fn reject_apply(
+    conn: &Connection,
+    app: Option<&AppHandle>,
+    run_id: &str,
+    note: &str,
+) -> Result<bool> {
+    let note = note.trim();
+    if note.is_empty() {
+        return Err(Error::Other("a rejection note is required".into()));
+    }
+    let (status, reason) = run_status(conn, run_id)?;
+    if status != "paused" || reason.as_deref() != Some("approval") {
+        return Err(Error::Other(format!(
+            "run is not awaiting approval (status: {status})"
+        )));
+    }
+    let exec_id: String = conn
+        .query_row(
+            "SELECT id FROM wf_step_exec WHERE run_id = ?1 AND status = 'awaiting_approval'
+             ORDER BY rowid DESC LIMIT 1",
+            [run_id],
+            |r| r.get(0),
+        )
+        .map_err(|e| Error::Other(format!("no awaiting_approval attempt: {e}")))?;
+
+    // Record the human decision on the timeline (spec §7.1).
+    journal_event(
+        conn,
+        app,
+        run_id,
+        event_type::DECISION,
+        Some(&exec_id),
+        &json!({ "decision": "rejected", "note": note }),
+    );
+
+    // Would a fresh attempt immediately hit the run budget? Mirror the drive
+    // loop's pre-spawn enforcement point (§11.2) against the frozen caps and the
+    // persisted ledger.
+    let run = load_run(conn, run_id)?;
+    let eff: EffectiveBudgets = serde_json::from_str(&run.budgets_json).unwrap_or_default();
+    let spent: Value = serde_json::from_str(&run.spent_json).unwrap_or_else(|_| json!({}));
+    let exhausted = Ledger::from_json(&spent)
+        .exceeded(&eff, super::now_ms())
+        .is_some();
+
+    // Either way the rejected attempt is done with: abandon it so it stops
+    // counting as awaiting_approval and its ferried (now discarded) ref is never
+    // mistaken for the line's fork source (`resume_line_state` only follows `done`
+    // execs).
+    abandon_exec(conn, app, run_id, &exec_id, "rejected");
+
+    if exhausted {
+        journal_event(
+            conn,
+            app,
+            run_id,
+            event_type::RUN_PAUSED,
+            Some(&exec_id),
+            &json!({ "reason": "blocked_gate", "detail": note }),
+        );
+        set_status(conn, app, run_id, "paused", Some("blocked_gate"), None);
+        Ok(false)
+    } else {
+        super::comms::queue_rejection(conn, run_id, &exec_id, note);
+        Ok(true)
+    }
 }
 
 pub(super) fn run_status(conn: &Connection, run_id: &str) -> Result<(String, Option<String>)> {
@@ -6214,6 +6412,35 @@ pub async fn wf_approve(run_id: String, service: Svc<'_>) -> std::result::Result
     service.approve(&run_id).map_err(|e| e.to_string())
 }
 
+/// Reject a run paused on an approval gate (spec §9): re-prompt the step with the
+/// `note` for one more attempt within budget, else pause `blocked_gate`.
+#[tauri::command]
+pub async fn wf_reject(
+    run_id: String,
+    note: String,
+    service: Svc<'_>,
+) -> std::result::Result<(), String> {
+    service.reject(&run_id, &note).map_err(|e| e.to_string())
+}
+
+/// The unified diff of `from_sha..to_sha` in a run's own repository (spec §9) —
+/// the review surface diffs a ferried step ref against the run base, both objects
+/// in `~/.fletch/runs/<id>/repo`. `path` scopes it to one file; omit for the whole
+/// diff. Read-only.
+#[tauri::command]
+pub async fn wf_run_diff(
+    run_id: String,
+    from_sha: String,
+    to_sha: String,
+    path: Option<String>,
+    service: Svc<'_>,
+) -> std::result::Result<String, String> {
+    service
+        .run_diff(&run_id, &from_sha, &to_sha, path.as_deref())
+        .await
+        .map_err(|e| e.to_string())
+}
+
 /// Delete a terminal run and everything it owns (spec §13): run-owned step
 /// agents (and their chats), the run directory, and the run's rows.
 #[tauri::command]
@@ -6796,6 +7023,152 @@ mod tests {
             .unwrap();
         assert_eq!(status, "paused");
         assert_eq!(reason.as_deref(), Some("blocked_gate"));
+    }
+
+    /// Drive a single approval-gated step to its pause and return the db + run id.
+    /// commit=true so the step ferries real work; the gate then awaits a human.
+    async fn drive_to_approval(tmp: &Path, run_id: &str, branch: &str) -> Db {
+        let (db, ws) = scaffold_one_step(tmp, run_id, branch, Gate::Approval { require: vec![] });
+        let ctx = RunCtx {
+            db: db.clone(),
+            driver: StubDriver::new(ws, true),
+            app: None,
+            cancel: Arc::new(AtomicBool::new(false)),
+            pending_ask: Arc::new(AtomicBool::new(false)),
+            deadlines: Deadlines::default(),
+            runs: None,
+        };
+        drive_run(&ctx, run_id).await;
+        db
+    }
+
+    #[tokio::test]
+    async fn approval_pause_journals_review_evidence() {
+        // §9: an approval pause must carry review evidence (verification + diff +
+        // budget + verdict) on its own `gate_evidence` event, keyed to the awaiting
+        // exec, and leave the step `awaiting_approval`.
+        let tmp = tempfile::tempdir().unwrap();
+        let db = drive_to_approval(tmp.path(), "run-appr", "wf/a-1").await;
+        assert_eq!(run_status_str(&db, "run-appr"), "paused");
+        let (reason, awaiting): (Option<String>, i64) = db
+            .lock()
+            .query_row(
+                "SELECT paused_reason,
+                    (SELECT COUNT(*) FROM wf_step_exec
+                     WHERE run_id='run-appr' AND status='awaiting_approval')
+                 FROM wf_run WHERE id='run-appr'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(reason.as_deref(), Some("approval"));
+        assert_eq!(awaiting, 1, "the step waits for approval");
+        assert_eq!(
+            count_events(&db, "run-appr", event_type::GATE_EVIDENCE),
+            1,
+            "one gate_evidence event journaled at the pause"
+        );
+        // The evidence payload carries the diff/budget/verification keys.
+        let payload: String = db
+            .lock()
+            .query_row(
+                "SELECT payload_json FROM wf_event
+                 WHERE run_id='run-appr' AND type=?1 LIMIT 1",
+                [event_type::GATE_EVIDENCE],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let v: Value = serde_json::from_str(&payload).unwrap();
+        assert!(v.get("diff").is_some(), "evidence has a diff: {v}");
+        assert!(v.get("budget").is_some(), "evidence has a budget: {v}");
+        assert!(v.get("verification").is_some(), "evidence has verification");
+    }
+
+    #[tokio::test]
+    async fn reject_with_budget_re_prompts_the_step() {
+        // §9: rejecting with budget left journals the decision, abandons the
+        // rejected attempt, and queues the note as a delivery for the fresh attempt.
+        let tmp = tempfile::tempdir().unwrap();
+        let db = drive_to_approval(tmp.path(), "run-rej", "wf/r-1").await;
+
+        let re_drive = {
+            let conn = db.lock();
+            reject_apply(&conn, None, "run-rej", "  please add a regression test  ").unwrap()
+        };
+        assert!(re_drive, "budget available → re-drive");
+
+        // Decision journaled with the trimmed note.
+        let note: String = db
+            .lock()
+            .query_row(
+                "SELECT json_extract(payload_json,'$.note') FROM wf_event
+                 WHERE run_id='run-rej' AND type='decision' LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(note, "please add a regression test");
+        // The rejected attempt is abandoned (no awaiting_approval lingers).
+        let awaiting: i64 = db
+            .lock()
+            .query_row(
+                "SELECT COUNT(*) FROM wf_step_exec
+                 WHERE run_id='run-rej' AND status='awaiting_approval'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(awaiting, 0, "rejected attempt abandoned");
+        // A notify delivery carrying the note is queued for the step's next attempt.
+        let queued: i64 = db
+            .lock()
+            .query_row(
+                "SELECT COUNT(*) FROM wf_message
+                 WHERE run_id='run-rej' AND kind='notify' AND status='queued'
+                   AND body_json LIKE '%regression test%'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(queued, 1, "the note is queued as a delivery");
+    }
+
+    #[tokio::test]
+    async fn reject_without_budget_pauses_blocked_gate_with_the_note() {
+        // §9 / §6.5: with the run budget spent there is no attempt to give — the
+        // reject pauses `blocked_gate` carrying the note as detail, no re-drive.
+        let tmp = tempfile::tempdir().unwrap();
+        let db = drive_to_approval(tmp.path(), "run-rej2", "wf/r-2").await;
+        // Spend the whole default turn budget (100) so a fresh attempt can't run.
+        db.lock()
+            .execute(
+                "UPDATE wf_run SET spent_json='{\"turns\":100}' WHERE id='run-rej2'",
+                [],
+            )
+            .unwrap();
+
+        let re_drive = {
+            let conn = db.lock();
+            reject_apply(&conn, None, "run-rej2", "out of scope").unwrap()
+        };
+        assert!(!re_drive, "budget spent → no re-drive");
+
+        let (status, reason, detail): (String, Option<String>, Option<String>) = db
+            .lock()
+            .query_row(
+                "SELECT r.status, r.paused_reason,
+                    (SELECT json_extract(payload_json,'$.detail') FROM wf_event
+                     WHERE run_id='run-rej2' AND type='run_paused'
+                       AND json_extract(payload_json,'$.reason')='blocked_gate'
+                     ORDER BY seq DESC LIMIT 1)
+                 FROM wf_run r WHERE r.id='run-rej2'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "paused");
+        assert_eq!(reason.as_deref(), Some("blocked_gate"));
+        assert_eq!(detail.as_deref(), Some("out of scope"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/workflow/spec.rs
+++ b/src-tauri/src/workflow/spec.rs
@@ -144,8 +144,38 @@ pub enum Gate {
     Artifact { path: String },
     /// The project test command exits 0.
     Tests,
-    /// A human approves.
-    Approval,
+    /// A human approves — optionally only after the listed deterministic gates
+    /// pass first (`require: [tests]`, spec §9). The approval pause is
+    /// unreachable while a required gate is unmet: a red `require: [tests]`
+    /// behaves exactly like a failing `tests` gate (blocked + re-prompt).
+    Approval {
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        require: Vec<Require>,
+    },
+}
+
+/// A deterministic prerequisite an `approval` gate can demand before it will
+/// pause for a human (spec §9). Only `tests` today; modeled as an enum so an
+/// unknown value fails deserialization loudly rather than being silently
+/// dropped, and so adding future prerequisites stays a typed change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Require {
+    Tests,
+}
+
+impl Gate {
+    /// Whether satisfying this gate requires running the project's tests: a
+    /// `tests` gate always, or an `approval` gate listing `require: [tests]`.
+    /// The attempt lifecycle consults this to decide whether to run the test
+    /// runner before evaluating the gate (spec §9.4).
+    pub fn requires_tests(&self) -> bool {
+        match self {
+            Gate::Tests => true,
+            Gate::Approval { require } => require.contains(&Require::Tests),
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -881,6 +911,42 @@ mod tests {
             step.gate = Gate::Tests;
         }
         assert!(validate(&s).is_ok(), "{:?}", errors(&s));
+    }
+
+    #[test]
+    fn approval_gate_with_and_without_require_is_accepted() {
+        // A bare `approval` gate and one that gates on tests first both validate.
+        for require in [vec![], vec![Require::Tests]] {
+            let mut s = minimal();
+            if let Block::Step(step) = &mut s.workflow[0] {
+                step.gate = Gate::Approval { require };
+            }
+            assert!(validate(&s).is_ok(), "{:?}", errors(&s));
+        }
+    }
+
+    #[test]
+    fn bare_approval_gate_json_round_trips_and_is_backward_compatible() {
+        // The pre-`require` on-disk shape is `{"type":"approval"}`; it must still
+        // deserialize (empty `require`), and an empty `require` must serialize
+        // back to that exact shape so old definitions round-trip byte-for-byte.
+        let bare: Gate = serde_json::from_str(r#"{"type":"approval"}"#).unwrap();
+        assert_eq!(bare, Gate::Approval { require: vec![] });
+        assert_eq!(
+            serde_json::to_string(&bare).unwrap(),
+            r#"{"type":"approval"}"#
+        );
+        let with: Gate =
+            serde_json::from_str(r#"{"type":"approval","require":["tests"]}"#).unwrap();
+        assert_eq!(
+            with,
+            Gate::Approval {
+                require: vec![Require::Tests]
+            }
+        );
+        assert!(with.requires_tests());
+        assert!(!bare.requires_tests());
+        assert!(Gate::Tests.requires_tests());
     }
 
     #[test]

--- a/src-tauri/src/workflow/types.rs
+++ b/src-tauri/src/workflow/types.rs
@@ -152,6 +152,12 @@ pub mod event_type {
     pub const PROMPT_SENT: &str = "prompt_sent";
     pub const TURN_ENDED: &str = "turn_ended";
     pub const GATE_EVALUATED: &str = "gate_evaluated";
+    /// The review evidence assembled when an `approval` gate pauses the run
+    /// (spec §9): the verification report, the ferried diff vs the run base,
+    /// budget spend vs cap, and the step's verdict summary. Carried on its own
+    /// event (keyed to the awaiting step exec) so ReviewSurface can query the
+    /// latest one from `wf_events` without parsing `run_paused`.
+    pub const GATE_EVIDENCE: &str = "gate_evidence";
     pub const BOUNDARY_COMMIT: &str = "boundary_commit";
     pub const ATTEMPT_ABANDONED: &str = "attempt_abandoned";
     pub const ATTEMPT_ERROR: &str = "attempt_error";

--- a/src/api.ts
+++ b/src/api.ts
@@ -396,6 +396,54 @@ export interface VerificationReport {
   checks: CheckResult[];
 }
 
+/** One changed file in an approval gate's ferried diff. */
+export interface GateDiffFile {
+  path: string;
+  additions: number;
+  deletions: number;
+}
+
+/** The ferried diff (vs the run base) summarized for review. */
+export interface GateDiff {
+  additions: number;
+  deletions: number;
+  files: GateDiffFile[];
+}
+
+/** Budget spent vs cap at an approval pause. `tokens_cap === null` means the run
+ *  has no token cap; a `tokens_spent` of 0 with no cap should render as "unknown"
+ *  (some providers don't report token usage — driver.rs). */
+export interface GateBudget {
+  turns_spent: number;
+  turns_cap: number;
+  tokens_spent: number;
+  tokens_cap: number | null;
+  wall_ms_spent: number;
+  wall_clock_cap_mins: number;
+}
+
+/** A reviewer step's `verdict.json` summary carried in the evidence. */
+export interface GateVerdict {
+  result: string;
+  summary: string;
+  detail: string | null;
+  target: string | null;
+}
+
+/** The review evidence assembled when an approval gate pauses a run (the Rust
+ *  `gate_evidence` event payload, spec §9): verification, the ferried diff vs the
+ *  run base, budget spend, and the step's verdict. `verification` is null when the
+ *  host couldn't build a verifier; its checks are all `skipped` when the project
+ *  configures no commands. `base_sha`/`head_sha` feed `api.wfRunDiff`. */
+export interface GateEvidence {
+  base_sha: string;
+  head_sha: string;
+  verification: VerificationReport | null;
+  diff: GateDiff;
+  budget: GateBudget;
+  verdict: GateVerdict | null;
+}
+
 /** Project-scoped run config resolved from a repo path: the detected configs
  *  plus the project_id they belong to (see Rust `supervisor::ProjectRunConfig`). */
 export interface ProjectRunConfig {
@@ -856,6 +904,14 @@ export const api = {
   wfCancel: (runId: string) => invoke<void>("wf_cancel", { runId }),
   /** Approve a run paused on an approval gate: boundary-commit + advance. */
   wfApprove: (runId: string) => invoke<void>("wf_approve", { runId }),
+  /** Reject a run paused on an approval gate (spec §9): re-prompt the gated step
+   *  with `note` for one more attempt within budget, else pause `blocked_gate`. */
+  wfReject: (runId: string, note: string) => invoke<void>("wf_reject", { runId, note }),
+  /** The unified diff of `fromSha..toSha` in a run's own repo — used by the review
+   *  surface to diff a ferried step ref against the run base. `path` scopes to one
+   *  file; omit for the whole diff. */
+  wfRunDiff: (runId: string, fromSha: string, toSha: string, path?: string) =>
+    invoke<string>("wf_run_diff", { runId, fromSha, toSha, path: path ?? null }),
   /** Retry a run paused on `blocked_gate` / `stalled` with a fresh attempt. */
   wfRetry: (runId: string) => invoke<void>("wf_retry", { runId }),
   /** Resume a paused run (§13). An optional `budgetPatch` additively raises the

--- a/src/app.css
+++ b/src/app.css
@@ -43,3 +43,4 @@
 @import "./components/SettingsScreen/CustomAgents/CustomAgents.css";
 @import "./components/ui/Loader.css";
 @import "./components/ui/Select.css";
+@import "./components/ReviewSurface/ReviewSurface.css";

--- a/src/components/ReviewSurface/BudgetSummary.test.ts
+++ b/src/components/ReviewSurface/BudgetSummary.test.ts
@@ -1,0 +1,38 @@
+// Tests for tokenBudgetLabel — the review surface's budget degraded-state rule.
+// The bug this guards: rendering unreported token usage as a confident "0"
+// instead of "unknown" (provider token usage is sometimes absent, driver.rs).
+
+import { describe, expect, it } from "vitest";
+import type { GateBudget } from "../../api";
+import { tokenBudgetLabel } from "./BudgetSummary";
+
+function budget(over: Partial<GateBudget>): GateBudget {
+  return {
+    turns_spent: 0,
+    turns_cap: 100,
+    tokens_spent: 0,
+    tokens_cap: null,
+    wall_ms_spent: 0,
+    wall_clock_cap_mins: 480,
+    ...over,
+  };
+}
+
+describe("tokenBudgetLabel", () => {
+  it("reads no cap + nothing measured as unknown, not zero", () => {
+    const r = tokenBudgetLabel(budget({ tokens_cap: null, tokens_spent: 0 }));
+    expect(r).toEqual({ text: "unknown", unknown: true });
+  });
+
+  it("shows spent / cap when the run has a token cap", () => {
+    const r = tokenBudgetLabel(budget({ tokens_cap: 500_000, tokens_spent: 1234 }));
+    expect(r.unknown).toBe(false);
+    expect(r.text).toBe("1,234 / 500,000");
+  });
+
+  it("shows what was used when uncapped but measured", () => {
+    const r = tokenBudgetLabel(budget({ tokens_cap: null, tokens_spent: 2048 }));
+    expect(r.unknown).toBe(false);
+    expect(r.text).toBe("2,048 used");
+  });
+});

--- a/src/components/ReviewSurface/BudgetSummary.tsx
+++ b/src/components/ReviewSurface/BudgetSummary.tsx
@@ -1,0 +1,43 @@
+// ReviewSurface/BudgetSummary — spent vs cap for the three run-level budgets.
+// Tokens can be genuinely unknown (some providers don't report usage), which
+// renders as "unknown" rather than a misleading zero.
+
+import type { GateBudget } from "../../api";
+
+const fmt = (n: number) => n.toLocaleString();
+
+/** Token budget display, encoding the degraded-state rule: some providers don't
+ *  report token usage, so no cap + zero measured reads as genuinely "unknown"
+ *  (never a misleading 0). A cap shows spent/cap; an uncapped-but-measured run
+ *  shows what was used. `unknown` is `true` when the value should render quietly. */
+export function tokenBudgetLabel(budget: GateBudget): { text: string; unknown: boolean } {
+  if (budget.tokens_cap == null && budget.tokens_spent === 0) {
+    return { text: "unknown", unknown: true };
+  }
+  if (budget.tokens_cap != null) {
+    return { text: `${fmt(budget.tokens_spent)} / ${fmt(budget.tokens_cap)}`, unknown: false };
+  }
+  return { text: `${fmt(budget.tokens_spent)} used`, unknown: false };
+}
+
+export function BudgetSummary({ budget }: { budget: GateBudget }) {
+  const minsSpent = Math.round(budget.wall_ms_spent / 60_000);
+  const tokens = tokenBudgetLabel(budget);
+
+  return (
+    <div className="rv-budget">
+      <Item label="Turns" value={`${fmt(budget.turns_spent)} / ${fmt(budget.turns_cap)}`} />
+      <Item label="Tokens" value={tokens.text} muted={tokens.unknown} />
+      <Item label="Time" value={`${fmt(minsSpent)} / ${fmt(budget.wall_clock_cap_mins)} min`} />
+    </div>
+  );
+}
+
+function Item({ label, value, muted }: { label: string; value: string; muted?: boolean }) {
+  return (
+    <div className="rv-budget-item">
+      <span className="rv-budget-label">{label}</span>
+      <span className={`rv-budget-value mono ${muted ? "muted" : ""}`}>{value}</span>
+    </div>
+  );
+}

--- a/src/components/ReviewSurface/Checks.tsx
+++ b/src/components/ReviewSurface/Checks.tsx
@@ -1,0 +1,78 @@
+// ReviewSurface/Checks — the verification report as scannable pass/fail rows,
+// mirroring GitPanel's ChecksSection vocabulary (ok / fail / skip dots). Passing
+// checks stay quiet; only failures draw attention. Output tails are progressive
+// disclosure — collapsed by default, expandable per row.
+
+import { useState } from "react";
+import type { CheckOutcome, CheckResult, VerificationReport } from "../../api";
+import { Icon } from "../Icon";
+
+type Tone = "ok" | "fail" | "skip";
+
+const TONE: Record<CheckOutcome, Tone> = {
+  passed: "ok",
+  failed: "fail",
+  timed_out: "fail",
+  setup_failed: "fail",
+  skipped: "skip",
+};
+
+const LABEL: Record<CheckOutcome, string> = {
+  passed: "passed",
+  failed: "failed",
+  timed_out: "timed out",
+  setup_failed: "setup failed",
+  skipped: "skipped",
+};
+
+export function Checks({ verification }: { verification: VerificationReport | null }) {
+  // Null verifier (e.g. no sandbox on this host) vs. nothing configured are
+  // distinct, honest states — never a fake empty or failed report.
+  if (!verification) {
+    return <div className="rv-checks-note">Verification isn't available on this host.</div>;
+  }
+  const ran = verification.checks.filter((c) => c.outcome !== "skipped");
+  if (ran.length === 0) {
+    return (
+      <div className="rv-checks-note">
+        No verification commands are configured for this project.
+      </div>
+    );
+  }
+  // Failures first so what needs attention is at the top.
+  const ordered = [...verification.checks].sort(
+    (a, b) => rank(TONE[a.outcome]) - rank(TONE[b.outcome]),
+  );
+  return (
+    <div className="rv-checks">
+      {ordered.map((c) => (
+        <CheckRow key={c.name} check={c} />
+      ))}
+    </div>
+  );
+}
+
+const rank = (t: Tone) => (t === "fail" ? 0 : t === "ok" ? 1 : 2);
+
+function CheckRow({ check }: { check: CheckResult }) {
+  const [open, setOpen] = useState(false);
+  const tone = TONE[check.outcome];
+  const hasTail = check.tail.length > 0;
+  return (
+    <div className={`rv-check ${tone}`}>
+      <button
+        type="button"
+        className="rv-check-head"
+        disabled={!hasTail}
+        onClick={() => hasTail && setOpen((v) => !v)}
+      >
+        <span className={`rv-dot ${tone}`} />
+        <span className="rv-check-name">{check.name}</span>
+        <span className="rv-check-cmd truncate">{check.command || "—"}</span>
+        <span className={`rv-check-status ${tone}`}>{LABEL[check.outcome]}</span>
+        {hasTail && <Icon name={open ? "chevD" : "chevR"} size={13} className="rv-check-chev" />}
+      </button>
+      {open && hasTail && <pre className="rv-check-tail">{check.tail.join("\n")}</pre>}
+    </div>
+  );
+}

--- a/src/components/ReviewSurface/DiffPanel.tsx
+++ b/src/components/ReviewSurface/DiffPanel.tsx
@@ -1,0 +1,128 @@
+// ReviewSurface/DiffPanel — the ferried diff: a file list on the left, the
+// selected file's unified diff on the right. Reuses the Code panel's diff
+// machinery (`parseUnifiedDiff` + `DiffBody`) so highlighting and markup match
+// the rest of the app; the diff source is injected (`getDiff`) so the surface
+// stays decoupled from any run-specific fetch.
+
+import { useEffect, useState } from "react";
+import type { GateDiffFile } from "../../api";
+import { useHljsTheme } from "../../util/codeTheme";
+import { type DiffHunk, parseUnifiedDiff } from "../../util/diff";
+import { Icon } from "../Icon";
+import { DiffBody, extOf } from "../RightPanel/Code/DiffView";
+
+export function DiffPanel({
+  files,
+  getDiff,
+}: {
+  files: GateDiffFile[];
+  getDiff: (path: string | null) => Promise<string>;
+}) {
+  const [selected, setSelected] = useState<string | null>(files[0]?.path ?? null);
+  const isBuiltInTheme = useHljsTheme();
+
+  // Keep the selection valid as the file set changes (e.g. a re-review).
+  useEffect(() => {
+    if (files.length > 0 && !files.some((f) => f.path === selected)) {
+      setSelected(files[0].path);
+    }
+  }, [files, selected]);
+
+  if (files.length === 0) {
+    return (
+      <div className="empty-msg" style={{ margin: "auto" }}>
+        <div className="et">No file changes</div>
+        <div>This step produced no diff against the run base.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rv-diff">
+      <div className="rv-files">
+        {files.map((f) => (
+          <button
+            key={f.path}
+            type="button"
+            className={`rv-file ${f.path === selected ? "active" : ""}`}
+            onClick={() => setSelected(f.path)}
+          >
+            <Icon name="file" size={12} className="rv-file-icon" />
+            <span className="rv-file-path truncate">{f.path}</span>
+            <span className="rv-file-stat">
+              <span className="add">+{f.additions}</span>
+              <span className="rem">−{f.deletions}</span>
+            </span>
+          </button>
+        ))}
+      </div>
+      <div className="rv-diff-body">
+        {selected && (
+          <FileDiff
+            key={selected}
+            path={selected}
+            getDiff={getDiff}
+            isBuiltInTheme={isBuiltInTheme}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+type LoadState = "loading" | "loaded" | "error";
+
+function FileDiff({
+  path,
+  getDiff,
+  isBuiltInTheme,
+}: {
+  path: string;
+  getDiff: (path: string | null) => Promise<string>;
+  isBuiltInTheme: boolean;
+}) {
+  const [hunks, setHunks] = useState<DiffHunk[]>([]);
+  const [state, setState] = useState<LoadState>("loading");
+
+  useEffect(() => {
+    let cancelled = false;
+    setState("loading");
+    getDiff(path)
+      .then((text) => {
+        if (cancelled) return;
+        setHunks(parseUnifiedDiff(text));
+        setState("loaded");
+      })
+      .catch(() => {
+        if (!cancelled) setState("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [path, getDiff]);
+
+  if (state === "loading") {
+    return (
+      <div className="empty-msg" style={{ margin: "auto" }}>
+        <div className="et">Loading diff…</div>
+      </div>
+    );
+  }
+  if (state === "error") {
+    return (
+      <div className="empty-msg" style={{ margin: "auto" }}>
+        <div className="et">Couldn't load diff</div>
+        <div>Reopen the review to try again.</div>
+      </div>
+    );
+  }
+  if (hunks.length === 0) {
+    return (
+      <div className="empty-msg" style={{ margin: "auto" }}>
+        <div className="et">No textual diff</div>
+        <div>This change has no line-level diff to show.</div>
+      </div>
+    );
+  }
+  return <DiffBody hunks={hunks} lang={extOf(path)} isBuiltInTheme={isBuiltInTheme} />;
+}

--- a/src/components/ReviewSurface/ReviewActions.tsx
+++ b/src/components/ReviewSurface/ReviewActions.tsx
@@ -8,10 +8,13 @@ import { Icon } from "../Icon";
 import { Button } from "../ui";
 
 export function ReviewActions({
+  disabled = false,
   onApprove,
   onReject,
   onError,
 }: {
+  /** Evidence hasn't arrived yet — hold both decisions until it renders. */
+  disabled?: boolean;
   onApprove: () => Promise<void>;
   onReject: (note: string) => Promise<void>;
   onError?: (message: string) => void;
@@ -27,7 +30,7 @@ export function ReviewActions({
   }, [rejecting]);
 
   const run = async (action: () => Promise<void>) => {
-    if (busy) return;
+    if (busy || disabled) return;
     setBusy(true);
     try {
       await action();
@@ -86,10 +89,15 @@ export function ReviewActions({
 
   return (
     <div className="rv-actions-row">
-      <Button variant="outline" danger disabled={busy} onClick={() => setRejecting(true)}>
+      <Button
+        variant="outline"
+        danger
+        disabled={busy || disabled}
+        onClick={() => setRejecting(true)}
+      >
         <Icon name="close" size={13} /> Request changes
       </Button>
-      <Button variant="primary" disabled={busy} onClick={() => void run(onApprove)}>
+      <Button variant="primary" disabled={busy || disabled} onClick={() => void run(onApprove)}>
         <Icon name="check" size={13} /> Approve
       </Button>
     </div>

--- a/src/components/ReviewSurface/ReviewActions.tsx
+++ b/src/components/ReviewSurface/ReviewActions.tsx
@@ -1,0 +1,97 @@
+// ReviewSurface/ReviewActions — the Approve / Request-changes footer. Reject
+// requires a note (a textarea), and the consequence is stated plainly: the
+// step's agent gets one more attempt within budget. Owns its own busy + note
+// state so the surface can stay a pure view.
+
+import { useEffect, useRef, useState } from "react";
+import { Icon } from "../Icon";
+import { Button } from "../ui";
+
+export function ReviewActions({
+  onApprove,
+  onReject,
+  onError,
+}: {
+  onApprove: () => Promise<void>;
+  onReject: (note: string) => Promise<void>;
+  onError?: (message: string) => void;
+}) {
+  const [rejecting, setRejecting] = useState(false);
+  const [note, setNote] = useState("");
+  const [busy, setBusy] = useState(false);
+  const noteRef = useRef<HTMLTextAreaElement>(null);
+
+  // Focus the note the moment the reject form opens — it's the sole task now.
+  useEffect(() => {
+    if (rejecting) noteRef.current?.focus();
+  }, [rejecting]);
+
+  const run = async (action: () => Promise<void>) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await action();
+      // On success the run row flips over the `wf:run` subscription; the parent
+      // closes the surface. Nothing to do here.
+    } catch (e) {
+      onError?.(`Action failed: ${e}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const submitReject = () => {
+    const trimmed = note.trim();
+    if (!trimmed || busy) return;
+    void run(() => onReject(trimmed));
+  };
+
+  if (rejecting) {
+    return (
+      <div className="rv-reject">
+        <label className="rv-reject-label" htmlFor="rv-reject-note">
+          Request changes
+        </label>
+        <textarea
+          id="rv-reject-note"
+          ref={noteRef}
+          className="rv-reject-input"
+          placeholder="What needs to change before this can be approved? Be specific — this note is sent straight to the agent."
+          value={note}
+          disabled={busy}
+          onChange={(e) => setNote(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+              e.preventDefault();
+              submitReject();
+            }
+          }}
+        />
+        <div className="rv-reject-row">
+          <span className="rv-reject-hint">
+            The step's agent gets one more attempt within budget.
+          </span>
+          <div className="rv-reject-btns">
+            <Button variant="ghost" disabled={busy} onClick={() => setRejecting(false)}>
+              Cancel
+            </Button>
+            <Button variant="outline" danger disabled={busy || !note.trim()} onClick={submitReject}>
+              <Icon name="close" size={13} /> Send rejection
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rv-actions-row">
+      <Button variant="outline" danger disabled={busy} onClick={() => setRejecting(true)}>
+        <Icon name="close" size={13} /> Request changes
+      </Button>
+      <Button variant="primary" disabled={busy} onClick={() => void run(onApprove)}>
+        <Icon name="check" size={13} /> Approve
+      </Button>
+    </div>
+  );
+}

--- a/src/components/ReviewSurface/ReviewSurface.css
+++ b/src/components/ReviewSurface/ReviewSurface.css
@@ -1,0 +1,394 @@
+/* ReviewSurface — the approval-gate review surface (spec §9). Tokens only: no
+ * hardcoded colors or font-sizes. Mirrors GitPanel's pass/fail vocabulary and the
+ * app's card/section conventions so it reads as one system in both themes. */
+
+/* ── modal chrome (used by PausedBanner's "Review changes…") ─────────────── */
+.rv-modal {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-overlay);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  background: color-mix(in oklch, var(--bg-0) 55%, transparent);
+}
+.rv-modal-card {
+  display: flex;
+  flex-direction: column;
+  width: min(920px, 100%);
+  max-height: min(84vh, 900px);
+  background: var(--bg-1);
+  border: 1px solid var(--bd);
+  border-radius: var(--r-lg);
+  box-shadow: var(--shadow-2);
+  overflow: hidden;
+}
+.rv-modal-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--bd-soft);
+  flex-shrink: 0;
+}
+.rv-modal-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  color: var(--fg-0);
+}
+.rv-modal-title .rv-modal-step {
+  color: var(--fg-2);
+  font-weight: 400;
+}
+.rv-modal-close {
+  margin-left: auto;
+}
+
+/* ── surface shell ───────────────────────────────────────────────────────── */
+.review-surface {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
+}
+.rv-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 14px;
+  overflow-y: auto;
+  min-height: 0;
+  flex: 1;
+}
+.rv-foot {
+  flex-shrink: 0;
+  padding: 10px 14px;
+  border-top: 1px solid var(--bd-soft);
+  background: var(--bg-1);
+}
+
+/* ── summary tiles (diff + budget at a glance) ───────────────────────────── */
+.rv-summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.6fr);
+  gap: 10px;
+}
+.rv-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  background: var(--bg-2);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-md);
+}
+.rv-tile-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--fg-2);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: var(--fs-xs);
+}
+.rv-tile-value {
+  font-size: var(--fs-lg);
+  font-weight: 600;
+  color: var(--fg-0);
+}
+.rv-tile-sub {
+  font-size: var(--fs-sm);
+  font-weight: 400;
+  color: var(--fg-2);
+}
+
+/* Additions / deletions colouring, shared across tiles, the file list, etc. */
+.review-surface .add {
+  color: var(--success);
+}
+.review-surface .rem {
+  color: var(--danger);
+}
+
+/* ── budget ──────────────────────────────────────────────────────────────── */
+.rv-budget {
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+.rv-budget-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.rv-budget-label {
+  font-size: var(--fs-xs);
+  color: var(--fg-3);
+}
+.rv-budget-value {
+  font-size: var(--fs-base);
+  color: var(--fg-1);
+}
+.rv-budget-value.muted {
+  color: var(--fg-3);
+  font-style: italic;
+}
+
+/* ── sections ────────────────────────────────────────────────────────────── */
+.rv-sect {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.rv-sect-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--fg-1);
+  font-weight: 600;
+  font-size: var(--fs-sm);
+}
+.rv-sect-diff {
+  flex: 1;
+  min-height: 240px;
+}
+
+/* ── checks ──────────────────────────────────────────────────────────────── */
+.rv-checks {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-md);
+  overflow: hidden;
+}
+.rv-checks-note {
+  color: var(--fg-3);
+  font-size: var(--fs-sm);
+  padding: 8px 2px;
+}
+.rv-check + .rv-check {
+  border-top: 1px solid var(--bd-soft);
+}
+.rv-check-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  background: var(--bg-1);
+  text-align: left;
+}
+.rv-check-head:not(:disabled):hover {
+  background: var(--hover);
+}
+.rv-check.fail .rv-check-head {
+  background: color-mix(in oklch, var(--danger) 8%, transparent);
+}
+.rv-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.rv-dot.ok {
+  background: var(--success);
+}
+.rv-dot.fail {
+  background: var(--danger);
+}
+.rv-dot.skip {
+  background: var(--fg-3);
+}
+.rv-check-name {
+  font-weight: 500;
+  color: var(--fg-0);
+  min-width: 48px;
+}
+.rv-check-cmd {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--fg-2);
+}
+.rv-check-status {
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.rv-check-status.ok {
+  color: var(--success);
+}
+.rv-check-status.fail {
+  color: var(--danger);
+}
+.rv-check-status.skip {
+  color: var(--fg-3);
+}
+.rv-check-chev {
+  color: var(--fg-3);
+}
+.rv-check-tail {
+  margin: 0;
+  padding: 8px 10px 10px 26px;
+  background: var(--bg-2);
+  border-top: 1px solid var(--bd-soft);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  line-height: var(--lh-snug);
+  color: var(--fg-1);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 260px;
+  overflow: auto;
+}
+
+/* ── verdict ─────────────────────────────────────────────────────────────── */
+.rv-verdict-badge {
+  padding: 1px 7px;
+  border-radius: var(--r-xs);
+  font-size: var(--fs-xs);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.rv-verdict-badge.v-done {
+  background: color-mix(in oklch, var(--success) 16%, transparent);
+  color: var(--success);
+}
+.rv-verdict-badge.v-revise {
+  background: color-mix(in oklch, var(--att) 16%, transparent);
+  color: var(--att);
+}
+.rv-verdict-badge.v-blocked {
+  background: color-mix(in oklch, var(--danger) 16%, transparent);
+  color: var(--danger);
+}
+.rv-verdict-summary {
+  color: var(--fg-1);
+  font-size: var(--fs-base);
+  line-height: var(--lh-normal);
+}
+.rv-verdict-detail {
+  margin: 0;
+  padding: 8px 10px;
+  background: var(--bg-2);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-sm);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  line-height: var(--lh-snug);
+  color: var(--fg-2);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 200px;
+  overflow: auto;
+}
+
+/* ── diff (file list + body) ─────────────────────────────────────────────── */
+.rv-diff {
+  display: grid;
+  grid-template-columns: minmax(160px, 240px) minmax(0, 1fr);
+  gap: 10px;
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-md);
+  overflow: hidden;
+  min-height: 240px;
+}
+.rv-files {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--bd-soft);
+  background: var(--bg-2);
+  overflow-y: auto;
+}
+.rv-file {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  text-align: left;
+  color: var(--fg-1);
+  border-bottom: 1px solid var(--bd-soft);
+}
+.rv-file:hover {
+  background: var(--hover);
+}
+.rv-file.active {
+  background: var(--selected);
+  color: var(--fg-0);
+}
+.rv-file-icon {
+  color: var(--fg-3);
+  flex-shrink: 0;
+}
+.rv-file-path {
+  flex: 1;
+  min-width: 0;
+  font-size: var(--fs-sm);
+}
+.rv-file-stat {
+  display: inline-flex;
+  gap: 5px;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  flex-shrink: 0;
+}
+.rv-diff-body {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: auto;
+  background: var(--bg-1);
+}
+
+/* ── actions / reject form ───────────────────────────────────────────────── */
+.rv-actions-row {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.rv-reject {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.rv-reject-label {
+  font-weight: 600;
+  color: var(--fg-0);
+  font-size: var(--fs-sm);
+}
+.rv-reject-input {
+  width: 100%;
+  min-height: 72px;
+  resize: vertical;
+  padding: 8px 10px;
+  background: var(--bg-2);
+  border: 1px solid var(--bd);
+  border-radius: var(--r-sm);
+  color: var(--fg-0);
+  font-family: var(--font-sans);
+  font-size: var(--fs-base);
+  line-height: var(--lh-normal);
+}
+.rv-reject-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.rv-reject-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.rv-reject-hint {
+  flex: 1;
+  color: var(--fg-3);
+  font-size: var(--fs-sm);
+}
+.rv-reject-btns {
+  display: flex;
+  gap: 8px;
+}

--- a/src/components/ReviewSurface/index.tsx
+++ b/src/components/ReviewSurface/index.tsx
@@ -1,0 +1,118 @@
+// ReviewSurface — the shared surface a human uses to decide a merge/handoff at
+// a workflow approval gate (spec §9). It shows the evidence (verification, the
+// ferried diff, budget spend, the step's verdict) and offers Approve / Request
+// changes. It is intentionally decoupled from any store: everything arrives as
+// props (evidence + a diff source + callbacks), so the next PR can mount the same
+// component from a fleet review queue without change.
+
+import type { GateEvidence } from "../../api";
+import { Icon } from "../Icon";
+import { BudgetSummary } from "./BudgetSummary";
+import { Checks } from "./Checks";
+import { DiffPanel } from "./DiffPanel";
+import { ReviewActions } from "./ReviewActions";
+
+export interface ReviewSurfaceProps {
+  /** The assembled gate evidence, or `null` while it's still being prepared. */
+  evidence: GateEvidence | null;
+  /** Fetch a file's unified diff (the whole diff when `path` is `null`). */
+  getDiff: (path: string | null) => Promise<string>;
+  /** Promote the step and advance the run. */
+  onApprove: () => Promise<void>;
+  /** Send the reviewer's note back to the step for another attempt. */
+  onReject: (note: string) => Promise<void>;
+  /** Surface an action failure (the parent's inline error channel). */
+  onError?: (message: string) => void;
+}
+
+export function ReviewSurface({
+  evidence,
+  getDiff,
+  onApprove,
+  onReject,
+  onError,
+}: ReviewSurfaceProps) {
+  return (
+    <div className="review-surface">
+      <div className="rv-body">
+        {evidence ? <Evidence evidence={evidence} getDiff={getDiff} /> : <Preparing />}
+      </div>
+      <div className="rv-foot">
+        <ReviewActions onApprove={onApprove} onReject={onReject} onError={onError} />
+      </div>
+    </div>
+  );
+}
+
+function Evidence({
+  evidence,
+  getDiff,
+}: {
+  evidence: GateEvidence;
+  getDiff: (path: string | null) => Promise<string>;
+}) {
+  const { diff, verdict } = evidence;
+  return (
+    <>
+      <div className="rv-summary">
+        <div className="rv-tile">
+          <span className="rv-tile-label">
+            <Icon name="diff" size={12} /> Changes
+          </span>
+          <span className="rv-tile-value">
+            <span className="add">+{diff.additions}</span>{" "}
+            <span className="rem">−{diff.deletions}</span>
+            <span className="rv-tile-sub">
+              {" · "}
+              {diff.files.length} {diff.files.length === 1 ? "file" : "files"}
+            </span>
+          </span>
+        </div>
+        <div className="rv-tile rv-tile-budget">
+          <span className="rv-tile-label">
+            <Icon name="zap" size={12} /> Budget
+          </span>
+          <BudgetSummary budget={evidence.budget} />
+        </div>
+      </div>
+
+      {verdict && (
+        <section className="rv-sect">
+          <div className="rv-sect-head">
+            <Icon name="notebookPen" size={13} /> Verdict
+            <span className={`rv-verdict-badge v-${verdict.result}`}>{verdict.result}</span>
+          </div>
+          {verdict.summary.trim() ? (
+            <div className="rv-verdict-summary">{verdict.summary}</div>
+          ) : (
+            <div className="rv-checks-note">The step left no summary.</div>
+          )}
+          {verdict.detail?.trim() && <pre className="rv-verdict-detail">{verdict.detail}</pre>}
+        </section>
+      )}
+
+      <section className="rv-sect">
+        <div className="rv-sect-head">
+          <Icon name="flask" size={13} /> Checks
+        </div>
+        <Checks verification={evidence.verification} />
+      </section>
+
+      <section className="rv-sect rv-sect-diff">
+        <div className="rv-sect-head">
+          <Icon name="code" size={13} /> Diff
+        </div>
+        <DiffPanel files={diff.files} getDiff={getDiff} />
+      </section>
+    </>
+  );
+}
+
+function Preparing() {
+  return (
+    <div className="empty-msg" style={{ margin: "auto" }}>
+      <div className="et">Preparing the review…</div>
+      <div>Gathering verification, the diff, and budget for this step.</div>
+    </div>
+  );
+}

--- a/src/components/ReviewSurface/index.tsx
+++ b/src/components/ReviewSurface/index.tsx
@@ -13,8 +13,11 @@ import { DiffPanel } from "./DiffPanel";
 import { ReviewActions } from "./ReviewActions";
 
 export interface ReviewSurfaceProps {
-  /** The assembled gate evidence, or `null` while it's still being prepared. */
+  /** The assembled gate evidence, or `null` when none was journaled. */
   evidence: GateEvidence | null;
+  /** Evidence may still arrive (events are loading). Actions stay disabled —
+   *  approving before the evidence renders defeats the surface's purpose. */
+  pending?: boolean;
   /** Fetch a file's unified diff (the whole diff when `path` is `null`). */
   getDiff: (path: string | null) => Promise<string>;
   /** Promote the step and advance the run. */
@@ -27,18 +30,31 @@ export interface ReviewSurfaceProps {
 
 export function ReviewSurface({
   evidence,
+  pending = false,
   getDiff,
   onApprove,
   onReject,
   onError,
 }: ReviewSurfaceProps) {
+  const waiting = pending && !evidence;
   return (
     <div className="review-surface">
       <div className="rv-body">
-        {evidence ? <Evidence evidence={evidence} getDiff={getDiff} /> : <Preparing />}
+        {evidence ? (
+          <Evidence evidence={evidence} getDiff={getDiff} />
+        ) : waiting ? (
+          <Preparing />
+        ) : (
+          <NoEvidence />
+        )}
       </div>
       <div className="rv-foot">
-        <ReviewActions onApprove={onApprove} onReject={onReject} onError={onError} />
+        <ReviewActions
+          disabled={waiting}
+          onApprove={onApprove}
+          onReject={onReject}
+          onError={onError}
+        />
       </div>
     </div>
   );
@@ -113,6 +129,18 @@ function Preparing() {
     <div className="empty-msg" style={{ margin: "auto" }}>
       <div className="et">Preparing the review…</div>
       <div>Gathering verification, the diff, and budget for this step.</div>
+    </div>
+  );
+}
+
+/** The pause pre-dates evidence collection (or the event was lost). Actions stay
+ *  live — an evidence-less legacy pause must never be unapprovable — but the
+ *  absence is stated plainly instead of an eternal "preparing" spinner. */
+function NoEvidence() {
+  return (
+    <div className="empty-msg" style={{ margin: "auto" }}>
+      <div className="et">No evidence was recorded for this pause</div>
+      <div>Review the step's chat and the run timeline before deciding.</div>
     </div>
   );
 }

--- a/src/workflows/run/RunView/PausedBanner.tsx
+++ b/src/workflows/run/RunView/PausedBanner.tsx
@@ -3,10 +3,12 @@
 // approve (S4), retry/resume (S4), answer a question (S10), and conflict
 // resolution (S9). No dead buttons — each paused reason wires to its command.
 
-import { useState } from "react";
-import { api, type WfMessage, type WfRun } from "../../../api";
+import { useCallback, useState } from "react";
+import { api, type GateEvidence, type WfMessage, type WfRun } from "../../../api";
 import type { IconName } from "../../../components/Icon";
 import { Icon } from "../../../components/Icon";
+import { ReviewSurface } from "../../../components/ReviewSurface";
+import { IconButton, Scrim } from "../../../components/ui";
 import { useAppStore } from "../../../store";
 import type { Budgets } from "../../spec";
 import { pausedLabel } from "../status";
@@ -25,7 +27,6 @@ interface BannerSpec {
   actions: Action[];
 }
 
-const APPROVE: Action = { label: "Approve", icon: "check", run: api.wfApprove, primary: true };
 const RETRY: Action = { label: "Retry", icon: "refresh", run: api.wfRetry, primary: true };
 const RESUME: Action = { label: "Resume", icon: "play", run: api.wfResume, primary: true };
 // Conflict resolution (§12.3): let an agent resolve the pinned conflict snapshot,
@@ -57,11 +58,13 @@ function specFor(run: WfRun, detail?: string): BannerSpec | null {
   const title = `Paused — ${pausedLabel(run.paused_reason)}`;
   switch (run.paused_reason) {
     case "approval":
+      // The action is the review surface (rendered inline below), not a bare
+      // Approve button — a merge decision deserves the evidence first.
       return {
         tone: "amber",
         title,
-        body: detail || "A step is waiting for your approval to hand off to the next.",
-        actions: [APPROVE],
+        body: detail || "A step is waiting for your review before handing off to the next.",
+        actions: [],
       };
     case "blocked_gate":
       return {
@@ -110,13 +113,18 @@ export function PausedBanner({
   run,
   detail,
   question,
+  evidence,
 }: {
   run: WfRun;
   detail?: string;
   /** The pending human `ask` message when `paused_reason === "question"`. */
   question?: WfMessage;
+  /** The review evidence for a `paused(approval)` run (its `gate_evidence`
+   *  event), or `null` while it's still loading. */
+  evidence?: GateEvidence | null;
 }) {
   const [busy, setBusy] = useState(false);
+  const [reviewing, setReviewing] = useState(false);
   const setLastError = useAppStore((s) => s.setLastError);
   const spec = specFor(run, detail);
   if (!spec) return null;
@@ -138,6 +146,7 @@ export function PausedBanner({
   const paused = run.status === "paused";
   const isQuestion = paused && run.paused_reason === "question";
   const isBudget = paused && run.paused_reason === "budget_exceeded";
+  const isApproval = paused && run.paused_reason === "approval";
 
   return (
     <div className={`wf-banner ${spec.tone}`}>
@@ -151,6 +160,11 @@ export function PausedBanner({
         {isBudget && <ResumeBudgetForm run={run} onError={setLastError} />}
       </div>
       <div className="wf-banner-actions">
+        {isApproval && (
+          <button type="button" className="btn-t primary" onClick={() => setReviewing(true)}>
+            <Icon name="diff" size={13} /> Review changes…
+          </button>
+        )}
         {spec.actions.map((a) => (
           <button
             key={a.label}
@@ -163,7 +177,64 @@ export function PausedBanner({
           </button>
         ))}
       </div>
+      {reviewing && (
+        <ReviewModal
+          run={run}
+          evidence={evidence ?? null}
+          onClose={() => setReviewing(false)}
+          onError={setLastError}
+        />
+      )}
     </div>
+  );
+}
+
+/** The approval review, framed as a modal over the run. Wires the shared
+ *  `ReviewSurface` to this run's diff source and approve/reject commands; the
+ *  surface itself is store-agnostic so a fleet queue can mount it elsewhere. */
+function ReviewModal({
+  run,
+  evidence,
+  onClose,
+  onError,
+}: {
+  run: WfRun;
+  evidence: GateEvidence | null;
+  onClose: () => void;
+  onError: (message: string) => void;
+}) {
+  const getDiff = useCallback(
+    (path: string | null): Promise<string> => {
+      if (!evidence) return Promise.resolve("");
+      return api.wfRunDiff(run.id, evidence.base_sha, evidence.head_sha, path ?? undefined);
+    },
+    [run.id, evidence],
+  );
+
+  return (
+    <>
+      <Scrim onClose={onClose} zIndex={399} />
+      <div className="rv-modal">
+        <div className="rv-modal-card">
+          <div className="rv-modal-head">
+            <span className="rv-modal-title">
+              <Icon name="combine" size={14} style={{ color: "var(--accent)" }} /> Review
+              <span className="rv-modal-step">{run.task || run.name}</span>
+            </span>
+            <IconButton className="rv-modal-close" tip="Close" onClick={onClose}>
+              <Icon name="close" size={14} />
+            </IconButton>
+          </div>
+          <ReviewSurface
+            evidence={evidence}
+            getDiff={getDiff}
+            onApprove={() => api.wfApprove(run.id)}
+            onReject={(note) => api.wfReject(run.id, note)}
+            onError={onError}
+          />
+        </div>
+      </div>
+    </>
   );
 }
 

--- a/src/workflows/run/RunView/PausedBanner.tsx
+++ b/src/workflows/run/RunView/PausedBanner.tsx
@@ -3,7 +3,7 @@
 // approve (S4), retry/resume (S4), answer a question (S10), and conflict
 // resolution (S9). No dead buttons — each paused reason wires to its command.
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { api, type GateEvidence, type WfMessage, type WfRun } from "../../../api";
 import type { IconName } from "../../../components/Icon";
 import { Icon } from "../../../components/Icon";
@@ -114,18 +114,31 @@ export function PausedBanner({
   detail,
   question,
   evidence,
+  evidencePending,
 }: {
   run: WfRun;
   detail?: string;
   /** The pending human `ask` message when `paused_reason === "question"`. */
   question?: WfMessage;
   /** The review evidence for a `paused(approval)` run (its `gate_evidence`
-   *  event), or `null` while it's still loading. */
+   *  event), or `null` when none has arrived. */
   evidence?: GateEvidence | null;
+  /** The journal is still loading — absent evidence may yet arrive. */
+  evidencePending?: boolean;
 }) {
   const [busy, setBusy] = useState(false);
   const [reviewing, setReviewing] = useState(false);
   const setLastError = useAppStore((s) => s.setLastError);
+
+  const isApproval = run.status === "paused" && run.paused_reason === "approval";
+
+  // The review is only meaningful while the run is paused on approval; when the
+  // state flips underneath it (approved elsewhere, reject exhausted the budget),
+  // an open modal would review a run that no longer awaits one — close it.
+  useEffect(() => {
+    if (!isApproval) setReviewing(false);
+  }, [isApproval]);
+
   const spec = specFor(run, detail);
   if (!spec) return null;
 
@@ -146,7 +159,6 @@ export function PausedBanner({
   const paused = run.status === "paused";
   const isQuestion = paused && run.paused_reason === "question";
   const isBudget = paused && run.paused_reason === "budget_exceeded";
-  const isApproval = paused && run.paused_reason === "approval";
 
   return (
     <div className={`wf-banner ${spec.tone}`}>
@@ -181,6 +193,7 @@ export function PausedBanner({
         <ReviewModal
           run={run}
           evidence={evidence ?? null}
+          pending={evidencePending ?? false}
           onClose={() => setReviewing(false)}
           onError={setLastError}
         />
@@ -195,11 +208,13 @@ export function PausedBanner({
 function ReviewModal({
   run,
   evidence,
+  pending,
   onClose,
   onError,
 }: {
   run: WfRun;
   evidence: GateEvidence | null;
+  pending: boolean;
   onClose: () => void;
   onError: (message: string) => void;
 }) {
@@ -209,6 +224,15 @@ function ReviewModal({
       return api.wfRunDiff(run.id, evidence.base_sha, evidence.head_sha, path ?? undefined);
     },
     [run.id, evidence],
+  );
+
+  // Close on success; the run-state effect above also catches external flips.
+  const decide = useCallback(
+    async (action: Promise<void>) => {
+      await action;
+      onClose();
+    },
+    [onClose],
   );
 
   return (
@@ -227,9 +251,10 @@ function ReviewModal({
           </div>
           <ReviewSurface
             evidence={evidence}
+            pending={pending}
             getDiff={getDiff}
-            onApprove={() => api.wfApprove(run.id)}
-            onReject={(note) => api.wfReject(run.id, note)}
+            onApprove={() => decide(api.wfApprove(run.id))}
+            onReject={(note) => decide(api.wfReject(run.id, note))}
             onError={onError}
           />
         </div>

--- a/src/workflows/run/RunView/index.tsx
+++ b/src/workflows/run/RunView/index.tsx
@@ -8,7 +8,7 @@
 // attempt's preserved chat (the existing ChatView), and the event timeline.
 
 import { useEffect, useMemo, useState } from "react";
-import type { AgentRecord, WfStepExec } from "../../../api";
+import type { AgentRecord, GateEvidence, WfStepExec } from "../../../api";
 import { Icon } from "../../../components/Icon";
 import { IconButton } from "../../../components/ui/IconButton";
 import { ChatView } from "../../../components/Workspace/ChatView";
@@ -99,6 +99,17 @@ export function RunView({ id }: { id: string }) {
     return undefined;
   }, [pausedEvent]);
 
+  // The review evidence for an approval pause: the most recent `gate_evidence`
+  // event (keyed to the awaiting step exec). Only meaningful while the run is
+  // paused on approval; the ReviewSurface renders a "preparing" state if absent.
+  const gateEvidence = useMemo<GateEvidence | null>(() => {
+    if (run?.status !== "paused" || run.paused_reason !== "approval") return null;
+    for (let i = events.length - 1; i >= 0; i--) {
+      if (events[i].type === "gate_evidence") return events[i].payload as GateEvidence;
+    }
+    return null;
+  }, [events, run?.status, run?.paused_reason]);
+
   if (loading && !run) {
     return (
       <div className="pane center">
@@ -161,7 +172,12 @@ export function RunView({ id }: { id: string }) {
 
       <BudgetMeter budgets={run.budgets} spent={run.spent} createdAt={run.created_at} />
 
-      <PausedBanner run={run} detail={pausedDetail} question={pendingQuestion} />
+      <PausedBanner
+        run={run}
+        detail={pausedDetail}
+        question={pendingQuestion}
+        evidence={gateEvidence}
+      />
 
       <div className="wf-run-main">
         <AttemptRail

--- a/src/workflows/run/RunView/index.tsx
+++ b/src/workflows/run/RunView/index.tsx
@@ -177,6 +177,7 @@ export function RunView({ id }: { id: string }) {
         detail={pausedDetail}
         question={pendingQuestion}
         evidence={gateEvidence}
+        evidencePending={loading}
       />
 
       <div className="wf-run-main">

--- a/src/workflows/spec.ts
+++ b/src/workflows/spec.ts
@@ -64,13 +64,18 @@ export interface AgentSpec {
   custom_agent?: string;
 }
 
-/** The deterministic predicate that marks a step attempt done (spec §9). */
+/** A deterministic prerequisite an `approval` gate can require first (spec §9). */
+export type Require = "tests";
+
+/** The deterministic predicate that marks a step attempt done (spec §9). An
+ *  `approval` gate may list `require: [tests]` — the human pause is unreachable
+ *  until the project's tests pass (optional, defaults to none). */
 export type Gate =
   | { type: "verdict" }
   | { type: "commit" }
   | { type: "artifact"; path: string }
   | { type: "tests" }
-  | { type: "approval" };
+  | { type: "approval"; require?: Require[] };
 
 export interface Step {
   id: string;


### PR DESCRIPTION
## What

Turns workflow approval gates from a black box (bare Approve on `{"reason":"approval"}`) into an evidence-backed review with a reject path — the first segment of the evidence loop (sandbox → gates → review queue → merge).

### Backend

- **`gate_evidence` journal event**, assembled when an approval gate pauses: full `VerificationReport` (reusing `verify.rs` from #462), diff numstat of the ferried ref vs the run base, budget spent vs cap, and the reviewer verdict when a step produced one. Dedicated `wf_event`, keyed to the awaiting exec — queryable, no schema migration. Payloads are snake_case per IPC convention.
- **`wf_reject(run_id, note)`** mirroring `wf_approve`: journals `decision{decision:"rejected", note}`, delivers the note to the gated step's agent through the existing comms fold for one more attempt within budget; if budget is exhausted, pauses `blocked_gate` with the note as detail. The rejected attempt is marked `abandoned` so its ferried ref is never mistaken for a fork source.
- **`gate: approval` gains optional `require: [tests]`**: tests evaluate first (shared helper with the plain `tests` gate, identical failure reason + output tail), so the approval pause is unreachable while tests fail. YAML stays version 1; bare `{"type":"approval"}` round-trips byte-for-byte and old specs import cleanly.
- **`wf_run_diff(run_id, from_sha, to_sha, path?)`**: run-repo diff command (both the ferried ref and the base live in the run repo) so the surface fetches per-file diffs on demand. New `diff_refs`/`diff_numstat` helpers in `git.rs`.

### Frontend

- **`src/components/ReviewSurface/`** — shared review component (evidence + `getDiff` + callbacks as props, no store access, so the upcoming fleet review queue mounts it unchanged): summary tiles (diff stats, budget), verdict badge + summary, checks with pass/fail and expandable output tails, ferried diff via the existing `parseUnifiedDiff`/DiffView machinery, and Approve / Request-changes actions. Reject requires a note (auto-focused, ⌘/Ctrl+Enter submits) with the consequence stated plainly.
- Degraded states are deliberate: budget renders "unknown" when provider token usage is unreported (never a fake zero); no verification commands configured is stated plainly; loading state designed.
- `PausedBanner`'s bare Approve becomes a "Review changes…" modal; `RunView` feeds it the latest `gate_evidence`.

## Testing

- `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings -A clippy::significant_drop_tightening` clean; `cargo test` → 954 passed, 0 failed (includes new spec round-trip/backward-compat, gate-ordering, evidence-journaled, reject-with-budget, and reject-exhausted tests).
- Frontend: typecheck, build, and vitest (453 passed) clean; biome clean on all changed files.

## Notes

- Approval gates remain unsupported inside orchestrate stages (inherited boundary, unchanged).
- Deferred: builder-UI control for `require: [tests]` (spec/validation/round-trip fully supported) and plumbing the project lint override into the evidence verifier (lint resolves by detection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)