### PR TITLE
fix(rpc): split the mailbox root per build

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -74,14 +74,15 @@ pub(crate) fn data_dir() -> PathBuf {
 
 /// The per-build path segment for a kind of on-disk state under a shared base
 /// (`~/.fletch`, or an override root): `<leaf>` for release, `dev/<leaf>` for
-/// debug — the same `dev` split [`data_dir`] applies to app data.
+/// debug — the same `dev` split [`data_dir`] applies to app data. Release keeps
+/// the historical flat segment, so existing installs need no migration.
 ///
-/// Every root a *live* agent's state hangs off must go through this. A debug
-/// instance and a release install have separate DBs but one filesystem, and
-/// their name allocators draw from the same pool, so any shared root lets one
-/// build's startup housekeeping delete — or one build's agent collide with —
-/// the other's live state. Release keeps the historical flat segment, so
-/// existing installs need no migration.
+/// Every root a *live* agent's state hangs off must go through this: a debug
+/// instance and a release install have separate DBs but one filesystem, so from
+/// a shared root each build's startup housekeeping sees the other's live state
+/// as garbage — and their name allocators, drawing from one pool, can hand both
+/// builds the same agent id. The `dev` prefix makes the two roots siblings, not
+/// nested, so neither build's sweep can even see the other's.
 pub(crate) fn build_state_subpath(leaf: &str) -> PathBuf {
     if cfg!(debug_assertions) {
         PathBuf::from("dev").join(leaf)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -72,6 +72,24 @@ pub(crate) fn data_dir() -> PathBuf {
     }
 }
 
+/// The per-build path segment for a kind of on-disk state under a shared base
+/// (`~/.fletch`, or an override root): `<leaf>` for release, `dev/<leaf>` for
+/// debug — the same `dev` split [`data_dir`] applies to app data.
+///
+/// Every root a *live* agent's state hangs off must go through this. A debug
+/// instance and a release install have separate DBs but one filesystem, and
+/// their name allocators draw from the same pool, so any shared root lets one
+/// build's startup housekeeping delete — or one build's agent collide with —
+/// the other's live state. Release keeps the historical flat segment, so
+/// existing installs need no migration.
+pub(crate) fn build_state_subpath(leaf: &str) -> PathBuf {
+    if cfg!(debug_assertions) {
+        PathBuf::from("dev").join(leaf)
+    } else {
+        PathBuf::from(leaf)
+    }
+}
+
 /// Fletch's log directory. On macOS this is `~/Library/Logs/<BUNDLE_ID>`
 /// (with a `dev` subfolder under debug builds, mirroring `data_dir`) — the
 /// platform convention, where Console.app indexes per-app logs. Elsewhere (the

--- a/src-tauri/src/rpc.rs
+++ b/src-tauri/src/rpc.rs
@@ -113,21 +113,40 @@ impl Response {
 /// a sandbox-writable root instead — see `sandbox::nested_rpc_root`.
 pub const RPC_ROOT_ENV: &str = "FLETCH_RPC_ROOT";
 
-/// `<root>/<agent-id>/` — the agent's private mailbox root. `<root>` is
-/// `$FLETCH_RPC_ROOT` when set and non-empty, else `~/.fletch/rpc`.
+/// `<root>/<agent-id>/` — the agent's private mailbox root. `<root>` is this
+/// build's mailbox root under `~/.fletch` (or under `$FLETCH_RPC_ROOT` when set
+/// and non-empty): `rpc/` for release, `dev/rpc/` for debug.
 pub fn mailbox_dir(agent_id: &str) -> Result<PathBuf> {
     Ok(rpc_root()?.join(agent_id))
 }
 
 fn rpc_root() -> Result<PathBuf> {
-    match std::env::var_os(RPC_ROOT_ENV).filter(|v| !v.is_empty()) {
-        Some(root) => Ok(PathBuf::from(root)),
-        None => {
-            let home = dirs::home_dir()
-                .ok_or_else(|| Error::Other("HOME directory not available".into()))?;
-            Ok(home.join(".fletch").join("rpc"))
-        }
-    }
+    let base = match std::env::var_os(RPC_ROOT_ENV).filter(|v| !v.is_empty()) {
+        Some(root) => PathBuf::from(root),
+        None => dirs::home_dir()
+            .ok_or_else(|| Error::Other("HOME directory not available".into()))?
+            .join(".fletch"),
+    };
+    Ok(rpc_root_in(&base))
+}
+
+/// Apply the per-build split to a mailbox base — the exact mirror of
+/// `workspace::paths::checkouts_root_in`, and split out for the same reasons:
+/// testable without mutating the process-global override, and the override and
+/// default paths share one "append the build subpath" step so neither can drift
+/// into bypassing the split.
+///
+/// The split is load-bearing, not hygiene. Each build has its own DB, so
+/// [`sweep_orphan_mailboxes`] removing every dir it can't account for would,
+/// from a shared root, delete the *other* build's live mailboxes — stranding a
+/// running agent whose `$FLETCH_RPC_DIR` has just vanished mid-turn. And since
+/// the two name allocators draw from one pool, a name live in both builds would
+/// map to a single mailbox that both watchers poll, so either build's dispatcher
+/// could execute the other's request against the wrong checkout. An exclusive
+/// root per build rules out both. Nothing migrates: a mailbox is per-spawn
+/// state, so a pre-split dir is simply an orphan the release build sweeps.
+pub(crate) fn rpc_root_in(base: &Path) -> PathBuf {
+    base.join(crate::build_state_subpath("rpc"))
 }
 
 /// Create the mailbox and its `requests/`/`responses/` subdirs. Idempotent;
@@ -178,6 +197,11 @@ pub fn remove_mailbox(agent_id: &str) -> Result<()> {
 /// teardown can still leak one. `live` is this build's non-archived agent ids
 /// (see `WorkspaceManager::live_agent_ids`) — the same set the name allocator
 /// treats as reserved, so the two never disagree about who's alive.
+///
+/// "Doesn't belong to a live agent" is only sound because the root is
+/// per-build (see [`rpc_root_in`]): every mailbox under it was created by an
+/// agent in the DB `live` came from. A root shared with another build would put
+/// that build's live agents outside `live` and delete their mailboxes.
 ///
 /// Skipped when `RPC_ROOT_ENV` is set: that's the nested-Fletch redirect, whose
 /// pid-keyed roots are reclaimed by `sandbox::cleanup_nested_rpc_roots`, and
@@ -397,6 +421,45 @@ mod tests {
 
     fn live(names: &[&str]) -> HashSet<String> {
         names.iter().map(|n| n.to_string()).collect()
+    }
+
+    #[test]
+    fn mailbox_root_is_split_per_build() {
+        // A shared base (`~/.fletch`, or a `$FLETCH_RPC_ROOT` redirect two
+        // builds could both be pointed at) must not bypass the split — the
+        // mailbox root is what keeps one build's housekeeping and name
+        // allocation off another build's live agents.
+        let base = Path::new("/tmp/shared-base");
+        let root = rpc_root_in(base);
+        assert!(root.starts_with(base));
+        // Tests compile with debug_assertions on.
+        if cfg!(debug_assertions) {
+            assert_eq!(root, base.join("dev").join("rpc"));
+        } else {
+            assert_eq!(root, base.join("rpc"));
+        }
+    }
+
+    #[test]
+    fn sweep_cannot_reach_another_builds_live_mailboxes() {
+        // The regression: a debug instance's startup sweep used to run over the
+        // one flat `~/.fletch/rpc`, so every release-build agent — absent from
+        // the debug DB's `live` set — lost its mailbox, including agents with a
+        // turn in flight. Per-build roots put them out of reach.
+        let td = tempfile::tempdir().unwrap();
+        let base = td.path();
+        let release = base.join("rpc");
+        let debug = base.join("dev").join("rpc");
+        ensure_mailbox(&release.join("pilbara")).unwrap();
+        ensure_mailbox(&debug.join("bromo")).unwrap();
+
+        sweep_orphan_mailboxes_in(&debug, &live(&["bromo"]));
+
+        assert!(
+            release.join("pilbara").is_dir(),
+            "another build's live mailbox was swept"
+        );
+        assert!(debug.join("bromo").is_dir());
     }
 
     #[test]

--- a/src-tauri/src/rpc.rs
+++ b/src-tauri/src/rpc.rs
@@ -130,22 +130,15 @@ fn rpc_root() -> Result<PathBuf> {
     Ok(rpc_root_in(&base))
 }
 
-/// Apply the per-build split to a mailbox base — the exact mirror of
-/// `workspace::paths::checkouts_root_in`, and split out for the same reasons:
-/// testable without mutating the process-global override, and the override and
-/// default paths share one "append the build subpath" step so neither can drift
-/// into bypassing the split.
+/// Apply the per-build split (see [`crate::build_state_subpath`]) to a mailbox
+/// base. The exact mirror of `workspace::paths::checkouts_root_in`, split out
+/// for the same reasons: testable without mutating the process-global override,
+/// and the override and default paths share one "append the build subpath" step
+/// so neither can drift into bypassing the split.
 ///
-/// The split is load-bearing, not hygiene. Each build has its own DB, so
-/// [`sweep_orphan_mailboxes`] removing every dir it can't account for would,
-/// from a shared root, delete the *other* build's live mailboxes — stranding a
-/// running agent whose `$FLETCH_RPC_DIR` has just vanished mid-turn. And since
-/// the two name allocators draw from one pool, a name live in both builds would
-/// map to a single mailbox that both watchers poll, so either build's dispatcher
-/// could execute the other's request against the wrong checkout. An exclusive
-/// root per build rules out both. Nothing migrates: a mailbox is per-spawn
-/// state, so a pre-split dir is simply an orphan the release build sweeps.
-pub(crate) fn rpc_root_in(base: &Path) -> PathBuf {
+/// Nothing migrates on upgrade — a mailbox is per-spawn state, so a pre-split
+/// dir is just an orphan the release build sweeps.
+fn rpc_root_in(base: &Path) -> PathBuf {
     base.join(crate::build_state_subpath("rpc"))
 }
 
@@ -199,9 +192,9 @@ pub fn remove_mailbox(agent_id: &str) -> Result<()> {
 /// treats as reserved, so the two never disagree about who's alive.
 ///
 /// "Doesn't belong to a live agent" is only sound because the root is
-/// per-build (see [`rpc_root_in`]): every mailbox under it was created by an
-/// agent in the DB `live` came from. A root shared with another build would put
-/// that build's live agents outside `live` and delete their mailboxes.
+/// per-build (`rpc_root_in`): every mailbox under it was created by an agent in
+/// the DB `live` came from. Sharing a root with another build would put that
+/// build's live agents outside `live` and delete their mailboxes mid-turn.
 ///
 /// Skipped when `RPC_ROOT_ENV` is set: that's the nested-Fletch redirect, whose
 /// pid-keyed roots are reclaimed by `sandbox::cleanup_nested_rpc_roots`, and
@@ -425,41 +418,32 @@ mod tests {
 
     #[test]
     fn mailbox_root_is_split_per_build() {
-        // A shared base (`~/.fletch`, or a `$FLETCH_RPC_ROOT` redirect two
-        // builds could both be pointed at) must not bypass the split — the
-        // mailbox root is what keeps one build's housekeeping and name
-        // allocation off another build's live agents.
+        // A shared base — `~/.fletch`, or one `$FLETCH_RPC_ROOT` redirect two
+        // builds are both pointed at — must not bypass the split. Tests compile
+        // with debug_assertions on.
         let base = Path::new("/tmp/shared-base");
-        let root = rpc_root_in(base);
-        assert!(root.starts_with(base));
-        // Tests compile with debug_assertions on.
-        if cfg!(debug_assertions) {
-            assert_eq!(root, base.join("dev").join("rpc"));
-        } else {
-            assert_eq!(root, base.join("rpc"));
-        }
+        assert_eq!(rpc_root_in(base), base.join("dev").join("rpc"));
     }
 
     #[test]
     fn sweep_cannot_reach_another_builds_live_mailboxes() {
-        // The regression: a debug instance's startup sweep used to run over the
-        // one flat `~/.fletch/rpc`, so every release-build agent — absent from
-        // the debug DB's `live` set — lost its mailbox, including agents with a
-        // turn in flight. Per-build roots put them out of reach.
+        // The regression: a debug instance's startup sweep ran over the one flat
+        // `~/.fletch/rpc`, so every release-build agent — absent from the debug
+        // DB's `live` set — lost its mailbox, including agents with a turn in
+        // flight. Per-build roots put them out of reach.
         let td = tempfile::tempdir().unwrap();
-        let base = td.path();
-        let release = base.join("rpc");
-        let debug = base.join("dev").join("rpc");
-        ensure_mailbox(&release.join("pilbara")).unwrap();
-        ensure_mailbox(&debug.join("bromo")).unwrap();
+        let ours = rpc_root_in(td.path());
+        let theirs = td.path().join("rpc"); // the release install's, same base
+        ensure_mailbox(&ours.join("bromo")).unwrap();
+        ensure_mailbox(&theirs.join("pilbara")).unwrap();
 
-        sweep_orphan_mailboxes_in(&debug, &live(&["bromo"]));
+        sweep_orphan_mailboxes_in(&ours, &live(&["bromo"]));
 
         assert!(
-            release.join("pilbara").is_dir(),
+            theirs.join("pilbara").is_dir(),
             "another build's live mailbox was swept"
         );
-        assert!(debug.join("bromo").is_dir());
+        assert!(ours.join("bromo").is_dir());
     }
 
     #[test]

--- a/src-tauri/src/workspace/paths.rs
+++ b/src-tauri/src/workspace/paths.rs
@@ -68,8 +68,8 @@ pub(super) fn checkouts_root_in(base: &Path) -> PathBuf {
 /// The workspaces path segment(s) under the checkouts base (`~/.fletch` or the
 /// `$FLETCH_WORKSPACES_ROOT` override), split per build so a debug instance
 /// never shares the checkout namespace with a release install: flat
-/// `workspaces/` for release, `dev/workspaces/` for debug. See
-/// [`crate::build_state_subpath`], which `rpc::rpc_root_in` shares.
+/// `workspaces/` for release, `dev/workspaces/` for debug — see
+/// [`crate::build_state_subpath`].
 pub(super) fn build_workspaces_subpath() -> PathBuf {
     crate::build_state_subpath("workspaces")
 }

--- a/src-tauri/src/workspace/paths.rs
+++ b/src-tauri/src/workspace/paths.rs
@@ -67,16 +67,11 @@ pub(super) fn checkouts_root_in(base: &Path) -> PathBuf {
 
 /// The workspaces path segment(s) under the checkouts base (`~/.fletch` or the
 /// `$FLETCH_WORKSPACES_ROOT` override), split per build so a debug instance
-/// never shares the checkout namespace with a release install. Release
-/// keeps the historical flat `workspaces/` (so existing installs need no
-/// migration); debug builds get a sibling `dev/workspaces/` root, mirroring the
-/// `dev` split `data_dir` already uses for app data.
+/// never shares the checkout namespace with a release install: flat
+/// `workspaces/` for release, `dev/workspaces/` for debug. See
+/// [`crate::build_state_subpath`], which `rpc::rpc_root_in` shares.
 pub(super) fn build_workspaces_subpath() -> PathBuf {
-    if cfg!(debug_assertions) {
-        PathBuf::from("dev").join("workspaces")
-    } else {
-        PathBuf::from("workspaces")
-    }
+    crate::build_state_subpath("workspaces")
 }
 
 /// Env var overriding the tools root (default `~/.fletch/tools`). Same style as


### PR DESCRIPTION
The RPC mailbox root was a single flat `~/.fletch/rpc` shared by every build, while the DB (`data_dir`) and the checkouts root are both split release/debug.

`sweep_orphan_mailboxes` deletes every mailbox absent from **this build's** `live_agent_ids()`, so launching the debug build wiped the release install's live mailboxes. A running agent then found `$FLETCH_RPC_DIR` gone mid-turn and its `open_pr` failed. From the logs:

```
dev/fletch.log   04:06:18Z  swept orphan rpc mailboxes removed=27 live=8
release log      04:20:00Z  agent status transition agent_id=pilbara Idle -> Running   # the turn that failed
```

`live=8` is the dev DB; none of the 14 live release agents are in it. (It reproduced again at 05:11:25Z, `removed=1` — the mailbox of the agent writing this PR.)

The same shared root also let a name live in both builds (independent allocators, one name pool) map to a single mailbox that both watchers poll — either build's dispatcher could execute the other's request against the wrong checkout.

## Change

- `rpc_root()` resolves a base (`~/.fletch`, or `$FLETCH_RPC_ROOT`) and appends the build subpath via a new `rpc_root_in()` — the mirror of `workspace::paths::checkouts_root_in`. The override goes through the same step, so two builds pointed at one redirect still land in separate roots.
- The `cfg!(debug_assertions)` branch both roots share moves into `build_state_subpath(leaf)` in `lib.rs`, next to `data_dir()` which already owned the `dev` split; `build_workspaces_subpath()` now delegates to it.
- `sweep_orphan_mailboxes` docs record why "not in `live`" implies "orphan" — it only holds because the root is exclusive to the build whose DB `live` came from.

## Tests

Two added in `rpc.rs`: the split applies to any base including an override, and a regression test where a debug-side sweep with its own `live` set leaves a release mailbox intact. Full suite 1093 passed; clippy and fmt clean.

## Migration

None. Release keeps the flat `rpc/`, so nothing running now is disturbed; the debug build moves to `~/.fletch/dev/rpc` on its next spawn. A mailbox is per-spawn state, so pre-split dev dirs are orphans the release build sweeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)