### PR TITLE
fix(mergeGate): don't claim merge-ready from mergeable with no CI status

### DIFF
--- a/src/mergeGate.test.ts
+++ b/src/mergeGate.test.ts
@@ -1,0 +1,111 @@
+// `mergeGate.ts` is the single classification of GitHub's merge gate that every
+// surface (status header, PR card, action bar) renders from. These tests pin the
+// one invariant those surfaces trust: `mergeAllowed` is true ONLY when the gate
+// positively opens — never inferred from the absence of a conflict, which says
+// nothing about CI.
+
+import { describe, expect, it } from "vitest";
+import type { Mergeable, MergeState } from "@/api";
+import { describeMergeGate } from "@/mergeGate";
+
+// No failing required checks unless a case says otherwise — the neutral context.
+const ctx = (mergeable: Mergeable, checksFailed = 0) => ({ checksFailed, mergeable });
+
+describe("describeMergeGate — real merge_state", () => {
+  it("opens the gate only on clean and unstable", () => {
+    // clean = green light; unstable = only non-required checks fail, still
+    // mergeable. Everything else is a closed gate.
+    expect(describeMergeGate("clean", ctx("mergeable"))).toMatchObject({
+      situation: "ready",
+      mergeAllowed: true,
+    });
+    expect(describeMergeGate("unstable", ctx("mergeable"))).toMatchObject({
+      situation: "mergeable-soft",
+      mergeAllowed: true,
+    });
+  });
+
+  it("keeps the gate closed for every blocking state", () => {
+    // `blocked` splits on failing required checks (agent-fixable) vs. a pure
+    // review gate, but both forbid merging.
+    expect(describeMergeGate("blocked", ctx("mergeable", 2))).toMatchObject({
+      situation: "checks-failing",
+      mergeAllowed: false,
+    });
+    expect(describeMergeGate("blocked", ctx("mergeable", 0))).toMatchObject({
+      situation: "review-required",
+      mergeAllowed: false,
+    });
+    expect(describeMergeGate("behind", ctx("mergeable"))).toMatchObject({
+      situation: "behind",
+      mergeAllowed: false,
+      needsUpdate: true,
+    });
+    expect(describeMergeGate("dirty", ctx("mergeable"))).toMatchObject({
+      situation: "conflicts",
+      mergeAllowed: false,
+      needsUpdate: true,
+    });
+    expect(describeMergeGate("draft", ctx("mergeable"))).toMatchObject({
+      situation: "draft",
+      mergeAllowed: false,
+    });
+  });
+
+  it("stays computing while GitHub is still resolving the gate", () => {
+    for (const s of ["unknown", "has_hooks"] as const) {
+      expect(describeMergeGate(s, ctx("mergeable"))).toMatchObject({
+        situation: "computing",
+        mergeAllowed: false,
+      });
+    }
+  });
+});
+
+describe("describeMergeGate — no checks data (mergeable-only fallback)", () => {
+  it("never claims merge-ready off a `mergeable` verdict with no CI knowledge", () => {
+    // The bug this pins: `merge_state === null` means zero check knowledge, so
+    // "no conflict" is NOT "safe to merge" — required checks could be failing or
+    // unrun. The surfaces still get the honest `no-conflicts` situation, but the
+    // gate stays shut.
+    const gate = describeMergeGate(null, ctx("mergeable"));
+    expect(gate).toEqual({
+      situation: "no-conflicts",
+      tone: "info",
+      mergeAllowed: false,
+      needsUpdate: false,
+    });
+  });
+
+  it("still reports a real conflict when GitHub actually reports one", () => {
+    expect(describeMergeGate(null, ctx("conflicting"))).toEqual({
+      situation: "conflicts",
+      tone: "attention",
+      mergeAllowed: false,
+      needsUpdate: true,
+    });
+  });
+
+  it("treats a not-yet-computed verdict as still computing, not as a conflict", () => {
+    // `unknown` is GitHub's "haven't computed it yet" (and every DB snapshot's
+    // value) — never a false "can't merge".
+    expect(describeMergeGate(null, ctx("unknown"))).toMatchObject({
+      situation: "computing",
+      mergeAllowed: false,
+    });
+  });
+
+  it("resolves the asymmetry: no `mergeable`-only path over-claims merge-readiness", () => {
+    // `unknown` merge_state, `null` + `mergeable: "unknown"`, and now `null` +
+    // `mergeable: "mergeable"` all agree: absent check data → `mergeAllowed`
+    // false. Only a positively-open real gate (clean/unstable) may open it.
+    const conservative: Array<[MergeState | null, Mergeable]> = [
+      ["unknown", "mergeable"],
+      [null, "unknown"],
+      [null, "mergeable"],
+    ];
+    for (const [state, mergeable] of conservative) {
+      expect(describeMergeGate(state, ctx(mergeable)).mergeAllowed).toBe(false);
+    }
+  });
+});

--- a/src/mergeGate.ts
+++ b/src/mergeGate.ts
@@ -20,7 +20,7 @@ export type MergeGateSituation =
   | "conflicts" // dirty — conflicts with base, update the branch
   | "draft" // draft — mark ready on GitHub before it can merge
   | "computing" // unknown/has_hooks, or no-checks + mergeable unknown — still resolving
-  | "no-conflicts"; // no checks data, `mergeable` says mergeable → no conflicts (not an all-clear)
+  | "no-conflicts"; // no checks data, `mergeable` says mergeable → no conflicts, but CI unknown → not merge-ready (never an all-clear)
 
 /** Shared severity. A subset of `StatusKind`/`HeaderKind` so every surface can
  *  derive its own tone class from one decision. */
@@ -92,10 +92,16 @@ export function describeMergeGate(
       // never a false "can't merge — update your branch".
       switch (mergeable) {
         case "mergeable":
+          // No conflict — but that says nothing about CI, and with no
+          // `merge_state` we have zero check knowledge. "No conflict" is not
+          // "safe to merge" (required checks could be failing or unrun), so this
+          // is deliberately NOT merge-ready: `mergeAllowed` stays false until a
+          // real gate confirms it. The surfaces still say "no conflicts" — an
+          // honest, not-an-all-clear signal — off the `no-conflicts` situation.
           return {
             situation: "no-conflicts",
             tone: "info",
-            mergeAllowed: true,
+            mergeAllowed: false,
             needsUpdate: false,
           };
         case "conflicting":

--- a/src/readiness.test.ts
+++ b/src/readiness.test.ts
@@ -312,6 +312,11 @@ describe("nextRung ordering", () => {
       do: "wait",
       why: "gate-computing",
     });
+    // No checks read, but `mergeable` says no conflict: that reports conflict
+    // presence only, NOT CI status, so it must NOT auto-merge off zero check
+    // knowledge — required checks could be failing or unrun. Nothing blocking,
+    // nothing merge-ready either → `ready`, for a human to decide.
+    expect(rung({ pr: pr({ mergeable: "mergeable" }) })).toEqual({ do: "ready" });
   });
 
   it("reports a landed proposal, and a clean local tree with nothing to do", () => {

--- a/src/readiness.ts
+++ b/src/readiness.ts
@@ -322,7 +322,10 @@ export function nextRung(input: ReadinessInput, ctx: LadderContext): Rung {
     mergeable: pr.mergeable,
   });
   if (gate.situation === "computing") return { do: "wait", why: "gate-computing" };
-  // Every gate that forbids merging has already surfaced as a blocker above, so
-  // this is a defensive total-function fallback, not an expected path.
+  // Nothing blocking, but merge is only offered when the gate positively opens.
+  // The one expected non-open path here is `no-conflicts` (no `merge_state`, so
+  // conflicts are absent but CI is unknown): not a blocker, yet not merge-ready
+  // either — fall to `ready` so a human decides rather than auto-merging blind.
+  // Every other merge-forbidding gate has already surfaced as a blocker above.
   return gate.mergeAllowed ? { do: "merge" } : { do: "ready" };
 }


### PR DESCRIPTION
## Summary

`describeMergeGate` claimed a PR was merge-ready (`mergeAllowed: true`) purely because GitHub's coarse `mergeable` tri-state said `"mergeable"`, even when no check data was available. That is an over-claim: `mergeable` reports **conflict presence only, never CI status**. This change makes the `mergeable`-only fallback conservative — "no conflict" is not "safe to merge".

## Root cause

In `src/mergeGate.ts`, the `merge_state === null` fallback branch for `mergeable === "mergeable"` returned:

```ts
{ situation: "no-conflicts", tone: "info", mergeAllowed: true, needsUpdate: false }
```

With `merge_state === null` there is **zero CI knowledge**, so a PR can be `mergeable: "mergeable"` while required checks are failing or haven't run. The module's own docs already describe `no-conflicts` as "not an all-clear", yet it asserted `mergeAllowed: true`.

This propagated:

- `src/readiness.ts` `nextRung` → `gate.mergeAllowed ? { do: "merge" } : …` → Mission Control's approve path (`useQueueActions.approveAgent`) and the Git-panel Merge button (`useActionBarModel`). On a repo without server-side required-check protection this genuinely merged an unverified PR; with protection the Merge button was enabled when it should be disabled (the click errors).

It was also an asymmetry: `merge_state === "unknown"` and `null + mergeable === "unknown"` both already yielded `computing` / `mergeAllowed: false`; only the `null + "mergeable"` branch over-claimed.

## Fix

- The `no-conflicts` situation now returns `mergeAllowed: false`. Conflicts are known absent, but CI is unknown, so merge is not offered until a real gate confirms it. The surfaces (status header, PR card) still render their honest "no conflicts" copy off the unchanged `situation`/`tone`.
- `readiness.ts` `nextRung` now falls to `{ do: "ready" }` (a human decides) instead of `{ do: "merge" }` for this state; comment updated to reflect that `no-conflicts` is now an expected non-open path.
- Preserved: `mergeable === "conflicting"` still reports conflicts; a real `merge_state` (clean/unstable/blocked/behind/dirty/draft/unknown/has_hooks) is unaffected. Autopilot never auto-merged (both `merge` and `ready` map to `wait`), so it is unchanged.

## Tests

- New `src/mergeGate.test.ts`: pins that `null + "mergeable"` yields `mergeAllowed: false` (`no-conflicts`), that conflicts and real merge states behave as before, and that no `mergeable`-only path over-claims.
- `src/readiness.test.ts`: added a `nextRung` assertion that `null + "mergeable"` resolves to `{ do: "ready" }`, not `{ do: "merge" }`.
- Full suite green (757 tests), `tsc --noEmit` clean, biome clean.