### PR TITLE
fix(macos): reopen main window on dock-icon click

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1527,6 +1527,15 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building fletch")
         .run(|app, event| {
+            // Dock-icon click (or any macOS reopen) while the app is running
+            // but the main window is hidden — closing the window only hides it
+            // (see the `CloseRequested` handler), so re-show it here, matching
+            // the tray's "Open Fletch" behavior. macOS-only event.
+            #[cfg(target_os = "macos")]
+            if let tauri::RunEvent::Reopen { .. } = event {
+                show_main_window(app);
+                return;
+            }
             if let tauri::RunEvent::ExitRequested { api, .. } = event {
                 use std::sync::atomic::Ordering;
                 // Quit confirmation: a quit kills every live agent/run child


### PR DESCRIPTION
## Problem

After the tray-icon change, closing the window no longer quits Fletch — the `CloseRequested` handler calls `api.prevent_close()` + `window.hide()`, so the app keeps running in the tray/dock. Reopening the window was only wired to the **tray icon** (`show_main_window`). Clicking the **dock icon** did nothing.

On macOS, clicking a running app's dock icon fires `applicationShouldHandleReopen`, which Tauri surfaces as `RunEvent::Reopen`. That event was never handled.

## Fix

Add a `RunEvent::Reopen` handler to the run-loop in `src-tauri/src/lib.rs` that calls the existing `show_main_window(app)` helper — the same one the tray's "Open Fletch" item uses (`unminimize` + `show` + `set_focus`).

The handler is `#[cfg(target_os = "macos")]`-gated because `RunEvent::Reopen` only exists on macOS (tauri 2.11.2), so non-macOS builds are unaffected.

## Testing

- `cargo check` passes.
- Requires a rebuild/relaunch to observe: after closing the window, clicking the dock icon now re-shows the main window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)