### PR TITLE
fix(db): run migrations with foreign-key enforcement off

### DIFF
--- a/src-tauri/migrations/0035_roadmap_items_drop_dormant.sql
+++ b/src-tauri/migrations/0035_roadmap_items_drop_dormant.sql
@@ -11,11 +11,14 @@
 --
 -- A rebuild rather than three ALTER ... DROP COLUMNs because `parent_id`
 -- carries a self-referencing FK, and SQLite refuses to drop a column named in
--- a foreign-key constraint. The migration runner (rusqlite_migration) applies
--- this with foreign-key enforcement off, so the DROP/RENAME below can't
--- cascade into roadmap_item_events/roadmap_proposals rows; their `REFERENCES
--- roadmap_items` clauses resolve against the renamed table again the moment
--- the rename lands, and both operations sit in the same migration transaction.
+-- a foreign-key constraint. `database::init` turns foreign-key enforcement OFF
+-- before running migrations (rusqlite_migration leaves the pragma to its
+-- caller), so the DROP/RENAME below can't cascade into roadmap_item_events/
+-- roadmap_proposals rows; their `REFERENCES roadmap_items` clauses resolve
+-- against the renamed table again the moment the rename lands, and `init`
+-- runs PRAGMA foreign_key_check afterwards to prove nothing dangles. Any
+-- future rebuild migration inherits that guarantee from `init`, not from
+-- anything written here.
 --
 -- Column order matches what 0026 + 0032 (rank) + 0033 (holds) left behind,
 -- minus the three dropped — the row decoder reads by name, but keeping the

--- a/src-tauri/src/database/connection.rs
+++ b/src-tauri/src/database/connection.rs
@@ -82,9 +82,30 @@ pub fn init(data_dir: &Path) -> Result<Arc<Mutex<Connection>>> {
     let db_path = data_dir.join(DB_FILENAME);
     let mut conn = open_db(&db_path)?;
     backup_before_upgrade(&conn, &db_path)?;
+    // Foreign-key enforcement must be OFF while migrations run, and that is the
+    // caller's job — rusqlite_migration never touches the pragma. With it on, a
+    // table-rebuild migration (CREATE new / INSERT SELECT / DROP old / RENAME,
+    // e.g. 0035) fires ON DELETE CASCADE at the DROP and silently deletes every
+    // child row pointing at the rebuilt table. The pragma is a no-op inside a
+    // transaction, so it has to be set here, outside the per-migration
+    // transactions the runner opens.
+    conn.pragma_update(None, "foreign_keys", false)?;
     get_migrations()
         .to_latest(&mut conn)
         .map_err(map_migration_error)?;
+    // The other half of running with enforcement off (SQLite's documented
+    // rebuild procedure): verify no migration left a dangling reference before
+    // trusting the schema.
+    let violations: i64 =
+        conn.query_row("SELECT COUNT(*) FROM pragma_foreign_key_check()", [], |r| {
+            r.get(0)
+        })?;
+    if violations > 0 {
+        return Err(Error::Other(format!(
+            "schema migration left {violations} foreign-key violation(s)"
+        )));
+    }
+    conn.pragma_update(None, "foreign_keys", true)?;
     Ok(Arc::new(Mutex::new(conn)))
 }
 

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -861,7 +861,10 @@ fn dormant_column_drop_preserves_rows_and_rebinds_references() {
                  'wf1', 'run1', 'https://x/1', 7, 'wait for signoff', 'pm', 111, 100, 200);
          INSERT INTO roadmap_item_events
                 (id, item_id, project_id, actor, kind, detail, created_at)
-         VALUES ('e1', 'i1', 'p', 'pm', 'note', 'a durable line', 0);",
+         VALUES ('e1', 'i1', 'p', 'pm', 'note', 'a durable line', 0);
+         INSERT INTO roadmap_proposals
+                (id, project_id, item_id, kind, patch_json, note, created_at)
+         VALUES ('pr1', 'p', 'i1', 'update', '{\"title\":\"renamed\"}', 'why', 0);",
     )
     .unwrap();
     drop(conn);
@@ -869,6 +872,25 @@ fn dormant_column_drop_preserves_rows_and_rebinds_references() {
     init(dir.path()).unwrap();
 
     let conn = Connection::open(dir.path().join(DB_FILENAME)).unwrap();
+
+    // The child rows survived the rebuild. This must be asserted positively,
+    // *before* any deletes below: with FK enforcement on during migrations, the
+    // rebuild's DROP TABLE fires ON DELETE CASCADE and wipes exactly these rows
+    // — and a post-delete zero-count check can't tell "cascade works" from
+    // "the upgrade already destroyed everything".
+    let (events, proposals): (i64, i64) = conn
+        .query_row(
+            "SELECT (SELECT COUNT(*) FROM roadmap_item_events),
+                    (SELECT COUNT(*) FROM roadmap_proposals)",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        (events, proposals),
+        (1, 1),
+        "the durable trail and pending asks must survive the rebuild"
+    );
     // Every kept column survived the copy with its value.
     let row: (
         String,
@@ -935,13 +957,34 @@ fn dormant_column_drop_preserves_rows_and_rebinds_references() {
     // flow project → item → event, exactly as before the rebuild.
     conn.execute("DELETE FROM projects WHERE id = 'p'", [])
         .unwrap();
-    let (items, events): (i64, i64) = conn
+    let (items, events, proposals): (i64, i64, i64) = conn
         .query_row(
             "SELECT (SELECT COUNT(*) FROM roadmap_items),
-                    (SELECT COUNT(*) FROM roadmap_item_events)",
+                    (SELECT COUNT(*) FROM roadmap_item_events),
+                    (SELECT COUNT(*) FROM roadmap_proposals)",
             [],
-            |r| Ok((r.get(0)?, r.get(1)?)),
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
         )
         .unwrap();
-    assert_eq!((items, events), (0, 0), "cascade must survive the rebuild");
+    assert_eq!(
+        (items, events, proposals),
+        (0, 0, 0),
+        "cascade must survive the rebuild"
+    );
+}
+
+/// `init` turns FK enforcement off around the migration run (so table rebuilds
+/// can't cascade into child rows) — this pins that it comes back ON for the
+/// connection the app actually uses. A raw `Connection::open` would not show
+/// this: the pragma is per-connection, so the assertion must run on the handle
+/// `init` returns.
+#[test]
+fn init_returns_a_connection_with_fk_enforcement_on() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = init(dir.path()).unwrap();
+    let conn = db.lock();
+    let fk: i64 = conn
+        .query_row("PRAGMA foreign_keys", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(fk, 1, "the app's connection must enforce foreign keys");
 }


### PR DESCRIPTION
## The bug

Migration 0035 (the dormant-column drop, #608) is a full table rebuild of `roadmap_items`, and it ran with **foreign-key enforcement ON**: `open_db` sets `PRAGMA foreign_keys = ON`, and rusqlite_migration deliberately leaves that pragma to its caller (its docs instruct callers to disable it around migrations). With enforcement on, the rebuild's `DROP TABLE roadmap_items` performs an implicit `DELETE FROM`, firing `ON DELETE CASCADE` into `roadmap_item_events` and `roadmap_proposals` — silently deleting the entire durable history trail and every pending PM proposal on upgrade from any v30–v34 install.

The 0035 header comment claimed the runner applies migrations with FK off. That guarantee never existed.

Why the upgrade test missed it: the item row itself is copied to the new table *before* the DROP (so it survives), and the test's only event assertion was a zero-count *after* deleting the project — vacuously true once the cascade had already wiped the rows.

## The fix (systemic, not per-migration)

"FK off during migrations" is a property of the connection lifecycle, so it lives in `database::init`, not in any migration's SQL:

- `init` sets `foreign_keys = OFF` before `to_latest` (the pragma is a no-op inside a transaction, so it must be set outside the runner's per-migration transactions), runs `PRAGMA foreign_key_check` before trusting the migrated schema, and sets it back ON for the connection the app uses.
- The 0035 header now states that `init` provides the guarantee, so a future rebuild migration inherits it rather than copying a false sentence.

## Tests

- The upgrade test now seeds an event **and** a pending proposal and asserts both survive `init` **positively, before** the cascade check. Verified red without the fix, green with it.
- New `init_returns_a_connection_with_fk_enforcement_on` pins that enforcement comes back on for the app's handle (per-connection pragma, so it must be asserted on the handle `init` returns).

Note for anyone who upgraded on current main: the pre-upgrade snapshot (`data.db.bak-v34-*`) written by `backup_before_upgrade` still holds the wiped rows.

Gates: tsc 0 · vitest 952 passed · cargo test green (incl. 30 database tests) · clippy 0 · fmt clean.