### PR TITLE
feat(roadmap): an issue you didn't file still lands where you rule on it

### DIFF
--- a/src/components/ProjectScreen/Roadmap/Roadmap.css
+++ b/src/components/ProjectScreen/Roadmap/Roadmap.css
@@ -1088,6 +1088,14 @@
 .rm-src.src-pm {
   color: var(--accent);
 }
+/* Tracker-routed rows (the issue funnel): distinct from both the user's quiet
+   neutral and the PM's accent, so provenance reads at a glance. */
+.rm-src.src-github {
+  color: var(--fg-2);
+}
+.rm-src.src-linear {
+  color: var(--info);
+}
 .rm-chev {
   flex-shrink: 0;
   color: var(--fg-3);

--- a/src/components/Workspace/MissionControl/IssueInbox.tsx
+++ b/src/components/Workspace/MissionControl/IssueInbox.tsx
@@ -1,8 +1,10 @@
 // MissionControl/IssueInbox.tsx — the Home issue inbox: a quiet section below
 // the review queue listing open issues for the workspace's tracked repos,
 // from every connected tracker (GitHub issues, Linear tickets). "Start work"
-// lands in the new-task composer, fully prefilled. This file is the data/poll
-// shell; row rendering lives in IssueRow, the pure derivation in inbox.ts.
+// lands in the new-task composer, fully prefilled; "Add to roadmap" routes the
+// issue onto the project's board as a ghost to rule on later. This file is the
+// data/poll shell; row rendering lives in IssueRow, the pure derivations in
+// inbox.ts and funnel.ts.
 
 import { useCallback, useMemo, useState } from "react";
 import { api, type TrackerIssue } from "@/api";
@@ -12,6 +14,7 @@ import { useAppStore } from "@/store";
 import { usePoll } from "@/util/hooks";
 import { IssueRow } from "./IssueRow";
 import { deriveInboxRows, type InboxRepo } from "./inbox";
+import { useIssueFunnel } from "./useIssueFunnel";
 
 /** Slow, connection-gated cadence — the inbox is secondary; open issues
  *  change on human timescales, so a modest poll matches the existing
@@ -65,6 +68,39 @@ export function IssueInbox() {
 
   const multiRepo = useMemo(() => new Set(rows.map((r) => r.repoPath)).size > 1, [rows]);
 
+  // Which board an issue's repo routes onto. Undefined is a legitimate answer
+  // (a pinned repo that isn't part of a project yet) and means no roadmap
+  // action at all.
+  const projectIdFor = useCallback(
+    (path: string) => projects.find((r) => r.path === path)?.project_id || undefined,
+    [projects],
+  );
+
+  // Only the boards actually reachable from the listed issues are read.
+  const projectIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const row of rows) {
+      const id = projectIdFor(row.repoPath);
+      if (id) ids.add(id);
+    }
+    return [...ids];
+  }, [rows, projectIdFor]);
+
+  const funnel = useIssueFunnel(projectIds);
+  const [funnelError, setFunnelError] = useState<string | null>(null);
+
+  const addToRoadmap = useCallback(
+    async (projectId: string, issue: TrackerIssue) => {
+      setFunnelError(null);
+      try {
+        await funnel.route(projectId, issue);
+      } catch (e) {
+        setFunnelError(e instanceof Error ? e.message : String(e));
+      }
+    },
+    [funnel],
+  );
+
   // Quiet degradation: no connected tracker, no tracked repos, or no open
   // issues → the section disappears entirely. Never an error, never a parked
   // spinner.
@@ -77,15 +113,23 @@ export function IssueInbox() {
         <span>Open issues</span>
         <span className="mc-inbox-count">{rows.length}</span>
       </div>
+      {funnelError && <div className="mc-inbox-error">{funnelError}</div>}
       <div className="mc-inbox-list">
-        {rows.map((row) => (
-          <IssueRow
-            key={row.key}
-            row={row}
-            showRepo={multiRepo}
-            onStart={() => void startWorkFromIssue(row.repoPath, row.issue)}
-          />
-        ))}
+        {rows.map((row) => {
+          const action = funnel.actionFor(projectIdFor(row.repoPath), row.issue);
+          return (
+            <IssueRow
+              key={row.key}
+              row={row}
+              showRepo={multiRepo}
+              onStart={() => void startWorkFromIssue(row.repoPath, row.issue)}
+              funnel={action}
+              onAddToRoadmap={() => {
+                if (action.kind === "add") void addToRoadmap(action.projectId, row.issue);
+              }}
+            />
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/Workspace/MissionControl/IssueRoadmapAction.tsx
+++ b/src/components/Workspace/MissionControl/IssueRoadmapAction.tsx
@@ -2,8 +2,9 @@ import { Icon } from "@/components/Icon";
 import type { FunnelAction } from "./funnel";
 
 /** The roadmap half of an inbox row's actions. Three states, decided in
- *  funnel.ts: offer the route, say it's already there, or say nothing at all
- *  (the repo belongs to no project, so there is no board to route onto). */
+ *  funnel.ts: offer the route, say it's already there, or say nothing at all —
+ *  no project owns the repo, or its board hasn't answered yet, and an Add
+ *  offered without knowing what's on the board is how duplicates get made. */
 export function IssueRoadmapAction({ action, onAdd }: { action: FunnelAction; onAdd: () => void }) {
   if (action.kind === "none") return null;
   if (action.kind === "routed") {

--- a/src/components/Workspace/MissionControl/IssueRoadmapAction.tsx
+++ b/src/components/Workspace/MissionControl/IssueRoadmapAction.tsx
@@ -1,0 +1,31 @@
+import { Icon } from "@/components/Icon";
+import type { FunnelAction } from "./funnel";
+
+/** The roadmap half of an inbox row's actions. Three states, decided in
+ *  funnel.ts: offer the route, say it's already there, or say nothing at all
+ *  (the repo belongs to no project, so there is no board to route onto). */
+export function IssueRoadmapAction({ action, onAdd }: { action: FunnelAction; onAdd: () => void }) {
+  if (action.kind === "none") return null;
+  if (action.kind === "routed") {
+    return (
+      <button
+        type="button"
+        className="mc-btn mc-inbox-routed"
+        disabled
+        title="Already a roadmap item — rule on it there"
+      >
+        <Icon name="check" size={12} /> On roadmap
+      </button>
+    );
+  }
+  return (
+    <button
+      type="button"
+      className="mc-btn"
+      onClick={onAdd}
+      title="Add as a proposed item you rule on"
+    >
+      <Icon name="map" size={12} /> Add to roadmap
+    </button>
+  );
+}

--- a/src/components/Workspace/MissionControl/IssueRow.tsx
+++ b/src/components/Workspace/MissionControl/IssueRow.tsx
@@ -1,5 +1,7 @@
 import { issueDisplayKey } from "@/api";
 import { Icon } from "@/components/Icon";
+import type { FunnelAction } from "./funnel";
+import { IssueRoadmapAction } from "./IssueRoadmapAction";
 import type { InboxRow } from "./inbox";
 
 /** Compact "updated N ago" hint from a ms-epoch, or "" when unknown. Mirrors
@@ -16,18 +18,23 @@ function updatedAgo(ms: number | undefined): string {
   return new Date(ms).toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
 
-/** One inbox row: issue number + title, quiet label chips, and a "Start work"
- *  button that lands in the composer prefilled. The row is compact and calm —
- *  secondary to the review queue above it. */
+/** One inbox row: issue number + title, quiet label chips, and the two things
+ *  it can become — a working agent now ("Start work", prefilled composer), or a
+ *  ghost row on the project's roadmap to rule on later. The row is compact and
+ *  calm — secondary to the review queue above it. */
 export function IssueRow({
   row,
   showRepo,
   onStart,
+  funnel,
+  onAddToRoadmap,
 }: {
   row: InboxRow;
   /** Show the originating repo (only meaningful when >1 repo has issues). */
   showRepo: boolean;
   onStart: () => void;
+  funnel: FunnelAction;
+  onAddToRoadmap: () => void;
 }) {
   const { issue } = row;
   const ago = updatedAgo(issue.updated_at);
@@ -64,9 +71,12 @@ export function IssueRow({
           {ago && <span className="mc-inbox-hint">{ago}</span>}
         </div>
       </div>
-      <button type="button" className="mc-btn mc-inbox-start" onClick={onStart}>
-        <Icon name="play" size={12} /> Start work
-      </button>
+      <div className="mc-inbox-actions">
+        <IssueRoadmapAction action={funnel} onAdd={onAddToRoadmap} />
+        <button type="button" className="mc-btn mc-inbox-start" onClick={onStart}>
+          <Icon name="play" size={12} /> Start work
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/Workspace/MissionControl/MissionControl.css
+++ b/src/components/Workspace/MissionControl/MissionControl.css
@@ -419,7 +419,29 @@
   font-size: var(--fs-xs);
   color: var(--fg-3);
 }
+.mc-inbox-actions {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
 .mc-inbox-start {
   flex-shrink: 0;
   height: 26px;
+}
+/* Already-routed issue: a statement, not an affordance — no hover, no pointer. */
+.mc-inbox-routed,
+.mc-inbox-routed:hover {
+  color: var(--fg-3);
+  border-color: var(--bd-soft);
+  background: transparent;
+  cursor: default;
+}
+.mc-inbox-error {
+  padding: 6px 10px;
+  border-radius: var(--r-sm);
+  font-size: var(--fs-sm);
+  color: var(--fg-0);
+  background: color-mix(in srgb, var(--danger), var(--bg-0) 85%);
+  border: 1px solid color-mix(in srgb, var(--danger), var(--bg-0) 60%);
 }

--- a/src/components/Workspace/MissionControl/funnel.test.ts
+++ b/src/components/Workspace/MissionControl/funnel.test.ts
@@ -44,6 +44,18 @@ describe("distillIssueBody", () => {
   it("hard-clips a single long word rather than losing everything", () => {
     expect(distillIssueBody("aaaaaaaaaaaaaaaa", 8)).toBe("aaaaaaaa…");
   });
+
+  it("spends the budget on prose, not screenshots, code fences or link urls", () => {
+    const body =
+      "![screenshot](https://user-images.example/a-very-long-signed-url-that-eats-the-budget.png)\n" +
+      "```\nthread 'main' panicked at src/lib.rs:42\n```\n" +
+      "Saving a note [drops the body](https://github.com/o/r/issues/7#issuecomment-1) every time.";
+    expect(distillIssueBody(body)).toBe("Saving a note drops the body every time.");
+  });
+
+  it("is empty for a body that is only markdown noise", () => {
+    expect(distillIssueBody("![shot](https://x/a.png)\n\n```\nlet x = 1;\n```")).toBe("");
+  });
 });
 
 describe("composeIssueWhy", () => {
@@ -127,6 +139,23 @@ describe("funnelAction", () => {
     expect(funnelAction("p1", "https://github.com/o/r/issues/2", routed)).toEqual({
       kind: "add",
       projectId: "p1",
+    });
+  });
+
+  it("offers no action for an issue with no url to dedup on", () => {
+    expect(funnelAction("p1", "", routed)).toEqual({ kind: "none" });
+  });
+
+  // The same origin repo can be pinned in two projects; each board is judged
+  // against its own routed set, so routing in one leaves the other addable.
+  it("scopes the routed decision to the project's own board", () => {
+    const routedByProject: Record<string, Set<string>> = { p1: routed, p2: new Set() };
+    expect(funnelAction("p1", "https://github.com/o/r/issues/1", routedByProject.p1)).toEqual({
+      kind: "routed",
+    });
+    expect(funnelAction("p2", "https://github.com/o/r/issues/1", routedByProject.p2)).toEqual({
+      kind: "add",
+      projectId: "p2",
     });
   });
 });

--- a/src/components/Workspace/MissionControl/funnel.test.ts
+++ b/src/components/Workspace/MissionControl/funnel.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import type { RoadmapItem, TrackerIssue } from "@/api";
+import {
+  composeIssueWhy,
+  distillIssueBody,
+  funnelAction,
+  issueToRoadmapItem,
+  routedIssueUrls,
+} from "./funnel";
+
+function issue(over: Partial<TrackerIssue> = {}): TrackerIssue {
+  return {
+    source: "github",
+    key: "1",
+    title: "An issue",
+    url: "https://github.com/o/r/issues/1",
+    labels: [],
+    ...over,
+  };
+}
+
+function row(why: string): Pick<RoadmapItem, "why"> {
+  return { why };
+}
+
+describe("distillIssueBody", () => {
+  it("collapses whitespace and drops template comments", () => {
+    expect(distillIssueBody("<!-- describe it -->\nLogin  fails\n\non save")).toBe(
+      "Login fails on save",
+    );
+  });
+
+  it("is empty for a missing or blank body", () => {
+    expect(distillIssueBody(undefined)).toBe("");
+    expect(distillIssueBody("  \n\n")).toBe("");
+    expect(distillIssueBody("<!-- only guidance -->")).toBe("");
+  });
+
+  it("clips at a word boundary with an ellipsis", () => {
+    const clipped = distillIssueBody("alpha beta gamma delta", 12);
+    expect(clipped).toBe("alpha beta…");
+  });
+
+  it("hard-clips a single long word rather than losing everything", () => {
+    expect(distillIssueBody("aaaaaaaaaaaaaaaa", 8)).toBe("aaaaaaaa…");
+  });
+});
+
+describe("composeIssueWhy", () => {
+  it("puts the url alone on the first line, body under it", () => {
+    const why = composeIssueWhy(issue({ url: "https://x/42", body: "Steps:\n1. save" }));
+    expect(why).toBe("https://x/42\nSteps: 1. save");
+    expect(why.split("\n")[0]).toBe("https://x/42");
+  });
+
+  it("is just the url when the body is empty", () => {
+    expect(composeIssueWhy(issue({ url: "https://x/42", body: "  " }))).toBe("https://x/42");
+    expect(composeIssueWhy(issue({ url: "https://x/42" }))).toBe("https://x/42");
+  });
+});
+
+describe("issueToRoadmapItem", () => {
+  it("lands a GitHub issue as a proposed ghost with the github source", () => {
+    expect(issueToRoadmapItem(issue({ title: "Crash on save", url: "https://x/1" }))).toEqual({
+      title: "Crash on save",
+      why: "https://x/1",
+      status: "proposed",
+      source: "github",
+    });
+  });
+
+  it("maps a Linear ticket to the linear source", () => {
+    const item = issueToRoadmapItem(
+      issue({ source: "linear", key: "ENG-9", url: "https://linear.app/acme/issue/ENG-9" }),
+    );
+    expect(item.source).toBe("linear");
+    expect(item.status).toBe("proposed");
+  });
+
+  it("leaves horizon and rank to the backend's defaults", () => {
+    const item = issueToRoadmapItem(issue());
+    expect(item.horizon).toBeUndefined();
+    expect(item.accept).toBeUndefined();
+  });
+});
+
+describe("routedIssueUrls", () => {
+  it("reads the url off each row's first line", () => {
+    const urls = routedIssueUrls([
+      row("https://github.com/o/r/issues/1\nLogin fails"),
+      row("https://linear.app/acme/issue/ENG-2"),
+    ]);
+    expect([...urls].sort()).toEqual([
+      "https://github.com/o/r/issues/1",
+      "https://linear.app/acme/issue/ENG-2",
+    ]);
+  });
+
+  it("ignores a why that doesn't open with a bare url", () => {
+    expect(
+      routedIssueUrls([
+        row("Because users keep asking"),
+        row(""),
+        row("see https://github.com/o/r/issues/9 for detail"),
+      ]).size,
+    ).toBe(0);
+  });
+});
+
+describe("funnelAction", () => {
+  const routed = new Set(["https://github.com/o/r/issues/1"]);
+
+  it("offers no action when the repo belongs to no project", () => {
+    expect(funnelAction(undefined, "https://github.com/o/r/issues/2", routed)).toEqual({
+      kind: "none",
+    });
+    expect(funnelAction("", "https://github.com/o/r/issues/1", routed)).toEqual({ kind: "none" });
+  });
+
+  it("reports an already-routed issue", () => {
+    expect(funnelAction("p1", "https://github.com/o/r/issues/1", routed)).toEqual({
+      kind: "routed",
+    });
+  });
+
+  it("offers the add carrying the project to create in", () => {
+    expect(funnelAction("p1", "https://github.com/o/r/issues/2", routed)).toEqual({
+      kind: "add",
+      projectId: "p1",
+    });
+  });
+});

--- a/src/components/Workspace/MissionControl/funnel.ts
+++ b/src/components/Workspace/MissionControl/funnel.ts
@@ -1,0 +1,91 @@
+// MissionControl/funnel.ts — pure logic for routing an inbox issue onto a
+// project's roadmap. Routing does not decide anything: the row lands `proposed`
+// (a ghost) and the board's existing Accept/Discard is still the ruling, so one
+// triage surface serves user ideas, PM proposals, and tracker issues alike.
+// Source-agnostic like inbox.ts — it speaks `TrackerIssue`, so GitHub and
+// Linear (and a future tracker) flow through the same code. Side-effect-free so
+// every rule is unit-tested without the store (funnel.test.ts).
+
+import type { IssueSource, ItemSource, NewRoadmapItem, RoadmapItem, TrackerIssue } from "@/api";
+
+/** Longest body distillation carried into `why`. The `why` is the one line
+ *  justifying an item's place on the board, and an issue template pasted whole
+ *  would drown the card — the URL on the line above is always there for the
+ *  full text. */
+const BODY_MAX = 240;
+
+/** Which `ItemSource` a tracker's issues land as. Exhaustive over
+ *  `IssueSource`, so adding a tracker fails to compile until the board's glyph
+ *  vocabulary knows about it. */
+const ITEM_SOURCE: Record<IssueSource, ItemSource> = { github: "github", linear: "linear" };
+
+/** One line of an issue's body: template comments dropped (issue forms are
+ *  mostly `<!-- -->` guidance), whitespace collapsed, clipped at a word
+ *  boundary. Empty when there is nothing worth carrying. */
+export function distillIssueBody(body: string | undefined, maxLen = BODY_MAX): string {
+  const text = (body ?? "")
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (text.length <= maxLen) return text;
+  const clipped = text.slice(0, maxLen);
+  const boundary = clipped.lastIndexOf(" ");
+  const kept = boundary > maxLen / 2 ? clipped.slice(0, boundary) : clipped;
+  return `${kept.replace(/[\s.,;:—-]+$/, "")}…`;
+}
+
+/** The `why` a routed issue carries: its URL alone on the first line, the
+ *  distilled body under it. That first line is load-bearing, not decoration —
+ *  it is the *only* record that this issue was routed (see `routedIssueUrls`),
+ *  which is what lets dedup survive a reload without a column of its own. */
+export function composeIssueWhy(issue: Pick<TrackerIssue, "url" | "body">): string {
+  const body = distillIssueBody(issue.body);
+  return body ? `${issue.url}\n${body}` : issue.url;
+}
+
+/** The row an inbox issue becomes. `proposed` is the whole point: routing is
+ *  triage, not a commitment, so the item arrives as a ghost the user rules on
+ *  with the same Accept/Discard every proposal gets. Horizon and rank are left
+ *  to the backend's defaults — where it belongs is a planning call, made after
+ *  the ruling. */
+export function issueToRoadmapItem(issue: TrackerIssue): NewRoadmapItem {
+  return {
+    title: issue.title,
+    why: composeIssueWhy(issue),
+    status: "proposed",
+    source: ITEM_SOURCE[issue.source],
+  };
+}
+
+/** Every issue URL already routed onto a board, read off the rows' `why` first
+ *  lines. Derived from the rows rather than remembered at the click, so the
+ *  inbox still knows after a reload — and so a row discarded on the board
+ *  offers its issue again. */
+export function routedIssueUrls(rows: readonly Pick<RoadmapItem, "why">[]): Set<string> {
+  const urls = new Set<string>();
+  for (const row of rows) {
+    const first = row.why.split("\n", 1)[0].trim();
+    if (/^https?:\/\/\S+$/.test(first)) urls.add(first);
+  }
+  return urls;
+}
+
+/** What an inbox row offers for its issue: `none` when the repo belongs to no
+ *  project (there is no board to route onto), `routed` when the issue is
+ *  already on one, else the action carrying the project to create in. */
+export type FunnelAction =
+  | { kind: "none" }
+  | { kind: "routed" }
+  | { kind: "add"; projectId: string };
+
+/** Decide that action. Project first: without a board there is nothing to say
+ *  about the issue at all. */
+export function funnelAction(
+  projectId: string | undefined,
+  issueUrl: string,
+  routed: ReadonlySet<string>,
+): FunnelAction {
+  if (!projectId) return { kind: "none" };
+  if (routed.has(issueUrl)) return { kind: "routed" };
+  return { kind: "add", projectId };
+}

--- a/src/components/Workspace/MissionControl/funnel.ts
+++ b/src/components/Workspace/MissionControl/funnel.ts
@@ -19,12 +19,21 @@ const BODY_MAX = 240;
  *  vocabulary knows about it. */
 const ITEM_SOURCE: Record<IssueSource, ItemSource> = { github: "github", linear: "linear" };
 
-/** One line of an issue's body: template comments dropped (issue forms are
- *  mostly `<!-- -->` guidance), whitespace collapsed, clipped at a word
- *  boundary. Empty when there is nothing worth carrying. */
+/** One line of an issue's body: markdown that carries no prose dropped —
+ *  template comments (issue forms are mostly `<!-- -->` guidance), fenced code,
+ *  screenshots — links unwrapped to their text, whitespace collapsed, clipped at
+ *  a word boundary. The clip budget is small, so noise spent on it is prose
+ *  lost: a body opening with a screenshot and a stack trace would otherwise
+ *  distill to a `why` that says nothing. Empty when there is nothing worth
+ *  carrying. */
 export function distillIssueBody(body: string | undefined, maxLen = BODY_MAX): string {
   const text = (body ?? "")
     .replace(/<!--[\s\S]*?-->/g, " ")
+    // Unterminated fence (a paste cut short) swallows the rest, which is the
+    // code it opened.
+    .replace(/```[\s\S]*?(?:```|$)/g, " ")
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
     .replace(/\s+/g, " ")
     .trim();
   if (text.length <= maxLen) return text;
@@ -70,22 +79,28 @@ export function routedIssueUrls(rows: readonly Pick<RoadmapItem, "why">[]): Set<
   return urls;
 }
 
-/** What an inbox row offers for its issue: `none` when the repo belongs to no
- *  project (there is no board to route onto), `routed` when the issue is
- *  already on one, else the action carrying the project to create in. */
+/** What an inbox row offers for its issue: `none` when there is no board to
+ *  route onto or no way to tell the issue apart later, `routed` when the issue
+ *  is already on one, else the action carrying the project to create in. */
 export type FunnelAction =
   | { kind: "none" }
   | { kind: "routed" }
   | { kind: "add"; projectId: string };
 
-/** Decide that action. Project first: without a board there is nothing to say
- *  about the issue at all. */
+/** Decide that action, against the routed urls of *that project's* board — the
+ *  same origin repo can be pinned in two projects, and routing an issue in one
+ *  says nothing about the other. Project first: without a board there is nothing
+ *  to say about the issue at all. */
 export function funnelAction(
   projectId: string | undefined,
   issueUrl: string,
   routed: ReadonlySet<string>,
 ): FunnelAction {
   if (!projectId) return { kind: "none" };
+  // No url is no dedup key: the `why` first line is the only record a routing
+  // happened, so an urlless issue would offer `add` forever and stack a fresh
+  // ghost on every click. Offering nothing is the honest answer.
+  if (!issueUrl) return { kind: "none" };
   if (routed.has(issueUrl)) return { kind: "routed" };
   return { kind: "add", projectId };
 }

--- a/src/components/Workspace/MissionControl/useIssueFunnel.ts
+++ b/src/components/Workspace/MissionControl/useIssueFunnel.ts
@@ -1,0 +1,67 @@
+// MissionControl/useIssueFunnel.ts — the inbox's roadmap side: which issues are
+// already on a board, and the one call that routes a new one there. Creation
+// goes through the typed `roadmap_create_item` command, which records the
+// item's `created` history line in the same transaction — the funnel adds no
+// writer of its own. The rules it applies are pure (funnel.ts).
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import { api, type RoadmapItem, type TrackerIssue } from "@/api";
+import { usePoll } from "@/util/hooks";
+import { type FunnelAction, funnelAction, issueToRoadmapItem, routedIssueUrls } from "./funnel";
+
+/** Same slow cadence as the inbox itself: this only answers "is it already on
+ *  the board?", and a routed row is folded in at the click, so the poll is just
+ *  what catches a board changed on another surface. */
+const POLL_MS = 120_000;
+
+export interface IssueFunnel {
+  /** What this issue's row should offer, given the project its repo belongs to
+   *  (empty/undefined when it belongs to none). */
+  actionFor: (projectId: string | undefined, issue: TrackerIssue) => FunnelAction;
+  /** Route the issue onto the project's board as a ghost row awaiting a ruling. */
+  route: (projectId: string, issue: TrackerIssue) => Promise<void>;
+}
+
+export function useIssueFunnel(projectIds: string[]): IssueFunnel {
+  const [rowsByProject, setRowsByProject] = useState<Record<string, RoadmapItem[]>>({});
+  // In-flight issue urls, in a ref rather than state: two fast clicks land in
+  // the same render, and a second ghost row is not something a reload undoes.
+  const inFlight = useRef(new Set<string>());
+
+  const poll = useCallback(async () => {
+    if (projectIds.length === 0) return;
+    const entries = await Promise.all(
+      projectIds.map(async (id) => [id, await api.roadmapListItems(id).catch(() => [])] as const),
+    );
+    setRowsByProject(Object.fromEntries(entries));
+  }, [projectIds]);
+
+  usePoll(poll, POLL_MS, [poll]);
+
+  const routed = useMemo(
+    () => routedIssueUrls(Object.values(rowsByProject).flat()),
+    [rowsByProject],
+  );
+
+  const actionFor = useCallback(
+    (projectId: string | undefined, issue: TrackerIssue) =>
+      funnelAction(projectId, issue.url, routed),
+    [routed],
+  );
+
+  const route = useCallback(async (projectId: string, issue: TrackerIssue) => {
+    if (inFlight.current.has(issue.url)) return;
+    inFlight.current.add(issue.url);
+    try {
+      const row = await api.roadmapCreateItem(projectId, issueToRoadmapItem(issue));
+      // Fold the stored row in rather than remembering the click: "on roadmap"
+      // stays a function of board rows, so this agrees with the next poll and
+      // with a reload.
+      setRowsByProject((prev) => ({ ...prev, [projectId]: [...(prev[projectId] ?? []), row] }));
+    } finally {
+      inFlight.current.delete(issue.url);
+    }
+  }, []);
+
+  return { actionFor, route };
+}

--- a/src/components/Workspace/MissionControl/useIssueFunnel.ts
+++ b/src/components/Workspace/MissionControl/useIssueFunnel.ts
@@ -16,14 +16,22 @@ const POLL_MS = 120_000;
 
 export interface IssueFunnel {
   /** What this issue's row should offer, given the project its repo belongs to
-   *  (empty/undefined when it belongs to none). */
+   *  (empty/undefined when it belongs to none). Nothing, until that project's
+   *  board has been read. */
   actionFor: (projectId: string | undefined, issue: TrackerIssue) => FunnelAction;
   /** Route the issue onto the project's board as a ghost row awaiting a ruling. */
   route: (projectId: string, issue: TrackerIssue) => Promise<void>;
 }
 
+/** A project's board as the funnel knows it. A read that failed is *not* an
+ *  empty board: the backend dedups nothing, so treating "we don't know" as
+ *  "nothing is routed" would re-enable Add on every already-routed row and let
+ *  one click stack a second ghost. A project absent from the record has not been
+ *  read yet, which is the same unknown. */
+type Board = { status: "loaded"; rows: RoadmapItem[] } | { status: "failed" };
+
 export function useIssueFunnel(projectIds: string[]): IssueFunnel {
-  const [rowsByProject, setRowsByProject] = useState<Record<string, RoadmapItem[]>>({});
+  const [boards, setBoards] = useState<Record<string, Board>>({});
   // In-flight issue urls, in a ref rather than state: two fast clicks land in
   // the same render, and a second ghost row is not something a reload undoes.
   const inFlight = useRef(new Set<string>());
@@ -31,22 +39,39 @@ export function useIssueFunnel(projectIds: string[]): IssueFunnel {
   const poll = useCallback(async () => {
     if (projectIds.length === 0) return;
     const entries = await Promise.all(
-      projectIds.map(async (id) => [id, await api.roadmapListItems(id).catch(() => [])] as const),
+      projectIds.map(async (id) => {
+        try {
+          return [id, { status: "loaded", rows: await api.roadmapListItems(id) }] as const;
+        } catch {
+          return [id, { status: "failed" }] as const;
+        }
+      }),
     );
-    setRowsByProject(Object.fromEntries(entries));
+    setBoards(Object.fromEntries(entries));
   }, [projectIds]);
 
   usePoll(poll, POLL_MS, [poll]);
 
-  const routed = useMemo(
-    () => routedIssueUrls(Object.values(rowsByProject).flat()),
-    [rowsByProject],
-  );
+  // Per project, never pooled: the same origin repo pinned at two paths in two
+  // projects would otherwise read "on roadmap" on both boards after one routing.
+  const routedByProject = useMemo(() => {
+    const byProject: Record<string, Set<string>> = {};
+    for (const [id, board] of Object.entries(boards)) {
+      if (board.status === "loaded") byProject[id] = routedIssueUrls(board.rows);
+    }
+    return byProject;
+  }, [boards]);
 
   const actionFor = useCallback(
-    (projectId: string | undefined, issue: TrackerIssue) =>
-      funnelAction(projectId, issue.url, routed),
-    [routed],
+    (projectId: string | undefined, issue: TrackerIssue) => {
+      const routed = projectId ? routedByProject[projectId] : undefined;
+      // Unknown board (unread or failed) → no roadmap action, the same quiet
+      // degradation the section gives a tracker that won't answer. Offering Add
+      // here is what creates duplicates.
+      if (!routed) return { kind: "none" } as const;
+      return funnelAction(projectId, issue.url, routed);
+    },
+    [routedByProject],
   );
 
   const route = useCallback(async (projectId: string, issue: TrackerIssue) => {
@@ -56,8 +81,13 @@ export function useIssueFunnel(projectIds: string[]): IssueFunnel {
       const row = await api.roadmapCreateItem(projectId, issueToRoadmapItem(issue));
       // Fold the stored row in rather than remembering the click: "on roadmap"
       // stays a function of board rows, so this agrees with the next poll and
-      // with a reload.
-      setRowsByProject((prev) => ({ ...prev, [projectId]: [...(prev[projectId] ?? []), row] }));
+      // with a reload. Only into a board we have actually read — inventing one
+      // from a single row would claim the rest of that board is empty.
+      setBoards((prev) => {
+        const board = prev[projectId];
+        if (board?.status !== "loaded") return prev;
+        return { ...prev, [projectId]: { status: "loaded", rows: [...board.rows, row] } };
+      });
     } finally {
       inFlight.current.delete(issue.url);
     }


### PR DESCRIPTION
Tier C, slice C2 of the roadmap/PM plan: the issue funnel — the first producer for the `github`/`linear` source glyphs that have existed on the board since day one.

## What
An open GitHub issue or Linear ticket in Mission Control's Issue Inbox previously had exactly one destination: an agent, right now. "Add to roadmap" gives it a second one — the issue lands on its project's board as a **`proposed` ghost** carrying the tracker's source glyph, in the same triage every PM proposal lands in. Your existing Accept/Discard is still the only ruling; routing decides nothing.

- Repo → project resolution reuses the inbox's existing mapping; an issue whose repo belongs to no project shows no action.
- Already-routed issues show "On roadmap" instead — derived from board rows, so it survives reload, and discarding the row offers the issue again.

## How
- **Zero backend changes.** `NewRoadmapItem` already accepted `status`/`source`; creation rides the typed `roadmap_create_item` command, which records the `created` history line in the same transaction as always.
- The issue URL is written as the `why`'s first line — that line is the routing record. Dedup reads it back off the rows: no column, no migration, no sync engine.
- Pure logic (body distillation, why-composition, URL dedup, action decision) lives in `MissionControl/funnel.ts` with 14 tests; the `Record<IssueSource, ItemSource>` map makes adding a tracker a compile error until the glyph vocabulary knows it.
- Small follow-through: `Roadmap.css` gains `src-github`/`src-linear` glyph tints (the enum had glyphs but no colors).

## Verification
- `bun run check` / `bun run lint` / `bun run test` (924 = 910 + 14 new) — all exit 0
- `cargo test` (1344, untouched) / CI clippy line — exit 0
- Also verified merged together with #605/#607 (sibling Tier C slices): 941 frontend tests, cargo 1350, clippy clean.

Part of the Tier C batch (independent of the other two PRs; any merge order works).