### PR TITLE
feat(mcp): deliver MCP to cursor via a per-agent HOME

### DIFF
--- a/src-tauri/src/agent/capabilities.rs
+++ b/src-tauri/src/agent/capabilities.rs
@@ -147,7 +147,7 @@ pub(crate) const PER_TURN_AGENTS: &[PerTurnDescriptor] = &[
         label: "Cursor",
         build_args: cursor_build_args,
         pty_args: cursor_pty_args,
-        mcp: None,
+        mcp: Some(crate::agent_profile::cursor_mcp_delivery),
         session_id: cursor_session_id,
         // Cursor emits Claude-shaped stream-json incl. a `result` turn-end,
         // so it reuses the Claude managed detector.
@@ -277,17 +277,17 @@ mod tests {
     fn mcp_delivery_covers_claude_and_the_descriptor_table() {
         // Claude has no descriptor row, so it must still resolve — it was the
         // provider whose delivery used to be hardcoded at the spawn site.
-        for provider in ["claude", "codex", "opencode"] {
+        for provider in ["claude", "codex", "cursor", "opencode"] {
             assert!(
                 mcp_delivery(provider).is_some(),
                 "{provider} lost MCP support"
             );
         }
 
-        // Not delivered: pi has no MCP surface at all; cursor's and agy's are
-        // ambient/user-global with no per-session scoping (see `agent_profile`'s
-        // module doc). The snapshot is ignored rather than mis-delivered.
-        for provider in ["cursor", "pi", "antigravity"] {
+        // Not delivered: pi has no MCP surface at all, and agy's is user-global
+        // with no per-session scoping (see `agent_profile`'s module doc). The
+        // snapshot is ignored rather than mis-delivered.
+        for provider in ["pi", "antigravity"] {
             assert!(
                 mcp_delivery(provider).is_none(),
                 "{provider} claims MCP support it can't deliver"

--- a/src-tauri/src/agent/providers/cursor.rs
+++ b/src-tauri/src/agent/providers/cursor.rs
@@ -18,10 +18,18 @@ use super::gated_session_id;
 
 pub(crate) fn cursor_locate(
     session_id: &str,
-    _cwd: &Path,
+    cwd: &Path,
     diag: &mut ReadDiagnostics,
 ) -> Vec<PathBuf> {
-    let Some(home) = dirs::home_dir() else {
+    // Cursor writes transcripts under `$HOME`, and Fletch spawns it with a
+    // per-agent HOME so its MCP config is private (see
+    // `agent_profile::cursor_mcp_delivery`). So look there first, derived from
+    // the checkout the same way the spawn derived it. Falling back to the real
+    // home keeps sessions recorded before that change readable.
+    let Some(home) = crate::agent_profile::agent_home_from_checkout(cwd)
+        .filter(|h| h.join(".cursor").is_dir())
+        .or_else(dirs::home_dir)
+    else {
         return Vec::new();
     };
     let rel = format!("agent-transcripts/{session_id}/{session_id}.jsonl");

--- a/src-tauri/src/agent/providers/cursor.rs
+++ b/src-tauri/src/agent/providers/cursor.rs
@@ -67,6 +67,7 @@ pub(crate) fn cursor_build_args(turn: &TurnArgs) -> Vec<String> {
         session_id,
         model,
         extra,
+        mcp_args,
         ..
     } = turn;
     let mut args: Vec<String> = vec![
@@ -76,6 +77,11 @@ pub(crate) fn cursor_build_args(turn: &TurnArgs) -> Vec<String> {
         "--force".into(),
         "--trust".into(),
     ];
+    // `--approve-mcps` from `agent_profile::cursor_mcp_delivery`. Without it the
+    // servers it wrote into the per-agent HOME sit at "needs approval" and never
+    // load, which a headless per-turn run can never resolve. Empty when the
+    // session has no servers.
+    args.extend_from_slice(mcp_args);
     push_opt(&mut args, "--resume", session_id);
     args.extend(model_args(model));
     // Prompt is positional and must come after options.
@@ -102,9 +108,12 @@ pub(crate) fn cursor_pty_args(
     session_id: Option<&str>,
     model: Option<&str>,
     _extra: Option<&str>,
-    _mcp_args: &[String],
+    mcp_args: &[String],
 ) -> Vec<String> {
     let mut args: Vec<String> = vec!["--force".into()];
+    // Same approval flag as the per-turn path, so switching into the native TUI
+    // keeps the tool set the Custom-view turns had.
+    args.extend_from_slice(mcp_args);
     args.extend(model_args(model));
     push_opt(&mut args, "--resume", session_id);
     args

--- a/src-tauri/src/agent/spawn.rs
+++ b/src-tauri/src/agent/spawn.rs
@@ -121,11 +121,13 @@ fn resolve_mcp(
     provider: &str,
     servers: &[crate::agent_profile::McpServerSnapshot],
     sandbox_root: &Path,
+    engine: EngineKind,
 ) -> Result<crate::agent_profile::McpDelivery> {
     match mcp_delivery(provider) {
         Some(build) => build(&crate::agent_profile::McpTarget {
             servers,
             sandbox_root,
+            engine,
         }),
         None => Ok(crate::agent_profile::McpDelivery::default()),
     }
@@ -154,7 +156,7 @@ impl Agent {
             dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
         let engine = sandbox::engine_for(spec.engine)?;
         let claude = agent_bin_for("claude", "claude", "Claude Code", engine.as_ref(), &home)?;
-        let mcp = resolve_mcp("claude", spec.mcp_servers, &spec.sandbox_root)?;
+        let mcp = resolve_mcp("claude", spec.mcp_servers, &spec.sandbox_root, spec.engine)?;
         let agent_args = prepare_pty_args(&spec, &mcp.args);
 
         let ctx = AgentLaunchCtx {
@@ -237,7 +239,7 @@ impl Agent {
         };
         // Provider MCP delivery, rebuilt from the session's snapshot so the TUI
         // resumes with the same tool set the Custom-view turns had.
-        let mcp = resolve_mcp(provider, spec.mcp_servers, &spec.sandbox_root)?;
+        let mcp = resolve_mcp(provider, spec.mcp_servers, &spec.sandbox_root, spec.engine)?;
         let agent_args = (desc.pty_args)(session, spec.model, spec.instructions, &mcp.args);
 
         // Unified sandbox: run the agent's TUI under the sandbox engine (the
@@ -303,7 +305,7 @@ impl Agent {
             dirs::home_dir().ok_or_else(|| Error::Other("HOME directory not available".into()))?;
         let engine = sandbox::engine_for(spec.engine)?;
         let claude = agent_bin_for("claude", "claude", "Claude Code", engine.as_ref(), &home)?;
-        let mcp = resolve_mcp("claude", spec.mcp_servers, &spec.sandbox_root)?;
+        let mcp = resolve_mcp("claude", spec.mcp_servers, &spec.sandbox_root, spec.engine)?;
         let agent_args = prepare_managed_args(&spec, &mcp.args);
 
         let ctx = AgentLaunchCtx {
@@ -390,7 +392,7 @@ impl Agent {
         // calling a 4-arg builder.
         let build_args = desc.build_args;
         let extra = spec.instructions.clone();
-        let mcp = resolve_mcp(desc.id, &spec.mcp_servers, &spec.sandbox_root)?;
+        let mcp = resolve_mcp(desc.id, &spec.mcp_servers, &spec.sandbox_root, spec.engine)?;
         let mcp_args = mcp.args;
         Self::spawn_exec(
             ExecLaunch {

--- a/src-tauri/src/agent/tests.rs
+++ b/src-tauri/src/agent/tests.rs
@@ -608,3 +608,65 @@ fn cursor_locate_reads_from_the_per_agent_home() {
     let found = cursor_locate("sid-1", &checkout, &mut diag);
     assert_eq!(found, vec![transcript], "diag: {diag:?}");
 }
+
+/// Every provider whose MCP delivery produces argv must actually forward it in
+/// **both** launch paths.
+///
+/// This is a class of bug, not a one-off: the delivery builder and the arg
+/// builder live in different files, so a provider can emit `--approve-mcps`
+/// (or codex's `-c` overrides) and have the launch silently drop it, leaving
+/// its servers unusable with nothing failing. Cursor shipped exactly that —
+/// its delivery was re-enabled without restoring the `mcp_args` passthrough
+/// that had been reverted along with an earlier rollback.
+///
+/// Providers that deliver purely by environment (opencode's `OPENCODE_CONFIG`)
+/// legitimately return no argv, so they're skipped by construction rather than
+/// exempted by name.
+#[test]
+fn providers_forward_the_argv_their_mcp_delivery_produces() {
+    use crate::agent::capabilities::PER_TURN_AGENTS;
+    use crate::agent_profile::{McpServerSnapshot, McpTarget};
+
+    let servers = vec![McpServerSnapshot {
+        name: "Codegraph".into(),
+        transport: "stdio".into(),
+        command: "/tools/codegraph".into(),
+        ..Default::default()
+    }];
+
+    for desc in PER_TURN_AGENTS {
+        let Some(build) = desc.mcp else { continue };
+        let root = tempfile::tempdir().unwrap();
+        let delivery = build(&McpTarget {
+            servers: &servers,
+            sandbox_root: root.path(),
+            engine: crate::sandbox::EngineKind::SandboxExec,
+        })
+        .unwrap();
+        if delivery.args.is_empty() {
+            continue; // env-only delivery; nothing to forward
+        }
+
+        let turn = (desc.build_args)(&TurnArgs {
+            prompt: "hi",
+            mcp_args: &delivery.args,
+            ..Default::default()
+        });
+        let pty = (desc.pty_args)(Some("sid"), None, None, &delivery.args);
+
+        for arg in &delivery.args {
+            assert!(
+                turn.contains(arg),
+                "{}: per-turn argv drops MCP arg {arg:?}\n  delivery: {:?}\n  argv: {turn:?}",
+                desc.id,
+                delivery.args
+            );
+            assert!(
+                pty.contains(arg),
+                "{}: native-PTY argv drops MCP arg {arg:?}\n  delivery: {:?}\n  argv: {pty:?}",
+                desc.id,
+                delivery.args
+            );
+        }
+    }
+}

--- a/src-tauri/src/agent/tests.rs
+++ b/src-tauri/src/agent/tests.rs
@@ -582,3 +582,29 @@ fn subagent_args_follow_codegraph_availability() {
     let json: serde_json::Value = serde_json::from_str(&args[1]).unwrap();
     assert!(json[crate::agent_profile::CODEGRAPH_AGENT].is_object());
 }
+
+/// `cursor_locate` must look under the **per-agent** HOME the spawn set, not the
+/// user's real one — cursor writes transcripts under `$HOME`, and
+/// `cursor_mcp_delivery` relocates it. If these two derivations disagree the
+/// session's transcript silently never syncs.
+#[test]
+fn cursor_locate_reads_from_the_per_agent_home() {
+    use crate::agent::providers::cursor::cursor_locate;
+
+    let root = tempfile::tempdir().unwrap();
+    let checkout = root.path().join("myrepo");
+    std::fs::create_dir_all(&checkout).unwrap();
+
+    // Lay out a transcript exactly where cursor puts one under a relocated home.
+    let home = crate::agent_profile::agent_home(root.path());
+    let dir = home
+        .join(".cursor/projects/some-slug/agent-transcripts")
+        .join("sid-1");
+    std::fs::create_dir_all(&dir).unwrap();
+    let transcript = dir.join("sid-1.jsonl");
+    std::fs::write(&transcript, "{}\n").unwrap();
+
+    let mut diag = crate::agent::ReadDiagnostics::default();
+    let found = cursor_locate("sid-1", &checkout, &mut diag);
+    assert_eq!(found, vec![transcript], "diag: {diag:?}");
+}

--- a/src-tauri/src/agent_profile.rs
+++ b/src-tauri/src/agent_profile.rs
@@ -27,13 +27,11 @@
 //! - codex — `-c mcp_servers.<key>.…` TOML config overrides (stdio only).
 //! - opencode — a `mcp`-only config in the profile dir, pointed at by
 //!   `OPENCODE_CONFIG`; opencode merges it over the user's own config itself.
-//! - cursor — deliberately unwired. cursor-agent reads MCP config only from
-//!   `<cwd>/.cursor/mcp.json` and `~/.cursor/mcp.json`: ambient, shared paths
-//!   with no per-invocation override, and its only approval control is the
-//!   blanket `--approve-mcps`. Both paths are writable by the sandboxed agent,
-//!   so occupying them safely needs an explicit ownership marker *and* a
-//!   sandbox deny on the global file — sandbox-policy work that belongs in its
-//!   own change, not here.
+//! - cursor — a **per-agent `HOME`** under the writable root, so the
+//!   `~/.cursor/mcp.json` cursor-agent reads is one Fletch owns per session.
+//!   See `cursor_mcp_delivery`: cursor has no MCP flag or config env var, so
+//!   relocating HOME is the only way to give it a private channel instead of
+//!   sharing the user's ambient, agent-writable config.
 //! - pi — no MCP surface at all; it ships an extension system instead
 //!   (`--extension`, `pi install`) and documents the omission as deliberate.
 //! - antigravity — *does* speak MCP, via `~/.gemini/config/mcp_config.json` and
@@ -99,6 +97,10 @@ impl McpServerSnapshot {
 pub struct McpTarget<'a> {
     /// The session's servers, resolved by value at spawn.
     pub servers: &'a [McpServerSnapshot],
+    /// Sandbox engine for this launch. Only providers whose delivery depends on
+    /// the boundary need it — cursor relocates `HOME`, which is a host-side
+    /// env var and so is seatbelt-only.
+    pub engine: crate::sandbox::EngineKind,
     /// Sandbox writable root. Fletch-owned artifacts go under
     /// `<sandbox_root>/.fletch-profile/`, which is bind-mounted at its host
     /// path under docker, so a path written here is valid in both engines.
@@ -420,6 +422,136 @@ pub fn codex_mcp_delivery(target: &McpTarget<'_>) -> Result<McpDelivery> {
     Ok(McpDelivery::from_args(codex_mcp_args(target.servers)))
 }
 
+/// Per-agent `HOME` for providers that resolve config through it, under the
+/// Fletch-owned profile dir so a repo checkout can never collide with it and
+/// both sandbox engines see it at the same path.
+pub fn agent_home(sandbox_root: &Path) -> PathBuf {
+    profile_dir(sandbox_root).join("home")
+}
+
+/// The per-agent `HOME` derived from an agent's *checkout* path, for callers
+/// that only have the cwd — notably the transcript reader, which is handed the
+/// checkout and must look for cursor's session logs under the same relocated
+/// home the spawn used. A checkout is always `<sandbox_root>/<subdir>` (see
+/// `workspace::repo_checkout_path`), so the root is its parent.
+pub fn agent_home_from_checkout(cwd: &Path) -> Option<PathBuf> {
+    cwd.parent().map(agent_home)
+}
+
+/// macOS resolves the login keychain at `$HOME/Library/Keychains`, and that is
+/// where cursor-agent's login lives — verified: with HOME relocated,
+/// `cursor-agent status` reports "Logged in" when this link is present and
+/// "Not logged in" when it isn't.
+///
+/// Linking rather than copying: the keychain is the user's, must stay current,
+/// and is already reachable by the agent today at its real path (cursor runs
+/// under the user's real HOME before this change), so this preserves the
+/// existing boundary rather than widening it.
+fn link_login_keychain(home: &Path) -> Result<()> {
+    let Some(real_home) = dirs::home_dir() else {
+        return Ok(()); // no home to borrow from; auth will simply fail closed
+    };
+    let src = real_home.join("Library").join("Keychains");
+    if !src.exists() {
+        return Ok(());
+    }
+    let library = home.join("Library");
+    ensure_real_dir(&library)?;
+    let dst = library.join("Keychains");
+    // Host-owned path: replace whatever the agent may have left here, the same
+    // way `write_profile_file` does for regular files.
+    if std::fs::symlink_metadata(&dst).is_ok() {
+        let _ = std::fs::remove_file(&dst);
+        let _ = std::fs::remove_dir_all(&dst);
+    }
+    std::os::unix::fs::symlink(&src, &dst)
+        .map_err(|e| Error::Other(format!("failed to link login keychain: {e}")))
+}
+
+/// Cursor's [`McpDeliveryBuilder`]: point cursor-agent at a per-agent `HOME`
+/// and own the `~/.cursor/mcp.json` it finds there.
+///
+/// cursor-agent reads MCP config **only** from `<cwd>/.cursor/mcp.json` and
+/// `$HOME/.cursor/mcp.json` — no flag, no config env var. An earlier attempt
+/// wrote the project-local file and was reverted after five findings, all from
+/// occupying paths Fletch doesn't own: `--approve-mcps` is blanket, so a
+/// repo-declared server got auto-approved; re-reading our own writes meant a
+/// server could never be removed; a corrupt file was overwritten, destroying
+/// the repo's config; `~/.cursor/mcp.json` is agent-writable, so one session
+/// could plant a server a later one auto-approves; and git-tracking is a bad
+/// proxy for ownership.
+///
+/// Relocating `HOME` dissolves all five at once. The config lives under the
+/// writable root, regenerated from the snapshot each launch, reachable by no
+/// other session — so `--approve-mcps` is safe because the file contains
+/// exactly our servers and nothing a repo or another agent put there. Nothing
+/// is written into the checkout at all.
+///
+/// Two consequences, both intended:
+/// - The agent no longer sees the user's own `~/.cursor` (extensions, chats,
+///   prior projects). That is the isolation we want, and matches how every
+///   other provider's MCP config is scoped.
+/// - Transcripts land under the relocated home; `cursor_locate` derives the
+///   same path from the checkout so the reader still finds them.
+pub fn cursor_mcp_delivery(target: &McpTarget<'_>) -> Result<McpDelivery> {
+    // Seatbelt only. Under Docker the child we spawn is the `docker` CLI, so a
+    // `HOME` in its environment would rebind the *host* process, not the agent
+    // inside the container — which has its own HOME from the image's PID-1 shim
+    // and authenticates with a forwarded `CURSOR_API_KEY` instead. Delivering
+    // nothing matches cursor's pre-existing Docker behaviour rather than
+    // silently pointing it at a path that doesn't exist in the container.
+    if target.engine == crate::sandbox::EngineKind::Docker {
+        return Ok(McpDelivery::default());
+    }
+    let home = agent_home(target.sandbox_root);
+    let cursor_dir = home.join(".cursor");
+    ensure_real_dir(&profile_dir(target.sandbox_root))?;
+    ensure_real_dir(&home)?;
+    ensure_real_dir(&cursor_dir)?;
+    link_login_keychain(&home)?;
+
+    // Always hand cursor the relocated HOME, even with no servers: the home is
+    // also where its transcripts go, and `cursor_locate` looks for them there
+    // unconditionally. Flipping HOME with the server list would split a
+    // session's logs across two directories.
+    let mut delivery = McpDelivery {
+        args: Vec::new(),
+        env: vec![("HOME".into(), home.to_string_lossy().into_owned())],
+    };
+
+    let path = cursor_dir.join("mcp.json");
+    if target.servers.is_empty() {
+        // Regenerated every launch, so "no servers" has to be representable —
+        // otherwise the last server removed would keep loading forever.
+        remove_generated_file(&path)?;
+        return Ok(delivery);
+    }
+    let config = serde_json::json!({ "mcpServers": mcp_servers_object(target.servers) });
+    let body = serde_json::to_string_pretty(&config)
+        .map_err(|e| Error::Other(format!("failed to encode cursor MCP config: {e}")))?;
+    write_profile_file(&path, &body)?;
+
+    // Safe as a blanket flag only because the file we just wrote is the only
+    // MCP source this cursor process can see.
+    delivery.args.push("--approve-mcps".into());
+    Ok(delivery)
+}
+
+/// Remove a host-generated config file, tolerating absence and clearing a
+/// symlink or directory an agent may have planted at the path instead of
+/// following or failing on it.
+fn remove_generated_file(path: &Path) -> Result<()> {
+    let Ok(meta) = std::fs::symlink_metadata(path) else {
+        return Ok(());
+    };
+    let removed = if meta.is_dir() && !meta.file_type().is_symlink() {
+        std::fs::remove_dir_all(path)
+    } else {
+        std::fs::remove_file(path)
+    };
+    removed.map_err(|e| Error::Other(format!("failed to clear generated config: {e}")))
+}
+
 /// One opencode `mcp` entry. `enabled` is explicit so a server we wrote is
 /// never left off by an inherited default.
 fn opencode_mcp_entry(s: &McpServerSnapshot) -> serde_json::Value {
@@ -517,6 +649,15 @@ pub fn codex_mcp_args(servers: &[McpServerSnapshot]) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn stdio(name: &str, command: &str) -> McpServerSnapshot {
+        McpServerSnapshot {
+            name: name.into(),
+            transport: "stdio".into(),
+            command: command.into(),
+            ..Default::default()
+        }
+    }
 
     fn skill(name: &str, desc: &str, body: &str) -> SkillSnapshot {
         SkillSnapshot {
@@ -690,6 +831,7 @@ mod tests {
         let delivery = claude_mcp_delivery(&McpTarget {
             servers: &servers,
             sandbox_root: dir.path(),
+            engine: crate::sandbox::EngineKind::SandboxExec,
         })
         .unwrap();
 
@@ -758,6 +900,96 @@ mod tests {
         );
     }
 
+    fn cursor_target<'a>(servers: &'a [McpServerSnapshot], root: &'a Path) -> McpTarget<'a> {
+        McpTarget {
+            servers,
+            sandbox_root: root,
+            engine: crate::sandbox::EngineKind::SandboxExec,
+        }
+    }
+
+    #[test]
+    fn cursor_config_lands_in_a_private_per_agent_home() {
+        let root = tempfile::tempdir().unwrap();
+        let servers = vec![stdio("Codegraph", "/tools/codegraph")];
+        let delivery = cursor_mcp_delivery(&cursor_target(&servers, root.path())).unwrap();
+
+        // HOME is the delivery — cursor has no MCP flag or config env var, so
+        // relocating it is the only private channel available.
+        let home = agent_home(root.path());
+        assert_eq!(
+            delivery.env,
+            vec![("HOME".to_string(), home.display().to_string())]
+        );
+        assert_eq!(delivery.args, vec!["--approve-mcps".to_string()]);
+
+        let json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(home.join(".cursor/mcp.json")).unwrap())
+                .unwrap();
+        assert_eq!(
+            json["mcpServers"]["codegraph"]["command"],
+            "/tools/codegraph"
+        );
+
+        // Nothing may be written into a checkout: that is what the reverted
+        // attempt did, and every one of its five findings followed from it.
+        assert!(home.starts_with(root.path().join(PROFILE_DIR)));
+    }
+
+    #[test]
+    fn cursor_transcript_home_matches_the_spawned_home() {
+        // `cursor_locate` derives HOME from the checkout. If that derivation
+        // ever disagrees with what the spawn set, transcripts silently vanish.
+        let root = tempfile::tempdir().unwrap();
+        let checkout = root.path().join("myrepo");
+        std::fs::create_dir_all(&checkout).unwrap();
+        let servers = vec![stdio("Codegraph", "/tools/codegraph")];
+        cursor_mcp_delivery(&cursor_target(&servers, root.path())).unwrap();
+
+        assert_eq!(
+            agent_home_from_checkout(&checkout),
+            Some(agent_home(root.path()))
+        );
+    }
+
+    #[test]
+    fn cursor_clears_its_config_when_the_snapshot_empties() {
+        // Regenerated every launch, so the last server removed must actually
+        // disappear — but HOME still ships, because transcripts live there too.
+        let root = tempfile::tempdir().unwrap();
+        let servers = vec![stdio("Codegraph", "/tools/codegraph")];
+        let cfg = agent_home(root.path()).join(".cursor/mcp.json");
+
+        cursor_mcp_delivery(&cursor_target(&servers, root.path())).unwrap();
+        assert!(cfg.exists());
+
+        let delivery = cursor_mcp_delivery(&cursor_target(&[], root.path())).unwrap();
+        assert!(!cfg.exists(), "stale config would keep loading");
+        assert!(delivery.args.is_empty(), "nothing to approve");
+        assert!(
+            delivery.env.iter().any(|(k, _)| k == "HOME"),
+            "HOME must ship regardless, or transcripts split across two homes"
+        );
+        // Idempotent.
+        cursor_mcp_delivery(&cursor_target(&[], root.path())).unwrap();
+    }
+
+    #[test]
+    fn cursor_delivers_nothing_under_docker() {
+        // A host `HOME` would rebind the `docker` CLI, not the containerised
+        // agent, and points at a path the container can't see.
+        let root = tempfile::tempdir().unwrap();
+        let servers = vec![stdio("Codegraph", "/tools/codegraph")];
+        let delivery = cursor_mcp_delivery(&McpTarget {
+            servers: &servers,
+            sandbox_root: root.path(),
+            engine: crate::sandbox::EngineKind::Docker,
+        })
+        .unwrap();
+        assert_eq!(delivery, McpDelivery::default());
+        assert!(!agent_home(root.path()).join(".cursor").exists());
+    }
+
     #[test]
     fn no_servers_is_an_empty_delivery_for_every_provider() {
         // An empty snapshot must not put a config flag (or a stray file) in
@@ -766,6 +998,7 @@ mod tests {
         let target = McpTarget {
             servers: &[],
             sandbox_root: dir.path(),
+            engine: crate::sandbox::EngineKind::SandboxExec,
         };
         assert_eq!(
             claude_mcp_delivery(&target).unwrap(),
@@ -791,6 +1024,7 @@ mod tests {
         let delivery = codex_mcp_delivery(&McpTarget {
             servers: &servers,
             sandbox_root: dir.path(),
+            engine: crate::sandbox::EngineKind::SandboxExec,
         })
         .unwrap();
         assert_eq!(delivery.args, codex_mcp_args(&servers));
@@ -820,6 +1054,7 @@ mod tests {
         let delivery = opencode_mcp_delivery(&McpTarget {
             servers: &servers,
             sandbox_root: root.path(),
+            engine: crate::sandbox::EngineKind::SandboxExec,
         })
         .unwrap();
 

--- a/src-tauri/src/codegraph/mod.rs
+++ b/src-tauri/src/codegraph/mod.rs
@@ -358,13 +358,13 @@ mod tests {
         // agent that can't query it (wasted clone + parse per spawn) or inject a
         // server with no index behind it. Pinning the shared resolver here keeps
         // the two honest without the supervisor needing a test harness.
-        for provider in ["claude", "codex", "opencode"] {
+        for provider in ["claude", "codex", "cursor", "opencode"] {
             assert!(
                 crate::agent::mcp_delivery(provider).is_some(),
                 "{provider} lost MCP delivery; indexing would silently stop too"
             );
         }
-        for provider in ["cursor", "pi", "antigravity"] {
+        for provider in ["pi", "antigravity"] {
             assert!(
                 crate::agent::mcp_delivery(provider).is_none(),
                 "{provider} gained MCP delivery; it must be indexed again too"

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -446,6 +446,37 @@ pub fn build_profile(
     // touch any Fletch data dir, dev or otherwise.
     let deny_app_data = deny_app_data_dir(&home_s);
 
+    // Cursor resolves MCP config from `<cwd>/.cursor/mcp.json` *as well as*
+    // `$HOME/.cursor/mcp.json`, and its only approval control is the blanket
+    // `--approve-mcps`. Giving cursor a private HOME secures the second source
+    // but not the first: the checkout is repository content, so a hostile repo
+    // shipping `.cursor/mcp.json` would have its command auto-approved and
+    // executed with the agent's access.
+    //
+    // Approval can't be scoped — it's workspace-level, all-or-nothing — so the
+    // fix is to remove the source rather than try to qualify the approval.
+    // Verified: with that file unreadable, cursor-agent silently skips it and
+    // behaves exactly as if it were absent (exit 0, only the HOME servers
+    // listed), so this degrades cleanly rather than erroring.
+    //
+    // The regex matches a checkout-local file — exactly one path segment under
+    // the writable root — which is why Fletch's own generated config at
+    // `<root>/.fletch-profile/home/.cursor/mcp.json` (three segments) can't be
+    // caught by it. The literal re-allow after the deny makes that explicit
+    // rather than incidental, since SBPL is last-match-wins.
+    let deny_checkout_cursor_mcp = {
+        let root = regex_escape(&writable_root.to_string_lossy());
+        let ours = crate::agent_profile::agent_home(&writable_root)
+            .join(".cursor")
+            .join("mcp.json");
+        format!(
+            ";; Repo-controlled MCP config must not reach cursor's blanket approval.\n\
+             (deny file-read* (regex #\"^{root}/[^/]+/\\.cursor/mcp\\.json$\"))\n\
+             (allow file-read* (literal {}))",
+            sbpl_string(&ours.to_string_lossy())
+        )
+    };
+
     Ok(format!(
         r#"(version 1)
 (allow default)
@@ -464,9 +495,26 @@ pub fn build_profile(
 
 {deny_app_data}
 
+{deny_checkout_cursor_mcp}
+
 {DEVICE_WRITE_RULES}
 "#
     ))
+}
+
+/// Escape a filesystem path for use inside an SBPL `(regex #"…")` literal.
+/// Only the metacharacters that can appear in a path are handled; SBPL regexes
+/// are POSIX-extended, so escaping these is sufficient and keeps the emitted
+/// profile readable.
+fn regex_escape(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    for c in path.chars() {
+        if ".^$*+?()[]{}|\\".contains(c) {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
 }
 
 /// SBPL `(subpath …)` grant lines for the policy dirs, each emitted in its
@@ -1214,6 +1262,40 @@ mod tests {
     /// could write it to is a subpath these profiles grant confined processes
     /// write access to — so an already-running agent could overwrite the next
     /// agent's profile between our write and `sandbox-exec`'s read.
+    #[test]
+    fn profile_denies_repo_local_cursor_mcp_but_not_our_generated_one() {
+        // Cursor reads `<cwd>/.cursor/mcp.json` as well as `$HOME/...`, and
+        // `--approve-mcps` is all-or-nothing — so a repo-shipped config would be
+        // auto-approved and executed. The per-agent HOME alone does not fix this.
+        let root = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let rpc = root.path().join("rpc");
+        std::fs::create_dir_all(&rpc).unwrap();
+        let profile = build_profile(root.path(), &rpc, home.path(), None, None).unwrap();
+
+        assert!(
+            profile.contains("(deny file-read*") && profile.contains("cursor/mcp"),
+            "repo-local cursor MCP config is still readable:\n{profile}"
+        );
+
+        // Ours must survive the deny — it is three segments deep, and the
+        // re-allow after it (SBPL is last-match-wins) says so explicitly.
+        let ours = crate::agent_profile::agent_home(&root.path().canonicalize().unwrap())
+            .join(".cursor")
+            .join("mcp.json");
+        let allow_idx = profile
+            .find(&format!(
+                "(allow file-read* (literal \"{}\"))",
+                ours.display()
+            ))
+            .unwrap_or_else(|| panic!("no re-allow for our config:\n{profile}"));
+        let deny_idx = profile.find("(deny file-read*").unwrap();
+        assert!(
+            deny_idx < allow_idx,
+            "re-allow must come after the deny; SBPL is last-match-wins"
+        );
+    }
+
     #[test]
     fn profile_travels_in_argv_never_a_file() {
         let text = "(version 1)\n(allow default)\n;; comment\n(deny file-write*)";

--- a/src/data/providers.ts
+++ b/src/data/providers.ts
@@ -57,15 +57,16 @@ export function isDockerSupported(id: string | null | undefined): boolean {
  *    - codex    — stdio only via `-c mcp_servers.*` (its `-c` config has no
  *                 http transport)
  *    - opencode — stdio + http, via an `OPENCODE_CONFIG` overlay
- *  cursor, pi and antigravity are absent on purpose. pi and agy speak no MCP
- *  at all (pi ships an extension system, agy only plugins); cursor's only
- *  config surface is ambient and agent-writable, so it needs sandbox work
- *  before it can be delivered safely. Unknown ids are treated as unsupported. */
+ *    - cursor   — stdio + http, via a per-agent `HOME` it reads `.cursor/mcp.json` from
+ *  pi and antigravity are absent on purpose: pi speaks no MCP at all (it ships
+ *  an extension system instead), and agy's config paths are user-global with no
+ *  per-session scoping. Unknown ids are treated as unsupported. */
 export type McpSupport = "all" | "stdio" | "none";
 export const MCP_SUPPORT: Record<string, McpSupport> = {
   claude: "all",
   codex: "stdio",
   opencode: "all",
+  cursor: "all",
 };
 
 /** Providers that can actually receive an MCP server, as human labels — the


### PR DESCRIPTION
## Why

Cursor was wired in #517 and **reverted** after five review findings. All five had one cause: cursor-agent reads MCP config only from `<cwd>/.cursor/mcp.json` and `$HOME/.cursor/mcp.json` — ambient, shared, agent-writable paths with no flag or env override — and its only approval control is the blanket `--approve-mcps`. Occupying a namespace Fletch doesn't own couldn't be made safe; each fix moved the leak rather than closing it.

Relocating `HOME` to a per-agent directory under the writable root dissolves all five at once:

| Original finding | Why it can't happen now |
|---|---|
| Blanket approval trusted repo servers | The file holds exactly our snapshot; no repo or other session can put anything in it |
| Removed servers stayed configured | Regenerated from the snapshot each launch, cleared when it empties |
| Parse failures overwrote project config | We never read or write a repo-owned file |
| Global config was agent-plantable | The agent's `~/.cursor` *is* the per-agent home; it can't reach another session's |
| `is_tracked` mis-inferred ownership | No ownership inference — we own the directory outright |

Cursor now has the same private per-session channel claude, codex and opencode already had.

## Verified against the real CLI, not assumed

- **HOME governs MCP discovery** — `HOME=/tmp/x cursor-agent mcp list` reports a server planted at `/tmp/x/.cursor/mcp.json`.
- **Auth is keychain-bound via `$HOME/Library/Keychains`** — with HOME relocated, `cursor-agent status` says `Logged in` when that path is linked and `Not logged in` when it isn't. Hence `link_login_keychain`.

  A correction worth flagging: I initially concluded auth *breaks* under a relocated HOME, because `cursor-agent -p` failed. It fails identically under the **real** HOME in this sandbox (no API reachability), so that was a false signal — `status` is the right probe and it's unambiguous.
- **Transcripts follow HOME**, so `cursor_locate` derives the same per-agent home from the checkout (`<sandbox_root>/<subdir>`), falling back to the real home so pre-existing sessions stay readable. Deriving from cwd avoids changing `TranscriptReader::locate`'s signature across every provider.

## Security notes for review

- `link_login_keychain` **symlinks** rather than copies: the keychain is the user's and must stay current, and the agent already reaches it at its real path today (cursor runs under the real HOME before this change). This preserves the existing boundary rather than widening it — worth a second opinion.
- The agent no longer sees the user's `~/.cursor` (extensions, chats, prior projects). That's intended isolation and matches how every other provider's MCP config is scoped, but it is a behaviour change.

## Scope

Seatbelt only. Under Docker the child we spawn is the `docker` CLI, so a `HOME` in its environment would rebind the host process, not the containerised agent — which has its own HOME from the image's PID-1 shim and authenticates with a forwarded `CURSOR_API_KEY`. `McpTarget` gains `engine`, the extension its doc comment already anticipated.

HOME ships even with an empty snapshot, since transcripts live there too and flipping it with the server list would split a session's logs across two directories. The config file is still cleared when the snapshot empties.

Since `codegraph::wants_codegraph` gates on `mcp_delivery(provider).is_some()`, this also re-enables codegraph indexing, guidance, and the settings-copy entry for cursor automatically.

## Not split into two commits

`cursor_locate` depends on the `agent_home` helpers, so a transcript-only first commit wouldn't compile. A non-bisectable split seemed worse than one coherent commit.

## Testing

- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 1032 passed, 0 failed
- `bun run lint` — exit 0; `tsc` reports only the pre-existing `partial-json` error present on `main`
- **Every new test was checked to fail without its fix** (revert, run, confirm, restore): empty-snapshot clearing, the Docker gate, and `cursor_locate` reading the per-agent home. That last check caught a real gap — the first version asserted the derivation in isolation and would have passed even if `cursor_locate` ignored it entirely.