### PR TITLE
feat(workspace): gate Mission Control behind a Developer setting with a Home landing screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -166,7 +166,11 @@ export function App() {
             </ErrorBoundary>
 
             {rightPaneVisible && <div className="splitter" onMouseDown={onRightDrag} />}
-            {!activeDraftId && (
+            {/* Only mount the right pane when an agent is selected — its content
+             *  needs one. Without this gate the container still claims layout
+             *  width on Home / the run view, stranding the center pane in a
+             *  narrow column beside an empty rail. */}
+            {!activeDraftId && selectedAgent && (
               <div
                 className={`pane right ${rightCollapsed ? "collapsed" : ""}`}
                 style={{

--- a/src/app.css
+++ b/src/app.css
@@ -18,6 +18,7 @@
 @import "./styles/shared/badge.css";
 @import "./components/Workspace/Workspace.css";
 @import "./components/Workspace/MissionControl/MissionControl.css";
+@import "./components/Workspace/Home/Home.css";
 @import "./components/Workspace/Chat.css";
 @import "./components/Workspace/messages/UserInput/UserInput.css";
 @import "./components/Composer/Composer.css";

--- a/src/components/SettingsScreen/DeveloperPane.tsx
+++ b/src/components/SettingsScreen/DeveloperPane.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Icon } from "@/components/Icon";
 import { Button } from "@/components/ui/Button";
 import { useAppStore } from "@/store";
-import { SetGroup, SetHead, SetRow } from "./primitives";
+import { SetGroup, SetHead, SetRow, SetToggle } from "./primitives";
 
 /** Dev-only settings surface. The nav entry that routes here is gated on
  *  `import.meta.env.DEV`, so this pane only ships under `bun tauri dev`. */
@@ -11,6 +11,8 @@ export function DeveloperPane() {
   const closeSettingsScreen = useAppStore((s) => s.closeSettingsScreen);
   const refreshModelCatalog = useAppStore((s) => s.refreshModelCatalog);
   const setUpdateReady = useAppStore((s) => s.setUpdateReady);
+  const features = useAppStore((s) => s.features);
+  const setFeature = useAppStore((s) => s.setFeature);
   const [refreshingModels, setRefreshingModels] = useState(false);
 
   const handleRefreshModels = async () => {
@@ -30,6 +32,18 @@ export function DeveloperPane() {
         title="Developer"
         desc="Tools for working on Fletch itself. Only available in development builds."
       />
+
+      <SetGroup label="Home">
+        <SetRow
+          title="Mission Control"
+          sub="Use the fleet review queue as the Home view. When off, Home is the quick-actions landing screen."
+        >
+          <SetToggle
+            on={!!features.missionControl}
+            onClick={() => setFeature("missionControl", !features.missionControl)}
+          />
+        </SetRow>
+      </SetGroup>
 
       <SetGroup label="Onboarding">
         <SetRow

--- a/src/components/Workspace/Home/ActionCard.tsx
+++ b/src/components/Workspace/Home/ActionCard.tsx
@@ -1,0 +1,52 @@
+import { Icon, type IconName } from "@/components/Icon";
+
+export interface ActionCardProps {
+  icon: IconName;
+  title: string;
+  sub: string;
+  onClick: () => void;
+  /** "primary" is the single hero action — larger, accent-tinted. */
+  tone?: "primary" | "default";
+  /** Optional keyboard hint shown on the trailing edge (e.g. "⌘N"). */
+  kbd?: string;
+  /** While true the icon spins and the card is non-interactive. */
+  busy?: boolean;
+  disabled?: boolean;
+}
+
+/** One quick action on the Home screen. A big, single-purpose button: an
+ *  accent icon tile, a title + one line of context, and a trailing affordance
+ *  (a keyboard hint, or an arrow that nudges on hover). */
+export function ActionCard({
+  icon,
+  title,
+  sub,
+  onClick,
+  tone = "default",
+  kbd,
+  busy = false,
+  disabled = false,
+}: ActionCardProps) {
+  const primary = tone === "primary";
+  return (
+    <button
+      type="button"
+      className={`home-card${primary ? " primary" : ""}`}
+      onClick={onClick}
+      disabled={disabled || busy}
+    >
+      <span className={`home-card-icon flex-center${busy ? " spin" : ""}`}>
+        <Icon name={busy ? "refresh" : icon} size={primary ? 19 : 16} />
+      </span>
+      <span className="home-card-text">
+        <span className="home-card-title">{title}</span>
+        <span className="home-card-sub truncate">{sub}</span>
+      </span>
+      {kbd ? (
+        <kbd className="home-kbd">{kbd}</kbd>
+      ) : (
+        <Icon name="arrowR" size={15} className="home-card-arrow" />
+      )}
+    </button>
+  );
+}

--- a/src/components/Workspace/Home/Home.css
+++ b/src/components/Workspace/Home/Home.css
@@ -1,0 +1,268 @@
+/* Home — the landing surface shown when nothing is selected and Mission
+ * Control is off. Editorial, calm, token-driven so it tracks theme + accent. */
+
+.home-wrap {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  justify-content: center;
+  padding: 64px 40px 72px;
+  overflow: hidden;
+}
+
+/* Ambient accent glow behind the hero — the same vocabulary as onboarding,
+ * dialled down so it reads as a whisper, not a spotlight. */
+.home-glow {
+  position: absolute;
+  top: -28%;
+  left: 50%;
+  width: 120vw;
+  height: 80vh;
+  transform: translateX(-50%);
+  pointer-events: none;
+  background: radial-gradient(
+    50% 50% at 50% 50%,
+    color-mix(in oklch, var(--accent), transparent 88%) 0%,
+    transparent 68%
+  );
+  opacity: 0.9;
+  animation: home-glow-drift 14s var(--ease) infinite alternate;
+}
+
+@keyframes home-glow-drift {
+  from {
+    transform: translateX(-50%) translateY(0) scale(1);
+    opacity: 0.75;
+  }
+  to {
+    transform: translateX(-50%) translateY(2%) scale(1.06);
+    opacity: 1;
+  }
+}
+
+.home-inner {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  max-width: 640px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+/* ---- Identity / hero copy ---- */
+
+.home-id {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 10px;
+  margin-bottom: 34px;
+}
+
+.home-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+}
+
+.home-eyebrow .d {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.home-title {
+  font-size: var(--fs-4xl);
+  line-height: var(--lh-none);
+  letter-spacing: -0.025em;
+  color: var(--fg-0);
+  margin: 0;
+}
+
+.home-sub {
+  font-size: var(--fs-base);
+  line-height: var(--lh-normal);
+  color: var(--fg-2);
+  max-width: 460px;
+  margin: 0;
+}
+
+/* ---- Action stack ---- */
+
+.home-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+}
+
+.home-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(196px, 1fr));
+  gap: 10px;
+}
+
+.home-card {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  width: 100%;
+  text-align: left;
+  padding: 13px 15px;
+  background: var(--bg-2);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-md);
+  box-shadow: var(--shadow-1);
+  cursor: pointer;
+  transition:
+    border-color 0.14s var(--ease),
+    background 0.14s var(--ease),
+    transform 0.14s var(--ease),
+    box-shadow 0.14s var(--ease);
+}
+
+.home-card:hover:not(:disabled) {
+  border-color: var(--bd);
+  background: var(--hover);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-2);
+}
+
+.home-card:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.home-card:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+
+/* Hero action — larger, accent-tinted, with a solid accent tile. */
+.home-card.primary {
+  padding: 17px 18px;
+  border-color: var(--accent-line);
+  background: color-mix(in oklch, var(--accent-soft) 55%, var(--bg-2));
+}
+
+.home-card.primary:hover:not(:disabled) {
+  border-color: var(--accent);
+  background: color-mix(in oklch, var(--accent-soft) 80%, var(--bg-2));
+}
+
+.home-card-icon {
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: var(--r-sm);
+  color: var(--accent);
+  background: color-mix(in oklch, var(--accent) 14%, transparent);
+}
+
+.home-card.primary .home-card-icon {
+  width: 42px;
+  height: 42px;
+  border-radius: var(--r-md);
+  background: color-mix(in oklch, var(--accent) 20%, transparent);
+}
+
+.home-card-icon.spin :where(svg) {
+  animation: home-spin 0.8s linear infinite;
+}
+
+@keyframes home-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.home-card-text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.home-card-title {
+  font-size: var(--fs-base);
+  font-weight: 500;
+  color: var(--fg-0);
+}
+
+.home-card.primary .home-card-title {
+  font-size: var(--fs-lg);
+}
+
+.home-card-sub {
+  font-size: var(--fs-sm);
+  color: var(--fg-2);
+}
+
+.home-card-arrow {
+  flex: none;
+  color: var(--fg-3);
+  transition:
+    color 0.14s var(--ease),
+    transform 0.14s var(--ease);
+}
+
+.home-card:hover:not(:disabled) .home-card-arrow {
+  color: var(--fg-1);
+  transform: translateX(2px);
+}
+
+/* Keyboard hint chip — reused for the hero and the tips footer. */
+.home-kbd {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--fg-2);
+  background: var(--bg-0);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-xs);
+  padding: 2px 6px;
+  line-height: var(--lh-none);
+}
+
+/* ---- Shortcut footer ---- */
+
+.home-tips {
+  gap: 18px;
+  margin-top: 30px;
+  flex-wrap: wrap;
+}
+
+.home-tip {
+  gap: 7px;
+  font-size: var(--fs-xs);
+  color: var(--fg-3);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-glow {
+    animation: none;
+  }
+  .home-card,
+  .home-card-arrow {
+    transition: none;
+  }
+  .home-card:hover:not(:disabled) {
+    transform: none;
+  }
+  .home-card-icon.spin :where(svg) {
+    animation: none;
+  }
+}

--- a/src/components/Workspace/Home/greeting.ts
+++ b/src/components/Workspace/Home/greeting.ts
@@ -1,0 +1,9 @@
+/** Time-of-day greeting for the Home hero. Pure so it can be unit-tested; the
+ *  caller passes the current Date (the component reads `new Date()` at render).
+ *  Buckets: 05:00–11:59 morning, 12:00–17:59 afternoon, otherwise evening. */
+export function greeting(now: Date): string {
+  const h = now.getHours();
+  if (h >= 5 && h < 12) return "Good morning";
+  if (h >= 12 && h < 18) return "Good afternoon";
+  return "Good evening";
+}

--- a/src/components/Workspace/Home/index.tsx
+++ b/src/components/Workspace/Home/index.tsx
@@ -1,0 +1,165 @@
+import { open } from "@tauri-apps/plugin-dialog";
+import { useState } from "react";
+import { Icon } from "@/components/Icon";
+import { IconButton } from "@/components/ui/IconButton";
+import { useAppStore } from "@/store";
+import { ActionCard } from "./ActionCard";
+import { greeting } from "./greeting";
+
+/** Home — the center pane when no agent, run, or draft is selected and Mission
+ *  Control is turned off (Developer setting). A calm landing surface that puts
+ *  the next real action one click away and adapts to where the user is: a
+ *  first-timer with no projects is pointed at adding one; a returning user gets
+ *  a greeting and a New-agent hero. Every action here maps to a live store
+ *  action — nothing decorative. */
+export function Home() {
+  const workspace = useAppStore((s) => s.workspace);
+  const leftCollapsed = useAppStore((s) => s.leftCollapsed);
+  const toggleLeft = useAppStore((s) => s.toggleLeft);
+  const createDraft = useAppStore((s) => s.createDraft);
+  const addWorkspaceRepo = useAppStore((s) => s.addWorkspaceRepo);
+  const setLastRepoPath = useAppStore((s) => s.setLastRepoPath);
+  const lastRepoPath = useAppStore((s) => s.lastRepoPath);
+  const selectedAgentId = useAppStore((s) => s.selectedAgentId);
+  const toggleHistory = useAppStore((s) => s.toggleHistory);
+  const openSettingsScreen = useAppStore((s) => s.openSettingsScreen);
+
+  const [adding, setAdding] = useState(false);
+
+  const repos = workspace?.repos ?? [];
+  const projects = workspace?.projects ?? [];
+  const agents = (workspace?.agents ?? []).filter((a) => !a.archive);
+  const hasProjects = repos.length > 0;
+  const hasAgents = agents.length > 0;
+
+  // Resolve the New-agent target repo the same way ⌘N does (see
+  // util/shortcuts.ts): the last project an agent was started in if it still
+  // exists, else the selected agent's project, else the first pinned repo.
+  const recent = lastRepoPath && repos.includes(lastRepoPath) ? lastRepoPath : undefined;
+  const targetRepo =
+    recent ?? agents.find((a) => a.id === selectedAgentId)?.repos[0]?.repo_path ?? repos[0];
+  const targetName = projects.find((p) => p.path === targetRepo)?.name;
+
+  const newAgent = () => {
+    if (targetRepo) createDraft(targetRepo);
+  };
+
+  // Same flow as the sidebar's "Open a folder" (NewProjectPopover): native
+  // directory picker → pin the repo → remember it as the next New-agent target.
+  const addProject = async () => {
+    if (adding) return;
+    setAdding(true);
+    try {
+      const picked = await open({
+        directory: true,
+        multiple: false,
+        title: "Select a git repository",
+      });
+      if (typeof picked === "string") {
+        await addWorkspaceRepo(picked);
+        setLastRepoPath(picked);
+      }
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const title = hasProjects ? greeting(new Date()) : "Welcome to Fletch";
+  const sub = !hasProjects
+    ? "Add a local git repository to spin up your first agent — each one gets its own isolated checkout and sandbox."
+    : hasAgents
+      ? "Pick up where you left off, or start something new."
+      : `You're all set. Start your first agent${targetName ? ` in ${targetName}` : ""}.`;
+
+  return (
+    <div className="pane center">
+      <div className="center-h flex-center">
+        <IconButton
+          tip={leftCollapsed ? "Show sidebar (⌘B)" : "Hide sidebar (⌘B)"}
+          onClick={toggleLeft}
+        >
+          <Icon name="sidebarL" />
+        </IconButton>
+      </div>
+
+      <div className="home-wrap flex-center fade-in">
+        <div className="home-glow" aria-hidden="true" />
+        <div className="home-inner">
+          <div className="home-id">
+            <span className="home-eyebrow">
+              <span className="d" />
+              Fletch
+            </span>
+            <h1 className="home-title serif">{title}</h1>
+            <p className="home-sub">{sub}</p>
+          </div>
+
+          <div className="home-actions">
+            {hasProjects ? (
+              <ActionCard
+                tone="primary"
+                icon="sparkle"
+                kbd="⌘ N"
+                title="New agent"
+                sub={targetName ? `Start a coding agent in ${targetName}` : "Start a coding agent"}
+                onClick={newAgent}
+              />
+            ) : (
+              <ActionCard
+                tone="primary"
+                icon="folder"
+                title="Add your first project"
+                sub="Open a local git repository on your machine"
+                onClick={() => void addProject()}
+                busy={adding}
+              />
+            )}
+
+            <div className="home-grid">
+              {hasProjects && (
+                <ActionCard
+                  icon="folder"
+                  title="Add a project"
+                  sub="Open another local repo"
+                  onClick={() => void addProject()}
+                  busy={adding}
+                />
+              )}
+              {hasAgents && (
+                <ActionCard
+                  icon="history"
+                  title="History"
+                  sub="Revisit archived agents"
+                  onClick={() => toggleHistory(true)}
+                />
+              )}
+              <ActionCard
+                icon="cube"
+                title="Connect a provider"
+                sub="Claude, Codex & more"
+                onClick={() => openSettingsScreen("providers")}
+              />
+            </div>
+          </div>
+
+          {hasProjects && (
+            <div className="home-tips flex-center">
+              <Tip k="⌘ N" label="New agent" />
+              <Tip k="⌘ K" label="Search" />
+              <Tip k="⌘ B" label="Sidebar" />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Tip({ k, label }: { k: string; label: string }) {
+  return (
+    <span className="home-tip iflex-center">
+      <kbd className="home-kbd">{k}</kbd>
+      <span>{label}</span>
+    </span>
+  );
+}

--- a/src/components/Workspace/Home/index.tsx
+++ b/src/components/Workspace/Home/index.tsx
@@ -23,21 +23,26 @@ export function Home() {
   const selectedAgentId = useAppStore((s) => s.selectedAgentId);
   const toggleHistory = useAppStore((s) => s.toggleHistory);
   const openSettingsScreen = useAppStore((s) => s.openSettingsScreen);
+  const setLastError = useAppStore((s) => s.setLastError);
 
   const [adding, setAdding] = useState(false);
 
   const repos = workspace?.repos ?? [];
   const projects = workspace?.projects ?? [];
-  const agents = (workspace?.agents ?? []).filter((a) => !a.archive);
+  const allAgents = workspace?.agents ?? [];
+  const liveAgents = allAgents.filter((a) => !a.archive);
   const hasProjects = repos.length > 0;
-  const hasAgents = agents.length > 0;
+  const hasAgents = liveAgents.length > 0;
+  // History surfaces archived agents, so it's the presence of an archive — not
+  // of live agents — that decides whether the card is worth showing.
+  const hasArchived = allAgents.some((a) => a.archive);
 
   // Resolve the New-agent target repo the same way ⌘N does (see
   // util/shortcuts.ts): the last project an agent was started in if it still
   // exists, else the selected agent's project, else the first pinned repo.
   const recent = lastRepoPath && repos.includes(lastRepoPath) ? lastRepoPath : undefined;
   const targetRepo =
-    recent ?? agents.find((a) => a.id === selectedAgentId)?.repos[0]?.repo_path ?? repos[0];
+    recent ?? liveAgents.find((a) => a.id === selectedAgentId)?.repos[0]?.repo_path ?? repos[0];
   const targetName = projects.find((p) => p.path === targetRepo)?.name;
 
   const newAgent = () => {
@@ -55,10 +60,15 @@ export function Home() {
         multiple: false,
         title: "Select a git repository",
       });
+      // `addWorkspaceRepo` routes its own failures to the error banner; the
+      // dialog itself can still reject (plugin/platform error), which we'd
+      // otherwise drop as an unhandled rejection with no user feedback.
       if (typeof picked === "string") {
         await addWorkspaceRepo(picked);
         setLastRepoPath(picked);
       }
+    } catch (e) {
+      setLastError(`Couldn't open the folder picker: ${String(e)}`);
     } finally {
       setAdding(false);
     }
@@ -125,7 +135,7 @@ export function Home() {
                   busy={adding}
                 />
               )}
-              {hasAgents && (
+              {hasArchived && (
                 <ActionCard
                   icon="history"
                   title="History"

--- a/src/components/Workspace/Home/index.tsx
+++ b/src/components/Workspace/Home/index.tsx
@@ -46,7 +46,13 @@ export function Home() {
   const targetName = projects.find((p) => p.path === targetRepo)?.name;
 
   const newAgent = () => {
-    if (targetRepo) createDraft(targetRepo);
+    if (!targetRepo) return;
+    // createDraft already routes name-allocation failures to the error banner,
+    // but never leave the returned promise floating: catch here so any other
+    // reject path can't become an unhandled rejection with no user feedback.
+    void createDraft(targetRepo).catch((e) => {
+      setLastError(`Couldn't start a new agent: ${String(e)}`);
+    });
   };
 
   // Same flow as the sidebar's "Open a folder" (NewProjectPopover): native

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -8,6 +8,7 @@ import { EMPTY_AGENTS, useAppStore } from "@/store";
 import { RunView } from "@/workflows/run/RunView";
 import { ChatView } from "./ChatView";
 import { EmptyWorkspace } from "./EmptyWorkspace";
+import { Home } from "./Home";
 import { MissionControl } from "./MissionControl";
 import { NativeView } from "./NativeView";
 import { WorkspaceHeader } from "./WorkspaceHeader";
@@ -24,6 +25,7 @@ export function Workspace() {
   const activeDraftId = useAppStore((s) => s.activeDraftId);
   const leftCollapsed = useAppStore((s) => s.leftCollapsed);
   const toggleLeft = useAppStore((s) => s.toggleLeft);
+  const missionControl = useAppStore((s) => s.features.missionControl);
 
   const draft = activeDraftId ? drafts.find((d) => d.id === activeDraftId) : null;
   // Only surface the draft while its repo is still pinned; a draft stranded on a
@@ -38,8 +40,9 @@ export function Workspace() {
     return <RunView id={selectedRunId} key={selectedRunId} />;
   }
 
-  // No agent selected → Home is Mission Control: the fleet review queue. The
-  // bare "Loading…" placeholder stands only until the workspace connects.
+  // No agent selected → Home. Mission Control (the fleet review queue) is gated
+  // behind the Developer setting; when off, Home is a blank pane. The bare
+  // "Loading…" placeholder stands only until the workspace connects.
   const agent = agents.find((a) => a.id === selectedId);
   if (!workspace) {
     return (
@@ -56,7 +59,7 @@ export function Workspace() {
       </div>
     );
   }
-  if (!agent) return <MissionControl />;
+  if (!agent) return missionControl ? <MissionControl /> : <Home />;
 
   return (
     <div className="pane center fade-in" key={agent.id}>

--- a/src/storage/preferences.ts
+++ b/src/storage/preferences.ts
@@ -36,6 +36,10 @@ export interface FeatureFlags {
    *  driven through the provider's own terminal UI. Off by default — native
    *  mode isn't equally solid across providers yet. */
   nativeView: boolean;
+  /** Use Mission Control (the fleet review queue) as the Home view. Off by
+   *  default — Home is then the quick-actions landing screen. Gated behind the
+   *  Developer tab. */
+  missionControl: boolean;
 }
 
 export const DEFAULT_FEATURES: FeatureFlags = {
@@ -46,6 +50,7 @@ export const DEFAULT_FEATURES: FeatureFlags = {
   thinkingBudget: true,
   tokenUsage: true,
   nativeView: false,
+  missionControl: false,
 };
 
 export function parseFeatures(raw: string | undefined): FeatureFlags {

--- a/src/store/drafts.ts
+++ b/src/store/drafts.ts
@@ -125,7 +125,17 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
       modelsByAgent,
     } = get();
     const used = [...usedNames(workspace, drafts)];
-    const name = await api.allocateDraftName(used);
+    // Name allocation is a backend call; if it fails there's no draft to
+    // create. Surface it in the global error banner and bail rather than
+    // leaving an unhandled rejection for the fire-and-forget callers (⌘N,
+    // the sidebar +, the Home screen) and a silently dead click.
+    let name: string;
+    try {
+      name = await api.allocateDraftName(used);
+    } catch (e) {
+      get().setLastError(`Couldn't start a new agent: ${String(e)}`);
+      return;
+    }
     const selection = normalizeDraftSelection(newDraftProvider, newDraftModel, modelsByAgent);
     // Carry the sticky custom-agent pick onto the new draft, but only if it
     // still exists (it may have been deleted since it was last persisted).


### PR DESCRIPTION
## Summary

Puts the Mission Control view behind a **Developer settings** toggle. When the toggle is off (the default), the no-selection Home view becomes a new premium quick-actions landing screen; when on, Mission Control stays as Home — preserving today's behavior for anyone who opts in.

## Changes

- **New `missionControl` feature flag** (`preferences.ts`), default `false`, persisted/hydrated via the existing `features` blob. Toggle added to the Developer pane (`DeveloperPane.tsx`).
- **New Home landing screen** (`src/components/Workspace/Home/`): an editorial, token-driven surface (serif display greeting, mono eyebrow, ambient accent glow, `.fade-in`) that tracks theme + accent palette and respects `prefers-reduced-motion`. It is **state-adaptive** and every action is wired to a real store action:
  - First run (no projects): hero = *Add your first project* → native folder picker → `addWorkspaceRepo`.
  - Has projects: hero = *New agent* (mirrors the exact ⌘N target-repo resolution) → `createDraft`, with a time-of-day greeting.
  - Secondary actions shown only when meaningful: Add a project, History (`toggleHistory`), Connect a provider (`openSettingsScreen`).
- **`Workspace/index.tsx`**: render `<MissionControl />` or `<Home />` based on the flag.
- **`App.tsx`**: hide the right-pane container when no agent is selected, aligning it with the splitter's existing gate — Home (and the run view) no longer strand the center pane beside an empty rail.

## Notes

- The Developer tab is only visible in dev builds or to admins, so regular users get the new Home screen and can't flip Mission Control back on.
- Desktop (Tauri) app — not visually screenshotted from the sandbox. `tsc` and Biome pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)