### PR TITLE
docs(readme): answer where feedback goes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,15 @@ The full write-up is [`docs/isolation.md`](docs/isolation.md) — the canonical,
 
 Concepts, the workflow reference, and the isolation design live at **[fletch.sh/docs](https://fletch.sh/docs)**.
 
+## Community
+
+Questions, workflows worth stealing, and anything that isn't a bug go in **[Discussions](https://github.com/fwdai/fletch/discussions)**. Two threads to start with:
+
+- **[Known gaps in the beta](https://github.com/fwdai/fletch/discussions/523)** — what doesn't work yet, written down rather than discovered. Read this before you file anything.
+- **[What would you fix first](https://github.com/fwdai/fletch/discussions/526)** — the one that actually shapes what gets built next.
+
+Reproducible bugs belong in [Issues](https://github.com/fwdai/fletch/issues). Common questions are answered on the [FAQ](https://fletch.sh/faq).
+
 ## Build from source
 
 ```bash


### PR DESCRIPTION
Adds a Community section to the README, between Documentation and Build from source.

The README linked the repo and the docs but never said where a question goes. The only visible destination was Issues, which is the wrong place for "how do I" and "is this supposed to work like this" — and Phase 1 is about to send strangers looking.

Points at Discussions and names the two seeded threads worth a first click:

- **Known gaps in the beta** (#523), so limitations get read rather than discovered and filed.
- **What would you fix first** (#526), which is where feature pressure should land.

Issues stays for reproducible bugs, the FAQ for the already-answered.

This closes the last open step of the community-surface work: the threads were seeded on Jul 27 but nothing in the product or the repo pointed at them.

Still to do by hand, and not in this PR: pin #522 and #523 (GitHub's GraphQL API has no pin mutation for discussions), and add the same link to the in-app menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)