### PR TITLE
feat(model): allow changing the model mid-conversation (backend)

### DIFF
--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -196,6 +196,17 @@ pub async fn set_agent_effort(
 }
 
 #[tauri::command]
+pub async fn set_agent_model(
+    supervisor: State<'_, Arc<Supervisor>>,
+    app: AppHandle,
+    agent_id: String,
+    model: Option<String>,
+) -> Result<()> {
+    let sup = supervisor.inner().clone();
+    sup.set_agent_model(&app, &agent_id, model.as_deref()).await
+}
+
+#[tauri::command]
 pub async fn discard_agent(supervisor: State<'_, Arc<Supervisor>>, agent_id: String) -> Result<()> {
     let sup = supervisor.inner().clone();
     sup.discard_agent(&agent_id).await

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1540,6 +1540,7 @@ pub fn run() {
             commands::resize_agent,
             commands::switch_view,
             commands::set_agent_effort,
+            commands::set_agent_model,
             commands::resume_agent,
             commands::stop_agent,
             commands::discard_agent,

--- a/src-tauri/src/supervisor/events.rs
+++ b/src-tauri/src/supervisor/events.rs
@@ -200,6 +200,25 @@ pub(super) fn emit_effort(app: &AppHandle, agent_id: &str, effort: Option<&str>)
 }
 
 #[derive(Clone, serde::Serialize)]
+struct AgentModelPayload {
+    agent_id: String,
+    model: Option<String>,
+}
+
+/// The session's model changed mid-conversation (user-initiated). Mirrors
+/// `agent:effort` so the composer reflects the new value without a full resync.
+pub(super) fn emit_model(app: &AppHandle, agent_id: &str, model: Option<&str>) {
+    emit(
+        app,
+        "agent:model",
+        AgentModelPayload {
+            agent_id: agent_id.to_string(),
+            model: model.map(str::to_string),
+        },
+    );
+}
+
+#[derive(Clone, serde::Serialize)]
 struct AgentTaskPayload {
     agent_id: String,
     task: String,

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -19,7 +19,9 @@ use crate::workspace::{
     repo_checkout_path, AgentRecord, AgentStatus, AgentView, TrackedRepo,
 };
 
-use super::events::{emit_agent_event, emit_agent_output, emit_effort, emit_repo_added, emit_view};
+use super::events::{
+    emit_agent_event, emit_agent_output, emit_effort, emit_model, emit_repo_added, emit_view,
+};
 use super::messaging::{
     drain_message_queue, flush_queued, mark_user_turn_started, on_first_user_message,
 };
@@ -1102,11 +1104,9 @@ impl Supervisor {
     }
 
     /// Change a session's reasoning effort mid-conversation. Persists the new
-    /// value so every future spawn reads it, then makes it take effect: claude
-    /// bakes `--effort` into the live process, so it needs a session-preserving
-    /// respawn (eager when idle, deferred to the next turn boundary when busy);
-    /// per-turn agents take effort per turn and apply it on their next message
-    /// with no restart. `None` clears the selection (provider default).
+    /// value so every future spawn reads it, then re-applies it to the live
+    /// process (see `reapply_session_config`). `None` clears the selection
+    /// (provider default).
     pub async fn set_agent_effort(
         self: &Arc<Self>,
         app: &AppHandle,
@@ -1115,11 +1115,36 @@ impl Supervisor {
     ) -> Result<()> {
         self.workspace.update_agent_effort(agent_id, effort)?;
         emit_effort(app, agent_id, effort);
+        self.reapply_session_config(app, agent_id).await
+    }
+
+    /// Change a session's model mid-conversation. Persists the new value so
+    /// every future spawn reads it, then re-applies it to the live process (see
+    /// `reapply_session_config`). `None` clears the selection (provider default).
+    pub async fn set_agent_model(
+        self: &Arc<Self>,
+        app: &AppHandle,
+        agent_id: &str,
+        model: Option<&str>,
+    ) -> Result<()> {
+        self.workspace.update_agent_model(agent_id, model)?;
+        emit_model(app, agent_id, model);
+        self.reapply_session_config(app, agent_id).await
+    }
+
+    /// Make a just-persisted model/effort change take effect on the live
+    /// process. claude bakes both into its launch args (`--model`/`--effort`),
+    /// so it needs a session-preserving respawn (eager when idle, deferred to
+    /// the next turn boundary when busy); per-turn agents re-read the record on
+    /// their next turn, so nothing to restart. A failed restart propagates: the
+    /// new value is persisted, but the caller must not report success when the
+    /// agent is left without a running process.
+    async fn reapply_session_config(
+        self: &Arc<Self>,
+        app: &AppHandle,
+        agent_id: &str,
+    ) -> Result<()> {
         if !is_per_turn_provider(&self.workspace.agent(agent_id)?.provider) {
-            // claude bakes --effort into the process, so re-apply it with a
-            // session-preserving restart. Propagate a failed restart: the new
-            // effort is persisted, but the caller must not report success when
-            // the agent is left without a running process.
             self.respawn_agent_preserving_session(app, agent_id).await?;
         }
         Ok(())

--- a/src-tauri/src/workspace/agents.rs
+++ b/src-tauri/src/workspace/agents.rs
@@ -279,6 +279,20 @@ impl WorkspaceManager {
         Ok(())
     }
 
+    /// Update the session's model mid-conversation. Like `update_agent_effort`,
+    /// this is user-changeable after spawn (see `Supervisor::set_agent_model`):
+    /// claude re-applies it on the next `--resume`, while per-turn agents read
+    /// it on their next turn. `None` clears the selection (provider default).
+    pub fn update_agent_model(&self, id: &str, model: Option<&str>) -> Result<()> {
+        let conn = self.db.lock();
+        Self::ensure_agent_exists(&conn, id)?;
+        conn.execute(
+            "UPDATE sessions SET model = ?1 WHERE workspace_id = ?2",
+            rusqlite::params![model, id],
+        )?;
+        Ok(())
+    }
+
     /// Re-tag an agent with the issue it's working ("123" / "ENG-123"), or
     /// clear it with `None`. The row is the durable source for the PR
     /// closing trailer across restarts; the caller also updates the live

--- a/src-tauri/src/workspace/tests.rs
+++ b/src-tauri/src/workspace/tests.rs
@@ -354,6 +354,35 @@ fn update_agent_effort_round_trips() {
 }
 
 #[test]
+fn update_agent_model_round_trips() {
+    let db = test_db();
+    seed_repo(&db, "/r");
+    let wm = WorkspaceManager::new(db);
+
+    let mut rec = new_agent_record(
+        "matterhorn".into(),
+        "a".into(),
+        "claude".into(),
+        mk_repo("/r"),
+        "t".into(),
+        AgentView::Custom,
+    );
+    wm.add_agent(&mut rec).unwrap();
+
+    // A mid-session model change persists and reloads — the composer's model
+    // picker reads this back, and every future spawn re-applies it.
+    wm.update_agent_model("matterhorn", Some("opus")).unwrap();
+    assert_eq!(
+        wm.agent("matterhorn").unwrap().model.as_deref(),
+        Some("opus")
+    );
+
+    // Clearing it falls back to the provider default (NULL).
+    wm.update_agent_model("matterhorn", None).unwrap();
+    assert_eq!(wm.agent("matterhorn").unwrap().model, None);
+}
+
+#[test]
 fn status_derivation() {
     // Archived workspaces are stopped regardless of error/run state.
     assert_eq!(


### PR DESCRIPTION
## What

Backend for mid-session **model** switching (**PR 3 of the series**) — a near-mechanical mirror of the effort backend, reusing the same session-preserving respawn.

> **Stacked on #507** (`feat/switch-effort-mid-session-ui`). Targets that branch, not `main`; merges after #506 → #507.

## Changes

- **`workspace/agents.rs`** — `update_agent_model`, a mutable UPDATE alongside `update_agent_effort` (model was previously write-once at spawn).
- **`supervisor`** — `set_agent_model`: persist → emit `agent:model` → re-apply. Extracted the shared "re-apply a persisted config change" tail of `set_agent_effort` into **`reapply_session_config`** (DRY): claude respawns (session-preserving) to re-read `--model`/`--effort`; per-turn agents pick it up on their next turn. A failed restart propagates (from #506's fix).
- **`commands/agent.rs` + `lib.rs`** — `set_agent_model` Tauri command, registered.

## Behavior

Same mechanics split as effort: claude restarts to re-apply `--model`; per-turn agents (codex/opencode/pi) re-read `record.model` on their next turn with no restart. Verified earlier that a cross-family model switch on `--resume` is safe on claude 2.1.218.

## Tests / checks

- New `update_agent_model_round_trips` persistence test.
- `cargo test --lib`: 997 passed, 10 ignored. `cargo check` + `cargo fmt --check` clean.

Backend only — the composer's model picker is unlocked in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)