### PR TITLE
feat(workflows): vertical pipeline editor with right-hand inspector

### DIFF
--- a/src/components/SettingsScreen/SettingsScreen.css
+++ b/src/components/SettingsScreen/SettingsScreen.css
@@ -113,9 +113,10 @@
   margin: 0 auto;
   padding: 52px 56px 96px;
 }
-/* Wider column for panes that opt in — e.g. the workflow builder canvas. */
+/* Wider column for panes that opt in — e.g. the workflow builder canvas,
+   which lays a pipeline canvas and a sticky inspector side by side. */
 .set-content.is-wide {
-  max-width: 1080px;
+  max-width: 1240px;
 }
 @media (max-width: 1080px) {
   .set-content {

--- a/src/workflows/builder/WorkflowBuilder.tsx
+++ b/src/workflows/builder/WorkflowBuilder.tsx
@@ -105,7 +105,8 @@ export function WorkflowBuilder({
         setState(r.state);
         setSel(r.nid);
       },
-      openAgent: (nid, role: AgentRole, e) => setPop({ type: "agent", nid, role, rect: rectFrom(e) }),
+      openAgent: (nid, role: AgentRole, e) =>
+        setPop({ type: "agent", nid, role, rect: rectFrom(e) }),
     }),
     // validation is derived from state, so ctx refreshes on every edit — the
     // closures over `state` above stay current.

--- a/src/workflows/builder/WorkflowBuilder.tsx
+++ b/src/workflows/builder/WorkflowBuilder.tsx
@@ -1,21 +1,23 @@
-// WorkflowBuilder.tsx — the block-tree editor (spec §14.1). The canvas renders
-// the recursive block sequence; a shared `ctx` lets any nested card dispatch an
-// edit or open a popover. Validation from `model.ts` renders inline and gates
-// the save. Persistence is the caller's job (Save hands back the editor state).
+// WorkflowBuilder.tsx — the block-tree editor (spec §14.1), v2 layout: a
+// vertical pipeline canvas on the left, a sticky inspector on the right editing
+// the selected node (or the workflow overview). A shared `ctx` lets any nested
+// card dispatch an edit, select itself, or open the agent picker. Validation
+// from `model.ts` renders inline and gates the save. Persistence is the
+// caller's job (Save hands back the editor state).
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Icon } from "../../components/Icon";
 import type { ModelMeta } from "../../data/modelCatalog/types";
 import type { CustomAgent } from "../../storage/customAgents";
 import { resolveAlias } from "../shared";
-import type { Budgets, Gate, Spec } from "../spec";
+import type { Spec } from "../spec";
 import { BlockSequence } from "./blocks/BlockSequence";
 import type { BuilderCtx, Pop, PopRect } from "./ctx";
 import {
   type AgentRole,
   addBlockOfType,
   addStepToContainer,
-  findStep,
+  findNode,
   patchBlock,
   patchStep,
   removeNode,
@@ -23,9 +25,10 @@ import {
   setField,
 } from "./edits";
 import { useDismissOnViewportChange } from "./hooks";
+import { Inspector } from "./inspector";
 import type { EditorState, NodeId } from "./model";
 import { toSpec, validateEditor } from "./model";
-import { AgentPick, BudgetsPopover, GatePick } from "./pickers";
+import { AgentPick } from "./pickers";
 
 /** Launch context threaded in when the builder was opened by "promote to
  *  workflow": the run's fork point + brief ride alongside the definition so the
@@ -67,6 +70,7 @@ export function WorkflowBuilder({
   promote?: PromoteLaunch;
 }) {
   const [state, setState] = useState<EditorState>(initial);
+  const [sel, setSel] = useState<NodeId | null>(null);
   const [launchTask, setLaunchTask] = useState(promote?.taskSeed ?? "");
   const [pop, setPop] = useState<Pop | null>(null);
   const closePop = () => setPop(null);
@@ -74,35 +78,41 @@ export function WorkflowBuilder({
 
   const validation = useMemo(() => validateEditor(state), [state]);
 
+  // A deleted node can't stay selected — fall back to the overview.
+  const selected = sel ? findNode(state, sel) : null;
+  useEffect(() => {
+    if (sel && !findNode(state, sel)) setSel(null);
+  }, [state, sel]);
+
   const ctx: BuilderCtx = useMemo(
     () => ({
       // `id` is an alias into `state.agents`; `resolveAlias` maps it to the
       // underlying custom-agent id or base provider before rendering.
       resolve: (id) => resolveAlias(state.agents, id ?? undefined, agents, modelsByAgent),
       errorsFor: (nid) => validation.byNode[nid],
+      selectedNid: sel,
+      select: setSel,
       patchStep: (nid, patch) => setState((s) => patchStep(s, nid, patch)),
       patchBlock: (nid, patch) => setState((s) => patchBlock(s, nid, patch)),
       removeNode: (nid) => setState((s) => removeNode(s, nid)),
-      addStepToContainer: (nid) => setState((s) => addStepToContainer(s, nid)),
-      addBlock: (seqNid, type) => setState((s) => addBlockOfType(s, seqNid, type)),
-      openAgent: (nid, role: AgentRole, e) =>
-        setPop({ type: "agent", nid, role, rect: rectFrom(e) }),
-      openGate: (nid, e) => setPop({ type: "gate", nid, rect: rectFrom(e) }),
-      openBudgets: (target, e) => setPop({ type: "budgets", target, rect: rectFrom(e) }),
+      addStepToContainer: (nid) => {
+        const r = addStepToContainer(state, nid);
+        setState(r.state);
+        setSel(r.nid);
+      },
+      addBlock: (seqNid, type, index) => {
+        const r = addBlockOfType(state, seqNid, type, index);
+        setState(r.state);
+        setSel(r.nid);
+      },
+      openAgent: (nid, role: AgentRole, e) => setPop({ type: "agent", nid, role, rect: rectFrom(e) }),
     }),
-    [agents, modelsByAgent, validation, state.agents],
+    // validation is derived from state, so ctx refreshes on every edit — the
+    // closures over `state` above stay current.
+    [agents, modelsByAgent, validation, state, sel],
   );
 
-  const runBudgetLabel = state.budgets?.turns ? `${state.budgets.turns} turns` : "budgets";
-  const finalize = state.finalize;
-
-  const setGate = (nid: NodeId, gate: Gate) => setState((s) => patchStep(s, nid, { gate }));
-  const budgetsOf = (target: NodeId | "run"): Budgets | undefined =>
-    target === "run" ? state.budgets : (findStep(state, target)?.budgets ?? undefined);
-  const setBudgets = (target: NodeId | "run", next: Budgets | undefined) =>
-    target === "run"
-      ? setState((s) => setField(s, { budgets: next }))
-      : setState((s) => patchStep(s, target, { budgets: next }));
+  const onField = (patch: Partial<EditorState>) => setState((s) => setField(s, patch));
 
   return (
     <div className="set-pane">
@@ -111,139 +121,53 @@ export function WorkflowBuilder({
           <Icon name="chevL" /> All workflows
         </button>
 
-        <div className="wb-top">
-          <div className="wb-titlewrap">
-            <input
-              className="wb-name"
-              placeholder="Name this workflow…"
-              value={state.name}
-              autoFocus
-              onChange={(e) => setState((s) => setField(s, { name: e.target.value }))}
-            />
-            <textarea
-              className="wb-desc"
-              rows={1}
-              placeholder="What is this pipeline for?"
-              value={state.description}
-              onChange={(e) => setState((s) => setField(s, { description: e.target.value }))}
-            />
-          </div>
-          <button
-            className="wb-chip-btn lg tip"
-            data-tip-down
-            data-tip="Run-level budgets"
-            onClick={(e) => ctx.openBudgets("run", e)}
-          >
-            <Icon name="clock" size={12} /> {runBudgetLabel}
-          </button>
-        </div>
-
-        <div className="wb-canvas">
-          <BlockSequence blocks={state.blocks} seqNid={null} ctx={ctx} />
-        </div>
-
-        <div className="wb-finish">
-          <span className="wb-finish-l">When the run finishes</span>
-          <label className="wb-toggle">
-            <input
-              type="checkbox"
-              checked={!!finalize?.push}
-              onChange={(e) =>
-                setState((s) =>
-                  setField(s, {
-                    finalize: {
-                      push: e.target.checked,
-                      open_pr: finalize?.open_pr ?? false,
-                      pr_base: finalize?.pr_base,
-                    },
-                  }),
-                )
-              }
-            />
-            Push the branch
-          </label>
-          <label className="wb-toggle">
-            <input
-              type="checkbox"
-              checked={!!finalize?.open_pr}
-              onChange={(e) =>
-                setState((s) =>
-                  setField(s, {
-                    finalize: {
-                      push: finalize?.push ?? false,
-                      open_pr: e.target.checked,
-                      pr_base: finalize?.pr_base,
-                    },
-                  }),
-                )
-              }
-            />
-            Open a PR
-          </label>
-          {finalize?.open_pr && (
-            <input
-              className="ca-input sm"
-              style={{ width: 120 }}
-              placeholder="base: main"
-              value={finalize.pr_base ?? ""}
-              onChange={(e) =>
-                setState((s) =>
-                  setField(s, {
-                    finalize: {
-                      push: finalize.push,
-                      open_pr: finalize.open_pr,
-                      pr_base: e.target.value.trim() || undefined,
-                    },
-                  }),
-                )
-              }
-            />
-          )}
-        </div>
-
-        {promote && (
-          <div className="wb-promote">
-            <div className="wb-promote-head">
-              <Icon name="combine" size={13} style={{ color: "var(--accent)" }} />
-              <span>Launch this workflow now</span>
-              <span
-                className="wb-promote-base tip"
-                data-tip="Forks from the promoted session's commit"
-              >
-                base <span className="mono">{promote.baseLabel}</span>
-              </span>
+        <div className="wb-body">
+          <div className="wb-canvas" style={{ "--h": state.hue } as React.CSSProperties}>
+            <div className="wb-head">
+              <div className="wb-eyebrow">Workflow pipeline</div>
+              <input
+                className="wb-name"
+                placeholder="Name this workflow…"
+                value={state.name}
+                autoFocus={isNew}
+                onChange={(e) => onField({ name: e.target.value })}
+              />
+              <textarea
+                className="wb-desc"
+                rows={2}
+                placeholder="What is this pipeline for? Each step hands off to the next."
+                value={state.description}
+                onChange={(e) => onField({ description: e.target.value })}
+              />
             </div>
-            <textarea
-              className="wb-desc"
-              rows={2}
-              placeholder="Task for the run…"
-              value={launchTask}
-              onChange={(e) => setLaunchTask(e.target.value)}
-            />
-            {promote.launchError && <div className="wb-summary-err">{promote.launchError}</div>}
-            <div className="wb-promote-foot">
-              <span className="wb-promote-note">Or just save it as a reusable workflow below.</span>
-              <span className="grow" />
-              <button
-                className="btn-t primary"
-                disabled={!validation.ok || !launchTask.trim() || promote.launching}
-                style={
-                  !validation.ok || !launchTask.trim() || promote.launching
-                    ? { opacity: 0.5 }
-                    : undefined
-                }
-                onClick={() =>
-                  validation.ok &&
-                  launchTask.trim() &&
-                  promote.onLaunch(toSpec(state), launchTask.trim())
-                }
-              >
-                <Icon name={promote.launching ? "refresh" : "arrowUp"} size={13} />{" "}
-                {promote.launching ? "Launching…" : "Launch run"}
-              </button>
-            </div>
+
+            <BlockSequence blocks={state.blocks} seqNid={null} ctx={ctx} />
           </div>
-        )}
+
+          <Inspector
+            state={state}
+            selected={selected}
+            ctx={ctx}
+            onField={onField}
+            formErrors={validation.form}
+            promote={
+              promote
+                ? {
+                    baseLabel: promote.baseLabel,
+                    task: launchTask,
+                    setTask: setLaunchTask,
+                    canLaunch: validation.ok && !!launchTask.trim(),
+                    launching: promote.launching,
+                    launchError: promote.launchError,
+                    onLaunch: () =>
+                      validation.ok &&
+                      launchTask.trim() &&
+                      promote.onLaunch(toSpec(state), launchTask.trim()),
+                  }
+                : undefined
+            }
+          />
+        </div>
 
         <div className="wb-foot">
           <div className="wb-summary">
@@ -286,44 +210,6 @@ export function WorkflowBuilder({
             setState((s) => setAgent(s, pop.nid, pop.role, id, agents));
             closePop();
           }}
-        />
-      )}
-      {pop?.type === "gate" && (
-        <GatePick
-          rect={pop.rect}
-          gate={findStep(state, pop.nid)?.gate.type ?? "verdict"}
-          requireTests={(() => {
-            const cur = findStep(state, pop.nid)?.gate;
-            return cur?.type === "approval" && (cur.require?.includes("tests") ?? false);
-          })()}
-          onPick={(kind) => {
-            const cur = findStep(state, pop.nid)?.gate;
-            const gate: Gate =
-              kind === "artifact"
-                ? { type: "artifact", path: cur?.type === "artifact" ? cur.path : "" }
-                : // Re-picking approval preserves any existing `require: [tests]`.
-                  kind === "approval"
-                  ? {
-                      type: "approval",
-                      require: cur?.type === "approval" ? cur.require : undefined,
-                    }
-                  : { type: kind };
-            setGate(pop.nid, gate);
-            // The gate mode is chosen; approval's require checkbox lives in the
-            // same popover, so keep it open rather than closing on pick.
-            if (kind !== "approval") closePop();
-          }}
-          onToggleRequireTests={(checked) => {
-            setGate(pop.nid, { type: "approval", require: checked ? ["tests"] : undefined });
-          }}
-        />
-      )}
-      {pop?.type === "budgets" && (
-        <BudgetsPopover
-          rect={pop.rect}
-          scope={pop.target === "run" ? "run" : "step"}
-          value={budgetsOf(pop.target)}
-          onChange={(next) => setBudgets(pop.target, next)}
         />
       )}
     </div>

--- a/src/workflows/builder/WorkflowBuilder.tsx
+++ b/src/workflows/builder/WorkflowBuilder.tsx
@@ -15,9 +15,11 @@ import { BlockSequence } from "./blocks/BlockSequence";
 import type { BuilderCtx, Pop, PopRect } from "./ctx";
 import {
   type AgentRole,
-  addBlockOfType,
+  addBlock,
   addStepToContainer,
+  editorStepIds,
   findNode,
+  newBlockOfType,
   patchBlock,
   patchStep,
   removeNode,
@@ -27,7 +29,7 @@ import {
 import { useDismissOnViewportChange } from "./hooks";
 import { Inspector } from "./inspector";
 import type { EditorState, NodeId } from "./model";
-import { toSpec, validateEditor } from "./model";
+import { newStep, toSpec, validateEditor } from "./model";
 import { AgentPick } from "./pickers";
 
 /** Launch context threaded in when the builder was opened by "promote to
@@ -95,15 +97,18 @@ export function WorkflowBuilder({
       patchStep: (nid, patch) => setState((s) => patchStep(s, nid, patch)),
       patchBlock: (nid, patch) => setState((s) => patchBlock(s, nid, patch)),
       removeNode: (nid) => setState((s) => removeNode(s, nid)),
+      // Structural adds build the node eagerly (fixed nid to select; the global
+      // id counters keep step ids unique) but insert with a functional update,
+      // so rapid successive adds merge instead of overwriting each other.
       addStepToContainer: (nid) => {
-        const r = addStepToContainer(state, nid);
-        setState(r.state);
-        setSel(r.nid);
+        const step = newStep(editorStepIds(state));
+        setState((s) => addStepToContainer(s, nid, step));
+        setSel(step.nid);
       },
       addBlock: (seqNid, type, index) => {
-        const r = addBlockOfType(state, seqNid, type, index);
-        setState(r.state);
-        setSel(r.nid);
+        const block = newBlockOfType(editorStepIds(state), type);
+        setState((s) => addBlock(s, seqNid, block, index));
+        setSel(block.nid);
       },
       openAgent: (nid, role: AgentRole, e) =>
         setPop({ type: "agent", nid, role, rect: rectFrom(e) }),

--- a/src/workflows/builder/blocks/BlockSequence.tsx
+++ b/src/workflows/builder/blocks/BlockSequence.tsx
@@ -1,10 +1,11 @@
-// BlockSequence.tsx — renders a sequence of blocks left-to-right with connectors
-// and an "add block" menu. Used at the top level and (recursively) for loop
-// bodies, so it takes its owning sequence's nid (`null` = top level).
+// BlockSequence.tsx — renders a sequence of blocks as a vertical pipeline with
+// connectors (each offering an insert point) and a trailing "Add block" button.
+// Used at the top level and (recursively) for loop bodies, so it takes its
+// owning sequence's nid (`null` = top level).
 
 import { Fragment, useState } from "react";
 import { Icon } from "../../../components/Icon";
-import { BLOCK_TYPES } from "../../data";
+import { BLOCK_TYPES, type BlockTypeDef } from "../../data";
 import type { BuilderCtx } from "../ctx";
 import { useDismissOnViewportChange } from "../hooks";
 import type { EBlock, NodeId } from "../model";
@@ -31,16 +32,51 @@ function BlockNode({
   if (block.kind === "step") {
     return <StepCard step={block} ctx={ctx} indexLabel={pad2(index + 1)} canRemove={canRemove} />;
   }
-  if (block.kind === "parallel") return <ParallelContainer block={block} ctx={ctx} />;
-  if (block.kind === "loop") return <LoopContainer block={block} ctx={ctx} />;
-  return <OrchestrateContainer block={block} ctx={ctx} />;
+  if (block.kind === "parallel") {
+    return <ParallelContainer block={block} ctx={ctx} indexLabel={pad2(index + 1)} />;
+  }
+  if (block.kind === "loop") {
+    return <LoopContainer block={block} ctx={ctx} indexLabel={pad2(index + 1)} />;
+  }
+  return <OrchestrateContainer block={block} ctx={ctx} indexLabel={pad2(index + 1)} />;
 }
 
-function Connector() {
+/** The fixed-positioned block-type menu shared by connectors and "Add block". */
+function BlockMenu({
+  at,
+  types,
+  onPick,
+  onClose,
+}: {
+  at: { top: number; left: number };
+  types: BlockTypeDef[];
+  onPick: (type: BlockTypeDef["id"]) => void;
+  onClose: () => void;
+}) {
   return (
-    <div className="wb-conn">
-      <Icon name="arrowR" />
-    </div>
+    <>
+      <div style={{ position: "fixed", inset: 0, zIndex: 55 }} onClick={onClose} />
+      <div className="dd wb-add-menu" style={{ position: "fixed", top: at.top, left: at.left }}>
+        {types.map((t) => (
+          <div
+            key={t.id}
+            className="dd-item"
+            onClick={() => {
+              onPick(t.id);
+              onClose();
+            }}
+            style={{ alignItems: "flex-start", flexDirection: "column", gap: 2 }}
+          >
+            <span style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <Icon name={t.icon} size={12} /> <span style={{ fontWeight: 500 }}>{t.label}</span>
+            </span>
+            <span style={{ fontSize: 11, color: "var(--fg-2)", lineHeight: 1.4, paddingLeft: 20 }}>
+              {t.note}
+            </span>
+          </div>
+        ))}
+      </div>
+    </>
   );
 }
 
@@ -53,9 +89,9 @@ export function BlockSequence({
   seqNid: NodeId | null;
   ctx: BuilderCtx;
 }) {
-  // The menu is fixed-positioned from the button's rect so it escapes the
-  // canvas's overflow clip (same trick as the builder's other popovers).
-  const [menu, setMenu] = useState<{ top: number; left: number } | null>(null);
+  // The menu is fixed-positioned from the trigger's rect so it escapes any
+  // overflow clip; `index` is where the picked block is inserted.
+  const [menu, setMenu] = useState<{ top: number; left: number; index?: number } | null>(null);
 
   useDismissOnViewportChange(!!menu, () => setMenu(null));
   const canRemove = blocks.length > 1 || seqNid !== null;
@@ -63,65 +99,45 @@ export function BlockSequence({
   // bodies of plain steps only (spec §6.6) — don't offer containers there.
   const blockTypes = seqNid === null ? BLOCK_TYPES : BLOCK_TYPES.filter((t) => t.id === "step");
 
+  const openMenuAt = (e: React.MouseEvent, index?: number) => {
+    const r = e.currentTarget.getBoundingClientRect();
+    setMenu((m) => (m ? null : { top: r.bottom + 6, left: r.left, index }));
+  };
+
   return (
     <div className="wb-seq">
       {blocks.map((b, i) => (
         <Fragment key={b.nid}>
-          {i > 0 && <Connector />}
+          {i > 0 && (
+            <div className="wb-conn">
+              <button
+                className="wb-insert tip"
+                data-tip="Insert here"
+                onClick={(e) => openMenuAt(e, i)}
+              >
+                <Icon name="plus" />
+              </button>
+            </div>
+          )}
           <BlockNode block={b} index={i} ctx={ctx} canRemove={canRemove} />
         </Fragment>
       ))}
 
-      {blocks.length > 0 && <Connector />}
+      <button className="wb-add" onClick={(e) => openMenuAt(e)}>
+        <span className="wb-add-ic">
+          <Icon name="plus" />
+        </span>
+        <span className="wb-add-l">{seqNid === null ? "Add block" : "Add step"}</span>
+      </button>
 
-      <div className="wb-addwrap">
-        <button
-          className="wb-add"
-          onClick={(e) => {
-            const r = e.currentTarget.getBoundingClientRect();
-            setMenu((m) => (m ? null : { top: r.bottom, left: r.left }));
-          }}
-        >
-          <span className="wb-add-ic">
-            <Icon name="plus" />
-          </span>
-          <span className="wb-add-l">Add block</span>
-        </button>
-        {menu && (
-          <>
-            <div
-              style={{ position: "fixed", inset: 0, zIndex: 55 }}
-              onClick={() => setMenu(null)}
-            />
-            <div
-              className="dd wb-add-menu"
-              style={{ position: "fixed", top: menu.top, left: menu.left }}
-            >
-              {blockTypes.map((t) => (
-                <div
-                  key={t.id}
-                  className="dd-item"
-                  onClick={() => {
-                    ctx.addBlock(seqNid, t.id);
-                    setMenu(null);
-                  }}
-                  style={{ alignItems: "flex-start", flexDirection: "column", gap: 2 }}
-                >
-                  <span style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                    <Icon name={t.icon} size={12} />{" "}
-                    <span style={{ fontWeight: 500 }}>{t.label}</span>
-                  </span>
-                  <span
-                    style={{ fontSize: 11, color: "var(--fg-2)", lineHeight: 1.4, paddingLeft: 20 }}
-                  >
-                    {t.note}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </>
-        )}
-      </div>
+      {menu && (
+        <BlockMenu
+          at={menu}
+          types={blockTypes}
+          onPick={(type) => ctx.addBlock(seqNid, type, menu.index)}
+          onClose={() => setMenu(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/workflows/builder/blocks/LoopContainer.tsx
+++ b/src/workflows/builder/blocks/LoopContainer.tsx
@@ -1,82 +1,63 @@
 // LoopContainer.tsx — a bounded loop: run the body, exit when the chosen step's
-// verdict is `done`, else repeat up to `max` times (spec §6.6). Drawn as a
-// bracket around a nested block sequence (replacing the v0 measured arc).
+// verdict is `done`, else repeat up to `max` times (spec §6.6). Drawn as an
+// accent-tinted group around a nested vertical sequence; max/exit are edited in
+// the inspector when the container is selected.
 
 import { Icon } from "../../../components/Icon";
 import type { BuilderCtx } from "../ctx";
-import type { EBlock, ELoop } from "../model";
+import { loopExitCandidates } from "../edits";
+import type { ELoop } from "../model";
 import { BlockSequence } from "./BlockSequence";
-import { ContainerErrors } from "./ContainerErrors";
 
-/** Every step in the body, flattened, as loop-exit candidates. */
-function bodySteps(blocks: EBlock[]): { nid: string; label: string }[] {
-  const out: { nid: string; label: string }[] = [];
-  const walk = (bs: EBlock[]) => {
-    for (const b of bs) {
-      if (b.kind === "step") out.push({ nid: b.nid, label: b.stepId });
-      else if (b.kind === "parallel")
-        for (const s of b.steps) out.push({ nid: s.nid, label: s.stepId });
-      else if (b.kind === "loop") walk(b.body);
-      else for (const s of b.body) out.push({ nid: s.nid, label: s.stepId });
-    }
-  };
-  walk(blocks);
-  return out;
-}
+export function LoopContainer({
+  block,
+  ctx,
+  indexLabel,
+}: {
+  block: ELoop;
+  ctx: BuilderCtx;
+  indexLabel?: string;
+}) {
+  const errors = ctx.errorsFor(block.nid);
+  const selected = ctx.selectedNid === block.nid;
+  const exit = block.untilNid
+    ? loopExitCandidates(block.body).find((c) => c.nid === block.untilNid)
+    : undefined;
 
-export function LoopContainer({ block, ctx }: { block: ELoop; ctx: BuilderCtx }) {
-  const candidates = bodySteps(block.body);
   return (
-    <div className="wb-cont wb-loop">
+    <div
+      className={`wb-cont wb-loop ${selected ? "sel" : ""} ${errors ? "has-err" : ""}`}
+      onClick={() => ctx.select(block.nid)}
+    >
       <div className="wb-cont-h">
-        <span className="wb-cont-badge">
+        {indexLabel && <span className="wb-step-idx">{indexLabel}</span>}
+        <span className="wb-cont-badge loop">
           <Icon name="loop" size={12} /> Loop
         </span>
-        <label className="wb-ctl">
-          max
-          <select
-            className="ca-select sm"
-            value={block.max}
-            onChange={(e) => ctx.patchBlock(block.nid, { max: Number(e.target.value) })}
-          >
-            {[1, 2, 3, 4, 5, 6, 8, 10].map((n) => (
-              <option key={n} value={n}>
-                {n}×
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="wb-ctl">
-          exit when
-          <select
-            className="ca-select sm"
-            value={block.untilNid ?? ""}
-            onChange={(e) => ctx.patchBlock(block.nid, { untilNid: e.target.value || null })}
-          >
-            <option value="">choose step…</option>
-            {candidates.map((c) => (
-              <option key={c.nid} value={c.nid}>
-                {c.label} is done
-              </option>
-            ))}
-          </select>
-        </label>
-        <span className="grow" />
+        <span className="wb-cont-sum">
+          up to {block.max}× · exits when {exit ? <b>{exit.label}</b> : "…"} is done
+        </span>
+        {errors && (
+          <span className="wb-chip err">
+            <Icon name="close" /> {errors.length}
+          </span>
+        )}
         <button
           className="wb-step-menu tip"
           data-tip-down
           data-tip="Remove loop"
-          onClick={() => ctx.removeNode(block.nid)}
+          onClick={(e) => {
+            e.stopPropagation();
+            ctx.removeNode(block.nid);
+          }}
         >
           <Icon name="close" />
         </button>
       </div>
 
-      <div className="wb-loop-body">
+      <div className="wb-cont-body wb-loop-body" onClick={(e) => e.stopPropagation()}>
         <BlockSequence blocks={block.body} seqNid={block.nid} ctx={ctx} />
       </div>
-
-      <ContainerErrors errors={ctx.errorsFor(block.nid)} />
     </div>
   );
 }

--- a/src/workflows/builder/blocks/OrchestrateContainer.tsx
+++ b/src/workflows/builder/blocks/OrchestrateContainer.tsx
@@ -1,83 +1,66 @@
 // OrchestrateContainer.tsx — a lead agent coordinating children (spec §6.6/§10).
-// The orchestrator card sits above its static children; toggles expose the
-// dynamic-children template, comms caps, and dynamic-composition limits. The
-// engine runs orchestrate stages with `integrate: none` only, so `merge` is not
-// offered (a legacy value renders disabled and validation flags it).
+// Collapsed chrome on the canvas: the lead's identity + goal preview above the
+// child grid, with summary chips for dynamic children / sub-workflows. The
+// lead's goal, comms, and the dynamic/compose settings are edited in the
+// inspector when the container is selected.
 
 import { Icon } from "../../../components/Icon";
-import { STEP_COMMS } from "../../data";
-import type { CommsCap } from "../../spec";
 import { AgentAvatar } from "../AgentAvatar";
 import type { BuilderCtx } from "../ctx";
 import type { EOrchestrate } from "../model";
-import { ContainerErrors } from "./ContainerErrors";
 import { StepCard } from "./StepCard";
 
-export function OrchestrateContainer({ block, ctx }: { block: EOrchestrate; ctx: BuilderCtx }) {
+export function OrchestrateContainer({
+  block,
+  ctx,
+  indexLabel,
+}: {
+  block: EOrchestrate;
+  ctx: BuilderCtx;
+  indexLabel?: string;
+}) {
   const lead = ctx.resolve(block.agent);
   const child = ctx.resolve(block.children?.agent ?? null);
-
-  const toggleComms = (cap: CommsCap) => {
-    const has = block.comms.includes(cap);
-    ctx.patchBlock(block.nid, {
-      comms: has ? block.comms.filter((c) => c !== cap) : [...block.comms, cap],
-    });
-  };
+  const errors = ctx.errorsFor(block.nid);
+  const selected = ctx.selectedNid === block.nid;
 
   return (
-    <div className="wb-cont wb-orch">
+    <div
+      className={`wb-cont wb-orch ${selected ? "sel" : ""} ${errors ? "has-err" : ""}`}
+      onClick={() => ctx.select(block.nid)}
+    >
       <div className="wb-cont-h">
+        {indexLabel && <span className="wb-step-idx">{indexLabel}</span>}
         <span className="wb-cont-badge">
           <Icon name="combine" size={12} /> Orchestrate
         </span>
-        <label className="wb-ctl">
-          join
-          <select
-            className="ca-select sm"
-            value={block.join}
-            onChange={(e) =>
-              ctx.patchBlock(block.nid, { join: e.target.value as EOrchestrate["join"] })
-            }
-          >
-            <option value="all">all</option>
-            <option value="any">any</option>
-          </select>
-        </label>
-        <label className="wb-ctl">
-          integrate
-          <select
-            className="ca-select sm"
-            value={block.integrate}
-            onChange={(e) =>
-              ctx.patchBlock(block.nid, { integrate: e.target.value as EOrchestrate["integrate"] })
-            }
-          >
-            <option value="none">none</option>
-            {/* The engine runs orchestrate with integrate: none only (§6.6); a
-                legacy definition may still carry merge — render it so the value
-                is visible and switchable, but don't offer it. */}
-            {block.integrate === "merge" && (
-              <option value="merge" disabled>
-                merge (unsupported)
-              </option>
-            )}
-          </select>
-        </label>
-        <span className="grow" />
+        <span className="wb-cont-sum">join {block.join}</span>
+        {errors && (
+          <span className="wb-chip err">
+            <Icon name="close" /> {errors.length}
+          </span>
+        )}
         <button
           className="wb-step-menu tip"
           data-tip-down
           data-tip="Remove orchestrate"
-          onClick={() => ctx.removeNode(block.nid)}
+          onClick={(e) => {
+            e.stopPropagation();
+            ctx.removeNode(block.nid);
+          }}
         >
           <Icon name="close" />
         </button>
       </div>
 
-      <div className="wb-orch-lead">
+      <div className="wb-orch-lead" style={{ "--h": lead?.hue ?? 250 } as React.CSSProperties}>
         <button
           className="wb-step-agent"
-          onClick={(e) => ctx.openAgent(block.nid, "orchestrator", e)}
+          onClick={(e) => {
+            e.stopPropagation();
+            ctx.select(block.nid);
+            ctx.openAgent(block.nid, "orchestrator", e);
+          }}
         >
           {lead ? (
             <AgentAvatar
@@ -85,7 +68,7 @@ export function OrchestrateContainer({ block, ctx }: { block: EOrchestrate; ctx:
               slug={lead.providerId}
               short={lead.short}
               hue={lead.hue}
-              size={26}
+              size={28}
             />
           ) : (
             <span className="wb-step-mono empty">
@@ -94,7 +77,7 @@ export function OrchestrateContainer({ block, ctx }: { block: EOrchestrate; ctx:
           )}
           <span className="wb-step-agent-text">
             <div className={`wb-an ${lead ? "" : "empty"}`}>
-              {lead ? lead.name : "Choose orchestrator"}
+              {lead ? lead.name : "Choose an orchestrator"}
             </div>
             {lead && (
               <div className="wb-am">
@@ -103,141 +86,52 @@ export function OrchestrateContainer({ block, ctx }: { block: EOrchestrate; ctx:
             )}
           </span>
         </button>
-        <textarea
-          className="wb-step-goal"
-          placeholder="How should the orchestrator coordinate its children?"
-          value={block.goal}
-          onChange={(e) => ctx.patchBlock(block.nid, { goal: e.target.value })}
-        />
-        <div className="wb-comms">
-          <span className="wb-comms-l">Children may</span>
-          {STEP_COMMS.map((c) => (
-            <button
-              key={c.id}
-              className={`wb-comm ${block.comms.includes(c.id) ? "on" : ""} tip`}
-              data-tip-down
-              data-tip={c.note}
-              onClick={() => toggleComms(c.id)}
-            >
-              {c.label}
-            </button>
-          ))}
+        <div className={`wb-step-goal ${block.goal.trim() ? "" : "empty"}`}>
+          {block.goal.trim() || "No coordination brief yet — select to add."}
         </div>
-      </div>
-
-      <div className="wb-orch-children">
-        <div className="wb-sub-h">Static children</div>
-        <div className="wb-parallel-body">
-          {block.body.map((s, i) => (
-            <StepCard
-              key={s.nid}
-              step={s}
-              ctx={ctx}
-              indexLabel={`${i + 1}`}
-              canRemove
-              role="child"
-            />
-          ))}
-          <button className="wb-add sm" onClick={() => ctx.addStepToContainer(block.nid)}>
-            <span className="wb-add-ic">
-              <Icon name="plus" />
+        <div className="wb-step-foot">
+          {block.comms.length > 0 && (
+            <span className="wb-chip">children may {block.comms.join(" · ")}</span>
+          )}
+          {block.children && (
+            <span className="wb-chip">
+              <Icon name="sparkle" /> dynamic ×{block.children.max}
+              {child ? ` · ${child.name}` : ""}
             </span>
-            <span className="wb-add-l">Add child</span>
-          </button>
+          )}
+          {block.compose && (
+            <span className="wb-chip">
+              <Icon name="combine" /> sub-workflows ×{block.compose.maxSubRuns}
+            </span>
+          )}
         </div>
       </div>
 
-      <div className="wb-orch-opts">
-        <label className="wb-toggle">
-          <input
-            type="checkbox"
-            checked={!!block.children}
-            onChange={(e) =>
-              ctx.patchBlock(block.nid, {
-                children: e.target.checked ? { agent: null, max: 3 } : null,
-              })
-            }
+      {/* Clicks inside the body select the child card, not this container. */}
+      <div className="wb-cont-body wb-branches" onClick={(e) => e.stopPropagation()}>
+        {block.body.map((s, i) => (
+          <StepCard
+            key={s.nid}
+            step={s}
+            ctx={ctx}
+            indexLabel={`${i + 1}`}
+            canRemove
+            role="child"
           />
-          Dynamic children
-        </label>
-        {block.children && (
-          <div className="wb-opt-row">
-            <button className="wb-adv-sel" onClick={(e) => ctx.openAgent(block.nid, "child", e)}>
-              {child ? child.name : "child agent…"}
-            </button>
-            <label className="wb-ctl">
-              max
-              <input
-                className="ca-input sm"
-                type="number"
-                min={1}
-                style={{ width: 52 }}
-                value={block.children.max}
-                onChange={(e) =>
-                  ctx.patchBlock(block.nid, {
-                    children: { agent: block.children?.agent ?? null, max: Number(e.target.value) },
-                  })
-                }
-              />
-            </label>
-          </div>
-        )}
-
-        <label className="wb-toggle">
-          <input
-            type="checkbox"
-            checked={!!block.compose}
-            onChange={(e) =>
-              ctx.patchBlock(block.nid, {
-                compose: e.target.checked ? { maxSubRuns: 2, maxDepth: 2 } : null,
-              })
-            }
-          />
-          Allow sub-workflows
-        </label>
-        {block.compose && (
-          <div className="wb-opt-row">
-            <label className="wb-ctl">
-              sub-runs
-              <input
-                className="ca-input sm"
-                type="number"
-                min={1}
-                style={{ width: 52 }}
-                value={block.compose.maxSubRuns}
-                onChange={(e) =>
-                  ctx.patchBlock(block.nid, {
-                    compose: {
-                      maxSubRuns: Number(e.target.value),
-                      maxDepth: block.compose?.maxDepth ?? 2,
-                    },
-                  })
-                }
-              />
-            </label>
-            <label className="wb-ctl">
-              depth
-              <select
-                className="ca-select sm"
-                value={block.compose.maxDepth}
-                onChange={(e) =>
-                  ctx.patchBlock(block.nid, {
-                    compose: {
-                      maxSubRuns: block.compose?.maxSubRuns ?? 2,
-                      maxDepth: Number(e.target.value),
-                    },
-                  })
-                }
-              >
-                <option value={1}>1</option>
-                <option value={2}>2</option>
-              </select>
-            </label>
-          </div>
-        )}
+        ))}
+        <button
+          className="wb-add sm"
+          onClick={(e) => {
+            e.stopPropagation();
+            ctx.addStepToContainer(block.nid);
+          }}
+        >
+          <span className="wb-add-ic">
+            <Icon name="plus" />
+          </span>
+          <span className="wb-add-l">Add child</span>
+        </button>
       </div>
-
-      <ContainerErrors errors={ctx.errorsFor(block.nid)} />
     </div>
   );
 }

--- a/src/workflows/builder/blocks/OrchestrateContainer.tsx
+++ b/src/workflows/builder/blocks/OrchestrateContainer.tsx
@@ -110,14 +110,7 @@ export function OrchestrateContainer({
       {/* Clicks inside the body select the child card, not this container. */}
       <div className="wb-cont-body wb-branches" onClick={(e) => e.stopPropagation()}>
         {block.body.map((s, i) => (
-          <StepCard
-            key={s.nid}
-            step={s}
-            ctx={ctx}
-            indexLabel={`${i + 1}`}
-            canRemove
-            role="child"
-          />
+          <StepCard key={s.nid} step={s} ctx={ctx} indexLabel={`${i + 1}`} canRemove role="child" />
         ))}
         <button
           className="wb-add sm"

--- a/src/workflows/builder/blocks/ParallelContainer.tsx
+++ b/src/workflows/builder/blocks/ParallelContainer.tsx
@@ -1,73 +1,59 @@
 // ParallelContainer.tsx — a fan-out stage: children run at once, then join.
-// Rendered as a labelled container wrapping a vertical stack of step cards.
+// Collapsed chrome on the canvas (a labelled container with a branch grid);
+// join/integrate/max-concurrency are edited in the inspector when selected.
 
 import { Icon } from "../../../components/Icon";
 import type { BuilderCtx } from "../ctx";
 import type { EParallel } from "../model";
-import { ContainerErrors } from "./ContainerErrors";
 import { StepCard } from "./StepCard";
 
-export function ParallelContainer({ block, ctx }: { block: EParallel; ctx: BuilderCtx }) {
+export function ParallelContainer({
+  block,
+  ctx,
+  indexLabel,
+}: {
+  block: EParallel;
+  ctx: BuilderCtx;
+  indexLabel?: string;
+}) {
+  const errors = ctx.errorsFor(block.nid);
+  const selected = ctx.selectedNid === block.nid;
+
   return (
-    <div className="wb-cont wb-parallel">
+    <div
+      className={`wb-cont wb-parallel ${selected ? "sel" : ""} ${errors ? "has-err" : ""}`}
+      onClick={() => ctx.select(block.nid)}
+    >
       <div className="wb-cont-h">
+        {indexLabel && <span className="wb-step-idx">{indexLabel}</span>}
         <span className="wb-cont-badge">
           <Icon name="layers" size={12} /> Parallel
         </span>
-        <label className="wb-ctl">
-          join
-          <select
-            className="ca-select sm"
-            value={block.join}
-            onChange={(e) =>
-              ctx.patchBlock(block.nid, { join: e.target.value as EParallel["join"] })
-            }
-          >
-            <option value="all">all</option>
-            <option value="any">any</option>
-          </select>
-        </label>
-        <label className="wb-ctl">
-          integrate
-          <select
-            className="ca-select sm"
-            value={block.integrate}
-            onChange={(e) =>
-              ctx.patchBlock(block.nid, { integrate: e.target.value as EParallel["integrate"] })
-            }
-          >
-            <option value="none">none</option>
-            <option value="merge">merge</option>
-          </select>
-        </label>
-        <label className="wb-ctl">
-          max at once
-          <input
-            className="ca-input sm"
-            type="number"
-            min={1}
-            style={{ width: 52 }}
-            placeholder="all"
-            value={block.maxConcurrent ?? ""}
-            onChange={(e) =>
-              ctx.patchBlock(block.nid, {
-                maxConcurrent: e.target.value.trim() === "" ? null : Number(e.target.value),
-              })
-            }
-          />
-        </label>
-        <span className="grow" />
+        <span className="wb-cont-sum">
+          join {block.join}
+          {block.maxConcurrent != null ? ` · ${block.maxConcurrent} at once` : ""} ·{" "}
+          {block.steps.length} branch{block.steps.length === 1 ? "" : "es"}
+        </span>
+        {errors && (
+          <span className="wb-chip err">
+            <Icon name="close" /> {errors.length}
+          </span>
+        )}
         <button
           className="wb-step-menu tip"
           data-tip-down
           data-tip="Remove parallel"
-          onClick={() => ctx.removeNode(block.nid)}
+          onClick={(e) => {
+            e.stopPropagation();
+            ctx.removeNode(block.nid);
+          }}
         >
           <Icon name="close" />
         </button>
       </div>
 
-      <div className="wb-cont-body wb-parallel-body">
+      {/* Clicks inside the body select the child card, not this container. */}
+      <div className="wb-cont-body wb-branches" onClick={(e) => e.stopPropagation()}>
         {block.steps.map((s, i) => (
           <StepCard
             key={s.nid}
@@ -78,15 +64,19 @@ export function ParallelContainer({ block, ctx }: { block: EParallel; ctx: Build
             role="child"
           />
         ))}
-        <button className="wb-add sm" onClick={() => ctx.addStepToContainer(block.nid)}>
+        <button
+          className="wb-add sm"
+          onClick={(e) => {
+            e.stopPropagation();
+            ctx.addStepToContainer(block.nid);
+          }}
+        >
           <span className="wb-add-ic">
             <Icon name="plus" />
           </span>
           <span className="wb-add-l">Add branch</span>
         </button>
       </div>
-
-      <ContainerErrors errors={ctx.errorsFor(block.nid)} />
     </div>
   );
 }

--- a/src/workflows/builder/blocks/StepCard.tsx
+++ b/src/workflows/builder/blocks/StepCard.tsx
@@ -1,14 +1,13 @@
-// StepCard.tsx — one step card: agent, goal, gate, comms caps, budgets. Reused
-// at the top level and inside parallel / loop / orchestrate containers, so it
-// takes only its step node + the shared editing ctx.
+// StepCard.tsx — one collapsed step card on the vertical canvas: agent identity,
+// a 2-line goal preview, and summary chips (gate, budgets, comms). All editing
+// happens in the inspector — clicking the card selects it there. Reused at the
+// top level and inside parallel / loop / orchestrate containers.
 
 import { Icon } from "../../../components/Icon";
-import { GATE_MODES, STEP_COMMS } from "../../data";
-import type { CommsCap } from "../../spec";
+import { GATE_MODES } from "../../data";
 import { AgentAvatar } from "../AgentAvatar";
 import type { BuilderCtx } from "../ctx";
 import type { EStep } from "../model";
-import { ContainerErrors } from "./ContainerErrors";
 
 export function StepCard({
   step,
@@ -27,26 +26,32 @@ export function StepCard({
   const a = ctx.resolve(step.agent);
   const gate = GATE_MODES.find((m) => m.id === step.gate.type) ?? GATE_MODES[0];
   const errors = ctx.errorsFor(step.nid);
-
-  const toggleComms = (cap: CommsCap) => {
-    const has = step.comms.includes(cap);
-    ctx.patchStep(step.nid, {
-      comms: has ? step.comms.filter((c) => c !== cap) : [...step.comms, cap],
-    });
-  };
+  const selected = ctx.selectedNid === step.nid;
+  const hasBudgets = !!step.budgets && Object.values(step.budgets).some((v) => v != null);
 
   return (
-    <div className={`wb-step ${errors ? "has-err" : ""}`}>
+    <div
+      className={`wb-step ${selected ? "sel" : ""} ${a ? "" : "unassigned"} ${errors ? "has-err" : ""}`}
+      style={{ "--h": a?.hue ?? 250 } as React.CSSProperties}
+      onClick={() => ctx.select(step.nid)}
+    >
       <div className="wb-step-h">
         {indexLabel && <span className="wb-step-idx">{indexLabel}</span>}
-        <button className="wb-step-agent" onClick={(e) => ctx.openAgent(step.nid, "step", e)}>
+        <button
+          className="wb-step-agent"
+          onClick={(e) => {
+            e.stopPropagation();
+            ctx.select(step.nid);
+            ctx.openAgent(step.nid, "step", e);
+          }}
+        >
           {a ? (
             <AgentAvatar
               custom={a.custom}
               slug={a.providerId}
               short={a.short}
               hue={a.hue}
-              size={26}
+              size={28}
             />
           ) : (
             <span className="wb-step-mono empty">
@@ -54,7 +59,7 @@ export function StepCard({
             </span>
           )}
           <span className="wb-step-agent-text">
-            <div className={`wb-an ${a ? "" : "empty"}`}>{a ? a.name : "Choose agent"}</div>
+            <div className={`wb-an ${a ? "" : "empty"}`}>{a ? a.name : "Choose an agent"}</div>
             {a && <div className="wb-am">{a.custom ? `${a.baseLabel} · ${a.model}` : a.model}</div>}
           </span>
         </button>
@@ -63,70 +68,45 @@ export function StepCard({
             className="tip wb-step-menu"
             data-tip-down
             data-tip={role === "child" ? "Remove" : "Remove step"}
-            onClick={() => ctx.removeNode(step.nid)}
+            onClick={(e) => {
+              e.stopPropagation();
+              ctx.removeNode(step.nid);
+            }}
           >
             <Icon name="close" />
           </button>
         )}
       </div>
 
-      <textarea
-        className="wb-step-goal"
-        placeholder="What should this step accomplish?"
-        value={step.goal}
-        onChange={(e) => ctx.patchStep(step.nid, { goal: e.target.value })}
-      />
-
-      {step.gate.type === "artifact" && (
-        <input
-          className="ca-input wb-artifact"
-          placeholder="Artifact path, e.g. PLAN.md"
-          value={step.gate.path}
-          onChange={(e) =>
-            ctx.patchStep(step.nid, { gate: { type: "artifact", path: e.target.value } })
-          }
-        />
-      )}
+      <div className={`wb-step-goal ${step.goal.trim() ? "" : "empty"}`}>
+        {step.goal.trim() || "No instructions yet — select to add."}
+      </div>
 
       <div className="wb-step-foot">
-        <span className="wb-advance">
-          <Icon name={gate.icon} />
-          <span>
-            Done on{" "}
-            <button className="wb-adv-sel" onClick={(e) => ctx.openGate(step.nid, e)}>
-              {gate.short}
-            </button>
-          </span>
+        <span className="wb-chip">
+          <Icon name={gate.icon} /> Done on <b>{gate.short}</b>
         </span>
-        <span className="grow" />
-        <button
-          className="wb-chip-btn tip"
-          data-tip-down
-          data-tip="Step budgets"
-          onClick={(e) => ctx.openBudgets(step.nid, e)}
-        >
-          <Icon name="clock" size={11} />
-          {(step.budgets?.turns_per_attempt ?? step.budgets?.turns) ? (
-            <span>{step.budgets.turns_per_attempt ?? step.budgets.turns}t</span>
-          ) : null}
-        </button>
-      </div>
-
-      <div className="wb-comms">
-        {STEP_COMMS.map((c) => (
-          <button
-            key={c.id}
-            className={`wb-comm ${step.comms.includes(c.id) ? "on" : ""} tip`}
-            data-tip-down
-            data-tip={c.note}
-            onClick={() => toggleComms(c.id)}
-          >
-            {c.label}
-          </button>
+        {step.gate.type === "artifact" && step.gate.path.trim() && (
+          <span className="wb-chip">
+            <Icon name="file" /> {step.gate.path}
+          </span>
+        )}
+        {hasBudgets && (
+          <span className="wb-chip">
+            <Icon name="clock" /> budgets
+          </span>
+        )}
+        {step.comms.map((c) => (
+          <span className="wb-chip" key={c}>
+            {c}
+          </span>
         ))}
+        {errors && (
+          <span className="wb-chip err">
+            <Icon name="close" /> {errors.length} issue{errors.length === 1 ? "" : "s"}
+          </span>
+        )}
       </div>
-
-      <ContainerErrors errors={errors} />
     </div>
   );
 }

--- a/src/workflows/builder/ctx.ts
+++ b/src/workflows/builder/ctx.ts
@@ -1,6 +1,9 @@
 // ctx.ts — the shared editing surface threaded through the recursive block tree,
 // so a StepCard nested three containers deep can dispatch an edit or open a
 // popover without prop-drilling every callback.
+//
+// v2 (vertical editor): the canvas renders collapsed cards and the right-hand
+// inspector edits the selected node, so the ctx also carries the selection.
 
 import type { BlockTypeDef } from "../data";
 import type { AgentResolver } from "../shared";
@@ -14,23 +17,25 @@ export interface PopRect {
   bottom: number;
 }
 
-/** The one open popover, positioned from a measured trigger rect. */
-export type Pop =
-  | { type: "agent"; nid: NodeId; role: AgentRole; rect: PopRect }
-  | { type: "gate"; nid: NodeId; rect: PopRect }
-  | { type: "budgets"; target: NodeId | "run"; rect: PopRect };
+/** The one open popover, positioned from a measured trigger rect. Gate and
+ *  budget editing live inline in the inspector now — only the agent picker
+ *  remains a popover. */
+export type Pop = { type: "agent"; nid: NodeId; role: AgentRole; rect: PopRect };
 
 export interface BuilderCtx {
   resolve: AgentResolver;
   /** Inline validation messages for a node, if any. */
   errorsFor: (nid: NodeId) => string[] | undefined;
+  /** The selected node (step or container) the inspector is editing. */
+  selectedNid: NodeId | null;
+  /** Select a node (`null` returns the inspector to the workflow overview). */
+  select: (nid: NodeId | null) => void;
   patchStep: (nid: NodeId, patch: Partial<EStep>) => void;
   patchBlock: (nid: NodeId, patch: Partial<EBlock>) => void;
   removeNode: (nid: NodeId) => void;
   addStepToContainer: (nid: NodeId) => void;
-  /** Append a block to a sequence: the top level (`null`) or a loop body's nid. */
-  addBlock: (seqNid: NodeId | null, type: BlockTypeDef["id"]) => void;
+  /** Insert a block into a sequence — the top level (`null`) or a loop body's
+   *  nid — at `index` (appended when omitted). Selects the new block. */
+  addBlock: (seqNid: NodeId | null, type: BlockTypeDef["id"], index?: number) => void;
   openAgent: (nid: NodeId, role: AgentRole, e: React.MouseEvent) => void;
-  openGate: (nid: NodeId, e: React.MouseEvent) => void;
-  openBudgets: (target: NodeId | "run", e: React.MouseEvent) => void;
 }

--- a/src/workflows/builder/edits.ts
+++ b/src/workflows/builder/edits.ts
@@ -16,7 +16,7 @@ import {
 } from "./model";
 
 /** Every spec step id currently in the tree (so new steps avoid collisions). */
-function editorStepIds(state: EditorState): Set<string> {
+export function editorStepIds(state: EditorState): Set<string> {
   const ids = new Set<string>();
   const walk = (blocks: EBlock[]) => {
     for (const b of blocks) {
@@ -128,13 +128,14 @@ export function addBlock(
   return { ...state, blocks: apply(state.blocks) };
 }
 
-/** Add a child step to a parallel or orchestrate container. Returns the new
- *  state and the child's nid so the caller can select it. */
+/** Append a prebuilt child step to a parallel or orchestrate container. The
+ *  step is constructed by the caller (see `newStep`) so this stays a pure
+ *  state→state op, safe to run inside a React functional update. */
 export function addStepToContainer(
   state: EditorState,
   containerNid: NodeId,
-): { state: EditorState; nid: NodeId } {
-  const step = newStep(editorStepIds(state));
+  step: EStep,
+): EditorState {
   const apply = (blocks: EBlock[]): EBlock[] =>
     blocks.map((b) => {
       if (b.nid === containerNid && b.kind === "parallel") {
@@ -146,28 +147,25 @@ export function addStepToContainer(
       if (b.kind === "loop") return { ...b, body: apply(b.body) };
       return b;
     });
-  return { state: { ...state, blocks: apply(state.blocks) }, nid: step.nid };
+  return { ...state, blocks: apply(state.blocks) };
 }
 
-/** Insert a fresh block of the chosen kind into a sequence (top level or loop),
- *  at `index` (appended when omitted). Returns the new state and the block's nid
- *  so the caller can select it. */
-export function addBlockOfType(
-  state: EditorState,
-  seqNid: NodeId | null,
+/** Construct a fresh block of the chosen kind. Built eagerly (outside any
+ *  React updater) so the node's nid/step-ids are fixed once per user action —
+ *  the caller then inserts it with `addBlock` inside a functional update. The
+ *  global id counters keep step ids unique even across rapid actions that
+ *  shared a `taken` snapshot. */
+export function newBlockOfType(
+  taken: Set<string>,
   type: "step" | "parallel" | "loop" | "orchestrate",
-  index?: number,
-): { state: EditorState; nid: NodeId } {
-  const taken = editorStepIds(state);
-  const block =
-    type === "step"
-      ? newStep(taken)
-      : type === "parallel"
-        ? newParallel(taken)
-        : type === "loop"
-          ? newLoop(taken)
-          : newOrchestrate(taken);
-  return { state: addBlock(state, seqNid, block, index), nid: block.nid };
+): EBlock {
+  return type === "step"
+    ? newStep(taken)
+    : type === "parallel"
+      ? newParallel(taken)
+      : type === "loop"
+        ? newLoop(taken)
+        : newOrchestrate(taken);
 }
 
 /** Find any node — step or container — by nid anywhere in the tree. Used by the

--- a/src/workflows/builder/edits.ts
+++ b/src/workflows/builder/edits.ts
@@ -106,20 +106,34 @@ export function removeNode(state: EditorState, nid: NodeId): EditorState {
 
 // ───────────────────────────── structural edits ────────────────────────────
 
-/** Append a block to a sequence: the top level (`seqNid = null`) or a loop body. */
-export function addBlock(state: EditorState, seqNid: NodeId | null, block: EBlock): EditorState {
-  if (seqNid === null) return { ...state, blocks: [...state.blocks, block] };
+/** Insert a block into a sequence — the top level (`seqNid = null`) or a loop
+ *  body — at `index` (appended when omitted or out of range). */
+export function addBlock(
+  state: EditorState,
+  seqNid: NodeId | null,
+  block: EBlock,
+  index?: number,
+): EditorState {
+  const insert = (blocks: EBlock[]): EBlock[] => {
+    const at = index == null || index < 0 || index > blocks.length ? blocks.length : index;
+    return [...blocks.slice(0, at), block, ...blocks.slice(at)];
+  };
+  if (seqNid === null) return { ...state, blocks: insert(state.blocks) };
   const apply = (blocks: EBlock[]): EBlock[] =>
     blocks.map((b) => {
       if (b.kind !== "loop") return b;
-      if (b.nid === seqNid) return { ...b, body: [...b.body, block] };
+      if (b.nid === seqNid) return { ...b, body: insert(b.body) };
       return { ...b, body: apply(b.body) };
     });
   return { ...state, blocks: apply(state.blocks) };
 }
 
-/** Add a child step to a parallel or orchestrate container. */
-export function addStepToContainer(state: EditorState, containerNid: NodeId): EditorState {
+/** Add a child step to a parallel or orchestrate container. Returns the new
+ *  state and the child's nid so the caller can select it. */
+export function addStepToContainer(
+  state: EditorState,
+  containerNid: NodeId,
+): { state: EditorState; nid: NodeId } {
   const step = newStep(editorStepIds(state));
   const apply = (blocks: EBlock[]): EBlock[] =>
     blocks.map((b) => {
@@ -132,15 +146,18 @@ export function addStepToContainer(state: EditorState, containerNid: NodeId): Ed
       if (b.kind === "loop") return { ...b, body: apply(b.body) };
       return b;
     });
-  return { ...state, blocks: apply(state.blocks) };
+  return { state: { ...state, blocks: apply(state.blocks) }, nid: step.nid };
 }
 
-/** Append a fresh block of the chosen kind to a sequence (top level or loop). */
+/** Insert a fresh block of the chosen kind into a sequence (top level or loop),
+ *  at `index` (appended when omitted). Returns the new state and the block's nid
+ *  so the caller can select it. */
 export function addBlockOfType(
   state: EditorState,
   seqNid: NodeId | null,
   type: "step" | "parallel" | "loop" | "orchestrate",
-): EditorState {
+  index?: number,
+): { state: EditorState; nid: NodeId } {
   const taken = editorStepIds(state);
   const block =
     type === "step"
@@ -150,28 +167,47 @@ export function addBlockOfType(
         : type === "loop"
           ? newLoop(taken)
           : newOrchestrate(taken);
-  return addBlock(state, seqNid, block);
+  return { state: addBlock(state, seqNid, block, index), nid: block.nid };
 }
 
-/** Find a step by nid anywhere in the tree (for popovers that need its data). */
-export function findStep(state: EditorState, nid: NodeId): EStep | null {
-  let found: EStep | null = null;
+/** Find any node — step or container — by nid anywhere in the tree. Used by the
+ *  inspector to render the selected node and to drop a stale selection. */
+export function findNode(state: EditorState, nid: NodeId): EBlock | null {
+  let found: EBlock | null = null;
   const walk = (blocks: EBlock[]) => {
     for (const b of blocks) {
       if (found) return;
-      if (b.kind === "step") {
-        if (b.nid === nid) found = b;
-      } else if (b.kind === "parallel") {
+      if (b.nid === nid) {
+        found = b;
+        return;
+      }
+      if (b.kind === "parallel") {
         found = b.steps.find((s) => s.nid === nid) ?? null;
       } else if (b.kind === "loop") {
         walk(b.body);
-      } else {
+      } else if (b.kind === "orchestrate") {
         found = b.body.find((s) => s.nid === nid) ?? null;
       }
     }
   };
   walk(state.blocks);
   return found;
+}
+
+/** Every step in a loop body, flattened, as loop-exit candidates. */
+export function loopExitCandidates(blocks: EBlock[]): { nid: NodeId; label: string }[] {
+  const out: { nid: NodeId; label: string }[] = [];
+  const walk = (bs: EBlock[]) => {
+    for (const b of bs) {
+      if (b.kind === "step") out.push({ nid: b.nid, label: b.stepId });
+      else if (b.kind === "parallel")
+        for (const s of b.steps) out.push({ nid: s.nid, label: s.stepId });
+      else if (b.kind === "loop") walk(b.body);
+      else for (const s of b.body) out.push({ nid: s.nid, label: s.stepId });
+    }
+  };
+  walk(blocks);
+  return out;
 }
 
 // ───────────────────────────── agent assignment ────────────────────────────

--- a/src/workflows/builder/inspector/ContainerInspectors.tsx
+++ b/src/workflows/builder/inspector/ContainerInspectors.tsx
@@ -1,0 +1,293 @@
+// ContainerInspectors.tsx — inspector panes for the three container blocks.
+// Branch/child steps are edited by selecting them on the canvas; these panes
+// hold the container's own knobs (join/integrate/limits, loop exit, the
+// orchestrator's brief and dynamic-children/compose settings).
+
+import { STEP_COMMS } from "../../data";
+import type { CommsCap } from "../../spec";
+import { ContainerErrors } from "../blocks/ContainerErrors";
+import type { BuilderCtx } from "../ctx";
+import { loopExitCandidates } from "../edits";
+import type { ELoop, EOrchestrate, EParallel } from "../model";
+import { AgentButton, Field } from "./bits";
+
+export function ParallelInspector({ block, ctx }: { block: EParallel; ctx: BuilderCtx }) {
+  return (
+    <>
+      <ContainerErrors errors={ctx.errorsFor(block.nid)} />
+
+      <Field label="Join" hint="when does the stage complete">
+        <select
+          className="ca-select"
+          value={block.join}
+          onChange={(e) => ctx.patchBlock(block.nid, { join: e.target.value as EParallel["join"] })}
+        >
+          <option value="all">all — every branch must finish</option>
+          <option value="any">any — the first finished branch wins</option>
+        </select>
+      </Field>
+
+      <Field label="Integrate">
+        <select
+          className="ca-select"
+          value={block.integrate}
+          onChange={(e) =>
+            ctx.patchBlock(block.nid, { integrate: e.target.value as EParallel["integrate"] })
+          }
+        >
+          <option value="none">none — branches stay on their own worktrees</option>
+          <option value="merge">merge — combine branch results</option>
+        </select>
+      </Field>
+
+      <Field label="Max at once" hint="blank runs all branches">
+        <input
+          className="ca-input"
+          type="number"
+          min={1}
+          placeholder="all"
+          value={block.maxConcurrent ?? ""}
+          onChange={(e) =>
+            ctx.patchBlock(block.nid, {
+              maxConcurrent: e.target.value.trim() === "" ? null : Number(e.target.value),
+            })
+          }
+        />
+      </Field>
+
+      <div className="wb-field-note">
+        Select a branch on the canvas to edit its agent, instructions, and gate. Add branches with
+        the + button inside the block.
+      </div>
+    </>
+  );
+}
+
+export function LoopInspector({ block, ctx }: { block: ELoop; ctx: BuilderCtx }) {
+  const candidates = loopExitCandidates(block.body);
+  return (
+    <>
+      <ContainerErrors errors={ctx.errorsFor(block.nid)} />
+
+      <Field label="Max iterations">
+        <select
+          className="ca-select"
+          value={block.max}
+          onChange={(e) => ctx.patchBlock(block.nid, { max: Number(e.target.value) })}
+        >
+          {[1, 2, 3, 4, 5, 6, 8, 10].map((n) => (
+            <option key={n} value={n}>
+              {n}×
+            </option>
+          ))}
+        </select>
+      </Field>
+
+      <Field label="Exit when" hint="the step whose verdict ends the loop">
+        <select
+          className="ca-select"
+          value={block.untilNid ?? ""}
+          onChange={(e) => ctx.patchBlock(block.nid, { untilNid: e.target.value || null })}
+        >
+          <option value="">choose step…</option>
+          {candidates.map((c) => (
+            <option key={c.nid} value={c.nid}>
+              {c.label} is done
+            </option>
+          ))}
+        </select>
+      </Field>
+
+      <div className="wb-field-note">
+        The body repeats until the chosen step writes a <span className="mono">done</span> verdict,
+        up to the max. The exit step must use the <b>verdict</b> gate.
+      </div>
+    </>
+  );
+}
+
+export function OrchestrateInspector({ block, ctx }: { block: EOrchestrate; ctx: BuilderCtx }) {
+  const lead = ctx.resolve(block.agent);
+  const child = ctx.resolve(block.children?.agent ?? null);
+
+  const toggleComms = (cap: CommsCap) => {
+    const has = block.comms.includes(cap);
+    ctx.patchBlock(block.nid, {
+      comms: has ? block.comms.filter((c) => c !== cap) : [...block.comms, cap],
+    });
+  };
+
+  return (
+    <>
+      <ContainerErrors errors={ctx.errorsFor(block.nid)} />
+
+      <Field label="Orchestrator" required>
+        <AgentButton
+          agent={lead}
+          placeholder="Choose an orchestrator"
+          onClick={(e) => ctx.openAgent(block.nid, "orchestrator", e)}
+        />
+      </Field>
+
+      <Field label="Coordination brief" hint="how to run the children">
+        <textarea
+          className="wb-insp-textarea"
+          value={block.goal}
+          placeholder="How should the orchestrator coordinate its children?"
+          onChange={(e) => ctx.patchBlock(block.nid, { goal: e.target.value })}
+        />
+      </Field>
+
+      <Field label="Join">
+        <select
+          className="ca-select"
+          value={block.join}
+          onChange={(e) =>
+            ctx.patchBlock(block.nid, { join: e.target.value as EOrchestrate["join"] })
+          }
+        >
+          <option value="all">all — every child must finish</option>
+          <option value="any">any — the first finished child wins</option>
+        </select>
+      </Field>
+
+      {/* The engine runs orchestrate with integrate: none only (§6.6); a legacy
+          definition may still carry merge — surface it so it can be switched off. */}
+      {block.integrate === "merge" && (
+        <Field label="Integrate">
+          <select
+            className="ca-select"
+            value={block.integrate}
+            onChange={(e) =>
+              ctx.patchBlock(block.nid, { integrate: e.target.value as EOrchestrate["integrate"] })
+            }
+          >
+            <option value="none">none</option>
+            <option value="merge" disabled>
+              merge (unsupported)
+            </option>
+          </select>
+        </Field>
+      )}
+
+      <Field label="Children may">
+        <div className="wb-comms">
+          {STEP_COMMS.map((c) => (
+            <button
+              key={c.id}
+              className={`wb-comm ${block.comms.includes(c.id) ? "on" : ""} tip`}
+              data-tip-down
+              data-tip={c.note}
+              onClick={() => toggleComms(c.id)}
+            >
+              {c.label}
+            </button>
+          ))}
+        </div>
+      </Field>
+
+      <Field label="Dynamic children" hint="spawned by the orchestrator">
+        <div className="wb-box">
+          <label className="wb-toggle">
+            <input
+              type="checkbox"
+              checked={!!block.children}
+              onChange={(e) =>
+                ctx.patchBlock(block.nid, {
+                  children: e.target.checked ? { agent: null, max: 3 } : null,
+                })
+              }
+            />
+            Let the orchestrator spawn children
+          </label>
+          {block.children && (
+            <div className="wb-box-cfg">
+              <AgentButton
+                agent={child}
+                placeholder="Choose the child agent"
+                onClick={(e) => ctx.openAgent(block.nid, "child", e)}
+              />
+              <label className="wb-budget-field">
+                <span>Max children</span>
+                <input
+                  className="ca-input sm"
+                  type="number"
+                  min={1}
+                  value={block.children.max}
+                  onChange={(e) =>
+                    ctx.patchBlock(block.nid, {
+                      children: {
+                        agent: block.children?.agent ?? null,
+                        max: Number(e.target.value),
+                      },
+                    })
+                  }
+                />
+              </label>
+            </div>
+          )}
+        </div>
+      </Field>
+
+      <Field label="Sub-workflows" hint="compose whole workflows">
+        <div className="wb-box">
+          <label className="wb-toggle">
+            <input
+              type="checkbox"
+              checked={!!block.compose}
+              onChange={(e) =>
+                ctx.patchBlock(block.nid, {
+                  compose: e.target.checked ? { maxSubRuns: 2, maxDepth: 2 } : null,
+                })
+              }
+            />
+            Allow launching sub-workflows
+          </label>
+          {block.compose && (
+            <div className="wb-box-cfg row">
+              <label className="wb-budget-field">
+                <span>Sub-runs</span>
+                <input
+                  className="ca-input sm"
+                  type="number"
+                  min={1}
+                  value={block.compose.maxSubRuns}
+                  onChange={(e) =>
+                    ctx.patchBlock(block.nid, {
+                      compose: {
+                        maxSubRuns: Number(e.target.value),
+                        maxDepth: block.compose?.maxDepth ?? 2,
+                      },
+                    })
+                  }
+                />
+              </label>
+              <label className="wb-budget-field">
+                <span>Depth</span>
+                <select
+                  className="ca-select sm"
+                  value={block.compose.maxDepth}
+                  onChange={(e) =>
+                    ctx.patchBlock(block.nid, {
+                      compose: {
+                        maxSubRuns: block.compose?.maxSubRuns ?? 2,
+                        maxDepth: Number(e.target.value),
+                      },
+                    })
+                  }
+                >
+                  <option value={1}>1</option>
+                  <option value={2}>2</option>
+                </select>
+              </label>
+            </div>
+          )}
+        </div>
+      </Field>
+
+      <div className="wb-field-note">
+        Select a child on the canvas to edit its agent and instructions.
+      </div>
+    </>
+  );
+}

--- a/src/workflows/builder/inspector/OverviewInspector.tsx
+++ b/src/workflows/builder/inspector/OverviewInspector.tsx
@@ -32,15 +32,7 @@ function countSteps(blocks: EBlock[]): number {
   return n;
 }
 
-function FlowRow({
-  index,
-  block,
-  ctx,
-}: {
-  index: number;
-  block: EBlock;
-  ctx: BuilderCtx;
-}) {
+function FlowRow({ index, block, ctx }: { index: number; block: EBlock; ctx: BuilderCtx }) {
   const idx = String(index + 1).padStart(2, "0");
   if (block.kind === "step") {
     const a = ctx.resolve(block.agent);
@@ -48,7 +40,13 @@ function FlowRow({
       <button className="wb-ov-step" onClick={() => ctx.select(block.nid)}>
         <span className="i">{idx}</span>
         {a ? (
-          <AgentAvatar custom={a.custom} slug={a.providerId} short={a.short} hue={a.hue} size={22} />
+          <AgentAvatar
+            custom={a.custom}
+            slug={a.providerId}
+            short={a.short}
+            hue={a.hue}
+            size={22}
+          />
         ) : (
           <span className="wb-step-mono empty sm">
             <Icon name="plus" size={10} />

--- a/src/workflows/builder/inspector/OverviewInspector.tsx
+++ b/src/workflows/builder/inspector/OverviewInspector.tsx
@@ -1,0 +1,241 @@
+// OverviewInspector.tsx — the inspector when nothing is selected: run-level
+// stats, a compact flow map, accent hue, run budgets, finalize actions, and the
+// promote-to-workflow launch card when the builder was opened from a session.
+
+import { Icon } from "../../../components/Icon";
+import { AgentAvatar } from "../AgentAvatar";
+import { ContainerErrors } from "../blocks/ContainerErrors";
+import type { BuilderCtx } from "../ctx";
+import type { EBlock, EditorState } from "../model";
+import { WF_HUES } from "../model";
+import { BudgetFields, Field, RUN_BUDGET_FIELDS } from "./bits";
+
+/** The promote-launch surface, threaded down from the builder. */
+export interface PromotePanel {
+  baseLabel: string;
+  task: string;
+  setTask: (t: string) => void;
+  canLaunch: boolean;
+  launching: boolean;
+  launchError: string | null;
+  onLaunch: () => void;
+}
+
+function countSteps(blocks: EBlock[]): number {
+  let n = 0;
+  for (const b of blocks) {
+    if (b.kind === "step") n += 1;
+    else if (b.kind === "parallel") n += b.steps.length;
+    else if (b.kind === "loop") n += countSteps(b.body);
+    else n += b.body.length;
+  }
+  return n;
+}
+
+function FlowRow({
+  index,
+  block,
+  ctx,
+}: {
+  index: number;
+  block: EBlock;
+  ctx: BuilderCtx;
+}) {
+  const idx = String(index + 1).padStart(2, "0");
+  if (block.kind === "step") {
+    const a = ctx.resolve(block.agent);
+    return (
+      <button className="wb-ov-step" onClick={() => ctx.select(block.nid)}>
+        <span className="i">{idx}</span>
+        {a ? (
+          <AgentAvatar custom={a.custom} slug={a.providerId} short={a.short} hue={a.hue} size={22} />
+        ) : (
+          <span className="wb-step-mono empty sm">
+            <Icon name="plus" size={10} />
+          </span>
+        )}
+        <span className="n">{a?.name ?? "Unassigned"}</span>
+      </button>
+    );
+  }
+  const meta =
+    block.kind === "parallel"
+      ? { icon: "layers" as const, label: `Parallel · ${block.steps.length} branches` }
+      : block.kind === "loop"
+        ? { icon: "loop" as const, label: `Loop · up to ${block.max}×` }
+        : { icon: "combine" as const, label: "Orchestrate" };
+  return (
+    <button className="wb-ov-step" onClick={() => ctx.select(block.nid)}>
+      <span className="i">{idx}</span>
+      <span className="wb-ov-cont-ic">
+        <Icon name={meta.icon} size={12} />
+      </span>
+      <span className="n">{meta.label}</span>
+    </button>
+  );
+}
+
+export function OverviewInspector({
+  state,
+  ctx,
+  onField,
+  formErrors,
+  promote,
+}: {
+  state: EditorState;
+  ctx: BuilderCtx;
+  onField: (patch: Partial<EditorState>) => void;
+  formErrors: string[];
+  promote?: PromotePanel;
+}) {
+  const steps = countSteps(state.blocks);
+  const loops = state.blocks.filter((b) => b.kind === "loop").length;
+  const finalize = state.finalize;
+
+  return (
+    <>
+      <ContainerErrors errors={formErrors.length ? formErrors : undefined} />
+
+      {promote && (
+        <div className="wb-promote">
+          <div className="wb-promote-head">
+            <Icon name="combine" size={13} style={{ color: "var(--accent)" }} />
+            <span>Launch this workflow now</span>
+            <span
+              className="wb-promote-base tip"
+              data-tip="Forks from the promoted session's commit"
+            >
+              base <span className="mono">{promote.baseLabel}</span>
+            </span>
+          </div>
+          <textarea
+            className="wb-insp-textarea sm"
+            placeholder="Task for the run…"
+            value={promote.task}
+            onChange={(e) => promote.setTask(e.target.value)}
+          />
+          {promote.launchError && <div className="wb-summary-err">{promote.launchError}</div>}
+          <div className="wb-promote-foot">
+            <span className="wb-promote-note">Or save it as a reusable workflow.</span>
+            <span className="grow" />
+            <button
+              className="btn-t primary"
+              disabled={!promote.canLaunch || promote.launching}
+              style={!promote.canLaunch || promote.launching ? { opacity: 0.5 } : undefined}
+              onClick={promote.onLaunch}
+            >
+              <Icon name={promote.launching ? "refresh" : "arrowUp"} size={13} />{" "}
+              {promote.launching ? "Launching…" : "Launch run"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="wb-stats">
+        <div className="wb-stat">
+          <div className="v">{state.blocks.length}</div>
+          <div className="k">block{state.blocks.length === 1 ? "" : "s"}</div>
+        </div>
+        <div className="wb-stat">
+          <div className="v">{steps}</div>
+          <div className="k">step{steps === 1 ? "" : "s"}</div>
+        </div>
+        <div className="wb-stat">
+          <div className="v">{loops}</div>
+          <div className="k">loop{loops === 1 ? "" : "s"}</div>
+        </div>
+      </div>
+
+      <Field label="Flow">
+        <div className="wb-ov-flow">
+          {state.blocks.map((b, i) => (
+            <FlowRow key={b.nid} index={i} block={b} ctx={ctx} />
+          ))}
+        </div>
+      </Field>
+
+      <Field label="Accent">
+        <div className="wb-hues">
+          {WF_HUES.map((h) => (
+            <button
+              key={h}
+              className={`wb-hue ${state.hue === h ? "on" : ""}`}
+              style={{ "--h": h } as React.CSSProperties}
+              onClick={() => onField({ hue: h })}
+            />
+          ))}
+        </div>
+      </Field>
+
+      <Field label="Run budgets" hint="pauses when exceeded">
+        <BudgetFields
+          fields={RUN_BUDGET_FIELDS}
+          value={state.budgets}
+          onChange={(next) => onField({ budgets: next })}
+        />
+      </Field>
+
+      <Field label="When the run finishes">
+        <div className="wb-box">
+          <label className="wb-toggle">
+            <input
+              type="checkbox"
+              checked={!!finalize?.push}
+              onChange={(e) =>
+                onField({
+                  finalize: {
+                    push: e.target.checked,
+                    open_pr: finalize?.open_pr ?? false,
+                    pr_base: finalize?.pr_base,
+                  },
+                })
+              }
+            />
+            Push the branch
+          </label>
+          <label className="wb-toggle">
+            <input
+              type="checkbox"
+              checked={!!finalize?.open_pr}
+              onChange={(e) =>
+                onField({
+                  finalize: {
+                    push: finalize?.push ?? false,
+                    open_pr: e.target.checked,
+                    pr_base: finalize?.pr_base,
+                  },
+                })
+              }
+            />
+            Open a PR
+          </label>
+          {finalize?.open_pr && (
+            <div className="wb-box-cfg">
+              <label className="wb-budget-field">
+                <span>PR base branch</span>
+                <input
+                  className="ca-input sm"
+                  placeholder="main"
+                  value={finalize.pr_base ?? ""}
+                  onChange={(e) =>
+                    onField({
+                      finalize: {
+                        push: finalize.push,
+                        open_pr: finalize.open_pr,
+                        pr_base: e.target.value.trim() || undefined,
+                      },
+                    })
+                  }
+                />
+              </label>
+            </div>
+          )}
+        </div>
+      </Field>
+
+      <div className="wb-field-note">
+        Select a step on the canvas to edit its agent, instructions, and hand-off rules.
+      </div>
+    </>
+  );
+}

--- a/src/workflows/builder/inspector/OverviewInspector.tsx
+++ b/src/workflows/builder/inspector/OverviewInspector.tsx
@@ -32,6 +32,15 @@ function countSteps(blocks: EBlock[]): number {
   return n;
 }
 
+/** Loops anywhere in the tree — imported specs may nest them in loop bodies. */
+function countLoops(blocks: EBlock[]): number {
+  let n = 0;
+  for (const b of blocks) {
+    if (b.kind === "loop") n += 1 + countLoops(b.body);
+  }
+  return n;
+}
+
 function FlowRow({ index, block, ctx }: { index: number; block: EBlock; ctx: BuilderCtx }) {
   const idx = String(index + 1).padStart(2, "0");
   if (block.kind === "step") {
@@ -87,7 +96,7 @@ export function OverviewInspector({
   promote?: PromotePanel;
 }) {
   const steps = countSteps(state.blocks);
-  const loops = state.blocks.filter((b) => b.kind === "loop").length;
+  const loops = countLoops(state.blocks);
   const finalize = state.finalize;
 
   return (

--- a/src/workflows/builder/inspector/StepInspector.tsx
+++ b/src/workflows/builder/inspector/StepInspector.tsx
@@ -32,7 +32,8 @@ export function StepInspector({ step, ctx }: { step: EStep; ctx: BuilderCtx }) {
     });
   };
 
-  const requireTests = step.gate.type === "approval" && (step.gate.require?.includes("tests") ?? false);
+  const requireTests =
+    step.gate.type === "approval" && (step.gate.require?.includes("tests") ?? false);
 
   return (
     <>

--- a/src/workflows/builder/inspector/StepInspector.tsx
+++ b/src/workflows/builder/inspector/StepInspector.tsx
@@ -1,0 +1,133 @@
+// StepInspector.tsx — edits the selected step: agent, instructions, done-gate
+// (the full §9 option list, inline instead of the old popover), budgets, comms.
+
+import { Icon } from "../../../components/Icon";
+import { GATE_MODES, type GateKind, STEP_COMMS } from "../../data";
+import type { CommsCap, Gate } from "../../spec";
+import { ContainerErrors } from "../blocks/ContainerErrors";
+import type { BuilderCtx } from "../ctx";
+import type { EStep } from "../model";
+import { AgentButton, BudgetFields, Field, STEP_BUDGET_FIELDS } from "./bits";
+
+export function StepInspector({ step, ctx }: { step: EStep; ctx: BuilderCtx }) {
+  const a = ctx.resolve(step.agent);
+  const errors = ctx.errorsFor(step.nid);
+
+  const pickGate = (kind: GateKind) => {
+    const cur = step.gate;
+    const gate: Gate =
+      kind === "artifact"
+        ? { type: "artifact", path: cur.type === "artifact" ? cur.path : "" }
+        : // Re-picking approval preserves any existing `require: [tests]`.
+          kind === "approval"
+          ? { type: "approval", require: cur.type === "approval" ? cur.require : undefined }
+          : { type: kind };
+    ctx.patchStep(step.nid, { gate });
+  };
+
+  const toggleComms = (cap: CommsCap) => {
+    const has = step.comms.includes(cap);
+    ctx.patchStep(step.nid, {
+      comms: has ? step.comms.filter((c) => c !== cap) : [...step.comms, cap],
+    });
+  };
+
+  const requireTests = step.gate.type === "approval" && (step.gate.require?.includes("tests") ?? false);
+
+  return (
+    <>
+      <ContainerErrors errors={errors} />
+
+      <Field label="Agent" required>
+        <AgentButton
+          agent={a}
+          placeholder="Choose an agent"
+          onClick={(e) => ctx.openAgent(step.nid, "step", e)}
+        />
+      </Field>
+
+      <Field label="Instructions" hint="what this step should accomplish">
+        <textarea
+          className="wb-insp-textarea"
+          value={step.goal}
+          placeholder="e.g. Explore the codebase and write a focused implementation plan to PLAN.md. Don't write feature code."
+          onChange={(e) => ctx.patchStep(step.nid, { goal: e.target.value })}
+        />
+      </Field>
+
+      <Field label="This step is done when…">
+        <div className="wb-opts">
+          {GATE_MODES.map((m) => (
+            <button
+              key={m.id}
+              className={`wb-opt ${m.id === step.gate.type ? "on" : ""}`}
+              onClick={() => pickGate(m.id)}
+            >
+              <span className="wb-opt-ic">
+                <Icon name={m.icon} />
+              </span>
+              <span className="wb-opt-l">
+                <span className="wb-opt-t">
+                  {m.label}
+                  {m.id === step.gate.type && <Icon className="ck" name="check" size={13} />}
+                </span>
+                <span className="wb-opt-s">{m.note}</span>
+              </span>
+            </button>
+          ))}
+        </div>
+        {step.gate.type === "artifact" && (
+          <input
+            className="ca-input"
+            style={{ marginTop: 9 }}
+            value={step.gate.path}
+            placeholder="File to wait for, e.g. PLAN.md"
+            onChange={(e) =>
+              ctx.patchStep(step.nid, { gate: { type: "artifact", path: e.target.value } })
+            }
+          />
+        )}
+        {step.gate.type === "approval" && (
+          // One extra prerequisite the approval gate can require first — the human
+          // pause stays unreachable until the project's tests pass (spec §9).
+          <label className="wb-toggle" style={{ marginTop: 9 }}>
+            <input
+              type="checkbox"
+              checked={requireTests}
+              onChange={(e) =>
+                ctx.patchStep(step.nid, {
+                  gate: { type: "approval", require: e.target.checked ? ["tests"] : undefined },
+                })
+              }
+            />
+            Require passing tests first
+          </label>
+        )}
+      </Field>
+
+      <Field label="Budgets" hint="pauses when exceeded">
+        <BudgetFields
+          fields={STEP_BUDGET_FIELDS}
+          value={step.budgets}
+          onChange={(next) => ctx.patchStep(step.nid, { budgets: next })}
+        />
+      </Field>
+
+      <Field label="This step may">
+        <div className="wb-comms">
+          {STEP_COMMS.map((c) => (
+            <button
+              key={c.id}
+              className={`wb-comm ${step.comms.includes(c.id) ? "on" : ""} tip`}
+              data-tip-down
+              data-tip={c.note}
+              onClick={() => toggleComms(c.id)}
+            >
+              {c.label}
+            </button>
+          ))}
+        </div>
+      </Field>
+    </>
+  );
+}

--- a/src/workflows/builder/inspector/bits.tsx
+++ b/src/workflows/builder/inspector/bits.tsx
@@ -1,0 +1,125 @@
+// bits.tsx — small shared pieces of the inspector: labelled fields, the agent
+// select button, and the budget field groups (formerly the budgets popover).
+
+import { Icon } from "../../../components/Icon";
+import type { ResolvedAgent } from "../../shared";
+import type { Budgets } from "../../spec";
+import { AgentAvatar } from "../AgentAvatar";
+
+export function Field({
+  label,
+  hint,
+  required,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  required?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="wb-field">
+      <div className="wb-label">
+        {label} {required && <span className="req">*</span>}
+        {hint && <span className="hint">{hint}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+/** The agent select button: identity when assigned, a dashed placeholder when
+ *  not. Opens the agent picker popover via `onClick`. */
+export function AgentButton({
+  agent,
+  placeholder,
+  onClick,
+}: {
+  agent: ResolvedAgent | null;
+  placeholder: string;
+  onClick: (e: React.MouseEvent) => void;
+}) {
+  return (
+    <button className="wb-agent-btn" onClick={onClick}>
+      {agent ? (
+        <AgentAvatar
+          custom={agent.custom}
+          slug={agent.providerId}
+          short={agent.short}
+          hue={agent.hue}
+          size={28}
+        />
+      ) : (
+        <span className="wb-step-mono empty">
+          <Icon name="plus" size={12} />
+        </span>
+      )}
+      <span className="wb-agent-btn-l">
+        <div className={`wb-an ${agent ? "" : "empty"}`}>{agent ? agent.name : placeholder}</div>
+        {agent && (
+          <div className="wb-am">
+            {agent.custom ? `${agent.baseLabel} · ${agent.model}` : agent.model}
+          </div>
+        )}
+      </span>
+      <Icon name="chevD" size={13} />
+    </button>
+  );
+}
+
+interface BudgetFieldDef {
+  key: keyof Budgets;
+  label: string;
+  placeholder: string;
+}
+
+/** Curated per-scope fields; the rest of §11.1 (timeouts) keep their defaults. */
+export const RUN_BUDGET_FIELDS: BudgetFieldDef[] = [
+  { key: "turns", label: "Total turns", placeholder: "100" },
+  { key: "tokens", label: "Total tokens", placeholder: "unlimited" },
+  { key: "wall_clock_mins", label: "Wall-clock (min)", placeholder: "480" },
+];
+export const STEP_BUDGET_FIELDS: BudgetFieldDef[] = [
+  { key: "turns", label: "Turns", placeholder: "—" },
+  { key: "turns_per_attempt", label: "Turns / attempt", placeholder: "10" },
+  { key: "max_attempts", label: "Max attempts", placeholder: "2" },
+];
+
+export function BudgetFields({
+  fields,
+  value,
+  onChange,
+}: {
+  fields: BudgetFieldDef[];
+  value: Budgets | undefined;
+  onChange: (next: Budgets | undefined) => void;
+}) {
+  const set = (key: keyof Budgets, raw: string) => {
+    const next: Budgets = { ...(value ?? {}) };
+    const n = raw.trim() === "" ? undefined : Number(raw);
+    if (n == null || Number.isNaN(n)) delete next[key];
+    else next[key] = n;
+    onChange(Object.keys(next).length ? next : undefined);
+  };
+
+  return (
+    <div className="wb-budget-grid">
+      {fields.map((f) => (
+        <label className="wb-budget-field" key={f.key}>
+          <span>{f.label}</span>
+          <input
+            className="ca-input sm"
+            type="number"
+            min={1}
+            value={value?.[f.key] ?? ""}
+            placeholder={f.placeholder}
+            onChange={(e) => set(f.key, e.target.value)}
+          />
+        </label>
+      ))}
+      <div className="wb-field-note">
+        Blank uses the app default. Exceeding a budget pauses the run — never a silent overspend.
+      </div>
+    </div>
+  );
+}

--- a/src/workflows/builder/inspector/index.tsx
+++ b/src/workflows/builder/inspector/index.tsx
@@ -1,0 +1,77 @@
+// inspector/index.tsx — the right-hand inspector: a sticky panel that edits the
+// selected canvas node, or shows the workflow overview when nothing is selected.
+
+import { Icon } from "../../../components/Icon";
+import type { BuilderCtx } from "../ctx";
+import type { EBlock, EditorState } from "../model";
+import { LoopInspector, OrchestrateInspector, ParallelInspector } from "./ContainerInspectors";
+import { OverviewInspector, type PromotePanel } from "./OverviewInspector";
+import { StepInspector } from "./StepInspector";
+
+function headerFor(selected: EBlock | null, state: EditorState, ctx: BuilderCtx) {
+  if (!selected) return { eyebrow: "Overview", title: state.name.trim() || "Untitled workflow" };
+  switch (selected.kind) {
+    case "step": {
+      const a = ctx.resolve(selected.agent);
+      return { eyebrow: `Step · ${selected.stepId}`, title: a?.name ?? "Unassigned" };
+    }
+    case "parallel":
+      return { eyebrow: "Block", title: "Parallel" };
+    case "loop":
+      return { eyebrow: "Block", title: "Loop" };
+    case "orchestrate":
+      return { eyebrow: "Block", title: "Orchestrate" };
+  }
+}
+
+export function Inspector({
+  state,
+  selected,
+  ctx,
+  onField,
+  formErrors,
+  promote,
+}: {
+  state: EditorState;
+  selected: EBlock | null;
+  ctx: BuilderCtx;
+  onField: (patch: Partial<EditorState>) => void;
+  formErrors: string[];
+  promote?: PromotePanel;
+}) {
+  const head = headerFor(selected, state, ctx);
+
+  return (
+    <aside className="wb-insp">
+      <div className="wb-insp-h">
+        <span className="wb-insp-eye">{head.eyebrow}</span>
+        <span className="wb-insp-t">{head.title}</span>
+        {selected && (
+          <button
+            className="wb-insp-close tip"
+            data-tip-down
+            data-tip="Back to overview"
+            onClick={() => ctx.select(null)}
+          >
+            <Icon name="close" size={13} />
+          </button>
+        )}
+      </div>
+      <div className="wb-insp-body" key={selected?.nid ?? "overview"}>
+        {!selected && (
+          <OverviewInspector
+            state={state}
+            ctx={ctx}
+            onField={onField}
+            formErrors={formErrors}
+            promote={promote}
+          />
+        )}
+        {selected?.kind === "step" && <StepInspector step={selected} ctx={ctx} />}
+        {selected?.kind === "parallel" && <ParallelInspector block={selected} ctx={ctx} />}
+        {selected?.kind === "loop" && <LoopInspector block={selected} ctx={ctx} />}
+        {selected?.kind === "orchestrate" && <OrchestrateInspector block={selected} ctx={ctx} />}
+      </div>
+    </aside>
+  );
+}

--- a/src/workflows/builder/model.ts
+++ b/src/workflows/builder/model.ts
@@ -177,7 +177,7 @@ export function newOrchestrate(taken: Set<string>): EOrchestrate {
 
 // ───────────────────────────── blank / defaults ───────────────────────────
 
-const WF_HUES = [265, 150, 25, 215, 320, 95, 175, 50];
+export const WF_HUES = [265, 150, 25, 215, 320, 95, 175, 50];
 
 export function blankEditor(seed: number): EditorState {
   const taken = new Set<string>();

--- a/src/workflows/builder/pickers.tsx
+++ b/src/workflows/builder/pickers.tsx
@@ -1,17 +1,14 @@
-// pickers.tsx — the builder popovers: agent picker, gate picker, budgets editor.
-// All are fixed-positioned (escaping the canvas clip) from a measured rect.
+// pickers.tsx — the builder's agent-picker popover, fixed-positioned (escaping
+// the canvas clip) from a measured rect. Gate and budget editing moved inline
+// into the inspector (see inspector/), so this is the one popover left.
 
-import { Icon } from "../../components/Icon";
 import { PROVIDERS } from "../../data/providers";
 import type { CustomAgent } from "../../storage/customAgents";
 import { useAppStore } from "../../store";
-import { GATE_MODES, type GateKind } from "../data";
 import { defaultModel, shortFor } from "../shared";
-import type { Budgets } from "../spec";
 import { AgentAvatar } from "./AgentAvatar";
 import type { PopRect } from "./ctx";
 
-// ── agent picker ──────────────────────────────────────────────────────────
 export function AgentPick({
   rect,
   agents,
@@ -55,124 +52,6 @@ export function AgentPick({
           </span>
         </div>
       ))}
-    </div>
-  );
-}
-
-// ── gate picker ───────────────────────────────────────────────────────────
-export function GatePick({
-  rect,
-  gate,
-  requireTests,
-  onPick,
-  onToggleRequireTests,
-}: {
-  rect: PopRect;
-  gate: GateKind;
-  /** Whether the current approval gate carries `require: [tests]`. */
-  requireTests: boolean;
-  onPick: (kind: GateKind) => void;
-  onToggleRequireTests: (checked: boolean) => void;
-}) {
-  return (
-    <div className="dd" style={{ position: "fixed", top: rect.top, left: rect.left, width: 300 }}>
-      <div className="dd-sect">This step is done when…</div>
-      {GATE_MODES.map((m) => (
-        <div
-          key={m.id}
-          className={`dd-item ${m.id === gate ? "active" : ""}`}
-          onClick={() => onPick(m.id)}
-          style={{ alignItems: "flex-start", flexDirection: "column", gap: 3 }}
-        >
-          <span style={{ display: "flex", alignItems: "center", gap: 8, width: "100%" }}>
-            <Icon name={m.icon} size={12} /> <span style={{ fontWeight: 500 }}>{m.label}</span>
-            {m.id === gate && <Icon name="check" size={12} style={{ marginLeft: "auto" }} />}
-          </span>
-          <span style={{ fontSize: 11, color: "var(--fg-2)", lineHeight: 1.45, paddingLeft: 20 }}>
-            {m.note}
-          </span>
-        </div>
-      ))}
-      {gate === "approval" && (
-        // One extra prerequisite the approval gate can require first — the human
-        // pause stays unreachable until the project's tests pass (spec §9).
-        <label
-          className="dd-item"
-          style={{ display: "flex", alignItems: "center", gap: 8, cursor: "pointer" }}
-        >
-          <input
-            type="checkbox"
-            checked={requireTests}
-            onChange={(e) => onToggleRequireTests(e.target.checked)}
-          />
-          <span style={{ fontSize: 12 }}>Require passing tests first</span>
-        </label>
-      )}
-    </div>
-  );
-}
-
-// ── budgets editor ──────────────────────────────────────────────────────────
-
-interface BudgetFieldDef {
-  key: keyof Budgets;
-  label: string;
-  placeholder: string;
-}
-
-/** Curated per-scope fields; the rest of §11.1 (timeouts) keep their defaults. */
-const RUN_FIELDS: BudgetFieldDef[] = [
-  { key: "turns", label: "Total turns", placeholder: "100" },
-  { key: "tokens", label: "Total tokens", placeholder: "unlimited" },
-  { key: "wall_clock_mins", label: "Wall-clock (min)", placeholder: "480" },
-];
-const STEP_FIELDS: BudgetFieldDef[] = [
-  { key: "turns", label: "Turns", placeholder: "—" },
-  { key: "turns_per_attempt", label: "Turns / attempt", placeholder: "10" },
-  { key: "max_attempts", label: "Max attempts", placeholder: "2" },
-];
-
-export function BudgetsPopover({
-  rect,
-  scope,
-  value,
-  onChange,
-}: {
-  rect: PopRect;
-  scope: "run" | "step";
-  value: Budgets | undefined;
-  onChange: (next: Budgets | undefined) => void;
-}) {
-  const fields = scope === "run" ? RUN_FIELDS : STEP_FIELDS;
-  const left = Math.max(12, rect.left - 60);
-
-  const set = (key: keyof Budgets, raw: string) => {
-    const next: Budgets = { ...(value ?? {}) };
-    const n = raw.trim() === "" ? undefined : Number(raw);
-    if (n == null || Number.isNaN(n)) delete next[key];
-    else next[key] = n;
-    onChange(Object.keys(next).length ? next : undefined);
-  };
-
-  return (
-    <div className="wb-loop-pop" style={{ position: "fixed", top: rect.top, left, width: 240 }}>
-      <div className="wlp-h">{scope === "run" ? "Run budgets" : "Step budgets"}</div>
-      {fields.map((f) => (
-        <div className="wlp-row" key={f.key}>
-          <label>{f.label}</label>
-          <input
-            className="ca-input"
-            type="number"
-            min={1}
-            value={value?.[f.key] ?? ""}
-            placeholder={f.placeholder}
-            onChange={(e) => set(f.key, e.target.value)}
-          />
-        </div>
-      ))}
-      <div style={{ fontSize: 11, color: "var(--fg-3)", lineHeight: 1.45, marginTop: 8 }}>
-        Blank uses the app default. Exceeding a budget pauses the run — never a silent overspend.
-      </div>
     </div>
   );
 }

--- a/src/workflows/workflows.css
+++ b/src/workflows/workflows.css
@@ -190,131 +190,258 @@
   width: 11px;
   height: 11px;
 }
+
+/* ───────────────────── Builder: vertical pipeline editor ─────────────────────
+   Canvas (a vertical flow of collapsed block cards) + a sticky right-hand
+   inspector editing the selected node. Cards carry previews and summary chips
+   only; all field editing happens in the inspector (builder/inspector/). */
+
 .wb {
-  --wb-step-w: 256px;
   display: flex;
   flex-direction: column;
   min-height: 0;
   animation: fade-in 0.2s var(--ease);
 }
-.wb-top {
+.wb-body {
   display: flex;
   align-items: flex-start;
-  gap: 16px;
-  margin-bottom: 4px;
+  gap: 24px;
+  margin-top: 14px;
 }
-.wb-top .wb-titlewrap {
+
+/* ── canvas ─────────────────────────────────────────────────────────── */
+.wb-canvas {
   flex: 1;
   min-width: 0;
+  padding: 34px 30px 52px;
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-lg);
+  background:
+    radial-gradient(var(--bd-soft) 0.6px, transparent 0.6px) 0 0 / 22px 22px,
+    radial-gradient(130% 50% at 50% -6%, oklch(0.72 0.13 var(--h, 50) / 0.05), transparent 60%),
+    var(--bg-1);
+}
+.wb-head {
+  max-width: 600px;
+  margin: 0 auto 30px;
+}
+.wb-eyebrow {
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 10px;
 }
 .wb-name {
-  font-size: 22px;
+  width: 100%;
+  font-size: 24px;
   font-weight: 500;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
   color: var(--fg-0);
-  letter-spacing: -0.015em;
   background: transparent;
   border: 0;
-  padding: 2px 5px;
+  padding: 3px 6px;
+  margin: 0 -6px;
   border-radius: var(--r-sm);
-  width: 100%;
+}
+.wb-name::placeholder {
+  color: var(--fg-3);
 }
 .wb-name:focus {
   background: var(--bg-2);
   box-shadow: 0 0 0 1px var(--accent-line);
 }
 .wb-desc {
-  margin-top: 4px;
   width: 100%;
+  margin: 6px -6px 0;
+  padding: 4px 6px;
   font-size: 13px;
-  line-height: 1.5;
+  line-height: 1.55;
   color: var(--fg-2);
   background: transparent;
   border: 0;
-  padding: 2px 5px;
-  border-radius: var(--r-sm);
   resize: none;
+  border-radius: var(--r-sm);
+  font-family: var(--font-sans);
+}
+.wb-desc::placeholder {
+  color: var(--fg-3);
 }
 .wb-desc:focus {
   background: var(--bg-2);
   box-shadow: 0 0 0 1px var(--accent-line);
   color: var(--fg-1);
 }
-.wb-canvas {
-  margin-top: 20px;
-  border: 1px solid var(--bd-soft);
-  border-radius: var(--r-lg);
-  background:
-    radial-gradient(var(--bd-soft) 0.6px, transparent 0.6px) 0 0 / 22px 22px,
-    var(--bg-1);
-  overflow: hidden;
+
+/* ── vertical flow ──────────────────────────────────────────────────── */
+.wb-seq {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+.wb-canvas > .wb-seq {
+  max-width: 600px;
+  margin: 0 auto;
 }
 .wb-conn {
-  width: 30px;
-  flex-shrink: 0;
+  position: relative;
+  height: 30px;
   display: flex;
   align-items: center;
   justify-content: center;
-  position: relative;
-  align-self: center;
 }
 .wb-conn::before {
   content: "";
   position: absolute;
-  left: -1px;
-  right: -1px;
-  top: 50%;
-  height: 1.5px;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 2px;
+  transform: translateX(-50%);
   background: var(--bd-strong);
 }
-.wb-conn svg {
+.wb-conn .wb-insert {
   position: relative;
-  z-index: 1;
+  z-index: 2;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-1);
+  border: 1.5px solid var(--bd-strong);
+  color: var(--fg-3);
+  opacity: 0;
+  transform: scale(0.8);
+  transition: all 0.14s var(--ease);
+}
+.wb-conn:hover .wb-insert {
+  opacity: 1;
+  transform: scale(1);
+}
+.wb-insert:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+.wb-insert svg {
   width: 12px;
   height: 12px;
-  color: var(--fg-3);
-  background: var(--bg-1);
-  border-radius: 50%;
 }
+
+/* add block / add branch */
+.wb-add {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 48px;
+  margin-top: 26px;
+  border: 1.5px dashed var(--bd-strong);
+  border-radius: var(--r-lg);
+  color: var(--fg-2);
+  font-size: 12.5px;
+  font-weight: 500;
+  background: transparent;
+  transition: all 0.14s var(--ease);
+}
+.wb-add:hover {
+  border-color: var(--accent-line);
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+.wb-add .wb-add-ic {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 1.5px solid currentColor;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.wb-add .wb-add-ic svg {
+  width: 12px;
+  height: 12px;
+}
+.wb-add.sm {
+  min-height: 38px;
+  margin-top: 0;
+  border-radius: var(--r-md);
+  font-size: 11.5px;
+}
+.wb-add-menu {
+  z-index: 56;
+  width: 270px;
+}
+
+/* ── step card (collapsed; edits happen in the inspector) ───────────── */
 .wb-step {
-  flex: 0 0 var(--wb-step-w);
-  width: var(--wb-step-w);
+  position: relative;
   display: flex;
   flex-direction: column;
   border: 1px solid var(--bd);
-  border-radius: var(--r-md);
+  border-radius: var(--r-lg);
   background: var(--bg-2);
   box-shadow: var(--shadow-1);
-  position: relative;
+  cursor: pointer;
   transition:
-    border-color 0.14s,
-    box-shadow 0.14s;
+    border-color 0.14s var(--ease),
+    box-shadow 0.14s var(--ease);
 }
 .wb-step:hover {
   border-color: var(--bd-strong);
 }
+.wb-step.sel {
+  border-color: var(--accent);
+  box-shadow:
+    0 0 0 3px var(--accent-soft),
+    var(--shadow-1);
+}
+.wb-step.has-err {
+  border-color: color-mix(in srgb, var(--danger) 55%, var(--bd));
+}
+/* left hue spine, tinted by the assigned agent */
+.wb-step::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 13px;
+  bottom: 13px;
+  width: 3px;
+  border-radius: 0 3px 3px 0;
+  background: oklch(0.72 0.13 var(--h));
+  opacity: 0.9;
+}
+.wb-step.unassigned::before {
+  background: var(--bd-strong);
+}
 .wb-step-h {
   display: flex;
   align-items: center;
-  gap: 7px;
-  padding: 9px 10px 8px;
-  border-bottom: 1px solid var(--bd-soft);
+  gap: 10px;
+  /* right padding clears the absolute remove button */
+  padding: 12px 34px 11px 16px;
 }
 .wb-step-idx {
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: 10px;
   font-weight: 600;
   color: var(--fg-3);
   letter-spacing: 0.04em;
+  flex-shrink: 0;
 }
 .wb-step-mono {
-  width: 26px;
-  height: 26px;
-  border-radius: 6px;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: 10px;
   font-weight: 600;
   color: oklch(0.18 0.03 var(--h));
   background: oklch(0.72 0.13 var(--h));
@@ -325,6 +452,11 @@
   color: var(--fg-3);
   border: 1.5px dashed var(--bd-strong);
 }
+.wb-step-mono.empty.sm {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+}
 .wb-step-agent {
   flex: 1;
   min-width: 0;
@@ -332,39 +464,39 @@
   text-align: left;
   display: flex;
   align-items: center;
-  gap: 7px;
+  gap: 9px;
 }
 .wb-step-agent .wb-step-agent-text {
   flex: 1;
   min-width: 0;
 }
-.wb-step-agent .wb-an {
-  font-size: 12.5px;
+.wb-an {
+  font-size: 13px;
   font-weight: 500;
   color: var(--fg-0);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.wb-step-agent .wb-an.empty {
+.wb-an.empty {
   color: var(--fg-3);
   font-weight: 400;
 }
-.wb-step-agent .wb-am {
+.wb-am {
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: 10px;
   color: var(--fg-3);
+  margin-top: 1px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-/* Scoped under .wb-step so `position: absolute` beats `.tip { position: relative }`
-   (same specificity otherwise — the tooltip class was winning, leaving the
-   button in flow and centered in the header). */
-.wb-step .wb-step-menu {
+/* Scoped so `position: absolute` beats `.tip { position: relative }`. */
+.wb-step .wb-step-menu,
+.wb-cont .wb-step-menu {
   position: absolute;
-  top: 6px;
-  right: 6px;
+  top: 8px;
+  right: 8px;
   width: 20px;
   height: 20px;
   display: inline-flex;
@@ -379,143 +511,583 @@
     color 0.12s;
   z-index: 3;
 }
-.wb-step .wb-step-menu svg {
+.wb-step .wb-step-menu svg,
+.wb-cont .wb-step-menu svg {
   width: 14px;
   height: 14px;
 }
-.wb-step .wb-step-menu:hover {
+.wb-step .wb-step-menu:hover,
+.wb-cont .wb-step-menu:hover {
   background: color-mix(in oklch, var(--danger) 14%, transparent);
   color: var(--danger);
 }
-.wb-step:hover .wb-step-menu {
+.wb-step:hover > .wb-step-h .wb-step-menu,
+.wb-cont:hover > .wb-cont-h .wb-step-menu {
   opacity: 1;
 }
 .wb-step-goal {
-  padding: 10px 11px;
-  font-size: 11px;
-  line-height: 1.45;
+  margin: 0 13px 0 16px;
+  padding: 10px 0;
+  border-top: 1px solid var(--bd-soft);
+  font-size: 12px;
+  line-height: 1.5;
   color: var(--fg-1);
-  min-height: 72px;
-  flex: 1;
-  background: transparent;
-  border: 0;
-  resize: none;
-  width: 100%;
-  font-family: var(--font-sans);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-wrap: pretty;
 }
-.wb-step-goal::placeholder {
+.wb-step-goal.empty {
   color: var(--fg-3);
-}
-.wb-step-goal:focus {
-  outline: 0;
-  background: var(--bg-1);
+  font-style: italic;
 }
 .wb-step-foot {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 8px 10px;
+  flex-wrap: wrap;
+  padding: 10px 13px 12px 16px;
   border-top: 1px solid var(--bd-soft);
-  background: var(--bg-1);
-  border-radius: 0 0 var(--r-md) var(--r-md);
 }
-.wb-advance {
-  flex: 1;
-  min-width: 0;
+.wb-step-foot:empty {
+  display: none;
+}
+.wb-chip {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  font-size: 10.5px;
+  gap: 5px;
+  height: 22px;
+  padding: 0 9px;
+  border-radius: 999px;
+  border: 1px solid var(--bd-soft);
+  background: var(--bg-1);
+  font-size: 11px;
   color: var(--fg-2);
+  white-space: nowrap;
 }
-.wb-advance svg {
+.wb-chip svg {
   width: 11px;
   height: 11px;
   color: var(--fg-3);
   flex-shrink: 0;
 }
-.wb-advance .wb-adv-sel {
+.wb-chip b {
   color: var(--fg-1);
   font-weight: 500;
-  text-decoration: underline;
-  text-decoration-color: var(--bd-strong);
-  text-underline-offset: 2px;
-  cursor: pointer;
 }
-.wb-advance .wb-adv-sel:hover {
-  color: var(--accent);
-  text-decoration-color: var(--accent-line);
+.wb-chip.err {
+  border-color: color-mix(in srgb, var(--danger) 40%, transparent);
+  color: var(--danger);
 }
-.wb-add {
-  flex: 0 0 var(--wb-step-w);
-  width: var(--wb-step-w);
-  align-self: stretch;
+.wb-chip.err svg {
+  color: var(--danger);
+}
+
+/* ── container blocks (parallel / loop / orchestrate) ───────────────── */
+.wb-cont {
+  position: relative;
   display: flex;
   flex-direction: column;
+  border: 1px solid var(--bd);
+  border-radius: var(--r-lg);
+  background: var(--bg-1);
+  box-shadow: var(--shadow-1);
+  cursor: pointer;
+  transition:
+    border-color 0.14s var(--ease),
+    box-shadow 0.14s var(--ease);
+}
+.wb-cont:hover {
+  border-color: var(--bd-strong);
+}
+.wb-cont.sel {
+  border-color: var(--accent);
+  box-shadow:
+    0 0 0 3px var(--accent-soft),
+    var(--shadow-1);
+}
+.wb-cont.has-err {
+  border-color: color-mix(in srgb, var(--danger) 55%, var(--bd));
+}
+.wb-loop {
+  border-left: 3px solid var(--accent-line);
+}
+.wb-cont-h {
+  display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 7px;
-  padding: 10px;
-  border: 1.5px dashed var(--bd-strong);
-  border-radius: var(--r-md);
-  color: var(--fg-3);
-  background: transparent;
-  transition: all 0.14s var(--ease);
+  gap: 10px;
+  /* right padding clears the absolute remove button */
+  padding: 11px 34px 11px 14px;
 }
-.wb-add:hover {
-  border-color: var(--accent-line);
+.wb-cont-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-1);
+}
+.wb-cont-badge.loop {
   color: var(--accent);
-  background: var(--accent-soft);
 }
-.wb-add .wb-add-ic {
-  width: 26px;
-  height: 26px;
-  border-radius: 50%;
-  border: 1.5px solid currentColor;
+.wb-cont-sum {
+  font-size: 11.5px;
+  color: var(--fg-2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wb-cont-sum b {
+  color: var(--fg-0);
+  font-weight: 500;
+}
+.wb-cont-body {
+  padding: 12px 14px 14px;
+  border-top: 1px solid var(--bd-soft);
+  cursor: default;
+}
+.wb-branches {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 10px;
+}
+.wb-branches > .wb-add.sm {
+  grid-column: 1 / -1;
+}
+.wb-loop-body .wb-seq .wb-conn {
+  height: 24px;
+}
+.wb-loop-body .wb-add {
+  margin-top: 18px;
+  min-height: 40px;
+}
+
+/* orchestrate lead row */
+.wb-orch-lead {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  padding: 12px 14px 13px 16px;
+  border-top: 1px solid var(--bd-soft);
+}
+.wb-orch-lead .wb-step-goal {
+  margin: 0;
+  padding: 0;
+  border-top: 0;
+}
+.wb-orch-lead .wb-step-foot {
+  padding: 0;
+  border-top: 0;
+}
+
+/* ── inspector ──────────────────────────────────────────────────────── */
+.wb-insp {
+  width: 340px;
+  flex-shrink: 0;
+  position: sticky;
+  top: 16px;
+  max-height: calc(100vh - 110px);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-lg);
+  background: var(--bg-1);
+  box-shadow: var(--shadow-1);
+}
+@media (max-width: 1200px) {
+  .wb-insp {
+    width: 300px;
+  }
+}
+.wb-insp-h {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 13px 16px;
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--bd-soft);
+}
+.wb-insp-eye {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  flex-shrink: 0;
+}
+.wb-insp-t {
+  flex: 1;
+  min-width: 0;
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--fg-0);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wb-insp-close {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--r-sm);
+  color: var(--fg-2);
+  flex-shrink: 0;
 }
-.wb-add .wb-add-ic svg {
-  width: 14px;
-  height: 14px;
+.wb-insp-close:hover {
+  background: var(--hover);
+  color: var(--fg-0);
 }
-.wb-add .wb-add-l {
+.wb-insp-body {
+  padding: 16px 16px 26px;
+  animation: fade-in 0.16s var(--ease);
+}
+
+.wb-field {
+  margin-bottom: 20px;
+}
+.wb-field:last-child {
+  margin-bottom: 0;
+}
+.wb-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  margin-bottom: 8px;
+}
+.wb-label .req {
+  color: var(--accent);
+}
+.wb-label .hint {
+  margin-left: auto;
+  font-weight: 400;
+  letter-spacing: 0;
+  text-transform: none;
   font-size: 11px;
-  font-weight: 500;
-  text-align: center;
+  color: var(--fg-3);
 }
-.wb-loop-pop {
-  position: absolute;
-  z-index: 60;
-  width: 260px;
-  padding: 13px 14px;
+.wb-field-note {
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--fg-3);
+  text-wrap: pretty;
+  margin-top: 8px;
+}
+
+/* agent select button */
+.wb-agent-btn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 11px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--bd);
+  background: var(--bg-2);
+  transition: border-color 0.12s;
+}
+.wb-agent-btn:hover {
+  border-color: var(--bd-strong);
+}
+.wb-agent-btn .wb-agent-btn-l {
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+}
+.wb-agent-btn > svg {
+  color: var(--fg-3);
+  flex-shrink: 0;
+}
+
+.wb-insp-textarea {
+  width: 100%;
   background: var(--bg-2);
   border: 1px solid var(--bd);
   border-radius: var(--r-md);
-  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.34);
-  animation: ddIn 0.14s var(--ease);
-}
-.wb-loop-pop .wlp-h {
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--fg-3);
-  margin-bottom: 10px;
-}
-.wb-loop-pop .wlp-row {
-  margin-bottom: 11px;
-}
-.wb-loop-pop .wlp-row:last-child {
-  margin-bottom: 0;
-}
-.wb-loop-pop label {
-  font-size: 11.5px;
   color: var(--fg-1);
-  display: block;
-  margin-bottom: 5px;
+  font-size: 12.5px;
+  line-height: 1.55;
+  padding: 10px 11px;
+  min-height: 130px;
+  resize: vertical;
+  font-family: var(--font-sans);
+  transition:
+    border-color 0.12s,
+    box-shadow 0.12s;
 }
+.wb-insp-textarea.sm {
+  min-height: 60px;
+}
+.wb-insp-textarea::placeholder {
+  color: var(--fg-3);
+}
+.wb-insp-textarea:focus {
+  outline: 0;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+/* gate option list */
+.wb-opts {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.wb-opt {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 9px 10px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--bd-soft);
+  background: var(--bg-2);
+  text-align: left;
+  transition:
+    border-color 0.12s,
+    background 0.12s;
+}
+.wb-opt:hover {
+  border-color: var(--bd-strong);
+  background: var(--hover);
+}
+.wb-opt.on {
+  border-color: var(--accent-line);
+  background: var(--accent-soft);
+}
+.wb-opt .wb-opt-ic {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  flex-shrink: 0;
+  margin-top: 1px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-1);
+  color: var(--fg-2);
+}
+.wb-opt.on .wb-opt-ic {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+.wb-opt .wb-opt-ic svg {
+  width: 12px;
+  height: 12px;
+}
+.wb-opt .wb-opt-l {
+  flex: 1;
+  min-width: 0;
+}
+.wb-opt .wb-opt-t {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--fg-0);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.wb-opt .wb-opt-t .ck {
+  margin-left: auto;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+.wb-opt .wb-opt-s {
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--fg-2);
+  margin-top: 2px;
+  text-wrap: pretty;
+}
+
+/* grouped boxes (finalize, dynamic children, sub-workflows) */
+.wb-box {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  padding: 11px 12px;
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-md);
+  background: var(--bg-2);
+}
+.wb-box-cfg {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-left: 22px;
+}
+.wb-box-cfg.row {
+  flex-direction: row;
+  align-items: flex-end;
+  gap: 10px;
+}
+.wb-toggle {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  color: var(--fg-1);
+  cursor: pointer;
+}
+
+/* budget fields */
+.wb-budget-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+.wb-budget-field {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 11.5px;
+  color: var(--fg-2);
+}
+.wb-budget-field .ca-input,
+.wb-budget-field .ca-select {
+  width: 110px;
+  flex-shrink: 0;
+}
+
+/* comms toggles */
+.wb-comms {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.wb-comm {
+  padding: 3px 10px;
+  border: 1px solid var(--bd);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--fg-3);
+  font-size: 11px;
+  cursor: pointer;
+  transition: all 0.14s var(--ease);
+}
+.wb-comm.on {
+  border-color: transparent;
+  background: color-mix(in oklch, var(--accent) 18%, transparent);
+  color: var(--fg-1);
+}
+
+/* overview: stats, flow map, hue picker */
+.wb-stats {
+  display: flex;
+  gap: 20px;
+  padding: 12px 2px 14px;
+  border-bottom: 1px solid var(--bd-soft);
+  margin-bottom: 18px;
+}
+.wb-stat .v {
+  font-size: 19px;
+  font-weight: 500;
+  color: var(--fg-0);
+  font-variant-numeric: tabular-nums;
+}
+.wb-stat .k {
+  font-size: 11px;
+  color: var(--fg-3);
+  margin-top: 1px;
+}
+.wb-ov-flow {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.wb-ov-step {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 5px 6px;
+  border-radius: var(--r-sm);
+  text-align: left;
+  color: var(--fg-1);
+  transition: background 0.12s;
+}
+.wb-ov-step:hover {
+  background: var(--hover);
+}
+.wb-ov-step .i {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  color: var(--fg-3);
+  width: 16px;
+  flex-shrink: 0;
+}
+.wb-ov-step .n {
+  font-size: 12px;
+  color: var(--fg-1);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wb-ov-cont-ic {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--bd-soft);
+  background: var(--bg-2);
+  color: var(--fg-2);
+  flex-shrink: 0;
+}
+.wb-hues {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.wb-hue {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  background: oklch(0.72 0.13 var(--h));
+  transition: transform 0.1s;
+}
+.wb-hue:hover {
+  transform: scale(1.12);
+}
+.wb-hue.on {
+  border-color: var(--fg-0);
+}
+
+/* inline validation (inspector) */
+.wb-errs {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 16px;
+  padding: 9px 11px;
+  border: 1px solid color-mix(in srgb, var(--danger) 35%, transparent);
+  border-radius: var(--r-md);
+  background: color-mix(in srgb, var(--danger) 7%, transparent);
+}
+.wb-err {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  color: var(--danger);
+}
+
+/* ── footer + shared bits ───────────────────────────────────────────── */
 .wb-foot {
   display: flex;
   align-items: center;
@@ -535,6 +1107,21 @@
   color: var(--fg-1);
   font-weight: 500;
 }
+.wb-summary-err {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--danger);
+}
+
+.ca-select.sm,
+.ca-input.sm {
+  height: 26px;
+  padding: 0 7px;
+  font-size: 11.5px;
+}
+
+/* agent picker popover */
 .wb-pick {
   min-width: 244px;
   max-height: 320px;
@@ -566,6 +1153,44 @@
 .wb-pick-item .wb-pick-m {
   font-family: var(--font-mono);
   font-size: 10px;
+  color: var(--fg-3);
+}
+
+/* promote-to-workflow launch card (inspector): accent-tinted so the "launch
+   now" path reads as the primary intent of a promoted session. */
+.wb-promote {
+  margin-bottom: 18px;
+  padding: 12px;
+  border: 1px solid color-mix(in oklch, var(--accent) 40%, var(--bd-soft));
+  border-radius: var(--r-md);
+  background: color-mix(in oklch, var(--accent) 6%, var(--bg-1));
+}
+.wb-promote-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--fg-0);
+  margin-bottom: 9px;
+}
+.wb-promote-base {
+  margin-left: auto;
+  font-size: 10.5px;
+  font-weight: 500;
+  color: var(--fg-2);
+}
+.wb-promote-foot {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 9px;
+}
+.wb-promote-foot .grow {
+  flex: 1;
+}
+.wb-promote-note {
+  font-size: 11px;
   color: var(--fg-3);
 }
 
@@ -1170,282 +1795,6 @@
   color: var(--fg-1);
   white-space: pre-wrap;
   word-break: break-word;
-}
-
-/* ───────────────────────── Builder v2: block editor ───────────────────────── */
-
-/* A sequence of blocks laid out left-to-right; the top-level one scrolls, nested
-   loop bodies sit inline. */
-.wb-seq {
-  position: relative;
-  display: flex;
-  align-items: stretch;
-}
-.wb-canvas > .wb-seq {
-  /* A horizontal scroller clips vertically too, so the vertical padding doubles
-     as breathing room that keeps `data-tip-down` tooltips inside the scrollport
-     instead of being cut off at the card edges. */
-  padding: 44px 24px 44px;
-  overflow-x: auto;
-}
-.wb-loop-body .wb-seq {
-  padding: 2px 0;
-}
-
-/* Small control chips shared by the top bar and container headers. */
-.wb-chip-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  height: 26px;
-  padding: 0 9px;
-  border: 1px solid var(--bd);
-  border-radius: var(--r-sm);
-  background: var(--bg-2);
-  color: var(--fg-2);
-  font-size: 11.5px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: border-color 0.14s var(--ease);
-}
-.wb-chip-btn.lg {
-  height: 30px;
-}
-.wb-chip-btn:hover {
-  border-color: var(--bd-strong);
-  color: var(--fg-1);
-}
-
-.ca-select.sm,
-.ca-input.sm {
-  height: 24px;
-  padding: 0 6px;
-  font-size: 11.5px;
-}
-
-/* Container blocks (parallel / loop / orchestrate). */
-.wb-cont {
-  flex: 0 0 auto;
-  align-self: center;
-  display: flex;
-  flex-direction: column;
-  border: 1px solid var(--bd);
-  border-radius: var(--r-md);
-  background: var(--bg-1);
-  box-shadow: var(--shadow-1);
-}
-.wb-cont-h {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--bd-soft);
-}
-.wb-cont-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  font-size: 10.5px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--fg-2);
-}
-.wb-ctl {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  font-size: 11px;
-  color: var(--fg-3);
-}
-.wb-cont-body {
-  padding: 14px;
-}
-.wb-parallel-body {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-.wb-loop {
-  border-left: 3px solid oklch(0.65 0.13 265);
-}
-.wb-loop-body {
-  padding: 8px 14px 14px;
-}
-
-/* Orchestrate internals. */
-.wb-orch-lead {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 12px 14px;
-  border-bottom: 1px solid var(--bd-soft);
-}
-.wb-orch-children {
-  padding: 12px 14px;
-}
-.wb-sub-h,
-.wb-comms-l {
-  font-size: 10.5px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--fg-3);
-  margin-bottom: 8px;
-}
-.wb-orch-opts {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 12px 14px;
-  border-top: 1px solid var(--bd-soft);
-}
-.wb-opt-row {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding-left: 22px;
-}
-.wb-toggle {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  font-size: 12px;
-  color: var(--fg-1);
-  cursor: pointer;
-}
-
-/* Comms caps + artifact path inside a step card. */
-.wb-comms {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 0 12px 10px;
-}
-.wb-comms-l {
-  margin-bottom: 0;
-}
-.wb-comm {
-  padding: 2px 9px;
-  border: 1px solid var(--bd);
-  border-radius: 999px;
-  background: transparent;
-  color: var(--fg-3);
-  font-size: 11px;
-  cursor: pointer;
-  transition: all 0.14s var(--ease);
-}
-.wb-comm.on {
-  border-color: transparent;
-  background: color-mix(in oklch, var(--accent, oklch(0.65 0.13 265)) 18%, transparent);
-  color: var(--fg-1);
-}
-.wb-artifact {
-  margin: 0 12px 8px;
-}
-
-/* Add-block menu (a sequence's "Add block" dropdown). */
-.wb-addwrap {
-  position: relative;
-  align-self: stretch;
-  display: flex;
-}
-.wb-add.sm {
-  flex: 0 0 auto;
-  width: auto;
-  min-height: 0;
-  flex-direction: row;
-  gap: 6px;
-  padding: 8px 12px;
-  font-size: 11.5px;
-}
-.wb-add-menu {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  z-index: 56;
-  width: 260px;
-  margin-top: 6px;
-}
-
-/* Inline validation. */
-.wb-step.has-err {
-  border-color: color-mix(in srgb, var(--danger) 55%, var(--bd));
-}
-.wb-errs {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  padding: 0 12px 10px;
-}
-.wb-err {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 11px;
-  color: var(--danger);
-}
-
-/* Finalize bar + save summary. */
-.wb-finish {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  margin-top: 16px;
-  padding: 12px 14px;
-  border: 1px solid var(--bd-soft);
-  border-radius: var(--r-md);
-  background: var(--bg-1);
-}
-.wb-finish-l {
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--fg-3);
-}
-.wb-summary-err {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  color: var(--danger);
-}
-
-/* Promote-to-workflow launch card: sits above the save footer, accent-tinted so
-   the "launch now" path reads as the primary intent of a promoted session. */
-.wb-promote {
-  margin-top: 16px;
-  padding: 12px 14px;
-  border: 1px solid color-mix(in oklch, var(--accent) 40%, var(--bd-soft));
-  border-radius: var(--r-md);
-  background: color-mix(in oklch, var(--accent) 6%, var(--bg-1));
-}
-.wb-promote-head {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-weight: 600;
-  color: var(--fg-0);
-  margin-bottom: 8px;
-}
-.wb-promote-base {
-  margin-left: auto;
-  font-size: 11px;
-  font-weight: 500;
-  color: var(--fg-2);
-}
-.wb-promote-foot {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  margin-top: 8px;
-}
-.wb-promote-foot .grow {
-  flex: 1;
-}
-.wb-promote-note {
-  font-size: 12px;
-  color: var(--fg-3);
 }
 
 /* ── YAML import/export (spec §14.3) ────────────────────────────────────── */

--- a/tests/components/Composer/mentions.test.ts
+++ b/tests/components/Composer/mentions.test.ts
@@ -43,11 +43,9 @@ describe("filterFiles", () => {
 
 describe("isFsPath", () => {
   it.each(["~", "~/Downloads", "/etc", "./src", "../x"])("treats %s as a filesystem path", (q) =>
-    expect(isFsPath(q)).toBe(true),
-  );
+    expect(isFsPath(q)).toBe(true));
   it.each(["src", "Composer", "index.ts", ""])("treats %s as a worktree search", (q) =>
-    expect(isFsPath(q)).toBe(false),
-  );
+    expect(isFsPath(q)).toBe(false));
 });
 
 describe("splitFsPath", () => {

--- a/tests/components/Composer/mentions.test.ts
+++ b/tests/components/Composer/mentions.test.ts
@@ -43,9 +43,11 @@ describe("filterFiles", () => {
 
 describe("isFsPath", () => {
   it.each(["~", "~/Downloads", "/etc", "./src", "../x"])("treats %s as a filesystem path", (q) =>
-    expect(isFsPath(q)).toBe(true));
+    expect(isFsPath(q)).toBe(true),
+  );
   it.each(["src", "Composer", "index.ts", ""])("treats %s as a worktree search", (q) =>
-    expect(isFsPath(q)).toBe(false));
+    expect(isFsPath(q)).toBe(false),
+  );
 });
 
 describe("splitFsPath", () => {


### PR DESCRIPTION
## Summary

Reworks the Workflows settings editor from the horizontal block canvas to the new design prototyped in Claude Design: a **vertical pipeline** of collapsed cards with a **sticky right-hand inspector** that edits the selected step or container (or shows the workflow overview when nothing is selected).

### What changed

- **Canvas**: dot-grid surface with inline name/description; blocks render as collapsed cards (agent identity, 2-line goal preview, summary chips for gate / artifact / budgets / comms / issues). Clicking a card selects it in the inspector.
- **Inspector** (`builder/inspector/`): step pane (agent, instructions, full done-gate option list, artifact path, approval require-tests, budgets, report/ask), container panes (parallel join/integrate/max, loop max + exit step, orchestrate lead/brief/comms/dynamic-children/sub-workflows), and an overview pane (stats, clickable flow map, accent hue, run budgets, push/PR finalize, promote-launch card).
- **Popovers**: gate and budget popovers removed — edited inline in the inspector; agent picker remains.
- **New**: insert-between-steps via connector "+" buttons (canvas was append-only); the stored workflow hue is now editable.
- Settings wide column bumped to 1240px for the two panes.

### Preserved behavior

All spec fields remain editable (gates ×5, run/step budgets, comms caps, parallel / loop / orchestrate incl. legacy `integrate: merge` surfacing, finalize, promote-to-workflow launch). Validation, save gating, and the `toSpec`/`fromDefinition` round-trip are untouched; list view (import/export/duplicate/delete/starter pack) unchanged.

### Testing

- `tsc --noEmit` clean; `biome check` at pre-change baseline (no new issues)
- 505/505 vitest tests pass (incl. model round-trip pins); `vite build` passes
- Not visually verified in the running app (sandbox can't run the Tauri backend) — worth a quick look at the pane in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)