### PR TITLE
feat(autopilot): work review comments — fix, answer, or push back

### DIFF
--- a/src-tauri/src/github/comments.rs
+++ b/src-tauri/src/github/comments.rs
@@ -3,11 +3,12 @@
 
 use std::path::Path;
 
-use serde_json::Value;
+use serde_json::{json, Value};
 
 use crate::error::Result;
 
-use super::query::pr_node_by_number;
+use super::client;
+use super::query::pr_node_and_viewer;
 use super::types::*;
 
 /// GraphQL selection for a PR's review threads. Reused by the branch lookup
@@ -18,25 +19,46 @@ use super::types::*;
 /// 30×100 = 3000 requests (~30 points), *regardless of how many threads the PR
 /// actually has* — GraphQL charges the declared shape, not the result. Read it
 /// by PR number wherever a number is known.
+///
+/// `id` is the thread's node id — what `resolveReviewThread` /
+/// `addPullRequestReviewThreadReply` address, so an agent can act on a thread
+/// rather than just read it.
+///
+/// `comments(last:1)` is here to answer one question: did WE have the last word?
+/// An agent that pushes back on a comment leaves the thread open deliberately,
+/// and without this it would re-argue the same point on every poll, posting a
+/// duplicate reply each time. Reading the last author off GitHub keeps that
+/// stateless — it survives a restart, where a local "already disputed" set
+/// wouldn't — and it distinguishes "we're waiting on the human" from "the human
+/// answered, engage again".
 pub(crate) const PR_COMMENTS_FIELDS: &str = r#"reviewThreads(first:100){
      nodes{
+       id
        isResolved
        isOutdated
        comments(first:1){
          totalCount
          nodes{ author{ login __typename } body path line url }
        }
+       lastComment: comments(last:1){
+         nodes{ author{ login } }
+       }
      }
    }"#;
 
 /// Extract [`PrComments`] from a PR node carrying [`PR_COMMENTS_FIELDS`].
-pub(crate) fn pr_comments_from_node(pr: &Value) -> PrComments {
+///
+/// `viewer_login` is the connected account, used to decide `we_replied_last`.
+/// `None` (login unknown) leaves the flag false everywhere, which is the safe
+/// default: threads read as needing attention rather than as awaiting a human,
+/// so nothing is silently parked.
+pub(crate) fn pr_comments_from_node(pr: &Value, viewer_login: Option<&str>) -> PrComments {
     let threads = pr["reviewThreads"]["nodes"]
         .as_array()
         .cloned()
         .unwrap_or_default();
     PrComments {
-        unresolved: parse_review_threads(&threads),
+        unresolved: parse_review_threads(&threads, viewer_login),
     }
 }
 
@@ -55,16 +77,17 @@ pub async fn pr_threads_number(
     source_repo: Option<&Path>,
     number: u32,
 ) -> Result<Option<PrComments>> {
-    let Some(node) = pr_node_by_number(checkout, source_repo, number, PR_COMMENTS_FIELDS).await?
+    let Some((node, viewer)) =
+        pr_node_and_viewer(checkout, source_repo, number, PR_COMMENTS_FIELDS).await?
     else {
         return Ok(None);
     };
-    Ok(Some(pr_comments_from_node(&node)))
+    Ok(Some(pr_comments_from_node(&node, viewer.as_deref())))
 }
 
 /// Flatten review-thread nodes into the root comment of each *unresolved,
 /// non-outdated* thread. Pure — unit tested against captured fixtures.
-fn parse_review_threads(nodes: &[Value]) -> Vec<PrComment> {
+fn parse_review_threads(nodes: &[Value], viewer_login: Option<&str>) -> Vec<PrComment> {
     nodes
         .iter()
         .filter(|t| {
@@ -75,7 +98,19 @@ fn parse_review_threads(nodes: &[Value]) -> Vec<PrComment> {
             let comments = &t["comments"];
             let root = comments["nodes"].get(0)?;
             let total = comments["totalCount"].as_u64().unwrap_or(1);
+            // Only a *reply* can be ours in the sense that matters. A thread we
+            // opened ourselves and nobody answered has us as the last author too,
+            // but there is nothing to wait for there — so require more than one
+            // comment before reading the last author as "we had the last word".
+            let we_replied_last = total > 1
+                && viewer_login.is_some_and(|me| {
+                    t["lastComment"]["nodes"]
+                        .get(0)
+                        .and_then(|c| c["author"]["login"].as_str())
+                        == Some(me)
+                });
             Some(PrComment {
+                id: t["id"].as_str().unwrap_or_default().to_string(),
                 author: root["author"]["login"]
                     .as_str()
                     .unwrap_or("unknown")
@@ -89,9 +124,46 @@ fn parse_review_threads(nodes: &[Value]) -> Vec<PrComment> {
                 line: root["line"].as_u64().map(|n| n as u32),
                 url: root["url"].as_str().unwrap_or_default().to_string(),
                 replies: total.saturating_sub(1) as u32,
+                we_replied_last,
             })
         })
         .collect()
+}
+
+/// Mark a review thread resolved. Only ever a claim that the thread is
+/// discharged — the agent fixed what it asked for, or answered it. A
+/// disagreement is deliberately NOT resolved this way: pushing back leaves the
+/// thread open for the human to settle.
+pub async fn pr_resolve_thread(thread_id: &str) -> Result<()> {
+    client::Client::new()?
+        .graphql(
+            r#"mutation($id:ID!){
+  resolveReviewThread(input:{threadId:$id}){ thread{ id isResolved } }
+}"#,
+            json!({ "id": thread_id }),
+        )
+        .await?;
+    Ok(())
+}
+
+/// Reply on a review thread. Every outcome carries one: a fix says what changed,
+/// an answer answers, a push-back gives its reasoning. That reply is the whole
+/// audit trail for an action nobody watched happen.
+pub async fn pr_reply_thread(thread_id: &str, body: &str) -> Result<()> {
+    if body.trim().is_empty() {
+        return Err(crate::error::Error::Gh("reply body is empty".into()));
+    }
+    client::Client::new()?
+        .graphql(
+            r#"mutation($id:ID!,$body:String!){
+  addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$id, body:$body}){
+    comment{ id }
+  }
+}"#,
+            json!({ "id": thread_id, "body": body }),
+        )
+        .await?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -101,25 +173,28 @@ mod tests {
     fn review_threads_fixture() -> Vec<Value> {
         serde_json::from_str(
             r#"[
-              {"isResolved":false,"isOutdated":false,"comments":{"totalCount":1,"nodes":[
+              {"id":"T1","isResolved":false,"isOutdated":false,"comments":{"totalCount":1,"nodes":[
                 {"author":{"login":"greptileai","__typename":"Bot"},
                  "body":"Consider handling the null case here.",
                  "path":"src/foo.rs","line":42,
-                 "url":"https://github.com/o/r/pull/1#discussion_r1"}]}},
-              {"isResolved":false,"isOutdated":false,"comments":{"totalCount":3,"nodes":[
+                 "url":"https://github.com/o/r/pull/1#discussion_r1"}]},
+               "lastComment":{"nodes":[{"author":{"login":"greptileai"}}]}},
+              {"id":"T2","isResolved":false,"isOutdated":false,"comments":{"totalCount":3,"nodes":[
                 {"author":{"login":"alice","__typename":"User"},
                  "body":"Can we rename this?",
                  "path":"src/bar.rs","line":7,
-                 "url":"https://github.com/o/r/pull/1#discussion_r2"}]}},
+                 "url":"https://github.com/o/r/pull/1#discussion_r2"}]},
+               "lastComment":{"nodes":[{"author":{"login":"me"}}]}},
               {"isResolved":true,"isOutdated":false,"comments":{"totalCount":1,"nodes":[
                 {"author":{"login":"bob","__typename":"User"},"body":"resolved one",
                  "path":"src/baz.rs","line":1,"url":"u3"}]}},
               {"isResolved":false,"isOutdated":true,"comments":{"totalCount":1,"nodes":[
                 {"author":{"login":"carol","__typename":"User"},"body":"stale one",
                  "path":"src/qux.rs","line":1,"url":"u4"}]}},
-              {"isResolved":false,"isOutdated":false,"comments":{"totalCount":1,"nodes":[
-                {"author":{"login":"dave","__typename":"User"},"body":"unanchored",
-                 "path":null,"line":null,"url":"u5"}]}}
+              {"id":"T5","isResolved":false,"isOutdated":false,"comments":{"totalCount":1,"nodes":[
+                {"author":{"login":"me","__typename":"User"},"body":"unanchored",
+                 "path":null,"line":null,"url":"u5"}]},
+               "lastComment":{"nodes":[{"author":{"login":"me"}}]}}
             ]"#,
         )
         .unwrap()
@@ -127,7 +202,7 @@ mod tests {
 
     #[test]
     fn review_threads_keep_only_unresolved_active() {
-        let comments = parse_review_threads(&review_threads_fixture());
+        let comments = parse_review_threads(&review_threads_fixture(), Some("me"));
         // Resolved + outdated dropped; 3 remain (greptile, alice, dave).
         assert_eq!(comments.len(), 3);
         assert!(comments
@@ -137,7 +212,7 @@ mod tests {
 
     #[test]
     fn review_threads_flag_bots_and_count_replies() {
-        let comments = parse_review_threads(&review_threads_fixture());
+        let comments = parse_review_threads(&review_threads_fixture(), Some("me"));
         let greptile = comments.iter().find(|c| c.author == "greptileai").unwrap();
         assert!(greptile.is_bot);
         assert_eq!(greptile.replies, 0);
@@ -151,9 +226,45 @@ mod tests {
 
     #[test]
     fn review_threads_tolerate_null_anchor() {
-        let comments = parse_review_threads(&review_threads_fixture());
-        let dave = comments.iter().find(|c| c.author == "dave").unwrap();
-        assert_eq!(dave.path, None);
-        assert_eq!(dave.line, None);
+        let comments = parse_review_threads(&review_threads_fixture(), Some("me"));
+        let unanchored = comments.iter().find(|c| c.url == "u5").unwrap();
+        assert_eq!(unanchored.path, None);
+        assert_eq!(unanchored.line, None);
+    }
+
+    /// The stateless "don't re-argue" signal: a thread whose last comment is ours
+    /// is a push-back awaiting a person, not work waiting to be done.
+    #[test]
+    fn review_threads_flag_the_thread_we_answered_last() {
+        let comments = parse_review_threads(&review_threads_fixture(), Some("me"));
+        let alice = comments.iter().find(|c| c.author == "alice").unwrap();
+        assert!(alice.we_replied_last, "we posted the last reply on T2");
+
+        let greptile = comments.iter().find(|c| c.author == "greptileai").unwrap();
+        assert!(!greptile.we_replied_last, "nobody has replied to T1 yet");
+    }
+
+    /// A single-comment thread we opened ourselves has us as last author too, but
+    /// there is nothing to wait for — only a genuine *reply* parks a thread.
+    #[test]
+    fn a_thread_we_opened_and_nobody_answered_is_not_awaiting_us() {
+        let comments = parse_review_threads(&review_threads_fixture(), Some("me"));
+        let ours = comments.iter().find(|c| c.url == "u5").unwrap();
+        assert_eq!(ours.author, "me");
+        assert!(!ours.we_replied_last, "totalCount 1 means no reply exists");
+    }
+
+    /// Unknown login must not park anything: false everywhere is the safe default.
+    #[test]
+    fn no_viewer_login_never_parks_a_thread() {
+        let comments = parse_review_threads(&review_threads_fixture(), None);
+        assert!(comments.iter().all(|c| !c.we_replied_last));
+    }
+
+    #[test]
+    fn review_threads_carry_the_thread_id_for_mutations() {
+        let comments = parse_review_threads(&review_threads_fixture(), Some("me"));
+        assert_eq!(comments.iter().filter(|c| c.id.is_empty()).count(), 0);
+        assert!(comments.iter().any(|c| c.id == "T1"));
     }
 }

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -30,7 +30,7 @@ pub use client::{git_auth_env, seed_token, set_token, TOKEN_SETTING};
 pub(crate) use closes::with_closes_trailer;
 
 pub use checks::*;
-pub use comments::pr_threads_number;
+pub use comments::{pr_reply_thread, pr_resolve_thread, pr_threads_number};
 pub use issues::*;
 pub use live::*;
 pub use pr::*;

--- a/src-tauri/src/github/query.rs
+++ b/src-tauri/src/github/query.rs
@@ -92,17 +92,26 @@ pub(crate) fn branch_prs_query(inner_fields: &str) -> String {
 /// `source_repo` (same origin) when the checkout is broken or gone.
 /// `Ok(None)` when the slug or the PR can't be resolved, or while a
 /// rate-limit backoff is active.
-pub(crate) async fn pr_node_by_number(
+/// The PR node for `number`, plus the connected account's login from the SAME
+/// response.
+///
+/// `viewer` is a single node, not a connection, so selecting it costs nothing on
+/// top of the PR read — which is the point: the alternative is `auth_status()`,
+/// a second round trip, on a read that already runs on a timer. Callers that
+/// need to know "is this comment ours?" get the answer consistent with the data
+/// it applies to, rather than from a separately-cached login.
+pub(crate) async fn pr_node_and_viewer(
     checkout: &Path,
     source_repo: Option<&Path>,
     number: u32,
     inner_fields: &str,
-) -> Result<Option<Value>> {
+) -> Result<Option<(Value, Option<String>)>> {
     let Some((owner, repo)) = resolve_slug(checkout, source_repo).await else {
         return Ok(None);
     };
     let query = format!(
         r#"query($owner:String!,$repo:String!,$number:Int!){{
+  viewer{{ login }}
   repository(owner:$owner,name:$repo){{ pullRequest(number:$number){{ state {inner_fields} }} }}
   {RATE_LIMIT_PROBE}
 }}"#
@@ -116,7 +125,11 @@ pub(crate) async fn pr_node_by_number(
         return Ok(None);
     };
     let node = &data["repository"]["pullRequest"];
-    Ok((!node.is_null()).then(|| node.clone()))
+    if node.is_null() {
+        return Ok(None);
+    }
+    let login = data["viewer"]["login"].as_str().map(str::to_string);
+    Ok(Some((node.clone(), login)))
 }
 
 /// The PR a branch "belongs to": the newest open PR, else the newest PR of

--- a/src-tauri/src/github/types.rs
+++ b/src-tauri/src/github/types.rs
@@ -156,6 +156,10 @@ pub struct PrChecks {
 /// coding agent.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct PrComment {
+    /// The review thread's node id — what `resolveReviewThread` /
+    /// `addPullRequestReviewThreadReply` address, so an agent can act on the
+    /// thread and not merely read it.
+    pub id: String,
     /// Comment author's login.
     pub author: String,
     /// True when the author is a GitHub App / bot (`__typename == "Bot"`).
@@ -171,6 +175,11 @@ pub struct PrComment {
     pub url: String,
     /// Replies after the root comment (thread length − 1, clamped at 0).
     pub replies: u32,
+    /// The connected account posted the last comment on this still-open thread —
+    /// i.e. we've had our say and are waiting on the human. Distinguishes a
+    /// deliberate push-back (leave open, don't re-argue) from a thread that
+    /// genuinely needs attention, without keeping any local state.
+    pub we_replied_last: bool,
 }
 
 /// Unresolved review threads for a PR. Heavier than `pr_view` — polled on the

--- a/src-tauri/src/instructions/git_actions.md
+++ b/src-tauri/src/instructions/git_actions.md
@@ -51,3 +51,19 @@ The pull request can't merge cleanly because `base` has advanced. First refresh 
 ### fix-checks — params: `failing` (check names)
 
 CI checks are failing on this branch's pull request. Investigate the failures, fix them, commit the fix with plain git (`git add -A` && `git commit`), and push by calling the `git_push` op so the checks re-run.
+
+### resolve-comments — params: `count`
+
+Unresolved review threads on this branch's pull request need addressing. Read them with the `pr_threads` op (`{"op":"pr_threads"}`), which returns each open thread's `id`, author, `is_bot`, body, and file anchor.
+
+Judge each thread on its merits and take exactly one of three outcomes:
+
+1. **Valid — fix it.** Make the change, then `reply_thread` saying what you changed, then `resolve_thread`.
+2. **A question — answer it.** `reply_thread` with the answer, then `resolve_thread`. No code change needed.
+3. **Wrong, or you disagree — push back.** `reply_thread` explaining why, and **do NOT resolve it**. Leaving it open is how a human gets to settle the disagreement; resolving would close an argument you don't get to end alone.
+
+Resolving a thread only ever claims it is discharged. Never resolve one you disagreed with, and never resolve one you did not reply to.
+
+Skip any thread where you already had the last word — you have said your piece and are waiting on a person. If a human has replied since, engage with what they said.
+
+If your fixes changed any files, commit and push them (`git add`-ing only the files you touched, then the `git_push` op) so the pull request carries the changes your replies describe.

--- a/src-tauri/src/rpc/git.rs
+++ b/src-tauri/src/rpc/git.rs
@@ -31,7 +31,10 @@ pub const EVENT_ACTION_DONE: &str = "git.action_done";
 /// (status, fetch) and the test ops (echo/ping) are excluded so they never read
 /// as a completed delegation.
 fn is_mutating_op(op: &str) -> bool {
-    matches!(op, "git_push" | "open_pr")
+    matches!(
+        op,
+        "git_push" | "open_pr" | "reply_thread" | "resolve_thread"
+    )
 }
 
 /// The local-git action names a delegation hook may report. Kept to a closed
@@ -185,6 +188,16 @@ impl GitDispatcher {
             // (post-commit / post-merge). Not a mutation the host performs —
             // it only relays that the agent's native git action ran.
             "signal_git_action" => self.signal_git_action(id, args),
+            // Review-thread actions. Both need the host's token, so the agent
+            // can't call GitHub itself. Kept as two ops rather than one
+            // "address this thread" because the outcomes genuinely differ: a
+            // fix or an answer replies AND resolves, while a push-back replies
+            // and deliberately leaves the thread open for the human to settle.
+            // Read side: the agent needs each thread's node id (and who wrote
+            // it) before it can reply to or resolve anything.
+            "pr_threads" => (self.pr_threads(id, args).await, Vec::new()),
+            "reply_thread" => (self.reply_thread(id, args).await, Vec::new()),
+            "resolve_thread" => (self.resolve_thread(id, args).await, Vec::new()),
             "echo" => (self.echo(id, args).await, Vec::new()),
             "ping" => (
                 Response::ok(id, 0, "pong".to_string(), String::new()),
@@ -213,6 +226,58 @@ impl GitDispatcher {
             ));
         }
         (resp, effects)
+    }
+
+    /// The open review threads on this checkout's pull request, as JSON. Two
+    /// round trips (resolve the PR by branch, then read its threads) — fine for a
+    /// once-per-turn agent read, unlike the panel's poll which is given a number.
+    async fn pr_threads(&self, id: &str, args: &Value) -> Response {
+        let t = match self.target(id, args) {
+            Ok(t) => t,
+            Err(resp) => return resp,
+        };
+        let number = match crate::github::pr_view(&t.cwd).await {
+            Ok(Some(pr)) => pr.number,
+            Ok(None) => return Response::err(id, "pr_threads: no pull request for this branch"),
+            Err(e) => return Response::err(id, format!("pr_threads: {e}")),
+        };
+        match crate::github::pr_threads_number(&t.cwd, None, number).await {
+            Ok(Some(threads)) => match serde_json::to_string_pretty(&threads.unresolved) {
+                Ok(json) => Response::ok(id, 0, json, String::new()),
+                Err(e) => Response::err(id, format!("pr_threads: {e}")),
+            },
+            Ok(None) => Response::ok(id, 0, "[]".to_string(), String::new()),
+            Err(e) => Response::err(id, format!("pr_threads: {e}")),
+        }
+    }
+
+    /// Post a reply on a review thread. Every outcome carries one — a fix says
+    /// what changed, an answer answers, a push-back gives its reasoning — so this
+    /// is the audit trail for work nobody watched happen.
+    async fn reply_thread(&self, id: &str, args: &Value) -> Response {
+        let (Some(thread), Some(body)) = (
+            args.get("thread").and_then(|v| v.as_str()),
+            args.get("body").and_then(|v| v.as_str()),
+        ) else {
+            return Response::err(id, "reply_thread requires `thread` and `body`");
+        };
+        match crate::github::pr_reply_thread(thread, body).await {
+            Ok(()) => Response::ok(id, 0, "replied".to_string(), String::new()),
+            Err(e) => Response::err(id, format!("reply_thread: {e}")),
+        }
+    }
+
+    /// Mark a review thread resolved. Only ever a claim that the thread is
+    /// discharged; a disagreement must be left open, which is why this is
+    /// separate from `reply_thread` instead of a flag on it.
+    async fn resolve_thread(&self, id: &str, args: &Value) -> Response {
+        let Some(thread) = args.get("thread").and_then(|v| v.as_str()) else {
+            return Response::err(id, "resolve_thread requires `thread`");
+        };
+        match crate::github::pr_resolve_thread(thread).await {
+            Ok(()) => Response::ok(id, 0, "resolved".to_string(), String::new()),
+            Err(e) => Response::err(id, format!("resolve_thread: {e}")),
+        }
     }
 
     async fn echo(&self, id: &str, args: &Value) -> Response {

--- a/src/api/types/pr.ts
+++ b/src/api/types/pr.ts
@@ -64,6 +64,9 @@ export interface PrChecks {
 
 /** One unresolved PR review thread, flattened to its root comment. */
 export interface PrComment {
+  /** The review thread's node id — what the agent's `reply_thread` /
+   *  `resolve_thread` ops address. */
+  id: string;
   author: string;
   /** Author is a GitHub App / bot (Greptile, CodeRabbit, …). Bots phrase
    *  their comments for an AI already, so the panel inserts them as-is;
@@ -75,6 +78,12 @@ export interface PrComment {
   url: string;
   /** Replies after the root comment. */
   replies: number;
+  /** We posted the last comment on this still-open thread: we've had our say and
+   *  are waiting on the human. Set when the agent pushed back on a comment and
+   *  deliberately left it open — read off GitHub rather than tracked locally, so
+   *  it survives a restart and can tell "waiting on them" from "they answered,
+   *  engage again". */
+  we_replied_last: boolean;
 }
 
 /** Unresolved review threads for a PR — polled on the slow checks cadence. */

--- a/src/autopilot.test.ts
+++ b/src/autopilot.test.ts
@@ -17,6 +17,7 @@ import {
   newEnrollment,
   RUNG_BUDGET,
   stateSignature,
+  unstagedEdits,
   verificationPassed,
 } from "@/autopilot";
 import type { LadderContext, ReadinessInput } from "@/readiness";
@@ -306,6 +307,116 @@ describe("autopilot judges a cycle in flight", () => {
   });
 });
 
+describe("the reconcile rungs", () => {
+  /** A mid-merge tree: the merge's own content is STAGED (git refuses to start a
+   *  merge with staged changes, so staged entries can only be its output), and the
+   *  unresolved files are conflicted. */
+  const midMerge = (over: Partial<GitState> = {}): ReadinessInput => ({
+    ...FAILING,
+    git: git({
+      files: [
+        { path: "a.ts", kind: "conflicted", staged: false, additions: 1, deletions: 0 },
+        { path: "b.ts", kind: "modified", staged: true, additions: 1, deletions: 0 },
+      ],
+      ...over,
+    }),
+  });
+
+  it("resolves conflicts, ahead of everything else that's wrong", () => {
+    // The PR is also failing checks and behind, but a broken tree comes first —
+    // every later rung would build on it.
+    expect(step({ readiness: midMerge() })).toMatchObject({
+      do: "dispatch",
+      rung: "resolve",
+      action: "resolve-conflicts",
+    });
+  });
+
+  it("refuses to finish a merge that would swallow the user's uncommitted work", () => {
+    // The playbook completes the merge with `git add -A`. An unstaged,
+    // non-conflicted edit is by definition the user's in-flight work (the merge's
+    // own content is staged), so this is not autopilot's merge to finish.
+    const withUserEdit = midMerge({
+      files: [
+        { path: "a.ts", kind: "conflicted", staged: false, additions: 1, deletions: 0 },
+        { path: "mine.ts", kind: "modified", staged: false, additions: 9, deletions: 0 },
+      ],
+    });
+    expect(step({ readiness: withUserEdit })).toEqual({
+      do: "escalate",
+      reason: "dirty-tree",
+      rung: "resolve",
+    });
+  });
+
+  it("updates a branch that has fallen behind its base", () => {
+    const behind = {
+      ...FAILING,
+      checks: checks({ merge_state: "behind", required_failing: ["test"] }),
+    };
+    expect(step({ readiness: behind })).toMatchObject({
+      do: "dispatch",
+      rung: "update-branch",
+      params: { base: "main" },
+    });
+  });
+
+  it("judges a reconcile on the world, not by running the tests", () => {
+    // A merge can be perfectly correct and still surface a pre-existing test
+    // failure. Verifying would answer a different question, so these rungs skip it.
+    for (const rung of ["resolve", "update-branch"] as const) {
+      expect(step({ state: state({ cycle: cycle({ rung, phase: "working" }) }) })).toEqual({
+        do: "await-evidence",
+      });
+    }
+    // And a failing local report must not condemn one.
+    expect(
+      step({
+        state: state({ cycle: cycle({ rung: "update-branch", phase: "awaiting-evidence" }) }),
+        readiness: GREEN,
+        verification: report(["test", "failed"]),
+      }),
+    ).toEqual({ do: "settle", rung: "update-branch" });
+  });
+
+  it("still runs the tests for a code fix", () => {
+    expect(step({ state: state({ cycle: cycle({ phase: "working" }) }) })).toEqual({
+      do: "verify",
+    });
+  });
+
+  it("gives a reconcile two attempts, not three", () => {
+    for (const rung of ["resolve", "update-branch"] as const) {
+      expect(RUNG_BUDGET[rung]).toBe(2);
+    }
+  });
+});
+
+describe("unstagedEdits", () => {
+  it("counts only the user's in-flight work, not the merge's own content", () => {
+    expect(unstagedEdits(null)).toBe(0);
+    expect(
+      unstagedEdits(
+        git({
+          files: [
+            // The conflict itself: autopilot's to resolve.
+            { path: "a.ts", kind: "conflicted", staged: false, additions: 1, deletions: 0 },
+            // Cleanly merged by git, already staged: also the merge's.
+            { path: "b.ts", kind: "modified", staged: true, additions: 1, deletions: 0 },
+          ],
+        }),
+      ),
+    ).toBe(0);
+    expect(
+      unstagedEdits(
+        git({
+          files: [{ path: "mine.ts", kind: "modified", staged: false, additions: 1, deletions: 0 }],
+        }),
+      ),
+    ).toBe(1);
+  });
+});
+
 describe("stateSignature", () => {
   it("changes with the commit and with the set of failures", () => {
     expect(stateSignature(FAILING)).not.toBe(stateSignature(GREEN));
@@ -322,6 +433,29 @@ describe("stateSignature", () => {
 
   it("is stable when nothing observable changed", () => {
     expect(stateSignature(FAILING)).toBe(stateSignature({ ...FAILING }));
+  });
+
+  it("tracks the conflict set, so a partial resolution counts as progress", () => {
+    // `resolve` leaves the sha untouched until the merge is completed, so without
+    // the conflicted paths an attempt that fixed two of three files would look
+    // identical to one that did nothing — and be written off as barren.
+    const conflicts = (...paths: string[]): ReadinessInput => ({
+      ...FAILING,
+      git: git({
+        files: paths.map((path) => ({
+          path,
+          kind: "conflicted" as const,
+          staged: false,
+          additions: 1,
+          deletions: 0,
+        })),
+      }),
+    });
+    expect(stateSignature(conflicts("a.ts", "b.ts"))).not.toBe(stateSignature(conflicts("a.ts")));
+    // Order of the report doesn't matter.
+    expect(stateSignature(conflicts("a.ts", "b.ts"))).toBe(
+      stateSignature(conflicts("b.ts", "a.ts")),
+    );
   });
 });
 

--- a/src/autopilot.test.ts
+++ b/src/autopilot.test.ts
@@ -6,7 +6,14 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import type { CheckOutcome, GitState, PrChecks, PrState, VerificationReport } from "@/api";
+import type {
+  CheckOutcome,
+  GitState,
+  PrChecks,
+  PrComment,
+  PrState,
+  VerificationReport,
+} from "@/api";
 import {
   type AutopilotInput,
   type AutopilotState,
@@ -389,6 +396,87 @@ describe("the reconcile rungs", () => {
     for (const rung of ["resolve", "update-branch"] as const) {
       expect(RUNG_BUDGET[rung]).toBe(2);
     }
+  });
+});
+
+describe("the review-comments rung", () => {
+  const thread = (id: string, over: Partial<PrComment> = {}): PrComment => ({
+    id,
+    author: "greptileai",
+    is_bot: true,
+    body: "Consider the null case",
+    path: "a.ts",
+    line: 1,
+    url: "https://x",
+    replies: 0,
+    we_replied_last: false,
+    ...over,
+  });
+  const withThreads = (...t: PrComment[]): ReadinessInput => ({
+    ...GREEN,
+    comments: { unresolved: t },
+  });
+
+  it("works threads that are waiting on us, with the count", () => {
+    expect(step({ readiness: withThreads(thread("t1"), thread("t2")) })).toMatchObject({
+      do: "dispatch",
+      rung: "resolve-comments",
+      params: { count: "2" },
+    });
+  });
+
+  it("never re-argues a thread it already pushed back on, and says so specifically", () => {
+    // We replied last and left it open on purpose. Re-dispatching would post a
+    // duplicate reply into a real person's conversation every cycle. The reason is
+    // its own kind: the next step is reading that thread, not eyeballing the PR.
+    expect(step({ readiness: withThreads(thread("t1", { we_replied_last: true })) })).toEqual({
+      do: "escalate",
+      reason: "disputed-review",
+      rung: null,
+    });
+  });
+
+  it("engages again once the human answers", () => {
+    // `we_replied_last` flips false when they reply after us — new input, our turn.
+    expect(step({ readiness: withThreads(thread("t1", { replies: 2 })) })).toMatchObject({
+      do: "dispatch",
+      rung: "resolve-comments",
+    });
+  });
+
+  it("is judged by the threads, not by the tests", () => {
+    // A comment round can legitimately change no code — answering a question,
+    // pushing back — so a failing test result says nothing about whether it worked.
+    expect(
+      step({ state: state({ cycle: cycle({ rung: "resolve-comments", phase: "working" }) }) }),
+    ).toEqual({ do: "await-evidence" });
+    expect(
+      step({
+        state: state({ cycle: cycle({ rung: "resolve-comments", phase: "awaiting-evidence" }) }),
+        readiness: GREEN,
+        verification: report(["test", "failed"]),
+      }),
+    ).toEqual({ do: "settle", rung: "resolve-comments" });
+  });
+
+  it("counts a push-back as progress, not as a barren cycle", () => {
+    // The thread went from "needs us" to "waiting on them". No code moved and the
+    // thread is still open, so without the signature tracking that flag this would
+    // look like a cycle that achieved nothing.
+    const before = withThreads(thread("t1"));
+    const after = withThreads(thread("t1", { we_replied_last: true }));
+    expect(stateSignature(before)).not.toBe(stateSignature(after));
+  });
+
+  it("counts a partial round as progress", () => {
+    // Three threads down to one: real work, even though the sha may not have moved.
+    const before = withThreads(thread("t1"), thread("t2"), thread("t3"));
+    const after = withThreads(thread("t3"));
+    expect(stateSignature(before)).not.toBe(stateSignature(after));
+  });
+
+  it("gets two attempts — each one posts into a real conversation", () => {
+    expect(RUNG_BUDGET["resolve-comments"]).toBe(2);
   });
 });
 

--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -30,7 +30,7 @@
 // Portable to Rust on the same terms as `readiness.ts` — pure, no framework, no
 // clock of its own (`now` is a parameter). Enforced by `autopilot.test.ts`.
 
-import type { VerificationReport } from "@/api";
+import type { GitState, VerificationReport } from "@/api";
 import type { DelegationKind } from "@/delegation";
 import { type LadderContext, nextRung, type ReadinessInput } from "@/readiness";
 
@@ -47,11 +47,42 @@ import { type LadderContext, nextRung, type ReadinessInput } from "@/readiness";
  *  with uncommitted edits correctly does nothing. That also keeps `fix-checks`
  *  off a dirty tree — its playbook runs `git add -A`, which would otherwise
  *  sweep the user's in-flight edits into the agent's fix commit. */
-export const AUTOPILOT_RUNGS: readonly DelegationKind[] = ["fix-checks"];
+export const AUTOPILOT_RUNGS: readonly DelegationKind[] = [
+  "fix-checks",
+  "resolve",
+  "update-branch",
+];
 
-/** Cycles one rung gets on a checkout before autopilot gives up. Three is enough
- *  for "the fix needed a second look" and short of "this is not converging". */
-export const RUNG_BUDGET: Partial<Record<DelegationKind, number>> = { "fix-checks": 3 };
+/** Cycles one rung gets on a checkout before autopilot gives up.
+ *
+ *  `fix-checks` gets three — a fix often needs a second look, and three is short
+ *  of "not converging". The reconcile rungs get two: a merge either goes in or it
+ *  needs a judgement call about intent that the second failure has already shown
+ *  the agent isn't making. */
+export const RUNG_BUDGET: Partial<Record<DelegationKind, number>> = {
+  "fix-checks": 3,
+  resolve: 2,
+  "update-branch": 2,
+};
+
+/** How a rung's cycle is judged.
+ *
+ *  `verify` — run the project's own tests/lints and believe them. Right for
+ *    `fix-checks`, where success means "the code works now" and a local run
+ *    answers that in seconds instead of a CI round trip.
+ *  `state` — judge on the world alone. Right for the reconcile rungs, where
+ *    success is structural ("no conflict markers left", "no longer behind") and
+ *    running tests would answer a *different* question — a merge can be perfectly
+ *    correct and still surface a pre-existing test failure, which must not read
+ *    as "the merge didn't work".
+ *
+ *  Rungs default to `state`, the conservative choice: it never invents a failure
+ *  the world doesn't show. */
+export const RUNG_EVIDENCE: Partial<Record<DelegationKind, "verify" | "state">> = {
+  "fix-checks": "verify",
+  resolve: "state",
+  "update-branch": "state",
+};
 
 /** How long to wait for evidence once the agent's turn ends. Generous: a CI run
  *  can legitimately take many minutes, and a false "no evidence" wastes a whole
@@ -80,6 +111,8 @@ export type StuckReason =
   | "no-progress"
   /** The ladder wants something autopilot isn't allowed to do. */
   | "needs-human"
+  /** Acting would have swallowed the user's uncommitted work. */
+  | "dirty-tree"
   /** No evidence arrived within `EVIDENCE_TIMEOUT_MS`. */
   | "no-evidence";
 
@@ -109,15 +142,38 @@ export function newEnrollment(): AutopilotState {
  *  signature faced the same world, so whatever happened between them changed
  *  nothing that matters.
  *
- *  Deliberately coarse: the head commit plus the sorted failing-check names. The
- *  sha moves whenever the agent commits at all, so a fix that changed code but
- *  not the outcome still counts as progress and earns another attempt; only a
- *  cycle that moved neither code nor failures reads as barren. Sorted so CI
- *  reordering its checks isn't mistaken for a change. */
+ *  Deliberately coarse: the head commit, the sorted failing-check names, and the
+ *  sorted conflicted paths. The sha moves whenever the agent commits at all, so a
+ *  fix that changed code but not the outcome still counts as progress and earns
+ *  another attempt; only a cycle that moved neither code, nor failures, nor the
+ *  conflict set reads as barren.
+ *
+ *  Conflicted paths are in here for the `resolve` rung, whose whole job leaves the
+ *  sha untouched until the merge is completed: an attempt that resolved two of
+ *  three files made real progress, and without the paths that would look
+ *  identical to an attempt that did nothing. Both lists are sorted so a reordered
+ *  report isn't mistaken for a change. */
 export function stateSignature({ git, checks }: ReadinessInput): string {
   const sha = git?.head_sha ?? "no-head";
   const failing = [...(checks?.required_failing ?? [])].sort().join(",");
-  return `${sha}|${failing}`;
+  const conflicted = (git?.files ?? [])
+    .filter((f) => f.kind === "conflicted")
+    .map((f) => f.path)
+    .sort()
+    .join(",");
+  return `${sha}|${failing}|${conflicted}`;
+}
+
+/** Unstaged, non-conflicted edits in the working copy.
+ *
+ *  The guard for the `resolve` rung. Its playbook finishes the merge with
+ *  `git add -A`, so anything the user was editing gets swept into the merge
+ *  commit. Mid-merge the tree legitimately holds the merge's own content — but as
+ *  *staged* entries, because git refuses to start a merge with staged changes.
+ *  So unstaged non-conflicted edits are exactly the user's in-flight work, and
+ *  their presence means this is not autopilot's merge to finish. */
+export function unstagedEdits(git: GitState | null): number {
+  return (git?.files ?? []).filter((f) => !f.staged && f.kind !== "conflicted").length;
 }
 
 export type WaitReason =
@@ -143,6 +199,9 @@ export type AutopilotEffect =
     }
   /** The turn ended: run local verification and enter `awaiting-evidence`. */
   | { do: "verify" }
+  /** The turn ended on a state-judged rung: enter `awaiting-evidence` without
+   *  running anything. The world is the evidence; it just needs time to settle. */
+  | { do: "await-evidence" }
   /** The cycle worked. Clear it and reset the rung's budget. */
   | { do: "settle"; rung: DelegationKind }
   /** The cycle failed but budget remains. Clear it, count the attempt, and
@@ -197,6 +256,12 @@ export function autopilotStep(input: AutopilotInput): AutopilotEffect {
         // resolution until that slice lands). The human decides.
         return { do: "escalate", reason: "needs-human", rung: rung.kind };
       }
+      // Finishing a merge stages everything (`git add -A`), so unstaged edits
+      // alongside the conflict are the user's in-flight work and would be swept
+      // into the merge commit. Not autopilot's merge to finish.
+      if (rung.kind === "resolve" && unstagedEdits(readiness.git) > 0) {
+        return { do: "escalate", reason: "dirty-tree", rung: rung.kind };
+      }
       const signature = stateSignature(readiness);
       // Refuse to re-enter a world we already failed to change.
       if (state.barren.includes(signature)) {
@@ -234,8 +299,9 @@ function judgeCycle(cycle: Cycle, input: AutopilotInput): AutopilotEffect {
   if (cycle.phase === "working") {
     // Still the agent's turn, or its delegation is still being tracked.
     if (agentBusy || delegationInFlight) return { do: "wait", why: "awaiting-evidence" };
-    // The turn ended. Get a fast local verdict rather than waiting out CI.
-    return { do: "verify" };
+    // The turn ended. A code fix gets a fast local verdict; a reconcile is judged
+    // by the world it was meant to change (see `RUNG_EVIDENCE`).
+    return RUNG_EVIDENCE[cycle.rung] === "verify" ? { do: "verify" } : { do: "await-evidence" };
   }
 
   // ── awaiting-evidence ──
@@ -253,9 +319,13 @@ function judgeCycle(cycle: Cycle, input: AutopilotInput): AutopilotEffect {
     return { do: "retry", rung: cycle.rung, barren };
   };
 
-  // Local verification is the cheap, decisive signal: if the project's own tests
-  // and lints fail, the fix did not work, whatever CI hasn't said yet.
-  if (verification && !verificationPassed(verification)) return failed();
+  // Local verification is the cheap, decisive signal for a code fix: if the
+  // project's own tests and lints fail, the fix did not work, whatever CI hasn't
+  // said yet. Only consulted for rungs judged that way — a reconcile can be
+  // correct and still surface a pre-existing failure.
+  if (RUNG_EVIDENCE[cycle.rung] === "verify" && verification && !verificationPassed(verification)) {
+    return failed();
+  }
 
   const rung = nextRung(readiness, ladder);
   // CI still resolving — no verdict available. Hold, unless we've held so long

--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -51,6 +51,7 @@ export const AUTOPILOT_RUNGS: readonly DelegationKind[] = [
   "fix-checks",
   "resolve",
   "update-branch",
+  "resolve-comments",
 ];
 
 /** Cycles one rung gets on a checkout before autopilot gives up.
@@ -63,6 +64,9 @@ export const RUNG_BUDGET: Partial<Record<DelegationKind, number>> = {
   "fix-checks": 3,
   resolve: 2,
   "update-branch": 2,
+  // Two. Each cycle posts real replies to a real conversation, so a loop that
+  // isn't converging is not just wasted tokens — it's noise in someone's inbox.
+  "resolve-comments": 2,
 };
 
 /** How a rung's cycle is judged.
@@ -82,6 +86,10 @@ export const RUNG_EVIDENCE: Partial<Record<DelegationKind, "verify" | "state">> 
   "fix-checks": "verify",
   resolve: "state",
   "update-branch": "state",
+  // Judged by the threads, not the tests. A comment round can legitimately change
+  // no code at all (answering a question, pushing back), so a test result says
+  // nothing about whether it succeeded.
+  "resolve-comments": "state",
 };
 
 /** How long to wait for evidence once the agent's turn ends. Generous: a CI run
@@ -111,6 +119,11 @@ export type StuckReason =
   | "no-progress"
   /** The ladder wants something autopilot isn't allowed to do. */
   | "needs-human"
+  /** The agent pushed back on a review comment and left the thread open. Not a
+   *  failure — a disagreement, which only a person can settle. Distinct from
+   *  `needs-human` because the next step is reading a specific thread, not
+   *  looking at the PR generally. */
+  | "disputed-review"
   /** Acting would have swallowed the user's uncommitted work. */
   | "dirty-tree"
   /** No evidence arrived within `EVIDENCE_TIMEOUT_MS`. */
@@ -153,7 +166,7 @@ export function newEnrollment(): AutopilotState {
  *  three files made real progress, and without the paths that would look
  *  identical to an attempt that did nothing. Both lists are sorted so a reordered
  *  report isn't mistaken for a change. */
-export function stateSignature({ git, checks }: ReadinessInput): string {
+export function stateSignature({ git, checks, comments }: ReadinessInput): string {
   const sha = git?.head_sha ?? "no-head";
   const failing = [...(checks?.required_failing ?? [])].sort().join(",");
   const conflicted = (git?.files ?? [])
@@ -161,7 +174,16 @@ export function stateSignature({ git, checks }: ReadinessInput): string {
     .map((f) => f.path)
     .sort()
     .join(",");
-  return `${sha}|${failing}|${conflicted}`;
+  // Thread ids for the same reason as conflicted paths: a comment round often
+  // changes no code, so without them a cycle that resolved three of five threads
+  // would be indistinguishable from one that did nothing. The `we_replied_last`
+  // flag rides along, so a thread turning into a push-back registers as progress
+  // too — it moved from "needs us" to "waiting on them".
+  const threads = (comments?.unresolved ?? [])
+    .map((t) => `${t.id}${t.we_replied_last ? "!" : ""}`)
+    .sort()
+    .join(",");
+  return `${sha}|${failing}|${conflicted}|${threads}`;
 }
 
 /** Unstaged, non-conflicted edits in the working copy.
@@ -283,7 +305,13 @@ export function autopilotStep(input: AutopilotInput): AutopilotEffect {
       // loop convinces itself there's work when there isn't.
       return { do: "wait", why: "gate-settling" };
     case "escalate":
-      return { do: "escalate", reason: "needs-human", rung: null };
+      return {
+        do: "escalate",
+        // A push-back is its own outcome: the agent did the work and disagreed,
+        // so point the user at the argument rather than at the PR in general.
+        reason: rung.blocker.kind === "review-disputed" ? "disputed-review" : "needs-human",
+        rung: null,
+      };
     default:
       // merge / ready / landed. Autopilot's job here is done; merging is a
       // decision, not a remediation, and deliberately not autopilot's to make.

--- a/src/components/RightPanel/GitPanel/AutopilotChip.tsx
+++ b/src/components/RightPanel/GitPanel/AutopilotChip.tsx
@@ -29,6 +29,8 @@ export function stuckLabel(reason: StuckReason): string {
       return "Autopilot stopped — its last attempt changed nothing";
     case "needs-human":
       return "Autopilot stopped — this needs you";
+    case "disputed-review":
+      return "Autopilot pushed back on a review comment — see the thread";
     case "dirty-tree":
       return "Autopilot stopped — it won't commit your uncommitted changes";
     case "no-evidence":

--- a/src/components/RightPanel/GitPanel/AutopilotChip.tsx
+++ b/src/components/RightPanel/GitPanel/AutopilotChip.tsx
@@ -29,6 +29,8 @@ export function stuckLabel(reason: StuckReason): string {
       return "Autopilot stopped — its last attempt changed nothing";
     case "needs-human":
       return "Autopilot stopped — this needs you";
+    case "dirty-tree":
+      return "Autopilot stopped — it won't commit your uncommitted changes";
     case "no-evidence":
       return "Autopilot stopped — no result came back";
   }

--- a/src/components/Workspace/MissionControl/QueueCard.tsx
+++ b/src/components/Workspace/MissionControl/QueueCard.tsx
@@ -12,6 +12,9 @@ const REASON_LABEL: Record<ReviewReason, string> = {
   "unseen-results": "New results to review",
   "checks-failing": "Checks failing",
   "unresolved-comments": "Unresolved comments",
+  // Phrased as what happened, not as an error: autopilot tried and handed it
+  // back, so the next move is the user's.
+  "autopilot-stuck": "Autopilot stopped",
 };
 
 function reasonLine(item: ReviewItem): string {

--- a/src/components/Workspace/MissionControl/queue.test.ts
+++ b/src/components/Workspace/MissionControl/queue.test.ts
@@ -59,6 +59,7 @@ function checks(over: Partial<PrChecks>): PrChecks {
 
 const comments = (n: number): PrComments => ({
   unresolved: Array.from({ length: n }, (_, i) => ({
+    id: `t${i}`,
     author: "bot",
     is_bot: true,
     body: `c${i}`,
@@ -66,6 +67,7 @@ const comments = (n: number): PrComments => ({
     line: null,
     url: `u${i}`,
     replies: 0,
+    we_replied_last: false,
   })),
 });
 

--- a/src/components/Workspace/MissionControl/queue.test.ts
+++ b/src/components/Workspace/MissionControl/queue.test.ts
@@ -10,6 +10,7 @@ import type {
   VerificationReport,
   WfRun,
 } from "@/api";
+import type { AutopilotState } from "@/autopilot";
 import { BUCKET, buildReviewQueue, type QueueInput } from "./queue";
 
 // ── fixtures ──────────────────────────────────────────────────────────────────
@@ -114,6 +115,7 @@ function input(over: Partial<QueueInput>): QueueInput {
     prChecks: {},
     prComments: {},
     verificationReports: {},
+    autopilot: {},
     runs: [],
     dismissed: {},
     ...over,
@@ -584,5 +586,88 @@ describe("buildReviewQueue", () => {
     );
     expect(q).toHaveLength(1);
     expect(q[0].fanout?.agents.map((a) => a.agentId)).toEqual(["live"]);
+  });
+
+  // ── autopilot escalation ──────────────────────────────────────────────────
+  // An enrolled checkout that gave up is the one signal autopilot can't surface
+  // itself: it has stopped, so if the queue doesn't raise its hand nothing does.
+
+  const stuckState = (over: Partial<AutopilotState> = {}): AutopilotState => ({
+    enrolled: true,
+    paused: false,
+    cycle: null,
+    attempts: {},
+    barren: [],
+    stuck: { reason: "budget-spent", rung: "fix-checks", at: 1 },
+    ...over,
+  });
+
+  it("raises a card when autopilot gave up, with nothing else wrong", () => {
+    const q = buildReviewQueue(
+      input({ agents: [agent({ id: "a" })], autopilot: { a: stuckState() } }),
+    );
+    expect(q).toHaveLength(1);
+    expect(q[0].reasons).toEqual(["autopilot-stuck"]);
+    expect(q[0].autopilotStuck).toEqual({ reason: "budget-spent", rung: "fix-checks" });
+  });
+
+  it("raises it for a secondary checkout too", () => {
+    // A stuck autopilot on `a::web` deserves the same card as one on the primary.
+    const q = buildReviewQueue(
+      input({ agents: [agent({ id: "a" })], autopilot: { "a::web": stuckState() } }),
+    );
+    expect(q).toHaveLength(1);
+    expect(q[0].reasons).toEqual(["autopilot-stuck"]);
+  });
+
+  it("stays quiet for a checkout that is enrolled but running fine", () => {
+    // Enrolled-and-working is the normal state; it must never generate a card.
+    const q = buildReviewQueue(
+      input({
+        agents: [agent({ id: "a" })],
+        autopilot: { a: stuckState({ stuck: null }) },
+      }),
+    );
+    expect(q).toHaveLength(0);
+  });
+
+  it("ignores a stuck record on a checkout that was un-enrolled", () => {
+    const q = buildReviewQueue(
+      input({
+        agents: [agent({ id: "a" })],
+        autopilot: { a: stuckState({ enrolled: false }) },
+      }),
+    );
+    expect(q).toHaveLength(0);
+  });
+
+  it("dedupes onto one card alongside the reason autopilot choked on", () => {
+    const q = buildReviewQueue(
+      input({
+        agents: [repoAgent("a", "/repo")],
+        prStates: { a: openPr(7) },
+        prChecks: { a: checks({}) },
+        autopilot: { a: stuckState() },
+      }),
+    );
+    expect(q).toHaveLength(1);
+    expect(q[0].reasons).toEqual(["autopilot-stuck", "checks-failing"]);
+  });
+
+  it("resurfaces a dismissed card when autopilot stops for a DIFFERENT reason", () => {
+    // Dismissing "stopped: budget spent" must not also hide a later "stopped:
+    // needs you" — a different reason is a different decision.
+    const spent = input({ agents: [agent({ id: "a" })], autopilot: { a: stuckState() } });
+    const first = buildReviewQueue(spent);
+    const dismissed = { [first[0].id]: first[0].signature };
+
+    expect(buildReviewQueue({ ...spent, dismissed })).toHaveLength(0);
+
+    const needsHuman = input({
+      agents: [agent({ id: "a" })],
+      autopilot: { a: stuckState({ stuck: { reason: "needs-human", rung: null, at: 2 } }) },
+      dismissed,
+    });
+    expect(buildReviewQueue(needsHuman)).toHaveLength(1);
   });
 });

--- a/src/components/Workspace/MissionControl/queue.ts
+++ b/src/components/Workspace/MissionControl/queue.ts
@@ -16,6 +16,7 @@ import type {
   WfPausedReason,
   WfRun,
 } from "@/api";
+import type { AutopilotState, StuckReason } from "@/autopilot";
 
 /** A card's tests-evidence chip state, derived from a turn-end
  *  [`VerificationReport`]. Only ever a definitive verdict — `undefined` while
@@ -30,7 +31,8 @@ export type ReviewReason =
   | "workflow-conflict"
   | "unseen-results"
   | "checks-failing"
-  | "unresolved-comments";
+  | "unresolved-comments"
+  | "autopilot-stuck";
 
 /** A "base moved under this agent" signal — quiet information, not an alarm (a
  *  moved base is normal in a parallel fleet). Fed from the fleet-wide `gitMeta`
@@ -110,6 +112,9 @@ export interface ReviewItem {
    *  Omitted when unknown/running/no-tests, so it decorates an existing card
    *  and never fakes a state. */
   tests?: TestsEvidence;
+  /** Why autopilot handed this agent back, when it did. Drives the card's
+   *  "Autopilot stopped" line and its retry affordance. */
+  autopilotStuck?: { reason: StuckReason; rung: string | null };
   staleness?: Staleness | null;
   /** Advisory overlap hints — other agents on the same repo touching some of
    *  the same files. Omitted when there are none. */
@@ -148,6 +153,10 @@ export interface QueueInput {
    *  = never verified. */
   verificationReports: Record<string, VerificationReport>;
   runs: readonly WfRun[];
+  /** Per-checkout autopilot state, keyed by `checkoutKey`. An enrolled checkout
+   *  that gave up is the one signal autopilot cannot surface itself: it has
+   *  stopped, so nothing else will raise its hand. */
+  autopilot: Record<string, AutopilotState>;
   /** Item id → signal signature it was dismissed at. */
   dismissed: Record<string, string>;
 }
@@ -227,11 +236,32 @@ function collectPrSignals(agentId: string, input: QueueInput): PrSignal[] {
 
 /** The agent item's signature: only the volatile review signals (across every
  *  repo's PR), so dismissing it holds until one of them changes. */
+/** The first of an agent's checkouts where autopilot gave up, or null.
+ *
+ *  Scanned across every checkout (`agentId` plus `agentId::subdir`) because a
+ *  secondary repo's stuck autopilot deserves the same card as the primary's —
+ *  same prefix scan `maxBehind` uses. First match wins: one card per agent, and
+ *  the reason is what matters, not which repo produced it. */
+function stuckCheckout(
+  agentId: string,
+  input: QueueInput,
+): { reason: StuckReason; rung: string | null } | null {
+  const prefix = `${agentId}::`;
+  for (const [key, state] of Object.entries(input.autopilot)) {
+    if (key !== agentId && !key.startsWith(prefix)) continue;
+    if (state.enrolled && state.stuck) {
+      return { reason: state.stuck.reason, rung: state.stuck.rung };
+    }
+  }
+  return null;
+}
+
 function agentSignature(p: {
   unseen: boolean;
   stats: ShortStats | undefined;
   signals: PrSignal[];
   tests: TestsEvidence | undefined;
+  stuck: { reason: StuckReason; rung: string | null } | null;
 }): string {
   const d = p.stats ? `${p.stats.additions}/${p.stats.deletions}/${p.stats.file_count}` : "-";
   const c = p.signals
@@ -241,8 +271,11 @@ function agentSignature(p: {
     })
     .join(",");
   // Include the tests verdict so a fresh verification resurfaces a dismissed
-  // card (a pass→fail flip, or the first result landing after dismissal).
-  return `u${p.unseen ? 1 : 0}|d${d}|c${c || "-"}|t${p.tests ?? "-"}`;
+  // card (a pass→fail flip, or the first result landing after dismissal), and the
+  // autopilot verdict so dismissing "stopped: budget spent" doesn't also hide a
+  // later "stopped: needs you" — a different reason is a different decision.
+  const ap = p.stuck ? `${p.stuck.reason}:${p.stuck.rung ?? "-"}` : "-";
+  return `u${p.unseen ? 1 : 0}|d${d}|c${c || "-"}|t${p.tests ?? "-"}|a${ap}`;
 }
 
 /** The agent's stalest checkout vs its base, or null when no base has moved
@@ -456,10 +489,15 @@ export function buildReviewQueue(input: QueueInput): ReviewItem[] {
     const failing = signals.filter((s) => s.checks?.rollup === "failing");
     const unresolved = signals.reduce((n, s) => n + s.unresolved, 0);
     const tests = testsEvidence(input.verificationReports[agent.id]);
+    // An enrolled checkout that gave up. Autopilot is stopped by then, so if this
+    // doesn't raise its hand nothing does — the whole point of an unattended loop
+    // is that you only hear about it when it needs you.
+    const stuck = stuckCheckout(agent.id, input);
 
     const reasons: ReviewReason[] = [];
     // Ad-hoc: a turn landed while you weren't looking and left changes behind.
     if (agent.status === "idle" && unseen && hasDiff) reasons.push("unseen-results");
+    if (stuck) reasons.push("autopilot-stuck");
     if (failing.length > 0) reasons.push("checks-failing");
     if (unresolved > 0) reasons.push("unresolved-comments");
     if (reasons.length === 0) continue;
@@ -467,12 +505,15 @@ export function buildReviewQueue(input: QueueInput): ReviewItem[] {
     // The evidence chips show one PR: the one carrying the issue (a failing
     // repo first, then one with unresolved threads, then the primary).
     const shown = failing[0] ?? signals.find((s) => s.unresolved > 0) ?? signals[0];
-    const isPr = reasons.includes("checks-failing") || reasons.includes("unresolved-comments");
+    const isPr =
+      reasons.includes("checks-failing") ||
+      reasons.includes("unresolved-comments") ||
+      reasons.includes("autopilot-stuck");
     items.push({
       id: `agent:${agent.id}`,
       kind: "agent",
       bucket: isPr ? BUCKET.pr : BUCKET.unseen,
-      signature: agentSignature({ unseen, stats, signals, tests }),
+      signature: agentSignature({ unseen, stats, signals, tests, stuck }),
       activityAt: parseCreated(agent.created_at),
       title: agent.name,
       goal: firstLine(agent.task) || "—",
@@ -486,6 +527,7 @@ export function buildReviewQueue(input: QueueInput): ReviewItem[] {
       // Decoration on an existing card (like staleness/overlaps below): the
       // tests chip never creates a card, only annotates one.
       tests,
+      autopilotStuck: stuck ?? undefined,
       // Always-visible signals (§2/§4): the base-moved chip and overlap hints
       // decorate an existing card in every panel state — they never create one.
       staleness: stalenessOf(agent.id, input),

--- a/src/components/Workspace/MissionControl/queue.ts
+++ b/src/components/Workspace/MissionControl/queue.ts
@@ -228,7 +228,12 @@ function collectPrSignals(agentId: string, input: QueueInput): PrSignal[] {
       repo: key === agentId ? "" : key.slice(prefix.length),
       pr,
       checks: input.prChecks[key] ?? null,
-      unresolved: (input.prComments[key] ?? null)?.unresolved.length ?? 0,
+      // Threads where WE had the last word are waiting on a person, not on
+      // anyone doing more work — counting them would leave a card sitting under
+      // an "unresolved comments" chip that nobody can clear by acting.
+      unresolved: ((input.prComments[key] ?? null)?.unresolved ?? []).filter(
+        (t) => !t.we_replied_last,
+      ).length,
     });
   }
   return out;

--- a/src/components/Workspace/MissionControl/useQueueActions.ts
+++ b/src/components/Workspace/MissionControl/useQueueActions.ts
@@ -92,6 +92,13 @@ export function useQueueActions(openReview: (runId: string) => void): QueueActio
         checks: s.prChecks[key] ?? null,
         comments: s.prComments[key] ?? null,
       };
+      // Approving a checkout autopilot gave up on IS the human "try again" it was
+      // waiting for, so clear the stuck state (and its spent budget) as part of
+      // the gesture. Without this the user would retry by hand while autopilot
+      // stayed stopped forever — and `stuck` is deliberately only clearable by a
+      // human, so nothing else would ever do it.
+      if (s.autopilot[key]?.stuck) s.resumeAutopilot(key);
+
       const rung = nextRung(input, {
         base: git?.parent_branch || "main",
         commitMode: commitMode(s.gitCommitAction),

--- a/src/components/Workspace/MissionControl/useReviewQueue.ts
+++ b/src/components/Workspace/MissionControl/useReviewQueue.ts
@@ -16,6 +16,7 @@ export function useReviewQueue(): ReviewItem[] {
   const prChecks = useAppStore((s) => s.prChecks);
   const prComments = useAppStore((s) => s.prComments);
   const verificationReports = useAppStore((s) => s.verificationReports);
+  const autopilot = useAppStore((s) => s.autopilot);
   const dismissed = useAppStore((s) => s.reviewDismissed);
   const runs = useRuns();
 
@@ -30,6 +31,7 @@ export function useReviewQueue(): ReviewItem[] {
         prChecks,
         prComments,
         verificationReports,
+        autopilot,
         runs,
         dismissed,
       }),
@@ -42,6 +44,7 @@ export function useReviewQueue(): ReviewItem[] {
       prChecks,
       prComments,
       verificationReports,
+      autopilot,
       runs,
       dismissed,
     ],

--- a/src/delegation.ts
+++ b/src/delegation.ts
@@ -27,7 +27,8 @@ export type DelegationKind =
   | "push"
   | "resolve"
   | "update-branch"
-  | "fix-checks";
+  | "fix-checks"
+  | "resolve-comments";
 
 export interface Delegation {
   kind: DelegationKind;
@@ -132,6 +133,12 @@ export function actionProvesKind(kind: DelegationKind, op: string): boolean {
       return op === "open_pr";
     case "push":
       return op === "git_push";
+    case "resolve-comments":
+      // Any thread action proves the turn engaged with the review. Resolution
+      // still gates completion (no threads left needing us), so accepting a bare
+      // reply here is safe — and necessary, since a turn that only pushed back is
+      // a legitimate outcome that resolves nothing.
+      return op === "reply_thread" || op === "resolve_thread";
     case "update-branch":
       // Proven only by an actual base merge: a clean merge fires the clone's
       // post-merge hook, and a conflicted merge's completing commit is a merge
@@ -180,6 +187,8 @@ export function delegationLabel(kind: DelegationKind): string {
       return "Agent is updating the branch…";
     case "fix-checks":
       return "Agent is fixing the failing checks…";
+    case "resolve-comments":
+      return "Agent is working through the review comments…";
   }
 }
 
@@ -202,6 +211,8 @@ export function delegationDone(kind: DelegationKind): string {
       return "Branch updated";
     case "fix-checks":
       return "Agent finished — checks are re-running";
+    case "resolve-comments":
+      return "Review comments addressed";
   }
 }
 
@@ -239,6 +250,11 @@ export function delegationResolved(
       if (checks) return !["behind", "dirty", "unknown"].includes(checks.merge_state);
       return pr?.mergeable === "mergeable";
     case "fix-checks":
+      return false;
+    case "resolve-comments":
+      // Threads only clear once GitHub reports them resolved, which the slow
+      // comments poll picks up. Like fix-checks, the caller resolves this on
+      // agent-idle and lets the polling carry the story.
       return false;
   }
 }

--- a/src/readiness.test.ts
+++ b/src/readiness.test.ts
@@ -7,7 +7,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import type { GitState, PrChecks, PrComments, PrState } from "@/api";
+import type { GitState, PrChecks, PrComment, PrComments, PrState } from "@/api";
 import { detectBlockers, type LadderContext, nextRung, type ReadinessInput } from "@/readiness";
 
 function git(over: Partial<GitState> = {}): GitState {
@@ -54,8 +54,9 @@ function checks(over: Partial<PrChecks> = {}): PrChecks {
     ...over,
   };
 }
-const comments = (n: number): PrComments => ({
+const comments = (n: number, over: Partial<PrComment> = {}): PrComments => ({
   unresolved: Array.from({ length: n }, (_, i) => ({
+    id: `t${i}`,
     author: "bot",
     is_bot: true,
     body: `c${i}`,
@@ -63,6 +64,8 @@ const comments = (n: number): PrComments => ({
     line: null,
     url: "https://x",
     replies: 0,
+    we_replied_last: false,
+    ...over,
   })),
 });
 
@@ -252,12 +255,38 @@ describe("nextRung ordering", () => {
     });
   });
 
-  it("escalates unresolved review threads rather than calling the PR ready", () => {
-    // No remediation kind exists for comments yet. Escalating is the honest
-    // answer; reporting "merge" would hide real feedback.
+  it("hands unresolved review threads to the agent, with the count", () => {
     expect(
-      rung({ pr: pr(), checks: checks({ merge_state: "clean" }), comments: comments(1) }),
-    ).toMatchObject({ do: "escalate", blocker: { kind: "review-unaddressed", count: 1 } });
+      rung({ pr: pr(), checks: checks({ merge_state: "clean" }), comments: comments(2) }),
+    ).toMatchObject({
+      do: "delegate",
+      kind: "resolve-comments",
+      params: { count: "2" },
+      blocker: { kind: "review-unaddressed", count: 2 },
+    });
+  });
+
+  it("escalates a thread it already pushed back on instead of re-arguing it", () => {
+    // We had the last word and left it open on purpose. There is no remediation
+    // for a disagreement — a person settles it.
+    expect(
+      rung({
+        pr: pr(),
+        checks: checks({ merge_state: "clean" }),
+        comments: comments(1, { we_replied_last: true }),
+      }),
+    ).toMatchObject({ do: "escalate", blocker: { kind: "review-disputed", count: 1 } });
+  });
+
+  it("works the actionable threads first when some are disputed and some aren't", () => {
+    // A mix must not stall on the disagreement: fix what can be fixed, and the
+    // disputed one surfaces once nothing else is left.
+    const mixed: PrComments = {
+      unresolved: [...comments(1, { we_replied_last: true }).unresolved, ...comments(1).unresolved],
+    };
+    expect(
+      rung({ pr: pr(), checks: checks({ merge_state: "clean" }), comments: mixed }),
+    ).toMatchObject({ do: "delegate", kind: "resolve-comments", params: { count: "1" } });
   });
 
   it("merges only on an open gate, and waits while the gate is still computing", () => {

--- a/src/readiness.ts
+++ b/src/readiness.ts
@@ -57,8 +57,13 @@ export type Blocker =
    *  masquerading as a fact. The local verifier (`verify.rs`) *does* know the
    *  difference — when its report becomes an input, the split can be real. */
   | { kind: "checks-failing"; checks: string[] }
-  /** Review threads nobody has addressed. */
+  /** Review threads waiting on us: nobody has replied, or the human answered our
+   *  last word and it's our turn again. */
   | { kind: "review-unaddressed"; count: number }
+  /** Open threads where WE had the last word — the agent pushed back and left
+   *  them open on purpose. Nothing more to do here; a person has to settle the
+   *  disagreement, so the ladder escalates rather than re-arguing. */
+  | { kind: "review-disputed"; count: number }
   /** A human has to approve. Not agent-fixable — the ladder escalates. */
   | { kind: "review-required" }
   /** Still a draft, so it isn't really proposed yet. Human-owned. */
@@ -136,8 +141,14 @@ export function detectBlockers({ git, pr, checks, comments }: ReadinessInput): B
         // the failing names are informational, not blocking.
         break;
     }
-    const unresolved = comments?.unresolved.length ?? 0;
-    if (unresolved > 0) blockers.push({ kind: "review-unaddressed", count: unresolved });
+    // Split by who holds the conversation. A thread we replied to last is a
+    // deliberate push-back awaiting a human; treating it as "unaddressed" would
+    // make the agent re-argue the same point every cycle.
+    const threads = comments?.unresolved ?? [];
+    const ours = threads.filter((t) => t.we_replied_last).length;
+    const theirs = threads.length - ours;
+    if (theirs > 0) blockers.push({ kind: "review-unaddressed", count: theirs });
+    if (ours > 0) blockers.push({ kind: "review-disputed", count: ours });
   }
 
   return blockers;
@@ -261,11 +272,21 @@ export function nextRung(input: ReadinessInput, ctx: LadderContext): Rung {
   const human = find("review-required") ?? find("draft") ?? find("proposal-closed");
   if (human) return { do: "escalate", blocker: human };
 
-  // No rung addresses review threads yet — the delegation kind and its playbook
-  // arrive with the comments slice. Escalating (rather than silently treating a
-  // commented PR as ready) keeps the honest answer: a human should look.
-  const comments = find("review-unaddressed");
-  if (comments) return { do: "escalate", blocker: comments };
+  const unaddressed = find("review-unaddressed");
+  if (unaddressed) {
+    return {
+      do: "delegate",
+      kind: "resolve-comments",
+      action: "resolve-comments",
+      params: { count: String(unaddressed.count) },
+      blocker: unaddressed,
+    };
+  }
+
+  // Only threads we already pushed back on remain. There is no remediation for a
+  // disagreement — the whole point of leaving them open is that a person decides.
+  const disputed = find("review-disputed");
+  if (disputed) return { do: "escalate", blocker: disputed };
 
   // Only an open proposal HAS a merge gate. Consulting it otherwise reads
   // GitHub's "not computed yet" as "still resolving" and parks forever on a

--- a/src/store/autopilotSync.ts
+++ b/src/store/autopilotSync.ts
@@ -107,6 +107,11 @@ async function apply(
       );
       return;
     }
+    case "await-evidence":
+      // A state-judged rung (a reconcile): nothing to run, the world just needs
+      // time to settle. Start the phase clock so the evidence timeout applies.
+      s.advanceAutopilotCycle(key, "awaiting-evidence", now);
+      return;
     case "verify": {
       // Enter `awaiting-evidence` first: the phase clock starts now, and the
       // effect is idempotent from here even if the verify call is slow or fails.

--- a/src/store/gitSync.ts
+++ b/src/store/gitSync.ts
@@ -93,13 +93,15 @@ export function useGitSync() {
   // reads are 304s GitHub doesn't bill, so there's nothing to back off from.
   useTrackedRepoPoll(fetchPrLive, 5000);
 
-  // Unresolved review threads — the one panel read still costing GraphQL points,
-  // so it gets the gentlest cadence, and the only one still scoped to the focused
-  // agent: no delegation kind resolves off comment threads yet, so widening this
-  // would spend points for nothing. Not filtered by PR state here: the backend
-  // returns nothing for a repo whose PR isn't open, and keeping that rule in one
-  // place beats mirroring it in the poller.
-  useFocusedRepoPoll(fetchPrThreads, 30000);
+  // Unresolved review threads — the one read still costing GraphQL points (thread
+  // resolution has no REST equivalent), so it keeps the gentlest cadence and the
+  // narrowest scope: the focused agent's repos, plus any checkout autopilot is
+  // enrolled on, because the comments rung can't act on threads it can't see.
+  // Deliberately NOT fleet-wide: that would bill points for every agent whether
+  // anything was going to use them or not. Not filtered by PR state either — the
+  // backend returns nothing for a repo whose PR isn't open, and keeping that rule
+  // in one place beats mirroring it in the poller.
+  useCommentPoll(fetchPrThreads, 30000);
 }
 
 /** The checkouts needing detail reads this tick, as `checkoutKey`s: every repo of
@@ -110,17 +112,57 @@ export function useGitSync() {
  *  closure. */
 function useTrackedCheckoutKeys(): string[] {
   return useAppStore(
-    useShallow((s) => {
-      const keys = new Set<string>(Object.keys(s.delegations));
-      const agent = s.workspace?.agents.find((a) => a.id === s.selectedAgentId);
-      if (agent) {
-        for (const [i, repo] of agent.repos.entries()) {
-          keys.add(checkoutKey(agent.id, i === 0 ? undefined : repo.subdir));
-        }
-      }
-      return [...keys].sort();
-    }),
+    useShallow((s) => [...withFocusedRepos(s, Object.keys(s.delegations))].sort()),
   );
+}
+
+/** The focused agent's repo keys unioned into `keys`. Shared by the checkout
+ *  pollers so "focused plus X" is expressed once. */
+function withFocusedRepos(
+  s: {
+    workspace: { agents: { id: string; repos: { subdir: string }[] }[] } | null;
+    selectedAgentId: string | null;
+  },
+  keys: Iterable<string>,
+): Set<string> {
+  const out = new Set<string>(keys);
+  const agent = s.workspace?.agents.find((a) => a.id === s.selectedAgentId);
+  if (agent) {
+    for (const [i, repo] of agent.repos.entries()) {
+      out.add(checkoutKey(agent.id, i === 0 ? undefined : repo.subdir));
+    }
+  }
+  return out;
+}
+
+/** Run `fetch` for the focused agent's repos plus every autopilot-enrolled
+ *  checkout — the scope for reads too expensive to run fleet-wide but useless if
+ *  the thing that acts on them can't see them. */
+function useCommentPoll(
+  fetch: (agentId: string, subdir?: string) => Promise<void>,
+  intervalMs: number,
+) {
+  const keys = useAppStore(
+    useShallow((s) =>
+      [
+        ...withFocusedRepos(
+          s,
+          Object.entries(s.autopilot)
+            .filter(([, a]) => a.enrolled)
+            .map(([key]) => key),
+        ),
+      ].sort(),
+    ),
+  );
+  const tick = useCallback(async () => {
+    await Promise.all(
+      keys.map((key) => {
+        const { agentId, subdir } = splitCheckoutKey(key);
+        return fetch(agentId, subdir);
+      }),
+    );
+  }, [keys, fetch]);
+  usePoll(tick, intervalMs, [tick]);
 }
 
 /** Run `fetch` for every tracked checkout, on `intervalMs`.
@@ -143,25 +185,5 @@ function useTrackedRepoPoll(
       }),
     );
   }, [keys, fetch]);
-  usePoll(tick, intervalMs, [tick]);
-}
-
-/** Run `fetch` for every repo of the focused agent only — for reads whose cost
- *  isn't worth paying on a checkout nobody is looking at. */
-function useFocusedRepoPoll(
-  fetch: (agentId: string, subdir?: string) => Promise<void>,
-  intervalMs: number,
-) {
-  const agentId = useAppStore((s) => s.selectedAgentId);
-  const subdirs = useAppStore(
-    useShallow((s) => {
-      const agent = s.workspace?.agents.find((a) => a.id === s.selectedAgentId);
-      return agent?.repos.map((r, i) => (i === 0 ? undefined : r.subdir)) ?? [];
-    }),
-  );
-  const tick = useCallback(async () => {
-    if (!agentId) return;
-    await Promise.all(subdirs.map((subdir) => fetch(agentId, subdir)));
-  }, [agentId, subdirs, fetch]);
   usePoll(tick, intervalMs, [tick]);
 }

--- a/tests/components/RightPanel/prComments.test.ts
+++ b/tests/components/RightPanel/prComments.test.ts
@@ -3,6 +3,7 @@ import type { PrComment } from "@/api";
 import { commentLocation, formatCommentForChat } from "@/components/RightPanel/prComments";
 
 const base: PrComment = {
+  id: "PRRT_1",
   author: "x",
   is_bot: false,
   body: "Body text",
@@ -10,6 +11,7 @@ const base: PrComment = {
   line: 42,
   url: "https://github.com/o/r/pull/1#discussion_r1",
   replies: 0,
+  we_replied_last: false,
 };
 
 describe("commentLocation", () => {


### PR DESCRIPTION
Fifth slice. The agent now judges each unresolved review thread instead of the PR quietly reporting green with feedback sitting on it.

| Thread is | Agent does | Thread ends |
|---|---|---|
| A valid request | makes the change, replies with what changed | resolved |
| A question | replies with the answer | resolved |
| Wrong, or it disagrees | replies with the reasoning | **left open** |

Resolving is only ever a claim that a thread is discharged. It is never how a disagreement ends — a push-back stays open for a person to settle. That's what makes autopilot touching human threads defensible at all, and it's why `reply_thread` and `resolve_thread` are two ops rather than one "address this" call.

## Not re-litigating, without local state

An agent that pushes back leaves the thread open *on purpose*, so the naive loop re-argues the same point every cycle and posts a duplicate reply each time. Tracking disputed ids locally works until the first reload — cycles aren't persisted — at which point it argues again into someone's inbox.

So the thread selection now reads whether **we** posted the last comment (`we_replied_last`), and the answer comes off GitHub:

- we had the last word → wait, nothing to do
- the human replied after us → new input, engage again

Stateless, restart-proof, and it splits the old blocker into `review-unaddressed` (ours to work) and `review-disputed` (theirs to settle). One subtlety: only a real *reply* parks a thread — a single-comment thread we opened ourselves has us as last author too, and there's nothing to wait for there.

`viewer{login}` rides the existing PR query rather than calling `auth_status()`. `viewer` is a single node, not a connection, so it costs nothing on a read that already runs on a timer — and the login is then consistent with the data it applies to, instead of coming from a separate cache.

## Surface

- `PrComment` carries the thread's node id. It previously kept only the root comment's `url`, so nothing could *act* on a thread.
- `resolveReviewThread` / `addPullRequestReviewThreadReply`, reached by the agent through three RPC ops: `pr_threads` (read), `reply_thread`, `resolve_thread`.
- New `resolve-comments` delegation kind and playbook.
- On scopes: `repo` already covers these. The real requirement is push access to the repo, which autopilot needs regardless — so nothing to change there.

## Autopilot

**Budget of two.** Each cycle posts into a real conversation, so a loop that isn't converging is noise in someone's inbox, not just wasted tokens.

**Evidence is `state`, not `verify`.** A comment round can legitimately change no code at all — answering a question, pushing back — so a test result says nothing about whether it worked.

**Thread ids join the signature**, for the same reason conflicted paths did in #548: a round that cleared three of five threads, or turned one into a push-back, has to register as progress rather than as a barren cycle.

A push-back escalates as its own `disputed-review` reason rather than generic `needs-human`, because the next step is reading one specific thread, not eyeballing the PR.

**Polling** widens from focused-only to focused-plus-enrolled — the rung can't act on threads it can't see. Deliberately *not* fleet-wide: this is the one read still costing GraphQL points.

The queue's unresolved count now excludes threads awaiting a human, so a disputed PR doesn't sit under an "unresolved comments" chip nobody can clear by acting.

## Verification

- `tsc --noEmit` clean; `cargo check` and `cargo fmt --check` clean.
- 677 TS tests (up from 670), plus 5 new Rust tests covering thread ids, the last-replier flag, the self-opened-thread edge case, and the unknown-login default (which must park nothing).
- `biome check` at parity: 0 errors, same 73 pre-existing warnings.
- **Mutation-checked**: treating a disputed thread as work, dropping thread ids from the signature, collapsing push-back into `needs-human`, or judging a comment round by the tests — each fails a test.

## Worth flagging

`is_bot` is `__typename == "Bot"`, which catches GitHub Apps. It no longer gates *whether* autopilot acts (it acts on all threads now), only whether a reply is warranted — so a Greptile install that isn't an App degrades to "treated as human", which is the safe direction.

Next and last planned slice is workflow PRs, which need a subject to act on since `finalize_run` disposes the run's workspaces. Merging stays deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)