### PR TITLE
chore(roadmap): drop the columns the model pruning cut

### DIFF
--- a/src-tauri/migrations/0035_roadmap_items_drop_dormant.sql
+++ b/src-tauri/migrations/0035_roadmap_items_drop_dormant.sql
@@ -1,0 +1,63 @@
+-- Drop the dormant roadmap_items columns: `size`, `epic`, `parent_id`.
+--
+-- `size` and `epic` were cut from every surface in the model-pruning pass (the
+-- roadmap plan's A0): nothing consumes them — there are no sprints to size for
+-- and no epics to group under; agent labor is rationed by budgets and
+-- concurrency caps, not story points. `parent_id` was a v1 bet on sub-items
+-- that no slice ever took; it has been documented-unused since 0026. The
+-- columns were left in place until now because dropping them costs a table
+-- rebuild (below), which wasn't worth taking while the table was still gaining
+-- columns every other slice.
+--
+-- A rebuild rather than three ALTER ... DROP COLUMNs because `parent_id`
+-- carries a self-referencing FK, and SQLite refuses to drop a column named in
+-- a foreign-key constraint. The migration runner (rusqlite_migration) applies
+-- this with foreign-key enforcement off, so the DROP/RENAME below can't
+-- cascade into roadmap_item_events/roadmap_proposals rows; their `REFERENCES
+-- roadmap_items` clauses resolve against the renamed table again the moment
+-- the rename lands, and both operations sit in the same migration transaction.
+--
+-- Column order matches what 0026 + 0032 (rank) + 0033 (holds) left behind,
+-- minus the three dropped — the row decoder reads by name, but keeping the
+-- shape recognizable costs nothing.
+CREATE TABLE roadmap_items_new (
+    id              TEXT PRIMARY KEY,            -- uuid
+    project_id      TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    code            TEXT NOT NULL,               -- "FLT-142" style, unique per project
+    title           TEXT NOT NULL,
+    why             TEXT NOT NULL DEFAULT '',
+    horizon         TEXT NOT NULL,               -- now | next | later
+    status          TEXT NOT NULL,               -- proposed | open | queued | active | in_review | done
+    rank            REAL NOT NULL DEFAULT 0,     -- priority order (0032)
+    area            TEXT,
+    source          TEXT NOT NULL DEFAULT 'user',-- user | pm | linear | github
+    accept_json     TEXT,                        -- JSON array of acceptance criteria strings
+    deps_json       TEXT,                        -- JSON array of item codes this must land after
+    agent_id        TEXT,                        -- workspace working it
+    workflow_def_id TEXT,                        -- assigned workflow override
+    run_id          TEXT,                        -- wf_run executing it
+    pr_url          TEXT,
+    pr_number       INTEGER,
+    hold_reason     TEXT,                        -- holds (0033)
+    held_by         TEXT,
+    held_at         INTEGER,
+    created_at      INTEGER NOT NULL,
+    updated_at      INTEGER NOT NULL,
+    UNIQUE(project_id, code)
+);
+
+INSERT INTO roadmap_items_new
+    (id, project_id, code, title, why, horizon, status, rank, area, source,
+     accept_json, deps_json, agent_id, workflow_def_id, run_id, pr_url,
+     pr_number, hold_reason, held_by, held_at, created_at, updated_at)
+SELECT
+     id, project_id, code, title, why, horizon, status, rank, area, source,
+     accept_json, deps_json, agent_id, workflow_def_id, run_id, pr_url,
+     pr_number, hold_reason, held_by, held_at, created_at, updated_at
+FROM roadmap_items;
+
+DROP TABLE roadmap_items;
+ALTER TABLE roadmap_items_new RENAME TO roadmap_items;
+
+-- The one index 0026 declared; DROP TABLE took it with the old table.
+CREATE INDEX idx_roadmap_items_project ON roadmap_items(project_id);

--- a/src-tauri/src/database/connection.rs
+++ b/src-tauri/src/database/connection.rs
@@ -68,6 +68,7 @@ pub(crate) const MIGRATIONS: &[&str] = &[
     include_str!("../../migrations/0032_roadmap_rank.sql"),
     include_str!("../../migrations/0033_roadmap_holds.sql"),
     include_str!("../../migrations/0034_roadmap_briefs.sql"),
+    include_str!("../../migrations/0035_roadmap_items_drop_dormant.sql"),
 ];
 
 pub(crate) fn get_migrations() -> Migrations<'static> {

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -870,7 +870,18 @@ fn dormant_column_drop_preserves_rows_and_rebinds_references() {
 
     let conn = Connection::open(dir.path().join(DB_FILENAME)).unwrap();
     // Every kept column survived the copy with its value.
-    let row: (String, String, f64, String, String, String, String, i64, String, i64) = conn
+    let row: (
+        String,
+        String,
+        f64,
+        String,
+        String,
+        String,
+        String,
+        i64,
+        String,
+        i64,
+    ) = conn
         .query_row(
             "SELECT code, title, rank, source, accept_json, deps_json, pr_url, pr_number,
                     hold_reason, held_at

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -830,3 +830,107 @@ fn project_repo_agent_worktree_hierarchy() {
     assert_eq!(db_count(&conn, "workspaces", json!({})).unwrap(), 0);
     assert_eq!(db_count(&conn, "worktrees", json!({})).unwrap(), 0);
 }
+
+/// Schema version just before the dormant-column drop (0035) — the state an
+/// existing install upgrades from. Pinned like `V_WORKTREE_PRS`, for the same
+/// reason.
+const V_BEFORE_DORMANT_DROP: usize = 34;
+
+/// The dormant-column drop (0035) is a full table rebuild (SQLite can't DROP a
+/// column named in an FK constraint, which `parent_id` was). A rebuild has two
+/// ways to lose data that a plain ALTER doesn't: the copy can drop or reorder
+/// values, and the DROP/RENAME can sever the `REFERENCES roadmap_items` clauses
+/// other roadmap tables carry. Both are asserted against a row that populates
+/// every kept column *and* all three dropped ones.
+#[test]
+fn dormant_column_drop_preserves_rows_and_rebinds_references() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut conn = open_db(&dir.path().join(DB_FILENAME)).unwrap();
+    get_migrations()
+        .to_version(&mut conn, V_BEFORE_DORMANT_DROP)
+        .unwrap();
+    conn.execute_batch(
+        "INSERT INTO projects (id, name, created_at) VALUES ('p', 'proj', 0);
+         INSERT INTO roadmap_items
+                (id, project_id, code, parent_id, title, why, horizon, status, size, epic,
+                 rank, area, source, accept_json, deps_json, agent_id, workflow_def_id,
+                 run_id, pr_url, pr_number, hold_reason, held_by, held_at,
+                 created_at, updated_at)
+         VALUES ('i1', 'p', 'PRJ-100', NULL, 'the item', 'because', 'now', 'queued', 'M',
+                 'an epic', 12.5, 'auth', 'pm', '[\"a\",\"b\"]', '[\"PRJ-90\"]', 'ag1',
+                 'wf1', 'run1', 'https://x/1', 7, 'wait for signoff', 'pm', 111, 100, 200);
+         INSERT INTO roadmap_item_events
+                (id, item_id, project_id, actor, kind, detail, created_at)
+         VALUES ('e1', 'i1', 'p', 'pm', 'note', 'a durable line', 0);",
+    )
+    .unwrap();
+    drop(conn);
+
+    init(dir.path()).unwrap();
+
+    let conn = Connection::open(dir.path().join(DB_FILENAME)).unwrap();
+    // Every kept column survived the copy with its value.
+    let row: (String, String, f64, String, String, String, String, i64, String, i64) = conn
+        .query_row(
+            "SELECT code, title, rank, source, accept_json, deps_json, pr_url, pr_number,
+                    hold_reason, held_at
+               FROM roadmap_items WHERE id = 'i1' AND status = 'queued'",
+            [],
+            |r| {
+                Ok((
+                    r.get(0)?,
+                    r.get(1)?,
+                    r.get(2)?,
+                    r.get(3)?,
+                    r.get(4)?,
+                    r.get(5)?,
+                    r.get(6)?,
+                    r.get(7)?,
+                    r.get(8)?,
+                    r.get(9)?,
+                ))
+            },
+        )
+        .unwrap();
+    assert_eq!(row.0, "PRJ-100");
+    assert_eq!(row.2, 12.5);
+    assert_eq!(row.4, "[\"a\",\"b\"]");
+    assert_eq!((row.7, row.8.as_str(), row.9), (7, "wait for signoff", 111));
+
+    // The dropped columns are gone from the schema, not merely unread.
+    for gone in ["size", "epic", "parent_id"] {
+        assert!(
+            conn.query_row(
+                &format!("SELECT {gone} FROM roadmap_items LIMIT 1"),
+                [],
+                |_| Ok(())
+            )
+            .is_err(),
+            "{gone} must not survive the rebuild"
+        );
+    }
+
+    // UNIQUE(project_id, code) crossed the rebuild.
+    assert!(conn
+        .execute(
+            "INSERT INTO roadmap_items (id, project_id, code, title, horizon, status,
+                                        created_at, updated_at)
+             VALUES ('i2', 'p', 'PRJ-100', 'dup', 'now', 'open', 0, 0)",
+            [],
+        )
+        .is_err());
+
+    // The rename re-bound the FK clauses pointing at the table: cascades still
+    // flow project → item → event, exactly as before the rebuild.
+    conn.execute("DELETE FROM projects WHERE id = 'p'", [])
+        .unwrap();
+    let (items, events): (i64, i64) = conn
+        .query_row(
+            "SELECT (SELECT COUNT(*) FROM roadmap_items),
+                    (SELECT COUNT(*) FROM roadmap_item_events)",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!((items, events), (0, 0), "cascade must survive the rebuild");
+}

--- a/src-tauri/src/roadmap/drainer/tests.rs
+++ b/src-tauri/src/roadmap/drainer/tests.rs
@@ -18,7 +18,6 @@ fn item(code: &str, rank: f64) -> RoadmapItem {
         id: format!("id-{code}"),
         project_id: "p1".into(),
         code: code.into(),
-        parent_id: None,
         title: format!("do {code}"),
         why: String::new(),
         horizon: Horizon::Next,

--- a/src-tauri/src/roadmap/merge_sweep/tests.rs
+++ b/src-tauri/src/roadmap/merge_sweep/tests.rs
@@ -14,7 +14,6 @@ fn in_review(code: &str, number: Option<i64>) -> RoadmapItem {
         id: format!("id-{code}"),
         project_id: "p1".into(),
         code: code.into(),
-        parent_id: None,
         title: format!("do {code}"),
         why: String::new(),
         horizon: Horizon::Now,

--- a/src-tauri/src/roadmap/pr_review.rs
+++ b/src-tauri/src/roadmap/pr_review.rs
@@ -139,7 +139,6 @@ mod tests {
             id: "i1".into(),
             project_id: "p1".into(),
             code: "FLT-1".into(),
-            parent_id: None,
             title: "t".into(),
             why: String::new(),
             horizon: Horizon::Now,

--- a/src-tauri/src/roadmap/review.rs
+++ b/src-tauri/src/roadmap/review.rs
@@ -570,7 +570,6 @@ mod tests {
             id: "i1".into(),
             project_id: "p1".into(),
             code: "MCA-104".into(),
-            parent_id: None,
             title: "Add the queue drainer".into(),
             why: "queued items sit forever with nothing to launch them".into(),
             horizon: crate::roadmap::types::Horizon::Now,

--- a/src-tauri/src/roadmap/store.rs
+++ b/src-tauri/src/roadmap/store.rs
@@ -74,9 +74,9 @@ pub fn create(conn: &Connection, project_id: &str, new: &NewItem) -> rusqlite::R
     let now = now_millis();
     conn.execute(
         "INSERT INTO roadmap_items
-           (id, project_id, code, parent_id, title, why, horizon, status, rank, area, source,
+           (id, project_id, code, title, why, horizon, status, rank, area, source,
             accept_json, deps_json, workflow_def_id, created_at, updated_at)
-         VALUES (?1, ?2, ?3, NULL, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?14)",
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?14)",
         params![
             id,
             project_id,
@@ -675,7 +675,6 @@ mod tests {
         assert_eq!(bare.source, ItemSource::User);
         assert!(bare.accept.is_empty() && bare.deps.is_empty());
         assert_eq!(bare.why, "");
-        assert!(bare.parent_id.is_none(), "v1 never writes a parent");
 
         let full = create(
             &conn,

--- a/src-tauri/src/roadmap/types.rs
+++ b/src-tauri/src/roadmap/types.rs
@@ -76,8 +76,6 @@ pub struct RoadmapItem {
     pub project_id: String,
     /// Short human id ("FLT-142"), unique per project and never reallocated.
     pub code: String,
-    /// Reserved for sub-items; always `None` today (no UI writes it).
-    pub parent_id: Option<String>,
     pub title: String,
     /// The one line that justifies the item's place on the board.
     pub why: String,
@@ -116,11 +114,7 @@ pub struct RoadmapItem {
 
 /// The columns every read selects, in one place so the row decoder and the
 /// queries can't disagree about what is available.
-///
-/// The table also carries `size` and `epic`, cut from every surface and left
-/// dormant until the cleanup migration that drops them alongside `parent_id`
-/// (see .context/roadmap-pm-plan.md).
-pub(crate) const COLUMNS: &str = "id, project_id, code, parent_id, title, why, horizon, status, \
+pub(crate) const COLUMNS: &str = "id, project_id, code, title, why, horizon, status, \
      rank, area, source, accept_json, deps_json, agent_id, workflow_def_id, run_id, \
      pr_url, pr_number, hold_reason, held_by, held_at, created_at, updated_at";
 
@@ -130,7 +124,6 @@ impl RoadmapItem {
             id: r.get("id")?,
             project_id: r.get("project_id")?,
             code: r.get("code")?,
-            parent_id: r.get("parent_id")?,
             title: r.get("title")?,
             why: r.get("why")?,
             horizon: enum_col(r, "horizon", Horizon::from_db)?,

--- a/src/api/types/roadmap.ts
+++ b/src/api/types/roadmap.ts
@@ -27,8 +27,6 @@ export interface RoadmapItem {
   project_id: string;
   /** Short human id ("FLT-142"), unique per project and never reallocated. */
   code: string;
-  /** Reserved for sub-items; always null today (no UI writes it). */
-  parent_id: string | null;
   title: string;
   /** The one line that justifies the item's place on the board. */
   why: string;

--- a/src/components/ProjectScreen/Roadmap/InFlightRail/select.test.ts
+++ b/src/components/ProjectScreen/Roadmap/InFlightRail/select.test.ts
@@ -8,7 +8,6 @@ function item(over: Partial<RoadmapItem> & { id: string }): RoadmapItem {
   return {
     project_id: "p1",
     code: `MCA-${over.id}`,
-    parent_id: null,
     title: `Item ${over.id}`,
     why: "",
     horizon: "now",

--- a/src/components/ProjectScreen/Roadmap/NeedsYou/select.test.ts
+++ b/src/components/ProjectScreen/Roadmap/NeedsYou/select.test.ts
@@ -14,7 +14,6 @@ function item(over: Partial<RoadmapItem> & { id: string }): RoadmapItem {
   return {
     project_id: "p1",
     code: `MCA-${over.id}`,
-    parent_id: null,
     title: `Item ${over.id}`,
     why: "",
     horizon: "next",

--- a/src/components/ProjectScreen/Roadmap/proposalDiff.test.ts
+++ b/src/components/ProjectScreen/Roadmap/proposalDiff.test.ts
@@ -7,7 +7,6 @@ function item(over: Partial<RoadmapItem> = {}): RoadmapItem {
     id: "i1",
     project_id: "p1",
     code: "FLT-100",
-    parent_id: null,
     title: "Old title",
     why: "old why",
     horizon: "later",

--- a/src/components/ProjectScreen/Roadmap/reviewPrompt.test.ts
+++ b/src/components/ProjectScreen/Roadmap/reviewPrompt.test.ts
@@ -7,7 +7,6 @@ function item(over: Partial<RoadmapItem> = {}): RoadmapItem {
     id: "i1",
     project_id: "p1",
     code: "FLT-142",
-    parent_id: null,
     title: "Say what the board is waiting on",
     why: "the why nobody should be re-litigating here",
     horizon: "now",

--- a/src/components/ProjectScreen/Roadmap/useItemReviews.test.ts
+++ b/src/components/ProjectScreen/Roadmap/useItemReviews.test.ts
@@ -7,7 +7,6 @@ function item(over: Partial<RoadmapItem> = {}): RoadmapItem {
     id: "i1",
     project_id: "p1",
     code: "FLT-1",
-    parent_id: null,
     title: "t",
     why: "",
     horizon: "now",

--- a/src/rowSync.test.ts
+++ b/src/rowSync.test.ts
@@ -8,7 +8,6 @@ function item(over: Partial<RoadmapItem> & { id: string }): RoadmapItem {
   return {
     project_id: "p1",
     code: `FLT-${over.id}`,
-    parent_id: null,
     title: `Item ${over.id}`,
     why: "",
     horizon: "later",


### PR DESCRIPTION
The cleanup A0 scheduled and B7 re-deferred: drop the dormant `roadmap_items` columns — `size`, `epic`, `parent_id`.

## Why now
`size`/`epic` were cut from every surface in the model-pruning pass (nothing consumes them; agent labor is rationed by budgets and concurrency caps, not story points) and `parent_id` was a v1 sub-items bet no slice ever took. The columns stayed because dropping them costs a table rebuild — `parent_id` carries a self-referencing FK, and SQLite refuses `DROP COLUMN` on anything named in an FK constraint — and the table was still gaining columns every other slice (rank in 0032, holds in 0033). With Tier B and Tier C batch 1 merged, it isn't anymore.

## What
- **Migration 0035**: full table rebuild (create → copy → drop → rename → recreate index). The runner (`rusqlite_migration`) applies it with FK enforcement off, and the rename re-binds the `REFERENCES roadmap_items` clauses that `roadmap_item_events`/`roadmap_proposals` carry.
- **Rust**: `RoadmapItem` loses `parent_id`; `COLUMNS`, `from_row`, the insert, and four test fixtures follow. The "dormant until the cleanup migration" comment is gone because the migration now exists.
- **TS**: `RoadmapItem.parent_id` deleted; six test fixtures follow.
- **New migration test** (`dormant_column_drop_preserves_rows_and_rebinds_references`): upgrades a v34 database with all three dormant columns *populated* and every kept column set, then asserts the row survives value-for-value, the dropped columns are gone from the schema (not merely unread), `UNIQUE(project_id, code)` still rejects duplicates, and the project → item → event cascade still flows across the rebuild.

## Verification
- `cargo test` 1353 passed / 0 failed (main's 1352 + the new test) — exit 0
- CI clippy line — exit 0
- `bun run check` / `bun run lint` / `bun run test` (952) — all exit 0

Closes out the last scheduled item from the roadmap plan's Tier B.