### PR TITLE
refactor(mcp): make MCP delivery one provider-agnostic seam

### DIFF
--- a/src-tauri/src/agent/args.rs
+++ b/src-tauri/src/agent/args.rs
@@ -1,7 +1,5 @@
 //! Shared, non-provider-specific CLI arg-building helpers.
 
-use std::path::Path;
-
 use crate::instructions;
 
 use super::spawn::SpawnSpec;
@@ -36,7 +34,11 @@ pub(crate) fn push_opt(args: &mut Vec<String>, flag: &str, value: Option<&str>) 
     }
 }
 
-pub(crate) fn prepare_pty_args(spec: &SpawnSpec<'_>) -> Vec<String> {
+/// `mcp_args` comes from the provider's `McpDeliveryBuilder`, resolved and run
+/// by the spawn path (see `agent::mcp_delivery`) — for claude that's
+/// `--mcp-config <path> --strict-mcp-config`. Empty when no servers are
+/// attached.
+pub(crate) fn prepare_pty_args(spec: &SpawnSpec<'_>, mcp_args: &[String]) -> Vec<String> {
     let mut args: Vec<String> = vec![
         "--dangerously-skip-permissions".into(),
         "--permission-mode".into(),
@@ -45,7 +47,7 @@ pub(crate) fn prepare_pty_args(spec: &SpawnSpec<'_>) -> Vec<String> {
     args.extend(effort_args(spec.effort));
     args.extend(model_args(spec.model));
     args.extend(instructions::append_system_prompt_args(spec.instructions));
-    args.extend(mcp_config_args(spec.mcp_config));
+    args.extend_from_slice(mcp_args);
 
     if spec.fresh {
         args.push("--session-id".into());
@@ -58,21 +60,7 @@ pub(crate) fn prepare_pty_args(spec: &SpawnSpec<'_>) -> Vec<String> {
     args
 }
 
-/// Claude's MCP flags for a generated config file: `--strict-mcp-config` makes
-/// the snapshot-derived file the *only* MCP source, so on-disk user/project MCP
-/// config never rides along with an agent Fletch spawns.
-fn mcp_config_args(config: Option<&Path>) -> Vec<String> {
-    match config {
-        Some(path) => vec![
-            "--mcp-config".into(),
-            path.to_string_lossy().into_owned(),
-            "--strict-mcp-config".into(),
-        ],
-        None => Vec::new(),
-    }
-}
-
-pub(crate) fn prepare_managed_args(spec: &SpawnSpec<'_>) -> Vec<String> {
+pub(crate) fn prepare_managed_args(spec: &SpawnSpec<'_>, mcp_args: &[String]) -> Vec<String> {
     // Stream-json input + output give us a structured back-and-forth
     // over stdio. --verbose is required when using stream-json output
     // so events keep flowing. --include-partial-messages emits
@@ -100,7 +88,7 @@ pub(crate) fn prepare_managed_args(spec: &SpawnSpec<'_>) -> Vec<String> {
     args.extend(effort_args(spec.effort));
     args.extend(model_args(spec.model));
     args.extend(instructions::append_system_prompt_args(spec.instructions));
-    args.extend(mcp_config_args(spec.mcp_config));
+    args.extend_from_slice(mcp_args);
 
     if spec.fresh {
         args.push("--session-id".into());

--- a/src-tauri/src/agent/capabilities.rs
+++ b/src-tauri/src/agent/capabilities.rs
@@ -24,7 +24,7 @@ use super::providers::opencode::{
 };
 use super::providers::pi::{pi_build_args, pi_locate, pi_pty_args, pi_read, pi_session_id};
 use super::transcript::{JsonlTail, TranscriptReader};
-use super::{McpArgsBuilder, PtyArgsBuilder, TurnArgs};
+use super::{McpDeliveryBuilder, PtyArgsBuilder, TurnArgs};
 
 /// Everything that varies between per-turn agents. The runner lifecycle —
 /// one fresh process per turn via `ExecSession` — is identical for all of
@@ -45,11 +45,12 @@ pub struct PerTurnDescriptor {
     /// (PTY) view: `(session [None = fresh], model, custom_instructions,
     /// mcp_args)`.
     pub(crate) pty_args: PtyArgsBuilder,
-    /// Builds this provider's MCP-delivery args from the session's snapshot
-    /// (e.g. codex `-c mcp_servers.*` overrides), applied to both the per-turn
-    /// and native-PTY launches. `None` = provider has no MCP config surface we
-    /// can drive; the snapshot is ignored (the editor UI says so up front).
-    pub(crate) mcp_args: Option<McpArgsBuilder>,
+    /// Places the session's MCP servers where this provider's CLI finds them,
+    /// applied to both the per-turn and native-PTY launches. `None` = provider
+    /// has no MCP config surface we can drive; the snapshot is ignored (the
+    /// editor UI says so up front). Resolve via [`mcp_delivery`], which also
+    /// covers claude.
+    pub(crate) mcp: Option<McpDeliveryBuilder>,
     /// Extracts the agent-assigned session id from a turn's events. The
     /// event-based agents are thin wrappers over `gated_session_id` (same shape,
     /// different gates). No-op for `plaintext` agents (they emit no events — see
@@ -128,7 +129,7 @@ pub(crate) const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         label: "Codex",
         build_args: codex_build_args,
         pty_args: codex_pty_args,
-        mcp_args: Some(crate::agent_profile::codex_mcp_args),
+        mcp: Some(crate::agent_profile::codex_mcp_delivery),
         session_id: codex_session_id,
         activity: || Box::new(ManagedActivity::codex()),
         native_view: true,
@@ -146,7 +147,7 @@ pub(crate) const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         label: "Cursor",
         build_args: cursor_build_args,
         pty_args: cursor_pty_args,
-        mcp_args: None,
+        mcp: None,
         session_id: cursor_session_id,
         // Cursor emits Claude-shaped stream-json incl. a `result` turn-end,
         // so it reuses the Claude managed detector.
@@ -166,7 +167,7 @@ pub(crate) const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         label: "OpenCode",
         build_args: opencode_build_args,
         pty_args: opencode_pty_args,
-        mcp_args: None,
+        mcp: None,
         session_id: opencode_session_id,
         activity: || Box::new(ManagedActivity::opencode()),
         native_view: true,
@@ -184,7 +185,7 @@ pub(crate) const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         label: "Pi",
         build_args: pi_build_args,
         pty_args: pi_pty_args,
-        mcp_args: None,
+        mcp: None,
         session_id: pi_session_id,
         activity: || Box::new(ManagedActivity::pi()),
         native_view: true,
@@ -205,7 +206,7 @@ pub(crate) const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         label: "Antigravity",
         build_args: antigravity_build_args,
         pty_args: antigravity_pty_args,
-        mcp_args: None,
+        mcp: None,
         // agy emits no JSON events; its session id is read from the filesystem.
         session_id: |_| None,
         // No event stream to detect turn-end from — the turn's process exit ends
@@ -243,6 +244,21 @@ pub fn transcript_reader(provider: &str) -> Option<&'static TranscriptReader> {
     }
 }
 
+/// The MCP-delivery builder for a provider, or `None` if it has no MCP surface
+/// Fletch can drive. Same dispatch as `transcript_reader`: per-turn descriptors
+/// plus the claude special case (claude is the lone persistent-runner agent, so
+/// it has no descriptor row of its own).
+///
+/// This is the single resolution point for MCP support — spawn paths and the
+/// injection gate both go through it, so no caller branches on a provider id.
+pub fn mcp_delivery(provider: &str) -> Option<McpDeliveryBuilder> {
+    match per_turn_descriptor(provider) {
+        Some(d) => d.mcp,
+        None if provider == "claude" => Some(crate::agent_profile::claude_mcp_delivery),
+        None => None,
+    }
+}
+
 /// (binary, human label) for a provider, or `None` if unknown. Same dispatch
 /// as `transcript_reader`: per-turn descriptors + the claude special case.
 pub(crate) fn provider_bin_label(provider: &str) -> Option<(&'static str, &'static str)> {
@@ -250,5 +266,28 @@ pub(crate) fn provider_bin_label(provider: &str) -> Option<(&'static str, &'stat
         Some(d) => Some((d.bin, d.label)),
         None if provider == "claude" => Some(("claude", "Claude Code")),
         None => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mcp_delivery_covers_claude_and_the_descriptor_table() {
+        // Claude has no descriptor row, so it must still resolve — it was the
+        // provider whose delivery used to be hardcoded at the spawn site.
+        assert!(mcp_delivery("claude").is_some());
+        assert!(mcp_delivery("codex").is_some());
+
+        // Not yet wired: the snapshot is ignored rather than mis-delivered.
+        for provider in ["cursor", "opencode", "pi", "antigravity"] {
+            assert!(
+                mcp_delivery(provider).is_none(),
+                "{provider} claims MCP support it can't deliver"
+            );
+        }
+
+        assert!(mcp_delivery("nonesuch").is_none());
     }
 }

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -86,6 +86,14 @@ pub struct TurnArgs<'a> {
 pub(crate) type PtyArgsBuilder =
     fn(Option<&str>, Option<&str>, Option<&str>, &[String]) -> Vec<String>;
 
-/// Builds a provider's MCP-delivery args from the session's server snapshot
-/// (e.g. codex `-c mcp_servers.*` overrides).
-pub(crate) type McpArgsBuilder = fn(&[crate::agent_profile::McpServerSnapshot]) -> Vec<String>;
+/// Places the session's MCP servers where a provider's CLI will find them.
+///
+/// The one seam every provider's MCP support goes through: the builder writes
+/// whatever config file its CLI reads (into the profile dir or the checkout,
+/// per `McpTarget`) and returns the argv and/or environment pointing at it.
+/// Fallible because most implementations touch the filesystem. Adding a
+/// provider means writing one of these and listing it on the descriptor — no
+/// new branch at any call site.
+pub(crate) type McpDeliveryBuilder = fn(
+    &crate::agent_profile::McpTarget<'_>,
+) -> crate::error::Result<crate::agent_profile::McpDelivery>;

--- a/src-tauri/src/agent/spawn.rs
+++ b/src-tauri/src/agent/spawn.rs
@@ -13,7 +13,7 @@ use crate::sandbox;
 use crate::sandbox::{AgentLaunchCtx, EngineKind, LaunchPlan, SandboxEngine};
 
 use super::args::{prepare_managed_args, prepare_pty_args};
-use super::capabilities::per_turn_descriptor;
+use super::capabilities::{mcp_delivery, per_turn_descriptor};
 use super::probe::resolve_agent_bin;
 use super::{Agent, ManagedAgent, PerTurnAgent, PerTurnDescriptor, PtyAgent, TurnArgs};
 
@@ -36,9 +36,9 @@ pub struct PerTurnSpec {
     /// Includes the materialized skill index when the session has skills.
     /// `None` for a plain built-in spawn.
     pub instructions: Option<String>,
-    /// The session's MCP-server snapshot, delivered by providers with a
-    /// descriptor-level `mcp_args` builder (codex). Empty for plain spawns and
-    /// ignored by providers without MCP support.
+    /// The session's MCP-server snapshot, delivered by the provider's
+    /// `McpDeliveryBuilder` (see `agent::mcp_delivery`). Empty for plain spawns
+    /// and ignored by providers without MCP support.
     pub mcp_servers: Vec<crate::agent_profile::McpServerSnapshot>,
     /// The agent's RPC mailbox dir, exposed to the child as `FLETCH_RPC_DIR`.
     pub rpc_dir: PathBuf,
@@ -76,13 +76,10 @@ pub struct SpawnSpec<'a> {
     /// system prompt on every spawn/resume. Includes the materialized skill
     /// index when the session has skills. `None` for a plain built-in spawn.
     pub instructions: Option<&'a str>,
-    /// The session's MCP-server snapshot, consumed by per-turn providers with
-    /// a descriptor `mcp_args` builder when this spec launches their native
-    /// TUI. Claude ignores it (it takes `mcp_config` instead).
+    /// The session's MCP-server snapshot. Delivered by the provider's
+    /// `McpDeliveryBuilder` at spawn (see `agent::mcp_delivery`); ignored for
+    /// providers that have no MCP surface.
     pub mcp_servers: &'a [crate::agent_profile::McpServerSnapshot],
-    /// Claude's generated MCP config file, passed as
-    /// `--mcp-config <path> --strict-mcp-config`. `None` = no servers attached.
-    pub mcp_config: Option<&'a Path>,
     /// The agent's RPC mailbox dir, exposed to the child as `FLETCH_RPC_DIR`.
     pub rpc_dir: PathBuf,
     pub cols: u16,
@@ -107,6 +104,41 @@ fn rpc_env(rpc_dir: &Path) -> Vec<(String, String)> {
     )]
 }
 
+/// Run `provider`'s MCP-delivery builder over the session's snapshot, writing
+/// whatever config file the provider reads and returning the argv/env that
+/// points at it. An empty delivery when the provider has no MCP surface, which
+/// is exactly the "snapshot not consumed" behavior those providers had before.
+///
+/// Called on every launch path (fresh, resume, view-switch) rather than
+/// persisted, so a config file is always regenerated from the current snapshot
+/// — the same reasoning as `write_claude_mcp_config` and the skill index.
+fn resolve_mcp(
+    provider: &str,
+    servers: &[crate::agent_profile::McpServerSnapshot],
+    sandbox_root: &Path,
+) -> Result<crate::agent_profile::McpDelivery> {
+    match mcp_delivery(provider) {
+        Some(build) => build(&crate::agent_profile::McpTarget {
+            servers,
+            sandbox_root,
+        }),
+        None => Ok(crate::agent_profile::McpDelivery::default()),
+    }
+}
+
+/// The provider-identity half of a per-turn launch: what to run, under whose
+/// name, and the extra environment its MCP delivery asked for. Bundled so
+/// `spawn_exec` keeps a readable signature as delivery grows inputs.
+struct ExecLaunch<'a> {
+    /// Provider id, forwarded to the sandbox engine's launch context.
+    provider: &'a str,
+    /// Resolved agent binary (host path under seatbelt, image bin under docker).
+    program: PathBuf,
+    /// Extra environment from the provider's MCP delivery, layered on after the
+    /// engine's launch env and `FLETCH_RPC_DIR`.
+    mcp_env: Vec<(String, String)>,
+}
+
 impl Agent {
     pub fn spawn_pty<F, G>(spec: SpawnSpec<'_>, on_output: F, on_exit: G) -> Result<Self>
     where
@@ -117,7 +149,8 @@ impl Agent {
             dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
         let engine = sandbox::engine_for(spec.engine)?;
         let claude = agent_bin_for("claude", "claude", "Claude Code", engine.as_ref(), &home)?;
-        let agent_args = prepare_pty_args(&spec);
+        let mcp = resolve_mcp("claude", spec.mcp_servers, &spec.sandbox_root)?;
+        let agent_args = prepare_pty_args(&spec, &mcp.args);
 
         let ctx = AgentLaunchCtx {
             agent_id: spec.agent_id,
@@ -139,6 +172,7 @@ impl Agent {
         args.extend(agent_args);
         let mut env = launch_env;
         env.extend(rpc_env(&spec.rpc_dir));
+        env.extend(mcp.env);
 
         tracing::info!(
             agent_id = %spec.agent_id,
@@ -196,14 +230,10 @@ impl Agent {
         } else {
             Some(spec.session_id)
         };
-        // Provider MCP overrides (codex `-c mcp_servers.*`), rebuilt from the
-        // session's snapshot so the TUI resumes with the same tool set the
-        // Custom-view turns had.
-        let mcp_args = desc
-            .mcp_args
-            .map(|build| build(spec.mcp_servers))
-            .unwrap_or_default();
-        let agent_args = (desc.pty_args)(session, spec.model, spec.instructions, &mcp_args);
+        // Provider MCP delivery, rebuilt from the session's snapshot so the TUI
+        // resumes with the same tool set the Custom-view turns had.
+        let mcp = resolve_mcp(provider, spec.mcp_servers, &spec.sandbox_root)?;
+        let agent_args = (desc.pty_args)(session, spec.model, spec.instructions, &mcp.args);
 
         // Unified sandbox: run the agent's TUI under the sandbox engine (the
         // agent's own sandbox is disabled in its arg builder), so per-turn
@@ -228,6 +258,7 @@ impl Agent {
         args.extend(agent_args);
         let mut env = launch_env;
         env.extend(rpc_env(&spec.rpc_dir));
+        env.extend(mcp.env);
 
         tracing::info!(
             agent_id = %spec.agent_id,
@@ -267,7 +298,8 @@ impl Agent {
             dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
         let engine = sandbox::engine_for(spec.engine)?;
         let claude = agent_bin_for("claude", "claude", "Claude Code", engine.as_ref(), &home)?;
-        let agent_args = prepare_managed_args(&spec);
+        let mcp = resolve_mcp("claude", spec.mcp_servers, &spec.sandbox_root)?;
+        let agent_args = prepare_managed_args(&spec, &mcp.args);
 
         let ctx = AgentLaunchCtx {
             agent_id: spec.agent_id,
@@ -289,6 +321,7 @@ impl Agent {
         args.extend(agent_args);
         let mut env = launch_env;
         env.extend(rpc_env(&spec.rpc_dir));
+        env.extend(mcp.env);
 
         tracing::info!(
             agent_id = %spec.agent_id,
@@ -352,13 +385,14 @@ impl Agent {
         // calling a 4-arg builder.
         let build_args = desc.build_args;
         let extra = spec.instructions.clone();
-        let mcp_args = desc
-            .mcp_args
-            .map(|build| build(&spec.mcp_servers))
-            .unwrap_or_default();
+        let mcp = resolve_mcp(desc.id, &spec.mcp_servers, &spec.sandbox_root)?;
+        let mcp_args = mcp.args;
         Self::spawn_exec(
-            desc.id,
-            program,
+            ExecLaunch {
+                provider: desc.id,
+                program,
+                mcp_env: mcp.env,
+            },
             spec,
             move |prompt, session_id, thinking, model| {
                 build_args(&TurnArgs {
@@ -387,8 +421,7 @@ impl Agent {
     /// failed turn that never emits an in-band turn-end still leaves the
     /// agent promptly.
     fn spawn_exec<A, I, F, G, H>(
-        provider: &str,
-        program: PathBuf,
+        launch: ExecLaunch<'_>,
         spec: PerTurnSpec,
         build_args: A,
         extract_session_id: I,
@@ -405,6 +438,11 @@ impl Agent {
         G: Fn(String) + Send + Sync + 'static,
         H: Fn(ExecExit) + Send + Sync + 'static,
     {
+        let ExecLaunch {
+            provider,
+            program,
+            mcp_env,
+        } = launch;
         let home =
             dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
         let agent_bin = program
@@ -429,6 +467,7 @@ impl Agent {
         } = sandbox::engine_for(spec.engine)?.launch_agent(&ctx, agent_bin)?;
         let mut env = launch_env;
         env.extend(rpc_env(&spec.rpc_dir));
+        env.extend(mcp_env);
 
         tracing::info!(
             agent_bin = %program.display(),

--- a/src-tauri/src/agent_profile.rs
+++ b/src-tauri/src/agent_profile.rs
@@ -12,13 +12,20 @@
 //! The writable root is bind-mounted at its host path under docker (path
 //! identity), so the index paths are valid in both sandbox engines.
 //!
-//! **MCP servers** are delivered per provider:
+//! **MCP servers** are delivered per provider, but through one shared shape:
+//! every provider that has an MCP surface implements an [`McpDeliveryBuilder`]
+//! — `fn(&McpTarget) -> Result<McpDelivery>` — which writes whatever config
+//! file its CLI reads and returns the argv and/or environment that points at
+//! it. `agent::mcp_delivery(provider)` resolves the builder; `None` means the
+//! provider has no surface we can drive and the snapshot is simply not
+//! consumed (the editor UI says so up front).
+//!
+//! Current builders:
 //! - claude — a generated config file passed via `--mcp-config` +
 //!   `--strict-mcp-config` (our snapshot is the *only* MCP source, so on-disk
 //!   user/project MCP config can't ride along).
 //! - codex — `-c mcp_servers.<key>.…` TOML config overrides (stdio only).
-//! - cursor/opencode/pi/antigravity — unsupported; the editor UI says so and
-//!   the snapshot is simply not consumed.
+//! - cursor/opencode/pi/antigravity — not yet wired.
 //!
 //! Both snapshots live on the session row (like `sessions.instructions`), so a
 //! running or resumed session keeps the exact profile it spawned with even if
@@ -67,6 +74,45 @@ pub struct McpServerSnapshot {
 impl McpServerSnapshot {
     fn is_stdio(&self) -> bool {
         self.transport != "http"
+    }
+}
+
+/// Everything a provider's MCP-delivery builder needs to place the session's
+/// servers where its CLI will look for them. Passed by reference so adding an
+/// input later (a second checkout, the engine kind) doesn't touch every
+/// builder signature.
+pub struct McpTarget<'a> {
+    /// The session's servers, resolved by value at spawn.
+    pub servers: &'a [McpServerSnapshot],
+    /// Sandbox writable root. Fletch-owned artifacts go under
+    /// `<sandbox_root>/.fletch-profile/`, which is bind-mounted at its host
+    /// path under docker, so a path written here is valid in both engines.
+    pub sandbox_root: &'a Path,
+}
+
+/// How a provider's MCP config reaches its CLI. A builder writes whatever file
+/// its provider reads as a side effect and returns the argv and/or environment
+/// that points at it; providers that carry config entirely in flags (codex)
+/// return args with no env. Default (both empty) is the correct no-op for a
+/// session with no servers attached.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct McpDelivery {
+    /// Extra argv appended to the provider's launch, for both the per-turn and
+    /// native-PTY paths.
+    pub args: Vec<String>,
+    /// Extra environment layered onto the child, after the sandbox engine's
+    /// own launch env and alongside `FLETCH_RPC_DIR`.
+    pub env: Vec<(String, String)>,
+}
+
+impl McpDelivery {
+    /// A delivery carrying only argv — the common case for flag-based
+    /// providers and for file-based ones whose path rides in a flag.
+    pub fn from_args(args: Vec<String>) -> Self {
+        Self {
+            args,
+            env: Vec::new(),
+        }
     }
 }
 
@@ -230,7 +276,7 @@ pub fn effective_instructions(
 /// and return its path for `--mcp-config`. `None` when no servers are attached.
 /// Generated from the session's snapshot on every spawn — never read from
 /// agent-writable or user-level config, and paired with `--strict-mcp-config`
-/// at the arg builder so this file is the only MCP source claude loads.
+/// by [`claude_mcp_delivery`] so this file is the only MCP source claude loads.
 pub fn write_claude_mcp_config(
     servers: &[McpServerSnapshot],
     sandbox_root: &Path,
@@ -271,6 +317,29 @@ pub fn write_claude_mcp_config(
         .map_err(|e| Error::Other(format!("failed to encode MCP config: {e}")))?;
     write_profile_file(&path, &body)?;
     Ok(Some(path))
+}
+
+/// Claude's [`McpDeliveryBuilder`]: write the generated config under the
+/// writable root and point claude at it with `--mcp-config <path>
+/// --strict-mcp-config`. `--strict-mcp-config` makes the generated file the
+/// *only* MCP source, so on-disk user/project MCP config never rides along
+/// with an agent Fletch spawns. No servers → an empty delivery, so claude runs
+/// with no MCP config flag at all (its pre-profile behavior).
+pub fn claude_mcp_delivery(target: &McpTarget<'_>) -> Result<McpDelivery> {
+    let Some(path) = write_claude_mcp_config(target.servers, target.sandbox_root)? else {
+        return Ok(McpDelivery::default());
+    };
+    Ok(McpDelivery::from_args(vec![
+        "--mcp-config".into(),
+        path.to_string_lossy().into_owned(),
+        "--strict-mcp-config".into(),
+    ]))
+}
+
+/// Codex's [`McpDeliveryBuilder`]: the servers ride entirely in `-c` config
+/// overrides, so there's no file to write and no environment to set.
+pub fn codex_mcp_delivery(target: &McpTarget<'_>) -> Result<McpDelivery> {
+    Ok(McpDelivery::from_args(codex_mcp_args(target.servers)))
 }
 
 /// Codex `-c mcp_servers.<key>.…` TOML overrides for the snapshot's stdio
@@ -426,6 +495,75 @@ mod tests {
         );
 
         assert_eq!(write_claude_mcp_config(&[], dir.path()).unwrap(), None);
+    }
+
+    #[test]
+    fn claude_delivery_emits_the_strict_config_flags() {
+        let dir = tempfile::tempdir().unwrap();
+        let servers = vec![McpServerSnapshot {
+            name: "GitHub".into(),
+            transport: "stdio".into(),
+            command: "npx".into(),
+            ..Default::default()
+        }];
+        let delivery = claude_mcp_delivery(&McpTarget {
+            servers: &servers,
+            sandbox_root: dir.path(),
+        })
+        .unwrap();
+
+        // The exact argv claude got before delivery was a shared seam: the
+        // generated path, and `--strict-mcp-config` so it's the only source.
+        let path = dir.path().join(PROFILE_DIR).join("mcp-servers.json");
+        assert_eq!(
+            delivery.args,
+            vec![
+                "--mcp-config".to_string(),
+                path.display().to_string(),
+                "--strict-mcp-config".to_string(),
+            ]
+        );
+        // Claude carries everything in argv — nothing in the environment.
+        assert!(delivery.env.is_empty());
+    }
+
+    #[test]
+    fn no_servers_is_an_empty_delivery_for_every_provider() {
+        // An empty snapshot must not put a config flag (or a stray file) in
+        // play: that's the pre-profile behavior each provider falls back to.
+        let dir = tempfile::tempdir().unwrap();
+        let target = McpTarget {
+            servers: &[],
+            sandbox_root: dir.path(),
+        };
+        assert_eq!(
+            claude_mcp_delivery(&target).unwrap(),
+            McpDelivery::default()
+        );
+        assert_eq!(codex_mcp_delivery(&target).unwrap(), McpDelivery::default());
+        assert!(!dir
+            .path()
+            .join(PROFILE_DIR)
+            .join("mcp-servers.json")
+            .exists());
+    }
+
+    #[test]
+    fn codex_delivery_carries_the_config_overrides_in_argv() {
+        let dir = tempfile::tempdir().unwrap();
+        let servers = vec![McpServerSnapshot {
+            name: "GitHub".into(),
+            transport: "stdio".into(),
+            command: "npx".into(),
+            ..Default::default()
+        }];
+        let delivery = codex_mcp_delivery(&McpTarget {
+            servers: &servers,
+            sandbox_root: dir.path(),
+        })
+        .unwrap();
+        assert_eq!(delivery.args, codex_mcp_args(&servers));
+        assert!(delivery.env.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -882,15 +882,10 @@ impl Supervisor {
             &record.skills,
             &sandbox_root,
         )?;
-        // Claude's generated MCP config, regenerated from the snapshot each
-        // launch and passed via `--mcp-config` + `--strict-mcp-config`. Other
-        // providers take their MCP delivery from the spec's snapshot instead
-        // (codex `-c` overrides); see `agent_profile`.
-        let mcp_config = if record.provider == "claude" {
-            crate::agent_profile::write_claude_mcp_config(&mcp_servers, &sandbox_root)?
-        } else {
-            None
-        };
+        // MCP delivery is resolved per provider at spawn from this snapshot
+        // (`agent::mcp_delivery`), so there's no provider fork here: the spawn
+        // path writes whatever config file the provider reads and adds the
+        // argv/env pointing at it. See `agent_profile`.
 
         if per_turn {
             match record.view {
@@ -916,7 +911,6 @@ impl Supervisor {
                         model: record.model.as_deref(),
                         instructions: instructions.as_deref(),
                         mcp_servers: &mcp_servers,
-                        mcp_config: None,
                         rpc_dir,
                         cols: 120,
                         rows: 32,
@@ -973,7 +967,6 @@ impl Supervisor {
                 model: record.model.as_deref(),
                 instructions: instructions.as_deref(),
                 mcp_servers: &mcp_servers,
-                mcp_config: mcp_config.as_deref(),
                 rpc_dir,
                 cols: 120,
                 rows: 32,


### PR DESCRIPTION
## Why

MCP support in Fletch was Claude-first by construction. Claude got a generated
config file via a hardcoded `record.provider == "claude"` branch in
`start_process`; codex got `-c` overrides through the per-turn descriptor table;
and cursor, opencode, pi and antigravity all had `mcp_args: None`. The practical
effect: **no MCP server a user configures in Fletch's registry ever reached four
of the six providers** — the snapshot was built, passed along, and silently
dropped.

The descriptor field was the right seam, but the wrong type.
`fn(&[McpServerSnapshot]) -> Vec<String>` is pure, and every unwired provider
needs to *write a config file* (cursor's `.cursor/mcp.json`, opencode's
`opencode.json`) or set an environment variable — not just emit argv.

## What changed

Widen the seam to `McpDeliveryBuilder`:

```rust
fn(&McpTarget) -> Result<McpDelivery>
```

- `McpTarget` carries the snapshot plus the paths a builder may write into.
- `McpDelivery` carries the resulting argv **and** environment.
- `agent::mcp_delivery(provider)` is the single resolution point, following the
  same per-turn-descriptor-plus-claude dispatch as `transcript_reader`.

Claude folds into that dispatch, so `supervisor::lifecycle` no longer forks on a
provider id and `SpawnSpec` drops its claude-only `mcp_config` field — one
`mcp_servers` input now covers every provider.

## No behavior change

This is a refactor. Claude still emits the same `--mcp-config <path>
--strict-mcp-config`, codex the same `-c mcp_servers.*` overrides, and the four
unwired providers still resolve to an empty delivery. Tests pin the claude argv
exactly so the equivalence is checked rather than asserted in a commit message.

Wiring the remaining providers is the follow-up this seam exists for.

## Note

`spawn_exec` gained an argument, which tripped clippy's `too_many_arguments`. Its
provider-identity inputs move into an `ExecLaunch` bundle rather than suppressing
the lint.

## Testing

- `cargo clippy --all-targets -- -D warnings` — clean, no new `#[allow]`
- `cargo test` — 1014 passed, 0 failed
- New: claude/codex delivery argv, empty-snapshot no-op, `mcp_delivery` dispatch
  across all six providers