### PR TITLE
refactor(ui): one owner for git/GitHub polling, components just read

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,26 +14,13 @@ import { UpdateToast } from "./components/UpdateToast";
 import { Workspace } from "./components/Workspace";
 import { ACCENT_VALUES } from "./data/providers";
 import { useAppStore } from "./store";
-import { usePoll } from "./util/hooks";
+import { useGitSync } from "./store/gitSync";
 import { useGlobalShortcuts } from "./util/shortcuts";
 import { useSplitter } from "./util/splitter";
 import { setAppBadgeCount } from "./util/window";
 
 export function App() {
   const init = useAppStore((s) => s.init);
-  const fetchAllShortstats = useAppStore((s) => s.fetchAllShortstats);
-  const fetchAllGitMeta = useAppStore((s) => s.fetchAllGitMeta);
-  const refreshBaseFreshness = useAppStore((s) => s.refreshBaseFreshness);
-  const refreshAllPrStatus = useAppStore((s) => s.refreshAllPrStatus);
-  // PR polls hit the GitHub API — skip them entirely in local-only mode
-  // (no connection) so a GitHub-unaware user generates zero network chatter.
-  const githubConnected = useAppStore((s) => s.github?.authenticated ?? false);
-  // Drive adaptive poll cadence: poll fast while there's an open PR and back off
-  // hard once everything has settled, so an idle workspace of merged PRs stops
-  // hitting the API. Checks no longer need their own signal — they ride the same
-  // sweep as state.
-  const anyOpenPr = useAppStore((s) => Object.values(s.prStates).some((p) => p?.state === "open"));
-
   const theme = useAppStore((s) => s.theme);
   const accent = useAppStore((s) => s.accent);
 
@@ -69,53 +56,8 @@ export function App() {
     setAppBadgeCount(unseenCount);
   }, [unseenCount]);
 
-  // App-wide poll: refresh compact shortstats for every live agent so the
-  // sidebar / right-rail badges stay current without waiting for a focused
-  // panel to mount. Queries run in parallel on the backend; the reply is a
-  // flat number-only map so payload stays small as agent count grows.
-  usePoll(fetchAllShortstats, 5000, [fetchAllShortstats]);
-
-  // App-wide poll for advisory git metadata — base staleness (how far each
-  // checkout has fallen behind its base) + changed-file paths for overlap
-  // hints. Local git only (no network), so it runs regardless of GitHub; a
-  // slower 15s cadence since it's advisory and the fleet's diff/base move far
-  // less often than the sidebar badges the 5s shortstats poll drives.
-  usePoll(fetchAllGitMeta, 15000, [fetchAllGitMeta]);
-
-  // App-wide slow poll that fetches each project's base branch on its source
-  // repo, so the staleness chips above track a base that moved on GitHub (a
-  // sibling's PR merging, a teammate's push). Network + GitHub-gated like the
-  // PR polls; 5min cadence — a moved base is normal, not urgent — and silent by
-  // contract (a background fetch never raises a user-facing error).
-  usePoll(
-    async () => {
-      if (githubConnected) await refreshBaseFreshness();
-    },
-    300000,
-    [refreshBaseFreshness, githubConnected],
-  );
-
-  // App-wide sweep for remote PR status — state (open → merged / closed,
-  // mergeability) plus the CI rollup that tints each sidebar pill — so the
-  // sidebar tracks changes made on GitHub by a teammate, CI, or the web UI
-  // without the user opening the Git panel.
-  //
-  // One batched query covers the whole fleet, and selecting state and checks
-  // together costs what either did alone (1 point for a full 50-PR chunk), so
-  // this replaces what used to be two sweeps on two clocks — which cost double
-  // and let a freshly-merged badge sit beside a CI tint from a cadence ago.
-  //
-  // 20s while any PR is open: cheap enough to be genuinely live, and it covers
-  // in-flight checks without a separate faster tick. Backs off to 5min once
-  // every PR has settled — merged PRs answer from the local snapshot anyway, so
-  // the slow tick just watches for a rare reopen.
-  usePoll(
-    async () => {
-      if (githubConnected) await refreshAllPrStatus();
-    },
-    anyOpenPr ? 20000 : 300000,
-    [refreshAllPrStatus, githubConnected, anyOpenPr],
-  );
+  // All git / GitHub polling lives in one place.
+  useGitSync();
 
   // Apply theme via html class; accent via CSS vars.
   useEffect(() => {

--- a/src/components/RightPanel/Code/CodeLivePanel.tsx
+++ b/src/components/RightPanel/Code/CodeLivePanel.tsx
@@ -12,7 +12,6 @@ import { Icon } from "@/components/Icon";
 import { useAppStore } from "@/store";
 import { useHljsTheme } from "@/util/codeTheme";
 import type { DiffLine } from "@/util/diff";
-import { usePoll } from "@/util/hooks";
 import { DiffBody, extOf, useFileDiff } from "./DiffView";
 
 interface CodeLivePanelProps {
@@ -51,7 +50,6 @@ export function CodeLivePanel({
   onOpenInEditor,
 }: CodeLivePanelProps) {
   const gitState = useAppStore((s) => s.gitStates[agent.id] ?? null);
-  const fetchGitState = useAppStore((s) => s.fetchGitState);
   // Is the agent mid-turn? Same signal the chat "thinking" spinner uses, so
   // the panel's "live" state appears and clears in lockstep with the rest of
   // the UI. Nothing is "live" once the turn ends.
@@ -59,11 +57,6 @@ export function CodeLivePanel({
   // Match the editor's syntax theme: the "quorum" palette is gated by `cq`;
   // other families color `.hljs-*` globally via a loaded stylesheet.
   const isBuiltInTheme = useHljsTheme();
-
-  // Reuse the same 1s git poll the Git tab uses; only one right-rail tab is
-  // mounted at a time, so this never double-polls.
-  const pollGitState = useMemo(() => () => fetchGitState(agent.id), [agent.id, fetchGitState]);
-  usePoll(pollGitState, 1000, [pollGitState]);
 
   const files = useMemo(() => gitState?.files ?? [], [gitState]);
   const fileSig = files.map((f) => `${f.path}#${sigOf(f)}`).join("|");

--- a/src/components/RightPanel/GitPanel/hooks/useGitPanelData.ts
+++ b/src/components/RightPanel/GitPanel/hooks/useGitPanelData.ts
@@ -3,21 +3,14 @@ import type { MergeState, TrackedRepo } from "@/api";
 import { deriveState } from "@/components/RightPanel/primaryActions";
 import { useAppStore } from "@/store";
 import { gitKey } from "@/store/git";
-import { usePoll } from "@/util/hooks";
 import { prSnapshot } from "@/util/prState";
 
-/** All the live git/PR reads the panel renders from, plus the polling that
- *  keeps them fresh while the panel is mounted:
- *  - git state at 1s,
- *  - PR state + CI at 5s via `fetchPrLive` — one backend pass over
- *    ETag-conditional REST, which GitHub doesn't bill when nothing changed, so
- *    the tick that users actually watch ("is it green", "did it merge") stays
- *    tight and near-free,
- *  - review threads at 30s while a PR is open. These stay on GraphQL (thread
- *    resolution has no REST equivalent) and so cost points per call — human
- *    review comments arrive on minute timescales, so the slower tick loses
- *    nothing.
- *  usePoll fires immediately, so the first read of each still lands on mount.
+/** The Git panel's view of one repo's git/PR state, derived from the store.
+ *
+ *  A pure read — `useGitSync` owns the polling that keeps these current. The
+ *  fetchers returned at the bottom are for *actions*, not refresh loops: after a
+ *  push or a delegated git op the caller wants the new state now rather than at
+ *  the next tick.
  *
  *  `repo`/`subdir` scope the hook to one repo of a multi-repo agent: `subdir`
  *  undefined = the primary repo, read/written under the plain agent key (the
@@ -55,8 +48,6 @@ export function useGitPanelData(agentId: string, repo?: TrackedRepo, subdir?: st
   const prChecksEntry = useAppStore((s) => s.prChecks[key]);
   const fetchPrChecksStore = useAppStore((s) => s.fetchPrChecks);
   const prCommentsEntry = useAppStore((s) => s.prComments[key]);
-  const fetchPrLiveStore = useAppStore((s) => s.fetchPrLive);
-  const fetchPrThreadsStore = useAppStore((s) => s.fetchPrThreads);
 
   // Subdir-bound fetchers, so every consumer (polls, actions, delegation
   // refresh) hits this section's repo without re-threading the scope.
@@ -72,33 +63,7 @@ export function useGitPanelData(agentId: string, repo?: TrackedRepo, subdir?: st
     (id: string) => fetchPrChecksStore(id, subdir),
     [fetchPrChecksStore, subdir],
   );
-  const fetchPrLive = useCallback(
-    (id: string) => fetchPrLiveStore(id, subdir),
-    [fetchPrLiveStore, subdir],
-  );
-  const fetchPrThreads = useCallback(
-    (id: string) => fetchPrThreadsStore(id, subdir),
-    [fetchPrThreadsStore, subdir],
-  );
-
-  const pollGitState = useCallback(() => fetchGitState(agentId), [agentId, fetchGitState]);
-  usePoll(pollGitState, 1000, [pollGitState]);
-
-  // State and CI in one conditional-REST pass. Runs regardless of PR status —
-  // it *is* how the panel learns a PR merged or closed — and stays at 5s even
-  // once checks settle, because an unchanged read is a 304 that GitHub doesn't
-  // bill. There's nothing to back off from.
-  const pollLive = useCallback(() => fetchPrLive(agentId), [agentId, fetchPrLive]);
-  usePoll(pollLive, 5000, [pollLive]);
-
   const prOpen = prState?.state === "open";
-  const pollThreads = useCallback(async () => {
-    if (!prOpen) return;
-    await fetchPrThreads(agentId);
-  }, [agentId, prOpen, fetchPrThreads]);
-  // 30s: this is the one panel read that still spends GraphQL points, and human
-  // review comments don't arrive faster than that.
-  usePoll(pollThreads, 30000, [pollThreads]);
 
   const checks = prChecksEntry ?? null;
   const comments = prCommentsEntry ?? null;

--- a/src/components/RightPanel/GitPanel/hooks/useGitPanelData.ts
+++ b/src/components/RightPanel/GitPanel/hooks/useGitPanelData.ts
@@ -49,8 +49,9 @@ export function useGitPanelData(agentId: string, repo?: TrackedRepo, subdir?: st
   const fetchPrChecksStore = useAppStore((s) => s.fetchPrChecks);
   const prCommentsEntry = useAppStore((s) => s.prComments[key]);
 
-  // Subdir-bound fetchers, so every consumer (polls, actions, delegation
-  // refresh) hits this section's repo without re-threading the scope.
+  // Subdir-bound fetchers for *actions* — a push, a merge, a delegated git op —
+  // so callers refresh this section's repo without re-threading the scope.
+  // Background freshness is `useGitSync`'s job, not theirs.
   const fetchGitState = useCallback(
     (id: string) => fetchGitStateStore(id, subdir),
     [fetchGitStateStore, subdir],

--- a/src/components/RightPanel/GitPanel/index.tsx
+++ b/src/components/RightPanel/GitPanel/index.tsx
@@ -1,9 +1,7 @@
-import { useCallback, useEffect, useRef } from "react";
 import type { AgentRecord, GitState, TrackedRepo } from "@/api";
 import { useAppStore } from "@/store";
 import { gitKey } from "@/store/git";
 import { basename } from "@/util/format";
-import { usePoll } from "@/util/hooks";
 import { prSnapshot } from "@/util/prState";
 import { GitRepoSection } from "./GitRepoSection";
 import { type PrSetEntry, PrSetStrip } from "./PrSetStrip";
@@ -49,7 +47,6 @@ export function GitPanel({ agent }: { agent: AgentRecord }) {
 }
 
 function MultiRepoGitPanel({ agent }: { agent: AgentRecord }) {
-  const fetchGitState = useAppStore((s) => s.fetchGitState);
   const gitStates = useAppStore((s) => s.gitStates);
   const prStates = useAppStore((s) => s.prStates);
   const prChecks = useAppStore((s) => s.prChecks);
@@ -77,25 +74,6 @@ function MultiRepoGitPanel({ agent }: { agent: AgentRecord }) {
     const pr = live !== undefined ? live : prSnapshot(sc.repo);
     return pr ? [{ repo: sc.repo, pr, checks: prChecks[key] ?? null }] : [];
   });
-
-  // On mount / agent change, fetch git state for EVERY repo so "active" can be
-  // computed — rendered sections then keep their own 1s poll going.
-  const repos = agent.repos;
-  useEffect(() => {
-    repos.forEach((repo, i) => void fetchGitState(agent.id, i === 0 ? undefined : repo.subdir));
-  }, [agent.id, repos, fetchGitState]);
-
-  // Repos without a rendered section have no per-section poll, so sweep them
-  // on a slow cadence — an agent touching a dormant repo promotes it to a
-  // section within a tick. Read through a ref so the poll's identity is
-  // stable (the active set changes with every gitStates write).
-  const dormantRef = useRef<RepoScope[]>([]);
-  dormantRef.current =
-    active.length > 0 ? scopes.filter((sc) => !active.includes(sc)) : scopes.slice(1);
-  const pollDormant = useCallback(async () => {
-    await Promise.all(dormantRef.current.map((sc) => fetchGitState(agent.id, sc.subdir)));
-  }, [agent.id, fetchGitState]);
-  usePoll(pollDormant, 5000, [pollDormant]);
 
   return (
     <div className="git-multi">

--- a/src/components/TitleBar/WorkspaceStatus/useCapsuleData.ts
+++ b/src/components/TitleBar/WorkspaceStatus/useCapsuleData.ts
@@ -1,33 +1,16 @@
-import { useCallback } from "react";
 import { useAppStore } from "@/store";
-import { usePoll } from "@/util/hooks";
 import { usePrState } from "@/util/prState";
 
-/** Live git/PR reads for the title-bar capsule of the active agent.
+/** The title-bar capsule's view of the active agent's git/PR state.
  *
- *  The always-visible badge already rides the app-wide polls (`gitShortstats`
- *  at 5s, `prStates` at 45s). This hook adds the richer reads the popover and
- *  checks-chip need — full git state and the CI rollup — which otherwise only
- *  refresh while the Git panel is mounted. Kept gentle (10s): the title bar is
- *  a glance, not the panel. Fires immediately on mount, so the first read still
- *  lands right away; checks only fetch while a PR is open. */
+ *  A pure read: `useGitSync` keeps all of this current. Checks are surfaced only
+ *  while the PR is open, since that's the only state the chip renders. */
 export function useCapsuleData(agentId: string) {
   const shortstats = useAppStore((s) => s.gitShortstats[agentId] ?? null);
   const gitState = useAppStore((s) => s.gitStates[agentId] ?? null);
   const prState = usePrState(agentId);
   const checks = useAppStore((s) => s.prChecks[agentId] ?? null);
-  const fetchGitState = useAppStore((s) => s.fetchGitState);
-  const fetchPrLive = useAppStore((s) => s.fetchPrLive);
-
   const prOpen = prState?.state === "open";
-  const poll = useCallback(async () => {
-    await fetchGitState(agentId);
-    // Same conditional-REST read the Git panel's fast tick uses: unchanged
-    // polls are 304s that GitHub doesn't bill, so the capsule's chip costs
-    // nothing to keep current (it previously spent a GraphQL point a tick).
-    if (prOpen) await fetchPrLive(agentId);
-  }, [agentId, prOpen, fetchGitState, fetchPrLive]);
-  usePoll(poll, 10000, [poll]);
 
   return { shortstats, gitState, prState, checks: prOpen ? checks : null };
 }

--- a/src/store/git.ts
+++ b/src/store/git.ts
@@ -22,9 +22,9 @@ export interface GitSlice {
   /** Full git state — branch, ahead/behind, file list, totals. Keyed by
    *  `gitKey(agentId, subdir?)` (store/git.ts): the plain agent_id addresses
    *  the primary repo, `agentId::subdir` a secondary repo of a multi-repo
-   *  agent. Only populated for the focused agent (by GitPanel's 1s poll
-   *  while it's mounted). For sidebar shortstats / right-rail badges of
-   *  other agents, read from `gitShortstats` instead. */
+   *  agent. Only populated for the focused agent (by `gitSync`, for every one of
+   *  its repos). For sidebar shortstats / right-rail badges of other agents,
+   *  read from `gitShortstats` instead. */
   gitStates: Record<string, GitState>;
   /** Compact per-agent shortstats (additions / deletions / file count),
    *  keyed by agent_id. Updated for every live agent on the app-wide 5s
@@ -207,6 +207,13 @@ const fetchPrAux = async <K extends "prChecks" | "prComments">(
   }
 };
 
+// Whether GitHub is usable. The reads below early-return on `false` so that a
+// user with no connection generates zero API chatter — the rule lives here, in
+// the data layer, rather than being re-checked by each poller. Action-driven
+// reads (`fetchPrState`, `fetchPrChecks`) are deliberately not gated: they
+// resolve against the persisted snapshot, which is still useful offline.
+const githubReady = (get: GitGet) => get().github?.authenticated ?? false;
+
 export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
   gitStates: {},
   gitShortstats: {},
@@ -254,6 +261,7 @@ export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
   },
 
   refreshBaseFreshness: async () => {
+    if (!githubReady(get)) return;
     try {
       await api.refreshBaseFreshness();
     } catch {
@@ -277,6 +285,7 @@ export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
   },
 
   refreshAllPrStatus: async () => {
+    if (!githubReady(get)) return;
     const ticket = issuePrWrite();
     try {
       // Set state directly from the reply (rather than via `pr:state_changed`
@@ -311,6 +320,7 @@ export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
   fetchPrChecks: (agentId, subdir) => fetchPrAux(set, agentId, "prChecks", api.getPrChecks, subdir),
 
   fetchPrLive: async (agentId, subdir) => {
+    if (!githubReady(get)) return;
     const mapKey = gitKey(agentId, subdir);
     const ticket = issuePrWrite();
     try {
@@ -347,8 +357,10 @@ export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
     }
   },
 
-  fetchPrThreads: (agentId, subdir) =>
-    fetchPrAux(set, agentId, "prComments", api.getPrThreads, subdir),
+  fetchPrThreads: async (agentId, subdir) => {
+    if (!githubReady(get)) return;
+    await fetchPrAux(set, agentId, "prComments", api.getPrThreads, subdir);
+  },
 
   delegateGitAction: (agentId, kind, prompt, subdir) => {
     // If the agent is already running, DON'T inject the trigger mid-turn: Claude

--- a/src/store/git.ts
+++ b/src/store/git.ts
@@ -83,15 +83,14 @@ export interface GitSlice {
    *  halves now come from the same instant. */
   refreshAllPrStatus: () => Promise<void>;
   fetchPrChecks: (agentId: string, subdir?: string) => Promise<void>;
-  /** The Git panel's fast tick: PR state + CI in one backend pass over
-   *  ETag-conditional REST. Free at GitHub whenever nothing changed, so it can
-   *  run at a tight cadence; supersedes polling `fetchPrState` and
-   *  `fetchPrChecks` separately, and keeps the two slices from disagreeing
-   *  since both come from the same moment. */
+  /** PR state + CI in one backend pass over ETag-conditional REST. Free at
+   *  GitHub whenever nothing changed, so it can run at a tight cadence, and both
+   *  slices come from the same moment so they can't disagree. Driven by
+   *  `gitSync` for the focused agent — not called from components. */
   fetchPrLive: (agentId: string, subdir?: string) => Promise<void>;
-  /** The Git panel's slow tick: unresolved review threads. Stays on GraphQL
-   *  (thread resolution has no REST equivalent) and so does cost points —
-   *  hence the gentler cadence. */
+  /** Unresolved review threads. Stays on GraphQL (thread resolution has no REST
+   *  equivalent) and so does cost points — hence the gentler cadence. Driven by
+   *  `gitSync`. */
   fetchPrThreads: (agentId: string, subdir?: string) => Promise<void>;
   delegateGitAction: (
     agentId: string,
@@ -316,9 +315,9 @@ export const createGitSlice: SliceCreator<GitSlice> = (set, get) => ({
     const ticket = issuePrWrite();
     try {
       const live = await api.getPrLive(agentId, subdir);
-      // One ticket, checked per slice: the panel and the title capsule both poll
-      // this for the same agent, so an older response must not land on top of a
-      // newer one (nor on top of the post-merge refresh).
+      // One ticket, checked per slice: the 20s fleet sweep writes these same
+      // keys for the focused agent, so an older response must not land on top of
+      // a newer one (nor on top of the post-merge refresh).
       const takeState = acceptPrWrite("prStates", mapKey, ticket);
       const takeChecks =
         (live?.checks != null || live == null) && acceptPrWrite("prChecks", mapKey, ticket);

--- a/src/store/gitSync.ts
+++ b/src/store/gitSync.ts
@@ -27,8 +27,6 @@ import { usePoll } from "@/util/hooks";
 
 /** Mount once, at the app root. */
 export function useGitSync() {
-  const githubConnected = useAppStore((s) => s.github?.authenticated ?? false);
-
   const fetchAllShortstats = useAppStore((s) => s.fetchAllShortstats);
   const fetchAllGitMeta = useAppStore((s) => s.fetchAllGitMeta);
   const refreshBaseFreshness = useAppStore((s) => s.refreshBaseFreshness);
@@ -48,16 +46,18 @@ export function useGitSync() {
   // base moves far less often than its diffs.
   usePoll(fetchAllGitMeta, 15000, [fetchAllGitMeta]);
 
+  // Whether GitHub is reachable is enforced *in the store* — see `githubReady`
+  // in `git.ts` — so nothing below re-checks it. It is still listed as a
+  // dependency of the two slow polls: that re-arms them (and fires one tick)
+  // the moment a connection appears. `github` hydrates asynchronously after
+  // launch, so without this a cold start would no-op its first tick and then
+  // wait out the 5-minute idle interval before trying again.
+  const githubConnected = useAppStore((s) => s.github?.authenticated ?? false);
+
   // Fetches each project's base branch on its source repo so the staleness
   // chips track a base that moved on GitHub. A git fetch, not an API call.
   // Silent by contract — a background fetch never raises a user-facing error.
-  usePoll(
-    async () => {
-      if (githubConnected) await refreshBaseFreshness();
-    },
-    300000,
-    [refreshBaseFreshness, githubConnected],
-  );
+  usePoll(refreshBaseFreshness, 300000, [refreshBaseFreshness, githubConnected]);
 
   // Remote PR status for every repo with a known PR: state plus the CI rollup
   // that tints each sidebar pill. One batched query for the whole fleet, 1
@@ -68,75 +68,51 @@ export function useGitSync() {
   // Deliberately derived from the store rather than passed in: the cadence
   // reacts to the data it fetches.
   const anyOpenPr = useAppStore((s) => Object.values(s.prStates).some((p) => p?.state === "open"));
-  usePoll(
-    async () => {
-      if (githubConnected) await refreshAllPrStatus();
-    },
-    anyOpenPr ? 20000 : 300000,
-    [refreshAllPrStatus, githubConnected, anyOpenPr],
-  );
+  usePoll(refreshAllPrStatus, anyOpenPr ? 20000 : 300000, [refreshAllPrStatus, githubConnected]);
 
   // ── focused agent ─────────────────────────────────────────────────────────
 
-  const agentId = useAppStore((s) => s.selectedAgentId);
+  // Full git state — branch, ahead/behind, file list. 1s while the right pane is
+  // showing it (the user is watching a diff); slower when it's collapsed, where
+  // only the title capsule reads it. Local git, but each call forks a process,
+  // so the distinction is worth one ternary.
+  const panelVisible = useAppStore((s) => !s.rightCollapsed && !s.activeDraftId);
+  useFocusedRepoPoll(fetchGitState, panelVisible ? 1000 : 10000);
 
-  // Every repo of the focused agent, as the `subdir` the fetchers take
-  // (undefined = primary). Covering all of them — not just the ones a panel
-  // section happens to render — is what retired `pollDormant`. Shallow-compared
-  // so the polls below keep a stable identity across unrelated store writes.
+  // PR state + CI in one backend pass over ETag-conditional REST. Unchanged
+  // reads are 304s GitHub doesn't bill, so there's nothing to back off from.
+  useFocusedRepoPoll(fetchPrLive, 5000);
+
+  // Unresolved review threads — the one panel read still costing GraphQL points,
+  // so it gets the gentlest cadence. Not filtered by PR state here: the backend
+  // returns nothing for a repo whose PR isn't open, and keeping that rule in one
+  // place beats mirroring it in the poller.
+  useFocusedRepoPoll(fetchPrThreads, 30000);
+}
+
+/** Run `fetch` for every repo of the focused agent, on `intervalMs`.
+ *
+ *  Covering *all* of the agent's repos — not just the ones a panel section
+ *  happens to render — is what retired `GitPanel`'s `pollDormant`. No-ops when
+ *  nothing is selected, so callers need no guard of their own. */
+function useFocusedRepoPoll(
+  fetch: (agentId: string, subdir?: string) => Promise<void>,
+  intervalMs: number,
+) {
+  const agentId = useAppStore((s) => s.selectedAgentId);
+  // Each repo as the `subdir` the fetchers take (undefined = primary).
+  // Shallow-compared so the tick keeps a stable identity across unrelated
+  // store writes — `usePoll` holds whatever callback it was last given, so an
+  // unstable one would keep firing a stale closure.
   const subdirs = useAppStore(
     useShallow((s) => {
       const agent = s.workspace?.agents.find((a) => a.id === s.selectedAgentId);
       return agent?.repos.map((r, i) => (i === 0 ? undefined : r.subdir)) ?? [];
     }),
   );
-
-  // Fan one fetcher across the focused agent's repos.
-  const forEachRepo = useCallback(
-    (fetch: (id: string, subdir?: string) => Promise<void>) => async () => {
-      if (!agentId) return;
-      await Promise.all(subdirs.map((subdir) => fetch(agentId, subdir)));
-    },
-    [agentId, subdirs],
-  );
-
-  // Full git state — branch, ahead/behind, file list. 1s while the right pane is
-  // showing it (the user is watching a diff); slower when it's collapsed, where
-  // only the title capsule reads it. Local git, but each call forks a process,
-  // so the distinction is worth one ternary.
-  const panelVisible = useAppStore(
-    (s) => !s.rightCollapsed && !s.activeDraftId && !!s.selectedAgentId,
-  );
-  const pollGitState = useCallback(
-    () => forEachRepo(fetchGitState)(),
-    [forEachRepo, fetchGitState],
-  );
-  usePoll(pollGitState, panelVisible ? 1000 : 10000, [pollGitState, panelVisible]);
-
-  // PR state + CI in one backend pass over ETag-conditional REST. Unchanged
-  // reads are 304s GitHub doesn't bill, so there's nothing to back off from.
-  const pollPrLive = useCallback(() => forEachRepo(fetchPrLive)(), [forEachRepo, fetchPrLive]);
-  usePoll(
-    async () => {
-      if (githubConnected) await pollPrLive();
-    },
-    5000,
-    [pollPrLive, githubConnected],
-  );
-
-  // Unresolved review threads — the one panel read still costing GraphQL points,
-  // so it gets the gentlest cadence. Not filtered by PR state here: the backend
-  // returns nothing for a repo whose PR isn't open, and keeping that rule in one
-  // place beats mirroring it in the poller.
-  const pollThreads = useCallback(
-    () => forEachRepo(fetchPrThreads)(),
-    [forEachRepo, fetchPrThreads],
-  );
-  usePoll(
-    async () => {
-      if (githubConnected) await pollThreads();
-    },
-    30000,
-    [pollThreads, githubConnected],
-  );
+  const tick = useCallback(async () => {
+    if (!agentId) return;
+    await Promise.all(subdirs.map((subdir) => fetch(agentId, subdir)));
+  }, [agentId, subdirs, fetch]);
+  usePoll(tick, intervalMs, [tick]);
 }

--- a/src/store/gitSync.ts
+++ b/src/store/gitSync.ts
@@ -1,0 +1,142 @@
+// The app's single owner of git + GitHub polling.
+//
+// Everything git-shaped is fetched here, written into the store, and read from
+// the store by components. No component polls: `useGitPanelData`,
+// `useCapsuleData`, `CodeLivePanel` and the sidebar are all pure views over
+// `gitStates` / `prStates` / `prChecks` / `prComments`.
+//
+// It used to be the other way round — each component polled what it rendered —
+// which meant four independent pollers for one agent's git state and two for its
+// PR, racing each other into the same store keys. `GitPanel`'s `pollDormant`
+// existed purely to cover repos no section happened to be rendering.
+//
+// Two scopes, because they genuinely differ:
+//
+//   fleet    — every agent, cheap projections for the sidebar.
+//   focused  — the selected agent's repos, the detail the panel and title
+//              capsule render.
+//
+// Cadences differ per domain on purpose: 1s is right for a diff the user is
+// watching and absurd for a fleet-wide PR sweep. What's centralized is *who
+// fetches*, not how often.
+
+import { useCallback } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { useAppStore } from "@/store";
+import { usePoll } from "@/util/hooks";
+
+/** Mount once, at the app root. */
+export function useGitSync() {
+  const githubConnected = useAppStore((s) => s.github?.authenticated ?? false);
+
+  const fetchAllShortstats = useAppStore((s) => s.fetchAllShortstats);
+  const fetchAllGitMeta = useAppStore((s) => s.fetchAllGitMeta);
+  const refreshBaseFreshness = useAppStore((s) => s.refreshBaseFreshness);
+  const refreshAllPrStatus = useAppStore((s) => s.refreshAllPrStatus);
+  const fetchGitState = useAppStore((s) => s.fetchGitState);
+  const fetchPrLive = useAppStore((s) => s.fetchPrLive);
+  const fetchPrThreads = useAppStore((s) => s.fetchPrThreads);
+
+  // ── fleet ─────────────────────────────────────────────────────────────────
+
+  // Compact shortstats for every live agent, so sidebar and right-rail badges
+  // stay current without a focused panel. Local git; no network.
+  usePoll(fetchAllShortstats, 5000, [fetchAllShortstats]);
+
+  // Advisory metadata — base staleness + changed-file paths for overlap hints.
+  // Local git too, so it runs regardless of GitHub; slower because a fleet's
+  // base moves far less often than its diffs.
+  usePoll(fetchAllGitMeta, 15000, [fetchAllGitMeta]);
+
+  // Fetches each project's base branch on its source repo so the staleness
+  // chips track a base that moved on GitHub. A git fetch, not an API call.
+  // Silent by contract — a background fetch never raises a user-facing error.
+  usePoll(
+    async () => {
+      if (githubConnected) await refreshBaseFreshness();
+    },
+    300000,
+    [refreshBaseFreshness, githubConnected],
+  );
+
+  // Remote PR status for every repo with a known PR: state plus the CI rollup
+  // that tints each sidebar pill. One batched query for the whole fleet, 1
+  // GraphQL point for up to 50 PRs. 20s while any PR is open, backing off hard
+  // once everything has settled — merged PRs answer from the local snapshot, so
+  // the slow tick only watches for a rare reopen.
+  //
+  // Deliberately derived from the store rather than passed in: the cadence
+  // reacts to the data it fetches.
+  const anyOpenPr = useAppStore((s) => Object.values(s.prStates).some((p) => p?.state === "open"));
+  usePoll(
+    async () => {
+      if (githubConnected) await refreshAllPrStatus();
+    },
+    anyOpenPr ? 20000 : 300000,
+    [refreshAllPrStatus, githubConnected, anyOpenPr],
+  );
+
+  // ── focused agent ─────────────────────────────────────────────────────────
+
+  const agentId = useAppStore((s) => s.selectedAgentId);
+
+  // Every repo of the focused agent, as the `subdir` the fetchers take
+  // (undefined = primary). Covering all of them — not just the ones a panel
+  // section happens to render — is what retired `pollDormant`. Shallow-compared
+  // so the polls below keep a stable identity across unrelated store writes.
+  const subdirs = useAppStore(
+    useShallow((s) => {
+      const agent = s.workspace?.agents.find((a) => a.id === s.selectedAgentId);
+      return agent?.repos.map((r, i) => (i === 0 ? undefined : r.subdir)) ?? [];
+    }),
+  );
+
+  // Fan one fetcher across the focused agent's repos.
+  const forEachRepo = useCallback(
+    (fetch: (id: string, subdir?: string) => Promise<void>) => async () => {
+      if (!agentId) return;
+      await Promise.all(subdirs.map((subdir) => fetch(agentId, subdir)));
+    },
+    [agentId, subdirs],
+  );
+
+  // Full git state — branch, ahead/behind, file list. 1s while the right pane is
+  // showing it (the user is watching a diff); slower when it's collapsed, where
+  // only the title capsule reads it. Local git, but each call forks a process,
+  // so the distinction is worth one ternary.
+  const panelVisible = useAppStore(
+    (s) => !s.rightCollapsed && !s.activeDraftId && !!s.selectedAgentId,
+  );
+  const pollGitState = useCallback(
+    () => forEachRepo(fetchGitState)(),
+    [forEachRepo, fetchGitState],
+  );
+  usePoll(pollGitState, panelVisible ? 1000 : 10000, [pollGitState, panelVisible]);
+
+  // PR state + CI in one backend pass over ETag-conditional REST. Unchanged
+  // reads are 304s GitHub doesn't bill, so there's nothing to back off from.
+  const pollPrLive = useCallback(() => forEachRepo(fetchPrLive)(), [forEachRepo, fetchPrLive]);
+  usePoll(
+    async () => {
+      if (githubConnected) await pollPrLive();
+    },
+    5000,
+    [pollPrLive, githubConnected],
+  );
+
+  // Unresolved review threads — the one panel read still costing GraphQL points,
+  // so it gets the gentlest cadence. Not filtered by PR state here: the backend
+  // returns nothing for a repo whose PR isn't open, and keeping that rule in one
+  // place beats mirroring it in the poller.
+  const pollThreads = useCallback(
+    () => forEachRepo(fetchPrThreads)(),
+    [forEachRepo, fetchPrThreads],
+  );
+  usePoll(
+    async () => {
+      if (githubConnected) await pollThreads();
+    },
+    30000,
+    [pollThreads, githubConnected],
+  );
+}

--- a/src/store/prWriteOrder.ts
+++ b/src/store/prWriteOrder.ts
@@ -1,13 +1,18 @@
 /** Write ordering for the PR store slices.
  *
- *  `prStates` / `prChecks` have several concurrent writers: the Git panel's 5s
- *  `fetchPrLive`, the title capsule's 10s one, the app-wide sweeps, and the
- *  post-merge refresh. `usePoll`'s in-flight guard is per hook instance, so two
- *  components polling the same agent can each have a request outstanding — and
- *  nothing stopped an older one from resolving *last* and overwriting newer
- *  data. That regressed the UI: a merged badge flipping back to open because a
- *  poll issued before the merge landed after it, or a stale CI tint persisting
- *  until the next tick.
+ *  `prStates` / `prChecks` have several concurrent writers, and centralizing the
+ *  polling into `gitSync` did not reduce them to one:
+ *
+ *    - the fleet sweep (`refreshAllPrStatus`, 20s) writes *every* agent's keys,
+ *    - the focused-agent poller (`fetchPrLive`, 5s) writes the selected one's,
+ *    - `createPr` / `commitAndOpenPr` and the pushed `pr:state_changed` event
+ *      write authoritatively at arbitrary moments.
+ *
+ *  The first two overlap on the focused agent's keys at different cadences, so
+ *  an older request can still resolve *last* and overwrite newer data. That
+ *  regressed the UI: a merged badge flipping back to open because a request
+ *  issued before the merge landed after it, or a stale CI tint persisting until
+ *  the next tick.
  *
  *  Every write claims a ticket from one monotonic counter *before* its request,
  *  then applies only if no later-issued write has already landed for the same


### PR DESCRIPTION
Stacked on #536 (based on `fix/throttle-pr-branch-discovery`; GitHub retargets to `main` when that merges).

## Problem

Every component polled what it rendered. For one focused agent that meant:

- **git state — four pollers**: panel sections (1s), `CodeLivePanel` (1s), title capsule (10s), `pollDormant` (5s)
- **PR state + CI — two pollers**: panel (5s), capsule (10s)

They raced each other into the same store keys, and `pollDormant` existed *only* to cover repos that no panel section happened to be rendering — a workaround for the decentralized model rather than a feature.

## Fix

`store/gitSync.ts` owns all of it, mounted once from `App.tsx`. Two scopes, because they genuinely differ:

| scope | what | cadence |
|---|---|---|
| **fleet** | shortstats, git meta, PR sweep, base freshness | 5s / 15s / 20s–5min / 5min |
| **focused** | git state, PR state + CI, review threads | 1s (10s if pane collapsed) / 5s / 30s |

Cadences still differ per domain on purpose — 1s suits a diff the user is watching and is absurd for a fleet-wide sweep. What's centralized is *who fetches*, not how often.

`useGitPanelData`, `useCapsuleData`, `CodeLivePanel` and `GitPanel` are now pure views over `gitStates` / `prStates` / `prChecks` / `prComments`. `useGitPanelData` still returns subdir-bound fetchers, but only for **actions** — after a push or a delegated git op the caller wants the new state now, not at the next tick.

**Net: 163 lines out of components, 142 into one owner.** `pollDormant` and the panel's mount-time sweep are both gone; polling every repo of the focused agent covers them by construction.

## Behaviour is preserved

Git state runs at 1s exactly when a panel section used to be mounted, and 10s otherwise — which is what the capsule polled on its own. `fetchPrLive` goes 10s → 5s while the pane is collapsed: strictly fresher, and free, since unchanged reads are 304s.

## A prediction of mine that did not hold

I expected this to retire the poll-vs-poll half of `prWriteOrder`. **It doesn't.** The fleet sweep writes every agent's keys *including the focused one*, so it still overlaps the 5s focused poller at a different cadence, and an older response can still land last.

The guard stays load-bearing. Worse, its doc comment — and `fetchPrLive`'s — described the panel/capsule pair as the racing writers, which is now wrong and would have invited someone to delete it. Both corrected to name the real pair.

## Left alone deliberately

- `FilePanel`'s tree poll is scoped to which directories are expanded rather than to an agent, so it belongs local.
- **`IssueInbox` is the same anti-pattern, unfixed.** It polls tracker issues on its own 120s tick and holds them in component-local `useState` rather than the store. I left it out because it has no duplication problem (one poller, one consumer), it spans Linear as well as GitHub so it doesn't belong under a `gitSync` owner, and folding it in would mean a new store slice — more surface for consistency alone. Worth doing as a small follow-up if you want the principle applied uniformly.

## Verification

- tsc clean, 563 frontend tests, biome clean on changed files (the 9 warnings in `CodeLivePanel` are pre-existing — identical count on `main`, checked by stashing)
- backend untouched here but re-verified: clippy clean under CI flags, `cargo fmt --check` clean, 1052 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)