### PR TITLE
feat(codegraph): tell agents to prefer the index over grep

### DIFF
--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -29,7 +29,8 @@ use crate::managed_session::ManagedSession;
 use crate::pty_session::PtySession;
 
 pub use capabilities::{
-    capabilities, injection_mode, per_turn_descriptor, transcript_reader, PerTurnDescriptor,
+    capabilities, injection_mode, mcp_delivery, per_turn_descriptor, transcript_reader,
+    PerTurnDescriptor,
 };
 pub(crate) use probe::parse_semver;
 pub use probe::{

--- a/src-tauri/src/agent_profile.rs
+++ b/src-tauri/src/agent_profile.rs
@@ -255,19 +255,29 @@ pub fn materialize_skills(skills: &[SkillSnapshot], sandbox_root: &Path) -> Resu
     Ok(Some(index.trim_end().to_string()))
 }
 
-/// The session's effective instruction suffix: the custom agent's standing
-/// brief, then a forked session's carried-conversation digest, then the
-/// materialized skill index. Each is optional; `None` when all are absent —
-/// which keeps every `instructions.rs` helper a no-op, exactly like today.
+/// The session's effective instruction suffix: the codegraph playbook (when
+/// this session got the server), then the custom agent's standing brief, then a
+/// forked session's carried-conversation digest, then the materialized skill
+/// index. Each is optional; `None` when all are absent — which keeps every
+/// `instructions.rs` helper a no-op, exactly like today.
 ///
 /// `brief` and `forked_context` are stored in separate session columns (so the
 /// user brief is never parsed apart from an injected block) but are injected
 /// together here, brief first.
+///
+/// `codegraph_available` says whether the codegraph MCP server actually landed
+/// in this session's delivery (`codegraph::McpInjection::codegraph_available`)
+/// — not whether the setting is on. It gates the one *conditional* Fletch
+/// block, which goes first so it sits with the other app-managed guidance the
+/// global text ends with, ahead of the user's role brief. Passing `false` for
+/// a provider that can't receive MCP is the whole point: never advertise a tool
+/// the agent wasn't given.
 pub fn effective_instructions(
     brief: Option<&str>,
     forked_context: Option<&str>,
     skills: &[SkillSnapshot],
     sandbox_root: &Path,
+    codegraph_available: bool,
 ) -> Result<Option<String>> {
     let index = materialize_skills(skills, sandbox_root)?;
     let clean = |s: Option<&str>| {
@@ -275,7 +285,10 @@ pub fn effective_instructions(
             .filter(|s| !s.is_empty())
             .map(str::to_string)
     };
-    let parts: Vec<String> = [clean(brief), clean(forked_context), index]
+    let codegraph = codegraph_available
+        .then(crate::instructions::codegraph_block)
+        .flatten();
+    let parts: Vec<String> = [codegraph, clean(brief), clean(forked_context), index]
         .into_iter()
         .flatten()
         .collect();
@@ -504,24 +517,55 @@ mod tests {
         let skills = vec![skill("Deploy", "cutting a release", "steps")];
 
         // Brief only.
-        let brief_only = effective_instructions(Some("Be terse."), None, &[], dir.path()).unwrap();
+        let brief_only =
+            effective_instructions(Some("Be terse."), None, &[], dir.path(), false).unwrap();
         assert_eq!(brief_only.as_deref(), Some("Be terse."));
 
         // Both: brief first, index after.
-        let both = effective_instructions(Some("Be terse."), None, &skills, dir.path())
+        let both = effective_instructions(Some("Be terse."), None, &skills, dir.path(), false)
             .unwrap()
             .unwrap();
         assert!(both.starts_with("Be terse.\n\n## Skills"));
 
         // Neither → None, so instructions.rs helpers stay no-ops.
         assert_eq!(
-            effective_instructions(None, None, &[], dir.path()).unwrap(),
+            effective_instructions(None, None, &[], dir.path(), false).unwrap(),
             None
         );
         assert_eq!(
-            effective_instructions(Some("  "), None, &[], dir.path()).unwrap(),
+            effective_instructions(Some("  "), None, &[], dir.path(), false).unwrap(),
             None
         );
+    }
+
+    #[test]
+    fn codegraph_block_rides_only_when_the_server_was_injected() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Not injected: no mention of the tool, and an otherwise-empty session
+        // still injects nothing at all.
+        let absent = effective_instructions(Some("Be terse."), None, &[], dir.path(), false)
+            .unwrap()
+            .unwrap();
+        assert!(!absent.contains("codegraph_explore"), "{absent}");
+        assert_eq!(
+            effective_instructions(None, None, &[], dir.path(), false).unwrap(),
+            None
+        );
+
+        // Injected: the block leads, ahead of the user's brief.
+        let present = effective_instructions(Some("Be terse."), None, &[], dir.path(), true)
+            .unwrap()
+            .unwrap();
+        assert!(present.contains("codegraph_explore"), "{present}");
+        assert!(present.ends_with("\n\nBe terse."), "{present}");
+
+        // It stands on its own too — a plain session with the server still
+        // learns about it.
+        let alone = effective_instructions(None, None, &[], dir.path(), true)
+            .unwrap()
+            .unwrap();
+        assert_eq!(Some(alone), crate::instructions::codegraph_block());
     }
 
     #[test]
@@ -530,18 +574,25 @@ mod tests {
         let skills = vec![skill("Deploy", "cutting a release", "steps")];
 
         // Forked context alone (no brief) still injects.
-        let ctx_only = effective_instructions(None, Some("prior convo"), &[], dir.path()).unwrap();
+        let ctx_only =
+            effective_instructions(None, Some("prior convo"), &[], dir.path(), false).unwrap();
         assert_eq!(ctx_only.as_deref(), Some("prior convo"));
 
         // All three compose in order: brief, forked context, skill index.
-        let all =
-            effective_instructions(Some("Be terse."), Some("prior convo"), &skills, dir.path())
-                .unwrap()
-                .unwrap();
+        let all = effective_instructions(
+            Some("Be terse."),
+            Some("prior convo"),
+            &skills,
+            dir.path(),
+            false,
+        )
+        .unwrap()
+        .unwrap();
         assert!(all.starts_with("Be terse.\n\nprior convo\n\n## Skills"));
 
         // Blank forked context is dropped like a blank brief.
-        let blank = effective_instructions(Some("Be terse."), Some("  "), &[], dir.path()).unwrap();
+        let blank =
+            effective_instructions(Some("Be terse."), Some("  "), &[], dir.path(), false).unwrap();
         assert_eq!(blank.as_deref(), Some("Be terse."));
     }
 

--- a/src-tauri/src/codegraph/mod.rs
+++ b/src-tauri/src/codegraph/mod.rs
@@ -109,44 +109,75 @@ fn mcp_server_snapshot() -> Option<McpServerSnapshot> {
 /// Pure gate for MCP injection, factored out so the decision is testable
 /// without touching global state or the filesystem. Inject only when indexing
 /// is enabled, the engine is not Docker (a container can't exec the host macOS
-/// binary), the binary is installed, and no server named `"codegraph"`
-/// (case-insensitive) already exists — a user-defined one must never be
-/// shadowed, and its config key would otherwise collide.
+/// binary), the binary is installed, the provider can actually *receive* an MCP
+/// server, and no server named `"codegraph"` (case-insensitive) already exists
+/// — a user-defined one must never be shadowed, and its config key would
+/// otherwise collide.
+///
+/// `can_receive_mcp` is resolved by the caller from
+/// `agent::mcp_delivery(provider)` rather than looked up here: it keeps this
+/// function free of provider ids and of the `agent` module, and it is the one
+/// input that decides whether the snapshot is delivered or silently dropped
+/// (pi and antigravity have no MCP surface at all).
 fn should_inject(
     enabled: bool,
     engine: EngineKind,
     binary_installed: bool,
+    can_receive_mcp: bool,
     existing_names: &[&str],
 ) -> bool {
     enabled
         && engine != EngineKind::Docker
         && binary_installed
+        && can_receive_mcp
         && !existing_names
             .iter()
             .any(|n| n.eq_ignore_ascii_case("codegraph"))
 }
 
+/// The outcome of the dynamic codegraph fold.
+pub struct McpInjection {
+    /// The session's servers, with codegraph appended when the gate allowed
+    /// it. Feeds the provider's delivery builder directly.
+    pub servers: Vec<McpServerSnapshot>,
+    /// Whether codegraph is actually in `servers` — i.e. whether this agent
+    /// will really have the tool. Every gate in [`should_inject`] can drop it
+    /// silently, so the instruction layer keys off this flag rather than off
+    /// the settings toggle (see `instructions::codegraph_block`).
+    pub codegraph_available: bool,
+}
+
 /// Return `servers` with the codegraph MCP server appended when [`should_inject`]
-/// allows it. Injection is dynamic — the returned list feeds the config writers
-/// directly and is never persisted onto the session snapshot, so the toggle's
-/// *current* state always wins for both fresh spawns and resumes.
+/// allows it, plus whether that happened. Injection is dynamic — the returned
+/// list feeds the config writers directly and is never persisted onto the
+/// session snapshot, so the toggle's *current* state always wins for both fresh
+/// spawns and resumes.
 pub fn inject_mcp_server(
     servers: &[McpServerSnapshot],
     engine: EngineKind,
-) -> Vec<McpServerSnapshot> {
+    provider: &str,
+) -> McpInjection {
     let mut out = servers.to_vec();
     let allow = {
         let names: Vec<&str> = out.iter().map(|s| s.name.as_str()).collect();
-        should_inject(enabled(), engine, is_installed(), &names)
+        should_inject(
+            enabled(),
+            engine,
+            is_installed(),
+            crate::agent::mcp_delivery(provider).is_some(),
+            &names,
+        )
     };
-    if allow {
-        // `is_installed()` was true, so this is `Some` barring a race with an
-        // uninstall between the two checks — in which case we simply skip.
-        if let Some(server) = mcp_server_snapshot() {
-            out.push(server);
-        }
+    // `is_installed()` was true, so this is `Some` barring a race with an
+    // uninstall between the two checks — in which case we simply skip, and the
+    // flag stays false so nothing advertises a tool that isn't there.
+    let server = if allow { mcp_server_snapshot() } else { None };
+    let codegraph_available = server.is_some();
+    out.extend(server);
+    McpInjection {
+        servers: out,
+        codegraph_available,
     }
-    out
 }
 
 #[cfg(test)]
@@ -163,23 +194,61 @@ mod tests {
 
     #[test]
     fn should_inject_happy_path() {
-        assert!(should_inject(true, EngineKind::SandboxExec, true, &[]));
+        assert!(should_inject(
+            true,
+            EngineKind::SandboxExec,
+            true,
+            true,
+            &[]
+        ));
     }
 
     #[test]
     fn should_inject_requires_enabled() {
-        assert!(!should_inject(false, EngineKind::SandboxExec, true, &[]));
+        assert!(!should_inject(
+            false,
+            EngineKind::SandboxExec,
+            true,
+            true,
+            &[]
+        ));
     }
 
     #[test]
     fn should_inject_skips_docker() {
         // A container can't exec the host macOS binary.
-        assert!(!should_inject(true, EngineKind::Docker, true, &[]));
+        assert!(!should_inject(true, EngineKind::Docker, true, true, &[]));
     }
 
     #[test]
     fn should_inject_requires_installed_binary() {
-        assert!(!should_inject(true, EngineKind::SandboxExec, false, &[]));
+        assert!(!should_inject(
+            true,
+            EngineKind::SandboxExec,
+            false,
+            true,
+            &[]
+        ));
+    }
+
+    #[test]
+    fn should_inject_requires_an_mcp_surface() {
+        // pi and antigravity can't consume MCP at all, so a snapshot pushed at
+        // them is dropped on the floor — don't index for them and don't tell
+        // them the tool exists.
+        assert!(!should_inject(
+            true,
+            EngineKind::SandboxExec,
+            true,
+            false,
+            &[]
+        ));
+        for provider in ["pi", "antigravity"] {
+            assert!(
+                crate::agent::mcp_delivery(provider).is_none(),
+                "{provider} would now pass the gate"
+            );
+        }
     }
 
     #[test]
@@ -189,7 +258,18 @@ mod tests {
             true,
             EngineKind::SandboxExec,
             true,
+            true,
             &["github", "CodeGraph"]
         ));
+    }
+
+    #[test]
+    fn inject_reports_nothing_for_a_provider_without_mcp() {
+        // End to end through the globals: whatever the toggle and the binary
+        // say, a provider with no MCP surface gets neither the server nor the
+        // instruction flag.
+        let injection = inject_mcp_server(&[], EngineKind::SandboxExec, "pi");
+        assert!(injection.servers.is_empty());
+        assert!(!injection.codegraph_available);
     }
 }

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -17,7 +17,7 @@
 //!   conversation, so later turns don't re-send it (no per-turn token tax, no
 //!   accumulating copies).
 //!
-//! The injected text has three layers: editable general guidance
+//! The injected text has three unconditional layers: editable general guidance
 //! (`instructions/system_prompt.md`), a Fletch-managed protocol block
 //! (`instructions/rpc_protocol.md`) that documents the file-RPC transport the
 //! app exposes (see `rpc.rs`), and Fletch-managed feature playbooks (for
@@ -26,6 +26,12 @@
 //! sync with the op allowlist / trigger names; the general layer is yours to
 //! edit. Blank all files to disable injection entirely — every helper below
 //! no-ops when the combined text is empty.
+//!
+//! One layer is *conditional* and therefore not part of [`text`]:
+//! [`codegraph_block`], which only makes sense for a session that actually got
+//! the codegraph MCP server. It rides the per-session suffix instead (see
+//! `agent_profile::effective_instructions`), which lands right after this
+//! block in all three deliveries above.
 
 /// Editable general guidance. Edit the file, not this constant.
 const SYSTEM_PROMPT: &str = include_str!("instructions/system_prompt.md");
@@ -40,6 +46,16 @@ const RPC_INSTRUCTIONS: &str = include_str!("instructions/rpc_protocol.md");
 /// `components/RightPanel/delegation.ts`).
 const GIT_ACTIONS: &str = include_str!("instructions/git_actions.md");
 
+/// Fletch-managed codegraph playbook: prefer the injected code-index MCP
+/// server over a grep/read loop, and tell delegated subagents to do the same.
+///
+/// Deliberately *not* in [`text`]. The codegraph server reaches only some
+/// sessions — indexing off, a Docker engine, a missing binary, a user-defined
+/// `codegraph` server, or a provider with no MCP surface at all each suppress
+/// it (see `codegraph::inject_mcp_server`) — and instructing an agent to call
+/// a tool it was never given is worse than staying quiet.
+const CODEGRAPH: &str = include_str!("instructions/codegraph.md");
+
 /// The combined instruction text, trimmed. Empty when every source is
 /// blank/whitespace, which makes every injection helper a no-op.
 pub fn text() -> String {
@@ -50,6 +66,14 @@ pub fn text() -> String {
         .collect::<Vec<_>>()
         .join("\n\n");
     combined
+}
+
+/// The codegraph guidance block, for sessions where the server was actually
+/// injected. `None` when the file is blank, so blanking every file under
+/// `instructions/` still disables injection entirely.
+pub fn codegraph_block() -> Option<String> {
+    let block = CODEGRAPH.trim();
+    (!block.is_empty()).then(|| block.to_string())
 }
 
 /// Per-agent workspace-layout note for multi-repo projects, composed ahead of
@@ -190,6 +214,23 @@ mod tests {
         let t = text();
         assert!(t.contains("[app-action]"), "playbook block missing");
         assert!(t.contains("### commit"), "commit playbook missing");
+    }
+
+    #[test]
+    fn codegraph_block_is_conditional_and_names_the_tool() {
+        // Never in the unconditional text: a session without the server must
+        // not be told to call it.
+        assert!(!text().contains("codegraph_explore"));
+
+        let block = codegraph_block().expect("shipped default is non-empty");
+        assert!(block.contains("codegraph_explore"), "block: {block}");
+        // The tool is namespaced differently per provider surface, so the
+        // agent has to be able to recognize both renderings.
+        assert!(block.contains("mcp__codegraph__codegraph_explore"));
+        assert!(block.contains("codegraph.codegraph_explore"));
+        // The whole point of the block: subagents don't inherit it, so the
+        // main agent must be told to pass it down.
+        assert!(block.to_lowercase().contains("subagent"), "block: {block}");
     }
 
     #[test]

--- a/src-tauri/src/instructions/codegraph.md
+++ b/src-tauri/src/instructions/codegraph.md
@@ -1,0 +1,18 @@
+## Codegraph: query the index instead of grepping
+
+This workspace has **codegraph** attached over MCP — a pre-built knowledge graph of
+the repo's symbols, files, and edges. One `codegraph_explore` call (a
+natural-language question, or just a bag of symbol/file names) returns the
+verbatim, line-numbered source of the matching symbols grouped by file, plus their
+callers and the blast radius of changing them. Its namespace differs per CLI
+(`mcp__codegraph__codegraph_explore` on Claude, `codegraph.codegraph_explore` on
+Codex) — it is whichever tool name ends in `codegraph_explore`.
+
+- Prefer it over a grep + read loop, both for questions ("how does X work", "where
+  is Y") and **before you edit** — one call gives you the code and everything that
+  depends on it. The output is line-numbered source, safe to edit from.
+- Fall back to grep/read when codegraph comes back empty; the index trails a
+  just-written file by about a second.
+- **Pass this on when you delegate.** Subagents do not inherit these instructions
+  and their definitions steer toward Grep/Glob, so say it in the task prompt
+  yourself: "use codegraph_explore rather than grep/read to locate code."

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -856,11 +856,15 @@ impl Supervisor {
 
         // Dynamically fold the codegraph MCP server into the session's snapshot
         // for this launch, when code indexing is on, the engine isn't Docker,
-        // and the binary is installed. Injected here (not persisted onto the
-        // session snapshot) so this runs identically for fresh spawns and
-        // resumes and the toggle's *current* state always wins. A user-defined
-        // "codegraph" server suppresses injection (see `codegraph`).
-        let mcp_servers = crate::codegraph::inject_mcp_server(&record.mcp_servers, engine);
+        // the binary is installed, and this provider can actually receive an
+        // MCP server at all. Injected here (not persisted onto the session
+        // snapshot) so this runs identically for fresh spawns and resumes and
+        // the toggle's *current* state always wins. A user-defined "codegraph"
+        // server suppresses injection (see `codegraph`).
+        let crate::codegraph::McpInjection {
+            servers: mcp_servers,
+            codegraph_available,
+        } = crate::codegraph::inject_mcp_server(&record.mcp_servers, engine, &record.provider);
 
         // Materialize the session's skill snapshot under the writable root and
         // fold its index into the injected instructions. Recomputed on every
@@ -876,11 +880,15 @@ impl Supervisor {
             (Some(note), None) => Some(note),
             (None, brief) => brief.map(str::to_string),
         };
+        // The codegraph playbook rides the same suffix, gated on the server
+        // having really landed above — so an agent is only ever told to prefer
+        // the tool in a session that actually has it.
         let instructions = crate::agent_profile::effective_instructions(
             brief.as_deref(),
             record.forked_context.as_deref(),
             &record.skills,
             &sandbox_root,
+            codegraph_available,
         )?;
         // MCP delivery is resolved per provider at spawn from this snapshot
         // (`agent::mcp_delivery`), so there's no provider fork here: the spawn


### PR DESCRIPTION
> Stacked on #517 — base is `feat/mcp-cursor-opencode`, which is itself stacked on
> #516. Review those first.

## Why

This is the PR that actually addresses the original complaint: **agents don't use
codegraph consistently, and their subagents essentially never do.**

Fletch injects the codegraph MCP server but injected **zero instruction text**
about it. `grep -rin codegraph src-tauri/src/instructions/` returned nothing. The
only "use codegraph" guidance came from the server's own `initialize` response,
which sits low in the priority stack and competes with Claude Code's built-in
prompting toward Grep/Glob. So agents keep running a grep + read loop over an
index we already paid to build.

Subagents are worse, for two compounding reasons: `--append-system-prompt` does
not reach Claude Code's Task-tool subagents, and the built-in subagent
definitions are written around keyword search.

## Two changes

**1. Gate injection on the provider actually being able to receive it.**

`should_inject` gained `can_receive_mcp`, resolved at the call site via
`agent::mcp_delivery(provider).is_some()` — no hardcoded provider list, and the
pure gate stays free of provider ids and of the `agent` module. Before this, pi
and antigravity were handed a codegraph snapshot that was silently dropped.

`inject_mcp_server` now returns `McpInjection { servers, codegraph_available }`
so the instruction layer keys off whether the tool is *really* present rather
than off the settings toggle. Full gate: indexing enabled && engine != Docker &&
binary installed && provider has an MCP delivery builder && no case-insensitive
`"codegraph"` collision.

**2. Emit guidance only when codegraph actually landed.**

`instructions/codegraph.md` is a new conditional layer — deliberately *not* part
of `text()`, so blanking every file under `instructions/` still disables
injection entirely, and so we never tell an agent to call a tool it doesn't have.
It rides the existing instruction suffix, which already reaches all three
delivery shapes (`--append-system-prompt`, `-c developer_instructions`, and
first-turn prompt prepend), so no per-provider work was needed.

The text covers what one call returns, that it's for edits as much as questions,
that the tool's namespace differs per CLI — and, the part we can't fix any other
way yet, that the agent must repeat the instruction in the task prompt when it
delegates.

## What this does *not* fix

Subagents still don't inherit the instruction; we're relying on the parent to
pass it down. The real fix is per-provider agent definitions written into the
checkout (`.claude/agents/*.md`, opencode's `agent` key) — a separate PR.

## Testing

- `cargo clippy --all-targets -- -D warnings` — clean, no new `#[allow]`
- `cargo test` — 1024 passed, 0 failed
- `tsc --noEmit` clean; vitest 534 passed; biome exit 0 (unchanged from baseline)
- New: gate rejects a provider with no MCP surface; end-to-end `inject_mcp_server`
  for pi reports neither server nor flag; `text()` never carries the block; the
  block is present when injected and absent when not

## Follow-up spotted while here

`lifecycle::provision_codegraph_index` still gates only on `enabled() && engine !=
Docker`, so for pi/antigravity we clone, index, and copy `codegraph.db` into a
checkout nothing will ever query. Harmless but wasted background work; the record
is available at that call site, so it's a one-line fix. Not done here to keep the
diff scoped.