### PR TITLE
fix: stop deleted/relocated projects from lingering in the sidebar

### DIFF
--- a/src-tauri/src/workspace/repos.rs
+++ b/src-tauri/src/workspace/repos.rs
@@ -341,7 +341,7 @@ impl WorkspaceManager {
             )));
         }
 
-        let conn = self.db.lock();
+        let mut conn = self.db.lock();
         let old_str = old_path.to_string_lossy().to_string();
         let new_str = new_path.to_string_lossy().to_string();
 
@@ -365,13 +365,25 @@ impl WorkspaceManager {
             )));
         }
 
-        let changed = conn.execute(
+        // Repoint the repo and, in the same transaction, every workflow run that
+        // snapshotted the old path at launch. `wf_run.repo_path` is a stored
+        // column with no FK to `repos`, so — unlike the agents' worktree join,
+        // which follows automatically via `repo_id` — it does not track the move
+        // on its own. Leaving it stale would fork the sidebar across both paths
+        // and resume runs from the old location.
+        let tx = conn.transaction()?;
+        let changed = tx.execute(
             "UPDATE repos SET path = ?1 WHERE path = ?2",
             rusqlite::params![new_str, old_str],
         )?;
         if changed == 0 {
             return Err(Error::Other(format!("repo not found: {old_str}")));
         }
+        tx.execute(
+            "UPDATE wf_run SET repo_path = ?1 WHERE repo_path = ?2",
+            rusqlite::params![new_str, old_str],
+        )?;
+        tx.commit()?;
         drop(conn);
         Ok(self.current().expect("workspace initialized"))
     }

--- a/src-tauri/src/workspace/repos.rs
+++ b/src-tauri/src/workspace/repos.rs
@@ -379,9 +379,19 @@ impl WorkspaceManager {
         if changed == 0 {
             return Err(Error::Other(format!("repo not found: {old_str}")));
         }
+        // Scope the run rewrite to the relocated repo's project. `repo_path` is a
+        // launch-time snapshot that isn't unique across projects — a lingering
+        // historical run from a previous occupant of this same path string would
+        // otherwise be dragged to the new location and resume against the wrong
+        // repo. `repos.path` is UNIQUE, so this resolves the one owning project.
+        let project_id: String = tx.query_row(
+            "SELECT project_id FROM repos WHERE path = ?1",
+            [&new_str],
+            |row| row.get(0),
+        )?;
         tx.execute(
-            "UPDATE wf_run SET repo_path = ?1 WHERE repo_path = ?2",
-            rusqlite::params![new_str, old_str],
+            "UPDATE wf_run SET repo_path = ?1 WHERE repo_path = ?2 AND project_id = ?3",
+            rusqlite::params![new_str, old_str, project_id],
         )?;
         tx.commit()?;
         drop(conn);

--- a/src-tauri/src/workspace/tests.rs
+++ b/src-tauri/src/workspace/tests.rs
@@ -523,6 +523,42 @@ fn relocate_repo_repoints_path() {
 }
 
 #[test]
+fn relocate_repo_repoints_workflow_runs() {
+    let db = test_db();
+    let td = tempfile::tempdir().unwrap();
+    let old = init_repo(td.path());
+    let new = td.path().join("moved");
+    std::fs::create_dir_all(new.join(".git")).unwrap();
+
+    let wm = WorkspaceManager::new(db.clone());
+    wm.add_workspace_repo(old.clone()).unwrap();
+    let pid = wm.current().unwrap().projects[0].project_id.clone();
+
+    let old_str = old.to_string_lossy().to_string();
+    let new_str = new.to_string_lossy().to_string();
+    // A run snapshots its repo path at launch; `wf_run.repo_path` has no FK to
+    // `repos`, so it won't follow the move unless relocate rewrites it.
+    db.lock()
+        .execute(
+            "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,branch,
+                    base_sha,status,budgets_json,spent_json,created_at,updated_at)
+                 VALUES ('r1','n','{}','t',?1,?2,'/d','wf/x','sha','done','{}','{}',0,0)",
+            [&pid, &old_str],
+        )
+        .unwrap();
+
+    wm.relocate_repo(&old, &new).unwrap();
+
+    let repo_path: String = db
+        .lock()
+        .query_row("SELECT repo_path FROM wf_run WHERE id = 'r1'", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(repo_path, new_str, "run repo_path follows the relocate");
+}
+
+#[test]
 fn relocate_repo_rejects_non_git_dest() {
     let db = test_db();
     let td = tempfile::tempdir().unwrap();

--- a/src-tauri/src/workspace/tests.rs
+++ b/src-tauri/src/workspace/tests.rs
@@ -533,29 +533,53 @@ fn relocate_repo_repoints_workflow_runs() {
     let wm = WorkspaceManager::new(db.clone());
     wm.add_workspace_repo(old.clone()).unwrap();
     let pid = wm.current().unwrap().projects[0].project_id.clone();
+    // A second, unrelated project whose historical run snapshotted the SAME path
+    // string as `old` (a previous occupant of that path). `repo_path` isn't
+    // unique across projects, so the rewrite must not drag this run along.
+    let other_pid = "other-project".to_string();
+    db.lock()
+        .execute(
+            "INSERT INTO projects (id, name, created_at) VALUES (?1, 'other', 0)",
+            [&other_pid],
+        )
+        .unwrap();
 
     let old_str = old.to_string_lossy().to_string();
     let new_str = new.to_string_lossy().to_string();
     // A run snapshots its repo path at launch; `wf_run.repo_path` has no FK to
     // `repos`, so it won't follow the move unless relocate rewrites it.
-    db.lock()
-        .execute(
-            "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,branch,
+    let insert = |id: &str, project_id: &String| {
+        db.lock()
+            .execute(
+                "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,branch,
                     base_sha,status,budgets_json,spent_json,created_at,updated_at)
-                 VALUES ('r1','n','{}','t',?1,?2,'/d','wf/x','sha','done','{}','{}',0,0)",
-            [&pid, &old_str],
-        )
-        .unwrap();
+                 VALUES (?1,'n','{}','t',?2,?3,'/d','wf/x','sha','done','{}','{}',0,0)",
+                [&id.to_string(), project_id, &old_str],
+            )
+            .unwrap();
+    };
+    insert("r1", &pid);
+    insert("r2", &other_pid);
 
     wm.relocate_repo(&old, &new).unwrap();
 
-    let repo_path: String = db
-        .lock()
-        .query_row("SELECT repo_path FROM wf_run WHERE id = 'r1'", [], |row| {
-            row.get(0)
-        })
-        .unwrap();
-    assert_eq!(repo_path, new_str, "run repo_path follows the relocate");
+    let repo_path = |id: &str| -> String {
+        db.lock()
+            .query_row("SELECT repo_path FROM wf_run WHERE id = ?1", [id], |row| {
+                row.get(0)
+            })
+            .unwrap()
+    };
+    assert_eq!(
+        repo_path("r1"),
+        new_str,
+        "this project's run follows the relocate"
+    );
+    assert_eq!(
+        repo_path("r2"),
+        old_str,
+        "another project's run sharing the path string is left untouched"
+    );
 }
 
 #[test]

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -29,11 +29,18 @@ interface ProjectGroupData {
   pinned: boolean;
 }
 
-/** Build one group per project from (a) pinned repos (each carries its
- *  project via ProjectRef; a multi-repo project folds into one group),
- *  (b) any repo referenced by an existing agent, draft, or workflow run —
- *  those resolve to their project's group, or a path-keyed fallback group
- *  when the repo isn't pinned. */
+/** Build one group per project. The pinned repos (`workspace.projects`) are the
+ *  single source of truth for which groups exist: a multi-repo project folds
+ *  into one group, keyed by `project_id`. Agents, runs, and drafts only *attach*
+ *  to those groups — they never fabricate one from a stale reference, so a
+ *  deleted or relocated project can't reappear as a phantom sidebar group.
+ *
+ *  Agents and runs resolve by `project_id` first (it survives a relocate, where
+ *  a run's stored `repo_path` and a draft's path both go stale), then by repo
+ *  path, and only a genuinely *unpinned* repo (e.g. detached while an agent
+ *  still runs in it) gets a path-keyed fallback group. Drafts carry no
+ *  project_id, so they attach by path only and are dropped from the view when
+ *  their repo is gone. */
 function groupByProject(
   refs: readonly ProjectRef[],
   agents: readonly AgentRecord[],
@@ -42,6 +49,7 @@ function groupByProject(
 ): ProjectGroupData[] {
   const groups = new Map<string, ProjectGroupData>();
   const byPath = new Map<string, ProjectGroupData>();
+  const byProjectId = new Map<string, ProjectGroupData>();
   for (const ref of refs) {
     const key = ref.project_id || ref.path;
     let g = groups.get(key);
@@ -57,34 +65,42 @@ function groupByProject(
         pinned: true,
       };
       groups.set(key, g);
+      if (ref.project_id) byProjectId.set(ref.project_id, g);
     }
     g.repoPaths.push(ref.path);
     byPath.set(ref.path, g);
   }
-  const ensure = (p: string): ProjectGroupData => {
-    let g = byPath.get(p);
+  // Resolve real backend work (agents, runs) to its group: by project first, so
+  // a relocate — which moves the repo path but keeps the project_id — attaches
+  // to the moved group instead of forking. A repo that isn't pinned at all
+  // still surfaces its work via a path-keyed fallback group.
+  const groupFor = (projectId: string, path: string | undefined): ProjectGroupData | null => {
+    const byId = projectId ? byProjectId.get(projectId) : undefined;
+    if (byId) return byId;
+    if (!path) return null;
+    let g = byPath.get(path);
     if (!g) {
       g = {
-        key: p,
-        label: basename(p),
-        repoPaths: [p],
-        primaryPath: p,
+        key: path,
+        label: basename(path),
+        repoPaths: [path],
+        primaryPath: path,
         agents: [],
         drafts: [],
         runs: [],
         pinned: false,
       };
-      groups.set(p, g);
-      byPath.set(p, g);
+      groups.set(path, g);
+      byPath.set(path, g);
     }
     return g;
   };
-  for (const a of agents) {
-    const primary = a.repos[0]?.repo_path;
-    if (primary) ensure(primary).agents.push(a);
-  }
-  for (const d of drafts) ensure(d.repoPath).drafts.push(d);
-  for (const r of runs) ensure(r.repo_path).runs.push(r);
+  for (const a of agents) groupFor(a.project_id, a.repos[0]?.repo_path)?.agents.push(a);
+  for (const r of runs) groupFor(r.project_id, r.repo_path)?.runs.push(r);
+  // Drafts are client-only and keyed solely by repo path. Attach to an existing
+  // group but never create one: a draft left pointing at a deleted/relocated
+  // repo is dropped from the view rather than resurrecting a phantom group.
+  for (const d of drafts) byPath.get(d.repoPath)?.drafts.push(d);
   return Array.from(groups.values());
 }
 

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -29,7 +29,8 @@ export function Workspace() {
   // Only surface the draft while its repo is still pinned; a draft stranded on a
   // deleted/relocated project falls through to the normal view instead of
   // showing a ghost composer for a project that's gone.
-  const draftRepoLive = draft && (workspace?.projects.some((p) => p.path === draft.repoPath) ?? false);
+  const draftRepoLive =
+    draft && (workspace?.projects.some((p) => p.path === draft.repoPath) ?? false);
   if (draft && draftRepoLive) return <EmptyWorkspace draft={draft} key={draft.id} />;
 
   // A selected workflow run takes the center pane.

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -26,7 +26,11 @@ export function Workspace() {
   const toggleLeft = useAppStore((s) => s.toggleLeft);
 
   const draft = activeDraftId ? drafts.find((d) => d.id === activeDraftId) : null;
-  if (draft) return <EmptyWorkspace draft={draft} key={draft.id} />;
+  // Only surface the draft while its repo is still pinned; a draft stranded on a
+  // deleted/relocated project falls through to the normal view instead of
+  // showing a ghost composer for a project that's gone.
+  const draftRepoLive = draft && (workspace?.projects.some((p) => p.path === draft.repoPath) ?? false);
+  if (draft && draftRepoLive) return <EmptyWorkspace draft={draft} key={draft.id} />;
 
   // A selected workflow run takes the center pane.
   if (selectedRunId) {

--- a/src/store/repos.ts
+++ b/src/store/repos.ts
@@ -115,9 +115,7 @@ export const createReposSlice: SliceCreator<ReposSlice> = (set, get) => ({
     // new location so it follows the move instead of being dropped from the view.
     set((state) => ({
       workspace: ws,
-      drafts: state.drafts.map((d) =>
-        d.repoPath === oldPath ? { ...d, repoPath: newPath } : d,
-      ),
+      drafts: state.drafts.map((d) => (d.repoPath === oldPath ? { ...d, repoPath: newPath } : d)),
     }));
     if (get().projectSettingsRepoPath === oldPath) get().openProjectSettings(newPath);
   },

--- a/src/store/repos.ts
+++ b/src/store/repos.ts
@@ -111,7 +111,14 @@ export const createReposSlice: SliceCreator<ReposSlice> = (set, get) => ({
     // Keep the project's manual sidebar position, and repoint the open settings
     // modal (keyed by repo path) at the new location so it doesn't go stale.
     remapProjectOrder(oldPath, newPath);
-    set({ workspace: ws });
+    // Drafts are keyed by repo path; carry any in-progress composer over to the
+    // new location so it follows the move instead of being dropped from the view.
+    set((state) => ({
+      workspace: ws,
+      drafts: state.drafts.map((d) =>
+        d.repoPath === oldPath ? { ...d, repoPath: newPath } : d,
+      ),
+    }));
     if (get().projectSettingsRepoPath === oldPath) get().openProjectSettings(newPath);
   },
 


### PR DESCRIPTION
## Problem

Deleting a project from the project modal didn't remove it from the sidebar, and relocating/changing a project's directory produced a duplicate ("fork") — the old project stayed alongside the new one.

The project **was** being fully deleted (DB row + FK cascade to repos, workspaces, worktrees, settings; runs deleted explicitly). The bug was purely in the sidebar view.

## Root cause

`groupByProject` had two ways to create a sidebar group: the authoritative `workspace.projects`, **and** a path-keyed fallback fabricated from any draft/agent/run (`ensure(path)`). Any client-side item still pointing at a stale path resurrected a phantom group:

- **Delete** → a leftover client-only draft (agents/runs were already cleared/cascaded).
- **Relocate** → a workflow run (its `wf_run.repo_path` is frozen at launch and never rewritten) plus a stale draft. Agents follow the move correctly via their `repos.id` join.

## Fix (centralized)

Make `workspace.projects` the single source of truth for which groups exist; drafts/agents/runs only *attach*:

- **Agents & runs** resolve by `project_id` (stable across a relocate) first, then by path; only a genuinely unpinned repo gets a path fallback.
- **Drafts** attach by path and never create a group — a draft on a deleted/relocated repo drops out of the view.
- **Center pane** only renders an active draft while its repo is still pinned (no ghost composer after delete).
- **`relocateProject`** remaps in-progress drafts' `repoPath` old→new so a composer follows the move. The earlier per-action `deleteProject` draft cleanup is reverted since the view now handles it.

## Backend (defense in depth)

`relocate_repo` now rewrites `wf_run.repo_path` alongside `repos.path` in one transaction. Since `wf_run.repo_path` is a launch-time snapshot with no FK to `repos`, it wouldn't track a move on its own — leaving it stale forked the sidebar and would resume runs from the old location.

## Testing

- New `relocate_repo_repoints_workflow_runs` test; all 4 relocate tests pass. `cargo check` clean.
- Frontend: biome clean. `tsc` not run in this environment (`node_modules` not installed) — types reasoned through; run `npm run check` locally to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)