### PR TITLE
fix(workspace): make name allocation DB-owned; sweep orphan RPC mailboxes

### DIFF
--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -11,14 +11,27 @@ use crate::new_project;
 use crate::supervisor::Supervisor;
 use crate::workspace::{ProjectDeleteResult, Workspace};
 
-/// Allocate a fresh name from the place pool for a draft agent. The frontend
-/// passes the names already taken (live agents + other open drafts); the
-/// per-build DB is authoritative for the rest, so there's nothing else to fold
-/// in. This is only a preview — `add_agent_allocating` is authoritative at create.
+/// Allocate a fresh name from the place pool for a draft agent.
+///
+/// Not a throwaway preview: a draft carries its name into `spawn_agent`, which
+/// pins it via `add_agent` (see `lifecycle.rs`), so whatever this returns is
+/// the agent's real name — `add_agent_allocating` only runs for the draft-less
+/// path. The reserved set is therefore load-bearing, and the DB owns it:
+/// `live_agent_ids` supplies the live agents, and the caller passes *only*
+/// `drafts` — the open, unpersisted drafts, the one piece of state the frontend
+/// has that the DB can't see.
+///
+/// Deliberately not "caller passes everything that's taken": that let a
+/// frontend set that also counted archived agents saturate the ~300-name pool
+/// and push roughly a quarter of new workspaces onto a `-2` suffix.
 #[tauri::command]
-pub fn allocate_draft_name(used: Vec<String>) -> String {
-    let reserved: std::collections::HashSet<String> = used.into_iter().collect();
-    names::allocate(&reserved)
+pub fn allocate_draft_name(
+    supervisor: State<'_, Arc<Supervisor>>,
+    drafts: Vec<String>,
+) -> Result<String> {
+    let mut reserved = supervisor.workspace.live_agent_ids()?;
+    reserved.extend(drafts);
+    Ok(names::allocate(&reserved))
 }
 
 /// Pin a folder as a workspace project. A folder that isn't a git repository

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1363,6 +1363,16 @@ pub fn run() {
 
             let db_for_wf = db.clone();
             let workspace = Arc::new(WorkspaceManager::new(db));
+
+            // Drop RPC mailboxes left by agents that are gone. Teardown removes
+            // them now, but installs predating that carry one leaked dir per
+            // agent ever spawned. Runs before anything spawns, so every mailbox
+            // present is either a live agent's or an orphan.
+            match workspace.live_agent_ids() {
+                Ok(live) => crate::rpc::sweep_orphan_mailboxes(&live),
+                Err(e) => tracing::warn!(error = %e, "skipping rpc mailbox sweep"),
+            }
+
             let supervisor = Arc::new(Supervisor::new(workspace));
             app.manage(supervisor.clone());
 

--- a/src-tauri/src/names.rs
+++ b/src-tauri/src/names.rs
@@ -330,11 +330,11 @@ pub fn allocate(used: &HashSet<String>) -> String {
             return candidate.to_string();
         }
     }
-    // Every random pick collided. With a ~300-name pool this is vanishingly
-    // rare unless `used` is large — and `used` folds in every on-disk checkout
-    // across all builds sharing the root, so hitting this points at namespace
-    // saturation or a pile-up of orphaned dirs. Log loudly with the set size so
-    // the cause is diagnosable rather than a silent `-2`.
+    // Every random pick collided. `used` is only the caller's live agents (plus
+    // any open drafts), so against a ~300-name pool this should be vanishingly
+    // rare — reaching it means `used` is far larger than the live agent count
+    // and something is over-reserving names. Log the set size so that shows up
+    // as a number rather than a silent `-2`.
     let base = pick_random();
     let mut n: u32 = 2;
     loop {

--- a/src-tauri/src/rpc.rs
+++ b/src-tauri/src/rpc.rs
@@ -153,6 +153,75 @@ pub fn ensure_mailbox(dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Remove one agent's mailbox. Called from teardown (archive / discard)
+/// alongside the checkout removal, so a mailbox's lifetime matches the agent's
+/// rather than accumulating one dead dir per agent ever spawned. Best-effort
+/// and idempotent: an already-absent dir is success, and any other error is the
+/// caller's to log — a surviving mailbox is wasted disk, never a correctness
+/// problem (`ensure_mailbox` recreates and re-chmods at the next spawn).
+pub fn remove_mailbox(agent_id: &str) -> Result<()> {
+    let dir = mailbox_dir(agent_id)?;
+    match std::fs::remove_dir_all(&dir) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(Error::Other(format!(
+            "remove rpc mailbox {}: {e}",
+            dir.display()
+        ))),
+    }
+}
+
+/// Startup sweep: drop every mailbox that doesn't belong to a live agent.
+///
+/// Teardown removes an agent's mailbox from now on, but installs predating that
+/// carry one leaked dir per agent ever spawned, and a crash between spawn and
+/// teardown can still leak one. `live` is this build's non-archived agent ids
+/// (see `WorkspaceManager::live_agent_ids`) — the same set the name allocator
+/// treats as reserved, so the two never disagree about who's alive.
+///
+/// Skipped when `RPC_ROOT_ENV` is set: that's the nested-Fletch redirect, whose
+/// pid-keyed roots are reclaimed by `sandbox::cleanup_nested_rpc_roots`, and
+/// whose live agents belong to a different build's DB than `live`.
+pub fn sweep_orphan_mailboxes(live: &HashSet<String>) {
+    if std::env::var_os(RPC_ROOT_ENV)
+        .filter(|v| !v.is_empty())
+        .is_some()
+    {
+        return;
+    }
+    let Ok(root) = rpc_root() else { return };
+    sweep_orphan_mailboxes_in(&root, live);
+}
+
+/// Testable core of [`sweep_orphan_mailboxes`]: within `root`, remove every
+/// subdir whose name isn't in `live`. Split out so tests don't have to mutate
+/// the process-global `RPC_ROOT_ENV` (which the public fn treats as "skip"),
+/// mirroring `workspace::paths::migrate_checkouts_root_in`. A missing root, a
+/// non-dir entry, and a per-entry failure are all skipped rather than fatal.
+pub(crate) fn sweep_orphan_mailboxes_in(root: &Path, live: &HashSet<String>) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    let mut removed = 0usize;
+    for entry in entries.flatten() {
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        if live.contains(&name) || !entry.path().is_dir() {
+            continue;
+        }
+        match std::fs::remove_dir_all(entry.path()) {
+            Ok(()) => removed += 1,
+            Err(e) => {
+                tracing::warn!(agent_id = %name, error = %e, "orphan rpc mailbox removal failed")
+            }
+        }
+    }
+    if removed > 0 {
+        tracing::info!(removed, live = live.len(), "swept orphan rpc mailboxes");
+    }
+}
+
 /// Process every pending request file once: parse -> dispatch -> write
 /// response -> delete the request. Driven on a fixed tick by the per-agent
 /// watcher. Errors on a single request are logged and isolated — one bad file
@@ -324,6 +393,67 @@ mod tests {
 
     fn write_request(requests: &Path, name: &str, body: &str) {
         std::fs::write(requests.join(name), body).unwrap();
+    }
+
+    fn live(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|n| n.to_string()).collect()
+    }
+
+    #[test]
+    fn sweep_removes_only_mailboxes_without_a_live_agent() {
+        let td = tempfile::tempdir().unwrap();
+        let root = td.path();
+        for name in ["everest", "yellowstone", "gobi"] {
+            ensure_mailbox(&root.join(name)).unwrap();
+        }
+
+        sweep_orphan_mailboxes_in(root, &live(&["everest"]));
+
+        assert!(root.join("everest").is_dir(), "live mailbox was removed");
+        assert!(!root.join("yellowstone").exists());
+        assert!(!root.join("gobi").exists());
+    }
+
+    #[test]
+    fn sweep_removes_a_mailbox_with_pending_traffic_in_it() {
+        // A crashed agent leaves request/response files behind; the sweep must
+        // still clear the dir rather than trip on a non-empty removal.
+        let td = tempfile::tempdir().unwrap();
+        let root = td.path();
+        let dir = root.join("gobi");
+        ensure_mailbox(&dir).unwrap();
+        write_request(&dir.join("requests"), "abc.json", r#"{"op":"echo"}"#);
+
+        sweep_orphan_mailboxes_in(root, &HashSet::new());
+
+        assert!(!dir.exists());
+    }
+
+    #[test]
+    fn sweep_leaves_stray_files_and_a_missing_root_alone() {
+        let td = tempfile::tempdir().unwrap();
+        let root = td.path();
+        std::fs::write(root.join("notes.txt"), "not a mailbox").unwrap();
+
+        sweep_orphan_mailboxes_in(root, &HashSet::new());
+        sweep_orphan_mailboxes_in(&root.join("does-not-exist"), &HashSet::new());
+
+        assert!(
+            root.join("notes.txt").is_file(),
+            "non-dir entry was removed"
+        );
+    }
+
+    #[test]
+    fn sweep_is_idempotent() {
+        let td = tempfile::tempdir().unwrap();
+        let root = td.path();
+        ensure_mailbox(&root.join("gobi")).unwrap();
+
+        sweep_orphan_mailboxes_in(root, &HashSet::new());
+        sweep_orphan_mailboxes_in(root, &HashSet::new());
+
+        assert!(!root.join("gobi").exists());
     }
 
     struct MockDispatcher;

--- a/src-tauri/src/supervisor/disposition.rs
+++ b/src-tauri/src/supervisor/disposition.rs
@@ -443,6 +443,12 @@ async fn teardown_agent_checkouts(agent_id: &str, repos: &[TrackedRepo], op: &st
     // Remove the parent dir (may still hold orphan files if any checkout
     // removal failed). Best-effort, retried + logged (see `remove_agent_dir`).
     let _ = remove_agent_dir(agent_id, op).await;
+
+    // The agent's RPC mailbox dies with it — nothing will ever read from it
+    // again, and leaving it behind leaks one dir per agent ever spawned.
+    if let Err(e) = crate::rpc::remove_mailbox(agent_id) {
+        tracing::warn!(agent_id, op, error = %e, "rpc mailbox removal failed");
+    }
 }
 
 /// Remove an agent's parent checkout dir, retrying briefly. Returns `true` once
@@ -479,8 +485,8 @@ async fn remove_agent_dir(agent_id: &str, op: &str) -> bool {
             Err(e) => {
                 tracing::error!(
                     agent_id, op, path = %parent.display(), error = %e,
-                    "checkout dir removal failed after retries; it now orphans the agent \
-                     name in the on-disk namespace the allocator consults"
+                    "checkout dir removal failed after retries; the dir is wasted disk \
+                     until the next spawn reuses this name and provision clears it"
                 );
                 return false;
             }

--- a/src-tauri/src/workspace/agents.rs
+++ b/src-tauri/src/workspace/agents.rs
@@ -4,6 +4,26 @@
 use super::*;
 
 impl WorkspaceManager {
+    /// Ids of every live (non-archived) agent in this build's DB — the set of
+    /// names that are actually reserved. Archived agents have had their
+    /// checkout and mailbox torn down, so their name is free to reuse.
+    ///
+    /// The one definition of "taken", shared by the draft-name preview
+    /// (`allocate_draft_name`) and the startup mailbox sweep. Callers never
+    /// assemble this set themselves — a caller-supplied set is how archived
+    /// agents once leaked into name allocation and saturated the pool.
+    /// `add_agent_allocating` runs the same query, but inline, because it must
+    /// read inside its own `IMMEDIATE` transaction to stay serialized.
+    pub fn live_agent_ids(&self) -> Result<HashSet<String>> {
+        let conn = self.db.lock();
+        let mut stmt = conn.prepare("SELECT id FROM workspaces WHERE archived_at IS NULL")?;
+        let ids = stmt
+            .query_map([], |row| row.get::<_, String>(0))?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(ids)
+    }
+
     pub fn add_agent(&self, record: &mut AgentRecord) -> Result<()> {
         let conn = self.db.lock();
         let tx = conn.unchecked_transaction()?;

--- a/src-tauri/src/workspace/tests.rs
+++ b/src-tauri/src/workspace/tests.rs
@@ -2059,3 +2059,53 @@ fn add_agent_allocating_assigns_distinct_live_names() {
     assert!(!a.id.is_empty() && !b.id.is_empty());
     assert_ne!(a.id, b.id, "two live agents must not share a name");
 }
+
+/// `live_agent_ids` is the single definition of "this name is taken", shared by
+/// the draft-name preview and the startup mailbox sweep. Archiving must free the
+/// name: counting archived agents is what saturated the ~300-name pool and
+/// pushed new workspaces onto `-2` suffixes.
+#[test]
+fn live_agent_ids_covers_live_agents_and_frees_archived_ones() {
+    let db = test_db();
+    seed_repo(&db, "/r");
+    let wm = WorkspaceManager::new(db);
+
+    for id in ["yosemite", "dolomites"] {
+        let mut rec = new_agent_record(
+            id.into(),
+            id.into(),
+            "claude".into(),
+            mk_repo("/r"),
+            "task".into(),
+            AgentView::Custom,
+        );
+        wm.add_agent(&mut rec).unwrap();
+    }
+
+    assert_eq!(
+        wm.live_agent_ids().unwrap(),
+        HashSet::from(["yosemite".to_string(), "dolomites".to_string()]),
+    );
+
+    wm.archive_agent(
+        "dolomites",
+        ArchiveMetadata {
+            archived_at: "2026-07-29T12:00:00+00:00".into(),
+            repos: vec![],
+            diff_stats: DiffStats {
+                additions: 0,
+                deletions: 0,
+            },
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        wm.live_agent_ids().unwrap(),
+        HashSet::from(["yosemite".to_string()]),
+        "archiving must release the name back to the pool"
+    );
+    // The archived agent is still readable (History shows it) — it just no
+    // longer reserves its name.
+    assert!(wm.agent("dolomites").unwrap().archive.is_some());
+}

--- a/src/api/domains/agents.ts
+++ b/src/api/domains/agents.ts
@@ -110,5 +110,7 @@ export const agentsApi = {
   restoreAgent: (agentId: string) => invoke<void>("restore_agent", { agentId }),
   addRepoToAgent: (agentId: string, repoPath: string) =>
     invoke<TrackedRepo>("add_repo_to_agent", { agentId, repoPath }),
-  allocateDraftName: (used: string[]) => invoke<string>("allocate_draft_name", { used }),
+  /** Name for a new draft. Pass only the *open drafts'* names — the backend
+   *  reads live agents from the DB itself, so callers can't over-reserve. */
+  allocateDraftName: (drafts: string[]) => invoke<string>("allocate_draft_name", { drafts }),
 };

--- a/src/helpers/agentLookups.ts
+++ b/src/helpers/agentLookups.ts
@@ -25,13 +25,17 @@ export function needsSessionIdRefresh(workspace: Workspace | null, agentId: stri
   return !!agent && !agent.session_id;
 }
 
-/** Names already taken by real or draft agents — passed to the backend
- *  name allocator so picks avoid collisions. */
-export function usedNames(workspace: Workspace | null, drafts: DraftAgent[]): Set<string> {
-  const used = new Set<string>();
-  for (const a of workspace?.agents ?? []) used.add(a.name);
-  for (const d of drafts) used.add(d.name);
-  return used;
+/** Names held by open drafts — the only reserved names the backend can't see
+ *  for itself, since a draft isn't persisted until it spawns. Everything else
+ *  taken is a live agent, which `allocate_draft_name` reads from the DB.
+ *
+ *  This used to also fold in `workspace.agents`, but that list carries archived
+ *  agents (History reads the same one), so every archive permanently burned a
+ *  slot in the ~300-name pool and pushed new workspaces onto `-2` suffixes.
+ *  Sending agents at all was the mistake — the DB already knows which are
+ *  live, so the frontend no longer gets a say. */
+export function draftNames(drafts: DraftAgent[]): string[] {
+  return drafts.map((d) => d.name);
 }
 
 /** Drop an agent's entries from a repo-scoped map: the plain `id` key (the

--- a/src/store/drafts.ts
+++ b/src/store/drafts.ts
@@ -3,11 +3,11 @@ import { composeIssueBrief } from "@/components/Workspace/MissionControl/inbox";
 import { DEFAULT_PROVIDER_ID, PROVIDERS } from "@/data/providers";
 import { discoverCommands } from "@/data/slashCommands";
 import {
+  draftNames,
   expandSlashCommand,
   resolveSkillInvocation,
   sendWhenAgentReady,
   snapshotAgentDeliverables,
-  usedNames,
 } from "@/helpers";
 import { setSetting } from "@/storage/settings";
 import { refreshWorkspace } from "./refreshWorkspace";
@@ -118,22 +118,14 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
 
   // ── drafts ─────────────────────────────────────────────────────────────────
   createDraft: async (repoPath) => {
-    const {
-      workspace,
-      drafts,
-      newDraftProvider,
-      newDraftModel,
-      newDraftCustomAgentId,
-      modelsByAgent,
-    } = get();
-    const used = [...usedNames(workspace, drafts)];
+    const { drafts, newDraftProvider, newDraftModel, newDraftCustomAgentId, modelsByAgent } = get();
     // Name allocation is a backend call; if it fails there's no draft to
     // create. Surface it in the global error banner and bail rather than
     // leaving an unhandled rejection for the fire-and-forget callers (⌘N,
     // the sidebar +, the Home screen) and a silently dead click.
     let name: string;
     try {
-      name = await api.allocateDraftName(used);
+      name = await api.allocateDraftName(draftNames(drafts));
     } catch (e) {
       get().setLastError(`Couldn't start a new agent: ${String(e)}`);
       return;
@@ -162,16 +154,8 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
   },
 
   startWorkFromIssue: async (repoPath, issue) => {
-    const {
-      workspace,
-      drafts,
-      newDraftProvider,
-      newDraftModel,
-      newDraftCustomAgentId,
-      modelsByAgent,
-    } = get();
-    const used = [...usedNames(workspace, drafts)];
-    const name = await api.allocateDraftName(used);
+    const { drafts, newDraftProvider, newDraftModel, newDraftCustomAgentId, modelsByAgent } = get();
+    const name = await api.allocateDraftName(draftNames(drafts));
     const selection = normalizeDraftSelection(newDraftProvider, newDraftModel, modelsByAgent);
     const customAgentId = get().customAgents.some((a) => a.id === newDraftCustomAgentId)
       ? newDraftCustomAgentId
@@ -239,10 +223,9 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
   },
 
   rerollDraftName: async (id) => {
-    const { workspace, drafts } = get();
-    const used = usedNames(workspace, drafts);
-    // Keep the current name in `used` so the allocator picks a different one.
-    const next = await api.allocateDraftName([...used]);
+    // This draft's current name stays in the list, so the allocator is forced
+    // to pick a different one.
+    const next = await api.allocateDraftName(draftNames(get().drafts));
     set((s) => ({
       drafts: s.drafts.map((d) => (d.id === id ? { ...d, name: next } : d)),
     }));

--- a/tests/helpers/draft-names.test.ts
+++ b/tests/helpers/draft-names.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { draftNames } from "@/helpers";
+import type { DraftAgent } from "@/store";
+
+function draft(name: string): DraftAgent {
+  return { id: `draft-${name}`, name } as DraftAgent;
+}
+
+describe("draftNames", () => {
+  it("reserves every open draft's name so two drafts never collide", () => {
+    expect(draftNames([draft("gobi"), draft("kyoto")])).toEqual(["gobi", "kyoto"]);
+  });
+
+  it("is empty with no drafts", () => {
+    expect(draftNames([])).toEqual([]);
+  });
+
+  // Regression guard for the `-2` suffix bug: this helper must NOT reach into
+  // `workspace.agents`. That list carries archived agents (History reads the
+  // same one), so folding it in burned a pool slot per archive until the
+  // allocator fell back to numbered suffixes. Live agents are the DB's job —
+  // see `allocate_draft_name` / `live_agent_ids`.
+  it("takes only drafts — it has no access to the agent list", () => {
+    expect(draftNames.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

New workspaces were landing with `-2` suffixes (`yellowstone-2`) despite 8dd2d63 making name allocation DB-authoritative.

That fix was correct, but it covered a path normal spawns don't take. A draft carries its name into `spawn_agent`, which pins it via `add_agent` — so the *preview* name from `allocate_draft_name` **is** the agent's real name. `add_agent_allocating` (the path 8dd2d63 fixed) only runs for the draft-less path.

The preview took its reserved set from the caller, and the frontend built it from `workspace.agents` — which carries archived agents, since History reads the same list. Every archive therefore burned a slot in the ~294-name pool permanently:

```
WARN names: name allocator exhausted 10 random picks; falling back to a
numbered suffix used=254 pool=294 name=yellowstone-2
```

At `used=254` of 294, `0.864^10 ≈ 23%` of new workspaces hit the suffix fallback — intermittent enough to look fixed.

## Fix: move ownership, not the filter

A one-line `!a.archive` filter would have made the current caller correct while leaving the next one free to get it wrong. The DB already knows which agents are live; the frontend knows exactly one thing it doesn't — open, unpersisted drafts.

So `allocate_draft_name` now reads live agents itself and accepts only `drafts`:

```rust
pub fn allocate_draft_name(
    supervisor: State<'_, Arc<Supervisor>>,
    drafts: Vec<String>,
) -> Result<String> {
    let mut reserved = supervisor.workspace.live_agent_ids()?;
    reserved.extend(drafts);
    Ok(names::allocate(&reserved))
}
```

The agent list is no longer a parameter, so over-reserving isn't expressible. `usedNames(workspace, drafts)` collapses to `draftNames(drafts)`, and `drafts.ts` loses 33 lines of set assembly.

`WorkspaceManager::live_agent_ids` is now the single definition of "taken", shared with the mailbox sweep. `add_agent_allocating` keeps its inline copy of the query deliberately — it must read inside its own `IMMEDIATE` transaction to stay serialized.

## RPC mailbox cleanup

Mailboxes leaked one dir per agent ever spawned (279 on this machine) — teardown never removed them.

- Teardown drops the agent's mailbox alongside its checkout.
- A startup sweep clears any mailbox without a live agent, covering installs predating the above and crashes between spawn and teardown. Skipped under `RPC_ROOT_ENV`, whose pid-keyed nested-Fletch roots are reclaimed by `cleanup_nested_rpc_roots`. Split into a `_in(root, live)` core so tests don't mutate process-global env, mirroring `migrate_checkouts_root_in`.

## Three corrected comments

These are why the gap survived 8dd2d63 — `commands/workspace.rs` asserted both halves of it away:

> *"the per-build DB is authoritative for the rest, so there's nothing else to fold in. This is only a preview — `add_agent_allocating` is authoritative at create."*

Both false. Also `names.rs` (still described the filesystem scan 8dd2d63 deleted) and a `disposition.rs` error log claiming a leftover dir orphans a name in "the on-disk namespace the allocator consults" — contradicting the doc comment four lines above it.

## Tests

1057 Rust + 566 frontend passing; clippy and `tsc` clean.

- `tests/helpers/draft-names.test.ts` — new, incl. a guard that the helper can't reach the agent list
- `live_agent_ids_covers_live_agents_and_frees_archived_ones` — archiving releases the name
- four `rpc.rs` sweep tests: live mailboxes survive, non-empty dirs clear, stray files and a missing root are left alone, idempotent

## Notes

- Existing `-2` workspaces keep their names; this only affects new allocations.
- The `-2` was not reproduced live (that needs a saturated DB) — the evidence is the log line above plus the removed code path, not an observed before/after.
- **Base**: this targets `main`, which is 148 commits behind `origin/HEAD` (`docs/readme-code-index`), so the PR carries those already-merged commits alongside this change. The fix itself is the single commit `de21aba`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)