### PR TITLE
feat(autopilot): reconcile a diverged branch and finish a stalled merge

### DIFF
--- a/src/autopilot.test.ts
+++ b/src/autopilot.test.ts
@@ -17,6 +17,7 @@ import {
   newEnrollment,
   RUNG_BUDGET,
   stateSignature,
+  unstagedEdits,
   verificationPassed,
 } from "@/autopilot";
 import type { LadderContext, ReadinessInput } from "@/readiness";
@@ -306,6 +307,116 @@ describe("autopilot judges a cycle in flight", () => {
   });
 });
 
+describe("the reconcile rungs", () => {
+  /** A mid-merge tree: the merge's own content is STAGED (git refuses to start a
+   *  merge with staged changes, so staged entries can only be its output), and the
+   *  unresolved files are conflicted. */
+  const midMerge = (over: Partial<GitState> = {}): ReadinessInput => ({
+    ...FAILING,
+    git: git({
+      files: [
+        { path: "a.ts", kind: "conflicted", staged: false, additions: 1, deletions: 0 },
+        { path: "b.ts", kind: "modified", staged: true, additions: 1, deletions: 0 },
+      ],
+      ...over,
+    }),
+  });
+
+  it("resolves conflicts, ahead of everything else that's wrong", () => {
+    // The PR is also failing checks and behind, but a broken tree comes first —
+    // every later rung would build on it.
+    expect(step({ readiness: midMerge() })).toMatchObject({
+      do: "dispatch",
+      rung: "resolve",
+      action: "resolve-conflicts",
+    });
+  });
+
+  it("refuses to finish a merge that would swallow the user's uncommitted work", () => {
+    // The playbook completes the merge with `git add -A`. An unstaged,
+    // non-conflicted edit is by definition the user's in-flight work (the merge's
+    // own content is staged), so this is not autopilot's merge to finish.
+    const withUserEdit = midMerge({
+      files: [
+        { path: "a.ts", kind: "conflicted", staged: false, additions: 1, deletions: 0 },
+        { path: "mine.ts", kind: "modified", staged: false, additions: 9, deletions: 0 },
+      ],
+    });
+    expect(step({ readiness: withUserEdit })).toEqual({
+      do: "escalate",
+      reason: "dirty-tree",
+      rung: "resolve",
+    });
+  });
+
+  it("updates a branch that has fallen behind its base", () => {
+    const behind = {
+      ...FAILING,
+      checks: checks({ merge_state: "behind", required_failing: ["test"] }),
+    };
+    expect(step({ readiness: behind })).toMatchObject({
+      do: "dispatch",
+      rung: "update-branch",
+      params: { base: "main" },
+    });
+  });
+
+  it("judges a reconcile on the world, not by running the tests", () => {
+    // A merge can be perfectly correct and still surface a pre-existing test
+    // failure. Verifying would answer a different question, so these rungs skip it.
+    for (const rung of ["resolve", "update-branch"] as const) {
+      expect(step({ state: state({ cycle: cycle({ rung, phase: "working" }) }) })).toEqual({
+        do: "await-evidence",
+      });
+    }
+    // And a failing local report must not condemn one.
+    expect(
+      step({
+        state: state({ cycle: cycle({ rung: "update-branch", phase: "awaiting-evidence" }) }),
+        readiness: GREEN,
+        verification: report(["test", "failed"]),
+      }),
+    ).toEqual({ do: "settle", rung: "update-branch" });
+  });
+
+  it("still runs the tests for a code fix", () => {
+    expect(step({ state: state({ cycle: cycle({ phase: "working" }) }) })).toEqual({
+      do: "verify",
+    });
+  });
+
+  it("gives a reconcile two attempts, not three", () => {
+    for (const rung of ["resolve", "update-branch"] as const) {
+      expect(RUNG_BUDGET[rung]).toBe(2);
+    }
+  });
+});
+
+describe("unstagedEdits", () => {
+  it("counts only the user's in-flight work, not the merge's own content", () => {
+    expect(unstagedEdits(null)).toBe(0);
+    expect(
+      unstagedEdits(
+        git({
+          files: [
+            // The conflict itself: autopilot's to resolve.
+            { path: "a.ts", kind: "conflicted", staged: false, additions: 1, deletions: 0 },
+            // Cleanly merged by git, already staged: also the merge's.
+            { path: "b.ts", kind: "modified", staged: true, additions: 1, deletions: 0 },
+          ],
+        }),
+      ),
+    ).toBe(0);
+    expect(
+      unstagedEdits(
+        git({
+          files: [{ path: "mine.ts", kind: "modified", staged: false, additions: 1, deletions: 0 }],
+        }),
+      ),
+    ).toBe(1);
+  });
+});
+
 describe("stateSignature", () => {
   it("changes with the commit and with the set of failures", () => {
     expect(stateSignature(FAILING)).not.toBe(stateSignature(GREEN));
@@ -322,6 +433,29 @@ describe("stateSignature", () => {
 
   it("is stable when nothing observable changed", () => {
     expect(stateSignature(FAILING)).toBe(stateSignature({ ...FAILING }));
+  });
+
+  it("tracks the conflict set, so a partial resolution counts as progress", () => {
+    // `resolve` leaves the sha untouched until the merge is completed, so without
+    // the conflicted paths an attempt that fixed two of three files would look
+    // identical to one that did nothing — and be written off as barren.
+    const conflicts = (...paths: string[]): ReadinessInput => ({
+      ...FAILING,
+      git: git({
+        files: paths.map((path) => ({
+          path,
+          kind: "conflicted" as const,
+          staged: false,
+          additions: 1,
+          deletions: 0,
+        })),
+      }),
+    });
+    expect(stateSignature(conflicts("a.ts", "b.ts"))).not.toBe(stateSignature(conflicts("a.ts")));
+    // Order of the report doesn't matter.
+    expect(stateSignature(conflicts("a.ts", "b.ts"))).toBe(
+      stateSignature(conflicts("b.ts", "a.ts")),
+    );
   });
 });
 

--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -30,7 +30,7 @@
 // Portable to Rust on the same terms as `readiness.ts` — pure, no framework, no
 // clock of its own (`now` is a parameter). Enforced by `autopilot.test.ts`.
 
-import type { VerificationReport } from "@/api";
+import type { GitState, VerificationReport } from "@/api";
 import type { DelegationKind } from "@/delegation";
 import { type LadderContext, nextRung, type ReadinessInput } from "@/readiness";
 
@@ -47,11 +47,42 @@ import { type LadderContext, nextRung, type ReadinessInput } from "@/readiness";
  *  with uncommitted edits correctly does nothing. That also keeps `fix-checks`
  *  off a dirty tree — its playbook runs `git add -A`, which would otherwise
  *  sweep the user's in-flight edits into the agent's fix commit. */
-export const AUTOPILOT_RUNGS: readonly DelegationKind[] = ["fix-checks"];
+export const AUTOPILOT_RUNGS: readonly DelegationKind[] = [
+  "fix-checks",
+  "resolve",
+  "update-branch",
+];
 
-/** Cycles one rung gets on a checkout before autopilot gives up. Three is enough
- *  for "the fix needed a second look" and short of "this is not converging". */
-export const RUNG_BUDGET: Partial<Record<DelegationKind, number>> = { "fix-checks": 3 };
+/** Cycles one rung gets on a checkout before autopilot gives up.
+ *
+ *  `fix-checks` gets three — a fix often needs a second look, and three is short
+ *  of "not converging". The reconcile rungs get two: a merge either goes in or it
+ *  needs a judgement call about intent that the second failure has already shown
+ *  the agent isn't making. */
+export const RUNG_BUDGET: Partial<Record<DelegationKind, number>> = {
+  "fix-checks": 3,
+  resolve: 2,
+  "update-branch": 2,
+};
+
+/** How a rung's cycle is judged.
+ *
+ *  `verify` — run the project's own tests/lints and believe them. Right for
+ *    `fix-checks`, where success means "the code works now" and a local run
+ *    answers that in seconds instead of a CI round trip.
+ *  `state` — judge on the world alone. Right for the reconcile rungs, where
+ *    success is structural ("no conflict markers left", "no longer behind") and
+ *    running tests would answer a *different* question — a merge can be perfectly
+ *    correct and still surface a pre-existing test failure, which must not read
+ *    as "the merge didn't work".
+ *
+ *  Rungs default to `state`, the conservative choice: it never invents a failure
+ *  the world doesn't show. */
+export const RUNG_EVIDENCE: Partial<Record<DelegationKind, "verify" | "state">> = {
+  "fix-checks": "verify",
+  resolve: "state",
+  "update-branch": "state",
+};
 
 /** How long to wait for evidence once the agent's turn ends. Generous: a CI run
  *  can legitimately take many minutes, and a false "no evidence" wastes a whole
@@ -80,6 +111,8 @@ export type StuckReason =
   | "no-progress"
   /** The ladder wants something autopilot isn't allowed to do. */
   | "needs-human"
+  /** Acting would have swallowed the user's uncommitted work. */
+  | "dirty-tree"
   /** No evidence arrived within `EVIDENCE_TIMEOUT_MS`. */
   | "no-evidence";
 
@@ -109,15 +142,38 @@ export function newEnrollment(): AutopilotState {
  *  signature faced the same world, so whatever happened between them changed
  *  nothing that matters.
  *
- *  Deliberately coarse: the head commit plus the sorted failing-check names. The
- *  sha moves whenever the agent commits at all, so a fix that changed code but
- *  not the outcome still counts as progress and earns another attempt; only a
- *  cycle that moved neither code nor failures reads as barren. Sorted so CI
- *  reordering its checks isn't mistaken for a change. */
+ *  Deliberately coarse: the head commit, the sorted failing-check names, and the
+ *  sorted conflicted paths. The sha moves whenever the agent commits at all, so a
+ *  fix that changed code but not the outcome still counts as progress and earns
+ *  another attempt; only a cycle that moved neither code, nor failures, nor the
+ *  conflict set reads as barren.
+ *
+ *  Conflicted paths are in here for the `resolve` rung, whose whole job leaves the
+ *  sha untouched until the merge is completed: an attempt that resolved two of
+ *  three files made real progress, and without the paths that would look
+ *  identical to an attempt that did nothing. Both lists are sorted so a reordered
+ *  report isn't mistaken for a change. */
 export function stateSignature({ git, checks }: ReadinessInput): string {
   const sha = git?.head_sha ?? "no-head";
   const failing = [...(checks?.required_failing ?? [])].sort().join(",");
-  return `${sha}|${failing}`;
+  const conflicted = (git?.files ?? [])
+    .filter((f) => f.kind === "conflicted")
+    .map((f) => f.path)
+    .sort()
+    .join(",");
+  return `${sha}|${failing}|${conflicted}`;
+}
+
+/** Unstaged, non-conflicted edits in the working copy.
+ *
+ *  The guard for the `resolve` rung. Its playbook finishes the merge with
+ *  `git add -A`, so anything the user was editing gets swept into the merge
+ *  commit. Mid-merge the tree legitimately holds the merge's own content — but as
+ *  *staged* entries, because git refuses to start a merge with staged changes.
+ *  So unstaged non-conflicted edits are exactly the user's in-flight work, and
+ *  their presence means this is not autopilot's merge to finish. */
+export function unstagedEdits(git: GitState | null): number {
+  return (git?.files ?? []).filter((f) => !f.staged && f.kind !== "conflicted").length;
 }
 
 export type WaitReason =
@@ -143,6 +199,9 @@ export type AutopilotEffect =
     }
   /** The turn ended: run local verification and enter `awaiting-evidence`. */
   | { do: "verify" }
+  /** The turn ended on a state-judged rung: enter `awaiting-evidence` without
+   *  running anything. The world is the evidence; it just needs time to settle. */
+  | { do: "await-evidence" }
   /** The cycle worked. Clear it and reset the rung's budget. */
   | { do: "settle"; rung: DelegationKind }
   /** The cycle failed but budget remains. Clear it, count the attempt, and
@@ -197,6 +256,12 @@ export function autopilotStep(input: AutopilotInput): AutopilotEffect {
         // resolution until that slice lands). The human decides.
         return { do: "escalate", reason: "needs-human", rung: rung.kind };
       }
+      // Finishing a merge stages everything (`git add -A`), so unstaged edits
+      // alongside the conflict are the user's in-flight work and would be swept
+      // into the merge commit. Not autopilot's merge to finish.
+      if (rung.kind === "resolve" && unstagedEdits(readiness.git) > 0) {
+        return { do: "escalate", reason: "dirty-tree", rung: rung.kind };
+      }
       const signature = stateSignature(readiness);
       // Refuse to re-enter a world we already failed to change.
       if (state.barren.includes(signature)) {
@@ -234,8 +299,9 @@ function judgeCycle(cycle: Cycle, input: AutopilotInput): AutopilotEffect {
   if (cycle.phase === "working") {
     // Still the agent's turn, or its delegation is still being tracked.
     if (agentBusy || delegationInFlight) return { do: "wait", why: "awaiting-evidence" };
-    // The turn ended. Get a fast local verdict rather than waiting out CI.
-    return { do: "verify" };
+    // The turn ended. A code fix gets a fast local verdict; a reconcile is judged
+    // by the world it was meant to change (see `RUNG_EVIDENCE`).
+    return RUNG_EVIDENCE[cycle.rung] === "verify" ? { do: "verify" } : { do: "await-evidence" };
   }
 
   // ── awaiting-evidence ──
@@ -253,9 +319,13 @@ function judgeCycle(cycle: Cycle, input: AutopilotInput): AutopilotEffect {
     return { do: "retry", rung: cycle.rung, barren };
   };
 
-  // Local verification is the cheap, decisive signal: if the project's own tests
-  // and lints fail, the fix did not work, whatever CI hasn't said yet.
-  if (verification && !verificationPassed(verification)) return failed();
+  // Local verification is the cheap, decisive signal for a code fix: if the
+  // project's own tests and lints fail, the fix did not work, whatever CI hasn't
+  // said yet. Only consulted for rungs judged that way — a reconcile can be
+  // correct and still surface a pre-existing failure.
+  if (RUNG_EVIDENCE[cycle.rung] === "verify" && verification && !verificationPassed(verification)) {
+    return failed();
+  }
 
   const rung = nextRung(readiness, ladder);
   // CI still resolving — no verdict available. Hold, unless we've held so long

--- a/src/components/RightPanel/GitPanel/AutopilotChip.tsx
+++ b/src/components/RightPanel/GitPanel/AutopilotChip.tsx
@@ -29,6 +29,8 @@ export function stuckLabel(reason: StuckReason): string {
       return "Autopilot stopped — its last attempt changed nothing";
     case "needs-human":
       return "Autopilot stopped — this needs you";
+    case "dirty-tree":
+      return "Autopilot stopped — it won't commit your uncommitted changes";
     case "no-evidence":
       return "Autopilot stopped — no result came back";
   }

--- a/src/components/Workspace/MissionControl/QueueCard.tsx
+++ b/src/components/Workspace/MissionControl/QueueCard.tsx
@@ -12,6 +12,9 @@ const REASON_LABEL: Record<ReviewReason, string> = {
   "unseen-results": "New results to review",
   "checks-failing": "Checks failing",
   "unresolved-comments": "Unresolved comments",
+  // Phrased as what happened, not as an error: autopilot tried and handed it
+  // back, so the next move is the user's.
+  "autopilot-stuck": "Autopilot stopped",
 };
 
 function reasonLine(item: ReviewItem): string {

--- a/src/components/Workspace/MissionControl/queue.test.ts
+++ b/src/components/Workspace/MissionControl/queue.test.ts
@@ -10,6 +10,7 @@ import type {
   VerificationReport,
   WfRun,
 } from "@/api";
+import type { AutopilotState } from "@/autopilot";
 import { BUCKET, buildReviewQueue, type QueueInput } from "./queue";
 
 // ── fixtures ──────────────────────────────────────────────────────────────────
@@ -114,6 +115,7 @@ function input(over: Partial<QueueInput>): QueueInput {
     prChecks: {},
     prComments: {},
     verificationReports: {},
+    autopilot: {},
     runs: [],
     dismissed: {},
     ...over,
@@ -584,5 +586,88 @@ describe("buildReviewQueue", () => {
     );
     expect(q).toHaveLength(1);
     expect(q[0].fanout?.agents.map((a) => a.agentId)).toEqual(["live"]);
+  });
+
+  // ── autopilot escalation ──────────────────────────────────────────────────
+  // An enrolled checkout that gave up is the one signal autopilot can't surface
+  // itself: it has stopped, so if the queue doesn't raise its hand nothing does.
+
+  const stuckState = (over: Partial<AutopilotState> = {}): AutopilotState => ({
+    enrolled: true,
+    paused: false,
+    cycle: null,
+    attempts: {},
+    barren: [],
+    stuck: { reason: "budget-spent", rung: "fix-checks", at: 1 },
+    ...over,
+  });
+
+  it("raises a card when autopilot gave up, with nothing else wrong", () => {
+    const q = buildReviewQueue(
+      input({ agents: [agent({ id: "a" })], autopilot: { a: stuckState() } }),
+    );
+    expect(q).toHaveLength(1);
+    expect(q[0].reasons).toEqual(["autopilot-stuck"]);
+    expect(q[0].autopilotStuck).toEqual({ reason: "budget-spent", rung: "fix-checks" });
+  });
+
+  it("raises it for a secondary checkout too", () => {
+    // A stuck autopilot on `a::web` deserves the same card as one on the primary.
+    const q = buildReviewQueue(
+      input({ agents: [agent({ id: "a" })], autopilot: { "a::web": stuckState() } }),
+    );
+    expect(q).toHaveLength(1);
+    expect(q[0].reasons).toEqual(["autopilot-stuck"]);
+  });
+
+  it("stays quiet for a checkout that is enrolled but running fine", () => {
+    // Enrolled-and-working is the normal state; it must never generate a card.
+    const q = buildReviewQueue(
+      input({
+        agents: [agent({ id: "a" })],
+        autopilot: { a: stuckState({ stuck: null }) },
+      }),
+    );
+    expect(q).toHaveLength(0);
+  });
+
+  it("ignores a stuck record on a checkout that was un-enrolled", () => {
+    const q = buildReviewQueue(
+      input({
+        agents: [agent({ id: "a" })],
+        autopilot: { a: stuckState({ enrolled: false }) },
+      }),
+    );
+    expect(q).toHaveLength(0);
+  });
+
+  it("dedupes onto one card alongside the reason autopilot choked on", () => {
+    const q = buildReviewQueue(
+      input({
+        agents: [repoAgent("a", "/repo")],
+        prStates: { a: openPr(7) },
+        prChecks: { a: checks({}) },
+        autopilot: { a: stuckState() },
+      }),
+    );
+    expect(q).toHaveLength(1);
+    expect(q[0].reasons).toEqual(["autopilot-stuck", "checks-failing"]);
+  });
+
+  it("resurfaces a dismissed card when autopilot stops for a DIFFERENT reason", () => {
+    // Dismissing "stopped: budget spent" must not also hide a later "stopped:
+    // needs you" — a different reason is a different decision.
+    const spent = input({ agents: [agent({ id: "a" })], autopilot: { a: stuckState() } });
+    const first = buildReviewQueue(spent);
+    const dismissed = { [first[0].id]: first[0].signature };
+
+    expect(buildReviewQueue({ ...spent, dismissed })).toHaveLength(0);
+
+    const needsHuman = input({
+      agents: [agent({ id: "a" })],
+      autopilot: { a: stuckState({ stuck: { reason: "needs-human", rung: null, at: 2 } }) },
+      dismissed,
+    });
+    expect(buildReviewQueue(needsHuman)).toHaveLength(1);
   });
 });

--- a/src/components/Workspace/MissionControl/queue.ts
+++ b/src/components/Workspace/MissionControl/queue.ts
@@ -16,6 +16,7 @@ import type {
   WfPausedReason,
   WfRun,
 } from "@/api";
+import type { AutopilotState, StuckReason } from "@/autopilot";
 
 /** A card's tests-evidence chip state, derived from a turn-end
  *  [`VerificationReport`]. Only ever a definitive verdict — `undefined` while
@@ -30,7 +31,8 @@ export type ReviewReason =
   | "workflow-conflict"
   | "unseen-results"
   | "checks-failing"
-  | "unresolved-comments";
+  | "unresolved-comments"
+  | "autopilot-stuck";
 
 /** A "base moved under this agent" signal — quiet information, not an alarm (a
  *  moved base is normal in a parallel fleet). Fed from the fleet-wide `gitMeta`
@@ -110,6 +112,9 @@ export interface ReviewItem {
    *  Omitted when unknown/running/no-tests, so it decorates an existing card
    *  and never fakes a state. */
   tests?: TestsEvidence;
+  /** Why autopilot handed this agent back, when it did. Drives the card's
+   *  "Autopilot stopped" line and its retry affordance. */
+  autopilotStuck?: { reason: StuckReason; rung: string | null };
   staleness?: Staleness | null;
   /** Advisory overlap hints — other agents on the same repo touching some of
    *  the same files. Omitted when there are none. */
@@ -148,6 +153,10 @@ export interface QueueInput {
    *  = never verified. */
   verificationReports: Record<string, VerificationReport>;
   runs: readonly WfRun[];
+  /** Per-checkout autopilot state, keyed by `checkoutKey`. An enrolled checkout
+   *  that gave up is the one signal autopilot cannot surface itself: it has
+   *  stopped, so nothing else will raise its hand. */
+  autopilot: Record<string, AutopilotState>;
   /** Item id → signal signature it was dismissed at. */
   dismissed: Record<string, string>;
 }
@@ -227,11 +236,32 @@ function collectPrSignals(agentId: string, input: QueueInput): PrSignal[] {
 
 /** The agent item's signature: only the volatile review signals (across every
  *  repo's PR), so dismissing it holds until one of them changes. */
+/** The first of an agent's checkouts where autopilot gave up, or null.
+ *
+ *  Scanned across every checkout (`agentId` plus `agentId::subdir`) because a
+ *  secondary repo's stuck autopilot deserves the same card as the primary's —
+ *  same prefix scan `maxBehind` uses. First match wins: one card per agent, and
+ *  the reason is what matters, not which repo produced it. */
+function stuckCheckout(
+  agentId: string,
+  input: QueueInput,
+): { reason: StuckReason; rung: string | null } | null {
+  const prefix = `${agentId}::`;
+  for (const [key, state] of Object.entries(input.autopilot)) {
+    if (key !== agentId && !key.startsWith(prefix)) continue;
+    if (state.enrolled && state.stuck) {
+      return { reason: state.stuck.reason, rung: state.stuck.rung };
+    }
+  }
+  return null;
+}
+
 function agentSignature(p: {
   unseen: boolean;
   stats: ShortStats | undefined;
   signals: PrSignal[];
   tests: TestsEvidence | undefined;
+  stuck: { reason: StuckReason; rung: string | null } | null;
 }): string {
   const d = p.stats ? `${p.stats.additions}/${p.stats.deletions}/${p.stats.file_count}` : "-";
   const c = p.signals
@@ -241,8 +271,11 @@ function agentSignature(p: {
     })
     .join(",");
   // Include the tests verdict so a fresh verification resurfaces a dismissed
-  // card (a pass→fail flip, or the first result landing after dismissal).
-  return `u${p.unseen ? 1 : 0}|d${d}|c${c || "-"}|t${p.tests ?? "-"}`;
+  // card (a pass→fail flip, or the first result landing after dismissal), and the
+  // autopilot verdict so dismissing "stopped: budget spent" doesn't also hide a
+  // later "stopped: needs you" — a different reason is a different decision.
+  const ap = p.stuck ? `${p.stuck.reason}:${p.stuck.rung ?? "-"}` : "-";
+  return `u${p.unseen ? 1 : 0}|d${d}|c${c || "-"}|t${p.tests ?? "-"}|a${ap}`;
 }
 
 /** The agent's stalest checkout vs its base, or null when no base has moved
@@ -456,10 +489,15 @@ export function buildReviewQueue(input: QueueInput): ReviewItem[] {
     const failing = signals.filter((s) => s.checks?.rollup === "failing");
     const unresolved = signals.reduce((n, s) => n + s.unresolved, 0);
     const tests = testsEvidence(input.verificationReports[agent.id]);
+    // An enrolled checkout that gave up. Autopilot is stopped by then, so if this
+    // doesn't raise its hand nothing does — the whole point of an unattended loop
+    // is that you only hear about it when it needs you.
+    const stuck = stuckCheckout(agent.id, input);
 
     const reasons: ReviewReason[] = [];
     // Ad-hoc: a turn landed while you weren't looking and left changes behind.
     if (agent.status === "idle" && unseen && hasDiff) reasons.push("unseen-results");
+    if (stuck) reasons.push("autopilot-stuck");
     if (failing.length > 0) reasons.push("checks-failing");
     if (unresolved > 0) reasons.push("unresolved-comments");
     if (reasons.length === 0) continue;
@@ -467,12 +505,15 @@ export function buildReviewQueue(input: QueueInput): ReviewItem[] {
     // The evidence chips show one PR: the one carrying the issue (a failing
     // repo first, then one with unresolved threads, then the primary).
     const shown = failing[0] ?? signals.find((s) => s.unresolved > 0) ?? signals[0];
-    const isPr = reasons.includes("checks-failing") || reasons.includes("unresolved-comments");
+    const isPr =
+      reasons.includes("checks-failing") ||
+      reasons.includes("unresolved-comments") ||
+      reasons.includes("autopilot-stuck");
     items.push({
       id: `agent:${agent.id}`,
       kind: "agent",
       bucket: isPr ? BUCKET.pr : BUCKET.unseen,
-      signature: agentSignature({ unseen, stats, signals, tests }),
+      signature: agentSignature({ unseen, stats, signals, tests, stuck }),
       activityAt: parseCreated(agent.created_at),
       title: agent.name,
       goal: firstLine(agent.task) || "—",
@@ -486,6 +527,7 @@ export function buildReviewQueue(input: QueueInput): ReviewItem[] {
       // Decoration on an existing card (like staleness/overlaps below): the
       // tests chip never creates a card, only annotates one.
       tests,
+      autopilotStuck: stuck ?? undefined,
       // Always-visible signals (§2/§4): the base-moved chip and overlap hints
       // decorate an existing card in every panel state — they never create one.
       staleness: stalenessOf(agent.id, input),

--- a/src/components/Workspace/MissionControl/useQueueActions.ts
+++ b/src/components/Workspace/MissionControl/useQueueActions.ts
@@ -92,6 +92,13 @@ export function useQueueActions(openReview: (runId: string) => void): QueueActio
         checks: s.prChecks[key] ?? null,
         comments: s.prComments[key] ?? null,
       };
+      // Approving a checkout autopilot gave up on IS the human "try again" it was
+      // waiting for, so clear the stuck state (and its spent budget) as part of
+      // the gesture. Without this the user would retry by hand while autopilot
+      // stayed stopped forever — and `stuck` is deliberately only clearable by a
+      // human, so nothing else would ever do it.
+      if (s.autopilot[key]?.stuck) s.resumeAutopilot(key);
+
       const rung = nextRung(input, {
         base: git?.parent_branch || "main",
         commitMode: commitMode(s.gitCommitAction),

--- a/src/components/Workspace/MissionControl/useReviewQueue.ts
+++ b/src/components/Workspace/MissionControl/useReviewQueue.ts
@@ -16,6 +16,7 @@ export function useReviewQueue(): ReviewItem[] {
   const prChecks = useAppStore((s) => s.prChecks);
   const prComments = useAppStore((s) => s.prComments);
   const verificationReports = useAppStore((s) => s.verificationReports);
+  const autopilot = useAppStore((s) => s.autopilot);
   const dismissed = useAppStore((s) => s.reviewDismissed);
   const runs = useRuns();
 
@@ -30,6 +31,7 @@ export function useReviewQueue(): ReviewItem[] {
         prChecks,
         prComments,
         verificationReports,
+        autopilot,
         runs,
         dismissed,
       }),
@@ -42,6 +44,7 @@ export function useReviewQueue(): ReviewItem[] {
       prChecks,
       prComments,
       verificationReports,
+      autopilot,
       runs,
       dismissed,
     ],

--- a/src/store/autopilotSync.ts
+++ b/src/store/autopilotSync.ts
@@ -107,6 +107,11 @@ async function apply(
       );
       return;
     }
+    case "await-evidence":
+      // A state-judged rung (a reconcile): nothing to run, the world just needs
+      // time to settle. Start the phase clock so the evidence timeout applies.
+      s.advanceAutopilotCycle(key, "awaiting-evidence", now);
+      return;
     case "verify": {
       // Enter `awaiting-evidence` first: the phase clock starts now, and the
       // effect is idempotent from here even if the verify call is slow or fails.


### PR DESCRIPTION
Fourth slice. Enables the two reconcile rungs and closes the escalation gap I shipped #547 with.

## Evidence is now per rung

`fix-checks` succeeds when the code works, so a local test run answers it in seconds. A reconcile succeeds when the world is *structurally* right — no markers left, no longer behind — and running tests there answers a different question: **a merge can be perfectly correct and still surface a pre-existing failure**, which must not read as "the merge didn't work".

So `RUNG_EVIDENCE` picks per rung, and the reconcile rungs enter `awaiting-evidence` without running anything. Rungs default to `state`, the conservative side — it can't invent a failure the world doesn't show.

## The signature now tracks the conflict set

`resolve` leaves the head sha untouched until the merge is completed. So an attempt that resolved two of three files would have looked identical to one that did nothing, and been written off as barren on its second pass. Conflicted paths join the fingerprint, sorted so a reordered report isn't mistaken for a change.

## A new brake: don't finish a merge over the user's work

`resolve-conflicts` completes the merge with `git add -A`, so anything the user was editing gets swept into the merge commit. The discriminator turns out to be clean:

- Mid-merge the tree legitimately holds the merge's own content — but as **staged** entries, because git refuses to start a merge with staged changes.
- So unstaged, non-conflicted edits are *exactly* the user's in-flight work.

Their presence means this isn't autopilot's merge to finish → escalate `dirty-tree`.

Worth noting why this needs a real guard when #547 didn't: there, the protection fell out of the ladder ordering for free (`uncommitted` outranks `checks-failing`, so a dirty tree yielded a rung autopilot declines). But `conflicted` outranks `uncommitted` — enabling `resolve` makes the hazard reachable for the first time.

Budgets are two cycles each, against `fix-checks`' three: a merge either goes in, or it needs a judgement about intent that a second failure has already shown the agent isn't making.

## Escalation resurfaces in Mission Control

The gap #547 shipped with — a stuck autopilot was only visible on that checkout's Git tab. An enrolled checkout that gave up is the one signal autopilot **cannot raise itself**, because it has stopped. The review queue now carries an `autopilot-stuck` reason:

- Scans every checkout of an agent, so a stuck secondary gets the same card as the primary.
- Dedupes onto the existing card alongside whatever autopilot choked on.
- The stuck verdict joins the dismissal signature, so dismissing "stopped: budget spent" doesn't also hide a later "stopped: needs you" — a different reason is a different decision.
- Approving a stuck card resumes autopilot as part of the gesture. That keypress *is* the human "try again" it was waiting for, and `stuck` is deliberately only clearable by a human — so without this the user would retry by hand while autopilot stayed stopped forever.

## Verification

- `tsc --noEmit` clean; `cargo check` clean.
- 668 tests, up from 654.
- `biome check` at parity: 0 errors, same 73 pre-existing warnings.
- **Every new rail mutation-checked** — dropping the unstaged-edits guard, ignoring `RUNG_EVIDENCE`, letting a failing local report condemn a reconcile, dropping conflicted paths from the signature, never raising the stuck reason, leaving it out of the dismissal signature, or ignoring enrollment when scanning for stuck: each fails a test.

One process note: my first mutation run reported the reconcile-evidence guard as surviving. It hadn't been applied — biome had reformatted that `if` across lines and my pattern assumed the old indentation. Re-run against the real source, it fails a test as it should.

## Not in this PR

Review comments (next), workflow PRs, merging (deferred). The window-hidden limitation from #547 stands unchanged: the loop pauses whenever the Fletch window is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)