### PR TITLE
feat(settings): group Custom agents / Tools / Skills under "Customize"

### DIFF
--- a/src/components/ProjectSettings/EnvVarsSection/index.tsx
+++ b/src/components/ProjectSettings/EnvVarsSection/index.tsx
@@ -199,11 +199,9 @@ export function EnvVarsSection({ projectId, repoPath }: Props) {
       <header className="ps-section-h">
         <h2 className="ps-section-t text-lg">Environment variables</h2>
         <p className="ps-section-lead text-sm">
-          Variables found in this project’s <code>.env</code>. Nothing is shared with the sandbox
-          unless you switch it on. Shared values are mirrored live from <code>.env</code>; edit one
-          to override it (e.g. a disposable per-agent database) — use <code>{"{{agent_id}}"}</code>{" "}
-          for a per-agent value, and clear the field to revert to <code>.env</code>. Add a variable
-          that isn’t in <code>.env</code> with the button below.
+          Variables from this project’s <code>.env</code> — nothing reaches the sandbox unless you
+          switch it on. Edit a shared value to override it (use <code>{"{{agent_id}}"}</code> per
+          agent), or add one below.
         </p>
       </header>
 

--- a/src/components/SettingsScreen/CustomAgents/AgentList.tsx
+++ b/src/components/SettingsScreen/CustomAgents/AgentList.tsx
@@ -1,4 +1,5 @@
 import { Icon } from "@/components/Icon";
+import { CustomizeSwitch } from "@/components/SettingsScreen/CustomizeSwitch";
 import { ArmedDeleteButton, useArmedDelete } from "@/components/SettingsScreen/LibraryList";
 import { SetHead } from "@/components/SettingsScreen/primitives";
 import { Button } from "@/components/ui/Button";
@@ -33,7 +34,8 @@ export function AgentList({
   return (
     <div className="set-pane">
       <SetHead
-        eyebrow="Settings · Custom agents"
+        eyebrow="Settings · Customize"
+        eyebrowAside={<CustomizeSwitch />}
         title="Custom agents"
         desc="Give a base coding agent a name, a model, and a standing brief. Custom agents show up in the composer next to the built-ins."
         actions={

--- a/src/components/SettingsScreen/CustomizeSwitch.tsx
+++ b/src/components/SettingsScreen/CustomizeSwitch.tsx
@@ -1,0 +1,33 @@
+import { Icon, type IconName } from "@/components/Icon";
+import type { SettingsSection } from "@/storage/preferences";
+import { useAppStore } from "@/store";
+
+/** The Custom agents / Tools / Skills switch shown on the eyebrow row of each
+ *  Customize pane. Same `.set-seg` pill styling as the new-agent page's
+ *  Agent | Workflow toggle. Reads the active section straight from the store so
+ *  the list panes can drop it in without threading section state through. */
+const TABS: { id: SettingsSection; label: string; icon: IconName }[] = [
+  { id: "agents", label: "Custom agents", icon: "bot" },
+  { id: "tools", label: "Tools", icon: "zap" },
+  { id: "skills", label: "Skills", icon: "notebookPen" },
+];
+
+export function CustomizeSwitch() {
+  const section = useAppStore((s) => s.settingsSection);
+  const setSection = useAppStore((s) => s.setSettingsSection);
+
+  return (
+    <div className="set-seg">
+      {TABS.map((t) => (
+        <button
+          key={t.id}
+          type="button"
+          className={section === t.id ? "active" : ""}
+          onClick={() => setSection(t.id)}
+        >
+          <Icon name={t.icon} size={13} /> {t.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/SettingsScreen/LibraryList.tsx
+++ b/src/components/SettingsScreen/LibraryList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 import { Icon, type IconName } from "@/components/Icon";
 import { SetHead } from "@/components/SettingsScreen/primitives";
 import { Button } from "@/components/ui/Button";
@@ -56,6 +56,7 @@ export function ArmedDeleteButton({ armed, onClick }: { armed: boolean; onClick:
  *  idiom via {@link useArmedDelete}. */
 export function LibraryList<T extends { id: string }>({
   eyebrow,
+  eyebrowAside,
   title,
   desc,
   newLabel,
@@ -68,6 +69,8 @@ export function LibraryList<T extends { id: string }>({
   onDelete,
 }: {
   eyebrow: string;
+  /** Optional controls for the eyebrow row — e.g. the Customize section switch. */
+  eyebrowAside?: ReactNode;
   title: string;
   desc: string;
   newLabel: string;
@@ -87,6 +90,7 @@ export function LibraryList<T extends { id: string }>({
     <div className="set-pane">
       <SetHead
         eyebrow={eyebrow}
+        eyebrowAside={eyebrowAside}
         title={title}
         desc={desc}
         actions={

--- a/src/components/SettingsScreen/McpServers/index.tsx
+++ b/src/components/SettingsScreen/McpServers/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { CustomizeSwitch } from "@/components/SettingsScreen/CustomizeSwitch";
 import { LibraryList } from "@/components/SettingsScreen/LibraryList";
 import type { McpServer, NewMcpServer } from "@/storage/mcpServers";
 import { useAppStore } from "@/store";
@@ -67,7 +68,8 @@ export function McpServersPane() {
 
   return (
     <LibraryList
-      eyebrow="Settings · Tools"
+      eyebrow="Settings · Customize"
+      eyebrowAside={<CustomizeSwitch />}
       title="Tools (MCP)"
       desc="MCP servers your custom agents can attach as tools. Supported by Claude Code and Codex bases; other bases run without them. Running sessions keep the configuration they spawned with."
       newLabel="New server"

--- a/src/components/SettingsScreen/SettingsScreen.css
+++ b/src/components/SettingsScreen/SettingsScreen.css
@@ -109,7 +109,7 @@
     var(--bg-1);
 }
 .set-content {
-  max-width: 720px;
+  max-width: 860px;
   margin: 0 auto;
   padding: 52px 56px 96px;
 }
@@ -143,13 +143,27 @@
   gap: 4px;
   flex-shrink: 0;
 }
+/* Eyebrow row: the "Settings · X" kicker, plus an optional right-aligned aside
+   (the Customize section switch). Sits above the tab-dependent title. */
+.set-head-eyebrow {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 32px;
+}
+.set-head-eyebrow-aside {
+  gap: 4px;
+  flex-shrink: 0;
+  /* Nudge the section switch up so it optically aligns with the eyebrow cap. */
+  margin-top: -12px;
+}
 .set-eyebrow {
   font-weight: 500;
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--accent);
   white-space: nowrap;
-  margin-bottom: 12px;
 }
 .set-h1 {
   font-weight: 500;
@@ -288,6 +302,13 @@
   background: var(--bg-2);
   color: var(--fg-0);
   box-shadow: var(--shadow-1);
+}
+/* Customize section switch: icon + label per pill, like the new-agent page's
+   Agent | Workflow toggle. */
+.set-head-eyebrow-aside .set-seg button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
 
 /* accent swatches */

--- a/src/components/SettingsScreen/Skills/index.tsx
+++ b/src/components/SettingsScreen/Skills/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { CustomizeSwitch } from "@/components/SettingsScreen/CustomizeSwitch";
 import { LibraryList } from "@/components/SettingsScreen/LibraryList";
 import type { NewSkill, Skill } from "@/storage/skills";
 import { useAppStore } from "@/store";
@@ -69,7 +70,8 @@ export function SkillsPane() {
 
   return (
     <LibraryList
-      eyebrow="Settings · Skills"
+      eyebrow="Settings · Customize"
+      eyebrowAside={<CustomizeSwitch />}
       title="Skills"
       desc="Named instruction documents your custom agents load on demand. Assign skills to agents in their editor; running sessions keep the version they spawned with."
       newLabel="New skill"

--- a/src/components/SettingsScreen/index.tsx
+++ b/src/components/SettingsScreen/index.tsx
@@ -21,17 +21,35 @@ const DeveloperPane = import.meta.env.DEV
 
 // Built-in sections carry explicit order weights (spaced by 10) so extension
 // panes can slot *between* them via their own `order`, not just append.
-type NavItem = { id: SettingsSection; label: string; icon: IconName; order: number };
+// `subsections` groups several sections behind a single nav entry, surfaced as
+// an in-pane segmented switch (see CUSTOMIZE_IDS below).
+type NavItem = {
+  id: SettingsSection;
+  label: string;
+  icon: IconName;
+  order: number;
+  subsections?: SettingsSection[];
+};
+
+// Custom agents / Tools / Skills are all agent-building primitives — tools and
+// skills exist mainly to be composed into agents — so they live behind one
+// "Customize" nav entry with an in-pane segmented switch (see CustomizeSwitch).
+// The nav entry's `id` is the default sub-tab.
+const CUSTOMIZE_IDS: SettingsSection[] = ["agents", "tools", "skills"];
 
 const NAV: NavItem[] = [
   { id: "account", label: "Account", icon: "user", order: 10 },
   { id: "general", label: "General", icon: "settings", order: 20 },
   { id: "providers", label: "Providers", icon: "cube", order: 30 },
-  { id: "agents", label: "Custom agents", icon: "bot", order: 40 },
-  // Right after Custom agents — workflows chain those agents.
+  {
+    id: "agents",
+    label: "Customize",
+    icon: "sparkle",
+    order: 40,
+    subsections: CUSTOMIZE_IDS,
+  },
+  // Right after Customize — workflows chain those custom agents.
   { id: "workflows", label: "Workflows", icon: "combine", order: 41 },
-  { id: "skills", label: "Skills", icon: "notebookPen", order: 42 },
-  { id: "tools", label: "Tools", icon: "zap", order: 44 },
   { id: "experimental", label: "Experimental", icon: "flask", order: 50 },
   // Dev-only: omitted entirely from production builds.
   ...(DeveloperPane
@@ -60,16 +78,25 @@ export function SettingsScreen() {
           <span>Back to app</span>
         </button>
         <div className="set-nav-list">
-          {NAV.map((n) => (
-            <button
-              key={n.id}
-              className={`set-nav-item flex-center text-base ${section === n.id ? "active" : ""}`}
-              onClick={() => setSection(n.id)}
-            >
-              <Icon name={n.icon} size={14} />
-              <span>{n.label}</span>
-            </button>
-          ))}
+          {NAV.map((n) => {
+            // A grouped entry stays active for any of its sub-sections, and
+            // clicking it while already inside the group keeps the current
+            // sub-tab rather than snapping back to the default.
+            const active = n.subsections ? n.subsections.includes(section) : section === n.id;
+            return (
+              <button
+                key={n.id}
+                className={`set-nav-item flex-center text-base ${active ? "active" : ""}`}
+                onClick={() => {
+                  if (active && n.subsections) return;
+                  setSection(n.id);
+                }}
+              >
+                <Icon name={n.icon} size={14} />
+                <span>{n.label}</span>
+              </button>
+            );
+          })}
         </div>
         <div className="set-nav-foot text-xs">
           <span className="mono">Fletch</span>

--- a/src/components/SettingsScreen/primitives.tsx
+++ b/src/components/SettingsScreen/primitives.tsx
@@ -14,11 +14,15 @@ export interface FeatureItem {
 
 export function SetHead({
   eyebrow,
+  eyebrowAside,
   title,
   desc,
   actions,
 }: {
   eyebrow: string;
+  /** Optional controls aligned to the right of the eyebrow row — e.g. the
+   *  Customize section switch, which sits above the (tab-dependent) title. */
+  eyebrowAside?: ReactNode;
   title: string;
   desc?: ReactNode;
   /** Optional controls aligned to the right of the title row. */
@@ -26,9 +30,12 @@ export function SetHead({
 }) {
   return (
     <header className="set-head">
+      <div className="set-head-eyebrow">
+        <div className="set-eyebrow mono text-xs">{eyebrow}</div>
+        {eyebrowAside && <div className="set-head-eyebrow-aside flex-center">{eyebrowAside}</div>}
+      </div>
       <div className="set-head-top">
         <div className="set-head-titles">
-          <div className="set-eyebrow mono text-xs">{eyebrow}</div>
           <h1 className="set-h1 text-3xl">{title}</h1>
         </div>
         {actions && <div className="set-head-actions flex-center">{actions}</div>}

--- a/src/workflows/builder/WorkflowList.tsx
+++ b/src/workflows/builder/WorkflowList.tsx
@@ -4,6 +4,7 @@
 import { Fragment } from "react";
 import { Icon } from "../../components/Icon";
 import { SetHead } from "../../components/SettingsScreen/primitives";
+import { Button } from "../../components/ui/Button";
 import type { ModelMeta } from "../../data/modelCatalog/types";
 import type { CustomAgent } from "../../storage/customAgents";
 import { type resolveAgent, resolveAlias } from "../shared";
@@ -117,7 +118,12 @@ export function WorkflowList({
       <SetHead
         eyebrow="Settings · Workflows"
         title="Workflows"
-        desc="Chain agents into a repeatable pipeline. Each step hands its work to the next on the same git branch — so the checkout itself is the shared context. Define once here; launch on any task."
+        desc="Chain agents into a repeatable pipeline, each handing off on the same git branch. Define once here; launch on any task."
+        actions={
+          <Button variant="primary" onClick={onNew}>
+            <Icon name="plus" size={13} /> New workflow
+          </Button>
+        }
       />
 
       <div className="set-list-head">
@@ -133,9 +139,6 @@ export function WorkflowList({
           )}
           <button className="btn-t" onClick={onImport}>
             <Icon name="upload" size={13} /> Import
-          </button>
-          <button className="btn-t primary" onClick={onNew}>
-            <Icon name="plus" size={13} /> New workflow
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Combines the three agent-building primitives — **Custom agents**, **Tools**, and **Skills** — behind a single **Customize** nav entry in settings, with an in-pane segmented switch to move between them (styled like the new-agent Agent/Workflow toggle). Tools and Skills exist mainly to be composed into custom agents, so this groups them by that relationship rather than presenting three peer sections. **Workflows** stays a separate top-level entry.

Underlying section ids (`agents`/`tools`/`skills`) are unchanged, so existing deep-links and the `settingsIntent` flow keep working — only the presentation changes.

## Changes

- **New `CustomizeSwitch`** component (reads section state from the store) shown on the eyebrow row of each Customize list pane.
- **`SetHead`** gains an `eyebrowAside` slot: the eyebrow is now its own row with a right-aligned aside. Panes without an aside are visually unchanged.
- Eyebrow copy for the three panes becomes `Settings · Customize`; per-tab titles (Custom agents / Tools (MCP) / Skills) stay in place.
- **Layout polish:** settings content column widened to 860px; eyebrow-to-title gap bumped to 32px; Customize switch nudged up 12px for optical alignment.
- **Workflows page:** `New workflow` button moved into the header `actions` slot (shared `Button`, primary), matching the Custom agents page; description trimmed to 2 lines.
- **Project settings:** Environment variables description trimmed to 2 lines.

## Testing

- `tsc --noEmit` passes
- `biome check` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)