### PR TITLE
feat(github): issue intake — inbox on Home, start-work prefill, Closes #N

### DIFF
--- a/src-tauri/migrations/0023_workspace_issue_ref.sql
+++ b/src-tauri/migrations/0023_workspace_issue_ref.sql
@@ -1,0 +1,8 @@
+-- The GitHub issue a workspace was started from, captured when the user hits
+-- "Start work" on a Home-inbox issue. Stored as the bare issue number (text)
+-- for the workspace's primary repo — enough to append a `Closes #<n>` trailer
+-- to the PR the agent opens, so merging that PR closes the originating issue.
+--
+-- NULL for a normal spawn that didn't originate from an issue. Only the
+-- primary repo's PR carries the trailer (the issue lives in that repo).
+ALTER TABLE workspaces ADD COLUMN issue_ref TEXT;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -375,6 +375,7 @@ pub async fn spawn_agent(
     skills: Option<Vec<crate::agent_profile::SkillSnapshot>>,
     mcp_servers: Option<Vec<crate::agent_profile::McpServerSnapshot>>,
     fork_base: Option<String>,
+    issue_ref: Option<String>,
 ) -> Result<AgentRecord> {
     let sup = supervisor.inner().clone();
     sup.spawn_agent(
@@ -399,6 +400,8 @@ pub async fn spawn_agent(
             owner_run_id: None,
             // Carrying another workspace's working tree is a fork-only path.
             carry_from: None,
+            // Set when the spawn originates from a Home-inbox issue.
+            issue_ref,
         },
     )
     .await
@@ -793,6 +796,16 @@ pub async fn list_prs(
 #[tauri::command]
 pub async fn list_repo_prs(repo_path: String) -> Result<Vec<gh::PrSummary>> {
     gh::pr_list(&expand_tilde(&repo_path), 50).await
+}
+
+/// List open GitHub issues for a repo by path, for the Home inbox. Like
+/// `list_repo_prs`, this needs no agent — Home works over the workspace's
+/// tracked repo paths. `Ok(None)` (not an error) when the repo has no token /
+/// non-GitHub origin / a rate-limit pause is active, so the inbox degrades
+/// quietly. Capped at 30 — the inbox shows a handful, newest-updated first.
+#[tauri::command]
+pub async fn list_repo_issues(repo_path: String) -> Result<Option<Vec<gh::IssueSummary>>> {
+    gh::issue_list(&expand_tilde(&repo_path), 30).await
 }
 
 /// Fetch the PR merge gate + per-check detail (spec §6). Best-effort: any

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -150,6 +150,7 @@ const MIGRATIONS: &[&str] = &[
     include_str!("../migrations/0020_workflow_base_branch.sql"),
     include_str!("../migrations/0021_session_forked_context.sql"),
     include_str!("../migrations/0022_repo_label.sql"),
+    include_str!("../migrations/0023_workspace_issue_ref.sql"),
 ];
 
 fn get_migrations() -> Migrations<'static> {

--- a/src-tauri/src/github/client.rs
+++ b/src-tauri/src/github/client.rs
@@ -229,6 +229,23 @@ impl Client {
         Ok((status, body))
     }
 
+    /// REST GET for a read/poll path: like [`rest`](Self::rest) but it also
+    /// feeds the response into the rate-limit gate (as the GraphQL path does),
+    /// so a `403`/`429` or an exhausted budget pauses subsequent polling instead
+    /// of hammering. Endpoints still map statuses themselves.
+    pub async fn rest_get_observed(&self, path: &str) -> Result<(reqwest::StatusCode, Value)> {
+        let resp = self
+            .request(reqwest::Method::GET, format!("{API_BASE}{path}"))
+            .send()
+            .await
+            .map_err(request_error)?;
+        let status = resp.status();
+        let headers = resp.headers().clone();
+        let body = resp.json::<Value>().await.unwrap_or(Value::Null);
+        observe_rate_limit(status, &headers, &body);
+        Ok((status, body))
+    }
+
     /// GraphQL call returning the `data` object. GraphQL reports failures as
     /// 200 + `errors[]`, so those are surfaced as `Error::Gh` with the
     /// server's messages — callers match on the text for expected cases

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -83,6 +83,35 @@ pub struct PrSummary {
     pub state: PrStatus,
 }
 
+/// One label on an issue, for the Home inbox's quiet chips. `color` is
+/// GitHub's 6-hex assignment (no leading `#`), used subtly when present.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct IssueLabel {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+}
+
+/// An open GitHub issue for the Home inbox — enough to list it, show its
+/// labels/assignee, and seed a "Start work" brief (title + body + url).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct IssueSummary {
+    pub number: u32,
+    pub title: String,
+    pub url: String,
+    pub labels: Vec<IssueLabel>,
+    /// Assignee login when the issue is assigned to someone.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assignee: Option<String>,
+    /// `updatedAt` as ms-epoch, for the "updated N ago" hint.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<i64>,
+    /// Issue body, carried so "Start work" composes the brief without a
+    /// second round-trip. `None`/empty when the issue has no description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
+}
+
 /// GitHub's combined merge gate (`mergeStateStatus`), normalized. This — not
 /// `mergeable` — is what actually decides whether a PR can land (spec §6).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
@@ -486,6 +515,88 @@ pub async fn pr_list(checkout: &Path, limit: u32) -> Result<Vec<PrSummary>> {
             },
         })
         .collect())
+}
+
+// ---------------------------------------------------------------------------
+// Issues (Home inbox)
+// ---------------------------------------------------------------------------
+
+/// One label node from the REST issues payload → [`IssueLabel`], dropping a
+/// nameless entry.
+fn parse_issue_label(node: &Value) -> Option<IssueLabel> {
+    let name = node["name"].as_str().filter(|s| !s.is_empty())?.to_string();
+    Some(IssueLabel {
+        name,
+        color: node["color"]
+            .as_str()
+            .filter(|c| !c.is_empty())
+            .map(str::to_string),
+    })
+}
+
+fn parse_issue(node: &Value) -> IssueSummary {
+    IssueSummary {
+        number: node["number"].as_u64().unwrap_or_default() as u32,
+        title: node["title"].as_str().unwrap_or_default().to_string(),
+        url: node["html_url"].as_str().unwrap_or_default().to_string(),
+        labels: node["labels"]
+            .as_array()
+            .map(|arr| arr.iter().filter_map(parse_issue_label).collect())
+            .unwrap_or_default(),
+        assignee: node["assignee"]["login"].as_str().map(str::to_string),
+        updated_at: gh_time_ms(node, "updated_at"),
+        body: node["body"]
+            .as_str()
+            .filter(|b| !b.is_empty())
+            .map(str::to_string),
+    }
+}
+
+/// Parse the REST `GET /issues` array into summaries, dropping pull requests —
+/// that endpoint returns both, and only a PR node carries a `pull_request` key.
+/// Pure, so the filter/parse is unit-tested without the network.
+fn parse_issue_list(body: &Value) -> Vec<IssueSummary> {
+    body.as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter(|n| n.get("pull_request").is_none())
+                .map(parse_issue)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// List open issues for the repo at `checkout`, newest-updated first, for the
+/// Home inbox. `Ok(None)` on any degradation (no token, non-GitHub origin,
+/// rate-limit pause, transport/HTTP error) — the same read-op contract the PR
+/// lookups use, so the section quietly disappears instead of erroring. A
+/// connected repo with no open issues returns `Ok(Some(vec![]))`.
+pub async fn issue_list(checkout: &Path, limit: u32) -> Result<Option<Vec<IssueSummary>>> {
+    // Honor the rate-limit pause like `graphql_opt` — serve nothing rather than
+    // spend a REST call that would likely 403.
+    if client::is_backing_off() {
+        return Ok(None);
+    }
+    let Some((owner, repo)) = repo_ref(checkout).await else {
+        return Ok(None);
+    };
+    // Background poll path: not being connected is a normal state, not an error.
+    let client = match client::Client::new() {
+        Ok(c) => c,
+        Err(_) => return Ok(None),
+    };
+    let path = format!(
+        "/repos/{owner}/{repo}/issues?state=open&sort=updated&direction=desc&per_page={}",
+        limit.min(100)
+    );
+    let (status, body) = match client.rest_get_observed(&path).await {
+        Ok(pair) => pair,
+        Err(_) => return Ok(None),
+    };
+    if !status.is_success() {
+        return Ok(None);
+    }
+    Ok(Some(parse_issue_list(&body)))
 }
 
 // ---------------------------------------------------------------------------
@@ -1195,6 +1306,56 @@ mod tests {
             Some(9)
         );
         assert!(pick_branch_pr(&[]).is_none());
+    }
+
+    /// The REST `/issues` array mixes issues and pull requests; only PR nodes
+    /// carry a `pull_request` key. Parsing must drop those and keep issue
+    /// fields (labels, assignee, body).
+    #[test]
+    fn issue_list_drops_pull_requests_and_parses_fields() {
+        let body = json!([
+            {
+                "number": 12,
+                "title": "Login crashes on empty password",
+                "html_url": "https://github.com/o/r/issues/12",
+                "updated_at": "2024-01-02T03:04:05Z",
+                "assignee": { "login": "octocat" },
+                "labels": [
+                    { "name": "bug", "color": "d73a4a" },
+                    { "name": "", "color": "ccc" },
+                    { "color": "no-name" }
+                ],
+                "body": "Steps to reproduce…"
+            },
+            {
+                "number": 13,
+                "title": "A PR masquerading as an issue",
+                "html_url": "https://github.com/o/r/pull/13",
+                "pull_request": { "url": "https://api.github.com/…/pulls/13" }
+            }
+        ]);
+        let issues = parse_issue_list(&body);
+        assert_eq!(
+            issues.len(),
+            1,
+            "the pull_request node must be filtered out"
+        );
+        let it = &issues[0];
+        assert_eq!(it.number, 12);
+        assert_eq!(it.assignee.as_deref(), Some("octocat"));
+        assert_eq!(it.body.as_deref(), Some("Steps to reproduce…"));
+        assert_eq!(it.labels.len(), 1, "nameless labels are dropped");
+        assert_eq!(it.labels[0].name, "bug");
+        assert_eq!(it.labels[0].color.as_deref(), Some("d73a4a"));
+        assert!(it.updated_at.is_some());
+    }
+
+    /// A non-array payload (an error object, an empty response) parses to an
+    /// empty list rather than panicking.
+    #[test]
+    fn issue_list_non_array_is_empty() {
+        assert!(parse_issue_list(&json!({ "message": "Not Found" })).is_empty());
+        assert!(parse_issue_list(&Value::Null).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1487,6 +1487,7 @@ pub fn run() {
             commands::run_claude_command,
             commands::list_prs,
             commands::list_repo_prs,
+            commands::list_repo_issues,
             commands::list_repo_tree,
             commands::read_checkout_file,
             commands::get_file_diff,

--- a/src-tauri/src/rpc/git.rs
+++ b/src-tauri/src/rpc/git.rs
@@ -67,6 +67,11 @@ pub struct GitDispatcher {
     /// dispatchers built without `with_repos` (tests, old call sites) — then
     /// `args.repo` is rejected as unknown.
     repos: std::collections::HashMap<String, (PathBuf, String)>,
+    /// The GitHub issue this workspace was started from (Home inbox "Start
+    /// work"). When set, `open_pr` appends a `Closes #<n>` trailer to the PR
+    /// body for the *primary* checkout, so merging the PR closes the issue.
+    /// `None` for a workspace not tied to an issue.
+    close_issue: Option<u32>,
 }
 
 impl GitDispatcher {
@@ -76,7 +81,15 @@ impl GitDispatcher {
             base_branch,
             default_subdir: None,
             repos: std::collections::HashMap::new(),
+            close_issue: None,
         }
+    }
+
+    /// Record the originating issue number so `open_pr` closes it from the PR
+    /// body. A no-op when `None` (the normal, non-issue spawn).
+    pub fn with_close_issue(mut self, number: Option<u32>) -> Self {
+        self.close_issue = number;
+        self
     }
 
     /// Register the agent's tracked checkouts as `(subdir, cwd, base_branch)`
@@ -139,6 +152,42 @@ fn with_repo(mut payload: Value, subdir: &Option<String>) -> Value {
         payload["repo"] = json!(s);
     }
     payload
+}
+
+/// True when `body` already references issue `#number` — bounded so `#12`
+/// doesn't match `#123` (a trailing digit means a different issue). Used to
+/// keep the `Closes` trailer idempotent when the agent already wrote one.
+fn mentions_issue(body: &str, number: u32) -> bool {
+    let needle = format!("#{number}");
+    let mut rest = body;
+    while let Some(pos) = rest.find(&needle) {
+        let after = &rest[pos + needle.len()..];
+        if after.chars().next().map_or(true, |c| !c.is_ascii_digit()) {
+            return true;
+        }
+        rest = after;
+    }
+    false
+}
+
+/// Append a `Closes #<n>` trailer to a PR body for an issue-originated
+/// workspace, unless the body already references the issue. `None` leaves the
+/// body untouched (the normal, non-issue spawn). A blank body becomes just the
+/// trailer.
+fn with_closes_trailer(body: &str, close_issue: Option<u32>) -> String {
+    let Some(number) = close_issue else {
+        return body.to_string();
+    };
+    if mentions_issue(body, number) {
+        return body.to_string();
+    }
+    let trailer = format!("Closes #{number}");
+    let trimmed = body.trim_end();
+    if trimmed.is_empty() {
+        trailer
+    } else {
+        format!("{trimmed}\n\n{trailer}")
+    }
 }
 
 impl RpcDispatcher for GitDispatcher {
@@ -229,7 +278,16 @@ impl GitDispatcher {
             Err(resp) => return (resp, Vec::new()),
         };
         let title = args.get("title").and_then(|v| v.as_str()).unwrap_or("");
-        let body = args.get("body").and_then(|v| v.as_str()).unwrap_or("");
+        let body_arg = args.get("body").and_then(|v| v.as_str()).unwrap_or("");
+        // Compose the final body: when this workspace originated from an issue
+        // and the PR targets the issue's (primary) repo, ensure a `Closes #<n>`
+        // trailer so merging the PR closes the issue — reliably, without relying
+        // on the agent to remember. Idempotent (skips if already referenced).
+        let closes = (t.subdir == self.default_subdir)
+            .then_some(self.close_issue)
+            .flatten();
+        let body_owned = with_closes_trailer(body_arg, closes);
+        let body = body_owned.as_str();
         let requested = arg_branch(args);
 
         let current = match crate::git::current_branch(&t.cwd).await {
@@ -486,6 +544,39 @@ mod tests {
 
     fn dispatcher(cwd: &Path) -> GitDispatcher {
         GitDispatcher::new(cwd.to_path_buf(), "main".to_string())
+    }
+
+    #[test]
+    fn closes_trailer_appends_only_when_issue_set() {
+        // No issue → body untouched.
+        assert_eq!(
+            with_closes_trailer("Fixes the thing", None),
+            "Fixes the thing"
+        );
+        // Issue set → trailer appended after a blank line.
+        assert_eq!(
+            with_closes_trailer("Fixes the thing", Some(42)),
+            "Fixes the thing\n\nCloses #42"
+        );
+        // Blank body → just the trailer.
+        assert_eq!(with_closes_trailer("   ", Some(7)), "Closes #7");
+    }
+
+    #[test]
+    fn closes_trailer_is_idempotent_and_number_bounded() {
+        // Already referenced → left as-is (no duplicate).
+        assert_eq!(
+            with_closes_trailer("Work.\n\nCloses #42", Some(42)),
+            "Work.\n\nCloses #42"
+        );
+        // A superstring number must NOT count as a mention (#12 vs #123).
+        assert!(!mentions_issue("Closes #123", 12));
+        assert!(mentions_issue("Closes #123", 123));
+        assert!(mentions_issue("see #42, thanks", 42));
+        assert_eq!(
+            with_closes_trailer("Refs #120 and #121", Some(12)),
+            "Refs #120 and #121\n\nCloses #12"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/rpc/git.rs
+++ b/src-tauri/src/rpc/git.rs
@@ -154,31 +154,58 @@ fn with_repo(mut payload: Value, subdir: &Option<String>) -> Value {
     payload
 }
 
-/// True when `body` already references issue `#number` — bounded so `#12`
-/// doesn't match `#123` (a trailing digit means a different issue). Used to
-/// keep the `Closes` trailer idempotent when the agent already wrote one.
-fn mentions_issue(body: &str, number: u32) -> bool {
+/// GitHub's closing keywords (case-insensitive). Only one of these directly
+/// preceding the reference makes merging the PR close the issue — a bare
+/// mention (`see #12`) links but never closes.
+const CLOSING_KEYWORDS: [&str; 9] = [
+    "close", "closes", "closed", "fix", "fixes", "fixed", "resolve", "resolves", "resolved",
+];
+
+/// True when `body` already contains a CLOSING reference to issue `#number`
+/// (`fixes #12`, `Closes: #12`, …) — bounded so `#12` doesn't match `#123` (a
+/// trailing digit means a different issue). A mere mention does NOT count: it
+/// wouldn't close the issue, so the trailer is still required. Used to keep
+/// the `Closes` trailer idempotent when the agent already wrote one.
+fn closes_issue(body: &str, number: u32) -> bool {
     let needle = format!("#{number}");
-    let mut rest = body;
-    while let Some(pos) = rest.find(&needle) {
-        let after = &rest[pos + needle.len()..];
-        if after.chars().next().map_or(true, |c| !c.is_ascii_digit()) {
+    let mut offset = 0;
+    while let Some(pos) = body[offset..].find(&needle) {
+        let at = offset + pos;
+        let after = &body[at + needle.len()..];
+        let bounded = after.chars().next().map_or(true, |c| !c.is_ascii_digit());
+        if bounded && ends_with_closing_keyword(&body[..at]) {
             return true;
         }
-        rest = after;
+        offset = at + needle.len();
     }
     false
 }
 
+/// Does the text leading up to a `#N` reference end with a closing keyword
+/// (allowing `fixes #12`, `Fixes: #12`, `fixes#12`)? Strict on the keyword
+/// itself (`prefixes #12` is not a match) — a false negative merely appends a
+/// redundant trailer, while a false positive would leave the issue open.
+fn ends_with_closing_keyword(before: &str) -> bool {
+    let trimmed = before.trim_end();
+    let trimmed = trimmed.strip_suffix(':').unwrap_or(trimmed);
+    let word_start = trimmed
+        .rfind(|c: char| !c.is_ascii_alphabetic())
+        .map_or(0, |i| i + 1);
+    let word = &trimmed[word_start..];
+    CLOSING_KEYWORDS
+        .iter()
+        .any(|k| word.eq_ignore_ascii_case(k))
+}
+
 /// Append a `Closes #<n>` trailer to a PR body for an issue-originated
-/// workspace, unless the body already references the issue. `None` leaves the
-/// body untouched (the normal, non-issue spawn). A blank body becomes just the
-/// trailer.
+/// workspace, unless the body already CLOSES the issue (a bare mention is not
+/// enough). `None` leaves the body untouched (the normal, non-issue spawn). A
+/// blank body becomes just the trailer.
 fn with_closes_trailer(body: &str, close_issue: Option<u32>) -> String {
     let Some(number) = close_issue else {
         return body.to_string();
     };
-    if mentions_issue(body, number) {
+    if closes_issue(body, number) {
         return body.to_string();
     }
     let trailer = format!("Closes #{number}");
@@ -564,19 +591,41 @@ mod tests {
 
     #[test]
     fn closes_trailer_is_idempotent_and_number_bounded() {
-        // Already referenced → left as-is (no duplicate).
+        // Already CLOSED by the body → left as-is (no duplicate).
         assert_eq!(
             with_closes_trailer("Work.\n\nCloses #42", Some(42)),
             "Work.\n\nCloses #42"
         );
-        // A superstring number must NOT count as a mention (#12 vs #123).
-        assert!(!mentions_issue("Closes #123", 12));
-        assert!(mentions_issue("Closes #123", 123));
-        assert!(mentions_issue("see #42, thanks", 42));
+        // A superstring number must NOT count (#12 vs #123).
+        assert!(!closes_issue("Closes #123", 12));
+        assert!(closes_issue("Closes #123", 123));
         assert_eq!(
             with_closes_trailer("Refs #120 and #121", Some(12)),
             "Refs #120 and #121\n\nCloses #12"
         );
+    }
+
+    #[test]
+    fn closes_trailer_requires_a_closing_keyword_not_a_mention() {
+        // A bare mention links but doesn't close — the trailer must still land.
+        assert!(!closes_issue("see #42, thanks", 42));
+        assert_eq!(
+            with_closes_trailer("Follow-up to the report in #42.", Some(42)),
+            "Follow-up to the report in #42.\n\nCloses #42"
+        );
+        // GitHub's closing spellings all count (case, colon, no-space).
+        for body in [
+            "fixes #42",
+            "Fixes: #42",
+            "RESOLVED #42",
+            "close#42",
+            "This should fix #42 for good",
+        ] {
+            assert!(closes_issue(body, 42), "should close: {body}");
+        }
+        // A keyword-suffixed word is not a keyword.
+        assert!(!closes_issue("prefixes #42", 42));
+        assert!(!closes_issue("sunfixed #42", 42));
     }
 
     #[tokio::test]

--- a/src-tauri/src/rpc/git.rs
+++ b/src-tauri/src/rpc/git.rs
@@ -182,11 +182,15 @@ fn closes_issue(body: &str, number: u32) -> bool {
 }
 
 /// Does the text leading up to a `#N` reference end with a closing keyword
-/// (allowing `fixes #12`, `Fixes: #12`, `fixes#12`)? Strict on the keyword
-/// itself (`prefixes #12` is not a match) — a false negative merely appends a
+/// plus a real separator (`fixes #12`, `Fixes: #12`)? Strict on both the
+/// keyword (`prefixes #12` is not a match) and the separator (GitHub does not
+/// document the glued `fixes#12` form) — a false negative merely appends a
 /// redundant trailer, while a false positive would leave the issue open.
 fn ends_with_closing_keyword(before: &str) -> bool {
     let trimmed = before.trim_end();
+    if trimmed.len() == before.len() {
+        return false;
+    }
     let trimmed = trimmed.strip_suffix(':').unwrap_or(trimmed);
     let word_start = trimmed
         .rfind(|c: char| !c.is_ascii_alphabetic())
@@ -613,19 +617,22 @@ mod tests {
             with_closes_trailer("Follow-up to the report in #42.", Some(42)),
             "Follow-up to the report in #42.\n\nCloses #42"
         );
-        // GitHub's closing spellings all count (case, colon, no-space).
+        // GitHub's documented closing spellings count (case, optional colon).
         for body in [
             "fixes #42",
             "Fixes: #42",
             "RESOLVED #42",
-            "close#42",
             "This should fix #42 for good",
         ] {
             assert!(closes_issue(body, 42), "should close: {body}");
         }
-        // A keyword-suffixed word is not a keyword.
+        // A keyword-suffixed word is not a keyword, and a keyword glued to the
+        // reference (no separator) is not a documented closing form — both must
+        // still receive the trailer.
         assert!(!closes_issue("prefixes #42", 42));
         assert!(!closes_issue("sunfixed #42", 42));
+        assert!(!closes_issue("close#42", 42));
+        assert!(!closes_issue("Fixes:#42", 42));
     }
 
     #[tokio::test]

--- a/src-tauri/src/supervisor/fork.rs
+++ b/src-tauri/src/supervisor/fork.rs
@@ -167,6 +167,9 @@ impl Supervisor {
             run_repo: None,
             owner_run_id: None,
             carry_from,
+            // A fork is a fresh line of work; it doesn't inherit the parent's
+            // originating issue (only one workspace should close it).
+            issue_ref: None,
         };
         let child = self.clone().spawn_agent(app, req).await?;
 

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -151,6 +151,10 @@ pub struct SpawnRequest {
     /// checkout after provisioning, so the fork starts from that workspace's
     /// state. `None` for a normal spawn or a clean fork.
     pub carry_from: Option<PathBuf>,
+    /// The GitHub issue this spawn originates from (bare issue number as text),
+    /// set by the Home inbox's "Start work". Persisted on the workspace so the
+    /// agent's PR closes it. `None` for a spawn not tied to an issue.
+    pub issue_ref: Option<String>,
 }
 
 impl Supervisor {
@@ -176,6 +180,7 @@ impl Supervisor {
             run_repo,
             owner_run_id,
             carry_from,
+            issue_ref,
         } = req;
         if !repo_path.join(".git").exists() {
             return Err(Error::InvalidPath(format!(
@@ -278,6 +283,9 @@ impl Supervisor {
         // Tag the agent with its owning run (workflow step spawn) so it's
         // hidden from the normal sidebar and cascaded on run delete.
         record.owner_run_id = owner_run_id;
+        // Carry the originating issue (Home inbox "Start work") onto the record
+        // so the git dispatcher can close it from the agent's PR.
+        record.issue_ref = issue_ref;
         let parent_dir = agent_parent_dir(&agent_id)?;
         let primary_checkout = repo_checkout_path(&agent_id, &subdir)?;
 
@@ -578,8 +586,15 @@ impl Supervisor {
                 .unwrap_or_else(|| "main".to_string());
             repo_targets.push((r.subdir.clone(), checkout, base));
         }
-        let git_dispatcher =
-            rpc::git::GitDispatcher::new(cwd.clone(), base_branch).with_repos(repo_targets);
+        // A workspace started from a Home-inbox issue carries its number here;
+        // the dispatcher appends `Closes #<n>` to the primary repo's PR body.
+        let close_issue = record
+            .issue_ref
+            .as_deref()
+            .and_then(|s| s.trim().parse().ok());
+        let git_dispatcher = rpc::git::GitDispatcher::new(cwd.clone(), base_branch)
+            .with_repos(repo_targets)
+            .with_close_issue(close_issue);
         // A run-owned step agent also gets the workflow comms ops (wf_report /
         // wf_ask / wf_notify, §10); everything else still falls through to the
         // git dispatcher. Plain agents keep the git dispatcher unchanged.

--- a/src-tauri/src/workflow/driver.rs
+++ b/src-tauri/src/workflow/driver.rs
@@ -156,6 +156,8 @@ impl AgentDriver for SupervisorDriver {
                         run_repo,
                         owner_run_id: Some(owner_run_id),
                         carry_from: None,
+                        // Workflow-step spawns aren't issue-intake spawns.
+                        issue_ref: None,
                     },
                 )
                 .await?;

--- a/src-tauri/src/workspace.rs
+++ b/src-tauri/src/workspace.rs
@@ -207,6 +207,12 @@ pub struct AgentRecord {
     /// user-spawned agent.
     #[serde(default)]
     pub owner_run_id: Option<String>,
+    /// The GitHub issue this workspace was started from (bare issue number as
+    /// text), captured when the user hits "Start work" on a Home-inbox issue.
+    /// `None` for a normal spawn. Drives the `Closes #<n>` trailer the agent's
+    /// PR carries so merging it closes the originating issue.
+    #[serde(default)]
+    pub issue_ref: Option<String>,
     pub created_at: String,
     #[serde(default)]
     pub last_error: Option<String>,
@@ -400,7 +406,7 @@ const AGENT_SELECT: &str = "SELECT w.id, w.project_id, w.name, w.task, w.created
             s.provider, s.view, s.provider_session_id, s.last_error,
             s.effort, s.model, s.instructions, s.forked_context, s.custom_agent_id,
             s.skills, s.mcp_servers,
-            w.sandbox_engine, w.owner_run_id
+            w.sandbox_engine, w.owner_run_id, w.issue_ref
      FROM workspaces w
      LEFT JOIN sessions s ON s.workspace_id = w.id";
 
@@ -426,6 +432,7 @@ type AgentRow = (
     Option<String>, // s.mcp_servers (JSON array of McpServerSnapshot)
     Option<String>, // w.sandbox_engine
     Option<String>, // w.owner_run_id
+    Option<String>, // w.issue_ref
 );
 
 impl WorkspaceManager {
@@ -907,8 +914,8 @@ impl WorkspaceManager {
 
         // The workspace is the durable work-area (identity + task metadata).
         tx.execute(
-            "INSERT INTO workspaces (id, project_id, name, task, created_at, sandbox_engine, owner_run_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            "INSERT INTO workspaces (id, project_id, name, task, created_at, sandbox_engine, owner_run_id, issue_ref)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
             rusqlite::params![
                 record.id,
                 project_id,
@@ -917,6 +924,7 @@ impl WorkspaceManager {
                 created_millis,
                 record.sandbox_engine,
                 record.owner_run_id,
+                record.issue_ref,
             ],
         )?;
 
@@ -2183,7 +2191,7 @@ impl WorkspaceManager {
     }
 
     /// Map a row from an [`AGENT_SELECT`] query into the raw column tuple.
-    /// Shared by `query_all_agents` and `load_agent` so the 20-column layout
+    /// Shared by `query_all_agents` and `load_agent` so the 21-column layout
     /// is decoded in exactly one place.
     fn map_agent_row(row: &rusqlite::Row) -> rusqlite::Result<AgentRow> {
         Ok((
@@ -2207,6 +2215,7 @@ impl WorkspaceManager {
             row.get(17)?,
             row.get(18)?,
             row.get(19)?,
+            row.get(20)?,
         ))
     }
 
@@ -2235,6 +2244,7 @@ impl WorkspaceManager {
             mcp_servers_json,
             sandbox_engine,
             owner_run_id,
+            issue_ref,
         ) = row;
 
         let is_archived = archived_millis.is_some();
@@ -2275,6 +2285,7 @@ impl WorkspaceManager {
             mcp_servers: decode_json_vec(mcp_servers_json.as_deref()),
             sandbox_engine,
             owner_run_id,
+            issue_ref,
             created_at: millis_to_iso(created_millis),
             last_error,
             archive,
@@ -2352,6 +2363,8 @@ pub fn new_agent_record(
         // Set by the workflow scheduler at step spawn; a plain spawn leaves it
         // unowned so the agent shows in the normal sidebar.
         owner_run_id: None,
+        // Set by the issue-intake spawn path; a plain spawn has no origin issue.
+        issue_ref: None,
         created_at: Utc::now().to_rfc3339(),
         last_error: None,
         archive: None,

--- a/src/api.ts
+++ b/src/api.ts
@@ -93,6 +93,9 @@ export interface AgentRecord {
    *  for the agent's life — a settings change never re-engines it. Null for
    *  agents created before engine selection existed (they run sandbox-exec). */
   sandbox_engine?: string | null;
+  /** The GitHub issue this workspace was started from (bare issue number as
+   *  text), set by the Home inbox's "Start work". Null for a normal spawn. */
+  issue_ref?: string | null;
 }
 
 /** A pinned repo joined with its owning project. `name` is the project's
@@ -299,6 +302,26 @@ export interface PrSummary {
   number: number;
   title: string;
   state: PrStatus;
+}
+
+/** One label on an issue, for the Home inbox's quiet chips. `color` is
+ *  GitHub's 6-hex assignment (no leading `#`), used subtly when present. */
+export interface IssueLabel {
+  name: string;
+  color?: string;
+}
+
+/** An open GitHub issue for the Home inbox. Carries the body so "Start work"
+ *  composes the brief without a second round-trip. */
+export interface IssueSummary {
+  number: number;
+  title: string;
+  url: string;
+  labels: IssueLabel[];
+  assignee?: string;
+  /** `updatedAt` as ms-epoch, for the "updated N ago" hint. */
+  updated_at?: number;
+  body?: string;
 }
 
 /** GitHub's combined merge gate (`mergeStateStatus`), normalized (spec §6). */
@@ -672,6 +695,10 @@ export const api = {
     skills?: SkillSnapshot[],
     /** A custom agent's MCP servers, resolved by value at spawn. */
     mcpServers?: McpServerSnapshot[],
+    /** The GitHub issue this spawn originates from (bare issue number as text),
+     *  set by the Home inbox's "Start work". Persisted so the agent's PR closes
+     *  it. `undefined` for a spawn not tied to an issue. */
+    issueRef?: string,
   ) =>
     invoke<AgentRecord>("spawn_agent", {
       view,
@@ -685,6 +712,7 @@ export const api = {
       skills: skills ?? null,
       mcpServers: mcpServers ?? null,
       forkBase: forkBase ?? null,
+      issueRef: issueRef ?? null,
     }),
   /** Fork an existing workspace into a new one, seeding its worktree (`code`)
    *  and conversation (`context`) independently. For `context.kind ===
@@ -843,6 +871,11 @@ export const api = {
   // has no agent/checkout yet.
   listRepoTree: (repoPath: string) => invoke<string[]>("list_repo_tree", { repoPath }),
   listRepoPrs: (repoPath: string) => invoke<PrSummary[]>("list_repo_prs", { repoPath }),
+  /** Open GitHub issues for the Home inbox, by repo path. `null` when the repo
+   *  has no token / non-GitHub origin / a rate-limit pause is active — the
+   *  section degrades quietly. `[]` means connected but no open issues. */
+  listRepoIssues: (repoPath: string) =>
+    invoke<IssueSummary[] | null>("list_repo_issues", { repoPath }),
   readCheckoutFile: (agentId: string, path: string) =>
     invoke<CheckoutFileContents>("read_checkout_file", { agentId, path }),
   getFileDiff: (agentId: string, path: string) =>

--- a/src/components/Workspace/MissionControl/IssueInbox.tsx
+++ b/src/components/Workspace/MissionControl/IssueInbox.tsx
@@ -1,0 +1,82 @@
+// MissionControl/IssueInbox.tsx — the Home issue inbox: a quiet section below
+// the review queue listing open GitHub issues for the workspace's tracked
+// repos. "Start work" lands in the new-task composer, fully prefilled. This
+// file is the data/poll shell; row rendering lives in IssueRow, the pure
+// derivation in inbox.ts.
+
+import { useCallback, useMemo, useState } from "react";
+import { api, type IssueSummary } from "@/api";
+import { Icon } from "@/components/Icon";
+import { useAppStore } from "@/store";
+import { usePoll } from "@/util/hooks";
+import { IssueRow } from "./IssueRow";
+import { deriveInboxRows, type InboxRepo } from "./inbox";
+
+/** Slow, GitHub-gated cadence — the inbox is secondary; open issues change on
+ *  human timescales, so a modest poll matches the existing PR-state cadence. */
+const POLL_MS = 120_000;
+
+export function IssueInbox() {
+  const githubConnected = useAppStore((s) => s.github?.authenticated ?? false);
+  const repoPaths = useAppStore((s) => s.workspace?.repos ?? []);
+  const projects = useAppStore((s) => s.workspace?.projects ?? []);
+  const startWorkFromIssue = useAppStore((s) => s.startWorkFromIssue);
+
+  // Open issues keyed by repo path. A `null` degrade (no token / non-GitHub
+  // origin / rate-limit pause) reads as "no issues" — the section just hides.
+  const [byRepo, setByRepo] = useState<Record<string, IssueSummary[]>>({});
+
+  const poll = useCallback(async () => {
+    if (!githubConnected || repoPaths.length === 0) return;
+    const entries = await Promise.all(
+      repoPaths.map(
+        async (path) => [path, (await api.listRepoIssues(path).catch(() => null)) ?? []] as const,
+      ),
+    );
+    setByRepo(Object.fromEntries(entries));
+  }, [githubConnected, repoPaths]);
+
+  usePoll(poll, POLL_MS, [poll]);
+
+  // Repo display label: the project's user label/name, else the folder name.
+  const labelFor = useCallback(
+    (path: string) => {
+      const ref = projects.find((r) => r.path === path);
+      return ref?.label || ref?.name || path.split("/").filter(Boolean).pop() || path;
+    },
+    [projects],
+  );
+
+  const rows = useMemo(() => {
+    const repos: InboxRepo[] = repoPaths
+      .map((path) => ({ repoPath: path, repoLabel: labelFor(path), issues: byRepo[path] ?? [] }))
+      .filter((r) => r.issues.length > 0);
+    return deriveInboxRows(repos);
+  }, [repoPaths, byRepo, labelFor]);
+
+  const multiRepo = useMemo(() => new Set(rows.map((r) => r.repoPath)).size > 1, [rows]);
+
+  // Quiet degradation: no token, no tracked GitHub repos, or no open issues →
+  // the section disappears entirely. Never an error, never a parked spinner.
+  if (!githubConnected || rows.length === 0) return null;
+
+  return (
+    <div className="mc-inbox-wrap">
+      <div className="mc-inbox-head">
+        <Icon name="inbox" size={13} />
+        <span>Open issues</span>
+        <span className="mc-inbox-count">{rows.length}</span>
+      </div>
+      <div className="mc-inbox-list">
+        {rows.map((row) => (
+          <IssueRow
+            key={row.key}
+            row={row}
+            showRepo={multiRepo}
+            onStart={() => void startWorkFromIssue(row.repoPath, row.issue)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Workspace/MissionControl/IssueRow.tsx
+++ b/src/components/Workspace/MissionControl/IssueRow.tsx
@@ -1,0 +1,71 @@
+import { Icon } from "@/components/Icon";
+import type { InboxRow } from "./inbox";
+
+/** Compact "updated N ago" hint from a ms-epoch, or "" when unknown. Mirrors
+ *  History's formatter so the whole app speaks the same relative time. */
+function updatedAgo(ms: number | undefined): string {
+  if (!ms) return "";
+  const minutes = Math.floor((Date.now() - ms) / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(ms).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+/** One inbox row: issue number + title, quiet label chips, and a "Start work"
+ *  button that lands in the composer prefilled. The row is compact and calm —
+ *  secondary to the review queue above it. */
+export function IssueRow({
+  row,
+  showRepo,
+  onStart,
+}: {
+  row: InboxRow;
+  /** Show the originating repo (only meaningful when >1 repo has issues). */
+  showRepo: boolean;
+  onStart: () => void;
+}) {
+  const { issue } = row;
+  const ago = updatedAgo(issue.updated_at);
+  return (
+    <div className="mc-inbox-row">
+      <div className="mc-inbox-body">
+        <div className="mc-inbox-titleline">
+          <span className="mc-inbox-num">#{issue.number}</span>
+          <span className="mc-inbox-title" title={issue.title}>
+            {issue.title}
+          </span>
+          <a
+            className="mc-inbox-ext"
+            href={issue.url}
+            target="_blank"
+            rel="noreferrer"
+            title="Open on GitHub"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Icon name="external" size={12} />
+          </a>
+        </div>
+        <div className="mc-inbox-meta">
+          {showRepo && <span className="mc-inbox-repo">{row.repoLabel}</span>}
+          {issue.labels.slice(0, 4).map((l) => (
+            <span className="mc-issue-label" key={l.name}>
+              {l.color && (
+                <span className="mc-issue-dot" style={{ backgroundColor: `#${l.color}` }} />
+              )}
+              {l.name}
+            </span>
+          ))}
+          {issue.assignee && <span className="mc-inbox-hint">@{issue.assignee}</span>}
+          {ago && <span className="mc-inbox-hint">{ago}</span>}
+        </div>
+      </div>
+      <button type="button" className="mc-btn mc-inbox-start" onClick={onStart}>
+        <Icon name="play" size={12} /> Start work
+      </button>
+    </div>
+  );
+}

--- a/src/components/Workspace/MissionControl/MissionControl.css
+++ b/src/components/Workspace/MissionControl/MissionControl.css
@@ -299,3 +299,127 @@
   color: var(--fg-3);
   line-height: var(--lh-snug);
 }
+
+/* ── issue inbox (secondary section) ──────────────────────────────────────── */
+/* Deliberately quieter than the review queue: a small header, compact rows,
+ * no rail/tint — it should never compete with "what needs me?". */
+.mc-inbox-wrap {
+  width: 100%;
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 8px 20px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.mc-inbox-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 2px;
+  color: var(--fg-3);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.mc-inbox-count {
+  color: var(--fg-3);
+  font-family: var(--font-mono);
+  letter-spacing: 0;
+}
+.mc-inbox-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.mc-inbox-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 9px 12px;
+  background: var(--bg-2);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-md);
+  transition: border-color 0.12s var(--ease);
+}
+.mc-inbox-row:hover {
+  border-color: var(--bd);
+}
+.mc-inbox-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.mc-inbox-titleline {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+}
+.mc-inbox-num {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--fg-3);
+}
+.mc-inbox-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--fs-sm);
+  color: var(--fg-0);
+}
+.mc-inbox-ext {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  color: var(--fg-3);
+  opacity: 0;
+  transition: var(--transition-ui-ease);
+}
+.mc-inbox-row:hover .mc-inbox-ext {
+  opacity: 1;
+}
+.mc-inbox-ext:hover {
+  color: var(--fg-1);
+}
+.mc-inbox-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+.mc-inbox-repo {
+  font-size: var(--fs-xs);
+  color: var(--fg-2);
+  font-family: var(--font-mono);
+}
+.mc-issue-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 7px;
+  border-radius: var(--r-xs);
+  font-size: var(--fs-xs);
+  color: var(--fg-2);
+  background: var(--bg-3);
+  border: 1px solid var(--bd-soft);
+  white-space: nowrap;
+}
+.mc-issue-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.mc-inbox-hint {
+  font-size: var(--fs-xs);
+  color: var(--fg-3);
+}
+.mc-inbox-start {
+  flex-shrink: 0;
+  height: 26px;
+}

--- a/src/components/Workspace/MissionControl/inbox.test.ts
+++ b/src/components/Workspace/MissionControl/inbox.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import type { IssueSummary } from "@/api";
+import {
+  branchKind,
+  composeIssueBrief,
+  deriveInboxRows,
+  slugifyTitle,
+  suggestBranchName,
+} from "./inbox";
+
+function issue(over: Partial<IssueSummary> = {}): IssueSummary {
+  return {
+    number: 1,
+    title: "An issue",
+    url: "https://github.com/o/r/issues/1",
+    labels: [],
+    ...over,
+  };
+}
+
+describe("slugifyTitle", () => {
+  it("lowercases, dashes non-alphanumerics, and clamps words", () => {
+    expect(slugifyTitle("Login crashes on empty password!")).toBe(
+      "login-crashes-on-empty-password",
+    );
+    expect(slugifyTitle("A B C D E F G", 3)).toBe("a-b-c");
+  });
+
+  it("collapses runs and trims trailing dashes", () => {
+    expect(slugifyTitle("  Fix   the -- thing  ")).toBe("fix-the-thing");
+    expect(slugifyTitle("!!!")).toBe("");
+  });
+});
+
+describe("branchKind", () => {
+  it("infers feat / chore / fix from labels", () => {
+    expect(branchKind([{ name: "enhancement" }])).toBe("feat");
+    expect(branchKind([{ name: "documentation" }])).toBe("chore");
+    expect(branchKind([{ name: "bug" }])).toBe("fix");
+    expect(branchKind([])).toBe("fix");
+  });
+});
+
+describe("suggestBranchName", () => {
+  it("builds kind/number-slug", () => {
+    expect(suggestBranchName(issue({ number: 123, title: "Login crash" }))).toBe(
+      "fix/123-login-crash",
+    );
+    expect(
+      suggestBranchName(
+        issue({ number: 9, title: "Add dark mode", labels: [{ name: "feature" }] }),
+      ),
+    ).toBe("feat/9-add-dark-mode");
+  });
+
+  it("falls back to the number when the title has no slug", () => {
+    expect(suggestBranchName(issue({ number: 7, title: "🎉🎉🎉" }))).toBe("fix/7");
+  });
+});
+
+describe("composeIssueBrief", () => {
+  it("includes reference, body, url, and the branch suggestion", () => {
+    const brief = composeIssueBrief(
+      issue({ number: 42, title: "Crash on save", body: "Steps:\n1. save", url: "https://x/42" }),
+    );
+    expect(brief).toContain("GitHub issue #42: Crash on save");
+    expect(brief).toContain("Steps:\n1. save");
+    expect(brief).toContain("https://x/42");
+    expect(brief).toContain("`fix/42-crash-on-save`");
+  });
+
+  it("omits an empty body block", () => {
+    const brief = composeIssueBrief(issue({ number: 5, title: "T", body: "  " }));
+    expect(brief).not.toContain("\n\n\n");
+  });
+});
+
+describe("deriveInboxRows", () => {
+  it("merges repos, keys by repo+number, and sorts newest-updated first", () => {
+    const rows = deriveInboxRows([
+      {
+        repoPath: "/a",
+        repoLabel: "A",
+        issues: [issue({ number: 1, updated_at: 100 }), issue({ number: 2, updated_at: 300 })],
+      },
+      { repoPath: "/b", repoLabel: "B", issues: [issue({ number: 1, updated_at: 200 })] },
+    ]);
+    expect(rows.map((r) => r.key)).toEqual(["/a#2", "/b#1", "/a#1"]);
+  });
+
+  it("sorts issues without a timestamp last and respects the limit", () => {
+    const rows = deriveInboxRows(
+      [
+        {
+          repoPath: "/a",
+          repoLabel: "A",
+          issues: [issue({ number: 1 }), issue({ number: 2, updated_at: 5 })],
+        },
+      ],
+      1,
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].key).toBe("/a#2");
+  });
+});

--- a/src/components/Workspace/MissionControl/inbox.ts
+++ b/src/components/Workspace/MissionControl/inbox.ts
@@ -1,0 +1,91 @@
+// MissionControl/inbox.ts — pure logic for the Home issue inbox: the
+// branch-name suggestion, the "Start work" brief composition, and merging
+// per-repo issue lists into one ordered set of rows. Kept side-effect-free so
+// each piece is unit-tested without the network or the store (inbox.test.ts).
+
+import type { IssueLabel, IssueSummary } from "@/api";
+
+/** A tracked GitHub repo's fetched issues, tagged with its display label. */
+export interface InboxRepo {
+  repoPath: string;
+  /** Human label for the repo (project/repo name), shown when >1 repo. */
+  repoLabel: string;
+  issues: IssueSummary[];
+}
+
+/** One rendered inbox row: an issue plus the repo it belongs to. Keyed by
+ *  repo+number so the same issue number in two repos never collides. */
+export interface InboxRow {
+  key: string;
+  repoPath: string;
+  repoLabel: string;
+  issue: IssueSummary;
+}
+
+/** Slugify an issue title for a branch name: lowercase, non-alphanumerics to
+ *  single dashes, trimmed, and clamped to a handful of words so the branch
+ *  stays short and conventional. Empty when the title has no usable words. */
+export function slugifyTitle(title: string, maxWords = 5, maxLen = 40): string {
+  const words = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, maxWords);
+  return words.join("-").slice(0, maxLen).replace(/-+$/, "");
+}
+
+/** Conventional branch prefix inferred from the issue's labels — `feat` for a
+ *  feature/enhancement, `chore` for chore/docs/deps, else `fix` (the safe
+ *  default for a bug or an unlabeled issue). */
+export function branchKind(labels: IssueLabel[]): "fix" | "feat" | "chore" {
+  const names = labels.map((l) => l.name.toLowerCase());
+  const has = (...needles: string[]) =>
+    names.some((n) => needles.some((needle) => n.includes(needle)));
+  if (has("feature", "enhancement", "feat")) return "feat";
+  if (has("chore", "docs", "documentation", "dependenc")) return "chore";
+  return "fix";
+}
+
+/** Suggested branch name for an issue, e.g. `fix/123-login-crash`. Visible and
+ *  editable in the composed brief — never hidden magic. Falls back to just the
+ *  number when the title yields no slug. */
+export function suggestBranchName(
+  issue: Pick<IssueSummary, "number" | "title" | "labels">,
+): string {
+  const kind = branchKind(issue.labels);
+  const slug = slugifyTitle(issue.title);
+  return slug ? `${kind}/${issue.number}-${slug}` : `${kind}/${issue.number}`;
+}
+
+/** Compose the new-task brief for "Start work": issue reference, title, body,
+ *  and a visible/editable branch suggestion. The `Closes #N` trailer is added
+ *  reliably by the backend at PR time, so the brief needn't instruct it. */
+export function composeIssueBrief(issue: IssueSummary): string {
+  const branch = suggestBranchName(issue);
+  const parts = [`GitHub issue #${issue.number}: ${issue.title}`];
+  const body = issue.body?.trim();
+  if (body) parts.push(body);
+  parts.push(issue.url);
+  parts.push(`When you open the PR, use the branch name \`${branch}\`.`);
+  return parts.join("\n\n");
+}
+
+/** Merge per-repo issue lists into one ordered set of rows, newest-updated
+ *  first (issues with no timestamp sort last), capped at `limit`. */
+export function deriveInboxRows(repos: InboxRepo[], limit = 20): InboxRow[] {
+  const rows: InboxRow[] = [];
+  for (const repo of repos) {
+    for (const issue of repo.issues) {
+      rows.push({
+        key: `${repo.repoPath}#${issue.number}`,
+        repoPath: repo.repoPath,
+        repoLabel: repo.repoLabel,
+        issue,
+      });
+    }
+  }
+  rows.sort((a, b) => (b.issue.updated_at ?? 0) - (a.issue.updated_at ?? 0));
+  return rows.slice(0, limit);
+}

--- a/src/components/Workspace/MissionControl/index.tsx
+++ b/src/components/Workspace/MissionControl/index.tsx
@@ -10,6 +10,7 @@ import { IconButton } from "@/components/ui/IconButton";
 import { useAppStore } from "@/store";
 import { AllClear } from "./AllClear";
 import { FanoutCard } from "./FanoutCard";
+import { IssueInbox } from "./IssueInbox";
 import { QueueCard } from "./QueueCard";
 import { useQueueActions } from "./useQueueActions";
 import { useQueueKeyboard } from "./useQueueKeyboard";
@@ -103,6 +104,10 @@ export function MissionControl() {
             </div>
           </div>
         )}
+
+        {/* Secondary section: open GitHub issues for the tracked repos. Below
+            the review queue, quieter, and self-hiding when there's nothing. */}
+        <IssueInbox />
       </div>
 
       {reviewRunId && (

--- a/src/store/drafts.ts
+++ b/src/store/drafts.ts
@@ -1,4 +1,5 @@
 import { api } from "@/api";
+import { composeIssueBrief } from "@/components/Workspace/MissionControl/inbox";
 import { DEFAULT_PROVIDER_ID, PROVIDERS } from "@/data/providers";
 import {
   resolveSkillInvocation,
@@ -30,6 +31,10 @@ export interface DraftAgent {
   customAgentId?: string;
   /** Base branch to fork from. */
   base: string;
+  /** GitHub issue number (as text) this draft was started from, via the Home
+   *  inbox's "Start work". Carried to the backend at spawn so the agent's PR
+   *  closes it. Undefined for a plain draft. */
+  issueRef?: string;
 }
 
 const NEW_DRAFT_SELECTION_SETTING = "newDraftSelection";
@@ -100,6 +105,44 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
       drafts: [draft, ...s.drafts],
       activeDraftId: draft.id,
       selectedAgentId: null,
+    }));
+    get().setLastRepoPath(repoPath);
+  },
+
+  startWorkFromIssue: async (repoPath, issue) => {
+    const {
+      workspace,
+      drafts,
+      newDraftProvider,
+      newDraftModel,
+      newDraftCustomAgentId,
+      modelsByAgent,
+    } = get();
+    const used = [...usedNames(workspace, drafts)];
+    const name = await api.allocateDraftName(used);
+    const selection = normalizeDraftSelection(newDraftProvider, newDraftModel, modelsByAgent);
+    const customAgentId = get().customAgents.some((a) => a.id === newDraftCustomAgentId)
+      ? newDraftCustomAgentId
+      : undefined;
+    const draft: DraftAgent = {
+      id: `draft-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      repoPath,
+      name,
+      provider: selection.provider,
+      model: selection.model,
+      customAgentId,
+      base: "main",
+      issueRef: String(issue.number),
+    };
+    // Seed the composer for this draft (read as its initial text on mount) with
+    // the issue brief, so "Start work" lands fully prefilled — the user reviews
+    // and hits ↵ to launch (two clicks from issue to working agent).
+    get().setComposerDraft(draft.id, composeIssueBrief(issue));
+    set((s) => ({
+      drafts: [draft, ...s.drafts],
+      activeDraftId: draft.id,
+      selectedAgentId: null,
+      selectedRunId: null,
     }));
     get().setLastRepoPath(repoPath);
   },
@@ -214,6 +257,9 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
         draft.base,
         skills,
         mcpServers,
+        // Tags the workspace with its originating issue so the agent's PR
+        // closes it (backend appends `Closes #N` to the primary repo's PR).
+        draft.issueRef,
       );
       const fresh = await api.getWorkspace();
       set((state) => {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -619,6 +619,11 @@ export interface DraftsSlice {
 
   // drafts
   createDraft: (repoPath: string) => Promise<void>;
+  /** Start a draft from a Home-inbox GitHub issue: opens a new draft on the
+   *  issue's repo, seeds the composer with the issue brief (title + body + url
+   *  + a suggested branch), and tags it with the issue number so the agent's
+   *  PR closes it. Lands the user in the composer, ready to launch. */
+  startWorkFromIssue: (repoPath: string, issue: import("@/api").IssueSummary) => Promise<void>;
   /** Remember the last project an agent was started in and persist it. */
   setLastRepoPath: (repoPath: string) => void;
   updateDraft: (id: string, patch: Partial<DraftAgent>) => void;


### PR DESCRIPTION
## What

The final segment of the coherency roadmap: GitHub issues flow into Fletch as work. Stacked on #469 (needs its composer toggle) — **base is `feat/workflow-cockpit`; retarget to `main` once #469 merges.**

### `issue_list` backend

- REST `GET /repos/{owner}/{repo}/issues` following `pr_list`'s pattern: PRs filtered out (the endpoint returns both), open state, assigned/recent first. Degrades to `Ok(None)` on any failure like the other read ops; never a user-facing error.
- `rest_get_observed` added to the client so REST polls arm the same rate-limit backoff as GraphQL; `is_backing_off()` respected.

### Issue inbox on Home

- A deliberately quieter section below the Mission Control review queue: compact rows (number, title, label chips, updated hint), 120s GitHub-gated `usePoll`, parallel per-repo fetch. No token / no GitHub repos / no issues → the section self-hides; never a parked spinner.
- **Start work**: prefills the new-task composer via the drafts store — title + body + URL composed into the brief, suggested branch name `kind/number-slug` (kind inferred from labels: feat/chore/fix) visible and editable in the brief, with the Quick agent | Pipeline toggle intact. Issue → working agent in two clicks.

### Closes #N

- New nullable `workspaces.issue_ref` column (migration 0023, following the established nullable-column pattern), set when a session originates from an issue. Forks and workflow-step spawns deliberately carry `None` (a fork is a fresh line of work; two workspaces shouldn't both claim one issue).
- The trailer is composed into the PR body inside `rpc/git.rs::open_pr` before `pr_create` — the agent can't forget it, and both the delegated and autonomous open-PR paths are covered. Primary repo only; idempotent and number-bounded (`#12` never matches `#123`).

## Testing

- Rust: `cargo fmt --check` clean; clippy with CI flags clean; `cargo test` → 959 passed (new: issue parsing/PR filtering, Closes-trailer append/idempotency/bounding).
- Frontend: typecheck clean; vitest → 482 passed (9 new inbox tests: row derivation, branch-name scheme, brief composition); build succeeds; biome clean on touched files.

## Notes

- Out of scope per the hand-off (V2): webhooks, issue daemons, issue writeback.
- Pipeline-path `Closes #N` deferred: workflow finalize is a separate open-PR code path and step agents carry no issue ref; the Quick-agent path (the primary intake flow) is fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)