### PR TITLE
feat(telemetry): track onboarding funnel and activation path

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -563,13 +563,50 @@ async fn warm_codegraph_index(repos: Vec<(String, PathBuf)>) {
     }
 }
 
-/// Emit the deferred first `app_opened`. The frontend calls this once, when the
-/// user finishes onboarding (after the data-sharing disclosure on the final
-/// step). On a fresh install `setup` skips the launch-time `app_opened`, so this
-/// is the first such event — sent only once consent has been disclosed.
+/// Send `app_opened` at most once per process.
+///
+/// Two callers race for it: `setup` at launch (for an already-onboarded
+/// install) and the `track_app_opened` command when the onboarding overlay
+/// mounts (for a fresh install, where the launch-time send is deferred until
+/// the data-sharing disclosure is on screen). Replaying onboarding from
+/// Settings › Developer puts both in play within one run, so without this flag
+/// that replay would double-count the launch.
+fn send_app_opened() {
+    static SENT: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+    if SENT.swap(true, std::sync::atomic::Ordering::SeqCst) {
+        return;
+    }
+    telemetry::track("app_opened", json!({}));
+}
+
+/// Emit the deferred first `app_opened`. The frontend calls this when the
+/// onboarding overlay mounts on a *fresh install* — the welcome step carries
+/// the data-sharing disclosure, so the event lands only once consent has been
+/// disclosed. On a fresh install `setup` skips the launch-time `app_opened`, so
+/// this is the first such event.
+///
+/// Safe to call spuriously: `send_app_opened` collapses repeat calls, so a
+/// StrictMode double-mount, the belt-and-braces call from `closeOnboarding`,
+/// and an onboarding replay are all no-ops.
 #[tauri::command]
 fn track_app_opened() {
-    telemetry::track("app_opened", json!({}));
+    send_app_opened();
+}
+
+/// Emit a product event raised by the renderer — the onboarding funnel and the
+/// activation-path moments that only the frontend can observe (a step viewed, a
+/// device-flow sign-in abandoned, a project added). Backend-observable events
+/// (`agent_spawned`, `pr_opened`, `turn_completed`) stay in the backend.
+///
+/// Consent and identity are enforced downstream by `telemetry::track`, so this
+/// is a no-op when the user has opted out.
+///
+/// `props` must stay categorical — counts, enums, booleans. Never pass paths,
+/// repo/branch names, prompts, or raw error strings: the frontend helper
+/// (`src/util/track.ts`) is the typed gate that keeps call sites honest.
+#[tauri::command]
+fn track_event(event: String, props: Option<serde_json::Value>) {
+    telemetry::track(&event, props.unwrap_or_else(|| json!({})));
 }
 
 /// The persisted sandbox engine selection (`"sandbox-exec"` | `"docker"`).
@@ -1337,12 +1374,13 @@ pub fn run() {
                 (distinct_id, enabled, onboarded, prev)
             };
             telemetry::init(distinct_id, telemetry_enabled, version.clone());
-            // On a fresh install the first `app_opened` is deferred until
-            // onboarding completes (see the `track_app_opened` command), so no
-            // event is sent before the user has seen the data-sharing disclosure.
-            // Once onboarded, every launch reports `app_opened` here as usual.
+            // On a fresh install the first `app_opened` is deferred until the
+            // onboarding overlay is on screen (see the `track_app_opened`
+            // command) — its welcome step carries the data-sharing disclosure,
+            // so no event is sent before the user has been told. Once onboarded,
+            // every launch reports `app_opened` here as usual.
             if onboarding_complete {
-                telemetry::track("app_opened", json!({}));
+                send_app_opened();
             }
             if let Some(prev) = prev_version {
                 if !prev.is_empty() && prev != version {
@@ -1494,6 +1532,7 @@ pub fn run() {
             set_telemetry_enabled,
             set_code_indexing_enabled,
             track_app_opened,
+            track_event,
             get_sandbox_engine,
             set_sandbox_engine,
             probe_docker_engine,

--- a/src/api/domains/misc.ts
+++ b/src/api/domains/misc.ts
@@ -15,7 +15,13 @@ export const miscApi = {
   // index in the background (install + per-repo mirror). Backend-owned.
   setCodeIndexingEnabled: (enabled: boolean) =>
     invoke<void>("set_code_indexing_enabled", { enabled }),
-  // Emit the deferred first `app_opened` once onboarding completes — i.e. after
-  // the data-sharing disclosure has been shown. See `track_app_opened` (Rust).
+  // Emit the deferred first `app_opened` once the onboarding overlay (which
+  // carries the data-sharing disclosure) is on screen. Idempotent per process.
+  // See `track_app_opened` (Rust).
   trackAppOpened: () => invoke<void>("track_app_opened"),
+  // Raise a renderer-observed product event. Don't call this directly — go
+  // through the typed `track()` in `@/util/track`, which is the gate that keeps
+  // event names and property shapes honest.
+  trackEvent: (event: string, props: Record<string, unknown>) =>
+    invoke<void>("track_event", { event, props }),
 };

--- a/src/components/GithubConnect/index.tsx
+++ b/src/components/GithubConnect/index.tsx
@@ -14,7 +14,7 @@ import { useGithubConnect } from "@/util/useGithubConnect";
 export function GithubConnectModal() {
   const open = useAppStore((s) => s.githubConnectOpen);
   const close = useAppStore((s) => s.closeGithubConnect);
-  const { connect, cancel, device, error, busy } = useGithubConnect(close);
+  const { connect, cancel, device, error, busy } = useGithubConnect(close, "connect_gate");
 
   // Kick off the flow once per open. We deliberately depend on `open` alone and
   // reach `connect` through a ref: `connect`'s identity changes on every `busy`

--- a/src/components/NewProject/shared.tsx
+++ b/src/components/NewProject/shared.tsx
@@ -51,7 +51,7 @@ export function DestRow({
  *  the device flow inline: on success the store's `github` flips and the
  *  parent view re-renders to the real form — no dialog reopen. */
 export function ConnectGitHub({ what }: { what: string }) {
-  const { connect, cancel, device, error, busy } = useGithubConnect();
+  const { connect, cancel, device, error, busy } = useGithubConnect(undefined, "new_project");
   return (
     <div className="np-body">
       <div className="np-gate flex-center">

--- a/src/components/Onboarding/AgentsStep.tsx
+++ b/src/components/Onboarding/AgentsStep.tsx
@@ -12,6 +12,7 @@ import { Icon } from "@/components/Icon";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import { installCommand, PROVIDER_DETAIL } from "@/data/providerDetail";
 import type { ProviderId } from "@/data/providers";
+import { track } from "@/util/track";
 import { ExBar } from "./exhibits";
 import { CopyCmd, DocsLink, SetupStep } from "./SetupBits";
 import type { OnboardingSetup } from "./useSetup";
@@ -44,8 +45,13 @@ export function AgentsStep({ setup, onSkip }: { setup: OnboardingSetup; onSkip: 
 
   const install = (id: ProviderId) => {
     setInstalls((m) => ({ ...m, [id]: { phase: "running" } }));
+    // At least one agent CLI is the hard gate on this step, so a failing
+    // one-click install is a dead stop. Provider id only — the installer's
+    // error text is a raw shell message and never leaves the machine.
+    track("agent_cli_install_started", { provider: id });
     void api.installAgent(id).then(
       async () => {
+        track("agent_cli_install_succeeded", { provider: id });
         // The install itself succeeded — the probe refresh is best-effort.
         // If it throws, clear the tile anyway rather than masking a good
         // install as "failed"; the 4s auto-poll picks the binary up.
@@ -55,7 +61,10 @@ export function AgentsStep({ setup, onSkip }: { setup: OnboardingSetup; onSkip: 
           return rest;
         });
       },
-      (err) => setInstalls((m) => ({ ...m, [id]: { phase: "failed", error: String(err) } })),
+      (err) => {
+        track("agent_cli_install_failed", { provider: id });
+        setInstalls((m) => ({ ...m, [id]: { phase: "failed", error: String(err) } }));
+      },
     );
   };
 

--- a/src/components/Onboarding/GithubStep.tsx
+++ b/src/components/Onboarding/GithubStep.tsx
@@ -15,7 +15,7 @@ export function GithubStep({ setup, onSkip }: { setup: OnboardingSetup; onSkip: 
   const { ghConnected, gh, recheck } = setup;
   // Own device-flow instance: on success re-run the shared checks so the
   // footer's Continue enables without leaving the step.
-  const { connect, cancel, device, error, busy } = useGithubConnect(recheck);
+  const { connect, cancel, device, error, busy } = useGithubConnect(recheck, "onboarding_github");
 
   let card: React.ReactNode;
   if (ghConnected) {

--- a/src/components/Onboarding/index.tsx
+++ b/src/components/Onboarding/index.tsx
@@ -6,9 +6,11 @@
 // transitions, progress rail, and keyboard nav carry over from the original
 // tour; the exhibits now sit beside real controls.
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { api } from "@/api";
 import { Icon } from "@/components/Icon";
 import { useAppStore } from "@/store";
+import { track } from "@/util/track";
 import { useGithubConnect } from "@/util/useGithubConnect";
 import { AgentsStep } from "./AgentsStep";
 import { Ambient } from "./Ambient";
@@ -28,10 +30,16 @@ const RAIL_LEN = 4; // welcome..agents (the ready handoff is excluded)
 
 export function Onboarding() {
   const closeOnboarding = useAppStore((s) => s.closeOnboarding);
+  const onboardingComplete = useAppStore((s) => s.onboardingComplete);
 
   const [idx, setIdx] = useState(0);
   const [phase, setPhase] = useState<"in" | "out">("in");
   const [ready, setReady] = useState(false);
+
+  // Is this the real first run, or a replay from Settings › Developer? Frozen
+  // at mount: `closeOnboarding` flips `onboardingComplete` to true, and the
+  // terminal event must not report itself as a replay on the way out.
+  const firstRun = useRef(!onboardingComplete).current;
 
   const step = STEPS[idx];
 
@@ -42,6 +50,25 @@ export function Onboarding() {
     const id = window.setTimeout(() => setReady(true), 40);
     return () => window.clearTimeout(id);
   }, [idx]);
+
+  // On a fresh install the backend defers the first `app_opened` to here: the
+  // welcome step carries the data-sharing disclosure, so this is the earliest
+  // point at which telemetry has been disclosed. Firing it on mount (rather
+  // than at completion, as before) is what makes the drop-off events below
+  // meaningful — a user who quits at step 02 is exactly who we want to see.
+  //
+  // Only on a real first run: an already-onboarded user got their `app_opened`
+  // at launch, so a replay must not send a second one. (`send_app_opened` in
+  // Rust also collapses repeats, which covers StrictMode's double-mount.)
+  useEffect(() => {
+    if (firstRun) void api.trackAppOpened();
+  }, [firstRun]);
+
+  // The funnel. One event per step reveal gives the whole drop-off curve;
+  // the skip/abandon/complete events below say *how* each user left.
+  useEffect(() => {
+    track("onboarding_step_viewed", { step: STEPS[idx], index: idx, first_run: firstRun });
+  }, [idx, firstRun]);
 
   const go = useCallback(
     (next: number) => {
@@ -77,6 +104,32 @@ export function Onboarding() {
           : false;
   const showNext = step === "git" || step === "github" || step === "agents";
 
+  // Exactly one terminal event per onboarding session, whichever exit the user
+  // takes: Esc, ✕, and "Enter Fletch" all funnel through `leave`. A ref (not
+  // state) guards it, so a second call during the closing render can't
+  // double-count. `completed` carries what the user actually finished with —
+  // the handoff is reachable with gaps via Skip, so the flags are the point.
+  const leftRef = useRef(false);
+  const leave = useCallback(
+    (reason: "completed" | "abandoned") => {
+      if (!leftRef.current) {
+        leftRef.current = true;
+        if (reason === "completed") {
+          track("onboarding_completed", {
+            git_ready: setup.gitReady,
+            gh_connected: setup.ghConnected,
+            agents_detected: setup.detected,
+            first_run: firstRun,
+          });
+        } else {
+          track("onboarding_abandoned", { step, first_run: firstRun });
+        }
+      }
+      closeOnboarding();
+    },
+    [closeOnboarding, step, firstRun, setup.gitReady, setup.ghConnected, setup.detected],
+  );
+
   // Shared device-flow sign-in. On success advance off the welcome step; the
   // hook persists the profile and refreshes the account + GitHub connection.
   // The requirement checks re-run so a GitHub sign-in pre-passes step 02.
@@ -91,12 +144,19 @@ export function Onboarding() {
     device,
     error: authError,
     busy,
-  } = useGithubConnect(onSignedIn);
+  } = useGithubConnect(onSignedIn, "onboarding_welcome");
   const onAuth = useCallback((provider: string) => void connect(provider), [connect]);
 
   // Handoff: just drop into the real app. Its empty state prompts the user to
   // add their first repo from the sidebar — no auto-picker.
-  const onEnter = useCallback(() => closeOnboarding(), [closeOnboarding]);
+  const onEnter = useCallback(() => leave("completed"), [leave]);
+
+  // A step's own opt-out ("I use GitLab…", "Set up later"), distinct from the
+  // title-bar Skip: it declines one requirement rather than the whole flow.
+  const skipStep = useCallback(() => {
+    track("onboarding_step_skipped", { step, first_run: firstRun });
+    next();
+  }, [next, step, firstRun]);
 
   // keyboard navigation
   useEffect(() => {
@@ -104,7 +164,7 @@ export function Onboarding() {
       const tag = (e.target as HTMLElement | null)?.tagName;
       const inField = tag === "TEXTAREA" || tag === "INPUT";
       if (e.key === "Escape") {
-        closeOnboarding();
+        leave(step === "ready" ? "completed" : "abandoned");
       } else if (e.key === "Enter" && step === "welcome" && !busy) {
         onAuth("github");
       } else if ((e.key === "ArrowRight" || e.key === "Enter") && showNext && !inField) {
@@ -118,7 +178,7 @@ export function Onboarding() {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [idx, busy, step, showNext, canContinue, next, back]);
+  }, [idx, busy, step, showNext, canContinue, next, back, leave]);
 
   let content = null;
   if (step === "welcome")
@@ -132,8 +192,8 @@ export function Onboarding() {
         <WelcomeStep onAuth={onAuth} busy={busy} />
       );
   else if (step === "git") content = <GitStep setup={setup} />;
-  else if (step === "github") content = <GithubStep setup={setup} onSkip={next} />;
-  else if (step === "agents") content = <AgentsStep setup={setup} onSkip={next} />;
+  else if (step === "github") content = <GithubStep setup={setup} onSkip={skipStep} />;
+  else if (step === "agents") content = <AgentsStep setup={setup} onSkip={skipStep} />;
   else if (step === "ready") content = <ReadyStep setup={setup} onEnter={onEnter} />;
 
   const showBack = idx > 0;
@@ -153,7 +213,13 @@ export function Onboarding() {
             </span>
           )}
           {step !== "ready" && (
-            <button className="ob-skip text-sm" onClick={() => go(STEPS.length - 1)}>
+            <button
+              className="ob-skip text-sm"
+              onClick={() => {
+                track("onboarding_skipped", { step, first_run: firstRun });
+                go(STEPS.length - 1);
+              }}
+            >
               Skip
             </button>
           )}
@@ -161,7 +227,7 @@ export function Onboarding() {
             className="ob-close"
             title="Close (Esc)"
             aria-label="Close onboarding"
-            onClick={() => closeOnboarding()}
+            onClick={() => leave(step === "ready" ? "completed" : "abandoned")}
           >
             <Icon name="close" size={15} />
           </button>

--- a/src/components/Onboarding/steps.tsx
+++ b/src/components/Onboarding/steps.tsx
@@ -120,7 +120,8 @@ export function WelcomeStep({
           >
             Privacy Policy
           </a>
-          . Your code never leaves your machine.
+          . Your code never leaves your machine. Fletch shares anonymous usage data to improve the
+          app — turn it off anytime in Settings › General.
         </p>
       </div>
     </div>

--- a/src/store/repos.ts
+++ b/src/store/repos.ts
@@ -2,6 +2,7 @@ import { api } from "@/api";
 import { dropAgentEntries } from "@/helpers";
 import { clearOutputBuffer } from "@/pty/buffers";
 import { remapProjectOrder } from "@/storage/projectOrder";
+import { track } from "@/util/track";
 import type { SliceCreator } from "./types";
 
 export interface ReposSlice {
@@ -44,8 +45,13 @@ export const createReposSlice: SliceCreator<ReposSlice> = (set, get) => ({
   addWorkspaceRepo: async (path) => {
     set({ busy: true, lastError: null });
     try {
+      const first = (get().workspace?.projects.length ?? 0) === 0;
       const ws = await api.addWorkspaceRepo(path);
       set({ workspace: ws });
+      // Activation: onboarding hands off to an empty sidebar, so the first
+      // project is the moment a new user actually starts. Method + first only —
+      // never the path.
+      track("project_added", { method: "existing", first });
     } catch (e) {
       set({ lastError: String(e) });
     } finally {
@@ -130,13 +136,18 @@ export const createReposSlice: SliceCreator<ReposSlice> = (set, get) => ({
 
   cloneRepo: async (spec, destParent) => {
     // The new project appears in the sidebar via the refreshed workspace.
-    // Errors propagate to the caller (the modal) for inline display.
+    // Errors propagate to the caller (the modal) for inline display — and skip
+    // the event, so `project_added` only ever means a project that landed.
+    const first = (get().workspace?.projects.length ?? 0) === 0;
     const ws = await api.cloneRepo(spec, destParent);
     set({ workspace: ws });
+    track("project_added", { method: "clone", first });
   },
 
   createRepo: async (name, destParent, isPrivate, description, publish) => {
+    const first = (get().workspace?.projects.length ?? 0) === 0;
     const ws = await api.createRepo(name, destParent, isPrivate, description, publish);
     set({ workspace: ws });
+    track("project_added", { method: "create", first });
   },
 });

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -143,9 +143,12 @@ export const createUiSlice: SliceCreator<UiSlice> = (set, get) => ({
     const firstCompletion = !get().onboardingComplete;
     set({ onboardingOpen: false, onboardingComplete: true });
     setSetting("onboardingComplete", "true");
-    // On a fresh install the backend defers the first `app_opened` until now, so
-    // the event lands only after the data-sharing disclosure shown during
-    // onboarding has been seen. Fire it once, on the first completion.
+    // Safety net. On a fresh install the backend defers the first `app_opened`
+    // to the onboarding overlay's mount (the welcome step carries the
+    // data-sharing disclosure) — see `Onboarding/index.tsx`. This covers the
+    // case where onboarding is marked complete without that mount ever having
+    // happened; `track_app_opened` is idempotent, so the normal path is a no-op
+    // here rather than a double count.
     if (firstCompletion) void api.trackAppOpened();
   },
   toggleHistory: (open) =>

--- a/src/util/track.ts
+++ b/src/util/track.ts
@@ -1,0 +1,94 @@
+// Renderer-side product telemetry. One typed gate over the backend's
+// `track_event` command, so every frontend event has a declared name and a
+// declared property shape — the compiler is what stops an ad-hoc
+// `track("thing", { repoPath })` from leaking a path into PostHog.
+//
+// Scope: the onboarding funnel and the activation-path moments only the
+// frontend can see. Backend-observable events (`app_opened`, `agent_spawned`,
+// `pr_opened`, `turn_completed`) are emitted from Rust and are not repeated
+// here — one event, one emitter.
+//
+// Consent is enforced downstream in `telemetry::track` (Rust), so nothing here
+// needs to check the opt-out flag. Properties stay categorical — enums, counts,
+// booleans; never paths, repo/branch names, prompts, or raw error strings.
+
+import { api } from "@/api";
+
+/** The onboarding overlay's flat step model (mirrors `Onboarding/index.tsx`). */
+export type OnboardingStep = "welcome" | "git" | "github" | "agents" | "ready";
+
+/** Where a GitHub device-flow sign-in was launched from. Lets us tell an
+ *  onboarding sign-in (funnel drop-off) from a later one (a connect gate the
+ *  user hit mid-task). */
+export type ConnectSource =
+  | "onboarding_welcome"
+  | "onboarding_github"
+  | "new_project"
+  | "settings"
+  | "connect_gate";
+
+/** How a project entered the sidebar. */
+export type ProjectAddMethod = "existing" | "clone" | "create";
+
+/** Carried by every onboarding event. Onboarding is replayable from Settings ›
+ *  Developer, and a replay by an existing user is not a new-user funnel — so
+ *  every step of a PostHog funnel must be filtered on `first_run = true` for
+ *  the drop-off numbers to mean anything.
+ *
+ *  Declared as a type alias, not an interface: only aliases get the implicit
+ *  index signature that makes them assignable to the `Record<string, unknown>`
+ *  the IPC boundary takes. */
+type OnboardingCommon = {
+  first_run: boolean;
+};
+
+/** Every renderer-emitted event, with its exact property shape. Adding an
+ *  event means adding a line here first. */
+interface EventMap {
+  // ── onboarding funnel ────────────────────────────────────────────────────
+  /** A step came on screen. The whole drop-off curve is derivable from this. */
+  onboarding_step_viewed: OnboardingCommon & { step: OnboardingStep; index: number };
+  /** A per-step opt-out ("I use GitLab…", "Set up later"). */
+  onboarding_step_skipped: OnboardingCommon & { step: OnboardingStep };
+  /** The title-bar Skip, which jumps straight to the handoff. */
+  onboarding_skipped: OnboardingCommon & { step: OnboardingStep };
+  /** Esc / ✕ before reaching the handoff — the "gave up here" signal. */
+  onboarding_abandoned: OnboardingCommon & { step: OnboardingStep };
+  /** "Enter Fletch", with what the user actually finished with. Reachable with
+   *  gaps via Skip, so the flags matter. */
+  onboarding_completed: OnboardingCommon & {
+    git_ready: boolean;
+    gh_connected: boolean;
+    agents_detected: number;
+  };
+
+  // ── GitHub device flow ───────────────────────────────────────────────────
+  // started + one terminal event, so the browser round-trip (the step most
+  // likely to strand someone) has a measurable completion rate.
+  github_connect_started: { source: ConnectSource; provider: string };
+  github_connect_succeeded: { source: ConnectSource; provider: string };
+  github_connect_failed: { source: ConnectSource; provider: string };
+  github_connect_cancelled: { source: ConnectSource; provider: string };
+
+  // ── portable git bootstrap ───────────────────────────────────────────────
+  git_install_started: Record<string, never>;
+  git_install_succeeded: Record<string, never>;
+  git_install_failed: Record<string, never>;
+
+  // ── one-click agent CLI install ──────────────────────────────────────────
+  agent_cli_install_started: { provider: string };
+  agent_cli_install_succeeded: { provider: string };
+  agent_cli_install_failed: { provider: string };
+
+  // ── activation ───────────────────────────────────────────────────────────
+  /** A project landed in the sidebar. `first` marks the activation moment. */
+  project_added: { method: ProjectAddMethod; first: boolean };
+}
+
+export type TrackedEvent = keyof EventMap;
+
+/** Record a product event. Fire-and-forget: telemetry must never break a user
+ *  flow, so a failed IPC is swallowed. */
+export function track<E extends TrackedEvent>(event: E, props: EventMap[E]): void {
+  void api.trackEvent(event, props).catch(() => {});
+}

--- a/src/util/useGitInstall.ts
+++ b/src/util/useGitInstall.ts
@@ -5,6 +5,7 @@
 
 import { useCallback, useState } from "react";
 import { api, type ToolStatus } from "@/api";
+import { track } from "./track";
 import { type GitDistState, useGitDist } from "./useGitDist";
 
 export interface GitInstall {
@@ -30,12 +31,22 @@ export function useGitInstall(git: ToolStatus | null, recheck: () => void): GitI
   const [installingGit, setInstallingGit] = useState(false);
   const installGit = useCallback(() => {
     setInstallingGit(true);
+    track("git_install_started", {});
     // Progress + failure reason arrive via git-dist:state; the final recheck
     // covers the case where the bootstrap already settled before mount (no
     // further events) yet the retry succeeded.
+    //
+    // The two-arm `then` reports the outcome and absorbs the rejection (as the
+    // old `.catch(() => {})` did), so `finally` still runs and nothing escapes
+    // unhandled. It measures whether the install *call* completed, which is the
+    // signal we want: a user stuck without git is one who never gets past the
+    // git step at all.
     void api
       .gitDistInstall()
-      .catch(() => {})
+      .then(
+        () => track("git_install_succeeded", {}),
+        () => track("git_install_failed", {}),
+      )
       .finally(() => {
         setInstallingGit(false);
         recheck();

--- a/src/util/useGithubConnect.ts
+++ b/src/util/useGithubConnect.ts
@@ -4,6 +4,7 @@ import { open as openExternal } from "@tauri-apps/plugin-shell";
 import { useCallback, useRef, useState } from "react";
 import { getOrCreateAccount, linkOAuthAccount, type OAuthProfile } from "@/storage/accounts";
 import { useAppStore } from "@/store";
+import { type ConnectSource, track } from "./track";
 
 /** Info shown while a device-flow sign-in is pending: the user code to enter
  *  at the provider's verification page (opened automatically in the browser). */
@@ -22,8 +23,15 @@ export interface DeviceInfo {
  *
  *  Late results from a superseded/cancelled attempt are dropped via a
  *  monotonic run id: the backend keeps polling until the code expires, but its
- *  outcome no longer touches the UI or the store. */
-export function useGithubConnect(onConnected?: () => void) {
+ *  outcome no longer touches the UI or the store.
+ *
+ *  Telemetry lives here rather than at the call sites so every entry point is
+ *  measured identically; `source` is the only thing a caller supplies, and it
+ *  separates an onboarding sign-in (funnel drop-off) from one the user hit
+ *  mid-task. The device flow sends the user to a browser to paste a code —
+ *  the likeliest place to strand someone — so started/succeeded/failed/
+ *  cancelled are all reported. */
+export function useGithubConnect(onConnected?: () => void, source: ConnectSource = "settings") {
   const refreshAccount = useAppStore((s) => s.refreshAccount);
   const refreshGithub = useAppStore((s) => s.refreshGithub);
 
@@ -42,6 +50,7 @@ export function useGithubConnect(onConnected?: () => void) {
       setBusy(provider);
       setError(null);
       setDevice(null);
+      track("github_connect_started", { source, provider });
       // Default no-op so `finally` can always call it; listen() lives inside
       // the try so an IPC failure surfaces as an error instead of throwing.
       let unlisten: UnlistenFn = () => {};
@@ -70,26 +79,33 @@ export function useGithubConnect(onConnected?: () => void) {
         if (stale()) return;
         setBusy(null);
         setDevice(null);
+        track("github_connect_succeeded", { source, provider });
         onConnectedRef.current?.();
       } catch (err) {
         if (stale()) return;
         setError(String(err));
         setBusy(null);
+        // Categorical only — the raw error can carry a URL or account handle.
+        track("github_connect_failed", { source, provider });
       } finally {
         unlisten();
       }
     },
-    [busy, refreshAccount, refreshGithub],
+    [busy, refreshAccount, refreshGithub, source],
   );
 
   /** Abandon the current attempt: invalidate its run id and clear UI state.
    *  The backend poll runs on until the code expires but is ignored. */
   const cancel = useCallback(() => {
     runRef.current++;
+    // Guarded on `busy` so only a live attempt counts as abandoned: the error
+    // branch clears `busy` first, and its Cancel button is a dismissal (already
+    // reported as `github_connect_failed`), not a second outcome.
+    if (busy) track("github_connect_cancelled", { source, provider: busy });
     setDevice(null);
     setError(null);
     setBusy(null);
-  }, []);
+  }, [busy, source]);
 
   return { connect, cancel, device, error, busy };
 }


### PR DESCRIPTION
## Why

PostHog saw `app_opened` and little else — no way to tell whether new users got through onboarding or where they stalled. The telemetry pipeline was **backend-only**: the renderer had no way to emit anything, which is exactly why the onboarding flow was invisible.

## The consent problem, and what changed

Onboarding drop-off is only measurable if events fire *before* the last step. Under the old design that was impossible by construction: the launch-time `app_opened` was skipped on fresh installs, and the only event fired came from `closeOnboarding()` — i.e. at the very end. The reason was the data-sharing disclosure, which sat on the final step.

So users who stalled at step 02 sent nothing. Precisely the cohort we wanted to see.

This moves the disclosure to the **welcome step** (it stays on the handoff too) and fires the deferred `app_opened` when the overlay mounts. Tracking now begins at the moment the user is told about it, rather than after they finish.

Worth noting the old guarantee was already leaky: Esc and ✕ both called `closeOnboarding()`, so bailing out on the welcome step already fired `app_opened` without the disclosure ever being shown.

⚠️ This shifts the `app_opened` baseline **up** slightly — fresh installs that abandon onboarding now count, where before they were invisible.

## What's added

**Bridge** — `track_event` Tauri command plus `src/util/track.ts`, the typed gate over it. Every event name and property shape is declared in one `EventMap`, so the compiler is what stops a path or prompt reaching a property. Consent stays enforced downstream in `telemetry::track`.

**16 events**

| Area | Events |
|---|---|
| Funnel | `onboarding_step_viewed` · `onboarding_step_skipped` · `onboarding_skipped` · `onboarding_abandoned` · `onboarding_completed` |
| GitHub device flow | `github_connect_` `started`/`succeeded`/`failed`/`cancelled` |
| Portable git | `git_install_` `started`/`succeeded`/`failed` |
| Agent CLI install | `agent_cli_install_` `started`/`succeeded`/`failed` |
| Activation | `project_added` |

`onboarding_step_viewed` alone gives the whole drop-off curve; the terminal events say *how* each user left. `onboarding_completed` carries `git_ready`/`gh_connected`/`agents_detected` because the handoff is reachable with gaps via Skip.

GitHub tracking lives in `useGithubConnect` behind a `source` param, and git-install tracking in `useGitInstall`, rather than at the call sites — so coverage can't drift as surfaces are added.

## Correctness details

- **`send_app_opened`** holds a process-static flag shared by *both* the launch-time send and the command. Without it, replaying onboarding from Settings › Developer would double-count a launch (launch fires one, the replay's mount fires another).
- **`first_run`** on every onboarding event, so a replay by an existing user is filterable out of the new-user funnel. Frozen at mount — `closeOnboarding()` flips `onboardingComplete` before the terminal event would otherwise read it.
- Both GitHub terminal events sit after the `stale()` guard, so a cancelled-then-late-resolving attempt can't emit a second outcome. `cancelled` is guarded on `busy` so dismissing a settled error isn't counted twice.
- `project_added` fires after the await, so a failed clone/create emits nothing.

## Privacy

Properties stay categorical throughout — provider ids, step names, counts, booleans. No paths, repo/branch names, or prompts. The OAuth and agent-installer error strings are deliberately dropped rather than sent.

## Testing

`tsc` clean · Biome 0 errors (72 pre-existing warnings, unchanged) · 732 tests pass · `cargo check` clean.

Not covered by unit tests: the repo has no React component test infrastructure (no `.test.tsx`, no testing-library) and these are component/hook wiring changes. Adding that harness felt out of scope for this PR.

## Follow-up (not in this PR)

Esc or ✕ marks onboarding complete even on the welcome step (`ui.ts:143`), so a user who dismisses at step 1 never sees it again. Pre-existing; now at least visible as `onboarding_abandoned`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
