### PR TITLE
feat(git): base staleness, merge fan-out, and overlap hints

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1069,6 +1069,98 @@ pub async fn get_all_shortstats(
     Ok(out)
 }
 
+/// Advisory fleet-wide git metadata for every live agent's checkouts, keyed by
+/// the frontend's `gitKey` convention (plain agent id for the primary repo,
+/// `"{agent_id}::{subdir}"` for secondaries — same as the PR maps). Feeds the
+/// always-visible "base moved · N behind" chips and the cross-agent file-overlap
+/// hints.
+///
+/// Purely local git — no network. Each checkout's `behind` is measured against
+/// the base tip resolved from its SOURCE repo's `refs/remotes/origin/<base>`,
+/// which the slow `refresh_base_freshness` poll advances; the clone shares the
+/// source's object store, so the moved base is reachable there without the clone
+/// fetching (see `git_state::git_meta`). Without a GitHub connection the source
+/// ref never advances, so `behind` stays unknown/zero and no chip shows — the
+/// intended silent degrade. File paths always resolve (local status), so overlap
+/// hints work with or without GitHub.
+///
+/// Queried in parallel; a git error degrades that checkout to a bare
+/// unknown-behind / empty-files entry rather than dropping it.
+#[tauri::command]
+pub async fn get_all_git_meta(
+    supervisor: State<'_, Arc<Supervisor>>,
+) -> Result<std::collections::HashMap<String, git_state::GitMeta>> {
+    let workspace = match supervisor.workspace.current() {
+        Some(w) => w,
+        None => return Ok(Default::default()),
+    };
+    let mut set = tokio::task::JoinSet::new();
+    for agent in workspace.agents {
+        if agent.archive.is_some() {
+            continue;
+        }
+        for (i, repo) in agent.repos.iter().enumerate() {
+            let Ok(checkout) = repo_checkout_path(&agent.id, &repo.subdir) else {
+                continue;
+            };
+            let base = repo.parent_branch.clone().unwrap_or_else(|| "main".into());
+            let key = crate::supervisor::pr_map_key(&agent.id, &repo.subdir, i == 0);
+            let source = repo.repo_path.clone();
+            set.spawn(async move {
+                let base_sha = git::remote_base_sha(&source, &base).await;
+                let meta = git_state::git_meta(&checkout, &base, base_sha.as_deref()).await;
+                (key, meta)
+            });
+        }
+    }
+    let mut out = std::collections::HashMap::new();
+    while let Some(res) = set.join_next().await {
+        if let Ok((key, meta)) = res {
+            out.insert(key, meta);
+        }
+    }
+    Ok(out)
+}
+
+/// Slow-cadence background fetch that advances each project's base branch on its
+/// SOURCE repo, so `get_all_git_meta` can measure staleness against a base that
+/// moved on GitHub (a sibling's PR merging, a teammate's push). One fetch per
+/// distinct `(source repo, base)` — deduped so a multi-agent project pays a
+/// single fetch, and the shared object store propagates it to every clone.
+///
+/// Best-effort and silent by contract: a paused rate-limit backoff skips the
+/// whole sweep, and each fetch failure is logged and stepped over — a background
+/// fetch must never raise a user-facing error. Returns nothing; the next
+/// `get_all_git_meta` tick reflects whatever landed.
+#[tauri::command]
+pub async fn refresh_base_freshness(supervisor: State<'_, Arc<Supervisor>>) -> Result<()> {
+    // Paused → touch no network; the last-fetched base tips still serve.
+    if gh::client::is_backing_off() {
+        return Ok(());
+    }
+    let Some(workspace) = supervisor.workspace.current() else {
+        return Ok(());
+    };
+    // Distinct (source repo, base) across every live agent's repos — one fetch
+    // covers all clones that share that source's objects.
+    let mut seen: BTreeSet<(PathBuf, String)> = BTreeSet::new();
+    for agent in &workspace.agents {
+        if agent.archive.is_some() {
+            continue;
+        }
+        for repo in &agent.repos {
+            let base = repo.parent_branch.clone().unwrap_or_else(|| "main".into());
+            seen.insert((repo.repo_path.clone(), base));
+        }
+    }
+    for (source, base) in seen {
+        if let Err(e) = git::fetch_base(&source, &base).await {
+            tracing::debug!(error = %e, source = %source.display(), base, "base freshness fetch skipped");
+        }
+    }
+    Ok(())
+}
+
 /// App-wide background poll that refreshes PR state for every repo with a
 /// recorded PR across every agent, so the sidebar badge (and any open Git
 /// panel) reflects merges / closes / mergeability changes that happen on

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -1167,6 +1167,55 @@ pub async fn pull(checkout: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Fetch a single base branch on a project's SOURCE repo from its `origin`
+/// (GitHub), authenticating the https transport with the app token. Updates the
+/// source's `refs/remotes/origin/<base>` and lands the new base commits in the
+/// object store every `--shared` agent clone borrows — so one fetch here makes
+/// a moved base measurable from every checkout without each clone fetching.
+///
+/// Background, best-effort: hook-disabling env is applied (the source repo may
+/// carry its own hooks), the token is never logged, and any failure is returned
+/// for the caller to log-and-skip rather than surface. No-op-ish when the source
+/// has no `origin` — git simply fails, which the caller swallows.
+pub async fn fetch_base(source_repo: &Path, base: &str) -> Result<()> {
+    let mut cmd = crate::git_dist::command(source_repo);
+    cmd.args(["fetch", "--quiet", "origin", base]);
+    for (k, v) in merge_git_env(&[&crate::github::git_auth_env(), &no_hooks_env()]) {
+        cmd.env(k, v);
+    }
+    let out = output_timed(&mut cmd, "git fetch base").await?;
+    if !out.status.success() {
+        return Err(Error::Git(format!(
+            "fetch base failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
+/// Resolve a source repo's remote-tracking base tip
+/// (`refs/remotes/origin/<base>`) — the freshest base a `--shared` clone can
+/// measure staleness against, since the clone shares this repo's objects but
+/// not its refs. `None` when the ref is absent (no origin, or never fetched).
+pub async fn remote_base_sha(source_repo: &Path, base: &str) -> Option<String> {
+    let out = git_output(
+        source_repo,
+        &[
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("refs/remotes/origin/{base}"),
+        ],
+    )
+    .await
+    .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!sha.is_empty()).then_some(sha)
+}
+
 /// Rebase the current branch onto `base` (e.g. "main"). Used by the clean-state
 /// panel action to bring the checkout up to date with its base branch when the
 /// base has moved ahead. Aborts the rebase on conflict so the checkout is never

--- a/src-tauri/src/git_state.rs
+++ b/src-tauri/src/git_state.rs
@@ -47,6 +47,26 @@ pub struct ShortStats {
     pub file_count: u32,
 }
 
+/// Advisory fleet-wide git metadata for one checkout: how far its base has
+/// moved ahead of it (staleness) and which files it touches (cross-agent
+/// overlap hints). Distinct from `ShortStats` — which is deliberately just the
+/// three badge numbers — so the always-current 5s shortstats path stays a flat
+/// number-only payload while this slower, advisory signal evolves on its own.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct GitMeta {
+    /// The base branch this checkout is measured against (its parent branch).
+    pub base: String,
+    /// Commits the base has moved ahead of this checkout's HEAD, or `None` when
+    /// the base tip can't be resolved (no origin ref / never fetched). `None`
+    /// and `Some(0)` both render no staleness chip — a moved base is only shown
+    /// when it's genuinely ahead.
+    pub behind: Option<u32>,
+    /// Working-tree file paths (same set `git status` reports), for the
+    /// frontend's pairwise overlap selector. Empty when the tree is clean or
+    /// unreadable.
+    pub files: Vec<String>,
+}
+
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct FileStatus {
     pub path: String,
@@ -193,6 +213,51 @@ pub async fn shortstats(checkout_path: &Path) -> ShortStats {
         deletions,
         file_count,
     }
+}
+
+/// Base-staleness + changed-file paths for one checkout — the advisory bulk
+/// poll behind the "base moved" chips and cross-agent overlap hints.
+///
+/// `base_sha` is the *fresh* base tip resolved from the SOURCE repo's
+/// `refs/remotes/origin/<base>` (see `commands::get_all_git_meta`). A `--shared`
+/// agent clone borrows the source's object store via alternates, so the new
+/// base commits are reachable by SHA in the clone even though the clone never
+/// fetched — counting `HEAD..<base_sha>` there yields a true "behind" without a
+/// per-clone network round-trip. `None` → the base couldn't be resolved (no
+/// origin / no fetch yet), so staleness degrades to unknown rather than a fake
+/// zero. File paths always come straight from the checkout's `git status`.
+pub async fn git_meta(checkout_path: &Path, base: &str, base_sha: Option<&str>) -> GitMeta {
+    let files = run_status(checkout_path)
+        .await
+        .map(|o| parse_porcelain(&o))
+        .unwrap_or_default()
+        .into_iter()
+        .map(|f| f.path)
+        .collect();
+    let behind = match base_sha {
+        Some(sha) => rev_list_count(checkout_path, &format!("HEAD..{sha}")).await,
+        None => None,
+    };
+    GitMeta {
+        base: base.to_string(),
+        behind,
+        files,
+    }
+}
+
+/// `git rev-list --count <range>`, or `None` when the range doesn't resolve
+/// (e.g. an object the shared store doesn't hold). One number — unlike
+/// `rev_list_counts`, which reads both sides of a symmetric range.
+async fn rev_list_count(checkout_path: &Path, range: &str) -> Option<u32> {
+    let out = read_command(checkout_path)
+        .args(["rev-list", "--count", range])
+        .output()
+        .await
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&out.stdout).trim().parse().ok()
 }
 
 /// Additions for an untracked file: the line count of its on-disk contents —
@@ -711,6 +776,87 @@ mod tests {
 
         // Bare `main` fails in the clone; the fallback resolves origin/main.
         assert_eq!(query_ahead_behind(&clone, "main").await, (0, 1));
+    }
+
+    // --- git_meta ---
+
+    #[tokio::test]
+    async fn git_meta_counts_behind_against_shared_base_sha() {
+        // Mirror the live topology: a `--shared` clone borrows the source's
+        // objects, so a base SHA that only exists in the source (a moved
+        // base the clone never fetched) is still countable in the clone.
+        let td = tempfile::tempdir().unwrap();
+        let run = |dir: &Path, args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .current_dir(dir)
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {args:?}: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        let capture = |dir: &Path, args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .current_dir(dir)
+                .args(args)
+                .output()
+                .unwrap();
+            String::from_utf8_lossy(&out.stdout).trim().to_string()
+        };
+
+        let source = td.path().join("source");
+        std::fs::create_dir_all(&source).unwrap();
+        run(&source, &["init", "-q", "-b", "main"]);
+        run(&source, &["config", "user.email", "t@example.com"]);
+        run(&source, &["config", "user.name", "Tester"]);
+        std::fs::write(source.join("a.txt"), b"one").unwrap();
+        run(&source, &["add", "-A"]);
+        run(&source, &["commit", "-q", "-m", "first"]);
+
+        // Shared clone, then branch off and commit — one ahead, zero behind.
+        let clone = td.path().join("clone");
+        run(
+            td.path(),
+            &[
+                "clone",
+                "-q",
+                "--shared",
+                source.to_str().unwrap(),
+                clone.to_str().unwrap(),
+            ],
+        );
+        run(&clone, &["config", "user.email", "t@example.com"]);
+        run(&clone, &["config", "user.name", "Tester"]);
+        run(&clone, &["checkout", "-q", "-b", "feature"]);
+        std::fs::write(clone.join("f.txt"), b"work").unwrap();
+        run(&clone, &["add", "-A"]);
+        run(&clone, &["commit", "-q", "-m", "feature work"]);
+
+        // The base advances by two commits in the source only (the clone never
+        // fetches) — but the objects are shared via alternates.
+        std::fs::write(source.join("b.txt"), b"two").unwrap();
+        run(&source, &["add", "-A"]);
+        run(&source, &["commit", "-q", "-m", "second"]);
+        std::fs::write(source.join("c.txt"), b"three").unwrap();
+        run(&source, &["add", "-A"]);
+        run(&source, &["commit", "-q", "-m", "third"]);
+        let moved_base = capture(&source, &["rev-parse", "main"]);
+
+        // A staged-but-uncommitted edit in the clone shows up as a changed file.
+        std::fs::write(clone.join("dirty.txt"), b"x").unwrap();
+
+        let meta = git_meta(&clone, "main", Some(&moved_base)).await;
+        assert_eq!(meta.base, "main");
+        assert_eq!(meta.behind, Some(2), "base moved two commits ahead");
+        assert!(meta.files.iter().any(|p| p == "dirty.txt"));
+
+        // No base SHA → unknown behind, files still resolve.
+        let meta_none = git_meta(&clone, "main", None).await;
+        assert_eq!(meta_none.behind, None);
+        assert!(meta_none.files.iter().any(|p| p == "dirty.txt"));
     }
 
     // --- parse_porcelain ---

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1448,6 +1448,8 @@ pub fn run() {
             commands::allocate_draft_name,
             commands::get_git_state,
             commands::get_all_shortstats,
+            commands::get_all_git_meta,
+            commands::refresh_base_freshness,
             commands::push_agent,
             commands::pull_agent,
             commands::rebase_agent,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,8 @@ import { setAppBadgeCount } from "./util/window";
 export function App() {
   const init = useAppStore((s) => s.init);
   const fetchAllShortstats = useAppStore((s) => s.fetchAllShortstats);
+  const fetchAllGitMeta = useAppStore((s) => s.fetchAllGitMeta);
+  const refreshBaseFreshness = useAppStore((s) => s.refreshBaseFreshness);
   const refreshAllPrStates = useAppStore((s) => s.refreshAllPrStates);
   const refreshAllPrChecks = useAppStore((s) => s.refreshAllPrChecks);
   // PR polls hit the GitHub API — skip them entirely in local-only mode
@@ -75,6 +77,26 @@ export function App() {
   // panel to mount. Queries run in parallel on the backend; the reply is a
   // flat number-only map so payload stays small as agent count grows.
   usePoll(fetchAllShortstats, 5000, [fetchAllShortstats]);
+
+  // App-wide poll for advisory git metadata — base staleness (how far each
+  // checkout has fallen behind its base) + changed-file paths for overlap
+  // hints. Local git only (no network), so it runs regardless of GitHub; a
+  // slower 15s cadence since it's advisory and the fleet's diff/base move far
+  // less often than the sidebar badges the 5s shortstats poll drives.
+  usePoll(fetchAllGitMeta, 15000, [fetchAllGitMeta]);
+
+  // App-wide slow poll that fetches each project's base branch on its source
+  // repo, so the staleness chips above track a base that moved on GitHub (a
+  // sibling's PR merging, a teammate's push). Network + GitHub-gated like the
+  // PR polls; 5min cadence — a moved base is normal, not urgent — and silent by
+  // contract (a background fetch never raises a user-facing error).
+  usePoll(
+    async () => {
+      if (githubConnected) await refreshBaseFreshness();
+    },
+    300000,
+    [refreshBaseFreshness, githubConnected],
+  );
 
   // App-wide poll for remote PR state (open → merged / closed, mergeability)
   // so the sidebar PR badge tracks changes made on GitHub — a merge by a

--- a/src/api.ts
+++ b/src/api.ts
@@ -187,6 +187,17 @@ export interface ShortStats {
   file_count: number;
 }
 
+/** Advisory fleet-wide git metadata for one checkout, keyed by `gitKey` in the
+ *  bulk `getAllGitMeta` reply. `behind` (base moved ahead of this checkout) and
+ *  `files` (working-tree paths) drive the always-visible staleness chip and the
+ *  cross-agent overlap hints. `behind` is null when the base tip can't be
+ *  resolved (no GitHub / no fetch yet) — render nothing, never a zero. */
+export interface GitMeta {
+  base: string;
+  behind: number | null;
+  files: string[];
+}
+
 export interface GitState {
   branch: string;
   parent_branch: string;
@@ -762,6 +773,8 @@ export const api = {
   getGitState: (agentId: string, subdir?: string) =>
     invoke<GitState | null>("get_git_state", { agentId, subdir }),
   getAllShortstats: () => invoke<Record<string, ShortStats>>("get_all_shortstats"),
+  getAllGitMeta: () => invoke<Record<string, GitMeta>>("get_all_git_meta"),
+  refreshBaseFreshness: () => invoke<void>("refresh_base_freshness"),
   getPrState: (agentId: string, subdir?: string) =>
     invoke<PrState | null>("get_pr_state", { agentId, subdir }),
   refreshAllPrStates: () => invoke<Record<string, PrState | null>>("refresh_all_pr_states"),

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -9,6 +9,7 @@ import { lookupModel } from "@/data/modelCatalog";
 import { providerChip, providerLabel } from "@/data/providers";
 import type { DraftAgent } from "@/store";
 import { useAppStore } from "@/store";
+import { maxBehind } from "@/store/git";
 import { formatAge } from "@/util/format";
 import { useMinuteClock } from "@/util/hooks";
 import { type AgentPr, useAgentPrs } from "@/util/prState";
@@ -60,10 +61,11 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
   // only PR lives on a secondary repo still gets its badge.
   const agentPrs = useAgentPrs(agent);
   const shortstats = useAppStore((s) => s.gitShortstats[agent.id]);
-  // Base-staleness for the primary checkout — a quiet "base moved" cue. Shown
-  // whenever the base has genuinely moved ahead (behind > 0); an unknown or
-  // zero count renders nothing (never a fake 0).
-  const behind = useAppStore((s) => s.gitMeta[agent.id]?.behind ?? null);
+  // Base-staleness across the agent's checkouts (stalest wins — a behind
+  // secondary must surface even when the primary is fresh). A quiet "base
+  // moved" cue, shown only when a base has genuinely moved ahead (behind > 0);
+  // an unknown or zero count renders nothing (never a fake 0).
+  const behind = useAppStore((s) => maxBehind(s.gitMeta, agent.id));
   const unseen = useAppStore((s) => s.unseenResults[agent.id] ?? false);
   // Dev-server state for this checkout — orthogonal to the agent's turn status,
   // so it shows as its own play chip beside the identity chip, not among the

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -60,6 +60,10 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
   // only PR lives on a secondary repo still gets its badge.
   const agentPrs = useAgentPrs(agent);
   const shortstats = useAppStore((s) => s.gitShortstats[agent.id]);
+  // Base-staleness for the primary checkout — a quiet "base moved" cue. Shown
+  // whenever the base has genuinely moved ahead (behind > 0); an unknown or
+  // zero count renders nothing (never a fake 0).
+  const behind = useAppStore((s) => s.gitMeta[agent.id]?.behind ?? null);
   const unseen = useAppStore((s) => s.unseenResults[agent.id] ?? false);
   // Dev-server state for this checkout — orthogonal to the agent's turn status,
   // so it shows as its own play chip beside the identity chip, not among the
@@ -220,6 +224,16 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
         ) : hasChanges ? (
           <DiffStat stats={shortstats} />
         ) : null}
+        {behind != null && behind > 0 && (
+          <span
+            className="a-stale tip"
+            data-tip={`Base has moved ${behind} commit(s) ahead`}
+            aria-label={`Base moved ${behind} commits ahead`}
+          >
+            <Icon name="branch" size={9} />
+            {behind}
+          </span>
+        )}
         <span
           className="a-time"
           onMouseEnter={() => setStatsOpen(true)}

--- a/src/components/Workspace/MissionControl/EvidenceChips.tsx
+++ b/src/components/Workspace/MissionControl/EvidenceChips.tsx
@@ -40,14 +40,32 @@ export function EvidenceChips({ item }: { item: ReviewItem }) {
         <Icon name="pr" size={11} />#{item.pr.number}
       </button>
     ) : null,
-    // Future-PR slot (§1): a staleness chip, wired here so it lands with no
-    // layout change when a later PR feeds `item.staleness`. Null today.
+    // Staleness (§2): quiet information, not an alarm — a moved base is normal
+    // in a parallel fleet, so it's muted, never danger-toned. Absent when the
+    // base hasn't moved (or is unknown), so it renders nothing rather than 0.
     item.staleness ? (
-      <span key="stale" className="mc-chip mc-chip-warn">
+      <span
+        key="stale"
+        className="mc-chip mc-chip-muted"
+        title={`Base ${item.staleness.base} has moved ${item.staleness.behind} commit(s) ahead`}
+      >
         <Icon name="branch" size={11} />
-        behind {item.staleness.base} by {item.staleness.behind}
+        base moved · {item.staleness.behind} behind
       </span>
     ) : null,
+    // Overlap hints (§4): the quietest chip of all — advisory heads-up that
+    // another agent on this repo touches some of the same files. Never a
+    // warning color; no gating.
+    ...(item.overlaps ?? []).map((o) => (
+      <span
+        key={`overlap:${o.agentName}`}
+        className="mc-chip mc-chip-muted"
+        title={`Overlaps with ${o.agentName} on ${o.count} file(s)`}
+      >
+        <Icon name="layers" size={11} />
+        overlaps {o.agentName} ({o.count})
+      </span>
+    )),
   ].filter(Boolean);
 
   if (chips.length === 0) return null;

--- a/src/components/Workspace/MissionControl/EvidenceChips.tsx
+++ b/src/components/Workspace/MissionControl/EvidenceChips.tsx
@@ -47,10 +47,13 @@ export function EvidenceChips({ item }: { item: ReviewItem }) {
       <span
         key="stale"
         className="mc-chip mc-chip-muted"
-        title={`Base ${item.staleness.base} has moved ${item.staleness.behind} commit(s) ahead`}
+        title={`Base ${item.staleness.base} has moved ${item.staleness.behind} commit(s) ahead${
+          item.staleness.repo ? ` (in ${item.staleness.repo})` : ""
+        }`}
       >
         <Icon name="branch" size={11} />
         base moved · {item.staleness.behind} behind
+        {item.staleness.repo && <span className="mc-chip-sub"> · {item.staleness.repo}</span>}
       </span>
     ) : null,
     // Overlap hints (§4): the quietest chip of all — advisory heads-up that

--- a/src/components/Workspace/MissionControl/FanoutCard.tsx
+++ b/src/components/Workspace/MissionControl/FanoutCard.tsx
@@ -1,0 +1,89 @@
+import type { KeyboardEvent } from "react";
+import { Icon } from "@/components/Icon";
+import type { ReviewItem } from "./queue";
+
+interface Props {
+  item: ReviewItem;
+  focused: boolean;
+  onFocus: () => void;
+  /** ↵ — open the merged PR on GitHub. */
+  onEnter: () => void;
+  /** a — Update all: delegate `update-branch` to every affected agent. */
+  onUpdateAll: () => void;
+  onDismiss: () => void;
+}
+
+/** A merge fan-out card (§3): one clear sentence — a sibling's PR merged and N
+ *  agents on the repo are now behind — with one obvious action, "Update all",
+ *  which flips each affected agent into its delegated/running state through the
+ *  existing update-branch machinery. The affected agents are listed as quiet
+ *  chips so the scope is visible without extra UI. Shares the queue-card shell
+ *  so it reads as one system with the agent/workflow cards. */
+export function FanoutCard({ item, focused, onFocus, onEnter, onUpdateAll, onDismiss }: Props) {
+  const fanout = item.fanout;
+  if (!fanout) return null;
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (e.target !== e.currentTarget) return;
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onEnter();
+    }
+  };
+
+  return (
+    <div
+      className={`mc-card ${focused ? "focused" : ""}`}
+      role="button"
+      tabIndex={0}
+      aria-current={focused ? "true" : undefined}
+      onMouseEnter={onFocus}
+      onClick={onEnter}
+      onKeyDown={onKeyDown}
+    >
+      <span className="mc-card-rail" />
+      <div className="mc-card-body">
+        <div className="mc-card-head">
+          <span className="mc-wf-chip iflex-center" title="Base moved">
+            <Icon name="merge" size={14} />
+          </span>
+          <span className="mc-card-title truncate">{fanout.merged.title} merged</span>
+          <span className="mc-card-reason">base moved</span>
+        </div>
+        <div className="mc-card-goal truncate">{item.goal}</div>
+        <div className="mc-chips">
+          {fanout.agents.map((a) => (
+            <span key={a.agentId} className="mc-chip mc-chip-muted" title={`${a.behind} behind`}>
+              <Icon name="branch" size={11} />
+              {a.name}
+            </span>
+          ))}
+        </div>
+      </div>
+      <div className="mc-card-actions">
+        <button
+          type="button"
+          className="mc-btn primary"
+          onClick={(e) => {
+            e.stopPropagation();
+            onUpdateAll();
+          }}
+        >
+          <Icon name="loop" size={12} /> Update all
+        </button>
+        <button
+          type="button"
+          className="mc-dismiss tip"
+          data-tip="Dismiss until this changes"
+          aria-label="Dismiss"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDismiss();
+          }}
+        >
+          <Icon name="close" size={12} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Workspace/MissionControl/MissionControl.css
+++ b/src/components/Workspace/MissionControl/MissionControl.css
@@ -166,6 +166,18 @@
   background: color-mix(in oklch, var(--att) 12%, transparent);
   border-color: color-mix(in oklch, var(--att) 30%, transparent);
 }
+/* Quiet advisory chips — staleness ("base moved") and overlap hints. A moved
+ * base is normal in a parallel fleet, so these read as muted information, never
+ * an alarm: no color tint, softer than a plain evidence chip. */
+.mc-chip-muted {
+  color: var(--fg-2);
+  background: transparent;
+  border-style: dashed;
+  border-color: var(--bd-soft);
+}
+.mc-chip-muted svg {
+  color: var(--fg-3);
+}
 
 /* ── actions ──────────────────────────────────────────────────────────────── */
 .mc-card-actions {

--- a/src/components/Workspace/MissionControl/index.tsx
+++ b/src/components/Workspace/MissionControl/index.tsx
@@ -9,6 +9,7 @@ import { Icon } from "@/components/Icon";
 import { IconButton } from "@/components/ui/IconButton";
 import { useAppStore } from "@/store";
 import { AllClear } from "./AllClear";
+import { FanoutCard } from "./FanoutCard";
 import { QueueCard } from "./QueueCard";
 import { useQueueActions } from "./useQueueActions";
 import { useQueueKeyboard } from "./useQueueKeyboard";
@@ -60,18 +61,30 @@ export function MissionControl() {
         ) : (
           <div className="mc-wrap">
             <div className="mc-list">
-              {items.map((item, i) => (
-                <QueueCard
-                  key={item.id}
-                  item={item}
-                  focused={i === index}
-                  onFocus={() => setIndex(i)}
-                  onEnter={() => actions.enter(item)}
-                  onApprove={() => actions.approve(item)}
-                  onRequestChanges={() => actions.requestChanges(item)}
-                  onDismiss={() => actions.dismiss(item)}
-                />
-              ))}
+              {items.map((item, i) =>
+                item.kind === "fanout" ? (
+                  <FanoutCard
+                    key={item.id}
+                    item={item}
+                    focused={i === index}
+                    onFocus={() => setIndex(i)}
+                    onEnter={() => actions.enter(item)}
+                    onUpdateAll={() => actions.approve(item)}
+                    onDismiss={() => actions.dismiss(item)}
+                  />
+                ) : (
+                  <QueueCard
+                    key={item.id}
+                    item={item}
+                    focused={i === index}
+                    onFocus={() => setIndex(i)}
+                    onEnter={() => actions.enter(item)}
+                    onApprove={() => actions.approve(item)}
+                    onRequestChanges={() => actions.requestChanges(item)}
+                    onDismiss={() => actions.dismiss(item)}
+                  />
+                ),
+              )}
             </div>
             <div className="mc-hints" aria-hidden="true">
               <span className="mc-hint">

--- a/src/components/Workspace/MissionControl/queue.test.ts
+++ b/src/components/Workspace/MissionControl/queue.test.ts
@@ -338,6 +338,21 @@ describe("buildReviewQueue", () => {
     ).toEqual([]);
   });
 
+  it("surfaces staleness from a secondary checkout — stalest wins, repo named", () => {
+    const q = buildReviewQueue(
+      input({
+        agents: [agent({ id: "a" })],
+        unseenResults: { a: true },
+        gitShortstats: { a: stats(1, 0) },
+        gitMeta: {
+          a: meta({ behind: 0 }), // primary fresh
+          "a::pkg/api": meta({ base: "main", behind: 4 }), // secondary stale
+        },
+      }),
+    );
+    expect(q[0].staleness).toEqual({ base: "main", behind: 4, repo: "pkg/api" });
+  });
+
   // ── overlap hints (§4) ────────────────────────────────────────────────────────
 
   it("adds pairwise overlap hints for agents on the same repo touching shared files", () => {
@@ -372,6 +387,31 @@ describe("buildReviewQueue", () => {
       }),
     );
     expect(q.find((i) => i.id === "agent:a")?.overlaps).toBeUndefined();
+  });
+
+  it("detects overlaps in secondary checkouts of the same source repo", () => {
+    const twoRepo = (id: string) =>
+      agent({
+        id,
+        repos: [
+          { repo_path: `/primary-${id}`, subdir: "", parent_branch: "main" },
+          { repo_path: "/shared", subdir: "pkg/api", parent_branch: "main" },
+        ],
+      });
+    const q = buildReviewQueue(
+      input({
+        agents: [twoRepo("a"), twoRepo("b")],
+        unseenResults: { a: true, b: true },
+        gitShortstats: { a: stats(1, 0), b: stats(1, 0) },
+        // Only the secondary checkouts (distinct primaries) touch shared files.
+        gitMeta: {
+          "a::pkg/api": meta({ files: ["src/x.ts"] }),
+          "b::pkg/api": meta({ files: ["src/x.ts", "src/y.ts"] }),
+        },
+      }),
+    );
+    expect(q.find((i) => i.id === "agent:a")?.overlaps).toEqual([{ agentName: "b", count: 1 }]);
+    expect(q.find((i) => i.id === "agent:b")?.overlaps).toEqual([{ agentName: "a", count: 1 }]);
   });
 
   // ── merge fan-out (§3) ────────────────────────────────────────────────────────

--- a/src/components/Workspace/MissionControl/queue.test.ts
+++ b/src/components/Workspace/MissionControl/queue.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { AgentRecord, PrChecks, PrComments, PrState, ShortStats, WfRun } from "@/api";
+import type { AgentRecord, GitMeta, PrChecks, PrComments, PrState, ShortStats, WfRun } from "@/api";
 import { BUCKET, buildReviewQueue, type QueueInput } from "./queue";
 
 // ── fixtures ──────────────────────────────────────────────────────────────────
@@ -82,10 +82,18 @@ function run(over: Partial<WfRun> & { id: string }): WfRun {
   };
 }
 
+const meta = (over: Partial<GitMeta>): GitMeta => ({
+  base: "main",
+  behind: null,
+  files: [],
+  ...over,
+});
+
 function input(over: Partial<QueueInput>): QueueInput {
   return {
     agents: [],
     gitShortstats: {},
+    gitMeta: {},
     unseenResults: {},
     prStates: {},
     prChecks: {},
@@ -94,6 +102,16 @@ function input(over: Partial<QueueInput>): QueueInput {
     dismissed: {},
     ...over,
   };
+}
+
+/** A single-repo agent bound to `repoPath`, so fan-out/overlap grouping keys off
+ *  a real primary repo. */
+function repoAgent(id: string, repoPath: string, over: Partial<AgentRecord> = {}): AgentRecord {
+  return agent({
+    id,
+    repos: [{ repo_path: repoPath, subdir: "", parent_branch: "main" }],
+    ...over,
+  });
 }
 
 // ── tests ───────────────────────────────────────────────────────────────────
@@ -282,5 +300,174 @@ describe("buildReviewQueue", () => {
     });
     expect(grown).toHaveLength(1);
     expect(grown[0].id).toBe("agent:a");
+  });
+
+  // ── staleness (§2) ──────────────────────────────────────────────────────────
+
+  it("feeds staleness onto an existing card when the base has moved", () => {
+    const q = buildReviewQueue(
+      input({
+        agents: [agent({ id: "a" })],
+        unseenResults: { a: true },
+        gitShortstats: { a: stats(4, 2) },
+        gitMeta: { a: meta({ base: "main", behind: 3 }) },
+      }),
+    );
+    expect(q).toHaveLength(1);
+    expect(q[0].staleness).toEqual({ base: "main", behind: 3 });
+  });
+
+  it("never fakes a zero/unknown staleness, and never creates a card on its own", () => {
+    // behind 0 and behind null both render nothing.
+    for (const behind of [0, null]) {
+      const q = buildReviewQueue(
+        input({
+          agents: [agent({ id: "a" })],
+          unseenResults: { a: true },
+          gitShortstats: { a: stats(1, 0) },
+          gitMeta: { a: meta({ behind }) },
+        }),
+      );
+      expect(q[0].staleness).toBeNull();
+    }
+    // Staleness alone (no other reason) does NOT surface a card.
+    expect(
+      buildReviewQueue(
+        input({ agents: [agent({ id: "a" })], gitMeta: { a: meta({ behind: 5 }) } }),
+      ),
+    ).toEqual([]);
+  });
+
+  // ── overlap hints (§4) ────────────────────────────────────────────────────────
+
+  it("adds pairwise overlap hints for agents on the same repo touching shared files", () => {
+    const q = buildReviewQueue(
+      input({
+        agents: [repoAgent("a", "/repo"), repoAgent("b", "/repo")],
+        // Both surface for unseen results so they have cards to decorate.
+        unseenResults: { a: true, b: true },
+        gitShortstats: { a: stats(1, 0), b: stats(1, 0) },
+        gitMeta: {
+          a: meta({ files: ["src/x.ts", "src/y.ts"] }),
+          b: meta({ files: ["src/y.ts", "src/z.ts"] }),
+        },
+      }),
+    );
+    const a = q.find((i) => i.id === "agent:a");
+    const b = q.find((i) => i.id === "agent:b");
+    expect(a?.overlaps).toEqual([{ agentName: "b", count: 1 }]);
+    expect(b?.overlaps).toEqual([{ agentName: "a", count: 1 }]);
+  });
+
+  it("no overlap hint when agents are on different repos or share no files", () => {
+    const q = buildReviewQueue(
+      input({
+        agents: [repoAgent("a", "/repo1"), repoAgent("b", "/repo2")],
+        unseenResults: { a: true, b: true },
+        gitShortstats: { a: stats(1, 0), b: stats(1, 0) },
+        gitMeta: {
+          a: meta({ files: ["src/x.ts"] }),
+          b: meta({ files: ["src/x.ts"] }), // same path, different repo
+        },
+      }),
+    );
+    expect(q.find((i) => i.id === "agent:a")?.overlaps).toBeUndefined();
+  });
+
+  // ── merge fan-out (§3) ────────────────────────────────────────────────────────
+
+  it("raises ONE fan-out item when a sibling merges and others are behind", () => {
+    const mergedPr: PrState = { ...openPr(42), state: "merged", title: "Add auth" };
+    const q = buildReviewQueue(
+      input({
+        agents: [
+          repoAgent("shipped", "/repo"),
+          repoAgent("behind1", "/repo"),
+          repoAgent("behind2", "/repo"),
+        ],
+        prStates: { shipped: mergedPr },
+        gitMeta: {
+          shipped: meta({ behind: 0 }),
+          behind1: meta({ behind: 2 }),
+          behind2: meta({ behind: 5 }),
+        },
+      }),
+    );
+    expect(q).toHaveLength(1);
+    const f = q[0];
+    expect(f.kind).toBe("fanout");
+    expect(f.bucket).toBe(BUCKET.fanout);
+    expect(f.id).toBe("fanout:/repo:main");
+    expect(f.fanout?.base).toBe("main");
+    expect(f.fanout?.merged).toEqual({ title: "Add auth", number: 42, url: "https://gh/pr/42" });
+    // Both behind siblings are affected (sorted by name); the shipped agent is
+    // excluded (its HEAD is the base, behind 0).
+    expect(f.fanout?.agents.map((a) => a.agentId)).toEqual(["behind1", "behind2"]);
+    expect(f.goal).toContain("2 agents are now behind main");
+  });
+
+  it("no fan-out when nobody is behind, or nobody merged", () => {
+    const mergedPr: PrState = { ...openPr(1), state: "merged" };
+    // Merged, but siblings caught up (behind 0) → no fan-out.
+    expect(
+      buildReviewQueue(
+        input({
+          agents: [repoAgent("shipped", "/repo"), repoAgent("sib", "/repo")],
+          prStates: { shipped: mergedPr },
+          gitMeta: { sib: meta({ behind: 0 }) },
+        }),
+      ),
+    ).toEqual([]);
+    // Behind, but no merged PR on the repo (a teammate push) → only per-agent
+    // staleness chips, no fan-out card.
+    expect(
+      buildReviewQueue(
+        input({
+          agents: [repoAgent("a", "/repo"), repoAgent("b", "/repo")],
+          gitMeta: { a: meta({ behind: 3 }), b: meta({ behind: 3 }) },
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("a fan-out item is dismissible and resurfaces when the affected set changes", () => {
+    const mergedPr: PrState = { ...openPr(7), state: "merged", title: "T" };
+    const base = input({
+      agents: [repoAgent("shipped", "/repo"), repoAgent("behind1", "/repo")],
+      prStates: { shipped: mergedPr },
+      gitMeta: { behind1: meta({ behind: 2 }) },
+    });
+    const [item] = buildReviewQueue(base);
+    expect(item.kind).toBe("fanout");
+    // Dismissed at its current signature → hidden.
+    expect(buildReviewQueue({ ...base, dismissed: { [item.id]: item.signature } })).toEqual([]);
+    // The behind count changed → new signature, dismissal expires, item returns.
+    const moved = buildReviewQueue({
+      ...base,
+      gitMeta: { behind1: meta({ behind: 9 }) },
+      dismissed: { [item.id]: item.signature },
+    });
+    expect(moved).toHaveLength(1);
+    expect(moved[0].id).toBe(item.id);
+  });
+
+  it("fan-out excludes agents that can't act (stopped/errored)", () => {
+    const mergedPr: PrState = { ...openPr(3), state: "merged" };
+    const q = buildReviewQueue(
+      input({
+        agents: [
+          repoAgent("shipped", "/repo"),
+          repoAgent("stopped", "/repo", { status: "stopped" }),
+          repoAgent("live", "/repo", { status: "idle" }),
+        ],
+        prStates: { shipped: mergedPr },
+        gitMeta: {
+          stopped: meta({ behind: 2 }),
+          live: meta({ behind: 2 }),
+        },
+      }),
+    );
+    expect(q).toHaveLength(1);
+    expect(q[0].fanout?.agents.map((a) => a.agentId)).toEqual(["live"]);
   });
 });

--- a/src/components/Workspace/MissionControl/queue.ts
+++ b/src/components/Workspace/MissionControl/queue.ts
@@ -7,6 +7,7 @@
 
 import type {
   AgentRecord,
+  GitMeta,
   PrChecks,
   PrComments,
   PrState,
@@ -25,10 +26,9 @@ export type ReviewReason =
   | "checks-failing"
   | "unresolved-comments";
 
-/** Future-PR slot (§1): a "base moved under this agent" signal. Designed now so
- *  the card can render a staleness chip without a type/layout change when a later
- *  PR feeds it; nothing populates it in this PR (backend deliberately deferred),
- *  so it is always `null` today and the chip never renders. */
+/** A "base moved under this agent" signal — quiet information, not an alarm (a
+ *  moved base is normal in a parallel fleet). Fed from the fleet-wide `gitMeta`
+ *  poll; rendered as a muted chip on every card state, and on the sidebar row. */
 export interface Staleness {
   /** The base branch the agent has fallen behind. */
   base: string;
@@ -36,11 +36,38 @@ export interface Staleness {
   behind: number;
 }
 
+/** One advisory file-overlap hint: another agent on the same repo is touching
+ *  `count` of the same files. Never a warning — just a heads-up that two agents
+ *  may conflict. Advisory only; no gating anywhere (docs/multi-repo-followups.md
+ *  §2 defers cross-repo merge gating). */
+export interface OverlapHint {
+  agentName: string;
+  count: number;
+}
+
+/** The merge fan-out payload (§3): a sibling's PR merged and moved the base, so
+ *  N other agents on the same repo are now behind. Carries the moved base, the
+ *  merged PR (the "what"), and the affected agents for the one-gesture
+ *  "Update all" action. */
+export interface FanoutAgent {
+  agentId: string;
+  name: string;
+  behind: number;
+  /** Secondary-repo checkout to update; undefined = the primary. */
+  subdir?: string;
+}
+export interface FanoutInfo {
+  base: string;
+  merged: { title: string; number: number; url: string };
+  agents: FanoutAgent[];
+}
+
 export interface ReviewItem {
   /** Stable id — `wf:<runId>` for a workflow item, `agent:<agentId>` for an
-   *  agent item. Drives keyboard focus and dismissal. */
+   *  agent item, `fanout:<repo>:<base>` for a merge fan-out. Drives keyboard
+   *  focus and dismissal. */
   id: string;
-  kind: "workflow" | "agent";
+  kind: "workflow" | "agent" | "fanout";
   /** Ordering bucket (see BUCKET). Lower = more decidable = higher in the queue. */
   bucket: number;
   /** Fingerprint of the item's *volatile* signals. Dismissal is keyed on this,
@@ -71,6 +98,12 @@ export interface ReviewItem {
   checks?: PrChecks;
   unresolvedComments?: number;
   staleness?: Staleness | null;
+  /** Advisory overlap hints — other agents on the same repo touching some of
+   *  the same files. Omitted when there are none. */
+  overlaps?: OverlapHint[];
+
+  // ── fan-out items ──
+  fanout?: FanoutInfo;
 }
 
 /** Ordering buckets, most-decidable-first. Rationale: an item is ranked by its
@@ -78,18 +111,22 @@ export interface ReviewItem {
  *  floats above one that just needs a look.
  *   0 workflow approval — a dedicated evidence surface + one-click promote.
  *   1 workflow conflict — a clear decision with a defined action.
- *   2 PR items (failing checks / unresolved threads) — CI evidence is present.
- *   3 plain unseen-diff agent items — a turn landed with changes to look at. */
+ *   2 merge fan-out — one gesture ("Update all") clears a moved base for many.
+ *   3 PR items (failing checks / unresolved threads) — CI evidence is present.
+ *   4 plain unseen-diff agent items — a turn landed with changes to look at. */
 export const BUCKET = {
   workflowApproval: 0,
   workflowConflict: 1,
-  pr: 2,
-  unseen: 3,
+  fanout: 2,
+  pr: 3,
+  unseen: 4,
 } as const;
 
 export interface QueueInput {
   agents: readonly AgentRecord[];
   gitShortstats: Record<string, ShortStats>;
+  /** Per-checkout base staleness + changed-file paths, keyed by `gitKey`. */
+  gitMeta: Record<string, GitMeta>;
   unseenResults: Record<string, boolean>;
   prStates: Record<string, PrState | null>;
   prChecks: Record<string, PrChecks | null>;
@@ -97,6 +134,13 @@ export interface QueueInput {
   runs: readonly WfRun[];
   /** Item id → signal signature it was dismissed at. */
   dismissed: Record<string, string>;
+}
+
+/** Per-repo map key mirroring `store/git.ts::gitKey` — plain agent id for the
+ *  primary repo, `agentId::subdir` for a secondary. Inlined (not imported) to
+ *  keep this selector free of the store, per the module contract above. */
+function repoKey(agentId: string, subdir?: string): string {
+  return subdir ? `${agentId}::${subdir}` : agentId;
 }
 
 /** First non-empty line of a brief, trimmed. Empty string when there's none —
@@ -172,11 +216,156 @@ function agentSignature(p: {
   return `u${p.unseen ? 1 : 0}|d${d}|c${c || "-"}`;
 }
 
+/** The agent's primary-repo base staleness, or null when the base hasn't moved
+ *  ahead (or is unknown). `behind === null` = base tip couldn't be resolved (no
+ *  GitHub / no fetch) → render nothing, never a zero. */
+function stalenessOf(agentId: string, input: QueueInput): Staleness | null {
+  const meta = input.gitMeta[agentId];
+  if (!meta || meta.behind == null || meta.behind <= 0) return null;
+  return { base: meta.base, behind: meta.behind };
+}
+
+/** Pairwise file-set overlaps among agents sharing a repo. Two agents "overlap"
+ *  when their primary checkouts touch ≥1 of the same file paths; the hint names
+ *  the other agent and the shared-file count. Grouped by the primary repo's
+ *  source path so only agents actually working the same repo are compared.
+ *  Advisory only — never gates anything. Returns agentId → hints (each side of a
+ *  pair gets one). */
+function computeOverlaps(input: QueueInput): Record<string, OverlapHint[]> {
+  // Agents with a non-empty primary file set, grouped by source repo path.
+  const byRepo = new Map<string, { agent: AgentRecord; files: Set<string> }[]>();
+  for (const agent of input.agents) {
+    const repoPath = agent.repos[0]?.repo_path;
+    if (!repoPath) continue;
+    const files = input.gitMeta[agent.id]?.files ?? [];
+    if (files.length === 0) continue;
+    const entry = { agent, files: new Set(files) };
+    const group = byRepo.get(repoPath);
+    if (group) group.push(entry);
+    else byRepo.set(repoPath, [entry]);
+  }
+
+  const out: Record<string, OverlapHint[]> = {};
+  const record = (id: string, hint: OverlapHint) => {
+    const list = out[id] ?? [];
+    list.push(hint);
+    out[id] = list;
+  };
+  for (const group of byRepo.values()) {
+    for (let i = 0; i < group.length; i++) {
+      for (let j = i + 1; j < group.length; j++) {
+        const a = group[i];
+        const b = group[j];
+        let count = 0;
+        for (const f of a.files) if (b.files.has(f)) count++;
+        if (count === 0) continue;
+        record(a.agent.id, { agentName: b.agent.name, count });
+        record(b.agent.id, { agentName: a.agent.name, count });
+      }
+    }
+  }
+  return out;
+}
+
+/** Can this agent act on an "Update all" delegation? Idle/running/spawning
+ *  agents can (running ones queue the trigger); stopped/errored ones can't. */
+function canDelegate(agent: AgentRecord): boolean {
+  return agent.status === "idle" || agent.status === "running" || agent.status === "spawning";
+}
+
+/** Build the merge fan-out items (§3): for each repo where a sibling's PR has
+ *  merged AND other agents on that repo are now behind the base, one actionable
+ *  card whose "Update all" delegates `update-branch` to every affected agent.
+ *  Pure over the current snapshot — the item disappears on its own once the
+ *  affected agents catch up (behind → 0). */
+function buildFanoutItems(input: QueueInput): ReviewItem[] {
+  interface RepoEntry {
+    agent: AgentRecord;
+    subdir?: string;
+    base: string;
+    pr: PrState | null;
+    behind: number | null;
+  }
+  // Group every agent-repo by (source repo path, base branch).
+  const groups = new Map<string, RepoEntry[]>();
+  for (const agent of input.agents) {
+    agent.repos.forEach((repo, i) => {
+      const key = repoKey(agent.id, i === 0 ? undefined : repo.subdir);
+      const base = repo.parent_branch || "main";
+      const groupKey = `${repo.repo_path} ${base}`;
+      const entry: RepoEntry = {
+        agent,
+        subdir: i === 0 ? undefined : repo.subdir,
+        base,
+        pr: input.prStates[key] ?? null,
+        behind: input.gitMeta[key]?.behind ?? null,
+      };
+      const group = groups.get(groupKey);
+      if (group) group.push(entry);
+      else groups.set(groupKey, [entry]);
+    });
+  }
+
+  const items: ReviewItem[] = [];
+  for (const [groupKey, entries] of groups) {
+    // The most recently merged PR in the group (highest number) is the "what".
+    const merged = entries
+      .filter((e) => e.pr?.state === "merged")
+      .sort((a, b) => (b.pr?.number ?? 0) - (a.pr?.number ?? 0))[0];
+    if (!merged?.pr) continue;
+    // Agents on this repo now behind the moved base — the merged agent itself
+    // is naturally excluded (its HEAD is the base), and only actionable agents
+    // are listed so "Update all" never dispatches to a stopped/errored one.
+    const affected: FanoutAgent[] = entries
+      .filter(
+        (e) =>
+          e.agent.id !== merged.agent.id &&
+          e.behind != null &&
+          e.behind > 0 &&
+          canDelegate(e.agent),
+      )
+      .map((e) => ({
+        agentId: e.agent.id,
+        name: e.agent.name,
+        behind: e.behind as number,
+        subdir: e.subdir,
+      }))
+      .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+    if (affected.length === 0) continue;
+
+    const base = merged.base;
+    const repoPath = groupKey.slice(0, groupKey.indexOf(" "));
+    const pr = merged.pr;
+    items.push({
+      id: `fanout:${repoPath}:${base}`,
+      kind: "fanout",
+      bucket: BUCKET.fanout,
+      // Merge identity + the affected set: a new merge, or an agent catching up
+      // (behind change) / dropping out, moves the signature so a dismissal
+      // expires exactly when the situation actually changes.
+      signature: `${pr.number}|${affected.map((a) => `${a.agentId}:${a.behind}`).join(",")}`,
+      // No natural timestamp; the most recent merge (highest PR number) floats
+      // its repo's fan-out to the top of the bucket. Pure + stable.
+      activityAt: pr.number,
+      title: pr.title || `PR #${pr.number}`,
+      goal: `${affected.length} ${affected.length === 1 ? "agent is" : "agents are"} now behind ${base}`,
+      reasons: [],
+      fanout: {
+        base,
+        merged: { title: pr.title || `PR #${pr.number}`, number: pr.number, url: pr.url },
+        agents: affected,
+      },
+    });
+  }
+  return items;
+}
+
 /** Compose the fleet review queue from current app state. Pure and synchronous:
  *  it never blocks on evidence (workflow approvals rank top because they carry a
  *  dedicated review surface, not because their evidence has finished loading). */
 export function buildReviewQueue(input: QueueInput): ReviewItem[] {
   const items: ReviewItem[] = [];
+  const overlaps = computeOverlaps(input);
 
   // ── workflow runs paused on a human decision (§1: approval or conflict) ──
   for (const run of input.runs) {
@@ -233,10 +422,15 @@ export function buildReviewQueue(input: QueueInput): ReviewItem[] {
       prSubdir: shown?.repo ? shown.repo : undefined,
       checks: shown?.checks ?? undefined,
       unresolvedComments: unresolved > 0 ? unresolved : undefined,
-      // Future-PR slot — no signal feeds it yet, so it's always absent today.
-      staleness: null,
+      // Always-visible signals (§2/§4): the base-moved chip and overlap hints
+      // decorate an existing card in every panel state — they never create one.
+      staleness: stalenessOf(agent.id, input),
+      overlaps: overlaps[agent.id],
     });
   }
+
+  // ── merge fan-out (§3): a sibling merged, siblings on the repo are behind ──
+  items.push(...buildFanoutItems(input));
 
   // Hide items dismissed at their *current* signature; a signature change (new
   // turn, new diff, CI flip) no longer matches the stored mark, so the item

--- a/src/components/Workspace/MissionControl/queue.ts
+++ b/src/components/Workspace/MissionControl/queue.ts
@@ -34,6 +34,9 @@ export interface Staleness {
   base: string;
   /** How many commits the base has moved ahead by. */
   behind: number;
+  /** The checkout the signal comes from — `undefined` for the primary, the
+   *  subdir for a secondary (so the chip can name it). */
+  repo?: string;
 }
 
 /** One advisory file-overlap hint: another agent on the same repo is touching
@@ -216,53 +219,84 @@ function agentSignature(p: {
   return `u${p.unseen ? 1 : 0}|d${d}|c${c || "-"}`;
 }
 
-/** The agent's primary-repo base staleness, or null when the base hasn't moved
- *  ahead (or is unknown). `behind === null` = base tip couldn't be resolved (no
- *  GitHub / no fetch) → render nothing, never a zero. */
+/** The agent's stalest checkout vs its base, or null when no base has moved
+ *  ahead (or all are unknown). Scans the primary AND every secondary key
+ *  (`agentId` / `agentId::subdir` — same convention as the PR maps): a stale
+ *  secondary must surface even when the primary is fresh. `behind === null` =
+ *  base tip couldn't be resolved (no GitHub / no fetch) → render nothing,
+ *  never a zero. */
 function stalenessOf(agentId: string, input: QueueInput): Staleness | null {
-  const meta = input.gitMeta[agentId];
-  if (!meta || meta.behind == null || meta.behind <= 0) return null;
-  return { base: meta.base, behind: meta.behind };
+  const prefix = `${agentId}::`;
+  const keys = [
+    agentId,
+    ...Object.keys(input.gitMeta)
+      .filter((k) => k.startsWith(prefix))
+      .sort(),
+  ];
+  let worst: Staleness | null = null;
+  for (const key of keys) {
+    const meta = input.gitMeta[key];
+    if (!meta || meta.behind == null || meta.behind <= 0) continue;
+    if (!worst || meta.behind > worst.behind) {
+      worst = {
+        base: meta.base,
+        behind: meta.behind,
+        repo: key === agentId ? undefined : key.slice(prefix.length),
+      };
+    }
+  }
+  return worst;
 }
 
 /** Pairwise file-set overlaps among agents sharing a repo. Two agents "overlap"
- *  when their primary checkouts touch ≥1 of the same file paths; the hint names
- *  the other agent and the shared-file count. Grouped by the primary repo's
- *  source path so only agents actually working the same repo are compared.
- *  Advisory only — never gates anything. Returns agentId → hints (each side of a
- *  pair gets one). */
+ *  when checkouts of the same source repo touch ≥1 of the same file paths; the
+ *  hint names the other agent and the shared-file count. EVERY checkout counts —
+ *  primary or secondary (`agentId::subdir` gitMeta keys) — since a same-repo
+ *  conflict is just as real in a sibling checkout. A pair overlapping in more
+ *  than one shared repo merges into one hint with the summed count. Advisory
+ *  only — never gates anything. Returns agentId → hints (each side of a pair
+ *  gets one). */
 function computeOverlaps(input: QueueInput): Record<string, OverlapHint[]> {
-  // Agents with a non-empty primary file set, grouped by source repo path.
+  // Every checkout with a non-empty file set, grouped by its source repo path.
   const byRepo = new Map<string, { agent: AgentRecord; files: Set<string> }[]>();
   for (const agent of input.agents) {
-    const repoPath = agent.repos[0]?.repo_path;
-    if (!repoPath) continue;
-    const files = input.gitMeta[agent.id]?.files ?? [];
-    if (files.length === 0) continue;
-    const entry = { agent, files: new Set(files) };
-    const group = byRepo.get(repoPath);
-    if (group) group.push(entry);
-    else byRepo.set(repoPath, [entry]);
+    agent.repos.forEach((repo, i) => {
+      if (!repo.repo_path) return;
+      const key = repoKey(agent.id, i === 0 ? undefined : repo.subdir);
+      const files = input.gitMeta[key]?.files ?? [];
+      if (files.length === 0) return;
+      const entry = { agent, files: new Set(files) };
+      const group = byRepo.get(repo.repo_path);
+      if (group) group.push(entry);
+      else byRepo.set(repo.repo_path, [entry]);
+    });
   }
 
-  const out: Record<string, OverlapHint[]> = {};
-  const record = (id: string, hint: OverlapHint) => {
-    const list = out[id] ?? [];
-    list.push(hint);
-    out[id] = list;
+  // agentId → (other agent's name → shared-file count), merged across repos.
+  const counts = new Map<string, Map<string, number>>();
+  const record = (id: string, otherName: string, count: number) => {
+    const per = counts.get(id) ?? new Map<string, number>();
+    per.set(otherName, (per.get(otherName) ?? 0) + count);
+    counts.set(id, per);
   };
   for (const group of byRepo.values()) {
     for (let i = 0; i < group.length; i++) {
       for (let j = i + 1; j < group.length; j++) {
         const a = group[i];
         const b = group[j];
+        if (a.agent.id === b.agent.id) continue;
         let count = 0;
         for (const f of a.files) if (b.files.has(f)) count++;
         if (count === 0) continue;
-        record(a.agent.id, { agentName: b.agent.name, count });
-        record(b.agent.id, { agentName: a.agent.name, count });
+        record(a.agent.id, b.agent.name, count);
+        record(b.agent.id, a.agent.name, count);
       }
     }
+  }
+
+  const out: Record<string, OverlapHint[]> = {};
+  for (const [id, per] of counts) {
+    out[id] = [...per].map(([agentName, count]) => ({ agentName, count }));
   }
   return out;
 }
@@ -292,7 +326,7 @@ function buildFanoutItems(input: QueueInput): ReviewItem[] {
     agent.repos.forEach((repo, i) => {
       const key = repoKey(agent.id, i === 0 ? undefined : repo.subdir);
       const base = repo.parent_branch || "main";
-      const groupKey = `${repo.repo_path} ${base}`;
+      const groupKey = `${repo.repo_path}\u0000${base}`;
       const entry: RepoEntry = {
         agent,
         subdir: i === 0 ? undefined : repo.subdir,
@@ -334,7 +368,7 @@ function buildFanoutItems(input: QueueInput): ReviewItem[] {
     if (affected.length === 0) continue;
 
     const base = merged.base;
-    const repoPath = groupKey.slice(0, groupKey.indexOf(" "));
+    const repoPath = groupKey.slice(0, groupKey.indexOf("\u0000"));
     const pr = merged.pr;
     items.push({
       id: `fanout:${repoPath}:${base}`,

--- a/src/components/Workspace/MissionControl/useQueueActions.ts
+++ b/src/components/Workspace/MissionControl/useQueueActions.ts
@@ -6,6 +6,7 @@
 // action: any state the ladder can't map cleanly falls back to opening the
 // agent's Git tab.
 
+import { open } from "@tauri-apps/plugin-shell";
 import { useCallback } from "react";
 import { api } from "@/api";
 import { appActionMessage, type GitDelegationKind } from "@/components/RightPanel/delegation";
@@ -148,8 +149,32 @@ export function useQueueActions(openReview: (runId: string) => void): QueueActio
     [fetchGitState, delegateGitAction, mergePr, openAgentGit],
   );
 
+  // Fan-out "Update all": dispatch the existing `update-branch` delegation to
+  // every affected agent, each scoped to its own checkout. Running agents queue
+  // the trigger and idle ones start immediately — either way each flips into its
+  // delegated/running state through the same machinery the Git panel uses, so no
+  // new progress UI is needed.
+  const updateAll = useCallback(
+    (item: ReviewItem) => {
+      const fanout = item.fanout;
+      if (!fanout) return;
+      for (const a of fanout.agents) {
+        const trigger = appActionMessage(
+          "update-branch",
+          a.subdir ? { base: fanout.base, repo: a.subdir } : { base: fanout.base },
+        );
+        delegateGitAction(a.agentId, "update-branch", trigger, a.subdir);
+      }
+    },
+    [delegateGitAction],
+  );
+
   const enter = useCallback(
     (item: ReviewItem) => {
+      if (item.kind === "fanout") {
+        if (item.fanout) void open(item.fanout.merged.url);
+        return;
+      }
       if (item.kind === "workflow" && item.runId) openReview(item.runId);
       else if (item.agent) openAgentGit(item.agent.id);
     },
@@ -158,17 +183,24 @@ export function useQueueActions(openReview: (runId: string) => void): QueueActio
 
   const approve = useCallback(
     (item: ReviewItem) => {
+      if (item.kind === "fanout") {
+        updateAll(item);
+        return;
+      }
       if (item.kind === "workflow" && item.runId) {
         void api.wfApprove(item.runId).catch((e) => setLastError(`Approve failed: ${e}`));
         return;
       }
       if (item.agent) void approveAgent(item.agent.id, item.prSubdir);
     },
-    [approveAgent, setLastError],
+    [approveAgent, updateAll, setLastError],
   );
 
   const requestChanges = useCallback(
     (item: ReviewItem) => {
+      // A fan-out card has no "request changes" gesture — its only action is
+      // Update all (bound to `a`). `r` is a no-op here.
+      if (item.kind === "fanout") return;
       // Workflow reject needs a note — that lives in the ReviewSurface's reject
       // form, so open the same modal rather than rejecting blind.
       if (item.kind === "workflow" && item.runId) {

--- a/src/components/Workspace/MissionControl/useReviewQueue.ts
+++ b/src/components/Workspace/MissionControl/useReviewQueue.ts
@@ -10,6 +10,7 @@ import { buildReviewQueue, type ReviewItem } from "./queue";
 export function useReviewQueue(): ReviewItem[] {
   const agents = useAppStore((s) => s.workspace?.agents ?? EMPTY_AGENTS);
   const gitShortstats = useAppStore((s) => s.gitShortstats);
+  const gitMeta = useAppStore((s) => s.gitMeta);
   const unseenResults = useAppStore((s) => s.unseenResults);
   const prStates = useAppStore((s) => s.prStates);
   const prChecks = useAppStore((s) => s.prChecks);
@@ -22,6 +23,7 @@ export function useReviewQueue(): ReviewItem[] {
       buildReviewQueue({
         agents,
         gitShortstats,
+        gitMeta,
         unseenResults,
         prStates,
         prChecks,
@@ -29,6 +31,16 @@ export function useReviewQueue(): ReviewItem[] {
         runs,
         dismissed,
       }),
-    [agents, gitShortstats, unseenResults, prStates, prChecks, prComments, runs, dismissed],
+    [
+      agents,
+      gitShortstats,
+      gitMeta,
+      unseenResults,
+      prStates,
+      prChecks,
+      prComments,
+      runs,
+      dismissed,
+    ],
   );
 }

--- a/src/store/git.ts
+++ b/src/store/git.ts
@@ -1,4 +1,4 @@
-import { api } from "@/api";
+import { api, type GitMeta } from "@/api";
 import { gitActionProvesKind } from "@/components/RightPanel/delegation";
 import type { GitCommitAction } from "@/components/RightPanel/primaryActions";
 import { setSetting } from "@/storage/settings";
@@ -14,6 +14,21 @@ type GitGet = Parameters<SliceCreator<GitSlice>>[1];
  *  the suffixed form. */
 export function gitKey(agentId: string, subdir?: string): string {
   return subdir ? `${agentId}::${subdir}` : agentId;
+}
+
+/** Max `behind` across an agent's checkouts (the `agentId` primary key plus
+ *  every `agentId::subdir` secondary in `gitMeta`), or null when every base is
+ *  unknown or fresh — a stale secondary must surface even when the primary is
+ *  current. */
+export function maxBehind(meta: Record<string, GitMeta>, agentId: string): number | null {
+  const prefix = `${agentId}::`;
+  let worst: number | null = null;
+  for (const [key, m] of Object.entries(meta)) {
+    if (key !== agentId && !key.startsWith(prefix)) continue;
+    if (m.behind == null || m.behind <= 0) continue;
+    if (worst == null || m.behind > worst) worst = m.behind;
+  }
+  return worst;
 }
 
 // Shared shape for the simple git mutations: run the backend call, refresh git

--- a/src/store/git.ts
+++ b/src/store/git.ts
@@ -60,6 +60,7 @@ const fetchPrAux = async <K extends "prChecks" | "prComments">(
 export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
   gitStates: {},
   gitShortstats: {},
+  gitMeta: {},
   prStates: {},
   prChecks: {},
   prComments: {},
@@ -86,6 +87,26 @@ export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
       set({ gitShortstats: map });
     } catch {
       // non-fatal — next poll tick will retry
+    }
+  },
+
+  fetchAllGitMeta: async () => {
+    try {
+      const map = await api.getAllGitMeta();
+      // Replace wholesale (like gitShortstats) — agents removed between ticks
+      // fall out naturally, and this map is independent of gitStates so the
+      // focused panel's full-state poll is never clobbered.
+      set({ gitMeta: map });
+    } catch {
+      // non-fatal — next poll tick will retry
+    }
+  },
+
+  refreshBaseFreshness: async () => {
+    try {
+      await api.refreshBaseFreshness();
+    } catch {
+      // Background fetch — silent by contract; the next tick retries.
     }
   },
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -9,6 +9,7 @@ import type {
   ForkCode,
   ForkContext,
   GhStatus,
+  GitMeta,
   GitState,
   PrChecks,
   PrComments,
@@ -231,6 +232,11 @@ export interface GitSlice {
    *  poll — kept in its own map so the focused agent's richer `gitStates`
    *  entry isn't clobbered by a slower bulk reply. */
   gitShortstats: Record<string, ShortStats>;
+  /** Advisory per-checkout git metadata (base staleness + changed-file paths),
+   *  keyed by `gitKey(agentId, subdir?)`. Fed by the app-wide `getAllGitMeta`
+   *  poll — separate from `gitShortstats` (badge numbers) so each evolves on its
+   *  own cadence. Drives the "base moved" staleness chips and overlap hints. */
+  gitMeta: Record<string, GitMeta>;
   /** PR state, keyed by `gitKey(agentId, subdir?)` — plain agent_id for the
    *  primary repo (updated by the pr:state_changed watcher event + bulk
    *  polls), `agentId::subdir` for a secondary repo. */
@@ -258,6 +264,13 @@ export interface GitSlice {
   /** Fetch compact shortstats for every live agent in one round-trip
    *  (used by the app-wide background poll). */
   fetchAllShortstats: () => Promise<void>;
+  /** Fetch advisory git metadata (base staleness + file paths) for every live
+   *  checkout in one round-trip (app-wide background poll, local git only). */
+  fetchAllGitMeta: () => Promise<void>;
+  /** Slow-cadence host-side fetch of each project's base branch on its source
+   *  repo, so `fetchAllGitMeta` can measure staleness against a moved base.
+   *  Network + GitHub-gated; silent (never surfaces an error). */
+  refreshBaseFreshness: () => Promise<void>;
   fetchPrState: (agentId: string, subdir?: string) => Promise<void>;
   /** Refresh PR state for every repo with a known PR across every agent in
    *  one round-trip (used by the app-wide background poll). The reply is

--- a/src/styles/shared/badge.css
+++ b/src/styles/shared/badge.css
@@ -95,6 +95,17 @@
 .agent-sub .a-diff .del {
   color: var(--danger);
 }
+/* "base moved" cue — quiet information, not an alarm (a moved base is normal in
+ * a parallel fleet), so it's muted like a-time, never a warning color. */
+.agent-sub .a-stale {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  color: var(--fg-3);
+  font-size: var(--fs-xs);
+  font-family: var(--font-mono);
+  flex-shrink: 0;
+}
 .agent-sub .a-time {
   color: var(--fg-3);
   font-size: var(--fs-xs);


### PR DESCRIPTION
## What

The parallelism-integration segment of the coherency roadmap: when one agent's PR merges, its siblings no longer silently rot behind the moved base. Builds on Mission Control (#467).

### Host-side base freshness (Rust)

- `refresh_base_freshness` command: an authenticated `git fetch` of each project's base branch on the **source** repo (via the existing `git_auth_env` pattern — token never on argv), gated on `is_backing_off()`. Verified empirically in a reproduced `--shared`-clone topology: a fetch on the source updates only the source's `origin/<base>` ref, but the objects are shared via alternates — so `git_meta` reads the fresh base SHA from the source and counts `HEAD..<sha>` inside each clone. One fetch genuinely serves the whole fleet.
- `get_all_git_meta` command: bulk per-agent `GitMeta { base, behind: Option<u32>, files }`. A **sibling** of `get_all_shortstats`, not an extension — the hot 5s badge poll keeps its documented three-number contract and zero new cost.
- Scheduling mirrors the existing frontend `usePoll` precedent: meta at 15s (local, un-gated), freshness at 5min (GitHub-gated). Unknown behind renders nothing — never a fake 0.

### Always-visible staleness

"behind main · N" chip on `AgentRow` and on queue cards in **every** panel state (previously only the clean-state RightPanel showed it) — muted tone, not an alarm; a moved base is normal in a fleet. Feeds the `ReviewItem.staleness` slot #467 left wired-but-empty.

### Merge fan-out

Derived state, no new events: the queue selector groups agent-repos by `(repo_path, base)`; a group with a merged sibling PR and behind siblings yields ONE fan-out card — "*X* merged — N agents on this repo are now behind" — with **Update all** dispatching the existing `update-branch` delegation to each affected agent, scoped per checkout. Agents flip to their normal delegated state; no new progress UI. Signature-based dismissal expires exactly when the affected set changes; the card self-clears when siblings catch up. Stopped/errored agents excluded.

### Overlap hints

Advisory pairwise file-set intersections among agents on the same repo — "overlaps with *agent* (n files)", the quietest chip, never a warning. File paths ride the meta poll (`git status` already runs there), so overlap covers the whole fleet. No gating anywhere, per the multi-repo follow-ups doc.

## Testing

- Rust: `cargo fmt --check` clean; clippy with CI flags clean; `cargo test --lib` — my modules fully green (git_state 34, git 37); 4 pre-existing parallel-load timing flakes in untouched `child_io`/`exec_session` tests pass in isolation.
- Frontend: typecheck clean; biome clean on touched files; vitest green including 19 queue selector tests (staleness feed, fan-out derivation/dismissal, overlap pairs); build succeeds.

## Notes

- Focused `GitState.behind` (RightPanel clean-state) deliberately keeps clone-time semantics; the always-visible chips read the fresh `gitMeta` path instead. Rewiring `git_state::query` to a source SHA was out of scope.
- `query_ahead_behind` lookup order left as-is: in a `--shared` clone both local and origin refs are frozen at clone time, so reordering is a no-op there and a risk elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)