### PR TITLE
fix(native-view): stop destructive spawns, route messages, theme the pane

### DIFF
--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -3,8 +3,8 @@
 //! An agent is a git worktree + a coding-agent process running inside
 //! it. There are three runner shapes:
 //!
-//! - **Pty** (claude native view): a sandboxed `claude` process in a PTY
-//!   rendering its TUI; the app overlays its own input over the prompt.
+//! - **Pty** (native view): a sandboxed agent process in a PTY rendering its
+//!   own TUI; xterm owns stdin, so the user types straight into it.
 //! - **Managed** (claude custom view): a sandboxed, persistent
 //!   `claude --print` stream-json subprocess; the app renders structured
 //!   chat. Both claude shapes attach to the same conversation via

--- a/src-tauri/src/agent/spawn.rs
+++ b/src-tauri/src/agent/spawn.rs
@@ -512,6 +512,9 @@ impl Agent {
     /// used only by per-turn runners, which bake them into that turn's argv.
     /// claude (Managed) ignores them — its config is fixed on the persistent
     /// process at spawn and changed via a session-preserving respawn instead.
+    /// The native (Pty) view has no structured input channel, so a message is
+    /// typed into the TUI exactly as a user would (see [`pty_input_line`]);
+    /// model/effort are likewise fixed on its running process.
     pub fn send_user_message(
         &self,
         text: &str,
@@ -524,7 +527,7 @@ impl Agent {
             Self::PerTurn(a) => a
                 .session
                 .send_user_message(text, attachments, model, effort),
-            Self::Pty(_) => Err(Error::Other("send_user_message called on pty agent".into())),
+            Self::Pty(a) => a.pty.write(pty_input_line(text, attachments).as_bytes()),
         }
     }
 
@@ -596,6 +599,24 @@ impl Agent {
             Self::PerTurn(a) => a.session.kill(),
         }
     }
+}
+
+/// Render an app-originated message as the keystrokes a user would type into an
+/// agent's TUI: one line, terminated by CR to submit.
+///
+/// Newlines are flattened to spaces because a TUI reads a bare LF/CR as "submit
+/// now" — an unflattened multi-line prompt would arrive as several truncated
+/// turns instead of one. Attachment paths are appended as text, which is what a
+/// user would type; there's no out-of-band attachment channel in a PTY, and
+/// dropping them silently would lose part of the message.
+pub(super) fn pty_input_line(text: &str, attachments: &[String]) -> String {
+    let mut line = text.replace("\r\n", "\n").replace(['\r', '\n'], " ");
+    for path in attachments {
+        line.push(' ');
+        line.push_str(path);
+    }
+    line.push('\r');
+    line
 }
 
 /// The agent binary handed to `launch_agent`, decided by the *resolved*

--- a/src-tauri/src/agent/spawn.rs
+++ b/src-tauri/src/agent/spawn.rs
@@ -513,8 +513,9 @@ impl Agent {
     /// claude (Managed) ignores them — its config is fixed on the persistent
     /// process at spawn and changed via a session-preserving respawn instead.
     /// The native (Pty) view has no structured input channel, so a message is
-    /// typed into the TUI exactly as a user would (see [`pty_input_line`]);
-    /// model/effort are likewise fixed on its running process.
+    /// typed into the TUI exactly as a user would — clearing whatever was in
+    /// the editor first (see [`pty_input_keystrokes`]); model/effort are
+    /// likewise fixed on its running process.
     pub fn send_user_message(
         &self,
         text: &str,
@@ -527,7 +528,7 @@ impl Agent {
             Self::PerTurn(a) => a
                 .session
                 .send_user_message(text, attachments, model, effort),
-            Self::Pty(a) => a.pty.write(pty_input_line(text, attachments).as_bytes()),
+            Self::Pty(a) => a.pty.write(&pty_input_keystrokes(text, attachments)),
         }
     }
 
@@ -601,22 +602,67 @@ impl Agent {
     }
 }
 
-/// Render an app-originated message as the keystrokes a user would type into an
-/// agent's TUI: one line, terminated by CR to submit.
+/// Put the TUI's line editor into a known-empty state: Ctrl-E (end of line)
+/// then Ctrl-U (kill line). Correct under both readline semantics — where
+/// Ctrl-U clears the whole line the Ctrl-E is a harmless no-op, and where it
+/// only kills back to the cursor, Ctrl-E has already moved the cursor to the
+/// end. `NativeInputTracker` models 0x15 as a line clear for the same reason.
+const CLEAR_LINE: &[u8] = &[0x05, 0x15];
+
+/// Render an app-originated message as the exact keystrokes a user would type
+/// into an agent's TUI: clear the editor, type one line, submit with CR.
 ///
-/// Newlines are flattened to spaces because a TUI reads a bare LF/CR as "submit
-/// now" — an unflattened multi-line prompt would arrive as several truncated
-/// turns instead of one. Attachment paths are appended as text, which is what a
-/// user would type; there's no out-of-band attachment channel in a PTY, and
-/// dropping them silently would lose part of the message.
-pub(super) fn pty_input_line(text: &str, attachments: &[String]) -> String {
-    let mut line = text.replace("\r\n", "\n").replace(['\r', '\n'], " ");
+/// Three ways this can otherwise submit something other than what we recorded
+/// as the turn — all of them make the agent run a conversation that diverges
+/// from `session_user_turns`:
+///
+/// 1. **The editor is not empty.** A half-typed prompt may be sitting at the
+///    prompt when a git-action trigger or a queued follow-up is delivered.
+///    Typing on top of it submits `<their draft><our message>`, so the editor
+///    is cleared first. (That discards the draft — unavoidable, and the right
+///    trade for "send this message now"; the app also drops its mirror of it,
+///    see `Supervisor::reset_native_input`.)
+/// 2. **Embedded newlines submit early.** A TUI reads LF/CR as "send now", so
+///    an unflattened multi-line prompt arrives as several truncated turns
+///    instead of one.
+/// 3. **Other control bytes steer the TUI rather than entering it.** Ctrl-C
+///    interrupts, ESC opens modes, Ctrl-U clears. These are dropped — in the
+///    message *and* in attachment paths, which are ordinary bytes on Unix and
+///    may legally contain a newline or a control character.
+pub(super) fn pty_input_keystrokes(text: &str, attachments: &[String]) -> Vec<u8> {
+    let mut line = String::new();
+    push_typed(&mut line, text);
     for path in attachments {
-        line.push(' ');
-        line.push_str(path);
+        // Only separate from preceding content — a message that is nothing but
+        // an attachment must not submit a leading space.
+        if !line.is_empty() {
+            line.push(' ');
+        }
+        push_typed(&mut line, path);
     }
-    line.push('\r');
-    line
+
+    let mut out = Vec::with_capacity(CLEAR_LINE.len() + line.len() + 1);
+    out.extend_from_slice(CLEAR_LINE);
+    out.extend_from_slice(line.as_bytes());
+    out.push(b'\r'); // the one and only submit
+    out
+}
+
+/// Append `s` as literal typing. Newlines become a single space so words stay
+/// separated (a run of them collapses rather than padding the prompt), and every
+/// other control character is dropped.
+fn push_typed(out: &mut String, s: &str) {
+    for ch in s.chars() {
+        match ch {
+            '\r' | '\n' => {
+                if !out.ends_with(' ') && !out.is_empty() {
+                    out.push(' ');
+                }
+            }
+            c if c.is_control() => {}
+            c => out.push(c),
+        }
+    }
 }
 
 /// The agent binary handed to `launch_agent`, decided by the *resolved*

--- a/src-tauri/src/agent/tests.rs
+++ b/src-tauri/src/agent/tests.rs
@@ -9,31 +9,74 @@ use super::providers::codex::{codex_build_args, codex_pty_args, codex_session_id
 use super::providers::cursor::{cursor_build_args, cursor_pty_args, cursor_session_id};
 use super::providers::opencode::{opencode_build_args, opencode_pty_args, opencode_session_id};
 use super::providers::pi::{pi_build_args, pi_pty_args, pi_session_id, pi_session_slug};
-use super::spawn::pty_input_line;
+use super::spawn::pty_input_keystrokes;
 use super::transcript::{jsonl_files_ending, records_with_id};
 use super::*;
 
 // ── native (PTY) view input ───────────────────────────────────────────
+//
+// These pin the invariant that one app-originated message becomes exactly one
+// turn, carrying exactly the text we recorded. A violation here means the agent
+// runs a conversation that diverges from `session_user_turns`.
 
-#[test]
-fn pty_input_line_submits_one_line_per_message() {
-    // A TUI reads a bare newline as "submit", so an app-sent multi-line prompt
-    // (a git-action trigger, a coalesced follow-up) must arrive as ONE turn —
-    // otherwise each line lands as its own truncated turn.
-    let line = pty_input_line("first\nsecond\r\nthird", &[]);
-    assert_eq!(line, "first second third\r");
-    assert_eq!(line.matches('\r').count(), 1, "exactly one submit");
+/// Ctrl-E, Ctrl-U — the editor clear that must precede every injected line.
+const CLEAR: &[u8] = &[0x05, 0x15];
+
+fn keys(text: &str, attachments: &[String]) -> Vec<u8> {
+    pty_input_keystrokes(text, attachments)
 }
 
 #[test]
-fn pty_input_line_appends_attachment_paths() {
-    let line = pty_input_line("look at this", &["/tmp/a.png".to_string()]);
-    assert_eq!(line, "look at this /tmp/a.png\r");
+fn pty_input_clears_the_editor_before_typing() {
+    // The user may have a half-typed prompt sitting at the prompt when a
+    // git-action trigger lands. Without the clear, the agent would submit
+    // `<their draft>commit this`.
+    let out = keys("commit this", &[]);
+    assert!(out.starts_with(CLEAR), "must clear the line editor first");
+    assert_eq!(&out[CLEAR.len()..], b"commit this\r");
 }
 
 #[test]
-fn pty_input_line_submits_even_when_empty() {
-    assert_eq!(pty_input_line("", &[]), "\r");
+fn pty_input_submits_exactly_once_per_message() {
+    // A TUI reads LF/CR as "send now", so an unflattened multi-line prompt
+    // would arrive as several truncated turns.
+    let out = keys("first\nsecond\r\nthird", &[]);
+    assert_eq!(&out[CLEAR.len()..], b"first second third\r");
+    // Exactly one CR in the whole byte stream — the submit. (The clear prefix
+    // is 0x05/0x15, so it contributes none.)
+    assert_eq!(out.iter().filter(|&&b| b == b'\r').count(), 1);
+    assert_eq!(out.iter().filter(|&&b| b == b'\n').count(), 0);
+}
+
+#[test]
+fn pty_input_sanitizes_attachment_paths() {
+    // Paths are ordinary bytes on Unix and may legally contain a newline; an
+    // unsanitized one would split the message into two turns.
+    let out = keys("look at this", &["/tmp/we\nird.png".to_string()]);
+    assert_eq!(&out[CLEAR.len()..], b"look at this /tmp/we ird.png\r");
+    assert_eq!(out.iter().filter(|&&b| b == b'\r').count(), 1);
+}
+
+#[test]
+fn pty_input_drops_control_bytes_that_steer_the_tui() {
+    // Ctrl-C would interrupt the turn, ESC would open a mode, Ctrl-U would
+    // clear what we just typed — none may reach the TUI from message content.
+    let out = keys("a\u{3}b\u{1b}c", &["/tmp/x\u{15}.png".to_string()]);
+    assert_eq!(&out[CLEAR.len()..], b"abc /tmp/x.png\r");
+}
+
+#[test]
+fn pty_input_omits_a_leading_separator_for_attachment_only_messages() {
+    let out = keys("", &["/tmp/a.png".to_string()]);
+    assert_eq!(&out[CLEAR.len()..], b"/tmp/a.png\r");
+}
+
+#[test]
+fn pty_input_submits_even_when_empty() {
+    // A bare submit is still a submit — never a no-op write that silently
+    // drops a recorded turn.
+    let out = keys("", &[]);
+    assert_eq!(&out[CLEAR.len()..], b"\r");
 }
 
 // ── transcript readers ────────────────────────────────────────────────

--- a/src-tauri/src/agent/tests.rs
+++ b/src-tauri/src/agent/tests.rs
@@ -9,8 +9,32 @@ use super::providers::codex::{codex_build_args, codex_pty_args, codex_session_id
 use super::providers::cursor::{cursor_build_args, cursor_pty_args, cursor_session_id};
 use super::providers::opencode::{opencode_build_args, opencode_pty_args, opencode_session_id};
 use super::providers::pi::{pi_build_args, pi_pty_args, pi_session_id, pi_session_slug};
+use super::spawn::pty_input_line;
 use super::transcript::{jsonl_files_ending, records_with_id};
 use super::*;
+
+// ── native (PTY) view input ───────────────────────────────────────────
+
+#[test]
+fn pty_input_line_submits_one_line_per_message() {
+    // A TUI reads a bare newline as "submit", so an app-sent multi-line prompt
+    // (a git-action trigger, a coalesced follow-up) must arrive as ONE turn —
+    // otherwise each line lands as its own truncated turn.
+    let line = pty_input_line("first\nsecond\r\nthird", &[]);
+    assert_eq!(line, "first second third\r");
+    assert_eq!(line.matches('\r').count(), 1, "exactly one submit");
+}
+
+#[test]
+fn pty_input_line_appends_attachment_paths() {
+    let line = pty_input_line("look at this", &["/tmp/a.png".to_string()]);
+    assert_eq!(line, "look at this /tmp/a.png\r");
+}
+
+#[test]
+fn pty_input_line_submits_even_when_empty() {
+    assert_eq!(pty_input_line("", &[]), "\r");
+}
 
 // ── transcript readers ────────────────────────────────────────────────
 

--- a/src-tauri/src/native_input.rs
+++ b/src-tauri/src/native_input.rs
@@ -79,6 +79,17 @@ impl NativeInputTracker {
 
         submitted
     }
+
+    /// Forget any partially-typed line.
+    ///
+    /// Called when the app itself submits into the TUI: that write clears the
+    /// real line editor (see `agent::spawn::pty_input_keystrokes`), so leaving
+    /// the mirror populated would make the user's *next* Enter report their
+    /// discarded draft as a prefix of the submitted line — capturing a turn the
+    /// agent never ran.
+    pub fn clear(&mut self) {
+        self.line.clear();
+    }
 }
 
 fn skip_escape_sequence(bytes: &[u8], start: usize) -> usize {

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -26,6 +26,7 @@ use super::messaging::{
     drain_message_queue, flush_queued, mark_user_turn_started, on_first_user_message,
 };
 use super::rpc_watch::spawn_rpc_watcher;
+use super::session_sync::{should_live_sync, spawn_live_transcript_sync};
 use super::{transition_active, Supervisor};
 
 const WATCHDOG_TICK: Duration = Duration::from_millis(500);
@@ -825,6 +826,16 @@ impl Supervisor {
         }
 
         spawn_turn_watchdog(self.clone(), app.clone(), agent_id_str.clone(), my_gen);
+
+        // A native-view agent drives its own TUI in a PTY, so there's no event
+        // stream to render progress from — without this the panel stays a raw
+        // terminal until the turn-end sync lands. Poll its on-disk transcript
+        // instead so structure (tool cards, thinking) appears while it works.
+        // Self-gating: a no-op for the custom view and for providers whose
+        // reader can't tail cheaply.
+        if should_live_sync(&record.provider, record.view) {
+            spawn_live_transcript_sync(self.clone(), app.clone(), agent_id_str.clone(), my_gen);
+        }
 
         // Register the dispatcher so the mailbox can also be drained on demand
         // (`settle_agent_rpc`), not only on the watcher's tick. Overwrites any

--- a/src-tauri/src/supervisor/messaging.rs
+++ b/src-tauri/src/supervisor/messaging.rs
@@ -124,6 +124,7 @@ impl Supervisor {
         // fixed on its running process — so no per-turn config to pass.
         self.live_agent(agent_id)?
             .send_user_message(&msg.text, &msg.attachments, None, None)?;
+        self.reset_native_input(agent_id);
         if let Err(e) =
             self.workspace
                 .insert_user_turn(agent_id, &msg.turn_id, &msg.text, &msg.attachments)
@@ -173,7 +174,19 @@ impl Supervisor {
             record.model.as_deref(),
             record.effort.as_deref(),
         )?;
+        self.reset_native_input(agent_id);
         Ok(())
+    }
+
+    /// Drop our mirror of a native agent's half-typed input line. A PTY
+    /// delivery clears the TUI's real editor before typing, so the mirror has
+    /// to be cleared in lockstep or the next Enter would attribute the
+    /// abandoned draft to the user's following turn. No-op for every other
+    /// transport (only native agents have a tracker entry).
+    fn reset_native_input(&self, agent_id: &str) {
+        if let Some(tracker) = self.native_inputs.lock().get_mut(agent_id) {
+            tracker.clear();
+        }
     }
 
     /// Deliver the user's answer to a held user-input prompt as a control

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -6,7 +6,9 @@ use tauri::AppHandle;
 
 use crate::agent::per_turn_descriptor;
 use crate::github::{MergeableState, PrState, PrStatus};
-use crate::workspace::{repo_checkout_path, AgentRecord, AgentView, TrackedRepo, WorkspaceManager};
+use crate::workspace::{
+    repo_checkout_path, AgentRecord, AgentStatus, AgentView, TrackedRepo, WorkspaceManager,
+};
 
 use super::events::{
     emit_pr_state, emit_session_records_appended, emit_session_sync_health, emit_verification,
@@ -15,6 +17,7 @@ use super::Supervisor;
 
 use parking_lot::Mutex;
 use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
 
 /// Wall-clock ceiling for a turn-end verification, matching the ad-hoc
 /// `run_verification` command (spec §9.4 uses the same 15-minute bound).
@@ -23,6 +26,12 @@ const TURN_END_VERIFY_TIMEOUT_SECS: u64 = 900;
 /// Project setting key (stored by the frontend Project Settings toggle) that
 /// opts a project into running verification at every ad-hoc turn end.
 const VERIFY_ON_TURN_END_KEY: &str = "verify.on_turn_end";
+
+/// How often the native-view live poller re-reads a running agent's transcript.
+/// A CLI flushes its JSONL once per *completed* assistant message (claude does
+/// so ~7 times in a turn, sub-second after each one), not per token — so a
+/// faster tick buys no extra freshness and only burns syscalls.
+const LIVE_SYNC_TICK: Duration = Duration::from_secs(1);
 
 impl Supervisor {
     /// Synchronously ingest the agent's transcript into session_records (used
@@ -430,6 +439,121 @@ fn is_persistent_runner(record: &AgentRecord) -> bool {
     !(per_turn && record.view == AgentView::Custom)
 }
 
+/// Whether this agent qualifies for the mid-turn live transcript poll.
+///
+/// Two independent things have to hold:
+///
+/// - **Native view.** There the CLI runs its own TUI in a PTY and we get no
+///   event stream, so the transcript on disk is the only structured view of the
+///   turn in progress. A custom-view agent already streams its structure, so
+///   polling would duplicate work and race the stream.
+/// - **A tailable reader.** `sync_session_records` only reads incrementally
+///   (O(new), seeking to the stored byte offset) when the reader declares
+///   `tail: Some(..)`. Readers with `tail: None` — codex and opencode locate
+///   several rollout files, antigravity a blob directory — fall back to a *full
+///   re-parse of every file on every call*. That's fine once at turn end and a
+///   performance bug at 1 Hz. Gating on `tail.is_some()` rather than a provider
+///   allowlist means any provider that later gains a single-file tail is picked
+///   up with no change here.
+pub(super) fn should_live_sync(provider: &str, view: AgentView) -> bool {
+    view == AgentView::Native
+        && crate::agent::transcript_reader(provider).is_some_and(|r| r.tail.is_some())
+}
+
+/// Ingest the native-view agent's transcript *during* the turn, so the UI can
+/// render tool cards and thinking blocks while its TUI is still working instead
+/// of waiting for the turn-end sync.
+///
+/// Gen-guarded exactly like `spawn_turn_watchdog`: no handle is tracked, the
+/// task simply retires itself once a respawn/teardown/view-switch bumps the
+/// generation it was started under. Because a view switch goes through
+/// `start_process` (new generation), the view/provider gate is evaluated once up
+/// front rather than re-read from the DB every tick.
+///
+/// This deliberately calls `sync_session_records` directly rather than reusing
+/// `trigger_session_sync`:
+///
+/// - `SyncPoll` stops after two consecutive zero-insert reads. At turn end that
+///   means "the file settled"; mid-turn it only means the model is thinking, so
+///   it would give up seconds into a long reasoning block.
+/// - `ReadDiagnostics::absorb` accumulates across passes and is never reset, and
+///   `classify` maps `records_parsed > 0 && io_errors > 0` to `PartialRead` — so
+///   a single transient read error would permanently pin this agent's reported
+///   health. Turn-end stays the sole authority on sync health; this path never
+///   classifies.
+pub(super) fn spawn_live_transcript_sync(
+    sup: Arc<Supervisor>,
+    app: AppHandle,
+    agent_id: String,
+    gen: u64,
+) {
+    tauri::async_runtime::spawn(async move {
+        loop {
+            tokio::time::sleep(LIVE_SYNC_TICK).await;
+
+            let current_gen = sup.generations.lock().get(&agent_id).copied().unwrap_or(0);
+            if current_gen != gen {
+                return;
+            }
+
+            // Only read while a turn is actually in flight. An idle agent's
+            // transcript cannot grow, so ticking the filesystem and the (global)
+            // sqlite lock once a second for it would be a permanent background
+            // tax that scales with the number of open agents. `Spawning` is
+            // excluded too — there is no turn yet, and the turn-end sync from
+            // the *previous* generation may still be draining.
+            if !matches!(sup.live_status(&agent_id), Some(AgentStatus::Running)) {
+                continue;
+            }
+
+            let inserted = sync_session_records(&sup.workspace, &agent_id)
+                .map(|o| o.inserted)
+                .unwrap_or(0);
+
+            // Emit only on a real insert. The frontend refetches the whole
+            // record list on this event, so firing it every tick would turn a
+            // thinking agent into a 1 Hz refetch loop over the conversation.
+            if inserted > 0 {
+                emit_session_records_appended(&app, &agent_id);
+            }
+        }
+    });
+}
+
+/// Per-agent lock serializing [`sync_session_records`].
+///
+/// The ingest is `read offset → read file → append rows → write offset` with no
+/// atomicity across the steps, and the live poller can now overlap the turn-end
+/// `trigger_session_sync` for the same agent (a turn ending mid-tick is the
+/// normal case, not a rare one). Two overlapping passes both start from the same
+/// stored offset, read the same byte range, and both write a `next` offset — the
+/// later writer wins, so the cursor can move *backwards*.
+///
+/// A backwards cursor cannot lose records: every offset written corresponds to
+/// bytes that pass actually appended, so the worst case is re-reading a range.
+/// But the re-read is not always harmless. Duplicate *rows* are absorbed only
+/// when the record ids come out of the file (`JsonlTail { id_field: Some(..) }`,
+/// as claude and pi use). A positional reader (`id_field: None`, cursor) mints
+/// `ln:{i}` ids from `session_record_count`, so two passes over the same lines
+/// with different starting counts produce *different* native ids for the same
+/// line and `INSERT OR IGNORE` inserts both — duplicated turns in the UI.
+///
+/// The lock therefore wraps the whole read/append/advance sequence here rather
+/// than at the call sites, so every caller (live poll, turn end, lazy backfill,
+/// fork) is covered without knowing about it. Per agent, not global, so one
+/// agent's full re-parse can't stall another's poll. Same pattern as
+/// `codegraph::mirror`'s per-path locks; the map is only ever added to, bounded
+/// by the number of distinct agent ids this process touches.
+fn agent_sync_lock(agent_id: &str) -> Arc<Mutex<()>> {
+    static LOCKS: OnceLock<Mutex<HashMap<String, Arc<Mutex<()>>>>> = OnceLock::new();
+    LOCKS
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .entry(agent_id.to_string())
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone()
+}
+
 /// Whether the turn-end transcript poll should keep going.
 #[derive(Debug, PartialEq, Eq)]
 enum PollControl {
@@ -684,6 +808,13 @@ fn report_sync_health(
 /// changed) plus the `ReadDiagnostics` the locate/read pass collected so the
 /// caller can tell those two apart.
 fn sync_session_records(workspace: &WorkspaceManager, agent_id: &str) -> Option<SyncOutcome> {
+    // The offset cursor is read here and written at the bottom, so two
+    // overlapping passes for the same agent would both start from the stale
+    // offset and re-read the same range (see `agent_sync_lock`). Held across the
+    // whole sequence, and only ever taken *outside* the workspace db lock.
+    let serialize = agent_sync_lock(agent_id);
+    let _pass = serialize.lock();
+
     let record = workspace.agent(agent_id).ok()?;
     let reader = crate::agent::transcript_reader(&record.provider)?;
 
@@ -1202,5 +1333,48 @@ mod tests {
         let mut bad_state = snapshot_repo();
         bad_state.pr_state = Some("weird".into());
         assert!(pr_snapshot(&bad_state).is_none());
+    }
+
+    // ── Live-poll gate: native view AND a reader that can tail ──
+
+    #[test]
+    fn live_sync_polls_native_agents_whose_reader_tails() {
+        // claude/pi/cursor all locate a single JSONL, so `sync_session_records`
+        // seeks to the stored offset and reads only what's new — cheap at 1 Hz.
+        // The gate is `tail.is_some()`, not a provider allowlist, so all three
+        // qualify without being named anywhere.
+        for provider in ["claude", "pi", "cursor"] {
+            assert!(
+                should_live_sync(provider, AgentView::Native),
+                "{provider} tails a single jsonl and should be polled live"
+            );
+        }
+    }
+
+    #[test]
+    fn live_sync_skips_the_custom_view() {
+        // Custom-view agents render from their event stream, which already
+        // carries live structure; polling the transcript would duplicate it.
+        for provider in ["claude", "pi", "cursor"] {
+            assert!(
+                !should_live_sync(provider, AgentView::Custom),
+                "{provider} in the custom view already streams structure"
+            );
+        }
+    }
+
+    #[test]
+    fn live_sync_skips_readers_that_cannot_tail() {
+        // These readers locate multiple files (codex rollouts, opencode's blob
+        // dir, antigravity), so every pass is a full re-parse of the whole
+        // conversation. Polling them once a second would be a performance bug.
+        for provider in ["codex", "opencode", "antigravity"] {
+            assert!(
+                !should_live_sync(provider, AgentView::Native),
+                "{provider} has tail: None — a live poll would re-parse everything"
+            );
+        }
+        // A provider with no transcript reader at all is likewise skipped.
+        assert!(!should_live_sync("nonesuch", AgentView::Native));
     }
 }

--- a/src-tauri/src/workspace/mod.rs
+++ b/src-tauri/src/workspace/mod.rs
@@ -50,11 +50,12 @@ pub enum AgentStatus {
 #[serde(rename_all = "snake_case")]
 #[derive(Default)]
 pub enum AgentView {
-    /// Structured chat UI rendered from claude's stream-json events.
+    /// Structured chat UI rendered from the agent's stream-json events.
     #[default]
     Custom,
-    /// Read-only xterm showing claude's native TUI, with our input box
-    /// overlaid on top of the claude input prompt.
+    /// The agent's own interactive TUI, streamed into an xterm that owns stdin
+    /// too — keystrokes go straight to the PTY. App-originated messages are
+    /// typed in as a line (see `agent::spawn::pty_input_line`).
     Native,
 }
 

--- a/src/components/RightPanel/RunPanel.tsx
+++ b/src/components/RightPanel/RunPanel.tsx
@@ -12,7 +12,6 @@ import {
 } from "@/components/RunConfig";
 import { useAppStore } from "@/store";
 import { useXterm } from "@/util/useXterm";
-import { resolveTheme } from "@/util/xtermTheme";
 import { RunSettingsSheet } from "./RunSettingsSheet";
 
 // Detected run config replaces the old hardcoded defaults. The backend
@@ -96,7 +95,6 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
     {
       fontSize: 12,
       lineHeight: 1.2,
-      theme: resolveTheme(),
       scrollback: 20000,
       // Read-only log view: no input, no blinking input caret.
       disableStdin: true,
@@ -208,19 +206,6 @@ export function RunPanel({ agent }: { agent: AgentRecord }) {
     [agent.id, setRunPhase],
     { autoFocus: false },
   );
-
-  // Re-apply the xterm theme on dark ↔ light switches without recreating the
-  // terminal (same approach as TermPanel).
-  useEffect(() => {
-    const observer = new MutationObserver(() => {
-      if (termRef.current) termRef.current.options.theme = resolveTheme();
-    });
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["class"],
-    });
-    return () => observer.disconnect();
-  }, []);
 
   // What each row inherits: the project setting when one exists, else the
   // detected value. Agent-level overrides compare against these, so a value

--- a/src/components/RightPanel/TermPanel.tsx
+++ b/src/components/RightPanel/TermPanel.tsx
@@ -1,27 +1,18 @@
 import { open } from "@tauri-apps/plugin-shell";
-import { SearchAddon } from "@xterm/addon-search";
 import { WebLinksAddon } from "@xterm/addon-web-links";
-import type { Terminal } from "@xterm/xterm";
-import { useEffect, useRef, useState } from "react";
 import { type AgentRecord, api } from "@/api";
-import { Icon } from "@/components/Icon";
-import { IconButton } from "@/components/ui/IconButton";
+import { useTerminalSearch } from "@/components/ui/TerminalSearch";
 import { getShellBuffer, registerShellSink } from "@/pty/buffers";
 import { useXterm } from "@/util/useXterm";
-import { resolveTheme } from "@/util/xtermTheme";
 
 export function TermPanel({ agent }: { agent: AgentRecord }) {
-  const termRef = useRef<Terminal | null>(null);
-  const searchAddonRef = useRef<SearchAddon | null>(null);
-  const [searchOpen, setSearchOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
+  const search = useTerminalSearch();
 
   // ── Terminal setup ──────────────────────────────────────────────
   const containerRef = useXterm(
     {
       fontSize: 12,
       lineHeight: 1.2,
-      theme: resolveTheme(),
       scrollback: 20000,
     },
     (term) => {
@@ -29,22 +20,8 @@ export function TermPanel({ agent }: { agent: AgentRecord }) {
         console.error("openAgentShell failed", err);
       });
 
-      const searchAddon = new SearchAddon();
-      term.loadAddon(searchAddon);
+      const detachSearch = search.attach(term);
       term.loadAddon(new WebLinksAddon((_, url) => open(url)));
-
-      termRef.current = term;
-      searchAddonRef.current = searchAddon;
-
-      // Intercept Ctrl/Cmd+F so it opens the search bar instead of being
-      // sent to the PTY as a raw byte sequence.
-      term.attachCustomKeyEventHandler((e) => {
-        if ((e.metaKey || e.ctrlKey) && e.key === "f" && e.type === "keydown") {
-          setSearchOpen(true);
-          return false; // prevent xterm from forwarding to PTY
-        }
-        return true;
-      });
 
       const buffered = getShellBuffer(agent.id);
       if (buffered && buffered.length > 0) term.write(buffered);
@@ -60,8 +37,7 @@ export function TermPanel({ agent }: { agent: AgentRecord }) {
       const unregister = registerShellSink(agent.id, (bytes) => term.write(bytes));
 
       return () => {
-        termRef.current = null;
-        searchAddonRef.current = null;
+        detachSearch();
         unregister();
         onResize.dispose();
         onData.dispose();
@@ -73,66 +49,9 @@ export function TermPanel({ agent }: { agent: AgentRecord }) {
     [agent.id],
   );
 
-  // ── Theme reactivity ────────────────────────────────────────────
-  // Watch <html> class for dark ↔ light switches and re-apply the theme
-  // without recreating the terminal.
-  useEffect(() => {
-    const observer = new MutationObserver(() => {
-      if (termRef.current) termRef.current.options.theme = resolveTheme();
-    });
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["class"],
-    });
-    return () => observer.disconnect();
-  }, []);
-
-  // ── Search helpers ──────────────────────────────────────────────
-  const runSearch = (query: string, direction: "next" | "prev" = "next") => {
-    if (!searchAddonRef.current || !query) return;
-    if (direction === "next") searchAddonRef.current.findNext(query);
-    else searchAddonRef.current.findPrevious(query);
-  };
-
-  const closeSearch = () => {
-    setSearchOpen(false);
-    setSearchQuery("");
-    termRef.current?.focus();
-  };
-
   return (
     <div className="term-panel">
-      {searchOpen && (
-        <div className="term-search flex-center">
-          <input
-            autoFocus
-            className="term-search-input"
-            placeholder="Find in terminal…"
-            value={searchQuery}
-            onChange={(e) => {
-              setSearchQuery(e.target.value);
-              runSearch(e.target.value);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") runSearch(searchQuery, e.shiftKey ? "prev" : "next");
-              if (e.key === "Escape") closeSearch();
-            }}
-          />
-          <IconButton
-            size="sm"
-            tip="Previous (Shift+Enter)"
-            onClick={() => runSearch(searchQuery, "prev")}
-          >
-            <Icon name="chevU" />
-          </IconButton>
-          <IconButton size="sm" tip="Next (Enter)" onClick={() => runSearch(searchQuery, "next")}>
-            <Icon name="chevD" />
-          </IconButton>
-          <IconButton size="sm" tip="Close (Esc)" onClick={closeSearch}>
-            <Icon name="close" />
-          </IconButton>
-        </div>
-      )}
+      {search.bar}
       <div className="xterm-slot">
         <div ref={containerRef} className="xterm-host" style={{ inset: "14px 4px 14px 12px" }} />
       </div>

--- a/src/components/Workspace/Chat.css
+++ b/src/components/Workspace/Chat.css
@@ -743,3 +743,58 @@
   color: var(--fg-2);
   white-space: pre-wrap;
 }
+
+/* ── Native view: terminal + transcript rail ──────────────────────────────
+   `.chat` is a column; the native body splits it into two columns instead —
+   the TUI you type into, and the structured inspector beside it. */
+.native-split {
+  flex-direction: row;
+}
+.native-term {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+}
+.native-rail {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  width: 380px;
+  min-height: 0;
+  border-left: 1px solid var(--bd-soft);
+  background: var(--bg-0);
+}
+/* Below this the rail costs the terminal more than it gives back — a TUI
+   reflows badly under ~80 columns. */
+@media (max-width: 1100px) {
+  .native-rail {
+    width: 320px;
+  }
+}
+.native-rail-h {
+  gap: 8px;
+  padding: 6px 6px 6px 12px;
+  border-bottom: 1px solid var(--bd-soft);
+  flex-shrink: 0;
+}
+.native-rail-title {
+  flex: 1;
+  min-width: 0;
+  color: var(--fg-2);
+  font-weight: 500;
+}
+.native-rail-foot {
+  justify-content: flex-end;
+  padding: 6px 12px;
+  border-top: 1px solid var(--bd-soft);
+  flex-shrink: 0;
+}
+/* The rail is narrow: let the log use its full width rather than the centred,
+   max-width column the main chat pane uses. */
+.native-rail .chat-inner {
+  padding: 12px 10px;
+  max-width: none;
+}

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -1,29 +1,20 @@
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { applyPolicy, getAdapter } from "@/adapters";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { type AgentRecord, api } from "@/api";
 import { Composer } from "@/components/Composer";
-import { APP_ACTION_PREFIX } from "@/components/RightPanel/delegation";
-import { Loader } from "@/components/ui/Loader";
 import { providerLabel } from "@/data/providers";
 import { getLinearTeamId } from "@/storage/projectSettings";
 import { useAppStore } from "@/store";
-import { stripInjectedInstructions } from "@/util/instructions";
-import { ChatNav } from "./ChatNav";
 import { ChatSearch } from "./ChatSearch";
 import { ChatWorkingStatus } from "./ChatWorkingStatus";
-import { MessageItem } from "./messages/MessageItem";
-import { type PairCache, pairToolItems, rowKey } from "./messages/pair";
+import { TranscriptList } from "./messages/TranscriptList";
 import { isTurnPending } from "./messages/turnPending";
-import { isUserInputTool } from "./messages/UserInput/parse";
-import { TurnFooter } from "./RunTimer";
+import { useTranscript } from "./messages/useTranscript";
 
 /** Custom-view body: scrolling chat log + composer at the bottom.
  *  The composer here dispatches the user's message via the store; it
  *  doesn't care about provider routing yet. */
 export function ChatView({ agent }: { agent: AgentRecord }) {
-  const log = useAppStore((s) => s.managedLogs[agent.id]);
   const transcriptLoading = useAppStore((s) => s.transcriptLoading[agent.id] ?? false);
-  const transcriptLoaded = useAppStore((s) => s.transcriptLoaded[agent.id] ?? false);
   const busy = useAppStore((s) => s.managedBusy[agent.id] ?? false);
   const busyLabel = useAppStore((s) => s.managedBusyLabel[agent.id]);
   const turnStartedAt = useAppStore((s) => s.turnStartedAt[agent.id]);
@@ -33,7 +24,6 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
   const setAgentModel = useAppStore((s) => s.setAgentModel);
   const stop = useAppStore((s) => s.stop);
   const runLocalCommand = useAppStore((s) => s.runLocalCommand);
-  const loadHistoryTranscript = useAppStore((s) => s.loadHistoryTranscript);
   const usage = useAppStore((s) => s.usage[agent.id]);
   // The custom agent this session was spawned from (if any, and still present),
   // so the chat surfaces the agent's name rather than its base provider.
@@ -71,7 +61,9 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
     };
   }, [projectId]);
 
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  // Owned here so sending a message can re-pin the log to the bottom.
+  const pinnedToBottom = useRef(true);
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
 
@@ -109,142 +101,10 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
     setSearchQuery("");
   }, [agent.id]);
 
-  // Whether the chat is "pinned" to the bottom. While true we follow new
-  // messages; once the user scrolls up we stop auto-scrolling and leave their
-  // position alone until they scroll back down to the bottom.
-  const pinnedToBottom = useRef(true);
-  const hasSession = Boolean(agent.session_id);
-  const hasPriorConversation = agent.task.trim().length > 0;
-
-  useEffect(() => {
-    if (!hasSession || transcriptLoaded || transcriptLoading || switchInFlight) {
-      return;
-    }
-    if (log !== undefined || !hasPriorConversation) {
-      return;
-    }
-    void loadHistoryTranscript(agent.id);
-  }, [
-    agent.id,
-    hasSession,
-    hasPriorConversation,
-    loadHistoryTranscript,
-    log,
-    switchInFlight,
-    transcriptLoaded,
-    transcriptLoading,
-  ]);
-
-  // Re-pin to the bottom whenever we switch to a different agent, so each
-  // conversation opens scrolled to its latest message.
-  useEffect(() => {
-    pinnedToBottom.current = true;
-  }, [agent.id]);
-
-  const handleScroll = () => {
-    const el = scrollRef.current;
-    if (!el) return;
-    // Allow a small slop so the user counts as "at the bottom" even a few
-    // pixels short — sub-pixel rounding otherwise makes exact equality flaky.
-    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    pinnedToBottom.current = distanceFromBottom <= 40;
-  };
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    if (transcriptLoading) return;
-    if (!pinnedToBottom.current) return;
-    el.scrollTop = el.scrollHeight;
-  }, [log, transcriptLoading]);
-
-  // Persist tool_pair wrapper identity across renders so memoized rows survive
-  // streaming deltas (see PairCache). Self-evicts stale ids each pass, so it
-  // needs no reset when switching agents (tool-use ids never collide).
-  const pairCache = useRef<PairCache>(new Map());
-
-  const items = useMemo(() => {
-    const adapter = getAdapter(agent.provider);
-    const visible = applyPolicy(log ?? [], adapter.policy);
-    return pairToolItems(visible, pairCache.current);
-  }, [log, agent.provider]);
-
-  // Navigable turns = the real user prompts (git-action chips excluded). Each
-  // gets a stable ordinal that maps an item to its `data-chat-turn` marker, so
-  // ChatNav can jump straight to any bubble.
-  const { turns, turnIds } = useMemo(() => {
-    const turns: { id: number; text: string }[] = [];
-    const turnIds = items.map((it) => {
-      if (it.kind !== "user_message" || it.text.startsWith(APP_ACTION_PREFIX)) {
-        return undefined;
-      }
-      const id = turns.length;
-      turns.push({ id, text: stripInjectedInstructions(it.text) });
-      return id;
-    });
-    return { turns, turnIds };
-  }, [items]);
-
-  // Footer closing each *ended* turn (border + "Ran …" + copy), placed at the
-  // turn's last item — the seam before the next turn. Gated on the same
-  // turn-end signal as the duration, so it only appears once the turn finishes;
-  // the open turn (started, not ended) carries no footer, just its live timer
-  // on the working strip.
-  const { turnFooters, openTurnStartedAt } = useMemo(() => {
-    // `turnOrdinal` is the footer turn's index among navigable prompts (the same
-    // 0-based ordinal `turns` uses), which is exactly what the fork action needs
-    // as its "up to this message" cutoff.
-    const footers: ({ runSec: number; copyText: string; turnOrdinal: number } | null)[] = items.map(
-      () => null,
-    );
-    let openStart: number | undefined;
-    const starts: number[] = [];
-    items.forEach((it, i) => {
-      if (it.kind === "user_message" && !it.text.startsWith(APP_ACTION_PREFIX)) starts.push(i);
-    });
-    starts.forEach((startIdx, k) => {
-      const start = items[startIdx];
-      if (start.kind !== "user_message" || start.startedAt == null) return;
-      const endExclusive = k + 1 < starts.length ? starts[k + 1] : items.length;
-      if (start.endedAt == null) {
-        openStart = start.startedAt; // turn still running
-        return;
-      }
-      // The agent's settled prose for this turn — what "copy" yields.
-      const texts: string[] = [];
-      for (let j = startIdx; j < endExclusive; j += 1) {
-        const it = items[j];
-        if (it.kind === "agent_message" && !it.streaming && it.text) texts.push(it.text);
-      }
-      footers[endExclusive - 1] = {
-        runSec: (start.endedAt - start.startedAt) / 1000,
-        copyText: texts.join("\n\n"),
-        turnOrdinal: k,
-      };
-    });
-    return { turnFooters: footers, openTurnStartedAt: openStart };
-  }, [items]);
-
-  // The model the agent actually used on its most recent turn (Claude, pi,
-  // Codex, OpenCode report it in their transcripts). Undefined for Cursor /
-  // Antigravity, or before the first turn — the composer then shows just the
-  // provider.
-  const activeModel = useMemo(() => {
-    for (let i = items.length - 1; i >= 0; i -= 1) {
-      const it = items[i];
-      if (it.kind === "agent_message" && it.model) return it.model;
-    }
-    return undefined;
-  }, [items]);
-  // When the last row is an unanswered user-input widget, the agent is paused
-  // on that tool waiting for the user — not working — so suppress the
-  // "is thinking" spinner (the widget itself signals it's the user's turn).
-  const awaitingInput = useMemo(() => {
-    const last = items[items.length - 1];
-    return Boolean(
-      last && last.kind === "tool_pair" && isUserInputTool(last.call.name) && !last.result,
-    );
-  }, [items]);
+  // Log derivation (lazy history load, display policy, tool pairing, per-turn
+  // bookkeeping) is shared with the native view's rail — see useTranscript.
+  const transcript = useTranscript(agent);
+  const { items, turns, activeModel, awaitingInput, openTurnStartedAt } = transcript;
 
   // The backend emits a transient `idle` between process spawn and the first
   // turn's `running` (every process rests at Idle at spawn). Raw `busy` thus
@@ -268,17 +128,6 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
   // and the bottom status strip carries the "is working" signal, so the inline
   // anchor is redundant.
   const turnPending = liveBusy && isTurnPending(items) && turns.length <= 1;
-
-  // Index where the currently-open turn begins (the last top-level user
-  // message). Only tools at/after it belong to the running turn, so only they
-  // may show a live spinner — a dangling tool_call left by an interrupted or
-  // reloaded earlier turn must not light up when a later turn sets `busy`.
-  const openTurnStart = useMemo(() => {
-    for (let i = items.length - 1; i >= 0; i -= 1) {
-      if (items[i].kind === "user_message") return i;
-    }
-    return 0;
-  }, [items]);
 
   // Live-timer anchor: the backend's turn-start timestamp (from `turn:started`,
   // the same value the footer's duration uses, so they never drift). On reload
@@ -306,44 +155,15 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
           onClose={closeSearch}
         />
       )}
-      <div className="chat-scroll-wrap">
-        <div className="chat-scroll" ref={scrollRef} onScroll={handleScroll}>
-          <div className="chat-inner fade-in" key={agent.id}>
-            {transcriptLoading && items.length === 0 ? (
-              <div className="writing flex-center">
-                <Loader variant="accent" />
-                <span>Loading transcript…</span>
-              </div>
-            ) : items.length === 0 && hasPriorConversation && !busy ? (
-              <div className="empty-msg" style={{ margin: "40px auto", maxWidth: 360 }}>
-                <div className="et">No transcript available</div>
-                <div>
-                  {providerLabel(agent.provider)}'s session file is not on disk for this agent.
-                </div>
-              </div>
-            ) : (
-              items.map((item, i) => (
-                <Fragment key={rowKey(item, i)}>
-                  <MessageItem
-                    item={item}
-                    provider={agent.provider}
-                    agentId={agent.id}
-                    busy={liveBusy && i >= openTurnStart}
-                    turnId={turnIds[i]}
-                  />
-                  {turnFooters[i] != null && <TurnFooter {...turnFooters[i]!} agentId={agent.id} />}
-                </Fragment>
-              ))
-            )}
-            {turnPending && (
-              <div className="chat-pending" aria-hidden="true">
-                <Loader variant="muted" size="md" />
-              </div>
-            )}
-          </div>
-        </div>
-        {!searchOpen && <ChatNav scrollRef={scrollRef} turns={turns} />}
-      </div>
+      <TranscriptList
+        agent={agent}
+        transcript={transcript}
+        liveBusy={liveBusy}
+        pending={turnPending}
+        scrollRef={scrollRef}
+        pinRef={pinnedToBottom}
+        hideNav={searchOpen}
+      />
       <div className="composer-wrap">
         <div className="composer-stack">
           <div className="composer-anchor">

--- a/src/components/Workspace/NativeView.tsx
+++ b/src/components/Workspace/NativeView.tsx
@@ -1,28 +1,26 @@
+import { open } from "@tauri-apps/plugin-shell";
+import { WebLinksAddon } from "@xterm/addon-web-links";
 import { type AgentRecord, api } from "@/api";
+import { useTerminalSearch } from "@/components/ui/TerminalSearch";
 import { getOutputBuffer, registerOutputSink } from "@/pty/buffers";
 import { useXterm } from "@/util/useXterm";
 
-/** Fixed dark background for the native TUI view — used by both the xterm
- *  theme and the host slot so they never drift out of sync. */
-const NATIVE_BG = "#1a1c20";
-
-/** Native view: Claude's Ink TUI is streamed verbatim into xterm.
+/** Native view: the provider's own TUI is streamed verbatim into xterm.
  *  xterm owns stdin too, so slash commands, paste, arrows, escape, and
- *  other terminal interactions go straight to the PTY. */
+ *  other terminal interactions go straight to the PTY.
+ *
+ *  Theme comes from the app palette via `useXterm` (and follows dark/light
+ *  live), and the surface carries the same find + link affordances as the
+ *  right-rail shell. */
 export function NativeView({ agent }: { agent: AgentRecord }) {
+  const search = useTerminalSearch();
+
   const containerRef = useXterm(
-    {
-      fontSize: 13,
-      theme: {
-        background: NATIVE_BG,
-        foreground: "#e6e8eb",
-        cursor: "#e6e8eb",
-        cursorAccent: NATIVE_BG,
-        selectionBackground: "#3a3f4a",
-      },
-      scrollback: 5000,
-    },
+    { fontSize: 13, scrollback: 5000 },
     (term) => {
+      const detachSearch = search.attach(term);
+      term.loadAddon(new WebLinksAddon((_, url) => open(url)));
+
       const buffered = getOutputBuffer(agent.id);
       if (buffered && buffered.length > 0) term.write(buffered);
 
@@ -37,6 +35,7 @@ export function NativeView({ agent }: { agent: AgentRecord }) {
       const unregister = registerOutputSink(agent.id, (bytes) => term.write(bytes));
 
       return () => {
+        detachSearch();
         unregister();
         onResize.dispose();
         onData.dispose();
@@ -46,8 +45,11 @@ export function NativeView({ agent }: { agent: AgentRecord }) {
   );
 
   return (
-    <div className="xterm-slot" style={{ background: NATIVE_BG }}>
-      <div ref={containerRef} className="xterm-host" style={{ inset: "8px 4px 8px 10px" }} />
-    </div>
+    <>
+      {search.bar}
+      <div className="xterm-slot">
+        <div ref={containerRef} className="xterm-host" style={{ inset: "8px 4px 8px 10px" }} />
+      </div>
+    </>
   );
 }

--- a/src/components/Workspace/NativeView.tsx
+++ b/src/components/Workspace/NativeView.tsx
@@ -3,6 +3,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { type AgentRecord, api } from "@/api";
 import { useTerminalSearch } from "@/components/ui/TerminalSearch";
 import { getOutputBuffer, registerOutputSink } from "@/pty/buffers";
+import { nativeTerminalKey } from "@/pty/terminals";
 import { useXterm } from "@/util/useXterm";
 
 /** Native view: the provider's own TUI is streamed verbatim into xterm.
@@ -11,16 +12,29 @@ import { useXterm } from "@/util/useXterm";
  *
  *  Theme comes from the app palette via `useXterm` (and follows dark/light
  *  live), and the surface carries the same find + link affordances as the
- *  right-rail shell. */
+ *  right-rail shell.
+ *
+ *  The terminal is cached per agent (see src/pty/terminals), so selecting
+ *  another agent and coming back re-attaches the same live screen rather than
+ *  rebuilding one from the ring buffer. */
 export function NativeView({ agent }: { agent: AgentRecord }) {
   const search = useTerminalSearch();
 
   const containerRef = useXterm(
     { fontSize: 13, scrollback: 5000 },
     (term) => {
-      const detachSearch = search.attach(term);
+      // Runs once per terminal, not once per mount. Everything below therefore
+      // outlives an unmount: the sink keeps writing this agent's PTY into its
+      // cached screen while another agent is selected, so returning here needs
+      // no catch-up at all.
+      //
+      // Which leaves the ring-buffer replay as a first-mount-only path — the
+      // PTY has been streaming since spawn, so the first terminal for an agent
+      // still has to be seeded from it. That replay is inherently lossy (the
+      // 256 KB cap cuts mid escape sequence, mid UTF-8, mid TUI frame); the
+      // point of the cache is that it now happens once instead of on every
+      // re-selection.
       term.loadAddon(new WebLinksAddon((_, url) => open(url)));
-
       const buffered = getOutputBuffer(agent.id);
       if (buffered && buffered.length > 0) term.write(buffered);
 
@@ -35,13 +49,19 @@ export function NativeView({ agent }: { agent: AgentRecord }) {
       const unregister = registerOutputSink(agent.id, (bytes) => term.write(bytes));
 
       return () => {
-        detachSearch();
         unregister();
         onResize.dispose();
         onData.dispose();
       };
     },
     [agent.id],
+    {
+      cacheKey: nativeTerminalKey(agent.id),
+      // Per mount, not per terminal: the find bar is this component
+      // instance's state, so a cached terminal must be re-bound to the
+      // current mount or ⌘F would drive an unmounted component's setState.
+      onMount: (term) => search.attach(term),
+    },
   );
 
   return (

--- a/src/components/Workspace/TranscriptRail.tsx
+++ b/src/components/Workspace/TranscriptRail.tsx
@@ -1,0 +1,55 @@
+// Structured transcript beside the native view's terminal.
+//
+// The TUI is the live surface; this is the inspector. It renders the same
+// structured log the custom view does — tool cards, thinking blocks, turn
+// footers, fork-from-here — sourced from the agent's own on-disk transcript
+// rather than from an event stream the PTY doesn't have.
+//
+// Granularity note (measured, see the live-sync poller in supervisor/): the
+// CLI flushes one complete assistant message plus its tool result at a time,
+// so tool activity appears within about a second, but a turn's final prose
+// lands atomically when the turn ends. This surface is therefore honest as
+// "structured progress", not as a mirror of the text typing out in the TUI.
+import { hasUsage } from "@/adapters/usage";
+import type { AgentRecord } from "@/api";
+import { UsageMeter } from "@/components/Composer/UsageMeter";
+import { Icon } from "@/components/Icon";
+import { IconButton } from "@/components/ui/IconButton";
+import { useAppStore } from "@/store";
+import { TranscriptList } from "./messages/TranscriptList";
+import { useTranscript } from "./messages/useTranscript";
+
+export function TranscriptRail({ agent, onClose }: { agent: AgentRecord; onClose: () => void }) {
+  const transcript = useTranscript(agent);
+  // Native turns produce no event stream, so `managedBusy` is never set for
+  // them. The agent's own status is the liveness signal here.
+  const liveBusy = agent.status === "running";
+
+  return (
+    <aside className="native-rail" aria-label="Transcript">
+      <div className="native-rail-h flex-center">
+        <span className="native-rail-title text-sm">Transcript</span>
+        <IconButton size="sm" tip="Hide transcript (⌘⇧T)" onClick={onClose}>
+          <Icon name="close" />
+        </IconButton>
+      </div>
+      <TranscriptList agent={agent} transcript={transcript} liveBusy={liveBusy} hideNav />
+      <UsageFoot agentId={agent.id} />
+    </aside>
+  );
+}
+
+/** Context/token usage for the session. The custom view shows this in the
+ *  composer foot, which native has no equivalent of — so without it here, cost
+ *  stays invisible in native even though the store already has it (usage is
+ *  folded from the same transcript records this rail renders). */
+function UsageFoot({ agentId }: { agentId: string }) {
+  const usage = useAppStore((s) => s.usage[agentId]);
+  const show = useAppStore((s) => s.features.tokenUsage);
+  if (!show || !usage || !hasUsage(usage)) return null;
+  return (
+    <div className="native-rail-foot flex-center">
+      <UsageMeter usage={usage} />
+    </div>
+  );
+}

--- a/src/components/Workspace/WorkspaceHeader.tsx
+++ b/src/components/Workspace/WorkspaceHeader.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef } from "react";
 import type { AgentRecord, AgentStatus, DiffStats } from "@/api";
 import { Icon } from "@/components/Icon";
 import { IconButton } from "@/components/ui/IconButton";
@@ -42,9 +41,9 @@ interface Props {
 export function WorkspaceHeader({ agent }: Props) {
   const switchView = useAppStore((s) => s.switchView);
   const switchInFlight = useAppStore((s) => s.switchInFlight[agent.id]);
-  // Native view is gated behind an experimental flag. While it's off, hide the
-  // switcher entirely; and if an agent was left in native mode when the flag
-  // flipped off, pull it back to the custom view so it can't get stranded.
+  // Native view is gated behind an experimental flag: while it's off the
+  // switcher is hidden, and Workspace renders any native-mode agent as chat so
+  // it can't get stranded behind a missing toggle.
   const nativeView = useAppStore((s) => s.features.nativeView);
   const leftCollapsed = useAppStore((s) => s.leftCollapsed);
   const rightCollapsed = useAppStore((s) => s.rightCollapsed);
@@ -61,22 +60,6 @@ export function WorkspaceHeader({ agent }: Props) {
   // diffstat and age (`+0 -0 · now`).
   const branch = agent.repos[0]?.branch ?? null;
   const age = formatAge(agent.created_at, now);
-
-  // Guard against an unbounded retry loop: switchInFlight is a dep, so a failed
-  // switch (view stays "native", switchInFlight falls back to false) would
-  // otherwise re-fire the effect forever. Attempt the forced switch at most
-  // once per agent; reset the guard once it's no longer stranded (the switch
-  // landed, or native got re-enabled) so a later off-flip can try again.
-  const forcedCustomFor = useRef<string | null>(null);
-  useEffect(() => {
-    if (nativeView || agent.view !== "native") {
-      forcedCustomFor.current = null;
-      return;
-    }
-    if (switchInFlight || forcedCustomFor.current === agent.id) return;
-    forcedCustomFor.current = agent.id;
-    void switchView(agent.id, "custom");
-  }, [nativeView, agent.view, agent.id, switchInFlight, switchView]);
 
   return (
     <div className="center-h flex-center">

--- a/src/components/Workspace/WorkspaceHeader.tsx
+++ b/src/components/Workspace/WorkspaceHeader.tsx
@@ -45,6 +45,8 @@ export function WorkspaceHeader({ agent }: Props) {
   // switcher is hidden, and Workspace renders any native-mode agent as chat so
   // it can't get stranded behind a missing toggle.
   const nativeView = useAppStore((s) => s.features.nativeView);
+  const railOpen = useAppStore((s) => s.transcriptRailOpen);
+  const toggleRail = useAppStore((s) => s.toggleTranscriptRail);
   const leftCollapsed = useAppStore((s) => s.leftCollapsed);
   const rightCollapsed = useAppStore((s) => s.rightCollapsed);
   const toggleLeft = useAppStore((s) => s.toggleLeft);
@@ -98,6 +100,18 @@ export function WorkspaceHeader({ agent }: Props) {
           nativeDisabled={!agent.session_id}
           nativeReason="Available after the agent's first turn"
         />
+      )}
+
+      {/* Only meaningful while the terminal is on screen — in the custom view
+          the transcript IS the pane. */}
+      {nativeView && agent.view === "native" && (
+        <IconButton
+          active={railOpen}
+          tip={railOpen ? "Hide transcript" : "Show transcript"}
+          onClick={toggleRail}
+        >
+          <Icon name="sparkle" />
+        </IconButton>
       )}
 
       <ForkMenu

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -26,6 +26,7 @@ export function Workspace() {
   const leftCollapsed = useAppStore((s) => s.leftCollapsed);
   const toggleLeft = useAppStore((s) => s.toggleLeft);
   const missionControl = useAppStore((s) => s.features.missionControl);
+  const nativeView = useAppStore((s) => s.features.nativeView);
 
   const draft = activeDraftId ? drafts.find((d) => d.id === activeDraftId) : null;
   // Only surface the draft while its repo is still pinned; a draft stranded on a
@@ -66,7 +67,16 @@ export function Workspace() {
       <WorkspaceHeader agent={agent} />
       {agent.status === "error" && <CrashBanner agent={agent} />}
       <SyncHealthBanner agentId={agent.id} />
-      {agent.view === "native" ? <NativeBody agent={agent} /> : <ChatView agent={agent} />}
+      {/* The flag gates the *presentation*, not the record: an agent left in
+          native mode when the flag flips off renders as chat (its transcript
+          is synced either way) instead of being force-switched, which would
+          kill and respawn its process — and could resurrect a stopped one.
+          Flipping the flag back on restores the terminal. */}
+      {agent.view === "native" && nativeView ? (
+        <NativeBody agent={agent} />
+      ) : (
+        <ChatView agent={agent} />
+      )}
     </div>
   );
 }
@@ -200,7 +210,7 @@ function SyncHealthBanner({ agentId }: { agentId: string }) {
 
 function NativeBody({ agent }: { agent: AgentRecord }) {
   return (
-    <div className="chat" style={{ background: "#1a1c20" }}>
+    <div className="chat">
       <NativeView agent={agent} />
     </div>
   );

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -11,6 +11,7 @@ import { EmptyWorkspace } from "./EmptyWorkspace";
 import { Home } from "./Home";
 import { MissionControl } from "./MissionControl";
 import { NativeView } from "./NativeView";
+import { TranscriptRail } from "./TranscriptRail";
 import { WorkspaceHeader } from "./WorkspaceHeader";
 
 /** Center pane orchestrator. Decides whether to show: a draft empty
@@ -208,10 +209,19 @@ function SyncHealthBanner({ agentId }: { agentId: string }) {
   );
 }
 
+/** Native view body: the agent's TUI, with the structured transcript rail
+ *  optionally docked beside it. The terminal is the live surface you type into;
+ *  the rail is the inspector (tool cards, turn footers, cost) that the raw
+ *  terminal can't give you. */
 function NativeBody({ agent }: { agent: AgentRecord }) {
+  const railOpen = useAppStore((s) => s.transcriptRailOpen);
+  const toggleRail = useAppStore((s) => s.toggleTranscriptRail);
   return (
-    <div className="chat">
-      <NativeView agent={agent} />
+    <div className="chat native-split">
+      <div className="native-term">
+        <NativeView agent={agent} />
+      </div>
+      {railOpen && <TranscriptRail agent={agent} onClose={toggleRail} />}
     </div>
   );
 }

--- a/src/components/Workspace/messages/TranscriptList.tsx
+++ b/src/components/Workspace/messages/TranscriptList.tsx
@@ -1,0 +1,120 @@
+// The scrolling transcript itself: rows, turn footers, bottom-pinning, and the
+// turn navigator. Shared by the custom view's ChatView (which stacks a composer
+// under it) and the native view's rail (which sits beside the terminal).
+import { Fragment, type MutableRefObject, useEffect, useRef } from "react";
+import type { AgentRecord } from "@/api";
+import { Loader } from "@/components/ui/Loader";
+import { providerLabel } from "@/data/providers";
+import { ChatNav } from "../ChatNav";
+import { TurnFooter } from "../RunTimer";
+import { MessageItem } from "./MessageItem";
+import { rowKey } from "./pair";
+import type { Transcript } from "./useTranscript";
+
+interface Props {
+  agent: AgentRecord;
+  transcript: Transcript;
+  /** The agent is mid-turn: rows in the open turn may show a live spinner. */
+  liveBusy: boolean;
+  /** Quiet inline anchor for a just-sent first prompt with nothing back yet. */
+  pending?: boolean;
+  /** Lifted so a parent can wire find-in-conversation to the same container.
+   *  Omit and the list owns its own ref. */
+  scrollRef?: MutableRefObject<HTMLDivElement | null>;
+  /** Lifted bottom-pin flag, so a parent that sends a message can re-pin the
+   *  log to the bottom the way an in-list scroll would. */
+  pinRef?: MutableRefObject<boolean>;
+  /** Suppress the turn navigator — while find-in-conversation is open (it owns
+   *  that corner), or in the native rail, which is too narrow for it. */
+  hideNav?: boolean;
+}
+
+export function TranscriptList({
+  agent,
+  transcript,
+  liveBusy,
+  pending,
+  scrollRef,
+  pinRef,
+  hideNav,
+}: Props) {
+  const { items, turns, turnIds, turnFooters, openTurnStart, transcriptLoading, log } = transcript;
+
+  const ownRef = useRef<HTMLDivElement | null>(null);
+  const ref = scrollRef ?? ownRef;
+
+  // Whether the log is "pinned" to the bottom. While true we follow new
+  // messages; once the user scrolls up we stop auto-scrolling and leave their
+  // position alone until they scroll back down to the bottom.
+  const ownPin = useRef(true);
+  const pinnedToBottom = pinRef ?? ownPin;
+
+  // Re-pin whenever we switch agents, so each conversation opens at its latest.
+  useEffect(() => {
+    pinnedToBottom.current = true;
+  }, [agent.id, pinnedToBottom]);
+
+  const handleScroll = () => {
+    const el = ref.current;
+    if (!el) return;
+    // Allow a small slop so the user counts as "at the bottom" even a few
+    // pixels short — sub-pixel rounding otherwise makes exact equality flaky.
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    pinnedToBottom.current = distanceFromBottom <= 40;
+  };
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `log` is the change
+  // signal rather than a value the body reads — new content arriving is exactly
+  // when a bottom-pinned log has to follow.
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    if (transcriptLoading) return;
+    if (!pinnedToBottom.current) return;
+    el.scrollTop = el.scrollHeight;
+  }, [log, transcriptLoading, ref, pinnedToBottom]);
+
+  return (
+    <div className="chat-scroll-wrap">
+      <div className="chat-scroll" ref={ref} onScroll={handleScroll}>
+        <div className="chat-inner fade-in" key={agent.id}>
+          {transcriptLoading && items.length === 0 ? (
+            <div className="writing flex-center">
+              <Loader variant="accent" />
+              <span>Loading transcript…</span>
+            </div>
+          ) : items.length === 0 && transcript.hasPriorConversation && !liveBusy ? (
+            <div className="empty-msg" style={{ margin: "40px auto", maxWidth: 360 }}>
+              <div className="et">No transcript available</div>
+              <div>
+                {providerLabel(agent.provider)}'s session file is not on disk for this agent.
+              </div>
+            </div>
+          ) : (
+            items.map((item, i) => {
+              const footer = turnFooters[i];
+              return (
+                <Fragment key={rowKey(item, i)}>
+                  <MessageItem
+                    item={item}
+                    provider={agent.provider}
+                    agentId={agent.id}
+                    busy={liveBusy && i >= openTurnStart}
+                    turnId={turnIds[i]}
+                  />
+                  {footer != null && <TurnFooter {...footer} agentId={agent.id} />}
+                </Fragment>
+              );
+            })
+          )}
+          {pending && (
+            <div className="chat-pending" aria-hidden="true">
+              <Loader variant="muted" size="md" />
+            </div>
+          )}
+        </div>
+      </div>
+      {!hideNav && <ChatNav scrollRef={ref} turns={turns} />}
+    </div>
+  );
+}

--- a/src/components/Workspace/messages/useTranscript.ts
+++ b/src/components/Workspace/messages/useTranscript.ts
@@ -1,0 +1,179 @@
+// Everything derived from an agent's chat log, in one place: the lazy history
+// load, the display-policy + tool-pairing pass, and the per-turn bookkeeping
+// (navigable prompts, closing footers, which turn is open).
+//
+// Extracted from ChatView so the native view's transcript rail renders the
+// identical log from the identical derivation — the two surfaces differ only in
+// chrome, and a second copy of this logic would drift.
+import { useEffect, useMemo, useRef } from "react";
+import { applyPolicy, getAdapter } from "@/adapters";
+import type { AgentRecord } from "@/api";
+import { APP_ACTION_PREFIX } from "@/components/RightPanel/delegation";
+import { useAppStore } from "@/store";
+import { stripInjectedInstructions } from "@/util/instructions";
+import type { ChatTurn } from "../ChatNav";
+import { type PairCache, pairToolItems, type ViewItem } from "./pair";
+import { isUserInputTool } from "./UserInput/parse";
+
+/** A turn's closing footer: how long it ran, its settled prose (for copy), and
+ *  its ordinal among navigable prompts (the fork cutoff). */
+export interface TurnFooterData {
+  runSec: number;
+  copyText: string;
+  turnOrdinal: number;
+}
+
+export interface Transcript {
+  items: ViewItem[];
+  turns: ChatTurn[];
+  /** Parallel to `items`: the navigable-turn ordinal for user prompts. */
+  turnIds: (number | undefined)[];
+  /** Parallel to `items`: a footer at each *ended* turn's last row. */
+  turnFooters: (TurnFooterData | null)[];
+  /** Index where the currently-open turn begins. Only rows at or after it may
+   *  show a live spinner, so a dangling tool_call from an interrupted earlier
+   *  turn can't light up when a later turn goes busy. */
+  openTurnStart: number;
+  /** Persisted start of the open turn, for the live timer after a reload. */
+  openTurnStartedAt: number | undefined;
+  /** Model the agent actually used most recently; undefined for providers that
+   *  don't report it, or before the first turn. */
+  activeModel: string | undefined;
+  /** The last row is an unanswered user-input widget — the agent is waiting on
+   *  the user, not working, so the "is thinking" spinner must be suppressed. */
+  awaitingInput: boolean;
+  transcriptLoading: boolean;
+  /** The agent has history worth loading (distinguishes "empty new session"
+   *  from "transcript missing on disk"). */
+  hasPriorConversation: boolean;
+  /** Raw log identity — a stable dep for scroll-to-bottom effects. */
+  log: unknown;
+}
+
+export function useTranscript(agent: AgentRecord): Transcript {
+  const log = useAppStore((s) => s.managedLogs[agent.id]);
+  const transcriptLoading = useAppStore((s) => s.transcriptLoading[agent.id] ?? false);
+  const transcriptLoaded = useAppStore((s) => s.transcriptLoaded[agent.id] ?? false);
+  const switchInFlight = useAppStore((s) => s.switchInFlight[agent.id] ?? false);
+  const loadHistoryTranscript = useAppStore((s) => s.loadHistoryTranscript);
+
+  const hasSession = Boolean(agent.session_id);
+  const hasPriorConversation = agent.task.trim().length > 0;
+
+  useEffect(() => {
+    if (!hasSession || transcriptLoaded || transcriptLoading || switchInFlight) {
+      return;
+    }
+    if (log !== undefined || !hasPriorConversation) {
+      return;
+    }
+    void loadHistoryTranscript(agent.id);
+  }, [
+    agent.id,
+    hasSession,
+    hasPriorConversation,
+    loadHistoryTranscript,
+    log,
+    switchInFlight,
+    transcriptLoaded,
+    transcriptLoading,
+  ]);
+
+  // Persist tool_pair wrapper identity across renders so memoized rows survive
+  // streaming deltas (see PairCache). Self-evicts stale ids each pass, so it
+  // needs no reset when switching agents (tool-use ids never collide).
+  const pairCache = useRef<PairCache>(new Map());
+
+  const items = useMemo(() => {
+    const adapter = getAdapter(agent.provider);
+    const visible = applyPolicy(log ?? [], adapter.policy);
+    return pairToolItems(visible, pairCache.current);
+  }, [log, agent.provider]);
+
+  // Navigable turns = the real user prompts (git-action chips excluded). Each
+  // gets a stable ordinal that maps an item to its `data-chat-turn` marker, so
+  // ChatNav can jump straight to any bubble.
+  const { turns, turnIds } = useMemo(() => {
+    const turns: ChatTurn[] = [];
+    const turnIds = items.map((it) => {
+      if (it.kind !== "user_message" || it.text.startsWith(APP_ACTION_PREFIX)) {
+        return undefined;
+      }
+      const id = turns.length;
+      turns.push({ id, text: stripInjectedInstructions(it.text) });
+      return id;
+    });
+    return { turns, turnIds };
+  }, [items]);
+
+  // Footer closing each *ended* turn (border + "Ran …" + copy), placed at the
+  // turn's last item — the seam before the next turn. Gated on the same
+  // turn-end signal as the duration, so it only appears once the turn finishes;
+  // the open turn (started, not ended) carries no footer, just its live timer
+  // on the working strip.
+  const { turnFooters, openTurnStartedAt } = useMemo(() => {
+    const footers: (TurnFooterData | null)[] = items.map(() => null);
+    let openStart: number | undefined;
+    const starts: number[] = [];
+    items.forEach((it, i) => {
+      if (it.kind === "user_message" && !it.text.startsWith(APP_ACTION_PREFIX)) starts.push(i);
+    });
+    starts.forEach((startIdx, k) => {
+      const start = items[startIdx];
+      if (start.kind !== "user_message" || start.startedAt == null) return;
+      const endExclusive = k + 1 < starts.length ? starts[k + 1] : items.length;
+      if (start.endedAt == null) {
+        openStart = start.startedAt; // turn still running
+        return;
+      }
+      // The agent's settled prose for this turn — what "copy" yields.
+      const texts: string[] = [];
+      for (let j = startIdx; j < endExclusive; j += 1) {
+        const it = items[j];
+        if (it.kind === "agent_message" && !it.streaming && it.text) texts.push(it.text);
+      }
+      footers[endExclusive - 1] = {
+        runSec: (start.endedAt - start.startedAt) / 1000,
+        copyText: texts.join("\n\n"),
+        turnOrdinal: k,
+      };
+    });
+    return { turnFooters: footers, openTurnStartedAt: openStart };
+  }, [items]);
+
+  const activeModel = useMemo(() => {
+    for (let i = items.length - 1; i >= 0; i -= 1) {
+      const it = items[i];
+      if (it.kind === "agent_message" && it.model) return it.model;
+    }
+    return undefined;
+  }, [items]);
+
+  const awaitingInput = useMemo(() => {
+    const last = items[items.length - 1];
+    return Boolean(
+      last && last.kind === "tool_pair" && isUserInputTool(last.call.name) && !last.result,
+    );
+  }, [items]);
+
+  const openTurnStart = useMemo(() => {
+    for (let i = items.length - 1; i >= 0; i -= 1) {
+      if (items[i].kind === "user_message") return i;
+    }
+    return 0;
+  }, [items]);
+
+  return {
+    items,
+    turns,
+    turnIds,
+    turnFooters,
+    openTurnStart,
+    openTurnStartedAt,
+    activeModel,
+    awaitingInput,
+    transcriptLoading,
+    hasPriorConversation,
+    log,
+  };
+}

--- a/src/components/ui/TerminalSearch.tsx
+++ b/src/components/ui/TerminalSearch.tsx
@@ -1,0 +1,102 @@
+// Find-in-terminal for any xterm surface. Owns the SearchAddon, the ⌘/Ctrl+F
+// interception (so the chord opens this bar instead of reaching the PTY as raw
+// bytes), and the bar itself — consumers wire two lines: call `attach` from
+// their `useXterm` onReady, and render `bar` above the terminal slot.
+import { SearchAddon } from "@xterm/addon-search";
+import type { Terminal } from "@xterm/xterm";
+import { useCallback, useRef, useState } from "react";
+import { Icon } from "@/components/Icon";
+import { IconButton } from "@/components/ui/IconButton";
+
+type Direction = "next" | "prev";
+
+export function useTerminalSearch() {
+  const addonRef = useRef<SearchAddon | null>(null);
+  const termRef = useRef<Terminal | null>(null);
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  /** Load the addon onto a freshly-mounted terminal. Returns the disposer the
+   *  caller folds into its own `onReady` cleanup. */
+  const attach = useCallback((term: Terminal) => {
+    const addon = new SearchAddon();
+    term.loadAddon(addon);
+    addonRef.current = addon;
+    termRef.current = term;
+    term.attachCustomKeyEventHandler((e) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "f" && e.type === "keydown") {
+        setOpen(true);
+        return false; // don't forward the chord to the PTY
+      }
+      return true;
+    });
+    return () => {
+      addonRef.current = null;
+      termRef.current = null;
+    };
+  }, []);
+
+  const find = useCallback((q: string, direction: Direction = "next") => {
+    if (!addonRef.current || !q) return;
+    if (direction === "next") addonRef.current.findNext(q);
+    else addonRef.current.findPrevious(q);
+  }, []);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setQuery("");
+    // Hand focus back so typing resumes in the terminal, not a dead input.
+    termRef.current?.focus();
+  }, []);
+
+  const bar = open ? (
+    <SearchBar
+      query={query}
+      onQueryChange={(q) => {
+        setQuery(q);
+        find(q);
+      }}
+      onFind={(d) => find(query, d)}
+      onClose={close}
+    />
+  ) : null;
+
+  return { attach, bar };
+}
+
+function SearchBar({
+  query,
+  onQueryChange,
+  onFind,
+  onClose,
+}: {
+  query: string;
+  onQueryChange: (q: string) => void;
+  onFind: (direction: Direction) => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="term-search flex-center">
+      <input
+        autoFocus
+        className="term-search-input"
+        placeholder="Find in terminal…"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") onFind(e.shiftKey ? "prev" : "next");
+          if (e.key === "Escape") onClose();
+        }}
+      />
+      <IconButton size="sm" tip="Previous (Shift+Enter)" onClick={() => onFind("prev")}>
+        <Icon name="chevU" />
+      </IconButton>
+      <IconButton size="sm" tip="Next (Enter)" onClick={() => onFind("next")}>
+        <Icon name="chevD" />
+      </IconButton>
+      <IconButton size="sm" tip="Close (Esc)" onClick={onClose}>
+        <Icon name="close" />
+      </IconButton>
+    </div>
+  );
+}

--- a/src/pty/buffers.ts
+++ b/src/pty/buffers.ts
@@ -3,8 +3,12 @@
 // xterm-backed views, so routing them through React state would be wasteful.
 //
 // Two parallel channels — the agent's own PTY and its side shell — each pair a
-// ring buffer (replayed when a view remounts after a tab/view switch) with an
-// optional live sink (the mounted view's writer).
+// ring buffer (replayed when a view mounts for the first time) with an optional
+// live sink (the view's writer).
+//
+// This module also owns the lifecycle of the live-terminal cache in
+// ./terminals, because "an agent's PTY state" is one thing: the ring buffer and
+// the terminal rendering it are cleared, reset and released together.
 
 export type OutputHandler = (bytes: Uint8Array) => void;
 
@@ -17,6 +21,27 @@ const outputBuffers = new Map<string, Uint8Array>();
 // ---- Side shell PTY -----------------------------------------------------------
 const shellSinks = new Map<string, OutputHandler>();
 const shellBuffers = new Map<string, Uint8Array>();
+
+// ---- Live terminal cache ------------------------------------------------------
+
+/** The bits of the ./terminals cache this module drives. */
+export interface TerminalCacheHooks {
+  /** Wipe a cached terminal's screen, keeping it cached and its sink live. */
+  reset: (agentId: string) => void;
+  /** Dispose a cached terminal for good. */
+  evict: (agentId: string) => void;
+}
+
+// Installed by ./terminals when it loads, rather than imported from here.
+// Importing xterm outside a browser throws (`self is not defined`), and the
+// store actions below flow into node-env tests — a registration keeps the
+// renderer out of that import graph. Absent until a terminal view has been
+// loaded, in which case there is nothing cached to clean up anyway.
+let terminalCache: TerminalCacheHooks | undefined;
+
+export function setTerminalCacheHooks(hooks: TerminalCacheHooks) {
+  terminalCache = hooks;
+}
 
 /** Append a chunk to an agent's ring buffer, trimming the oldest bytes once it
  *  grows past the cap so a long-lived session can't grow without bound. */
@@ -46,10 +71,32 @@ export function getOutputBuffer(agentId: string): Uint8Array | undefined {
   return outputBuffers.get(agentId);
 }
 
+/** Drop an agent's replay history because its PTY restarted (view switch,
+ *  resume). Any cached terminal is displaying exactly the history being
+ *  dropped, so wipe its screen too — otherwise the next mount would re-attach a
+ *  dead session's frame instead of the blank one a restart used to produce. */
 export function clearOutputBuffer(agentId: string) {
   outputBuffers.delete(agentId);
+  terminalCache?.reset(agentId);
 }
 
+/** Release everything held for an agent that is gone (discarded, archived).
+ *  Nothing else clears `shellBuffers` or the terminal cache, so without this
+ *  both grow for the life of the app session. */
+export function dropAgentPty(agentId: string) {
+  outputBuffers.delete(agentId);
+  shellBuffers.delete(agentId);
+  outputSinks.delete(agentId);
+  shellSinks.delete(agentId);
+  terminalCache?.evict(agentId);
+}
+
+/** Point an agent's live output at `handler`, replacing any previous one — a
+ *  single sink per agent, by design. The owner is the agent's cached `Terminal`
+ *  (see ./terminals), not the React view: it registers when the terminal is
+ *  created and unregisters when the terminal is disposed, so an unmounted
+ *  native view keeps feeding its cached screen in the background and no second
+ *  view can ever be contending for the same slot. */
 export function registerOutputSink(agentId: string, handler: OutputHandler): () => void {
   outputSinks.set(agentId, handler);
   return () => {

--- a/src/pty/terminals.ts
+++ b/src/pty/terminals.ts
@@ -1,0 +1,145 @@
+// A cache of live xterm `Terminal`s, one per cached surface (today: each
+// agent's native TUI), kept alive while its React view is unmounted.
+//
+// The native view used to dispose its Terminal on every agent switch and
+// rebuild the screen by replaying the 256 KB ring buffer in ./buffers. That
+// slab is cut at an arbitrary byte offset, so the replay begins mid ANSI escape
+// sequence, mid UTF-8 codepoint and mid TUI frame — and a TUI's redraws blow
+// past 256 KB in seconds, so the cut was the rule rather than the exception:
+// re-selecting an agent painted garbage until the TUI happened to repaint. The
+// rebuilt Terminal also started at xterm's default 80x24 while the PTY was
+// still at its last fitted size, so the replay reflowed against the wrong
+// width before FitAddon caught up a frame later.
+//
+// Re-parenting a still-live Terminal instead means there is nothing to replay
+// and nothing to corrupt: the screen is already correct and already the right
+// size. xterm cooperates — its renderer pauses on an IntersectionObserver while
+// the element is out of the tree and does a full refresh when it comes back.
+
+import { FitAddon } from "@xterm/addon-fit";
+import { WebglAddon } from "@xterm/addon-webgl";
+import { type ITerminalOptions, Terminal } from "@xterm/xterm";
+import { setTerminalCacheHooks } from "./buffers";
+
+export interface LiveTerminal {
+  term: Terminal;
+  fit: FitAddon;
+  /** The element `term` was `open()`ed into, exactly once. xterm offers no way
+   *  to re-open a Terminal into a different element without rebuilding its DOM,
+   *  so mounting moves THIS node into the visible slot and unmounting detaches
+   *  it again. */
+  host: HTMLDivElement;
+  /** Absent when the WebGL context couldn't be created (DOM renderer in use). */
+  webgl?: WebglAddon;
+  /** Teardown for the owner's terminal-lifetime wiring (output sink, PTY
+   *  listeners). Runs on disposal only, never on unmount — that is what keeps a
+   *  cached terminal's sink registered so a background agent's screen stays
+   *  current and needs no replay when it is selected again. */
+  teardown?: () => void;
+}
+
+const cache = new Map<string, LiveTerminal>();
+
+/** Cache key for an agent's native TUI terminal. Namespaced so another cached
+ *  surface for the same agent (e.g. its side shell) can never collide with it. */
+export const nativeTerminalKey = (agentId: string) => `native:${agentId}`;
+
+/** Build a Terminal + FitAddon (+ WebGL renderer when available) inside a host
+ *  element appended to `parent`.
+ *
+ *  The host is created here rather than opening straight into `parent` because
+ *  a cached terminal outlives the React element it was first mounted in: the
+ *  one and only `open()` has to target a node we own and can move. It is
+ *  appended BEFORE `open()` — xterm measures cell size at open time and a
+ *  detached element measures zero. */
+export function createTerminal(parent: HTMLElement, options: ITerminalOptions): LiveTerminal {
+  const host = document.createElement("div");
+  // Fill the slot exactly. FitAddon derives cols/rows from the terminal
+  // element's parent, so a host that didn't fill would mis-size the PTY.
+  host.style.cssText = "position:absolute;inset:0";
+  parent.appendChild(host);
+
+  const term = new Terminal(options);
+  const fit = new FitAddon();
+  term.loadAddon(fit);
+  term.open(host);
+
+  // GPU renderer: positions cells on exact device pixels. The default DOM
+  // renderer rasterizes the last column short on fractional cell widths
+  // (e.g. 7.42px @ dpr 2), clipping the rightmost glyph. Fall back to the
+  // DOM renderer if the WebGL context is unavailable or gets lost.
+  let webgl: WebglAddon | undefined;
+  try {
+    webgl = new WebglAddon();
+    webgl.onContextLoss(() => webgl?.dispose());
+    term.loadAddon(webgl);
+  } catch {
+    // WebGL unavailable — DOM renderer remains in use
+  }
+
+  return { term, fit, host, webgl };
+}
+
+/** Tear a terminal down for good, owner wiring included. */
+export function disposeTerminal(entry: LiveTerminal) {
+  entry.host.remove();
+  entry.teardown?.();
+  // Dispose the WebGL renderer BEFORE the terminal. Tearing it down after the
+  // core is gone dereferences a disposed _core._store and throws (React
+  // StrictMode's dev mount→unmount cycle triggers this every time). Guarded so
+  // the terminal's own addon disposal can't double-free it.
+  try {
+    entry.webgl?.dispose();
+  } catch {
+    /* already disposed */
+  }
+  entry.term.dispose();
+}
+
+/** Get the terminal cached under `key`, re-parented into `parent`, or create
+ *  and cache a new one there. The re-attach path is the point of this module:
+ *  no rebuild, no replay, same pixels.
+ *
+ *  `created` tells the caller whether the one-time wiring still has to run —
+ *  false on a re-attach, and false on the second half of StrictMode's dev
+ *  mount→unmount→mount, which is what keeps that cycle from registering
+ *  duplicate listeners. */
+export function acquireTerminal(
+  key: string,
+  parent: HTMLElement,
+  options: ITerminalOptions,
+): { entry: LiveTerminal; created: boolean } {
+  const existing = cache.get(key);
+  if (existing) {
+    parent.appendChild(existing.host);
+    return { entry: existing, created: false };
+  }
+  const entry = createTerminal(parent, options);
+  cache.set(key, entry);
+  return { entry, created: true };
+}
+
+/** Wipe a cached native terminal's screen in place, keeping it cached and its
+ *  output sink registered. Called when the agent's PTY restarts (view switch,
+ *  resume) and its replay history is dropped: the live terminal is showing that
+ *  very history, so leaving it would re-attach a dead session's frame on the
+ *  next mount. `reset()` clears buffer, scrollback and modes without touching
+ *  the DOM or the fitted geometry. */
+function resetAgentTerminal(agentId: string) {
+  cache.get(nativeTerminalKey(agentId))?.term.reset();
+}
+
+/** Dispose an agent's cached native terminal — the agent is gone. */
+function evictAgentTerminal(agentId: string) {
+  const key = nativeTerminalKey(agentId);
+  const entry = cache.get(key);
+  if (!entry) return;
+  cache.delete(key);
+  disposeTerminal(entry);
+}
+
+// Hand the cache's lifecycle to ./buffers rather than have the store call in
+// here: importing xterm outside a browser throws (`self is not defined`), and
+// the store actions that clear an agent's PTY state are exercised in node-env
+// tests. Registering keeps xterm out of that import graph entirely.
+setTerminalCacheHooks({ reset: resetAgentTerminal, evict: evictAgentTerminal });

--- a/src/storage/preferences.ts
+++ b/src/storage/preferences.ts
@@ -8,7 +8,6 @@ import { DEFAULT_PROVIDER_ID } from "@/data/providers";
 // ---- Appearance & feature-flag types -----------------------------------------
 
 export type ThemeMode = "dark" | "light";
-export type WorkspaceView = "custom" | "native";
 export type SettingsSection =
   | "general"
   | "account"

--- a/src/store/appearance.ts
+++ b/src/store/appearance.ts
@@ -1,9 +1,4 @@
-import {
-  DEFAULT_FEATURES,
-  type FeatureFlags,
-  type ThemeMode,
-  type WorkspaceView,
-} from "@/storage/preferences";
+import { DEFAULT_FEATURES, type FeatureFlags, type ThemeMode } from "@/storage/preferences";
 import { setSetting } from "@/storage/settings";
 import type { SliceCreator } from "./types";
 
@@ -22,10 +17,6 @@ export interface AppearanceSlice {
   /** Send a native OS notification when an agent turn finishes or needs input
    *  while you're not watching that chat. Opt-out. */
   notifyEnabled: boolean;
-  /** View mode preference for the workspace pane. Persisted; falls
-   *  back to the agent's own `view` field for native vs. custom
-   *  switching. */
-  viewMode: WorkspaceView;
 
   // appearance
   setTheme: (t: ThemeMode) => void;
@@ -34,7 +25,6 @@ export interface AppearanceSlice {
   setFeature: <K extends keyof FeatureFlags>(k: K, v: FeatureFlags[K]) => void;
   setSoundEnabled: (on: boolean) => void;
   setNotifyEnabled: (on: boolean) => void;
-  setViewMode: (v: WorkspaceView) => void;
 }
 
 export const createAppearanceSlice: SliceCreator<AppearanceSlice> = (set) => ({
@@ -44,7 +34,6 @@ export const createAppearanceSlice: SliceCreator<AppearanceSlice> = (set) => ({
   features: DEFAULT_FEATURES,
   soundEnabled: true,
   notifyEnabled: true,
-  viewMode: "custom" as WorkspaceView,
 
   // ── appearance ──────────────────────────────────────────────────────────────
   setTheme: (t) => {
@@ -72,9 +61,5 @@ export const createAppearanceSlice: SliceCreator<AppearanceSlice> = (set) => ({
   setNotifyEnabled: (on) => {
     set({ notifyEnabled: on });
     setSetting("notifyEnabled", String(on));
-  },
-  setViewMode: (v) => {
-    set({ viewMode: v });
-    setSetting("viewMode", v);
   },
 });

--- a/src/store/discardRestore.test.ts
+++ b/src/store/discardRestore.test.ts
@@ -19,7 +19,7 @@ const { discardAgent, restoreAgent, archiveAgent, getWorkspace } = vi.hoisted(()
 vi.mock("@/api", () => ({
   api: { discardAgent, restoreAgent, archiveAgent, getWorkspace },
 }));
-vi.mock("@/pty/buffers", () => ({ clearOutputBuffer: vi.fn() }));
+vi.mock("@/pty/buffers", () => ({ clearOutputBuffer: vi.fn(), dropAgentPty: vi.fn() }));
 
 import type { AppState } from "./types";
 import { createWorkspaceSlice } from "./workspace";

--- a/src/store/drafts.ts
+++ b/src/store/drafts.ts
@@ -263,7 +263,10 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
     set({ busy: true, lastError: null });
     const turnId = crypto.randomUUID();
     try {
-      const view = get().viewMode;
+      // Every agent starts in the custom view. Native is entered per agent via
+      // the header toggle, never as a spawn default — a per-turn provider has
+      // no session id before its first turn, and the backend's native path
+      // requires one, so a native spawn would fail and tear the checkout down.
       // Resolve the selected custom agent's standing brief. Snapshotted at spawn
       // (passed by value, not by id) so the running agent is unaffected if the
       // custom agent is later edited or deleted. Empty/blank instructions inject
@@ -288,10 +291,9 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
       // A bodied provider command (codex prompt) expands app-side: `codex
       // exec` takes the prompt as a positional arg and never resolves
       // `/name`. Skills win name clashes (resolved above, mirroring the
-      // menu's precedence), and the native view is exempt — the provider's
-      // own TUI expands the typed command there. Discovery is awaited so a
-      // spawn typed straight into a fresh composer still sees disk prompts.
-      if (view === "custom" && !invocation && text.startsWith("/")) {
+      // menu's precedence). Discovery is awaited so a spawn typed straight
+      // into a fresh composer still sees disk prompts.
+      if (!invocation && text.startsWith("/")) {
         await discoverCommands(provider, draft.repoPath);
         prompt = expandSlashCommand(provider, text, draft.repoPath) ?? prompt;
       }
@@ -306,7 +308,7 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
       // spawn (claude reads it as `--effort`; per-turn agents re-read it from
       // the record on each turn), so it never rides individual messages.
       const rec = await api.spawnAgent(
-        view,
+        "custom",
         draft.repoPath,
         provider,
         draft.name,
@@ -324,9 +326,9 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
         // closes it (backend appends `Closes #N` to the primary repo's PR).
         draft.issueRef,
       );
-      // Apply the selection, draft cleanup and custom-view log seed immediately,
-      // ahead of the guarded workspace refresh, so this user-intent state can
-      // never be dropped if a concurrent refresh supersedes ours.
+      // Apply the selection, draft cleanup and log seed immediately, ahead of
+      // the guarded workspace refresh, so this user-intent state can never be
+      // dropped if a concurrent refresh supersedes ours.
       set((state) => {
         const { [id]: _droppedDraft, ...restComposerDrafts } = state.composerDrafts;
         const patches: Partial<AppState> = {
@@ -334,28 +336,20 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
           drafts: state.drafts.filter((d) => d.id !== id),
           activeDraftId: null,
           composerDrafts: restComposerDrafts,
-        };
-        if (view === "custom") {
-          patches.managedLogs = {
+          managedLogs: {
             ...state.managedLogs,
             [rec.id]: [
               attachments.length > 0
                 ? { kind: "user_message", text: prompt, attachments }
                 : { kind: "user_message", text: prompt },
             ],
-          };
-          patches.managedBusy = { ...state.managedBusy, [rec.id]: true };
-        }
+          },
+          managedBusy: { ...state.managedBusy, [rec.id]: true },
+        };
         return patches;
       });
       await refreshWorkspace(set);
-      if (view === "native") {
-        await sendWhenAgentReady(() =>
-          api.writeToAgent(rec.id, `${prompt.replace(/\r?\n/g, " ")}\r`),
-        );
-      } else {
-        await sendWhenAgentReady(() => api.sendUserMessage(rec.id, turnId, prompt, attachments));
-      }
+      await sendWhenAgentReady(() => api.sendUserMessage(rec.id, turnId, prompt, attachments));
     } catch (e) {
       const selected = get().selectedAgentId;
       set((state) => ({

--- a/src/store/eventListeners.ts
+++ b/src/store/eventListeners.ts
@@ -125,6 +125,8 @@ export const hydrateSettings = async (set: AppSet) => {
       newDraftModel,
       newDraftCustomAgentId,
       lastRepoPath: s.lastRepoPath || undefined,
+      // Opt-out: only an explicit "false" hides the native view's rail.
+      transcriptRailOpen: s.transcriptRailOpen !== "false",
       gitCommitAction: isCommitAction(s.gitCommitAction) ? s.gitCommitAction : "agent-commit-pr",
       onboardingComplete: s.onboardingComplete === "true",
       // Telemetry is opt-out: only an explicit "false" disables it. The key is

--- a/src/store/eventListeners.ts
+++ b/src/store/eventListeners.ts
@@ -53,7 +53,6 @@ import {
   parseReviewDismissed,
   parseSandboxEngine,
   type ThemeMode,
-  type WorkspaceView,
 } from "@/storage/preferences";
 import { getAllSettings } from "@/storage/settings";
 import { recordUsageSnapshot } from "@/storage/usageDaily";
@@ -126,7 +125,6 @@ export const hydrateSettings = async (set: AppSet) => {
       newDraftModel,
       newDraftCustomAgentId,
       lastRepoPath: s.lastRepoPath || undefined,
-      viewMode: (s.viewMode as WorkspaceView) || "custom",
       gitCommitAction: isCommitAction(s.gitCommitAction) ? s.gitCommitAction : "agent-commit-pr",
       onboardingComplete: s.onboardingComplete === "true",
       // Telemetry is opt-out: only an explicit "false" disables it. The key is

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -46,6 +46,10 @@ export interface UiSlice {
   projectSettingsRepoPath: string | null;
   leftCollapsed: boolean;
   rightCollapsed: boolean;
+  /** Show the structured transcript rail beside the native view's terminal.
+   *  App-wide (not per agent): it's a way of working, not a property of one
+   *  session. Persisted. */
+  transcriptRailOpen: boolean;
   leftWidth: number;
   rightWidth: number;
   /** Last-open right-rail tab per agent, keyed by agent id. Lets the panel
@@ -82,6 +86,7 @@ export interface UiSlice {
   closeProjectSettings: () => void;
   toggleLeft: () => void;
   toggleRight: () => void;
+  toggleTranscriptRail: () => void;
   /** Live (in-memory) width update during a splitter drag. */
   setLeftWidth: (w: number) => void;
   setRightWidth: (w: number) => void;
@@ -109,6 +114,7 @@ export const createUiSlice: SliceCreator<UiSlice> = (set, get) => ({
   projectSettingsRepoPath: null,
   leftCollapsed: false,
   rightCollapsed: false,
+  transcriptRailOpen: true,
   leftWidth: DEFAULT_LEFT_WIDTH,
   rightWidth: DEFAULT_RIGHT_WIDTH,
   rightPanelTabs: {},
@@ -157,6 +163,12 @@ export const createUiSlice: SliceCreator<UiSlice> = (set, get) => ({
       const leftCollapsed = !s.leftCollapsed;
       setSetting("leftCollapsed", String(leftCollapsed));
       return { leftCollapsed };
+    }),
+  toggleTranscriptRail: () =>
+    set((s) => {
+      const transcriptRailOpen = !s.transcriptRailOpen;
+      setSetting("transcriptRailOpen", String(transcriptRailOpen));
+      return { transcriptRailOpen };
     }),
   toggleRight: () =>
     set((s) => {

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -22,7 +22,7 @@ import {
   sendWhenAgentReady,
   unsupportedManagedCommand,
 } from "@/helpers";
-import { clearOutputBuffer } from "@/pty/buffers";
+import { clearOutputBuffer, dropAgentPty } from "@/pty/buffers";
 import { recordUsageSnapshot } from "@/storage/usageDaily";
 import { forkContextDigest } from "./forkDigest";
 import { interruptedAgents } from "./interrupted";
@@ -622,7 +622,9 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
   discard: async (id) => {
     try {
       await api.discardAgent(id);
-      clearOutputBuffer(id);
+      // The agent is gone for good: release its PTY state (both ring buffers
+      // and its cached live terminal) along with the store's side maps below.
+      dropAgentPty(id);
       // The discard has committed, so drop the agent optimistically: remove its
       // row from the workspace AND its side maps together, and clear the
       // selection. Editing the workspace here (not just the side maps) keeps the
@@ -670,7 +672,9 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
     }));
     try {
       await api.archiveAgent(id);
-      clearOutputBuffer(id);
+      // Archiving kills the agent's processes, so release its PTY state (both
+      // ring buffers and its cached live terminal); a restore starts fresh.
+      dropAgentPty(id);
       // Drop the agent's side maps ATOMICALLY with the post-commit snapshot that
       // archives (hides) the row, by folding the cleanup into the guarded
       // refresh. Unlike the sidebar's optimistic placeholder — which a stale,

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -23,7 +23,6 @@ import {
   unsupportedManagedCommand,
 } from "@/helpers";
 import { clearOutputBuffer } from "@/pty/buffers";
-import { setSetting } from "@/storage/settings";
 import { recordUsageSnapshot } from "@/storage/usageDaily";
 import { forkContextDigest } from "./forkDigest";
 import { interruptedAgents } from "./interrupted";
@@ -579,8 +578,6 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
       if (view === "custom") {
         await get().loadHistoryTranscript(id);
       }
-      set({ viewMode: view });
-      setSetting("viewMode", view);
     } catch (e) {
       set({ lastError: String(e) });
     } finally {

--- a/src/styles/shared/terminal.css
+++ b/src/styles/shared/terminal.css
@@ -5,6 +5,10 @@
   position: relative;
   flex: 1;
   min-height: 0;
+  /* Matches the resolved xterm background (--bg-1, see util/xtermTheme.ts) so
+     the host's inset gap reads as part of the terminal rather than as a frame
+     around it. */
+  background: var(--bg-1);
 }
 .xterm-host {
   position: absolute;

--- a/src/util/useXterm.ts
+++ b/src/util/useXterm.ts
@@ -1,7 +1,6 @@
-import { FitAddon } from "@xterm/addon-fit";
-import { WebglAddon } from "@xterm/addon-webgl";
-import { type ITerminalOptions, Terminal } from "@xterm/xterm";
+import type { ITerminalOptions, Terminal } from "@xterm/xterm";
 import { type DependencyList, useEffect, useRef } from "react";
+import { acquireTerminal, createTerminal, disposeTerminal } from "@/pty/terminals";
 import { resolveTheme } from "./xtermTheme";
 import "@xterm/xterm/css/xterm.css";
 
@@ -23,9 +22,8 @@ const XTERM_BASE_OPTIONS: ITerminalOptions = {
  *
  *  Callers wire their own data flow in `onReady`: load extra addons, replay
  *  buffered output, hook `onData`/`onResize`, register a sink, etc., and
- *  return a cleanup that the hook runs on unmount, before disposing the
- *  terminal. The whole lifecycle re-runs whenever `deps` change (e.g. a
- *  different agent id).
+ *  return a cleanup that the hook runs before disposing the terminal. The whole
+ *  lifecycle re-runs whenever `deps` change (e.g. a different agent id).
  *
  *  `hostOptions.autoFocus` (default true) focuses the terminal after mount.
  *  Read-only surfaces (e.g. a log view) pass false so mounting doesn't pull
@@ -35,14 +33,34 @@ const XTERM_BASE_OPTIONS: ITerminalOptions = {
  *  palette (`resolveTheme`) and re-resolves it live when the theme or accent
  *  changes, so no caller has to wire its own observer. A caller that passes
  *  `options.theme` pins its own palette and opts out of that reactivity.
+ *
+ *  `hostOptions.cacheKey` opts into the live-terminal cache (src/pty/terminals):
+ *  the `Terminal` outlives this component and is re-attached on the next mount
+ *  under the same key instead of being rebuilt. `onReady` then runs ONCE per
+ *  terminal rather than once per mount, and its cleanup runs at eviction — so
+ *  sinks and PTY listeners stay live in the background and nothing has to be
+ *  replayed on return. The key must be derived from the same values as `deps`,
+ *  or a dep change would re-attach the wrong terminal.
+ *
+ *  `hostOptions.onMount` is the per-MOUNT counterpart to `onReady`: it runs on
+ *  every mount, including a re-attach, and its cleanup runs on every unmount.
+ *  Anything holding this component instance's state belongs here rather than in
+ *  `onReady`, whose closure would otherwise be pinned to the first mount.
  */
 export function useXterm(
   options: ITerminalOptions,
   onReady: (term: Terminal) => (() => void) | undefined,
   deps: DependencyList,
-  hostOptions?: { autoFocus?: boolean },
+  hostOptions?: {
+    autoFocus?: boolean;
+    cacheKey?: string;
+    /** Per-mount wiring; see the note on `cacheKey` above. */
+    onMount?: (term: Terminal) => (() => void) | undefined;
+  },
 ) {
   const autoFocus = hostOptions?.autoFocus ?? true;
+  const cacheKey = hostOptions?.cacheKey;
+  const onMount = hostOptions?.onMount;
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -51,23 +69,17 @@ export function useXterm(
 
     // The app palette sits between the shared base and the caller's overrides,
     // so passing `theme` still wins (and pins it — see the observer below).
-    const term = new Terminal({ ...XTERM_BASE_OPTIONS, theme: resolveTheme(), ...options });
-    const fit = new FitAddon();
-    term.loadAddon(fit);
-    term.open(el);
+    const merged = { ...XTERM_BASE_OPTIONS, theme: resolveTheme(), ...options };
+    const { entry, created } =
+      cacheKey === undefined
+        ? { entry: createTerminal(el, merged), created: true }
+        : acquireTerminal(cacheKey, el, merged);
+    const { term, fit } = entry;
 
-    // GPU renderer: positions cells on exact device pixels. The default DOM
-    // renderer rasterizes the last column short on fractional cell widths
-    // (e.g. 7.42px @ dpr 2), clipping the rightmost glyph. Fall back to the
-    // DOM renderer if the WebGL context is unavailable or gets lost.
-    let webgl: WebglAddon | undefined;
-    try {
-      webgl = new WebglAddon();
-      webgl.onContextLoss(() => webgl?.dispose());
-      term.loadAddon(webgl);
-    } catch {
-      // WebGL unavailable — DOM renderer remains in use
-    }
+    // A cached terminal was built with whatever palette was current then, and
+    // its observer was disconnected while unmounted — so re-resolve on every
+    // mount or a theme flip that happened in the background would persist.
+    if (options.theme === undefined && !created) term.options.theme = resolveTheme();
 
     // Re-resolve the palette when the app flips dark↔light (a class swap on
     // <html>) or the accent changes (CSS vars set inline on the same element).
@@ -83,7 +95,12 @@ export function useXterm(
       });
     }
 
-    const cleanup = onReady(term);
+    // One-time wiring, keyed to the terminal rather than to this mount. A
+    // re-attach skips it: the listeners and output sink from the first mount
+    // are still attached — which is also what keeps StrictMode's dev
+    // mount→unmount→mount from registering a duplicate set.
+    if (created) entry.teardown = onReady(term);
+    const unmount = onMount?.(term);
 
     const initialFit = requestAnimationFrame(() => {
       try {
@@ -116,17 +133,17 @@ export function useXterm(
       if (resizeTimer) clearTimeout(resizeTimer);
       ro.disconnect();
       themeObserver?.disconnect();
-      cleanup?.();
-      // Dispose the WebGL renderer BEFORE the terminal. Tearing it down after
-      // the core is gone dereferences a disposed _core._store and throws
-      // (React StrictMode's dev mount→unmount cycle triggers this every time).
-      // Guarded so the terminal's own addon disposal can't double-free it.
-      try {
-        webgl?.dispose();
-      } catch {
-        /* already disposed */
+      unmount?.();
+      if (cacheKey === undefined) {
+        disposeTerminal(entry);
+        return;
       }
-      term.dispose();
+      // Cached: pull the host out of the tree but leave the terminal running.
+      // xterm's renderer pauses itself while detached and full-refreshes on
+      // re-attach, so the screen survives intact. Removing an already-removed
+      // node is a no-op, which covers an eviction that landed between this
+      // mount and this unmount.
+      entry.host.remove();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
     // biome-ignore lint/correctness/useExhaustiveDependencies: caller supplies the dep list

--- a/src/util/useXterm.ts
+++ b/src/util/useXterm.ts
@@ -2,6 +2,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { type ITerminalOptions, Terminal } from "@xterm/xterm";
 import { type DependencyList, useEffect, useRef } from "react";
+import { resolveTheme } from "./xtermTheme";
 import "@xterm/xterm/css/xterm.css";
 
 /** Options shared by every terminal in the app; callers override per use. */
@@ -29,6 +30,11 @@ const XTERM_BASE_OPTIONS: ITerminalOptions = {
  *  `hostOptions.autoFocus` (default true) focuses the terminal after mount.
  *  Read-only surfaces (e.g. a log view) pass false so mounting doesn't pull
  *  keyboard focus away from the editor.
+ *
+ *  Theming is owned here: every terminal in the app renders the current
+ *  palette (`resolveTheme`) and re-resolves it live when the theme or accent
+ *  changes, so no caller has to wire its own observer. A caller that passes
+ *  `options.theme` pins its own palette and opts out of that reactivity.
  */
 export function useXterm(
   options: ITerminalOptions,
@@ -43,7 +49,9 @@ export function useXterm(
     const el = containerRef.current;
     if (!el) return;
 
-    const term = new Terminal({ ...XTERM_BASE_OPTIONS, ...options });
+    // The app palette sits between the shared base and the caller's overrides,
+    // so passing `theme` still wins (and pins it — see the observer below).
+    const term = new Terminal({ ...XTERM_BASE_OPTIONS, theme: resolveTheme(), ...options });
     const fit = new FitAddon();
     term.loadAddon(fit);
     term.open(el);
@@ -59,6 +67,20 @@ export function useXterm(
       term.loadAddon(webgl);
     } catch {
       // WebGL unavailable — DOM renderer remains in use
+    }
+
+    // Re-resolve the palette when the app flips dark↔light (a class swap on
+    // <html>) or the accent changes (CSS vars set inline on the same element).
+    // Skipped when the caller pinned its own theme.
+    let themeObserver: MutationObserver | undefined;
+    if (options.theme === undefined) {
+      themeObserver = new MutationObserver(() => {
+        term.options.theme = resolveTheme();
+      });
+      themeObserver.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["class", "style"],
+      });
     }
 
     const cleanup = onReady(term);
@@ -93,6 +115,7 @@ export function useXterm(
       cancelAnimationFrame(initialFit);
       if (resizeTimer) clearTimeout(resizeTimer);
       ro.disconnect();
+      themeObserver?.disconnect();
       cleanup?.();
       // Dispose the WebGL renderer BEFORE the terminal. Tearing it down after
       // the core is gone dereferences a disposed _core._store and throws


### PR DESCRIPTION
Three fixes to the native (PTY/TUI) view, from the audit of how it connects to the rest of the app. In dependency order; each is independently reviewable in the commit.

## 1. Spawning could destroy a workspace

`viewMode` was a single global preference whose **only** writer was the per-agent view toggle (`store/workspace.ts`), and every spawn read it as its view (`store/drafts.ts`). So flipping one Claude agent to Native silently made every later spawn request Native.

Every provider reports `native_view: true`, so `spawn_agent` did not downgrade. A fresh per-turn agent (codex, cursor, opencode, pi, agy) has no session id until its first turn, which the backend's native path requires — so the spawn failed, and its error path tears the checkout down and deletes the workspace dir. Reachable purely by having toggled one unrelated agent to Native earlier.

Fix: remove the global (and the dead `setViewMode`, which no UI ever called). Agents always start in the custom view; Native is entered per agent via the header toggle, the only place the session-id precondition can be satisfied.

The experimental flag now gates *presentation*: an agent left in native mode when the flag flips off renders as chat (its transcript is synced either way) instead of being force-switched, which respawned the process and could resurrect a stopped one. Flipping the flag back on restores the terminal.

## 2. Any app-originated message to a native agent errored

`Agent::send_user_message` rejected the `Pty` variant outright. The right panel is a sibling of the workspace pane, so its Git tab renders for native agents — meaning Commit / Push / Open PR / Update branch / Resolve conflicts all failed with `send_user_message called on pty agent`, as did Mission Control queue actions and any drained follow-up.

Fix: type the message into the TUI as a user would (`pty_input_line`). Newlines are flattened — a bare LF reads as "submit", so an unflattened multi-line prompt arrived as several truncated turns — attachment paths are appended as text, and CR submits. `deliver_as_turn` already handles the durable turn row and turn-start marking around this, so the delegation lifecycle resolves normally.

## 3. The pane ignored the theme system

`NativeView` hardcoded a five-colour dark palette, with the same hex repeated in three places, while `util/xtermTheme.ts` already exported `resolveTheme()` — a full 16-colour palette derived from the CSS vars — used by the right-rail shell. In light mode the centre pane was a dark slab with clashing ANSI colours.

Fix: move theming into `useXterm`, so every terminal in the app renders the current palette and re-resolves it live on theme **and** accent changes. A caller passing its own `theme` still pins it. This drops the observer duplicated in `TermPanel` and `RunPanel` (RunPanel additionally never followed accent changes, only dark/light).

Native also gains the find bar and clickable links the shell already had — extracted to a shared `useTerminalSearch` rather than copied, so both surfaces stay in sync.

Also corrects two doc comments describing "our input box overlaid on top of the claude input prompt"; that design is long gone — xterm owns stdin.

## Testing

`cargo test --lib` 1030 passed / 10 ignored (3 new, covering the one-line-per-message invariant). `tsc --noEmit` clean. `biome check` clean on all changed files. `vitest run` 553 passed. No existing test covered these paths.

Net −55 lines.

## Not in scope

The two larger items from the audit — caching one live `Terminal` per agent instead of dispose-and-replay (the corrupt-looking replay on agent switch), and transcript-driven turn detection to replace the 2.5s byte-silence heuristic — are design work and land separately. Native still has no completion chime or unseen dot; that depends on the turn-detection change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)