### PR TITLE
feat(followups): verify-on-turn-end, require-tests builder toggle, pipeline Closes #N

### DIFF
--- a/src-tauri/migrations/0024_wf_run_issue_ref.sql
+++ b/src-tauri/migrations/0024_wf_run_issue_ref.sql
@@ -1,0 +1,9 @@
+-- The GitHub issue a workflow run was started from, captured when the user
+-- hits "Start work" on a Home-inbox issue and launches a Pipeline (rather than
+-- a Quick agent). Stored as the bare issue number (text) for the run's repo —
+-- enough to append a `Closes #<n>` trailer to the PR the run's finalize path
+-- opens, so merging that PR closes the originating issue.
+--
+-- NULL for a normal launch that didn't originate from an issue. Mirrors
+-- `workspaces.issue_ref` (migration 0023) for the pipeline path.
+ALTER TABLE wf_run ADD COLUMN issue_ref TEXT;

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -151,6 +151,7 @@ const MIGRATIONS: &[&str] = &[
     include_str!("../migrations/0021_session_forked_context.sql"),
     include_str!("../migrations/0022_repo_label.sql"),
     include_str!("../migrations/0023_workspace_issue_ref.sql"),
+    include_str!("../migrations/0024_wf_run_issue_ref.sql"),
 ];
 
 fn get_migrations() -> Migrations<'static> {

--- a/src-tauri/src/github/closes.rs
+++ b/src-tauri/src/github/closes.rs
@@ -1,0 +1,138 @@
+//! Shared `Closes #<n>` PR-body trailer helpers.
+//!
+//! An issue-originated workspace (a Home-inbox "Start work") gets its PR body
+//! stamped with a `Closes #<n>` trailer so merging the PR closes the issue —
+//! reliably, without relying on the agent to remember. Two open-PR paths need
+//! the identical, strict semantics: the ad-hoc agent dispatcher
+//! (`crate::rpc::git`) and the workflow finalize publish (`crate::workflow`).
+//! The helpers live here so both re-use one implementation.
+
+/// GitHub's closing keywords (case-insensitive). Only one of these directly
+/// preceding the reference makes merging the PR close the issue — a bare
+/// mention (`see #12`) links but never closes.
+const CLOSING_KEYWORDS: [&str; 9] = [
+    "close", "closes", "closed", "fix", "fixes", "fixed", "resolve", "resolves", "resolved",
+];
+
+/// True when `body` already contains a CLOSING reference to issue `#number`
+/// (`fixes #12`, `Closes: #12`, …) — bounded so `#12` doesn't match `#123` (a
+/// trailing digit means a different issue). A mere mention does NOT count: it
+/// wouldn't close the issue, so the trailer is still required. Used to keep
+/// the `Closes` trailer idempotent when the agent already wrote one.
+pub(crate) fn closes_issue(body: &str, number: u32) -> bool {
+    let needle = format!("#{number}");
+    let mut offset = 0;
+    while let Some(pos) = body[offset..].find(&needle) {
+        let at = offset + pos;
+        let after = &body[at + needle.len()..];
+        let bounded = after.chars().next().map_or(true, |c| !c.is_ascii_digit());
+        if bounded && ends_with_closing_keyword(&body[..at]) {
+            return true;
+        }
+        offset = at + needle.len();
+    }
+    false
+}
+
+/// Does the text leading up to a `#N` reference end with a closing keyword
+/// plus a real separator (`fixes #12`, `Fixes: #12`)? Strict on both the
+/// keyword (`prefixes #12` is not a match) and the separator (GitHub does not
+/// document the glued `fixes#12` form) — a false negative merely appends a
+/// redundant trailer, while a false positive would leave the issue open.
+fn ends_with_closing_keyword(before: &str) -> bool {
+    let trimmed = before.trim_end();
+    if trimmed.len() == before.len() {
+        return false;
+    }
+    let trimmed = trimmed.strip_suffix(':').unwrap_or(trimmed);
+    let word_start = trimmed
+        .rfind(|c: char| !c.is_ascii_alphabetic())
+        .map_or(0, |i| i + 1);
+    let word = &trimmed[word_start..];
+    CLOSING_KEYWORDS
+        .iter()
+        .any(|k| word.eq_ignore_ascii_case(k))
+}
+
+/// Append a `Closes #<n>` trailer to a PR body for an issue-originated
+/// workspace, unless the body already CLOSES the issue (a bare mention is not
+/// enough). `None` leaves the body untouched (the normal, non-issue spawn). A
+/// blank body becomes just the trailer.
+pub(crate) fn with_closes_trailer(body: &str, close_issue: Option<u32>) -> String {
+    let Some(number) = close_issue else {
+        return body.to_string();
+    };
+    if closes_issue(body, number) {
+        return body.to_string();
+    }
+    let trailer = format!("Closes #{number}");
+    let trimmed = body.trim_end();
+    if trimmed.is_empty() {
+        trailer
+    } else {
+        format!("{trimmed}\n\n{trailer}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn closes_trailer_appends_only_when_issue_set() {
+        // No issue → body untouched.
+        assert_eq!(
+            with_closes_trailer("Fixes the thing", None),
+            "Fixes the thing"
+        );
+        // Issue set → trailer appended after a blank line.
+        assert_eq!(
+            with_closes_trailer("Fixes the thing", Some(42)),
+            "Fixes the thing\n\nCloses #42"
+        );
+        // Blank body → just the trailer.
+        assert_eq!(with_closes_trailer("   ", Some(7)), "Closes #7");
+    }
+
+    #[test]
+    fn closes_trailer_is_idempotent_and_number_bounded() {
+        // Already CLOSED by the body → left as-is (no duplicate).
+        assert_eq!(
+            with_closes_trailer("Work.\n\nCloses #42", Some(42)),
+            "Work.\n\nCloses #42"
+        );
+        // A superstring number must NOT count (#12 vs #123).
+        assert!(!closes_issue("Closes #123", 12));
+        assert!(closes_issue("Closes #123", 123));
+        assert_eq!(
+            with_closes_trailer("Refs #120 and #121", Some(12)),
+            "Refs #120 and #121\n\nCloses #12"
+        );
+    }
+
+    #[test]
+    fn closes_trailer_requires_a_closing_keyword_not_a_mention() {
+        // A bare mention links but doesn't close — the trailer must still land.
+        assert!(!closes_issue("see #42, thanks", 42));
+        assert_eq!(
+            with_closes_trailer("Follow-up to the report in #42.", Some(42)),
+            "Follow-up to the report in #42.\n\nCloses #42"
+        );
+        // GitHub's documented closing spellings count (case, optional colon).
+        for body in [
+            "fixes #42",
+            "Fixes: #42",
+            "RESOLVED #42",
+            "This should fix #42 for good",
+        ] {
+            assert!(closes_issue(body, 42), "should close: {body}");
+        }
+        // A keyword-suffixed word is not a keyword, and a keyword glued to the
+        // reference (no separator) is not a documented closing form — both must
+        // still receive the trailer.
+        assert!(!closes_issue("prefixes #42", 42));
+        assert!(!closes_issue("sunfixed #42", 42));
+        assert!(!closes_issue("close#42", 42));
+        assert!(!closes_issue("Fixes:#42", 42));
+    }
+}

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -15,12 +15,14 @@
 //! same ones that parsed gh's output.
 
 pub mod client;
+pub mod closes;
 
 use std::path::Path;
 
 use serde_json::{json, Value};
 
 pub use client::{git_auth_env, set_token, TOKEN_SETTING};
+pub(crate) use closes::with_closes_trailer;
 
 use crate::error::{Error, Result};
 

--- a/src-tauri/src/rpc/git.rs
+++ b/src-tauri/src/rpc/git.rs
@@ -154,73 +154,6 @@ fn with_repo(mut payload: Value, subdir: &Option<String>) -> Value {
     payload
 }
 
-/// GitHub's closing keywords (case-insensitive). Only one of these directly
-/// preceding the reference makes merging the PR close the issue — a bare
-/// mention (`see #12`) links but never closes.
-const CLOSING_KEYWORDS: [&str; 9] = [
-    "close", "closes", "closed", "fix", "fixes", "fixed", "resolve", "resolves", "resolved",
-];
-
-/// True when `body` already contains a CLOSING reference to issue `#number`
-/// (`fixes #12`, `Closes: #12`, …) — bounded so `#12` doesn't match `#123` (a
-/// trailing digit means a different issue). A mere mention does NOT count: it
-/// wouldn't close the issue, so the trailer is still required. Used to keep
-/// the `Closes` trailer idempotent when the agent already wrote one.
-fn closes_issue(body: &str, number: u32) -> bool {
-    let needle = format!("#{number}");
-    let mut offset = 0;
-    while let Some(pos) = body[offset..].find(&needle) {
-        let at = offset + pos;
-        let after = &body[at + needle.len()..];
-        let bounded = after.chars().next().map_or(true, |c| !c.is_ascii_digit());
-        if bounded && ends_with_closing_keyword(&body[..at]) {
-            return true;
-        }
-        offset = at + needle.len();
-    }
-    false
-}
-
-/// Does the text leading up to a `#N` reference end with a closing keyword
-/// plus a real separator (`fixes #12`, `Fixes: #12`)? Strict on both the
-/// keyword (`prefixes #12` is not a match) and the separator (GitHub does not
-/// document the glued `fixes#12` form) — a false negative merely appends a
-/// redundant trailer, while a false positive would leave the issue open.
-fn ends_with_closing_keyword(before: &str) -> bool {
-    let trimmed = before.trim_end();
-    if trimmed.len() == before.len() {
-        return false;
-    }
-    let trimmed = trimmed.strip_suffix(':').unwrap_or(trimmed);
-    let word_start = trimmed
-        .rfind(|c: char| !c.is_ascii_alphabetic())
-        .map_or(0, |i| i + 1);
-    let word = &trimmed[word_start..];
-    CLOSING_KEYWORDS
-        .iter()
-        .any(|k| word.eq_ignore_ascii_case(k))
-}
-
-/// Append a `Closes #<n>` trailer to a PR body for an issue-originated
-/// workspace, unless the body already CLOSES the issue (a bare mention is not
-/// enough). `None` leaves the body untouched (the normal, non-issue spawn). A
-/// blank body becomes just the trailer.
-fn with_closes_trailer(body: &str, close_issue: Option<u32>) -> String {
-    let Some(number) = close_issue else {
-        return body.to_string();
-    };
-    if closes_issue(body, number) {
-        return body.to_string();
-    }
-    let trailer = format!("Closes #{number}");
-    let trimmed = body.trim_end();
-    if trimmed.is_empty() {
-        trailer
-    } else {
-        format!("{trimmed}\n\n{trailer}")
-    }
-}
-
 impl RpcDispatcher for GitDispatcher {
     fn dispatch<'a>(
         &'a self,
@@ -317,7 +250,7 @@ impl GitDispatcher {
         let closes = (t.subdir == self.default_subdir)
             .then_some(self.close_issue)
             .flatten();
-        let body_owned = with_closes_trailer(body_arg, closes);
+        let body_owned = crate::github::with_closes_trailer(body_arg, closes);
         let body = body_owned.as_str();
         let requested = arg_branch(args);
 
@@ -575,64 +508,6 @@ mod tests {
 
     fn dispatcher(cwd: &Path) -> GitDispatcher {
         GitDispatcher::new(cwd.to_path_buf(), "main".to_string())
-    }
-
-    #[test]
-    fn closes_trailer_appends_only_when_issue_set() {
-        // No issue → body untouched.
-        assert_eq!(
-            with_closes_trailer("Fixes the thing", None),
-            "Fixes the thing"
-        );
-        // Issue set → trailer appended after a blank line.
-        assert_eq!(
-            with_closes_trailer("Fixes the thing", Some(42)),
-            "Fixes the thing\n\nCloses #42"
-        );
-        // Blank body → just the trailer.
-        assert_eq!(with_closes_trailer("   ", Some(7)), "Closes #7");
-    }
-
-    #[test]
-    fn closes_trailer_is_idempotent_and_number_bounded() {
-        // Already CLOSED by the body → left as-is (no duplicate).
-        assert_eq!(
-            with_closes_trailer("Work.\n\nCloses #42", Some(42)),
-            "Work.\n\nCloses #42"
-        );
-        // A superstring number must NOT count (#12 vs #123).
-        assert!(!closes_issue("Closes #123", 12));
-        assert!(closes_issue("Closes #123", 123));
-        assert_eq!(
-            with_closes_trailer("Refs #120 and #121", Some(12)),
-            "Refs #120 and #121\n\nCloses #12"
-        );
-    }
-
-    #[test]
-    fn closes_trailer_requires_a_closing_keyword_not_a_mention() {
-        // A bare mention links but doesn't close — the trailer must still land.
-        assert!(!closes_issue("see #42, thanks", 42));
-        assert_eq!(
-            with_closes_trailer("Follow-up to the report in #42.", Some(42)),
-            "Follow-up to the report in #42.\n\nCloses #42"
-        );
-        // GitHub's documented closing spellings count (case, optional colon).
-        for body in [
-            "fixes #42",
-            "Fixes: #42",
-            "RESOLVED #42",
-            "This should fix #42 for good",
-        ] {
-            assert!(closes_issue(body, 42), "should close: {body}");
-        }
-        // A keyword-suffixed word is not a keyword, and a keyword glued to the
-        // reference (no separator) is not a documented closing form — both must
-        // still receive the trailer.
-        assert!(!closes_issue("prefixes #42", 42));
-        assert!(!closes_issue("sunfixed #42", 42));
-        assert!(!closes_issue("close#42", 42));
-        assert!(!closes_issue("Fixes:#42", 42));
     }
 
     #[tokio::test]

--- a/src-tauri/src/supervisor/events.rs
+++ b/src-tauri/src/supervisor/events.rs
@@ -357,3 +357,28 @@ pub(super) fn emit_run_port(app: &AppHandle, agent_id: &str, port: u16) {
 pub(super) fn emit_workspace_changed(app: &AppHandle) {
     emit(app, "workspace:changed", ());
 }
+
+#[derive(Clone, serde::Serialize)]
+struct VerificationReportPayload {
+    agent_id: String,
+    report: crate::verify::VerificationReport,
+}
+
+/// A turn-end verification (opt-in per project) finished for an ad-hoc agent —
+/// its Mission Control card renders a tests chip from this report. Fire-and-
+/// forget from `trigger_turn_end_verification`; the frontend stores the latest
+/// per agent.
+pub(super) fn emit_verification(
+    app: &AppHandle,
+    agent_id: &str,
+    report: crate::verify::VerificationReport,
+) {
+    emit(
+        app,
+        "verify:report",
+        VerificationReportPayload {
+            agent_id: agent_id.to_string(),
+            report,
+        },
+    );
+}

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -105,6 +105,12 @@ pub struct Supervisor {
     /// never persisted (see `session_sync`). Behind an `Arc` so the fire-and-
     /// forget sync task can hold it without borrowing `self`.
     pub sync_health: Arc<Mutex<HashMap<String, session_sync::SyncHealth>>>,
+    /// Agent ids with a turn-end verification currently running, so a fresh turn
+    /// end never launches a second concurrent verify for the same agent (they'd
+    /// race on the checkout). Cleared when the background task finishes. Behind
+    /// an `Arc` so the fire-and-forget task can drop its entry without borrowing
+    /// `self`. See `trigger_turn_end_verification` in `session_sync`.
+    pub verify_inflight: Arc<Mutex<HashSet<String>>>,
     /// Per-agent RPC dispatchers, so the mailbox can be drained on demand
     /// (`settle_agent_rpc`) in addition to the polling watcher — the scheduler
     /// drains a step agent's mailbox at turn end so a `wf_ask` is dispatched
@@ -134,6 +140,7 @@ impl Supervisor {
             message_queue: Mutex::new(MessageQueue::new()),
             interrupted: Mutex::new(HashSet::new()),
             sync_health: Arc::new(Mutex::new(HashMap::new())),
+            verify_inflight: Arc::new(Mutex::new(HashSet::new())),
             rpc_dispatchers: Mutex::new(HashMap::new()),
             // Capacity is generous: a lagging subscriber gets `Lagged` and
             // re-reads `status_of`, so overflow degrades to a resync, never a
@@ -559,6 +566,10 @@ fn transition_active(sup: &Supervisor, app: &AppHandle, agent_id: &str, new: Age
             // session_records. Idempotent + reader-gated, so it's a cheap no-op
             // for agents without a reader.
             sup.trigger_session_sync(app.clone(), agent_id.to_string());
+            // Opt-in per project (OFF by default): run verification on the
+            // agent's checkout so its Mission Control card carries test
+            // evidence. Ad-hoc agents only, fire-and-forget, never blocks.
+            sup.trigger_turn_end_verification(app.clone(), agent_id.to_string());
             drain_pending_bin_respawn(sup, app, agent_id);
             drain_message_queue(sup, app, agent_id);
         }

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -8,11 +8,21 @@ use crate::agent::per_turn_descriptor;
 use crate::github::{PrState, PrStatus};
 use crate::workspace::{repo_checkout_path, AgentRecord, AgentView, TrackedRepo, WorkspaceManager};
 
-use super::events::{emit_pr_state, emit_session_records_appended, emit_session_sync_health};
+use super::events::{
+    emit_pr_state, emit_session_records_appended, emit_session_sync_health, emit_verification,
+};
 use super::Supervisor;
 
 use parking_lot::Mutex;
 use std::collections::HashMap;
+
+/// Wall-clock ceiling for a turn-end verification, matching the ad-hoc
+/// `run_verification` command (spec §9.4 uses the same 15-minute bound).
+const TURN_END_VERIFY_TIMEOUT_SECS: u64 = 900;
+
+/// Project setting key (stored by the frontend Project Settings toggle) that
+/// opts a project into running verification at every ad-hoc turn end.
+const VERIFY_ON_TURN_END_KEY: &str = "verify.on_turn_end";
 
 impl Supervisor {
     /// Synchronously ingest the agent's transcript into session_records (used
@@ -91,6 +101,78 @@ impl Supervisor {
                 .await
                 .and_then(|(pr, bound)| bound.then_some(pr));
             emit_pr_state(&app, &agent_id, state);
+        });
+    }
+
+    /// Fire-and-forget turn-end verification for an ad-hoc agent, gated on the
+    /// project's opt-in `verify.on_turn_end` flag. Runs the same engine as the
+    /// `run_verification` command on the agent's primary checkout and emits
+    /// `verify:report`, so the agent's Mission Control card arrives with test
+    /// evidence (workflow items already carry gate evidence). Never blocks the
+    /// turn; any failure is silent.
+    ///
+    /// Guardrails (each a cheap early return): only ad-hoc agents (a workflow
+    /// step agent has gates — `owner_run_id` set → skip), only when the flag is
+    /// on, and never two at once for the same agent (they'd race on the
+    /// checkout). Called only on a normal Idle transition (not stop/archive).
+    pub fn trigger_turn_end_verification(&self, app: AppHandle, agent_id: String) {
+        let Ok(record) = self.workspace.agent(&agent_id) else {
+            return;
+        };
+        // Workflow step agents have their own gate evidence — skip them.
+        if record.owner_run_id.is_some() {
+            return;
+        }
+        // A user-stopped turn also converges on Idle, but its checkout is a
+        // half-done interruption — not a turn to certify. The flag is still set
+        // here (drain_message_queue consumes it after us), so peek without
+        // clearing.
+        if self.interrupted.lock().contains(&agent_id) {
+            return;
+        }
+        let project_id = record.project_id;
+        if project_id.is_empty() {
+            return;
+        }
+        // Opt-in per project, OFF by default.
+        let enabled = self
+            .workspace
+            .project_setting(&project_id, VERIFY_ON_TURN_END_KEY)
+            .is_some_and(|v| matches!(v.trim(), "1" | "true"));
+        if !enabled {
+            return;
+        }
+        // Primary repo's checkout (the repo the agent was spawned against).
+        let Some(primary) = record.repos.first() else {
+            return;
+        };
+        let Ok(checkout) = repo_checkout_path(&agent_id, &primary.subdir) else {
+            return;
+        };
+        // Debounce: skip if a verification for this agent is already running.
+        if !self.verify_inflight.lock().insert(agent_id.clone()) {
+            return;
+        }
+        // Project command overrides layer over detection, same as the ad-hoc
+        // `run_verification` command and the workflow tests gate.
+        let setting = |key: &str| self.workspace.project_setting(&project_id, key);
+        let verifier = match crate::verify::Verifier::new(
+            setting("run.test"),
+            setting("run.install"),
+            setting("run.lint"),
+            TURN_END_VERIFY_TIMEOUT_SECS,
+        ) {
+            Ok(v) => v,
+            Err(_) => {
+                self.verify_inflight.lock().remove(&agent_id);
+                return;
+            }
+        };
+        let inflight = self.verify_inflight.clone();
+        tauri::async_runtime::spawn(async move {
+            let report = verifier.verify(&checkout).await;
+            inflight.lock().remove(&agent_id);
+            emit_verification(&app, &agent_id, report);
         });
     }
 }

--- a/src-tauri/src/workflow/scheduler.rs
+++ b/src-tauri/src/workflow/scheduler.rs
@@ -144,6 +144,11 @@ impl WorkflowService {
         // entry step's prompt only (see `drive_run_inner` / `execute_step`) — the
         // same form a chat message delivers them, scoped to the first agent.
         attachments: Vec<String>,
+        // The GitHub issue this run was started from (Home-inbox "Start work" →
+        // Pipeline), as a bare issue number. Threaded onto the run row so the
+        // finalize open-PR path can append a `Closes #<n>` trailer. `None` for a
+        // normal launch — backward-compatible with today's behavior.
+        issue_ref: Option<String>,
     ) -> Result<String> {
         let _lifecycle_guard = self.lifecycle.lock().await;
         let run_id = format!("run-{}", uuid::Uuid::new_v4());
@@ -192,8 +197,8 @@ impl WorkflowService {
             conn.execute(
                 "INSERT INTO wf_run (id, definition_id, parent_run_id, name, spec_json, task,
                      project_id, repo_path, run_dir, branch, base_sha, base_branch, status,
-                     budgets_json, spent_json, created_at, updated_at)
-                 VALUES (?1, ?2, NULL, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 'pending', ?12, '{}', ?13, ?13)",
+                     budgets_json, spent_json, created_at, updated_at, issue_ref)
+                 VALUES (?1, ?2, NULL, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 'pending', ?12, '{}', ?13, ?13, ?14)",
                 rusqlite::params![
                     run_id,
                     definition_id,
@@ -208,6 +213,7 @@ impl WorkflowService {
                     base_branch,
                     budgets_json,
                     now,
+                    issue_ref,
                 ],
             )
             .map_err(|e| Error::Other(e.to_string()))?;
@@ -766,6 +772,9 @@ struct RunEssentials {
     status: String,
     budgets_json: String,
     spent_json: String,
+    /// The GitHub issue this run was started from (bare number), or `None`.
+    /// Drives the finalized PR's `Closes #<n>` trailer.
+    issue_ref: Option<String>,
 }
 
 /// Drive one run to a terminal or paused state. Any error bubbling out marks the
@@ -1168,13 +1177,20 @@ async fn finalize_run(
         .or_else(|| Some(run.base_branch.clone()).filter(|b| !b.is_empty()))
         .unwrap_or_else(|| "main".to_string());
     let title = format!("wf: {}", spec.name);
+    // A run started from a Home-inbox issue carries its number; append a
+    // `Closes #<n>` trailer so merging the finalized PR closes the issue. The
+    // run repo is inherently the issue's repo (single-repo), so no subdir
+    // gating — unlike the multi-repo agent path. Idempotent; `None` (a normal
+    // launch) leaves the empty body untouched.
+    let close_issue = run.issue_ref.as_deref().and_then(|s| s.trim().parse().ok());
+    let body = crate::github::with_closes_trailer("", close_issue);
     let outcome = gitops::finalize(
         run_repo,
         &final_ref,
         &run.branch,
         &base,
         &title,
-        "",
+        &body,
         fin.open_pr,
     )
     .await?;
@@ -5644,7 +5660,7 @@ fn project_setting(conn: &Connection, project_id: &str, key: &str) -> Option<Str
 fn load_run(conn: &Connection, run_id: &str) -> Result<RunEssentials> {
     conn.query_row(
         "SELECT spec_json, task, project_id, repo_path, run_dir, branch, base_sha, base_branch,
-                status, budgets_json, spent_json
+                status, budgets_json, spent_json, issue_ref
          FROM wf_run WHERE id = ?1",
         [run_id],
         |r| {
@@ -5660,6 +5676,7 @@ fn load_run(conn: &Connection, run_id: &str) -> Result<RunEssentials> {
                 status: r.get(8)?,
                 budgets_json: r.get(9)?,
                 spent_json: r.get(10)?,
+                issue_ref: r.get(11)?,
             })
         },
     )
@@ -6371,6 +6388,10 @@ pub async fn wf_launch(
     base_branch: Option<String>,
     base_sha: Option<String>,
     attachments: Vec<String>,
+    // Set when the launch originates from a Home-inbox issue (Pipeline mode);
+    // carried onto the run row so its finalized PR closes the issue. `None` for
+    // a normal launch.
+    issue_ref: Option<String>,
     service: Svc<'_>,
     supervisor: tauri::State<'_, Arc<Supervisor>>,
 ) -> std::result::Result<String, String> {
@@ -6393,6 +6414,7 @@ pub async fn wf_launch(
             base_branch,
             base_sha,
             attachments,
+            issue_ref,
         )
         .await
         .map_err(|e| e.to_string())

--- a/src/api.ts
+++ b/src/api.ts
@@ -297,6 +297,13 @@ export interface PrStateChangedEvent {
   state: PrState | null;
 }
 
+/** A turn-end verification finished for an ad-hoc agent (opt-in per project) —
+ *  the Mission Control card renders a tests chip from this report. */
+export interface VerificationReportEvent {
+  agent_id: string;
+  report: VerificationReport;
+}
+
 /** Lightweight PR summary for the composer's "#" mention autocomplete. */
 export interface PrSummary {
   number: number;
@@ -942,6 +949,10 @@ export const api = {
     /** Explicit fork-point commit (promote-to-workflow). Wins over `baseBranch`
      *  for the fork point; leave undefined for a normal branch-based launch. */
     baseSha?: string,
+    /** GitHub issue number (as text) this run was started from, via the Home
+     *  inbox "Start work" in Pipeline mode. The finalized PR closes it
+     *  (backend appends `Closes #N`). Undefined for a normal launch. */
+    issueRef?: string,
   ) =>
     invoke<string>("wf_launch", {
       spec,
@@ -952,6 +963,7 @@ export const api = {
       baseBranch,
       baseSha,
       attachments,
+      issueRef,
     }),
   /** Cancel a run: stops the live attempt's agent and marks the run canceled. */
   wfCancel: (runId: string) => invoke<void>("wf_cancel", { runId }),
@@ -1265,6 +1277,12 @@ export function onWorkspaceChanged(cb: () => void): Promise<UnlistenFn> {
 
 export function onPrStateChanged(cb: (e: PrStateChangedEvent) => void): Promise<UnlistenFn> {
   return listen<PrStateChangedEvent>("pr:state_changed", (event) => cb(event.payload));
+}
+
+export function onVerificationReport(
+  cb: (e: VerificationReportEvent) => void,
+): Promise<UnlistenFn> {
+  return listen<VerificationReportEvent>("verify:report", (event) => cb(event.payload));
 }
 
 export function onRunOutput(cb: (e: RunOutputEvent) => void): Promise<UnlistenFn> {

--- a/src/components/ProjectSettings/VerifySection.tsx
+++ b/src/components/ProjectSettings/VerifySection.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import { Toggle } from "@/components/Settings/Toggle";
+import {
+  deleteProjectSetting,
+  getProjectSettings,
+  setProjectSetting,
+} from "@/storage/projectSettings";
+
+/** Project-settings key the backend turn-end hook reads (Rust
+ *  `VERIFY_ON_TURN_END_KEY`). Keep the string in sync with that constant. */
+const KEY = "verify.on_turn_end";
+
+/** Opt-in: run the project's checks after each ad-hoc agent turn so its Mission
+ *  Control card arrives with a tests verdict. OFF by default — it costs a full
+ *  install/test/lint pass per turn, so it's the user's call per project. */
+export function VerifySection({ projectId }: { projectId: string }) {
+  const [on, setOn] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getProjectSettings(projectId)
+      .then((all) => {
+        if (!cancelled) setOn(all[KEY] === "1" || all[KEY] === "true");
+      })
+      .catch((e) => console.error("load verify.on_turn_end failed", e));
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+
+  const toggle = (next: boolean) => {
+    setOn(next);
+    const write = next
+      ? setProjectSetting(projectId, KEY, "1")
+      : deleteProjectSetting(projectId, KEY);
+    write.catch((e) => console.error("save verify.on_turn_end failed", e));
+  };
+
+  return (
+    <section className="ps-section">
+      <header className="ps-section-h">
+        <h2 className="ps-section-t text-lg">Verify on turn end</h2>
+        <p className="ps-section-lead text-sm">
+          When on, each ad-hoc agent&rsquo;s turn end runs your project&rsquo;s install / test /
+          lint checks on its checkout, so its Mission Control card shows a tests verdict. Off by
+          default — it runs a full check pass after every turn.
+        </p>
+      </header>
+
+      <div className="ps-field ps-name-row">
+        <label className="ps-label text-sm" htmlFor="ps-verify">
+          Run checks after each turn
+        </label>
+        <Toggle value={on} onChange={toggle} />
+      </div>
+    </section>
+  );
+}

--- a/src/components/ProjectSettings/index.tsx
+++ b/src/components/ProjectSettings/index.tsx
@@ -10,6 +10,7 @@ import { EnvVarsSection } from "./EnvVarsSection";
 import { GeneralSection } from "./GeneralSection";
 import { ProjectPulse } from "./ProjectPulse";
 import { RunEnvSection } from "./RunEnvSection";
+import { VerifySection } from "./VerifySection";
 
 interface Loaded {
   projectId: string;
@@ -114,6 +115,7 @@ export function ProjectSettings({ repoPath }: { repoPath: string }) {
                 initialOverrides={loaded.overrides}
               />
               <EnvVarsSection projectId={loaded.projectId} repoPath={repoPath} />
+              <VerifySection projectId={loaded.projectId} />
               <DeleteSection projectId={loaded.projectId} projectName={name} />
             </div>
           )}

--- a/src/components/Workspace/EmptyWorkspace.tsx
+++ b/src/components/Workspace/EmptyWorkspace.tsx
@@ -175,6 +175,7 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
                 name={draft.name}
                 projectId={projectId}
                 defaultWorkflowId={defaultWorkflowId}
+                issueRef={draft.issueRef}
               />
             ) : (
               <Composer

--- a/src/components/Workspace/MissionControl/EvidenceChips.tsx
+++ b/src/components/Workspace/MissionControl/EvidenceChips.tsx
@@ -20,6 +20,23 @@ export function EvidenceChips({ item }: { item: ReviewItem }) {
       </span>
     ) : null,
     item.checks ? <ChecksChip key="checks" checks={item.checks} /> : null,
+    // Turn-end verification (§ opt-in): a quiet tests verdict, tinted only on a
+    // definitive pass/fail — `item.tests` is undefined while unknown/running,
+    // so nothing renders (never a fake state).
+    item.tests ? (
+      <span
+        key="tests"
+        className={`mc-chip ${item.tests === "passed" ? "mc-chip-ok" : "mc-chip-fail"}`}
+        title={
+          item.tests === "passed"
+            ? "Project tests passed at the last turn end"
+            : "Project tests failed at the last turn end"
+        }
+      >
+        <Icon name="flask" size={11} />
+        tests {item.tests === "passed" ? "✓" : "✗"}
+      </span>
+    ) : null,
     typeof item.unresolvedComments === "number" && item.unresolvedComments > 0 ? (
       <span key="comments" className="mc-chip">
         <Icon name="bot" size={11} />

--- a/src/components/Workspace/MissionControl/queue.test.ts
+++ b/src/components/Workspace/MissionControl/queue.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
-import type { AgentRecord, GitMeta, PrChecks, PrComments, PrState, ShortStats, WfRun } from "@/api";
+import type {
+  AgentRecord,
+  CheckOutcome,
+  GitMeta,
+  PrChecks,
+  PrComments,
+  PrState,
+  ShortStats,
+  VerificationReport,
+  WfRun,
+} from "@/api";
 import { BUCKET, buildReviewQueue, type QueueInput } from "./queue";
 
 // ── fixtures ──────────────────────────────────────────────────────────────────
@@ -89,6 +99,11 @@ const meta = (over: Partial<GitMeta>): GitMeta => ({
   ...over,
 });
 
+/** A verification report whose `test` check has the given outcome. */
+const report = (testOutcome: CheckOutcome): VerificationReport => ({
+  checks: [{ name: "test", command: "npm test", outcome: testOutcome, duration_ms: 1, tail: [] }],
+});
+
 function input(over: Partial<QueueInput>): QueueInput {
   return {
     agents: [],
@@ -98,6 +113,7 @@ function input(over: Partial<QueueInput>): QueueInput {
     prStates: {},
     prChecks: {},
     prComments: {},
+    verificationReports: {},
     runs: [],
     dismissed: {},
     ...over,
@@ -300,6 +316,65 @@ describe("buildReviewQueue", () => {
     });
     expect(grown).toHaveLength(1);
     expect(grown[0].id).toBe("agent:a");
+  });
+
+  // ── tests evidence (verify on turn end) ───────────────────────────────────
+
+  it("feeds a passing/failing tests verdict onto an existing card", () => {
+    const base = {
+      agents: [agent({ id: "a" })],
+      unseenResults: { a: true },
+      gitShortstats: { a: stats(4, 2) },
+    };
+    const pass = buildReviewQueue(input({ ...base, verificationReports: { a: report("passed") } }));
+    expect(pass).toHaveLength(1);
+    expect(pass[0].tests).toBe("passed");
+
+    for (const outcome of ["failed", "timed_out", "setup_failed"] as const) {
+      const q = buildReviewQueue(input({ ...base, verificationReports: { a: report(outcome) } }));
+      expect(q[0].tests).toBe("failed");
+    }
+  });
+
+  it("shows no tests verdict when unknown, skipped, or absent (never a fake state)", () => {
+    const base = {
+      agents: [agent({ id: "a" })],
+      unseenResults: { a: true },
+      gitShortstats: { a: stats(4, 2) },
+    };
+    // No report at all.
+    expect(buildReviewQueue(input(base))[0].tests).toBeUndefined();
+    // A skipped test (no command resolved) is not a verdict.
+    const skipped = buildReviewQueue(
+      input({ ...base, verificationReports: { a: report("skipped") } }),
+    );
+    expect(skipped[0].tests).toBeUndefined();
+  });
+
+  it("does not create a card from a tests verdict alone", () => {
+    // No unseen/diff/PR signals → no card, even with a report present.
+    const q = buildReviewQueue(
+      input({ agents: [agent({ id: "a" })], verificationReports: { a: report("failed") } }),
+    );
+    expect(q).toEqual([]);
+  });
+
+  it("resurfaces a dismissed card when a fresh tests verdict flips", () => {
+    const base = input({
+      agents: [agent({ id: "a" })],
+      unseenResults: { a: true },
+      gitShortstats: { a: stats(4, 2) },
+      verificationReports: { a: report("passed") },
+    });
+    const [item] = buildReviewQueue(base);
+    // Dismissed while green; a later failing verification changes the signature.
+    const flipped = buildReviewQueue({
+      ...base,
+      verificationReports: { a: report("failed") },
+      dismissed: { [item.id]: item.signature },
+    });
+    expect(flipped).toHaveLength(1);
+    expect(flipped[0].tests).toBe("failed");
   });
 
   // ── staleness (§2) ──────────────────────────────────────────────────────────

--- a/src/components/Workspace/MissionControl/queue.ts
+++ b/src/components/Workspace/MissionControl/queue.ts
@@ -12,9 +12,15 @@ import type {
   PrComments,
   PrState,
   ShortStats,
+  VerificationReport,
   WfPausedReason,
   WfRun,
 } from "@/api";
+
+/** A card's tests-evidence chip state, derived from a turn-end
+ *  [`VerificationReport`]. Only ever a definitive verdict — `undefined` while
+ *  unknown/running/skipped, so the card never shows a fake state. */
+export type TestsEvidence = "passed" | "failed";
 
 /** Why an item is in the queue. One card can carry several (an agent with both
  *  unseen results and a failing PR is ONE item with both reasons — see the
@@ -100,6 +106,10 @@ export interface ReviewItem {
   prSubdir?: string;
   checks?: PrChecks;
   unresolvedComments?: number;
+  /** Turn-end verification verdict (opt-in per project) — a quiet tests chip.
+   *  Omitted when unknown/running/no-tests, so it decorates an existing card
+   *  and never fakes a state. */
+  tests?: TestsEvidence;
   staleness?: Staleness | null;
   /** Advisory overlap hints — other agents on the same repo touching some of
    *  the same files. Omitted when there are none. */
@@ -134,9 +144,22 @@ export interface QueueInput {
   prStates: Record<string, PrState | null>;
   prChecks: Record<string, PrChecks | null>;
   prComments: Record<string, PrComments | null>;
+  /** Latest turn-end verification report per agent (keyed by agent_id). Absent
+   *  = never verified. */
+  verificationReports: Record<string, VerificationReport>;
   runs: readonly WfRun[];
   /** Item id → signal signature it was dismissed at. */
   dismissed: Record<string, string>;
+}
+
+/** The definitive tests verdict from a turn-end verification, or `undefined`
+ *  when there's nothing to show (no report, or its `test` check never ran).
+ *  A failing/timed-out/setup-failed test all read as `"failed"` — tests didn't
+ *  pass; a `skipped` test (no command) is not a verdict. */
+function testsEvidence(report: VerificationReport | undefined): TestsEvidence | undefined {
+  const test = report?.checks.find((c) => c.name === "test");
+  if (!test || test.outcome === "skipped") return undefined;
+  return test.outcome === "passed" ? "passed" : "failed";
 }
 
 /** Per-repo map key mirroring `store/git.ts::gitKey` — plain agent id for the
@@ -208,6 +231,7 @@ function agentSignature(p: {
   unseen: boolean;
   stats: ShortStats | undefined;
   signals: PrSignal[];
+  tests: TestsEvidence | undefined;
 }): string {
   const d = p.stats ? `${p.stats.additions}/${p.stats.deletions}/${p.stats.file_count}` : "-";
   const c = p.signals
@@ -216,7 +240,9 @@ function agentSignature(p: {
       return `${s.repo}=${checks}:${s.unresolved}`;
     })
     .join(",");
-  return `u${p.unseen ? 1 : 0}|d${d}|c${c || "-"}`;
+  // Include the tests verdict so a fresh verification resurfaces a dismissed
+  // card (a pass→fail flip, or the first result landing after dismissal).
+  return `u${p.unseen ? 1 : 0}|d${d}|c${c || "-"}|t${p.tests ?? "-"}`;
 }
 
 /** The agent's stalest checkout vs its base, or null when no base has moved
@@ -429,6 +455,7 @@ export function buildReviewQueue(input: QueueInput): ReviewItem[] {
     const signals = collectPrSignals(agent.id, input);
     const failing = signals.filter((s) => s.checks?.rollup === "failing");
     const unresolved = signals.reduce((n, s) => n + s.unresolved, 0);
+    const tests = testsEvidence(input.verificationReports[agent.id]);
 
     const reasons: ReviewReason[] = [];
     // Ad-hoc: a turn landed while you weren't looking and left changes behind.
@@ -445,7 +472,7 @@ export function buildReviewQueue(input: QueueInput): ReviewItem[] {
       id: `agent:${agent.id}`,
       kind: "agent",
       bucket: isPr ? BUCKET.pr : BUCKET.unseen,
-      signature: agentSignature({ unseen, stats, signals }),
+      signature: agentSignature({ unseen, stats, signals, tests }),
       activityAt: parseCreated(agent.created_at),
       title: agent.name,
       goal: firstLine(agent.task) || "—",
@@ -456,6 +483,9 @@ export function buildReviewQueue(input: QueueInput): ReviewItem[] {
       prSubdir: shown?.repo ? shown.repo : undefined,
       checks: shown?.checks ?? undefined,
       unresolvedComments: unresolved > 0 ? unresolved : undefined,
+      // Decoration on an existing card (like staleness/overlaps below): the
+      // tests chip never creates a card, only annotates one.
+      tests,
       // Always-visible signals (§2/§4): the base-moved chip and overlap hints
       // decorate an existing card in every panel state — they never create one.
       staleness: stalenessOf(agent.id, input),

--- a/src/components/Workspace/MissionControl/useReviewQueue.ts
+++ b/src/components/Workspace/MissionControl/useReviewQueue.ts
@@ -15,6 +15,7 @@ export function useReviewQueue(): ReviewItem[] {
   const prStates = useAppStore((s) => s.prStates);
   const prChecks = useAppStore((s) => s.prChecks);
   const prComments = useAppStore((s) => s.prComments);
+  const verificationReports = useAppStore((s) => s.verificationReports);
   const dismissed = useAppStore((s) => s.reviewDismissed);
   const runs = useRuns();
 
@@ -28,6 +29,7 @@ export function useReviewQueue(): ReviewItem[] {
         prStates,
         prChecks,
         prComments,
+        verificationReports,
         runs,
         dismissed,
       }),
@@ -39,6 +41,7 @@ export function useReviewQueue(): ReviewItem[] {
       prStates,
       prChecks,
       prComments,
+      verificationReports,
       runs,
       dismissed,
     ],

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -19,6 +19,7 @@ import {
   onSessionSyncHealth,
   onShellOutput,
   onTurnStarted,
+  onVerificationReport,
   onWorkspaceChanged,
 } from "@/api";
 import { isCommitAction } from "@/components/RightPanel/primaryActions";
@@ -404,6 +405,14 @@ const registerEventListeners = async (set: AppSet, get: AppGet) => {
 
   await onPrStateChanged((e) => {
     set((s) => ({ prStates: { ...s.prStates, [e.agent_id]: e.state } }));
+  });
+
+  // Turn-end verification result (opt-in per project) — stored per agent to
+  // feed the Mission Control card's tests chip.
+  await onVerificationReport((e) => {
+    set((s) => ({
+      verificationReports: { ...s.verificationReports, [e.agent_id]: e.report },
+    }));
   });
 
   // App-wide run-phase tracking. The RunPanel unmounts when its tab isn't

--- a/src/store/git.ts
+++ b/src/store/git.ts
@@ -80,6 +80,7 @@ export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
   prChecks: {},
   prComments: {},
   gitDelegations: {},
+  verificationReports: {},
   gitCommitAction: "agent-commit-pr" as GitCommitAction,
 
   fetchGitState: async (agentId, subdir) => {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -16,6 +16,7 @@ import type {
   PrState,
   RunPhase,
   ShortStats,
+  VerificationReport,
   Workspace,
 } from "@/api";
 import type { GitDelegation, GitDelegationKind } from "@/components/RightPanel/delegation";
@@ -287,6 +288,10 @@ export interface GitSlice {
    *  panel action hands control to the agent; cleared by the panel when the
    *  watched git/PR transition lands or the agent gives up. */
   gitDelegations: Record<string, GitDelegation>;
+  /** Latest turn-end verification report per agent (keyed by agent_id), from
+   *  the opt-in `verify:report` event. Feeds the Mission Control card's tests
+   *  chip. Absent = never verified (no chip). */
+  verificationReports: Record<string, VerificationReport>;
   /** Sticky changes-state commit mode (Commit / & push / & open PR). Global
    *  across workspaces, persisted in settings until the user picks another. */
   gitCommitAction: GitCommitAction;

--- a/src/workflows/builder/WorkflowBuilder.tsx
+++ b/src/workflows/builder/WorkflowBuilder.tsx
@@ -292,14 +292,29 @@ export function WorkflowBuilder({
         <GatePick
           rect={pop.rect}
           gate={findStep(state, pop.nid)?.gate.type ?? "verdict"}
+          requireTests={(() => {
+            const cur = findStep(state, pop.nid)?.gate;
+            return cur?.type === "approval" && (cur.require?.includes("tests") ?? false);
+          })()}
           onPick={(kind) => {
             const cur = findStep(state, pop.nid)?.gate;
             const gate: Gate =
               kind === "artifact"
                 ? { type: "artifact", path: cur?.type === "artifact" ? cur.path : "" }
-                : { type: kind };
+                : // Re-picking approval preserves any existing `require: [tests]`.
+                  kind === "approval"
+                  ? {
+                      type: "approval",
+                      require: cur?.type === "approval" ? cur.require : undefined,
+                    }
+                  : { type: kind };
             setGate(pop.nid, gate);
-            closePop();
+            // The gate mode is chosen; approval's require checkbox lives in the
+            // same popover, so keep it open rather than closing on pick.
+            if (kind !== "approval") closePop();
+          }}
+          onToggleRequireTests={(checked) => {
+            setGate(pop.nid, { type: "approval", require: checked ? ["tests"] : undefined });
           }}
         />
       )}

--- a/src/workflows/builder/model.test.ts
+++ b/src/workflows/builder/model.test.ts
@@ -3,7 +3,7 @@
 // through the editor is value-preserving.
 
 import { describe, expect, it } from "vitest";
-import type { Definition, Spec } from "../spec";
+import type { Definition, Gate, Spec } from "../spec";
 import { blankEditor, ensureAlias, fromDefinition, toSpec, validateEditor } from "./model";
 
 /** The canonical §5.3 example in the stored (JSON) shape: gates always present,
@@ -91,6 +91,25 @@ describe("spec ↔ editor mapping", () => {
     const spec = canonicalSpec();
     const editor = fromDefinition(asDefinition(spec));
     expect(toSpec(editor)).toEqual(spec);
+  });
+
+  it("round-trips an approval gate with and without require: [tests]", () => {
+    // A minimal spec whose only agent is the one the step references (the
+    // editor prunes unreferenced aliases, so the fixture must be self-contained).
+    const approvalSpec = (gate: Gate): Spec => ({
+      version: 1,
+      name: "approval-flow",
+      budgets: { turns: 10, wall_clock_mins: 30, tokens: 100000 },
+      agents: { reviewer: { base: "claude" } },
+      workflow: [{ step: { id: "handoff", agent: "reviewer", goal: "Hand off.", gate } }],
+      finalize: { push: true, open_pr: true, pr_base: "main" },
+    });
+
+    const withReq = approvalSpec({ type: "approval", require: ["tests"] });
+    expect(toSpec(fromDefinition(asDefinition(withReq)))).toEqual(withReq);
+
+    const bare = approvalSpec({ type: "approval" });
+    expect(toSpec(fromDefinition(asDefinition(bare)))).toEqual(bare);
   });
 
   it("preserves the definition id and hue for the edit path", () => {

--- a/src/workflows/builder/pickers.tsx
+++ b/src/workflows/builder/pickers.tsx
@@ -63,11 +63,16 @@ export function AgentPick({
 export function GatePick({
   rect,
   gate,
+  requireTests,
   onPick,
+  onToggleRequireTests,
 }: {
   rect: PopRect;
   gate: GateKind;
+  /** Whether the current approval gate carries `require: [tests]`. */
+  requireTests: boolean;
   onPick: (kind: GateKind) => void;
+  onToggleRequireTests: (checked: boolean) => void;
 }) {
   return (
     <div className="dd" style={{ position: "fixed", top: rect.top, left: rect.left, width: 300 }}>
@@ -88,6 +93,21 @@ export function GatePick({
           </span>
         </div>
       ))}
+      {gate === "approval" && (
+        // One extra prerequisite the approval gate can require first — the human
+        // pause stays unreachable until the project's tests pass (spec §9).
+        <label
+          className="dd-item"
+          style={{ display: "flex", alignItems: "center", gap: 8, cursor: "pointer" }}
+        >
+          <input
+            type="checkbox"
+            checked={requireTests}
+            onChange={(e) => onToggleRequireTests(e.target.checked)}
+          />
+          <span style={{ fontSize: 12 }}>Require passing tests first</span>
+        </label>
+      )}
     </div>
   );
 }

--- a/src/workflows/run/WorkflowComposer.tsx
+++ b/src/workflows/run/WorkflowComposer.tsx
@@ -37,6 +37,10 @@ export interface ComposerContext {
   /** The project's remembered default workflow — preselected when the user
    *  hasn't picked another this session. */
   defaultWorkflowId?: string | null;
+  /** GitHub issue number (as text) this launch was started from (Home inbox
+   *  "Start work" → Pipeline). Threaded onto the run so its finalized PR
+   *  closes the issue. Undefined for a normal launch. */
+  issueRef?: string;
 }
 
 /** Heading slot for the workflow mode — replaces the agent's title/subtitle on
@@ -57,6 +61,7 @@ export function WorkflowComposer({
   baseBranch,
   projectId,
   defaultWorkflowId,
+  issueRef,
 }: ComposerContext) {
   const selectRun = useAppStore((s) => s.selectRun);
   const setLastError = useAppStore((s) => s.setLastError);
@@ -117,6 +122,8 @@ export function WorkflowComposer({
         def.id,
         baseBranch || undefined,
         input.attachments,
+        undefined,
+        issueRef,
       );
       selectRun(runId);
     } catch (e) {


### PR DESCRIPTION
## What

Bundles the three items consciously deferred across the coherency roadmap (#466–#470), now that the full loop is on main.

### 1. "Verify on turn end" project setting (off by default)

- New per-project flag (`project_settings` key `verify.on_turn_end`, read via the existing KV layer — no new IPC): when on, an ad-hoc agent's turn end fire-and-forgets the existing verification engine (`verify.rs`) on its checkout, mirroring `fetch_and_emit_pr_state`'s spawn pattern (silent failure, never blocks the turn).
- Result rides a `verify:report` event into a per-agent store map and onto the agent's Mission Control card as a quiet tests ✓/✗ chip — definitive results only, nothing while unknown; the verdict folds into the dismissal signature so a fresh run resurfaces a dismissed card. Ad-hoc queue items now arrive with the same class of test evidence workflow approvals have carried since #466.
- Guardrails: ad-hoc agents only (step agents have gates), skips user-stopped turns, debounced per agent so verifications never race the same checkout. Flag off = zero behavior change.

### 2. Builder control for `require: [tests]`

One line under the approval-gate picker: "Require passing tests first" sets/unsets `require: ["tests"]`. The backend has supported this since #466 (tests evaluate before the human is ever asked); it just had no UI. YAML round-trips both ways, builder-model test added.

### 3. Pipeline-path "Closes #N"

- Issue-started **pipeline** runs now close their issue like quick-agent sessions have since #470: the composer threads the issue number into `wf_launch`, a nullable `wf_run.issue_ref` column (migration 0024, same pattern as `workspaces.issue_ref`) carries it, and `finalize_run` appends the trailer.
- The trailer helpers (`with_closes_trailer` + the strict closing-keyword/separator semantics) moved to a shared `github/closes.rs` — `rpc/git.rs` re-uses them; no duplication, one set of tests.
- Promote-to-workflow and all non-issue launches pass `None` → unchanged; step agents/forks stay unlinked (the deliberate #470 boundary).

## Testing

- Rust: `cargo fmt --check` clean; clippy with CI flags clean; `cargo test` → 961 passed.
- Frontend: typecheck clean; vitest → 497 passed (56 files; new queue tests-evidence/signature tests + builder round-trip); build succeeds; biome clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)