### PR TITLE
feat(effort): allow changing reasoning effort mid-conversation

### DIFF
--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -184,6 +184,18 @@ pub async fn stop_agent(
 }
 
 #[tauri::command]
+pub async fn set_agent_effort(
+    supervisor: State<'_, Arc<Supervisor>>,
+    app: AppHandle,
+    agent_id: String,
+    effort: Option<String>,
+) -> Result<()> {
+    let sup = supervisor.inner().clone();
+    sup.set_agent_effort(&app, &agent_id, effort.as_deref())
+        .await
+}
+
+#[tauri::command]
 pub async fn discard_agent(supervisor: State<'_, Arc<Supervisor>>, agent_id: String) -> Result<()> {
     let sup = supervisor.inner().clone();
     sup.discard_agent(&agent_id).await

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1539,6 +1539,7 @@ pub fn run() {
             commands::answer_tool_use,
             commands::resize_agent,
             commands::switch_view,
+            commands::set_agent_effort,
             commands::resume_agent,
             commands::stop_agent,
             commands::discard_agent,

--- a/src-tauri/src/supervisor/events.rs
+++ b/src-tauri/src/supervisor/events.rs
@@ -180,6 +180,26 @@ pub(super) fn emit_view(app: &AppHandle, agent_id: &str, view: AgentView) {
 }
 
 #[derive(Clone, serde::Serialize)]
+struct AgentEffortPayload {
+    agent_id: String,
+    effort: Option<String>,
+}
+
+/// The session's reasoning-effort level changed mid-conversation
+/// (user-initiated). Mirrors `agent:view` so the composer reflects the new
+/// value without a full resync.
+pub(super) fn emit_effort(app: &AppHandle, agent_id: &str, effort: Option<&str>) {
+    emit(
+        app,
+        "agent:effort",
+        AgentEffortPayload {
+            agent_id: agent_id.to_string(),
+            effort: effort.map(str::to_string),
+        },
+    );
+}
+
+#[derive(Clone, serde::Serialize)]
 struct AgentTaskPayload {
     agent_id: String,
     task: String,

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -1116,7 +1116,11 @@ impl Supervisor {
         self.workspace.update_agent_effort(agent_id, effort)?;
         emit_effort(app, agent_id, effort);
         if !is_per_turn_provider(&self.workspace.agent(agent_id)?.provider) {
-            self.respawn_agent_preserving_session(app, agent_id).await;
+            // claude bakes --effort into the process, so re-apply it with a
+            // session-preserving restart. Propagate a failed restart: the new
+            // effort is persisted, but the caller must not report success when
+            // the agent is left without a running process.
+            self.respawn_agent_preserving_session(app, agent_id).await?;
         }
         Ok(())
     }
@@ -1141,7 +1145,9 @@ impl Supervisor {
                 Ok(r) if r.provider == provider_id => {}
                 _ => continue, // wrong provider, or removed out from under us
             }
-            self.respawn_agent_preserving_session(app, &id).await;
+            // Fire-and-forget: a failed restart is logged and reflected in the
+            // agent's status inside the call; there's no caller to surface it to.
+            let _ = self.respawn_agent_preserving_session(app, &id).await;
         }
     }
 
@@ -1160,11 +1166,19 @@ impl Supervisor {
     /// it in `respawn_pending`; the next turn-end Idle transition retries it
     /// (see `transition_active`). This is what keeps the "change config → keep
     /// going" flow working for an agent that's busy at the time.
+    ///
+    /// Returns `Err` only when the replacement process fails to start (the agent
+    /// is left in `Error` status): the caller that initiated the change (e.g.
+    /// `set_agent_effort`) then surfaces it instead of reporting false success.
+    /// Every "nothing to restart now" outcome — deferred because busy, or the
+    /// agent already gone — is `Ok`: the new record still applies on the next
+    /// spawn. Fire-and-forget callers (binary swap, the turn-end drain) ignore
+    /// the result and rely on the internal status/logging.
     pub(super) async fn respawn_agent_preserving_session(
         self: &Arc<Self>,
         app: &AppHandle,
         agent_id: &str,
-    ) {
+    ) -> Result<()> {
         // Keep the complete idle -> teardown -> Spawning -> restarted
         // transition mutually exclusive with project deletion. The deletion
         // marker is installed before that path waits for this lifecycle lock,
@@ -1174,12 +1188,12 @@ impl Supervisor {
             Ok(r) => r,
             Err(_) => {
                 self.respawn_pending.lock().remove(agent_id);
-                return;
+                return Ok(());
             }
         };
         if self.deleting_projects.lock().contains(&record.project_id) {
             self.respawn_pending.lock().remove(agent_id);
-            return;
+            return Ok(());
         }
         // Atomic idle-check + remove. `busy` distinguishes "left running" from
         // "already gone" when no agent is taken.
@@ -1203,11 +1217,11 @@ impl Supervisor {
             None if busy => {
                 self.respawn_pending.lock().insert(agent_id.to_string());
                 tracing::info!(agent_id, "session-preserving respawn deferred: agent busy");
-                return;
+                return Ok(());
             }
             None => {
                 self.respawn_pending.lock().remove(agent_id);
-                return;
+                return Ok(());
             }
         };
         self.respawn_pending.lock().remove(agent_id);
@@ -1226,7 +1240,7 @@ impl Supervisor {
             let err = e.to_string();
             tracing::warn!(agent_id, error = %err, "session-preserving respawn failed");
             self.set_status(app, agent_id, AgentStatus::Error, Some(err));
-            return;
+            return Err(e);
         }
 
         // This respawn passed through a turn-end Idle where the normal queue
@@ -1238,6 +1252,7 @@ impl Supervisor {
                 tracing::warn!(agent_id, error = %e, "post-respawn queue flush failed");
             }
         }
+        Ok(())
     }
 
     pub async fn stop_agent(self: Arc<Self>, app: AppHandle, agent_id: &str) -> Result<()> {

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -19,7 +19,7 @@ use crate::workspace::{
     repo_checkout_path, AgentRecord, AgentStatus, AgentView, TrackedRepo,
 };
 
-use super::events::{emit_agent_event, emit_agent_output, emit_repo_added, emit_view};
+use super::events::{emit_agent_event, emit_agent_output, emit_effort, emit_repo_added, emit_view};
 use super::messaging::{
     drain_message_queue, flush_queued, mark_user_turn_started, on_first_user_message,
 };
@@ -1101,6 +1101,26 @@ impl Supervisor {
         Ok(())
     }
 
+    /// Change a session's reasoning effort mid-conversation. Persists the new
+    /// value so every future spawn reads it, then makes it take effect: claude
+    /// bakes `--effort` into the live process, so it needs a session-preserving
+    /// respawn (eager when idle, deferred to the next turn boundary when busy);
+    /// per-turn agents take effort per turn and apply it on their next message
+    /// with no restart. `None` clears the selection (provider default).
+    pub async fn set_agent_effort(
+        self: &Arc<Self>,
+        app: &AppHandle,
+        agent_id: &str,
+        effort: Option<&str>,
+    ) -> Result<()> {
+        self.workspace.update_agent_effort(agent_id, effort)?;
+        emit_effort(app, agent_id, effort);
+        if !is_per_turn_provider(&self.workspace.agent(agent_id)?.provider) {
+            self.respawn_agent_preserving_session(app, agent_id).await;
+        }
+        Ok(())
+    }
+
     /// Respawn every live agent using `provider_id` so it picks up a freshly
     /// changed binary path. The binary is resolved only inside `start_process`
     /// (spawn / resume / view-switch), so a live agent keeps the old binary —
@@ -1113,21 +1133,24 @@ impl Supervisor {
     /// will resolve the new binary on its next spawn anyway.
     pub async fn respawn_provider(self: &Arc<Self>, app: &AppHandle, provider_id: &str) {
         // Snapshot ids under a short-lived lock; never hold a guard across the
-        // `start_process` await in `respawn_agent_for_bin` (parking_lot guards
-        // aren't Send, and `start_process` re-locks these maps → deadlock).
+        // `start_process` await in `respawn_agent_preserving_session` (parking_lot
+        // guards aren't Send, and `start_process` re-locks these maps → deadlock).
         let ids: Vec<String> = self.agents.lock().keys().cloned().collect();
         for id in ids {
             match self.workspace.agent(&id) {
                 Ok(r) if r.provider == provider_id => {}
                 _ => continue, // wrong provider, or removed out from under us
             }
-            self.respawn_agent_for_bin(app, &id).await;
+            self.respawn_agent_preserving_session(app, &id).await;
         }
     }
 
-    /// Tear down and restart one live agent so it execs the freshly resolved
-    /// binary, resuming its existing session (`fresh = false`) so the
-    /// transcript/conversation is preserved.
+    /// Tear down and restart one live agent, resuming its existing session
+    /// (`fresh = false`) so the transcript/conversation is preserved, and
+    /// re-reading the record so any value baked into the launch args (binary
+    /// path, `--model`, `--effort`) is picked up. Shared by the binary-swap
+    /// respawn (`respawn_provider`) and mid-session config changes
+    /// (`set_agent_effort`).
     ///
     /// The idle-check and the `agents` removal happen atomically under a single
     /// `agents` lock: a concurrent send can flip an agent Idle→Running on
@@ -1135,9 +1158,13 @@ impl Supervisor {
     /// separate check-then-remove would risk shutting down an in-flight turn.
     /// If the agent is mid-turn (Spawning/Running) we leave it running and flag
     /// it in `respawn_pending`; the next turn-end Idle transition retries it
-    /// (see `transition_active`). This is what keeps the "swap binary → keep
-    /// going" flow working for an agent that's busy at swap time.
-    pub(super) async fn respawn_agent_for_bin(self: &Arc<Self>, app: &AppHandle, agent_id: &str) {
+    /// (see `transition_active`). This is what keeps the "change config → keep
+    /// going" flow working for an agent that's busy at the time.
+    pub(super) async fn respawn_agent_preserving_session(
+        self: &Arc<Self>,
+        app: &AppHandle,
+        agent_id: &str,
+    ) {
         // Keep the complete idle -> teardown -> Spawning -> restarted
         // transition mutually exclusive with project deletion. The deletion
         // marker is installed before that path waits for this lifecycle lock,
@@ -1175,7 +1202,7 @@ impl Supervisor {
             Some(agent) => agent,
             None if busy => {
                 self.respawn_pending.lock().insert(agent_id.to_string());
-                tracing::info!(agent_id, "binary-swap respawn deferred: agent busy");
+                tracing::info!(agent_id, "session-preserving respawn deferred: agent busy");
                 return;
             }
             None => {
@@ -1197,7 +1224,7 @@ impl Supervisor {
 
         if let Err(e) = self.start_process(app, agent_id, false).await {
             let err = e.to_string();
-            tracing::warn!(agent_id, error = %err, "binary-swap respawn failed");
+            tracing::warn!(agent_id, error = %err, "session-preserving respawn failed");
             self.set_status(app, agent_id, AgentStatus::Error, Some(err));
             return;
         }

--- a/src-tauri/src/supervisor/messaging.rs
+++ b/src-tauri/src/supervisor/messaging.rs
@@ -424,7 +424,9 @@ pub(super) fn drain_pending_respawn(sup: &Supervisor, app: &AppHandle, agent_id:
     let app = app.clone();
     let agent_id = agent_id.to_string();
     tauri::async_runtime::spawn(async move {
-        sup_arc
+        // Fire-and-forget at the turn boundary: a failed restart is logged and
+        // set on the agent's status inside the call.
+        let _ = sup_arc
             .respawn_agent_preserving_session(&app, &agent_id)
             .await;
     });

--- a/src-tauri/src/supervisor/messaging.rs
+++ b/src-tauri/src/supervisor/messaging.rs
@@ -366,19 +366,19 @@ pub(super) fn flush_queued(sup: &Arc<Supervisor>, app: &AppHandle, agent_id: &st
 /// At a turn-end Idle transition, flush any queued follow-up messages as the
 /// next turn — but only on a *natural* completion. Order of the guards matters:
 ///
-/// 1. A pending binary-swap respawn owns the flush (and the interrupt check):
-///    it tears down and restarts the agent, then flushes once it's ready (see
-///    `respawn_agent_for_bin`). Flushing here would race that teardown and
-///    `AgentNotFound` could drop the queue. The flag is still set at this point
-///    — `transition_active` calls us synchronously right after
-///    `drain_pending_bin_respawn`, before its spawned task clears it.
+/// 1. A pending session-preserving respawn owns the flush (and the interrupt
+///    check): it tears down and restarts the agent, then flushes once it's
+///    ready (see `respawn_agent_preserving_session`). Flushing here would race
+///    that teardown and `AgentNotFound` could drop the queue. The flag is still
+///    set at this point — `transition_active` calls us synchronously right after
+///    `drain_pending_respawn`, before its spawned task clears it.
 /// 2. A user stop converges on this same Idle (the dying process emits its
 ///    result), so when the interrupt flag is set we clear it and keep the queue
 ///    intact (A2-A: stop never auto-sends).
 ///
 /// Spawns the flush because `transition_active` holds only `&Supervisor`, and
 /// the delivery needs an owned `Arc` (recovered from Tauri state, like
-/// `drain_pending_bin_respawn`).
+/// `drain_pending_respawn`).
 pub(super) fn drain_message_queue(sup: &Supervisor, app: &AppHandle, agent_id: &str) {
     if sup.respawn_pending.lock().contains(agent_id) {
         return;
@@ -404,12 +404,14 @@ pub(super) fn drain_message_queue(sup: &Supervisor, app: &AppHandle, agent_id: &
     });
 }
 
-/// If a binary-path change was deferred for this agent because it was
-/// mid-turn (see `respawn_agent_for_bin`), now that it's Idle restart it onto
-/// the new binary. No-op unless the agent is flagged. We recover the managed
-/// `Arc<Supervisor>` from Tauri state because `transition_active` only holds
-/// `&Supervisor`, and the respawn needs an owned `Arc` for its spawned task.
-pub(super) fn drain_pending_bin_respawn(sup: &Supervisor, app: &AppHandle, agent_id: &str) {
+/// If a session-preserving respawn (binary swap or a mid-session model/effort
+/// change) was deferred for this agent because it was mid-turn (see
+/// `respawn_agent_preserving_session`), now that it's Idle restart it so it
+/// re-reads the record. No-op unless the agent is flagged. We recover the
+/// managed `Arc<Supervisor>` from Tauri state because `transition_active` only
+/// holds `&Supervisor`, and the respawn needs an owned `Arc` for its spawned
+/// task.
+pub(super) fn drain_pending_respawn(sup: &Supervisor, app: &AppHandle, agent_id: &str) {
     if !sup.respawn_pending.lock().contains(agent_id) {
         return;
     }
@@ -422,7 +424,9 @@ pub(super) fn drain_pending_bin_respawn(sup: &Supervisor, app: &AppHandle, agent
     let app = app.clone();
     let agent_id = agent_id.to_string();
     tauri::async_runtime::spawn(async move {
-        sup_arc.respawn_agent_for_bin(&app, &agent_id).await;
+        sup_arc
+            .respawn_agent_preserving_session(&app, &agent_id)
+            .await;
     });
 }
 

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -38,7 +38,7 @@ use crate::workspace::{
 };
 
 use events::emit_status;
-use messaging::{drain_message_queue, drain_pending_bin_respawn};
+use messaging::{drain_message_queue, drain_pending_respawn};
 
 /// A runtime status transition, broadcast to in-process subscribers the moment
 /// it is recorded. The workflow scheduler (`workflow::driver`) subscribes to
@@ -570,7 +570,7 @@ fn transition_active(sup: &Supervisor, app: &AppHandle, agent_id: &str, new: Age
             // agent's checkout so its Mission Control card carries test
             // evidence. Ad-hoc agents only, fire-and-forget, never blocks.
             sup.trigger_turn_end_verification(app.clone(), agent_id.to_string());
-            drain_pending_bin_respawn(sup, app, agent_id);
+            drain_pending_respawn(sup, app, agent_id);
             drain_message_queue(sup, app, agent_id);
         }
     }

--- a/src-tauri/src/workspace/agents.rs
+++ b/src-tauri/src/workspace/agents.rs
@@ -264,6 +264,21 @@ impl WorkspaceManager {
         Ok(())
     }
 
+    /// Update the session's reasoning-effort level mid-conversation. Unlike the
+    /// spawn-time value, this is user-changeable (see
+    /// `Supervisor::set_agent_effort`): claude re-applies it on the next
+    /// `--resume`, while per-turn agents read it on their next turn. `None`
+    /// clears the selection, falling back to the provider's default.
+    pub fn update_agent_effort(&self, id: &str, effort: Option<&str>) -> Result<()> {
+        let conn = self.db.lock();
+        Self::ensure_agent_exists(&conn, id)?;
+        conn.execute(
+            "UPDATE sessions SET effort = ?1 WHERE workspace_id = ?2",
+            rusqlite::params![effort, id],
+        )?;
+        Ok(())
+    }
+
     /// Re-tag an agent with the issue it's working ("123" / "ENG-123"), or
     /// clear it with `None`. The row is the durable source for the PR
     /// closing trailer across restarts; the caller also updates the live

--- a/src-tauri/src/workspace/tests.rs
+++ b/src-tauri/src/workspace/tests.rs
@@ -328,6 +328,32 @@ fn sandbox_engine_stamp_round_trips() {
 }
 
 #[test]
+fn update_agent_effort_round_trips() {
+    let db = test_db();
+    seed_repo(&db, "/r");
+    let wm = WorkspaceManager::new(db);
+
+    let mut rec = new_agent_record(
+        "eiger".into(),
+        "a".into(),
+        "claude".into(),
+        mk_repo("/r"),
+        "t".into(),
+        AgentView::Custom,
+    );
+    wm.add_agent(&mut rec).unwrap();
+
+    // A mid-session effort change persists and reloads — the composer's effort
+    // picker reads this back, and every future spawn re-applies it.
+    wm.update_agent_effort("eiger", Some("high")).unwrap();
+    assert_eq!(wm.agent("eiger").unwrap().effort.as_deref(), Some("high"));
+
+    // Clearing it falls back to the provider default (NULL).
+    wm.update_agent_effort("eiger", None).unwrap();
+    assert_eq!(wm.agent("eiger").unwrap().effort, None);
+}
+
+#[test]
 fn status_derivation() {
     // Archived workspaces are stopped regardless of error/run state.
     assert_eq!(


### PR DESCRIPTION
## What

Reasoning effort was chosen once at session creation and locked for the whole session. This makes it **user-changeable mid-conversation**, with an identical UX across providers but provider-appropriate mechanics under the hood.

This is **PR 1 of the effort/model-switching series** — backend only. The composer still locks the control; PR 2 wires up the UI.

## Changes

- **`workspace/agents.rs`** — `update_agent_effort`, a mutable UPDATE mirroring `update_agent_view` (effort was previously write-once, set only at spawn).
- **`supervisor` — `set_agent_effort`**: persists the new value, emits an `agent:effort` event, and applies it. For providers that bake `--effort` into the live process (claude) it applies via a session-preserving respawn; per-turn agents (codex/opencode/pi) read effort per turn and need no restart.
- **Reuse over reinvention** — generalized the existing binary-swap respawn into the shared `respawn_agent_preserving_session` primitive (and renamed its turn-end drain to `drain_pending_respawn`). It already re-reads the record on `--resume`, restarts eagerly when idle, and defers to the next turn boundary when busy. Used verbatim for config changes — no new lifecycle logic.
- **`commands/agent.rs` + `lib.rs`** — exposed the `set_agent_effort` Tauri command.

## Safety

- **Mid-turn change** defers to the turn-end Idle transition via the existing `respawn_pending` flag — never kills an in-flight turn.
- **Transcript + queued messages preserved** — same teardown→`--resume` path `switch_view` already uses.
- Verified empirically on claude 2.1.218 that `--resume` with a changed effort/model applies cleanly and preserves prior context (including old signed thinking blocks).

## Tests

- New `update_agent_effort_round_trips` persistence test.
- `cargo test --lib`: 996 passed, 10 ignored. `cargo fmt --check` and `cargo check` (lib + tests) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)