### PR TITLE
feat(model): interactive model picker in the chat composer

### DIFF
--- a/src/api/domains/agents.ts
+++ b/src/api/domains/agents.ts
@@ -108,6 +108,8 @@ export const agentsApi = {
   switchView: (agentId: string, view: AgentView) => invoke<void>("switch_view", { agentId, view }),
   setAgentEffort: (agentId: string, effort: string | null) =>
     invoke<void>("set_agent_effort", { agentId, effort }),
+  setAgentModel: (agentId: string, model: string | null) =>
+    invoke<void>("set_agent_model", { agentId, model }),
   resumeAgent: (agentId: string) => invoke<void>("resume_agent", { agentId }),
   stopAgent: (agentId: string) => invoke<void>("stop_agent", { agentId }),
   discardAgent: (agentId: string) => invoke<void>("discard_agent", { agentId }),

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -4,6 +4,7 @@ import type {
   AgentEffortEvent,
   AgentGitActionEvent,
   AgentManagedEvent,
+  AgentModelEvent,
   AgentOutputEvent,
   AgentRepoAddedEvent,
   AgentStatusEvent,
@@ -89,6 +90,12 @@ export function onAgentView(cb: (e: AgentViewEvent) => void): Promise<UnlistenFn
  *  composer's effort chip reflects the new value without a full resync. */
 export function onAgentEffort(cb: (e: AgentEffortEvent) => void): Promise<UnlistenFn> {
   return listen<AgentEffortEvent>("agent:effort", (event) => cb(event.payload));
+}
+
+/** Fires when a session's model is changed mid-conversation, so the composer's
+ *  model picker reflects the new value without a full resync. */
+export function onAgentModel(cb: (e: AgentModelEvent) => void): Promise<UnlistenFn> {
+  return listen<AgentModelEvent>("agent:model", (event) => cb(event.payload));
 }
 
 export function onAgentTask(cb: (e: AgentTaskEvent) => void): Promise<UnlistenFn> {

--- a/src/api/types/agent.ts
+++ b/src/api/types/agent.ts
@@ -142,6 +142,11 @@ export interface AgentEffortEvent {
   effort: string | null;
 }
 
+export interface AgentModelEvent {
+  agent_id: string;
+  model: string | null;
+}
+
 export interface AgentTaskEvent {
   agent_id: string;
   task: string;

--- a/src/components/Composer/ModelPicker.tsx
+++ b/src/components/Composer/ModelPicker.tsx
@@ -4,6 +4,7 @@ import { ProviderIcon } from "@/components/ProviderIcon";
 import { Mono } from "@/components/SettingsScreen/CustomAgents/Mono";
 import { Chip } from "@/components/ui/Chip";
 import { Scrim } from "@/components/ui/Scrim";
+import { PROVIDER_DETAIL } from "@/data/providerDetail";
 import { isDockerSupported, PROVIDERS, providerLabel } from "@/data/providers";
 import { useAppStore } from "@/store";
 
@@ -15,6 +16,11 @@ interface Props {
   customAgentId?: string;
   onChange: (provider: string, model?: string, customAgentId?: string) => void;
   locked?: boolean;
+  /** Existing sessions: restrict the picker to changing the MODEL within the
+   *  session's current provider. Provider and custom-agent identity are fixed
+   *  at spawn, so the dropdown drops the agent/custom-agent sections and shows
+   *  only this provider's models. */
+  modelOnly?: boolean;
 }
 
 function formatContext(tokens: number): string {
@@ -28,7 +34,14 @@ function formatContext(tokens: number): string {
  *  hovering a coding agent opens a flyout on the right for model selection.
  *  Clicking an agent row commits its default model; leaving model unset
  *  preserves the provider CLI's default. Selections stay sticky via `onChange`. */
-export function ModelPicker({ provider, model, customAgentId, onChange, locked = false }: Props) {
+export function ModelPicker({
+  provider,
+  model,
+  customAgentId,
+  onChange,
+  locked = false,
+  modelOnly = false,
+}: Props) {
   const [open, setOpen] = useState(false);
   // Coding agent whose model flyout is currently expanded (null = none).
   const [hovered, setHovered] = useState<string | null>(null);
@@ -66,9 +79,23 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
     if (open) setHovered(null);
   }, [open]);
 
+  // Model-only (existing session): changing the model on a provider that bakes
+  // it into the process (claude, `restartToApply`) restarts the agent; surface
+  // that in the chip tooltip, mirroring the effort chip.
+  const restartOnChange =
+    modelOnly && !!PROVIDER_DETAIL[provider as keyof typeof PROVIDER_DETAIL]?.restartToApply;
+  const chipTip = locked
+    ? (activeCustom?.name ?? selected.label)
+    : modelOnly
+      ? restartOnChange
+        ? "Model — changing restarts the agent (rebuilds cache)"
+        : "Model"
+      : "Agent and model";
+
   function pickModel(providerId: string, id: string | undefined) {
-    // Selecting a built-in model clears any custom-agent selection.
-    onChange(providerId, id, undefined);
+    // A model-only pick (existing session) keeps the session's custom-agent
+    // identity; a full-picker pick clears it.
+    onChange(providerId, id, modelOnly ? customAgentId : undefined);
     setOpen(false);
   }
 
@@ -79,7 +106,9 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
 
   function renderModelList(p: (typeof PROVIDERS)[number]) {
     const models = modelsByAgent[p.id] ?? [];
-    const isCurrent = p.id === provider && !customAgentId;
+    // In model-only mode the list is always the session's own provider, so its
+    // current model highlights even for a custom-agent session (customAgentId set).
+    const isCurrent = modelOnly || (p.id === provider && !customAgentId);
     return (
       <div className="model-list">
         <button
@@ -141,7 +170,7 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
         onClick={() => {
           if (!locked) setOpen((v) => !v);
         }}
-        tip={locked ? (activeCustom?.name ?? selected.label) : "Agent and model"}
+        tip={chipTip}
         className="model-chip"
       >
         {activeCustom ? (
@@ -162,7 +191,7 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
         {!locked && <Icon name="chevD" size={9} />}
       </Chip>
 
-      {open && (
+      {open && !modelOnly && (
         <>
           <Scrim onClose={() => setOpen(false)} />
           {/* Transparent wrapper: the main card sits above (z-index 2) the
@@ -309,6 +338,21 @@ export function ModelPicker({ provider, model, customAgentId, onChange, locked =
                 </div>
               </div>
             )}
+          </div>
+        </>
+      )}
+
+      {open && modelOnly && (
+        <>
+          <Scrim onClose={() => setOpen(false)} />
+          <div className="model-dd-wrap" style={{ bottom: "calc(100% + 6px)", left: 0 }}>
+            <div className="model-dd-main">
+              <div className="model-sect flex-center text-xs">
+                <span>Model</span>
+                <span className="model-sect-line" />
+              </div>
+              {renderModelList(selected)}
+            </div>
           </div>
         </>
       )}

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -106,6 +106,12 @@ interface Props {
    *  also carry the value on the next message via `onSend`'s `thinking`. Omit
    *  for new-session composers, where effort is chosen at spawn. */
   onChangeEffort?: (value: string) => void;
+  /** For existing sessions: persist a mid-session model change. Called with the
+   *  new model id (or undefined for the provider default) when the user picks a
+   *  model. For claude this restarts the session to re-apply `--model`; per-turn
+   *  agents pick it up on their next turn. Omit for new-session composers, where
+   *  the model is chosen at spawn. */
+  onChangeModel?: (model: string | undefined) => void;
   /** The model the agent actually used on its most recent turn, read from the
    *  transcript (Claude, pi, Codex, OpenCode report it). Used as a fallback
    *  when the transcript has not yielded a model yet, so the picker can still
@@ -166,6 +172,7 @@ export function Composer({
   existingSession = false,
   initialThinking,
   onChangeEffort,
+  onChangeModel,
   activeModel,
   usage,
 }: Props) {
@@ -316,14 +323,21 @@ export function Composer({
             provider={provider}
             model={model}
             customAgentId={customAgentId}
-            locked={existingSession}
+            modelOnly={existingSession}
             onChange={(nextProvider, nextModel, nextCustomAgentId) => {
               // Effort follows from the selection via the effect above (a custom
               // agent's reasoning budget, else the per-provider default).
               setProvider(nextProvider);
               setModel(nextModel);
               setCustomAgentId(nextCustomAgentId);
-              onChangeSelection?.(nextProvider, nextModel, nextCustomAgentId);
+              if (existingSession) {
+                // Model-only change on an existing session: provider/custom-agent
+                // are unchanged; persist the new model (backend restarts claude
+                // to re-apply --model, per-turn agents pick it up next turn).
+                onChangeModel?.(nextModel);
+              } else {
+                onChangeSelection?.(nextProvider, nextModel, nextCustomAgentId);
+              }
             }}
           />
           {features.thinkingBudget && thinkingLevels.length > 0 && modelSupportsThinking && (

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -189,12 +189,18 @@ export function Composer({
   const [provider, setProvider] = useState(defaultProvider);
   const [model, setModel] = useState<string | undefined>(defaultModel);
   const [customAgentId, setCustomAgentId] = useState<string | undefined>(defaultCustomAgentId);
-  // Resolve the model within the SELECTED provider's list first: a model id
-  // shared across agents keeps only the first-discovered entry in the global
-  // `byId` view, which may belong to another provider and omit this provider's
-  // per-model metadata (e.g. codex's reasoning levels). Fall back to `byId` for
-  // ids the provider list doesn't carry (unknown/new models).
-  const activeModelId = existingSession ? (activeModel ?? model) : model;
+  // Resolve reasoning metadata from the model the NEXT turn will actually use.
+  // The picker's current selection (`model`) wins, so a mid-session model change
+  // immediately drives the effort levels — otherwise the newly picked model
+  // could be paired with a thinking value only the previous model supported.
+  // Fall back to the last transcript-reported model only when no explicit model
+  // is set (provider default), so we still reflect the real running model.
+  // Resolve within the SELECTED provider's list first: a model id shared across
+  // agents keeps only the first-discovered entry in the global `byId` view,
+  // which may belong to another provider and omit this provider's per-model
+  // metadata (e.g. codex's reasoning levels). Fall back to `byId` for ids the
+  // provider list doesn't carry (unknown/new models).
+  const activeModelId = existingSession ? (model ?? activeModel) : model;
   const activeMeta =
     lookupModelInList(modelsByAgent[provider], activeModelId) ??
     lookupModel(modelCatalog, activeModelId);

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -371,6 +371,15 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
                   console.error("set_agent_effort failed", e);
                 });
               }}
+              onChangeModel={(model) => {
+                // Persist the mid-session model change; the backend restarts
+                // claude (resuming the same session) to re-apply --model, and
+                // per-turn agents pick it up on their next turn. Best-effort: a
+                // failure just leaves the prior model in force.
+                api.setAgentModel(agent.id, model ?? null).catch((e) => {
+                  console.error("set_agent_model failed", e);
+                });
+              }}
               disabled={!canSend}
               placeholder={
                 canSend

--- a/src/store/eventListeners.ts
+++ b/src/store/eventListeners.ts
@@ -12,6 +12,7 @@ import {
   onAgentEffort,
   onAgentEvent,
   onAgentGitAction,
+  onAgentModel,
   onAgentOutput,
   onAgentRepoAdded,
   onAgentStatus,
@@ -347,6 +348,10 @@ export const registerEventListeners = async (set: AppSet, get: AppGet) => {
 
   await onAgentEffort((e) => {
     patchAgent(get, set, e.agent_id, { effort: e.effort });
+  });
+
+  await onAgentModel((e) => {
+    patchAgent(get, set, e.agent_id, { model: e.model });
   });
 
   await onAgentStatus((e) => {


### PR DESCRIPTION
## What

Frontend for mid-session **model** switching (**PR 4 of the series**) — unlocks the composer's model picker for existing sessions.

> **Stacked on #508** (`feat/switch-model-mid-session`). Targets that branch; merges after #506 → #507 → #508.

## The wrinkle vs. effort

The `ModelPicker` selects provider *and* custom-agent *and* model — but provider and custom-agent identity are fixed at spawn and can't change mid-session. So instead of unlocking the full picker, this adds a **model-only mode** for existing sessions: the dropdown shows just the session provider's model list, and picking preserves the session's custom-agent identity.

## Changes

- **`ModelPicker`** — new `modelOnly` prop. Drops the agent/custom-agent sections; shows only the current provider's models; picking keeps `customAgentId`. For `restartToApply` providers (claude), the chip tooltip notes the model change restarts the agent and rebuilds the cache (mirrors the effort chip).
- **`Composer`** — `modelOnly={existingSession}` (was `locked`); an existing-session pick persists via a new `onChangeModel` prop rather than the new-draft `onChangeSelection` path.
- **`ChatView`** — wires `onChangeModel` → `api.setAgentModel(agent.id, model)` (best-effort).
- **api layer** — `set_agent_model` wrapper, `agent:model` event + `onAgentModel` subscription, and a store listener patching `agent.model`.

## Behavior

- **claude** — model-only dropdown; picking persists + triggers the session-preserving restart (from #508); tooltip flags the restart.
- **per-turn (codex/opencode/pi)** — picking persists; the next turn's fresh spawn reads `record.model`. No restart.
- **new-session composer** — full agent/model picker, unchanged.

## Checks

- `tsc --noEmit` clean.
- biome clean on all changed files (the 4 pre-existing `ChatView` warnings are on `main` already; none introduced here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)