### PR TITLE
fix(codegraph): don't index for providers that can't query it

### DIFF
--- a/src-tauri/src/agent/capabilities.rs
+++ b/src-tauri/src/agent/capabilities.rs
@@ -284,9 +284,9 @@ mod tests {
             );
         }
 
-        // Not delivered: pi and agy have no MCP surface at all, and cursor's
-        // is ambient + agent-writable (see `agent_profile`'s module doc). The
-        // snapshot is ignored rather than mis-delivered.
+        // Not delivered: pi has no MCP surface at all; cursor's and agy's are
+        // ambient/user-global with no per-session scoping (see `agent_profile`'s
+        // module doc). The snapshot is ignored rather than mis-delivered.
         for provider in ["cursor", "pi", "antigravity"] {
             assert!(
                 mcp_delivery(provider).is_none(),

--- a/src-tauri/src/agent_profile.rs
+++ b/src-tauri/src/agent_profile.rs
@@ -34,8 +34,13 @@
 //!   so occupying them safely needs an explicit ownership marker *and* a
 //!   sandbox deny on the global file — sandbox-policy work that belongs in its
 //!   own change, not here.
-//! - pi/antigravity — no MCP surface at all (pi ships an extension system
-//!   instead, agy only plugins), so the snapshot is not consumed.
+//! - pi — no MCP surface at all; it ships an extension system instead
+//!   (`--extension`, `pi install`) and documents the omission as deliberate.
+//! - antigravity — *does* speak MCP, via `~/.gemini/config/mcp_config.json` and
+//!   `plugins/<name>/mcp_config.json`, but every path it accepts is user-global
+//!   with no project or env override. That can't express a per-session snapshot
+//!   and would leak into the user's own agy, so it's unwired for the same
+//!   reason as cursor rather than for lack of a surface.
 //!
 //! Both snapshots live on the session row (like `sessions.instructions`), so a
 //! running or resumed session keeps the exact profile it spawned with even if

--- a/src-tauri/src/codegraph/mod.rs
+++ b/src-tauri/src/codegraph/mod.rs
@@ -126,13 +126,50 @@ fn should_inject(
     can_receive_mcp: bool,
     existing_names: &[&str],
 ) -> bool {
+    wants_codegraph(enabled, engine, can_receive_mcp, existing_names) && binary_installed
+}
+
+/// Everything that decides whether codegraph takes part in a session *except*
+/// whether the binary is on disk yet: indexing is on, the engine can exec a host
+/// binary, the provider's CLI can actually receive an MCP server, and the
+/// session hasn't already defined its own `"codegraph"` (case-insensitive) that
+/// we must not shadow.
+///
+/// Factored out because the injection gate and the index-provisioning gate need
+/// exactly these four and must never drift — a session that won't get the server
+/// must not pay to build an index, and vice versa. They differ on the fifth
+/// condition only: `should_inject` requires the binary to already exist, while
+/// provisioning is the code path that *installs* it, so requiring it there would
+/// deadlock the first run.
+fn wants_codegraph(
+    enabled: bool,
+    engine: EngineKind,
+    can_receive_mcp: bool,
+    existing_names: &[&str],
+) -> bool {
     enabled
         && engine != EngineKind::Docker
-        && binary_installed
         && can_receive_mcp
         && !existing_names
             .iter()
             .any(|n| n.eq_ignore_ascii_case("codegraph"))
+}
+
+/// [`wants_codegraph`] resolved against live state, for the index-provisioning
+/// gate. `session_servers` is the session's own MCP snapshot — the same list
+/// `inject_mcp_server` checks for a user-defined `"codegraph"` collision.
+pub fn session_wants_codegraph(
+    engine: EngineKind,
+    provider: &str,
+    session_servers: &[McpServerSnapshot],
+) -> bool {
+    let names: Vec<&str> = session_servers.iter().map(|s| s.name.as_str()).collect();
+    wants_codegraph(
+        enabled(),
+        engine,
+        crate::agent::mcp_delivery(provider).is_some(),
+        &names,
+    )
 }
 
 /// The outcome of the dynamic codegraph fold.
@@ -260,6 +297,57 @@ mod tests {
             true,
             true,
             &["github", "CodeGraph"]
+        ));
+    }
+
+    #[test]
+    fn provisioning_and_injection_agree_on_every_shared_condition() {
+        // The index-provisioning gate must reject everything injection rejects,
+        // or we pay for a mirror clone + parse the agent can never query. Both
+        // go through `wants_codegraph`, so this pins the four shared conditions
+        // rather than trusting two hand-written copies to stay in step.
+        // A session that defines its own "codegraph" suppresses injection — and
+        // so must suppress indexing. This is the case that shipped broken.
+        assert!(!wants_codegraph(
+            true,
+            EngineKind::SandboxExec,
+            true,
+            &["CodeGraph"]
+        ));
+        assert!(!should_inject(
+            true,
+            EngineKind::SandboxExec,
+            true,
+            true,
+            &["CodeGraph"]
+        ));
+
+        // The other three shared conditions, same answer on both sides.
+        for (enabled, engine, can_mcp) in [
+            (false, EngineKind::SandboxExec, true),
+            (true, EngineKind::Docker, true),
+            (true, EngineKind::SandboxExec, false),
+        ] {
+            assert!(!wants_codegraph(enabled, engine, can_mcp, &[]));
+            assert!(!should_inject(enabled, engine, true, can_mcp, &[]));
+        }
+
+        // All four satisfied: both gates open (injection additionally needs the
+        // binary, which provisioning installs itself).
+        assert!(wants_codegraph(true, EngineKind::SandboxExec, true, &[]));
+    }
+
+    #[test]
+    fn provisioning_does_not_require_an_installed_binary() {
+        // The deliberate asymmetry: provisioning is the install path, so gating
+        // it on `is_installed` would stop the first run from ever bootstrapping.
+        assert!(wants_codegraph(true, EngineKind::SandboxExec, true, &[]));
+        assert!(!should_inject(
+            true,
+            EngineKind::SandboxExec,
+            false,
+            true,
+            &[]
         ));
     }
 

--- a/src-tauri/src/codegraph/mod.rs
+++ b/src-tauri/src/codegraph/mod.rs
@@ -264,6 +264,27 @@ mod tests {
     }
 
     #[test]
+    fn indexing_and_injection_share_one_provider_condition() {
+        // `provision_codegraph_index` gates on the same `mcp_delivery` resolver
+        // as `should_inject`. If they ever diverge we would either index for an
+        // agent that can't query it (wasted clone + parse per spawn) or inject a
+        // server with no index behind it. Pinning the shared resolver here keeps
+        // the two honest without the supervisor needing a test harness.
+        for provider in ["claude", "codex", "opencode"] {
+            assert!(
+                crate::agent::mcp_delivery(provider).is_some(),
+                "{provider} lost MCP delivery; indexing would silently stop too"
+            );
+        }
+        for provider in ["cursor", "pi", "antigravity"] {
+            assert!(
+                crate::agent::mcp_delivery(provider).is_none(),
+                "{provider} gained MCP delivery; it must be indexed again too"
+            );
+        }
+    }
+
+    #[test]
     fn inject_reports_nothing_for_a_provider_without_mcp() {
         // End to end through the globals: whatever the toggle and the binary
         // say, a provider with no MCP surface gets neither the server nor the

--- a/src-tauri/src/supervisor/disposition.rs
+++ b/src-tauri/src/supervisor/disposition.rs
@@ -196,6 +196,7 @@ impl Supervisor {
                 Some(tip_sha.to_string()),
                 stamped_engine(&record),
                 &record.provider,
+                &record.mcp_servers,
             )
             .await;
 

--- a/src-tauri/src/supervisor/disposition.rs
+++ b/src-tauri/src/supervisor/disposition.rs
@@ -195,6 +195,7 @@ impl Supervisor {
                 checkout.clone(),
                 Some(tip_sha.to_string()),
                 stamped_engine(&record),
+                &record.provider,
             )
             .await;
 

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -83,20 +83,23 @@ pub(super) async fn provision_codegraph_index(
     base_sha: Option<String>,
     engine: EngineKind,
     provider: &str,
+    session_servers: &[crate::agent_profile::McpServerSnapshot],
 ) {
     use crate::codegraph;
 
-    // Mirror `codegraph::should_inject`'s provider condition: an agent whose CLI
-    // has no MCP delivery builder never receives the codegraph server, so it can
-    // never query the index we would build for it. Cloning the mirror, indexing
-    // it, and copying the db into that checkout is pure waste — minutes of
-    // background git and parse work per spawn for a tool the agent doesn't have.
-    // Resolved through the same `agent::mcp_delivery` the injection gate uses, so
-    // wiring a provider's MCP delivery automatically re-enables its indexing.
-    if !codegraph::enabled()
-        || engine == EngineKind::Docker
-        || crate::agent::mcp_delivery(provider).is_none()
-    {
+    // Don't build an index this session will never be able to query. Shares
+    // `codegraph::session_wants_codegraph` with the injection gate rather than
+    // re-stating its conditions, so the two can't drift: a provider with no MCP
+    // delivery, a Docker engine, indexing switched off, or a session that
+    // already defines its own `"codegraph"` server all mean the built-in server
+    // is never injected — and cloning the mirror, indexing it, and copying the
+    // db in would be minutes of background git and parse work per spawn for a
+    // tool the agent doesn't have.
+    //
+    // The one condition deliberately *not* shared is `binary_installed`: this is
+    // the path that installs it (see `ensure_installed` below), so requiring it
+    // up front would mean the first run never bootstraps.
+    if !codegraph::session_wants_codegraph(engine, provider, session_servers) {
         return;
     }
     let mirror = match codegraph::mirror_dir(&project_id, &source_repo) {
@@ -411,6 +414,7 @@ impl Supervisor {
         let id_for_task = agent_id.clone();
         let project_id_for_task = record.project_id.clone();
         let provider_for_task = record.provider.clone();
+        let mcp_servers_for_task = record.mcp_servers.clone();
         tauri::async_runtime::spawn(async move {
             if let Err(e) = tokio::fs::create_dir_all(&parent_dir).await {
                 fail_spawn(&sup, &app_for_task, &id_for_task, e.to_string());
@@ -486,6 +490,7 @@ impl Supervisor {
                 base_sha.clone(),
                 engine_kind,
                 &provider_for_task,
+                &mcp_servers_for_task,
             )
             .await;
 
@@ -637,6 +642,7 @@ impl Supervisor {
             base_sha.clone(),
             stamped_engine(&record),
             &record.provider,
+            &record.mcp_servers,
         )
         .await;
 

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -82,10 +82,21 @@ pub(super) async fn provision_codegraph_index(
     checkout: PathBuf,
     base_sha: Option<String>,
     engine: EngineKind,
+    provider: &str,
 ) {
     use crate::codegraph;
 
-    if !codegraph::enabled() || engine == EngineKind::Docker {
+    // Mirror `codegraph::should_inject`'s provider condition: an agent whose CLI
+    // has no MCP delivery builder never receives the codegraph server, so it can
+    // never query the index we would build for it. Cloning the mirror, indexing
+    // it, and copying the db into that checkout is pure waste — minutes of
+    // background git and parse work per spawn for a tool the agent doesn't have.
+    // Resolved through the same `agent::mcp_delivery` the injection gate uses, so
+    // wiring a provider's MCP delivery automatically re-enables its indexing.
+    if !codegraph::enabled()
+        || engine == EngineKind::Docker
+        || crate::agent::mcp_delivery(provider).is_none()
+    {
         return;
     }
     let mirror = match codegraph::mirror_dir(&project_id, &source_repo) {
@@ -399,6 +410,7 @@ impl Supervisor {
         let app_for_task = app.clone();
         let id_for_task = agent_id.clone();
         let project_id_for_task = record.project_id.clone();
+        let provider_for_task = record.provider.clone();
         tauri::async_runtime::spawn(async move {
             if let Err(e) = tokio::fs::create_dir_all(&parent_dir).await {
                 fail_spawn(&sup, &app_for_task, &id_for_task, e.to_string());
@@ -473,6 +485,7 @@ impl Supervisor {
                 primary_checkout.clone(),
                 base_sha.clone(),
                 engine_kind,
+                &provider_for_task,
             )
             .await;
 
@@ -623,6 +636,7 @@ impl Supervisor {
             checkout.clone(),
             base_sha.clone(),
             stamped_engine(&record),
+            &record.provider,
         )
         .await;
 

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { Icon } from "@/components/Icon";
 import { Button } from "@/components/ui/Button";
 import { Select } from "@/components/ui/Select";
-import { ACCENTS } from "@/data/providers";
+import { ACCENTS, mcpCapableLabels } from "@/data/providers";
 import type { SandboxEngine, ThemeMode } from "@/storage/preferences";
 import { useAppStore } from "@/store";
 import { ContainerAuth } from "./ContainerAuth";
@@ -164,7 +164,7 @@ export function GeneralPane() {
       <SetGroup label="Code indexing">
         <SetRow
           title="Code indexing"
-          sub="Let agents query symbols and call graphs instead of searching files. Stored in Fletch's data directory."
+          sub={`Let agents query symbols and call graphs instead of searching files. Stored in Fletch's data directory. Delivered over MCP, so it applies to ${mcpCapableLabels().join(", ")} — other agents are unaffected and are not indexed.`}
         >
           <SetToggle
             on={codeIndexingEnabled}

--- a/src/data/providers.ts
+++ b/src/data/providers.ts
@@ -68,6 +68,15 @@ export const MCP_SUPPORT: Record<string, McpSupport> = {
   opencode: "all",
 };
 
+/** Providers that can actually receive an MCP server, as human labels — the
+ *  same set the backend derives from `agent::mcp_delivery`. Code indexing is
+ *  delivered to agents over MCP, so this doubles as "which agents benefit from
+ *  the code-indexing setting". Derived rather than hardcoded so wiring a new
+ *  provider updates the settings copy for free. */
+export function mcpCapableLabels(): string[] {
+  return PROVIDERS.filter((p) => (MCP_SUPPORT[p.id] ?? "none") !== "none").map((p) => p.label);
+}
+
 /** Whether a provider with `support` can actually deliver an MCP server of
  *  `transport` at spawn. The single rule behind the agent editor's disabled
  *  rows, its save-path filter, and the spawn snapshot in `store/drafts.ts`,


### PR DESCRIPTION
## Why

`provision_codegraph_index` gated only on `codegraph::enabled()` and the engine.
So every spawn cloned the mirror, ran `codegraph init`/`sync`, and copied
`codegraph.db` into the checkout — including for agents whose CLI never receives
the codegraph MCP server and therefore has no way to read it.

That's pi and antigravity, and since #517 pulled cursor's delivery, cursor too:
**three of six providers** doing minutes of background git and parse work per
spawn for a tool the agent doesn't have.

## The fix

Gate on `agent::mcp_delivery(provider).is_some()` — the same resolver
`codegraph::should_inject` already uses. The two conditions now can't drift:
wiring a provider's MCP delivery re-enables its indexing automatically, and
dropping one disables it. A test pins the resolver across all six providers so a
future change has to update both sides on purpose rather than by accident.

`record.provider` was already in scope at all three call sites (spawn, add-repo,
disposition-restore), so this only threads an existing value.

## Also: a factual correction

I wrote in #517 that antigravity has "no MCP surface at all (agy only plugins)".
**That's wrong.** `agy` reads `~/.gemini/config/mcp_config.json` and
`plugins/<name>/mcp_config.json`, and its binary carries `McpServerSpec` types
and a `ToggleMcpServer` RPC.

It's unwired because every path it accepts is user-global with no project or env
override — it can't express a per-session snapshot and would leak into the
user's own agy. That's the same reason cursor is unwired, not a missing surface.
Left as written, the comment would have told the next person never to look.

## Testing

- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 1022 passed, 0 failed
- Frontend untouched by this diff.