### PR TITLE
fix(workflow): enforce run budget during parallel/orchestrate stages

### DIFF
--- a/src-tauri/src/workflow/budget.rs
+++ b/src-tauri/src/workflow/budget.rs
@@ -246,6 +246,22 @@ pub struct Ledger {
     #[serde(default)]
     pub reserved_tokens: i64,
 
+    /// Turns/tokens promised to the parallel/orchestrate stage children currently
+    /// in flight (§11.2) — the stage analogue of a composed sub-run's
+    /// [`reserved_turns`](Self::reserved_turns): concurrent children draw from ONE
+    /// run budget, so each reserves its worst-case spend here before it runs and
+    /// `exceeded` / `remaining_*` count it, keeping N children from collectively
+    /// overrunning the run cap *during* the stage (not just at the post-stage fold).
+    /// Unlike a sub-run — resumed in place from the journal, so its reservation must
+    /// survive a restart — a stage child is simply re-run on resume, so its slice
+    /// must NOT persist (it would double-count against the re-run). Hence
+    /// `#[serde(skip)]`: a fresh drive re-reserves from a clean base, and a stage
+    /// clears its own outstanding child slices when it finishes.
+    #[serde(skip)]
+    child_reserved_turns: i64,
+    #[serde(skip)]
+    child_reserved_tokens: i64,
+
     /// Transient (never serialized): the current drive's start, set by
     /// [`Self::start_drive`]. `wall_ms` already holds prior drives' time.
     #[serde(skip)]
@@ -322,14 +338,15 @@ impl Ledger {
     /// The first run-level cap this ledger has reached, if any (§11.2). Checked at
     /// each enforcement point; `Some` pauses the run. `>=` because a cap of N
     /// permits N units of spend — reaching N means the next unit would exceed.
-    /// Reserved sub-run capacity (§10.3) counts against the caps: the parent must
-    /// not spend budget it has already promised to a live sub-run.
+    /// Reserved sub-run capacity (§10.3) and reserved stage-child capacity (§11.2)
+    /// both count against the caps: the parent must not spend budget it has already
+    /// promised to a live sub-run or an in-flight stage child.
     pub fn exceeded(&self, eff: &EffectiveBudgets, now_ms: i64) -> Option<BudgetLimit> {
-        if self.turns + self.reserved_turns >= eff.turns {
+        if self.turns + self.reserved_turns + self.child_reserved_turns >= eff.turns {
             return Some(BudgetLimit::Turns);
         }
         if let Some(cap) = eff.tokens {
-            if self.tokens + self.reserved_tokens >= cap {
+            if self.tokens + self.reserved_tokens + self.child_reserved_tokens >= cap {
                 return Some(BudgetLimit::Tokens);
             }
         }
@@ -339,17 +356,19 @@ impl Ledger {
         None
     }
 
-    /// Turns still spendable under `eff` after committed spend and live reservations
-    /// (spec §10.3 budget-fit check). Never negative.
+    /// Turns still spendable under `eff` after committed spend and every live
+    /// reservation — composed sub-runs (§10.3) and in-flight stage children (§11.2)
+    /// alike. Never negative.
     pub fn remaining_turns(&self, eff: &EffectiveBudgets) -> i64 {
-        (eff.turns - self.turns - self.reserved_turns).max(0)
+        (eff.turns - self.turns - self.reserved_turns - self.child_reserved_turns).max(0)
     }
 
     /// Tokens still spendable, or `None` when the run has no token cap (so a token
     /// reservation is unbounded and never rejected on token grounds).
     pub fn remaining_tokens(&self, eff: &EffectiveBudgets) -> Option<i64> {
-        eff.tokens
-            .map(|cap| (cap - self.tokens - self.reserved_tokens).max(0))
+        eff.tokens.map(|cap| {
+            (cap - self.tokens - self.reserved_tokens - self.child_reserved_tokens).max(0)
+        })
     }
 
     /// Reserve a sub-run's budget slice out of the parent ledger (§10.3). The slice
@@ -369,6 +388,61 @@ impl Ledger {
     pub fn release_reservation(&mut self, turns: i64, tokens: i64) {
         self.reserved_turns = (self.reserved_turns - turns).max(0);
         self.reserved_tokens = (self.reserved_tokens - tokens).max(0);
+    }
+
+    /// Reserve one parallel/orchestrate stage child's budget slice out of what the
+    /// run has left (§11.2), the stage analogue of [`Self::reserve`] for a composed
+    /// sub-run (§10.3). Concurrent children share the run's single ledger, so each
+    /// carves its worst-case turn spend — `max_attempts × turns_per_attempt`,
+    /// exactly the ceiling the child's own attempt/retry caps impose — off the
+    /// remaining turns before it starts; N children therefore cannot collectively
+    /// exceed the remaining run turns. The child carries no token cap of its own, so
+    /// its token slice mirrors its turn slice: the same fraction of the remaining
+    /// tokens it takes of the remaining turns (all of them when it takes all the
+    /// remaining turns). That bounds the stage's token spend to what the run has left
+    /// without a single child starving its siblings of the whole token budget — and
+    /// collapses to nothing when the run is token-uncapped. `remaining_*` already
+    /// nets out committed spend AND slices held by live siblings, so reserving in
+    /// launch order makes the children mutually exclusive. Returns the reserved
+    /// `(turns, tokens)`; the stage releases exactly this much with
+    /// [`Self::release_child_slice`] and folds the child's *actual* spend when it
+    /// finishes (never both, so a slice is never double-counted).
+    pub fn reserve_child_slice(
+        &mut self,
+        run: &EffectiveBudgets,
+        child: &EffectiveBudgets,
+    ) -> (i64, i64) {
+        let rem_turns = self.remaining_turns(run);
+        let want = child
+            .max_attempts
+            .saturating_mul(child.turns_per_attempt)
+            .max(0);
+        let turns = want.min(rem_turns);
+        let tokens = match self.remaining_tokens(run) {
+            None => 0, // token-uncapped run: nothing to reserve, never rejected
+            Some(rem) if rem_turns > 0 => rem.saturating_mul(turns) / rem_turns,
+            Some(rem) => rem, // no turns left → this child would hold the remainder
+        };
+        self.child_reserved_turns += turns;
+        self.child_reserved_tokens += tokens;
+        (turns, tokens)
+    }
+
+    /// Release a finished stage child's reserved slice (§11.2), paired with folding
+    /// its actual spend — the child analogue of [`Self::release_reservation`].
+    /// Floored at zero so a double release can never drive the reservation negative.
+    pub fn release_child_slice(&mut self, turns: i64, tokens: i64) {
+        self.child_reserved_turns = (self.child_reserved_turns - turns).max(0);
+        self.child_reserved_tokens = (self.child_reserved_tokens - tokens).max(0);
+    }
+
+    /// Drop every outstanding stage-child slice (§11.2). Called once when a
+    /// parallel/orchestrate stage finishes: a child that was cancelled and drained,
+    /// or that panicked, never released its slice through the normal fold path, and
+    /// — being transient — it must not linger into the next block's budget math.
+    pub fn clear_child_reservations(&mut self) {
+        self.child_reserved_turns = 0;
+        self.child_reserved_tokens = 0;
     }
 }
 
@@ -676,5 +750,140 @@ mod tests {
         assert_eq!(restored.reserved_tokens, 900);
         // Transient fields do not survive serialization.
         assert!(restored.agent_tokens_seen.is_empty());
+    }
+
+    /// A parallel/orchestrate stage child reserves its worst-case turn spend
+    /// (`max_attempts × turns_per_attempt`), and — like a sub-run slice — that
+    /// reservation counts against `remaining_*` and `exceeded` so the run cap is
+    /// honored *during* the stage, not only at the post-stage fold.
+    #[test]
+    fn child_slice_reserves_worst_case_and_counts_against_remaining() {
+        let eff = EffectiveBudgets {
+            turns: 100,
+            tokens: Some(1000),
+            max_attempts: 2,
+            turns_per_attempt: 10,
+            ..Default::default()
+        };
+        let mut l = Ledger::default();
+        let (t, k) = l.reserve_child_slice(&eff, &eff);
+        assert_eq!((t, k), (20, 200), "2×10 turns, proportional token share");
+        assert_eq!(l.remaining_turns(&eff), 80, "100 − 20 reserved");
+        assert_eq!(l.remaining_tokens(&eff), Some(800));
+        // The slice bites even though nothing has actually been spent yet.
+        let tight = EffectiveBudgets {
+            turns: 20,
+            ..eff.clone()
+        };
+        assert_eq!(l.exceeded(&tight, 0), Some(BudgetLimit::Turns));
+    }
+
+    /// The core invariant: N concurrent children near the run's cap collectively
+    /// cannot reserve more than the run has left — the first child takes what
+    /// remains and the rest get an empty slice (they will budget-exceed at once).
+    #[test]
+    fn concurrent_child_slices_cannot_exceed_remaining() {
+        let eff = EffectiveBudgets {
+            turns: 100,
+            tokens: Some(1000),
+            max_attempts: 2,
+            turns_per_attempt: 10, // each child wants 20 turns
+            ..Default::default()
+        };
+        let mut l = Ledger::default();
+        for _ in 0..97 {
+            l.charge_turn("prior", "e"); // enter the stage with only 3 turns left
+        }
+        assert_eq!(l.remaining_turns(&eff), 3);
+        let a = l.reserve_child_slice(&eff, &eff);
+        let b = l.reserve_child_slice(&eff, &eff);
+        let c = l.reserve_child_slice(&eff, &eff);
+        assert_eq!(a.0, 3, "first child takes the 3 remaining turns");
+        assert_eq!((b.0, c.0), (0, 0), "no turns left for the rest");
+        assert!(
+            a.0 + b.0 + c.0 <= 3,
+            "children collectively cannot exceed the remaining run turns"
+        );
+        assert_eq!(l.remaining_turns(&eff), 0);
+    }
+
+    /// When the run budget is ample, every child gets its full worst-case slice —
+    /// no false early-stop: three children of 20 fit comfortably under 100.
+    #[test]
+    fn ample_budget_gives_every_child_its_full_slice() {
+        let eff = EffectiveBudgets {
+            turns: 100,
+            tokens: None,
+            max_attempts: 2,
+            turns_per_attempt: 10,
+            ..Default::default()
+        };
+        let mut l = Ledger::default();
+        let slices: Vec<_> = (0..3).map(|_| l.reserve_child_slice(&eff, &eff)).collect();
+        assert!(
+            slices.iter().all(|(t, _)| *t == 20),
+            "each child keeps its full 20-turn slice"
+        );
+        assert_eq!(l.remaining_turns(&eff), 40, "100 − 3×20");
+    }
+
+    /// Release + fold replaces a child's slice with its actual spend (never both),
+    /// mirroring the sub-run reconciliation.
+    #[test]
+    fn release_child_then_fold_replaces_slice_with_actual_spend() {
+        let eff = EffectiveBudgets {
+            turns: 100,
+            max_attempts: 2,
+            turns_per_attempt: 10,
+            ..Default::default()
+        };
+        let mut l = Ledger::default();
+        let (t, k) = l.reserve_child_slice(&eff, &eff);
+        assert_eq!(l.remaining_turns(&eff), 80);
+        // The child actually spent only 3 of its reserved 20 turns.
+        l.release_child_slice(t, k);
+        l.turns += 3; // mirrors fold_child_ledger
+        assert_eq!(l.remaining_turns(&eff), 97, "only the 3 real turns count");
+    }
+
+    /// A stage clears any slice a cancelled-and-drained or panicked child never
+    /// released, so a leftover reservation can't bleed into the next block.
+    #[test]
+    fn clear_child_reservations_drops_outstanding_slices() {
+        let eff = EffectiveBudgets {
+            turns: 100,
+            max_attempts: 2,
+            turns_per_attempt: 10,
+            ..Default::default()
+        };
+        let mut l = Ledger::default();
+        l.reserve_child_slice(&eff, &eff);
+        l.reserve_child_slice(&eff, &eff);
+        assert_eq!(l.remaining_turns(&eff), 60);
+        l.clear_child_reservations();
+        assert_eq!(l.remaining_turns(&eff), 100, "outstanding slices dropped");
+    }
+
+    /// Child slices are transient: unlike a sub-run reservation they must not
+    /// survive a pause/resume, because a resumed stage re-runs its children (which
+    /// re-reserve) rather than resuming them in place.
+    #[test]
+    fn child_reservations_do_not_persist() {
+        let eff = EffectiveBudgets {
+            turns: 100,
+            max_attempts: 2,
+            turns_per_attempt: 10,
+            ..Default::default()
+        };
+        let mut l = Ledger::default();
+        l.reserve(7, 0); // a sub-run slice — this one DOES persist
+        l.reserve_child_slice(&eff, &eff); // a stage-child slice — transient
+        let restored = Ledger::from_json(&l.to_json());
+        assert_eq!(restored.reserved_turns, 7, "sub-run slice survives");
+        assert_eq!(
+            restored.remaining_turns(&eff),
+            93,
+            "only the sub-run slice is charged after resume; the child slice is gone"
+        );
     }
 }

--- a/src-tauri/src/workflow/scheduler/context.rs
+++ b/src-tauri/src/workflow/scheduler/context.rs
@@ -71,6 +71,11 @@ pub(crate) struct ChildResult {
     pub(crate) step_id: String,
     pub(crate) outcome: ChildOutcome,
     pub(crate) ledger: Ledger,
+    /// The run-budget slice reserved for this child at launch (§11.2), echoed back
+    /// so the stage releases exactly it and folds the child's actual spend in its
+    /// place (never both). `(0, 0)` when nothing was reserved.
+    pub(crate) reserved_turns: i64,
+    pub(crate) reserved_tokens: i64,
 }
 
 /// Everything one parallel child owns to drive itself on its own task (child
@@ -111,6 +116,14 @@ pub(crate) struct ChildCtx {
     /// superseded (lower-generation) attempt so a stale finish of the cancelled
     /// task can't win the join. Always `0` outside an orchestrate stage.
     pub(crate) generation: u64,
+    /// The run-budget slice reserved for this child out of the run ledger before it
+    /// launched (§11.2): the child clamps its own zero-based ledger's run caps to
+    /// this slice, so N concurrent children can't collectively overrun the run cap.
+    /// Stamped by [`reserve_child_budget`](super::parallel); `0` until reserved, and
+    /// echoed into the child's result so the stage releases it and folds the child's
+    /// actual spend when it finishes.
+    pub(crate) reserved_turns: i64,
+    pub(crate) reserved_tokens: i64,
     /// Set by the stage to wind this child down (loser cancellation, §6.6).
     pub(crate) stage_cancel: Arc<AtomicBool>,
 }

--- a/src-tauri/src/workflow/scheduler/orchestrate.rs
+++ b/src-tauri/src/workflow/scheduler/orchestrate.rs
@@ -10,6 +10,11 @@ pub(crate) struct OrchChildResult {
     pub(crate) generation: u64,
     pub(crate) outcome: ChildOutcome,
     pub(crate) ledger: Ledger,
+    /// The run-budget slice reserved for this child at launch (§11.2), echoed back
+    /// so the stage releases exactly it and folds the child's actual spend in its
+    /// place. `(0, 0)` when nothing was reserved.
+    pub(crate) reserved_turns: i64,
+    pub(crate) reserved_tokens: i64,
 }
 
 /// Result of waiting for the orchestrator to answer a child's ask (§10.4).
@@ -275,7 +280,7 @@ pub(crate) async fn run_orchestrate_stage(
         child_cancels.insert(step.id.clone(), cancel.clone());
         child_gen.insert(step.id.clone(), 0);
         child_specs.insert(step.id.clone(), step.clone());
-        let c = build_orch_child_ctx(
+        let mut c = build_orch_child_ctx(
             ctx,
             run_id,
             run,
@@ -294,6 +299,10 @@ pub(crate) async fn run_orchestrate_stage(
             0,
             cancel,
         );
+        // Reserve this child's slice of the run budget before it launches (§11.2),
+        // so the orchestrator and its concurrent children can't collectively overrun
+        // the run cap mid-stage.
+        reserve_child_budget(ledger, eff, &mut c);
         let entry = stage_entry_sha.clone();
         set.spawn(async move { drive_orch_child(c, entry).await });
     }
@@ -459,7 +468,7 @@ pub(crate) async fn run_orchestrate_stage(
                         child_cancels.insert(step.id.clone(), cancel.clone());
                         child_gen.insert(step.id.clone(), 0);
                         child_specs.insert(step.id.clone(), step.clone());
-                        let c = build_orch_child_ctx(
+                        let mut c = build_orch_child_ctx(
                             ctx,
                             run_id,
                             run,
@@ -478,6 +487,7 @@ pub(crate) async fn run_orchestrate_stage(
                             0,
                             cancel,
                         );
+                        reserve_child_budget(ledger, eff, &mut c);
                         let entry = stage_entry_sha.clone();
                         set.spawn(async move { drive_orch_child(c, entry).await });
                     }
@@ -519,7 +529,7 @@ pub(crate) async fn run_orchestrate_stage(
                                      with this guidance:\n\n{guidance}"
                                 )
                             });
-                            let c = build_orch_child_ctx(
+                            let mut c = build_orch_child_ctx(
                                 ctx,
                                 run_id,
                                 run,
@@ -538,6 +548,7 @@ pub(crate) async fn run_orchestrate_stage(
                                 gen,
                                 cancel,
                             );
+                            reserve_child_budget(ledger, eff, &mut c);
                             let entry = stage_entry_sha.clone();
                             set.spawn(async move { drive_orch_child(c, entry).await });
                         }
@@ -855,6 +866,10 @@ pub(crate) async fn run_orchestrate_stage(
     // `stage_done` — the orchestrator chose to end without waiting for them.
     drain_children(&child_cancels, &mut set).await;
     cancel_sub_runs(ctx, &sub_runs).await;
+    // The children just drained were cancelled without going through the fold path,
+    // so drop any slice they still held (§11.2) before the run advances to the next
+    // block — a leftover child reservation would wrongly shrink its budget.
+    ledger.clear_child_reservations();
     let _ = ctx.driver.archive(&orch_agent_id).await;
     let conn = ctx.db.lock();
     finish_step_exec(&conn, &orch_exec, "done", None);
@@ -1524,6 +1539,9 @@ fn build_orch_child_ctx(
         integrate: Integrate::None,
         extra_note,
         generation,
+        // Stamped by `reserve_child_budget` at each spawn site, before the child runs.
+        reserved_turns: 0,
+        reserved_tokens: 0,
         stage_cancel: cancel,
     }
 }
@@ -1534,13 +1552,19 @@ fn build_orch_child_ctx(
 /// routed to the orchestrator it parks for the answer and re-attempts with it
 /// folded in rather than failing.
 async fn drive_orch_child(c: ChildCtx, stage_entry_sha: Option<String>) -> OrchChildResult {
-    let step_eff = c.eff.for_step(c.step.budgets.as_ref());
+    let mut step_eff = c.eff.for_step(c.step.budgets.as_ref());
+    // Bound this child to the run-budget slice reserved for it (§11.2): its ledger
+    // is zero-based, so its run caps become the slice — it stops at its share of the
+    // run budget, and its concurrent siblings can't add up past the run cap.
+    clamp_eff_to_slice(&mut step_eff, c.reserved_turns, c.reserved_tokens);
     let deadlines = deadlines_from(&c.base_deadlines, &step_eff);
     let max_attempts = step_eff.max_attempts;
     let mut child_ledger = Ledger::default();
     let mut last_exec = String::new();
 
     let generation = c.generation;
+    let reserved_turns = c.reserved_turns;
+    let reserved_tokens = c.reserved_tokens;
     let done =
         |step_id: String, exec_id: String, outcome: ChildOutcome, ledger: Ledger| OrchChildResult {
             step_id,
@@ -1548,6 +1572,8 @@ async fn drive_orch_child(c: ChildCtx, stage_entry_sha: Option<String>) -> OrchC
             generation,
             outcome,
             ledger,
+            reserved_turns,
+            reserved_tokens,
         };
 
     let test_runner = match crate::workflow::tests_gate::SandboxTestRunner::new(
@@ -1942,9 +1968,12 @@ pub(crate) fn handle_orch_child(
             return;
         }
     };
-    // Its spend counts regardless, but a result from an attempt a later
-    // `retry_child` superseded must not touch the join outcome or wind losers
-    // down — otherwise the stale attempt could decide the stage (§10.2).
+    // Reconcile against the run budget (§11.2): release the slice this attempt
+    // reserved at launch and fold its actual spend in its place — never both. Its
+    // spend counts regardless, but a result from an attempt a later `retry_child`
+    // superseded must not touch the join outcome or wind losers down — otherwise the
+    // stale attempt could decide the stage (§10.2).
+    ledger.release_child_slice(res.reserved_turns, res.reserved_tokens);
     fold_child_ledger(ledger, &res.ledger);
     if child_gen.get(&res.step_id).copied().unwrap_or(0) != res.generation {
         let conn = ctx.db.lock();

--- a/src-tauri/src/workflow/scheduler/parallel.rs
+++ b/src-tauri/src/workflow/scheduler/parallel.rs
@@ -17,6 +17,60 @@ pub(crate) fn fold_child_ledger(run: &mut Ledger, child: &Ledger) {
     }
 }
 
+/// Reserve a stage child's budget slice out of the run ledger just before it
+/// launches (§11.2) and stamp it on the child ctx, so the child bounds its own
+/// ledger to the slice and the stage releases it on completion. The
+/// parallel/orchestrate analogue of a composed sub-run's reservation (§10.3):
+/// concurrent children draw from ONE run budget, so each carves its worst-case
+/// spend off what remains and N of them can't collectively overrun the run cap
+/// before the boundary fold ever runs. Reserving *here* — the moment a child
+/// actually starts, not when its ctx was built — means a child that starts only
+/// after an earlier one freed its slice draws from the up-to-date remaining budget,
+/// so an ample budget still lets every child run (no false early-stop).
+pub(crate) fn reserve_child_budget(
+    ledger: &mut Ledger,
+    run_eff: &EffectiveBudgets,
+    c: &mut ChildCtx,
+) {
+    let step_eff = run_eff.for_step(c.step.budgets.as_ref());
+    let (turns, tokens) = ledger.reserve_child_slice(run_eff, &step_eff);
+    c.reserved_turns = turns;
+    c.reserved_tokens = tokens;
+}
+
+/// Clamp a stage child's effective run caps to the slice reserved for it (§11.2).
+/// The child runs against its own zero-based ledger on a detached task, so the run
+/// cap can't be enforced against the shared ledger from inside it; capping `turns`
+/// (and `tokens`, when the run is token-capped) at the reserved slice is what stops
+/// the child at its share. A token-uncapped run stays uncapped.
+pub(crate) fn clamp_eff_to_slice(
+    step_eff: &mut EffectiveBudgets,
+    reserved_turns: i64,
+    reserved_tokens: i64,
+) {
+    step_eff.turns = reserved_turns;
+    if step_eff.tokens.is_some() {
+        step_eff.tokens = Some(reserved_tokens);
+    }
+}
+
+/// Launch the next queued parallel child: reserve its budget slice out of the run
+/// ledger first (§11.2), then spawn it onto the join set. A no-op once the queue is
+/// drained.
+fn launch_child(
+    set: &mut JoinSet<ChildResult>,
+    queue: &mut VecDeque<ChildCtx>,
+    ledger: &mut Ledger,
+    run_eff: &EffectiveBudgets,
+    stage_entry_sha: &Option<String>,
+) {
+    if let Some(mut c) = queue.pop_front() {
+        reserve_child_budget(ledger, run_eff, &mut c);
+        let entry = stage_entry_sha.clone();
+        set.spawn(async move { drive_child(c, entry).await });
+    }
+}
+
 /// Run a `parallel` stage with `integrate: none` (§6.6, §12.3): fork every child
 /// from the stage-entry ref, run them concurrently (bounded by `max_concurrent`),
 /// and join.
@@ -185,19 +239,15 @@ pub(crate) async fn run_parallel_stage(
             integrate: par.integrate,
             extra_note: None,
             generation: 0,
+            reserved_turns: 0,
+            reserved_tokens: 0,
             stage_cancel: stage_cancel.clone(),
         });
     }
 
     let mut set: JoinSet<ChildResult> = JoinSet::new();
-    let launch = |set: &mut JoinSet<ChildResult>, queue: &mut VecDeque<ChildCtx>| {
-        if let Some(c) = queue.pop_front() {
-            let entry = stage_entry_sha.clone();
-            set.spawn(async move { drive_child(c, entry).await });
-        }
-    };
     for _ in 0..concurrency {
-        launch(&mut set, &mut queue);
+        launch_child(&mut set, &mut queue, ledger, eff, &stage_entry_sha);
     }
 
     let mut successes = 0usize;
@@ -239,7 +289,10 @@ pub(crate) async fn run_parallel_stage(
                 continue;
             }
         };
-        // Fold the child's spend into the run ledger regardless of outcome.
+        // Reconcile the child against the run budget regardless of outcome (§11.2):
+        // release the slice it reserved at launch and fold its actual spend in its
+        // place — never both, so a slice is never double-counted.
+        ledger.release_child_slice(res.reserved_turns, res.reserved_tokens);
         fold_child_ledger(ledger, &res.ledger);
         match res.outcome {
             ChildOutcome::Success { moved_head, head } => {
@@ -276,9 +329,13 @@ pub(crate) async fn run_parallel_stage(
         }
         // Keep the pipeline full unless we're winding the stage down.
         if !stage_cancel.load(Ordering::SeqCst) {
-            launch(&mut set, &mut queue);
+            launch_child(&mut set, &mut queue, ledger, eff, &stage_entry_sha);
         }
     }
+
+    // Every child is terminal now; drop any slice a panicked child never released
+    // through the fold path above (§11.2) so it can't bleed into the next block.
+    ledger.clear_child_reservations();
 
     // Persist the folded ledger (children's turns/tokens) before returning.
     {
@@ -812,15 +869,23 @@ async fn resume_merge_stage(
 /// and honours `stage_cancel` — a loser's `run_attempt` stops its own agent and
 /// returns `Canceled`, so no agent is ever left running outside the workflow.
 async fn drive_child(c: ChildCtx, stage_entry_sha: Option<String>) -> ChildResult {
-    let step_eff = c.eff.for_step(c.step.budgets.as_ref());
+    let mut step_eff = c.eff.for_step(c.step.budgets.as_ref());
+    // Bound this child to the run-budget slice reserved for it (§11.2): its ledger
+    // is zero-based, so its run caps become the slice — it stops at its share of the
+    // run budget, and its concurrent siblings can't add up past the run cap.
+    clamp_eff_to_slice(&mut step_eff, c.reserved_turns, c.reserved_tokens);
     let deadlines = deadlines_from(&c.base_deadlines, &step_eff);
     let max_attempts = step_eff.max_attempts;
     let mut child_ledger = Ledger::default();
 
+    let reserved_turns = c.reserved_turns;
+    let reserved_tokens = c.reserved_tokens;
     let done = |outcome: ChildOutcome, ledger: Ledger| ChildResult {
         step_id: c.step.id.clone(),
         outcome,
         ledger,
+        reserved_turns,
+        reserved_tokens,
     };
 
     // Tests-gate runner for this child, honoring its own `tests_timeout_secs`

--- a/src-tauri/src/workflow/scheduler/tests.rs
+++ b/src-tauri/src/workflow/scheduler/tests.rs
@@ -3803,6 +3803,8 @@ fn stale_retry_result_is_discarded_by_generation() {
             head: None,
         },
         ledger: Ledger::default(),
+        reserved_turns: 0,
+        reserved_tokens: 0,
     };
 
     // A stale (generation 0) success is ignored — records no join outcome.


### PR DESCRIPTION
## Summary

The workflow engine enforces run-level budgets (turns, tokens, wall-clock), but parallel/orchestrate **stage children** slipped the turn/token cap: each ran against a fresh zero-based ledger that inherited the **full run cap** (`Budgets::for_step` leaves the run-scoped `turns`/`tokens` untouched). So N concurrent children could each spend up to the whole run budget, and the cap was only reconciled at the post-stage boundary fold — never enforced *during* the stage. A stage could add up to ~N × max_attempts × turns_per_attempt turns regardless of remaining run budget.

## Fix (structural)

Put stage children on the same reservation mechanism composed sub-runs already use (§10.3 → §11.2), rather than inventing a parallel one:

- **Reserve before launch.** `Ledger::reserve_child_slice` carves each child's worst-case spend — `max_attempts × turns_per_attempt` turns plus a proportional share of the remaining tokens — out of the run ledger's *remaining* budget. `exceeded` / `remaining_turns` / `remaining_tokens` count child reservations, so reserving in **launch order** makes concurrent children mutually exclusive: N of them cannot collectively overrun the run cap.
- **Clamp the child to its slice.** Each child's effective run caps are clamped to the reserved slice (`clamp_eff_to_slice`). The child's ledger is zero-based, so this clamp is what actually stops it at its share.
- **Reconcile on completion.** Release the reserved slice and fold the child's *actual* spend in its place — never both, so a slice is never double-counted. After every child is terminal, `clear_child_reservations` drops any slice a cancelled-and-drained or panicked child never released, so it can't bleed into the next block.
- **Transient by design.** Child reservations are `#[serde(skip)]`: unlike a composed sub-run (resumed in place from the journal), a resumed stage **re-runs** its children (which re-reserve), so persisting a slice would double-count on the re-run.
- Reserving at **launch** (not when the child ctx is built) means a child that starts only after an earlier sibling freed its slice draws from the up-to-date remaining budget — so an ample budget still lets every child run (no false early-stops).

Covers both the `parallel` and `orchestrate` stage paths (all spawn sites).

## Tests

Six budget unit tests: worst-case reservation counts against `remaining`/`exceeded`; N concurrent children can't exceed the remaining run turns; an ample budget gives every child its full slice (no false early-stop); release+fold replaces the slice with actual spend; `clear` drops outstanding slices; child reservations do not survive a pause/resume while sub-run reservations do. Full `workflow::{budget,scheduler,comms}` suite passes (125 tests).