### PR TITLE
Fix Codex turn details disappearing after completion

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -32,9 +32,9 @@ pub fn sync_session(supervisor: State<'_, Arc<Supervisor>>, agent_id: String) ->
 }
 
 /// Persist a runtime-compiled record (`source = 'live_compiled'`) the frontend
-/// holds but the on-disk transcript lacks — currently cursor's per-turn token
-/// usage, which it emits only on its live `result` event. Idempotent on
-/// `native_id` (use the event's `request_id`), so re-sending a turn is a no-op.
+/// holds but the on-disk transcript lacks — for example live-only usage and
+/// readable Codex reasoning (the rollout stores only encrypted text). Idempotent
+/// on `native_id`, so re-sending a turn is a no-op.
 /// Returns whether a new row was inserted.
 #[tauri::command]
 pub fn append_live_record(

--- a/src/adapters/codex/normalize.ts
+++ b/src/adapters/codex/normalize.ts
@@ -9,7 +9,7 @@
 //
 // We take the conversational backbone (user/agent text, turn end) from the
 // clean `event_msg` channel, and tool activity from `response_item`
-// function calls (which cover both shell `exec_command` and MCP calls).
+// function/custom-tool calls (which cover shell, MCP, and app tools).
 // `response_item` user/assistant messages are skipped — they duplicate the
 // event_msg ones and carry injected noise (AGENTS.md, permissions blurb).
 
@@ -27,18 +27,59 @@ function parseArgs(v: unknown): unknown {
   return v ?? {};
 }
 
+/** Flatten Codex's persisted output shapes. Legacy function calls store a
+ * string; current custom tools store Responses-style input_text blocks. */
+function outputText(v: unknown): string {
+  if (typeof v === "string") return v;
+  if (Array.isArray(v)) {
+    return v
+      .map((block) => {
+        const rec = asRecord(block);
+        return typeof rec.text === "string" ? rec.text : "";
+      })
+      .join("");
+  }
+  return v == null ? "" : JSON.stringify(v);
+}
+
+function reasoningSummary(v: unknown): string {
+  if (!Array.isArray(v)) return "";
+  return v
+    .map((part) => {
+      const rec = asRecord(part);
+      return typeof rec.text === "string" ? rec.text : "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
 export function normalizeTranscript(lines: unknown[]): RawEvent[] {
-  // Pre-pass: a tool call's output lands on a later `function_call_output`
-  // line, so index outputs by call_id first.
+  // Pre-pass: a tool call's output lands on a later function/custom-tool
+  // output line, so index outputs by call_id first.
   const outputs = new Map<string, string>();
+  // The rollout encrypts reasoning and often persists no readable summary.
+  // Fletch therefore stores the completed live event alongside the rollout;
+  // index that text here and place it at the matching response_item below.
+  const liveReasoning = new Map<string, string>();
   for (const raw of lines) {
     const env = asRecord(raw);
+    if (env.type === "item.completed") {
+      const item = asRecord(env.item);
+      if (
+        item.type === "reasoning" &&
+        typeof item.id === "string" &&
+        typeof item.text === "string"
+      ) {
+        liveReasoning.set(item.id, item.text);
+      }
+      continue;
+    }
     if (env.type !== "response_item") continue;
     const p = asRecord(env.payload);
-    if (p.type === "function_call_output") {
+    if (p.type === "function_call_output" || p.type === "custom_tool_call_output") {
       const id = String(p.call_id ?? "");
       if (id) {
-        outputs.set(id, typeof p.output === "string" ? p.output : JSON.stringify(p.output ?? ""));
+        outputs.set(id, outputText(p.output));
       }
     }
   }
@@ -77,12 +118,24 @@ export function normalizeTranscript(lines: unknown[]): RawEvent[] {
       continue;
     }
 
-    if (env.type === "response_item" && ptype === "function_call") {
+    if (env.type === "response_item" && ptype === "reasoning") {
+      const id = String(p.id ?? "");
+      const text = liveReasoning.get(id) ?? reasoningSummary(p.summary);
+      if (id && text) {
+        out.push({ type: "item.completed", item: { id, type: "reasoning", text } });
+      }
+      continue;
+    }
+
+    if (
+      env.type === "response_item" &&
+      (ptype === "function_call" || ptype === "custom_tool_call")
+    ) {
       const id = String(p.call_id ?? "");
       if (!id) continue;
       const name = typeof p.name === "string" ? p.name : "";
       const namespace = typeof p.namespace === "string" ? p.namespace : "";
-      const args = parseArgs(p.arguments);
+      const args = parseArgs(ptype === "custom_tool_call" ? p.input : p.arguments);
       const output = outputs.get(id) ?? "";
 
       const argRec = asRecord(args);

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -6,10 +6,12 @@
 //   - commands:     slash-command / skill-invocation resolution
 //   - transcript:   session-record → chat-item reduction and log rebuild
 //   - usage:        live-usage persistence into session_records
+//   - reasoning:    readable Codex reasoning persistence for transcript replay
 //   - spawn:        spawn-payload snapshots + the send-when-ready retry util
 
 export * from "./agentLookups";
 export * from "./commands";
+export * from "./reasoning";
 export * from "./spawn";
 export * from "./transcript";
 export * from "./usage";

--- a/src/helpers/reasoning.ts
+++ b/src/helpers/reasoning.ts
@@ -1,0 +1,35 @@
+// Codex persists reasoning encrypted in its rollout, so the readable text from
+// the live item.completed event has to be stored separately for transcript
+// replay. The rollout's matching reasoning item supplies its canonical order.
+
+import type { RawEvent } from "../adapters";
+import { api } from "../api";
+import type { AppState } from "../store";
+import { providerFor } from "./agentLookups";
+
+export async function persistLiveReasoning(
+  get: () => AppState,
+  agentId: string,
+  rawEvent: RawEvent,
+): Promise<void> {
+  if (providerFor(get(), agentId) !== "codex" || rawEvent.type !== "item.completed") return;
+  const item =
+    rawEvent.item && typeof rawEvent.item === "object" && !Array.isArray(rawEvent.item)
+      ? (rawEvent.item as Record<string, unknown>)
+      : undefined;
+  if (
+    item?.type !== "reasoning" ||
+    typeof item.id !== "string" ||
+    typeof item.text !== "string" ||
+    !item.text
+  ) {
+    return;
+  }
+
+  try {
+    await api.appendLiveRecord(agentId, "codex", `reasoning:${item.id}`, rawEvent);
+  } catch {
+    // Non-critical: carryForwardStoreOnly keeps the live text for this app
+    // session even if durable persistence is temporarily unavailable.
+  }
+}

--- a/src/helpers/transcript.ts
+++ b/src/helpers/transcript.ts
@@ -96,19 +96,29 @@ export function applyUserTurns(items: ChatItem[], turns: UserTurn[]): ChatItem[]
 }
 
 /** Locate a `prev` item within the freshly-rebuilt transcript so a carried-over
- *  follow-up can be re-anchored next to it. Scans forward from `from` and
+ *  store-only item can be re-anchored next to it. Scans forward from `from` and
  *  returns the FIRST match, so callers advancing `from` in step with a forward
  *  walk through `prev` get a monotonically-advancing anchor: duplicate text
  *  (e.g. repeated "OK" acknowledgements) then resolves to the occurrence at this
  *  point in the turn rather than the last one in the log. Tool calls match on
- *  their stable id; user/agent messages on exact text; other kinds aren't
- *  reliable anchors. Returns -1 when not found at or after `from`. */
+ *  their stable id; user/agent messages and reasoning on exact text; other
+ *  kinds aren't reliable anchors. Returns -1 when not found at or after `from`. */
 function locateAnchor(rebuilt: ChatItem[], item: ChatItem, from: number): number {
-  if (item.kind !== "tool_call" && item.kind !== "user_message" && item.kind !== "agent_message") {
+  const isReasoning = item.kind === "notice" && item.subtype === "reasoning";
+  if (
+    item.kind !== "tool_call" &&
+    item.kind !== "user_message" &&
+    item.kind !== "agent_message" &&
+    !isReasoning
+  ) {
     return -1;
   }
   const textOf = (r: ChatItem): string | undefined =>
-    r.kind === "user_message" || r.kind === "agent_message" ? r.text : undefined;
+    r.kind === "user_message" ||
+    r.kind === "agent_message" ||
+    (r.kind === "notice" && r.subtype === "reasoning")
+      ? r.text
+      : undefined;
   for (let i = Math.max(from, 0); i < rebuilt.length; i += 1) {
     const r = rebuilt[i];
     if (item.kind === "tool_call") {
@@ -120,7 +130,8 @@ function locateAnchor(rebuilt: ChatItem[], item: ChatItem, from: number): number
   return -1;
 }
 
-/** Carry forward store-only items — optimistic mid-turn follow-ups
+/** Carry forward store-only items — optimistic mid-turn follow-ups,
+ *  readable Codex reasoning awaiting its durable compiled-record write,
  *  (`queued_message`) and user-invoked command output (`command_output`
  *  notices: `/doctor`, `/cost`, a blocked-command explanation) — onto a log
  *  just rebuilt from canonical records. Neither ever lands in the transcript,
@@ -170,6 +181,12 @@ export function carryForwardStoreOnly(rebuilt: ChatItem[], prev: ChatItem[]): Ch
     } else if (it.kind === "notice" && it.subtype === "command_output") {
       // Command output lives only in the store — always re-insert it.
       carry(it);
+    } else if (it.kind === "notice" && it.subtype === "reasoning") {
+      // A persisted compiled reasoning record may already have restored it. If
+      // not, keep the live row in place while that asynchronous write settles.
+      const idx = locateAnchor(rebuilt, it, anchor + 1);
+      if (idx >= 0) anchor = idx;
+      else carry(it);
     } else {
       const idx = locateAnchor(rebuilt, it, anchor + 1);
       if (idx >= 0) anchor = idx;

--- a/src/store/eventListeners.ts
+++ b/src/store/eventListeners.ts
@@ -36,6 +36,7 @@ import {
   applyUserTurns,
   carryForwardStoreOnly,
   needsSessionIdRefresh,
+  persistLiveReasoning,
   persistLiveUsage,
   providerFor,
   reduceRecords,
@@ -241,6 +242,9 @@ export const registerEventListeners = async (set: AppSet, get: AppGet) => {
     // Capture usage that lives only on the live stream (cursor) into
     // session_records so it folds like every other agent (see persistLiveUsage).
     void persistLiveUsage(get, set, e.agent_id, e.event as RawEvent);
+    // Codex rollout files encrypt reasoning text, so retain the readable live
+    // event as a compiled record and merge it back at its rollout item on replay.
+    void persistLiveReasoning(get, e.agent_id, e.event as RawEvent);
     // A turn can't end with prompts still held — clear any stale entries
     // (e.g. an interrupt that denied a pending question).
     if (turnEnded && get().pendingToolUse[e.agent_id]) {

--- a/tests/adapters/codex/reduce.test.ts
+++ b/tests/adapters/codex/reduce.test.ts
@@ -186,7 +186,67 @@ describe("codexAdapter", () => {
     expect(call).toMatchObject({ name: "apply_patch", input: { patch: "diff..." } });
   });
 
-  it("drops injected noise (response_item user/developer messages, reasoning)", () => {
+  it("replays current custom tool calls and block-array outputs", () => {
+    const events = codexAdapter.normalizeTranscript([
+      {
+        type: "response_item",
+        payload: {
+          type: "custom_tool_call",
+          id: "ctc_1",
+          call_id: "call_1",
+          name: "exec",
+          input: "text('hello')",
+          status: "completed",
+        },
+      },
+      {
+        type: "response_item",
+        payload: {
+          type: "custom_tool_call_output",
+          call_id: "call_1",
+          output: [
+            { type: "input_text", text: "Script completed\n" },
+            { type: "input_text", text: "Output:\nhello\n" },
+          ],
+        },
+      },
+    ]);
+    expect(run(events)).toEqual([
+      {
+        kind: "tool_call",
+        id: "call_1",
+        name: "exec",
+        input: "text('hello')",
+        streaming: false,
+      },
+      {
+        kind: "tool_result",
+        tool_use_id: "call_1",
+        content: "Script completed\nOutput:\nhello\n",
+        is_error: false,
+      },
+    ]);
+  });
+
+  it("merges readable live reasoning into its encrypted rollout position", () => {
+    const events = codexAdapter.normalizeTranscript([
+      {
+        type: "item.completed",
+        item: { id: "rs_1", type: "reasoning", text: "Inspect the transcript handoff." },
+      },
+      {
+        type: "response_item",
+        payload: { type: "reasoning", id: "rs_1", summary: [], encrypted_content: "opaque" },
+      },
+      { type: "event_msg", payload: { type: "agent_message", message: "Found it." } },
+    ]);
+    expect(run(events)).toEqual([
+      { kind: "notice", subtype: "reasoning", text: "Inspect the transcript handoff." },
+      { kind: "agent_message", text: "Found it.", model: undefined },
+    ]);
+  });
+
+  it("drops injected messages and encrypted reasoning with no readable text", () => {
     const lines = readJsonl("rollout.jsonl");
     const events = codexAdapter.normalizeTranscript(lines);
     // Only the clean event_msg user prompt survives, not the AGENTS.md /

--- a/tests/helpers/queued.test.ts
+++ b/tests/helpers/queued.test.ts
@@ -14,6 +14,7 @@ const cmdOut = (label: string, text: string): ChatItem => ({
   label,
   text,
 });
+const reasoning = (text: string): ChatItem => ({ kind: "notice", subtype: "reasoning", text });
 
 describe("carryForwardStoreOnly", () => {
   it("keeps an undelivered follow-up the transcript hasn't caught up to", () => {
@@ -71,6 +72,22 @@ describe("carryForwardStoreOnly", () => {
     const prev = [...rebuilt, cmdOut("/doctor", "all good")];
     const out = carryForwardStoreOnly(rebuilt, prev);
     expect(out).toEqual([...rebuilt, cmdOut("/doctor", "all good")]);
+  });
+
+  it("keeps live reasoning in place while its compiled record is persisted", () => {
+    const rebuilt = [userMsg("start"), toolCall("t1"), agentMsg("done")];
+    const prev = [userMsg("start"), reasoning("inspect"), toolCall("t1"), agentMsg("done")];
+    expect(carryForwardStoreOnly(rebuilt, prev)).toEqual([
+      userMsg("start"),
+      reasoning("inspect"),
+      toolCall("t1"),
+      agentMsg("done"),
+    ]);
+  });
+
+  it("does not duplicate reasoning already restored from compiled records", () => {
+    const rebuilt = [userMsg("start"), reasoning("inspect"), agentMsg("done")];
+    expect(carryForwardStoreOnly(rebuilt, rebuilt)).toEqual(rebuilt);
   });
 
   it("keeps command output at its injection point, not the end", () => {


### PR DESCRIPTION
## Summary
- replay current Codex custom tool calls and block-array outputs from persisted rollout records
- persist readable live reasoning and merge it back at its canonical rollout position
- carry reasoning across the turn-end rebuild race without duplicates

## Verification
- `bun run test` (761 tests)
- `bun run check`
- Biome check on changed TypeScript files