### PR TITLE
feat(roadmap): thin the page header, align the chrome, make the split resizable

### DIFF
--- a/src/components/Composer/ModelPicker.css
+++ b/src/components/Composer/ModelPicker.css
@@ -2,9 +2,19 @@
  *  side panel (below it) so the panel slides out from underneath the dropdown. */
 .model-dd-wrap {
   position: absolute;
+  left: 0;
   z-index: var(--z-dropdown);
   /* The side panel is absolute, so it must not be clipped by the wrapper. */
   overflow: visible;
+}
+/* Which edge the menu grows from. `up` is the composer, which sits on the
+ * bottom edge of the window; `down` is for a picker mounted near the top of a
+ * panel, where opening upward puts the card off the top of the screen. */
+.model-dd-wrap.drop-up {
+  bottom: calc(100% + 6px);
+}
+.model-dd-wrap.drop-down {
+  top: calc(100% + 6px);
 }
 .model-dd-main {
   position: relative;
@@ -27,6 +37,24 @@
   from {
     opacity: 0;
     transform: translateY(7px) scale(0.975);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+/* Mirror of the growth animation for a downward menu — one that drops down but
+ * scales up out of its bottom edge reads backwards. Must sit after the base
+ * `.model-dd-main` rule: that rule sets `animation` as a shorthand, which
+ * rewrites `animation-name`. */
+.model-dd-wrap.drop-down .model-dd-main {
+  transform-origin: top left;
+  animation-name: modelDdInDown;
+}
+@keyframes modelDdInDown {
+  from {
+    opacity: 0;
+    transform: translateY(-7px) scale(0.975);
   }
   to {
     opacity: 1;

--- a/src/components/Composer/ModelPicker.tsx
+++ b/src/components/Composer/ModelPicker.tsx
@@ -21,6 +21,34 @@ interface Props {
    *  at spawn, so the dropdown drops the agent/custom-agent sections and shows
    *  only this provider's models. */
   modelOnly?: boolean;
+  /** Which way the menu opens. The composer lives on the bottom edge of the
+   *  window, so `up` is the default; a picker mounted near the top of a panel
+   *  must open `down` or it runs off the top of the screen and is clipped. */
+  drop?: "up" | "down";
+  /** Restrict the custom-agent section to these ids. Omitted means every custom
+   *  agent whose base provider is enabled — the composer, where the whole
+   *  library is fair game. An empty array hides the section outright.
+   *
+   *  This exists for surfaces that are about one job rather than about spawning
+   *  anything: the Roadmap's chat picker offers the Project Manager and the bare
+   *  coding agents, because a tester or an architect in that list is an offer to
+   *  do something the surface can't do. */
+  customAgentIds?: string[];
+  /** How the two groups are titled and ordered. The defaults describe the
+   *  composer: built-in coding agents lead, the user's own library follows.
+   *
+   *  A surface where one custom agent *is* the intended choice wants the
+   *  reverse — leading with a section called "Custom agents" that holds the
+   *  recommended default reads as an optional extra, and the bare providers
+   *  become the fallback they actually are. */
+  sections?: {
+    /** Heading over the built-in providers. Default "Coding agents". */
+    providers?: string;
+    /** Heading over the custom agents. Default "Custom agents". */
+    custom?: string;
+    /** Draw the custom group above the providers. */
+    customFirst?: boolean;
+  };
 }
 
 function formatContext(tokens: number): string {
@@ -41,7 +69,11 @@ export function ModelPicker({
   onChange,
   locked = false,
   modelOnly = false,
+  drop = "up",
+  customAgentIds,
+  sections,
 }: Props) {
+  const customFirst = sections?.customFirst ?? false;
   const [open, setOpen] = useState(false);
   // Coding agent whose model flyout is currently expanded (null = none).
   const [hovered, setHovered] = useState<string | null>(null);
@@ -68,9 +100,16 @@ export function ModelPicker({
   }, [model, modelsByAgent, provider]);
 
   // The active custom agent (chip identity + dropdown highlight). Only custom
-  // agents whose base provider is enabled are offered.
+  // agents whose base provider is enabled are offered, narrowed further to the
+  // caller's allow-list when it gave one.
+  //
+  // `activeCustom` is looked up against the full library on purpose: it drives
+  // the chip, and a selection made elsewhere must still render with its own
+  // name rather than silently reading as a bare provider.
   const activeCustom = customAgents.find((a) => a.id === customAgentId);
-  const selectableCustom = customAgents.filter((a) => providerFlags[a.base] !== false);
+  const selectableCustom = customAgents.filter(
+    (a) => providerFlags[a.base] !== false && (!customAgentIds || customAgentIds.includes(a.id)),
+  );
   // The coding agent whose model panel is currently shown (null = none).
   const hoveredAgent = hovered ? (PROVIDERS.find((p) => p.id === hovered) ?? null) : null;
 
@@ -162,6 +201,73 @@ export function ModelPicker({
     );
   }
 
+  /* Extracted so the two groups can be drawn in either order — see
+     `sections.customFirst`. */
+  const customSection = (
+    <>
+      {/* On a restricted picker the heading is only worth drawing if the section
+          has something under it: the "set up a custom agent" CTA is an
+          invitation to build an agent the surface wouldn't offer anyway, and an
+          empty allow-list means the one agent it wants is still seeding. */}
+      {(!customAgentIds || selectableCustom.length > 0) && (
+        <div className="model-sect flex-center text-xs">
+          <span>{sections?.custom ?? "Custom agents"}</span>
+          <span className="model-sect-line" />
+        </div>
+      )}
+      {selectableCustom.length > 0 ? (
+        selectableCustom.map((a) => {
+          const active = a.id === customAgentId;
+          // A custom agent inherits its base provider's docker support.
+          const dockerBlocked = dockerOnly && !isDockerSupported(a.base);
+          return (
+            <button
+              key={a.id}
+              type="button"
+              // Same reasoning as the provider rows: aria-disabled (not the
+              // native attr) keeps the row hover-capable so the CSS
+              // .tip/data-tip refusal is reachable in the WebView.
+              aria-disabled={dockerBlocked}
+              data-tip={
+                dockerBlocked
+                  ? `${providerLabel(a.base)} isn't available in Docker sandboxes yet`
+                  : undefined
+              }
+              className={`model-custom-row flex-center ${dockerBlocked ? "is-disabled tip" : ""} ${active ? "active" : ""}`}
+              onMouseEnter={() => setHovered(null)}
+              onClick={() => !dockerBlocked && pickCustom(a.id, a.base, a.model)}
+            >
+              <Mono name={a.name} hue={a.color} size={26} />
+              <span className="model-custom-text">
+                <span>{a.name}</span>
+                <span>{a.description || providerLabel(a.base)}</span>
+              </span>
+              {active && <Icon name="check" size={12} />}
+            </button>
+          );
+        })
+      ) : customAgentIds ? null : (
+        <button
+          type="button"
+          className="model-custom-cta flex-center"
+          onMouseEnter={() => setHovered(null)}
+          onClick={() => {
+            setOpen(false);
+            openSettingsScreen("agents", "new-custom-agent");
+          }}
+        >
+          <span className="model-custom-cta-icon">
+            <Icon name="plus" size={14} />
+          </span>
+          <span className="model-custom-text">
+            <span>Set up a custom agent</span>
+            <span>Pair an agent with a model and a standing brief</span>
+          </span>
+        </button>
+      )}
+    </>
+  );
+
   return (
     <div className="model-picker">
       <Chip
@@ -197,14 +303,11 @@ export function ModelPicker({
           {/* Transparent wrapper: the main card sits above (z-index 2) the
            *  model side panel (z-index 1) so the panel slides out from
            *  underneath the dropdown rather than floating beside it. */}
-          <div
-            className="model-dd-wrap"
-            style={{ bottom: "calc(100% + 6px)", left: 0 }}
-            onMouseLeave={() => setHovered(null)}
-          >
+          <div className={`model-dd-wrap drop-${drop}`} onMouseLeave={() => setHovered(null)}>
             <div className="model-dd-main">
+              {customFirst && customSection}
               <div className="model-sect flex-center text-xs">
-                <span>Coding agents</span>
+                <span>{sections?.providers ?? "Coding agents"}</span>
                 <span className="model-sect-line" />
               </div>
               {enabled.map((p) => {
@@ -261,60 +364,7 @@ export function ModelPicker({
                 );
               })}
 
-              <div className="model-sect flex-center text-xs">
-                <span>Custom agents</span>
-                <span className="model-sect-line" />
-              </div>
-              {selectableCustom.length > 0 ? (
-                selectableCustom.map((a) => {
-                  const active = a.id === customAgentId;
-                  // A custom agent inherits its base provider's docker support.
-                  const dockerBlocked = dockerOnly && !isDockerSupported(a.base);
-                  return (
-                    <button
-                      key={a.id}
-                      type="button"
-                      // Same reasoning as the provider rows above: aria-disabled
-                      // (not the native attr) keeps the row hover-capable so the
-                      // CSS .tip/data-tip refusal is reachable in the WebView.
-                      aria-disabled={dockerBlocked}
-                      data-tip={
-                        dockerBlocked
-                          ? `${providerLabel(a.base)} isn't available in Docker sandboxes yet`
-                          : undefined
-                      }
-                      className={`model-custom-row flex-center ${dockerBlocked ? "is-disabled tip" : ""} ${active ? "active" : ""}`}
-                      onMouseEnter={() => setHovered(null)}
-                      onClick={() => !dockerBlocked && pickCustom(a.id, a.base, a.model)}
-                    >
-                      <Mono name={a.name} hue={a.color} size={26} />
-                      <span className="model-custom-text">
-                        <span>{a.name}</span>
-                        <span>{a.description || providerLabel(a.base)}</span>
-                      </span>
-                      {active && <Icon name="check" size={12} />}
-                    </button>
-                  );
-                })
-              ) : (
-                <button
-                  type="button"
-                  className="model-custom-cta flex-center"
-                  onMouseEnter={() => setHovered(null)}
-                  onClick={() => {
-                    setOpen(false);
-                    openSettingsScreen("agents", "new-custom-agent");
-                  }}
-                >
-                  <span className="model-custom-cta-icon">
-                    <Icon name="plus" size={14} />
-                  </span>
-                  <span className="model-custom-text">
-                    <span>Set up a custom agent</span>
-                    <span>Pair an agent with a model and a standing brief</span>
-                  </span>
-                </button>
-              )}
+              {!customFirst && customSection}
             </div>
 
             {hoveredAgent && (
@@ -345,7 +395,7 @@ export function ModelPicker({
       {open && modelOnly && (
         <>
           <Scrim onClose={() => setOpen(false)} />
-          <div className="model-dd-wrap" style={{ bottom: "calc(100% + 6px)", left: 0 }}>
+          <div className={`model-dd-wrap drop-${drop}`}>
             <div className="model-dd-main">
               <div className="model-sect flex-center text-xs">
                 <span>Model</span>

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -1,4 +1,5 @@
 import {
+  Activity,
   Archive,
   ArchiveRestore,
   ArrowDown,
@@ -160,6 +161,7 @@ const ICON_COMPONENTS = {
   hand: Hand,
   grip: GripVertical,
   feedback: MessageSquare,
+  activity: Activity,
 } satisfies Record<string, ComponentType<IconComponentProps>>;
 
 // Originally rendered with fill="currentColor". Setting fill on the root SVG

--- a/src/components/ProjectScreen/ProjectHeader.tsx
+++ b/src/components/ProjectScreen/ProjectHeader.tsx
@@ -8,19 +8,18 @@ const TABS: { id: ProjectScreenTab; label: string; icon: IconName }[] = [
   { id: "settings", label: "Settings", icon: "settings" },
 ];
 
-/** The project page header: the back button, the project's identity, the board
- *  counts right-aligned, and the tab row sitting on the bottom rule. */
+/** The project page header: one thin chrome bar — back on the left, the tab
+ *  segment centered, the board counts on the right.
+ *
+ *  No project name or path here: the title bar already names the project the
+ *  page belongs to, and repeating it cost a whole second row of height above
+ *  two panels that each have a header of their own. */
 export function ProjectHeader({
-  name,
-  subtitle,
   roadmap,
   tab,
   onTab,
   onClose,
 }: {
-  name: string;
-  /** Repo path, or the repo count for a multi-repo project. */
-  subtitle: string;
   roadmap: RoadmapState;
   tab: ProjectScreenTab;
   onTab: (tab: ProjectScreenTab) => void;
@@ -30,35 +29,10 @@ export function ProjectHeader({
 
   return (
     <div className="ps-head">
-      <div className="ps-head-row">
-        <button type="button" className="ps-back flex-center text-base" onClick={onClose}>
-          <Icon name="chevL" size={13} />
-          <span>Back to app</span>
-        </button>
-        <div className="ps-id">
-          <div className="ps-title text-lg truncate">{name}</div>
-          <div className="ps-path mono text-xs truncate">{subtitle}</div>
-        </div>
-        <div className="stat-row ps-stats text-sm">
-          <Stat label="in flight">
-            <CountUp value={counts.now} />
-          </Stat>
-          <span className="stat-sep" />
-          <Stat label="next">
-            <CountUp value={counts.next} />
-          </Stat>
-          <span className="stat-sep" />
-          <Stat label="later">
-            <CountUp value={counts.later} />
-          </Stat>
-          <span className="stat-sep" />
-          <Stat label="shipped">
-            <span className="ps-stat-shipped">
-              <CountUp value={shipped} />
-            </span>
-          </Stat>
-        </div>
-      </div>
+      <button type="button" className="ps-back flex-center text-sm" onClick={onClose}>
+        <Icon name="chevL" size={13} />
+        <span>Back to app</span>
+      </button>
 
       <nav className="ps-tabs">
         {TABS.map((t) => (
@@ -73,6 +47,31 @@ export function ProjectHeader({
           </button>
         ))}
       </nav>
+
+      <div className="stat-row ps-stats text-sm">
+        <Stat label="in flight">
+          <CountUp value={counts.now} />
+        </Stat>
+        {/* Dropped first on a narrow window — see `.ps-stats-mid`. The wrapper
+            is `display: contents`, so at full width the strip lays out exactly
+            as if these were direct children. */}
+        <span className="ps-stats-mid">
+          <span className="stat-sep" />
+          <Stat label="next">
+            <CountUp value={counts.next} />
+          </Stat>
+          <span className="stat-sep" />
+          <Stat label="later">
+            <CountUp value={counts.later} />
+          </Stat>
+        </span>
+        <span className="stat-sep" />
+        <Stat label="shipped">
+          <span className="ps-stat-shipped">
+            <CountUp value={shipped} />
+          </span>
+        </Stat>
+      </div>
     </div>
   );
 }

--- a/src/components/ProjectScreen/ProjectHeader.tsx
+++ b/src/components/ProjectScreen/ProjectHeader.tsx
@@ -5,6 +5,7 @@ import type { RoadmapState } from "./Roadmap";
 
 const TABS: { id: ProjectScreenTab; label: string; icon: IconName }[] = [
   { id: "roadmap", label: "Roadmap", icon: "map" },
+  { id: "activity", label: "Activity", icon: "activity" },
   { id: "settings", label: "Settings", icon: "settings" },
 ];
 

--- a/src/components/ProjectScreen/ProjectPulse.tsx
+++ b/src/components/ProjectScreen/ProjectPulse.tsx
@@ -14,8 +14,13 @@ const WEEKS = 52;
 // One extra week of margin past the grid so the oldest column is never short.
 const HORIZON_MS = (WEEKS + 1) * 7 * 86_400_000;
 
-/** The "Project Pulse" block atop Project Settings: a year of daily activity
- *  on the accent heat ramp, a streak counter, and lifetime hero numbers.
+/** The Activity tab's body: a year of daily activity on the accent heat ramp,
+ *  a streak counter, and lifetime hero numbers.
+ *
+ *  It carries its own heading. On Settings it had none — it was the first
+ *  block on a page whose tab already named it — but a tab holding one section
+ *  needs to say what the section is, and the grid alone doesn't.
+ *
  *  Turn/agent/PR series load in one round of fast indexed queries; the token
  *  total folds every session's records, so it streams in behind a shimmer. */
 export function ProjectPulse({ projectId }: { projectId: string }) {
@@ -65,6 +70,14 @@ export function ProjectPulse({ projectId }: { projectId: string }) {
 
   return (
     <section className="ps-section">
+      <header className="ps-section-h">
+        <h2 className="ps-section-t text-lg">Project pulse</h2>
+        <p className="ps-section-lead text-sm">
+          Every day an agent took a turn on this project, over the past year. Totals below are
+          lifetime — what this project has cost and produced since you added it.
+        </p>
+      </header>
+
       {activity ? (
         <ActivityHeatmap
           counts={turns}

--- a/src/components/ProjectScreen/ProjectScreen.css
+++ b/src/components/ProjectScreen/ProjectScreen.css
@@ -1,7 +1,7 @@
 /* ─── project screen ─────────────────────────────────────────────────
  * Full-screen project page (mirrors `.set-screen`): replaces the workspace
- * panes while `projectScreenRepoPath` is set. A header row (back button +
- * project identity) above one scrollable page of sections. */
+ * panes while `projectScreenRepoPath` is set. One thin chrome bar above either
+ * the roadmap's two panels or the scrollable settings page. */
 .proj-screen {
   flex: 1;
   display: flex;
@@ -11,24 +11,34 @@
   background: var(--bg-1);
 }
 
-/* header — back + project identity + board counts, over the tab row. The tabs
- * sit ON the bottom rule (see .ps-tab's negative margin), so the active tab's
- * underline reads as continuous with the header. */
+/* header — one bar, three zones: back / tabs / counts.
+ *
+ * A grid rather than a flex row with spacers, because the tabs are centered on
+ * the *window*, not on whatever is left between two clusters of unequal width —
+ * the counts change as the board moves, and a flex-centered segment would drift
+ * with them. `1fr auto 1fr` pins the middle column no matter what flanks it.
+ *
+ * The height is deliberately the same as the roadmap's panel headers
+ * (`--rm-head-h`), so the chrome above the board reads as two even bands. */
 .ps-head {
   flex-shrink: 0;
-  padding: 12px 24px 0;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 12px;
+  height: 46px;
+  padding: 0 14px;
   border-bottom: 1px solid var(--bd-soft);
 }
-.ps-head-row {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-}
+/* Pulled left by its own inset so the chevron lands on the 16px gutter the
+   panels below use, while the hover box still clears the window edge. */
 .ps-back {
-  gap: 9px;
+  justify-self: start;
+  gap: 6px;
+  height: 26px;
+  padding: 0 10px 0 8px;
+  margin-left: -6px;
   white-space: nowrap;
-  padding: 8px 10px;
-  margin-left: -10px;
   border-radius: var(--r-sm);
   color: var(--fg-2);
   font-weight: 500;
@@ -44,49 +54,63 @@
 .ps-back:hover svg {
   transform: translateX(-2px);
 }
-.ps-id {
-  flex: 1;
-  min-width: 0;
-}
-.ps-title {
-  font-weight: 600;
-  color: var(--fg-0);
-  letter-spacing: -0.01em;
-}
-.ps-path {
-  margin-top: 3px;
-  color: var(--fg-3);
-}
-/* Board counts, right-aligned against the identity block. */
-.ps-stats {
+/* Board counts. The strip must never wrap — the bar has a fixed height, so a
+ * second line would be clipped rather than shown. `.stat-row` (Stats.css, which
+ * loads after this file) sets `flex-wrap: wrap`, so this needs the extra
+ * specificity to win. */
+.ps-head .ps-stats {
+  justify-self: end;
   flex-shrink: 0;
   flex-wrap: nowrap;
+  gap: 12px;
+}
+.ps-stats .stat {
+  gap: 5px;
 }
 .ps-stat-shipped {
   color: var(--success);
 }
+/* Below this the three zones stop fitting side by side. The two middle counts
+ * go first: "in flight" and "shipped" are the ends of the pipeline and carry
+ * the most on their own. `display: contents` means the wrapper is invisible to
+ * the flex layout at full width — the strip lays out as if it weren't there. */
+.ps-stats-mid {
+  display: contents;
+}
+@media (max-width: 1000px) {
+  .ps-stats-mid {
+    display: none;
+  }
+}
 
-/* tabs — Roadmap ⇄ Settings */
+/* tabs — Roadmap ⇄ Settings, as a segmented control.
+ * The page's primary nav is a *control* (a raised pill inside a track); the
+ * board's own tabs below stay bare text pills, so the two levels never read as
+ * the same thing. */
 .ps-tabs {
+  justify-self: center;
   display: flex;
-  gap: 4px;
-  margin-top: 10px;
+  gap: 2px;
+  padding: 2px;
+  background: var(--bg-0);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-md);
 }
 .ps-tab {
-  gap: 7px;
-  padding: 8px 12px 9px;
-  margin-bottom: -1px;
+  gap: 6px;
+  height: 24px;
+  padding: 0 12px;
   font-weight: 500;
   color: var(--fg-2);
-  border-radius: var(--r-sm) var(--r-sm) 0 0;
-  border-bottom: 2px solid transparent;
+  border-radius: var(--r-sm);
   transition:
     background 0.14s var(--ease),
     color 0.14s var(--ease),
-    border-color 0.14s var(--ease);
+    box-shadow 0.14s var(--ease);
 }
 .ps-tab svg {
   color: var(--fg-3);
+  transition: color 0.14s var(--ease);
 }
 .ps-tab:hover {
   color: var(--fg-0);
@@ -94,7 +118,8 @@
 }
 .ps-tab.active {
   color: var(--fg-0);
-  border-bottom-color: var(--accent);
+  background: var(--bg-2);
+  box-shadow: var(--shadow-1);
 }
 .ps-tab.active svg {
   color: var(--accent);

--- a/src/components/ProjectScreen/Roadmap/Board/ItemCard.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/ItemCard.tsx
@@ -138,7 +138,7 @@ export function ItemCard({
         {item.status === "active" && (
           <span className="rm-live iflex-center mono text-xs">
             <span className="rm-pearl" />
-            {item.agent ?? "running"}
+            <span className="truncate">{item.agent ?? "running"}</span>
           </span>
         )}
         {state && (
@@ -155,9 +155,9 @@ export function ItemCard({
           </span>
         )}
         <span className={`rm-src iflex-center src-${item.source}`} title={source.tip}>
-          <Icon name={source.icon} size={10} />
+          <Icon name={source.icon} size={11} />
         </span>
-        <Icon name="chevD" size={10} className="rm-chev" />
+        <Icon name="chevD" size={11} className="rm-chev" />
       </button>
 
       {/* The two buttons that decide a proposal's fate. Outside the header
@@ -201,89 +201,96 @@ export function ItemCard({
               ))}
             </ul>
           )}
-          <div className="rm-item-foot flex-center">
-            {item.area && <span className="rm-area mono text-xs">{item.area}</span>}
-            {item.deps?.map((d) => (
-              <span key={d} className="rm-dep iflex-center mono text-xs">
-                <Icon name="arrowR" size={9} />
-                after {d}
-              </span>
-            ))}
-            {/* What the queue would run this under, so the user knows before
-                they queue rather than after it stalls. */}
-            {(onQueue || onUnqueue) && (
-              <span
-                className={`rm-wf iflex-center mono text-xs ${workflowName ? "" : "none"}`}
-                title={
-                  workflowName
-                    ? `Runs under the ${workflowName} workflow`
-                    : "No workflow set on this item and no project default — the queue can't run it yet"
-                }
-              >
-                <Icon name="combine" size={9} />
-                {workflowName ?? "no workflow"}
-              </span>
-            )}
-            <span className="grow" />
-            {onEdit && (
-              <Button variant="ghost" size="sm" onClick={onEdit}>
-                <Icon name="edit" size={11} /> Edit
-              </Button>
-            )}
-            {/* The manual hand-off stays available on every real row: the queue
+          {/* Two groups rather than one row with a spacer: when the card is too
+              narrow to hold both, the actions wrap as a block and stay together
+              on the right. A spacer would drop them one at a time, leaving the
+              primary button stranded on its own line. */}
+          <div className="rm-item-foot">
+            <div className="rm-item-meta">
+              {item.area && <span className="rm-area mono text-xs">{item.area}</span>}
+              {item.deps?.map((d) => (
+                <span key={d} className="rm-dep iflex-center mono text-xs">
+                  <Icon name="arrowR" size={11} />
+                  after {d}
+                </span>
+              ))}
+              {/* What the queue would run this under, so the user knows before
+                  they queue rather than after it stalls. */}
+              {(onQueue || onUnqueue) && (
+                <span
+                  className={`rm-wf iflex-center mono text-xs ${workflowName ? "" : "none"}`}
+                  title={
+                    workflowName
+                      ? `Runs under the ${workflowName} workflow`
+                      : "No workflow set on this item and no project default — the queue can't run it yet"
+                  }
+                >
+                  <Icon name="combine" size={11} />
+                  <span className="truncate">{workflowName ?? "no workflow"}</span>
+                </span>
+              )}
+            </div>
+            <div className="rm-item-acts">
+              {onEdit && (
+                <Button variant="ghost" size="sm" onClick={onEdit}>
+                  <Icon name="edit" size={11} /> Edit
+                </Button>
+              )}
+              {/* The manual hand-off stays available on every real row: the queue
                 is autonomous, and sometimes you want to drive. Demoted to a
                 ghost button next to "Queue", which is the path most rows take.
                 A proposed row isn't work anyone has agreed to do — accept it
                 first, then send it. */}
-            {!ghost && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={async () => {
-                  const draftId = await createDraft(repoPath, briefFor(item));
-                  // The draft lives in the workspace, which this page covers —
-                  // but stay put if it couldn't be created, so the user isn't
-                  // dropped somewhere else to read the error.
-                  if (draftId) closeProjectScreen();
-                }}
-              >
-                <Icon name="zap" size={11} /> Send to an agent
-              </Button>
-            )}
-            {/* An item in review is waiting on a PR, so the PR is the thing to
+              {!ghost && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={async () => {
+                    const draftId = await createDraft(repoPath, briefFor(item));
+                    // The draft lives in the workspace, which this page covers —
+                    // but stay put if it couldn't be created, so the user isn't
+                    // dropped somewhere else to read the error.
+                    if (draftId) closeProjectScreen();
+                  }}
+                >
+                  <Icon name="zap" size={11} /> Send to an agent
+                </Button>
+              )}
+              {/* An item in review is waiting on a PR, so the PR is the thing to
                 go to — the run behind it is already finished. */}
-            {item.item.pr_url && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  void openExternal(item.item.pr_url as string).catch(() => {});
-                }}
-              >
-                <Icon name="pr" size={11} />
-                {item.item.pr_number ? `PR #${item.item.pr_number}` : "View PR"}
-              </Button>
-            )}
-            {onOpenRun && (
-              <Button variant="outline" size="sm" onClick={onOpenRun}>
-                <Icon name="combine" size={11} /> View run
-              </Button>
-            )}
-            {onUnqueue && (
-              <Button variant="outline" size="sm" onClick={onUnqueue}>
-                Take off the queue
-              </Button>
-            )}
-            {onMarkDone && (
-              <Button variant="outline" size="sm" onClick={onMarkDone}>
-                <Icon name="check" size={11} /> Mark done
-              </Button>
-            )}
-            {onQueue && (
-              <Button variant="primary" size="sm" onClick={onQueue}>
-                <Icon name="play" size={11} /> Queue
-              </Button>
-            )}
+              {item.item.pr_url && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    void openExternal(item.item.pr_url as string).catch(() => {});
+                  }}
+                >
+                  <Icon name="pr" size={11} />
+                  {item.item.pr_number ? `PR #${item.item.pr_number}` : "View PR"}
+                </Button>
+              )}
+              {onOpenRun && (
+                <Button variant="outline" size="sm" onClick={onOpenRun}>
+                  <Icon name="combine" size={11} /> View run
+                </Button>
+              )}
+              {onUnqueue && (
+                <Button variant="outline" size="sm" onClick={onUnqueue}>
+                  Take off the queue
+                </Button>
+              )}
+              {onMarkDone && (
+                <Button variant="outline" size="sm" onClick={onMarkDone}>
+                  <Icon name="check" size={11} /> Mark done
+                </Button>
+              )}
+              {onQueue && (
+                <Button variant="primary" size="sm" onClick={onQueue}>
+                  <Icon name="play" size={11} /> Queue
+                </Button>
+              )}
+            </div>
           </div>
         </div>
       )}

--- a/src/components/ProjectScreen/Roadmap/Board/index.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { type RefObject, useEffect, useRef, useState } from "react";
 import type { Horizon, RoadmapItem } from "@/api";
 import { Icon } from "@/components/Icon";
 import { IconButton } from "@/components/ui/IconButton";
@@ -18,12 +18,24 @@ type Editing = { item: RoadmapItem | null; horizon: Horizon };
 /** The board the PM agent maintains: horizon groups of expandable items, with
  *  the PM's outstanding proposals rendered inline as ghost rows in the horizon
  *  they'd land in. Sibling tab shows the product map the agent reasons against. */
-export function Board({ roadmap, repoPath }: { roadmap: RoadmapState; repoPath: string }) {
+export function Board({
+  roadmap,
+  repoPath,
+  width,
+  asideRef,
+}: {
+  roadmap: RoadmapState;
+  repoPath: string;
+  /** Column width set by the splitter, or null for the default even split —
+   *  which is a CSS percentage, so it stays even as the window resizes. */
+  width?: number | null;
+  /** Lets the splitter measure this column at drag start. */
+  asideRef?: RefObject<HTMLElement>;
+}) {
   const {
     items,
     ghosts,
     map,
-    shipped,
     tab,
     setTab,
     openCodes,
@@ -67,8 +79,11 @@ export function Board({ roadmap, repoPath }: { roadmap: RoadmapState; repoPath: 
   const blank = !loading && items.length === 0 && ghosts.length === 0;
   const openNew = (horizon: Horizon) => setEditing({ item: null, horizon });
 
+  // Only the width is set inline. The stylesheet's min/max stay in force, so a
+  // width persisted on a wide window can't crush the chat on a narrow one — the
+  // column is clamped back on render, not silently overflowed.
   return (
-    <aside className="rm-board">
+    <aside className="rm-board" ref={asideRef} style={width == null ? undefined : { width }}>
       <div className="rm-board-h flex-center">
         <div className="rm-tabs">
           <button
@@ -76,37 +91,29 @@ export function Board({ roadmap, repoPath }: { roadmap: RoadmapState; repoPath: 
             className={`rm-tab iflex-center text-sm ${tab === "roadmap" ? "active" : ""}`}
             onClick={() => setTab("roadmap")}
           >
-            <Icon name="map" size={12} /> Roadmap
+            <Icon name="map" size={13} /> Roadmap
           </button>
           <button
             type="button"
             className={`rm-tab iflex-center text-sm ${tab === "map" ? "active" : ""}`}
             onClick={() => setTab("map")}
           >
-            <Icon name="cube" size={12} /> Product map
+            <Icon name="cube" size={13} /> Product map
           </button>
         </div>
         <span className="grow" />
-        {tab === "roadmap" && (
-          <>
-            {/* Zero shipped is the honest state of a new project, and saying so
-                adds nothing — the stat appears once there's something to count. */}
-            {shipped > 0 && (
-              <span className="rm-shipped iflex-center mono text-xs">
-                <Icon name="merge" size={11} />
-                {shipped} shipped
-              </span>
-            )}
-            {!readOnly && (
-              <IconButton
-                aria-label="Add roadmap item"
-                tip="Add an item"
-                onClick={() => openNew("next")}
-              >
-                <Icon name="plus" />
-              </IconButton>
-            )}
-          </>
+        {/* No shipped count here: the page header already carries it, and two
+            copies of the same number a centimetre apart is clutter, not
+            reinforcement. */}
+        {tab === "roadmap" && !readOnly && (
+          <IconButton
+            aria-label="Add roadmap item"
+            tip="Add an item"
+            tipDown
+            onClick={() => openNew("next")}
+          >
+            <Icon name="plus" />
+          </IconButton>
         )}
       </div>
 

--- a/src/components/ProjectScreen/Roadmap/Roadmap.css
+++ b/src/components/ProjectScreen/Roadmap/Roadmap.css
@@ -4,6 +4,21 @@
  * and the composer are reused from the agent transcript — only what is unique
  * to the roadmap is styled here. */
 .rm {
+  /* Floors for the two columns, mirroring ROADMAP_MIN_BOARD / _THREAD in
+     storage/preferences.ts — the splitter clamps the drag to these, and the
+     rules below clamp the *rendered* width, which is what protects a width
+     persisted on a wide window from crushing the chat on a narrow one. */
+  --rm-min-board: 360px;
+  --rm-min-thread: 400px;
+  /* The two panel headers are separate elements in separate columns with
+     entirely different contents, so nothing makes their bottom rules line up
+     except agreeing on a number. They agree here — and the page header above
+     uses the same one, so the chrome reads as even bands. 46px is the tallest
+     thing either header holds (a 26px icon button) plus 10px of air. */
+  --rm-head-h: 46px;
+  /* One gutter for the board column: its header, its rows, and every strip
+     that can appear between them start on the same vertical line. */
+  --rm-gut: 16px;
   flex: 1;
   display: flex;
   min-width: 0;
@@ -13,7 +28,6 @@
 .rm-board-h .grow,
 .rm-props .grow,
 .rm-ghostbar .grow,
-.rm-item-foot .grow,
 .rm-dialog .modal-foot .grow,
 .rm-composer-wrap .composer-foot .grow {
   flex: 1;
@@ -56,21 +70,31 @@
 /* ── header: who you're talking to, and which conversation ── */
 .rm-thread-head {
   flex-shrink: 0;
+  height: var(--rm-head-h);
   gap: 9px;
-  padding: 10px 16px 10px 20px;
+  padding: 0 10px 0 var(--rm-gut);
   border-bottom: 1px solid var(--bd-soft);
 }
 .rm-thread-head .grow {
   flex: 1;
 }
+/* Both identity marks — the placeholder badge and the real agent chip — are the
+   same 22px square, so switching from "Project manager" to a live chat doesn't
+   shift the title beside it. */
 .rm-pm-badge {
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   flex-shrink: 0;
-  border-radius: var(--r-md);
+  justify-content: center;
+  border-radius: var(--r-sm);
   color: var(--accent);
   background: var(--accent-soft);
   border: 1px solid var(--accent-line);
+}
+.rm-thread-head .ag-prov-chip {
+  width: 22px;
+  height: 22px;
+  justify-content: center;
 }
 .rm-pm-n {
   color: var(--fg-0);
@@ -83,17 +107,24 @@
   min-width: 0;
   flex: 1;
 }
+/* Sized like the header's icon button so the two hover targets in the bar are
+   the same height and share its optical center. */
 .rm-picker-btn {
   gap: 7px;
+  height: 26px;
   max-width: 100%;
-  padding: 3px 7px;
+  padding: 0 7px;
+  margin-left: -3px;
   border-radius: var(--r-sm);
   color: var(--fg-0);
   background: transparent;
-  transition: background 0.14s;
+  transition: var(--transition-ui);
 }
 .rm-picker-btn:hover {
   background: var(--hover);
+}
+.rm-picker-btn svg {
+  color: var(--fg-3);
 }
 .rm-picker-t {
   min-width: 0;
@@ -145,9 +176,14 @@
 .rm-picker-row-t {
   color: var(--fg-0);
 }
+/* Same footprint as the `xs` icon button it replaces, so confirming a delete
+   doesn't resize the row it sits on. */
 .rm-picker-del {
+  display: inline-flex;
+  align-items: center;
   flex-shrink: 0;
-  padding: 3px 7px;
+  height: 22px;
+  padding: 0 8px;
   color: var(--danger);
   background: transparent;
   border: 1px solid var(--danger);
@@ -218,7 +254,7 @@
 .rm-thread-err {
   flex-shrink: 0;
   gap: 10px;
-  padding: 7px 16px 7px 20px;
+  padding: 8px var(--rm-gut);
   color: var(--danger);
   background: color-mix(in oklch, var(--danger), var(--bg-1) 92%);
   border-bottom: 1px solid var(--bd-soft);
@@ -255,10 +291,15 @@
 }
 
 /* ═══ right column: the board ══════════════════════════════════════ */
+/* Half the page until the splitter is dragged, at which point React sets a px
+   width inline. `flex-shrink: 0` so the chat (which is `flex: 1`) is the one
+   that gives; the max-width is what stops the board from taking the chat's
+   floor when the window narrows below the width the user chose. */
 .rm-board {
-  width: 45%;
-  min-width: 380px;
-  max-width: 620px;
+  width: 50%;
+  flex-shrink: 0;
+  min-width: var(--rm-min-board);
+  max-width: calc(100% - var(--rm-min-thread));
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -266,14 +307,19 @@
 }
 .rm-board-h {
   flex-shrink: 0;
-  height: 44px;
+  height: var(--rm-head-h);
   gap: 10px;
-  padding: 0 14px;
+  /* Left gutter matches the rows below; the right is inset by the icon
+     button's own padding so its glyph lands on the same margin. */
+  padding: 0 10px 0 var(--rm-gut);
   border-bottom: 1px solid var(--bd-soft);
 }
+/* Secondary nav: bare pills, not the page header's segmented control. Nesting
+   one control inside another would give two levels of tabs the same weight. */
 .rm-tabs {
   display: flex;
   gap: 2px;
+  margin-left: -8px;
 }
 .rm-tab {
   gap: 6px;
@@ -282,27 +328,31 @@
   border-radius: var(--r-sm);
   font-weight: 500;
   color: var(--fg-2);
-  transition: var(--transition-ui);
+  transition:
+    background 0.14s var(--ease),
+    color 0.14s var(--ease),
+    box-shadow 0.14s var(--ease);
+}
+.rm-tab svg {
+  color: var(--fg-3);
+  transition: color 0.14s var(--ease);
 }
 .rm-tab:hover {
   background: var(--hover);
   color: var(--fg-0);
 }
 .rm-tab.active {
-  background: var(--selected);
+  background: var(--bg-2);
   color: var(--fg-0);
+  box-shadow: inset 0 0 0 1px var(--bd-soft);
 }
-.rm-shipped {
-  gap: 5px;
-  color: var(--fg-3);
-}
-.rm-shipped svg {
-  color: var(--success);
+.rm-tab.active svg {
+  color: var(--accent);
 }
 .rm-board-scroll {
   flex: 1;
   overflow-y: auto;
-  padding: 14px 14px 48px;
+  padding: 14px var(--rm-gut) 48px;
 }
 
 /* A write that failed. Sits between the tabs and the rows, because it is about
@@ -310,7 +360,7 @@
 .rm-board-err {
   flex-shrink: 0;
   gap: 10px;
-  padding: 8px 14px;
+  padding: 8px var(--rm-gut);
   color: var(--danger);
   background: color-mix(in srgb, var(--danger) 10%, transparent);
   border-bottom: 1px solid color-mix(in srgb, var(--danger) 28%, transparent);
@@ -339,13 +389,11 @@
 .rm-props {
   flex-shrink: 0;
   gap: 10px;
-  padding: 7px 10px 7px 14px;
+  padding: 8px 10px 8px var(--rm-gut);
   background: color-mix(in oklch, var(--accent), var(--bg-1) 92%);
   border-bottom: 1px solid var(--accent-line);
 }
 .rm-props-n {
-  flex-shrink: 0;
-  gap: 5px;
   font-weight: 600;
   color: var(--accent);
 }
@@ -355,11 +403,16 @@
 }
 .rm-props-x,
 .rm-props-ok {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   flex-shrink: 0;
   gap: 4px;
-  padding: 3px 9px;
+  height: 22px;
+  padding: 0 9px;
   border-radius: var(--r-xs);
   background: transparent;
+  transition: var(--transition-ui);
 }
 .rm-props-x {
   color: var(--fg-2);
@@ -395,6 +448,7 @@
   width: 40px;
   height: 40px;
   margin-bottom: 2px;
+  justify-content: center;
   border-radius: var(--r-md);
   color: var(--accent);
   background: var(--accent-soft);
@@ -436,7 +490,11 @@
 .rm-group-n {
   color: var(--fg-3);
 }
+/* The label and its note align on their baselines; the count and the button are
+   boxes, and align on their centers — `align-self` is what keeps a baseline
+   row from hanging a bare glyph off the text's baseline. */
 .rm-group-c {
+  align-self: center;
   margin-left: auto;
   color: var(--fg-3);
   font-variant-numeric: tabular-nums;
@@ -444,9 +502,11 @@
 /* Add straight into this horizon. Quiet until the group is hovered — one of
    these per group would otherwise be three competing buttons. */
 .rm-group-add {
+  align-self: center;
   width: 18px;
   height: 18px;
   margin-left: 2px;
+  justify-content: center;
   border-radius: var(--r-xs);
   color: var(--fg-3);
   opacity: 0;
@@ -473,6 +533,37 @@
   font-style: italic;
 }
 
+/* ── chips ───────────────────────────────────────────────────────────
+   Every small tag on this surface — filled pills on the row header, bare
+   icon+label meta in the footer and the strips — is built from one block, so
+   they cannot drift apart.
+
+   Two things do the real work. `line-height: 1` is why an icon and its label
+   share a center: with the inherited ratio the text's line box is several
+   pixels taller than its glyphs, and centering *that* box against an 11px icon
+   leaves the icon riding visibly high. And one fixed `height` for all of them
+   is why a row carrying a size tag is exactly as tall as one carrying a state
+   pill — the chips no longer set the row's height, the row does. */
+.rm-epic,
+.rm-state,
+.rm-size,
+.rm-live,
+.rm-src,
+.rm-area,
+.rm-dep,
+.rm-wf,
+.rm-props-n,
+.rm-group-c {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  height: 18px;
+  flex-shrink: 0;
+  line-height: var(--lh-none);
+  white-space: nowrap;
+}
+
 /* ── item row ── */
 .rm-item {
   overflow: hidden;
@@ -484,20 +575,27 @@
     background 0.14s var(--ease);
 }
 .rm-item:hover {
-  border-color: var(--bd-strong);
+  background: var(--hover);
+  border-color: var(--bd);
 }
 .rm-item.open {
   border-color: var(--bd);
+  box-shadow: var(--shadow-1);
 }
+/* A fixed height, not padding around whatever chips the row happens to carry:
+   otherwise a row with a size tag is a pixel taller than the one above it and
+   the stack reads as ragged. */
 .rm-item-h {
   width: 100%;
+  height: 38px;
   gap: 9px;
-  padding: 9px 11px;
+  padding: 0 10px;
   text-align: left;
 }
 .rm-code {
   flex-shrink: 0;
   color: var(--fg-3);
+  font-variant-numeric: tabular-nums;
 }
 .rm-title {
   flex: 1;
@@ -505,8 +603,12 @@
   color: var(--fg-0);
 }
 .rm-epic {
-  flex-shrink: 0;
-  padding: 2px 6px;
+  max-width: 130px;
+  padding: 0 8px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-block;
+  line-height: 18px;
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -514,15 +616,21 @@
   background: var(--accent-soft);
   border-radius: 999px;
 }
-/* An agent is on this one right now. */
+/* An agent is on this one right now. The label is whatever the queue stamped on
+   the row — an agent id, which can be long — so it is capped and truncated
+   rather than allowed to push the title out of the row. */
 .rm-live {
-  flex-shrink: 0;
   gap: 5px;
+  max-width: 120px;
   color: var(--fg-2);
+}
+.rm-live > .truncate {
+  min-width: 0;
 }
 .rm-pearl {
   width: 7px;
   height: 7px;
+  flex-shrink: 0;
   border-radius: 50%;
   background: var(--success);
   box-shadow: 0 0 0 2px color-mix(in oklch, var(--success), transparent 82%);
@@ -536,10 +644,9 @@
 /* One-word lifecycle chip. Only the statuses that mean something is (or should
    be) happening get one — `open` is the board's resting state. */
 .rm-state {
-  flex-shrink: 0;
-  padding: 2px 7px;
+  padding: 0 8px;
+  font-weight: 500;
   border-radius: 999px;
-  white-space: nowrap;
 }
 /* Waiting its turn: present, unhurried, not an alert. */
 .rm-state.st-q {
@@ -552,10 +659,11 @@
   background: color-mix(in oklch, var(--info), transparent 88%);
 }
 
+/* A one-letter tier tag. Square-ish rather than a pill: it is a measure, not a
+   state, and the different shape is what tells them apart at a glance. */
 .rm-size {
-  flex-shrink: 0;
-  width: 18px;
-  height: 17px;
+  width: 20px;
+  padding: 0;
   border-radius: var(--r-xs);
   font-weight: 600;
   color: var(--fg-2);
@@ -566,8 +674,10 @@
   color: var(--warn);
   background: color-mix(in oklch, var(--warn), transparent 88%);
 }
+/* Provenance glyph. A fixed square so the chevron after it sits on the same
+   line on every row, whichever source drew it. */
 .rm-src {
-  flex-shrink: 0;
+  width: 18px;
   color: var(--fg-3);
 }
 .rm-src.src-pm {
@@ -576,14 +686,22 @@
 .rm-chev {
   flex-shrink: 0;
   color: var(--fg-3);
-  transition: transform 0.15s var(--ease);
+  opacity: 0.75;
+  transition:
+    transform 0.15s var(--ease),
+    opacity 0.15s var(--ease);
+}
+.rm-item:hover .rm-chev {
+  opacity: 1;
 }
 .rm-item.open .rm-chev {
   transform: rotate(180deg);
 }
 
+/* Left padding matches the header button's, so the rationale starts on the
+   same line as the item code above it. */
 .rm-item-body {
-  padding: 2px 12px 11px;
+  padding: 2px 10px 11px;
 }
 .rm-why {
   margin: 0 0 9px;
@@ -616,9 +734,25 @@
   border: 1px solid var(--bd-strong);
   border-radius: 2px;
 }
+/* Meta on the left, actions on the right, each wrapping as a block. */
 .rm-item-foot {
-  gap: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   flex-wrap: wrap;
+  gap: 8px;
+}
+.rm-item-meta,
+.rm-item-acts {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
+}
+.rm-item-acts {
+  margin-left: auto;
+  justify-content: flex-end;
 }
 .rm-area {
   letter-spacing: 0.07em;
@@ -626,14 +760,16 @@
   color: var(--fg-3);
 }
 .rm-dep {
-  gap: 4px;
   color: var(--info);
 }
 /* What the queue would run this item under. Muted — it's a fact about the row,
    not an action — until there is no answer, which is a problem worth seeing. */
 .rm-wf {
-  gap: 4px;
+  max-width: 190px;
   color: var(--fg-3);
+}
+.rm-wf > .truncate {
+  min-width: 0;
 }
 .rm-wf.none {
   color: var(--warn);
@@ -651,7 +787,8 @@
    and the body, like the ghostbar, so a stalled item says so collapsed. */
 .rm-note {
   gap: 6px;
-  padding: 6px 11px 7px;
+  padding: 7px 10px;
+  line-height: var(--lh-snug);
   color: var(--warn);
   border-top: 1px solid color-mix(in oklch, var(--warn), transparent 82%);
   background: color-mix(in oklch, var(--warn), transparent 94%);
@@ -675,7 +812,7 @@
 /* The decision, always visible on a ghost — collapsed or open. */
 .rm-ghostbar {
   gap: 8px;
-  padding: 6px 8px 7px 11px;
+  padding: 7px 8px 7px 10px;
   border-top: 1px dashed var(--accent-line);
 }
 .rm-ghostbar-l {
@@ -794,12 +931,11 @@
   color: var(--fg-3);
 }
 
-/* ── narrow windows ── */
+/* ── narrow windows ──
+   The columns' widths need no override any more: the board is clamped by
+   `min-width`/`max-width` against the live page width, so it gives way on its
+   own. Only the chat's inner gutters still want tightening. */
 @media (max-width: 1180px) {
-  .rm-board {
-    width: 44%;
-    min-width: 320px;
-  }
   .rm-thread .chat-inner {
     padding: 0 18px;
   }

--- a/src/components/ProjectScreen/Roadmap/Roadmap.css
+++ b/src/components/ProjectScreen/Roadmap/Roadmap.css
@@ -214,12 +214,20 @@
   position: relative;
   flex-shrink: 0;
 }
+/* Centred in the empty state, where the form is the invitation; left-aligned in
+   the header popover, so the chip and the menu it opens share an edge. */
+.rm-newchat-pop .rm-newchat {
+  justify-content: flex-start;
+}
+/* Sized to the agent menu it opens (296px card + 12px padding a side), and its
+   row left-aligned to match: the menu anchors to the picker chip's left edge,
+   so a centred chip left it hanging off the popover by ~46px. */
 .rm-newchat-pop {
   position: absolute;
   z-index: 200;
   top: calc(100% + 6px);
   right: 0;
-  width: 300px;
+  width: 320px;
   padding: 12px;
   background: var(--bg-2);
   border: 1px solid var(--bd-strong);

--- a/src/components/ProjectScreen/Roadmap/Thread/NewChatForm.tsx
+++ b/src/components/ProjectScreen/Roadmap/Thread/NewChatForm.tsx
@@ -8,12 +8,22 @@ import type { ChatAgentPick } from "./usePmChats";
 
 /** Choose who runs the next PM chat, and start it.
  *
- *  The Project Manager preset is the default, but any custom agent or bare
- *  provider is fair game — a chat is just a conversation with a repo attached,
- *  and someone who has tuned their own planning agent should be able to use it
- *  here. The picker is the composer's own `ModelPicker`, so the vocabulary
- *  (agent, then model) is the one the user already knows from spawning agents.
- *  Effort isn't offered: it belongs to the agent definition, not to one chat. */
+ *  The picker is the composer's own `ModelPicker`, so the vocabulary (agent,
+ *  then model) is the one the user already knows from spawning agents. Effort
+ *  isn't offered: it belongs to the agent definition, not to one chat.
+ *
+ *  Three things are narrowed for this surface.
+ *
+ *  The custom-agent list is limited to the Project Manager: the rest of the
+ *  library is built to *write code*, and this chat is denied the publish ops
+ *  backend-side, so offering a tester or an architect here is an offer the
+ *  surface can't honour. Bare coding agents stay — talking to Claude or Codex
+ *  about the roadmap is a real thing to want, which is why they are titled
+ *  "Default agents" and sit *under* the PM rather than leading.
+ *
+ *  And the menu drops downward. This form renders inside the thread header's
+ *  popover, near the top of the window; the composer's default upward menu
+ *  opened straight off the top of the screen and was clipped. */
 export function NewChatForm({
   defaultAgentId,
   starting,
@@ -37,6 +47,8 @@ export function NewChatForm({
       : { provider: DEFAULT_PROVIDER_ID };
   }, [customAgents, defaultAgentId]);
   const pick = picked ?? fallback;
+  /** Allow-list for the picker's custom-agent section: the PM preset alone. */
+  const pmAgentIds = defaultAgentId ? [defaultAgentId] : [];
 
   return (
     <div className="rm-newchat flex-center">
@@ -44,6 +56,11 @@ export function NewChatForm({
         provider={pick.provider}
         model={pick.model}
         customAgentId={pick.customAgentId}
+        drop="down"
+        // Empty while the preset seeds, which hides the section rather than
+        // showing an empty one — the bare coding agents are still selectable.
+        customAgentIds={pmAgentIds}
+        sections={{ custom: "Project manager", providers: "Default agents", customFirst: true }}
         onChange={(provider, model, customAgentId) => setPicked({ provider, model, customAgentId })}
       />
       <Button variant="primary" size="sm" disabled={starting} onClick={() => onStart(pick)}>

--- a/src/components/ProjectScreen/Roadmap/index.tsx
+++ b/src/components/ProjectScreen/Roadmap/index.tsx
@@ -1,3 +1,7 @@
+import { useRef } from "react";
+import { ROADMAP_MIN_BOARD, ROADMAP_MIN_THREAD } from "@/storage/preferences";
+import { useAppStore } from "@/store";
+import { useSplitter } from "@/util/splitter";
 import { Board } from "./Board";
 import { Thread } from "./Thread";
 import type { RoadmapState } from "./useRoadmap";
@@ -8,14 +12,42 @@ export { useRoadmap } from "./useRoadmap";
 /** The Roadmap tab of the project page: a real chat with the project's PM
  *  agent on the left, the board it maintains on the right.
  *
+ *  The columns split the page evenly and are resizable from the rule between
+ *  them. Which of the two you want wide swings through the day — shaping a
+ *  proposal is a reading task, triaging the board is a scanning one — and no
+ *  single ratio serves both. The drag reuses the app shell's splitter, so it
+ *  behaves exactly like the sidebar's; the width is persisted on drag end.
+ *
  *  Board state is owned by `useRoadmap` in the parent, because the page header
  *  shows the same counts the board does. The chats are owned by the Thread —
  *  nothing above it needs them. */
 export function Roadmap({ roadmap, repoPath }: { roadmap: RoadmapState; repoPath: string }) {
+  const width = useAppStore((s) => s.roadmapBoardWidth);
+  const setWidth = useAppStore((s) => s.setRoadmapBoardWidth);
+  const commitWidth = useAppStore((s) => s.commitRoadmapBoardWidth);
+  const board = useRef<HTMLElement>(null);
+
+  const onDrag = useSplitter(
+    // Measured off the element rather than read from `width`: until the first
+    // drag the board is sized by CSS (50%) and the store holds null, so there
+    // is no number to start the drag from.
+    () => board.current?.getBoundingClientRect().width ?? 0,
+    setWidth,
+    "right",
+    commitWidth,
+    {
+      min: ROADMAP_MIN_BOARD,
+      // The board may take everything the chat doesn't need. Measured from the
+      // splitter's parent — this row — whose width is fixed for the drag.
+      max: (el) => (el.parentElement?.getBoundingClientRect().width ?? 0) - ROADMAP_MIN_THREAD,
+    },
+  );
+
   return (
     <div className="rm">
       <Thread roadmap={roadmap} repoPath={repoPath} />
-      <Board roadmap={roadmap} repoPath={repoPath} />
+      <div className="splitter" onMouseDown={onDrag} />
+      <Board roadmap={roadmap} repoPath={repoPath} width={width} asideRef={board} />
     </div>
   );
 }

--- a/src/components/ProjectScreen/index.tsx
+++ b/src/components/ProjectScreen/index.tsx
@@ -43,12 +43,9 @@ export function ProjectScreen({ repoPath }: { repoPath: string }) {
   const roadmap = useRoadmap(repoPath);
 
   // Custom display name for this repo, falling back to the folder basename.
+  // Not shown in the page header (the title bar already names the project) —
+  // the settings sections below still need it.
   const name = projects?.find((p) => p.path === repoPath)?.name ?? basename(repoPath);
-  // The project's repos (known once the project_id resolves). A single-repo
-  // project reads as "the repo at this path"; multi-repo has no single
-  // location, so the header shows the repo count instead.
-  const projectRepoCount =
-    loaded == null ? 1 : (projects?.filter((p) => p.project_id === loaded.projectId).length ?? 1);
 
   // Resolve project_id + detected run config for the repo, then load the
   // persisted overrides. Both must be ready before the editor mounts so the
@@ -82,14 +79,7 @@ export function ProjectScreen({ repoPath }: { repoPath: string }) {
 
   return (
     <div className="proj-screen">
-      <ProjectHeader
-        name={name}
-        subtitle={projectRepoCount > 1 ? `${projectRepoCount} repositories` : repoPath}
-        roadmap={roadmap}
-        tab={tab}
-        onTab={setTab}
-        onClose={close}
-      />
+      <ProjectHeader roadmap={roadmap} tab={tab} onTab={setTab} onClose={close} />
 
       {tab === "roadmap" ? (
         <Roadmap roadmap={roadmap} repoPath={repoPath} />

--- a/src/components/ProjectScreen/index.tsx
+++ b/src/components/ProjectScreen/index.tsx
@@ -22,11 +22,14 @@ interface Loaded {
 }
 
 /** Full-screen project page. Rendered in place of the workspace panes while
- *  `projectScreenRepoPath` is set (mirrors SettingsScreen). Two tabs under a
- *  shared header: the Roadmap (what gets built) and Settings — the activity
- *  pulse plus the per-project config every agent in the project inherits.
+ *  `projectScreenRepoPath` is set (mirrors SettingsScreen). Three tabs under a
+ *  shared header, one per question you can ask about a project: the Roadmap
+ *  (what gets built next), Activity (what has been built), and Settings (the
+ *  per-project config every agent in the project inherits).
+ *
  *  Keyed by the project's primary repo path; resolves the project_id and
- *  detected run config on open. */
+ *  detected run config on open. Both non-roadmap tabs need the resolved
+ *  project_id, so they share one load gate. */
 export function ProjectScreen({ repoPath }: { repoPath: string }) {
   const close = useAppStore((s) => s.closeProjectScreen);
   const projects = useAppStore((s) => s.workspace?.projects);
@@ -85,28 +88,31 @@ export function ProjectScreen({ repoPath }: { repoPath: string }) {
         <Roadmap roadmap={roadmap} repoPath={repoPath} />
       ) : (
         <div className="ps-content">
-          {error ? (
-            <div className="ps-state text-sm">Couldn’t load project settings.</div>
-          ) : !loaded ? (
-            <div className="ps-state iflex-center text-sm">
-              <Loader variant="inherit" /> Loading…
-            </div>
-          ) : (
-            <div className="ps-sections">
+          <div className="ps-sections">
+            {error ? (
+              <div className="ps-state text-sm">Couldn’t load this project.</div>
+            ) : !loaded ? (
+              <div className="ps-state iflex-center text-sm">
+                <Loader variant="inherit" /> Loading…
+              </div>
+            ) : tab === "activity" ? (
               <ProjectPulse projectId={loaded.projectId} />
-              <GeneralSection projectId={loaded.projectId} currentName={name} />
-              <RunEnvSection
-                projectId={loaded.projectId}
-                rows={loaded.rows}
-                ecosystem={loaded.ecosystem}
-                initialOverrides={loaded.overrides}
-              />
-              <EnvVarsSection projectId={loaded.projectId} repoPath={repoPath} />
-              <LinearSection projectId={loaded.projectId} />
-              <VerifySection projectId={loaded.projectId} />
-              <DeleteSection projectId={loaded.projectId} projectName={name} />
-            </div>
-          )}
+            ) : (
+              <>
+                <GeneralSection projectId={loaded.projectId} currentName={name} />
+                <RunEnvSection
+                  projectId={loaded.projectId}
+                  rows={loaded.rows}
+                  ecosystem={loaded.ecosystem}
+                  initialOverrides={loaded.overrides}
+                />
+                <EnvVarsSection projectId={loaded.projectId} repoPath={repoPath} />
+                <LinearSection projectId={loaded.projectId} />
+                <VerifySection projectId={loaded.projectId} />
+                <DeleteSection projectId={loaded.projectId} projectName={name} />
+              </>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -349,11 +349,6 @@
     background-position: -40% 0;
   }
 }
-.agent-row .ag-prov-chip {
-  flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
-}
 /* dev-server "running" indicator — a green play mark in a tinted, bordered
  * circle beside the identity chip. Signals the worktree's app is up, distinct
  * from the agent's turn status (rail / loader / shimmer). The slow breathing

--- a/src/storage/preferences.ts
+++ b/src/storage/preferences.ts
@@ -185,6 +185,25 @@ export function parsePaneWidth(raw: string | undefined, fallback: number): numbe
   return Math.min(MAX_PANE_WIDTH, Math.max(MIN_PANE_WIDTH, n));
 }
 
+/** Floors for the Roadmap tab's two columns. The board stops being a list
+ *  below ~360px (the row's chips start wrapping); the chat's transcript is
+ *  laid out for a reading column and stops being one below ~400px. */
+export const ROADMAP_MIN_BOARD = 360;
+export const ROADMAP_MIN_THREAD = 400;
+
+/** Board width on the Roadmap tab, or `null` for the default even split.
+ *
+ *  `null` is meaningfully different from a number here: until the user drags
+ *  the splitter the columns stay *proportional* (a CSS 50%), so the page looks
+ *  right on any window. The first drag converts that into a fixed width, which
+ *  is how the app's other panes behave. */
+export function parseRoadmapBoardWidth(raw: string | undefined): number | null {
+  if (!raw) return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return null;
+  return Math.min(MAX_PANE_WIDTH, Math.max(ROADMAP_MIN_BOARD, n));
+}
+
 // ---- Sandbox engine ------------------------------------------------------------
 
 /** Isolation engine new agents are stamped with. Mirrors the backend's

--- a/src/store/eventListeners.ts
+++ b/src/store/eventListeners.ts
@@ -54,6 +54,7 @@ import {
   parseProviderFlags,
   parseProviderPathOverrides,
   parseReviewDismissed,
+  parseRoadmapBoardWidth,
   parseSandboxEngine,
   type ThemeMode,
 } from "@/storage/preferences";
@@ -167,6 +168,9 @@ export const hydrateSettings = async (set: AppSet) => {
       rightCollapsed: s.rightCollapsed === "true",
       leftWidth: parsePaneWidth(s.leftWidth, DEFAULT_LEFT_WIDTH),
       rightWidth: parsePaneWidth(s.rightWidth, DEFAULT_RIGHT_WIDTH),
+      // Absent until the Roadmap splitter is dragged for the first time; null
+      // keeps the even split.
+      roadmapBoardWidth: parseRoadmapBoardWidth(s.roadmapBoardWidth),
       // Mission Control's dismissed review-queue marks (item id → signal
       // signature); the queue honors a mark only while the signature matches.
       reviewDismissed: parseReviewDismissed(s.reviewDismissed),

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -12,10 +12,11 @@ import type { SliceCreator } from "./types";
  *  store can remember the last-open tab per agent without importing a component. */
 export type RightPanelTab = "code" | "git" | "run" | "term";
 
-/** Project page tabs — what gets built, and how the project is run. Kept here
- *  (like `RightPanelTab`) so callers of `openProjectScreen` can pick the tab
- *  without the store importing a component. */
-export type ProjectScreenTab = "roadmap" | "settings";
+/** Project page tabs, in display order: what gets built next, what has been
+ *  built, and how the project is run. Kept here (like `RightPanelTab`) so
+ *  callers of `openProjectScreen` can pick the tab without the store importing
+ *  a component. */
+export type ProjectScreenTab = "roadmap" | "activity" | "settings";
 
 export interface UiSlice {
   /** Quick-settings popover (gear / ⌘,). */

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -64,6 +64,10 @@ export interface UiSlice {
   transcriptRailOpen: boolean;
   leftWidth: number;
   rightWidth: number;
+  /** Board column width on the Roadmap tab. `null` — the default — means the
+   *  two columns split the page evenly and stay proportional as the window
+   *  resizes; the first splitter drag pins it to a width. Persisted. */
+  roadmapBoardWidth: number | null;
   /** Last-open right-rail tab per agent, keyed by agent id. Lets the panel
    *  restore the tab the user was on (e.g. Git) when they switch back to an
    *  agent, instead of always resetting to the first tab. In-memory only. */
@@ -107,9 +111,11 @@ export interface UiSlice {
   /** Live (in-memory) width update during a splitter drag. */
   setLeftWidth: (w: number) => void;
   setRightWidth: (w: number) => void;
+  setRoadmapBoardWidth: (w: number) => void;
   /** Persist the final width once a splitter drag ends. */
   commitLeftWidth: (w: number) => void;
   commitRightWidth: (w: number) => void;
+  commitRoadmapBoardWidth: (w: number) => void;
   /** Remember the right-rail tab an agent was last viewing. */
   setRightPanelTab: (agentId: string, tab: RightPanelTab) => void;
   /** Dismiss a Mission Control review-queue item at its current signal
@@ -136,6 +142,7 @@ export const createUiSlice: SliceCreator<UiSlice> = (set, get) => ({
   transcriptRailOpen: true,
   leftWidth: DEFAULT_LEFT_WIDTH,
   rightWidth: DEFAULT_RIGHT_WIDTH,
+  roadmapBoardWidth: null,
   rightPanelTabs: {},
   reviewDismissed: {},
   admin: false,
@@ -215,8 +222,10 @@ export const createUiSlice: SliceCreator<UiSlice> = (set, get) => ({
   // state. Persistence is deferred to commit*Width on drag end (see splitter).
   setLeftWidth: (w) => set({ leftWidth: w }),
   setRightWidth: (w) => set({ rightWidth: w }),
+  setRoadmapBoardWidth: (w) => set({ roadmapBoardWidth: w }),
   commitLeftWidth: (w) => setSetting("leftWidth", String(w)),
   commitRightWidth: (w) => setSetting("rightWidth", String(w)),
+  commitRoadmapBoardWidth: (w) => setSetting("roadmapBoardWidth", String(w)),
   setRightPanelTab: (agentId, tab) =>
     set((s) => ({ rightPanelTabs: { ...s.rightPanelTabs, [agentId]: tab } })),
   dismissReviewItem: (id, signature) =>

--- a/src/styles/shared/badge.css
+++ b/src/styles/shared/badge.css
@@ -1,3 +1,14 @@
+/* Agent identity chip (`<AgentIdentityChip>`): a monogram or provider glyph.
+ * Inline-flex, not inline — as a bare inline box its glyph sits on the text
+ * baseline, which leaves descender space underneath and pushes the chip a
+ * couple of pixels off-center against anything beside it. Every call site
+ * wants it centered, so it is centered here once rather than per surface. */
+.ag-prov-chip {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
 /* compact status badges (PR state, error, draft) */
 .ag-badge {
   gap: 3px;

--- a/src/util/splitter.ts
+++ b/src/util/splitter.ts
@@ -5,40 +5,64 @@ const MIN_WIDTH = 220;
  *  pane's width (computed per-drag below). */
 const LEFT_MAX = 520;
 
+/** Travel limits for one splitter. Omit either and the app shell's defaults
+ *  apply — a 220px floor, and a ceiling of 520px on the left / half the shared
+ *  space on the right.
+ *
+ *  `max` takes a function because a cap usually depends on how much room the
+ *  *other* pane needs, which is only knowable from the live layout. It is
+ *  called once at drag start with the splitter element, so a caller can measure
+ *  its container or siblings. */
+export interface SplitBounds {
+  min?: number;
+  max?: number | ((el: HTMLElement) => number);
+}
+
 /** Pane-resize drag handler. Returns an `onMouseDown` to attach to a
  *  splitter element; while dragging it sets the receiving width via
- *  `set`. Left width is clamped to [220, 520]; the right pane may expand
- *  until it is as wide as the center pane. `commit`, if given, fires once
- *  on drag end with the final width — use it to persist (the per-frame
- *  `set` stays in-memory only). */
+ *  `set`. `commit`, if given, fires once on drag end with the final width —
+ *  use it to persist (the per-frame `set` stays in-memory only).
+ *
+ *  `current` may be a getter rather than a number, for a pane whose resting
+ *  width is expressed in CSS (a percentage, say) and so isn't a number the
+ *  caller holds. It is read once at drag start, off the live element. */
 export function useSplitter(
-  current: number,
+  current: number | (() => number),
   set: (w: number) => void,
   side: "left" | "right",
   commit?: (w: number) => void,
+  bounds?: SplitBounds,
 ) {
   return (e: MouseEvent<HTMLDivElement>) => {
     e.preventDefault();
     const startX = e.clientX;
-    const startW = current;
-    let lastW = current;
+    const startW = typeof current === "function" ? current() : current;
+    let lastW = startW;
     const el = e.currentTarget;
+    const min = bounds?.min ?? MIN_WIDTH;
     // The right pane may grow until it matches the center pane. With the
     // left pane and window fixed, `center + right` is constant for the
     // duration of the drag, so the cap is half their combined width —
     // measured once from the splitter's siblings (center precedes it,
     // the right pane follows it).
-    let max = LEFT_MAX;
-    if (side === "right") {
+    let max: number;
+    if (bounds?.max !== undefined) {
+      max = typeof bounds.max === "function" ? bounds.max(el) : bounds.max;
+    } else if (side === "right") {
       const center = el.previousElementSibling?.getBoundingClientRect().width ?? 0;
       const right = el.nextElementSibling?.getBoundingClientRect().width ?? startW;
-      max = Math.max(MIN_WIDTH, Math.floor((center + right) / 2));
+      max = Math.floor((center + right) / 2);
+    } else {
+      max = LEFT_MAX;
     }
+    // A caller's cap can come out below the floor on a small window; the floor
+    // wins, exactly as the CSS `min-width`/`max-width` pair would resolve it.
+    max = Math.max(min, max);
     el.classList.add("dragging");
     const move = (ev: globalThis.MouseEvent) => {
       const dx = ev.clientX - startX;
       const next = side === "left" ? startW + dx : startW - dx;
-      lastW = Math.max(MIN_WIDTH, Math.min(max, next));
+      lastW = Math.max(min, Math.min(max, next));
       set(lastW);
     };
     const up = () => {


### PR DESCRIPTION
The Roadmap tab shipped unpolished. This is a facelift within the existing design vocabulary — no new patterns, no new tokens beyond two locals — plus one behavioural change (a resizable split) that came out of review.

Most of what was wrong shared a cause: nothing on the surface agreed on a number.

## Header

The project page spent two rows — an identity block plus a tab row — restating a name the title bar already shows, above two panels that each have a header of their own. It is now one 46px bar: **back on the left, tabs centered, counts on the right.**

A `1fr auto 1fr` grid rather than a flex row with spacers, so the tabs stay centered on the window rather than drifting as the counts change. The tabs became a segmented control; the board's own tabs stay bare pills so the two nav levels don't read as equals.

## Chips

Icons sat visibly high inside their labels. The cause was line-height: the chips inherited a ratio, so the text's line box is several pixels taller than its glyphs, and centering *that* box against an 11px icon leaves the icon riding above the text.

Every chip now comes from one block with `line-height: 1` and a fixed 18px height. A row carrying a size tag is exactly as tall as one that isn't — the chips no longer set the row's height, the row does. Chip icons were 9–10px in places; normalized to 11.

## Panel headers

Both were sized by their contents, so the board's came out 44px and the chat's ~46px, and their bottom rules never lined up. They now share `--rm-head-h`, as does the page header above them — three even bands. A `--rm-gut` puts the board header, its rows, and every strip between them on one vertical line.

## Resizable split

The board was capped at `max-width: 620px` while the chat grew unbounded — but the chat's transcript is itself capped at 640px, so a wide window gave a narrow board beside a mostly-empty column.

Now **50/50 and resizable** from the rule between them: which column you want wide swings through the day (shaping a proposal is a reading task, triaging the board is a scanning one) and no single ratio serves both.

It reuses the app shell's `useSplitter` rather than adding a second drag implementation. Two generalizations were needed: bounds are now injectable (its limits were hardcoded for the three-pane layout), and the start width may be a getter, since this pane's resting width is a CSS percentage rather than a number we hold. `null` until the first drag keeps the split proportional on any window; the drag pins it to a width, persisted like the sidebar's. Floors (360px board / 400px chat) are enforced twice — during the drag and on render — so a width saved on a wide monitor can't crush the chat on a laptop.

## Also fixed

Several instances of the same "centered by luck" bug:

- `.rm-pm-badge` and `.rm-blank-badge` had `iflex-center` but no `justify-content`, so their icons sat left of center in a 24/40px box.
- The horizon `+` button baseline-aligned against text and hung low.
- `AgentIdentityChip` was a bare inline span, so its glyph sat on the text baseline with descender space beneath it. Fixed globally in `badge.css`, which makes the local patch in `Sidebar.css` redundant — that one is removed. This also corrects the chip in `RunRow` and the onboarding exhibits.
- A wrapping item footer stranded the primary "Queue" button alone on the left; meta and actions are now two groups that wrap as blocks.
- `.ps-stats` needed extra specificity to win `flex-wrap: nowrap` against `.stat-row`, which loads after it. Without it the counts wrapped into a second line that the fixed-height bar clips. Below 1000px the two middle counts now drop out entirely.

The board header's "N shipped" was dropped: the page header already carries that number a few centimetres away.

## Verification

`tsc --noEmit`, `biome check`, and the full suite (768 tests) pass.

Visual checking was done by building the real stylesheet and rendering a static harness of the markup in headless Chromium — screenshots at 1500px, 940px and 3× zoom, in both themes — covering every chip combination, a bare row, an open row, a ghost, and a stalled row. Worth naming the limit: this was **not** driven through the actual Tauri app, which needs a live project and PM chat. Layout, alignment and the narrow-window degradation are confirmed; the splitter drag itself is verified by inspection only and deserves a hands-on pass before merge.