### PR TITLE
feat(autopilot): fix the dispatch race, add an audit trail, surface it in the sidebar

### DIFF
--- a/src/autopilot.test.ts
+++ b/src/autopilot.test.ts
@@ -18,16 +18,18 @@ import {
   type AutopilotInput,
   type AutopilotState,
   autopilotStep,
+  blockerFingerprint,
   type Cycle,
   EVIDENCE_TIMEOUT_MS,
   failedCheckNames,
   newEnrollment,
   RUNG_BUDGET,
+  type StuckReason,
   stateSignature,
   unstagedEdits,
   verificationPassed,
 } from "@/autopilot";
-import type { LadderContext, ReadinessInput } from "@/readiness";
+import { detectBlockers, type LadderContext, type ReadinessInput } from "@/readiness";
 
 const NOW = 1_000_000;
 
@@ -92,6 +94,11 @@ const GREEN: ReadinessInput = {
 
 const LADDER: LadderContext = { base: "main", commitMode: "commit-pr" };
 
+/** The blocker fingerprint of FAILING — the situation a stuck fixture stopped in.
+ *  Stamping it means "stays stuck" tests assert the world is UNCHANGED, which is
+ *  the actual precondition for staying stopped. */
+const STUCK_ON = blockerFingerprint(detectBlockers(FAILING));
+
 const state = (over: Partial<AutopilotState> = {}): AutopilotState => ({
   ...newEnrollment(),
   ...over,
@@ -133,7 +140,11 @@ describe("autopilot refuses to act", () => {
     // paused or handed-back checkout into another dispatch.
     expect(step({ state: state({ paused: true }) })).toEqual({ do: "wait", why: "paused" });
     expect(
-      step({ state: state({ stuck: { reason: "budget-spent", rung: "fix-checks", at: NOW } }) }),
+      step({
+        state: state({
+          stuck: { reason: "budget-spent", rung: "fix-checks", at: NOW, blockers: STUCK_ON },
+        }),
+      }),
     ).toEqual({ do: "wait", why: "stuck" });
   });
 
@@ -159,7 +170,7 @@ describe("autopilot refuses to act", () => {
         files: [{ path: "a.ts", kind: "modified", staged: false, additions: 1, deletions: 0 }],
       }),
     };
-    expect(step({ readiness: dirty })).toEqual({
+    expect(step({ readiness: dirty })).toMatchObject({
       do: "escalate",
       reason: "needs-human",
       rung: "commit-push",
@@ -180,7 +191,7 @@ describe("autopilot refuses to act", () => {
 
   it("escalates a human-only gate instead of retrying it", () => {
     const reviewGate = { ...FAILING, checks: checks({ merge_state: "blocked" }) };
-    expect(step({ readiness: reviewGate })).toEqual({
+    expect(step({ readiness: reviewGate })).toMatchObject({
       do: "escalate",
       reason: "needs-human",
       rung: null,
@@ -209,7 +220,7 @@ describe("autopilot opens a cycle", () => {
     // Checked BEFORE the budget: a repeat of a barren world is futile even with
     // attempts to spare.
     const s = state({ barren: [stateSignature(FAILING)] });
-    expect(step({ state: s })).toEqual({
+    expect(step({ state: s })).toMatchObject({
       do: "escalate",
       reason: "no-progress",
       rung: "fix-checks",
@@ -218,7 +229,7 @@ describe("autopilot opens a cycle", () => {
 
   it("stops when the rung's budget is spent", () => {
     const s = state({ attempts: { "fix-checks": RUNG_BUDGET["fix-checks"] } });
-    expect(step({ state: s })).toEqual({
+    expect(step({ state: s })).toMatchObject({
       do: "escalate",
       reason: "budget-spent",
       rung: "fix-checks",
@@ -272,7 +283,7 @@ describe("autopilot judges a cycle in flight", () => {
       cycle: cycle({ phase: "awaiting-evidence" }),
       barren: [stateSignature(FAILING)],
     });
-    expect(step({ state: s })).toEqual({
+    expect(step({ state: s })).toMatchObject({
       do: "escalate",
       reason: "no-progress",
       rung: "fix-checks",
@@ -291,7 +302,9 @@ describe("autopilot judges a cycle in flight", () => {
   });
 
   it("gives up when the failing cycle was the last one in the budget", () => {
-    expect(inFlight({ phase: "awaiting-evidence", attempt: RUNG_BUDGET["fix-checks"] })).toEqual({
+    expect(
+      inFlight({ phase: "awaiting-evidence", attempt: RUNG_BUDGET["fix-checks"] }),
+    ).toMatchObject({
       do: "escalate",
       reason: "budget-spent",
       rung: "fix-checks",
@@ -310,7 +323,7 @@ describe("autopilot judges a cycle in flight", () => {
         { phase: "awaiting-evidence", phaseSince: NOW - EVIDENCE_TIMEOUT_MS - 1 },
         { readiness: computing },
       ),
-    ).toEqual({ do: "escalate", reason: "no-evidence", rung: "fix-checks" });
+    ).toMatchObject({ do: "escalate", reason: "no-evidence", rung: "fix-checks" });
   });
 });
 
@@ -349,7 +362,7 @@ describe("the reconcile rungs", () => {
         { path: "mine.ts", kind: "modified", staged: false, additions: 9, deletions: 0 },
       ],
     });
-    expect(step({ readiness: withUserEdit })).toEqual({
+    expect(step({ readiness: withUserEdit })).toMatchObject({
       do: "escalate",
       reason: "dirty-tree",
       rung: "resolve",
@@ -429,11 +442,13 @@ describe("the review-comments rung", () => {
     // We replied last and left it open on purpose. Re-dispatching would post a
     // duplicate reply into a real person's conversation every cycle. The reason is
     // its own kind: the next step is reading that thread, not eyeballing the PR.
-    expect(step({ readiness: withThreads(thread("t1", { we_replied_last: true })) })).toEqual({
-      do: "escalate",
-      reason: "disputed-review",
-      rung: null,
-    });
+    expect(step({ readiness: withThreads(thread("t1", { we_replied_last: true })) })).toMatchObject(
+      {
+        do: "escalate",
+        reason: "disputed-review",
+        rung: null,
+      },
+    );
   });
 
   it("engages again once the human answers", () => {
@@ -586,5 +601,144 @@ describe("portability to Rust", () => {
 
   it("reads no clock or randomness, so a pass is reproducible from its inputs", () => {
     expect(code).not.toMatch(/Date\.now|new Date|Math\.random/);
+  });
+});
+
+describe("autopilot stops only while it is genuinely blocked", () => {
+  // It stops because it needs the user — a dirty tree it won't commit over, a
+  // review gate, a thread it pushed back on, a fix it failed to land. Every one
+  // of those clears OUTSIDE Fletch. Latching on the reason alone meant autopilot
+  // never noticed and abandoned the checkout for good, so the next failing check
+  // went unhandled too.
+
+  const stuckOn = (readiness: ReadinessInput, reason: StuckReason = "budget-spent") =>
+    state({
+      stuck: {
+        reason,
+        rung: "fix-checks",
+        at: NOW,
+        blockers: blockerFingerprint(detectBlockers(readiness)),
+      },
+    });
+
+  it("stays stopped while the same thing is still blocking it", () => {
+    expect(step({ state: stuckOn(FAILING), readiness: FAILING })).toEqual({
+      do: "wait",
+      why: "stuck",
+    });
+  });
+
+  it("picks the checkout back up once that thing is gone", () => {
+    // The user fixed the failing check themselves. Sitting out now would mean
+    // abandoning the checkout over a problem that no longer exists.
+    expect(step({ state: stuckOn(FAILING), readiness: GREEN })).toEqual({ do: "revive" });
+  });
+
+  it("picks it back up when the blocker changes rather than clears", () => {
+    // A different failing check is a different situation — autopilot has not
+    // tried and failed at this one.
+    const otherFailure = {
+      ...FAILING,
+      checks: checks({ merge_state: "blocked", required_failing: ["lint"] }),
+    };
+    expect(step({ state: stuckOn(FAILING), readiness: otherFailure })).toEqual({ do: "revive" });
+  });
+
+  it("resumes after the user commits the work it refused to commit over", () => {
+    // The dirty-tree stop, which is the case whose copy most clearly implies
+    // autopilot will carry on once you have committed.
+    const dirty = {
+      ...FAILING,
+      git: git({
+        files: [{ path: "a.ts", kind: "modified", staged: false, additions: 1, deletions: 0 }],
+      }),
+    };
+    expect(step({ state: stuckOn(dirty, "dirty-tree"), readiness: dirty })).toEqual({
+      do: "wait",
+      why: "stuck",
+    });
+    // Committed: the tree is clean and the checks are the only thing left.
+    expect(step({ state: stuckOn(dirty, "dirty-tree"), readiness: FAILING })).toEqual({
+      do: "revive",
+    });
+  });
+
+  it("resumes after a reviewer approves, which moves nothing but the gate", () => {
+    // The case a state-signature comparison would MISS: an approval changes no
+    // commit, no check and no thread. Comparing blockers is what catches it.
+    const gated = { ...FAILING, checks: checks({ merge_state: "blocked" }) };
+    expect(step({ state: stuckOn(gated, "needs-human"), readiness: gated })).toEqual({
+      do: "wait",
+      why: "stuck",
+    });
+    expect(step({ state: stuckOn(gated, "needs-human"), readiness: GREEN })).toEqual({
+      do: "revive",
+    });
+  });
+
+  it("resumes after the user settles a thread it pushed back on", () => {
+    const disputed: ReadinessInput = {
+      ...GREEN,
+      comments: {
+        unresolved: [
+          {
+            id: "t1",
+            author: "alice",
+            is_bot: false,
+            body: "no",
+            path: null,
+            line: null,
+            url: "https://x",
+            replies: 2,
+            we_replied_last: true,
+          },
+        ],
+      },
+    };
+    expect(step({ state: stuckOn(disputed, "disputed-review"), readiness: disputed })).toEqual({
+      do: "wait",
+      why: "stuck",
+    });
+    // Thread resolved on GitHub → it drops out of `unresolved` entirely.
+    expect(step({ state: stuckOn(disputed, "disputed-review"), readiness: GREEN })).toEqual({
+      do: "revive",
+    });
+  });
+
+  it("stamps every escalation with the situation it stopped in", () => {
+    // Without this the guard above has nothing to compare and autopilot could
+    // never tell a cleared blocker from a persisting one.
+    const escalation = step({ state: state({ attempts: { "fix-checks": 3 } }) });
+    expect(escalation).toMatchObject({ do: "escalate" });
+    expect(escalation).toHaveProperty("blockers", blockerFingerprint(detectBlockers(FAILING)));
+  });
+
+  it("still refuses to act while paused, whatever the world does", () => {
+    // Paused is the user's explicit instruction, so unlike `stuck` it is NOT
+    // conditional on anything.
+    expect(step({ state: state({ paused: true }), readiness: GREEN })).toEqual({
+      do: "wait",
+      why: "paused",
+    });
+  });
+});
+
+describe("blockerFingerprint", () => {
+  it("distinguishes which instance of a blocker, not just its kind", () => {
+    const fp = (names: string[]) =>
+      blockerFingerprint(
+        detectBlockers({
+          ...FAILING,
+          checks: checks({ merge_state: "blocked", required_failing: names }),
+        }),
+      );
+    expect(fp(["test"])).not.toBe(fp(["lint"]));
+    // Order of CI's report is not a change.
+    expect(fp(["test", "lint"])).toBe(fp(["lint", "test"]));
+  });
+
+  it("is empty when nothing is blocking, so a cleared world never matches", () => {
+    expect(blockerFingerprint(detectBlockers(GREEN))).toBe("");
+    expect(blockerFingerprint(detectBlockers(FAILING))).not.toBe("");
   });
 });

--- a/src/autopilot.test.ts
+++ b/src/autopilot.test.ts
@@ -705,6 +705,17 @@ describe("autopilot stops only while it is genuinely blocked", () => {
     });
   });
 
+  it("won't spend its refreshed budget re-entering a world it already failed at", () => {
+    // The safety property behind revive granting fresh attempts: `barren` is kept,
+    // so an oscillating world (a flaky check flipping back) escalates immediately
+    // instead of burning a whole new budget on a world already proven futile.
+    const revived = state({ attempts: {}, barren: [stateSignature(FAILING)] });
+    expect(step({ state: revived, readiness: FAILING })).toMatchObject({
+      do: "escalate",
+      reason: "no-progress",
+    });
+  });
+
   it("stamps every escalation with the situation it stopped in", () => {
     // Without this the guard above has nothing to compare and autopilot could
     // never tell a cleared blocker from a persisting one.

--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -32,7 +32,13 @@
 
 import type { GitState, VerificationReport } from "@/api";
 import type { DelegationKind } from "@/delegation";
-import { type LadderContext, nextRung, type ReadinessInput } from "@/readiness";
+import {
+  type Blocker,
+  detectBlockers,
+  type LadderContext,
+  nextRung,
+  type ReadinessInput,
+} from "@/readiness";
 
 /** Rungs autopilot may run on its own, this slice.
  *
@@ -141,9 +147,20 @@ export interface AutopilotState {
   attempts: Partial<Record<DelegationKind, number>>;
   /** Signatures that have already produced a cycle with no progress. */
   barren: string[];
-  /** Set when autopilot handed the checkout back. Sticky: it took a human to get
-   *  here, it takes a human to leave, so it can't quietly resume retrying. */
-  stuck: { reason: StuckReason; rung: DelegationKind | null; at: number } | null;
+  /** Set when autopilot handed the checkout back because it could not proceed
+   *  without the user.
+   *
+   *  `blockers` is the situation that stopped it (see `blockerFingerprint`).
+   *  While the situation holds, autopilot stays stopped — re-running would just
+   *  fail the same way. Once it changes, autopilot picks the checkout back up on
+   *  its own: the user has done whatever was needed, and continuing to sit out
+   *  would mean abandoning the checkout over a problem that no longer exists. */
+  stuck: {
+    reason: StuckReason;
+    rung: DelegationKind | null;
+    at: number;
+    blockers: string;
+  } | null;
 }
 
 /** Fresh state for a newly enrolled checkout. */
@@ -184,6 +201,44 @@ export function stateSignature({ git, checks, comments }: ReadinessInput): strin
     .sort()
     .join(",");
   return `${sha}|${failing}|${conflicted}|${threads}`;
+}
+
+/** A fingerprint of WHY autopilot is blocked — the blocker kinds plus the detail
+ *  that distinguishes one instance from another.
+ *
+ *  This is what makes `stuck` self-clearing. Autopilot stops when it genuinely
+ *  cannot proceed without the user (a dirty tree it won't commit over, a review
+ *  gate, a thread it pushed back on, a fix it failed to land three times), and
+ *  every one of those clears OUTSIDE Fletch — you commit, the reviewer approves,
+ *  you settle the argument. Latching on the reason alone meant autopilot never
+ *  noticed, and quietly stopped helping that checkout for good; the next failing
+ *  check went unhandled too.
+ *
+ *  Deliberately NOT `stateSignature`: that one answers "did the last cycle change
+ *  anything" and excludes the merge gate on purpose, because the gate flickers
+ *  through `unknown` while CI recomputes and would read as false progress. Here
+ *  the question is different — "does the reason I stopped still apply" — and a
+ *  review approval moves nothing but the gate, so the blocker set is the right
+ *  thing to compare. Two questions, two fingerprints. */
+export function blockerFingerprint(blockers: Blocker[]): string {
+  return blockers
+    .map((b) => {
+      switch (b.kind) {
+        // Payloads that identify WHICH instance, so a different failure or a
+        // different conflict reads as a new situation rather than the old one.
+        case "checks-failing":
+          return `${b.kind}:${[...b.checks].sort().join(",")}`;
+        case "conflicted":
+          return `${b.kind}:${[...b.paths].sort().join(",")}`;
+        case "review-unaddressed":
+        case "review-disputed":
+          return `${b.kind}:${b.count}`;
+        default:
+          return b.kind;
+      }
+    })
+    .sort()
+    .join("|");
 }
 
 /** Unstaged, non-conflicted edits in the working copy.
@@ -229,8 +284,17 @@ export type AutopilotEffect =
   /** The cycle failed but budget remains. Clear it, count the attempt, and
    *  record `barren` (when non-null) so a repeat of that world gives up. */
   | { do: "retry"; rung: DelegationKind; barren: string | null }
-  /** Hand back to the human. */
-  | { do: "escalate"; reason: StuckReason; rung: DelegationKind | null }
+  /** Hand back to the user, recording the situation that stopped it so autopilot
+   *  can tell when that situation has passed. */
+  | {
+      do: "escalate";
+      reason: StuckReason;
+      rung: DelegationKind | null;
+      blockers: string;
+    }
+  /** The situation that stopped it has changed — clear `stuck` and start looking
+   *  again. */
+  | { do: "revive" }
   /** Nothing to do this tick. */
   | { do: "wait"; why: WaitReason };
 
@@ -256,10 +320,26 @@ export interface AutopilotInput {
  *  ladder result. */
 export function autopilotStep(input: AutopilotInput): AutopilotEffect {
   const { state, readiness, ladder, agentBusy, delegationInFlight } = input;
+  // Every escalation records the situation it stopped in, so the guard above can
+  // tell later whether it still applies.
+  const stop = (reason: StuckReason, rung: DelegationKind | null): AutopilotEffect => ({
+    do: "escalate",
+    reason,
+    rung,
+    blockers: blockerFingerprint(detectBlockers(readiness)),
+  });
 
   if (!state?.enrolled) return { do: "wait", why: "not-enrolled" };
   if (state.paused) return { do: "wait", why: "paused" };
-  if (state.stuck) return { do: "wait", why: "stuck" };
+  if (state.stuck) {
+    // Stay stopped only while the situation that stopped us still holds. Autopilot
+    // stops because it needs the user, and the user acts OUTSIDE Fletch — so the
+    // signal that it may proceed is the blockers changing, not a click.
+    if (blockerFingerprint(detectBlockers(readiness)) === state.stuck.blockers) {
+      return { do: "wait", why: "stuck" };
+    }
+    return { do: "revive" };
+  }
 
   if (state.cycle) return judgeCycle(state.cycle, input);
 
@@ -276,21 +356,21 @@ export function autopilotStep(input: AutopilotInput): AutopilotEffect {
       if (!AUTOPILOT_RUNGS.includes(rung.kind)) {
         // A real action, just not one autopilot may take (a commit; a conflict
         // resolution until that slice lands). The human decides.
-        return { do: "escalate", reason: "needs-human", rung: rung.kind };
+        return stop("needs-human", rung.kind);
       }
       // Finishing a merge stages everything (`git add -A`), so unstaged edits
       // alongside the conflict are the user's in-flight work and would be swept
       // into the merge commit. Not autopilot's merge to finish.
       if (rung.kind === "resolve" && unstagedEdits(readiness.git) > 0) {
-        return { do: "escalate", reason: "dirty-tree", rung: rung.kind };
+        return stop("dirty-tree", rung.kind);
       }
       const signature = stateSignature(readiness);
       // Refuse to re-enter a world we already failed to change.
       if (state.barren.includes(signature)) {
-        return { do: "escalate", reason: "no-progress", rung: rung.kind };
+        return stop("no-progress", rung.kind);
       }
       if ((state.attempts[rung.kind] ?? 0) >= (RUNG_BUDGET[rung.kind] ?? 0)) {
-        return { do: "escalate", reason: "budget-spent", rung: rung.kind };
+        return stop("budget-spent", rung.kind);
       }
       return {
         do: "dispatch",
@@ -305,18 +385,32 @@ export function autopilotStep(input: AutopilotInput): AutopilotEffect {
       // loop convinces itself there's work when there isn't.
       return { do: "wait", why: "gate-settling" };
     case "escalate":
-      return {
-        do: "escalate",
-        // A push-back is its own outcome: the agent did the work and disagreed,
-        // so point the user at the argument rather than at the PR in general.
-        reason: rung.blocker.kind === "review-disputed" ? "disputed-review" : "needs-human",
-        rung: null,
-      };
+      // A push-back is its own outcome: the agent did the work and disagreed, so
+      // point the user at the argument rather than at the PR in general.
+      return stop(
+        rung.blocker.kind === "review-disputed" ? "disputed-review" : "needs-human",
+        null,
+      );
     default:
       // merge / ready / landed. Autopilot's job here is done; merging is a
       // decision, not a remediation, and deliberately not autopilot's to make.
       return { do: "wait", why: "nothing-to-do" };
   }
+}
+
+/** An escalation stamped with the situation it stopped in — the `judgeCycle` half
+ *  of `autopilotStep`'s local `stop`. */
+function stopIn(
+  input: AutopilotInput,
+  reason: StuckReason,
+  rung: DelegationKind | null,
+): AutopilotEffect {
+  return {
+    do: "escalate",
+    reason,
+    rung,
+    blockers: blockerFingerprint(detectBlockers(input.readiness)),
+  };
 }
 
 /** Judge a cycle already in flight. Split out so `autopilotStep` reads as the
@@ -339,10 +433,10 @@ function judgeCycle(cycle: Cycle, input: AutopilotInput): AutopilotEffect {
     // A second barren cycle on the same world means retrying is futile, not
     // unlucky — stop before spending the rest of the budget on it.
     if (barren && (state?.barren.includes(barren) ?? false)) {
-      return { do: "escalate", reason: "no-progress", rung: cycle.rung };
+      return stopIn(input, "no-progress", cycle.rung);
     }
     if (cycle.attempt >= (RUNG_BUDGET[cycle.rung] ?? 0)) {
-      return { do: "escalate", reason: "budget-spent", rung: cycle.rung };
+      return stopIn(input, "budget-spent", cycle.rung);
     }
     return { do: "retry", rung: cycle.rung, barren };
   };
@@ -360,7 +454,7 @@ function judgeCycle(cycle: Cycle, input: AutopilotInput): AutopilotEffect {
   // the cycle is better called inconclusive than successful.
   if (rung.do === "wait") {
     if (now - cycle.phaseSince > EVIDENCE_TIMEOUT_MS) {
-      return { do: "escalate", reason: "no-evidence", rung: cycle.rung };
+      return stopIn(input, "no-evidence", cycle.rung);
     }
     return { do: "wait", why: "awaiting-evidence" };
   }

--- a/src/components/RightPanel/GitPanel/AutopilotHistory.tsx
+++ b/src/components/RightPanel/GitPanel/AutopilotHistory.tsx
@@ -39,6 +39,11 @@ export function eventLabel(entry: AutopilotLogEntry): string {
       return "Didn't work — trying again";
     case "escalate":
       return entry.reason ? stuckLabel(entry.reason) : "Autopilot stopped";
+    case "revive":
+      // Phrased as what changed, not as a state flag: the user did something
+      // outside Fletch (committed, approved, settled a thread) and autopilot
+      // noticed. Saying so is the whole reason this row exists.
+      return "Picked it back up — what was blocking it changed";
   }
 }
 

--- a/src/components/RightPanel/GitPanel/AutopilotHistory.tsx
+++ b/src/components/RightPanel/GitPanel/AutopilotHistory.tsx
@@ -1,0 +1,101 @@
+import { useState } from "react";
+import { Icon } from "@/components/Icon";
+import type { DelegationKind } from "@/delegation";
+import { useAppStore } from "@/store";
+import type { AutopilotLogEntry } from "@/store/autopilotLog";
+import { checkoutKey } from "@/store/git";
+import { stuckLabel } from "./AutopilotChip";
+
+// ── What autopilot did on this checkout ───────────────────────────────────────
+// Directly under the chip, because the chip answers "what is it doing now?" and
+// the very next question a user has — especially about a loop that ran while they
+// were away — is "what did it already do, and what did that cost?". Collapsed by
+// default: it is a receipt, not a dashboard, and absent entirely until autopilot
+// has done something worth reading.
+
+/** The rung as a thing on the PR, not as an action name — a log row reads as
+ *  "what it was working on". Partial because an escalation can name a rung
+ *  autopilot doesn't drive (`needs-human` on a commit), and the raw kind is a
+ *  perfectly honest fallback for those. */
+const RUNG_NOUN: Partial<Record<DelegationKind, string>> = {
+  "fix-checks": "failing checks",
+  resolve: "conflicts",
+  "update-branch": "branch update",
+  "resolve-comments": "review comments",
+};
+
+const rungNoun = (kind: DelegationKind): string => RUNG_NOUN[kind] ?? kind;
+
+/** One row's phrasing, past tense — this already happened. Escalations reuse the
+ *  chip's `stuckLabel`, so the reason a user reads in the log is worded exactly
+ *  like the one that stopped the chip. */
+export function eventLabel(entry: AutopilotLogEntry): string {
+  switch (entry.outcome) {
+    case "dispatch":
+      return "Handed to the agent";
+    case "settle":
+      return "Worked";
+    case "retry":
+      return "Didn't work — trying again";
+    case "escalate":
+      return entry.reason ? stuckLabel(entry.reason) : "Autopilot stopped";
+  }
+}
+
+/** Clock time of the event. Formats the timestamp the driver recorded — the
+ *  entry's own `at` — rather than reading a clock here, so a row can't drift or
+ *  disagree with the moment it describes. */
+const clock = (at: number) =>
+  new Date(at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+
+export function AutopilotHistory({ agentId, subdir }: { agentId: string; subdir?: string }) {
+  const key = checkoutKey(agentId, subdir);
+  const log = useAppStore((s) => s.autopilotLog[key]);
+  const [open, setOpen] = useState(false);
+
+  // Nothing has happened yet: say nothing. An empty "history" affordance on every
+  // checkout would be noise in a footer that is already dense.
+  if (!log?.length) return null;
+
+  return (
+    <div className="ap-log">
+      <button
+        type="button"
+        className="ap-log-toggle text-xs"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        title="What autopilot has done on this checkout"
+      >
+        <Icon name={open ? "chevD" : "chevR"} />
+        <Icon name="history" />
+        <span>Autopilot history</span>
+        <span className="ap-log-count">{log.length}</span>
+      </button>
+
+      {open && (
+        // Newest first, as stored — the last thing it did is the thing being
+        // asked about.
+        <ol className="ap-log-list text-xs">
+          {log.map((entry) => (
+            <li
+              // The driver applies at most one effect per checkout per tick, so
+              // the stamp plus what happened identifies the row — and unlike the
+              // array index it survives the oldest entry being pruned.
+              key={`${entry.at}-${entry.outcome}-${entry.rung}`}
+              className={`ap-log-row o-${entry.outcome}`}
+            >
+              <span className="ap-log-time">{clock(entry.at)}</span>
+              <span className="ap-log-what">{eventLabel(entry)}</span>
+              {entry.rung && <span className="ap-log-rung">{rungNoun(entry.rung)}</span>}
+              {/* The attempt number is the budget being spent — the number that
+               *  explains why it eventually gave up. */}
+              {entry.attempt != null && entry.attempt > 1 && (
+                <span className="ap-attempt">#{entry.attempt}</span>
+              )}
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/src/components/RightPanel/GitPanel/GitPanel.css
+++ b/src/components/RightPanel/GitPanel/GitPanel.css
@@ -1146,3 +1146,71 @@
 .ap-off:hover {
   color: var(--fg-1);
 }
+
+/* ── Autopilot history ─────────────────────────────────────────────────────
+   The receipt for a loop that ran unattended, folded under the chip. Quiet and
+   collapsed: it earns attention only when someone comes looking for it, so the
+   toggle reads as a caption and only the rows that mean trouble take colour. */
+.ap-log {
+  padding: 4px 18px 0;
+}
+.ap-log-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 0;
+  border: 0;
+  background: transparent;
+  color: var(--fg-3);
+  cursor: pointer;
+}
+.ap-log-toggle:hover {
+  color: var(--fg-1);
+}
+.ap-log-toggle svg {
+  width: 11px;
+  height: 11px;
+}
+.ap-log-count {
+  padding: 0 4px;
+  border-radius: 999px;
+  background: var(--bg-1);
+  color: var(--fg-3);
+}
+/* Capped so a full log scrolls inside the footer instead of pushing the action
+   bar — the primary CTA must stay reachable. */
+.ap-log-list {
+  max-height: 132px;
+  margin: 3px 0 0;
+  padding: 0;
+  overflow-y: auto;
+  list-style: none;
+  border-left: 1px solid var(--bd-soft);
+}
+.ap-log-row {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 2px 0 2px 8px;
+  color: var(--fg-2);
+}
+.ap-log-time {
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+  color: var(--fg-3);
+}
+.ap-log-what {
+  flex: 1;
+  min-width: 0;
+}
+.ap-log-rung {
+  flex-shrink: 0;
+  color: var(--fg-3);
+}
+.ap-log-row.o-settle .ap-log-what {
+  color: var(--success);
+}
+/* The row that ended the loop — the one a returning user is looking for. */
+.ap-log-row.o-escalate .ap-log-what {
+  color: var(--warn);
+}

--- a/src/components/RightPanel/GitPanel/GitRepoSection.tsx
+++ b/src/components/RightPanel/GitPanel/GitRepoSection.tsx
@@ -5,6 +5,7 @@ import { useAppStore } from "@/store";
 import { checkoutKey } from "@/store/git";
 import { ActionBar } from "./ActionBar";
 import { AutopilotChip } from "./AutopilotChip";
+import { AutopilotHistory } from "./AutopilotHistory";
 import { ChangesList } from "./ChangesList";
 import { CommitComposer } from "./CommitComposer";
 import { ClosedPRCard, ConflictCard, PRCard } from "./cards";
@@ -190,6 +191,9 @@ export function GitRepoSection({
         )}
 
         <AutopilotChip agentId={agent.id} subdir={subdir} />
+        {/* The chip's own history, right below it — renders nothing until
+         *  autopilot has actually done something here. */}
+        <AutopilotHistory agentId={agent.id} subdir={subdir} />
 
         <ActionBar
           statusKind={primary.statusKind}

--- a/src/components/Sidebar/AgentRow.tsx
+++ b/src/components/Sidebar/AgentRow.tsx
@@ -14,6 +14,7 @@ import { formatAge } from "@/util/format";
 import { useMinuteClock } from "@/util/hooks";
 import { type AgentPr, useAgentPrs } from "@/util/prState";
 import { type AgentStats, AgentStatsPopover } from "./AgentStatsPopover";
+import { type AutopilotSignal, autopilotSignal, autopilotTip } from "./autopilotSignal";
 
 /** The agent rows carry nested buttons (stop/archive/discard), so they can't be
  *  a `<button>`; they use `role="button"` + this handler to stay keyboard
@@ -67,6 +68,14 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
   // an unknown or zero count renders nothing (never a fake 0).
   const behind = useAppStore((s) => maxBehind(s.gitMeta, agent.id));
   const unseen = useAppStore((s) => s.unseenResults[agent.id] ?? false);
+  // Autopilot across the agent's checkouts, rolled up to the one mark the row has
+  // room for (see autopilotSignal for the precedence). Until now enrollment was
+  // only visible after selecting the agent and opening the Git tab, so a fleet
+  // quietly working on itself looked identical to a fleet doing nothing. The map
+  // is selected whole — a stable reference, same as MissionControl's queue does —
+  // and the derivation runs outside the selector.
+  const autopilotStates = useAppStore((s) => s.autopilot);
+  const autopilot = autopilotSignal(autopilotStates, agent.id);
   // Dev-server state for this checkout — orthogonal to the agent's turn status,
   // so it shows as its own play chip beside the identity chip, not among the
   // activity cues (rail / loader / shimmer). Fed by the app-wide `run:state`
@@ -246,6 +255,7 @@ function RealRow({ agent, active, onClick }: RealRowProps) {
             {behind}
           </span>
         )}
+        <AutopilotMark signal={autopilot} />
         <span
           className="a-time"
           onMouseEnter={() => setStatsOpen(true)}
@@ -402,6 +412,27 @@ function ciTint(checks: PrChecks | null): { variant: BadgeVariant; tip: string }
     default:
       return { variant: "pr-open", tip: "" };
   }
+}
+
+/** Autopilot's mark on the row — advisory, so it decorates the sub-row it shares
+ *  with the stale/diff hints and never claims space of its own.
+ *
+ *  Only two of the five modes render at all. `working` explains motion the user
+ *  didn't start, and `stuck` is waiting on them; enrolled-and-idle is the normal
+ *  case, paused is a state they chose, and off is the default everywhere — a mark
+ *  for any of those would be noise on most rows and would train the eye to skip
+ *  the two that matter. The full state stays one click away in the Git panel. */
+function AutopilotMark({ signal }: { signal: AutopilotSignal | null }) {
+  if (!signal || (signal.mode !== "working" && signal.mode !== "stuck")) return null;
+  const tip = autopilotTip(signal);
+  return (
+    <span className={`a-autopilot ${signal.mode} tip`} data-tip={tip} aria-label={tip}>
+      <Icon name={signal.mode === "working" ? "refresh" : "wrench"} size={9} />
+      {/* The retry count only while it means something — a second or third try is
+       *  how close autopilot is to giving up, which mirrors the git-panel chip. */}
+      {signal.mode === "working" && signal.attempt != null && signal.attempt > 1 && signal.attempt}
+    </span>
+  );
 }
 
 function DiffStat({ stats }: { stats: ShortStats }) {

--- a/src/components/Sidebar/autopilotSignal.test.ts
+++ b/src/components/Sidebar/autopilotSignal.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import type { AutopilotState, StuckReason } from "@/autopilot";
+import { autopilotSignal, autopilotTip } from "./autopilotSignal";
+
+function state(over: Partial<AutopilotState> = {}): AutopilotState {
+  return {
+    enrolled: true,
+    paused: false,
+    cycle: null,
+    attempts: {},
+    barren: [],
+    stuck: null,
+    ...over,
+  };
+}
+
+const working = (attempt = 1) =>
+  state({
+    cycle: { rung: "fix-checks", attempt, signature: "s", phase: "working", phaseSince: 0 },
+  });
+
+const stuck = (reason: StuckReason) => state({ stuck: { reason, rung: "fix-checks", at: 1 } });
+
+describe("autopilotSignal", () => {
+  it("is absent when the agent has no enrolled checkout", () => {
+    expect(autopilotSignal({}, "a")).toBeNull();
+    expect(autopilotSignal({ a: state({ enrolled: false }) }, "a")).toBeNull();
+  });
+
+  it("reports an enrolled-but-quiet checkout as idle, not as nothing", () => {
+    expect(autopilotSignal({ a: state() }, "a")).toMatchObject({ mode: "idle", repo: null });
+  });
+
+  it("ignores other agents' checkouts, including id prefixes", () => {
+    const map = { b: working(), ab: working(), "ab::web": working() };
+    expect(autopilotSignal(map, "a")).toBeNull();
+  });
+
+  it("sees a secondary checkout's state and names the repo", () => {
+    expect(autopilotSignal({ "a::web": working() }, "a")).toMatchObject({
+      mode: "working",
+      repo: "web",
+    });
+  });
+
+  it("keeps the first `::` so a subdir containing the separator round-trips", () => {
+    expect(autopilotSignal({ "a::web::v2": working() }, "a")).toMatchObject({ repo: "web::v2" });
+  });
+
+  it("prefers stuck over working, whichever checkout it came from", () => {
+    expect(autopilotSignal({ a: working(), "a::web": stuck("budget-spent") }, "a")).toMatchObject({
+      mode: "stuck",
+      repo: "web",
+      reason: "budget-spent",
+    });
+    // ...and the other way round, so the answer can't be an artifact of key order.
+    expect(autopilotSignal({ "a::web": stuck("budget-spent"), a: working() }, "a")).toMatchObject({
+      mode: "stuck",
+      repo: "web",
+    });
+  });
+
+  it("prefers working over paused and idle", () => {
+    expect(
+      autopilotSignal({ a: state(), "a::api": state({ paused: true }), "a::web": working() }, "a"),
+    ).toMatchObject({ mode: "working", repo: "web" });
+  });
+
+  it("prefers paused over idle", () => {
+    expect(autopilotSignal({ a: state(), "a::web": state({ paused: true }) }, "a")).toMatchObject({
+      mode: "paused",
+      repo: "web",
+    });
+  });
+
+  it("keeps the first checkout on a tie, so the row doesn't flip between equals", () => {
+    expect(autopilotSignal({ "a::api": working(), "a::web": working() }, "a")).toMatchObject({
+      repo: "api",
+    });
+  });
+
+  it("carries the in-flight attempt count", () => {
+    expect(autopilotSignal({ a: working(3) }, "a")).toMatchObject({ mode: "working", attempt: 3 });
+  });
+});
+
+describe("autopilotTip", () => {
+  it("explains a stuck checkout with the same words as the git-panel chip", () => {
+    const tip = autopilotTip({
+      mode: "stuck",
+      repo: null,
+      attempt: null,
+      reason: "needs-human",
+    });
+    expect(tip).toBe("Autopilot stopped — this needs you");
+  });
+
+  it("names the repo so a multi-repo agent's mark isn't ambiguous", () => {
+    expect(autopilotTip({ mode: "working", repo: "web", attempt: 1, reason: null })).toBe(
+      "Autopilot working (web)",
+    );
+  });
+
+  it("mentions the attempt only once retrying means something", () => {
+    expect(autopilotTip({ mode: "working", repo: null, attempt: 1, reason: null })).toBe(
+      "Autopilot working",
+    );
+    expect(autopilotTip({ mode: "working", repo: null, attempt: 2, reason: null })).toBe(
+      "Autopilot working, attempt 2",
+    );
+  });
+});

--- a/src/components/Sidebar/autopilotSignal.test.ts
+++ b/src/components/Sidebar/autopilotSignal.test.ts
@@ -19,7 +19,8 @@ const working = (attempt = 1) =>
     cycle: { rung: "fix-checks", attempt, signature: "s", phase: "working", phaseSince: 0 },
   });
 
-const stuck = (reason: StuckReason) => state({ stuck: { reason, rung: "fix-checks", at: 1 } });
+const stuck = (reason: StuckReason) =>
+  state({ stuck: { reason, rung: "fix-checks", at: 1, blockers: "" } });
 
 describe("autopilotSignal", () => {
   it("is absent when the agent has no enrolled checkout", () => {

--- a/src/components/Sidebar/autopilotSignal.ts
+++ b/src/components/Sidebar/autopilotSignal.ts
@@ -1,0 +1,100 @@
+// ── Autopilot, rolled up to one sidebar row ──────────────────────────────────
+//
+// Autopilot is per CHECKOUT; the sidebar row is per AGENT. A multi-repo agent
+// therefore has several autopilot states behind one row, and the row has space
+// for exactly one mark — so this picks which of them the row speaks for.
+//
+// Kept pure and out of the component for the usual reason: the interesting part
+// is the choice, not the markup, and the choice is what a test can pin down.
+
+import type { AutopilotState, StuckReason } from "@/autopilot";
+// `stuckLabel` is imported rather than re-worded so the Git panel chip and this
+// row can never disagree about what happened to a checkout.
+import {
+  type ChipMode,
+  chipMode,
+  stuckLabel,
+} from "@/components/RightPanel/GitPanel/AutopilotChip";
+
+/** How much of the user's attention each mode has earned.
+ *
+ *  Ordered by "what would you want to know first if only one thing could be
+ *  shown": `stuck` outranks everything because it's the only mode waiting on a
+ *  person — a working sibling will resolve itself, an abandoned one won't.
+ *  `working` next: it explains motion the user didn't start. `paused` and `idle`
+ *  are states the user chose or expects, and `off` is the default everywhere, so
+ *  they rank low and (see the sidebar row) render nothing at all. */
+const ATTENTION: Record<ChipMode, number> = {
+  off: 0,
+  idle: 1,
+  paused: 2,
+  working: 3,
+  stuck: 4,
+};
+
+/** The one autopilot state a row speaks for, plus the context its tooltip needs. */
+export interface AutopilotSignal {
+  mode: Exclude<ChipMode, "off">;
+  /** The secondary repo this came from, or null for the agent's primary — so a
+   *  multi-repo agent's tooltip can say WHERE without the row growing a label. */
+  repo: string | null;
+  /** Retry number of the in-flight cycle, when there is one. */
+  attempt: number | null;
+  /** Why autopilot handed it back, when stuck. */
+  reason: StuckReason | null;
+}
+
+/** The most attention-worthy autopilot state across ALL of an agent's checkouts,
+ *  or null when none of them is enrolled.
+ *
+ *  Scans the primary key (`agentId`) plus every `agentId::subdir` secondary —
+ *  the same prefix scan `maxBehind` and `stuckCheckout` use, because a secondary
+ *  repo's autopilot is just as real as the primary's and would otherwise be
+ *  invisible outside the Git panel. Ties keep the first checkout scanned, so the
+ *  row doesn't flip between equally-loud siblings as the map's key order shifts. */
+export function autopilotSignal(
+  autopilot: Record<string, AutopilotState>,
+  agentId: string,
+): AutopilotSignal | null {
+  const prefix = `${agentId}::`;
+  let best: AutopilotSignal | null = null;
+  // Starting at `off`'s rank is what makes "nothing enrolled" return null: an
+  // off checkout can never outrank it, so it never becomes the answer. The
+  // explicit `off` test below says the same thing to the type checker.
+  let bestRank = ATTENTION.off;
+  for (const [key, state] of Object.entries(autopilot)) {
+    if (key !== agentId && !key.startsWith(prefix)) continue;
+    const mode = chipMode(state);
+    if (mode === "off" || ATTENTION[mode] <= bestRank) continue;
+    bestRank = ATTENTION[mode];
+    best = {
+      mode,
+      repo: key === agentId ? null : key.slice(prefix.length),
+      attempt: state.cycle?.attempt ?? null,
+      reason: state.stuck?.reason ?? null,
+    };
+  }
+  return best;
+}
+
+/** The hover line for the row's mark. Phrased as what autopilot is doing, since
+ *  the mark itself is a single glyph and can't say it. */
+export function autopilotTip(signal: AutopilotSignal): string {
+  const where = signal.repo ? ` (${signal.repo})` : "";
+  switch (signal.mode) {
+    case "stuck":
+      // `reason` is always set alongside a stuck mode; the fallback exists so a
+      // tooltip can never come out empty.
+      return `${signal.reason ? stuckLabel(signal.reason) : "Autopilot stopped"}${where}`;
+    case "working": {
+      // A second or third try is the part worth knowing — it's how close this is
+      // to giving up.
+      const attempt = signal.attempt && signal.attempt > 1 ? `, attempt ${signal.attempt}` : "";
+      return `Autopilot working${where}${attempt}`;
+    }
+    case "paused":
+      return `Autopilot paused${where}`;
+    default:
+      return `Autopilot on${where}`;
+  }
+}

--- a/src/components/Workspace/MissionControl/queue.test.ts
+++ b/src/components/Workspace/MissionControl/queue.test.ts
@@ -600,7 +600,7 @@ describe("buildReviewQueue", () => {
     cycle: null,
     attempts: {},
     barren: [],
-    stuck: { reason: "budget-spent", rung: "fix-checks", at: 1 },
+    stuck: { reason: "budget-spent", rung: "fix-checks", at: 1, blockers: "" },
     ...over,
   });
 
@@ -667,7 +667,9 @@ describe("buildReviewQueue", () => {
 
     const needsHuman = input({
       agents: [agent({ id: "a" })],
-      autopilot: { a: stuckState({ stuck: { reason: "needs-human", rung: null, at: 2 } }) },
+      autopilot: {
+        a: stuckState({ stuck: { reason: "needs-human", rung: null, at: 2, blockers: "" } }),
+      },
       dismissed,
     });
     expect(buildReviewQueue(needsHuman)).toHaveLength(1);

--- a/src/delegation.ts
+++ b/src/delegation.ts
@@ -13,22 +13,44 @@ import type { AgentStatus, GitState, PrChecks, PrState } from "@/api";
 // named for the problem instead, so a future non-git remediation slots in
 // without renaming the machinery around it.
 
-/** One unit of work handed to the coding agent. The agent runs local mutations
- *  (commit, merge, conflict resolution) as plain in-sandbox git, and the
- *  credentialed remote actions through the app's file RPC (`open_pr` /
- *  `git_push` / `git_fetch`). The `agent:git-action` signal that confirms a
- *  local mutation arrives via the clone's `post-commit` / `post-merge` hooks
- *  (see `actionProvesKind`). */
-export type DelegationKind =
-  | "commit"
-  | "commit-push"
-  | "commit-pr"
-  | "open-pr"
-  | "push"
-  | "resolve"
-  | "update-branch"
-  | "fix-checks"
-  | "resolve-comments";
+/** Every unit of work that can be handed to the coding agent. The agent runs
+ *  local mutations (commit, merge, conflict resolution) as plain in-sandbox git,
+ *  and the credentialed remote actions through the app's file RPC (`open_pr` /
+ *  `git_push` / `git_fetch` / `reply_thread`). The `agent:git-action` signal that
+ *  confirms a local mutation arrives via the clone's `post-commit` /
+ *  `post-merge` hooks (see `actionProvesKind`).
+ *
+ *  Declared as a value, with the type derived from it, so tests that claim to
+ *  cover "every kind" actually do: a hand-maintained list beside a union
+ *  silently drifts, and the copy test had already fallen two kinds behind
+ *  (`push`, `resolve-comments`) without failing. Mirrors `COMMIT_ACTIONS` in
+ *  primaryActions.ts. */
+export const DELEGATION_KINDS = [
+  "commit",
+  "commit-push",
+  "commit-pr",
+  "open-pr",
+  "push",
+  "resolve",
+  "update-branch",
+  "fix-checks",
+  "resolve-comments",
+] as const;
+
+export type DelegationKind = (typeof DELEGATION_KINDS)[number];
+
+/** Kinds whose completion cannot be observed in git/PR state: CI takes minutes,
+ *  and GitHub reports thread resolution on its own schedule. `delegationResolved`
+ *  therefore never returns true for them, which means a settled agent is their
+ *  NORMAL ending rather than an abandonment — so the watcher must report success
+ *  and let the polling carry the story, not "review the chat for details".
+ *
+ *  Both places that care read this predicate instead of naming kinds, because
+ *  they had already drifted apart: the give-up notice special-cased `fix-checks`
+ *  only, so a finished `resolve-comments` told the user it had given up. */
+export function settlesOnIdle(kind: DelegationKind): boolean {
+  return kind === "fix-checks" || kind === "resolve-comments";
+}
 
 export interface Delegation {
   kind: DelegationKind;
@@ -250,11 +272,10 @@ export function delegationResolved(
       if (checks) return !["behind", "dirty", "unknown"].includes(checks.merge_state);
       return pr?.mergeable === "mergeable";
     case "fix-checks":
-      return false;
     case "resolve-comments":
-      // Threads only clear once GitHub reports them resolved, which the slow
-      // comments poll picks up. Like fix-checks, the caller resolves this on
-      // agent-idle and lets the polling carry the story.
+      // Not observable here — see `settlesOnIdle`, which both this and the
+      // watcher's give-up notice read so they can't disagree about which kinds
+      // end on idle.
       return false;
   }
 }

--- a/src/helpers/agentLookups.ts
+++ b/src/helpers/agentLookups.ts
@@ -69,6 +69,10 @@ export function dropAgentEntries(state: AppState, id: string): Partial<AppState>
   const delegationNotices = dropScopedEntries(state.delegationNotices, id);
   const autopilot = dropScopedEntries(state.autopilot, id);
   const autopilotVerdicts = dropScopedEntries(state.autopilotVerdicts, id);
+  // The activity log goes with the agent it describes: once the row is gone
+  // there is no surface left to read it from, and the durable record of what
+  // autopilot did is the transcript and the PR, not this.
+  const autopilotLog = dropScopedEntries(state.autopilotLog, id);
   const { [id]: _short, ...gitShortstats } = state.gitShortstats;
   const { [id]: _seed, ...composerSeeds } = state.composerSeeds;
   const { [id]: _draft, ...composerDrafts } = state.composerDrafts;
@@ -97,6 +101,7 @@ export function dropAgentEntries(state: AppState, id: string): Partial<AppState>
     delegationNotices,
     autopilot,
     autopilotVerdicts,
+    autopilotLog,
     unseenResults,
     rightPanelTabs,
   };

--- a/src/store/autopilot.test.ts
+++ b/src/store/autopilot.test.ts
@@ -67,7 +67,9 @@ describe("enrollment", () => {
     const store = makeStore();
     store.getState().enrollAutopilot("a1");
     store.getState().retryAutopilotCycle("a1", "fix-checks", "sig");
-    store.getState().markAutopilotStuck("a1", "budget-spent", "fix-checks", 5);
+    store
+      .getState()
+      .markAutopilotStuck("a1", "budget-spent", "fix-checks", 5, "checks-failing:test");
     expect(store.getState().autopilot.a1.stuck).not.toBeNull();
 
     store.getState().resumeAutopilot("a1");
@@ -92,7 +94,7 @@ describe("enrollment", () => {
     // not resurrect an entry.
     const store = makeStore();
     store.getState().openAutopilotCycle("ghost", "fix-checks", "sig");
-    store.getState().markAutopilotStuck("ghost", "no-progress", null, 1);
+    store.getState().markAutopilotStuck("ghost", "no-progress", null, 1, "");
     expect(store.getState().autopilot.ghost).toBeUndefined();
   });
 });

--- a/src/store/autopilot.test.ts
+++ b/src/store/autopilot.test.ts
@@ -79,6 +79,28 @@ describe("enrollment", () => {
     expect(s.barren).toEqual([]);
   });
 
+  it("reviving grants a fresh budget but REMEMBERS what it already failed at", () => {
+    // Revive is autopilot noticing the world moved, not the user insisting — so
+    // unlike `resumeAutopilot` it keeps `barren`. Without that, a checkout whose
+    // world oscillates (a flaky check flipping back and forth) would get a full
+    // budget on every flip and burn agent turns re-attempting a world it has
+    // already proven it cannot change.
+    const store = makeStore();
+    store.getState().enrollAutopilot("a1");
+    store.getState().retryAutopilotCycle("a1", "fix-checks", "dead-world");
+    store.getState().markAutopilotStuck("a1", "budget-spent", "fix-checks", 5, "checks-failing:x");
+
+    store.getState().reviveAutopilot("a1");
+
+    const s = store.getState().autopilot.a1;
+    expect(s.stuck).toBeNull();
+    expect(s.attempts).toEqual({});
+    expect(s.barren).toEqual(["dead-world"]);
+    // A human insisting DOES clear it — that is the difference between the two.
+    store.getState().resumeAutopilot("a1");
+    expect(store.getState().autopilot.a1.barren).toEqual([]);
+  });
+
   it("unenrolling forgets the checkout entirely", () => {
     const store = makeStore();
     store.getState().enrollAutopilot("a1");

--- a/src/store/autopilot.ts
+++ b/src/store/autopilot.ts
@@ -57,13 +57,23 @@ export interface AutopilotSlice {
   /** The cycle failed with budget left: clear it, count the attempt, and record
    *  a barren signature when the world didn't move. */
   retryAutopilotCycle: (key: string, rung: DelegationKind, barren: string | null) => void;
-  /** Hand the checkout back to the human. */
+  /** Hand the checkout back to the user. `blockers` is the situation that
+   *  stopped it, so `autopilotStep` can tell when that situation has passed. */
   markAutopilotStuck: (
     key: string,
     reason: StuckReason,
     rung: DelegationKind | null,
     now: number,
+    blockers: string,
   ) => void;
+  /** The situation that stopped it has changed — start looking again.
+   *
+   *  Distinct from `resumeAutopilot`: this is autopilot noticing the world moved,
+   *  not the user insisting. It grants a fresh budget (a new situation deserves
+   *  its own attempts) but KEEPS `barren`, so a world autopilot has already
+   *  proven it cannot change stays refused even if the checkout oscillates back
+   *  to it. A human saying "try again" clears barren too. */
+  reviveAutopilot: (key: string) => void;
   /** Store the local verification that will judge this cycle. */
   recordAutopilotVerdict: (key: string, report: VerificationReport) => void;
 }
@@ -191,8 +201,11 @@ export const createAutopilotSlice: SliceCreator<AutopilotSlice> = (set) => ({
       barren: barren && !s.barren.includes(barren) ? [...s.barren, barren] : s.barren,
     })),
 
-  markAutopilotStuck: (key, reason, rung, now) =>
-    patch(set, key, (s) => ({ ...s, cycle: null, stuck: { reason, rung, at: now } })),
+  markAutopilotStuck: (key, reason, rung, now, blockers) =>
+    patch(set, key, (s) => ({ ...s, cycle: null, stuck: { reason, rung, at: now, blockers } })),
+
+  reviveAutopilot: (key) =>
+    patch(set, key, (s) => ({ ...s, stuck: null, cycle: null, attempts: {} })),
 
   recordAutopilotVerdict: (key, report) =>
     set((s) => ({ autopilotVerdicts: { ...s.autopilotVerdicts, [key]: report } })),

--- a/src/store/autopilotLog.test.ts
+++ b/src/store/autopilotLog.test.ts
@@ -1,0 +1,182 @@
+// The audit trail: that events are kept in the order a user reads them, that the
+// log is bounded, and that a checkout's history can't be confused with another's.
+// The point of the feature is being trustworthy about work nobody watched, so the
+// invariants worth testing are "nothing is lost that matters" and "nothing grows
+// without limit".
+
+import { describe, expect, it, vi } from "vitest";
+import { create } from "zustand";
+
+// `vi.mock` is hoisted above the module body, so the spy has to be too. Nothing
+// here should persist; the assertion at the bottom is what enforces that.
+const { setSetting } = vi.hoisted(() => ({ setSetting: vi.fn() }));
+vi.mock("@/storage/settings", () => ({ setSetting }));
+
+import { dropAgentEntries } from "@/helpers/agentLookups";
+import {
+  AUTOPILOT_LOG_LIMIT,
+  type AutopilotLogEntry,
+  createAutopilotLogSlice,
+} from "./autopilotLog";
+import type { AppState } from "./types";
+
+const makeStore = () =>
+  create<AppState>()((...a) => ({ ...createAutopilotLogSlice(...a) }) as AppState);
+
+const entry = (over: Partial<AutopilotLogEntry> = {}): AutopilotLogEntry => ({
+  at: 1_000,
+  outcome: "dispatch",
+  rung: "fix-checks",
+  ...over,
+});
+
+describe("recording what autopilot did", () => {
+  it("starts empty — a checkout with no history has no log", () => {
+    expect(makeStore().getState().autopilotLog).toEqual({});
+  });
+
+  it("keeps the newest event first, which is the order the panel reads", () => {
+    const store = makeStore();
+    store.getState().recordAutopilotEvent("a1", entry({ at: 1 }));
+    store.getState().recordAutopilotEvent("a1", entry({ at: 2 }));
+    store.getState().recordAutopilotEvent("a1", entry({ at: 3 }));
+
+    expect(store.getState().autopilotLog.a1.map((e) => e.at)).toEqual([3, 2, 1]);
+  });
+
+  it("records the rung, the attempt and the escalation reason verbatim", () => {
+    // These four fields ARE the audit: what it worked on, which try, and why it
+    // handed back. An entry that loses any of them can't answer the question a
+    // user opens the log with.
+    const store = makeStore();
+    store.getState().recordAutopilotEvent(
+      "a1",
+      entry({
+        at: 7,
+        outcome: "escalate",
+        rung: "resolve-comments",
+        attempt: 2,
+        reason: "no-progress",
+      }),
+    );
+
+    expect(store.getState().autopilotLog.a1[0]).toEqual({
+      at: 7,
+      outcome: "escalate",
+      rung: "resolve-comments",
+      attempt: 2,
+      reason: "no-progress",
+    });
+  });
+
+  it("takes its timestamp from the caller, never from a clock of its own", () => {
+    // Same convention as autopilot.ts / readiness.ts: the driver already holds
+    // the `now` it decided with, and a second clock read would misdate the event.
+    const store = makeStore();
+    vi.useFakeTimers();
+    vi.setSystemTime(9_999_999);
+    store.getState().recordAutopilotEvent("a1", entry({ at: 42 }));
+    vi.useRealTimers();
+
+    expect(store.getState().autopilotLog.a1[0].at).toBe(42);
+  });
+
+  it("never rewrites a recorded entry — the log is append-only", () => {
+    const store = makeStore();
+    const first = entry({ at: 1, outcome: "dispatch" });
+    store.getState().recordAutopilotEvent("a1", first);
+    const snapshot = store.getState().autopilotLog.a1[0];
+    store.getState().recordAutopilotEvent("a1", entry({ at: 2, outcome: "settle" }));
+
+    expect(store.getState().autopilotLog.a1.at(-1)).toBe(snapshot);
+    expect(store.getState().autopilotLog.a1.at(-1)).toEqual(first);
+  });
+
+  it("records an event even for a checkout that is no longer enrolled", () => {
+    // Unlike the cycle transitions (which ignore absent enrollments), the log has
+    // no enrollment to check: an event that already happened must survive the
+    // unenroll that raced it, or the record would be a lie of omission.
+    const store = makeStore();
+    store.getState().recordAutopilotEvent("never-enrolled", entry());
+    expect(store.getState().autopilotLog["never-enrolled"]).toHaveLength(1);
+  });
+
+  it("does not persist — nothing is written to settings", () => {
+    // Cycles aren't persisted either: a restart drops the machinery and re-derives
+    // from the world, so a surviving log would describe loops the app can no
+    // longer reason about.
+    const store = makeStore();
+    store.getState().recordAutopilotEvent("a1", entry());
+    expect(setSetting).not.toHaveBeenCalled();
+  });
+});
+
+describe("the log is bounded", () => {
+  it(`keeps at most ${AUTOPILOT_LOG_LIMIT} entries, dropping the oldest`, () => {
+    const store = makeStore();
+    const total = AUTOPILOT_LOG_LIMIT + 5;
+    for (let i = 1; i <= total; i++) store.getState().recordAutopilotEvent("a1", entry({ at: i }));
+
+    const log = store.getState().autopilotLog.a1;
+    expect(log).toHaveLength(AUTOPILOT_LOG_LIMIT);
+    // Newest kept, oldest gone — a long session can't grow this without limit.
+    expect(log[0].at).toBe(total);
+    expect(log.at(-1)?.at).toBe(total - AUTOPILOT_LOG_LIMIT + 1);
+    expect(log.some((e) => e.at === 1)).toBe(false);
+  });
+
+  it("bounds each checkout separately", () => {
+    // A busy primary repo must not evict a secondary checkout's history.
+    const store = makeStore();
+    for (let i = 0; i < AUTOPILOT_LOG_LIMIT * 2; i++) {
+      store.getState().recordAutopilotEvent("a1", entry({ at: i }));
+    }
+    store.getState().recordAutopilotEvent("a1::web", entry({ at: 500 }));
+
+    expect(store.getState().autopilotLog.a1).toHaveLength(AUTOPILOT_LOG_LIMIT);
+    expect(store.getState().autopilotLog["a1::web"]).toHaveLength(1);
+  });
+});
+
+describe("dropped with the agent", () => {
+  it("prunes both the plain and the `id::subdir` keys, and only that agent's", () => {
+    // Checkout-scoped like every other autopilot map, so archiving a multi-repo
+    // agent must not leave its secondary checkouts' logs behind.
+    const store = makeStore();
+    store.getState().recordAutopilotEvent("a1", entry());
+    store.getState().recordAutopilotEvent("a1::web", entry());
+    store.getState().recordAutopilotEvent("a2", entry());
+
+    const patch = dropAgentEntries(
+      // biome-ignore lint/suspicious/noExplicitAny: partial state fixture
+      { ...EMPTY_MAPS, autopilotLog: store.getState().autopilotLog } as any,
+      "a1",
+    );
+
+    expect(Object.keys(patch.autopilotLog ?? {})).toEqual(["a2"]);
+  });
+});
+
+// dropAgentEntries destructures every per-agent side map, so they must exist.
+const EMPTY_MAPS = {
+  managedLogs: {},
+  transcriptLoading: {},
+  transcriptLoaded: {},
+  managedBusy: {},
+  turnStartedAt: {},
+  usage: {},
+  gitStates: {},
+  prStates: {},
+  prChecks: {},
+  prComments: {},
+  gitShortstats: {},
+  composerSeeds: {},
+  composerDrafts: {},
+  delegations: {},
+  delegationNotices: {},
+  autopilot: {},
+  autopilotVerdicts: {},
+  autopilotLog: {},
+  unseenResults: {},
+  rightPanelTabs: {},
+};

--- a/src/store/autopilotLog.ts
+++ b/src/store/autopilotLog.ts
@@ -1,0 +1,94 @@
+// What autopilot actually did, per checkout — the audit trail for a loop whose
+// whole premise is acting while nobody is watching.
+//
+// The other autopilot maps hold only the present tick: `autopilot` is the live
+// state, `autopilotVerdicts` the evidence for the cycle in flight. Both are
+// overwritten as the loop moves, so returning to a PR autopilot touched three
+// times leaves nothing to read but the agent's chat transcript. A user who can't
+// see what was spent on their behalf can't trust the feature, so the driver
+// records each decisive effect here as it applies it.
+//
+// NOT persisted, deliberately — same reasoning as cycles (see the header of
+// store/autopilot.ts). A restart drops the cycle machinery and re-derives from
+// the live world; a log that outlived it would be the only surviving trace of
+// loops the app can no longer reason about, describing agents that may since have
+// been archived. What survives a restart is the durable record: the agent's
+// transcript and the PR itself.
+
+import type { AutopilotEffect, StuckReason } from "@/autopilot";
+import type { DelegationKind } from "@/delegation";
+import type { SliceCreator } from "./types";
+
+/** Entries kept per checkout. Sized to hold one complete ladder exhaustion — the
+ *  full story behind a single `stuck`: the four rungs' budgets sum to 9 cycles
+ *  (`RUNG_BUDGET`), each writing a dispatch plus its outcome, so 18 entries cover
+ *  everything autopilot can do between a human's "go" and its handing back, with
+ *  slack for the escalation itself. Beyond that the oldest rows are answering a
+ *  question nobody is asking, and an unbounded array in a day-long session is
+ *  just a leak. */
+export const AUTOPILOT_LOG_LIMIT = 20;
+
+/** The effects worth remembering: the ones that spend an agent turn or change
+ *  what autopilot will do next. Derived from `AutopilotEffect` so the driver can
+ *  pass `effect.do` straight through, and so a new effect can't silently go
+ *  unlogged — the `Extract` stops compiling if one of these is renamed.
+ *
+ *  `wait` is excluded because it is most ticks (every 10s, on every enrolled
+ *  checkout): logging it would bury the four events that matter and burn the
+ *  bound. `verify` / `await-evidence` are excluded as steps *within* a cycle —
+ *  the cycle's own outcome already says how it went. */
+export type AutopilotOutcome = Extract<
+  AutopilotEffect["do"],
+  "dispatch" | "settle" | "retry" | "escalate"
+>;
+
+/** One thing autopilot did, in the terms a user would ask about it: what
+ *  happened, to which rung, on which try, and — when it gave up — why.
+ *
+ *  Field names and nullability mirror `AutopilotEffect` so the driver's effect
+ *  switch can hand its own values over unchanged. */
+export interface AutopilotLogEntry {
+  /** Epoch ms, PASSED IN by the caller. Nothing in this module reads a clock:
+   *  the driver already has the `now` it made the decision with, and an entry
+   *  stamped with a second, later clock read would misdate the event it
+   *  describes. Same convention as `autopilot.ts` / `readiness.ts`. */
+  at: number;
+  outcome: AutopilotOutcome;
+  /** The rung concerned. Null only for an escalation the ladder raised before
+   *  settling on a rung. */
+  rung: DelegationKind | null;
+  /** 1-based cycle attempt, when the event belongs to a cycle. */
+  attempt?: number;
+  /** Why autopilot handed the checkout back. Only ever set on an `escalate`. */
+  reason?: StuckReason;
+}
+
+export interface AutopilotLogSlice {
+  /** Per-checkout activity log, keyed by `checkoutKey` (see store/git.ts) —
+   *  the same scope as `autopilot` itself, so a multi-repo agent's secondary
+   *  checkout keeps its own history rather than sharing the primary's.
+   *
+   *  Newest first: that is the order the panel reads them in, and it makes
+   *  pruning the oldest a single tail slice. */
+  autopilotLog: Record<string, AutopilotLogEntry[]>;
+
+  /** Append one event for a checkout, dropping the oldest beyond
+   *  `AUTOPILOT_LOG_LIMIT`. Append-only by design — nothing edits or reorders a
+   *  recorded entry, so what the user reads is what happened. */
+  recordAutopilotEvent: (key: string, entry: AutopilotLogEntry) => void;
+}
+
+export const createAutopilotLogSlice: SliceCreator<AutopilotLogSlice> = (set) => ({
+  autopilotLog: {},
+
+  recordAutopilotEvent: (key, entry) =>
+    set((s) => ({
+      autopilotLog: {
+        ...s.autopilotLog,
+        // Unlike the other autopilot actions, this one does NOT require an
+        // existing entry: the log is the record of what happened, so an event
+        // must survive the unenroll that raced it.
+        [key]: [entry, ...(s.autopilotLog[key] ?? [])].slice(0, AUTOPILOT_LOG_LIMIT),
+      },
+    })),
+});

--- a/src/store/autopilotLog.ts
+++ b/src/store/autopilotLog.ts
@@ -39,7 +39,7 @@ export const AUTOPILOT_LOG_LIMIT = 20;
  *  the cycle's own outcome already says how it went. */
 export type AutopilotOutcome = Extract<
   AutopilotEffect["do"],
-  "dispatch" | "settle" | "retry" | "escalate"
+  "dispatch" | "settle" | "retry" | "escalate" | "revive"
 >;
 
 /** One thing autopilot did, in the terms a user would ask about it: what

--- a/src/store/autopilotSync.test.ts
+++ b/src/store/autopilotSync.test.ts
@@ -1,0 +1,322 @@
+// The autopilot POLICY is pure and exhaustively covered in `autopilot.test.ts`.
+// What is left is the wiring — the store transitions, the delegation the effect
+// turns into, and the two guards that only exist in the pass itself:
+//
+//   1. One dispatch per agent per pass. `delegateAction` sends the agent a
+//      message, but the status flip to `running` comes back asynchronously from
+//      the backend, so both checkouts of a multi-repo agent see an `idle` agent
+//      inside a single pass. Both dispatching coalesces two triggers into one
+//      turn — what `queued` exists to prevent — and `delegationInFlight` can't
+//      see it because it is keyed per checkout.
+//   2. One verification per checkout in flight. A verify outlives a pass, and a
+//      dependency change re-runs `usePoll`'s effect (whose own `inFlight` flag is
+//      fresh), so a slow verify can be re-entered; the caller's `verifying` set
+//      is what survives that.
+//
+// `autopilotPass` is the whole sweep, so both are testable without a rendered
+// hook — the same reason `planDelegationPass` is exported.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "zustand";
+import type { AgentStatus, GitState, PrChecks, PrState, VerificationReport } from "@/api";
+import type { AutopilotState, Cycle } from "@/autopilot";
+import { newEnrollment } from "@/autopilot";
+
+const { runVerification } = vi.hoisted(() => ({ runVerification: vi.fn() }));
+vi.mock("@/api", () => ({ api: { runVerification } }));
+vi.mock("@/storage/settings", () => ({ setSetting: vi.fn() }));
+
+// The pass reads `useAppStore.getState()` on every key, so the mock has to
+// forward to whatever store the current test built.
+const held = vi.hoisted(() => ({ store: null as { getState: () => unknown } | null }));
+vi.mock("@/store", () => ({
+  useAppStore: {
+    getState: () => held.store?.getState(),
+  },
+}));
+
+import { createAutopilotSlice } from "./autopilot";
+import { autopilotPass } from "./autopilotSync";
+import { checkoutKey, createGitSlice } from "./git";
+import type { AppState } from "./types";
+
+const git = (over: Partial<GitState> = {}): GitState => ({
+  branch: "feat",
+  parent_branch: "main",
+  ahead: 1,
+  behind: 0,
+  unpushed: 0,
+  files: [],
+  additions: 0,
+  deletions: 0,
+  has_origin: true,
+  head_sha: "sha1",
+  ...over,
+});
+const pr = (over: Partial<PrState> = {}): PrState => ({
+  number: 7,
+  url: "https://x",
+  state: "open",
+  title: "t",
+  mergeable: "mergeable",
+  ...over,
+});
+const checks = (over: Partial<PrChecks> = {}): PrChecks => ({
+  merge_state: "blocked",
+  rollup: "failing",
+  total: 1,
+  passed: 0,
+  failed: 1,
+  pending: 0,
+  required_failing: ["test"],
+  runs: [],
+  ...over,
+});
+const passing: VerificationReport = {
+  checks: [{ name: "test", command: "run test", outcome: "passed", duration_ms: 1, tail: [] }],
+};
+
+const state = (over: Partial<AutopilotState> = {}): AutopilotState => ({
+  ...newEnrollment(),
+  ...over,
+});
+const cycle = (over: Partial<Cycle> = {}): Cycle => ({
+  rung: "fix-checks",
+  attempt: 1,
+  signature: "sha1|test||",
+  phase: "working",
+  phaseSince: 0,
+  ...over,
+});
+
+/** The trigger a `fix-checks` dispatch sends, as `appActionMessage` builds it. */
+const TRIGGER = '[app-action] fix-checks failing="test"';
+
+interface Fixture {
+  /** Enrolled checkouts, by `checkoutKey`. Their readiness is seeded to the one
+   *  world autopilot acts on: an open PR whose required check is failing. */
+  autopilot: Record<string, AutopilotState>;
+  /** Live agents and their status. A key absent here is an agent that's gone. */
+  agents: Record<string, AgentStatus>;
+}
+
+function makeStore({ autopilot, agents }: Fixture) {
+  const sendUserMessage = vi.fn();
+  const store = create<AppState>()(
+    (...a) =>
+      ({
+        ...createGitSlice(...a),
+        ...createAutopilotSlice(...a),
+      }) as AppState,
+  );
+  const per = <T>(value: T) => Object.fromEntries(Object.keys(autopilot).map((k) => [k, value]));
+  store.setState({
+    sendUserMessage,
+    workspace: {
+      agents: Object.entries(agents).map(([id, status]) => ({ id, status })),
+      // biome-ignore lint/suspicious/noExplicitAny: minimal workspace fixture
+    } as any,
+    autopilot,
+    gitStates: per(git()),
+    prStates: per(pr()),
+    prChecks: per(checks()),
+    prComments: per({ unresolved: [] }),
+    // biome-ignore lint/suspicious/noExplicitAny: partial store seed
+  } as any);
+  held.store = store;
+  return { store, sendUserMessage };
+}
+
+const key = { primary: checkoutKey("a1"), web: checkoutKey("a1", "web") };
+
+beforeEach(() => {
+  runVerification.mockReset();
+  runVerification.mockResolvedValue(passing);
+});
+
+describe("autopilotPass dispatches at most once per agent per pass", () => {
+  it("hands a rung to only ONE checkout of a multi-repo agent", async () => {
+    // Both checkouts are enrolled, both blocked on failing checks, and the agent
+    // reads `idle` for both because the status flip from the first dispatch
+    // hasn't come back yet. Dispatching both would coalesce the triggers.
+    const { store, sendUserMessage } = makeStore({
+      autopilot: { [key.primary]: state(), [key.web]: state() },
+      agents: { a1: "idle" },
+    });
+
+    await autopilotPass([key.primary, key.web], new Set());
+
+    expect(Object.keys(store.getState().delegations)).toEqual([key.primary]);
+    expect(sendUserMessage).toHaveBeenCalledExactlyOnceWith("a1", TRIGGER);
+    // The loser is left completely untouched — no cycle was opened for it, so
+    // the next tick re-derives it against a world that now shows a busy agent.
+    expect(store.getState().autopilot[key.primary].cycle).not.toBeNull();
+    expect(store.getState().autopilot[key.web].cycle).toBeNull();
+  });
+
+  it("still dispatches concurrently for different agents", async () => {
+    // The guard is per agent, not global: two agents can each take a turn.
+    const { store, sendUserMessage } = makeStore({
+      autopilot: { a1: state(), a2: state() },
+      agents: { a1: "idle", a2: "idle" },
+    });
+
+    await autopilotPass(["a1", "a2"], new Set());
+
+    expect(Object.keys(store.getState().delegations).sort()).toEqual(["a1", "a2"]);
+    expect(sendUserMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("lets the loser dispatch on the NEXT pass, once its sibling turn is done", async () => {
+    // The set is per pass, so nothing is remembered: the deferral costs one tick,
+    // it doesn't blacklist the checkout.
+    const { store, sendUserMessage } = makeStore({
+      autopilot: { [key.primary]: state(), [key.web]: state() },
+      agents: { a1: "idle" },
+    });
+
+    await autopilotPass([key.primary, key.web], new Set());
+    // That turn landed: the primary's checks are green, its cycle settled and its
+    // delegation was cleared — so this pass has nothing for the primary, and the
+    // sibling deferred a tick ago takes its turn.
+    store.getState().clearDelegation(key.primary);
+    store.setState({
+      autopilot: { ...store.getState().autopilot, [key.primary]: state() },
+      prChecks: {
+        ...store.getState().prChecks,
+        [key.primary]: checks({
+          merge_state: "clean",
+          rollup: "passing",
+          passed: 1,
+          failed: 0,
+          required_failing: [],
+        }),
+      },
+    });
+    await autopilotPass([key.primary, key.web], new Set());
+
+    expect(store.getState().autopilot[key.web].cycle).not.toBeNull();
+    expect(sendUserMessage).toHaveBeenLastCalledWith(
+      "a1",
+      '[app-action] fix-checks failing="test" repo="web"',
+    );
+  });
+});
+
+describe("autopilotPass applies a dispatch", () => {
+  it("opens the cycle AND sends the delegation, so the turn is tracked", async () => {
+    const { store, sendUserMessage } = makeStore({
+      autopilot: { [key.primary]: state() },
+      agents: { a1: "idle" },
+    });
+
+    await autopilotPass([key.primary], new Set());
+
+    // The cycle records the rung and the world it started from, which is what
+    // makes a barren retry detectable.
+    expect(store.getState().autopilot[key.primary].cycle).toEqual({
+      rung: "fix-checks",
+      attempt: 1,
+      signature: "sha1|test||",
+      phase: "working",
+      phaseSince: 0,
+    });
+    // Without the delegation nothing would ever advance the cycle out of
+    // `working` — the driver depends on the delegation layer's lifecycle.
+    expect(store.getState().delegations[key.primary].kind).toBe("fix-checks");
+    expect(sendUserMessage).toHaveBeenCalledExactlyOnceWith("a1", TRIGGER);
+  });
+
+  it("scopes a secondary checkout's trigger to its repo", async () => {
+    // Without `repo=`, the agent would run the fix in the primary repo — the
+    // wrong checkout entirely.
+    const { store, sendUserMessage } = makeStore({
+      autopilot: { [key.web]: state() },
+      agents: { a1: "idle" },
+    });
+
+    await autopilotPass([key.web], new Set());
+
+    expect(sendUserMessage).toHaveBeenCalledExactlyOnceWith(
+      "a1",
+      '[app-action] fix-checks failing="test" repo="web"',
+    );
+    expect(store.getState().delegations[key.web].subdir).toBe("web");
+  });
+});
+
+describe("autopilotPass applies a verification", () => {
+  /** A cycle mid-turn on a `fix-checks` rung, with the agent now settled — the
+   *  one shape that produces a `verify` effect. */
+  const working: Fixture = {
+    autopilot: { [key.primary]: state({ cycle: cycle() }) },
+    agents: { a1: "idle" },
+  };
+
+  it("enters awaiting-evidence and records the verdict for this cycle", async () => {
+    const { store } = makeStore(working);
+
+    await autopilotPass([key.primary], new Set());
+
+    const advanced = store.getState().autopilot[key.primary].cycle;
+    expect(advanced?.phase).toBe("awaiting-evidence");
+    // The phase clock has to start, or the evidence timeout never fires.
+    expect(advanced?.phaseSince).toBeGreaterThan(0);
+    expect(runVerification).toHaveBeenCalledExactlyOnceWith("a1", undefined);
+    expect(store.getState().autopilotVerdicts[key.primary]).toEqual(passing);
+  });
+
+  it("does not let a verification that COULDN'T run look like a fix that didn't work", async () => {
+    // A crashed verifier says nothing about the code. The phase must still
+    // advance (so the cycle is judged on CI, bounded by the evidence timeout)
+    // and no verdict may be recorded, because a recorded failure would burn a
+    // budget slot on a cycle that was possibly fine.
+    runVerification.mockRejectedValue(new Error("no verify command"));
+    const { store } = makeStore(working);
+    const verifying = new Set<string>();
+
+    await autopilotPass([key.primary], verifying);
+
+    expect(store.getState().autopilot[key.primary].cycle?.phase).toBe("awaiting-evidence");
+    expect(store.getState().autopilotVerdicts).toEqual({});
+    // And the in-flight marker is released, or the checkout could never be
+    // verified again.
+    expect(verifying.size).toBe(0);
+  });
+
+  it("issues only one verification per checkout while one is in flight", async () => {
+    // Two overlapping passes: `usePoll` guards re-entry per mounted effect, but a
+    // dependency change starts a fresh effect while a slow verify is still out.
+    let release!: (r: VerificationReport) => void;
+    runVerification.mockReturnValueOnce(
+      new Promise<VerificationReport>((r) => {
+        release = r;
+      }),
+    );
+    const { store } = makeStore(working);
+    const verifying = new Set<string>();
+
+    const first = autopilotPass([key.primary], verifying);
+    await autopilotPass([key.primary], verifying);
+
+    expect(runVerification).toHaveBeenCalledTimes(1);
+    release(passing);
+    await first;
+    expect(store.getState().autopilotVerdicts[key.primary]).toEqual(passing);
+  });
+});
+
+describe("autopilotPass drops an enrollment whose agent is gone", () => {
+  it("unenrolls rather than ticking forever against nothing", async () => {
+    // Archiving or discarding an agent leaves its persisted enrollment behind.
+    const { store, sendUserMessage } = makeStore({
+      autopilot: { [key.primary]: state(), [key.web]: state() },
+      agents: {},
+    });
+
+    await autopilotPass([key.primary, key.web], new Set());
+
+    expect(store.getState().autopilot).toEqual({});
+    expect(sendUserMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/autopilotSync.test.ts
+++ b/src/store/autopilotSync.test.ts
@@ -36,6 +36,7 @@ vi.mock("@/store", () => ({
 }));
 
 import { createAutopilotSlice } from "./autopilot";
+import { createAutopilotLogSlice } from "./autopilotLog";
 import { autopilotPass } from "./autopilotSync";
 import { checkoutKey, createGitSlice } from "./git";
 import type { AppState } from "./types";
@@ -107,6 +108,9 @@ function makeStore({ autopilot, agents }: Fixture) {
       ({
         ...createGitSlice(...a),
         ...createAutopilotSlice(...a),
+        // The applier records every meaningful effect to the audit log, so the
+        // store it runs against needs that slice too.
+        ...createAutopilotLogSlice(...a),
       }) as AppState,
   );
   const per = <T>(value: T) => Object.fromEntries(Object.keys(autopilot).map((k) => [k, value]));
@@ -318,5 +322,73 @@ describe("autopilotPass drops an enrollment whose agent is gone", () => {
 
     expect(store.getState().autopilot).toEqual({});
     expect(sendUserMessage).not.toHaveBeenCalled();
+  });
+});
+
+// ── audit log wiring ─────────────────────────────────────────────────────────
+// The log slice is tested in isolation (autopilotLog.test.ts); what is only
+// testable here is that the applier actually FEEDS it, with the attempt number
+// read at the point it is correct. A dispatch has no cycle until
+// `openAutopilotCycle` creates one, so logging too early records `undefined`.
+
+describe("autopilotPass records what it did", () => {
+  it("logs a dispatch with the attempt number of the cycle it just opened", async () => {
+    const { store } = makeStore({
+      autopilot: { [key.primary]: state() },
+      agents: { a1: "idle" },
+    });
+
+    await autopilotPass([key.primary], new Set());
+
+    const log = store.getState().autopilotLog[key.primary];
+    expect(log).toHaveLength(1);
+    expect(log[0]).toMatchObject({ outcome: "dispatch", rung: "fix-checks", attempt: 1 });
+    expect(log[0].at).toBeGreaterThan(0);
+  });
+
+  it("carries the attempt number forward, so a retry reads as the try it was", async () => {
+    // Second cycle on the same rung: the entry has to say #2, which is the whole
+    // reason the attempt is read from the cycle rather than counted in the log.
+    const { store } = makeStore({
+      autopilot: { [key.primary]: state({ attempts: { "fix-checks": 1 } }) },
+      agents: { a1: "idle" },
+    });
+
+    await autopilotPass([key.primary], new Set());
+
+    expect(store.getState().autopilotLog[key.primary][0]).toMatchObject({
+      outcome: "dispatch",
+      attempt: 2,
+    });
+  });
+
+  it("logs an escalation with the reason that stopped it", async () => {
+    // Budget spent: the pass escalates instead of dispatching, and the log has to
+    // record WHY — that reason is the only explanation the user ever gets.
+    const { store } = makeStore({
+      autopilot: { [key.primary]: state({ attempts: { "fix-checks": 3 } }) },
+      agents: { a1: "idle" },
+    });
+
+    await autopilotPass([key.primary], new Set());
+
+    expect(store.getState().autopilotLog[key.primary][0]).toMatchObject({
+      outcome: "escalate",
+      reason: "budget-spent",
+      rung: "fix-checks",
+    });
+  });
+
+  it("stays silent on a tick with nothing to do", async () => {
+    // `wait` is most ticks. Logging them would bury the handful of entries that
+    // explain what actually happened.
+    const { store } = makeStore({
+      autopilot: { [key.primary]: state() },
+      agents: { a1: "running" },
+    });
+
+    await autopilotPass([key.primary], new Set());
+
+    expect(store.getState().autopilotLog[key.primary]).toBeUndefined();
   });
 });

--- a/src/store/autopilotSync.ts
+++ b/src/store/autopilotSync.ts
@@ -19,6 +19,7 @@ import { type AutopilotEffect, autopilotStep } from "@/autopilot";
 import { appActionMessage } from "@/delegation";
 import { useAppStore } from "@/store";
 import { usePoll } from "@/util/hooks";
+import type { AutopilotLogEntry } from "./autopilotLog";
 import { splitCheckoutKey } from "./git";
 
 /** How often to evaluate enrolled checkouts. Slower than the git poll on
@@ -118,9 +119,21 @@ async function apply(
   verifying: Set<string>,
 ) {
   const s = useAppStore.getState();
+  // Log the four effects a user would want to know about (see `autopilotLog`).
+  // `wait` is most ticks and would bury them; `verify` / `await-evidence` are
+  // steps inside a cycle whose outcome already reports how it went. Each call
+  // sits where the attempt number is correct — a dispatch has no cycle until
+  // `openAutopilotCycle` creates one, while settle/retry read the cycle the
+  // action they precede is about to clear. Stamped with the pass's `now` rather
+  // than a fresh clock read, so an entry's time matches the decision behind it.
+  const log = (entry: Omit<AutopilotLogEntry, "at">) =>
+    useAppStore.getState().recordAutopilotEvent(key, { at: now, ...entry });
+  const attemptNow = () => useAppStore.getState().autopilot[key]?.cycle?.attempt;
+
   switch (effect.do) {
     case "dispatch": {
       s.openAutopilotCycle(key, effect.rung, effect.signature);
+      log({ outcome: "dispatch", rung: effect.rung, attempt: attemptNow() });
       // Same trigger construction the panel and Mission Control use, including
       // the `repo=` scope for a secondary checkout.
       s.delegateAction(
@@ -159,12 +172,15 @@ async function apply(
       return;
     }
     case "settle":
+      log({ outcome: "settle", rung: effect.rung, attempt: attemptNow() });
       s.settleAutopilotCycle(key, effect.rung);
       return;
     case "retry":
+      log({ outcome: "retry", rung: effect.rung, attempt: attemptNow() });
       s.retryAutopilotCycle(key, effect.rung, effect.barren);
       return;
     case "escalate":
+      log({ outcome: "escalate", rung: effect.rung, reason: effect.reason });
       s.markAutopilotStuck(key, effect.reason, effect.rung, now);
       return;
     case "wait":

--- a/src/store/autopilotSync.ts
+++ b/src/store/autopilotSync.ts
@@ -44,41 +44,68 @@ export function useAutopilotSync() {
   // verify would be re-issued every 10s for the same cycle.
   const verifying = useRef<Set<string>>(new Set());
 
-  const tick = useCallback(async () => {
-    for (const key of keys) {
-      const s = useAppStore.getState();
-      const { agentId, subdir } = splitCheckoutKey(key);
-      const agent = s.workspace?.agents.find((a) => a.id === agentId);
-      // The checkout's agent is gone (archived/discarded) — drop the enrollment
-      // rather than ticking forever against nothing.
-      if (!agent) {
-        s.unenrollAutopilot(key);
-        continue;
-      }
-      const git = s.gitStates[key] ?? null;
-      const readiness = {
-        git,
-        pr: s.prStates[key] ?? null,
-        checks: s.prChecks[key] ?? null,
-        comments: s.prComments[key] ?? null,
-      };
-      const now = Date.now();
-      const effect = autopilotStep({
-        state: s.autopilot[key],
-        readiness,
-        ladder: { base: git?.parent_branch || "main", commitMode: "commit-pr" },
-        agentBusy: agent.status === "running" || agent.status === "spawning",
-        delegationInFlight: s.delegations[key] != null,
-        // Only a verdict produced FOR the current cycle counts as its evidence
-        // (cleared on dispatch); see `autopilotVerdicts`.
-        verification: s.autopilotVerdicts[key] ?? null,
-        now,
-      });
-      await apply(key, agentId, subdir, effect, now, verifying.current);
-    }
-  }, [keys]);
+  const tick = useCallback(() => autopilotPass(keys, verifying.current), [keys]);
 
   usePoll(tick, AUTOPILOT_TICK_MS, [tick]);
+}
+
+/** One sweep over every enrolled checkout, applying what the policy decided.
+ *
+ *  Exported so the WIRING is testable without a rendered hook: the decision is
+ *  pure and covered by `autopilot.test.ts`, but the store transitions, the
+ *  delegation it sends and the per-agent/per-checkout guards below only exist
+ *  here. Same reason `planDelegationPass` is exported from `delegationSync`.
+ *
+ *  `verifying` is owned by the caller (a ref on the hook) because it must
+ *  outlive a single pass — see `useAutopilotSync`. */
+export async function autopilotPass(keys: string[], verifying: Set<string>) {
+  // Agents that were handed a rung earlier in THIS pass. A dispatch sends the
+  // agent a message, but the resulting flip to `running` arrives asynchronously
+  // from the backend, so for the rest of this pass the snapshot still reads
+  // `idle`. Two checkouts of one multi-repo agent (`a1` and `a1::web`) would
+  // both see an idle agent and both dispatch, and Claude would coalesce the two
+  // triggers into ONE turn — the exact failure `queued` exists to prevent, and
+  // the one `delegationInFlight` cannot catch because it is keyed per checkout
+  // and the sibling has no delegation of its own. So an agent already dispatched
+  // to counts as busy, which also stops a sibling cycle from being verified
+  // while a turn we just started rewrites the tree under it. The loser waits for
+  // the next tick, by which time the real status has caught up. Mirrors the
+  // per-pass `dequeued` set in `planDelegationPass`.
+  const dispatchedTo = new Set<string>();
+
+  for (const key of keys) {
+    const s = useAppStore.getState();
+    const { agentId, subdir } = splitCheckoutKey(key);
+    const agent = s.workspace?.agents.find((a) => a.id === agentId);
+    // The checkout's agent is gone (archived/discarded) — drop the enrollment
+    // rather than ticking forever against nothing.
+    if (!agent) {
+      s.unenrollAutopilot(key);
+      continue;
+    }
+    const git = s.gitStates[key] ?? null;
+    const readiness = {
+      git,
+      pr: s.prStates[key] ?? null,
+      checks: s.prChecks[key] ?? null,
+      comments: s.prComments[key] ?? null,
+    };
+    const now = Date.now();
+    const effect = autopilotStep({
+      state: s.autopilot[key],
+      readiness,
+      ladder: { base: git?.parent_branch || "main", commitMode: "commit-pr" },
+      agentBusy:
+        agent.status === "running" || agent.status === "spawning" || dispatchedTo.has(agentId),
+      delegationInFlight: s.delegations[key] != null,
+      // Only a verdict produced FOR the current cycle counts as its evidence
+      // (cleared on dispatch); see `autopilotVerdicts`.
+      verification: s.autopilotVerdicts[key] ?? null,
+      now,
+    });
+    if (effect.do === "dispatch") dispatchedTo.add(agentId);
+    await apply(key, agentId, subdir, effect, now, verifying);
+  }
 }
 
 /** Perform one effect. Split out so the tick reads as the sweep it is. */

--- a/src/store/autopilotSync.ts
+++ b/src/store/autopilotSync.ts
@@ -181,7 +181,13 @@ async function apply(
       return;
     case "escalate":
       log({ outcome: "escalate", rung: effect.rung, reason: effect.reason });
-      s.markAutopilotStuck(key, effect.reason, effect.rung, now);
+      s.markAutopilotStuck(key, effect.reason, effect.rung, now, effect.blockers);
+      return;
+    case "revive":
+      // Recorded, because "it picked this back up on its own" is exactly the kind
+      // of unattended action the audit trail exists to explain.
+      log({ outcome: "revive", rung: null });
+      s.reviveAutopilot(key);
       return;
     case "wait":
       return;

--- a/src/store/delegationSync.test.ts
+++ b/src/store/delegationSync.test.ts
@@ -14,7 +14,13 @@
 import { describe, expect, it, vi } from "vitest";
 import { create } from "zustand";
 import type { AgentStatus, GitState, PrState } from "@/api";
-import { DELEGATION_GIVE_UP_GRACE_MS, type Delegation } from "@/delegation";
+import {
+  DELEGATION_GIVE_UP_GRACE_MS,
+  DELEGATION_KINDS,
+  type Delegation,
+  delegationDone,
+  settlesOnIdle,
+} from "@/delegation";
 import { type DelegationEffect, planDelegationPass } from "./delegationSync";
 
 vi.mock("@/api", () => ({ api: {} }));
@@ -161,6 +167,31 @@ describe("planDelegationPass advances delegations wherever they live", () => {
     expect(
       plan({ a1: delegation({ kind: "fix-checks", sawRunning: true }) }, { a1: "idle" }),
     ).toEqual([{ do: "give-up", key: "a1", notice: "Agent finished — checks are re-running" }]);
+  });
+
+  it("says the same for EVERY kind that can't be observed in state", () => {
+    // The bug this pins: the notice hardcoded `fix-checks`, so a finished
+    // `resolve-comments` round — which also never resolves from state, by
+    // design — told the user to go read the chat as though it had given up.
+    for (const kind of DELEGATION_KINDS.filter(settlesOnIdle)) {
+      expect(plan({ a1: delegation({ kind, sawRunning: true }) }, { a1: "idle" })).toEqual([
+        { do: "give-up", key: "a1", notice: delegationDone(kind) },
+      ]);
+    }
+  });
+
+  it("still reports an unobservable-target kind honestly when it really did stall", () => {
+    // A kind whose target IS observable must keep the honest message — the fix
+    // must not turn every give-up into a success notice.
+    expect(
+      plan(
+        { a1: delegation({ kind: "commit", sawRunning: true }) },
+        { a1: "idle" },
+        { gitStates: { a1: git({ files: [modified] }) } },
+      ),
+    ).toEqual([
+      { do: "give-up", key: "a1", notice: "Agent finished — review the chat for details" },
+    ]);
   });
 
   it("drops a delegation whose agent was archived or discarded under it", () => {

--- a/src/store/delegationSync.test.ts
+++ b/src/store/delegationSync.test.ts
@@ -43,6 +43,7 @@ const EMPTY_MAPS = {
   delegationNotices: {},
   autopilot: {},
   autopilotVerdicts: {},
+  autopilotLog: {},
   unseenResults: {},
   rightPanelTabs: {},
 };

--- a/src/store/delegationSync.ts
+++ b/src/store/delegationSync.ts
@@ -25,7 +25,13 @@
 
 import { useEffect } from "react";
 import type { AgentStatus, GitState, PrChecks, PrState } from "@/api";
-import { type Delegation, delegationDone, delegationResolved, delegationStep } from "@/delegation";
+import {
+  type Delegation,
+  delegationDone,
+  delegationResolved,
+  delegationStep,
+  settlesOnIdle,
+} from "@/delegation";
 import { EMPTY_AGENTS, useAppStore } from "@/store";
 import { splitCheckoutKey } from "./git";
 
@@ -105,12 +111,14 @@ export function planDelegationPass(input: DelegationPassInput): DelegationEffect
         effects.push({
           do: "give-up",
           key,
-          // `fix-checks` never resolves from state (CI takes minutes), so a
-          // settled agent is its NORMAL ending, not an abandonment — say so.
-          notice:
-            delegation.kind === "fix-checks"
-              ? delegationDone("fix-checks")
-              : "Agent finished — review the chat for details",
+          // For kinds whose completion isn't observable in state, a settled agent
+          // is the NORMAL ending, not an abandonment — say so. Keyed on
+          // `settlesOnIdle` rather than naming a kind: this used to hardcode
+          // `fix-checks`, so `resolve-comments` (which also never resolves from
+          // state) reported "review the chat" on every successful round.
+          notice: settlesOnIdle(delegation.kind)
+            ? delegationDone(delegation.kind)
+            : "Agent finished — review the chat for details",
         });
         break;
       case "wait":

--- a/src/store/discardRestore.test.ts
+++ b/src/store/discardRestore.test.ts
@@ -43,6 +43,7 @@ const EMPTY_MAPS = {
   delegationNotices: {},
   autopilot: {},
   autopilotVerdicts: {},
+  autopilotLog: {},
   unseenResults: {},
   rightPanelTabs: {},
 };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -4,6 +4,7 @@ import { createAccountSlice } from "./account";
 import { createAppSlice } from "./app";
 import { createAppearanceSlice } from "./appearance";
 import { createAutopilotSlice } from "./autopilot";
+import { createAutopilotLogSlice } from "./autopilotLog";
 import { createComposerSlice } from "./composer";
 import { createCustomAgentsSlice } from "./customAgents";
 import { createDraftsSlice } from "./drafts";
@@ -31,6 +32,7 @@ export const useAppStore = create<AppState>()((...a) => ({
   ...createAccountSlice(...a),
   ...createAppearanceSlice(...a),
   ...createAutopilotSlice(...a),
+  ...createAutopilotLogSlice(...a),
   ...createProvidersSlice(...a),
   ...createCustomAgentsSlice(...a),
   ...createSkillsSlice(...a),

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -10,6 +10,7 @@ import type { AccountSlice } from "./account";
 import type { AppSlice } from "./app";
 import type { AppearanceSlice } from "./appearance";
 import type { AutopilotSlice } from "./autopilot";
+import type { AutopilotLogSlice } from "./autopilotLog";
 import type { ComposerSlice } from "./composer";
 import type { CustomAgentsSlice } from "./customAgents";
 import type { DraftsSlice } from "./drafts";
@@ -27,6 +28,7 @@ export type {
   AccountSlice,
   AppearanceSlice,
   AppSlice,
+  AutopilotLogSlice,
   AutopilotSlice,
   ComposerSlice,
   CustomAgentsSlice,
@@ -56,6 +58,7 @@ export type AppState = AppSlice &
   AccountSlice &
   AppearanceSlice &
   AutopilotSlice &
+  AutopilotLogSlice &
   ProvidersSlice &
   CustomAgentsSlice &
   SkillsSlice &

--- a/src/styles/shared/badge.css
+++ b/src/styles/shared/badge.css
@@ -106,6 +106,45 @@
   font-family: var(--font-mono);
   flex-shrink: 0;
 }
+/* autopilot mark — same weight and metrics as the a-stale cue, because it is the
+ * same kind of thing: a hint on an existing row, not an announcement. Only the
+ * two modes a human might act on are ever rendered (see AutopilotMark). */
+.agent-sub .a-autopilot {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: var(--fs-xs);
+  font-family: var(--font-mono);
+  flex-shrink: 0;
+}
+/* working: the accent, breathing like the row's dev-server heartbeat but without
+ * the halo — the agent's own activity cues (rail / loader / shimmer) already own
+ * the loud end of this row. */
+.agent-sub .a-autopilot.working {
+  color: var(--accent);
+}
+.agent-sub .a-autopilot.working svg {
+  animation: apBreathe 2.6s var(--ease) infinite;
+}
+@keyframes apBreathe {
+  0%,
+  100% {
+    opacity: 0.5;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+/* stopped: warn, not danger. Nothing is broken — autopilot did what it could and
+ * the next step is a person's. Danger stays reserved for the error badge. */
+.agent-sub .a-autopilot.stuck {
+  color: var(--warn);
+}
+@media (prefers-reduced-motion: reduce) {
+  .agent-sub .a-autopilot.working svg {
+    animation: none;
+  }
+}
 .agent-sub .a-time {
   color: var(--fg-3);
   font-size: var(--fs-xs);

--- a/tests/delegation.test.ts
+++ b/tests/delegation.test.ts
@@ -5,6 +5,7 @@ import {
   actionProvesKind,
   appActionMessage,
   DELEGATION_GIVE_UP_GRACE_MS,
+  DELEGATION_KINDS,
   type Delegation,
   delegationDone,
   delegationLabel,
@@ -246,15 +247,9 @@ describe("appActionMessage", () => {
 
 describe("copy", () => {
   it("has a label and done message for every kind", () => {
-    for (const k of [
-      "commit",
-      "commit-push",
-      "commit-pr",
-      "open-pr",
-      "resolve",
-      "update-branch",
-      "fix-checks",
-    ] as const) {
+    // Iterating DELEGATION_KINDS, not a hand-written list — the hand-written one
+    // had silently fallen two kinds behind while still claiming "every kind".
+    for (const k of DELEGATION_KINDS) {
       expect(delegationLabel(k).length).toBeGreaterThan(0);
       expect(delegationDone(k).length).toBeGreaterThan(0);
     }


### PR DESCRIPTION
**Stacked on #549** (`feat/autopilot-review-comments`), which isn't merged yet — review that first. Four commits here.

Addresses the gaps I flagged after #549: one real bug, two things I said #547 would include and didn't build, and the untested-wiring hole.

## 1. Dispatch race — a real bug (`01ecf036`)

`agentBusy` was read from the workspace snapshot, but the flip to `running` arrives asynchronously from the backend. So in a single tick, two checkouts of one multi-repo agent (`a1` and `a1::web`) both observed `idle`, both dispatched, and both triggers went out — coalescing into one agent turn. Exactly the failure `queued` exists to prevent, and the one `delegationInFlight` can't catch because it's keyed per checkout and the sibling has no delegation.

Same class as the dequeue bug fixed in #545; I hadn't carried the lesson across to dispatch. Fixed with a per-pass dispatched-agents set folded into `agentBusy` — which also stops a sibling cycle being verified while a turn we just started rewrites the tree under it. The loser waits one tick, by which time the real status has caught up.

## 2. The applier is now tested (`01ecf036`)

The pure policy was thoroughly covered; the *wiring* had zero tests, which is where the bug above lived. The sweep is extracted as `autopilotPass` (mirroring `planDelegationPass` in #545) and covered by 9 tests: the race, per-repo trigger scoping, cycle-opening paired with delegation, the in-flight verification guard, a throwing verifier not looking like a failed fix, and a vanished agent being unenrolled.

## 3. Audit trail (`bcbd3f39`)

There was no record of what autopilot did — for a feature whose premise is acting while nobody watches, that was the most serious omission. New bounded (20/checkout), unpersisted `autopilotLog` slice, pruned with the agent via the existing checkout-scoped `dropScopedEntries`, with an expandable history under the Git panel chip. Entry fields mirror `AutopilotEffect` so the driver passes its own values through unchanged; `Extract<AutopilotEffect["do"], …>` means renaming an effect stops compiling rather than silently drifting.

## 4. Sidebar visibility (`000bda18`)

Enrollment was invisible until you selected an agent and opened the Git tab. Agent rows now carry a quiet mark, following the existing `a-stale` cue exactly. Only `working` and `stuck` render — enrolled-and-idle is the normal case, and a mark on every row would train the eye to skip the two that matter. Aggregated across all of an agent's checkouts by a pure `autopilotSignal`, using the same prefix scan as `maxBehind`/`stuckCheckout`, with `stuck > working > paused > idle` and a stable tie-break.

## 5. Integration (`acc50f65`)

The log slice shipped without a caller by design — the driver file was owned by the race fix — so this connects them. **I introduced an ordering bug doing it**: logging a dispatch before `openAutopilotCycle` records `attempt: undefined`, because the cycle doesn't exist yet. There's now a test that fails on it, plus three more for the wiring, because "the slice is tested but nobody checks the driver feeds it" is the exact gap this stack set out to close.

## Verification

- `tsc --noEmit` clean; `cargo check` clean.
- 713 tests (up from 677 — 36 new).
- `biome check` at parity: 0 errors, same 73 pre-existing warnings.
- Every guard mutation-checked, in each commit: 10 mutations on the race fix and applier, 6 on the log slice's invariants, 5 on the sidebar aggregation, 3 on the wiring.

## Still open, and product calls rather than defects

**Enrollment discoverability** — the only way to switch autopilot on is the Git panel chip. No project-level default, nothing announcing the feature exists.

**The window-hidden limitation** — unchanged from #547 and now spanning four rungs: `usePoll` stops on `document.hidden`, so closing the Fletch window pauses the loop while the app and its agents keep running. Of everything in this arc it's the one I'd revisit before calling autopilot done, since "unattended" is the pitch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)