### PR TITLE
feat(roadmap): queued items dispatch workflows autonomously

### DIFF
--- a/src-tauri/migrations/0028_wf_run_roadmap_item.sql
+++ b/src-tauri/migrations/0028_wf_run_roadmap_item.sql
@@ -1,0 +1,12 @@
+-- The roadmap item a workflow run was dispatched for, set when the roadmap
+-- queue drainer (src-tauri/src/roadmap/drainer.rs) launches a run for a queued
+-- item. Nullable back-link: the item already carries `run_id` forward, and this
+-- is the reverse edge the drainer needs to count a project's live
+-- roadmap-dispatched runs without reading the whole board.
+--
+-- NULL for every run a human launched by hand (the composer, a promotion, a
+-- Home-inbox issue) — those are not the queue's to throttle or to settle.
+-- Mirrors `wf_run.issue_ref` (migration 0024): a plain nullable TEXT column, no
+-- foreign key, so deleting a roadmap item never cascades away the run that
+-- proves the work happened.
+ALTER TABLE wf_run ADD COLUMN roadmap_item_id TEXT;

--- a/src-tauri/src/database/connection.rs
+++ b/src-tauri/src/database/connection.rs
@@ -61,6 +61,7 @@ pub(crate) const MIGRATIONS: &[&str] = &[
     include_str!("../../migrations/0025_worktree_pr_history.sql"),
     include_str!("../../migrations/0026_roadmap_items.sql"),
     include_str!("../../migrations/0027_workspace_purpose.sql"),
+    include_str!("../../migrations/0028_wf_run_roadmap_item.sql"),
 ];
 
 pub(crate) fn get_migrations() -> Migrations<'static> {

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -342,6 +342,80 @@ fn workspace_purpose_migration_leaves_existing_workspaces_untagged() {
     assert_eq!(tagged, 1);
 }
 
+/// Schema version at which `workspaces.purpose` (0027) exists — the version an
+/// install upgrading into the roadmap back-link comes from. Pinned like the
+/// two above, for the same reason.
+const V_WORKSPACE_PURPOSE: usize = 27;
+
+/// `wf_run.roadmap_item_id` (0028) lands on an existing install as a nullable
+/// column: every run already on disk was launched by a human, and stays
+/// unattributed. Only runs the queue drainer dispatches carry an item id — and
+/// that is what the drainer counts to enforce its per-project concurrency cap,
+/// so a human-launched run must never be caught by it.
+#[test]
+fn roadmap_backlink_migration_leaves_existing_runs_unattributed() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut conn = open_db(&dir.path().join(DB_FILENAME)).unwrap();
+    get_migrations()
+        .to_version(&mut conn, V_WORKSPACE_PURPOSE)
+        .unwrap();
+    conn.execute_batch(
+        "INSERT INTO projects (id, name, created_at) VALUES ('p', 'proj', 0);
+         INSERT INTO wf_run (id, name, spec_json, task, project_id, repo_path, run_dir,
+                             branch, base_sha, status, budgets_json, spent_json,
+                             created_at, updated_at)
+              VALUES ('run-old', 'wf', '{}', 'do a thing', 'p', '/r', '/d',
+                      'wf/x', 'abc', 'running', '{}', '{}', 0, 0);",
+    )
+    .unwrap();
+    drop(conn);
+
+    init(dir.path()).unwrap();
+
+    let conn = Connection::open(dir.path().join(DB_FILENAME)).unwrap();
+    let existing: Option<String> = conn
+        .query_row(
+            "SELECT roadmap_item_id FROM wf_run WHERE id = 'run-old'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        existing, None,
+        "a run launched by hand is not the queue's to throttle"
+    );
+
+    // A dispatched run is an ordinary row otherwise, and the column is a plain
+    // back-link: deleting the item it names must not cascade the run away —
+    // the run is the evidence that the work happened.
+    conn.execute(
+        "INSERT INTO roadmap_items (id, project_id, code, title, horizon, status,
+                                    created_at, updated_at)
+         VALUES ('i1', 'p', 'PRJ-100', 'queued work', 'now', 'active', 0, 0)",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO wf_run (id, name, spec_json, task, project_id, repo_path, run_dir,
+                             branch, base_sha, status, budgets_json, spent_json,
+                             created_at, updated_at, roadmap_item_id)
+              VALUES ('run-new', 'wf', '{}', 'PRJ-100', 'p', '/r', '/d',
+                      'wf/y', 'abc', 'running', '{}', '{}', 0, 0, 'i1')",
+        [],
+    )
+    .unwrap();
+    conn.execute("DELETE FROM roadmap_items WHERE id = 'i1'", [])
+        .unwrap();
+    let survivors: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM wf_run WHERE id = 'run-new'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(survivors, 1);
+}
+
 #[test]
 fn fresh_init_creates_no_backup() {
     let dir = tempfile::tempdir().unwrap();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1475,6 +1475,7 @@ pub fn run() {
             crate::workspace::migrate_default_checkouts_root();
 
             let db_for_wf = db.clone();
+            let db_for_roadmap = db.clone();
             let workspace = Arc::new(WorkspaceManager::new(db));
 
             // Drop RPC mailboxes left by agents that are gone. Teardown removes
@@ -1515,6 +1516,16 @@ pub fn run() {
             ));
             app.manage(wf_service.clone());
             wf_service.resume_active_runs();
+            // The roadmap queue drainer: turns `queued` roadmap items into runs
+            // through the service above, and settles finished runs back onto
+            // the board. Started after `resume_active_runs` so a run this
+            // process is already re-driving is counted against the per-project
+            // concurrency cap before the first tick can dispatch anything.
+            crate::roadmap::drainer::spawn(
+                app.handle().clone(),
+                db_for_roadmap,
+                wf_service.clone(),
+            );
             // Reload follow-ups that were queued behind an in-flight turn when a
             // prior run exited, so a mid-turn message survives a restart. They
             // rest in the queue and flush on the user's next send (no auto-spawn).

--- a/src-tauri/src/roadmap/drainer.rs
+++ b/src-tauri/src/roadmap/drainer.rs
@@ -28,7 +28,12 @@
 //! before [`WorkflowService::launch`] is awaited. That also makes the *claim*
 //! atomic: the drainer re-reads the item and flips `queued → active` inside one
 //! guard, so an unqueue that races the tick either lands before the claim (and
-//! the item is skipped) or after it (and finds an `active` row).
+//! the item is skipped) or after it — and one that lands after is *refused*,
+//! because the queue actions go through `roadmap_update_item`'s conditional path
+//! (`expect_status`, i.e. [`store::update_where_status`]). A blind
+//! `active → open` there would orphan the run this tick is about to launch: the
+//! `run_id` write-back would land on an `open` row and [`settle_project`], which
+//! only looks at `active` items, would never settle it.
 //!
 //! # Surfacing why an item isn't moving
 //!
@@ -36,13 +41,15 @@
 //! so on the card rather than sitting silent. Rather than add a `blocked_note`
 //! column for a fact that is only true until the next tick, the drainer emits a
 //! transient `roadmap:queue-note` event ([`QueueNote`]) the board renders inline
-//! on the row. Notes are de-duplicated in memory, so a permanently blocked item
-//! doesn't re-emit the same string every fifteen seconds.
+//! on the row. Notes are de-duplicated in memory *per row version* (see [`say`]),
+//! so a permanently blocked item doesn't re-emit the same string every fifteen
+//! seconds, while an item the user touched hears its explanation again.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
+use parking_lot::Mutex;
 use rusqlite::{Connection, OptionalExtension};
 use serde::Serialize;
 use tauri::{AppHandle, Emitter};
@@ -102,6 +109,15 @@ pub struct QueueNote {
     pub code: String,
     pub note: String,
 }
+
+/// What was last said about one item: the note, and the `updated_at` of the row
+/// version it was computed from. Both halves are the dedup key — see [`say`].
+type SaidNote = (String, i64);
+
+/// The drainer's note-dedup memory, by item id. Behind a mutex because each tick
+/// body runs in its own task (panic containment, see [`spawn`]) and the map has
+/// to outlive any one of them; never held across an `.await`.
+type SaidNotes = Mutex<HashMap<String, SaidNote>>;
 
 // ───────────────────────────── pure decisions ───────────────────────────
 
@@ -300,14 +316,29 @@ struct Plan {
 pub fn spawn(app: AppHandle, db: Db, service: Arc<crate::workflow::scheduler::WorkflowService>) {
     tauri::async_runtime::spawn(async move {
         // A note is re-emitted only when it changes, so a permanently blocked
-        // item says its piece once instead of every tick.
-        let mut said: HashMap<String, String> = HashMap::new();
+        // item says its piece once instead of every tick. Shared rather than
+        // owned by this loop because each tick runs in its own task.
+        let said: Arc<SaidNotes> = Arc::new(Mutex::new(HashMap::new()));
         loop {
             tokio::select! {
                 _ = tokio::time::sleep(TICK) => {}
                 _ = signal().notified() => {}
             }
-            tick(&app, &db, &service, &mut said).await;
+            // Panic containment (as the scheduler's drive tasks do): the tick
+            // body runs in its own task, so a panic anywhere inside it comes
+            // back as a `JoinError` here instead of unwinding this loop.
+            // Autonomous dispatch has to survive one bad row — silently dead
+            // until the next app start is the worst possible failure mode for a
+            // queue nobody is watching.
+            let ticked = {
+                let (app, db, service, said) =
+                    (app.clone(), db.clone(), service.clone(), said.clone());
+                tauri::async_runtime::spawn(async move { tick(&app, &db, &service, &said).await })
+                    .await
+            };
+            if ticked.is_err() {
+                tracing::error!("roadmap drainer tick panicked — queue processing continues");
+            }
         }
     });
 }
@@ -316,7 +347,7 @@ async fn tick(
     app: &AppHandle,
     db: &Db,
     service: &Arc<crate::workflow::scheduler::WorkflowService>,
-    said: &mut HashMap<String, String>,
+    said: &SaidNotes,
 ) {
     for project_id in projects_with_work(db) {
         settle_project(app, db, &project_id, said);
@@ -364,11 +395,12 @@ struct Settled {
 /// An item with *neither* is a claim whose launch never finished writing back —
 /// the app died between `launch` (which inserts the run with the back-link) and
 /// the drainer's `run_id` write. The back-link is what makes that recoverable:
-/// the run is found by item id and adopted. Only if there is no run at all is
-/// the item released. This can't misfire on a launch that is merely still in
-/// flight: the drainer is one task, and `dispatch` is awaited inside the tick,
-/// so a tick never observes its own pending launch.
-fn settle_project(app: &AppHandle, db: &Db, project_id: &str, said: &mut HashMap<String, String>) {
+/// the run is found by item id and adopted, provided it is still live (see
+/// [`dispatched_run_id`] for why a terminal one is always stale). Only if there
+/// is no such run is the item released. This can't misfire on a launch that is
+/// merely still in flight: the drainer is one task, and `dispatch` is awaited
+/// inside the tick, so a tick never observes its own pending launch.
+fn settle_project(app: &AppHandle, db: &Db, project_id: &str, said: &SaidNotes) {
     let settled: Vec<Settled> = {
         let conn = db.lock();
         let items = match store::list(&conn, project_id) {
@@ -483,13 +515,27 @@ fn settle_project(app: &AppHandle, db: &Db, project_id: &str, said: &mut HashMap
     }
 }
 
-/// The run dispatched for this item, newest first — the reverse of the item's
-/// own `run_id`, read through the `wf_run.roadmap_item_id` back-link. This is
-/// what makes a crash between `launch` and the drainer's write-back
+/// The *live* run dispatched for this item, newest first — the reverse of the
+/// item's own `run_id`, read through the `wf_run.roadmap_item_id` back-link. This
+/// is what makes a crash between `launch` and the drainer's write-back
 /// recoverable; see [`settle_project`].
+///
+/// Terminal runs are excluded (the same live statuses the concurrency cap
+/// counts), because for a claimed item with no `run_id` a terminal back-linked
+/// run is *always* stale: a run that completed legitimately had its item settled
+/// — with `run_id` written — before it went terminal. So a newest-but-terminal
+/// back-link means this claim's run never started, and adopting it would settle
+/// the item against a previous cycle's outcome (resurrecting a dead PR as
+/// `in_review`, or shipping an item on the strength of last week's run). Falling
+/// through to `None` puts it on the existing "its run never started" release
+/// path, which is the truth.
 fn dispatched_run_id(conn: &Connection, item_id: &str) -> Option<String> {
     conn.query_row(
-        "SELECT id FROM wf_run WHERE roadmap_item_id = ?1 ORDER BY created_at DESC LIMIT 1",
+        &format!(
+            "SELECT id FROM wf_run
+              WHERE roadmap_item_id = ?1 AND status IN ({LIVE_RUN_STATUSES})
+              ORDER BY created_at DESC LIMIT 1"
+        ),
         [item_id],
         |r| r.get::<_, String>(0),
     )
@@ -551,12 +597,7 @@ enum Claim {
 /// Decide what to dispatch for this project and *claim* it. Returns the plan
 /// for a claimed item — already flipped to `active`, so neither a second tick
 /// nor another writer can pick it up.
-fn claim_next(
-    app: &AppHandle,
-    db: &Db,
-    project_id: &str,
-    said: &mut HashMap<String, String>,
-) -> Option<Plan> {
+fn claim_next(app: &AppHandle, db: &Db, project_id: &str, said: &SaidNotes) -> Option<Plan> {
     let claim = {
         let conn = db.lock();
         plan_and_claim(&conn, project_id)
@@ -851,12 +892,19 @@ fn emit_note(app: &AppHandle, note: &QueueNote) {
     let _ = app.emit("roadmap:queue-note", note);
 }
 
-/// Emit a note unless the same one was the last thing said about this item.
-fn say(app: &AppHandle, said: &mut HashMap<String, String>, item: &RoadmapItem, note: &str) {
-    if said.get(&item.id).map(String::as_str) == Some(note) {
+/// Emit a note unless the same thing was already said about this same version of
+/// the row.
+///
+/// The dedup key is the note *and* the row's `updated_at`, never the note alone.
+/// A blocked item nobody touches keeps both, so it stays quiet tick after tick —
+/// which is the point of the dedup. But an item that was unqueued and re-queued
+/// has a bumped `updated_at` (every write bumps it), so the identical string is
+/// said again: recomputing "Waiting on FLT-100" for a row the user just put back
+/// on the queue and swallowing it would leave the card with no explanation at all.
+fn say(app: &AppHandle, said: &SaidNotes, item: &RoadmapItem, note: &str) {
+    if !record_note(&mut said.lock(), item, note) {
         return;
     }
-    said.insert(item.id.clone(), note.to_string());
     emit_note(
         app,
         &QueueNote {
@@ -867,8 +915,20 @@ fn say(app: &AppHandle, said: &mut HashMap<String, String>, item: &RoadmapItem, 
     );
 }
 
-fn forget(said: &mut HashMap<String, String>, item_id: &str) {
-    said.remove(item_id);
+/// Remember a note against the row version it describes, and report whether it
+/// still needs emitting. Split out of [`say`] so the rule is testable without an
+/// `AppHandle`.
+fn record_note(said: &mut HashMap<String, SaidNote>, item: &RoadmapItem, note: &str) -> bool {
+    let entry = (note.to_string(), item.updated_at);
+    if said.get(&item.id) == Some(&entry) {
+        return false;
+    }
+    said.insert(item.id.clone(), entry);
+    true
+}
+
+fn forget(said: &SaidNotes, item_id: &str) {
+    said.lock().remove(item_id);
 }
 
 #[cfg(test)]

--- a/src-tauri/src/roadmap/drainer.rs
+++ b/src-tauri/src/roadmap/drainer.rs
@@ -1,0 +1,875 @@
+//! The roadmap queue drainer: the background task that turns `queued` roadmap
+//! items into running workflows, and reflects those runs back onto the board.
+//!
+//! # Why status is the queue
+//!
+//! There is no queue table. `roadmap_items.status` *is* the queue — `queued`
+//! means "the user asked for this to be built", and `created_at` orders it
+//! (FIFO). A second table would be a second source of truth for the one fact
+//! the board already draws, and would need its own reconciliation after every
+//! crash. The horizon (`now`/`next`/`later`) deliberately does **not** gate
+//! dispatch: queueing is an explicit act, and the drainer never moves an item
+//! between horizons on its own.
+//!
+//! # The tick
+//!
+//! Every [`TICK`] (and immediately on a [`nudge`], poked by the roadmap
+//! commands so a queue action doesn't wait out the interval) the drainer, per
+//! project that has roadmap work in flight:
+//!
+//! 1. **Settles** every `active` item against its run row ([`settle`]).
+//! 2. **Dispatches** at most one queued item ([`pick_next`]), if the project is
+//!    under [`MAX_CONCURRENT_ROADMAP_RUNS`] live roadmap-dispatched runs.
+//!
+//! # Locking
+//!
+//! Everything that reads or writes the database happens inside a
+//! `parking_lot::Mutex` guard with no `.await` in scope — the guard is dropped
+//! before [`WorkflowService::launch`] is awaited. That also makes the *claim*
+//! atomic: the drainer re-reads the item and flips `queued → active` inside one
+//! guard, so an unqueue that races the tick either lands before the claim (and
+//! the item is skipped) or after it (and finds an `active` row).
+//!
+//! # Surfacing why an item isn't moving
+//!
+//! A queued item with no resolvable workflow, or one whose run failed, must say
+//! so on the card rather than sitting silent. Rather than add a `blocked_note`
+//! column for a fact that is only true until the next tick, the drainer emits a
+//! transient `roadmap:queue-note` event ([`QueueNote`]) the board renders inline
+//! on the row. Notes are de-duplicated in memory, so a permanently blocked item
+//! doesn't re-emit the same string every fifteen seconds.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use rusqlite::{Connection, OptionalExtension};
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+use tokio::sync::Notify;
+
+use super::types::{ItemPatch, ItemStatus, RoadmapItem};
+use super::{emit_item, store, Db};
+use crate::workflow::spec::{self, Spec};
+use crate::workflow::types::RunStatus;
+
+/// How many roadmap-dispatched runs one project may have in flight at once.
+///
+/// One, for now. An autonomous queue that opens five PRs into the same repo in
+/// parallel buys throughput with merge conflicts and a review backlog the user
+/// didn't ask for; one run at a time keeps every dispatch reviewable and every
+/// dependency edge meaningful (the next item forks from a tree that includes
+/// the last one). Raising this is a one-line change once the merge sweep can
+/// keep up — nothing else in this module assumes the value is 1.
+pub const MAX_CONCURRENT_ROADMAP_RUNS: usize = 1;
+
+/// How often the drainer wakes on its own. Short enough that a queued item
+/// starts within a moment of its dependency landing, long enough that an idle
+/// board costs nothing. Queue actions don't wait for it — see [`nudge`].
+const TICK: Duration = Duration::from_secs(15);
+
+/// Run statuses that count as "still in flight" for the concurrency cap. The
+/// terminal three (`done`/`failed`/`canceled`) free the slot.
+const LIVE_RUN_STATUSES: &str = "'pending','running','paused'";
+
+// ───────────────────────────── the nudge ────────────────────────────────
+
+/// Wakes the drainer between ticks. A single process-wide `Notify`: there is
+/// one drainer, and `notify_one` stores a permit, so a nudge that arrives while
+/// the tick is running is not lost.
+fn signal() -> &'static Notify {
+    static SIGNAL: OnceLock<Notify> = OnceLock::new();
+    SIGNAL.get_or_init(Notify::new)
+}
+
+/// Ask the drainer to re-check now. Called by the roadmap commands after any
+/// mutation — queueing an item is the obvious one, but so is marking a
+/// dependency `done`, which may unblock something already queued. Cheap enough
+/// to call unconditionally rather than guessing which patches matter.
+pub(crate) fn nudge() {
+    signal().notify_one();
+}
+
+// ───────────────────────────── queue notes ──────────────────────────────
+
+/// The `roadmap:queue-note` payload: why an item is not moving, addressed to
+/// the row that isn't moving. Transient by design — nothing persists it, and
+/// the next state change on the row makes it stale, which is exactly when the
+/// board drops it.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct QueueNote {
+    pub item_id: String,
+    pub code: String,
+    pub note: String,
+}
+
+// ───────────────────────────── pure decisions ───────────────────────────
+
+/// What the drainer will do with a project's queue this tick. Computed by
+/// [`pick_next`] from a snapshot, so the decision is unit-testable without a
+/// database, a tokio runtime, or a clock.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum Decision {
+    /// Nothing queued at all.
+    Empty,
+    /// The project is already at [`MAX_CONCURRENT_ROADMAP_RUNS`].
+    AtCapacity,
+    /// Everything queued is waiting on a dependency. Carries the head of the
+    /// queue and the codes it waits on, so the caller can say so on the card.
+    Blocked {
+        item_id: String,
+        waiting_on: Vec<String>,
+    },
+    /// Dispatch this item (an index into the queue slice given to [`pick_next`]).
+    Dispatch(usize),
+}
+
+/// Whether every code in `deps` counts as landed.
+///
+/// A dep is satisfied when its item is `done`. `in_review` is *not* done: the
+/// PR is open, the work isn't in the base branch, and a dependant forked now
+/// would build on a tree that doesn't contain it.
+///
+/// A dep code that resolves to no item at all is also satisfied. The item it
+/// pointed at was deleted off the board, and a deleted item never ships — so
+/// waiting for it would block the dependant forever on work nobody intends to
+/// do. Treating the reference as stale is the only outcome the user can act on.
+pub(crate) fn unsatisfied_deps(
+    deps: &[String],
+    done: &HashSet<String>,
+    known: &HashSet<String>,
+) -> Vec<String> {
+    deps.iter()
+        .filter(|d| known.contains(*d) && !done.contains(*d))
+        .cloned()
+        .collect()
+}
+
+/// Pick the oldest queued item whose dependencies have all landed.
+///
+/// `queued` must be in FIFO order (the DAO lists oldest-first, which is the
+/// order the board draws and the order the user queued in). An item with
+/// unsatisfied deps is *skipped*, never failed — its turn comes when the thing
+/// it waits on lands.
+pub(crate) fn pick_next(
+    queued: &[RoadmapItem],
+    live_runs: usize,
+    done: &HashSet<String>,
+    known: &HashSet<String>,
+) -> Decision {
+    if queued.is_empty() {
+        return Decision::Empty;
+    }
+    if live_runs >= MAX_CONCURRENT_ROADMAP_RUNS {
+        return Decision::AtCapacity;
+    }
+    let mut head_block: Option<(String, Vec<String>)> = None;
+    for (i, item) in queued.iter().enumerate() {
+        let waiting = unsatisfied_deps(&item.deps, done, known);
+        if waiting.is_empty() {
+            return Decision::Dispatch(i);
+        }
+        head_block.get_or_insert((item.id.clone(), waiting));
+    }
+    // Unreachable with a non-empty queue, but expressed as a fallback rather
+    // than an unwrap so a future edit can't panic here.
+    match head_block {
+        Some((item_id, waiting_on)) => Decision::Blocked {
+            item_id,
+            waiting_on,
+        },
+        None => Decision::Empty,
+    }
+}
+
+/// Which workflow definition to run an item under: the item's own override,
+/// else the project's default. There is deliberately no hardcoded fallback
+/// spec — inventing a workflow for work the user queued would be a worse
+/// outcome than saying "pick one", which is what the caller does with `None`.
+pub(crate) fn resolve_workflow(
+    item: &RoadmapItem,
+    project_default: Option<&str>,
+) -> Option<String> {
+    item.workflow_def_id
+        .clone()
+        .or_else(|| project_default.map(str::to_string))
+}
+
+/// What an `active` item's run says should happen to the item.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum Settlement {
+    /// The run is still going. Leave the item alone.
+    Running,
+    /// The run finished and opened a PR. The work isn't merged yet, so the item
+    /// is `in_review` — PR 5's merge sweep is what moves it to `done`.
+    InReview,
+    /// The run finished without opening a PR (a spec with `open_pr: false`, or
+    /// a finalize that only pushed). Nothing else is coming, so the item is
+    /// done as far as this app can tell.
+    Done,
+    /// The run failed, was canceled, or its row is gone. The item goes back to
+    /// `open` with the reason on the card.
+    ///
+    /// Deliberately **not** back to `queued`: an auto-retry loop on a failing
+    /// workflow burns tokens all night and re-opens the same broken PR. Losing
+    /// a run is a decision point — the user re-queues once they know why.
+    Released(&'static str),
+}
+
+/// Map a roadmap-dispatched run's state onto its item. `status` is `None` when
+/// the run row no longer exists (a `wf_delete_run`, or a project half-deleted
+/// under us).
+pub(crate) fn settle(status: Option<RunStatus>, pr_url: Option<&str>) -> Settlement {
+    match status {
+        None => Settlement::Released("its run was deleted"),
+        Some(RunStatus::Pending) | Some(RunStatus::Running) | Some(RunStatus::Paused) => {
+            Settlement::Running
+        }
+        Some(RunStatus::Done) if pr_url.is_some() => Settlement::InReview,
+        Some(RunStatus::Done) => Settlement::Done,
+        Some(RunStatus::Failed) => Settlement::Released("its run failed"),
+        Some(RunStatus::Canceled) => Settlement::Released("its run was canceled"),
+    }
+}
+
+/// The trailing number of a GitHub PR URL (`.../pull/142` → `142`).
+///
+/// PR 5's seam: the merge sweep needs a number to poll, and today the only
+/// record of the PR is the `finalize_pr` journal event's URL. PR 5 persists
+/// `pr_number`/`pr_url` on `wf_run` at finalize time and reads them from there;
+/// this parse exists so an item settled by *this* build still carries enough to
+/// be polled, and can be deleted once the run row holds the truth.
+pub(crate) fn pr_number_from_url(url: &str) -> Option<i64> {
+    let tail = url.trim_end_matches('/').rsplit('/').next()?;
+    tail.parse().ok()
+}
+
+/// The task brief a dispatched run receives, built from the item.
+///
+/// A superset of the card's "Send to an agent" prompt (`ItemCard.briefFor`):
+/// same code/title/why/acceptance shape, plus the two things a *non-interactive*
+/// run needs and a human in a chat doesn't — what already landed underneath it,
+/// and the instruction to stamp the code on the PR so the board can find its
+/// way back to the work.
+pub(crate) fn build_brief(item: &RoadmapItem, deps: &[&RoadmapItem]) -> String {
+    let mut lines = vec![format!("{}: {}", item.code, item.title)];
+    if !item.why.trim().is_empty() {
+        lines.push(String::new());
+        lines.push(item.why.trim().to_string());
+    }
+    if !item.accept.is_empty() {
+        lines.push(String::new());
+        lines.push("Done when:".to_string());
+        lines.extend(item.accept.iter().map(|a| format!("- [ ] {a}")));
+    }
+    if !deps.is_empty() {
+        lines.push(String::new());
+        lines.push("Builds on work that has already landed:".to_string());
+        lines.extend(
+            deps.iter()
+                .map(|d| format!("- {}: {} (done)", d.code, d.title)),
+        );
+    }
+    lines.push(String::new());
+    lines.push(format!(
+        "Reference [{}] in the pull request title and description so this item \
+         can be tracked back to the roadmap.",
+        item.code
+    ));
+    lines.join("\n")
+}
+
+// ───────────────────────────── the task ─────────────────────────────────
+
+/// Everything one dispatch needs, resolved under the connection lock so the
+/// launch itself can be awaited with no guard held.
+struct Plan {
+    item: RoadmapItem,
+    definition_id: String,
+    spec: Spec,
+    repo_path: String,
+    brief: String,
+}
+
+/// Start the drainer. Called once from setup, after the [`WorkflowService`] is
+/// managed — it launches through the same service the composer does, so runs it
+/// starts are ordinary runs in every other respect (resumable, cancellable,
+/// visible in the sidebar).
+///
+/// [`WorkflowService`]: crate::workflow::scheduler::WorkflowService
+pub fn spawn(app: AppHandle, db: Db, service: Arc<crate::workflow::scheduler::WorkflowService>) {
+    tauri::async_runtime::spawn(async move {
+        // A note is re-emitted only when it changes, so a permanently blocked
+        // item says its piece once instead of every tick.
+        let mut said: HashMap<String, String> = HashMap::new();
+        loop {
+            tokio::select! {
+                _ = tokio::time::sleep(TICK) => {}
+                _ = signal().notified() => {}
+            }
+            tick(&app, &db, &service, &mut said).await;
+        }
+    });
+}
+
+async fn tick(
+    app: &AppHandle,
+    db: &Db,
+    service: &Arc<crate::workflow::scheduler::WorkflowService>,
+    said: &mut HashMap<String, String>,
+) {
+    for project_id in projects_with_work(db) {
+        settle_project(app, db, &project_id, said);
+        // At most one dispatch per project per tick: the cap is re-read from
+        // the database next tick, so a burst can never exceed it.
+        if let Some(plan) = claim_next(app, db, &project_id, said) {
+            dispatch(app, db, service, plan).await;
+        }
+    }
+}
+
+/// Projects with a roadmap item the drainer could act on. Scoping the tick to
+/// these keeps an install with fifty projects and one live queue from walking
+/// fifty boards.
+fn projects_with_work(db: &Db) -> Vec<String> {
+    let conn = db.lock();
+    conn.prepare(
+        "SELECT DISTINCT project_id FROM roadmap_items WHERE status IN ('queued','active')",
+    )
+    .and_then(|mut s| {
+        s.query_map([], |r| r.get::<_, String>(0))?
+            .collect::<std::result::Result<Vec<_>, _>>()
+    })
+    .unwrap_or_default()
+}
+
+// ───────────────────────────── settlement ───────────────────────────────
+
+/// One `active` item's run, as this tick found it.
+struct Settled {
+    item: RoadmapItem,
+    outcome: Settlement,
+    pr_url: Option<String>,
+    /// The run this item is tied to, when the item's own `run_id` didn't name
+    /// it — recovered through the `wf_run.roadmap_item_id` back-link and written
+    /// back onto the row.
+    adopted_run_id: Option<String>,
+}
+
+/// Reflect each `active` item's run back onto the item.
+///
+/// Items with an `agent_id` and no run are left alone: that's the manual "Send
+/// to an agent" hand-off, which the queue doesn't own.
+///
+/// An item with *neither* is a claim whose launch never finished writing back —
+/// the app died between `launch` (which inserts the run with the back-link) and
+/// the drainer's `run_id` write. The back-link is what makes that recoverable:
+/// the run is found by item id and adopted. Only if there is no run at all is
+/// the item released. This can't misfire on a launch that is merely still in
+/// flight: the drainer is one task, and `dispatch` is awaited inside the tick,
+/// so a tick never observes its own pending launch.
+fn settle_project(app: &AppHandle, db: &Db, project_id: &str, said: &mut HashMap<String, String>) {
+    let settled: Vec<Settled> = {
+        let conn = db.lock();
+        let items = match store::list(&conn, project_id) {
+            Ok(items) => items,
+            Err(e) => {
+                tracing::warn!(project_id, error = %e, "roadmap drainer: cannot read board");
+                return;
+            }
+        };
+        items
+            .into_iter()
+            .filter(|i| i.status == ItemStatus::Active)
+            // The manual hand-off: an agent is on it, no run to settle against.
+            .filter(|i| i.run_id.is_some() || i.agent_id.is_none())
+            .map(|item| {
+                let adopted_run_id = match &item.run_id {
+                    Some(_) => None,
+                    None => dispatched_run_id(&conn, &item.id),
+                };
+                let run_id = item.run_id.clone().or_else(|| adopted_run_id.clone());
+                let status = match &run_id {
+                    Some(id) => run_status(&conn, id),
+                    // No run row at all — neither named nor back-linked.
+                    None => None,
+                };
+                let pr_url = match status {
+                    // Only a finished run can have finalized, so the journal
+                    // scan is paid once per item, not once per tick.
+                    Some(RunStatus::Done) => {
+                        run_id.as_deref().and_then(|id| finalized_pr_url(&conn, id))
+                    }
+                    _ => None,
+                };
+                let outcome = match run_id {
+                    // A claim whose run never reached the database. `settle`
+                    // can't tell this from a deleted run — the item can, and
+                    // "never started" is the honest thing to put on the card.
+                    None => Settlement::Released("its run never started"),
+                    Some(_) => settle(status, pr_url.as_deref()),
+                };
+                Settled {
+                    item,
+                    outcome,
+                    pr_url,
+                    adopted_run_id,
+                }
+            })
+            // A still-running item needs no write unless its link was recovered.
+            .filter(|s| s.outcome != Settlement::Running || s.adopted_run_id.is_some())
+            .collect()
+    };
+
+    for Settled {
+        item,
+        outcome,
+        pr_url,
+        adopted_run_id,
+    } in settled
+    {
+        let patch = match &outcome {
+            Settlement::Running => {
+                // Recovered only: repair the link and leave the item running.
+                write_item(
+                    app,
+                    db,
+                    &item.id,
+                    ItemPatch {
+                        run_id: Some(adopted_run_id.clone()),
+                        ..Default::default()
+                    },
+                );
+                tracing::info!(
+                    item = %item.code,
+                    run = ?adopted_run_id,
+                    "roadmap drainer: re-attached item to its run"
+                );
+                continue;
+            }
+            Settlement::InReview => ItemPatch {
+                status: Some(ItemStatus::InReview),
+                // PR 5's seam: the merge sweep will read `pr_number`/`pr_url`
+                // off `wf_run` (persisted at finalize) rather than off the
+                // journal, and poll from there. Stamping them on the item now
+                // means a board settled by this build is already pollable.
+                pr_url: Some(pr_url.clone()),
+                pr_number: Some(pr_url.as_deref().and_then(pr_number_from_url)),
+                ..Default::default()
+            },
+            Settlement::Done => ItemPatch {
+                status: Some(ItemStatus::Done),
+                ..Default::default()
+            },
+            Settlement::Released(_) => ItemPatch {
+                status: Some(ItemStatus::Open),
+                // The run is over; the item is not "the thing that run is
+                // doing" any more. Clearing the link keeps a re-queue from
+                // settling instantly against the old, terminal run.
+                run_id: Some(None),
+                ..Default::default()
+            },
+        };
+        write_item(app, db, &item.id, patch);
+        match outcome {
+            Settlement::Released(why) => {
+                tracing::info!(item = %item.code, %why, "roadmap drainer: released item");
+                say(app, said, &item, &format!("Back on the board — {why}."));
+            }
+            // A settled-forward item is no longer waiting on anything, so any
+            // note it carried is stale.
+            _ => forget(said, &item.id),
+        }
+    }
+}
+
+/// The run dispatched for this item, newest first — the reverse of the item's
+/// own `run_id`, read through the `wf_run.roadmap_item_id` back-link. This is
+/// what makes a crash between `launch` and the drainer's write-back
+/// recoverable; see [`settle_project`].
+fn dispatched_run_id(conn: &Connection, item_id: &str) -> Option<String> {
+    conn.query_row(
+        "SELECT id FROM wf_run WHERE roadmap_item_id = ?1 ORDER BY created_at DESC LIMIT 1",
+        [item_id],
+        |r| r.get::<_, String>(0),
+    )
+    .optional()
+    .ok()
+    .flatten()
+}
+
+/// A run's status, or `None` when the row is gone.
+fn run_status(conn: &Connection, run_id: &str) -> Option<RunStatus> {
+    conn.query_row("SELECT status FROM wf_run WHERE id = ?1", [run_id], |r| {
+        r.get::<_, String>(0)
+    })
+    .optional()
+    .ok()
+    .flatten()
+    .and_then(|s| RunStatus::from_db(&s))
+}
+
+/// The URL of the PR a finished run opened, from its `finalize_pr` journal
+/// event. That event carries either `{"url": …}` or `{"error": …}`; only the
+/// former means a PR exists.
+///
+/// PR 5's seam — see [`pr_number_from_url`]: once `wf_run` carries the PR
+/// columns, this reads a column instead of scanning the journal.
+fn finalized_pr_url(conn: &Connection, run_id: &str) -> Option<String> {
+    let payload: String = conn
+        .query_row(
+            "SELECT payload_json FROM wf_event
+              WHERE run_id = ?1 AND type = ?2 ORDER BY seq DESC LIMIT 1",
+            rusqlite::params![run_id, crate::workflow::types::event_type::FINALIZE_PR],
+            |r| r.get(0),
+        )
+        .optional()
+        .ok()
+        .flatten()?;
+    let value: serde_json::Value = serde_json::from_str(&payload).ok()?;
+    value
+        .get("url")
+        .and_then(|u| u.as_str())
+        .filter(|u| !u.trim().is_empty())
+        .map(str::to_string)
+}
+
+// ───────────────────────────── dispatch ─────────────────────────────────
+
+/// What one project's queue produced this tick. Returned out of the connection
+/// guard so every emit — the claimed row, or the note explaining why there
+/// isn't one — happens with no lock held.
+enum Claim {
+    /// Nothing to do and nothing to say.
+    Nothing,
+    /// Something is queued but can't run yet, and the card should say why.
+    Note(Box<RoadmapItem>, String),
+    /// An item was claimed (already `active`) and is ready to launch.
+    Claimed(Box<Plan>),
+}
+
+/// Decide what to dispatch for this project and *claim* it. Returns the plan
+/// for a claimed item — already flipped to `active`, so neither a second tick
+/// nor another writer can pick it up.
+fn claim_next(
+    app: &AppHandle,
+    db: &Db,
+    project_id: &str,
+    said: &mut HashMap<String, String>,
+) -> Option<Plan> {
+    let claim = {
+        let conn = db.lock();
+        plan_and_claim(&conn, project_id)
+    };
+    match claim {
+        Claim::Nothing => None,
+        Claim::Note(item, text) => {
+            say(app, said, &item, &text);
+            None
+        }
+        Claim::Claimed(plan) => {
+            // Whatever was blocking this item no longer is.
+            forget(said, &plan.item.id);
+            emit_item(app, &plan.item);
+            Some(*plan)
+        }
+    }
+}
+
+/// The whole decision, inside one connection guard: read the board, count live
+/// runs, pick, resolve, and claim. No `.await`, no emits — so the read the
+/// decision is made on and the write that acts on it cannot be interleaved with
+/// another writer (the app has one connection behind one mutex).
+fn plan_and_claim(conn: &Connection, project_id: &str) -> Claim {
+    let items = match store::list(conn, project_id) {
+        Ok(items) => items,
+        Err(e) => {
+            tracing::warn!(project_id, error = %e, "roadmap drainer: cannot read board");
+            return Claim::Nothing;
+        }
+    };
+    let done: HashSet<String> = items
+        .iter()
+        .filter(|i| i.status == ItemStatus::Done)
+        .map(|i| i.code.clone())
+        .collect();
+    let known: HashSet<String> = items.iter().map(|i| i.code.clone()).collect();
+    let queued: Vec<RoadmapItem> = items
+        .iter()
+        .filter(|i| i.status == ItemStatus::Queued)
+        .cloned()
+        .collect();
+
+    let live = live_run_count(conn, project_id);
+    let item = match pick_next(&queued, live, &done, &known) {
+        Decision::Dispatch(i) => queued[i].clone(),
+        Decision::Blocked {
+            item_id,
+            waiting_on,
+        } => {
+            return match queued.into_iter().find(|i| i.id == item_id) {
+                Some(item) => Claim::Note(
+                    Box::new(item),
+                    format!("Waiting on {}", waiting_on.join(", ")),
+                ),
+                None => Claim::Nothing,
+            };
+        }
+        // Nothing to say: an empty queue is silence, and being at capacity is
+        // the drainer working as intended.
+        Decision::Empty | Decision::AtCapacity => return Claim::Nothing,
+    };
+
+    let project_default = project_setting(conn, project_id, DEFAULT_WORKFLOW_KEY);
+    let Some(definition_id) = resolve_workflow(&item, project_default.as_deref()) else {
+        return Claim::Note(
+            Box::new(item),
+            "No workflow to run it under. Pick one on this item, or set the project's \
+             default workflow."
+                .to_string(),
+        );
+    };
+    let Some(spec) = definition_spec(conn, &definition_id) else {
+        return Claim::Note(
+            Box::new(item),
+            "Its workflow is missing or no longer valid — pick another.".to_string(),
+        );
+    };
+    let Some(repo_path) = primary_repo_path(conn, project_id) else {
+        return Claim::Note(
+            Box::new(item),
+            "This project has no repo to run in.".to_string(),
+        );
+    };
+
+    // Only deps that still resolve get quoted in the brief; a stale code counts
+    // as satisfied (see `unsatisfied_deps`) but has nothing to say.
+    let dep_rows: Vec<&RoadmapItem> = item
+        .deps
+        .iter()
+        .filter_map(|code| items.iter().find(|i| &i.code == code))
+        .collect();
+    let brief = build_brief(&item, &dep_rows);
+
+    // The claim. Re-read under the same guard the decision was made under, so
+    // an unqueue that raced this tick either already landed (and the item was
+    // never in `queued` above) or lands after, against an `active` row.
+    match store::get(conn, &item.id) {
+        Ok(Some(fresh)) if fresh.status == ItemStatus::Queued => {}
+        _ => return Claim::Nothing,
+    }
+    let claimed = store::update(
+        conn,
+        &item.id,
+        &ItemPatch {
+            status: Some(ItemStatus::Active),
+            // Pin the resolved definition on the item, so the card keeps
+            // showing what it actually ran under even if the project default
+            // moves afterwards.
+            workflow_def_id: Some(Some(definition_id.clone())),
+            ..Default::default()
+        },
+    );
+    match claimed {
+        Ok(Some(claimed)) => Claim::Claimed(Box::new(Plan {
+            item: claimed,
+            definition_id,
+            spec,
+            repo_path,
+            brief,
+        })),
+        Ok(None) => Claim::Nothing,
+        Err(e) => {
+            tracing::warn!(item = %item.code, error = %e, "roadmap drainer: claim failed");
+            Claim::Nothing
+        }
+    }
+}
+
+/// Launch the claimed item's run. The only `.await` in the tick, and no DB
+/// guard is held across it.
+async fn dispatch(
+    app: &AppHandle,
+    db: &Db,
+    service: &Arc<crate::workflow::scheduler::WorkflowService>,
+    plan: Plan,
+) {
+    let Plan {
+        item,
+        definition_id,
+        spec,
+        repo_path,
+        brief,
+    } = plan;
+    tracing::info!(item = %item.code, %definition_id, "roadmap drainer: dispatching");
+
+    let launched = service
+        .launch(
+            spec,
+            brief,
+            item.project_id.clone(),
+            repo_path,
+            Some(definition_id),
+            // No base branch: `launch` resolves the spec's `finalize.pr_base`,
+            // then HEAD. A queued item has no opinion about where to fork from
+            // that the workflow doesn't already carry.
+            None,
+            None,
+            Vec::new(),
+            None,
+            Some(item.id.clone()),
+        )
+        .await;
+
+    match launched {
+        Ok(run_id) => write_item(
+            app,
+            db,
+            &item.id,
+            ItemPatch {
+                run_id: Some(Some(run_id)),
+                ..Default::default()
+            },
+        ),
+        Err(e) => {
+            // The claim already flipped the item to `active`; nothing is going
+            // to run, so hand it back rather than leaving a phantom.
+            tracing::warn!(item = %item.code, error = %e, "roadmap drainer: launch failed");
+            write_item(
+                app,
+                db,
+                &item.id,
+                ItemPatch {
+                    status: Some(ItemStatus::Open),
+                    ..Default::default()
+                },
+            );
+            emit_note(
+                app,
+                &QueueNote {
+                    item_id: item.id.clone(),
+                    code: item.code.clone(),
+                    note: format!("Couldn't start a run — {e}"),
+                },
+            );
+        }
+    }
+}
+
+// ───────────────────────────── db helpers ───────────────────────────────
+
+/// `project_settings` key holding a project's default workflow definition id.
+/// The same key the composer writes (`src/workflows/run/projectPipeline.ts`), so
+/// "the workflow this project runs" means one thing on both sides.
+const DEFAULT_WORKFLOW_KEY: &str = "workflow.default";
+
+fn project_setting(conn: &Connection, project_id: &str, key: &str) -> Option<String> {
+    conn.query_row(
+        "SELECT value FROM project_settings WHERE project_id = ?1 AND key = ?2",
+        rusqlite::params![project_id, key],
+        |r| r.get::<_, String>(0),
+    )
+    .ok()
+    .map(|s| s.trim().to_string())
+    .filter(|s| !s.is_empty())
+}
+
+/// Roadmap-dispatched runs still in flight for a project. Human-launched runs
+/// (`roadmap_item_id IS NULL`) are not throttled by the queue and don't count.
+fn live_run_count(conn: &Connection, project_id: &str) -> usize {
+    conn.query_row(
+        &format!(
+            "SELECT COUNT(*) FROM wf_run
+              WHERE project_id = ?1 AND roadmap_item_id IS NOT NULL
+                AND status IN ({LIVE_RUN_STATUSES})"
+        ),
+        [project_id],
+        |r| r.get::<_, i64>(0),
+    )
+    .unwrap_or(0)
+    .max(0) as usize
+}
+
+/// The project's primary repo — the first attached, mirroring
+/// `WorkspaceManager::project_repo_paths`. A run targets one repo; the queue
+/// picks the same one the rest of the app calls primary.
+fn primary_repo_path(conn: &Connection, project_id: &str) -> Option<String> {
+    conn.query_row(
+        "SELECT path FROM repos WHERE project_id = ?1 ORDER BY created_at LIMIT 1",
+        [project_id],
+        |r| r.get::<_, String>(0),
+    )
+    .optional()
+    .ok()
+    .flatten()
+    .filter(|p| !p.trim().is_empty())
+}
+
+/// A definition's spec, parsed and validated. An invalid stored spec is treated
+/// as a missing workflow: `launch` would fail on it anyway, and saying "pick
+/// another" is more useful than a failed run.
+fn definition_spec(conn: &Connection, definition_id: &str) -> Option<Spec> {
+    let spec_json: String = conn
+        .query_row(
+            "SELECT spec_json FROM wf_definition WHERE id = ?1",
+            [definition_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .ok()
+        .flatten()?;
+    let spec: Spec = serde_json::from_str(&spec_json)
+        .map_err(|e| tracing::warn!(definition_id, error = %e, "unreadable workflow spec"))
+        .ok()?;
+    // Same validation the save/import path runs, so a definition persisted
+    // before a rule existed can't reach a launch.
+    if let Err(errs) = spec::validate(&spec) {
+        tracing::warn!(definition_id, errors = %errs.join("; "), "invalid workflow spec");
+        return None;
+    }
+    Some(spec)
+}
+
+/// Apply a patch and announce the row. Every drainer write goes through here,
+/// so nothing it changes can reach the database without reaching the board.
+fn write_item(app: &AppHandle, db: &Db, id: &str, patch: ItemPatch) {
+    let updated = {
+        let conn = db.lock();
+        store::update(&conn, id, &patch)
+    };
+    match updated {
+        Ok(Some(row)) => emit_item(app, &row),
+        // The row was deleted mid-tick; nothing to announce.
+        Ok(None) => {}
+        Err(e) => tracing::warn!(id, error = %e, "roadmap drainer: item write failed"),
+    }
+}
+
+// ───────────────────────────── notes ────────────────────────────────────
+
+fn emit_note(app: &AppHandle, note: &QueueNote) {
+    let _ = app.emit("roadmap:queue-note", note);
+}
+
+/// Emit a note unless the same one was the last thing said about this item.
+fn say(app: &AppHandle, said: &mut HashMap<String, String>, item: &RoadmapItem, note: &str) {
+    if said.get(&item.id).map(String::as_str) == Some(note) {
+        return;
+    }
+    said.insert(item.id.clone(), note.to_string());
+    emit_note(
+        app,
+        &QueueNote {
+            item_id: item.id.clone(),
+            code: item.code.clone(),
+            note: note.to_string(),
+        },
+    );
+}
+
+fn forget(said: &mut HashMap<String, String>, item_id: &str) {
+    said.remove(item_id);
+}
+
+#[cfg(test)]
+mod tests;

--- a/src-tauri/src/roadmap/drainer/tests.rs
+++ b/src-tauri/src/roadmap/drainer/tests.rs
@@ -289,6 +289,82 @@ fn pr_numbers_come_off_the_url_or_not_at_all() {
     assert_eq!(pr_number_from_url(""), None);
 }
 
+// ───────────────────────────── crash recovery ───────────────────────────
+
+/// A migrated in-memory DB, as the app opens the real file.
+fn test_conn() -> Connection {
+    let mut conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    crate::database::get_migrations()
+        .to_latest(&mut conn)
+        .unwrap();
+    conn
+}
+
+/// A roadmap-dispatched run for `item_id`, in `status`, created at `created_at`.
+fn run(conn: &Connection, id: &str, item_id: &str, status: &str, created_at: i64) {
+    conn.execute(
+        "INSERT INTO wf_run (id, name, spec_json, task, project_id, repo_path, run_dir, branch,
+                             base_sha, status, budgets_json, spent_json, created_at, updated_at,
+                             roadmap_item_id)
+         VALUES (?1, 'n', '{}', 't', 'p1', '/r', '/d', 'wf/x', 'sha', ?2, '{}', '{}', ?3, ?3, ?4)",
+        rusqlite::params![id, status, created_at, item_id],
+    )
+    .unwrap();
+}
+
+#[test]
+fn recovery_adopts_only_a_live_run() {
+    // The item is `active` with `run_id` NULL — a claim whose launch never wrote
+    // back. The newest back-linked run is a *terminal* one from a previous
+    // cycle: adopting it would settle this claim against last cycle's outcome
+    // (resurrecting a merged-or-dead PR as `in_review`). Only the live run may
+    // be adopted.
+    let conn = test_conn();
+    run(&conn, "old-done", "id-FLT-100", "done", 10);
+    run(&conn, "live", "id-FLT-100", "running", 20);
+    assert_eq!(
+        dispatched_run_id(&conn, "id-FLT-100"),
+        Some("live".to_string())
+    );
+
+    // Newest is terminal and nothing live remains: the claim's run never
+    // started, which is the release path — not an adoption.
+    run(&conn, "newest-failed", "id-FLT-101", "failed", 30);
+    run(&conn, "older-canceled", "id-FLT-101", "canceled", 20);
+    assert_eq!(dispatched_run_id(&conn, "id-FLT-101"), None);
+
+    // No back-link at all is the same answer.
+    assert_eq!(dispatched_run_id(&conn, "id-FLT-999"), None);
+}
+
+// ───────────────────────────── note dedup ───────────────────────────────
+
+#[test]
+fn a_note_repeats_when_the_row_moved_and_stays_quiet_when_it_didnt() {
+    let mut said: HashMap<String, SaidNote> = HashMap::new();
+    let blocked = item("FLT-100", 10);
+    let note = "Waiting on FLT-099";
+
+    // First time it's said, and then it's silent — a permanently blocked item
+    // must not re-emit the same string every tick.
+    assert!(record_note(&mut said, &blocked, note));
+    assert!(!record_note(&mut said, &blocked, note));
+
+    // Unqueue + re-queue bumps `updated_at` (every write does), and the note is
+    // recomputed to the same string. It has to be said again: the user is
+    // looking at a card that has no explanation on it any more.
+    let requeued = RoadmapItem {
+        updated_at: blocked.updated_at + 1,
+        ..blocked.clone()
+    };
+    assert!(record_note(&mut said, &requeued, note));
+    assert!(!record_note(&mut said, &requeued, note));
+
+    // A different reason is always news, version or no version.
+    assert!(record_note(&mut said, &requeued, "Waiting on FLT-098"));
+}
+
 // ───────────────────────────── the brief ────────────────────────────────
 
 #[test]

--- a/src-tauri/src/roadmap/drainer/tests.rs
+++ b/src-tauri/src/roadmap/drainer/tests.rs
@@ -1,0 +1,331 @@
+//! Drainer decision tests.
+//!
+//! Everything the drainer *decides* is a pure function over a snapshot
+//! ([`pick_next`], [`unsatisfied_deps`], [`resolve_workflow`], [`settle`],
+//! [`build_brief`]), so the rules are tested here without a tokio runtime, a
+//! clock, or a database. The tick itself is the thin part: read a snapshot,
+//! call these, write the answer back.
+
+use super::*;
+use crate::roadmap::types::{Horizon, ItemSource};
+
+/// A queued item, `n` milliseconds into the board's life. `created_at` is what
+/// orders the queue, so the tests set it explicitly rather than relying on
+/// insertion order.
+fn item(code: &str, created_at: i64) -> RoadmapItem {
+    RoadmapItem {
+        id: format!("id-{code}"),
+        project_id: "p1".into(),
+        code: code.into(),
+        parent_id: None,
+        title: format!("do {code}"),
+        why: String::new(),
+        horizon: Horizon::Next,
+        status: ItemStatus::Queued,
+        size: None,
+        area: None,
+        source: ItemSource::User,
+        epic: None,
+        accept: Vec::new(),
+        deps: Vec::new(),
+        agent_id: None,
+        workflow_def_id: None,
+        run_id: None,
+        pr_url: None,
+        pr_number: None,
+        created_at,
+        updated_at: created_at,
+    }
+}
+
+fn codes(list: &[&str]) -> HashSet<String> {
+    list.iter().map(|s| (*s).to_string()).collect()
+}
+
+// ───────────────────────────── ordering ─────────────────────────────────
+
+#[test]
+fn the_queue_is_fifo() {
+    // The user queued these in this order; the drainer honours it. Horizon is
+    // deliberately not consulted — a `later` item the user queued outranks a
+    // `now` item they didn't.
+    let mut first = item("FLT-100", 10);
+    first.horizon = Horizon::Later;
+    let mut second = item("FLT-101", 20);
+    second.horizon = Horizon::Now;
+    let queue = vec![first, second];
+
+    assert_eq!(
+        pick_next(&queue, 0, &codes(&[]), &codes(&["FLT-100", "FLT-101"])),
+        Decision::Dispatch(0)
+    );
+}
+
+#[test]
+fn an_empty_queue_decides_nothing() {
+    assert_eq!(pick_next(&[], 0, &codes(&[]), &codes(&[])), Decision::Empty);
+}
+
+// ───────────────────────────── dependencies ─────────────────────────────
+
+#[test]
+fn a_done_dependency_lets_an_item_through() {
+    let mut it = item("FLT-101", 10);
+    it.deps = vec!["FLT-100".into()];
+
+    assert_eq!(
+        pick_next(
+            &[it],
+            0,
+            &codes(&["FLT-100"]),
+            &codes(&["FLT-100", "FLT-101"])
+        ),
+        Decision::Dispatch(0)
+    );
+}
+
+#[test]
+fn an_in_review_dependency_still_blocks() {
+    // `in_review` means the PR is open, not merged: a dependant forked now
+    // would build on a tree that doesn't contain the work it depends on.
+    let mut it = item("FLT-101", 10);
+    it.deps = vec!["FLT-100".into()];
+
+    assert_eq!(
+        pick_next(
+            &[it],
+            0,
+            // FLT-100 exists but is not done.
+            &codes(&[]),
+            &codes(&["FLT-100", "FLT-101"])
+        ),
+        Decision::Blocked {
+            item_id: "id-FLT-101".into(),
+            waiting_on: vec!["FLT-100".into()],
+        }
+    );
+}
+
+#[test]
+fn a_dependency_that_no_longer_exists_counts_as_satisfied() {
+    // The item it pointed at was deleted off the board, and a deleted item
+    // never ships — waiting for it would block this one forever.
+    let mut it = item("FLT-101", 10);
+    it.deps = vec!["FLT-100".into()];
+
+    assert_eq!(
+        pick_next(&[it], 0, &codes(&[]), &codes(&["FLT-101"])),
+        Decision::Dispatch(0)
+    );
+}
+
+#[test]
+fn a_blocked_head_does_not_block_the_rest_of_the_queue() {
+    // Skipped, never failed: FLT-100's turn comes when its dep lands.
+    let mut blocked = item("FLT-100", 10);
+    blocked.deps = vec!["FLT-099".into()];
+    let ready = item("FLT-101", 20);
+
+    assert_eq!(
+        pick_next(
+            &[blocked, ready],
+            0,
+            &codes(&[]),
+            &codes(&["FLT-099", "FLT-100", "FLT-101"])
+        ),
+        Decision::Dispatch(1)
+    );
+}
+
+#[test]
+fn an_all_blocked_queue_reports_the_head_and_what_it_waits_on() {
+    let mut head = item("FLT-100", 10);
+    head.deps = vec!["FLT-098".into(), "FLT-099".into()];
+    let mut tail = item("FLT-101", 20);
+    tail.deps = vec!["FLT-100".into()];
+
+    let known = codes(&["FLT-098", "FLT-099", "FLT-100", "FLT-101"]);
+    // FLT-098 landed; FLT-099 hasn't.
+    assert_eq!(
+        pick_next(&[head, tail], 0, &codes(&["FLT-098"]), &known),
+        Decision::Blocked {
+            item_id: "id-FLT-100".into(),
+            waiting_on: vec!["FLT-099".into()],
+        }
+    );
+}
+
+#[test]
+fn unsatisfied_deps_reports_only_the_live_unlanded_ones() {
+    let deps = vec![
+        "FLT-100".to_string(), // done
+        "FLT-101".to_string(), // exists, not done
+        "FLT-102".to_string(), // deleted
+    ];
+    assert_eq!(
+        unsatisfied_deps(&deps, &codes(&["FLT-100"]), &codes(&["FLT-100", "FLT-101"])),
+        vec!["FLT-101".to_string()]
+    );
+}
+
+// ───────────────────────────── concurrency ──────────────────────────────
+
+#[test]
+fn the_cap_holds_the_queue_even_with_a_ready_item() {
+    let ready = item("FLT-100", 10);
+    assert_eq!(
+        pick_next(
+            &[ready],
+            MAX_CONCURRENT_ROADMAP_RUNS,
+            &codes(&[]),
+            &codes(&["FLT-100"])
+        ),
+        Decision::AtCapacity
+    );
+}
+
+#[test]
+fn capacity_is_checked_before_dependencies() {
+    // An at-capacity project says so rather than reporting a dep block the user
+    // can't act on — the item may well be unblocked by the time a slot frees.
+    let mut blocked = item("FLT-100", 10);
+    blocked.deps = vec!["FLT-099".into()];
+    assert_eq!(
+        pick_next(
+            &[blocked],
+            MAX_CONCURRENT_ROADMAP_RUNS,
+            &codes(&[]),
+            &codes(&["FLT-099", "FLT-100"])
+        ),
+        Decision::AtCapacity
+    );
+}
+
+// ───────────────────────────── workflow choice ──────────────────────────
+
+#[test]
+fn an_items_own_workflow_wins_over_the_project_default() {
+    let mut it = item("FLT-100", 10);
+    it.workflow_def_id = Some("wf-item".into());
+    assert_eq!(
+        resolve_workflow(&it, Some("wf-default")),
+        Some("wf-item".to_string())
+    );
+}
+
+#[test]
+fn an_item_without_one_falls_back_to_the_project_default() {
+    let it = item("FLT-100", 10);
+    assert_eq!(
+        resolve_workflow(&it, Some("wf-default")),
+        Some("wf-default".to_string())
+    );
+}
+
+#[test]
+fn no_workflow_anywhere_resolves_to_nothing() {
+    // Explicitly not a hardcoded fallback spec: inventing a workflow for work
+    // the user queued is worse than asking them to pick one.
+    assert_eq!(resolve_workflow(&item("FLT-100", 10), None), None);
+}
+
+// ───────────────────────────── settlement ───────────────────────────────
+
+#[test]
+fn a_live_run_leaves_its_item_alone() {
+    for status in [RunStatus::Pending, RunStatus::Running, RunStatus::Paused] {
+        assert_eq!(settle(Some(status), None), Settlement::Running);
+    }
+}
+
+#[test]
+fn a_finished_run_with_a_pr_lands_in_review() {
+    // PR 5's merge sweep is what takes it from here to `done`.
+    assert_eq!(
+        settle(
+            Some(RunStatus::Done),
+            Some("https://github.com/o/r/pull/42")
+        ),
+        Settlement::InReview
+    );
+}
+
+#[test]
+fn a_finished_run_with_no_pr_is_simply_done() {
+    // A workflow with `open_pr: false` finished the work; nothing else is
+    // coming, so there is nothing to review.
+    assert_eq!(settle(Some(RunStatus::Done), None), Settlement::Done);
+}
+
+#[test]
+fn a_lost_run_releases_its_item_back_to_the_board() {
+    // Never back to `queued`: an auto-retry loop on a failing workflow burns
+    // tokens all night. Re-queueing is the user's call, once they know why.
+    assert_eq!(
+        settle(Some(RunStatus::Failed), None),
+        Settlement::Released("its run failed")
+    );
+    assert_eq!(
+        settle(Some(RunStatus::Canceled), None),
+        Settlement::Released("its run was canceled")
+    );
+    assert_eq!(
+        settle(None, None),
+        Settlement::Released("its run was deleted")
+    );
+}
+
+#[test]
+fn pr_numbers_come_off_the_url_or_not_at_all() {
+    assert_eq!(
+        pr_number_from_url("https://github.com/o/r/pull/142"),
+        Some(142)
+    );
+    assert_eq!(
+        pr_number_from_url("https://github.com/o/r/pull/142/"),
+        Some(142)
+    );
+    assert_eq!(pr_number_from_url("https://github.com/o/r/pulls"), None);
+    assert_eq!(pr_number_from_url(""), None);
+}
+
+// ───────────────────────────── the brief ────────────────────────────────
+
+#[test]
+fn the_brief_carries_the_item_its_criteria_and_its_ancestry() {
+    let mut it = item("FLT-142", 10);
+    it.title = "Persist worktree state across restarts".into();
+    it.why = "A hard quit loses every checkout binding.".into();
+    it.accept = vec!["survives a quit".into(), "orphans are offered".into()];
+    it.deps = vec!["FLT-140".into()];
+
+    let mut dep = item("FLT-140", 5);
+    dep.title = "Worktree registry".into();
+    dep.status = ItemStatus::Done;
+
+    let brief = build_brief(&it, &[&dep]);
+
+    assert!(brief.starts_with("FLT-142: Persist worktree state across restarts"));
+    assert!(brief.contains("A hard quit loses every checkout binding."));
+    // Acceptance criteria arrive as a checklist the run can tick through.
+    assert!(brief.contains("Done when:"));
+    assert!(brief.contains("- [ ] survives a quit"));
+    assert!(brief.contains("- [ ] orphans are offered"));
+    // What already landed underneath it — context a human in a chat would have
+    // and a non-interactive run wouldn't.
+    assert!(brief.contains("- FLT-140: Worktree registry (done)"));
+    // And the string that lets the board find its way back to the work.
+    assert!(brief.contains("[FLT-142]"));
+    assert!(brief.contains("pull request title"));
+}
+
+#[test]
+fn a_bare_item_still_produces_a_usable_brief() {
+    // No why, no criteria, no deps: the run gets the title and the tracking
+    // instruction, and no empty headings pretending there's more.
+    let brief = build_brief(&item("FLT-100", 10), &[]);
+    assert!(brief.starts_with("FLT-100: do FLT-100"));
+    assert!(!brief.contains("Done when:"));
+    assert!(!brief.contains("Builds on"));
+    assert!(brief.contains("[FLT-100]"));
+}

--- a/src-tauri/src/roadmap/mod.rs
+++ b/src-tauri/src/roadmap/mod.rs
@@ -34,7 +34,7 @@ use parking_lot::Mutex;
 use rusqlite::Connection;
 use tauri::{AppHandle, Emitter};
 
-use types::{ItemPatch, NewItem, RoadmapItem};
+use types::{ItemPatch, ItemStatus, ItemUpdate, NewItem, RoadmapItem};
 
 /// The app's single connection. Public because the PM agent's RPC dispatcher
 /// (`rpc::roadmap`) writes the same table from outside this module and takes
@@ -90,21 +90,61 @@ pub async fn roadmap_create_item(
 /// Patch an item. Absent fields are left alone; an explicit `null` clears a
 /// nullable one (see [`ItemPatch`]). `code` and `project_id` are not patchable —
 /// a code that moved would break every reference to it.
+///
+/// `expect_status` makes the write *conditional*: the patch lands only while the
+/// row still says that, and a miss returns `applied: false` with the row as it
+/// actually is — nothing written, nothing emitted. That is how a status
+/// transition sent from a client snapshot stays safe against the drainer, which
+/// claims `queued → active` under this same lock: an unqueue that arrives a
+/// moment late is dropped instead of flipping a live run's item back onto the
+/// board (which would orphan the run — see [`drainer`]). Omitting it keeps the
+/// unconditional behaviour every other caller wants (a retitle, a horizon move).
 #[tauri::command]
 pub async fn roadmap_update_item(
     id: String,
     patch: ItemPatch,
+    expect_status: Option<ItemStatus>,
     app: AppHandle,
     db: tauri::State<'_, Db>,
-) -> Result<RoadmapItem, String> {
-    let updated = {
+) -> Result<ItemUpdate, String> {
+    let outcome = {
         let conn = db.lock();
-        store::update(&conn, &id, &patch).map_err(|e| e.to_string())?
+        match expect_status {
+            Some(expected) => {
+                match store::update_where_status(&conn, &id, expected, &patch)
+                    .map_err(|e| e.to_string())?
+                {
+                    Some(item) => Some(ItemUpdate {
+                        applied: true,
+                        item,
+                    }),
+                    // Missed the precondition. Read the current row under the
+                    // same guard the failed update ran in, so what the caller
+                    // gets back is the state that beat it.
+                    None => store::get(&conn, &id)
+                        .map_err(|e| e.to_string())?
+                        .map(|item| ItemUpdate {
+                            applied: false,
+                            item,
+                        }),
+                }
+            }
+            None => store::update(&conn, &id, &patch)
+                .map_err(|e| e.to_string())?
+                .map(|item| ItemUpdate {
+                    applied: true,
+                    item,
+                }),
+        }
     };
-    let updated = updated.ok_or_else(|| format!("roadmap item {id} no longer exists"))?;
-    emit_item(&app, &updated);
-    drainer::nudge();
-    Ok(updated)
+    let outcome = outcome.ok_or_else(|| format!("roadmap item {id} no longer exists"))?;
+    // A miss changed nothing, so there is nothing to announce and nothing new
+    // for the drainer to look at.
+    if outcome.applied {
+        emit_item(&app, &outcome.item);
+        drainer::nudge();
+    }
+    Ok(outcome)
 }
 
 /// Delete an item. Silent when the row is already gone — the caller's intent

--- a/src-tauri/src/roadmap/mod.rs
+++ b/src-tauri/src/roadmap/mod.rs
@@ -11,13 +11,20 @@
 //! and every mutation must announce itself — a frontend `db_insert` would skip
 //! all three.
 //!
-//! Events (both best-effort; a failed emit never affects what was persisted):
+//! Events (all best-effort; a failed emit never affects what was persisted):
 //! - `roadmap:item` — the full row, on every create/update. The frontend upserts
 //!   by `id`, the same shape `wf:run` uses, so any writer (this surface, the PM
 //!   agent's RPC, the queue drainer) updates the board without a refetch.
 //! - `roadmap:item-deleted` — the deleted row's id, so the board drops it
 //!   instead of upserting it.
+//! - `roadmap:queue-note` — transient, from [`drainer`]: why a queued item isn't
+//!   moving. Nothing persists it; see that module's docs for why.
+//!
+//! Autonomous dispatch lives in [`drainer`]: `queued` items become running
+//! workflows there, and every mutation on this surface [`drainer::nudge`]s it so
+//! a queue action doesn't wait out the tick interval.
 
+pub mod drainer;
 pub mod store;
 pub mod types;
 
@@ -73,6 +80,10 @@ pub async fn roadmap_create_item(
         store::create(&conn, &project_id, &item).map_err(|e| e.to_string())?
     };
     emit_item(&app, &created);
+    // A row can arrive already `queued` (or as a dependency another queued item
+    // is waiting on), so every mutation re-checks the queue rather than trying
+    // to guess which ones matter.
+    drainer::nudge();
     Ok(created)
 }
 
@@ -92,6 +103,7 @@ pub async fn roadmap_update_item(
     };
     let updated = updated.ok_or_else(|| format!("roadmap item {id} no longer exists"))?;
     emit_item(&app, &updated);
+    drainer::nudge();
     Ok(updated)
 }
 
@@ -109,6 +121,9 @@ pub async fn roadmap_delete_item(
     };
     if removed {
         emit_item_deleted(&app, &id);
+        // A deleted item can be the dep something queued was waiting on — a
+        // stale code counts as satisfied, so the removal can unblock a run.
+        drainer::nudge();
     }
     Ok(())
 }

--- a/src-tauri/src/roadmap/store.rs
+++ b/src-tauri/src/roadmap/store.rs
@@ -89,10 +89,44 @@ pub fn create(conn: &Connection, project_id: &str, new: &NewItem) -> rusqlite::R
 /// Apply a partial update and return the stored row. An empty patch is a no-op
 /// that still returns the row (and still bumps nothing), so callers can send a
 /// patch built from a form without special-casing "nothing changed".
+///
+/// Unconditional: the `SET` lands whatever the row currently says. Use
+/// [`update_where_status`] for a *transition*, where applying the patch on top of
+/// a status somebody else already moved would be wrong.
 pub fn update(
     conn: &Connection,
     id: &str,
     patch: &ItemPatch,
+) -> rusqlite::Result<Option<RoadmapItem>> {
+    apply(conn, id, patch, None)
+}
+
+/// Apply a partial update only while the row is still in `expected`, and return
+/// the stored row — or `None` when the precondition missed (or the row is gone).
+///
+/// The precondition rides the `UPDATE`'s own `WHERE`, so the check and the write
+/// are one statement and nothing can slip between them. That is what makes a
+/// status *transition* safe to express from a client holding a stale snapshot:
+/// an unqueue (`queued → open`) issued a moment after the drainer claimed the
+/// item (`queued → active`) matches no row and is dropped, rather than flipping a
+/// live run's item back onto the board.
+pub fn update_where_status(
+    conn: &Connection,
+    id: &str,
+    expected: ItemStatus,
+    patch: &ItemPatch,
+) -> rusqlite::Result<Option<RoadmapItem>> {
+    apply(conn, id, patch, Some(expected))
+}
+
+/// The one implementation behind [`update`] and [`update_where_status`]: build
+/// the `SET` list from the patch, optionally carry a status precondition, and
+/// read the row back.
+fn apply(
+    conn: &Connection,
+    id: &str,
+    patch: &ItemPatch,
+    expected: Option<ItemStatus>,
 ) -> rusqlite::Result<Option<RoadmapItem>> {
     // Built as (column, value) pairs so the SQL only ever contains literal
     // column names written here — never caller-supplied identifiers.
@@ -149,23 +183,43 @@ pub fn update(
         set("pr_number", Box::new(v));
     }
 
-    if !sets.is_empty() {
-        let assignments: Vec<String> = sets
-            .iter()
-            .enumerate()
-            .map(|(i, col)| format!("{col} = ?{}", i + 1))
-            .collect();
-        let n = vals.len();
-        vals.push(Box::new(now_millis()));
-        vals.push(Box::new(id.to_string()));
-        let sql = format!(
-            "UPDATE roadmap_items SET {}, updated_at = ?{} WHERE id = ?{}",
-            assignments.join(", "),
-            n + 1,
-            n + 2
-        );
-        let refs: Vec<&dyn rusqlite::ToSql> = vals.iter().map(|v| v.as_ref()).collect();
-        conn.execute(&sql, refs.as_slice())?;
+    if sets.is_empty() {
+        // Nothing to write, but a precondition still has to be honoured: an
+        // empty patch against a row that has moved on is a miss, not a no-op.
+        let row = get(conn, id)?;
+        return Ok(match expected {
+            Some(status) => row.filter(|r| r.status == status),
+            None => row,
+        });
+    }
+
+    let assignments: Vec<String> = sets
+        .iter()
+        .enumerate()
+        .map(|(i, col)| format!("{col} = ?{}", i + 1))
+        .collect();
+    let n = vals.len();
+    vals.push(Box::new(now_millis()));
+    vals.push(Box::new(id.to_string()));
+    let guard = match expected {
+        Some(status) => {
+            vals.push(Box::new(status.as_str()));
+            format!(" AND status = ?{}", n + 3)
+        }
+        None => String::new(),
+    };
+    let sql = format!(
+        "UPDATE roadmap_items SET {}, updated_at = ?{} WHERE id = ?{}{guard}",
+        assignments.join(", "),
+        n + 1,
+        n + 2
+    );
+    let refs: Vec<&dyn rusqlite::ToSql> = vals.iter().map(|v| v.as_ref()).collect();
+    let changed = conn.execute(&sql, refs.as_slice())?;
+    // A guarded update that matched nothing is a missed precondition — the
+    // caller must be able to tell that from "applied", so don't hand back a row.
+    if expected.is_some() && changed == 0 {
+        return Ok(None);
     }
     get(conn, id)
 }
@@ -518,6 +572,95 @@ mod tests {
             "second delete is a no-op"
         );
         assert!(list(&conn, &p).unwrap().is_empty());
+    }
+
+    #[test]
+    fn a_conditional_update_applies_only_while_the_status_still_holds() {
+        // The unqueue race: the drainer claims `queued → active` under the
+        // connection lock, and the click that says `queued → open` arrives a
+        // moment later off a stale board. A blind SET would flip the row back to
+        // `open` while a run is being launched against it.
+        let conn = test_conn();
+        let p = project(&conn, "p1", "fletch");
+        let item = create(
+            &conn,
+            &p,
+            &NewItem {
+                title: "queue me".into(),
+                status: Some(ItemStatus::Queued),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        // Hit: the row still says `queued`, so the transition lands.
+        let unqueued = update_where_status(
+            &conn,
+            &item.id,
+            ItemStatus::Queued,
+            &ItemPatch {
+                status: Some(ItemStatus::Open),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(unqueued.status, ItemStatus::Open);
+
+        // The drainer claims it.
+        let claimed = update(
+            &conn,
+            &item.id,
+            &ItemPatch {
+                status: Some(ItemStatus::Active),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .unwrap();
+
+        // Miss: the same click, replayed against the claimed row. Nothing is
+        // written — not the status, not `updated_at` — and `None` is what tells
+        // the command layer to emit nothing and report the row as it is.
+        assert!(update_where_status(
+            &conn,
+            &item.id,
+            ItemStatus::Queued,
+            &ItemPatch {
+                status: Some(ItemStatus::Open),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .is_none());
+        assert_eq!(get(&conn, &item.id).unwrap().unwrap(), claimed);
+
+        // An empty patch honours the precondition too, rather than reporting a
+        // success the caller would read as "the transition happened".
+        assert!(
+            update_where_status(&conn, &item.id, ItemStatus::Queued, &ItemPatch::default())
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            update_where_status(&conn, &item.id, ItemStatus::Active, &ItemPatch::default())
+                .unwrap()
+                .is_some()
+        );
+
+        // And a row that is gone is a miss, not an error.
+        assert!(delete(&conn, &item.id).unwrap());
+        assert!(update_where_status(
+            &conn,
+            &item.id,
+            ItemStatus::Active,
+            &ItemPatch {
+                status: Some(ItemStatus::Open),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .is_none());
     }
 
     #[test]

--- a/src-tauri/src/roadmap/store.rs
+++ b/src-tauri/src/roadmap/store.rs
@@ -61,8 +61,8 @@ pub fn create(conn: &Connection, project_id: &str, new: &NewItem) -> rusqlite::R
     conn.execute(
         "INSERT INTO roadmap_items
            (id, project_id, code, parent_id, title, why, horizon, status, size, area, source,
-            epic, accept_json, deps_json, created_at, updated_at)
-         VALUES (?1, ?2, ?3, NULL, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?14)",
+            epic, accept_json, deps_json, workflow_def_id, created_at, updated_at)
+         VALUES (?1, ?2, ?3, NULL, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?15)",
         params![
             id,
             project_id,
@@ -77,6 +77,7 @@ pub fn create(conn: &Connection, project_id: &str, new: &NewItem) -> rusqlite::R
             new.epic,
             strings_to_col(&new.accept),
             strings_to_col(&new.deps),
+            new.workflow_def_id,
             now,
         ],
     )?;
@@ -396,6 +397,7 @@ mod tests {
                 epic: Some("persistence".into()),
                 accept: vec!["survives a quit".into(), "reattaches".into()],
                 deps: vec![bare.code.clone()],
+                workflow_def_id: Some("wf-pipeline".into()),
             },
         )
         .unwrap();
@@ -410,6 +412,10 @@ mod tests {
         assert_eq!(stored.deps, vec![bare.code]);
         assert_eq!(stored.status, ItemStatus::Proposed);
         assert_eq!(stored.size, Some(ItemSize::L));
+        // Assignable at creation, so the item form can create-and-assign in one
+        // round-trip; unset on the bare row, which means "the project default".
+        assert_eq!(stored.workflow_def_id.as_deref(), Some("wf-pipeline"));
+        assert_eq!(bare.workflow_def_id, None);
     }
 
     #[test]

--- a/src-tauri/src/roadmap/types.rs
+++ b/src-tauri/src/roadmap/types.rs
@@ -153,6 +153,11 @@ pub struct NewItem {
     pub accept: Vec<String>,
     #[serde(default)]
     pub deps: Vec<String>,
+    /// Workflow this item is dispatched under when it's queued. `None` means
+    /// "whatever the project's default is at dispatch time" — accepted here so
+    /// the item form can create and assign in one round-trip.
+    #[serde(default)]
+    pub workflow_def_id: Option<String>,
 }
 
 /// A partial update. An absent field is left alone; an explicit `null` on a

--- a/src-tauri/src/roadmap/types.rs
+++ b/src-tauri/src/roadmap/types.rs
@@ -198,6 +198,21 @@ pub struct ItemPatch {
     pub pr_number: Option<Option<i64>>,
 }
 
+/// The outcome of a patch: the stored row, and whether the patch was the thing
+/// that stored it.
+///
+/// `applied` is false only when the caller asked for a *conditional* update
+/// (`expect_status`) and the row had already moved on — a queue action racing the
+/// drainer's claim. The row still comes back, because the caller's board is what
+/// was wrong: showing it the truth is more useful than an error it would have to
+/// invent a message for.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ItemUpdate {
+    pub applied: bool,
+    /// The patched row when `applied`, the row as it actually is otherwise.
+    pub item: RoadmapItem,
+}
+
 /// Keep a double-`Option` field's `null` distinct from its absence. Serde's
 /// stock `Option` deserializer folds JSON `null` into the *outer* `None`, which
 /// would make "clear this column" unreachable from the frontend — the patch

--- a/src-tauri/src/rpc/roadmap.rs
+++ b/src-tauri/src/rpc/roadmap.rs
@@ -286,6 +286,9 @@ fn validate(items: &[ProposedItem], known: &HashSet<&str>) -> Result<Vec<NewItem
             epic: clean(it.epic.as_deref()),
             accept: clean_list(&it.accept),
             deps,
+            // Which workflow builds it is the user's call, not the PM's — a
+            // proposal isn't work anyone has agreed to do yet.
+            workflow_def_id: None,
         });
     }
     Ok(out)

--- a/src-tauri/src/workflow/scheduler/mod.rs
+++ b/src-tauri/src/workflow/scheduler/mod.rs
@@ -167,6 +167,13 @@ impl WorkflowService {
         // finalize open-PR path can append a `Closes #<n>` trailer. `None` for a
         // normal launch — backward-compatible with today's behavior.
         issue_ref: Option<String>,
+        // The roadmap item this run was dispatched for (the queue drainer,
+        // `roadmap::drainer`). Written in the same INSERT as the rest of the
+        // row rather than patched in afterwards, so a crash between launch and
+        // the drainer's next write can never orphan a run from the item that
+        // owns it — the drainer counts a project's live runs through this
+        // column. `None` for every human-initiated launch.
+        roadmap_item_id: Option<String>,
     ) -> Result<String> {
         let _lifecycle_guard = self.lifecycle.lock().await;
         let run_id = format!("run-{}", uuid::Uuid::new_v4());
@@ -215,8 +222,9 @@ impl WorkflowService {
             conn.execute(
                 "INSERT INTO wf_run (id, definition_id, parent_run_id, name, spec_json, task,
                      project_id, repo_path, run_dir, branch, base_sha, base_branch, status,
-                     budgets_json, spent_json, created_at, updated_at, issue_ref)
-                 VALUES (?1, ?2, NULL, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 'pending', ?12, '{}', ?13, ?13, ?14)",
+                     budgets_json, spent_json, created_at, updated_at, issue_ref,
+                     roadmap_item_id)
+                 VALUES (?1, ?2, NULL, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 'pending', ?12, '{}', ?13, ?13, ?14, ?15)",
                 rusqlite::params![
                     run_id,
                     definition_id,
@@ -232,6 +240,7 @@ impl WorkflowService {
                     budgets_json,
                     now,
                     issue_ref,
+                    roadmap_item_id,
                 ],
             )
             .map_err(|e| Error::Other(e.to_string()))?;
@@ -686,6 +695,8 @@ pub async fn wf_launch(
             base_sha,
             attachments,
             issue_ref,
+            // A hand-launched run answers to nobody's queue.
+            None,
         )
         .await
         .map_err(|e| e.to_string())

--- a/src/api/domains/roadmap.ts
+++ b/src/api/domains/roadmap.ts
@@ -1,5 +1,11 @@
 import { invoke } from "../invoke";
-import type { NewRoadmapItem, RoadmapItem, RoadmapItemPatch } from "../types/roadmap";
+import type {
+  ItemStatus,
+  NewRoadmapItem,
+  RoadmapItem,
+  RoadmapItemPatch,
+  RoadmapItemUpdate,
+} from "../types/roadmap";
 
 /** Per-project roadmap storage (`roadmap_*`, src-tauri/src/roadmap). Every
  *  mutation also broadcasts the row on `roadmap:item` / `roadmap:item-deleted`,
@@ -15,9 +21,22 @@ export const roadmapApi = {
   roadmapCreateItem: (projectId: string, item: NewRoadmapItem) =>
     invoke<RoadmapItem>("roadmap_create_item", { projectId, item }),
   /** Patch an item and get the stored row back. Omitted keys are left alone; an
-   *  explicit `null` clears a nullable column. */
-  roadmapUpdateItem: (id: string, patch: RoadmapItemPatch) =>
-    invoke<RoadmapItem>("roadmap_update_item", { id, patch }),
+   *  explicit `null` clears a nullable column.
+   *
+   *  `expectStatus` makes it a *conditional* transition: the patch lands only
+   *  while the row still says that status, and a miss comes back as
+   *  `applied: false` with the row as it actually is (nothing written, nothing
+   *  broadcast). That is what keeps a status change sent off a stale board from
+   *  overwriting one the Rust drainer made in the meantime — see `unqueueItems`
+   *  in useRoadmap.ts. Without it the patch is unconditional and `applied` is
+   *  always true. */
+  roadmapUpdateItem: (id: string, patch: RoadmapItemPatch, expectStatus?: ItemStatus) =>
+    invoke<RoadmapItemUpdate>("roadmap_update_item", {
+      id,
+      patch,
+      // Always sent, so the argument is present-and-null rather than absent.
+      expectStatus: expectStatus ?? null,
+    }),
   /** Remove an item from the board. */
   roadmapDeleteItem: (id: string) => invoke<void>("roadmap_delete_item", { id }),
 };

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -14,7 +14,7 @@ import type {
 } from "./types/agent";
 import type { PrStateChangedEvent } from "./types/pr";
 import type { AgentInstallEvent } from "./types/providers";
-import type { RoadmapItem } from "./types/roadmap";
+import type { RoadmapItem, RoadmapQueueNote } from "./types/roadmap";
 import type { RunOutputEvent, RunPortEvent, RunStateEvent } from "./types/run";
 import type { DockerBuildEvent, PublishApproval } from "./types/sandbox";
 import type {
@@ -52,6 +52,15 @@ export function onRoadmapItem(cb: (item: RoadmapItem) => void): Promise<Unlisten
  *  row instead of upserting it. */
 export function onRoadmapItemDeleted(cb: (id: string) => void): Promise<UnlistenFn> {
   return listen<string>("roadmap:item-deleted", (event) => cb(event.payload));
+}
+
+/** `roadmap:queue-note` explains why a queued item isn't moving — no workflow
+ *  to run it under, a dependency that hasn't landed, a launch that failed. The
+ *  board shows it inline on the row; nothing persists it, so a listener that
+ *  wasn't mounted simply didn't hear it (the drainer repeats itself when the
+ *  reason changes). */
+export function onRoadmapQueueNote(cb: (note: RoadmapQueueNote) => void): Promise<UnlistenFn> {
+  return listen<RoadmapQueueNote>("roadmap:queue-note", (event) => cb(event.payload));
 }
 
 export function onAgentInstallState(cb: (e: AgentInstallEvent) => void): Promise<UnlistenFn> {

--- a/src/api/types/roadmap.ts
+++ b/src/api/types/roadmap.ts
@@ -68,6 +68,21 @@ export interface NewRoadmapItem {
   epic?: string | null;
   accept?: string[];
   deps?: string[];
+  /** Workflow this item is dispatched under when queued. Omitted (or null)
+   *  means "the project's default at dispatch time". */
+  workflow_def_id?: string | null;
+}
+
+/** Why a queued item isn't moving, as the drainer sees it
+ *  (`roadmap:queue-note`, src-tauri/src/roadmap/drainer.rs).
+ *
+ *  Transient: nothing persists it, and the next change to the row makes it
+ *  stale — which is exactly when the board drops it. Carries the code so a
+ *  listener can name the item without holding the row. */
+export interface RoadmapQueueNote {
+  item_id: string;
+  code: string;
+  note: string;
 }
 
 /** A partial update. An omitted key is left alone; an explicit `null` on a

--- a/src/api/types/roadmap.ts
+++ b/src/api/types/roadmap.ts
@@ -85,6 +85,18 @@ export interface RoadmapQueueNote {
   note: string;
 }
 
+/** The result of a patch: the stored row, and whether this patch is what stored
+ *  it.
+ *
+ *  `applied` is false only for a *conditional* update (`expectStatus`) whose
+ *  precondition missed — the row had already moved on, so nothing was written and
+ *  nothing was broadcast. `item` is then the row as it actually is, which is what
+ *  the caller should put on the board: its own snapshot was the stale one. */
+export interface RoadmapItemUpdate {
+  applied: boolean;
+  item: RoadmapItem;
+}
+
 /** A partial update. An omitted key is left alone; an explicit `null` on a
  *  nullable column clears it — so `{ size: null }` unsets the size while `{}`
  *  changes nothing. `code` and `project_id` are not patchable. */

--- a/src/components/ProjectScreen/Roadmap/Board/ItemCard.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/ItemCard.tsx
@@ -1,7 +1,8 @@
+import { open as openExternal } from "@tauri-apps/plugin-shell";
 import { Icon, type IconName } from "@/components/Icon";
 import { Button } from "@/components/ui/Button";
 import { useAppStore } from "@/store";
-import { type BoardItem, type ItemSource, SIZE_HINT } from "../types";
+import { type BoardItem, type ItemSource, type ItemStatus, SIZE_HINT } from "../types";
 
 /** Where the item came from, as a one-glyph tag. */
 const SOURCE: Record<ItemSource, { icon: IconName; tip: string }> = {
@@ -9,6 +10,22 @@ const SOURCE: Record<ItemSource, { icon: IconName; tip: string }> = {
   pm: { icon: "sparkle", tip: "Written here with the PM agent" },
   linear: { icon: "layers", tip: "From Linear" },
   github: { icon: "github", tip: "From GitHub" },
+};
+
+/** The one-word state chip on the header line, for the statuses that mean
+ *  something is (or should be) happening. `open`/`proposed` get none — an item
+ *  nobody has queued is the board's resting state and needs no label. */
+const STATE: Partial<Record<ItemStatus, { label: string; cls: string; tip: string }>> = {
+  queued: {
+    label: "Queued",
+    cls: "q",
+    tip: "Waiting for a slot — the queue runs one item per project at a time",
+  },
+  in_review: {
+    label: "In review",
+    cls: "r",
+    tip: "Its run opened a pull request; it ships when that merges",
+  },
 };
 
 interface Props {
@@ -23,6 +40,18 @@ interface Props {
   onAccept?: () => void;
   /** Discard the proposal — the row is deleted. Ghosts only. */
   onDiscard?: () => void;
+  /** Hand the item to the queue (`open → queued`). Absent for a ghost and on a
+   *  read-only board. */
+  onQueue?: () => void;
+  /** Take it back off the queue before it's dispatched (`queued → open`). */
+  onUnqueue?: () => void;
+  /** Open the run this item is being built by. Only on an item with a run. */
+  onOpenRun?: () => void;
+  /** The workflow this item would run under ("Project default" resolved), or
+   *  null when nothing would run it — the queue would stall on it. */
+  workflowName?: string | null;
+  /** Why this queued item isn't moving, straight from the drainer. */
+  note?: string;
   /** Ring the row: it was just jumped to, or a pending proposal moves it. */
   focused?: boolean;
   /** Transient highlight for a row that just landed or just moved. */
@@ -56,17 +85,24 @@ export function ItemCard({
   onEdit,
   onAccept,
   onDiscard,
+  onQueue,
+  onUnqueue,
+  onOpenRun,
+  workflowName,
+  note,
   cardRef,
 }: Props) {
   const createDraft = useAppStore((s) => s.createDraft);
   const closeProjectScreen = useAppStore((s) => s.closeProjectScreen);
   const source = SOURCE[item.source];
+  const state = STATE[item.status];
   const cls = [
     "rm-item",
     ghost ? "ghost" : "",
     open ? "open" : "",
     landed ? "landed" : "",
     focused ? "focus" : "",
+    item.status === "queued" ? "queued" : "",
   ]
     .filter(Boolean)
     .join(" ");
@@ -84,10 +120,18 @@ export function ItemCard({
         <span className="rm-code mono text-xs">{item.code}</span>
         <span className="rm-title text-sm truncate">{item.title}</span>
         {item.epic && <span className="rm-epic text-xs">{item.epic}</span>}
-        {item.status === "active" && item.agent && (
+        {/* A dispatched item shows the pearl whether or not an agent id has
+            been stamped on it yet: the queue flips it to `active` at the moment
+            it claims the row, a beat before the run exists. */}
+        {item.status === "active" && (
           <span className="rm-live iflex-center mono text-xs">
             <span className="rm-pearl" />
-            {item.agent}
+            {item.agent ?? "running"}
+          </span>
+        )}
+        {state && (
+          <span className={`rm-state iflex-center text-xs st-${state.cls}`} title={state.tip}>
+            {state.label}
           </span>
         )}
         {item.size && (
@@ -125,6 +169,16 @@ export function ItemCard({
         </div>
       )}
 
+      {/* Why a queued row isn't moving. Outside the collapsible body and
+          outside the header button, like the ghostbar: an item that has stalled
+          must say so without the user having to go looking for it. */}
+      {note && (
+        <div className="rm-note flex-center text-xs">
+          <Icon name="hand" size={11} />
+          <span className="rm-note-t">{note}</span>
+        </div>
+      )}
+
       {open && (
         <div className="rm-item-body">
           {item.why && <p className="rm-why text-sm">{item.why}</p>}
@@ -143,17 +197,35 @@ export function ItemCard({
                 after {d}
               </span>
             ))}
+            {/* What the queue would run this under, so the user knows before
+                they queue rather than after it stalls. */}
+            {(onQueue || onUnqueue) && (
+              <span
+                className={`rm-wf iflex-center mono text-xs ${workflowName ? "" : "none"}`}
+                title={
+                  workflowName
+                    ? `Runs under the ${workflowName} workflow`
+                    : "No workflow set on this item and no project default — the queue can't run it yet"
+                }
+              >
+                <Icon name="combine" size={9} />
+                {workflowName ?? "no workflow"}
+              </span>
+            )}
             <span className="grow" />
             {onEdit && (
               <Button variant="ghost" size="sm" onClick={onEdit}>
                 <Icon name="edit" size={11} /> Edit
               </Button>
             )}
-            {/* A proposed row isn't work anyone has agreed to do — accept it
+            {/* The manual hand-off stays available on every real row: the queue
+                is autonomous, and sometimes you want to drive. Demoted to a
+                ghost button next to "Queue", which is the path most rows take.
+                A proposed row isn't work anyone has agreed to do — accept it
                 first, then send it. */}
             {!ghost && (
               <Button
-                variant="outline"
+                variant="ghost"
                 size="sm"
                 onClick={async () => {
                   const draftId = await createDraft(repoPath, briefFor(item));
@@ -164,6 +236,35 @@ export function ItemCard({
                 }}
               >
                 <Icon name="zap" size={11} /> Send to an agent
+              </Button>
+            )}
+            {/* An item in review is waiting on a PR, so the PR is the thing to
+                go to — the run behind it is already finished. */}
+            {item.item.pr_url && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  void openExternal(item.item.pr_url as string).catch(() => {});
+                }}
+              >
+                <Icon name="pr" size={11} />
+                {item.item.pr_number ? `PR #${item.item.pr_number}` : "View PR"}
+              </Button>
+            )}
+            {onOpenRun && (
+              <Button variant="outline" size="sm" onClick={onOpenRun}>
+                <Icon name="combine" size={11} /> View run
+              </Button>
+            )}
+            {onUnqueue && (
+              <Button variant="outline" size="sm" onClick={onUnqueue}>
+                Take off the queue
+              </Button>
+            )}
+            {onQueue && (
+              <Button variant="primary" size="sm" onClick={onQueue}>
+                <Icon name="play" size={11} /> Queue
               </Button>
             )}
           </div>

--- a/src/components/ProjectScreen/Roadmap/Board/ItemDialog.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/ItemDialog.tsx
@@ -7,6 +7,7 @@ import { Modal, ModalBody, ModalFooter } from "@/components/ui/Modal";
 import { Select, type SelectOption } from "@/components/ui/Select";
 import { TextArea, TextInput } from "@/components/ui/TextInput";
 import { HORIZONS, SIZE_HINT } from "../types";
+import type { ProjectWorkflows } from "../useProjectWorkflows";
 
 /** The fields a human fills in. Deliberately a subset of the row: `code`,
  *  `status`, `source` and everything the agent runtime owns are not typed by
@@ -19,11 +20,18 @@ export interface ItemDraft {
   size: ItemSize | null;
   area: string | null;
   accept: string[];
+  /** Which workflow the queue dispatches this under. `null` means "whatever the
+   *  project's default is at dispatch time" — resolved by the Rust drainer, not
+   *  frozen here, so changing the project default moves every un-pinned item. */
+  workflow_def_id: string | null;
 }
 
 /** `null` is a real value here — "no size yet", which is the honest state of an
  *  idea nobody has shaped. */
 const NO_SIZE = "none";
+
+/** The picker's stand-in for `workflow_def_id: null`. */
+const PROJECT_DEFAULT = "default";
 
 const SIZE_OPTIONS: SelectOption<string>[] = [
   { value: NO_SIZE, label: "Unsized", hint: "not shaped yet" },
@@ -50,6 +58,9 @@ interface Props {
   item: RoadmapItem | null;
   /** Where a new item lands — the group whose "+" was pressed. */
   horizon: Horizon;
+  /** The workflows this project could run the item under, and which one is its
+   *  default. */
+  workflows: ProjectWorkflows;
   onClose: () => void;
   onSave: (draft: ItemDraft) => Promise<unknown>;
   /** Absent while creating: there is nothing to delete yet. */
@@ -58,18 +69,36 @@ interface Props {
 
 /** Create or edit one roadmap item. The same form for both, because the fields
  *  are the same and a separate "quick add" would drift from it. */
-export function ItemDialog({ item, horizon, onClose, onSave, onDelete }: Props) {
+export function ItemDialog({ item, horizon, workflows, onClose, onSave, onDelete }: Props) {
   const [title, setTitle] = useState(item?.title ?? "");
   const [why, setWhy] = useState(item?.why ?? "");
   const [place, setPlace] = useState<Horizon>(item?.horizon ?? horizon);
   const [size, setSize] = useState<string>(item?.size ?? NO_SIZE);
   const [area, setArea] = useState(item?.area ?? "");
   const [accept, setAccept] = useState((item?.accept ?? []).join("\n"));
+  const [workflow, setWorkflow] = useState<string>(item?.workflow_def_id ?? PROJECT_DEFAULT);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   const canSave = title.trim().length > 0 && !busy;
+
+  // "Project default" names the definition when there is one, so the choice is
+  // legible rather than a promise the user has to go and verify. When there
+  // isn't one, the option says so — queueing still works, it just won't move
+  // until a workflow exists, and the card will say that too.
+  const workflowOptions: SelectOption<string>[] = [
+    {
+      value: PROJECT_DEFAULT,
+      label: "Project default",
+      hint: workflows.defaultName ?? (workflows.ready ? "none set yet" : undefined),
+    },
+    ...workflows.definitions.map((d) => ({
+      value: d.id,
+      label: d.name,
+      hint: d.description || undefined,
+    })),
+  ];
 
   const save = async () => {
     if (!canSave) return;
@@ -83,6 +112,7 @@ export function ItemDialog({ item, horizon, onClose, onSave, onDelete }: Props) 
         size: size === NO_SIZE ? null : (size as ItemSize),
         area: area.trim() || null,
         accept: linesToList(accept),
+        workflow_def_id: workflow === PROJECT_DEFAULT ? null : workflow,
       });
       onClose();
     } catch (e) {
@@ -154,6 +184,18 @@ export function ItemDialog({ item, horizon, onClose, onSave, onDelete }: Props) 
               onChange={(e) => setArea(e.target.value)}
             />
           </div>
+        </div>
+
+        <div className="modal-field">
+          <span className="modal-label text-sm">
+            Build it with <span className="modal-opt">when queued</span>
+          </span>
+          <Select
+            value={workflow}
+            options={workflowOptions}
+            onChange={setWorkflow}
+            ariaLabel="Workflow"
+          />
         </div>
 
         <div className="modal-field">

--- a/src/components/ProjectScreen/Roadmap/Board/index.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import type { Horizon, RoadmapItem } from "@/api";
 import { Icon } from "@/components/Icon";
 import { IconButton } from "@/components/ui/IconButton";
+import { useAppStore } from "@/store";
 import { HORIZONS } from "../types";
 import type { RoadmapState } from "../useRoadmap";
 import { EmptyBoard } from "./EmptyBoard";
@@ -33,11 +34,17 @@ export function Board({ roadmap, repoPath }: { roadmap: RoadmapState; repoPath: 
     readOnly,
     error,
     clearError,
+    notes,
     addItem,
     editItem,
     removeItems,
     acceptItems,
+    queueItems,
+    unqueueItems,
+    workflows,
   } = roadmap;
+  const selectRun = useAppStore((s) => s.selectRun);
+  const closeProjectScreen = useAppStore((s) => s.closeProjectScreen);
 
   const [editing, setEditing] = useState<Editing | null>(null);
   /** The row the form is editing, if it isn't creating one. */
@@ -168,6 +175,10 @@ export function Board({ roadmap, repoPath }: { roadmap: RoadmapState; repoPath: 
                   // A proposed row is on the board but not *of* it yet: it is
                   // ruled on rather than edited or sent to an agent.
                   const ghost = it.status === "proposed";
+                  // The queue owns everything from `queued` on: an `active` or
+                  // `in_review` row is the drainer's, and the user's lever on it
+                  // is the run, not the row.
+                  const writable = !ghost && !readOnly;
                   return (
                     <ItemCard
                       key={it.code}
@@ -177,6 +188,12 @@ export function Board({ roadmap, repoPath }: { roadmap: RoadmapState; repoPath: 
                       open={openCodes.has(it.code)}
                       landed={landed.has(it.code)}
                       focused={focusCode === it.code}
+                      note={notes.get(row.id)}
+                      workflowName={
+                        writable
+                          ? (workflows.resolve(row.workflow_def_id)?.name ?? null)
+                          : undefined
+                      }
                       onToggle={() => toggleItem(it.code)}
                       onEdit={
                         ghost || readOnly
@@ -185,6 +202,25 @@ export function Board({ roadmap, repoPath }: { roadmap: RoadmapState; repoPath: 
                       }
                       onAccept={ghost && !readOnly ? () => acceptItems([row.id]) : undefined}
                       onDiscard={ghost && !readOnly ? () => removeItems([row.id]) : undefined}
+                      onQueue={
+                        writable && it.status === "open" ? () => queueItems([row.id]) : undefined
+                      }
+                      onUnqueue={
+                        writable && it.status === "queued"
+                          ? () => unqueueItems([row.id])
+                          : undefined
+                      }
+                      onOpenRun={
+                        row.run_id
+                          ? () => {
+                              // The run lives in the workspace, which this
+                              // full-screen page covers — select it, then get
+                              // out of the way.
+                              selectRun(row.run_id as string);
+                              closeProjectScreen();
+                            }
+                          : undefined
+                      }
                       cardRef={(el) => {
                         rows.current[it.code] = el;
                       }}
@@ -201,6 +237,7 @@ export function Board({ roadmap, repoPath }: { roadmap: RoadmapState; repoPath: 
         <ItemDialog
           item={editing.item}
           horizon={editing.horizon}
+          workflows={workflows}
           onClose={() => setEditing(null)}
           onSave={(draft) => (editRow ? editItem(editRow.id, draft) : addItem(draft))}
           onDelete={editRow ? () => removeItems([editRow.id]) : undefined}

--- a/src/components/ProjectScreen/Roadmap/Roadmap.css
+++ b/src/components/ProjectScreen/Roadmap/Roadmap.css
@@ -533,6 +533,25 @@
     box-shadow: 0 0 0 4px color-mix(in oklch, var(--success), transparent 90%);
   }
 }
+/* One-word lifecycle chip. Only the statuses that mean something is (or should
+   be) happening get one — `open` is the board's resting state. */
+.rm-state {
+  flex-shrink: 0;
+  padding: 2px 7px;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+/* Waiting its turn: present, unhurried, not an alert. */
+.rm-state.st-q {
+  color: var(--fg-2);
+  background: var(--bg-3);
+}
+/* Built, PR open, not merged — the same vocabulary the PR surfaces use. */
+.rm-state.st-r {
+  color: var(--info);
+  background: color-mix(in oklch, var(--info), transparent 88%);
+}
+
 .rm-size {
   flex-shrink: 0;
   width: 18px;
@@ -609,6 +628,38 @@
 .rm-dep {
   gap: 4px;
   color: var(--info);
+}
+/* What the queue would run this item under. Muted — it's a fact about the row,
+   not an action — until there is no answer, which is a problem worth seeing. */
+.rm-wf {
+  gap: 4px;
+  color: var(--fg-3);
+}
+.rm-wf.none {
+  color: var(--warn);
+}
+
+/* An item the queue has taken responsibility for. A left rule rather than a
+   fill: it marks the row as spoken for without competing with a ghost's tint or
+   the landed flash. */
+.rm-item.queued {
+  border-left-color: var(--bd-strong);
+  border-left-width: 2px;
+}
+
+/* Why a queued row isn't moving (`roadmap:queue-note`). Sits between the header
+   and the body, like the ghostbar, so a stalled item says so collapsed. */
+.rm-note {
+  gap: 6px;
+  padding: 6px 11px 7px;
+  color: var(--warn);
+  border-top: 1px solid color-mix(in oklch, var(--warn), transparent 82%);
+  background: color-mix(in oklch, var(--warn), transparent 94%);
+}
+.rm-note-t {
+  min-width: 0;
+  color: var(--fg-2);
+  text-wrap: pretty;
 }
 
 /* A proposed row — dashed and tinted until the user accepts it. */

--- a/src/components/ProjectScreen/Roadmap/useProjectWorkflows.ts
+++ b/src/components/ProjectScreen/Roadmap/useProjectWorkflows.ts
@@ -1,0 +1,74 @@
+// Which workflow a roadmap item runs under.
+//
+// Two facts, loaded once per project: the workflow definitions on this machine,
+// and the project's default. The board needs both to *say* what a queued item
+// will run under before it runs, and the item form needs both to let the user
+// override it.
+//
+// The default is read through `loadPipelinePrefs` — the same `project_settings`
+// key the composer writes (`src/workflows/run/projectPipeline.ts`) and the same
+// key the Rust drainer falls back to. One "the workflow this project runs",
+// three readers.
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { api } from "@/api";
+import { loadPipelinePrefs } from "@/workflows/run/projectPipeline";
+import type { Definition } from "@/workflows/spec";
+
+export interface ProjectWorkflows {
+  definitions: Definition[];
+  /** The project's default definition id, or null if none is set. */
+  defaultId: string | null;
+  /** The default's name, or null when unset or pointing at a deleted one. */
+  defaultName: string | null;
+  /** True once both loads have settled — until then "no default" is unknown,
+   *  not false, and the UI must not warn about it. */
+  ready: boolean;
+  /** What an item will actually run under: its override, else the project
+   *  default. `null` means nothing would run it — the queue would stall. */
+  resolve: (workflowDefId: string | null) => Definition | null;
+}
+
+export function useProjectWorkflows(projectId: string | null): ProjectWorkflows {
+  const [definitions, setDefinitions] = useState<Definition[]>([]);
+  const [defaultId, setDefaultId] = useState<string | null>(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (!projectId) {
+      setDefinitions([]);
+      setDefaultId(null);
+      setReady(false);
+      return;
+    }
+    let alive = true;
+    setReady(false);
+    Promise.all([api.wfDefList().catch(() => []), loadPipelinePrefs(projectId)])
+      .then(([defs, prefs]) => {
+        if (!alive) return;
+        setDefinitions(defs);
+        setDefaultId(prefs.defaultWorkflowId);
+      })
+      .finally(() => {
+        if (alive) setReady(true);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [projectId]);
+
+  const resolve = useCallback(
+    (workflowDefId: string | null) => {
+      const id = workflowDefId ?? defaultId;
+      return definitions.find((d) => d.id === id) ?? null;
+    },
+    [definitions, defaultId],
+  );
+
+  const defaultName = useMemo(
+    () => definitions.find((d) => d.id === defaultId)?.name ?? null,
+    [definitions, defaultId],
+  );
+
+  return { definitions, defaultId, defaultName, ready, resolve };
+}

--- a/src/components/ProjectScreen/Roadmap/useRoadmap.ts
+++ b/src/components/ProjectScreen/Roadmap/useRoadmap.ts
@@ -17,6 +17,12 @@
 // board grows ghost rows live while the PM is still talking. Accepting one is a
 // status patch (`proposed → open`); discarding it is a delete. Those two are
 // the only ways a proposed row leaves that state.
+//
+// Queueing works the same way, one status further along: `open → queued` is the
+// user handing an item to the Rust drainer (src-tauri/src/roadmap/drainer.rs),
+// which owns everything after it — `queued → active` when it launches a run,
+// and `active → in_review`/`done`/back to `open` when that run settles. This
+// hook never writes those; it only ever asks for `queued` or takes it back.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -24,6 +30,7 @@ import {
   type NewRoadmapItem,
   onRoadmapItem,
   onRoadmapItemDeleted,
+  onRoadmapQueueNote,
   type RoadmapItem,
   type RoadmapItemPatch,
 } from "@/api";
@@ -32,6 +39,7 @@ import { applyBoardEvent, createBoardSync } from "./boardSync";
 import { PRODUCT_MAP } from "./mockData";
 import type { Horizon } from "./types";
 import { toBoardItem } from "./types";
+import { useProjectWorkflows } from "./useProjectWorkflows";
 
 /** How long a row stays highlighted after landing on the board. */
 const LANDED_MS = 2200;
@@ -57,6 +65,9 @@ export function useRoadmap(repoPath: string) {
   // yet", not "no project" — telling a populated board it's empty for a frame
   // would flash the empty state at someone who has a roadmap.
   const workspaceReady = useAppStore((s) => s.workspace != null);
+  // What a queued item will run under. Loaded here rather than in the Board so
+  // the item form and the card's queue affordance read the same answer.
+  const workflows = useProjectWorkflows(projectId);
 
   const [rows, setRows] = useState<RoadmapItem[]>([]);
   const [loading, setLoading] = useState(true);
@@ -68,6 +79,10 @@ export function useRoadmap(repoPath: string) {
   const [focusCode, setFocusCode] = useState<string | null>(null);
   /** Codes highlighted because they just landed or just moved. */
   const [landed, setLanded] = useState<ReadonlySet<string>>(() => new Set());
+  /** Why a queued item isn't moving, by item id — the drainer's transient
+   *  `roadmap:queue-note`. Not persisted anywhere, on purpose: it's only true
+   *  until the next tick, and the row's own next change supersedes it. */
+  const [notes, setNotes] = useState<ReadonlyMap<string, string>>(() => new Map());
 
   // Every pending highlight timer, so unmounting can't set state on a dead
   // component.
@@ -83,11 +98,29 @@ export function useRoadmap(repoPath: string) {
   }, []);
 
   // ── the persisted board ────────────────────────────────────────────
+  /** Drop an item's queue note. Notes are independent of the row buffer, so
+   *  clearing at event-arrival time is safe even mid-load. */
+  const dropNote = useCallback((id: string) => {
+    setNotes((prev) => {
+      if (!prev.has(id)) return prev;
+      const next = new Map(prev);
+      next.delete(id);
+      return next;
+    });
+  }, []);
+
   /** Upsert a row by id, appending new ones — the backend lists oldest-first
    *  and a new row is the newest, so append keeps the two in the same order. */
-  const upsert = useCallback((row: RoadmapItem) => {
-    setRows((prev) => applyBoardEvent(prev, { kind: "upsert", row }));
-  }, []);
+  const upsert = useCallback(
+    (row: RoadmapItem) => {
+      setRows((prev) => applyBoardEvent(prev, { kind: "upsert", row }));
+      // A note explains why a *queued* row is stuck. The moment the row moves
+      // on, whatever it said is history — drop it rather than leave a stale
+      // excuse under a running item.
+      if (row.status !== "queued") dropNote(row.id);
+    },
+    [dropNote],
+  );
 
   // Load the board: subscribe first, buffer during the fetch, then replay — so a
   // row the PM proposes while the board is loading cannot be lost. Rows change
@@ -111,8 +144,20 @@ export function useRoadmap(repoPath: string) {
     const off = onRoadmapItem((row) => {
       if (row.project_id !== projectId) return;
       sync.push({ kind: "upsert", row });
+      // Rows go through the sequencer; notes don't need to — they're a
+      // separate map, and a stale excuse should vanish even mid-load.
+      if (row.status !== "queued") dropNote(row.id);
     });
-    const offDeleted = onRoadmapItemDeleted((id) => sync.push({ kind: "delete", id }));
+    const offDeleted = onRoadmapItemDeleted((id) => {
+      sync.push({ kind: "delete", id });
+      dropNote(id);
+    });
+    // Addressed by item id, and every id on this board belongs to this project,
+    // so no extra filtering is needed — a note for a row we don't hold is
+    // simply never rendered.
+    const offNote = onRoadmapQueueNote(({ item_id, note }) => {
+      setNotes((prev) => new Map(prev).set(item_id, note));
+    });
 
     void (async () => {
       // Registration has to be awaited, not just started: an event emitted
@@ -138,8 +183,9 @@ export function useRoadmap(repoPath: string) {
       alive = false;
       void off.then((f) => f());
       void offDeleted.then((f) => f());
+      void offNote.then((f) => f());
     };
-  }, [projectId, workspaceReady]);
+  }, [projectId, workspaceReady, dropNote]);
 
   /** Light up rows for a moment after they land, then clear only those — a
    *  later landing must not have its highlight cut short by an earlier timer. */
@@ -254,6 +300,31 @@ export function useRoadmap(repoPath: string) {
     [guarded, markLanded, upsert],
   );
 
+  /** Hand items to the drainer: `open → queued`. From here the Rust side owns
+   *  the item — it picks the oldest queued item whose dependencies have landed,
+   *  resolves a workflow, and launches a run. Queueing something it can't run
+   *  yet is fine and deliberate: it waits, and says why on the card. */
+  const queueItems = useCallback(
+    (ids: string[]) =>
+      guarded(async () => {
+        for (const id of ids) upsert(await api.roadmapUpdateItem(id, { status: "queued" }));
+      }),
+    [guarded, upsert],
+  );
+
+  /** Take an item back off the queue before it's dispatched (`queued → open`).
+   *  Racing the drainer is safe: it re-reads the row under the connection lock
+   *  immediately before claiming it, so this either lands first (and the item
+   *  is skipped) or lands after, against an already-`active` row — which the
+   *  board draws as running, because it is. */
+  const unqueueItems = useCallback(
+    (ids: string[]) =>
+      guarded(async () => {
+        for (const id of ids) upsert(await api.roadmapUpdateItem(id, { status: "open" }));
+      }),
+    [guarded, upsert],
+  );
+
   // ── board interaction ──────────────────────────────────────────────
   const toggleItem = useCallback((code: string) => {
     setOpenCodes((s) => {
@@ -298,11 +369,18 @@ export function useRoadmap(repoPath: string) {
     focusCode,
     focusItem,
     landed,
+    /** Why a queued item isn't moving, by item id. */
+    notes,
     addItem,
     editItem,
     moveItem,
     removeItems,
     acceptItems,
+    queueItems,
+    unqueueItems,
+    /** Definitions + the project default, for the queue affordance and the
+     *  item form. */
+    workflows,
   };
 }
 

--- a/src/components/ProjectScreen/Roadmap/useRoadmap.ts
+++ b/src/components/ProjectScreen/Roadmap/useRoadmap.ts
@@ -240,9 +240,9 @@ export function useRoadmap(repoPath: string) {
   /** Edit a row. Throws, like `addItem` — its caller is the same form. */
   const editItem = useCallback(
     async (id: string, patch: RoadmapItemPatch) => {
-      const row = await api.roadmapUpdateItem(id, patch);
-      upsert(row);
-      return row;
+      const { item } = await api.roadmapUpdateItem(id, patch);
+      upsert(item);
+      return item;
     },
     [upsert],
   );
@@ -261,9 +261,9 @@ export function useRoadmap(repoPath: string) {
   const moveItem = useCallback(
     (id: string, to: Horizon) =>
       guarded(async () => {
-        const row = await api.roadmapUpdateItem(id, { horizon: to });
-        upsert(row);
-        markLanded([row.code]);
+        const { item } = await api.roadmapUpdateItem(id, { horizon: to });
+        upsert(item);
+        markLanded([item.code]);
       }),
     [guarded, markLanded, upsert],
   );
@@ -291,9 +291,9 @@ export function useRoadmap(repoPath: string) {
       guarded(async () => {
         const codes: string[] = [];
         for (const id of ids) {
-          const row = await api.roadmapUpdateItem(id, { status: "open" });
-          upsert(row);
-          codes.push(row.code);
+          const { item } = await api.roadmapUpdateItem(id, { status: "open" });
+          upsert(item);
+          codes.push(item.code);
         }
         markLanded(codes);
       }),
@@ -303,24 +303,47 @@ export function useRoadmap(repoPath: string) {
   /** Hand items to the drainer: `open → queued`. From here the Rust side owns
    *  the item — it picks the oldest queued item whose dependencies have landed,
    *  resolves a workflow, and launches a run. Queueing something it can't run
-   *  yet is fine and deliberate: it waits, and says why on the card. */
+   *  yet is fine and deliberate: it waits, and says why on the card.
+   *
+   *  Conditional on `open` for symmetry with [`unqueueItems`]: a row that already
+   *  moved on (the PM re-proposed it, another window queued it) is reported as it
+   *  is rather than dragged back to `queued`. */
   const queueItems = useCallback(
     (ids: string[]) =>
       guarded(async () => {
-        for (const id of ids) upsert(await api.roadmapUpdateItem(id, { status: "queued" }));
+        for (const id of ids) {
+          // Any note this row carries is about its previous life ("Back on the
+          // board — its run failed."), not about the queued one, and the `queued`
+          // row coming back won't clear it — `upsert` only drops notes for rows
+          // that left the queue. Dropped *before* the write, so the note the
+          // drainer emits on the resulting nudge is the one left standing.
+          dropNote(id);
+          const { item } = await api.roadmapUpdateItem(id, { status: "queued" }, "open");
+          upsert(item);
+        }
       }),
-    [guarded, upsert],
+    [dropNote, guarded, upsert],
   );
 
   /** Take an item back off the queue before it's dispatched (`queued → open`).
-   *  Racing the drainer is safe: it re-reads the row under the connection lock
-   *  immediately before claiming it, so this either lands first (and the item
-   *  is skipped) or lands after, against an already-`active` row — which the
-   *  board draws as running, because it is. */
+   *
+   *  Conditional on `queued`, because racing the drainer is *not* safe: it claims
+   *  `queued → active` under the connection lock and only then writes the
+   *  launched run's id onto the row, so a blind `→ open` landing in between would
+   *  leave a live run tied to an item nothing ever settles (the drainer settles
+   *  `active` items only) — the run would finish invisibly while holding the
+   *  project's queue slot, and the item would sit `open` forever.
+   *
+   *  A miss means the drainer got there first. That is not an error to shout
+   *  about: the click was simply a moment late, so the row that comes back
+   *  (`active`) is upserted and the board draws it as running, because it is. */
   const unqueueItems = useCallback(
     (ids: string[]) =>
       guarded(async () => {
-        for (const id of ids) upsert(await api.roadmapUpdateItem(id, { status: "open" }));
+        for (const id of ids) {
+          const { item } = await api.roadmapUpdateItem(id, { status: "open" }, "queued");
+          upsert(item);
+        }
       }),
     [guarded, upsert],
   );


### PR DESCRIPTION
PR 4 of 5 (roadmap stack, on #583). Queueing an accepted item hands it to the agent runtime with no further clicks.

## What
- `status='queued'` IS the queue (no extra table); `created_at` orders it FIFO.
- Rust drainer (`roadmap/drainer.rs`, pure decision functions + 18 unit tests): 15s tick + nudge on item mutations. Dispatches the oldest queued item whose deps are all `done` (`in_review` does not satisfy — the PR isn't merged), capped at one autonomous run per project. Workflow resolution: item override → project default (same `project_settings` keys the pipeline UI uses); no workflow → queue note, never a hard fail.
- `wf_run.roadmap_item_id` (migration 0028) written atomically in the launch INSERT; crash between launch and item update recovers through the back-link. Failed/deleted runs release the item to `open` — deliberately no auto-retry loops.
- Run done + `finalize_pr` in journal → item `in_review` with `pr_url`/`pr_number` (journal scan is a documented seam for PR 5's `wf_run` columns); no PR → `done`.
- Transient `roadmap:queue-note` events surface why an item isn't moving, deduped, rendered inline on the card. Queue/unqueue, per-item workflow picker with "Project default", View-run + PR links.

## Verification
cargo fmt/check/test (1178) · clippy zero warnings · tsc · biome · vitest (761).

PR 5 (Rust-side merge sweep flipping `in_review → done`) follows.