### PR TITLE
feat(git): keep every PR a checkout has held, not just the current one

### DIFF
--- a/src-tauri/migrations/0025_worktree_pr_history.sql
+++ b/src-tauri/migrations/0025_worktree_pr_history.sql
@@ -1,0 +1,47 @@
+-- Every PR a checkout has ever held, not just the current binding.
+--
+-- `worktrees.pr_number` + its snapshot columns track the ONE PR a checkout is
+-- bound to right now, and re-binding replaces them (see `set_repo_pr_number`):
+-- a workspace that keeps working after its PR merges loses the merged PR's
+-- identity the moment a follow-up binds. That made "merged" look terminal in
+-- the data even though it isn't, and it under-counted the Project Pulse "PRs
+-- opened" chart, which read one row per checkout.
+--
+-- This is the append-only log beside it: one row per (checkout, PR number),
+-- upserted from `set_repo_pr_snapshot` — the single choke point every path that
+-- learns a PR's state already funnels through. The `worktrees` columns stay the
+-- current-binding fast path, so no read path changes; this table answers "what
+-- else has this checkout proposed".
+CREATE TABLE worktree_prs (
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    -- The checkout within the workspace, matching `worktrees.subdir`. Not a
+    -- foreign key: `worktrees` is unique on (workspace_id, repo_id), not on
+    -- subdir, so there is no key to point at. Deleting a workspace cascades;
+    -- rows for a removed checkout are simply never read (every query scopes by
+    -- workspace_id + subdir).
+    subdir       TEXT NOT NULL,
+    number       INTEGER NOT NULL,
+    url          TEXT NOT NULL,
+    title        TEXT NOT NULL,
+    -- 'open' | 'merged' | 'closed' (serialized github::PrStatus)
+    state        TEXT NOT NULL,
+    -- ms-epoch, from GitHub's own createdAt/mergedAt. NULL = not yet observed.
+    opened_at    INTEGER,
+    merged_at    INTEGER,
+    PRIMARY KEY (workspace_id, subdir, number)
+);
+
+-- Backs the per-project "PRs opened per day" range query in pulseData.ts.
+CREATE INDEX idx_worktree_prs_opened ON worktree_prs(opened_at);
+
+-- Seed from the current bindings so history starts complete rather than at
+-- today: without this the Pulse chart would blank its past days until each PR
+-- happened to be re-fetched. Only rows with a persisted state are carried —
+-- `pr_state IS NULL` means no fetch ever succeeded, so there is no snapshot to
+-- preserve (the same bar `pr_snapshot` sets before it will render one).
+INSERT INTO worktree_prs (workspace_id, subdir, number, url, title, state, opened_at, merged_at)
+SELECT workspace_id, subdir, pr_number,
+       COALESCE(pr_url, ''), COALESCE(pr_title, ''), pr_state,
+       pr_opened_at, pr_merged_at
+  FROM worktrees
+ WHERE pr_number IS NOT NULL AND pr_state IS NOT NULL;

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -157,6 +157,31 @@ pub async fn get_pr_state(
     .map(|(pr, _bound)| pr))
 }
 
+/// Every PR this checkout has held, newest number first — the panel's earlier-PRs
+/// strip. A pure database read (no network, no git): the history log is written
+/// by `set_repo_pr_snapshot`, so this only reports what a fetch already confirmed.
+/// An unknown subdir or a repo-less agent reads as an empty history rather than
+/// an error — the strip simply doesn't render.
+#[tauri::command]
+pub fn get_pr_history(
+    supervisor: State<'_, Arc<Supervisor>>,
+    agent_id: String,
+    subdir: Option<String>,
+) -> Result<Vec<PrState>> {
+    let record = supervisor.workspace.agent(&agent_id)?;
+    let repo = match subdir.as_deref() {
+        Some(s) => record.repos.iter().find(|r| r.subdir == s),
+        // Default to the primary, matching every other PR command's shape.
+        None => record.repos.first(),
+    };
+    let Some(repo) = repo else {
+        return Ok(vec![]);
+    };
+    supervisor
+        .workspace
+        .repo_pr_history(&agent_id, &repo.subdir)
+}
+
 /// List the open PRs for the agent's repo, for the composer's "#" mention
 /// autocomplete. Capped at 50 — the picker filters and shows a handful.
 #[tauri::command]

--- a/src-tauri/src/database/connection.rs
+++ b/src-tauri/src/database/connection.rs
@@ -58,6 +58,7 @@ pub(crate) const MIGRATIONS: &[&str] = &[
     include_str!("../../migrations/0022_repo_label.sql"),
     include_str!("../../migrations/0023_workspace_issue_ref.sql"),
     include_str!("../../migrations/0024_wf_run_issue_ref.sql"),
+    include_str!("../../migrations/0025_worktree_pr_history.sql"),
 ];
 
 pub(crate) fn get_migrations() -> Migrations<'static> {

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -169,6 +169,63 @@ fn upgrading_an_older_schema_backs_it_up_first() {
     assert_eq!(version, 1);
 }
 
+/// The PR-history migration seeds itself from the bindings already on disk, so
+/// an upgrading install starts with history rather than with today. Without the
+/// backfill the Project Pulse "PRs opened" series — which now reads the log —
+/// would blank every past day until each PR happened to be re-fetched. A binding
+/// with no persisted state carries no renderable snapshot and is skipped.
+#[test]
+fn pr_history_migration_backfills_existing_bindings() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut conn = open_db(&dir.path().join(DB_FILENAME)).unwrap();
+    // One migration short of the history table: the state an existing install
+    // upgrades from.
+    let before = MIGRATIONS.len() - 1;
+    get_migrations().to_version(&mut conn, before).unwrap();
+
+    conn.execute_batch(
+        "INSERT INTO projects (id, name, created_at) VALUES ('p', 'proj', 0);
+         INSERT INTO repos (id, project_id, path, created_at) VALUES ('r', 'p', '/r', 0);
+         INSERT INTO workspaces (id, project_id, name, created_at) VALUES ('w', 'p', 'ws', 0);
+         INSERT INTO worktrees (id, workspace_id, repo_id, subdir, created_at,
+                                pr_number, pr_url, pr_title, pr_state, pr_opened_at, pr_merged_at)
+              VALUES ('wt1', 'w', 'r', 'repo', 0,
+                      42, 'https://x/42', 'feat: landed', 'merged', 1000, 2000);
+         INSERT INTO workspaces (id, project_id, name, created_at) VALUES ('w2', 'p', 'ws2', 0);
+         INSERT INTO worktrees (id, workspace_id, repo_id, subdir, created_at, pr_number, pr_state)
+              VALUES ('wt2', 'w2', 'r', 'repo', 0, 99, NULL);",
+    )
+    .unwrap();
+    drop(conn);
+
+    init(dir.path()).unwrap();
+
+    let conn = Connection::open(dir.path().join(DB_FILENAME)).unwrap();
+    let (n, url, state, opened, merged): (i64, String, String, i64, i64) = conn
+        .query_row(
+            "SELECT number, url, state, opened_at, merged_at FROM worktree_prs
+              WHERE workspace_id = 'w' AND subdir = 'repo'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        (n, state.as_str(), opened, merged),
+        (42, "merged", 1000, 2000)
+    );
+    assert_eq!(url, "https://x/42");
+
+    // The state-less binding is not invented into history.
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM worktree_prs WHERE workspace_id = 'w2'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(count, 0, "no persisted state means no renderable snapshot");
+}
+
 #[test]
 fn fresh_init_creates_no_backup() {
     let dir = tempfile::tempdir().unwrap();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1582,6 +1582,7 @@ pub fn run() {
             commands::refresh_all_pr_status,
             commands::get_pr_checks,
             commands::get_pr_live,
+            commands::get_pr_history,
             commands::get_pr_threads,
             commands::open_agent_shell,
             commands::close_agent_shell,

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -231,6 +231,11 @@ pub(crate) fn persist_pr_snapshot(
 /// branch and no PR (an agent mid-task: the common case) never becomes bound, so
 /// a background poll would re-scan forever: at the Git panel's 5s cadence that
 /// was ~720 points/hour, the largest single consumer left in the app.
+///
+/// A repo bound to a *merged* PR reads the same distinction (see
+/// `resolve_pr_state`): `Forced` scans for a follow-up PR, `Throttled` stays on
+/// the free snapshot. So the mode means the same thing in both cases — "is a new
+/// PR plausible enough right now to spend a point looking for it".
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Discovery {
     /// Scan now. For paths where a push or a turn just happened, so a brand-new
@@ -244,12 +249,12 @@ pub enum Discovery {
 /// Minimum gap between branch scans for the same unbound repo under
 /// [`Discovery::Throttled`]. A PR opened outside the app (on github.com, by a
 /// teammate) is still adopted within this window, and once adopted the repo is
-/// bound and never scans again.
+/// bound and scans only on the `Forced` follow-up path.
 const DISCOVERY_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Last throttled branch scan per `(agent_id, subdir)`. Only unbound repos land
-/// here — adoption removes the reason to scan at all — so this is bounded by the
-/// number of repos still waiting on a first PR.
+/// here — a bound repo's scans are all `Forced`, which never touches the clock —
+/// so this is bounded by the number of repos still waiting on a first PR.
 fn discovery_clock() -> &'static Mutex<HashMap<(String, String), Instant>> {
     static CLOCK: OnceLock<Mutex<HashMap<(String, String), Instant>>> = OnceLock::new();
     CLOCK.get_or_init(|| Mutex::new(HashMap::new()))
@@ -274,6 +279,20 @@ fn may_discover(agent_id: &str, subdir: &str, discovery: Discovery) -> bool {
     }
 }
 
+/// Whether a branch scan's result supersedes a merged binding — i.e. it is a
+/// genuine follow-up PR rather than the merged one we already hold.
+///
+/// Only an OPEN PR qualifies. `pick_branch_pr` prefers the newest open PR and
+/// falls back to the newest of any state, so a branch with a follow-up scans to
+/// that follow-up, and a branch without one scans back to the merged PR itself.
+/// The number guard makes the second case explicit rather than relying on "a
+/// merged PR can never read OPEN" — an adoption that re-bound the number we
+/// already have would clear its own snapshot columns (see
+/// `set_repo_pr_number`'s identity rule) for no reason.
+fn supersedes_merged(scanned: &PrState, bound: i64) -> bool {
+    matches!(scanned.state, PrStatus::Open) && scanned.number as i64 != bound
+}
+
 /// Drop a repo's discovery record — called once it binds a PR, so the entry
 /// doesn't outlive the state that made it necessary.
 fn clear_discovery(agent_id: &str, subdir: &str) {
@@ -290,11 +309,13 @@ fn clear_discovery(agent_id: &str, subdir: &str) {
 ///
 /// - **Bound PR** (`pr_number` recorded): a persisted `merged` state returns
 ///   straight from the database — merges don't un-happen, so no network or
-///   git access is spent re-confirming them. Otherwise fetch by number
-///   (resolving owner/repo from the checkout, or from the source repo when
-///   the checkout is broken), persist the result, and on failure degrade to
-///   the last persisted snapshot — a failed fetch must never erase state
-///   GitHub already confirmed.
+///   git access is spent re-confirming them. The one exception is a `Forced`
+///   resolve, which scans the branch for a *follow-up* PR: a merged PR ends
+///   that PR, not the workspace, and an open one found there is adopted in its
+///   place. Otherwise fetch by number (resolving owner/repo from the checkout,
+///   or from the source repo when the checkout is broken), persist the result,
+///   and on failure degrade to the last persisted snapshot — a failed fetch
+///   must never erase state GitHub already confirmed.
 /// - **No bound PR**: discover one by branch name, subject to `discovery` (see
 ///   [`Discovery`] — background polls scan on an interval, event-driven paths
 ///   scan immediately). An OPEN PR is adopted (persisted, becoming bound); a
@@ -329,9 +350,33 @@ pub(crate) async fn resolve_pr_state(
         // reopened, so it stays on the live-fetch path (and keeps costing a
         // poll per cycle) to catch that transition.
         if repo.pr_state.as_deref() == Some(PrStatus::Merged.as_str()) {
+            // …unless a follow-up PR may have appeared. A merged PR doesn't end
+            // the workspace: the agent keeps working in the same worktree and
+            // opens further PRs, and without this the repo stays bound to the
+            // merged one forever — a follow-up opened out-of-band (on
+            // github.com, by a teammate) is never adopted, because the return
+            // above precedes every scan.
+            //
+            // Gated on `Forced`, which already means "a push or a turn just
+            // landed, so a brand-new PR is genuinely plausible and worth a
+            // point". Background polls keep the free short-circuit, so this adds
+            // nothing to the steady state — the cost tracks user/agent activity
+            // in a merged workspace, not a timer.
+            if discovery == Discovery::Forced {
+                if let Some(found) = crate::github::pr_view(&checkout).await.unwrap_or(None) {
+                    if supersedes_merged(&found, number) {
+                        persist_pr_snapshot(workspace, agent_id, &repo.subdir, &found);
+                        return Some((found, true));
+                    }
+                }
+            }
+            // No scan, nothing newer, or the scan didn't resolve — the merged
+            // snapshot stands. Never `None`: a failed lookup must not blank a
+            // state GitHub already confirmed.
             return pr_snapshot(repo).map(|pr| (pr, true));
         }
-        // Bound: this repo never needs discovery again.
+        // Bound to a live PR: a by-number fetch tells us everything a branch
+        // scan could, so no throttled scan is owed and the record can go.
         clear_discovery(agent_id, &repo.subdir);
         match crate::github::pr_view_number(&checkout, Some(&repo.repo_path), number as u32).await {
             Ok(Some(pr)) => {
@@ -1456,8 +1501,42 @@ mod tests {
         clear_discovery("ag-1", "backend");
     }
 
-    /// Binding a PR clears the record: the repo will never scan again, so the
-    /// entry shouldn't outlive the state that justified it.
+    /// Only an OPEN PR takes a merged binding's place. `pick_branch_pr` scans a
+    /// branch back to its merged PR when there's no follow-up, and adopting that
+    /// would re-bind the number we already hold — clearing its own snapshot
+    /// columns (see `set_repo_pr_number`) to replace merged state with merged
+    /// state.
+    #[test]
+    fn only_an_open_follow_up_supersedes_a_merged_binding() {
+        let pr = |number: u32, state: PrStatus| PrState {
+            number,
+            url: format!("https://github.com/o/r/pull/{number}"),
+            title: "t".into(),
+            state,
+            mergeable: MergeableState::Unknown,
+            opened_at: None,
+            merged_at: None,
+        };
+        assert!(
+            supersedes_merged(&pr(43, PrStatus::Open), 42),
+            "an open follow-up is the workspace's current PR"
+        );
+        assert!(
+            !supersedes_merged(&pr(42, PrStatus::Merged), 42),
+            "the scan found the PR we already hold"
+        );
+        assert!(
+            !supersedes_merged(&pr(43, PrStatus::Closed), 42),
+            "a closed follow-up is never claimed as the binding"
+        );
+        assert!(
+            !supersedes_merged(&pr(43, PrStatus::Merged), 42),
+            "a second merged PR is history too, not the current state"
+        );
+    }
+
+    /// Binding a PR clears the record: the repo is owed no further throttled
+    /// scan, so the entry shouldn't outlive the state that justified it.
     #[test]
     fn clearing_discovery_reopens_the_window() {
         let (agent, sub) = ("ag-clear", "");

--- a/src-tauri/src/workspace/agents.rs
+++ b/src-tauri/src/workspace/agents.rs
@@ -252,6 +252,57 @@ impl WorkspaceManager {
     /// only for the PR they describe: a follow-up PR bound into the same
     /// checkout (the workspace kept working after a merge) takes the payload's
     /// times as they are, so it can't inherit the previous PR's merge stamp.
+    /// Every PR this checkout has held, newest number first — the append-only
+    /// log `set_repo_pr_snapshot` maintains beside the current binding. Includes
+    /// the currently-bound PR; callers that want only the earlier ones filter by
+    /// number (the panel does, so the strip never repeats the header's PR).
+    ///
+    /// `mergeable` reads `Unknown` for the same reason it does in `pr_snapshot`:
+    /// it isn't persisted, and a stored merge verdict would be stale anyway.
+    pub fn repo_pr_history(
+        &self,
+        agent_id: &str,
+        subdir: &str,
+    ) -> Result<Vec<crate::github::PrState>> {
+        let conn = self.db.lock();
+        let mut stmt = conn.prepare(
+            "SELECT number, url, title, state, opened_at, merged_at
+               FROM worktree_prs
+              WHERE workspace_id = ?1 AND subdir = ?2
+              ORDER BY number DESC",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![agent_id, subdir], |row| {
+            let state: String = row.get(3)?;
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                state,
+                row.get::<_, Option<i64>>(4)?,
+                row.get::<_, Option<i64>>(5)?,
+            ))
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            let (number, url, title, state, opened_at, merged_at) = row?;
+            // An unparseable state is a row we can't render honestly — skip it
+            // rather than fabricate a status, matching `pr_snapshot`.
+            let Some(state) = crate::github::PrStatus::parse(&state) else {
+                continue;
+            };
+            out.push(crate::github::PrState {
+                number: number as u32,
+                url,
+                title,
+                state,
+                mergeable: crate::github::MergeableState::Unknown,
+                opened_at,
+                merged_at,
+            });
+        }
+        Ok(out)
+    }
+
     pub fn set_repo_pr_snapshot(
         &self,
         agent_id: &str,
@@ -259,7 +310,38 @@ impl WorkspaceManager {
         pr: &crate::github::PrState,
     ) -> Result<()> {
         let conn = self.db.lock();
-        conn.execute(
+        let tx = conn.unchecked_transaction()?;
+        // The history log (spec: every PR a checkout ever held). Upserted by
+        // number so a PR's row tracks its latest state and times, and a
+        // re-bound follow-up adds a row instead of overwriting the one it
+        // replaces. Same transaction as the current-binding write below, so the
+        // two can never disagree about a PR we just learned about.
+        tx.execute(
+            "INSERT INTO worktree_prs
+                    (workspace_id, subdir, number, url, title, state, opened_at, merged_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+             ON CONFLICT(workspace_id, subdir, number) DO UPDATE SET
+                    url       = excluded.url,
+                    title     = excluded.title,
+                    state     = excluded.state,
+                    -- Times COALESCE for the same reason they do on the
+                    -- worktrees row: a payload that omits one must not erase an
+                    -- earlier-observed value. Identity is the PK here, so
+                    -- there's no cross-PR bleed to guard against.
+                    opened_at = COALESCE(excluded.opened_at, opened_at),
+                    merged_at = COALESCE(excluded.merged_at, merged_at)",
+            rusqlite::params![
+                agent_id,
+                subdir,
+                pr.number as i64,
+                pr.url,
+                pr.title,
+                pr.state.as_str(),
+                pr.opened_at,
+                pr.merged_at,
+            ],
+        )?;
+        tx.execute(
             "UPDATE worktrees SET pr_number = ?1, pr_url = ?2, pr_title = ?3, pr_state = ?4,
                                   pr_opened_at = CASE WHEN pr_number IS ?1
                                                  THEN COALESCE(?5, pr_opened_at) ELSE ?5 END,
@@ -277,6 +359,7 @@ impl WorkspaceManager {
                 subdir,
             ],
         )?;
+        tx.commit()?;
         Ok(())
     }
 

--- a/src-tauri/src/workspace/tests.rs
+++ b/src-tauri/src/workspace/tests.rs
@@ -1128,6 +1128,136 @@ fn pr_number_persists_and_resets_on_name_reuse() {
     assert_eq!(wm.agent(&reused_id).unwrap().repos[0].pr_number, None);
 }
 
+/// A checkout accumulates every PR it has held, not just the current binding:
+/// a workspace that keeps working after a merge opens follow-ups, and the
+/// merged PR's identity is cleared off the `worktrees` row when the next one
+/// binds. The history log is what keeps it — the panel's "Earlier" strip and
+/// the Pulse "PRs opened" series both read it.
+#[test]
+fn pr_history_accumulates_across_rebinds() {
+    let db = test_db();
+    let wm = WorkspaceManager::new(db.clone());
+    seed_repo(&db, "/r");
+
+    let mut rec = new_agent_record(
+        "denali".into(),
+        "a".into(),
+        "claude".into(),
+        mk_repo("/r"),
+        "task".into(),
+        AgentView::Custom,
+    );
+    let id = rec.id.clone();
+    wm.add_agent(&mut rec).unwrap();
+    let subdir = wm.agent(&id).unwrap().repos[0].subdir.clone();
+
+    assert!(
+        wm.repo_pr_history(&id, &subdir).unwrap().is_empty(),
+        "a fresh checkout has proposed nothing"
+    );
+
+    let first_open = crate::github::PrState {
+        number: 42,
+        url: "https://github.com/o/r/pull/42".into(),
+        title: "feat: first".into(),
+        state: crate::github::PrStatus::Open,
+        mergeable: crate::github::MergeableState::Mergeable,
+        opened_at: Some(1_000),
+        merged_at: None,
+    };
+    wm.set_repo_pr_snapshot(&id, &subdir, &first_open).unwrap();
+
+    // The same PR merging updates its row in place rather than adding one.
+    let first_merged = crate::github::PrState {
+        state: crate::github::PrStatus::Merged,
+        opened_at: None, // a payload that omits it must not erase the stamp
+        merged_at: Some(2_000),
+        ..first_open.clone()
+    };
+    wm.set_repo_pr_snapshot(&id, &subdir, &first_merged)
+        .unwrap();
+    let history = wm.repo_pr_history(&id, &subdir).unwrap();
+    assert_eq!(history.len(), 1, "one PR seen twice is one row");
+    assert!(matches!(history[0].state, crate::github::PrStatus::Merged));
+    assert_eq!(
+        history[0].opened_at,
+        Some(1_000),
+        "COALESCE keeps the stamp"
+    );
+    assert_eq!(history[0].merged_at, Some(2_000));
+
+    // A follow-up PR binds. The worktrees row moves on; history keeps both.
+    let second = crate::github::PrState {
+        number: 43,
+        url: "https://github.com/o/r/pull/43".into(),
+        title: "feat: second".into(),
+        state: crate::github::PrStatus::Open,
+        mergeable: crate::github::MergeableState::Mergeable,
+        opened_at: Some(3_000),
+        merged_at: None,
+    };
+    wm.set_repo_pr_snapshot(&id, &subdir, &second).unwrap();
+
+    let history = wm.repo_pr_history(&id, &subdir).unwrap();
+    assert_eq!(history.len(), 2);
+    // Newest number first, so the panel's strip reads most-recent-first.
+    assert_eq!(history[0].number, 43);
+    assert_eq!(history[1].number, 42);
+    assert_eq!(history[1].title, "feat: first");
+    assert!(
+        matches!(history[1].state, crate::github::PrStatus::Merged),
+        "the merged PR keeps its own state, not the follow-up's"
+    );
+    assert_eq!(
+        history[1].url, "https://github.com/o/r/pull/42",
+        "each row keeps its own url — the bug that made a follow-up link to the merged PR"
+    );
+    // The current binding is unchanged by history-keeping.
+    assert_eq!(wm.agent(&id).unwrap().repos[0].pr_number, Some(43));
+}
+
+/// History is per checkout: one repo of a multi-repo agent can't see another's
+/// PRs, and neither can a different agent.
+#[test]
+fn pr_history_is_scoped_to_its_checkout() {
+    let db = test_db();
+    let wm = WorkspaceManager::new(db.clone());
+    seed_repo(&db, "/r");
+
+    let mut rec = new_agent_record(
+        "denali".into(),
+        "a".into(),
+        "claude".into(),
+        mk_repo("/r"),
+        "task".into(),
+        AgentView::Custom,
+    );
+    let id = rec.id.clone();
+    wm.add_agent(&mut rec).unwrap();
+    let subdir = wm.agent(&id).unwrap().repos[0].subdir.clone();
+
+    let pr = crate::github::PrState {
+        number: 42,
+        url: "u".into(),
+        title: "t".into(),
+        state: crate::github::PrStatus::Merged,
+        mergeable: crate::github::MergeableState::Unknown,
+        opened_at: Some(1_000),
+        merged_at: Some(2_000),
+    };
+    wm.set_repo_pr_snapshot(&id, &subdir, &pr).unwrap();
+
+    assert_eq!(wm.repo_pr_history(&id, &subdir).unwrap().len(), 1);
+    assert!(
+        wm.repo_pr_history(&id, "other-repo").unwrap().is_empty(),
+        "a sibling checkout has its own history"
+    );
+    assert!(
+        wm.repo_pr_history("ag-other", &subdir).unwrap().is_empty(),
+        "another agent's checkout has its own history"
+    );
+}
+
 /// A successful PR fetch persists the full snapshot (number, url, title,
 /// state, times) and it loads back on the repo record — the database copy
 /// the UI falls back to when GitHub or the checkout is unavailable. A

--- a/src/api/domains/github.ts
+++ b/src/api/domains/github.ts
@@ -32,6 +32,8 @@ export const githubApi = {
     invoke<PrChecks | null>("get_pr_checks", { agentId, subdir }),
   getPrLive: (agentId: string, subdir?: string) =>
     invoke<PrLive | null>("get_pr_live", { agentId, subdir }),
+  getPrHistory: (agentId: string, subdir?: string) =>
+    invoke<PrState[]>("get_pr_history", { agentId, subdir }),
   getPrThreads: (agentId: string, subdir?: string) =>
     invoke<PrComments | null>("get_pr_threads", { agentId, subdir }),
   createPr: (agentId: string, title: string, body: string, subdir?: string) =>

--- a/src/components/ProjectSettings/pulseData.ts
+++ b/src/components/ProjectSettings/pulseData.ts
@@ -63,10 +63,14 @@ export async function loadPulseActivity(
        GROUP BY day`,
       [projectId, sinceMs],
     ),
+    // Every PR the project's checkouts have opened — from the history log, not
+    // `worktrees.pr_*`. Those columns hold only a checkout's CURRENT binding, so
+    // a workspace that merged and then opened a follow-up counted once, and the
+    // earlier PR's `pr_opened_at` was overwritten out of the series entirely.
     dbQuery<{ day: string; n: number }>(
-      `SELECT date(wt.pr_opened_at/1000, 'unixepoch', 'localtime') AS day, COUNT(*) AS n
-       FROM worktrees wt JOIN workspaces w ON w.id = wt.workspace_id
-       WHERE w.project_id = ? AND wt.pr_opened_at >= ?
+      `SELECT date(p.opened_at/1000, 'unixepoch', 'localtime') AS day, COUNT(*) AS n
+       FROM worktree_prs p JOIN workspaces w ON w.id = p.workspace_id
+       WHERE w.project_id = ? AND p.opened_at >= ?
        GROUP BY day`,
       [projectId, sinceMs],
     ),

--- a/src/components/RightPanel/GitPanel/GitRepoSection.tsx
+++ b/src/components/RightPanel/GitPanel/GitRepoSection.tsx
@@ -14,7 +14,9 @@ import { useActionBarModel } from "./hooks/useActionBarModel";
 import { useCommitDraft } from "./hooks/useCommitDraft";
 import { useGitActions } from "./hooks/useGitActions";
 import { useGitPanelData } from "./hooks/useGitPanelData";
+import { usePrHistory } from "./hooks/usePrHistory";
 import { useTransientFeedback } from "./hooks/useTransientFeedback";
+import { PrSetStrip } from "./PrSetStrip";
 import { StatusHeader } from "./StatusHeader";
 
 /** One repo's worth of git panel: the full header / body / footer stack,
@@ -137,6 +139,11 @@ export function GitRepoSection({
   const showFiles = panelState === "changes" || panelState === "conflicts";
   const showCommit = panelState === "changes" && !delegation;
 
+  // The PRs this checkout held before the current one — a workspace that kept
+  // working after a merge has them. Each is a linked pill, so landed work stays
+  // reachable once the header has moved on to the follow-up.
+  const priorPrs = usePrHistory(agent.id, prState?.number ?? null, subdir);
+
   return (
     <div className="git-wrap">
       {/* ── color-coded status header: the at-a-glance state signal ── */}
@@ -149,6 +156,24 @@ export function GitRepoSection({
         mergeState={mergeState}
         checksFailed={checks?.failed ?? 0}
       />
+
+      {/* Earlier PRs of this checkout, once it has any — merged work stays one
+          click away after the panel moves on to the follow-up. */}
+      {priorPrs.length > 0 && (
+        <PrSetStrip
+          heading="Earlier"
+          entries={priorPrs.map((pr) => ({
+            key: String(pr.number),
+            // Backfilled rows can carry an empty title (the pre-history schema
+            // stored no snapshot until a fetch succeeded) — fall back to the
+            // number so the tooltip never reads as a bare " · merged".
+            context: pr.title || `PR #${pr.number}`,
+            pr,
+            // Settled PRs have no live CI to show; the pill reads its state.
+            checks: null,
+          }))}
+        />
+      )}
 
       {/* ── scrollable body: the changes are the focus ── */}
       <div className={`git-body ${busy ? "busy" : ""}`}>

--- a/src/components/RightPanel/GitPanel/PrSetStrip.tsx
+++ b/src/components/RightPanel/GitPanel/PrSetStrip.tsx
@@ -1,12 +1,14 @@
 import { open } from "@tauri-apps/plugin-shell";
-import type { PrChecks, PrState, TrackedRepo } from "@/api";
+import type { PrChecks, PrState } from "@/api";
 import { Icon } from "@/components/Icon";
 import { Badge, type BadgeVariant } from "@/components/ui/Badge";
-import { basename } from "@/util/format";
 
-/** One repo's PR for the strip: the panel section's own resolved state. */
+/** One PR chip in the strip. `context` names what this PR belongs to — the repo
+ *  for a multi-repo set ("Frontend"), the PR's own title for a checkout's
+ *  history — and is what the tooltip and screen-reader label lead with. */
 export interface PrSetEntry {
-  repo: TrackedRepo;
+  key: string;
+  context: string;
   pr: PrState;
   checks: PrChecks | null;
 }
@@ -28,25 +30,28 @@ function chipStatus(pr: PrState, checks: PrChecks | null): { variant: BadgeVaria
   }
 }
 
-/** Slim summary strip above a multi-repo agent's panel sections when the task
- *  produced PRs in two or more repos: "2 PRs" plus one linked pill per PR, so
- *  the set reads as a unit and each PR is one click away. Rendered only by
- *  `MultiRepoGitPanel` (never for single-repo agents). */
-export function PrSetStrip({ entries }: { entries: PrSetEntry[] }) {
+/** Slim strip of linked PR pills above the panel body, under a short heading.
+ *
+ *  Two callers, one shape — a row of PRs that belong together, each one click
+ *  away:
+ *  - `MultiRepoGitPanel`: one task's PRs across two or more repos ("3 PRs").
+ *  - `GitRepoSection`: the PRs this checkout held before its current one
+ *    ("Earlier"), which a workspace that kept working after a merge accumulates.
+ */
+export function PrSetStrip({ heading, entries }: { heading: string; entries: PrSetEntry[] }) {
   return (
     <div className="git-pr-set text-xs">
-      <span className="git-pr-set-label">{entries.length} PRs</span>
-      {entries.map(({ repo, pr, checks }) => {
+      <span className="git-pr-set-label">{heading}</span>
+      {entries.map(({ key, context, pr, checks }) => {
         const { variant, word } = chipStatus(pr, checks);
-        const label = repo.label ?? basename(repo.repo_path);
         return (
           <button
-            key={repo.subdir}
+            key={key}
             className="git-pr-set-chip"
             onClick={() => pr.url && void open(pr.url)}
-            aria-label={`${label} PR #${pr.number} — ${word}`}
+            aria-label={`${context} PR #${pr.number} — ${word}`}
           >
-            <Badge variant={variant} tip={`${label} · ${word}`}>
+            <Badge variant={variant} tip={`${context} · ${word}`}>
               <Icon name={pr.state === "merged" ? "merge" : "pr"} size={10} />#{pr.number}
             </Badge>
           </button>

--- a/src/components/RightPanel/GitPanel/hooks/usePrHistory.ts
+++ b/src/components/RightPanel/GitPanel/hooks/usePrHistory.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+import { api, type PrState } from "@/api";
+
+/** The PRs this checkout held *before* its current one, newest first.
+ *
+ *  A workspace doesn't end when its PR merges — it keeps working and opens
+ *  follow-ups — so a checkout accumulates PRs over its life. The backend logs
+ *  each one (`worktree_prs`, written on every PR-state fetch); this reads that
+ *  log and drops the currently-bound PR, which the header already shows.
+ *
+ *  A plain database read, so it needs no polling: the history only grows when a
+ *  new PR binds, which is exactly what `currentNumber` changing means. `null`
+ *  for `currentNumber` (no PR yet) still fetches — a recycled checkout can hold
+ *  history with nothing bound right now.
+ */
+export function usePrHistory(
+  agentId: string,
+  currentNumber: number | null,
+  subdir?: string,
+): PrState[] {
+  const [prior, setPrior] = useState<PrState[]>([]);
+
+  useEffect(() => {
+    let live = true;
+    api
+      .getPrHistory(agentId, subdir)
+      .then((all) => {
+        if (live) setPrior(all.filter((pr) => pr.number !== currentNumber));
+      })
+      // Non-fatal: history is context, not state. An empty strip is the right
+      // degradation — never a stale one from the previous checkout.
+      .catch(() => {
+        if (live) setPrior([]);
+      });
+    return () => {
+      live = false;
+    };
+  }, [agentId, subdir, currentNumber]);
+
+  return prior;
+}

--- a/src/components/RightPanel/GitPanel/index.tsx
+++ b/src/components/RightPanel/GitPanel/index.tsx
@@ -72,13 +72,22 @@ function MultiRepoGitPanel({ agent }: { agent: AgentRecord }) {
     const key = checkoutKey(agent.id, sc.subdir);
     const live = prStates[key];
     const pr = live !== undefined ? live : prSnapshot(sc.repo);
-    return pr ? [{ repo: sc.repo, pr, checks: prChecks[key] ?? null }] : [];
+    return pr
+      ? [
+          {
+            key: sc.repo.subdir,
+            context: sc.repo.label ?? basename(sc.repo.repo_path),
+            pr,
+            checks: prChecks[key] ?? null,
+          },
+        ]
+      : [];
   });
 
   return (
     <div className="git-multi">
       {/* ≥2 PRs → the "one task, N PRs" strip presents the set as a unit. */}
-      {prSet.length >= 2 && <PrSetStrip entries={prSet} />}
+      {prSet.length >= 2 && <PrSetStrip heading={`${prSet.length} PRs`} entries={prSet} />}
       {sections.map((sc) => (
         <section key={sc.repo.subdir} className="git-repo-sect">
           {active.length > 0 && (


### PR DESCRIPTION
Stacked on #555 (which is stacked on #554) — **base is `fix/adopt-follow-up-pr-after-merge`; merge #554 then #555 first.**

Last slice of the merged-workspace work. #554 let a workspace keep working after its PR lands; #555 lets it adopt a follow-up PR opened out-of-band. Both leave the *earlier* PR unrecorded — this keeps it.

## Why

`worktrees.pr_*` tracks the one PR a checkout is bound to right now, and re-binding replaces it (#554 makes that explicit: a new number clears the columns, because inheriting `merged` would render the follow-up as already landed). So the merged PR's identity is lost the moment a follow-up binds. Two consequences:

- The panel can't link to work that landed — the header has moved on to the follow-up.
- Project Pulse's "PRs opened per day" read `worktrees.pr_opened_at`, one row per checkout. A workspace's second PR overwrote the first's timestamp, so the earlier PR left the series entirely and the count under-reported.

## Design

`worktree_prs`: one row per `(workspace_id, subdir, number)`, upserted from `set_repo_pr_snapshot` — the choke point every path that learns a PR's state already funnels through ("so the persistence contract lives in one place", per its own doc). That means **one new write site and no read-path changes**: `worktrees.pr_*` stays the current-binding fast path with its careful degradation logic untouched, and the new table answers only "what else has this checkout proposed".

A PR's row tracks its latest state and times. `COALESCE` on the timestamps, so a payload omitting a stamp can't erase an earlier-observed one — and unlike the `worktrees` row there's no cross-PR bleed to guard against, because identity *is* the primary key here. Both writes share one transaction, so the log and the binding can't disagree about a PR we just learned.

I checked that the choke point is complete: `insert_worktree` never writes the PR columns, and `set_repo_pr_number` (the delegated `open_pr` path) binds a bare number and — since #554 — clears the snapshot, so a fetch follows immediately and writes history. A PR bound but never successfully fetched has no row, which is honest: there's no renderable snapshot either.

**Migration backfills from existing bindings.** Otherwise the Pulse chart would blank every past day until each PR happened to be re-fetched. Bindings with `pr_state IS NULL` are skipped — no fetch ever succeeded, so there's nothing to carry (the same bar `pr_snapshot` sets before it will render).

## UI

An "Earlier" strip under the Git panel header, listing prior PRs as linked pills. `PrSetStrip` already rendered exactly this shape for a multi-repo agent's PR set, so rather than copy 30 lines of JSX and a second `chipStatus`, it's generalized from repo-keyed entries to `{key, context, pr, checks}` plus a `heading`, and now serves both callers. `context` is the repo name for the multi-repo set and the PR title for history (falling back to `PR #N` for backfilled rows, which can carry an empty title).

`usePrHistory` is a plain database read keyed on the current PR number — no polling, because history only grows when a new PR binds, which is exactly what that number changing means. A failed read degrades to an empty strip, never a stale one from the previous checkout.

## Testing

1092 Rust lib tests and 732 frontend tests pass; fmt, clippy, tsc and biome clean.

New coverage: history accumulates across a re-bind (one PR seen twice stays one row; each row keeps its own url and state — the exact bug that made a follow-up link to the merged PR); history is scoped per checkout and per agent; and the migration backfill, including the skipped state-less binding.

One unrelated flake in the full Rust run: `run_detect::port::tests::free_port_returns_start_when_open` expects port 64267 and loses it to a concurrent test. Passes in isolation; predates this stack.

## Not included

No UI for *reopening* or comparing prior PRs — the strip is a link out to GitHub. And history is per checkout, so it doesn't attempt a cross-workspace "PR stack" view; that's a different feature, not a gap in this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)