### PR TITLE
fix(spawn): fork new workspaces from the remote base, never the checked-out branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ### A new kind of IDE for agentic engineering.
 
-Run Claude Code, Codex, Cursor, OpenCode and more in parallel, each in an isolated sandbox, chained into deterministic workflows that plan, build, review, and test.
+Run Claude Code, Codex, Cursor, OpenCode and more in sealed workspaces, each with its own repo clone and a served index of your codebase, chained into deterministic workflows that plan, build, review, and test.
 
 [![Download for macOS](https://img.shields.io/badge/Download%20for%20macOS-Apple%20Silicon%20%26%20Intel-111?style=for-the-badge&logo=apple)](https://fletch.sh)
 
@@ -47,6 +47,8 @@ If you want to fire off a dozen agents and merge whatever comes back, there are 
 ## What you get
 
 **Real isolation.** Every agent gets its own full clone of your repo (shared git objects make spawning effectively free), sandboxed by macOS Seatbelt by default or by an opt-in Docker container per agent. Either way, an agent can't touch your repo, your machine, or another agent's work.
+
+**Agents that know your codebase.** Isolation has a cost nobody mentions: an agent alone in a fresh clone has to rediscover your project by grepping. So Fletch indexes your repo's symbols and call graph and serves it to every agent as an MCP server — an agent asks where a symbol is defined and what calls it instead of reading files until it finds out. The index is built in a throwaway mirror clone and copied into each workspace, so nothing is ever written to your repo, and a file watcher keeps it current as the agent edits. Built on [codegraph](https://github.com/colbymchenry/codegraph), which Fletch vendors and drives rather than reimplements. Best-effort by design: if indexing fails, the agent falls back to searching files and the run continues. On by default, with a toggle in Settings.
 
 **Deterministic workflows.** Define a pipeline once (architect, coder, reviewer, tester) and launch it on any task. Steps hand context forward, loops repeat _review → fix_ until a verdict says done, parallel blocks fan work out and join it back. Control flow belongs to the engine, not to an LLM: gates are checked, budgets (turns, iterations, wall-clock, tokens) are enforced, every pause names its cause, and runs survive an app restart. Workflows are shareable YAML.
 

--- a/src-tauri/src/commands/git_ops.rs
+++ b/src-tauri/src/commands/git_ops.rs
@@ -79,6 +79,16 @@ pub async fn list_repo_branches(repo_path: String) -> Result<Vec<String>> {
     git::list_local_branches(Path::new(&repo_path)).await
 }
 
+/// The repo's default branch — what the new-agent screen pre-selects as the
+/// base, instead of assuming `"main"` (which silently forks the wrong branch on
+/// a `master`/`develop` repo). Resolved from the repo's remote, never from the
+/// branch the user currently has checked out; see `git::default_branch`.
+/// Infallible by construction — falls back to `"main"` on its own.
+#[tauri::command]
+pub async fn repo_default_branch(repo_path: String) -> Result<String> {
+    Ok(git::default_branch(Path::new(&repo_path)).await)
+}
+
 /// Force-delete the agent's local branch from its parent repository.
 /// Used by the merged-state UI to clean up after a PR lands. Safe-noops
 /// if the branch is already gone (matches `git::branch_delete` semantics).
@@ -113,6 +123,12 @@ pub async fn rebase_agent(
     subdir: Option<String>,
 ) -> Result<()> {
     let (repo, checkout) = agent_repo_checkout(&supervisor, &agent_id, subdir.as_deref())?;
-    let base = repo.parent_branch.as_deref().unwrap_or("main");
-    git::rebase_onto(&checkout, base).await
+    // `parent_branch` is always recorded at spawn now; the fallback only covers
+    // rows written before that, and resolves the repo's real default rather than
+    // assuming `"main"`.
+    let base = match repo.parent_branch.as_deref() {
+        Some(b) => b.to_string(),
+        None => git::default_branch(&repo.repo_path).await,
+    };
+    git::rebase_onto(&checkout, &base).await
 }

--- a/src-tauri/src/commands/git_state.rs
+++ b/src-tauri/src/commands/git_state.rs
@@ -15,6 +15,18 @@ use crate::workspace::repo_checkout_path;
 
 use super::files::agent_repo_checkout_opt;
 
+/// The base branch a checkout is measured against. Every repo tracked since the
+/// spawn path started resolving a default has one recorded; the fallback only
+/// covers older rows, and asks the repo what its default actually is rather than
+/// assuming `"main"` — guessing wrong there silently reports a `master` repo as
+/// unmeasurably behind.
+async fn base_branch(repo: &crate::workspace::TrackedRepo) -> String {
+    match &repo.parent_branch {
+        Some(base) => base.clone(),
+        None => git::default_branch(&repo.repo_path).await,
+    }
+}
+
 /// Returns git state for one of the agent's checkouts — the repo whose
 /// `subdir` matches, or the primary when none is given.
 #[tauri::command]
@@ -28,8 +40,8 @@ pub async fn get_git_state(
     else {
         return Ok(None);
     };
-    let parent = repo.parent_branch.as_deref().unwrap_or("main");
-    let state = git_state::query(&checkout, parent).await?;
+    let parent = base_branch(&repo).await;
+    let state = git_state::query(&checkout, &parent).await?;
     Ok(Some(state))
 }
 
@@ -120,10 +132,14 @@ pub async fn get_all_git_meta(
             let Ok(checkout) = repo_checkout_path(&agent.id, &repo.subdir) else {
                 continue;
             };
-            let base = repo.parent_branch.clone().unwrap_or_else(|| "main".into());
             let key = crate::supervisor::pr_map_key(&agent.id, &repo.subdir, i == 0);
             let source = repo.repo_path.clone();
+            // Resolved inside the task, not in this loop: the legacy-row branch
+            // shells out to git, and doing that serially would make the poll's
+            // latency scale with the fleet size instead of the slowest checkout.
+            let repo = repo.clone();
             set.spawn(async move {
+                let base = base_branch(&repo).await;
                 let base_sha = git::remote_base_sha(&source, &base).await;
                 let meta = git_state::git_meta(&checkout, &base, base_sha.as_deref()).await;
                 (key, meta)
@@ -166,8 +182,7 @@ pub async fn refresh_base_freshness(supervisor: State<'_, Arc<Supervisor>>) -> R
             continue;
         }
         for repo in &agent.repos {
-            let base = repo.parent_branch.clone().unwrap_or_else(|| "main".into());
-            seen.insert((repo.repo_path.clone(), base));
+            seen.insert((repo.repo_path.clone(), base_branch(repo).await));
         }
     }
     for (source, base) in seen {

--- a/src-tauri/src/git/branch.rs
+++ b/src-tauri/src/git/branch.rs
@@ -12,22 +12,30 @@ use super::cmd::{apply_github_auth, git_output, no_hooks_env, run_git, run_git_e
 /// past the supervisor's 15s spawn watchdog — which would mark the agent
 /// `Error` while the background task later still runs `start_process`, leaving
 /// a live process under a failed-looking agent. Bounding it keeps the fetch
-/// inside the spawn budget; on timeout we fall back to local HEAD.
+/// inside the spawn budget; on timeout the caller degrades to a local ref.
 const FETCH_TIMEOUT: Duration = Duration::from_secs(8);
 
-/// Best-effort fetch of `branch` from `origin` so a freshly-spawned checkout
-/// can fork from the latest remote state rather than a stale local ref.
-/// Returns the commit-ish a checkout should be based on — the SHA that
-/// `origin/<branch>` resolves to **in this repo** when the fetch succeeded —
-/// otherwise `None`, signalling the caller to fall back to local HEAD.
+/// Best-effort fetch of `branch` from `origin`, returning the SHA that
+/// `origin/<branch>` resolves to **in `repo`** afterwards — the tip a checkout
+/// should fork from — or `None` when the remote couldn't be reached.
 ///
-/// The SHA (not the symbolic `origin/<branch>`) is essential for Clone-mode
-/// provisioning: the checkout is a `git clone --shared` of this repo, so
-/// inside the clone `origin/<branch>` resolves to this repo's *local*
-/// `refs/heads/<branch>` — potentially stale — not the remote-tracking ref
-/// the fetch just updated. A SHA resolves identically everywhere, and its
-/// objects are reachable from the clone via alternates (shared clones) or
-/// the copied object store (self-contained clones).
+/// Run this on the freshly-provisioned **workspace clone**, not on the source
+/// repo, and that is the whole point. A workspace is `git clone --shared
+/// <source path>`, and `git clone` of a local path maps the source's *local*
+/// `refs/heads/*` into the clone's `refs/remotes/origin/*` (the source's own
+/// remote-tracking refs are never copied); provisioning then repoints `origin`
+/// at the real GitHub URL. So before this fetch, a workspace's `origin/<branch>`
+/// looks like a remote-tracking ref but is really a snapshot of the source's
+/// local branch — arbitrarily far behind the branch on GitHub. Fetching here
+/// corrects that ref *and* yields the true fork point; fetching into the source
+/// instead would do neither, because the clone borrows the source's objects but
+/// not its refs.
+///
+/// Returns the SHA rather than the symbolic `origin/<branch>` because the fork
+/// point must stay pinned: it is recorded as the workspace's `base_sha` (the
+/// diff baseline) and passed to `checkout --detach`, where a *branch name* the
+/// clone has no local head for would trip git's remote-DWIM (an implicit `-b`)
+/// and fail.
 ///
 /// Never errors: a missing `origin`, an offline machine, or a purely local
 /// branch are all expected and simply mean "use local state".
@@ -41,17 +49,72 @@ pub async fn fetch_fork_point(repo: &Path, branch: &str) -> Option<String> {
         .kill_on_drop(true);
     apply_github_auth(&mut fetch_cmd);
     let fetched = tokio::time::timeout(FETCH_TIMEOUT, fetch_cmd.output()).await;
-    // Timed out, failed to spawn, or non-zero exit → fall back to local HEAD.
+    // Timed out, failed to spawn, or non-zero exit → the caller degrades.
     match fetched {
         Ok(Ok(out)) if out.status.success() => {}
         _ => return None,
     }
     // Resolve the remote-tracking ref to a SHA here, in the repo the fetch
     // updated. This both confirms the refspec mapped the branch into
-    // refs/remotes and pins the base to the fetched tip regardless of which
-    // repo (source or clone) later checks it out.
+    // refs/remotes and pins the base to the fetched tip.
     let remote_ref = format!("origin/{branch}");
     rev_parse(repo, &remote_ref).await.ok()
+}
+
+/// Remote-tracking refs, then local heads, for the two conventional default
+/// branch names — the probe order [`default_branch`] falls through when the
+/// repo has no `origin/HEAD` symref to read.
+const DEFAULT_BRANCH_CANDIDATES: [&str; 4] = [
+    "refs/remotes/origin/main",
+    "refs/remotes/origin/master",
+    "refs/heads/main",
+    "refs/heads/master",
+];
+
+/// The repo's default branch — the base a new agent forks from when the user
+/// didn't pick one on the new-agent screen.
+///
+/// Read from `refs/remotes/origin/HEAD`, the symref `git clone` writes to record
+/// what the remote's HEAD pointed at. That is the same branch GitHub calls the
+/// repository default, resolved locally: no network round-trip on the spawn
+/// path and no GitHub token required. Repos built by `git init` + `git remote
+/// add` never get that symref, so fall through to whichever conventional name
+/// actually exists (remote-tracking first, then local, so a mirror of an
+/// unfetched repo still resolves), and only then to `"main"`.
+///
+/// Deliberately infallible and deliberately *never* the currently-checked-out
+/// branch. Forking a new agent from whatever the user happens to have open is
+/// never the intent — the user may pick their current branch from the dropdown,
+/// but it must never be the implicit default. A wrong guess here is recoverable
+/// (pick a base in the dropdown); an error would block the spawn.
+pub async fn default_branch(repo: &Path) -> String {
+    if let Ok(out) = git_output(
+        repo,
+        &["symbolic-ref", "--short", "-q", "refs/remotes/origin/HEAD"],
+    )
+    .await
+    {
+        if out.status.success() {
+            let full = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if let Some(branch) = full.strip_prefix("origin/") {
+                if !branch.is_empty() {
+                    return branch.to_string();
+                }
+            }
+        }
+    }
+    for refname in DEFAULT_BRANCH_CANDIDATES {
+        if let Ok(out) = git_output(repo, &["show-ref", "--verify", "--quiet", refname]).await {
+            if out.status.success() {
+                // Every candidate is a full refname whose last segment is the
+                // branch name (none of the conventional names contain a slash).
+                if let Some(branch) = refname.rsplit('/').next() {
+                    return branch.to_string();
+                }
+            }
+        }
+    }
+    "main".to_string()
 }
 
 /// Inside an existing checkout, create a new branch at the current
@@ -203,6 +266,7 @@ pub async fn list_local_branches(repo: &Path) -> Result<Vec<String>> {
 mod tests {
     use super::super::worktree::{commit_all, init_repo};
     use super::*;
+    use std::path::PathBuf;
     use tokio::process::Command;
 
     async fn config(repo: &Path, key: &str, val: &str) {
@@ -232,11 +296,9 @@ mod tests {
 
     #[tokio::test]
     async fn fetch_fork_point_returns_fetched_tip_sha_not_stale_local_head() {
-        // Clone-mode workspaces are `git clone --shared` of the source repo,
-        // where `origin/<branch>` resolves to the source's *local* head —
-        // stale when the user hasn't pulled. The fork point must therefore be
-        // the SHA of the freshly-fetched remote tip, resolved in the source
-        // repo, never the symbolic `origin/<branch>`.
+        // The fork point must be the SHA of the freshly-fetched remote tip, not
+        // whatever the repo already had locally — the whole reason provisioning
+        // calls this instead of resolving a ref it inherited.
         let td = tempfile::tempdir().unwrap();
 
         // `upstream` plays the true remote.
@@ -269,5 +331,90 @@ mod tests {
 
         let base = fetch_fork_point(&source, "main").await.unwrap();
         assert_eq!(base, upstream_tip);
+    }
+
+    /// A repo with a real `origin`, cloned from `upstream` so git writes the
+    /// `refs/remotes/origin/HEAD` symref the way it does for a user's checkout.
+    /// Returns (upstream, clone).
+    async fn cloned_repo(td: &Path, default: &str) -> (PathBuf, PathBuf) {
+        let upstream = td.join("upstream");
+        init_repo(&upstream).await.unwrap();
+        config(&upstream, "user.email", "t@example.com").await;
+        config(&upstream, "user.name", "Tester").await;
+        std::fs::write(upstream.join("a.txt"), b"one").unwrap();
+        commit_all(&upstream, "first").await.unwrap();
+        // Rename (not `checkout -B`) so the initial branch doesn't linger: `git
+        // init` names it from the host's `init.defaultBranch`, and a stray
+        // `main`/`master` would make the fallback probes non-deterministic.
+        run_git(&upstream, &["branch", "-m", default], "branch -m default")
+            .await
+            .unwrap();
+
+        let clone = td.join("clone");
+        let out = Command::new("git")
+            .current_dir(td)
+            .args(["clone", upstream.to_str().unwrap(), "clone"])
+            .output()
+            .await
+            .unwrap();
+        assert!(out.status.success());
+        (upstream, clone)
+    }
+
+    #[tokio::test]
+    async fn default_branch_reads_origin_head_not_the_checked_out_branch() {
+        // The product rule: a new agent must never implicitly fork from
+        // whatever the user happens to have open. `develop` is checked out and
+        // `master` also exists — neither may win over the remote's HEAD.
+        let td = tempfile::tempdir().unwrap();
+        let (_upstream, repo) = cloned_repo(td.path(), "trunk").await;
+        run_git(&repo, &["checkout", "-b", "develop"], "checkout -b develop")
+            .await
+            .unwrap();
+        run_git(&repo, &["branch", "master"], "branch master")
+            .await
+            .unwrap();
+
+        assert_eq!(default_branch(&repo).await, "trunk");
+    }
+
+    #[tokio::test]
+    async fn default_branch_falls_back_to_a_conventional_name_without_origin_head() {
+        // `git init` + `git remote add` never writes the `origin/HEAD` symref,
+        // so fall through to whichever conventional name actually exists —
+        // `master` here, not the hardcoded `"main"` that used to be assumed.
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path().join("repo");
+        init_repo(&repo).await.unwrap();
+        config(&repo, "user.email", "t@example.com").await;
+        config(&repo, "user.name", "Tester").await;
+        std::fs::write(repo.join("a.txt"), b"x").unwrap();
+        commit_all(&repo, "first").await.unwrap();
+        run_git(&repo, &["branch", "-m", "master"], "branch -m master")
+            .await
+            .unwrap();
+        run_git(&repo, &["checkout", "-b", "wip"], "checkout -b wip")
+            .await
+            .unwrap();
+
+        assert_eq!(default_branch(&repo).await, "master");
+    }
+
+    #[tokio::test]
+    async fn default_branch_last_resort_is_main() {
+        // Nothing to go on (no origin, no conventionally-named branch): return
+        // `"main"` rather than erroring, so a spawn is never blocked on this.
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path().join("repo");
+        init_repo(&repo).await.unwrap();
+        config(&repo, "user.email", "t@example.com").await;
+        config(&repo, "user.name", "Tester").await;
+        std::fs::write(repo.join("a.txt"), b"x").unwrap();
+        commit_all(&repo, "first").await.unwrap();
+        run_git(&repo, &["branch", "-m", "trunk"], "branch -m trunk")
+            .await
+            .unwrap();
+
+        assert_eq!(default_branch(&repo).await, "main");
     }
 }

--- a/src-tauri/src/git/branch.rs
+++ b/src-tauri/src/git/branch.rs
@@ -117,6 +117,38 @@ pub async fn default_branch(repo: &Path) -> String {
     "main".to_string()
 }
 
+/// This machine's best-known tip for `base` — what a fresh workspace opens at
+/// when it can't reach `origin`.
+///
+/// Prefers `origin/<base>` over the local head. The tracking ref is the fresher
+/// of the two: the app advances it on a background sweep
+/// (`refresh_base_freshness`), while a local branch only moves when the user
+/// checks it out and pulls. It is also the one that exists at all in a
+/// single-branch clone, or for a default branch resolved from `origin/HEAD`
+/// that was never checked out locally.
+///
+/// `None` means this machine has genuinely never seen `base`. Callers must not
+/// paper over that with `HEAD`: that is the currently-checked-out branch, which
+/// has nothing to do with `base` and is exactly what [`default_branch`] exists
+/// to avoid. Substituting it would open the workspace on an unrelated feature
+/// branch *and* report it as `base` — a wrong answer delivered confidently.
+/// Prefer failing the spawn.
+pub async fn base_tip(repo: &Path, base: &str) -> Option<String> {
+    // Full refnames, so a branch called e.g. `origin` can't make the short form
+    // ambiguous, and so a tag never satisfies a branch lookup.
+    for refname in [
+        format!("refs/remotes/origin/{base}"),
+        format!("refs/heads/{base}"),
+    ] {
+        if let Ok(sha) = rev_parse(repo, &refname).await {
+            if !sha.is_empty() {
+                return Some(sha);
+            }
+        }
+    }
+    None
+}
+
 /// Inside an existing checkout, create a new branch at the current
 /// commit and check it out (`git checkout -b <branch>`). Used to
 /// promote a detached-HEAD checkout onto a named branch once the
@@ -416,5 +448,93 @@ mod tests {
             .unwrap();
 
         assert_eq!(default_branch(&repo).await, "main");
+    }
+
+    /// `base_tip` prefers the remote-tracking ref: the app advances it on a
+    /// background sweep, so it is the fresher of the two, and it is the only one
+    /// that exists for a base the user never checked out locally.
+    #[tokio::test]
+    async fn base_tip_prefers_the_tracking_ref_over_the_local_head() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path();
+        init_repo(repo).await.unwrap();
+        config(repo, "user.email", "t@example.com").await;
+        config(repo, "user.name", "Tester").await;
+        std::fs::write(repo.join("a.txt"), b"x").unwrap();
+        commit_all(repo, "first").await.unwrap();
+        let local = rev_parse(repo, "HEAD").await.unwrap();
+
+        // A tracking ref that has moved ahead of the local branch.
+        std::fs::write(repo.join("b.txt"), b"y").unwrap();
+        commit_all(repo, "second").await.unwrap();
+        let ahead = rev_parse(repo, "HEAD").await.unwrap();
+        run_git(
+            repo,
+            &["update-ref", "refs/remotes/origin/main", &ahead],
+            "seed tracking ref",
+        )
+        .await
+        .unwrap();
+        run_git(
+            repo,
+            &["update-ref", "refs/heads/main", &local],
+            "rewind local main",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(base_tip(repo, "main").await, Some(ahead));
+    }
+
+    #[tokio::test]
+    async fn base_tip_falls_back_to_the_local_head() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path();
+        init_repo(repo).await.unwrap();
+        config(repo, "user.email", "t@example.com").await;
+        config(repo, "user.name", "Tester").await;
+        std::fs::write(repo.join("a.txt"), b"x").unwrap();
+        commit_all(repo, "first").await.unwrap();
+        let head = rev_parse(repo, "HEAD").await.unwrap();
+        run_git(
+            repo,
+            &["update-ref", "refs/heads/main", &head],
+            "seed local main",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(base_tip(repo, "main").await, Some(head));
+    }
+
+    /// Regression guard for the spawn path: a base this machine has never seen
+    /// must resolve to `None`, NOT to whatever branch happens to be checked out.
+    /// Returning a tip here would open the workspace on an unrelated branch and
+    /// then report it as the base — the failure `base_tip` exists to prevent.
+    #[tokio::test]
+    async fn base_tip_is_none_for_an_unknown_base_even_with_a_branch_checked_out() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path();
+        init_repo(repo).await.unwrap();
+        config(repo, "user.email", "t@example.com").await;
+        config(repo, "user.name", "Tester").await;
+        std::fs::write(repo.join("a.txt"), b"x").unwrap();
+        commit_all(repo, "first").await.unwrap();
+        run_git(
+            repo,
+            &["checkout", "-q", "-b", "feature"],
+            "checkout feature",
+        )
+        .await
+        .unwrap();
+        let checked_out = rev_parse(repo, "HEAD").await.unwrap();
+
+        let got = base_tip(repo, "develop").await;
+        assert_eq!(got, None, "unknown base must not resolve");
+        assert_ne!(
+            got,
+            Some(checked_out),
+            "must never hand back the checked-out branch"
+        );
     }
 }

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -117,6 +117,31 @@ pub fn multi_repo_workspace_note(repos: &[crate::workspace::TrackedRepo]) -> Opt
     ))
 }
 
+/// Per-agent heads-up for a workspace whose base branch could not be fetched
+/// from `origin` while it was being provisioned (offline, no credentials, the
+/// branch gone from the remote). Composed ahead of any custom brief by the
+/// spawn path, exactly like [`multi_repo_workspace_note`], and only for the
+/// agents that actually degraded — see `provision::BaseFreshness`.
+///
+/// The agent, not the app, delivers this: it is the surface the user is already
+/// talking to, and it knows whether the task even depends on being current. The
+/// alternative — failing the spawn — would make an offline machine unusable,
+/// and staying quiet would let the agent redo work that already landed on the
+/// base branch.
+pub fn stale_base_note(base: &str) -> String {
+    format!(
+        "## Heads-up: this workspace's base may be out of date\n\n\
+         Fletch could not reach `origin` while creating this workspace, so it started from \
+         the last copy of `{base}` present on this machine rather than the branch's current \
+         tip on the remote. Your starting commit — and `origin/{base}` inside this checkout \
+         — may be behind by an unknown amount.\n\n\
+         Tell the user this early, before doing work that depends on being up to date \
+         (anything touching recently-changed code, or a task that may already have landed \
+         on `{base}`). Once the network or GitHub credentials are back, \
+         `git fetch origin {base}` in this checkout brings it current."
+    )
+}
+
 /// The global instruction text plus an optional per-session suffix (a custom
 /// agent's standing brief). The suffix is appended *after* the global block so
 /// project/global guidance composes with the agent's role rather than replacing
@@ -328,6 +353,19 @@ mod tests {
         assert!(note.contains("args"), "must point at args.repo: {note}");
         // No redundant "frontend — frontend" suffix when label == subdir.
         assert!(!note.contains("frontend/` — frontend"), "note: {note}");
+    }
+
+    #[test]
+    fn stale_base_note_names_the_base_and_asks_the_agent_to_tell_the_user() {
+        // The whole point of the note is that the *agent* relays the
+        // degradation, so it must name the branch and say to speak up.
+        let note = stale_base_note("develop");
+        assert!(note.contains("`develop`"), "note: {note}");
+        assert!(note.contains("Tell the user"), "note: {note}");
+        assert!(
+            note.contains("git fetch origin develop"),
+            "note must give the recovery command: {note}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1565,6 +1565,7 @@ pub fn run() {
             commands::abort_merge_agent,
             commands::delete_branch_agent,
             commands::list_repo_branches,
+            commands::repo_default_branch,
             commands::create_pr,
             commands::merge_pr,
             commands::get_pr_state,

--- a/src-tauri/src/sandbox/provision.rs
+++ b/src-tauri/src/sandbox/provision.rs
@@ -119,6 +119,20 @@ pub async fn provision_at_remote_base(
                 Ok(BaseFreshness::Fetched)
             }
             None => {
+                // No fallback to degrade to: the fetch failed *and* this
+                // machine has never seen the base (`git::base_tip` found
+                // nothing, so the caller passed the bare branch name). Say that
+                // plainly — the alternative reads as a raw `rev-parse` failure,
+                // and opening somewhere arbitrary is what this whole function
+                // exists to prevent.
+                if !commit_present(&dest, spec.base_ref).await {
+                    return Err(Error::Git(format!(
+                        "could not fetch `{base_branch}` from origin, and this machine has \
+                         no copy of it to fall back to — there is no commit to open the \
+                         workspace at. Connect to the network, or pick a base branch this \
+                         repo already has."
+                    )));
+                }
                 tracing::warn!(
                     base = %base_branch,
                     dest = %dest.display(),
@@ -740,6 +754,41 @@ mod tests {
 
         assert_eq!(freshness, BaseFreshness::Stale);
         assert_eq!(run(&dest, &["rev-parse", "HEAD"]), stale);
+    }
+
+    #[tokio::test]
+    async fn provision_at_remote_base_errors_when_offline_with_no_local_copy_of_the_base() {
+        // The fetch fails *and* this machine has never seen the base, so
+        // `git::base_tip` found nothing and the caller passed the bare branch
+        // name. There is no commit to open at. Failing here is the point: the
+        // spawn path used to substitute `HEAD` — the source repo's checked-out
+        // branch — which opened the workspace on an unrelated branch and then
+        // told the agent it was on the base.
+        let td = tempfile::tempdir().unwrap();
+        let (source, _stale, _fresh) = fixture_with_stale_source(td.path());
+        let unreachable = td.path().join("gone.git");
+        run(
+            &source,
+            &["remote", "set-url", "origin", unreachable.to_str().unwrap()],
+        );
+        let dest = td.path().join("clone");
+        let spec = CheckoutSpec {
+            source_repo: &source,
+            // What the caller passes when `base_tip` returns `None`.
+            base_ref: "develop",
+            dest: &dest,
+        };
+
+        let err = provision_at_remote_base(&spec, "develop", true)
+            .await
+            .expect_err("no fetch and no local copy must not silently pick a commit");
+
+        let msg = err.to_string();
+        assert!(msg.contains("develop"), "error should name the base: {msg}");
+        assert!(
+            msg.contains("no copy of it"),
+            "error should explain why, not read as a raw rev-parse failure: {msg}"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/sandbox/provision.rs
+++ b/src-tauri/src/sandbox/provision.rs
@@ -12,7 +12,10 @@
 //! objects) and copies **no** objects, so a spawn costs kilobytes and
 //! milliseconds instead of a full history copy. New objects (agent commits,
 //! fetches) land in the clone's own `.git/objects`; reads of existing history
-//! fall through to the borrowed store. Because the clone lives at the normal
+//! fall through to the borrowed store. That property is what makes
+//! [`provision_at_remote_base`]'s spawn-time `git fetch` cheap and safe: only
+//! commits the source has never seen transfer, and they never touch the user's
+//! object store. Because the clone lives at the normal
 //! host path, all host-side git (diff polling, RPC commit/push,
 //! archive/restore) operates on it unchanged. For Docker the borrowed object
 //! store is mounted read-only at its identical host path (see
@@ -31,45 +34,112 @@ use crate::git;
 pub struct CheckoutSpec<'a> {
     /// The user's real repo root.
     pub source_repo: &'a Path,
-    /// Commit-ish the workspace starts from, checked out detached.
+    /// Commit-ish the workspace starts from, checked out detached. Under
+    /// [`provision_at_remote_base`] this is only the *fallback* — the base as
+    /// this machine already knows it, used when the clone can't reach `origin`.
     pub base_ref: &'a str,
     /// Workspace path (`workspace::repo_checkout_path(agent_id, subdir)`).
     pub dest: &'a Path,
 }
 
-/// Create the workspace at `spec.dest`, detached at `spec.base_ref`.
+/// Create the workspace at `spec.dest`, detached at `spec.base_ref`, taking the
+/// ref exactly as given — no fetch. For callers whose base is already an exact
+/// commit that must not move (restore's archived tip). A fresh spawn wants
+/// [`provision_at_remote_base`] instead, so its base branch is the remote's.
 ///
 /// `--shared`: objects borrowed from the source. For Docker the borrowed store
 /// is mounted RO at launch — safe for the primary workspace and any repo
 /// present when the container starts.
 pub async fn provision(spec: &CheckoutSpec<'_>) -> Result<()> {
-    clone_detached(spec, true).await
+    clone_detached(spec).await
 }
 
-/// Provision a **self-contained** clone (full object copy, no alternates),
-/// detached at `spec.base_ref`. For a repo added to an *already-running* Docker
-/// agent: the container's bind mounts are fixed at `docker run`, so a `--shared`
-/// clone's borrowed object store could never be mounted and in-container git
-/// would fail with missing objects. A self-contained clone needs no extra mount
-/// and works immediately. Seatbelt has no such constraint and uses [`provision`]
-/// (`--shared`) even for added repos — same filesystem, no mount involved.
-pub async fn provision_self_contained(spec: &CheckoutSpec<'_>) -> Result<()> {
-    clone_detached(spec, false).await
+/// Where a freshly-provisioned workspace's starting commit came from. Only
+/// [`BaseFreshness::Stale`] is a degradation, and the spawn path relays it to
+/// the agent so it can warn the user (see `instructions::stale_base_note`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BaseFreshness {
+    /// The base branch was fetched from `origin`: the workspace starts at its
+    /// real remote tip and its `origin/<base>` is a genuine tracking ref.
+    Fetched,
+    /// The source repo has no `origin`, so there is no fresher state to be
+    /// behind — its local refs are the only truth there is. Not a degradation.
+    NoRemote,
+    /// The fetch failed (offline, no credentials, base deleted on the remote).
+    /// The workspace fell back to `spec.base_ref`, which may be arbitrarily far
+    /// behind the branch on the remote.
+    Stale,
 }
 
-/// Shared clone-arm body for [`provision`] / [`provision_self_contained`]:
-/// clone (borrowing objects when `shared`), run the post-clone fixups, then
-/// check out `spec.base_ref` detached.
-async fn clone_detached(spec: &CheckoutSpec<'_>, shared: bool) -> Result<()> {
+/// Provision a workspace at the **remote** tip of `base_branch`.
+///
+/// `git clone --shared <source path>` seeds the clone's `refs/remotes/origin/*`
+/// from the source's *local* heads, and [`rewrite_origin`] then repoints
+/// `origin` at GitHub — so a fresh workspace's `origin/<base>` is a relabelled
+/// snapshot of the source's local branch, not the remote. Nothing inside the
+/// workspace ever fetches on its own, so it never self-corrects: the agent
+/// would start from, and diff against, however stale the user's local branch
+/// happened to be.
+///
+/// So fetch the base here, in the clone, while we still run host-side with the
+/// app's git credentials (the sandboxed agent has none). Cost is one ref against
+/// a mostly-shared object store: `--shared` means only commits the source has
+/// never seen transfer, and they land in the clone's own `.git/objects`, never
+/// the user's. Provisioning already runs in a background task, so the latency
+/// lands in workspace-ready time, not UI responsiveness.
+///
+/// Degrades instead of failing: an unreachable remote leaves the workspace at
+/// `spec.base_ref` (the inherited, possibly stale ref) and reports
+/// [`BaseFreshness::Stale`] rather than killing the spawn.
+///
+/// `shared` picks the object strategy, exactly as in [`clone_base`]. Pass
+/// `false` for a repo added to an *already-running* Docker agent: the
+/// container's bind mounts are fixed at `docker run`, so a `--shared` clone's
+/// borrowed object store could never be mounted and in-container git would fail
+/// with missing objects. Seatbelt has no such constraint and always shares.
+pub async fn provision_at_remote_base(
+    spec: &CheckoutSpec<'_>,
+    base_branch: &str,
+    shared: bool,
+) -> Result<BaseFreshness> {
     clone_base(spec, shared).await?;
+    let base_branch = base_branch.to_string();
     finish_clone(spec, |dest| async move {
-        git::run_git(
-            &dest,
-            &["checkout", "--detach", spec.base_ref],
-            &format!("checkout --detach {}", spec.base_ref),
-        )
-        .await?;
-        Ok(())
+        // `rewrite_origin` *removes* the clone's local-path `origin` when the
+        // source repo has no remote. There is then nothing to fetch and nothing
+        // to be stale against, so take the inherited ref without warning the
+        // agent about a repo that is its own source of truth.
+        if !has_origin(&dest).await {
+            checkout_detached(&dest, spec.base_ref).await?;
+            return Ok(BaseFreshness::NoRemote);
+        }
+        match git::fetch_fork_point(&dest, &base_branch).await {
+            Some(tip) => {
+                checkout_detached(&dest, &tip).await?;
+                Ok(BaseFreshness::Fetched)
+            }
+            None => {
+                tracing::warn!(
+                    base = %base_branch,
+                    dest = %dest.display(),
+                    fallback = %spec.base_ref,
+                    "could not fetch base from origin while provisioning; starting \
+                     from the inherited ref, which may be stale"
+                );
+                checkout_detached(&dest, spec.base_ref).await?;
+                Ok(BaseFreshness::Stale)
+            }
+        }
+    })
+    .await
+}
+
+/// Body of [`provision`]: `--shared` clone, the post-clone fixups, then check
+/// out `spec.base_ref` detached.
+async fn clone_detached(spec: &CheckoutSpec<'_>) -> Result<()> {
+    clone_base(spec, true).await?;
+    finish_clone(spec, |dest| async move {
+        checkout_detached(&dest, spec.base_ref).await
     })
     .await
 }
@@ -259,7 +329,7 @@ pub async fn teardown(dest: &Path) -> Result<()> {
 /// - `false` → `git clone --no-hardlinks`: a full, self-contained object copy
 ///   with no alternates. Used when the clone can't rely on the borrowed store
 ///   being mounted — a repo added to an already-running Docker container, whose
-///   bind mounts are fixed at `docker run` (see [`provision_self_contained`]).
+///   bind mounts are fixed at `docker run` (see [`provision_at_remote_base`]).
 ///
 /// Caveat — gc/prune on the source (`shared` only): `--shared` breaks only if
 /// the source prunes an object the clone references. Base history stays
@@ -484,6 +554,16 @@ async fn seed_identity(spec: &CheckoutSpec<'_>) -> Result<()> {
     Ok(())
 }
 
+/// Does the clone still have an `origin` remote? False when [`rewrite_origin`]
+/// removed it because the source repo has none — the "no remote at all" state,
+/// distinct from "a remote we couldn't reach".
+async fn has_origin(repo: &Path) -> bool {
+    matches!(
+        git::git_output(repo, &["remote", "get-url", "origin"]).await,
+        Ok(out) if out.status.success()
+    )
+}
+
 /// Does `commit` resolve to a commit already present in `repo`?
 async fn commit_present(repo: &Path, commit: &str) -> bool {
     let spec = format!("{commit}^{{commit}}");
@@ -574,6 +654,111 @@ mod tests {
         run(&repo, &["commit", "-q", "-m", "second"]);
         let head = run(&repo, &["rev-parse", "HEAD"]);
         (repo, first, head)
+    }
+
+    /// The real topology: an `upstream` repo playing GitHub, a `source` clone
+    /// of it (the user's repo) that was cloned *before* upstream advanced, and
+    /// therefore a stale local `main`. Returns
+    /// (source, stale local tip, true upstream tip).
+    fn fixture_with_stale_source(dir: &Path) -> (PathBuf, String, String) {
+        let upstream = dir.join("upstream");
+        std::fs::create_dir_all(&upstream).unwrap();
+        run(&upstream, &["init", "-q", "-b", "main"]);
+        run(&upstream, &["config", "user.email", "t@example.com"]);
+        run(&upstream, &["config", "user.name", "Tester"]);
+        std::fs::write(upstream.join("a.txt"), b"one").unwrap();
+        run(&upstream, &["add", "-A"]);
+        run(&upstream, &["commit", "-q", "-m", "first"]);
+
+        let source = dir.join("source");
+        run(dir, &["clone", "-q", upstream.to_str().unwrap(), "source"]);
+        run(&source, &["config", "user.email", "t@example.com"]);
+        run(&source, &["config", "user.name", "Tester"]);
+        let stale = run(&source, &["rev-parse", "main"]);
+
+        // Upstream moves on; nothing ever pulls it into `source`.
+        std::fs::write(upstream.join("b.txt"), b"two").unwrap();
+        run(&upstream, &["add", "-A"]);
+        run(&upstream, &["commit", "-q", "-m", "second"]);
+        let fresh = run(&upstream, &["rev-parse", "main"]);
+        assert_ne!(stale, fresh);
+        (source, stale, fresh)
+    }
+
+    #[tokio::test]
+    async fn provision_at_remote_base_starts_at_the_fetched_tip_not_the_sources_local_branch() {
+        // The bug this guards: `git clone <local path>` maps the source's own
+        // *local* heads into the clone's `refs/remotes/origin/*`, and the origin
+        // rewrite then relabels them as if they came from GitHub. Without a
+        // fetch in the clone, both HEAD and `origin/main` would sit at the
+        // source's stale local `main` forever.
+        let td = tempfile::tempdir().unwrap();
+        let (source, stale, fresh) = fixture_with_stale_source(td.path());
+        let dest = td.path().join("clone");
+        let spec = CheckoutSpec {
+            source_repo: &source,
+            base_ref: &stale,
+            dest: &dest,
+        };
+
+        let freshness = provision_at_remote_base(&spec, "main", true).await.unwrap();
+
+        assert_eq!(freshness, BaseFreshness::Fetched);
+        assert_eq!(run(&dest, &["rev-parse", "HEAD"]), fresh);
+        // The tracking ref matters as much as HEAD: every later ahead/behind,
+        // rebase and PR base in this workspace reads `origin/main`.
+        assert_eq!(run(&dest, &["rev-parse", "origin/main"]), fresh);
+        // Still detached — the fetch must not put the workspace on a branch.
+        let out = std::process::Command::new("git")
+            .current_dir(&dest)
+            .args(["symbolic-ref", "-q", "HEAD"])
+            .output()
+            .unwrap();
+        assert!(!out.status.success(), "clone HEAD should be detached");
+    }
+
+    #[tokio::test]
+    async fn provision_at_remote_base_degrades_to_the_inherited_ref_when_the_fetch_fails() {
+        // Offline / no credentials / deleted branch: the spawn must still
+        // succeed, land on `spec.base_ref`, and report the degradation so the
+        // caller can tell the agent its base may be stale.
+        let td = tempfile::tempdir().unwrap();
+        let (source, stale, _fresh) = fixture_with_stale_source(td.path());
+        let unreachable = td.path().join("gone.git");
+        run(
+            &source,
+            &["remote", "set-url", "origin", unreachable.to_str().unwrap()],
+        );
+        let dest = td.path().join("clone");
+        let spec = CheckoutSpec {
+            source_repo: &source,
+            base_ref: &stale,
+            dest: &dest,
+        };
+
+        let freshness = provision_at_remote_base(&spec, "main", true).await.unwrap();
+
+        assert_eq!(freshness, BaseFreshness::Stale);
+        assert_eq!(run(&dest, &["rev-parse", "HEAD"]), stale);
+    }
+
+    #[tokio::test]
+    async fn provision_at_remote_base_reports_no_remote_rather_than_stale() {
+        // A repo with no `origin` has no fresher state to be behind, so it must
+        // not trip the agent-facing stale-base warning.
+        let td = tempfile::tempdir().unwrap();
+        let (repo, _first, head) = fixture_repo(td.path());
+        let dest = td.path().join("clone");
+        let spec = CheckoutSpec {
+            source_repo: &repo,
+            base_ref: &head,
+            dest: &dest,
+        };
+
+        let freshness = provision_at_remote_base(&spec, "main", true).await.unwrap();
+
+        assert_eq!(freshness, BaseFreshness::NoRemote);
+        assert_eq!(run(&dest, &["rev-parse", "HEAD"]), head);
     }
 
     #[tokio::test]
@@ -1045,7 +1230,14 @@ mod tests {
             dest: &dest,
         };
 
-        provision_self_contained(&spec).await.unwrap();
+        // No `origin` on the fixture, so there is nothing to fetch — the point
+        // here is purely the object strategy (`shared = false`).
+        assert_eq!(
+            provision_at_remote_base(&spec, "main", false)
+                .await
+                .unwrap(),
+            BaseFreshness::NoRemote
+        );
 
         // No alternates file — objects live in the clone itself.
         assert!(!dest.join(".git/objects/info/alternates").exists());

--- a/src-tauri/src/supervisor/disposition.rs
+++ b/src-tauri/src/supervisor/disposition.rs
@@ -302,6 +302,9 @@ impl Supervisor {
             }
         }
         self.interrupted.lock().remove(agent_id);
+        // The stale-base warning belongs to one provisioning of one workspace:
+        // a restore re-provisions from scratch and re-decides for itself.
+        self.stale_base.lock().remove(agent_id);
         self.shells.lock().remove(agent_id);
         if let Some(run) = self.runs.lock().remove(agent_id) {
             run.stop();

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -322,11 +322,18 @@ impl Supervisor {
 
         // The agent's parent branch — the base its checkout forks from and the
         // ref it later targets for PRs / ahead-behind. The base the user chose
-        // on the new-agent screen (`fork_base`) wins; absent a choice, fall back
-        // to the branch the repo was on when the user hit Spawn.
+        // on the new-agent screen (`fork_base`) wins; absent a choice, resolve
+        // the repo's *default* branch.
+        //
+        // Explicitly NOT the branch the source repo happens to have checked out.
+        // Forking a new agent onto the user's in-progress local work is never
+        // the intent, and as an implicit default it is invisible: the frontend's
+        // draft path passes a base, but every other caller silently inherited
+        // whatever the repo was on. Resolving the default here makes the rule
+        // hold structurally instead of depending on each caller remembering.
         let parent_branch = match &fork_base {
-            Some(base) if !base.trim().is_empty() => Some(base.clone()),
-            _ => git::current_branch(&repo_path).await.ok().flatten(),
+            Some(base) if !base.trim().is_empty() => base.trim().to_string(),
+            _ => git::default_branch(&repo_path).await,
         };
         let subdir = allocate_repo_subdir(&repo_path, &[]);
         // Cloned for the background fork task — `parent_branch`/`subdir` are
@@ -343,7 +350,7 @@ impl Supervisor {
             repo_path: repo_path.clone(),
             subdir: subdir.clone(),
             branch: None, // materialized at first push, named by the agent
-            parent_branch,
+            parent_branch: Some(parent_branch),
             base_sha: None,  // captured by the fork task once HEAD is known
             pr_number: None, // set when a PR is opened for this branch
             pr_url: None,
@@ -422,53 +429,57 @@ impl Supervisor {
                 return;
             }
 
-            // Fork point: prefer the freshest remote state of the parent branch
-            // (the user's chosen base, or the repo's current branch) so the agent
-            // never starts on stale local refs — as the fetched tip's SHA, which
-            // resolves the same in the source repo and in a clone-mode workspace
-            // (a symbolic `origin/<branch>` would resolve against the source's
-            // stale local head inside the clone). Best-effort — if the remote is
-            // unavailable (offline, no remote, a local-only branch, or a workflow
-            // commit-ish), resolve the ref to its local SHA, otherwise fall
-            // through to HEAD so an unresolvable base degrades instead of failing
-            // the spawn. The SHA (never the branch name) matters even in the
-            // fallback: a clone-mode workspace only has the source's HEAD branch
-            // as a local branch, so checking out any *other* branch by name
-            // trips git's remote-DWIM (an implicit `-b`), which is fatal
-            // combined with `--detach`.
+            // Fork point: the workspace fetches its base branch from `origin`
+            // itself and detaches at the tip that came back, so the agent starts
+            // from the branch as GitHub has it — see
+            // `provision::provision_at_remote_base` for why fetching in the
+            // *clone* (not the source) is what makes that true.
+            //
+            // `base_ref` is the offline fallback: the base as this machine
+            // already knows it, resolved to a local SHA and finally to HEAD so
+            // an unresolvable base degrades instead of failing the spawn. A SHA,
+            // never the branch name — a clone-mode workspace only has the
+            // source's HEAD branch as a local branch, so checking out any
+            // *other* branch by name trips git's remote-DWIM (an implicit `-b`),
+            // which is fatal combined with `--detach`.
+            let mut base_freshness = None;
             let provision_result = match &run_repo_for_task {
                 // Workflow step (§12.1): fork from `fork_base` in the run repo.
-                // `base_ref` is used as-is — step 1's `base_sha` is already in
-                // the fresh source clone, so the run-repo fetch is skipped; step
-                // N's `refs/wf/steps/<prev>` is fetched from the run repo first.
+                // `base_ref` is used as-is and never fetched from `origin` —
+                // it's a run-internal commit-ish, not a branch: step 1's
+                // `base_sha` is already in the fresh source clone, and step N's
+                // `refs/wf/steps/<prev>` is fetched from the run repo instead.
                 Some(run_repo) => {
-                    let base_ref = parent_for_fork.as_deref().unwrap_or("HEAD");
                     let spec = CheckoutSpec {
                         source_repo: &repo_path,
-                        base_ref,
+                        base_ref: &parent_for_fork,
                         dest: &primary_checkout,
                     };
                     provision::provision_forking_run_repo(&spec, run_repo).await
                 }
                 None => {
-                    let base = match &parent_for_fork {
-                        Some(b) => match git::fetch_fork_point(&repo_path, b).await {
-                            Some(sha) => Some(sha),
-                            None => git::rev_parse(&repo_path, b).await.ok(),
-                        },
-                        None => None,
-                    };
+                    let local = git::rev_parse(&repo_path, &parent_for_fork).await.ok();
                     let spec = CheckoutSpec {
                         source_repo: &repo_path,
-                        base_ref: base.as_deref().unwrap_or("HEAD"),
+                        base_ref: local.as_deref().unwrap_or("HEAD"),
                         dest: &primary_checkout,
                     };
-                    provision::provision(&spec).await
+                    provision::provision_at_remote_base(&spec, &parent_for_fork, true)
+                        .await
+                        .map(|freshness| base_freshness = Some(freshness))
                 }
             };
             if let Err(e) = provision_result {
                 fail_spawn(&sup, &app_for_task, &id_for_task, e.to_string());
                 return;
+            }
+            if base_freshness == Some(provision::BaseFreshness::Stale) {
+                // The workspace couldn't reach `origin`, so it starts at
+                // whatever this machine last had. Flag it so the agent's brief
+                // carries a heads-up and it can tell the user (see
+                // `start_process`) — silently working off a stale base is how
+                // an agent rebuilds something that already landed.
+                sup.stale_base.lock().insert(id_for_task.clone());
             }
 
             // Record the fork point so diffs measure against the exact starting
@@ -613,24 +624,21 @@ impl Supervisor {
         let used: Vec<String> = record.repos.iter().map(|r| r.subdir.clone()).collect();
         let subdir = allocate_repo_subdir(&repo_path, &used);
         let checkout = repo_checkout_path(agent_id, &subdir)?;
-        let parent_branch = git::current_branch(&repo_path).await.ok().flatten();
+        // Secondary repos have no base picker of their own, so they take the
+        // repo's default branch — never the branch it happens to have checked
+        // out, for the same reason the primary repo doesn't (see `spawn_agent`).
+        let parent_branch = git::default_branch(&repo_path).await;
 
-        // Fork from the freshest remote state of the parent branch (best-effort,
-        // falls back to local HEAD), then record the fork point as the diff base.
-        let base = match &parent_branch {
-            Some(b) => git::fetch_fork_point(&repo_path, b).await,
-            None => None,
-        };
+        // Fork from the base as `origin` has it, falling back to the local SHA
+        // (then HEAD) when the fetch can't happen; then record the fork point as
+        // the diff base.
+        let local = git::rev_parse(&repo_path, &parent_branch).await.ok();
         let spec = CheckoutSpec {
             source_repo: &repo_path,
-            base_ref: base.as_deref().unwrap_or("HEAD"),
+            base_ref: local.as_deref().unwrap_or("HEAD"),
             dest: &checkout,
         };
-        if self_contained {
-            provision::provision_self_contained(&spec).await?;
-        } else {
-            provision::provision(&spec).await?;
-        }
+        provision::provision_at_remote_base(&spec, &parent_branch, !self_contained).await?;
         let base_sha = git::rev_parse(&checkout, "HEAD").await.ok();
 
         // Warm the codegraph index for this additional checkout too, so a
@@ -651,7 +659,7 @@ impl Supervisor {
             repo_path: repo_path.clone(),
             subdir: subdir.clone(),
             branch: None,
-            parent_branch,
+            parent_branch: Some(parent_branch),
             base_sha,
             pr_number: None,
             pr_url: None,
@@ -906,10 +914,31 @@ impl Supervisor {
         // brief, so the agent knows about its sibling checkouts from turn one.
         // Recomputed every launch, like the rest of the instruction layers.
         let workspace_note = crate::instructions::multi_repo_workspace_note(&record.repos);
-        let brief = match (workspace_note, record.instructions.as_deref()) {
-            (Some(note), Some(brief)) => Some(format!("{note}\n\n{brief}")),
-            (Some(note), None) => Some(note),
-            (None, brief) => brief.map(str::to_string),
+        // A workspace whose base fetch failed at provision time carries a
+        // heads-up so the agent can warn the user its starting point may be
+        // behind (see `spawn_agent`). Keyed on the primary repo's base — the one
+        // the user picked and the one the flag was set for.
+        let stale_note = self
+            .stale_base
+            .lock()
+            .contains(agent_id)
+            .then(|| {
+                record
+                    .repos
+                    .first()
+                    .and_then(|r| r.parent_branch.as_deref())
+            })
+            .flatten()
+            .map(crate::instructions::stale_base_note);
+        let notes = [stale_note, workspace_note]
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        let brief = match (notes.is_empty(), record.instructions.as_deref()) {
+            (false, Some(brief)) => Some(format!("{notes}\n\n{brief}")),
+            (false, None) => Some(notes),
+            (true, brief) => brief.map(str::to_string),
         };
         // The codegraph playbook rides the same suffix, gated on the server
         // having really landed above — so an agent is only ever told to prefer

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -458,10 +458,16 @@ impl Supervisor {
                     provision::provision_forking_run_repo(&spec, run_repo).await
                 }
                 None => {
-                    let local = git::rev_parse(&repo_path, &parent_for_fork).await.ok();
+                    // Offline fallback: the base as this machine already knows
+                    // it, never `HEAD` — that is the source repo's checked-out
+                    // branch, unrelated to the base the user picked (see
+                    // `git::base_tip`). With no local copy at all, pass the
+                    // branch name so an unreachable `origin` fails the spawn
+                    // instead of opening somewhere arbitrary.
+                    let fallback = git::base_tip(&repo_path, &parent_for_fork).await;
                     let spec = CheckoutSpec {
                         source_repo: &repo_path,
-                        base_ref: local.as_deref().unwrap_or("HEAD"),
+                        base_ref: fallback.as_deref().unwrap_or(&parent_for_fork),
                         dest: &primary_checkout,
                     };
                     provision::provision_at_remote_base(&spec, &parent_for_fork, true)
@@ -629,13 +635,14 @@ impl Supervisor {
         // out, for the same reason the primary repo doesn't (see `spawn_agent`).
         let parent_branch = git::default_branch(&repo_path).await;
 
-        // Fork from the base as `origin` has it, falling back to the local SHA
-        // (then HEAD) when the fetch can't happen; then record the fork point as
-        // the diff base.
-        let local = git::rev_parse(&repo_path, &parent_branch).await.ok();
+        // Fork from the base as `origin` has it, falling back to this machine's
+        // best-known tip for that branch when the fetch can't happen — never
+        // `HEAD`, which is an unrelated branch (see `git::base_tip`). Then
+        // record the fork point as the diff base.
+        let fallback = git::base_tip(&repo_path, &parent_branch).await;
         let spec = CheckoutSpec {
             source_repo: &repo_path,
-            base_ref: local.as_deref().unwrap_or("HEAD"),
+            base_ref: fallback.as_deref().unwrap_or(&parent_branch),
             dest: &checkout,
         };
         provision::provision_at_remote_base(&spec, &parent_branch, !self_contained).await?;

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -95,6 +95,15 @@ pub struct Supervisor {
     /// at the next turn boundary (per-turn agents, or claude paused on a tool
     /// gate). In-memory only — see `message_queue`.
     pub message_queue: Mutex<MessageQueue>,
+    /// Agent ids whose workspace could not fetch its base branch from `origin`
+    /// at provision time, so it started from the ref inherited from the source
+    /// clone — possibly far behind the branch on the remote. Read at launch to
+    /// fold a heads-up into the agent's brief (see
+    /// `instructions::stale_base_note`) so it can tell the user, rather than
+    /// silently doing work against a stale base. In-memory and advisory: an app
+    /// restart clears it, which is fine — the warning is only useful while the
+    /// workspace is new.
+    pub stale_base: Mutex<HashSet<String>>,
     /// Agent ids whose current turn was stopped by the user. The dying process
     /// still converges on the Idle transition, so this flag lets the turn-end
     /// flush distinguish a natural completion (flush queued follow-ups) from a
@@ -139,6 +148,7 @@ impl Supervisor {
             deleting_projects: Mutex::new(HashSet::new()),
             respawn_pending: Mutex::new(HashSet::new()),
             message_queue: Mutex::new(MessageQueue::new()),
+            stale_base: Mutex::new(HashSet::new()),
             interrupted: Mutex::new(HashSet::new()),
             sync_health: Arc::new(Mutex::new(HashMap::new())),
             verify_inflight: Arc::new(Mutex::new(HashSet::new())),

--- a/src/api/domains/git.ts
+++ b/src/api/domains/git.ts
@@ -30,4 +30,9 @@ export const gitApi = {
   deleteBranchAgent: (agentId: string, subdir?: string) =>
     invoke<void>("delete_branch_agent", { agentId, subdir }),
   listRepoBranches: (repoPath: string) => invoke<string[]>("list_repo_branches", { repoPath }),
+  /** The repo's default branch, resolved from its remote — what the new-agent
+   *  screen pre-selects as the base. Never the branch the user currently has
+   *  checked out, and never a hardcoded "main" (which forks the wrong branch on
+   *  a master/develop repo). Infallible backend-side; falls back to "main". */
+  repoDefaultBranch: (repoPath: string) => invoke<string>("repo_default_branch", { repoPath }),
 };

--- a/src/components/Workspace/EmptyWorkspace.tsx
+++ b/src/components/Workspace/EmptyWorkspace.tsx
@@ -5,6 +5,7 @@ import { BranchPicker } from "@/components/Composer/BranchPicker";
 import { type ProjectOption, ProjectPicker } from "@/components/Composer/ProjectPicker";
 import { Icon, LandmarkGlyph } from "@/components/Icon";
 import { IconButton } from "@/components/ui/IconButton";
+import { resolveBaseBranch } from "@/helpers";
 import { getLinearTeamId } from "@/storage/projectSettings";
 import type { DraftAgent } from "@/store";
 import { useAppStore } from "@/store";
@@ -237,14 +238,21 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
               <ProjectPicker
                 value={draft.repoPath}
                 projects={projectOptions}
-                onChange={(repoPath) => {
+                onChange={async (repoPath) => {
                   // Switching projects: the previously chosen base branch may not
-                  // exist in the new repo, so reset to main — and drop any issue
-                  // tag, which belongs to the previous project's tracker (its key
-                  // would close the wrong issue, or a dead one, from the new
-                  // repo's PR). The brief text stays: it's visible and editable,
-                  // unlike the hidden ref.
-                  updateDraft(draft.id, { repoPath, base: "main", issueRef: undefined });
+                  // exist in the new repo, so reset to the new repo's *default*
+                  // (not a hardcoded "main") — and drop any issue tag, which
+                  // belongs to the previous project's tracker (its key would
+                  // close the wrong issue, or a dead one, from the new repo's
+                  // PR). The brief text stays: it's visible and editable, unlike
+                  // the hidden ref.
+                  //
+                  // Resolved before the switch is applied, so the draft is never
+                  // momentarily pointing at a base from the previous repo — a
+                  // spawn in that window would fork from a branch this repo may
+                  // not even have. It's a local ref read, not a network call.
+                  const base = await resolveBaseBranch(repoPath);
+                  updateDraft(draft.id, { repoPath, base, issueRef: undefined });
                   setLastRepoPath(repoPath);
                 }}
               />

--- a/src/helpers/spawn.ts
+++ b/src/helpers/spawn.ts
@@ -1,12 +1,32 @@
-// Spawn-time helpers: resolving a custom agent's skill/MCP assignments into
-// by-value snapshots for the spawn payload, and the small retry util that
-// tolerates the brief window before a freshly-spawned agent is addressable.
+// Spawn-time helpers: resolving the base branch a new agent forks from,
+// resolving a custom agent's skill/MCP assignments into by-value snapshots for
+// the spawn payload, and the small retry util that tolerates the brief window
+// before a freshly-spawned agent is addressable.
 
+import { api } from "../api";
 import { MCP_SUPPORT, mcpAttachable } from "../data/providers";
 import type { CustomAgent } from "../storage/customAgents";
 import { type McpServerSnapshot, snapshotMcpServer } from "../storage/mcpServers";
 import type { SkillSnapshot } from "../storage/skills";
 import type { AppState } from "../store";
+
+/** The base branch a new agent forks from when the user hasn't picked one: the
+ *  repo's real default, resolved from its remote by the backend. This used to be
+ *  a hardcoded "main", which silently forked the wrong branch on a
+ *  master/develop repo — and leaving it unset was worse still, because the
+ *  backend then fell back to whatever branch the source repo happened to have
+ *  checked out. Every spawn path must pass a base.
+ *
+ *  The backend already degrades to "main" internally, so the catch here only
+ *  covers the IPC call itself failing; a base must always come back, because
+ *  spawning without one is the bug we're closing. */
+export async function resolveBaseBranch(repoPath: string): Promise<string> {
+  try {
+    return await api.repoDefaultBranch(repoPath);
+  } catch {
+    return "main";
+  }
+}
 
 /** Resolve a custom agent's skill/MCP assignments into by-value spawn
  *  snapshots, in the agent's assignment order. Dangling ids (deleted library

--- a/src/store/drafts.ts
+++ b/src/store/drafts.ts
@@ -4,6 +4,7 @@ import { DEFAULT_PROVIDER_ID, PROVIDERS } from "@/data/providers";
 import { discoverCommands } from "@/data/slashCommands";
 import {
   expandSlashCommand,
+  resolveBaseBranch,
   resolveSkillInvocation,
   sendWhenAgentReady,
   snapshotAgentDeliverables,
@@ -151,7 +152,7 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
       provider: selection.provider,
       model: selection.model,
       customAgentId,
-      base: "main",
+      base: await resolveBaseBranch(repoPath),
     };
     set((s) => ({
       drafts: [draft, ...s.drafts],
@@ -183,7 +184,7 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
       provider: selection.provider,
       model: selection.model,
       customAgentId,
-      base: "main",
+      base: await resolveBaseBranch(repoPath),
       issueRef: issue.key,
     };
     // Seed the composer for this draft (read as its initial text on mount) with

--- a/src/store/spawnBase.test.ts
+++ b/src/store/spawnBase.test.ts
@@ -1,0 +1,67 @@
+// Regression tests for the base branch a spawn forks from.
+//
+// The bug these pin: `spawn(view, repoPath)` passed no `forkBase` at all, so the
+// backend fell back to the source repo's *currently-checked-out* branch — a new
+// agent silently forked onto the user's in-progress local work. The product rule
+// is that the app must never pick that branch implicitly, so every spawn path
+// has to supply a base, and that base is the repo's resolved default (not a
+// hardcoded "main", which forks the wrong branch on a master/develop repo).
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "zustand";
+
+const { spawnAgent, getWorkspace, repoDefaultBranch } = vi.hoisted(() => ({
+  spawnAgent: vi.fn(),
+  getWorkspace: vi.fn(),
+  repoDefaultBranch: vi.fn(),
+}));
+vi.mock("@/api", () => ({ api: { spawnAgent, getWorkspace, repoDefaultBranch } }));
+vi.mock("@/pty/buffers", () => ({ clearOutputBuffer: vi.fn(), dropAgentPty: vi.fn() }));
+
+import { resolveBaseBranch } from "@/helpers";
+import type { AppState } from "./types";
+import { createWorkspaceSlice } from "./workspace";
+
+const makeStore = () => {
+  const store = create<AppState>()((...a) => ({ ...createWorkspaceSlice(...a) }) as AppState);
+  // biome-ignore lint/suspicious/noExplicitAny: partial store seed
+  store.setState({ managedLogs: {}, managedBusy: {} } as any);
+  return store;
+};
+
+/** `forkBase` is the 9th positional arg of `api.spawnAgent`. */
+const forkBaseArg = (call: unknown[]) => call[8];
+
+describe("spawn base branch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    spawnAgent.mockResolvedValue({ id: "a1" });
+    getWorkspace.mockResolvedValue(null);
+  });
+
+  it("passes the repo's resolved default branch as the fork base", async () => {
+    repoDefaultBranch.mockResolvedValue("develop");
+    const store = makeStore();
+
+    await store.getState().spawn("custom", "/repos/app");
+
+    expect(repoDefaultBranch).toHaveBeenCalledWith("/repos/app");
+    expect(forkBaseArg(spawnAgent.mock.calls[0])).toBe("develop");
+  });
+
+  it("never leaves the fork base unset, even when the resolve fails", async () => {
+    // An unset base is what let the backend fall back to the checked-out
+    // branch, so a failure here must still yield a concrete base.
+    repoDefaultBranch.mockRejectedValue(new Error("no such repo"));
+    const store = makeStore();
+
+    await store.getState().spawn("custom", "/repos/app");
+
+    expect(forkBaseArg(spawnAgent.mock.calls[0])).toBe("main");
+  });
+
+  it("resolves the default branch rather than assuming main", async () => {
+    repoDefaultBranch.mockResolvedValue("master");
+    await expect(resolveBaseBranch("/repos/legacy")).resolves.toBe("master");
+  });
+});

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -19,6 +19,7 @@ import {
   providerFor,
   reduceRecords,
   repoPathFor,
+  resolveBaseBranch,
   sendWhenAgentReady,
   unsupportedManagedCommand,
 } from "@/helpers";
@@ -343,7 +344,22 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
   spawn: async (view, repoPath) => {
     set({ busy: true, lastError: null });
     try {
-      const rec = await api.spawnAgent(view, repoPath);
+      // The draft path carries the base the user picked; this one has no picker,
+      // so resolve the repo's default explicitly. Passing nothing used to make
+      // the backend fall back to the source repo's currently-checked-out branch
+      // — forking a new agent onto the user's in-progress local work.
+      const base = await resolveBaseBranch(repoPath);
+      const rec = await api.spawnAgent(
+        view,
+        repoPath,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        base,
+      );
       // Apply the selection (and custom-view log seeds) immediately, ahead of the
       // guarded workspace refresh, so this user-intent state can never be dropped
       // if a concurrent refresh supersedes ours.


### PR DESCRIPTION
New agent workspaces now start at the **remote** tip of the selected base branch, and never implicitly fork from whatever branch the source repo happens to be sitting on.

## The reported symptom

A workspace spawned today opened 6 commits behind `main` — and its `origin/main` read `3868c7b` while the real `origin/main` was `2946690`, **154 commits newer**. Nothing in the workspace had ever fetched.

## Root cause — two independent defects

**1. The base branch was the wrong branch.** `lifecycle.rs` fell back to `git::current_branch(&repo_path)` when no `fork_base` was supplied. The draft spawn path does pass one, but `spawn(view, repoPath)` passed none, so it forked from whatever the source repo was checked out on. The product rule is that the app must *never* pick the checked-out branch implicitly — a user may select it from the dropdown, but it can't be the default. Both fallbacks (primary spawn and secondary-repo attach) are gone; `parent_branch` is now always recorded.

**2. The clone's `origin/<base>` was never real.** `clone_base` clones from the local source repo, then rewrites `origin` to the GitHub URL. Plain `git clone <local-path>` maps the source's *local* branches into the clone's `refs/remotes/origin/*` — the source's own remote-tracking refs aren't copied. So after the URL rewrite, a workspace's `origin/main` looks like a GitHub tracking ref but is a relabelled snapshot of the source's local `main`, and nothing in the workspace ever corrects it.

### Correcting the record on defect 2

The spawn path was **not** fetch-free, contrary to how this was initially scoped. `lifecycle.rs` already called `git::fetch_fork_point(&repo_path, base)` — a bounded, authed fetch into the *source* repo — and used the returned SHA as `base_ref`. On an online machine HEAD was often already correct. What was never fixed is the clone's tracking ref, plus the degradation path: an 8s timeout or unreachable remote silently fell back to the source's stale local SHA with **no signal at all**.

## The fix

`provision_at_remote_base(spec, base_branch, shared) -> Result<BaseFreshness>` clones as before, then fetches the base **in the clone** and detaches at the tip that came back. `BaseFreshness` is `Fetched` / `NoRemote` / `Stale`. `provision_self_contained` folds into the `shared` flag; `provision` stays for restore, whose base is an exact archived tip that must not move.

Net fetch count at spawn is unchanged — one, moved from the source repo to the clone — so the spawn budget is the same.

**Timeout constraint worth knowing:** `provision::fetch_branch` and `git::fetch_base` both use the 60s `NET_TIMEOUT`, which would blow the supervisor's 15s `SPAWN_TIMEOUT`. This reuses `git::fetch_fork_point`, bounded at 8s specifically for this, `kill_on_drop`, authed, and it returns the resolved SHA.

## Offline degradation, surfaced through the agent

Falling back silently is what made this invisible for so long. On `BaseFreshness::Stale` the supervisor records the agent in `stale_base: Mutex<HashSet<String>>`; `start_process` turns that into `instructions::stale_base_note(base)`, prepended to the brief alongside the existing `multi_repo_workspace_note` and delivered through `agent_profile::effective_instructions` — the same per-agent suffix channel every provider already uses (`--append-system-prompt`, `developer_instructions`, or first-turn prepend). **No new channel.** Cleared on teardown; also `tracing::warn!` at the provision site.

The agent delivers it, not the app: it's the surface the user is already talking to, and it knows whether the task even depends on being current. Failing the spawn would make an offline machine unusable; staying quiet would let the agent redo work that already landed on the base.

## Default branch resolution

New infallible `git::branch::default_branch()`: `refs/remotes/origin/HEAD` → conventional-name probes (remote-tracking, then local) → `"main"`. Never consults the checked-out branch. No GitHub API call — `origin/HEAD` is local, instant, token-free, and is exactly what the remote default becomes on clone. Exposed as `repo_default_branch` → `helpers/resolveBaseBranch`, used by draft creation, issue-intake drafts, the project-switch reset, and `spawn(view, repoPath)`.

This replaces **four** hardcoded `"main"` literals (`drafts.ts` ×2, `git_state.rs`, and `rebase_agent` in `git_ops.rs`), which silently forked the wrong branch on a `master`/`develop` repo.

## Trade-offs taken deliberately

- **Dropped the source-side fetch** rather than doing two. The source's `refs/remotes/origin/<base>` is no longer advanced at spawn, so `get_all_git_meta`'s behind-chip (which reads the *source's* tracking ref) lags until the next `refresh_base_freshness` sweep. It under-reports, never over-reports.
- **Secondary repos** fetch but don't set the stale flag — the note names a single base and they have no picker. Warn-logged only.

## Not verified

- The app was never run. Tests use local-path remotes, so the authed-https path is exercised in shape only, not against real GitHub.
- The stale note was not observed landing in a live agent's prompt; it relies on riding the same `effective_instructions` suffix as the multi-repo note.
- `BranchPicker` still lists only local branches, so a default resolved from `origin/HEAD` with no local head shows in the pill but not the dropdown. Pre-existing, left alone.

## Verification

`cargo fmt --check` · `cargo clippy --all-targets` · `cargo test --lib` **1059 passed** · `tsc --noEmit` · `vitest run` **566 passed / 62 files** · `biome check` clean. Independently re-run by the parent agent, which also confirmed the pre-existing `fetch_fork_point` call and the 15s `SPAWN_TIMEOUT`.

New tests: 3 in `provision.rs` (fetched tip beats stale local branch incl. `origin/main` correctness and still-detached; failed fetch → `Stale` at inherited ref; no-remote → `NoRemote`), 3 in `branch.rs`, 1 in `instructions.rs`, 3 in `src/store/spawnBase.test.ts`.

## Related

Overlaps `provision.rs` with #543 (unifying the fetch/fallback ladders); whichever lands second needs a small rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)