### PR TITLE
fix(security): stop agent-writable git alternates from bind-mounting arbitrary host paths (Docker)

### DIFF
--- a/src-tauri/src/agent/spawn.rs
+++ b/src-tauri/src/agent/spawn.rs
@@ -29,6 +29,11 @@ pub struct PerTurnSpec {
     /// `SpawnSpec::sandbox_root`). Per-turn agents now run under sandbox-exec
     /// too, so they need it to build the profile.
     pub sandbox_root: PathBuf,
+    /// The authoritative source repos this agent's checkouts were forked from
+    /// (`AgentRecord.repos[].repo_path`). Threaded to the sandbox engine so the
+    /// Docker borrowed-object-store mounts derive from these user-owned paths,
+    /// never from the agent-writable checkout alternates (see `AgentLaunchCtx`).
+    pub source_repos: Vec<PathBuf>,
     /// Session id to resume, if one has been captured already.
     pub session_id: Option<String>,
     /// A custom agent's standing instructions, snapshotted on the session and
@@ -59,6 +64,11 @@ pub struct SpawnSpec<'a> {
     /// contain multiple per-repo checkouts as siblings of `cwd`. Writes
     /// are allowed anywhere under this path.
     pub sandbox_root: PathBuf,
+    /// The authoritative source repos this agent's checkouts were forked from
+    /// (`AgentRecord.repos[].repo_path`). Threaded to the sandbox engine so the
+    /// Docker borrowed-object-store mounts derive from these user-owned paths,
+    /// never from the agent-writable checkout alternates (see `AgentLaunchCtx`).
+    pub source_repos: &'a [PathBuf],
     pub session_id: &'a str,
     /// True if this is the agent's first spawn (no prior conversation
     /// on disk for this session). False if we're respawning to switch
@@ -161,6 +171,7 @@ impl Agent {
             agent_id: spec.agent_id,
             provider: "claude",
             writable_root: &spec.sandbox_root,
+            source_repos: spec.source_repos,
             rpc_dir: &spec.rpc_dir,
             cwd: &spec.cwd,
             home: &home,
@@ -247,6 +258,7 @@ impl Agent {
             agent_id: spec.agent_id,
             provider,
             writable_root: &spec.sandbox_root,
+            source_repos: spec.source_repos,
             rpc_dir: &spec.rpc_dir,
             cwd: &spec.cwd,
             home: &home,
@@ -310,6 +322,7 @@ impl Agent {
             agent_id: spec.agent_id,
             provider: "claude",
             writable_root: &spec.sandbox_root,
+            source_repos: spec.source_repos,
             rpc_dir: &spec.rpc_dir,
             cwd: &spec.cwd,
             home: &home,
@@ -458,6 +471,7 @@ impl Agent {
             agent_id: &spec.agent_id,
             provider,
             writable_root: &spec.sandbox_root,
+            source_repos: &spec.source_repos,
             rpc_dir: &spec.rpc_dir,
             cwd: &spec.cwd,
             home: &home,

--- a/src-tauri/src/sandbox/docker/engine/config_dir.rs
+++ b/src-tauri/src/sandbox/docker/engine/config_dir.rs
@@ -73,25 +73,40 @@ pub(super) fn config_dir_is_default(dir: &Path, home: &Path) -> bool {
     resolve_existing_prefix(dir) == resolve_existing_prefix(&home.join(".claude"))
 }
 
-/// Every object store borrowed via git alternates by any checkout under the
-/// agent's `writable_root` — each an absolute path to mount read-only.
+/// Every object store an agent's `--shared` checkouts borrow via git
+/// alternates — each an absolute path to mount read-only.
 ///
-/// `writable_root` is the agent's parent dir, holding one checkout per tracked
-/// repo at `<root>/<subdir>/`. Each `--shared` clone records its source's
-/// objects in `<subdir>/.git/objects/info/alternates`; a multi-repo agent has
-/// several, so scanning only the primary `cwd` would leave secondary checkouts'
-/// borrowed objects unmounted and break git (log/diff/checkout/commit) there.
+/// SECURITY: the mount set is derived from `source_repos`, Fletch's
+/// authoritative record of each checkout's source repo
+/// (`AgentRecord.repos[].repo_path` — the user's own repos, which the agent
+/// cannot write). It is deliberately NOT derived from the checkout's own
+/// `<subdir>/.git/objects/info/alternates`. Under Docker the whole checkout is
+/// bind-mounted read-write, so a container agent can overwrite that alternates
+/// file to name any absolute host path (`~/.ssh`, `~/.aws`, Fletch's own DB);
+/// were the mount set read from it, a later relaunch that reuses the on-disk
+/// checkout without re-provisioning (`resume_agent` / `switch_view`) would
+/// bind-mount the attacker's path read-only into the container and expose it
+/// over the always-open network — defeating the Docker ConfinedReads /
+/// OpaqueAppData guarantees. Reading only the user-owned source repos keeps
+/// that agent-writable file out of the trust boundary entirely.
 ///
-/// For each checkout the chain is followed transitively: `git clone --shared`
-/// records only the immediate source, so a chained source (B borrowed from A)
-/// leaves the checkout pointing at B while git resolves B→A at runtime — A must
-/// be mounted too or in-container git fails to normalize the alternate. Results
-/// are deduped (repos may share a base). No alternates anywhere (old full-copy
-/// clones, worktrees) → empty, so no extra mount is added — backward
-/// compatible. Reading the files rather than reconstructing paths keeps fresh
-/// spawn, resume, and view-switch uniform.
-pub(super) fn borrowed_object_stores(writable_root: &Path) -> Vec<PathBuf> {
-    /// The alternates listed in `<objects_dir>/info/alternates`, if any.
+/// This reproduces exactly what a `--shared` clone borrows: `git clone
+/// --shared <source>` records `<source>/.git/objects` in the checkout's
+/// alternates, so that store is what must be mounted. A multi-repo agent has
+/// one source per repo, so every entry is walked, not just the primary — else
+/// secondary checkouts' borrowed objects stay unmounted and git breaks
+/// (log/diff/checkout/commit) there.
+///
+/// The chain is followed transitively from each SOURCE (safe — the source is
+/// user-owned): a source may itself borrow (B from A), leaving the checkout
+/// pointing at `<B>/.git/objects` while git resolves B→A at runtime, so A must
+/// be mounted too or in-container git can't normalize the alternate. Results
+/// are deduped (repos may share a base) and cycle-guarded. A missing store is
+/// dropped, not mounted — see below.
+pub(super) fn borrowed_object_stores(source_repos: &[PathBuf]) -> Vec<PathBuf> {
+    /// The alternates listed in `<objects_dir>/info/alternates`, if any. Only
+    /// ever called on stores reached from a trusted source repo, so the file it
+    /// reads is always under user-owned (non-agent-writable) state.
     fn read_alternates(objects_dir: &Path) -> Vec<PathBuf> {
         let Ok(contents) = std::fs::read_to_string(objects_dir.join("info/alternates")) else {
             return Vec::new();
@@ -104,35 +119,31 @@ pub(super) fn borrowed_object_stores(writable_root: &Path) -> Vec<PathBuf> {
             .collect()
     }
 
-    // Seed the chain walk from every checkout's own object store. Sort the
-    // subdirs so the mount order is deterministic (read_dir order isn't).
-    let mut checkouts: Vec<PathBuf> = match std::fs::read_dir(writable_root) {
-        Ok(entries) => entries
-            .filter_map(|e| e.ok())
-            .map(|e| e.path())
-            .filter(|p| p.is_dir())
-            .collect(),
-        Err(_) => Vec::new(),
-    };
-    checkouts.sort();
-
     let mut out: Vec<PathBuf> = Vec::new();
     let mut seen = std::collections::HashSet::new();
-    // BFS over the alternates chains: each checkout's own alternates first (in
-    // file order), then each borrowed store's own. `seen` dedups shared bases
-    // and guards against a cyclic alternates chain.
-    let mut queue: std::collections::VecDeque<PathBuf> = checkouts
+    // Seed the walk from each tracked SOURCE repo's own object store — the exact
+    // store a `--shared` clone of that source records in the checkout. Order
+    // follows the record's repo order (primary first), which is deterministic.
+    let mut queue: std::collections::VecDeque<PathBuf> = source_repos
         .iter()
-        .flat_map(|c| read_alternates(&c.join(".git/objects")))
+        .map(|repo| repo.join(".git/objects"))
         .collect();
     while let Some(store) = queue.pop_front() {
         if !seen.insert(store.clone()) {
             continue;
         }
+        // Follow the source's own alternates chain before emitting the store,
+        // so a chained base (A behind B) is discovered and mounted too.
         for next in read_alternates(&store) {
             queue.push_back(next);
         }
-        out.push(store);
+        // Only mount a store that exists on disk: a bare `-v <path>:<path>:ro`
+        // on a missing source has Docker create it *root-owned*, and a
+        // `--shared` clone can only resolve objects that actually exist, so a
+        // missing store is never one in-container git needs.
+        if store.is_dir() {
+            out.push(store);
+        }
     }
     out
 }

--- a/src-tauri/src/sandbox/docker/engine/mod.rs
+++ b/src-tauri/src/sandbox/docker/engine/mod.rs
@@ -210,13 +210,20 @@ impl SandboxEngine for DockerEngine {
         let name = container_name(ctx.agent_id);
 
         // Object stores every checkout under the agent's writable root borrows
-        // via git alternates (a --shared clone). Scanned across all tracked
-        // repos, not just the primary `cwd`: a multi-repo agent has one shared
-        // clone per repo, each borrowing its own source's objects. Mounted
-        // read-only so in-container git reads borrowed history; empty for old
-        // full-copy clones or worktrees (no mount). Docker forces Clone-mode
+        // via git alternates (a --shared clone). Derived from `ctx.source_repos`
+        // — Fletch's authoritative record of each checkout's user-owned source
+        // repo — NOT from the checkout's own `.git/objects/info/alternates`.
+        // That alternates file lives inside the agent's read-write checkout, so
+        // a container agent can overwrite it to name any host path and, on a
+        // reused-checkout relaunch (resume / switch_view), have that path
+        // bind-mounted read-only into its container — defeating ConfinedReads.
+        // Deriving from the source repos (which the agent cannot write) mounts
+        // exactly what a `--shared` clone borrows without trusting agent state.
+        // Spans every tracked repo, not just the primary: a multi-repo agent
+        // has one shared clone per repo. Mounted read-only; empty when a source
+        // is missing or has no object store. Docker forces Clone-mode
         // workspaces for every provider, so this is provider-agnostic.
-        let borrowed_object_stores = borrowed_object_stores(ctx.writable_root);
+        let borrowed_object_stores = borrowed_object_stores(ctx.source_repos);
 
         // Env set on the docker CLI process; forwarded into the container by the
         // bare `-e NAME` flags `run_args` emits (values never touch argv —

--- a/src-tauri/src/sandbox/docker/engine/tests.rs
+++ b/src-tauri/src/sandbox/docker/engine/tests.rs
@@ -662,78 +662,105 @@ fn argv_mounts_every_chained_alternate_read_only() {
 }
 
 #[test]
-fn borrowed_object_stores_reads_alternates_lines() {
-    // Layout: writable_root/<subdir>/.git/objects/info/alternates.
+fn borrowed_object_stores_mounts_the_source_object_store() {
+    // The mount set is derived from the authoritative source repo, not the
+    // agent-writable checkout: a `--shared` clone of `<src>` borrows
+    // `<src>/.git/objects`, so that store — and only that — is mounted.
     let td = tempfile::tempdir().unwrap();
-    let root = td.path();
-    let info = root.join("repo/.git/objects/info");
-    std::fs::create_dir_all(&info).unwrap();
+    let src = td.path().join("src");
+    std::fs::create_dir_all(src.join(".git/objects/info")).unwrap();
 
-    // Absent alternates → nothing to mount (worktree / full-copy clone).
-    assert!(borrowed_object_stores(root).is_empty());
+    // No tracked repos → nothing to mount.
+    assert!(borrowed_object_stores(&[]).is_empty());
 
-    std::fs::write(
-        info.join("alternates"),
-        "/src/a/.git/objects\n\n  /src/b/objects  \n",
-    )
-    .unwrap();
     assert_eq!(
-        borrowed_object_stores(root),
-        vec![
-            PathBuf::from("/src/a/.git/objects"),
-            PathBuf::from("/src/b/objects"),
-        ],
+        borrowed_object_stores(std::slice::from_ref(&src)),
+        vec![src.join(".git/objects")],
     );
 }
 
 #[test]
-fn borrowed_object_stores_follows_chained_alternates() {
-    // Model checkout --shared→ B --shared→ A: the checkout points only at
-    // B; B points at A. Both B and A must be discovered so both get
-    // mounted, or in-container git can't reach A's objects.
+fn borrowed_object_stores_follows_source_alternate_chain() {
+    // Model source B --shared→ A: the tracked source is B, whose own object
+    // store borrows A via alternates. Both B and A must be mounted, or
+    // in-container git can't normalize B→A. The chain is walked from the
+    // user-owned SOURCE (B), never from the agent's checkout.
     let td = tempfile::tempdir().unwrap();
     let a = td.path().join("A/.git/objects");
     let b = td.path().join("B/.git/objects");
-    // The checkout lives under the writable root as a subdir.
-    let checkout = td.path().join("root/repo/.git/objects");
-    for dir in [&a, &b, &checkout] {
+    for dir in [&a, &b] {
         std::fs::create_dir_all(dir.join("info")).unwrap();
     }
-    std::fs::write(
-        checkout.join("info/alternates"),
-        format!("{}\n", b.display()),
-    )
-    .unwrap();
     std::fs::write(b.join("info/alternates"), format!("{}\n", a.display())).unwrap();
 
     assert_eq!(
-        borrowed_object_stores(&td.path().join("root")),
+        borrowed_object_stores(&[td.path().join("B")]),
         vec![b, a],
-        "chain must resolve checkout→B→A, mounting both borrowed stores"
+        "chain must resolve source B→A, mounting both borrowed stores"
     );
 }
 
 #[test]
-fn borrowed_object_stores_scans_every_repo_checkout() {
-    // A multi-repo agent: two shared-clone checkouts under one writable
-    // root, each borrowing a different source. Both borrowed stores must be
-    // discovered — scanning only the primary would strand the secondary.
+fn borrowed_object_stores_covers_every_tracked_source() {
+    // A multi-repo agent: two tracked source repos. Each source's object
+    // store must be mounted — covering only the primary would strand the
+    // secondary checkout's borrowed objects.
     let td = tempfile::tempdir().unwrap();
-    let root = td.path().join("agent");
-    let primary = root.join("app/.git/objects/info");
-    let secondary = root.join("lib/.git/objects/info");
-    std::fs::create_dir_all(&primary).unwrap();
-    std::fs::create_dir_all(&secondary).unwrap();
-    std::fs::write(primary.join("alternates"), "/src/app/.git/objects\n").unwrap();
-    std::fs::write(secondary.join("alternates"), "/src/lib/.git/objects\n").unwrap();
+    let app = td.path().join("src/app");
+    let lib = td.path().join("src/lib");
+    std::fs::create_dir_all(app.join(".git/objects/info")).unwrap();
+    std::fs::create_dir_all(lib.join(".git/objects/info")).unwrap();
 
-    // Sorted by subdir name: `app` before `lib`.
+    // Order follows the record's repo order (primary first).
     assert_eq!(
-        borrowed_object_stores(&root),
-        vec![
-            PathBuf::from("/src/app/.git/objects"),
-            PathBuf::from("/src/lib/.git/objects"),
-        ],
+        borrowed_object_stores(&[app.clone(), lib.clone()]),
+        vec![app.join(".git/objects"), lib.join(".git/objects")],
+    );
+}
+
+#[test]
+fn borrowed_object_stores_ignores_agent_writable_checkout_alternates() {
+    // SECURITY REGRESSION. Under Docker the agent's checkout is bind-mounted
+    // read-write, so a container agent can overwrite
+    // `<checkout>/.git/objects/info/alternates` to name a sensitive host path
+    // (here a temp dir standing in for ~/.ssh). If the mount set were read from
+    // that agent-writable file, a reused-checkout relaunch (resume /
+    // switch_view) would bind-mount the attacker's path read-only and leak it.
+    // The mount set is derived from the authoritative SOURCE repo instead, so
+    // the poisoned alternates is never consulted: the real source object store
+    // is mounted and the sensitive path is not.
+    let td = tempfile::tempdir().unwrap();
+
+    // The legitimate, user-owned source the checkout was forked from.
+    let src = td.path().join("src");
+    std::fs::create_dir_all(src.join(".git/objects/info")).unwrap();
+
+    // A sensitive out-of-tree dir the attacker wants mounted. It exists on
+    // disk, so the only thing keeping it out is that we never read the
+    // checkout's alternates.
+    let secret = td.path().join("dot-ssh");
+    std::fs::create_dir_all(&secret).unwrap();
+
+    // The agent-writable checkout, poisoned to borrow the secret dir.
+    let checkout = td.path().join("agent/repo/.git/objects");
+    std::fs::create_dir_all(checkout.join("info")).unwrap();
+    std::fs::write(
+        checkout.join("info/alternates"),
+        format!("{}\n", secret.display()),
+    )
+    .unwrap();
+
+    // Compute from the trusted source list only (what the supervisor threads
+    // from `record.repos`). The poisoned checkout is deliberately NOT passed.
+    let stores = borrowed_object_stores(std::slice::from_ref(&src));
+    assert_eq!(
+        stores,
+        vec![src.join(".git/objects")],
+        "only the user-owned source object store is mounted"
+    );
+    assert!(
+        !stores.contains(&secret),
+        "an agent-writable checkout alternates must never reach the mount set"
     );
 }
 

--- a/src-tauri/src/sandbox/engine.rs
+++ b/src-tauri/src/sandbox/engine.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::error::Result;
@@ -45,6 +45,18 @@ pub struct AgentLaunchCtx<'a> {
     /// [`sandbox::docker::DockerProvider`]).
     pub provider: &'a str,
     pub writable_root: &'a Path,
+    /// The authoritative source repos each checkout under `writable_root` was
+    /// forked from — `AgentRecord.repos[].repo_path`, the user's own repos,
+    /// which the agent cannot write. The Docker engine derives its borrowed git
+    /// object-store mounts from THESE user-owned paths, never from the checkout's
+    /// own `.git/objects/info/alternates`: that file lives inside the container's
+    /// read-write checkout, so a container agent could overwrite it to point a
+    /// read-only bind mount at an arbitrary host path (`~/.ssh`, `~/.aws`, …) on
+    /// the next reused-checkout relaunch (resume / switch_view). Deriving the
+    /// mount set from the trusted source repos keeps that agent-writable file out
+    /// of the trust boundary. Seatbelt ignores it: it shares the host filesystem,
+    /// so borrowed objects need no separate mount/grant here.
+    pub source_repos: &'a [PathBuf],
     pub rpc_dir: &'a Path,
     pub cwd: &'a Path,
     pub home: &'a Path,

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -1438,6 +1438,8 @@ mod tests {
             agent_id: "a1",
             provider: "claude",
             writable_root: &root,
+            // Seatbelt ignores source_repos (host-shared filesystem, no mounts).
+            source_repos: &[],
             rpc_dir: &rpc,
             cwd: &root,
             home: &home,

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -974,6 +974,14 @@ impl Supervisor {
         // path writes whatever config file the provider reads and adds the
         // argv/env pointing at it. See `agent_profile`.
 
+        // The authoritative source repos each checkout was forked from — the
+        // user's own repos, which the agent cannot write. Threaded into the
+        // sandbox engine so the Docker borrowed-object-store mounts derive from
+        // these (never from the agent-writable checkout alternates a container
+        // agent could rewrite to smuggle an arbitrary read-only host mount into
+        // a reused-checkout relaunch). See `sandbox::engine::AgentLaunchCtx`.
+        let source_repos: Vec<PathBuf> = record.repos.iter().map(|r| r.repo_path.clone()).collect();
+
         if per_turn {
             match record.view {
                 // Native view: launch the agent's interactive TUI in a PTY,
@@ -988,6 +996,7 @@ impl Supervisor {
                         agent_id: &agent_id_str,
                         cwd,
                         sandbox_root,
+                        source_repos: &source_repos,
                         session_id,
                         // Per-turn native always resumes (the agent built its
                         // session in the Custom view first).
@@ -1023,6 +1032,7 @@ impl Supervisor {
                         agent_id: agent_id_str.clone(),
                         cwd,
                         sandbox_root,
+                        source_repos: source_repos.clone(),
                         session_id,
                         // model/effort aren't spawn-time for per-turn agents:
                         // the supervisor resolves them from the record and passes
@@ -1047,6 +1057,7 @@ impl Supervisor {
                 agent_id: &agent_id_str,
                 cwd,
                 sandbox_root,
+                source_repos: &source_repos,
                 session_id,
                 fresh: effective_fresh,
                 // Claude's session-level effort, persisted on the record so it


### PR DESCRIPTION
## Summary

Critical Docker-engine sandbox escape: an agent could cause **any host path** (`~/.ssh`, `~/.aws`, `~/.config/gh/hosts.yml`, Fletch's own DB) to be bind-mounted read-only into its container and read as root, then exfiltrated over the always-open network — defeating the Docker `ConfinedReads` ("Cannot read the rest of your disk") and `OpaqueAppData` guarantees.

## Root cause

On every container launch, `borrowed_object_stores` read each checkout's `.git/objects/info/alternates` and emitted every listed path verbatim as `-v <path>:<path>:ro`. That file lives **inside the agent's read-write checkout** (under Docker the whole checkout is bind-mounted RW), so an agent overwrites it with an attacker-chosen absolute path; a subsequent relaunch that reuses the on-disk checkout without re-provisioning (`resume_agent` / `switch_view`) then mounts that path into the container. No validation of any kind.

## Fix (structural)

Redraw the trust boundary: derive the mount set from Fletch's **authoritative** record of each checkout's source repo (`AgentRecord.repos[].repo_path` — the user's own repos, which the agent cannot write), never from the agent-writable checkout alternates.

- `borrowed_object_stores(source_repos)` now seeds the walk from each source's `.git/objects` (exactly what a `git clone --shared` records) and follows only the **source's own** transitive alternate chain (safe — the source is user-owned). Results are deduped, cycle-guarded, and a store that doesn't exist on disk is dropped rather than mounted (avoids Docker creating a root-owned dir).
- `AgentLaunchCtx` gains `source_repos`, threaded from the supervisor (which holds the `AgentRecord`) through the spawn specs. Seatbelt ignores it (host-shared filesystem — no mounts).
- The checkout's own agent-writable alternates file is never read.

Behaviour for a real `--shared` clone is identical (same borrowed stores, multi-repo and chained-alternate correctness preserved).

## Tests

- `borrowed_object_stores_ignores_agent_writable_checkout_alternates` — poisons a checkout's alternates to point at a sensitive out-of-tree dir (stand-in for `~/.ssh`) and asserts it is **never** mounted, while the user-owned source object store still is.
- Existing pinning tests rewritten to the source-derived contract (`_mounts_the_source_object_store`, `_follows_source_alternate_chain`, `_covers_every_tracked_source`); full sandbox/docker/seatbelt suite (130 tests) passes; `cargo check --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)