### PR TITLE
fix(chat): render streaming tool calls the same way finished ones render

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "highlight.js": "^11.11.1",
         "lucide-react": "^1.21.0",
         "material-icon-theme": "^5.36.0",
+        "partial-json": "^0.1.7",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^10.1.0",
@@ -517,6 +518,8 @@
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
+
+    "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "highlight.js": "^11.11.1",
     "lucide-react": "^1.21.0",
     "material-icon-theme": "^5.36.0",
+    "partial-json": "^0.1.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",

--- a/src/adapters/claude/reduce.ts
+++ b/src/adapters/claude/reduce.ts
@@ -5,7 +5,7 @@
 // addition of the sanitizer pass on user-message text and the resulting
 // slash_command / hook_output notices.
 
-import { asBlockList, asRecord } from "@/adapters/shared/json";
+import { asBlockList, asRecord, isRecord } from "@/adapters/shared/json";
 import {
   appendToolInputDelta,
   dedupAgainstLast,
@@ -83,12 +83,17 @@ function handleStreamEvent(prev: ChatItem[], ev: RawEvent): ChatItem[] {
       return extendLastAssistant(prev, block.text);
     }
     if (block.type === "tool_use") {
+      // Stamp the content-block index so this call's `input_json_delta`
+      // fragments — which carry that index and nothing else identifying —
+      // can be routed back here rather than to whichever tool call happens
+      // to sit at the same ordinal in the log.
       return upsertToolCall(prev, {
         kind: "tool_call",
         id: String(block.id ?? ""),
         name: String(block.name ?? "tool"),
-        input: block.input ?? "",
+        input: isRecord(block.input) ? block.input : {},
         streaming: true,
+        partial: { block: typeof inner.index === "number" ? inner.index : -1, json: "" },
       });
     }
     return prev;

--- a/src/adapters/shared/partial-json.ts
+++ b/src/adapters/shared/partial-json.ts
@@ -1,0 +1,27 @@
+import { Allow, parse } from "partial-json";
+
+// Partial strings and containers, but NOT partial numbers: a streamed `8` may
+// still be growing into `80`, so a number is only trustworthy once a delimiter
+// follows it. Strings are the opposite — showing a file path or command fill
+// in character by character is exactly what we want.
+const ALLOW = Allow.STR | Allow.OBJ | Allow.ARR;
+
+/**
+ * Best-effort parse of a JSON document we've only received a prefix of.
+ *
+ * Claude streams a tool call's input as `input_json_delta` fragments, so at any
+ * moment the accumulated text is a partial document — `{"file_path": "/Users/a`.
+ * The UI renders tool inputs as objects (a Read row wants `file_path`, not the
+ * raw text), so we complete the prefix rather than hand presenters a string.
+ *
+ * Returns `{}` for input that can't be salvaged — the same shape as the very
+ * first fragment, which presenters already render as "no arguments yet".
+ */
+export function parsePartialJson(raw: string): unknown {
+  if (!raw.trim()) return {};
+  try {
+    return parse(raw, ALLOW);
+  } catch {
+    return {};
+  }
+}

--- a/src/adapters/shared/reducer-helpers.ts
+++ b/src/adapters/shared/reducer-helpers.ts
@@ -1,5 +1,6 @@
 import type { ChatItem } from "@/adapters/types";
 import { asRecord } from "./json";
+import { parsePartialJson } from "./partial-json";
 
 // Walk from the end since the items we care about (latest streaming
 // agent_message, latest tool_call) are always near the tail.
@@ -50,7 +51,8 @@ export function finalizeStreamingItems(items: ChatItem[]): ChatItem[] {
     }
     if (item.kind === "tool_call" && item.streaming) {
       mutated = true;
-      const { streaming: _s, ...rest } = item;
+      // Drop the stream-assembly scratch space along with the flag.
+      const { streaming: _s, partial: _p, ...rest } = item;
       return { ...rest, streaming: false };
     }
     return item;
@@ -71,31 +73,37 @@ export function upsertToolCall(
 }
 
 /**
- * Append partial JSON to the input of a streaming tool_call. `index` is the
- * positional index *among tool_call items* (Claude's `stream_event.index`),
- * not the absolute items array index. Falls back to the last tool_call if
- * the positional lookup misses (rare ordering races).
+ * Append a fragment of a streaming tool_call's input JSON.
+ *
+ * `blockIndex` is the content-block index within the in-flight assistant
+ * message (Claude's `stream_event.index`) — it counts text and thinking blocks
+ * too and restarts at 0 each message, so it only identifies a tool call when
+ * matched against the index stamped on it at `content_block_start`. Falls back
+ * to the newest streaming tool_call when the stamp is missing.
+ *
+ * The raw fragments accumulate in `partial.json`; `input` holds the best-effort
+ * parse of them, so presenters see the same object shape mid-stream that they
+ * get from the finalized event.
  */
 export function appendToolInputDelta(
   items: ChatItem[],
-  toolCallIndex: number,
+  blockIndex: number,
   partialJson: string,
 ): ChatItem[] {
-  let seen = -1;
-  let idx = items.findIndex((item) => {
-    if (item.kind !== "tool_call") return false;
-    seen += 1;
-    return seen === toolCallIndex;
-  });
-  if (idx === -1) {
-    idx = findLastIndex(items, (item) => item.kind === "tool_call");
-  }
+  const open = (item: ChatItem): item is Extract<ChatItem, { kind: "tool_call" }> =>
+    item.kind === "tool_call" && item.streaming === true;
+  let idx = findLastIndex(items, (item) => open(item) && item.partial?.block === blockIndex);
+  if (idx === -1) idx = findLastIndex(items, open);
   if (idx === -1) return items;
   const item = items[idx];
   if (item.kind !== "tool_call") return items;
-  const input = typeof item.input === "string" ? item.input + partialJson : partialJson;
+  const json = (item.partial?.json ?? "") + partialJson;
   const next = items.slice();
-  next[idx] = { ...item, input };
+  next[idx] = {
+    ...item,
+    input: parsePartialJson(json),
+    partial: { block: item.partial?.block ?? blockIndex, json },
+  };
   return next;
 }
 

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -54,6 +54,13 @@ export type ChatItem =
       name: string;
       input: unknown;
       streaming?: boolean;
+      /** Scratch space for assembling `input` from stream deltas, present only
+       *  while `streaming`. `block` is the content-block index this call
+       *  occupies in the in-flight assistant message — Claude keys its
+       *  `input_json_delta` fragments by it — and `json` is the raw JSON text
+       *  accumulated so far, which `input` is the best-effort parse of.
+       *  Cleared when the finalized event lands. */
+      partial?: { block: number; json: string };
       /** Sub-conversation produced by a subagent spawned through this tool
        *  call (Claude's Task/Agent tool). The reducer routes sidechain events
        *  — those the SDK tags with `parent_tool_use_id === this id` — into a

--- a/tests/adapters/claude/reduce.test.ts
+++ b/tests/adapters/claude/reduce.test.ts
@@ -226,6 +226,123 @@ describe("claudeAdapter.reduce — extended thinking", () => {
   });
 });
 
+describe("claudeAdapter.reduce — streaming tool input", () => {
+  const startBlock = (index: number, id: string, name: string): RawEvent =>
+    ({
+      type: "stream_event",
+      event: {
+        index,
+        type: "content_block_start",
+        content_block: { type: "tool_use", id, name, input: {} },
+      },
+    }) as RawEvent;
+
+  const inputDelta = (index: number, partial_json: string): RawEvent =>
+    ({
+      type: "stream_event",
+      event: {
+        index,
+        type: "content_block_delta",
+        delta: { type: "input_json_delta", partial_json },
+      },
+    }) as RawEvent;
+
+  function inputsById(items: ChatItem[]): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    for (const item of items) if (item.kind === "tool_call") out[item.id] = item.input;
+    return out;
+  }
+
+  it("routes deltas by content-block index, not by position among tool_calls", () => {
+    // Claude's `index` is the block's slot in the *current* assistant message:
+    // it restarts at 0 each message and counts text blocks too. A log that
+    // already holds an earlier tool_call must not have these deltas land on it.
+    const items = reduceAll([
+      startBlock(0, "toolu_first", "Bash"),
+      inputDelta(0, '{"command":"ls"}'),
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "tool_use", id: "toolu_first", name: "Bash", input: { command: "ls" } },
+          ],
+        },
+      },
+      // Next message: a text block, then two parallel tool calls at blocks 1
+      // and 2 — the ordinals that used to point at the wrong rows.
+      {
+        type: "stream_event",
+        event: {
+          index: 0,
+          type: "content_block_start",
+          content_block: { type: "text", text: "ok" },
+        },
+      },
+      startBlock(1, "toolu_read", "Read"),
+      startBlock(2, "toolu_edit", "Edit"),
+      inputDelta(1, '{"file_path":"/a/pkg.json"}'),
+      inputDelta(2, '{"file_path":"/a/Cargo.toml","old_string":"x"}'),
+    ]);
+
+    expect(inputsById(items)).toEqual({
+      toolu_first: { command: "ls" },
+      toolu_read: { file_path: "/a/pkg.json" },
+      toolu_edit: { file_path: "/a/Cargo.toml", old_string: "x" },
+    });
+  });
+
+  it("exposes input as a parsed object while fragments are still arriving", () => {
+    const items = reduceAll([
+      startBlock(0, "toolu_read", "Read"),
+      inputDelta(0, '{"file_'),
+      inputDelta(0, 'path":"/a/pkg'),
+    ]);
+    expect(items).toEqual([
+      {
+        kind: "tool_call",
+        id: "toolu_read",
+        name: "Read",
+        input: { file_path: "/a/pkg" },
+        streaming: true,
+        partial: { block: 0, json: '{"file_path":"/a/pkg' },
+      },
+    ]);
+  });
+
+  it("clears the stream scratch space when the finalized event lands", () => {
+    const items = reduceAll([
+      startBlock(0, "toolu_read", "Read"),
+      inputDelta(0, '{"file_path":"/a/pkg.json"}'),
+      {
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_read",
+              name: "Read",
+              input: { file_path: "/a/pkg.json" },
+            },
+          ],
+        },
+      },
+    ] as RawEvent[]);
+    expect(items).toEqual([
+      {
+        kind: "tool_call",
+        id: "toolu_read",
+        name: "Read",
+        input: { file_path: "/a/pkg.json" },
+      },
+    ]);
+  });
+
+  it("ignores deltas that arrive with no streaming tool_call open", () => {
+    const items = reduceAll([inputDelta(0, '{"command":"ls"}')]);
+    expect(items).toEqual([]);
+  });
+});
+
 describe("claudeAdapter.reduce — model", () => {
   it("stamps the model from a finalized assistant event onto the agent_message", () => {
     const items = reduceAll([
@@ -346,7 +463,8 @@ describe("claudeAdapter.reduce — subagent sidechain routing", () => {
       // The subagent's tool call streams in: content_block_start opens it,
       // input_json_delta fills its input — both tagged with the parent id, so
       // upsertToolCall / appendToolInputDelta must operate on the children
-      // slice (positional index 0 there), not the main items list.
+      // slice, not the main items list. This start carries no index, so the
+      // delta also exercises the "newest streaming tool_call" fallback.
       {
         type: "stream_event",
         parent_tool_use_id: "toolu_task",
@@ -376,8 +494,9 @@ describe("claudeAdapter.reduce — subagent sidechain routing", () => {
           kind: "tool_call",
           id: "toolu_child",
           name: "Read",
-          input: '{"path":"/x"}',
+          input: { path: "/x" },
           streaming: true,
+          partial: { block: -1, json: '{"path":"/x"}' },
         },
       ]);
     }

--- a/tests/adapters/shared/partial-json.test.ts
+++ b/tests/adapters/shared/partial-json.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { parsePartialJson } from "@/adapters/shared/partial-json";
+
+// These pin the *configuration* we hand `partial-json` (which types may be
+// partial) and the throw → `{}` fallback — not the library's own parsing,
+// which it tests itself.
+describe("parsePartialJson", () => {
+  it("parses a complete document unchanged", () => {
+    expect(parsePartialJson('{"file_path":"/a/b.ts","limit":8}')).toEqual({
+      file_path: "/a/b.ts",
+      limit: 8,
+    });
+  });
+
+  it("fills in a string value as it arrives", () => {
+    expect(parsePartialJson('{"file_path": "/Users/a')).toEqual({ file_path: "/Users/a" });
+  });
+
+  it("withholds a number until a delimiter proves it complete", () => {
+    // `8` could still be growing into `80`.
+    expect(parsePartialJson('{"file_path":"/a","limit":8')).toEqual({ file_path: "/a" });
+    expect(parsePartialJson('{"file_path":"/a","limit":8,')).toEqual({
+      file_path: "/a",
+      limit: 8,
+    });
+  });
+
+  it("drops a half-written key", () => {
+    expect(parsePartialJson('{"file_path":"/a","old_st')).toEqual({ file_path: "/a" });
+  });
+
+  it("returns an empty bag rather than throwing on unusable input", () => {
+    expect(parsePartialJson("")).toEqual({});
+    expect(parsePartialJson("   ")).toEqual({});
+    expect(parsePartialJson("{")).toEqual({});
+    expect(parsePartialJson("not json at all")).toEqual({});
+  });
+});


### PR DESCRIPTION
## Problem

While a turn was running, tool rows rendered raw JSON and `(no path)` — then snapped to a proper filename and diff count once the turn ended. Same tool call, two different renderings.

<img width="900" alt="mid-turn" src="https://github.com/user-attachments/assets/placeholder" />

Two independent bugs were behind it.

**1. Input deltas landed on the wrong rows.** `appendToolInputDelta` interpreted Claude's `stream_event.index` as "the Nth `tool_call` in the log". It is actually the content-block index *within the current assistant message*: it restarts at 0 each message and counts text and thinking blocks too. So with parallel tool calls, an `Edit`'s fragments were appended to a `Bash` row from an earlier message, and the real `Edit` row never received anything — which is why it stayed at `(no path)`.

**2. `input` stayed a raw partial-JSON string mid-stream.** Presenters read fields off an object (`getStringField(input, "file_path")`), so they got nothing: `Read`/`Edit` fell back to `(no path)`, and `Bash`'s `getCommandField` returns a string input verbatim — that is the JSON blob that was on screen.

## Fix

- Stamp the content-block index onto the tool call at `content_block_start` and route deltas by it, falling back to the newest streaming `tool_call` when the stamp is absent.
- Accumulate the raw fragments in `partial.json` and expose `input` as a best-effort parse of them, so presenters see the same object shape mid-stream that the finalized event gives them. Paths and commands now fill in as they arrive instead of appearing all at once.
- `partial` is transient scratch space, cleared by `finalizeStreamingItems` alongside the `streaming` flag.

Parsing uses the [`partial-json`](https://www.npmjs.com/package/partial-json) package (MIT, zero deps, 32 KB) rather than a hand-rolled repair — a first pass wrote one, then it was checked against the library across 19 cases (including `\` at a fragment boundary, truncated `\u26`, braces inside strings) and behavior was identical, so the hand-rolled version was dropped. The one judgment call we keep is the flag set: `Allow.STR | Allow.OBJ | Allow.ARR` — partial strings and containers, but **not** partial numbers, since a streamed `8` may still be growing into `80`.

No presenter changes.

## Scope note

Anthropic streams content blocks strictly sequentially, so "append to the newest streaming tool_call" alone would fix the misrouting without the `partial.block` field. The explicit index match is kept because the event carries the identifier and depending on undocumented ordering is fragile; the fallback path already does the ordering-based thing.

## Testing

`npm test` (543 pass), `tsc --noEmit`, `biome check`, and `npm run build` all clean. New coverage: delta routing across messages with parallel tool calls, `input` exposed as a parsed object mid-fragment, scratch space cleared on finalize, deltas with no open tool call ignored, plus the `parsePartialJson` config contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)