### PR TITLE
fix(chat): render unregistered tool inputs readably instead of as JSON

### DIFF
--- a/src/components/Workspace/messages/presenters/default.tsx
+++ b/src/components/Workspace/messages/presenters/default.tsx
@@ -1,12 +1,11 @@
 import type { ToolPresenter } from "./types";
-import { firstLineOf, renderToolResult, stringifyInput, ToolBlock } from "./util";
+import { describeInput, renderToolResult, stringifyInput, ToolBlock } from "./util";
 
-/** Fallback presenter for tools without a dedicated implementation.
- *  Mirrors the prior generic ToolUseItem/ToolResultItem behavior:
- *  one-line JSON-summary in collapsed view, full input + result when
- *  expanded. */
+/** Fallback presenter for tools without a dedicated implementation:
+ *  a readable one-line rendering of the input when collapsed, the exact
+ *  input JSON plus the result when expanded. */
 export const defaultPresenter: ToolPresenter = {
-  summary: (call) => firstLineOf(stringifyInput(call.input), 120),
+  summary: (call) => describeInput(call.input, 120),
   expanded: (call, result) => (
     <>
       <ToolBlock label="input">{stringifyInput(call.input, 2)}</ToolBlock>

--- a/src/components/Workspace/messages/presenters/util.tsx
+++ b/src/components/Workspace/messages/presenters/util.tsx
@@ -119,12 +119,24 @@ export function describeInput(input: unknown, max = 120): string {
   if (input == null) return "";
   if (typeof input !== "object") return firstLineOf(compactValue(input), max);
   if (Array.isArray(input)) return firstLineOf(compactValue(input), max);
-  const entries = Object.entries(input as Record<string, unknown>).filter(
-    ([, v]) => v !== undefined && v !== null && v !== "",
-  );
+  const entries = compactEntries(input as Record<string, unknown>);
   if (entries.length === 0) return "";
-  if (entries.length === 1) return firstLineOf(compactValue(entries[0][1]), max);
-  return firstLineOf(entries.map(([k, v]) => `${k} ${compactValue(v)}`).join(" · "), max);
+  if (entries.length === 1) return firstLineOf(entries[0][1], max);
+  return firstLineOf(entries.map(([k, v]) => `${k} ${v}`).join(" · "), max);
+}
+
+/** Compact every field, keeping only those that render to something. Emptiness
+ *  is judged *after* compacting, so a field that contributes nothing but its
+ *  own key — `null`, `""`, `[]`, or an object whose fields are all empty —
+ *  drops out at any depth. Note `0` and `false` compact to "0"/"false" and are
+ *  kept: they're values the tool was actually called with. */
+function compactEntries(obj: Record<string, unknown>): [key: string, text: string][] {
+  const out: [string, string][] = [];
+  for (const [key, value] of Object.entries(obj)) {
+    const text = compactValue(value);
+    if (text) out.push([key, text]);
+  }
+  return out;
 }
 
 /** Flatten one value to inline text. Whitespace collapses so a multi-line
@@ -134,8 +146,8 @@ function compactValue(value: unknown): string {
   if (typeof value === "string") return value.replace(/\s+/g, " ").trim();
   if (Array.isArray(value)) return value.map(compactValue).filter(Boolean).join(", ");
   if (typeof value === "object") {
-    return Object.entries(value as Record<string, unknown>)
-      .map(([k, v]) => `${k} ${compactValue(v)}`)
+    return compactEntries(value as Record<string, unknown>)
+      .map(([key, text]) => `${key} ${text}`)
       .join(" ");
   }
   return String(value);

--- a/src/components/Workspace/messages/presenters/util.tsx
+++ b/src/components/Workspace/messages/presenters/util.tsx
@@ -110,6 +110,37 @@ export function getCommandField(input: unknown, field = "command"): string {
   return "";
 }
 
+/** One-line, punctuation-free view of an arbitrary tool input, for tools with
+ *  no dedicated presenter. Dumping `JSON.stringify` there spent the row's whole
+ *  width on braces and quotes, so instead: a lone field shows just its value
+ *  (`{query: "…"}` reads as the query), several show `key value` pairs. The
+ *  expanded view still carries the exact JSON. */
+export function describeInput(input: unknown, max = 120): string {
+  if (input == null) return "";
+  if (typeof input !== "object") return firstLineOf(compactValue(input), max);
+  if (Array.isArray(input)) return firstLineOf(compactValue(input), max);
+  const entries = Object.entries(input as Record<string, unknown>).filter(
+    ([, v]) => v !== undefined && v !== null && v !== "",
+  );
+  if (entries.length === 0) return "";
+  if (entries.length === 1) return firstLineOf(compactValue(entries[0][1]), max);
+  return firstLineOf(entries.map(([k, v]) => `${k} ${compactValue(v)}`).join(" · "), max);
+}
+
+/** Flatten one value to inline text. Whitespace collapses so a multi-line
+ *  string (a prompt, a patch) stays on the summary's single line. */
+function compactValue(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value.replace(/\s+/g, " ").trim();
+  if (Array.isArray(value)) return value.map(compactValue).filter(Boolean).join(", ");
+  if (typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>)
+      .map(([k, v]) => `${k} ${compactValue(v)}`)
+      .join(" ");
+  }
+  return String(value);
+}
+
 /** Truncate at the first newline, with an ellipsis if there's more. */
 export function firstLineOf(text: string, max = 120): string {
   const nl = text.indexOf("\n");

--- a/tests/components/Workspace/messages/presenters/index.test.ts
+++ b/tests/components/Workspace/messages/presenters/index.test.ts
@@ -86,6 +86,30 @@ describe("defaultPresenter.summary", () => {
     ).toBe("filter kind file · tags a, b");
   });
 
+  it("skips empty fields nested inside an object", () => {
+    expect(
+      defaultPresenter.summary(
+        toolCall({ query: "x", filter: { kind: null, path: "", depth: 2 } }),
+        null,
+      ),
+    ).toBe("query x · filter depth 2");
+  });
+
+  it("drops a field whose value is empty all the way down", () => {
+    // Nothing left to say about `filter`, so it should not contribute a key.
+    expect(
+      defaultPresenter.summary(toolCall({ query: "x", filter: { kind: null, path: "" } }), null),
+    ).toBe("x");
+    expect(defaultPresenter.summary(toolCall({ filter: { kind: null } }), null)).toBe("");
+    expect(defaultPresenter.summary(toolCall({ query: "x", tags: [], meta: {} }), null)).toBe("x");
+  });
+
+  it("keeps falsy values the tool was actually called with", () => {
+    expect(defaultPresenter.summary(toolCall({ recursive: false, depth: 0 }), null)).toBe(
+      "recursive false · depth 0",
+    );
+  });
+
   it("renders a bare string or array input", () => {
     expect(defaultPresenter.summary(toolCall("just a string"), null)).toBe("just a string");
     expect(defaultPresenter.summary(toolCall(["a", "b"]), null)).toBe("a, b");

--- a/tests/components/Workspace/messages/presenters/index.test.ts
+++ b/tests/components/Workspace/messages/presenters/index.test.ts
@@ -49,6 +49,54 @@ describe("getPresenter", () => {
   });
 });
 
+describe("defaultPresenter.summary", () => {
+  // Unregistered tools used to render `JSON.stringify(input)`, spending the
+  // row on braces and quotes — `ToolSearch` showed up as
+  // `{"max_results":3,"query":"select:mcp__codegraph__codegraph_explore"}`.
+  it("renders a multi-field input as key/value pairs, not JSON", () => {
+    expect(
+      defaultPresenter.summary(
+        toolCall({ max_results: 3, query: "select:mcp__codegraph__codegraph_explore" }),
+        null,
+      ),
+    ).toBe("max_results 3 · query select:mcp__codegraph__codegraph_explore");
+  });
+
+  it("shows just the value when there is only one field", () => {
+    expect(defaultPresenter.summary(toolCall({ query: "how does auth work" }), null)).toBe(
+      "how does auth work",
+    );
+  });
+
+  it("keeps a multi-line value on one line", () => {
+    expect(defaultPresenter.summary(toolCall({ prompt: "line one\nline two" }), null)).toBe(
+      "line one line two",
+    );
+  });
+
+  it("skips empty fields", () => {
+    expect(defaultPresenter.summary(toolCall({ query: "x", cursor: "", limit: null }), null)).toBe(
+      "x",
+    );
+  });
+
+  it("flattens nested values", () => {
+    expect(
+      defaultPresenter.summary(toolCall({ filter: { kind: "file" }, tags: ["a", "b"] }), null),
+    ).toBe("filter kind file · tags a, b");
+  });
+
+  it("renders a bare string or array input", () => {
+    expect(defaultPresenter.summary(toolCall("just a string"), null)).toBe("just a string");
+    expect(defaultPresenter.summary(toolCall(["a", "b"]), null)).toBe("a, b");
+  });
+
+  it("renders nothing for an empty input", () => {
+    expect(defaultPresenter.summary(toolCall({}), null)).toBe("");
+    expect(defaultPresenter.summary(toolCall(null), null)).toBe("");
+  });
+});
+
 describe("bashPresenter.summary", () => {
   // Claude's `Bash` hands over an object input; Codex/Cursor `shell` hand over
   // the command as a bare value. All three must render the command, not the


### PR DESCRIPTION
## Problem

Tools with no dedicated presenter fall through to `defaultPresenter`, whose collapsed summary was `firstLineOf(JSON.stringify(call.input))`. The row then spent its whole width on braces and quotes:

```
ToolSearch  {"max_results":3,"query":"select:mcp__codegraph__codegraph_explore"}
```

This affects every unregistered tool, including any MCP server a user attaches — not just the built-ins.

## Fix

Add `describeInput()` in `presenters/util.tsx` and use it for the collapsed summary:

```
ToolSearch  max_results 3 · query select:mcp__codegraph__codegraph_explore
```

Rules, deliberately dumb and predictable:

- one field → just its value, no key noise (`{query: "how does auth work"}` reads as the question)
- several → `key value` pairs joined by `·`
- nested objects/arrays flattened inline; empty/null fields dropped
- whitespace collapsed, so a multi-line prompt or patch stays on the summary's single line

The expanded view is untouched and still shows exact pretty-printed JSON — that's the point of deliberately opening an unknown tool's row.

## Notes on the approach

Fixing the fallback rather than registering a `ToolSearch` presenter: one-presenter-per-tool doesn't scale, and the generic path is where the problem actually lives.

Field order follows the input's own order rather than promoting an "interesting" field. A name-priority list would surface `query` ahead of `max_results` here, but would guess wrong on the next tool.

## Testing

`npm test` (541 pass, 7 new), `tsc --noEmit`, and `biome check` clean. New cases cover the multi-field ToolSearch shape, single-field collapse, multi-line values, empty-field skipping, nested flattening, bare string/array inputs, and empty input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)