### PR TITLE
fix(github): read PR checks + review threads by number in one query

### DIFF
--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -193,15 +193,23 @@ pub async fn get_pr_checks(
     Ok(gh::pr_checks(&checkout).await.unwrap_or(None))
 }
 
-/// Fetch the unresolved PR review threads (Greptile / other bots / humans),
-/// flattened to each thread's root comment. Best-effort: any failure (no PR,
-/// gh missing, API error) returns `None` and the panel omits the section.
+/// The Git panel's per-poll read: merge gate + checks + unresolved review
+/// threads in one round-trip (spec §6). Supersedes polling `get_pr_checks` and
+/// `get_pr_comments` side by side — those went through the `first:30` branch
+/// scan, under which the review-thread selection bills ~30 GraphQL points a
+/// call; off a single `pullRequest(number:)` node the pair costs 1.
+///
+/// Resolution prefers the bound PR number (one query). A repo with an open PR
+/// but no number yet — a PR opened on GitHub that adoption hasn't claimed —
+/// discovers the number via the cheap state lookup first, then reads by number:
+/// two 1-point queries rather than one 30-point scan. Best-effort throughout:
+/// any degradation returns `None` and the panel keeps its last-known values.
 #[tauri::command]
-pub async fn get_pr_comments(
+pub async fn get_pr_detail(
     supervisor: State<'_, Arc<Supervisor>>,
     agent_id: String,
     subdir: Option<String>,
-) -> Result<Option<gh::PrComments>> {
+) -> Result<Option<gh::PrDetail>> {
     let Some((repo, checkout)) =
         agent_repo_checkout_opt(&supervisor, &agent_id, subdir.as_deref())?
     else {
@@ -210,7 +218,18 @@ pub async fn get_pr_comments(
     if repo.branch.is_none() {
         return Ok(None);
     }
-    Ok(gh::pr_comments(&checkout).await.unwrap_or(None))
+    let number = match repo.pr_number {
+        Some(n) => n as u32,
+        None => match gh::pr_view(&checkout).await.unwrap_or(None) {
+            Some(pr) => pr.number,
+            None => return Ok(None),
+        },
+    };
+    Ok(
+        gh::pr_detail_number(&checkout, Some(&repo.repo_path), number)
+            .await
+            .unwrap_or(None),
+    )
 }
 
 /// App-wide background poll that refreshes PR state for every repo with a

--- a/src-tauri/src/github/comments.rs
+++ b/src-tauri/src/github/comments.rs
@@ -1,57 +1,45 @@
-//! Unresolved PR review threads: the branch lookup and the pure flattener.
+//! Unresolved PR review threads: the GraphQL selection, node extractor, and
+//! the pure flattener.
 
-use std::path::Path;
+use serde_json::Value;
 
-use serde_json::{json, Value};
-
-use crate::error::Result;
-
-use super::query::{branch_pr_nodes, branch_prs_query, graphql_opt, pick_branch_pr, repo_ref};
 use super::types::*;
 
-/// Fetch the unresolved review threads for the current branch's PR — one
-/// GraphQL call (threads inline with the branch-PR lookup; the gh version
-/// needed two). `Ok(None)` when there is no PR; the command layer maps both
-/// `None` and `Err` to "comments unavailable".
-pub async fn pr_comments(checkout: &Path) -> Result<Option<PrComments>> {
-    let Some((owner, repo)) = repo_ref(checkout).await else {
-        return Ok(None);
-    };
-    let Some(branch) = crate::git::current_branch(checkout).await? else {
-        return Ok(None);
-    };
-    let query = branch_prs_query(
-        r#"reviewThreads(first:100){
-             nodes{
-               isResolved
-               isOutdated
-               comments(first:1){
-                 totalCount
-                 nodes{ author{ login __typename } body path line url }
-               }
-             }
-           }"#,
-    );
-    let Some(data) = graphql_opt(
-        &query,
-        json!({ "owner": owner, "repo": repo, "branch": branch }),
-    )
-    .await?
-    else {
-        return Ok(None);
-    };
-    let nodes = branch_pr_nodes(&data);
-    let Some(pr) = pick_branch_pr(&nodes) else {
-        return Ok(None);
-    };
+/// GraphQL selection for a PR's review threads. Reused by the branch lookup
+/// (`pr_comments`) and the by-number detail read (`pr_detail_number`).
+///
+/// This is the app's most expensive selection by a wide margin: `comments` is
+/// nested two connections deep, so under a `first:30` branch scan it bills
+/// 30×100 = 3000 requests (~30 points), *regardless of how many threads the PR
+/// actually has* — GraphQL charges the declared shape, not the result. Read it
+/// by PR number wherever a number is known.
+pub(crate) const PR_COMMENTS_FIELDS: &str = r#"reviewThreads(first:100){
+     nodes{
+       isResolved
+       isOutdated
+       comments(first:1){
+         totalCount
+         nodes{ author{ login __typename } body path line url }
+       }
+     }
+   }"#;
+
+/// Extract [`PrComments`] from a PR node carrying [`PR_COMMENTS_FIELDS`].
+pub(crate) fn pr_comments_from_node(pr: &Value) -> PrComments {
     let threads = pr["reviewThreads"]["nodes"]
         .as_array()
         .cloned()
         .unwrap_or_default();
-    Ok(Some(PrComments {
+    PrComments {
         unresolved: parse_review_threads(&threads),
-    }))
+    }
 }
+
+// There is deliberately no branch-scan variant of this read. Under
+// `branch_prs_query`'s `first:30`, PR_COMMENTS_FIELDS bills ~30 GraphQL points
+// per call — one open Git panel polling it drained the whole hourly budget.
+// Review threads are only ever read for a PR we can name, so the by-number
+// path (`pr_detail_number`, 1 point) is the only one.
 
 /// Flatten review-thread nodes into the root comment of each *unresolved,
 /// non-outdated* thread. Pure — unit tested against captured fixtures.

--- a/src-tauri/src/github/detail.rs
+++ b/src-tauri/src/github/detail.rs
@@ -1,0 +1,38 @@
+//! The Git panel's combined PR read: merge gate + per-check rollup + unresolved
+//! review threads for one PR, in a single by-number GraphQL round-trip.
+//!
+//! Why this exists: the panel used to poll `pr_checks` and `pr_comments`
+//! separately, both through the `first:30` branch scan. Because GraphQL bills a
+//! nested connection *per parent node the parent connection declares*, the
+//! review-thread selection cost ~30 points there — 30× what the same fields
+//! cost hanging off a single `pullRequest(number:)` node. Fetching both field
+//! sets off one by-number node makes the pair cost 1 point total and halves the
+//! round-trips, so the panel can stay on a tight cadence.
+
+use std::path::Path;
+
+use crate::error::Result;
+
+use super::checks::{pr_checks_from_node, PR_CHECKS_FIELDS};
+use super::comments::{pr_comments_from_node, PR_COMMENTS_FIELDS};
+use super::query::pr_node_by_number;
+use super::types::*;
+
+/// Fetch the merge gate, checks, and unresolved review threads for one PR by
+/// number, in a single query. `Ok(None)` when the PR (or the GitHub slug) can't
+/// be resolved, or while a rate-limit backoff is active — the panel then keeps
+/// its last-known values, matching the per-field fetchers' contract.
+pub async fn pr_detail_number(
+    checkout: &Path,
+    source_repo: Option<&Path>,
+    number: u32,
+) -> Result<Option<PrDetail>> {
+    let fields = format!("{PR_CHECKS_FIELDS}\n{PR_COMMENTS_FIELDS}");
+    let Some(node) = pr_node_by_number(checkout, source_repo, number, &fields).await? else {
+        return Ok(None);
+    };
+    Ok(Some(PrDetail {
+        checks: pr_checks_from_node(&node),
+        comments: pr_comments_from_node(&node),
+    }))
+}

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -19,6 +19,7 @@ pub mod closes;
 
 mod checks;
 mod comments;
+mod detail;
 mod issues;
 mod pr;
 mod query;
@@ -29,7 +30,7 @@ pub use client::{git_auth_env, seed_token, set_token, TOKEN_SETTING};
 pub(crate) use closes::with_closes_trailer;
 
 pub use checks::*;
-pub use comments::*;
+pub use detail::*;
 pub use issues::*;
 pub use pr::*;
 pub use repo::*;

--- a/src-tauri/src/github/query.rs
+++ b/src-tauri/src/github/query.rs
@@ -55,8 +55,20 @@ pub(crate) async fn require_current_branch(checkout: &Path, what: &str) -> Resul
         .ok_or_else(|| Error::Gh(format!("{what}: HEAD is detached — no branch to look up")))
 }
 
+/// The budget probe every read query carries. GraphQL bills *points* (~5000/hr),
+/// not requests, and the cost is charged on the query's declared shape — so a
+/// poll path can drain the whole budget without ever seeing an error. Riding
+/// this selection on every read (it is itself free) lets [`note_budget`] arm the
+/// backoff gate *before* exhaustion rather than after GitHub starts 403-ing.
+pub(crate) const RATE_LIMIT_PROBE: &str = "rateLimit{cost remaining resetAt}";
+
 /// Shared query fields for a PR looked up by branch. Created-desc so
 /// `pick_branch_pr` sees the newest first, mirroring gh's branch resolution.
+///
+/// Note the `first:30`: every connection nested under this one is billed
+/// *per parent*, so a selection with its own `first:N` costs 30×N requests
+/// here. Prefer [`pr_node_by_number`] for anything with a nested connection —
+/// the branch scan is for *discovery* (no PR number known yet), not polling.
 pub(crate) fn branch_prs_query(inner_fields: &str) -> String {
     format!(
         r#"query($owner:String!,$repo:String!,$branch:String!){{
@@ -66,8 +78,45 @@ pub(crate) fn branch_prs_query(inner_fields: &str) -> String {
       nodes{{ state {inner_fields} }}
     }}
   }}
+  {RATE_LIMIT_PROBE}
 }}"#
     )
+}
+
+/// Fetch one PR node by number with `inner_fields` selected. The by-number
+/// counterpart to [`branch_prs_query`]: `pullRequest(number:)` is a single
+/// node, not a connection, so nested selections are billed once instead of
+/// thirty times — the same collapse the batched fetchers rely on.
+///
+/// `owner/repo` resolves from the checkout's origin, falling back to
+/// `source_repo` (same origin) when the checkout is broken or gone.
+/// `Ok(None)` when the slug or the PR can't be resolved, or while a
+/// rate-limit backoff is active.
+pub(crate) async fn pr_node_by_number(
+    checkout: &Path,
+    source_repo: Option<&Path>,
+    number: u32,
+    inner_fields: &str,
+) -> Result<Option<Value>> {
+    let Some((owner, repo)) = resolve_slug(checkout, source_repo).await else {
+        return Ok(None);
+    };
+    let query = format!(
+        r#"query($owner:String!,$repo:String!,$number:Int!){{
+  repository(owner:$owner,name:$repo){{ pullRequest(number:$number){{ state {inner_fields} }} }}
+  {RATE_LIMIT_PROBE}
+}}"#
+    );
+    let Some(data) = graphql_opt(
+        &query,
+        json!({ "owner": owner, "repo": repo, "number": number }),
+    )
+    .await?
+    else {
+        return Ok(None);
+    };
+    let node = &data["repository"]["pullRequest"];
+    Ok((!node.is_null()).then(|| node.clone()))
 }
 
 /// The PR a branch "belongs to": the newest open PR, else the newest PR of
@@ -96,7 +145,13 @@ pub(crate) async fn graphql_opt(query: &str, variables: Value) -> Result<Option<
         Err(_) => return Ok(None),
     };
     match client.graphql(query, variables).await {
-        Ok(data) => Ok(Some(data)),
+        Ok(data) => {
+            // Feed the budget back into the gate for any query carrying
+            // `RATE_LIMIT_PROBE` (a no-op for those that don't), so the
+            // single-PR read paths throttle themselves like the batches do.
+            note_budget(&data);
+            Ok(Some(data))
+        }
         Err(Error::Gh(msg)) => {
             let low = msg.to_lowercase();
             if low.contains("could not resolve") || low.contains("not found") {

--- a/src-tauri/src/github/repo.rs
+++ b/src-tauri/src/github/repo.rs
@@ -154,7 +154,7 @@ pub async fn repo_create_and_push(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::github::{pr_checks, pr_comments, pr_list, pr_view, pr_view_number};
+    use crate::github::{pr_checks, pr_detail_number, pr_list, pr_view, pr_view_number};
 
     #[test]
     fn clone_url_forms() {
@@ -216,7 +216,13 @@ mod tests {
             assert_eq!(by_number.number, pr.number);
             let checks = pr_checks(&repo).await.unwrap();
             assert!(checks.is_some(), "checks must resolve for an existing PR");
-            let _ = pr_comments(&repo).await.unwrap();
+            // The panel's combined by-number read: both halves must come back
+            // together off the one PR node.
+            let detail = pr_detail_number(&repo, None, pr.number).await.unwrap();
+            assert!(
+                detail.is_some(),
+                "combined detail must resolve for an existing PR"
+            );
         }
 
         // A PR number that can't exist maps to None, not an error.

--- a/src-tauri/src/github/types.rs
+++ b/src-tauri/src/github/types.rs
@@ -180,6 +180,16 @@ pub struct PrComments {
     pub unresolved: Vec<PrComment>,
 }
 
+/// The Git panel's per-poll PR read: the merge gate + checks rollup and the
+/// unresolved review threads, fetched together off one PR node. Both halves
+/// come from the same round-trip, so a present `PrDetail` means both are
+/// current — the panel writes them as a pair.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct PrDetail {
+    pub checks: PrChecks,
+    pub comments: PrComments,
+}
+
 /// GitHub connection state. Drives the New Project UI and readiness rows.
 /// `installed` is a legacy of the gh-CLI era kept for IPC compatibility —
 /// there is no binary to install anymore, so it is always `true`; what

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1571,7 +1571,7 @@ pub fn run() {
             commands::refresh_all_pr_states,
             commands::refresh_all_pr_checks,
             commands::get_pr_checks,
-            commands::get_pr_comments,
+            commands::get_pr_detail,
             commands::open_agent_shell,
             commands::close_agent_shell,
             commands::write_to_shell,

--- a/src/api/domains/github.ts
+++ b/src/api/domains/github.ts
@@ -1,6 +1,6 @@
 import { invoke } from "../invoke";
 import type { Workspace } from "../types/agent";
-import type { PrChecks, PrComments, PrState, PrSummary } from "../types/pr";
+import type { PrChecks, PrDetail, PrState, PrSummary } from "../types/pr";
 import type { GhRepoSummary, GhStatus } from "../types/providers";
 
 export const githubApi = {
@@ -31,8 +31,8 @@ export const githubApi = {
   refreshAllPrChecks: () => invoke<Record<string, PrChecks | null>>("refresh_all_pr_checks"),
   getPrChecks: (agentId: string, subdir?: string) =>
     invoke<PrChecks | null>("get_pr_checks", { agentId, subdir }),
-  getPrComments: (agentId: string, subdir?: string) =>
-    invoke<PrComments | null>("get_pr_comments", { agentId, subdir }),
+  getPrDetail: (agentId: string, subdir?: string) =>
+    invoke<PrDetail | null>("get_pr_detail", { agentId, subdir }),
   createPr: (agentId: string, title: string, body: string, subdir?: string) =>
     invoke<PrState>("create_pr", { agentId, title, body, subdir }),
   mergePr: (agentId: string, subdir?: string) => invoke<void>("merge_pr", { agentId, subdir }),

--- a/src/api/types/pr.ts
+++ b/src/api/types/pr.ts
@@ -81,3 +81,11 @@ export interface PrComment {
 export interface PrComments {
   unresolved: PrComment[];
 }
+
+/** The Git panel's per-poll PR read — checks and review threads fetched in one
+ *  backend round-trip, so they're always from the same moment. Written to the
+ *  `prChecks` / `prComments` slices as a pair. */
+export interface PrDetail {
+  checks: PrChecks;
+  comments: PrComments;
+}

--- a/src/components/RightPanel/GitPanel/hooks/useGitPanelData.ts
+++ b/src/components/RightPanel/GitPanel/hooks/useGitPanelData.ts
@@ -10,7 +10,8 @@ import { prSnapshot } from "@/util/prState";
  *  keeps them fresh while the panel is mounted:
  *  - git state at 1s,
  *  - PR state at 5s (so a merge/close/mergeable flip on GitHub shows up),
- *  - the heavier checks + review comments at 5s, only while a PR is open.
+ *  - checks + review comments at 5s, only while a PR is open — one combined
+ *    backend read (`fetchPrDetail`), so both land from the same moment.
  *  usePoll fires immediately, so the first read of each still lands on mount.
  *
  *  `repo`/`subdir` scope the hook to one repo of a multi-repo agent: `subdir`
@@ -49,7 +50,7 @@ export function useGitPanelData(agentId: string, repo?: TrackedRepo, subdir?: st
   const prChecksEntry = useAppStore((s) => s.prChecks[key]);
   const fetchPrChecksStore = useAppStore((s) => s.fetchPrChecks);
   const prCommentsEntry = useAppStore((s) => s.prComments[key]);
-  const fetchPrCommentsStore = useAppStore((s) => s.fetchPrComments);
+  const fetchPrDetailStore = useAppStore((s) => s.fetchPrDetail);
 
   // Subdir-bound fetchers, so every consumer (polls, actions, delegation
   // refresh) hits this section's repo without re-threading the scope.
@@ -65,9 +66,9 @@ export function useGitPanelData(agentId: string, repo?: TrackedRepo, subdir?: st
     (id: string) => fetchPrChecksStore(id, subdir),
     [fetchPrChecksStore, subdir],
   );
-  const fetchPrComments = useCallback(
-    (id: string) => fetchPrCommentsStore(id, subdir),
-    [fetchPrCommentsStore, subdir],
+  const fetchPrDetail = useCallback(
+    (id: string) => fetchPrDetailStore(id, subdir),
+    [fetchPrDetailStore, subdir],
   );
 
   const pollGitState = useCallback(() => fetchGitState(agentId), [agentId, fetchGitState]);
@@ -79,10 +80,12 @@ export function useGitPanelData(agentId: string, repo?: TrackedRepo, subdir?: st
   const prOpen = prState?.state === "open";
   const pollChecks = useCallback(async () => {
     if (!prOpen) return;
-    // Checks + review comments share a cadence: both are heavier gh reads that
-    // only matter while a PR is open.
-    await Promise.all([fetchPrChecks(agentId), fetchPrComments(agentId)]);
-  }, [agentId, prOpen, fetchPrChecks, fetchPrComments]);
+    // Checks + review comments arrive together, off one PR node in a single
+    // GraphQL round-trip. Fetching them separately used to cost ~31 rate-limit
+    // points a tick (the review-thread selection billed 30 under the branch
+    // scan) — enough for one open panel to drain the hourly budget on its own.
+    await fetchPrDetail(agentId);
+  }, [agentId, prOpen, fetchPrDetail]);
   // Adaptive: 5s while checks are still in flight (or not yet fetched), backing
   // off to 15s once they've settled pass/fail — a settled PR rarely changes, and
   // the app-wide poll still covers it. `undefined` (first fetch pending) counts

--- a/src/store/git.ts
+++ b/src/store/git.ts
@@ -85,7 +85,11 @@ export interface GitSlice {
    *  opening the Git panel. */
   refreshAllPrChecks: () => Promise<void>;
   fetchPrChecks: (agentId: string, subdir?: string) => Promise<void>;
-  fetchPrComments: (agentId: string, subdir?: string) => Promise<void>;
+  /** Refresh checks + review comments together in one backend round-trip —
+   *  what the Git panel polls. Cheaper than the two fetchers side by side (the
+   *  backend reads both off a single PR node) and keeps the two slices
+   *  consistent, since they come from the same moment. */
+  fetchPrDetail: (agentId: string, subdir?: string) => Promise<void>;
   delegateGitAction: (
     agentId: string,
     kind: GitDelegationKind,
@@ -294,8 +298,27 @@ export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
 
   fetchPrChecks: (agentId, subdir) => fetchPrAux(set, agentId, "prChecks", api.getPrChecks, subdir),
 
-  fetchPrComments: (agentId, subdir) =>
-    fetchPrAux(set, agentId, "prComments", api.getPrComments, subdir),
+  fetchPrDetail: async (agentId, subdir) => {
+    const mapKey = gitKey(agentId, subdir);
+    try {
+      const detail = await api.getPrDetail(agentId, subdir);
+      // A null detail is "confirmed unavailable" for both halves — the same
+      // meaning fetchPrAux gives a null value, so the panel drops the
+      // "checking…" placeholder rather than hanging on it.
+      set((s) => ({
+        prChecks: { ...s.prChecks, [mapKey]: detail?.checks ?? null },
+        prComments: { ...s.prComments, [mapKey]: detail?.comments ?? null },
+      }));
+    } catch {
+      // Mirror fetchPrAux's failure contract per slice: degrade an absent key
+      // to null so the placeholder clears, but let a later transient error
+      // keep the last good value.
+      set((s) => ({
+        prChecks: mapKey in s.prChecks ? s.prChecks : { ...s.prChecks, [mapKey]: null },
+        prComments: mapKey in s.prComments ? s.prComments : { ...s.prComments, [mapKey]: null },
+      }));
+    }
+  },
 
   delegateGitAction: (agentId, kind, prompt, subdir) => {
     // If the agent is already running, DON'T inject the trigger mid-turn: Claude


### PR DESCRIPTION
## Problem

GitHub's GraphQL API bills a **points** budget (~5000/hr), not a request count — and cost is charged on a query's *declared shape*, before execution.

The Git panel polled `get_pr_checks` and `get_pr_comments` side by side, both through `branch_prs_query`'s `first:30` branch scan. A nested connection is billed once per parent node the parent connection declares, so the review-thread selection cost:

| connection | requests |
|---|---|
| `pullRequests(first:30)` | 1 |
| `reviewThreads(first:100)` × 30 PRs | 30 |
| `comments(first:1)` × 3,000 threads | 3,000 |
| **total** | **3,031 → ~30 points** |

Every other query in the codebase is ~1 point. At the panel's 5s cadence that is ~23,000 pts/hr against a 5,000/hr budget — **one open Git panel drained the entire account**, with no push or PR activity. Because the limit is per-user, it also starved the `gh` CLI the user and their agents share it with.

Two things made it fail hard rather than degrade:

1. Only the *batched* fetchers carried a `rateLimit` probe, so single-PR reads burned 5000 → 0 blind; the backoff gate armed only after GitHub started returning 403/`RATE_LIMITED`.
2. Cost is shape-based, so a PR with zero review threads billed the same 30 points as one with a hundred.

## Fix

Read both field sets off a single `pullRequest(number:)` node. `pullRequest` is a single node, not a connection, so the nested selections are billed once instead of thirty times.

**Measured against the live API: 30 points → 1** for the pair.

- `query::pr_node_by_number` — the by-number counterpart to `branch_prs_query`
- `github::detail::pr_detail_number` — composes the checks + comments selections into one round-trip
- `RATE_LIMIT_PROBE` now rides every read query, with `graphql_opt` feeding it to `note_budget`, so single-PR paths throttle *before* exhaustion
- deleted the branch-scan `pr_comments`, its Tauri command, and its api/store bindings — review threads are only ever read for a PR we can name, and leaving the 30-point path `pub` with no callers invites the regression
- frontend `fetchPrDetail` writes `prChecks`/`prComments` as a pair, preserving `fetchPrAux`'s null-vs-absent contract per slice

Cadence is unchanged at 5s/15s, so the panel is no less realtime — it makes one round-trip where it made two, and both halves now come from the same moment.

## Effect

A settled open panel goes from ~7,700 pts/hr to ~250 — from 1.5× over budget to roughly 5% of it.

## Verification

- merged query measured at `cost: 1` against the real API
- `cargo check`, `cargo clippy --all-targets`, `cargo fmt` clean; 29 github tests pass
- `tsc --noEmit` and biome clean on changed files; 553 frontend tests pass

## Follow-up (not in this PR)

Confirmed by measurement that REST conditional requests are free (`x-ratelimit-used` held flat across 5 × `If-None-Match` → 304), and the REST budget is essentially idle (10/5000 used while GraphQL sat at 5000/5000). A follow-up can move the hot signals — `GET /pulls/{n}` and `/commits/{sha}/check-runs` — to ETag'd REST and poll them *faster* than today at zero primary cost, keeping GraphQL only for review-thread resolution (`isResolved`/`isOutdated` has no REST equivalent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)