### PR TITLE
fix(git-panel): stop showing false "can't merge yet" for mergeable PRs

### DIFF
--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -31,12 +31,12 @@ pub(crate) fn parse_pr_state(node: &Value) -> PrState {
         // distinct from a real conflict (Conflicting).
         mergeable: if node["state"].as_str() == Some("OPEN") {
             match node["mergeable"].as_str() {
-                Some("MERGEABLE") => Mergeable::Mergeable,
-                Some("CONFLICTING") => Mergeable::Conflicting,
-                _ => Mergeable::Unknown,
+                Some("MERGEABLE") => MergeableState::Mergeable,
+                Some("CONFLICTING") => MergeableState::Conflicting,
+                _ => MergeableState::Unknown,
             }
         } else {
-            Mergeable::Unknown
+            MergeableState::Unknown
         },
         opened_at: gh_time_ms(node, "createdAt"),
         merged_at: gh_time_ms(node, "mergedAt"),
@@ -375,7 +375,7 @@ mod tests {
     fn pr_state_open_mergeable() {
         let pr = parse_pr_state(&pr_node("OPEN", 42, "MERGEABLE"));
         assert!(matches!(pr.state, PrStatus::Open));
-        assert_eq!(pr.mergeable, Mergeable::Mergeable);
+        assert_eq!(pr.mergeable, MergeableState::Mergeable);
         assert_eq!(pr.number, 42);
     }
 
@@ -384,19 +384,19 @@ mod tests {
         // The whole point of the tri-state: CONFLICTING (a real conflict) must
         // not read the same as UNKNOWN (GitHub hasn't computed it yet).
         let conflicting = parse_pr_state(&pr_node("OPEN", 7, "CONFLICTING"));
-        assert_eq!(conflicting.mergeable, Mergeable::Conflicting);
+        assert_eq!(conflicting.mergeable, MergeableState::Conflicting);
         let unknown = parse_pr_state(&pr_node("OPEN", 8, "UNKNOWN"));
-        assert_eq!(unknown.mergeable, Mergeable::Unknown);
+        assert_eq!(unknown.mergeable, MergeableState::Unknown);
     }
 
     #[test]
     fn pr_state_merged_and_closed_are_never_mergeable() {
         let merged = parse_pr_state(&pr_node("MERGED", 1, "MERGEABLE"));
         assert!(matches!(merged.state, PrStatus::Merged));
-        assert_eq!(merged.mergeable, Mergeable::Unknown);
+        assert_eq!(merged.mergeable, MergeableState::Unknown);
         let closed = parse_pr_state(&pr_node("CLOSED", 2, "UNKNOWN"));
         assert!(matches!(closed.state, PrStatus::Closed));
-        assert_eq!(closed.mergeable, Mergeable::Unknown);
+        assert_eq!(closed.mergeable, MergeableState::Unknown);
     }
 
     #[test]

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -26,8 +26,18 @@ pub(crate) fn parse_pr_state(node: &Value) -> PrState {
             _ => PrStatus::Open,
         },
         title: node["title"].as_str().unwrap_or_default().to_string(),
-        mergeable: node["state"].as_str() == Some("OPEN")
-            && node["mergeable"].as_str() == Some("MERGEABLE"),
+        // Only an OPEN PR has a meaningful mergeability; carry GitHub's
+        // tri-state verdict through so "not computed yet" (Unknown) stays
+        // distinct from a real conflict (Conflicting).
+        mergeable: if node["state"].as_str() == Some("OPEN") {
+            match node["mergeable"].as_str() {
+                Some("MERGEABLE") => Mergeable::Mergeable,
+                Some("CONFLICTING") => Mergeable::Conflicting,
+                _ => Mergeable::Unknown,
+            }
+        } else {
+            Mergeable::Unknown
+        },
         opened_at: gh_time_ms(node, "createdAt"),
         merged_at: gh_time_ms(node, "mergedAt"),
     }
@@ -365,18 +375,28 @@ mod tests {
     fn pr_state_open_mergeable() {
         let pr = parse_pr_state(&pr_node("OPEN", 42, "MERGEABLE"));
         assert!(matches!(pr.state, PrStatus::Open));
-        assert!(pr.mergeable);
+        assert_eq!(pr.mergeable, Mergeable::Mergeable);
         assert_eq!(pr.number, 42);
+    }
+
+    #[test]
+    fn pr_state_open_carries_conflicting_and_unknown_distinctly() {
+        // The whole point of the tri-state: CONFLICTING (a real conflict) must
+        // not read the same as UNKNOWN (GitHub hasn't computed it yet).
+        let conflicting = parse_pr_state(&pr_node("OPEN", 7, "CONFLICTING"));
+        assert_eq!(conflicting.mergeable, Mergeable::Conflicting);
+        let unknown = parse_pr_state(&pr_node("OPEN", 8, "UNKNOWN"));
+        assert_eq!(unknown.mergeable, Mergeable::Unknown);
     }
 
     #[test]
     fn pr_state_merged_and_closed_are_never_mergeable() {
         let merged = parse_pr_state(&pr_node("MERGED", 1, "MERGEABLE"));
         assert!(matches!(merged.state, PrStatus::Merged));
-        assert!(!merged.mergeable);
+        assert_eq!(merged.mergeable, Mergeable::Unknown);
         let closed = parse_pr_state(&pr_node("CLOSED", 2, "UNKNOWN"));
         assert!(matches!(closed.state, PrStatus::Closed));
-        assert!(!closed.mergeable);
+        assert_eq!(closed.mergeable, Mergeable::Unknown);
     }
 
     #[test]

--- a/src-tauri/src/github/types.rs
+++ b/src-tauri/src/github/types.rs
@@ -39,7 +39,7 @@ impl PrStatus {
 /// claim "can't merge — update your branch" for perfectly mergeable PRs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum Mergeable {
+pub enum MergeableState {
     Mergeable,
     Conflicting,
     Unknown,
@@ -51,7 +51,7 @@ pub struct PrState {
     pub url: String,
     pub state: PrStatus,
     pub title: String,
-    pub mergeable: Mergeable,
+    pub mergeable: MergeableState,
     /// GitHub's createdAt / mergedAt as ms-epoch, when reported. Stamped onto
     /// `worktrees.pr_opened_at/pr_merged_at` by every PR-state fetch path so
     /// per-day PR history accrues locally (see `record_pr_times`).

--- a/src-tauri/src/github/types.rs
+++ b/src-tauri/src/github/types.rs
@@ -31,13 +31,27 @@ impl PrStatus {
     }
 }
 
+/// GitHub's coarse `mergeable` verdict — the *only* merge signal when the
+/// richer `MergeState` (from `mergeStateStatus`) is unavailable. Deliberately
+/// tri-state: GitHub computes mergeability lazily, so `Unknown` ("not computed
+/// yet", normal for a while after any push) must stay distinct from
+/// `Conflicting` (a real conflict) — collapsing both to a bool made the panel
+/// claim "can't merge — update your branch" for perfectly mergeable PRs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Mergeable {
+    Mergeable,
+    Conflicting,
+    Unknown,
+}
+
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct PrState {
     pub number: u32,
     pub url: String,
     pub state: PrStatus,
     pub title: String,
-    pub mergeable: bool,
+    pub mergeable: Mergeable,
     /// GitHub's createdAt / mergedAt as ms-epoch, when reported. Stamped onto
     /// `worktrees.pr_opened_at/pr_merged_at` by every PR-state fetch path so
     /// per-day PR history accrues locally (see `record_pr_times`).

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use tauri::AppHandle;
 
 use crate::agent::per_turn_descriptor;
-use crate::github::{Mergeable, PrState, PrStatus};
+use crate::github::{MergeableState, PrState, PrStatus};
 use crate::workspace::{repo_checkout_path, AgentRecord, AgentView, TrackedRepo, WorkspaceManager};
 
 use super::events::{
@@ -192,7 +192,7 @@ pub(crate) fn pr_snapshot(repo: &TrackedRepo) -> Option<PrState> {
         url: repo.pr_url.clone().unwrap_or_default(),
         state,
         title: repo.pr_title.clone().unwrap_or_default(),
-        mergeable: Mergeable::Unknown,
+        mergeable: MergeableState::Unknown,
         opened_at: None,
         merged_at: None,
     })
@@ -1182,7 +1182,7 @@ mod tests {
         assert!(matches!(pr.state, PrStatus::Merged));
         assert_eq!(
             pr.mergeable,
-            Mergeable::Unknown,
+            MergeableState::Unknown,
             "mergeable isn't persisted — must read Unknown, never a fabricated verdict"
         );
     }

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use tauri::AppHandle;
 
 use crate::agent::per_turn_descriptor;
-use crate::github::{PrState, PrStatus};
+use crate::github::{Mergeable, PrState, PrStatus};
 use crate::workspace::{repo_checkout_path, AgentRecord, AgentView, TrackedRepo, WorkspaceManager};
 
 use super::events::{
@@ -180,8 +180,10 @@ impl Supervisor {
 /// The last persisted state of a repo's bound PR, rebuilt from its database
 /// columns — what the UI shows when GitHub or the checkout is unavailable.
 /// `None` when no PR is bound or no fetch has ever succeeded (state column
-/// still NULL). `mergeable` isn't persisted and reads `false`; it only means
-/// anything while an open PR is being polled live.
+/// still NULL). `mergeable` isn't persisted and reads `Unknown` — a snapshot
+/// carries no merge verdict, and `Unknown` (not `Conflicting`) is the honest
+/// stand-in so the panel says "checking…" rather than falsely claiming a
+/// conflict. It only means anything while an open PR is being polled live.
 pub(crate) fn pr_snapshot(repo: &TrackedRepo) -> Option<PrState> {
     let number = repo.pr_number?;
     let state = PrStatus::parse(repo.pr_state.as_deref()?)?;
@@ -190,7 +192,7 @@ pub(crate) fn pr_snapshot(repo: &TrackedRepo) -> Option<PrState> {
         url: repo.pr_url.clone().unwrap_or_default(),
         state,
         title: repo.pr_title.clone().unwrap_or_default(),
-        mergeable: false,
+        mergeable: Mergeable::Unknown,
         opened_at: None,
         merged_at: None,
     })
@@ -1178,7 +1180,11 @@ mod tests {
         assert_eq!(pr.url, "https://github.com/o/r/pull/42");
         assert_eq!(pr.title, "feat: x");
         assert!(matches!(pr.state, PrStatus::Merged));
-        assert!(!pr.mergeable, "mergeable isn't persisted — must read false");
+        assert_eq!(
+            pr.mergeable,
+            Mergeable::Unknown,
+            "mergeable isn't persisted — must read Unknown, never a fabricated verdict"
+        );
     }
 
     /// No bound number, no persisted state, or an unknown state string all

--- a/src-tauri/src/workspace/tests.rs
+++ b/src-tauri/src/workspace/tests.rs
@@ -1102,7 +1102,7 @@ fn pr_snapshot_persists_and_loads() {
         url: "https://github.com/o/r/pull/42".into(),
         title: "feat: thing".into(),
         state: crate::github::PrStatus::Open,
-        mergeable: crate::github::Mergeable::Mergeable,
+        mergeable: crate::github::MergeableState::Mergeable,
         opened_at: Some(1_000),
         merged_at: None,
     };
@@ -1119,7 +1119,7 @@ fn pr_snapshot_persists_and_loads() {
     // Merge lands; a payload without opened_at keeps the earlier value.
     let merged = crate::github::PrState {
         state: crate::github::PrStatus::Merged,
-        mergeable: crate::github::Mergeable::Unknown,
+        mergeable: crate::github::MergeableState::Unknown,
         opened_at: None,
         merged_at: Some(2_000),
         ..open

--- a/src-tauri/src/workspace/tests.rs
+++ b/src-tauri/src/workspace/tests.rs
@@ -1102,7 +1102,7 @@ fn pr_snapshot_persists_and_loads() {
         url: "https://github.com/o/r/pull/42".into(),
         title: "feat: thing".into(),
         state: crate::github::PrStatus::Open,
-        mergeable: true,
+        mergeable: crate::github::Mergeable::Mergeable,
         opened_at: Some(1_000),
         merged_at: None,
     };
@@ -1119,7 +1119,7 @@ fn pr_snapshot_persists_and_loads() {
     // Merge lands; a payload without opened_at keeps the earlier value.
     let merged = crate::github::PrState {
         state: crate::github::PrStatus::Merged,
-        mergeable: false,
+        mergeable: crate::github::Mergeable::Unknown,
         opened_at: None,
         merged_at: Some(2_000),
         ..open

--- a/src/api/types/pr.ts
+++ b/src/api/types/pr.ts
@@ -1,11 +1,18 @@
 export type PrStatus = "open" | "merged" | "closed";
 
+/** GitHub's coarse `mergeable` verdict — the only merge signal when the richer
+ *  `MergeState` (from `mergeStateStatus`) is unavailable. Tri-state on purpose:
+ *  GitHub computes mergeability lazily, so `"unknown"` ("not computed yet",
+ *  normal for a while after any push) must stay distinct from `"conflicting"`
+ *  (a real conflict) — see mergeGate's no-checks fallback. */
+export type Mergeable = "mergeable" | "conflicting" | "unknown";
+
 export interface PrState {
   number: number;
   url: string;
   state: PrStatus;
   title: string;
-  mergeable: boolean;
+  mergeable: Mergeable;
 }
 
 export interface PrStateChangedEvent {

--- a/src/components/RightPanel/GitPanel/StatusHeader.tsx
+++ b/src/components/RightPanel/GitPanel/StatusHeader.tsx
@@ -31,7 +31,6 @@ const HEADER_TEXT_BY_SITUATION: Record<
   draft: () => "draft",
   computing: () => "checking…",
   "no-conflicts": () => "no conflicts",
-  "cant-merge": () => "can’t merge yet",
 };
 
 interface HeaderInfo {
@@ -81,7 +80,7 @@ export function describeHeader(
       const pill = n != null ? `PR #${n}` : "PR";
       const gate = describeMergeGate(mergeState, {
         checksFailed,
-        mergeable: !!pr?.mergeable,
+        mergeable: pr?.mergeable ?? "unknown",
       });
       return {
         kind: HEADER_KIND_BY_TONE[gate.tone],

--- a/src/components/RightPanel/GitPanel/cards/PRCard.tsx
+++ b/src/components/RightPanel/GitPanel/cards/PRCard.tsx
@@ -20,10 +20,6 @@ const CARD_GATE_BY_SITUATION: Record<
   draft: { cls: "ok", text: () => "Draft — mark ready on GitHub to merge" },
   computing: { cls: "ok", text: () => "Computing merge status…" },
   "no-conflicts": { cls: "ok", text: () => "✓ No merge conflicts" },
-  "cant-merge": {
-    cls: "att",
-    text: (base) => `△ Can’t merge cleanly with ${base} — update your branch`,
-  },
 };
 
 export function PRCard({

--- a/src/components/RightPanel/GitPanel/hooks/useActionBarModel.ts
+++ b/src/components/RightPanel/GitPanel/hooks/useActionBarModel.ts
@@ -46,7 +46,7 @@ export function useActionBarModel(input: {
   const setGitCommitAction = useAppStore((s) => s.setGitCommitAction);
 
   const behind = gitState?.behind ?? 0;
-  const mergeable = prState?.mergeable ?? false;
+  const mergeable = prState?.mergeable ?? "unknown";
 
   const counts = {
     files: gitState?.files.length ?? 0,

--- a/src/components/RightPanel/delegation.ts
+++ b/src/components/RightPanel/delegation.ts
@@ -222,7 +222,7 @@ export function delegationResolved(
     case "update-branch":
       // `unknown` = GitHub still recomputing after a push — keep waiting.
       if (checks) return !["behind", "dirty", "unknown"].includes(checks.merge_state);
-      return pr?.mergeable === true;
+      return pr?.mergeable === "mergeable";
     case "fix-checks":
       return false;
   }

--- a/src/components/RightPanel/mergeGate.ts
+++ b/src/components/RightPanel/mergeGate.ts
@@ -1,4 +1,4 @@
-import type { MergeState } from "@/api";
+import type { Mergeable, MergeState } from "@/api";
 
 // ── Merge-gate semantics: the single source of truth ──────────────────────
 // GitHub's combined merge gate (`mergeStateStatus`, spec §6) feeds three
@@ -19,9 +19,8 @@ export type MergeGateSituation =
   | "behind" // behind base — update the branch
   | "conflicts" // dirty — conflicts with base, update the branch
   | "draft" // draft — mark ready on GitHub before it can merge
-  | "computing" // unknown/has_hooks — gate still resolving
-  | "no-conflicts" // no checks data, `mergeable` only → no conflicts (not an all-clear)
-  | "cant-merge"; // no checks data, not mergeable → can't merge yet
+  | "computing" // unknown/has_hooks, or no-checks + mergeable unknown — still resolving
+  | "no-conflicts"; // no checks data, `mergeable` says mergeable → no conflicts (not an all-clear)
 
 /** Shared severity. A subset of `StatusKind`/`HeaderKind` so every surface can
  *  derive its own tone class from one decision. */
@@ -42,9 +41,10 @@ export interface MergeGateContext {
   /** Number of failing required checks — splits `blocked` into agent-fixable
    *  (checks failing) vs. a pure review gate. */
   checksFailed: number;
-  /** `PrState.mergeable` — the only signal when `merge_state` is unavailable; it
-   *  reports the absence of conflicts, never CI status. */
-  mergeable: boolean;
+  /** `PrState.mergeable` — the only signal when `merge_state` is unavailable. A
+   *  tri-state that reports conflict presence, never CI status: `"unknown"`
+   *  means GitHub hasn't computed mergeability yet, NOT that it can't merge. */
+  mergeable: Mergeable;
 }
 
 /** Map GitHub's combined merge gate to the canonical situation + tone every
@@ -84,10 +84,29 @@ export function describeMergeGate(
     case "has_hooks":
       return { situation: "computing", tone: "info", mergeAllowed: false, needsUpdate: false };
     default:
-      // No checks data — `mergeable` only reports the absence of merge
-      // conflicts, NOT CI status, so claim no more than that.
-      return mergeable
-        ? { situation: "no-conflicts", tone: "info", mergeAllowed: true, needsUpdate: false }
-        : { situation: "cant-merge", tone: "attention", mergeAllowed: false, needsUpdate: true };
+      // No checks data — fall back to GitHub's coarse tri-state `mergeable`,
+      // which reports conflict presence only (never CI status). Crucially,
+      // only claim a conflict when GitHub actually reports one: `"unknown"`
+      // means "not computed yet" (normal for a while after any push, and the
+      // value a DB snapshot always carries), so render it as still-computing —
+      // never a false "can't merge — update your branch".
+      switch (mergeable) {
+        case "mergeable":
+          return {
+            situation: "no-conflicts",
+            tone: "info",
+            mergeAllowed: true,
+            needsUpdate: false,
+          };
+        case "conflicting":
+          return {
+            situation: "conflicts",
+            tone: "attention",
+            mergeAllowed: false,
+            needsUpdate: true,
+          };
+        default: // "unknown"
+          return { situation: "computing", tone: "info", mergeAllowed: false, needsUpdate: false };
+      }
   }
 }

--- a/src/components/RightPanel/primaryActions.ts
+++ b/src/components/RightPanel/primaryActions.ts
@@ -1,4 +1,4 @@
-import type { GitState, MergeState, PrState } from "@/api";
+import type { GitState, Mergeable, MergeState, PrState } from "@/api";
 import type { IconName } from "@/components/Icon";
 import { describeMergeGate } from "./mergeGate";
 
@@ -79,9 +79,10 @@ export interface ActionCounts {
   /** Changes state: the user opened the override field and typed a message, so
    *  the commit is direct (agent bypassed) rather than delegated. */
   customActive?: boolean;
-  /** PR-open state: whether GitHub reports the PR cleanly mergeable. Gates the
-   *  Merge CTA — when false the panel reads as "can't merge yet" (attention). */
-  mergeable?: boolean;
+  /** PR-open state: GitHub's coarse tri-state mergeability. The only merge
+   *  signal when `mergeState` is unavailable; `"unknown"` means not-yet-computed
+   *  (renders as "checking…"), only `"conflicting"` claims a real conflict. */
+  mergeable?: Mergeable;
   /** PR-open state: GitHub's combined merge gate (spec §6). Null/omitted =
    *  checks unavailable → fall back to `mergeable`-only behavior. */
   mergeState?: MergeState | null;
@@ -145,7 +146,7 @@ export function primaryFor(state: GitPanelState, counts?: ActionCounts): Primary
     prNumber,
     base = "main",
     customActive = false,
-    mergeable = false,
+    mergeable = "unknown",
     mergeState = null,
     checksFailed = 0,
     commitAction = "agent-commit-pr",
@@ -286,8 +287,10 @@ export function primaryFor(state: GitPanelState, counts?: ActionCounts): Primary
           // No checks data — `mergeable` only reports the absence of merge
           // conflicts, NOT CI status, so claim no more than that.
           return merge("no conflicts");
-        default: // cant-merge
-          return merge("can’t merge yet");
+        default:
+          // Defensive: a still-resolving gate renders as "checking…", never a
+          // false "can't merge" (the old cant-merge overclaim, now removed).
+          return merge("checking…");
       }
     }
     case "conflicts":
@@ -347,7 +350,7 @@ export function secondaryFor(state: GitPanelState, counts?: ActionCounts): Secon
     unpushed = 0,
     base = "main",
     customActive = false,
-    mergeable = false,
+    mergeable = "unknown",
     mergeState = null,
     checksFailed = 0,
     prOpen = false,

--- a/src/components/Workspace/MissionControl/queue.test.ts
+++ b/src/components/Workspace/MissionControl/queue.test.ts
@@ -39,7 +39,7 @@ const openPr = (number = 1): PrState => ({
   url: `https://gh/pr/${number}`,
   state: "open",
   title: "PR",
-  mergeable: true,
+  mergeable: "mergeable",
 });
 
 function checks(over: Partial<PrChecks>): PrChecks {

--- a/src/components/Workspace/MissionControl/useQueueActions.ts
+++ b/src/components/Workspace/MissionControl/useQueueActions.ts
@@ -120,7 +120,7 @@ export function useQueueActions(openReview: (runId: string) => void): QueueActio
         case "pr-open": {
           const gate = describeMergeGate(checks?.merge_state ?? null, {
             checksFailed: checks?.required_failing.length ?? 0,
-            mergeable: pr?.mergeable ?? false,
+            mergeable: pr?.mergeable ?? "unknown",
           });
           if (gate.mergeAllowed) {
             await mergePr(agentId, subdir);

--- a/src/util/prState.ts
+++ b/src/util/prState.ts
@@ -14,7 +14,9 @@ const PR_STATUSES: readonly PrStatus[] = ["open", "merged", "closed"];
 
 /** Rebuild the last persisted PR state from a repo record's snapshot columns.
  *  Null when no PR is bound or no fetch has ever succeeded. `mergeable` isn't
- *  persisted and reads false — it only means anything while polling live. */
+ *  persisted and reads `"unknown"` — a snapshot carries no merge verdict, and
+ *  `"unknown"` (not `"conflicting"`) is the honest stand-in so the panel says
+ *  "checking…" rather than a false conflict. It only means anything live. */
 export function prSnapshot(repo: TrackedRepo | undefined): PrState | null {
   if (!repo || repo.pr_number == null || !repo.pr_state) return null;
   if (!(PR_STATUSES as readonly string[]).includes(repo.pr_state)) return null;
@@ -23,7 +25,7 @@ export function prSnapshot(repo: TrackedRepo | undefined): PrState | null {
     url: repo.pr_url ?? "",
     state: repo.pr_state as PrStatus,
     title: repo.pr_title ?? "",
-    mergeable: false,
+    mergeable: "unknown",
   };
 }
 

--- a/tests/components/RightPanel/delegation.test.ts
+++ b/tests/components/RightPanel/delegation.test.ts
@@ -46,7 +46,14 @@ const file = (kind: GitState["files"][number]["kind"]) => ({
   deletions: 0,
 });
 function pr(over: Partial<PrState> = {}): PrState {
-  return { number: 7, url: "https://x", state: "open", title: "t", mergeable: true, ...over };
+  return {
+    number: 7,
+    url: "https://x",
+    state: "open",
+    title: "t",
+    mergeable: "mergeable",
+    ...over,
+  };
 }
 function checks(merge_state: PrChecks["merge_state"]): PrChecks {
   return {
@@ -107,8 +114,13 @@ describe("delegationResolved", () => {
     expect(delegationResolved("update-branch", git(), pr(), checks("dirty"))).toBe(false);
     expect(delegationResolved("update-branch", git(), pr(), checks("unknown"))).toBe(false);
     expect(delegationResolved("update-branch", git(), pr(), checks("clean"))).toBe(true);
-    expect(delegationResolved("update-branch", git(), pr({ mergeable: false }), null)).toBe(false);
-    expect(delegationResolved("update-branch", git(), pr({ mergeable: true }), null)).toBe(true);
+    // No checks → fall back to the tri-state mergeable: only a real conflict or
+    // a not-yet-computed verdict keeps waiting; a clean "mergeable" resolves.
+    const noChecks = (m: PrState["mergeable"]) =>
+      delegationResolved("update-branch", git(), pr({ mergeable: m }), null);
+    expect(noChecks("conflicting")).toBe(false);
+    expect(noChecks("unknown")).toBe(false);
+    expect(noChecks("mergeable")).toBe(true);
   });
 
   it("fix-checks never resolves from state (caller resolves on agent idle)", () => {

--- a/tests/components/RightPanel/primaryActions.test.ts
+++ b/tests/components/RightPanel/primaryActions.test.ts
@@ -26,7 +26,14 @@ const file = (kind: GitState["files"][number]["kind"]) => ({
   deletions: 0,
 });
 function pr(over: Partial<PrState> = {}): PrState {
-  return { number: 7, url: "https://x", state: "open", title: "t", mergeable: true, ...over };
+  return {
+    number: 7,
+    url: "https://x",
+    state: "open",
+    title: "t",
+    mergeable: "mergeable",
+    ...over,
+  };
 }
 
 describe("deriveState", () => {
@@ -165,13 +172,19 @@ describe("pr-open primary by merge_state (§7)", () => {
     }
   });
 
-  it("no checks data falls back to mergeable-only behavior", () => {
-    const ok = primaryFor("pr-open", { ...base, mergeable: true });
+  it("no checks data falls back to the tri-state mergeable verdict", () => {
+    const ok = primaryFor("pr-open", { ...base, mergeable: "mergeable" });
     expect(ok.key).toBe("merge");
     expect(ok.statusLabel).toContain("no conflicts");
-    const blocked = primaryFor("pr-open", { ...base, mergeable: false });
-    expect(blocked.key).toBe("merge");
-    expect(blocked.statusKind).toBe("attention");
+    // Unknown = GitHub hasn't computed mergeability yet (also the snapshot's
+    // value) → still-computing, never a false "can't merge — update branch".
+    const unknown = primaryFor("pr-open", { ...base, mergeable: "unknown" });
+    expect(unknown.key).toBe("merge");
+    expect(unknown.statusLabel).toContain("checking");
+    // Only an actual conflict routes to Update branch.
+    const conflicting = primaryFor("pr-open", { ...base, mergeable: "conflicting" });
+    expect(conflicting.key).toBe("agent-update-branch");
+    expect(conflicting.statusKind).toBe("attention");
   });
 });
 

--- a/tests/util/prState.test.ts
+++ b/tests/util/prState.test.ts
@@ -21,7 +21,7 @@ describe("prSnapshot", () => {
       url: "https://github.com/o/r/pull/42",
       state: "merged",
       title: "feat: x",
-      mergeable: false,
+      mergeable: "unknown",
     });
   });
 


### PR DESCRIPTION
## Problem

The Git panel could show **"can't merge yet — update your branch"** for a PR that GitHub actually reports as `CLEAN` + `MERGEABLE` (confirmed live: `gh pr view` returned `mergeStateStatus: CLEAN, mergeable: MERGEABLE`). A false, actionable verdict.

## Root cause

`parse_pr_state` collapsed GitHub's **tri-state** `mergeable` enum (`MERGEABLE` / `CONFLICTING` / `UNKNOWN`) into a **bool** that was `true` only for `MERGEABLE`. GitHub computes mergeability lazily, so `UNKNOWN` ("not computed yet" — normal for a while after any push, and the value a DB snapshot always carries) became indistinguishable from a real `CONFLICTING`.

When checks data was also unavailable (`get_pr_checks` returns `None` when `repo.branch` is unset or the API call fails), `describeMergeGate` fell back to the `mergeable`-only path and read that `false` as the definitive `cant-merge` situation — attention tone, `needsUpdate: true`, "update your branch" — an overclaim from mere absence of data.

## Fix — carry GitHub's tri-state mergeability end to end

**Backend**
- New `Mergeable` enum (`mergeable` / `conflicting` / `unknown`) on `PrState`.
- `parse_pr_state` maps the three GitHub values distinctly (non-open PRs → `Unknown`).
- The persisted snapshot (`pr_snapshot`) now reports `Unknown` instead of a hardcoded `false`.

**Frontend**
- `PrState.mergeable` is now the tri-state; snapshot reports `"unknown"`.
- `describeMergeGate`'s no-checks fallback now maps `mergeable → no-conflicts`, `conflicting → conflicts` (the only case that says "update your branch"), and `unknown → computing` ("checking…").
- Removed the now-dead `"cant-merge"` situation and its surface copy (header / PR card / primary action).
- Updated `delegation`, `useActionBarModel`, `useQueueActions`, `StatusHeader` consumers.

**Net effect:** a mergeable-but-uncomputed PR renders "✓ No merge conflicts" or a neutral "checking…", never a false conflict. Only a genuine GitHub `CONFLICTING` prompts "update your branch".

## Testing

- `cargo check` passes; Rust PR-state/snapshot tests pass (incl. a new test asserting `CONFLICTING` and `UNKNOWN` stay distinct).
- Frontend tests updated to the tri-state (`primaryActions`, `delegation`, `prState`, `queue`). Note: `tsc`/`vitest` were not run in this sandboxed workspace (no `node_modules`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)