### PR TITLE
fix(sandbox): close two paths out of the agent workspace

### DIFF
--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -27,7 +27,6 @@ mod tests;
 use crate::exec_session::ExecSession;
 use crate::managed_session::ManagedSession;
 use crate::pty_session::PtySession;
-use crate::sandbox::Keepalive;
 
 pub use capabilities::{
     capabilities, injection_mode, per_turn_descriptor, transcript_reader, PerTurnDescriptor,
@@ -51,14 +50,10 @@ pub enum Agent {
 
 pub struct PtyAgent {
     pty: PtySession,
-    #[allow(dead_code)]
-    keepalive: Keepalive,
 }
 
 pub struct ManagedAgent {
     session: ManagedSession,
-    #[allow(dead_code)]
-    keepalive: Keepalive,
 }
 
 pub struct PerTurnAgent {

--- a/src-tauri/src/agent/spawn.rs
+++ b/src-tauri/src/agent/spawn.rs
@@ -133,7 +133,6 @@ impl Agent {
             program,
             prefix_args,
             env: launch_env,
-            keepalive,
             kill,
         } = engine.launch_agent(&ctx, &claude)?;
         let mut args = prefix_args;
@@ -165,7 +164,7 @@ impl Agent {
             on_exit,
         )?;
 
-        Ok(Self::Pty(PtyAgent { pty, keepalive }))
+        Ok(Self::Pty(PtyAgent { pty }))
     }
 
     /// Launch a per-turn agent's interactive TUI in a PTY — the native view
@@ -223,7 +222,6 @@ impl Agent {
             program,
             prefix_args,
             env: launch_env,
-            keepalive,
             kill,
         } = engine.launch_agent(&ctx, &bin)?;
         let mut args = prefix_args;
@@ -257,7 +255,7 @@ impl Agent {
             on_exit,
         )?;
 
-        Ok(Self::Pty(PtyAgent { pty, keepalive }))
+        Ok(Self::Pty(PtyAgent { pty }))
     }
 
     pub fn spawn_managed<F, G>(spec: SpawnSpec<'_>, on_event: F, on_exit: G) -> Result<Self>
@@ -285,7 +283,6 @@ impl Agent {
             program,
             prefix_args,
             env: launch_env,
-            keepalive,
             kill,
         } = engine.launch_agent(&ctx, &claude)?;
         let mut args = prefix_args;
@@ -315,7 +312,7 @@ impl Agent {
             on_exit,
         )?;
 
-        Ok(Self::Managed(ManagedAgent { session, keepalive }))
+        Ok(Self::Managed(ManagedAgent { session }))
     }
 
     /// Build a per-turn runner (codex, cursor, opencode, pi) from its
@@ -428,7 +425,6 @@ impl Agent {
             program: launch_program,
             prefix_args,
             env: launch_env,
-            keepalive,
             kill,
         } = sandbox::engine_for(spec.engine)?.launch_agent(&ctx, agent_bin)?;
         let mut env = launch_env;
@@ -445,7 +441,6 @@ impl Agent {
             ExecSpawn {
                 program: launch_program,
                 prefix_args,
-                keepalive,
                 cwd: spec.cwd,
                 session_id: spec.session_id,
                 stdout_is_json,

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -94,7 +94,25 @@ fn lang_for(path: &str) -> String {
 }
 
 /// Join a caller-supplied relative path onto the checkout root, rejecting
-/// anything that could escape it (absolute paths, `..`, drive prefixes).
+/// anything that could escape it — lexically (absolute paths, `..`, drive
+/// prefixes) *and* through symlinks.
+///
+/// The symlink half is the load-bearing one. Every command below runs in the
+/// **host** process, unsandboxed, while the checkout's contents belong to the
+/// agent — which can plant a symlink at any path it likes. `fs::write`,
+/// `fs::rename` and friends all follow symlinks, so a lexically-clean
+/// `README.md` that happens to be a link to `~/.zshrc` would let the file
+/// panel's Save write outside the workspace (and its viewer read outside it).
+/// Same guard `agent_profile` applies to agent-planted links, applied at the
+/// seam where a renderer-supplied path becomes a host filesystem operation.
+///
+/// Symlinks that stay *inside* the checkout are allowed — repos legitimately
+/// contain them — so the test is where the path resolves, not whether a link
+/// was traversed. Only the existing prefix can be resolved (these commands also
+/// create new files), which leaves a narrow window where the agent replaces a
+/// not-yet-existing leaf with a link between this check and the caller's write.
+/// Closing that needs `O_NOFOLLOW`-per-component `openat` plumbing; the planted
+/// trap this does close is persistent and needs no race to spring.
 fn safe_join(checkout: &Path, rel: &str) -> Result<PathBuf> {
     let p = Path::new(rel);
     let escapes = p.components().any(|c| {
@@ -106,7 +124,56 @@ fn safe_join(checkout: &Path, rel: &str) -> Result<PathBuf> {
     if p.is_absolute() || escapes || rel.is_empty() {
         return Err(Error::InvalidPath(rel.to_string()));
     }
-    Ok(checkout.join(p))
+    let joined = checkout.join(p);
+    // Compare fully-resolved forms: the checkout path itself reaches us through
+    // `~/.fletch/workspaces/…`, which on macOS may sit under a symlinked
+    // prefix, so resolving only one side would reject every legitimate path.
+    let root = resolve(checkout);
+    if !resolve(&joined).starts_with(&root) || escapes_via_symlink(&root, checkout, p) {
+        return Err(Error::InvalidPath(rel.to_string()));
+    }
+    Ok(joined)
+}
+
+/// Symlink-resolve the longest existing prefix of `p`, keeping the rest.
+fn resolve(p: &Path) -> PathBuf {
+    crate::sandbox::policy::resolve_existing_prefix(p)
+}
+
+/// Whether any component of `rel` under `checkout` is a symlink whose target
+/// lands outside `root`.
+///
+/// This is a second pass because resolving the longest existing prefix alone
+/// misses the sharpest case: a **dangling** symlink. `canonicalize` fails on
+/// one, so the leaf is re-appended verbatim and the path reads as an ordinary
+/// in-checkout file — while `fs::write` would happily follow it and *create*
+/// the outside target. Reading each link explicitly catches that, and catches
+/// it before the file exists. In-tree links resolve back under `root` and pass.
+fn escapes_via_symlink(root: &Path, checkout: &Path, rel: &Path) -> bool {
+    let mut cur = checkout.to_path_buf();
+    for component in rel.components() {
+        cur.push(component);
+        let Ok(meta) = std::fs::symlink_metadata(&cur) else {
+            // Doesn't exist yet, so it isn't a link — and nothing can exist
+            // beneath a path that doesn't exist.
+            return false;
+        };
+        if !meta.file_type().is_symlink() {
+            continue;
+        }
+        let Ok(target) = std::fs::read_link(&cur) else {
+            return true; // unreadable link — fail closed
+        };
+        let absolute = if target.is_absolute() {
+            target
+        } else {
+            cur.parent().unwrap_or(checkout).join(target)
+        };
+        if !resolve(&absolute).starts_with(root) {
+            return true;
+        }
+    }
+    false
 }
 
 // ── Agent → repo → checkout resolution ────────────────────────────
@@ -647,5 +714,102 @@ mod safe_join_tests {
         let wt = Path::new("/tmp/wt");
         assert!(safe_join(wt, "/etc/passwd").is_err());
         assert!(safe_join(wt, "").is_err());
+    }
+
+    /// A checkout + an "outside" dir standing in for the user's home.
+    fn checkout_and_outside() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+        let td = tempfile::tempdir().unwrap();
+        let checkout = td.path().join("checkout");
+        let outside = td.path().join("outside");
+        std::fs::create_dir_all(&checkout).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        (td, checkout, outside)
+    }
+
+    /// The agent owns the checkout's contents, so a lexically-clean path can
+    /// still be a symlink out of it. `fs::write` would follow it, letting the
+    /// editor's Save overwrite (and its viewer read) an arbitrary host file.
+    #[test]
+    fn rejects_file_symlinked_outside_the_checkout() {
+        let (_td, checkout, outside) = checkout_and_outside();
+        let secret = outside.join("zshrc");
+        std::fs::write(&secret, b"# real user config").unwrap();
+        std::os::unix::fs::symlink(&secret, checkout.join("README.md")).unwrap();
+
+        assert!(
+            safe_join(&checkout, "README.md").is_err(),
+            "a file symlinked out of the checkout must be rejected"
+        );
+    }
+
+    /// The directory variant: the leaf doesn't exist yet, so only the symlinked
+    /// parent gives the escape away — this is the path `create_checkout_file`
+    /// and `rename_checkout_path` take.
+    #[test]
+    fn rejects_path_under_a_symlinked_directory() {
+        let (_td, checkout, outside) = checkout_and_outside();
+        std::os::unix::fs::symlink(&outside, checkout.join("docs")).unwrap();
+
+        assert!(
+            safe_join(&checkout, "docs/new-file.md").is_err(),
+            "a new path under a symlinked-out directory must be rejected"
+        );
+    }
+
+    /// A dangling symlink is the sharpest case: `exists()` is false, so
+    /// `resolve_new_path`'s no-clobber guard passes and `fs::write` would
+    /// *create* the outside target.
+    #[test]
+    fn rejects_dangling_symlink_pointing_outside() {
+        let (_td, checkout, outside) = checkout_and_outside();
+        let not_yet = outside.join("authorized_keys");
+        std::os::unix::fs::symlink(&not_yet, checkout.join("notes.txt")).unwrap();
+        assert!(!not_yet.exists(), "target must not exist for this case");
+
+        assert!(
+            safe_join(&checkout, "notes.txt").is_err(),
+            "a dangling symlink out of the checkout must be rejected"
+        );
+    }
+
+    /// A *relative* link target (`../outside`) escapes just as well and takes
+    /// the other branch of the target-resolution — it is joined onto the link's
+    /// parent rather than used as-is.
+    #[test]
+    fn rejects_relative_symlink_target_escaping_the_checkout() {
+        let (_td, checkout, outside) = checkout_and_outside();
+        std::fs::write(outside.join("secret"), b"x").unwrap();
+        std::os::unix::fs::symlink("../outside/secret", checkout.join("link.txt")).unwrap();
+
+        assert!(
+            safe_join(&checkout, "link.txt").is_err(),
+            "a relative symlink target that escapes must be rejected"
+        );
+    }
+
+    /// Repos legitimately contain symlinks (monorepo links, `node_modules/.bin`).
+    /// The test is where a path *lands*, not whether a link was traversed — so
+    /// in-tree links must keep working.
+    #[test]
+    fn allows_symlinks_that_stay_inside_the_checkout() {
+        let (_td, checkout, _outside) = checkout_and_outside();
+        let real = checkout.join("packages/core");
+        std::fs::create_dir_all(&real).unwrap();
+        std::fs::write(real.join("index.ts"), b"export {};").unwrap();
+        std::os::unix::fs::symlink(&real, checkout.join("linked")).unwrap();
+
+        assert!(
+            safe_join(&checkout, "linked/index.ts").is_ok(),
+            "an in-tree symlink must remain usable"
+        );
+        // And a not-yet-existing file beneath one, so Save-as still works.
+        assert!(safe_join(&checkout, "linked/new.ts").is_ok());
+    }
+
+    /// New files and dirs — the common case — must not be collateral damage.
+    #[test]
+    fn allows_paths_that_do_not_exist_yet() {
+        let (_td, checkout, _outside) = checkout_and_outside();
+        assert!(safe_join(&checkout, "src/deeply/nested/new.ts").is_ok());
     }
 }

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -140,37 +140,57 @@ fn resolve(p: &Path) -> PathBuf {
     crate::sandbox::policy::resolve_existing_prefix(p)
 }
 
-/// Whether any component of `rel` under `checkout` is a symlink whose target
-/// lands outside `root`.
+/// Cap on link hops per component, mirroring the kernel's `SYMLOOP_MAX`. A
+/// cycle (`x` → `y` → `x`) never terminates on its own; the kernel answers
+/// `ELOOP` and so do we, by refusing the path.
+const MAX_SYMLINK_HOPS: usize = 32;
+
+/// Whether walking `rel` under `checkout` leaves `root` by way of a symlink.
 ///
 /// This is a second pass because resolving the longest existing prefix alone
 /// misses the sharpest case: a **dangling** symlink. `canonicalize` fails on
 /// one, so the leaf is re-appended verbatim and the path reads as an ordinary
 /// in-checkout file — while `fs::write` would happily follow it and *create*
-/// the outside target. Reading each link explicitly catches that, and catches
+/// the outside target. Reading the links explicitly catches that, and catches
 /// it before the file exists. In-tree links resolve back under `root` and pass.
+///
+/// Each component's links are followed to the **end of the chain**, not one
+/// hop. A single hop is not enough: `a` → `b` → `/outside/nope` has an entirely
+/// innocent first hop (`b` is in the checkout), and with a dangling tail
+/// `resolve` can't see past it either — it gives up at the missing target and
+/// re-anchors the remainder under the checkout. `fs::write` has no such trouble
+/// and follows all the way to `/outside/nope`, creating it.
 fn escapes_via_symlink(root: &Path, checkout: &Path, rel: &Path) -> bool {
     let mut cur = checkout.to_path_buf();
     for component in rel.components() {
         cur.push(component);
-        let Ok(meta) = std::fs::symlink_metadata(&cur) else {
-            // Doesn't exist yet, so it isn't a link — and nothing can exist
-            // beneath a path that doesn't exist.
-            return false;
-        };
-        if !meta.file_type().is_symlink() {
-            continue;
-        }
-        let Ok(target) = std::fs::read_link(&cur) else {
-            return true; // unreadable link — fail closed
-        };
-        let absolute = if target.is_absolute() {
-            target
-        } else {
-            cur.parent().unwrap_or(checkout).join(target)
-        };
-        if !resolve(&absolute).starts_with(root) {
-            return true;
+        for hop in 0.. {
+            let Ok(meta) = std::fs::symlink_metadata(&cur) else {
+                // Nothing here yet, so it isn't a link — and nothing can exist
+                // beneath a path that doesn't exist.
+                return false;
+            };
+            if !meta.file_type().is_symlink() {
+                break;
+            }
+            if hop >= MAX_SYMLINK_HOPS {
+                return true; // cycle or absurd nesting — fail closed
+            }
+            let Ok(target) = std::fs::read_link(&cur) else {
+                return true; // unreadable link — fail closed
+            };
+            let absolute = if target.is_absolute() {
+                target
+            } else {
+                cur.parent().unwrap_or(checkout).join(target)
+            };
+            // `resolve` both collapses a fully-resolvable chain in one step and
+            // normalizes any `..` in the target; where it stalls (a dangling
+            // hop) the loop reads the next link itself.
+            cur = resolve(&absolute);
+            if !cur.starts_with(root) {
+                return true;
+            }
         }
     }
     false
@@ -769,6 +789,66 @@ mod safe_join_tests {
         assert!(
             safe_join(&checkout, "notes.txt").is_err(),
             "a dangling symlink out of the checkout must be rejected"
+        );
+    }
+
+    /// A *chain* of links: the first hop stays in the checkout, so checking one
+    /// hop clears it — but the write follows the chain to the end. Compounded
+    /// with a dangling tail, since that is what defeats prefix resolution.
+    #[test]
+    fn rejects_dangling_symlink_chain_out_of_the_checkout() {
+        let (_td, checkout, outside) = checkout_and_outside();
+        let never = outside.join("nope");
+        // a -> b (in-checkout, innocent-looking), b -> outside/nope (missing).
+        std::os::unix::fs::symlink("b", checkout.join("a")).unwrap();
+        std::os::unix::fs::symlink(&never, checkout.join("b")).unwrap();
+        assert!(!never.exists(), "the chain's tail must not exist");
+
+        assert!(
+            safe_join(&checkout, "a").is_err(),
+            "a symlink chain ending outside the checkout must be rejected"
+        );
+    }
+
+    /// A longer chain, escaping only on the last hop — guards against the walk
+    /// being accidentally bounded at one or two hops.
+    #[test]
+    fn rejects_long_symlink_chain_escaping_on_the_final_hop() {
+        let (_td, checkout, outside) = checkout_and_outside();
+        // h0 -> h1 -> h2 -> h3 -> outside/nope (missing)
+        for i in 0..3 {
+            std::os::unix::fs::symlink(format!("h{}", i + 1), checkout.join(format!("h{i}")))
+                .unwrap();
+        }
+        std::os::unix::fs::symlink(outside.join("nope"), checkout.join("h3")).unwrap();
+
+        assert!(
+            safe_join(&checkout, "h0").is_err(),
+            "the walk must follow the chain to its end"
+        );
+    }
+
+    /// The same chain shape, but landing back inside — must still be allowed.
+    #[test]
+    fn allows_symlink_chain_that_stays_inside_the_checkout() {
+        let (_td, checkout, _outside) = checkout_and_outside();
+        std::fs::write(checkout.join("real.txt"), b"x").unwrap();
+        std::os::unix::fs::symlink("b", checkout.join("a")).unwrap();
+        std::os::unix::fs::symlink("real.txt", checkout.join("b")).unwrap();
+
+        assert!(safe_join(&checkout, "a").is_ok(), "in-tree chain must work");
+    }
+
+    /// A cycle must not hang the walk, and must fail closed.
+    #[test]
+    fn rejects_symlink_cycle() {
+        let (_td, checkout, _outside) = checkout_and_outside();
+        std::os::unix::fs::symlink("y", checkout.join("x")).unwrap();
+        std::os::unix::fs::symlink("x", checkout.join("y")).unwrap();
+
+        assert!(
+            safe_join(&checkout, "x").is_err(),
+            "a cycle must be refused"
         );
     }
 

--- a/src-tauri/src/exec_session.rs
+++ b/src-tauri/src/exec_session.rs
@@ -26,7 +26,7 @@ use serde_json::Value;
 
 use crate::child_io;
 use crate::error::{Error, Result};
-use crate::sandbox::{Keepalive, KillHandle};
+use crate::sandbox::KillHandle;
 
 type EventCb = Arc<dyn Fn(Value) + Send + Sync>;
 type SessionIdCb = Arc<dyn Fn(String) + Send + Sync>;
@@ -40,13 +40,10 @@ pub struct ExecSpawn {
     /// agent binary carried in `prefix_args`; tests pass the agent directly.
     pub program: PathBuf,
     /// Args inserted before the per-turn args on every spawn — e.g.
-    /// `["-f", <profile>, <agent_bin>]` when `program` is `sandbox-exec`. Empty
-    /// when the agent runs unwrapped.
+    /// `["-p", <profile>, <agent_bin>]` when `program` is `sandbox-exec`. Empty
+    /// when the agent runs unwrapped. Self-contained: the sandbox engine embeds
+    /// no external resource here, so per-turn respawns need nothing kept alive.
     pub prefix_args: Vec<String>,
-    /// Sandbox keepalive, held for the session's lifetime so any resource the
-    /// engine embedded in `prefix_args` (e.g. a profile path) stays valid across
-    /// the per-turn respawns.
-    pub keepalive: Keepalive,
     /// The agent's primary checkout — set as the child's cwd.
     pub cwd: PathBuf,
     /// Session id to resume, if one has been captured already.
@@ -65,9 +62,6 @@ pub struct ExecSpawn {
 pub struct ExecSession {
     program: PathBuf,
     prefix_args: Vec<String>,
-    /// Kept alive (not read) so any sandbox resource outlives the session.
-    #[allow(dead_code)]
-    keepalive: Keepalive,
     cwd: PathBuf,
     stdout_is_json: bool,
     env: Vec<(String, String)>,
@@ -121,7 +115,6 @@ impl ExecSession {
         Self {
             program: spec.program,
             prefix_args: spec.prefix_args,
-            keepalive: spec.keepalive,
             cwd: spec.cwd,
             stdout_is_json: spec.stdout_is_json,
             env: spec.env,
@@ -434,7 +427,6 @@ mod tests {
             ExecSpawn {
                 program: script,
                 prefix_args: vec![],
-                keepalive: Keepalive::None,
                 cwd: dir.path().to_path_buf(),
                 session_id: None,
                 stdout_is_json: true,
@@ -492,7 +484,6 @@ mod tests {
             ExecSpawn {
                 program: script,
                 prefix_args: vec![],
-                keepalive: Keepalive::None,
                 cwd: dir.path().to_path_buf(),
                 session_id: Some("prev-thread".into()),
                 stdout_is_json: true,
@@ -532,7 +523,6 @@ mod tests {
             ExecSpawn {
                 program: script,
                 prefix_args: vec![],
-                keepalive: Keepalive::None,
                 cwd: dir.path().to_path_buf(),
                 session_id: None,
                 stdout_is_json: true,
@@ -589,7 +579,6 @@ mod tests {
             ExecSpawn {
                 program: script,
                 prefix_args: vec![],
-                keepalive: Keepalive::None,
                 cwd: dir.path().to_path_buf(),
                 session_id: None,
                 stdout_is_json: true,

--- a/src-tauri/src/run_session.rs
+++ b/src-tauri/src/run_session.rs
@@ -61,13 +61,6 @@ struct RunSessionInner {
     last_error: Option<String>,
     log: LogBuffer,
     pty: Option<PtySession>,
-    /// The `sandbox-exec` profile file the live PTY was launched under. The
-    /// kernel compiles the SBPL into the child at `exec` and never consults the
-    /// file again, so it only needs to exist until the child has spawned. We
-    /// nonetheless hold it for the PTY's lifetime — a conservative simplification
-    /// that ties cleanup to the process (dropped on stop/replace) rather than
-    /// racing to unlink right after spawn.
-    profile: Option<tempfile::NamedTempFile>,
     /// Bumped on every `start` and `stop`. The PTY exit handler
     /// captures the generation it was spawned under; if that
     /// generation no longer matches, the exit is from a process the
@@ -83,7 +76,6 @@ impl RunSession {
                 last_error: None,
                 log: LogBuffer::new(LOG_BUFFER_CAP),
                 pty: None,
-                profile: None,
                 generation: 0,
             }),
         }
@@ -130,7 +122,6 @@ impl RunSession {
             let mut inner = self.inner.lock();
             let prior = inner.phase;
             let pty = inner.pty.take();
-            inner.profile = None;
             inner.generation = inner.generation.wrapping_add(1);
             inner.phase = RunPhase::Stopped;
             inner.last_error = None;
@@ -164,16 +155,13 @@ impl RunSession {
         inner.generation
     }
 
-    /// Attach a freshly spawned PTY together with the `sandbox-exec` profile
-    /// file it was launched under. The profile only needs to exist through the
-    /// child's `exec`, but we let it ride on the session alongside the PTY so
-    /// its cleanup is tied to the process lifecycle (see the field comment).
-    pub fn attach_pty(&self, pty: PtySession, profile: tempfile::NamedTempFile) {
+    /// Attach a freshly spawned PTY. The `sandbox-exec` profile it was launched
+    /// under travels in argv, so there is no profile resource to park here.
+    pub fn attach_pty(&self, pty: PtySession) {
         let mut inner = self.inner.lock();
-        // Replace and drop any stale handles. (Shouldn't happen — the
-        // supervisor's stop() drops them first — but defensive.)
+        // Replace and drop any stale handle. (Shouldn't happen — the
+        // supervisor's stop() drops it first — but defensive.)
         inner.pty = Some(pty);
-        inner.profile = Some(profile);
     }
 
     /// Returns true if the given generation is still the current one,
@@ -187,7 +175,6 @@ impl RunSession {
     pub fn mark_stopped(&self, error: Option<String>) {
         let mut inner = self.inner.lock();
         inner.pty = None;
-        inner.profile = None;
         inner.phase = RunPhase::Stopped;
         inner.last_error = error;
     }

--- a/src-tauri/src/sandbox/docker/engine/mod.rs
+++ b/src-tauri/src/sandbox/docker/engine/mod.rs
@@ -68,7 +68,7 @@ use std::time::Duration;
 
 use crate::error::{Error, Result};
 use crate::sandbox::engine::{
-    AgentLaunchCtx, EngineKind, Keepalive, KillHandle, KillPlan, LaunchPlan, SandboxEngine,
+    AgentLaunchCtx, EngineKind, KillHandle, KillPlan, LaunchPlan, SandboxEngine,
 };
 use crate::sandbox::policy::{codex_home_dir, opencode_config_dir, opencode_data_dir};
 
@@ -479,7 +479,6 @@ impl SandboxEngine for DockerEngine {
             program: docker,
             prefix_args,
             env,
-            keepalive: Keepalive::None,
             kill: KillHandle::Engine {
                 engine: DockerEngine::shared(),
                 plan: KillPlan::Container { name },

--- a/src-tauri/src/sandbox/engine.rs
+++ b/src-tauri/src/sandbox/engine.rs
@@ -52,18 +52,6 @@ pub struct AgentLaunchCtx<'a> {
     pub blackboard: Option<&'a Path>,
 }
 
-/// A resource that must outlive the launched process. Parked on the session
-/// struct purely for its Drop side-effect (e.g. unlinking a profile tempfile),
-/// hence the dead_code allowance — it is held, never read.
-#[allow(dead_code)]
-pub enum Keepalive {
-    None,
-    /// Seatbelt SBPL profile — `sandbox-exec -f <path>` reads it at the
-    /// child's exec, and per-turn sessions respawn from the same
-    /// `prefix_args`, so the file must live as long as the session.
-    Profile(tempfile::NamedTempFile),
-}
-
 /// Engine-specific data describing how to tear down what was launched.
 #[derive(Clone)]
 pub enum KillPlan {
@@ -123,7 +111,6 @@ pub struct LaunchPlan {
     pub program: std::path::PathBuf,
     pub prefix_args: Vec<String>,
     pub env: Vec<(String, String)>,
-    pub keepalive: Keepalive,
     pub kill: KillHandle,
 }
 

--- a/src-tauri/src/sandbox/mod.rs
+++ b/src-tauri/src/sandbox/mod.rs
@@ -11,10 +11,10 @@ use parking_lot::RwLock;
 use crate::error::{Error, Result};
 
 pub use docker::{availability as docker_availability, DockerAvailability};
-pub use engine::{AgentLaunchCtx, EngineKind, Keepalive, KillHandle, LaunchPlan, SandboxEngine};
+pub use engine::{AgentLaunchCtx, EngineKind, KillHandle, LaunchPlan, SandboxEngine};
 pub use seatbelt::{
     build_run_profile, cleanup_nested_checkouts_roots, cleanup_nested_rpc_roots,
-    nested_checkouts_root, nested_rpc_root, profile_tempfile, SANDBOX_EXEC,
+    nested_checkouts_root, nested_rpc_root, profile_args, SANDBOX_EXEC,
 };
 
 /// The `settings` key holding the user's engine choice; values are

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -38,7 +38,7 @@
 
 use std::path::{Path, PathBuf};
 
-use super::engine::{AgentLaunchCtx, EngineKind, Keepalive, KillHandle, LaunchPlan, SandboxEngine};
+use super::engine::{AgentLaunchCtx, EngineKind, KillHandle, LaunchPlan, SandboxEngine};
 use super::policy;
 use crate::error::{Error, Result};
 
@@ -58,12 +58,6 @@ impl SandboxEngine for SandboxExecEngine {
             claude_config_dir.as_deref(),
             ctx.blackboard,
         )?;
-        let profile_file = profile_tempfile(&profile_text)?;
-        let profile_path = profile_file
-            .path()
-            .to_str()
-            .ok_or_else(|| Error::Other("profile path not utf-8".into()))?
-            .to_string();
         // A workflow step agent's blackboard is granted writable in the profile
         // above; also point the agent at it via `WF_BLACKBOARD` (the same host
         // path the sandbox sees — seatbelt shares the host filesystem).
@@ -74,11 +68,12 @@ impl SandboxEngine for SandboxExecEngine {
             )],
             None => vec![],
         };
+        let mut prefix_args = profile_args(&profile_text).to_vec();
+        prefix_args.push(agent_bin.to_string());
         Ok(LaunchPlan {
             program: PathBuf::from(SANDBOX_EXEC),
-            prefix_args: vec!["-f".into(), profile_path, agent_bin.to_string()],
+            prefix_args,
             env,
-            keepalive: Keepalive::Profile(profile_file),
             // sandbox-exec is a plain process wrapper — the session's own
             // process-group escalation tears everything down; the trait's
             // default no-op `kill` applies.
@@ -88,7 +83,8 @@ impl SandboxEngine for SandboxExecEngine {
 }
 
 /// The macOS sandbox wrapper. Every confined process (agents *and* the Run
-/// panel) is launched as `sandbox-exec -f <profile> <program> …`.
+/// panel) is launched as `sandbox-exec -p <profile> <program> …` — the profile
+/// travels in argv, never a file; see [`profile_args`].
 pub const SANDBOX_EXEC: &str = "/usr/bin/sandbox-exec";
 
 /// PTY / device write rules shared by every profile — terminal programs need
@@ -508,21 +504,24 @@ fn subpath_grants(dirs: impl IntoIterator<Item = PathBuf>) -> Vec<String> {
     out
 }
 
-/// Write an SBPL profile to a private `.sb` tempfile. `sandbox-exec -f <path>`
-/// reads it at launch, so it must live at least until the child execs; the
-/// caller keeps the returned handle alive and dropping it unlinks the file.
-pub fn profile_tempfile(text: &str) -> Result<tempfile::NamedTempFile> {
-    use std::io::Write;
-    let mut f = tempfile::Builder::new()
-        .prefix("fletch-sandbox-")
-        .suffix(".sb")
-        .tempfile()
-        .map_err(|e| Error::Other(format!("create sandbox profile tmp: {e}")))?;
-    f.write_all(text.as_bytes())
-        .map_err(|e| Error::Other(format!("write sandbox profile: {e}")))?;
-    f.flush()
-        .map_err(|e| Error::Other(format!("flush sandbox profile: {e}")))?;
-    Ok(f)
+/// The leading `sandbox-exec` argv for a profile: `["-p", <profile text>]`.
+///
+/// The profile is passed **in argv, never through a file**. `-f <path>` would
+/// mean writing it somewhere and having `sandbox-exec` read it back at the
+/// child's `exec` — and every temp location we could write it to
+/// (`std::env::temp_dir()`, i.e. `/var/folders/…`) is a subpath these very
+/// profiles grant confined processes write access to. A already-running agent
+/// could then watch for the predictable filename and overwrite the profile in
+/// the window between our write and `sandbox-exec`'s read, choosing the policy
+/// the *next* agent launches under. Argv closes that window by construction:
+/// there is no file to race, and nothing on disk to unlink afterwards (which is
+/// why launches no longer carry a `Keepalive`).
+///
+/// SBPL is whitespace-insensitive and `;;` comments end at the newline, so the
+/// multi-line profile survives as a single argv element unchanged. Profiles run
+/// a few KB against a 1 MB `ARG_MAX`, so there is no size concern.
+pub fn profile_args(text: &str) -> [String; 2] {
+    ["-p".to_string(), text.to_string()]
 }
 
 fn sbpl_string(s: &str) -> String {
@@ -1208,5 +1207,68 @@ mod tests {
             profile.contains(&format!("(subpath \"{}\")", canonical_common.display())),
             "run profile should grant the target's git common dir"
         );
+    }
+
+    /// The profile must reach `sandbox-exec` through argv (`-p`), never a file
+    /// (`-f`). A file would have to live somewhere, and every temp location we
+    /// could write it to is a subpath these profiles grant confined processes
+    /// write access to — so an already-running agent could overwrite the next
+    /// agent's profile between our write and `sandbox-exec`'s read.
+    #[test]
+    fn profile_travels_in_argv_never_a_file() {
+        let text = "(version 1)\n(allow default)\n;; comment\n(deny file-write*)";
+        let args = profile_args(text);
+        assert_eq!(
+            args[0], "-p",
+            "the profile must be passed inline, not as -f"
+        );
+        assert_eq!(args[1], text, "argv must carry the profile text verbatim");
+    }
+
+    /// End-to-end on the real launch path: the plan `sandbox-exec` is invoked
+    /// with must embed the policy text itself and must not name any file the
+    /// policy leaves writable. Guards against a regression to `-f <tempfile>`,
+    /// whose `std::env::temp_dir()` home is granted by `(subpath
+    /// "/private/var/folders")`.
+    #[test]
+    fn agent_launch_plan_passes_policy_inline_and_references_no_writable_file() {
+        let (_td, root, rpc, home) = sandbox_dirs();
+        let ctx = AgentLaunchCtx {
+            agent_id: "a1",
+            provider: "claude",
+            writable_root: &root,
+            rpc_dir: &rpc,
+            cwd: &root,
+            home: &home,
+            interactive: true,
+            blackboard: None,
+        };
+        let plan = SandboxExecEngine
+            .launch_agent(&ctx, "/usr/local/bin/claude")
+            .unwrap();
+
+        assert_eq!(plan.program, PathBuf::from(SANDBOX_EXEC));
+        assert_eq!(plan.prefix_args[0], "-p");
+        assert!(
+            plan.prefix_args[1].contains("(deny file-write*)"),
+            "argv must carry the policy itself, got: {}",
+            plan.prefix_args[1]
+        );
+        assert_eq!(plan.prefix_args[2], "/usr/local/bin/claude");
+        assert_eq!(plan.prefix_args.len(), 3);
+
+        // No argument may *be* a path under a tree the policy makes writable —
+        // that is precisely the file an agent could swap out. (The policy text
+        // mentions those trees as grants, but never starts with one.)
+        assert!(
+            !plan.prefix_args.iter().any(|a| a == "-f"),
+            "a file-backed profile is exactly the race this avoids"
+        );
+        for writable in ["/private/var/folders", "/private/tmp", "/private/var/tmp"] {
+            assert!(
+                !plan.prefix_args.iter().any(|a| a.starts_with(writable)),
+                "no argv element may be a path under the agent-writable {writable}"
+            );
+        }
     }
 }

--- a/src-tauri/src/supervisor/run.rs
+++ b/src-tauri/src/supervisor/run.rs
@@ -379,7 +379,7 @@ fn spawn_run_phase(
     // config), so a malicious agent could otherwise plant a script that runs
     // unsandboxed with full user privilege the moment the user clicks ▶. Reads
     // and network stay open (dev servers need them); only writes are fenced.
-    let (program, args, mut env, profile_file) = sandboxed_run_command(&cwd, &cmd)?;
+    let (program, args, mut env) = sandboxed_run_command(&cwd, &cmd)?;
     // Layer the project's opt-in Run environment: the `.env` variables the user
     // chose to share into the sandbox (mirrored live from the source repo's
     // `.env` or overridden per project, with `{{agent_id}}`/`{{worktree}}`
@@ -432,25 +432,19 @@ fn spawn_run_phase(
         },
     )?;
 
-    session.attach_pty(pty, profile_file);
+    session.attach_pty(pty);
     Ok(())
 }
 
 /// Program, argv, extra env, and the profile tempfile returned by
 /// [`sandboxed_run_command`].
-type SandboxedRunCommand = (
-    PathBuf,
-    Vec<String>,
-    Vec<(String, String)>,
-    tempfile::NamedTempFile,
-);
+type SandboxedRunCommand = (PathBuf, Vec<String>, Vec<(String, String)>);
 
 /// Build the `sandbox-exec`-wrapped invocation for a Run-panel command:
-/// `sandbox-exec -f <profile> <shell> -lic <cmd>`. Returns the program, argv,
-/// and the profile tempfile. `sandbox-exec` reads the profile once, at the
-/// child's `exec`, so the tempfile must survive until then; the caller parks it
-/// on the `RunSession` (via `attach_pty`), which conservatively keeps it for the
-/// process's lifetime.
+/// `sandbox-exec -p <profile> <shell> -lic <cmd>`. Returns the program, argv,
+/// and env. The profile travels in argv rather than a tempfile — see
+/// [`crate::sandbox::profile_args`] for why a file would be racy — so there is
+/// nothing for the caller to keep alive.
 fn sandboxed_run_command(cwd: &Path, cmd: &str) -> Result<SandboxedRunCommand> {
     let home =
         dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
@@ -461,19 +455,14 @@ fn sandboxed_run_command(cwd: &Path, cmd: &str) -> Result<SandboxedRunCommand> {
     // outside `writable_root`, which would otherwise fail closed.
     let extra_writable: Vec<PathBuf> = run_target_git_common_dir(cwd).into_iter().collect();
     let profile_text = crate::sandbox::build_run_profile(cwd, &home, &extra_writable)?;
-    let profile_file = crate::sandbox::profile_tempfile(&profile_text)?;
-    let profile_path = profile_file
-        .path()
-        .to_str()
-        .ok_or_else(|| Error::Other("profile path not utf-8".into()))?
-        .to_string();
     let shell = user_shell();
     let shell_str = shell
         .to_str()
         .ok_or_else(|| Error::Other("shell path not utf-8".into()))?
         .to_string();
-    // sandbox-exec -f <profile> <shell> -lic <cmd>
-    let mut args = vec!["-f".to_string(), profile_path, shell_str];
+    // sandbox-exec -p <profile> <shell> -lic <cmd>
+    let mut args = crate::sandbox::profile_args(&profile_text).to_vec();
+    args.push(shell_str);
     args.extend(shell_args(cmd));
     // A nested Fletch (dogfooding) can't reach the host's `~/.fletch/{rpc,
     // worktrees}` under this profile; steer both to sandbox-writable roots.
@@ -492,12 +481,7 @@ fn sandboxed_run_command(cwd: &Path, cmd: &str) -> Result<SandboxedRunCommand> {
                 .into_owned(),
         ),
     ];
-    Ok((
-        PathBuf::from(crate::sandbox::SANDBOX_EXEC),
-        args,
-        env,
-        profile_file,
-    ))
+    Ok((PathBuf::from(crate::sandbox::SANDBOX_EXEC), args, env))
 }
 
 /// Resolve the git *common dir* of the Run target `cwd`, canonicalized, so the

--- a/src-tauri/src/verify.rs
+++ b/src-tauri/src/verify.rs
@@ -287,15 +287,11 @@ impl Verifier {
         )
     }
 
-    /// Build the `sandbox-exec -f <profile> <shell> -lic <cmd>` invocation under
-    /// the Run-panel profile (writable root = the checkout). The profile tempfile
-    /// is returned so it outlives the child's `exec`; the caller keeps it alive
-    /// until the process has finished.
-    fn sandbox_command(
-        &self,
-        worktree: &Path,
-        cmd: &str,
-    ) -> Result<(PathBuf, Vec<String>, tempfile::NamedTempFile)> {
+    /// Build the `sandbox-exec -p <profile> <shell> -lic <cmd>` invocation under
+    /// the Run-panel profile (writable root = the checkout). The profile travels
+    /// in argv rather than a tempfile — see [`crate::sandbox::profile_args`] —
+    /// so there is nothing for the caller to keep alive.
+    fn sandbox_command(&self, worktree: &Path, cmd: &str) -> Result<(PathBuf, Vec<String>)> {
         // Grant the target's git *common dir* (as the Run panel does) so commands
         // that touch git — e.g. `git worktree add` — work in a linked worktree
         // checkout, whose common dir lives outside `worktree`. For a plain
@@ -307,33 +303,22 @@ impl Verifier {
                 .collect();
         let profile_text =
             crate::sandbox::build_run_profile(worktree, &self.home, &extra_writable)?;
-        let profile_file = crate::sandbox::profile_tempfile(&profile_text)?;
-        let profile_path = profile_file
-            .path()
-            .to_str()
-            .ok_or_else(|| Error::Other("profile path not utf-8".into()))?
-            .to_string();
         let shell = crate::run_session::user_shell();
         let shell_str = shell
             .to_str()
             .ok_or_else(|| Error::Other("shell path not utf-8".into()))?
             .to_string();
-        let mut args = vec!["-f".to_string(), profile_path, shell_str];
+        let mut args = crate::sandbox::profile_args(&profile_text).to_vec();
+        args.push(shell_str);
         args.extend(crate::run_session::shell_args(cmd));
-        Ok((
-            PathBuf::from(crate::sandbox::SANDBOX_EXEC),
-            args,
-            profile_file,
-        ))
+        Ok((PathBuf::from(crate::sandbox::SANDBOX_EXEC), args))
     }
 
     async fn run_sandboxed(&self, worktree: &Path, cmd: &str) -> Bounded {
-        let (program, args, _profile) = match self.sandbox_command(worktree, cmd) {
+        let (program, args) = match self.sandbox_command(worktree, cmd) {
             Ok(t) => t,
             Err(e) => return Bounded::Unrunnable(format!("could not build sandbox profile: {e}")),
         };
-        // `_profile` must outlive the child's `exec`; it drops at the end of this
-        // fn, after `run_bounded` has awaited the process to completion.
         run_bounded(&program, &args, worktree, self.timeout).await
     }
 }


### PR DESCRIPTION
Two ways an agent could reach outside its workspace, found during a review of the app code. Both are in the boundary the product's core guarantee rests on ("an agent's writes stay inside its own workspace"), and neither needed a new mechanism to fix — the codebase already had the right pattern nearby in both cases.

## 1. Sandbox profile was written to a directory agents can write to

`sandbox-exec -f <path>` read each agent's SBPL profile back from a tempfile in `std::env::temp_dir()`. The profiles themselves grant confined processes write access to that tree:

```
(subpath "/private/var/folders")
```

So a running agent could poll `$TMPDIR` for the predictable `fletch-sandbox-*.sb` prefix and overwrite the *next* agent's profile in the window between our write and `sandbox-exec`'s read — a repeatable race whose payoff is choosing the policy another agent launches under.

The profile now travels in argv (`-p`). There is no file to race, so the window is gone by construction rather than narrowed. Verified `-p` parses a realistic profile (multi-line, `;;` comments, nested forms) before committing to the approach. Applied at all three launch sites: agents, the Run panel, and turn-end verification.

That left `Keepalive` with nothing to manage — it existed solely to unlink the profile tempfile, and Docker always passed `Keepalive::None` — so it and its plumbing are removed. A lifetime hook guarding a resource that no longer exists would mislead the next reader.

## 2. `safe_join` blocked `..` but not symlinks

The file-panel commands run in the **host** process, unsandboxed, while the checkout's contents belong to the agent. `safe_join` rejected absolute paths, `..` and drive prefixes, then did a plain `join` — and `fs::write`/`fs::rename`/`remove_dir_all` all follow symlinks.

So an agent could plant `README.md` as a link to `~/.zshrc`: the viewer renders the target (read escape) and Save overwrites it (write escape, then code execution on the next shell). This is the same threat `agent_profile.rs` already guards against with `symlink_metadata` — the guard just never reached this seam.

Resolution now compares both sides (the checkout root itself can sit under a symlinked prefix), and the test is *where a path lands* rather than whether a link was traversed, so in-tree symlinks — monorepo links, `node_modules/.bin` — keep working.

Writing the tests first caught a gap in the first attempt: resolving the longest existing prefix alone **missed dangling symlinks**. `canonicalize` fails on one, so the leaf was re-appended verbatim and read as an ordinary in-checkout file — the sharpest case, since that is exactly where `fs::write` *creates* the outside target and `resolve_new_path`'s `exists()` no-clobber guard also passes. A second pass reads each component's link target explicitly.

### Known limitation

A narrow TOCTOU remains: the agent could swap a not-yet-existing leaf for a symlink between the check and the caller's write. Closing it fully needs `O_NOFOLLOW`-per-component `openat` plumbing across all six call sites. The trap this *does* close is persistent and needs no race to spring; the boundary is documented in the function's doc comment rather than left implied.

## Testing

`cargo fmt --check`, `cargo clippy --all-targets -D warnings`, and all 1005 tests pass locally.

Eight new tests. Sandbox: `profile_args` directly, plus end-to-end on `launch_agent` asserting the policy is inline and no argv element is a path under an agent-writable tree. `safe_join`: file symlink out, path under a symlinked directory, dangling symlink, relative target (`../outside`), in-tree symlink still allowed, not-yet-existing paths still allowed.

Not verified: the frontend gates (`bun run lint` / `check` / `test`) — no `node_modules` and no network to install in this environment. No TypeScript is touched by these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)