### PR TITLE
chore(release): bump version to 0.7.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fletch",
   "private": true,
-  "version": "0.7.15",
+  "version": "0.7.16",
   "license": "AGPL-3.0-only",
   "author": "Alex Chaplinsky and fwdai.org",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "fletch"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fletch"
-version = "0.7.15"
+version = "0.7.16"
 description = "Spawn coding agents in isolated sandboxes"
 authors = ["Alex Chaplinsky", "fwdai.org"]
 license = "AGPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Fletch",
   "mainBinaryName": "Fletch",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "identifier": "com.fletch.desktop",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Bumps the app version from `0.7.15` to `0.7.16` (patch release).

Updated in all four places that carry the version:
- `package.json`
- `src-tauri/Cargo.toml`
- `src-tauri/tauri.conf.json`
- `src-tauri/Cargo.lock` (the `fletch` package entry)

No functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)