### PR TITLE
fix(git): a merged PR no longer ends the workspace

### DIFF
--- a/src-tauri/src/workspace/agents.rs
+++ b/src-tauri/src/workspace/agents.rs
@@ -209,10 +209,30 @@ impl WorkspaceManager {
     /// Written when a PR is created through the app or adopted from an OPEN
     /// out-of-band PR. Overwrites unconditionally — the latest PR opened for
     /// the branch is the one we track.
+    ///
+    /// Binding a *different* number clears the display snapshot and lifecycle
+    /// stamps, because they describe the PR being replaced. This matters most
+    /// after a merge: `resolve_pr_state` short-circuits a `merged` snapshot with
+    /// no network (merges don't un-happen), so a follow-up PR that inherited
+    /// `pr_state = 'merged'` would render as "merged #<new>" with the previous
+    /// PR's url and title, forever, with no fetch left to correct it. Cleared
+    /// columns read as "never fetched" instead, and the next resolve fills them
+    /// in from GitHub. Re-binding the same number is a no-op, so the ordinary
+    /// path keeps its snapshot.
     pub fn set_repo_pr_number(&self, agent_id: &str, subdir: &str, pr_number: i64) -> Result<()> {
         let conn = self.db.lock();
+        // SQLite evaluates SET expressions against the pre-update row, so each
+        // `pr_number IS ?1` compares the number being replaced. `IS` (not `=`)
+        // so a first bind, where the old number is NULL, also counts as a change.
         conn.execute(
-            "UPDATE worktrees SET pr_number = ?1 WHERE workspace_id = ?2 AND subdir = ?3",
+            "UPDATE worktrees
+                SET pr_number    = ?1,
+                    pr_url       = CASE WHEN pr_number IS ?1 THEN pr_url       ELSE NULL END,
+                    pr_title     = CASE WHEN pr_number IS ?1 THEN pr_title     ELSE NULL END,
+                    pr_state     = CASE WHEN pr_number IS ?1 THEN pr_state     ELSE NULL END,
+                    pr_opened_at = CASE WHEN pr_number IS ?1 THEN pr_opened_at ELSE NULL END,
+                    pr_merged_at = CASE WHEN pr_number IS ?1 THEN pr_merged_at ELSE NULL END
+              WHERE workspace_id = ?2 AND subdir = ?3",
             rusqlite::params![pr_number, agent_id, subdir],
         )?;
         Ok(())
@@ -228,7 +248,10 @@ impl WorkspaceManager {
     /// (url / title / state), and GitHub's own lifecycle times. One write per
     /// fetch keeps the database the durable source of truth the UI can render
     /// from when GitHub or the checkout is unavailable. Times COALESCE so an
-    /// earlier-observed value is never erased by a payload that omits it.
+    /// earlier-observed value is never erased by a payload that omits it — but
+    /// only for the PR they describe: a follow-up PR bound into the same
+    /// checkout (the workspace kept working after a merge) takes the payload's
+    /// times as they are, so it can't inherit the previous PR's merge stamp.
     pub fn set_repo_pr_snapshot(
         &self,
         agent_id: &str,
@@ -238,8 +261,10 @@ impl WorkspaceManager {
         let conn = self.db.lock();
         conn.execute(
             "UPDATE worktrees SET pr_number = ?1, pr_url = ?2, pr_title = ?3, pr_state = ?4,
-                                  pr_opened_at = COALESCE(?5, pr_opened_at),
-                                  pr_merged_at = COALESCE(?6, pr_merged_at)
+                                  pr_opened_at = CASE WHEN pr_number IS ?1
+                                                 THEN COALESCE(?5, pr_opened_at) ELSE ?5 END,
+                                  pr_merged_at = CASE WHEN pr_number IS ?1
+                                                 THEN COALESCE(?6, pr_merged_at) ELSE ?6 END
              WHERE workspace_id = ?7 AND subdir = ?8",
             rusqlite::params![
                 pr.number as i64,

--- a/src-tauri/src/workspace/tests.rs
+++ b/src-tauri/src/workspace/tests.rs
@@ -1196,6 +1196,131 @@ fn pr_snapshot_persists_and_loads() {
     assert_eq!(merged_at, Some(2_000));
 }
 
+/// A merged PR doesn't end the workspace: the agent keeps working in the same
+/// worktree and opens a follow-up PR. Binding that new number must drop the
+/// merged PR's display snapshot and stamps, or `resolve_pr_state` short-circuits
+/// the inherited `merged` state and renders "merged #<new>" — with the previous
+/// PR's url and title — with no fetch left to correct it.
+#[test]
+fn binding_a_follow_up_pr_clears_the_merged_snapshot() {
+    let db = test_db();
+    let wm = WorkspaceManager::new(db.clone());
+    seed_repo(&db, "/r");
+
+    let mut rec = new_agent_record(
+        "denali".into(),
+        "a".into(),
+        "claude".into(),
+        mk_repo("/r"),
+        "task".into(),
+        AgentView::Custom,
+    );
+    let id = rec.id.clone();
+    wm.add_agent(&mut rec).unwrap();
+    let subdir = wm.agent(&id).unwrap().repos[0].subdir.clone();
+
+    let merged = crate::github::PrState {
+        number: 42,
+        url: "https://github.com/o/r/pull/42".into(),
+        title: "feat: first".into(),
+        state: crate::github::PrStatus::Merged,
+        mergeable: crate::github::MergeableState::Unknown,
+        opened_at: Some(1_000),
+        merged_at: Some(2_000),
+    };
+    wm.set_repo_pr_snapshot(&id, &subdir, &merged).unwrap();
+
+    // Re-binding the SAME number is the ordinary path — it must keep the
+    // snapshot, so a poll never blanks a badge it just confirmed.
+    wm.set_repo_pr_number(&id, &subdir, 42).unwrap();
+    let repo = wm.agent(&id).unwrap().repos[0].clone();
+    assert_eq!(repo.pr_state.as_deref(), Some("merged"));
+    assert_eq!(repo.pr_title.as_deref(), Some("feat: first"));
+
+    // The agent opens a follow-up PR (the delegated `open_pr` path, which binds
+    // a number and nothing else).
+    wm.set_repo_pr_number(&id, &subdir, 43).unwrap();
+    let repo = wm.agent(&id).unwrap().repos[0].clone();
+    assert_eq!(repo.pr_number, Some(43));
+    assert_eq!(
+        repo.pr_state, None,
+        "the new PR must not inherit 'merged' — that state is served with no network"
+    );
+    assert_eq!(repo.pr_url, None, "url would link to the previous PR");
+    assert_eq!(repo.pr_title, None, "title would name the previous PR");
+    let conn = db.lock();
+    let (opened, merged_at): (Option<i64>, Option<i64>) = conn
+        .query_row(
+            "SELECT pr_opened_at, pr_merged_at FROM worktrees WHERE workspace_id = ?1",
+            [&id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(opened, None);
+    assert_eq!(
+        merged_at, None,
+        "an open PR carrying the previous PR's merge stamp reads as already landed"
+    );
+}
+
+/// The direct in-app path (`create_pr` → `set_repo_pr_snapshot`) opens a
+/// follow-up PR without going through `set_repo_pr_number`, so the times must
+/// not COALESCE across the identity change either.
+#[test]
+fn a_follow_up_snapshot_does_not_inherit_the_previous_merge_stamp() {
+    let db = test_db();
+    let wm = WorkspaceManager::new(db.clone());
+    seed_repo(&db, "/r");
+
+    let mut rec = new_agent_record(
+        "denali".into(),
+        "a".into(),
+        "claude".into(),
+        mk_repo("/r"),
+        "task".into(),
+        AgentView::Custom,
+    );
+    let id = rec.id.clone();
+    wm.add_agent(&mut rec).unwrap();
+    let subdir = wm.agent(&id).unwrap().repos[0].subdir.clone();
+
+    let merged = crate::github::PrState {
+        number: 42,
+        url: "https://github.com/o/r/pull/42".into(),
+        title: "feat: first".into(),
+        state: crate::github::PrStatus::Merged,
+        mergeable: crate::github::MergeableState::Unknown,
+        opened_at: Some(1_000),
+        merged_at: Some(2_000),
+    };
+    wm.set_repo_pr_snapshot(&id, &subdir, &merged).unwrap();
+
+    let follow_up = crate::github::PrState {
+        number: 43,
+        url: "https://github.com/o/r/pull/43".into(),
+        title: "feat: second".into(),
+        state: crate::github::PrStatus::Open,
+        mergeable: crate::github::MergeableState::Mergeable,
+        opened_at: Some(3_000),
+        merged_at: None,
+    };
+    wm.set_repo_pr_snapshot(&id, &subdir, &follow_up).unwrap();
+
+    let repo = wm.agent(&id).unwrap().repos[0].clone();
+    assert_eq!(repo.pr_number, Some(43));
+    assert_eq!(repo.pr_state.as_deref(), Some("open"));
+    let conn = db.lock();
+    let (opened, merged_at): (Option<i64>, Option<i64>) = conn
+        .query_row(
+            "SELECT pr_opened_at, pr_merged_at FROM worktrees WHERE workspace_id = ?1",
+            [&id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(opened, Some(3_000));
+    assert_eq!(merged_at, None, "PR #43 is open, not merged at 2_000");
+}
+
 #[test]
 fn agent_status_transitions() {
     let db = test_db();

--- a/src/components/RightPanel/GitPanel/StatusHeader.tsx
+++ b/src/components/RightPanel/GitPanel/StatusHeader.tsx
@@ -57,21 +57,23 @@ export function describeHeader(
   checksFailed: number,
 ): HeaderInfo {
   const n = pr?.number;
+  // Keep the bound PR's GitHub link reachable from the header while new work
+  // takes over the panel — whether that PR is still open (a push updates it) or
+  // already merged (this is follow-up work, and the merged PR is its context).
+  const prLink = pr?.state === "open" || pr?.state === "merged";
   switch (state) {
     case "loading":
       return { kind: "neutral", text: "Loading…" };
-    // With an open PR, keep its GitHub link reachable from the header even
-    // while new uncommitted changes take over the panel.
     case "changes":
       return {
         kind: "changes",
         pill: "Uncommitted",
         text: branch,
         diff: true,
-        ext: pr?.state === "open",
+        ext: prLink,
       };
     case "pushed":
-      return { kind: "info", pill: "Pushed", text: branch };
+      return { kind: "info", pill: "Pushed", text: branch, ext: prLink };
     case "conflicts":
       return { kind: "att", pill: "Conflicts", text: branch, sub: `← ${base}` };
     case "pr-open": {

--- a/src/components/RightPanel/GitPanel/hooks/useActionBarModel.ts
+++ b/src/components/RightPanel/GitPanel/hooks/useActionBarModel.ts
@@ -67,6 +67,7 @@ export function useActionBarModel(input: {
     checksFailed,
     commitAction: gitCommitAction,
     prOpen,
+    prMerged: prState?.state === "merged",
     githubConnected,
     // A local-only repo (no origin) can't push/PR until published. GitState is
     // null while loading — assume an origin then so the CTA doesn't flicker to

--- a/src/components/RightPanel/primaryActions.ts
+++ b/src/components/RightPanel/primaryActions.ts
@@ -100,6 +100,11 @@ export interface ActionCounts {
   /** Changes state: a PR is already open for this branch — "open PR" is
    *  meaningless (push updates it) and Merge belongs in the menu. */
   prOpen?: boolean;
+  /** The bound PR has merged, so anything here is follow-up work. Changes the
+   *  pushed state's copy: `ahead` still counts the commits that landed (the
+   *  local base stays stale until the next fetch), and "no PR yet" would read
+   *  as "never had one". */
+  prMerged?: boolean;
   /** Whether GitHub is connected (a valid app token). When false, any
    *  push/PR action is replaced by "Connect GitHub" — local work still runs. */
   githubConnected?: boolean;
@@ -150,6 +155,7 @@ export function primaryFor(state: GitPanelState, counts?: ActionCounts): Primary
     files = 0,
     ahead = 0,
     behind = 0,
+    unpushed = 0,
     prNumber,
     base = "main",
     customActive = false,
@@ -158,6 +164,7 @@ export function primaryFor(state: GitPanelState, counts?: ActionCounts): Primary
     checksFailed = 0,
     commitAction = "agent-commit-pr",
     prOpen = false,
+    prMerged = false,
   } = counts ?? {};
   const prLabel = prNumber != null ? `PR #${prNumber}` : "PR";
 
@@ -224,8 +231,16 @@ export function primaryFor(state: GitPanelState, counts?: ActionCounts): Primary
         key: "agent-open-pr",
         label: "Open PR",
         icon: "pr",
-        statusLabel:
-          ahead === 1 ? "1 commit pushed, no PR yet" : `${ahead} commits pushed, no PR yet`,
+        // Follow-up work after a merge needs its own count and phrasing: the
+        // landed commits are still in `ahead` (the local base doesn't move until
+        // the next fetch) and they ARE pushed, so only the unpushed ones are new
+        // — and the PR isn't missing, it merged. `unpushed > 0` is exactly how
+        // this state was reached (see `hasWorkSinceMerge`).
+        statusLabel: prMerged
+          ? `${unpushed === 1 ? "1 new commit" : `${unpushed} new commits`} since ${prLabel}`
+          : ahead === 1
+            ? "1 commit pushed, no PR yet"
+            : `${ahead} commits pushed, no PR yet`,
         statusKind: "info",
       };
     }

--- a/src/components/RightPanel/primaryActions.ts
+++ b/src/components/RightPanel/primaryActions.ts
@@ -1,6 +1,7 @@
 import type { GitState, Mergeable, MergeState, PrState } from "@/api";
 import type { IconName } from "@/components/Icon";
 import { describeMergeGate } from "@/mergeGate";
+import { hasWorkSinceMerge } from "@/readiness";
 
 /** Derived git panel state — computed from live GitState, not stored. */
 export type GitPanelState =
@@ -15,11 +16,17 @@ export type GitPanelState =
 
 /** Map live git + PR state to the panel state. Uncommitted changes outrank
  *  an open PR — the user's in-flight work is the actionable thing; the PR
- *  (and Merge) stays one click away in the menu and the status chip. */
+ *  (and Merge) stays one click away in the menu and the status chip.
+ *
+ *  A merged PR is not terminal for the workspace, only for that PR: the agent
+ *  goes on working in the same worktree and opens follow-up PRs. So `merged`
+ *  claims the panel only while nothing has happened since the merge — otherwise
+ *  it would hide the new work behind an Archive button (the merged state renders
+ *  no file list and offers no way to commit). */
 export function deriveState(git: GitState | null, pr: PrState | null): GitPanelState {
   if (!git) return "loading";
   if (git.files.some((f) => f.kind === "conflicted")) return "conflicts";
-  if (pr?.state === "merged") return "merged";
+  if (pr?.state === "merged" && !hasWorkSinceMerge(git)) return "merged";
   if (git.files.length > 0) return "changes";
   if (pr?.state === "open") return "pr-open";
   if (pr?.state === "closed") return "pr-closed";

--- a/src/readiness.test.ts
+++ b/src/readiness.test.ts
@@ -119,10 +119,19 @@ describe("detectBlockers", () => {
     expect(kinds(input({ git: git({ unpushed: 2 }), pr: pr(), checks: checks() }))).toEqual([
       "unpushed",
     ]);
-    // Merged/closed is not "unsubmitted" — there is nothing left to propose. A
-    // closed proposal is its own blocker (see below), a merged one is done.
-    expect(kinds(input({ pr: pr({ state: "merged" }) }))).toEqual([]);
-    expect(kinds(input({ pr: pr({ state: "closed" }) }))).not.toContain("unsubmitted");
+    // A merged proposal covers the work that landed, `ahead` and all — nothing
+    // left to propose. A closed one is its own blocker (see below); replacing it
+    // is a human call, never a silent re-submit.
+    expect(kinds(input({ git: git({ ahead: 3 }), pr: pr({ state: "merged" }) }))).toEqual([]);
+    expect(kinds(input({ git: git({ unpushed: 2 }), pr: pr({ state: "closed" }) }))).not.toContain(
+      "unsubmitted",
+    );
+    // But commits made *after* the merge need a follow-up proposal. Only
+    // `unpushed` can see them — `ahead` above is stale-base noise.
+    expect(kinds(input({ git: git({ unpushed: 2 }), pr: pr({ state: "merged" }) }))).toEqual([
+      "unpushed",
+      "unsubmitted",
+    ]);
   });
 
   it("maps the merge gate onto diverged / checks / review / draft", () => {
@@ -309,6 +318,21 @@ describe("nextRung ordering", () => {
     expect(rung({ pr: pr({ state: "merged" }) })).toEqual({ do: "landed" });
     // Clean tree, nothing pushed anywhere, no proposal to make.
     expect(rung({ git: git({ ahead: 0 }) })).toEqual({ do: "ready" });
+  });
+
+  it("keeps climbing after a merge — landed is not the end of the workspace", () => {
+    const merged = pr({ state: "merged" });
+    // Uncommitted work → commit it, and (no open proposal now) open a follow-up.
+    expect(rung({ git: git({ files: [file("modified")] }), pr: merged })).toMatchObject({
+      do: "delegate",
+      kind: "commit-pr",
+      params: { base: "main" },
+    });
+    // Already committed → straight to the follow-up proposal.
+    expect(rung({ git: git({ unpushed: 1 }), pr: merged })).toMatchObject({
+      do: "delegate",
+      kind: "open-pr",
+    });
   });
 
   it("is total — every combination yields a rung", () => {

--- a/src/readiness.ts
+++ b/src/readiness.ts
@@ -72,6 +72,21 @@ export type Blocker =
    *  human call, so this escalates rather than silently reading as ready. */
   | { kind: "proposal-closed" };
 
+/** Local work that appeared *after* a merge — the signal that "merged" is
+ *  history rather than this workspace's current state. A merged PR doesn't end a
+ *  workspace: the agent keeps working in the same worktree and opens follow-up
+ *  PRs, so every derivation asks this before letting `merged` speak.
+ *
+ *  Deliberately local-only. `ahead` is NOT consulted: it is measured against the
+ *  base branch, which stays stale until the next fetch, so a squash-merge leaves
+ *  `ahead > 0` with nothing new in the tree — reading that as new work would
+ *  claim follow-up work the moment every PR lands. Uncommitted files and commits
+ *  the origin branch doesn't have are both true the instant they happen and
+ *  false right after a merge. */
+export function hasWorkSinceMerge(git: GitState): boolean {
+  return git.files.length > 0 || git.unpushed > 0;
+}
+
 export interface ReadinessInput {
   /** Null while the first read is in flight — reported as `unknown`, never as
    *  "nothing wrong". */
@@ -106,9 +121,13 @@ export function detectBlockers({ git, pr, checks, comments }: ReadinessInput): B
   if (git.unpushed > 0) blockers.push({ kind: "unpushed", commits: git.unpushed });
 
   const prOpen = pr?.state === "open";
-  // A merged or closed proposal is not "unsubmitted" — there is nothing to
-  // propose. Only work that exists and was never proposed counts.
-  if (!pr && git.ahead > 0) blockers.push({ kind: "unsubmitted" });
+  // Work no proposal covers. With no PR at all, "ahead of base" is the measure.
+  // After a merge the same work needs a *follow-up* proposal, but `ahead` can't
+  // see it (see `hasWorkSinceMerge`) — only commits the origin branch lacks
+  // prove work appeared since. A closed proposal is its own blocker below:
+  // replacing it is a human call, not a silent re-submit.
+  const unproposed = pr == null ? git.ahead > 0 : pr.state === "merged" && git.unpushed > 0;
+  if (unproposed) blockers.push({ kind: "unsubmitted" });
   if (pr?.state === "closed") blockers.push({ kind: "proposal-closed" });
 
   if (prOpen) {
@@ -199,7 +218,10 @@ export function nextRung(input: ReadinessInput, ctx: LadderContext): Rung {
   const { git, pr, checks } = input;
   // No read yet: acting on absent state would be acting on a guess.
   if (!git) return { do: "wait", why: "unknown-state" };
-  if (pr?.state === "merged") return { do: "landed" };
+  // Landed is only terminal while nothing new has appeared since the merge;
+  // otherwise the ladder keeps climbing and the follow-up work gets committed,
+  // pushed and proposed like any other.
+  if (pr?.state === "merged" && !hasWorkSinceMerge(git)) return { do: "landed" };
 
   const blockers = detectBlockers(input);
   const find = <K extends Blocker["kind"]>(kind: K) =>

--- a/tests/components/RightPanel/primaryActions.test.ts
+++ b/tests/components/RightPanel/primaryActions.test.ts
@@ -42,9 +42,27 @@ describe("deriveState", () => {
     expect(deriveState(git(), pr())).toBe("pr-open");
   });
 
-  it("conflicts and merged still take precedence over changes", () => {
+  it("conflicts still take precedence over changes", () => {
     expect(deriveState(git({ files: [file("conflicted")] }), pr())).toBe("conflicts");
-    expect(deriveState(git({ files: [file("modified")] }), pr({ state: "merged" }))).toBe("merged");
+    expect(deriveState(git({ files: [file("conflicted")] }), pr({ state: "merged" }))).toBe(
+      "conflicts",
+    );
+  });
+
+  it("merged claims the panel only while nothing has happened since the merge", () => {
+    const merged = pr({ state: "merged" });
+    expect(deriveState(git(), merged)).toBe("merged");
+    // A squash-merge leaves `ahead > 0` against a stale local base with nothing
+    // new in the tree — that must NOT read as follow-up work.
+    expect(deriveState(git({ ahead: 3 }), merged)).toBe("merged");
+  });
+
+  it("keeps working after a merge: follow-up work moves the panel off merged", () => {
+    const merged = pr({ state: "merged" });
+    // New edits → the file list and a commit CTA come back...
+    expect(deriveState(git({ files: [file("modified")] }), merged)).toBe("changes");
+    // ...and once committed, "pushed" offers the follow-up PR.
+    expect(deriveState(git({ unpushed: 1 }), merged)).toBe("pushed");
   });
 });
 

--- a/tests/components/RightPanel/primaryActions.test.ts
+++ b/tests/components/RightPanel/primaryActions.test.ts
@@ -66,6 +66,29 @@ describe("deriveState", () => {
   });
 });
 
+describe("pushed state after a merge", () => {
+  it("counts and names follow-up commits honestly, never as 'no PR yet'", () => {
+    // `ahead` still includes the 3 commits that landed in #7 — the local base
+    // doesn't move until the next fetch — and those ARE pushed. Only the 1
+    // unpushed commit is new work, and the PR isn't missing, it merged.
+    const p = primaryFor("pushed", { ...base, ahead: 4, unpushed: 1, prMerged: true });
+    expect(p.key).toBe("agent-open-pr");
+    expect(p.statusLabel).toBe("1 new commit since PR #7");
+    expect(
+      primaryFor("pushed", { ...base, ahead: 9, unpushed: 2, prMerged: true }).statusLabel,
+    ).toBe("2 new commits since PR #7");
+  });
+
+  it("leaves the no-PR-yet copy alone when nothing has merged", () => {
+    expect(primaryFor("pushed", { ...base, ahead: 1 }).statusLabel).toBe(
+      "1 commit pushed, no PR yet",
+    );
+    expect(primaryFor("pushed", { ...base, ahead: 3 }).statusLabel).toBe(
+      "3 commits pushed, no PR yet",
+    );
+  });
+});
+
 describe("changes-state sticky commit action", () => {
   it("defaults to Commit & open PR", () => {
     const p = primaryFor("changes", { files: 2 });


### PR DESCRIPTION
A workspace whose PR has merged can keep working — more changes, follow-up PRs — but `merged` was treated as an absorbing state in three places, so the Git panel froze in "Merged" and there was no way forward.

## What was wrong

**The panel hid the new work.** `deriveState` tested `merged` above `git.files.length > 0`, and the merged panel state renders no file list (`showFiles` covers only `changes`/`conflicts`) and offers only Archive / Delete branch. New changes in the worktree were invisible, with no CTA to commit them.

**The ladder called it done.** `nextRung` returned `landed` before detecting blockers, so Mission Control and autopilot reported a landed PR while uncommitted work sat in the tree.

**A follow-up PR corrupted the binding.** The delegated `open_pr` path calls `set_repo_pr_number`, which bound the new number but left `pr_state = 'merged'` and the previous PR's url/title in place. `resolve_pr_state` serves a merged snapshot with no network (merges don't un-happen), so the panel rendered `merged #<new>` linking to the *old* PR — permanently, with no fetch left to correct it. The direct in-app `create_pr` path recovered, because it overwrites the whole snapshot.

## What changed

`merged` is now history rather than state. One shared predicate, `hasWorkSinceMerge(git)` in `readiness.ts`, gates both derivations: `merged`/`landed` hold only while nothing has happened since the merge. New edits → `changes` (file list + "Commit & open PR"); committed → `pushed` ("Open PR"). `detectBlockers` reports `unsubmitted` for commits made after a merge, so the ladder delegates a follow-up PR instead of parking. Autopilot reaches it through the existing `delegate` path, still bounded by `RUNG_BUDGET` and the no-progress signature.

The predicate reads `files` and `unpushed` only — **never `ahead`**. `ahead` is measured against a base branch that stays stale until the next fetch, so a squash-merge leaves it `> 0` with nothing new in the tree; using it would claim follow-up work the moment every PR lands. Pinned by a test.

Backend: `set_repo_pr_number` clears `pr_url`/`pr_title`/`pr_state`/`pr_opened_at`/`pr_merged_at` when the number actually changes (`CASE WHEN pr_number IS ?1`, evaluated against the pre-update row), so a follow-up PR can't inherit `merged` and get served from the short-circuit forever. Re-binding the same number is a no-op, so ordinary polls keep the snapshot they just confirmed. `set_repo_pr_snapshot`'s timestamp `COALESCE` is scoped to the same PR identity too — `create_pr` bypasses `set_repo_pr_number`, and without this a new open PR inherited the previous one's `pr_merged_at`.

No change was needed in `GitRepoSection` — reordering `deriveState` makes `panelState` become `changes`, which `showFiles` already handles. The status header keeps the bound PR's ↗ link in `changes`/`pushed` when it is open *or* merged, so the merged PR stays reachable as context for the follow-up work.

## Testing

730 frontend tests pass, `tsc --noEmit` and biome clean; 1088 Rust lib tests pass, `cargo fmt --check` and clippy clean. New coverage for merged-with-follow-up-work in `primaryActions.test.ts` and `readiness.test.ts`, and two `workspace/tests.rs` cases for the rebind (columns cleared on a new number, kept on the same one) and the timestamp scoping.

One unrelated failure in the full Rust run: `run_detect::port::tests::free_port_returns_start_when_open` expected port 64267 and got 64268. It passes in isolation — a pre-existing parallel-test port race, untouched here.

## Deliberately not in scope

- **Out-of-band discovery.** A follow-up PR opened on github.com is still not adopted: `resolve_pr_state` returns from the merged short-circuit before `may_discover`. Re-opening that window costs a GraphQL point per 60s per merged-and-moved repo, and that tradeoff deserves its own review. Follows separately.
- **PR history.** This keeps one *current* PR per checkout, rebinding on each new one; merged PRs aren't retained. Worth noting that `pulseData.ts` counts PRs via `worktrees.pr_opened_at` (one row per checkout), so a workspace's second PR already overwrote the first's timestamp — that chart undercounts follow-up PRs today, and only real history fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)