### PR TITLE
feat(codegraph): silent code indexing for agents via bundled codegraph MCP

### DIFF
--- a/src-tauri/src/codegraph/install.rs
+++ b/src-tauri/src/codegraph/install.rs
@@ -1,0 +1,170 @@
+//! Silent, background install of the pinned codegraph release bundle into
+//! Fletch's tools dir. Mirrors `agent_install.rs`'s process handling but with no
+//! UI: there is no user-facing progress, and every failure is logged and
+//! swallowed by callers (indexing simply stays off until a later retry).
+//!
+//! The vendor `install.sh` honors `CODEGRAPH_VERSION`, `CODEGRAPH_INSTALL_DIR`,
+//! and `CODEGRAPH_BIN_DIR`, which is exactly how we redirect it away from its
+//! defaults (`~/.codegraph`, `~/.local/bin`) and into `~/.fletch/tools/`. We
+//! never invoke the tool's own `install`/`uninstall` subcommands — those rewrite
+//! `~/.claude.json` and other global agent configs.
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
+
+use crate::error::{Error, Result};
+
+/// Pinned codegraph release tag. Verified against the repo's latest release at
+/// implementation time; bump deliberately when adopting a newer bundle.
+pub const CODEGRAPH_VERSION: &str = "v1.4.1";
+
+/// Where the vendor installer script is fetched from.
+const INSTALL_SCRIPT_URL: &str =
+    "https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh";
+
+/// Records the version last installed by us, alongside the bundle, so
+/// `ensure_installed` can skip a reinstall when the pinned version already
+/// matches. Lives in the install dir (not app-data).
+const STAMP_FILE: &str = ".fletch-version";
+
+/// Ceiling on a single installer run — the bundle is tens of MB and finishes
+/// well under a minute, so this only stops a hung download from holding the
+/// install lock forever.
+const INSTALL_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+
+/// Serializes installs process-wide: startup, the toggle, and concurrent spawns
+/// can all call `ensure_installed`, and two installers racing over the same dir
+/// would corrupt the bundle.
+fn install_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Ensure the pinned codegraph bundle is installed under `~/.fletch/tools/` and
+/// return the absolute path to its binary. Returns immediately when the binary
+/// already exists and the version stamp matches the pin; otherwise downloads and
+/// runs the vendor `install.sh` (redirected via env vars), then writes the
+/// stamp. Serialized so concurrent callers don't race the same install dir.
+pub async fn ensure_installed() -> Result<PathBuf> {
+    let bin = super::bin_path()?;
+    if bin.exists() && stamp_matches(&super::install_dir()?).await {
+        return Ok(bin);
+    }
+
+    let _guard = install_lock().lock().await;
+    // Re-check under the lock: a racing caller may have finished the install
+    // while we waited.
+    if bin.exists() && stamp_matches(&super::install_dir()?).await {
+        return Ok(bin);
+    }
+
+    let install_dir = super::install_dir()?;
+    let bin_dir = super::bin_dir()?;
+    tokio::fs::create_dir_all(&install_dir)
+        .await
+        .map_err(|e| Error::Other(format!("create codegraph install dir: {e}")))?;
+
+    let script = install_dir.join("install.sh");
+    download_script(INSTALL_SCRIPT_URL, &script).await?;
+
+    tracing::info!(version = CODEGRAPH_VERSION, "installing codegraph bundle");
+    run_installer(&script, &install_dir, &bin_dir).await?;
+
+    if !bin.exists() {
+        return Err(Error::Other(format!(
+            "codegraph installer finished but no binary at {}",
+            bin.display()
+        )));
+    }
+    write_stamp(&install_dir).await;
+    tracing::info!(path = %bin.display(), "codegraph installed");
+    Ok(bin)
+}
+
+/// True when the install dir's version stamp equals the pinned version.
+async fn stamp_matches(install_dir: &std::path::Path) -> bool {
+    match tokio::fs::read_to_string(install_dir.join(STAMP_FILE)).await {
+        Ok(s) => s.trim() == CODEGRAPH_VERSION,
+        Err(_) => false,
+    }
+}
+
+/// Record the pinned version so later runs skip the reinstall. Best-effort — a
+/// missing stamp only costs a redundant reinstall next launch.
+async fn write_stamp(install_dir: &std::path::Path) {
+    if let Err(e) =
+        tokio::fs::write(install_dir.join(STAMP_FILE), CODEGRAPH_VERSION.as_bytes()).await
+    {
+        tracing::warn!(error = %e, "failed to write codegraph version stamp; continuing");
+    }
+}
+
+/// Download the installer script to `dest` (reqwest — already a dep).
+async fn download_script(url: &str, dest: &std::path::Path) -> Result<()> {
+    let body = reqwest::get(url)
+        .await
+        .map_err(|e| Error::Other(format!("download codegraph install.sh: {e}")))?
+        .error_for_status()
+        .map_err(|e| Error::Other(format!("download codegraph install.sh: {e}")))?
+        .bytes()
+        .await
+        .map_err(|e| Error::Other(format!("read codegraph install.sh: {e}")))?;
+    let mut file = tokio::fs::File::create(dest)
+        .await
+        .map_err(|e| Error::Other(format!("create {}: {e}", dest.display())))?;
+    file.write_all(&body)
+        .await
+        .map_err(|e| Error::Other(format!("write {}: {e}", dest.display())))?;
+    file.flush()
+        .await
+        .map_err(|e| Error::Other(format!("flush {}: {e}", dest.display())))?;
+    Ok(())
+}
+
+/// Run `sh <script>` with the redirect env vars set, streaming nothing but
+/// capturing the last output line for the error message. Follows
+/// `agent_install.rs`'s process handling (login-shell env, kill_on_drop, a
+/// bounded timeout).
+async fn run_installer(
+    script: &std::path::Path,
+    install_dir: &std::path::Path,
+    bin_dir: &std::path::Path,
+) -> Result<()> {
+    let mut command = tokio::process::Command::new("sh");
+    command.arg(script);
+    // GUI processes inherit launchd's sparse env; the installer expects a normal
+    // user environment (PATH, HOME, proxy vars) to fetch the bundle.
+    if let Some(env) = crate::bin_resolve::login_shell_env() {
+        command.envs(env);
+    }
+    command
+        .env("CODEGRAPH_VERSION", CODEGRAPH_VERSION)
+        .env("CODEGRAPH_INSTALL_DIR", install_dir)
+        .env("CODEGRAPH_BIN_DIR", bin_dir)
+        // Never let the installer chatter to a daemon or phone home.
+        .env("CODEGRAPH_TELEMETRY", "0")
+        .env("CODEGRAPH_NO_DAEMON", "1")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true);
+
+    let output = tokio::time::timeout(INSTALL_TIMEOUT, command.output())
+        .await
+        .map_err(|_| Error::Other("codegraph installer timed out".into()))?
+        .map_err(|e| Error::Other(format!("spawn codegraph installer: {e}")))?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let last = stderr.lines().rev().find(|l| !l.trim().is_empty());
+    Err(Error::Other(match last {
+        Some(msg) => format!("codegraph installer exited with {}: {msg}", output.status),
+        None => format!("codegraph installer exited with {}", output.status),
+    }))
+}

--- a/src-tauri/src/codegraph/install.rs
+++ b/src-tauri/src/codegraph/install.rs
@@ -1,40 +1,66 @@
 //! Silent, background install of the pinned codegraph release bundle into
-//! Fletch's tools dir. Mirrors `agent_install.rs`'s process handling but with no
-//! UI: there is no user-facing progress, and every failure is logged and
-//! swallowed by callers (indexing simply stays off until a later retry).
+//! Fletch's tools dir. Follows `git_dist.rs`'s supply-chain posture: the
+//! release tarball is fetched from a **pinned version tag** and verified
+//! against a **pinned SHA-256** before anything is unpacked — no vendor
+//! install script is ever downloaded or executed, so a compromised or edited
+//! upstream `main` can't run code here. Bumping the pin means updating both
+//! the tag and the digests below, deliberately.
 //!
-//! The vendor `install.sh` honors `CODEGRAPH_VERSION`, `CODEGRAPH_INSTALL_DIR`,
-//! and `CODEGRAPH_BIN_DIR`, which is exactly how we redirect it away from its
-//! defaults (`~/.codegraph`, `~/.local/bin`) and into `~/.fletch/tools/`. We
-//! never invoke the tool's own `install`/`uninstall` subcommands — those rewrite
-//! `~/.claude.json` and other global agent configs.
+//! There is no UI: every failure is logged and swallowed by callers (indexing
+//! simply stays off until a later retry). We never invoke the tool's own
+//! `install`/`uninstall` subcommands — those rewrite `~/.claude.json` and
+//! other global agent configs.
+//!
+//! Layout mirrors the vendor installer so the rest of the module is agnostic
+//! to how the bundle got there:
+//!
+//! ```text
+//! ~/.fletch/tools/codegraph/
+//!   versions/<tag>/        the verified, extracted bundle (bin/, lib/)
+//!   bin/codegraph          symlink -> versions/<tag>/bin/codegraph
+//! ```
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::time::Duration;
 
-use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
 
 use crate::error::{Error, Result};
 
-/// Pinned codegraph release tag. Verified against the repo's latest release at
-/// implementation time; bump deliberately when adopting a newer bundle.
+/// Pinned codegraph release tag. Bump deliberately when adopting a newer
+/// bundle — and re-pin the per-target digests in [`dist_asset`] with it.
 pub const CODEGRAPH_VERSION: &str = "v1.4.1";
 
-/// Where the vendor installer script is fetched from.
-const INSTALL_SCRIPT_URL: &str =
-    "https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh";
-
-/// Records the version last installed by us, alongside the bundle, so
-/// `ensure_installed` can skip a reinstall when the pinned version already
-/// matches. Lives in the install dir (not app-data).
-const STAMP_FILE: &str = ".fletch-version";
-
-/// Ceiling on a single installer run — the bundle is tens of MB and finishes
+/// Ceiling on a single install run — the bundle is tens of MB and finishes
 /// well under a minute, so this only stops a hung download from holding the
 /// install lock forever.
 const INSTALL_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+
+/// Release asset URL and its pinned SHA-256 for the current platform, `None`
+/// on platforms we don't ship codegraph for. Digests are of the `.tar.gz`
+/// exactly as published on the GitHub release for [`CODEGRAPH_VERSION`].
+fn dist_asset() -> Option<(String, &'static str)> {
+    let (target, sha): (&str, &str) = if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+        (
+            "darwin-arm64",
+            "4a679ae5a5cb9fff900dd59bb786da6a581b7f68f4cf713bdedd137e347d34dc",
+        )
+    } else if cfg!(all(target_os = "macos", target_arch = "x86_64")) {
+        (
+            "darwin-x64",
+            "436f96943cfd926ea6d0a8454f18833d21254d5fd9b3d224317b1426132def95",
+        )
+    } else {
+        return None;
+    };
+    Some((
+        format!(
+            "https://github.com/colbymchenry/codegraph/releases/download/{CODEGRAPH_VERSION}/codegraph-{target}.tar.gz"
+        ),
+        sha,
+    ))
+}
 
 /// Serializes installs process-wide: startup, the toggle, and concurrent spawns
 /// can all call `ensure_installed`, and two installers racing over the same dir
@@ -44,127 +70,289 @@ fn install_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
-/// Ensure the pinned codegraph bundle is installed under `~/.fletch/tools/` and
-/// return the absolute path to its binary. Returns immediately when the binary
-/// already exists and the version stamp matches the pin; otherwise downloads and
-/// runs the vendor `install.sh` (redirected via env vars), then writes the
-/// stamp. Serialized so concurrent callers don't race the same install dir.
+/// The pinned version's bundle dir: `<install_dir>/versions/<tag>`.
+fn version_dir(install_dir: &Path) -> PathBuf {
+    install_dir.join("versions").join(CODEGRAPH_VERSION)
+}
+
+/// True when the pinned bundle is fully installed: the versioned bundle has
+/// its launcher and the `bin/codegraph` symlink resolves to an existing file
+/// (`exists()` follows symlinks).
+fn install_complete(install_dir: &Path, bin: &Path) -> bool {
+    version_dir(install_dir)
+        .join("bin")
+        .join("codegraph")
+        .is_file()
+        && bin.exists()
+}
+
+/// Ensure the pinned codegraph bundle is installed under `~/.fletch/tools/`
+/// and return the absolute path to its binary. Returns immediately when the
+/// pinned version is already in place; otherwise downloads the release
+/// tarball, verifies its SHA-256 against the pin, extracts it, and points the
+/// `bin/codegraph` symlink at it. Serialized so concurrent callers don't race
+/// the same install dir.
 pub async fn ensure_installed() -> Result<PathBuf> {
     let bin = super::bin_path()?;
-    if bin.exists() && stamp_matches(&super::install_dir()?).await {
+    let install_dir = super::install_dir()?;
+    if install_complete(&install_dir, &bin) {
         return Ok(bin);
     }
 
     let _guard = install_lock().lock().await;
     // Re-check under the lock: a racing caller may have finished the install
     // while we waited.
-    if bin.exists() && stamp_matches(&super::install_dir()?).await {
+    if install_complete(&install_dir, &bin) {
         return Ok(bin);
     }
 
-    let install_dir = super::install_dir()?;
-    let bin_dir = super::bin_dir()?;
+    let (url, sha) = dist_asset()
+        .ok_or_else(|| Error::Other("codegraph: no pinned bundle for this platform".into()))?;
     tokio::fs::create_dir_all(&install_dir)
         .await
         .map_err(|e| Error::Other(format!("create codegraph install dir: {e}")))?;
 
-    let script = install_dir.join("install.sh");
-    download_script(INSTALL_SCRIPT_URL, &script).await?;
-
     tracing::info!(version = CODEGRAPH_VERSION, "installing codegraph bundle");
-    run_installer(&script, &install_dir, &bin_dir).await?;
+    let dest = version_dir(&install_dir);
+    tokio::time::timeout(INSTALL_TIMEOUT, async {
+        let tarball = download_verified(&url, sha, &install_dir).await?;
+        // Blocking CPU/fs work off the async runtime.
+        let dest = dest.clone();
+        tokio::task::spawn_blocking(move || extract_bundle(&tarball, &dest))
+            .await
+            .map_err(|e| Error::Other(format!("codegraph extract task: {e}")))?
+    })
+    .await
+    .map_err(|_| Error::Other("codegraph install timed out".into()))??;
 
-    if !bin.exists() {
+    link_launcher(&dest, &bin).await?;
+    if !install_complete(&install_dir, &bin) {
         return Err(Error::Other(format!(
-            "codegraph installer finished but no binary at {}",
+            "codegraph install finished but no binary at {}",
             bin.display()
         )));
     }
-    write_stamp(&install_dir).await;
+    prune_old_versions(&install_dir, &dest).await;
     tracing::info!(path = %bin.display(), "codegraph installed");
     Ok(bin)
 }
 
-/// True when the install dir's version stamp equals the pinned version.
-async fn stamp_matches(install_dir: &std::path::Path) -> bool {
-    match tokio::fs::read_to_string(install_dir.join(STAMP_FILE)).await {
-        Ok(s) => s.trim() == CODEGRAPH_VERSION,
-        Err(_) => false,
-    }
-}
+/// Stream the release tarball to a temp file inside `install_dir`, hashing as
+/// it downloads; error (and remove the temp file) unless the digest matches
+/// the pinned SHA-256. Returns the temp path.
+async fn download_verified(url: &str, expected_sha: &str, install_dir: &Path) -> Result<PathBuf> {
+    use sha2::Digest;
+    use tokio::io::AsyncWriteExt;
 
-/// Record the pinned version so later runs skip the reinstall. Best-effort — a
-/// missing stamp only costs a redundant reinstall next launch.
-async fn write_stamp(install_dir: &std::path::Path) {
-    if let Err(e) =
-        tokio::fs::write(install_dir.join(STAMP_FILE), CODEGRAPH_VERSION.as_bytes()).await
-    {
-        tracing::warn!(error = %e, "failed to write codegraph version stamp; continuing");
-    }
-}
-
-/// Download the installer script to `dest` (reqwest — already a dep).
-async fn download_script(url: &str, dest: &std::path::Path) -> Result<()> {
-    let body = reqwest::get(url)
+    let mut resp = reqwest::get(url)
         .await
-        .map_err(|e| Error::Other(format!("download codegraph install.sh: {e}")))?
+        .map_err(|e| Error::Other(format!("download codegraph bundle: {e}")))?
         .error_for_status()
-        .map_err(|e| Error::Other(format!("download codegraph install.sh: {e}")))?
-        .bytes()
+        .map_err(|e| Error::Other(format!("download codegraph bundle: {e}")))?;
+
+    let tmp_path = install_dir.join(format!("download-{}.tmp", std::process::id()));
+    let mut file = tokio::fs::File::create(&tmp_path)
         .await
-        .map_err(|e| Error::Other(format!("read codegraph install.sh: {e}")))?;
-    let mut file = tokio::fs::File::create(dest)
-        .await
-        .map_err(|e| Error::Other(format!("create {}: {e}", dest.display())))?;
-    file.write_all(&body)
-        .await
-        .map_err(|e| Error::Other(format!("write {}: {e}", dest.display())))?;
-    file.flush()
-        .await
-        .map_err(|e| Error::Other(format!("flush {}: {e}", dest.display())))?;
-    Ok(())
+        .map_err(|e| Error::Other(format!("create {}: {e}", tmp_path.display())))?;
+
+    let mut hasher = sha2::Sha256::new();
+    let result: Result<()> = async {
+        while let Some(chunk) = resp
+            .chunk()
+            .await
+            .map_err(|e| Error::Other(format!("download codegraph bundle: {e}")))?
+        {
+            hasher.update(&chunk);
+            file.write_all(&chunk)
+                .await
+                .map_err(|e| Error::Other(format!("write {}: {e}", tmp_path.display())))?;
+        }
+        file.flush()
+            .await
+            .map_err(|e| Error::Other(format!("flush {}: {e}", tmp_path.display())))?;
+        Ok(())
+    }
+    .await;
+    drop(file);
+    if let Err(e) = result {
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+        return Err(e);
+    }
+
+    let digest = format!("{:x}", hasher.finalize());
+    if !digest.eq_ignore_ascii_case(expected_sha) {
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+        return Err(Error::Other(format!(
+            "codegraph bundle checksum mismatch (got {digest}, expected {expected_sha})"
+        )));
+    }
+    Ok(tmp_path)
 }
 
-/// Run `sh <script>` with the redirect env vars set, streaming nothing but
-/// capturing the last output line for the error message. Follows
-/// `agent_install.rs`'s process handling (login-shell env, kill_on_drop, a
-/// bounded timeout).
-async fn run_installer(
-    script: &std::path::Path,
-    install_dir: &std::path::Path,
-    bin_dir: &std::path::Path,
-) -> Result<()> {
-    let mut command = tokio::process::Command::new("sh");
-    command.arg(script);
-    // GUI processes inherit launchd's sparse env; the installer expects a normal
-    // user environment (PATH, HOME, proxy vars) to fetch the bundle.
-    if let Some(env) = crate::bin_resolve::login_shell_env() {
-        command.envs(env);
-    }
-    command
-        .env("CODEGRAPH_VERSION", CODEGRAPH_VERSION)
-        .env("CODEGRAPH_INSTALL_DIR", install_dir)
-        .env("CODEGRAPH_BIN_DIR", bin_dir)
-        // Never let the installer chatter to a daemon or phone home.
-        .env("CODEGRAPH_TELEMETRY", "0")
-        .env("CODEGRAPH_NO_DAEMON", "1")
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .kill_on_drop(true);
+/// Unpack `tarball` and move the bundle into `dest`. Extraction goes to a
+/// sibling staging dir first so `dest` only ever appears complete; the tarball
+/// and staging dir are always removed. Release archives wrap their content in
+/// a single `codegraph-<target>/` dir, but a flat layout is tolerated too.
+fn extract_bundle(tarball: &Path, dest: &Path) -> Result<()> {
+    // Appended, not `with_extension` — the version dir name contains dots
+    // (`v1.4.1`), which with_extension would truncate at.
+    let mut staging = dest.as_os_str().to_owned();
+    staging.push(".partial");
+    let staging = PathBuf::from(staging);
+    let result = (|| {
+        if staging.exists() {
+            std::fs::remove_dir_all(&staging)
+                .map_err(|e| Error::Other(format!("clear staging: {e}")))?;
+        }
+        std::fs::create_dir_all(&staging)
+            .map_err(|e| Error::Other(format!("create staging: {e}")))?;
 
-    let output = tokio::time::timeout(INSTALL_TIMEOUT, command.output())
+        let file =
+            std::fs::File::open(tarball).map_err(|e| Error::Other(format!("open tarball: {e}")))?;
+        let gz = flate2::read::GzDecoder::new(std::io::BufReader::new(file));
+        tar::Archive::new(gz)
+            .unpack(&staging)
+            .map_err(|e| Error::Other(format!("unpack codegraph bundle: {e}")))?;
+
+        let bundle_root = locate_bundle_root(&staging).ok_or_else(|| {
+            Error::Other("codegraph archive does not contain bin/codegraph".into())
+        })?;
+
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| Error::Other(format!("create versions dir: {e}")))?;
+        }
+        if dest.exists() {
+            std::fs::remove_dir_all(dest).map_err(|e| Error::Other(format!("clear dest: {e}")))?;
+        }
+        std::fs::rename(&bundle_root, dest)
+            .map_err(|e| Error::Other(format!("install codegraph bundle: {e}")))?;
+        Ok(())
+    })();
+
+    let _ = std::fs::remove_dir_all(&staging);
+    let _ = std::fs::remove_file(tarball);
+    result
+}
+
+/// The dir holding `bin/codegraph` — the unpack root itself, or its single
+/// subdirectory (the archive's `codegraph-<target>/` wrapper).
+fn locate_bundle_root(unpacked: &Path) -> Option<PathBuf> {
+    if unpacked.join("bin").join("codegraph").is_file() {
+        return Some(unpacked.to_path_buf());
+    }
+    let dirs: Vec<_> = std::fs::read_dir(unpacked)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect();
+    match dirs.as_slice() {
+        [only] if only.join("bin").join("codegraph").is_file() => Some(only.clone()),
+        _ => None,
+    }
+}
+
+/// Point `<install_dir>/bin/codegraph` at the freshly installed bundle's
+/// launcher, replacing whatever the symlink pointed at before.
+async fn link_launcher(bundle_dir: &Path, bin: &Path) -> Result<()> {
+    let target = bundle_dir.join("bin").join("codegraph");
+    if let Some(parent) = bin.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| Error::Other(format!("create codegraph bin dir: {e}")))?;
+    }
+    // Remove-then-link: `symlink` refuses to overwrite. `remove_file` also
+    // clears a dangling symlink (`exists()` would report false for those).
+    match tokio::fs::remove_file(bin).await {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(Error::Other(format!("replace codegraph launcher: {e}"))),
+    }
+    tokio::fs::symlink(&target, bin)
         .await
-        .map_err(|_| Error::Other("codegraph installer timed out".into()))?
-        .map_err(|e| Error::Other(format!("spawn codegraph installer: {e}")))?;
+        .map_err(|e| Error::Other(format!("link codegraph launcher: {e}")))
+}
 
-    if output.status.success() {
-        return Ok(());
+/// Drop bundles other than the one just installed so upgrades don't accumulate
+/// ~50 MB dirs forever. Best-effort; safe even if an old daemon still runs an
+/// older bundle (POSIX keeps the inodes alive until that process exits).
+async fn prune_old_versions(install_dir: &Path, keep: &Path) {
+    let versions = install_dir.join("versions");
+    let Ok(mut entries) = tokio::fs::read_dir(&versions).await else {
+        return;
+    };
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let path = entry.path();
+        if path != keep && path.is_dir() {
+            if let Err(e) = tokio::fs::remove_dir_all(&path).await {
+                tracing::debug!(path = %path.display(), error = %e, "prune old codegraph bundle");
+            }
+        }
     }
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    let last = stderr.lines().rev().find(|l| !l.trim().is_empty());
-    Err(Error::Other(match last {
-        Some(msg) => format!("codegraph installer exited with {}: {msg}", output.status),
-        None => format!("codegraph installer exited with {}", output.status),
-    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build `<root>/<wrapper?>/bin/codegraph` for layout tests.
+    fn make_bundle(root: &Path, wrapper: Option<&str>) {
+        let base = match wrapper {
+            Some(w) => root.join(w),
+            None => root.to_path_buf(),
+        };
+        std::fs::create_dir_all(base.join("bin")).unwrap();
+        std::fs::write(base.join("bin").join("codegraph"), b"#!/bin/sh\n").unwrap();
+    }
+
+    #[test]
+    fn locate_bundle_root_accepts_flat_layout() {
+        let td = tempfile::tempdir().unwrap();
+        make_bundle(td.path(), None);
+        assert_eq!(locate_bundle_root(td.path()), Some(td.path().to_path_buf()));
+    }
+
+    #[test]
+    fn locate_bundle_root_accepts_single_wrapper_dir() {
+        let td = tempfile::tempdir().unwrap();
+        make_bundle(td.path(), Some("codegraph-darwin-arm64"));
+        assert_eq!(
+            locate_bundle_root(td.path()),
+            Some(td.path().join("codegraph-darwin-arm64"))
+        );
+    }
+
+    #[test]
+    fn locate_bundle_root_rejects_missing_launcher() {
+        let td = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(td.path().join("lib")).unwrap();
+        assert_eq!(locate_bundle_root(td.path()), None);
+    }
+
+    #[test]
+    fn dist_asset_is_pinned_on_macos() {
+        // On the platforms we build for, the asset must carry the pinned tag
+        // in its URL and a full-length digest.
+        if let Some((url, sha)) = dist_asset() {
+            assert!(url.contains(CODEGRAPH_VERSION));
+            assert_eq!(sha.len(), 64);
+        }
+    }
+
+    #[tokio::test]
+    async fn link_launcher_replaces_existing_symlink() {
+        let td = tempfile::tempdir().unwrap();
+        let old = td.path().join("old");
+        let new = td.path().join("new");
+        make_bundle(&old, None);
+        make_bundle(&new, None);
+        let bin = td.path().join("bin").join("codegraph");
+        link_launcher(&old, &bin).await.unwrap();
+        link_launcher(&new, &bin).await.unwrap();
+        assert_eq!(
+            tokio::fs::read_link(&bin).await.unwrap(),
+            new.join("bin").join("codegraph")
+        );
+    }
 }

--- a/src-tauri/src/codegraph/mirror.rs
+++ b/src-tauri/src/codegraph/mirror.rs
@@ -230,7 +230,9 @@ pub async fn append_git_exclude(checkout: &Path) -> Result<()> {
         .await
         .map_err(|e| Error::Other(format!("create .git/info: {e}")))?;
     let exclude = info_dir.join("exclude");
-    let existing = tokio::fs::read_to_string(&exclude).await.unwrap_or_default();
+    let existing = tokio::fs::read_to_string(&exclude)
+        .await
+        .unwrap_or_default();
     if existing.lines().any(|l| l.trim() == INDEX_DIR) {
         return Ok(());
     }
@@ -298,8 +300,7 @@ mod tests {
         append_git_exclude(checkout).await.unwrap();
         append_git_exclude(checkout).await.unwrap();
         append_git_exclude(checkout).await.unwrap();
-        let body =
-            std::fs::read_to_string(checkout.join(".git/info/exclude")).unwrap();
+        let body = std::fs::read_to_string(checkout.join(".git/info/exclude")).unwrap();
         let count = body.lines().filter(|l| l.trim() == ".codegraph").count();
         assert_eq!(count, 1, "the exclude line must appear exactly once");
     }
@@ -340,7 +341,10 @@ mod tests {
         assert_eq!(std::fs::read(dst.join("codegraph.db")).unwrap(), b"DB");
         assert_eq!(std::fs::read(dst.join("codegraph.db-wal")).unwrap(), b"WAL");
         assert_eq!(std::fs::read(dst.join("codegraph.db-shm")).unwrap(), b"SHM");
-        assert!(!dst.join("daemon.pid").exists(), "daemon.pid must be skipped");
+        assert!(
+            !dst.join("daemon.pid").exists(),
+            "daemon.pid must be skipped"
+        );
         assert!(
             !dst.join("daemon.sock").exists(),
             "daemon.sock must be skipped"

--- a/src-tauri/src/codegraph/mirror.rs
+++ b/src-tauri/src/codegraph/mirror.rs
@@ -1,0 +1,368 @@
+//! Per-repo codegraph index *mirrors* and how a built index reaches an agent's
+//! checkout — the mechanism that keeps the index out of the user's source repo.
+//!
+//! A mirror is a throwaway `git clone --shared` of the source repo living under
+//! `~/.fletch/projects/<project_id>/codegraph/<repo>/`. We index the mirror
+//! (`codegraph init`/`sync`) and copy the resulting `.codegraph/codegraph.db`
+//! into each fresh agent checkout. The db is content-hash based and stores
+//! project-root-relative paths, so it is valid in any other checkout of the same
+//! repo; the MCP server in the workspace catch-up-syncs and watches from there.
+//!
+//! Every operation is best-effort: callers log and continue, and a mirror is
+//! serialized against itself with a per-path async mutex so two concurrent
+//! spawns of the same repo don't race the clone / fetch / reset / sync.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex as StdMutex, OnceLock};
+
+use sha2::{Digest, Sha256};
+use tokio::sync::Mutex;
+
+use crate::error::{Error, Result};
+use crate::workspace::projects_root;
+
+/// The index directory name codegraph writes inside a project root, and the
+/// line we add to a checkout's `.git/info/exclude` so it never shows in diffs.
+const INDEX_DIR: &str = ".codegraph";
+/// The index db and its WAL sidecars — the only files worth copying between
+/// checkouts. `daemon.pid`/`daemon.sock` are per-checkout runtime state and are
+/// deliberately never copied.
+const INDEX_DB_FILES: [&str; 3] = ["codegraph.db", "codegraph.db-wal", "codegraph.db-shm"];
+
+/// Stable per-repo identifier: the hex SHA-256 of the canonicalized source path,
+/// truncated. Canonicalization means two spellings of the same repo share a
+/// mirror; a path that can't be canonicalized (e.g. already gone) falls back to
+/// the raw path, which is still stable for a given string.
+fn repo_identifier(source_repo: &Path) -> String {
+    let canonical = source_repo
+        .canonicalize()
+        .unwrap_or_else(|_| source_repo.to_path_buf());
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.to_string_lossy().as_bytes());
+    let digest = hasher.finalize();
+    hex16(&digest)
+}
+
+/// First 16 bytes of a digest as lowercase hex (32 chars) — plenty to avoid
+/// collisions across a user's repo set without an unwieldy dir name.
+fn hex16(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(32);
+    for b in bytes.iter().take(16) {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// Absolute path to a repo's index mirror:
+/// `~/.fletch/projects/<project_id>/codegraph/<repo-id>/`.
+pub fn mirror_dir(project_id: &str, source_repo: &Path) -> Result<PathBuf> {
+    Ok(projects_root()?
+        .join(project_id)
+        .join("codegraph")
+        .join(repo_identifier(source_repo)))
+}
+
+/// Per-mirror lock registry: serializes clone/fetch/reset/sync on one mirror dir
+/// so concurrent spawns of the same repo don't race. Keyed by the mirror path.
+fn mirror_lock(dir: &Path) -> Arc<Mutex<()>> {
+    static LOCKS: OnceLock<StdMutex<HashMap<PathBuf, Arc<Mutex<()>>>>> = OnceLock::new();
+    let map = LOCKS.get_or_init(|| StdMutex::new(HashMap::new()));
+    let mut guard = map.lock().unwrap();
+    guard
+        .entry(dir.to_path_buf())
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone()
+}
+
+/// Ensure the mirror exists and holds an initial index. If the mirror dir is
+/// missing, `git clone --shared` the source into it and run `codegraph init`.
+/// A no-op (bar the lock) when the mirror is already present.
+pub async fn ensure_mirror(
+    source_repo: &Path,
+    mirror_dir: &Path,
+    codegraph_bin: &Path,
+) -> Result<()> {
+    let lock = mirror_lock(mirror_dir);
+    let _guard = lock.lock().await;
+
+    if mirror_dir.join(".git").exists() {
+        return Ok(());
+    }
+    if let Some(parent) = mirror_dir.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| Error::Other(format!("create codegraph mirror parent: {e}")))?;
+    }
+    // A leftover partial dir (crashed clone) would fail the clone; clear it.
+    if mirror_dir.exists() {
+        let _ = tokio::fs::remove_dir_all(mirror_dir).await;
+    }
+
+    let source = path_str(source_repo)?;
+    let dest = path_str(mirror_dir)?;
+    let out = crate::git_dist::command(source_repo)
+        .args(["clone", "--shared", &source, &dest])
+        .kill_on_drop(true)
+        .output()
+        .await
+        .map_err(|e| Error::Other(format!("spawn git clone for mirror: {e}")))?;
+    if !out.status.success() {
+        let _ = tokio::fs::remove_dir_all(mirror_dir).await;
+        return Err(Error::Git(format!(
+            "clone --shared for codegraph mirror failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+
+    run_codegraph(codegraph_bin, mirror_dir, "init").await
+}
+
+/// Advance an existing mirror to `sha` and re-index incrementally: fetch the
+/// commit from the source, hard-reset the mirror to it, then `codegraph sync`.
+/// Codegraph's content-hash change detection only re-parses files that differ,
+/// so this is cheap on a small delta.
+pub async fn advance_mirror(
+    mirror_dir: &Path,
+    source_repo: &Path,
+    sha: &str,
+    codegraph_bin: &Path,
+) -> Result<()> {
+    let lock = mirror_lock(mirror_dir);
+    let _guard = lock.lock().await;
+
+    let source = path_str(source_repo)?;
+    // Best-effort fetch: the mirror is a `--shared` clone borrowing the source's
+    // live object store via alternates, so a fork-point commit reachable in the
+    // source is already visible here and `reset --hard` alone advances the tree.
+    // A raw-SHA fetch over local transport is also refused by default
+    // (`uploadpack.allowAnySHA1InWant` off), so treat a fetch failure as a no-op
+    // and let the reset be authoritative — it fails loudly if the object really
+    // is missing.
+    match crate::git_dist::command(mirror_dir)
+        .args(["fetch", &source, sha])
+        .kill_on_drop(true)
+        .output()
+        .await
+    {
+        Ok(out) if out.status.success() => {}
+        Ok(out) => tracing::debug!(
+            sha,
+            stderr = %String::from_utf8_lossy(&out.stderr).trim(),
+            "codegraph mirror fetch by sha not served; relying on borrowed objects"
+        ),
+        Err(e) => tracing::debug!(error = %e, "codegraph mirror fetch spawn failed; continuing"),
+    }
+    let reset = crate::git_dist::command(mirror_dir)
+        .args(["reset", "--hard", sha])
+        .kill_on_drop(true)
+        .output()
+        .await
+        .map_err(|e| Error::Other(format!("spawn git reset for mirror: {e}")))?;
+    if !reset.status.success() {
+        return Err(Error::Git(format!(
+            "reset --hard {sha} in codegraph mirror failed: {}",
+            String::from_utf8_lossy(&reset.stderr).trim()
+        )));
+    }
+
+    run_codegraph(codegraph_bin, mirror_dir, "sync").await
+}
+
+/// Run a codegraph subcommand (`init` / `sync`) against a mirror. cwd is the
+/// mirror and the target path is passed explicitly; `CODEGRAPH_NO_DAEMON=1` +
+/// `CODEGRAPH_TELEMETRY=0` keep host-side runs from leaving a daemon or phoning
+/// home. Never runs `install`/`uninstall`.
+async fn run_codegraph(bin: &Path, mirror_dir: &Path, subcommand: &str) -> Result<()> {
+    let dest = path_str(mirror_dir)?;
+    let out = tokio::process::Command::new(bin)
+        .arg(subcommand)
+        .arg(&dest)
+        .current_dir(mirror_dir)
+        .env("CODEGRAPH_NO_DAEMON", "1")
+        .env("CODEGRAPH_TELEMETRY", "0")
+        .kill_on_drop(true)
+        .output()
+        .await
+        .map_err(|e| Error::Other(format!("spawn codegraph {subcommand}: {e}")))?;
+    if !out.status.success() {
+        return Err(Error::Other(format!(
+            "codegraph {subcommand} failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
+/// Copy the mirror's built index db (and WAL sidecars, if present) into
+/// `<checkout>/.codegraph/`, then register the exclude entry. Per-checkout
+/// runtime files (`daemon.pid`/`daemon.sock`) and anything else are skipped: a
+/// copied daemon socket/pid would point another checkout's runtime at stale
+/// state. A no-op when the mirror has no `codegraph.db` yet (a late index copies
+/// on a subsequent spawn).
+pub async fn copy_index_into(mirror_dir: &Path, checkout: &Path) -> Result<()> {
+    let src_index = mirror_dir.join(INDEX_DIR);
+    let db = src_index.join(INDEX_DB_FILES[0]);
+    if !db.exists() {
+        return Ok(());
+    }
+    let dst_index = checkout.join(INDEX_DIR);
+    tokio::fs::create_dir_all(&dst_index)
+        .await
+        .map_err(|e| Error::Other(format!("create checkout .codegraph: {e}")))?;
+    for name in INDEX_DB_FILES {
+        let from = src_index.join(name);
+        if from.exists() {
+            tokio::fs::copy(&from, dst_index.join(name))
+                .await
+                .map_err(|e| Error::Other(format!("copy {name} into checkout: {e}")))?;
+        }
+    }
+    append_git_exclude(checkout).await
+}
+
+/// Add `.codegraph` to a checkout's `.git/info/exclude` so the copied index
+/// never surfaces in `git status`/diffs. Idempotent: the line is added at most
+/// once, and the file (and its parent) is created if missing.
+pub async fn append_git_exclude(checkout: &Path) -> Result<()> {
+    let info_dir = checkout.join(".git").join("info");
+    tokio::fs::create_dir_all(&info_dir)
+        .await
+        .map_err(|e| Error::Other(format!("create .git/info: {e}")))?;
+    let exclude = info_dir.join("exclude");
+    let existing = tokio::fs::read_to_string(&exclude).await.unwrap_or_default();
+    if existing.lines().any(|l| l.trim() == INDEX_DIR) {
+        return Ok(());
+    }
+    let mut next = existing;
+    if !next.is_empty() && !next.ends_with('\n') {
+        next.push('\n');
+    }
+    next.push_str(INDEX_DIR);
+    next.push('\n');
+    tokio::fs::write(&exclude, next)
+        .await
+        .map_err(|e| Error::Other(format!("write .git/info/exclude: {e}")))?;
+    Ok(())
+}
+
+fn path_str(path: &Path) -> Result<String> {
+    path.to_str()
+        .map(str::to_string)
+        .ok_or_else(|| Error::InvalidPath(path.display().to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mirror_path_derivation_is_stable_and_namespaced() {
+        // Derive against the real `projects_root()` without mutating the
+        // process-global env (which would race parallel tests). We only assert
+        // structure relative to that root.
+        let root = projects_root().unwrap();
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path().join("acme");
+        std::fs::create_dir_all(&repo).unwrap();
+
+        let a = mirror_dir("proj-1", &repo).unwrap();
+        let b = mirror_dir("proj-1", &repo).unwrap();
+        assert_eq!(a, b, "same repo → same mirror dir");
+
+        // Namespaced under the project and the codegraph subdir.
+        assert!(a.starts_with(root.join("proj-1").join("codegraph")));
+
+        // A different project yields a different dir even for the same repo.
+        let c = mirror_dir("proj-2", &repo).unwrap();
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn repo_identifier_differs_by_path() {
+        let td = tempfile::tempdir().unwrap();
+        let one = td.path().join("one");
+        let two = td.path().join("two");
+        std::fs::create_dir_all(&one).unwrap();
+        std::fs::create_dir_all(&two).unwrap();
+        assert_ne!(repo_identifier(&one), repo_identifier(&two));
+        // 32 hex chars (16 bytes).
+        assert_eq!(repo_identifier(&one).len(), 32);
+    }
+
+    #[tokio::test]
+    async fn append_git_exclude_is_idempotent() {
+        let td = tempfile::tempdir().unwrap();
+        let checkout = td.path();
+        // No .git/info yet — must be created.
+        append_git_exclude(checkout).await.unwrap();
+        append_git_exclude(checkout).await.unwrap();
+        append_git_exclude(checkout).await.unwrap();
+        let body =
+            std::fs::read_to_string(checkout.join(".git/info/exclude")).unwrap();
+        let count = body.lines().filter(|l| l.trim() == ".codegraph").count();
+        assert_eq!(count, 1, "the exclude line must appear exactly once");
+    }
+
+    #[tokio::test]
+    async fn append_git_exclude_preserves_existing_content() {
+        let td = tempfile::tempdir().unwrap();
+        let checkout = td.path();
+        let info = checkout.join(".git/info");
+        std::fs::create_dir_all(&info).unwrap();
+        std::fs::write(info.join("exclude"), "# user rules\n*.log").unwrap();
+        append_git_exclude(checkout).await.unwrap();
+        let body = std::fs::read_to_string(info.join("exclude")).unwrap();
+        assert!(body.contains("# user rules"));
+        assert!(body.contains("*.log"));
+        assert!(body.contains(".codegraph"));
+        // The missing trailing newline before our append must not glue lines.
+        assert!(body.contains("*.log\n.codegraph"));
+    }
+
+    #[tokio::test]
+    async fn copy_index_skips_daemon_files_and_copies_db() {
+        let td = tempfile::tempdir().unwrap();
+        let mirror = td.path().join("mirror");
+        let src_index = mirror.join(".codegraph");
+        std::fs::create_dir_all(&src_index).unwrap();
+        std::fs::write(src_index.join("codegraph.db"), b"DB").unwrap();
+        std::fs::write(src_index.join("codegraph.db-wal"), b"WAL").unwrap();
+        std::fs::write(src_index.join("codegraph.db-shm"), b"SHM").unwrap();
+        std::fs::write(src_index.join("daemon.pid"), b"1234").unwrap();
+        std::fs::write(src_index.join("daemon.sock"), b"").unwrap();
+
+        let checkout = td.path().join("checkout");
+        std::fs::create_dir_all(&checkout).unwrap();
+        copy_index_into(&mirror, &checkout).await.unwrap();
+
+        let dst = checkout.join(".codegraph");
+        assert_eq!(std::fs::read(dst.join("codegraph.db")).unwrap(), b"DB");
+        assert_eq!(std::fs::read(dst.join("codegraph.db-wal")).unwrap(), b"WAL");
+        assert_eq!(std::fs::read(dst.join("codegraph.db-shm")).unwrap(), b"SHM");
+        assert!(!dst.join("daemon.pid").exists(), "daemon.pid must be skipped");
+        assert!(
+            !dst.join("daemon.sock").exists(),
+            "daemon.sock must be skipped"
+        );
+        // The copy also registered the exclude entry.
+        let body = std::fs::read_to_string(checkout.join(".git/info/exclude")).unwrap();
+        assert!(body.contains(".codegraph"));
+    }
+
+    #[tokio::test]
+    async fn copy_index_noop_when_no_db() {
+        let td = tempfile::tempdir().unwrap();
+        let mirror = td.path().join("mirror");
+        std::fs::create_dir_all(mirror.join(".codegraph")).unwrap();
+        // WAL present but no primary db → nothing to copy yet.
+        std::fs::write(mirror.join(".codegraph/codegraph.db-wal"), b"WAL").unwrap();
+        let checkout = td.path().join("checkout");
+        std::fs::create_dir_all(&checkout).unwrap();
+        copy_index_into(&mirror, &checkout).await.unwrap();
+        assert!(
+            !checkout.join(".codegraph").exists(),
+            "no index dir should be created without a db"
+        );
+    }
+}

--- a/src-tauri/src/codegraph/mod.rs
+++ b/src-tauri/src/codegraph/mod.rs
@@ -64,13 +64,12 @@ pub fn parse_enabled(raw: Option<&str>) -> bool {
     raw != Some("false")
 }
 
-/// Install root passed to the vendor installer as `CODEGRAPH_INSTALL_DIR`:
-/// `~/.fletch/tools/codegraph/`.
+/// Install root for the verified release bundle: `~/.fletch/tools/codegraph/`.
 pub fn install_dir() -> Result<PathBuf> {
     Ok(tools_root()?.join("codegraph"))
 }
 
-/// Symlink/bin dir passed as `CODEGRAPH_BIN_DIR`: `~/.fletch/tools/codegraph/bin`.
+/// Launcher symlink dir: `~/.fletch/tools/codegraph/bin`.
 pub fn bin_dir() -> Result<PathBuf> {
     Ok(install_dir()?.join("bin"))
 }

--- a/src-tauri/src/codegraph/mod.rs
+++ b/src-tauri/src/codegraph/mod.rs
@@ -1,0 +1,196 @@
+//! Integration of the `codegraph` code-indexing tool
+//! (<https://github.com/colbymchenry/codegraph>) so Fletch's sandboxed agents
+//! can query a repo's symbols and call graph over MCP instead of grepping files.
+//!
+//! **Why the shape here.** The tool is a self-contained release bundle (vendored
+//! Node runtime) installed under `~/.fletch/tools/codegraph/` — deliberately
+//! *outside* the app-data dir the sandbox policy denies agents from reading, so
+//! a sandboxed agent can still `exec` the binary as an MCP stdio server. We never
+//! run its `install`/`uninstall` subcommands (they rewrite `~/.claude.json` and
+//! other global agent configs) and never put it on `PATH`; the binary is always
+//! referenced by absolute path.
+//!
+//! **The index is never written to the user's source repo.** Instead we keep a
+//! throwaway `git clone --shared` *mirror* per repo under
+//! `~/.fletch/projects/<project_id>/codegraph/<repo>/`, index that, and copy the
+//! resulting `.codegraph/codegraph.db` into each fresh agent checkout. The index
+//! db is content-hash based and stores project-root-relative paths, so a db built
+//! against the mirror is valid in any other checkout of the same repo; the MCP
+//! server running in the workspace picks it up and keeps it fresh with its own
+//! file watcher.
+//!
+//! Everything here is **best-effort**: install, mirror, and copy failures are
+//! logged and swallowed. A spawn never fails because indexing didn't work — the
+//! agent just falls back to searching files, and a later spawn retries.
+
+mod install;
+mod mirror;
+
+pub use install::ensure_installed;
+pub use mirror::{advance_mirror, append_git_exclude, copy_index_into, ensure_mirror, mirror_dir};
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::agent_profile::McpServerSnapshot;
+use crate::error::Result;
+use crate::sandbox::EngineKind;
+use crate::workspace::tools_root;
+
+/// `settings` key for the user's code-indexing consent. Backend-owned (written
+/// only by `set_code_indexing_enabled`, never a frontend `setSetting`), so it
+/// uses the snake_case convention like `telemetry_enabled` / `sandbox_engine`.
+/// **Default on**: absent or anything but the literal `"false"` means enabled.
+pub const SETTING: &str = "code_indexing_enabled";
+
+/// In-memory mirror of the [`SETTING`] value, so the spawn path (deep in agent
+/// code, no DB handle) can read it. Seeded at startup and updated by the
+/// `set_code_indexing_enabled` command. Defaults to the enabled state.
+static ENABLED: AtomicBool = AtomicBool::new(true);
+
+/// Update the in-memory enabled mirror (called from startup seed + the toggle).
+pub fn set_enabled(enabled: bool) {
+    ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+/// Whether code indexing is currently enabled (the in-memory mirror).
+pub fn enabled() -> bool {
+    ENABLED.load(Ordering::Relaxed)
+}
+
+/// Interpret a raw `code_indexing_enabled` setting value as opt-out: only an
+/// explicit `"false"` disables. Shared by the startup seed and the read path.
+pub fn parse_enabled(raw: Option<&str>) -> bool {
+    raw != Some("false")
+}
+
+/// Install root passed to the vendor installer as `CODEGRAPH_INSTALL_DIR`:
+/// `~/.fletch/tools/codegraph/`.
+pub fn install_dir() -> Result<PathBuf> {
+    Ok(tools_root()?.join("codegraph"))
+}
+
+/// Symlink/bin dir passed as `CODEGRAPH_BIN_DIR`: `~/.fletch/tools/codegraph/bin`.
+pub fn bin_dir() -> Result<PathBuf> {
+    Ok(install_dir()?.join("bin"))
+}
+
+/// Absolute path to the installed `codegraph` binary.
+pub fn bin_path() -> Result<PathBuf> {
+    Ok(bin_dir()?.join("codegraph"))
+}
+
+/// Cheap existence check for the binary — the gate for MCP injection and for
+/// skipping a redundant install probe on the hot spawn path.
+pub fn is_installed() -> bool {
+    bin_path().map(|p| p.exists()).unwrap_or(false)
+}
+
+/// Build the codegraph MCP server snapshot for injection, or `None` if the
+/// binary isn't installed. stdio server running `codegraph serve --mcp`; the
+/// server resolves its project by walking up from its cwd (the agent's checkout)
+/// to the nearest `.codegraph/`. `CODEGRAPH_TELEMETRY=0` disables telemetry;
+/// `CODEGRAPH_NO_DAEMON` is intentionally *not* set here — the in-workspace
+/// daemon/watcher keeps the index fresh live while the agent works.
+fn mcp_server_snapshot() -> Option<McpServerSnapshot> {
+    let bin = bin_path().ok()?;
+    if !bin.exists() {
+        return None;
+    }
+    Some(McpServerSnapshot {
+        name: "codegraph".into(),
+        transport: "stdio".into(),
+        command: bin.to_string_lossy().into_owned(),
+        args: vec!["serve".into(), "--mcp".into()],
+        env: vec![("CODEGRAPH_TELEMETRY".into(), "0".into())],
+        ..Default::default()
+    })
+}
+
+/// Pure gate for MCP injection, factored out so the decision is testable
+/// without touching global state or the filesystem. Inject only when indexing
+/// is enabled, the engine is not Docker (a container can't exec the host macOS
+/// binary), the binary is installed, and no server named `"codegraph"`
+/// (case-insensitive) already exists — a user-defined one must never be
+/// shadowed, and its config key would otherwise collide.
+fn should_inject(
+    enabled: bool,
+    engine: EngineKind,
+    binary_installed: bool,
+    existing_names: &[&str],
+) -> bool {
+    enabled
+        && engine != EngineKind::Docker
+        && binary_installed
+        && !existing_names
+            .iter()
+            .any(|n| n.eq_ignore_ascii_case("codegraph"))
+}
+
+/// Return `servers` with the codegraph MCP server appended when [`should_inject`]
+/// allows it. Injection is dynamic — the returned list feeds the config writers
+/// directly and is never persisted onto the session snapshot, so the toggle's
+/// *current* state always wins for both fresh spawns and resumes.
+pub fn inject_mcp_server(
+    servers: &[McpServerSnapshot],
+    engine: EngineKind,
+) -> Vec<McpServerSnapshot> {
+    let mut out = servers.to_vec();
+    let allow = {
+        let names: Vec<&str> = out.iter().map(|s| s.name.as_str()).collect();
+        should_inject(enabled(), engine, is_installed(), &names)
+    };
+    if allow {
+        // `is_installed()` was true, so this is `Some` barring a race with an
+        // uninstall between the two checks — in which case we simply skip.
+        if let Some(server) = mcp_server_snapshot() {
+            out.push(server);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_enabled_is_opt_out() {
+        assert!(parse_enabled(None));
+        assert!(parse_enabled(Some("true")));
+        assert!(parse_enabled(Some("anything")));
+        assert!(!parse_enabled(Some("false")));
+    }
+
+    #[test]
+    fn should_inject_happy_path() {
+        assert!(should_inject(true, EngineKind::SandboxExec, true, &[]));
+    }
+
+    #[test]
+    fn should_inject_requires_enabled() {
+        assert!(!should_inject(false, EngineKind::SandboxExec, true, &[]));
+    }
+
+    #[test]
+    fn should_inject_skips_docker() {
+        // A container can't exec the host macOS binary.
+        assert!(!should_inject(true, EngineKind::Docker, true, &[]));
+    }
+
+    #[test]
+    fn should_inject_requires_installed_binary() {
+        assert!(!should_inject(true, EngineKind::SandboxExec, false, &[]));
+    }
+
+    #[test]
+    fn should_inject_skips_user_defined_collision() {
+        // Case-insensitive: a user-defined "CodeGraph" must not be shadowed.
+        assert!(!should_inject(
+            true,
+            EngineKind::SandboxExec,
+            true,
+            &["github", "CodeGraph"]
+        ));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod agent_install;
 mod agent_profile;
 mod bin_resolve;
 mod child_io;
+mod codegraph;
 mod commands;
 mod database;
 mod editors;
@@ -490,6 +491,76 @@ async fn set_telemetry_enabled(
     }
     telemetry::set_enabled(enabled);
     Ok(())
+}
+
+/// Flip code-indexing consent. Persists it to `settings` (so the renderer's
+/// `getAllSettings` sees it as `s.code_indexing_enabled`) and updates the
+/// in-process mirror the spawn path reads — the same persist-then-mirror shape
+/// as `set_sandbox_engine`/`set_telemetry_enabled`. Backend-owned snake_case key.
+///
+/// Turning it ON kicks a best-effort background task: install the codegraph
+/// bundle, then warm the index mirror for every pinned repo so the first agent
+/// spawn after a fresh enable already has an index to copy in. Turning it OFF
+/// does nothing else — indexes die with their workspaces, no cleanup needed.
+#[tauri::command]
+async fn set_code_indexing_enabled(
+    enabled: bool,
+    state: tauri::State<'_, DbState>,
+    supervisor: tauri::State<'_, Arc<Supervisor>>,
+) -> Result<(), String> {
+    {
+        let conn = state.lock();
+        database::set_setting(
+            &conn,
+            codegraph::SETTING,
+            if enabled { "true" } else { "false" },
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    codegraph::set_enabled(enabled);
+    if enabled {
+        // Snapshot the pinned repos (path + owning project) up front so the
+        // background task holds no DB handle across awaits.
+        let repos: Vec<(String, PathBuf)> = supervisor
+            .workspace
+            .current()
+            .map(|w| {
+                w.projects
+                    .into_iter()
+                    .map(|p| (p.project_id, p.path))
+                    .collect()
+            })
+            .unwrap_or_default();
+        tauri::async_runtime::spawn(async move {
+            warm_codegraph_index(repos).await;
+        });
+    }
+    Ok(())
+}
+
+/// Best-effort: ensure codegraph is installed, then build/refresh the index
+/// mirror for each `(project_id, source_repo)`. Every step logs and continues —
+/// a failure here just means indexing warms up on a later spawn.
+async fn warm_codegraph_index(repos: Vec<(String, PathBuf)>) {
+    let bin = match codegraph::ensure_installed().await {
+        Ok(bin) => bin,
+        Err(e) => {
+            tracing::warn!(error = %e, "codegraph install failed; indexing stays off until retry");
+            return;
+        }
+    };
+    for (project_id, source_repo) in repos {
+        let mirror = match codegraph::mirror_dir(&project_id, &source_repo) {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::warn!(error = %e, repo = %source_repo.display(), "codegraph mirror path failed");
+                continue;
+            }
+        };
+        if let Err(e) = codegraph::ensure_mirror(&source_repo, &mirror, &bin).await {
+            tracing::warn!(error = %e, repo = %source_repo.display(), "codegraph mirror warm-up failed");
+        }
+    }
 }
 
 /// Emit the deferred first `app_opened`. The frontend calls this once, when the
@@ -1130,6 +1201,26 @@ pub fn run() {
                 sandbox::set_selected_engine_kind(kind);
             }
 
+            // Seed the in-memory code-indexing consent (mirror of the
+            // `code_indexing_enabled` setting, default on) so the spawn path can
+            // read it without a DB handle. If enabled, kick a silent background
+            // install of the codegraph bundle — non-fatal: a failure just means
+            // MCP injection doesn't happen until a later successful install
+            // (retried next launch or when the user re-toggles).
+            {
+                let enabled = codegraph::parse_enabled(
+                    database::get_setting(&db.lock(), codegraph::SETTING).as_deref(),
+                );
+                codegraph::set_enabled(enabled);
+                if enabled {
+                    tauri::async_runtime::spawn(async {
+                        if let Err(e) = codegraph::ensure_installed().await {
+                            tracing::warn!(error = %e, "codegraph startup install failed; continuing");
+                        }
+                    });
+                }
+            }
+
             // Seed the docker launch knobs (image override + resource limits)
             // the same way — mirrored in-process for the spawn path. Slice C2
             // adds the settings UI whose set-commands keep this in sync
@@ -1391,6 +1482,7 @@ pub fn run() {
             db_query,
             set_agent_bin_override,
             set_telemetry_enabled,
+            set_code_indexing_enabled,
             track_app_opened,
             get_sandbox_engine,
             set_sandbox_engine,

--- a/src-tauri/src/supervisor/disposition.rs
+++ b/src-tauri/src/supervisor/disposition.rs
@@ -14,7 +14,7 @@ use crate::workspace::{
 };
 
 use super::events::emit_workspace_changed;
-use super::lifecycle::{arm_spawn_timeout, fail_spawn};
+use super::lifecycle::{arm_spawn_timeout, fail_spawn, provision_codegraph_index, stamped_engine};
 use super::Supervisor;
 
 impl Supervisor {
@@ -186,6 +186,17 @@ impl Supervisor {
                     None
                 }
             };
+
+            // Warm the codegraph index for the restored checkout too (best-effort;
+            // no-op when indexing is off or under Docker).
+            provision_codegraph_index(
+                record.project_id.clone(),
+                snap.repo_path.clone(),
+                checkout.clone(),
+                Some(tip_sha.to_string()),
+                stamped_engine(&record),
+            )
+            .await;
 
             restored.push(TrackedRepo {
                 repo_path: snap.repo_path.clone(),

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -62,6 +62,87 @@ fn ensure_engine_supports_provider(engine: EngineKind, provider: &str) -> Result
     Ok(())
 }
 
+/// Wire codegraph indexing into a freshly-provisioned checkout — best-effort and
+/// never fatal to a spawn. Skipped entirely when indexing is off or the engine
+/// is Docker (a container can't exec the host binary).
+///
+/// The cheap, synchronous part runs inline before the agent starts: register
+/// the `.git/info/exclude` entry, and — if the repo's mirror already holds a
+/// built index — copy `codegraph.db` into `<checkout>/.codegraph/` so the MCP
+/// server has an index from turn one. The expensive part (install + clone +
+/// index/advance the mirror to this checkout's base commit) is detached to a
+/// background task. When no index existed to copy synchronously, that task
+/// copies the freshly-built db into the checkout afterward if it still exists —
+/// codegraph's MCP server picks up a late-appearing index on a later tool call.
+pub(super) async fn provision_codegraph_index(
+    project_id: String,
+    source_repo: PathBuf,
+    checkout: PathBuf,
+    base_sha: Option<String>,
+    engine: EngineKind,
+) {
+    use crate::codegraph;
+
+    if !codegraph::enabled() || engine == EngineKind::Docker {
+        return;
+    }
+    let mirror = match codegraph::mirror_dir(&project_id, &source_repo) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(error = %e, repo = %source_repo.display(), "codegraph mirror path failed");
+            return;
+        }
+    };
+
+    // Always register the exclude entry when enabled, even if no index exists
+    // yet — so the index dir never surfaces in diffs once it lands.
+    if let Err(e) = codegraph::append_git_exclude(&checkout).await {
+        tracing::warn!(error = %e, "codegraph exclude entry failed");
+    }
+    // Synchronously copy an already-built index in, if the mirror has one.
+    let db = mirror.join(".codegraph").join("codegraph.db");
+    let copied_sync = db.exists();
+    if copied_sync {
+        if let Err(e) = codegraph::copy_index_into(&mirror, &checkout).await {
+            tracing::warn!(error = %e, "codegraph index copy failed");
+        }
+    }
+
+    // Prefer the resolved fork-point SHA; fall back to the checkout's HEAD when
+    // the base was a local/HEAD fallback so the mirror still advances to the
+    // exact commit the agent starts on.
+    let sha = match base_sha {
+        Some(s) => Some(s),
+        None => git::rev_parse(&checkout, "HEAD").await.ok(),
+    };
+
+    tauri::async_runtime::spawn(async move {
+        let bin = match codegraph::ensure_installed().await {
+            Ok(bin) => bin,
+            Err(e) => {
+                tracing::warn!(error = %e, "codegraph install failed; skipping mirror advance");
+                return;
+            }
+        };
+        if let Err(e) = codegraph::ensure_mirror(&source_repo, &mirror, &bin).await {
+            tracing::warn!(error = %e, "codegraph ensure_mirror failed");
+            return;
+        }
+        if let Some(sha) = &sha {
+            if let Err(e) = codegraph::advance_mirror(&mirror, &source_repo, sha, &bin).await {
+                tracing::warn!(error = %e, "codegraph advance_mirror failed");
+            }
+        }
+        // Late index: nothing was copied synchronously, so copy the db the
+        // mirror just built — provided the checkout wasn't torn down meanwhile.
+        if !copied_sync && checkout.exists() {
+            if let Err(e) = codegraph::copy_index_into(&mirror, &checkout).await {
+                tracing::warn!(error = %e, "codegraph late index copy failed");
+            }
+        }
+    });
+}
+
 /// Resolved, per-spawn inputs for `spawn_agent_process` — everything that
 /// isn't already carried on the `AgentRecord` (paths, session id, and this
 /// spawn's generation number).
@@ -370,6 +451,18 @@ impl Supervisor {
                     .set_repo_base_sha(&id_for_task, &subdir_for_fork, sha);
             }
 
+            // Warm the codegraph index for this checkout (best-effort; no-op when
+            // indexing is off or under Docker). Runs the cheap copy inline and
+            // advances the mirror in the background.
+            provision_codegraph_index(
+                project_id_for_task.clone(),
+                repo_path.clone(),
+                primary_checkout.clone(),
+                base_sha.clone(),
+                engine_kind,
+            )
+            .await;
+
             // Fork "carry code": overlay the source workspace's current working
             // tree onto the fresh checkout, so the fork starts from that
             // workspace's uncommitted work. Fatal on failure — the user asked to
@@ -507,6 +600,18 @@ impl Supervisor {
             provision::provision(&spec).await?;
         }
         let base_sha = git::rev_parse(&checkout, "HEAD").await.ok();
+
+        // Warm the codegraph index for this additional checkout too, so a
+        // multi-repo workspace (and a live "+ Repo") indexes every repo. Uses
+        // the agent's stamped engine — a docker-stamped agent is skipped inside.
+        provision_codegraph_index(
+            record.project_id.clone(),
+            repo_path.clone(),
+            checkout.clone(),
+            base_sha.clone(),
+            stamped_engine(&record),
+        )
+        .await;
 
         let repo = TrackedRepo {
             repo_path: repo_path.clone(),
@@ -736,6 +841,14 @@ impl Supervisor {
         // respawn), not just fresh spawns: only claude runs under docker.
         ensure_engine_supports_provider(engine, &record.provider)?;
 
+        // Dynamically fold the codegraph MCP server into the session's snapshot
+        // for this launch, when code indexing is on, the engine isn't Docker,
+        // and the binary is installed. Injected here (not persisted onto the
+        // session snapshot) so this runs identically for fresh spawns and
+        // resumes and the toggle's *current* state always wins. A user-defined
+        // "codegraph" server suppresses injection (see `codegraph`).
+        let mcp_servers = crate::codegraph::inject_mcp_server(&record.mcp_servers, engine);
+
         // Materialize the session's skill snapshot under the writable root and
         // fold its index into the injected instructions. Recomputed on every
         // launch path so the files always exist (e.g. after a checkout is
@@ -761,7 +874,7 @@ impl Supervisor {
         // providers take their MCP delivery from the spec's snapshot instead
         // (codex `-c` overrides); see `agent_profile`.
         let mcp_config = if record.provider == "claude" {
-            crate::agent_profile::write_claude_mcp_config(&record.mcp_servers, &sandbox_root)?
+            crate::agent_profile::write_claude_mcp_config(&mcp_servers, &sandbox_root)?
         } else {
             None
         };
@@ -789,7 +902,7 @@ impl Supervisor {
                         effort: None,
                         model: record.model.as_deref(),
                         instructions: instructions.as_deref(),
-                        mcp_servers: &record.mcp_servers,
+                        mcp_servers: &mcp_servers,
                         mcp_config: None,
                         rpc_dir,
                         cols: 120,
@@ -818,7 +931,7 @@ impl Supervisor {
                         session_id,
                         model: record.model.clone(),
                         instructions: instructions.clone(),
-                        mcp_servers: record.mcp_servers.clone(),
+                        mcp_servers: mcp_servers.clone(),
                         rpc_dir,
                         engine,
                         blackboard: blackboard.clone(),
@@ -844,7 +957,7 @@ impl Supervisor {
                 effort: record.effort.as_deref(),
                 model: record.model.as_deref(),
                 instructions: instructions.as_deref(),
-                mcp_servers: &record.mcp_servers,
+                mcp_servers: &mcp_servers,
                 mcp_config: mcp_config.as_deref(),
                 rpc_dir,
                 cols: 120,

--- a/src-tauri/src/workspace/mod.rs
+++ b/src-tauri/src/workspace/mod.rs
@@ -29,7 +29,7 @@ mod turns;
 pub use factory::{is_per_turn_provider, new_agent_record};
 pub use paths::{
     agent_parent_dir, allocate_repo_subdir, migrate_default_checkouts_root, occupied_checkout_dirs,
-    repo_checkout_path, WORKSPACES_ROOT_ENV,
+    projects_root, repo_checkout_path, tools_root, WORKSPACES_ROOT_ENV,
 };
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src-tauri/src/workspace/paths.rs
+++ b/src-tauri/src/workspace/paths.rs
@@ -49,6 +49,42 @@ pub fn checkouts_root() -> Result<PathBuf> {
     Ok(home.join(".fletch").join("workspaces"))
 }
 
+/// Env var overriding the tools root (default `~/.fletch/tools`). Same style as
+/// [`WORKSPACES_ROOT_ENV`] — set in tests so the codegraph install/probe never
+/// touches a developer's real `~/.fletch`.
+pub const TOOLS_ROOT_ENV: &str = "FLETCH_TOOLS_ROOT";
+
+/// Absolute path to the root holding Fletch-managed external tool installs:
+/// `~/.fletch/tools/`. A sibling of the workspaces root, deliberately **outside**
+/// the app-data dir (`~/Library/Application Support/com.fletch.desktop`) which
+/// the sandbox policy denies sandboxed agents from reading — agents must be able
+/// to exec the codegraph binary that lands here. `$FLETCH_TOOLS_ROOT` overrides
+/// it when set and non-empty.
+pub fn tools_root() -> Result<PathBuf> {
+    if let Some(root) = std::env::var_os(TOOLS_ROOT_ENV).filter(|v| !v.is_empty()) {
+        return Ok(PathBuf::from(root));
+    }
+    let home =
+        dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
+    Ok(home.join(".fletch").join("tools"))
+}
+
+/// Env var overriding the projects root (default `~/.fletch/projects`).
+pub const PROJECTS_ROOT_ENV: &str = "FLETCH_PROJECTS_ROOT";
+
+/// Absolute path to the root holding per-project Fletch state that isn't a
+/// live agent checkout — currently the codegraph index mirrors at
+/// `~/.fletch/projects/<project_id>/codegraph/<repo>/`. A sibling of the
+/// workspaces root; `$FLETCH_PROJECTS_ROOT` overrides it when set and non-empty.
+pub fn projects_root() -> Result<PathBuf> {
+    if let Some(root) = std::env::var_os(PROJECTS_ROOT_ENV).filter(|v| !v.is_empty()) {
+        return Ok(PathBuf::from(root));
+    }
+    let home =
+        dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
+    Ok(home.join(".fletch").join("projects"))
+}
+
 /// The set of agent-id directories that physically exist under the checkouts
 /// root. These are off-limits as new agent ids regardless of what any single
 /// database knows: the directory is the resource `git worktree add` collides

--- a/src/api/domains/misc.ts
+++ b/src/api/domains/misc.ts
@@ -11,6 +11,10 @@ export const miscApi = {
   // Anonymous usage telemetry. Persists the opt-out flag and toggles the live
   // pipeline (events themselves are emitted from the backend).
   setTelemetryEnabled: (enabled: boolean) => invoke<void>("set_telemetry_enabled", { enabled }),
+  // Code indexing (codegraph). Persists the flag and, when enabled, warms the
+  // index in the background (install + per-repo mirror). Backend-owned.
+  setCodeIndexingEnabled: (enabled: boolean) =>
+    invoke<void>("set_code_indexing_enabled", { enabled }),
   // Emit the deferred first `app_opened` once onboarding completes — i.e. after
   // the data-sharing disclosure has been shown. See `track_app_opened` (Rust).
   trackAppOpened: () => invoke<void>("track_app_opened"),

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -54,6 +54,8 @@ export function GeneralPane() {
   const setNotifyEnabled = useAppStore((s) => s.setNotifyEnabled);
   const telemetryEnabled = useAppStore((s) => s.telemetryEnabled);
   const setTelemetryEnabled = useAppStore((s) => s.setTelemetryEnabled);
+  const codeIndexingEnabled = useAppStore((s) => s.codeIndexingEnabled);
+  const setCodeIndexingEnabled = useAppStore((s) => s.setCodeIndexingEnabled);
   const revealLogs = useAppStore((s) => s.revealLogs);
   const sandboxEngine = useAppStore((s) => s.sandboxEngine);
   const setSandboxEngine = useAppStore((s) => s.setSandboxEngine);
@@ -159,6 +161,18 @@ export function GeneralPane() {
           sub="Show a desktop notification when an agent finishes a turn or needs your input while you're looking elsewhere."
         >
           <SetToggle on={notifyEnabled} onClick={() => setNotifyEnabled(!notifyEnabled)} />
+        </SetRow>
+      </SetGroup>
+
+      <SetGroup label="Code indexing">
+        <SetRow
+          title="Code indexing"
+          sub="Index project code so agents can query symbols and call graphs instead of searching files. Indexes are stored inside Fletch's data directory."
+        >
+          <SetToggle
+            on={codeIndexingEnabled}
+            onClick={() => setCodeIndexingEnabled(!codeIndexingEnabled)}
+          />
         </SetRow>
       </SetGroup>
 

--- a/src/store/account.ts
+++ b/src/store/account.ts
@@ -7,6 +7,8 @@ export interface AccountSlice {
   account: AccountProfile | null;
   /** Anonymous usage telemetry consent. Opt-out: defaults on. */
   telemetryEnabled: boolean;
+  /** Code-indexing (codegraph) consent. Opt-out: defaults on. */
+  codeIndexingEnabled: boolean;
   /** GitHub connection: null until the first probe, then the live status.
    *  `authenticated` gates push/PR/clone affordances app-wide. */
   github: GhStatus | null;
@@ -27,11 +29,13 @@ export interface AccountSlice {
    *  and once on init). */
   refreshLinear: () => Promise<void>;
   setTelemetryEnabled: (enabled: boolean) => void;
+  setCodeIndexingEnabled: (enabled: boolean) => void;
 }
 
 export const createAccountSlice: SliceCreator<AccountSlice> = (set, get) => ({
   account: null,
   telemetryEnabled: true,
+  codeIndexingEnabled: true,
   github: null,
   linear: null,
 
@@ -88,5 +92,11 @@ export const createAccountSlice: SliceCreator<AccountSlice> = (set, get) => ({
     // The backend command persists the `telemetry_enabled` setting AND toggles
     // the live pipeline, so we don't also call setSetting here.
     void api.setTelemetryEnabled(enabled);
+  },
+  setCodeIndexingEnabled: (enabled) => {
+    set({ codeIndexingEnabled: enabled });
+    // The backend command persists `code_indexing_enabled` and (when enabling)
+    // warms the index in the background, so we don't also call setSetting here.
+    void api.setCodeIndexingEnabled(enabled);
   },
 });

--- a/src/store/eventListeners.ts
+++ b/src/store/eventListeners.ts
@@ -134,6 +134,10 @@ export const hydrateSettings = async (set: AppSet) => {
       // switch a caller to `setSetting("telemetryEnabled", …)`: that's a
       // different key and the toggle would silently stop working.
       telemetryEnabled: s.telemetry_enabled !== "false",
+      // Code indexing is opt-out too, and backend-owned (snake_case, written by
+      // the `set_code_indexing_enabled` Rust command): read `s.code_indexing_enabled`,
+      // never setSetting it. Only an explicit "false" disables.
+      codeIndexingEnabled: s.code_indexing_enabled !== "false",
       // Backend-owned like telemetry_enabled (snake_case, written by the
       // `set_sandbox_engine` Rust command) — read it, never setSetting it.
       sandboxEngine: parseSandboxEngine(s.sandbox_engine),


### PR DESCRIPTION
## Summary

Integrates the [codegraph](https://github.com/colbymchenry/codegraph) code-indexing tool so agents can query symbols, call paths, and blast radius via MCP instead of grepping files — fully under the hood, with a single "Code indexing" toggle in Settings → General (default on) as the only user-visible surface.

## How it works

- **Silent install** — `src-tauri/src/codegraph/install.rs` downloads the pinned codegraph release (v1.4.1) in the background into `~/.fletch/tools/codegraph/` (agent-readable under seatbelt; never Application Support, never PATH, never `codegraph install`'s global agent hookup).
- **Per-repo base mirror** — `src-tauri/src/codegraph/mirror.rs` keeps a `--shared` clone per repo under `~/.fletch/projects/`, indexed once (`codegraph init`) and advanced to each spawn's resolved base SHA (`reset --hard` + incremental `codegraph sync`; zero extra network since objects are shared via alternates).
- **Copy-on-spawn** — after provision, the mirror's `codegraph.db` is copied into the checkout's `.codegraph/` (daemon runtime files excluded) and `.codegraph` is added to `.git/info/exclude`. Never blocks spawn: if the mirror isn't ready, a background task builds it and drops the index in late; codegraph's content-hash catch-up sync reconciles any drift.
- **MCP injection** — when enabled (and not on the Docker engine), a `codegraph serve --mcp` stdio server is appended at MCP-config materialization time for both fresh spawns and resumes (`supervisor/lifecycle.rs`), so the toggle's current state always wins. It's never persisted to the session snapshot or the user-visible MCP registry, and a user-defined server named "codegraph" takes precedence.
- **Toggle off** — new sessions simply get no codegraph MCP; existing indexes remain and die with workspace cleanup.

## Guarantees

- The user's source repo is never written to (no `.codegraph/`, hooks, or config changes).
- No global agent configs touched (`~/.claude.json` etc.); telemetry disabled on every invocation; no new sandbox write grants (policy guard test still passes).

## Verification

- `cargo test`: 985 passed (12 new codegraph tests incl. injection gate, exclude idempotency, daemon-file skip)
- `cargo clippy` / `cargo check`: clean
- `tsc --noEmit`, `vitest` (505 passed), biome on changed files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)