### PR TITLE
feat(roadmap): autonomy is a dial, and holds outrank it

### DIFF
--- a/src-tauri/src/roadmap/drainer.rs
+++ b/src-tauri/src/roadmap/drainer.rs
@@ -24,8 +24,25 @@
 //! 1. **Settles** every `active` item against its run row ([`settle`]), and
 //!    hands each settlement to the project-manager chat as a review turn
 //!    ([`super::review`]) — the loop back up to the agent that wrote the brief.
-//! 2. **Dispatches** at most one queued item ([`pick_next`]), if the project is
-//!    under [`MAX_CONCURRENT_ROADMAP_RUNS`] live roadmap-dispatched runs.
+//! 2. **Dispatches** queued items ([`pick_next`]) until the project is at its
+//!    concurrency cap ([`concurrency_cap`]) or nothing is claimable.
+//!
+//! # The dial
+//!
+//! One run at a time is the *default*, not the design (B3,
+//! .context/roadmap-pm-plan.md): `roadmap.max_concurrent` raises it per project,
+//! and [`MAX_CONCURRENT_ROADMAP_RUNS`] is what an unset dial means. The honest
+//! trade is unchanged by making it settable — N parallel runs on one repo buy
+//! throughput with merge conflicts between their PRs and a review backlog only
+//! the user can clear, and each fork sees a tree without the others' work in it.
+//! So the dial is the user's, it clamps at [`MAX_CONCURRENT_ROADMAP_CEILING`],
+//! and the default keeps a board that was never configured behaving exactly as it
+//! did when the number was a constant.
+//!
+//! Each dispatch inside one tick re-runs the *whole* decision under the
+//! connection lock — the live-run count, the board read, [`dispatchable`],
+//! [`pick_next`] — so raising the cap widens what a tick may do and loosens none
+//! of the gates it does it through.
 //!
 //! # Holds
 //!
@@ -35,6 +52,12 @@
 //! is not autonomy: it is the app noticing that a run it already started has
 //! finished. Refusing to reflect that would leave an `active` card lying about a
 //! run that ended hours ago, which is the opposite of what a brake is for.
+//!
+//! Holds outrank the dial in both directions: a raised cap dispatches more of
+//! what is *already* dispatchable and can't reach a held row, and autoqueue
+//! ([`autoqueue`], read by the accept path in [`super::update_and_record`]) lands
+//! an accepted item `open` rather than `queued` while a hold stands. A hold may
+//! only ever reduce autonomy (invariant 2), so the dial can never override one.
 //!
 //! An item settled into `in_review` leaves the drainer's world entirely —
 //! `projects_with_work` only looks at `queued`/`active`, so a board waiting on
@@ -90,15 +113,24 @@ use super::{deps, emit_item, emit_item_event, holds, store, Db};
 use crate::workflow::spec::{self, Spec};
 use crate::workflow::types::RunStatus;
 
-/// How many roadmap-dispatched runs one project may have in flight at once.
+/// How many roadmap-dispatched runs one project may have in flight when nobody
+/// has said otherwise — the default behind [`MAX_CONCURRENT_KEY`], not a ceiling.
 ///
-/// One, for now. An autonomous queue that opens five PRs into the same repo in
-/// parallel buys throughput with merge conflicts and a review backlog the user
-/// didn't ask for; one run at a time keeps every dispatch reviewable and every
-/// dependency edge meaningful (the next item forks from a tree that includes
-/// the last one). Raising this is a one-line change once the merge sweep can
-/// keep up — nothing else in this module assumes the value is 1.
+/// One, because that is the conservative reading of an autonomous queue: every
+/// dispatch stays reviewable and every dependency edge stays meaningful (the next
+/// item forks from a tree that includes the last one). A project that wants
+/// throughput asks for it explicitly; see the module docs for what it buys and
+/// what it costs.
 pub const MAX_CONCURRENT_ROADMAP_RUNS: usize = 1;
+
+/// The highest cap the dial offers, and the clamp every read applies.
+///
+/// Four, and the limit is not the machine. Parallel runs land parallel pull
+/// requests into **one** repo: past a handful, the merge sweep is serializing
+/// merges that increasingly conflict with each other, and the review bandwidth of
+/// the single human who has to rule on them is the real bottleneck. A number
+/// nobody can keep up with is not more autonomy, it is a backlog.
+pub const MAX_CONCURRENT_ROADMAP_CEILING: usize = 4;
 
 /// How often the drainer wakes on its own. Short enough that a queued item
 /// starts within a moment of its dependency landing, long enough that an idle
@@ -158,7 +190,7 @@ type SaidNotes = Mutex<HashMap<String, SaidNote>>;
 pub(crate) enum Decision {
     /// Nothing queued at all.
     Empty,
-    /// The project is already at [`MAX_CONCURRENT_ROADMAP_RUNS`].
+    /// The project is already at its cap ([`concurrency_cap`]).
     AtCapacity,
     /// Everything queued is waiting on a dependency. Carries the head of the
     /// queue and the codes it waits on, so the caller can say so on the card.
@@ -215,11 +247,12 @@ pub(crate) fn unsatisfied_deps(
 ///   while the hold stands.
 ///
 /// Pure over a board snapshot, so both skips are unit-testable without a
-/// database. **When autoqueue lands (B3, see .context/roadmap-pm-plan.md), it
-/// must dispatch through this filter and the project check in
-/// [`plan_and_claim`]** — a dial that moves `open → queued` on accept would
-/// otherwise walk straight past both brakes, which is exactly the mode holds
-/// exist to make safe.
+/// database. **Autoqueue (B3) dispatches through here, and through the project
+/// check in [`plan_and_claim`], like everything else**: it changes only which
+/// status an accepted item lands in, so an autoqueued row is an ordinary `queued`
+/// row this filter reads exactly as it reads a hand-queued one. It also refuses to
+/// queue a held row at all ([`super::accept_landing`]), which is belt to this
+/// brace — the mode autoqueue creates is the one holds exist to make safe.
 pub(crate) fn dispatchable(items: &[RoadmapItem]) -> Vec<RoadmapItem> {
     items
         .iter()
@@ -235,16 +268,23 @@ pub(crate) fn dispatchable(items: &[RoadmapItem]) -> Vec<RoadmapItem> {
 /// so the item the user dragged to the top is the item this dispatches — and
 /// already stripped of the rows nothing may claim. An item with unsatisfied deps
 /// is *skipped*, never failed — its turn comes when the thing it waits on lands.
+///
+/// `cap` is the project's [`concurrency_cap`], passed in rather than read from a
+/// constant so the whole decision stays pure: one dispatch at cap 1 and up to
+/// four at cap 4 are the *same* rule seen at two settings. Nothing about
+/// parallelism needs new graph logic — deps already serialize dependants, so a
+/// second slot can only ever go to work that was independent anyway.
 pub(crate) fn pick_next(
     queued: &[RoadmapItem],
     live_runs: usize,
+    cap: usize,
     done: &HashSet<String>,
     known: &HashSet<String>,
 ) -> Decision {
     if queued.is_empty() {
         return Decision::Empty;
     }
-    if live_runs >= MAX_CONCURRENT_ROADMAP_RUNS {
+    if live_runs >= cap {
         return Decision::AtCapacity;
     }
     let mut head_block: Option<(String, Vec<String>)> = None;
@@ -437,9 +477,29 @@ async fn tick(
 ) {
     for project_id in projects_with_work(db) {
         settle_project(app, db, &project_id, said);
-        // At most one dispatch per project per tick: the cap is re-read from
-        // the database next tick, so a burst can never exceed it.
-        if let Some(plan) = claim_next(app, db, &project_id, said) {
+        let cap = {
+            let conn = db.lock();
+            concurrency_cap(&conn, &project_id)
+        };
+        // Claim until the project is full or nothing is claimable, and never more
+        // than `cap` times in one tick.
+        //
+        // The bound is the cap for two reasons. It is enough: an idle project can
+        // fill every slot in a single tick, which is what makes a raised dial
+        // felt immediately rather than one item per fifteen seconds. And it is
+        // *needed*: a claim whose launch fails hands its item back to the board
+        // (see [`dispatch`]), so an unbounded loop would burn through a whole
+        // queue of failing dispatches in one tick — at cap 1 that is exactly the
+        // one-attempt-per-tick behaviour this had before the dial existed, kept.
+        //
+        // Sequential, and each iteration re-reads everything under the lock:
+        // `dispatch` is awaited before the next claim, so the run row it inserts
+        // is already counted by the next `live_run_count` and the loop cannot
+        // overshoot by racing itself.
+        for _ in 0..cap {
+            let Some(plan) = claim_next(app, db, &project_id, cap, said) else {
+                break;
+            };
             dispatch(app, db, service, plan).await;
         }
     }
@@ -728,10 +788,16 @@ impl Claim {
 /// Decide what to dispatch for this project and *claim* it. Returns the plan
 /// for a claimed item — already flipped to `active`, so neither a second tick
 /// nor another writer can pick it up.
-fn claim_next(app: &AppHandle, db: &Db, project_id: &str, said: &SaidNotes) -> Option<Plan> {
+fn claim_next(
+    app: &AppHandle,
+    db: &Db,
+    project_id: &str,
+    cap: usize,
+    said: &SaidNotes,
+) -> Option<Plan> {
     let claim = {
         let conn = db.lock();
-        plan_and_claim(&conn, project_id)
+        plan_and_claim(&conn, project_id, cap)
     };
     match claim {
         Claim::Nothing => None,
@@ -768,9 +834,14 @@ fn claim_next(app: &AppHandle, db: &Db, project_id: &str, said: &SaidNotes) -> O
 /// calls this, so a held board still reflects the runs it already started
 /// (see the module docs — settling is not autonomy). A held project says nothing
 /// on the cards either: the reason is one banner above the board, and repeating
-/// it per row would be the same sentence five times. **Autoqueue (B3) must come
-/// through this function**, or it would dispatch straight past this check.
-fn plan_and_claim(conn: &Connection, project_id: &str) -> Claim {
+/// it per row would be the same sentence five times. **Autoqueue comes through
+/// this function** like every other queued row: it writes a status, and this is
+/// still the only thing that turns a status into a run.
+///
+/// `cap` is the project's dial, read once per tick by the caller and re-applied
+/// here on every claim — the *count* it is compared against ([`live_run_count`])
+/// is re-read inside this guard, which is the half that has to be fresh.
+fn plan_and_claim(conn: &Connection, project_id: &str, cap: usize) -> Claim {
     match holds::get_project(conn, project_id) {
         Ok(Some(hold)) => {
             tracing::debug!(project_id, reason = %hold.reason, "roadmap drainer: project held");
@@ -802,7 +873,7 @@ fn plan_and_claim(conn: &Connection, project_id: &str) -> Claim {
     let queued = dispatchable(&items);
 
     let live = live_run_count(conn, project_id);
-    let item = match pick_next(&queued, live, &done, &known) {
+    let item = match pick_next(&queued, live, cap, &done, &known) {
         Decision::Dispatch(i) => queued[i].clone(),
         Decision::Blocked {
             item_id,
@@ -1062,6 +1133,23 @@ async fn dispatch(
 /// "the workflow this project runs" means one thing on both sides.
 const DEFAULT_WORKFLOW_KEY: &str = "workflow.default";
 
+/// `project_settings` key holding how many roadmap runs this project may have in
+/// flight. Absent (or unreadable) means [`MAX_CONCURRENT_ROADMAP_RUNS`]; every
+/// value is clamped to `1..=`[`MAX_CONCURRENT_ROADMAP_CEILING`]. Written by the
+/// Roadmap section of project settings (`RoadmapSection.tsx`, which mirrors these
+/// spellings).
+const MAX_CONCURRENT_KEY: &str = "roadmap.max_concurrent";
+
+/// `project_settings` key for the autonomy dial's other half: when on, accepting
+/// a proposed item lands it `queued` instead of `open`, so one click is the whole
+/// distance from the PM's suggestion to a running build. Default **off** — the
+/// conservative reading, and the one every existing board already has.
+///
+/// Read by the accept path ([`super::update_and_record`]) rather than by this
+/// module: the dial decides where an accept *lands*, and dispatch then treats the
+/// result as the ordinary `queued` row it is.
+const AUTOQUEUE_KEY: &str = "roadmap.autoqueue";
+
 /// One per-project setting, trimmed, with a blank treated as absent. Shared with
 /// [`super::review`], which reads its own dial the same way.
 pub(super) fn project_setting(conn: &Connection, project_id: &str, key: &str) -> Option<String> {
@@ -1073,6 +1161,52 @@ pub(super) fn project_setting(conn: &Connection, project_id: &str, key: &str) ->
     .ok()
     .map(|s| s.trim().to_string())
     .filter(|s| !s.is_empty())
+}
+
+/// One per-project boolean dial. `default` is what an absent row means, and also
+/// what an unrecognized value means — a setting nobody can read is not a mandate
+/// in either direction.
+///
+/// Shared by every roadmap dial ([`autoqueue`] here, `roadmap.settle_review` in
+/// [`super::review`]) so "off" is spelled the same way for all of them: whatever
+/// a checkbox writes (`1`/`0`), whatever a hand-edited row plausibly says
+/// (`true`/`false`, `on`/`off`, `yes`/`no`).
+pub(super) fn project_flag(conn: &Connection, project_id: &str, key: &str, default: bool) -> bool {
+    parse_flag(project_setting(conn, project_id, key).as_deref(), default)
+}
+
+/// [`project_flag`]'s rule, without the database.
+pub(crate) fn parse_flag(raw: Option<&str>, default: bool) -> bool {
+    match raw.map(|v| v.to_ascii_lowercase()) {
+        None => default,
+        Some(v) => match v.as_str() {
+            "1" | "true" | "on" | "yes" => true,
+            "0" | "false" | "off" | "no" => false,
+            _ => default,
+        },
+    }
+}
+
+/// Does accepting a proposed item queue it straight away for this project?
+pub(super) fn autoqueue(conn: &Connection, project_id: &str) -> bool {
+    project_flag(conn, project_id, AUTOQUEUE_KEY, false)
+}
+
+/// How many roadmap runs this project may have in flight at once.
+pub(crate) fn concurrency_cap(conn: &Connection, project_id: &str) -> usize {
+    parse_cap(project_setting(conn, project_id, MAX_CONCURRENT_KEY).as_deref())
+}
+
+/// [`concurrency_cap`]'s rule, without the database: parse, clamp, and fall back.
+///
+/// Garbage falls back to the default rather than to zero or to the ceiling. Zero
+/// would stop the queue with no hold to explain it (that is what holds are for,
+/// and they are visible); the ceiling would answer a typo with four parallel runs.
+pub(crate) fn parse_cap(raw: Option<&str>) -> usize {
+    raw.and_then(|v| v.parse::<usize>().ok())
+        .filter(|n| *n >= 1)
+        .unwrap_or(MAX_CONCURRENT_ROADMAP_RUNS)
+        .min(MAX_CONCURRENT_ROADMAP_CEILING)
 }
 
 /// Roadmap-dispatched runs still in flight for a project. Human-launched runs

--- a/src-tauri/src/roadmap/drainer/tests.rs
+++ b/src-tauri/src/roadmap/drainer/tests.rs
@@ -69,14 +69,17 @@ fn the_queue_follows_rank() {
     let queue = vec![first, second];
 
     assert_eq!(
-        pick_next(&queue, 0, &codes(&[]), &codes(&["FLT-100", "FLT-101"])),
+        pick_next(&queue, 0, 1, &codes(&[]), &codes(&["FLT-100", "FLT-101"])),
         Decision::Dispatch(0)
     );
 }
 
 #[test]
 fn an_empty_queue_decides_nothing() {
-    assert_eq!(pick_next(&[], 0, &codes(&[]), &codes(&[])), Decision::Empty);
+    assert_eq!(
+        pick_next(&[], 0, 1, &codes(&[]), &codes(&[])),
+        Decision::Empty
+    );
 }
 
 // ───────────────────────────── what is in the queue ─────────────────────
@@ -123,7 +126,7 @@ fn a_held_head_is_skipped_and_the_next_item_still_dispatches() {
     let queue = dispatchable(&[held, ready]);
     assert_eq!(queue.len(), 1);
     assert_eq!(
-        pick_next(&queue, 0, &codes(&[]), &codes(&["FLT-100", "FLT-101"])),
+        pick_next(&queue, 0, 1, &codes(&[]), &codes(&["FLT-100", "FLT-101"])),
         Decision::Dispatch(0),
     );
     assert_eq!(queue[0].code, "FLT-101");
@@ -140,6 +143,7 @@ fn a_done_dependency_lets_an_item_through() {
         pick_next(
             &[it],
             0,
+            1,
             &codes(&["FLT-100"]),
             &codes(&["FLT-100", "FLT-101"])
         ),
@@ -158,6 +162,7 @@ fn an_in_review_dependency_still_blocks() {
         pick_next(
             &[it],
             0,
+            1,
             // FLT-100 exists but is not done.
             &codes(&[]),
             &codes(&["FLT-100", "FLT-101"])
@@ -177,7 +182,7 @@ fn a_dependency_that_no_longer_exists_counts_as_satisfied() {
     it.deps = vec!["FLT-100".into()];
 
     assert_eq!(
-        pick_next(&[it], 0, &codes(&[]), &codes(&["FLT-101"])),
+        pick_next(&[it], 0, 1, &codes(&[]), &codes(&["FLT-101"])),
         Decision::Dispatch(0)
     );
 }
@@ -193,6 +198,7 @@ fn a_blocked_head_does_not_block_the_rest_of_the_queue() {
         pick_next(
             &[blocked, ready],
             0,
+            1,
             &codes(&[]),
             &codes(&["FLT-099", "FLT-100", "FLT-101"])
         ),
@@ -210,7 +216,7 @@ fn an_all_blocked_queue_reports_the_head_and_what_it_waits_on() {
     let known = codes(&["FLT-098", "FLT-099", "FLT-100", "FLT-101"]);
     // FLT-098 landed; FLT-099 hasn't.
     assert_eq!(
-        pick_next(&[head, tail], 0, &codes(&["FLT-098"]), &known),
+        pick_next(&[head, tail], 0, 1, &codes(&["FLT-098"]), &known),
         Decision::Blocked {
             item_id: "id-FLT-100".into(),
             waiting_on: vec!["FLT-099".into()],
@@ -240,6 +246,7 @@ fn the_cap_holds_the_queue_even_with_a_ready_item() {
         pick_next(
             &[ready],
             MAX_CONCURRENT_ROADMAP_RUNS,
+            MAX_CONCURRENT_ROADMAP_RUNS,
             &codes(&[]),
             &codes(&["FLT-100"])
         ),
@@ -257,11 +264,197 @@ fn capacity_is_checked_before_dependencies() {
         pick_next(
             &[blocked],
             MAX_CONCURRENT_ROADMAP_RUNS,
+            MAX_CONCURRENT_ROADMAP_RUNS,
             &codes(&[]),
             &codes(&["FLT-099", "FLT-100"])
         ),
         Decision::AtCapacity
     );
+}
+
+/// The dial, as the tick walks it: two independent items both dispatch under a
+/// cap of 2, in rank order, one per claim — and the third claim (of a two-item
+/// queue) reports capacity rather than picking something twice.
+#[test]
+fn a_raised_cap_dispatches_a_second_independent_item() {
+    let queue = vec![item("FLT-100", 1.0), item("FLT-101", 2.0)];
+    let known = codes(&["FLT-100", "FLT-101"]);
+
+    // Nothing live yet: the head goes, exactly as at cap 1.
+    assert_eq!(
+        pick_next(&queue, 0, 2, &codes(&[]), &known),
+        Decision::Dispatch(0)
+    );
+    // One live run, and the same board — the second item is the next claim of
+    // this same tick, and the queue it reads no longer holds the claimed row (it
+    // is `active`, so `dispatchable` drops it).
+    assert_eq!(
+        pick_next(&queue[1..], 1, 2, &codes(&[]), &known),
+        Decision::Dispatch(0)
+    );
+    // Both live: full.
+    assert_eq!(
+        pick_next(&queue[1..], 2, 2, &codes(&[]), &known),
+        Decision::AtCapacity
+    );
+}
+
+/// Raising the cap buys parallelism only where the graph allows it. A dependant
+/// stays blocked with a free slot going spare — deps serialize dependants, which
+/// is why parallel dispatch needed no new graph logic.
+#[test]
+fn a_dependant_stays_blocked_however_high_the_cap() {
+    let mut dependant = item("FLT-101", 2.0);
+    dependant.deps = vec!["FLT-100".into()];
+    let known = codes(&["FLT-100", "FLT-101"]);
+
+    // FLT-100 was claimed a moment ago (so it is out of the queue) and is not
+    // `done`. Three free slots, and nothing to put in them.
+    assert_eq!(
+        pick_next(
+            &[dependant.clone()],
+            1,
+            MAX_CONCURRENT_ROADMAP_CEILING,
+            &codes(&[]),
+            &known
+        ),
+        Decision::Blocked {
+            item_id: "id-FLT-101".into(),
+            waiting_on: vec!["FLT-100".into()],
+        }
+    );
+    // Once it lands, the dependant goes — cap or no cap.
+    assert_eq!(
+        pick_next(
+            &[dependant],
+            1,
+            MAX_CONCURRENT_ROADMAP_CEILING,
+            &codes(&["FLT-100"]),
+            &known
+        ),
+        Decision::Dispatch(0)
+    );
+}
+
+/// Cap 1 is the default, and the default is today's behaviour to the letter: one
+/// dispatch, then capacity — never two, however much is ready.
+#[test]
+fn the_default_cap_still_dispatches_one_at_a_time() {
+    let queue = vec![item("FLT-100", 1.0), item("FLT-101", 2.0)];
+    let known = codes(&["FLT-100", "FLT-101"]);
+    assert_eq!(MAX_CONCURRENT_ROADMAP_RUNS, 1);
+    assert_eq!(
+        pick_next(&queue, 0, MAX_CONCURRENT_ROADMAP_RUNS, &codes(&[]), &known),
+        Decision::Dispatch(0)
+    );
+    assert_eq!(
+        pick_next(
+            &queue[1..],
+            1,
+            MAX_CONCURRENT_ROADMAP_RUNS,
+            &codes(&[]),
+            &known
+        ),
+        Decision::AtCapacity
+    );
+}
+
+// ───────────────────────────── the dial ─────────────────────────────────
+
+#[test]
+fn the_cap_setting_is_parsed_clamped_and_defaulted() {
+    // Unset is the default — a board nobody configured behaves as it always did.
+    assert_eq!(parse_cap(None), MAX_CONCURRENT_ROADMAP_RUNS);
+    assert_eq!(parse_cap(Some("1")), 1);
+    assert_eq!(parse_cap(Some("4")), 4);
+    // Above the ceiling clamps down rather than being refused: the value is a
+    // dial, and the honest answer to "twelve" is "four".
+    assert_eq!(parse_cap(Some("12")), MAX_CONCURRENT_ROADMAP_CEILING);
+    // Garbage, a zero, and a negative all fall back to the default. Zero would
+    // stop the queue with no hold to explain it, which is what holds are for.
+    for bad in ["0", "-1", "two", "3.5", "", "1e3"] {
+        assert_eq!(
+            parse_cap(Some(bad)),
+            MAX_CONCURRENT_ROADMAP_RUNS,
+            "{bad:?} should read as the default"
+        );
+    }
+}
+
+#[test]
+fn the_boolean_dials_read_both_answers_and_fall_back() {
+    // One spelling table for every roadmap dial (autoqueue here, settle_review in
+    // `review`), so "off" can't mean two things on two settings.
+    for on in ["1", "true", "on", "yes", "TRUE", "On"] {
+        assert!(parse_flag(Some(on), false), "{on} should read as on");
+    }
+    for off in ["0", "false", "off", "no", "FALSE", "Off"] {
+        assert!(!parse_flag(Some(off), true), "{off} should read as off");
+    }
+    // Absent or unreadable is the default, in both directions: a setting nobody
+    // can parse is not a mandate.
+    assert!(!parse_flag(None, false));
+    assert!(parse_flag(None, true));
+    assert!(!parse_flag(Some("maybe"), false));
+    assert!(parse_flag(Some("maybe"), true));
+}
+
+/// Every dial's key and default is declared identically on both sides of the wire.
+///
+/// The frontend *writes* these rows (project settings → Roadmap) and this side
+/// *reads* them, with nothing in between to catch a mismatch: a key that drifts is
+/// a toggle that appears to work and changes nothing, and a default that drifts is
+/// a board behaving one way and describing itself another. Same reasoning as the
+/// `EventKind` pin in `events.rs`, for the same reason (a filed B5 follow-up).
+#[test]
+fn every_dial_is_declared_on_both_sides_of_the_wire() {
+    const TS: &str = include_str!("../../../../src/components/ProjectScreen/Roadmap/autonomy.ts");
+    for expected in [
+        format!("export const AUTOQUEUE_KEY = {AUTOQUEUE_KEY:?};"),
+        format!("export const MAX_CONCURRENT_KEY = {MAX_CONCURRENT_KEY:?};"),
+        format!(
+            "export const SETTLE_REVIEW_KEY = {:?};",
+            crate::roadmap::review::SETTLE_REVIEW_KEY
+        ),
+        format!("export const DEFAULT_MAX_CONCURRENT = {MAX_CONCURRENT_ROADMAP_RUNS};"),
+        format!("export const MAX_CONCURRENT_CEILING = {MAX_CONCURRENT_ROADMAP_CEILING};"),
+    ] {
+        assert!(
+            TS.contains(&expected),
+            "autonomy.ts must declare `{expected}` — the host reads what it writes"
+        );
+    }
+}
+
+#[test]
+fn the_cap_is_read_per_project() {
+    let conn = test_conn();
+    conn.execute(
+        "INSERT INTO projects (id, name, created_at) VALUES ('p1', 'fletch', 0), ('p2', 'o', 0)",
+        [],
+    )
+    .unwrap();
+    assert_eq!(concurrency_cap(&conn, "p1"), MAX_CONCURRENT_ROADMAP_RUNS);
+    assert!(!autoqueue(&conn, "p1"));
+
+    for (project, value) in [("p1", "3"), ("p2", "nonsense")] {
+        conn.execute(
+            "INSERT INTO project_settings (project_id, key, value) VALUES (?1, ?2, ?3)",
+            rusqlite::params![project, MAX_CONCURRENT_KEY, value],
+        )
+        .unwrap();
+    }
+    conn.execute(
+        "INSERT INTO project_settings (project_id, key, value) VALUES ('p1', ?1, '1')",
+        rusqlite::params![AUTOQUEUE_KEY],
+    )
+    .unwrap();
+
+    assert_eq!(concurrency_cap(&conn, "p1"), 3);
+    // The other project keeps the default, and a garbage value is not contagious.
+    assert_eq!(concurrency_cap(&conn, "p2"), MAX_CONCURRENT_ROADMAP_RUNS);
+    assert!(autoqueue(&conn, "p1"));
+    assert!(!autoqueue(&conn, "p2"));
 }
 
 // ───────────────────────────── workflow choice ──────────────────────────
@@ -594,7 +787,7 @@ fn a_wedged_queue_head_records_one_blocked_event_not_one_per_tick() {
         item,
         text,
         recorded,
-    } = plan_and_claim(&conn, "p1")
+    } = plan_and_claim(&conn, "p1", 1)
     else {
         panic!("expected a note about the wedged head");
     };
@@ -611,7 +804,7 @@ fn a_wedged_queue_head_records_one_blocked_event_not_one_per_tick() {
 
     // Next tick, same loop: the note may repeat (it's transient), the row may
     // not.
-    let Claim::Note { recorded, .. } = plan_and_claim(&conn, "p1") else {
+    let Claim::Note { recorded, .. } = plan_and_claim(&conn, "p1", 1) else {
         panic!("expected a note");
     };
     assert!(
@@ -631,7 +824,7 @@ fn ordinary_dep_waiting_stays_transient() {
     let waiting = db_item(&conn, ItemStatus::Queued);
     set_deps(&conn, &waiting, &[&dep.code]);
 
-    let Claim::Note { text, recorded, .. } = plan_and_claim(&conn, "p1") else {
+    let Claim::Note { text, recorded, .. } = plan_and_claim(&conn, "p1", 1) else {
         panic!("expected a note");
     };
     assert_eq!(text, format!("Waiting on {}", dep.code));
@@ -648,7 +841,7 @@ fn ordinary_dep_waiting_stays_transient() {
 /// queue selection — so it is the honest signal that the item was in the queue,
 /// without a `wf_definition` and a repo row to make a real claim possible.
 fn reached(conn: &Connection, project_id: &str) -> &'static str {
-    match plan_and_claim(conn, project_id) {
+    match plan_and_claim(conn, project_id, 1) {
         Claim::Nothing => "nothing",
         Claim::Note { .. } => "in the queue",
         Claim::Claimed(..) => "claimed",

--- a/src-tauri/src/roadmap/merge_sweep.rs
+++ b/src-tauri/src/roadmap/merge_sweep.rs
@@ -268,10 +268,12 @@ fn watch_list(db: &Db) -> Vec<Watched> {
 }
 
 /// Poll each watched PR and apply whatever GitHub says. Sequential on purpose:
-/// in-review items *accumulate* — [`drainer::MAX_CONCURRENT_ROADMAP_RUNS`] caps
-/// live runs, not open reviews, and a settled run frees its slot — but the list
-/// only grows as fast as runs finish, and conditional requests make a repeat
-/// read of an unchanged PR nearly free (a 304 isn't billed).
+/// in-review items *accumulate* — [`drainer::concurrency_cap`] caps live runs,
+/// not open reviews, and a settled run frees its slot — but the list only grows as
+/// fast as runs finish, and conditional requests make a repeat read of an
+/// unchanged PR nearly free (a 304 isn't billed). A project that raises its cap
+/// fills this list faster, which is the honest cost of the dial (see the drainer's
+/// docs) rather than a problem this loop has to solve.
 async fn sweep(app: &AppHandle, db: &Db, watching: Vec<Watched>) {
     // One repo path per project per sweep — resolving it is a database read,
     // and every item in a project shares the answer.

--- a/src-tauri/src/roadmap/mod.rs
+++ b/src-tauri/src/roadmap/mod.rs
@@ -69,6 +69,7 @@ pub mod review;
 pub mod store;
 pub mod types;
 
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use parking_lot::Mutex;
@@ -247,17 +248,24 @@ fn create_checked(
 /// moment late is dropped instead of flipping a live run's item back onto the
 /// board (which would orphan the run — see [`drainer`]). Omitting it keeps the
 /// unconditional behaviour every other caller wants (a retitle, a horizon move).
+///
+/// `queue` is the accept path's one extra gesture: "Accept & queue", one click
+/// instead of accept-then-queue. It is meaningful *only* on an accept
+/// (`expect_status: proposed`, `status: open`) and ignored everywhere else — see
+/// [`accept_landing`], which is also where the project's autoqueue dial is read,
+/// so the button and the dial are one implementation and a hold overrules both.
 #[tauri::command]
 pub async fn roadmap_update_item(
     id: String,
     patch: ItemPatch,
     expect_status: Option<ItemStatus>,
+    queue: Option<bool>,
     app: AppHandle,
     db: tauri::State<'_, Db>,
 ) -> Result<ItemUpdate, String> {
     let (outcome, event) = {
         let conn = db.lock();
-        update_and_record(&conn, &id, &patch, expect_status)?
+        update_and_record(&conn, &id, &patch, expect_status, queue.unwrap_or(false))?
     };
     let outcome = outcome.ok_or_else(|| format!("roadmap item {id} no longer exists"))?;
     // A miss changed nothing, so there is nothing to announce and nothing new
@@ -267,6 +275,9 @@ pub async fn roadmap_update_item(
         if let Some(event) = &event {
             emit_item_event(&app, event);
         }
+        // Unconditional, and load-bearing for the dial: an autoqueued accept
+        // leaves the row `queued`, so this is the call that turns one click into a
+        // run without waiting out the tick.
         drainer::nudge();
         // The sweep parks while nothing is in review, and the drainer's
         // settlement is otherwise its only alarm clock — a patch that leaves a
@@ -292,11 +303,19 @@ pub async fn roadmap_update_item(
 /// guard: this command is the item dialog's door, and a dep list that closes a
 /// loop would leave the queue skipping the whole chain forever. The refusal is
 /// an `Err` the dialog renders in its error slot, not a silent drop.
+///
+/// An *accept* is the one transition this function may redirect: [`accept_landing`]
+/// decides whether the row lands `open` or `queued`, so the autonomy dial applies
+/// to every accept surface there is — the card's bar, the batch bar, anything
+/// added later — without one line of frontend logic deciding it. The event still
+/// says `accepted` (from the transition the caller *asked* for), with what became
+/// of it as the detail.
 fn update_and_record(
     conn: &Connection,
     id: &str,
     patch: &ItemPatch,
     expect_status: Option<ItemStatus>,
+    queue: bool,
 ) -> Result<(Option<ItemUpdate>, Option<ItemEvent>), String> {
     if let Some(new_deps) = &patch.deps {
         // A row that is already gone falls through to the normal "no longer
@@ -305,13 +324,29 @@ fn update_and_record(
             check_dep_edit(conn, &current, new_deps)?;
         }
     }
+    // Where an accept lands, resolved before the write and in the same guard as
+    // it: the dial, the button, and the two holds are all read here.
+    let landing = is_accept(expect_status, patch)
+        .then(|| landing_for(conn, id, queue))
+        .flatten();
+    // An accept writes the status its landing names — `open` for all but a
+    // queueing one, which is the status the caller already sent. Only the
+    // `status` field is ever rewritten; everything else lands exactly as sent.
+    let mut effective = Cow::Borrowed(patch);
+    if let Some(landing) = landing {
+        effective.to_mut().status = Some(landing.status());
+    }
     let updated = match expect_status {
-        Some(expected) => store::update_where_status(conn, id, expected, patch),
-        None => store::update(conn, id, patch),
+        Some(expected) => store::update_where_status(conn, id, expected, &effective),
+        None => store::update(conn, id, &effective),
     }
     .map_err(|e| e.to_string())?;
     match updated {
         Some(item) => {
+            // The transition the *caller* performed, not the status the row
+            // landed in: an autoqueued accept is one ruling by one actor, and
+            // `accepted` is the name of that ruling. What the dial then did with
+            // it is the detail — see [`Landing::detail`].
             let kind = events::transition_kind(expect_status, patch.status);
             let event = events::record(
                 conn,
@@ -321,7 +356,7 @@ fn update_and_record(
                 // RPC, drainer, sweep) record under their own actors.
                 EventActor::User,
                 kind,
-                None,
+                landing.and_then(Landing::detail),
             )
             .map_err(|e| e.to_string())?;
             Ok((
@@ -348,6 +383,99 @@ fn update_and_record(
             None => Ok((None, None)),
         },
     }
+}
+
+/// Is this patch *the accept* — the `proposed → open` ruling that turns a PM
+/// suggestion into a roadmap item? The only transition the autonomy dial touches.
+fn is_accept(expect_status: Option<ItemStatus>, patch: &ItemPatch) -> bool {
+    expect_status == Some(ItemStatus::Proposed) && patch.status == Some(ItemStatus::Open)
+}
+
+/// Where an accepted item lands.
+///
+/// The autonomy dial's entire user-visible effect, as three outcomes rather than a
+/// bool, because the third one has to be *sayable*: a user who pressed "Accept &
+/// queue" on a held row and got an `open` item is owed the reason.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum Landing {
+    /// `proposed → open`. The accept alone — what every accept did before the
+    /// dial existed, and still the default.
+    Board,
+    /// `proposed → queued`. Either the project's autoqueue dial is on, or this
+    /// click was "Accept & queue".
+    Queue,
+    /// Queueing was asked for and a hold stands, so it lands `open` after all.
+    HeldBack,
+}
+
+impl Landing {
+    /// The status the row actually lands in.
+    fn status(self) -> ItemStatus {
+        match self {
+            Landing::Queue => ItemStatus::Queued,
+            Landing::Board | Landing::HeldBack => ItemStatus::Open,
+        }
+    }
+
+    /// What the `accepted` line says beyond "accepted", or `None` when the accept
+    /// is the whole story.
+    ///
+    /// One event, not two. An `accepted` + `queued` pair would read as two rulings
+    /// where the user made one, and would make this the only write in the module
+    /// whose single transition emits two history rows; the trail's job is to name
+    /// the *gesture*, and "Accepted — auto-queued" names it exactly. Both readers
+    /// of the trail are served by that: the card's history line renders the detail
+    /// inline, and the PM's `last_event` projection (and the standup that reads the
+    /// newest event) sees one line it can quote verbatim.
+    fn detail(self) -> Option<&'static str> {
+        match self {
+            Landing::Board => None,
+            Landing::Queue => Some("auto-queued"),
+            Landing::HeldBack => Some("left off the queue — this is held"),
+        }
+    }
+}
+
+/// The dial, the button, and the brake — one rule, pure over the three facts.
+///
+/// Holds trump the dial, always (invariant 2: a hold may only ever *reduce*
+/// autonomy). So `held` can turn a queueing accept into a plain one, and nothing
+/// can turn a plain accept into a queueing one behind the user's back. The row
+/// still becomes a roadmap item — refusing the accept itself would be a hold
+/// blocking the user's own ruling, which is the opposite of what it is for.
+pub(crate) fn accept_landing(queue_requested: bool, autoqueue: bool, held: bool) -> Landing {
+    if !queue_requested && !autoqueue {
+        return Landing::Board;
+    }
+    if held {
+        return Landing::HeldBack;
+    }
+    Landing::Queue
+}
+
+/// [`accept_landing`] against the database: read the project's dial and both
+/// brakes for the row being accepted. Called with the connection lock held, in the
+/// same guard as the write it decides.
+///
+/// `None` when the row is gone — the caller's write then misses on its own and
+/// reports the row as it is.
+fn landing_for(conn: &Connection, id: &str, queue: bool) -> Option<Landing> {
+    let item = store::get(conn, id).ok().flatten()?;
+    // An unreadable project hold counts as held: the drainer refuses to dispatch
+    // when it can't read one (see `plan_and_claim`), and this must not be the door
+    // that queues something anyway.
+    let project_held = match holds::get_project(conn, &item.project_id) {
+        Ok(hold) => hold.is_some(),
+        Err(e) => {
+            tracing::warn!(id, error = %e, "roadmap: cannot read the project hold — accepting without queueing");
+            true
+        }
+    };
+    Some(accept_landing(
+        queue,
+        drainer::autoqueue(conn, &item.project_id),
+        item.is_held() || project_held,
+    ))
 }
 
 /// Check a dep list an item that already exists is about to be given: the codes
@@ -1293,7 +1421,7 @@ mod tests {
         for (from, to, kind) in cases {
             let it = with_status(&conn, from);
             let (outcome, event) =
-                update_and_record(&conn, &it.id, &status_patch(to), Some(from)).unwrap();
+                update_and_record(&conn, &it.id, &status_patch(to), Some(from), false).unwrap();
             assert!(outcome.unwrap().applied);
             let event = event.expect("an applied transition records itself");
             assert_eq!(event.kind, kind);
@@ -1315,6 +1443,7 @@ mod tests {
             &it.id,
             &status_patch(ItemStatus::Open),
             Some(ItemStatus::Queued),
+            false,
         )
         .unwrap();
         let outcome = outcome.unwrap();
@@ -1334,8 +1463,187 @@ mod tests {
             title: Some("retitled".into()),
             ..Default::default()
         };
-        let (_, event) = update_and_record(&conn, &it.id, &patch, None).unwrap();
+        let (_, event) = update_and_record(&conn, &it.id, &patch, None, false).unwrap();
         assert_eq!(event.unwrap().kind, EventKind::Edited);
+    }
+
+    // ───────────────────────── the autonomy dial ────────────────────────
+
+    /// Turn a project's dial on.
+    fn set_autoqueue(conn: &Connection, on: bool) {
+        conn.execute(
+            "INSERT OR REPLACE INTO project_settings (project_id, key, value)
+             VALUES ('p1', 'roadmap.autoqueue', ?1)",
+            rusqlite::params![if on { "1" } else { "0" }],
+        )
+        .unwrap();
+    }
+
+    /// Accept one proposed row, with or without the "Accept & queue" flag, and
+    /// report where it landed and what the trail says about it. Exactly the call
+    /// [`roadmap_update_item`] makes.
+    fn accept(conn: &Connection, id: &str, queue: bool) -> (ItemStatus, EventKind, Option<String>) {
+        let (outcome, event) = update_and_record(
+            conn,
+            id,
+            &status_patch(ItemStatus::Open),
+            Some(ItemStatus::Proposed),
+            queue,
+        )
+        .unwrap();
+        let outcome = outcome.expect("the row is there");
+        assert!(outcome.applied);
+        let event = event.expect("an applied accept records itself");
+        (outcome.item.status, event.kind, event.detail)
+    }
+
+    /// The whole rule, without a database: the button, the dial, and the brake.
+    #[test]
+    fn the_dial_and_the_button_land_in_the_same_place() {
+        // Neither asked: today's accept, unchanged.
+        assert_eq!(accept_landing(false, false, false), Landing::Board);
+        // Either one queues it — one implementation, two doors.
+        assert_eq!(accept_landing(true, false, false), Landing::Queue);
+        assert_eq!(accept_landing(false, true, false), Landing::Queue);
+        assert_eq!(accept_landing(true, true, false), Landing::Queue);
+        // A hold beats both, and beats them the same way (invariant 2: a hold can
+        // only ever reduce autonomy).
+        assert_eq!(accept_landing(true, false, true), Landing::HeldBack);
+        assert_eq!(accept_landing(false, true, true), Landing::HeldBack);
+        // A hold on a row nobody asked to queue changes nothing — the accept
+        // itself is the user's ruling and is never refused.
+        assert_eq!(accept_landing(false, false, true), Landing::Board);
+
+        // Each landing's status and its one line of trail.
+        assert_eq!(Landing::Board.status(), ItemStatus::Open);
+        assert_eq!(Landing::Queue.status(), ItemStatus::Queued);
+        assert_eq!(Landing::HeldBack.status(), ItemStatus::Open);
+        assert_eq!(Landing::Board.detail(), None);
+        assert!(Landing::Queue.detail().is_some());
+        assert!(Landing::HeldBack.detail().is_some());
+    }
+
+    /// With the dial on, accepting is the only touch before a run starts: the row
+    /// lands `queued`, and one `accepted` event says how it got there.
+    #[test]
+    fn autoqueue_lands_an_accepted_item_in_the_queue() {
+        let conn = test_conn();
+        set_autoqueue(&conn, true);
+        let it = with_status(&conn, ItemStatus::Proposed);
+
+        let (status, kind, detail) = accept(&conn, &it.id, false);
+        assert_eq!(status, ItemStatus::Queued);
+        // Still `accepted`: one ruling by one actor, whatever the dial did with
+        // it. The detail is what names the dial's part.
+        assert_eq!(kind, EventKind::Accepted);
+        assert_eq!(detail.as_deref(), Some("auto-queued"));
+        // One line, not an `accepted` + `queued` pair.
+        assert_eq!(events::list_for_item(&conn, &it.id).unwrap().len(), 1);
+    }
+
+    /// With the dial off, the accept is unchanged — and the same code path takes
+    /// "Accept & queue" (`queue: true`) to `queued`, so the button and the dial
+    /// can never disagree about where an accepted item goes.
+    #[test]
+    fn the_dial_off_accepts_to_the_board_unless_the_click_asked_to_queue() {
+        let conn = test_conn();
+        let plain = with_status(&conn, ItemStatus::Proposed);
+        assert_eq!(
+            accept(&conn, &plain.id, false),
+            (ItemStatus::Open, EventKind::Accepted, None)
+        );
+
+        let queued = with_status(&conn, ItemStatus::Proposed);
+        let (status, kind, detail) = accept(&conn, &queued.id, true);
+        assert_eq!(status, ItemStatus::Queued);
+        assert_eq!(kind, EventKind::Accepted);
+        assert_eq!(detail.as_deref(), Some("auto-queued"));
+    }
+
+    /// Holds trump the dial. A held row (and every row of a held board) is
+    /// accepted onto the roadmap and left `open` — the brake the PM can pull is
+    /// exactly what makes high-autonomy mode safe, so it must survive the mode
+    /// that needs it. The trail says why, because otherwise the user who pressed
+    /// "Accept & queue" has an `open` item and no explanation.
+    #[test]
+    fn a_hold_keeps_an_accepted_item_off_the_queue() {
+        let conn = test_conn();
+        set_autoqueue(&conn, true);
+
+        let held = with_status(&conn, ItemStatus::Proposed);
+        holds::hold_item(
+            &conn,
+            &held.id,
+            "confirm the direction first",
+            EventActor::Pm,
+        )
+        .unwrap();
+        let (status, kind, detail) = accept(&conn, &held.id, true);
+        assert_eq!(status, ItemStatus::Open, "the item's own hold stopped it");
+        assert_eq!(kind, EventKind::Accepted);
+        assert!(detail.unwrap().contains("held"));
+
+        // The board-wide brake does the same for a row with no hold of its own.
+        let ordinary = with_status(&conn, ItemStatus::Proposed);
+        holds::hold_project(&conn, "p1", "re-planning the quarter", EventActor::Pm).unwrap();
+        assert_eq!(accept(&conn, &ordinary.id, false).0, ItemStatus::Open);
+
+        // Released, the dial applies again — nothing about the accept path
+        // remembers the hold.
+        assert!(holds::release_project(&conn, "p1").unwrap());
+        let after = with_status(&conn, ItemStatus::Proposed);
+        assert_eq!(accept(&conn, &after.id, false).0, ItemStatus::Queued);
+    }
+
+    /// The dial reaches exactly one transition. A queue action, an unqueue, or a
+    /// form edit is not an accept, so neither the setting nor the flag may touch
+    /// it — otherwise "Accept & queue"'s flag, sent by any caller, would become a
+    /// second way to queue anything.
+    #[test]
+    fn nothing_but_an_accept_is_redirected() {
+        let conn = test_conn();
+        set_autoqueue(&conn, true);
+
+        // An unqueue with the flag set stays an unqueue.
+        let queued = with_status(&conn, ItemStatus::Queued);
+        let (outcome, event) = update_and_record(
+            &conn,
+            &queued.id,
+            &status_patch(ItemStatus::Open),
+            Some(ItemStatus::Queued),
+            true,
+        )
+        .unwrap();
+        assert_eq!(outcome.unwrap().item.status, ItemStatus::Open);
+        let event = event.unwrap();
+        assert_eq!(event.kind, EventKind::Unqueued);
+        assert_eq!(event.detail, None);
+
+        // And a plain edit is still an edit, with no status invented for it.
+        let open = with_status(&conn, ItemStatus::Open);
+        let (outcome, event) = update_and_record(
+            &conn,
+            &open.id,
+            &ItemPatch {
+                title: Some("retitled".into()),
+                ..Default::default()
+            },
+            None,
+            true,
+        )
+        .unwrap();
+        assert_eq!(outcome.unwrap().item.status, ItemStatus::Open);
+        assert_eq!(event.unwrap().kind, EventKind::Edited);
+
+        assert!(is_accept(
+            Some(ItemStatus::Proposed),
+            &status_patch(ItemStatus::Open)
+        ));
+        assert!(!is_accept(None, &status_patch(ItemStatus::Open)));
+        assert!(!is_accept(
+            Some(ItemStatus::Proposed),
+            &status_patch(ItemStatus::Queued)
+        ));
     }
 
     /// `roadmap_get_item`'s one read: a live id returns the row, and an id that
@@ -1776,11 +2084,13 @@ mod tests {
         };
 
         // b after a: an ordinary edge, applied.
-        let (outcome, _) = update_and_record(&conn, &b.id, &deps_patch(&[&a.code]), None).unwrap();
+        let (outcome, _) =
+            update_and_record(&conn, &b.id, &deps_patch(&[&a.code]), None, false).unwrap();
         assert_eq!(outcome.unwrap().item.deps, vec![a.code.clone()]);
 
         // a after b now closes the loop — refused, and the row is untouched.
-        let err = update_and_record(&conn, &a.id, &deps_patch(&[&b.code]), None).unwrap_err();
+        let err =
+            update_and_record(&conn, &a.id, &deps_patch(&[&b.code]), None, false).unwrap_err();
         assert!(err.contains("loop"), "{err}");
         assert!(
             err.contains(&format!("{} → {} → {}", a.code, b.code, a.code)),
@@ -1789,11 +2099,13 @@ mod tests {
         assert!(store::get(&conn, &a.id).unwrap().unwrap().deps.is_empty());
 
         // A code that isn't on the board at all is refused too.
-        let err = update_and_record(&conn, &a.id, &deps_patch(&["MCA-999"]), None).unwrap_err();
+        let err =
+            update_and_record(&conn, &a.id, &deps_patch(&["MCA-999"]), None, false).unwrap_err();
         assert!(err.contains("MCA-999"), "{err}");
 
         // Self-reference, and the same rule on the create path.
-        let err = update_and_record(&conn, &a.id, &deps_patch(&[&a.code]), None).unwrap_err();
+        let err =
+            update_and_record(&conn, &a.id, &deps_patch(&[&a.code]), None, false).unwrap_err();
         assert!(err.contains("depend on itself"), "{err}");
         let err = create_checked(
             &conn,
@@ -1845,7 +2157,7 @@ mod tests {
             deps: Some(vec![b.code.clone()]),
             ..Default::default()
         };
-        let (outcome, _) = update_and_record(&conn, &a.id, &patch, None).unwrap();
+        let (outcome, _) = update_and_record(&conn, &a.id, &patch, None, false).unwrap();
         assert_eq!(outcome.unwrap().item.title, "retitled");
     }
 

--- a/src-tauri/src/roadmap/review.rs
+++ b/src-tauri/src/roadmap/review.rs
@@ -46,7 +46,7 @@ use std::sync::Arc;
 use rusqlite::{Connection, OptionalExtension};
 use tauri::{AppHandle, Manager};
 
-use super::drainer::{project_setting, FinalizedPr, Settlement};
+use super::drainer::{project_flag, FinalizedPr, Settlement};
 use super::events::{self, EventActor, EventKind};
 use super::types::RoadmapItem;
 use super::{emit_item_event, Db};
@@ -56,7 +56,10 @@ use crate::supervisor::Supervisor;
 /// `workflow.default`. Absent means on: a user who has never touched the dial
 /// gets the oversight loop the product is about, and turning it off is the
 /// explicit act.
-const SETTLE_REVIEW_KEY: &str = "roadmap.settle_review";
+/// (Visible to the module so the drainer's cross-language pin can walk all three
+/// roadmap dials in one place — the frontend writes these rows, this side reads
+/// them, and a key that drifts is a setting that silently stops working.)
+pub(super) const SETTLE_REVIEW_KEY: &str = "roadmap.settle_review";
 
 /// The instruction line the review turn ends on — what the PM is being asked to
 /// *do* with the outcome, as opposed to acknowledge. Both halves matter: a
@@ -173,16 +176,13 @@ pub(crate) fn plan(conn: &Connection, project_id: &str) -> Plan {
     }
 }
 
-/// Is the settle review on for this project? Absent is on; the off spellings are
-/// the ones a checkbox or a hand-edited row would plausibly write.
+/// Is the settle review on for this project? Absent is on, and the spellings both
+/// answers are recognized in are the drainer's ([`project_flag`]) — this is one of
+/// three roadmap dials now (B3 added autoqueue and the concurrency cap), and one
+/// of them reading "off" differently from the others would be a bug nobody sees
+/// until a hand-edited row behaves two ways.
 fn enabled(conn: &Connection, project_id: &str) -> bool {
-    match project_setting(conn, project_id, SETTLE_REVIEW_KEY) {
-        None => true,
-        Some(v) => !matches!(
-            v.to_ascii_lowercase().as_str(),
-            "false" | "0" | "off" | "no"
-        ),
-    }
+    project_flag(conn, project_id, SETTLE_REVIEW_KEY, true)
 }
 
 /// The project's newest live PM chat, by the same filter and order the Roadmap

--- a/src/api/domains/roadmap.ts
+++ b/src/api/domains/roadmap.ts
@@ -38,13 +38,26 @@ export const roadmapApi = {
    *  broadcast). That is what keeps a status change sent off a stale board from
    *  overwriting one the Rust drainer made in the meantime — see `unqueueItems`
    *  in useRoadmap.ts. Without it the patch is unconditional and `applied` is
-   *  always true. */
-  roadmapUpdateItem: (id: string, patch: RoadmapItemPatch, expectStatus?: ItemStatus) =>
+   *  always true.
+   *
+   *  `queue` is "Accept & queue": on an accept (`{status:"open"}` with
+   *  `expectStatus:"proposed"`) it asks for the row to land `queued` instead, in
+   *  one click. Ignored on every other patch. The project's `roadmap.autoqueue`
+   *  dial goes through the same backend decision, so the button and the dial land
+   *  in the same place — and a hold overrules both, leaving the item `open` with
+   *  the reason on its trail. */
+  roadmapUpdateItem: (
+    id: string,
+    patch: RoadmapItemPatch,
+    expectStatus?: ItemStatus,
+    queue?: boolean,
+  ) =>
     invoke<RoadmapItemUpdate>("roadmap_update_item", {
       id,
       patch,
       // Always sent, so the argument is present-and-null rather than absent.
       expectStatus: expectStatus ?? null,
+      queue: queue ?? null,
     }),
   /** Move an item in the project's priority order — the board's drag within a
    *  horizon group. Bookkeeping, so it writes no history line (a *horizon* move

--- a/src/components/ProjectScreen/Roadmap/Board/DecisionBar.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/DecisionBar.tsx
@@ -18,8 +18,10 @@ export function DecisionBar({
   note,
   variant = "ghost",
   acceptLabel = "Accept",
+  queueLabel,
   declineLabel,
   onAccept,
+  onAcceptQueue,
   onDecline,
 }: {
   /** What is being asked, in a few words ("Proposed — not on the roadmap yet").
@@ -32,8 +34,15 @@ export function DecisionBar({
    *  decision surface stands out from a body that *is* the roadmap). */
   variant?: "ghost" | "prop";
   acceptLabel?: string;
+  /** Label for the second accept, when the caller has one — see `onAcceptQueue`. */
+  queueLabel?: string | null;
   declineLabel: string;
   onAccept?: () => void;
+  /** Accept *and* queue, in one click (a ghost row's `queue: true` accept). Only
+   *  offered while the project's autoqueue dial is off: with it on, `onAccept`
+   *  already queues and this would be the same button twice. Drawn as an outline
+   *  so the plain accept stays the primary — the extra autonomy is the opt-in. */
+  onAcceptQueue?: () => void;
   onDecline?: () => void;
 }) {
   return (
@@ -46,6 +55,11 @@ export function DecisionBar({
       {onDecline && (
         <Button variant="ghost" size="sm" onClick={onDecline}>
           {declineLabel}
+        </Button>
+      )}
+      {onAcceptQueue && queueLabel && (
+        <Button variant="outline" size="sm" onClick={onAcceptQueue}>
+          <Icon name="zap" size={11} /> {queueLabel}
         </Button>
       )}
       {onAccept && (

--- a/src/components/ProjectScreen/Roadmap/Board/ItemCard.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/ItemCard.tsx
@@ -36,7 +36,9 @@ const STATE: Partial<Record<ItemStatus, { label: string; cls: string; tip: strin
   queued: {
     label: "Queued",
     cls: "q",
-    tip: "Waiting for a slot — the queue runs one item per project at a time",
+    // How many slots there are is a per-project dial (Settings → Roadmap), so the
+    // tip talks about slots rather than promising a number it can't see here.
+    tip: "Waiting for a slot — the queue runs as many items at once as this project allows",
   },
   in_review: {
     label: "In review",
@@ -58,8 +60,17 @@ interface Props {
   ghost?: boolean;
   open: boolean;
   onToggle: () => void;
-  /** Accept the proposal (`proposed → open`). Ghosts only, and not read-only. */
+  /** Accept the proposal (`proposed → open`). Ghosts only, and not read-only.
+   *  Where it lands is the project's business, not this card's: with autoqueue on
+   *  it queues (which is why `acceptLabel` changes), and a hold leaves it `open`. */
   onAccept?: () => void;
+  /** Accept *and* queue in one click. Passed only while autoqueue is off — with it
+   *  on, `onAccept` already does this. */
+  onAcceptQueue?: () => void;
+  /** What the two accepts say, from `acceptActions` — so the words the board uses
+   *  and the words this card uses are computed once. */
+  acceptLabel?: string;
+  queueLabel?: string | null;
   /** Discard the proposal — the row is deleted. Ghosts only. */
   onDiscard?: () => void;
   /** The PM's pending ask against this row — a change or a discard the user
@@ -154,6 +165,9 @@ export function ItemCard({
   landed,
   onEdit,
   onAccept,
+  onAcceptQueue,
+  acceptLabel,
+  queueLabel,
   onDiscard,
   proposal,
   onAcceptProposal,
@@ -282,8 +296,11 @@ export function ItemCard({
       {ghost && (onAccept || onDiscard) && (
         <DecisionBar
           label="Proposed — not on the roadmap yet"
+          acceptLabel={acceptLabel}
+          queueLabel={queueLabel}
           declineLabel="Discard"
           onAccept={onAccept}
+          onAcceptQueue={onAcceptQueue}
           onDecline={onDiscard}
         />
       )}

--- a/src/components/ProjectScreen/Roadmap/Board/index.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/index.tsx
@@ -2,7 +2,9 @@ import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } fro
 import type { Horizon, RoadmapItem } from "@/api";
 import { Icon } from "@/components/Icon";
 import { IconButton } from "@/components/ui/IconButton";
+import { getProjectSettings } from "@/storage/projectSettings";
 import { useAppStore } from "@/store";
+import { AUTOQUEUE_KEY, acceptActions, flagOn } from "../autonomy";
 import { NeedsYou } from "../NeedsYou";
 import { HORIZONS } from "../types";
 import { reviewGate } from "../useItemReviews";
@@ -38,6 +40,7 @@ export function Board({
   asideRef?: RefObject<HTMLElement>;
 }) {
   const {
+    projectId,
     items,
     ghosts,
     proposals,
@@ -125,6 +128,28 @@ export function Board({
 
   /** Nothing on the board at all — not even a pending proposal. */
   const blank = !loading && items.length === 0 && ghosts.length === 0;
+
+  /** The project's autoqueue dial — what an accept *does*, so the accept buttons
+   *  can say it (`acceptActions`). Read here rather than in `useRoadmap` on
+   *  purpose: this component mounts every time the user comes back to the Roadmap
+   *  tab, so a dial they just changed two tabs over is never stale on screen.
+   *  Where an accept actually lands is decided host-side either way — this only
+   *  labels the button. */
+  const [autoqueue, setAutoqueue] = useState(false);
+  useEffect(() => {
+    if (!projectId) return;
+    let cancelled = false;
+    getProjectSettings(projectId)
+      .then((all) => {
+        if (!cancelled) setAutoqueue(flagOn(all[AUTOQUEUE_KEY], false));
+      })
+      .catch((e) => console.error("load roadmap.autoqueue failed", e));
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+  const cardAccept = acceptActions(autoqueue, "Accept");
+  const batchAccept = acceptActions(autoqueue, "Accept all");
 
   /** The PM's asks against admitted rows only. An ask targeting a row that is
    *  itself still a ghost stays out of the batch bar — its card shows no bar
@@ -253,6 +278,25 @@ export function Board({
           >
             Discard all
           </button>
+          {/* The batch's one-click queue, on the same terms as a card's: offered
+              only while the dial is off, and only when there is a ghost to queue
+              — a bar counting nothing but pending *changes* has nothing to hand
+              the drainer (an accepted patch doesn't move a status). */}
+          {batchAccept.queue && ghosts.length > 0 && (
+            <button
+              type="button"
+              className="rm-props-q iflex-center"
+              onClick={() => {
+                void acceptItems(
+                  ghosts.map((g) => g.item.id),
+                  true,
+                );
+                if (asks.length) void acceptProposals(asks.map((p) => p.id));
+              }}
+            >
+              <Icon name="zap" size={11} /> {batchAccept.queue}
+            </button>
+          )}
           <button
             type="button"
             className="rm-props-ok iflex-center"
@@ -261,7 +305,7 @@ export function Board({
               if (asks.length) void acceptProposals(asks.map((p) => p.id));
             }}
           >
-            <Icon name="check" size={11} /> Accept all
+            <Icon name="check" size={11} /> {batchAccept.primary}
           </button>
         </div>
       )}
@@ -346,6 +390,18 @@ export function Board({
                           : () => setEditing({ item: row, horizon: row.horizon })
                       }
                       onAccept={ghost && !readOnly ? () => acceptItems([row.id]) : undefined}
+                      acceptLabel={cardAccept.primary}
+                      queueLabel={cardAccept.queue}
+                      onAcceptQueue={
+                        // Ghost rows only, and only while the dial is off: with it
+                        // on the primary Accept already queues (and says so). A
+                        // pending *proposal*'s bar never gets this — accepting a
+                        // patch changes a row's shape, not what the queue does
+                        // with it.
+                        ghost && !readOnly && cardAccept.queue
+                          ? () => acceptItems([row.id], true)
+                          : undefined
+                      }
                       onDiscard={ghost && !readOnly ? () => removeItems([row.id]) : undefined}
                       proposal={proposal}
                       onAcceptProposal={

--- a/src/components/ProjectScreen/Roadmap/Roadmap.css
+++ b/src/components/ProjectScreen/Roadmap/Roadmap.css
@@ -745,6 +745,7 @@
   color: var(--fg-3);
 }
 .rm-props-x,
+.rm-props-q,
 .rm-props-ok {
   display: inline-flex;
   align-items: center;
@@ -762,6 +763,16 @@
 }
 .rm-props-x:hover {
   color: var(--fg-0);
+  background: var(--hover);
+}
+/* The batch's "Accept all & queue": the same shape as Accept all, drawn one step
+   quieter (no border) because it is the more autonomous of the two and should not
+   be the one the eye lands on first. */
+.rm-props-q {
+  color: var(--fg-2);
+}
+.rm-props-q:hover {
+  color: var(--accent);
   background: var(--hover);
 }
 .rm-props-ok {

--- a/src/components/ProjectScreen/Roadmap/autonomy.test.ts
+++ b/src/components/ProjectScreen/Roadmap/autonomy.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  acceptActions,
+  CONCURRENCY_CHOICES,
+  DEFAULT_MAX_CONCURRENT,
+  flagOn,
+  MAX_CONCURRENT_CEILING,
+  parseCap,
+} from "./autonomy";
+
+describe("flagOn", () => {
+  it("reads every spelling the host writes or recognizes", () => {
+    for (const on of ["1", "true", "on", "yes", "TRUE", " On "]) {
+      expect(flagOn(on, false)).toBe(true);
+    }
+    for (const off of ["0", "false", "off", "no", "FALSE", " Off "]) {
+      expect(flagOn(off, true)).toBe(false);
+    }
+  });
+
+  it("falls back on an absent, blank or unreadable value — in both directions", () => {
+    // A dial nobody can parse is not a mandate: the default decides, so a
+    // hand-edited row can't silently switch autonomy on.
+    for (const raw of [undefined, "", "  ", "maybe"]) {
+      expect(flagOn(raw, false)).toBe(false);
+      expect(flagOn(raw, true)).toBe(true);
+    }
+  });
+});
+
+describe("parseCap", () => {
+  it("shows the number actually in force, clamped like the host", () => {
+    expect(parseCap(undefined)).toBe(DEFAULT_MAX_CONCURRENT);
+    expect(parseCap("1")).toBe(1);
+    expect(parseCap("4")).toBe(4);
+    // Hand-edited above the ceiling: the select must show what the drainer will
+    // really do, not the row's wishful number.
+    expect(parseCap("12")).toBe(MAX_CONCURRENT_CEILING);
+  });
+
+  it("defaults on garbage, zero and fractions", () => {
+    for (const bad of ["0", "-1", "two", "3.5", "", "1e3"]) {
+      expect(parseCap(bad)).toBe(DEFAULT_MAX_CONCURRENT);
+    }
+  });
+
+  it("offers every setting between the default and the ceiling", () => {
+    expect(CONCURRENCY_CHOICES).toEqual([1, 2, 3, 4]);
+  });
+});
+
+describe("acceptActions", () => {
+  it("offers the one-click queue as a second action while the dial is off", () => {
+    expect(acceptActions(false, "Accept")).toEqual({
+      primary: "Accept",
+      queue: "Accept & queue",
+    });
+    expect(acceptActions(false, "Accept all")).toEqual({
+      primary: "Accept all",
+      queue: "Accept all & queue",
+    });
+  });
+
+  it("says what the primary does once the dial makes it queue", () => {
+    // With autoqueue on, Accept *is* Accept & queue — a button that hid that
+    // would be the one place the board understates what a click starts.
+    expect(acceptActions(true, "Accept")).toEqual({
+      primary: "Accept & queue",
+      queue: null,
+    });
+    expect(acceptActions(true, "Accept all").queue).toBeNull();
+  });
+});

--- a/src/components/ProjectScreen/Roadmap/autonomy.ts
+++ b/src/components/ProjectScreen/Roadmap/autonomy.ts
@@ -1,0 +1,87 @@
+/** The autonomy dial: how much of the pipeline runs without a further click.
+ *
+ *  Two per-project settings and the words the board says because of them. Pure —
+ *  no storage, no React — so the board and the Settings section read one
+ *  implementation, and the label logic is testable without a DOM.
+ *
+ *  Every key and every parse rule here mirrors a Rust constant
+ *  (`roadmap/drainer.rs`, `roadmap/review.rs`). The spellings must agree: the
+ *  frontend writes these rows and the host reads them, and a `"0"` one side calls
+ *  off and the other calls unrecognized is a dial that lies. */
+
+/** Accepting a proposed item lands it `queued` instead of `open`. Default off —
+ *  `drainer::AUTOQUEUE_KEY`. */
+export const AUTOQUEUE_KEY = "roadmap.autoqueue";
+
+/** How many roadmap runs one project may have in flight — `drainer::MAX_CONCURRENT_KEY`. */
+export const MAX_CONCURRENT_KEY = "roadmap.max_concurrent";
+
+/** The PM reviews every settled run — `review::SETTLE_REVIEW_KEY`. Default on. */
+export const SETTLE_REVIEW_KEY = "roadmap.settle_review";
+
+/** What an unset concurrency dial means — `drainer::MAX_CONCURRENT_ROADMAP_RUNS`. */
+export const DEFAULT_MAX_CONCURRENT = 1;
+
+/** The highest the dial goes — `drainer::MAX_CONCURRENT_ROADMAP_CEILING`. The limit
+ *  is the repo, not the machine: parallel runs open parallel PRs into one repo, and
+ *  past a handful they conflict with each other faster than one person can review
+ *  them. */
+export const MAX_CONCURRENT_CEILING = 4;
+
+/** Every setting the concurrency select offers, low to high. */
+export const CONCURRENCY_CHOICES = Array.from({ length: MAX_CONCURRENT_CEILING }, (_, i) => i + 1);
+
+/** A stored boolean dial, in the spellings the host recognizes
+ *  (`drainer::parse_flag`). An absent row — or one nobody can parse — is
+ *  `fallback`: a setting that can't be read is not a mandate in either direction. */
+export function flagOn(raw: string | undefined, fallback: boolean): boolean {
+  switch (raw?.trim().toLowerCase()) {
+    case undefined:
+    case "":
+      return fallback;
+    case "1":
+    case "true":
+    case "on":
+    case "yes":
+      return true;
+    case "0":
+    case "false":
+    case "off":
+    case "no":
+      return false;
+    default:
+      return fallback;
+  }
+}
+
+/** A stored concurrency cap, parsed and clamped exactly as the host does
+ *  (`drainer::parse_cap`) — so the select shows the number that is actually in
+ *  force, including for a row somebody hand-edited to `12`. */
+export function parseCap(raw: string | undefined): number {
+  const text = raw?.trim() ?? "";
+  // Plain digits only, because that is what the host's `usize::from_str` accepts:
+  // `Number()` would read "1e3" as a thousand where Rust reads it as garbage, and
+  // the two sides disagreeing about a hand-edited row is exactly the bug this
+  // mirroring exists to prevent.
+  if (!/^\+?\d+$/.test(text)) return DEFAULT_MAX_CONCURRENT;
+  const n = Number(text);
+  if (n < 1) return DEFAULT_MAX_CONCURRENT;
+  return Math.min(n, MAX_CONCURRENT_CEILING);
+}
+
+/** What the accept actions on a proposal say, and how many there are.
+ *
+ *  With the dial off there are two: the plain accept, and the one-click
+ *  "Accept & queue" (which sends `queue: true` — the same backend decision the
+ *  dial takes). With the dial on there is one, and it is *labelled* for what it
+ *  does: the primary accept already queues, so a button still saying "Accept"
+ *  would understate it. */
+export function acceptActions(
+  autoqueue: boolean,
+  /** The gesture in the caller's words — "Accept" on a card, "Accept all" on the
+   *  batch bar. */
+  verb: string,
+): { primary: string; queue: string | null } {
+  const both = `${verb} & queue`;
+  return autoqueue ? { primary: both, queue: null } : { primary: verb, queue: both };
+}

--- a/src/components/ProjectScreen/Roadmap/useRoadmap.ts
+++ b/src/components/ProjectScreen/Roadmap/useRoadmap.ts
@@ -625,15 +625,26 @@ export function useRoadmap(repoPath: string) {
    *  a roadmap item. The row (and its code) already exist, so nothing is
    *  re-created and nothing is renumbered — the code the PM quoted in the chat
    *  is the code that stays on the board. The other half of the decision is
-   *  [`removeItems`]. */
+   *  [`removeItems`].
+   *
+   *  `queue` is the "Accept & queue" click: accept and hand it to the drainer in
+   *  one gesture. Where an accept *lands* is decided backend-side, not here — the
+   *  project's autoqueue dial can queue it with `queue` unset, and a hold leaves
+   *  it `open` even with `queue` set (holds trump the dial). So this reads the
+   *  status off the row that comes back rather than assuming one. */
   const acceptItems = useCallback(
-    (ids: string[]) =>
+    (ids: string[], queue = false) =>
       guarded(async () => {
         const codes: string[] = [];
         for (const id of ids) {
           // Conditional like every other status transition: accepting is only
           // meaningful on a row that is still a proposal.
-          const { applied, item } = await api.roadmapUpdateItem(id, { status: "open" }, "proposed");
+          const { applied, item } = await api.roadmapUpdateItem(
+            id,
+            { status: "open" },
+            "proposed",
+            queue,
+          );
           upsert(item);
           if (applied) codes.push(item.code);
         }

--- a/src/components/ProjectScreen/RoadmapSection.tsx
+++ b/src/components/ProjectScreen/RoadmapSection.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useState } from "react";
+import { Toggle } from "@/components/Settings/Toggle";
+import {
+  deleteProjectSetting,
+  getProjectSettings,
+  setProjectSetting,
+} from "@/storage/projectSettings";
+import {
+  AUTOQUEUE_KEY,
+  CONCURRENCY_CHOICES,
+  DEFAULT_MAX_CONCURRENT,
+  flagOn,
+  MAX_CONCURRENT_KEY,
+  parseCap,
+  SETTLE_REVIEW_KEY,
+} from "./Roadmap/autonomy";
+
+/** The autonomy dial: how much of the roadmap pipeline runs without you.
+ *
+ *  Three per-project settings, all read host-side (`roadmap/drainer.rs`,
+ *  `roadmap/review.rs`) — the keys and the spellings live in `Roadmap/autonomy.ts`,
+ *  which both this section and the board read, so nothing here decides anything
+ *  the queue doesn't also see.
+ *
+ *  Each row follows the neighbouring sections' pattern: load on mount, write (or
+ *  delete) on change, absent meaning the default. Deleting rather than writing the
+ *  default keeps "never configured" and "configured back to the default" the same
+ *  row, which is what makes a future change of default actually reach old
+ *  projects. */
+export function RoadmapSection({ projectId }: { projectId: string }) {
+  const [autoqueue, setAutoqueue] = useState(false);
+  const [cap, setCap] = useState(DEFAULT_MAX_CONCURRENT);
+  const [settleReview, setSettleReview] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    getProjectSettings(projectId)
+      .then((all) => {
+        if (cancelled) return;
+        setAutoqueue(flagOn(all[AUTOQUEUE_KEY], false));
+        setCap(parseCap(all[MAX_CONCURRENT_KEY]));
+        setSettleReview(flagOn(all[SETTLE_REVIEW_KEY], true));
+      })
+      .catch((e) => console.error("load roadmap settings failed", e));
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+
+  /** Persist one dial, treating `value === null` as "back to the default". */
+  const save = (key: string, value: string | null) => {
+    const write =
+      value === null
+        ? deleteProjectSetting(projectId, key)
+        : setProjectSetting(projectId, key, value);
+    write.catch((e) => console.error(`save ${key} failed`, e));
+  };
+
+  const toggleAutoqueue = (next: boolean) => {
+    setAutoqueue(next);
+    save(AUTOQUEUE_KEY, next ? "1" : null);
+  };
+
+  const pickCap = (next: number) => {
+    setCap(next);
+    save(MAX_CONCURRENT_KEY, next === DEFAULT_MAX_CONCURRENT ? null : String(next));
+  };
+
+  const toggleSettleReview = (next: boolean) => {
+    setSettleReview(next);
+    // On is the default here, so *off* is the row that has to exist.
+    save(SETTLE_REVIEW_KEY, next ? null : "0");
+  };
+
+  return (
+    <section className="ps-section">
+      <header className="ps-section-h">
+        <h2 className="ps-section-t text-lg">Roadmap</h2>
+        <p className="ps-section-lead text-sm">
+          How much of the roadmap runs without you. Every item still starts as something you accept
+          — these decide what happens after that, and a hold (yours or the PM&rsquo;s) overrules all
+          three.
+        </p>
+      </header>
+
+      <div className="ps-field ps-name-row">
+        <label className="ps-label text-sm" htmlFor="ps-rm-autoqueue">
+          Accepted items queue automatically
+        </label>
+        <Toggle value={autoqueue} onChange={toggleAutoqueue} />
+      </div>
+      <p className="ps-section-lead text-sm">
+        With this on, accepting a proposal is the only touch before a pull request arrives —
+        &ldquo;Accept&rdquo; hands the item straight to the queue. Off, accepting puts it on the
+        roadmap and you queue it when you&rsquo;re ready (the card still offers &ldquo;Accept &amp;
+        queue&rdquo; for one-click cases).
+      </p>
+
+      <div className="ps-field ps-name-row">
+        <label className="ps-label text-sm" htmlFor="ps-rm-concurrency">
+          Runs at once
+        </label>
+        <select
+          id="ps-rm-concurrency"
+          className="ps-input text-base"
+          value={String(cap)}
+          onChange={(e) => pickCap(Number(e.target.value))}
+        >
+          {CONCURRENCY_CHOICES.map((n) => (
+            <option key={n} value={n}>
+              {n === DEFAULT_MAX_CONCURRENT ? `${n} — one at a time` : n}
+            </option>
+          ))}
+        </select>
+      </div>
+      <p className="ps-section-lead text-sm">
+        More than one queued item builds at a time, each in its own run. They land parallel pull
+        requests into the same repo, so past two or three they start conflicting with each other —
+        and every one of them still needs your review.
+      </p>
+
+      <div className="ps-field ps-name-row">
+        <label className="ps-label text-sm" htmlFor="ps-rm-settle-review">
+          The PM reviews every finished run
+        </label>
+        <Toggle value={settleReview} onChange={toggleSettleReview} />
+      </div>
+      <p className="ps-section-lead text-sm">
+        When a run settles, the PM agent reads the outcome against the item it wrote and records
+        what deviated — as notes on the card and proposals you rule on. On by default; turning it
+        off costs one chat turn per finished run and leaves nobody watching whether the work matched
+        the plan.
+      </p>
+    </section>
+  );
+}

--- a/src/components/ProjectScreen/index.tsx
+++ b/src/components/ProjectScreen/index.tsx
@@ -11,6 +11,7 @@ import { GeneralSection } from "./GeneralSection";
 import { LinearSection } from "./LinearSection";
 import { ProjectHeader } from "./ProjectHeader";
 import { Roadmap, useRoadmap } from "./Roadmap";
+import { RoadmapSection } from "./RoadmapSection";
 import { RunEnvSection } from "./RunEnvSection";
 import { VerifySection } from "./VerifySection";
 
@@ -108,6 +109,7 @@ export function ProjectScreen({ repoPath }: { repoPath: string }) {
                 />
                 <EnvVarsSection projectId={loaded.projectId} repoPath={repoPath} />
                 <LinearSection projectId={loaded.projectId} />
+                <RoadmapSection projectId={loaded.projectId} />
                 <VerifySection projectId={loaded.projectId} />
                 <DeleteSection projectId={loaded.projectId} projectName={name} />
               </>


### PR DESCRIPTION
Control granularity becomes a per-project choice — from rule-on-everything to accept-means-build — and a hold always outranks the dial.

## What
- **Two settings** (project Settings tab gains a Roadmap section, which also finally gives the settle-review setting its toggle): `roadmap.autoqueue` (default off) and `roadmap.max_concurrent` (1–4; the ceiling is review bandwidth, not the machine — parallel PRs into one repo conflict faster than one reviewer can rule).
- **Parallel dispatch:** the drainer claims per tick until the cap or nothing is dispatchable, every claim re-running the full decision under the lock — deps, holds, agent links, project hold all still gate. Bounded by the cap, not run-until-empty, so a failing dispatch can't burn a whole queue in one tick. Cap 1 reproduces today's behavior exactly (pinned).
- **Autoqueue:** accepting a ghost lands it `queued`, decided backend-side in the accept transition so every accept surface inherits it. A held item (or held board) lands `open` instead — holds trump the dial, and the trail says so: one `accepted` event with the detail ("auto-queued" / "left off the queue — this is held"). One user ruling, one history line.
- **"Accept & queue"** when autoqueue is off — the same backend path via an explicit `queue` flag, one implementation. When autoqueue is on, the primary button relabels to say what it now does.
- Cross-language pin test over the three settings keys and both numeric bounds.

## Verification (exit codes, all 0)
cargo 1334 (+12) · vitest 909 (+7) · clippy clean (CI flags) · tsc/biome clean.