### PR TITLE
feat(settings): unlock Developer section for admin users

### DIFF
--- a/src/components/SettingsScreen/index.tsx
+++ b/src/components/SettingsScreen/index.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useMemo } from "react";
 import { Icon, type IconName } from "@/components/Icon";
 import type { SettingsSection } from "@/storage/preferences";
 import { useAppStore } from "@/store";
@@ -12,12 +12,12 @@ import { McpServersPane } from "./McpServers";
 import { ProvidersPane } from "./ProvidersPane";
 import { SkillsPane } from "./Skills";
 
-// Lazily loaded behind `import.meta.env.DEV`. In production the ternary's dead
-// branch — including the dynamic import() — is dropped by Rollup, so the
-// DeveloperPane chunk is never emitted into the build (not merely unloaded).
-const DeveloperPane = import.meta.env.DEV
-  ? lazy(() => import("./DeveloperPane").then((m) => ({ default: m.DeveloperPane })))
-  : null;
+// Lazily loaded — code-split into its own chunk, fetched only when the Developer
+// section is actually opened. Visibility is gated at render (dev builds, or an
+// admin user in production), not by dropping the chunk from the build.
+const DeveloperPane = lazy(() =>
+  import("./DeveloperPane").then((m) => ({ default: m.DeveloperPane })),
+);
 
 // Built-in sections carry explicit order weights (spaced by 10) so extension
 // panes can slot *between* them via their own `order`, not just append.
@@ -51,13 +51,13 @@ const NAV: NavItem[] = [
   // Right after Customize — workflows chain those custom agents.
   { id: "workflows", label: "Workflows", icon: "combine", order: 41 },
   { id: "experimental", label: "Experimental", icon: "flask", order: 50 },
-  // Dev-only: omitted entirely from production builds.
-  ...(DeveloperPane
-    ? [{ id: "developer" as const, label: "Developer", icon: "wrench" as const, order: 60 }]
-    : []),
 ];
 // Stable sort by weight keeps contribution order on ties.
 NAV.sort((a, b) => a.order - b.order);
+
+// Developer is appended at render only when unlocked (dev build or admin user),
+// so it slots by `order` among the base entries above.
+const DEVELOPER_NAV: NavItem = { id: "developer", label: "Developer", icon: "wrench", order: 60 };
 
 /** Dedicated full-screen settings surface. Rendered in place of the workspace
  *  panes while `settingsScreenOpen` is true. The quick-settings popover stays
@@ -66,6 +66,14 @@ export function SettingsScreen() {
   const section = useAppStore((s) => s.settingsSection);
   const setSection = useAppStore((s) => s.setSettingsSection);
   const close = useAppStore((s) => s.closeSettingsScreen);
+  const admin = useAppStore((s) => s.admin);
+
+  // Dev builds always expose Developer; production unlocks it only for admins.
+  const showDeveloper = import.meta.env.DEV || admin;
+  const nav = useMemo(
+    () => (showDeveloper ? [...NAV, DEVELOPER_NAV].sort((a, b) => a.order - b.order) : NAV),
+    [showDeveloper],
+  );
 
   return (
     <div className="set-screen">
@@ -75,7 +83,7 @@ export function SettingsScreen() {
           <span>Back to app</span>
         </button>
         <div className="set-nav-list">
-          {NAV.map((n) => {
+          {nav.map((n) => {
             // A grouped entry stays active for any of its sub-sections, and
             // clicking it while already inside the group keeps the current
             // sub-tab rather than snapping back to the default.
@@ -110,14 +118,14 @@ export function SettingsScreen() {
           {section === "skills" && <SkillsPane />}
           {section === "tools" && <McpServersPane />}
           {section === "experimental" && <ExperimentalPane />}
-          {section === "developer" && DeveloperPane && (
+          {section === "developer" && showDeveloper && (
             <Suspense fallback={null}>
               <DeveloperPane />
             </Suspense>
           )}
-          {/* Fallback: "developer" can't be selected in prod (no nav entry, and
-              DeveloperPane is null), so a stale section value falls back here. */}
-          {(section === "general" || (section === "developer" && !DeveloperPane)) && (
+          {/* Fallback: a stale "developer" section value (e.g. an admin flag
+              that flipped off) has no nav entry, so it falls back to General. */}
+          {(section === "general" || (section === "developer" && !showDeveloper)) && (
             <GeneralPane />
           )}
         </div>

--- a/src/store/eventListeners.ts
+++ b/src/store/eventListeners.ts
@@ -157,6 +157,9 @@ export const hydrateSettings = async (set: AppSet) => {
       // Mission Control's dismissed review-queue marks (item id → signal
       // signature); the queue honors a mark only while the signature matches.
       reviewDismissed: parseReviewDismissed(s.reviewDismissed),
+      // Admin unlocks the Developer settings section in production. Opt-in:
+      // only an explicit "true" in the `admin` settings row grants it.
+      admin: s.admin === "true",
     });
   } catch {
     // First launch or DB not ready — defaults are fine.

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -57,6 +57,10 @@ export interface UiSlice {
    *  still matches, so a dismissed item resurfaces when its signal changes.
    *  Persisted in settings (`reviewDismissed`); hydrated on init. */
   reviewDismissed: Record<string, string>;
+  /** Whether the current user is an admin — set from the `admin` row in the
+   *  settings table (`value === "true"`). Unlocks the Developer settings
+   *  section in production builds (dev builds always show it). */
+  admin: boolean;
 
   toggleSettings: (open?: boolean) => void;
   openSettingsScreen: (section?: SettingsSection, intent?: SettingsIntent) => void;
@@ -109,6 +113,7 @@ export const createUiSlice: SliceCreator<UiSlice> = (set, get) => ({
   rightWidth: DEFAULT_RIGHT_WIDTH,
   rightPanelTabs: {},
   reviewDismissed: {},
+  admin: false,
 
   // ── UI ──────────────────────────────────────────────────────────────────────
   toggleSettings: (open) => set((s) => ({ settingsOpen: open ?? !s.settingsOpen })),


### PR DESCRIPTION
## Summary

Shows the **Developer** settings section for admin users, not only in dev builds. An admin is any user whose `admin` row in the `settings` table has value `"true"`.

## Changes

- **`src/store/ui.ts`** — new `admin: boolean` field on the UI slice (default `false`).
- **`src/store/eventListeners.ts`** — `hydrateSettings` sets `admin: s.admin === "true"` (opt-in; only an explicit `"true"` grants it).
- **`src/components/SettingsScreen/index.tsx`** — `DeveloperPane` is now always lazy-loaded into its own code-split chunk (previously stripped from production via `import.meta.env.DEV`); it's still only fetched when the section is opened. The nav entry and render are gated on `import.meta.env.DEV || admin`.

## Notes

- Production builds now ship the DeveloperPane chunk so admins can load it; it's only reachable when the `admin` flag is true. Its current contents (replay tour, refresh model catalog, trigger update toast) are not sensitive.
- To grant admin: `setSetting("admin", "true")`. There is no admin-granting UI in this PR.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `biome check` passes on changed files
- [ ] Dev build: Developer section visible as before
- [ ] Prod build with `admin=true`: Developer section visible
- [ ] Prod build without the flag: Developer section hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)