### PR TITLE
fix(git): adopt a follow-up PR opened out-of-band after a merge

### DIFF
--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -231,6 +231,11 @@ pub(crate) fn persist_pr_snapshot(
 /// branch and no PR (an agent mid-task: the common case) never becomes bound, so
 /// a background poll would re-scan forever: at the Git panel's 5s cadence that
 /// was ~720 points/hour, the largest single consumer left in the app.
+///
+/// A repo bound to a *merged* PR reads the same distinction (see
+/// `resolve_pr_state`): `Forced` scans for a follow-up PR, `Throttled` stays on
+/// the free snapshot. So the mode means the same thing in both cases — "is a new
+/// PR plausible enough right now to spend a point looking for it".
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Discovery {
     /// Scan now. For paths where a push or a turn just happened, so a brand-new
@@ -244,12 +249,12 @@ pub enum Discovery {
 /// Minimum gap between branch scans for the same unbound repo under
 /// [`Discovery::Throttled`]. A PR opened outside the app (on github.com, by a
 /// teammate) is still adopted within this window, and once adopted the repo is
-/// bound and never scans again.
+/// bound and scans only on the `Forced` follow-up path.
 const DISCOVERY_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Last throttled branch scan per `(agent_id, subdir)`. Only unbound repos land
-/// here — adoption removes the reason to scan at all — so this is bounded by the
-/// number of repos still waiting on a first PR.
+/// here — a bound repo's scans are all `Forced`, which never touches the clock —
+/// so this is bounded by the number of repos still waiting on a first PR.
 fn discovery_clock() -> &'static Mutex<HashMap<(String, String), Instant>> {
     static CLOCK: OnceLock<Mutex<HashMap<(String, String), Instant>>> = OnceLock::new();
     CLOCK.get_or_init(|| Mutex::new(HashMap::new()))
@@ -274,6 +279,20 @@ fn may_discover(agent_id: &str, subdir: &str, discovery: Discovery) -> bool {
     }
 }
 
+/// Whether a branch scan's result supersedes a merged binding — i.e. it is a
+/// genuine follow-up PR rather than the merged one we already hold.
+///
+/// Only an OPEN PR qualifies. `pick_branch_pr` prefers the newest open PR and
+/// falls back to the newest of any state, so a branch with a follow-up scans to
+/// that follow-up, and a branch without one scans back to the merged PR itself.
+/// The number guard makes the second case explicit rather than relying on "a
+/// merged PR can never read OPEN" — an adoption that re-bound the number we
+/// already have would clear its own snapshot columns (see
+/// `set_repo_pr_number`'s identity rule) for no reason.
+fn supersedes_merged(scanned: &PrState, bound: i64) -> bool {
+    matches!(scanned.state, PrStatus::Open) && scanned.number as i64 != bound
+}
+
 /// Drop a repo's discovery record — called once it binds a PR, so the entry
 /// doesn't outlive the state that made it necessary.
 fn clear_discovery(agent_id: &str, subdir: &str) {
@@ -290,11 +309,13 @@ fn clear_discovery(agent_id: &str, subdir: &str) {
 ///
 /// - **Bound PR** (`pr_number` recorded): a persisted `merged` state returns
 ///   straight from the database — merges don't un-happen, so no network or
-///   git access is spent re-confirming them. Otherwise fetch by number
-///   (resolving owner/repo from the checkout, or from the source repo when
-///   the checkout is broken), persist the result, and on failure degrade to
-///   the last persisted snapshot — a failed fetch must never erase state
-///   GitHub already confirmed.
+///   git access is spent re-confirming them. The one exception is a `Forced`
+///   resolve, which scans the branch for a *follow-up* PR: a merged PR ends
+///   that PR, not the workspace, and an open one found there is adopted in its
+///   place. Otherwise fetch by number (resolving owner/repo from the checkout,
+///   or from the source repo when the checkout is broken), persist the result,
+///   and on failure degrade to the last persisted snapshot — a failed fetch
+///   must never erase state GitHub already confirmed.
 /// - **No bound PR**: discover one by branch name, subject to `discovery` (see
 ///   [`Discovery`] — background polls scan on an interval, event-driven paths
 ///   scan immediately). An OPEN PR is adopted (persisted, becoming bound); a
@@ -329,9 +350,33 @@ pub(crate) async fn resolve_pr_state(
         // reopened, so it stays on the live-fetch path (and keeps costing a
         // poll per cycle) to catch that transition.
         if repo.pr_state.as_deref() == Some(PrStatus::Merged.as_str()) {
+            // …unless a follow-up PR may have appeared. A merged PR doesn't end
+            // the workspace: the agent keeps working in the same worktree and
+            // opens further PRs, and without this the repo stays bound to the
+            // merged one forever — a follow-up opened out-of-band (on
+            // github.com, by a teammate) is never adopted, because the return
+            // above precedes every scan.
+            //
+            // Gated on `Forced`, which already means "a push or a turn just
+            // landed, so a brand-new PR is genuinely plausible and worth a
+            // point". Background polls keep the free short-circuit, so this adds
+            // nothing to the steady state — the cost tracks user/agent activity
+            // in a merged workspace, not a timer.
+            if discovery == Discovery::Forced {
+                if let Some(found) = crate::github::pr_view(&checkout).await.unwrap_or(None) {
+                    if supersedes_merged(&found, number) {
+                        persist_pr_snapshot(workspace, agent_id, &repo.subdir, &found);
+                        return Some((found, true));
+                    }
+                }
+            }
+            // No scan, nothing newer, or the scan didn't resolve — the merged
+            // snapshot stands. Never `None`: a failed lookup must not blank a
+            // state GitHub already confirmed.
             return pr_snapshot(repo).map(|pr| (pr, true));
         }
-        // Bound: this repo never needs discovery again.
+        // Bound to a live PR: a by-number fetch tells us everything a branch
+        // scan could, so no throttled scan is owed and the record can go.
         clear_discovery(agent_id, &repo.subdir);
         match crate::github::pr_view_number(&checkout, Some(&repo.repo_path), number as u32).await {
             Ok(Some(pr)) => {
@@ -1456,8 +1501,42 @@ mod tests {
         clear_discovery("ag-1", "backend");
     }
 
-    /// Binding a PR clears the record: the repo will never scan again, so the
-    /// entry shouldn't outlive the state that justified it.
+    /// Only an OPEN PR takes a merged binding's place. `pick_branch_pr` scans a
+    /// branch back to its merged PR when there's no follow-up, and adopting that
+    /// would re-bind the number we already hold — clearing its own snapshot
+    /// columns (see `set_repo_pr_number`) to replace merged state with merged
+    /// state.
+    #[test]
+    fn only_an_open_follow_up_supersedes_a_merged_binding() {
+        let pr = |number: u32, state: PrStatus| PrState {
+            number,
+            url: format!("https://github.com/o/r/pull/{number}"),
+            title: "t".into(),
+            state,
+            mergeable: MergeableState::Unknown,
+            opened_at: None,
+            merged_at: None,
+        };
+        assert!(
+            supersedes_merged(&pr(43, PrStatus::Open), 42),
+            "an open follow-up is the workspace's current PR"
+        );
+        assert!(
+            !supersedes_merged(&pr(42, PrStatus::Merged), 42),
+            "the scan found the PR we already hold"
+        );
+        assert!(
+            !supersedes_merged(&pr(43, PrStatus::Closed), 42),
+            "a closed follow-up is never claimed as the binding"
+        );
+        assert!(
+            !supersedes_merged(&pr(43, PrStatus::Merged), 42),
+            "a second merged PR is history too, not the current state"
+        );
+    }
+
+    /// Binding a PR clears the record: the repo is owed no further throttled
+    /// scan, so the entry shouldn't outlive the state that justified it.
     #[test]
     fn clearing_discovery_reopens_the_window() {
         let (agent, sub) = ("ag-clear", "");

--- a/src-tauri/src/workspace/agents.rs
+++ b/src-tauri/src/workspace/agents.rs
@@ -209,10 +209,30 @@ impl WorkspaceManager {
     /// Written when a PR is created through the app or adopted from an OPEN
     /// out-of-band PR. Overwrites unconditionally — the latest PR opened for
     /// the branch is the one we track.
+    ///
+    /// Binding a *different* number clears the display snapshot and lifecycle
+    /// stamps, because they describe the PR being replaced. This matters most
+    /// after a merge: `resolve_pr_state` short-circuits a `merged` snapshot with
+    /// no network (merges don't un-happen), so a follow-up PR that inherited
+    /// `pr_state = 'merged'` would render as "merged #<new>" with the previous
+    /// PR's url and title, forever, with no fetch left to correct it. Cleared
+    /// columns read as "never fetched" instead, and the next resolve fills them
+    /// in from GitHub. Re-binding the same number is a no-op, so the ordinary
+    /// path keeps its snapshot.
     pub fn set_repo_pr_number(&self, agent_id: &str, subdir: &str, pr_number: i64) -> Result<()> {
         let conn = self.db.lock();
+        // SQLite evaluates SET expressions against the pre-update row, so each
+        // `pr_number IS ?1` compares the number being replaced. `IS` (not `=`)
+        // so a first bind, where the old number is NULL, also counts as a change.
         conn.execute(
-            "UPDATE worktrees SET pr_number = ?1 WHERE workspace_id = ?2 AND subdir = ?3",
+            "UPDATE worktrees
+                SET pr_number    = ?1,
+                    pr_url       = CASE WHEN pr_number IS ?1 THEN pr_url       ELSE NULL END,
+                    pr_title     = CASE WHEN pr_number IS ?1 THEN pr_title     ELSE NULL END,
+                    pr_state     = CASE WHEN pr_number IS ?1 THEN pr_state     ELSE NULL END,
+                    pr_opened_at = CASE WHEN pr_number IS ?1 THEN pr_opened_at ELSE NULL END,
+                    pr_merged_at = CASE WHEN pr_number IS ?1 THEN pr_merged_at ELSE NULL END
+              WHERE workspace_id = ?2 AND subdir = ?3",
             rusqlite::params![pr_number, agent_id, subdir],
         )?;
         Ok(())
@@ -228,7 +248,10 @@ impl WorkspaceManager {
     /// (url / title / state), and GitHub's own lifecycle times. One write per
     /// fetch keeps the database the durable source of truth the UI can render
     /// from when GitHub or the checkout is unavailable. Times COALESCE so an
-    /// earlier-observed value is never erased by a payload that omits it.
+    /// earlier-observed value is never erased by a payload that omits it — but
+    /// only for the PR they describe: a follow-up PR bound into the same
+    /// checkout (the workspace kept working after a merge) takes the payload's
+    /// times as they are, so it can't inherit the previous PR's merge stamp.
     pub fn set_repo_pr_snapshot(
         &self,
         agent_id: &str,
@@ -238,8 +261,10 @@ impl WorkspaceManager {
         let conn = self.db.lock();
         conn.execute(
             "UPDATE worktrees SET pr_number = ?1, pr_url = ?2, pr_title = ?3, pr_state = ?4,
-                                  pr_opened_at = COALESCE(?5, pr_opened_at),
-                                  pr_merged_at = COALESCE(?6, pr_merged_at)
+                                  pr_opened_at = CASE WHEN pr_number IS ?1
+                                                 THEN COALESCE(?5, pr_opened_at) ELSE ?5 END,
+                                  pr_merged_at = CASE WHEN pr_number IS ?1
+                                                 THEN COALESCE(?6, pr_merged_at) ELSE ?6 END
              WHERE workspace_id = ?7 AND subdir = ?8",
             rusqlite::params![
                 pr.number as i64,

--- a/src-tauri/src/workspace/tests.rs
+++ b/src-tauri/src/workspace/tests.rs
@@ -1196,6 +1196,131 @@ fn pr_snapshot_persists_and_loads() {
     assert_eq!(merged_at, Some(2_000));
 }
 
+/// A merged PR doesn't end the workspace: the agent keeps working in the same
+/// worktree and opens a follow-up PR. Binding that new number must drop the
+/// merged PR's display snapshot and stamps, or `resolve_pr_state` short-circuits
+/// the inherited `merged` state and renders "merged #<new>" — with the previous
+/// PR's url and title — with no fetch left to correct it.
+#[test]
+fn binding_a_follow_up_pr_clears_the_merged_snapshot() {
+    let db = test_db();
+    let wm = WorkspaceManager::new(db.clone());
+    seed_repo(&db, "/r");
+
+    let mut rec = new_agent_record(
+        "denali".into(),
+        "a".into(),
+        "claude".into(),
+        mk_repo("/r"),
+        "task".into(),
+        AgentView::Custom,
+    );
+    let id = rec.id.clone();
+    wm.add_agent(&mut rec).unwrap();
+    let subdir = wm.agent(&id).unwrap().repos[0].subdir.clone();
+
+    let merged = crate::github::PrState {
+        number: 42,
+        url: "https://github.com/o/r/pull/42".into(),
+        title: "feat: first".into(),
+        state: crate::github::PrStatus::Merged,
+        mergeable: crate::github::MergeableState::Unknown,
+        opened_at: Some(1_000),
+        merged_at: Some(2_000),
+    };
+    wm.set_repo_pr_snapshot(&id, &subdir, &merged).unwrap();
+
+    // Re-binding the SAME number is the ordinary path — it must keep the
+    // snapshot, so a poll never blanks a badge it just confirmed.
+    wm.set_repo_pr_number(&id, &subdir, 42).unwrap();
+    let repo = wm.agent(&id).unwrap().repos[0].clone();
+    assert_eq!(repo.pr_state.as_deref(), Some("merged"));
+    assert_eq!(repo.pr_title.as_deref(), Some("feat: first"));
+
+    // The agent opens a follow-up PR (the delegated `open_pr` path, which binds
+    // a number and nothing else).
+    wm.set_repo_pr_number(&id, &subdir, 43).unwrap();
+    let repo = wm.agent(&id).unwrap().repos[0].clone();
+    assert_eq!(repo.pr_number, Some(43));
+    assert_eq!(
+        repo.pr_state, None,
+        "the new PR must not inherit 'merged' — that state is served with no network"
+    );
+    assert_eq!(repo.pr_url, None, "url would link to the previous PR");
+    assert_eq!(repo.pr_title, None, "title would name the previous PR");
+    let conn = db.lock();
+    let (opened, merged_at): (Option<i64>, Option<i64>) = conn
+        .query_row(
+            "SELECT pr_opened_at, pr_merged_at FROM worktrees WHERE workspace_id = ?1",
+            [&id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(opened, None);
+    assert_eq!(
+        merged_at, None,
+        "an open PR carrying the previous PR's merge stamp reads as already landed"
+    );
+}
+
+/// The direct in-app path (`create_pr` → `set_repo_pr_snapshot`) opens a
+/// follow-up PR without going through `set_repo_pr_number`, so the times must
+/// not COALESCE across the identity change either.
+#[test]
+fn a_follow_up_snapshot_does_not_inherit_the_previous_merge_stamp() {
+    let db = test_db();
+    let wm = WorkspaceManager::new(db.clone());
+    seed_repo(&db, "/r");
+
+    let mut rec = new_agent_record(
+        "denali".into(),
+        "a".into(),
+        "claude".into(),
+        mk_repo("/r"),
+        "task".into(),
+        AgentView::Custom,
+    );
+    let id = rec.id.clone();
+    wm.add_agent(&mut rec).unwrap();
+    let subdir = wm.agent(&id).unwrap().repos[0].subdir.clone();
+
+    let merged = crate::github::PrState {
+        number: 42,
+        url: "https://github.com/o/r/pull/42".into(),
+        title: "feat: first".into(),
+        state: crate::github::PrStatus::Merged,
+        mergeable: crate::github::MergeableState::Unknown,
+        opened_at: Some(1_000),
+        merged_at: Some(2_000),
+    };
+    wm.set_repo_pr_snapshot(&id, &subdir, &merged).unwrap();
+
+    let follow_up = crate::github::PrState {
+        number: 43,
+        url: "https://github.com/o/r/pull/43".into(),
+        title: "feat: second".into(),
+        state: crate::github::PrStatus::Open,
+        mergeable: crate::github::MergeableState::Mergeable,
+        opened_at: Some(3_000),
+        merged_at: None,
+    };
+    wm.set_repo_pr_snapshot(&id, &subdir, &follow_up).unwrap();
+
+    let repo = wm.agent(&id).unwrap().repos[0].clone();
+    assert_eq!(repo.pr_number, Some(43));
+    assert_eq!(repo.pr_state.as_deref(), Some("open"));
+    let conn = db.lock();
+    let (opened, merged_at): (Option<i64>, Option<i64>) = conn
+        .query_row(
+            "SELECT pr_opened_at, pr_merged_at FROM worktrees WHERE workspace_id = ?1",
+            [&id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(opened, Some(3_000));
+    assert_eq!(merged_at, None, "PR #43 is open, not merged at 2_000");
+}
+
 #[test]
 fn agent_status_transitions() {
     let db = test_db();

--- a/src/components/RightPanel/GitPanel/StatusHeader.tsx
+++ b/src/components/RightPanel/GitPanel/StatusHeader.tsx
@@ -57,21 +57,23 @@ export function describeHeader(
   checksFailed: number,
 ): HeaderInfo {
   const n = pr?.number;
+  // Keep the bound PR's GitHub link reachable from the header while new work
+  // takes over the panel — whether that PR is still open (a push updates it) or
+  // already merged (this is follow-up work, and the merged PR is its context).
+  const prLink = pr?.state === "open" || pr?.state === "merged";
   switch (state) {
     case "loading":
       return { kind: "neutral", text: "Loading…" };
-    // With an open PR, keep its GitHub link reachable from the header even
-    // while new uncommitted changes take over the panel.
     case "changes":
       return {
         kind: "changes",
         pill: "Uncommitted",
         text: branch,
         diff: true,
-        ext: pr?.state === "open",
+        ext: prLink,
       };
     case "pushed":
-      return { kind: "info", pill: "Pushed", text: branch };
+      return { kind: "info", pill: "Pushed", text: branch, ext: prLink };
     case "conflicts":
       return { kind: "att", pill: "Conflicts", text: branch, sub: `← ${base}` };
     case "pr-open": {

--- a/src/components/RightPanel/GitPanel/hooks/useActionBarModel.ts
+++ b/src/components/RightPanel/GitPanel/hooks/useActionBarModel.ts
@@ -67,6 +67,7 @@ export function useActionBarModel(input: {
     checksFailed,
     commitAction: gitCommitAction,
     prOpen,
+    prMerged: prState?.state === "merged",
     githubConnected,
     // A local-only repo (no origin) can't push/PR until published. GitState is
     // null while loading — assume an origin then so the CTA doesn't flicker to

--- a/src/components/RightPanel/primaryActions.ts
+++ b/src/components/RightPanel/primaryActions.ts
@@ -100,6 +100,11 @@ export interface ActionCounts {
   /** Changes state: a PR is already open for this branch — "open PR" is
    *  meaningless (push updates it) and Merge belongs in the menu. */
   prOpen?: boolean;
+  /** The bound PR has merged, so anything here is follow-up work. Changes the
+   *  pushed state's copy: `ahead` still counts the commits that landed (the
+   *  local base stays stale until the next fetch), and "no PR yet" would read
+   *  as "never had one". */
+  prMerged?: boolean;
   /** Whether GitHub is connected (a valid app token). When false, any
    *  push/PR action is replaced by "Connect GitHub" — local work still runs. */
   githubConnected?: boolean;
@@ -150,6 +155,7 @@ export function primaryFor(state: GitPanelState, counts?: ActionCounts): Primary
     files = 0,
     ahead = 0,
     behind = 0,
+    unpushed = 0,
     prNumber,
     base = "main",
     customActive = false,
@@ -158,6 +164,7 @@ export function primaryFor(state: GitPanelState, counts?: ActionCounts): Primary
     checksFailed = 0,
     commitAction = "agent-commit-pr",
     prOpen = false,
+    prMerged = false,
   } = counts ?? {};
   const prLabel = prNumber != null ? `PR #${prNumber}` : "PR";
 
@@ -224,8 +231,16 @@ export function primaryFor(state: GitPanelState, counts?: ActionCounts): Primary
         key: "agent-open-pr",
         label: "Open PR",
         icon: "pr",
-        statusLabel:
-          ahead === 1 ? "1 commit pushed, no PR yet" : `${ahead} commits pushed, no PR yet`,
+        // Follow-up work after a merge needs its own count and phrasing: the
+        // landed commits are still in `ahead` (the local base doesn't move until
+        // the next fetch) and they ARE pushed, so only the unpushed ones are new
+        // — and the PR isn't missing, it merged. `unpushed > 0` is exactly how
+        // this state was reached (see `hasWorkSinceMerge`).
+        statusLabel: prMerged
+          ? `${unpushed === 1 ? "1 new commit" : `${unpushed} new commits`} since ${prLabel}`
+          : ahead === 1
+            ? "1 commit pushed, no PR yet"
+            : `${ahead} commits pushed, no PR yet`,
         statusKind: "info",
       };
     }

--- a/src/components/RightPanel/primaryActions.ts
+++ b/src/components/RightPanel/primaryActions.ts
@@ -1,6 +1,7 @@
 import type { GitState, Mergeable, MergeState, PrState } from "@/api";
 import type { IconName } from "@/components/Icon";
 import { describeMergeGate } from "@/mergeGate";
+import { hasWorkSinceMerge } from "@/readiness";
 
 /** Derived git panel state — computed from live GitState, not stored. */
 export type GitPanelState =
@@ -15,11 +16,17 @@ export type GitPanelState =
 
 /** Map live git + PR state to the panel state. Uncommitted changes outrank
  *  an open PR — the user's in-flight work is the actionable thing; the PR
- *  (and Merge) stays one click away in the menu and the status chip. */
+ *  (and Merge) stays one click away in the menu and the status chip.
+ *
+ *  A merged PR is not terminal for the workspace, only for that PR: the agent
+ *  goes on working in the same worktree and opens follow-up PRs. So `merged`
+ *  claims the panel only while nothing has happened since the merge — otherwise
+ *  it would hide the new work behind an Archive button (the merged state renders
+ *  no file list and offers no way to commit). */
 export function deriveState(git: GitState | null, pr: PrState | null): GitPanelState {
   if (!git) return "loading";
   if (git.files.some((f) => f.kind === "conflicted")) return "conflicts";
-  if (pr?.state === "merged") return "merged";
+  if (pr?.state === "merged" && !hasWorkSinceMerge(git)) return "merged";
   if (git.files.length > 0) return "changes";
   if (pr?.state === "open") return "pr-open";
   if (pr?.state === "closed") return "pr-closed";

--- a/src/readiness.test.ts
+++ b/src/readiness.test.ts
@@ -119,10 +119,19 @@ describe("detectBlockers", () => {
     expect(kinds(input({ git: git({ unpushed: 2 }), pr: pr(), checks: checks() }))).toEqual([
       "unpushed",
     ]);
-    // Merged/closed is not "unsubmitted" — there is nothing left to propose. A
-    // closed proposal is its own blocker (see below), a merged one is done.
-    expect(kinds(input({ pr: pr({ state: "merged" }) }))).toEqual([]);
-    expect(kinds(input({ pr: pr({ state: "closed" }) }))).not.toContain("unsubmitted");
+    // A merged proposal covers the work that landed, `ahead` and all — nothing
+    // left to propose. A closed one is its own blocker (see below); replacing it
+    // is a human call, never a silent re-submit.
+    expect(kinds(input({ git: git({ ahead: 3 }), pr: pr({ state: "merged" }) }))).toEqual([]);
+    expect(kinds(input({ git: git({ unpushed: 2 }), pr: pr({ state: "closed" }) }))).not.toContain(
+      "unsubmitted",
+    );
+    // But commits made *after* the merge need a follow-up proposal. Only
+    // `unpushed` can see them — `ahead` above is stale-base noise.
+    expect(kinds(input({ git: git({ unpushed: 2 }), pr: pr({ state: "merged" }) }))).toEqual([
+      "unpushed",
+      "unsubmitted",
+    ]);
   });
 
   it("maps the merge gate onto diverged / checks / review / draft", () => {
@@ -309,6 +318,21 @@ describe("nextRung ordering", () => {
     expect(rung({ pr: pr({ state: "merged" }) })).toEqual({ do: "landed" });
     // Clean tree, nothing pushed anywhere, no proposal to make.
     expect(rung({ git: git({ ahead: 0 }) })).toEqual({ do: "ready" });
+  });
+
+  it("keeps climbing after a merge — landed is not the end of the workspace", () => {
+    const merged = pr({ state: "merged" });
+    // Uncommitted work → commit it, and (no open proposal now) open a follow-up.
+    expect(rung({ git: git({ files: [file("modified")] }), pr: merged })).toMatchObject({
+      do: "delegate",
+      kind: "commit-pr",
+      params: { base: "main" },
+    });
+    // Already committed → straight to the follow-up proposal.
+    expect(rung({ git: git({ unpushed: 1 }), pr: merged })).toMatchObject({
+      do: "delegate",
+      kind: "open-pr",
+    });
   });
 
   it("is total — every combination yields a rung", () => {

--- a/src/readiness.ts
+++ b/src/readiness.ts
@@ -72,6 +72,21 @@ export type Blocker =
    *  human call, so this escalates rather than silently reading as ready. */
   | { kind: "proposal-closed" };
 
+/** Local work that appeared *after* a merge — the signal that "merged" is
+ *  history rather than this workspace's current state. A merged PR doesn't end a
+ *  workspace: the agent keeps working in the same worktree and opens follow-up
+ *  PRs, so every derivation asks this before letting `merged` speak.
+ *
+ *  Deliberately local-only. `ahead` is NOT consulted: it is measured against the
+ *  base branch, which stays stale until the next fetch, so a squash-merge leaves
+ *  `ahead > 0` with nothing new in the tree — reading that as new work would
+ *  claim follow-up work the moment every PR lands. Uncommitted files and commits
+ *  the origin branch doesn't have are both true the instant they happen and
+ *  false right after a merge. */
+export function hasWorkSinceMerge(git: GitState): boolean {
+  return git.files.length > 0 || git.unpushed > 0;
+}
+
 export interface ReadinessInput {
   /** Null while the first read is in flight — reported as `unknown`, never as
    *  "nothing wrong". */
@@ -106,9 +121,13 @@ export function detectBlockers({ git, pr, checks, comments }: ReadinessInput): B
   if (git.unpushed > 0) blockers.push({ kind: "unpushed", commits: git.unpushed });
 
   const prOpen = pr?.state === "open";
-  // A merged or closed proposal is not "unsubmitted" — there is nothing to
-  // propose. Only work that exists and was never proposed counts.
-  if (!pr && git.ahead > 0) blockers.push({ kind: "unsubmitted" });
+  // Work no proposal covers. With no PR at all, "ahead of base" is the measure.
+  // After a merge the same work needs a *follow-up* proposal, but `ahead` can't
+  // see it (see `hasWorkSinceMerge`) — only commits the origin branch lacks
+  // prove work appeared since. A closed proposal is its own blocker below:
+  // replacing it is a human call, not a silent re-submit.
+  const unproposed = pr == null ? git.ahead > 0 : pr.state === "merged" && git.unpushed > 0;
+  if (unproposed) blockers.push({ kind: "unsubmitted" });
   if (pr?.state === "closed") blockers.push({ kind: "proposal-closed" });
 
   if (prOpen) {
@@ -199,7 +218,10 @@ export function nextRung(input: ReadinessInput, ctx: LadderContext): Rung {
   const { git, pr, checks } = input;
   // No read yet: acting on absent state would be acting on a guess.
   if (!git) return { do: "wait", why: "unknown-state" };
-  if (pr?.state === "merged") return { do: "landed" };
+  // Landed is only terminal while nothing new has appeared since the merge;
+  // otherwise the ladder keeps climbing and the follow-up work gets committed,
+  // pushed and proposed like any other.
+  if (pr?.state === "merged" && !hasWorkSinceMerge(git)) return { do: "landed" };
 
   const blockers = detectBlockers(input);
   const find = <K extends Blocker["kind"]>(kind: K) =>

--- a/tests/components/RightPanel/primaryActions.test.ts
+++ b/tests/components/RightPanel/primaryActions.test.ts
@@ -42,9 +42,27 @@ describe("deriveState", () => {
     expect(deriveState(git(), pr())).toBe("pr-open");
   });
 
-  it("conflicts and merged still take precedence over changes", () => {
+  it("conflicts still take precedence over changes", () => {
     expect(deriveState(git({ files: [file("conflicted")] }), pr())).toBe("conflicts");
-    expect(deriveState(git({ files: [file("modified")] }), pr({ state: "merged" }))).toBe("merged");
+    expect(deriveState(git({ files: [file("conflicted")] }), pr({ state: "merged" }))).toBe(
+      "conflicts",
+    );
+  });
+
+  it("merged claims the panel only while nothing has happened since the merge", () => {
+    const merged = pr({ state: "merged" });
+    expect(deriveState(git(), merged)).toBe("merged");
+    // A squash-merge leaves `ahead > 0` against a stale local base with nothing
+    // new in the tree — that must NOT read as follow-up work.
+    expect(deriveState(git({ ahead: 3 }), merged)).toBe("merged");
+  });
+
+  it("keeps working after a merge: follow-up work moves the panel off merged", () => {
+    const merged = pr({ state: "merged" });
+    // New edits → the file list and a commit CTA come back...
+    expect(deriveState(git({ files: [file("modified")] }), merged)).toBe("changes");
+    // ...and once committed, "pushed" offers the follow-up PR.
+    expect(deriveState(git({ unpushed: 1 }), merged)).toBe("pushed");
   });
 });
 

--- a/tests/components/RightPanel/primaryActions.test.ts
+++ b/tests/components/RightPanel/primaryActions.test.ts
@@ -66,6 +66,29 @@ describe("deriveState", () => {
   });
 });
 
+describe("pushed state after a merge", () => {
+  it("counts and names follow-up commits honestly, never as 'no PR yet'", () => {
+    // `ahead` still includes the 3 commits that landed in #7 — the local base
+    // doesn't move until the next fetch — and those ARE pushed. Only the 1
+    // unpushed commit is new work, and the PR isn't missing, it merged.
+    const p = primaryFor("pushed", { ...base, ahead: 4, unpushed: 1, prMerged: true });
+    expect(p.key).toBe("agent-open-pr");
+    expect(p.statusLabel).toBe("1 new commit since PR #7");
+    expect(
+      primaryFor("pushed", { ...base, ahead: 9, unpushed: 2, prMerged: true }).statusLabel,
+    ).toBe("2 new commits since PR #7");
+  });
+
+  it("leaves the no-PR-yet copy alone when nothing has merged", () => {
+    expect(primaryFor("pushed", { ...base, ahead: 1 }).statusLabel).toBe(
+      "1 commit pushed, no PR yet",
+    );
+    expect(primaryFor("pushed", { ...base, ahead: 3 }).statusLabel).toBe(
+      "3 commits pushed, no PR yet",
+    );
+  });
+});
+
 describe("changes-state sticky commit action", () => {
   it("defaults to Commit & open PR", () => {
     const p = primaryFor("changes", { files: 2 });


### PR DESCRIPTION
Stacked on #554 — **base is `fix/merged-is-not-terminal`, merge that one first.**

#554 made a merged PR stop absorbing the Git panel, so a workspace can keep working after its PR lands. This closes the one gap it left: a follow-up PR opened *outside* the app is still never adopted.

## The gap

`resolve_pr_state` serves a merged snapshot with no network — merges don't un-happen, so re-confirming one is wasted budget. But that return precedes every branch scan:

```rust
if repo.pr_state.as_deref() == Some(PrStatus::Merged.as_str()) {
    return pr_snapshot(repo).map(|pr| (pr, true));   // before may_discover
}
```

So a repo bound to a merged PR could never learn about a *follow-up*. Opening one through the app works (the RPC/`create_pr` paths bind the number directly, fixed in #554), but a PR opened on github.com — or by a teammate — was invisible: the workspace stayed bound to the merged PR forever.

## The change

A merged PR ends that PR, not the workspace. A `Forced` resolve now scans the branch and adopts an open PR found there.

`Forced` already means *"a push or a turn just happened, so a brand-new PR is genuinely plausible and worth a point"* — precisely this situation. So the mode now means the same thing for a bound-merged repo as for an unbound one, rather than becoming a new concept.

**Cost.** `Throttled` keeps the free short-circuit, so nothing changes in the steady state — that covers the Git panel's 5s tick (`get_pr_live`) and the batched sidebar sweep (`resolve_all_pr_status`, untouched here). The spend is one GraphQL point per `Forced` resolve in a workspace whose PR has merged, i.e. per turn end, push, or delegated git op. That tracks user/agent activity, not a timer: a chatty merged workspace might reach ~20 points/hour, against the ~720/hour the throttle was introduced to kill. Nothing accrues for a merged workspace nobody is touching.

**Adoption rule.** Only an OPEN PR with a different number supersedes the binding (`supersedes_merged`). `pick_branch_pr` prefers the newest open PR and falls back to the newest of any state, so a branch *without* a follow-up scans back to the merged PR itself — adopting that would re-bind the number we already hold and, under #554's identity rule, clear its own snapshot columns to replace merged state with merged state. A scan that fails or finds nothing newer falls through to the snapshot, never to `None`: a failed lookup must not blank state GitHub already confirmed.

## Testing

1090 Rust lib tests pass, `cargo fmt --check` and clippy clean. `supersedes_merged` is covered directly (open follow-up adopted; same-number merged, closed follow-up, and second merged PR all refused) — the surrounding scan needs live GitHub, so the predicate is where the decision is pinned.

## If this needs tightening later

The gate is "a `Forced` resolve happened", not "the branch actually moved past the merged PR". Making it exact means persisting the merged PR's head sha and scanning only when `HEAD` differs — a schema column and a new `PrState` field. That's a real reduction but not obviously worth the migration at this volume, so it's deliberately left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)