### PR TITLE
feat(run-panel): render output with read-only xterm (ANSI + cursor control)

### DIFF
--- a/src-tauri/src/run_session.rs
+++ b/src-tauri/src/run_session.rs
@@ -40,6 +40,13 @@ pub struct RunStateSnapshot {
     /// Encoded as a byte array so the frontend can render or strip
     /// ANSI without re-decoding.
     pub log: Vec<u8>,
+    /// Absolute end offset of `log` — the total number of bytes ever
+    /// appended to this session (monotonic, uncapped, unaffected by ring
+    /// eviction). Each `run:output` event carries the same running counter
+    /// as its `seq`, so a panel that subscribes before fetching this snapshot
+    /// can dedupe the overlap exactly at this boundary: any live chunk whose
+    /// `seq <= log_seq` is already contained here.
+    pub log_seq: u64,
 }
 
 /// State for one agent's run process. Reused across start/stop cycles
@@ -88,6 +95,7 @@ impl RunSession {
             phase: inner.phase,
             last_error: inner.last_error.clone(),
             log: inner.log.bytes().to_vec(),
+            log_seq: inner.log.total(),
         }
     }
 
@@ -99,10 +107,14 @@ impl RunSession {
         matches!(self.phase(), RunPhase::Setup | RunPhase::Running)
     }
 
-    /// Append PTY output to the rolling buffer. Called from the
-    /// per-spawn output callback.
-    pub fn append_log(&self, bytes: &[u8]) {
-        self.inner.lock().log.append(bytes);
+    /// Append PTY output to the rolling buffer. Called from the per-spawn
+    /// output callback. Returns the new absolute end offset (total bytes ever
+    /// appended) so the caller can stamp the emitted `run:output` event with a
+    /// `seq` the panel dedupes against `RunStateSnapshot::log_seq`.
+    pub fn append_log(&self, bytes: &[u8]) -> u64 {
+        let mut inner = self.inner.lock();
+        inner.log.append(bytes);
+        inner.log.total()
     }
 
     /// Kill the active PTY (if any), bump generation so any in-flight
@@ -239,6 +251,9 @@ pub fn shell_args(cmd: &str) -> Vec<String> {
 struct LogBuffer {
     bytes: Vec<u8>,
     cap: usize,
+    /// Monotonic count of every byte ever appended, independent of ring
+    /// eviction. Serves as the absolute offset frontends align against.
+    total: u64,
 }
 
 impl LogBuffer {
@@ -246,10 +261,16 @@ impl LogBuffer {
         Self {
             bytes: Vec::new(),
             cap,
+            total: 0,
         }
     }
 
+    fn total(&self) -> u64 {
+        self.total
+    }
+
     fn append(&mut self, b: &[u8]) {
+        self.total += b.len() as u64;
         self.bytes.extend_from_slice(b);
         // Compact only when we've drifted ≥50% past cap so per-byte
         // amortized work stays O(1).
@@ -279,6 +300,30 @@ mod tests {
         assert!(buf.bytes().len() >= 100);
         assert!(buf.bytes().len() <= 150);
         assert!(buf.bytes().iter().all(|&b| b == b'x'));
+    }
+
+    #[test]
+    fn log_buffer_total_counts_all_bytes_past_eviction() {
+        let mut buf = LogBuffer::new(100);
+        assert_eq!(buf.total(), 0);
+        for _ in 0..20 {
+            buf.append(&[b'x'; 50]);
+        }
+        // total is monotonic and uncapped even though the ring evicts: it is
+        // the absolute offset the panel dedupes against.
+        assert_eq!(buf.total(), 20 * 50);
+    }
+
+    #[test]
+    fn append_log_returns_running_offset_and_snapshot_matches() {
+        let s = RunSession::new();
+        assert_eq!(s.append_log(b"hello"), 5);
+        assert_eq!(s.append_log(b" world"), 11);
+        let snap = s.snapshot();
+        // The snapshot's end offset equals the last append's returned seq, so a
+        // `run:output` event stamped with that seq is recognized as contained.
+        assert_eq!(snap.log_seq, 11);
+        assert_eq!(snap.log, b"hello world");
     }
 
     #[test]

--- a/src-tauri/src/supervisor/events.rs
+++ b/src-tauri/src/supervisor/events.rs
@@ -293,16 +293,22 @@ pub(super) fn emit_pr_state(app: &AppHandle, agent_id: &str, state: Option<PrSta
 struct RunOutputPayload {
     agent_id: String,
     bytes: Vec<u8>,
+    /// Absolute end offset of this chunk (total bytes appended to the run log
+    /// including it). The panel dedupes against `RunStateSnapshot::log_seq`:
+    /// a chunk with `seq <= log_seq` is already in the snapshot.
+    seq: u64,
 }
 
-/// Raw bytes from the Run panel's PTY (setup or dev-server phase).
-pub(super) fn emit_run_output(app: &AppHandle, agent_id: &str, bytes: Vec<u8>) {
+/// Raw bytes from the Run panel's PTY (setup or dev-server phase). `seq` is the
+/// running byte offset returned by `RunSession::append_log`.
+pub(super) fn emit_run_output(app: &AppHandle, agent_id: &str, bytes: Vec<u8>, seq: u64) {
     emit(
         app,
         "run:output",
         RunOutputPayload {
             agent_id: agent_id.to_string(),
             bytes,
+            seq,
         },
     );
 }

--- a/src-tauri/src/supervisor/run.rs
+++ b/src-tauri/src/supervisor/run.rs
@@ -141,6 +141,7 @@ impl Supervisor {
                 phase: RunPhase::Idle,
                 last_error: None,
                 log: Vec::new(),
+                log_seq: 0,
             },
         }
     }
@@ -239,12 +240,12 @@ pub struct ProjectRunConfig {
 /// Inject a "$ <cmd>" header line into the log so each phase has a
 /// visible boundary, then emit it like any other PTY output.
 fn write_header(app: &AppHandle, agent_id: &str, session: &Arc<RunSession>, cmd: &str) {
-    // Dim ANSI for the prompt — the frontend strips ANSI for v1,
-    // so the line still reads fine without color support.
+    // Dim ANSI for the prompt — the panel renders ANSI, so this shows as a
+    // muted prompt line separating each phase.
     let line = format!("\x1b[2m$ {cmd}\x1b[0m\r\n");
     let bytes = line.into_bytes();
-    session.append_log(&bytes);
-    emit_run_output(app, agent_id, bytes);
+    let seq = session.append_log(&bytes);
+    emit_run_output(app, agent_id, bytes, seq);
 }
 
 /// Inject a port-safety note (e.g. "Port 3000 in use — using 3001") into the
@@ -252,8 +253,8 @@ fn write_header(app: &AppHandle, agent_id: &str, session: &Arc<RunSession>, cmd:
 fn write_note(app: &AppHandle, agent_id: &str, session: &Arc<RunSession>, note: &str) {
     let line = format!("\x1b[2m{note}\x1b[0m\r\n");
     let bytes = line.into_bytes();
-    session.append_log(&bytes);
-    emit_run_output(app, agent_id, bytes);
+    let seq = session.append_log(&bytes);
+    emit_run_output(app, agent_id, bytes, seq);
 }
 
 /// A dev command prepared for spawn: the (possibly port-rewritten) command,
@@ -412,8 +413,8 @@ fn spawn_run_phase(
         &cwd,
         &env,
         move |bytes| {
-            session_out.append_log(&bytes);
-            emit_run_output(&app_out, &id_out, bytes);
+            let seq = session_out.append_log(&bytes);
+            emit_run_output(&app_out, &id_out, bytes, seq);
         },
         move |exit| {
             handle_run_phase_exit(

--- a/src/api/types/run.ts
+++ b/src/api/types/run.ts
@@ -6,6 +6,11 @@ export interface RunStateSnapshot {
   /** Raw PTY bytes accumulated since the panel was last cleared.
    *  Sent as a JSON array of u8 values; decode with TextDecoder. */
   log: number[];
+  /** Absolute end offset of `log` — total bytes ever appended to the run
+   *  session (monotonic, unaffected by ring eviction). A panel that subscribes
+   *  to `run:output` before fetching this snapshot dedupes the overlap here:
+   *  any live chunk with `seq <= log_seq` is already contained in `log`. */
+  log_seq: number;
 }
 
 /** A single detected run-config row (see Rust `run_detect::DetectedRow`). */
@@ -42,6 +47,10 @@ export interface EnvEntry {
 export interface RunOutputEvent {
   agent_id: string;
   bytes: number[];
+  /** Absolute end offset of this chunk (running total of bytes appended to the
+   *  run log, including these). Compared against `RunStateSnapshot.log_seq` to
+   *  drop bytes already present in the rehydration snapshot. */
+  seq: number;
 }
 
 export interface RunStateEvent {

--- a/src/components/RightPanel/RunPanel.css
+++ b/src/components/RightPanel/RunPanel.css
@@ -156,52 +156,22 @@
   box-shadow: 0 0 0 1.5px var(--bg-1);
 }
 
-.run-logs {
-  flex: 1;
-  overflow-y: auto;
-  min-height: 0;
-  font-family: var(--font-mono);
-  line-height: var(--lh-relaxed);
-  padding: 10px 18px 16px;
-  color: var(--fg-1);
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-.run-logs .p {
-  color: var(--accent);
-}
-.run-logs .d {
-  color: var(--fg-3);
-}
-.run-logs .s {
-  color: var(--success);
-}
-.run-logs .w {
-  color: var(--warn);
-}
-.run-logs .e {
-  color: var(--danger);
-}
-.run-logs .i {
-  color: var(--info);
-}
-.run-logs .b {
-  font-weight: 600;
-  color: var(--fg-0);
+/* xterm output owns its own scrolling; force the viewport to scroll within
+   the flex slot (matches the .term-panel rule in shared/terminal.css). */
+.run-wrap .xterm-viewport {
+  overflow-y: auto !important;
 }
 
-@keyframes term-blink {
-  50% {
-    opacity: 0;
-  }
-}
-.term-cursor {
-  display: inline-block;
-  width: 7px;
-  height: 14px;
-  vertical-align: text-bottom;
-  background: var(--accent);
-  animation: term-blink 1s steps(2) infinite;
+/* Supervisor-level error (distinct from the process's own stderr, which is
+   already in the terminal above). Shown below the log when stopped. */
+.run-error {
+  flex-shrink: 0;
+  padding: 8px 14px 10px;
+  font-family: var(--font-mono);
+  color: var(--danger);
+  white-space: pre-wrap;
+  word-break: break-word;
+  border-top: 1px solid var(--bd-soft);
 }
 
 /* run settings sheet */

--- a/src/components/RightPanel/RunPanel.tsx
+++ b/src/components/RightPanel/RunPanel.tsx
@@ -166,6 +166,7 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
 
         // With the listeners live, fetch the snapshot. Its `log_seq` is the
         // boundary the buffered/live chunks dedupe against.
+        let snapEnd = 0;
         try {
           const snap = await api.runState(agent.id);
           if (cancelled) return;
@@ -177,14 +178,21 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
           // multi-byte runes) itself, so no TextDecoder is needed here or on
           // live chunks.
           if (snap.log.length > 0) term.write(new Uint8Array(snap.log));
-          boundary = snap.log_seq;
-          // Flush anything buffered during the round-trip, deduped, then release
-          // the buffer — subsequent events write directly via `writeChunk`.
-          for (const c of pending) writeChunk(c.bytes, c.seq);
-          pending.length = 0;
+          snapEnd = snap.log_seq;
         } catch (err) {
-          console.error("runState failed", err);
+          // Snapshot failed: fall back to a zero boundary so buffered and
+          // future chunks still stream (writeChunk against 0 writes them
+          // whole). We lose the rehydrated backlog, but the gate MUST open —
+          // otherwise every event strands in `pending` and the terminal stays
+          // blank until the panel remounts.
+          console.error("runState failed — streaming live output without snapshot", err);
         }
+        if (cancelled) return;
+        // Open the gate regardless of snapshot success, then flush the buffer
+        // (deduped); subsequent events write directly via `writeChunk`.
+        boundary = snapEnd;
+        for (const c of pending) writeChunk(c.bytes, c.seq);
+        pending.length = 0;
       })();
 
       return () => {

--- a/src/components/RightPanel/RunPanel.tsx
+++ b/src/components/RightPanel/RunPanel.tsx
@@ -1,3 +1,4 @@
+import type { Terminal } from "@xterm/xterm";
 import { useEffect, useRef, useState } from "react";
 import { type AgentRecord, api, onRunOutput, onRunState } from "@/api";
 import { Icon } from "@/components/Icon";
@@ -10,6 +11,8 @@ import {
   toSetupRows,
 } from "@/components/RunConfig";
 import { useAppStore } from "@/store";
+import { useXterm } from "@/util/useXterm";
+import { resolveTheme } from "@/util/xtermTheme";
 import { RunSettingsSheet } from "./RunSettingsSheet";
 
 // Detected run config replaces the old hardcoded defaults. The backend
@@ -17,23 +20,12 @@ import { RunSettingsSheet } from "./RunSettingsSheet";
 // highest-confidence one. Two settings layers sit on top: the project's
 // `run.*` settings (edited in Project Settings), then this agent's
 // `run.agent.<id>.*` overrides (edited here in the sheet).
-
-// Strip ANSI escape sequences before rendering. v1 keeps log rendering
-// dead-simple (plain text with pre-wrap); colorization can come later.
-// Covers CSI (ESC [ ... letter) and OSC (ESC ] ... BEL / ST).
-const ANSI_RE = /\x1b\[[0-9;?]*[a-zA-Z]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
-const stripAnsi = (s: string) => s.replace(ANSI_RE, "");
-
-// Cap the in-memory log so a long-running dev server can't grow React state
-// without bound. Keep the tail — what a terminal would show — and trim from
-// the front on a line boundary so a half-line never gets rendered.
-const MAX_LOG_CHARS = 256 * 1024;
-const capLog = (s: string): string => {
-  if (s.length <= MAX_LOG_CHARS) return s;
-  const tail = s.slice(s.length - MAX_LOG_CHARS);
-  const nl = tail.indexOf("\n");
-  return nl === -1 ? tail : tail.slice(nl + 1);
-};
+//
+// Output is rendered by a read-only xterm terminal (same hook as TermPanel),
+// so ANSI colors *and* cursor control (spinners, progress-bar rewrites) render
+// faithfully. Raw PTY bytes from `run:output` are written straight to the
+// terminal — no ANSI stripping, no React state per chunk; xterm owns decoding,
+// scrollback, and scrolling.
 
 export function RunPanel({ agent }: { agent: AgentRecord }) {
   // Phase is owned by the store (fed by an app-wide `run:state` subscription) so
@@ -42,17 +34,12 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
   const setRunPhase = useAppStore((s) => s.setRunPhase);
   const setRunPort = useAppStore((s) => s.setRunPort);
   const [lastError, setLastError] = useState<string | null>(null);
-  const [log, setLog] = useState<string>("");
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [projectValues, setProjectValues] = useState<Record<string, string>>({});
   const [overrides, setOverrides] = useState<Record<string, string>>({});
   const [rows, setRows] = useState<SetupRow[]>([]);
   const [ecosystem, setEcosystem] = useState<string | null>(null);
-  const logRef = useRef<HTMLDivElement | null>(null);
-  // Streaming UTF-8 decoder so a multi-byte rune split across two
-  // PTY chunks doesn't produce a replacement character. Reset each
-  // time we re-subscribe (agent switch).
-  const decoderRef = useRef<TextDecoder | null>(null);
+  const termRef = useRef<Terminal | null>(null);
 
   // Load the project's run settings (the base every agent inherits) and this
   // agent's overrides on top of them. Re-loads on agent switch.
@@ -100,73 +87,92 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
     };
   }, [agent.id]);
 
-  // Subscribe to run output and state events for this agent.
-  // Rehydrate snapshot on mount/agent-switch so the panel preserves
-  // logs from prior starts (and across panel mounts).
+  // Mount a read-only xterm terminal and stream run output into it.
+  // Rehydrate the snapshot on mount/agent-switch so the panel preserves logs
+  // from prior starts (and across panel mounts). The whole lifecycle re-runs
+  // when the agent id changes: the old terminal is disposed and a fresh one
+  // replays that agent's snapshot.
+  const termContainerRef = useXterm(
+    {
+      fontSize: 12,
+      lineHeight: 1.2,
+      theme: resolveTheme(),
+      scrollback: 20000,
+      // Read-only log view: no input, no blinking input caret.
+      disableStdin: true,
+      cursorBlink: false,
+      cursorInactiveStyle: "none",
+    },
+    (term) => {
+      termRef.current = term;
+
+      // `onRunOutput` / `onRunState` return promises that resolve to the
+      // unlisten fn. StrictMode runs effects twice in dev, and cleanup may fire
+      // before those promises resolve — so we track a cancelled flag and
+      // dispose any unlistener that arrives late. Without this, the first
+      // mount's listener leaks and every event is delivered twice.
+      let cancelled = false;
+      let unlistenOutput: (() => void) | null = null;
+      let unlistenState: (() => void) | null = null;
+
+      api.runState(agent.id).then((snap) => {
+        if (cancelled) return;
+        // Rehydrate the store phase too, so a running app opened after an app
+        // reload lights the tab dot even before the next live event arrives.
+        setRunPhase(agent.id, snap.phase);
+        setLastError(snap.last_error);
+        // Write raw snapshot bytes; xterm decodes UTF-8 (and handles multi-byte
+        // runes) itself, so no TextDecoder is needed here or on live chunks.
+        if (snap.log.length > 0) term.write(new Uint8Array(snap.log));
+      });
+
+      onRunOutput((e) => {
+        if (e.agent_id !== agent.id) return;
+        term.write(new Uint8Array(e.bytes));
+      }).then((un) => {
+        if (cancelled) {
+          un();
+          return;
+        }
+        unlistenOutput = un;
+      });
+
+      onRunState((e) => {
+        if (e.agent_id !== agent.id) return;
+        // Phase flows through the store via the app-wide listener; this local
+        // subscription only mirrors last_error, which the store doesn't track.
+        setLastError(e.last_error);
+      }).then((un) => {
+        if (cancelled) {
+          un();
+          return;
+        }
+        unlistenState = un;
+      });
+
+      return () => {
+        cancelled = true;
+        termRef.current = null;
+        unlistenOutput?.();
+        unlistenState?.();
+      };
+    },
+    [agent.id, setRunPhase],
+    { autoFocus: false },
+  );
+
+  // Re-apply the xterm theme on dark ↔ light switches without recreating the
+  // terminal (same approach as TermPanel).
   useEffect(() => {
-    // `onRunOutput` / `onRunState` return promises that resolve to
-    // the unlisten fn. StrictMode runs effects twice in dev, and the
-    // cleanup may fire before those promises resolve — so we track a
-    // cancelled flag and dispose any unlistener that arrives late.
-    // Without this, the first mount's listener leaks and every event
-    // is delivered twice.
-    let cancelled = false;
-    let unlistenOutput: (() => void) | null = null;
-    let unlistenState: (() => void) | null = null;
-    const decoder = new TextDecoder("utf-8", { fatal: false });
-    decoderRef.current = decoder;
-
-    api.runState(agent.id).then((snap) => {
-      if (cancelled) return;
-      // Rehydrate the store phase too, so a running app opened after an app
-      // reload lights the tab dot even before the next live event arrives.
-      setRunPhase(agent.id, snap.phase);
-      setLastError(snap.last_error);
-      // Snapshot is a one-shot buffer — decode it without streaming
-      // mode using its own decoder so it doesn't pollute the live
-      // stream decoder.
-      const snapDecoder = new TextDecoder("utf-8", { fatal: false });
-      setLog(capLog(stripAnsi(snapDecoder.decode(new Uint8Array(snap.log)))));
+    const observer = new MutationObserver(() => {
+      if (termRef.current) termRef.current.options.theme = resolveTheme();
     });
-
-    onRunOutput((e) => {
-      if (e.agent_id !== agent.id) return;
-      const chunk = stripAnsi(decoder.decode(new Uint8Array(e.bytes), { stream: true }));
-      setLog((prev) => capLog(prev + chunk));
-    }).then((un) => {
-      if (cancelled) {
-        un();
-        return;
-      }
-      unlistenOutput = un;
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
     });
-
-    onRunState((e) => {
-      if (e.agent_id !== agent.id) return;
-      // Phase flows through the store via the app-wide listener; this local
-      // subscription only mirrors last_error, which the store doesn't track.
-      setLastError(e.last_error);
-    }).then((un) => {
-      if (cancelled) {
-        un();
-        return;
-      }
-      unlistenState = un;
-    });
-
-    return () => {
-      cancelled = true;
-      unlistenOutput?.();
-      unlistenState?.();
-    };
-  }, [agent.id, setRunPhase]);
-
-  // Auto-scroll to bottom on log append.
-  useEffect(() => {
-    const el = logRef.current;
-    if (!el) return;
-    el.scrollTop = el.scrollHeight;
-  }, [log]);
+    return () => observer.disconnect();
+  }, []);
 
   // What each row inherits: the project setting when one exists, else the
   // detected value. Agent-level overrides compare against these, so a value
@@ -271,17 +277,11 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
         </button>
       </div>
 
-      {/* ── Logs ── */}
-      <div className="run-logs text-sm" ref={logRef}>
-        {log.length > 0 && <div>{log}</div>}
-        {lastError && phase === "stopped" && <div className="e">{lastError}</div>}
-        {isActive && (
-          <div className="p">
-            {"› "}
-            <span className="term-cursor" />
-          </div>
-        )}
+      {/* ── Logs (read-only xterm) ── */}
+      <div className="xterm-slot">
+        <div ref={termContainerRef} className="xterm-host" style={{ inset: "10px 6px 12px 14px" }} />
       </div>
+      {lastError && phase === "stopped" && <div className="run-error e text-sm">{lastError}</div>}
 
       {/* ── Settings sheet ── */}
       {settingsOpen && (

--- a/src/components/RightPanel/RunPanel.tsx
+++ b/src/components/RightPanel/RunPanel.tsx
@@ -113,35 +113,38 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
       let unlistenState: (() => void) | null = null;
       termRef.current = term;
 
-      // Rehydrate the persisted snapshot, THEN subscribe to the live stream —
-      // in that order. `term.write` is append-only, so the snapshot must be
-      // written before any live byte can be: if a live chunk landed first, the
-      // later snapshot write would replay older bytes *after* newer ones,
-      // duplicating and reordering output for a run that's still writing.
-      // Awaiting the snapshot before registering the output listener makes that
-      // ordering deterministic. (The narrow window between the backend snapshot
-      // and the listener going live can drop a chunk, but never duplicate or
-      // reorder — the same guarantee the previous plain-text panel had.)
-      (async () => {
-        try {
-          const snap = await api.runState(agent.id);
-          if (cancelled) return;
-          // Rehydrate the store phase too, so a running app opened after an app
-          // reload lights the tab dot even before the next live event arrives.
-          setRunPhase(agent.id, snap.phase);
-          setLastError(snap.last_error);
-          // Write raw snapshot bytes; xterm decodes UTF-8 (and handles
-          // multi-byte runes) itself, so no TextDecoder is needed here or on
-          // live chunks.
-          if (snap.log.length > 0) term.write(new Uint8Array(snap.log));
-        } catch (err) {
-          console.error("runState failed", err);
-        }
-        if (cancelled) return;
+      // Subscribe to live output BEFORE fetching the snapshot, so no chunk
+      // produced during the snapshot round-trip can slip through the gap. Live
+      // chunks that arrive before the snapshot resolves are held in `pending`
+      // (we can't write them yet — `term.write` is append-only, so they must go
+      // *after* the snapshot). Once the snapshot's end offset `boundary` is
+      // known, `writeChunk` dedupes each chunk against it exactly: the backend
+      // stamps every chunk with an absolute `seq` (its end offset), so a chunk
+      // already contained in the snapshot (`seq <= boundary`) is dropped, and
+      // the one chunk straddling the boundary is trimmed to just its new tail.
+      // Net: no gap (subscribed first), no duplication/reorder (deduped by
+      // offset) — even when the panel opens mid-run.
+      let boundary: number | null = null;
+      const pending: { bytes: Uint8Array; seq: number }[] = [];
 
+      const writeChunk = (bytes: Uint8Array, seq: number) => {
+        if (boundary === null) return;
+        const start = seq - bytes.length; // absolute start offset of this chunk
+        if (seq <= boundary) return; // fully within the snapshot — already shown
+        if (start >= boundary) {
+          term.write(bytes); // entirely new
+          return;
+        }
+        term.write(bytes.subarray(boundary - start)); // straddles: write new tail only
+      };
+
+      (async () => {
         const unOutput = await onRunOutput((e) => {
           if (e.agent_id !== agent.id) return;
-          term.write(new Uint8Array(e.bytes));
+          const bytes = new Uint8Array(e.bytes);
+          // Buffer until the boundary is known; after that, write directly.
+          if (boundary === null) pending.push({ bytes, seq: e.seq });
+          else writeChunk(bytes, e.seq);
         });
         if (cancelled) {
           unOutput();
@@ -160,6 +163,28 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
           return;
         }
         unlistenState = unState;
+
+        // With the listeners live, fetch the snapshot. Its `log_seq` is the
+        // boundary the buffered/live chunks dedupe against.
+        try {
+          const snap = await api.runState(agent.id);
+          if (cancelled) return;
+          // Rehydrate the store phase too, so a running app opened after an app
+          // reload lights the tab dot even before the next live event arrives.
+          setRunPhase(agent.id, snap.phase);
+          setLastError(snap.last_error);
+          // Write raw snapshot bytes; xterm decodes UTF-8 (and handles
+          // multi-byte runes) itself, so no TextDecoder is needed here or on
+          // live chunks.
+          if (snap.log.length > 0) term.write(new Uint8Array(snap.log));
+          boundary = snap.log_seq;
+          // Flush anything buffered during the round-trip, deduped, then release
+          // the buffer — subsequent events write directly via `writeChunk`.
+          for (const c of pending) writeChunk(c.bytes, c.seq);
+          pending.length = 0;
+        } catch (err) {
+          console.error("runState failed", err);
+        }
       })();
 
       return () => {

--- a/src/components/RightPanel/RunPanel.tsx
+++ b/src/components/RightPanel/RunPanel.tsx
@@ -104,51 +104,63 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
       cursorInactiveStyle: "none",
     },
     (term) => {
-      termRef.current = term;
-
-      // `onRunOutput` / `onRunState` return promises that resolve to the
-      // unlisten fn. StrictMode runs effects twice in dev, and cleanup may fire
-      // before those promises resolve — so we track a cancelled flag and
-      // dispose any unlistener that arrives late. Without this, the first
-      // mount's listener leaks and every event is delivered twice.
+      // StrictMode runs effects twice in dev, and cleanup may fire before the
+      // async setup below resolves — so we track a cancelled flag and dispose
+      // any listener that registers late. Without this, the first mount's
+      // listener leaks and every event is delivered twice.
       let cancelled = false;
       let unlistenOutput: (() => void) | null = null;
       let unlistenState: (() => void) | null = null;
+      termRef.current = term;
 
-      api.runState(agent.id).then((snap) => {
+      // Rehydrate the persisted snapshot, THEN subscribe to the live stream —
+      // in that order. `term.write` is append-only, so the snapshot must be
+      // written before any live byte can be: if a live chunk landed first, the
+      // later snapshot write would replay older bytes *after* newer ones,
+      // duplicating and reordering output for a run that's still writing.
+      // Awaiting the snapshot before registering the output listener makes that
+      // ordering deterministic. (The narrow window between the backend snapshot
+      // and the listener going live can drop a chunk, but never duplicate or
+      // reorder — the same guarantee the previous plain-text panel had.)
+      (async () => {
+        try {
+          const snap = await api.runState(agent.id);
+          if (cancelled) return;
+          // Rehydrate the store phase too, so a running app opened after an app
+          // reload lights the tab dot even before the next live event arrives.
+          setRunPhase(agent.id, snap.phase);
+          setLastError(snap.last_error);
+          // Write raw snapshot bytes; xterm decodes UTF-8 (and handles
+          // multi-byte runes) itself, so no TextDecoder is needed here or on
+          // live chunks.
+          if (snap.log.length > 0) term.write(new Uint8Array(snap.log));
+        } catch (err) {
+          console.error("runState failed", err);
+        }
         if (cancelled) return;
-        // Rehydrate the store phase too, so a running app opened after an app
-        // reload lights the tab dot even before the next live event arrives.
-        setRunPhase(agent.id, snap.phase);
-        setLastError(snap.last_error);
-        // Write raw snapshot bytes; xterm decodes UTF-8 (and handles multi-byte
-        // runes) itself, so no TextDecoder is needed here or on live chunks.
-        if (snap.log.length > 0) term.write(new Uint8Array(snap.log));
-      });
 
-      onRunOutput((e) => {
-        if (e.agent_id !== agent.id) return;
-        term.write(new Uint8Array(e.bytes));
-      }).then((un) => {
+        const unOutput = await onRunOutput((e) => {
+          if (e.agent_id !== agent.id) return;
+          term.write(new Uint8Array(e.bytes));
+        });
         if (cancelled) {
-          un();
+          unOutput();
           return;
         }
-        unlistenOutput = un;
-      });
+        unlistenOutput = unOutput;
 
-      onRunState((e) => {
-        if (e.agent_id !== agent.id) return;
-        // Phase flows through the store via the app-wide listener; this local
-        // subscription only mirrors last_error, which the store doesn't track.
-        setLastError(e.last_error);
-      }).then((un) => {
+        const unState = await onRunState((e) => {
+          if (e.agent_id !== agent.id) return;
+          // Phase flows through the store via the app-wide listener; this local
+          // subscription only mirrors last_error, which the store doesn't track.
+          setLastError(e.last_error);
+        });
         if (cancelled) {
-          un();
+          unState();
           return;
         }
-        unlistenState = un;
-      });
+        unlistenState = unState;
+      })();
 
       return () => {
         cancelled = true;
@@ -279,7 +291,11 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
 
       {/* ── Logs (read-only xterm) ── */}
       <div className="xterm-slot">
-        <div ref={termContainerRef} className="xterm-host" style={{ inset: "10px 6px 12px 14px" }} />
+        <div
+          ref={termContainerRef}
+          className="xterm-host"
+          style={{ inset: "10px 6px 12px 14px" }}
+        />
       </div>
       {lastError && phase === "stopped" && <div className="run-error e text-sm">{lastError}</div>}
 

--- a/src/components/RightPanel/RunPanel.tsx
+++ b/src/components/RightPanel/RunPanel.tsx
@@ -114,37 +114,30 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
       termRef.current = term;
 
       // Subscribe to live output BEFORE fetching the snapshot, so no chunk
-      // produced during the snapshot round-trip can slip through the gap. Live
-      // chunks that arrive before the snapshot resolves are held in `pending`
-      // (we can't write them yet — `term.write` is append-only, so they must go
-      // *after* the snapshot). Once the snapshot's end offset `boundary` is
-      // known, `writeChunk` dedupes each chunk against it exactly: the backend
-      // stamps every chunk with an absolute `seq` (its end offset), so a chunk
-      // already contained in the snapshot (`seq <= boundary`) is dropped, and
-      // the one chunk straddling the boundary is trimmed to just its new tail.
-      // Net: no gap (subscribed first), no duplication/reorder (deduped by
-      // offset) — even when the panel opens mid-run.
-      let boundary: number | null = null;
+      // produced during the snapshot round-trip can slip through a gap. Because
+      // we subscribe first, `pending` is a *complete, contiguous* byte range
+      // from the moment the listener went live (`liveStart`) onward — we never
+      // miss a chunk in that range, and we never drop one. The snapshot is only
+      // needed to prepend BACKLOG that predates `liveStart`.
+      //
+      // This matters because the backend log is a capped ring: `snap.log` holds
+      // only the tail `[log_seq - log.length, log_seq)`, while `log_seq` counts
+      // every byte ever appended. A noisy run can evict, during the round trip,
+      // bytes that a buffered chunk still carries — so we must NOT dedupe
+      // buffered chunks by offset against `log_seq` (that would drop chunks
+      // whose bytes are no longer in `snap.log`). Instead: write the snapshot's
+      // prefix up to `liveStart`, then every buffered chunk in full.
+      let gateOpen = false;
       const pending: { bytes: Uint8Array; seq: number }[] = [];
-
-      const writeChunk = (bytes: Uint8Array, seq: number) => {
-        if (boundary === null) return;
-        const start = seq - bytes.length; // absolute start offset of this chunk
-        if (seq <= boundary) return; // fully within the snapshot — already shown
-        if (start >= boundary) {
-          term.write(bytes); // entirely new
-          return;
-        }
-        term.write(bytes.subarray(boundary - start)); // straddles: write new tail only
-      };
 
       (async () => {
         const unOutput = await onRunOutput((e) => {
           if (e.agent_id !== agent.id) return;
           const bytes = new Uint8Array(e.bytes);
-          // Buffer until the boundary is known; after that, write directly.
-          if (boundary === null) pending.push({ bytes, seq: e.seq });
-          else writeChunk(bytes, e.seq);
+          // Buffer until the handoff completes; after that every chunk is
+          // strictly newer than everything written, so write it directly.
+          if (gateOpen) term.write(bytes);
+          else pending.push({ bytes, seq: e.seq });
         });
         if (cancelled) {
           unOutput();
@@ -164,9 +157,9 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
         }
         unlistenState = unState;
 
-        // With the listeners live, fetch the snapshot. Its `log_seq` is the
-        // boundary the buffered/live chunks dedupe against.
-        let snapEnd = 0;
+        // With the listeners live, fetch the rehydration snapshot.
+        let snapLog: Uint8Array | null = null;
+        let snapEnd = 0; // absolute end offset of the snapshot (log_seq)
         try {
           const snap = await api.runState(agent.id);
           if (cancelled) return;
@@ -174,25 +167,35 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
           // reload lights the tab dot even before the next live event arrives.
           setRunPhase(agent.id, snap.phase);
           setLastError(snap.last_error);
-          // Write raw snapshot bytes; xterm decodes UTF-8 (and handles
-          // multi-byte runes) itself, so no TextDecoder is needed here or on
-          // live chunks.
-          if (snap.log.length > 0) term.write(new Uint8Array(snap.log));
+          if (snap.log.length > 0) snapLog = new Uint8Array(snap.log);
           snapEnd = snap.log_seq;
         } catch (err) {
-          // Snapshot failed: fall back to a zero boundary so buffered and
-          // future chunks still stream (writeChunk against 0 writes them
-          // whole). We lose the rehydrated backlog, but the gate MUST open —
-          // otherwise every event strands in `pending` and the terminal stays
-          // blank until the panel remounts.
+          // Snapshot failed: no backlog, but the handoff MUST still complete —
+          // otherwise every buffered/future chunk strands in `pending` and the
+          // terminal stays blank until remount. Fall through with snapLog=null.
           console.error("runState failed — streaming live output without snapshot", err);
         }
         if (cancelled) return;
-        // Open the gate regardless of snapshot success, then flush the buffer
-        // (deduped); subsequent events write directly via `writeChunk`.
-        boundary = snapEnd;
-        for (const c of pending) writeChunk(c.bytes, c.seq);
+
+        // Handoff. `liveStart` is the absolute offset of the first buffered
+        // byte; the snapshot need only supply what precedes it. With no buffered
+        // output, the snapshot is the whole story up to `snapEnd`.
+        const liveStart = pending.length > 0 ? pending[0].seq - pending[0].bytes.length : snapEnd;
+        if (snapLog) {
+          const snapStart = snapEnd - snapLog.length;
+          // Backlog = snapshot bytes before our live coverage. Clamp to the
+          // retained range: if eviction already advanced past `liveStart`
+          // (snapStart >= liveStart), there's no backlog to prepend and the
+          // buffered chunks cover everything the snapshot could. Writing whole
+          // chunks (below) then means no drop, no dup, no reorder.
+          const backlogLen = Math.max(0, Math.min(liveStart, snapEnd) - snapStart);
+          if (backlogLen > 0) term.write(snapLog.subarray(0, backlogLen));
+        }
+        // Every buffered chunk in full — never dropped, even if its bytes were
+        // evicted from the snapshot tail during the round trip.
+        for (const c of pending) term.write(c.bytes);
         pending.length = 0;
+        gateOpen = true;
       })();
 
       return () => {

--- a/src/components/RightPanel/TermPanel.tsx
+++ b/src/components/RightPanel/TermPanel.tsx
@@ -1,65 +1,14 @@
 import { open } from "@tauri-apps/plugin-shell";
 import { SearchAddon } from "@xterm/addon-search";
 import { WebLinksAddon } from "@xterm/addon-web-links";
-import type { ITheme, Terminal } from "@xterm/xterm";
+import type { Terminal } from "@xterm/xterm";
 import { useEffect, useRef, useState } from "react";
 import { type AgentRecord, api } from "@/api";
 import { Icon } from "@/components/Icon";
 import { IconButton } from "@/components/ui/IconButton";
 import { getShellBuffer, registerShellSink } from "@/pty/buffers";
 import { useXterm } from "@/util/useXterm";
-
-/** Resolve a CSS custom property to a #rrggbb hex string.
- *  Works because the browser resolves oklch/hsl/etc to rgb() in getComputedStyle. */
-function resolveCSSVar(name: string): string {
-  const el = document.createElement("span");
-  el.style.cssText = `position:absolute;visibility:hidden;color:var(${name})`;
-  document.body.appendChild(el);
-  const rgb = getComputedStyle(el).color; // "rgb(r, g, b)"
-  document.body.removeChild(el);
-  const m = rgb.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
-  if (!m) return rgb;
-  return `#${[m[1], m[2], m[3]].map((n) => parseInt(n, 10).toString(16).padStart(2, "0")).join("")}`;
-}
-
-/** Resolve --accent to an rgba() string with the given alpha (0–1).
- *  Used for selection highlight so it inherits the active palette tint. */
-function resolveAccentRgba(alpha: number): string {
-  const hex = resolveCSSVar("--accent");
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-}
-
-/** Build the full xterm theme from the current CSS variable values.
- *  Called at mount and whenever the dark/light class changes on <html>. */
-function resolveTheme(): ITheme {
-  return {
-    background: resolveCSSVar("--bg-1"),
-    foreground: resolveCSSVar("--fg-1"),
-    cursor: resolveCSSVar("--accent"),
-    cursorAccent: resolveCSSVar("--bg-1"),
-    selectionBackground: resolveAccentRgba(0.28),
-    selectionInactiveBackground: resolveAccentRgba(0.14),
-    black: resolveCSSVar("--fg-3"),
-    red: resolveCSSVar("--danger"),
-    green: resolveCSSVar("--success"),
-    yellow: resolveCSSVar("--warn"),
-    blue: resolveCSSVar("--info"),
-    magenta: resolveCSSVar("--accent"),
-    cyan: resolveCSSVar("--info"),
-    white: resolveCSSVar("--fg-0"),
-    brightBlack: resolveCSSVar("--fg-3"),
-    brightRed: resolveCSSVar("--danger"),
-    brightGreen: resolveCSSVar("--success"),
-    brightYellow: resolveCSSVar("--warn"),
-    brightBlue: resolveCSSVar("--info"),
-    brightMagenta: resolveCSSVar("--accent"),
-    brightCyan: resolveCSSVar("--info"),
-    brightWhite: resolveCSSVar("--fg-0"),
-  };
-}
+import { resolveTheme } from "@/util/xtermTheme";
 
 export function TermPanel({ agent }: { agent: AgentRecord }) {
   const termRef = useRef<Terminal | null>(null);

--- a/src/util/useXterm.ts
+++ b/src/util/useXterm.ts
@@ -25,12 +25,18 @@ const XTERM_BASE_OPTIONS: ITerminalOptions = {
  *  return a cleanup that the hook runs on unmount, before disposing the
  *  terminal. The whole lifecycle re-runs whenever `deps` change (e.g. a
  *  different agent id).
+ *
+ *  `hostOptions.autoFocus` (default true) focuses the terminal after mount.
+ *  Read-only surfaces (e.g. a log view) pass false so mounting doesn't pull
+ *  keyboard focus away from the editor.
  */
 export function useXterm(
   options: ITerminalOptions,
   onReady: (term: Terminal) => (() => void) | undefined,
   deps: DependencyList,
+  hostOptions?: { autoFocus?: boolean },
 ) {
+  const autoFocus = hostOptions?.autoFocus ?? true;
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -81,7 +87,7 @@ export function useXterm(
       }, 100);
     });
     ro.observe(el);
-    term.focus();
+    if (autoFocus) term.focus();
 
     return () => {
       cancelAnimationFrame(initialFit);

--- a/src/util/xtermTheme.ts
+++ b/src/util/xtermTheme.ts
@@ -1,0 +1,53 @@
+import type { ITheme } from "@xterm/xterm";
+
+/** Resolve a CSS custom property to a #rrggbb hex string.
+ *  Works because the browser resolves oklch/hsl/etc to rgb() in getComputedStyle. */
+export function resolveCSSVar(name: string): string {
+  const el = document.createElement("span");
+  el.style.cssText = `position:absolute;visibility:hidden;color:var(${name})`;
+  document.body.appendChild(el);
+  const rgb = getComputedStyle(el).color; // "rgb(r, g, b)"
+  document.body.removeChild(el);
+  const m = rgb.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
+  if (!m) return rgb;
+  return `#${[m[1], m[2], m[3]].map((n) => parseInt(n, 10).toString(16).padStart(2, "0")).join("")}`;
+}
+
+/** Resolve --accent to an rgba() string with the given alpha (0–1).
+ *  Used for selection highlight so it inherits the active palette tint. */
+export function resolveAccentRgba(alpha: number): string {
+  const hex = resolveCSSVar("--accent");
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+/** Build the full xterm theme from the current CSS variable values.
+ *  Called at mount and whenever the dark/light class changes on <html>. */
+export function resolveTheme(): ITheme {
+  return {
+    background: resolveCSSVar("--bg-1"),
+    foreground: resolveCSSVar("--fg-1"),
+    cursor: resolveCSSVar("--accent"),
+    cursorAccent: resolveCSSVar("--bg-1"),
+    selectionBackground: resolveAccentRgba(0.28),
+    selectionInactiveBackground: resolveAccentRgba(0.14),
+    black: resolveCSSVar("--fg-3"),
+    red: resolveCSSVar("--danger"),
+    green: resolveCSSVar("--success"),
+    yellow: resolveCSSVar("--warn"),
+    blue: resolveCSSVar("--info"),
+    magenta: resolveCSSVar("--accent"),
+    cyan: resolveCSSVar("--info"),
+    white: resolveCSSVar("--fg-0"),
+    brightBlack: resolveCSSVar("--fg-3"),
+    brightRed: resolveCSSVar("--danger"),
+    brightGreen: resolveCSSVar("--success"),
+    brightYellow: resolveCSSVar("--warn"),
+    brightBlue: resolveCSSVar("--info"),
+    brightMagenta: resolveCSSVar("--accent"),
+    brightCyan: resolveCSSVar("--info"),
+    brightWhite: resolveCSSVar("--fg-0"),
+  };
+}


### PR DESCRIPTION
## What

Replaces the Run panel's plain-text log `<div>` with a **read-only xterm terminal** — the same hook (`useXterm`) that already powers `TermPanel`. Run output now renders ANSI **colors** *and* **cursor control** (spinners, progress-bar `\r` rewrites) faithfully, instead of being ANSI-stripped to plain text.

Raw PTY bytes from the `run:output` event are written straight to the terminal (`term.write(Uint8Array)`), so xterm owns UTF-8 decoding, scrollback, and scrolling.

## Why

The previous approach stripped all ANSI and accumulated output into React state, doing a full re-render + up-to-256KB string realloc + regex pass on every chunk. Cursor-control sequences (spinners, in-place progress bars common to dev servers) rendered as garbled duplicated lines.

xterm was already a proven dependency here, so this is a low-overhead swap — writes now bypass React entirely. The only added cost is the per-panel xterm buffer + WebGL context, which the app already pays for `TermPanel`.

## Changes

- **`RunPanel.tsx`** — mount a read-only xterm (`disableStdin`, no input caret, `scrollback: 20000`); stream `run:output` bytes + snapshot rehydration into it. Removed `stripAnsi`/`ANSI_RE`, `capLog`/`MAX_LOG_CHARS`, the `log` state, the streaming `TextDecoder`, and the auto-scroll effect. Added the dark/light theme `MutationObserver`. `last_error` stays a separate banner (supervisor message, distinct from process stderr already in the terminal).
- **`src/util/xtermTheme.ts`** (new) — extracted `resolveTheme`/`resolveCSSVar`/`resolveAccentRgba` out of `TermPanel.tsx` so both panels share one theme source.
- **`TermPanel.tsx`** — imports the shared theme helpers instead of defining them inline.
- **`useXterm.ts`** — added optional `hostOptions.autoFocus` (default `true`); the read-only Run panel passes `false` so mounting doesn't steal keyboard focus from the editor.
- **`RunPanel.css`** — dropped dead `.run-logs`/`.term-cursor` rules; added `.run-error` banner + viewport scroll rule.

## Testing

- `tsc --noEmit` — passes
- `biome check` — passes

Not yet verified live in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)