### PR TITLE
fix(provision): point a workspace clone's origin/HEAD at the real default branch

### DIFF
--- a/src-tauri/src/sandbox/provision.rs
+++ b/src-tauri/src/sandbox/provision.rs
@@ -430,8 +430,10 @@ async fn clone_base(spec: &CheckoutSpec<'_>, shared: bool) -> Result<()> {
 /// Run the shared post-clone fixups, then the mode-specific checkout step.
 /// The origin rewrite must come first: the branch-restore checkout may need
 /// to `fetch origin`, which has to hit the real remote, not the source path.
-/// Any failure tears the half-built clone down so nothing orphaned blocks a
-/// retry (a clone is self-contained, so `rm -rf` is always safe here).
+/// The `origin/HEAD` rewrite must come *last*, for the mirror-image reason —
+/// see [`rewrite_origin_head`]. Any failure tears the half-built clone down so
+/// nothing orphaned blocks a retry (a clone is self-contained, so `rm -rf` is
+/// always safe here).
 async fn finish_clone<F, Fut, T>(spec: &CheckoutSpec<'_>, checkout: F) -> Result<T>
 where
     F: FnOnce(std::path::PathBuf) -> Fut,
@@ -441,7 +443,9 @@ where
         rewrite_origin(spec).await?;
         seed_identity(spec).await?;
         install_delegation_hooks(spec.dest).await?;
-        checkout(spec.dest.to_path_buf()).await
+        let checked_out = checkout(spec.dest.to_path_buf()).await?;
+        rewrite_origin_head(spec).await;
+        Ok(checked_out)
     }
     .await;
     if result.is_err() {
@@ -478,7 +482,6 @@ async fn rewrite_origin(spec: &CheckoutSpec<'_>) -> Result<()> {
         "remote set-url origin",
     )
     .await?;
-    rewrite_origin_head(spec).await;
     Ok(())
 }
 
@@ -487,7 +490,7 @@ async fn rewrite_origin(spec: &CheckoutSpec<'_>) -> Result<()> {
 ///
 /// `git clone <local path>` writes that symref from the source repo's **HEAD**
 /// — the branch the user happens to have checked out — not from the source's
-/// own `origin/HEAD`. Rewriting the URL above leaves it behind, so a workspace
+/// own `origin/HEAD`. Rewriting the origin URL leaves it behind, so a workspace
 /// cloned while the user sat on `docs/some-branch` reports that branch as the
 /// repo default forever after. The spawn path never sees this (it resolves the
 /// base against the *source*, where the symref is right), but everything that
@@ -495,16 +498,29 @@ async fn rewrite_origin(spec: &CheckoutSpec<'_>) -> Result<()> {
 /// pr create`'s implicit base, and [`git::default_branch`] on any checkout
 /// path. That is the whole gap this closes.
 ///
-/// Best-effort by design, and the failure mode is deliberate. `set-head` with
-/// an explicit branch is purely local (no network, so nothing added to the
-/// spawn budget) but it does require `refs/remotes/origin/<default>` to exist
-/// in the clone — which it won't when the source has no local head for its own
-/// default branch. Git then refuses and leaves the inherited value untouched,
-/// so we delete the symref instead: with none, [`git::default_branch`] falls
-/// through to the conventional names and finally to `"main"`. A merely
-/// conventional guess is recoverable; confidently naming the user's
-/// in-progress branch as the repo default is the bug.
+/// Runs **after** the checkout step, and that ordering is load-bearing.
+/// `set-head` with an explicit branch is purely local (no network, so nothing
+/// added to the spawn budget) but it requires `refs/remotes/origin/<default>`
+/// to exist in the clone, and the clone only inherits refs for branches the
+/// source keeps a *local* head for. A source that tracks `develop` without
+/// checking it out gives the clone no `origin/develop` — until the checkout
+/// step's base fetch creates it. Running first would mean resolving the
+/// symref against refs that do not exist yet and then never revisiting it.
+///
+/// Best-effort, and the remaining failure mode is deliberate. When the ref is
+/// still absent (the base fetch was for some other branch, or failed offline),
+/// git refuses and leaves the inherited value untouched — so drop the symref
+/// instead: with none, [`git::default_branch`] falls through to the
+/// conventional names and finally to `"main"`. A merely conventional guess is
+/// recoverable; confidently naming the user's in-progress branch as the repo
+/// default is the bug.
 async fn rewrite_origin_head(spec: &CheckoutSpec<'_>) {
+    // `rewrite_origin` *removes* the remote when the source has none, taking
+    // every `refs/remotes/origin/*` with it — including the bad symref. There
+    // is nothing left to correct, and no remote to correct it against.
+    if !has_origin(spec.dest).await {
+        return;
+    }
     // Resolved against the source, whose `origin/HEAD` is a genuine record of
     // the remote's default; the clone's is the value we're here to correct.
     let default = git::default_branch(spec.source_repo).await;
@@ -1050,6 +1066,57 @@ mod tests {
 
         assert_eq!(origin_head(&dest).as_deref(), Some("origin/main"));
         assert_eq!(git::default_branch(&dest).await, "main");
+    }
+
+    #[tokio::test]
+    async fn clone_origin_head_survives_a_default_branch_only_the_base_fetch_supplies() {
+        // Ordering regression. The clone only inherits `origin/<x>` for
+        // branches the source keeps a *local* head for, so a source that
+        // tracks `develop` without checking it out gives the clone no
+        // `origin/develop` — the checkout step's base fetch creates it. With
+        // the symref rewrite running before that fetch, `set-head` failed, the
+        // inherited value was dropped, and nothing re-pointed it afterwards:
+        // `default_branch` then fell through to the conventional names and
+        // answered "main" for a repo whose default is `develop`.
+        let td = tempfile::tempdir().unwrap();
+        let upstream = td.path().join("upstream");
+        std::fs::create_dir_all(&upstream).unwrap();
+        run(&upstream, &["init", "-q", "-b", "develop"]);
+        run(&upstream, &["config", "user.email", "t@example.com"]);
+        run(&upstream, &["config", "user.name", "Tester"]);
+        std::fs::write(upstream.join("a.txt"), b"one").unwrap();
+        run(&upstream, &["add", "-A"]);
+        run(&upstream, &["commit", "-q", "-m", "first"]);
+        let develop_tip = run(&upstream, &["rev-parse", "HEAD"]);
+
+        let source = td.path().join("source");
+        run(
+            td.path(),
+            &["clone", "-q", upstream.to_str().unwrap(), "source"],
+        );
+        run(&source, &["config", "user.email", "t@example.com"]);
+        run(&source, &["config", "user.name", "Tester"]);
+        run(&source, &["checkout", "-q", "-b", "feat/x"]);
+        std::fs::write(source.join("s.txt"), b"side").unwrap();
+        run(&source, &["add", "-A"]);
+        run(&source, &["commit", "-q", "-m", "side work"]);
+        // No local head for the default branch: the clone will not inherit
+        // `refs/remotes/origin/develop`.
+        run(&source, &["branch", "-q", "-D", "develop"]);
+        assert_eq!(origin_head(&source).as_deref(), Some("origin/develop"));
+
+        let dest = td.path().join("clone");
+        let spec = CheckoutSpec {
+            source_repo: &source,
+            base_ref: &develop_tip,
+            dest: &dest,
+        };
+        provision_at_remote_base(&spec, "develop", true)
+            .await
+            .unwrap();
+
+        assert_eq!(origin_head(&dest).as_deref(), Some("origin/develop"));
+        assert_eq!(git::default_branch(&dest).await, "develop");
     }
 
     #[tokio::test]

--- a/src-tauri/src/sandbox/provision.rs
+++ b/src-tauri/src/sandbox/provision.rs
@@ -478,7 +478,57 @@ async fn rewrite_origin(spec: &CheckoutSpec<'_>) -> Result<()> {
         "remote set-url origin",
     )
     .await?;
+    rewrite_origin_head(spec).await;
     Ok(())
+}
+
+/// Repoint the clone's `refs/remotes/origin/HEAD` at the source's *real*
+/// default branch.
+///
+/// `git clone <local path>` writes that symref from the source repo's **HEAD**
+/// — the branch the user happens to have checked out — not from the source's
+/// own `origin/HEAD`. Rewriting the URL above leaves it behind, so a workspace
+/// cloned while the user sat on `docs/some-branch` reports that branch as the
+/// repo default forever after. The spawn path never sees this (it resolves the
+/// base against the *source*, where the symref is right), but everything that
+/// re-derives a default from inside the workspace does: agent worktrees, `gh
+/// pr create`'s implicit base, and [`git::default_branch`] on any checkout
+/// path. That is the whole gap this closes.
+///
+/// Best-effort by design, and the failure mode is deliberate. `set-head` with
+/// an explicit branch is purely local (no network, so nothing added to the
+/// spawn budget) but it does require `refs/remotes/origin/<default>` to exist
+/// in the clone — which it won't when the source has no local head for its own
+/// default branch. Git then refuses and leaves the inherited value untouched,
+/// so we delete the symref instead: with none, [`git::default_branch`] falls
+/// through to the conventional names and finally to `"main"`. A merely
+/// conventional guess is recoverable; confidently naming the user's
+/// in-progress branch as the repo default is the bug.
+async fn rewrite_origin_head(spec: &CheckoutSpec<'_>) {
+    // Resolved against the source, whose `origin/HEAD` is a genuine record of
+    // the remote's default; the clone's is the value we're here to correct.
+    let default = git::default_branch(spec.source_repo).await;
+    if git::run_git(
+        spec.dest,
+        &["remote", "set-head", "origin", &default],
+        "remote set-head origin",
+    )
+    .await
+    .is_ok()
+    {
+        return;
+    }
+    tracing::info!(
+        source = %spec.source_repo.display(),
+        default = %default,
+        "clone has no origin/<default> ref; dropping the inherited origin/HEAD"
+    );
+    let _ = git::run_git(
+        spec.dest,
+        &["remote", "set-head", "origin", "--delete"],
+        "remote set-head origin --delete",
+    )
+    .await;
 }
 
 /// Install Fletch's delegation-signal git hooks into the clone's `.git/hooks`.
@@ -958,6 +1008,78 @@ mod tests {
             run(&dest, &["remote", "get-url", "origin"]),
             "https://github.com/acme/widget.git"
         );
+    }
+
+    /// `refs/remotes/origin/HEAD` in the clone, or `None` when there is no
+    /// symref — the two states the origin/HEAD rewrite chooses between.
+    fn origin_head(repo: &Path) -> Option<String> {
+        let out = std::process::Command::new("git")
+            .current_dir(repo)
+            .args(["symbolic-ref", "--short", "-q", "refs/remotes/origin/HEAD"])
+            .output()
+            .unwrap();
+        out.status
+            .success()
+            .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+    }
+
+    #[tokio::test]
+    async fn clone_origin_head_is_the_sources_default_not_its_checked_out_branch() {
+        // The bug this guards: `git clone <local path>` writes the clone's
+        // `refs/remotes/origin/HEAD` from the source's *HEAD*, so a workspace
+        // provisioned while the user sat on a feature branch reported that
+        // branch as the repo default to everything running inside the
+        // workspace — agent worktrees, `gh pr create`, `default_branch` on a
+        // checkout path — even though the spawn itself forked from `main`.
+        let td = tempfile::tempdir().unwrap();
+        let (source, stale, _fresh) = fixture_with_stale_source(td.path());
+        run(&source, &["checkout", "-q", "-b", "docs/side"]);
+        std::fs::write(source.join("s.txt"), b"side").unwrap();
+        run(&source, &["add", "-A"]);
+        run(&source, &["commit", "-q", "-m", "side work"]);
+        // The source is the one with an honest record of the remote default.
+        assert_eq!(origin_head(&source).as_deref(), Some("origin/main"));
+
+        let dest = td.path().join("clone");
+        let spec = CheckoutSpec {
+            source_repo: &source,
+            base_ref: &stale,
+            dest: &dest,
+        };
+        provision(&spec).await.unwrap();
+
+        assert_eq!(origin_head(&dest).as_deref(), Some("origin/main"));
+        assert_eq!(git::default_branch(&dest).await, "main");
+    }
+
+    #[tokio::test]
+    async fn clone_drops_origin_head_when_the_default_branch_has_no_ref() {
+        // `set-head` needs `refs/remotes/origin/<default>` to exist in the
+        // clone, and it won't when the source kept no local head for its own
+        // default branch. Leaving git's inherited value would name the user's
+        // feature branch as the repo default; dropping the symref instead lets
+        // `default_branch` fall through to the conventional names.
+        let td = tempfile::tempdir().unwrap();
+        let (source, _stale, _fresh) = fixture_with_stale_source(td.path());
+        run(&source, &["checkout", "-q", "-b", "docs/side"]);
+        std::fs::write(source.join("s.txt"), b"side").unwrap();
+        run(&source, &["add", "-A"]);
+        run(&source, &["commit", "-q", "-m", "side work"]);
+        run(&source, &["branch", "-q", "-D", "main"]);
+        let side_tip = run(&source, &["rev-parse", "HEAD"]);
+
+        let dest = td.path().join("clone");
+        let spec = CheckoutSpec {
+            source_repo: &source,
+            base_ref: &side_tip,
+            dest: &dest,
+        };
+        provision(&spec).await.unwrap();
+
+        assert_eq!(origin_head(&dest), None);
+        // Not `docs/side`: a conventional guess beats confidently naming the
+        // branch the user happened to have open.
+        assert_eq!(git::default_branch(&dest).await, "main");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## The bug

`git clone <local path>` writes the clone's `refs/remotes/origin/HEAD` from the **source repo's HEAD** — whatever branch the user has checked out — not from the source's own `origin/HEAD`. `rewrite_origin` repointed the clone's origin URL at the real remote but left that symref behind, so a workspace provisioned while the source sat on a feature branch reported that branch as the repo default for the rest of its life.

The spawn path never saw this, because it resolves the base against the *source*, where the symref is correct. Everything that re-derives a default from **inside** the workspace did:

- agent worktrees, which were being created at the stale branch
- `gh pr create`'s implicit base
- `git::default_branch` on any checkout path

Observed in a live workspace: HEAD correctly detached at the real `main` tip, while `refs/remotes/origin/HEAD` read `origin/docs/readme-code-index` — a branch 149 commits divergent. Agents spun up there did verified work on top of stale code.

## The fix

Resolve the default against the source (whose `origin/HEAD` is a genuine record of the remote) and write it into the clone with `git remote set-head origin <branch>`. The explicit-branch form is purely local — no network round-trip, nothing added to the 15s spawn watchdog budget.

This goes inside `rewrite_origin` rather than beside it. That function already exists to make the clone's `origin` look like the real remote instead of the local source path; correcting the symref is the half of that job that was missing.

### Edge case

`set-head` requires `refs/remotes/origin/<default>` to exist in the clone, which it won't when the source keeps no local head for its own default branch. Git's behaviour here was checked rather than assumed: it exits 1 and leaves the existing value **untouched**, so there is no dangling-symref risk — but silently keeping the inherited value is exactly the bug. On failure the symref is dropped instead, letting `git::default_branch` fall through to its conventional-name probe. A conventional guess is recoverable; confidently naming the user's in-progress branch as the repo default is not.

## Tests

Two tests, both confirmed to fail with the call disabled:

```
clone_origin_head_is_the_sources_default_not_its_checked_out_branch
  left: Some("origin/docs/side")   right: Some("origin/main")

clone_drops_origin_head_when_the_default_branch_has_no_ref
  left: Some("origin/docs/side")   right: None
```

The first reproduces the production symptom in a fixture. Full suite: 1124 passed. clippy and fmt clean.

## Scope

All four clone-based provisioning paths route through `finish_clone` → `rewrite_origin`, so coverage is complete. Worktree-mode workspaces need no change: a linked worktree shares the source's ref db and already reads the correct symref.

## Known follow-up (not in this PR)

A clone's `refs/remotes/origin/*` entries are copies of the source's **local** branch heads, which the origin rewrite then relabels as if they came from GitHub. Only the base branch gets corrected, and only when online. So a workspace can have `HEAD` at the real remote tip while its own `origin/main` sits 149 commits behind — the same checkout disagreeing with itself. The likely fix is to copy the source's real remote-tracking refs into the clone (one local ref-only fetch, prototyped and working in both `--shared` and `--no-hardlinks` modes), but that is a separate change.