### PR TITLE
refactor(effort): make reasoning effort session-level for all providers

### DIFF
--- a/src-tauri/migrations/0025_drop_pending_message_thinking.sql
+++ b/src-tauri/migrations/0025_drop_pending_message_thinking.sql
@@ -1,0 +1,6 @@
+-- Reasoning effort is a session-level setting, read from the session record on
+-- every turn (like the model) rather than carried per message. The per-message
+-- `thinking` tag on queued follow-ups is therefore dead — drop the column.
+-- Every per-turn CLI treats effort as a config/session value re-passed each
+-- invocation, so nothing was ever gained by varying it per message.
+ALTER TABLE pending_messages DROP COLUMN thinking;

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -45,8 +45,10 @@ pub enum Agent {
     Managed(ManagedAgent),
     /// A per-turn runner (codex, cursor): holds no live process between
     /// turns; each user message spawns a fresh process. The agent
-    /// sandboxes itself, so there's no sandbox-exec profile.
-    PerTurn(PerTurnAgent),
+    /// sandboxes itself, so there's no sandbox-exec profile. Boxed: its
+    /// `ExecSession` inlines far more state than the other variants, so
+    /// boxing keeps the enum small (it always lives behind an `Arc` anyway).
+    PerTurn(Box<PerTurnAgent>),
 }
 
 pub struct PtyAgent {

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -45,10 +45,8 @@ pub enum Agent {
     Managed(ManagedAgent),
     /// A per-turn runner (codex, cursor): holds no live process between
     /// turns; each user message spawns a fresh process. The agent
-    /// sandboxes itself, so there's no sandbox-exec profile. Boxed: its
-    /// `ExecSession` inlines far more state than the other variants, so
-    /// boxing keeps the enum small (it always lives behind an `Arc` anyway).
-    PerTurn(Box<PerTurnAgent>),
+    /// sandboxes itself, so there's no sandbox-exec profile.
+    PerTurn(PerTurnAgent),
 }
 
 pub struct PtyAgent {

--- a/src-tauri/src/agent/spawn.rs
+++ b/src-tauri/src/agent/spawn.rs
@@ -463,7 +463,7 @@ impl Agent {
             extract_session_id,
             cb,
         );
-        Ok(Self::PerTurn(PerTurnAgent { session }))
+        Ok(Self::PerTurn(Box::new(PerTurnAgent { session })))
     }
 
     pub fn write_pty(&self, bytes: &[u8]) -> Result<()> {
@@ -472,6 +472,16 @@ impl Agent {
             Self::Managed(_) | Self::PerTurn(_) => {
                 Err(Error::Other("write_pty called on a managed agent".into()))
             }
+        }
+    }
+
+    /// Push a mid-session model/effort change into a live per-turn runner so the
+    /// next turn uses it. No-op for claude (Managed/Pty), whose config is baked
+    /// into its persistent process and re-applied by a session-preserving
+    /// respawn instead.
+    pub fn set_config(&self, model: Option<&str>, effort: Option<&str>) {
+        if let Self::PerTurn(a) = self {
+            a.session.set_config(model, effort);
         }
     }
 

--- a/src-tauri/src/agent/spawn.rs
+++ b/src-tauri/src/agent/spawn.rs
@@ -33,6 +33,9 @@ pub struct PerTurnSpec {
     pub session_id: Option<String>,
     /// Session-level model override. `None` keeps the provider CLI default.
     pub model: Option<String>,
+    /// Session-level reasoning effort, re-emitted on every turn like `model`
+    /// (each turn is a fresh process). `None` keeps the CLI default.
+    pub effort: Option<String>,
     /// A custom agent's standing instructions, snapshotted on the session and
     /// injected into every turn (appended after Fletch's global system prompt).
     /// Includes the materialized skill index when the session has skills.
@@ -451,6 +454,7 @@ impl Agent {
                 cwd: spec.cwd,
                 session_id: spec.session_id,
                 model: spec.model,
+                effort: spec.effort,
                 stdout_is_json,
                 env,
                 kill_plan: kill,
@@ -471,15 +475,10 @@ impl Agent {
         }
     }
 
-    pub fn send_user_message(
-        &self,
-        text: &str,
-        attachments: &[String],
-        thinking: Option<&str>,
-    ) -> Result<()> {
+    pub fn send_user_message(&self, text: &str, attachments: &[String]) -> Result<()> {
         match self {
             Self::Managed(a) => a.session.send_user_message(text, attachments),
-            Self::PerTurn(a) => a.session.send_user_message(text, attachments, thinking),
+            Self::PerTurn(a) => a.session.send_user_message(text, attachments),
             Self::Pty(_) => Err(Error::Other("send_user_message called on pty agent".into())),
         }
     }

--- a/src-tauri/src/agent/spawn.rs
+++ b/src-tauri/src/agent/spawn.rs
@@ -31,11 +31,6 @@ pub struct PerTurnSpec {
     pub sandbox_root: PathBuf,
     /// Session id to resume, if one has been captured already.
     pub session_id: Option<String>,
-    /// Session-level model override. `None` keeps the provider CLI default.
-    pub model: Option<String>,
-    /// Session-level reasoning effort, re-emitted on every turn like `model`
-    /// (each turn is a fresh process). `None` keeps the CLI default.
-    pub effort: Option<String>,
     /// A custom agent's standing instructions, snapshotted on the session and
     /// injected into every turn (appended after Fletch's global system prompt).
     /// Includes the materialized skill index when the session has skills.
@@ -453,8 +448,6 @@ impl Agent {
                 keepalive,
                 cwd: spec.cwd,
                 session_id: spec.session_id,
-                model: spec.model,
-                effort: spec.effort,
                 stdout_is_json,
                 env,
                 kill_plan: kill,
@@ -463,7 +456,7 @@ impl Agent {
             extract_session_id,
             cb,
         );
-        Ok(Self::PerTurn(Box::new(PerTurnAgent { session })))
+        Ok(Self::PerTurn(PerTurnAgent { session }))
     }
 
     pub fn write_pty(&self, bytes: &[u8]) -> Result<()> {
@@ -475,29 +468,23 @@ impl Agent {
         }
     }
 
-    /// Push a mid-session model change into a live per-turn runner so the next
-    /// turn uses it. No-op for claude (Managed/Pty), whose config is baked into
-    /// its persistent process and re-applied by a session-preserving respawn.
-    /// Model and effort are set independently so concurrent changes to each
-    /// can't overwrite one another.
-    pub fn set_model(&self, model: Option<&str>) {
-        if let Self::PerTurn(a) = self {
-            a.session.set_model(model);
-        }
-    }
-
-    /// Push a mid-session effort change into a live per-turn runner (see
-    /// `set_model`).
-    pub fn set_effort(&self, effort: Option<&str>) {
-        if let Self::PerTurn(a) = self {
-            a.session.set_effort(effort);
-        }
-    }
-
-    pub fn send_user_message(&self, text: &str, attachments: &[String]) -> Result<()> {
+    /// Deliver a user turn. `model`/`effort` are the session's current config,
+    /// resolved from the record at dispatch (see `deliver_user_message`) and
+    /// used only by per-turn runners, which bake them into that turn's argv.
+    /// claude (Managed) ignores them — its config is fixed on the persistent
+    /// process at spawn and changed via a session-preserving respawn instead.
+    pub fn send_user_message(
+        &self,
+        text: &str,
+        attachments: &[String],
+        model: Option<&str>,
+        effort: Option<&str>,
+    ) -> Result<()> {
         match self {
             Self::Managed(a) => a.session.send_user_message(text, attachments),
-            Self::PerTurn(a) => a.session.send_user_message(text, attachments),
+            Self::PerTurn(a) => a
+                .session
+                .send_user_message(text, attachments, model, effort),
             Self::Pty(_) => Err(Error::Other("send_user_message called on pty agent".into())),
         }
     }

--- a/src-tauri/src/agent/spawn.rs
+++ b/src-tauri/src/agent/spawn.rs
@@ -475,13 +475,22 @@ impl Agent {
         }
     }
 
-    /// Push a mid-session model/effort change into a live per-turn runner so the
-    /// next turn uses it. No-op for claude (Managed/Pty), whose config is baked
-    /// into its persistent process and re-applied by a session-preserving
-    /// respawn instead.
-    pub fn set_config(&self, model: Option<&str>, effort: Option<&str>) {
+    /// Push a mid-session model change into a live per-turn runner so the next
+    /// turn uses it. No-op for claude (Managed/Pty), whose config is baked into
+    /// its persistent process and re-applied by a session-preserving respawn.
+    /// Model and effort are set independently so concurrent changes to each
+    /// can't overwrite one another.
+    pub fn set_model(&self, model: Option<&str>) {
         if let Self::PerTurn(a) = self {
-            a.session.set_config(model, effort);
+            a.session.set_model(model);
+        }
+    }
+
+    /// Push a mid-session effort change into a live per-turn runner (see
+    /// `set_model`).
+    pub fn set_effort(&self, effort: Option<&str>) {
+        if let Self::PerTurn(a) = self {
+            a.session.set_effort(effort);
         }
     }
 

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -115,17 +115,9 @@ pub fn send_user_message(
     turn_id: String,
     text: String,
     attachments: Vec<String>,
-    thinking: Option<String>,
 ) -> Result<bool> {
     let sup = supervisor.inner().clone();
-    sup.send_user_message(
-        &app,
-        &agent_id,
-        &turn_id,
-        &text,
-        &attachments,
-        thinking.as_deref(),
-    )
+    sup.send_user_message(&app, &agent_id, &turn_id, &text, &attachments)
 }
 
 #[tauri::command]

--- a/src-tauri/src/exec_session.rs
+++ b/src-tauri/src/exec_session.rs
@@ -152,12 +152,17 @@ impl ExecSession {
         }
     }
 
-    /// Update the live session's model/effort mid-conversation. The next turn's
-    /// argv picks them up (each turn is a fresh process that re-reads this), so
-    /// no process restart is needed — unlike claude, whose config is baked into
-    /// its persistent process.
-    pub fn set_config(&self, model: Option<&str>, effort: Option<&str>) {
+    /// Update the live session's model mid-conversation. The next turn's argv
+    /// picks it up (each turn is a fresh process that re-reads this), so no
+    /// restart is needed. Touches only the model field so a concurrent effort
+    /// change can't be clobbered.
+    pub fn set_model(&self, model: Option<&str>) {
         *self.model.lock() = model.map(str::to_string);
+    }
+
+    /// Update the live session's effort mid-conversation (see `set_model`).
+    /// Touches only the effort field.
+    pub fn set_effort(&self, effort: Option<&str>) {
         *self.effort.lock() = effort.map(str::to_string);
     }
 

--- a/src-tauri/src/exec_session.rs
+++ b/src-tauri/src/exec_session.rs
@@ -80,8 +80,11 @@ pub struct ExecSession {
     env: Vec<(String, String)>,
     kill_plan: KillHandle,
     session_id: Arc<Mutex<Option<String>>>,
-    model: Option<String>,
-    effort: Option<String>,
+    /// Session-level model + effort. Interior-mutable (like `session_id`) so a
+    /// mid-session change (`set_config`) is picked up on the next turn without
+    /// recreating the session.
+    model: Mutex<Option<String>>,
+    effort: Mutex<Option<String>>,
     child: Arc<Mutex<Option<Child>>>,
     interrupted: Arc<AtomicBool>,
     /// Monotonic turn counter. A reap thread only reports its exit if its
@@ -136,8 +139,8 @@ impl ExecSession {
             env: spec.env,
             kill_plan: spec.kill_plan,
             session_id: Arc::new(Mutex::new(spec.session_id)),
-            model: spec.model,
-            effort: spec.effort,
+            model: Mutex::new(spec.model),
+            effort: Mutex::new(spec.effort),
             child: Arc::new(Mutex::new(None)),
             interrupted: Arc::new(AtomicBool::new(false)),
             turn_seq: Arc::new(AtomicU64::new(0)),
@@ -147,6 +150,15 @@ impl ExecSession {
             on_session_id: Arc::new(cb.on_session_id),
             on_exit: Arc::new(cb.on_exit),
         }
+    }
+
+    /// Update the live session's model/effort mid-conversation. The next turn's
+    /// argv picks them up (each turn is a fresh process that re-reads this), so
+    /// no process restart is needed — unlike claude, whose config is baked into
+    /// its persistent process.
+    pub fn set_config(&self, model: Option<&str>, effort: Option<&str>) {
+        *self.model.lock() = model.map(str::to_string);
+        *self.effort.lock() = effort.map(str::to_string);
     }
 
     pub fn send_user_message(&self, text: &str, attachments: &[String]) -> Result<()> {
@@ -173,15 +185,15 @@ impl ExecSession {
             prompt.push_str(&format!("Attached file: {path}"));
         }
 
+        // Read the live session config fresh each turn: model/effort are
+        // session-level but user-changeable mid-session (see `set_config`), so a
+        // change lands on the very next turn without recreating the session.
+        // Clone out of each lock independently so we never hold two at once.
         let args = {
-            let id = self.session_id.lock();
-            // Effort is a session-level setting, re-emitted each turn like model.
-            (self.build_args)(
-                &prompt,
-                id.as_deref(),
-                self.effort.as_deref(),
-                self.model.as_deref(),
-            )
+            let id = self.session_id.lock().clone();
+            let effort = self.effort.lock().clone();
+            let model = self.model.lock().clone();
+            (self.build_args)(&prompt, id.as_deref(), effort.as_deref(), model.as_deref())
         };
         let mut cmd = Command::new(&self.program);
         cmd.args(&self.prefix_args);

--- a/src-tauri/src/exec_session.rs
+++ b/src-tauri/src/exec_session.rs
@@ -53,6 +53,11 @@ pub struct ExecSpawn {
     pub session_id: Option<String>,
     /// Session-level model override. `None` keeps the provider CLI default.
     pub model: Option<String>,
+    /// Session-level reasoning effort, re-emitted on every turn's argv (like
+    /// `model`) because each turn is a fresh process that re-reads its config;
+    /// `None` keeps the CLI default. Sourced from the session record, not per
+    /// message — effort is a session/config setting in every per-turn CLI.
+    pub effort: Option<String>,
     /// When false, the turn's stdout is **plaintext** — drained without JSON
     /// parsing (no events emitted). History for such agents comes from their
     /// on-disk transcript, and the session id from the filesystem.
@@ -76,6 +81,7 @@ pub struct ExecSession {
     kill_plan: KillHandle,
     session_id: Arc<Mutex<Option<String>>>,
     model: Option<String>,
+    effort: Option<String>,
     child: Arc<Mutex<Option<Child>>>,
     interrupted: Arc<AtomicBool>,
     /// Monotonic turn counter. A reap thread only reports its exit if its
@@ -131,6 +137,7 @@ impl ExecSession {
             kill_plan: spec.kill_plan,
             session_id: Arc::new(Mutex::new(spec.session_id)),
             model: spec.model,
+            effort: spec.effort,
             child: Arc::new(Mutex::new(None)),
             interrupted: Arc::new(AtomicBool::new(false)),
             turn_seq: Arc::new(AtomicU64::new(0)),
@@ -142,12 +149,7 @@ impl ExecSession {
         }
     }
 
-    pub fn send_user_message(
-        &self,
-        text: &str,
-        attachments: &[String],
-        thinking: Option<&str>,
-    ) -> Result<()> {
+    pub fn send_user_message(&self, text: &str, attachments: &[String]) -> Result<()> {
         // Claim this turn's sequence number first, so a superseded turn's
         // reap thread sees it's no longer current and stays quiet.
         let seq = self.turn_seq.fetch_add(1, Ordering::SeqCst) + 1;
@@ -173,7 +175,13 @@ impl ExecSession {
 
         let args = {
             let id = self.session_id.lock();
-            (self.build_args)(&prompt, id.as_deref(), thinking, self.model.as_deref())
+            // Effort is a session-level setting, re-emitted each turn like model.
+            (self.build_args)(
+                &prompt,
+                id.as_deref(),
+                self.effort.as_deref(),
+                self.model.as_deref(),
+            )
         };
         let mut cmd = Command::new(&self.program);
         cmd.args(&self.prefix_args);
@@ -437,6 +445,7 @@ mod tests {
                 cwd: dir.path().to_path_buf(),
                 session_id: None,
                 model: None,
+                effort: None,
                 stdout_is_json: true,
                 env: vec![],
                 kill_plan: KillHandle::ProcessGroup,
@@ -456,7 +465,7 @@ mod tests {
             },
         );
 
-        session.send_user_message("hello", &[], None).unwrap();
+        session.send_user_message("hello", &[]).unwrap();
 
         let mut events = Vec::new();
         let deadline = Instant::now() + Duration::from_secs(5);
@@ -496,6 +505,7 @@ mod tests {
                 cwd: dir.path().to_path_buf(),
                 session_id: Some("prev-thread".into()),
                 model: Some("gpt-5.2-codex".into()),
+                effort: None,
                 stdout_is_json: true,
                 env: vec![],
                 kill_plan: KillHandle::ProcessGroup,
@@ -511,7 +521,7 @@ mod tests {
             },
         );
 
-        session.send_user_message("again", &[], None).unwrap();
+        session.send_user_message("again", &[]).unwrap();
         erx.recv_timeout(Duration::from_secs(5)).unwrap();
         let args = std::fs::read_to_string(dir.path().join("argv.txt")).unwrap();
         assert!(args.contains("exec resume prev-thread"), "argv was: {args}");
@@ -535,6 +545,7 @@ mod tests {
                 cwd: dir.path().to_path_buf(),
                 session_id: None,
                 model: None,
+                effort: None,
                 stdout_is_json: true,
                 env: vec![],
                 kill_plan: KillHandle::ProcessGroup,
@@ -550,7 +561,7 @@ mod tests {
             },
         );
 
-        session.send_user_message("hello", &[], None).unwrap();
+        session.send_user_message("hello", &[]).unwrap();
         let exit = xrx.recv_timeout(Duration::from_secs(2)).unwrap();
         assert!(!exit.success);
         assert!(!exit.interrupted);
@@ -593,6 +604,7 @@ mod tests {
                 cwd: dir.path().to_path_buf(),
                 session_id: None,
                 model: None,
+                effort: None,
                 stdout_is_json: true,
                 env: vec![],
                 kill_plan: KillHandle::ProcessGroup,
@@ -617,7 +629,7 @@ mod tests {
                 session.interrupt();
                 drop(busy_fd);
             });
-            session.send_user_message("hello", &[], None).unwrap();
+            session.send_user_message("hello", &[]).unwrap();
         });
 
         let exit = xrx

--- a/src-tauri/src/exec_session.rs
+++ b/src-tauri/src/exec_session.rs
@@ -51,13 +51,6 @@ pub struct ExecSpawn {
     pub cwd: PathBuf,
     /// Session id to resume, if one has been captured already.
     pub session_id: Option<String>,
-    /// Session-level model override. `None` keeps the provider CLI default.
-    pub model: Option<String>,
-    /// Session-level reasoning effort, re-emitted on every turn's argv (like
-    /// `model`) because each turn is a fresh process that re-reads its config;
-    /// `None` keeps the CLI default. Sourced from the session record, not per
-    /// message — effort is a session/config setting in every per-turn CLI.
-    pub effort: Option<String>,
     /// When false, the turn's stdout is **plaintext** — drained without JSON
     /// parsing (no events emitted). History for such agents comes from their
     /// on-disk transcript, and the session id from the filesystem.
@@ -80,11 +73,6 @@ pub struct ExecSession {
     env: Vec<(String, String)>,
     kill_plan: KillHandle,
     session_id: Arc<Mutex<Option<String>>>,
-    /// Session-level model + effort. Interior-mutable (like `session_id`) so a
-    /// mid-session change (`set_config`) is picked up on the next turn without
-    /// recreating the session.
-    model: Mutex<Option<String>>,
-    effort: Mutex<Option<String>>,
     child: Arc<Mutex<Option<Child>>>,
     interrupted: Arc<AtomicBool>,
     /// Monotonic turn counter. A reap thread only reports its exit if its
@@ -139,8 +127,6 @@ impl ExecSession {
             env: spec.env,
             kill_plan: spec.kill_plan,
             session_id: Arc::new(Mutex::new(spec.session_id)),
-            model: Mutex::new(spec.model),
-            effort: Mutex::new(spec.effort),
             child: Arc::new(Mutex::new(None)),
             interrupted: Arc::new(AtomicBool::new(false)),
             turn_seq: Arc::new(AtomicU64::new(0)),
@@ -152,21 +138,17 @@ impl ExecSession {
         }
     }
 
-    /// Update the live session's model mid-conversation. The next turn's argv
-    /// picks it up (each turn is a fresh process that re-reads this), so no
-    /// restart is needed. Touches only the model field so a concurrent effort
-    /// change can't be clobbered.
-    pub fn set_model(&self, model: Option<&str>) {
-        *self.model.lock() = model.map(str::to_string);
-    }
-
-    /// Update the live session's effort mid-conversation (see `set_model`).
-    /// Touches only the effort field.
-    pub fn set_effort(&self, effort: Option<&str>) {
-        *self.effort.lock() = effort.map(str::to_string);
-    }
-
-    pub fn send_user_message(&self, text: &str, attachments: &[String]) -> Result<()> {
+    /// Run one turn. `model`/`effort` are the session's current config, resolved
+    /// by the supervisor from the session record at dispatch and passed in per
+    /// turn (each turn is a fresh process). The session stores no config of its
+    /// own, so there's nothing to go stale or be raced by a concurrent change.
+    pub fn send_user_message(
+        &self,
+        text: &str,
+        attachments: &[String],
+        model: Option<&str>,
+        effort: Option<&str>,
+    ) -> Result<()> {
         // Claim this turn's sequence number first, so a superseded turn's
         // reap thread sees it's no longer current and stays quiet.
         let seq = self.turn_seq.fetch_add(1, Ordering::SeqCst) + 1;
@@ -190,15 +172,9 @@ impl ExecSession {
             prompt.push_str(&format!("Attached file: {path}"));
         }
 
-        // Read the live session config fresh each turn: model/effort are
-        // session-level but user-changeable mid-session (see `set_config`), so a
-        // change lands on the very next turn without recreating the session.
-        // Clone out of each lock independently so we never hold two at once.
         let args = {
-            let id = self.session_id.lock().clone();
-            let effort = self.effort.lock().clone();
-            let model = self.model.lock().clone();
-            (self.build_args)(&prompt, id.as_deref(), effort.as_deref(), model.as_deref())
+            let id = self.session_id.lock();
+            (self.build_args)(&prompt, id.as_deref(), effort, model)
         };
         let mut cmd = Command::new(&self.program);
         cmd.args(&self.prefix_args);
@@ -461,8 +437,6 @@ mod tests {
                 keepalive: Keepalive::None,
                 cwd: dir.path().to_path_buf(),
                 session_id: None,
-                model: None,
-                effort: None,
                 stdout_is_json: true,
                 env: vec![],
                 kill_plan: KillHandle::ProcessGroup,
@@ -482,7 +456,7 @@ mod tests {
             },
         );
 
-        session.send_user_message("hello", &[]).unwrap();
+        session.send_user_message("hello", &[], None, None).unwrap();
 
         let mut events = Vec::new();
         let deadline = Instant::now() + Duration::from_secs(5);
@@ -521,8 +495,6 @@ mod tests {
                 keepalive: Keepalive::None,
                 cwd: dir.path().to_path_buf(),
                 session_id: Some("prev-thread".into()),
-                model: Some("gpt-5.2-codex".into()),
-                effort: None,
                 stdout_is_json: true,
                 env: vec![],
                 kill_plan: KillHandle::ProcessGroup,
@@ -538,7 +510,9 @@ mod tests {
             },
         );
 
-        session.send_user_message("again", &[]).unwrap();
+        session
+            .send_user_message("again", &[], Some("gpt-5.2-codex"), None)
+            .unwrap();
         erx.recv_timeout(Duration::from_secs(5)).unwrap();
         let args = std::fs::read_to_string(dir.path().join("argv.txt")).unwrap();
         assert!(args.contains("exec resume prev-thread"), "argv was: {args}");
@@ -561,8 +535,6 @@ mod tests {
                 keepalive: Keepalive::None,
                 cwd: dir.path().to_path_buf(),
                 session_id: None,
-                model: None,
-                effort: None,
                 stdout_is_json: true,
                 env: vec![],
                 kill_plan: KillHandle::ProcessGroup,
@@ -578,7 +550,7 @@ mod tests {
             },
         );
 
-        session.send_user_message("hello", &[]).unwrap();
+        session.send_user_message("hello", &[], None, None).unwrap();
         let exit = xrx.recv_timeout(Duration::from_secs(2)).unwrap();
         assert!(!exit.success);
         assert!(!exit.interrupted);
@@ -620,8 +592,6 @@ mod tests {
                 keepalive: Keepalive::None,
                 cwd: dir.path().to_path_buf(),
                 session_id: None,
-                model: None,
-                effort: None,
                 stdout_is_json: true,
                 env: vec![],
                 kill_plan: KillHandle::ProcessGroup,
@@ -646,7 +616,7 @@ mod tests {
                 session.interrupt();
                 drop(busy_fd);
             });
-            session.send_user_message("hello", &[]).unwrap();
+            session.send_user_message("hello", &[], None, None).unwrap();
         });
 
         let exit = xrx

--- a/src-tauri/src/message_queue.rs
+++ b/src-tauri/src/message_queue.rs
@@ -45,13 +45,13 @@ pub enum InjectionMode {
 }
 
 /// One follow-up message the user sent. `text` + `attachments` are what get
-/// coalesced; `thinking` rides along to the delivery path.
+/// coalesced. (Reasoning effort is session-level — read from the record on each
+/// turn — so it no longer rides individual messages.)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PendingMsg {
     pub turn_id: String,
     pub text: String,
     pub attachments: Vec<String>,
-    pub thinking: Option<String>,
 }
 
 /// What to do with a freshly-sent message. Pure decision — see
@@ -161,8 +161,8 @@ impl MessageQueue {
 /// Merge queued messages into one delivery:
 /// - text: non-empty bodies newline-joined in send order,
 /// - attachments: unioned, order-preserving, deduped,
-/// - metadata (`thinking`) + `turn_id`: taken from the LAST message — most
-///   recent intent (CQ1-A), and a real client-known id for the coalesced row.
+/// - `turn_id`: taken from the LAST message — a real client-known id for the
+///   coalesced row (CQ1-A).
 ///
 /// A single queued message passes through untouched (no separators, no churn).
 fn coalesce(msgs: Vec<PendingMsg>) -> PendingMsg {
@@ -188,7 +188,6 @@ fn coalesce(msgs: Vec<PendingMsg>) -> PendingMsg {
         turn_id: last.turn_id.clone(),
         text: texts.join("\n\n"),
         attachments,
-        thinking: last.thinking.clone(),
     }
 }
 
@@ -196,12 +195,11 @@ fn coalesce(msgs: Vec<PendingMsg>) -> PendingMsg {
 mod tests {
     use super::*;
 
-    fn msg(turn_id: &str, text: &str, attachments: &[&str], thinking: Option<&str>) -> PendingMsg {
+    fn msg(turn_id: &str, text: &str, attachments: &[&str]) -> PendingMsg {
         PendingMsg {
             turn_id: turn_id.into(),
             text: text.into(),
             attachments: attachments.iter().map(|s| s.to_string()).collect(),
-            thinking: thinking.map(str::to_string),
         }
     }
 
@@ -264,8 +262,8 @@ mod tests {
         let mut q = MessageQueue::new();
         assert!(q.is_empty("a"));
         assert_eq!(q.len("a"), 0);
-        q.enqueue("a", msg("t1", "hi", &[], None));
-        q.enqueue("a", msg("t2", "there", &[], None));
+        q.enqueue("a", msg("t1", "hi", &[]));
+        q.enqueue("a", msg("t2", "there", &[]));
         assert!(!q.is_empty("a"));
         assert_eq!(q.len("a"), 2);
         // isolation between agents
@@ -276,8 +274,8 @@ mod tests {
     fn turn_ids_lists_queued_in_fifo_order() {
         let mut q = MessageQueue::new();
         assert!(q.turn_ids("a").is_empty());
-        q.enqueue("a", msg("t1", "hi", &[], None));
-        q.enqueue("a", msg("t2", "there", &[], None));
+        q.enqueue("a", msg("t1", "hi", &[]));
+        q.enqueue("a", msg("t2", "there", &[]));
         assert_eq!(q.turn_ids("a"), vec!["t1".to_string(), "t2".to_string()]);
         // Draining empties it; the persisted-row cleanup then keeps nothing.
         q.drain_coalesced("a");
@@ -293,7 +291,7 @@ mod tests {
     #[test]
     fn drain_clears_the_queue() {
         let mut q = MessageQueue::new();
-        q.enqueue("a", msg("t1", "hi", &[], None));
+        q.enqueue("a", msg("t1", "hi", &[]));
         assert!(q.drain_coalesced("a").is_some());
         assert!(q.is_empty("a"));
         assert_eq!(q.drain_coalesced("a"), None);
@@ -304,11 +302,8 @@ mod tests {
         // A failed flush re-queues the coalesced batch; a message queued since
         // must not jump ahead of it.
         let mut q = MessageQueue::new();
-        q.enqueue(
-            "a",
-            msg("t-new", "queued after the failed flush", &[], None),
-        );
-        q.requeue_front("a", msg("t-coalesced", "first\n\nsecond", &[], None));
+        q.enqueue("a", msg("t-new", "queued after the failed flush", &[]));
+        q.requeue_front("a", msg("t-coalesced", "first\n\nsecond", &[]));
         let out = q.drain_coalesced("a").unwrap();
         assert_eq!(out.text, "first\n\nsecond\n\nqueued after the failed flush");
     }
@@ -316,7 +311,7 @@ mod tests {
     #[test]
     fn clear_drops_messages() {
         let mut q = MessageQueue::new();
-        q.enqueue("a", msg("t1", "hi", &[], None));
+        q.enqueue("a", msg("t1", "hi", &[]));
         q.clear("a");
         assert!(q.is_empty("a"));
     }
@@ -326,7 +321,7 @@ mod tests {
     #[test]
     fn single_message_passes_through() {
         let mut q = MessageQueue::new();
-        let m = msg("t1", "only", &["/a.txt"], Some("high"));
+        let m = msg("t1", "only", &["/a.txt"]);
         q.enqueue("a", m.clone());
         assert_eq!(q.drain_coalesced("a"), Some(m));
     }
@@ -334,9 +329,9 @@ mod tests {
     #[test]
     fn coalesce_joins_text_in_order() {
         let mut q = MessageQueue::new();
-        q.enqueue("a", msg("t1", "first", &[], None));
-        q.enqueue("a", msg("t2", "second", &[], None));
-        q.enqueue("a", msg("t3", "third", &[], None));
+        q.enqueue("a", msg("t1", "first", &[]));
+        q.enqueue("a", msg("t2", "second", &[]));
+        q.enqueue("a", msg("t3", "third", &[]));
         let out = q.drain_coalesced("a").unwrap();
         assert_eq!(out.text, "first\n\nsecond\n\nthird");
     }
@@ -345,8 +340,8 @@ mod tests {
     fn coalesce_skips_empty_text_bodies() {
         // An attachment-only message contributes no text line.
         let mut q = MessageQueue::new();
-        q.enqueue("a", msg("t1", "hello", &[], None));
-        q.enqueue("a", msg("t2", "", &["/img.png"], None));
+        q.enqueue("a", msg("t1", "hello", &[]));
+        q.enqueue("a", msg("t2", "", &["/img.png"]));
         let out = q.drain_coalesced("a").unwrap();
         assert_eq!(out.text, "hello");
         assert_eq!(out.attachments, vec!["/img.png".to_string()]);
@@ -355,8 +350,8 @@ mod tests {
     #[test]
     fn coalesce_unions_attachments_dedup_preserving_order() {
         let mut q = MessageQueue::new();
-        q.enqueue("a", msg("t1", "x", &["/a.txt", "/b.txt"], None));
-        q.enqueue("a", msg("t2", "y", &["/b.txt", "/c.txt"], None));
+        q.enqueue("a", msg("t1", "x", &["/a.txt", "/b.txt"]));
+        q.enqueue("a", msg("t2", "y", &["/b.txt", "/c.txt"]));
         let out = q.drain_coalesced("a").unwrap();
         assert_eq!(
             out.attachments,
@@ -369,13 +364,12 @@ mod tests {
     }
 
     #[test]
-    fn coalesce_takes_last_message_metadata_and_turn_id() {
-        // CQ1-A: last-message-wins for thinking; turn_id is the last id.
+    fn coalesce_takes_last_turn_id() {
+        // CQ1-A: the coalesced row carries the last message's turn_id.
         let mut q = MessageQueue::new();
-        q.enqueue("a", msg("t1", "x", &[], Some("low")));
-        q.enqueue("a", msg("t2", "y", &[], Some("high")));
+        q.enqueue("a", msg("t1", "x", &[]));
+        q.enqueue("a", msg("t2", "y", &[]));
         let out = q.drain_coalesced("a").unwrap();
-        assert_eq!(out.thinking, Some("high".to_string()));
         assert_eq!(out.turn_id, "t2");
     }
 }

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -1118,7 +1118,8 @@ impl Supervisor {
     ) -> Result<()> {
         self.workspace.update_agent_effort(agent_id, effort)?;
         emit_effort(app, agent_id, effort);
-        self.reapply_session_config(app, agent_id).await
+        self.reapply_session_config(app, agent_id, |agent| agent.set_effort(effort))
+            .await
     }
 
     /// Change a session's model mid-conversation. Persists the new value so
@@ -1132,7 +1133,8 @@ impl Supervisor {
     ) -> Result<()> {
         self.workspace.update_agent_model(agent_id, model)?;
         emit_model(app, agent_id, model);
-        self.reapply_session_config(app, agent_id).await
+        self.reapply_session_config(app, agent_id, |agent| agent.set_model(model))
+            .await
     }
 
     /// Make a just-persisted model/effort change take effect on the live agent.
@@ -1144,18 +1146,23 @@ impl Supervisor {
     /// without a running process.
     ///
     /// Per-turn agents keep a live `ExecSession` across turns that froze its
-    /// config at construction, so we push the new values into it directly — the
-    /// next turn's fresh process picks them up, no restart. If the agent isn't
+    /// config at construction, so `apply_live` pushes the change into it — the
+    /// next turn's fresh process picks it up, no restart. If the agent isn't
     /// live, the record update alone suffices (its next spawn reads it).
+    ///
+    /// `apply_live` touches only the one field the caller changed (`set_model`
+    /// *or* `set_effort`), so a model change and an effort change made
+    /// concurrently can't overwrite each other's live value — each writes its
+    /// own independent field.
     async fn reapply_session_config(
         self: &Arc<Self>,
         app: &AppHandle,
         agent_id: &str,
+        apply_live: impl FnOnce(&Agent),
     ) -> Result<()> {
-        let record = self.workspace.agent(agent_id)?;
-        if is_per_turn_provider(&record.provider) {
+        if is_per_turn_provider(&self.workspace.agent(agent_id)?.provider) {
             if let Some(agent) = self.agents.lock().get(agent_id) {
-                agent.set_config(record.model.as_deref(), record.effort.as_deref());
+                apply_live(agent);
             }
         } else {
             self.respawn_agent_preserving_session(app, agent_id).await?;

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -942,10 +942,9 @@ impl Supervisor {
                         cwd,
                         sandbox_root,
                         session_id,
-                        model: record.model.clone(),
-                        // Session-level effort, re-applied on every turn's argv
-                        // just like model (the CLI reads it per invocation).
-                        effort: record.effort.clone(),
+                        // model/effort aren't spawn-time for per-turn agents:
+                        // the supervisor resolves them from the record and passes
+                        // them into each turn's dispatch (see deliver_user_message).
                         instructions: instructions.clone(),
                         mcp_servers: mcp_servers.clone(),
                         rpc_dir,
@@ -1118,8 +1117,7 @@ impl Supervisor {
     ) -> Result<()> {
         self.workspace.update_agent_effort(agent_id, effort)?;
         emit_effort(app, agent_id, effort);
-        self.reapply_session_config(app, agent_id, |agent| agent.set_effort(effort))
-            .await
+        self.reapply_session_config(app, agent_id).await
     }
 
     /// Change a session's model mid-conversation. Persists the new value so
@@ -1133,38 +1131,26 @@ impl Supervisor {
     ) -> Result<()> {
         self.workspace.update_agent_model(agent_id, model)?;
         emit_model(app, agent_id, model);
-        self.reapply_session_config(app, agent_id, |agent| agent.set_model(model))
-            .await
+        self.reapply_session_config(app, agent_id).await
     }
 
-    /// Make a just-persisted model/effort change take effect on the live agent.
+    /// Make a just-persisted model/effort change take effect.
     ///
-    /// claude bakes both into its launch args (`--model`/`--effort`), so it
-    /// needs a session-preserving respawn (eager when idle, deferred to the next
-    /// turn boundary when busy). A failed restart propagates: the new value is
-    /// persisted, but the caller must not report success when the agent is left
-    /// without a running process.
+    /// Per-turn agents read model/effort from the session record when each turn
+    /// is dispatched (see `deliver_user_message`), so persisting the record is
+    /// all that's needed — nothing to do here.
     ///
-    /// Per-turn agents keep a live `ExecSession` across turns that froze its
-    /// config at construction, so `apply_live` pushes the change into it — the
-    /// next turn's fresh process picks it up, no restart. If the agent isn't
-    /// live, the record update alone suffices (its next spawn reads it).
-    ///
-    /// `apply_live` touches only the one field the caller changed (`set_model`
-    /// *or* `set_effort`), so a model change and an effort change made
-    /// concurrently can't overwrite each other's live value — each writes its
-    /// own independent field.
+    /// claude bakes both into its persistent process's launch args
+    /// (`--model`/`--effort`), so it needs a session-preserving respawn (eager
+    /// when idle, deferred to the next turn boundary when busy). A failed restart
+    /// propagates: the new value is persisted, but the caller must not report
+    /// success when the agent is left without a running process.
     async fn reapply_session_config(
         self: &Arc<Self>,
         app: &AppHandle,
         agent_id: &str,
-        apply_live: impl FnOnce(&Agent),
     ) -> Result<()> {
-        if is_per_turn_provider(&self.workspace.agent(agent_id)?.provider) {
-            if let Some(agent) = self.agents.lock().get(agent_id) {
-                apply_live(agent);
-            }
-        } else {
+        if !is_per_turn_provider(&self.workspace.agent(agent_id)?.provider) {
             self.respawn_agent_preserving_session(app, agent_id).await?;
         }
         Ok(())

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -1135,19 +1135,29 @@ impl Supervisor {
         self.reapply_session_config(app, agent_id).await
     }
 
-    /// Make a just-persisted model/effort change take effect on the live
-    /// process. claude bakes both into its launch args (`--model`/`--effort`),
-    /// so it needs a session-preserving respawn (eager when idle, deferred to
-    /// the next turn boundary when busy); per-turn agents re-read the record on
-    /// their next turn, so nothing to restart. A failed restart propagates: the
-    /// new value is persisted, but the caller must not report success when the
-    /// agent is left without a running process.
+    /// Make a just-persisted model/effort change take effect on the live agent.
+    ///
+    /// claude bakes both into its launch args (`--model`/`--effort`), so it
+    /// needs a session-preserving respawn (eager when idle, deferred to the next
+    /// turn boundary when busy). A failed restart propagates: the new value is
+    /// persisted, but the caller must not report success when the agent is left
+    /// without a running process.
+    ///
+    /// Per-turn agents keep a live `ExecSession` across turns that froze its
+    /// config at construction, so we push the new values into it directly — the
+    /// next turn's fresh process picks them up, no restart. If the agent isn't
+    /// live, the record update alone suffices (its next spawn reads it).
     async fn reapply_session_config(
         self: &Arc<Self>,
         app: &AppHandle,
         agent_id: &str,
     ) -> Result<()> {
-        if !is_per_turn_provider(&self.workspace.agent(agent_id)?.provider) {
+        let record = self.workspace.agent(agent_id)?;
+        if is_per_turn_provider(&record.provider) {
+            if let Some(agent) = self.agents.lock().get(agent_id) {
+                agent.set_config(record.model.as_deref(), record.effort.as_deref());
+            }
+        } else {
             self.respawn_agent_preserving_session(app, agent_id).await?;
         }
         Ok(())

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -943,6 +943,9 @@ impl Supervisor {
                         sandbox_root,
                         session_id,
                         model: record.model.clone(),
+                        // Session-level effort, re-applied on every turn's argv
+                        // just like model (the CLI reads it per invocation).
+                        effort: record.effort.clone(),
                         instructions: instructions.clone(),
                         mcp_servers: mcp_servers.clone(),
                         rpc_dir,

--- a/src-tauri/src/supervisor/messaging.rs
+++ b/src-tauri/src/supervisor/messaging.rs
@@ -120,8 +120,10 @@ impl Supervisor {
         // `live_agent` yields `AgentNotFound` when the turn already ended; the
         // send error then propagates untouched so the caller's fallback still
         // fires. Both happen with the `agents` lock released (see `live_agent`).
+        // Live injection is claude-only (managed), and claude's model/effort are
+        // fixed on its running process — so no per-turn config to pass.
         self.live_agent(agent_id)?
-            .send_user_message(&msg.text, &msg.attachments)?;
+            .send_user_message(&msg.text, &msg.attachments, None, None)?;
         if let Err(e) =
             self.workspace
                 .insert_user_turn(agent_id, &msg.turn_id, &msg.text, &msg.attachments)
@@ -160,8 +162,17 @@ impl Supervisor {
         {
             tracing::warn!(error = %e, agent_id, "persist outgoing user turn failed");
         }
+        // Resolve the session's current model/effort from the record at dispatch
+        // — the single source of truth. Per-turn runners bake it into this turn's
+        // argv; claude (managed) ignores it (config fixed on its process).
+        let record = self.workspace.agent(agent_id)?;
         let agent = self.live_agent(agent_id)?;
-        agent.send_user_message(text, attachments)?;
+        agent.send_user_message(
+            text,
+            attachments,
+            record.model.as_deref(),
+            record.effort.as_deref(),
+        )?;
         Ok(())
     }
 

--- a/src-tauri/src/supervisor/messaging.rs
+++ b/src-tauri/src/supervisor/messaging.rs
@@ -33,7 +33,6 @@ impl Supervisor {
         turn_id: &str,
         text: &str,
         attachments: &[String],
-        thinking: Option<&str>,
     ) -> Result<bool> {
         let mode = injection_mode(&self.workspace.agent(agent_id)?.provider);
         let busy = self.is_busy(agent_id);
@@ -48,7 +47,6 @@ impl Supervisor {
             turn_id: turn_id.to_string(),
             text: text.to_string(),
             attachments: attachments.to_vec(),
-            thinking: thinking.map(str::to_string),
         };
 
         let delivery = decide_delivery(busy, mode, tool_gated, queue_nonempty);
@@ -122,11 +120,8 @@ impl Supervisor {
         // `live_agent` yields `AgentNotFound` when the turn already ended; the
         // send error then propagates untouched so the caller's fallback still
         // fires. Both happen with the `agents` lock released (see `live_agent`).
-        self.live_agent(agent_id)?.send_user_message(
-            &msg.text,
-            &msg.attachments,
-            msg.thinking.as_deref(),
-        )?;
+        self.live_agent(agent_id)?
+            .send_user_message(&msg.text, &msg.attachments)?;
         if let Err(e) =
             self.workspace
                 .insert_user_turn(agent_id, &msg.turn_id, &msg.text, &msg.attachments)
@@ -157,7 +152,6 @@ impl Supervisor {
         turn_id: &str,
         text: &str,
         attachments: &[String],
-        thinking: Option<&str>,
     ) -> Result<()> {
         // Durable capture first — independent of whether the agent accepts.
         if let Err(e) = self
@@ -167,7 +161,7 @@ impl Supervisor {
             tracing::warn!(error = %e, agent_id, "persist outgoing user turn failed");
         }
         let agent = self.live_agent(agent_id)?;
-        agent.send_user_message(text, attachments, thinking)?;
+        agent.send_user_message(text, attachments)?;
         Ok(())
     }
 
@@ -305,13 +299,7 @@ fn deliver_as_turn(
     if deletion_guard.contains(&project_id) {
         return Err(Error::Other("project deletion is in progress".into()));
     }
-    sup.deliver_user_message(
-        agent_id,
-        &msg.turn_id,
-        &msg.text,
-        &msg.attachments,
-        msg.thinking.as_deref(),
-    )?;
+    sup.deliver_user_message(agent_id, &msg.turn_id, &msg.text, &msg.attachments)?;
     mark_user_turn_started(sup, app, agent_id, Some(&msg.turn_id));
     on_first_user_message(
         sup.clone(),
@@ -466,7 +454,7 @@ mod tests {
         sup.workspace.add_agent(&mut record).unwrap();
 
         let err = sup
-            .deliver_user_message("yosemite", "turn-1", "hello", &[], None)
+            .deliver_user_message("yosemite", "turn-1", "hello", &[])
             .unwrap_err();
         assert!(matches!(err, Error::AgentNotFound(_)));
 

--- a/src-tauri/src/workflow/driver.rs
+++ b/src-tauri/src/workflow/driver.rs
@@ -194,7 +194,7 @@ impl AgentDriver for SupervisorDriver {
             let turn_id = uuid::Uuid::new_v4().to_string();
             self.sup
                 .clone()
-                .send_user_message(&self.app, agent_id, &turn_id, &text, &[], None)?;
+                .send_user_message(&self.app, agent_id, &turn_id, &text, &[])?;
             Ok(())
         })
     }

--- a/src-tauri/src/workspace/message_queue.rs
+++ b/src-tauri/src/workspace/message_queue.rs
@@ -34,15 +34,14 @@ impl WorkspaceManager {
         )?;
         tx.execute(
             "INSERT INTO pending_messages
-                (session_id, seq, turn_id, text, attachments, thinking, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                (session_id, seq, turn_id, text, attachments, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             rusqlite::params![
                 sid,
                 seq,
                 msg.turn_id,
                 msg.text,
                 attachments_json,
-                msg.thinking,
                 now_millis()
             ],
         )?;
@@ -105,34 +104,29 @@ impl WorkspaceManager {
     ) -> Result<Vec<(String, crate::message_queue::PendingMsg)>> {
         let conn = self.db.lock();
         let mut stmt = conn.prepare(
-            "SELECT s.workspace_id, p.turn_id, p.text, p.attachments, p.thinking
+            "SELECT s.workspace_id, p.turn_id, p.text, p.attachments
              FROM pending_messages p
              JOIN sessions s ON s.id = p.session_id
              JOIN workspaces w ON w.id = s.workspace_id
              WHERE w.archived_at IS NULL
              ORDER BY s.workspace_id, p.seq ASC",
         )?;
-        let rows: Vec<(String, String, String, String, Option<String>)> = stmt
-            .query_map([], |r| {
-                Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?))
-            })?
+        let rows: Vec<(String, String, String, String)> = stmt
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)))?
             .collect::<std::result::Result<_, rusqlite::Error>>()?;
         rows.into_iter()
-            .map(
-                |(workspace_id, turn_id, text, attachments_text, thinking)| {
-                    let attachments = serde_json::from_str(&attachments_text)
-                        .map_err(|e| Error::Other(format!("deserialize attachments: {e}")))?;
-                    Ok((
-                        workspace_id,
-                        crate::message_queue::PendingMsg {
-                            turn_id,
-                            text,
-                            attachments,
-                            thinking,
-                        },
-                    ))
-                },
-            )
+            .map(|(workspace_id, turn_id, text, attachments_text)| {
+                let attachments = serde_json::from_str(&attachments_text)
+                    .map_err(|e| Error::Other(format!("deserialize attachments: {e}")))?;
+                Ok((
+                    workspace_id,
+                    crate::message_queue::PendingMsg {
+                        turn_id,
+                        text,
+                        attachments,
+                    },
+                ))
+            })
             .collect()
     }
 }

--- a/src-tauri/src/workspace/tests.rs
+++ b/src-tauri/src/workspace/tests.rs
@@ -212,7 +212,6 @@ fn pending_messages_round_trip_and_scoped_delete() {
         turn_id: id.into(),
         text: text.into(),
         attachments: vec![],
-        thinking: None,
     };
 
     // Enqueue three follow-ups; they read back for this workspace in seq order.
@@ -273,7 +272,6 @@ fn pending_messages_excluded_for_archived_workspace() {
             turn_id: "t1".into(),
             text: "hi".into(),
             attachments: vec![],
-            thinking: None,
         },
     )
     .unwrap();

--- a/src/api/domains/agents.ts
+++ b/src/api/domains/agents.ts
@@ -75,19 +75,12 @@ export const agentsApi = {
     invoke<void>("write_to_agent", { agentId, data }),
   /** Resolves to `true` when the message was enqueued for a later turn boundary
    *  rather than delivered now (injected live / sent as a new turn). */
-  sendUserMessage: (
-    agentId: string,
-    turnId: string,
-    text: string,
-    attachments: string[] = [],
-    thinking?: string,
-  ) =>
+  sendUserMessage: (agentId: string, turnId: string, text: string, attachments: string[] = []) =>
     invoke<boolean>("send_user_message", {
       agentId,
       turnId,
       text,
       attachments,
-      thinking: thinking ?? null,
     }),
   answerToolUse: (
     agentId: string,

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -410,9 +410,13 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
               seed={composerSeed}
               onSeedConsumed={onSeedConsumed}
               draftKey={agent.id}
-              onSend={({ text, thinking, attachments }) => {
+              onSend={({ text, attachments }) => {
+                // Effort is session-level now (persisted via onChangeEffort and
+                // read from the record each turn), so sends carry no per-message
+                // effort — the composer's `thinking` in the payload is only used
+                // by the new-agent spawn path.
                 pinnedToBottom.current = true;
-                send(agent.id, text, attachments, thinking);
+                send(agent.id, text, attachments);
               }}
               onStop={() => stop(agent.id)}
             />

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -29,6 +29,8 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
   const turnStartedAt = useAppStore((s) => s.turnStartedAt[agent.id]);
   const switchInFlight = useAppStore((s) => s.switchInFlight[agent.id] ?? false);
   const send = useAppStore((s) => s.sendUserMessage);
+  const setAgentEffort = useAppStore((s) => s.setAgentEffort);
+  const setAgentModel = useAppStore((s) => s.setAgentModel);
   const stop = useAppStore((s) => s.stop);
   const runLocalCommand = useAppStore((s) => s.runLocalCommand);
   const loadHistoryTranscript = useAppStore((s) => s.loadHistoryTranscript);
@@ -363,20 +365,16 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
               defaultCustomAgentId={agent.custom_agent_id ?? undefined}
               initialThinking={agent.effort ?? undefined}
               onChangeEffort={(value) => {
-                // Persist the mid-session change; the backend restarts claude
-                // (resuming the same session) to re-apply --effort, and per-turn
-                // agents pick it up on their next message. Best-effort: a failure
-                // just leaves the prior effort in force.
-                api.setAgentEffort(agent.id, value).catch((e) => {
+                // Go through the store so the change is serialized per agent and
+                // a subsequent send waits for it to land (see queueConfigOp).
+                // claude restarts to re-apply --effort; per-turn agents read the
+                // new value from the record on their next turn.
+                setAgentEffort(agent.id, value).catch((e) => {
                   console.error("set_agent_effort failed", e);
                 });
               }}
               onChangeModel={(model) => {
-                // Persist the mid-session model change; the backend restarts
-                // claude (resuming the same session) to re-apply --model, and
-                // per-turn agents pick it up on their next turn. Best-effort: a
-                // failure just leaves the prior model in force.
-                api.setAgentModel(agent.id, model ?? null).catch((e) => {
+                setAgentModel(agent.id, model ?? null).catch((e) => {
                   console.error("set_agent_model failed", e);
                 });
               }}

--- a/src/store/drafts.ts
+++ b/src/store/drafts.ts
@@ -301,9 +301,10 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
             invocation.snapshot,
           ]
         : assigned;
-      // `thinking` carries the composer's effort selection. For claude it's a
-      // session-level spawn flag (--effort), applied here; per-turn agents
-      // ignore it at spawn and take it per-turn via sendUserMessage below.
+      // `thinking` carries the composer's effort selection. Effort is
+      // session-level for every provider — it's persisted on the record here at
+      // spawn (claude reads it as `--effort`; per-turn agents re-read it from
+      // the record on each turn), so it never rides individual messages.
       const rec = await api.spawnAgent(
         view,
         draft.repoPath,
@@ -353,9 +354,7 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
           api.writeToAgent(rec.id, `${prompt.replace(/\r?\n/g, " ")}\r`),
         );
       } else {
-        await sendWhenAgentReady(() =>
-          api.sendUserMessage(rec.id, turnId, prompt, attachments, thinking),
-        );
+        await sendWhenAgentReady(() => api.sendUserMessage(rec.id, turnId, prompt, attachments));
       }
     } catch (e) {
       const selected = get().selectedAgentId;

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -146,12 +146,7 @@ export interface WorkspaceSlice {
     code: ForkCode,
     context: ForkContext,
   ) => Promise<AgentRecord | null>;
-  sendUserMessage: (
-    id: string,
-    text: string,
-    attachments?: string[],
-    thinking?: string,
-  ) => Promise<void>;
+  sendUserMessage: (id: string, text: string, attachments?: string[]) => Promise<void>;
   /** Answer a paused user-input tool (Claude's AskUserQuestion/ExitPlanMode).
    *  Looks up the held control-protocol request for `toolUseId` and delivers
    *  `updatedInput` (the tool's input with the user's `answers` merged in) as
@@ -389,7 +384,7 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
     }
   },
 
-  sendUserMessage: async (id, text, attachments = [], thinking) => {
+  sendUserMessage: async (id, text, attachments = []) => {
     // Guard: some Claude built-in control commands (e.g. /usage, /agents,
     // /login) only work in its interactive TUI and don't resolve over this
     // view's stream-json transport. Dispatched as a plain message they'd
@@ -480,7 +475,7 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
         };
       });
       try {
-        const enqueued = await api.sendUserMessage(id, turnId, sendText, attachments, thinking);
+        const enqueued = await api.sendUserMessage(id, turnId, sendText, attachments);
         // Only a genuinely-held message wears the badge; a delivered one stays a
         // plain bubble. Match by turnId — agent output may have appended since.
         if (wasBusy && enqueued) {
@@ -499,9 +494,7 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
           // process in --resume mode, then deliver the message once ready.
           // Not busy, so it lands as a new turn (never queued) — no badge.
           await api.resumeAgent(id);
-          await sendWhenAgentReady(() =>
-            api.sendUserMessage(id, turnId, sendText, attachments, thinking),
-          );
+          await sendWhenAgentReady(() => api.sendUserMessage(id, turnId, sendText, attachments));
         } else {
           throw e;
         }

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -30,6 +30,25 @@ import { interruptedAgents } from "./interrupted";
 import { refreshWorkspace } from "./refreshWorkspace";
 import type { AppState, SliceCreator } from "./types";
 
+// Per-agent serialization of session-config mutations (effort/model). Config
+// and message sends travel on separate async channels, so without this a send
+// could reach the backend and dispatch a turn before a just-issued effort/model
+// change was persisted — the turn would then read stale config from the record.
+// `sendUserMessage` awaits the agent's pending config op before dispatching, and
+// chaining also applies rapid config changes in call order.
+const configOps = new Map<string, Promise<void>>();
+
+function queueConfigOp(id: string, op: () => Promise<void>): Promise<void> {
+  const next = (configOps.get(id) ?? Promise.resolve()).catch(() => {}).then(op);
+  configOps.set(id, next);
+  void next
+    .catch(() => {})
+    .finally(() => {
+      if (configOps.get(id) === next) configOps.delete(id);
+    });
+  return next;
+}
+
 /** A degraded transcript-ingest state stored per agent (the `healthy` status is
  *  never stored — it deletes the key). `provider`/`version` are for the banner
  *  copy; `status` picks the message. */
@@ -147,6 +166,12 @@ export interface WorkspaceSlice {
     context: ForkContext,
   ) => Promise<AgentRecord | null>;
   sendUserMessage: (id: string, text: string, attachments?: string[]) => Promise<void>;
+  /** Persist a mid-session reasoning-effort change and (for claude) restart to
+   *  apply it. Serialized per agent so a subsequent send waits for it to land —
+   *  the next turn then reads the new value from the record. */
+  setAgentEffort: (id: string, effort: string | null) => Promise<void>;
+  /** Persist a mid-session model change (see `setAgentEffort`). */
+  setAgentModel: (id: string, model: string | null) => Promise<void>;
   /** Answer a paused user-input tool (Claude's AskUserQuestion/ExitPlanMode).
    *  Looks up the held control-protocol request for `toolUseId` and delivers
    *  `updatedInput` (the tool's input with the user's `answers` merged in) as
@@ -384,7 +409,14 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
     }
   },
 
+  setAgentEffort: (id, effort) => queueConfigOp(id, () => api.setAgentEffort(id, effort)),
+  setAgentModel: (id, model) => queueConfigOp(id, () => api.setAgentModel(id, model)),
+
   sendUserMessage: async (id, text, attachments = []) => {
+    // Wait for any in-flight effort/model change for this agent to land before
+    // dispatching, so the turn reads the intended config from the record (the
+    // backend resolves per-turn config at dispatch). See `queueConfigOp`.
+    await configOps.get(id)?.catch(() => {});
     // Guard: some Claude built-in control commands (e.g. /usage, /agents,
     // /login) only work in its interactive TUI and don't resolve over this
     // view's stream-json transport. Dispatched as a plain message they'd


### PR DESCRIPTION
## What

Simplify how reasoning effort is handled — **no functional change**, changing effort/model still works for every provider; only the under-the-hood mechanism changes.

> **Stacked on #509.** Targets `feat/switch-model-mid-session-ui`; merges after the rest of the series.

## Why

Effort was modeled two different ways:
- **claude:** session-level — `--effort` from `record.effort`.
- **per-turn agents:** per-*message* — the value rode `pending_messages.thinking` → `TurnArgs.thinking` → the CLI flag.

But every per-turn CLI treats effort as a **config value re-passed on each invocation, exactly like model** — codex `-c reasoning_effort`, opencode `--variant`, pi `--thinking` — never as a per-message concept, and none of them receive it in the native TUI (the CLI owns it there). So the per-message transport modeled a distinction no tool makes, and after the mid-session-effort work `record.effort` was written but **never read** for per-turn agents (write-only-for-display).

## Change

Source effort from the session record on every turn, mirroring model:

- **`exec_session` / `spawn`:** `ExecSession` carries `effort` (like `model`) and emits it on each turn's argv; `PerTurnSpec.effort` is threaded from `record.effort` in the per-turn Custom spawn. `Agent`/`ExecSession::send_user_message` and the supervisor + Tauri command send path drop the per-message `thinking` param.
- **message queue:** drop `PendingMsg.thinking`, its coalescing, and the `pending_messages.thinking` column (migration `0025`).
- **frontend:** `api.sendUserMessage`, store `sendUserMessage`, and ChatView `onSend` drop per-message thinking. Effort is persisted at spawn (`spawnAgent`) and mid-session (`set_agent_effort`), then read from the record each turn.

`build_args` and their unit tests are **untouched** — they still take the effort value; only its *source* moved from the message to the session record.

## Net simplification
- One column dropped, plus `PendingMsg.thinking`, `TurnArgs`'s per-message source, and the `thinking` params through `send_user_message` (Rust + TS).
- Effort and model are now symmetric: both session-level, both re-emitted per turn for per-turn agents, both applied via restart for claude.

## Checks
- Backend: `cargo test --lib` 997 passed / 10 ignored; `cargo check` + `cargo fmt --check` clean (migration `0025` applied on fresh DBs in tests).
- Frontend: `biome` clean on changed files (the 4 pre-existing `ChatView` warnings are on `main`). Local `tsc` unavailable (workspace has no `node_modules`) → CI is the authoritative typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)