### PR TITLE
fix(messaging): revive a resting session instead of stranding its message

### DIFF
--- a/src-tauri/src/supervisor/messaging.rs
+++ b/src-tauri/src/supervisor/messaging.rs
@@ -164,7 +164,10 @@ impl Supervisor {
         let app = app.clone();
         let agent_id = agent_id.to_string();
         tauri::async_runtime::spawn(async move {
-            tracing::info!(agent_id, "reviving a resting session to deliver a held message");
+            tracing::info!(
+                agent_id,
+                "reviving a resting session to deliver a held message"
+            );
             if let Err(e) = self.clone().resume_agent(app.clone(), &agent_id).await {
                 // The status is already Error with this reason (set inside the
                 // resume), so the user sees why; the message stays queued and a
@@ -580,7 +583,10 @@ mod tests {
         let mut record = record_with_status("yosemite", AgentStatus::Idle);
         sup.workspace.add_agent(&mut record).unwrap();
 
-        assert!(sup.live_status("yosemite").is_none(), "no runtime state yet");
+        assert!(
+            sup.live_status("yosemite").is_none(),
+            "no runtime state yet"
+        );
         assert!(sup.needs_revive("yosemite"));
     }
 

--- a/src-tauri/src/supervisor/messaging.rs
+++ b/src-tauri/src/supervisor/messaging.rs
@@ -67,7 +67,9 @@ impl Supervisor {
                     // the (already-persisted) turn: the respawn's post-restart
                     // flush, or this flush once the restart lands, delivers it
                     // onto the fresh process — which is the intent, since the
-                    // message then runs under the new config (CQ3-C).
+                    // message then runs under the new config (CQ3-C). If there
+                    // was no teardown to race and simply no process at all, the
+                    // revive below is what picks the message up.
                     tracing::warn!(error = %e, agent_id, "deliver-now raced a teardown; re-queueing");
                     self.persist_and_enqueue(agent_id, msg);
                     flush_queued(&self, app, agent_id)?
@@ -106,7 +108,78 @@ impl Supervisor {
                 self.is_busy(agent_id) || flush_queued(&self, app, agent_id)?
             }
         };
+        // Every arm above holds the message rather than dropping it, but holding
+        // only helps if something will eventually come along to deliver it. When
+        // no process is live at all there is no such boundary — the session is
+        // resting after an app restart, or its process exited when it last went
+        // idle — so revive it and flush. Without this the message sits in the
+        // queue until the user gives up: the spinner runs, no turn ever starts,
+        // and each retry only grows the backlog.
+        if queued && self.needs_revive(agent_id) {
+            self.clone().revive_and_flush(app, agent_id);
+        }
         Ok(queued)
+    }
+
+    /// Whether a *held* message needs its session revived before anything can
+    /// deliver it. True only when no live process exists **and** nothing is
+    /// already on its way to producing one:
+    ///
+    /// - a `Spawning` agent is excluded — its own `start_process` drains the
+    ///   queue when the process comes up (see `start_process`), and reviving
+    ///   underneath it would race that spawn;
+    /// - a project mid-deletion is excluded — nothing may be started under it
+    ///   (the same guard `respawn_agent_preserving_session` applies), and
+    ///   `deliver_as_turn` rejects for that reason too, so the hold there is
+    ///   deliberate rather than a missing process.
+    ///
+    /// A session-preserving respawn briefly presents as "no live process" while
+    /// it tears the old one down. Reviving into that window is harmless: the
+    /// revive waits on the same `agent_lifecycle` lock the respawn holds, then
+    /// finds the agent already restored and returns without spawning.
+    fn needs_revive(&self, agent_id: &str) -> bool {
+        if matches!(self.live_status(agent_id), Some(AgentStatus::Spawning)) {
+            return false;
+        }
+        if self.agents.lock().contains_key(agent_id) {
+            return false;
+        }
+        match self.workspace.agent(agent_id) {
+            Ok(record) => !self.deleting_projects.lock().contains(&record.project_id),
+            Err(_) => false,
+        }
+    }
+
+    /// Restart the agent's process in `--resume` mode and deliver whatever is
+    /// queued onto it. Fire-and-forget: `send_user_message` is synchronous and
+    /// already reported the message as held, so the caller isn't kept waiting on
+    /// a spawn — the `Spawning` status event tells the frontend what's happening
+    /// and the flushed turn tells it when the agent picked the message up.
+    ///
+    /// Safe to fire more than once (a user sending twice in a row): `resume_agent`
+    /// serializes on `agent_lifecycle` and no-ops once the agent is live, and
+    /// `flush_queued` drains under the queue lock, so a second call finds nothing
+    /// left to send rather than double-delivering.
+    fn revive_and_flush(self: Arc<Self>, app: &AppHandle, agent_id: &str) {
+        let app = app.clone();
+        let agent_id = agent_id.to_string();
+        tauri::async_runtime::spawn(async move {
+            tracing::info!(agent_id, "reviving a resting session to deliver a held message");
+            if let Err(e) = self.clone().resume_agent(app.clone(), &agent_id).await {
+                // The status is already Error with this reason (set inside the
+                // resume), so the user sees why; the message stays queued and a
+                // later successful revive still delivers it.
+                tracing::warn!(error = %e, agent_id, "revive for a held message failed");
+                return;
+            }
+            // `start_process` drains the queue itself on the spawn-completion
+            // Idle, so this is usually a no-op. It still matters when the revive
+            // no-oped because a concurrent respawn had already restored the
+            // agent — then nobody else owns this message.
+            if let Err(e) = flush_queued(&self, &app, &agent_id) {
+                tracing::warn!(error = %e, agent_id, "post-revive queue flush failed");
+            }
+        });
     }
 
     /// Inject a message into the running turn over the managed agent's open
@@ -495,5 +568,69 @@ mod tests {
         assert_eq!(turns[0].turn_id, "turn-1");
         assert_eq!(turns[0].text, "hello");
         assert_eq!(turns[0].native_id, None);
+    }
+
+    /// The regression this guards: after an app restart no process is live and
+    /// the supervisor holds no runtime status at all, so a held message has
+    /// nobody to deliver it. That state must ask for a revive — otherwise the
+    /// message sits queued forever while the composer spins.
+    #[test]
+    fn a_resting_session_with_no_live_process_asks_for_a_revive() {
+        let sup = test_supervisor();
+        let mut record = record_with_status("yosemite", AgentStatus::Idle);
+        sup.workspace.add_agent(&mut record).unwrap();
+
+        assert!(sup.live_status("yosemite").is_none(), "no runtime state yet");
+        assert!(sup.needs_revive("yosemite"));
+    }
+
+    /// The same holds once the agent's process has exited within this run: the
+    /// live status lingers at Idle but the `agents` map no longer has a handle.
+    #[test]
+    fn an_exited_process_still_asks_for_a_revive() {
+        let sup = test_supervisor();
+        let mut record = record_with_status("yosemite", AgentStatus::Idle);
+        sup.workspace.add_agent(&mut record).unwrap();
+        sup.statuses
+            .lock()
+            .insert("yosemite".to_string(), AgentStatus::Idle);
+
+        assert!(sup.needs_revive("yosemite"));
+    }
+
+    /// A spawn already in flight owns the delivery — `start_process` drains the
+    /// queue when it completes. Reviving here would race that spawn.
+    #[test]
+    fn a_spawning_agent_does_not_ask_for_a_revive() {
+        let sup = test_supervisor();
+        let mut record = record_with_status("yosemite", AgentStatus::Spawning);
+        sup.workspace.add_agent(&mut record).unwrap();
+        sup.statuses
+            .lock()
+            .insert("yosemite".to_string(), AgentStatus::Spawning);
+
+        assert!(!sup.needs_revive("yosemite"));
+    }
+
+    /// Nothing may be started under a project being deleted — the hold there is
+    /// deliberate (`deliver_as_turn` rejects for that reason), not a missing
+    /// process.
+    #[test]
+    fn an_agent_in_a_deleting_project_does_not_ask_for_a_revive() {
+        let sup = test_supervisor();
+        let mut record = record_with_status("yosemite", AgentStatus::Idle);
+        sup.workspace.add_agent(&mut record).unwrap();
+        sup.deleting_projects
+            .lock()
+            .insert(sup.workspace.agent("yosemite").unwrap().project_id);
+
+        assert!(!sup.needs_revive("yosemite"));
+    }
+
+    /// An unknown agent has nothing to revive.
+    #[test]
+    fn an_unknown_agent_does_not_ask_for_a_revive() {
+        let sup = test_supervisor();
+        assert!(!sup.needs_revive("nowhere"));
     }
 }

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -20,7 +20,6 @@ import {
   reduceRecords,
   repoPathFor,
   resolveBaseBranch,
-  sendWhenAgentReady,
   unsupportedManagedCommand,
 } from "@/helpers";
 import { clearOutputBuffer, dropAgentPty } from "@/pty/buffers";
@@ -521,30 +520,25 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
               }),
         };
       });
-      try {
-        const enqueued = await api.sendUserMessage(id, turnId, sendText, attachments);
-        // Only a genuinely-held message wears the badge; a delivered one stays a
-        // plain bubble. Match by turnId — agent output may have appended since.
-        if (wasBusy && enqueued) {
-          set((state) => ({
-            managedLogs: {
-              ...state.managedLogs,
-              [id]: (state.managedLogs[id] ?? []).map((it) =>
-                it.kind === "queued_message" && it.turnId === turnId ? { ...it, queued: true } : it,
-              ),
-            },
-          }));
-        }
-      } catch (e) {
-        if (String(e).includes("agent not found")) {
-          // Dead idle agent (finished its prior task) — resume the
-          // process in --resume mode, then deliver the message once ready.
-          // Not busy, so it lands as a new turn (never queued) — no badge.
-          await api.resumeAgent(id);
-          await sendWhenAgentReady(() => api.sendUserMessage(id, turnId, sendText, attachments));
-        } else {
-          throw e;
-        }
+      // A dead session (one whose process exited when it last went idle, or any
+      // session after an app restart) needs no special handling here: the
+      // backend revives it in --resume mode and delivers this message onto the
+      // fresh process. That used to live here, keyed off an "agent not found"
+      // error, but the backend no longer surfaces one — it holds the message
+      // instead — and keeping the revive there covers every other sender
+      // (autopilot, delegation, drafts) rather than just this one.
+      const enqueued = await api.sendUserMessage(id, turnId, sendText, attachments);
+      // Only a genuinely-held message wears the badge; a delivered one stays a
+      // plain bubble. Match by turnId — agent output may have appended since.
+      if (wasBusy && enqueued) {
+        set((state) => ({
+          managedLogs: {
+            ...state.managedLogs,
+            [id]: (state.managedLogs[id] ?? []).map((it) =>
+              it.kind === "queued_message" && it.turnId === turnId ? { ...it, queued: true } : it,
+            ),
+          },
+        }));
       }
     } catch (e) {
       set((state) => ({


### PR DESCRIPTION
## Problem

Sessions could not be resumed after quitting the app. Sending a message to any resting workspace showed the "working" spinner for a while, but no request was ever made and no reply came back. Once the spinner cleared, sending again repeated the story — and each retry silently grew the backlog.

## Root cause

After an app restart nothing auto-spawns an agent process, so the first send takes `Delivery::DeliverNow` (`is_busy` is false) and `live_agent()` fails with `AgentNotFound`.

`send_user_message` caught that error, persisted + re-queued the message, and returned `Ok(true)` instead of propagating. The frontend only revives a dead session when the send **throws** with `"agent not found"` — so `api.resumeAgent` was never called and no turn ever started. `managedBusy` stayed set until `setupResync` reconciled it from the backend's at-rest `idle` status on window foreground, which is the spinner disappearing.

Confirmed in production logs:

```
00:54:27  managed: exited success=true exit status: 0
00:55:24  WARN deliver-now raced a teardown; re-queueing error=agent not found: ningaloo
00:55:24  WARN flush delivery failed; re-queueing follow-ups error=agent not found: ningaloo
00:55:34  DEBUG flushing coalesced follow-up messages as one turn agent_id="ningaloo" count=2
00:55:34  WARN flush delivery failed; re-queueing follow-ups error=agent not found: ningaloo
```

No spawn line ever follows. Contrast a *fresh* spawn (`kilauea`), which hits the same warnings but then spawns anyway — only the resume path was broken.

Introduced by 4cdceae2 ("fix(effort): re-queue a send that races a config-triggered respawn"), which made the `DeliverNow` arm catch-and-requeue to close a respawn race. That fix is correct for its case, but it cannot distinguish "a teardown raced my delivery" from "there is no process at all, revive the session".

## Fix

Keep holding the message, then ask whether anything will actually come along to deliver it.

- **`needs_revive`** — true only when no live process exists **and** nothing is already on its way to producing one. Excludes a `Spawning` agent (its own `start_process` drains the queue on completion, and reviving underneath would race that spawn) and a project mid-deletion (nothing may be started under it — the same guard `respawn_agent_preserving_session` applies).
- **`revive_and_flush`** — fire-and-forget `resume_agent` (`--resume`) followed by `flush_queued`. Idempotent under repeated sends: `resume_agent` serializes on `agent_lifecycle` and no-ops once the agent is live, and `flush_queued` drains under the queue lock, so a second call finds nothing left rather than double-delivering. A session-preserving respawn briefly presents as "no live process"; reviving into that window waits on the same lifecycle lock and then returns without spawning.

4cdceae2's respawn-race behaviour is untouched — the revive is a separate arm for the case where there was no teardown to race.

The frontend fallback this replaces is removed. It was already unreachable, and owning the revive in the supervisor covers every other sender — autopilot, delegation, drafts — which never had a retry at all.

## Behaviour for already-stuck sessions

They recover on the next message. Because retries were persisted and are rehydrated at startup, the accumulated backlog is delivered as one coalesced turn (newline-joined in send order) — existing coalescing behaviour, noted here because a stuck workspace will reply to all of the user's retries at once.

## Testing

- 5 new tests pinning `needs_revive`, including the exact regression state (record `Idle`, no live status, no live process → revive), an exited process within a run, a `Spawning` agent, a deleting project, and an unknown agent.
- `cargo test --lib` — 1087 passed, `cargo clippy --all-targets` clean.
- `vitest run` — 727 passed, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)