### PR TITLE
feat(workspace): enlarge composer on new workspace screen

### DIFF
--- a/src/components/Workspace/Draft.css
+++ b/src/components/Workspace/Draft.css
@@ -71,7 +71,7 @@
 }
 .empty-composer {
   width: 100%;
-  max-width: 640px;
+  max-width: 760px;
 }
 
 .empty-meta {

--- a/src/components/Workspace/EmptyWorkspace.tsx
+++ b/src/components/Workspace/EmptyWorkspace.tsx
@@ -203,6 +203,7 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
                 // composer) — otherwise a wrong-repo file/PR could be inserted.
                 key={draft.repoPath}
                 autoFocus
+                minRows={2}
                 draftKey={draft.id}
                 defaultProvider={draft.provider}
                 projectDir={draft.repoPath}


### PR DESCRIPTION
## Summary
Makes the composer box on the new-workspace screen larger and roomier for first prompts.

- **Height**: pass `minRows={2}` to the `<Composer>` in `EmptyWorkspace`, so the box starts at 2 lines instead of 1 (this also aligns the code with the existing `minRows` doc-comment that said the new-agent page uses 2). It still auto-grows to the 240px cap.
- **Width**: widen `.empty-composer` `max-width` from `640px` → `760px` (still under the composer shell's own `860px` cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)