### PR TITLE
feat(roadmap): every item transition writes a durable history row

### DIFF
--- a/src-tauri/migrations/0030_roadmap_item_events.sql
+++ b/src-tauri/migrations/0030_roadmap_item_events.sql
@@ -1,0 +1,35 @@
+-- Durable history for roadmap items: one row per lifecycle transition.
+--
+-- Until now the only record of *why* an item moved was transient — the
+-- `roadmap:queue-note` event a card renders until the next tick, or a line in
+-- the PM chat. A failed run's reason vanished on reload; "when did this ship?"
+-- had no answer beyond `updated_at`, which any edit overwrites. This table is
+-- the durable object every later slice hangs off: decision cards, PM oversight
+-- digests, and `done_at` (the `shipped` event's timestamp).
+--
+-- Written exclusively by `roadmap::events::record`, in the same connection-lock
+-- scope as the item write it describes — every status transition writes exactly
+-- one event. `actor` is who moved the item (user | pm | drainer | sweep);
+-- `kind` is the transition's name; `detail` is the human-readable payload
+-- (a failure reason, a PR url, a workflow id) rendered on the card's history
+-- line.
+--
+-- ON DELETE CASCADE on `item_id` is deliberate: a deleted item was ruled off
+-- the board and needs no history, so its events go with it. `project_id` is
+-- denormalized so event listeners can filter to a board without a join.
+--
+-- Deliberately NOT added to the generic CRUD allow-list (`database::validate`),
+-- like `roadmap_items` itself: events must ride the typed write paths so they
+-- can never disagree with the transition they record.
+CREATE TABLE roadmap_item_events (
+    id         TEXT PRIMARY KEY,            -- uuid
+    item_id    TEXT NOT NULL REFERENCES roadmap_items(id) ON DELETE CASCADE,
+    project_id TEXT NOT NULL,
+    actor      TEXT NOT NULL,               -- user | pm | drainer | sweep
+    kind       TEXT NOT NULL,               -- see roadmap::events::EventKind
+    detail     TEXT,                        -- human-readable; NULL when the kind says it all
+    created_at INTEGER NOT NULL
+);
+
+-- Every read is "this item's history"; nothing queries events any other way.
+CREATE INDEX idx_roadmap_item_events_item ON roadmap_item_events(item_id);

--- a/src-tauri/src/database/connection.rs
+++ b/src-tauri/src/database/connection.rs
@@ -63,6 +63,7 @@ pub(crate) const MIGRATIONS: &[&str] = &[
     include_str!("../../migrations/0027_workspace_purpose.sql"),
     include_str!("../../migrations/0028_wf_run_roadmap_item.sql"),
     include_str!("../../migrations/0029_wf_run_pr.sql"),
+    include_str!("../../migrations/0030_roadmap_item_events.sql"),
 ];
 
 pub(crate) fn get_migrations() -> Migrations<'static> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1664,6 +1664,7 @@ pub fn run() {
             roadmap::roadmap_create_item,
             roadmap::roadmap_update_item,
             roadmap::roadmap_delete_item,
+            roadmap::roadmap_list_item_events,
             oauth::oauth_device_login,
             commands::get_workspace,
             commands::wf_run_agents,

--- a/src-tauri/src/roadmap/drainer.rs
+++ b/src-tauri/src/roadmap/drainer.rs
@@ -60,8 +60,9 @@ use serde::Serialize;
 use tauri::{AppHandle, Emitter};
 use tokio::sync::Notify;
 
+use super::events::{self, EventActor, EventKind, ItemEvent};
 use super::types::{ItemPatch, ItemStatus, RoadmapItem};
-use super::{emit_item, store, Db};
+use super::{emit_item, emit_item_event, store, Db};
 use crate::workflow::spec::{self, Spec};
 use crate::workflow::types::RunStatus;
 
@@ -264,6 +265,22 @@ pub(crate) fn settle(status: Option<RunStatus>, pr: Option<&FinalizedPr>) -> Set
         Some(RunStatus::Done) => Settlement::Done,
         Some(RunStatus::Failed) => Settlement::Released("its run failed"),
         Some(RunStatus::Canceled) => Settlement::Released("its run was canceled"),
+    }
+}
+
+/// The history event a settlement writes alongside its item patch — `None` for
+/// a run that is still going. The `run_failed` detail is the same reason string
+/// the transient queue note wraps, so the durable record and the toast never
+/// tell two stories; unlike the note, this one survives a reload.
+pub(crate) fn settlement_event(
+    outcome: &Settlement,
+    pr: Option<&FinalizedPr>,
+) -> Option<(EventKind, Option<String>)> {
+    match outcome {
+        Settlement::Running => None,
+        Settlement::InReview => Some((EventKind::PrOpened, pr.map(|p| p.url.clone()))),
+        Settlement::Done => Some((EventKind::Shipped, None)),
+        Settlement::Released(why) => Some((EventKind::RunFailed, Some((*why).to_string()))),
     }
 }
 
@@ -511,7 +528,12 @@ fn settle_project(app: &AppHandle, db: &Db, project_id: &str, said: &SaidNotes) 
                 ..Default::default()
             },
         };
-        write_item(app, db, &item.id, patch);
+        match settlement_event(&outcome, pr.as_ref()) {
+            Some((kind, detail)) => write_item_with_event(app, db, &item.id, patch, kind, detail),
+            // Unreachable — `Running` bailed above — but a settlement without
+            // an event must still land its patch rather than vanish.
+            None => write_item(app, db, &item.id, patch),
+        }
         match outcome {
             Settlement::Released(why) => {
                 tracing::info!(item = %item.code, %why, "roadmap drainer: released item");
@@ -600,8 +622,10 @@ enum Claim {
     Nothing,
     /// Something is queued but can't run yet, and the card should say why.
     Note(Box<RoadmapItem>, String),
-    /// An item was claimed (already `active`) and is ready to launch.
-    Claimed(Box<Plan>),
+    /// An item was claimed (already `active`) and is ready to launch. Carries
+    /// the `dispatched` history event recorded with the claim, so it can be
+    /// emitted once the lock is dropped.
+    Claimed(Box<Plan>, ItemEvent),
 }
 
 /// Decide what to dispatch for this project and *claim* it. Returns the plan
@@ -618,10 +642,11 @@ fn claim_next(app: &AppHandle, db: &Db, project_id: &str, said: &SaidNotes) -> O
             say(app, said, &item, &text);
             None
         }
-        Claim::Claimed(plan) => {
+        Claim::Claimed(plan, event) => {
             // Whatever was blocking this item no longer is.
             forget(said, &plan.item.id);
             emit_item(app, &plan.item);
+            emit_item_event(app, &event);
             Some(*plan)
         }
     }
@@ -702,39 +727,68 @@ fn plan_and_claim(conn: &Connection, project_id: &str) -> Claim {
         .collect();
     let brief = build_brief(&item, &dep_rows);
 
-    // The claim. Re-read under the same guard the decision was made under, so
-    // an unqueue that raced this tick either already landed (and the item was
+    // The claim. Runs under the same guard the decision was made under, so an
+    // unqueue that raced this tick either already landed (and the item was
     // never in `queued` above) or lands after, against an `active` row.
-    match store::get(conn, &item.id) {
-        Ok(Some(fresh)) if fresh.status == ItemStatus::Queued => {}
-        _ => return Claim::Nothing,
-    }
-    let claimed = store::update(
-        conn,
-        &item.id,
-        &ItemPatch {
-            status: Some(ItemStatus::Active),
-            // Pin the resolved definition on the item, so the card keeps
-            // showing what it actually ran under even if the project default
-            // moves afterwards.
-            workflow_def_id: Some(Some(definition_id.clone())),
-            ..Default::default()
-        },
-    );
-    match claimed {
-        Ok(Some(claimed)) => Claim::Claimed(Box::new(Plan {
-            item: claimed,
-            definition_id,
-            spec,
-            repo_path,
-            brief,
-        })),
+    match claim_item(conn, &item.id, &definition_id) {
+        Ok(Some((claimed, event))) => Claim::Claimed(
+            Box::new(Plan {
+                item: claimed,
+                definition_id,
+                spec,
+                repo_path,
+                brief,
+            }),
+            event,
+        ),
         Ok(None) => Claim::Nothing,
         Err(e) => {
             tracing::warn!(item = %item.code, error = %e, "roadmap drainer: claim failed");
             Claim::Nothing
         }
     }
+}
+
+/// Flip a picked item `queued → active`, pin the workflow it will run under,
+/// and record the `dispatched` history event — one lock-held sequence, so the
+/// claim and its record cannot disagree. `None` when the row moved (or went)
+/// between the pick and here: re-read first, so a racing unqueue is honoured
+/// rather than overwritten.
+fn claim_item(
+    conn: &Connection,
+    item_id: &str,
+    definition_id: &str,
+) -> rusqlite::Result<Option<(RoadmapItem, ItemEvent)>> {
+    match store::get(conn, item_id)? {
+        Some(fresh) if fresh.status == ItemStatus::Queued => {}
+        _ => return Ok(None),
+    }
+    let Some(claimed) = store::update(
+        conn,
+        item_id,
+        &ItemPatch {
+            status: Some(ItemStatus::Active),
+            // Pin the resolved definition on the item, so the card keeps
+            // showing what it actually ran under even if the project default
+            // moves afterwards.
+            workflow_def_id: Some(Some(definition_id.to_string())),
+            ..Default::default()
+        },
+    )?
+    else {
+        return Ok(None);
+    };
+    let event = events::record(
+        conn,
+        &claimed.id,
+        &claimed.project_id,
+        EventActor::Drainer,
+        EventKind::Dispatched,
+        // What it was dispatched under — the pinned definition id, the same
+        // fact `workflow_def_id` now carries.
+        Some(definition_id),
+    )?;
+    Ok(Some((claimed, event)))
 }
 
 /// Launch the claimed item's run. The only `.await` in the tick, and no DB
@@ -786,7 +840,11 @@ async fn dispatch(
             // The claim already flipped the item to `active`; nothing is going
             // to run, so hand it back rather than leaving a phantom.
             tracing::warn!(item = %item.code, error = %e, "roadmap drainer: launch failed");
-            write_item(
+            // One reason string for both channels: the transient note the card
+            // shows now, and the durable `run_failed` event that still says so
+            // after a reload.
+            let reason = format!("Couldn't start a run — {e}");
+            write_item_with_event(
                 app,
                 db,
                 &item.id,
@@ -794,13 +852,15 @@ async fn dispatch(
                     status: Some(ItemStatus::Open),
                     ..Default::default()
                 },
+                EventKind::RunFailed,
+                Some(reason.clone()),
             );
             emit_note(
                 app,
                 &QueueNote {
                     item_id: item.id.clone(),
                     code: item.code.clone(),
-                    note: format!("Couldn't start a run — {e}"),
+                    note: reason,
                 },
             );
         }
@@ -885,8 +945,9 @@ fn definition_spec(conn: &Connection, definition_id: &str) -> Option<Spec> {
     Some(spec)
 }
 
-/// Apply a patch and announce the row. Every drainer write goes through here,
-/// so nothing it changes can reach the database without reaching the board.
+/// Apply a patch and announce the row. Every drainer write goes through here
+/// (or [`write_item_with_event`]), so nothing it changes can reach the database
+/// without reaching the board.
 pub(crate) fn write_item(app: &AppHandle, db: &Db, id: &str, patch: ItemPatch) {
     let updated = {
         let conn = db.lock();
@@ -900,24 +961,59 @@ pub(crate) fn write_item(app: &AppHandle, db: &Db, id: &str, patch: ItemPatch) {
     }
 }
 
-/// [`write_item`], but only when the row is still in `expected` status — the
-/// transition-safe variant for a verdict decided *before* a wait. The merge
-/// sweep decides over a network read, so by write time the row may have moved
-/// (re-queued, re-dispatched); stamping a stale verdict over that would orphan
-/// the fresh work. A miss writes and announces nothing.
+/// [`write_item`] for a *transition*: the patch and the history event that
+/// names it land in one lock scope, then both are announced. Used for every
+/// drainer write that moves an item's status; link repairs and `run_id`
+/// write-backs stay on [`write_item`], because they are bookkeeping, not
+/// history.
+fn write_item_with_event(
+    app: &AppHandle,
+    db: &Db,
+    id: &str,
+    patch: ItemPatch,
+    kind: EventKind,
+    detail: Option<String>,
+) {
+    let updated = {
+        let conn = db.lock();
+        apply_and_record(&conn, id, None, &patch, EventActor::Drainer, kind, detail)
+    };
+    match updated {
+        Ok(Some((row, event))) => {
+            emit_item(app, &row);
+            emit_item_event(app, &event);
+        }
+        // The row was deleted mid-tick; its events cascaded with it.
+        Ok(None) => {}
+        Err(e) => tracing::warn!(id, error = %e, "roadmap drainer: item write failed"),
+    }
+}
+
+/// [`write_item_with_event`], but only when the row is still in `expected`
+/// status — the transition-safe variant for a verdict decided *before* a wait.
+/// The merge sweep decides over a network read, so by write time the row may
+/// have moved (re-queued, re-dispatched); stamping a stale verdict over that
+/// would orphan the fresh work. A miss writes and announces nothing — no row,
+/// and no event, because history for a write that lost its race would be false.
 pub(crate) fn write_item_where(
     app: &AppHandle,
     db: &Db,
     id: &str,
     expected: ItemStatus,
     patch: ItemPatch,
+    actor: EventActor,
+    kind: EventKind,
+    detail: Option<String>,
 ) {
     let updated = {
         let conn = db.lock();
-        store::update_where_status(&conn, id, expected, &patch)
+        apply_and_record(&conn, id, Some(expected), &patch, actor, kind, detail)
     };
     match updated {
-        Ok(Some(row)) => emit_item(app, &row),
+        Ok(Some((row, event))) => {
+            emit_item(app, &row);
+            emit_item_event(app, &event);
+        }
         // Deleted, or no longer in `expected` — either way the verdict is
         // stale and the row's current owner wins.
         Ok(None) => tracing::debug!(
@@ -926,6 +1022,36 @@ pub(crate) fn write_item_where(
         ),
         Err(e) => tracing::warn!(id, error = %e, "roadmap: item write failed"),
     }
+}
+
+/// The one lock-held write behind the event-carrying helpers: apply the
+/// (possibly conditional) patch, and record the event only when the patch
+/// actually landed — a miss must leave no trace anywhere.
+fn apply_and_record(
+    conn: &Connection,
+    id: &str,
+    expected: Option<ItemStatus>,
+    patch: &ItemPatch,
+    actor: EventActor,
+    kind: EventKind,
+    detail: Option<String>,
+) -> rusqlite::Result<Option<(RoadmapItem, ItemEvent)>> {
+    let updated = match expected {
+        Some(expected) => store::update_where_status(conn, id, expected, patch)?,
+        None => store::update(conn, id, patch)?,
+    };
+    let Some(row) = updated else {
+        return Ok(None);
+    };
+    let event = events::record(
+        conn,
+        &row.id,
+        &row.project_id,
+        actor,
+        kind,
+        detail.as_deref(),
+    )?;
+    Ok(Some((row, event)))
 }
 
 // ───────────────────────────── notes ────────────────────────────────────

--- a/src-tauri/src/roadmap/drainer.rs
+++ b/src-tauri/src/roadmap/drainer.rs
@@ -60,7 +60,7 @@ use serde::Serialize;
 use tauri::{AppHandle, Emitter};
 use tokio::sync::Notify;
 
-use super::events::{self, EventActor, EventKind, ItemEvent};
+use super::events::{self, EventActor, EventKind, ItemEvent, TrailEntry};
 use super::types::{ItemPatch, ItemStatus, RoadmapItem};
 use super::{emit_item, emit_item_event, store, Db};
 use crate::workflow::spec::{self, Spec};
@@ -1001,13 +1001,19 @@ pub(crate) fn write_item_where(
     id: &str,
     expected: ItemStatus,
     patch: ItemPatch,
-    actor: EventActor,
-    kind: EventKind,
-    detail: Option<String>,
+    entry: TrailEntry,
 ) {
     let updated = {
         let conn = db.lock();
-        apply_and_record(&conn, id, Some(expected), &patch, actor, kind, detail)
+        apply_and_record(
+            &conn,
+            id,
+            Some(expected),
+            &patch,
+            entry.actor,
+            entry.kind,
+            entry.detail,
+        )
     };
     match updated {
         Ok(Some((row, event))) => {

--- a/src-tauri/src/roadmap/drainer/tests.rs
+++ b/src-tauri/src/roadmap/drainer/tests.rs
@@ -339,6 +339,133 @@ fn recovery_adopts_only_a_live_run() {
     assert_eq!(dispatched_run_id(&conn, "id-FLT-999"), None);
 }
 
+// ───────────────────────────── durable history ──────────────────────────
+
+/// A project row for the FK, plus one roadmap item in `status`.
+fn db_item(conn: &Connection, status: ItemStatus) -> RoadmapItem {
+    conn.execute(
+        "INSERT OR IGNORE INTO projects (id, name, created_at) VALUES ('p1', 'fletch', 0)",
+        [],
+    )
+    .unwrap();
+    store::create(
+        conn,
+        "p1",
+        &crate::roadmap::types::NewItem {
+            title: "it".into(),
+            status: Some(status),
+            ..Default::default()
+        },
+    )
+    .unwrap()
+}
+
+#[test]
+fn each_settlement_names_its_event() {
+    let with_pr = pr(Some(42));
+    assert_eq!(settlement_event(&Settlement::Running, None), None);
+    assert_eq!(
+        settlement_event(&Settlement::InReview, Some(&with_pr)),
+        Some((EventKind::PrOpened, Some(with_pr.url.clone())))
+    );
+    assert_eq!(
+        settlement_event(&Settlement::Done, None),
+        Some((EventKind::Shipped, None))
+    );
+    // The durable detail is the same reason string the transient note wraps.
+    assert_eq!(
+        settlement_event(&Settlement::Released("its run failed"), None),
+        Some((EventKind::RunFailed, Some("its run failed".to_string())))
+    );
+}
+
+#[test]
+fn a_claim_records_one_dispatched_event_naming_the_workflow() {
+    let conn = test_conn();
+    let it = db_item(&conn, ItemStatus::Queued);
+
+    let (claimed, event) = claim_item(&conn, &it.id, "wf-1").unwrap().expect("claims");
+    assert_eq!(claimed.status, ItemStatus::Active);
+    assert_eq!(claimed.workflow_def_id.as_deref(), Some("wf-1"));
+    assert_eq!(event.kind, EventKind::Dispatched);
+    assert_eq!(event.actor, EventActor::Drainer);
+    assert_eq!(event.detail.as_deref(), Some("wf-1"));
+    assert_eq!(events::list_for_item(&conn, &it.id).unwrap(), vec![event]);
+
+    // A second claim finds the row no longer queued: no write, and no second
+    // event pretending there was one.
+    assert!(claim_item(&conn, &it.id, "wf-1").unwrap().is_none());
+    assert_eq!(events::list_for_item(&conn, &it.id).unwrap().len(), 1);
+}
+
+#[test]
+fn a_release_persists_its_reason_where_the_note_never_lands() {
+    // The card's toast ("Back on the board — its run failed.") is a transient
+    // `roadmap:queue-note`; nothing below asserts on it because nothing stores
+    // it — the schema has no note table at all, which is the second half of
+    // this pin. The durable record is the `run_failed` event, which a reload
+    // (any fresh read of the table) still finds.
+    let conn = test_conn();
+    let it = db_item(&conn, ItemStatus::Active);
+
+    let (row, event) = apply_and_record(
+        &conn,
+        &it.id,
+        None,
+        &ItemPatch {
+            status: Some(ItemStatus::Open),
+            run_id: Some(None),
+            ..Default::default()
+        },
+        EventActor::Drainer,
+        EventKind::RunFailed,
+        Some("its run failed".to_string()),
+    )
+    .unwrap()
+    .expect("the item is there to release");
+    assert_eq!(row.status, ItemStatus::Open);
+
+    let listed = events::list_for_item(&conn, &it.id).unwrap();
+    assert_eq!(listed, vec![event]);
+    assert_eq!(listed[0].kind, EventKind::RunFailed);
+    assert_eq!(listed[0].detail.as_deref(), Some("its run failed"));
+
+    // No table anywhere persists queue notes — the reason string's only durable
+    // home is the event above.
+    let note_tables: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name LIKE '%note%'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(note_tables, 0);
+}
+
+#[test]
+fn a_conditional_verdict_that_misses_records_nothing() {
+    // The sweep's path: the verdict was decided over a network read, and the
+    // row moved meanwhile. No patch lands, so no history may claim one did.
+    let conn = test_conn();
+    let it = db_item(&conn, ItemStatus::Queued);
+
+    let outcome = apply_and_record(
+        &conn,
+        &it.id,
+        Some(ItemStatus::InReview),
+        &ItemPatch {
+            status: Some(ItemStatus::Done),
+            ..Default::default()
+        },
+        EventActor::Sweep,
+        EventKind::Shipped,
+        None,
+    )
+    .unwrap();
+    assert!(outcome.is_none());
+    assert!(events::list_for_item(&conn, &it.id).unwrap().is_empty());
+}
+
 // ───────────────────────────── note dedup ───────────────────────────────
 
 #[test]

--- a/src-tauri/src/roadmap/events.rs
+++ b/src-tauri/src/roadmap/events.rs
@@ -1,0 +1,262 @@
+//! Durable item history: the `roadmap_item_events` DAO (migration 0030).
+//!
+//! Why this exists: everything else that explains an item's movement
+//! evaporates. The queue note is re-derived every tick and never stored, a
+//! toast dies with the render, and a chat line is buried in a transcript no
+//! surface re-reads. But "why did this run fail", "when did this ship"
+//! (`done_at` is the `shipped` event's timestamp) and "who ruled on this" are
+//! facts the decision cards, PM oversight digests, and standup all hang off —
+//! so every status transition writes exactly one row here, in the same
+//! connection-lock scope as the item write it describes, and the frontend
+//! follows along on `roadmap:item-event`.
+//!
+//! What deliberately does *not* land here: the drainer's re-derived-every-tick
+//! conditions (waiting on deps, no workflow, no repo). Persisting one of those
+//! per tick would bury the transitions in noise; they stay on the transient
+//! `roadmap:queue-note` channel. Only failures and transitions persist.
+//!
+//! Like `roadmap_items`, the table is absent from the generic CRUD allow-list:
+//! an event that didn't ride a typed write path could disagree with the
+//! transition it claims to record.
+
+use rusqlite::{params, Connection, Row};
+use serde::Serialize;
+
+use super::types::{enum_col, ItemStatus};
+use crate::database::now_millis;
+
+crate::db_enum! {
+    /// Who moved the item. The four writers of `roadmap_items`, by surface:
+    /// the typed commands (`user`), the propose RPC (`pm`), the queue drainer
+    /// (`drainer`), and the merge sweep (`sweep`).
+    EventActor {
+        User    => "user",
+        Pm      => "pm",
+        Drainer => "drainer",
+        Sweep   => "sweep",
+    }
+}
+
+crate::db_enum! {
+    /// What happened. One kind per transition, so a history line never has to
+    /// re-derive meaning from a status pair.
+    ///
+    /// `held` and `released` arrive with the holds slice (B5, see
+    /// .context/roadmap-pm-plan.md) — not declared here until they have a writer.
+    EventKind {
+        Proposed   => "proposed",
+        Accepted   => "accepted",
+        Discarded  => "discarded",
+        Edited     => "edited",
+        Queued     => "queued",
+        Unqueued   => "unqueued",
+        Dispatched => "dispatched",
+        PrOpened   => "pr_opened",
+        RunFailed  => "run_failed",
+        Shipped    => "shipped",
+        Abandoned  => "abandoned",
+        Blocked    => "blocked",
+        Note       => "note",
+    }
+}
+
+/// One history row, as the frontend sees it (`roadmap:item-event` and
+/// `roadmap_list_item_events` carry the same shape).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ItemEvent {
+    pub id: String,
+    pub item_id: String,
+    /// Denormalized off the item so board-scoped listeners filter without a join.
+    pub project_id: String,
+    pub actor: EventActor,
+    pub kind: EventKind,
+    /// Human-readable payload: a failure reason, a PR url, a workflow id.
+    pub detail: Option<String>,
+    pub created_at: i64,
+}
+
+const COLUMNS: &str = "id, item_id, project_id, actor, kind, detail, created_at";
+
+impl ItemEvent {
+    fn from_row(r: &Row) -> rusqlite::Result<Self> {
+        Ok(Self {
+            id: r.get("id")?,
+            item_id: r.get("item_id")?,
+            project_id: r.get("project_id")?,
+            actor: enum_col(r, "actor", EventActor::from_db)?,
+            kind: enum_col(r, "kind", EventKind::from_db)?,
+            detail: r.get("detail")?,
+            created_at: r.get("created_at")?,
+        })
+    }
+}
+
+/// Append one event and return the stored row, so the caller can emit it after
+/// the connection lock drops. Must be called with the lock held, in the same
+/// guard scope as the item write it records — that is what keeps the history
+/// and the row it describes from ever disagreeing.
+pub fn record(
+    conn: &Connection,
+    item_id: &str,
+    project_id: &str,
+    actor: EventActor,
+    kind: EventKind,
+    detail: Option<&str>,
+) -> rusqlite::Result<ItemEvent> {
+    let id = uuid::Uuid::new_v4().to_string();
+    let created_at = now_millis();
+    conn.execute(
+        &format!("INSERT INTO roadmap_item_events ({COLUMNS}) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)"),
+        params![
+            id,
+            item_id,
+            project_id,
+            actor.as_str(),
+            kind.as_str(),
+            detail,
+            created_at
+        ],
+    )?;
+    Ok(ItemEvent {
+        id,
+        item_id: item_id.to_string(),
+        project_id: project_id.to_string(),
+        actor,
+        kind,
+        detail: detail.map(str::to_string),
+        created_at,
+    })
+}
+
+/// One item's history, newest first — the order the card's disclosure renders.
+/// `rowid` breaks ties so two events in the same millisecond keep write order.
+pub fn list_for_item(conn: &Connection, item_id: &str) -> rusqlite::Result<Vec<ItemEvent>> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {COLUMNS} FROM roadmap_item_events WHERE item_id = ?1
+          ORDER BY created_at DESC, rowid DESC"
+    ))?;
+    let rows = stmt.query_map([item_id], ItemEvent::from_row)?;
+    rows.collect()
+}
+
+/// The history kind a user patch implies, from the transition it performs.
+///
+/// The typed commands express a transition as `expect_status` (where the row
+/// must still be) plus `patch.status` (where it goes), so the four named
+/// transitions the frontend performs are recognized from exactly those two —
+/// and every other applied patch is an `edited`, including an unconditional one
+/// that happens to move status (no UI does that today).
+pub(crate) fn transition_kind(expected: Option<ItemStatus>, to: Option<ItemStatus>) -> EventKind {
+    match (expected, to) {
+        (Some(ItemStatus::Proposed), Some(ItemStatus::Open)) => EventKind::Accepted,
+        (Some(ItemStatus::Open), Some(ItemStatus::Queued)) => EventKind::Queued,
+        (Some(ItemStatus::Queued), Some(ItemStatus::Open)) => EventKind::Unqueued,
+        (Some(ItemStatus::InReview), Some(ItemStatus::Done)) => EventKind::Shipped,
+        _ => EventKind::Edited,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::get_migrations;
+    use crate::roadmap::store;
+    use crate::roadmap::types::NewItem;
+
+    fn test_conn() -> Connection {
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        get_migrations().to_latest(&mut conn).unwrap();
+        conn.execute(
+            "INSERT INTO projects (id, name, created_at) VALUES ('p1', 'fletch', 0)",
+            [],
+        )
+        .unwrap();
+        conn
+    }
+
+    fn item(conn: &Connection) -> crate::roadmap::types::RoadmapItem {
+        store::create(
+            conn,
+            "p1",
+            &NewItem {
+                title: "one".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn events_round_trip_and_list_newest_first() {
+        let conn = test_conn();
+        let it = item(&conn);
+
+        let first = record(
+            &conn,
+            &it.id,
+            "p1",
+            EventActor::Pm,
+            EventKind::Proposed,
+            None,
+        )
+        .unwrap();
+        let second = record(
+            &conn,
+            &it.id,
+            "p1",
+            EventActor::Drainer,
+            EventKind::RunFailed,
+            Some("its run failed"),
+        )
+        .unwrap();
+
+        let listed = list_for_item(&conn, &it.id).unwrap();
+        // Newest first: the card's inline line is `listed[0]`.
+        assert_eq!(listed, vec![second.clone(), first]);
+        assert_eq!(listed[0].detail.as_deref(), Some("its run failed"));
+        assert_eq!(second.actor, EventActor::Drainer);
+        assert_eq!(second.kind, EventKind::RunFailed);
+    }
+
+    #[test]
+    fn deleting_an_item_takes_its_history() {
+        // Deletion writes no event on purpose: a deleted item was ruled off the
+        // board, and history for a row nothing can render is a leak, not a record.
+        let conn = test_conn();
+        let it = item(&conn);
+        record(
+            &conn,
+            &it.id,
+            "p1",
+            EventActor::User,
+            EventKind::Queued,
+            None,
+        )
+        .unwrap();
+        assert!(store::delete(&conn, &it.id).unwrap());
+        assert!(list_for_item(&conn, &it.id).unwrap().is_empty());
+    }
+
+    #[test]
+    fn the_user_transitions_map_to_their_kinds() {
+        use ItemStatus::{Done, InReview, Open, Proposed, Queued};
+        let cases = [
+            (Some(Proposed), Some(Open), EventKind::Accepted),
+            (Some(Open), Some(Queued), EventKind::Queued),
+            (Some(Queued), Some(Open), EventKind::Unqueued),
+            (Some(InReview), Some(Done), EventKind::Shipped),
+            // A form edit: no precondition, no status move.
+            (None, None, EventKind::Edited),
+            // A conditional edit that isn't one of the four transitions.
+            (Some(Open), None, EventKind::Edited),
+        ];
+        for (expected, to, kind) in cases {
+            assert_eq!(
+                transition_kind(expected, to),
+                kind,
+                "{expected:?} -> {to:?}"
+            );
+        }
+    }
+}

--- a/src-tauri/src/roadmap/events.rs
+++ b/src-tauri/src/roadmap/events.rs
@@ -77,6 +77,15 @@ pub struct ItemEvent {
 
 const COLUMNS: &str = "id, item_id, project_id, actor, kind, detail, created_at";
 
+/// What one transition writes to the trail: who moved the item, what happened,
+/// and the human-readable payload. Travels as one value so a write helper's
+/// signature names the transition rather than three loose fields.
+pub(crate) struct TrailEntry {
+    pub actor: EventActor,
+    pub kind: EventKind,
+    pub detail: Option<String>,
+}
+
 impl ItemEvent {
     fn from_row(r: &Row) -> rusqlite::Result<Self> {
         Ok(Self {

--- a/src-tauri/src/roadmap/merge_sweep.rs
+++ b/src-tauri/src/roadmap/merge_sweep.rs
@@ -53,6 +53,7 @@ use tauri::AppHandle;
 use tokio::sync::Notify;
 
 use super::drainer::{self, QueueNote};
+use super::events::{EventActor, EventKind};
 use super::types::{ItemPatch, ItemStatus, RoadmapItem};
 use super::Db;
 use crate::github::PrStatus;
@@ -151,10 +152,25 @@ pub(crate) fn patch_for(verdict: &Verdict) -> Option<ItemPatch> {
     }
 }
 
+/// The history event a verdict writes alongside its patch — the durable half of
+/// the answer, paired with [`patch_for`] (`None` exactly when that is). The
+/// `shipped` event's timestamp is the item's `done_at`.
+pub(crate) fn event_for(verdict: &Verdict) -> Option<(EventKind, Option<String>)> {
+    match verdict {
+        Verdict::Waiting => None,
+        Verdict::Landed => Some((EventKind::Shipped, None)),
+        Verdict::Abandoned => Some((
+            EventKind::Abandoned,
+            Some("PR closed without merging".to_string()),
+        )),
+    }
+}
+
 /// What the board is told when a PR is closed unmerged. Nothing persists it —
 /// same transient `roadmap:queue-note` channel the drainer explains a stuck
 /// queue on, for the same reason: it is true until the user does something
-/// about it, and the row's own next change supersedes it.
+/// about it, and the row's own next change supersedes it. The durable record is
+/// the `abandoned` event [`event_for`] pairs with the same verdict.
 pub(crate) fn abandoned_note(number: i64) -> String {
     format!("PR #{number} was closed without merging — back on the board.")
 }
@@ -275,11 +291,24 @@ async fn sweep(app: &AppHandle, db: &Db, watching: Vec<Watched>) {
         let Some(patch) = patch_for(&outcome) else {
             continue;
         };
+        // `patch_for` and `event_for` are `Some` for exactly the same verdicts;
+        // the expect documents that rather than inventing a fallback event.
+        let (kind, detail) = event_for(&outcome).expect("a verdict that writes also records");
         tracing::info!(item = %w.code, pr = w.number, ?outcome, "roadmap merge sweep");
         // Conditional on the row still being in review: the verdict was decided
         // over a network read, and a row the user moved meanwhile (marked done
-        // by hand, re-queued after a delete) must not be stamped over.
-        drainer::write_item_where(app, db, &w.id, ItemStatus::InReview, patch);
+        // by hand, re-queued after a delete) must not be stamped over. A miss
+        // records no event either — the row's current owner writes its own.
+        drainer::write_item_where(
+            app,
+            db,
+            &w.id,
+            ItemStatus::InReview,
+            patch,
+            EventActor::Sweep,
+            kind,
+            detail,
+        );
         match outcome {
             Verdict::Landed => {
                 // The item is `done`, which is what a dependant's dep gate is

--- a/src-tauri/src/roadmap/merge_sweep.rs
+++ b/src-tauri/src/roadmap/merge_sweep.rs
@@ -53,7 +53,7 @@ use tauri::AppHandle;
 use tokio::sync::Notify;
 
 use super::drainer::{self, QueueNote};
-use super::events::{EventActor, EventKind};
+use super::events::{EventActor, EventKind, TrailEntry};
 use super::types::{ItemPatch, ItemStatus, RoadmapItem};
 use super::Db;
 use crate::github::PrStatus;
@@ -305,9 +305,11 @@ async fn sweep(app: &AppHandle, db: &Db, watching: Vec<Watched>) {
             &w.id,
             ItemStatus::InReview,
             patch,
-            EventActor::Sweep,
-            kind,
-            detail,
+            TrailEntry {
+                actor: EventActor::Sweep,
+                kind,
+                detail,
+            },
         );
         match outcome {
             Verdict::Landed => {

--- a/src-tauri/src/roadmap/merge_sweep/tests.rs
+++ b/src-tauri/src/roadmap/merge_sweep/tests.rs
@@ -113,6 +113,27 @@ fn a_failed_read_changes_nothing_either() {
     assert!(patch_for(&verdict(None)).is_none());
 }
 
+// ───────────────────────────── the history event ────────────────────────
+
+#[test]
+fn a_verdict_writes_and_records_together_or_not_at_all() {
+    // `event_for` pairs `patch_for` verdict by verdict: whatever writes the
+    // board also writes the durable record, and a verdict that touches nothing
+    // records nothing. The `shipped` event's timestamp is the item's `done_at`.
+    assert!(event_for(&Verdict::Waiting).is_none());
+    assert_eq!(
+        event_for(&Verdict::Landed),
+        Some((EventKind::Shipped, None))
+    );
+    assert_eq!(
+        event_for(&Verdict::Abandoned),
+        Some((
+            EventKind::Abandoned,
+            Some("PR closed without merging".to_string())
+        ))
+    );
+}
+
 // ───────────────────────────── the note ─────────────────────────────────
 
 #[test]

--- a/src-tauri/src/roadmap/mod.rs
+++ b/src-tauri/src/roadmap/mod.rs
@@ -17,9 +17,13 @@
 //!   agent's RPC, the queue drainer) updates the board without a refetch.
 //! - `roadmap:item-deleted` — the deleted row's id, so the board drops it
 //!   instead of upserting it.
+//! - `roadmap:item-event` — one durable history row ([`events`]), on every
+//!   status transition. The expanded card renders the trail; `roadmap:item`
+//!   already carries the row itself, so this only carries the *why*.
 //! - `roadmap:queue-note` — transient: why an item isn't moving on its own.
 //!   From [`drainer`] (a queued item's blocker) and [`merge_sweep`] (a PR that
 //!   closed without merging). Nothing persists it; see the drainer's docs.
+//!   Failures and transitions, by contrast, persist as [`events`] rows.
 //!
 //! Autonomous dispatch lives in [`drainer`]: `queued` items become running
 //! workflows there, and every mutation on this surface [`drainer::nudge`]s it so
@@ -31,6 +35,7 @@
 //! with the window shut.
 
 pub mod drainer;
+pub mod events;
 pub mod merge_sweep;
 pub mod store;
 pub mod types;
@@ -41,6 +46,7 @@ use parking_lot::Mutex;
 use rusqlite::Connection;
 use tauri::{AppHandle, Emitter};
 
+use events::{EventActor, ItemEvent};
 use types::{ItemPatch, ItemStatus, ItemUpdate, NewItem, RoadmapItem};
 
 /// The app's single connection. Public because the PM agent's RPC dispatcher
@@ -56,6 +62,13 @@ pub(crate) fn emit_item(app: &AppHandle, item: &RoadmapItem) {
 /// Notify the frontend that an item was deleted, so the board drops the row.
 fn emit_item_deleted(app: &AppHandle, id: &str) {
     let _ = app.emit("roadmap:item-deleted", id);
+}
+
+/// Notify the frontend that a history row landed; carries the full event so an
+/// expanded card appends it without a refetch. Best-effort, after the lock
+/// drops, like every other emit here.
+pub(crate) fn emit_item_event(app: &AppHandle, event: &ItemEvent) {
+    let _ = app.emit("roadmap:item-event", event);
 }
 
 /// Every item on a project's roadmap, oldest first. Includes `done` items — the
@@ -114,41 +127,18 @@ pub async fn roadmap_update_item(
     app: AppHandle,
     db: tauri::State<'_, Db>,
 ) -> Result<ItemUpdate, String> {
-    let outcome = {
+    let (outcome, event) = {
         let conn = db.lock();
-        match expect_status {
-            Some(expected) => {
-                match store::update_where_status(&conn, &id, expected, &patch)
-                    .map_err(|e| e.to_string())?
-                {
-                    Some(item) => Some(ItemUpdate {
-                        applied: true,
-                        item,
-                    }),
-                    // Missed the precondition. Read the current row under the
-                    // same guard the failed update ran in, so what the caller
-                    // gets back is the state that beat it.
-                    None => store::get(&conn, &id)
-                        .map_err(|e| e.to_string())?
-                        .map(|item| ItemUpdate {
-                            applied: false,
-                            item,
-                        }),
-                }
-            }
-            None => store::update(&conn, &id, &patch)
-                .map_err(|e| e.to_string())?
-                .map(|item| ItemUpdate {
-                    applied: true,
-                    item,
-                }),
-        }
+        update_and_record(&conn, &id, &patch, expect_status).map_err(|e| e.to_string())?
     };
     let outcome = outcome.ok_or_else(|| format!("roadmap item {id} no longer exists"))?;
     // A miss changed nothing, so there is nothing to announce and nothing new
     // for either background task to look at.
     if outcome.applied {
         emit_item(&app, &outcome.item);
+        if let Some(event) = &event {
+            emit_item_event(&app, event);
+        }
         drainer::nudge();
         // The sweep parks while nothing is in review, and the drainer's
         // settlement is otherwise its only alarm clock — a patch that leaves a
@@ -161,8 +151,67 @@ pub async fn roadmap_update_item(
     Ok(outcome)
 }
 
+/// The one write behind [`roadmap_update_item`]: apply the (possibly
+/// conditional) patch and, when it actually lands, record the history event the
+/// transition implies — both under the caller's single lock scope, so the event
+/// can never describe a write that lost a race.
+///
+/// The event is `Some` exactly when the update applied: a missed precondition
+/// wrote nothing, so there is no history to invent for it — the applied /
+/// not-applied contract is untouched. Outer `None` means the row is gone.
+fn update_and_record(
+    conn: &Connection,
+    id: &str,
+    patch: &ItemPatch,
+    expect_status: Option<ItemStatus>,
+) -> rusqlite::Result<(Option<ItemUpdate>, Option<ItemEvent>)> {
+    let updated = match expect_status {
+        Some(expected) => store::update_where_status(conn, id, expected, patch)?,
+        None => store::update(conn, id, patch)?,
+    };
+    match updated {
+        Some(item) => {
+            let kind = events::transition_kind(expect_status, patch.status);
+            let event = events::record(
+                conn,
+                &item.id,
+                &item.project_id,
+                // This surface is the frontend's door; the other writers (PM
+                // RPC, drainer, sweep) record under their own actors.
+                EventActor::User,
+                kind,
+                None,
+            )?;
+            Ok((
+                Some(ItemUpdate {
+                    applied: true,
+                    item,
+                }),
+                Some(event),
+            ))
+        }
+        // Missed the precondition (or the row is gone). Read the current row
+        // under the same guard the failed update ran in, so what the caller
+        // gets back is the state that beat it.
+        None => match expect_status {
+            Some(_) => Ok((
+                store::get(conn, id)?.map(|item| ItemUpdate {
+                    applied: false,
+                    item,
+                }),
+                None,
+            )),
+            None => Ok((None, None)),
+        },
+    }
+}
+
 /// Delete an item. Silent when the row is already gone — the caller's intent
 /// ("this should not be on the board") is satisfied either way.
+///
+/// Deletion records no history event on purpose: `roadmap_item_events` cascades
+/// with the row, so a deleted item (including a discarded proposal) takes its
+/// trail with it — an item ruled off the board needs no history.
 #[tauri::command]
 pub async fn roadmap_delete_item(
     id: String,
@@ -180,4 +229,115 @@ pub async fn roadmap_delete_item(
         drainer::nudge();
     }
     Ok(())
+}
+
+/// One item's durable history, newest first. Fetched lazily by the board on
+/// first card expand; live rows arrive on `roadmap:item-event`.
+#[tauri::command]
+pub async fn roadmap_list_item_events(
+    item_id: String,
+    db: tauri::State<'_, Db>,
+) -> Result<Vec<ItemEvent>, String> {
+    let conn = db.lock();
+    events::list_for_item(&conn, &item_id).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::get_migrations;
+    use events::EventKind;
+    use types::NewItem;
+
+    fn test_conn() -> Connection {
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        get_migrations().to_latest(&mut conn).unwrap();
+        conn.execute(
+            "INSERT INTO projects (id, name, created_at) VALUES ('p1', 'fletch', 0)",
+            [],
+        )
+        .unwrap();
+        conn
+    }
+
+    fn with_status(conn: &Connection, status: ItemStatus) -> RoadmapItem {
+        store::create(
+            conn,
+            "p1",
+            &NewItem {
+                title: "it".into(),
+                status: Some(status),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+    }
+
+    fn status_patch(to: ItemStatus) -> ItemPatch {
+        ItemPatch {
+            status: Some(to),
+            ..Default::default()
+        }
+    }
+
+    /// Every user transition the board performs writes exactly one event of the
+    /// right kind, attributed to the user.
+    #[test]
+    fn each_user_transition_writes_exactly_one_event() {
+        use ItemStatus::{Done, InReview, Open, Proposed, Queued};
+        let conn = test_conn();
+        let cases = [
+            (Proposed, Open, EventKind::Accepted),
+            (Open, Queued, EventKind::Queued),
+            (Queued, Open, EventKind::Unqueued),
+            (InReview, Done, EventKind::Shipped),
+        ];
+        for (from, to, kind) in cases {
+            let it = with_status(&conn, from);
+            let (outcome, event) =
+                update_and_record(&conn, &it.id, &status_patch(to), Some(from)).unwrap();
+            assert!(outcome.unwrap().applied);
+            let event = event.expect("an applied transition records itself");
+            assert_eq!(event.kind, kind);
+            assert_eq!(event.actor, EventActor::User);
+            assert_eq!(event.detail, None);
+            assert_eq!(events::list_for_item(&conn, &it.id).unwrap(), vec![event]);
+        }
+    }
+
+    /// A missed precondition writes nothing — not the row, and not history. The
+    /// applied/not-applied contract is what the frontend's races lean on, and an
+    /// event for a write that never happened would be a lie on the card.
+    #[test]
+    fn a_missed_precondition_records_nothing() {
+        let conn = test_conn();
+        let it = with_status(&conn, ItemStatus::Active);
+        let (outcome, event) = update_and_record(
+            &conn,
+            &it.id,
+            &status_patch(ItemStatus::Open),
+            Some(ItemStatus::Queued),
+        )
+        .unwrap();
+        let outcome = outcome.unwrap();
+        assert!(!outcome.applied);
+        assert_eq!(outcome.item.status, ItemStatus::Active);
+        assert!(event.is_none());
+        assert!(events::list_for_item(&conn, &it.id).unwrap().is_empty());
+    }
+
+    /// Any other applied patch is an `edited` — the catch-all that keeps "every
+    /// transition writes exactly one event" true for the form too.
+    #[test]
+    fn a_plain_edit_records_edited() {
+        let conn = test_conn();
+        let it = with_status(&conn, ItemStatus::Open);
+        let patch = ItemPatch {
+            title: Some("retitled".into()),
+            ..Default::default()
+        };
+        let (_, event) = update_and_record(&conn, &it.id, &patch, None).unwrap();
+        assert_eq!(event.unwrap().kind, EventKind::Edited);
+    }
 }

--- a/src-tauri/src/roadmap/types.rs
+++ b/src-tauri/src/roadmap/types.rs
@@ -225,8 +225,9 @@ fn strings_col(r: &Row, col: &str) -> rusqlite::Result<Vec<String>> {
     }
 }
 
-/// Parse a required enum TEXT column via its `from_db`.
-fn enum_col<T>(r: &Row, col: &str, parse: fn(&str) -> Option<T>) -> rusqlite::Result<T> {
+/// Parse a required enum TEXT column via its `from_db`. Shared with
+/// [`super::events`], whose rows carry the same kind of column.
+pub(crate) fn enum_col<T>(r: &Row, col: &str, parse: fn(&str) -> Option<T>) -> rusqlite::Result<T> {
     let raw: String = r.get(col)?;
     parse(&raw).ok_or_else(|| conversion_err(col, format!("unexpected value {raw:?}")))
 }

--- a/src-tauri/src/rpc/roadmap.rs
+++ b/src-tauri/src/rpc/roadmap.rs
@@ -30,6 +30,7 @@ use serde::Deserialize;
 use serde_json::{json, Map, Value};
 use tauri::AppHandle;
 
+use crate::roadmap::events::{self, EventActor, EventKind, ItemEvent};
 use crate::roadmap::store;
 use crate::roadmap::types::{Horizon, ItemSource, ItemStatus, NewItem, RoadmapItem};
 use crate::roadmap::Db;
@@ -276,17 +277,19 @@ fn validate(items: &[ProposedItem], known: &HashSet<&str>) -> Result<Vec<NewItem
 /// `roadmap_propose`: validate the batch, insert it as `proposed` rows in one
 /// transaction, and hand back the allocated codes.
 ///
-/// Returns the created rows alongside the response so the caller can announce
-/// each one to the frontend — the board grows ghost rows live, mid-conversation.
+/// Returns the created rows — and the `proposed` history events recorded with
+/// them — alongside the response so the caller can announce both to the
+/// frontend: the board grows ghost rows live, mid-conversation.
 fn propose_op(
     conn: &Connection,
     project_id: &str,
     id: &str,
     args: &Value,
-) -> (Response, Vec<RoadmapItem>) {
+) -> (Response, Vec<RoadmapItem>, Vec<ItemEvent>) {
     let err = |msg: String| {
         (
             Response::err(id, format!("roadmap_propose: {msg}")),
+            Vec::new(),
             Vec::new(),
         )
     };
@@ -306,17 +309,29 @@ fn propose_op(
     };
 
     // All or nothing: a failure half-way through must not leave the user
-    // staring at three of the five tickets they were promised.
-    let created = (|| -> rusqlite::Result<Vec<RoadmapItem>> {
+    // staring at three of the five tickets they were promised. Each row's
+    // `proposed` history event rides the same transaction, so a ghost can never
+    // exist without the record of who suggested it.
+    let created = (|| -> rusqlite::Result<(Vec<RoadmapItem>, Vec<ItemEvent>)> {
         let tx = conn.unchecked_transaction()?;
         let mut created = Vec::with_capacity(news.len());
+        let mut recorded = Vec::with_capacity(news.len());
         for new in &news {
-            created.push(store::create(&tx, project_id, new)?);
+            let item = store::create(&tx, project_id, new)?;
+            recorded.push(events::record(
+                &tx,
+                &item.id,
+                project_id,
+                EventActor::Pm,
+                EventKind::Proposed,
+                None,
+            )?);
+            created.push(item);
         }
         tx.commit()?;
-        Ok(created)
+        Ok((created, recorded))
     })();
-    let created = match created {
+    let (created, recorded) = match created {
         Ok(created) => created,
         Err(e) => return err(e.to_string()),
     };
@@ -328,12 +343,17 @@ fn propose_op(
             .collect::<Vec<_>>(),
     });
     match serde_json::to_string(&payload) {
-        Ok(stdout) => (Response::ok(id, 0, stdout, String::new()), created),
+        Ok(stdout) => (
+            Response::ok(id, 0, stdout, String::new()),
+            created,
+            recorded,
+        ),
         // The rows exist either way — say so rather than implying nothing
         // happened, and still emit them.
         Err(e) => (
             Response::err(id, format!("roadmap_propose: created, but {e}")),
             created,
+            recorded,
         ),
     }
 }
@@ -388,13 +408,16 @@ impl RpcDispatcher for RoadmapDispatcher {
                 "roadmap_propose" => {
                     // Lock held only for the validate+insert; the emits happen
                     // after it is dropped.
-                    let (resp, created) = {
+                    let (resp, created, recorded) = {
                         let conn = self.db.lock();
                         propose_op(&conn, &self.project_id, id, args)
                     };
                     if let Some(app) = &self.app {
                         for item in &created {
                             crate::roadmap::emit_item(app, item);
+                        }
+                        for event in &recorded {
+                            crate::roadmap::emit_item_event(app, event);
                         }
                     }
                     (resp, Vec::new())
@@ -501,6 +524,12 @@ mod tests {
             // wrote it.
             assert_eq!(row.status, ItemStatus::Proposed);
             assert_eq!(row.source, ItemSource::Pm);
+            // Each proposal starts its durable history: one `proposed` event,
+            // attributed to the PM.
+            let history = events::list_for_item(&db.lock(), &row.id).unwrap();
+            assert_eq!(history.len(), 1);
+            assert_eq!(history[0].kind, EventKind::Proposed);
+            assert_eq!(history[0].actor, EventActor::Pm);
         }
         assert_eq!(rows[0].horizon, Horizon::Now);
         assert_eq!(rows[0].accept, vec!["it drains".to_string()]);

--- a/src/api/domains/roadmap.ts
+++ b/src/api/domains/roadmap.ts
@@ -3,6 +3,7 @@ import type {
   ItemStatus,
   NewRoadmapItem,
   RoadmapItem,
+  RoadmapItemEvent,
   RoadmapItemPatch,
   RoadmapItemUpdate,
 } from "../types/roadmap";
@@ -39,4 +40,8 @@ export const roadmapApi = {
     }),
   /** Remove an item from the board. */
   roadmapDeleteItem: (id: string) => invoke<void>("roadmap_delete_item", { id }),
+  /** One item's durable history, newest first. Fetched lazily on first card
+   *  expand; live rows arrive on `roadmap:item-event`. */
+  roadmapListItemEvents: (itemId: string) =>
+    invoke<RoadmapItemEvent[]>("roadmap_list_item_events", { itemId }),
 };

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -14,7 +14,7 @@ import type {
 } from "./types/agent";
 import type { PrStateChangedEvent } from "./types/pr";
 import type { AgentInstallEvent } from "./types/providers";
-import type { RoadmapItem, RoadmapQueueNote } from "./types/roadmap";
+import type { RoadmapItem, RoadmapItemEvent, RoadmapQueueNote } from "./types/roadmap";
 import type { RunOutputEvent, RunPortEvent, RunStateEvent } from "./types/run";
 import type { DockerBuildEvent, PublishApproval } from "./types/sandbox";
 import type {
@@ -52,6 +52,15 @@ export function onRoadmapItem(cb: (item: RoadmapItem) => void): Promise<Unlisten
  *  row instead of upserting it. */
 export function onRoadmapItemDeleted(cb: (id: string) => void): Promise<UnlistenFn> {
   return listen<string>("roadmap:item-deleted", (event) => cb(event.payload));
+}
+
+/** `roadmap:item-event` fires when a durable history row lands — one per status
+ *  transition, carrying the full event. The board appends it to an expanded
+ *  card's trail; anything missed is refetched on the next expand
+ *  (`roadmap_list_item_events`), so a listener that wasn't mounted loses
+ *  nothing. */
+export function onRoadmapItemEvent(cb: (e: RoadmapItemEvent) => void): Promise<UnlistenFn> {
+  return listen<RoadmapItemEvent>("roadmap:item-event", (event) => cb(event.payload));
 }
 
 /** `roadmap:queue-note` explains why an item isn't moving — no workflow to run

--- a/src/api/types/roadmap.ts
+++ b/src/api/types/roadmap.ts
@@ -78,6 +78,46 @@ export interface RoadmapQueueNote {
   note: string;
 }
 
+/** Who moved an item — the four writers of `roadmap_items`, by surface: the
+ *  typed commands (`user`), the propose RPC (`pm`), the queue drainer
+ *  (`drainer`), and the merge sweep (`sweep`). */
+export type RoadmapEventActor = "user" | "pm" | "drainer" | "sweep";
+
+/** What happened to an item — one kind per transition, so a history line never
+ *  re-derives meaning from a status pair. `held`/`released` arrive with the
+ *  holds slice (B5). */
+export type RoadmapEventKind =
+  | "proposed"
+  | "accepted"
+  | "discarded"
+  | "edited"
+  | "queued"
+  | "unqueued"
+  | "dispatched"
+  | "pr_opened"
+  | "run_failed"
+  | "shipped"
+  | "abandoned"
+  | "blocked"
+  | "note";
+
+/** One durable history row (`roadmap_item_events`, mirroring
+ *  src-tauri/src/roadmap/events.rs). Every status transition writes exactly
+ *  one; unlike the queue note, these survive a reload — a failed run's reason
+ *  is still on the card tomorrow. */
+export interface RoadmapItemEvent {
+  id: string;
+  item_id: string;
+  /** Denormalized off the item so a board-scoped listener filters without
+   *  holding the row. */
+  project_id: string;
+  actor: RoadmapEventActor;
+  kind: RoadmapEventKind;
+  /** Human-readable payload: a failure reason, a PR url, a workflow id. */
+  detail: string | null;
+  created_at: number;
+}
+
 /** The result of a patch: the stored row, and whether this patch is what stored
  *  it.
  *

--- a/src/components/ProjectScreen/Roadmap/Board/ItemCard.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/ItemCard.tsx
@@ -1,7 +1,11 @@
 import { open as openExternal } from "@tauri-apps/plugin-shell";
+import { useState } from "react";
+import type { RoadmapItemEvent } from "@/api";
 import { Icon, type IconName } from "@/components/Icon";
 import { Button } from "@/components/ui/Button";
 import { useAppStore } from "@/store";
+import { formatAge } from "@/util/format";
+import { eventLine } from "../itemHistory";
 import type { BoardItem, ItemSource, ItemStatus } from "../types";
 
 /** Where the item came from, as a one-glyph tag. */
@@ -63,6 +67,9 @@ interface Props {
    *  a queued row is stuck, or the merge sweep's "PR #N was closed without
    *  merging" for one that came back off review. */
   note?: string;
+  /** The item's durable history, newest first — fetched lazily on first expand
+   *  (see `useRoadmap.loadEvents`), so it can be absent for a beat. */
+  events?: RoadmapItemEvent[];
   /** Ring the row: it was just jumped to, or a pending proposal moves it. */
   focused?: boolean;
   /** Transient highlight for a row that just landed or just moved. */
@@ -102,6 +109,7 @@ export function ItemCard({
   onOpenRun,
   workflowName,
   note,
+  events,
   cardRef,
 }: Props) {
   const createDraft = useAppStore((s) => s.createDraft);
@@ -283,7 +291,59 @@ export function ItemCard({
               )}
             </div>
           </div>
+          {events && events.length > 0 && <ItemHistory events={events} />}
         </div>
+      )}
+    </div>
+  );
+}
+
+/** The card's history footnote: the latest event inline ("Run failed — its run
+ *  failed · 2h ago"), with the full trail behind a disclosure when there is
+ *  more than one line to show. Deliberately quiet — this is provenance, not an
+ *  action surface. */
+function ItemHistory({ events }: { events: RoadmapItemEvent[] }) {
+  const [open, setOpen] = useState(false);
+  const now = Date.now();
+  const latest = events[0];
+  const line = (e: RoadmapItemEvent) => (
+    <>
+      <span className="rm-hist-t truncate">{eventLine(e)}</span>
+      <span className="rm-hist-age mono">{formatAge(e.created_at, now)}</span>
+    </>
+  );
+  if (events.length === 1) {
+    return (
+      <div className="rm-hist">
+        <div className="rm-hist-h flex-center text-xs">
+          <Icon name="history" size={11} />
+          {line(latest)}
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="rm-hist">
+      <button
+        type="button"
+        className="rm-hist-h flex-center text-xs"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        <Icon name="history" size={11} />
+        {line(latest)}
+        <Icon name="chevD" size={9} className="rm-hist-chev" />
+      </button>
+      {open && (
+        <ul className="rm-hist-list text-xs">
+          {/* The latest repeats at the top of the trail on purpose: the list is
+              the whole history, not "the rest of it". */}
+          {events.map((e) => (
+            <li key={e.id} className="flex-center">
+              {line(e)}
+            </li>
+          ))}
+        </ul>
       )}
     </div>
   );

--- a/src/components/ProjectScreen/Roadmap/Board/index.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/index.tsx
@@ -47,6 +47,7 @@ export function Board({
     error,
     clearError,
     notes,
+    events,
     addItem,
     editItem,
     removeItems,
@@ -198,12 +199,13 @@ export function Board({
                       landed={landed.has(it.code)}
                       focused={focusCode === it.code}
                       note={notes.get(row.id)}
+                      events={events.get(row.id)}
                       workflowName={
                         writable
                           ? (workflows.resolve(row.workflow_def_id)?.name ?? null)
                           : undefined
                       }
-                      onToggle={() => toggleItem(it.code)}
+                      onToggle={() => toggleItem(it.code, row.id)}
                       onEdit={
                         ghost || readOnly
                           ? undefined

--- a/src/components/ProjectScreen/Roadmap/Roadmap.css
+++ b/src/components/ProjectScreen/Roadmap/Roadmap.css
@@ -912,6 +912,56 @@
   color: var(--warn);
 }
 
+/* The card's durable history (`roadmap:item-event`) — a footnote under the
+   expanded body: latest event inline, full trail on disclosure. Everything is
+   fg-3 on purpose; provenance should never compete with the body above it. */
+.rm-hist {
+  margin-top: 10px;
+  padding-top: 8px;
+  border-top: 1px solid var(--bd-soft);
+}
+.rm-hist-h {
+  width: 100%;
+  gap: 6px;
+  color: var(--fg-3);
+  line-height: var(--lh-none);
+  text-align: left;
+}
+button.rm-hist-h:hover {
+  color: var(--fg-2);
+}
+.rm-hist-t {
+  min-width: 0;
+}
+/* The "· 2h ago" tail; the dot is styling, not content. */
+.rm-hist-age {
+  flex-shrink: 0;
+}
+.rm-hist-age::before {
+  content: "· ";
+}
+.rm-hist-chev {
+  flex-shrink: 0;
+  opacity: 0.75;
+  transition: transform 0.15s var(--ease);
+}
+.rm-hist-h[aria-expanded="true"] .rm-hist-chev {
+  transform: rotate(180deg);
+}
+.rm-hist-list {
+  margin: 7px 0 0;
+  padding: 0 0 0 17px; /* under the header's text, past its icon */
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.rm-hist-list li {
+  gap: 6px;
+  color: var(--fg-3);
+  line-height: var(--lh-none);
+}
+
 /* An item the queue has taken responsibility for. A left rule rather than a
    fill: it marks the row as spoken for without competing with a ghost's tint or
    the landed flash. */

--- a/src/components/ProjectScreen/Roadmap/itemHistory.test.ts
+++ b/src/components/ProjectScreen/Roadmap/itemHistory.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { RoadmapItemEvent } from "@/api";
+import { eventLine, insertEvent, mergeSnapshot } from "./itemHistory";
+
+function event(over: Partial<RoadmapItemEvent> & { id: string }): RoadmapItemEvent {
+  return {
+    item_id: "i1",
+    project_id: "p1",
+    actor: "drainer",
+    kind: "dispatched",
+    detail: null,
+    created_at: 0,
+    ...over,
+  };
+}
+
+describe("insertEvent", () => {
+  it("prepends a live event, newest first", () => {
+    const older = event({ id: "a", created_at: 10 });
+    const newer = event({ id: "b", created_at: 20 });
+    expect(insertEvent([older], newer)).toEqual([newer, older]);
+  });
+
+  it("drops a duplicate id — the same event can arrive live and in a snapshot", () => {
+    const e = event({ id: "a", created_at: 10 });
+    const trail = insertEvent([], e);
+    expect(insertEvent(trail, e)).toBe(trail);
+  });
+});
+
+describe("mergeSnapshot", () => {
+  it("lays the snapshot under live arrivals without duplicating the overlap", () => {
+    // The lazy-load race: `c` landed while the fetch was in flight, so it is in
+    // both the live buffer and the snapshot. It must appear once, in order.
+    const live = [event({ id: "c", created_at: 30 })];
+    const snapshot = [
+      event({ id: "c", created_at: 30 }),
+      event({ id: "b", created_at: 20 }),
+      event({ id: "a", created_at: 10 }),
+    ];
+    expect(mergeSnapshot(live, snapshot).map((e) => e.id)).toEqual(["c", "b", "a"]);
+  });
+
+  it("keeps the trail newest first when live events outrun the snapshot", () => {
+    const live = [event({ id: "d", created_at: 40 })];
+    const snapshot = [event({ id: "a", created_at: 10 })];
+    expect(mergeSnapshot(live, snapshot).map((e) => e.id)).toEqual(["d", "a"]);
+  });
+});
+
+describe("eventLine", () => {
+  it("says the kind, with the detail when there is one", () => {
+    expect(eventLine(event({ id: "a", kind: "run_failed", detail: "its run failed" }))).toBe(
+      "Run failed — its run failed",
+    );
+    expect(eventLine(event({ id: "b", kind: "shipped" }))).toBe("Shipped");
+  });
+});

--- a/src/components/ProjectScreen/Roadmap/itemHistory.ts
+++ b/src/components/ProjectScreen/Roadmap/itemHistory.ts
@@ -1,0 +1,58 @@
+// An item's durable history, as the card renders it — the pure half of the
+// lazy load, kept out of the hook so the ordering rules are testable without
+// React.
+//
+// History is loaded per item on first expand, with the `roadmap:item-event`
+// listener already live (the board subscribes before it fetches anything). That
+// leaves one window: an event that lands while the snapshot request is in
+// flight is delivered live *and* included in the snapshot. `mergeSnapshot`
+// closes it the same way boardSync closes the board's — by id, so an event can
+// appear once however it arrived.
+
+import type { RoadmapEventKind, RoadmapItemEvent } from "@/api";
+
+/** The kind, as the card's history line says it. */
+export const EVENT_LABEL: Record<RoadmapEventKind, string> = {
+  proposed: "Proposed",
+  accepted: "Accepted",
+  discarded: "Discarded",
+  edited: "Edited",
+  queued: "Queued",
+  unqueued: "Taken off the queue",
+  dispatched: "Dispatched",
+  pr_opened: "PR opened",
+  run_failed: "Run failed",
+  shipped: "Shipped",
+  abandoned: "Abandoned",
+  blocked: "Blocked",
+  note: "Note",
+};
+
+/** One history entry as one line: the kind, and the detail when there is one. */
+export function eventLine(e: RoadmapItemEvent): string {
+  return e.detail ? `${EVENT_LABEL[e.kind]} — ${e.detail}` : EVENT_LABEL[e.kind];
+}
+
+/** Newest first, ties kept in their existing relative order (the backend
+ *  already breaks same-millisecond ties by write order). */
+function newestFirst(list: RoadmapItemEvent[]): RoadmapItemEvent[] {
+  return [...list].sort((a, b) => b.created_at - a.created_at);
+}
+
+/** Add one live event to a trail, newest first. A duplicate id is dropped — the
+ *  same event can arrive live and in a snapshot merged moments later. */
+export function insertEvent(list: RoadmapItemEvent[], e: RoadmapItemEvent): RoadmapItemEvent[] {
+  if (list.some((x) => x.id === e.id)) return list;
+  return newestFirst([e, ...list]);
+}
+
+/** Lay a fetched snapshot under whatever live events already arrived: dedupe by
+ *  id (live wins, the rows are identical) and keep the whole trail newest
+ *  first. */
+export function mergeSnapshot(
+  live: RoadmapItemEvent[],
+  snapshot: RoadmapItemEvent[],
+): RoadmapItemEvent[] {
+  const seen = new Set(live.map((e) => e.id));
+  return newestFirst([...live, ...snapshot.filter((e) => !seen.has(e.id))]);
+}

--- a/src/components/ProjectScreen/Roadmap/useRoadmap.ts
+++ b/src/components/ProjectScreen/Roadmap/useRoadmap.ts
@@ -31,12 +31,15 @@ import {
   type NewRoadmapItem,
   onRoadmapItem,
   onRoadmapItemDeleted,
+  onRoadmapItemEvent,
   onRoadmapQueueNote,
   type RoadmapItem,
+  type RoadmapItemEvent,
   type RoadmapItemPatch,
 } from "@/api";
 import { useAppStore } from "@/store";
 import { applyBoardEvent, createBoardSync } from "./boardSync";
+import { insertEvent, mergeSnapshot } from "./itemHistory";
 import { PRODUCT_MAP } from "./mockData";
 import type { Horizon } from "./types";
 import { toBoardItem } from "./types";
@@ -86,6 +89,16 @@ export function useRoadmap(repoPath: string) {
    *  Not persisted anywhere, on purpose: it's only true until the next tick,
    *  and the row's own next change supersedes it. */
   const [notes, setNotes] = useState<ReadonlyMap<string, string>>(() => new Map());
+  /** Each item's durable history, newest first (`roadmap:item-event` +
+   *  `roadmap_list_item_events`). Held lazily: an item's trail is fetched on
+   *  first expand and followed live from then on — events for items nobody
+   *  ever expanded are simply dropped, so the map only ever holds what some
+   *  card has shown. */
+  const [events, setEvents] = useState<ReadonlyMap<string, RoadmapItemEvent[]>>(() => new Map());
+  /** Items whose history has been requested — the "followed live" set. In a
+   *  ref because the event listener must read the current answer without
+   *  resubscribing per expand. */
+  const requestedEvents = useRef<Set<string>>(new Set());
 
   // Every pending highlight timer, so unmounting can't set state on a dead
   // component.
@@ -140,6 +153,10 @@ export function useRoadmap(repoPath: string) {
     }
     let alive = true;
     setLoading(true);
+    // A new board means new trails: what the previous project's cards loaded
+    // says nothing about this one's items.
+    requestedEvents.current = new Set();
+    setEvents(new Map());
 
     // Unmounting mid-load must not write state, so every commit goes through
     // the same `alive` gate the fetch does.
@@ -156,6 +173,23 @@ export function useRoadmap(repoPath: string) {
     const offDeleted = onRoadmapItemDeleted((id) => {
       sync.push({ kind: "delete", id });
       dropNote(id);
+      // The backend cascades the row's history away; drop ours too, and let a
+      // reused id (there are none, but the map shouldn't bet on that) refetch.
+      requestedEvents.current.delete(id);
+      setEvents((prev) => {
+        if (!prev.has(id)) return prev;
+        const next = new Map(prev);
+        next.delete(id);
+        return next;
+      });
+    });
+    // History rows, appended only to trails some card already loaded — an
+    // event for a never-expanded item is dropped here and refetched whole on
+    // that item's first expand, which keeps the map leak-free.
+    const offEvent = onRoadmapItemEvent((e) => {
+      if (e.project_id !== projectId) return;
+      if (!requestedEvents.current.has(e.item_id)) return;
+      setEvents((prev) => new Map(prev).set(e.item_id, insertEvent(prev.get(e.item_id) ?? [], e)));
     });
     // Addressed by item id, and every id on this board belongs to this project,
     // so no extra filtering is needed — a note for a row we don't hold is
@@ -188,9 +222,30 @@ export function useRoadmap(repoPath: string) {
       alive = false;
       void off.then((f) => f());
       void offDeleted.then((f) => f());
+      void offEvent.then((f) => f());
       void offNote.then((f) => f());
     };
   }, [projectId, workspaceReady, dropNote]);
+
+  /** Fetch an item's history once, on first expand. The listener above is
+   *  already appending live rows for it from the moment this is called, and
+   *  `mergeSnapshot` folds the two together by id — the same
+   *  subscribe-then-fetch-then-replay shape the board load uses. A failed fetch
+   *  un-requests the item so the next expand retries. */
+  const loadEvents = useCallback(async (itemId: string) => {
+    if (requestedEvents.current.has(itemId)) return;
+    requestedEvents.current.add(itemId);
+    try {
+      const snapshot = await api.roadmapListItemEvents(itemId);
+      setEvents((prev) =>
+        new Map(prev).set(itemId, mergeSnapshot(prev.get(itemId) ?? [], snapshot)),
+      );
+    } catch {
+      // History is a footnote: not worth the board's error bar. The card
+      // simply has no trail until a later expand succeeds.
+      requestedEvents.current.delete(itemId);
+    }
+  }, []);
 
   /** Light up rows for a moment after they land, then clear only those — a
    *  later landing must not have its highlight cut short by an earlier timer. */
@@ -370,13 +425,21 @@ export function useRoadmap(repoPath: string) {
   );
 
   // ── board interaction ──────────────────────────────────────────────
-  const toggleItem = useCallback((code: string) => {
-    setOpenCodes((s) => {
-      const next = new Set(s);
-      if (!next.delete(code)) next.add(code);
-      return next;
-    });
-  }, []);
+  /** Expand/collapse a card. `itemId` (when the caller holds the row) is what
+   *  triggers the item's one-time history fetch — on every toggle rather than
+   *  only on opens, because `loadEvents` is idempotent and "is it open" would
+   *  otherwise be a second source of truth here. */
+  const toggleItem = useCallback(
+    (code: string, itemId?: string) => {
+      setOpenCodes((s) => {
+        const next = new Set(s);
+        if (!next.delete(code)) next.add(code);
+        return next;
+      });
+      if (itemId) void loadEvents(itemId);
+    },
+    [loadEvents],
+  );
 
   /** Jump the board to an item and flash it — used by the "on the board" links. */
   const focusItem = useCallback(
@@ -415,6 +478,9 @@ export function useRoadmap(repoPath: string) {
     landed,
     /** Why a queued item isn't moving, by item id. */
     notes,
+    /** Each item's durable history, by item id — only for items whose card has
+     *  been expanded at least once. */
+    events,
     addItem,
     editItem,
     moveItem,

--- a/src/components/ProjectScreen/Roadmap/useRoadmap.ts
+++ b/src/components/ProjectScreen/Roadmap/useRoadmap.ts
@@ -447,9 +447,15 @@ export function useRoadmap(repoPath: string) {
       setTab("roadmap");
       setFocusCode(code);
       setOpenCodes((s) => new Set(s).add(code));
+      // The card lands expanded, so its trail must load exactly as if the
+      // user had expanded it by hand — otherwise the history line the caller
+      // is often pointing at ("its run failed") is invisible until a manual
+      // collapse and re-expand.
+      const row = rows.find((r) => r.code === code);
+      if (row) void loadEvents(row.id);
       after(FOCUS_MS, () => setFocusCode(null));
     },
-    [after],
+    [after, rows, loadEvents],
   );
 
   return {


### PR DESCRIPTION
> Stacked on #592 (`feat/roadmap-prune-model`) — this PR's base is that branch, so the diff shows only this slice. Retarget to `main` after #592 merges if GitHub doesn't do it automatically.

## What

Adds `roadmap_item_events` (migration 0030): one durable history row per item transition, written by every writer of `roadmap_items`:

- **PM propose** → `proposed` (recorded inside the insert transaction, all-or-nothing with the batch)
- **User rulings** (typed commands) → `accepted` / `queued` / `unqueued` / `shipped` / `edited`, derived from the status transition; recorded only when the conditional update actually applied, so the applied/not-applied contract of `roadmap_update_item` is untouched
- **Drainer** → `dispatched` (detail = pinned workflow definition id) on claim; `pr_opened` (detail = PR url) / `shipped` / `run_failed` (detail = the same reason string the transient queue note wraps — one string, two channels, no divergent stories) on settle; launch failures → `run_failed`
- **Merge sweep** → `shipped` on merge, `abandoned` on close-without-merge

Every event rides the same connection-lock scope as the item write it describes, so history can never disagree with the transition. Deleted items cascade their events away by design — a row ruled off the board needs no history.

Frontend: the expanded card gets a low-weight history footnote — latest event inline ("Run failed — … · 2h ago"), disclosure for the full trail. Trails load lazily on first expand and follow live `roadmap:item-event` rows from then on; the fetch-vs-live race is closed by id-dedupe (`itemHistory.ts`, the boardSync pattern applied per item).

What deliberately does NOT persist: the drainer's re-derived-every-tick conditions (waiting on deps, no workflow, no repo) stay on the transient queue-note channel — persisting one per tick would bury the transitions in noise.

## Why

Until now the only record of *why* an item moved was transient: a failed run's reason vanished on reload, and "when did this ship?" had no answer beyond `updated_at`, which any edit overwrites. This table is the substrate the next slices hang off: decision cards, PM oversight digests, and `done_at` (the `shipped` event's timestamp).

`held`/`released` kinds are deliberately absent until the holds slice gives them a writer. Like `roadmap_items`, the table is excluded from the generic CRUD allow-list — events must ride the typed write paths.

## Verification

- `bun run check`, `bun run lint`: clean
- `bun run test`: 794 passed (76 files), incl. new `itemHistory.test.ts`
- `cargo test`: 1212 passed, 12 ignored (pre-existing); pins include "a missed precondition records nothing" and "a release persists its reason where the note never lands"