### PR TITLE
feat(home): Mission Control fleet review queue

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -17,6 +17,7 @@
 @import "./components/Sidebar/Sidebar.css";
 @import "./styles/shared/badge.css";
 @import "./components/Workspace/Workspace.css";
+@import "./components/Workspace/MissionControl/MissionControl.css";
 @import "./components/Workspace/Chat.css";
 @import "./components/Workspace/messages/UserInput/UserInput.css";
 @import "./components/Composer/Composer.css";

--- a/src/components/AgentIdentityChip.tsx
+++ b/src/components/AgentIdentityChip.tsx
@@ -1,0 +1,32 @@
+import type { AgentRecord } from "@/api";
+import { ProviderIcon } from "@/components/ProviderIcon";
+import { Mono } from "@/components/SettingsScreen/CustomAgents/Mono";
+import { providerChip, providerLabel } from "@/data/providers";
+import { useAppStore } from "@/store";
+
+/** The agent's identity chip: a custom agent's colored monogram (its `color`
+ *  hue + name initials), or the base provider glyph for a built-in spawn. Shared
+ *  by the sidebar row and Mission Control so both read the same identity — the
+ *  custom-agent lookup + provider fallback lives here once, not per call-site. */
+export function AgentIdentityChip({ agent, size = 14 }: { agent: AgentRecord; size?: number }) {
+  const customAgent = useAppStore((s) =>
+    agent.custom_agent_id ? s.customAgents.find((a) => a.id === agent.custom_agent_id) : undefined,
+  );
+  return (
+    <span
+      className="ag-prov-chip tip"
+      data-tip={
+        customAgent
+          ? `${customAgent.name} · ${providerLabel(agent.provider)}`
+          : providerLabel(agent.provider)
+      }
+      data-tip-down=""
+    >
+      {customAgent ? (
+        <Mono name={customAgent.name} hue={customAgent.color} size={size} />
+      ) : (
+        <ProviderIcon slug={agent.provider} {...providerChip(agent.provider)} size={size} />
+      )}
+    </span>
+  );
+}

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -1,9 +1,9 @@
 import type { KeyboardEvent, MouseEvent } from "react";
 import { useState } from "react";
 import type { AgentRecord, AgentStatus, PrChecks, PrState, ShortStats } from "@/api";
+import { AgentIdentityChip } from "@/components/AgentIdentityChip";
 import { Icon } from "@/components/Icon";
 import { ProviderIcon } from "@/components/ProviderIcon";
-import { Mono } from "@/components/SettingsScreen/CustomAgents/Mono";
 import { Badge, type BadgeVariant } from "@/components/ui/Badge";
 import { lookupModel } from "@/data/modelCatalog";
 import { providerChip, providerLabel } from "@/data/providers";
@@ -75,12 +75,6 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
   const pending = useAppStore((s) => s.pendingToolUse[agent.id]);
   const stop = useAppStore((s) => s.stop);
   const archive = useAppStore((s) => s.archive);
-  // The custom agent this session was spawned from, if any (and still present).
-  // Drives the row's identity chip; falls back to the base provider when the
-  // custom agent has since been deleted.
-  const customAgent = useAppStore((s) =>
-    agent.custom_agent_id ? s.customAgents.find((a) => a.id === agent.custom_agent_id) : undefined,
-  );
   const now = useMinuteClock();
   const [statsOpen, setStatsOpen] = useState(false);
 
@@ -161,21 +155,7 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
       <span className={`ag-rail ${railClass}`} />
       <div className="agent-row flex-center">
         <span className={`ag-name ${working && !awaiting ? "shimmer" : ""}`}>{agent.name}</span>
-        <span
-          className="ag-prov-chip tip"
-          data-tip={
-            customAgent
-              ? `${customAgent.name} · ${providerLabel(agent.provider)}`
-              : providerLabel(agent.provider)
-          }
-          data-tip-down=""
-        >
-          {customAgent ? (
-            <Mono name={customAgent.name} hue={customAgent.color} size={14} />
-          ) : (
-            <ProviderIcon slug={agent.provider} {...providerChip(agent.provider)} size={14} />
-          )}
-        </span>
+        <AgentIdentityChip agent={agent} size={14} />
         {runLive && (
           <span
             className="ag-run tip"

--- a/src/components/Workspace/MissionControl/AllClear.tsx
+++ b/src/components/Workspace/MissionControl/AllClear.tsx
@@ -1,0 +1,21 @@
+import { Icon } from "@/components/Icon";
+
+/** The calm empty state — a quiet checkmark and one line, in the app's
+ *  empty-state vocabulary. Not a blank pane, not celebratory. Tailors its copy
+ *  to whether the workspace has any agents yet (first-run onboarding hint vs.
+ *  "nothing needs you"). */
+export function AllClear({ hasAgents }: { hasAgents: boolean }) {
+  return (
+    <div className="mc-allclear">
+      <span className="mc-allclear-mark iflex-center">
+        <Icon name={hasAgents ? "check" : "sparkle"} size={22} />
+      </span>
+      <div className="mc-allclear-title">{hasAgents ? "All clear" : "No agents yet"}</div>
+      <div className="mc-allclear-sub">
+        {hasAgents
+          ? "Nothing needs your review right now."
+          : "Spawn an agent from a project in the sidebar, and it'll show up here when it needs you."}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Workspace/MissionControl/EvidenceChips.tsx
+++ b/src/components/Workspace/MissionControl/EvidenceChips.tsx
@@ -1,0 +1,79 @@
+import { open } from "@tauri-apps/plugin-shell";
+import type { PrChecks } from "@/api";
+import { Icon } from "@/components/Icon";
+import type { ReviewItem } from "./queue";
+
+/** The evidence row under a card's identity line: one chip per signal we
+ *  actually have. Everything degrades gracefully — a missing signal (no diff, no
+ *  checks, unknown budget) renders nothing rather than a fake zero or a broken
+ *  chip. */
+export function EvidenceChips({ item }: { item: ReviewItem }) {
+  const chips = [
+    item.diff && (item.diff.additions > 0 || item.diff.deletions > 0) ? (
+      <span key="diff" className="mc-chip" title={`${item.diff.file_count} file(s) changed`}>
+        <Icon name="diff" size={11} />
+        {item.diff.additions > 0 && <span className="add">+{item.diff.additions}</span>}
+        {item.diff.deletions > 0 && <span className="rem">−{item.diff.deletions}</span>}
+        <span className="mc-chip-sub">
+          {item.diff.file_count} {item.diff.file_count === 1 ? "file" : "files"}
+        </span>
+      </span>
+    ) : null,
+    item.checks ? <ChecksChip key="checks" checks={item.checks} /> : null,
+    typeof item.unresolvedComments === "number" && item.unresolvedComments > 0 ? (
+      <span key="comments" className="mc-chip">
+        <Icon name="bot" size={11} />
+        {item.unresolvedComments} unresolved
+      </span>
+    ) : null,
+    item.pr ? (
+      <button
+        key="pr"
+        type="button"
+        className="mc-chip mc-chip-link"
+        title={`Open PR #${item.pr.number} on GitHub`}
+        onClick={(e) => {
+          e.stopPropagation();
+          if (item.pr) void open(item.pr.url);
+        }}
+      >
+        <Icon name="pr" size={11} />#{item.pr.number}
+      </button>
+    ) : null,
+    // Future-PR slot (§1): a staleness chip, wired here so it lands with no
+    // layout change when a later PR feeds `item.staleness`. Null today.
+    item.staleness ? (
+      <span key="stale" className="mc-chip mc-chip-warn">
+        <Icon name="branch" size={11} />
+        behind {item.staleness.base} by {item.staleness.behind}
+      </span>
+    ) : null,
+  ].filter(Boolean);
+
+  if (chips.length === 0) return null;
+  return <div className="mc-chips">{chips}</div>;
+}
+
+/** CI rollup chip — tinted only on a settled pass/fail; pending stays neutral;
+ *  a rollup of "none" (no checks configured) shows nothing. */
+function ChecksChip({ checks }: { checks: PrChecks }) {
+  if (checks.rollup === "none") return null;
+  const tone =
+    checks.rollup === "passing"
+      ? "mc-chip-ok"
+      : checks.rollup === "failing"
+        ? "mc-chip-fail"
+        : "mc-chip-pending";
+  const label =
+    checks.rollup === "passing"
+      ? `checks passing (${checks.passed}/${checks.total})`
+      : checks.rollup === "failing"
+        ? `${checks.failed} ${checks.failed === 1 ? "check" : "checks"} failing`
+        : `${checks.pending} pending`;
+  return (
+    <span className={`mc-chip ${tone}`}>
+      <Icon name="flask" size={11} />
+      {label}
+    </span>
+  );
+}

--- a/src/components/Workspace/MissionControl/MissionControl.css
+++ b/src/components/Workspace/MissionControl/MissionControl.css
@@ -1,0 +1,287 @@
+/* Mission Control — the fleet review queue (Home). Tokens only: no hardcoded
+ * colors or font-sizes, so it reads as one system with the sidebar, ReviewSurface,
+ * and empty states in both themes. Quiet until something needs attention; the
+ * focused card gets a subtle accent rail + tint for keyboard triage. */
+
+.mc-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.mc-wrap {
+  width: 100%;
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 24px 20px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.mc-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+/* ── card ─────────────────────────────────────────────────────────────────── */
+.mc-card {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  gap: 14px;
+  padding: 14px 16px 14px 15px;
+  background: var(--bg-2);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-md);
+  box-shadow: var(--shadow-1);
+  cursor: default;
+  transition:
+    border-color 0.12s var(--ease),
+    background 0.12s var(--ease);
+}
+.mc-card:hover {
+  border-color: var(--bd);
+}
+.mc-card.focused {
+  border-color: var(--accent-line);
+  background: color-mix(in oklch, var(--accent-soft) 60%, var(--bg-2));
+}
+.mc-card-rail {
+  position: absolute;
+  left: 0;
+  top: 10px;
+  bottom: 10px;
+  width: 2px;
+  border-radius: 0 2px 2px 0;
+  background: transparent;
+  transition: background 0.12s var(--ease);
+}
+.mc-card.focused .mc-card-rail {
+  background: var(--accent);
+}
+
+.mc-card-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.mc-card-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.mc-card-title {
+  font-size: var(--fs-base);
+  font-weight: 500;
+  color: var(--fg-0);
+  min-width: 0;
+}
+.mc-card-reason {
+  margin-left: auto;
+  flex-shrink: 0;
+  font-size: var(--fs-xs);
+  color: var(--fg-2);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.mc-card-goal {
+  font-size: var(--fs-sm);
+  color: var(--fg-1);
+  min-width: 0;
+}
+
+/* workflow identity glyph — mirrors the .ag-prov-chip footprint */
+.mc-wf-chip {
+  width: 18px;
+  height: 18px;
+  border-radius: var(--r-xs);
+  flex-shrink: 0;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-line);
+}
+
+/* ── evidence chips ───────────────────────────────────────────────────────── */
+.mc-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 2px;
+}
+.mc-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 7px;
+  border-radius: var(--r-xs);
+  font-size: var(--fs-xs);
+  font-family: var(--font-mono);
+  color: var(--fg-1);
+  background: var(--bg-3);
+  border: 1px solid var(--bd-soft);
+  white-space: nowrap;
+}
+.mc-chip .add {
+  color: var(--success);
+}
+.mc-chip .rem {
+  color: var(--danger);
+}
+.mc-chip-sub {
+  color: var(--fg-2);
+}
+.mc-chip-link {
+  cursor: pointer;
+}
+.mc-chip-link:hover {
+  border-color: var(--bd-strong);
+  color: var(--fg-0);
+}
+.mc-chip-ok {
+  color: var(--success);
+  background: color-mix(in oklch, var(--success) 12%, transparent);
+  border-color: color-mix(in oklch, var(--success) 30%, transparent);
+}
+.mc-chip-fail {
+  color: var(--danger);
+  background: color-mix(in oklch, var(--danger) 12%, transparent);
+  border-color: color-mix(in oklch, var(--danger) 30%, transparent);
+}
+.mc-chip-pending {
+  color: var(--warn);
+  background: color-mix(in oklch, var(--warn) 12%, transparent);
+  border-color: color-mix(in oklch, var(--warn) 30%, transparent);
+}
+.mc-chip-warn {
+  color: var(--att);
+  background: color-mix(in oklch, var(--att) 12%, transparent);
+  border-color: color-mix(in oklch, var(--att) 30%, transparent);
+}
+
+/* ── actions ──────────────────────────────────────────────────────────────── */
+.mc-card-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+  flex-shrink: 0;
+  justify-content: center;
+}
+.mc-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  height: 26px;
+  padding: 0 12px;
+  border-radius: var(--r-sm);
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  color: var(--fg-1);
+  border: 1px solid var(--bd);
+  background: var(--bg-1);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: var(--transition-ui-ease);
+}
+.mc-btn:hover {
+  color: var(--fg-0);
+  border-color: var(--bd-strong);
+}
+.mc-btn.primary {
+  color: var(--btn-fg-dark);
+  background: var(--accent);
+  border-color: transparent;
+}
+.mc-btn.primary:hover {
+  color: var(--btn-fg-dark);
+  filter: brightness(1.05);
+}
+.mc-dismiss {
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--r-sm);
+  color: var(--fg-3);
+  cursor: pointer;
+  opacity: 0;
+  transition: var(--transition-ui-ease);
+}
+.mc-card:hover .mc-dismiss,
+.mc-card.focused .mc-dismiss {
+  opacity: 1;
+}
+.mc-dismiss:hover {
+  color: var(--fg-1);
+  background: var(--hover);
+}
+
+/* ── keyboard hint row ────────────────────────────────────────────────────── */
+.mc-hints {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  padding: 2px 4px;
+  font-size: var(--fs-xs);
+  color: var(--fg-3);
+}
+.mc-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.mc-hints kbd {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--fg-2);
+  background: var(--bg-2);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-xs);
+}
+
+/* ── all-clear ────────────────────────────────────────────────────────────── */
+.mc-allclear {
+  margin: auto;
+  padding: 40px 30px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 4px;
+  max-width: 360px;
+}
+.mc-allclear-mark {
+  width: 48px;
+  height: 48px;
+  margin-bottom: 12px;
+  border-radius: 50%;
+  color: var(--success);
+  background: color-mix(in oklch, var(--success) 12%, transparent);
+}
+.mc-allclear-title {
+  font-size: var(--fs-lg);
+  font-weight: 500;
+  color: var(--fg-1);
+}
+.mc-allclear-sub {
+  font-size: var(--fs-sm);
+  color: var(--fg-3);
+  line-height: var(--lh-snug);
+}

--- a/src/components/Workspace/MissionControl/MissionControl.css
+++ b/src/components/Workspace/MissionControl/MissionControl.css
@@ -103,6 +103,7 @@
   width: 18px;
   height: 18px;
   border-radius: var(--r-xs);
+  justify-content: center;
   flex-shrink: 0;
   color: var(--accent);
   background: var(--accent-soft);
@@ -272,6 +273,7 @@
   height: 48px;
   margin-bottom: 12px;
   border-radius: 50%;
+  justify-content: center;
   color: var(--success);
   background: color-mix(in oklch, var(--success) 12%, transparent);
 }

--- a/src/components/Workspace/MissionControl/QueueCard.tsx
+++ b/src/components/Workspace/MissionControl/QueueCard.tsx
@@ -1,0 +1,114 @@
+import type { KeyboardEvent } from "react";
+import { AgentIdentityChip } from "@/components/AgentIdentityChip";
+import { Icon } from "@/components/Icon";
+import { EvidenceChips } from "./EvidenceChips";
+import type { ReviewItem, ReviewReason } from "./queue";
+
+/** The "what" line — a short phrase per reason, joined when a card carries
+ *  several (an agent with unseen results AND a failing PR). */
+const REASON_LABEL: Record<ReviewReason, string> = {
+  "workflow-approval": "Awaiting approval",
+  "workflow-conflict": "Merge conflict",
+  "unseen-results": "New results to review",
+  "checks-failing": "Checks failing",
+  "unresolved-comments": "Unresolved comments",
+};
+
+function reasonLine(item: ReviewItem): string {
+  return item.reasons.map((r) => REASON_LABEL[r]).join(" · ");
+}
+
+interface Props {
+  item: ReviewItem;
+  focused: boolean;
+  onFocus: () => void;
+  onEnter: () => void;
+  onApprove: () => void;
+  onRequestChanges: () => void;
+  onDismiss: () => void;
+}
+
+/** One "needs you" card: who (identity chip) → what (reason) → evidence (chips)
+ *  → action. The whole card opens the review; the action buttons are explicit
+ *  affordances mirroring the a/r keys. Quiet by default; the focused card gets a
+ *  subtle accent rail + tint so keyboard triage is always locatable. */
+export function QueueCard({
+  item,
+  focused,
+  onFocus,
+  onEnter,
+  onApprove,
+  onRequestChanges,
+  onDismiss,
+}: Props) {
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (e.target !== e.currentTarget) return;
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onEnter();
+    }
+  };
+
+  return (
+    <div
+      className={`mc-card ${focused ? "focused" : ""}`}
+      role="button"
+      tabIndex={0}
+      aria-current={focused ? "true" : undefined}
+      onMouseEnter={onFocus}
+      onClick={onEnter}
+      onKeyDown={onKeyDown}
+    >
+      <span className="mc-card-rail" />
+      <div className="mc-card-body">
+        <div className="mc-card-head">
+          {item.kind === "workflow" ? (
+            <span className="mc-wf-chip iflex-center" title="Workflow run">
+              <Icon name="combine" size={14} />
+            </span>
+          ) : (
+            item.agent && <AgentIdentityChip agent={item.agent} size={18} />
+          )}
+          <span className="mc-card-title truncate">{item.title}</span>
+          <span className="mc-card-reason">{reasonLine(item)}</span>
+        </div>
+        <div className="mc-card-goal truncate">{item.goal}</div>
+        <EvidenceChips item={item} />
+      </div>
+      <div className="mc-card-actions">
+        <button
+          type="button"
+          className="mc-btn primary"
+          onClick={(e) => {
+            e.stopPropagation();
+            onApprove();
+          }}
+        >
+          <Icon name="check" size={12} /> Approve
+        </button>
+        <button
+          type="button"
+          className="mc-btn"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRequestChanges();
+          }}
+        >
+          <Icon name="arrowR" size={12} /> Request changes
+        </button>
+        <button
+          type="button"
+          className="mc-dismiss tip"
+          data-tip="Dismiss until this changes"
+          aria-label="Dismiss"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDismiss();
+          }}
+        >
+          <Icon name="close" size={12} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Workspace/MissionControl/WorkflowReviewModal.tsx
+++ b/src/components/Workspace/MissionControl/WorkflowReviewModal.tsx
@@ -1,0 +1,78 @@
+// MissionControl/WorkflowReviewModal.tsx — mounts the shared ReviewSurface over a
+// workflow run straight from the queue, so an approval can be decided without
+// visiting the run's tab. Same wiring as RunView/PausedBanner's ReviewModal
+// (evidence = the latest `gate_evidence` event; approve/reject via wfApprove /
+// wfReject; diff via wfRunDiff) — the surface is store-agnostic by design, so
+// this is a thin second mount, not a fork.
+
+import { useCallback, useEffect, useMemo } from "react";
+import { api, type GateEvidence } from "@/api";
+import { Icon } from "@/components/Icon";
+import { ReviewSurface } from "@/components/ReviewSurface";
+import { IconButton, Scrim } from "@/components/ui";
+import { useAppStore } from "@/store";
+import { useRunDetail } from "@/workflows/run/RunView/useRunDetail";
+
+export function WorkflowReviewModal({ runId, onClose }: { runId: string; onClose: () => void }) {
+  const { detail, events, loading } = useRunDetail(runId);
+  const run = detail?.run ?? null;
+  const setLastError = useAppStore((s) => s.setLastError);
+
+  const evidence = useMemo<GateEvidence | null>(() => {
+    if (run?.status !== "paused" || run.paused_reason !== "approval") return null;
+    for (let i = events.length - 1; i >= 0; i--) {
+      if (events[i].type === "gate_evidence") return events[i].payload as GateEvidence;
+    }
+    return null;
+  }, [events, run?.status, run?.paused_reason]);
+
+  // If the run flips out of paused(approval) underneath the modal (approved
+  // elsewhere, reject exhausted the budget, deleted), close it — an open surface
+  // over a run that no longer awaits a decision is stale.
+  useEffect(() => {
+    if (run && !(run.status === "paused" && run.paused_reason === "approval")) onClose();
+  }, [run, onClose]);
+
+  const getDiff = useCallback(
+    (path: string | null): Promise<string> => {
+      if (!evidence) return Promise.resolve("");
+      return api.wfRunDiff(runId, evidence.base_sha, evidence.head_sha, path ?? undefined);
+    },
+    [runId, evidence],
+  );
+
+  const decide = useCallback(
+    async (action: Promise<void>) => {
+      await action;
+      onClose();
+    },
+    [onClose],
+  );
+
+  return (
+    <>
+      <Scrim onClose={onClose} zIndex={399} />
+      <div className="rv-modal">
+        <div className="rv-modal-card">
+          <div className="rv-modal-head">
+            <span className="rv-modal-title">
+              <Icon name="combine" size={14} style={{ color: "var(--accent)" }} /> Review
+              <span className="rv-modal-step">{run?.task || run?.name || "…"}</span>
+            </span>
+            <IconButton className="rv-modal-close" tip="Close" onClick={onClose}>
+              <Icon name="close" size={14} />
+            </IconButton>
+          </div>
+          <ReviewSurface
+            evidence={evidence}
+            pending={loading}
+            getDiff={getDiff}
+            onApprove={() => decide(api.wfApprove(runId))}
+            onReject={(note) => decide(api.wfReject(runId, note))}
+            onError={setLastError}
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/Workspace/MissionControl/index.tsx
+++ b/src/components/Workspace/MissionControl/index.tsx
@@ -1,0 +1,100 @@
+// MissionControl — Home as the fleet review queue (PR 3). When no agent is
+// selected, the center pane answers "what needs me?": one ordered card per
+// "needs you" signal across every agent and workflow run, most-decidable-first.
+// The derivation is a pure selector (queue.ts); this file is the pane shell,
+// keyboard triage, and the workflow review modal host.
+
+import { useState } from "react";
+import { Icon } from "@/components/Icon";
+import { IconButton } from "@/components/ui/IconButton";
+import { useAppStore } from "@/store";
+import { AllClear } from "./AllClear";
+import { QueueCard } from "./QueueCard";
+import { useQueueActions } from "./useQueueActions";
+import { useQueueKeyboard } from "./useQueueKeyboard";
+import { useReviewQueue } from "./useReviewQueue";
+import { WorkflowReviewModal } from "./WorkflowReviewModal";
+
+export function MissionControl() {
+  const leftCollapsed = useAppStore((s) => s.leftCollapsed);
+  const toggleLeft = useAppStore((s) => s.toggleLeft);
+  const agentCount = useAppStore((s) => s.workspace?.agents.length ?? 0);
+
+  const items = useReviewQueue();
+  const [reviewRunId, setReviewRunId] = useState<string | null>(null);
+  const actions = useQueueActions(setReviewRunId);
+  // Triage keys pause while the review modal is open.
+  const { index, setIndex } = useQueueKeyboard({
+    items,
+    active: reviewRunId === null,
+    onEnter: actions.enter,
+    onApprove: actions.approve,
+    onRequestChanges: actions.requestChanges,
+  });
+
+  return (
+    <div className="pane center fade-in">
+      <div className="center-h flex-center">
+        <IconButton
+          tip={leftCollapsed ? "Show sidebar (⌘B)" : "Hide sidebar (⌘B)"}
+          onClick={toggleLeft}
+        >
+          <Icon name="sidebarL" />
+        </IconButton>
+        <div className="task">
+          <div className="t-name">
+            <Icon name="layers" size={14} style={{ color: "var(--accent)", flexShrink: 0 }} />
+            <span>Mission Control</span>
+          </div>
+          <div className="t-meta">
+            {items.length === 0
+              ? "review queue"
+              : `${items.length} ${items.length === 1 ? "item" : "items"} need you`}
+          </div>
+        </div>
+      </div>
+
+      <div className="mc-scroll">
+        {items.length === 0 ? (
+          <AllClear hasAgents={agentCount > 0} />
+        ) : (
+          <div className="mc-wrap">
+            <div className="mc-list">
+              {items.map((item, i) => (
+                <QueueCard
+                  key={item.id}
+                  item={item}
+                  focused={i === index}
+                  onFocus={() => setIndex(i)}
+                  onEnter={() => actions.enter(item)}
+                  onApprove={() => actions.approve(item)}
+                  onRequestChanges={() => actions.requestChanges(item)}
+                  onDismiss={() => actions.dismiss(item)}
+                />
+              ))}
+            </div>
+            <div className="mc-hints" aria-hidden="true">
+              <span className="mc-hint">
+                <kbd>j</kbd>
+                <kbd>k</kbd> navigate
+              </span>
+              <span className="mc-hint">
+                <kbd>↵</kbd> review
+              </span>
+              <span className="mc-hint">
+                <kbd>a</kbd> approve
+              </span>
+              <span className="mc-hint">
+                <kbd>r</kbd> request changes
+              </span>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {reviewRunId && (
+        <WorkflowReviewModal runId={reviewRunId} onClose={() => setReviewRunId(null)} />
+      )}
+    </div>
+  );
+}

--- a/src/components/Workspace/MissionControl/queue.test.ts
+++ b/src/components/Workspace/MissionControl/queue.test.ts
@@ -186,8 +186,10 @@ describe("buildReviewQueue", () => {
     );
     expect(q).toHaveLength(1);
     expect(q[0].reasons).toEqual(["checks-failing", "unresolved-comments"]);
-    // The chips show the PR carrying the issue — the failing secondary.
+    // The chips show the PR carrying the issue — the failing secondary — and
+    // the item carries its repo so actions act on the same scoped state.
     expect(q[0].pr).toEqual({ number: 2, url: "https://gh/pr/2" });
+    expect(q[0].prSubdir).toBe("pkg/api");
     expect(q[0].checks?.rollup).toBe("failing");
     expect(q[0].unresolvedComments).toBe(2);
     // A fix on the secondary changes the signature, so a dismissal expires.

--- a/src/components/Workspace/MissionControl/queue.test.ts
+++ b/src/components/Workspace/MissionControl/queue.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "vitest";
+import type { AgentRecord, PrChecks, PrComments, PrState, ShortStats, WfRun } from "@/api";
+import { BUCKET, buildReviewQueue, type QueueInput } from "./queue";
+
+// ── fixtures ──────────────────────────────────────────────────────────────────
+
+function agent(over: Partial<AgentRecord> & { id: string }): AgentRecord {
+  return {
+    project_id: "p1",
+    name: over.id,
+    provider: "claude",
+    repos: [],
+    task: "Do the thing",
+    status: "idle",
+    view: "custom",
+    created_at: "2026-07-17T00:00:00.000Z",
+    ...over,
+  };
+}
+
+const stats = (additions: number, deletions: number, file_count = 1): ShortStats => ({
+  additions,
+  deletions,
+  file_count,
+});
+
+const openPr = (number = 1): PrState => ({
+  number,
+  url: `https://gh/pr/${number}`,
+  state: "open",
+  title: "PR",
+  mergeable: true,
+});
+
+function checks(over: Partial<PrChecks>): PrChecks {
+  return {
+    merge_state: "blocked",
+    rollup: "failing",
+    total: 3,
+    passed: 2,
+    failed: 1,
+    pending: 0,
+    required_failing: ["test"],
+    runs: [],
+    ...over,
+  };
+}
+
+const comments = (n: number): PrComments => ({
+  unresolved: Array.from({ length: n }, (_, i) => ({
+    author: "bot",
+    is_bot: true,
+    body: `c${i}`,
+    path: null,
+    line: null,
+    url: `u${i}`,
+    replies: 0,
+  })),
+});
+
+function run(over: Partial<WfRun> & { id: string }): WfRun {
+  return {
+    definition_id: null,
+    parent_run_id: null,
+    name: over.id,
+    spec: {},
+    task: "Ship it",
+    project_id: "p1",
+    repo_path: "/repo",
+    run_dir: "/run",
+    branch: "wf/x",
+    base_sha: "abc",
+    status: "paused",
+    paused_reason: "approval",
+    cursor: null,
+    budgets: {},
+    spent: {},
+    error: null,
+    created_at: 1,
+    updated_at: 1000,
+    ...over,
+  };
+}
+
+function input(over: Partial<QueueInput>): QueueInput {
+  return {
+    agents: [],
+    gitShortstats: {},
+    unseenResults: {},
+    prStates: {},
+    prChecks: {},
+    prComments: {},
+    runs: [],
+    dismissed: {},
+    ...over,
+  };
+}
+
+// ── tests ───────────────────────────────────────────────────────────────────
+
+describe("buildReviewQueue", () => {
+  it("returns nothing for an idle fleet with no signals", () => {
+    expect(buildReviewQueue(input({ agents: [agent({ id: "a" })] }))).toEqual([]);
+  });
+
+  it("surfaces an idle agent with unseen results AND a nonzero diff", () => {
+    const q = buildReviewQueue(
+      input({
+        agents: [agent({ id: "a" })],
+        unseenResults: { a: true },
+        gitShortstats: { a: stats(4, 2) },
+      }),
+    );
+    expect(q).toHaveLength(1);
+    expect(q[0].id).toBe("agent:a");
+    expect(q[0].bucket).toBe(BUCKET.unseen);
+    expect(q[0].reasons).toEqual(["unseen-results"]);
+    expect(q[0].diff).toEqual(stats(4, 2));
+  });
+
+  it("requires all three of idle + unseen + diff", () => {
+    // Running (not idle) → excluded.
+    expect(
+      buildReviewQueue(
+        input({
+          agents: [agent({ id: "a", status: "running" })],
+          unseenResults: { a: true },
+          gitShortstats: { a: stats(4, 2) },
+        }),
+      ),
+    ).toEqual([]);
+    // Seen (no unseen flag) → excluded.
+    expect(
+      buildReviewQueue(input({ agents: [agent({ id: "a" })], gitShortstats: { a: stats(4, 2) } })),
+    ).toEqual([]);
+    // No diff → excluded.
+    expect(
+      buildReviewQueue(input({ agents: [agent({ id: "a" })], unseenResults: { a: true } })),
+    ).toEqual([]);
+  });
+
+  it("only counts PR signals against an OPEN pr", () => {
+    const merged: PrState = { ...openPr(), state: "merged" };
+    const q = buildReviewQueue(
+      input({
+        agents: [agent({ id: "a" })],
+        prStates: { a: merged },
+        prChecks: { a: checks({ rollup: "failing" }) },
+        prComments: { a: comments(2) },
+      }),
+    );
+    expect(q).toEqual([]);
+  });
+
+  it("dedupes one agent's many signals into ONE card with all reasons", () => {
+    const q = buildReviewQueue(
+      input({
+        agents: [agent({ id: "a" })],
+        unseenResults: { a: true },
+        gitShortstats: { a: stats(1, 1) },
+        prStates: { a: openPr(7) },
+        prChecks: { a: checks({ rollup: "failing", failed: 2 }) },
+        prComments: { a: comments(3) },
+      }),
+    );
+    expect(q).toHaveLength(1);
+    expect(q[0].reasons).toEqual(["unseen-results", "checks-failing", "unresolved-comments"]);
+    // Ranked by its most-decidable reason (PR), not the plain unseen bucket.
+    expect(q[0].bucket).toBe(BUCKET.pr);
+    expect(q[0].pr).toEqual({ number: 7, url: "https://gh/pr/7" });
+    expect(q[0].unresolvedComments).toBe(3);
+  });
+
+  it("orders approval < conflict < pr < unseen", () => {
+    const q = buildReviewQueue(
+      input({
+        agents: [agent({ id: "unseenAgent" }), agent({ id: "prAgent" })],
+        unseenResults: { unseenAgent: true, prAgent: true },
+        gitShortstats: { unseenAgent: stats(1, 0), prAgent: stats(2, 0) },
+        prStates: { prAgent: openPr(9) },
+        prChecks: { prAgent: checks({ rollup: "failing" }) },
+        runs: [
+          run({ id: "conflict", paused_reason: "conflict" }),
+          run({ id: "approval", paused_reason: "approval" }),
+        ],
+      }),
+    );
+    expect(q.map((i) => i.id)).toEqual([
+      "wf:approval",
+      "wf:conflict",
+      "agent:prAgent",
+      "agent:unseenAgent",
+    ]);
+  });
+
+  it("ignores workflow runs not paused on approval/conflict", () => {
+    const q = buildReviewQueue(
+      input({
+        runs: [
+          run({ id: "q", paused_reason: "question" }),
+          run({ id: "b", paused_reason: "budget_exceeded" }),
+          run({ id: "r", status: "running", paused_reason: null }),
+        ],
+      }),
+    );
+    expect(q).toEqual([]);
+  });
+
+  it("tiebreaks a bucket by most-recent activity", () => {
+    const q = buildReviewQueue(
+      input({
+        runs: [
+          run({ id: "old", paused_reason: "approval", updated_at: 100 }),
+          run({ id: "new", paused_reason: "approval", updated_at: 900 }),
+        ],
+      }),
+    );
+    expect(q.map((i) => i.id)).toEqual(["wf:new", "wf:old"]);
+  });
+
+  it("hides an item dismissed at its current signature", () => {
+    const base = input({
+      agents: [agent({ id: "a" })],
+      unseenResults: { a: true },
+      gitShortstats: { a: stats(4, 2) },
+    });
+    const [item] = buildReviewQueue(base);
+    const hidden = buildReviewQueue({ ...base, dismissed: { [item.id]: item.signature } });
+    expect(hidden).toEqual([]);
+  });
+
+  it("resurfaces a dismissed item once its signal (signature) changes", () => {
+    const base = input({
+      agents: [agent({ id: "a" })],
+      unseenResults: { a: true },
+      gitShortstats: { a: stats(4, 2) },
+    });
+    const [item] = buildReviewQueue(base);
+    // Dismissed at the old signature, but the diff grew → new signature, so the
+    // stored mark no longer matches and the item returns.
+    const grown = buildReviewQueue({
+      ...base,
+      gitShortstats: { a: stats(9, 2) },
+      dismissed: { [item.id]: item.signature },
+    });
+    expect(grown).toHaveLength(1);
+    expect(grown[0].id).toBe("agent:a");
+  });
+});

--- a/src/components/Workspace/MissionControl/queue.test.ts
+++ b/src/components/Workspace/MissionControl/queue.test.ts
@@ -171,6 +171,41 @@ describe("buildReviewQueue", () => {
     expect(q[0].unresolvedComments).toBe(3);
   });
 
+  it("surfaces PR signals from a secondary repo key (agentId::subdir)", () => {
+    const q = buildReviewQueue(
+      input({
+        agents: [agent({ id: "a" })],
+        // Primary repo: open PR, all green. Secondary repo: failing checks.
+        prStates: { a: openPr(1), "a::pkg/api": openPr(2) },
+        prChecks: {
+          a: checks({ rollup: "passing", failed: 0, required_failing: [] }),
+          "a::pkg/api": checks({ rollup: "failing", failed: 1 }),
+        },
+        prComments: { "a::pkg/api": comments(2) },
+      }),
+    );
+    expect(q).toHaveLength(1);
+    expect(q[0].reasons).toEqual(["checks-failing", "unresolved-comments"]);
+    // The chips show the PR carrying the issue — the failing secondary.
+    expect(q[0].pr).toEqual({ number: 2, url: "https://gh/pr/2" });
+    expect(q[0].checks?.rollup).toBe("failing");
+    expect(q[0].unresolvedComments).toBe(2);
+    // A fix on the secondary changes the signature, so a dismissal expires.
+    const fixed = buildReviewQueue(
+      input({
+        agents: [agent({ id: "a" })],
+        prStates: { a: openPr(1), "a::pkg/api": openPr(2) },
+        prChecks: {
+          a: checks({ rollup: "passing", failed: 0, required_failing: [] }),
+          "a::pkg/api": checks({ rollup: "failing", failed: 1 }),
+        },
+        prComments: { "a::pkg/api": comments(2) },
+        dismissed: { "agent:a": q[0].signature },
+      }),
+    );
+    expect(fixed).toEqual([]);
+  });
+
   it("orders approval < conflict < pr < unseen", () => {
     const q = buildReviewQueue(
       input({

--- a/src/components/Workspace/MissionControl/queue.ts
+++ b/src/components/Workspace/MissionControl/queue.ts
@@ -114,17 +114,59 @@ function parseCreated(iso: string): number {
   return Number.isNaN(t) ? 0 : t;
 }
 
-/** The agent item's signature: only the volatile review signals, so dismissing
- *  it holds until one of them changes. */
+/** One repo's open-PR signals for an agent. The PR maps are keyed `agentId`
+ *  for the primary repo and `agentId::subdir` for secondaries (store/git.ts
+ *  `gitKey`) — a multi-repo agent's failing check must surface no matter which
+ *  repo it's on. */
+interface PrSignal {
+  /** "" for the primary repo, the subdir for a secondary. */
+  repo: string;
+  pr: PrState;
+  checks: PrChecks | null;
+  unresolved: number;
+}
+
+/** Collect the agent's open-PR signals across every repo key, primary first
+ *  then secondaries in stable (sorted) order. */
+function collectPrSignals(agentId: string, input: QueueInput): PrSignal[] {
+  const prefix = `${agentId}::`;
+  const keys = [
+    agentId,
+    ...Object.keys(input.prStates)
+      .filter((k) => k.startsWith(prefix))
+      .sort(),
+  ];
+  const out: PrSignal[] = [];
+  for (const key of keys) {
+    const pr = input.prStates[key] ?? null;
+    // Signals only count against an open PR — a merged/closed PR's stale
+    // rollup must never nag.
+    if (pr?.state !== "open") continue;
+    out.push({
+      repo: key === agentId ? "" : key.slice(prefix.length),
+      pr,
+      checks: input.prChecks[key] ?? null,
+      unresolved: (input.prComments[key] ?? null)?.unresolved.length ?? 0,
+    });
+  }
+  return out;
+}
+
+/** The agent item's signature: only the volatile review signals (across every
+ *  repo's PR), so dismissing it holds until one of them changes. */
 function agentSignature(p: {
   unseen: boolean;
   stats: ShortStats | undefined;
-  checks: PrChecks | null;
-  unresolved: number;
+  signals: PrSignal[];
 }): string {
   const d = p.stats ? `${p.stats.additions}/${p.stats.deletions}/${p.stats.file_count}` : "-";
-  const c = p.checks ? `${p.checks.rollup}:${p.checks.failed}` : "-";
-  return `u${p.unseen ? 1 : 0}|d${d}|c${c}|r${p.unresolved}`;
+  const c = p.signals
+    .map((s) => {
+      const checks = s.checks ? `${s.checks.rollup}:${s.checks.failed}` : "-";
+      return `${s.repo}=${checks}:${s.unresolved}`;
+    })
+    .join(",");
+  return `u${p.unseen ? 1 : 0}|d${d}|c${c || "-"}`;
 }
 
 /** Compose the fleet review queue from current app state. Pure and synchronous:
@@ -158,36 +200,35 @@ export function buildReviewQueue(input: QueueInput): ReviewItem[] {
     const stats = input.gitShortstats[agent.id];
     const hasDiff = !!stats && (stats.additions > 0 || stats.deletions > 0);
     const unseen = input.unseenResults[agent.id] ?? false;
-    const pr = input.prStates[agent.id] ?? null;
-    const checks = input.prChecks[agent.id] ?? null;
-    const comments = input.prComments[agent.id] ?? null;
-    const prOpen = pr?.state === "open";
-    const unresolved = comments?.unresolved.length ?? 0;
+    const signals = collectPrSignals(agent.id, input);
+    const failing = signals.filter((s) => s.checks?.rollup === "failing");
+    const unresolved = signals.reduce((n, s) => n + s.unresolved, 0);
 
     const reasons: ReviewReason[] = [];
     // Ad-hoc: a turn landed while you weren't looking and left changes behind.
     if (agent.status === "idle" && unseen && hasDiff) reasons.push("unseen-results");
-    // PR signals only count against an open PR — a merged/closed PR's stale
-    // rollup must never nag.
-    if (prOpen && checks?.rollup === "failing") reasons.push("checks-failing");
-    if (prOpen && unresolved > 0) reasons.push("unresolved-comments");
+    if (failing.length > 0) reasons.push("checks-failing");
+    if (unresolved > 0) reasons.push("unresolved-comments");
     if (reasons.length === 0) continue;
 
+    // The evidence chips show one PR: the one carrying the issue (a failing
+    // repo first, then one with unresolved threads, then the primary).
+    const shown = failing[0] ?? signals.find((s) => s.unresolved > 0) ?? signals[0];
     const isPr = reasons.includes("checks-failing") || reasons.includes("unresolved-comments");
     items.push({
       id: `agent:${agent.id}`,
       kind: "agent",
       bucket: isPr ? BUCKET.pr : BUCKET.unseen,
-      signature: agentSignature({ unseen, stats, checks, unresolved }),
+      signature: agentSignature({ unseen, stats, signals }),
       activityAt: parseCreated(agent.created_at),
       title: agent.name,
       goal: firstLine(agent.task) || "—",
       reasons,
       agent,
       diff: hasDiff ? stats : undefined,
-      pr: prOpen && pr ? { number: pr.number, url: pr.url } : undefined,
-      checks: prOpen && checks ? checks : undefined,
-      unresolvedComments: reasons.includes("unresolved-comments") ? unresolved : undefined,
+      pr: shown ? { number: shown.pr.number, url: shown.pr.url } : undefined,
+      checks: shown?.checks ?? undefined,
+      unresolvedComments: unresolved > 0 ? unresolved : undefined,
       // Future-PR slot — no signal feeds it yet, so it's always absent today.
       staleness: null,
     });

--- a/src/components/Workspace/MissionControl/queue.ts
+++ b/src/components/Workspace/MissionControl/queue.ts
@@ -1,0 +1,209 @@
+// MissionControl/queue.ts — the fleet review queue derivation (PR 3, §1). A pure
+// function that composes the app's already-polled state (agents + their diff /
+// unseen / PR signals, and workflow runs) into one ordered list of "needs you"
+// items. No store, no IPC, no React here — so the ordering, dedupe, signature,
+// and dismissal-filter logic are unit-testable in isolation (queue.test.ts) and
+// the hook (useReviewQueue) is a thin adapter over this.
+
+import type {
+  AgentRecord,
+  PrChecks,
+  PrComments,
+  PrState,
+  ShortStats,
+  WfPausedReason,
+  WfRun,
+} from "@/api";
+
+/** Why an item is in the queue. One card can carry several (an agent with both
+ *  unseen results and a failing PR is ONE item with both reasons — see the
+ *  dedupe in buildReviewQueue). */
+export type ReviewReason =
+  | "workflow-approval"
+  | "workflow-conflict"
+  | "unseen-results"
+  | "checks-failing"
+  | "unresolved-comments";
+
+/** Future-PR slot (§1): a "base moved under this agent" signal. Designed now so
+ *  the card can render a staleness chip without a type/layout change when a later
+ *  PR feeds it; nothing populates it in this PR (backend deliberately deferred),
+ *  so it is always `null` today and the chip never renders. */
+export interface Staleness {
+  /** The base branch the agent has fallen behind. */
+  base: string;
+  /** How many commits the base has moved ahead by. */
+  behind: number;
+}
+
+export interface ReviewItem {
+  /** Stable id — `wf:<runId>` for a workflow item, `agent:<agentId>` for an
+   *  agent item. Drives keyboard focus and dismissal. */
+  id: string;
+  kind: "workflow" | "agent";
+  /** Ordering bucket (see BUCKET). Lower = more decidable = higher in the queue. */
+  bucket: number;
+  /** Fingerprint of the item's *volatile* signals. Dismissal is keyed on this,
+   *  so a dismissed item returns the moment its signature changes (a new turn,
+   *  a new diff, a CI pass/fail flip). */
+  signature: string;
+  /** Deterministic within-bucket tiebreak — most recent activity first. */
+  activityAt: number;
+  /** Who: the agent / run display name. */
+  title: string;
+  /** What (the one-line brief): the session's task text, first line only. */
+  goal: string;
+  reasons: ReviewReason[];
+
+  // ── agent items ──
+  agent?: AgentRecord;
+
+  // ── workflow items ──
+  runId?: string;
+  pausedReason?: WfPausedReason;
+
+  // ── evidence (all optional — omit when unknown; never fake a zero) ──
+  diff?: ShortStats;
+  pr?: { number: number; url: string };
+  checks?: PrChecks;
+  unresolvedComments?: number;
+  staleness?: Staleness | null;
+}
+
+/** Ordering buckets, most-decidable-first. Rationale: an item is ranked by its
+ *  most-decidable reason, so a card with evidence you can act on in one gesture
+ *  floats above one that just needs a look.
+ *   0 workflow approval — a dedicated evidence surface + one-click promote.
+ *   1 workflow conflict — a clear decision with a defined action.
+ *   2 PR items (failing checks / unresolved threads) — CI evidence is present.
+ *   3 plain unseen-diff agent items — a turn landed with changes to look at. */
+export const BUCKET = {
+  workflowApproval: 0,
+  workflowConflict: 1,
+  pr: 2,
+  unseen: 3,
+} as const;
+
+export interface QueueInput {
+  agents: readonly AgentRecord[];
+  gitShortstats: Record<string, ShortStats>;
+  unseenResults: Record<string, boolean>;
+  prStates: Record<string, PrState | null>;
+  prChecks: Record<string, PrChecks | null>;
+  prComments: Record<string, PrComments | null>;
+  runs: readonly WfRun[];
+  /** Item id → signal signature it was dismissed at. */
+  dismissed: Record<string, string>;
+}
+
+/** First non-empty line of a brief, trimmed. Empty string when there's none —
+ *  the card falls back to a placeholder rather than showing whitespace. */
+function firstLine(s: string | null | undefined): string {
+  if (!s) return "";
+  for (const raw of s.split("\n")) {
+    const line = raw.trim();
+    if (line) return line;
+  }
+  return "";
+}
+
+/** Epoch ms from an ISO created_at, or 0 when unparseable — a stable tiebreak
+ *  key for agent items (which carry no updated_at). */
+function parseCreated(iso: string): number {
+  const t = new Date(iso).getTime();
+  return Number.isNaN(t) ? 0 : t;
+}
+
+/** The agent item's signature: only the volatile review signals, so dismissing
+ *  it holds until one of them changes. */
+function agentSignature(p: {
+  unseen: boolean;
+  stats: ShortStats | undefined;
+  checks: PrChecks | null;
+  unresolved: number;
+}): string {
+  const d = p.stats ? `${p.stats.additions}/${p.stats.deletions}/${p.stats.file_count}` : "-";
+  const c = p.checks ? `${p.checks.rollup}:${p.checks.failed}` : "-";
+  return `u${p.unseen ? 1 : 0}|d${d}|c${c}|r${p.unresolved}`;
+}
+
+/** Compose the fleet review queue from current app state. Pure and synchronous:
+ *  it never blocks on evidence (workflow approvals rank top because they carry a
+ *  dedicated review surface, not because their evidence has finished loading). */
+export function buildReviewQueue(input: QueueInput): ReviewItem[] {
+  const items: ReviewItem[] = [];
+
+  // ── workflow runs paused on a human decision (§1: approval or conflict) ──
+  for (const run of input.runs) {
+    if (run.status !== "paused") continue;
+    if (run.paused_reason !== "approval" && run.paused_reason !== "conflict") continue;
+    const approval = run.paused_reason === "approval";
+    items.push({
+      id: `wf:${run.id}`,
+      kind: "workflow",
+      bucket: approval ? BUCKET.workflowApproval : BUCKET.workflowConflict,
+      // Status + reason: dismissed until the run moves off this pause.
+      signature: `${run.status}:${run.paused_reason}`,
+      activityAt: run.updated_at,
+      title: run.name,
+      goal: firstLine(run.task) || run.name,
+      reasons: [approval ? "workflow-approval" : "workflow-conflict"],
+      runId: run.id,
+      pausedReason: run.paused_reason,
+    });
+  }
+
+  // ── agents (one card per agent; multiple reasons dedupe onto its chips) ──
+  for (const agent of input.agents) {
+    const stats = input.gitShortstats[agent.id];
+    const hasDiff = !!stats && (stats.additions > 0 || stats.deletions > 0);
+    const unseen = input.unseenResults[agent.id] ?? false;
+    const pr = input.prStates[agent.id] ?? null;
+    const checks = input.prChecks[agent.id] ?? null;
+    const comments = input.prComments[agent.id] ?? null;
+    const prOpen = pr?.state === "open";
+    const unresolved = comments?.unresolved.length ?? 0;
+
+    const reasons: ReviewReason[] = [];
+    // Ad-hoc: a turn landed while you weren't looking and left changes behind.
+    if (agent.status === "idle" && unseen && hasDiff) reasons.push("unseen-results");
+    // PR signals only count against an open PR — a merged/closed PR's stale
+    // rollup must never nag.
+    if (prOpen && checks?.rollup === "failing") reasons.push("checks-failing");
+    if (prOpen && unresolved > 0) reasons.push("unresolved-comments");
+    if (reasons.length === 0) continue;
+
+    const isPr = reasons.includes("checks-failing") || reasons.includes("unresolved-comments");
+    items.push({
+      id: `agent:${agent.id}`,
+      kind: "agent",
+      bucket: isPr ? BUCKET.pr : BUCKET.unseen,
+      signature: agentSignature({ unseen, stats, checks, unresolved }),
+      activityAt: parseCreated(agent.created_at),
+      title: agent.name,
+      goal: firstLine(agent.task) || "—",
+      reasons,
+      agent,
+      diff: hasDiff ? stats : undefined,
+      pr: prOpen && pr ? { number: pr.number, url: pr.url } : undefined,
+      checks: prOpen && checks ? checks : undefined,
+      unresolvedComments: reasons.includes("unresolved-comments") ? unresolved : undefined,
+      // Future-PR slot — no signal feeds it yet, so it's always absent today.
+      staleness: null,
+    });
+  }
+
+  // Hide items dismissed at their *current* signature; a signature change (new
+  // turn, new diff, CI flip) no longer matches the stored mark, so the item
+  // resurfaces on its own.
+  const visible = items.filter((it) => input.dismissed[it.id] !== it.signature);
+
+  // Most-decidable-first, then most-recent-first, then id for a stable order.
+  visible.sort(
+    (a, b) =>
+      a.bucket - b.bucket ||
+      b.activityAt - a.activityAt ||
+      (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
+  );
+  return visible;
+}

--- a/src/components/Workspace/MissionControl/queue.ts
+++ b/src/components/Workspace/MissionControl/queue.ts
@@ -65,6 +65,9 @@ export interface ReviewItem {
   // ── evidence (all optional — omit when unknown; never fake a zero) ──
   diff?: ShortStats;
   pr?: { number: number; url: string };
+  /** The repo the shown PR lives in — `undefined` for the primary, the subdir
+   *  for a secondary. Actions must act on THIS repo's state, not the primary's. */
+  prSubdir?: string;
   checks?: PrChecks;
   unresolvedComments?: number;
   staleness?: Staleness | null;
@@ -227,6 +230,7 @@ export function buildReviewQueue(input: QueueInput): ReviewItem[] {
       agent,
       diff: hasDiff ? stats : undefined,
       pr: shown ? { number: shown.pr.number, url: shown.pr.url } : undefined,
+      prSubdir: shown?.repo ? shown.repo : undefined,
       checks: shown?.checks ?? undefined,
       unresolvedComments: unresolved > 0 ? unresolved : undefined,
       // Future-PR slot — no signal feeds it yet, so it's always absent today.

--- a/src/components/Workspace/MissionControl/useQueueActions.ts
+++ b/src/components/Workspace/MissionControl/useQueueActions.ts
@@ -81,7 +81,13 @@ export function useQueueActions(openReview: (runId: string) => void): QueueActio
       const state = deriveState(git, pr);
       switch (state) {
         case "changes": {
-          const { kind, trigger } = commitDelegation(s.gitCommitAction);
+          // With a PR already open, "open PR" degrades to "push" — that's what
+          // updates the existing PR (mirrors primaryActions' changes state).
+          const mode: GitCommitAction =
+            pr?.state === "open" && s.gitCommitAction === "agent-commit-pr"
+              ? "agent-commit-push"
+              : s.gitCommitAction;
+          const { kind, trigger } = commitDelegation(mode);
           delegateGitAction(
             agentId,
             kind,

--- a/src/components/Workspace/MissionControl/useQueueActions.ts
+++ b/src/components/Workspace/MissionControl/useQueueActions.ts
@@ -12,6 +12,7 @@ import { appActionMessage, type GitDelegationKind } from "@/components/RightPane
 import { describeMergeGate } from "@/components/RightPanel/mergeGate";
 import { deriveState, type GitCommitAction } from "@/components/RightPanel/primaryActions";
 import { useAppStore } from "@/store";
+import { gitKey } from "@/store/git";
 import type { ReviewItem } from "./queue";
 
 /** Composer scaffold seeded for "request changes" on an ad-hoc agent item — an
@@ -70,13 +71,16 @@ export function useQueueActions(openReview: (runId: string) => void): QueueActio
   // The ad-hoc "approve" ladder: pull authoritative git/PR state (the queue only
   // holds compact shortstats), classify it exactly as the Git panel does, and
   // delegate the matching action — or open the tab when there's no clean move.
+  // `subdir` scopes everything to the repo whose signal the card shows — a
+  // secondary repo's failing PR must never dispatch an action on the primary.
   const approveAgent = useCallback(
-    async (agentId: string) => {
-      await fetchGitState(agentId);
+    async (agentId: string, subdir: string | undefined) => {
+      await fetchGitState(agentId, subdir);
       const s = useAppStore.getState();
-      const git = s.gitStates[agentId] ?? null;
-      const pr = s.prStates[agentId] ?? null;
-      const checks = s.prChecks[agentId] ?? null;
+      const key = gitKey(agentId, subdir);
+      const git = s.gitStates[key] ?? null;
+      const pr = s.prStates[key] ?? null;
+      const checks = s.prChecks[key] ?? null;
       const base = git?.parent_branch || "main";
       const state = deriveState(git, pr);
       switch (state) {
@@ -92,14 +96,15 @@ export function useQueueActions(openReview: (runId: string) => void): QueueActio
             agentId,
             kind,
             appActionMessage(trigger, kind === "commit-pr" ? { base } : undefined),
+            subdir,
           );
           return;
         }
         case "pushed":
-          delegateGitAction(agentId, "open-pr", appActionMessage("open-pr", { base }));
+          delegateGitAction(agentId, "open-pr", appActionMessage("open-pr", { base }), subdir);
           return;
         case "conflicts":
-          delegateGitAction(agentId, "resolve", appActionMessage("resolve-conflicts"));
+          delegateGitAction(agentId, "resolve", appActionMessage("resolve-conflicts"), subdir);
           return;
         case "pr-open": {
           const gate = describeMergeGate(checks?.merge_state ?? null, {
@@ -107,7 +112,7 @@ export function useQueueActions(openReview: (runId: string) => void): QueueActio
             mergeable: pr?.mergeable ?? false,
           });
           if (gate.mergeAllowed) {
-            await mergePr(agentId);
+            await mergePr(agentId, subdir);
             return;
           }
           if (gate.situation === "checks-failing") {
@@ -117,6 +122,7 @@ export function useQueueActions(openReview: (runId: string) => void): QueueActio
               appActionMessage("fix-checks", {
                 failing: (checks?.required_failing ?? []).join(", "),
               }),
+              subdir,
             );
             return;
           }
@@ -125,6 +131,7 @@ export function useQueueActions(openReview: (runId: string) => void): QueueActio
               agentId,
               "update-branch",
               appActionMessage("update-branch", { base }),
+              subdir,
             );
             return;
           }
@@ -152,7 +159,7 @@ export function useQueueActions(openReview: (runId: string) => void): QueueActio
         void api.wfApprove(item.runId).catch((e) => setLastError(`Approve failed: ${e}`));
         return;
       }
-      if (item.agent) void approveAgent(item.agent.id);
+      if (item.agent) void approveAgent(item.agent.id, item.prSubdir);
     },
     [approveAgent, setLastError],
   );

--- a/src/components/Workspace/MissionControl/useQueueActions.ts
+++ b/src/components/Workspace/MissionControl/useQueueActions.ts
@@ -17,8 +17,13 @@ import type { ReviewItem } from "./queue";
 
 /** Composer scaffold seeded for "request changes" on an ad-hoc agent item — an
  *  editable starting point (like the PR-comment "→ chat" seed), not a sent
- *  message. The user refines it in the agent's chat before sending. */
-const REQUEST_CHANGES_SEED = "Please make the following changes before this is ready:\n\n- ";
+ *  message. The user refines it in the agent's chat before sending. When the
+ *  card's signal lives in a secondary repo, the seed names it — the composer is
+ *  agent-level, so the repo scope must ride in the prompt itself. */
+function requestChangesSeed(subdir: string | undefined): string {
+  const scope = subdir ? ` in the \`${subdir}\` repo` : "";
+  return `Please make the following changes${scope} before this is ready:\n\n- `;
+}
 
 /** Map the user's sticky commit mode to the delegation it drives — the same
  *  triple the Git panel's `changes` state uses. */
@@ -171,7 +176,7 @@ export function useQueueActions(openReview: (runId: string) => void): QueueActio
         return;
       }
       if (item.agent) {
-        seedComposer(item.agent.id, REQUEST_CHANGES_SEED);
+        seedComposer(item.agent.id, requestChangesSeed(item.prSubdir));
         selectAgent(item.agent.id);
       }
     },

--- a/src/components/Workspace/MissionControl/useQueueActions.ts
+++ b/src/components/Workspace/MissionControl/useQueueActions.ts
@@ -82,6 +82,11 @@ export function useQueueActions(openReview: (runId: string) => void): QueueActio
       const pr = s.prStates[key] ?? null;
       const checks = s.prChecks[key] ?? null;
       const base = git?.parent_branch || "main";
+      // Trigger builder scoped to this repo: a secondary adds `repo="<subdir>"`
+      // so the agent works in that sibling checkout, not the primary (mirrors
+      // useGitActions' trigger).
+      const trigger = (name: string, params?: Record<string, string>) =>
+        appActionMessage(name, subdir ? { ...params, repo: subdir } : params);
       const state = deriveState(git, pr);
       switch (state) {
         case "changes": {
@@ -91,20 +96,20 @@ export function useQueueActions(openReview: (runId: string) => void): QueueActio
             pr?.state === "open" && s.gitCommitAction === "agent-commit-pr"
               ? "agent-commit-push"
               : s.gitCommitAction;
-          const { kind, trigger } = commitDelegation(mode);
+          const { kind, trigger: name } = commitDelegation(mode);
           delegateGitAction(
             agentId,
             kind,
-            appActionMessage(trigger, kind === "commit-pr" ? { base } : undefined),
+            trigger(name, kind === "commit-pr" ? { base } : undefined),
             subdir,
           );
           return;
         }
         case "pushed":
-          delegateGitAction(agentId, "open-pr", appActionMessage("open-pr", { base }), subdir);
+          delegateGitAction(agentId, "open-pr", trigger("open-pr", { base }), subdir);
           return;
         case "conflicts":
-          delegateGitAction(agentId, "resolve", appActionMessage("resolve-conflicts"), subdir);
+          delegateGitAction(agentId, "resolve", trigger("resolve-conflicts"), subdir);
           return;
         case "pr-open": {
           const gate = describeMergeGate(checks?.merge_state ?? null, {
@@ -119,20 +124,13 @@ export function useQueueActions(openReview: (runId: string) => void): QueueActio
             delegateGitAction(
               agentId,
               "fix-checks",
-              appActionMessage("fix-checks", {
-                failing: (checks?.required_failing ?? []).join(", "),
-              }),
+              trigger("fix-checks", { failing: (checks?.required_failing ?? []).join(", ") }),
               subdir,
             );
             return;
           }
           if (gate.needsUpdate) {
-            delegateGitAction(
-              agentId,
-              "update-branch",
-              appActionMessage("update-branch", { base }),
-              subdir,
-            );
+            delegateGitAction(agentId, "update-branch", trigger("update-branch", { base }), subdir);
             return;
           }
           break;

--- a/src/components/Workspace/MissionControl/useQueueActions.ts
+++ b/src/components/Workspace/MissionControl/useQueueActions.ts
@@ -1,0 +1,176 @@
+// MissionControl/useQueueActions.ts — the action layer (§3/§4). One surface, two
+// backends: a workflow item decides through the workflow commands (wfApprove /
+// wfReject via the ReviewSurface modal); an ad-hoc agent item routes through the
+// SAME delegation ladder the Git panel uses (deriveState + the merge-gate +
+// delegateGitAction / mergePr). No new backend commands — and never a dead
+// action: any state the ladder can't map cleanly falls back to opening the
+// agent's Git tab.
+
+import { useCallback } from "react";
+import { api } from "@/api";
+import { appActionMessage, type GitDelegationKind } from "@/components/RightPanel/delegation";
+import { describeMergeGate } from "@/components/RightPanel/mergeGate";
+import { deriveState, type GitCommitAction } from "@/components/RightPanel/primaryActions";
+import { useAppStore } from "@/store";
+import type { ReviewItem } from "./queue";
+
+/** Composer scaffold seeded for "request changes" on an ad-hoc agent item — an
+ *  editable starting point (like the PR-comment "→ chat" seed), not a sent
+ *  message. The user refines it in the agent's chat before sending. */
+const REQUEST_CHANGES_SEED = "Please make the following changes before this is ready:\n\n- ";
+
+/** Map the user's sticky commit mode to the delegation it drives — the same
+ *  triple the Git panel's `changes` state uses. */
+function commitDelegation(mode: GitCommitAction): { kind: GitDelegationKind; trigger: string } {
+  switch (mode) {
+    case "agent-commit":
+      return { kind: "commit", trigger: "commit" };
+    case "agent-commit-push":
+      return { kind: "commit-push", trigger: "commit-push" };
+    default:
+      return { kind: "commit-pr", trigger: "commit-pr" };
+  }
+}
+
+export interface QueueActions {
+  /** ↵ — open the item's review (workflow: the ReviewSurface modal; agent: its
+   *  Git tab). */
+  enter: (item: ReviewItem) => void;
+  /** a — approve / advance (workflow: wfApprove; agent: the delegation ladder). */
+  approve: (item: ReviewItem) => void;
+  /** r — request changes (workflow: the reject form in the modal; agent: seed
+   *  its composer). */
+  requestChanges: (item: ReviewItem) => void;
+  /** The dismiss affordance — hides the card until its signal changes. */
+  dismiss: (item: ReviewItem) => void;
+}
+
+/** Build the queue's action handlers. `openReview` hands a workflow run id up to
+ *  the pane, which mounts the shared ReviewSurface over it. */
+export function useQueueActions(openReview: (runId: string) => void): QueueActions {
+  const selectAgent = useAppStore((s) => s.selectAgent);
+  const setRightPanelTab = useAppStore((s) => s.setRightPanelTab);
+  const seedComposer = useAppStore((s) => s.seedComposer);
+  const fetchGitState = useAppStore((s) => s.fetchGitState);
+  const mergePr = useAppStore((s) => s.mergePr);
+  const delegateGitAction = useAppStore((s) => s.delegateGitAction);
+  const setLastError = useAppStore((s) => s.setLastError);
+  const dismissReviewItem = useAppStore((s) => s.dismissReviewItem);
+
+  // Send the user to the agent's Git tab — the honest fallback whenever an
+  // action can't be mapped to a single clean gesture.
+  const openAgentGit = useCallback(
+    (agentId: string) => {
+      selectAgent(agentId);
+      setRightPanelTab(agentId, "git");
+    },
+    [selectAgent, setRightPanelTab],
+  );
+
+  // The ad-hoc "approve" ladder: pull authoritative git/PR state (the queue only
+  // holds compact shortstats), classify it exactly as the Git panel does, and
+  // delegate the matching action — or open the tab when there's no clean move.
+  const approveAgent = useCallback(
+    async (agentId: string) => {
+      await fetchGitState(agentId);
+      const s = useAppStore.getState();
+      const git = s.gitStates[agentId] ?? null;
+      const pr = s.prStates[agentId] ?? null;
+      const checks = s.prChecks[agentId] ?? null;
+      const base = git?.parent_branch || "main";
+      const state = deriveState(git, pr);
+      switch (state) {
+        case "changes": {
+          const { kind, trigger } = commitDelegation(s.gitCommitAction);
+          delegateGitAction(
+            agentId,
+            kind,
+            appActionMessage(trigger, kind === "commit-pr" ? { base } : undefined),
+          );
+          return;
+        }
+        case "pushed":
+          delegateGitAction(agentId, "open-pr", appActionMessage("open-pr", { base }));
+          return;
+        case "conflicts":
+          delegateGitAction(agentId, "resolve", appActionMessage("resolve-conflicts"));
+          return;
+        case "pr-open": {
+          const gate = describeMergeGate(checks?.merge_state ?? null, {
+            checksFailed: checks?.required_failing.length ?? 0,
+            mergeable: pr?.mergeable ?? false,
+          });
+          if (gate.mergeAllowed) {
+            await mergePr(agentId);
+            return;
+          }
+          if (gate.situation === "checks-failing") {
+            delegateGitAction(
+              agentId,
+              "fix-checks",
+              appActionMessage("fix-checks", {
+                failing: (checks?.required_failing ?? []).join(", "),
+              }),
+            );
+            return;
+          }
+          if (gate.needsUpdate) {
+            delegateGitAction(
+              agentId,
+              "update-branch",
+              appActionMessage("update-branch", { base }),
+            );
+            return;
+          }
+          break;
+        }
+      }
+      // clean / merged / pr-closed / review-required / loading — nothing to
+      // delegate: open the tab so the decision is the user's, never a dead key.
+      openAgentGit(agentId);
+    },
+    [fetchGitState, delegateGitAction, mergePr, openAgentGit],
+  );
+
+  const enter = useCallback(
+    (item: ReviewItem) => {
+      if (item.kind === "workflow" && item.runId) openReview(item.runId);
+      else if (item.agent) openAgentGit(item.agent.id);
+    },
+    [openReview, openAgentGit],
+  );
+
+  const approve = useCallback(
+    (item: ReviewItem) => {
+      if (item.kind === "workflow" && item.runId) {
+        void api.wfApprove(item.runId).catch((e) => setLastError(`Approve failed: ${e}`));
+        return;
+      }
+      if (item.agent) void approveAgent(item.agent.id);
+    },
+    [approveAgent, setLastError],
+  );
+
+  const requestChanges = useCallback(
+    (item: ReviewItem) => {
+      // Workflow reject needs a note — that lives in the ReviewSurface's reject
+      // form, so open the same modal rather than rejecting blind.
+      if (item.kind === "workflow" && item.runId) {
+        openReview(item.runId);
+        return;
+      }
+      if (item.agent) {
+        seedComposer(item.agent.id, REQUEST_CHANGES_SEED);
+        selectAgent(item.agent.id);
+      }
+    },
+    [openReview, seedComposer, selectAgent],
+  );
+
+  const dismiss = useCallback(
+    (item: ReviewItem) => dismissReviewItem(item.id, item.signature),
+    [dismissReviewItem],
+  );
+
+  return { enter, approve, requestChanges, dismiss };
+}

--- a/src/components/Workspace/MissionControl/useQueueKeyboard.ts
+++ b/src/components/Workspace/MissionControl/useQueueKeyboard.ts
@@ -14,8 +14,9 @@ interface Args {
 /** Keyboard triage for the queue: j/k (and ↓/↑) move the focused card, ↵ opens
  *  its review, `a` approves, `r` requests changes. Mirrors the app's global-
  *  shortcut guard (ignore while typing in an input/textarea) and additionally
- *  bows out for contenteditable, any modifier chord, and while a modal is open —
- *  so it never steals a keystroke meant for a field or a shortcut. */
+ *  bows out for contenteditable, any modifier chord, a focused control (button,
+ *  link, card), and while a modal is open — so it never steals or doubles a
+ *  keystroke meant for the focused element. */
 export function useQueueKeyboard({ items, active, onEnter, onApprove, onRequestChanges }: Args) {
   const [index, setIndex] = useState(0);
 
@@ -30,7 +31,11 @@ export function useQueueKeyboard({ items, active, onEnter, onApprove, onRequestC
       if (e.metaKey || e.ctrlKey || e.altKey) return;
       const el = document.activeElement as HTMLElement | null;
       const tag = el?.tagName ?? "";
-      if (tag === "INPUT" || tag === "TEXTAREA" || el?.isContentEditable) return;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || el?.isContentEditable)
+        return;
+      // A focused control (a card's Approve button, the card itself) owns its
+      // keys — Enter must not both click it and fire the triage action.
+      if (tag === "BUTTON" || tag === "A" || el?.getAttribute("role") === "button") return;
       if (items.length === 0) return;
       const cur = items[Math.min(index, items.length - 1)];
       switch (e.key) {

--- a/src/components/Workspace/MissionControl/useQueueKeyboard.ts
+++ b/src/components/Workspace/MissionControl/useQueueKeyboard.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+import type { ReviewItem } from "./queue";
+
+interface Args {
+  items: ReviewItem[];
+  /** False while a review modal is open — triage keys pause so they don't fire
+   *  behind the surface. */
+  active: boolean;
+  onEnter: (item: ReviewItem) => void;
+  onApprove: (item: ReviewItem) => void;
+  onRequestChanges: (item: ReviewItem) => void;
+}
+
+/** Keyboard triage for the queue: j/k (and ↓/↑) move the focused card, ↵ opens
+ *  its review, `a` approves, `r` requests changes. Mirrors the app's global-
+ *  shortcut guard (ignore while typing in an input/textarea) and additionally
+ *  bows out for contenteditable, any modifier chord, and while a modal is open —
+ *  so it never steals a keystroke meant for a field or a shortcut. */
+export function useQueueKeyboard({ items, active, onEnter, onApprove, onRequestChanges }: Args) {
+  const [index, setIndex] = useState(0);
+
+  // Keep the focused index in range as the queue shrinks/grows.
+  useEffect(() => {
+    setIndex((i) => Math.min(Math.max(0, i), Math.max(0, items.length - 1)));
+  }, [items.length]);
+
+  useEffect(() => {
+    if (!active) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      const el = document.activeElement as HTMLElement | null;
+      const tag = el?.tagName ?? "";
+      if (tag === "INPUT" || tag === "TEXTAREA" || el?.isContentEditable) return;
+      if (items.length === 0) return;
+      const cur = items[Math.min(index, items.length - 1)];
+      switch (e.key) {
+        case "j":
+        case "ArrowDown":
+          e.preventDefault();
+          setIndex((i) => Math.min(items.length - 1, i + 1));
+          break;
+        case "k":
+        case "ArrowUp":
+          e.preventDefault();
+          setIndex((i) => Math.max(0, i - 1));
+          break;
+        case "Enter":
+          e.preventDefault();
+          onEnter(cur);
+          break;
+        case "a":
+          e.preventDefault();
+          onApprove(cur);
+          break;
+        case "r":
+          e.preventDefault();
+          onRequestChanges(cur);
+          break;
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [active, items, index, onEnter, onApprove, onRequestChanges]);
+
+  return { index, setIndex };
+}

--- a/src/components/Workspace/MissionControl/useReviewQueue.ts
+++ b/src/components/Workspace/MissionControl/useReviewQueue.ts
@@ -1,0 +1,34 @@
+import { useMemo } from "react";
+import { EMPTY_AGENTS, useAppStore } from "@/store";
+import { useRuns } from "@/workflows/run/useRuns";
+import { buildReviewQueue, type ReviewItem } from "./queue";
+
+/** The live fleet review queue: subscribes to the already-polled store slices +
+ *  the reactive run list and folds them through the pure `buildReviewQueue`
+ *  selector. Derives instantly from state we already hold, so there's no spinner
+ *  — the queue paints with the pane. */
+export function useReviewQueue(): ReviewItem[] {
+  const agents = useAppStore((s) => s.workspace?.agents ?? EMPTY_AGENTS);
+  const gitShortstats = useAppStore((s) => s.gitShortstats);
+  const unseenResults = useAppStore((s) => s.unseenResults);
+  const prStates = useAppStore((s) => s.prStates);
+  const prChecks = useAppStore((s) => s.prChecks);
+  const prComments = useAppStore((s) => s.prComments);
+  const dismissed = useAppStore((s) => s.reviewDismissed);
+  const runs = useRuns();
+
+  return useMemo(
+    () =>
+      buildReviewQueue({
+        agents,
+        gitShortstats,
+        unseenResults,
+        prStates,
+        prChecks,
+        prComments,
+        runs,
+        dismissed,
+      }),
+    [agents, gitShortstats, unseenResults, prStates, prChecks, prComments, runs, dismissed],
+  );
+}

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -8,6 +8,7 @@ import { EMPTY_AGENTS, useAppStore } from "@/store";
 import { RunView } from "@/workflows/run/RunView";
 import { ChatView } from "./ChatView";
 import { EmptyWorkspace } from "./EmptyWorkspace";
+import { MissionControl } from "./MissionControl";
 import { NativeView } from "./NativeView";
 import { WorkspaceHeader } from "./WorkspaceHeader";
 
@@ -32,8 +33,10 @@ export function Workspace() {
     return <RunView id={selectedRunId} key={selectedRunId} />;
   }
 
+  // No agent selected → Home is Mission Control: the fleet review queue. The
+  // bare "Loading…" placeholder stands only until the workspace connects.
   const agent = agents.find((a) => a.id === selectedId);
-  if (!workspace || !agent) {
+  if (!workspace) {
     return (
       <div className="pane center">
         <div className="center-h flex-center">
@@ -44,19 +47,11 @@ export function Workspace() {
             <Icon name="sidebarL" />
           </IconButton>
         </div>
-        <Placeholder
-          title={!workspace ? "Loading…" : agents.length === 0 ? "No agents yet" : "Pick an agent"}
-          body={
-            !workspace
-              ? "Connecting to Fletch…"
-              : agents.length === 0
-                ? "Click the + button on a project to spawn one, or add a repo from the sidebar."
-                : "Choose an agent from the sidebar to attach."
-          }
-        />
+        <Placeholder title="Loading…" body="Connecting to Fletch…" />
       </div>
     );
   }
+  if (!agent) return <MissionControl />;
 
   return (
     <div className="pane center fade-in" key={agent.id}>

--- a/src/storage/preferences.ts
+++ b/src/storage/preferences.ts
@@ -138,6 +138,29 @@ export function parseNewDraftSelection(raw: string | undefined): NewDraftSelecti
   }
 }
 
+// ---- Mission Control dismissals ----------------------------------------------
+
+/** Mission Control's "dismissed" marks: a review-queue item id → the signature
+ *  of the signal state it was dismissed at (see MissionControl/queue.ts). A mark
+ *  is honored only while the item's live signature still matches, so a dismissed
+ *  item resurfaces the moment its underlying signal changes (a new turn, a new
+ *  diff, a CI flip). Stored as one JSON object under `reviewDismissed`; a corrupt
+ *  or missing blob reads as "nothing dismissed". */
+export function parseReviewDismissed(raw: string | undefined): Record<string, string> {
+  if (!raw) return {};
+  try {
+    const saved = JSON.parse(raw) as unknown;
+    if (!saved || typeof saved !== "object") return {};
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(saved as Record<string, unknown>)) {
+      if (typeof v === "string") out[k] = v;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
 // ---- Pane widths --------------------------------------------------------------
 
 /** Default pane widths (px); also the fallback when a stored value is missing

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -42,6 +42,7 @@ import {
   parsePaneWidth,
   parseProviderFlags,
   parseProviderPathOverrides,
+  parseReviewDismissed,
   parseSandboxEngine,
   type ThemeMode,
   type WorkspaceView,
@@ -143,6 +144,9 @@ const hydrateSettings = async (set: AppSet) => {
       rightCollapsed: s.rightCollapsed === "true",
       leftWidth: parsePaneWidth(s.leftWidth, DEFAULT_LEFT_WIDTH),
       rightWidth: parsePaneWidth(s.rightWidth, DEFAULT_RIGHT_WIDTH),
+      // Mission Control's dismissed review-queue marks (item id → signal
+      // signature); the queue honors a mark only while the signature matches.
+      reviewDismissed: parseReviewDismissed(s.reviewDismissed),
     });
   } catch {
     // First launch or DB not ready — defaults are fine.

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -376,6 +376,11 @@ export interface UiSlice {
    *  restore the tab the user was on (e.g. Git) when they switch back to an
    *  agent, instead of always resetting to the first tab. In-memory only. */
   rightPanelTabs: Record<string, RightPanelTab>;
+  /** Mission Control dismissals: review-queue item id → the signal signature it
+   *  was dismissed at. The queue hides an item only while its live signature
+   *  still matches, so a dismissed item resurfaces when its signal changes.
+   *  Persisted in settings (`reviewDismissed`); hydrated on init. */
+  reviewDismissed: Record<string, string>;
 
   toggleSettings: (open?: boolean) => void;
   openSettingsScreen: (section?: SettingsSection, intent?: SettingsIntent) => void;
@@ -405,6 +410,10 @@ export interface UiSlice {
   commitRightWidth: (w: number) => void;
   /** Remember the right-rail tab an agent was last viewing. */
   setRightPanelTab: (agentId: string, tab: RightPanelTab) => void;
+  /** Dismiss a Mission Control review-queue item at its current signal
+   *  signature; persists the mark so it survives reloads (until the signal
+   *  changes and the signature no longer matches). */
+  dismissReviewItem: (id: string, signature: string) => void;
 }
 
 export interface AccountSlice {

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -23,6 +23,7 @@ export const createUiSlice: SliceCreator<UiSlice> = (set, get) => ({
   leftWidth: DEFAULT_LEFT_WIDTH,
   rightWidth: DEFAULT_RIGHT_WIDTH,
   rightPanelTabs: {},
+  reviewDismissed: {},
 
   // ── UI ──────────────────────────────────────────────────────────────────────
   toggleSettings: (open) => set((s) => ({ settingsOpen: open ?? !s.settingsOpen })),
@@ -81,4 +82,13 @@ export const createUiSlice: SliceCreator<UiSlice> = (set, get) => ({
   commitRightWidth: (w) => setSetting("rightWidth", String(w)),
   setRightPanelTab: (agentId, tab) =>
     set((s) => ({ rightPanelTabs: { ...s.rightPanelTabs, [agentId]: tab } })),
+  dismissReviewItem: (id, signature) =>
+    set((s) => {
+      // No-op if the exact same mark is already stored — avoids a redundant DB
+      // write (and re-render) when a card is dismissed twice at one signature.
+      if (s.reviewDismissed[id] === signature) return s;
+      const reviewDismissed = { ...s.reviewDismissed, [id]: signature };
+      setSetting("reviewDismissed", reviewDismissed);
+      return { reviewDismissed };
+    }),
 });


### PR DESCRIPTION
## What

Home becomes Mission Control: when no agent is selected, the center pane renders a fleet review queue instead of the empty "pick an agent" state. The first screen now answers "what needs me?" — one ordered card per "needs you" signal across every agent and workflow run. Builds directly on #466's ReviewSurface.

### Queue derivation (frontend-only v1, no new tables)

- Pure selector (`MissionControl/queue.ts`) composing existing store state: idle agents with unseen results + nonzero diff (`gitShortstats`), workflow runs paused on `approval`/`conflict`, PRs with failing checks (`prChecks`) or unresolved threads.
- **Dedupe by agent**: an agent with unseen results AND a failing PR is one card carrying all reasons, never two cards.
- **Ordering, most-decidable-first**: workflow approvals (dedicated evidence surface, one-click decision) → workflow conflicts → PR items with CI evidence → plain unseen-diff items; tiebreak by most recent activity. Documented in the selector.
- `ReviewItem` carries an optional `staleness` slot (`{base, behind}`) with the chip already wired — always `null` today; the staleness PR feeds it without reshaping anything.
- Dismissal persists via the existing settings pattern as item-id → signal-signature: a dismissed card resurfaces the moment its underlying signal changes (new turn, new diff, CI flip), not never.

### One surface, two backends

- Workflow items: Enter opens the shared `ReviewSurface` (from #466) in the same modal pattern as `PausedBanner` — evidence, diff, Approve / Reject-with-note via `wf_approve`/`wf_reject`.
- Ad-hoc items: `a` re-derives the Git panel's authoritative state (`deriveState` + `describeMergeGate`) and dispatches the existing delegation ladder (commit/commit-push/commit-pr, open-pr, resolve, merge, fix-checks, update-branch). States with no clean mapping open the agent's Git tab — never a dead button. `r` seeds that agent's composer (existing `seedComposer` mechanism).

### Triage UX

- j/k (and arrows) navigate, Enter reviews, `a` approve, `r` request changes, with a quiet kbd hint row; keys pause while the modal is open and never fire from inputs/textareas.
- Cards: identity chip (extracted `AgentIdentityChip`, now shared with `AgentRow`), reason line, one-line goal, evidence chips (diff ±, CI, unresolved count, budget) that omit unknowns rather than faking zeros.
- Empty queue is a designed calm "all clear" state.

## Testing

- vitest: 463 passed (53 files), including 10 new selector tests (ordering, dedupe, PR-only-when-open, dismissal expiry).
- `tsc --noEmit` clean; vite build succeeds; biome clean on all touched files.

## Notes

- Deferred per hand-off: the flag-gated "verify on turn end" setting; the staleness backend (slot designed, not built).
- `unresolved-comments` renders when `prComments` data exists (fetched by the focused Git panel today); fleet-wide failing-checks coverage comes from the app-wide `prChecks` poll.
- Multi-repo agents: the queue reads the primary-repo PR key for v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)