### PR TITLE
feat(roadmap): the board tells you what it's building without you looking for it

### DIFF
--- a/src/components/ProjectScreen/Roadmap/Board/index.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/index.tsx
@@ -258,11 +258,13 @@ export function Board({
         />
       )}
 
-      {/* What is moving, right under what is stopped. The pair is the board's
-          status line: the strip above is every decision you owe it, this is
-          everything in flight that owes you nothing. Decisions come first
-          because an item that stopped moving outranks one that hasn't, and the
-          rail renders nothing when the pipeline is idle. */}
+      {/* The pipeline, right under the decisions. The pair is the board's status
+          line: the strip above is every decision you owe it, this is the state of
+          everything the pipeline is holding. They overlap on purpose — a paused or
+          held row is a card up there *and* a line down here, because the two
+          answer different questions: what you have to do about it, and where it
+          sits. Decisions come first because an item that stopped moving outranks
+          one that hasn't, and the rail renders nothing when the pipeline is idle. */}
       {tab === "roadmap" && <InFlightRail entries={inFlight} onFocusItem={focusItem} />}
 
       {/* The whole board is stopped. Below the strip (which already carries a

--- a/src/components/ProjectScreen/Roadmap/Board/index.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/index.tsx
@@ -5,6 +5,8 @@ import { IconButton } from "@/components/ui/IconButton";
 import { getProjectSettings } from "@/storage/projectSettings";
 import { useAppStore } from "@/store";
 import { AUTOQUEUE_KEY, acceptActions, flagOn } from "../autonomy";
+import { InFlightRail } from "../InFlightRail";
+import { buildInFlight } from "../InFlightRail/select";
 import { NeedsYou } from "../NeedsYou";
 import { HORIZONS } from "../types";
 import { reviewGate } from "../useItemReviews";
@@ -113,6 +115,15 @@ export function Board({
   );
   // Drag-to-reorder; the ranks it computes live in rank.ts.
   const dnd = useBoardDnd({ rows: drawn.map((i) => i.item), moveItem, setRanks });
+
+  /** What is in motion right now — the rail above the groups. Derived here rather
+   *  than in `useRoadmap` because it is pure composition of three things this
+   *  component already has in hand, and nothing outside the board reads it. The
+   *  rules live in InFlightRail/select.ts. */
+  const inFlight = useMemo(
+    () => buildInFlight({ items: items.map((i) => i.item), runsById, reviews }),
+    [items, runsById, reviews],
+  );
 
   const [editing, setEditing] = useState<Editing | null>(null);
   /** The row the form is editing, if it isn't creating one. */
@@ -246,6 +257,13 @@ export function Board({
           onReleaseProject={readOnly ? undefined : releaseProject}
         />
       )}
+
+      {/* What is moving, right under what is stopped. The pair is the board's
+          status line: the strip above is every decision you owe it, this is
+          everything in flight that owes you nothing. Decisions come first
+          because an item that stopped moving outranks one that hasn't, and the
+          rail renders nothing when the pipeline is idle. */}
+      {tab === "roadmap" && <InFlightRail entries={inFlight} onFocusItem={focusItem} />}
 
       {/* The whole board is stopped. Below the strip (which already carries a
           card for it, with the same one-click release) because this band is the

--- a/src/components/ProjectScreen/Roadmap/InFlightRail/index.tsx
+++ b/src/components/ProjectScreen/Roadmap/InFlightRail/index.tsx
@@ -1,0 +1,88 @@
+// InFlightRail — the board's pulse: one line per item actually in motion, above
+// the horizon groups and beside the "Needs you" strip. `active` rows say which
+// run is building them and for how long; `in_review` rows say what their PR is
+// waiting on. Level-1 answer to "what is happening right now", which the board
+// otherwise only tells you by scrolling three groups looking for pearls.
+//
+// The two strips are complements, which is why they sit together and look
+// different: NeedsYou is warn-toned and every card is a decision you owe it;
+// this is neutral and carries no decision at all — every entry's one gesture is
+// the jump to its card. Nothing in flight means nothing to say, so an empty rail
+// renders nothing rather than a "nothing is running" placeholder above every
+// resting board.
+//
+// The derivation is a pure selector (select.ts). All this file adds is the clock:
+// the elapsed span has to re-render on its own, and a selector that read the
+// time would be untestable.
+
+import { Icon } from "@/components/Icon";
+import { formatAge } from "@/util/format";
+import { useMinuteClock } from "@/util/hooks";
+import type { RailEntry } from "./select";
+
+/** What the strip is looking at, in the counts' own words. Both halves are named
+ *  because they mean different things to the reader: one is spending tokens, the
+ *  other is waiting on GitHub. */
+function hint(entries: readonly RailEntry[]): string {
+  const building = entries.filter((e) => e.kind === "active").length;
+  const shipping = entries.length - building;
+  const parts: string[] = [];
+  if (building) parts.push(`${building} being built`);
+  if (shipping) parts.push(`${shipping} waiting to ship`);
+  return `${parts.join(", ")}.`;
+}
+
+export function InFlightRail({
+  entries,
+  onFocusItem,
+}: {
+  entries: readonly RailEntry[];
+  /** Jump the board to an item by code — the hook's `focusItem`, the same path
+   *  the decision strip and the chat's code chips take. */
+  onFocusItem: (code: string) => void;
+}) {
+  const now = useMinuteClock();
+
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="rm-rail">
+      <div className="rm-rail-h flex-center text-xs">
+        <span className="rm-rail-n iflex-center mono">
+          <Icon name="activity" size={11} />
+          In flight
+        </span>
+        <span className="rm-rail-hint truncate">{hint(entries)}</span>
+      </div>
+      {entries.map((e) => (
+        <button
+          key={e.id}
+          type="button"
+          className="rm-rail-e flex-center"
+          onClick={() => onFocusItem(e.code)}
+          title="Show this item on the board"
+        >
+          {/* The same pearl the card's live chip uses for a running row, and the
+              PR glyph for one in review — the rail's two halves are told apart at
+              a glance, before any word is read. */}
+          {e.kind === "active" ? (
+            <span className="rm-pearl" />
+          ) : (
+            <Icon name="pr" size={11} className="rm-rail-glyph" />
+          )}
+          <span className="rm-code mono text-xs">{e.code}</span>
+          <span className="rm-rail-title truncate">{e.title}</span>
+          <span className={`rm-rail-s tone-${e.tone}`}>{e.state}</span>
+          {/* How long its run has been at it. Absent for a row the drainer has
+              claimed but whose run hasn't been recorded yet, and for everything
+              in review — a PR's age is not this board's clock. */}
+          {e.startedAt != null && (
+            <span className="rm-rail-age mono" title="Elapsed since its run started">
+              {formatAge(e.startedAt, now)}
+            </span>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/ProjectScreen/Roadmap/InFlightRail/index.tsx
+++ b/src/components/ProjectScreen/Roadmap/InFlightRail/index.tsx
@@ -20,14 +20,19 @@ import { formatAge } from "@/util/format";
 import { useMinuteClock } from "@/util/hooks";
 import type { RailEntry } from "./select";
 
-/** What the strip is looking at, in the counts' own words. Both halves are named
- *  because they mean different things to the reader: one is spending tokens, the
- *  other is waiting on GitHub. */
+/** What the strip is looking at, in the counts' own words. Three buckets because
+ *  they mean three different things to the reader: one is spending tokens, one is
+ *  waiting on GitHub, and one is a row in the build lane that has stopped — paused,
+ *  held, or a run that ended without the board catching up. Counting that last
+ *  group as "being built" is a claim about work nobody is doing, so it gets its own
+ *  word. */
 function hint(entries: readonly RailEntry[]): string {
-  const building = entries.filter((e) => e.kind === "active").length;
-  const shipping = entries.length - building;
+  const building = entries.filter((e) => e.building).length;
+  const stopped = entries.filter((e) => e.kind === "active" && !e.building).length;
+  const shipping = entries.filter((e) => e.kind === "in_review").length;
   const parts: string[] = [];
   if (building) parts.push(`${building} being built`);
+  if (stopped) parts.push(`${stopped} not moving`);
   if (shipping) parts.push(`${shipping} waiting to ship`);
   return `${parts.join(", ")}.`;
 }
@@ -50,7 +55,10 @@ export function InFlightRail({
       <div className="rm-rail-h flex-center text-xs">
         <span className="rm-rail-n iflex-center mono">
           <Icon name="activity" size={11} />
-          In flight
+          {/* Not "In flight": that is the `now` horizon's label (Roadmap/types.ts)
+              and this strip's membership is a different set — a `now` item that
+              hasn't started is in that horizon and not on this strip. */}
+          In motion
         </span>
         <span className="rm-rail-hint truncate">{hint(entries)}</span>
       </div>

--- a/src/components/ProjectScreen/Roadmap/InFlightRail/select.test.ts
+++ b/src/components/ProjectScreen/Roadmap/InFlightRail/select.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest";
+import type { ItemStatus, PrChecks, RoadmapItem, RoadmapItemReview, WfRun } from "@/api";
+import { buildInFlight } from "./select";
+
+// ── fixtures ──────────────────────────────────────────────────────────────────
+
+function item(over: Partial<RoadmapItem> & { id: string }): RoadmapItem {
+  return {
+    project_id: "p1",
+    code: `MCA-${over.id}`,
+    parent_id: null,
+    title: `Item ${over.id}`,
+    why: "",
+    horizon: "now",
+    status: "active",
+    rank: 1,
+    area: null,
+    source: "user",
+    accept: [],
+    deps: [],
+    agent_id: null,
+    workflow_def_id: null,
+    run_id: null,
+    pr_url: null,
+    pr_number: null,
+    hold_reason: null,
+    held_by: null,
+    held_at: null,
+    created_at: 0,
+    updated_at: 0,
+    ...over,
+  };
+}
+
+function run(over: Partial<WfRun> & { id: string }): WfRun {
+  return {
+    definition_id: null,
+    parent_run_id: null,
+    name: `run-${over.id}`,
+    spec: null,
+    task: "",
+    project_id: "p1",
+    repo_path: "/repo",
+    run_dir: "/runs/x",
+    branch: "wf/x",
+    base_sha: "abc",
+    status: "running",
+    paused_reason: null,
+    cursor: null,
+    budgets: null,
+    spent: null,
+    error: null,
+    pr_number: null,
+    pr_url: null,
+    roadmap_item_id: null,
+    created_at: 1_000,
+    updated_at: 2_000,
+    ...over,
+  };
+}
+
+function checks(over: Partial<PrChecks> = {}): PrChecks {
+  return {
+    merge_state: "clean",
+    rollup: "passing",
+    total: 1,
+    passed: 1,
+    failed: 0,
+    pending: 0,
+    required_failing: [],
+    runs: [],
+    ...over,
+  };
+}
+
+function review(over: Partial<RoadmapItemReview> = {}): RoadmapItemReview {
+  return { checks: checks(), comments: null, head_ref: null, base_ref: null, ...over };
+}
+
+type Input = Parameters<typeof buildInFlight>[0];
+
+function input(over: Partial<Input> = {}): Input {
+  return {
+    items: [],
+    runsById: new Map<string, WfRun>(),
+    reviews: new Map<string, RoadmapItemReview>(),
+    ...over,
+  };
+}
+
+/** The one-item board every case below is a variation of. */
+function railOf(row: RoadmapItem, over: Partial<Input> = {}) {
+  return buildInFlight(input({ items: [row], ...over }));
+}
+
+// ── what is being built ───────────────────────────────────────────────────────
+
+describe("buildInFlight — active rows", () => {
+  it("reports a running run, with the run and its start time for the clock", () => {
+    const rail = railOf(item({ id: "a", run_id: "r", title: "Ship the drainer" }), {
+      runsById: new Map([["r", run({ id: "r", status: "running", created_at: 5_000 })]]),
+    });
+    expect(rail).toEqual([
+      {
+        id: "a",
+        kind: "active",
+        code: "MCA-a",
+        title: "Ship the drainer",
+        state: "running",
+        tone: "info",
+        runId: "r",
+        startedAt: 5_000,
+      },
+    ]);
+  });
+
+  it("names a pause in the same words the item card's chip uses", () => {
+    const rail = railOf(item({ id: "a", run_id: "r" }), {
+      runsById: new Map([["r", run({ id: "r", status: "paused", paused_reason: "approval" })]]),
+    });
+    expect(rail[0]).toMatchObject({ state: "paused — needs approval", tone: "warn" });
+  });
+
+  it("still lists a row the drainer claimed before its run existed", () => {
+    // The queue flips the status a beat before the run row lands, and a row with
+    // no run resolved is exactly the one worth seeing on the rail.
+    const rail = railOf(item({ id: "a", run_id: null }));
+    expect(rail[0]).toMatchObject({ state: "running", runId: undefined, startedAt: undefined });
+  });
+
+  it("says nothing about a run this project doesn't own", () => {
+    // `runsById` is already project-scoped; a miss must read as "no run state",
+    // never as another board's.
+    const rail = railOf(item({ id: "a", run_id: "elsewhere" }));
+    expect(rail[0]).toMatchObject({ state: "running", tone: "info" });
+  });
+});
+
+// ── what is waiting to ship ───────────────────────────────────────────────────
+
+describe("buildInFlight — in-review rows", () => {
+  const gates: { merge_state: PrChecks["merge_state"]; state: string; tone: string }[] = [
+    { merge_state: "clean", state: "ready to merge", tone: "ready" },
+    { merge_state: "unstable", state: "optional checks failing", tone: "warn" },
+    { merge_state: "dirty", state: "conflicts with main", tone: "attention" },
+    { merge_state: "behind", state: "behind main", tone: "attention" },
+    { merge_state: "draft", state: "draft", tone: "info" },
+    { merge_state: "unknown", state: "checking…", tone: "info" },
+  ];
+
+  for (const { merge_state, state, tone } of gates) {
+    it(`${merge_state} → "${state}"`, () => {
+      const rail = railOf(item({ id: "a", status: "in_review", pr_number: 7 }), {
+        reviews: new Map([["a", review({ checks: checks({ merge_state }), base_ref: "main" })]]),
+      });
+      expect(rail[0]).toMatchObject({ kind: "in_review", state, tone });
+    });
+  }
+
+  it("splits a blocked gate the way the shared classifier does", () => {
+    // Failing *required* checks are agent-fixable; a pure review gate is not.
+    const failing = railOf(item({ id: "a", status: "in_review" }), {
+      reviews: new Map([
+        ["a", review({ checks: checks({ merge_state: "blocked", required_failing: ["test"] }) })],
+      ]),
+    });
+    expect(failing[0]).toMatchObject({ state: "checks failing", tone: "attention" });
+
+    const gated = railOf(item({ id: "a", status: "in_review" }), {
+      reviews: new Map([["a", review({ checks: checks({ merge_state: "blocked", failed: 3 }) })]]),
+    });
+    expect(gated[0]).toMatchObject({ state: "review required", tone: "attention" });
+  });
+
+  it("reads a missing answer as plain 'in review', never as a clean gate", () => {
+    const rail = railOf(item({ id: "a", status: "in_review", pr_number: 7 }));
+    expect(rail[0]).toMatchObject({ state: "in review", tone: "info" });
+  });
+
+  it("carries no run or clock — a PR's age is not this board's", () => {
+    const rail = railOf(item({ id: "a", status: "in_review", run_id: "r" }), {
+      runsById: new Map([["r", run({ id: "r" })]]),
+    });
+    expect(rail[0]).not.toHaveProperty("runId");
+    expect(rail[0]).not.toHaveProperty("startedAt");
+  });
+});
+
+// ── what the rail is not about ────────────────────────────────────────────────
+
+describe("buildInFlight — scope", () => {
+  it("ignores every status that isn't in motion", () => {
+    const resting: ItemStatus[] = ["proposed", "open", "queued", "done"];
+    expect(
+      buildInFlight(input({ items: resting.map((status, i) => item({ id: `${i}`, status })) })),
+    ).toEqual([]);
+  });
+
+  it("renders nothing for an empty board", () => {
+    expect(buildInFlight(input())).toEqual([]);
+  });
+
+  it("puts what is building above what is shipping, each in board order", () => {
+    const rail = buildInFlight(
+      input({
+        items: [
+          item({ id: "r2", status: "in_review", rank: 40 }),
+          item({ id: "a2", status: "active", rank: 30 }),
+          item({ id: "r1", status: "in_review", rank: 20 }),
+          item({ id: "a1", status: "active", rank: 10 }),
+        ],
+      }),
+    );
+    expect(rail.map((e) => e.id)).toEqual(["a1", "a2", "r1", "r2"]);
+  });
+
+  it("breaks a rank tie on the code, so the order never flickers", () => {
+    const rail = buildInFlight(
+      input({
+        items: [
+          item({ id: "b", code: "MCA-9", rank: 10 }),
+          item({ id: "a", code: "MCA-2", rank: 10 }),
+        ],
+      }),
+    );
+    expect(rail.map((e) => e.code)).toEqual(["MCA-2", "MCA-9"]);
+  });
+});

--- a/src/components/ProjectScreen/Roadmap/InFlightRail/select.test.ts
+++ b/src/components/ProjectScreen/Roadmap/InFlightRail/select.test.ts
@@ -108,6 +108,7 @@ describe("buildInFlight — active rows", () => {
         title: "Ship the drainer",
         state: "running",
         tone: "info",
+        building: true,
         runId: "r",
         startedAt: 5_000,
       },
@@ -118,7 +119,66 @@ describe("buildInFlight — active rows", () => {
     const rail = railOf(item({ id: "a", run_id: "r" }), {
       runsById: new Map([["r", run({ id: "r", status: "paused", paused_reason: "approval" })]]),
     });
-    expect(rail[0]).toMatchObject({ state: "paused — needs approval", tone: "warn" });
+    expect(rail[0]).toMatchObject({
+      state: "paused — needs approval",
+      tone: "warn",
+      building: false,
+    });
+  });
+
+  it("calls a pause with no recorded reason a pause, not motion", () => {
+    // The reason is what names the pause; without one there is still nothing
+    // happening, and the old guard let this row through as "running".
+    const rail = railOf(item({ id: "a", run_id: "r" }), {
+      runsById: new Map([["r", run({ id: "r", status: "paused", paused_reason: null })]]),
+    });
+    expect(rail[0]).toMatchObject({ state: "paused", tone: "warn", building: false });
+    // Keeps its clock: that elapsed time is what the pause is costing.
+    expect(rail[0].startedAt).toBe(1_000);
+  });
+
+  it("says a run failed rather than showing it as still running", () => {
+    // `runsById` carries terminal rows (`wf_list_runs` filters nothing) and the
+    // drainer settles the item a tick later — or never, if that write fails.
+    const rail = railOf(item({ id: "a", run_id: "r" }), {
+      runsById: new Map([["r", run({ id: "r", status: "failed" })]]),
+    });
+    expect(rail[0]).toMatchObject({ state: "run failed", tone: "attention", building: false });
+    expect(rail[0].startedAt).toBeUndefined();
+  });
+
+  it("says a run was canceled rather than showing it as still running", () => {
+    const rail = railOf(item({ id: "a", run_id: "r" }), {
+      runsById: new Map([["r", run({ id: "r", status: "canceled" })]]),
+    });
+    expect(rail[0]).toMatchObject({ state: "run canceled", tone: "warn", building: false });
+    expect(rail[0].startedAt).toBeUndefined();
+  });
+
+  it("reads an ended run as finishing, with no clock left to run", () => {
+    const rail = railOf(item({ id: "a", run_id: "r" }), {
+      runsById: new Map([["r", run({ id: "r", status: "done", created_at: 5_000 })]]),
+    });
+    expect(rail[0]).toMatchObject({ state: "finishing", tone: "info", building: false });
+    // A span that keeps counting on a run that ended is time nothing is spending.
+    expect(rail[0].startedAt).toBeUndefined();
+  });
+
+  it("reads a run that hasn't begun as starting, and still counts it as motion", () => {
+    const rail = railOf(item({ id: "a", run_id: "r" }), {
+      runsById: new Map([["r", run({ id: "r", status: "pending" })]]),
+    });
+    expect(rail[0]).toMatchObject({ state: "starting", tone: "info", building: true });
+    expect(rail[0].startedAt).toBe(1_000);
+  });
+
+  it("lets a hold outrank a live run — a held row is not being built", () => {
+    // The Needs-you strip above carries the release; the rail only has to stop
+    // claiming the row is moving.
+    const rail = railOf(item({ id: "a", run_id: "r", hold_reason: "waiting on me" }), {
+      runsById: new Map([["r", run({ id: "r", status: "running" })]]),
+    });
+    expect(rail[0]).toMatchObject({ state: "held", tone: "attention", building: false });
   });
 
   it("still lists a row the drainer claimed before its run existed", () => {
@@ -128,11 +188,11 @@ describe("buildInFlight — active rows", () => {
     expect(rail[0]).toMatchObject({ state: "running", runId: undefined, startedAt: undefined });
   });
 
-  it("says nothing about a run this project doesn't own", () => {
+  it("falls back to plain 'running' when the run id resolves to nothing", () => {
     // `runsById` is already project-scoped; a miss must read as "no run state",
     // never as another board's.
     const rail = railOf(item({ id: "a", run_id: "elsewhere" }));
-    expect(rail[0]).toMatchObject({ state: "running", tone: "info" });
+    expect(rail[0]).toMatchObject({ state: "running", tone: "info", building: true });
   });
 });
 
@@ -174,7 +234,21 @@ describe("buildInFlight — in-review rows", () => {
 
   it("reads a missing answer as plain 'in review', never as a clean gate", () => {
     const rail = railOf(item({ id: "a", status: "in_review", pr_number: 7 }));
-    expect(rail[0]).toMatchObject({ state: "in review", tone: "info" });
+    expect(rail[0]).toMatchObject({ state: "in review", tone: "info", building: false });
+  });
+
+  it("says a PR with no number can't be watched, the way its card does", () => {
+    // A URL with no number is what `merge_sweep::pollable` skips, so no gate ever
+    // arrives: "in review" here would be a wait that never ends.
+    const rail = railOf(
+      item({
+        id: "a",
+        status: "in_review",
+        pr_url: "https://github.com/o/r/pull/5",
+        pr_number: null,
+      }),
+    );
+    expect(rail[0]).toMatchObject({ state: "can't watch this PR", tone: "warn" });
   });
 
   it("carries no run or clock — a PR's age is not this board's", () => {

--- a/src/components/ProjectScreen/Roadmap/InFlightRail/select.ts
+++ b/src/components/ProjectScreen/Roadmap/InFlightRail/select.ts
@@ -21,9 +21,10 @@ import type { MergeGateTone } from "@/mergeGate";
 import { pausedLabel } from "@/workflows/run/status";
 import { reviewGate } from "../useItemReviews";
 
-/** Which half of the pipeline an entry is in. `active` is being built, `in_review`
- *  is built and waiting on its PR — the two statuses the user did not put the item
- *  in and cannot move by hand. */
+/** Which half of the pipeline an entry is in. `active` is in the build lane (not
+ *  necessarily moving — see `building`), `in_review` is built and waiting on its
+ *  PR — the two statuses the user did not put the item in and cannot move by
+ *  hand. */
 export type RailKind = "active" | "in_review";
 
 export interface RailEntry {
@@ -39,6 +40,10 @@ export interface RailEntry {
   /** Severity for the state chip, the shared `MergeGateTone` so an `in_review`
    *  entry and its card's gate chip cannot read differently. */
   tone: MergeGateTone;
+  /** Whether tokens are actually being spent on this row right now. Only an
+   *  `active` row with a live run is; a hold, a pause or a run that already ended
+   *  is not, and the strip's count must not add it to "being built". */
+  building: boolean;
   /** The run building an `active` row, when one is recorded — the drainer flips
    *  the status a beat before the run exists, so this can be absent on a row
    *  that is legitimately active. */
@@ -63,14 +68,70 @@ export interface RailInput {
   reviews: ReadonlyMap<string, RoadmapItemReview>;
 }
 
-/** What an `active` row's run is doing. Paused outranks everything: the pearl is
- *  still pulsing and nothing is happening, which is the one thing this rail must
- *  not let pass as motion. */
-function activeState(run: WfRun | undefined): { state: string; tone: MergeGateTone } {
-  if (run?.status === "paused" && run.paused_reason) {
-    return { state: `paused — ${pausedLabel(run.paused_reason)}`, tone: "warn" };
+/** A run row that has stopped for good. These linger in `runsById` — `wf_list_runs`
+ *  filters nothing and the drainer settles the item it belongs to on a 15s tick (or
+ *  never, if that write fails) — so the rail meets them routinely and must not read
+ *  them as motion. */
+function isOver(run: WfRun | undefined): boolean {
+  return run?.status === "done" || run?.status === "failed" || run?.status === "canceled";
+}
+
+/** What an `active` row is doing.
+ *
+ *  A hold outranks the run: the row was stopped by hand, and whatever its run says
+ *  the item is not going anywhere until it is released (the Needs-you strip above
+ *  carries that affordance; this strip only has to stop claiming motion).
+ *
+ *  Then the run's own status, every branch of it. Collapsing "not paused" to
+ *  "running" is how a failed run kept a live clock on this strip for a tick — or
+ *  forever. `paused` is unconditional: a pause with no recorded reason is still a
+ *  pause, not motion. */
+function activeState(
+  item: RoadmapItem,
+  run: WfRun | undefined,
+): { state: string; tone: MergeGateTone; building: boolean } {
+  if (item.hold_reason) return { state: "held", tone: "attention", building: false };
+  switch (run?.status) {
+    case "paused":
+      return {
+        state: run.paused_reason ? `paused — ${pausedLabel(run.paused_reason)}` : "paused",
+        tone: "warn",
+        building: false,
+      };
+    case "failed":
+      return { state: "run failed", tone: "attention", building: false };
+    case "canceled":
+      return { state: "run canceled", tone: "warn", building: false };
+    // The run is over and the item hasn't caught up yet: the drainer moves it to
+    // review (or done) on its next tick. "complete" is the run's word for this and
+    // would read as a shipped item on a board row, so say what the *item* is doing.
+    case "done":
+      return { state: "finishing", tone: "info", building: false };
+    case "pending":
+      return { state: "starting", tone: "info", building: true };
+    // `running`, and the row whose run isn't in hand yet — the drainer flips the
+    // status a beat before the run exists, and a lookup miss says nothing either
+    // way. Both are the board's claim that this is being built, unrefuted.
+    default:
+      return { state: "running", tone: "info", building: true };
   }
-  return { state: "running", tone: "info" };
+}
+
+/** What an `in_review` row is doing: its PR's merge gate, in the gate's own words.
+ *
+ *  Except when there is nothing to watch — a URL with no number is exactly what
+ *  `merge_sweep::pollable` skips, so no gate will ever arrive and a bland "in
+ *  review" would sit there forever. The card says the same thing (and offers "Mark
+ *  done"); the rail must not look calmer than the card. */
+function reviewState(
+  item: RoadmapItem,
+  review: RoadmapItemReview | undefined,
+): { state: string; tone: MergeGateTone } {
+  if (item.pr_url && item.pr_number == null) {
+    return { state: "can't watch this PR", tone: "warn" };
+  }
+  const gate = review ? reviewGate(review) : null;
+  return { state: gate?.label ?? "in review", tone: gate?.tone ?? "info" };
 }
 
 /** Compose the rail from the board's current state. Board order (rank) within
@@ -89,14 +150,16 @@ export function buildInFlight(input: RailInput): RailEntry[] {
           kind: "active",
           code: item.code,
           title: item.title,
-          ...activeState(run),
+          ...activeState(item, run),
           runId: run?.id,
-          startedAt: run?.created_at,
+          // No clock on a run that has stopped: a span that keeps counting is the
+          // strip asserting work is happening, which is the lie this rail exists to
+          // avoid. A held or paused row keeps it — that elapsed time is the cost of
+          // the decision the user hasn't made.
+          startedAt: isOver(run) ? undefined : run?.created_at,
         },
       });
     } else if (item.status === "in_review") {
-      const review = input.reviews.get(item.id);
-      const gate = review ? reviewGate(review) : null;
       entries.push({
         rank: item.rank,
         entry: {
@@ -104,8 +167,8 @@ export function buildInFlight(input: RailInput): RailEntry[] {
           kind: "in_review",
           code: item.code,
           title: item.title,
-          state: gate?.label ?? "in review",
-          tone: gate?.tone ?? "info",
+          building: false,
+          ...reviewState(item, input.reviews.get(item.id)),
         },
       });
     }

--- a/src/components/ProjectScreen/Roadmap/InFlightRail/select.ts
+++ b/src/components/ProjectScreen/Roadmap/InFlightRail/select.ts
@@ -1,0 +1,121 @@
+// InFlightRail/select.ts — the board's pulse, derived. A pure function that
+// joins state the board already holds (its rows, the runs behind them, the
+// review poll's answers) into one ordered list of what is moving right now. No
+// store, no IPC, no React, and no clock — so the join, the ordering and the
+// wording are unit-testable in isolation (select.test.ts) and the rail is a thin
+// renderer over this.
+//
+// Modelled on NeedsYou/select.ts, its sibling strip, and deliberately narrower:
+// that one answers "what is stopped and yours to unstick", this one answers "what
+// is in motion". Nothing here is a decision, so there is no bucket ordering and
+// no action per entry beyond the jump every entry shares.
+//
+// Every word an entry says is borrowed, never restated: a pause is named by
+// `pausedLabel` (the item card's chip and the sidebar badge use the same one) and
+// a PR's gate by `mergeGate.ts` through `reviewGate`. A rail that called
+// "review required" something else would be the drift those modules exist to
+// prevent.
+
+import type { RoadmapItem, RoadmapItemReview, WfRun } from "@/api";
+import type { MergeGateTone } from "@/mergeGate";
+import { pausedLabel } from "@/workflows/run/status";
+import { reviewGate } from "../useItemReviews";
+
+/** Which half of the pipeline an entry is in. `active` is being built, `in_review`
+ *  is built and waiting on its PR — the two statuses the user did not put the item
+ *  in and cannot move by hand. */
+export type RailKind = "active" | "in_review";
+
+export interface RailEntry {
+  /** The item id: one entry per in-flight row, so this is also the render key. */
+  id: string;
+  kind: RailKind;
+  code: string;
+  title: string;
+  /** What it is doing, in the vocabulary its own card already uses — a run's
+   *  pause, a PR's merge gate, or the plain word when there is nothing more
+   *  specific to say yet. */
+  state: string;
+  /** Severity for the state chip, the shared `MergeGateTone` so an `in_review`
+   *  entry and its card's gate chip cannot read differently. */
+  tone: MergeGateTone;
+  /** The run building an `active` row, when one is recorded — the drainer flips
+   *  the status a beat before the run exists, so this can be absent on a row
+   *  that is legitimately active. */
+  runId?: string;
+  /** When that run started (ms epoch). The elapsed span is rendered from a clock
+   *  in the component: a selector that read `Date.now()` would be untestable and
+   *  would re-derive on every tick. */
+  startedAt?: number;
+}
+
+export interface RailInput {
+  /** The rows the board renders. A shipped item has left the board and is not in
+   *  flight; everything before `active` hasn't started. */
+  items: readonly RoadmapItem[];
+  /** This project's runs by id — `useRoadmap.runsById`, which is already scoped
+   *  to the project, so a run id that doesn't resolve here simply yields no run
+   *  state rather than another board's. */
+  runsById: ReadonlyMap<string, WfRun>;
+  /** The review poll's answers by item id (`useRoadmap.reviews`). An item absent
+   *  from it has no answer yet, which reads as "in review" — never as a clean
+   *  gate. */
+  reviews: ReadonlyMap<string, RoadmapItemReview>;
+}
+
+/** What an `active` row's run is doing. Paused outranks everything: the pearl is
+ *  still pulsing and nothing is happening, which is the one thing this rail must
+ *  not let pass as motion. */
+function activeState(run: WfRun | undefined): { state: string; tone: MergeGateTone } {
+  if (run?.status === "paused" && run.paused_reason) {
+    return { state: `paused — ${pausedLabel(run.paused_reason)}`, tone: "warn" };
+  }
+  return { state: "running", tone: "info" };
+}
+
+/** Compose the rail from the board's current state. Board order (rank) within
+ *  each half, `active` first: what is being built now sits above what is waiting
+ *  to ship, which is the direction the pipeline runs. */
+export function buildInFlight(input: RailInput): RailEntry[] {
+  const entries: { entry: RailEntry; rank: number }[] = [];
+
+  for (const item of input.items) {
+    if (item.status === "active") {
+      const run = item.run_id ? input.runsById.get(item.run_id) : undefined;
+      entries.push({
+        rank: item.rank,
+        entry: {
+          id: item.id,
+          kind: "active",
+          code: item.code,
+          title: item.title,
+          ...activeState(run),
+          runId: run?.id,
+          startedAt: run?.created_at,
+        },
+      });
+    } else if (item.status === "in_review") {
+      const review = input.reviews.get(item.id);
+      const gate = review ? reviewGate(review) : null;
+      entries.push({
+        rank: item.rank,
+        entry: {
+          id: item.id,
+          kind: "in_review",
+          code: item.code,
+          title: item.title,
+          state: gate?.label ?? "in review",
+          tone: gate?.tone ?? "info",
+        },
+      });
+    }
+  }
+
+  entries.sort(
+    (a, b) =>
+      (a.entry.kind === b.entry.kind ? 0 : a.entry.kind === "active" ? -1 : 1) ||
+      a.rank - b.rank ||
+      (a.entry.code < b.entry.code ? -1 : a.entry.code > b.entry.code ? 1 : 0),
+  );
+  return entries.map((e) => e.entry);
+}

--- a/src/components/ProjectScreen/Roadmap/Roadmap.css
+++ b/src/components/ProjectScreen/Roadmap/Roadmap.css
@@ -692,6 +692,108 @@
   margin-top: 4px;
 }
 
+/* ── the "In flight" rail ──
+   What the pipeline is doing, directly under what it needs. Same band grammar as
+   the "Needs you" strip above it (a flat row per item, the header's mono label,
+   the gutter alignment) but read as neutral: nothing here is a demand, so the
+   ground is the plain surface tint and the only colour is the state chip. That
+   contrast is the point — the two strips sit together and must not look like the
+   same kind of thing. */
+.rm-rail {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--bd-soft);
+}
+.rm-rail-h {
+  gap: 10px;
+  padding: 7px 10px 4px var(--rm-gut);
+}
+.rm-rail-n {
+  gap: 5px;
+  font-weight: 600;
+  color: var(--fg-2);
+}
+.rm-rail-hint {
+  min-width: 0;
+  color: var(--fg-3);
+}
+/* One in-flight item. A button, because its one gesture is the jump to its card
+   — the same navigation the decision strip's item gives. */
+.rm-rail-e {
+  gap: 8px;
+  min-height: 24px;
+  padding: 2px 10px 2px var(--rm-gut);
+  font-size: 11.5px;
+  color: var(--fg-1);
+  text-align: left;
+  transition: var(--transition-ui);
+}
+.rm-rail-e:last-child {
+  margin-bottom: 6px;
+}
+.rm-rail-e:hover {
+  background: var(--hover);
+}
+.rm-rail-glyph {
+  flex-shrink: 0;
+  color: var(--info);
+}
+/* Takes the slack, the way the card's own title does — so the state chip and the
+   clock sit hard against the right edge without a spacer element. */
+.rm-rail-title {
+  flex: 1;
+  min-width: 0;
+}
+.rm-rail-e:hover .rm-rail-title {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+/* The state chip, drawn exactly like the card's gate chip — `tone-*` is the
+   shared `MergeGateTone` (see mergeGate.ts), so an unknown tone renders untinted
+   rather than wrong. */
+.rm-rail-s {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  gap: 4px;
+  height: 18px;
+  padding: 0 8px;
+  line-height: var(--lh-none);
+  white-space: nowrap;
+  font-weight: 500;
+  border-radius: 999px;
+  color: var(--fg-2);
+  background: var(--bg-2);
+}
+.rm-rail-s.tone-ready {
+  color: var(--success);
+  background: color-mix(in oklch, var(--success), transparent 88%);
+}
+.rm-rail-s.tone-warn {
+  color: var(--warn);
+  background: color-mix(in oklch, var(--warn), transparent 88%);
+}
+.rm-rail-s.tone-attention {
+  color: var(--att);
+  background: color-mix(in oklch, var(--att), transparent 88%);
+}
+.rm-rail-s.tone-info {
+  color: var(--info);
+  background: color-mix(in oklch, var(--info), transparent 88%);
+}
+/* How long the run has been at it. Tabular, so a column of them doesn't jitter
+   as the minute clock ticks. */
+.rm-rail-age {
+  flex-shrink: 0;
+  min-width: 26px;
+  text-align: right;
+  color: var(--fg-3);
+  font-variant-numeric: tabular-nums;
+}
+
 /* ── the project hold banner ──
    The whole board is stopped. The strip's grammar (warn ground, one accent line,
    an action on the right) rather than the proposal bars' accent: a hold is


### PR DESCRIPTION
Tier C, slice C1 of the roadmap/PM plan: the in-flight rail.

## What
A thin strip directly under the "Needs you" strip showing the board's pulse:

- **`active` items** — code, title, the run's state (`running`, or `paused — <reason>` via the shared `pausedLabel`), and elapsed time since the run started.
- **`in_review` items** — code, title, and the PR's merge-gate state in the exact vocabulary the item card already uses (`ready to merge` / `checks failing` / `review required` / `conflicts with main` / `behind main` / `draft` / `checking…`).

The two strips are complements by design: Needs-you is warn-toned and every card is a decision you owe the board; the rail is neutral and every entry owes you nothing. An idle pipeline renders nothing at all. Clicking an entry focuses its card (the existing `focusItem` path).

## How
Pure UI composition — no backend, no new polling, no new data layer. `InFlightRail/select.ts` is a pure selector over three things the Board already holds (`items`, `runsById`, `reviews`), with 17 test cases covering every gate tone, the paused/running split, the claimed-before-run-row race, and status exclusions. `in_review` entries deliberately carry no clock: the run's start time is the build's clock, not the PR's, and showing it would misread.

## Verification
- `bun run check` / `bun run lint` / `bun run test` (927 = 910 + 17 new) — all exit 0
- `cargo test` (1344) / CI clippy line — exit 0
- Also verified merged together with #606/#607 (sibling Tier C slices): 941 frontend tests, cargo 1350, clippy clean.

Part of the Tier C batch (independent of the other two PRs; any merge order works).