### PR TITLE
feat(project): give the Activity tab its own metrics

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -41,6 +41,10 @@
    Chat.css/Composer.css, whose message + composer skins it reuses. */
 @import "./components/ProjectScreen/Roadmap/Roadmap.css";
 @import "./components/Stats/Stats.css";
+/* After Stats.css: the Activity sections compose on its chart + stat
+   primitives (`.act-key` matches the `.mb-bar` ramp, the shipped skeleton
+   reuses its `stat-shimmer` keyframes). */
+@import "./components/ProjectScreen/Activity/Activity.css";
 @import "./components/RightPanel/FilePanel/FilePanel.css";
 /* Ahead of SettingsScreen.css (its former home) and of CustomAgents.css /
    Feedback.css, whose prose-box classes compose on top of `.ui-input`. */

--- a/src/components/ProjectScreen/Activity/Activity.css
+++ b/src/components/ProjectScreen/Activity/Activity.css
@@ -1,0 +1,80 @@
+/* ─── Activity tab ────────────────────────────────────────────────────────
+ * Sections specific to the Activity page. The heatmap, stat strips and bar
+ * charts they're built from are shared primitives and live in Stats.css; the
+ * page shell (`.ps-section*`) is ProjectScreen.css. Only the two things with
+ * no reuse elsewhere are here: the chart legend and the shipped list.
+ *
+ * Imported AFTER Stats.css so `.act-key` can compose on the `.mb-bar` ramp
+ * without a specificity fight — see the manifest note in app.css. */
+
+/* Two-swatch key under the merged-vs-opened chart. Deliberately not a generic
+ * legend primitive: one chart on one page needs it, and the heatmap's own
+ * Less/More ramp already covers the other shape a legend takes here. */
+.act-legend {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.act-key {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  background: var(--accent);
+}
+/* Matches `.mb-bar.back` — the same mix, so the key reads as the same series. */
+.act-key.back {
+  background: color-mix(in oklab, var(--accent) 26%, var(--bg-2));
+}
+.act-key:not(:first-child) {
+  margin-left: 8px;
+}
+
+/* ── recently shipped ── */
+.act-ship {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-sm);
+}
+.act-ship-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 11px;
+  border-top: 1px solid var(--bd-soft);
+}
+.act-ship-row:first-child {
+  border-top: none;
+}
+/* Fixed-width so the titles start on one line down the list — the codes are a
+ * column of identifiers, not inline text. */
+.act-ship-code {
+  flex-shrink: 0;
+  width: 62px;
+  color: var(--fg-3);
+}
+.act-ship-title {
+  flex: 1;
+  min-width: 0;
+  color: var(--fg-0);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.act-ship-age {
+  flex-shrink: 0;
+  color: var(--fg-3);
+  font-variant-numeric: tabular-nums;
+}
+/* The shared outline button, just shortened — a 26px CTA would set the row
+ * height here, and these rows are a list to scan, not a stack of actions.
+ *
+ * Two classes deep on purpose: the height it overrides comes from
+ * `.btn-t.sm-t` (icon-button.css), so a bare `.act-ship-pr` loses the cascade
+ * on specificity no matter how late this file is imported. */
+.act-ship .act-ship-pr {
+  flex-shrink: 0;
+  gap: 4px;
+  height: 22px;
+  padding: 0 8px;
+}

--- a/src/components/ProjectScreen/Activity/MergeTime.tsx
+++ b/src/components/ProjectScreen/Activity/MergeTime.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react";
+import { CountUp, formatDayTick, type MiniBar, MiniBars, Stat } from "@/components/Stats";
+import { formatDuration } from "@/util/format";
+import { loadMergeStats } from "./activityData";
+import type { MergeStats } from "./derive";
+
+const WEEKS = 12;
+
+/** How long this project's pull requests take to land, and how many it opens
+ *  and lands week to week.
+ *
+ *  The one metric on this page whose history is complete: `worktree_prs` is
+ *  append-only and migration 0025 back-seeded it from the existing bindings,
+ *  so these numbers cover the project rather than the time since the tab was
+ *  first opened. */
+export function MergeTime({ projectId }: { projectId: string }) {
+  const [stats, setStats] = useState<MergeStats | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setStats(null);
+    loadMergeStats(projectId, Date.now(), WEEKS)
+      .then((s) => !cancelled && setStats(s))
+      .catch((err) => console.error("merge stats failed", err));
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+
+  const bars: MiniBar[] = (stats?.weeks ?? []).map((w, i) => ({
+    key: w.start,
+    // Merged sits inside opened: the gap between the two bars is the week's
+    // work that hasn't landed, which is the thing worth seeing at a glance.
+    value: w.merged,
+    backdrop: w.opened,
+    // Only every third week gets a tick — 12 dates in a row is a wall of text.
+    label: i % 3 === 0 ? formatDayTick(w.start) : "",
+    tip: `Week of ${formatDayTick(w.start)} · ${w.opened} opened · ${w.merged} merged`,
+  }));
+
+  return (
+    <section className="ps-section">
+      <header className="ps-section-h">
+        <h2 className="ps-section-t text-lg">Time to merge</h2>
+        <p className="ps-section-lead text-sm">
+          How long a pull request from this project waits between opening and landing, over its
+          whole history. The bars are the last {WEEKS} weeks: opened behind, merged in front.
+        </p>
+      </header>
+
+      {/* Keyed on the whole window being empty, not on `merged === 0`: a
+          project that has opened PRs but landed none yet still has a real
+          trend to show, and it is the one most worth looking at. */}
+      <MiniBars
+        bars={bars}
+        loading={!stats}
+        ariaLabel={`Pull requests opened and merged per week, last ${WEEKS} weeks`}
+        empty={`No pull requests in the last ${WEEKS} weeks.`}
+        footer={
+          <span className="act-legend">
+            <span className="act-key back" /> opened
+            <span className="act-key" /> merged
+          </span>
+        }
+      />
+
+      <div className="stat-row text-sm">
+        <Stat
+          label="median"
+          loading={!stats}
+          tip={stats?.fastestMs != null ? `fastest ${formatDuration(stats.fastestMs)}` : undefined}
+        >
+          {stats && (stats.medianMs == null ? "—" : formatDuration(stats.medianMs))}
+        </Stat>
+        <span className="stat-sep" />
+        <Stat label="merged" loading={!stats}>
+          {stats && <CountUp value={stats.merged} />}
+        </Stat>
+        <span className="stat-sep" />
+        <Stat label="still open" loading={!stats}>
+          {stats && <CountUp value={stats.open} />}
+        </Stat>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ProjectScreen/Activity/ProjectPulse.tsx
+++ b/src/components/ProjectScreen/Activity/ProjectPulse.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useState } from "react";
-import { ActivityHeatmap, CountUp, computeStreak, formatHeatDay, Stat } from "@/components/Stats";
+import {
+  ActivityHeatmap,
+  CountUp,
+  computeStreak,
+  formatHeatDay,
+  Skeleton,
+  Stat,
+} from "@/components/Stats";
 import { formatCost, formatTokens } from "@/util/format";
 import {
   loadPulseActivity,
@@ -8,18 +15,20 @@ import {
   type PulseActivity,
   type PulseTotals,
   type PulseUsage,
-} from "./pulseData";
+} from "./activityData";
 
 const WEEKS = 52;
 // One extra week of margin past the grid so the oldest column is never short.
 const HORIZON_MS = (WEEKS + 1) * 7 * 86_400_000;
 
-/** The Activity tab's body: a year of daily activity on the accent heat ramp,
- *  a streak counter, and lifetime hero numbers.
+/** The Activity tab's opening section: a year of daily activity on the accent
+ *  heat ramp, a streak counter, and lifetime hero numbers. The widest lens on
+ *  the page — the sections below it narrow to merge speed, spend and specific
+ *  shipped items.
  *
  *  It carries its own heading. On Settings it had none — it was the first
- *  block on a page whose tab already named it — but a tab holding one section
- *  needs to say what the section is, and the grid alone doesn't.
+ *  block on a page whose tab already named it — but a section among siblings
+ *  has to say what it is, and the grid alone doesn't.
  *
  *  Turn/agent/PR series load in one round of fast indexed queries; the token
  *  total folds every session's records, so it streams in behind a shimmer. */
@@ -93,7 +102,7 @@ export function ProjectPulse({ projectId }: { projectId: string }) {
           }
         />
       ) : (
-        <div className="pulse-skeleton" />
+        <Skeleton height={128} className="pulse-skeleton" />
       )}
 
       <div className="stat-row text-sm">

--- a/src/components/ProjectScreen/Activity/RecentlyShipped.tsx
+++ b/src/components/ProjectScreen/Activity/RecentlyShipped.tsx
@@ -1,0 +1,73 @@
+import { open as openExternal } from "@tauri-apps/plugin-shell";
+import { useEffect, useState } from "react";
+import { Icon } from "@/components/Icon";
+import { Skeleton } from "@/components/Stats";
+import { Button } from "@/components/ui/Button";
+import { formatAge } from "@/util/format";
+import { loadRecentlyShipped, type ShippedItem } from "./activityData";
+
+const LIMIT = 10;
+
+/** The last few roadmap items this project shipped, newest first.
+ *
+ *  The counterpart to the Roadmap tab: done items leave the board entirely, so
+ *  without this the only trace of them is a number in the page header. */
+export function RecentlyShipped({ projectId }: { projectId: string }) {
+  const [items, setItems] = useState<ShippedItem[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setItems(null);
+    loadRecentlyShipped(projectId, LIMIT)
+      .then((rows) => !cancelled && setItems(rows))
+      .catch((err) => console.error("recently shipped failed", err));
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+
+  const now = Date.now();
+
+  return (
+    <section className="ps-section">
+      <header className="ps-section-h">
+        <h2 className="ps-section-t text-lg">Recently shipped</h2>
+        <p className="ps-section-lead text-sm">
+          The last {LIMIT} roadmap items marked done. They’re off the board now, so this is where
+          they stay visible.
+        </p>
+      </header>
+
+      {items == null ? (
+        <Skeleton height={132} />
+      ) : items.length === 0 ? (
+        <div className="mb-empty text-sm">
+          Nothing shipped yet. Items land here as the board marks them done.
+        </div>
+      ) : (
+        <ul className="act-ship">
+          {items.map((it) => (
+            <li key={it.id} className="act-ship-row">
+              <span className="act-ship-code mono text-xs">{it.code}</span>
+              <span className="act-ship-title text-sm">{it.title}</span>
+              <span className="act-ship-age text-xs">{formatAge(it.updated_at, now)}</span>
+              {it.pr_url && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="act-ship-pr"
+                  onClick={() => {
+                    void openExternal(it.pr_url as string).catch(() => {});
+                  }}
+                >
+                  <Icon name="pr" size={11} />
+                  {it.pr_number ? `#${it.pr_number}` : "PR"}
+                </Button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/components/ProjectScreen/Activity/Spend.tsx
+++ b/src/components/ProjectScreen/Activity/Spend.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useMemo, useState } from "react";
+import { formatDayTick, formatHeatDay, type MiniBar, MiniBars, Stat } from "@/components/Stats";
+import { formatCost, formatTokens } from "@/util/format";
+import { loadSpend } from "./activityData";
+import { recentDays, type SpendDay } from "./derive";
+
+const DAYS = 30;
+
+/** What this project has been spending, day by day.
+ *
+ *  Plots tokens rather than dollars because tokens are the one unit every
+ *  provider reports — claude, codex and cursor price nothing, so a cost chart
+ *  would be empty for most projects. Cost rides along in the tooltip and the
+ *  stat row wherever a provider actually reported it. */
+export function Spend({ projectId }: { projectId: string }) {
+  const [spend, setSpend] = useState<SpendDay[] | null>(null);
+  const days = useMemo(() => recentDays(Date.now(), DAYS), []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setSpend(null);
+    loadSpend(projectId, days)
+      .then((s) => !cancelled && setSpend(s))
+      .catch((err) => console.error("spend series failed", err));
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId, days]);
+
+  const bars: MiniBar[] = (spend ?? []).map((d, i) => ({
+    key: d.day,
+    value: d.tokens,
+    label: i % 7 === 0 ? formatDayTick(d.day) : "",
+    tip:
+      d.tokens == null
+        ? `${formatHeatDay(d.day)} · not recorded`
+        : `${formatHeatDay(d.day)} · ${formatTokens(d.tokens)} tokens${
+            d.cost != null && d.cost > 0 ? ` · ${formatCost(d.cost)}` : ""
+          }`,
+  }));
+
+  // Only over days that were actually observed — summing nulls as zero would
+  // present a partial window as a complete one.
+  const observed = (spend ?? []).filter((d) => d.tokens != null);
+  const tokens = observed.reduce((n, d) => n + (d.tokens ?? 0), 0);
+  const cost = observed.reduce((n, d) => n + (d.cost ?? 0), 0);
+
+  return (
+    <section className="ps-section">
+      <header className="ps-section-h">
+        <h2 className="ps-section-t text-lg">Spend over time</h2>
+        <p className="ps-section-lead text-sm">
+          Fresh input and output tokens per day for the last {DAYS} days. History accrues only while
+          you use the app, so days before this project’s first visit here — and any day it went
+          unopened — show as a gap rather than a zero.
+        </p>
+      </header>
+
+      <MiniBars
+        bars={bars}
+        loading={!spend}
+        ariaLabel={`Tokens used per day, last ${DAYS} days`}
+        empty={
+          <>
+            No usage recorded yet. This starts filling in from the next time an agent takes a turn
+            on this project.
+          </>
+        }
+      />
+
+      <div className="stat-row text-sm">
+        <Stat
+          label="tokens"
+          loading={!spend}
+          tip={observed.length > 0 ? `over ${observed.length} recorded days` : undefined}
+        >
+          {spend && formatTokens(tokens)}
+        </Stat>
+        {cost > 0 && (
+          <>
+            <span className="stat-sep" />
+            <Stat label="cost" loading={!spend} tip="only providers that price their own calls">
+              {spend && formatCost(cost)}
+            </Stat>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/ProjectScreen/Activity/activityData.ts
+++ b/src/components/ProjectScreen/Activity/activityData.ts
@@ -2,11 +2,22 @@ import { hasUsage, usageFromRecords } from "@/adapters/usage";
 import { api } from "@/api";
 import { dbQuery } from "@/storage/db";
 import { recordUsageSnapshot } from "@/storage/usageDaily";
+import {
+  dailySpend,
+  type MergeStats,
+  mergeStats,
+  type PrRow,
+  type SpendDay,
+  type UsageRow,
+} from "./derive";
 
-// Data layer for the Project Pulse block. Everything here reads what the app
-// already persists (session_user_turns, workspaces, worktrees) via SELECT-only
-// raw queries; nothing is recorded on open except the opportunistic usage
-// snapshots seeded by `loadPulseUsage`.
+// Data layer for the Activity tab. Everything here reads what the app already
+// persists (session_user_turns, workspaces, worktrees, worktree_prs,
+// usage_daily, roadmap_items) via SELECT-only raw queries; nothing is recorded
+// on open except the opportunistic usage snapshots seeded by `loadPulseUsage`.
+//
+// Each loader is a query plus a call into `derive` — the shaping lives there so
+// it can be tested without a database.
 
 /** Per-local-day counts feeding the heatmap and its tooltip. */
 export interface PulseActivity {
@@ -146,4 +157,73 @@ export async function loadPulseUsage(projectId: string): Promise<PulseUsage> {
     );
   }
   return { tokens, costUsd };
+}
+
+/** Open→merge times and the opened/merged trend, from the append-only PR log.
+ *
+ *  `worktree_prs` (migration 0025) back-seeded itself from the existing
+ *  bindings, so this covers the project's whole history rather than starting
+ *  at install — unlike the usage series below. Every PR the project has is a
+ *  few hundred rows at worst, so the whole log is folded in JS rather than
+ *  asking SQLite for a median it has no percentile function for. */
+export async function loadMergeStats(
+  projectId: string,
+  nowMs: number,
+  weeks: number,
+): Promise<MergeStats> {
+  const rows = await dbQuery<PrRow>(
+    `SELECT p.opened_at AS opened_at, p.merged_at AS merged_at, p.state AS state
+       FROM worktree_prs p JOIN workspaces w ON w.id = p.workspace_id
+      WHERE w.project_id = ?`,
+    [projectId],
+  );
+  return mergeStats(rows, nowMs, weeks);
+}
+
+/** Per-day token/dollar spend over `days`.
+ *
+ *  Reads the project's ENTIRE `usage_daily` history, not just the window: the
+ *  rows are cumulative, so the first day in range needs its predecessor to
+ *  produce a delta at all. One row per (workspace, day) keeps that cheap. */
+export async function loadSpend(projectId: string, days: string[]): Promise<SpendDay[]> {
+  const rows = await dbQuery<UsageRow>(
+    `SELECT workspace_id, day,
+            input_tokens + output_tokens AS tokens,
+            cost_usd AS cost
+       FROM usage_daily WHERE project_id = ?`,
+    [projectId],
+  );
+  return dailySpend(rows, days);
+}
+
+/** A shipped roadmap item, as the recent list renders it. */
+export interface ShippedItem {
+  id: string;
+  code: string;
+  title: string;
+  pr_url: string | null;
+  pr_number: number | null;
+  /** Ship time, approximated by the last write to the row (see below). */
+  updated_at: number;
+}
+
+/** The most recently shipped roadmap items.
+ *
+ *  Ordered by `updated_at`, which is the ship time only until something edits
+ *  the row afterwards — `roadmap_items` has no `done_at` column. That is
+ *  precise enough for a "recently shipped" list, where a slightly out-of-order
+ *  entry costs nothing, and is exactly why there is no shipped-per-week chart
+ *  here: a chart would be quietly wrong rather than visibly approximate. */
+export async function loadRecentlyShipped(
+  projectId: string,
+  limit: number,
+): Promise<ShippedItem[]> {
+  return dbQuery<ShippedItem>(
+    `SELECT id, code, title, pr_url, pr_number, updated_at
+       FROM roadmap_items
+      WHERE project_id = ? AND status = 'done'
+      ORDER BY updated_at DESC
+      LIMIT ?`,
+    [projectId, limit],
+  );
 }

--- a/src/components/ProjectScreen/Activity/derive.test.ts
+++ b/src/components/ProjectScreen/Activity/derive.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import {
+  dailySpend,
+  mergeStats,
+  type PrRow,
+  recentDays,
+  recentWeeks,
+  type UsageRow,
+} from "./derive";
+
+// Local-midnight epoch for a YYYY-MM-DD day, so fixtures read as dates and the
+// bucketing under test sees the same local calendar the app runs on.
+const at = (day: string, hour = 12): number => {
+  const [y, m, d] = day.split("-").map(Number);
+  return new Date(y, m - 1, d, hour).getTime();
+};
+
+const HOUR = 3_600_000;
+
+// ── calendar ranges ───────────────────────────────────────────────────────
+
+describe("recentDays", () => {
+  it("returns n days oldest-first, ending today", () => {
+    expect(recentDays(at("2026-03-05"), 4)).toEqual([
+      "2026-03-02",
+      "2026-03-03",
+      "2026-03-04",
+      "2026-03-05",
+    ]);
+  });
+
+  it("steps across a month boundary", () => {
+    expect(recentDays(at("2026-03-02"), 3)).toEqual(["2026-02-28", "2026-03-01", "2026-03-02"]);
+  });
+});
+
+describe("recentWeeks", () => {
+  it("returns Mondays oldest-first, ending with this week", () => {
+    // 2026-03-05 is a Thursday; its week starts Monday the 2nd.
+    expect(recentWeeks(at("2026-03-05"), 3)).toEqual(["2026-02-16", "2026-02-23", "2026-03-02"]);
+  });
+
+  it("treats Sunday as the end of its week, not the start of the next", () => {
+    // 2026-03-08 is a Sunday — still the week of Monday the 2nd.
+    expect(recentWeeks(at("2026-03-08"), 1)).toEqual(["2026-03-02"]);
+  });
+});
+
+// ── time to merge ─────────────────────────────────────────────────────────
+
+const pr = (over: Partial<PrRow> = {}): PrRow => ({
+  opened_at: at("2026-03-02"),
+  merged_at: at("2026-03-02") + 2 * HOUR,
+  state: "merged",
+  ...over,
+});
+
+describe("mergeStats", () => {
+  it("takes the middle duration for an odd count", () => {
+    const rows = [1, 5, 3].map((h) =>
+      pr({ opened_at: at("2026-03-02"), merged_at: at("2026-03-02") + h * HOUR }),
+    );
+    expect(mergeStats(rows, at("2026-03-05"), 1).medianMs).toBe(3 * HOUR);
+  });
+
+  it("averages the two middle durations for an even count", () => {
+    const rows = [1, 2, 4, 9].map((h) =>
+      pr({ opened_at: at("2026-03-02"), merged_at: at("2026-03-02") + h * HOUR }),
+    );
+    expect(mergeStats(rows, at("2026-03-05"), 1).medianMs).toBe(3 * HOUR);
+  });
+
+  it("reports the fastest merge alongside the median", () => {
+    const rows = [8, 1, 4].map((h) =>
+      pr({ opened_at: at("2026-03-02"), merged_at: at("2026-03-02") + h * HOUR }),
+    );
+    expect(mergeStats(rows, at("2026-03-05"), 1).fastestMs).toBe(1 * HOUR);
+  });
+
+  it("has no median until something merges", () => {
+    const s = mergeStats([pr({ merged_at: null, state: "open" })], at("2026-03-05"), 1);
+    expect(s.medianMs).toBeNull();
+    expect(s.fastestMs).toBeNull();
+    expect(s.merged).toBe(0);
+    expect(s.open).toBe(1);
+  });
+
+  it("counts a back-seeded row as merged but takes no duration from it", () => {
+    // Migration 0025 seeded rows whose merge time can predate the open time it
+    // also seeded; that is a data artifact, not a negative-lifetime PR.
+    const rows = [
+      pr({ opened_at: at("2026-03-03"), merged_at: at("2026-03-02") }),
+      pr({ opened_at: at("2026-03-02"), merged_at: at("2026-03-02") + 6 * HOUR }),
+    ];
+    const s = mergeStats(rows, at("2026-03-05"), 1);
+    expect(s.merged).toBe(2);
+    expect(s.medianMs).toBe(6 * HOUR);
+  });
+
+  it("counts a PR with no observed open time as merged", () => {
+    const s = mergeStats([pr({ opened_at: null })], at("2026-03-05"), 1);
+    expect(s.merged).toBe(1);
+    expect(s.medianMs).toBeNull();
+  });
+
+  it("buckets opened and merged into their own weeks", () => {
+    // Opened in the week of Feb 23, merged in the week of Mar 2.
+    const rows = [pr({ opened_at: at("2026-02-25"), merged_at: at("2026-03-03") })];
+    const weeks = mergeStats(rows, at("2026-03-05"), 3).weeks;
+    expect(weeks.map((w) => [w.start, w.opened, w.merged])).toEqual([
+      ["2026-02-16", 0, 0],
+      ["2026-02-23", 1, 0],
+      ["2026-03-02", 0, 1],
+    ]);
+  });
+
+  it("reports a quiet week as a real zero", () => {
+    // The PR log is complete, so no rows genuinely means no PRs — unlike the
+    // usage series, absence here is knowledge and must plot as 0, not a gap.
+    const weeks = mergeStats([], at("2026-03-05"), 2).weeks;
+    expect(weeks.every((w) => w.opened === 0 && w.merged === 0)).toBe(true);
+    expect(weeks).toHaveLength(2);
+  });
+});
+
+// ── spend over time ───────────────────────────────────────────────────────
+
+const usage = (workspace_id: string, day: string, tokens: number, cost = 0): UsageRow => ({
+  workspace_id,
+  day,
+  tokens,
+  cost,
+});
+
+const DAYS = ["2026-03-01", "2026-03-02", "2026-03-03", "2026-03-04"];
+
+describe("dailySpend", () => {
+  it("charts the difference between consecutive snapshots, not the total", () => {
+    const rows = [
+      usage("w1", "2026-03-01", 100),
+      usage("w1", "2026-03-02", 250),
+      usage("w1", "2026-03-03", 300),
+    ];
+    expect(dailySpend(rows, DAYS).map((d) => d.tokens)).toEqual([null, 150, 50, null]);
+  });
+
+  it("skips a workspace's first snapshot rather than inventing a spike", () => {
+    // That row is a running total accrued before usage_daily existed for this
+    // workspace; attributing it to its day would fake a launch-day spike.
+    const rows = [usage("w1", "2026-03-02", 900_000), usage("w1", "2026-03-03", 900_100)];
+    expect(dailySpend(rows, DAYS).map((d) => d.tokens)).toEqual([null, null, 100, null]);
+  });
+
+  it("contributes nothing from a workspace seen only once", () => {
+    expect(dailySpend([usage("w1", "2026-03-02", 500)], DAYS).map((d) => d.tokens)).toEqual([
+      null,
+      null,
+      null,
+      null,
+    ]);
+  });
+
+  it("sums deltas across workspaces on the same day", () => {
+    const rows = [
+      usage("w1", "2026-03-01", 10),
+      usage("w1", "2026-03-02", 40),
+      usage("w2", "2026-03-01", 5),
+      usage("w2", "2026-03-02", 12),
+    ];
+    expect(dailySpend(rows, DAYS)[1].tokens).toBe(30 + 7);
+  });
+
+  it("keeps an unobserved day null rather than zero", () => {
+    // A day the app never folded a session is unknown. A 0 would claim the
+    // project was idle, which the data does not say.
+    const rows = [usage("w1", "2026-03-01", 10), usage("w1", "2026-03-02", 40)];
+    const out = dailySpend(rows, DAYS);
+    expect(out[2].tokens).toBeNull();
+    expect(out[3].tokens).toBeNull();
+  });
+
+  it("distinguishes an observed-but-idle day from an unobserved one", () => {
+    // Two snapshots with identical totals: the app looked and nothing moved.
+    // That is a real 0, and must not be conflated with the null above.
+    const rows = [usage("w1", "2026-03-01", 10), usage("w1", "2026-03-02", 10)];
+    expect(dailySpend(rows, DAYS)[1].tokens).toBe(0);
+  });
+
+  it("clamps a shrinking total to zero", () => {
+    // A re-folded ledger (pruned records) can report less than before; that is
+    // a correction, never negative spend.
+    const rows = [usage("w1", "2026-03-01", 500), usage("w1", "2026-03-02", 200)];
+    expect(dailySpend(rows, DAYS)[1].tokens).toBe(0);
+  });
+
+  it("carries cost through the same delta path as tokens", () => {
+    const rows = [usage("w1", "2026-03-01", 10, 1.5), usage("w1", "2026-03-02", 40, 4.25)];
+    expect(dailySpend(rows, DAYS)[1].cost).toBeCloseTo(2.75);
+  });
+
+  it("orders snapshots by day regardless of row order", () => {
+    const rows = [
+      usage("w1", "2026-03-03", 300),
+      usage("w1", "2026-03-01", 100),
+      usage("w1", "2026-03-02", 250),
+    ];
+    expect(dailySpend(rows, DAYS).map((d) => d.tokens)).toEqual([null, 150, 50, null]);
+  });
+});

--- a/src/components/ProjectScreen/Activity/derive.ts
+++ b/src/components/ProjectScreen/Activity/derive.ts
@@ -1,0 +1,180 @@
+import { localDay, weekStartDay } from "@/util/format";
+
+// Pure math behind the Activity tab's charts. Everything here takes rows
+// exactly as they come off `activityData`'s queries and returns exactly what a
+// section renders — no React, no DB — so the three genuinely subtle parts are
+// unit-testable: cumulative usage snapshots turned into per-day deltas, week
+// bucketing across DST, and the distinction between "none" and "not observed".
+
+// ── calendar ranges ───────────────────────────────────────────────────────
+// Both build their keys by stepping a noon-anchored Date, so a DST boundary
+// can never land a bucket on the wrong day (see `weekStartDay`).
+
+/** The last `n` local day keys, oldest first, ending on the day of `nowMs`. */
+export function recentDays(nowMs: number, n: number): string[] {
+  const d = new Date(nowMs);
+  d.setHours(12, 0, 0, 0);
+  d.setDate(d.getDate() - (n - 1));
+  const out: string[] = [];
+  for (let i = 0; i < n; i++) {
+    out.push(localDay(d.getTime()));
+    d.setDate(d.getDate() + 1);
+  }
+  return out;
+}
+
+/** The last `n` local Monday keys, oldest first, ending with the week
+ *  containing `nowMs`. Aligns with `weekStartDay`, which buckets into them. */
+export function recentWeeks(nowMs: number, n: number): string[] {
+  const d = new Date(nowMs);
+  d.setHours(12, 0, 0, 0);
+  d.setDate(d.getDate() - ((d.getDay() + 6) % 7) - (n - 1) * 7);
+  const out: string[] = [];
+  for (let i = 0; i < n; i++) {
+    out.push(localDay(d.getTime()));
+    d.setDate(d.getDate() + 7);
+  }
+  return out;
+}
+
+// ── time to merge ─────────────────────────────────────────────────────────
+
+/** One `worktree_prs` row, which is append-only and was back-seeded from the
+ *  existing bindings — so unlike the usage snapshots, this history is complete
+ *  rather than starting at first-open. */
+export interface PrRow {
+  opened_at: number | null;
+  merged_at: number | null;
+  /** Serialized `github::PrStatus`: open | merged | closed. */
+  state: string;
+}
+
+export interface MergeWeek {
+  /** Monday of the week, as a local day key. */
+  start: string;
+  opened: number;
+  merged: number;
+}
+
+export interface MergeStats {
+  /** Median open→merge span in ms; null until something has merged. Median,
+   *  not mean — one PR left open over a holiday would drag a mean into
+   *  uselessness while the typical PR is unchanged. */
+  medianMs: number | null;
+  fastestMs: number | null;
+  /** PRs with a merge time, lifetime. */
+  merged: number;
+  /** PRs still open right now. */
+  open: number;
+  /** Oldest-first weekly buckets. A week with no PRs is a real zero here —
+   *  the log is complete, so absence is knowledge. */
+  weeks: MergeWeek[];
+}
+
+const bump = (m: Map<string, number>, k: string) => m.set(k, (m.get(k) ?? 0) + 1);
+
+function median(sorted: number[]): number | null {
+  if (sorted.length === 0) return null;
+  const mid = sorted.length >> 1;
+  return sorted.length % 2 === 1 ? sorted[mid] : Math.round((sorted[mid - 1] + sorted[mid]) / 2);
+}
+
+export function mergeStats(rows: PrRow[], nowMs: number, weeks: number): MergeStats {
+  const durations: number[] = [];
+  const openedBy = new Map<string, number>();
+  const mergedBy = new Map<string, number>();
+  let merged = 0;
+  let open = 0;
+
+  for (const r of rows) {
+    if (r.state === "open") open++;
+    if (r.opened_at != null) bump(openedBy, weekStartDay(r.opened_at));
+    if (r.merged_at != null) {
+      merged++;
+      bump(mergedBy, weekStartDay(r.merged_at));
+      // A merge stamped at or before its open is a back-seeded or clock-skewed
+      // row, not a zero-second PR. It still counts as merged — it just can't
+      // contribute a duration.
+      if (r.opened_at != null && r.merged_at > r.opened_at) {
+        durations.push(r.merged_at - r.opened_at);
+      }
+    }
+  }
+
+  durations.sort((a, b) => a - b);
+  return {
+    medianMs: median(durations),
+    fastestMs: durations[0] ?? null,
+    merged,
+    open,
+    weeks: recentWeeks(nowMs, weeks).map((start) => ({
+      start,
+      opened: openedBy.get(start) ?? 0,
+      merged: mergedBy.get(start) ?? 0,
+    })),
+  };
+}
+
+// ── spend over time ───────────────────────────────────────────────────────
+
+/** One `usage_daily` row: a workspace's CUMULATIVE totals as of the last fold
+ *  on that local day (see `recordUsageSnapshot`). */
+export interface UsageRow {
+  workspace_id: string;
+  day: string;
+  tokens: number;
+  cost: number;
+}
+
+export interface SpendDay {
+  day: string;
+  /** Tokens attributable to this day, or `null` when no workspace produced a
+   *  usable delta for it — unknown, not zero. */
+  tokens: number | null;
+  /** Same, in dollars. 0 is real: most providers report tokens but no cost. */
+  cost: number | null;
+}
+
+/** Turn cumulative per-workspace snapshots into per-day project spend, over
+ *  exactly the days in `days`.
+ *
+ *  Two things make this less obvious than a GROUP BY:
+ *
+ *  1. Rows are running totals, so a day's spend is the *difference* between
+ *     consecutive rows for the same workspace.
+ *  2. A workspace's FIRST row is therefore unattributable and is skipped. It
+ *     is a total accumulated over an unknown stretch before it — `usage_daily`
+ *     only starts recording once this tab has been opened — so plotting it as
+ *     that day's spend would invent a launch-day spike that never happened.
+ *     Undercounting the first observation is the honest failure here.
+ *
+ *  A day with no row at all for any workspace stays `null` rather than 0: the
+ *  app simply never folded a session, which is not the same as a quiet day. */
+export function dailySpend(rows: UsageRow[], days: string[]): SpendDay[] {
+  const byWorkspace = new Map<string, UsageRow[]>();
+  for (const r of rows) {
+    const list = byWorkspace.get(r.workspace_id);
+    if (list) list.push(r);
+    else byWorkspace.set(r.workspace_id, [r]);
+  }
+
+  const observed = new Map<string, { tokens: number; cost: number }>();
+  for (const list of byWorkspace.values()) {
+    list.sort((a, b) => (a.day < b.day ? -1 : a.day > b.day ? 1 : 0));
+    for (let i = 1; i < list.length; i++) {
+      const cur = list[i];
+      const prev = list[i - 1];
+      const acc = observed.get(cur.day) ?? { tokens: 0, cost: 0 };
+      // Clamped: a re-fold that shrinks a total (pruned records, a rebuilt
+      // ledger) is a correction, never negative spend.
+      acc.tokens += Math.max(0, cur.tokens - prev.tokens);
+      acc.cost += Math.max(0, cur.cost - prev.cost);
+      observed.set(cur.day, acc);
+    }
+  }
+
+  return days.map((day) => {
+    const hit = observed.get(day);
+    return { day, tokens: hit?.tokens ?? null, cost: hit?.cost ?? null };
+  });
+}

--- a/src/components/ProjectScreen/Activity/index.tsx
+++ b/src/components/ProjectScreen/Activity/index.tsx
@@ -1,0 +1,24 @@
+import { MergeTime } from "./MergeTime";
+import { ProjectPulse } from "./ProjectPulse";
+import { RecentlyShipped } from "./RecentlyShipped";
+import { Spend } from "./Spend";
+
+/** The Activity tab: what this project has actually done, as against the
+ *  Roadmap tab's what it is going to do.
+ *
+ *  Four sections, ordered widest lens to narrowest — a year of daily activity,
+ *  then how fast work lands, then what it costs, then the specific items that
+ *  shipped. Each owns its own query and loading state rather than sharing one
+ *  gate: the pulse's token fold walks every session's transcript and takes far
+ *  longer than the three indexed queries beside it, so one shared gate would
+ *  hold the whole page at the speed of its slowest part. */
+export function Activity({ projectId }: { projectId: string }) {
+  return (
+    <>
+      <ProjectPulse projectId={projectId} />
+      <MergeTime projectId={projectId} />
+      <Spend projectId={projectId} />
+      <RecentlyShipped projectId={projectId} />
+    </>
+  );
+}

--- a/src/components/ProjectScreen/ProjectScreen.css
+++ b/src/components/ProjectScreen/ProjectScreen.css
@@ -215,19 +215,10 @@
 .ps-section .heat {
   margin-bottom: 24px;
 }
+/* Stands in for the heatmap; the shimmer itself is `.blk-skeleton`
+ * (Stats.css), so this only owns the gap to the stat row below. */
 .pulse-skeleton {
-  height: 128px;
   margin-bottom: 24px;
-  border-radius: var(--r-sm);
-  background: linear-gradient(90deg, var(--bg-2) 25%, var(--bg-3) 50%, var(--bg-2) 75%);
-  background-size: 200% 100%;
-  animation: stat-shimmer 1.2s linear infinite;
-  opacity: 0.5;
-}
-@media (prefers-reduced-motion: reduce) {
-  .pulse-skeleton {
-    animation: none;
-  }
 }
 .ps-section-t {
   font-weight: 600;

--- a/src/components/ProjectScreen/index.tsx
+++ b/src/components/ProjectScreen/index.tsx
@@ -4,12 +4,12 @@ import { loadRunOverrides, type SetupRow, toSetupRows } from "@/components/RunCo
 import { Loader } from "@/components/ui/Loader";
 import { useAppStore } from "@/store";
 import { basename } from "@/util/format";
+import { Activity } from "./Activity";
 import { DeleteSection } from "./DeleteSection";
 import { EnvVarsSection } from "./EnvVarsSection";
 import { GeneralSection } from "./GeneralSection";
 import { LinearSection } from "./LinearSection";
 import { ProjectHeader } from "./ProjectHeader";
-import { ProjectPulse } from "./ProjectPulse";
 import { Roadmap, useRoadmap } from "./Roadmap";
 import { RunEnvSection } from "./RunEnvSection";
 import { VerifySection } from "./VerifySection";
@@ -96,7 +96,7 @@ export function ProjectScreen({ repoPath }: { repoPath: string }) {
                 <Loader variant="inherit" /> Loading…
               </div>
             ) : tab === "activity" ? (
-              <ProjectPulse projectId={loaded.projectId} />
+              <Activity projectId={loaded.projectId} />
             ) : (
               <>
                 <GeneralSection projectId={loaded.projectId} currentName={name} />

--- a/src/components/Stats/ActivityHeatmap.tsx
+++ b/src/components/Stats/ActivityHeatmap.tsx
@@ -1,6 +1,7 @@
-import { type ReactNode, useMemo, useState } from "react";
+import { type ReactNode, useMemo } from "react";
 import { localDay } from "@/util/format";
 import { buildHeatmapWeeks, heatLevel, monthLabels } from "./heatmap";
+import { useHoverTip } from "./useHoverTip";
 
 interface Props {
   /** Activity count per local day (YYYY-MM-DD). Missing days are 0. */
@@ -17,12 +18,6 @@ interface Props {
   footer?: ReactNode;
 }
 
-interface Tip {
-  x: number;
-  y: number;
-  text: string;
-}
-
 /** GitHub-style contribution grid on the app's accent ramp. One cell per
  *  local day, columns are Monday-first weeks, intensity scales to the
  *  busiest day in range. Hover any cell for the exact counts. */
@@ -35,7 +30,7 @@ export function ActivityHeatmap({ counts, weeks = 52, endMs, tooltipFor, footer 
     [grid],
   );
   const today = localDay(end);
-  const [tip, setTip] = useState<Tip | null>(null);
+  const tip = useHoverTip();
 
   return (
     <div className="heat">
@@ -63,15 +58,8 @@ export function ActivityHeatmap({ counts, weeks = 52, endMs, tooltipFor, footer 
                     className={`heat-cell${cell.day === today ? " today" : ""}`}
                     data-level={heatLevel(cell.count, max)}
                     aria-label={tooltipFor(cell.day, cell.count)}
-                    onMouseEnter={(e) => {
-                      const r = e.currentTarget.getBoundingClientRect();
-                      setTip({
-                        x: r.left + r.width / 2,
-                        y: r.bottom + 6,
-                        text: tooltipFor(cell.day, cell.count),
-                      });
-                    }}
-                    onMouseLeave={() => setTip(null)}
+                    onMouseEnter={(e) => tip.show(e, tooltipFor(cell.day, cell.count))}
+                    onMouseLeave={tip.hide}
                   />
                 ) : (
                   <div key={cell.day} className="heat-cell out" />
@@ -91,15 +79,7 @@ export function ActivityHeatmap({ counts, weeks = 52, endMs, tooltipFor, footer 
           More
         </div>
       </div>
-      {tip && (
-        <div
-          className="heat-tip mono text-xs"
-          style={{ left: tip.x, top: tip.y }}
-          role="presentation"
-        >
-          {tip.text}
-        </div>
-      )}
+      {tip.node}
     </div>
   );
 }

--- a/src/components/Stats/MiniBars.tsx
+++ b/src/components/Stats/MiniBars.tsx
@@ -1,0 +1,100 @@
+import type { ReactNode } from "react";
+import { Skeleton } from "./Skeleton";
+import { useHoverTip } from "./useHoverTip";
+
+/** What the loaded chart occupies: the `--mb-h` grid (72px) plus the axis row
+ *  under it. Kept in sync by hand so the skeleton reserves the same space and
+ *  the section doesn't jump when the data lands. */
+const CHART_H = 92;
+
+/** One column of the chart. */
+export interface MiniBar {
+  key: string;
+  /** The plotted value. `null` means *no observation* — drawn as a baseline
+   *  tick rather than a zero-height bar, because "we never looked" and "there
+   *  was none" are different facts and a flat bar would state the second. */
+  value: number | null;
+  /** An optional larger value drawn behind `value` on the same scale, for the
+   *  part-of-whole case (PRs merged inside PRs opened). */
+  backdrop?: number | null;
+  /** Exact numbers for hover + aria — the readout that keeps the chart legible
+   *  without relying on bar height or color. */
+  tip: string;
+  /** Sparse x-axis label; omit or pass "" on the unlabeled majority. */
+  label?: string;
+}
+
+interface Props {
+  bars: MiniBar[];
+  /** Describes the series for screen readers, e.g. "Tokens used per day". */
+  ariaLabel: string;
+  /** The data hasn't arrived yet. Handled here rather than left to callers
+   *  because the obvious caller-side spelling — pass `[]` until it loads —
+   *  is indistinguishable from a genuinely empty series, so every chart would
+   *  flash its "nothing here" copy on the way to rendering fine. */
+  loading?: boolean;
+  /** Rendered in place of the grid when there is nothing to plot. */
+  empty?: ReactNode;
+  /** Legend / caption slot under the axis. */
+  footer?: ReactNode;
+}
+
+/** A compact column chart on the accent ramp: one bar per bucket, scaled to
+ *  the tallest value in range, exact figures on hover.
+ *
+ *  Deliberately axis-free apart from sparse tick labels — these sit inside a
+ *  page section under a headline stat row, where the shape over time is the
+ *  point and the precise numbers are one hover away. */
+export function MiniBars({ bars, ariaLabel, loading, empty, footer }: Props) {
+  const tip = useHoverTip();
+  const max = bars.reduce((m, b) => Math.max(m, b.value ?? 0, b.backdrop ?? 0), 0);
+
+  if (loading) return <Skeleton height={CHART_H} className="mb-skel" />;
+  // Nothing anywhere in range — every bucket is zero or unobserved. A grid of
+  // empty columns states that badly; say it in words instead.
+  if (empty !== undefined && max <= 0) {
+    return <div className="mb-empty text-sm">{empty}</div>;
+  }
+
+  // A bar rounds up to a visible sliver so a real-but-tiny value never renders
+  // as the same nothing a zero does.
+  const height = (v: number) => (v <= 0 ? 0 : Math.max(2, Math.round((v / max) * 100)));
+
+  return (
+    <div className="mb">
+      <div className="mb-grid" role="img" aria-label={ariaLabel}>
+        {bars.map((b) => (
+          <div
+            key={b.key}
+            className="mb-col"
+            aria-label={b.tip}
+            onMouseEnter={(e) => tip.show(e, b.tip)}
+            onMouseLeave={tip.hide}
+          >
+            <div className="mb-track">
+              {b.value == null ? (
+                <span className="mb-gap" />
+              ) : (
+                <>
+                  {b.backdrop != null && b.backdrop > 0 && (
+                    <span className="mb-bar back" style={{ height: `${height(b.backdrop)}%` }} />
+                  )}
+                  <span className="mb-bar" style={{ height: `${height(b.value)}%` }} />
+                </>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="mb-axis text-xs" aria-hidden="true">
+        {bars.map((b) => (
+          <span key={b.key} className="mb-tick">
+            {b.label ?? ""}
+          </span>
+        ))}
+      </div>
+      {footer && <div className="mb-foot text-xs">{footer}</div>}
+      {tip.node}
+    </div>
+  );
+}

--- a/src/components/Stats/Skeleton.tsx
+++ b/src/components/Stats/Skeleton.tsx
@@ -1,0 +1,13 @@
+/** A shimmer placeholder for a block that hasn't loaded.
+ *
+ *  `height` should match what lands in its place, so the page doesn't jump
+ *  when it does — which is the whole reason to prefer this over a spinner for
+ *  a known-size region. Sized by the caller because only the caller knows.
+ *
+ *  Its inline sibling is `.stat-shimmer` (Stat.tsx), for a single value inside
+ *  a line of text; both run off the same keyframes. */
+export function Skeleton({ height, className }: { height: number; className?: string }) {
+  return (
+    <div className={className ? `blk-skeleton ${className}` : "blk-skeleton"} style={{ height }} />
+  );
+}

--- a/src/components/Stats/Stats.css
+++ b/src/components/Stats/Stats.css
@@ -131,8 +131,10 @@
   margin-right: 3px;
 }
 
-/* Fixed-position so the modal's scroll container can't clip it. */
-.heat-tip {
+/* Shared by every chart mark here (see `useHoverTip`). Fixed-position so a
+ * scroll container — the modal, or the project page's `.ps-content` — can't
+ * clip it against the top of a tall bar. */
+.hover-tip {
   position: fixed;
   transform: translateX(-50%);
   z-index: var(--z-popover);
@@ -144,6 +146,108 @@
   white-space: nowrap;
   pointer-events: none;
   box-shadow: var(--shadow-2);
+}
+
+/* ── MiniBars: compact column chart, same accent ramp as the heatmap ──────
+ * Columns flex to fill the width so the grid's edges line up with the section
+ * around it; the bar inside each column is a fixed width, centered, so a
+ * 12-bucket and a 30-bucket chart read as the same kind of object rather than
+ * one looking like a block and the other like a comb. */
+.mb {
+  --mb-h: 72px;
+  margin-bottom: 20px;
+}
+.mb-grid {
+  display: flex;
+  align-items: flex-end;
+  gap: 3px;
+  height: var(--mb-h);
+}
+.mb-col {
+  flex: 1 1 0;
+  min-width: 0;
+  height: 100%;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+/* A proportion of the column rather than a fixed width, so a 12-bucket and a
+ * 30-bucket chart both land on a sane bar:gap ratio without either knowing how
+ * many buckets it has. The cap stops a short series turning into slabs. */
+.mb-track {
+  position: relative;
+  width: 72%;
+  max-width: 26px;
+  height: 100%;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+.mb-bar {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  border-radius: 2px;
+  background: var(--accent);
+  transition: filter 0.08s var(--ease);
+}
+/* The whole of which the foreground bar is a part (PRs opened behind PRs
+ * merged). Same hue, dropped toward the surface — a second accent-adjacent
+ * color would imply an unrelated series. */
+.mb-bar.back {
+  background: color-mix(in oklab, var(--accent) 26%, var(--bg-2));
+}
+/* No observation for this bucket — drawn as a faint full-height band, not a
+ * short mark. A mark near the baseline is exactly what a small value looks
+ * like, which is the one reading this must never invite; a band occupies the
+ * column without asserting a height, so "nothing recorded" and "recorded, and
+ * it was nearly nothing" stay visibly different. A real zero renders as an
+ * empty column, which is the honest picture of a measured zero. */
+.mb-gap {
+  width: 100%;
+  height: 100%;
+  border-radius: 2px;
+  background: var(--bg-2);
+}
+.mb-col:hover .mb-bar {
+  filter: brightness(1.15);
+}
+
+.mb-axis {
+  display: flex;
+  gap: 3px;
+  margin-top: 6px;
+  color: var(--fg-3);
+}
+.mb-tick {
+  flex: 1 1 0;
+  min-width: 0;
+  text-align: center;
+  white-space: nowrap;
+  overflow: visible;
+}
+.mb-foot {
+  margin-top: 10px;
+  color: var(--fg-3);
+}
+.mb-empty {
+  padding: 20px 14px;
+  margin-bottom: 20px;
+  color: var(--fg-3);
+  text-align: center;
+  border: 1px dashed var(--bd-soft);
+  border-radius: var(--r-sm);
+  line-height: 1.5;
+}
+/* Occupies the same vertical space as the chart it stands in for. */
+.mb-skel {
+  margin-bottom: 20px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mb-col:hover .mb-bar {
+    filter: none;
+  }
 }
 
 /* ── Stat strip: one text line of value–label pairs, detail on hover ── */
@@ -189,13 +293,24 @@
   background-size: 200% 100%;
   animation: stat-shimmer 1.2s linear infinite;
 }
+
+/* Block-level sibling of `.stat-shimmer`, for a whole region rather than one
+ * value in a line of text. Height comes from `<Skeleton>`'s caller. */
+.blk-skeleton {
+  border-radius: var(--r-sm);
+  background: linear-gradient(90deg, var(--bg-2) 25%, var(--bg-3) 50%, var(--bg-2) 75%);
+  background-size: 200% 100%;
+  animation: stat-shimmer 1.2s linear infinite;
+  opacity: 0.5;
+}
 @keyframes stat-shimmer {
   to {
     background-position: -200% 0;
   }
 }
 @media (prefers-reduced-motion: reduce) {
-  .stat-shimmer {
+  .stat-shimmer,
+  .blk-skeleton {
     animation: none;
   }
   .heat-grid .heat-cell:hover {

--- a/src/components/Stats/heatmap.ts
+++ b/src/components/Stats/heatmap.ts
@@ -82,12 +82,23 @@ export function computeStreak(counts: Record<string, number>, todayMs: number): 
   return streak;
 }
 
+/** A YYYY-MM-DD key as a local `Date`. Built from parts rather than parsed:
+ *  `new Date("2026-07-08")` is UTC midnight, which is the previous day for
+ *  anyone west of Greenwich. */
+const parseDay = (day: string): Date =>
+  new Date(Number(day.slice(0, 4)), Number(day.slice(5, 7)) - 1, Number(day.slice(8, 10)));
+
 /** "Tue, Jul 8" for a YYYY-MM-DD key, in the user's locale. */
 export function formatHeatDay(day: string): string {
-  const d = new Date(
-    Number(day.slice(0, 4)),
-    Number(day.slice(5, 7)) - 1,
-    Number(day.slice(8, 10)),
-  );
-  return d.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" });
+  return parseDay(day).toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/** "Jul 8" — the axis-tick form of `formatHeatDay`, without the weekday a
+ *  tick has no room for. */
+export function formatDayTick(day: string): string {
+  return parseDay(day).toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }

--- a/src/components/Stats/index.ts
+++ b/src/components/Stats/index.ts
@@ -1,3 +1,13 @@
 export { ActivityHeatmap } from "./ActivityHeatmap";
-export { buildHeatmapWeeks, computeStreak, formatHeatDay, heatLevel, monthLabels } from "./heatmap";
+export {
+  buildHeatmapWeeks,
+  computeStreak,
+  formatDayTick,
+  formatHeatDay,
+  heatLevel,
+  monthLabels,
+} from "./heatmap";
+export { type MiniBar, MiniBars } from "./MiniBars";
+export { Skeleton } from "./Skeleton";
 export { CountUp, Stat, useCountUp } from "./Stat";
+export { type HoverTip, useHoverTip } from "./useHoverTip";

--- a/src/components/Stats/useHoverTip.tsx
+++ b/src/components/Stats/useHoverTip.tsx
@@ -1,0 +1,48 @@
+import { type MouseEvent, type ReactNode, useCallback, useState } from "react";
+
+// A hover readout for chart marks. Every chart here encodes a value as an area
+// or a color, both of which are approximate by nature and unreadable to anyone
+// who can't distinguish the ramp — so each mark carries the exact numbers in
+// text, on hover and in its aria-label.
+//
+// Fixed-position rather than an absolutely-positioned child, so the page's
+// scroll container (`.ps-content`) can't clip it at the top of a tall bar.
+
+interface Tip {
+  x: number;
+  y: number;
+  text: string;
+}
+
+export interface HoverTip {
+  /** Anchor the tip under the hovered element. */
+  show: (e: MouseEvent<HTMLElement>, text: string) => void;
+  hide: () => void;
+  /** Render this at the end of the chart; null when nothing is hovered. */
+  node: ReactNode;
+}
+
+export function useHoverTip(): HoverTip {
+  const [tip, setTip] = useState<Tip | null>(null);
+
+  const show = useCallback((e: MouseEvent<HTMLElement>, text: string) => {
+    const r = e.currentTarget.getBoundingClientRect();
+    setTip({ x: r.left + r.width / 2, y: r.bottom + 6, text });
+  }, []);
+
+  const hide = useCallback(() => setTip(null), []);
+
+  return {
+    show,
+    hide,
+    node: tip ? (
+      <div
+        className="hover-tip mono text-xs"
+        style={{ left: tip.x, top: tip.y }}
+        role="presentation"
+      >
+        {tip.text}
+      </div>
+    ) : null,
+  };
+}

--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -22,8 +22,10 @@ export function firstLine(s: string, max = 56): string {
   return head.length > max ? `${head.slice(0, max - 1)}…` : head;
 }
 
-export function formatAge(iso: string, nowMs: number): string {
-  const t = new Date(iso).getTime();
+/** How long ago `at` was, at one scale ("now", "42m", "6h", "3d"). Accepts an
+ *  ISO string or an ms-epoch number — the app stores timestamps both ways. */
+export function formatAge(at: string | number, nowMs: number): string {
+  const t = typeof at === "number" ? at : new Date(at).getTime();
   if (Number.isNaN(t)) return "";
   const seconds = Math.max(0, Math.floor((nowMs - t) / 1000));
   if (seconds < 60) return "now";
@@ -51,6 +53,28 @@ export function localDay(ms: number): string {
   const d = new Date(ms);
   const p = (n: number) => String(n).padStart(2, "0");
   return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+}
+
+/** The local Monday of the week containing `ms`, as a `localDay` key. Anchored
+ *  at noon before stepping whole days, so a DST boundary can't land the result
+ *  on the wrong date (the same trick the heatmap grid uses). */
+export function weekStartDay(ms: number): string {
+  const d = new Date(ms);
+  d.setHours(12, 0, 0, 0);
+  d.setDate(d.getDate() - ((d.getDay() + 6) % 7));
+  return localDay(d.getTime());
+}
+
+/** A span of elapsed time at one significant scale: minutes under an hour,
+ *  hours under a day, then days. One decimal below 10 of a unit ("4.2h") so
+ *  short spans stay distinguishable, none above it ("14h"). */
+export function formatDuration(ms: number): string {
+  const minutes = Math.max(0, ms) / 60_000;
+  if (minutes < 60) return `${Math.round(minutes)}m`;
+  const hours = minutes / 60;
+  if (hours < 24) return `${hours.toFixed(hours < 10 ? 1 : 0)}h`;
+  const days = hours / 24;
+  return `${days.toFixed(days < 10 ? 1 : 0)}d`;
 }
 
 export function formatTokens(n: number): string {


### PR DESCRIPTION
Fills out the Activity tab, which shipped with a single section (the pulse heatmap plus lifetime totals). Adds the three surfaces that read data the app already persists but never displayed.

Frontend only — no migration, no Rust.

## Sections

**Time to merge** — median open→merge plus a 12-week opened-vs-merged trend, from `worktree_prs`. That table is append-only and was back-seeded by migration 0025, so unlike everything else here its history is complete rather than starting at install.

**Spend over time** — 30 days of per-day tokens. This is the first read of `usage_daily` anywhere in the codebase; it has been written since migration 0014 with no consumer.

**Recently shipped** — the last ten `done` roadmap items with PR links. Done items leave the board entirely, so without this the only trace of them is a number in the page header.

## Three judgement calls worth reviewing

**Cumulative snapshots.** `usage_daily` rows are running totals, so a day's spend is the difference between consecutive rows. Each workspace's **first** snapshot is skipped entirely — it is a total accrued over an unknown stretch before recording began, so attributing it to its day would invent a launch-day spike. Undercounting the first observation is the honest failure mode here.

**Gaps are not zeros.** A day nothing was recorded renders as a faint full-height band; a measured zero renders as an empty column. The first draft drew gaps as a baseline tick and that was wrong — a mark near the baseline is precisely what a small value looks like, which is the one reading this must not invite.

**No ship-rate chart.** `roadmap_items` has no `done_at` column. `updated_at` approximates ship time until any later edit overwrites it, which is acceptable for a *list* and not for a chart — a shipped-per-week chart would be quietly wrong rather than visibly approximate. Adding `done_at` is the follow-up if that metric is wanted.

## Reuse

Rather than two bespoke charts, `MiniBars` joins `Stats/` as a shared primitive. `useHoverTip` and `Skeleton` are extracted from logic already duplicated in `ActivityHeatmap` and `ProjectPulse`, which let me delete three near-identical shimmer CSS blocks and a hand-rolled PR pill (now the shared `Button`). `ProjectPulse`/`pulseData` move into the new `Activity/` folder — git tracks both as renames.

Queries and shaping are split: `derive.ts` is pure, so the cumulative-delta math, week bucketing across DST, and the none-vs-not-observed distinction are tested without a database.

## Two bugs caught in self-review

- Both charts **flashed their empty state on every load** — `bars=[]` while loading is indistinguishable from a genuinely empty series. Fixed by moving the loading state into `MiniBars` so no caller can get it wrong.
- `MergeTime` hid the chart whenever `merged === 0`, **discarding the opened-PR trend** — the most informative view for a project that has not landed anything yet.

Also note `.act-ship-pr` is scoped two classes deep deliberately: the height it overrides comes from `.btn-t.sm-t`, so a bare class loses on specificity regardless of import order.

## Verification

`npx tsc --noEmit` clean, `biome check` clean, **789 tests passing** (was 768 — 21 new), `bun run build` succeeds.

Layout, loading and empty states were checked visually by screenshotting the real compiled stylesheet in a static harness — that is how the bar-width and gap-marker problems were found rather than guessed. **Limit worth stating: that harness is not the running Tauri app, so the live queries have never executed against a real database.**

One deliberate gap: sections load once per `projectId` and do not refresh live, so a PR merging while the tab is open will not appear until you navigate away and back. That matches existing `ProjectPulse` behaviour, so it is not a regression — happy to subscribe them to the roadmap/PR events if wanted.