### PR TITLE
feat(roadmap): merged PRs ship roadmap items automatically

### DIFF
--- a/src-tauri/migrations/0029_wf_run_pr.sql
+++ b/src-tauri/migrations/0029_wf_run_pr.sql
@@ -1,0 +1,23 @@
+-- The pull request a workflow run's finalize opened, recorded on the run row
+-- itself rather than only in the journal.
+--
+-- `finalize_run` already knows the PR: `gitops::finalize` gets a full `PrState`
+-- back from `pr_create_head`, journals `finalize_pr {url}`, and throws the rest
+-- away. That was enough while the only consumer was the run timeline, which
+-- reads events. It is not enough for the roadmap merge sweep
+-- (src-tauri/src/roadmap/merge_sweep.rs), which has to answer "did this run's PR
+-- merge?" for every `in_review` item on every tick: a journal scan per run per
+-- tick, with the number recovered by parsing the URL's trailing path segment,
+-- is a query and a string parse standing in for two columns.
+--
+-- Both nullable, and NULL is the ordinary case: a spec with `open_pr: false`
+-- pushes without proposing anything, a `pr create` that failed leaves the run
+-- `done` with the error in the journal, and every run that finished before this
+-- migration keeps its PR only in its `finalize_pr` event. Nothing reads these
+-- columns expecting them to be populated — a NULL simply means "no PR to poll".
+--
+-- The `finalize_pr` journal event stays exactly as it was: it is the run's
+-- append-only history, the timeline renders it, and it is the only record of a
+-- finalize whose PR creation *failed*.
+ALTER TABLE wf_run ADD COLUMN pr_number INTEGER;
+ALTER TABLE wf_run ADD COLUMN pr_url TEXT;

--- a/src-tauri/src/database/connection.rs
+++ b/src-tauri/src/database/connection.rs
@@ -62,6 +62,7 @@ pub(crate) const MIGRATIONS: &[&str] = &[
     include_str!("../../migrations/0026_roadmap_items.sql"),
     include_str!("../../migrations/0027_workspace_purpose.sql"),
     include_str!("../../migrations/0028_wf_run_roadmap_item.sql"),
+    include_str!("../../migrations/0029_wf_run_pr.sql"),
 ];
 
 pub(crate) fn get_migrations() -> Migrations<'static> {

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -416,6 +416,70 @@ fn roadmap_backlink_migration_leaves_existing_runs_unattributed() {
     assert_eq!(survivors, 1);
 }
 
+/// Schema version at which `wf_run.roadmap_item_id` (0028) exists — the version
+/// an install upgrading into the run PR columns comes from. Pinned like the
+/// three above, for the same reason.
+const V_ROADMAP_BACKLINK: usize = 28;
+
+/// `wf_run.pr_number`/`pr_url` (0029) land on an existing install as nullable
+/// columns, and NULL is a meaningful value, not a gap to backfill: a run that
+/// finished before this migration recorded its PR only in its `finalize_pr`
+/// journal event, and the roadmap merge sweep reads "no PR to poll" off exactly
+/// that NULL. Backfilling by parsing the event's URL would invent a number the
+/// app never got from GitHub.
+#[test]
+fn run_pr_columns_land_nullable_on_existing_runs() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut conn = open_db(&dir.path().join(DB_FILENAME)).unwrap();
+    get_migrations()
+        .to_version(&mut conn, V_ROADMAP_BACKLINK)
+        .unwrap();
+    conn.execute_batch(
+        "INSERT INTO projects (id, name, created_at) VALUES ('p', 'proj', 0);
+         INSERT INTO wf_run (id, name, spec_json, task, project_id, repo_path, run_dir,
+                             branch, base_sha, status, budgets_json, spent_json,
+                             created_at, updated_at)
+              VALUES ('run-old', 'wf', '{}', 'do a thing', 'p', '/r', '/d',
+                      'wf/x', 'abc', 'done', '{}', '{}', 0, 0);",
+    )
+    .unwrap();
+    drop(conn);
+
+    init(dir.path()).unwrap();
+
+    let conn = Connection::open(dir.path().join(DB_FILENAME)).unwrap();
+    let (number, url): (Option<i64>, Option<String>) = conn
+        .query_row(
+            "SELECT pr_number, pr_url FROM wf_run WHERE id = 'run-old'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        number, None,
+        "no PR is recorded for a run that predates 0029"
+    );
+    assert_eq!(url, None);
+
+    // A finalize that opens a PR writes both, and they are the columns the
+    // merge sweep settles an item's `in_review` state from.
+    conn.execute(
+        "UPDATE wf_run SET pr_number = 142, pr_url = 'https://github.com/o/r/pull/142'
+          WHERE id = 'run-old'",
+        [],
+    )
+    .unwrap();
+    let stored: (Option<i64>, Option<String>) = conn
+        .query_row(
+            "SELECT pr_number, pr_url FROM wf_run WHERE id = 'run-old'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(stored.0, Some(142));
+    assert_eq!(stored.1.as_deref(), Some("https://github.com/o/r/pull/142"));
+}
+
 #[test]
 fn fresh_init_creates_no_backup() {
     let dir = tempfile::tempdir().unwrap();

--- a/src-tauri/src/github/live.rs
+++ b/src-tauri/src/github/live.rs
@@ -186,6 +186,38 @@ async fn fetch_all_checks(
     Ok(Some(items))
 }
 
+/// Fetch one PR's state by number over conditional REST, resolving the repo
+/// from any checkout of it.
+///
+/// The state-only counterpart to [`pr_checks_live`], for background pollers
+/// that need "did it merge?" and nothing else. Conditional, so a PR that hasn't
+/// moved since the last read answers `304` and is not billed against the rate
+/// limit — which is what makes it affordable to ask every couple of minutes for
+/// as long as a review takes.
+///
+/// `Ok(None)` means "no answer this round": a rate-limit backoff, no token, a
+/// non-GitHub remote, or a PR the API won't serve. Callers must treat that as
+/// *unchanged*, never as a state — see `roadmap::merge_sweep`.
+pub async fn pr_state_live(checkout: &Path, number: u32) -> Result<Option<PrState>> {
+    if client::is_backing_off() {
+        return Ok(None);
+    }
+    let Some((owner, repo)) = resolve_slug(checkout, None).await else {
+        return Ok(None);
+    };
+    // Background poll path: not being connected is a normal state, not an error.
+    let Ok(client) = client::Client::new() else {
+        return Ok(None);
+    };
+    let (status, pr) = client
+        .rest_get_conditional(&format!("/repos/{owner}/{repo}/pulls/{number}"))
+        .await?;
+    if !status.is_success() {
+        return Ok(None);
+    }
+    Ok(Some(parse_pr_state_rest(&pr)))
+}
+
 /// Fetch the merge gate + CI rollup for one **open** PR by number, over
 /// conditional REST.
 ///

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1476,6 +1476,7 @@ pub fn run() {
 
             let db_for_wf = db.clone();
             let db_for_roadmap = db.clone();
+            let db_for_merge_sweep = db.clone();
             let workspace = Arc::new(WorkspaceManager::new(db));
 
             // Drop RPC mailboxes left by agents that are gone. Teardown removes
@@ -1526,6 +1527,14 @@ pub fn run() {
                 db_for_roadmap,
                 wf_service.clone(),
             );
+            // The other end of the same loop: watch the PRs of items already
+            // `in_review` and ship them when they merge. Host-side on purpose —
+            // the webview's PR polling stops with the window, and a queue whose
+            // dependants unblock only while you are looking at the board is not
+            // an autonomous queue. Sweeps once now (a PR may well have merged
+            // while the app was closed), then sleeps until there is something
+            // to watch.
+            crate::roadmap::merge_sweep::spawn(app.handle().clone(), db_for_merge_sweep);
             // Reload follow-ups that were queued behind an in-flight turn when a
             // prior run exited, so a mid-turn message survives a restart. They
             // rest in the queue and flush on the user's next send (no auto-spawn).

--- a/src-tauri/src/roadmap/drainer.rs
+++ b/src-tauri/src/roadmap/drainer.rs
@@ -887,7 +887,6 @@ fn definition_spec(conn: &Connection, definition_id: &str) -> Option<Spec> {
 
 /// Apply a patch and announce the row. Every drainer write goes through here,
 /// so nothing it changes can reach the database without reaching the board.
-/// [`super::merge_sweep`] writes through it too, for the same guarantee.
 pub(crate) fn write_item(app: &AppHandle, db: &Db, id: &str, patch: ItemPatch) {
     let updated = {
         let conn = db.lock();
@@ -898,6 +897,34 @@ pub(crate) fn write_item(app: &AppHandle, db: &Db, id: &str, patch: ItemPatch) {
         // The row was deleted mid-tick; nothing to announce.
         Ok(None) => {}
         Err(e) => tracing::warn!(id, error = %e, "roadmap drainer: item write failed"),
+    }
+}
+
+/// [`write_item`], but only when the row is still in `expected` status — the
+/// transition-safe variant for a verdict decided *before* a wait. The merge
+/// sweep decides over a network read, so by write time the row may have moved
+/// (re-queued, re-dispatched); stamping a stale verdict over that would orphan
+/// the fresh work. A miss writes and announces nothing.
+pub(crate) fn write_item_where(
+    app: &AppHandle,
+    db: &Db,
+    id: &str,
+    expected: ItemStatus,
+    patch: ItemPatch,
+) {
+    let updated = {
+        let conn = db.lock();
+        store::update_where_status(&conn, id, expected, &patch)
+    };
+    match updated {
+        Ok(Some(row)) => emit_item(app, &row),
+        // Deleted, or no longer in `expected` — either way the verdict is
+        // stale and the row's current owner wins.
+        Ok(None) => tracing::debug!(
+            id,
+            "roadmap: row moved before a verdict landed — left alone"
+        ),
+        Err(e) => tracing::warn!(id, error = %e, "roadmap: item write failed"),
     }
 }
 

--- a/src-tauri/src/roadmap/drainer.rs
+++ b/src-tauri/src/roadmap/drainer.rs
@@ -21,6 +21,11 @@
 //! 2. **Dispatches** at most one queued item ([`pick_next`]), if the project is
 //!    under [`MAX_CONCURRENT_ROADMAP_RUNS`] live roadmap-dispatched runs.
 //!
+//! An item settled into `in_review` leaves the drainer's world entirely —
+//! `projects_with_work` only looks at `queued`/`active`, so a board waiting on
+//! reviews is inert here. [`super::merge_sweep`] owns it from there and hands it
+//! back (as `done`, unblocking dependants, or as `open` if the PR was closed).
+//!
 //! # Locking
 //!
 //! Everything that reads or writes the database happens inside a
@@ -211,13 +216,27 @@ pub(crate) fn resolve_workflow(
         .or_else(|| project_default.map(str::to_string))
 }
 
+/// The pull request a finished run opened, as `wf_run` records it (0029).
+///
+/// `number` is nullable independently of the URL: the columns are written
+/// together from one `PrState`, but a row written before 0029 landed (or by a
+/// path that only knew the URL) can still carry a link with nothing to poll.
+/// The merge sweep needs the number, so the two are kept distinct rather than
+/// pretending a URL implies one.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct FinalizedPr {
+    pub url: String,
+    pub number: Option<i64>,
+}
+
 /// What an `active` item's run says should happen to the item.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum Settlement {
     /// The run is still going. Leave the item alone.
     Running,
     /// The run finished and opened a PR. The work isn't merged yet, so the item
-    /// is `in_review` — PR 5's merge sweep is what moves it to `done`.
+    /// is `in_review` — [`super::merge_sweep`] is what moves it to `done` once
+    /// GitHub says the PR landed.
     InReview,
     /// The run finished without opening a PR (a spec with `open_pr: false`, or
     /// a finalize that only pushed). Nothing else is coming, so the item is
@@ -235,29 +254,17 @@ pub(crate) enum Settlement {
 /// Map a roadmap-dispatched run's state onto its item. `status` is `None` when
 /// the run row no longer exists (a `wf_delete_run`, or a project half-deleted
 /// under us).
-pub(crate) fn settle(status: Option<RunStatus>, pr_url: Option<&str>) -> Settlement {
+pub(crate) fn settle(status: Option<RunStatus>, pr: Option<&FinalizedPr>) -> Settlement {
     match status {
         None => Settlement::Released("its run was deleted"),
         Some(RunStatus::Pending) | Some(RunStatus::Running) | Some(RunStatus::Paused) => {
             Settlement::Running
         }
-        Some(RunStatus::Done) if pr_url.is_some() => Settlement::InReview,
+        Some(RunStatus::Done) if pr.is_some() => Settlement::InReview,
         Some(RunStatus::Done) => Settlement::Done,
         Some(RunStatus::Failed) => Settlement::Released("its run failed"),
         Some(RunStatus::Canceled) => Settlement::Released("its run was canceled"),
     }
-}
-
-/// The trailing number of a GitHub PR URL (`.../pull/142` → `142`).
-///
-/// PR 5's seam: the merge sweep needs a number to poll, and today the only
-/// record of the PR is the `finalize_pr` journal event's URL. PR 5 persists
-/// `pr_number`/`pr_url` on `wf_run` at finalize time and reads them from there;
-/// this parse exists so an item settled by *this* build still carries enough to
-/// be polled, and can be deleted once the run row holds the truth.
-pub(crate) fn pr_number_from_url(url: &str) -> Option<i64> {
-    let tail = url.trim_end_matches('/').rsplit('/').next()?;
-    tail.parse().ok()
 }
 
 /// The task brief a dispatched run receives, built from the item.
@@ -380,7 +387,9 @@ fn projects_with_work(db: &Db) -> Vec<String> {
 struct Settled {
     item: RoadmapItem,
     outcome: Settlement,
-    pr_url: Option<String>,
+    /// The PR the run opened, when it opened one — stamped onto the item so the
+    /// merge sweep can poll it without re-joining to the run.
+    pr: Option<FinalizedPr>,
     /// The run this item is tied to, when the item's own `run_id` didn't name
     /// it — recovered through the `wf_run.roadmap_item_id` back-link and written
     /// back onto the row.
@@ -426,11 +435,10 @@ fn settle_project(app: &AppHandle, db: &Db, project_id: &str, said: &SaidNotes) 
                     // No run row at all — neither named nor back-linked.
                     None => None,
                 };
-                let pr_url = match status {
-                    // Only a finished run can have finalized, so the journal
-                    // scan is paid once per item, not once per tick.
+                let pr = match status {
+                    // Only a finished run can have finalized.
                     Some(RunStatus::Done) => {
-                        run_id.as_deref().and_then(|id| finalized_pr_url(&conn, id))
+                        run_id.as_deref().and_then(|id| finalized_pr(&conn, id))
                     }
                     _ => None,
                 };
@@ -439,12 +447,12 @@ fn settle_project(app: &AppHandle, db: &Db, project_id: &str, said: &SaidNotes) 
                     // can't tell this from a deleted run — the item can, and
                     // "never started" is the honest thing to put on the card.
                     None => Settlement::Released("its run never started"),
-                    Some(_) => settle(status, pr_url.as_deref()),
+                    Some(_) => settle(status, pr.as_ref()),
                 };
                 Settled {
                     item,
                     outcome,
-                    pr_url,
+                    pr,
                     adopted_run_id,
                 }
             })
@@ -456,7 +464,7 @@ fn settle_project(app: &AppHandle, db: &Db, project_id: &str, said: &SaidNotes) 
     for Settled {
         item,
         outcome,
-        pr_url,
+        pr,
         adopted_run_id,
     } in settled
     {
@@ -481,12 +489,13 @@ fn settle_project(app: &AppHandle, db: &Db, project_id: &str, said: &SaidNotes) 
             }
             Settlement::InReview => ItemPatch {
                 status: Some(ItemStatus::InReview),
-                // PR 5's seam: the merge sweep will read `pr_number`/`pr_url`
-                // off `wf_run` (persisted at finalize) rather than off the
-                // journal, and poll from there. Stamping them on the item now
-                // means a board settled by this build is already pollable.
-                pr_url: Some(pr_url.clone()),
-                pr_number: Some(pr_url.as_deref().and_then(pr_number_from_url)),
+                // Copied off the run row onto the item, so the item's own
+                // columns are authoritative from here on: the merge sweep
+                // selects on `status = 'in_review' AND pr_number IS NOT NULL`
+                // and never has to join back to a run that may since have been
+                // deleted, nor to a run repo that has since been cleaned up.
+                pr_url: Some(pr.as_ref().map(|p| p.url.clone())),
+                pr_number: Some(pr.as_ref().and_then(|p| p.number)),
                 ..Default::default()
             },
             Settlement::Done => ItemPatch {
@@ -507,6 +516,12 @@ fn settle_project(app: &AppHandle, db: &Db, project_id: &str, said: &SaidNotes) 
             Settlement::Released(why) => {
                 tracing::info!(item = %item.code, %why, "roadmap drainer: released item");
                 say(app, said, &item, &format!("Back on the board — {why}."));
+            }
+            // A new PR to watch. The sweep sleeps while nothing is in review,
+            // so it has to be told rather than left to find this on a tick.
+            Settlement::InReview => {
+                forget(said, &item.id);
+                super::merge_sweep::nudge();
             }
             // A settled-forward item is no longer waiting on anything, so any
             // note it carried is stale.
@@ -555,29 +570,24 @@ fn run_status(conn: &Connection, run_id: &str) -> Option<RunStatus> {
     .and_then(|s| RunStatus::from_db(&s))
 }
 
-/// The URL of the PR a finished run opened, from its `finalize_pr` journal
-/// event. That event carries either `{"url": …}` or `{"error": …}`; only the
-/// former means a PR exists.
+/// The PR a finished run opened, read off the run row (0029).
 ///
-/// PR 5's seam — see [`pr_number_from_url`]: once `wf_run` carries the PR
-/// columns, this reads a column instead of scanning the journal.
-fn finalized_pr_url(conn: &Connection, run_id: &str) -> Option<String> {
-    let payload: String = conn
+/// A blank or absent URL means no PR: a `push`-only finalize, a `pr create`
+/// that failed (the reason is in the run's `finalize_pr` journal event), or a
+/// run that finished before the columns existed. All three settle the item
+/// straight to `done` — there is nothing to review.
+fn finalized_pr(conn: &Connection, run_id: &str) -> Option<FinalizedPr> {
+    let (url, number): (Option<String>, Option<i64>) = conn
         .query_row(
-            "SELECT payload_json FROM wf_event
-              WHERE run_id = ?1 AND type = ?2 ORDER BY seq DESC LIMIT 1",
-            rusqlite::params![run_id, crate::workflow::types::event_type::FINALIZE_PR],
-            |r| r.get(0),
+            "SELECT pr_url, pr_number FROM wf_run WHERE id = ?1",
+            [run_id],
+            |r| Ok((r.get(0)?, r.get(1)?)),
         )
         .optional()
         .ok()
         .flatten()?;
-    let value: serde_json::Value = serde_json::from_str(&payload).ok()?;
-    value
-        .get("url")
-        .and_then(|u| u.as_str())
-        .filter(|u| !u.trim().is_empty())
-        .map(str::to_string)
+    let url = url.filter(|u| !u.trim().is_empty())?;
+    Some(FinalizedPr { url, number })
 }
 
 // ───────────────────────────── dispatch ─────────────────────────────────
@@ -834,7 +844,11 @@ fn live_run_count(conn: &Connection, project_id: &str) -> usize {
 /// The project's primary repo — the first attached, mirroring
 /// `WorkspaceManager::project_repo_paths`. A run targets one repo; the queue
 /// picks the same one the rest of the app calls primary.
-fn primary_repo_path(conn: &Connection, project_id: &str) -> Option<String> {
+///
+/// Shared with [`super::merge_sweep`], which resolves `owner/repo` from this
+/// checkout's remote: it is the one path tied to the *project* rather than to a
+/// run, and so is still there after a finished run's directory is cleaned up.
+pub(crate) fn primary_repo_path(conn: &Connection, project_id: &str) -> Option<String> {
     conn.query_row(
         "SELECT path FROM repos WHERE project_id = ?1 ORDER BY created_at LIMIT 1",
         [project_id],
@@ -873,7 +887,8 @@ fn definition_spec(conn: &Connection, definition_id: &str) -> Option<Spec> {
 
 /// Apply a patch and announce the row. Every drainer write goes through here,
 /// so nothing it changes can reach the database without reaching the board.
-fn write_item(app: &AppHandle, db: &Db, id: &str, patch: ItemPatch) {
+/// [`super::merge_sweep`] writes through it too, for the same guarantee.
+pub(crate) fn write_item(app: &AppHandle, db: &Db, id: &str, patch: ItemPatch) {
     let updated = {
         let conn = db.lock();
         store::update(&conn, id, &patch)
@@ -888,7 +903,7 @@ fn write_item(app: &AppHandle, db: &Db, id: &str, patch: ItemPatch) {
 
 // ───────────────────────────── notes ────────────────────────────────────
 
-fn emit_note(app: &AppHandle, note: &QueueNote) {
+pub(crate) fn emit_note(app: &AppHandle, note: &QueueNote) {
     let _ = app.emit("roadmap:queue-note", note);
 }
 

--- a/src-tauri/src/roadmap/drainer/tests.rs
+++ b/src-tauri/src/roadmap/drainer/tests.rs
@@ -42,6 +42,14 @@ fn codes(list: &[&str]) -> HashSet<String> {
     list.iter().map(|s| (*s).to_string()).collect()
 }
 
+/// The PR a finished run recorded on its row.
+fn pr(number: Option<i64>) -> FinalizedPr {
+    FinalizedPr {
+        url: "https://github.com/o/r/pull/42".into(),
+        number,
+    }
+}
+
 // ───────────────────────────── ordering ─────────────────────────────────
 
 #[test]
@@ -240,12 +248,21 @@ fn a_live_run_leaves_its_item_alone() {
 
 #[test]
 fn a_finished_run_with_a_pr_lands_in_review() {
-    // PR 5's merge sweep is what takes it from here to `done`.
+    // `merge_sweep` is what takes it from here to `done`, once GitHub says the
+    // PR merged.
     assert_eq!(
-        settle(
-            Some(RunStatus::Done),
-            Some("https://github.com/o/r/pull/42")
-        ),
+        settle(Some(RunStatus::Done), Some(&pr(Some(42)))),
+        Settlement::InReview
+    );
+}
+
+#[test]
+fn a_pr_whose_number_never_landed_still_reaches_review() {
+    // The URL is what makes it reviewable; the number is what makes it
+    // *pollable*. Without one the item sits in review until a human moves it,
+    // which is better than settling work that has an open PR straight to done.
+    assert_eq!(
+        settle(Some(RunStatus::Done), Some(&pr(None))),
         Settlement::InReview
     );
 }
@@ -273,20 +290,6 @@ fn a_lost_run_releases_its_item_back_to_the_board() {
         settle(None, None),
         Settlement::Released("its run was deleted")
     );
-}
-
-#[test]
-fn pr_numbers_come_off_the_url_or_not_at_all() {
-    assert_eq!(
-        pr_number_from_url("https://github.com/o/r/pull/142"),
-        Some(142)
-    );
-    assert_eq!(
-        pr_number_from_url("https://github.com/o/r/pull/142/"),
-        Some(142)
-    );
-    assert_eq!(pr_number_from_url("https://github.com/o/r/pulls"), None);
-    assert_eq!(pr_number_from_url(""), None);
 }
 
 // ───────────────────────────── crash recovery ───────────────────────────

--- a/src-tauri/src/roadmap/merge_sweep.rs
+++ b/src-tauri/src/roadmap/merge_sweep.rs
@@ -176,18 +176,41 @@ struct Watched {
 pub fn spawn(app: AppHandle, db: Db) {
     tauri::async_runtime::spawn(async move {
         loop {
-            let watching = watch_list(&db);
-            if watching.is_empty() {
+            // Each pass runs in its own task so a panic is contained: silently
+            // dead until the next app start is the worst possible failure mode
+            // for the thing that ships merged work — the same guard the
+            // drainer's tick carries.
+            let pass = {
+                let app = app.clone();
+                let db = db.clone();
+                tauri::async_runtime::spawn(async move {
+                    let watching = watch_list(&db);
+                    let idle = watching.is_empty();
+                    if !idle {
+                        sweep(&app, &db, watching).await;
+                    }
+                    idle
+                })
+                .await
+            };
+            match pass {
                 // Nothing in review: sleep until the drainer says there is.
                 // Checked before waiting, not after, so a board that is already
                 // mid-review at launch is swept without needing a start nudge.
-                signal().notified().await;
-                continue;
-            }
-            sweep(&app, &db, watching).await;
-            tokio::select! {
-                _ = tokio::time::sleep(SWEEP) => {}
-                _ = signal().notified() => {}
+                Ok(true) => signal().notified().await,
+                Ok(false) => tokio::select! {
+                    _ = tokio::time::sleep(SWEEP) => {}
+                    _ = signal().notified() => {}
+                },
+                Err(e) => {
+                    tracing::error!(error = %e, "roadmap merge sweep pass panicked — sweeping continues");
+                    // Don't park: the watch list may be non-empty, and the only
+                    // thing that nudges a parked sweep is a drainer settlement.
+                    tokio::select! {
+                        _ = tokio::time::sleep(SWEEP) => {}
+                        _ = signal().notified() => {}
+                    }
+                }
             }
         }
     });
@@ -227,10 +250,11 @@ fn watch_list(db: &Db) -> Vec<Watched> {
         .collect()
 }
 
-/// Poll each watched PR and apply whatever GitHub says. Sequential: the list is
-/// bounded by how many items are in review at once (one per project, given
-/// [`drainer::MAX_CONCURRENT_ROADMAP_RUNS`]), and conditional requests make a
-/// repeat read of an unchanged PR nearly free.
+/// Poll each watched PR and apply whatever GitHub says. Sequential on purpose:
+/// in-review items *accumulate* — [`drainer::MAX_CONCURRENT_ROADMAP_RUNS`] caps
+/// live runs, not open reviews, and a settled run frees its slot — but the list
+/// only grows as fast as runs finish, and conditional requests make a repeat
+/// read of an unchanged PR nearly free (a 304 isn't billed).
 async fn sweep(app: &AppHandle, db: &Db, watching: Vec<Watched>) {
     // One repo path per project per sweep — resolving it is a database read,
     // and every item in a project shares the answer.
@@ -252,7 +276,10 @@ async fn sweep(app: &AppHandle, db: &Db, watching: Vec<Watched>) {
             continue;
         };
         tracing::info!(item = %w.code, pr = w.number, ?outcome, "roadmap merge sweep");
-        drainer::write_item(app, db, &w.id, patch);
+        // Conditional on the row still being in review: the verdict was decided
+        // over a network read, and a row the user moved meanwhile (marked done
+        // by hand, re-queued after a delete) must not be stamped over.
+        drainer::write_item_where(app, db, &w.id, ItemStatus::InReview, patch);
         match outcome {
             Verdict::Landed => {
                 // The item is `done`, which is what a dependant's dep gate is

--- a/src-tauri/src/roadmap/merge_sweep.rs
+++ b/src-tauri/src/roadmap/merge_sweep.rs
@@ -1,0 +1,305 @@
+//! The roadmap merge sweep: the background task that closes the loop by moving
+//! an `in_review` item to `done` once its pull request merges on GitHub.
+//!
+//! # Why this exists in Rust at all
+//!
+//! Every other PR poll in the app runs in the webview — the Git panel's fast
+//! tick, the fleet sweep in `supervisor::session_sync`. Those are *views*: they
+//! keep a badge honest while you are looking at it, and stopping when
+//! `document.hidden` is exactly right for them.
+//!
+//! The roadmap queue is not a view. Its whole promise is that you can queue five
+//! items, close the window, and come back to five merged PRs — and `done` is
+//! what unblocks the next item's dependants ([`drainer::nudge`] below). A merge
+//! detector that only runs while the board is on screen would stall the queue
+//! behind whichever PR you happened not to be watching. So this one poll lives
+//! host-side, on the same footing as the drainer.
+//!
+//! # The sweep
+//!
+//! Every [`SWEEP`] while anything is `in_review`, for each such item with a PR
+//! number: one conditional REST read of the PR, then
+//!
+//! - **merged** → `done`, and [`drainer::nudge`] so a dependant queued behind it
+//!   dispatches immediately rather than waiting out the drainer's own tick.
+//! - **closed, not merged** → back to `open`, with a note saying so.
+//! - **still open, or no answer** → untouched, retried next sweep.
+//!
+//! When nothing is in review the task sleeps on its [`nudge`] instead of ticking:
+//! an install whose board is all `done` costs nothing and makes no requests.
+//!
+//! # Why polling, and why it is nearly free
+//!
+//! GitHub can push this (webhooks) only to a public endpoint, which a desktop
+//! app does not have. Polling is the available mechanism, and the cost is held
+//! down by reusing [`crate::github::pr_state_live`]: an ETag-conditional REST
+//! read whose `304 Not Modified` is not billed against the rate limit. An
+//! unchanged PR costs one round-trip and no budget, so a slow-moving review
+//! queue is effectively free to watch.
+//!
+//! # What it never does
+//!
+//! It never *blanks* state. A failed fetch, an unresolvable repo, a missing
+//! token — all leave the item exactly as it was and try again later, the same
+//! policy `supervisor::resolve_pr_state` follows. The only writes are the two
+//! definite verdicts GitHub gave us.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use tauri::AppHandle;
+use tokio::sync::Notify;
+
+use super::drainer::{self, QueueNote};
+use super::types::{ItemPatch, ItemStatus, RoadmapItem};
+use super::Db;
+use crate::github::PrStatus;
+
+/// How often the sweep re-reads its watch list while anything is in review.
+///
+/// Two minutes. A merge is a human act at the end of a review, so nobody is
+/// waiting on sub-minute latency here — and the thing that *is* waiting (a
+/// dependant item) is unblocked within one drainer tick of the flip. Longer
+/// than the drainer's 15s because each pass costs network, and shorter than the
+/// span in which "I merged it, why is the board stale" becomes a real thought.
+const SWEEP: Duration = Duration::from_secs(120);
+
+// ───────────────────────────── the nudge ────────────────────────────────
+
+/// Wakes the sweep. Separate from the drainer's signal on purpose: the two
+/// tasks wake on different events (a queue mutation vs. an item entering
+/// review), and sharing one `Notify` would have each spuriously waking the
+/// other — the drainer walking every board because a PR merged, the sweep
+/// making a network round-trip because someone edited an item's title.
+fn signal() -> &'static Notify {
+    static SIGNAL: OnceLock<Notify> = OnceLock::new();
+    SIGNAL.get_or_init(Notify::new)
+}
+
+/// Ask the sweep to look now. Called by the drainer when it settles an item into
+/// `in_review`, which is the only way an item acquires a PR to watch.
+pub(crate) fn nudge() {
+    signal().notify_one();
+}
+
+// ───────────────────────────── pure decisions ───────────────────────────
+
+/// The items a sweep polls: `in_review` with a PR number to poll with.
+///
+/// An `in_review` item *without* a number is left alone rather than guessed at.
+/// It means the run finished, opened something, and the number never made it
+/// onto the row — polling would need a number invented from the URL, and a
+/// wrong number is a wrong verdict written to the board. The card still links
+/// the PR; the user merges it and marks the item done by hand.
+pub(crate) fn pollable(items: &[RoadmapItem]) -> Vec<&RoadmapItem> {
+    items
+        .iter()
+        .filter(|i| i.status == ItemStatus::InReview && i.pr_number.is_some())
+        .collect()
+}
+
+/// What one polled PR means for the item watching it.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum Verdict {
+    /// Still open, or no answer this round. Leave the item alone.
+    Waiting,
+    /// Merged. The work is in the base branch; the item shipped.
+    Landed,
+    /// Closed without merging. The work was proposed and rejected.
+    Abandoned,
+}
+
+/// Map a PR's state onto its item. `None` is "we didn't learn anything this
+/// round" — a fetch error, a rate-limit pause, a repo we couldn't resolve — and
+/// is deliberately indistinguishable from `Open` here: both mean *don't write*.
+pub(crate) fn verdict(state: Option<PrStatus>) -> Verdict {
+    match state {
+        Some(PrStatus::Merged) => Verdict::Landed,
+        Some(PrStatus::Closed) => Verdict::Abandoned,
+        Some(PrStatus::Open) | None => Verdict::Waiting,
+    }
+}
+
+/// The write a verdict implies, or `None` when the item stays as it is.
+///
+/// **Landed** sets only the status: `pr_url`/`pr_number` stay, because a shipped
+/// item's PR is the record of how it shipped.
+///
+/// **Abandoned** returns the item to `open` rather than to `done` or to some
+/// `rejected` state the board has no column for. A closed PR is a decision the
+/// user made outside this app, and the honest reflection of it is "this is back
+/// on your board" — not a silent completion, and not a new lifecycle state that
+/// every consumer would have to learn. The PR columns are kept for history (the
+/// card keeps its "PR #N" link), but `run_id` is cleared for the same reason
+/// [`drainer::Settlement::Released`] clears it: the run is over, and leaving the
+/// link would have a re-queue settle instantly against that old terminal run
+/// instead of dispatching a fresh one.
+pub(crate) fn patch_for(verdict: &Verdict) -> Option<ItemPatch> {
+    match verdict {
+        Verdict::Waiting => None,
+        Verdict::Landed => Some(ItemPatch {
+            status: Some(ItemStatus::Done),
+            ..Default::default()
+        }),
+        Verdict::Abandoned => Some(ItemPatch {
+            status: Some(ItemStatus::Open),
+            run_id: Some(None),
+            ..Default::default()
+        }),
+    }
+}
+
+/// What the board is told when a PR is closed unmerged. Nothing persists it —
+/// same transient `roadmap:queue-note` channel the drainer explains a stuck
+/// queue on, for the same reason: it is true until the user does something
+/// about it, and the row's own next change supersedes it.
+pub(crate) fn abandoned_note(number: i64) -> String {
+    format!("PR #{number} was closed without merging — back on the board.")
+}
+
+// ───────────────────────────── the task ─────────────────────────────────
+
+/// One item the sweep is watching, flattened out of the connection guard.
+struct Watched {
+    id: String,
+    code: String,
+    project_id: String,
+    number: i64,
+}
+
+/// Start the sweep. Called once from setup, beside [`drainer::spawn`].
+///
+/// Takes no `WorkflowService`: by the time an item is `in_review` its run is
+/// finished and the only remaining authority is GitHub.
+pub fn spawn(app: AppHandle, db: Db) {
+    tauri::async_runtime::spawn(async move {
+        loop {
+            let watching = watch_list(&db);
+            if watching.is_empty() {
+                // Nothing in review: sleep until the drainer says there is.
+                // Checked before waiting, not after, so a board that is already
+                // mid-review at launch is swept without needing a start nudge.
+                signal().notified().await;
+                continue;
+            }
+            sweep(&app, &db, watching).await;
+            tokio::select! {
+                _ = tokio::time::sleep(SWEEP) => {}
+                _ = signal().notified() => {}
+            }
+        }
+    });
+}
+
+/// Every item under review that has a PR to poll, across all projects. One
+/// query rather than per-project, because the sweep's unit of work is a PR and
+/// its cost is the network read, not the row.
+fn watch_list(db: &Db) -> Vec<Watched> {
+    let conn = db.lock();
+    let items = conn
+        .prepare(&format!(
+            "SELECT {} FROM roadmap_items
+              WHERE status = 'in_review' AND pr_number IS NOT NULL",
+            super::types::COLUMNS
+        ))
+        .and_then(|mut s| {
+            s.query_map([], RoadmapItem::from_row)?
+                .collect::<std::result::Result<Vec<_>, _>>()
+        })
+        .unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "roadmap merge sweep: cannot read the watch list");
+            Vec::new()
+        });
+    // The query already narrows to what `pollable` selects; running it anyway
+    // keeps one definition of "watchable" and costs a filter over a short list.
+    pollable(&items)
+        .into_iter()
+        .filter_map(|i| {
+            Some(Watched {
+                id: i.id.clone(),
+                code: i.code.clone(),
+                project_id: i.project_id.clone(),
+                number: i.pr_number?,
+            })
+        })
+        .collect()
+}
+
+/// Poll each watched PR and apply whatever GitHub says. Sequential: the list is
+/// bounded by how many items are in review at once (one per project, given
+/// [`drainer::MAX_CONCURRENT_ROADMAP_RUNS`]), and conditional requests make a
+/// repeat read of an unchanged PR nearly free.
+async fn sweep(app: &AppHandle, db: &Db, watching: Vec<Watched>) {
+    // One repo path per project per sweep — resolving it is a database read,
+    // and every item in a project shares the answer.
+    let mut repos: HashMap<String, Option<PathBuf>> = HashMap::new();
+    for w in watching {
+        let repo = repos
+            .entry(w.project_id.clone())
+            .or_insert_with(|| project_repo(db, &w.project_id))
+            .clone();
+        let Some(repo) = repo else {
+            // No repo row, or the project was deleted under us: there is no
+            // remote to ask. Say nothing and touch nothing.
+            tracing::debug!(item = %w.code, "roadmap merge sweep: no repo to resolve the PR against");
+            continue;
+        };
+        let state = poll(&repo, w.number).await;
+        let outcome = verdict(state);
+        let Some(patch) = patch_for(&outcome) else {
+            continue;
+        };
+        tracing::info!(item = %w.code, pr = w.number, ?outcome, "roadmap merge sweep");
+        drainer::write_item(app, db, &w.id, patch);
+        match outcome {
+            Verdict::Landed => {
+                // The item is `done`, which is what a dependant's dep gate is
+                // waiting for. Nudge rather than let it sit until the drainer's
+                // next tick — this is the moment the queue can move.
+                drainer::nudge();
+            }
+            Verdict::Abandoned => drainer::emit_note(
+                app,
+                &QueueNote {
+                    item_id: w.id.clone(),
+                    code: w.code.clone(),
+                    note: abandoned_note(w.number),
+                },
+            ),
+            Verdict::Waiting => {}
+        }
+    }
+}
+
+/// One PR's state, or `None` when we learned nothing. Every failure mode —
+/// no token, a non-GitHub remote, a rate-limit pause, a deleted PR — collapses
+/// to `None` here, because they all mean the same thing to the caller: leave
+/// the item alone and ask again later.
+async fn poll(repo: &std::path::Path, number: i64) -> Option<PrStatus> {
+    let number = u32::try_from(number).ok()?;
+    match crate::github::pr_state_live(repo, number).await {
+        Ok(Some(state)) => Some(state.state),
+        Ok(None) => None,
+        Err(e) => {
+            tracing::debug!(pr = number, error = %e, "roadmap merge sweep: PR read failed");
+            None
+        }
+    }
+}
+
+/// The checkout the sweep resolves `owner/repo` from: the project's primary
+/// repo, the same one the drainer launches runs in.
+///
+/// Deliberately *not* the run's own repo (`~/.fletch/runs/<id>/repo`): that
+/// directory is a scratch clone that may be cleaned up once the run finishes,
+/// and the sweep's whole job happens after that point. The project's checkout
+/// shares the origin remote and outlives every run in it.
+fn project_repo(db: &Db, project_id: &str) -> Option<PathBuf> {
+    let conn = db.lock();
+    drainer::primary_repo_path(&conn, project_id).map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests;

--- a/src-tauri/src/roadmap/merge_sweep/tests.rs
+++ b/src-tauri/src/roadmap/merge_sweep/tests.rs
@@ -1,0 +1,125 @@
+//! Merge-sweep decision tests.
+//!
+//! Same shape as the drainer's: everything the sweep *decides* is a pure
+//! function over a snapshot ([`pollable`], [`verdict`], [`patch_for`]), so the
+//! rules are tested with no network, no runtime, and no database. The task is
+//! the thin part — read the watch list, call these, write the answer back.
+
+use super::*;
+use crate::roadmap::types::{Horizon, ItemSource};
+
+/// An item under review with an open PR against it.
+fn in_review(code: &str, number: Option<i64>) -> RoadmapItem {
+    RoadmapItem {
+        id: format!("id-{code}"),
+        project_id: "p1".into(),
+        code: code.into(),
+        parent_id: None,
+        title: format!("do {code}"),
+        why: String::new(),
+        horizon: Horizon::Now,
+        status: ItemStatus::InReview,
+        size: None,
+        area: None,
+        source: ItemSource::User,
+        epic: None,
+        accept: Vec::new(),
+        deps: Vec::new(),
+        agent_id: None,
+        workflow_def_id: None,
+        run_id: Some("run-1".into()),
+        pr_url: number.map(|n| format!("https://github.com/o/r/pull/{n}")),
+        pr_number: number,
+        created_at: 10,
+        updated_at: 10,
+    }
+}
+
+// ───────────────────────────── the watch list ───────────────────────────
+
+#[test]
+fn an_empty_board_gives_the_sweep_nothing_to_do() {
+    // The idle case, and the common one: with nothing in review the task sleeps
+    // on its nudge instead of ticking, so an install whose board is all `done`
+    // makes no requests at all.
+    assert!(pollable(&[]).is_empty());
+}
+
+#[test]
+fn only_in_review_items_with_a_pr_number_are_polled() {
+    let mut queued = in_review("FLT-100", Some(1));
+    queued.status = ItemStatus::Queued;
+    let mut active = in_review("FLT-101", Some(2));
+    active.status = ItemStatus::Active;
+    let mut done = in_review("FLT-102", Some(3));
+    done.status = ItemStatus::Done;
+    let watched = in_review("FLT-103", Some(4));
+
+    let items = vec![queued, active, done, watched];
+    let picked = pollable(&items);
+
+    assert_eq!(picked.len(), 1);
+    assert_eq!(picked[0].code, "FLT-103");
+}
+
+#[test]
+fn an_item_in_review_without_a_number_is_left_to_the_user() {
+    // Nothing to poll with, and a number guessed off the URL could be wrong —
+    // a wrong number is a wrong verdict written to the board. The card still
+    // links the PR.
+    assert!(pollable(&[in_review("FLT-100", None)]).is_empty());
+}
+
+// ───────────────────────────── verdicts ─────────────────────────────────
+
+#[test]
+fn a_merged_pr_ships_its_item() {
+    assert_eq!(verdict(Some(PrStatus::Merged)), Verdict::Landed);
+    let patch = patch_for(&Verdict::Landed).expect("a merge is a write");
+    assert_eq!(patch.status, Some(ItemStatus::Done));
+    // The PR is how the item shipped — the link stays on the row.
+    assert_eq!(patch.pr_url, None);
+    assert_eq!(patch.pr_number, None);
+    // And the run stays attached: it is the record of the work.
+    assert_eq!(patch.run_id, None);
+}
+
+#[test]
+fn a_pr_closed_without_merging_puts_its_item_back_on_the_board() {
+    assert_eq!(verdict(Some(PrStatus::Closed)), Verdict::Abandoned);
+    let patch = patch_for(&Verdict::Abandoned).expect("a close is a write");
+    assert_eq!(patch.status, Some(ItemStatus::Open));
+    // Not `done` (nothing shipped) and not `queued` (re-running work someone
+    // just rejected is the last thing they asked for). Back to the user.
+    //
+    // The run link is dropped so a re-queue dispatches a fresh run instead of
+    // settling instantly against the old terminal one…
+    assert_eq!(patch.run_id, Some(None));
+    // …while the PR columns are left alone, so the card keeps its history.
+    assert_eq!(patch.pr_url, None);
+    assert_eq!(patch.pr_number, None);
+}
+
+#[test]
+fn an_open_pr_changes_nothing() {
+    assert_eq!(verdict(Some(PrStatus::Open)), Verdict::Waiting);
+    assert!(patch_for(&Verdict::Waiting).is_none());
+}
+
+#[test]
+fn a_failed_read_changes_nothing_either() {
+    // Never blank state on a fetch failure: no token, a rate-limit pause, or an
+    // unresolvable remote all mean "we learned nothing", not "the PR is gone".
+    // Same policy `supervisor::resolve_pr_state` follows.
+    assert_eq!(verdict(None), Verdict::Waiting);
+    assert!(patch_for(&verdict(None)).is_none());
+}
+
+// ───────────────────────────── the note ─────────────────────────────────
+
+#[test]
+fn the_closed_note_names_the_pr() {
+    let note = abandoned_note(142);
+    assert!(note.contains("#142"));
+    assert!(note.contains("without merging"));
+}

--- a/src-tauri/src/roadmap/mod.rs
+++ b/src-tauri/src/roadmap/mod.rs
@@ -17,8 +17,9 @@
 //!   agent's RPC, the queue drainer) updates the board without a refetch.
 //! - `roadmap:item-deleted` — the deleted row's id, so the board drops it
 //!   instead of upserting it.
-//! - `roadmap:queue-note` — transient, from [`drainer`]: why a queued item isn't
-//!   moving. Nothing persists it; see that module's docs for why.
+//! - `roadmap:queue-note` — transient: why an item isn't moving on its own.
+//!   From [`drainer`] (a queued item's blocker) and [`merge_sweep`] (a PR that
+//!   closed without merging). Nothing persists it; see the drainer's docs.
 //!
 //! Autonomous dispatch lives in [`drainer`]: `queued` items become running
 //! workflows there, and every mutation on this surface [`drainer::nudge`]s it so
@@ -145,10 +146,17 @@ pub async fn roadmap_update_item(
     };
     let outcome = outcome.ok_or_else(|| format!("roadmap item {id} no longer exists"))?;
     // A miss changed nothing, so there is nothing to announce and nothing new
-    // for the drainer to look at.
+    // for either background task to look at.
     if outcome.applied {
         emit_item(&app, &outcome.item);
         drainer::nudge();
+        // The sweep parks while nothing is in review, and the drainer's
+        // settlement is otherwise its only alarm clock — a patch that leaves a
+        // row in review through this surface must ring it too. Gated on the
+        // status so a title edit doesn't cut a sleeping sweep's interval short.
+        if outcome.item.status == types::ItemStatus::InReview {
+            merge_sweep::nudge();
+        }
     }
     Ok(outcome)
 }

--- a/src-tauri/src/roadmap/mod.rs
+++ b/src-tauri/src/roadmap/mod.rs
@@ -23,8 +23,14 @@
 //! Autonomous dispatch lives in [`drainer`]: `queued` items become running
 //! workflows there, and every mutation on this surface [`drainer::nudge`]s it so
 //! a queue action doesn't wait out the tick interval.
+//!
+//! [`merge_sweep`] closes the loop at the other end: it watches the PRs of
+//! `in_review` items and moves them to `done` when they merge on GitHub. It is
+//! host-side rather than in the webview precisely so a queue keeps draining
+//! with the window shut.
 
 pub mod drainer;
+pub mod merge_sweep;
 pub mod store;
 pub mod types;
 

--- a/src-tauri/src/workflow/gitops.rs
+++ b/src-tauri/src/workflow/gitops.rs
@@ -199,6 +199,10 @@ pub struct FinalizeOutcome {
     pub pushed: bool,
     pub branch: String,
     pub pr_url: Option<String>,
+    /// The PR's number, from the same `PrState` the URL came off. Carried
+    /// beside the URL (rather than re-parsed from it downstream) so the run row
+    /// can record the PR's identity as GitHub reported it — see migration 0029.
+    pub pr_number: Option<i64>,
     pub pr_error: Option<String>,
 }
 
@@ -228,18 +232,19 @@ pub async fn finalize(
     .await?;
     git::push_head_to_branch(run_repo, branch).await?;
 
-    let (pr_url, pr_error) = if open_pr {
+    let (pr_url, pr_number, pr_error) = if open_pr {
         match crate::github::pr_create_head(run_repo, branch, title, body, base).await {
-            Ok(pr) => (Some(pr.url), None),
-            Err(e) => (None, Some(e.to_string())),
+            Ok(pr) => (Some(pr.url), Some(i64::from(pr.number)), None),
+            Err(e) => (None, None, Some(e.to_string())),
         }
     } else {
-        (None, None)
+        (None, None, None)
     };
     Ok(FinalizeOutcome {
         pushed: true,
         branch: branch.to_string(),
         pr_url,
+        pr_number,
         pr_error,
     })
 }

--- a/src-tauri/src/workflow/scheduler/drive.rs
+++ b/src-tauri/src/workflow/scheduler/drive.rs
@@ -550,6 +550,11 @@ async fn finalize_run(
             None,
             &json!({ "url": url }),
         );
+        // …and onto the row itself (0029). The journal event is the run's
+        // history; the columns are the queryable fact. The roadmap merge sweep
+        // needs the latter — "every `in_review` item's PR number" has to be one
+        // read, not a journal scan per run per tick.
+        set_pr(&conn, ctx.app.as_ref(), run_id, outcome.pr_number, &url);
     } else if let Some(err) = outcome.pr_error {
         journal_event(
             &conn,

--- a/src-tauri/src/workflow/scheduler/persistence.rs
+++ b/src-tauri/src/workflow/scheduler/persistence.rs
@@ -73,6 +73,39 @@ pub(crate) fn set_status(
     }
 }
 
+/// Record the PR a finalize opened on the run row and emit `wf:run` (0029).
+///
+/// Called only when a PR actually exists — a `push`-only finalize or a failed
+/// `pr create` leaves both columns NULL, which every reader treats as "no PR to
+/// poll". Written before the run flips `done` so nothing can observe a finished
+/// roadmap-dispatched run without its PR: the drainer settles such a run into
+/// `in_review` off exactly these columns, and the merge sweep polls from there.
+///
+/// `updated_at` is deliberately *not* bumped: this records something that was
+/// already true the moment GitHub answered, and the run's own status write
+/// (immediately after) carries the timestamp the sidebar orders on.
+pub(crate) fn set_pr(
+    conn: &Connection,
+    app: Option<&AppHandle>,
+    run_id: &str,
+    number: Option<i64>,
+    url: &str,
+) {
+    let _ = conn.execute(
+        "UPDATE wf_run SET pr_number = ?1, pr_url = ?2 WHERE id = ?3",
+        rusqlite::params![number, url, run_id],
+    );
+    if let Some(app) = app {
+        if let Ok(run) = conn.query_row(
+            "SELECT * FROM wf_run WHERE id = ?1",
+            [run_id],
+            crate::workflow::types::Run::from_row,
+        ) {
+            journal::emit_run(app, &run);
+        }
+    }
+}
+
 /// Mark a run `failed`: journal `run_failed {error}` first, then update the row.
 /// A failure is an append-only timeline event (§6.1, §7.1) — the observability
 /// goal (§1.2) requires every terminal outcome to be a journal event, not only a

--- a/src-tauri/src/workflow/types.rs
+++ b/src-tauri/src/workflow/types.rs
@@ -213,6 +213,13 @@ pub struct Run {
     pub budgets: Value,
     pub spent: Value,
     pub error: Option<String>,
+    /// The PR this run's finalize opened (0029). Both `None` until a finalize
+    /// actually proposes one — a `push`-only spec, a `pr create` that failed,
+    /// or a run that never reached finalize all leave them unset. Persisted so
+    /// "did this run's PR merge?" is a column read rather than a journal scan;
+    /// the roadmap merge sweep is the caller that needs it.
+    pub pr_number: Option<i64>,
+    pub pr_url: Option<String>,
     pub created_at: i64,
     pub updated_at: i64,
 }
@@ -237,6 +244,8 @@ impl Run {
             budgets: json_col(r, "budgets_json")?,
             spent: json_col(r, "spent_json")?,
             error: r.get("error")?,
+            pr_number: r.get("pr_number")?,
+            pr_url: r.get("pr_url")?,
             created_at: r.get("created_at")?,
             updated_at: r.get("updated_at")?,
         })

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -54,11 +54,12 @@ export function onRoadmapItemDeleted(cb: (id: string) => void): Promise<Unlisten
   return listen<string>("roadmap:item-deleted", (event) => cb(event.payload));
 }
 
-/** `roadmap:queue-note` explains why a queued item isn't moving — no workflow
- *  to run it under, a dependency that hasn't landed, a launch that failed. The
- *  board shows it inline on the row; nothing persists it, so a listener that
- *  wasn't mounted simply didn't hear it (the drainer repeats itself when the
- *  reason changes). */
+/** `roadmap:queue-note` explains why an item isn't moving — no workflow to run
+ *  it under, a dependency that hasn't landed, a launch that failed, or a PR
+ *  that was closed without merging (the merge sweep sends that one alongside
+ *  the row's flip back to `open`). The board shows it inline on the row;
+ *  nothing persists it, so a listener that wasn't mounted simply didn't hear it
+ *  (the drainer repeats itself when the reason changes). */
 export function onRoadmapQueueNote(cb: (note: RoadmapQueueNote) => void): Promise<UnlistenFn> {
   return listen<RoadmapQueueNote>("roadmap:queue-note", (event) => cb(event.payload));
 }

--- a/src/api/types/workflow.ts
+++ b/src/api/types/workflow.ts
@@ -45,6 +45,12 @@ export interface WfRun {
   budgets: unknown;
   spent: unknown;
   error: string | null;
+  /** The PR this run's finalize opened, when it opened one. Null for a
+   *  `push`-only spec, a `pr create` that failed, and every run that never
+   *  reached finalize. Recorded on the row (migration 0029) so the host-side
+   *  roadmap merge sweep can poll it with the window closed. */
+  pr_number: number | null;
+  pr_url: string | null;
   created_at: number;
   updated_at: number;
 }

--- a/src/components/ProjectScreen/Roadmap/Board/ItemCard.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/ItemCard.tsx
@@ -24,7 +24,10 @@ const STATE: Partial<Record<ItemStatus, { label: string; cls: string; tip: strin
   in_review: {
     label: "In review",
     cls: "r",
-    tip: "Its run opened a pull request; it ships when that merges",
+    // The watch is host-side (src-tauri/src/roadmap/merge_sweep.rs), so this is
+    // a promise the app keeps with the window closed — worth saying, because it
+    // is the difference between "check back here" and "go merge it".
+    tip: "Its run opened a pull request — merge it and this ships on its own",
   },
 };
 
@@ -50,7 +53,9 @@ interface Props {
   /** The workflow this item would run under ("Project default" resolved), or
    *  null when nothing would run it — the queue would stall on it. */
   workflowName?: string | null;
-  /** Why this queued item isn't moving, straight from the drainer. */
+  /** Why this item isn't moving, straight from the queue: the drainer's reason
+   *  a queued row is stuck, or the merge sweep's "PR #N was closed without
+   *  merging" for one that came back off review. */
   note?: string;
   /** Ring the row: it was just jumped to, or a pending proposal moves it. */
   focused?: boolean;

--- a/src/components/ProjectScreen/Roadmap/Board/ItemCard.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/ItemCard.tsx
@@ -26,7 +26,9 @@ const STATE: Partial<Record<ItemStatus, { label: string; cls: string; tip: strin
     cls: "r",
     // The watch is host-side (src-tauri/src/roadmap/merge_sweep.rs), so this is
     // a promise the app keeps with the window closed — worth saying, because it
-    // is the difference between "check back here" and "go merge it".
+    // is the difference between "check back here" and "go merge it". "Mark
+    // done" on the card is the manual fallback for when the watch can't see
+    // the merge (revoked token, deleted PR).
     tip: "Its run opened a pull request — merge it and this ships on its own",
   },
 };
@@ -48,6 +50,10 @@ interface Props {
   onQueue?: () => void;
   /** Take it back off the queue before it's dispatched (`queued → open`). */
   onUnqueue?: () => void;
+  /** Ship it by hand (`in_review → done`) when the sweep can't see the merge —
+   *  a revoked token, a deleted PR, a repo that left the project. In-review
+   *  items only, and not read-only. */
+  onMarkDone?: () => void;
   /** Open the run this item is being built by. Only on an item with a run. */
   onOpenRun?: () => void;
   /** The workflow this item would run under ("Project default" resolved), or
@@ -92,6 +98,7 @@ export function ItemCard({
   onDiscard,
   onQueue,
   onUnqueue,
+  onMarkDone,
   onOpenRun,
   workflowName,
   note,
@@ -265,6 +272,11 @@ export function ItemCard({
             {onUnqueue && (
               <Button variant="outline" size="sm" onClick={onUnqueue}>
                 Take off the queue
+              </Button>
+            )}
+            {onMarkDone && (
+              <Button variant="outline" size="sm" onClick={onMarkDone}>
+                <Icon name="check" size={11} /> Mark done
               </Button>
             )}
             {onQueue && (

--- a/src/components/ProjectScreen/Roadmap/Board/index.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/index.tsx
@@ -41,6 +41,7 @@ export function Board({ roadmap, repoPath }: { roadmap: RoadmapState; repoPath: 
     acceptItems,
     queueItems,
     unqueueItems,
+    markDone,
     workflows,
   } = roadmap;
   const selectRun = useAppStore((s) => s.selectRun);
@@ -175,9 +176,10 @@ export function Board({ roadmap, repoPath }: { roadmap: RoadmapState; repoPath: 
                   // A proposed row is on the board but not *of* it yet: it is
                   // ruled on rather than edited or sent to an agent.
                   const ghost = it.status === "proposed";
-                  // The queue owns everything from `queued` on: an `active` or
-                  // `in_review` row is the drainer's, and the user's lever on it
-                  // is the run, not the row.
+                  // The queue owns everything from `queued` on: an `active`
+                  // row is the drainer's, and the user's lever on it is the
+                  // run, not the row. `in_review` keeps one manual lever —
+                  // "Mark done" — for merges the sweep can't see.
                   const writable = !ghost && !readOnly;
                   return (
                     <ItemCard
@@ -209,6 +211,9 @@ export function Board({ roadmap, repoPath }: { roadmap: RoadmapState; repoPath: 
                         writable && it.status === "queued"
                           ? () => unqueueItems([row.id])
                           : undefined
+                      }
+                      onMarkDone={
+                        writable && it.status === "in_review" ? () => markDone(row.id) : undefined
                       }
                       onOpenRun={
                         row.run_id

--- a/src/components/ProjectScreen/Roadmap/useRoadmap.ts
+++ b/src/components/ProjectScreen/Roadmap/useRoadmap.ts
@@ -22,7 +22,8 @@
 // user handing an item to the Rust drainer (src-tauri/src/roadmap/drainer.rs),
 // which owns everything after it — `queued → active` when it launches a run,
 // and `active → in_review`/`done`/back to `open` when that run settles. This
-// hook never writes those; it only ever asks for `queued` or takes it back.
+// hook never writes those; it only ever asks for `queued`, takes it back, or
+// ships an `in_review` item by hand when the merge sweep can't see the merge.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -79,9 +80,11 @@ export function useRoadmap(repoPath: string) {
   const [focusCode, setFocusCode] = useState<string | null>(null);
   /** Codes highlighted because they just landed or just moved. */
   const [landed, setLanded] = useState<ReadonlySet<string>>(() => new Set());
-  /** Why a queued item isn't moving, by item id — the drainer's transient
-   *  `roadmap:queue-note`. Not persisted anywhere, on purpose: it's only true
-   *  until the next tick, and the row's own next change supersedes it. */
+  /** Why an item isn't moving on its own, by item id — the transient
+   *  `roadmap:queue-note`. The drainer sends them for stuck *queued* rows; the
+   *  merge sweep sends one for an *open* row whose PR closed without merging.
+   *  Not persisted anywhere, on purpose: it's only true until the next tick,
+   *  and the row's own next change supersedes it. */
   const [notes, setNotes] = useState<ReadonlyMap<string, string>>(() => new Map());
 
   // Every pending highlight timer, so unmounting can't set state on a dead
@@ -114,9 +117,11 @@ export function useRoadmap(repoPath: string) {
   const upsert = useCallback(
     (row: RoadmapItem) => {
       setRows((prev) => applyBoardEvent(prev, { kind: "upsert", row }));
-      // A note explains why a *queued* row is stuck. The moment the row moves
-      // on, whatever it said is history — drop it rather than leave a stale
-      // excuse under a running item.
+      // A note explains why a row isn't moving on its own. The moment the row
+      // moves, whatever it said is history — drop it rather than leave a stale
+      // excuse under a running item. Queued rows keep theirs: the drainer's
+      // blocked-note must survive the row events around it. (A sweep note on an
+      // open row survives arrival because it's emitted after the row event.)
       if (row.status !== "queued") dropNote(row.id);
     },
     [dropNote],
@@ -291,9 +296,11 @@ export function useRoadmap(repoPath: string) {
       guarded(async () => {
         const codes: string[] = [];
         for (const id of ids) {
-          const { item } = await api.roadmapUpdateItem(id, { status: "open" });
+          // Conditional like every other status transition: accepting is only
+          // meaningful on a row that is still a proposal.
+          const { applied, item } = await api.roadmapUpdateItem(id, { status: "open" }, "proposed");
           upsert(item);
-          codes.push(item.code);
+          if (applied) codes.push(item.code);
         }
         markLanded(codes);
       }),
@@ -344,6 +351,20 @@ export function useRoadmap(repoPath: string) {
           const { item } = await api.roadmapUpdateItem(id, { status: "open" }, "queued");
           upsert(item);
         }
+      }),
+    [guarded, upsert],
+  );
+
+  /** Ship an in-review item by hand: `in_review → done`. The sweep normally
+   *  does this when the PR merges, but it can't always know — a revoked GitHub
+   *  token, a deleted PR, a repo that left the project all read as "still
+   *  open" forever. This is the escape hatch; conditional so a verdict the
+   *  sweep landed a moment earlier wins. */
+  const markDone = useCallback(
+    (id: string) =>
+      guarded(async () => {
+        const { item } = await api.roadmapUpdateItem(id, { status: "done" }, "in_review");
+        upsert(item);
       }),
     [guarded, upsert],
   );
@@ -401,6 +422,7 @@ export function useRoadmap(repoPath: string) {
     acceptItems,
     queueItems,
     unqueueItems,
+    markDone,
     /** Definitions + the project default, for the queue affordance and the
      *  item form. */
     workflows,

--- a/src/components/Workspace/MissionControl/queue.test.ts
+++ b/src/components/Workspace/MissionControl/queue.test.ts
@@ -89,6 +89,8 @@ function run(over: Partial<WfRun> & { id: string }): WfRun {
     budgets: {},
     spent: {},
     error: null,
+    pr_number: null,
+    pr_url: null,
     created_at: 1,
     updated_at: 1000,
     ...over,


### PR DESCRIPTION
PR 5 of 5 (roadmap stack, on #584). Closes the loop: an `in_review` roadmap item flips to `done` when its PR merges — host-side, so it works with the app window closed (all existing PR polling lives in the webview and stops on `document.hidden`).

## What
- `wf_run.pr_number`/`pr_url` (migration 0029), persisted in `finalize_run` off the same `PrState` the journal event already had in hand (previously discarded), re-emitted on `wf:run`. The drainer's journal-scan seam becomes a column read; `pr_number_from_url` deleted as its doc comment promised.
- `merge_sweep` background task: watches `in_review` items' PRs via a new state-only conditional-REST read reusing `github::live`'s ETag cache (a quiet PR costs a 304, not rate-limit budget). 120s cadence while non-empty; parks on its own `Notify` when idle; the watch list is computed before the wait, so app start sweeps immediately — a PR merged while the app was closed ships on next launch.
- Merged → `done`: item leaves the board, shipped ticks, and the drainer is nudged so dependants queued behind it dispatch on the spot (dep gating counts only `done`, not `in_review`). Closed unmerged → back to `open` with `run_id` cleared (a re-queue must dispatch a fresh run, not settle against the old terminal one) plus a transient note.
- Every fetch failure maps to "don't write" — state is never blanked.
- Pure decision functions (`verdict`/`patch_for`) unit-tested with no network/DB/runtime.

## The loop, end to end
PM proposes (ghost) → user accepts (`open`) → queue (`queued`) → drainer dispatches a workflow when deps are `done` (`active`) → run finalizes with a PR (`in_review`, PR stamped) → merge sweep sees the merge → `done`, dependants unblock.

## Verification
cargo fmt/clippy (zero warnings)/test (1187) · tsc · biome · vitest (761).

Known follow-ups (documented in code): concurrency cap fixed at 1 run/project; flat 120s sweep cadence (no age backoff); PRs opened outside a roadmap dispatch aren't modelled; the closed-PR note is transient.