### PR TITLE
refactor(ui): extract PanelToggle and stop highlighting the right rail

### DIFF
--- a/src/components/PanelToggle.tsx
+++ b/src/components/PanelToggle.tsx
@@ -1,0 +1,60 @@
+import { Icon, type IconName } from "@/components/Icon";
+import { IconButton } from "@/components/ui/IconButton";
+import type { AppState } from "@/store";
+import { useAppStore } from "@/store";
+
+type Side = "left" | "right";
+
+interface SideSpec {
+  icon: IconName;
+  /** What the tooltip calls this rail — "Show sidebar" / "Hide panel". */
+  noun: string;
+  kbd: string;
+  collapsed: (s: AppState) => boolean;
+  toggle: (s: AppState) => () => void;
+}
+
+/** Everything that differs between the two rails. Keeping it as a table (rather
+ *  than branching in the body) is what makes divergence impossible: adding a
+ *  tooltip, an icon, or a state class means editing one row, and the other side
+ *  either gets it too or visibly doesn't. */
+const SIDES: Record<Side, SideSpec> = {
+  left: {
+    icon: "sidebarL",
+    noun: "sidebar",
+    kbd: "⌘B",
+    collapsed: (s) => s.leftCollapsed,
+    toggle: (s) => s.toggleLeft,
+  },
+  right: {
+    icon: "sidebarR",
+    noun: "panel",
+    kbd: "⌘/",
+    collapsed: (s) => s.rightCollapsed,
+    toggle: (s) => s.toggleRight,
+  },
+};
+
+/** Show/hide toggle for one of the two side rails. Shared by every pane that
+ *  renders a `.center-h` header (Workspace, Home, Mission Control, the draft
+ *  empty state, and the workflow run monitor) so the icon, the tooltip wording,
+ *  and the resting appearance can't drift between call sites — they had: the
+ *  right toggle carried `active`, and two RunView copies said "Toggle sidebar"
+ *  instead of the show/hide pair.
+ *
+ *  Deliberately never `active`. Both rails are open by default, so an accent
+ *  tied to "open" would be the resting state — permanently orange, carrying no
+ *  information, and competing with the accents that do mean something (status
+ *  dots, the git CTA). The glyph says which rail and the tooltip says what a
+ *  click will do; that's the whole signal. Reserve `IconButton`'s `active` for
+ *  states that are off by default, the way the composer's pickers use it. */
+export function PanelToggle({ side }: { side: Side }) {
+  const { icon, noun, kbd } = SIDES[side];
+  const collapsed = useAppStore(SIDES[side].collapsed);
+  const toggle = useAppStore(SIDES[side].toggle);
+  return (
+    <IconButton tip={`${collapsed ? "Show" : "Hide"} ${noun} (${kbd})`} onClick={toggle}>
+      <Icon name={icon} />
+    </IconButton>
+  );
+}

--- a/src/components/Workspace/EmptyWorkspace.tsx
+++ b/src/components/Workspace/EmptyWorkspace.tsx
@@ -4,6 +4,7 @@ import { Composer } from "@/components/Composer";
 import { BranchPicker } from "@/components/Composer/BranchPicker";
 import { type ProjectOption, ProjectPicker } from "@/components/Composer/ProjectPicker";
 import { Icon, LandmarkGlyph } from "@/components/Icon";
+import { PanelToggle } from "@/components/PanelToggle";
 import { IconButton } from "@/components/ui/IconButton";
 import { resolveBaseBranch } from "@/helpers";
 import { getLinearTeamId } from "@/storage/projectSettings";
@@ -44,8 +45,6 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
     if (!projectId) return 1;
     return projectRefs.filter((r) => r.project_id === projectId).length;
   }, [projectRefs, draft.repoPath]);
-  const toggleLeft = useAppStore((s) => s.toggleLeft);
-  const leftCollapsed = useAppStore((s) => s.leftCollapsed);
   const runLocalCommand = useAppStore((s) => s.runLocalCommand);
 
   // The project this draft targets — keys the remembered composer mode + default
@@ -103,12 +102,7 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
   return (
     <div className="pane center">
       <div className="center-h flex-center">
-        <IconButton
-          tip={leftCollapsed ? "Show sidebar (⌘B)" : "Hide sidebar (⌘B)"}
-          onClick={toggleLeft}
-        >
-          <Icon name="sidebarL" />
-        </IconButton>
+        <PanelToggle side="left" />
         <div className="task" style={{ flexDirection: "row", alignItems: "center", gap: 10 }}>
           <span
             style={{

--- a/src/components/Workspace/Home/index.tsx
+++ b/src/components/Workspace/Home/index.tsx
@@ -1,7 +1,6 @@
 import { open } from "@tauri-apps/plugin-dialog";
 import { useState } from "react";
-import { Icon } from "@/components/Icon";
-import { IconButton } from "@/components/ui/IconButton";
+import { PanelToggle } from "@/components/PanelToggle";
 import { useAppStore } from "@/store";
 import { ActionCard } from "./ActionCard";
 import { greeting } from "./greeting";
@@ -14,8 +13,6 @@ import { greeting } from "./greeting";
  *  action — nothing decorative. */
 export function Home() {
   const workspace = useAppStore((s) => s.workspace);
-  const leftCollapsed = useAppStore((s) => s.leftCollapsed);
-  const toggleLeft = useAppStore((s) => s.toggleLeft);
   const createDraft = useAppStore((s) => s.createDraft);
   const addWorkspaceRepo = useAppStore((s) => s.addWorkspaceRepo);
   const setLastRepoPath = useAppStore((s) => s.setLastRepoPath);
@@ -90,12 +87,7 @@ export function Home() {
   return (
     <div className="pane center">
       <div className="center-h flex-center">
-        <IconButton
-          tip={leftCollapsed ? "Show sidebar (⌘B)" : "Hide sidebar (⌘B)"}
-          onClick={toggleLeft}
-        >
-          <Icon name="sidebarL" />
-        </IconButton>
+        <PanelToggle side="left" />
       </div>
 
       <div className="home-wrap flex-center fade-in">

--- a/src/components/Workspace/MissionControl/index.tsx
+++ b/src/components/Workspace/MissionControl/index.tsx
@@ -6,7 +6,7 @@
 
 import { useState } from "react";
 import { Icon } from "@/components/Icon";
-import { IconButton } from "@/components/ui/IconButton";
+import { PanelToggle } from "@/components/PanelToggle";
 import { useAppStore } from "@/store";
 import { AllClear } from "./AllClear";
 import { FanoutCard } from "./FanoutCard";
@@ -18,8 +18,6 @@ import { useReviewQueue } from "./useReviewQueue";
 import { WorkflowReviewModal } from "./WorkflowReviewModal";
 
 export function MissionControl() {
-  const leftCollapsed = useAppStore((s) => s.leftCollapsed);
-  const toggleLeft = useAppStore((s) => s.toggleLeft);
   const agentCount = useAppStore((s) => s.workspace?.agents.length ?? 0);
 
   const items = useReviewQueue();
@@ -37,12 +35,7 @@ export function MissionControl() {
   return (
     <div className="pane center fade-in">
       <div className="center-h flex-center">
-        <IconButton
-          tip={leftCollapsed ? "Show sidebar (⌘B)" : "Hide sidebar (⌘B)"}
-          onClick={toggleLeft}
-        >
-          <Icon name="sidebarL" />
-        </IconButton>
+        <PanelToggle side="left" />
         <div className="task">
           <div className="t-name">
             <Icon name="layers" size={14} style={{ color: "var(--accent)", flexShrink: 0 }} />

--- a/src/components/Workspace/WorkspaceHeader.tsx
+++ b/src/components/Workspace/WorkspaceHeader.tsx
@@ -1,5 +1,6 @@
 import type { AgentRecord, AgentStatus, DiffStats } from "@/api";
 import { Icon } from "@/components/Icon";
+import { PanelToggle } from "@/components/PanelToggle";
 import { IconButton } from "@/components/ui/IconButton";
 import { useAppStore } from "@/store";
 import { formatAge } from "@/util/format";
@@ -47,10 +48,6 @@ export function WorkspaceHeader({ agent }: Props) {
   const nativeView = useAppStore((s) => s.features.nativeView);
   const railOpen = useAppStore((s) => s.transcriptRailOpen);
   const toggleRail = useAppStore((s) => s.toggleTranscriptRail);
-  const leftCollapsed = useAppStore((s) => s.leftCollapsed);
-  const rightCollapsed = useAppStore((s) => s.rightCollapsed);
-  const toggleLeft = useAppStore((s) => s.toggleLeft);
-  const toggleRight = useAppStore((s) => s.toggleRight);
   const now = useMinuteClock();
   // Use shortstats (5s app-wide poll) rather than full git state, since
   // the header shows shortstats regardless of which right-rail tab is
@@ -65,12 +62,7 @@ export function WorkspaceHeader({ agent }: Props) {
 
   return (
     <div className="center-h flex-center">
-      <IconButton
-        tip={leftCollapsed ? "Show sidebar (⌘B)" : "Hide sidebar (⌘B)"}
-        onClick={toggleLeft}
-      >
-        <Icon name="sidebarL" />
-      </IconButton>
+      <PanelToggle side="left" />
 
       <div className="task">
         <div className="t-name">
@@ -120,13 +112,7 @@ export function WorkspaceHeader({ agent }: Props) {
         tip="Fork this workspace and conversation"
       />
 
-      <IconButton
-        active={!rightCollapsed}
-        tip={rightCollapsed ? "Show panel (⌘/)" : "Hide panel (⌘/)"}
-        onClick={toggleRight}
-      >
-        <Icon name="sidebarR" />
-      </IconButton>
+      <PanelToggle side="right" />
     </div>
   );
 }

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import type { AgentRecord } from "@/api";
 import { Icon } from "@/components/Icon";
+import { PanelToggle } from "@/components/PanelToggle";
 import { Button } from "@/components/ui/Button";
-import { IconButton } from "@/components/ui/IconButton";
 import { providerLabel } from "@/data/providers";
 import { EMPTY_AGENTS, useAppStore } from "@/store";
 import { RunView } from "@/workflows/run/RunView";
@@ -24,8 +24,6 @@ export function Workspace() {
   const selectedRunId = useAppStore((s) => s.selectedRunId);
   const drafts = useAppStore((s) => s.drafts);
   const activeDraftId = useAppStore((s) => s.activeDraftId);
-  const leftCollapsed = useAppStore((s) => s.leftCollapsed);
-  const toggleLeft = useAppStore((s) => s.toggleLeft);
   const missionControl = useAppStore((s) => s.features.missionControl);
   const nativeView = useAppStore((s) => s.features.nativeView);
 
@@ -50,12 +48,7 @@ export function Workspace() {
     return (
       <div className="pane center">
         <div className="center-h flex-center">
-          <IconButton
-            tip={leftCollapsed ? "Show sidebar (⌘B)" : "Hide sidebar (⌘B)"}
-            onClick={toggleLeft}
-          >
-            <Icon name="sidebarL" />
-          </IconButton>
+          <PanelToggle side="left" />
         </div>
         <Placeholder title="Loading…" body="Connecting to Fletch…" />
       </div>

--- a/src/components/ui/README.md
+++ b/src/components/ui/README.md
@@ -36,6 +36,13 @@ Tooltips are CSS-only: pass `tip="…"` (and `tipDown` where supported) — it s
 - Rows, cards, and tabs that happen to be `<button>` for keyboard access are not
   buttons in this sense — they keep their own classes (`.np-item`, `.np-repo`,
   `.hrow`, `.np-dest`, `.dd-item`).
+- **`active` is for states that are off by default.** It paints the button with
+  `var(--accent)`, which only reads as a signal if the unaccented state is the
+  common one — `active={open}` on a popover trigger, not `active={!collapsed}` on
+  a rail that's open by default (that's just a permanently orange button
+  competing with the accents that mean something). When several call sites render
+  the same control, give it a shared component rather than repeating the
+  `IconButton` — see `components/PanelToggle` for the two side rails.
 - Import directly (`import { Badge } from "../ui/Badge"`) or via the barrel
   (`import { Badge } from "../ui"`).
 

--- a/src/workflows/run/RunView/index.tsx
+++ b/src/workflows/run/RunView/index.tsx
@@ -10,7 +10,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { AgentRecord, GateEvidence, WfStepExec } from "../../../api";
 import { Icon } from "../../../components/Icon";
-import { IconButton } from "../../../components/ui/IconButton";
+import { PanelToggle } from "../../../components/PanelToggle";
 import { ChatView } from "../../../components/Workspace/ChatView";
 import { useAppStore } from "../../../store";
 import { resolveAlias } from "../../shared";
@@ -28,8 +28,6 @@ import { useRunDetail } from "./useRunDetail";
 export function RunView({ id }: { id: string }) {
   const customAgents = useAppStore((s) => s.customAgents);
   const modelsByAgent = useAppStore((s) => s.modelsByAgent);
-  const toggleLeft = useAppStore((s) => s.toggleLeft);
-  const leftCollapsed = useAppStore((s) => s.leftCollapsed);
   const selectRun = useAppStore((s) => s.selectRun);
   const focusedStepAgentId = useAppStore((s) => s.focusedStepAgentId);
   const clearFocusedStepAgent = useAppStore((s) => s.clearFocusedStepAgent);
@@ -136,9 +134,7 @@ export function RunView({ id }: { id: string }) {
     return (
       <div className="pane center">
         <div className="center-h">
-          <IconButton tip="Toggle sidebar (⌘B)" onClick={toggleLeft}>
-            <Icon name="sidebarL" />
-          </IconButton>
+          <PanelToggle side="left" />
         </div>
         <div className="empty-msg" style={{ margin: "auto" }}>
           <div className="et">Loading run…</div>
@@ -151,9 +147,7 @@ export function RunView({ id }: { id: string }) {
     return (
       <div className="pane center">
         <div className="center-h">
-          <IconButton tip="Toggle sidebar (⌘B)" onClick={toggleLeft}>
-            <Icon name="sidebarL" />
-          </IconButton>
+          <PanelToggle side="left" />
         </div>
         <div className="empty-msg" style={{ margin: "auto", maxWidth: 320 }}>
           <div className="et">Run not found</div>
@@ -171,12 +165,7 @@ export function RunView({ id }: { id: string }) {
   return (
     <div className="pane center wf-run">
       <div className="center-h">
-        <IconButton
-          tip={leftCollapsed ? "Show sidebar (⌘B)" : "Hide sidebar (⌘B)"}
-          onClick={toggleLeft}
-        >
-          <Icon name="sidebarL" />
-        </IconButton>
+        <PanelToggle side="left" />
         <div className="task">
           <div className="t-name">
             <Icon name="combine" size={14} style={{ color: "var(--accent)", flexShrink: 0 }} />


### PR DESCRIPTION
## The bug

The hide-right-panel toggle was always highlighted orange; the left-panel toggle was always grey.

The cause is a one-line divergence in `WorkspaceHeader` — the right toggle passed `active`, the left one didn't:

```tsx
<IconButton active={!rightCollapsed} … />   // right
<IconButton tip={…} onClick={toggleLeft} /> // left
```

`active` maps to `.btn-i.active { color: var(--accent) }`. Because `rightCollapsed` defaults to `false`, `active` is true in the resting state — so the accent wasn't a signal, just the button's colour, competing with the accents that do carry meaning (status dots, the git CTA).

Compare the healthy use of the same prop: `IssuePicker` does `active={open}` on a popover that's *closed* by default, so the accent appears only while something unusual is true. The right-panel toggle inherited that pattern from a control whose default is the opposite.

**Fix:** drop `active`. Both toggles are now plain grey. The glyph says which rail; the tooltip says what a click will do.

## The DRY part

The two toggles could drift because the same `IconButton` was hand-rolled at **eight call sites across six files**. `active` wasn't the only divergence — `RunView.tsx:139` and `:154` said `"Toggle sidebar (⌘B)"` instead of the show/hide pair used everywhere else.

All eight are now `<PanelToggle side="left" />` / `side="right"`. The new `src/components/PanelToggle.tsx` is store-connected and sits at the `src/components/` top level, following the `AgentIdentityChip` precedent — `ui/` stays presentational-only per its README.

Everything that differs between the rails lives in one `SIDES` table (icon, tooltip noun, shortcut, and the two store selectors), so a future change either lands on both sides or is visibly a one-row exception. The selectors are module constants, hence referentially stable per side, which is what zustand wants.

Also added a Conventions bullet to `src/components/ui/README.md` on when `active` is appropriate — that's the rule that was violated, and `active` is an `IconButton` prop.

## Not touched

Two `toggleLeft`/`toggleRight` consumers are deliberately unchanged, because neither is a toggle button:

- `util/shortcuts.ts` — the ⌘B / ⌘/ key handlers
- `TitleBar/WorkspaceStatus/Capsule.tsx` — opens the panel if collapsed (one-directional)

## Known, out of scope

`active={railOpen}` on the transcript-rail toggle (`WorkspaceHeader.tsx`) has the **identical** problem — `transcriptRailOpen` also defaults to `true`, so that button is accent-at-rest too. It only appears in native view, and it's outside the reported bug, so it's left for a follow-up.

## Verification

- `tsc --noEmit` clean
- `biome check` clean on all 7 touched files (the repo's 1 pre-existing error + ~70 warnings elsewhere were confirmed via `git stash` to predate this branch)
- 736 tests pass across 71 files

Net: **-68 / +22** at the call sites, plus a 58-line shared component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)