### PR TITLE
feat(workflows): step agents in sidebar, promote-to-workflow, project pipeline default

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -137,6 +137,19 @@ pub async fn get_agent_diff_stats(
     Ok(stats)
 }
 
+/// The current HEAD commit SHA of an agent's checkout (primary repo when
+/// `subdir` is omitted). Powers "promote to workflow", where the run forks from
+/// the promoted session's exact working commit rather than a branch tip.
+#[tauri::command]
+pub async fn agent_head_sha(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+    subdir: Option<String>,
+) -> Result<String> {
+    let (_repo, checkout) = agent_repo_checkout(&supervisor, &agent_id, subdir.as_deref())?;
+    git::rev_parse(&checkout, "HEAD").await
+}
+
 /// Allocate a fresh name from the shared place pool for a draft agent.
 /// Frontend passes the names already taken (real agents + other drafts) so
 /// the picker avoids collisions.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1413,6 +1413,7 @@ pub fn run() {
             commands::get_workspace,
             commands::wf_run_agents,
             commands::get_agent_diff_stats,
+            commands::agent_head_sha,
             commands::add_workspace_repo,
             commands::remove_workspace_repo,
             commands::attach_repo_to_project,

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -134,6 +134,11 @@ impl WorkflowService {
         repo_path: String,
         definition_id: Option<String>,
         base_branch: Option<String>,
+        // An explicit fork-point commit (promote-to-workflow): the run forks from
+        // this SHA instead of a branch tip. Wins over `base_branch` for the fork
+        // point, and leaves `base_branch` empty so finalization falls back to
+        // `finalize.pr_base`/`main` rather than treating a raw SHA as a PR base.
+        base_sha_override: Option<String>,
         // Launch-time file attachments (absolute paths). Persisted durably in a
         // host-only sidecar and rendered as `Attached file: {path}` lines into the
         // entry step's prompt only (see `drive_run_inner` / `execute_step`) — the
@@ -144,19 +149,26 @@ impl WorkflowService {
         let run_id = format!("run-{}", uuid::Uuid::new_v4());
         let repo = PathBuf::from(&repo_path);
 
-        // Resolve the base branch to a SHA in the source repo now, so the fork
-        // point is fixed and journaled (§12.2).
-        let base_ref = base_branch
+        // Resolve the fork point to a SHA in the source repo now, so it is fixed
+        // and journaled (§12.2). An explicit override (promotion) resolves
+        // directly; otherwise the caller's branch, the spec's pr_base, then HEAD.
+        let base_ref = base_sha_override
             .clone()
+            .or_else(|| base_branch.clone())
             .or_else(|| spec.finalize.as_ref().and_then(|f| f.pr_base.clone()))
             .unwrap_or_else(|| "HEAD".to_string());
         let base_sha = crate::git::rev_parse(&repo, &base_ref)
             .await
             .map_err(|e| Error::Other(format!("cannot resolve base '{base_ref}': {e}")))?;
-        // Persist the caller-selected branch name (not the "HEAD"/pr_base
+        // Persist the caller-selected branch name (not the "HEAD"/pr_base/SHA
         // fallback), so finalization can open the PR against the branch the run
-        // forked from when the spec doesn't pin `finalize.pr_base` (§12.2).
-        let base_branch = base_branch.unwrap_or_default();
+        // forked from when the spec doesn't pin `finalize.pr_base` (§12.2). A
+        // SHA-forked promotion carries no branch name.
+        let base_branch = if base_sha_override.is_some() {
+            String::new()
+        } else {
+            base_branch.unwrap_or_default()
+        };
 
         let run_dir = blackboard::run_dir(&run_id)?;
         let task_md = format!("# {}\n\n{}\n", spec.name, task);
@@ -6357,6 +6369,7 @@ pub async fn wf_launch(
     repo_path: String,
     definition_id: Option<String>,
     base_branch: Option<String>,
+    base_sha: Option<String>,
     attachments: Vec<String>,
     service: Svc<'_>,
     supervisor: tauri::State<'_, Arc<Supervisor>>,
@@ -6378,6 +6391,7 @@ pub async fn wf_launch(
             repo_path,
             definition_id,
             base_branch,
+            base_sha,
             attachments,
         )
         .await

--- a/src/api.ts
+++ b/src/api.ts
@@ -592,6 +592,9 @@ export const api = {
    *  rejects elsewhere. */
   startDockerDesktop: () => invoke<void>("start_docker_desktop"),
   getAgentDiffStats: (agentId: string) => invoke<DiffStats>("get_agent_diff_stats", { agentId }),
+  /** The current HEAD commit SHA of an agent's checkout (primary repo). The
+   *  fork point for "promote to workflow". */
+  agentHeadSha: (agentId: string) => invoke<string>("agent_head_sha", { agentId }),
   addWorkspaceRepo: (repoPath: string) => invoke<Workspace>("add_workspace_repo", { repoPath }),
   removeWorkspaceRepo: (repoPath: string) =>
     invoke<Workspace>("remove_workspace_repo", { repoPath }),
@@ -890,6 +893,9 @@ export const api = {
     /** Absolute paths of files to attach to the run's first prompt, like a chat
      *  message's attachments. Empty by default. */
     attachments: string[] = [],
+    /** Explicit fork-point commit (promote-to-workflow). Wins over `baseBranch`
+     *  for the fork point; leave undefined for a normal branch-based launch. */
+    baseSha?: string,
   ) =>
     invoke<string>("wf_launch", {
       spec,
@@ -898,6 +904,7 @@ export const api = {
       repoPath,
       definitionId,
       baseBranch,
+      baseSha,
       attachments,
     }),
   /** Cancel a run: stops the live attempt's agent and marks the run canceled. */

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -75,6 +75,7 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
   const pending = useAppStore((s) => s.pendingToolUse[agent.id]);
   const stop = useAppStore((s) => s.stop);
   const archive = useAppStore((s) => s.archive);
+  const promoteAgentToWorkflow = useAppStore((s) => s.promoteAgentToWorkflow);
   const now = useMinuteClock();
   const [statsOpen, setStatsOpen] = useState(false);
 
@@ -142,6 +143,10 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
     e.stopPropagation();
     archive(agent.id);
   };
+  const onPromote = (e: MouseEvent) => {
+    e.stopPropagation();
+    void promoteAgentToWorkflow(agent.id);
+  };
 
   return (
     <div
@@ -188,6 +193,14 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
             {agent.status === "error" && <Badge variant="err">error</Badge>}
           </span>
           <span className="ag-actions">
+            <button
+              className="ag-act iflex-center tip"
+              data-tip="Promote to workflow"
+              onClick={onPromote}
+              aria-label="Promote to workflow"
+            >
+              <Icon name="combine" size={11} />
+            </button>
             {stoppable && !awaiting && (
               <button
                 className="ag-act iflex-center tip"

--- a/src/components/Sidebar/StepAgentRow.tsx
+++ b/src/components/Sidebar/StepAgentRow.tsx
@@ -1,0 +1,49 @@
+import type { KeyboardEvent } from "react";
+import { AgentIdentityChip } from "@/components/AgentIdentityChip";
+import { Icon } from "@/components/Icon";
+import { useAppStore } from "@/store";
+import type { StepChild } from "./stepChildren";
+
+/** A run's step agent as a sidebar child of its RunRow — visually subordinate
+ *  (indented, quieter) but speaking the same status vocabulary as `AgentRow`.
+ *  Clicking focuses that step's chat in the run monitor. Step agents are
+ *  capability-restricted and owned by the run, so this row carries no
+ *  stop/archive/promote actions — its lifecycle is the run's. */
+export function StepAgentRow({ runId, child }: { runId: string; child: StepChild }) {
+  const { agent, rail, working } = child;
+  const selectRunStep = useAppStore((s) => s.selectRunStep);
+
+  const onSelect = () => selectRunStep(runId, agent.id);
+
+  return (
+    <div
+      className="agent run-step"
+      role="button"
+      tabIndex={0}
+      onClick={onSelect}
+      onKeyDown={(e: KeyboardEvent) => {
+        if (e.target !== e.currentTarget) return;
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
+    >
+      <span className={`ag-rail ${rail}`} />
+      <div className="agent-row flex-center">
+        <span className={`ag-name ${working ? "shimmer" : ""}`}>{agent.name}</span>
+        <AgentIdentityChip agent={agent} />
+        <span className="ag-slot iflex-center">
+          <span className="ag-meta">
+            {working && <span className="ag-loader" aria-label="Working" />}
+            {agent.status === "error" && (
+              <span className="ag-waiting tip" data-tip="Step failed" aria-label="Step failed">
+                <Icon name="close" size={12} />
+              </span>
+            )}
+          </span>
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Sidebar/stepChildren.test.ts
+++ b/src/components/Sidebar/stepChildren.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import type { AgentRecord, AgentStatus } from "@/api";
+import { deriveStepChildren } from "./stepChildren";
+
+function agent(over: Partial<AgentRecord> & { id: string }): AgentRecord {
+  return {
+    project_id: "p",
+    name: over.id,
+    provider: "claude",
+    repos: [],
+    task: "",
+    status: "idle" as AgentStatus,
+    view: "custom",
+    created_at: "2026-01-01T00:00:00.000Z",
+    ...over,
+  } as AgentRecord;
+}
+
+describe("deriveStepChildren", () => {
+  it("orders by spawn time, then id for stable ties", () => {
+    const out = deriveStepChildren([
+      agent({ id: "b", created_at: "2026-01-01T00:00:02.000Z" }),
+      agent({ id: "a", created_at: "2026-01-01T00:00:01.000Z" }),
+      agent({ id: "c", created_at: "2026-01-01T00:00:02.000Z" }),
+    ]);
+    expect(out.map((c) => c.agent.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("maps status to the AgentRow rail vocabulary", () => {
+    const out = deriveStepChildren([
+      agent({ id: "run", status: "running" }),
+      agent({ id: "spawn", status: "spawning" }),
+      agent({ id: "err", status: "error" }),
+      agent({ id: "idle", status: "idle" }),
+    ]);
+    const by = Object.fromEntries(out.map((c) => [c.agent.id, c]));
+    expect(by.run).toMatchObject({ rail: "run", working: true });
+    expect(by.spawn).toMatchObject({ rail: "run", working: true });
+    expect(by.err).toMatchObject({ rail: "err", working: false });
+    expect(by.idle).toMatchObject({ rail: "idle", working: false });
+  });
+
+  it("drops archived step agents so a finished run shows no tombstones", () => {
+    const out = deriveStepChildren([
+      agent({ id: "live" }),
+      agent({
+        id: "gone",
+        archive: { archived_at: "x", repos: [], diff_stats: { additions: 0, deletions: 0 } },
+      }),
+    ]);
+    expect(out.map((c) => c.agent.id)).toEqual(["live"]);
+  });
+
+  it("yields an empty list when there are no live step agents", () => {
+    expect(deriveStepChildren([])).toEqual([]);
+  });
+});

--- a/src/components/Sidebar/stepChildren.ts
+++ b/src/components/Sidebar/stepChildren.ts
@@ -1,0 +1,40 @@
+// Sidebar/stepChildren.ts — derive a run's step-agent children for the sidebar.
+// Run-owned step agents are ordinary AgentRecords fetched via `wf_run_agents`;
+// this collapses them into the ordered, live subset the RunRow expands under
+// itself, each carrying the same status-rail vocabulary as a regular AgentRow.
+
+import type { AgentRecord } from "@/api";
+
+/** Left-spine rail state, matching `AgentRow`'s vocabulary (minus the PR-merged
+ *  purple — step agents are capability-restricted and never own a PR). */
+export type StepRail = "run" | "err" | "idle";
+
+export interface StepChild {
+  agent: AgentRecord;
+  rail: StepRail;
+  /** Live turn in flight — drives the name shimmer + loader, like AgentRow. */
+  working: boolean;
+}
+
+function railFor(status: AgentRecord["status"]): { rail: StepRail; working: boolean } {
+  if (status === "running" || status === "spawning") return { rail: "run", working: true };
+  if (status === "error") return { rail: "err", working: false };
+  return { rail: "idle", working: false };
+}
+
+/** The live step agents of a run, in step (spawn) order. Archived step agents
+ *  are dropped — a finished run's expander shows nothing rather than a wall of
+ *  tombstones — and a run with no live step agent yields an empty list so the
+ *  RunRow can skip the expander stub entirely. */
+export function deriveStepChildren(agents: AgentRecord[]): StepChild[] {
+  return agents
+    .filter((a) => !a.archive)
+    .slice()
+    .sort((a, b) => {
+      const at = new Date(a.created_at).getTime();
+      const bt = new Date(b.created_at).getTime();
+      if (at !== bt) return at - bt;
+      return a.id.localeCompare(b.id);
+    })
+    .map((agent) => ({ agent, ...railFor(agent.status) }));
+}

--- a/src/components/Workspace/EmptyWorkspace.tsx
+++ b/src/components/Workspace/EmptyWorkspace.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { api } from "@/api";
 import { Composer } from "@/components/Composer";
 import { BranchPicker } from "@/components/Composer/BranchPicker";
@@ -56,14 +56,18 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
   // Kickoff mode: a quick single agent, or a multi-step pipeline. The toggle
   // sits at the top of the page and swaps the whole block — it never gates the
   // quick path. It defaults to the project's remembered choice (a suggestion),
-  // and remembers a change for next time.
+  // and remembers a change for next time. The remembered mode loads async — a
+  // pick made before it resolves wins (the load must never flip the toggle
+  // back under the user's cursor); a project switch re-arms the default.
   const [mode, setMode] = useState<ComposerMode>("agent");
   const [defaultWorkflowId, setDefaultWorkflowId] = useState<string | null>(null);
+  const modePicked = useRef(false);
   useEffect(() => {
+    modePicked.current = false;
     let cancelled = false;
     void loadPipelinePrefs(projectId).then((prefs) => {
       if (cancelled) return;
-      setMode(prefs.mode);
+      if (!modePicked.current) setMode(prefs.mode);
       setDefaultWorkflowId(prefs.defaultWorkflowId);
     });
     return () => {
@@ -71,6 +75,7 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
     };
   }, [projectId]);
   const pickMode = (next: ComposerMode) => {
+    modePicked.current = true;
     setMode(next);
     rememberComposerMode(projectId, next);
   };

--- a/src/components/Workspace/EmptyWorkspace.tsx
+++ b/src/components/Workspace/EmptyWorkspace.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { api } from "@/api";
 import { Composer } from "@/components/Composer";
 import { BranchPicker } from "@/components/Composer/BranchPicker";
@@ -7,7 +7,11 @@ import { Icon, LandmarkGlyph } from "@/components/Icon";
 import { IconButton } from "@/components/ui/IconButton";
 import type { DraftAgent } from "@/store";
 import { useAppStore } from "@/store";
-import { useDefinitions } from "@/workflows/run/useDefinitions";
+import {
+  type ComposerMode,
+  loadPipelinePrefs,
+  rememberComposerMode,
+} from "@/workflows/run/projectPipeline";
 import { WorkflowComposer, WorkflowHeading } from "@/workflows/run/WorkflowComposer";
 
 /** Empty-state pane shown when the user has started a draft agent.
@@ -42,13 +46,35 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
   const leftCollapsed = useAppStore((s) => s.leftCollapsed);
   const runLocalCommand = useAppStore((s) => s.runLocalCommand);
 
-  // Kickoff mode: a single agent, or a workflow. The toggle sits at the top of
-  // the page and swaps the whole block — it is not part of the prompt box. The
-  // Workflow option only appears once at least one workflow has been defined.
-  const [mode, setMode] = useState<"agent" | "workflow">("agent");
-  const { definitions } = useDefinitions();
-  const hasWorkflows = definitions.length > 0;
-  const workflowMode = mode === "workflow" && hasWorkflows;
+  // The project this draft targets — keys the remembered composer mode + default
+  // workflow (per-project `project_settings`).
+  const projectId = useMemo(
+    () => projectRefs.find((r) => r.path === draft.repoPath)?.project_id ?? "",
+    [projectRefs, draft.repoPath],
+  );
+
+  // Kickoff mode: a quick single agent, or a multi-step pipeline. The toggle
+  // sits at the top of the page and swaps the whole block — it never gates the
+  // quick path. It defaults to the project's remembered choice (a suggestion),
+  // and remembers a change for next time.
+  const [mode, setMode] = useState<ComposerMode>("agent");
+  const [defaultWorkflowId, setDefaultWorkflowId] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void loadPipelinePrefs(projectId).then((prefs) => {
+      if (cancelled) return;
+      setMode(prefs.mode);
+      setDefaultWorkflowId(prefs.defaultWorkflowId);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+  const pickMode = (next: ComposerMode) => {
+    setMode(next);
+    rememberComposerMode(projectId, next);
+  };
+  const workflowMode = mode === "workflow";
 
   return (
     <div className="pane center">
@@ -81,21 +107,19 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
       </div>
 
       <div className="empty-wrap flex-center fade-in">
-        {hasWorkflows && (
-          <div className="empty-modeswitch">
-            <div className="set-seg">
-              <button className={mode === "agent" ? "active" : ""} onClick={() => setMode("agent")}>
-                <Icon name="bot" size={13} /> Agent
-              </button>
-              <button
-                className={mode === "workflow" ? "active" : ""}
-                onClick={() => setMode("workflow")}
-              >
-                <Icon name="combine" size={13} /> Workflow
-              </button>
-            </div>
+        <div className="empty-modeswitch">
+          <div className="set-seg">
+            <button className={mode === "agent" ? "active" : ""} onClick={() => pickMode("agent")}>
+              <Icon name="bot" size={13} /> Quick agent
+            </button>
+            <button
+              className={mode === "workflow" ? "active" : ""}
+              onClick={() => pickMode("workflow")}
+            >
+              <Icon name="combine" size={13} /> Pipeline
+            </button>
           </div>
-        )}
+        </div>
 
         {/* Everything but the switcher — identity, the mode-variable heading +
             composer, and the pickers — centered as one unit and keyed by mode so
@@ -144,6 +168,8 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
                 repoPath={draft.repoPath}
                 baseBranch={draft.base}
                 name={draft.name}
+                projectId={projectId}
+                defaultWorkflowId={defaultWorkflowId}
               />
             ) : (
               <Composer

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -44,6 +44,27 @@ export interface SyncHealthInfo {
   version: string | null;
 }
 
+/** A seed for "promote to workflow": everything the builder needs to open
+ *  pre-filled from an ad-hoc session and launch a run that forks at the
+ *  session's working commit. */
+export interface PromoteSeed {
+  agentId: string;
+  /** The session's display name — titles the seeded workflow. */
+  agentName: string;
+  /** Custom-agent id (when the session had one and it still exists), else the
+   *  base-provider id — the argument `ensureAlias` turns into a spec alias. */
+  agentPick: string;
+  /** The session brief — becomes the run's task text. */
+  task: string;
+  /** The session's HEAD commit — the run's fork point. Empty when the checkout
+   *  has no commit yet (the launch then resolves HEAD in the source repo). */
+  baseSha: string;
+  /** Short, human-facing label for the fork point (short SHA or branch). */
+  baseLabel: string;
+  repoPath: string;
+  projectId: string;
+}
+
 export interface AppSlice {
   busy: boolean;
   lastError: string | null;
@@ -79,6 +100,11 @@ export interface WorkspaceSlice {
   /** A workflow run selected for the main pane, by run id. Mutually exclusive
    *  with selectedAgentId / activeDraftId. */
   selectedRunId: string | null;
+  /** A run's step agent whose chat the monitor should focus (set when a sidebar
+   *  step child is clicked). Consumed and cleared by RunView. */
+  focusedStepAgentId: string | null;
+  /** Pending "promote to workflow" seed: the builder opens pre-filled from it. */
+  promoteSeed: PromoteSeed | null;
   managedLogs: Record<string, ChatItem[]>;
   /** Question tools the agent is paused on, awaiting a human answer.
    *  Keyed by agent id, then by the tool_use id of the held `AskUserQuestion`
@@ -137,6 +163,14 @@ export interface WorkspaceSlice {
   selectAgent: (id: string | null) => void;
   /** Select a workflow run for the main pane (clears agent/draft/settings selection). */
   selectRun: (id: string) => void;
+  /** Select a run and focus one of its step agents' chats in the monitor. */
+  selectRunStep: (runId: string, agentId: string) => void;
+  /** Clear the pending step-agent focus once the monitor has applied it. */
+  clearFocusedStepAgent: () => void;
+  /** Seed the workflow builder from an ad-hoc session and open it. */
+  promoteAgentToWorkflow: (agentId: string) => Promise<void>;
+  /** Discard a consumed promote seed so it fires only once. */
+  clearPromoteSeed: () => void;
   spawn: (view: AgentView, repoPath: string) => Promise<AgentRecord | null>;
   /** Fork an existing workspace into a new one, seeding its worktree (`code`)
    *  and conversation (`context`) independently. Refreshes the workspace and

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -52,6 +52,8 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
   workspace: null,
   selectedAgentId: null,
   selectedRunId: null,
+  focusedStepAgentId: null,
+  promoteSeed: null,
   managedLogs: {},
   pendingToolUse: {},
   transcriptLoading: {},
@@ -97,6 +99,58 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
       selectedHistoryAgentId: null,
       settingsScreenOpen: false,
     }),
+
+  // Select a run and focus one of its step agents' chats in the monitor. The
+  // RunView reads `focusedStepAgentId` and drives its attempt selection to the
+  // attempt owned by that agent, then clears it — so the sidebar step child and
+  // the monitor's attempt rail stay one selection.
+  selectRunStep: (runId, agentId) =>
+    set({
+      selectedRunId: runId,
+      focusedStepAgentId: agentId,
+      selectedAgentId: null,
+      activeDraftId: null,
+      historyOpen: false,
+      selectedHistoryAgentId: null,
+      settingsScreenOpen: false,
+    }),
+  clearFocusedStepAgent: () => set({ focusedStepAgentId: null }),
+
+  // Promote an ad-hoc session into a workflow: seed the builder with the
+  // session's agent (as an alias), its brief (as the run task), and its current
+  // HEAD commit (as the run's fork point), then open the builder. Launching from
+  // there forks the run at exactly the promoted session's working commit.
+  promoteAgentToWorkflow: async (agentId) => {
+    const agent = get().workspace?.agents.find((a) => a.id === agentId);
+    if (!agent) return;
+    const customAgents = get().customAgents;
+    const hasCustom =
+      agent.custom_agent_id && customAgents.some((c) => c.id === agent.custom_agent_id);
+    const agentPick = hasCustom ? (agent.custom_agent_id as string) : agent.provider;
+    const repoPath = agent.repos[0]?.repo_path ?? "";
+    let baseSha = "";
+    try {
+      baseSha = await api.agentHeadSha(agentId);
+    } catch (e) {
+      // A never-committed checkout still promotes — the launch resolves HEAD in
+      // the source repo instead (base_sha left empty).
+      console.error("agentHeadSha failed", e);
+    }
+    set({
+      promoteSeed: {
+        agentId,
+        agentName: agent.name,
+        agentPick,
+        task: agent.task ?? "",
+        baseSha,
+        baseLabel: baseSha ? baseSha.slice(0, 8) : (agent.repos[0]?.branch ?? "HEAD"),
+        repoPath,
+        projectId: agent.project_id,
+      },
+    });
+    get().openSettingsScreen("workflows");
+  },
+  clearPromoteSeed: () => set({ promoteSeed: null }),
 
   spawn: async (view, repoPath) => {
     set({ busy: true, lastError: null });

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -132,9 +132,14 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
     try {
       baseSha = await api.agentHeadSha(agentId);
     } catch (e) {
-      // A never-committed checkout still promotes — the launch resolves HEAD in
-      // the source repo instead (base_sha left empty).
-      console.error("agentHeadSha failed", e);
+      // The whole point of promoting is forking at the session's working
+      // commit; a checkout whose HEAD can't be resolved must not silently
+      // launch from the source repo's HEAD instead. Surface and abort.
+      get().setLastError(
+        `Promote failed: couldn't resolve the session's HEAD commit (${e}). ` +
+          "The checkout may be broken — you can still create a workflow manually.",
+      );
+      return;
     }
     set({
       promoteSeed: {

--- a/src/workflows/builder/WorkflowBuilder.tsx
+++ b/src/workflows/builder/WorkflowBuilder.tsx
@@ -8,7 +8,7 @@ import { Icon } from "../../components/Icon";
 import type { ModelMeta } from "../../data/modelCatalog/types";
 import type { CustomAgent } from "../../storage/customAgents";
 import { resolveAlias } from "../shared";
-import type { Budgets, Gate } from "../spec";
+import type { Budgets, Gate, Spec } from "../spec";
 import { BlockSequence } from "./blocks/BlockSequence";
 import type { BuilderCtx, Pop, PopRect } from "./ctx";
 import {
@@ -24,8 +24,21 @@ import {
 } from "./edits";
 import { useDismissOnViewportChange } from "./hooks";
 import type { EditorState, NodeId } from "./model";
-import { validateEditor } from "./model";
+import { toSpec, validateEditor } from "./model";
 import { AgentPick, BudgetsPopover, GatePick } from "./pickers";
+
+/** Launch context threaded in when the builder was opened by "promote to
+ *  workflow": the run's fork point + brief ride alongside the definition so the
+ *  user can launch straight from the builder, no re-typing. */
+export interface PromoteLaunch {
+  /** Prefilled run task (the promoted session's brief). */
+  taskSeed: string;
+  /** Human label for the fork point (short SHA or branch). */
+  baseLabel: string;
+  launching: boolean;
+  launchError: string | null;
+  onLaunch: (spec: Spec, task: string) => void;
+}
 
 function rectFrom(e: React.MouseEvent): PopRect {
   const r = e.currentTarget.getBoundingClientRect();
@@ -41,6 +54,7 @@ export function WorkflowBuilder({
   saveError,
   onCancel,
   onSave,
+  promote,
 }: {
   initial: EditorState;
   isNew: boolean;
@@ -50,8 +64,10 @@ export function WorkflowBuilder({
   saveError: string | null;
   onCancel: () => void;
   onSave: (state: EditorState) => void;
+  promote?: PromoteLaunch;
 }) {
   const [state, setState] = useState<EditorState>(initial);
+  const [launchTask, setLaunchTask] = useState(promote?.taskSeed ?? "");
   const [pop, setPop] = useState<Pop | null>(null);
   const closePop = () => setPop(null);
   useDismissOnViewportChange(!!pop, closePop);
@@ -184,6 +200,50 @@ export function WorkflowBuilder({
             />
           )}
         </div>
+
+        {promote && (
+          <div className="wb-promote">
+            <div className="wb-promote-head">
+              <Icon name="combine" size={13} style={{ color: "var(--accent)" }} />
+              <span>Launch this workflow now</span>
+              <span
+                className="wb-promote-base tip"
+                data-tip="Forks from the promoted session's commit"
+              >
+                base <span className="mono">{promote.baseLabel}</span>
+              </span>
+            </div>
+            <textarea
+              className="wb-desc"
+              rows={2}
+              placeholder="Task for the run…"
+              value={launchTask}
+              onChange={(e) => setLaunchTask(e.target.value)}
+            />
+            {promote.launchError && <div className="wb-summary-err">{promote.launchError}</div>}
+            <div className="wb-promote-foot">
+              <span className="wb-promote-note">Or just save it as a reusable workflow below.</span>
+              <span className="grow" />
+              <button
+                className="btn-t primary"
+                disabled={!validation.ok || !launchTask.trim() || promote.launching}
+                style={
+                  !validation.ok || !launchTask.trim() || promote.launching
+                    ? { opacity: 0.5 }
+                    : undefined
+                }
+                onClick={() =>
+                  validation.ok &&
+                  launchTask.trim() &&
+                  promote.onLaunch(toSpec(state), launchTask.trim())
+                }
+              >
+                <Icon name={promote.launching ? "refresh" : "arrowUp"} size={13} />{" "}
+                {promote.launching ? "Launching…" : "Launch run"}
+              </button>
+            </div>
+          </div>
+        )}
 
         <div className="wb-foot">
           <div className="wb-summary">

--- a/src/workflows/builder/index.tsx
+++ b/src/workflows/builder/index.tsx
@@ -6,9 +6,11 @@ import { useEffect, useState } from "react";
 import { api } from "../../api";
 import { installStarterPack, STARTER_WORKFLOW_NAME } from "../../starterPack";
 import { useAppStore } from "../../store";
+import type { PromoteSeed } from "../../store/types";
 import type { Definition, ImportReport, Spec } from "../spec";
 import { ImportDialog } from "./ImportDialog";
 import { blankEditor, type EditorState, fromDefinition, toSpec } from "./model";
+import { seedEditorFromPromotion } from "./promote";
 import { WorkflowBuilder } from "./WorkflowBuilder";
 import { WorkflowList } from "./WorkflowList";
 import { exportDefinitionYaml, pickYamlText } from "./yamlFile";
@@ -20,11 +22,20 @@ export function WorkflowsPane() {
   const createCustomAgent = useAppStore((s) => s.createCustomAgent);
   const modelsByAgent = useAppStore((s) => s.modelsByAgent);
   const setLastError = useAppStore((s) => s.setLastError);
+  const promoteSeed = useAppStore((s) => s.promoteSeed);
+  const clearPromoteSeed = useAppStore((s) => s.clearPromoteSeed);
+  const closeSettingsScreen = useAppStore((s) => s.closeSettingsScreen);
+  const selectRun = useAppStore((s) => s.selectRun);
 
   const [definitions, setDefinitions] = useState<Definition[]>([]);
   const [loading, setLoading] = useState(true);
   const [installing, setInstalling] = useState(false);
   const [editing, setEditing] = useState<Editing | null>(null);
+  // The promote-to-workflow launch context, live while the builder was opened
+  // from a promoted session. Carries the fork point + brief the run launches at.
+  const [promoteCtx, setPromoteCtx] = useState<PromoteSeed | null>(null);
+  const [launching, setLaunching] = useState(false);
+  const [launchError, setLaunchError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [importReport, setImportReport] = useState<ImportReport | null>(null);
@@ -46,18 +57,66 @@ export function WorkflowsPane() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Consume a pending "promote to workflow" seed: open the builder pre-filled
+  // from the promoted session and hold its launch context. One-shot — the seed
+  // is cleared so a re-open of this pane starts on the list.
+  useEffect(() => {
+    if (!promoteSeed) return;
+    const state = seedEditorFromPromotion(
+      promoteSeed,
+      agents,
+      definitions.length,
+      promoteSeed.agentName,
+    );
+    setPromoteCtx(promoteSeed);
+    setLaunchError(null);
+    setSaveError(null);
+    setEditing({ state, isNew: true });
+    clearPromoteSeed();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [promoteSeed]);
+
   const save = async (state: EditorState) => {
     setSaving(true);
     setSaveError(null);
     try {
       await api.wfDefSave(toSpec(state), state.id ?? undefined, state.hue);
       setEditing(null);
+      setPromoteCtx(null);
       await reload();
     } catch (e) {
       // Surface backend validation (the joined §5.2 messages) inline in the builder.
       setSaveError(String(e));
     } finally {
       setSaving(false);
+    }
+  };
+
+  // Launch straight from the builder (promote flow): the run forks at the
+  // promoted session's HEAD (`baseSha`), so no branch is passed. Definition-less
+  // — the user can still Save the workflow separately if they want it reusable.
+  const launch = async (spec: Spec, task: string) => {
+    if (!promoteCtx) return;
+    setLaunching(true);
+    setLaunchError(null);
+    try {
+      const runId = await api.wfLaunch(
+        spec,
+        task,
+        promoteCtx.projectId,
+        promoteCtx.repoPath,
+        undefined,
+        undefined,
+        [],
+        promoteCtx.baseSha || undefined,
+      );
+      setEditing(null);
+      setPromoteCtx(null);
+      closeSettingsScreen();
+      selectRun(runId);
+    } catch (e) {
+      setLaunchError(String(e));
+      setLaunching(false);
     }
   };
 
@@ -85,6 +144,8 @@ export function WorkflowsPane() {
 
   const openEditor = (next: Editing) => {
     setSaveError(null);
+    setPromoteCtx(null);
+    setLaunchError(null);
     setEditing(next);
   };
 
@@ -154,8 +215,22 @@ export function WorkflowsPane() {
         modelsByAgent={modelsByAgent}
         saving={saving}
         saveError={saveError}
-        onCancel={() => setEditing(null)}
+        onCancel={() => {
+          setEditing(null);
+          setPromoteCtx(null);
+        }}
         onSave={save}
+        promote={
+          promoteCtx
+            ? {
+                taskSeed: promoteCtx.task,
+                baseLabel: promoteCtx.baseLabel,
+                launching,
+                launchError,
+                onLaunch: launch,
+              }
+            : undefined
+        }
       />
     );
   }

--- a/src/workflows/builder/promote.test.ts
+++ b/src/workflows/builder/promote.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { CustomAgent } from "../../storage/customAgents";
+import type { PromoteSeed } from "../../store/types";
+import { seedEditorFromPromotion } from "./promote";
+
+function seed(over: Partial<PromoteSeed> = {}): PromoteSeed {
+  return {
+    agentId: "ag-1",
+    agentName: "Fuji",
+    agentPick: "claude",
+    task: "Add retry/backoff to the sync worker",
+    baseSha: "deadbeefcafef00d",
+    baseLabel: "deadbeef",
+    repoPath: "/repo",
+    projectId: "p-1",
+    ...over,
+  };
+}
+
+describe("seedEditorFromPromotion", () => {
+  it("seeds a single step assigned to the session's provider, goaled with the brief", () => {
+    const ed = seedEditorFromPromotion(seed(), [], 0, "Fuji");
+    expect(ed.blocks).toHaveLength(1);
+    const step = ed.blocks[0];
+    expect(step.kind).toBe("step");
+    if (step.kind !== "step") throw new Error("expected step");
+    expect(step.goal).toBe("Add retry/backoff to the sync worker");
+    // The step's alias resolves to the picked base provider.
+    expect(ed.agents[step.agent as string]).toEqual({ base: "claude" });
+  });
+
+  it("names the workflow from the brief's first line", () => {
+    const ed = seedEditorFromPromotion(
+      seed({ task: "Fix the flaky login test\nmore detail" }),
+      [],
+      0,
+      "Fuji",
+    );
+    expect(ed.name).toBe("Fix the flaky login test");
+  });
+
+  it("resolves a custom-agent pick to a custom-agent alias spec", () => {
+    const custom: CustomAgent[] = [
+      { id: "ca-1", name: "Reviewer", base: "codex", color: 200 } as CustomAgent,
+    ];
+    const ed = seedEditorFromPromotion(seed({ agentPick: "ca-1" }), custom, 0, "Fuji");
+    const step = ed.blocks[0];
+    if (step.kind !== "step") throw new Error("expected step");
+    expect(ed.agents[step.agent as string]).toEqual({ base: "codex", custom_agent: "ca-1" });
+  });
+
+  it("keeps finalize off — promotion never lifts the run publish boundary", () => {
+    const ed = seedEditorFromPromotion(seed(), [], 0, "Fuji");
+    expect(ed.finalize).toEqual({ push: false, open_pr: false });
+  });
+
+  it("falls back to an agent-named title when the brief is empty", () => {
+    const ed = seedEditorFromPromotion(seed({ task: "" }), [], 0, "Fuji");
+    expect(ed.name).toBe("Promoted from Fuji");
+  });
+});

--- a/src/workflows/builder/promote.ts
+++ b/src/workflows/builder/promote.ts
@@ -1,0 +1,42 @@
+// builder/promote.ts — seed the workflow builder from a promoted ad-hoc session
+// (spec §14.1 / PR "close the cockpit ↔ workflow loop"). Pure: maps a
+// `PromoteSeed` to a fresh `EditorState` whose single step runs the session's
+// agent on the session's brief. The run's fork point (the session's HEAD) rides
+// alongside as a launch parameter — not part of the definition — so the promoted
+// workflow stays reusable while this one launch forks where the session left off.
+
+import type { CustomAgent } from "../../storage/customAgents";
+import type { PromoteSeed } from "../../store/types";
+import { blankEditor, type EditorState, ensureAlias } from "./model";
+
+/** First non-empty line of the brief, trimmed to a workflow-name length. */
+function nameFromBrief(brief: string): string {
+  const line = brief.split("\n").find((l) => l.trim()) ?? "";
+  const head = line.trim();
+  return head.length > 60 ? `${head.slice(0, 59)}…` : head;
+}
+
+/** Build editor state for a promoted session: one step, assigned to the
+ *  session's agent (a reused/synthesized alias), goaled with the brief. The
+ *  workflow is named from the brief so it's launchable without re-typing, and
+ *  finalize stays off — promotion never lifts the run's publish boundary. */
+export function seedEditorFromPromotion(
+  seed: PromoteSeed,
+  customAgents: CustomAgent[],
+  seedIndex: number,
+  agentName: string,
+): EditorState {
+  const base = blankEditor(seedIndex);
+  const { agents, alias } = ensureAlias(base.agents, seed.agentPick, customAgents);
+  const name = nameFromBrief(seed.task) || `Promoted from ${agentName}`;
+  const description = `Promoted from the “${agentName}” session`;
+  const step = base.blocks[0];
+  if (step.kind !== "step") return { ...base, name, description, agents };
+  return {
+    ...base,
+    name,
+    description,
+    agents,
+    blocks: [{ ...step, agent: alias, goal: seed.task }],
+  };
+}

--- a/src/workflows/run/RunRow.tsx
+++ b/src/workflows/run/RunRow.tsx
@@ -6,6 +6,8 @@
 import { type KeyboardEvent, type MouseEvent, useState } from "react";
 import { api, type WfRun } from "../../api";
 import { Icon } from "../../components/Icon";
+import { StepAgentRow } from "../../components/Sidebar/StepAgentRow";
+import { deriveStepChildren } from "../../components/Sidebar/stepChildren";
 import { useAppStore } from "../../store";
 import { formatAge } from "../../util/format";
 import { useMinuteClock } from "../../util/hooks";
@@ -14,6 +16,15 @@ import { resolveAlias } from "../shared";
 import type { Spec } from "../spec";
 import { flattenSteps } from "./RunView/flatten";
 import { pausedLabel } from "./status";
+import { useRunAgents } from "./useRunAgents";
+
+/** Step-agent children are only meaningful — and only fetched — while a run is
+ *  live or waiting: a finished run's step agents are archived, and a pending run
+ *  hasn't spawned any yet. Both auto-expand (an active run wants its steps in
+ *  view; a paused run needs attention). */
+function hasStepChildren(status: WfRun["status"]): boolean {
+  return status === "running" || status === "paused";
+}
 
 export function RunRow({
   run,
@@ -39,6 +50,14 @@ export function RunRow({
   // clicks: the first arms the button and the tooltip states what is lost.
   const deletable = run.status === "done" || run.status === "failed" || run.status === "canceled";
   const [confirmDelete, setConfirmDelete] = useState(false);
+
+  // Expandable step-agent children. Default expanded for live/waiting runs;
+  // `userExpanded` (null until the user toggles) overrides that default. Agents
+  // are fetched only while expanded, so collapsed runs cost nothing.
+  const canExpand = hasStepChildren(run.status);
+  const [userExpanded, setUserExpanded] = useState<boolean | null>(null);
+  const expanded = canExpand && (userExpanded ?? true);
+  const stepChildren = deriveStepChildren(useRunAgents(run.id, expanded));
   // Same left-spine vocabulary as an agent row: live → accent, failed → danger,
   // everything else (pending/paused/done/canceled) → the faint idle grey.
   const railClass = working ? "run" : run.status === "failed" ? "err" : "idle";
@@ -75,80 +94,105 @@ export function RunRow({
     }
   };
 
+  const onToggleExpand = (e: MouseEvent) => {
+    e.stopPropagation();
+    setUserExpanded(!expanded);
+  };
+
   return (
-    <div
-      className={`agent ${selected ? "active" : ""} ${nested ? "run-nested" : ""}`}
-      role="button"
-      tabIndex={0}
-      aria-current={selected ? "page" : undefined}
-      onClick={onSelect}
-      onKeyDown={(e: KeyboardEvent) => {
-        // Ignore keys bubbling from the nested stop button.
-        if (e.target !== e.currentTarget) return;
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          onSelect();
-        }
-      }}
-      onMouseLeave={() => setConfirmDelete(false)}
-    >
-      <span className={`ag-rail ${railClass}`} />
-      <div className="agent-row">
-        <span className="ag-wf-prefix tip" data-tip="Workflow" data-tip-down="">
-          <Icon name="combine" size={12} />
-        </span>
-        <span className={`ag-name ${working ? "shimmer" : ""}`}>{run.name}</span>
-        {a && (
-          <span className="ag-prov-chip">
-            <AgentAvatar
-              custom={a.custom}
-              slug={a.providerId}
-              short={a.short}
-              hue={a.hue}
-              size={14}
-            />
+    <>
+      <div
+        className={`agent ${selected ? "active" : ""} ${nested ? "run-nested" : ""}`}
+        role="button"
+        tabIndex={0}
+        aria-current={selected ? "page" : undefined}
+        onClick={onSelect}
+        onKeyDown={(e: KeyboardEvent) => {
+          // Ignore keys bubbling from the nested stop button.
+          if (e.target !== e.currentTarget) return;
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onSelect();
+          }
+        }}
+        onMouseLeave={() => setConfirmDelete(false)}
+      >
+        <span className={`ag-rail ${railClass}`} />
+        <div className="agent-row">
+          {canExpand ? (
+            <button
+              className={`ag-wf-expander ${expanded ? "open" : ""}`}
+              onClick={onToggleExpand}
+              aria-label={expanded ? "Collapse steps" : "Expand steps"}
+              aria-expanded={expanded}
+            >
+              <Icon name="chevR" size={10} />
+            </button>
+          ) : (
+            <span className="ag-wf-prefix tip" data-tip="Workflow" data-tip-down="">
+              <Icon name="combine" size={12} />
+            </span>
+          )}
+          <span className={`ag-name ${working ? "shimmer" : ""}`}>{run.name}</span>
+          {a && (
+            <span className="ag-prov-chip">
+              <AgentAvatar
+                custom={a.custom}
+                slug={a.providerId}
+                short={a.short}
+                hue={a.hue}
+                size={14}
+              />
+            </span>
+          )}
+          <span className="ag-slot">
+            <span className="ag-meta">
+              {working && <span className="ag-loader" aria-label="Working" />}
+              {run.status === "paused" && run.paused_reason && (
+                <span className="ag-badge warn">{pausedLabel(run.paused_reason)}</span>
+              )}
+              {run.status === "failed" && <span className="ag-badge err">failed</span>}
+            </span>
+            <span className="ag-actions">
+              {stoppable && (
+                <button
+                  className="ag-act tip"
+                  data-tip="Stop"
+                  onClick={(e) => void onStop(e)}
+                  aria-label="Stop"
+                >
+                  <Icon name="stop" size={11} />
+                </button>
+              )}
+              {deletable && (
+                <button
+                  className={`ag-act tip ${confirmDelete ? "confirm-del" : ""}`}
+                  data-tip={
+                    confirmDelete
+                      ? "Deletes this run's chats too — click again to confirm"
+                      : "Delete run"
+                  }
+                  onClick={(e) => void onDelete(e)}
+                  aria-label="Delete run"
+                >
+                  <Icon name="trash" size={11} />
+                </button>
+              )}
+            </span>
           </span>
-        )}
-        <span className="ag-slot">
-          <span className="ag-meta">
-            {working && <span className="ag-loader" aria-label="Working" />}
-            {run.status === "paused" && run.paused_reason && (
-              <span className="ag-badge warn">{pausedLabel(run.paused_reason)}</span>
-            )}
-            {run.status === "failed" && <span className="ag-badge err">failed</span>}
-          </span>
-          <span className="ag-actions">
-            {stoppable && (
-              <button
-                className="ag-act tip"
-                data-tip="Stop"
-                onClick={(e) => void onStop(e)}
-                aria-label="Stop"
-              >
-                <Icon name="stop" size={11} />
-              </button>
-            )}
-            {deletable && (
-              <button
-                className={`ag-act tip ${confirmDelete ? "confirm-del" : ""}`}
-                data-tip={
-                  confirmDelete
-                    ? "Deletes this run's chats too — click again to confirm"
-                    : "Delete run"
-                }
-                onClick={(e) => void onDelete(e)}
-                aria-label="Delete run"
-              >
-                <Icon name="trash" size={11} />
-              </button>
-            )}
-          </span>
-        </span>
+        </div>
+        <div className="agent-sub">
+          <span className="a-task">{run.task || "workflow run"}</span>
+          <span className="a-time">{age}</span>
+        </div>
       </div>
-      <div className="agent-sub">
-        <span className="a-task">{run.task || "workflow run"}</span>
-        <span className="a-time">{age}</span>
-      </div>
-    </div>
+      {expanded && stepChildren.length > 0 && (
+        <div className="run-steps">
+          {stepChildren.map((child) => (
+            <StepAgentRow key={child.agent.id} runId={run.id} child={child} />
+          ))}
+        </div>
+      )}
+    </>
   );
 }

--- a/src/workflows/run/RunView/index.tsx
+++ b/src/workflows/run/RunView/index.tsx
@@ -95,17 +95,22 @@ export function RunView({ id }: { id: string }) {
   // A sidebar step child was clicked: focus that step's chat by driving the
   // attempt selection to the (latest) attempt owned by the requested agent,
   // then clear the one-shot request so a later manual pick isn't overridden.
+  // While the run detail is still loading, hold the request (the effect
+  // re-fires when attempts land); once loaded, apply it or drop it — an
+  // unmatched request must not stay armed to hijack a selection later.
   useEffect(() => {
     if (!focusedStepAgentId) return;
+    if (loading && attempts.length === 0) return;
     const owned = attempts.filter((a) => a.agent_id === focusedStepAgentId);
-    if (owned.length === 0) return;
-    const latest = owned.reduce((best, cur) => {
-      if (cur.iteration !== best.iteration) return cur.iteration > best.iteration ? cur : best;
-      return cur.attempt > best.attempt ? cur : best;
-    });
-    setPickedAttemptId(latest.id);
+    if (owned.length > 0) {
+      const latest = owned.reduce((best, cur) => {
+        if (cur.iteration !== best.iteration) return cur.iteration > best.iteration ? cur : best;
+        return cur.attempt > best.attempt ? cur : best;
+      });
+      setPickedAttemptId(latest.id);
+    }
     clearFocusedStepAgent();
-  }, [focusedStepAgentId, attempts, clearFocusedStepAgent]);
+  }, [focusedStepAgentId, attempts, loading, clearFocusedStepAgent]);
 
   const pausedDetail = useMemo(() => {
     const p = pausedEvent?.payload;

--- a/src/workflows/run/RunView/index.tsx
+++ b/src/workflows/run/RunView/index.tsx
@@ -31,6 +31,8 @@ export function RunView({ id }: { id: string }) {
   const toggleLeft = useAppStore((s) => s.toggleLeft);
   const leftCollapsed = useAppStore((s) => s.leftCollapsed);
   const selectRun = useAppStore((s) => s.selectRun);
+  const focusedStepAgentId = useAppStore((s) => s.focusedStepAgentId);
+  const clearFocusedStepAgent = useAppStore((s) => s.clearFocusedStepAgent);
 
   // Composed sub-runs (§10.3) nest under this run in the monitor; each links to
   // its own RunView. Sourced from the live run list, filtered to our children.
@@ -89,6 +91,21 @@ export function RunView({ id }: { id: string }) {
       setPickedAttemptId(null);
     }
   }, [attempts, pickedAttemptId]);
+
+  // A sidebar step child was clicked: focus that step's chat by driving the
+  // attempt selection to the (latest) attempt owned by the requested agent,
+  // then clear the one-shot request so a later manual pick isn't overridden.
+  useEffect(() => {
+    if (!focusedStepAgentId) return;
+    const owned = attempts.filter((a) => a.agent_id === focusedStepAgentId);
+    if (owned.length === 0) return;
+    const latest = owned.reduce((best, cur) => {
+      if (cur.iteration !== best.iteration) return cur.iteration > best.iteration ? cur : best;
+      return cur.attempt > best.attempt ? cur : best;
+    });
+    setPickedAttemptId(latest.id);
+    clearFocusedStepAgent();
+  }, [focusedStepAgentId, attempts, clearFocusedStepAgent]);
 
   const pausedDetail = useMemo(() => {
     const p = pausedEvent?.payload;

--- a/src/workflows/run/WorkflowComposer.tsx
+++ b/src/workflows/run/WorkflowComposer.tsx
@@ -21,6 +21,7 @@ import { useAppStore } from "../../store";
 import { AgentAvatar } from "../builder/AgentAvatar";
 import { resolveAlias } from "../shared";
 import type { Definition, Spec } from "../spec";
+import { rememberDefaultWorkflow } from "./projectPipeline";
 import { flattenSteps } from "./RunView/flatten";
 import { useDefinitions } from "./useDefinitions";
 
@@ -31,6 +32,11 @@ export interface ComposerContext {
   repoPath: string;
   baseBranch: string;
   name: string;
+  /** Project id for per-project prefs (remembering the picked default flow). */
+  projectId?: string;
+  /** The project's remembered default workflow — preselected when the user
+   *  hasn't picked another this session. */
+  defaultWorkflowId?: string | null;
 }
 
 /** Heading slot for the workflow mode — replaces the agent's title/subtitle on
@@ -46,18 +52,31 @@ export function WorkflowHeading() {
   );
 }
 
-export function WorkflowComposer({ repoPath, baseBranch }: ComposerContext) {
+export function WorkflowComposer({
+  repoPath,
+  baseBranch,
+  projectId,
+  defaultWorkflowId,
+}: ComposerContext) {
   const selectRun = useAppStore((s) => s.selectRun);
   const setLastError = useAppStore((s) => s.setLastError);
+  const openSettingsScreen = useAppStore((s) => s.openSettingsScreen);
   const customAgents = useAppStore((s) => s.customAgents);
   const modelsByAgent = useAppStore((s) => s.modelsByAgent);
 
   const { definitions, loading } = useDefinitions();
+  // "" until the user picks this session — then the project's remembered default
+  // (which may load async) leads, falling back to the first definition.
   const [defId, setDefId] = useState("");
   const [busy, setBusy] = useState(false);
 
-  // Default to the first definition once they load.
-  const def = definitions.find((d) => d.id === defId) ?? definitions[0];
+  const preferredId = defId || defaultWorkflowId || "";
+  const def = definitions.find((d) => d.id === preferredId) ?? definitions[0];
+
+  const pickDef = (id: string) => {
+    setDefId(id);
+    if (projectId) rememberDefaultWorkflow(projectId, id);
+  };
   const steps = flattenSteps(def?.spec ?? null);
 
   const resolve = (alias: string) =>
@@ -118,7 +137,16 @@ export function WorkflowComposer({ repoPath, baseBranch }: ComposerContext) {
   if (definitions.length === 0) {
     return (
       <div className="wf-field-empty" style={{ textAlign: "center" }}>
-        No workflows yet — create one in <b>Settings → Workflows</b>.
+        <p style={{ margin: "0 0 10px" }}>
+          No pipelines yet — build one to chain agents on a task.
+        </p>
+        <button
+          type="button"
+          className="btn-t primary"
+          onClick={() => openSettingsScreen("workflows")}
+        >
+          <Icon name="combine" size={13} /> Create a workflow
+        </button>
       </div>
     );
   }
@@ -160,7 +188,7 @@ export function WorkflowComposer({ repoPath, baseBranch }: ComposerContext) {
       }
       foot={
         <>
-          <WorkflowSelect definitions={definitions} selected={def} onPick={setDefId} />
+          <WorkflowSelect definitions={definitions} selected={def} onPick={pickDef} />
           <span style={{ flex: 1 }} />
           <button
             type="button"

--- a/src/workflows/run/projectPipeline.ts
+++ b/src/workflows/run/projectPipeline.ts
@@ -1,0 +1,46 @@
+// run/projectPipeline.ts — per-project composer preferences, persisted in the
+// `project_settings` table (same store as run-config overrides). Two keys:
+//   composer.mode     — "agent" | "workflow": the kickoff mode the composer
+//                        opens in for this project (a remembered suggestion,
+//                        never a gate).
+//   workflow.default  — the definition id the Pipeline side preselects.
+// Failures are logged, not thrown: a missing/unreadable setting degrades to the
+// built-in default (quick agent, first workflow).
+
+import { getProjectSettings, setProjectSetting } from "@/storage/projectSettings";
+
+export type ComposerMode = "agent" | "workflow";
+
+const MODE_KEY = "composer.mode";
+const DEFAULT_WORKFLOW_KEY = "workflow.default";
+
+export interface PipelinePrefs {
+  mode: ComposerMode;
+  defaultWorkflowId: string | null;
+}
+
+export async function loadPipelinePrefs(projectId: string): Promise<PipelinePrefs> {
+  if (!projectId) return { mode: "agent", defaultWorkflowId: null };
+  try {
+    const all = await getProjectSettings(projectId);
+    const mode = all[MODE_KEY] === "workflow" ? "workflow" : "agent";
+    return { mode, defaultWorkflowId: all[DEFAULT_WORKFLOW_KEY] || null };
+  } catch (e) {
+    console.error("loadPipelinePrefs failed", e);
+    return { mode: "agent", defaultWorkflowId: null };
+  }
+}
+
+export function rememberComposerMode(projectId: string, mode: ComposerMode): void {
+  if (!projectId) return;
+  setProjectSetting(projectId, MODE_KEY, mode).catch((e) =>
+    console.error("rememberComposerMode failed", e),
+  );
+}
+
+export function rememberDefaultWorkflow(projectId: string, definitionId: string): void {
+  if (!projectId || !definitionId) return;
+  setProjectSetting(projectId, DEFAULT_WORKFLOW_KEY, definitionId).catch((e) =>
+    console.error("rememberDefaultWorkflow failed", e),
+  );
+}

--- a/src/workflows/run/useRunAgents.ts
+++ b/src/workflows/run/useRunAgents.ts
@@ -1,0 +1,54 @@
+// run/useRunAgents.ts — a run's step agents for the sidebar expander. Lighter
+// than useRunDetail (no journal, no messages): it fetches `wf_run_agents` only
+// while `enabled` (the RunRow is expanded) and keeps the list live over the
+// same `wf:run` / `wf:event` streams the monitor uses, so a step agent's status
+// rail tracks reality without polling every collapsed run.
+
+import { useEffect, useRef, useState } from "react";
+import { type AgentRecord, api, onWfEvent, onWfRun } from "../../api";
+
+export function useRunAgents(runId: string, enabled: boolean): AgentRecord[] {
+  const [agents, setAgents] = useState<AgentRecord[]>([]);
+  const pending = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      setAgents([]);
+      return;
+    }
+    let cancelled = false;
+
+    const refresh = async () => {
+      try {
+        const next = await api.wfRunAgents(runId);
+        if (!cancelled) setAgents(next);
+      } catch {
+        /* transient — the next event or a re-expand retries */
+      }
+    };
+    const schedule = () => {
+      if (pending.current) return;
+      pending.current = setTimeout(() => {
+        pending.current = null;
+        void refresh();
+      }, 150);
+    };
+
+    void refresh();
+    const offEvent = onWfEvent((e) => {
+      if (e.run_id === runId) schedule();
+    });
+    const offRun = onWfRun((row) => {
+      if (row.id === runId) schedule();
+    });
+
+    return () => {
+      cancelled = true;
+      if (pending.current) clearTimeout(pending.current);
+      void offEvent.then((f) => f());
+      void offRun.then((f) => f());
+    };
+  }, [runId, enabled]);
+
+  return agents;
+}

--- a/src/workflows/run/useRunAgents.ts
+++ b/src/workflows/run/useRunAgents.ts
@@ -44,7 +44,12 @@ export function useRunAgents(runId: string, enabled: boolean): AgentRecord[] {
 
     return () => {
       cancelled = true;
-      if (pending.current) clearTimeout(pending.current);
+      if (pending.current) {
+        clearTimeout(pending.current);
+        // Disarm, not just cancel — a truthy ref would make the next mount's
+        // schedule() no-op forever, freezing rows on their initial fetch.
+        pending.current = null;
+      }
       void offEvent.then((f) => f());
       void offRun.then((f) => f());
     };

--- a/src/workflows/workflows.css
+++ b/src/workflows/workflows.css
@@ -599,6 +599,48 @@
   padding-left: 6px;
 }
 
+/* Expand/collapse toggle that replaces the workflow glyph on a run with live
+   step agents — same footprint as the glyph; the chevron rotates when open. */
+.ag-wf-expander {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  padding: 0;
+  color: var(--accent);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.ag-wf-expander svg {
+  transition: transform 0.15s var(--ease);
+}
+.ag-wf-expander.open svg {
+  transform: rotate(90deg);
+}
+.ag-wf-expander:hover {
+  color: var(--fg-0);
+}
+
+/* A run's step agents nest under it — indented past the run's rail with a faint
+   guide rail, quieter than a top-level agent so the run stays the anchor. */
+.run-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  margin: 1px 0 3px 14px;
+  padding-left: 6px;
+  border-left: 1px solid var(--bd-soft);
+}
+.agent.run-step {
+  padding-top: 5px;
+  padding-bottom: 5px;
+}
+.agent.run-step .ag-name {
+  font-weight: 500;
+  color: var(--fg-1);
+}
+
 /* Run monitor: the sub-runs section above the timeline (§10.3, §14.2). */
 .wf-subruns {
   display: flex;
@@ -1367,6 +1409,43 @@
   align-items: center;
   gap: 4px;
   color: var(--danger);
+}
+
+/* Promote-to-workflow launch card: sits above the save footer, accent-tinted so
+   the "launch now" path reads as the primary intent of a promoted session. */
+.wb-promote {
+  margin-top: 16px;
+  padding: 12px 14px;
+  border: 1px solid color-mix(in oklch, var(--accent) 40%, var(--bd-soft));
+  border-radius: var(--r-md);
+  background: color-mix(in oklch, var(--accent) 6%, var(--bg-1));
+}
+.wb-promote-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  color: var(--fg-0);
+  margin-bottom: 8px;
+}
+.wb-promote-base {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--fg-2);
+}
+.wb-promote-foot {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 8px;
+}
+.wb-promote-foot .grow {
+  flex: 1;
+}
+.wb-promote-note {
+  font-size: 12px;
+  color: var(--fg-3);
 }
 
 /* ── YAML import/export (spec §14.3) ────────────────────────────────────── */


### PR DESCRIPTION
## What

Closes the cockpit ↔ workflow loop from the coherency roadmap: workflow step agents become visible and intervenable from the sidebar, a promising ad-hoc session can be promoted into a structured workflow, and each project can remember a preferred way of starting work.

### Step agents under the RunRow

- A `running`/`paused` run's row grows an expander (default expanded — that's when steps are inspectable); step agents render as subordinate children with the same status vocabulary as `AgentRow`, reusing the shared `AgentIdentityChip`.
- Clicking a step child selects that step's chat in RunView: the sidebar sets a one-shot `focusedStepAgentId`, RunView maps it to the latest attempt owned by that agent and drives the existing interactive ChatView selection.
- Data comes lazily through the existing `wf_run_agents` IPC (`useRunAgents`, fetched only while expanded, live over `wf:run`/`wf:event`). Step agents stay OUT of the flat all-agents list (`owner_run_id` filter untouched), and their capability restrictions / the run `finalize` publish boundary are unchanged.

### Promote ad-hoc → workflow

- "Promote to workflow" action on the agent row opens the builder pre-seeded: the session's provider/custom-agent as an alias (`ensureAlias`), the brief as task text, and run base = the agent's current HEAD.
- New `agent_head_sha(agent_id, subdir?)` command resolves the fork point; `wf_launch` gained an optional `base_sha` — when set it's the fork ref, and `base_branch` stays empty so finalize falls back to `pr_base`/`main` rather than treating a raw SHA as a PR base. Backward-compatible (`Option`, absent = today's behavior).
- Pre-seed mapping is a pure, unit-tested function (`builder/promote.ts`).

### Per-project pipeline default

- "Quick agent | Pipeline" toggle in the new-task composer, remembered per project via `project_settings` (`composer.mode`, `workflow.default`). The composer preselects the project's remembered workflow; with no workflows defined, the Pipeline side leads to the builder — never an error. The quick path is never gated.

## Testing

- Rust: `cargo fmt --check` clean; clippy with CI flags clean; `cargo test` → 955 passed, 0 failed.
- Frontend: typecheck clean; `vitest run` → 473 passed, 0 failed (9 new: `deriveStepChildren`, `seedEditorFromPromotion`); build succeeds; biome clean on touched files.

## Notes

- Rebased onto post-#467 main: adopted main's shared `AgentIdentityChip` (adapted `StepAgentRow` to its `{agent}` API) and re-applied the promote action on top of main's `AgentRow`.
- "Default workflow" is implemented as remember-the-last-picked per project (simplest-first) rather than a new settings-form control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)