### PR TITLE
fix(security): close push-guard bypass via option-named branch (main/master force-overwrite)

### DIFF
--- a/src-tauri/src/git/transport.rs
+++ b/src-tauri/src/git/transport.rs
@@ -45,13 +45,26 @@ pub async fn push_head_to_branch(checkout: &Path, branch: &str) -> Result<()> {
 /// Returns `"up-to-date"` when the remote already had everything (a no-op
 /// push), otherwise `"pushed"`. Lets the UI confirm the outcome instead of
 /// silently doing nothing when there was nothing to send.
+///
+/// `branch` is resolved host-side from the agent-writable `.git/HEAD`, so it is
+/// pushed as a fully-qualified `refs/heads/<branch>:refs/heads/<branch>`
+/// refspec, NEVER as a bare `origin <branch>` positional. As a bare positional
+/// an option-named branch (`--mirror`, `--all`, `--force`) is reparsed by git as
+/// a push *option* — mirror-force-pushing every ref and clobbering protected
+/// `main`/`master`/base. Inside a refspec the string can only ever be a
+/// source/destination branch name, so such a name becomes a harmless same-named
+/// remote branch (or git rejects it) and can never trigger option behaviour or
+/// redirect to a trunk. This primitive is the single choke point behind every
+/// push caller (agent broker, PR broker, Git panel, publish), so the defence
+/// lives here.
 pub async fn push(checkout: &Path, branch: &str, force: bool) -> Result<String> {
     let mut cmd = crate::git_dist::command(checkout);
     cmd.args(["push", "-u"]);
     if force {
         cmd.args(["--force-with-lease", "--force-if-includes"]);
     }
-    cmd.args(["origin", branch]);
+    let refspec = format!("refs/heads/{branch}:refs/heads/{branch}");
+    cmd.args(["origin", refspec.as_str()]);
     // Auth for the https transport. `pre-push` would fire on the host, but
     // hooks are already neutralised at the spawn seam (`git::hardening`).
     for (k, v) in crate::github::git_auth_env() {
@@ -285,6 +298,125 @@ mod tests {
             .await
             .unwrap();
         assert!(out.status.success());
+    }
+
+    async fn git_ok(dir: &Path, args: &[&str]) {
+        let out = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .await
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    async fn rev(dir: &Path, refname: &str) -> String {
+        let out = Command::new("git")
+            .current_dir(dir)
+            .args(["rev-parse", refname])
+            .output()
+            .await
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "rev-parse {refname}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    /// The agent owns its `.git/HEAD`/`refs`, so the `branch` string reaching
+    /// `push` can be an option-looking name (`--mirror`, `--all`). Pushing a
+    /// fully-qualified refspec must make such a name only ever a destination
+    /// branch — never a git-push OPTION that mirror-force-pushes every ref over
+    /// protected `main`. Reproduces the real injection: the ref + HEAD are
+    /// written directly, and `push` is driven with the resolved option string.
+    #[tokio::test]
+    async fn push_refspec_neutralizes_option_named_branch_injection() {
+        let td = tempfile::tempdir().unwrap();
+        let root = td.path();
+        let remote = root.join("remote.git");
+        let attacker = root.join("attacker");
+
+        // Bare remote seeded with a protected `main`.
+        git_ok(root, &["init", "-q", "--bare", "remote.git"]).await;
+        let seed = root.join("seed");
+        std::fs::create_dir_all(&seed).unwrap();
+        git_ok(&seed, &["init", "-q", "-b", "main"]).await;
+        config(&seed, "user.email", "v@example.com").await;
+        config(&seed, "user.name", "V").await;
+        std::fs::write(seed.join("main.txt"), b"legit main\n").unwrap();
+        git_ok(&seed, &["add", "-A"]).await;
+        git_ok(&seed, &["commit", "-q", "-m", "protected main"]).await;
+        git_ok(
+            &seed,
+            &["remote", "add", "origin", remote.to_str().unwrap()],
+        )
+        .await;
+        git_ok(&seed, &["push", "-q", "-u", "origin", "main"]).await;
+        let protected = rev(&remote, "refs/heads/main").await;
+
+        // Attacker checkout: an agent clone that fully controls its own `.git`.
+        git_ok(
+            root,
+            &[
+                "clone",
+                "-q",
+                remote.to_str().unwrap(),
+                attacker.to_str().unwrap(),
+            ],
+        )
+        .await;
+        config(&attacker, "user.email", "a@example.com").await;
+        config(&attacker, "user.name", "A").await;
+        std::fs::write(attacker.join("main.txt"), b"PWNED by attacker\n").unwrap();
+        git_ok(&attacker, &["add", "-A"]).await;
+        git_ok(&attacker, &["commit", "-q", "-m", "attacker payload"]).await;
+        let payload = rev(&attacker, "HEAD").await;
+
+        for opt in ["--mirror", "--all"] {
+            // Plant the option-named branch and point HEAD at it directly —
+            // `.git/HEAD` and `.git/refs` are outside the config deny list.
+            std::fs::write(
+                attacker.join(format!(".git/refs/heads/{opt}")),
+                format!("{payload}\n"),
+            )
+            .unwrap();
+            std::fs::write(
+                attacker.join(".git/HEAD"),
+                format!("ref: refs/heads/{opt}\n"),
+            )
+            .unwrap();
+            // `current_branch` resolves to the injected option string, exactly
+            // as the brokers would hand it to `push`.
+            assert_eq!(
+                current_branch(&attacker).await.unwrap().as_deref(),
+                Some(opt),
+                "the injected option name must be what a broker would push"
+            );
+
+            // Drive the real primitive both ways. Neither may mirror or redirect:
+            // as a refspec `{opt}` is only ever a plain destination branch.
+            push(&attacker, opt, false).await.unwrap();
+            push(&attacker, opt, true).await.unwrap();
+
+            // Protected main is untouched; the attack achieves at most a harmless
+            // same-named remote branch pointing at the attacker's own commit.
+            assert_eq!(
+                rev(&remote, "refs/heads/main").await,
+                protected,
+                "protected main must be untouched by an option-named push of {opt:?}"
+            );
+            assert_eq!(
+                rev(&remote, &format!("refs/heads/{opt}")).await,
+                payload,
+                "{opt:?} must land only as a literal same-named branch"
+            );
+        }
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/rpc/git.rs
+++ b/src-tauri/src/rpc/git.rs
@@ -424,6 +424,9 @@ impl GitDispatcher {
             }
         };
 
+        if let Some(resp) = refuse_option_like_branch(id, "open_pr", &branch) {
+            return (resp, effects);
+        }
         if let Some(why) = self.caps.refuses_branch(&branch, &t.base_branch) {
             return (Response::err(id, why), effects);
         }
@@ -493,6 +496,9 @@ impl GitDispatcher {
             },
         };
 
+        if let Some(resp) = refuse_option_like_branch(id, "git_push", &branch) {
+            return (resp, effects);
+        }
         if let Some(why) = self
             .refuse_unless_publish_approved(
                 "git_push",
@@ -578,6 +584,19 @@ fn approval_repo<'a>(subdir: Option<&'a str>, primary: Option<&str>) -> Option<&
 
 fn arg_branch(args: &Value) -> Option<String> {
     arg_branch_named(args, "branch")
+}
+
+/// Refuse a branch name git could reinterpret as an option (leading `-`). The
+/// resolved branch comes from the agent-writable `.git/HEAD`; the `git::push`
+/// primitive already neutralises injection by pushing a fully-qualified refspec,
+/// but the same string also flows into `pr_create` (the PR head) and event
+/// payloads — so reject it up front here (parity with `git_fetch`) so an agent
+/// that planted an option-named HEAD fails loudly instead of silently creating a
+/// junk remote branch or PR.
+fn refuse_option_like_branch(id: &str, op: &str, branch: &str) -> Option<Response> {
+    branch
+        .starts_with('-')
+        .then(|| Response::err(id, format!("{op}: refusing option-like branch {branch:?}")))
 }
 
 /// Read a boolean flag arg by key, defaulting to `false` when absent or not a
@@ -776,6 +795,49 @@ mod tests {
             effects.is_empty(),
             "a rejected signal must emit nothing, got: {effects:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn git_push_refuses_option_named_head_branch() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        run_git(&repo, &["init", "-q", "-b", "main"]);
+        run_git(&repo, &["config", "user.email", "t@example.com"]);
+        run_git(&repo, &["config", "user.name", "Tester"]);
+        std::fs::write(repo.join("a.txt"), b"x").unwrap();
+        run_git(&repo, &["add", "-A"]);
+        run_git(&repo, &["commit", "-q", "-m", "init"]);
+
+        // Plant an option-named branch and repoint HEAD at it directly, as an
+        // agent with full control of its own `.git` would. `current_branch` then
+        // resolves the injected option string.
+        let head = std::process::Command::new("git")
+            .current_dir(&repo)
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .unwrap();
+        let sha = String::from_utf8_lossy(&head.stdout).trim().to_string();
+        std::fs::write(repo.join(".git/refs/heads/--mirror"), format!("{sha}\n")).unwrap();
+        std::fs::write(repo.join(".git/HEAD"), "ref: refs/heads/--mirror\n").unwrap();
+
+        let disp = dispatcher(&repo);
+        let (resp, fx) = disp.dispatch_inner("p", "git_push", &Value::Null).await;
+        // Refused at the broker (parity with git_fetch) before any git runs, so
+        // the option-named string never reaches a push at all.
+        assert!(
+            !resp.ok,
+            "an option-named HEAD must be refused before any push: {resp:?}"
+        );
+        assert!(
+            resp.error
+                .as_deref()
+                .unwrap_or_default()
+                .contains("option-like"),
+            "error must name the refusal, got: {:?}",
+            resp.error
+        );
+        assert!(fx.is_empty(), "a refused push must emit nothing: {fx:?}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Critical, reproduced sandbox-escape-adjacent vulnerability: an agent could **force-overwrite protected `main`/`master`/the review base** through the host-side push broker, defeating the guarantee that "no agent can push the branch its work is reviewed against, nor main/master."

## Root cause

An agent fully controls its own `.git/HEAD` and `.git/refs/` (neither is in the config-file deny list, under **both** sandbox engines). `git::transport::push` passed the resolved branch name as a bare `origin <branch>` positional:

```
git push -u [--force-with-lease --force-if-includes] origin <branch>
```

By planting `.git/refs/heads/--mirror` + `.git/HEAD = ref: refs/heads/--mirror`, `current_branch` resolves to `--mirror`, the branch cap (a string comparison against trunk names) sees a non-trunk string and passes, and git then reparses `--mirror` as the **push option** — mirror-force-pushing every ref and clobbering `main`. `--all`/`--force` are equally injectable. No config write, no user interaction, works under autopilot.

**Reproduced end-to-end** against real git: protected `main` overwritten to an attacker commit, exit 0.

## Fix (structural)

Push a fully-qualified refspec `refs/heads/<branch>:refs/heads/<branch>` instead of a bare positional. Inside a refspec the string can only ever be a source/destination branch name, so an option-named branch becomes a harmless same-named remote branch (or git rejects it) and can never trigger option behaviour or redirect to a trunk. `git::transport::push` is the single choke point behind all four push callers (agent broker, PR broker, Git-panel push, new-project publish), so the fix closes the hole for each at once; `-u` and `--force-with-lease --force-if-includes` are preserved.

Secondary hardening: `git_push`/`open_pr` now reject an option-like resolved branch name up front (parity with `git_fetch`'s existing guard), so a planted option-named HEAD fails loudly instead of silently creating a junk remote branch or PR head.

## Tests

- `transport::push_refspec_neutralizes_option_named_branch_injection` — plants `--mirror`/`--all` via direct HEAD/refs writes, drives the real `push` both non-force and force, asserts protected `main` is untouched and the option name lands only as a literal same-named branch.
- `git::git_push_refuses_option_named_head_branch` — the broker refuses an injected `--mirror` HEAD before any git runs, emitting nothing.
- Existing `git_push_force_*` / `git_push_detached_*` tests still pass (force-with-lease + upstream behaviour preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)