### PR TITLE
feat(project-settings): add env vars not in .env

### DIFF
--- a/src/components/ProjectSettings/EnvVarsSection/AddVarForm.tsx
+++ b/src/components/ProjectSettings/EnvVarsSection/AddVarForm.tsx
@@ -1,0 +1,109 @@
+import { useState } from "react";
+import { Icon } from "@/components/Icon";
+
+interface Props {
+  /** Keys already listed (from `.env` or configured) — for duplicate rejection. */
+  existingKeys: Set<string>;
+  /** Persist a new variable's value as a shared override. Rejects if the save
+   *  fails, so the form can keep the draft and surface the error. */
+  onAdd: (key: string, value: string) => Promise<void>;
+}
+
+/** A valid POSIX-ish env var name: a letter or underscore, then word chars. */
+const NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** Adds a variable that isn't in `.env`. Its value is stored as an override
+ *  (keychain) and shared by default — the reason to add one is to proxy it into
+ *  the sandbox. Collapsed to a button until opened. */
+export function AddVarForm({ existingKeys, onAdd }: Props) {
+  const [open, setOpen] = useState(false);
+  const [key, setKey] = useState("");
+  const [value, setValue] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const reset = () => {
+    setKey("");
+    setValue("");
+    setError(null);
+  };
+  const cancel = () => {
+    reset();
+    setOpen(false);
+  };
+
+  const submit = async () => {
+    const name = key.trim();
+    if (!NAME_RE.test(name)) {
+      setError("Name must be letters, digits and underscores, not starting with a digit.");
+      return;
+    }
+    if (existingKeys.has(name)) {
+      setError(`“${name}” is already listed.`);
+      return;
+    }
+    if (value === "") {
+      setError("Enter a value.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await onAdd(name, value);
+      reset();
+      setOpen(false);
+    } catch {
+      setError("Couldn’t save. Try again.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        className="ev-add-btn iflex-center text-sm"
+        onClick={() => setOpen(true)}
+      >
+        <Icon name="plus" size={13} /> Add variable
+      </button>
+    );
+  }
+
+  return (
+    <div className="ev-add-form">
+      <div className="ev-add-fields flex-center">
+        <input
+          className="ps-input mono"
+          placeholder="NAME"
+          aria-label="New variable name"
+          value={key}
+          autoFocus
+          onChange={(e) => setKey(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && submit()}
+        />
+        <input
+          className="ps-input mono"
+          placeholder="value"
+          aria-label="New variable value"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && submit()}
+        />
+        <button type="button" className="ps-btn" onClick={submit} disabled={busy}>
+          Add
+        </button>
+        <button
+          type="button"
+          className="ev-add-cancel iflex-center"
+          aria-label="Cancel"
+          onClick={cancel}
+        >
+          <Icon name="close" size={14} />
+        </button>
+      </div>
+      {error && <div className="ev-add-err text-xs">{error}</div>}
+    </div>
+  );
+}

--- a/src/components/ProjectSettings/EnvVarsSection/AddVarForm.tsx
+++ b/src/components/ProjectSettings/EnvVarsSection/AddVarForm.tsx
@@ -81,7 +81,7 @@ export function AddVarForm({ existingKeys, onAdd }: Props) {
           value={key}
           autoFocus
           onChange={(e) => setKey(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && submit()}
+          onKeyDown={(e) => e.key === "Enter" && !busy && submit()}
         />
         <input
           className="ps-input mono"
@@ -89,7 +89,7 @@ export function AddVarForm({ existingKeys, onAdd }: Props) {
           aria-label="New variable value"
           value={value}
           onChange={(e) => setValue(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && submit()}
+          onKeyDown={(e) => e.key === "Enter" && !busy && submit()}
         />
         <button type="button" className="ps-btn" onClick={submit} disabled={busy}>
           Add

--- a/src/components/ProjectSettings/EnvVarsSection/EnvVarRow.tsx
+++ b/src/components/ProjectSettings/EnvVarsSection/EnvVarRow.tsx
@@ -13,8 +13,10 @@ interface Props {
   overrideValue: string | undefined;
   cfg: EnvVarCfg;
   onToggleShare: (shared: boolean) => void;
-  /** Committed value from the chip: non-empty sets an override, empty reverts. */
-  onCommit: (value: string) => void;
+  /** Committed value from the chip: non-empty sets an override, empty reverts.
+   *  Async — the row awaits it so it can hold the revert/remove controls back
+   *  until the keychain + document writes settle. */
+  onCommit: (value: string) => void | Promise<void>;
   /** Explicit revert-to-`.env` (the revert control by the caption). */
   onRevert: () => void;
   /** Delete a variable that isn't in `.env` (a user-added or now-stale one). */
@@ -35,12 +37,24 @@ export function EnvVarRow({
   onRevert,
   onRemove,
 }: Props) {
-  // Hide the revert/remove controls while the value chip is being edited: the
-  // chip's blur commits, so a control clicked mid-edit would fire its mutation
-  // in the same gesture as that commit and the two could race on the keychain +
-  // document. Gone during editing, they can only be clicked after the commit
-  // has already dispatched. (Same guard the run-config row uses for revert.)
+  // Hold the revert/remove controls back while the value chip is being edited
+  // *and* while its blur-commit is still writing. A control clicked in that
+  // window would fire its mutation concurrently with the commit and the two
+  // could race on the keychain + document (e.g. a commit re-adding a variable
+  // that remove just deleted). The chip drops `editing` on blur *before* it
+  // fires the async `onCommit`, so `editing` alone reopens the controls mid-
+  // write; `committing` keeps them hidden until that write settles. Both flip
+  // in the same blur event, so React batches them — the controls never flash
+  // back in between. (The run-config row only needs the `editing` guard.)
   const [editing, setEditing] = useState(false);
+  const [committing, setCommitting] = useState(false);
+  const busy = editing || committing;
+
+  const handleCommit = (value: string) => {
+    setCommitting(true);
+    Promise.resolve(onCommit(value)).finally(() => setCommitting(false));
+  };
+
   const isOverride = cfg.source === "override";
   const inEnv = envValue !== undefined;
   // The effective value: the override when set, otherwise the mirrored `.env`
@@ -72,7 +86,7 @@ export function EnvVarRow({
       <div className="ev-l">
         <div className="ev-key-row iflex-center">
           <span className="ev-key mono text-base truncate">{varKey}</span>
-          {isOverride && inEnv && !editing && (
+          {isOverride && inEnv && !busy && (
             <IconButton
               size="sm"
               tip="Revert to .env"
@@ -82,7 +96,7 @@ export function EnvVarRow({
               <Icon name="refresh" size={12} />
             </IconButton>
           )}
-          {!inEnv && !editing && (
+          {!inEnv && !busy && (
             <IconButton
               size="sm"
               tip="Remove variable"
@@ -100,7 +114,7 @@ export function EnvVarRow({
           value={display}
           placeholder={envValue ?? "not set"}
           ariaLabel={varKey}
-          onCommit={onCommit}
+          onCommit={handleCommit}
           onEditingChange={setEditing}
         />
         <SandboxToggle value={cfg.shared} onChange={onToggleShare} />

--- a/src/components/ProjectSettings/EnvVarsSection/EnvVarRow.tsx
+++ b/src/components/ProjectSettings/EnvVarsSection/EnvVarRow.tsx
@@ -16,6 +16,8 @@ interface Props {
   onCommit: (value: string) => void;
   /** Explicit revert-to-`.env` (the revert control by the caption). */
   onRevert: () => void;
+  /** Delete a variable that isn't in `.env` (a user-added or now-stale one). */
+  onRemove: () => void;
 }
 
 /** One environment-variable row. Same value-editing UX as the run-config rows
@@ -30,6 +32,7 @@ export function EnvVarRow({
   onToggleShare,
   onCommit,
   onRevert,
+  onRemove,
 }: Props) {
   const isOverride = cfg.source === "override";
   const inEnv = envValue !== undefined;
@@ -38,15 +41,23 @@ export function EnvVarRow({
   const display = isOverride ? (overrideValue ?? "") : (envValue ?? "");
 
   const caption = isOverride ? (
-    <>
-      <span className="dot" /> Overridden · differs from <code>.env</code>
-    </>
+    inEnv ? (
+      <>
+        <span className="dot" /> Overridden · differs from <code>.env</code>
+      </>
+    ) : (
+      <>
+        <span className="dot" /> Added · not in <code>.env</code>
+      </>
+    )
   ) : inEnv ? (
     <>
       from <code>.env</code>
     </>
   ) : (
-    <>not in .env</>
+    <>
+      not in <code>.env</code>
+    </>
   );
 
   return (
@@ -54,7 +65,7 @@ export function EnvVarRow({
       <div className="ev-l">
         <div className="ev-key-row iflex-center">
           <span className="ev-key mono text-base truncate">{varKey}</span>
-          {isOverride && (
+          {isOverride && inEnv && (
             <IconButton
               size="sm"
               tip="Revert to .env"
@@ -62,6 +73,16 @@ export function EnvVarRow({
               onClick={onRevert}
             >
               <Icon name="refresh" size={12} />
+            </IconButton>
+          )}
+          {!inEnv && (
+            <IconButton
+              size="sm"
+              tip="Remove variable"
+              aria-label="Remove variable"
+              onClick={onRemove}
+            >
+              <Icon name="trash" size={12} />
             </IconButton>
           )}
         </div>

--- a/src/components/ProjectSettings/EnvVarsSection/EnvVarRow.tsx
+++ b/src/components/ProjectSettings/EnvVarsSection/EnvVarRow.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Icon } from "@/components/Icon";
 import { ValueChip } from "@/components/RunConfig";
 import { IconButton } from "@/components/ui/IconButton";
@@ -34,6 +35,12 @@ export function EnvVarRow({
   onRevert,
   onRemove,
 }: Props) {
+  // Hide the revert/remove controls while the value chip is being edited: the
+  // chip's blur commits, so a control clicked mid-edit would fire its mutation
+  // in the same gesture as that commit and the two could race on the keychain +
+  // document. Gone during editing, they can only be clicked after the commit
+  // has already dispatched. (Same guard the run-config row uses for revert.)
+  const [editing, setEditing] = useState(false);
   const isOverride = cfg.source === "override";
   const inEnv = envValue !== undefined;
   // The effective value: the override when set, otherwise the mirrored `.env`
@@ -65,7 +72,7 @@ export function EnvVarRow({
       <div className="ev-l">
         <div className="ev-key-row iflex-center">
           <span className="ev-key mono text-base truncate">{varKey}</span>
-          {isOverride && inEnv && (
+          {isOverride && inEnv && !editing && (
             <IconButton
               size="sm"
               tip="Revert to .env"
@@ -75,7 +82,7 @@ export function EnvVarRow({
               <Icon name="refresh" size={12} />
             </IconButton>
           )}
-          {!inEnv && (
+          {!inEnv && !editing && (
             <IconButton
               size="sm"
               tip="Remove variable"
@@ -94,6 +101,7 @@ export function EnvVarRow({
           placeholder={envValue ?? "not set"}
           ariaLabel={varKey}
           onCommit={onCommit}
+          onEditingChange={setEditing}
         />
         <SandboxToggle value={cfg.shared} onChange={onToggleShare} />
       </div>

--- a/src/components/ProjectSettings/EnvVarsSection/index.tsx
+++ b/src/components/ProjectSettings/EnvVarsSection/index.tsx
@@ -1,7 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { api, type EnvEntry } from "@/api";
-import { loadRunEnvDoc, type RunEnvDoc, saveRunEnvDoc, varConfig, withVar } from "@/storage/runEnv";
+import {
+  loadRunEnvDoc,
+  type RunEnvDoc,
+  saveRunEnvDoc,
+  varConfig,
+  withoutVar,
+  withVar,
+} from "@/storage/runEnv";
 import { basename } from "@/util/format";
+import { AddVarForm } from "./AddVarForm";
 import { EnvVarRow } from "./EnvVarRow";
 
 interface Props {
@@ -63,6 +71,9 @@ export function EnvVarsSection({ projectId, repoPath }: Props) {
     for (const v of doc.vars) if (!envMap.has(v.key)) keys.push(v.key);
     return keys.map((key) => ({ key, envValue: envMap.get(key) }));
   }, [envMap, doc]);
+
+  // Every key already on screen — for rejecting a duplicate add.
+  const existingKeys = useMemo(() => new Set(rows.map((r) => r.key)), [rows]);
 
   // Apply a pure mutation to the latest document: update ref + state
   // synchronously (no `await` across the mutation, so concurrent edits can't
@@ -137,6 +148,52 @@ export function EnvVarsSection({ projectId, repoPath }: Props) {
     }
   };
 
+  // Add a variable that isn't in `.env`: store its value as an override and
+  // share it by default — the reason to add one is to proxy it into the sandbox.
+  // Rolls back the keychain write if the document save fails, so the two stores
+  // don't split; rethrows so the form can surface the failure.
+  const addVar = async (key: string, value: string) => {
+    await api.setEnvOverride(projectId, key, value);
+    setOverrides((prev) => ({ ...prev, [key]: value }));
+    try {
+      await setVar(key, { shared: true, source: "override" });
+    } catch (e) {
+      console.error("run_env: add save failed; rolling back keychain", e);
+      await api.clearEnvOverride(projectId, key).catch(() => {});
+      setOverrides((prev) => {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+      throw e;
+    }
+  };
+
+  // Delete a variable that isn't backed by `.env` (a user-added or now-stale
+  // override). Clear its keychain value and drop it from the document. Capture
+  // the prior config/value first so a failed document save can be rolled back,
+  // leaving both stores exactly as they were.
+  const removeVar = async (key: string) => {
+    const prevCfg = varConfig(docRef.current, key);
+    const prevValue = await api.getEnvOverride(projectId, key);
+    await api.clearEnvOverride(projectId, key);
+    setOverrides((prev) => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+    try {
+      await commitDoc((d) => withoutVar(d, key));
+    } catch (e) {
+      console.error("run_env: remove save failed; restoring variable", e);
+      if (prevCfg.source === "override" && prevValue != null) {
+        await api.setEnvOverride(projectId, key, prevValue).catch(() => {});
+        setOverrides((prev) => ({ ...prev, [key]: prevValue }));
+      }
+      await commitDoc((d) => withVar(d, prevCfg)).catch(() => {});
+    }
+  };
+
   return (
     <section className="ps-section">
       <header className="ps-section-h">
@@ -145,7 +202,8 @@ export function EnvVarsSection({ projectId, repoPath }: Props) {
           Variables found in this project’s <code>.env</code>. Nothing is shared with the sandbox
           unless you switch it on. Shared values are mirrored live from <code>.env</code>; edit one
           to override it (e.g. a disposable per-agent database) — use <code>{"{{agent_id}}"}</code>{" "}
-          for a per-agent value, and clear the field to revert to <code>.env</code>.
+          for a per-agent value, and clear the field to revert to <code>.env</code>. Add a variable
+          that isn’t in <code>.env</code> with the button below.
         </p>
       </header>
 
@@ -167,10 +225,13 @@ export function EnvVarsSection({ projectId, repoPath }: Props) {
               onToggleShare={(shared) => onToggleShare(key, shared)}
               onCommit={(value) => onCommit(key, value)}
               onRevert={() => revertToMirror(key)}
+              onRemove={() => removeVar(key)}
             />
           ))}
         </div>
       )}
+
+      {entries !== null && <AddVarForm existingKeys={existingKeys} onAdd={addVar} />}
     </section>
   );
 }

--- a/src/components/ProjectSettings/ProjectSettings.css
+++ b/src/components/ProjectSettings/ProjectSettings.css
@@ -534,3 +534,51 @@
   font-family: var(--font-mono);
   color: var(--fg-2);
 }
+/* Add-a-variable control: a dashed button that opens an inline key/value form
+ * for a var that isn't in `.env` (stored as a shared override). */
+.ev-add-btn {
+  gap: 6px;
+  margin-top: 10px;
+  padding: 7px 11px;
+  color: var(--fg-2);
+  background: transparent;
+  border: 1px dashed var(--bd-soft);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  transition:
+    color 0.1s,
+    border-color 0.1s,
+    background 0.1s;
+}
+.ev-add-btn:hover {
+  color: var(--fg-0);
+  border-color: var(--bd);
+  background: var(--hover);
+}
+.ev-add-form {
+  margin-top: 10px;
+}
+.ev-add-fields {
+  gap: 8px;
+}
+.ev-add-cancel {
+  flex-shrink: 0;
+  width: 34px;
+  height: 34px;
+  color: var(--fg-3);
+  background: transparent;
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  transition:
+    color 0.1s,
+    border-color 0.1s;
+}
+.ev-add-cancel:hover {
+  color: var(--fg-1);
+  border-color: var(--bd);
+}
+.ev-add-err {
+  margin-top: 6px;
+  color: var(--danger);
+}

--- a/src/storage/runEnv.ts
+++ b/src/storage/runEnv.ts
@@ -60,3 +60,11 @@ export function withVar(doc: RunEnvDoc, next: EnvVarCfg): RunEnvDoc {
   const isDefault = !next.shared && next.source === "mirror";
   return { ...doc, vars: isDefault ? rest : [...rest, next] };
 }
+
+/** Remove one variable's config from the document (immutably). Used to delete a
+ *  variable that isn't backed by `.env` (a user-added or now-stale override) —
+ *  `withVar` only drops a var that reverts to the default shape, so removing a
+ *  shared/override var needs this. */
+export function withoutVar(doc: RunEnvDoc, key: string): RunEnvDoc {
+  return { ...doc, vars: doc.vars.filter((v) => v.key !== key) };
+}


### PR DESCRIPTION
## Summary

Project Settings lists a project's `.env` variables and lets you opt each one into the sandbox membrane, but there was **no way to add a variable that isn't in `.env`**. This adds that.

The whole change is **frontend** — the backend already supports it: `run_env::resolve` proxies any *shared* var whose source is `override`, and only falls back to `.env` when the keychain entry is missing. So an added variable (stored as a shared override) works end-to-end with no Rust changes.

## Changes

- **`AddVarForm.tsx`** (new) — a dashed "＋ Add variable" button that opens an inline NAME / value form. Validates the name (`^[A-Za-z_][A-Za-z0-9_]*$`), rejects duplicates and empty values inline, disables while saving.
- **`EnvVarsSection/index.tsx`** — `addVar` stores the value as a keychain override and marks the var `{ shared: true, source: "override" }` (shared by default — the reason to add one is to proxy it in), with keychain rollback if the doc save fails. `removeVar` clears the override and drops the var, with rollback. Renders the form; wires `onRemove`; updated section copy.
- **`EnvVarRow.tsx`** — a var **not in `.env`** now shows a **Remove** (trash) control instead of the meaningless "Revert to .env"; caption reads "Added · not in `.env`". Also cleans up the pre-existing orphan case (a var overridden, then deleted from `.env`).
- **`storage/runEnv.ts`** — added `withoutVar()` (`withVar` only drops vars that revert to the default shape).
- **`ProjectSettings.css`** — styles for the add button/form, reusing existing `.ps-input`/`.ps-btn` and tokens.

Added variables live in the sharing doc + keychain like existing overrides — nothing user-entered is written back to `.env` or into SQLite.

## Testing

- `bun run check` (tsc) — passes
- `bun run lint` (biome) — clean on touched files
- `bun run test` — 499 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)