### PR TITLE
feat(autopilot): fix failing checks on an enrolled PR without being asked

### DIFF
--- a/src-tauri/src/commands/run.rs
+++ b/src-tauri/src/commands/run.rs
@@ -56,7 +56,10 @@ struct VerifyGuard {
 
 impl Drop for VerifyGuard {
     fn drop(&mut self) {
-        self.supervisor.verify_inflight.lock().remove(&self.agent_id);
+        self.supervisor
+            .verify_inflight
+            .lock()
+            .remove(&self.agent_id);
     }
 }
 

--- a/src-tauri/src/commands/run.rs
+++ b/src-tauri/src/commands/run.rs
@@ -47,6 +47,19 @@ pub fn run_state(
 /// checkouts have no step budget to draw from.
 const VERIFY_TIMEOUT_SECS: u64 = 900;
 
+/// Releases an agent's `verify_inflight` slot however `run_verification` returns
+/// — including the `?` early exits below, which a manual `remove` would leak.
+struct VerifyGuard {
+    supervisor: Arc<Supervisor>,
+    agent_id: String,
+}
+
+impl Drop for VerifyGuard {
+    fn drop(&mut self) {
+        self.supervisor.verify_inflight.lock().remove(&self.agent_id);
+    }
+}
+
 /// Run the project's deterministic checks — install → test → lint — in an
 /// agent's checkout and return a [`crate::verify::VerificationReport`]. Resolves
 /// the target repo via `subdir` (primary when `None`) and layers the project's
@@ -59,6 +72,27 @@ pub async fn run_verification(
     subdir: Option<String>,
 ) -> Result<crate::verify::VerificationReport> {
     let (_repo, checkout) = agent_repo_checkout(&supervisor, &agent_id, subdir.as_deref())?;
+    // Serialize against the turn-end verification (`trigger_turn_end_verification`)
+    // and any other in-flight run for this agent. Both drive the same install /
+    // test / lint commands in the agent's checkout, so two at once race on the
+    // working tree and on whatever build cache the project shares — and only the
+    // turn-end path used to guard itself, leaving this command free to collide
+    // with it. Autopilot calls this after every cycle, so the collision went from
+    // theoretical to routine.
+    //
+    // Coarse on purpose: the key is the agent, not the checkout, because two
+    // checkouts of one agent still contend for CPU and for a shared dependency
+    // cache. Refusing is better than queueing here — the caller (Run panel or
+    // autopilot) can retry, and neither wants to block on a 15-minute test run.
+    if !supervisor.verify_inflight.lock().insert(agent_id.clone()) {
+        return Err(crate::error::Error::Other(format!(
+            "verification already running for agent {agent_id}"
+        )));
+    }
+    let _guard = VerifyGuard {
+        supervisor: supervisor.inner().clone(),
+        agent_id: agent_id.clone(),
+    };
     // Project-scoped command overrides (mirrors the tests gate's `run.test` /
     // `run.install`, plus `run.lint`). Empty project_id → detection only.
     let project_id = supervisor

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { UpdateToast } from "./components/UpdateToast";
 import { Workspace } from "./components/Workspace";
 import { ACCENT_VALUES } from "./data/providers";
 import { useAppStore } from "./store";
+import { useAutopilotSync } from "./store/autopilotSync";
 import { useDelegationSync } from "./store/delegationSync";
 import { useGitSync } from "./store/gitSync";
 import { useGlobalShortcuts } from "./util/shortcuts";
@@ -62,6 +63,8 @@ export function App() {
   // …and so does every in-flight delegation's lifecycle, so one running on an
   // agent the user has navigated away from still completes.
   useDelegationSync();
+  // …and the autopilot loop for checkouts the user enrolled.
+  useAutopilotSync();
 
   // Apply theme via html class; accent via CSS vars.
   useEffect(() => {

--- a/src/autopilot.test.ts
+++ b/src/autopilot.test.ts
@@ -1,0 +1,368 @@
+// Autopilot spends agent turns and CI runs without being asked, so the tests
+// that matter most are the ones proving it STOPS: on a spent budget, on a world
+// it failed to change, on a rung it isn't allowed to take, and on anything the
+// user is doing themselves. The happy path is one test; the brakes are twelve.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import type { CheckOutcome, GitState, PrChecks, PrState, VerificationReport } from "@/api";
+import {
+  type AutopilotInput,
+  type AutopilotState,
+  autopilotStep,
+  type Cycle,
+  EVIDENCE_TIMEOUT_MS,
+  failedCheckNames,
+  newEnrollment,
+  RUNG_BUDGET,
+  stateSignature,
+  verificationPassed,
+} from "@/autopilot";
+import type { LadderContext, ReadinessInput } from "@/readiness";
+
+const NOW = 1_000_000;
+
+function git(over: Partial<GitState> = {}): GitState {
+  return {
+    branch: "feat",
+    parent_branch: "main",
+    ahead: 1,
+    behind: 0,
+    unpushed: 0,
+    files: [],
+    additions: 0,
+    deletions: 0,
+    has_origin: true,
+    head_sha: "sha1",
+    ...over,
+  };
+}
+const pr = (over: Partial<PrState> = {}): PrState => ({
+  number: 7,
+  url: "https://x",
+  state: "open",
+  title: "t",
+  mergeable: "mergeable",
+  ...over,
+});
+const checks = (over: Partial<PrChecks> = {}): PrChecks => ({
+  merge_state: "clean",
+  rollup: "none",
+  total: 0,
+  passed: 0,
+  failed: 0,
+  pending: 0,
+  required_failing: [],
+  runs: [],
+  ...over,
+});
+const report = (...outcomes: [string, CheckOutcome][]): VerificationReport => ({
+  checks: outcomes.map(([name, outcome]) => ({
+    name,
+    command: `run ${name}`,
+    outcome,
+    duration_ms: 1,
+    tail: [],
+  })),
+});
+
+/** A PR whose required checks are failing — the one world autopilot acts on. */
+const FAILING: ReadinessInput = {
+  git: git(),
+  pr: pr(),
+  checks: checks({ merge_state: "blocked", required_failing: ["test"] }),
+  comments: { unresolved: [] },
+};
+/** The same PR, fixed. */
+const GREEN: ReadinessInput = {
+  git: git({ head_sha: "sha2" }),
+  pr: pr(),
+  checks: checks({ merge_state: "clean" }),
+  comments: { unresolved: [] },
+};
+
+const LADDER: LadderContext = { base: "main", commitMode: "commit-pr" };
+
+const state = (over: Partial<AutopilotState> = {}): AutopilotState => ({
+  ...newEnrollment(),
+  ...over,
+});
+const cycle = (over: Partial<Cycle> = {}): Cycle => ({
+  rung: "fix-checks",
+  attempt: 1,
+  signature: stateSignature(FAILING),
+  phase: "working",
+  phaseSince: NOW,
+  ...over,
+});
+
+const step = (over: Partial<AutopilotInput> = {}) =>
+  autopilotStep({
+    state: state(),
+    readiness: FAILING,
+    ladder: LADDER,
+    agentBusy: false,
+    delegationInFlight: false,
+    verification: null,
+    now: NOW,
+    ...over,
+  });
+
+describe("autopilot refuses to act", () => {
+  it("does nothing at all unless the checkout was explicitly enrolled", () => {
+    // Default-off everywhere is the whole safety posture; an absent entry and an
+    // un-enrolled one must both be inert.
+    expect(step({ state: undefined })).toEqual({ do: "wait", why: "not-enrolled" });
+    expect(step({ state: state({ enrolled: false }) })).toEqual({
+      do: "wait",
+      why: "not-enrolled",
+    });
+  });
+
+  it("stays paused, and stays stuck, however inviting the ladder looks", () => {
+    // Both checks sit ahead of every reason to act, so a failing PR can't talk a
+    // paused or handed-back checkout into another dispatch.
+    expect(step({ state: state({ paused: true }) })).toEqual({ do: "wait", why: "paused" });
+    expect(
+      step({ state: state({ stuck: { reason: "budget-spent", rung: "fix-checks", at: NOW } }) }),
+    ).toEqual({ do: "wait", why: "stuck" });
+  });
+
+  it("never interleaves with a turn it didn't start", () => {
+    // delegateAction would HOLD the trigger and deliver it after the running
+    // turn — right for a human click, wrong here: it would append an action to
+    // whatever the user just asked for. Skip the tick instead.
+    expect(step({ agentBusy: true })).toEqual({ do: "wait", why: "agent-busy" });
+    expect(step({ delegationInFlight: true })).toEqual({
+      do: "wait",
+      why: "delegation-in-flight",
+    });
+  });
+
+  it("escalates a rung it isn't allowed to take, which is what keeps it off a dirty tree", () => {
+    // `fix-checks` runs `git add -A`. The ladder ranks uncommitted work above
+    // failing checks, so a dirty tree yields a commit rung — not in
+    // AUTOPILOT_RUNGS — and autopilot hands it back instead of sweeping the
+    // user's in-flight edits into an agent commit.
+    const dirty = {
+      ...FAILING,
+      git: git({
+        files: [{ path: "a.ts", kind: "modified", staged: false, additions: 1, deletions: 0 }],
+      }),
+    };
+    expect(step({ readiness: dirty })).toEqual({
+      do: "escalate",
+      reason: "needs-human",
+      rung: "commit-push",
+    });
+  });
+
+  it("waits out an unsettled world rather than inventing work", () => {
+    // No read yet, and a gate GitHub hasn't computed. Acting on either is how a
+    // loop convinces itself there is something to do.
+    expect(step({ readiness: { ...FAILING, git: null } })).toEqual({
+      do: "wait",
+      why: "gate-settling",
+    });
+    expect(step({ readiness: { ...FAILING, checks: checks({ merge_state: "unknown" }) } })).toEqual(
+      { do: "wait", why: "gate-settling" },
+    );
+  });
+
+  it("escalates a human-only gate instead of retrying it", () => {
+    const reviewGate = { ...FAILING, checks: checks({ merge_state: "blocked" }) };
+    expect(step({ readiness: reviewGate })).toEqual({
+      do: "escalate",
+      reason: "needs-human",
+      rung: null,
+    });
+  });
+
+  it("does nothing once there is nothing left that it handles", () => {
+    // A mergeable PR is not autopilot's to merge — that decision stays the
+    // user's, this slice and by design.
+    expect(step({ readiness: GREEN })).toEqual({ do: "wait", why: "nothing-to-do" });
+  });
+});
+
+describe("autopilot opens a cycle", () => {
+  it("dispatches fix-checks with the failing names and the world it started from", () => {
+    expect(step()).toEqual({
+      do: "dispatch",
+      rung: "fix-checks",
+      action: "fix-checks",
+      params: { failing: "test" },
+      signature: stateSignature(FAILING),
+    });
+  });
+
+  it("refuses to re-enter a world it already failed to change", () => {
+    // Checked BEFORE the budget: a repeat of a barren world is futile even with
+    // attempts to spare.
+    const s = state({ barren: [stateSignature(FAILING)] });
+    expect(step({ state: s })).toEqual({
+      do: "escalate",
+      reason: "no-progress",
+      rung: "fix-checks",
+    });
+  });
+
+  it("stops when the rung's budget is spent", () => {
+    const s = state({ attempts: { "fix-checks": RUNG_BUDGET["fix-checks"] } });
+    expect(step({ state: s })).toEqual({
+      do: "escalate",
+      reason: "budget-spent",
+      rung: "fix-checks",
+    });
+  });
+});
+
+describe("autopilot judges a cycle in flight", () => {
+  const inFlight = (c: Partial<Cycle>, over: Partial<AutopilotInput> = {}) =>
+    step({ state: state({ cycle: cycle(c) }), ...over });
+
+  it("holds while the agent works, then asks for a local verdict", () => {
+    expect(inFlight({ phase: "working" }, { agentBusy: true })).toEqual({
+      do: "wait",
+      why: "awaiting-evidence",
+    });
+    // Turn over: verify locally rather than waiting minutes for CI to speak.
+    expect(inFlight({ phase: "working" })).toEqual({ do: "verify" });
+  });
+
+  it("settles when the checks it was fixing are gone and the world moved", () => {
+    expect(inFlight({ phase: "awaiting-evidence" }, { readiness: GREEN })).toEqual({
+      do: "settle",
+      rung: "fix-checks",
+    });
+  });
+
+  it("believes a failing local verification over CI's silence", () => {
+    // The cheap decisive signal: the project's own tests fail, so the fix didn't
+    // work — no reason to spend minutes waiting for CI to agree.
+    expect(
+      inFlight(
+        { phase: "awaiting-evidence" },
+        { readiness: GREEN, verification: report(["test", "failed"]) },
+      ),
+    ).toEqual({ do: "retry", rung: "fix-checks", barren: null });
+  });
+
+  it("records a barren signature when a cycle changed nothing", () => {
+    // Same world as at dispatch → this cycle achieved nothing, so remember the
+    // signature. Next time it comes round, autopilot gives up instead.
+    expect(inFlight({ phase: "awaiting-evidence" })).toEqual({
+      do: "retry",
+      rung: "fix-checks",
+      barren: stateSignature(FAILING),
+    });
+  });
+
+  it("gives up the second time the same world produces nothing", () => {
+    const s = state({
+      cycle: cycle({ phase: "awaiting-evidence" }),
+      barren: [stateSignature(FAILING)],
+    });
+    expect(step({ state: s })).toEqual({
+      do: "escalate",
+      reason: "no-progress",
+      rung: "fix-checks",
+    });
+  });
+
+  it("treats a changed commit as progress even when the failure is identical", () => {
+    // The agent did change code; the fix just didn't land. That earns another
+    // attempt (bounded by the budget) rather than an immediate give-up.
+    const movedSha = { ...FAILING, git: git({ head_sha: "sha9" }) };
+    expect(inFlight({ phase: "awaiting-evidence" }, { readiness: movedSha })).toEqual({
+      do: "retry",
+      rung: "fix-checks",
+      barren: null,
+    });
+  });
+
+  it("gives up when the failing cycle was the last one in the budget", () => {
+    expect(inFlight({ phase: "awaiting-evidence", attempt: RUNG_BUDGET["fix-checks"] })).toEqual({
+      do: "escalate",
+      reason: "budget-spent",
+      rung: "fix-checks",
+    });
+  });
+
+  it("waits for CI, but calls the cycle inconclusive rather than successful if it never speaks", () => {
+    const computing = { ...FAILING, checks: checks({ merge_state: "unknown" }) };
+    expect(inFlight({ phase: "awaiting-evidence" }, { readiness: computing })).toEqual({
+      do: "wait",
+      why: "awaiting-evidence",
+    });
+    // Past the timeout, "no evidence" is the honest verdict — never a silent pass.
+    expect(
+      inFlight(
+        { phase: "awaiting-evidence", phaseSince: NOW - EVIDENCE_TIMEOUT_MS - 1 },
+        { readiness: computing },
+      ),
+    ).toEqual({ do: "escalate", reason: "no-evidence", rung: "fix-checks" });
+  });
+});
+
+describe("stateSignature", () => {
+  it("changes with the commit and with the set of failures", () => {
+    expect(stateSignature(FAILING)).not.toBe(stateSignature(GREEN));
+    expect(stateSignature(FAILING)).not.toBe(
+      stateSignature({ ...FAILING, git: git({ head_sha: "other" }) }),
+    );
+  });
+
+  it("ignores the order CI reports its checks in", () => {
+    const a = { ...FAILING, checks: checks({ required_failing: ["lint", "test"] }) };
+    const b = { ...FAILING, checks: checks({ required_failing: ["test", "lint"] }) };
+    expect(stateSignature(a)).toBe(stateSignature(b));
+  });
+
+  it("is stable when nothing observable changed", () => {
+    expect(stateSignature(FAILING)).toBe(stateSignature({ ...FAILING }));
+  });
+});
+
+describe("verification verdicts", () => {
+  it("counts skipped as passing — nothing to run is not a failure", () => {
+    expect(verificationPassed(report(["test", "passed"], ["lint", "skipped"]))).toBe(true);
+    expect(verificationPassed(report())).toBe(true);
+  });
+
+  it("counts every non-pass as a failure, including a blocked setup", () => {
+    for (const outcome of ["failed", "timed_out", "setup_failed"] as const) {
+      expect(verificationPassed(report(["test", outcome]))).toBe(false);
+    }
+  });
+
+  it("names the failures, which is the tests-vs-lint split CI can't give us", () => {
+    // A CI context is free-form text; the local verifier's checks are named.
+    expect(
+      failedCheckNames(report(["install", "passed"], ["test", "failed"], ["lint", "failed"])),
+    ).toEqual(["test", "lint"]);
+  });
+});
+
+describe("portability to Rust", () => {
+  const source = readFileSync(fileURLToPath(new URL("./autopilot.ts", import.meta.url)), "utf8");
+  const imports = [...source.matchAll(/^import\s[\s\S]*?from\s+"([^"]+)";$/gm)].map((m) => m[1]);
+  // Assert against code, not prose — the header documents these rules, and naming
+  // a banned construct in order to ban it must not trip the guard.
+  const code = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+
+  it("imports only from the pure core", () => {
+    expect(imports.sort()).toEqual(["@/api", "@/delegation", "@/readiness"]);
+  });
+
+  it("pulls in no framework, store, or platform runtime", () => {
+    for (const forbidden of ["react", "zustand", "@tauri-apps", "@/store", "@/components"]) {
+      expect(imports.filter((i) => i.includes(forbidden))).toEqual([]);
+    }
+  });
+
+  it("reads no clock or randomness, so a pass is reproducible from its inputs", () => {
+    expect(code).not.toMatch(/Date\.now|new Date|Math\.random/);
+  });
+});

--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -1,0 +1,290 @@
+// ── Autopilot: drive an enrolled checkout toward landable, unattended ────────
+//
+// `readiness.ts` says what's wrong and what would fix it. This module decides
+// whether to actually do it — and, crucially, when to stop.
+//
+// The unit here is a CYCLE, not a turn:
+//
+//   dispatch → agent turn → await evidence → verdict
+//
+// That distinction is the whole reason this module exists. A delegation's unit is
+// one agent turn, and `delegationResolved("fix-checks")` deliberately returns
+// false forever (CI takes minutes), so the delegation layer clears it on
+// agent-idle with "checks are re-running". That is an honest thing to tell a
+// human who clicked a button, but it is NOT a verdict — nobody has yet found out
+// whether the fix worked. Autopilot waits for evidence, then judges.
+//
+// ── Why an unattended loop needs more than a ladder ─────────────────────────
+// Every cycle costs an agent turn and a CI run. Two failure modes would burn them
+// indefinitely:
+//
+//   1. A genuinely broken check. The agent "fixes" it, CI fails identically, the
+//      ladder says fix-checks again, forever. Caught by the state SIGNATURE: a
+//      cycle that ends on the signature it started from changed nothing.
+//   2. A rung that oscillates (fix → push → a different failure → fix → the
+//      first failure again). Caught by the per-rung attempt BUDGET.
+//
+// Both end in `escalate`, never in silence: the checkout goes back to the human
+// with a reason, which is the only honest outcome for "I couldn't do this".
+//
+// Portable to Rust on the same terms as `readiness.ts` — pure, no framework, no
+// clock of its own (`now` is a parameter). Enforced by `autopilot.test.ts`.
+
+import type { VerificationReport } from "@/api";
+import type { DelegationKind } from "@/delegation";
+import { type LadderContext, nextRung, type ReadinessInput } from "@/readiness";
+
+/** Rungs autopilot may run on its own, this slice.
+ *
+ *  Everything else the ladder returns escalates. Growing this set is how the
+ *  later slices land — conflicts (`resolve`, `update-branch`), then review
+ *  comments — each arriving with its own budget and evidence rule.
+ *
+ *  The commit / push / open-pr rungs are deliberately absent and not planned:
+ *  auto-committing someone's working tree is a different risk class from fixing
+ *  CI on work they already pushed. The ladder still computes them for the Git
+ *  panel's button; autopilot declines them, which is why an enrolled checkout
+ *  with uncommitted edits correctly does nothing. That also keeps `fix-checks`
+ *  off a dirty tree — its playbook runs `git add -A`, which would otherwise
+ *  sweep the user's in-flight edits into the agent's fix commit. */
+export const AUTOPILOT_RUNGS: readonly DelegationKind[] = ["fix-checks"];
+
+/** Cycles one rung gets on a checkout before autopilot gives up. Three is enough
+ *  for "the fix needed a second look" and short of "this is not converging". */
+export const RUNG_BUDGET: Partial<Record<DelegationKind, number>> = { "fix-checks": 3 };
+
+/** How long to wait for evidence once the agent's turn ends. Generous: a CI run
+ *  can legitimately take many minutes, and a false "no evidence" wastes a whole
+ *  budget slot on a cycle that was actually fine. */
+export const EVIDENCE_TIMEOUT_MS = 15 * 60 * 1000;
+
+/** `working` spans the agent's turn; `awaiting-evidence` is the gap between the
+ *  turn ending and the world having something to say about it. */
+export type CyclePhase = "working" | "awaiting-evidence";
+
+export interface Cycle {
+  rung: DelegationKind;
+  /** 1-based, compared against `RUNG_BUDGET`. */
+  attempt: number;
+  /** The observable world at dispatch — see `stateSignature`. */
+  signature: string;
+  phase: CyclePhase;
+  /** Epoch ms the current phase was entered, for the evidence timeout. */
+  phaseSince: number;
+}
+
+export type StuckReason =
+  /** The rung's cycle budget is spent. */
+  | "budget-spent"
+  /** A cycle ended on a signature that had already produced nothing. */
+  | "no-progress"
+  /** The ladder wants something autopilot isn't allowed to do. */
+  | "needs-human"
+  /** No evidence arrived within `EVIDENCE_TIMEOUT_MS`. */
+  | "no-evidence";
+
+/** Per-checkout autopilot state, keyed by `checkoutKey`. Absent = never enrolled. */
+export interface AutopilotState {
+  /** The user turned it on for this checkout. Off by default, everywhere. */
+  enrolled: boolean;
+  /** Paused by the user; enrollment is kept so resuming is one click. */
+  paused: boolean;
+  cycle: Cycle | null;
+  /** Cycles spent per rung. Reset on a successful cycle, so a long-lived PR
+   *  isn't capped globally — only a non-converging stretch is. */
+  attempts: Partial<Record<DelegationKind, number>>;
+  /** Signatures that have already produced a cycle with no progress. */
+  barren: string[];
+  /** Set when autopilot handed the checkout back. Sticky: it took a human to get
+   *  here, it takes a human to leave, so it can't quietly resume retrying. */
+  stuck: { reason: StuckReason; rung: DelegationKind | null; at: number } | null;
+}
+
+/** Fresh state for a newly enrolled checkout. */
+export function newEnrollment(): AutopilotState {
+  return { enrolled: true, paused: false, cycle: null, attempts: {}, barren: [], stuck: null };
+}
+
+/** A fingerprint of everything autopilot could act on. Two cycles with the same
+ *  signature faced the same world, so whatever happened between them changed
+ *  nothing that matters.
+ *
+ *  Deliberately coarse: the head commit plus the sorted failing-check names. The
+ *  sha moves whenever the agent commits at all, so a fix that changed code but
+ *  not the outcome still counts as progress and earns another attempt; only a
+ *  cycle that moved neither code nor failures reads as barren. Sorted so CI
+ *  reordering its checks isn't mistaken for a change. */
+export function stateSignature({ git, checks }: ReadinessInput): string {
+  const sha = git?.head_sha ?? "no-head";
+  const failing = [...(checks?.required_failing ?? [])].sort().join(",");
+  return `${sha}|${failing}`;
+}
+
+export type WaitReason =
+  | "not-enrolled"
+  | "paused"
+  | "stuck"
+  | "agent-busy"
+  | "delegation-in-flight"
+  | "gate-settling"
+  | "awaiting-evidence"
+  | "nothing-to-do";
+
+/** What autopilot wants done about one checkout this tick. Plain data — the
+ *  caller performs the effect and owns the state transition it implies. */
+export type AutopilotEffect =
+  /** Open a cycle: hand `rung` to the agent, recording `signature` on it. */
+  | {
+      do: "dispatch";
+      rung: DelegationKind;
+      action: string;
+      params?: Record<string, string>;
+      signature: string;
+    }
+  /** The turn ended: run local verification and enter `awaiting-evidence`. */
+  | { do: "verify" }
+  /** The cycle worked. Clear it and reset the rung's budget. */
+  | { do: "settle"; rung: DelegationKind }
+  /** The cycle failed but budget remains. Clear it, count the attempt, and
+   *  record `barren` (when non-null) so a repeat of that world gives up. */
+  | { do: "retry"; rung: DelegationKind; barren: string | null }
+  /** Hand back to the human. */
+  | { do: "escalate"; reason: StuckReason; rung: DelegationKind | null }
+  /** Nothing to do this tick. */
+  | { do: "wait"; why: WaitReason };
+
+export interface AutopilotInput {
+  state: AutopilotState | undefined;
+  readiness: ReadinessInput;
+  ladder: LadderContext;
+  /** The agent is mid-turn — autopilot never interleaves with a turn it didn't
+   *  start. */
+  agentBusy: boolean;
+  /** A delegation is already in flight for this checkout (possibly the user's). */
+  delegationInFlight: boolean;
+  /** Local verification since the turn ended, or null when there is none yet —
+   *  in which case the cycle is judged on CI alone. */
+  verification: VerificationReport | null;
+  now: number;
+}
+
+/** Decide the next move for one checkout. Pure and total.
+ *
+ *  Every reason NOT to act is checked before any reason to act, so a paused or
+ *  stuck checkout can never be talked into a dispatch by an interesting-looking
+ *  ladder result. */
+export function autopilotStep(input: AutopilotInput): AutopilotEffect {
+  const { state, readiness, ladder, agentBusy, delegationInFlight } = input;
+
+  if (!state?.enrolled) return { do: "wait", why: "not-enrolled" };
+  if (state.paused) return { do: "wait", why: "paused" };
+  if (state.stuck) return { do: "wait", why: "stuck" };
+
+  if (state.cycle) return judgeCycle(state.cycle, input);
+
+  // ── No cycle in flight: should we start one? ──
+  // Never interleave with a turn we didn't start. `delegateAction` would hold the
+  // trigger and deliver it once the running turn ends — right for a human click,
+  // wrong here: it would append an action to whatever the user just asked for.
+  if (agentBusy) return { do: "wait", why: "agent-busy" };
+  if (delegationInFlight) return { do: "wait", why: "delegation-in-flight" };
+
+  const rung = nextRung(readiness, ladder);
+  switch (rung.do) {
+    case "delegate": {
+      if (!AUTOPILOT_RUNGS.includes(rung.kind)) {
+        // A real action, just not one autopilot may take (a commit; a conflict
+        // resolution until that slice lands). The human decides.
+        return { do: "escalate", reason: "needs-human", rung: rung.kind };
+      }
+      const signature = stateSignature(readiness);
+      // Refuse to re-enter a world we already failed to change.
+      if (state.barren.includes(signature)) {
+        return { do: "escalate", reason: "no-progress", rung: rung.kind };
+      }
+      if ((state.attempts[rung.kind] ?? 0) >= (RUNG_BUDGET[rung.kind] ?? 0)) {
+        return { do: "escalate", reason: "budget-spent", rung: rung.kind };
+      }
+      return {
+        do: "dispatch",
+        rung: rung.kind,
+        action: rung.action,
+        params: rung.params,
+        signature,
+      };
+    }
+    case "wait":
+      // `gate-computing` / `unknown-state`. Acting on an unsettled world is how a
+      // loop convinces itself there's work when there isn't.
+      return { do: "wait", why: "gate-settling" };
+    case "escalate":
+      return { do: "escalate", reason: "needs-human", rung: null };
+    default:
+      // merge / ready / landed. Autopilot's job here is done; merging is a
+      // decision, not a remediation, and deliberately not autopilot's to make.
+      return { do: "wait", why: "nothing-to-do" };
+  }
+}
+
+/** Judge a cycle already in flight. Split out so `autopilotStep` reads as the
+ *  guard sequence it is. */
+function judgeCycle(cycle: Cycle, input: AutopilotInput): AutopilotEffect {
+  const { state, readiness, ladder, agentBusy, delegationInFlight, verification, now } = input;
+
+  if (cycle.phase === "working") {
+    // Still the agent's turn, or its delegation is still being tracked.
+    if (agentBusy || delegationInFlight) return { do: "wait", why: "awaiting-evidence" };
+    // The turn ended. Get a fast local verdict rather than waiting out CI.
+    return { do: "verify" };
+  }
+
+  // ── awaiting-evidence ──
+  const moved = stateSignature(readiness) !== cycle.signature;
+  const barren = moved ? null : cycle.signature;
+  const failed = (): AutopilotEffect => {
+    // A second barren cycle on the same world means retrying is futile, not
+    // unlucky — stop before spending the rest of the budget on it.
+    if (barren && (state?.barren.includes(barren) ?? false)) {
+      return { do: "escalate", reason: "no-progress", rung: cycle.rung };
+    }
+    if (cycle.attempt >= (RUNG_BUDGET[cycle.rung] ?? 0)) {
+      return { do: "escalate", reason: "budget-spent", rung: cycle.rung };
+    }
+    return { do: "retry", rung: cycle.rung, barren };
+  };
+
+  // Local verification is the cheap, decisive signal: if the project's own tests
+  // and lints fail, the fix did not work, whatever CI hasn't said yet.
+  if (verification && !verificationPassed(verification)) return failed();
+
+  const rung = nextRung(readiness, ladder);
+  // CI still resolving — no verdict available. Hold, unless we've held so long
+  // the cycle is better called inconclusive than successful.
+  if (rung.do === "wait") {
+    if (now - cycle.phaseSince > EVIDENCE_TIMEOUT_MS) {
+      return { do: "escalate", reason: "no-evidence", rung: cycle.rung };
+    }
+    return { do: "wait", why: "awaiting-evidence" };
+  }
+
+  // The world settled. Is the thing we were fixing gone?
+  const stillBlocked = rung.do === "delegate" && rung.kind === cycle.rung;
+  if (stillBlocked || !moved) return failed();
+  return { do: "settle", rung: cycle.rung };
+}
+
+/** Whether a verification report is a pass. `skipped` counts as passing — no
+ *  command resolved means there was nothing to run, not a failure (mirrors
+ *  `VerificationReport::passed` in verify.rs). */
+export function verificationPassed(report: VerificationReport): boolean {
+  return report.checks.every((c) => c.outcome === "passed" || c.outcome === "skipped");
+}
+
+/** The report's failing check names — `"test"` / `"lint"` / `"install"`. This is
+ *  the split CI check names can't give us: the local verifier knows which of its
+ *  checks is which, where a CI context is just free-form text. */
+export function failedCheckNames(report: VerificationReport): string[] {
+  return report.checks
+    .filter((c) => c.outcome !== "passed" && c.outcome !== "skipped")
+    .map((c) => c.name);
+}

--- a/src/components/RightPanel/GitPanel/AutopilotChip.tsx
+++ b/src/components/RightPanel/GitPanel/AutopilotChip.tsx
@@ -1,0 +1,98 @@
+import type { AutopilotState, StuckReason } from "@/autopilot";
+import { Icon } from "@/components/Icon";
+import { useAppStore } from "@/store";
+import { checkoutKey } from "@/store/git";
+
+// ── Autopilot control + status, per checkout ──────────────────────────────────
+// An unattended loop that spends agent turns has to be visible and stoppable
+// from the surface it acts on, so this is both the switch and the readout. Off is
+// the default everywhere; nothing here starts on its own.
+
+/** What the chip says, derived from the stored state. Kept separate from the
+ *  component so the phrasing is testable and the render stays dumb. */
+export type ChipMode = "off" | "idle" | "working" | "paused" | "stuck";
+
+export function chipMode(state: AutopilotState | undefined): ChipMode {
+  if (!state?.enrolled) return "off";
+  if (state.stuck) return "stuck";
+  if (state.paused) return "paused";
+  return state.cycle ? "working" : "idle";
+}
+
+/** Why autopilot handed this checkout back — phrased as what happened, not as an
+ *  error code, since the next move is the user's. */
+export function stuckLabel(reason: StuckReason): string {
+  switch (reason) {
+    case "budget-spent":
+      return "Autopilot tried three times without fixing it";
+    case "no-progress":
+      return "Autopilot stopped — its last attempt changed nothing";
+    case "needs-human":
+      return "Autopilot stopped — this needs you";
+    case "no-evidence":
+      return "Autopilot stopped — no result came back";
+  }
+}
+
+const LABEL: Record<ChipMode, string> = {
+  off: "Autopilot",
+  idle: "Autopilot on",
+  working: "Autopilot working…",
+  paused: "Autopilot paused",
+  stuck: "Autopilot stopped",
+};
+
+export function AutopilotChip({ agentId, subdir }: { agentId: string; subdir?: string }) {
+  const key = checkoutKey(agentId, subdir);
+  const state = useAppStore((s) => s.autopilot[key]);
+  const enroll = useAppStore((s) => s.enrollAutopilot);
+  const unenroll = useAppStore((s) => s.unenrollAutopilot);
+  const pause = useAppStore((s) => s.pauseAutopilot);
+  const resume = useAppStore((s) => s.resumeAutopilot);
+
+  const mode = chipMode(state);
+  const attempt = state?.cycle?.attempt;
+
+  // Primary click: the least surprising thing for the current mode. Enrolling is
+  // the only action that starts work, and it takes an explicit click every time.
+  const onClick = () => {
+    if (mode === "off") return enroll(key);
+    if (mode === "stuck" || mode === "paused") return resume(key);
+    return pause(key);
+  };
+
+  const title =
+    mode === "stuck" && state?.stuck
+      ? `${stuckLabel(state.stuck.reason)}. Click to let it try again.`
+      : mode === "off"
+        ? "Let Fletch fix failing checks on this PR without being asked"
+        : mode === "paused"
+          ? "Click to resume"
+          : "Click to pause";
+
+  return (
+    <div className="git-autopilot flex-center">
+      <button type="button" className={`ap-chip text-xs m-${mode}`} onClick={onClick} title={title}>
+        <Icon name={mode === "working" ? "refresh" : "wrench"} />
+        <span>{LABEL[mode]}</span>
+        {/* Attempt count only while it means something — a second or third try is
+         *  exactly when a user wants to know before it gives up. */}
+        {mode === "working" && attempt != null && attempt > 1 && (
+          <span className="ap-attempt">#{attempt}</span>
+        )}
+      </button>
+      {/* Turning it off entirely is deliberately separate from pausing, so
+       *  "stop for now" can't be mistaken for "forget this checkout". */}
+      {mode !== "off" && (
+        <button
+          type="button"
+          className="ap-off text-xs"
+          onClick={() => unenroll(key)}
+          title="Turn autopilot off for this checkout"
+        >
+          Off
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/RightPanel/GitPanel/GitPanel.css
+++ b/src/components/RightPanel/GitPanel/GitPanel.css
@@ -1077,3 +1077,72 @@
 .git-pr-set-chip:hover .ag-badge {
   filter: brightness(1.15);
 }
+
+/* ── Autopilot chip ────────────────────────────────────────────────────────
+   Sits in the footer above the action bar, next to the action it automates.
+   Quiet by default (off is the norm) and only takes on colour once it is
+   actually doing something or has stopped needing you. */
+.git-autopilot {
+  gap: 6px;
+  padding: 10px 18px 0;
+}
+.ap-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 8px;
+  border: 1px solid var(--bd);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--fg-2);
+  cursor: pointer;
+}
+.ap-chip:hover {
+  color: var(--fg-1);
+  border-color: var(--bd-2);
+}
+.ap-chip svg {
+  width: 12px;
+  height: 12px;
+}
+/* On but idle: enrolled and watching, nothing to do — stated, not shouted. */
+.ap-chip.m-idle {
+  color: var(--accent);
+  border-color: var(--accent-line);
+  background: var(--accent-soft);
+}
+/* Working: a turn is in flight. The spin marks it as live rather than stuck. */
+.ap-chip.m-working {
+  color: var(--accent);
+  border-color: var(--accent-line);
+  background: var(--accent-soft);
+}
+.ap-chip.m-working svg {
+  animation: ap-spin 1.6s linear infinite;
+}
+@keyframes ap-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.ap-chip.m-paused {
+  color: var(--fg-3);
+}
+/* Stopped and waiting on a human — the one state that should catch the eye. */
+.ap-chip.m-stuck {
+  color: var(--warn, #d08770);
+  border-color: currentColor;
+}
+.ap-attempt {
+  opacity: 0.7;
+}
+.ap-off {
+  padding: 3px 6px;
+  border: 0;
+  background: transparent;
+  color: var(--fg-3);
+  cursor: pointer;
+}
+.ap-off:hover {
+  color: var(--fg-1);
+}

--- a/src/components/RightPanel/GitPanel/GitRepoSection.tsx
+++ b/src/components/RightPanel/GitPanel/GitRepoSection.tsx
@@ -4,6 +4,7 @@ import { delegationLabel } from "@/delegation";
 import { useAppStore } from "@/store";
 import { checkoutKey } from "@/store/git";
 import { ActionBar } from "./ActionBar";
+import { AutopilotChip } from "./AutopilotChip";
 import { ChangesList } from "./ChangesList";
 import { CommitComposer } from "./CommitComposer";
 import { ClosedPRCard, ConflictCard, PRCard } from "./cards";
@@ -187,6 +188,8 @@ export function GitRepoSection({
             onSubmit={() => runAction(effectiveKey)}
           />
         )}
+
+        <AutopilotChip agentId={agent.id} subdir={subdir} />
 
         <ActionBar
           statusKind={primary.statusKind}

--- a/src/helpers/agentLookups.ts
+++ b/src/helpers/agentLookups.ts
@@ -67,6 +67,8 @@ export function dropAgentEntries(state: AppState, id: string): Partial<AppState>
   const prComments = dropScopedEntries(state.prComments, id);
   const delegations = dropScopedEntries(state.delegations, id);
   const delegationNotices = dropScopedEntries(state.delegationNotices, id);
+  const autopilot = dropScopedEntries(state.autopilot, id);
+  const autopilotVerdicts = dropScopedEntries(state.autopilotVerdicts, id);
   const { [id]: _short, ...gitShortstats } = state.gitShortstats;
   const { [id]: _seed, ...composerSeeds } = state.composerSeeds;
   const { [id]: _draft, ...composerDrafts } = state.composerDrafts;
@@ -93,6 +95,8 @@ export function dropAgentEntries(state: AppState, id: string): Partial<AppState>
     composerDrafts,
     delegations,
     delegationNotices,
+    autopilot,
+    autopilotVerdicts,
     unseenResults,
     rightPanelTabs,
   };

--- a/src/store/autopilot.test.ts
+++ b/src/store/autopilot.test.ts
@@ -1,0 +1,201 @@
+// The slice behind autopilot: what persists, what deliberately doesn't, and the
+// transitions the driver applies. The pure policy is tested in autopilot.test.ts
+// at the root; this covers the state it reads.
+
+import { describe, expect, it, vi } from "vitest";
+import { create } from "zustand";
+
+// `vi.mock` is hoisted above the module body, so the spy has to be too.
+const { setSetting } = vi.hoisted(() => ({ setSetting: vi.fn() }));
+vi.mock("@/storage/settings", () => ({ setSetting }));
+
+import { AUTOPILOT_SETTING, createAutopilotSlice, parseAutopilotEnrollment } from "./autopilot";
+import type { AppState } from "./types";
+
+const makeStore = () =>
+  create<AppState>()((...a) => ({ ...createAutopilotSlice(...a) }) as AppState);
+const report = (outcome: "passed" | "failed") => ({
+  checks: [{ name: "test", command: "t", outcome, duration_ms: 1, tail: [] }],
+});
+
+describe("enrollment", () => {
+  it("starts absent — nothing is enrolled by default", () => {
+    expect(makeStore().getState().autopilot).toEqual({});
+  });
+
+  it("enrolls clean, with no spent budget and nothing in flight", () => {
+    const store = makeStore();
+    store.getState().enrollAutopilot("a1");
+    expect(store.getState().autopilot.a1).toEqual({
+      enrolled: true,
+      paused: false,
+      cycle: null,
+      attempts: {},
+      barren: [],
+      stuck: null,
+    });
+  });
+
+  it("persists only the user's intent, never in-flight machinery", () => {
+    const store = makeStore();
+    store.getState().enrollAutopilot("a1");
+    store.getState().openAutopilotCycle("a1", "fix-checks", "sig");
+    store.getState().pauseAutopilot("a1");
+
+    // The last write is what a reload would read: enrolled + paused, no cycle.
+    const [key, value] = setSetting.mock.calls.at(-1) ?? [];
+    expect(key).toBe(AUTOPILOT_SETTING);
+    expect(value).toEqual({ a1: { paused: true } });
+  });
+
+  it("pausing drops the in-flight cycle but keeps enrollment", () => {
+    // The agent's turn isn't interrupted, but autopilot stops judging it — so
+    // resuming re-derives from the world instead of scoring a turn nobody watched.
+    const store = makeStore();
+    store.getState().enrollAutopilot("a1");
+    store.getState().openAutopilotCycle("a1", "fix-checks", "sig");
+    store.getState().pauseAutopilot("a1");
+
+    expect(store.getState().autopilot.a1.cycle).toBeNull();
+    expect(store.getState().autopilot.a1.enrolled).toBe(true);
+  });
+
+  it("resuming is the only thing that clears stuck, and it clears the budget with it", () => {
+    // `stuck` is sticky by design: a human got it there, a human gets it out. The
+    // spent attempts and barren signatures go too — otherwise "try again" would
+    // immediately give up again.
+    const store = makeStore();
+    store.getState().enrollAutopilot("a1");
+    store.getState().retryAutopilotCycle("a1", "fix-checks", "sig");
+    store.getState().markAutopilotStuck("a1", "budget-spent", "fix-checks", 5);
+    expect(store.getState().autopilot.a1.stuck).not.toBeNull();
+
+    store.getState().resumeAutopilot("a1");
+    const s = store.getState().autopilot.a1;
+    expect(s.stuck).toBeNull();
+    expect(s.attempts).toEqual({});
+    expect(s.barren).toEqual([]);
+  });
+
+  it("unenrolling forgets the checkout entirely", () => {
+    const store = makeStore();
+    store.getState().enrollAutopilot("a1");
+    store.getState().enrollAutopilot("a1::web");
+    store.getState().unenrollAutopilot("a1");
+
+    expect(Object.keys(store.getState().autopilot)).toEqual(["a1::web"]);
+    expect(setSetting.mock.calls.at(-1)?.[1]).toEqual({ "a1::web": { paused: false } });
+  });
+
+  it("ignores transitions for a checkout that was never enrolled", () => {
+    // The driver only ticks enrolled keys, but a race (unenroll mid-tick) must
+    // not resurrect an entry.
+    const store = makeStore();
+    store.getState().openAutopilotCycle("ghost", "fix-checks", "sig");
+    store.getState().markAutopilotStuck("ghost", "no-progress", null, 1);
+    expect(store.getState().autopilot.ghost).toBeUndefined();
+  });
+});
+
+describe("cycle bookkeeping", () => {
+  it("numbers attempts from the rung's spent budget", () => {
+    const store = makeStore();
+    store.getState().enrollAutopilot("a1");
+    store.getState().openAutopilotCycle("a1", "fix-checks", "sig");
+    expect(store.getState().autopilot.a1.cycle?.attempt).toBe(1);
+
+    store.getState().retryAutopilotCycle("a1", "fix-checks", null);
+    store.getState().openAutopilotCycle("a1", "fix-checks", "sig2");
+    expect(store.getState().autopilot.a1.cycle?.attempt).toBe(2);
+  });
+
+  it("records a barren signature once, and only when given one", () => {
+    const store = makeStore();
+    store.getState().enrollAutopilot("a1");
+    store.getState().retryAutopilotCycle("a1", "fix-checks", "sig");
+    store.getState().retryAutopilotCycle("a1", "fix-checks", "sig");
+    store.getState().retryAutopilotCycle("a1", "fix-checks", null);
+    expect(store.getState().autopilot.a1.barren).toEqual(["sig"]);
+    expect(store.getState().autopilot.a1.attempts).toEqual({ "fix-checks": 3 });
+  });
+
+  it("gives the budget back on success, so a long-lived PR isn't capped for life", () => {
+    const store = makeStore();
+    store.getState().enrollAutopilot("a1");
+    store.getState().retryAutopilotCycle("a1", "fix-checks", null);
+    store.getState().retryAutopilotCycle("a1", "fix-checks", null);
+    store.getState().settleAutopilotCycle("a1", "fix-checks");
+    expect(store.getState().autopilot.a1.attempts["fix-checks"]).toBe(0);
+    expect(store.getState().autopilot.a1.cycle).toBeNull();
+  });
+
+  it("stamps the phase clock when evidence starts being awaited", () => {
+    const store = makeStore();
+    store.getState().enrollAutopilot("a1");
+    store.getState().openAutopilotCycle("a1", "fix-checks", "sig");
+    store.getState().advanceAutopilotCycle("a1", "awaiting-evidence", 4242);
+    expect(store.getState().autopilot.a1.cycle).toMatchObject({
+      phase: "awaiting-evidence",
+      phaseSince: 4242,
+    });
+  });
+});
+
+describe("verdicts belong to the cycle that produced them", () => {
+  it("drops the previous cycle's verdict when a new cycle opens", () => {
+    // Otherwise a stale "tests failed" from the last attempt would immediately
+    // condemn the next one.
+    const store = makeStore();
+    store.getState().enrollAutopilot("a1");
+    store.getState().recordAutopilotVerdict("a1", report("failed"));
+    expect(store.getState().autopilotVerdicts.a1).toBeDefined();
+
+    store.getState().openAutopilotCycle("a1", "fix-checks", "sig");
+    expect(store.getState().autopilotVerdicts.a1).toBeUndefined();
+  });
+
+  it("keys verdicts per checkout, so a secondary repo gets its own evidence", () => {
+    // The existing `verificationReports` map is agent-keyed, which is why
+    // autopilot keeps its own: a secondary checkout would otherwise overwrite the
+    // primary's report and be judged by it.
+    const store = makeStore();
+    store.getState().recordAutopilotVerdict("a1", report("passed"));
+    store.getState().recordAutopilotVerdict("a1::web", report("failed"));
+    expect(store.getState().autopilotVerdicts.a1.checks[0].outcome).toBe("passed");
+    expect(store.getState().autopilotVerdicts["a1::web"].checks[0].outcome).toBe("failed");
+  });
+});
+
+describe("parseAutopilotEnrollment", () => {
+  it("restores enrollment and the paused flag", () => {
+    const parsed = parseAutopilotEnrollment(JSON.stringify({ a1: { paused: true }, a2: {} }));
+    expect(parsed.a1).toMatchObject({ enrolled: true, paused: true });
+    expect(parsed.a2).toMatchObject({ enrolled: true, paused: false });
+  });
+
+  it("never restores a cycle, a spent budget, or a stuck the user didn't see", () => {
+    // A hand-edited or corrupt row must not be able to inject machinery — the
+    // persisted shape carries intent only.
+    const parsed = parseAutopilotEnrollment(
+      JSON.stringify({
+        a1: { paused: false, cycle: { rung: "fix-checks" }, attempts: { "fix-checks": 3 } },
+      }),
+    );
+    expect(parsed.a1).toEqual({
+      enrolled: true,
+      paused: false,
+      cycle: null,
+      attempts: {},
+      barren: [],
+      stuck: null,
+    });
+  });
+
+  it("fails closed on junk or absence — nothing enrolled", () => {
+    // The wrong way to fail is "enroll everything"; a loop that spends agent
+    // turns must default to off.
+    expect(parseAutopilotEnrollment(undefined)).toEqual({});
+    expect(parseAutopilotEnrollment("")).toEqual({});
+    expect(parseAutopilotEnrollment("{oops")).toEqual({});
+  });
+});

--- a/src/store/autopilot.ts
+++ b/src/store/autopilot.ts
@@ -1,0 +1,199 @@
+// Autopilot enrollment + cycle bookkeeping. The policy is in `@/autopilot`
+// (pure); this slice is the state it reads and the transitions the driver
+// (`autopilotSync`) applies to it.
+//
+// Enrollment is persisted, deliberately: a loop the user switched on should
+// survive a reload rather than quietly stopping. Cycles are NOT persisted —
+// an in-flight cycle's agent turn doesn't survive a restart either, so resuming
+// one would be judging a turn that never finished. A restart drops back to
+// "enrolled, no cycle", and the next tick re-derives from the live world.
+
+import type { VerificationReport } from "@/api";
+import type { AutopilotState, Cycle, CyclePhase, StuckReason } from "@/autopilot";
+import { newEnrollment } from "@/autopilot";
+import type { DelegationKind } from "@/delegation";
+import { setSetting } from "@/storage/settings";
+import type { SliceCreator } from "./types";
+
+/** Settings key holding the persisted enrollment set. */
+export const AUTOPILOT_SETTING = "autopilotEnrollment";
+
+/** The persisted shape: only the user's intent, never in-flight machinery. */
+interface PersistedEnrollment {
+  paused: boolean;
+}
+
+export interface AutopilotSlice {
+  /** Per-checkout autopilot state, keyed by `checkoutKey`. Absent = never
+   *  enrolled, which is the default for every checkout. */
+  autopilot: Record<string, AutopilotState>;
+  /** Local verification autopilot ran to judge the CURRENT cycle, keyed by
+   *  `checkoutKey`.
+   *
+   *  Deliberately not the existing `verificationReports`: that map is keyed by
+   *  agent (so a secondary checkout's report would overwrite the primary's) and
+   *  is fed by the opt-in turn-end hook, whose latest entry may be evidence from
+   *  an unrelated user turn. Cleared when a cycle opens, so a cycle can only ever
+   *  be judged by a report produced for it. */
+  autopilotVerdicts: Record<string, VerificationReport>;
+
+  /** Turn autopilot on for a checkout. */
+  enrollAutopilot: (key: string) => void;
+  /** Turn it off entirely and forget the checkout's history. */
+  unenrollAutopilot: (key: string) => void;
+  /** Hold without losing enrollment; resuming is one click. */
+  pauseAutopilot: (key: string) => void;
+  /** Resume, clearing any `stuck` state and its spent budget — an explicit
+   *  human "try again", which is the only thing that may clear it. */
+  resumeAutopilot: (key: string) => void;
+
+  // ── driver transitions (called by autopilotSync, not by the UI) ──
+  /** Open a cycle for a dispatched rung. */
+  openAutopilotCycle: (key: string, rung: DelegationKind, signature: string) => void;
+  /** Move the in-flight cycle to a new phase, restamping its clock. */
+  advanceAutopilotCycle: (key: string, phase: CyclePhase, now: number) => void;
+  /** The cycle worked: clear it and give the rung its budget back. */
+  settleAutopilotCycle: (key: string, rung: DelegationKind) => void;
+  /** The cycle failed with budget left: clear it, count the attempt, and record
+   *  a barren signature when the world didn't move. */
+  retryAutopilotCycle: (key: string, rung: DelegationKind, barren: string | null) => void;
+  /** Hand the checkout back to the human. */
+  markAutopilotStuck: (
+    key: string,
+    reason: StuckReason,
+    rung: DelegationKind | null,
+    now: number,
+  ) => void;
+  /** Store the local verification that will judge this cycle. */
+  recordAutopilotVerdict: (key: string, report: VerificationReport) => void;
+}
+
+/** Parse the persisted enrollment set at launch (mirrors `parseReviewDismissed`
+ *  in eventListeners). Rebuilds from a fresh enrollment so a hand-edited or
+ *  corrupt row can never inject a cycle, a spent budget, or a `stuck` the user
+ *  never saw — and an unparseable value yields nothing enrolled, which is the
+ *  right way for a loop that spends agent turns to fail. */
+export function parseAutopilotEnrollment(raw: string | undefined): Record<string, AutopilotState> {
+  if (!raw) return {};
+  try {
+    const parsed: Record<string, PersistedEnrollment> = JSON.parse(raw);
+    const out: Record<string, AutopilotState> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      out[key] = { ...newEnrollment(), paused: Boolean(value?.paused) };
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/** Persist just the enrollment intent for every enrolled checkout. */
+function persist(map: Record<string, AutopilotState>) {
+  const out: Record<string, PersistedEnrollment> = {};
+  for (const [key, s] of Object.entries(map)) {
+    if (s.enrolled) out[key] = { paused: s.paused };
+  }
+  void setSetting(AUTOPILOT_SETTING, out);
+}
+
+/** Update one checkout's state and persist, skipping absent entries. */
+const patch = (
+  set: Parameters<SliceCreator<AutopilotSlice>>[0],
+  key: string,
+  fn: (s: AutopilotState) => AutopilotState,
+  { save = false }: { save?: boolean } = {},
+) => {
+  set((store) => {
+    const current = store.autopilot[key];
+    if (!current) return store;
+    const autopilot = { ...store.autopilot, [key]: fn(current) };
+    if (save) persist(autopilot);
+    return { autopilot };
+  });
+};
+
+/** Drop a checkout's stale verdict — called whenever a cycle opens or ends, so a
+ *  report can never outlive the cycle it was produced for. */
+const clearVerdict = (verdicts: Record<string, VerificationReport>, key: string) => {
+  const { [key]: _dropped, ...rest } = verdicts;
+  return rest;
+};
+
+export const createAutopilotSlice: SliceCreator<AutopilotSlice> = (set) => ({
+  autopilot: {},
+  autopilotVerdicts: {},
+
+  enrollAutopilot: (key) => {
+    set((s) => {
+      const autopilot = { ...s.autopilot, [key]: newEnrollment() };
+      persist(autopilot);
+      return { autopilot };
+    });
+  },
+
+  unenrollAutopilot: (key) => {
+    set((s) => {
+      const { [key]: _dropped, ...autopilot } = s.autopilot;
+      persist(autopilot);
+      return { autopilot };
+    });
+  },
+
+  pauseAutopilot: (key) =>
+    // Drop any in-flight cycle: the agent's turn continues (we don't interrupt
+    // it), but autopilot stops judging it, so resuming re-derives from the world
+    // rather than from a verdict nobody was waiting for.
+    patch(set, key, (s) => ({ ...s, paused: true, cycle: null }), { save: true }),
+
+  resumeAutopilot: (key) =>
+    // Clearing `stuck` AND the spent attempts is the point: the human has looked
+    // and wants another go. Barren signatures are cleared too — the world may
+    // have changed under them.
+    patch(set, key, (s) => ({ ...s, paused: false, stuck: null, attempts: {}, barren: [] }), {
+      save: true,
+    }),
+
+  openAutopilotCycle: (key, rung, signature) => {
+    patch(set, key, (s) => ({
+      ...s,
+      // `phaseSince` is stamped when the phase that needs a clock
+      // (`awaiting-evidence`) is entered, so `working` carries the dispatch time
+      // only for display.
+      cycle: {
+        rung,
+        attempt: (s.attempts[rung] ?? 0) + 1,
+        signature,
+        phase: "working",
+        phaseSince: 0,
+      } satisfies Cycle,
+    }));
+    // The previous cycle's verdict must not be read as this one's.
+    set((s) => ({ autopilotVerdicts: clearVerdict(s.autopilotVerdicts, key) }));
+  },
+
+  advanceAutopilotCycle: (key, phase, now) =>
+    patch(set, key, (s) => (s.cycle ? { ...s, cycle: { ...s.cycle, phase, phaseSince: now } } : s)),
+
+  settleAutopilotCycle: (key, rung) =>
+    patch(set, key, (s) => ({
+      ...s,
+      cycle: null,
+      // Success earns a fresh budget: a long-lived PR that autopilot keeps
+      // helping shouldn't hit a lifetime cap, only a non-converging stretch.
+      attempts: { ...s.attempts, [rung]: 0 },
+    })),
+
+  retryAutopilotCycle: (key, rung, barren) =>
+    patch(set, key, (s) => ({
+      ...s,
+      cycle: null,
+      attempts: { ...s.attempts, [rung]: (s.attempts[rung] ?? 0) + 1 },
+      barren: barren && !s.barren.includes(barren) ? [...s.barren, barren] : s.barren,
+    })),
+
+  markAutopilotStuck: (key, reason, rung, now) =>
+    patch(set, key, (s) => ({ ...s, cycle: null, stuck: { reason, rung, at: now } })),
+
+  recordAutopilotVerdict: (key, report) =>
+    set((s) => ({ autopilotVerdicts: { ...s.autopilotVerdicts, [key]: report } })),
+});

--- a/src/store/autopilotSync.ts
+++ b/src/store/autopilotSync.ts
@@ -1,0 +1,141 @@
+// The autopilot driver: one tick, every enrolled checkout.
+//
+// Mounted once at the app root, like `useGitSync` and `useDelegationSync`. The
+// decision for each checkout is pure (`autopilotStep`); this hook is the applier
+// — it turns effects into store transitions, delegations and verification calls.
+//
+// ── Known limitation, stated plainly ────────────────────────────────────────
+// This runs in the webview, and `usePoll` stops when `document.hidden` (see
+// util/hooks.ts). Closing the Fletch window hides it — the app and its agents
+// keep running, but this loop does not. So autopilot progresses only while the
+// window is open. Moving the loop into the supervisor is what fixes that;
+// `autopilot.ts` and `readiness.ts` are written to be portable for exactly that
+// reason, and their tests enforce it.
+
+import { useCallback, useRef } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { api } from "@/api";
+import { type AutopilotEffect, autopilotStep } from "@/autopilot";
+import { appActionMessage } from "@/delegation";
+import { useAppStore } from "@/store";
+import { usePoll } from "@/util/hooks";
+import { splitCheckoutKey } from "./git";
+
+/** How often to evaluate enrolled checkouts. Slower than the git poll on
+ *  purpose: every action this can take costs an agent turn, so there is nothing
+ *  to gain from reacting inside a second, and a slow tick makes accidental
+ *  double-dispatch structurally unlikely. */
+const AUTOPILOT_TICK_MS = 10_000;
+
+/** Mount once, at the app root. */
+export function useAutopilotSync() {
+  // Only enrolled checkouts are ever considered. Sorted + shallow-compared so the
+  // tick keeps a stable identity across unrelated store writes.
+  const keys = useAppStore(
+    useShallow((s) =>
+      Object.entries(s.autopilot)
+        .filter(([, a]) => a.enrolled)
+        .map(([key]) => key)
+        .sort(),
+    ),
+  );
+
+  // Verification is an async round-trip that outlives a tick; without this a slow
+  // verify would be re-issued every 10s for the same cycle.
+  const verifying = useRef<Set<string>>(new Set());
+
+  const tick = useCallback(async () => {
+    for (const key of keys) {
+      const s = useAppStore.getState();
+      const { agentId, subdir } = splitCheckoutKey(key);
+      const agent = s.workspace?.agents.find((a) => a.id === agentId);
+      // The checkout's agent is gone (archived/discarded) — drop the enrollment
+      // rather than ticking forever against nothing.
+      if (!agent) {
+        s.unenrollAutopilot(key);
+        continue;
+      }
+      const git = s.gitStates[key] ?? null;
+      const readiness = {
+        git,
+        pr: s.prStates[key] ?? null,
+        checks: s.prChecks[key] ?? null,
+        comments: s.prComments[key] ?? null,
+      };
+      const now = Date.now();
+      const effect = autopilotStep({
+        state: s.autopilot[key],
+        readiness,
+        ladder: { base: git?.parent_branch || "main", commitMode: "commit-pr" },
+        agentBusy: agent.status === "running" || agent.status === "spawning",
+        delegationInFlight: s.delegations[key] != null,
+        // Only a verdict produced FOR the current cycle counts as its evidence
+        // (cleared on dispatch); see `autopilotVerdicts`.
+        verification: s.autopilotVerdicts[key] ?? null,
+        now,
+      });
+      await apply(key, agentId, subdir, effect, now, verifying.current);
+    }
+  }, [keys]);
+
+  usePoll(tick, AUTOPILOT_TICK_MS, [tick]);
+}
+
+/** Perform one effect. Split out so the tick reads as the sweep it is. */
+async function apply(
+  key: string,
+  agentId: string,
+  subdir: string | undefined,
+  effect: AutopilotEffect,
+  now: number,
+  verifying: Set<string>,
+) {
+  const s = useAppStore.getState();
+  switch (effect.do) {
+    case "dispatch": {
+      s.openAutopilotCycle(key, effect.rung, effect.signature);
+      // Same trigger construction the panel and Mission Control use, including
+      // the `repo=` scope for a secondary checkout.
+      s.delegateAction(
+        agentId,
+        effect.rung,
+        appActionMessage(
+          effect.action,
+          subdir ? { ...effect.params, repo: subdir } : effect.params,
+        ),
+        subdir,
+      );
+      return;
+    }
+    case "verify": {
+      // Enter `awaiting-evidence` first: the phase clock starts now, and the
+      // effect is idempotent from here even if the verify call is slow or fails.
+      s.advanceAutopilotCycle(key, "awaiting-evidence", now);
+      if (verifying.has(key)) return;
+      verifying.add(key);
+      try {
+        // Recorded per checkout so the next tick reads it as THIS cycle's
+        // evidence.
+        s.recordAutopilotVerdict(key, await api.runVerification(agentId, subdir));
+      } catch {
+        // No local verdict available — the cycle falls back to judging on CI,
+        // bounded by the evidence timeout. A verify that couldn't run must never
+        // look like a fix that didn't work.
+      } finally {
+        verifying.delete(key);
+      }
+      return;
+    }
+    case "settle":
+      s.settleAutopilotCycle(key, effect.rung);
+      return;
+    case "retry":
+      s.retryAutopilotCycle(key, effect.rung, effect.barren);
+      return;
+    case "escalate":
+      s.markAutopilotStuck(key, effect.reason, effect.rung, now);
+      return;
+    case "wait":
+      return;
+  }
+}

--- a/src/store/delegationSync.test.ts
+++ b/src/store/delegationSync.test.ts
@@ -41,6 +41,8 @@ const EMPTY_MAPS = {
   composerDrafts: {},
   delegations: {},
   delegationNotices: {},
+  autopilot: {},
+  autopilotVerdicts: {},
   unseenResults: {},
   rightPanelTabs: {},
 };

--- a/src/store/discardRestore.test.ts
+++ b/src/store/discardRestore.test.ts
@@ -41,6 +41,8 @@ const EMPTY_MAPS = {
   composerDrafts: {},
   delegations: {},
   delegationNotices: {},
+  autopilot: {},
+  autopilotVerdicts: {},
   unseenResults: {},
   rightPanelTabs: {},
 };

--- a/src/store/eventListeners.ts
+++ b/src/store/eventListeners.ts
@@ -58,6 +58,7 @@ import { getAllSettings } from "@/storage/settings";
 import { recordUsageSnapshot } from "@/storage/usageDaily";
 import { notify } from "@/util/notify";
 import { playAgentDone } from "@/util/sound";
+import { AUTOPILOT_SETTING, parseAutopilotEnrollment } from "./autopilot";
 import { interruptedAgents } from "./interrupted";
 import { stampPrWrite } from "./prWriteOrder";
 import { refreshWorkspace } from "./refreshWorkspace";
@@ -163,6 +164,11 @@ export const hydrateSettings = async (set: AppSet) => {
       // Admin unlocks the Developer settings section in production. Opt-in:
       // only an explicit "true" in the `admin` settings row grants it.
       admin: s.admin === "true",
+      // Autopilot enrollment (checkout key → paused). Only the user's intent is
+      // persisted; cycles and budgets always start fresh — an in-flight cycle's
+      // agent turn doesn't survive a restart either, so resuming one would mean
+      // judging a turn that never finished.
+      autopilot: parseAutopilotEnrollment(s[AUTOPILOT_SETTING]),
     });
   } catch {
     // First launch or DB not ready — defaults are fine.

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -3,6 +3,7 @@ import type { AgentRecord } from "@/api"; // for EMPTY_AGENTS
 import { createAccountSlice } from "./account";
 import { createAppSlice } from "./app";
 import { createAppearanceSlice } from "./appearance";
+import { createAutopilotSlice } from "./autopilot";
 import { createComposerSlice } from "./composer";
 import { createCustomAgentsSlice } from "./customAgents";
 import { createDraftsSlice } from "./drafts";
@@ -29,6 +30,7 @@ export const useAppStore = create<AppState>()((...a) => ({
   ...createUiSlice(...a),
   ...createAccountSlice(...a),
   ...createAppearanceSlice(...a),
+  ...createAutopilotSlice(...a),
   ...createProvidersSlice(...a),
   ...createCustomAgentsSlice(...a),
   ...createSkillsSlice(...a),

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -9,6 +9,7 @@ import type { StateCreator } from "zustand";
 import type { AccountSlice } from "./account";
 import type { AppSlice } from "./app";
 import type { AppearanceSlice } from "./appearance";
+import type { AutopilotSlice } from "./autopilot";
 import type { ComposerSlice } from "./composer";
 import type { CustomAgentsSlice } from "./customAgents";
 import type { DraftsSlice } from "./drafts";
@@ -26,6 +27,7 @@ export type {
   AccountSlice,
   AppearanceSlice,
   AppSlice,
+  AutopilotSlice,
   ComposerSlice,
   CustomAgentsSlice,
   DockerBuildProgress,
@@ -53,6 +55,7 @@ export type AppState = AppSlice &
   UiSlice &
   AccountSlice &
   AppearanceSlice &
+  AutopilotSlice &
   ProvidersSlice &
   CustomAgentsSlice &
   SkillsSlice &


### PR DESCRIPTION
**Stacked on #546** (`refactor/extract-readiness-ladder`) — it needs `readiness.ts`. Review that one first; this diff is only the autopilot on top.

Third slice, and the first with actual autonomy: enroll a checkout, and when its PR has failing checks Fletch hands the fix to the agent, judges the result, and retries within a budget. Off by default everywhere.

## The unit is a cycle, not a turn

```
dispatch → agent turn → await evidence → verdict
```

`delegationResolved("fix-checks")` returns `false` forever by design (CI takes minutes), so the delegation layer clears it on agent-idle with "checks are re-running". That's honest to tell a human who clicked a button, but it isn't a *verdict* — nobody has found out yet whether the fix worked. `autopilot.ts` owns the cycle on top; the delegation layer keeps its one-turn scope unchanged.

## Brakes, because every cycle spends an agent turn and a CI run

| Rail | Why |
|---|---|
| Per-rung budget (`fix-checks` ≤ 3) | Catches a rung that oscillates |
| State **signature** (head sha + sorted failing names) | A cycle ending on the signature it started from changed nothing. A second barren cycle on that world gives up instead of spending the rest of the budget — without this, a genuinely broken test retries forever |
| Never interleave with the user's turn | `delegateAction` *holds* a trigger and delivers it after the running turn — right for a click, wrong here, since it would append an action to whatever they just asked for. Skip the tick instead |
| Escalate anything outside `AUTOPILOT_RUNGS` | Human-owned gates, and rungs later slices will add |
| `stuck` is sticky | A human got it there, a human clears it |

**Dirty trees fall out for free.** `fix-checks` runs `git add -A`, and the ladder already ranks uncommitted work above failing checks — so a dirty tree yields a commit rung autopilot declines, rather than sweeping your in-flight edits into the agent's fix commit. Commit / push / open-pr are deliberately not in `AUTOPILOT_RUNGS` and aren't planned to be: auto-committing someone's working tree is a different risk class from fixing CI on work they already pushed.

## Local verification, and a revision to what I described

I'd planned "only push once the tests pass". That doesn't work: the `fix-checks` playbook commits and pushes *inside* its turn, so it would mean trusting the agent to pick the right command when `verify.rs` already has detection plus project overrides the agent can't see. Instead the app runs `run_verification` after the turn as **its own verdict** — a failed attempt is known in seconds instead of a CI round trip. A bad fix still gets pushed and burns one CI run; that's the trade, and it's the cheap half of the benefit.

Verdicts are keyed per checkout in `autopilotVerdicts` rather than reused from `verificationReports`, which is agent-keyed (a secondary checkout would overwrite the primary's) and fed by an opt-in turn-end hook whose latest entry may be evidence from an unrelated turn. Cleared when a cycle opens, so a cycle can only ever be judged by a report produced *for it*.

## Fixes a pre-existing race this would have provoked

`run_verification` had no debounce, while the turn-end path guards itself with `verify_inflight` — so the command could already collide with it: two verifier passes in one checkout, racing on the working tree and any shared build cache. Autopilot would hit that every cycle, so the command now takes the same guard (RAII-released, so the `?` paths can't leak it) and refuses rather than queueing. Small Rust change; it makes the existing Run-panel button safe too.

## Enrollment

Per checkout, persisted, default off. Only *intent* is persisted — cycles and budgets always start fresh, because an in-flight cycle's agent turn doesn't survive a restart either, so resuming one would mean judging a turn that never finished. A corrupt row yields nothing enrolled, which is the right way for this to fail. The chip in the Git panel footer is both the switch and the readout; pausing and turning off are separate gestures so "stop for now" can't be mistaken for "forget this checkout".

## Known limitation, stated in the code too

The loop runs in the webview, and `usePoll` stops on `document.hidden`. Closing the Fletch window hides it — the app and its agents keep running, this loop does not. **So autopilot progresses only while the window is open**; a PR that starts failing overnight waits until you reopen Fletch. Moving the loop into the supervisor is what fixes that, and both `autopilot.ts` and `readiness.ts` are pure with tests enforcing the import/clock rules that keep that port mechanical rather than a rewrite.

## Verification

- `tsc --noEmit` clean; `cargo check` clean.
- 654 tests, up from 611.
- `biome check` at parity: 0 errors, same 73 pre-existing warnings.
- **Every brake mutation-checked** — removing the agent-busy guard, the allowed-rungs filter, the barren check, the budget check, or the evidence timeout each fails a test.

## Not in this PR

Conflicts / `update-branch` (next), review comments, workflow PRs, merging (deferred). `checks-failing` is still one blocker rather than split into tests-vs-lint: CI check names are free-form, so splitting there would be a heuristic dressed as a fact. `failedCheckNames` gives the real split from the local verifier, ready for the next slice to use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)