### PR TITLE
fix(caps): confine force pushes to the agent's own branch

### DIFF
--- a/docs/isolation.md
+++ b/docs/isolation.md
@@ -185,8 +185,18 @@ later policy change can't widen an agent already running (`rpc/caps.rs`):
 - **No agent can push the branch its work is reviewed against**, nor a
   conventional trunk (`main`, `master`) whatever a repo declares as its base.
   Before this grant existed `git_push` validated nothing, so an agent sitting on
-  the base pushed straight onto it — and `args.force` made that a lease-guarded
-  force-push.
+  the base pushed straight onto it.
+- **No agent can *force*-push a branch other than its own.** A
+  `--force-with-lease` push rewrites remote history, and the lease passes for any
+  branch the agent just fetched — so with only the rule above (which fences the
+  review base and the trunks, nothing else) an agent could fetch a shared branch
+  (`develop`, a `release/*`, a teammate's), `checkout -B` its HEAD onto it, and
+  force-overwrite it under your identity. Force is therefore confined to the
+  agent's own recorded work branch (`AgentRecord.repos[].branch`) — the
+  spawn-stable name it cannot repoint the way it can its live `HEAD`. Until that
+  branch has been recorded (a fresh checkout that hasn't materialized one yet),
+  force fails **closed**; a non-force push is unaffected and may still create a
+  branch (`rpc/caps.rs`, `refuses_force`).
 - **A workflow step agent cannot publish at all.** A run publishes through its
   own `wf/`-guarded finalize; a step publishing directly would bypass that guard.
 

--- a/src-tauri/src/rpc/caps.rs
+++ b/src-tauri/src/rpc/caps.rs
@@ -11,10 +11,13 @@
 //! re-read — the discipline [`crate::sandbox::EngineKind`] uses, so changing
 //! policy later cannot retroactively widen an agent that is already running.
 //!
-//! Two checks, at the two points where the answer is knowable: [`AgentCaps::refuses`]
-//! before any work happens, and [`AgentCaps::refuses_branch`] once the target
-//! branch has been resolved, which is the earliest moment it is known (it may
-//! come from the checkout's HEAD rather than from the request).
+//! Three checks, at the points where the answer is knowable: [`AgentCaps::refuses`]
+//! before any work happens; [`AgentCaps::refuses_branch`] once the target branch
+//! has been resolved, which is the earliest moment it is known (it may come from
+//! the checkout's HEAD rather than from the request); and [`AgentCaps::refuses_force`]
+//! for the destructive case — a `--force-with-lease` push, whose lease passes for
+//! any branch the agent just fetched, so it is fenced to the agent's *own* work
+//! branch rather than any branch it can repoint its HEAD onto.
 
 /// Ops that spend the host's GitHub credentials to *publish*. `git_fetch` is
 /// credentialed too but reads only, so it is deliberately not gated here — a
@@ -93,6 +96,49 @@ impl AgentCaps {
             )
         })
     }
+
+    /// Why a *force* push to `branch` may not proceed, if so.
+    ///
+    /// SECURITY: a `--force-with-lease --force-if-includes` push rewrites remote
+    /// history, and its lease passes for any branch the agent just fetched — so
+    /// without this gate an agent can fetch a shared branch (`develop`, a
+    /// `release/*`, a teammate's), `checkout -B` its HEAD onto it locally, and
+    /// force-overwrite it under the user's GitHub identity. [`refuses_branch`]
+    /// only fences the review base and the trunks; every *other* existing branch
+    /// is force-clobberable once fetched. So force is confined to the agent's
+    /// **own** work branch — `own_branch`, the name the host recorded when it
+    /// materialized the branch (`AgentRecord.repos[].branch`), which, unlike the
+    /// live `HEAD` the agent repoints at will, the agent cannot forge. `None`
+    /// (no branch recorded yet, or a checkout that never materialized one) fails
+    /// **closed**: the destructive op is refused rather than risked. A non-force
+    /// push never reaches here and may still create a branch.
+    ///
+    /// [`refuses_branch`]: AgentCaps::refuses_branch
+    pub fn refuses_force(self, branch: &str, own_branch: Option<&str>) -> Option<String> {
+        // A denied grant never reaches git at all (the op gate stops it), but the
+        // branch/force gates re-check it so no single call site can leak one.
+        if let Publish::Denied(why) = self.publish {
+            return Some(why.to_string());
+        }
+        // Compared as `is_review_target` compares: trimmed and case-insensitive,
+        // because the app's target is a case-insensitive filesystem where `Fix/X`
+        // and `fix/x` name the same loose ref.
+        let same = |a: &str, b: &str| a.trim().eq_ignore_ascii_case(b.trim());
+        match own_branch.map(str::trim).filter(|s| !s.is_empty()) {
+            Some(own) if same(branch, own) => None,
+            Some(own) => Some(format!(
+                "refusing to force-push '{}': force is limited to this agent's own branch \
+                 '{own}'. Push without --force to create or update a different branch",
+                branch.trim()
+            )),
+            None => Some(format!(
+                "refusing to force-push '{}': this agent has no recorded work branch to \
+                 authorize a force against yet. Push without --force first (e.g. to open \
+                 your pull request); force becomes available for that branch afterward",
+                branch.trim()
+            )),
+        }
+    }
 }
 
 /// Whether `branch` is something no agent may publish to: the repo's own review
@@ -166,8 +212,37 @@ mod tests {
         }
         // Reads stay reachable: `update-branch` refreshes the base this way.
         assert!(caps.refuses("git_fetch").is_none());
-        // And the branch-level check agrees, so neither call site can let a
-        // denied grant through on its own.
+        // And the branch-level checks agree, so no call site can let a denied
+        // grant through on its own — force included.
         assert!(caps.refuses_branch("wf/anything", "main").is_some());
+        assert!(caps
+            .refuses_force("wf/anything", Some("wf/anything"))
+            .is_some());
+    }
+
+    /// The gap this closes: `refuses_branch` fences the review base and the
+    /// trunks, but a force push could still overwrite any *other* existing branch
+    /// (develop, release/*, a teammate's) once fetched. Force is now confined to
+    /// the agent's own recorded branch.
+    #[test]
+    fn force_is_confined_to_the_agents_own_branch() {
+        let caps = AgentCaps::interactive();
+        // The whole reason force exists: rewrite your own branch after a rebase.
+        assert!(caps.refuses_force("fix/login", Some("fix/login")).is_none());
+        // Case and whitespace fold to the same ref on the case-insensitive target.
+        assert!(caps
+            .refuses_force(" Fix/Login ", Some("fix/login"))
+            .is_none());
+        // A shared branch the agent fetched and repointed HEAD onto — refused,
+        // even though `refuses_branch` alone would wave `develop` through.
+        for other in ["develop", "release/24", "teammate/wip", "main"] {
+            assert!(
+                caps.refuses_force(other, Some("fix/login")).is_some(),
+                "{other:?} is not the agent's own branch and must not be force-pushed"
+            );
+        }
+        // Fail closed: with no recorded own branch, no force can be authorized.
+        assert!(caps.refuses_force("fix/login", None).is_some());
+        assert!(caps.refuses_force("develop", None).is_some());
     }
 }

--- a/src-tauri/src/rpc/git.rs
+++ b/src-tauri/src/rpc/git.rs
@@ -56,6 +56,12 @@ struct Target {
     subdir: Option<String>,
     cwd: PathBuf,
     base_branch: String,
+    /// The agent's own work branch for this checkout, as the host recorded it
+    /// when the branch was materialized (`AgentRecord.repos[].branch`). The
+    /// spawn-stable anchor [`AgentCaps::refuses_force`] authorizes a force push
+    /// against — `None` until a branch has been recorded and the dispatcher
+    /// rebuilt (resume / next turn), which fails a force closed.
+    own_branch: Option<String>,
 }
 
 #[derive(Clone)]
@@ -67,11 +73,18 @@ pub struct GitDispatcher {
     /// The default checkout's subdir, resolved from `repos` by matching `cwd`.
     /// Stamped into events for defaulted ops.
     default_subdir: Option<String>,
+    /// The agent's own work branch on the *default* checkout, threaded from the
+    /// record at spawn (`AgentRecord.repos[].branch`) exactly as `base_branch` is
+    /// — the spawn-stable anchor the force-push gate authorizes against. `None`
+    /// until the host has recorded a materialized branch and this dispatcher has
+    /// been rebuilt to carry it, which fails a force closed (see
+    /// [`crate::rpc::caps::AgentCaps::refuses_force`]).
+    own_branch: Option<String>,
     /// Sibling checkouts by subdir (directory name under the workspace root),
-    /// each with its own base branch. Includes the primary. Empty for
-    /// dispatchers built without `with_repos` (tests, old call sites) — then
-    /// `args.repo` is rejected as unknown.
-    repos: std::collections::HashMap<String, (PathBuf, String)>,
+    /// each with its own base branch and own recorded work branch. Includes the
+    /// primary. Empty for dispatchers built without `with_repos` (tests, old call
+    /// sites) — then `args.repo` is rejected as unknown.
+    repos: std::collections::HashMap<String, (PathBuf, String, Option<String>)>,
     /// Agent whose *live* issue ref (`crate::issues::live_issue_ref`) drives
     /// `open_pr`'s closing trailer — `"123"` for a GitHub issue, `"ENG-123"`
     /// for a Linear ticket. Resolved at open_pr time, not construction, so a
@@ -100,11 +113,22 @@ impl GitDispatcher {
             cwd,
             base_branch,
             default_subdir: None,
+            own_branch: None,
             repos: std::collections::HashMap::new(),
             issue_agent: None,
             caps,
             approval: None,
         }
+    }
+
+    /// Record the agent's own work branch for the *primary* checkout, the anchor
+    /// the force-push gate authorizes against. `with_repos` already derives this
+    /// for the primary from its entry, which is the production path; this exists
+    /// for single-checkout test call sites that don't build a repo table.
+    #[cfg(test)]
+    pub fn with_own_branch(mut self, branch: Option<String>) -> Self {
+        self.own_branch = branch;
+        self
     }
 
     /// Bind this dispatcher to the window it can ask for publish approval through.
@@ -155,18 +179,19 @@ impl GitDispatcher {
         self
     }
 
-    /// Register the agent's tracked checkouts as `(subdir, cwd, base_branch)`
-    /// so ops can be pointed at any of them via `args.repo`.
-    pub fn with_repos(mut self, repos: Vec<(String, PathBuf, String)>) -> Self {
+    /// Register the agent's tracked checkouts as `(subdir, cwd, base_branch,
+    /// own_branch)` so ops can be pointed at any of them via `args.repo`.
+    /// `own_branch` is the record's recorded work branch for that checkout, the
+    /// force-push anchor; the primary's is lifted onto `self.own_branch` here so
+    /// a defaulted op (no `args.repo`) resolves it too.
+    pub fn with_repos(mut self, repos: Vec<(String, PathBuf, String, Option<String>)>) -> Self {
         self.repos = repos
             .into_iter()
-            .map(|(subdir, cwd, base)| (subdir, (cwd, base)))
+            .map(|(subdir, cwd, base, own)| (subdir, (cwd, base, own)))
             .collect();
-        self.default_subdir = self
-            .repos
-            .iter()
-            .find(|(_, (cwd, _))| *cwd == self.cwd)
-            .map(|(subdir, _)| subdir.clone());
+        let primary = self.repos.iter().find(|(_, (cwd, _, _))| *cwd == self.cwd);
+        self.default_subdir = primary.map(|(subdir, _)| subdir.clone());
+        self.own_branch = primary.and_then(|(_, (_, _, own))| own.clone());
         self
     }
 
@@ -185,12 +210,14 @@ impl GitDispatcher {
                 subdir: self.default_subdir.clone(),
                 cwd: self.cwd.clone(),
                 base_branch: self.base_branch.clone(),
+                own_branch: self.own_branch.clone(),
             }),
             Some(name) => match self.repos.get(name) {
-                Some((cwd, base)) => Ok(Target {
+                Some((cwd, base, own)) => Ok(Target {
                     subdir: Some(name.to_string()),
                     cwd: cwd.clone(),
                     base_branch: base.clone(),
+                    own_branch: own.clone(),
                 }),
                 None => {
                     let mut known: Vec<&str> = self.repos.keys().map(String::as_str).collect();
@@ -515,6 +542,19 @@ impl GitDispatcher {
         // history (e.g. after the agent rebased its branch). Lease-based so a
         // stale local view can't clobber remote work it hasn't seen.
         let force = arg_bool(args, "force");
+        // SECURITY: the lease alone is not enough. It passes for any branch the
+        // agent just fetched, so an agent can fetch a shared branch (`develop`, a
+        // teammate's), `checkout -B` its HEAD onto it, and force-overwrite it —
+        // `refuses_branch` fences only the review base and the trunks. `branch`
+        // here came from that mutable HEAD, so a force is authorized against the
+        // spawn-stable *own* branch (`t.own_branch`) instead, failing closed when
+        // none is recorded yet. A non-force push is untouched (it can still create
+        // a branch); this only gates the destructive rewrite.
+        if force {
+            if let Some(why) = self.caps.refuses_force(&branch, t.own_branch.as_deref()) {
+                return (Response::err(id, why), effects);
+            }
+        }
         match crate::git::push(&cwd, &branch, force).await {
             Ok(summary) => (Response::ok(id, 0, summary, String::new()), effects),
             Err(e) => (Response::err(id, e.to_string()), effects),
@@ -1025,7 +1065,9 @@ mod tests {
         let rpc_dir = td.path().join("rpc");
         ensure_mailbox(&rpc_dir).unwrap();
         let requests = rpc_dir.join("requests");
-        let dispatcher = dispatcher(&repo);
+        // `fix/diverged` is this agent's own recorded branch, so the force-push
+        // gate authorizes rewriting it after the rebase below.
+        let dispatcher = dispatcher(&repo).with_own_branch(Some("fix/diverged".to_string()));
 
         // First push seeds the remote branch.
         write_request(&requests, "p1.json", r#"{"id":"p1","op":"git_push"}"#);
@@ -1076,6 +1118,91 @@ mod tests {
             String::from_utf8_lossy(&local.stdout).trim(),
             String::from_utf8_lossy(&remote_head.stdout).trim(),
             "the remote branch should match the rewritten local HEAD"
+        );
+    }
+
+    /// The gap this closes: an agent owns `fix/mine`, but fetches a shared branch
+    /// and `checkout -B`s its HEAD onto it, then force-pushes. `refuses_branch`
+    /// waves `develop` through (not the review base), so only the force gate stops
+    /// the destructive overwrite — before any git runs, like the option-name gate.
+    #[tokio::test]
+    async fn git_push_force_refuses_a_branch_the_agent_does_not_own() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        run_git(&repo, &["init", "-q", "-b", "main"]);
+        run_git(&repo, &["config", "user.email", "t@example.com"]);
+        run_git(&repo, &["config", "user.name", "Tester"]);
+        std::fs::write(repo.join("a.txt"), b"x").unwrap();
+        run_git(&repo, &["add", "-A"]);
+        run_git(&repo, &["commit", "-q", "-m", "init"]);
+        // The fetch + repoint an attacker would do: HEAD now names a shared branch.
+        run_git(&repo, &["checkout", "-q", "-b", "develop"]);
+
+        let disp = dispatcher(&repo).with_own_branch(Some("fix/mine".to_string()));
+        let (resp, fx) = disp
+            .dispatch_inner("p", "git_push", &json!({ "force": true }))
+            .await;
+        assert!(
+            !resp.ok,
+            "force-pushing a non-own branch must be refused before any push: {resp:?}"
+        );
+        assert!(
+            resp.error.as_deref().unwrap_or_default().contains("force"),
+            "the refusal must name the force constraint, got: {:?}",
+            resp.error
+        );
+        assert!(
+            fx.is_empty(),
+            "a refused force push must emit nothing: {fx:?}"
+        );
+
+        // The very same branch WITHOUT force is not the force gate's business — it
+        // only fails later for lack of a remote, proving the gate is force-specific
+        // and a non-force push can still target another branch.
+        let (resp, _fx) = disp.dispatch_inner("p2", "git_push", &Value::Null).await;
+        let err = resp.error.as_deref().unwrap_or_default();
+        assert!(
+            err.contains("push failed") && !err.contains("force is limited"),
+            "a non-force push must reach the transport, not the force gate: {err:?}"
+        );
+    }
+
+    /// Fail closed: until the host has recorded the agent's branch (and this
+    /// dispatcher been rebuilt to carry it), a force cannot be authorized — so a
+    /// fresh session can't force-overwrite anything. The cost is the documented
+    /// residual: a same-session rebase force is deferred until the branch is
+    /// tracked. Non-force stays available throughout.
+    #[tokio::test]
+    async fn git_push_force_is_refused_until_the_own_branch_is_recorded() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        run_git(&repo, &["init", "-q", "-b", "main"]);
+        run_git(&repo, &["config", "user.email", "t@example.com"]);
+        run_git(&repo, &["config", "user.name", "Tester"]);
+        std::fs::write(repo.join("a.txt"), b"x").unwrap();
+        run_git(&repo, &["add", "-A"]);
+        run_git(&repo, &["commit", "-q", "-m", "init"]);
+        run_git(&repo, &["checkout", "-q", "-b", "fix/fresh"]);
+
+        // A `new`-built dispatcher, as at first spawn: no own branch threaded yet.
+        let disp = dispatcher(&repo);
+        let (resp, fx) = disp
+            .dispatch_inner("p", "git_push", &json!({ "force": true }))
+            .await;
+        assert!(
+            !resp.ok,
+            "force must fail closed while no own branch is recorded: {resp:?}"
+        );
+        assert!(
+            resp.error.as_deref().unwrap_or_default().contains("force"),
+            "the refusal must name the force constraint, got: {:?}",
+            resp.error
+        );
+        assert!(
+            fx.is_empty(),
+            "a refused force push must emit nothing: {fx:?}"
         );
     }
 
@@ -1178,8 +1305,8 @@ mod tests {
 
         let disp = GitDispatcher::new(a.clone(), "main".into(), AgentCaps::interactive())
             .with_repos(vec![
-                ("a".into(), a.clone(), "main".into()),
-                ("b".into(), b.clone(), "main".into()),
+                ("a".into(), a.clone(), "main".into(), None),
+                ("b".into(), b.clone(), "main".into(), None),
             ]);
 
         let (resp, _fx) = disp
@@ -1217,8 +1344,8 @@ mod tests {
 
         let disp = GitDispatcher::new(a.clone(), "main".into(), AgentCaps::interactive())
             .with_repos(vec![
-                ("a".into(), a.clone(), "main".into()),
-                ("b".into(), b.clone(), "main".into()),
+                ("a".into(), a.clone(), "main".into(), None),
+                ("b".into(), b.clone(), "main".into(), None),
             ]);
 
         // Targeting the sibling: the branch event must name `b`, so the
@@ -1265,7 +1392,7 @@ mod tests {
         run_git(&a, &["init", "-q", "-b", "main"]);
 
         let disp = GitDispatcher::new(a.clone(), "main".into(), AgentCaps::interactive())
-            .with_repos(vec![("a".into(), a.clone(), "main".into())]);
+            .with_repos(vec![("a".into(), a.clone(), "main".into(), None)]);
         let (resp, fx) = disp
             .dispatch_inner("p", "git_push", &json!({"repo": "nope"}))
             .await;

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -738,7 +738,11 @@ impl Supervisor {
                 .parent_branch
                 .clone()
                 .unwrap_or_else(|| "main".to_string());
-            repo_targets.push((r.subdir.clone(), checkout, base));
+            // `r.branch` is the agent's own work branch on this checkout, recorded
+            // when the host materialized it. Threaded here so a force push is
+            // fenced to it; `None` until the branch exists and this dispatcher is
+            // rebuilt on the next resume/turn (see `rpc::caps::refuses_force`).
+            repo_targets.push((r.subdir.clone(), checkout, base, r.branch.clone()));
         }
         // A workspace started from an issue carries its ref here ("123" for
         // GitHub, "ENG-123" for Linear); it seeds the agent's live issue ref,


### PR DESCRIPTION
## Summary

Brokered `git_push` refuses pushing to the review base and the conventional trunks (`main`/`master`), but nothing else — so an agent could **force-overwrite any other existing branch it doesn't own** (`develop`, `release/*`, a teammate's) under the user's GitHub identity, with publish approval off by default. This confines a *force* push to the agent's own recorded work branch.

## Root cause

`AgentCaps::refuses_branch` (`src-tauri/src/rpc/caps.rs`, `is_review_target`) fences only the review base + trunks. The force path in `GitDispatcher::git_push` (`src-tauri/src/rpc/git.rs`) then derives its target branch from the checkout's **mutable** `HEAD`. Because `git_fetch` accepts an arbitrary ref, an agent can:

1. `git_fetch develop` (read-only, deliberately ungated),
2. `checkout -B develop` locally (repoint HEAD),
3. `git_push { force: true }` → `--force-with-lease --force-if-includes`.

The lease passes because the tracking ref was just fetched, so `develop`'s history is destructively rewritten on the remote. `docs/isolation.md` ("the destination is constrained") overstated what was enforced.

## Fix

- Add `AgentCaps::refuses_force(branch, own_branch)` — a force push is authorized only against the agent's **own** work branch, not the branch its live HEAD happens to point at.
- Thread the agent's own branch (`AgentRecord.repos[].branch`) into `GitDispatcher` at construction, exactly as `base_branch` is threaded from the record in `supervisor/lifecycle.rs` — a spawn-stable anchor the agent cannot repoint the way it can its HEAD. Resolved per-checkout via `Target` (primary + `args.repo` siblings).
- Gate only `force` pushes in `git_push`, before the transport runs. Non-force pushes are untouched and may still create branches.

Legitimate flows preserved: force-pushing the agent's own branch after a rebase (the reason `force` exists); `open_pr` (non-force); and `update-branch` (credentialed `git_fetch` + native in-container merge, no force). Run-owned workflow step agents remain denied publish entirely.

## Residual (documented)

The own branch is `None` until the host records a materialized branch **and** the dispatcher is rebuilt (resume / next turn); there is no spawn-stable branch *name* at first spawn, since the agent names its branch at first push. In that window a force **fails closed** — a fresh session cannot force-overwrite anything, at the cost of deferring a same-session rebase-force until the branch is tracked (the common rebase-after-review flow spans sessions, so it resolves the recorded branch on resume). Non-force stays available throughout. Recorded in `docs/isolation.md`.

## Tests

`cargo check` and `cargo test --lib -- caps rpc::git` pass. Added:

- `caps.rs`: `force_is_confined_to_the_agents_own_branch` (own branch allowed incl. case/whitespace fold; `develop`/`release/*`/teammate/`main` refused; `None` fails closed) and a denied-grant force refusal.
- `rpc/git.rs`: `git_push_force_refuses_a_branch_the_agent_does_not_own` (refused before any git runs; non-force to the same branch still reaches the transport), `git_push_force_is_refused_until_the_own_branch_is_recorded` (fail-closed), and the existing diverged-remote force test now threads its own branch to prove force-own-branch still rewrites.