### PR TITLE
fix(workspace): make agent-name allocation DB-authoritative per build

### DIFF
--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -14,7 +14,7 @@ use crate::workspace::{ProjectDeleteResult, Workspace};
 /// Allocate a fresh name from the place pool for a draft agent. The frontend
 /// passes the names already taken (live agents + other open drafts); the
 /// per-build DB is authoritative for the rest, so there's nothing else to fold
-/// in. This is only a preview — `allocate_agent_id` is authoritative at create.
+/// in. This is only a preview — `add_agent_allocating` is authoritative at create.
 #[tauri::command]
 pub fn allocate_draft_name(used: Vec<String>) -> String {
     let reserved: std::collections::HashSet<String> = used.into_iter().collect();

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -11,15 +11,13 @@ use crate::new_project;
 use crate::supervisor::Supervisor;
 use crate::workspace::{ProjectDeleteResult, Workspace};
 
-/// Allocate a fresh name from the shared place pool for a draft agent.
-/// Frontend passes the names already taken (real agents + other drafts) so
-/// the picker avoids collisions.
+/// Allocate a fresh name from the place pool for a draft agent. The frontend
+/// passes the names already taken (live agents + other open drafts); the
+/// per-build DB is authoritative for the rest, so there's nothing else to fold
+/// in. This is only a preview — `allocate_agent_id` is authoritative at create.
 #[tauri::command]
 pub fn allocate_draft_name(used: Vec<String>) -> String {
-    // Fold in the names already on disk (other instances, stale checkouts) so a
-    // draft never previews a name that `git worktree add` would later reject.
-    let mut reserved: std::collections::HashSet<String> = used.into_iter().collect();
-    reserved.extend(crate::workspace::occupied_checkout_dirs());
+    let reserved: std::collections::HashSet<String> = used.into_iter().collect();
     names::allocate(&reserved)
 }
 

--- a/src-tauri/src/names.rs
+++ b/src-tauri/src/names.rs
@@ -330,11 +330,22 @@ pub fn allocate(used: &HashSet<String>) -> String {
             return candidate.to_string();
         }
     }
+    // Every random pick collided. With a ~300-name pool this is vanishingly
+    // rare unless `used` is large — and `used` folds in every on-disk checkout
+    // across all builds sharing the root, so hitting this points at namespace
+    // saturation or a pile-up of orphaned dirs. Log loudly with the set size so
+    // the cause is diagnosable rather than a silent `-2`.
     let base = pick_random();
     let mut n: u32 = 2;
     loop {
         let candidate = format!("{base}-{n}");
         if !used.contains(&candidate) {
+            tracing::warn!(
+                used = used.len(),
+                pool = PLACES.len(),
+                name = %candidate,
+                "name allocator exhausted 10 random picks; falling back to a numbered suffix"
+            );
             return candidate;
         }
         n += 1;

--- a/src-tauri/src/sandbox/provision.rs
+++ b/src-tauri/src/sandbox/provision.rs
@@ -274,9 +274,10 @@ async fn clone_base(spec: &CheckoutSpec<'_>, shared: bool) -> Result<()> {
     let dest = path_str(spec.dest)?;
 
     // A leftover directory at the target can only be an orphan from a crashed
-    // spawn: agent-id allocation refuses ids whose checkout dir physically
-    // exists (`occupied_checkout_dirs`), so no live workspace can be here.
-    // Clear it rather than letting `git clone` fail on a non-empty dir.
+    // spawn or a failed teardown: allocation only hands out ids that are free
+    // in this build's DB, and each build has its own checkouts root, so no live
+    // workspace can be here. Clear it rather than letting `git clone` fail on a
+    // non-empty dir — this is what makes DB-authoritative allocation safe.
     if spec.dest.exists() {
         tracing::warn!(path = %spec.dest.display(), "clearing orphan dir at clone target");
         tokio::fs::remove_dir_all(spec.dest).await?;

--- a/src-tauri/src/supervisor/disposition.rs
+++ b/src-tauri/src/supervisor/disposition.rs
@@ -439,12 +439,52 @@ async fn teardown_agent_checkouts(agent_id: &str, repos: &[TrackedRepo], op: &st
     }
 
     // Remove the parent dir (may still hold orphan files if any checkout
-    // removal failed). Best-effort.
-    if let Ok(parent) = agent_parent_dir(agent_id) {
-        if parent.exists() {
-            let _ = tokio::fs::remove_dir_all(&parent).await;
+    // removal failed). Best-effort, retried + logged (see `remove_agent_dir`).
+    let _ = remove_agent_dir(agent_id, op).await;
+}
+
+/// Remove an agent's parent checkout dir, retrying briefly. Returns `true` once
+/// the dir is gone (removed now or already absent).
+///
+/// The common failure right after process shutdown is a still-open file handle
+/// — a just-exited child, the codegraph indexer — that clears within a moment,
+/// so a few spaced retries recover most cases. A dir that survives everything
+/// is logged at `error`. It no longer reserves the agent's name — allocation is
+/// DB-authoritative (per-build root) and provision clears any leftover at the
+/// clone target — so a lingering dir is only wasted disk, not a correctness
+/// problem; the log is the hygiene hook.
+async fn remove_agent_dir(agent_id: &str, op: &str) -> bool {
+    let parent = match agent_parent_dir(agent_id) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(agent_id, op, error = %e, "agent dir path resolution failed");
+            return false;
+        }
+    };
+    for attempt in 1..=3u32 {
+        if !parent.exists() {
+            return true;
+        }
+        match tokio::fs::remove_dir_all(&parent).await {
+            Ok(()) => return true,
+            Err(e) if attempt < 3 => {
+                tracing::warn!(
+                    agent_id, op, attempt, path = %parent.display(), error = %e,
+                    "checkout dir removal failed; retrying"
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(150 * attempt as u64)).await;
+            }
+            Err(e) => {
+                tracing::error!(
+                    agent_id, op, path = %parent.display(), error = %e,
+                    "checkout dir removal failed after retries; it now orphans the agent \
+                     name in the on-disk namespace the allocator consults"
+                );
+                return false;
+            }
         }
     }
+    !parent.exists()
 }
 
 #[cfg(test)]

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -293,11 +293,15 @@ impl Supervisor {
         // Use the name the draft already showed in the sidebar so it locks in
         // rather than being regenerated; only allocate a fresh one when the
         // caller didn't supply it (the draft-less spawn path).
-        let agent_id = match name {
-            Some(n) if !n.trim().is_empty() => n,
-            _ => self.workspace.allocate_agent_id()?,
+        // Whether the caller pinned a name (draft / restore) or we auto-allocate.
+        // For the auto path the id is chosen inside `add_agent_allocating`, under
+        // the same lock as the insert, so concurrent spawns can't race on it — so
+        // the final id isn't known until after the row is written, below.
+        let supplied_name = match name {
+            Some(n) if !n.trim().is_empty() => Some(n),
+            _ => None,
         };
-        let name = agent_id.clone();
+        let initial_id = supplied_name.clone().unwrap_or_default();
 
         // The agent's parent branch — the base its checkout forks from and the
         // ref it later targets for PRs / ahead-behind. The base the user chose
@@ -332,8 +336,8 @@ impl Supervisor {
         };
 
         let mut record = new_agent_record(
-            agent_id.clone(),
-            name,
+            initial_id.clone(),
+            initial_id,
             provider,
             primary,
             String::new(),
@@ -367,10 +371,17 @@ impl Supervisor {
         // Carry the originating issue (Home inbox "Start work") onto the record
         // so the git dispatcher can close it from the agent's PR.
         record.issue_ref = issue_ref;
+        // Insert first: on the auto path this both allocates the id and writes
+        // the row under one lock, so `record.id` is final only afterward. A
+        // pinned name goes through `add_agent`, where a clash is a real error.
+        if supplied_name.is_some() {
+            self.workspace.add_agent(&mut record)?;
+        } else {
+            self.workspace.add_agent_allocating(&mut record)?;
+        }
+        let agent_id = record.id.clone();
         let parent_dir = agent_parent_dir(&agent_id)?;
         let primary_checkout = repo_checkout_path(&agent_id, &subdir)?;
-
-        self.workspace.add_agent(&mut record)?;
         crate::telemetry::track(
             "agent_spawned",
             serde_json::json!({

--- a/src-tauri/src/workspace/agents.rs
+++ b/src-tauri/src/workspace/agents.rs
@@ -5,6 +5,11 @@ use super::*;
 
 impl WorkspaceManager {
     pub fn allocate_agent_id(&self) -> Result<String> {
+        // DB-authoritative (see `live_agent_ids`); no filesystem check needed.
+        // Two instances of the same build share this DB, so a concurrent
+        // allocation race is resolved by the `workspaces.id` primary key: the
+        // loser's `add_agent` INSERT fails, and since insert precedes provision
+        // in the spawn path it never creates — or clears — a checkout dir.
         let used: HashSet<String> = self.live_agent_ids()?.into_iter().collect();
         Ok(names::allocate(&used))
     }

--- a/src-tauri/src/workspace/agents.rs
+++ b/src-tauri/src/workspace/agents.rs
@@ -4,40 +4,50 @@
 use super::*;
 
 impl WorkspaceManager {
-    pub fn allocate_agent_id(&self) -> Result<String> {
-        // DB-authoritative (see `live_agent_ids`); no filesystem check needed.
-        // Two instances of the same build share this DB, so a concurrent
-        // allocation race is resolved by the `workspaces.id` primary key: the
-        // loser's `add_agent` INSERT fails, and since insert precedes provision
-        // in the spawn path it never creates — or clears — a checkout dir.
-        let used: HashSet<String> = self.live_agent_ids()?.into_iter().collect();
-        Ok(names::allocate(&used))
-    }
-
-    /// Ids of every live (non-archived) agent — the only names that are
-    /// reserved. Archived agents have had their checkout torn down, so their
-    /// name is free to reuse. With a per-build checkouts root (see
-    /// `checkouts_root`) no other build shares this namespace, so the DB is
-    /// authoritative and allocation never consults the filesystem: a stale dir
-    /// from a crashed spawn or a failed teardown can't collide either, since
-    /// provision clears any leftover at the clone target.
-    pub fn live_agent_ids(&self) -> Result<Vec<String>> {
-        let conn = self.db.lock();
-        let mut stmt = conn.prepare("SELECT id FROM workspaces WHERE archived_at IS NULL")?;
-        let ids = stmt
-            .query_map([], |row| row.get::<_, String>(0))?
-            .filter_map(|r| r.ok())
-            .collect();
-        Ok(ids)
-    }
-
     pub fn add_agent(&self, record: &mut AgentRecord) -> Result<()> {
         let conn = self.db.lock();
+        Self::insert_agent(&conn, record)
+    }
 
+    /// Allocate a fresh name and insert the record under a *single* held lock.
+    ///
+    /// Allocation is DB-authoritative: the only reserved names are this build's
+    /// live (non-archived) rows. Archived agents have had their checkout torn
+    /// down, and each build has its own checkouts root (see `checkouts_root`),
+    /// so no other build shares this namespace and we never consult the
+    /// filesystem — a stale dir from a crashed spawn or a failed teardown can't
+    /// collide, since provision clears any leftover at the clone target.
+    ///
+    /// Reading the live set and inserting under one lock is what makes
+    /// concurrent spawns safe: a split (allocate, then insert in a separate
+    /// lock) would let a multi-threaded race pick the same free name and fail
+    /// the loser's INSERT on the `workspaces.id` primary key. Overwrites
+    /// `record.id`/`record.name`; callers that must keep a specific id (restore,
+    /// a draft-supplied name) use `add_agent`, where a clash is a real error.
+    pub fn add_agent_allocating(&self, record: &mut AgentRecord) -> Result<()> {
+        let conn = self.db.lock();
+        // Read live names on the *same* connection the insert uses — routing
+        // through `live_agent_ids` would re-lock and deadlock, and holding one
+        // lock across the read + insert is exactly what closes the race.
+        let live: HashSet<String> = {
+            let mut stmt = conn.prepare("SELECT id FROM workspaces WHERE archived_at IS NULL")?;
+            let ids = stmt
+                .query_map([], |row| row.get::<_, String>(0))?
+                .filter_map(|r| r.ok())
+                .collect();
+            ids
+        };
+        let id = names::allocate(&live);
+        record.name = id.clone();
+        record.id = id;
+        Self::insert_agent(&conn, record)
+    }
+
+    fn insert_agent(conn: &rusqlite::Connection, record: &mut AgentRecord) -> Result<()> {
         // Look up project_id from the primary repo path.
         let project_id = if let Some(primary) = record.repos.first() {
             let path_str = primary.repo_path.to_string_lossy().to_string();
-            Self::project_id_for_repo_path(&conn, &path_str)?
+            Self::project_id_for_repo_path(conn, &path_str)?
         } else {
             return Err(Error::Other("agent must have at least one repo".into()));
         };

--- a/src-tauri/src/workspace/agents.rs
+++ b/src-tauri/src/workspace/agents.rs
@@ -6,10 +6,13 @@ use super::*;
 impl WorkspaceManager {
     pub fn add_agent(&self, record: &mut AgentRecord) -> Result<()> {
         let conn = self.db.lock();
-        Self::insert_agent(&conn, record)
+        let tx = conn.unchecked_transaction()?;
+        Self::insert_agent(&tx, record)?;
+        tx.commit()?;
+        Ok(())
     }
 
-    /// Allocate a fresh name and insert the record under a *single* held lock.
+    /// Allocate a fresh name and insert the record in one serialized transaction.
     ///
     /// Allocation is DB-authoritative: the only reserved names are this build's
     /// live (non-archived) rows. Archived agents have had their checkout torn
@@ -18,19 +21,21 @@ impl WorkspaceManager {
     /// filesystem — a stale dir from a crashed spawn or a failed teardown can't
     /// collide, since provision clears any leftover at the clone target.
     ///
-    /// Reading the live set and inserting under one lock is what makes
-    /// concurrent spawns safe: a split (allocate, then insert in a separate
-    /// lock) would let a multi-threaded race pick the same free name and fail
-    /// the loser's INSERT on the `workspaces.id` primary key. Overwrites
-    /// `record.id`/`record.name`; callers that must keep a specific id (restore,
-    /// a draft-supplied name) use `add_agent`, where a clash is a real error.
+    /// The live-name read and the insert run in a single `IMMEDIATE`
+    /// transaction, so allocation is serialized by the database's write lock —
+    /// the one coordinator threads *and* separate processes share. Two instances
+    /// of the same build hold separate connections the in-process mutex can't
+    /// coordinate, but `IMMEDIATE` takes the write lock up front, so a second
+    /// allocator waits (WAL + `busy_timeout`), then reads the committed set and
+    /// picks a distinct name. No `workspaces.id` conflict can arise, so there is
+    /// nothing to retry. Overwrites `record.id`/`record.name`; callers that must
+    /// keep a specific id (restore, a draft-supplied name) use `add_agent`,
+    /// where a clash is a real error.
     pub fn add_agent_allocating(&self, record: &mut AgentRecord) -> Result<()> {
-        let conn = self.db.lock();
-        // Read live names on the *same* connection the insert uses — routing
-        // through `live_agent_ids` would re-lock and deadlock, and holding one
-        // lock across the read + insert is exactly what closes the race.
+        let mut conn = self.db.lock();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
         let live: HashSet<String> = {
-            let mut stmt = conn.prepare("SELECT id FROM workspaces WHERE archived_at IS NULL")?;
+            let mut stmt = tx.prepare("SELECT id FROM workspaces WHERE archived_at IS NULL")?;
             let ids = stmt
                 .query_map([], |row| row.get::<_, String>(0))?
                 .filter_map(|r| r.ok())
@@ -40,14 +45,20 @@ impl WorkspaceManager {
         let id = names::allocate(&live);
         record.name = id.clone();
         record.id = id;
-        Self::insert_agent(&conn, record)
+        Self::insert_agent(&tx, record)?;
+        tx.commit()?;
+        Ok(())
     }
 
-    fn insert_agent(conn: &rusqlite::Connection, record: &mut AgentRecord) -> Result<()> {
+    /// Write the workspace + session + worktree rows for a new agent. Runs
+    /// inside the caller's transaction — which also scopes name allocation in
+    /// `add_agent_allocating` — so the recycle-delete and every insert commit
+    /// (or roll back) as one unit.
+    fn insert_agent(tx: &rusqlite::Transaction, record: &mut AgentRecord) -> Result<()> {
         // Look up project_id from the primary repo path.
         let project_id = if let Some(primary) = record.repos.first() {
             let path_str = primary.repo_path.to_string_lossy().to_string();
-            Self::project_id_for_repo_path(conn, &path_str)?
+            Self::project_id_for_repo_path(tx, &path_str)?
         } else {
             return Err(Error::Other("agent must have at least one repo".into()));
         };
@@ -57,14 +68,6 @@ impl WorkspaceManager {
         let created_millis = chrono::DateTime::parse_from_rfc3339(&record.created_at)
             .map(|dt| dt.timestamp_millis())
             .unwrap_or_else(|_| now_millis());
-
-        // Evicting the recycled archived row and writing its replacement must be
-        // atomic. Without a transaction the DELETE auto-commits immediately, so
-        // any later failure (a failed INSERT, disk-full, UUID collision) would
-        // leave the archived agent — and its cascaded sessions/worktrees —
-        // permanently gone with nothing in its place. The transaction rolls the
-        // DELETE back on any error before `commit`.
-        let tx = conn.unchecked_transaction()?;
 
         // Recycling a freed name: the allocator only hands back ids held by
         // *archived* agents (live ones and on-disk checkouts are excluded), but
@@ -126,10 +129,9 @@ impl WorkspaceManager {
 
         // Insert checkout records for each TrackedRepo.
         for repo in &record.repos {
-            Self::insert_worktree(&tx, &record.id, repo)?;
+            Self::insert_worktree(tx, &record.id, repo)?;
         }
 
-        tx.commit()?;
         Ok(())
     }
 

--- a/src-tauri/src/workspace/agents.rs
+++ b/src-tauri/src/workspace/agents.rs
@@ -5,21 +5,25 @@ use super::*;
 
 impl WorkspaceManager {
     pub fn allocate_agent_id(&self) -> Result<String> {
+        let used: HashSet<String> = self.live_agent_ids()?.into_iter().collect();
+        Ok(names::allocate(&used))
+    }
+
+    /// Ids of every live (non-archived) agent — the only names that are
+    /// reserved. Archived agents have had their checkout torn down, so their
+    /// name is free to reuse. With a per-build checkouts root (see
+    /// `checkouts_root`) no other build shares this namespace, so the DB is
+    /// authoritative and allocation never consults the filesystem: a stale dir
+    /// from a crashed spawn or a failed teardown can't collide either, since
+    /// provision clears any leftover at the clone target.
+    pub fn live_agent_ids(&self) -> Result<Vec<String>> {
         let conn = self.db.lock();
-        // Only *live* (non-archived) agents reserve their name. Once an agent
-        // is archived its checkout is torn down, so the name is free to reuse —
-        // unless a directory still lingers on disk (cleanup failed, or it
-        // belongs to another running instance such as a dev build, which shares
-        // this same checkouts root). The on-disk listing closes that gap: it's
-        // the only namespace shared across every Fletch process on the machine,
-        // so a collision there is what actually breaks `git worktree add`.
         let mut stmt = conn.prepare("SELECT id FROM workspaces WHERE archived_at IS NULL")?;
-        let mut used: HashSet<String> = stmt
+        let ids = stmt
             .query_map([], |row| row.get::<_, String>(0))?
             .filter_map(|r| r.ok())
             .collect();
-        used.extend(occupied_checkout_dirs());
-        Ok(names::allocate(&used))
+        Ok(ids)
     }
 
     pub fn add_agent(&self, record: &mut AgentRecord) -> Result<()> {

--- a/src-tauri/src/workspace/mod.rs
+++ b/src-tauri/src/workspace/mod.rs
@@ -28,8 +28,8 @@ mod turns;
 
 pub use factory::{is_per_turn_provider, new_agent_record};
 pub use paths::{
-    agent_parent_dir, allocate_repo_subdir, migrate_default_checkouts_root, occupied_checkout_dirs,
-    projects_root, repo_checkout_path, tools_root, WORKSPACES_ROOT_ENV,
+    agent_parent_dir, allocate_repo_subdir, migrate_default_checkouts_root, projects_root,
+    repo_checkout_path, tools_root, WORKSPACES_ROOT_ENV,
 };
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src-tauri/src/workspace/paths.rs
+++ b/src-tauri/src/workspace/paths.rs
@@ -35,22 +35,39 @@ pub fn allocate_repo_subdir(repo_path: &Path, used: &[String]) -> String {
 /// `sandbox::nested_checkouts_root`. Mirrors `rpc::RPC_ROOT_ENV`.
 pub const WORKSPACES_ROOT_ENV: &str = "FLETCH_WORKSPACES_ROOT";
 
-/// Absolute path to the root holding every agent's checkouts:
-/// `~/.fletch/workspaces/`. Shared by *all* Fletch processes on the machine
-/// (release and dev builds alike — only the database is namespaced per build),
-/// which is why name allocation has to consult it directly. `$FLETCH_WORKSPACES_ROOT`
-/// overrides it when set and non-empty (nested-Fletch Run redirect).
+/// Absolute path to the root holding this build's agent checkouts —
+/// `~/.fletch/workspaces/` (release) or `~/.fletch/dev/workspaces/` (debug).
+///
+/// The per-build split is what lets name allocation be DB-authoritative: each
+/// build gets an *exclusive* root, so a name freed in one build's DB can be
+/// reused without the filesystem colliding with another build, and provision
+/// can safely clear a leftover dir (it can only ever be this build's own
+/// crash-orphan). `$FLETCH_WORKSPACES_ROOT` redirects the *base* (nested-Fletch
+/// Run, whose sandbox denies the host's `~/.fletch`) — but the build subpath is
+/// still appended, so the override can't bypass the split: two different builds
+/// pointed at the same override still land in separate roots, preserving that
+/// exclusivity invariant.
 pub fn checkouts_root() -> Result<PathBuf> {
-    if let Some(root) = std::env::var_os(WORKSPACES_ROOT_ENV).filter(|v| !v.is_empty()) {
-        return Ok(PathBuf::from(root));
-    }
-    let home =
-        dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
-    Ok(home.join(".fletch").join(build_workspaces_subpath()))
+    let base = match std::env::var_os(WORKSPACES_ROOT_ENV).filter(|v| !v.is_empty()) {
+        Some(root) => PathBuf::from(root),
+        None => dirs::home_dir()
+            .ok_or_else(|| Error::Other("HOME directory not available".into()))?
+            .join(".fletch"),
+    };
+    Ok(checkouts_root_in(&base))
 }
 
-/// The workspaces path segment(s) under `~/.fletch`, split per build so a debug
-/// instance never shares the checkout namespace with a release install. Release
+/// Apply the per-build split to a checkouts base. Split out so it's testable
+/// without mutating the process-global override env var — and to keep the
+/// override and default paths sharing the exact same "append the build subpath"
+/// step, so neither can drift into bypassing the split.
+pub(super) fn checkouts_root_in(base: &Path) -> PathBuf {
+    base.join(build_workspaces_subpath())
+}
+
+/// The workspaces path segment(s) under the checkouts base (`~/.fletch` or the
+/// `$FLETCH_WORKSPACES_ROOT` override), split per build so a debug instance
+/// never shares the checkout namespace with a release install. Release
 /// keeps the historical flat `workspaces/` (so existing installs need no
 /// migration); debug builds get a sibling `dev/workspaces/` root, mirroring the
 /// `dev` split `data_dir` already uses for app data.

--- a/src-tauri/src/workspace/paths.rs
+++ b/src-tauri/src/workspace/paths.rs
@@ -54,7 +54,7 @@ pub fn checkouts_root() -> Result<PathBuf> {
 /// keeps the historical flat `workspaces/` (so existing installs need no
 /// migration); debug builds get a sibling `dev/workspaces/` root, mirroring the
 /// `dev` split `data_dir` already uses for app data.
-fn build_workspaces_subpath() -> PathBuf {
+pub(super) fn build_workspaces_subpath() -> PathBuf {
     if cfg!(debug_assertions) {
         PathBuf::from("dev").join("workspaces")
     } else {

--- a/src-tauri/src/workspace/paths.rs
+++ b/src-tauri/src/workspace/paths.rs
@@ -46,7 +46,20 @@ pub fn checkouts_root() -> Result<PathBuf> {
     }
     let home =
         dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
-    Ok(home.join(".fletch").join("workspaces"))
+    Ok(home.join(".fletch").join(build_workspaces_subpath()))
+}
+
+/// The workspaces path segment(s) under `~/.fletch`, split per build so a debug
+/// instance never shares the checkout namespace with a release install. Release
+/// keeps the historical flat `workspaces/` (so existing installs need no
+/// migration); debug builds get a sibling `dev/workspaces/` root, mirroring the
+/// `dev` split `data_dir` already uses for app data.
+fn build_workspaces_subpath() -> PathBuf {
+    if cfg!(debug_assertions) {
+        PathBuf::from("dev").join("workspaces")
+    } else {
+        PathBuf::from("workspaces")
+    }
 }
 
 /// Env var overriding the tools root (default `~/.fletch/tools`). Same style as
@@ -83,28 +96,6 @@ pub fn projects_root() -> Result<PathBuf> {
     let home =
         dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
     Ok(home.join(".fletch").join("projects"))
-}
-
-/// The set of agent-id directories that physically exist under the checkouts
-/// root. These are off-limits as new agent ids regardless of what any single
-/// database knows: the directory is the resource `git worktree add` collides
-/// on. Best-effort — a missing or unreadable root just yields an empty set.
-pub fn occupied_checkout_dirs() -> HashSet<String> {
-    match checkouts_root() {
-        Ok(root) => occupied_checkout_dirs_in(&root),
-        Err(_) => HashSet::new(),
-    }
-}
-
-pub(super) fn occupied_checkout_dirs_in(root: &Path) -> HashSet<String> {
-    let Ok(entries) = std::fs::read_dir(root) else {
-        return HashSet::new();
-    };
-    entries
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
-        .filter_map(|e| e.file_name().into_string().ok())
-        .collect()
 }
 
 /// Absolute path to the dir holding all of one agent's checkouts:

--- a/src-tauri/src/workspace/tests.rs
+++ b/src-tauri/src/workspace/tests.rs
@@ -1,4 +1,4 @@
-use super::paths::migrate_checkouts_root_in;
+use super::paths::{build_workspaces_subpath, migrate_checkouts_root_in};
 use super::*;
 
 /// The one branch that mutates on-disk state: legacy dir present, new dir
@@ -1812,6 +1812,18 @@ fn allocate_subdir_handles_collision() {
         allocate_repo_subdir(Path::new("/foo/fresh"), &used),
         "fresh"
     );
+}
+
+#[test]
+fn build_workspaces_subpath_splits_debug_from_release() {
+    // The per-build split keeps a debug instance's checkouts out of the release
+    // install's flat root. Tests compile with debug_assertions on.
+    let sub = build_workspaces_subpath();
+    if cfg!(debug_assertions) {
+        assert_eq!(sub, std::path::PathBuf::from("dev").join("workspaces"));
+    } else {
+        assert_eq!(sub, std::path::PathBuf::from("workspaces"));
+    }
 }
 
 /// Mark a workspace archived directly (tests don't go through the full

--- a/src-tauri/src/workspace/tests.rs
+++ b/src-tauri/src/workspace/tests.rs
@@ -1,4 +1,4 @@
-use super::paths::{build_workspaces_subpath, migrate_checkouts_root_in};
+use super::paths::{build_workspaces_subpath, checkouts_root_in, migrate_checkouts_root_in};
 use super::*;
 
 /// The one branch that mutates on-disk state: legacy dir present, new dir
@@ -1812,6 +1812,19 @@ fn allocate_subdir_handles_collision() {
         allocate_repo_subdir(Path::new("/foo/fresh"), &used),
         "fresh"
     );
+}
+
+#[test]
+fn override_base_still_gets_the_build_split() {
+    // A redirected base (`$FLETCH_WORKSPACES_ROOT`, nested-Fletch Run) must not
+    // bypass the per-build split: without it, two different builds sharing the
+    // same override would land in one root, allocate the same id from their
+    // separate DBs, and provision would clobber the other build's live checkout.
+    let base = std::path::Path::new("/tmp/shared-override");
+    let root = checkouts_root_in(base);
+    assert!(root.starts_with(base));
+    assert!(root.ends_with(build_workspaces_subpath()));
+    assert_ne!(root, base, "the build subpath must be appended, not bypassed");
 }
 
 #[test]

--- a/src-tauri/src/workspace/tests.rs
+++ b/src-tauri/src/workspace/tests.rs
@@ -1824,7 +1824,10 @@ fn override_base_still_gets_the_build_split() {
     let root = checkouts_root_in(base);
     assert!(root.starts_with(base));
     assert!(root.ends_with(build_workspaces_subpath()));
-    assert_ne!(root, base, "the build subpath must be appended, not bypassed");
+    assert_ne!(
+        root, base,
+        "the build subpath must be appended, not bypassed"
+    );
 }
 
 #[test]

--- a/src-tauri/src/workspace/tests.rs
+++ b/src-tauri/src/workspace/tests.rs
@@ -1926,12 +1926,12 @@ fn add_agent_does_not_evict_a_live_name_clash() {
 }
 
 #[test]
-fn allocate_agent_id_excludes_archived_from_reservation() {
+fn add_agent_allocating_excludes_archived_from_reservation() {
     let db = test_db();
     seed_repo(&db, "/r");
     let wm = WorkspaceManager::new(db.clone());
 
-    // Fill the whole pool with archived agents, then one live agent.
+    // Fill the whole pool with archived agents.
     for place in names::PLACES {
         let mut rec = new_agent_record(
             (*place).into(),
@@ -1945,11 +1945,48 @@ fn allocate_agent_id_excludes_archived_from_reservation() {
         mark_archived(&db, place);
     }
 
-    // Every pool name is archived (so all are reusable) — the allocator
-    // should hand back a bare pool name, never a "-N" exhaustion suffix.
-    let id = wm.allocate_agent_id().unwrap();
-    assert!(
-        names::PLACES.contains(&id.as_str()),
-        "expected a reusable pool name, got {id}"
+    // Every pool name is archived (so all are reusable) — allocation should
+    // hand back a bare pool name, never a "-N" exhaustion suffix, evicting the
+    // archived row it reuses.
+    let mut rec = new_agent_record(
+        String::new(),
+        String::new(),
+        "claude".into(),
+        mk_repo("/r"),
+        String::new(),
+        AgentView::Custom,
     );
+    wm.add_agent_allocating(&mut rec).unwrap();
+    assert!(
+        names::PLACES.contains(&rec.id.as_str()),
+        "expected a reusable pool name, got {}",
+        rec.id
+    );
+}
+
+#[test]
+fn add_agent_allocating_assigns_distinct_live_names() {
+    let db = test_db();
+    seed_repo(&db, "/r");
+    let wm = WorkspaceManager::new(db);
+
+    // The second allocation sees the first as a live row and must pick another
+    // name — allocation and insert happen under one lock, so no two live agents
+    // can share a name.
+    let mk = || {
+        new_agent_record(
+            String::new(),
+            String::new(),
+            "claude".into(),
+            mk_repo("/r"),
+            String::new(),
+            AgentView::Custom,
+        )
+    };
+    let mut a = mk();
+    let mut b = mk();
+    wm.add_agent_allocating(&mut a).unwrap();
+    wm.add_agent_allocating(&mut b).unwrap();
+    assert!(!a.id.is_empty() && !b.id.is_empty());
+    assert_ne!(a.id, b.id, "two live agents must not share a name");
 }

--- a/src-tauri/src/workspace/tests.rs
+++ b/src-tauri/src/workspace/tests.rs
@@ -1,4 +1,4 @@
-use super::paths::{migrate_checkouts_root_in, occupied_checkout_dirs_in};
+use super::paths::migrate_checkouts_root_in;
 use super::*;
 
 /// The one branch that mutates on-disk state: legacy dir present, new dir
@@ -1812,28 +1812,6 @@ fn allocate_subdir_handles_collision() {
         allocate_repo_subdir(Path::new("/foo/fresh"), &used),
         "fresh"
     );
-}
-
-#[test]
-fn occupied_checkout_dirs_lists_only_subdirs() {
-    let root = tempfile::tempdir().unwrap();
-    std::fs::create_dir_all(root.path().join("kilimanjaro")).unwrap();
-    std::fs::create_dir_all(root.path().join("seychelles")).unwrap();
-    // A stray file (not a dir) must not be reported as an occupied name.
-    std::fs::write(root.path().join("notes.txt"), b"x").unwrap();
-
-    let found = occupied_checkout_dirs_in(root.path());
-    assert_eq!(found.len(), 2);
-    assert!(found.contains("kilimanjaro"));
-    assert!(found.contains("seychelles"));
-    assert!(!found.contains("notes.txt"));
-}
-
-#[test]
-fn occupied_checkout_dirs_empty_when_root_missing() {
-    let root = tempfile::tempdir().unwrap();
-    let missing = root.path().join("does-not-exist");
-    assert!(occupied_checkout_dirs_in(&missing).is_empty());
 }
 
 /// Mark a workspace archived directly (tests don't go through the full


### PR DESCRIPTION
Supersedes #500 (its head got stuck after a force-push; GitHub wouldn't re-sync or reopen it — same branch, same work).

## Problem

Workspace names come from a fixed ~300-name pool; the allocator appends `-2`, `-3`, … when a base name is taken. A name counted as taken if a directory with that name existed under `~/.fletch/workspaces/` — a root **shared by every Fletch build on the machine** (dev + release). Teardown was best-effort and swallowed failures, so a checkout dir left behind by a failed teardown reserved its name forever, and as leaks piled up across builds the allocator was forced into `-2` suffixes (e.g. `iguazu-2`).

## Fix — fix the model, not the symptom

- **Per-build checkouts root.** Release keeps the historical flat `~/.fletch/workspaces/` (no migration); debug builds get their own sibling `~/.fletch/dev/workspaces/`, mirroring the `dev` split `data_dir` already uses. Builds no longer share a checkout namespace.
- **DB-authoritative allocation.** Name allocation consults only live rows in this build's DB. All filesystem-based name reservation is gone (`occupied_checkout_dirs` deleted).
- **Safe by construction.** Provision already clears any leftover dir at the clone target, so a stale dir from a crashed spawn or a failed teardown can't collide or force a `-2` — a lingering dir is only wasted disk.
- **Atomic allocate + insert.** `add_agent_allocating` reads the live names and writes the row under a *single* held lock, so concurrent spawns (tokio is multi-threaded; workflows fan out agents) can't pick the same free name and fail the loser's INSERT on the `workspaces.id` primary key. Pinned names (restore / draft) still go through `add_agent`, where a clash is a real error. (This race pre-dated the PR — the old allocate-then-insert split had the same gap — but it lives in the allocation code reworked here.)
- **Teardown** keeps a bounded retry + loud logging on parent-dir removal (handles the transient open-handle case right after shutdown); it's now hygiene, not correctness.

No markers, no reconcile sweep, no migration.

## Known / accepted trade-off

A debug build that upgrades looks in `~/.fletch/dev/workspaces` and won't find agents whose checkouts sit in the old flat root. This is dev-only, non-destructive (old checkouts remain on disk), and production is unaffected — accepted deliberately (no migration).

## Testing

`cargo fmt --check` clean; `cargo clippy --all-targets -D warnings` clean; `cargo test` green (990 lib tests, incl. new per-build-subpath and atomic-allocation coverage).