### PR TITLE
feat(project): add a Roadmap tab to the project page

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -37,6 +37,9 @@
 @import "./styles/shared/terminal.css";
 @import "./components/History/History.css";
 @import "./components/ProjectScreen/ProjectScreen.css";
+/* After ProjectScreen.css (it composes on the page shell) and after
+   Chat.css/Composer.css, whose message + composer skins it reuses. */
+@import "./components/ProjectScreen/Roadmap/Roadmap.css";
 @import "./components/Stats/Stats.css";
 @import "./components/RightPanel/FilePanel/FilePanel.css";
 /* Ahead of SettingsScreen.css (its former home) and of CustomAgents.css /

--- a/src/components/ProjectScreen/ProjectHeader.tsx
+++ b/src/components/ProjectScreen/ProjectHeader.tsx
@@ -1,10 +1,9 @@
 import { Icon, type IconName } from "@/components/Icon";
 import { CountUp, Stat } from "@/components/Stats";
+import type { ProjectScreenTab } from "@/store/ui";
 import type { RoadmapState } from "./Roadmap";
 
-export type ProjectTab = "roadmap" | "settings";
-
-const TABS: { id: ProjectTab; label: string; icon: IconName }[] = [
+const TABS: { id: ProjectScreenTab; label: string; icon: IconName }[] = [
   { id: "roadmap", label: "Roadmap", icon: "map" },
   { id: "settings", label: "Settings", icon: "settings" },
 ];
@@ -23,8 +22,8 @@ export function ProjectHeader({
   /** Repo path, or the repo count for a multi-repo project. */
   subtitle: string;
   roadmap: RoadmapState;
-  tab: ProjectTab;
-  onTab: (tab: ProjectTab) => void;
+  tab: ProjectScreenTab;
+  onTab: (tab: ProjectScreenTab) => void;
   onClose: () => void;
 }) {
   const { counts, shipped } = roadmap;

--- a/src/components/ProjectScreen/ProjectHeader.tsx
+++ b/src/components/ProjectScreen/ProjectHeader.tsx
@@ -1,0 +1,79 @@
+import { Icon, type IconName } from "@/components/Icon";
+import { CountUp, Stat } from "@/components/Stats";
+import type { RoadmapState } from "./Roadmap";
+
+export type ProjectTab = "roadmap" | "settings";
+
+const TABS: { id: ProjectTab; label: string; icon: IconName }[] = [
+  { id: "roadmap", label: "Roadmap", icon: "map" },
+  { id: "settings", label: "Settings", icon: "settings" },
+];
+
+/** The project page header: the back button, the project's identity, the board
+ *  counts right-aligned, and the tab row sitting on the bottom rule. */
+export function ProjectHeader({
+  name,
+  subtitle,
+  roadmap,
+  tab,
+  onTab,
+  onClose,
+}: {
+  name: string;
+  /** Repo path, or the repo count for a multi-repo project. */
+  subtitle: string;
+  roadmap: RoadmapState;
+  tab: ProjectTab;
+  onTab: (tab: ProjectTab) => void;
+  onClose: () => void;
+}) {
+  const { counts, shipped } = roadmap;
+
+  return (
+    <div className="ps-head">
+      <div className="ps-head-row">
+        <button type="button" className="ps-back flex-center text-base" onClick={onClose}>
+          <Icon name="chevL" size={13} />
+          <span>Back to app</span>
+        </button>
+        <div className="ps-id">
+          <div className="ps-title text-lg truncate">{name}</div>
+          <div className="ps-path mono text-xs truncate">{subtitle}</div>
+        </div>
+        <div className="stat-row ps-stats text-sm">
+          <Stat label="in flight">
+            <CountUp value={counts.now} />
+          </Stat>
+          <span className="stat-sep" />
+          <Stat label="next">
+            <CountUp value={counts.next} />
+          </Stat>
+          <span className="stat-sep" />
+          <Stat label="later">
+            <CountUp value={counts.later} />
+          </Stat>
+          <span className="stat-sep" />
+          <Stat label="shipped">
+            <span className="ps-stat-shipped">
+              <CountUp value={shipped} />
+            </span>
+          </Stat>
+        </div>
+      </div>
+
+      <nav className="ps-tabs">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            className={`ps-tab iflex-center text-sm ${tab === t.id ? "active" : ""}`}
+            onClick={() => onTab(t.id)}
+          >
+            <Icon name={t.icon} size={13} />
+            {t.label}
+          </button>
+        ))}
+      </nav>
+    </div>
+  );
+}

--- a/src/components/ProjectScreen/ProjectScreen.css
+++ b/src/components/ProjectScreen/ProjectScreen.css
@@ -11,14 +11,18 @@
   background: var(--bg-1);
 }
 
-/* header — back + project identity */
+/* header — back + project identity + board counts, over the tab row. The tabs
+ * sit ON the bottom rule (see .ps-tab's negative margin), so the active tab's
+ * underline reads as continuous with the header. */
 .ps-head {
+  flex-shrink: 0;
+  padding: 12px 24px 0;
+  border-bottom: 1px solid var(--bd-soft);
+}
+.ps-head-row {
   display: flex;
   align-items: center;
   gap: 14px;
-  padding: 12px 24px;
-  border-bottom: 1px solid var(--bd-soft);
-  flex-shrink: 0;
 }
 .ps-back {
   gap: 9px;
@@ -52,6 +56,48 @@
 .ps-path {
   margin-top: 3px;
   color: var(--fg-3);
+}
+/* Board counts, right-aligned against the identity block. */
+.ps-stats {
+  flex-shrink: 0;
+  flex-wrap: nowrap;
+}
+.ps-stat-shipped {
+  color: var(--success);
+}
+
+/* tabs — Roadmap ⇄ Settings */
+.ps-tabs {
+  display: flex;
+  gap: 4px;
+  margin-top: 10px;
+}
+.ps-tab {
+  gap: 7px;
+  padding: 8px 12px 9px;
+  margin-bottom: -1px;
+  font-weight: 500;
+  color: var(--fg-2);
+  border-radius: var(--r-sm) var(--r-sm) 0 0;
+  border-bottom: 2px solid transparent;
+  transition:
+    background 0.14s var(--ease),
+    color 0.14s var(--ease),
+    border-color 0.14s var(--ease);
+}
+.ps-tab svg {
+  color: var(--fg-3);
+}
+.ps-tab:hover {
+  color: var(--fg-0);
+  background: var(--hover);
+}
+.ps-tab.active {
+  color: var(--fg-0);
+  border-bottom-color: var(--accent);
+}
+.ps-tab.active svg {
+  color: var(--accent);
 }
 
 /* body — one scrollable page; sections stack in a centered column */

--- a/src/components/ProjectScreen/Roadmap/Board/HorizonGroup.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/HorizonGroup.tsx
@@ -6,11 +6,16 @@ export function HorizonGroup({
   label,
   note,
   count,
+  empty,
   children,
 }: {
   label: string;
   note: string;
+  /** Committed rows only — proposed ones aren't real yet, so they don't count
+   *  here either (this is the same number the page header shows). */
   count: number;
+  /** Nothing to render at all, committed or proposed. */
+  empty: boolean;
   children: ReactNode;
 }) {
   return (
@@ -21,7 +26,7 @@ export function HorizonGroup({
         <span className="rm-group-c mono text-xs">{count}</span>
       </div>
       <div className="rm-group-body">
-        {count === 0 ? <div className="rm-empty text-xs">Nothing here yet.</div> : children}
+        {empty ? <div className="rm-empty text-xs">Nothing here yet.</div> : children}
       </div>
     </section>
   );

--- a/src/components/ProjectScreen/Roadmap/Board/HorizonGroup.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/HorizonGroup.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+
+/** One horizon section of the board — a labelled header with a right-aligned
+ *  count over a rule-anchored stack of rows. */
+export function HorizonGroup({
+  label,
+  note,
+  count,
+  children,
+}: {
+  label: string;
+  note: string;
+  count: number;
+  children: ReactNode;
+}) {
+  return (
+    <section className="rm-group">
+      <div className="rm-group-h">
+        <span className="rm-group-l mono text-xs">{label}</span>
+        <span className="rm-group-n text-xs">{note}</span>
+        <span className="rm-group-c mono text-xs">{count}</span>
+      </div>
+      <div className="rm-group-body">
+        {count === 0 ? <div className="rm-empty text-xs">Nothing here yet.</div> : children}
+      </div>
+    </section>
+  );
+}

--- a/src/components/ProjectScreen/Roadmap/Board/ItemCard.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/ItemCard.tsx
@@ -1,0 +1,97 @@
+import { Icon, type IconName } from "@/components/Icon";
+import { Button } from "@/components/ui/Button";
+import { type ItemSource, type RoadmapItem, SIZE_HINT } from "../types";
+
+/** Where the item came from, as a one-glyph tag. */
+const SOURCE: Record<ItemSource, { icon: IconName; tip: string }> = {
+  pm: { icon: "sparkle", tip: "Written here with the PM agent" },
+  linear: { icon: "layers", tip: "From Linear" },
+  github: { icon: "github", tip: "From GitHub" },
+};
+
+interface Props {
+  item: RoadmapItem;
+  /** A proposed row — real only once the user accepts the proposal. */
+  ghost?: boolean;
+  open: boolean;
+  onToggle: () => void;
+  /** Ring the row: it was just jumped to, or a pending proposal moves it. */
+  focused?: boolean;
+  /** Lets the board scroll a focused row into view. */
+  cardRef?: (el: HTMLDivElement | null) => void;
+}
+
+/** One roadmap row: a click-to-expand header line (code, title, size, source)
+ *  over the rationale, acceptance criteria and dependencies. */
+export function ItemCard({ item, ghost, open, onToggle, focused, cardRef }: Props) {
+  const source = SOURCE[item.source];
+  const cls = [
+    "rm-item",
+    ghost ? "ghost" : "",
+    open ? "open" : "",
+    item.justAdded ? "landed" : "",
+    focused ? "focus" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div ref={cardRef} className={cls}>
+      <button
+        type="button"
+        className="rm-item-h flex-center"
+        onClick={onToggle}
+        aria-expanded={open}
+      >
+        <span className="rm-code mono text-xs">{item.code}</span>
+        <span className="rm-title text-sm truncate">{item.title}</span>
+        {item.epic && <span className="rm-epic text-xs">{item.epic}</span>}
+        {item.status === "active" && item.agent && (
+          <span className="rm-live iflex-center mono text-xs">
+            <span className="rm-pearl" />
+            {item.agent}
+          </span>
+        )}
+        <span
+          className={`rm-size iflex-center mono text-xs s-${item.size}`}
+          title={SIZE_HINT[item.size]}
+        >
+          {item.size}
+        </span>
+        <span className={`rm-src iflex-center src-${item.source}`} title={source.tip}>
+          <Icon name={source.icon} size={10} />
+        </span>
+        <Icon name="chevD" size={10} className="rm-chev" />
+      </button>
+
+      {open && (
+        <div className="rm-item-body">
+          <p className="rm-why text-sm">{item.why}</p>
+          {item.accept && (
+            <ul className="rm-accept text-sm">
+              {item.accept.map((a) => (
+                <li key={a}>{a}</li>
+              ))}
+            </ul>
+          )}
+          <div className="rm-item-foot flex-center">
+            <span className="rm-area mono text-xs">{item.area}</span>
+            {item.deps?.map((d) => (
+              <span key={d} className="rm-dep iflex-center mono text-xs">
+                <Icon name="arrowR" size={9} />
+                after {d}
+              </span>
+            ))}
+            <span className="grow" />
+            {/* A proposed row has nothing to send an agent at yet. */}
+            {!ghost && (
+              <Button variant="outline" size="sm">
+                <Icon name="zap" size={11} /> Send to an agent
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ProjectScreen/Roadmap/Board/ItemCard.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/ItemCard.tsx
@@ -1,5 +1,6 @@
 import { Icon, type IconName } from "@/components/Icon";
 import { Button } from "@/components/ui/Button";
+import { useAppStore } from "@/store";
 import { type ItemSource, type RoadmapItem, SIZE_HINT } from "../types";
 
 /** Where the item came from, as a one-glyph tag. */
@@ -11,6 +12,8 @@ const SOURCE: Record<ItemSource, { icon: IconName; tip: string }> = {
 
 interface Props {
   item: RoadmapItem;
+  /** The project's primary repo — where "Send to an agent" opens the draft. */
+  repoPath: string;
   /** A proposed row — real only once the user accepts the proposal. */
   ghost?: boolean;
   open: boolean;
@@ -21,9 +24,20 @@ interface Props {
   cardRef?: (el: HTMLDivElement | null) => void;
 }
 
+/** The item as a starting prompt for an agent: what to build, why, and what
+ *  "done" means. Prefills the new draft's composer so the user reviews and
+ *  launches rather than retyping the row. */
+function briefFor(item: RoadmapItem): string {
+  const lines = [`${item.code}: ${item.title}`, "", item.why];
+  if (item.accept?.length) lines.push("", "Done when:", ...item.accept.map((a) => `- ${a}`));
+  return lines.join("\n");
+}
+
 /** One roadmap row: a click-to-expand header line (code, title, size, source)
  *  over the rationale, acceptance criteria and dependencies. */
-export function ItemCard({ item, ghost, open, onToggle, focused, cardRef }: Props) {
+export function ItemCard({ item, repoPath, ghost, open, onToggle, focused, cardRef }: Props) {
+  const createDraft = useAppStore((s) => s.createDraft);
+  const closeProjectScreen = useAppStore((s) => s.closeProjectScreen);
   const source = SOURCE[item.source];
   const cls = [
     "rm-item",
@@ -85,7 +99,17 @@ export function ItemCard({ item, ghost, open, onToggle, focused, cardRef }: Prop
             <span className="grow" />
             {/* A proposed row has nothing to send an agent at yet. */}
             {!ghost && (
-              <Button variant="outline" size="sm">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={async () => {
+                  const draftId = await createDraft(repoPath, briefFor(item));
+                  // The draft lives in the workspace, which this page covers —
+                  // but stay put if it couldn't be created, so the user isn't
+                  // dropped somewhere else to read the error.
+                  if (draftId) closeProjectScreen();
+                }}
+              >
                 <Icon name="zap" size={11} /> Send to an agent
               </Button>
             )}

--- a/src/components/ProjectScreen/Roadmap/Board/ProductMap.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/ProductMap.tsx
@@ -1,0 +1,30 @@
+import { HEAT_LABEL, type MapDomain } from "../types";
+
+/** What the PM agent knows about the codebase — the map it checks new ideas
+ *  against before writing anything on the board. */
+export function ProductMap({ map }: { map: MapDomain[] }) {
+  return (
+    <div className="rm-map">
+      <p className="rm-map-lede text-sm">
+        What the PM agent knows about this codebase. It checks new ideas against this before writing
+        anything down.
+      </p>
+      {map.map((d) => (
+        <div key={d.id} className={`rm-dom flex-center heat-${d.heat}`}>
+          <span className="rm-dom-bar" />
+          <div className="rm-dom-id">
+            <div className="rm-dom-l text-sm">{d.label}</div>
+            <div className="rm-dom-n mono text-xs">{d.note}</div>
+          </div>
+          <div className="rm-dom-m">
+            <span className="rm-dom-files mono text-xs">{d.files} files</span>
+            <span className={`rm-dom-items mono text-xs ${d.items ? "on" : ""}`}>
+              {d.items} planned
+            </span>
+          </div>
+          <span className="rm-dom-heat mono text-xs">{HEAT_LABEL[d.heat]}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/ProjectScreen/Roadmap/Board/index.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/index.tsx
@@ -9,7 +9,7 @@ import { ProductMap } from "./ProductMap";
 /** The board the PM agent maintains: horizon groups of expandable items, with
  *  a proposal's additions rendered inline as ghost rows. Sibling tab shows the
  *  product map the agent reasons against. */
-export function Board({ roadmap }: { roadmap: RoadmapState }) {
+export function Board({ roadmap, repoPath }: { roadmap: RoadmapState; repoPath: string }) {
   const { items, ghosts, moves, map, shipped, tab, setTab, openCodes, toggleItem, focusCode } =
     roadmap;
 
@@ -62,18 +62,24 @@ export function Board({ roadmap }: { roadmap: RoadmapState }) {
           <ProductMap map={map} />
         ) : (
           HORIZONS.map((h) => {
+            const real = items.filter((i) => i.horizon === h.id);
             // Proposed additions sit in their target group, so the user sees
-            // where a change would land before committing to it.
-            const rowsFor = [
-              ...items.filter((i) => i.horizon === h.id),
-              ...ghosts.filter((i) => i.horizon === h.id),
-            ];
+            // where a change would land before committing to it — but they
+            // don't move the count until they're accepted.
+            const rowsFor = [...real, ...ghosts.filter((i) => i.horizon === h.id)];
             return (
-              <HorizonGroup key={h.id} label={h.label} note={h.note} count={rowsFor.length}>
+              <HorizonGroup
+                key={h.id}
+                label={h.label}
+                note={h.note}
+                count={real.length}
+                empty={rowsFor.length === 0}
+              >
                 {rowsFor.map((it) => (
                   <ItemCard
                     key={it.code}
                     item={it}
+                    repoPath={repoPath}
                     ghost={ghostCodes.has(it.code)}
                     open={openCodes.has(it.code)}
                     focused={focusCode === it.code || movedCodes.has(it.code)}

--- a/src/components/ProjectScreen/Roadmap/Board/index.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/index.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef } from "react";
+import { Icon } from "@/components/Icon";
+import { HORIZONS } from "../types";
+import type { RoadmapState } from "../useRoadmap";
+import { HorizonGroup } from "./HorizonGroup";
+import { ItemCard } from "./ItemCard";
+import { ProductMap } from "./ProductMap";
+
+/** The board the PM agent maintains: horizon groups of expandable items, with
+ *  a proposal's additions rendered inline as ghost rows. Sibling tab shows the
+ *  product map the agent reasons against. */
+export function Board({ roadmap }: { roadmap: RoadmapState }) {
+  const { items, ghosts, moves, map, shipped, tab, setTab, openCodes, toggleItem, focusCode } =
+    roadmap;
+
+  const scroll = useRef<HTMLDivElement>(null);
+  const rows = useRef<Record<string, HTMLDivElement | null>>({});
+
+  // Bring a jumped-to row into the upper third of the viewport.
+  useEffect(() => {
+    if (!focusCode) return;
+    const el = rows.current[focusCode];
+    const box = scroll.current;
+    if (!el || !box) return;
+    const top = el.getBoundingClientRect().top - box.getBoundingClientRect().top + box.scrollTop;
+    box.scrollTop = Math.max(0, top - box.clientHeight / 3);
+  }, [focusCode]);
+
+  const ghostCodes = new Set(ghosts.map((g) => g.code));
+  const movedCodes = new Set(moves.map((m) => m.code));
+
+  return (
+    <aside className="rm-board">
+      <div className="rm-board-h flex-center">
+        <div className="rm-tabs">
+          <button
+            type="button"
+            className={`rm-tab iflex-center text-sm ${tab === "roadmap" ? "active" : ""}`}
+            onClick={() => setTab("roadmap")}
+          >
+            <Icon name="map" size={12} /> Roadmap
+          </button>
+          <button
+            type="button"
+            className={`rm-tab iflex-center text-sm ${tab === "map" ? "active" : ""}`}
+            onClick={() => setTab("map")}
+          >
+            <Icon name="cube" size={12} /> Product map
+          </button>
+        </div>
+        <span className="grow" />
+        {tab === "roadmap" && (
+          <span className="rm-shipped iflex-center mono text-xs">
+            <Icon name="merge" size={11} />
+            {shipped} shipped
+          </span>
+        )}
+      </div>
+
+      <div className="rm-board-scroll" ref={scroll}>
+        {tab === "map" ? (
+          <ProductMap map={map} />
+        ) : (
+          HORIZONS.map((h) => {
+            // Proposed additions sit in their target group, so the user sees
+            // where a change would land before committing to it.
+            const rowsFor = [
+              ...items.filter((i) => i.horizon === h.id),
+              ...ghosts.filter((i) => i.horizon === h.id),
+            ];
+            return (
+              <HorizonGroup key={h.id} label={h.label} note={h.note} count={rowsFor.length}>
+                {rowsFor.map((it) => (
+                  <ItemCard
+                    key={it.code}
+                    item={it}
+                    ghost={ghostCodes.has(it.code)}
+                    open={openCodes.has(it.code)}
+                    focused={focusCode === it.code || movedCodes.has(it.code)}
+                    onToggle={() => toggleItem(it.code)}
+                    cardRef={(el) => {
+                      rows.current[it.code] = el;
+                    }}
+                  />
+                ))}
+              </HorizonGroup>
+            );
+          })
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/src/components/ProjectScreen/Roadmap/Roadmap.css
+++ b/src/components/ProjectScreen/Roadmap/Roadmap.css
@@ -1,0 +1,608 @@
+/* ─── Roadmap tab ────────────────────────────────────────────────────
+ * Two columns under the project header: the PM conversation (left) and the
+ * board it maintains (right). Message bubbles, the question card, the tool row
+ * and the composer are reused from the agent transcript — only what is unique
+ * to the roadmap is styled here. */
+.rm {
+  flex: 1;
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+}
+/* `.grow` is scoped per component in this app, not a global utility. */
+.rm-board-h .grow,
+.rm-prop-foot .grow,
+.rm-item-foot .grow,
+.rm-composer-wrap .composer-foot .grow {
+  flex: 1;
+}
+
+/* ── left column: the PM conversation ── */
+.rm-thread {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--bd-soft);
+}
+.rm-thread-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 22px 0 10px;
+}
+.rm-thread-col {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 0 28px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 20px;
+}
+/* The transcript skins carry their own bottom margin; the column's gap owns
+   spacing here. */
+.rm-thread-col .m-user,
+.rm-thread-col .m-agent {
+  margin-bottom: 0;
+}
+
+/* PM identity card — sets the tone once, then gets out of the way. */
+.rm-pm {
+  gap: 11px;
+  padding-bottom: 2px;
+}
+.rm-pm-badge {
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  border-radius: var(--r-md);
+  color: var(--accent);
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-line);
+}
+.rm-pm-n {
+  color: var(--fg-0);
+  font-weight: 600;
+}
+.rm-pm-s {
+  margin-top: 1px;
+  color: var(--fg-3);
+}
+
+/* The PM's repo-check summary is the substance of the row, not a tool
+   argument — let it wrap rather than ellipsize at the column's width. */
+.rm-thread-col .m-tool .t-arg {
+  white-space: normal;
+  text-overflow: clip;
+  line-height: var(--lh-snug);
+}
+
+/* findings inside the collapsed repo check */
+.rm-findings {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.rm-findings li {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  line-height: var(--lh-normal);
+  color: var(--fg-1);
+  text-wrap: pretty;
+}
+.rm-f-tag {
+  flex-shrink: 0;
+  width: 42px;
+  margin-top: 1px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+}
+.rm-findings li.f-ok .rm-f-tag {
+  color: var(--success);
+}
+.rm-findings li.f-warn .rm-f-tag {
+  color: var(--warn);
+}
+.rm-findings li.f-dep .rm-f-tag {
+  color: var(--info);
+}
+.rm-f-t code {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  padding: 1px 5px;
+  background: var(--hover);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-xs);
+}
+
+/* ── proposal: the commit point ── */
+.rm-prop {
+  overflow: hidden;
+  border: 1px solid var(--accent-line);
+  border-radius: var(--r-md);
+  background: color-mix(in oklch, var(--accent), var(--bg-2) 94%);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent), transparent 93%);
+}
+.rm-prop.accepted,
+.rm-prop.discarded {
+  border-color: var(--bd-soft);
+  background: var(--bg-1);
+  box-shadow: none;
+}
+.rm-prop.discarded {
+  opacity: 0.6;
+}
+.rm-prop-h {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 12px 14px 9px;
+}
+.rm-prop-l {
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+.rm-prop.accepted .rm-prop-l {
+  color: var(--success);
+}
+.rm-prop.discarded .rm-prop-l {
+  color: var(--fg-3);
+}
+.rm-prop-n {
+  margin-left: auto;
+  color: var(--fg-3);
+}
+.rm-prop-row {
+  gap: 10px;
+  padding: 7px 14px;
+  border-top: 1px solid var(--bd-soft);
+}
+.rm-prop-op {
+  width: 14px;
+  flex-shrink: 0;
+  font-weight: 700;
+}
+.rm-prop-op.add {
+  color: var(--success);
+}
+.rm-prop-op.move {
+  color: var(--info);
+}
+.rm-prop-code {
+  flex-shrink: 0;
+  color: var(--fg-2);
+}
+.rm-prop-title {
+  flex: 1;
+  min-width: 0;
+  color: var(--fg-0);
+}
+.rm-prop-tag {
+  flex-shrink: 0;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+}
+.rm-prop-foot {
+  gap: 8px;
+  padding: 10px 12px 11px 14px;
+  border-top: 1px solid var(--bd-soft);
+}
+.rm-prop-hint {
+  color: var(--fg-3);
+}
+
+/* "FLT-142 · FLT-149 on the board" — jumps the board to the row. */
+.rm-landed {
+  gap: 7px;
+  flex-wrap: wrap;
+  color: var(--fg-3);
+}
+.rm-landed-code {
+  color: var(--accent);
+  border-bottom: 1px solid var(--accent-line);
+}
+.rm-landed-code:hover {
+  color: var(--fg-0);
+  border-color: var(--fg-0);
+}
+
+/* ── composer ── */
+.rm-composer-wrap {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 9px;
+  padding: 8px 28px 18px;
+}
+.rm-composer-wrap .composer {
+  max-width: 640px;
+}
+.rm-composer-wrap .composer.is-blocked {
+  opacity: 0.55;
+  box-shadow: none;
+}
+.rm-sugg {
+  width: 100%;
+  max-width: 640px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.rm-sugg-c {
+  padding: 8px 12px;
+  text-align: left;
+  line-height: var(--lh-snug);
+  color: var(--fg-2);
+  background: transparent;
+  border: 1px dashed var(--bd);
+  border-radius: var(--r-md);
+  transition:
+    border-color 0.14s,
+    background 0.14s,
+    color 0.14s;
+}
+.rm-sugg-c:hover {
+  color: var(--fg-0);
+  background: var(--hover);
+  border-style: solid;
+  border-color: var(--accent-line);
+}
+
+/* ═══ right column: the board ══════════════════════════════════════ */
+.rm-board {
+  width: 45%;
+  min-width: 380px;
+  max-width: 620px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--bg-0);
+}
+.rm-board-h {
+  flex-shrink: 0;
+  height: 44px;
+  gap: 10px;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--bd-soft);
+}
+.rm-tabs {
+  display: flex;
+  gap: 2px;
+}
+.rm-tab {
+  gap: 6px;
+  height: 26px;
+  padding: 0 10px;
+  border-radius: var(--r-sm);
+  font-weight: 500;
+  color: var(--fg-2);
+  transition: var(--transition-ui);
+}
+.rm-tab:hover {
+  background: var(--hover);
+  color: var(--fg-0);
+}
+.rm-tab.active {
+  background: var(--selected);
+  color: var(--fg-0);
+}
+.rm-shipped {
+  gap: 5px;
+  color: var(--fg-3);
+}
+.rm-shipped svg {
+  color: var(--success);
+}
+.rm-board-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px 14px 48px;
+}
+
+/* ── horizon group ── */
+.rm-group + .rm-group {
+  margin-top: 22px;
+}
+.rm-group-h {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 0 4px 8px;
+}
+.rm-group-l {
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--fg-1);
+}
+.rm-group-n {
+  color: var(--fg-3);
+}
+.rm-group-c {
+  margin-left: auto;
+  color: var(--fg-3);
+  font-variant-numeric: tabular-nums;
+}
+.rm-group-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-left: 11px;
+  border-left: 1px solid var(--bd-soft);
+}
+.rm-empty {
+  padding: 4px 2px;
+  color: var(--fg-3);
+  font-style: italic;
+}
+
+/* ── item row ── */
+.rm-item {
+  overflow: hidden;
+  background: var(--bg-2);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-md);
+  transition:
+    border-color 0.14s var(--ease),
+    background 0.14s var(--ease);
+}
+.rm-item:hover {
+  border-color: var(--bd-strong);
+}
+.rm-item.open {
+  border-color: var(--bd);
+}
+.rm-item-h {
+  width: 100%;
+  gap: 9px;
+  padding: 9px 11px;
+  text-align: left;
+}
+.rm-code {
+  flex-shrink: 0;
+  color: var(--fg-3);
+}
+.rm-title {
+  flex: 1;
+  min-width: 0;
+  color: var(--fg-0);
+}
+.rm-epic {
+  flex-shrink: 0;
+  padding: 2px 6px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border-radius: 999px;
+}
+/* An agent is on this one right now. */
+.rm-live {
+  flex-shrink: 0;
+  gap: 5px;
+  color: var(--fg-2);
+}
+.rm-pearl {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--success);
+  box-shadow: 0 0 0 2px color-mix(in oklch, var(--success), transparent 82%);
+  animation: rm-pulse 1.8s ease-in-out infinite;
+}
+@keyframes rm-pulse {
+  50% {
+    box-shadow: 0 0 0 4px color-mix(in oklch, var(--success), transparent 90%);
+  }
+}
+.rm-size {
+  flex-shrink: 0;
+  width: 18px;
+  height: 17px;
+  border-radius: var(--r-xs);
+  font-weight: 600;
+  color: var(--fg-2);
+  background: var(--bg-3);
+}
+/* Only the multi-day tier earns a color — the rest are unremarkable. */
+.rm-size.s-L {
+  color: var(--warn);
+  background: color-mix(in oklch, var(--warn), transparent 88%);
+}
+.rm-src {
+  flex-shrink: 0;
+  color: var(--fg-3);
+}
+.rm-src.src-pm {
+  color: var(--accent);
+}
+.rm-chev {
+  flex-shrink: 0;
+  color: var(--fg-3);
+  transition: transform 0.15s var(--ease);
+}
+.rm-item.open .rm-chev {
+  transform: rotate(180deg);
+}
+
+.rm-item-body {
+  padding: 2px 12px 11px;
+}
+.rm-why {
+  margin: 0 0 9px;
+  line-height: var(--lh-normal);
+  color: var(--fg-1);
+  text-wrap: pretty;
+}
+.rm-accept {
+  margin: 0 0 10px;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.rm-accept li {
+  position: relative;
+  padding-left: 15px;
+  line-height: var(--lh-snug);
+  color: var(--fg-2);
+  text-wrap: pretty;
+}
+.rm-accept li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 5px;
+  width: 7px;
+  height: 7px;
+  border: 1px solid var(--bd-strong);
+  border-radius: 2px;
+}
+.rm-item-foot {
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.rm-area {
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+}
+.rm-dep {
+  gap: 4px;
+  color: var(--info);
+}
+
+/* A proposed row — dashed and tinted until the user accepts it. */
+.rm-item.ghost {
+  border-style: dashed;
+  border-color: var(--accent-line);
+  background: color-mix(in oklch, var(--accent), var(--bg-0) 93%);
+  animation: rm-ghost-in 0.34s var(--ease) both;
+}
+.rm-item.ghost .rm-code {
+  color: var(--accent);
+}
+@keyframes rm-ghost-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
+/* Just accepted or just moved. */
+.rm-item.landed {
+  animation: rm-land 2.2s var(--ease);
+}
+@keyframes rm-land {
+  0% {
+    border-color: var(--accent);
+    background: color-mix(in oklch, var(--accent), var(--bg-2) 78%);
+  }
+}
+.rm-item.focus {
+  border-color: var(--accent-line);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent), transparent 86%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rm-pearl,
+  .rm-item.ghost,
+  .rm-item.landed {
+    animation: none;
+  }
+}
+
+/* ── product map tab ── */
+.rm-map {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.rm-map-lede {
+  margin: 2px 4px 12px;
+  line-height: var(--lh-normal);
+  color: var(--fg-2);
+  text-wrap: pretty;
+}
+.rm-dom {
+  gap: 11px;
+  padding: 11px 12px 11px 0;
+  overflow: hidden;
+  background: var(--bg-2);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-md);
+}
+.rm-dom-bar {
+  width: 3px;
+  flex-shrink: 0;
+  align-self: stretch;
+  background: var(--bd-strong);
+}
+.rm-dom.heat-hot .rm-dom-bar {
+  background: var(--accent);
+}
+.rm-dom.heat-warm .rm-dom-bar {
+  background: color-mix(in oklch, var(--accent), transparent 55%);
+}
+.rm-dom-id {
+  flex: 1;
+  min-width: 0;
+}
+.rm-dom-l {
+  color: var(--fg-0);
+  font-weight: 500;
+}
+.rm-dom-n {
+  margin-top: 2px;
+  color: var(--fg-3);
+}
+.rm-dom-m {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+}
+.rm-dom-files {
+  color: var(--fg-2);
+}
+.rm-dom-items {
+  color: var(--fg-3);
+}
+.rm-dom-items.on {
+  color: var(--accent);
+}
+.rm-dom-heat {
+  flex-shrink: 0;
+  width: 52px;
+  text-align: right;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+}
+
+/* ── narrow windows ── */
+@media (max-width: 1180px) {
+  .rm-board {
+    width: 44%;
+    min-width: 320px;
+  }
+  .rm-thread-col {
+    padding: 0 18px;
+  }
+  .rm-composer-wrap {
+    padding: 8px 18px 16px;
+  }
+}

--- a/src/components/ProjectScreen/Roadmap/Thread/Composer.tsx
+++ b/src/components/ProjectScreen/Roadmap/Thread/Composer.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import { Icon } from "@/components/Icon";
+import { Chip } from "@/components/ui/Chip";
+
+/** The PM composer. Reuses the agent composer's skin, but not its input core —
+ *  there are no mentions, attachments or model picker to wire up here. Closed
+ *  while a proposal or question is waiting on the user, so the board can't
+ *  drift behind an unanswered decision. */
+export function Composer({
+  blocked,
+  suggestions,
+  onSend,
+}: {
+  blocked: boolean;
+  /** Unplayed openers, offered as dashed chips above the box. */
+  suggestions: string[];
+  onSend: (text: string) => void;
+}) {
+  const [draft, setDraft] = useState("");
+
+  const send = () => {
+    if (blocked || !draft.trim()) return;
+    onSend(draft);
+    setDraft("");
+  };
+
+  return (
+    <div className="rm-composer-wrap">
+      {!blocked && suggestions.length > 0 && (
+        <div className="rm-sugg">
+          {suggestions.map((s) => (
+            <button key={s} type="button" className="rm-sugg-c text-sm" onClick={() => onSend(s)}>
+              {s}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className={`composer ${blocked ? "is-blocked" : ""}`}>
+        <textarea
+          className="composer-input text-base"
+          rows={2}
+          placeholder={
+            blocked
+              ? "Resolve the proposal above to keep going…"
+              : "Tell the PM what the product should do…"
+          }
+          value={draft}
+          disabled={blocked}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              send();
+            }
+          }}
+        />
+        <div className="composer-foot flex-center">
+          <Chip disabled={blocked}>
+            <Icon name="attach" size={12} /> Attach
+          </Chip>
+          <span className="grow" />
+          <button
+            type="button"
+            className="send flex-center"
+            disabled={blocked || !draft.trim()}
+            onClick={send}
+            aria-label="Send"
+          >
+            <Icon name="arrowUp" size={13} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProjectScreen/Roadmap/Thread/Composer.tsx
+++ b/src/components/ProjectScreen/Roadmap/Thread/Composer.tsx
@@ -1,32 +1,39 @@
 import { useState } from "react";
 import { Icon } from "@/components/Icon";
-import { Chip } from "@/components/ui/Chip";
 
 /** The PM composer. Reuses the agent composer's skin, but not its input core —
- *  there are no mentions, attachments or model picker to wire up here. Closed
- *  while a proposal or question is waiting on the user, so the board can't
- *  drift behind an unanswered decision. */
+ *  there are no mentions, attachments or model picker to wire up here.
+ *
+ *  Closed while the PM is mid-reply (`busy`) so a second message can't
+ *  interleave its beats with the first, and while a proposal or question is
+ *  waiting on the user (`blocked`) so the board can't drift behind an
+ *  unresolved decision. */
 export function Composer({
   blocked,
+  busy,
   suggestions,
   onSend,
 }: {
+  /** A proposal or question is waiting on the user. */
   blocked: boolean;
+  /** A reply is still landing. */
+  busy: boolean;
   /** Unplayed openers, offered as dashed chips above the box. */
   suggestions: string[];
   onSend: (text: string) => void;
 }) {
   const [draft, setDraft] = useState("");
+  const closed = blocked || busy;
 
   const send = () => {
-    if (blocked || !draft.trim()) return;
+    if (closed || !draft.trim()) return;
     onSend(draft);
     setDraft("");
   };
 
   return (
     <div className="rm-composer-wrap">
-      {!blocked && suggestions.length > 0 && (
+      {!closed && suggestions.length > 0 && (
         <div className="rm-sugg">
           {suggestions.map((s) => (
             <button key={s} type="button" className="rm-sugg-c text-sm" onClick={() => onSend(s)}>
@@ -36,17 +43,19 @@ export function Composer({
         </div>
       )}
 
-      <div className={`composer ${blocked ? "is-blocked" : ""}`}>
+      <div className={`composer ${closed ? "is-blocked" : ""}`}>
         <textarea
           className="composer-input text-base"
           rows={2}
           placeholder={
             blocked
               ? "Resolve the proposal above to keep going…"
-              : "Tell the PM what the product should do…"
+              : busy
+                ? "The PM is working through it…"
+                : "Tell the PM what the product should do…"
           }
           value={draft}
-          disabled={blocked}
+          disabled={closed}
           onChange={(e) => setDraft(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === "Enter" && !e.shiftKey) {
@@ -56,14 +65,11 @@ export function Composer({
           }}
         />
         <div className="composer-foot flex-center">
-          <Chip disabled={blocked}>
-            <Icon name="attach" size={12} /> Attach
-          </Chip>
           <span className="grow" />
           <button
             type="button"
             className="send flex-center"
-            disabled={blocked || !draft.trim()}
+            disabled={closed || !draft.trim()}
             onClick={send}
             aria-label="Send"
           >

--- a/src/components/ProjectScreen/Roadmap/Thread/Message.tsx
+++ b/src/components/ProjectScreen/Roadmap/Thread/Message.tsx
@@ -1,0 +1,79 @@
+import { Icon } from "@/components/Icon";
+import { Loader } from "@/components/ui/Loader";
+import { QuestionCard } from "@/components/Workspace/messages/UserInput/QuestionCard";
+import type { PmMessage } from "../types";
+import type { RoadmapState } from "../useRoadmap";
+import { Probe } from "./Probe";
+import { Proposal } from "./Proposal";
+
+/** One thread message. The user bubble and agent prose reuse the transcript's
+ *  `.m-user` / `.m-agent` skins, and a clarifying question reuses the agent
+ *  view's question card verbatim — the PM asks in the same vocabulary. */
+export function Message({ msg, roadmap }: { msg: PmMessage; roadmap: RoadmapState }) {
+  switch (msg.kind) {
+    case "user":
+      return <div className="m-user">{msg.body}</div>;
+
+    case "text":
+      return <div className="m-agent">{msg.body}</div>;
+
+    case "thinking":
+      return <Thinking body={msg.body} />;
+
+    case "probe":
+      return <Probe summary={msg.summary} findings={msg.findings} />;
+
+    case "question":
+      return (
+        <QuestionCard
+          question={msg.question}
+          index={0}
+          total={1}
+          committed={!!msg.answer}
+          answer={msg.answer ?? null}
+          onAnswer={(a) => roadmap.answerQuestion(msg.id, a)}
+        />
+      );
+
+    case "proposal":
+      return (
+        <Proposal
+          note={msg.note}
+          changes={msg.changes}
+          resolved={msg.resolved}
+          onAccept={() => roadmap.accept(msg.id)}
+          onDiscard={() => roadmap.discard(msg.id)}
+        />
+      );
+
+    case "landed":
+      return (
+        <div className="rm-landed flex-center mono text-xs">
+          <Icon name="map" size={11} />
+          {msg.codes.map((c) => (
+            <button
+              key={c}
+              type="button"
+              className="rm-landed-code"
+              onClick={() => roadmap.focusItem(c)}
+            >
+              {c}
+            </button>
+          ))}
+          <span>on the board</span>
+        </div>
+      );
+  }
+}
+
+/** The PM narrating what it's about to check. Also the live placeholder while
+ *  a beat is still arriving (`body` is the generic line then). Same skin as the
+ *  transcript's "agent is working" line. */
+export function Thinking({ body }: { body: string }) {
+  return (
+    <div className="writing flex-center">
+      <Loader />
+      <span>{body}</span>
+    </div>
+  );
+}

--- a/src/components/ProjectScreen/Roadmap/Thread/Probe.tsx
+++ b/src/components/ProjectScreen/Roadmap/Thread/Probe.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+import { ToolRow } from "@/components/Workspace/messages/ToolRow";
+import { FINDING_TAG, type Finding } from "../types";
+
+/** Render `backticked` spans in a finding as inline code. */
+function ticks(text: string): ReactNode[] {
+  // Odd indices are the captured groups, i.e. what was inside the backticks.
+  return text.split(/`([^`]+)`/g).map((part, i) =>
+    i % 2 === 1 ? (
+      // biome-ignore lint/suspicious/noArrayIndexKey: a split of fixed text — the pieces never reorder
+      <code key={i}>{part}</code>
+    ) : (
+      part
+    ),
+  );
+}
+
+/** The repo check the PM runs before proposing anything — collapsed to its
+ *  one-line summary, expanding to the findings. Uses the same row chrome as a
+ *  tool call in the agent transcript, because that is what it is. */
+export function Probe({ summary, findings }: { summary: string; findings: Finding[] }) {
+  return (
+    <ToolRow
+      name="Repo check"
+      icon="cube"
+      summary={summary}
+      expanded={
+        <ul className="rm-findings">
+          {findings.map((f) => (
+            <li key={f.text} className={`f-${f.kind}`}>
+              <span className="rm-f-tag mono text-xs">{FINDING_TAG[f.kind]}</span>
+              <span className="rm-f-t text-sm">{ticks(f.text)}</span>
+            </li>
+          ))}
+        </ul>
+      }
+    />
+  );
+}

--- a/src/components/ProjectScreen/Roadmap/Thread/Proposal.tsx
+++ b/src/components/ProjectScreen/Roadmap/Thread/Proposal.tsx
@@ -1,0 +1,72 @@
+import { Icon } from "@/components/Icon";
+import { Button } from "@/components/ui/Button";
+import type { ProposalChange } from "../types";
+
+const HEADLINE = {
+  accepted: "Added to the roadmap",
+  discarded: "Discarded",
+  open: "Proposed changes",
+} as const;
+
+/** The commit point: everything the PM wants to change to the board, and the
+ *  two buttons that make it real or drop it. Until one is pressed the board
+ *  only shows these as ghosts. */
+export function Proposal({
+  note,
+  changes,
+  resolved,
+  onAccept,
+  onDiscard,
+}: {
+  note: string;
+  changes: ProposalChange[];
+  resolved: "accepted" | "discarded" | null | undefined;
+  onAccept: () => void;
+  onDiscard: () => void;
+}) {
+  return (
+    <div className={`rm-prop ${resolved ?? ""}`}>
+      <div className="rm-prop-h">
+        <span className="rm-prop-l mono text-xs">{HEADLINE[resolved ?? "open"]}</span>
+        <span className="rm-prop-n mono text-xs">{note}</span>
+      </div>
+
+      <div className="rm-prop-list">
+        {changes.map((c) =>
+          c.kind === "add" ? (
+            <div key={c.item.code} className="rm-prop-row flex-center text-sm">
+              <span className="rm-prop-op add iflex-center mono">+</span>
+              <span className="rm-prop-code mono text-xs">{c.item.code}</span>
+              <span className="rm-prop-title truncate">{c.item.title}</span>
+              <span className="rm-prop-tag mono text-xs">{c.item.horizon}</span>
+            </div>
+          ) : (
+            <div key={c.code} className="rm-prop-row flex-center text-sm">
+              <span className="rm-prop-op move iflex-center">
+                <Icon name="arrowUp" size={10} />
+              </span>
+              <span className="rm-prop-code mono text-xs">{c.code}</span>
+              <span className="rm-prop-title truncate">{c.why}</span>
+              <span className="rm-prop-tag mono text-xs">
+                {c.from} → {c.to}
+              </span>
+            </div>
+          ),
+        )}
+      </div>
+
+      {!resolved && (
+        <div className="rm-prop-foot flex-center">
+          <span className="rm-prop-hint text-xs">Nothing changes until you say so.</span>
+          <span className="grow" />
+          <Button variant="ghost" size="sm" onClick={onDiscard}>
+            Discard
+          </Button>
+          <Button variant="primary" size="sm" onClick={onAccept}>
+            <Icon name="check" size={11} /> Add to roadmap
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ProjectScreen/Roadmap/Thread/index.tsx
+++ b/src/components/ProjectScreen/Roadmap/Thread/index.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from "react";
+import { Icon } from "@/components/Icon";
+import type { RoadmapState } from "../useRoadmap";
+import { Composer } from "./Composer";
+import { Message, Thinking } from "./Message";
+
+/** The left column: the conversation with the project's PM agent. It reads the
+ *  repo, asks when a decision is genuinely open, and proposes board changes —
+ *  it never edits the board itself. */
+export function Thread({ roadmap }: { roadmap: RoadmapState }) {
+  const { messages, thinking, blocked, suggestions, send } = roadmap;
+  const scroll = useRef<HTMLDivElement>(null);
+
+  // Beats arrive on a timer, so pin to the bottom as the thread grows.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the deps are the intended re-run triggers, not unused reads
+  useEffect(() => {
+    const el = scroll.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages.length, thinking]);
+
+  return (
+    <section className="rm-thread">
+      <div className="rm-thread-scroll" ref={scroll}>
+        <div className="rm-thread-col">
+          <div className="rm-pm flex-center">
+            <span className="rm-pm-badge iflex-center">
+              <Icon name="sparkle" size={13} />
+            </span>
+            <div>
+              <div className="rm-pm-n text-sm">Project manager</div>
+              <div className="rm-pm-s text-xs">
+                Keeps the roadmap. Reads the repo before it writes anything down.
+              </div>
+            </div>
+          </div>
+
+          {messages.map((m) => (
+            <Message key={m.id} msg={m} roadmap={roadmap} />
+          ))}
+
+          {thinking && <Thinking body="Working through it" />}
+        </div>
+      </div>
+
+      <Composer blocked={blocked} suggestions={suggestions} onSend={send} />
+    </section>
+  );
+}

--- a/src/components/ProjectScreen/Roadmap/Thread/index.tsx
+++ b/src/components/ProjectScreen/Roadmap/Thread/index.tsx
@@ -8,7 +8,7 @@ import { Message, Thinking } from "./Message";
  *  repo, asks when a decision is genuinely open, and proposes board changes —
  *  it never edits the board itself. */
 export function Thread({ roadmap }: { roadmap: RoadmapState }) {
-  const { messages, thinking, blocked, suggestions, send } = roadmap;
+  const { messages, busy, blocked, suggestions, send } = roadmap;
   const scroll = useRef<HTMLDivElement>(null);
 
   // Beats arrive on a timer, so pin to the bottom as the thread grows.
@@ -16,7 +16,7 @@ export function Thread({ roadmap }: { roadmap: RoadmapState }) {
   useEffect(() => {
     const el = scroll.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, [messages.length, thinking]);
+  }, [messages.length, busy]);
 
   return (
     <section className="rm-thread">
@@ -38,11 +38,11 @@ export function Thread({ roadmap }: { roadmap: RoadmapState }) {
             <Message key={m.id} msg={m} roadmap={roadmap} />
           ))}
 
-          {thinking && <Thinking body="Working through it" />}
+          {busy && <Thinking body="Working through it" />}
         </div>
       </div>
 
-      <Composer blocked={blocked} suggestions={suggestions} onSend={send} />
+      <Composer blocked={blocked} busy={busy} suggestions={suggestions} onSend={send} />
     </section>
   );
 }

--- a/src/components/ProjectScreen/Roadmap/index.tsx
+++ b/src/components/ProjectScreen/Roadmap/index.tsx
@@ -10,11 +10,11 @@ export { useRoadmap } from "./useRoadmap";
  *
  *  State is owned by `useRoadmap` in the parent, because the page header shows
  *  the same counts the board does. */
-export function Roadmap({ roadmap }: { roadmap: RoadmapState }) {
+export function Roadmap({ roadmap, repoPath }: { roadmap: RoadmapState; repoPath: string }) {
   return (
     <div className="rm">
       <Thread roadmap={roadmap} />
-      <Board roadmap={roadmap} />
+      <Board roadmap={roadmap} repoPath={repoPath} />
     </div>
   );
 }

--- a/src/components/ProjectScreen/Roadmap/index.tsx
+++ b/src/components/ProjectScreen/Roadmap/index.tsx
@@ -1,0 +1,20 @@
+import { Board } from "./Board";
+import { Thread } from "./Thread";
+import type { RoadmapState } from "./useRoadmap";
+
+export type { RoadmapState } from "./useRoadmap";
+export { useRoadmap } from "./useRoadmap";
+
+/** The Roadmap tab of the project page: a conversation with the project's PM
+ *  agent on the left, the board it maintains on the right.
+ *
+ *  State is owned by `useRoadmap` in the parent, because the page header shows
+ *  the same counts the board does. */
+export function Roadmap({ roadmap }: { roadmap: RoadmapState }) {
+  return (
+    <div className="rm">
+      <Thread roadmap={roadmap} />
+      <Board roadmap={roadmap} />
+    </div>
+  );
+}

--- a/src/components/ProjectScreen/Roadmap/mockData.ts
+++ b/src/components/ProjectScreen/Roadmap/mockData.ts
@@ -1,0 +1,472 @@
+// Placeholder roadmap content. There is no roadmap table or API yet, so the
+// board renders from this module for every project. It is deliberately diverse
+// — every horizon, size, source and status is represented, plus an epic, a
+// dependency chain and an item an agent is actively working — so the shapes in
+// `types.ts` can be turned into a schema without discovering missing columns.
+//
+// Replacing this with real data means swapping the four exports below for
+// loaders; nothing else in the folder reads from it.
+
+import type { MapDomain, PmBody, RoadmapItem, ScriptBeat } from "./types";
+
+/** Codes minted for free-form ideas the PM captures mid-conversation. */
+export const CODE_PREFIX = "FLT-";
+export const FIRST_FREE_CODE = 160;
+
+/** Items already merged. Not on the board — only the header stat. */
+export const SHIPPED_COUNT = 18;
+
+export const SEED_ITEMS: RoadmapItem[] = [
+  {
+    code: "FLT-142",
+    horizon: "now",
+    size: "M",
+    area: "runtime",
+    source: "linear",
+    status: "active",
+    agent: "dolomites",
+    title: "Persist worktree state across app restarts",
+    why: "Fletch forgets in-flight agents when the app quits — the loudest complaint of the last two weeks.",
+    accept: [
+      "Worktree registry survives a hard quit",
+      "Reattaching shows the agent's last transcript",
+      "Orphaned worktrees are offered for cleanup",
+    ],
+  },
+  {
+    code: "FLT-149",
+    horizon: "now",
+    size: "S",
+    area: "runtime",
+    source: "pm",
+    status: "open",
+    title: "Recover orphaned worktrees on launch",
+    why: "Falls out of FLT-142 — without recovery the registry drifts from what's on disk.",
+    accept: ["Scan .fletch/ on boot", "One-click adopt or delete"],
+    deps: ["FLT-142"],
+  },
+  {
+    code: "FLT-137",
+    horizon: "next",
+    size: "S",
+    area: "runtime",
+    source: "linear",
+    status: "open",
+    title: "Backpressure on agent output streaming",
+    why: "Large diffs flood the renderer; the paint-jitter fix only masked it.",
+    accept: ["Stream chunks capped per frame", "No dropped tokens under load"],
+  },
+  {
+    code: "FLT-144",
+    horizon: "next",
+    size: "M",
+    area: "chrome",
+    source: "pm",
+    status: "open",
+    title: "Per-project agent presets",
+    why: "Every new agent in a repo gets the same provider, base branch and workflow — stop re-picking it.",
+    accept: ["Preset editable from the project page", "New-agent draft pre-filled"],
+  },
+  {
+    code: "FLT-131",
+    horizon: "next",
+    size: "XS",
+    area: "chrome",
+    source: "github",
+    status: "open",
+    title: "Surface per-agent token spend in the title bar",
+    why: "Spend is invisible until the invoice arrives.",
+    accept: ["Live cost per worktree", "Roll-up per project"],
+  },
+  {
+    code: "FLT-119",
+    horizon: "later",
+    size: "L",
+    area: "platform",
+    source: "pm",
+    status: "open",
+    title: "Multi-repo projects",
+    why: "Teams with split front/back repos run two Fletch projects today and lose the shared roadmap.",
+    accept: ["One project, many repos", "Agents pick a repo at spawn"],
+  },
+  {
+    code: "FLT-124",
+    horizon: "later",
+    size: "M",
+    area: "chrome",
+    source: "pm",
+    status: "open",
+    title: "Ambient run monitoring outside the app",
+    why: "People leave Fletch while agents work and want a glanceable signal.",
+    accept: ["Menu-bar summary", "Notification when an agent needs you"],
+  },
+];
+
+export const PRODUCT_MAP: MapDomain[] = [
+  {
+    id: "runtime",
+    label: "Agent runtime",
+    note: "spawner · worktrees · providers",
+    files: 42,
+    items: 3,
+    heat: "hot",
+  },
+  {
+    id: "chrome",
+    label: "App chrome",
+    note: "title bar · panels · settings",
+    files: 61,
+    items: 3,
+    heat: "warm",
+  },
+  {
+    id: "planning",
+    label: "Planning",
+    note: "backlog · roadmap · this page",
+    files: 18,
+    items: 1,
+    heat: "warm",
+  },
+  {
+    id: "vcs",
+    label: "Git & review",
+    note: "diffs · PRs · checks",
+    files: 34,
+    items: 0,
+    heat: "cool",
+  },
+  {
+    id: "platform",
+    label: "Workflows",
+    note: "steps · loops · runs",
+    files: 27,
+    items: 0,
+    heat: "cool",
+  },
+];
+
+/** What's already in the thread when the page opens. */
+export const SEED_THREAD: PmBody[] = [
+  {
+    kind: "user",
+    body: "The thing people keep hitting is that quitting Fletch loses everything in flight. Make that not happen.",
+  },
+  {
+    kind: "probe",
+    summary: "Read 9 files across the runtime · found 1 partial capability",
+    findings: [
+      {
+        kind: "ok",
+        text: "`WorktreeRegistry` already tracks live worktrees in memory — no persistence layer.",
+      },
+      {
+        kind: "warn",
+        text: "The reattach path assumes a live child process; it needs a resume branch.",
+      },
+      {
+        kind: "ok",
+        text: "`.fletch/` on disk is already the source of truth for the checkout itself.",
+      },
+    ],
+  },
+  {
+    kind: "text",
+    body: "That's a real gap, not a bug — the registry is memory-only. I filed it at the top of In flight and split the recovery half out, because the two land at different times.",
+  },
+  { kind: "landed", codes: ["FLT-142", "FLT-149"] },
+];
+
+/** Canned exchanges, offered as suggestion chips until they've been used. */
+export const SCRIPT: ScriptBeat[] = [
+  {
+    prompt: "I'd like the app to export a project's roadmap as a shareable PDF.",
+    msgs: [
+      { kind: "thinking", body: "Checking whether anything already serializes the roadmap." },
+      {
+        kind: "probe",
+        summary: "Read 4 files in planning · 1 reusable capability · 0 conflicts",
+        findings: [
+          {
+            kind: "ok",
+            text: "`serializeRoadmap()` already exists for the share link — shipped in FLT-118.",
+          },
+          { kind: "ok", text: "The changelog page's print stylesheet applies here unchanged." },
+        ],
+      },
+      {
+        kind: "text",
+        body: "Straightforward. This is a renderer on top of a serializer you already ship, so it's one small item — no epic needed.",
+      },
+      {
+        kind: "proposal",
+        note: "1 addition",
+        changes: [
+          {
+            kind: "add",
+            item: {
+              code: "FLT-151",
+              horizon: "next",
+              size: "S",
+              area: "planning",
+              source: "pm",
+              status: "open",
+              title: "Export roadmap as a shareable PDF",
+              why: "Rides on the existing serializer and print stylesheet, so it's cheap and unblocks weekly stakeholder updates.",
+              accept: [
+                "Print view groups by horizon",
+                "Includes owner and size",
+                "One click from the project page",
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    prompt: "I want teams to be able to review agent work before it merges.",
+    msgs: [
+      {
+        kind: "thinking",
+        body: "This one touches the merge path — mapping the blast radius before I write anything down.",
+      },
+      {
+        kind: "probe",
+        summary: "Read 16 files across runtime, git & review · 3 touchpoints · 1 related item",
+        findings: [
+          {
+            kind: "warn",
+            text: "Merging happens in two places today: the Git panel and the workflow `merge` step. A gate has to cover both.",
+          },
+          {
+            kind: "ok",
+            text: "`PrChecks` already models a pass/fail/pending trio — a human gate can reuse that shape.",
+          },
+          {
+            kind: "dep",
+            text: "Overlaps FLT-142: reattaching a paused agent needs the persisted registry.",
+          },
+        ],
+      },
+      {
+        kind: "question",
+        question: {
+          id: "gate-shape",
+          header: "review gates · merge path",
+          prompt:
+            "Two shapes here, and they cost very differently. Where should the gate actually sit?",
+          multiSelect: false,
+          allowOther: true,
+          options: [
+            {
+              id: "merge",
+              label: "Hard gate on merge",
+              desc: "The agent opens the PR, then blocks. Nothing lands without an approval. Strongest, and it needs the pause/resume work.",
+              recommended: true,
+            },
+            {
+              id: "pr",
+              label: "Gate before the PR opens",
+              desc: "Review the diff inside Fletch first. Cheaper, but reviewers lose GitHub's tooling.",
+            },
+            {
+              id: "advisory",
+              label: "Advisory only",
+              desc: "Notify a reviewer and keep going. Ships in a day and satisfies nobody who asked for this.",
+            },
+          ],
+        },
+        answered: {
+          text: "Hard gate it is. That's three items, not one — the gate, the pause/resume it depends on, and the reviewer surface. I've ordered them so nothing is blocked.",
+          note: "1 epic · 3 additions · 1 dependency",
+          changes: [
+            {
+              kind: "add",
+              item: {
+                code: "FLT-152",
+                horizon: "now",
+                size: "M",
+                area: "runtime",
+                source: "pm",
+                status: "open",
+                epic: "Review gates",
+                title: "Pause an agent at the merge boundary",
+                why: "The gate is only real if the agent can stop cleanly and resume later — this is the hard half.",
+                accept: [
+                  "Agent parks with its worktree intact",
+                  "Resume replays the remaining steps",
+                  "Covers the workflow merge step too",
+                ],
+                deps: ["FLT-142"],
+              },
+            },
+            {
+              kind: "add",
+              item: {
+                code: "FLT-153",
+                horizon: "next",
+                size: "M",
+                area: "vcs",
+                source: "pm",
+                status: "open",
+                epic: "Review gates",
+                title: "Approval gate on PR merge",
+                why: "Reuses the existing checks model, so the gate reads like any other check.",
+                accept: [
+                  "Named reviewers per project",
+                  "Gate visible in the title-bar capsule",
+                  "Override with an audit note",
+                ],
+                deps: ["FLT-152"],
+              },
+            },
+            {
+              kind: "add",
+              item: {
+                code: "FLT-154",
+                horizon: "later",
+                size: "S",
+                area: "chrome",
+                source: "pm",
+                status: "open",
+                epic: "Review gates",
+                title: "Reviewer inbox",
+                why: "Reviewers need one place to see what is waiting on them across projects.",
+                accept: [
+                  "Cross-project queue",
+                  "Approve or request changes without opening the agent",
+                ],
+                deps: ["FLT-153"],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+  {
+    prompt: "Agents should check with me before they touch anything in the Tauri shell.",
+    msgs: [
+      {
+        kind: "thinking",
+        body: "Sounds like one rule, but I think it's two mechanisms. Checking it against what's already planned.",
+      },
+      {
+        kind: "probe",
+        summary: "Read 11 files · 2 touchpoints · 1 conflict with the current plan",
+        findings: [
+          {
+            kind: "warn",
+            text: '"Sensitive paths" doesn\'t exist yet — there is no path policy anywhere in the runtime.',
+          },
+          {
+            kind: "dep",
+            text: "The stopping half is exactly FLT-152 (pause at a boundary), already in flight.",
+          },
+          {
+            kind: "warn",
+            text: "FLT-137 (backpressure) touches the same stream loop. Doing both at once will conflict.",
+          },
+        ],
+      },
+      {
+        kind: "text",
+        body: "The pause mechanism is already on the board, so this is really just the policy — which paths are sensitive, and who gets asked. I'd also pull FLT-137 forward so the two stream changes don't collide later.",
+      },
+      {
+        kind: "proposal",
+        note: "2 additions · 1 reorder",
+        changes: [
+          {
+            kind: "add",
+            item: {
+              code: "FLT-155",
+              horizon: "next",
+              size: "S",
+              area: "runtime",
+              source: "pm",
+              status: "open",
+              title: "Sensitive path policy per project",
+              why: "The rule people actually want: declare paths that require a human before an edit.",
+              accept: [
+                "Glob list editable in project settings",
+                "Matches shown before the agent starts",
+              ],
+              deps: ["FLT-152"],
+            },
+          },
+          {
+            kind: "add",
+            item: {
+              code: "FLT-156",
+              horizon: "later",
+              size: "S",
+              area: "chrome",
+              source: "pm",
+              status: "open",
+              title: "Ask-before-edit prompt in the agent view",
+              why: "The interruption surface — small, but it's the whole experience of the feature.",
+              accept: [
+                "Inline approve / deny / always-allow",
+                "A denial leaves a note in the transcript",
+              ],
+              deps: ["FLT-155"],
+            },
+          },
+          {
+            kind: "move",
+            code: "FLT-137",
+            from: "next",
+            to: "now",
+            why: "Land the stream change before the pause work touches the same loop.",
+          },
+        ],
+      },
+    ],
+  },
+];
+
+/** What the PM plays when the user says something no script beat covers: it
+ *  refuses to size an unshaped idea and parks it in Later instead. */
+export function freeFormBeat(text: string, code: string): PmBody[] {
+  const title = text
+    .replace(/^(i'?d like|i want|can you|please)\s+/i, "")
+    .replace(/\.$/, "")
+    .trim();
+  return [
+    {
+      kind: "probe",
+      summary: "Read 6 files · no existing capability matches this yet",
+      findings: [
+        {
+          kind: "warn",
+          text: "Nothing in the product map covers this — it would be new surface area.",
+        },
+      ],
+    },
+    {
+      kind: "text",
+      body: "I can't size this until we agree on the shape, so I'll park it in Later as an idea and we can shape it when you want to.",
+    },
+    {
+      kind: "proposal",
+      note: "1 addition · unshaped",
+      changes: [
+        {
+          kind: "add",
+          item: {
+            code,
+            horizon: "later",
+            size: "M",
+            area: "chrome",
+            source: "pm",
+            status: "open",
+            title: title || "Captured idea",
+            why: "Captured from your note. Needs shaping before it can be sized or ordered.",
+            accept: ["Shape it with the PM agent", "Then size and place it"],
+          },
+        },
+      ],
+    },
+  ];
+}

--- a/src/components/ProjectScreen/Roadmap/types.ts
+++ b/src/components/ProjectScreen/Roadmap/types.ts
@@ -1,0 +1,130 @@
+// The Roadmap surface's data model. Everything here is currently fed by
+// `mockData.ts` — there is no roadmap table or API yet. The shapes are written
+// as if they came from the DB (flat rows, string codes, explicit enums) so the
+// eventual schema can be modelled straight off them.
+
+import type { UIAnswer, UIQuestion } from "@/components/Workspace/messages/UserInput/parse";
+
+/** Where an item sits on the board. `now` is being built, `next` is queued,
+ *  `later` is the backlog. Shipped items leave the board (see `shipped`). */
+export type Horizon = "now" | "next" | "later";
+
+export type ItemSize = "XS" | "S" | "M" | "L";
+
+/** Where the item came from — drawn as a glyph on the row. */
+export type ItemSource = "pm" | "linear" | "github";
+
+/** `active` means an agent is on it right now. */
+export type ItemStatus = "open" | "active";
+
+export interface RoadmapItem {
+  /** Short human id ("FLT-142", "#207") — unique per project. */
+  code: string;
+  title: string;
+  horizon: Horizon;
+  size: ItemSize;
+  /** Product-map domain this belongs to (`MapDomain.id`). */
+  area: string;
+  source: ItemSource;
+  status: ItemStatus;
+  /** Why it's on the board — the one line that justifies its place. */
+  why: string;
+  /** Acceptance criteria, rendered as a checklist. */
+  accept?: string[];
+  /** Codes this item must land after. */
+  deps?: string[];
+  /** Optional grouping label when several items were shaped together. */
+  epic?: string;
+  /** Agent working it — only meaningful while `status === "active"`. */
+  agent?: string;
+  /** Transient highlight for a row that just landed on the board. */
+  justAdded?: boolean;
+}
+
+/** A slice of the codebase the PM agent knows about, shown on the Product map
+ *  tab. `heat` is how much recent work has touched it. */
+export interface MapDomain {
+  id: string;
+  label: string;
+  note: string;
+  files: number;
+  /** Roadmap items currently pointing at this domain. */
+  items: number;
+  heat: "hot" | "warm" | "cool";
+}
+
+// ── the PM conversation ──────────────────────────────────────────────
+
+/** One line of the repo check the PM runs before writing anything down.
+ *  `ok` — capability found, `warn` — nothing covers it / a hazard,
+ *  `dep` — it links to something already on the board. */
+export type FindingKind = "ok" | "warn" | "dep";
+
+export interface Finding {
+  kind: FindingKind;
+  /** May contain `backticked` spans, rendered as inline code. */
+  text: string;
+}
+
+/** A single edit the PM proposes to the board. Nothing is applied until the
+ *  user accepts the proposal that carries it. */
+export type ProposalChange =
+  | { kind: "add"; item: RoadmapItem }
+  | { kind: "move"; code: string; from: Horizon; to: Horizon; why: string };
+
+/** The follow-up the PM plays once a question is answered. */
+export interface AnsweredBeat {
+  text: string;
+  note: string;
+  changes: ProposalChange[];
+}
+
+/** A thread message without its id — the shape mock data and the runtime
+ *  script are authored in. `useRoadmap` stamps an id on push. */
+export type PmBody =
+  | { kind: "user"; body: string }
+  | { kind: "text"; body: string }
+  | { kind: "thinking"; body: string }
+  | { kind: "probe"; summary: string; findings: Finding[] }
+  | { kind: "question"; question: UIQuestion; answered: AnsweredBeat; answer?: UIAnswer | null }
+  | {
+      kind: "proposal";
+      note: string;
+      changes: ProposalChange[];
+      resolved?: "accepted" | "discarded" | null;
+    }
+  | { kind: "landed"; codes: string[] };
+
+export type PmMessage = { id: string } & PmBody;
+
+/** A canned exchange: what the user says, and what the PM plays back. */
+export interface ScriptBeat {
+  prompt: string;
+  msgs: PmBody[];
+}
+
+export const SIZE_HINT: Record<ItemSize, string> = {
+  XS: "a few minutes",
+  S: "under an hour",
+  M: "half a day",
+  L: "multi-day",
+};
+
+/** Board groups, in display order. The same labels drive the header stats. */
+export const HORIZONS: { id: Horizon; label: string; note: string }[] = [
+  { id: "now", label: "In flight", note: "being built" },
+  { id: "next", label: "Next", note: "queued" },
+  { id: "later", label: "Later", note: "backlog" },
+];
+
+export const FINDING_TAG: Record<FindingKind, string> = {
+  ok: "found",
+  warn: "watch",
+  dep: "links",
+};
+
+export const HEAT_LABEL: Record<MapDomain["heat"], string> = {
+  hot: "active",
+  warm: "planned",
+  cool: "quiet",
+};

--- a/src/components/ProjectScreen/Roadmap/useRoadmap.ts
+++ b/src/components/ProjectScreen/Roadmap/useRoadmap.ts
@@ -72,8 +72,12 @@ export function useRoadmap() {
   // ── derived ────────────────────────────────────────────────────────
   const pending = messages.find((m) => m.kind === "proposal" && !m.resolved) ?? null;
   const openQuestion = messages.find((m) => m.kind === "question" && !m.answer) ?? null;
-  /** The composer is closed while the user owes an answer or a decision. */
+  /** The user owes an answer or a decision before the thread can move on. */
   const blocked = Boolean(pending || openQuestion);
+  /** A reply is still landing. Also closes the composer: a second message sent
+   *  mid-reply would interleave its beats with the first and could leave two
+   *  proposals open at once, only one of which the board renders. */
+  const busy = thinking;
 
   const ghosts =
     pending?.kind === "proposal"
@@ -113,7 +117,7 @@ export function useRoadmap() {
   const send = useCallback(
     (text: string) => {
       const body = text.trim();
-      if (!body || blocked) return;
+      if (!body || blocked || busy) return;
       push({ kind: "user", body });
 
       // Match on what was actually said — suggestion chips can be clicked in
@@ -129,7 +133,7 @@ export function useRoadmap() {
       setCaptured((n) => n + 1);
       play(freeFormBeat(body, `${CODE_PREFIX}${FIRST_FREE_CODE + captured}`));
     },
-    [blocked, captured, play, push, used],
+    [blocked, busy, captured, play, push, used],
   );
 
   const answerQuestion = useCallback(
@@ -161,10 +165,15 @@ export function useRoadmap() {
         }),
         ...adds,
       ]);
+      // Clear only the rows this call lit up, so a later landing doesn't have
+      // its highlight cut short by an earlier one's timer.
+      const landed = new Set([...adds.map((a) => a.code), ...moved.keys()]);
       after(LANDED_MS, () =>
-        setItems((arr) => arr.map((it) => (it.justAdded ? { ...it, justAdded: false } : it))),
+        setItems((arr) =>
+          arr.map((it) => (landed.has(it.code) ? { ...it, justAdded: false } : it)),
+        ),
       );
-      return [...adds.map((a) => a.code), ...moved.keys()];
+      return [...landed];
     },
     [after],
   );
@@ -229,7 +238,7 @@ export function useRoadmap() {
     focusItem,
     // thread
     messages,
-    thinking,
+    busy,
     blocked,
     suggestions,
     send,

--- a/src/components/ProjectScreen/Roadmap/useRoadmap.ts
+++ b/src/components/ProjectScreen/Roadmap/useRoadmap.ts
@@ -1,0 +1,242 @@
+// The Roadmap's single source of truth: the board's items and the PM thread
+// that edits them. The PM never writes to the board directly — it *proposes*,
+// the board renders the proposal as ghost rows, and the user commits. That rule
+// lives here, so both columns stay honest about what is real.
+//
+// State is in-memory only (see `mockData.ts`); reloading the page resets it.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { UIAnswer } from "@/components/Workspace/messages/UserInput/parse";
+import {
+  CODE_PREFIX,
+  FIRST_FREE_CODE,
+  freeFormBeat,
+  PRODUCT_MAP,
+  SCRIPT,
+  SEED_ITEMS,
+  SEED_THREAD,
+  SHIPPED_COUNT,
+} from "./mockData";
+import type { Horizon, PmBody, PmMessage, ProposalChange, RoadmapItem } from "./types";
+
+/** Beat pacing, in ms after the previous message. A probe reads as work, so it
+ *  lands slower than a line of prose. */
+const BEAT_DELAY: Record<PmBody["kind"], number> = {
+  thinking: 420,
+  probe: 1150,
+  question: 900,
+  user: 780,
+  text: 780,
+  proposal: 780,
+  landed: 780,
+};
+
+/** How long a row stays highlighted after landing on the board. */
+const LANDED_MS = 2200;
+/** How long a focused row keeps its ring after being jumped to. */
+const FOCUS_MS = 2200;
+
+let seq = 0;
+const nextId = () => `pm-${++seq}`;
+const withId = (body: PmBody): PmMessage => ({ ...body, id: nextId() });
+
+export type BoardTab = "roadmap" | "map";
+
+export function useRoadmap() {
+  const [items, setItems] = useState<RoadmapItem[]>(SEED_ITEMS);
+  const [messages, setMessages] = useState<PmMessage[]>(() => SEED_THREAD.map(withId));
+  const [thinking, setThinking] = useState(false);
+  /** Indices into SCRIPT already played — they drop out of the suggestions. */
+  const [used, setUsed] = useState<ReadonlySet<number>>(() => new Set());
+  /** Free-form ideas captured so far, so minted codes don't collide. */
+  const [captured, setCaptured] = useState(0);
+  const [tab, setTab] = useState<BoardTab>("roadmap");
+  const [openCodes, setOpenCodes] = useState<ReadonlySet<string>>(() => new Set());
+  const [focusCode, setFocusCode] = useState<string | null>(null);
+
+  // Every pending beat, so unmounting mid-conversation can't set state on a
+  // dead component.
+  const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
+  useEffect(() => {
+    const pending = timers.current;
+    return () => {
+      for (const t of pending) clearTimeout(t);
+    };
+  }, []);
+  const after = useCallback((ms: number, fn: () => void) => {
+    timers.current.push(setTimeout(fn, ms));
+  }, []);
+
+  const push = useCallback((body: PmBody) => setMessages((m) => [...m, withId(body)]), []);
+
+  // ── derived ────────────────────────────────────────────────────────
+  const pending = messages.find((m) => m.kind === "proposal" && !m.resolved) ?? null;
+  const openQuestion = messages.find((m) => m.kind === "question" && !m.answer) ?? null;
+  /** The composer is closed while the user owes an answer or a decision. */
+  const blocked = Boolean(pending || openQuestion);
+
+  const ghosts =
+    pending?.kind === "proposal"
+      ? pending.changes.flatMap((c) => (c.kind === "add" ? [c.item] : []))
+      : [];
+  const moves =
+    pending?.kind === "proposal"
+      ? pending.changes.flatMap((c) => (c.kind === "move" ? [c] : []))
+      : [];
+
+  const counts = useMemo(() => {
+    const by: Record<Horizon, number> = { now: 0, next: 0, later: 0 };
+    for (const i of items) by[i.horizon] += 1;
+    return by;
+  }, [items]);
+
+  const suggestions = SCRIPT.filter((_, i) => !used.has(i))
+    .slice(0, 2)
+    .map((s) => s.prompt);
+
+  // ── playing a beat ─────────────────────────────────────────────────
+  const play = useCallback(
+    (list: PmBody[]) => {
+      setThinking(true);
+      let at = 260;
+      list.forEach((body, i) => {
+        at += BEAT_DELAY[body.kind];
+        after(at, () => {
+          push(body);
+          if (i === list.length - 1) setThinking(false);
+        });
+      });
+    },
+    [after, push],
+  );
+
+  const send = useCallback(
+    (text: string) => {
+      const body = text.trim();
+      if (!body || blocked) return;
+      push({ kind: "user", body });
+
+      // Match on what was actually said — suggestion chips can be clicked in
+      // any order, and a beat only ever plays once.
+      const idx = SCRIPT.findIndex(
+        (s, i) => !used.has(i) && s.prompt.toLowerCase() === body.toLowerCase(),
+      );
+      if (idx >= 0) {
+        setUsed((s) => new Set(s).add(idx));
+        play(SCRIPT[idx].msgs);
+        return;
+      }
+      setCaptured((n) => n + 1);
+      play(freeFormBeat(body, `${CODE_PREFIX}${FIRST_FREE_CODE + captured}`));
+    },
+    [blocked, captured, play, push, used],
+  );
+
+  const answerQuestion = useCallback(
+    (id: string, answer: UIAnswer) => {
+      const q = messages.find((m) => m.id === id);
+      if (q?.kind !== "question") return;
+      setMessages((arr) => arr.map((m) => (m.id === id ? { ...m, answer } : m)));
+      play([
+        { kind: "text", body: q.answered.text },
+        { kind: "proposal", note: q.answered.note, changes: q.answered.changes },
+      ]);
+    },
+    [messages, play],
+  );
+
+  // ── committing a proposal ──────────────────────────────────────────
+  const applyChanges = useCallback(
+    (changes: ProposalChange[]) => {
+      const adds = changes.flatMap((c) =>
+        c.kind === "add" ? [{ ...c.item, justAdded: true }] : [],
+      );
+      const moved = new Map(
+        changes.flatMap((c) => (c.kind === "move" ? [[c.code, c.to] as const] : [])),
+      );
+      setItems((arr) => [
+        ...arr.map((it) => {
+          const to = moved.get(it.code);
+          return to ? { ...it, horizon: to, justAdded: true } : it;
+        }),
+        ...adds,
+      ]);
+      after(LANDED_MS, () =>
+        setItems((arr) => arr.map((it) => (it.justAdded ? { ...it, justAdded: false } : it))),
+      );
+      return [...adds.map((a) => a.code), ...moved.keys()];
+    },
+    [after],
+  );
+
+  const accept = useCallback(
+    (id: string) => {
+      const p = messages.find((m) => m.id === id);
+      if (p?.kind !== "proposal" || p.resolved) return;
+      const codes = applyChanges(p.changes);
+      setMessages((arr) => arr.map((m) => (m.id === id ? { ...m, resolved: "accepted" } : m)));
+      after(420, () => push({ kind: "landed", codes }));
+    },
+    [after, applyChanges, messages, push],
+  );
+
+  const discard = useCallback(
+    (id: string) => {
+      setMessages((arr) => arr.map((m) => (m.id === id ? { ...m, resolved: "discarded" } : m)));
+      after(360, () =>
+        push({
+          kind: "text",
+          body: "Dropped — the board is unchanged. Tell me what's off about it and I'll re-shape.",
+        }),
+      );
+    },
+    [after, push],
+  );
+
+  // ── board interaction ──────────────────────────────────────────────
+  const toggleItem = useCallback((code: string) => {
+    setOpenCodes((s) => {
+      const next = new Set(s);
+      if (!next.delete(code)) next.add(code);
+      return next;
+    });
+  }, []);
+
+  /** Jump the board to an item and flash it — used by the "on the board" links. */
+  const focusItem = useCallback(
+    (code: string) => {
+      setTab("roadmap");
+      setFocusCode(code);
+      setOpenCodes((s) => new Set(s).add(code));
+      after(FOCUS_MS, () => setFocusCode(null));
+    },
+    [after],
+  );
+
+  return {
+    // board
+    items,
+    ghosts,
+    moves,
+    counts,
+    shipped: SHIPPED_COUNT,
+    map: PRODUCT_MAP,
+    tab,
+    setTab,
+    openCodes,
+    toggleItem,
+    focusCode,
+    focusItem,
+    // thread
+    messages,
+    thinking,
+    blocked,
+    suggestions,
+    send,
+    answerQuestion,
+    accept,
+    discard,
+  };
+}
+
+export type RoadmapState = ReturnType<typeof useRoadmap>;

--- a/src/components/ProjectScreen/index.tsx
+++ b/src/components/ProjectScreen/index.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { api } from "@/api";
-import { Icon } from "@/components/Icon";
 import { loadRunOverrides, type SetupRow, toSetupRows } from "@/components/RunConfig";
 import { Loader } from "@/components/ui/Loader";
 import { useAppStore } from "@/store";
@@ -9,7 +8,9 @@ import { DeleteSection } from "./DeleteSection";
 import { EnvVarsSection } from "./EnvVarsSection";
 import { GeneralSection } from "./GeneralSection";
 import { LinearSection } from "./LinearSection";
+import { ProjectHeader, type ProjectTab } from "./ProjectHeader";
 import { ProjectPulse } from "./ProjectPulse";
+import { Roadmap, useRoadmap } from "./Roadmap";
 import { RunEnvSection } from "./RunEnvSection";
 import { VerifySection } from "./VerifySection";
 
@@ -21,15 +22,20 @@ interface Loaded {
 }
 
 /** Full-screen project page. Rendered in place of the workspace panes while
- *  `projectScreenRepoPath` is set (mirrors SettingsScreen). One scrollable
- *  page: activity pulse + per-project settings every agent in the project
- *  inherits. Keyed by the project's primary repo path; resolves the
- *  project_id and detected run config on open. */
+ *  `projectScreenRepoPath` is set (mirrors SettingsScreen). Two tabs under a
+ *  shared header: the Roadmap (what gets built) and Settings — the activity
+ *  pulse plus the per-project config every agent in the project inherits.
+ *  Keyed by the project's primary repo path; resolves the project_id and
+ *  detected run config on open. */
 export function ProjectScreen({ repoPath }: { repoPath: string }) {
   const close = useAppStore((s) => s.closeProjectScreen);
   const projects = useAppStore((s) => s.workspace?.projects);
+  const [tab, setTab] = useState<ProjectTab>("roadmap");
   const [loaded, setLoaded] = useState<Loaded | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Lives here, not in <Roadmap>, because the header shows the same counts —
+  // and they move when the user accepts a proposal.
+  const roadmap = useRoadmap();
 
   // Custom display name for this repo, falling back to the folder basename.
   const name = projects?.find((p) => p.path === repoPath)?.name ?? basename(repoPath);
@@ -71,43 +77,43 @@ export function ProjectScreen({ repoPath }: { repoPath: string }) {
 
   return (
     <div className="proj-screen">
-      <div className="ps-head">
-        <button type="button" className="ps-back flex-center text-base" onClick={close}>
-          <Icon name="chevL" size={13} />
-          <span>Back to app</span>
-        </button>
-        <div className="ps-id">
-          <div className="ps-title text-lg truncate">{name}</div>
-          <div className="ps-path mono text-xs truncate">
-            {projectRepoCount > 1 ? `${projectRepoCount} repositories` : repoPath}
-          </div>
-        </div>
-      </div>
+      <ProjectHeader
+        name={name}
+        subtitle={projectRepoCount > 1 ? `${projectRepoCount} repositories` : repoPath}
+        roadmap={roadmap}
+        tab={tab}
+        onTab={setTab}
+        onClose={close}
+      />
 
-      <div className="ps-content">
-        {error ? (
-          <div className="ps-state text-sm">Couldn’t load project settings.</div>
-        ) : !loaded ? (
-          <div className="ps-state iflex-center text-sm">
-            <Loader variant="inherit" /> Loading…
-          </div>
-        ) : (
-          <div className="ps-sections">
-            <ProjectPulse projectId={loaded.projectId} />
-            <GeneralSection projectId={loaded.projectId} currentName={name} />
-            <RunEnvSection
-              projectId={loaded.projectId}
-              rows={loaded.rows}
-              ecosystem={loaded.ecosystem}
-              initialOverrides={loaded.overrides}
-            />
-            <EnvVarsSection projectId={loaded.projectId} repoPath={repoPath} />
-            <LinearSection projectId={loaded.projectId} />
-            <VerifySection projectId={loaded.projectId} />
-            <DeleteSection projectId={loaded.projectId} projectName={name} />
-          </div>
-        )}
-      </div>
+      {tab === "roadmap" ? (
+        <Roadmap roadmap={roadmap} />
+      ) : (
+        <div className="ps-content">
+          {error ? (
+            <div className="ps-state text-sm">Couldn’t load project settings.</div>
+          ) : !loaded ? (
+            <div className="ps-state iflex-center text-sm">
+              <Loader variant="inherit" /> Loading…
+            </div>
+          ) : (
+            <div className="ps-sections">
+              <ProjectPulse projectId={loaded.projectId} />
+              <GeneralSection projectId={loaded.projectId} currentName={name} />
+              <RunEnvSection
+                projectId={loaded.projectId}
+                rows={loaded.rows}
+                ecosystem={loaded.ecosystem}
+                initialOverrides={loaded.overrides}
+              />
+              <EnvVarsSection projectId={loaded.projectId} repoPath={repoPath} />
+              <LinearSection projectId={loaded.projectId} />
+              <VerifySection projectId={loaded.projectId} />
+              <DeleteSection projectId={loaded.projectId} projectName={name} />
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/ProjectScreen/index.tsx
+++ b/src/components/ProjectScreen/index.tsx
@@ -8,7 +8,7 @@ import { DeleteSection } from "./DeleteSection";
 import { EnvVarsSection } from "./EnvVarsSection";
 import { GeneralSection } from "./GeneralSection";
 import { LinearSection } from "./LinearSection";
-import { ProjectHeader, type ProjectTab } from "./ProjectHeader";
+import { ProjectHeader } from "./ProjectHeader";
 import { ProjectPulse } from "./ProjectPulse";
 import { Roadmap, useRoadmap } from "./Roadmap";
 import { RunEnvSection } from "./RunEnvSection";
@@ -30,7 +30,11 @@ interface Loaded {
 export function ProjectScreen({ repoPath }: { repoPath: string }) {
   const close = useAppStore((s) => s.closeProjectScreen);
   const projects = useAppStore((s) => s.workspace?.projects);
-  const [tab, setTab] = useState<ProjectTab>("roadmap");
+  // The tab lives in the store so whoever opened the screen picks it — the
+  // sidebar's "Project settings" gear lands on Settings, the title-bar pill
+  // on the roadmap.
+  const tab = useAppStore((s) => s.projectScreenTab);
+  const setTab = useAppStore((s) => s.setProjectScreenTab);
   const [loaded, setLoaded] = useState<Loaded | null>(null);
   const [error, setError] = useState<string | null>(null);
   // Lives here, not in <Roadmap>, because the header shows the same counts —
@@ -87,7 +91,7 @@ export function ProjectScreen({ repoPath }: { repoPath: string }) {
       />
 
       {tab === "roadmap" ? (
-        <Roadmap roadmap={roadmap} />
+        <Roadmap roadmap={roadmap} repoPath={repoPath} />
       ) : (
         <div className="ps-content">
           {error ? (

--- a/src/components/Sidebar/ProjectGroup.tsx
+++ b/src/components/Sidebar/ProjectGroup.tsx
@@ -66,7 +66,9 @@ export function ProjectGroup({
 
   function onOpenSettings(e: React.MouseEvent) {
     e.stopPropagation();
-    openProjectScreen(repoPath);
+    // This button says "Project settings", so it opens that tab — the project
+    // page's default (the roadmap) is what the title-bar pill gets.
+    openProjectScreen(repoPath, "settings");
   }
 
   const dropClass = dropIndicator ? `drop-${dropIndicator}` : "";

--- a/src/store/drafts.ts
+++ b/src/store/drafts.ts
@@ -54,7 +54,12 @@ export interface DraftsSlice {
   lastRepoPath?: string;
 
   // drafts
-  createDraft: (repoPath: string) => Promise<void>;
+  /** Open a new draft on `repoPath`. `seedPrompt` prefills its composer (read
+   *  as the initial text on mount), so a caller that already knows what the
+   *  agent should do — a roadmap item, a template — lands the user ready to
+   *  launch rather than at an empty box. Resolves to the new draft's id, or
+   *  `null` if it couldn't be created (the error is already surfaced). */
+  createDraft: (repoPath: string, seedPrompt?: string) => Promise<string | null>;
   /** Start a draft from a Home-inbox issue (any tracker source): opens a new
    *  draft on the issue's repo, seeds the composer with the issue brief
    *  (title + body + url + a suggested branch), and tags it with the issue
@@ -118,7 +123,7 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
   },
 
   // ── drafts ─────────────────────────────────────────────────────────────────
-  createDraft: async (repoPath) => {
+  createDraft: async (repoPath, seedPrompt) => {
     const { drafts, newDraftProvider, newDraftModel, newDraftCustomAgentId, modelsByAgent } = get();
     // Name allocation is a backend call; if it fails there's no draft to
     // create. Surface it in the global error banner and bail rather than
@@ -129,7 +134,7 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
       name = await api.allocateDraftName(draftNames(drafts));
     } catch (e) {
       get().setLastError(`Couldn't start a new agent: ${String(e)}`);
-      return;
+      return null;
     }
     const selection = normalizeDraftSelection(newDraftProvider, newDraftModel, modelsByAgent);
     // Carry the sticky custom-agent pick onto the new draft, but only if it
@@ -146,12 +151,16 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
       customAgentId,
       base: await resolveBaseBranch(repoPath),
     };
+    // Seed before the draft is visible, so the composer reads it on mount
+    // (same ordering as startWorkFromIssue).
+    if (seedPrompt) get().setComposerDraft(draft.id, seedPrompt);
     set((s) => ({
       drafts: [draft, ...s.drafts],
       activeDraftId: draft.id,
       selectedAgentId: null,
     }));
     get().setLastRepoPath(repoPath);
+    return draft.id;
   },
 
   startWorkFromIssue: async (repoPath, issue) => {

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -12,6 +12,11 @@ import type { SliceCreator } from "./types";
  *  store can remember the last-open tab per agent without importing a component. */
 export type RightPanelTab = "code" | "git" | "run" | "term";
 
+/** Project page tabs — what gets built, and how the project is run. Kept here
+ *  (like `RightPanelTab`) so callers of `openProjectScreen` can pick the tab
+ *  without the store importing a component. */
+export type ProjectScreenTab = "roadmap" | "settings";
+
 export interface UiSlice {
   /** Quick-settings popover (gear / ⌘,). */
   settingsOpen: boolean;
@@ -44,10 +49,13 @@ export interface UiSlice {
   /** When in history mode, the archived agent whose chat preview is
    *  being shown. `null` = list view. */
   selectedHistoryAgentId: string | null;
-  /** Full-screen project page (settings + pulse). Replaces the workspace
+  /** Full-screen project page (roadmap + settings). Replaces the workspace
    *  panes while non-null, like the settings screen. Keyed by the project's
    *  primary repo path — the screen resolves the project_id on open. */
   projectScreenRepoPath: string | null;
+  /** Which tab of the project page is showing. Set by whoever opened the
+   *  screen, so a control labelled "Project settings" lands on Settings. */
+  projectScreenTab: ProjectScreenTab;
   leftCollapsed: boolean;
   rightCollapsed: boolean;
   /** Show the structured transcript rail beside the native view's terminal.
@@ -88,9 +96,11 @@ export interface UiSlice {
   closeOnboarding: () => void;
   toggleHistory: (open?: boolean) => void;
   selectHistoryAgent: (id: string | null) => void;
-  /** Open the full-screen project page for a sidebar repo group. */
-  openProjectScreen: (repoPath: string) => void;
+  /** Open the full-screen project page for a sidebar repo group, on `tab`
+   *  (default: the roadmap). */
+  openProjectScreen: (repoPath: string, tab?: ProjectScreenTab) => void;
   closeProjectScreen: () => void;
+  setProjectScreenTab: (tab: ProjectScreenTab) => void;
   toggleLeft: () => void;
   toggleRight: () => void;
   toggleTranscriptRail: () => void;
@@ -120,6 +130,7 @@ export const createUiSlice: SliceCreator<UiSlice> = (set, get) => ({
   historyOpen: false,
   selectedHistoryAgentId: null,
   projectScreenRepoPath: null,
+  projectScreenTab: "roadmap",
   leftCollapsed: false,
   rightCollapsed: false,
   transcriptRailOpen: true,
@@ -171,15 +182,17 @@ export const createUiSlice: SliceCreator<UiSlice> = (set, get) => ({
       return next ? { historyOpen: true } : { historyOpen: false, selectedHistoryAgentId: null };
     }),
   selectHistoryAgent: (id) => set({ selectedHistoryAgentId: id }),
-  openProjectScreen: (repoPath) =>
+  openProjectScreen: (repoPath, tab = "roadmap") =>
     set({
       projectScreenRepoPath: repoPath,
+      projectScreenTab: tab,
       // Same takeover rules as the settings screen: one full-screen surface
       // at a time, and a hidden run view shouldn't stay selected.
       settingsScreenOpen: false,
       selectedRunId: null,
     }),
   closeProjectScreen: () => set({ projectScreenRepoPath: null }),
+  setProjectScreenTab: (tab) => set({ projectScreenTab: tab }),
   toggleLeft: () =>
     set((s) => {
       const leftCollapsed = !s.leftCollapsed;


### PR DESCRIPTION
The project page only showed settings. This splits it into two tabs — **Roadmap** and **Settings** — under a shared header, and builds the Roadmap surface from the design prototype.

## Header

The back button is unchanged. The project identity now sits beside a right-aligned stat strip — **in flight / next / later / shipped** — over a tab row anchored on the header rule. No prose headline.

## Roadmap tab

A self-contained folder under `ProjectScreen/Roadmap/`: a conversation with the project's PM agent on the left, the board it maintains on the right.

```
Roadmap/
  index.tsx        assembles Thread + Board
  useRoadmap.ts    state machine (propose → ghost → commit)
  types.ts         RoadmapItem / MapDomain / PmMessage …
  mockData.ts      seed content
  Roadmap.css
  Board/  index.tsx · HorizonGroup · ItemCard · ProductMap
  Thread/ index.tsx · Message · Probe · Proposal · Composer
```

The PM never edits the board directly — it proposes, the board renders the proposal as ghost rows, and the user commits. That rule lives in `useRoadmap`, so both columns stay honest about what is real. State is lifted to `ProjectScreen` because the header shows the same counts, and they move when a proposal is accepted.

## Reuse over reimplementation

The prototype's chat vocabulary already exists in the app, so this wires to it rather than re-styling it:

| Prototype | Reused from the app |
|---|---|
| `.rm-m-user` / `.rm-m-text` | `.m-user` / `.m-agent` transcript skins |
| `.m-q` question card (~130 lines) | `QuestionCard`, via `UIQuestion`/`UIAnswer` |
| `.rm-m-probe` collapsible | `ToolRow` — a repo check *is* a tool call |
| `.rm-m-think` | `.writing` + `Loader` |
| composer + `.c-chip` + `.send` | the composer's own classes + `Chip` |
| item / proposal buttons | `Button` variants |
| header stats | `Stat` / `CountUp` |

Only genuinely new vocabulary is styled in `Roadmap.css` — board rows, horizon groups, ghost/landed states, the proposal card, the product map. No hardcoded sizes or colors: everything is on the `--fs-*` / `--r-*` / `--lh-*` and theme tokens, so it recolors with the palette and works in both themes.

## Data

`mockData.ts` is the only source — there is no roadmap table or API yet, and one is planned as a follow-up. The seed is deliberately diverse: every horizon, size, source (`pm`/`linear`/`github`) and status, plus an epic, a dependency chain, a live agent, a clarifying-question beat and a move/reorder proposal. That's so the shapes in `types.ts` can be turned into a schema without discovering missing columns later. Swapping the exports for loaders is the only change needed; nothing else in the folder reads it.

## Notes for review

- Board horizon labels read **In flight / Next / Later** (matching the header stats) rather than the prototype's *Now / Next / Later*.
- **Not visually verified** — the headless browser is unavailable in this environment, so this was built from the prototype's markup and CSS rather than a screenshot. Worth a look in the running app, particularly the header stat strip: it uses the app's inline `Stat` (value + label on one line) rather than the prototype's stacked big numbers, for consistency with the pulse stats on the Settings tab.

`tsc`, `biome`, `vite build` and the 750 existing tests all pass.