### PR TITLE
feat(workflows): rework builder into full-width canvas + right drawer

### DIFF
--- a/src/components/SettingsScreen/SettingsScreen.css
+++ b/src/components/SettingsScreen/SettingsScreen.css
@@ -100,6 +100,9 @@
   flex: 1;
   min-width: 0;
   overflow-y: auto;
+  /* Glide the centered content column left/right as the workflow builder's
+     inspector drawer reserves (or releases) room on the right. */
+  transition: padding-right 0.34s var(--ease);
   background:
     radial-gradient(
       120% 60% at 100% 0%,
@@ -112,11 +115,6 @@
   max-width: 860px;
   margin: 0 auto;
   padding: 52px 56px 96px;
-}
-/* Wider column for panes that opt in — e.g. the workflow builder canvas,
-   which lays a pipeline canvas and a sticky inspector side by side. */
-.set-content.is-wide {
-  max-width: 1240px;
 }
 @media (max-width: 1080px) {
   .set-content {

--- a/src/components/SettingsScreen/index.tsx
+++ b/src/components/SettingsScreen/index.tsx
@@ -67,9 +67,6 @@ export function SettingsScreen() {
   const setSection = useAppStore((s) => s.setSettingsSection);
   const close = useAppStore((s) => s.closeSettingsScreen);
 
-  // The workflow builder canvas needs a wider content column than the forms.
-  const wide = section === "workflows";
-
   return (
     <div className="set-screen">
       <nav className="set-nav">
@@ -105,7 +102,7 @@ export function SettingsScreen() {
       </nav>
 
       <div className="set-main">
-        <div className={`set-content ${wide ? "is-wide" : ""}`}>
+        <div className="set-content">
           {section === "account" && <AccountPane />}
           {section === "providers" && <ProvidersPane />}
           {section === "agents" && <CustomAgentsPane />}

--- a/src/workflows/builder/WorkflowBuilder.tsx
+++ b/src/workflows/builder/WorkflowBuilder.tsx
@@ -80,6 +80,14 @@ export function WorkflowBuilder({
 
   const validation = useMemo(() => validateEditor(state), [state]);
 
+  // The inspector renders as a full-height right-hand drawer pinned outside the
+  // settings content column. Flag the shell while the builder is mounted so the
+  // scroll area reserves room for it (see `.set-main` rule in workflows.css).
+  useEffect(() => {
+    document.body.classList.add("wb-drawer-open");
+    return () => document.body.classList.remove("wb-drawer-open");
+  }, []);
+
   // A deleted node can't stay selected — fall back to the overview.
   const selected = sel ? findNode(state, sel) : null;
   useEffect(() => {
@@ -123,14 +131,14 @@ export function WorkflowBuilder({
   return (
     <div className="set-pane">
       <div className="wb">
-        <button className="ca-ed-back" onClick={onCancel}>
-          <Icon name="chevL" /> All workflows
+        <div className="set-eyebrow mono text-xs wb-section-eye">Settings · Workflows</div>
+        <button className="ca-ed-back iflex-center text-sm" onClick={onCancel}>
+          <Icon name="chevL" size={13} /> All workflows
         </button>
 
         <div className="wb-body">
           <div className="wb-canvas" style={{ "--h": state.hue } as React.CSSProperties}>
             <div className="wb-head">
-              <div className="wb-eyebrow">Workflow pipeline</div>
               <input
                 className="wb-name"
                 placeholder="Name this workflow…"

--- a/src/workflows/builder/hooks.ts
+++ b/src/workflows/builder/hooks.ts
@@ -7,18 +7,27 @@ import { useEffect, useRef } from "react";
  *  trigger moves, the fixed element doesn't). While `open`, listen on both and
  *  invoke `close`. Capture-phase catches scrolls inside the horizontal canvas
  *  scroller, which don't bubble. `close` is read through a ref so the listeners
- *  are attached only when `open` flips — not on every render. */
+ *  are attached only when `open` flips — not on every render.
+ *
+ *  Scrolls that originate *inside* the popover (a `.dd` menu with its own
+ *  overflow) must NOT dismiss it — otherwise scrolling a long list snaps the
+ *  menu shut and leaks the wheel to the page. Those are filtered by target. */
 export function useDismissOnViewportChange(open: boolean, close: () => void): void {
   const closeRef = useRef(close);
   closeRef.current = close;
   useEffect(() => {
     if (!open) return;
-    const handler = () => closeRef.current();
-    window.addEventListener("scroll", handler, true);
-    window.addEventListener("resize", handler);
+    const onScroll = (e: Event) => {
+      const t = e.target;
+      if (t instanceof Element && t.closest(".dd")) return;
+      closeRef.current();
+    };
+    const onResize = () => closeRef.current();
+    window.addEventListener("scroll", onScroll, true);
+    window.addEventListener("resize", onResize);
     return () => {
-      window.removeEventListener("scroll", handler, true);
-      window.removeEventListener("resize", handler);
+      window.removeEventListener("scroll", onScroll, true);
+      window.removeEventListener("resize", onResize);
     };
   }, [open]);
 }

--- a/src/workflows/workflows.css
+++ b/src/workflows/workflows.css
@@ -719,6 +719,28 @@
 body.wb-drawer-open .set-main {
   padding-right: var(--wb-drawer-w);
 }
+/* On narrower desktop windows (min supported is 900px), the drawer + settings
+   nav would otherwise crush the canvas. Shrink the drawer (the token drives both
+   its width and the reserved padding) and tighten the content column's side
+   padding while the builder is open, keeping the canvas workable down to 900px. */
+@media (max-width: 1280px) {
+  :root {
+    --wb-drawer-w: 340px;
+  }
+  body.wb-drawer-open .set-content {
+    padding-left: 32px;
+    padding-right: 32px;
+  }
+}
+@media (max-width: 1080px) {
+  :root {
+    --wb-drawer-w: 300px;
+  }
+  body.wb-drawer-open .set-content {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+}
 .wb-insp-h {
   position: sticky;
   top: 0;

--- a/src/workflows/workflows.css
+++ b/src/workflows/workflows.css
@@ -192,9 +192,16 @@
 }
 
 /* ───────────────────── Builder: vertical pipeline editor ─────────────────────
-   Canvas (a vertical flow of collapsed block cards) + a sticky right-hand
-   inspector editing the selected node. Cards carry previews and summary chips
-   only; all field editing happens in the inspector (builder/inspector/). */
+   A full-width canvas (a vertical flow of collapsed block cards) with a
+   full-height inspector drawer pinned to the right edge of the settings shell.
+   Cards carry previews and summary chips only; all field editing happens in the
+   inspector (builder/inspector/). */
+
+/* Width of the right-hand inspector drawer; the settings scroll area reserves
+   this much room on the right while the builder is mounted. */
+:root {
+  --wb-drawer-w: 380px;
+}
 
 .wb {
   display: flex;
@@ -202,17 +209,17 @@
   min-height: 0;
   animation: fade-in 0.2s var(--ease);
 }
+/* Section kicker mirroring the workflows list header, so the builder still reads
+   as living under Settings · Workflows — sits at the top like the other panes. */
+.wb-section-eye {
+  margin-bottom: 10px;
+}
 .wb-body {
-  display: flex;
-  align-items: flex-start;
-  gap: 24px;
   margin-top: 14px;
 }
 
 /* ── canvas ─────────────────────────────────────────────────────────── */
 .wb-canvas {
-  flex: 1;
-  min-width: 0;
   padding: 34px 30px 52px;
   border: 1px solid var(--bd-soft);
   border-radius: var(--r-lg);
@@ -222,16 +229,8 @@
     var(--bg-1);
 }
 .wb-head {
-  max-width: 600px;
+  max-width: 640px;
   margin: 0 auto 30px;
-}
-.wb-eyebrow {
-  font-size: 10.5px;
-  font-weight: 500;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--accent);
-  margin-bottom: 10px;
 }
 .wb-name {
   width: 100%;
@@ -282,7 +281,7 @@
   align-items: stretch;
 }
 .wb-canvas > .wb-seq {
-  max-width: 600px;
+  max-width: 640px;
   margin: 0 auto;
 }
 .wb-conn {
@@ -683,25 +682,42 @@
   border-top: 0;
 }
 
-/* ── inspector ──────────────────────────────────────────────────────── */
+/* ── inspector drawer ───────────────────────────────────────────────────
+   A full-height panel pinned to the right edge of the settings shell. `top`
+   clears the 36px title bar (.tb); the settings scroll area reserves matching
+   room on the right via the `.set-main` rule below, so the drawer never covers
+   the canvas or the save bar. */
 .wb-insp {
-  width: 340px;
-  flex-shrink: 0;
-  position: sticky;
-  top: 16px;
-  max-height: calc(100vh - 110px);
+  position: fixed;
+  top: 36px;
+  right: 0;
+  bottom: 0;
+  z-index: 10;
+  width: var(--wb-drawer-w);
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  border: 1px solid var(--bd-soft);
-  border-radius: var(--r-lg);
+  border-left: 1px solid var(--bd-soft);
   background: var(--bg-1);
-  box-shadow: var(--shadow-1);
+  box-shadow: var(--shadow-2);
+  animation: wb-drawer-in 0.34s var(--ease);
 }
-@media (max-width: 1200px) {
-  .wb-insp {
-    width: 300px;
+/* Slide + fade in from the right edge as the builder opens, timed to match the
+   content column's shift (.set-main padding-right transition). */
+@keyframes wb-drawer-in {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
   }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+/* Reserve room for the drawer so the centered content column shifts clear of
+   it. Toggled on the shell by WorkflowBuilder for as long as it is mounted. */
+body.wb-drawer-open .set-main {
+  padding-right: var(--wb-drawer-w);
 }
 .wb-insp-h {
   position: sticky;
@@ -1126,11 +1142,8 @@
   min-width: 244px;
   max-height: 320px;
   overflow-y: auto;
-}
-.wb-pick .dd-sect {
-  position: sticky;
-  top: 0;
-  background: var(--bg-2);
+  /* Keep wheel scrolling inside the menu — don't chain to the page at the edge. */
+  overscroll-behavior: contain;
 }
 .wb-pick-item {
   display: flex;


### PR DESCRIPTION
Polishes the workspace workflows settings, both the list and the editor.

## Settings width
- The workflows **list** now uses the same 860px content column as every other settings pane (dropped the `is-wide` 1240px opt-in and its unused CSS).

## Workflow editor layout
- **Headers/eyebrows:** `SETTINGS · WORKFLOWS` eyebrow sits at the top (matching the other panes), with the `‹ All workflows` back link directly beneath it — the chevron is now vertically centered. Removed the redundant `WORKFLOW PIPELINE` eyebrow from inside the canvas.
- **One column + drawer:** the canvas takes the full width; the inspector is now a full-height right-hand drawer (`position: fixed`, pinned below the 36px title bar). `WorkflowBuilder` toggles a `wb-drawer-open` class on `<body>` while mounted so the scroll area reserves matching room on the right — the drawer never covers the canvas or the save bar.
- **Transition:** opening the editor glides the content column left (`padding-right` transition on `.set-main`) while the drawer slides in from the right (`wb-drawer-in` keyframe), timed together.
- Bumped the canvas content column to 640px and kept the framed canvas styling.

## Agent picker dropdown fixes
- Scrolling inside the menu no longer dismisses it or leaks the wheel to the page (`useDismissOnViewportChange` ignores scrolls originating within a `.dd` popover; added `overscroll-behavior: contain`).
- Section labels (`Custom agents` / `Base agents`) scroll with the list for consistent behavior (removed the sticky-header override that also caused avatar/label layering and top-gap glitches).

## Testing
- `tsc --noEmit` clean
- `biome check` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)