### PR TITLE
feat(roadmap): the PM watches what gets built, not just what gets planned

### DIFF
--- a/src-tauri/src/instructions/roadmap.md
+++ b/src-tauri/src/instructions/roadmap.md
@@ -1,6 +1,6 @@
 ## The roadmap board (project-manager chat)
 
-You are the project manager for this project, and this chat has five extra RPC
+You are the project manager for this project, and this chat has six extra RPC
 ops — over the same `$FLETCH_RPC_DIR` mailbox as everything else — for the
 board the user is looking at next to this conversation. No other agent has
 them.
@@ -8,7 +8,9 @@ them.
 You cannot commit, push, or open a pull request. Your deliverable is the board:
 read the codebase, then write tickets that someone (or some agent) can pick up
 — and keep them true as the plan evolves, by proposing changes the user rules
-on.
+on. You also **oversee** what gets built from those tickets: the app hands you
+each finished run's outcome, and judging it against what the ticket asked for is
+your job, not the user's.
 
 ### `roadmap_list` — read the board
 
@@ -26,8 +28,12 @@ cat "$FLETCH_RPC_DIR/responses/$ID.json"
 `stdout` is a JSON array of the project's items:
 
 ```json
-[{"code":"FLT-100","title":"Queue drainer","horizon":"now","status":"open",
-  "why":"the queue needs one","area":"workflow","accept":["it drains"]}]
+[{"code":"FLT-100","title":"Queue drainer","horizon":"now","status":"in_review",
+  "why":"the queue needs one","area":"workflow","accept":["it drains"],
+  "deps":["FLT-99"],
+  "last_event":{"kind":"pr_opened","detail":"https://github.com/o/r/pull/7",
+                "age":"2h"},
+  "pr":{"url":"https://github.com/o/r/pull/7"}}]
 ```
 
 Optional filter: `{"op":"roadmap_list","args":{"status":["open","done"]}}`.
@@ -37,9 +43,23 @@ The array is in **board order**, which is also **dispatch order**: the queue
 builds items top to bottom (dependencies permitting), so the position of a code
 in this list is its priority. Nothing extra to read — the order *is* the answer.
 
-An item you have already asked to change carries your outstanding ask as
-`"pending_proposal": {"kind","note","fields"}` — check it before proposing
-again, so you revise your ask instead of re-sending it.
+Empty fields are omitted rather than sent as null. Per item:
+
+- `last_event` — the newest thing that happened to this item, when anything has:
+  `kind` (`created | proposed | accepted | discarded | edited | queued |
+  unqueued | dispatched | pr_opened | run_failed | shipped | abandoned |
+  blocked | note`), the `detail` that kind carries when it carries one (a failure
+  reason, a PR url, the text of a note), and `age` — how long ago, coarse
+  (`"4m"`, `"2h"`, `"3d"`; absent means within the last minute). This is how you
+  answer "why did FLT-104 fail?" without asking the user: `status` says where an
+  item is, `last_event` says what happened to it.
+- `pr` — `{"url"}` for an item whose run opened a pull request. `status` already
+  says whether that PR is still open (`in_review`) or landed (`done`). You cannot
+  read the diff from here; the URL is what you cite when you tell the user to
+  look.
+- `pending_proposal` — `{"kind","note","fields"}` for an item you have already
+  asked to change. Check it before proposing again, so you revise your ask
+  instead of re-sending it.
 
 ### `roadmap_propose` — put tickets on the board
 
@@ -188,6 +208,36 @@ visibly wrong — a dependency below its dependant, urgent work behind filler. N
 as a reflex after every batch you propose: new tickets already land last, which
 is usually where they belong.
 
+### `roadmap_note` — record an observation on an item
+
+The one op that writes **directly**, because it advances nothing: it appends a
+line to the item's durable history, visible on the card and in your next
+`roadmap_list`. Use it to make something survive the conversation.
+
+```sh
+ID=$(uuidgen)
+jq -n --arg id "$ID" '{id:$id,op:"roadmap_note",args:{
+  code:"FLT-104",
+  note:"shipped, but only for the primary repo — the multi-repo case in the acceptance criteria is untouched"
+}}' > "$FLETCH_RPC_DIR/requests/$ID.json.tmp"
+mv "$FLETCH_RPC_DIR/requests/$ID.json.tmp" "$FLETCH_RPC_DIR/requests/$ID.json"
+until [ -f "$FLETCH_RPC_DIR/responses/$ID.json" ]; do sleep 0.2; done
+cat "$FLETCH_RPC_DIR/responses/$ID.json"
+```
+
+`stdout` confirms it landed: `{"noted":{"code":"FLT-104"}}`.
+
+When to use it: an observation about an item that should outlive this chat — a
+run that deviated from the ticket's intent, a caveat the next builder needs, a
+decision the two of you reached about that item. Unlike the propose ops, a note
+works at **any** status, including `active`, `in_review` and `done` — which is
+usually the point, since those are exactly the items a proposal is refused on.
+
+When *not* to use it: as a substitute for doing something. A note does not
+change the board, unblock anything, or stop a run. If the roadmap should change,
+propose the change; the note is for the fact, not the fix. One honest sentence,
+under 500 characters — anything longer wanted to be a proposal.
+
 ### How to work
 
 Read before you propose. A ticket that names the files, the seam, and the
@@ -199,3 +249,34 @@ When the plan shifts, reshape the board instead of growing it: propose changes
 to the tickets that drifted rather than proposing near-duplicates next to them,
 and propose discarding what no longer earns its place. Keep every `note` and
 `reason` to one honest sentence.
+
+### Overseeing the work
+
+Start from reality, not from memory. Read `roadmap_list` before you propose
+anything: the statuses tell you what is in flight, and `last_event` tells you
+what happened to it. Proposing a ticket for work that shipped last night, or
+re-asking for a change the user already declined, is the failure mode this one
+call prevents.
+
+The app hands you a review turn every time a run settles: the ticket, and what
+the run actually did. Judge the outcome against the ticket's *intent*, not just
+its checklist — a run can pass every acceptance criterion and still answer a
+narrower question than the one that earned the item its place on the board. When
+it deviates:
+
+1. Say so plainly to the user. Name what you expected and what landed. Do not
+   soften it, and do not report a clean outcome as a deviation to look diligent.
+2. Record a `roadmap_note` on the item, so the deviation is on the card
+   tomorrow and in your next session's listing.
+3. If the roadmap should change because of it — a follow-up slice, a retitle, a
+   ticket that turned out to be wrong — propose that too. The note is the fact;
+   the proposal is the fix.
+
+You cannot reshape an `active` or `in_review` item by proposal: it is being built
+or judged, and the refusal names its status. A note is what you have on those,
+and it is enough — the item comes back to the board when it settles, and your
+note is waiting there.
+
+When a session opens after things have moved, you may be asked to summarize what
+shipped, failed, or got blocked since you last spoke. Answer it from
+`roadmap_list`, not from the transcript: the board is what actually happened.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1668,6 +1668,7 @@ pub fn run() {
             roadmap::roadmap_hand_off_item,
             roadmap::roadmap_delete_item,
             roadmap::roadmap_list_item_events,
+            roadmap::roadmap_latest_event,
             roadmap::roadmap_list_proposals,
             roadmap::roadmap_accept_proposal,
             roadmap::roadmap_reject_proposal,

--- a/src-tauri/src/roadmap/drainer.rs
+++ b/src-tauri/src/roadmap/drainer.rs
@@ -21,7 +21,9 @@
 //! commands so a queue action doesn't wait out the interval) the drainer, per
 //! project that has roadmap work in flight:
 //!
-//! 1. **Settles** every `active` item against its run row ([`settle`]).
+//! 1. **Settles** every `active` item against its run row ([`settle`]), and
+//!    hands each settlement to the project-manager chat as a review turn
+//!    ([`super::review`]) — the loop back up to the agent that wrote the brief.
 //! 2. **Dispatches** at most one queued item ([`pick_next`]), if the project is
 //!    under [`MAX_CONCURRENT_ROADMAP_RUNS`] live roadmap-dispatched runs.
 //!
@@ -65,6 +67,7 @@ use tauri::{AppHandle, Emitter};
 use tokio::sync::Notify;
 
 use super::events::{self, EventActor, EventKind, ItemEvent, TrailEntry};
+use super::review;
 use super::types::{ItemPatch, ItemStatus, RoadmapItem};
 use super::{emit_item, emit_item_event, store, Db};
 use crate::workflow::spec::{self, Spec};
@@ -417,7 +420,9 @@ struct Settled {
     adopted_run_id: Option<String>,
 }
 
-/// Reflect each `active` item's run back onto the item.
+/// Reflect each `active` item's run back onto the item, and ask the PM to review
+/// what it did ([`super::review`] — one turn per settlement, behind a
+/// per-project dial, never for a run the queue didn't dispatch).
 ///
 /// Items with an `agent_id` and no run are left alone: that's the manual "Send
 /// to an agent" hand-off, which the queue doesn't own.
@@ -532,11 +537,24 @@ fn settle_project(app: &AppHandle, db: &Db, project_id: &str, said: &SaidNotes) 
                 ..Default::default()
             },
         };
-        match settlement_event(&outcome, pr.as_ref()) {
+        let landed = match settlement_event(&outcome, pr.as_ref()) {
             Some((kind, detail)) => write_item_with_event(app, db, &item.id, patch, kind, detail),
             // Unreachable — `Running` bailed above — but a settlement without
             // an event must still land its patch rather than vanish.
-            None => write_item(app, db, &item.id, patch),
+            None => {
+                write_item(app, db, &item.id, patch);
+                true
+            }
+        };
+        // Ask the PM to review what the run actually did, once per settlement.
+        // Gated on the write landing: a row deleted mid-tick has no outcome to
+        // review and no card to record a deferral on. Fired before the notes
+        // below because it is the only step that can wake a resting session, and
+        // it needs no lock held (see [`review`]).
+        if landed {
+            if let Some(reviewable) = review::outcome_for(&outcome, pr.as_ref()) {
+                review::request(app, db, &item, &reviewable);
+            }
         }
         match outcome {
             Settlement::Released(why) => {
@@ -883,7 +901,9 @@ async fn dispatch(
 /// "the workflow this project runs" means one thing on both sides.
 const DEFAULT_WORKFLOW_KEY: &str = "workflow.default";
 
-fn project_setting(conn: &Connection, project_id: &str, key: &str) -> Option<String> {
+/// One per-project setting, trimmed, with a blank treated as absent. Shared with
+/// [`super::review`], which reads its own dial the same way.
+pub(super) fn project_setting(conn: &Connection, project_id: &str, key: &str) -> Option<String> {
     conn.query_row(
         "SELECT value FROM project_settings WHERE project_id = ?1 AND key = ?2",
         rusqlite::params![project_id, key],
@@ -975,6 +995,9 @@ pub(crate) fn write_item(app: &AppHandle, db: &Db, id: &str, patch: ItemPatch) {
 /// drainer write that moves an item's status; link repairs and `run_id`
 /// write-backs stay on [`write_item`], because they are bookkeeping, not
 /// history.
+///
+/// Returns whether the transition landed. A settlement's follow-on work (the PM
+/// review turn) hangs off that: a row deleted mid-tick has no state to describe.
 fn write_item_with_event(
     app: &AppHandle,
     db: &Db,
@@ -982,7 +1005,7 @@ fn write_item_with_event(
     patch: ItemPatch,
     kind: EventKind,
     detail: Option<String>,
-) {
+) -> bool {
     let updated = {
         let conn = db.lock();
         apply_and_record(&conn, id, None, &patch, EventActor::Drainer, kind, detail)
@@ -991,10 +1014,14 @@ fn write_item_with_event(
         Ok(Some((row, event))) => {
             emit_item(app, &row);
             emit_item_event(app, &event);
+            true
         }
         // The row was deleted mid-tick; its events cascaded with it.
-        Ok(None) => {}
-        Err(e) => tracing::warn!(id, error = %e, "roadmap drainer: item write failed"),
+        Ok(None) => false,
+        Err(e) => {
+            tracing::warn!(id, error = %e, "roadmap drainer: item write failed");
+            false
+        }
     }
 }
 

--- a/src-tauri/src/roadmap/events.rs
+++ b/src-tauri/src/roadmap/events.rs
@@ -19,6 +19,8 @@
 //! an event that didn't ride a typed write path could disagree with the
 //! transition it claims to record.
 
+use std::collections::HashMap;
+
 use rusqlite::{params, Connection, Row};
 use serde::Serialize;
 
@@ -44,6 +46,7 @@ crate::db_enum! {
     /// `held` and `released` arrive with the holds slice (B5, see
     /// .context/roadmap-pm-plan.md) — not declared here until they have a writer.
     EventKind {
+        Created    => "created",
         Proposed   => "proposed",
         Accepted   => "accepted",
         Discarded  => "discarded",
@@ -148,6 +151,51 @@ pub fn list_for_item(conn: &Connection, item_id: &str) -> rusqlite::Result<Vec<I
     rows.collect()
 }
 
+/// Every item's newest event on one board, keyed by `item_id`.
+///
+/// The card renders an item's whole trail ([`list_for_item`]); the PM's
+/// projection only ever needs the last line of each — so this is one statement
+/// for the whole board rather than a query per row, and it never pulls a
+/// hundred rows to look at one.
+///
+/// The window function is what makes "newest per item" one pass; the ordering
+/// inside it is [`list_for_item`]'s, so the line the PM is shown and the line at
+/// the top of the card's trail are the same row even for two events written in
+/// the same millisecond.
+pub fn latest_by_item(
+    conn: &Connection,
+    project_id: &str,
+) -> rusqlite::Result<HashMap<String, ItemEvent>> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {COLUMNS} FROM (
+           SELECT {COLUMNS}, ROW_NUMBER() OVER (
+             PARTITION BY item_id ORDER BY created_at DESC, rowid DESC
+           ) AS rn
+           FROM roadmap_item_events WHERE project_id = ?1
+         ) WHERE rn = 1"
+    ))?;
+    let rows = stmt.query_map([project_id], ItemEvent::from_row)?;
+    rows.map(|r| r.map(|e| (e.item_id.clone(), e)))
+        .collect::<rusqlite::Result<HashMap<_, _>>>()
+}
+
+/// The newest event anywhere on a board — "when did this board last move".
+///
+/// The standup digest compares exactly this against the PM chat's last turn: if
+/// nothing has happened since the two of you spoke, there is nothing to
+/// summarize, and asking for a digest anyway trains the user to ignore them.
+pub fn latest_for_project(
+    conn: &Connection,
+    project_id: &str,
+) -> rusqlite::Result<Option<ItemEvent>> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {COLUMNS} FROM roadmap_item_events WHERE project_id = ?1
+          ORDER BY created_at DESC, rowid DESC LIMIT 1"
+    ))?;
+    let mut rows = stmt.query_map([project_id], ItemEvent::from_row)?;
+    rows.next().transpose()
+}
+
 /// The history kind a user patch implies, from the transition it performs.
 ///
 /// The typed commands express a transition as `expect_status` (where the row
@@ -226,6 +274,54 @@ mod tests {
         assert_eq!(listed[0].detail.as_deref(), Some("its run failed"));
         assert_eq!(second.actor, EventActor::Drainer);
         assert_eq!(second.kind, EventKind::RunFailed);
+    }
+
+    /// Both "newest" reads agree with the head of the trail: the per-item map
+    /// `roadmap_list` projects from, and the board-wide one the standup compares
+    /// against. Same-millisecond writes tie-break on write order, which is what
+    /// keeps the PM's `last_event` and the card's top line the same row.
+    #[test]
+    fn the_newest_reads_agree_with_the_head_of_the_trail() {
+        let conn = test_conn();
+        let a = item(&conn);
+        let b = item(&conn);
+        assert!(latest_for_project(&conn, "p1").unwrap().is_none());
+        assert!(latest_by_item(&conn, "p1").unwrap().is_empty());
+
+        for kind in [EventKind::Created, EventKind::Queued, EventKind::Dispatched] {
+            record(&conn, &a.id, "p1", EventActor::User, kind, None).unwrap();
+        }
+        let b_note = record(
+            &conn,
+            &b.id,
+            "p1",
+            EventActor::Pm,
+            EventKind::Note,
+            Some("watch this one"),
+        )
+        .unwrap();
+
+        let a_head = list_for_item(&conn, &a.id).unwrap()[0].clone();
+        assert_eq!(a_head.kind, EventKind::Dispatched);
+        // Board-wide: the newest write anywhere, whichever item it landed on.
+        assert_eq!(
+            latest_for_project(&conn, "p1").unwrap(),
+            Some(b_note.clone())
+        );
+
+        let by_item = latest_by_item(&conn, "p1").unwrap();
+        assert_eq!(by_item.len(), 2);
+        assert_eq!(by_item.get(&a.id), Some(&a_head));
+        assert_eq!(by_item.get(&b.id), Some(&b_note));
+
+        // Another project's history is invisible to both board-scoped reads.
+        conn.execute(
+            "INSERT INTO projects (id, name, created_at) VALUES ('p2', 'other', 0)",
+            [],
+        )
+        .unwrap();
+        assert!(latest_for_project(&conn, "p2").unwrap().is_none());
+        assert!(latest_by_item(&conn, "p2").unwrap().is_empty());
     }
 
     #[test]

--- a/src-tauri/src/roadmap/mod.rs
+++ b/src-tauri/src/roadmap/mod.rs
@@ -37,12 +37,17 @@
 //! `in_review` items and moves them to `done` when they merge on GitHub. It is
 //! host-side rather than in the webview precisely so a queue keeps draining
 //! with the window shut.
+//!
+//! [`review`] closes it a third time, upwards: every run the drainer settles is
+//! handed to the project-manager chat as a review turn, so the agent that wrote
+//! the brief is the agent that reads what came back.
 
 pub mod drainer;
 pub mod events;
 pub mod merge_sweep;
 pub mod order;
 pub mod proposals;
+pub mod review;
 pub mod store;
 pub mod types;
 
@@ -133,6 +138,12 @@ pub async fn roadmap_get_item(
 /// Add an item to a project's roadmap. The `code` is allocated here, not passed
 /// in: it's the item's identity for the rest of its life, and only the DB knows
 /// which numbers are taken.
+///
+/// The row starts its durable history here with a `created` event, the mirror of
+/// the propose RPC's `proposed`. Without it a hand-built board has no history at
+/// all, and every consumer that reads "what changed since?" off the event trail
+/// — the PM's standup digest above all — would call a board the user filled in
+/// by hand unchanged (see .context/roadmap-pm-plan.md, B4).
 #[tauri::command]
 pub async fn roadmap_create_item(
     project_id: String,
@@ -143,16 +154,41 @@ pub async fn roadmap_create_item(
     if item.title.trim().is_empty() {
         return Err("a roadmap item needs a title".into());
     }
-    let created = {
+    let (created, event) = {
         let conn = db.lock();
-        store::create(&conn, &project_id, &item).map_err(|e| e.to_string())?
+        create_and_record(&conn, &project_id, &item).map_err(|e| e.to_string())?
     };
     emit_item(&app, &created);
+    emit_item_event(&app, &event);
     // A row can arrive already `queued` (or as a dependency another queued item
     // is waiting on), so every mutation re-checks the queue rather than trying
     // to guess which ones matter.
     drainer::nudge();
     Ok(created)
+}
+
+/// The one write behind [`roadmap_create_item`]: insert the row and open its
+/// history, in one transaction inside the caller's lock scope — so an item can
+/// never exist without the line saying who put it there.
+fn create_and_record(
+    conn: &Connection,
+    project_id: &str,
+    new: &NewItem,
+) -> rusqlite::Result<(RoadmapItem, ItemEvent)> {
+    let tx = conn.unchecked_transaction()?;
+    let item = store::create(&tx, project_id, new)?;
+    let event = events::record(
+        &tx,
+        &item.id,
+        project_id,
+        // This surface is the frontend's door: a row that arrives here was typed
+        // by the user, even when it lands straight into `queued`.
+        EventActor::User,
+        EventKind::Created,
+        None,
+    )?;
+    tx.commit()?;
+    Ok((item, event))
 }
 
 /// Patch an item. Absent fields are left alone; an explicit `null` clears a
@@ -424,6 +460,21 @@ pub async fn roadmap_list_item_events(
 ) -> Result<Vec<ItemEvent>, String> {
     let conn = db.lock();
     events::list_for_item(&conn, &item_id).map_err(|e| e.to_string())
+}
+
+/// The newest history row anywhere on a project's board, or `None` for a board
+/// that has never moved.
+///
+/// One row, not a trail: this answers "has the board changed since?" for the
+/// Roadmap tab's standup digest, which compares it against the PM chat's last
+/// turn and only asks for a summary when there is something to summarize.
+#[tauri::command]
+pub async fn roadmap_latest_event(
+    project_id: String,
+    db: tauri::State<'_, Db>,
+) -> Result<Option<ItemEvent>, String> {
+    let conn = db.lock();
+    events::latest_for_project(&conn, &project_id).map_err(|e| e.to_string())
 }
 
 /// Every pending PM proposal on a project's board — the board load's companion
@@ -740,6 +791,49 @@ mod tests {
             status: Some(to),
             ..Default::default()
         }
+    }
+
+    /// A hand-built item opens its own history. Without this line a board the
+    /// user typed in has no events at all, so every "what moved since we last
+    /// spoke?" reader — the PM's standup digest above all — calls it unchanged.
+    #[test]
+    fn creating_an_item_records_created() {
+        let conn = test_conn();
+        let (item, event) = create_and_record(
+            &conn,
+            "p1",
+            &NewItem {
+                title: "hand-written".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(event.item_id, item.id);
+        assert_eq!(event.project_id, "p1");
+        assert_eq!(event.kind, EventKind::Created);
+        assert_eq!(event.actor, EventActor::User);
+        assert_eq!(event.detail, None);
+        // Exactly one, and it is the row's whole history so far.
+        assert_eq!(events::list_for_item(&conn, &item.id).unwrap(), vec![event]);
+    }
+
+    /// The insert and its history line ride one transaction, so a failed event
+    /// write can't leave a row with no provenance. Forced by pointing the write
+    /// at a project id the FK refuses.
+    #[test]
+    fn a_failed_create_leaves_no_row_behind() {
+        let conn = test_conn();
+        assert!(create_and_record(
+            &conn,
+            "no-such-project",
+            &NewItem {
+                title: "orphan".into(),
+                ..Default::default()
+            },
+        )
+        .is_err());
+        assert!(store::list(&conn, "no-such-project").unwrap().is_empty());
     }
 
     /// Every user transition the board performs writes exactly one event of the

--- a/src-tauri/src/roadmap/review.rs
+++ b/src-tauri/src/roadmap/review.rs
@@ -1,0 +1,558 @@
+//! The settle review: one turn into the PM chat every time a roadmap run lands.
+//!
+//! Why this exists: until now the PM only ever saw the board it *asked* for.
+//! It wrote the brief, the drainer built it, and whatever came back — a PR, a
+//! silent ship, a failure — was known only to the user staring at the card. A
+//! manager who never reads the work it commissioned cannot notice that the
+//! implementation answered a different question than the ticket, which is the
+//! one deviation nobody else is positioned to catch (the run passed its own
+//! acceptance criteria; only the item's *intent* was missed).
+//!
+//! So the moment [`super::drainer::settle_project`] decides what a run did, it
+//! asks here for a review turn: the item's brief plus the outcome, delivered
+//! into the project's newest `roadmap-pm` chat as an ordinary user-role message.
+//! The PM answers with `roadmap_note`s (attention, invariant 2's conservative
+//! direction) and proposals (everything that advances state) — never by editing
+//! the board itself.
+//!
+//! # The delivery seam
+//!
+//! A PM chat is an ordinary workspace session, so this goes through the exact
+//! path the composer and `ChatPane` use: [`Supervisor::send_user_message`]. That
+//! one call already owns every case this needs and none of them are ours to
+//! re-derive — the agent is mid-turn (live injection or the durable
+//! `pending_messages` queue, flushed at the next boundary), or resting after an
+//! app restart (revived in `--resume` mode and flushed). Writing into
+//! `pending_messages` directly would persist the message and then wait for
+//! *something else* to trigger a flush, which is the half of the mechanism that
+//! lives in the supervisor anyway.
+//!
+//! Consequence worth naming: a settled run can wake a resting PM session, which
+//! is what makes the review land while the Roadmap tab is closed. It never
+//! *spawns* a chat — a project with no PM chat gets a durable `note` instead
+//! (see [`Plan::NoChat`]), so the review is deferred to the standup digest
+//! rather than lost.
+//!
+//! # Locking
+//!
+//! `WorkspaceManager` is built on the same `Arc<Mutex<Connection>>` this module
+//! is handed, and `parking_lot::Mutex` is not reentrant — so the decision
+//! ([`plan`]) takes the lock, drops it, and only then is anything delivered.
+//! Same discipline as every other roadmap write: DB under the lock, effects
+//! after.
+
+use std::sync::Arc;
+
+use rusqlite::{Connection, OptionalExtension};
+use tauri::{AppHandle, Manager};
+
+use super::drainer::{project_setting, FinalizedPr, Settlement};
+use super::events::{self, EventActor, EventKind};
+use super::types::RoadmapItem;
+use super::{emit_item_event, Db};
+use crate::supervisor::Supervisor;
+
+/// `project_settings` key gating the review, read the way the drainer reads
+/// `workflow.default`. Absent means on: a user who has never touched the dial
+/// gets the oversight loop the product is about, and turning it off is the
+/// explicit act.
+const SETTLE_REVIEW_KEY: &str = "roadmap.settle_review";
+
+/// The instruction line the review turn ends on — what the PM is being asked to
+/// *do* with the outcome, as opposed to acknowledge. Both halves matter: a
+/// deviation the user never hears about is a note nobody reads, and a roadmap
+/// that should change is a proposal, never a direct edit.
+const INSTRUCTION: &str =
+    "Review this outcome against the item's intent. If it deviates, record a \
+                           roadmap_note on the item and tell the user what you'd change; if the \
+                           roadmap should change, propose it.";
+
+/// What a settled run did, in the words the review turn uses. Narrower than
+/// [`Settlement`] on purpose: the three things worth reviewing, with the payload
+/// the PM needs to go look for itself.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum Outcome {
+    /// The run finished and opened a pull request, which is where the diff is.
+    PrOpened(String),
+    /// The run finished without a PR, so the item is done as far as this app can
+    /// tell — nothing is coming for the PM to read.
+    Shipped,
+    /// The run failed, was canceled, or never started. Carries the drainer's own
+    /// reason string, so the durable `run_failed` event and this turn agree.
+    Failed(String),
+}
+
+impl Outcome {
+    /// The outcome as one clause, the way the prompt's first line says it.
+    fn line(&self) -> String {
+        match self {
+            Outcome::PrOpened(url) => format!("PR opened at {url}"),
+            Outcome::Shipped => "shipped directly (the run finished without opening a PR)".into(),
+            Outcome::Failed(why) => format!("failed: {why}"),
+        }
+    }
+}
+
+/// The outcome a settlement is worth reviewing as, or `None` for a run that is
+/// still going (nothing has happened yet to review).
+///
+/// Mirrors [`super::drainer::settlement_event`] one-to-one, off the same two
+/// inputs, so the item's durable history and the PM's turn can never describe
+/// two different endings for one run.
+pub(crate) fn outcome_for(settlement: &Settlement, pr: Option<&FinalizedPr>) -> Option<Outcome> {
+    match settlement {
+        Settlement::Running => None,
+        // A PR-less `in_review` is impossible (`settle` only reaches it with a
+        // PR), but the projection stays total rather than unwrapping.
+        Settlement::InReview => Some(match pr {
+            Some(p) => Outcome::PrOpened(p.url.clone()),
+            None => Outcome::Shipped,
+        }),
+        Settlement::Done => Some(Outcome::Shipped),
+        Settlement::Released(why) => Some(Outcome::Failed((*why).to_string())),
+    }
+}
+
+/// The review turn's text: what was asked for, what came back, and the one
+/// instruction.
+///
+/// Pure over the item and the outcome — no clock, no database, no app handle —
+/// so the wording the PM actually receives is what the tests assert on.
+///
+/// Deliberately the *item's* brief rather than the run's
+/// ([`super::drainer::build_brief`]): the question here is "did this answer the
+/// ticket", so quoting the ticket is the whole point. The run's own additions
+/// (what landed underneath it, the stamp-the-code instruction) would only be
+/// noise in a review.
+pub(crate) fn review_prompt(item: &RoadmapItem, outcome: &Outcome) -> String {
+    let mut lines = vec![
+        format!("{} settled — {}.", item.code, outcome.line()),
+        String::new(),
+        format!("{}: {}", item.code, item.title),
+    ];
+    if !item.why.trim().is_empty() {
+        lines.push(String::new());
+        lines.push(item.why.trim().to_string());
+    }
+    if !item.accept.is_empty() {
+        lines.push(String::new());
+        lines.push("Done when:".to_string());
+        lines.extend(item.accept.iter().map(|a| format!("- {a}")));
+    }
+    lines.push(String::new());
+    lines.push(INSTRUCTION.to_string());
+    lines.join("\n")
+}
+
+/// What the drainer should do with a settled item's review, decided in one lock
+/// scope so the setting and the chat it resolves are read off the same moment.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum Plan {
+    /// The project turned the review off. Nothing is sent and nothing is
+    /// recorded — a dial the user set is not a failure to report.
+    Off,
+    /// The project has no PM chat to deliver into. The review becomes a durable
+    /// note on the item, which the standup digest picks up whenever a chat does
+    /// exist. We do *not* spawn one: a chat the user never asked for would start
+    /// burning a context window on a board they may not be managing this way.
+    NoChat,
+    /// Deliver into this chat — the newest one, which is the conversation the
+    /// Roadmap tab opens on.
+    Deliver { agent_id: String },
+}
+
+/// Read the dial and resolve the target chat. Called with the connection lock
+/// held; performs no delivery.
+pub(crate) fn plan(conn: &Connection, project_id: &str) -> Plan {
+    if !enabled(conn, project_id) {
+        return Plan::Off;
+    }
+    match newest_pm_chat(conn, project_id) {
+        Some(agent_id) => Plan::Deliver { agent_id },
+        None => Plan::NoChat,
+    }
+}
+
+/// Is the settle review on for this project? Absent is on; the off spellings are
+/// the ones a checkbox or a hand-edited row would plausibly write.
+fn enabled(conn: &Connection, project_id: &str) -> bool {
+    match project_setting(conn, project_id, SETTLE_REVIEW_KEY) {
+        None => true,
+        Some(v) => !matches!(
+            v.to_ascii_lowercase().as_str(),
+            "false" | "0" | "off" | "no"
+        ),
+    }
+}
+
+/// The project's newest live PM chat, by the same filter and order the Roadmap
+/// tab's picker lists (`purpose`-tagged, not archived, newest first) — so "the
+/// chat this review lands in" is the conversation the user would open.
+fn newest_pm_chat(conn: &Connection, project_id: &str) -> Option<String> {
+    conn.query_row(
+        "SELECT id FROM workspaces
+          WHERE project_id = ?1 AND purpose = ?2 AND archived_at IS NULL
+          ORDER BY created_at DESC LIMIT 1",
+        rusqlite::params![project_id, crate::workspace::PURPOSE_ROADMAP_PM],
+        |r| r.get::<_, String>(0),
+    )
+    .optional()
+    .ok()
+    .flatten()
+}
+
+/// Ask the PM to review one settled item. Best-effort by construction: every
+/// path either delivers the turn or leaves a durable line on the card, and
+/// neither can fail the settlement that called it.
+pub(crate) fn request(app: &AppHandle, db: &Db, item: &RoadmapItem, outcome: &Outcome) {
+    // Decided under the lock, acted on after it drops — the workspace manager
+    // this delivery goes through holds the same non-reentrant mutex.
+    let decision = {
+        let conn = db.lock();
+        plan(&conn, &item.project_id)
+    };
+    match decision {
+        Plan::Off => {}
+        Plan::NoChat => defer(app, db, item, outcome),
+        Plan::Deliver { agent_id } => {
+            if !deliver(app, &agent_id, &review_prompt(item, outcome)) {
+                defer(app, db, item, outcome);
+            }
+        }
+    }
+}
+
+/// Hand the turn to the PM's session. `true` means the message is the
+/// supervisor's problem now — delivered as a turn, injected into a running one,
+/// or persisted in `pending_messages` for the next boundary. Only an outright
+/// refusal (no supervisor, no such workspace) is `false`, which is what makes
+/// the fallback fire exactly when the review would otherwise vanish.
+fn deliver(app: &AppHandle, agent_id: &str, prompt: &str) -> bool {
+    let Some(sup) = app
+        .try_state::<Arc<Supervisor>>()
+        .map(|s| s.inner().clone())
+    else {
+        tracing::warn!("roadmap settle review: no supervisor to deliver through");
+        return false;
+    };
+    // A fresh turn id: this is a first-class user-role turn in that chat, and
+    // `insert_user_turn` is idempotent on it, so it must not collide with one the
+    // frontend allocated.
+    let turn_id = uuid::Uuid::new_v4().to_string();
+    match sup.send_user_message(app, agent_id, &turn_id, prompt, &[]) {
+        Ok(held) => {
+            tracing::info!(agent_id, held, "roadmap settle review: review turn sent");
+            true
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, agent_id, "roadmap settle review: delivery refused");
+            false
+        }
+    }
+}
+
+/// No chat could take the review: record it on the item instead, so the outcome
+/// is still waiting to be reviewed rather than silently unreviewed (invariant 3
+/// — a deviation is a durable object, not a message that failed to send). The
+/// standup digest reads the same trail, so the next PM session sees it.
+fn defer(app: &AppHandle, db: &Db, item: &RoadmapItem, outcome: &Outcome) {
+    let detail = format!("PM review pending: {}", outcome.line());
+    let recorded = {
+        let conn = db.lock();
+        events::record(
+            &conn,
+            &item.id,
+            &item.project_id,
+            // The drainer is what noticed, and what could not hand it on.
+            EventActor::Drainer,
+            EventKind::Note,
+            Some(&detail),
+        )
+    };
+    match recorded {
+        Ok(event) => emit_item_event(app, &event),
+        // The row was deleted mid-tick, or the write failed; there is nothing
+        // left to review either way.
+        Err(e) => tracing::warn!(item = %item.code, error = %e, "roadmap settle review: \
+                                  recording the deferred review failed"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::get_migrations;
+    use crate::roadmap::store;
+    use crate::roadmap::types::{ItemStatus, NewItem};
+
+    fn test_conn() -> Connection {
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        get_migrations().to_latest(&mut conn).unwrap();
+        conn.execute(
+            "INSERT INTO projects (id, name, created_at) VALUES ('p1', 'fletch', 0)",
+            [],
+        )
+        .unwrap();
+        conn
+    }
+
+    fn chat(conn: &Connection, id: &str, created_at: i64, purpose: Option<&str>) {
+        conn.execute(
+            "INSERT INTO workspaces (id, project_id, name, created_at, purpose)
+             VALUES (?1, 'p1', ?1, ?2, ?3)",
+            rusqlite::params![id, created_at, purpose],
+        )
+        .unwrap();
+    }
+
+    fn setting(conn: &Connection, value: &str) {
+        conn.execute(
+            "INSERT OR REPLACE INTO project_settings (project_id, key, value)
+             VALUES ('p1', ?1, ?2)",
+            rusqlite::params![SETTLE_REVIEW_KEY, value],
+        )
+        .unwrap();
+    }
+
+    fn item() -> RoadmapItem {
+        RoadmapItem {
+            id: "i1".into(),
+            project_id: "p1".into(),
+            code: "MCA-104".into(),
+            parent_id: None,
+            title: "Add the queue drainer".into(),
+            why: "queued items sit forever with nothing to launch them".into(),
+            horizon: crate::roadmap::types::Horizon::Now,
+            status: ItemStatus::InReview,
+            rank: 1.0,
+            area: None,
+            source: crate::roadmap::types::ItemSource::Pm,
+            accept: vec!["a queued item launches a run".into()],
+            deps: Vec::new(),
+            agent_id: None,
+            workflow_def_id: None,
+            run_id: None,
+            pr_url: None,
+            pr_number: None,
+            created_at: 0,
+            updated_at: 0,
+        }
+    }
+
+    fn pr() -> FinalizedPr {
+        FinalizedPr {
+            url: "https://github.com/o/r/pull/42".into(),
+            number: Some(42),
+        }
+    }
+
+    /// Every settlement the drainer can reach maps to the outcome the review
+    /// turn names — and a still-running one to nothing at all.
+    #[test]
+    fn each_settlement_becomes_the_outcome_it_describes() {
+        assert_eq!(outcome_for(&Settlement::Running, None), None);
+        assert_eq!(
+            outcome_for(&Settlement::InReview, Some(&pr())),
+            Some(Outcome::PrOpened(
+                "https://github.com/o/r/pull/42".to_string()
+            ))
+        );
+        assert_eq!(outcome_for(&Settlement::Done, None), Some(Outcome::Shipped));
+        assert_eq!(
+            outcome_for(&Settlement::Released("its run failed"), None),
+            Some(Outcome::Failed("its run failed".to_string()))
+        );
+        // The PR is what distinguishes review from shipped, so a review without
+        // one degrades rather than panicking.
+        assert_eq!(
+            outcome_for(&Settlement::InReview, None),
+            Some(Outcome::Shipped)
+        );
+    }
+
+    /// The durable record and the review turn are two projections of one
+    /// settlement, so they must agree on *whether* there is one: an outcome the
+    /// PM is asked about but the card never records (or the reverse) would be two
+    /// stories about one run.
+    #[test]
+    fn a_settlement_produces_a_review_exactly_when_it_produces_an_event() {
+        use crate::roadmap::drainer::settlement_event;
+        for (settlement, pr) in [
+            (Settlement::Running, None),
+            (Settlement::InReview, Some(pr())),
+            (Settlement::Done, None),
+            (Settlement::Released("its run failed"), None),
+            (Settlement::Released("its run never started"), None),
+        ] {
+            assert_eq!(
+                outcome_for(&settlement, pr.as_ref()).is_some(),
+                settlement_event(&settlement, pr.as_ref()).is_some(),
+                "{settlement:?}"
+            );
+        }
+    }
+
+    /// The PR case: the prompt opens with the outcome and the link, quotes the
+    /// ticket the run was built from, and closes on the one instruction.
+    #[test]
+    fn a_pr_review_quotes_the_ticket_and_the_link() {
+        let prompt = review_prompt(
+            &item(),
+            &Outcome::PrOpened("https://github.com/o/r/pull/42".into()),
+        );
+        let lines: Vec<&str> = prompt.lines().collect();
+        assert_eq!(
+            lines[0],
+            "MCA-104 settled — PR opened at https://github.com/o/r/pull/42."
+        );
+        assert_eq!(lines[2], "MCA-104: Add the queue drainer");
+        assert!(
+            prompt.contains("queued items sit forever"),
+            "the why is the intent being reviewed against: {prompt}"
+        );
+        assert!(
+            prompt.contains("Done when:\n- a queued item launches a run"),
+            "{prompt}"
+        );
+        assert!(prompt.ends_with(INSTRUCTION), "{prompt}");
+        // The instruction names both durable outputs the PM may produce.
+        assert!(prompt.contains("roadmap_note") && prompt.contains("propose it"));
+    }
+
+    /// A run that shipped without a PR says so plainly — there is no diff to go
+    /// read, which is exactly what the PM needs to know.
+    #[test]
+    fn a_shipped_review_names_the_missing_pr() {
+        let prompt = review_prompt(&item(), &Outcome::Shipped);
+        assert_eq!(
+            prompt.lines().next().unwrap(),
+            "MCA-104 settled — shipped directly (the run finished without opening a PR)."
+        );
+        assert!(prompt.ends_with(INSTRUCTION));
+    }
+
+    /// A failure carries the drainer's own reason string, so this turn and the
+    /// item's `run_failed` event tell one story.
+    #[test]
+    fn a_failed_review_carries_the_reason() {
+        let prompt = review_prompt(&item(), &Outcome::Failed("its run was canceled".into()));
+        assert_eq!(
+            prompt.lines().next().unwrap(),
+            "MCA-104 settled — failed: its run was canceled."
+        );
+    }
+
+    /// A bare ticket (no why, no acceptance criteria) still produces a coherent
+    /// turn rather than blank sections.
+    #[test]
+    fn a_bare_ticket_still_reviews() {
+        let mut bare = item();
+        bare.why = "   ".into();
+        bare.accept = Vec::new();
+        let prompt = review_prompt(&bare, &Outcome::Shipped);
+        assert!(!prompt.contains("Done when"), "{prompt}");
+        assert_eq!(
+            prompt,
+            format!(
+                "MCA-104 settled — shipped directly (the run finished without opening a PR).\n\n\
+                 MCA-104: Add the queue drainer\n\n{INSTRUCTION}"
+            )
+        );
+    }
+
+    /// The default is on, and the target is the *newest* PM chat — the one the
+    /// Roadmap tab opens on. Chats of other purposes, archived ones, and other
+    /// projects' are all invisible.
+    #[test]
+    fn the_plan_targets_the_newest_live_pm_chat_by_default() {
+        let conn = test_conn();
+        chat(&conn, "old-pm", 100, Some("roadmap-pm"));
+        chat(&conn, "new-pm", 200, Some("roadmap-pm"));
+        // A sidebar agent, and an archived PM chat: neither is a conversation
+        // the user can be handed a review in.
+        chat(&conn, "sidebar", 300, None);
+        chat(&conn, "gone-pm", 400, Some("roadmap-pm"));
+        conn.execute(
+            "UPDATE workspaces SET archived_at = 500 WHERE id = 'gone-pm'",
+            [],
+        )
+        .unwrap();
+
+        assert_eq!(
+            plan(&conn, "p1"),
+            Plan::Deliver {
+                agent_id: "new-pm".into()
+            }
+        );
+    }
+
+    /// No PM chat at all: the review is deferred to a durable note rather than
+    /// spawning a conversation the user never asked for.
+    #[test]
+    fn a_project_without_a_pm_chat_defers() {
+        let conn = test_conn();
+        chat(&conn, "sidebar", 100, None);
+        assert_eq!(plan(&conn, "p1"), Plan::NoChat);
+    }
+
+    /// The dial off suppresses the review entirely — no turn, and nothing
+    /// recorded either.
+    #[test]
+    fn the_setting_off_suppresses_the_review() {
+        let conn = test_conn();
+        chat(&conn, "pm", 100, Some("roadmap-pm"));
+        for off in ["false", "0", "off", "no", "FALSE", "Off"] {
+            setting(&conn, off);
+            assert_eq!(plan(&conn, "p1"), Plan::Off, "{off} should read as off");
+        }
+        // Anything else — including a blank the drainer's reader treats as
+        // absent — leaves it on.
+        for on in ["true", "1", "on", "  "] {
+            setting(&conn, on);
+            assert_eq!(
+                plan(&conn, "p1"),
+                Plan::Deliver {
+                    agent_id: "pm".into()
+                },
+                "{on} should read as on"
+            );
+        }
+    }
+
+    /// The deferred note is a real event on the item, attributed to the drainer
+    /// and naming the outcome — so nothing about the settlement is lost when
+    /// there is nobody to review it.
+    #[test]
+    fn the_deferred_note_names_the_outcome() {
+        let conn = test_conn();
+        let it = store::create(
+            &conn,
+            "p1",
+            &NewItem {
+                title: "one".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let detail = format!(
+            "PM review pending: {}",
+            Outcome::PrOpened("https://github.com/o/r/pull/42".into()).line()
+        );
+        let event = events::record(
+            &conn,
+            &it.id,
+            "p1",
+            EventActor::Drainer,
+            EventKind::Note,
+            Some(&detail),
+        )
+        .unwrap();
+        assert_eq!(event.kind, EventKind::Note);
+        assert_eq!(event.actor, EventActor::Drainer);
+        assert_eq!(
+            event.detail.as_deref(),
+            Some("PM review pending: PR opened at https://github.com/o/r/pull/42")
+        );
+    }
+}

--- a/src-tauri/src/rpc/roadmap.rs
+++ b/src-tauri/src/rpc/roadmap.rs
@@ -7,13 +7,16 @@
 //! surface every other agent has (its `AgentCaps::advisory()` still refuses the
 //! publish ops, one mechanism checked once).
 //!
-//! Five ops, all scoped to the project this chat belongs to. The project id is
+//! Six ops, all scoped to the project this chat belongs to. The project id is
 //! stamped at construction from the workspace record, never taken from `args`:
 //! a chat can only ever read and write its own project's board.
 //!
 //! - `roadmap_list` — the whole board, compact, in board order (which is rank
 //!   order, i.e. dispatch order), including `done` items (the PM needs to know
-//!   what already shipped before it proposes more).
+//!   what already shipped before it proposes more). Each row carries its
+//!   `last_event` and its PR link when it has one, so "why did MCA-104 fail?"
+//!   is answerable from this one call — the PM oversees execution, not just
+//!   intake.
 //! - `roadmap_propose` — creates rows with `status = "proposed"`, `source =
 //!   "pm"`. A proposed row is a *ghost* on the board: it renders where it would
 //!   land, counts for nothing, and only becomes real when the user accepts it
@@ -29,6 +32,10 @@
 //!   the sequence the PM argues for. Board scoped rather than item scoped, and
 //!   refused unless it covers the orderable set exactly, so what the user rules
 //!   on is unambiguous.
+//! - `roadmap_note` — the one op that writes *directly*, because it advances
+//!   nothing: a durable `note` on the item's history. Attention, not action.
+//!   That is the whole of the PM's direct-write licence (invariant 2 in
+//!   .context/roadmap-pm-plan.md): it may raise a hand, never move a piece.
 //!
 //! Validation rejects the whole batch rather than creating a partial one: the
 //! PM gets one precise error it can fix and retry, and the user never sees half
@@ -53,12 +60,13 @@ use crate::rpc::{Response, RpcDispatcher, RpcEvent, RpcFuture};
 /// The ops this dispatcher owns. Pinned by a test against the instruction block
 /// so the two can't drift — an agent told about an op that doesn't exist (or
 /// given one it was never told about) is a silently broken tool.
-pub const OPS: [&str; 5] = [
+pub const OPS: [&str; 6] = [
     "roadmap_list",
     "roadmap_propose",
     "roadmap_propose_update",
     "roadmap_propose_discard",
     "roadmap_propose_order",
+    "roadmap_note",
 ];
 
 /// Most items one `roadmap_propose` call may carry. A proposal is a thing a
@@ -150,6 +158,16 @@ struct ProposeOrderArgs {
     note: Option<String>,
 }
 
+/// `roadmap_note` args: which item, and the observation. Both required — a note
+/// with no text is the one thing this op cannot record.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NoteArgs {
+    code: String,
+    #[serde(default)]
+    note: String,
+}
+
 /// Decode `args` into an op's shape. A missing `args` arrives as JSON null,
 /// which is the same as `{}` for every op here.
 fn parse_args<T: Default + serde::de::DeserializeOwned>(args: &Value) -> Result<T, String> {
@@ -199,7 +217,26 @@ fn one_of(values: &[&str]) -> String {
 /// `pending` is the item's outstanding delta, if any, summarized as
 /// `pending_proposal` — so the PM knows what it has already asked for and
 /// never re-proposes blind (or mistakes "not applied yet" for "declined").
-fn compact(item: &RoadmapItem, pending: Option<&Proposal>) -> Value {
+///
+/// `last` is the item's newest history row, projected as `last_event`. This is
+/// what turns the listing from an intake queue into an execution report: the
+/// status says *where* an item is, the last event says *what happened* — a
+/// failure reason, a workflow, a note somebody left. `age` is relative on
+/// purpose, computed against `now`: an absolute epoch means nothing to an agent
+/// reasoning about "since we last spoke", and a wall-clock timestamp it would
+/// have to diff itself is a round trip and a mistake waiting to happen.
+///
+/// The PR link rides along as `pr` for the same reason — the diff is where a
+/// review actually happens, and the item's own `status` already says whether
+/// that PR is still open (`in_review`) or landed (`done`), so no polled state is
+/// invented here. Raw ids stay hidden throughout: run ids, item ids and PR
+/// numbers are the app's handles, not the PM's vocabulary.
+fn compact(
+    item: &RoadmapItem,
+    pending: Option<&Proposal>,
+    last: Option<&ItemEvent>,
+    now: i64,
+) -> Value {
     let mut o = Map::new();
     o.insert("code".into(), json!(item.code));
     o.insert("title".into(), json!(item.title));
@@ -216,6 +253,25 @@ fn compact(item: &RoadmapItem, pending: Option<&Proposal>) -> Value {
     }
     if !item.deps.is_empty() {
         o.insert("deps".into(), json!(item.deps));
+    }
+    if let Some(e) = last {
+        let mut le = Map::new();
+        le.insert("kind".into(), json!(e.kind.as_str()));
+        if let Some(detail) = &e.detail {
+            le.insert("detail".into(), json!(detail));
+        }
+        if let Some(age) = age(now, e.created_at) {
+            le.insert("age".into(), json!(age));
+        }
+        o.insert("last_event".into(), Value::Object(le));
+    }
+    if let Some(url) = item
+        .pr_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|u| !u.is_empty())
+    {
+        o.insert("pr".into(), json!({ "url": url }));
     }
     // Quoted only while the item can still be ruled: an ask whose item has
     // advanced past the gate has no card to rule it from, and quoting it
@@ -234,6 +290,24 @@ fn compact(item: &RoadmapItem, pending: Option<&Proposal>) -> Value {
         o.insert("pending_proposal".into(), Value::Object(pp));
     }
     Value::Object(o)
+}
+
+/// How long ago something happened, in the coarsest unit that is still true:
+/// `"4m"`, `"2h"`, `"3d"`. `None` for anything under a minute (and for a clock
+/// that ran backwards) — "just now" is what the absence means, and inventing
+/// `"0m"` would read as staler than it is.
+///
+/// Coarse deliberately: the PM reasons in "since we last spoke", and a precise
+/// duration would invite arithmetic it has no reason to do.
+fn age(now: i64, then: i64) -> Option<String> {
+    let ms = now.checked_sub(then).filter(|d| *d > 0)?;
+    let minutes = ms / 60_000;
+    match minutes {
+        0 => None,
+        m if m < 60 => Some(format!("{m}m")),
+        m if m < 60 * 24 => Some(format!("{}h", m / 60)),
+        m => Some(format!("{}d", m / (60 * 24))),
+    }
 }
 
 /// `roadmap_list`: the project's board as a JSON array on stdout.
@@ -286,6 +360,14 @@ fn list_op(conn: &Connection, project_id: &str, id: &str, args: &Value) -> Respo
     };
     let by_item: HashMap<&str, &Proposal> =
         pending.iter().map(|p| (p.item_id.as_str(), p)).collect();
+    // One statement for the whole board rather than a query per row: the PM
+    // reads this listing constantly, and it is the only thing between it and
+    // knowing what the runs did.
+    let last = match events::latest_by_item(conn, project_id) {
+        Ok(map) => map,
+        Err(e) => return Response::err(id, format!("roadmap_list: {e}")),
+    };
+    let now = crate::database::now_millis();
     let keep = |i: &RoadmapItem| match &filter {
         None => true,
         Some(f) => f.contains(i.status.as_str()),
@@ -293,7 +375,7 @@ fn list_op(conn: &Connection, project_id: &str, id: &str, args: &Value) -> Respo
     let rows: Vec<Value> = items
         .iter()
         .filter(|i| keep(i))
-        .map(|i| compact(i, by_item.get(i.id.as_str()).copied()))
+        .map(|i| compact(i, by_item.get(i.id.as_str()).copied(), last.get(&i.id), now))
         .collect();
     match serde_json::to_string(&rows) {
         Ok(stdout) => Response::ok(id, 0, stdout, String::new()),
@@ -643,6 +725,92 @@ fn propose_discard_op(
     }
 }
 
+// ───────────────────────────── roadmap_note ─────────────────────────────
+
+/// Longest note this op will store. A note is a line on a card and a line in the
+/// PM's next listing — past a couple of sentences it stops being an observation
+/// and starts being an essay nobody reads, and the thing it should have been is
+/// a proposal.
+const MAX_NOTE: usize = 500;
+
+/// `roadmap_note`: record one durable observation on an item.
+///
+/// The PM's only direct write, and it is allowed precisely because it advances
+/// nothing: no status moves, no field changes, no queue is touched. It raises
+/// attention — the conservative direction of invariant 2 — where every ask that
+/// would *do* something stays a proposal the user rules on.
+///
+/// Unlike the propose ops, the target may be at **any** status. The observation
+/// worth recording most often concerns an item that is already `active`,
+/// `in_review` or `done` ("this shipped, but it solved a narrower problem than
+/// MCA-104 asked for"), and that is exactly the item a proposal is refused on.
+/// Refusing the note too would leave the PM with nowhere to put the one thing it
+/// is uniquely positioned to notice.
+///
+/// Returns the recorded event alongside the response so the dispatcher can
+/// announce it (`roadmap:item-event`) once the lock drops — the card's trail
+/// grows mid-conversation.
+fn note_op(
+    conn: &Connection,
+    project_id: &str,
+    id: &str,
+    args: &Value,
+) -> (Response, Option<ItemEvent>) {
+    let err = |msg: String| (Response::err(id, format!("roadmap_note: {msg}")), None);
+    let args: NoteArgs = match parse_required(args) {
+        Ok(a) => a,
+        Err(e) => return err(e),
+    };
+    let note = args.note.trim();
+    if note.is_empty() {
+        return err("`note` is required — say what you observed, in one honest sentence".into());
+    }
+    // Counted in characters, not bytes: the cap is about how much a human will
+    // read, and a byte limit would refuse a shorter note for containing an
+    // em-dash.
+    let length = note.chars().count();
+    if length > MAX_NOTE {
+        return err(format!(
+            "`note` is {length} characters — keep it under {MAX_NOTE}. A note is one observation; \
+             if it needs more than that, it is a proposal"
+        ));
+    }
+    let items = match store::list(conn, project_id) {
+        Ok(items) => items,
+        Err(e) => return err(e.to_string()),
+    };
+    let code = args.code.trim();
+    // Any status: see the doc comment. Only "no such item" is refused.
+    let Some(item) = items.iter().find(|i| i.code == code) else {
+        return err(format!(
+            "no item {code:?} on this board — `roadmap_list` shows what exists"
+        ));
+    };
+    let recorded = events::record(
+        conn,
+        &item.id,
+        project_id,
+        EventActor::Pm,
+        EventKind::Note,
+        Some(note),
+    );
+    let event = match recorded {
+        Ok(event) => event,
+        Err(e) => return err(e.to_string()),
+    };
+
+    let payload = json!({ "noted": { "code": item.code } });
+    match serde_json::to_string(&payload) {
+        Ok(stdout) => (Response::ok(id, 0, stdout, String::new()), Some(event)),
+        // The note is on the card either way — say so rather than implying
+        // nothing happened, and still announce it.
+        Err(e) => (
+            Response::err(id, format!("roadmap_note: recorded, but {e}")),
+            Some(event),
+        ),
+    }
+}
+
 // ───────────────────────── roadmap_propose_order ────────────────────────
 
 /// `roadmap_propose_order`: park a whole-board order ask, replacing any the
@@ -786,6 +954,19 @@ impl RpcDispatcher for RoadmapDispatcher {
                     }
                     (resp, Vec::new())
                 }
+                "roadmap_note" => {
+                    // The one op that writes directly. Same lock discipline all
+                    // the same: the event lands under the lock, and the card
+                    // hears about it after the guard drops.
+                    let (resp, recorded) = {
+                        let conn = self.db.lock();
+                        note_op(&conn, &self.project_id, id, args)
+                    };
+                    if let (Some(app), Some(event)) = (&self.app, &recorded) {
+                        crate::roadmap::emit_item_event(app, event);
+                    }
+                    (resp, Vec::new())
+                }
                 other => (
                     Response::err(
                         id,
@@ -863,6 +1044,11 @@ mod tests {
     fn propose_order(db: &Db, args: Value) -> (Response, Option<OrderProposal>) {
         let conn = db.lock();
         propose_order_op(&conn, "p1", "r1", &args)
+    }
+
+    fn note(db: &Db, args: Value) -> (Response, Option<ItemEvent>) {
+        let conn = db.lock();
+        note_op(&conn, "p1", "r1", &args)
     }
 
     fn one_item(title: &str) -> Value {
@@ -1041,6 +1227,280 @@ mod tests {
         let resp = list(&db, json!({ "status": ["shipped"] }));
         assert!(!resp.ok);
         assert!(resp.error.unwrap().contains("unknown status"));
+    }
+
+    /// The listing is the PM's execution report, not just its intake queue: each
+    /// row carries the newest thing that happened to it, and the PR link when
+    /// there is one — enough to answer "why did MCA-101 fail?" from this one
+    /// call, with no ids leaked.
+    #[test]
+    fn the_listing_carries_each_items_last_event_and_pr() {
+        let db = test_db("p1");
+        assert!(propose(&db, one_item("proposed one")).ok); // MCA-100
+        let failed = {
+            let conn = db.lock();
+            let it = store::create(
+                &conn,
+                "p1",
+                &NewItem {
+                    title: "failed one".into(),
+                    status: Some(ItemStatus::Open),
+                    ..Default::default()
+                },
+            )
+            .unwrap(); // MCA-101
+            events::record(
+                &conn,
+                &it.id,
+                "p1",
+                EventActor::Drainer,
+                EventKind::RunFailed,
+                Some("its run failed"),
+            )
+            .unwrap();
+            it
+        };
+        // An item in review, with the PR the run opened stamped on it.
+        {
+            let conn = db.lock();
+            let it = store::create(
+                &conn,
+                "p1",
+                &NewItem {
+                    title: "in review".into(),
+                    status: Some(ItemStatus::InReview),
+                    ..Default::default()
+                },
+            )
+            .unwrap(); // MCA-102
+            store::update(
+                &conn,
+                &it.id,
+                &crate::roadmap::types::ItemPatch {
+                    pr_url: Some(Some("https://github.com/o/r/pull/7".into())),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+            events::record(
+                &conn,
+                &it.id,
+                "p1",
+                EventActor::Drainer,
+                EventKind::PrOpened,
+                Some("https://github.com/o/r/pull/7"),
+            )
+            .unwrap();
+        }
+
+        let resp = list(&db, Value::Null);
+        let rows: Vec<Value> = serde_json::from_str(&resp.stdout.unwrap()).unwrap();
+        assert_eq!(rows[0]["last_event"]["kind"], "proposed");
+        // No detail, no age (it happened this millisecond) — the keys are simply
+        // absent rather than null.
+        assert!(rows[0]["last_event"].get("detail").is_none());
+        assert!(rows[0]["last_event"].get("age").is_none());
+        assert!(rows[0].get("pr").is_none());
+
+        assert_eq!(rows[1]["code"], failed.code);
+        assert_eq!(rows[1]["last_event"]["kind"], "run_failed");
+        assert_eq!(rows[1]["last_event"]["detail"], "its run failed");
+
+        assert_eq!(rows[2]["last_event"]["kind"], "pr_opened");
+        assert_eq!(rows[2]["pr"]["url"], "https://github.com/o/r/pull/7");
+        // The PR's *number* is an app handle, not the PM's vocabulary.
+        assert!(rows[2]["pr"].get("number").is_none());
+
+        // An item with no history at all simply has no `last_event`.
+        {
+            let conn = db.lock();
+            store::create(
+                &conn,
+                "p1",
+                &NewItem {
+                    title: "silent".into(),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        }
+        let resp = list(&db, Value::Null);
+        let rows: Vec<Value> = serde_json::from_str(&resp.stdout.unwrap()).unwrap();
+        assert!(rows[3].get("last_event").is_none());
+    }
+
+    /// `age` is coarse and relative, because "since we last spoke" is the only
+    /// question the PM asks of it. Under a minute is absent — "just now".
+    #[test]
+    fn the_age_of_an_event_reads_in_the_coarsest_true_unit() {
+        let now = 1_000_000_000_000;
+        let min = 60_000;
+        for (ago, expected) in [
+            (0, None),
+            (min - 1, None),
+            (min, Some("1m")),
+            (59 * min, Some("59m")),
+            (60 * min, Some("1h")),
+            (23 * 60 * min + 59 * min, Some("23h")),
+            (24 * 60 * min, Some("1d")),
+            (9 * 24 * 60 * min, Some("9d")),
+        ] {
+            assert_eq!(age(now, now - ago).as_deref(), expected, "{ago}ms ago");
+        }
+        // A clock that ran backwards reads as "just now" rather than negative.
+        assert_eq!(age(now, now + 5 * min), None);
+    }
+
+    /// `roadmap_note` writes one durable `note` event attributed to the PM, and
+    /// changes nothing else about the item — the whole of the direct-write
+    /// licence.
+    #[test]
+    fn note_records_an_observation_and_advances_nothing() {
+        let db = test_db("p1");
+        assert!(propose(&db, one_item("target")).ok); // MCA-100
+        let before = store::list(&db.lock(), "p1").unwrap();
+
+        let (resp, event) = note(
+            &db,
+            json!({"code": "MCA-100", "note": "the run solved a narrower problem than this asked for"}),
+        );
+        assert!(resp.ok, "{resp:?}");
+        let out: Value = serde_json::from_str(&resp.stdout.unwrap()).unwrap();
+        assert_eq!(out["noted"]["code"], "MCA-100");
+
+        let event = event.expect("the note is returned so the card can hear about it");
+        assert_eq!(event.kind, EventKind::Note);
+        assert_eq!(event.actor, EventActor::Pm);
+        assert_eq!(
+            event.detail.as_deref(),
+            Some("the run solved a narrower problem than this asked for")
+        );
+        assert_eq!(event.item_id, before[0].id);
+        assert_eq!(event.project_id, "p1");
+
+        // The row itself is byte-for-byte what it was: a note is attention, not
+        // action.
+        assert_eq!(store::list(&db.lock(), "p1").unwrap(), before);
+        // And it is on the trail, on top of the `proposed` that opened it.
+        let trail = events::list_for_item(&db.lock(), &before[0].id).unwrap();
+        assert_eq!(trail.len(), 2);
+        assert_eq!(trail[0], event);
+    }
+
+    /// A note is the one PM write allowed on an item a proposal is refused on —
+    /// `active`, `in_review`, `done`. That item is usually the whole reason the
+    /// op exists.
+    #[test]
+    fn note_lands_on_items_no_proposal_could_touch() {
+        let db = test_db("p1");
+        for status in [ItemStatus::Active, ItemStatus::InReview, ItemStatus::Done] {
+            let it = {
+                let conn = db.lock();
+                store::create(
+                    &conn,
+                    "p1",
+                    &NewItem {
+                        title: "shipped something".into(),
+                        status: Some(status),
+                        ..Default::default()
+                    },
+                )
+                .unwrap()
+            };
+            let (resp, event) = note(
+                &db,
+                json!({"code": it.code, "note": "narrower than agreed"}),
+            );
+            assert!(
+                resp.ok,
+                "a note on {} must be allowed: {resp:?}",
+                status.as_str()
+            );
+            assert_eq!(event.unwrap().item_id, it.id);
+            // The proposal path still refuses it — the two gates say different
+            // things on purpose.
+            let items = store::list(&db.lock(), "p1").unwrap();
+            assert!(proposable(&items, &it.code).is_err());
+        }
+    }
+
+    /// Every way a note can be wrong, named precisely, writing nothing.
+    #[test]
+    fn note_rejects_bad_asks_precisely() {
+        let db = test_db("p1");
+        assert!(propose(&db, one_item("target")).ok); // MCA-100
+        let long = "x".repeat(MAX_NOTE + 1);
+
+        for (args, needle) in [
+            (json!({"code": "MCA-777", "note": "hi"}), "no item"),
+            (
+                json!({"code": "MCA-100", "note": "   "}),
+                "`note` is required",
+            ),
+            (json!({"code": "MCA-100"}), "`note` is required"),
+            (
+                json!({"code": "MCA-100", "note": long.clone()}),
+                "keep it under",
+            ),
+            // The note is not a back door to the fields the propose ops gate.
+            (
+                json!({"code": "MCA-100", "note": "hi", "status": "done"}),
+                "unknown field",
+            ),
+            (json!({"note": "no code"}), "missing field `code`"),
+        ] {
+            let (resp, event) = note(&db, args);
+            assert!(!resp.ok, "should have been rejected");
+            let e = resp.error.unwrap();
+            assert!(e.contains(needle), "expected {needle:?} in {e:?}");
+            assert!(event.is_none());
+        }
+        // Args at all are required, and nothing above wrote a line.
+        assert!(!note(&db, Value::Null).0.ok);
+        let items = store::list(&db.lock(), "p1").unwrap();
+        let trail = events::list_for_item(&db.lock(), &items[0].id).unwrap();
+        assert!(
+            trail.iter().all(|e| e.kind == EventKind::Proposed),
+            "{trail:?}"
+        );
+
+        // Exactly at the cap is fine — the refusal is for going over it.
+        let (resp, _) = note(
+            &db,
+            json!({"code": "MCA-100", "note": "y".repeat(MAX_NOTE)}),
+        );
+        assert!(resp.ok, "{resp:?}");
+    }
+
+    /// The note reaches the board through the dispatcher, which is the only path
+    /// the PM actually has.
+    #[tokio::test]
+    async fn note_routes_through_the_dispatcher() {
+        let db = test_db("p1");
+        let d = dispatcher(&db, "p1");
+        assert!(propose(&db, one_item("target")).ok); // MCA-100
+
+        let resp = d
+            .dispatch(
+                "r1",
+                "roadmap_note",
+                &json!({"code": "MCA-100", "note": "watch the migration on this one"}),
+            )
+            .await
+            .0;
+        assert!(resp.ok, "{resp:?}");
+        let items = store::list(&db.lock(), "p1").unwrap();
+        let trail = events::list_for_item(&db.lock(), &items[0].id).unwrap();
+        assert_eq!(trail[0].kind, EventKind::Note);
+        assert_eq!(trail[0].actor, EventActor::Pm);
+        // And the listing shows it back, so the PM can see its own note landed.
+        let resp = list(&db, Value::Null);
+        let rows: Vec<Value> = serde_json::from_str(&resp.stdout.unwrap()).unwrap();
+        assert_eq!(rows[0]["last_event"]["kind"], "note");
+        assert_eq!(
+            rows[0]["last_event"]["detail"],
+            "watch the migration on this one"
+        );
     }
 
     #[test]

--- a/src/api/domains/roadmap.ts
+++ b/src/api/domains/roadmap.ts
@@ -62,6 +62,12 @@ export const roadmapApi = {
    *  expand; live rows arrive on `roadmap:item-event`. */
   roadmapListItemEvents: (itemId: string) =>
     invoke<RoadmapItemEvent[]>("roadmap_list_item_events", { itemId }),
+  /** The newest history row anywhere on a project's board, or `null` for a board
+   *  that never moved. One row, not a trail: this answers "has the board changed
+   *  since?" for the standup digest (see `standup.ts`), which compares it against
+   *  the PM chat's last turn. */
+  roadmapLatestEvent: (projectId: string) =>
+    invoke<RoadmapItemEvent | null>("roadmap_latest_event", { projectId }),
   /** Every pending PM proposal on a project's board — fetched with the item
    *  snapshot; live rows arrive on `roadmap:proposal`. */
   roadmapListProposals: (projectId: string) =>

--- a/src/api/types/roadmap.ts
+++ b/src/api/types/roadmap.ts
@@ -90,8 +90,13 @@ export type RoadmapEventActor = "user" | "pm" | "drainer" | "sweep";
 
 /** What happened to an item — one kind per transition, so a history line never
  *  re-derives meaning from a status pair. `held`/`released` arrive with the
- *  holds slice (B5). */
+ *  holds slice (B5).
+ *
+ *  `created` is the user-typed row's opening line, the mirror of the PM's
+ *  `proposed`: without it a hand-built board has no history at all, and every
+ *  "what changed since?" reader calls it unchanged. */
 export type RoadmapEventKind =
+  | "created"
   | "proposed"
   | "accepted"
   | "discarded"

--- a/src/components/ProjectScreen/Roadmap/Thread/standup.test.ts
+++ b/src/components/ProjectScreen/Roadmap/Thread/standup.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import type { AgentRecord, UserTurn } from "@/api";
+import { chatActiveAt, type StandupSignals, shouldAskForStandup } from "./standup";
+
+/** A board that moved an hour after the chat was last live — the case the
+ *  digest exists for. */
+function signals(over: Partial<StandupSignals> = {}): StandupSignals {
+  return {
+    boardMovedAt: 2_000,
+    chatActiveAt: 1_000,
+    freshlySpawned: false,
+    alreadyAsked: false,
+    ...over,
+  };
+}
+
+function turn(over: Partial<UserTurn> = {}): UserTurn {
+  return {
+    turn_id: "t1",
+    seq: 1,
+    text: "hi",
+    attachments: [],
+    native_id: null,
+    started_at: null,
+    ended_at: null,
+    ...over,
+  };
+}
+
+const chat = { created_at: "2026-08-04T10:00:00.000Z" } as Pick<AgentRecord, "created_at">;
+
+describe("shouldAskForStandup", () => {
+  it("asks when the board moved after the chat was last live", () => {
+    expect(shouldAskForStandup(signals())).toBe(true);
+  });
+
+  it("stays quiet when nothing has happened since", () => {
+    expect(shouldAskForStandup(signals({ boardMovedAt: 1_000 }))).toBe(false);
+    expect(shouldAskForStandup(signals({ boardMovedAt: 999 }))).toBe(false);
+  });
+
+  it("stays quiet on a board with no history at all", () => {
+    // Nothing has ever happened, so there is nothing to summarize — and asking
+    // would train the user to ignore the next one.
+    expect(shouldAskForStandup(signals({ boardMovedAt: null }))).toBe(false);
+  });
+
+  it("never fires on a chat spawned in this session", () => {
+    // Its opening turn *is* the conversation: there is no "since we last spoke",
+    // however old the board's last movement is.
+    expect(shouldAskForStandup(signals({ freshlySpawned: true }))).toBe(false);
+  });
+
+  it("fires at most once per project per app session", () => {
+    expect(shouldAskForStandup(signals({ alreadyAsked: true }))).toBe(false);
+  });
+
+  it("weighs the guards independently", () => {
+    // Every combination that has any blocker set stays quiet; only the all-clear
+    // case asks.
+    for (const boardMovedAt of [null, 500, 2_000]) {
+      for (const freshlySpawned of [false, true]) {
+        for (const alreadyAsked of [false, true]) {
+          const clear = boardMovedAt === 2_000 && !freshlySpawned && !alreadyAsked;
+          expect(shouldAskForStandup(signals({ boardMovedAt, freshlySpawned, alreadyAsked }))).toBe(
+            clear,
+          );
+        }
+      }
+    }
+  });
+});
+
+describe("chatActiveAt", () => {
+  it("takes the newest turn's end", () => {
+    expect(
+      chatActiveAt(chat, [
+        turn({ turn_id: "a", started_at: 100, ended_at: 200 }),
+        turn({ turn_id: "b", started_at: 300, ended_at: 400 }),
+      ]),
+    ).toBe(400);
+  });
+
+  it("falls back to the start of a turn still in flight", () => {
+    expect(chatActiveAt(chat, [turn({ started_at: 300, ended_at: null })])).toBe(300);
+  });
+
+  it("skips a turn that never started and keeps looking", () => {
+    // A failed send awaiting retry has no timestamps; counting it as "now" would
+    // suppress the digest forever.
+    expect(
+      chatActiveAt(chat, [
+        turn({ turn_id: "a", started_at: 100, ended_at: 200 }),
+        turn({ turn_id: "b", started_at: null, ended_at: null }),
+      ]),
+    ).toBe(200);
+  });
+
+  it("falls back to when the chat was created", () => {
+    // A chat the user opened and never typed in: the last moment it can be said
+    // to have been in sync with the board.
+    expect(chatActiveAt(chat, [])).toBe(Date.parse("2026-08-04T10:00:00.000Z"));
+    expect(chatActiveAt(chat, [turn()])).toBe(Date.parse("2026-08-04T10:00:00.000Z"));
+  });
+
+  it("reads an undateable chat as epoch zero", () => {
+    // Any board movement then counts as newer — the safe direction, since a chat
+    // we can't date is one we can't claim is current.
+    expect(chatActiveAt({ created_at: "not a date" }, [])).toBe(0);
+  });
+});

--- a/src/components/ProjectScreen/Roadmap/Thread/standup.ts
+++ b/src/components/ProjectScreen/Roadmap/Thread/standup.ts
@@ -1,0 +1,80 @@
+// The standup digest: the one unprompted message a reopened PM chat gets when
+// the board moved while nobody was looking.
+//
+// Why it exists: the board is autonomous. Runs dispatch, PRs open, the merge
+// sweep ships things — all with the Roadmap tab closed. So the conversation the
+// user comes back to is stale in a way neither party can see from the transcript,
+// and the user ends up typing "what happened?" every single time. This asks it
+// for them, once, from the board rather than from memory.
+//
+// Why it is a *pure* decision: firing this wrongly is worse than not firing it.
+// A digest on a chat where nothing changed is noise the user learns to ignore; a
+// second one in the same sitting reads as a bug; one on a chat that was created
+// seconds ago asks an agent to summarize a board it has never seen. Each of
+// those is a rule about timestamps and nothing else, so they live here with
+// tests rather than tangled into an effect.
+
+import type { AgentRecord, UserTurn } from "@/api";
+
+/** The message the digest sends. Ends on the tool call so the answer comes from
+ *  the board and not from the transcript — the whole point is that the board
+ *  moved without this conversation hearing about it. */
+export const STANDUP_PROMPT =
+  "Summarize what shipped, failed, or got blocked since we last spoke, then " +
+  "recommend what to queue next — check roadmap_list first.";
+
+/** Everything the decision turns on. All times are epoch millis. */
+export interface StandupSignals {
+  /** When the board last moved — the newest item-event's timestamp. `null` for a
+   *  board with no history at all, which is a board with nothing to summarize. */
+  boardMovedAt: number | null;
+  /** When this conversation was last live: its newest turn, else when the chat
+   *  was created (see `chatActiveAt`). */
+  chatActiveAt: number;
+  /** This chat was spawned in this app session, so its opening turn *is* the
+   *  conversation — there is no "since we last spoke". */
+  freshlySpawned: boolean;
+  /** A digest already fired for this project in this app session. Once per
+   *  session per project: the second one in a sitting reads as a bug. */
+  alreadyAsked: boolean;
+}
+
+/** Should the tab dispatch a digest into the chat it just opened?
+ *
+ *  The guards are ordered cheapest-first, but each is independently sufficient —
+ *  none of them is a heuristic standing in for another. */
+export function shouldAskForStandup(s: StandupSignals): boolean {
+  if (s.alreadyAsked) return false;
+  if (s.freshlySpawned) return false;
+  if (s.boardMovedAt === null) return false;
+  // Strictly newer: a board whose last movement *is* the last thing this chat
+  // did (the PM's own accepted proposal, a settle review it already answered)
+  // has told it nothing new.
+  return s.boardMovedAt > s.chatActiveAt;
+}
+
+/** When this conversation was last live, from the cheapest honest signals the
+ *  chat carries.
+ *
+ *  The newest turn's end — or its start, for one still in flight — is the real
+ *  answer, and it covers the settle review too: those arrive as ordinary
+ *  user-role turns, so a chat that was handed a review a minute ago is correctly
+ *  read as current. A chat with no turns at all falls back to when it was
+ *  created, which is the last moment it can be said to have been in sync with
+ *  the board.
+ *
+ *  Turns arrive in `seq` order, so the last element is the newest; a turn that
+ *  never started (a failed send awaiting retry) carries no timestamp and is
+ *  skipped rather than counted as now. */
+export function chatActiveAt(chat: Pick<AgentRecord, "created_at">, turns: UserTurn[]): number {
+  for (let i = turns.length - 1; i >= 0; i--) {
+    const t = turns[i];
+    const at = t.ended_at ?? t.started_at;
+    if (at !== null && at !== undefined) return at;
+  }
+  // ISO string on the record (see the Rust `millis_to_iso`); an unparseable one
+  // reads as epoch 0, which makes any board movement newer — the safe direction
+  // for a chat we can't date.
+  const created = Date.parse(chat.created_at);
+  return Number.isNaN(created) ? 0 : created;
+}

--- a/src/components/ProjectScreen/Roadmap/Thread/usePmChats.ts
+++ b/src/components/ProjectScreen/Roadmap/Thread/usePmChats.ts
@@ -11,13 +11,27 @@
 // thread ends up with a broken cache and a maxed-out context window, and a new
 // chat costs kilobytes (`git clone --shared`). So "New chat" is a first-class
 // action, and the picker keeps the old ones around until the user drops them.
+//
+// This hook also owns the *standup digest*: the board keeps moving with the tab
+// closed (runs dispatch, PRs open, the sweep ships), so opening an existing chat
+// that is behind the board asks it, once, to say what happened. The rule for
+// "behind" is a pure function in `standup.ts`; everything here is the plumbing
+// and the once-per-session guards.
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { type AgentRecord, api, onAgentStatus, onAgentTask, ROADMAP_PM_PURPOSE } from "@/api";
+import {
+  type AgentRecord,
+  api,
+  onAgentStatus,
+  onAgentTask,
+  ROADMAP_PM_PURPOSE,
+  type UserTurn,
+} from "@/api";
 import { resolveAgentSpawnProfile, resolveBaseBranch } from "@/helpers";
 import { PROJECT_MANAGER_NAME, PROJECT_MANAGER_PRESET } from "@/starterPack";
 import { listCustomAgents } from "@/storage/customAgents";
 import { useAppStore } from "@/store";
+import { chatActiveAt, STANDUP_PROMPT, shouldAskForStandup } from "./standup";
 
 /** How the user picked the agent for a new chat: a custom agent (the Project
  *  Manager preset, or any other), or a bare provider. Mirrors what the
@@ -55,6 +69,64 @@ async function ensureProjectManager(): Promise<string | undefined> {
       });
   }
   return seeding;
+}
+
+// ── the standup digest ───────────────────────────────────────────────
+// Module-level rather than per-mount, for the same reason `seeding` is: the
+// Roadmap tab remounts on every navigation, and a guard that remounted with it
+// would ask again every time the user came back to the tab.
+
+/** Projects that have had their one digest this app session. */
+const askedProjects = new Set<string>();
+
+/** Chats spawned in this app session. Their opening turn *is* the conversation,
+ *  so there is nothing for a digest to summarize — and the spawn may have
+ *  dispatched a first message that hasn't persisted a turn row yet, which would
+ *  otherwise read as "no turns, therefore stale". */
+const freshChats = new Set<string>();
+
+/** In-flight digest checks, by project. The check awaits two fetches before it
+ *  decides, and `selected` re-identifies on every status event — so without this
+ *  two overlapping runs could both pass the `askedProjects` guard and send two
+ *  digests. Mirrors `seeding`'s shape. */
+const checkingStandup = new Map<string, Promise<void>>();
+
+/** Ask the opened chat for a digest, if the board moved since it was last live.
+ *  Never throws: a failed digest is a message the user didn't get, not an error
+ *  worth putting on the Roadmap tab. */
+async function askForStandup(projectId: string, chat: AgentRecord): Promise<void> {
+  if (askedProjects.has(projectId)) return;
+  const inFlight = checkingStandup.get(projectId);
+  if (inFlight) return inFlight;
+  const run = (async () => {
+    const [event, turns] = await Promise.all([
+      api.roadmapLatestEvent(projectId).catch(() => null),
+      api.readUserTurns(chat.id).catch(() => [] as UserTurn[]),
+    ]);
+    const ask = shouldAskForStandup({
+      boardMovedAt: event?.created_at ?? null,
+      chatActiveAt: chatActiveAt(chat, turns),
+      freshlySpawned: freshChats.has(chat.id),
+      // Re-read after the awaits: another project's check can't have set it, but
+      // a remount racing this one could.
+      alreadyAsked: askedProjects.has(projectId),
+    });
+    if (!ask) return;
+    // Claimed before the send, so a failure doesn't retry on the next remount —
+    // the digest is a nicety, and one that keeps re-firing is worse than one
+    // that was missed.
+    askedProjects.add(projectId);
+    // The digest lands as an ordinary user turn in this chat, which is what makes
+    // it self-limiting across app restarts too: the next session reads it as the
+    // chat's last activity.
+    await useAppStore.getState().sendUserMessage(chat.id, STANDUP_PROMPT);
+  })()
+    .catch(() => {})
+    .finally(() => {
+      checkingStandup.delete(projectId);
+    });
+  checkingStandup.set(projectId, run);
+  return run;
 }
 
 export interface PmChatsState {
@@ -182,6 +254,20 @@ export function usePmChats(projectId: string | null, repoPath: string): PmChatsS
     };
   }, [patch]);
 
+  // ── the standup digest ─────────────────────────────────────────────
+  // Read the opened chat through a ref: the records re-identify on every status
+  // event (see `patch`), and depending on the object would re-run this on each
+  // one. The id is the only thing that means "a different conversation opened".
+  const chatsRef = useRef(chats);
+  chatsRef.current = chats;
+  useEffect(() => {
+    // `loading` gates it so the digest is decided against the real list, not the
+    // empty one this hook starts with.
+    if (!projectId || loading || !selectedId) return;
+    const chat = chatsRef.current.find((c) => c.id === selectedId);
+    if (chat) void askForStandup(projectId, chat);
+  }, [projectId, loading, selectedId]);
+
   // ── actions ────────────────────────────────────────────────────────
   // Read through a ref so `startChat` doesn't change identity per keystroke of
   // the picker; it only ever needs the value at call time.
@@ -231,6 +317,9 @@ export function usePmChats(projectId: string | null, repoPath: string): PmChatsS
       // on the next render reads, so the message is already on screen when the
       // transcript appears. Failures land in the store's own error channel —
       // this hook's `error` is about the spawn, and the chat now exists.
+      // Never digest into a chat this session created: there is no "since we
+      // last spoke", and the opening turn below may not have persisted a row yet.
+      freshChats.add(rec.id);
       const opening = firstMessage?.trim();
       if (opening) void useAppStore.getState().sendUserMessage(rec.id, opening);
       return true;

--- a/src/components/ProjectScreen/Roadmap/itemHistory.test.ts
+++ b/src/components/ProjectScreen/Roadmap/itemHistory.test.ts
@@ -55,4 +55,11 @@ describe("eventLine", () => {
     );
     expect(eventLine(event({ id: "b", kind: "shipped" }))).toBe("Shipped");
   });
+
+  it("labels a hand-built item's opening line", () => {
+    // `created` is the user-typed row's `proposed`. The label map is typed
+    // `Record<RoadmapEventKind, …>`, so omitting it would fail `tsc` — this only
+    // pins the wording the card shows.
+    expect(eventLine(event({ id: "c", kind: "created", actor: "user" }))).toBe("Created");
+  });
 });

--- a/src/components/ProjectScreen/Roadmap/itemHistory.ts
+++ b/src/components/ProjectScreen/Roadmap/itemHistory.ts
@@ -13,6 +13,7 @@ import type { RoadmapEventKind, RoadmapItemEvent } from "@/api";
 
 /** The kind, as the card's history line says it. */
 export const EVENT_LABEL: Record<RoadmapEventKind, string> = {
+  created: "Created",
   proposed: "Proposed",
   accepted: "Accepted",
   discarded: "Discarded",


### PR DESCRIPTION
First of the Tier B trio (this → needs-you strip → hardening). The PM stops being intake-only: it watches what gets built.

## What
- **Settle-triggered review turns** (`roadmap::review`, new): every run the drainer settles — PR opened, shipped, or failed — is composed into a short review prompt (brief vs outcome) and delivered to the project's newest PM chat via `Supervisor::send_user_message`: live injection mid-turn, the durable `pending_messages` queue at rest, and it can wake a resting session — so the review lands with the tab shut. No PM chat → a durable "PM review pending" event on the item; nothing is silently lost. Gated per project (`roadmap.settle_review`, default on). Lock discipline documented: plan under the shared connection lock, deliver after release.
- **`roadmap_note(code, note)`** — OPS → 6 (pin test green). The PM's one direct write, attention-only (invariant 2's conservative direction): a durable `note` on any item, including `active`/`in_review`/`done` — exactly the rows proposals are refused on, and exactly where an observation is worth recording.
- **Execution awareness:** the PM's `roadmap_list` rows gain `last_event {kind, detail, age}` and `pr {url}` — "why did MCA-104 fail?" is now answerable from the tool alone. Instructions grew an "Overseeing the work" section.
- **Standup digest:** opening the roadmap on a PM chat whose board moved since its last turn auto-dispatches one summarize-and-recommend message (pure, tested trigger; at most once per session; never on a fresh chat).
- **`created` event** (review-gap fix): user-typed rows open their history like PM-proposed ones do — without it, a hand-built board looked unchanged to every "what changed since?" reader, the standup above all.

## Verification (at branch tip, incl. the merge of current main)
cargo 1286 passed / clippy clean (CI flags) · vitest 843 · tsc/biome clean · OPS⇄instructions pin test at 6 ops.