### PR TITLE
feat(mcp): deliver MCP servers to opencode

### DIFF
--- a/src-tauri/src/agent/capabilities.rs
+++ b/src-tauri/src/agent/capabilities.rs
@@ -167,7 +167,7 @@ pub(crate) const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         label: "OpenCode",
         build_args: opencode_build_args,
         pty_args: opencode_pty_args,
-        mcp: None,
+        mcp: Some(crate::agent_profile::opencode_mcp_delivery),
         session_id: opencode_session_id,
         activity: || Box::new(ManagedActivity::opencode()),
         native_view: true,
@@ -277,11 +277,17 @@ mod tests {
     fn mcp_delivery_covers_claude_and_the_descriptor_table() {
         // Claude has no descriptor row, so it must still resolve — it was the
         // provider whose delivery used to be hardcoded at the spawn site.
-        assert!(mcp_delivery("claude").is_some());
-        assert!(mcp_delivery("codex").is_some());
+        for provider in ["claude", "codex", "opencode"] {
+            assert!(
+                mcp_delivery(provider).is_some(),
+                "{provider} lost MCP support"
+            );
+        }
 
-        // Not yet wired: the snapshot is ignored rather than mis-delivered.
-        for provider in ["cursor", "opencode", "pi", "antigravity"] {
+        // Not delivered: pi and agy have no MCP surface at all, and cursor's
+        // is ambient + agent-writable (see `agent_profile`'s module doc). The
+        // snapshot is ignored rather than mis-delivered.
+        for provider in ["cursor", "pi", "antigravity"] {
             assert!(
                 mcp_delivery(provider).is_none(),
                 "{provider} claims MCP support it can't deliver"

--- a/src-tauri/src/agent_profile.rs
+++ b/src-tauri/src/agent_profile.rs
@@ -25,7 +25,17 @@
 //!   `--strict-mcp-config` (our snapshot is the *only* MCP source, so on-disk
 //!   user/project MCP config can't ride along).
 //! - codex — `-c mcp_servers.<key>.…` TOML config overrides (stdio only).
-//! - cursor/opencode/pi/antigravity — not yet wired.
+//! - opencode — a `mcp`-only config in the profile dir, pointed at by
+//!   `OPENCODE_CONFIG`; opencode merges it over the user's own config itself.
+//! - cursor — deliberately unwired. cursor-agent reads MCP config only from
+//!   `<cwd>/.cursor/mcp.json` and `~/.cursor/mcp.json`: ambient, shared paths
+//!   with no per-invocation override, and its only approval control is the
+//!   blanket `--approve-mcps`. Both paths are writable by the sandboxed agent,
+//!   so occupying them safely needs an explicit ownership marker *and* a
+//!   sandbox deny on the global file — sandbox-policy work that belongs in its
+//!   own change, not here.
+//! - pi/antigravity — no MCP surface at all (pi ships an extension system
+//!   instead, agy only plugins), so the snapshot is not consumed.
 //!
 //! Both snapshots live on the session row (like `sessions.instructions`), so a
 //! running or resumed session keeps the exact profile it spawned with even if
@@ -272,6 +282,42 @@ pub fn effective_instructions(
     Ok((!parts.is_empty()).then(|| parts.join("\n\n")))
 }
 
+/// Pairs as a JSON string map — the shape `env`/`headers` take in every
+/// provider's config file.
+fn json_string_map(pairs: &[(String, String)]) -> serde_json::Map<String, serde_json::Value> {
+    pairs
+        .iter()
+        .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+        .collect()
+}
+
+/// The `{"<key>": {…}}` server map used verbatim by claude *and* cursor — both
+/// read a `mcpServers` object with `command`/`args`/`env` for stdio and
+/// `type: "http"` + `url`/`headers` for http. Keys are slugged and deduped so
+/// two servers with the same display name can't silently overwrite each other.
+fn mcp_servers_object(servers: &[McpServerSnapshot]) -> serde_json::Value {
+    let mut map = serde_json::Map::new();
+    let mut used: Vec<String> = Vec::new();
+    for s in servers {
+        let key = dedupe(&slug(&s.name), &mut used, '-');
+        let entry = if s.is_stdio() {
+            serde_json::json!({
+                "command": s.command,
+                "args": s.args,
+                "env": json_string_map(&s.env),
+            })
+        } else {
+            serde_json::json!({
+                "type": "http",
+                "url": s.url,
+                "headers": json_string_map(&s.headers),
+            })
+        };
+        map.insert(key, entry);
+    }
+    serde_json::Value::Object(map)
+}
+
 /// Write claude's MCP config (`{"mcpServers": {…}}`) under the writable root
 /// and return its path for `--mcp-config`. `None` when no servers are attached.
 /// Generated from the session's snapshot on every spawn — never read from
@@ -284,32 +330,7 @@ pub fn write_claude_mcp_config(
     if servers.is_empty() {
         return Ok(None);
     }
-    let mut map = serde_json::Map::new();
-    let mut used: Vec<String> = Vec::new();
-    for s in servers {
-        let key = dedupe(&slug(&s.name), &mut used, '-');
-        let to_map = |pairs: &[(String, String)]| {
-            pairs
-                .iter()
-                .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
-                .collect::<serde_json::Map<_, _>>()
-        };
-        let entry = if s.is_stdio() {
-            serde_json::json!({
-                "command": s.command,
-                "args": s.args,
-                "env": to_map(&s.env),
-            })
-        } else {
-            serde_json::json!({
-                "type": "http",
-                "url": s.url,
-                "headers": to_map(&s.headers),
-            })
-        };
-        map.insert(key, entry);
-    }
-    let config = serde_json::json!({ "mcpServers": serde_json::Value::Object(map) });
+    let config = serde_json::json!({ "mcpServers": mcp_servers_object(servers) });
     let dir = profile_dir(sandbox_root);
     ensure_real_dir(&dir)?;
     let path = dir.join("mcp-servers.json");
@@ -340,6 +361,71 @@ pub fn claude_mcp_delivery(target: &McpTarget<'_>) -> Result<McpDelivery> {
 /// overrides, so there's no file to write and no environment to set.
 pub fn codex_mcp_delivery(target: &McpTarget<'_>) -> Result<McpDelivery> {
     Ok(McpDelivery::from_args(codex_mcp_args(target.servers)))
+}
+
+/// One opencode `mcp` entry. `enabled` is explicit so a server we wrote is
+/// never left off by an inherited default.
+fn opencode_mcp_entry(s: &McpServerSnapshot) -> serde_json::Value {
+    if s.is_stdio() {
+        // opencode takes one `command` array (argv), not command + args.
+        let mut argv = vec![serde_json::Value::String(s.command.clone())];
+        argv.extend(s.args.iter().map(|a| serde_json::Value::String(a.clone())));
+        serde_json::json!({
+            "type": "local",
+            "command": argv,
+            "environment": json_string_map(&s.env),
+            "enabled": true,
+        })
+    } else {
+        serde_json::json!({
+            "type": "remote",
+            "url": s.url,
+            "headers": json_string_map(&s.headers),
+            "enabled": true,
+        })
+    }
+}
+
+/// OpenCode's [`McpDeliveryBuilder`]: write a config carrying only the `mcp`
+/// key into the profile dir and point opencode at it with `OPENCODE_CONFIG`.
+///
+/// opencode treats `OPENCODE_CONFIG` as an *additional* config layered into its
+/// normal resolution order, so it does the merging itself: the user's global
+/// config (providers, models, auth) and any project `opencode.json` all still
+/// apply, and we contribute only servers. That's why this writes to the profile
+/// dir and never touches the checkout — unlike cursor, nothing here can dirty a
+/// repo or collide with a tracked file.
+pub fn opencode_mcp_delivery(target: &McpTarget<'_>) -> Result<McpDelivery> {
+    if target.servers.is_empty() {
+        return Ok(McpDelivery::default());
+    }
+    let mut map = serde_json::Map::new();
+    let mut used: Vec<String> = Vec::new();
+    for s in target.servers {
+        map.insert(
+            dedupe(&slug(&s.name), &mut used, '-'),
+            opencode_mcp_entry(s),
+        );
+    }
+    let config = serde_json::json!({
+        "$schema": "https://opencode.ai/config.json",
+        "mcp": serde_json::Value::Object(map),
+    });
+
+    let dir = profile_dir(target.sandbox_root);
+    ensure_real_dir(&dir)?;
+    let path = dir.join("opencode-mcp.json");
+    let body = serde_json::to_string_pretty(&config)
+        .map_err(|e| Error::Other(format!("failed to encode opencode MCP config: {e}")))?;
+    write_profile_file(&path, &body)?;
+
+    Ok(McpDelivery {
+        args: Vec::new(),
+        env: vec![(
+            "OPENCODE_CONFIG".into(),
+            path.to_string_lossy().into_owned(),
+        )],
+    })
 }
 
 /// Codex `-c mcp_servers.<key>.…` TOML overrides for the snapshot's stdio
@@ -564,6 +650,63 @@ mod tests {
         .unwrap();
         assert_eq!(delivery.args, codex_mcp_args(&servers));
         assert!(delivery.env.is_empty());
+    }
+
+    #[test]
+    fn opencode_config_goes_to_the_profile_dir_and_rides_an_env_var() {
+        let root = tempfile::tempdir().unwrap();
+        let servers = vec![
+            McpServerSnapshot {
+                name: "Codegraph".into(),
+                transport: "stdio".into(),
+                command: "/tools/codegraph".into(),
+                args: vec!["serve".into(), "--mcp".into()],
+                env: vec![("CODEGRAPH_TELEMETRY".into(), "0".into())],
+                ..Default::default()
+            },
+            McpServerSnapshot {
+                name: "Docs".into(),
+                transport: "http".into(),
+                url: "https://mcp.example.com".into(),
+                headers: vec![("Authorization".into(), "Bearer x".into())],
+                ..Default::default()
+            },
+        ];
+        let delivery = opencode_mcp_delivery(&McpTarget {
+            servers: &servers,
+            sandbox_root: root.path(),
+        })
+        .unwrap();
+
+        // Delivered by environment, not argv — opencode has no MCP flag.
+        let path = root.path().join(PROFILE_DIR).join("opencode-mcp.json");
+        assert!(delivery.args.is_empty());
+        assert_eq!(
+            delivery.env,
+            vec![("OPENCODE_CONFIG".to_string(), path.display().to_string())]
+        );
+        let json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        // stdio collapses to one argv array, unlike claude's command + args.
+        assert_eq!(json["mcp"]["codegraph"]["type"], "local");
+        assert_eq!(
+            json["mcp"]["codegraph"]["command"],
+            serde_json::json!(["/tools/codegraph", "serve", "--mcp"])
+        );
+        assert_eq!(
+            json["mcp"]["codegraph"]["environment"]["CODEGRAPH_TELEMETRY"],
+            "0"
+        );
+        assert_eq!(json["mcp"]["codegraph"]["enabled"], true);
+        assert_eq!(json["mcp"]["docs"]["type"], "remote");
+        assert_eq!(json["mcp"]["docs"]["url"], "https://mcp.example.com");
+        assert_eq!(json["mcp"]["docs"]["headers"]["Authorization"], "Bearer x");
+        // Only the `mcp` key: anything else would override the user's config,
+        // which opencode merges ours into.
+        let obj = json.as_object().unwrap();
+        let mut keys: Vec<&str> = obj.keys().map(String::as_str).collect();
+        keys.sort();
+        assert_eq!(keys, vec!["$schema", "mcp"]);
     }
 
     #[test]

--- a/src-tauri/src/codegraph/mirror.rs
+++ b/src-tauri/src/codegraph/mirror.rs
@@ -222,30 +222,11 @@ pub async fn copy_index_into(mirror_dir: &Path, checkout: &Path) -> Result<()> {
 }
 
 /// Add `.codegraph` to a checkout's `.git/info/exclude` so the copied index
-/// never surfaces in `git status`/diffs. Idempotent: the line is added at most
-/// once, and the file (and its parent) is created if missing.
+/// never surfaces in `git status`/diffs. Thin async wrapper over the shared
+/// [`crate::git_state::ensure_git_exclude`] — the same helper cursor's MCP
+/// config write uses — since the underlying work is a few bytes of file I/O.
 pub async fn append_git_exclude(checkout: &Path) -> Result<()> {
-    let info_dir = checkout.join(".git").join("info");
-    tokio::fs::create_dir_all(&info_dir)
-        .await
-        .map_err(|e| Error::Other(format!("create .git/info: {e}")))?;
-    let exclude = info_dir.join("exclude");
-    let existing = tokio::fs::read_to_string(&exclude)
-        .await
-        .unwrap_or_default();
-    if existing.lines().any(|l| l.trim() == INDEX_DIR) {
-        return Ok(());
-    }
-    let mut next = existing;
-    if !next.is_empty() && !next.ends_with('\n') {
-        next.push('\n');
-    }
-    next.push_str(INDEX_DIR);
-    next.push('\n');
-    tokio::fs::write(&exclude, next)
-        .await
-        .map_err(|e| Error::Other(format!("write .git/info/exclude: {e}")))?;
-    Ok(())
+    crate::git_state::ensure_git_exclude(checkout, INDEX_DIR)
 }
 
 fn path_str(path: &Path) -> Result<String> {

--- a/src-tauri/src/git_state.rs
+++ b/src-tauri/src/git_state.rs
@@ -1031,3 +1031,83 @@ mod tests {
         assert_eq!(map.get("café.ts"), Some(&(4, 0)));
     }
 }
+
+/// Add `entry` to a checkout's `.git/info/exclude` if it isn't already listed,
+/// so a host-generated file inside the worktree never shows up in `git status`.
+///
+/// `.git/info/exclude` (not `.gitignore`) because it's local to the checkout
+/// and untracked — Fletch never edits a file the repo ships. Idempotent: the
+/// entry is written once and re-checked on every later spawn.
+///
+/// Only hides files git isn't already tracking; a *tracked* path stays visible
+/// as a modification, which is the honest outcome — see `cursor_mcp_delivery`.
+pub fn ensure_git_exclude(checkout: &Path, entry: &str) -> Result<()> {
+    use crate::error::Error;
+
+    let info_dir = checkout.join(".git").join("info");
+    std::fs::create_dir_all(&info_dir)
+        .map_err(|e| Error::Other(format!("create .git/info: {e}")))?;
+    let exclude = info_dir.join("exclude");
+    let existing = std::fs::read_to_string(&exclude).unwrap_or_default();
+    if existing.lines().any(|l| l.trim() == entry) {
+        return Ok(());
+    }
+    let mut next = existing;
+    if !next.is_empty() && !next.ends_with('\n') {
+        next.push('\n');
+    }
+    next.push_str(entry);
+    next.push('\n');
+    std::fs::write(&exclude, next)
+        .map_err(|e| Error::Other(format!("write .git/info/exclude: {e}")))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod exclude_tests {
+    use super::*;
+
+    fn repo() -> tempfile::TempDir {
+        let td = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(td.path().join(".git").join("info")).unwrap();
+        td
+    }
+
+    #[test]
+    fn entry_is_appended_once_and_preserves_existing_lines() {
+        let td = repo();
+        let exclude = td.path().join(".git/info/exclude");
+        std::fs::write(&exclude, "# user's own\nbuild/\n").unwrap();
+
+        ensure_git_exclude(td.path(), ".cursor/mcp.json").unwrap();
+        ensure_git_exclude(td.path(), ".cursor/mcp.json").unwrap();
+
+        let body = std::fs::read_to_string(&exclude).unwrap();
+        assert_eq!(body.matches(".cursor/mcp.json").count(), 1, "{body}");
+        assert!(
+            body.contains("# user's own"),
+            "clobbered user lines: {body}"
+        );
+        assert!(body.contains("build/"), "clobbered user lines: {body}");
+    }
+
+    #[test]
+    fn missing_exclude_file_is_created_with_a_trailing_newline() {
+        let td = repo();
+        ensure_git_exclude(td.path(), ".cursor/mcp.json").unwrap();
+        let body = std::fs::read_to_string(td.path().join(".git/info/exclude")).unwrap();
+        assert_eq!(body, ".cursor/mcp.json\n");
+    }
+
+    #[test]
+    fn a_file_without_a_trailing_newline_does_not_glue_entries_together() {
+        let td = repo();
+        let exclude = td.path().join(".git/info/exclude");
+        std::fs::write(&exclude, "build/").unwrap();
+        ensure_git_exclude(td.path(), ".codegraph").unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&exclude).unwrap(),
+            "build/\n.codegraph\n"
+        );
+    }
+}

--- a/src/data/providers.ts
+++ b/src/data/providers.ts
@@ -51,14 +51,21 @@ export function isDockerSupported(id: string | null | undefined): boolean {
 }
 
 /** Which MCP transports each provider can attach — mirrors the backend
- *  delivery in `agent_profile.rs`: claude takes stdio + http via
- *  `--mcp-config`, codex only stdio via `-c mcp_servers.*` (its `-c` config
- *  has no http transport), and the rest have no MCP surface we can drive.
- *  Unknown ids are treated as unsupported. */
+ *  delivery builders in `agent_profile.rs`, one entry per wired
+ *  `McpDeliveryBuilder`:
+ *    - claude   — stdio + http via `--mcp-config`
+ *    - codex    — stdio only via `-c mcp_servers.*` (its `-c` config has no
+ *                 http transport)
+ *    - opencode — stdio + http, via an `OPENCODE_CONFIG` overlay
+ *  cursor, pi and antigravity are absent on purpose. pi and agy speak no MCP
+ *  at all (pi ships an extension system, agy only plugins); cursor's only
+ *  config surface is ambient and agent-writable, so it needs sandbox work
+ *  before it can be delivered safely. Unknown ids are treated as unsupported. */
 export type McpSupport = "all" | "stdio" | "none";
 export const MCP_SUPPORT: Record<string, McpSupport> = {
   claude: "all",
   codex: "stdio",
+  opencode: "all",
 };
 
 /** Whether a provider with `support` can actually deliver an MCP server of


### PR DESCRIPTION
## What this ships

OpenCode MCP delivery — one of the `mcp: None` rows the seam in #516 was built
for. `OPENCODE_CONFIG` names an *additional* config that opencode layers into
its own resolution order, so it does the merging for us: we write an `mcp`-only
file into the profile dir and point the env var at it. The user's providers,
models and auth all still apply, and nothing is written into the checkout.
Schema verified against the real CLI, not assumed.

## Cursor has been pulled out of this PR

Three review rounds found five defects in the cursor path. They were not
independent bugs — they shared one root cause.

Every provider Fletch delivers to safely has a **private, per-session channel**:
claude `--mcp-config` + `--strict-mcp-config`, codex `-c mcp_servers.*`,
opencode `OPENCODE_CONFIG`. Cursor is the only one without one. It resolves MCP
config solely from `<cwd>/.cursor/mcp.json` and `~/.cursor/mcp.json` — ambient,
shared paths with no per-invocation override — and its only approval control is
the blanket `--approve-mcps`. Both paths are writable by the sandboxed agent
(`~/.cursor` is bind-mounted read-write because cursor writes the transcripts
the host reader tails), so a compromised session can plant a server that a later
session auto-approves.

Each of my fixes was another attempt to safely occupy a namespace Fletch doesn't
own. That is not patchable at this layer.

Doing it properly needs either:

- an explicit **ownership marker** in the file we generate — git-tracked vs
  untracked is a proxy that guesses wrong on a legitimately ignored config —
  **plus** a sandbox deny on `~/.cursor/mcp.json` (seatbelt is last-match-wins,
  Docker can bind a single file read-only); or
- better, a **per-agent `HOME`** so `~/.cursor` becomes Fletch-owned per
  session. That collapses all five findings at once and needs neither the marker
  nor the deny. The blocker is that `cursor_locate` resolves transcripts via the
  host's `dirs::home_dir()`, so the per-agent home has to be threaded through
  `TranscriptReader::locate`.

Both are sandbox-policy work and belong in their own change. Cursor stays
`mcp: None` here, and `agent_profile`'s module doc records the reasoning so the
next person doesn't re-derive it. `McpTarget::cwd` goes with it — cursor was its
only consumer, and a checkout path is exactly what a provider with a private
channel never needs.

## Also

`ensure_git_exclude` stays as a shared `git_state` helper regardless;
`codegraph::append_git_exclude` delegates to it instead of duplicating it.

## Testing

- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 1017 passed, 0 failed
- Frontend: `tsc` reports one pre-existing error (`partial-json`, a dep `main`
  added) and vitest runs 360 — **both identical on pristine `main`** in this
  environment, which has a stale `node_modules` that bun can't refresh under the
  sandbox. Neither is affected by this diff; CI installs fresh.