### PR TITLE
feat(roadmap): persist roadmap items per project

### DIFF
--- a/src-tauri/migrations/0026_roadmap_items.sql
+++ b/src-tauri/migrations/0026_roadmap_items.sql
@@ -1,0 +1,67 @@
+-- The project roadmap: what this project is going to build, per project.
+--
+-- Until now the Roadmap tab rendered from a frontend mock module, so every
+-- project showed the same seven invented items and nothing survived a reload.
+-- This is the real table behind it. It is deliberately a *flat* list of items
+-- keyed by a short human code ("FLT-142") that is unique within the project —
+-- the same identifier the PM agent, the board, and (later) commit messages and
+-- PR titles all quote, so the code has to be allocated once and never move.
+--
+-- Codes are allocated Rust-side inside the single connection mutex
+-- (`roadmap::store::next_code`): prefix from `project_settings`
+-- (`roadmap.code_prefix`, derived from the project name on first allocation),
+-- number = MAX(existing suffix) + 1 starting at 100. Because every writer
+-- serializes through that one mutex, the read-max/insert pair is atomic, and
+-- `UNIQUE(project_id, code)` is the backstop if a future writer forgets.
+--
+-- `status` lifecycle:
+--   proposed  — the PM suggested it and the user hasn't accepted yet; renders
+--               as a ghost row on the board and counts for nothing.
+--   open      — a real item on the board, nobody is on it.
+--   queued    — handed to the run queue, waiting for a slot.
+--   active    — an agent/workflow run is working it right now.
+--   in_review — the work is done and a PR is open awaiting review.
+--   done      — shipped. Done items leave the board entirely; the board header
+--               shows their count as the "shipped" stat.
+-- The full enum is written down now so later slices (queue drainer, workflow
+-- binding, PR tracking) don't need a migration to move an item along it; this
+-- slice only ever writes proposed/open/active/done.
+--
+-- `parent_id` carries no UI yet and is always NULL: sub-items are a known next
+-- step, and retrofitting a self-referencing FK later would mean another table
+-- rewrite. The forward-looking columns after `agent_id` are the same bet — the
+-- roadmap is the hand-off point to the agent runtime, and those are the four
+-- facts a hand-off produces.
+--
+-- Deliberately NOT added to the generic CRUD allow-list (`database::validate`):
+-- like the `wf_*` tables, roadmap rows are written by typed commands only, so
+-- code allocation, JSON marshalling and the row-level `roadmap:item` event can
+-- never be bypassed by a frontend `db_insert`.
+CREATE TABLE roadmap_items (
+    id              TEXT PRIMARY KEY,            -- uuid
+    project_id      TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    code            TEXT NOT NULL,               -- "FLT-142" style, unique per project
+    parent_id       TEXT REFERENCES roadmap_items(id) ON DELETE CASCADE,  -- future subtasks; always NULL in v1, no UI
+    title           TEXT NOT NULL,
+    why             TEXT NOT NULL DEFAULT '',
+    horizon         TEXT NOT NULL,               -- now | next | later
+    status          TEXT NOT NULL,               -- proposed | open | queued | active | in_review | done
+    size            TEXT,                        -- XS | S | M | L, nullable
+    area            TEXT,
+    source          TEXT NOT NULL DEFAULT 'user',-- user | pm | linear | github
+    epic            TEXT,
+    accept_json     TEXT,                        -- JSON array of acceptance criteria strings
+    deps_json       TEXT,                        -- JSON array of item codes this must land after
+    agent_id        TEXT,                        -- workspace working it
+    workflow_def_id TEXT,                        -- assigned workflow override
+    run_id          TEXT,                        -- wf_run executing it
+    pr_url          TEXT,
+    pr_number       INTEGER,
+    created_at      INTEGER NOT NULL,
+    updated_at      INTEGER NOT NULL,
+    UNIQUE(project_id, code)
+);
+
+-- Every read is "the board for this project"; the UNIQUE above already covers
+-- code lookups, so this is the one index the surface needs.
+CREATE INDEX idx_roadmap_items_project ON roadmap_items(project_id);

--- a/src-tauri/src/database/connection.rs
+++ b/src-tauri/src/database/connection.rs
@@ -59,6 +59,7 @@ pub(crate) const MIGRATIONS: &[&str] = &[
     include_str!("../../migrations/0023_workspace_issue_ref.sql"),
     include_str!("../../migrations/0024_wf_run_issue_ref.sql"),
     include_str!("../../migrations/0025_worktree_pr_history.sql"),
+    include_str!("../../migrations/0026_roadmap_items.sql"),
 ];
 
 pub(crate) fn get_migrations() -> Migrations<'static> {

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -169,6 +169,11 @@ fn upgrading_an_older_schema_backs_it_up_first() {
     assert_eq!(version, 1);
 }
 
+/// Schema version at which `worktree_prs` (0025) exists. Pinned rather than
+/// derived from `MIGRATIONS.len()`: every later migration would otherwise shift
+/// the "one version short of it" baseline these tests upgrade from.
+const V_WORKTREE_PRS: usize = 25;
+
 /// The PR-history migration seeds itself from the bindings already on disk, so
 /// an upgrading install starts with history rather than with today. Without the
 /// backfill the Project Pulse "PRs opened" series — which now reads the log —
@@ -180,7 +185,7 @@ fn pr_history_migration_backfills_existing_bindings() {
     let mut conn = open_db(&dir.path().join(DB_FILENAME)).unwrap();
     // One migration short of the history table: the state an existing install
     // upgrades from.
-    let before = MIGRATIONS.len() - 1;
+    let before = V_WORKTREE_PRS - 1;
     get_migrations().to_version(&mut conn, before).unwrap();
 
     conn.execute_batch(
@@ -224,6 +229,65 @@ fn pr_history_migration_backfills_existing_bindings() {
         )
         .unwrap();
     assert_eq!(count, 0, "no persisted state means no renderable snapshot");
+}
+
+/// The roadmap table (0026) lands on an existing install with the shape the DAO
+/// assumes: per-project unique codes, cascade from the owning project, and no
+/// generic-CRUD access (typed commands only, like the `wf_*` tables).
+#[test]
+fn roadmap_items_migration_adds_the_table_with_its_constraints() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut conn = open_db(&dir.path().join(DB_FILENAME)).unwrap();
+    // The version an existing install upgrades from — the table must be created,
+    // not assumed to exist.
+    get_migrations()
+        .to_version(&mut conn, V_WORKTREE_PRS)
+        .unwrap();
+    drop(conn);
+
+    let db = init(dir.path()).unwrap();
+    let conn = db.lock();
+    let pid = make_project(&conn);
+
+    let insert = |id: &str, code: &str| {
+        conn.execute(
+            "INSERT INTO roadmap_items (id, project_id, code, title, horizon, status,
+                                        created_at, updated_at)
+             VALUES (?1, ?2, ?3, 'a title', 'now', 'open', 0, 0)",
+            rusqlite::params![id, pid, code],
+        )
+    };
+    insert("i1", "PRJ-100").unwrap();
+    // Codes are the identity the board, the PM and PR titles all quote — one
+    // project can never hold two of the same.
+    assert!(
+        insert("i2", "PRJ-100").is_err(),
+        "UNIQUE(project_id, code) must reject a duplicate code"
+    );
+    // Defaults the DAO relies on rather than writing explicitly.
+    let (why, source): (String, String) = conn
+        .query_row(
+            "SELECT why, source FROM roadmap_items WHERE id = 'i1'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!((why.as_str(), source.as_str()), ("", "user"));
+
+    // Deleting the project takes its roadmap with it — a roadmap outliving its
+    // project would be unreachable rows that still consume codes.
+    db_delete(&conn, "projects", json!({ "where": { "id": pid } })).unwrap();
+    let left: i64 = conn
+        .query_row("SELECT COUNT(*) FROM roadmap_items", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(left, 0);
+
+    // Writes go through `roadmap_*` commands so code allocation, JSON
+    // marshalling and the row event can't be bypassed.
+    assert!(
+        db_select(&conn, "roadmap_items", json!({})).is_err(),
+        "roadmap_items must stay off the generic CRUD allow-list"
+    );
 }
 
 #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,6 +26,7 @@ mod new_project;
 mod oauth;
 mod power;
 mod pty_session;
+mod roadmap;
 mod rpc;
 mod run_detect;
 mod run_env;
@@ -1639,6 +1640,10 @@ pub fn run() {
             workflow::definition::wf_def_delete,
             workflow::definition::wf_def_export_yaml,
             workflow::definition::wf_def_import_yaml,
+            roadmap::roadmap_list_items,
+            roadmap::roadmap_create_item,
+            roadmap::roadmap_update_item,
+            roadmap::roadmap_delete_item,
             oauth::oauth_device_login,
             commands::get_workspace,
             commands::wf_run_agents,

--- a/src-tauri/src/roadmap/mod.rs
+++ b/src-tauri/src/roadmap/mod.rs
@@ -1,0 +1,111 @@
+//! The project roadmap: the per-project list of items the Roadmap tab renders.
+//!
+//! Layout mirrors the workflow module: [`types`] is the row and its enums,
+//! [`store`] is the DAO (called with the connection lock held), and this file is
+//! the typed `#[tauri::command]` surface plus the row-level events the frontend
+//! syncs on.
+//!
+//! `roadmap_items` is deliberately absent from the generic CRUD allow-list
+//! (`database::validate`), exactly like the `wf_*` tables. Codes must be
+//! allocated under the connection lock, the `*_json` columns must be marshalled,
+//! and every mutation must announce itself — a frontend `db_insert` would skip
+//! all three.
+//!
+//! Events (both best-effort; a failed emit never affects what was persisted):
+//! - `roadmap:item` — the full row, on every create/update. The frontend upserts
+//!   by `id`, the same shape `wf:run` uses, so any writer (this surface, the PM
+//!   agent's RPC, the queue drainer) updates the board without a refetch.
+//! - `roadmap:item-deleted` — the deleted row's id, so the board drops it
+//!   instead of upserting it.
+
+pub mod store;
+pub mod types;
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use rusqlite::Connection;
+use tauri::{AppHandle, Emitter};
+
+use types::{ItemPatch, NewItem, RoadmapItem};
+
+type Db = Arc<Mutex<Connection>>;
+
+/// Notify the frontend that an item row changed; carries the full row.
+fn emit_item(app: &AppHandle, item: &RoadmapItem) {
+    let _ = app.emit("roadmap:item", item);
+}
+
+/// Notify the frontend that an item was deleted, so the board drops the row.
+fn emit_item_deleted(app: &AppHandle, id: &str) {
+    let _ = app.emit("roadmap:item-deleted", id);
+}
+
+/// Every item on a project's roadmap, oldest first. Includes `done` items — the
+/// board hides them from the horizons and counts them as "shipped".
+#[tauri::command]
+pub async fn roadmap_list_items(
+    project_id: String,
+    db: tauri::State<'_, Db>,
+) -> Result<Vec<RoadmapItem>, String> {
+    let conn = db.lock();
+    store::list(&conn, &project_id).map_err(|e| e.to_string())
+}
+
+/// Add an item to a project's roadmap. The `code` is allocated here, not passed
+/// in: it's the item's identity for the rest of its life, and only the DB knows
+/// which numbers are taken.
+#[tauri::command]
+pub async fn roadmap_create_item(
+    project_id: String,
+    item: NewItem,
+    app: AppHandle,
+    db: tauri::State<'_, Db>,
+) -> Result<RoadmapItem, String> {
+    if item.title.trim().is_empty() {
+        return Err("a roadmap item needs a title".into());
+    }
+    let created = {
+        let conn = db.lock();
+        store::create(&conn, &project_id, &item).map_err(|e| e.to_string())?
+    };
+    emit_item(&app, &created);
+    Ok(created)
+}
+
+/// Patch an item. Absent fields are left alone; an explicit `null` clears a
+/// nullable one (see [`ItemPatch`]). `code` and `project_id` are not patchable —
+/// a code that moved would break every reference to it.
+#[tauri::command]
+pub async fn roadmap_update_item(
+    id: String,
+    patch: ItemPatch,
+    app: AppHandle,
+    db: tauri::State<'_, Db>,
+) -> Result<RoadmapItem, String> {
+    let updated = {
+        let conn = db.lock();
+        store::update(&conn, &id, &patch).map_err(|e| e.to_string())?
+    };
+    let updated = updated.ok_or_else(|| format!("roadmap item {id} no longer exists"))?;
+    emit_item(&app, &updated);
+    Ok(updated)
+}
+
+/// Delete an item. Silent when the row is already gone — the caller's intent
+/// ("this should not be on the board") is satisfied either way.
+#[tauri::command]
+pub async fn roadmap_delete_item(
+    id: String,
+    app: AppHandle,
+    db: tauri::State<'_, Db>,
+) -> Result<(), String> {
+    let removed = {
+        let conn = db.lock();
+        store::delete(&conn, &id).map_err(|e| e.to_string())?
+    };
+    if removed {
+        emit_item_deleted(&app, &id);
+    }
+    Ok(())
+}

--- a/src-tauri/src/roadmap/store.rs
+++ b/src-tauri/src/roadmap/store.rs
@@ -413,6 +413,35 @@ mod tests {
     }
 
     #[test]
+    fn a_wire_borne_null_clears_the_column() {
+        // The other update tests build `ItemPatch` in Rust and bypass serde;
+        // the frontend's patches arrive as JSON through the command layer.
+        // This is the edit dialog's "Unsized" path, end to end.
+        let conn = test_conn();
+        let p = project(&conn, "p1", "fletch");
+        let item = create(
+            &conn,
+            &p,
+            &NewItem {
+                title: "sized".into(),
+                size: Some(ItemSize::M),
+                area: Some("runtime".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let patch: ItemPatch = serde_json::from_str(r#"{"size": null}"#).unwrap();
+        let row = update(&conn, &item.id, &patch).unwrap().unwrap();
+        assert_eq!(row.size, None, "the dialog's clear must stick");
+        assert_eq!(
+            row.area.as_deref(),
+            Some("runtime"),
+            "absent keys stay untouched"
+        );
+    }
+
+    #[test]
     fn update_patches_only_named_fields_and_clears_with_null() {
         let conn = test_conn();
         let p = project(&conn, "p1", "fletch");

--- a/src-tauri/src/roadmap/store.rs
+++ b/src-tauri/src/roadmap/store.rs
@@ -1,0 +1,512 @@
+//! The `roadmap_items` DAO: every read and write of the table, as plain
+//! functions over a `&Connection`.
+//!
+//! Kept separate from the command surface in `mod.rs` on purpose. The commands
+//! are the frontend's door, but the roadmap's other writers are Rust-side (the
+//! RPC dispatcher the PM agent talks to, and the queue drainer that flips items
+//! to `queued`/`active`), and they hold the connection lock themselves. Both
+//! doors therefore share one implementation of code allocation and JSON
+//! marshalling, so neither can drift.
+//!
+//! Every function here must be called with the connection mutex held. That is
+//! what makes [`next_code`]'s read-max/insert pair atomic: the app has exactly
+//! one `Connection` behind one `Mutex`, so no second writer can allocate the
+//! same code between the `MAX` and the `INSERT`.
+
+use rusqlite::{params, Connection, OptionalExtension};
+
+use super::types::{strings_to_col, ItemPatch, ItemSource, ItemStatus, NewItem};
+use super::types::{Horizon, RoadmapItem, COLUMNS};
+use crate::database::now_millis;
+
+/// `project_settings` key holding a project's roadmap code prefix. Stored on
+/// first allocation so the prefix survives a project rename — the codes already
+/// minted under it don't change, and neither should the next one.
+const PREFIX_KEY: &str = "roadmap.code_prefix";
+
+/// Where a project's numbering starts. Three digits from the outset so codes
+/// sort and align in the UI without zero-padding.
+const FIRST_NUMBER: i64 = 100;
+
+/// Fallback prefix when a project name yields no usable letters.
+const FALLBACK_PREFIX: &str = "PRJ";
+
+/// Every item on a project's roadmap, oldest first — the order rows were added
+/// within a horizon is the order the board draws them, and it's stable across
+/// edits (unlike `updated_at`, which would make a row jump when it's touched).
+pub fn list(conn: &Connection, project_id: &str) -> rusqlite::Result<Vec<RoadmapItem>> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {COLUMNS} FROM roadmap_items WHERE project_id = ?1 ORDER BY created_at, rowid"
+    ))?;
+    let rows = stmt.query_map([project_id], RoadmapItem::from_row)?;
+    rows.collect()
+}
+
+/// One item by id, or `None` if it's gone.
+pub fn get(conn: &Connection, id: &str) -> rusqlite::Result<Option<RoadmapItem>> {
+    conn.query_row(
+        &format!("SELECT {COLUMNS} FROM roadmap_items WHERE id = ?1"),
+        [id],
+        RoadmapItem::from_row,
+    )
+    .optional()
+}
+
+/// Insert an item, allocating its `code`. Defaults: `later` horizon, `open`
+/// status, `user` source.
+pub fn create(conn: &Connection, project_id: &str, new: &NewItem) -> rusqlite::Result<RoadmapItem> {
+    let id = uuid::Uuid::new_v4().to_string();
+    let code = next_code(conn, project_id)?;
+    let now = now_millis();
+    conn.execute(
+        "INSERT INTO roadmap_items
+           (id, project_id, code, parent_id, title, why, horizon, status, size, area, source,
+            epic, accept_json, deps_json, created_at, updated_at)
+         VALUES (?1, ?2, ?3, NULL, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?14)",
+        params![
+            id,
+            project_id,
+            code,
+            new.title,
+            new.why,
+            new.horizon.unwrap_or(Horizon::Later).as_str(),
+            new.status.unwrap_or(ItemStatus::Open).as_str(),
+            new.size.map(|s| s.as_str()),
+            new.area,
+            new.source.unwrap_or(ItemSource::User).as_str(),
+            new.epic,
+            strings_to_col(&new.accept),
+            strings_to_col(&new.deps),
+            now,
+        ],
+    )?;
+    // Read back rather than reconstructing, so the returned row is exactly what
+    // a later `list` will produce (column defaults included).
+    get(conn, &id)?.ok_or(rusqlite::Error::QueryReturnedNoRows)
+}
+
+/// Apply a partial update and return the stored row. An empty patch is a no-op
+/// that still returns the row (and still bumps nothing), so callers can send a
+/// patch built from a form without special-casing "nothing changed".
+pub fn update(
+    conn: &Connection,
+    id: &str,
+    patch: &ItemPatch,
+) -> rusqlite::Result<Option<RoadmapItem>> {
+    // Built as (column, value) pairs so the SQL only ever contains literal
+    // column names written here — never caller-supplied identifiers.
+    let mut sets: Vec<&str> = Vec::new();
+    let mut vals: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+    let mut set = |col: &'static str, v: Box<dyn rusqlite::ToSql>| {
+        sets.push(col);
+        vals.push(v);
+    };
+
+    if let Some(v) = &patch.title {
+        set("title", Box::new(v.clone()));
+    }
+    if let Some(v) = &patch.why {
+        set("why", Box::new(v.clone()));
+    }
+    if let Some(v) = patch.horizon {
+        set("horizon", Box::new(v.as_str()));
+    }
+    if let Some(v) = patch.status {
+        set("status", Box::new(v.as_str()));
+    }
+    if let Some(v) = patch.source {
+        set("source", Box::new(v.as_str()));
+    }
+    if let Some(v) = &patch.accept {
+        set("accept_json", Box::new(strings_to_col(v)));
+    }
+    if let Some(v) = &patch.deps {
+        set("deps_json", Box::new(strings_to_col(v)));
+    }
+    if let Some(v) = patch.size {
+        set("size", Box::new(v.map(|s| s.as_str())));
+    }
+    if let Some(v) = &patch.area {
+        set("area", Box::new(v.clone()));
+    }
+    if let Some(v) = &patch.epic {
+        set("epic", Box::new(v.clone()));
+    }
+    if let Some(v) = &patch.agent_id {
+        set("agent_id", Box::new(v.clone()));
+    }
+    if let Some(v) = &patch.workflow_def_id {
+        set("workflow_def_id", Box::new(v.clone()));
+    }
+    if let Some(v) = &patch.run_id {
+        set("run_id", Box::new(v.clone()));
+    }
+    if let Some(v) = &patch.pr_url {
+        set("pr_url", Box::new(v.clone()));
+    }
+    if let Some(v) = patch.pr_number {
+        set("pr_number", Box::new(v));
+    }
+
+    if !sets.is_empty() {
+        let assignments: Vec<String> = sets
+            .iter()
+            .enumerate()
+            .map(|(i, col)| format!("{col} = ?{}", i + 1))
+            .collect();
+        let n = vals.len();
+        vals.push(Box::new(now_millis()));
+        vals.push(Box::new(id.to_string()));
+        let sql = format!(
+            "UPDATE roadmap_items SET {}, updated_at = ?{} WHERE id = ?{}",
+            assignments.join(", "),
+            n + 1,
+            n + 2
+        );
+        let refs: Vec<&dyn rusqlite::ToSql> = vals.iter().map(|v| v.as_ref()).collect();
+        conn.execute(&sql, refs.as_slice())?;
+    }
+    get(conn, id)
+}
+
+/// Delete an item. Returns whether a row was actually removed, so a caller
+/// doesn't announce a deletion that didn't happen.
+pub fn delete(conn: &Connection, id: &str) -> rusqlite::Result<bool> {
+    let n = conn.execute("DELETE FROM roadmap_items WHERE id = ?1", [id])?;
+    Ok(n > 0)
+}
+
+/// The next free code for a project ("FLT-142").
+///
+/// The number is `MAX(existing suffix) + 1`, computed in Rust rather than SQL so
+/// codes that don't match the project's own prefix (an imported `#207`, a
+/// hand-edited row) are skipped instead of poisoning the max. Must be called
+/// with the connection lock held — see the module docs.
+///
+/// The max is taken over *live* rows, so deleting the highest-numbered item
+/// hands its number back to the next one. That is the accepted cost of keeping
+/// the allocator stateless (no counter to drift from the rows): an item deleted
+/// off the board never shipped, so nothing outside the table quotes its code.
+pub fn next_code(conn: &Connection, project_id: &str) -> rusqlite::Result<String> {
+    let prefix = code_prefix(conn, project_id)?;
+    let mut stmt = conn.prepare("SELECT code FROM roadmap_items WHERE project_id = ?1")?;
+    let highest = stmt
+        .query_map([project_id], |r| r.get::<_, String>(0))?
+        .filter_map(|c| c.ok())
+        .filter_map(|c| code_number(&c))
+        .max()
+        .unwrap_or(FIRST_NUMBER - 1);
+    Ok(format!("{prefix}-{}", highest + 1))
+}
+
+/// The numeric tail of a code, if it has one. `"FLT-142"` → `142`.
+fn code_number(code: &str) -> Option<i64> {
+    code.rsplit('-').next()?.parse().ok()
+}
+
+/// A project's code prefix, deriving and persisting one on first use so it
+/// survives a rename.
+fn code_prefix(conn: &Connection, project_id: &str) -> rusqlite::Result<String> {
+    let stored: Option<String> = conn
+        .query_row(
+            "SELECT value FROM project_settings WHERE project_id = ?1 AND key = ?2",
+            params![project_id, PREFIX_KEY],
+            |r| r.get(0),
+        )
+        .optional()?;
+    if let Some(p) = stored.filter(|p| !p.trim().is_empty()) {
+        return Ok(p);
+    }
+
+    let name: Option<String> = conn
+        .query_row(
+            "SELECT name FROM projects WHERE id = ?1",
+            [project_id],
+            |r| r.get(0),
+        )
+        .optional()?;
+    let prefix = derive_prefix(name.as_deref().unwrap_or_default());
+    conn.execute(
+        "INSERT INTO project_settings (project_id, key, value) VALUES (?1, ?2, ?3) \
+         ON CONFLICT(project_id, key) DO UPDATE SET value = excluded.value",
+        params![project_id, PREFIX_KEY, prefix],
+    )?;
+    Ok(prefix)
+}
+
+/// Turn a project name into a 2–4 letter code prefix: initials for a
+/// multi-word name ("my cool app" → `MCA`), the leading letters otherwise
+/// ("fletch" → `FLE`). Falls back to `PRJ` when there is nothing to work with,
+/// because a project with an unusable name still needs codes.
+fn derive_prefix(name: &str) -> String {
+    let words: Vec<&str> = name
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|w| !w.is_empty())
+        .collect();
+    let candidate: String = if words.len() >= 2 {
+        words
+            .iter()
+            .take(4)
+            .filter_map(|w| w.chars().next())
+            .collect()
+    } else {
+        words
+            .first()
+            .map(|w| w.chars().take(3).collect())
+            .unwrap_or_default()
+    };
+    let candidate = candidate.to_ascii_uppercase();
+    if candidate.len() >= 2 {
+        candidate
+    } else {
+        FALLBACK_PREFIX.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::get_migrations;
+    use crate::roadmap::types::ItemSize;
+
+    /// A migrated in-memory DB with foreign keys on, matching how the app opens
+    /// the real file — the cascade and the FK to `projects` are part of what
+    /// these tests exercise.
+    fn test_conn() -> Connection {
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        get_migrations().to_latest(&mut conn).unwrap();
+        conn
+    }
+
+    fn project(conn: &Connection, id: &str, name: &str) -> String {
+        conn.execute(
+            "INSERT INTO projects (id, name, created_at) VALUES (?1, ?2, 0)",
+            params![id, name],
+        )
+        .unwrap();
+        id.to_string()
+    }
+
+    fn titled(title: &str) -> NewItem {
+        NewItem {
+            title: title.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn codes_run_sequentially_from_100_with_a_derived_prefix() {
+        let conn = test_conn();
+        let p = project(&conn, "p1", "my-cool-app");
+
+        let first = create(&conn, &p, &titled("one")).unwrap();
+        let second = create(&conn, &p, &titled("two")).unwrap();
+
+        assert_eq!(first.code, "MCA-100");
+        assert_eq!(second.code, "MCA-101");
+        // The prefix is persisted on first allocation, so renaming the project
+        // later can't renumber anything.
+        let stored: String = conn
+            .query_row(
+                "SELECT value FROM project_settings WHERE project_id = 'p1' AND key = ?1",
+                [PREFIX_KEY],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, "MCA");
+    }
+
+    #[test]
+    fn code_allocation_is_per_project() {
+        let conn = test_conn();
+        let a = project(&conn, "pa", "alpha");
+        let b = project(&conn, "pb", "beta service");
+
+        let a1 = create(&conn, &a, &titled("a1")).unwrap();
+        let b1 = create(&conn, &b, &titled("b1")).unwrap();
+        let a2 = create(&conn, &a, &titled("a2")).unwrap();
+
+        // Each project numbers independently and carries its own prefix.
+        assert_eq!(a1.code, "ALP-100");
+        assert_eq!(a2.code, "ALP-101");
+        assert_eq!(b1.code, "BS-100");
+    }
+
+    #[test]
+    fn deleting_an_item_never_renumbers_the_survivors() {
+        // A code is an item's identity — the PM quotes it, and later slices put
+        // it in branch names and PR titles. Removing a neighbour must not move
+        // anyone else's, and the next allocation must not collide with a live
+        // one. (Deleting the *highest* item does free its number back: see
+        // `next_code`.)
+        let conn = test_conn();
+        let p = project(&conn, "p1", "fletch");
+        let one = create(&conn, &p, &titled("one")).unwrap();
+        let two = create(&conn, &p, &titled("two")).unwrap();
+        let three = create(&conn, &p, &titled("three")).unwrap();
+        assert!(delete(&conn, &two.id).unwrap());
+
+        let four = create(&conn, &p, &titled("four")).unwrap();
+        assert_eq!(one.code, "FLE-100");
+        assert_eq!(three.code, "FLE-102", "survivors keep their codes");
+        assert_eq!(four.code, "FLE-103", "and the gap is not backfilled");
+    }
+
+    #[test]
+    fn foreign_codes_do_not_poison_the_next_number() {
+        let conn = test_conn();
+        let p = project(&conn, "p1", "fletch");
+        // An imported row, as a Linear/GitHub import would leave it.
+        conn.execute(
+            "INSERT INTO roadmap_items (id, project_id, code, title, horizon, status,
+                                        created_at, updated_at)
+             VALUES ('imported', 'p1', '#207', 'from github', 'later', 'open', 0, 0)",
+            [],
+        )
+        .unwrap();
+        assert_eq!(create(&conn, &p, &titled("x")).unwrap().code, "FLE-100");
+    }
+
+    #[test]
+    fn create_defaults_and_round_trips_json_arrays() {
+        let conn = test_conn();
+        let p = project(&conn, "p1", "fletch");
+
+        let bare = create(&conn, &p, &titled("bare")).unwrap();
+        assert_eq!(bare.horizon, Horizon::Later, "an unplaced item is backlog");
+        assert_eq!(bare.status, ItemStatus::Open);
+        assert_eq!(bare.source, ItemSource::User);
+        assert_eq!(bare.size, None);
+        assert!(bare.accept.is_empty() && bare.deps.is_empty());
+        assert_eq!(bare.why, "");
+        assert!(bare.parent_id.is_none(), "v1 never writes a parent");
+
+        let full = create(
+            &conn,
+            &p,
+            &NewItem {
+                title: "shaped".into(),
+                why: "because".into(),
+                horizon: Some(Horizon::Now),
+                status: Some(ItemStatus::Proposed),
+                size: Some(ItemSize::L),
+                area: Some("runtime".into()),
+                source: Some(ItemSource::Pm),
+                epic: Some("persistence".into()),
+                accept: vec!["survives a quit".into(), "reattaches".into()],
+                deps: vec![bare.code.clone()],
+            },
+        )
+        .unwrap();
+
+        // Read back through `list`, so the JSON columns went through both the
+        // write and the read path.
+        let rows = list(&conn, &p).unwrap();
+        assert_eq!(rows.len(), 2);
+        let stored = rows.iter().find(|i| i.id == full.id).unwrap();
+        assert_eq!(stored, &full);
+        assert_eq!(stored.accept, vec!["survives a quit", "reattaches"]);
+        assert_eq!(stored.deps, vec![bare.code]);
+        assert_eq!(stored.status, ItemStatus::Proposed);
+        assert_eq!(stored.size, Some(ItemSize::L));
+    }
+
+    #[test]
+    fn update_patches_only_named_fields_and_clears_with_null() {
+        let conn = test_conn();
+        let p = project(&conn, "p1", "fletch");
+        let item = create(
+            &conn,
+            &p,
+            &NewItem {
+                title: "move me".into(),
+                horizon: Some(Horizon::Later),
+                size: Some(ItemSize::M),
+                area: Some("runtime".into()),
+                accept: vec!["one".into()],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        // The board's drag-to-horizon: one field, everything else untouched.
+        let moved = update(
+            &conn,
+            &item.id,
+            &ItemPatch {
+                horizon: Some(Horizon::Now),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(moved.horizon, Horizon::Now);
+        assert_eq!(
+            moved.size,
+            Some(ItemSize::M),
+            "an absent field is left alone"
+        );
+        assert_eq!(moved.area.as_deref(), Some("runtime"));
+        assert_eq!(moved.accept, vec!["one"]);
+        assert_eq!(moved.code, item.code, "a code never moves");
+        assert_eq!(moved.created_at, item.created_at);
+
+        // An explicit null clears a nullable column; an empty list clears a
+        // JSON one.
+        let cleared = update(
+            &conn,
+            &item.id,
+            &ItemPatch {
+                size: Some(None),
+                area: Some(None),
+                accept: Some(vec![]),
+                title: Some("retitled".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(cleared.size, None);
+        assert_eq!(cleared.area, None);
+        assert!(cleared.accept.is_empty());
+        assert_eq!(cleared.title, "retitled");
+
+        // Patching a row that no longer exists is not an error — it reports
+        // that there is nothing there.
+        assert!(delete(&conn, &item.id).unwrap());
+        assert!(update(&conn, &item.id, &ItemPatch::default())
+            .unwrap()
+            .is_none());
+        assert!(
+            !delete(&conn, &item.id).unwrap(),
+            "second delete is a no-op"
+        );
+        assert!(list(&conn, &p).unwrap().is_empty());
+    }
+
+    #[test]
+    fn deleting_a_project_takes_its_roadmap() {
+        let conn = test_conn();
+        let p = project(&conn, "p1", "fletch");
+        create(&conn, &p, &titled("one")).unwrap();
+        conn.execute("DELETE FROM projects WHERE id = 'p1'", [])
+            .unwrap();
+        assert!(list(&conn, &p).unwrap().is_empty());
+    }
+
+    #[test]
+    fn prefixes_are_derived_from_whatever_the_name_offers() {
+        assert_eq!(derive_prefix("fletch"), "FLE");
+        assert_eq!(derive_prefix("my-cool-app"), "MCA");
+        assert_eq!(derive_prefix("A very long product name here"), "AVLP");
+        assert_eq!(derive_prefix("q"), "PRJ", "one letter is not a prefix");
+        assert_eq!(derive_prefix("  "), "PRJ");
+        assert_eq!(
+            derive_prefix("🚀"),
+            "PRJ",
+            "non-ascii yields nothing usable"
+        );
+        assert_eq!(derive_prefix("2fa"), "2FA");
+    }
+}

--- a/src-tauri/src/roadmap/types.rs
+++ b/src-tauri/src/roadmap/types.rs
@@ -1,0 +1,242 @@
+//! The `roadmap_items` domain types: one row, its four string-backed enums, and
+//! the create/patch payloads the commands accept.
+//!
+//! The enums use the shared [`crate::db_enum`] macro, so the on-disk spelling
+//! and the on-wire spelling are the same string by construction — a `horizon`
+//! the frontend sends is literally the value stored in the column.
+//!
+//! The `*_json` TEXT columns (`accept_json`, `deps_json`) are marshalled here
+//! and never leak: [`RoadmapItem`] carries real `Vec<String>`s, so the frontend
+//! receives JSON arrays rather than strings-of-JSON.
+
+use rusqlite::types::Type;
+use rusqlite::Row;
+use serde::{Deserialize, Serialize};
+
+crate::db_enum! {
+    /// Where an item sits on the board. `now` is being built, `next` is queued
+    /// up, `later` is the backlog. Shipped items leave the board entirely.
+    Horizon {
+        Now   => "now",
+        Next  => "next",
+        Later => "later",
+    }
+}
+
+crate::db_enum! {
+    /// Item lifecycle: `proposed → open → queued → active → in_review → done`.
+    /// `proposed` is a PM suggestion the user hasn't accepted (a ghost row);
+    /// `done` items leave the board and become the header's "shipped" count.
+    ItemStatus {
+        Proposed => "proposed",
+        Open     => "open",
+        Queued   => "queued",
+        Active   => "active",
+        InReview => "in_review",
+        Done     => "done",
+    }
+}
+
+crate::db_enum! {
+    /// Rough effort tier. Nullable on the row — an unshaped idea has no size.
+    ItemSize {
+        Xs => "XS",
+        S  => "S",
+        M  => "M",
+        L  => "L",
+    }
+}
+
+crate::db_enum! {
+    /// Where the item came from. `user` is a hand-written row, `pm` came out of
+    /// the roadmap conversation, the rest are imports.
+    ItemSource {
+        User   => "user",
+        Pm     => "pm",
+        Linear => "linear",
+        Github => "github",
+    }
+}
+
+/// One `roadmap_items` row as the frontend sees it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RoadmapItem {
+    pub id: String,
+    pub project_id: String,
+    /// Short human id ("FLT-142"), unique per project and never reallocated.
+    pub code: String,
+    /// Reserved for sub-items; always `None` today (no UI writes it).
+    pub parent_id: Option<String>,
+    pub title: String,
+    /// The one line that justifies the item's place on the board.
+    pub why: String,
+    pub horizon: Horizon,
+    pub status: ItemStatus,
+    pub size: Option<ItemSize>,
+    /// Product-map domain this belongs to.
+    pub area: Option<String>,
+    pub source: ItemSource,
+    /// Grouping label when several items were shaped together.
+    pub epic: Option<String>,
+    /// Acceptance criteria, rendered as a checklist. Empty, never null.
+    pub accept: Vec<String>,
+    /// Codes this item must land after. Empty, never null.
+    pub deps: Vec<String>,
+    pub agent_id: Option<String>,
+    pub workflow_def_id: Option<String>,
+    pub run_id: Option<String>,
+    pub pr_url: Option<String>,
+    pub pr_number: Option<i64>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+/// The columns every read selects, in one place so the row decoder and the
+/// queries can't disagree about what is available.
+pub(crate) const COLUMNS: &str = "id, project_id, code, parent_id, title, why, horizon, status, \
+     size, area, source, epic, accept_json, deps_json, agent_id, workflow_def_id, run_id, \
+     pr_url, pr_number, created_at, updated_at";
+
+impl RoadmapItem {
+    pub fn from_row(r: &Row) -> rusqlite::Result<Self> {
+        Ok(Self {
+            id: r.get("id")?,
+            project_id: r.get("project_id")?,
+            code: r.get("code")?,
+            parent_id: r.get("parent_id")?,
+            title: r.get("title")?,
+            why: r.get("why")?,
+            horizon: enum_col(r, "horizon", Horizon::from_db)?,
+            status: enum_col(r, "status", ItemStatus::from_db)?,
+            size: opt_enum_col(r, "size", ItemSize::from_db)?,
+            area: r.get("area")?,
+            source: enum_col(r, "source", ItemSource::from_db)?,
+            epic: r.get("epic")?,
+            accept: strings_col(r, "accept_json")?,
+            deps: strings_col(r, "deps_json")?,
+            agent_id: r.get("agent_id")?,
+            workflow_def_id: r.get("workflow_def_id")?,
+            run_id: r.get("run_id")?,
+            pr_url: r.get("pr_url")?,
+            pr_number: r.get("pr_number")?,
+            created_at: r.get("created_at")?,
+            updated_at: r.get("updated_at")?,
+        })
+    }
+}
+
+/// A new item. Everything but `title` has a defined default, so the smallest
+/// useful call is a title and nothing else — the board's quick-add path.
+/// `code` is never accepted from the caller: it is allocated by
+/// [`crate::roadmap::store::create`] under the connection lock.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct NewItem {
+    pub title: String,
+    #[serde(default)]
+    pub why: String,
+    #[serde(default)]
+    pub horizon: Option<Horizon>,
+    /// Defaults to `open`. `proposed` is how a PM suggestion is persisted
+    /// before the user accepts it.
+    #[serde(default)]
+    pub status: Option<ItemStatus>,
+    #[serde(default)]
+    pub size: Option<ItemSize>,
+    #[serde(default)]
+    pub area: Option<String>,
+    /// Defaults to `user` — a row typed on the board by hand.
+    #[serde(default)]
+    pub source: Option<ItemSource>,
+    #[serde(default)]
+    pub epic: Option<String>,
+    #[serde(default)]
+    pub accept: Vec<String>,
+    #[serde(default)]
+    pub deps: Vec<String>,
+}
+
+/// A partial update. An absent field is left alone; an explicit `null` on a
+/// nullable column clears it (`Option<Option<T>>` — serde maps absent to `None`
+/// and `null` to `Some(None)`), which is how "unset the size" is expressed
+/// without a second command.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ItemPatch {
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub why: Option<String>,
+    #[serde(default)]
+    pub horizon: Option<Horizon>,
+    #[serde(default)]
+    pub status: Option<ItemStatus>,
+    #[serde(default)]
+    pub source: Option<ItemSource>,
+    #[serde(default)]
+    pub accept: Option<Vec<String>>,
+    #[serde(default)]
+    pub deps: Option<Vec<String>>,
+    #[serde(default)]
+    pub size: Option<Option<ItemSize>>,
+    #[serde(default)]
+    pub area: Option<Option<String>>,
+    #[serde(default)]
+    pub epic: Option<Option<String>>,
+    #[serde(default)]
+    pub agent_id: Option<Option<String>>,
+    #[serde(default)]
+    pub workflow_def_id: Option<Option<String>>,
+    #[serde(default)]
+    pub run_id: Option<Option<String>>,
+    #[serde(default)]
+    pub pr_url: Option<Option<String>>,
+    #[serde(default)]
+    pub pr_number: Option<Option<i64>>,
+}
+
+// ───────────────────────────── row helpers ──────────────────────────────
+
+fn conversion_err(col: &str, detail: String) -> rusqlite::Error {
+    rusqlite::Error::FromSqlConversionFailure(0, Type::Text, format!("{col}: {detail}").into())
+}
+
+/// Parse a nullable JSON-array TEXT column into a `Vec<String>`. NULL and a
+/// stored `[]` both read as empty, so callers never branch on which one a
+/// writer chose.
+fn strings_col(r: &Row, col: &str) -> rusqlite::Result<Vec<String>> {
+    let raw: Option<String> = r.get(col)?;
+    match raw.as_deref() {
+        None | Some("") => Ok(Vec::new()),
+        Some(s) => serde_json::from_str(s).map_err(|e| conversion_err(col, e.to_string())),
+    }
+}
+
+/// Parse a required enum TEXT column via its `from_db`.
+fn enum_col<T>(r: &Row, col: &str, parse: fn(&str) -> Option<T>) -> rusqlite::Result<T> {
+    let raw: String = r.get(col)?;
+    parse(&raw).ok_or_else(|| conversion_err(col, format!("unexpected value {raw:?}")))
+}
+
+/// Parse a nullable enum TEXT column via its `from_db`.
+fn opt_enum_col<T>(
+    r: &Row,
+    col: &str,
+    parse: fn(&str) -> Option<T>,
+) -> rusqlite::Result<Option<T>> {
+    let raw: Option<String> = r.get(col)?;
+    match raw {
+        None => Ok(None),
+        Some(s) => parse(&s)
+            .map(Some)
+            .ok_or_else(|| conversion_err(col, format!("unexpected value {s:?}"))),
+    }
+}
+
+/// Serialize a string list for its `*_json` column. An empty list stores as
+/// NULL rather than `"[]"` — the column's "nothing here" value is one thing.
+pub(crate) fn strings_to_col(v: &[String]) -> Option<String> {
+    if v.is_empty() {
+        None
+    } else {
+        serde_json::to_string(v).ok()
+    }
+}

--- a/src-tauri/src/roadmap/types.rs
+++ b/src-tauri/src/roadmap/types.rs
@@ -156,9 +156,9 @@ pub struct NewItem {
 }
 
 /// A partial update. An absent field is left alone; an explicit `null` on a
-/// nullable column clears it (`Option<Option<T>>` — serde maps absent to `None`
-/// and `null` to `Some(None)`), which is how "unset the size" is expressed
-/// without a second command.
+/// nullable column clears it (`Option<Option<T>>` with [`double_option`] —
+/// absent is `None`, `null` is `Some(None)`), which is how "unset the size" is
+/// expressed without a second command.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct ItemPatch {
     #[serde(default)]
@@ -175,22 +175,36 @@ pub struct ItemPatch {
     pub accept: Option<Vec<String>>,
     #[serde(default)]
     pub deps: Option<Vec<String>>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "double_option")]
     pub size: Option<Option<ItemSize>>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "double_option")]
     pub area: Option<Option<String>>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "double_option")]
     pub epic: Option<Option<String>>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "double_option")]
     pub agent_id: Option<Option<String>>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "double_option")]
     pub workflow_def_id: Option<Option<String>>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "double_option")]
     pub run_id: Option<Option<String>>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "double_option")]
     pub pr_url: Option<Option<String>>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "double_option")]
     pub pr_number: Option<Option<i64>>,
+}
+
+/// Keep a double-`Option` field's `null` distinct from its absence. Serde's
+/// stock `Option` deserializer folds JSON `null` into the *outer* `None`, which
+/// would make "clear this column" unreachable from the frontend — the patch
+/// would read as "leave it alone" and the edit dialog's clears would silently
+/// revert. This runs only when the key is present, so `null` lands as
+/// `Some(None)`; `#[serde(default)]` still covers the absent case.
+fn double_option<'de, T, D>(d: D) -> Result<Option<Option<T>>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: serde::Deserializer<'de>,
+{
+    Option::<T>::deserialize(d).map(Some)
 }
 
 // ───────────────────────────── row helpers ──────────────────────────────
@@ -238,5 +252,24 @@ pub(crate) fn strings_to_col(v: &[String]) -> Option<String> {
         None
     } else {
         serde_json::to_string(v).ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the wire semantics of the patch: the store tests build `ItemPatch`
+    /// in Rust and never touch serde, but the frontend's patches arrive as
+    /// JSON through the command layer, where `null` and "absent" are different
+    /// bytes that must stay different values.
+    #[test]
+    fn patch_null_clears_value_sets_absent_keeps() {
+        let p: ItemPatch = serde_json::from_str(r#"{"size": null, "area": "runtime"}"#).unwrap();
+        assert_eq!(p.size, Some(None), "an explicit null means 'clear'");
+        assert_eq!(p.area, Some(Some("runtime".into())), "a value means 'set'");
+        assert_eq!(p.epic, None, "an absent key means 'leave alone'");
+        assert_eq!(p.workflow_def_id, None);
+        assert_eq!(p.title, None);
     }
 }

--- a/src-tauri/src/workflow/types.rs
+++ b/src-tauri/src/workflow/types.rs
@@ -15,6 +15,10 @@ use serde_json::Value;
 /// Declares a string-backed enum with a single source of truth for the
 /// on-disk / on-wire spelling: `as_str` (DB write + serialize) and `from_db`
 /// (DB read + deserialize) can never drift apart.
+///
+/// Exported at the crate root (`crate::db_enum!`) because every module with
+/// status-string columns wants the same guarantee — see `roadmap::types`.
+#[macro_export]
 macro_rules! db_enum {
     ($(#[$meta:meta])* $name:ident { $($variant:ident => $s:literal),+ $(,)? }) => {
         $(#[$meta])*

--- a/src/api/domains/roadmap.ts
+++ b/src/api/domains/roadmap.ts
@@ -1,0 +1,23 @@
+import { invoke } from "../invoke";
+import type { NewRoadmapItem, RoadmapItem, RoadmapItemPatch } from "../types/roadmap";
+
+/** Per-project roadmap storage (`roadmap_*`, src-tauri/src/roadmap). Every
+ *  mutation also broadcasts the row on `roadmap:item` / `roadmap:item-deleted`,
+ *  so callers that already subscribe don't need to refetch after writing —
+ *  see `useRoadmap`. */
+export const roadmapApi = {
+  /** Every item on a project's roadmap, oldest first. Includes `done` items:
+   *  the board hides them from the horizons and counts them as shipped. */
+  roadmapListItems: (projectId: string) =>
+    invoke<RoadmapItem[]>("roadmap_list_items", { projectId }),
+  /** Add an item. The `code` is allocated backend-side (per-project, under the
+   *  connection lock), which is why it isn't part of the payload. */
+  roadmapCreateItem: (projectId: string, item: NewRoadmapItem) =>
+    invoke<RoadmapItem>("roadmap_create_item", { projectId, item }),
+  /** Patch an item and get the stored row back. Omitted keys are left alone; an
+   *  explicit `null` clears a nullable column. */
+  roadmapUpdateItem: (id: string, patch: RoadmapItemPatch) =>
+    invoke<RoadmapItem>("roadmap_update_item", { id, patch }),
+  /** Remove an item from the board. */
+  roadmapDeleteItem: (id: string) => invoke<void>("roadmap_delete_item", { id }),
+};

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -14,6 +14,7 @@ import type {
 } from "./types/agent";
 import type { PrStateChangedEvent } from "./types/pr";
 import type { AgentInstallEvent } from "./types/providers";
+import type { RoadmapItem } from "./types/roadmap";
 import type { RunOutputEvent, RunPortEvent, RunStateEvent } from "./types/run";
 import type { DockerBuildEvent, PublishApproval } from "./types/sandbox";
 import type {
@@ -38,6 +39,19 @@ export function onWfRun(cb: (e: WfRun) => void): Promise<UnlistenFn> {
  *  rows, so the sidebar drops the row instead of upserting it. */
 export function onWfRunDeleted(cb: (runId: string) => void): Promise<UnlistenFn> {
   return listen<string>("wf:run-deleted", (event) => cb(event.payload));
+}
+
+/** Fires whenever a roadmap item is created or changed; carries the full row so
+ *  the board upserts by id without a refetch. Fires for every project — a
+ *  listener scoped to one board filters on `project_id`. */
+export function onRoadmapItem(cb: (item: RoadmapItem) => void): Promise<UnlistenFn> {
+  return listen<RoadmapItem>("roadmap:item", (event) => cb(event.payload));
+}
+
+/** `roadmap:item-deleted` fires the deleted item's id, so the board drops the
+ *  row instead of upserting it. */
+export function onRoadmapItemDeleted(cb: (id: string) => void): Promise<UnlistenFn> {
+  return listen<string>("roadmap:item-deleted", (event) => cb(event.payload));
 }
 
 export function onAgentInstallState(cb: (e: AgentInstallEvent) => void): Promise<UnlistenFn> {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,6 +6,7 @@ import { githubApi } from "./domains/github";
 import { issuesApi } from "./domains/issues";
 import { miscApi } from "./domains/misc";
 import { providersApi } from "./domains/providers";
+import { roadmapApi } from "./domains/roadmap";
 import { runApi } from "./domains/run";
 import { sandboxApi } from "./domains/sandbox";
 import { sessionApi } from "./domains/session";
@@ -23,6 +24,7 @@ export * from "./types/git";
 export * from "./types/issues";
 export * from "./types/pr";
 export * from "./types/providers";
+export * from "./types/roadmap";
 export * from "./types/run";
 export * from "./types/sandbox";
 export * from "./types/session";
@@ -47,4 +49,5 @@ export const api = {
   ...commandsApi,
   ...providersApi,
   ...workflowsApi,
+  ...roadmapApi,
 };

--- a/src/api/types/roadmap.ts
+++ b/src/api/types/roadmap.ts
@@ -1,0 +1,92 @@
+// Roadmap DTOs — the TypeScript mirror of the Rust `roadmap::types`
+// (see src-tauri/src/roadmap/types.rs). These match the serde JSON exactly, so
+// a row returned by `roadmap_list_items` and one delivered on the `roadmap:item`
+// event are the same shape.
+//
+// The `*_json` TEXT columns are marshalled backend-side: `accept` and `deps`
+// arrive as real arrays (empty, never null). Nullable columns arrive as `null`,
+// never `undefined`.
+
+/** Where an item sits on the board. `now` is being built, `next` is queued up,
+ *  `later` is the backlog. Shipped items leave the board entirely. */
+export type Horizon = "now" | "next" | "later";
+
+export type ItemSize = "XS" | "S" | "M" | "L";
+
+/** Where the item came from — drawn as a glyph on the row. */
+export type ItemSource = "user" | "pm" | "linear" | "github";
+
+/** Item lifecycle. `proposed` is a PM suggestion the user hasn't accepted yet
+ *  (a ghost row); `active` means an agent is on it right now; `done` items leave
+ *  the board and become the header's "shipped" count. */
+export type ItemStatus = "proposed" | "open" | "queued" | "active" | "in_review" | "done";
+
+/** One `roadmap_items` row. */
+export interface RoadmapItem {
+  id: string;
+  project_id: string;
+  /** Short human id ("FLT-142"), unique per project and never reallocated. */
+  code: string;
+  /** Reserved for sub-items; always null today (no UI writes it). */
+  parent_id: string | null;
+  title: string;
+  /** The one line that justifies the item's place on the board. */
+  why: string;
+  horizon: Horizon;
+  status: ItemStatus;
+  size: ItemSize | null;
+  /** Product-map domain this belongs to. */
+  area: string | null;
+  source: ItemSource;
+  /** Grouping label when several items were shaped together. */
+  epic: string | null;
+  /** Acceptance criteria, rendered as a checklist. */
+  accept: string[];
+  /** Codes this item must land after. */
+  deps: string[];
+  /** Workspace working it. */
+  agent_id: string | null;
+  workflow_def_id: string | null;
+  run_id: string | null;
+  pr_url: string | null;
+  pr_number: number | null;
+  created_at: number;
+  updated_at: number;
+}
+
+/** The payload `roadmap_create_item` accepts. Only `title` is required; the
+ *  backend defaults the rest (`later` / `open` / `user`) and allocates the code,
+ *  which is why there is no `code` field here. */
+export interface NewRoadmapItem {
+  title: string;
+  why?: string;
+  horizon?: Horizon;
+  status?: ItemStatus;
+  size?: ItemSize | null;
+  area?: string | null;
+  source?: ItemSource;
+  epic?: string | null;
+  accept?: string[];
+  deps?: string[];
+}
+
+/** A partial update. An omitted key is left alone; an explicit `null` on a
+ *  nullable column clears it — so `{ size: null }` unsets the size while `{}`
+ *  changes nothing. `code` and `project_id` are not patchable. */
+export interface RoadmapItemPatch {
+  title?: string;
+  why?: string;
+  horizon?: Horizon;
+  status?: ItemStatus;
+  source?: ItemSource;
+  accept?: string[];
+  deps?: string[];
+  size?: ItemSize | null;
+  area?: string | null;
+  epic?: string | null;
+  agent_id?: string | null;
+  workflow_def_id?: string | null;
+  run_id?: string | null;
+  pr_url?: string | null;
+  pr_number?: number | null;
+}

--- a/src/components/ProjectScreen/Roadmap/Board/EmptyBoard.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/EmptyBoard.tsx
@@ -1,0 +1,30 @@
+import { Icon } from "@/components/Icon";
+import { Button } from "@/components/ui/Button";
+
+/** What a new project's board says instead of three empty horizons.
+ *
+ *  Three empty groups read as a broken screen; this reads as a starting point.
+ *  It names the two ways in — the conversation on the left (the one we want) and
+ *  the manual row (the one that's always available) — and nothing else. */
+export function EmptyBoard({ onAdd, readOnly }: { onAdd: () => void; readOnly?: boolean }) {
+  return (
+    <div className="rm-blank">
+      <span className="rm-blank-badge iflex-center">
+        <Icon name="map" size={18} />
+      </span>
+      <h3 className="rm-blank-h text-base">Nothing on the roadmap yet</h3>
+      <p className="rm-blank-b text-sm">
+        Tell the project manager on the left what you want to build. It reads the repo first, then
+        proposes items — you decide what lands here.
+      </p>
+      {!readOnly && (
+        <>
+          <span className="rm-blank-or text-xs">or</span>
+          <Button variant="outline" size="sm" onClick={onAdd}>
+            <Icon name="plus" size={11} /> Add an item yourself
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/ProjectScreen/Roadmap/Board/HorizonGroup.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/HorizonGroup.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { Icon } from "@/components/Icon";
 
 /** One horizon section of the board — a labelled header with a right-aligned
  *  count over a rule-anchored stack of rows. */
@@ -7,6 +8,7 @@ export function HorizonGroup({
   note,
   count,
   empty,
+  onAdd,
   children,
 }: {
   label: string;
@@ -16,6 +18,9 @@ export function HorizonGroup({
   count: number;
   /** Nothing to render at all, committed or proposed. */
   empty: boolean;
+  /** Add an item straight into this horizon — the group is the placement, so
+   *  the form opens already knowing it. Omitted on a read-only board. */
+  onAdd?: () => void;
   children: ReactNode;
 }) {
   return (
@@ -24,6 +29,16 @@ export function HorizonGroup({
         <span className="rm-group-l mono text-xs">{label}</span>
         <span className="rm-group-n text-xs">{note}</span>
         <span className="rm-group-c mono text-xs">{count}</span>
+        {onAdd && (
+          <button
+            type="button"
+            className="rm-group-add iflex-center"
+            onClick={onAdd}
+            aria-label={`Add an item to ${label}`}
+          >
+            <Icon name="plus" size={11} />
+          </button>
+        )}
       </div>
       <div className="rm-group-body">
         {empty ? <div className="rm-empty text-xs">Nothing here yet.</div> : children}

--- a/src/components/ProjectScreen/Roadmap/Board/ItemCard.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/ItemCard.tsx
@@ -1,17 +1,18 @@
 import { Icon, type IconName } from "@/components/Icon";
 import { Button } from "@/components/ui/Button";
 import { useAppStore } from "@/store";
-import { type ItemSource, type RoadmapItem, SIZE_HINT } from "../types";
+import { type BoardItem, type ItemSource, SIZE_HINT } from "../types";
 
 /** Where the item came from, as a one-glyph tag. */
 const SOURCE: Record<ItemSource, { icon: IconName; tip: string }> = {
+  user: { icon: "user", tip: "Added by hand" },
   pm: { icon: "sparkle", tip: "Written here with the PM agent" },
   linear: { icon: "layers", tip: "From Linear" },
   github: { icon: "github", tip: "From GitHub" },
 };
 
 interface Props {
-  item: RoadmapItem;
+  item: BoardItem;
   /** The project's primary repo — where "Send to an agent" opens the draft. */
   repoPath: string;
   /** A proposed row — real only once the user accepts the proposal. */
@@ -20,6 +21,11 @@ interface Props {
   onToggle: () => void;
   /** Ring the row: it was just jumped to, or a pending proposal moves it. */
   focused?: boolean;
+  /** Transient highlight for a row that just landed or just moved. */
+  landed?: boolean;
+  /** Open this item's form. Absent for a ghost (there is no row to edit yet)
+   *  and on a read-only board. */
+  onEdit?: () => void;
   /** Lets the board scroll a focused row into view. */
   cardRef?: (el: HTMLDivElement | null) => void;
 }
@@ -27,15 +33,25 @@ interface Props {
 /** The item as a starting prompt for an agent: what to build, why, and what
  *  "done" means. Prefills the new draft's composer so the user reviews and
  *  launches rather than retyping the row. */
-function briefFor(item: RoadmapItem): string {
+function briefFor(item: BoardItem): string {
   const lines = [`${item.code}: ${item.title}`, "", item.why];
   if (item.accept?.length) lines.push("", "Done when:", ...item.accept.map((a) => `- ${a}`));
-  return lines.join("\n");
+  return lines.join("\n").trim();
 }
 
 /** One roadmap row: a click-to-expand header line (code, title, size, source)
  *  over the rationale, acceptance criteria and dependencies. */
-export function ItemCard({ item, repoPath, ghost, open, onToggle, focused, cardRef }: Props) {
+export function ItemCard({
+  item,
+  repoPath,
+  ghost,
+  open,
+  onToggle,
+  focused,
+  landed,
+  onEdit,
+  cardRef,
+}: Props) {
   const createDraft = useAppStore((s) => s.createDraft);
   const closeProjectScreen = useAppStore((s) => s.closeProjectScreen);
   const source = SOURCE[item.source];
@@ -43,7 +59,7 @@ export function ItemCard({ item, repoPath, ghost, open, onToggle, focused, cardR
     "rm-item",
     ghost ? "ghost" : "",
     open ? "open" : "",
-    item.justAdded ? "landed" : "",
+    landed ? "landed" : "",
     focused ? "focus" : "",
   ]
     .filter(Boolean)
@@ -57,7 +73,9 @@ export function ItemCard({ item, repoPath, ghost, open, onToggle, focused, cardR
         onClick={onToggle}
         aria-expanded={open}
       >
-        <span className="rm-code mono text-xs">{item.code}</span>
+        {/* A proposal has no code yet — one is allocated when the user accepts
+            it — so a number here would be a promise the board then breaks. */}
+        <span className="rm-code mono text-xs">{ghost ? "NEW" : item.code}</span>
         <span className="rm-title text-sm truncate">{item.title}</span>
         {item.epic && <span className="rm-epic text-xs">{item.epic}</span>}
         {item.status === "active" && item.agent && (
@@ -66,12 +84,14 @@ export function ItemCard({ item, repoPath, ghost, open, onToggle, focused, cardR
             {item.agent}
           </span>
         )}
-        <span
-          className={`rm-size iflex-center mono text-xs s-${item.size}`}
-          title={SIZE_HINT[item.size]}
-        >
-          {item.size}
-        </span>
+        {item.size && (
+          <span
+            className={`rm-size iflex-center mono text-xs s-${item.size}`}
+            title={SIZE_HINT[item.size]}
+          >
+            {item.size}
+          </span>
+        )}
         <span className={`rm-src iflex-center src-${item.source}`} title={source.tip}>
           <Icon name={source.icon} size={10} />
         </span>
@@ -80,7 +100,7 @@ export function ItemCard({ item, repoPath, ghost, open, onToggle, focused, cardR
 
       {open && (
         <div className="rm-item-body">
-          <p className="rm-why text-sm">{item.why}</p>
+          {item.why && <p className="rm-why text-sm">{item.why}</p>}
           {item.accept && (
             <ul className="rm-accept text-sm">
               {item.accept.map((a) => (
@@ -89,7 +109,7 @@ export function ItemCard({ item, repoPath, ghost, open, onToggle, focused, cardR
             </ul>
           )}
           <div className="rm-item-foot flex-center">
-            <span className="rm-area mono text-xs">{item.area}</span>
+            {item.area && <span className="rm-area mono text-xs">{item.area}</span>}
             {item.deps?.map((d) => (
               <span key={d} className="rm-dep iflex-center mono text-xs">
                 <Icon name="arrowR" size={9} />
@@ -97,6 +117,11 @@ export function ItemCard({ item, repoPath, ghost, open, onToggle, focused, cardR
               </span>
             ))}
             <span className="grow" />
+            {onEdit && (
+              <Button variant="ghost" size="sm" onClick={onEdit}>
+                <Icon name="edit" size={11} /> Edit
+              </Button>
+            )}
             {/* A proposed row has nothing to send an agent at yet. */}
             {!ghost && (
               <Button

--- a/src/components/ProjectScreen/Roadmap/Board/ItemDialog.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/ItemDialog.tsx
@@ -1,0 +1,210 @@
+import { useState } from "react";
+import type { Horizon, ItemSize, RoadmapItem } from "@/api";
+import { Icon } from "@/components/Icon";
+import { Segmented } from "@/components/Settings/Segmented";
+import { Button } from "@/components/ui/Button";
+import { Modal, ModalBody, ModalFooter } from "@/components/ui/Modal";
+import { Select, type SelectOption } from "@/components/ui/Select";
+import { TextArea, TextInput } from "@/components/ui/TextInput";
+import { HORIZONS, SIZE_HINT } from "../types";
+
+/** The fields a human fills in. Deliberately a subset of the row: `code`,
+ *  `status`, `source` and everything the agent runtime owns are not typed by
+ *  hand. Shaped so it can be passed straight to either `roadmap_create_item` or
+ *  `roadmap_update_item` — the same keys mean the same thing in both. */
+export interface ItemDraft {
+  title: string;
+  why: string;
+  horizon: Horizon;
+  size: ItemSize | null;
+  area: string | null;
+  accept: string[];
+}
+
+/** `null` is a real value here — "no size yet", which is the honest state of an
+ *  idea nobody has shaped. */
+const NO_SIZE = "none";
+
+const SIZE_OPTIONS: SelectOption<string>[] = [
+  { value: NO_SIZE, label: "Unsized", hint: "not shaped yet" },
+  ...(["XS", "S", "M", "L"] as const).map((s) => ({
+    value: s,
+    label: s,
+    hint: SIZE_HINT[s],
+  })),
+];
+
+const HORIZON_OPTIONS = HORIZONS.map((h) => ({ value: h.id, label: h.label }));
+
+/** Acceptance criteria are edited as lines, not as a list widget: they're
+ *  written in one sitting, and a textarea beats five inputs and an "add" button
+ *  for that. Blank lines are dropped. */
+const linesToList = (text: string) =>
+  text
+    .split("\n")
+    .map((l) => l.trim().replace(/^[-*]\s*/, ""))
+    .filter(Boolean);
+
+interface Props {
+  /** The row being edited, or `null` to create one. */
+  item: RoadmapItem | null;
+  /** Where a new item lands — the group whose "+" was pressed. */
+  horizon: Horizon;
+  onClose: () => void;
+  onSave: (draft: ItemDraft) => Promise<unknown>;
+  /** Absent while creating: there is nothing to delete yet. */
+  onDelete?: () => Promise<unknown>;
+}
+
+/** Create or edit one roadmap item. The same form for both, because the fields
+ *  are the same and a separate "quick add" would drift from it. */
+export function ItemDialog({ item, horizon, onClose, onSave, onDelete }: Props) {
+  const [title, setTitle] = useState(item?.title ?? "");
+  const [why, setWhy] = useState(item?.why ?? "");
+  const [place, setPlace] = useState<Horizon>(item?.horizon ?? horizon);
+  const [size, setSize] = useState<string>(item?.size ?? NO_SIZE);
+  const [area, setArea] = useState(item?.area ?? "");
+  const [accept, setAccept] = useState((item?.accept ?? []).join("\n"));
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const canSave = title.trim().length > 0 && !busy;
+
+  const save = async () => {
+    if (!canSave) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await onSave({
+        title: title.trim(),
+        why: why.trim(),
+        horizon: place,
+        size: size === NO_SIZE ? null : (size as ItemSize),
+        area: area.trim() || null,
+        accept: linesToList(accept),
+      });
+      onClose();
+    } catch (e) {
+      setError(String(e));
+      setBusy(false);
+    }
+  };
+
+  const remove = async () => {
+    if (!onDelete || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await onDelete();
+      onClose();
+    } catch (e) {
+      setError(String(e));
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Modal
+      icon={item ? "edit" : "plus"}
+      title={item ? `Edit ${item.code}` : "New roadmap item"}
+      size="lg"
+      className="rm-dialog"
+      onClose={onClose}
+    >
+      <ModalBody>
+        <div className="modal-field">
+          <label className="modal-label text-sm" htmlFor="rm-title">
+            Title
+          </label>
+          <TextInput
+            id="rm-title"
+            autoFocus
+            placeholder="Persist worktree state across app restarts"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            onKeyDown={(e) => {
+              // Enter commits from the one-line field; the prose boxes below
+              // need their newlines.
+              if (e.key === "Enter") void save();
+            }}
+          />
+        </div>
+
+        <div className="modal-field">
+          <span className="modal-label text-sm">Horizon</span>
+          <Segmented value={place} options={HORIZON_OPTIONS} onChange={setPlace} />
+        </div>
+
+        <div className="rm-form-row">
+          <div className="modal-field">
+            <span className="modal-label text-sm">
+              Size <span className="modal-opt">optional</span>
+            </span>
+            <Select value={size} options={SIZE_OPTIONS} onChange={setSize} ariaLabel="Size" />
+          </div>
+          <div className="modal-field">
+            <label className="modal-label text-sm" htmlFor="rm-area">
+              Area <span className="modal-opt">optional</span>
+            </label>
+            <TextInput
+              id="rm-area"
+              placeholder="runtime"
+              value={area}
+              onChange={(e) => setArea(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <div className="modal-field">
+          <label className="modal-label text-sm" htmlFor="rm-why">
+            Why <span className="modal-opt">optional</span>
+          </label>
+          <TextArea
+            id="rm-why"
+            className="rm-textarea"
+            placeholder="The one line that justifies its place on the board."
+            value={why}
+            onChange={(e) => setWhy(e.target.value)}
+          />
+        </div>
+
+        <div className="modal-field">
+          <label className="modal-label text-sm" htmlFor="rm-accept">
+            Done when <span className="modal-opt">one per line, optional</span>
+          </label>
+          <TextArea
+            id="rm-accept"
+            className="rm-textarea"
+            placeholder={"Worktree registry survives a hard quit\nOrphans are offered for cleanup"}
+            value={accept}
+            onChange={(e) => setAccept(e.target.value)}
+          />
+        </div>
+
+        {error && <div className="modal-error text-sm">{error}</div>}
+      </ModalBody>
+
+      <ModalFooter>
+        {onDelete && (
+          <Button
+            variant="ghost"
+            danger
+            disabled={busy}
+            onClick={() => (confirmDelete ? void remove() : setConfirmDelete(true))}
+          >
+            <Icon name="trash" size={12} />
+            {confirmDelete ? "Delete for good?" : "Delete"}
+          </Button>
+        )}
+        <span className="grow" />
+        <Button variant="ghost" onClick={onClose} disabled={busy}>
+          Cancel
+        </Button>
+        <Button variant="primary" onClick={() => void save()} disabled={!canSave}>
+          {item ? "Save" : "Add to roadmap"}
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/src/components/ProjectScreen/Roadmap/Board/index.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/index.tsx
@@ -1,18 +1,47 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import type { Horizon, RoadmapItem } from "@/api";
 import { Icon } from "@/components/Icon";
+import { IconButton } from "@/components/ui/IconButton";
 import { HORIZONS } from "../types";
 import type { RoadmapState } from "../useRoadmap";
+import { EmptyBoard } from "./EmptyBoard";
 import { HorizonGroup } from "./HorizonGroup";
 import { ItemCard } from "./ItemCard";
+import { ItemDialog } from "./ItemDialog";
 import { ProductMap } from "./ProductMap";
+
+/** What the form is open on: an existing row, or a new one destined for
+ *  `horizon` — the group whose "+" was pressed. */
+type Editing = { item: RoadmapItem | null; horizon: Horizon };
 
 /** The board the PM agent maintains: horizon groups of expandable items, with
  *  a proposal's additions rendered inline as ghost rows. Sibling tab shows the
  *  product map the agent reasons against. */
 export function Board({ roadmap, repoPath }: { roadmap: RoadmapState; repoPath: string }) {
-  const { items, ghosts, moves, map, shipped, tab, setTab, openCodes, toggleItem, focusCode } =
-    roadmap;
+  const {
+    items,
+    ghosts,
+    moves,
+    map,
+    shipped,
+    tab,
+    setTab,
+    openCodes,
+    toggleItem,
+    focusCode,
+    landed,
+    loading,
+    readOnly,
+    error,
+    clearError,
+    addItem,
+    editItem,
+    removeItem,
+  } = roadmap;
 
+  const [editing, setEditing] = useState<Editing | null>(null);
+  /** The row the form is editing, if it isn't creating one. */
+  const editRow = editing?.item ?? null;
   const scroll = useRef<HTMLDivElement>(null);
   const rows = useRef<Record<string, HTMLDivElement | null>>({});
 
@@ -28,6 +57,9 @@ export function Board({ roadmap, repoPath }: { roadmap: RoadmapState; repoPath: 
 
   const ghostCodes = new Set(ghosts.map((g) => g.code));
   const movedCodes = new Set(moves.map((m) => m.code));
+  /** Nothing on the board at all — not even a pending proposal. */
+  const blank = !loading && items.length === 0 && ghosts.length === 0;
+  const openNew = (horizon: Horizon) => setEditing({ item: null, horizon });
 
   return (
     <aside className="rm-board">
@@ -50,16 +82,42 @@ export function Board({ roadmap, repoPath }: { roadmap: RoadmapState; repoPath: 
         </div>
         <span className="grow" />
         {tab === "roadmap" && (
-          <span className="rm-shipped iflex-center mono text-xs">
-            <Icon name="merge" size={11} />
-            {shipped} shipped
-          </span>
+          <>
+            {/* Zero shipped is the honest state of a new project, and saying so
+                adds nothing — the stat appears once there's something to count. */}
+            {shipped > 0 && (
+              <span className="rm-shipped iflex-center mono text-xs">
+                <Icon name="merge" size={11} />
+                {shipped} shipped
+              </span>
+            )}
+            {!readOnly && (
+              <IconButton
+                aria-label="Add roadmap item"
+                tip="Add an item"
+                onClick={() => openNew("next")}
+              >
+                <Icon name="plus" />
+              </IconButton>
+            )}
+          </>
         )}
       </div>
+
+      {error && (
+        <div className="rm-board-err flex-center text-xs">
+          <span className="rm-board-err-t">{error}</span>
+          <button type="button" className="rm-board-err-x" onClick={clearError}>
+            Dismiss
+          </button>
+        </div>
+      )}
 
       <div className="rm-board-scroll" ref={scroll}>
         {tab === "map" ? (
           <ProductMap map={map} />
+        ) : blank ? (
+          <EmptyBoard readOnly={readOnly} onAdd={() => openNew("next")} />
         ) : (
           HORIZONS.map((h) => {
             const real = items.filter((i) => i.horizon === h.id);
@@ -74,26 +132,49 @@ export function Board({ roadmap, repoPath }: { roadmap: RoadmapState; repoPath: 
                 note={h.note}
                 count={real.length}
                 empty={rowsFor.length === 0}
+                onAdd={readOnly ? undefined : () => openNew(h.id)}
               >
-                {rowsFor.map((it) => (
-                  <ItemCard
-                    key={it.code}
-                    item={it}
-                    repoPath={repoPath}
-                    ghost={ghostCodes.has(it.code)}
-                    open={openCodes.has(it.code)}
-                    focused={focusCode === it.code || movedCodes.has(it.code)}
-                    onToggle={() => toggleItem(it.code)}
-                    cardRef={(el) => {
-                      rows.current[it.code] = el;
-                    }}
-                  />
-                ))}
+                {rowsFor.map((it) => {
+                  const row = it.item;
+                  return (
+                    <ItemCard
+                      key={it.code}
+                      item={it}
+                      repoPath={repoPath}
+                      // A row the PM has only proposed isn't real yet, whether
+                      // it's a pending ghost in this session or a `proposed`
+                      // row someone else's session wrote.
+                      ghost={ghostCodes.has(it.code) || it.status === "proposed"}
+                      open={openCodes.has(it.code)}
+                      landed={landed.has(it.code)}
+                      focused={focusCode === it.code || movedCodes.has(it.code)}
+                      onToggle={() => toggleItem(it.code)}
+                      onEdit={
+                        row && !readOnly
+                          ? () => setEditing({ item: row, horizon: row.horizon })
+                          : undefined
+                      }
+                      cardRef={(el) => {
+                        rows.current[it.code] = el;
+                      }}
+                    />
+                  );
+                })}
               </HorizonGroup>
             );
           })
         )}
       </div>
+
+      {editing && (
+        <ItemDialog
+          item={editing.item}
+          horizon={editing.horizon}
+          onClose={() => setEditing(null)}
+          onSave={(draft) => (editRow ? editItem(editRow.id, draft) : addItem(draft))}
+          onDelete={editRow ? () => removeItem(editRow.id) : undefined}
+        />
+      )}
     </aside>
   );
 }

--- a/src/components/ProjectScreen/Roadmap/Roadmap.css
+++ b/src/components/ProjectScreen/Roadmap/Roadmap.css
@@ -13,6 +13,7 @@
 .rm-board-h .grow,
 .rm-prop-foot .grow,
 .rm-item-foot .grow,
+.rm-dialog .modal-foot .grow,
 .rm-composer-wrap .composer-foot .grow {
   flex: 1;
 }
@@ -310,6 +311,71 @@
   padding: 14px 14px 48px;
 }
 
+/* A write that failed. Sits between the tabs and the rows, because it is about
+   the board as a whole and there is no single row to hang it off. */
+.rm-board-err {
+  flex-shrink: 0;
+  gap: 10px;
+  padding: 8px 14px;
+  color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 10%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--danger) 28%, transparent);
+}
+.rm-board-err-t {
+  flex: 1;
+  min-width: 0;
+  line-height: var(--lh-snug);
+  text-wrap: pretty;
+}
+.rm-board-err-x {
+  flex-shrink: 0;
+  color: var(--fg-2);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.rm-board-err-x:hover {
+  color: var(--fg-0);
+}
+
+/* ── the empty board ──
+   A brand-new project. Three empty horizon groups read as a broken screen, so
+   the whole board is replaced by one panel that names the two ways in. */
+.rm-blank {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  max-width: 340px;
+  margin: 12% auto 0;
+  padding: 0 8px;
+  text-align: center;
+}
+.rm-blank-badge {
+  width: 40px;
+  height: 40px;
+  margin-bottom: 2px;
+  border-radius: var(--r-md);
+  color: var(--accent);
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-line);
+}
+.rm-blank-h {
+  margin: 0;
+  font-weight: 600;
+  color: var(--fg-0);
+}
+.rm-blank-b {
+  margin: 0;
+  line-height: var(--lh-normal);
+  color: var(--fg-2);
+  text-wrap: pretty;
+}
+.rm-blank-or {
+  margin-top: 2px;
+  color: var(--fg-3);
+  font-style: italic;
+}
+
 /* ── horizon group ── */
 .rm-group + .rm-group {
   margin-top: 22px;
@@ -333,6 +399,25 @@
   margin-left: auto;
   color: var(--fg-3);
   font-variant-numeric: tabular-nums;
+}
+/* Add straight into this horizon. Quiet until the group is hovered — one of
+   these per group would otherwise be three competing buttons. */
+.rm-group-add {
+  width: 18px;
+  height: 18px;
+  margin-left: 2px;
+  border-radius: var(--r-xs);
+  color: var(--fg-3);
+  opacity: 0;
+  transition: var(--transition-ui);
+}
+.rm-group:hover .rm-group-add,
+.rm-group-add:focus-visible {
+  opacity: 1;
+}
+.rm-group-add:hover {
+  color: var(--fg-0);
+  background: var(--hover);
 }
 .rm-group-body {
   display: flex;
@@ -522,6 +607,20 @@
   .rm-item.landed {
     animation: none;
   }
+}
+
+/* ── the item form ── */
+/* Two short fields share a line: size and area are both one glance wide, and
+   stacking them would push "Why" below the fold. */
+.rm-form-row {
+  display: grid;
+  grid-template-columns: 130px 1fr;
+  gap: 12px;
+}
+.rm-textarea {
+  min-height: 62px;
+  resize: vertical;
+  line-height: var(--lh-normal);
 }
 
 /* ── product map tab ── */

--- a/src/components/ProjectScreen/Roadmap/Thread/Proposal.tsx
+++ b/src/components/ProjectScreen/Roadmap/Thread/Proposal.tsx
@@ -36,7 +36,8 @@ export function Proposal({
           c.kind === "add" ? (
             <div key={c.item.code} className="rm-prop-row flex-center text-sm">
               <span className="rm-prop-op add iflex-center mono">+</span>
-              <span className="rm-prop-code mono text-xs">{c.item.code}</span>
+              {/* No code yet — the backend allocates one if this is accepted. */}
+              <span className="rm-prop-code mono text-xs">NEW</span>
               <span className="rm-prop-title truncate">{c.item.title}</span>
               <span className="rm-prop-tag mono text-xs">{c.item.horizon}</span>
             </div>

--- a/src/components/ProjectScreen/Roadmap/mockData.ts
+++ b/src/components/ProjectScreen/Roadmap/mockData.ts
@@ -1,106 +1,18 @@
-// Placeholder roadmap content. There is no roadmap table or API yet, so the
-// board renders from this module for every project. It is deliberately diverse
-// — every horizon, size, source and status is represented, plus an epic, a
-// dependency chain and an item an agent is actively working — so the shapes in
-// `types.ts` can be turned into a schema without discovering missing columns.
+// Placeholder content for the parts of the Roadmap surface that aren't real
+// yet: the PM conversation (a canned script) and the product map.
 //
-// Replacing this with real data means swapping the four exports below for
-// loaders; nothing else in the folder reads from it.
+// The *board* is no longer here — items are rows in `roadmap_items`, loaded by
+// `useRoadmap` (see src/api/domains/roadmap.ts). The seed items, the shipped
+// count and the code prefix that used to live in this file are gone with it:
+// codes are allocated by the backend, per project.
+//
+// What remains is the script the thread plays until the real PM agent replaces
+// it. Its proposals are mock, but accepting one is not — the changes are
+// written through the API like any other edit. The codes it quotes are
+// placeholders (ghost rows render as "NEW"); the real code is allocated on
+// accept.
 
-import type { MapDomain, PmBody, RoadmapItem, ScriptBeat } from "./types";
-
-/** Codes minted for free-form ideas the PM captures mid-conversation. */
-export const CODE_PREFIX = "FLT-";
-export const FIRST_FREE_CODE = 160;
-
-/** Items already merged. Not on the board — only the header stat. */
-export const SHIPPED_COUNT = 18;
-
-export const SEED_ITEMS: RoadmapItem[] = [
-  {
-    code: "FLT-142",
-    horizon: "now",
-    size: "M",
-    area: "runtime",
-    source: "linear",
-    status: "active",
-    agent: "dolomites",
-    title: "Persist worktree state across app restarts",
-    why: "Fletch forgets in-flight agents when the app quits — the loudest complaint of the last two weeks.",
-    accept: [
-      "Worktree registry survives a hard quit",
-      "Reattaching shows the agent's last transcript",
-      "Orphaned worktrees are offered for cleanup",
-    ],
-  },
-  {
-    code: "FLT-149",
-    horizon: "now",
-    size: "S",
-    area: "runtime",
-    source: "pm",
-    status: "open",
-    title: "Recover orphaned worktrees on launch",
-    why: "Falls out of FLT-142 — without recovery the registry drifts from what's on disk.",
-    accept: ["Scan .fletch/ on boot", "One-click adopt or delete"],
-    deps: ["FLT-142"],
-  },
-  {
-    code: "FLT-137",
-    horizon: "next",
-    size: "S",
-    area: "runtime",
-    source: "linear",
-    status: "open",
-    title: "Backpressure on agent output streaming",
-    why: "Large diffs flood the renderer; the paint-jitter fix only masked it.",
-    accept: ["Stream chunks capped per frame", "No dropped tokens under load"],
-  },
-  {
-    code: "FLT-144",
-    horizon: "next",
-    size: "M",
-    area: "chrome",
-    source: "pm",
-    status: "open",
-    title: "Per-project agent presets",
-    why: "Every new agent in a repo gets the same provider, base branch and workflow — stop re-picking it.",
-    accept: ["Preset editable from the project page", "New-agent draft pre-filled"],
-  },
-  {
-    code: "FLT-131",
-    horizon: "next",
-    size: "XS",
-    area: "chrome",
-    source: "github",
-    status: "open",
-    title: "Surface per-agent token spend in the title bar",
-    why: "Spend is invisible until the invoice arrives.",
-    accept: ["Live cost per worktree", "Roll-up per project"],
-  },
-  {
-    code: "FLT-119",
-    horizon: "later",
-    size: "L",
-    area: "platform",
-    source: "pm",
-    status: "open",
-    title: "Multi-repo projects",
-    why: "Teams with split front/back repos run two Fletch projects today and lose the shared roadmap.",
-    accept: ["One project, many repos", "Agents pick a repo at spawn"],
-  },
-  {
-    code: "FLT-124",
-    horizon: "later",
-    size: "M",
-    area: "chrome",
-    source: "pm",
-    status: "open",
-    title: "Ambient run monitoring outside the app",
-    why: "People leave Fletch while agents work and want a glanceable signal.",
-    accept: ["Menu-bar summary", "Notification when an agent needs you"],
-  },
-];
+import type { MapDomain, PmBody, ScriptBeat } from "./types";
 
 export const PRODUCT_MAP: MapDomain[] = [
   {
@@ -145,35 +57,15 @@ export const PRODUCT_MAP: MapDomain[] = [
   },
 ];
 
-/** What's already in the thread when the page opens. */
+/** What's already in the thread when the page opens. Deliberately says nothing
+ *  about the board's contents: the board is real now, and a scripted opener
+ *  that claimed to have filed items would contradict whatever is actually
+ *  there — starting with a new project's empty board. */
 export const SEED_THREAD: PmBody[] = [
   {
-    kind: "user",
-    body: "The thing people keep hitting is that quitting Fletch loses everything in flight. Make that not happen.",
-  },
-  {
-    kind: "probe",
-    summary: "Read 9 files across the runtime · found 1 partial capability",
-    findings: [
-      {
-        kind: "ok",
-        text: "`WorktreeRegistry` already tracks live worktrees in memory — no persistence layer.",
-      },
-      {
-        kind: "warn",
-        text: "The reattach path assumes a live child process; it needs a resume branch.",
-      },
-      {
-        kind: "ok",
-        text: "`.fletch/` on disk is already the source of truth for the checkout itself.",
-      },
-    ],
-  },
-  {
     kind: "text",
-    body: "That's a real gap, not a bug — the registry is memory-only. I filed it at the top of In flight and split the recovery half out, because the two land at different times.",
+    body: "Tell me what you want this project to do next — an outcome, a complaint, a half-formed idea. I'll read the repo before I write anything down, and nothing reaches the board until you accept it.",
   },
-  { kind: "landed", codes: ["FLT-142", "FLT-149"] },
 ];
 
 /** Canned exchanges, offered as suggestion chips until they've been used. */

--- a/src/components/ProjectScreen/Roadmap/types.ts
+++ b/src/components/ProjectScreen/Roadmap/types.ts
@@ -1,34 +1,34 @@
-// The Roadmap surface's data model. Everything here is currently fed by
-// `mockData.ts` — there is no roadmap table or API yet. The shapes are written
-// as if they came from the DB (flat rows, string codes, explicit enums) so the
-// eventual schema can be modelled straight off them.
+// The Roadmap surface's data model.
+//
+// The board's rows are real, persisted `roadmap_items` — their shape lives in
+// `@/api` (src/api/types/roadmap.ts, mirroring src-tauri/src/roadmap/types.rs)
+// and is re-exported here so the folder keeps importing from one place. What is
+// defined here is what the *screen* adds on top: the display row the board
+// draws (which can be a persisted item or a not-yet-real proposal), the product
+// map, and the PM conversation — all three still fed by `mockData.ts`.
 
+import type { Horizon, ItemSize, ItemSource, ItemStatus, RoadmapItem } from "@/api";
 import type { UIAnswer, UIQuestion } from "@/components/Workspace/messages/UserInput/parse";
 
-/** Where an item sits on the board. `now` is being built, `next` is queued,
- *  `later` is the backlog. Shipped items leave the board (see `shipped`). */
-export type Horizon = "now" | "next" | "later";
+export type { Horizon, ItemSize, ItemSource, ItemStatus, RoadmapItem } from "@/api";
 
-export type ItemSize = "XS" | "S" | "M" | "L";
-
-/** Where the item came from — drawn as a glyph on the row. */
-export type ItemSource = "pm" | "linear" | "github";
-
-/** `active` means an agent is on it right now. */
-export type ItemStatus = "open" | "active";
-
-export interface RoadmapItem {
-  /** Short human id ("FLT-142", "#207") — unique per project. */
+/** A row as the board draws it. Persisted items reach it through
+ *  [`toBoardItem`]; a proposal the PM hasn't had accepted yet has no row in the
+ *  database, so it arrives as one of these directly (a "ghost"). Fields the
+ *  board can do without are optional, because an unaccepted proposal is allowed
+ *  to be less complete than a stored item. */
+export interface BoardItem {
+  /** Short human id ("FLT-142"). Unique per project, and the board's row key. */
   code: string;
   title: string;
   horizon: Horizon;
-  size: ItemSize;
-  /** Product-map domain this belongs to (`MapDomain.id`). */
-  area: string;
-  source: ItemSource;
-  status: ItemStatus;
   /** Why it's on the board — the one line that justifies its place. */
   why: string;
+  status: ItemStatus;
+  source: ItemSource;
+  size?: ItemSize;
+  /** Product-map domain this belongs to (`MapDomain.id`). */
+  area?: string;
   /** Acceptance criteria, rendered as a checklist. */
   accept?: string[];
   /** Codes this item must land after. */
@@ -37,8 +37,30 @@ export interface RoadmapItem {
   epic?: string;
   /** Agent working it — only meaningful while `status === "active"`. */
   agent?: string;
-  /** Transient highlight for a row that just landed on the board. */
-  justAdded?: boolean;
+  /** The stored row, when there is one. Absent on a ghost, which is exactly
+   *  what gates the edit / delete / send-to-agent affordances: they all need
+   *  something real to act on. */
+  item?: RoadmapItem;
+}
+
+/** Adapt a persisted row for the board. The DTO's nulls become `undefined` so
+ *  the display type stays uniform with a ghost's optional fields. */
+export function toBoardItem(item: RoadmapItem): BoardItem {
+  return {
+    code: item.code,
+    title: item.title,
+    horizon: item.horizon,
+    why: item.why,
+    status: item.status,
+    source: item.source,
+    size: item.size ?? undefined,
+    area: item.area ?? undefined,
+    accept: item.accept.length ? item.accept : undefined,
+    deps: item.deps.length ? item.deps : undefined,
+    epic: item.epic ?? undefined,
+    agent: item.agent_id ?? undefined,
+    item,
+  };
 }
 
 /** A slice of the codebase the PM agent knows about, shown on the Product map
@@ -69,7 +91,7 @@ export interface Finding {
 /** A single edit the PM proposes to the board. Nothing is applied until the
  *  user accepts the proposal that carries it. */
 export type ProposalChange =
-  | { kind: "add"; item: RoadmapItem }
+  | { kind: "add"; item: BoardItem }
   | { kind: "move"; code: string; from: Horizon; to: Horizon; why: string };
 
 /** The follow-up the PM plays once a question is answered. */

--- a/src/components/ProjectScreen/Roadmap/useRoadmap.ts
+++ b/src/components/ProjectScreen/Roadmap/useRoadmap.ts
@@ -3,21 +3,30 @@
 // the board renders the proposal as ghost rows, and the user commits. That rule
 // lives here, so both columns stay honest about what is real.
 //
-// State is in-memory only (see `mockData.ts`); reloading the page resets it.
+// The board is persisted, per project, in `roadmap_items` (src-tauri/src/roadmap).
+// This hook loads it once for the current project and then keeps it live off the
+// `roadmap:item` / `roadmap:item-deleted` events, upserting the full row by id —
+// the same fetch-once-then-upsert shape `useRuns` uses. Every mutation goes
+// through the API, including the ones the thread triggers: accepting a proposal
+// creates real rows, and takes their real, backend-allocated codes.
+//
+// The PM thread itself is still the canned script in `mockData.ts` — a real
+// agent replaces it next. What is no longer fake is everything it writes.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { UIAnswer } from "@/components/Workspace/messages/UserInput/parse";
 import {
-  CODE_PREFIX,
-  FIRST_FREE_CODE,
-  freeFormBeat,
-  PRODUCT_MAP,
-  SCRIPT,
-  SEED_ITEMS,
-  SEED_THREAD,
-  SHIPPED_COUNT,
-} from "./mockData";
-import type { Horizon, PmBody, PmMessage, ProposalChange, RoadmapItem } from "./types";
+  api,
+  type NewRoadmapItem,
+  onRoadmapItem,
+  onRoadmapItemDeleted,
+  type RoadmapItem,
+  type RoadmapItemPatch,
+} from "@/api";
+import type { UIAnswer } from "@/components/Workspace/messages/UserInput/parse";
+import { useAppStore } from "@/store";
+import { freeFormBeat, PRODUCT_MAP, SCRIPT, SEED_THREAD } from "./mockData";
+import type { BoardItem, Horizon, PmBody, PmMessage, ProposalChange } from "./types";
+import { toBoardItem } from "./types";
 
 /** Beat pacing, in ms after the previous message. A probe reads as work, so it
  *  lands slower than a line of prose. */
@@ -40,19 +49,43 @@ let seq = 0;
 const nextId = () => `pm-${++seq}`;
 const withId = (body: PmBody): PmMessage => ({ ...body, id: nextId() });
 
+/** Placeholder key for a row the PM proposed mid-conversation. It is never
+ *  displayed — a ghost renders as "NEW", because its real code isn't allocated
+ *  until the user accepts — it only has to be unique so React keys and
+ *  `openCodes` can tell two pending ghosts apart. */
+let draftSeq = 0;
+const nextDraftCode = () => `draft-${++draftSeq}`;
+
 export type BoardTab = "roadmap" | "map";
 
-export function useRoadmap() {
-  const [items, setItems] = useState<RoadmapItem[]>(SEED_ITEMS);
+/** A shipped item leaves the board entirely and survives only as the header's
+ *  count, so "on the board" is every status but `done`. */
+const isOnBoard = (i: RoadmapItem) => i.status !== "done";
+
+export function useRoadmap(repoPath: string) {
+  // The board is per project, not per repo: a multi-repo project has one
+  // roadmap. Resolved from the pinned-repo list the sidebar already loads.
+  const projectId =
+    useAppStore((s) => s.workspace?.projects.find((p) => p.path === repoPath)?.project_id) ?? null;
+  // Until the workspace itself is loaded, a missing project_id means "not known
+  // yet", not "no project" — telling a populated board it's empty for a frame
+  // would flash the empty state at someone who has a roadmap.
+  const workspaceReady = useAppStore((s) => s.workspace != null);
+
+  const [rows, setRows] = useState<RoadmapItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  /** The last failure from a mutation with no form of its own to report into
+   *  (a move, a delete, an accepted proposal). */
+  const [error, setError] = useState<string | null>(null);
   const [messages, setMessages] = useState<PmMessage[]>(() => SEED_THREAD.map(withId));
   const [thinking, setThinking] = useState(false);
   /** Indices into SCRIPT already played — they drop out of the suggestions. */
   const [used, setUsed] = useState<ReadonlySet<number>>(() => new Set());
-  /** Free-form ideas captured so far, so minted codes don't collide. */
-  const [captured, setCaptured] = useState(0);
   const [tab, setTab] = useState<BoardTab>("roadmap");
   const [openCodes, setOpenCodes] = useState<ReadonlySet<string>>(() => new Set());
   const [focusCode, setFocusCode] = useState<string | null>(null);
+  /** Codes highlighted because they just landed or just moved. */
+  const [landed, setLanded] = useState<ReadonlySet<string>>(() => new Set());
 
   // Every pending beat, so unmounting mid-conversation can't set state on a
   // dead component.
@@ -69,7 +102,78 @@ export function useRoadmap() {
 
   const push = useCallback((body: PmBody) => setMessages((m) => [...m, withId(body)]), []);
 
+  // ── the persisted board ────────────────────────────────────────────
+  /** Upsert a row by id, appending new ones — the backend lists oldest-first
+   *  and a new row is the newest, so append keeps the two in the same order. */
+  const upsert = useCallback((row: RoadmapItem) => {
+    setRows((prev) =>
+      prev.some((r) => r.id === row.id)
+        ? prev.map((r) => (r.id === row.id ? row : r))
+        : [...prev, row],
+    );
+  }, []);
+
+  useEffect(() => {
+    if (!projectId) {
+      setRows([]);
+      setLoading(!workspaceReady);
+      return;
+    }
+    let alive = true;
+    setLoading(true);
+    api
+      .roadmapListItems(projectId)
+      .then((items) => {
+        if (!alive) return;
+        setRows(items);
+        setLoading(false);
+      })
+      .catch((e) => {
+        if (!alive) return;
+        setError(String(e));
+        setLoading(false);
+      });
+
+    // Rows change from more than this screen (the PM agent's own writes, and
+    // later the run queue), so the board follows the event rather than only
+    // its own command results.
+    const off = onRoadmapItem((row) => {
+      if (row.project_id !== projectId) return;
+      upsert(row);
+    });
+    const offDeleted = onRoadmapItemDeleted((id) => {
+      setRows((prev) => prev.filter((r) => r.id !== id));
+    });
+
+    return () => {
+      alive = false;
+      void off.then((f) => f());
+      void offDeleted.then((f) => f());
+    };
+  }, [projectId, upsert, workspaceReady]);
+
+  /** Light up rows for a moment after they land, then clear only those — a
+   *  later landing must not have its highlight cut short by an earlier timer. */
+  const markLanded = useCallback(
+    (codes: string[]) => {
+      if (!codes.length) return;
+      setLanded((prev) => new Set([...prev, ...codes]));
+      after(LANDED_MS, () =>
+        setLanded((prev) => {
+          const next = new Set(prev);
+          for (const c of codes) next.delete(c);
+          return next;
+        }),
+      );
+    },
+    [after],
+  );
+
   // ── derived ────────────────────────────────────────────────────────
+  const items = useMemo(() => rows.filter(isOnBoard).map(toBoardItem), [rows]);
+  /** Shipped items aren't on the board; the header carries the count. */
+  const shipped = useMemo(() => rows.filter((r) => !isOnBoard(r)).length, [rows]);
+
   const pending = messages.find((m) => m.kind === "proposal" && !m.resolved) ?? null;
   const openQuestion = messages.find((m) => m.kind === "question" && !m.answer) ?? null;
   /** The user owes an answer or a decision before the thread can move on. */
@@ -79,7 +183,7 @@ export function useRoadmap() {
    *  proposals open at once, only one of which the board renders. */
   const busy = thinking;
 
-  const ghosts =
+  const ghosts: BoardItem[] =
     pending?.kind === "proposal"
       ? pending.changes.flatMap((c) => (c.kind === "add" ? [c.item] : []))
       : [];
@@ -97,6 +201,62 @@ export function useRoadmap() {
   const suggestions = SCRIPT.filter((_, i) => !used.has(i))
     .slice(0, 2)
     .map((s) => s.prompt);
+
+  // ── board mutations ────────────────────────────────────────────────
+  /** Add a row; the code is allocated backend-side. Throws on failure, because
+   *  its caller is a form that can say so inline. */
+  const addItem = useCallback(
+    async (input: NewRoadmapItem) => {
+      if (!projectId) throw new Error("This repo isn't part of a project yet.");
+      const row = await api.roadmapCreateItem(projectId, input);
+      upsert(row);
+      markLanded([row.code]);
+      return row;
+    },
+    [projectId, upsert, markLanded],
+  );
+
+  /** Edit a row. Throws, like `addItem` — its caller is the same form. */
+  const editItem = useCallback(
+    async (id: string, patch: RoadmapItemPatch) => {
+      const row = await api.roadmapUpdateItem(id, patch);
+      upsert(row);
+      return row;
+    },
+    [upsert],
+  );
+
+  /** Run a mutation whose caller has nowhere to render a failure, and surface
+   *  it on the board instead of dropping it on the floor. */
+  const guarded = useCallback(async (fn: () => Promise<unknown>) => {
+    try {
+      setError(null);
+      await fn();
+    } catch (e) {
+      setError(String(e));
+    }
+  }, []);
+
+  const moveItem = useCallback(
+    (id: string, to: Horizon) =>
+      guarded(async () => {
+        const row = await api.roadmapUpdateItem(id, { horizon: to });
+        upsert(row);
+        markLanded([row.code]);
+      }),
+    [guarded, markLanded, upsert],
+  );
+
+  const removeItem = useCallback(
+    (id: string) =>
+      guarded(async () => {
+        await api.roadmapDeleteItem(id);
+        setRows((prev) => prev.filter((r) => r.id !== id));
+      }),
+    [guarded],
+  );
+
+  const clearError = useCallback(() => setError(null), []);
 
   // ── playing a beat ─────────────────────────────────────────────────
   const play = useCallback(
@@ -130,10 +290,9 @@ export function useRoadmap() {
         play(SCRIPT[idx].msgs);
         return;
       }
-      setCaptured((n) => n + 1);
-      play(freeFormBeat(body, `${CODE_PREFIX}${FIRST_FREE_CODE + captured}`));
+      play(freeFormBeat(body, nextDraftCode()));
     },
-    [blocked, busy, captured, play, push, used],
+    [blocked, busy, play, push, used],
   );
 
   const answerQuestion = useCallback(
@@ -150,39 +309,58 @@ export function useRoadmap() {
   );
 
   // ── committing a proposal ──────────────────────────────────────────
+  /** Turn a proposal into rows. An add becomes a real item — the ghost's code
+   *  was only ever a placeholder, so what the user sees afterwards is the code
+   *  the backend allocated. A move addresses its row by code; one naming a code
+   *  this project doesn't have is skipped rather than failing the whole commit.
+   *  Returns the codes that actually landed. */
   const applyChanges = useCallback(
-    (changes: ProposalChange[]) => {
-      const adds = changes.flatMap((c) =>
-        c.kind === "add" ? [{ ...c.item, justAdded: true }] : [],
-      );
-      const moved = new Map(
-        changes.flatMap((c) => (c.kind === "move" ? [[c.code, c.to] as const] : [])),
-      );
-      setItems((arr) => [
-        ...arr.map((it) => {
-          const to = moved.get(it.code);
-          return to ? { ...it, horizon: to, justAdded: true } : it;
-        }),
-        ...adds,
-      ]);
-      // Clear only the rows this call lit up, so a later landing doesn't have
-      // its highlight cut short by an earlier one's timer.
-      const landed = new Set([...adds.map((a) => a.code), ...moved.keys()]);
-      after(LANDED_MS, () =>
-        setItems((arr) =>
-          arr.map((it) => (landed.has(it.code) ? { ...it, justAdded: false } : it)),
-        ),
-      );
-      return [...landed];
+    async (changes: ProposalChange[]) => {
+      if (!projectId) throw new Error("This repo isn't part of a project yet.");
+      const codes: string[] = [];
+      for (const c of changes) {
+        if (c.kind === "add") {
+          const row = await api.roadmapCreateItem(projectId, {
+            title: c.item.title,
+            why: c.item.why,
+            horizon: c.item.horizon,
+            size: c.item.size ?? null,
+            area: c.item.area ?? null,
+            source: "pm",
+            epic: c.item.epic ?? null,
+            accept: c.item.accept ?? [],
+            deps: c.item.deps ?? [],
+          });
+          upsert(row);
+          codes.push(row.code);
+        } else {
+          const target = rows.find((r) => r.code === c.code);
+          if (!target) continue;
+          const row = await api.roadmapUpdateItem(target.id, { horizon: c.to });
+          upsert(row);
+          codes.push(row.code);
+        }
+      }
+      markLanded(codes);
+      return codes;
     },
-    [after],
+    [markLanded, projectId, rows, upsert],
   );
 
   const accept = useCallback(
-    (id: string) => {
+    async (id: string) => {
       const p = messages.find((m) => m.id === id);
       if (p?.kind !== "proposal" || p.resolved) return;
-      const codes = applyChanges(p.changes);
+      let codes: string[];
+      try {
+        setError(null);
+        codes = await applyChanges(p.changes);
+      } catch (e) {
+        // The proposal stays open: nothing was committed, so the user can
+        // retry once whatever failed is fixed.
+        setError(String(e));
+        return;
+      }
       setMessages((arr) => arr.map((m) => (m.id === id ? { ...m, resolved: "accepted" } : m)));
       after(420, () => push({ kind: "landed", codes }));
     },
@@ -228,7 +406,13 @@ export function useRoadmap() {
     ghosts,
     moves,
     counts,
-    shipped: SHIPPED_COUNT,
+    shipped,
+    loading,
+    /** No project row for this repo — the board can be read but not written,
+     *  so the write affordances stay out of the way. */
+    readOnly: workspaceReady && projectId == null,
+    error,
+    clearError,
     map: PRODUCT_MAP,
     tab,
     setTab,
@@ -236,6 +420,11 @@ export function useRoadmap() {
     toggleItem,
     focusCode,
     focusItem,
+    landed,
+    addItem,
+    editItem,
+    moveItem,
+    removeItem,
     // thread
     messages,
     busy,

--- a/src/components/ProjectScreen/index.tsx
+++ b/src/components/ProjectScreen/index.tsx
@@ -38,8 +38,9 @@ export function ProjectScreen({ repoPath }: { repoPath: string }) {
   const [loaded, setLoaded] = useState<Loaded | null>(null);
   const [error, setError] = useState<string | null>(null);
   // Lives here, not in <Roadmap>, because the header shows the same counts —
-  // and they move when the user accepts a proposal.
-  const roadmap = useRoadmap();
+  // and they move when the user accepts a proposal. Keyed by the repo, which
+  // the hook resolves to the owning project (one roadmap per project).
+  const roadmap = useRoadmap(repoPath);
 
   // Custom display name for this repo, falling back to the folder basename.
   const name = projects?.find((p) => p.path === repoPath)?.name ?? basename(repoPath);


### PR DESCRIPTION
PR 1 of 5 (roadmap stack). Replaces the Roadmap tab's mock board with real per-project persistence.

## What
- `roadmap_items` table (migration 0026): flat list with per-project human codes ("FLT-142"), full status lifecycle written down now (`proposed → open → queued → active → in_review → done`), nullable `parent_id` reserved for future subtasks (no UI in v1), and forward columns for the agent hand-off (`agent_id`, `workflow_def_id`, `run_id`, `pr_url`/`pr_number`).
- `src-tauri/src/roadmap/`: typed commands + row-level `roadmap:item` / `roadmap:item-deleted` events; DAO split out so later Rust-side writers (PM RPC tool, queue drainer) reuse it. Deliberately **not** in the generic CRUD allow-list — code allocation, JSON marshalling and events can't be bypassed.
- Frontend: fetch-once-then-upsert hook (same shape as `useRuns`), manual add/edit/delete dialog, empty-board state, real shipped count (= done items).
- The PM thread stays scripted (replaced in PR 2), but accepted proposals now persist real rows with backend-allocated codes.

## Verification
cargo fmt/check/test (1145 passed) · tsc · biome · vitest (761 passed)

Stack: this PR → #582 → #583 → #584 → merge-sweep (PR 5 in progress).