### PR TITLE
feat(roadmap): dependencies are validated everywhere and cycles are named

### DIFF
--- a/src-tauri/src/instructions/roadmap.md
+++ b/src-tauri/src/instructions/roadmap.md
@@ -56,10 +56,12 @@ Fields, per item:
 - `horizon` — required: `now` (being built), `next` (up next), `later` (backlog).
 - `area` — optional product-map domain.
 - `accept` — optional array of acceptance criteria: what makes it done.
-- `deps` — optional array of **codes** (`["FLT-100"]`) this must land after.
-  Only codes already on the board — items in the same batch have no code yet,
-  so if two of your tickets are ordered, propose the first, then the second
-  with a dep on the code you got back.
+- `deps` — optional array of what this must land after. Either a **code**
+  already on the board (`["FLT-100"]`) or a **position in this batch**
+  (`["#2"]` = the second ticket in this call, counting from 1). So an ordered
+  plan is one call: propose the slices in build order and point each at the one
+  before it. The positions are turned into the real codes as the tickets are
+  created, and `roadmap_list` shows codes from then on.
 
 Build the request with `jq` so free text is escaped correctly:
 
@@ -69,7 +71,10 @@ jq -n --arg id "$ID" '{id:$id,op:"roadmap_propose",args:{items:[
   {title:"Add the queue drainer",
    why:"queued items sit forever with nothing to launch them",
    horizon:"next", area:"workflow",
-   accept:["a queued item launches a run","the run id is stored on the item"]}
+   accept:["a queued item launches a run","the run id is stored on the item"]},
+  {title:"Reflect a finished run back onto the board",
+   why:"a dispatched item has to leave the queue when its run lands",
+   horizon:"next", deps:["#1"]}
 ]}}' > "$FLETCH_RPC_DIR/requests/$ID.json.tmp"
 mv "$FLETCH_RPC_DIR/requests/$ID.json.tmp" "$FLETCH_RPC_DIR/requests/$ID.json"
 until [ -f "$FLETCH_RPC_DIR/responses/$ID.json" ]; do sleep 0.2; done
@@ -79,7 +84,8 @@ cat "$FLETCH_RPC_DIR/responses/$ID.json"
 `stdout` carries the allocated codes — refer to them by code from then on:
 
 ```json
-{"created":[{"code":"FLT-142","title":"Add the queue drainer"}]}
+{"created":[{"code":"FLT-142","title":"Add the queue drainer"},
+            {"code":"FLT-143","title":"Reflect a finished run back onto the board"}]}
 ```
 
 Rules the app enforces, so save yourself a round trip:
@@ -88,6 +94,11 @@ Rules the app enforces, so save yourself a round trip:
   conversation, not to send a bigger batch.
 - The whole batch is rejected if any item is invalid — nothing is half-created.
   The error names the item; fix it and resend.
+- `deps` may not form a circle. Nothing in a loop is ever built — each item
+  waits on the next — so a batch that closes one is refused, and the refusal
+  draws the loop (`FLT-142 → FLT-143 → FLT-142`). The same is true of a ticket
+  that merely *waits on* a loop already on the board: propose the fix to that
+  loop first.
 - An unknown field is an error (a misspelled `horizon` must not silently become
   a backlog item). You cannot set `status` or `source`: a proposal is always
   proposed, and always attributed to you.
@@ -116,9 +127,16 @@ cat "$FLETCH_RPC_DIR/responses/$ID.json"
 ["title","horizon","accept"]}}` — say it in the conversation.
 
 `patch` takes any of `title | why | horizon | area | accept | deps`, with the
-same rules as proposing (deps are codes already on the board; `"area": null`
-clears the area). Nothing else is patchable — not `status`, not `code`.
+same rules as proposing (`"area": null` clears the area). `deps` here are codes
+on the board — there is no batch to point into — and the whole list replaces the
+item's current one. Nothing else is patchable — not `status`, not `code`.
 `note` is one honest sentence on why; the user reads it next to the diff.
+
+A dep patch that would close a loop is refused, here *and* again when the user
+accepts it: the board moves while an ask is pending, so a patch that was fine
+when you sent it can be a circle by the time it is ruled on. If that happens the
+ask is dropped and the user is told which loop it would have made — read a fresh
+`roadmap_list` and re-ask if the change still matters.
 
 ### `roadmap_propose_discard` — propose retiring an item
 

--- a/src-tauri/src/roadmap/deps.rs
+++ b/src-tauri/src/roadmap/deps.rs
@@ -1,0 +1,462 @@
+//! Dependency-graph rules: the one place that answers "may this item depend on
+//! these codes?".
+//!
+//! Why a module of its own. `deps` is written from five surfaces — the item
+//! dialog's create and update commands, the PM's `roadmap_propose` batch, its
+//! `roadmap_propose_update` patch, and the user's ruling that applies one — and
+//! every one of them can close a loop. A loop is the worst failure this board
+//! has: nothing in it is ever `done`, so [`super::drainer::unsatisfied_deps`]
+//! never resolves for any of its members, the drainer skips the whole chain on
+//! every tick forever, and the only trace is a transient note nobody was
+//! watching. That was reachable through an accepted dep patch until this module
+//! existed. So the rule lives here once, runs before every dep write, runs
+//! *again* when a stored ask is applied (the board moves between the ask and the
+//! click), and answers the drainer's "is this queue head wedged for good?".
+//!
+//! Pure by construction: a `code → deps` map in, a refusal naming the problem
+//! out. No connection, no clock, no app handle — so the table below is the
+//! whole specification of the rule.
+
+use std::collections::{BTreeMap, HashSet};
+
+use super::types::RoadmapItem;
+
+/// Every code on a board mapped to the codes it must land after.
+///
+/// A `BTreeMap` rather than a `HashMap` so a refusal that lists the board's
+/// codes lists them in a stable order — an error message that reshuffles
+/// between two identical calls reads like two different problems.
+pub type Graph = BTreeMap<String, Vec<String>>;
+
+/// How a batch item names another item in the same batch: `"#2"` is the second
+/// item in the array. Codes are allocated inside the insert transaction, so at
+/// validation time a batch's own items are known only by position.
+pub const BATCH_PREFIX: char = '#';
+
+/// How many codes a refusal lists before it says "and n more". A message the
+/// PM has to read (or the dialog has to fit) stops helping past a dozen.
+const LISTED: usize = 12;
+
+/// The dependency graph of a project's board, exactly as stored.
+pub fn graph_of(items: &[RoadmapItem]) -> Graph {
+    items
+        .iter()
+        .map(|i| (i.code.clone(), i.deps.clone()))
+        .collect()
+}
+
+/// The node name a batch item takes while it has no code yet: `"#1"` for the
+/// first item. Cannot collide with a real code (`PREFIX-nnn`), which is what
+/// lets the batch's edges and the board's edges live in one graph.
+fn placeholder(index: usize) -> String {
+    format!("{BATCH_PREFIX}{}", index + 1)
+}
+
+/// The 0-based batch position a `"#n"` dep resolves to, for the caller that
+/// rewrites it into a real code once the batch is inserted. `None` for a plain
+/// code, and for anything [`validate_batch`] would have refused — so a caller
+/// that validated first can treat `None` as "this is a code".
+pub fn batch_index(dep: &str, batch_len: usize) -> Option<usize> {
+    let n: usize = dep.strip_prefix(BATCH_PREFIX)?.trim().parse().ok()?;
+    (1..=batch_len).contains(&n).then(|| n - 1)
+}
+
+/// Validate the deps of an item that does not exist yet — the create path.
+///
+/// Only the codes are checked: nothing can depend on a row that has no code, so
+/// a brand-new item cannot close a loop no matter what it names.
+pub fn validate_new(graph: &Graph, deps: &[String]) -> Result<(), String> {
+    check_codes(graph, None, deps, "")
+}
+
+/// Validate a new dep list for an item that already exists — the dialog's edit,
+/// the PM's patch, and the ruling that applies one.
+///
+/// Refuses an unknown code, a self-reference, and any loop the edit would leave
+/// reachable from this item.
+pub fn validate_edit(graph: &Graph, code: &str, deps: &[String]) -> Result<(), String> {
+    check_codes(graph, Some(code), deps, "")?;
+    // The graph as it would be *after* the write: the check has to be about the
+    // board this edit produces, not the one it was computed from.
+    let mut after = graph.clone();
+    after.insert(code.to_string(), deps.to_vec());
+    match find_cycle(&after, code) {
+        Some(cycle) => Err(loop_message(code, &cycle)),
+        None => Ok(()),
+    }
+}
+
+/// Which item in a batch was refused, and why. The batch's own validator knows
+/// the position; only its caller knows the title, so the two are handed back
+/// separately rather than baked into one string here.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BatchRefusal {
+    /// 0-based index into the batch.
+    pub at: usize,
+    pub message: String,
+}
+
+/// Validate a whole batch of new items as one graph merged with the board's.
+///
+/// `batch` is each proposed item's dep list, in batch order; an entry may name a
+/// real code or another item in the same batch as `"#n"`. Refuses an unknown
+/// code, an out-of-range or self `"#n"`, and any loop — including one made
+/// entirely of the batch's own edges, which is the whole reason intra-batch
+/// references need checking at all.
+pub fn validate_batch(graph: &Graph, batch: &[Vec<String>]) -> Result<(), BatchRefusal> {
+    let refuse = |at: usize, message: String| BatchRefusal { at, message };
+    let batch_note = ", and not a \"#n\" reference to an item in this batch";
+    let mut merged = graph.clone();
+    for (n, deps) in batch.iter().enumerate() {
+        for d in deps {
+            if d.starts_with(BATCH_PREFIX) {
+                let position = batch_index(d, batch.len()).ok_or_else(|| {
+                    refuse(
+                        n,
+                        format!(
+                            "`deps` names {d:?}, which is not an item in this batch — a batch \
+                             reference is \"#1\" to \"#{}\", counting the items in the order you \
+                             sent them",
+                            batch.len()
+                        ),
+                    )
+                })?;
+                if position == n {
+                    return Err(refuse(
+                        n,
+                        format!("{d} is this item — an item cannot depend on itself"),
+                    ));
+                }
+            } else if !graph.contains_key(d.as_str()) {
+                return Err(refuse(n, unknown_code(d, graph, batch_note)));
+            }
+        }
+        merged.insert(placeholder(n), deps.clone());
+    }
+    // Every new node, not just the ones with batch references: an item whose dep
+    // chain runs into a loop already on the board is just as unbuildable as one
+    // that closes a fresh loop with its neighbour.
+    for n in 0..batch.len() {
+        let from = placeholder(n);
+        if let Some(cycle) = find_cycle(&merged, &from) {
+            return Err(refuse(n, loop_message(&from, &cycle)));
+        }
+    }
+    Ok(())
+}
+
+/// The first dependency loop reachable from `start`: the codes in it, first and
+/// last the same node, so rendering it reads as a closed walk
+/// (`MCA-101 → MCA-104 → MCA-101`). `None` when every chain under `start` ends.
+///
+/// Reachability rather than "is `start` itself in a loop", on purpose: an item
+/// whose dep chain *ends* in a loop can never be built either, and that is the
+/// usual shape of a wedged queue head — the loop is two items further down.
+/// A code with no node (an item that was deleted) is a leaf, matching
+/// [`super::drainer::unsatisfied_deps`], where a stale code counts as satisfied.
+pub fn find_cycle(graph: &Graph, start: &str) -> Option<Vec<String>> {
+    let mut path: Vec<String> = Vec::new();
+    let mut settled: HashSet<String> = HashSet::new();
+    walk(graph, start, &mut path, &mut settled)
+}
+
+/// Depth-first walk carrying its own path, so hitting a node already on the
+/// path *is* the loop and the path spells it out. `settled` holds the nodes
+/// already proven loop-free, which is what keeps a diamond-shaped board from
+/// being re-walked once per route into it.
+fn walk(
+    graph: &Graph,
+    at: &str,
+    path: &mut Vec<String>,
+    settled: &mut HashSet<String>,
+) -> Option<Vec<String>> {
+    if let Some(from) = path.iter().position(|p| p == at) {
+        let mut cycle = path[from..].to_vec();
+        cycle.push(at.to_string());
+        return Some(cycle);
+    }
+    if settled.contains(at) {
+        return None;
+    }
+    path.push(at.to_string());
+    if let Some(deps) = graph.get(at) {
+        for dep in deps {
+            if let Some(cycle) = walk(graph, dep, path, settled) {
+                return Some(cycle);
+            }
+        }
+    }
+    path.pop();
+    settled.insert(at.to_string());
+    None
+}
+
+/// A loop as one line: `MCA-101 → MCA-104 → MCA-101`. The rendering every
+/// surface uses — the refusal, the card's note, and the durable `blocked`
+/// event's detail — so the same loop reads the same everywhere.
+pub fn loop_path(cycle: &[String]) -> String {
+    cycle.join(" → ")
+}
+
+/// Why a loop is a refusal and not a warning, in the words of whichever item is
+/// being written. Two shapes, because "you just closed this" and "you are
+/// depending on something already broken" are different things to fix.
+fn loop_message(code: &str, cycle: &[String]) -> String {
+    let path = loop_path(cycle);
+    match cycle.first().map(String::as_str) {
+        Some(first) if first == code => format!(
+            "{code} can't depend on {}: that closes a dependency loop — {path}. Nothing in a \
+             loop is ever built, because each item waits on the next.",
+            cycle.get(1).map(String::as_str).unwrap_or(code)
+        ),
+        _ => format!(
+            "{code} would wait on a dependency loop — {path}. Nothing in a loop is ever built, \
+             so that chain has to be broken first."
+        ),
+    }
+}
+
+/// Check every dep resolves, and that the item isn't naming itself. `code` is
+/// `None` for an item that has none yet (the create path).
+fn check_codes(
+    graph: &Graph,
+    code: Option<&str>,
+    deps: &[String],
+    batch_note: &str,
+) -> Result<(), String> {
+    for d in deps {
+        if code == Some(d.as_str()) {
+            return Err(format!("{d} cannot depend on itself"));
+        }
+        if !graph.contains_key(d.as_str()) {
+            return Err(unknown_code(d, graph, batch_note));
+        }
+    }
+    Ok(())
+}
+
+/// A dep naming nothing on the board, with what it could have named instead —
+/// the difference between an error the caller can fix and one it has to guess at.
+fn unknown_code(dep: &str, graph: &Graph, batch_note: &str) -> String {
+    if graph.is_empty() {
+        return format!("`deps` names {dep:?}, and this board has no items to depend on yet");
+    }
+    let mut codes: Vec<&str> = graph.keys().map(String::as_str).collect();
+    let extra = codes.len().saturating_sub(LISTED);
+    codes.truncate(LISTED);
+    let mut listed = codes.join(", ");
+    if extra > 0 {
+        listed.push_str(&format!(", and {extra} more"));
+    }
+    format!(
+        "`deps` names {dep:?}, which is not an item on this board{batch_note} — the codes on it \
+         are {listed}"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A board, as `(code, deps)` pairs — the whole input this module reasons
+    /// over, so the tests state the graph and nothing else.
+    fn graph(edges: &[(&str, &[&str])]) -> Graph {
+        edges
+            .iter()
+            .map(|(code, deps)| {
+                (
+                    (*code).to_string(),
+                    deps.iter().map(|d| (*d).to_string()).collect(),
+                )
+            })
+            .collect()
+    }
+
+    fn list(codes: &[&str]) -> Vec<String> {
+        codes.iter().map(|c| (*c).to_string()).collect()
+    }
+
+    #[test]
+    fn an_item_with_no_deps_is_always_fine() {
+        let g = graph(&[("MCA-100", &[]), ("MCA-101", &[])]);
+        assert_eq!(validate_edit(&g, "MCA-100", &[]), Ok(()));
+        assert_eq!(validate_new(&g, &[]), Ok(()));
+        assert_eq!(find_cycle(&g, "MCA-100"), None);
+    }
+
+    #[test]
+    fn a_chain_however_long_is_fine() {
+        // 102 → 101 → 100. Adding 103 → 102 keeps it a chain.
+        let g = graph(&[
+            ("MCA-100", &[]),
+            ("MCA-101", &["MCA-100"]),
+            ("MCA-102", &["MCA-101"]),
+            ("MCA-103", &[]),
+        ]);
+        assert_eq!(validate_edit(&g, "MCA-103", &list(&["MCA-102"])), Ok(()));
+        // Two routes into the same node is not a loop either.
+        assert_eq!(
+            validate_edit(&g, "MCA-103", &list(&["MCA-102", "MCA-100"])),
+            Ok(())
+        );
+        assert_eq!(find_cycle(&g, "MCA-102"), None);
+    }
+
+    #[test]
+    fn a_direct_cycle_is_refused_and_spelled_out() {
+        // 104 already depends on 101; making 101 depend on 104 closes the loop.
+        let g = graph(&[("MCA-101", &[]), ("MCA-104", &["MCA-101"])]);
+        let err = validate_edit(&g, "MCA-101", &list(&["MCA-104"])).unwrap_err();
+        assert!(
+            err.contains("MCA-101 → MCA-104 → MCA-101"),
+            "the refusal must name the loop: {err}"
+        );
+        assert!(err.contains("loop"), "{err}");
+    }
+
+    #[test]
+    fn a_transitive_cycle_is_refused_with_the_whole_path() {
+        // 101 → 102 → 103, and now 103 → 101.
+        let g = graph(&[
+            ("MCA-101", &["MCA-102"]),
+            ("MCA-102", &["MCA-103"]),
+            ("MCA-103", &[]),
+        ]);
+        let err = validate_edit(&g, "MCA-103", &list(&["MCA-101"])).unwrap_err();
+        assert!(
+            err.contains("MCA-103 → MCA-101 → MCA-102 → MCA-103"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn depending_on_a_loop_you_are_not_in_is_refused_too() {
+        // The loop is 101 ⇄ 102; 200 merely waits on it — and so waits forever.
+        let g = graph(&[
+            ("MCA-101", &["MCA-102"]),
+            ("MCA-102", &["MCA-101"]),
+            ("MCA-200", &[]),
+        ]);
+        let err = validate_edit(&g, "MCA-200", &list(&["MCA-101"])).unwrap_err();
+        assert!(
+            err.contains("MCA-200 would wait on a dependency loop"),
+            "{err}"
+        );
+        assert!(err.contains("MCA-101 → MCA-102 → MCA-101"), "{err}");
+    }
+
+    #[test]
+    fn an_item_cannot_depend_on_itself() {
+        let g = graph(&[("MCA-100", &[])]);
+        let err = validate_edit(&g, "MCA-100", &list(&["MCA-100"])).unwrap_err();
+        assert!(err.contains("depend on itself"), "{err}");
+    }
+
+    #[test]
+    fn an_unknown_code_is_refused_and_the_board_is_listed() {
+        let g = graph(&[("MCA-100", &[]), ("MCA-101", &[])]);
+        let err = validate_edit(&g, "MCA-100", &list(&["MCA-999"])).unwrap_err();
+        assert!(err.contains("MCA-999"), "{err}");
+        assert!(
+            err.contains("MCA-100, MCA-101"),
+            "the codes it could name: {err}"
+        );
+        // The create path applies the same rule without a code of its own.
+        assert!(validate_new(&g, &list(&["MCA-999"])).is_err());
+        // An empty board says so rather than offering an empty list.
+        let err = validate_new(&Graph::new(), &list(&["MCA-999"])).unwrap_err();
+        assert!(err.contains("no items to depend on yet"), "{err}");
+    }
+
+    #[test]
+    fn a_long_board_lists_only_the_first_codes() {
+        let codes: Vec<String> = (0..20).map(|n| format!("MCA-1{n:02}")).collect();
+        let g: Graph = codes.iter().map(|c| (c.clone(), Vec::new())).collect();
+        let err = validate_edit(&g, "MCA-100", &list(&["nope"])).unwrap_err();
+        assert!(err.contains("and 8 more"), "{err}");
+    }
+
+    // ─────────────────────────── batches ────────────────────────────────
+
+    #[test]
+    fn a_batch_may_order_itself_with_hash_references() {
+        let g = graph(&[("MCA-100", &[])]);
+        // Item 2 lands after item 1; item 3 after item 2 and after the board's
+        // own MCA-100. Forward references are fine too — item 1 on item 3.
+        let batch = vec![
+            list(&["#3"]),
+            list(&["#1"]),
+            list(&["MCA-100", "#4"]),
+            Vec::new(),
+        ];
+        assert_eq!(validate_batch(&g, &batch), Ok(()));
+        // And the positions resolve for the caller that rewrites them.
+        assert_eq!(batch_index("#3", 4), Some(2));
+        assert_eq!(batch_index("MCA-100", 4), None);
+        assert_eq!(batch_index("#9", 4), None);
+    }
+
+    #[test]
+    fn a_batch_internal_cycle_is_refused() {
+        let batch = vec![list(&["#2"]), list(&["#3"]), list(&["#1"])];
+        let refusal = validate_batch(&Graph::new(), &batch).unwrap_err();
+        assert_eq!(refusal.at, 0);
+        assert!(refusal.message.contains("#1 → #2 → #3 → #1"), "{refusal:?}");
+    }
+
+    #[test]
+    fn a_batch_item_that_waits_on_a_board_loop_is_refused() {
+        // The loop is entirely the board's (a pair from before this check
+        // existed); the batch item merely hangs off it, which is still a ticket
+        // that can never be built.
+        let g = graph(&[("MCA-101", &["MCA-102"]), ("MCA-102", &["MCA-101"])]);
+        let batch = vec![Vec::new(), list(&["MCA-101"])];
+        let refusal = validate_batch(&g, &batch).unwrap_err();
+        assert_eq!(refusal.at, 1);
+        assert!(
+            refusal.message.contains("MCA-101 → MCA-102 → MCA-101"),
+            "{refusal:?}"
+        );
+    }
+
+    #[test]
+    fn a_batch_reference_must_be_in_range_and_not_itself() {
+        let batch = vec![Vec::new(), Vec::new()];
+        for (deps, at, needle) in [
+            (list(&["#3"]), 0, "not an item in this batch"),
+            (list(&["#0"]), 0, "not an item in this batch"),
+            (list(&["#two"]), 0, "not an item in this batch"),
+            (list(&["#1"]), 0, "depend on itself"),
+        ] {
+            let mut batch = batch.clone();
+            batch[at] = deps;
+            let refusal = validate_batch(&Graph::new(), &batch).unwrap_err();
+            assert_eq!(refusal.at, at);
+            assert!(refusal.message.contains(needle), "{refusal:?}");
+        }
+    }
+
+    #[test]
+    fn a_batch_dep_on_an_unknown_code_names_the_batch_syntax_too() {
+        let g = graph(&[("MCA-100", &[])]);
+        let batch = vec![list(&["MCA-999"])];
+        let refusal = validate_batch(&g, &batch).unwrap_err();
+        assert_eq!(refusal.at, 0);
+        assert!(refusal.message.contains("MCA-999"), "{refusal:?}");
+        assert!(refusal.message.contains("#n"), "{refusal:?}");
+    }
+
+    #[test]
+    fn a_deleted_dependency_is_a_leaf_not_a_loop() {
+        // `unsatisfied_deps` treats a code with no row as satisfied; the walk
+        // has to agree, or a board with a stale code would read as wedged.
+        let g = graph(&[("MCA-100", &["MCA-099"])]);
+        assert_eq!(find_cycle(&g, "MCA-100"), None);
+    }
+
+    #[test]
+    fn the_graph_comes_straight_off_the_board() {
+        let g = graph_of(&[]);
+        assert!(g.is_empty());
+    }
+}

--- a/src-tauri/src/roadmap/drainer.rs
+++ b/src-tauri/src/roadmap/drainer.rs
@@ -53,6 +53,14 @@
 //! on the row. Notes are de-duplicated in memory *per row version* (see [`say`]),
 //! so a permanently blocked item doesn't re-emit the same string every fifteen
 //! seconds, while an item the user touched hears its explanation again.
+//!
+//! One blockage is not transient, though: a *dependency loop*. Nothing in a loop
+//! is ever `done`, so [`unsatisfied_deps`] never resolves for any of its members
+//! and the queue skips the chain on every tick, forever. That is a durable fact,
+//! so when the queue head is wedged that way the drainer also writes one
+//! `blocked` event naming the loop ([`record_wedge`]) — the writer
+//! `EventKind::Blocked` was declared for. Ordinary dep-waiting stays
+//! transient-only: it resolves itself the moment the dependency lands.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock};
@@ -66,7 +74,7 @@ use tokio::sync::Notify;
 
 use super::events::{self, EventActor, EventKind, ItemEvent, TrailEntry};
 use super::types::{ItemPatch, ItemStatus, RoadmapItem};
-use super::{emit_item, emit_item_event, store, Db};
+use super::{deps, emit_item, emit_item_event, store, Db};
 use crate::workflow::spec::{self, Spec};
 use crate::workflow::types::RunStatus;
 
@@ -625,11 +633,31 @@ enum Claim {
     /// Nothing to do and nothing to say.
     Nothing,
     /// Something is queued but can't run yet, and the card should say why.
-    Note(Box<RoadmapItem>, String),
+    ///
+    /// `recorded` is the durable `blocked` event a *permanent* blockage also
+    /// writes — see [`record_wedge`]. Every ordinary "waiting on …" leaves it
+    /// `None`: that condition is re-derived every tick and resolves itself the
+    /// moment the dependency lands, so persisting it would bury the trail.
+    Note {
+        item: Box<RoadmapItem>,
+        text: String,
+        recorded: Option<ItemEvent>,
+    },
     /// An item was claimed (already `active`) and is ready to launch. Carries
     /// the `dispatched` history event recorded with the claim, so it can be
     /// emitted once the lock is dropped.
     Claimed(Box<Plan>, ItemEvent),
+}
+
+impl Claim {
+    /// A transient explanation, nothing persisted.
+    fn note(item: RoadmapItem, text: String) -> Self {
+        Claim::Note {
+            item: Box::new(item),
+            text,
+            recorded: None,
+        }
+    }
 }
 
 /// Decide what to dispatch for this project and *claim* it. Returns the plan
@@ -642,8 +670,17 @@ fn claim_next(app: &AppHandle, db: &Db, project_id: &str, said: &SaidNotes) -> O
     };
     match claim {
         Claim::Nothing => None,
-        Claim::Note(item, text) => {
+        Claim::Note {
+            item,
+            text,
+            recorded,
+        } => {
             say(app, said, &item, &text);
+            // The durable half, when there was one: emitted after the lock
+            // dropped, exactly like every other event this module writes.
+            if let Some(event) = &recorded {
+                emit_item_event(app, event);
+            }
             None
         }
         Claim::Claimed(plan, event) => {
@@ -692,12 +729,27 @@ fn plan_and_claim(conn: &Connection, project_id: &str) -> Claim {
             item_id,
             waiting_on,
         } => {
-            return match queued.into_iter().find(|i| i.id == item_id) {
-                Some(item) => Claim::Note(
-                    Box::new(item),
-                    format!("Waiting on {}", waiting_on.join(", ")),
-                ),
-                None => Claim::Nothing,
+            let Some(item) = queued.into_iter().find(|i| i.id == item_id) else {
+                return Claim::Nothing;
+            };
+            // Two kinds of blocked, and only one of them is news. Waiting on a
+            // dependency that is still being built resolves itself — the note
+            // says so and nothing persists. A *loop* never resolves: every
+            // member waits on the next, so this item is skipped on every tick
+            // from here to the end of the app's life. That is a durable fact
+            // about the board, so it lands as a `blocked` event naming the loop
+            // (see .context/roadmap-pm-plan.md, A4).
+            return match deps::find_cycle(&deps::graph_of(&items), &item.code) {
+                Some(cycle) => {
+                    let text = format!("Stuck in a dependency loop: {}", deps::loop_path(&cycle));
+                    let recorded = record_wedge(conn, &item, &text);
+                    Claim::Note {
+                        item: Box::new(item),
+                        text,
+                        recorded,
+                    }
+                }
+                None => Claim::note(item, format!("Waiting on {}", waiting_on.join(", "))),
             };
         }
         // Nothing to say: an empty queue is silence, and being at capacity is
@@ -707,24 +759,21 @@ fn plan_and_claim(conn: &Connection, project_id: &str) -> Claim {
 
     let project_default = project_setting(conn, project_id, DEFAULT_WORKFLOW_KEY);
     let Some(definition_id) = resolve_workflow(&item, project_default.as_deref()) else {
-        return Claim::Note(
-            Box::new(item),
+        return Claim::note(
+            item,
             "No workflow to run it under. Pick one on this item, or set the project's \
              default workflow."
                 .to_string(),
         );
     };
     let Some(spec) = definition_spec(conn, &definition_id) else {
-        return Claim::Note(
-            Box::new(item),
+        return Claim::note(
+            item,
             "Its workflow is missing or no longer valid — pick another.".to_string(),
         );
     };
     let Some(repo_path) = primary_repo_path(conn, project_id) else {
-        return Claim::Note(
-            Box::new(item),
-            "This project has no repo to run in.".to_string(),
-        );
+        return Claim::note(item, "This project has no repo to run in.".to_string());
     };
 
     // Only deps that still resolve get quoted in the brief; a stale code counts
@@ -754,6 +803,43 @@ fn plan_and_claim(conn: &Connection, project_id: &str) -> Claim {
         Err(e) => {
             tracing::warn!(item = %item.code, error = %e, "roadmap drainer: claim failed");
             Claim::Nothing
+        }
+    }
+}
+
+/// Record a wedged queue head's `blocked` event — once, not once a tick.
+///
+/// The de-dup is a query rather than the in-memory [`SaidNotes`] map: that map is
+/// process-local and empty after a restart, which is fine for a transient note
+/// and useless for a durable table (every app start would append another
+/// identical row). So the check is "is the item's *newest* event already this
+/// same `blocked` line?" — newest rather than any, because a loop that was fixed
+/// and re-formed is news again, and the events in between are what say so.
+///
+/// Called with the connection lock held, in the same guard as the read the loop
+/// was detected from. A failure is logged and dropped: the transient note still
+/// reaches the card, and refusing to dispatch anything else because history
+/// couldn't be written would be a worse outcome than a missing line.
+fn record_wedge(conn: &Connection, item: &RoadmapItem, detail: &str) -> Option<ItemEvent> {
+    match events::latest_for_item(conn, &item.id) {
+        Ok(Some(last))
+            if last.kind == EventKind::Blocked && last.detail.as_deref() == Some(detail) =>
+        {
+            None
+        }
+        Ok(_) => events::record(
+            conn,
+            &item.id,
+            &item.project_id,
+            EventActor::Drainer,
+            EventKind::Blocked,
+            Some(detail),
+        )
+        .map_err(|e| tracing::warn!(item = %item.code, error = %e, "roadmap drainer: blocked event not recorded"))
+        .ok(),
+        Err(e) => {
+            tracing::warn!(item = %item.code, error = %e, "roadmap drainer: cannot read item history");
+            None
         }
     }
 }

--- a/src-tauri/src/roadmap/drainer/tests.rs
+++ b/src-tauri/src/roadmap/drainer/tests.rs
@@ -470,6 +470,85 @@ fn a_conditional_verdict_that_misses_records_nothing() {
     assert!(events::list_for_item(&conn, &it.id).unwrap().is_empty());
 }
 
+// ───────────────────────────── wedged queues ────────────────────────────
+
+/// Give `item` a dep list, straight through the DAO — the write paths refuse a
+/// loop now, so a board that has one is built by hand here.
+fn set_deps(conn: &Connection, item: &RoadmapItem, codes: &[&str]) {
+    store::update(
+        conn,
+        &item.id,
+        &ItemPatch {
+            deps: Some(codes.iter().map(|c| (*c).to_string()).collect()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+}
+
+#[test]
+fn a_wedged_queue_head_records_one_blocked_event_not_one_per_tick() {
+    // Two queued items waiting on each other: neither is ever `done`, so
+    // neither is ever dispatched, and the transient note nobody was watching
+    // was the only trace. That is the durable line `EventKind::Blocked` exists
+    // for — and it must land once, not once every fifteen seconds.
+    let conn = test_conn();
+    let a = db_item(&conn, ItemStatus::Queued);
+    let b = db_item(&conn, ItemStatus::Queued);
+    set_deps(&conn, &a, &[&b.code]);
+    set_deps(&conn, &b, &[&a.code]);
+
+    let Claim::Note {
+        item,
+        text,
+        recorded,
+    } = plan_and_claim(&conn, "p1")
+    else {
+        panic!("expected a note about the wedged head");
+    };
+    assert_eq!(item.id, a.id, "the head of the queue is what's wedged");
+    assert!(
+        text.contains(&format!("{} → {} → {}", a.code, b.code, a.code)),
+        "the loop is named, not just the wait: {text}"
+    );
+    let event = recorded.expect("a blockage that never resolves is durable");
+    assert_eq!(event.kind, EventKind::Blocked);
+    assert_eq!(event.actor, EventActor::Drainer);
+    // One reason string for both channels, as everywhere else in this module.
+    assert_eq!(event.detail.as_deref(), Some(text.as_str()));
+
+    // Next tick, same loop: the note may repeat (it's transient), the row may
+    // not.
+    let Claim::Note { recorded, .. } = plan_and_claim(&conn, "p1") else {
+        panic!("expected a note");
+    };
+    assert!(
+        recorded.is_none(),
+        "a durable line must not repeat per tick"
+    );
+    assert_eq!(events::list_for_item(&conn, &a.id).unwrap().len(), 1);
+}
+
+#[test]
+fn ordinary_dep_waiting_stays_transient() {
+    // The dependency is real work that hasn't landed yet — it will, and then
+    // this item dispatches. Nothing durable, or every queue would grow a
+    // history of "still waiting" lines it re-derives every tick anyway.
+    let conn = test_conn();
+    let dep = db_item(&conn, ItemStatus::Open);
+    let waiting = db_item(&conn, ItemStatus::Queued);
+    set_deps(&conn, &waiting, &[&dep.code]);
+
+    let Claim::Note { text, recorded, .. } = plan_and_claim(&conn, "p1") else {
+        panic!("expected a note");
+    };
+    assert_eq!(text, format!("Waiting on {}", dep.code));
+    assert!(recorded.is_none());
+    assert!(events::list_for_item(&conn, &waiting.id)
+        .unwrap()
+        .is_empty());
+}
+
 // ───────────────────────────── note dedup ───────────────────────────────
 
 #[test]

--- a/src-tauri/src/roadmap/events.rs
+++ b/src-tauri/src/roadmap/events.rs
@@ -19,7 +19,7 @@
 //! an event that didn't ride a typed write path could disagree with the
 //! transition it claims to record.
 
-use rusqlite::{params, Connection, Row};
+use rusqlite::{params, Connection, OptionalExtension, Row};
 use serde::Serialize;
 
 use super::types::{enum_col, ItemStatus};
@@ -146,6 +146,25 @@ pub fn list_for_item(conn: &Connection, item_id: &str) -> rusqlite::Result<Vec<I
     ))?;
     let rows = stmt.query_map([item_id], ItemEvent::from_row)?;
     rows.collect()
+}
+
+/// The item's newest event, or `None` for an item with no history yet.
+///
+/// One row rather than the whole trail because of the one caller that needs it:
+/// the drainer's wedged-queue check, which writes a `blocked` line only when the
+/// last thing said about the item isn't already that same line (see
+/// [`super::drainer::record_wedge`]). Same ordering as [`list_for_item`], so
+/// "newest" means one thing in both.
+pub fn latest_for_item(conn: &Connection, item_id: &str) -> rusqlite::Result<Option<ItemEvent>> {
+    conn.query_row(
+        &format!(
+            "SELECT {COLUMNS} FROM roadmap_item_events WHERE item_id = ?1
+              ORDER BY created_at DESC, rowid DESC LIMIT 1"
+        ),
+        [item_id],
+        ItemEvent::from_row,
+    )
+    .optional()
 }
 
 /// The history kind a user patch implies, from the transition it performs.

--- a/src-tauri/src/roadmap/mod.rs
+++ b/src-tauri/src/roadmap/mod.rs
@@ -3,7 +3,8 @@
 //! Layout mirrors the workflow module: [`types`] is the row and its enums,
 //! [`store`] is the DAO (called with the connection lock held), and this file is
 //! the typed `#[tauri::command]` surface plus the row-level events the frontend
-//! syncs on.
+//! syncs on. [`deps`] holds the one rule every dep write on every surface has to
+//! pass — no loops — because a loop wedges the queue silently and forever.
 //!
 //! `roadmap_items` is deliberately absent from the generic CRUD allow-list
 //! (`database::validate`), exactly like the `wf_*` tables. Codes must be
@@ -38,6 +39,7 @@
 //! host-side rather than in the webview precisely so a queue keeps draining
 //! with the window shut.
 
+pub mod deps;
 pub mod drainer;
 pub mod events;
 pub mod merge_sweep;
@@ -145,7 +147,7 @@ pub async fn roadmap_create_item(
     }
     let created = {
         let conn = db.lock();
-        store::create(&conn, &project_id, &item).map_err(|e| e.to_string())?
+        create_checked(&conn, &project_id, &item)?
     };
     emit_item(&app, &created);
     // A row can arrive already `queued` (or as a dependency another queued item
@@ -153,6 +155,25 @@ pub async fn roadmap_create_item(
     // to guess which ones matter.
     drainer::nudge();
     Ok(created)
+}
+
+/// The one write behind [`roadmap_create_item`]: check the row's deps against
+/// the board and insert it, in the caller's single lock scope.
+///
+/// A new row can carry deps (the dialog's chips), so the codes have to resolve —
+/// a dep naming nothing reads as *satisfied* to the drainer, which silently means
+/// "no dependency at all", the opposite of what was typed. It cannot close a
+/// loop: nothing can depend on a row that has no code yet.
+fn create_checked(
+    conn: &Connection,
+    project_id: &str,
+    item: &NewItem,
+) -> Result<RoadmapItem, String> {
+    if !item.deps.is_empty() {
+        let board = store::list(conn, project_id).map_err(|e| e.to_string())?;
+        deps::validate_new(&deps::graph_of(&board), &item.deps)?;
+    }
+    store::create(conn, project_id, item).map_err(|e| e.to_string())
 }
 
 /// Patch an item. Absent fields are left alone; an explicit `null` clears a
@@ -177,7 +198,7 @@ pub async fn roadmap_update_item(
 ) -> Result<ItemUpdate, String> {
     let (outcome, event) = {
         let conn = db.lock();
-        update_and_record(&conn, &id, &patch, expect_status).map_err(|e| e.to_string())?
+        update_and_record(&conn, &id, &patch, expect_status)?
     };
     let outcome = outcome.ok_or_else(|| format!("roadmap item {id} no longer exists"))?;
     // A miss changed nothing, so there is nothing to announce and nothing new
@@ -207,16 +228,29 @@ pub async fn roadmap_update_item(
 /// The event is `Some` exactly when the update applied: a missed precondition
 /// wrote nothing, so there is no history to invent for it — the applied /
 /// not-applied contract is untouched. Outer `None` means the row is gone.
+///
+/// A patch carrying `deps` is checked against [`deps`] *first*, in this same
+/// guard: this command is the item dialog's door, and a dep list that closes a
+/// loop would leave the queue skipping the whole chain forever. The refusal is
+/// an `Err` the dialog renders in its error slot, not a silent drop.
 fn update_and_record(
     conn: &Connection,
     id: &str,
     patch: &ItemPatch,
     expect_status: Option<ItemStatus>,
-) -> rusqlite::Result<(Option<ItemUpdate>, Option<ItemEvent>)> {
+) -> Result<(Option<ItemUpdate>, Option<ItemEvent>), String> {
+    if let Some(new_deps) = &patch.deps {
+        // A row that is already gone falls through to the normal "no longer
+        // exists" path below rather than being refused for its deps.
+        if let Some(current) = store::get(conn, id).map_err(|e| e.to_string())? {
+            check_dep_edit(conn, &current, new_deps)?;
+        }
+    }
     let updated = match expect_status {
-        Some(expected) => store::update_where_status(conn, id, expected, patch)?,
-        None => store::update(conn, id, patch)?,
-    };
+        Some(expected) => store::update_where_status(conn, id, expected, patch),
+        None => store::update(conn, id, patch),
+    }
+    .map_err(|e| e.to_string())?;
     match updated {
         Some(item) => {
             let kind = events::transition_kind(expect_status, patch.status);
@@ -229,7 +263,8 @@ fn update_and_record(
                 EventActor::User,
                 kind,
                 None,
-            )?;
+            )
+            .map_err(|e| e.to_string())?;
             Ok((
                 Some(ItemUpdate {
                     applied: true,
@@ -243,15 +278,39 @@ fn update_and_record(
         // gets back is the state that beat it.
         None => match expect_status {
             Some(_) => Ok((
-                store::get(conn, id)?.map(|item| ItemUpdate {
-                    applied: false,
-                    item,
-                }),
+                store::get(conn, id)
+                    .map_err(|e| e.to_string())?
+                    .map(|item| ItemUpdate {
+                        applied: false,
+                        item,
+                    }),
                 None,
             )),
             None => Ok((None, None)),
         },
     }
+}
+
+/// Check a dep list an item that already exists is about to be given: the codes
+/// must resolve, and the graph the write leaves behind must be acyclic
+/// ([`deps::validate_edit`]).
+///
+/// Skipped when the list is the one the item already has. Both writers send whole
+/// lists — the dialog posts its form, a PM patch can include an unchanged `deps`
+/// — and re-stating an item's own deps cannot make the graph worse. Refusing a
+/// retitle because of a loop that was already there would strand the row instead
+/// of helping fix it; the drainer's durable `blocked` event is what surfaces
+/// those.
+fn check_dep_edit(
+    conn: &Connection,
+    item: &RoadmapItem,
+    new_deps: &[String],
+) -> Result<(), String> {
+    if item.deps == new_deps {
+        return Ok(());
+    }
+    let board = store::list(conn, &item.project_id).map_err(|e| e.to_string())?;
+    deps::validate_edit(&deps::graph_of(&board), &item.code, new_deps)
 }
 
 /// Move an item in the project's priority order — the board's drag, landing as
@@ -449,8 +508,10 @@ enum Ruling {
     },
     /// The item was deleted at the PM's ask; emit the deletion.
     Discarded { item_id: String },
-    /// The item outran the ask (it went `active`+ since the PM proposed) — the
-    /// proposal was deleted without applying, and the message says why.
+    /// The board outran the ask — the item went `active`+ since the PM
+    /// proposed, or the dep list it asked for no longer resolves (or would now
+    /// close a loop). The proposal was deleted without applying, and the message
+    /// says why.
     Stale { message: String },
 }
 
@@ -480,9 +541,9 @@ fn ruling_detail(verb: &str, note: Option<&str>) -> String {
 
 /// The one write behind [`roadmap_accept_proposal`]: re-read the proposal and
 /// its item under the caller's lock, re-check the status gate (the item may
-/// have gone `active` since the PM asked), then apply-and-record or drop the
-/// stale ask. The proposal row is gone on every path — a ruling consumes it,
-/// and a dead ask shouldn't haunt the card.
+/// have gone `active` since the PM asked) and the dep graph ([`deps`]), then
+/// apply-and-record or drop the stale ask. The proposal row is gone on every
+/// path — a ruling consumes it, and a dead ask shouldn't haunt the card.
 fn accept_proposal(conn: &Connection, proposal_id: &str) -> Result<Ruling, String> {
     let proposal = proposals::get(conn, proposal_id)
         .map_err(|e| e.to_string())?
@@ -502,6 +563,20 @@ fn accept_proposal(conn: &Connection, proposal_id: &str) -> Result<Ruling, Strin
             let patch: ProposalPatch =
                 serde_json::from_value(proposal.patch.clone().ok_or("proposal carries no patch")?)
                     .map_err(|e| e.to_string())?;
+            // Re-checked here, not just when the PM asked: an item the patch
+            // depends on can have been deleted, and another item can have taken
+            // a dep on *this* one, since — either of which turns a dep list that
+            // was fine into a dangling reference or a loop. Same policy as a
+            // stale ask: refuse, say why, and consume the proposal rather than
+            // leaving a bar that fails every time it is clicked.
+            if let Some(new_deps) = &patch.deps {
+                if let Err(why) = check_dep_edit(conn, &item, new_deps) {
+                    proposals::delete(conn, proposal_id).map_err(|e| e.to_string())?;
+                    return Ok(Ruling::Stale {
+                        message: format!("the board changed since the PM asked — {why}"),
+                    });
+                }
+            }
             let updated = store::update(conn, &item.id, &patch.to_item_patch())
                 .map_err(|e| e.to_string())?
                 .ok_or("the item this proposal targets no longer exists")?;
@@ -1038,6 +1113,181 @@ mod tests {
         assert!(order::get(&conn, "p1").unwrap().is_none());
         assert_eq!(store::get(&conn, &a.id).unwrap().unwrap().rank, a.rank);
         assert!(events::list_for_item(&conn, &a.id).unwrap().is_empty());
+    }
+
+    /// A dep list the dialog sends is checked before it lands: an unknown code
+    /// (which the drainer would read as "satisfied") and a loop (which would
+    /// wedge the queue forever) are both refused, with nothing written.
+    #[test]
+    fn a_dep_edit_is_refused_when_it_closes_a_loop_or_names_nothing() {
+        let conn = test_conn();
+        let a = with_status(&conn, ItemStatus::Open);
+        let b = with_status(&conn, ItemStatus::Open);
+
+        let deps_patch = |codes: &[&str]| ItemPatch {
+            deps: Some(codes.iter().map(|c| (*c).to_string()).collect()),
+            ..Default::default()
+        };
+
+        // b after a: an ordinary edge, applied.
+        let (outcome, _) = update_and_record(&conn, &b.id, &deps_patch(&[&a.code]), None).unwrap();
+        assert_eq!(outcome.unwrap().item.deps, vec![a.code.clone()]);
+
+        // a after b now closes the loop — refused, and the row is untouched.
+        let err = update_and_record(&conn, &a.id, &deps_patch(&[&b.code]), None).unwrap_err();
+        assert!(err.contains("loop"), "{err}");
+        assert!(
+            err.contains(&format!("{} → {} → {}", a.code, b.code, a.code)),
+            "the refusal names the loop: {err}"
+        );
+        assert!(store::get(&conn, &a.id).unwrap().unwrap().deps.is_empty());
+
+        // A code that isn't on the board at all is refused too.
+        let err = update_and_record(&conn, &a.id, &deps_patch(&["MCA-999"]), None).unwrap_err();
+        assert!(err.contains("MCA-999"), "{err}");
+
+        // Self-reference, and the same rule on the create path.
+        let err = update_and_record(&conn, &a.id, &deps_patch(&[&a.code]), None).unwrap_err();
+        assert!(err.contains("depend on itself"), "{err}");
+        let err = create_checked(
+            &conn,
+            "p1",
+            &NewItem {
+                title: "fresh".into(),
+                deps: vec!["MCA-999".into()],
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(err.contains("MCA-999"), "{err}");
+        // A create naming a real code is fine — a new row can't be depended on.
+        assert!(create_checked(
+            &conn,
+            "p1",
+            &NewItem {
+                title: "fresh".into(),
+                deps: vec![a.code.clone()],
+                ..Default::default()
+            },
+        )
+        .is_ok());
+    }
+
+    /// Re-stating the deps an item already has is not a refusal — even when they
+    /// are part of a loop written before this check existed. The dialog posts the
+    /// whole form, so blocking a retitle would strand the row; the drainer's
+    /// durable `blocked` event is what surfaces a loop like that.
+    #[test]
+    fn resending_an_items_own_deps_is_not_refused() {
+        let conn = test_conn();
+        let a = with_status(&conn, ItemStatus::Open);
+        let b = with_status(&conn, ItemStatus::Open);
+        for (row, dep) in [(&a, &b.code), (&b, &a.code)] {
+            store::update(
+                &conn,
+                &row.id,
+                &ItemPatch {
+                    deps: Some(vec![dep.clone()]),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        }
+
+        let patch = ItemPatch {
+            title: Some("retitled".into()),
+            deps: Some(vec![b.code.clone()]),
+            ..Default::default()
+        };
+        let (outcome, _) = update_and_record(&conn, &a.id, &patch, None).unwrap();
+        assert_eq!(outcome.unwrap().item.title, "retitled");
+    }
+
+    /// A dep patch that was fine when the PM asked can be a loop by the time the
+    /// user clicks: the board moved. Re-validated at ruling time, refused, and
+    /// the ask is consumed rather than left to fail on every click.
+    #[test]
+    fn accepting_a_dep_patch_that_became_a_loop_refuses_and_clears() {
+        let conn = test_conn();
+        let a = with_status(&conn, ItemStatus::Open);
+        let b = with_status(&conn, ItemStatus::Open);
+        let patch = ProposalPatch {
+            deps: Some(vec![b.code.clone()]),
+            ..Default::default()
+        };
+        let p = proposals::upsert(
+            &conn,
+            "p1",
+            &a.id,
+            ProposalKind::Update,
+            Some(&patch),
+            Some("b first"),
+        )
+        .unwrap();
+        // Meanwhile the user (or an earlier ruling) made b depend on a.
+        store::update(
+            &conn,
+            &b.id,
+            &ItemPatch {
+                deps: Some(vec![a.code.clone()]),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let Ruling::Stale { message } = accept_proposal(&conn, &p.id).unwrap() else {
+            panic!("expected Stale");
+        };
+        assert!(message.contains("the board changed"), "{message}");
+        assert!(message.contains("loop"), "{message}");
+        assert!(proposals::get(&conn, &p.id).unwrap().is_none());
+        // Nothing applied, and no history invented for a write that didn't land.
+        assert!(store::get(&conn, &a.id).unwrap().unwrap().deps.is_empty());
+        assert!(events::list_for_item(&conn, &a.id).unwrap().is_empty());
+    }
+
+    /// The other half of the same re-check: the item the ask depends on was
+    /// deleted since. Applying it blind would leave a dangling code the drainer
+    /// silently treats as satisfied — so it refuses and says what vanished.
+    #[test]
+    fn accepting_a_dep_patch_whose_dependency_vanished_refuses() {
+        let conn = test_conn();
+        let a = with_status(&conn, ItemStatus::Open);
+        let gone = with_status(&conn, ItemStatus::Open);
+        let patch = ProposalPatch {
+            deps: Some(vec![gone.code.clone()]),
+            ..Default::default()
+        };
+        let p = proposals::upsert(&conn, "p1", &a.id, ProposalKind::Update, Some(&patch), None)
+            .unwrap();
+        store::delete(&conn, &gone.id).unwrap();
+
+        let Ruling::Stale { message } = accept_proposal(&conn, &p.id).unwrap() else {
+            panic!("expected Stale");
+        };
+        assert!(message.contains(&gone.code), "{message}");
+        assert!(proposals::get(&conn, &p.id).unwrap().is_none());
+        assert!(store::get(&conn, &a.id).unwrap().unwrap().deps.is_empty());
+    }
+
+    /// A dep patch that is still valid applies as any other patch does — the
+    /// re-check is a gate, not a second refusal path for good asks.
+    #[test]
+    fn accepting_a_still_valid_dep_patch_applies_it() {
+        let conn = test_conn();
+        let a = with_status(&conn, ItemStatus::Open);
+        let b = with_status(&conn, ItemStatus::Open);
+        let patch = ProposalPatch {
+            deps: Some(vec![b.code.clone()]),
+            ..Default::default()
+        };
+        let p = proposals::upsert(&conn, "p1", &a.id, ProposalKind::Update, Some(&patch), None)
+            .unwrap();
+
+        let Ruling::Updated { item, .. } = accept_proposal(&conn, &p.id).unwrap() else {
+            panic!("expected Updated");
+        };
+        assert_eq!(item.deps, vec![b.code]);
     }
 
     /// Declining leaves the item alone and writes the refusal as a durable

--- a/src-tauri/src/rpc/roadmap.rs
+++ b/src-tauri/src/rpc/roadmap.rs
@@ -18,7 +18,10 @@
 //!   "pm"`. A proposed row is a *ghost* on the board: it renders where it would
 //!   land, counts for nothing, and only becomes real when the user accepts it
 //!   (`proposed → open`) or vanishes when they discard it. That is the whole
-//!   safety property of this tool — the agent can suggest, never commit.
+//!   safety property of this tool — the agent can suggest, never commit. A
+//!   batch item's `deps` may name another item in the same batch as `"#n"`,
+//!   resolved to real codes inside the insert transaction, so an ordered plan
+//!   is one call rather than one call per link.
 //! - `roadmap_propose_update` / `roadmap_propose_discard` — the same contract
 //!   for items that already exist: the ask lands as a pending delta
 //!   ([`crate::roadmap::proposals`], at most one per item, a newer one
@@ -41,11 +44,12 @@ use serde::Deserialize;
 use serde_json::{json, Map, Value};
 use tauri::AppHandle;
 
+use crate::roadmap::deps;
 use crate::roadmap::events::{self, EventActor, EventKind, ItemEvent};
 use crate::roadmap::order::{self, OrderProposal};
 use crate::roadmap::proposals::{self, Proposal, ProposalKind, ProposalPatch};
 use crate::roadmap::store;
-use crate::roadmap::types::{Horizon, ItemSource, ItemStatus, NewItem, RoadmapItem};
+use crate::roadmap::types::{Horizon, ItemPatch, ItemSource, ItemStatus, NewItem, RoadmapItem};
 use crate::roadmap::Db;
 use crate::rpc::git::GitDispatcher;
 use crate::rpc::{Response, RpcDispatcher, RpcEvent, RpcFuture};
@@ -304,10 +308,16 @@ fn list_op(conn: &Connection, project_id: &str, id: &str, args: &Value) -> Respo
 // ─────────────────────────── roadmap_propose ────────────────────────────
 
 /// Turn the agent's items into validated [`NewItem`]s, or explain what's wrong
-/// with the batch. `known` is every code already on this project's board —
-/// `deps` may only reference those (codes are allocated on insert, so an item
-/// cannot depend on one from the same batch).
-fn validate(items: &[ProposedItem], known: &HashSet<&str>) -> Result<Vec<NewItem>, String> {
+/// with the batch. `existing` is the project's board: `deps` may name a code
+/// already on it, or another item in *this* batch as `"#n"` (1-based), which is
+/// what lets one call express an ordered plan. The whole merged graph — the
+/// batch's own edges plus the board's — has to stay acyclic
+/// ([`deps::validate_batch`]).
+///
+/// The `"#n"` entries survive into the returned [`NewItem`]s untouched; only the
+/// insert transaction can resolve them, because that is where codes are
+/// allocated (see [`resolve_batch_deps`]).
+fn validate(items: &[ProposedItem], existing: &[RoadmapItem]) -> Result<Vec<NewItem>, String> {
     if items.is_empty() {
         return Err("`items` must be a non-empty array of tickets".into());
     }
@@ -318,7 +328,7 @@ fn validate(items: &[ProposedItem], known: &HashSet<&str>) -> Result<Vec<NewItem
             items.len()
         ));
     }
-    let mut out = Vec::with_capacity(items.len());
+    let mut out: Vec<NewItem> = Vec::with_capacity(items.len());
     for (n, it) in items.iter().enumerate() {
         // 1-based: "item 1" is the first thing the agent wrote.
         let at = n + 1;
@@ -340,16 +350,6 @@ fn validate(items: &[ProposedItem], known: &HashSet<&str>) -> Result<Vec<NewItem
                 )
             })?,
         };
-        let deps = clean_list(&it.deps);
-        for d in &deps {
-            if !known.contains(d.as_str()) {
-                return Err(format!(
-                    "item {at} ({title:?}): `deps` names {d:?}, which is not an item on this \
-                     board — depend only on codes `roadmap_list` returns (a ticket from this \
-                     same batch has no code yet)"
-                ));
-            }
-        }
         out.push(NewItem {
             title: title.to_string(),
             why: it.why.trim().to_string(),
@@ -360,13 +360,37 @@ fn validate(items: &[ProposedItem], known: &HashSet<&str>) -> Result<Vec<NewItem
             area: clean(it.area.as_deref()),
             source: Some(ItemSource::Pm),
             accept: clean_list(&it.accept),
-            deps,
+            deps: clean_list(&it.deps),
             // Which workflow builds it is the user's call, not the PM's — a
             // proposal isn't work anyone has agreed to do yet.
             workflow_def_id: None,
         });
     }
+    // The deps of the whole batch at once, because that is the only scope an
+    // intra-batch loop is visible in. Refused per item, with the item's own
+    // number and title — the PM fixes one ticket, not a graph.
+    let lists: Vec<Vec<String>> = out.iter().map(|n| n.deps.clone()).collect();
+    deps::validate_batch(&deps::graph_of(existing), &lists)
+        .map_err(|r| format!("item {} ({:?}): {}", r.at + 1, out[r.at].title, r.message))?;
     Ok(out)
+}
+
+/// Rewrite a batch item's `"#n"` references into the codes the insert allocated.
+///
+/// Called *inside* the insert transaction, once every row exists: `"#2"` means
+/// "the second ticket in this call", and only the transaction knows what code
+/// that ticket got. Forward references work for the same reason — the rewrite
+/// happens after all the inserts, not during them.
+///
+/// A dep that isn't a batch reference is left exactly as written; validation has
+/// already established it is a code on the board.
+fn resolve_batch_deps(raw: &[String], created: &[RoadmapItem]) -> Vec<String> {
+    raw.iter()
+        .map(|d| match deps::batch_index(d, created.len()) {
+            Some(i) => created[i].code.clone(),
+            None => d.clone(),
+        })
+        .collect()
 }
 
 /// `roadmap_propose`: validate the batch, insert it as `proposed` rows in one
@@ -397,8 +421,7 @@ fn propose_op(
         Ok(items) => items,
         Err(e) => return err(e.to_string()),
     };
-    let known: HashSet<&str> = existing.iter().map(|i| i.code.as_str()).collect();
-    let news = match validate(&args.items, &known) {
+    let news = match validate(&args.items, &existing) {
         Ok(news) => news,
         Err(msg) => return err(msg),
     };
@@ -406,7 +429,9 @@ fn propose_op(
     // All or nothing: a failure half-way through must not leave the user
     // staring at three of the five tickets they were promised. Each row's
     // `proposed` history event rides the same transaction, so a ghost can never
-    // exist without the record of who suggested it.
+    // exist without the record of who suggested it. The `"#n"` rewrite rides it
+    // too — a batch whose internal ordering half-applied would be a plan nobody
+    // proposed.
     let created = (|| -> rusqlite::Result<(Vec<RoadmapItem>, Vec<ItemEvent>)> {
         let tx = conn.unchecked_transaction()?;
         let mut created = Vec::with_capacity(news.len());
@@ -422,6 +447,25 @@ fn propose_op(
                 None,
             )?);
             created.push(item);
+        }
+        // Second pass, now that every ticket has a code: turn the batch
+        // references into real deps. Only the rows that used one are rewritten,
+        // so an ordinary batch costs no extra write.
+        for (n, new) in news.iter().enumerate() {
+            if !new.deps.iter().any(|d| d.starts_with(deps::BATCH_PREFIX)) {
+                continue;
+            }
+            let resolved = resolve_batch_deps(&new.deps, &created);
+            if let Some(row) = store::update(
+                &tx,
+                &created[n].id,
+                &ItemPatch {
+                    deps: Some(resolved),
+                    ..Default::default()
+                },
+            )? {
+                created[n] = row;
+            }
         }
         tx.commit()?;
         Ok((created, recorded))
@@ -487,12 +531,16 @@ fn rulable(status: ItemStatus) -> bool {
 }
 
 /// Normalize and validate an update's patch against the board, or say exactly
-/// what's wrong: same rules the batch propose applies, plus "don't depend on
-/// yourself" (possible here because the target already has a code).
+/// what's wrong: same rules the batch propose applies, plus the two a patch can
+/// break that a new ticket can't — depending on yourself, and closing a loop
+/// with an item that already depends on you ([`deps::validate_edit`]).
+///
+/// Checked here *and* again when the user rules on the ask: the board moves in
+/// between, and an accepted loop is a permanently wedged queue.
 fn validate_patch(
     patch: &ProposalPatch,
     item: &RoadmapItem,
-    known: &HashSet<&str>,
+    board: &[RoadmapItem],
 ) -> Result<ProposalPatch, String> {
     if patch.is_empty() {
         return Err("`patch` must change at least one field — \
@@ -520,20 +568,10 @@ fn validate_patch(
     if let Some(accept) = &out.accept {
         out.accept = Some(clean_list(accept));
     }
-    if let Some(deps) = &out.deps {
-        let deps = clean_list(deps);
-        for d in &deps {
-            if d == &item.code {
-                return Err(format!("{} cannot depend on itself", item.code));
-            }
-            if !known.contains(d.as_str()) {
-                return Err(format!(
-                    "`deps` names {d:?}, which is not an item on this board — \
-                     depend only on codes `roadmap_list` returns"
-                ));
-            }
-        }
-        out.deps = Some(deps);
+    if let Some(patched) = &out.deps {
+        let patched = clean_list(patched);
+        deps::validate_edit(&deps::graph_of(board), &item.code, &patched)?;
+        out.deps = Some(patched);
     }
     Ok(out)
 }
@@ -569,8 +607,7 @@ fn propose_update_op(
         Ok(item) => item,
         Err(e) => return err(e),
     };
-    let known: HashSet<&str> = items.iter().map(|i| i.code.as_str()).collect();
-    let patch = match validate_patch(&args.patch, item, &known) {
+    let patch = match validate_patch(&args.patch, item, &items) {
         Ok(patch) => patch,
         Err(e) => return err(e),
     };
@@ -979,7 +1016,7 @@ mod tests {
     }
 
     #[test]
-    fn deps_must_name_codes_already_on_this_board() {
+    fn deps_must_name_a_code_on_the_board_or_an_item_in_this_batch() {
         let db = test_db("p1");
         assert!(propose(&db, one_item("first")).ok);
 
@@ -990,15 +1027,174 @@ mod tests {
         );
         assert!(resp.ok, "{resp:?}");
 
-        // One that doesn't exist rejects the batch, and says why.
+        // One that doesn't exist rejects the batch, names it, and offers the
+        // codes it could have named instead.
         let resp = propose(
             &db,
             json!({"items": [{"title": "third", "horizon": "next", "deps": ["MCA-999"]}]}),
         );
         assert!(!resp.ok);
         let e = resp.error.unwrap();
-        assert!(e.contains("MCA-999") && e.contains("roadmap_list"), "{e}");
+        assert!(
+            e.contains("MCA-999") && e.contains("MCA-100, MCA-101"),
+            "{e}"
+        );
+        // And the batch syntax is offered too, since that is the other legal
+        // spelling in this op.
+        assert!(e.contains("#n"), "{e}");
         assert_eq!(store::list(&db.lock(), "p1").unwrap().len(), 2);
+    }
+
+    /// The whole point of `"#n"`: an ordered plan in one call. The references are
+    /// resolved to the codes the insert allocated — forward ones included, since
+    /// the rewrite runs after every row exists.
+    #[test]
+    fn a_batch_can_order_itself_with_hash_references() {
+        let db = test_db("p1");
+        let resp = propose(
+            &db,
+            json!({"items": [
+                {"title": "the seam", "horizon": "now"},
+                {"title": "the drainer", "horizon": "now", "deps": ["#1"]},
+                {"title": "the card", "horizon": "next", "deps": ["#2", "#1"]},
+            ]}),
+        );
+        assert!(resp.ok, "{resp:?}");
+
+        let rows = store::list(&db.lock(), "p1").unwrap();
+        assert_eq!(rows.len(), 3);
+        assert!(rows[0].deps.is_empty());
+        // Stored as real codes, so every reader (the drainer, the card, the next
+        // `roadmap_list`) sees ordinary deps — `"#n"` exists only in the ask.
+        assert_eq!(rows[1].deps, vec!["MCA-100".to_string()]);
+        assert_eq!(
+            rows[2].deps,
+            vec!["MCA-101".to_string(), "MCA-100".to_string()]
+        );
+
+        // A forward reference (item 1 after item 2) is the same mechanism.
+        let resp = propose(
+            &db,
+            json!({"items": [
+                {"title": "later", "horizon": "next", "deps": ["#2"]},
+                {"title": "first", "horizon": "next"},
+            ]}),
+        );
+        assert!(resp.ok, "{resp:?}");
+        let rows = store::list(&db.lock(), "p1").unwrap();
+        assert_eq!(rows[3].deps, vec!["MCA-104".to_string()]);
+    }
+
+    /// A batch that orders itself into a circle is refused whole — the failure
+    /// this slice exists to make unreachable, caught before a single row lands.
+    #[test]
+    fn a_batch_that_closes_a_loop_is_refused_whole() {
+        let db = test_db("p1");
+        let resp = propose(
+            &db,
+            json!({"items": [
+                {"title": "one", "horizon": "now", "deps": ["#2"]},
+                {"title": "two", "horizon": "now", "deps": ["#1"]},
+            ]}),
+        );
+        assert!(!resp.ok);
+        let e = resp.error.unwrap();
+        assert!(e.contains("loop"), "{e}");
+        assert!(
+            e.contains("#1 → #2 → #1"),
+            "the refusal spells the loop: {e}"
+        );
+        assert!(store::list(&db.lock(), "p1").unwrap().is_empty());
+    }
+
+    /// A ticket hanging off a loop that is already on the board (one written
+    /// before this check existed) is refused too: it could never be built
+    /// either, and the refusal names the loop the PM has to propose away first.
+    #[test]
+    fn a_batch_item_waiting_on_an_existing_loop_is_refused() {
+        let db = test_db("p1");
+        assert!(propose(&db, one_item("a")).ok); // MCA-100
+        assert!(propose(&db, one_item("b")).ok); // MCA-101
+        {
+            // Straight through the DAO: the ops above are exactly what stops
+            // this shape being reachable now, so the legacy board is built by hand.
+            let conn = db.lock();
+            let rows = store::list(&conn, "p1").unwrap();
+            for (row, dep) in [(&rows[0], "MCA-101"), (&rows[1], "MCA-100")] {
+                store::update(
+                    &conn,
+                    &row.id,
+                    &ItemPatch {
+                        deps: Some(vec![dep.to_string()]),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+            }
+        }
+
+        let resp = propose(
+            &db,
+            json!({"items": [{"title": "after", "horizon": "now", "deps": ["MCA-100"]}]}),
+        );
+        assert!(!resp.ok);
+        let e = resp.error.unwrap();
+        assert!(e.contains("MCA-100 → MCA-101 → MCA-100"), "{e}");
+        assert_eq!(store::list(&db.lock(), "p1").unwrap().len(), 2);
+    }
+
+    /// A reference to a position the batch doesn't have is a mistake worth
+    /// naming: it would otherwise resolve to nothing and read as "no dependency".
+    #[test]
+    fn a_hash_reference_out_of_range_is_refused() {
+        let db = test_db("p1");
+        for (deps, needle) in [
+            (json!(["#3"]), "not an item in this batch"),
+            (json!(["#0"]), "not an item in this batch"),
+            (json!(["#two"]), "not an item in this batch"),
+        ] {
+            let resp = propose(
+                &db,
+                json!({"items": [
+                    {"title": "one", "horizon": "now", "deps": deps},
+                    {"title": "two", "horizon": "now"},
+                ]}),
+            );
+            assert!(!resp.ok, "should have been rejected");
+            let e = resp.error.unwrap();
+            assert!(e.contains(needle), "expected {needle:?} in {e:?}");
+            assert!(e.contains("item 1"), "the refusal names the item: {e}");
+        }
+        assert!(store::list(&db.lock(), "p1").unwrap().is_empty());
+    }
+
+    /// The urgent one (see .context/roadmap-pm-plan.md, A4): a dep patch that
+    /// closes a loop is refused at propose time, so the user is never offered a
+    /// diff whose acceptance would wedge the queue.
+    #[test]
+    fn propose_update_refuses_a_dep_patch_that_closes_a_loop() {
+        let db = test_db("p1");
+        assert!(propose(&db, one_item("first")).ok); // MCA-100
+        assert!(
+            propose(
+                &db,
+                json!({"items": [{"title": "second", "horizon": "next", "deps": ["MCA-100"]}]})
+            )
+            .ok
+        ); // MCA-101, after MCA-100
+
+        let (resp, stored) = propose_update(
+            &db,
+            json!({"code": "MCA-100", "patch": {"deps": ["MCA-101"]},
+                   "note": "actually the other way round"}),
+        );
+        assert!(!resp.ok);
+        let e = resp.error.unwrap();
+        assert!(e.contains("MCA-100 → MCA-101 → MCA-100"), "{e}");
+        assert!(stored.is_none(), "a refused ask is not parked");
+        assert!(proposals::list_for_project(&db.lock(), "p1")
+            .unwrap()
+            .is_empty());
     }
 
     #[test]

--- a/src/components/ProjectScreen/Roadmap/Board/ItemDialog.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/ItemDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import type { Horizon, RoadmapItem } from "@/api";
 import { Icon } from "@/components/Icon";
 import { Segmented } from "@/components/Settings/Segmented";
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/Button";
 import { Modal, ModalBody, ModalFooter } from "@/components/ui/Modal";
 import { Select, type SelectOption } from "@/components/ui/Select";
 import { TextArea, TextInput } from "@/components/ui/TextInput";
+import { addDep, removeDep, suggestCodes } from "../depsField";
 import { HORIZONS } from "../types";
 import type { ProjectWorkflows } from "../useProjectWorkflows";
 
@@ -19,6 +20,11 @@ export interface ItemDraft {
   horizon: Horizon;
   area: string | null;
   accept: string[];
+  /** Codes this item must land after. The queue skips an item whose deps aren't
+   *  `done`, so this is the user's half of dispatch order (rank is the other).
+   *  Validated against the board here for speed and against the real dependency
+   *  graph backend-side, which is the authority — only it can see a loop. */
+  deps: string[];
   /** Which workflow the queue dispatches this under. `null` means "whatever the
    *  project's default is at dispatch time" — resolved by the Rust drainer, not
    *  frozen here, so changing the project default moves every un-pinned item. */
@@ -47,6 +53,9 @@ interface Props {
   /** The workflows this project could run the item under, and which one is its
    *  default. */
   workflows: ProjectWorkflows;
+  /** Every code on the board, for the dep field — exact matches only, because
+   *  the prefix varies per project. */
+  codes: ReadonlySet<string>;
   onClose: () => void;
   onSave: (draft: ItemDraft) => Promise<unknown>;
   /** Absent while creating: there is nothing to delete yet. */
@@ -55,18 +64,51 @@ interface Props {
 
 /** Create or edit one roadmap item. The same form for both, because the fields
  *  are the same and a separate "quick add" would drift from it. */
-export function ItemDialog({ item, horizon, workflows, onClose, onSave, onDelete }: Props) {
+export function ItemDialog({ item, horizon, workflows, codes, onClose, onSave, onDelete }: Props) {
   const [title, setTitle] = useState(item?.title ?? "");
   const [why, setWhy] = useState(item?.why ?? "");
   const [place, setPlace] = useState<Horizon>(item?.horizon ?? horizon);
   const [area, setArea] = useState(item?.area ?? "");
   const [accept, setAccept] = useState((item?.accept ?? []).join("\n"));
+  const [deps, setDeps] = useState<string[]>(item?.deps ?? []);
+  /** What is typed in the dep box but not yet a chip. */
+  const [depDraft, setDepDraft] = useState("");
   const [workflow, setWorkflow] = useState<string>(item?.workflow_def_id ?? PROJECT_DEFAULT);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   const canSave = title.trim().length > 0 && !busy;
+
+  /** Every code this item could still depend on — the board minus itself and
+   *  minus the chips already there. Independent of what is typed, so the field
+   *  doesn't disable itself mid-word when a query matches nothing. */
+  const depsAvailable = useMemo(
+    () => suggestCodes("", codes, deps, item?.code),
+    [codes, deps, item?.code],
+  );
+  /** …narrowed to what has been typed, for the suggestion list. Filtered here
+   *  rather than left to the datalist, whose matching rules vary by engine. */
+  const depOptions = useMemo(
+    () => suggestCodes(depDraft, codes, deps, item?.code),
+    [depDraft, codes, deps, item?.code],
+  );
+
+  /** Turn the typed token into a chip, or say why it can't be one. Refusals the
+   *  board can answer (unknown code, self) land here; a *loop* comes back from
+   *  the backend on save, into the same slot. */
+  const commitDep = () => {
+    const { deps: next, error: refusal } = addDep(deps, depDraft, codes, item?.code);
+    if (refusal) {
+      setError(refusal);
+      return;
+    }
+    if (next) {
+      setDeps(next);
+      setError(null);
+    }
+    setDepDraft("");
+  };
 
   // "Project default" names the definition when there is one, so the choice is
   // legible rather than a promise the user has to go and verify. When there
@@ -87,6 +129,13 @@ export function ItemDialog({ item, horizon, workflows, onClose, onSave, onDelete
 
   const save = async () => {
     if (!canSave) return;
+    // A code left in the box is meant as a dep — saving without it would drop
+    // it silently. A refusal stops the save, with the reason on screen.
+    const pending = addDep(deps, depDraft, codes, item?.code);
+    if (pending.error) {
+      setError(pending.error);
+      return;
+    }
     setBusy(true);
     setError(null);
     try {
@@ -96,6 +145,7 @@ export function ItemDialog({ item, horizon, workflows, onClose, onSave, onDelete
         horizon: place,
         area: area.trim() || null,
         accept: linesToList(accept),
+        deps: pending.deps ?? deps,
         workflow_def_id: workflow === PROJECT_DEFAULT ? null : workflow,
       });
       onClose();
@@ -148,6 +198,61 @@ export function ItemDialog({ item, horizon, workflows, onClose, onSave, onDelete
         <div className="modal-field">
           <span className="modal-label text-sm">Horizon</span>
           <Segmented value={place} options={HORIZON_OPTIONS} onChange={setPlace} />
+        </div>
+
+        {/* Dependencies as chips: a code is a thing you pick, not prose, and the
+            row already draws them this way ("after FLT-100"). The queue skips an
+            item whose deps aren't done, so this field is dispatch order the user
+            can state — the loop check is the backend's (see roadmap::deps). */}
+        <div className="modal-field">
+          <label className="modal-label text-sm" htmlFor="rm-deps">
+            After <span className="modal-opt">codes this must land after, optional</span>
+          </label>
+          <div className="rm-deps flex-center">
+            {deps.map((d) => (
+              <span key={d} className="rm-dep-chip iflex-center mono text-xs">
+                {d}
+                <button
+                  type="button"
+                  className="rm-dep-x iflex-center"
+                  aria-label={`Remove ${d}`}
+                  onClick={() => {
+                    setDeps(removeDep(deps, d));
+                    setError(null);
+                  }}
+                >
+                  <Icon name="close" size={9} />
+                </button>
+              </span>
+            ))}
+            <input
+              id="rm-deps"
+              className="rm-deps-in mono text-xs"
+              list="rm-deps-codes"
+              autoComplete="off"
+              placeholder={deps.length ? "" : (depsAvailable[0] ?? "nothing else on the board yet")}
+              disabled={depsAvailable.length === 0 && deps.length === 0}
+              value={depDraft}
+              onChange={(e) => setDepDraft(e.target.value)}
+              onBlur={commitDep}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === ",") {
+                  // The chip, not the form: Enter here means "that's a dep".
+                  e.preventDefault();
+                  commitDep();
+                } else if (e.key === "Backspace" && !depDraft && deps.length) {
+                  setDeps(deps.slice(0, -1));
+                }
+              }}
+            />
+            {/* Native suggestions rather than a popup: the answer is a short
+                list of codes, and the datalist filters as the user types. */}
+            <datalist id="rm-deps-codes">
+              {depOptions.map((c) => (
+                <option key={c} value={c} />
+              ))}
+            </datalist>
+          </div>
         </div>
 
         <div className="modal-field">

--- a/src/components/ProjectScreen/Roadmap/Board/index.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/index.tsx
@@ -54,6 +54,7 @@ export function Board({
     notes,
     events,
     runsById,
+    codes,
     addItem,
     editItem,
     removeItems,
@@ -323,6 +324,7 @@ export function Board({
           item={editing.item}
           horizon={editing.horizon}
           workflows={workflows}
+          codes={codes}
           onClose={() => setEditing(null)}
           onSave={(draft) => (editRow ? editItem(editRow.id, draft) : addItem(draft))}
           onDelete={editRow ? () => removeItems([editRow.id]) : undefined}

--- a/src/components/ProjectScreen/Roadmap/Roadmap.css
+++ b/src/components/ProjectScreen/Roadmap/Roadmap.css
@@ -1304,6 +1304,67 @@ button.rm-hist-h:hover {
   line-height: var(--lh-normal);
 }
 
+/* The dependency field: chips in a box that wears `.ui-input`'s skin, with a
+   bare input trailing them. Not a `TextInput` with a comma-separated string,
+   because a dep is a *code that exists* — one chip per resolved item is the
+   whole point, and removing one has to be a click rather than careful editing.
+   The box grows down as chips wrap; it never scrolls. */
+.rm-deps {
+  flex-wrap: wrap;
+  gap: 6px;
+  min-height: 36px;
+  padding: 6px 8px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--bd);
+  background: var(--bg-0);
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
+}
+.rm-deps:focus-within {
+  border-color: var(--accent-line);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent), transparent 90%);
+}
+/* Same ink as the row's `after FLT-100` chip, so the form and the card are
+   visibly talking about one thing. */
+.rm-dep-chip {
+  gap: 5px;
+  height: 22px;
+  padding: 0 4px 0 7px;
+  border-radius: var(--r-sm);
+  border: 1px solid color-mix(in oklch, var(--info), transparent 70%);
+  background: color-mix(in oklch, var(--info), transparent 88%);
+  color: var(--info);
+  line-height: var(--lh-none);
+  white-space: nowrap;
+}
+.rm-dep-x {
+  width: 16px;
+  height: 16px;
+  justify-content: center;
+  border-radius: var(--r-sm);
+  color: inherit;
+  opacity: 0.65;
+}
+.rm-dep-x:hover {
+  opacity: 1;
+  background: color-mix(in oklch, var(--info), transparent 80%);
+}
+.rm-deps-in {
+  flex: 1;
+  min-width: 90px;
+  height: 22px;
+  border: none;
+  background: none;
+  color: var(--fg-0);
+}
+.rm-deps-in::placeholder {
+  color: var(--fg-3);
+}
+.rm-deps-in:focus {
+  outline: none;
+}
+
 /* ── product map tab ── */
 .rm-map {
   display: flex;

--- a/src/components/ProjectScreen/Roadmap/depsField.test.ts
+++ b/src/components/ProjectScreen/Roadmap/depsField.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { addDep, removeDep, resolveCode, suggestCodes } from "./depsField";
+
+const board = new Set(["FLT-100", "FLT-101", "FLT-142"]);
+
+describe("resolveCode", () => {
+  it("matches exactly first, then case-insensitively", () => {
+    expect(resolveCode("  FLT-100 ", board)).toBe("FLT-100");
+    expect(resolveCode("flt-142", board)).toBe("FLT-142");
+    // Nothing on the board: handed back as typed, for the refusal to name.
+    expect(resolveCode("nope", board)).toBe("nope");
+  });
+});
+
+describe("addDep", () => {
+  it("adds a code that is on the board", () => {
+    expect(addDep([], "flt-100", board)).toEqual({ deps: ["FLT-100"], error: null });
+    expect(addDep(["FLT-100"], "FLT-101", board)).toEqual({
+      deps: ["FLT-100", "FLT-101"],
+      error: null,
+    });
+  });
+
+  it("does nothing for an empty box", () => {
+    expect(addDep(["FLT-100"], "   ", board)).toEqual({ deps: null, error: null });
+  });
+
+  it("keeps a duplicate out without calling it an error", () => {
+    expect(addDep(["FLT-100"], "FLT-100", board)).toEqual({ deps: ["FLT-100"], error: null });
+  });
+
+  it("refuses a code that isn't on the board", () => {
+    const { deps, error } = addDep([], "FLT-999", board);
+    expect(deps).toBeNull();
+    expect(error).toContain("FLT-999");
+  });
+
+  it("refuses the item's own code", () => {
+    // The loop of length one. Longer loops are the backend's answer — it holds
+    // the graph — and arrive as the dialog's error.
+    const { deps, error } = addDep([], "flt-142", board, "FLT-142");
+    expect(deps).toBeNull();
+    expect(error).toContain("itself");
+  });
+});
+
+describe("removeDep", () => {
+  it("drops just that chip", () => {
+    expect(removeDep(["FLT-100", "FLT-101"], "FLT-100")).toEqual(["FLT-101"]);
+  });
+});
+
+describe("suggestCodes", () => {
+  it("offers the board, minus this item and what is already chosen", () => {
+    expect(suggestCodes("", board, ["FLT-101"], "FLT-142")).toEqual(["FLT-100"]);
+  });
+
+  it("matches on the number alone, since the prefix is the same for every row", () => {
+    expect(suggestCodes("10", board, [])).toEqual(["FLT-100", "FLT-101"]);
+    expect(suggestCodes("142", board, [])).toEqual(["FLT-142"]);
+    expect(suggestCodes("zzz", board, [])).toEqual([]);
+  });
+
+  it("caps the list so it stays glanceable", () => {
+    const many = new Set(Array.from({ length: 30 }, (_, n) => `FLT-${100 + n}`));
+    expect(suggestCodes("", many, [], null, 3)).toEqual(["FLT-100", "FLT-101", "FLT-102"]);
+  });
+});

--- a/src/components/ProjectScreen/Roadmap/depsField.ts
+++ b/src/components/ProjectScreen/Roadmap/depsField.ts
@@ -1,0 +1,75 @@
+// The item form's dependency chips, as pure functions.
+//
+// `deps` is a list of item *codes* ("FLT-142") this item must land after — the
+// same field the PM writes and the queue drainer reads (src-tauri/src/roadmap).
+// The rules here are the fast half of the answer: they refuse a code that isn't
+// on the board, a duplicate, and self-reference before a round trip. They
+// deliberately do NOT know about loops — that is a graph question, and the
+// backend's `roadmap::deps` module is the authority for it (a loop refusal comes
+// back as an error the dialog renders, naming the loop). Two implementations of
+// cycle detection would be one too many.
+//
+// Split out of the dialog because it is exactly the part worth testing: a chip
+// field is markup, but "which token becomes which code" is a rule.
+
+/** Nothing to do (the box was empty), a new list, or a refusal — exactly one. */
+export interface DepAdd {
+  /** The list to keep, when the token resolved. Null when nothing changed. */
+  deps: string[] | null;
+  /** Why the token was refused, for the dialog's error slot. */
+  error: string | null;
+}
+
+/** The code a typed token means. Codes are upper case by construction
+ *  (`store::code_prefix`), so "flt-142" is the same item — but an exact match
+ *  always wins, because the prefix is per project and this must not invent one. */
+export function resolveCode(raw: string, codes: ReadonlySet<string>): string {
+  const trimmed = raw.trim();
+  if (codes.has(trimmed)) return trimmed;
+  const upper = trimmed.toUpperCase();
+  return codes.has(upper) ? upper : trimmed;
+}
+
+/** Add a typed token to a dep list, or say why not. Idempotent on a code that
+ *  is already there: re-typing a dep is not an error worth a red line. */
+export function addDep(
+  current: readonly string[],
+  raw: string,
+  codes: ReadonlySet<string>,
+  self?: string | null,
+): DepAdd {
+  if (!raw.trim()) return { deps: null, error: null };
+  const code = resolveCode(raw, codes);
+  if (self && code === self) {
+    return { deps: null, error: `${code} can't depend on itself.` };
+  }
+  if (!codes.has(code)) {
+    return { deps: null, error: `There is no ${code} on this board.` };
+  }
+  if (current.includes(code)) return { deps: [...current], error: null };
+  return { deps: [...current, code], error: null };
+}
+
+/** Drop a chip. */
+export function removeDep(current: readonly string[], code: string): string[] {
+  return current.filter((c) => c !== code);
+}
+
+/** The codes to offer for what has been typed so far: every code on the board
+ *  that isn't this item, isn't already a chip, and contains the query (so
+ *  "142" finds "FLT-142" — the prefix is the same for every row and typing it
+ *  is pure ceremony). Sorted, and capped so the list stays glanceable. */
+export function suggestCodes(
+  query: string,
+  codes: ReadonlySet<string>,
+  chosen: readonly string[],
+  self?: string | null,
+  limit = 8,
+): string[] {
+  const q = query.trim().toUpperCase();
+  const taken = new Set(chosen);
+  return [...codes]
+    .filter((c) => c !== self && !taken.has(c) && (!q || c.toUpperCase().includes(q)))
+    .sort()
+    .slice(0, limit);
+}


### PR DESCRIPTION
Closes the urgent finding from the stack review: since #594, an accepted dep-proposal could close a dependency loop — the drainer then skips the whole chain on every tick forever, with only a transient note as evidence. This slice makes that structurally impossible and finishes the A4 scope.

## What

- **One pure dependency-graph module** (`roadmap::deps`) is the single authority for "may this item depend on these codes?" — wired into all five dep-write surfaces: dialog create, dialog edit, `roadmap_propose`, `roadmap_propose_update`, and `roadmap_accept_proposal`. Refusals name the problem precisely: unknown code (listing the board's codes, capped at 12), self-dep, or the cycle spelled out (`MCA-101 → MCA-104 → MCA-101`). Semantics are *reachability*, not membership — an item whose chain merely ends in a loop is refused too, since it's equally unbuildable. 15-case table test.
- **Accept-time re-validation:** a stored ask whose dep list no longer resolves (or would now close a loop) is consumed as stale with a message, exactly like the existing raced-away-item path — never applied blind, never left as a bar that fails on every click.
- **Intra-batch ordering:** a `roadmap_propose` batch may reference its own items as `"#2"` (validated as positions, cycle-checked as placeholder nodes so a batch-internal loop reads `#1 → #2 → #1`, resolved to real codes inside the single insert transaction — forward references work). The PM's two-round-trip workaround paragraph is deleted from the instructions; OPS pin test green.
- **The `blocked` event gets its writer:** a queue head wedged on a loop records one durable `blocked` event naming the cycle (actor `drainer`), deduped against the trail itself (newest-event query, not process memory — survives restarts without duplicating per launch). Plain dep-waiting stays transient-only, as designed in the history slice.
- **Deps editing in the dialog:** an "After" chips field with suggestions from the board's own codes, client-side refusal of self/unknown/duplicate for fast feedback, backend as the authority — its named-cycle refusal surfaces in the dialog's error slot. Unchanged dep lists are not re-checked, so a retitle can't be held hostage by a pre-existing legacy loop (the durable event surfaces those instead).

## Known limitation (deliberate)

Accept-time re-validation is existence-based: a dep code deleted *and recycled onto a different item* between propose and accept passes, because proposals store codes, not item ids. The root cause is `next_code` reusing freed numbers — B7's "persist the code counter" removes recycling entirely, which is the right fix rather than a schema change here.

## Verification

- `cargo test`: 1267 passed, 12 ignored (27 new)
- `cargo clippy --all-targets -- -D warnings -A clippy::significant_drop_tightening`: clean
- `bun run test`: 831 passed (81 files; 10 new); `bun run check` / `bun run lint`: clean