### PR TITLE
fix(roadmap): join the satellite surfaces to the spine, complete the ruling grammar

### DIFF
--- a/src-tauri/migrations/0036_roadmap_issue_url.sql
+++ b/src-tauri/migrations/0036_roadmap_issue_url.sql
@@ -1,0 +1,36 @@
+-- The tracker issue a roadmap row came from, as a real column.
+--
+-- Why this exists: the issue funnel (Mission Control's "Add to roadmap") needs
+-- to answer one question every time the inbox renders — "is this issue already
+-- on that project's board?" — and until now the answer was read out of the
+-- item's `why`: the funnel wrote the issue URL alone on the first line and the
+-- inbox parsed it back. That made a *dedup key* out of a field the user is
+-- invited to edit. Retitling the rationale, or letting the PM propose a better
+-- `why`, un-deduped the issue: the inbox offered it again and one click stacked a
+-- second ghost for work already on the board.
+--
+-- So the routing record becomes a column. NULL for every row that did not come
+-- from a tracker (the overwhelming majority), the canonical URL otherwise. The
+-- funnel keys on it; the `why` goes back to being prose the user owns. Rows
+-- written before this migration keep their URL only in the `why`, so the
+-- frontend's reader falls back to that first line for them (see funnel.ts
+-- `routedIssueUrl`) — a backfill would have to re-parse user-editable text into
+-- a column claiming to be canonical, which is exactly the property we are buying.
+--
+-- Plain ADD COLUMN, deliberately: no table rebuild. 0035 had to rebuild because
+-- `parent_id`'s self-referencing FK forbids DROP COLUMN, and that rebuild is the
+-- expensive, cascade-sensitive operation this file must not repeat. A nullable
+-- TEXT column with no constraint and no default is the one shape SQLite adds in
+-- O(1) with nothing else touched.
+--
+-- No index: the only query is "the rows of one project" (`roadmap_list_items`,
+-- already indexed by `project_id`), and the URL matching happens in the frontend
+-- over that project's rows. An index on a column that is NULL for most rows and
+-- never appears in a WHERE clause would be pure write cost.
+--
+-- The other half of the routing record — an issue the user *declined* — cannot
+-- live here, because discarding a ghost deletes its row (that is what a discard
+-- is). It lives in `project_settings` under `roadmap.declined_issues`, written by
+-- the delete path when the row it removes is a `proposed` row carrying an
+-- `issue_url` (see roadmap/store.rs `decline_issue`).
+ALTER TABLE roadmap_items ADD COLUMN issue_url TEXT;

--- a/src-tauri/src/database/connection.rs
+++ b/src-tauri/src/database/connection.rs
@@ -69,6 +69,7 @@ pub(crate) const MIGRATIONS: &[&str] = &[
     include_str!("../../migrations/0033_roadmap_holds.sql"),
     include_str!("../../migrations/0034_roadmap_briefs.sql"),
     include_str!("../../migrations/0035_roadmap_items_drop_dormant.sql"),
+    include_str!("../../migrations/0036_roadmap_issue_url.sql"),
 ];
 
 pub(crate) fn get_migrations() -> Migrations<'static> {

--- a/src-tauri/src/roadmap/drainer/tests.rs
+++ b/src-tauri/src/roadmap/drainer/tests.rs
@@ -35,6 +35,7 @@ fn item(code: &str, rank: f64) -> RoadmapItem {
         hold_reason: None,
         held_by: None,
         held_at: None,
+        issue_url: None,
         created_at: 0,
         updated_at: 0,
     }

--- a/src-tauri/src/roadmap/merge_sweep/tests.rs
+++ b/src-tauri/src/roadmap/merge_sweep/tests.rs
@@ -31,6 +31,7 @@ fn in_review(code: &str, number: Option<i64>) -> RoadmapItem {
         hold_reason: None,
         held_by: None,
         held_at: None,
+        issue_url: None,
         created_at: 10,
         updated_at: 10,
     }

--- a/src-tauri/src/roadmap/mod.rs
+++ b/src-tauri/src/roadmap/mod.rs
@@ -1005,6 +1005,15 @@ fn reclaim(conn: &Connection, item_id: &str) -> Result<(RoadmapItem, ItemEvent),
 /// Deletion records no history event on purpose: `roadmap_item_events` cascades
 /// with the row, so a deleted item (including a discarded proposal) takes its
 /// trail with it — an item ruled off the board needs no history.
+///
+/// One thing does have to outlive the row: a *routed issue's* refusal. A ghost
+/// the issue funnel created carries the tracker URL it came from
+/// ([`RoadmapItem::issue_url`]), and discarding it is the user saying "not this
+/// one" — a decision the inbox must respect after a reload, when the row it was
+/// expressed on is gone. So the tombstone is written here, in the same lock scope
+/// as the delete, from the row as it was (see [`store::decline_issue`]). Only for
+/// a still-`proposed` row: removing an item the user already *accepted* is a
+/// different decision, and re-offering that issue later is correct.
 #[tauri::command]
 pub async fn roadmap_delete_item(
     id: String,
@@ -1017,7 +1026,17 @@ pub async fn roadmap_delete_item(
         // its disappearance can be announced — the board holds proposals in
         // their own stream and would otherwise count a ghost of one forever.
         let pending = proposals::for_item(&conn, &id).map_err(|e| e.to_string())?;
+        // Read before the delete for the same reason: the routing record this row
+        // may carry is only legible while the row exists.
+        let doomed = store::get(&conn, &id).map_err(|e| e.to_string())?;
         let removed = store::delete(&conn, &id).map_err(|e| e.to_string())?;
+        if removed {
+            if let Some(row) = doomed.filter(|r| r.status == ItemStatus::Proposed) {
+                if let Some(url) = row.issue_url.as_deref() {
+                    store::decline_issue(&conn, &row.project_id, url).map_err(|e| e.to_string())?;
+                }
+            }
+        }
         (removed, pending.filter(|_| removed))
     };
     if removed {

--- a/src-tauri/src/roadmap/pr_review.rs
+++ b/src-tauri/src/roadmap/pr_review.rs
@@ -157,6 +157,7 @@ mod tests {
             hold_reason: None,
             held_by: None,
             held_at: None,
+            issue_url: None,
             updated_at: 1,
         }
     }

--- a/src-tauri/src/roadmap/review.rs
+++ b/src-tauri/src/roadmap/review.rs
@@ -587,6 +587,7 @@ mod tests {
             hold_reason: None,
             held_by: None,
             held_at: None,
+            issue_url: None,
             created_at: 0,
             updated_at: 0,
         }

--- a/src-tauri/src/roadmap/store.rs
+++ b/src-tauri/src/roadmap/store.rs
@@ -75,8 +75,8 @@ pub fn create(conn: &Connection, project_id: &str, new: &NewItem) -> rusqlite::R
     conn.execute(
         "INSERT INTO roadmap_items
            (id, project_id, code, title, why, horizon, status, rank, area, source,
-            accept_json, deps_json, workflow_def_id, created_at, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?14)",
+            accept_json, deps_json, workflow_def_id, issue_url, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?15)",
         params![
             id,
             project_id,
@@ -91,6 +91,7 @@ pub fn create(conn: &Connection, project_id: &str, new: &NewItem) -> rusqlite::R
             strings_to_col(&new.accept),
             strings_to_col(&new.deps),
             new.workflow_def_id,
+            new.issue_url,
             now,
         ],
     )?;
@@ -239,6 +240,68 @@ fn apply(
 pub fn delete(conn: &Connection, id: &str) -> rusqlite::Result<bool> {
     let n = conn.execute("DELETE FROM roadmap_items WHERE id = ?1", [id])?;
     Ok(n > 0)
+}
+
+/// `project_settings` key holding the tracker issues the user has *turned down* —
+/// a JSON array of URLs.
+///
+/// Not a column and not a table, for one reason: the fact it records is about a
+/// row that no longer exists. Discarding a ghost deletes it (that is what a
+/// discard is, and what makes the trail cascade away with it), so the "declined"
+/// half of a routing record has nowhere on `roadmap_items` to live. A table would
+/// be the tidier home, but a roadmap table is off the generic CRUD allow-list by
+/// invariant and would therefore need a typed read command of its own for one
+/// list of strings; `project_settings` is already the project-scoped key/value
+/// store the frontend can read (`getProjectSettings`), and already holds JSON
+/// documents this way (see `run_env`).
+pub(crate) const DECLINED_ISSUES_KEY: &str = "roadmap.declined_issues";
+
+/// How many declined URLs a project keeps. Oldest are dropped first: the list
+/// exists to stop the inbox re-offering something you just said no to, and an
+/// issue you declined a thousand tickets ago being offered once more is a far
+/// smaller sin than an unbounded settings value re-read on every inbox render.
+const DECLINED_MAX: usize = 500;
+
+/// Remember that an imported issue was turned down, so the inbox stops offering
+/// it. Idempotent: a URL already on the list is left where it is rather than
+/// re-appended, so re-declining can't push the rest of the list out.
+///
+/// Called from the delete path when the row being removed is a *proposed* row
+/// carrying an `issue_url` — the exact shape of "the user discarded the ghost
+/// this issue was routed as". Deleting a row that was already *accepted* records
+/// nothing: that issue reached the roadmap and was then removed from it, which is
+/// a different decision from refusing it at the door.
+pub fn decline_issue(conn: &Connection, project_id: &str, issue_url: &str) -> rusqlite::Result<()> {
+    let mut urls = declined_issues(conn, project_id)?;
+    if urls.iter().any(|u| u == issue_url) {
+        return Ok(());
+    }
+    urls.push(issue_url.to_string());
+    if urls.len() > DECLINED_MAX {
+        urls.drain(..urls.len() - DECLINED_MAX);
+    }
+    let json = serde_json::to_string(&urls).unwrap_or_else(|_| "[]".to_string());
+    conn.execute(
+        "INSERT INTO project_settings (project_id, key, value) VALUES (?1, ?2, ?3) \
+         ON CONFLICT(project_id, key) DO UPDATE SET value = excluded.value",
+        params![project_id, DECLINED_ISSUES_KEY, json],
+    )?;
+    Ok(())
+}
+
+/// The stored declined list, oldest first. A missing or unparseable value reads
+/// as empty — a corrupt setting must cost the dedup, never the discard.
+fn declined_issues(conn: &Connection, project_id: &str) -> rusqlite::Result<Vec<String>> {
+    let stored: Option<String> = conn
+        .query_row(
+            "SELECT value FROM project_settings WHERE project_id = ?1 AND key = ?2",
+            params![project_id, DECLINED_ISSUES_KEY],
+            |r| r.get(0),
+        )
+        .optional()?;
+    Ok(stored
+        .and_then(|v| serde_json::from_str::<Vec<String>>(&v).ok())
+        .unwrap_or_default())
 }
 
 /// The next free code for a project ("FLT-142").
@@ -689,6 +752,7 @@ mod tests {
                 accept: vec!["survives a quit".into(), "reattaches".into()],
                 deps: vec![bare.code.clone()],
                 workflow_def_id: Some("wf-pipeline".into()),
+                issue_url: None,
             },
         )
         .unwrap();
@@ -893,6 +957,166 @@ mod tests {
         )
         .unwrap()
         .is_none());
+    }
+
+    /// The funnel's dedup key is a column, so it survives every edit to the
+    /// prose that used to carry it.
+    #[test]
+    fn a_routed_row_carries_its_issue_url_and_a_hand_typed_one_does_not() {
+        let conn = test_conn();
+        let p = project(&conn, "p1", "fletch");
+        let routed = create(
+            &conn,
+            &p,
+            &NewItem {
+                title: "Crash on save".into(),
+                why: "https://github.com/o/r/issues/7\nSaving drops the body".into(),
+                status: Some(ItemStatus::Proposed),
+                source: Some(ItemSource::Github),
+                issue_url: Some("https://github.com/o/r/issues/7".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let typed = create(&conn, &p, &titled("my own idea")).unwrap();
+        assert_eq!(
+            routed.issue_url.as_deref(),
+            Some("https://github.com/o/r/issues/7")
+        );
+        assert_eq!(typed.issue_url, None, "nothing imported this one");
+
+        // The whole point of the column: the `why` it used to be read out of is
+        // the user's to rewrite, and dedup must not notice.
+        let edited = update(
+            &conn,
+            &routed.id,
+            &ItemPatch {
+                why: Some("Because three people asked".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            edited.issue_url.as_deref(),
+            Some("https://github.com/o/r/issues/7"),
+            "an edited rationale is still the same issue"
+        );
+        // And there is no way to patch it: `ItemPatch` has no such field, so a
+        // wire patch naming it changes nothing.
+        let patch: ItemPatch = serde_json::from_str(r#"{"issue_url": "https://evil/1"}"#).unwrap();
+        let after = update(&conn, &routed.id, &patch).unwrap().unwrap();
+        assert_eq!(
+            after.issue_url.as_deref(),
+            Some("https://github.com/o/r/issues/7"),
+            "provenance is not editable"
+        );
+        assert_eq!(list(&conn, &p).unwrap().len(), 2);
+    }
+
+    /// The other half of the routing record: a refusal, which has to outlive the
+    /// row it was expressed on.
+    #[test]
+    fn a_declined_issue_is_remembered_once_per_project() {
+        let conn = test_conn();
+        let a = project(&conn, "pa", "alpha");
+        let b = project(&conn, "pb", "beta");
+        let url = "https://github.com/o/r/issues/7";
+
+        decline_issue(&conn, &a, url).unwrap();
+        // Idempotent — declining twice is one entry, not two.
+        decline_issue(&conn, &a, url).unwrap();
+        decline_issue(&conn, &a, "https://github.com/o/r/issues/9").unwrap();
+        // Per project: the same origin repo pinned in two projects means routing
+        // (and refusing) in one says nothing about the other.
+        assert!(declined_issues(&conn, &b).unwrap().is_empty());
+        assert_eq!(
+            declined_issues(&conn, &a).unwrap(),
+            vec![
+                url.to_string(),
+                "https://github.com/o/r/issues/9".to_string()
+            ]
+        );
+
+        // Stored as a JSON array under the shared key, which is how the frontend
+        // reads it (`getProjectSettings`) — no command of its own.
+        let raw: String = conn
+            .query_row(
+                "SELECT value FROM project_settings WHERE project_id = 'pa' AND key = ?1",
+                [DECLINED_ISSUES_KEY],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(raw.starts_with('['), "{raw}");
+        assert!(raw.contains(url));
+
+        // A corrupt value costs the dedup, never a panic.
+        conn.execute(
+            "UPDATE project_settings SET value = 'not json' WHERE project_id = 'pa'",
+            [],
+        )
+        .unwrap();
+        assert!(declined_issues(&conn, &a).unwrap().is_empty());
+        decline_issue(&conn, &a, url).unwrap();
+        assert_eq!(declined_issues(&conn, &a).unwrap(), vec![url.to_string()]);
+    }
+
+    /// 0036 is a plain `ADD COLUMN`, so the rows a shipped install already holds
+    /// must cross it untouched — no rebuild, no cascade, and the new column
+    /// reading NULL rather than absent.
+    #[test]
+    fn the_issue_url_migration_leaves_existing_rows_alone() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        // Everything up to and including 0035 — pinned by count for the same
+        // reason the rank backfill test pins its own: a later migration must not
+        // quietly change which schema this rebuilds.
+        const BEFORE_ISSUE_URL: usize = 35;
+        Migrations::new(
+            crate::database::MIGRATIONS[..BEFORE_ISSUE_URL]
+                .iter()
+                .map(|&sql| M::up(sql))
+                .collect(),
+        )
+        .to_latest(&mut conn)
+        .unwrap();
+        conn.execute_batch(
+            "INSERT INTO projects (id, name, created_at) VALUES ('p1', 'one', 0);
+             INSERT INTO roadmap_items (id, project_id, code, title, why, horizon, status,
+                                        rank, created_at, updated_at) VALUES
+               ('old', 'p1', 'ONE-100', 'from before',
+                'https://github.com/o/r/issues/1\nrouted the old way',
+                'later', 'proposed', 1.0, 10, 10);",
+        )
+        .unwrap();
+
+        get_migrations().to_latest(&mut conn).unwrap();
+
+        let rows = list(&conn, "p1").unwrap();
+        assert_eq!(rows.len(), 1, "the row survived the migration");
+        assert_eq!(rows[0].code, "ONE-100");
+        assert_eq!(
+            rows[0].issue_url, None,
+            "not backfilled — the legacy URL stays in the `why`, where the \
+             frontend's fallback reader finds it"
+        );
+        assert!(rows[0].why.starts_with("https://github.com/o/r/issues/1"));
+        // And the column really is there to write.
+        decline_issue(&conn, "p1", "https://github.com/o/r/issues/1").unwrap();
+        let fresh = create(
+            &conn,
+            "p1",
+            &NewItem {
+                title: "new import".into(),
+                issue_url: Some("https://github.com/o/r/issues/2".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            fresh.issue_url.as_deref(),
+            Some("https://github.com/o/r/issues/2")
+        );
     }
 
     #[test]

--- a/src-tauri/src/roadmap/types.rs
+++ b/src-tauri/src/roadmap/types.rs
@@ -108,6 +108,18 @@ pub struct RoadmapItem {
     /// exactly when `hold_reason` is.
     pub held_by: Option<super::events::EventActor>,
     pub held_at: Option<i64>,
+    /// The tracker issue this row was routed from, or `None` for a row nobody
+    /// imported (migration 0036). The issue funnel's dedup key: "is this issue
+    /// already on that board?" is answered by matching this column, *not* by
+    /// parsing the `why` — which is prose the user and the PM both edit, and
+    /// which used to carry the URL on its first line as a de-facto key.
+    ///
+    /// Written once, at creation, by the funnel's `roadmap_create_item` call.
+    /// Deliberately absent from [`ItemPatch`] and from the PM's
+    /// [`super::proposals::ProposalPatch`]: where a row came from is a fact, not
+    /// a field — nothing that edits an item should be able to make it claim a
+    /// different origin, or claim one at all.
+    pub issue_url: Option<String>,
     pub created_at: i64,
     pub updated_at: i64,
 }
@@ -116,7 +128,7 @@ pub struct RoadmapItem {
 /// queries can't disagree about what is available.
 pub(crate) const COLUMNS: &str = "id, project_id, code, title, why, horizon, status, \
      rank, area, source, accept_json, deps_json, agent_id, workflow_def_id, run_id, \
-     pr_url, pr_number, hold_reason, held_by, held_at, created_at, updated_at";
+     pr_url, pr_number, hold_reason, held_by, held_at, issue_url, created_at, updated_at";
 
 impl RoadmapItem {
     pub fn from_row(r: &Row) -> rusqlite::Result<Self> {
@@ -141,6 +153,7 @@ impl RoadmapItem {
             hold_reason: r.get("hold_reason")?,
             held_by: opt_enum_col(r, "held_by", super::events::EventActor::from_db)?,
             held_at: r.get("held_at")?,
+            issue_url: r.get("issue_url")?,
             created_at: r.get("created_at")?,
             updated_at: r.get("updated_at")?,
         })
@@ -184,6 +197,17 @@ pub struct NewItem {
     /// the item form can create and assign in one round-trip.
     #[serde(default)]
     pub workflow_def_id: Option<String>,
+    /// The tracker issue this row is being routed from — the issue funnel's
+    /// field, and the only writer of [`RoadmapItem::issue_url`]. Accepted at
+    /// creation because "where did this come from" is settled the moment the row
+    /// exists and never afterwards.
+    ///
+    /// Not reachable from the PM: `roadmap_propose` builds its `NewItem`s from
+    /// its own `ProposedItem` (`rpc::roadmap`), which has no such field and
+    /// rejects unknown ones. An agent cannot make a row it invented claim to be
+    /// somebody's GitHub issue.
+    #[serde(default)]
+    pub issue_url: Option<String>,
 }
 
 /// A partial update. An absent field is left alone; an explicit `null` on a

--- a/src-tauri/src/rpc/roadmap.rs
+++ b/src-tauri/src/rpc/roadmap.rs
@@ -513,6 +513,13 @@ fn validate(items: &[ProposedItem], existing: &[RoadmapItem]) -> Result<Vec<NewI
             // Which workflow builds it is the user's call, not the PM's — a
             // proposal isn't work anyone has agreed to do yet.
             workflow_def_id: None,
+            // Where a row came from is a fact about its provenance, and the only
+            // producer of one is the issue funnel's own create call. `source: pm`
+            // above is already this item's honest origin; letting the agent name a
+            // tracker URL here would let it dress an invention up as somebody's
+            // filed issue — and would collide with the funnel's dedup key.
+            // `ProposedItem` has no such field, so this is the whole exclusion.
+            issue_url: None,
         });
     }
     // The deps of the whole batch at once, because that is the only scope an

--- a/src/api/types/roadmap.ts
+++ b/src/api/types/roadmap.ts
@@ -61,6 +61,17 @@ export interface RoadmapItem {
    *  exactly when `hold_reason` is. */
   held_by: RoadmapEventActor | null;
   held_at: number | null;
+  /** The tracker issue this row was routed from, or null for a row nobody
+   *  imported (migration 0036).
+   *
+   *  The issue funnel's dedup key — "is this issue already on that board?" is
+   *  answered by matching this field. It used to be answered by parsing the
+   *  `why`'s first line, which made a key out of prose the user and the PM both
+   *  edit: retitling the rationale re-offered the issue and one click stacked a
+   *  second ghost. Set once, by the funnel's create call; not patchable and not
+   *  reachable from the PM, because where a row came from is a fact rather than a
+   *  field. */
+  issue_url: string | null;
   created_at: number;
   updated_at: number;
 }
@@ -130,6 +141,10 @@ export interface NewRoadmapItem {
   /** Workflow this item is dispatched under when queued. Omitted (or null)
    *  means "the project's default at dispatch time". */
   workflow_def_id?: string | null;
+  /** The tracker issue this row is being routed from — the issue funnel's field
+   *  and the only writer of [`RoadmapItem.issue_url`]. Settable only here,
+   *  because provenance is decided when the row is created and never after. */
+  issue_url?: string | null;
 }
 
 /** Why a queued item isn't moving, as the drainer sees it

--- a/src/components/ProjectScreen/Roadmap/Board/DecisionBar.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/DecisionBar.tsx
@@ -70,3 +70,56 @@ export function DecisionBar({
     </div>
   );
 }
+
+/** The *board*-scoped ruling's buttons: the batch of proposals above the horizon
+ *  groups, and the PM's whole-board order ask.
+ *
+ *  Actions only, deliberately — where a card's bar is one fixed row (headline,
+ *  rationale, buttons), a board bar's left half differs per caller: the batch bar
+ *  carries a count and a hint, the order bar carries a collapsible numbered
+ *  sequence. What they share is the trio on the right, which both used to
+ *  hand-roll — three near-identical copies of markup [`DecisionBar`] exists to
+ *  own, drifting one button at a time. This is that markup's one home for them.
+ *
+ *  Drawn with the board bars' own classes (`rm-props-*`) rather than the card
+ *  bar's `Button`s: a board-level bar is an accent band across the column, and the
+ *  two vocabularies are a deliberate visual distinction between "this row" and
+ *  "this board". Any action may be absent — a read-only board hands none, and a
+ *  caller with nothing to offer shouldn't render a bar at all. */
+export function BoardRulingActions({
+  acceptLabel = "Accept",
+  queueLabel,
+  declineLabel = "Decline",
+  onAccept,
+  onAcceptQueue,
+  onDecline,
+}: {
+  acceptLabel?: string;
+  /** Label for the second accept, when the caller has one — see
+   *  [`DecisionBar`]'s `onAcceptQueue`. */
+  queueLabel?: string | null;
+  declineLabel?: string;
+  onAccept?: () => void;
+  onAcceptQueue?: () => void;
+  onDecline?: () => void;
+}) {
+  return (
+    <>
+      {onDecline && (
+        <button type="button" className="rm-props-x" onClick={onDecline}>
+          {declineLabel}
+        </button>
+      )}
+      {onAcceptQueue && queueLabel && (
+        <button type="button" className="rm-props-q iflex-center" onClick={onAcceptQueue}>
+          <Icon name="zap" size={11} /> {queueLabel}
+        </button>
+      )}
+      {onAccept && (
+        <button type="button" className="rm-props-ok iflex-center" onClick={onAccept}>
+          <Icon name="check" size={11} /> {acceptLabel}
+        </button>
+      )}
+    </>
+  );
+}

--- a/src/components/ProjectScreen/Roadmap/Board/ItemCard.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/ItemCard.tsx
@@ -15,6 +15,7 @@ import { formatAge } from "@/util/format";
 import { pausedLabel } from "@/workflows/run/status";
 import { EVENT_LABEL, eventDetailUrl, eventLine } from "../itemHistory";
 import { buildProposalDiff, isEmptyDiff } from "../proposalDiff";
+import { cardRuling } from "../ruling";
 import type { BoardItem, ItemSource, ItemStatus } from "../types";
 import { reviewGate } from "../useItemReviews";
 import { DecisionBar } from "./DecisionBar";
@@ -60,27 +61,28 @@ interface Props {
   ghost?: boolean;
   open: boolean;
   onToggle: () => void;
-  /** Accept the proposal (`proposed → open`). Ghosts only, and not read-only.
-   *  Where it lands is the project's business, not this card's: with autoqueue on
-   *  it queues (which is why `acceptLabel` changes), and a hold leaves it `open`. */
+  /** Say yes to whatever this row has pending — admit the ghost, apply the PM's
+   *  ask, or (a revised ghost) both, in that order. Which of those it is comes
+   *  from `cardRuling`, and the board binds the matching mutation; absent on a
+   *  read-only board. Where an admission *lands* is the project's business, not
+   *  this card's: with autoqueue on it queues (which is why `acceptLabel`
+   *  changes), and a hold leaves it `open`. */
   onAccept?: () => void;
-  /** Accept *and* queue in one click. Passed only while autoqueue is off — with it
-   *  on, `onAccept` already does this. */
+  /** Accept *and* queue in one click. Passed only for a ruling that admits a row,
+   *  and only while autoqueue is off — with it on, `onAccept` already does this. */
   onAcceptQueue?: () => void;
   /** What the two accepts say, from `acceptActions` — so the words the board uses
    *  and the words this card uses are computed once. */
   acceptLabel?: string;
   queueLabel?: string | null;
-  /** Discard the proposal — the row is deleted. Ghosts only. */
+  /** Say no: discard the ghost, or decline the ask and leave the row alone. Same
+   *  one-bar/one-pair shape as `onAccept`. */
   onDiscard?: () => void;
   /** The PM's pending ask against this row — a change or a discard the user
-   *  hasn't ruled on. Drawn as an always-visible bar (the ghost bar's grammar)
-   *  plus, for a change, a per-field diff in the expanded body. */
+   *  hasn't ruled on. Folded into this card's single ruling (see `cardRuling`),
+   *  and, for a change the ruling can apply, drawn as a per-field diff in the
+   *  expanded body. */
   proposal?: RoadmapProposal;
-  /** Apply the pending ask. Absent on a read-only board. */
-  onAcceptProposal?: () => void;
-  /** Decline it — the item stays as it is, the refusal lands in history. */
-  onRejectProposal?: () => void;
   /** Hand the item to the queue (`open → queued`). Absent for a ghost and on a
    *  read-only board. */
   onQueue?: () => void;
@@ -170,8 +172,6 @@ export function ItemCard({
   queueLabel,
   onDiscard,
   proposal,
-  onAcceptProposal,
-  onRejectProposal,
   onQueue,
   onUnqueue,
   onReclaim,
@@ -216,10 +216,15 @@ export function ItemCard({
   const paused = run?.status === "paused" ? run.paused_reason : null;
   const source = SOURCE[item.source];
   const state = STATE[item.status];
+  /** The single question this card is asking, if any — one answer for the bar and
+   *  the diff (and, board-side, for the batch count). */
+  const ruling = cardRuling(!!ghost, proposal ?? null);
   const cls = [
     "rm-item",
     ghost ? "ghost" : "",
-    proposal ? "prop" : "",
+    // A revised ghost is drawn as a ghost, not as both: the row isn't on the
+    // roadmap yet, which is the louder of the two facts.
+    ruling.kind === "ask" ? "prop" : "",
     open ? "open" : "",
     landed ? "landed" : "",
     focused ? "focus" : "",
@@ -289,36 +294,24 @@ export function ItemCard({
         <Icon name="chevD" size={11} className="rm-chev" />
       </button>
 
-      {/* The two buttons that decide a proposal's fate. Outside the header
-          button (no nesting) and outside the collapsible body, so ruling on a
-          ghost never costs an expand — reading it first is what the expand is
-          for. */}
-      {ghost && (onAccept || onDiscard) && (
+      {/* The one bar that decides everything pending on this row. Outside the
+          header button (no nesting) and outside the collapsible body, so ruling
+          never costs an expand — reading it first is what the expand is for.
+          Which question it asks is `cardRuling`'s call, not this component's: a
+          ghost carrying a PM ask is ONE ruling ("accept the revised item"), not
+          two stacked Accepts meaning different things, and the same answer drives
+          the diff below and the batch bar's count. */}
+      {ruling.kind !== "none" && (onAccept || onDiscard) && (
         <DecisionBar
-          label="Proposed — not on the roadmap yet"
+          variant={ruling.variant}
+          label={ruling.label}
+          note={ruling.proposal?.note}
           acceptLabel={acceptLabel}
           queueLabel={queueLabel}
-          declineLabel="Discard"
+          declineLabel={ruling.declineLabel}
           onAccept={onAccept}
           onAcceptQueue={onAcceptQueue}
           onDecline={onDiscard}
-        />
-      )}
-
-      {/* The PM's pending ask against this row — the same bar for a delta
-          instead of a new ticket: always visible, ruled on without an expand.
-          The expanded body carries the per-field diff. Never rendered on a
-          ghost: two stacked bars whose Accepts mean different things ("put it
-          on the board" vs "apply the patch") is a coin-flip for the user —
-          rule on the ghost first, the ask stays pending. */}
-      {proposal && !ghost && (onAcceptProposal || onRejectProposal) && (
-        <DecisionBar
-          variant="prop"
-          label={proposal.kind === "discard" ? "PM proposes discarding" : "PM proposes changes"}
-          note={proposal.note}
-          declineLabel="Decline"
-          onAccept={onAcceptProposal}
-          onDecline={onRejectProposal}
         />
       )}
 
@@ -400,9 +393,11 @@ export function ItemCard({
       {open && (
         <div className="rm-item-body">
           {/* The pending change, first: the reader came to rule on it, and the
-              unchanged body below is the context, not the news. */}
-          {proposal?.kind === "update" && proposal.patch && (
-            <ProposalDiff item={item.item} patch={proposal.patch} />
+              unchanged body below is the context, not the news. Gated on the
+              *ruling*, not merely on a patch existing — a diff the bar above
+              cannot act on is what made a revised ghost unrulable. */}
+          {ruling.showsDiff && ruling.proposal?.patch && (
+            <ProposalDiff item={item.item} patch={ruling.proposal.patch} />
           )}
           {item.why && <p className="rm-why text-sm">{item.why}</p>}
           {item.accept && (

--- a/src/components/ProjectScreen/Roadmap/Board/OrderProposalBar.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/OrderProposalBar.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { RoadmapItem, RoadmapOrderProposal } from "@/api";
 import { Icon } from "@/components/Icon";
+import { BoardRulingActions } from "./DecisionBar";
 
 /** One line of the proposed sequence: where the item would sit, what it is, and
  *  whether that is a change. */
@@ -73,16 +74,9 @@ export function OrderProposalBar({
           <Icon name="chevD" size={9} className="rm-order-chev" />
         </button>
         <span className="grow" />
-        {onDecline && (
-          <button type="button" className="rm-props-x" onClick={onDecline}>
-            Decline
-          </button>
-        )}
-        {onAccept && (
-          <button type="button" className="rm-props-ok iflex-center" onClick={onAccept}>
-            <Icon name="check" size={11} /> Accept
-          </button>
-        )}
+        {/* The ruling trio lives in DecisionBar.tsx, with the batch bar's — this
+            bar's own contribution is the sequence, not the buttons. */}
+        <BoardRulingActions onAccept={onAccept} onDecline={onDecline} />
       </div>
       {open && (
         <ol className="rm-order-list text-xs">

--- a/src/components/ProjectScreen/Roadmap/Board/index.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/index.tsx
@@ -8,9 +8,11 @@ import { AUTOQUEUE_KEY, acceptActions, flagOn } from "../autonomy";
 import { InFlightRail } from "../InFlightRail";
 import { buildInFlight } from "../InFlightRail/select";
 import { NeedsYou } from "../NeedsYou";
+import { cardRuling, pendingDeltas, pendingElsewhere } from "../ruling";
 import { HORIZONS } from "../types";
 import { reviewGate } from "../useItemReviews";
 import type { RoadmapState } from "../useRoadmap";
+import { BoardRulingActions } from "./DecisionBar";
 import { EmptyBoard } from "./EmptyBoard";
 import { HorizonGroup } from "./HorizonGroup";
 import { ItemCard } from "./ItemCard";
@@ -56,7 +58,7 @@ export function Board({
     openCodes,
     toggleItem,
     focusCode,
-    focusItem,
+    revealItem,
     needsYou,
     landed,
     loading,
@@ -72,8 +74,7 @@ export function Board({
     addItem,
     editItem,
     removeItems,
-    acceptItems,
-    acceptProposals,
+    acceptDeltas,
     rejectProposals,
     acceptOrder,
     rejectOrder,
@@ -166,13 +167,23 @@ export function Board({
   const cardAccept = acceptActions(autoqueue, "Accept");
   const batchAccept = acceptActions(autoqueue, "Accept all");
 
-  /** The PM's asks against admitted rows only. An ask targeting a row that is
-   *  itself still a ghost stays out of the batch bar — its card shows no bar
-   *  either (see ItemCard), so the count and the buttons agree. */
-  const asks = useMemo(() => {
-    const ghostIds = new Set(ghosts.map((g) => g.item.id));
-    return [...proposals.values()].filter((p) => !ghostIds.has(p.item_id));
-  }, [ghosts, proposals]);
+  /** Everything this board owes the user a ruling on, by kind — the batch bar's
+   *  count and copy, and the Product-brief tab's dot. Pure, and tested, because
+   *  three surfaces read it and they used to each count a different subset: the
+   *  bar added up ghosts and asks-on-admitted-rows (two of the four pending kinds,
+   *  dropping an ask against a ghost entirely), while the tab dot answered its own
+   *  question separately. See ruling.ts. */
+  const deltas = useMemo(
+    () =>
+      pendingDeltas({
+        ghostIds: ghosts.map((g) => g.item.id),
+        asks: [...proposals.values()],
+        orderProposal,
+        briefProposal,
+      }),
+    [ghosts, proposals, orderProposal, briefProposal],
+  );
+  const ghostIds = useMemo(() => ghosts.map((g) => g.item.id), [ghosts]);
   const openNew = (horizon: Horizon) => setEditing({ item: null, horizon });
 
   // Only the width is set inline. The stylesheet's min/max stay in force, so a
@@ -199,7 +210,7 @@ export function Board({
             onClick={() => setTab("brief")}
           >
             <Icon name="notebookPen" size={13} /> Product brief
-            {briefProposal && <span className="rm-tab-dot" aria-label="1 pending change" />}
+            {deltas.brief > 0 && <span className="rm-tab-dot" aria-label="1 pending change" />}
           </button>
         </div>
         <span className="grow" />
@@ -251,7 +262,7 @@ export function Board({
       {tab === "roadmap" && (
         <NeedsYou
           cards={needsYou}
-          onFocusItem={focusItem}
+          onFocusItem={revealItem}
           onOpenRun={openRun}
           onReleaseItem={readOnly ? undefined : releaseItem}
           onReleaseProject={readOnly ? undefined : releaseProject}
@@ -265,7 +276,7 @@ export function Board({
           answer different questions: what you have to do about it, and where it
           sits. Decisions come first because an item that stopped moving outranks
           one that hasn't, and the rail renders nothing when the pipeline is idle. */}
-      {tab === "roadmap" && <InFlightRail entries={inFlight} onFocusItem={focusItem} />}
+      {tab === "roadmap" && <InFlightRail entries={inFlight} onFocusItem={revealItem} />}
 
       {/* The whole board is stopped. Below the strip (which already carries a
           card for it, with the same one-click release) because this band is the
@@ -281,61 +292,40 @@ export function Board({
       {/* One proposal is ruled on from its own card; a batch gets a single bar,
           so accepting six tickets isn't six trips down the board. It sits above
           the scroller rather than inside it — the ghosts and pending changes it
-          acts on can be in three different horizons. Accept-all rules both:
-          ghost rows join the roadmap, pending changes are applied. An ask
-          against a row that is itself still a ghost is neither counted nor
-          bulk-ruled — its card shows no bar for it (rule on the ghost first),
-          and bulk-applying a patch to a ticket the user hasn't admitted would
-          rule two questions with one click. */}
-      {tab === "roadmap" && ghosts.length + asks.length > 1 && (
+          acts on can be in three different horizons. Accept-all rules both, in
+          the order the backend needs: ghost rows join the roadmap, then pending
+          changes are applied (see `acceptDeltas`) — which is what makes an ask
+          against a still-ghost row bulk-rulable rather than something the bar has
+          to pretend isn't there. Discard-all is not symmetrical, and can't be: a
+          discarded ghost takes its ask with it (the row is deleted and the ask
+          cascades), so only asks on rows that survive are declined by name. */}
+      {tab === "roadmap" && deltas.batch > 1 && (
         <div className="rm-props flex-center text-xs">
           <span className="rm-props-n iflex-center mono">
             <Icon name="sparkle" size={11} />
-            {ghosts.length + asks.length} proposed
+            {deltas.batch} proposed
           </span>
           <span className="rm-props-hint truncate">
             Nothing is on the roadmap until you say so.
+            {deltas.batch < deltas.total ? ` ${pendingElsewhere(deltas)}` : ""}
           </span>
           <span className="grow" />
-          <button
-            type="button"
-            className="rm-props-x"
-            onClick={() => {
-              if (ghosts.length) void removeItems(ghosts.map((g) => g.item.id));
-              if (asks.length) void rejectProposals(asks.map((p) => p.id));
+          <BoardRulingActions
+            declineLabel="Discard all"
+            acceptLabel={batchAccept.primary}
+            // The batch's one-click queue, on the same terms as a card's: offered
+            // only while the dial is off, and only when there is a ghost to queue
+            // — a bar counting nothing but pending *changes* has nothing to hand
+            // the drainer (an accepted patch doesn't move a status).
+            queueLabel={deltas.ghosts > 0 ? batchAccept.queue : null}
+            onDecline={() => {
+              if (deltas.ghosts) void removeItems(ghostIds);
+              if (deltas.declinableAskIds.length)
+                void rejectProposals([...deltas.declinableAskIds]);
             }}
-          >
-            Discard all
-          </button>
-          {/* The batch's one-click queue, on the same terms as a card's: offered
-              only while the dial is off, and only when there is a ghost to queue
-              — a bar counting nothing but pending *changes* has nothing to hand
-              the drainer (an accepted patch doesn't move a status). */}
-          {batchAccept.queue && ghosts.length > 0 && (
-            <button
-              type="button"
-              className="rm-props-q iflex-center"
-              onClick={() => {
-                void acceptItems(
-                  ghosts.map((g) => g.item.id),
-                  true,
-                );
-                if (asks.length) void acceptProposals(asks.map((p) => p.id));
-              }}
-            >
-              <Icon name="zap" size={11} /> {batchAccept.queue}
-            </button>
-          )}
-          <button
-            type="button"
-            className="rm-props-ok iflex-center"
-            onClick={() => {
-              if (ghosts.length) void acceptItems(ghosts.map((g) => g.item.id));
-              if (asks.length) void acceptProposals(asks.map((p) => p.id));
-            }}
-          >
-            <Icon name="check" size={11} /> {batchAccept.primary}
-          </button>
+            onAcceptQueue={() => void acceptDeltas(ghostIds, deltas.askIds, true)}
+            onAccept={() => void acceptDeltas(ghostIds, deltas.askIds)}
+          />
         </div>
       )}
 
@@ -386,6 +376,11 @@ export function Board({
                   const ghost = it.status === "proposed";
                   /** The PM's pending ask against this row, if any. */
                   const proposal = proposals.get(row.id);
+                  /** The single question this card asks. The card computes the
+                   *  same answer for its bar and its diff; this side of it is what
+                   *  binds the mutation each ruling means, so the words and the
+                   *  write can't disagree. */
+                  const ruling = cardRuling(ghost, proposal ?? null);
                   // The queue owns everything from `queued` on: an `active`
                   // row is the drainer's, and the user's lever on it is the
                   // run, not the row. `in_review` keeps one manual lever —
@@ -423,27 +418,48 @@ export function Board({
                           ? undefined
                           : () => setEditing({ item: row, horizon: row.horizon })
                       }
-                      onAccept={ghost && !readOnly ? () => acceptItems([row.id]) : undefined}
-                      acceptLabel={cardAccept.primary}
+                      onAccept={
+                        // One accept per card, whatever is pending on it: admit the
+                        // ghost, apply the ask, or — a revised ghost — both, in that
+                        // order. `acceptDeltas` owns the sequencing.
+                        ruling.kind === "none" || readOnly
+                          ? undefined
+                          : () =>
+                              acceptDeltas(
+                                ruling.admits ? [row.id] : [],
+                                ruling.appliesPatch && ruling.proposal ? [ruling.proposal.id] : [],
+                              )
+                      }
+                      // The ghost accept's wording is the project's autoqueue dial's
+                      // business; a patch-only ruling just says "Accept".
+                      acceptLabel={ruling.admits ? cardAccept.primary : "Accept"}
                       queueLabel={cardAccept.queue}
                       onAcceptQueue={
-                        // Ghost rows only, and only while the dial is off: with it
-                        // on the primary Accept already queues (and says so). A
-                        // pending *proposal*'s bar never gets this — accepting a
-                        // patch changes a row's shape, not what the queue does
-                        // with it.
-                        ghost && !readOnly && cardAccept.queue
-                          ? () => acceptItems([row.id], true)
+                        // Only where the ruling admits a row, and only while the
+                        // dial is off: with it on the primary Accept already queues
+                        // (and says so). A pending *patch* alone never gets this —
+                        // accepting it changes a row's shape, not what the queue
+                        // does with it.
+                        ruling.admits && !readOnly && cardAccept.queue
+                          ? () =>
+                              acceptDeltas(
+                                [row.id],
+                                ruling.appliesPatch && ruling.proposal ? [ruling.proposal.id] : [],
+                                true,
+                              )
                           : undefined
                       }
-                      onDiscard={ghost && !readOnly ? () => removeItems([row.id]) : undefined}
+                      onDiscard={
+                        // The mirror image: discarding a ghost deletes the row (and
+                        // cascades any ask on it), declining a patch leaves the row
+                        // exactly as it is.
+                        ruling.kind === "none" || readOnly
+                          ? undefined
+                          : ruling.declineRemovesRow
+                            ? () => removeItems([row.id])
+                            : () => rejectProposals(ruling.proposal ? [ruling.proposal.id] : [])
+                      }
                       proposal={proposal}
-                      onAcceptProposal={
-                        proposal && !readOnly ? () => acceptProposals([proposal.id]) : undefined
-                      }
-                      onRejectProposal={
-                        proposal && !readOnly ? () => rejectProposals([proposal.id]) : undefined
-                      }
                       onQueue={
                         // A handed-off row already has its builder; queueing it
                         // would dispatch a second one. The drainer refuses such

--- a/src/components/ProjectScreen/Roadmap/InFlightRail/select.test.ts
+++ b/src/components/ProjectScreen/Roadmap/InFlightRail/select.test.ts
@@ -25,6 +25,7 @@ function item(over: Partial<RoadmapItem> & { id: string }): RoadmapItem {
     hold_reason: null,
     held_by: null,
     held_at: null,
+    issue_url: null,
     created_at: 0,
     updated_at: 0,
     ...over,

--- a/src/components/ProjectScreen/Roadmap/NeedsYou/select.test.ts
+++ b/src/components/ProjectScreen/Roadmap/NeedsYou/select.test.ts
@@ -31,6 +31,7 @@ function item(over: Partial<RoadmapItem> & { id: string }): RoadmapItem {
     hold_reason: null,
     held_by: null,
     held_at: null,
+    issue_url: null,
     created_at: 0,
     updated_at: 0,
     ...over,

--- a/src/components/ProjectScreen/Roadmap/proposalDiff.test.ts
+++ b/src/components/ProjectScreen/Roadmap/proposalDiff.test.ts
@@ -24,6 +24,7 @@ function item(over: Partial<RoadmapItem> = {}): RoadmapItem {
     hold_reason: null,
     held_by: null,
     held_at: null,
+    issue_url: null,
     created_at: 0,
     updated_at: 0,
     ...over,

--- a/src/components/ProjectScreen/Roadmap/reveal.test.ts
+++ b/src/components/ProjectScreen/Roadmap/reveal.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { revealRefusal, revealTarget } from "./reveal";
+
+const rows = [
+  { code: "FLT-100", status: "open" },
+  { code: "FLT-101", status: "proposed" },
+  { code: "FLT-102", status: "active" },
+  { code: "FLT-103", status: "done" },
+];
+
+describe("revealTarget", () => {
+  it("sends every row the board draws to the board", () => {
+    for (const code of ["FLT-100", "FLT-101", "FLT-102"]) {
+      expect(revealTarget(code, rows)).toEqual({ kind: "board", code });
+    }
+  });
+
+  // The defect this exists for: the board renders `status !== done`, so a chip
+  // for a shipped item used to focus nothing at all — and the standup digest's
+  // subject *is* shipped items.
+  it("sends a shipped row to where it lives instead of to the board", () => {
+    expect(revealTarget("FLT-103", rows)).toEqual({ kind: "shipped", code: "FLT-103" });
+  });
+
+  it("refuses a code this board has never held", () => {
+    expect(revealTarget("FLT-999", rows)).toEqual({ kind: "unknown", code: "FLT-999" });
+    expect(revealTarget("OTH-100", rows)).toEqual({ kind: "unknown", code: "OTH-100" });
+    expect(revealTarget("FLT-100", [])).toEqual({ kind: "unknown", code: "FLT-100" });
+  });
+});
+
+describe("revealRefusal", () => {
+  it("only speaks up when there is nowhere to go", () => {
+    expect(revealRefusal({ kind: "board", code: "FLT-100" })).toBeNull();
+    expect(revealRefusal({ kind: "shipped", code: "FLT-103" })).toBeNull();
+    expect(revealRefusal({ kind: "unknown", code: "FLT-999" })).toContain("FLT-999");
+  });
+});

--- a/src/components/ProjectScreen/Roadmap/reveal.ts
+++ b/src/components/ProjectScreen/Roadmap/reveal.ts
@@ -1,0 +1,47 @@
+// Where a roadmap code goes when something asks to be shown it.
+//
+// Codes are addresses. The PM quotes them in chat, the standup digest quotes them,
+// a run's monitor carries one, and every one of those is rendered as something to
+// click. Until now "click" meant one thing — focus the row on the board — and the
+// board does not render every row: a shipped item leaves it entirely. So a chip
+// for a done item was a dead click, and the standup digest, whose whole subject is
+// what shipped, manufactured them by the handful.
+//
+// The fix is to make the destination a decision rather than an assumption, in one
+// place, so every caller resolves it the same way and a code with nowhere to go is
+// a refusal the user can read instead of a click that does nothing.
+
+/** What is on the other end of a code. */
+export type RevealTarget =
+  /** A row the board draws: focus it there. */
+  | { kind: "board"; code: string }
+  /** A shipped row. It left the board, and where it lives now is the Activity
+   *  tab's record of what has been built. */
+  | { kind: "shipped"; code: string }
+  /** No such code on this project's board. A typo, another project's prefix, or a
+   *  code whose row was discarded since it was quoted — the PM's transcript is
+   *  permanent and the board is not. */
+  | { kind: "unknown"; code: string };
+
+/** Resolve a code against the board's rows.
+ *
+ *  Takes the *whole* row buffer, `done` items included, because "it shipped" and
+ *  "there is no such thing" are different answers and only the full buffer can
+ *  tell them apart. Callers that hold the filtered board set cannot ask this
+ *  question. */
+export function revealTarget(
+  code: string,
+  rows: readonly { code: string; status: string }[],
+): RevealTarget {
+  const row = rows.find((r) => r.code === code);
+  if (!row) return { kind: "unknown", code };
+  return { kind: row.status === "done" ? "shipped" : "board", code };
+}
+
+/** Why a reveal couldn't happen, for the board's error bar. Only `unknown` has
+ *  nothing to say for itself — the other two land somewhere. */
+export function revealRefusal(target: RevealTarget): string | null {
+  return target.kind === "unknown"
+    ? `${target.code} isn't on this project's roadmap — it may have been discarded.`
+    : null;
+}

--- a/src/components/ProjectScreen/Roadmap/reviewPrompt.test.ts
+++ b/src/components/ProjectScreen/Roadmap/reviewPrompt.test.ts
@@ -25,6 +25,7 @@ function item(over: Partial<RoadmapItem> = {}): RoadmapItem {
     hold_reason: null,
     held_by: null,
     held_at: null,
+    issue_url: null,
     updated_at: 0,
     ...over,
   };

--- a/src/components/ProjectScreen/Roadmap/ruling.test.ts
+++ b/src/components/ProjectScreen/Roadmap/ruling.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import type { RoadmapProposal } from "@/api";
+import { cardRuling, pendingDeltas, pendingElsewhere } from "./ruling";
+
+function ask(over: Partial<RoadmapProposal> = {}): RoadmapProposal {
+  return {
+    id: "pr-1",
+    item_id: "i-1",
+    project_id: "p1",
+    kind: "update",
+    patch: { title: "A better title" },
+    note: "clearer",
+    created_at: 0,
+    ...over,
+  };
+}
+
+describe("cardRuling", () => {
+  it("draws nothing on a plain row", () => {
+    const r = cardRuling(false, null);
+    expect(r.kind).toBe("none");
+    expect(r.label).toBe("");
+    expect(r.showsDiff).toBe(false);
+  });
+
+  it("asks for admission on a ghost", () => {
+    const r = cardRuling(true, null);
+    expect(r.kind).toBe("ghost");
+    expect(r.admits).toBe(true);
+    expect(r.appliesPatch).toBe(false);
+    expect(r.declineRemovesRow).toBe(true);
+    expect(r.variant).toBe("ghost");
+  });
+
+  it("asks for the patch on a row already on the roadmap", () => {
+    const r = cardRuling(false, ask());
+    expect(r.kind).toBe("ask");
+    expect(r.admits).toBe(false);
+    expect(r.appliesPatch).toBe(true);
+    expect(r.declineRemovesRow).toBe(false);
+    expect(r.declineLabel).toBe("Decline");
+    expect(r.variant).toBe("prop");
+  });
+
+  // The bug: a ghost carrying an ask showed the ask's *diff* with no bar able to
+  // rule it, and the batch bar dropped the ask from its count. One ruling now
+  // covers both, and the diff is rendered exactly when it can be ruled.
+  it("folds a ghost and an ask against it into one ruling", () => {
+    const r = cardRuling(true, ask());
+    expect(r.kind).toBe("revised");
+    expect(r.admits).toBe(true);
+    expect(r.appliesPatch).toBe(true);
+    expect(r.showsDiff).toBe(true);
+    expect(r.declineRemovesRow).toBe(true);
+    expect(r.declineLabel).toBe("Discard");
+    expect(r.variant).toBe("ghost");
+    expect(r.proposal?.id).toBe("pr-1");
+  });
+
+  it("never shows a diff nobody can rule", () => {
+    for (const r of [
+      cardRuling(false, null),
+      cardRuling(true, null),
+      cardRuling(false, ask({ kind: "discard", patch: null })),
+      cardRuling(true, ask({ kind: "discard", patch: null })),
+    ]) {
+      expect(r.showsDiff).toBe(false);
+    }
+    // …and shows it in exactly the two cases where a patch is on the table.
+    expect(cardRuling(false, ask()).showsDiff).toBe(true);
+    expect(cardRuling(true, ask()).showsDiff).toBe(true);
+  });
+
+  it("reads a withdrawal on a ghost as the PM taking its suggestion back", () => {
+    const r = cardRuling(true, ask({ kind: "discard", patch: null }));
+    expect(r.kind).toBe("revised");
+    expect(r.appliesPatch, "there is no patch on a discard ask").toBe(false);
+    expect(r.label).toContain("withdrawn");
+  });
+});
+
+describe("pendingDeltas", () => {
+  const order = { project_id: "p1", codes: ["FLT-100"], note: null, created_at: 0 };
+  const brief = { project_id: "p1", content: "# vision", note: null, created_at: 0 };
+
+  it("counts all four kinds, not two", () => {
+    const d = pendingDeltas({
+      ghostIds: ["g1", "g2"],
+      asks: [ask({ id: "a1", item_id: "i-1" })],
+      orderProposal: order,
+      briefProposal: brief,
+    });
+    expect(d).toMatchObject({ ghosts: 2, asks: 1, order: 1, brief: 1, total: 5, batch: 3 });
+  });
+
+  it("is empty on a board with nothing pending", () => {
+    const d = pendingDeltas({ ghostIds: [], asks: [], orderProposal: null, briefProposal: null });
+    expect(d.total).toBe(0);
+    expect(d.batch).toBe(0);
+    expect(d.askIds).toEqual([]);
+    expect(d.declinableAskIds).toEqual([]);
+  });
+
+  // The B4 half: an ask against a ghost is a real pending delta the user must
+  // rule (the backend keeps quoting it), so it counts — where the batch bar used
+  // to drop it entirely.
+  it("counts an ask against a ghost, and accepts it after the admission", () => {
+    const d = pendingDeltas({
+      ghostIds: ["g1"],
+      asks: [ask({ id: "a1", item_id: "g1" })],
+      orderProposal: null,
+      briefProposal: null,
+    });
+    expect(d.asks).toBe(1);
+    expect(d.batch, "the ghost and its revision are both owed a ruling").toBe(2);
+    expect(d.askIds).toEqual(["a1"]);
+  });
+
+  // …but it cannot be *declined* on its own: discarding the ghost deletes the row
+  // and the backend cascades the ask away with it.
+  it("keeps a ghost's ask out of the declinable set", () => {
+    const d = pendingDeltas({
+      ghostIds: ["g1"],
+      asks: [ask({ id: "a1", item_id: "g1" }), ask({ id: "a2", item_id: "i-9" })],
+      orderProposal: null,
+      briefProposal: null,
+    });
+    expect(d.askIds).toEqual(["a1", "a2"]);
+    expect(d.declinableAskIds).toEqual(["a2"]);
+  });
+
+  it("does not let the batch bar claim the board-scoped pair", () => {
+    const d = pendingDeltas({
+      ghostIds: [],
+      asks: [],
+      orderProposal: order,
+      briefProposal: brief,
+    });
+    expect(d.total).toBe(2);
+    expect(d.batch, "neither is ruled from the batch bar").toBe(0);
+  });
+});
+
+describe("pendingElsewhere", () => {
+  const base = { ghostIds: ["g1"], asks: [], orderProposal: null, briefProposal: null };
+  const order = { project_id: "p1", codes: [], note: null, created_at: 0 };
+  const brief = { project_id: "p1", content: "", note: null, created_at: 0 };
+
+  it("says nothing when the batch bar covers everything", () => {
+    expect(pendingElsewhere(pendingDeltas(base))).toBe("");
+  });
+
+  it("names the surfaces the batch buttons don't reach", () => {
+    expect(pendingElsewhere(pendingDeltas({ ...base, orderProposal: order }))).toBe(
+      "Also pending: a new order.",
+    );
+    expect(pendingElsewhere(pendingDeltas({ ...base, briefProposal: brief }))).toBe(
+      "Also pending: a brief update.",
+    );
+    expect(
+      pendingElsewhere(pendingDeltas({ ...base, orderProposal: order, briefProposal: brief })),
+    ).toBe("Also pending: a new order and a brief update.");
+  });
+});

--- a/src/components/ProjectScreen/Roadmap/ruling.ts
+++ b/src/components/ProjectScreen/Roadmap/ruling.ts
@@ -1,0 +1,193 @@
+// What the user is being asked to rule on, per card and per board — the one
+// answer the decision bar, the diff and the batch count all read.
+//
+// Two things can be pending against a single row at once: the row itself may be a
+// ghost the PM proposed and the user hasn't admitted, and there may be a *further*
+// PM ask against it (a retitle, a re-scoped `accept`, a discard). The board used to
+// disagree with itself about that combination in three places at the same time:
+// the card suppressed the ask's decision bar on a ghost (rightly — two Accepts
+// meaning different things is a coin flip) but rendered the ask's *diff*
+// regardless, and the batch bar dropped the ask from its count. The backend, for
+// its part, kept quoting the ask to the PM as pending, because it is: `is_rulable`
+// includes `proposed`. So the user saw a diff of a change with no way to rule it,
+// and a count that said there was nothing there.
+//
+// The shape that fixes it is one ruling per row. A ghost carrying an ask is not two
+// questions, it is one: "do you want the revised item?" — and accepting it admits
+// the row and then applies the patch, in that order (the row is `open` by then,
+// which is still rulable, so the patch lands). Declining it discards the ghost, and
+// the ask dies with the row (`roadmap_delete_item` reads the pending proposal, the
+// FK cascades it away, and the deletion is broadcast on both streams).
+//
+// Pure and tested so the three surfaces cannot drift apart again.
+
+import type { RoadmapProposal } from "@/api";
+
+/** Which ruling a card carries.
+ *
+ *  - `none` — nothing pending; the card is just a row.
+ *  - `ghost` — a proposed row awaiting admission.
+ *  - `revised` — a proposed row *and* a PM ask against it: one ruling.
+ *  - `ask` — a PM ask against a row that is already on the roadmap. */
+export type RulingKind = "none" | "ghost" | "revised" | "ask";
+
+export interface CardRuling {
+  kind: RulingKind;
+  /** The pending ask this ruling covers, or null. */
+  proposal: RoadmapProposal | null;
+  /** The bar's headline. Empty for `none`, which draws no bar. */
+  label: string;
+  /** What the decline button says. */
+  declineLabel: string;
+  /** How loudly the bar is drawn: `ghost` for a row that isn't on the roadmap
+   *  yet, `prop` for a delta against one that is. A revised ghost is still a
+   *  ghost — the row's admission is the bigger half of the question. */
+  variant: "ghost" | "prop";
+  /** Does accepting put the row on the roadmap (`proposed → open`)? */
+  admits: boolean;
+  /** Does accepting apply the pending patch? */
+  appliesPatch: boolean;
+  /** Does declining delete the row, rather than leaving it as it is? */
+  declineRemovesRow: boolean;
+  /** Should the expanded body show the pending patch's field-by-field diff? True
+   *  exactly when the bar above it can rule that patch — a diff the user cannot
+   *  act on is the bug this flag exists to make impossible. */
+  showsDiff: boolean;
+}
+
+const NONE: CardRuling = {
+  kind: "none",
+  proposal: null,
+  label: "",
+  declineLabel: "",
+  variant: "prop",
+  admits: false,
+  appliesPatch: false,
+  declineRemovesRow: false,
+  showsDiff: false,
+};
+
+/** The ruling for one card.
+ *
+ *  `ghost` is the row's own status question and `proposal` is the PM's ask against
+ *  it; every combination of the two has exactly one answer here. */
+export function cardRuling(ghost: boolean, proposal: RoadmapProposal | null = null): CardRuling {
+  if (ghost && proposal) {
+    return {
+      kind: "revised",
+      proposal,
+      // Named for what the user gets, not for the two writes it takes: the item
+      // as the PM would now have it. A `discard` ask on a ghost is the PM
+      // withdrawing its own suggestion, which the single Discard already does —
+      // so the accept still admits, and the patch (there is none) is a no-op.
+      label:
+        proposal.kind === "discard"
+          ? "Proposed, and the PM has since withdrawn it"
+          : "Proposed, with a revision — accept both together",
+      declineLabel: "Discard",
+      variant: "ghost",
+      admits: true,
+      appliesPatch: proposal.kind === "update",
+      declineRemovesRow: true,
+      showsDiff: proposal.kind === "update",
+    };
+  }
+  if (ghost) {
+    return {
+      kind: "ghost",
+      proposal: null,
+      label: "Proposed — not on the roadmap yet",
+      declineLabel: "Discard",
+      variant: "ghost",
+      admits: true,
+      appliesPatch: false,
+      declineRemovesRow: true,
+      showsDiff: false,
+    };
+  }
+  if (proposal) {
+    return {
+      kind: "ask",
+      proposal,
+      label: proposal.kind === "discard" ? "PM proposes discarding" : "PM proposes changes",
+      declineLabel: "Decline",
+      variant: "prop",
+      admits: false,
+      appliesPatch: true,
+      declineRemovesRow: false,
+      showsDiff: proposal.kind === "update",
+    };
+  }
+  return NONE;
+}
+
+// ─────────────────────────── the board's pending set ───────────────────────────
+
+/** Everything the user owes this board a ruling on, by kind.
+ *
+ *  Four kinds, not two. The batch bar counted ghosts and item asks and silently
+ *  ignored the board-scoped pair — the PM's whole-board order ask and its brief
+ *  update — both of which are pending deltas the user must rule, and both of which
+ *  are rendered somewhere else on the same screen. Counting two of four made the
+ *  board's one summary number wrong. */
+export interface PendingDeltas {
+  /** Every pending delta, board-scoped ones included. */
+  total: number;
+  /** Proposed rows awaiting admission. */
+  ghosts: number;
+  /** Pending per-item PM asks — ghost-targeted ones included, because a revised
+   *  ghost is one ruling that covers both. */
+  asks: number;
+  /** The whole-board order ask: 0 or 1. */
+  order: number;
+  /** The brief update: 0 or 1. */
+  brief: number;
+  /** The subset the batch bar itself can rule in one click: the card-scoped
+   *  deltas. The other two have their own surfaces (the order bar below, the
+   *  Product brief tab), so its buttons must never claim them. */
+  batch: number;
+  /** Ask ids to accept, after the ghosts are admitted — order matters: a patch
+   *  against a row nobody has accepted is refused by the same gate that lets one
+   *  through a moment later (`is_rulable`). */
+  askIds: readonly string[];
+  /** Ask ids that can be *declined* on their own. A ghost's ask is not one of
+   *  them: discarding the ghost deletes the row and cascades the ask away, so
+   *  declining it separately would be a write against a row that is about to not
+   *  exist. */
+  declinableAskIds: readonly string[];
+}
+
+export function pendingDeltas(input: {
+  /** Ids of the board's proposed rows. */
+  ghostIds: readonly string[];
+  /** Every pending per-item ask on the board. */
+  asks: readonly Pick<RoadmapProposal, "id" | "item_id">[];
+  orderProposal: unknown | null;
+  briefProposal: unknown | null;
+}): PendingDeltas {
+  const ghostIds = new Set(input.ghostIds);
+  const ghosts = ghostIds.size;
+  const asks = input.asks.length;
+  const order = input.orderProposal ? 1 : 0;
+  const brief = input.briefProposal ? 1 : 0;
+  return {
+    total: ghosts + asks + order + brief,
+    ghosts,
+    asks,
+    order,
+    brief,
+    batch: ghosts + asks,
+    askIds: input.asks.map((a) => a.id),
+    declinableAskIds: input.asks.filter((a) => !ghostIds.has(a.item_id)).map((a) => a.id),
+  };
+}
+
+/** The batch bar's one line, naming what is pending — including the two kinds its
+ *  own buttons don't rule, so the number above it and the screen around it agree.
+ *  Empty when nothing is pending elsewhere. */
+export function pendingElsewhere(d: PendingDeltas): string {
+  const parts: string[] = [];
+  if (d.order) parts.push("a new order");
+  if (d.brief) parts.push("a brief update");
+  return parts.length ? `Also pending: ${parts.join(" and ")}.` : "";
+}

--- a/src/components/ProjectScreen/Roadmap/useItemReviews.test.ts
+++ b/src/components/ProjectScreen/Roadmap/useItemReviews.test.ts
@@ -25,6 +25,7 @@ function item(over: Partial<RoadmapItem> = {}): RoadmapItem {
     hold_reason: null,
     held_by: null,
     held_at: null,
+    issue_url: null,
     updated_at: 0,
     ...over,
   };

--- a/src/components/ProjectScreen/Roadmap/useRoadmap.ts
+++ b/src/components/ProjectScreen/Roadmap/useRoadmap.ts
@@ -2,10 +2,14 @@
 // mutations every surface on this screen goes through.
 //
 // The board is persisted, per project, in `roadmap_items` (src-tauri/src/roadmap).
-// This hook loads it once for the current project and then keeps it live off the
-// `roadmap:item` / `roadmap:item-deleted` events, upserting the full row by id.
-// The load subscribes before it fetches and replays anything that arrived in
-// between (see rowSync.ts), because this board has writers other than the user.
+// The rows themselves come from `useRoadmapRows` (src/roadmapRows.ts), which
+// subscribes before it fetches and replays anything that arrived in between (see
+// rowSync.ts), because this board has writers other than the user. That hook is
+// shared: the workspace's issue inbox and a run's roadmap chip follow the same
+// stream through it, so "what is on this board" cannot mean two different things
+// on two screens. Everything else on this board — the PM's asks, the holds, the
+// brief, the history trails, the queue notes — is loaded by the effect below,
+// which applies the same discipline to six more streams.
 //
 // The PM conversation is NOT here: it is a real agent chat, owned by the Thread
 // column (see Thread/usePmChats.ts). What the two share is this contract — the
@@ -53,8 +57,6 @@ import {
   onRoadmapBrief,
   onRoadmapBriefProposal,
   onRoadmapBriefProposalDeleted,
-  onRoadmapItem,
-  onRoadmapItemDeleted,
   onRoadmapItemEvent,
   onRoadmapOrderProposal,
   onRoadmapOrderProposalDeleted,
@@ -74,11 +76,13 @@ import {
   type RoadmapProposal,
   type WfRun,
 } from "@/api";
-import { applyRowEvent, createRowSync, createSingleSync } from "@/rowSync";
+import { useRoadmapRows } from "@/roadmapRows";
+import { createRowSync, createSingleSync } from "@/rowSync";
 import { useAppStore } from "@/store";
 import { useRuns } from "@/workflows/run/useRuns";
 import { insertEvent, mergeSnapshot } from "./itemHistory";
 import { buildNeedsYou, mergeLatest, upsertLatest } from "./NeedsYou/select";
+import { revealRefusal, revealTarget } from "./reveal";
 import { reviewFeedbackPrompt } from "./reviewPrompt";
 import type { Horizon } from "./types";
 import { toBoardItem } from "./types";
@@ -129,7 +133,6 @@ export function useRoadmap(repoPath: string) {
   // of its own. Cheap: one list fetch and one subscription, both event-driven.
   const allRuns = useRuns();
 
-  const [rows, setRows] = useState<RoadmapItem[]>([]);
   /** The PM's pending asks against existing items (`roadmap:proposal` +
    *  `roadmap_list_proposals`) — at most one per item, replaced in place under
    *  a stable id. Loaded with the item snapshot through the same
@@ -154,7 +157,9 @@ export function useRoadmap(repoPath: string) {
    *  (`roadmap:brief-proposal`). Board scoped, replaced in place, ruled on from
    *  the Product brief tab. */
   const [briefProposal, setBriefProposal] = useState<RoadmapBriefProposal | null>(null);
-  const [loading, setLoading] = useState(true);
+  /** Are the six streams the effect below owns still loading? The rows have their
+   *  own answer (`rowsLoading`); the board is loading while either is. */
+  const [sideLoading, setSideLoading] = useState(true);
   /** The last failure from a mutation with no form of its own to report into
    *  (a move, a delete, an accepted proposal). */
   const [error, setError] = useState<string | null>(null);
@@ -217,40 +222,88 @@ export function useRoadmap(repoPath: string) {
     });
   }, []);
 
-  /** Upsert a row by id, appending new ones — the backend lists oldest-first
-   *  and a new row is the newest, so append keeps the two in the same order. */
-  const upsert = useCallback(
+  /** A note explains why a row isn't moving on its own. The moment the row moves,
+   *  whatever it said is history — drop it rather than leave a stale excuse under
+   *  a running item. Queued rows keep theirs: the drainer's blocked-note must
+   *  survive the row events around it. (A sweep note on an open row survives
+   *  arrival because it's emitted after the row event.) */
+  const noteStale = useCallback(
     (row: RoadmapItem) => {
-      setRows((prev) => applyRowEvent(prev, { kind: "upsert", row }));
-      // A note explains why a row isn't moving on its own. The moment the row
-      // moves, whatever it said is history — drop it rather than leave a stale
-      // excuse under a running item. Queued rows keep theirs: the drainer's
-      // blocked-note must survive the row events around it. (A sweep note on an
-      // open row survives arrival because it's emitted after the row event.)
       if (row.status !== "queued") dropNote(row.id);
     },
     [dropNote],
   );
 
-  // Load the board: subscribe first, buffer during the fetch, then replay — so a
-  // row the PM proposes while the board is loading cannot be lost. Rows change
-  // from more than this screen (the PM agent's own writes, and later the run
-  // queue), so the board follows the event rather than only its own command
-  // results; the ordering the sequencer buys us is spelled out in rowSync.ts.
+  /** Forget everything this board was holding *about* a row that has been
+   *  deleted. The backend cascades the row's history away; drop ours too, and let
+   *  a reused id (there are none, but the map shouldn't bet on that) refetch. */
+  const forgetItem = useCallback(
+    (id: string) => {
+      dropNote(id);
+      requestedEvents.current.delete(id);
+      setEvents((prev) => {
+        if (!prev.has(id)) return prev;
+        const next = new Map(prev);
+        next.delete(id);
+        return next;
+      });
+      setLatestEvents((prev) =>
+        prev.some((e) => e.item_id === id) ? prev.filter((e) => e.item_id !== id) : prev,
+      );
+    },
+    [dropNote],
+  );
+
+  // The rows, from the shared subscription (src/roadmapRows.ts). A one-project
+  // list because a board is one project's: the hook takes a set because the issue
+  // inbox follows several at once.
+  const projectIds = useMemo(() => (projectId ? [projectId] : []), [projectId]);
+  const {
+    rows,
+    load: boardLoad,
+    loading: rowsLoading,
+    error: rowsError,
+    upsert: upsertRow,
+    remove: removeRows,
+  } = useRoadmapRows(projectIds, { onRow: noteStale, onDeleted: forgetItem });
+
+  /** Fold a row a command just returned straight in — the optimistic half of a
+   *  mutation this hook already awaited. The event is coming too and says the
+   *  same thing; this is what stops the card flickering in between. */
+  const upsert = useCallback(
+    (row: RoadmapItem) => {
+      upsertRow(row);
+      noteStale(row);
+    },
+    [upsertRow, noteStale],
+  );
+
+  // A failed snapshot belongs on the board's error bar, like every other failure
+  // with nowhere else to go. Copied into the local state rather than merged at
+  // read time so "Dismiss" can actually dismiss it.
+  useEffect(() => {
+    if (rowsError) setError(rowsError);
+  }, [rowsError]);
+
+  // Load everything else this board shows: subscribe first, buffer during the
+  // fetch, then replay — so an ask the PM parks while the board is loading cannot
+  // be lost. These streams change from more than this screen (the PM agent's own
+  // writes, the run queue, the merge sweep), so the board follows the event rather
+  // than only its own command results; the ordering the sequencer buys us is
+  // spelled out in rowSync.ts.
   useEffect(() => {
     if (!projectId) {
-      setRows([]);
       setProposalRows([]);
       setOrderProposal(null);
       setProjectHold(null);
       setBrief(null);
       setBriefProposal(null);
       setLatestEvents([]);
-      setLoading(!workspaceReady);
+      setSideLoading(!workspaceReady);
       return;
     }
     let alive = true;
-    setLoading(true);
+    setSideLoading(true);
     // A new board means new trails: what the previous project's cards loaded
     // says nothing about this one's items. The generation bump is what stops an
     // already-in-flight `loadEvents` from writing the old board's history into
@@ -260,18 +313,6 @@ export function useRoadmap(repoPath: string) {
     setEvents(new Map());
     setLatestEvents([]);
 
-    // Unmounting mid-load must not write state, so every commit goes through
-    // the same `alive` gate the fetch does.
-    const sync = createRowSync<RoadmapItem>((update) => {
-      if (alive) setRows(update);
-    });
-    const off = onRoadmapItem((row) => {
-      if (row.project_id !== projectId) return;
-      sync.push({ kind: "upsert", row });
-      // Rows go through the sequencer; notes don't need to — they're a
-      // separate map, and a stale excuse should vanish even mid-load.
-      if (row.status !== "queued") dropNote(row.id);
-    });
     // The proposal stream rides its own instance of the same sequencer: the
     // same two loss windows exist for it, and a replaced ask arrives as an
     // upsert under a stable id (see rowSync.ts).
@@ -340,22 +381,6 @@ export function useRoadmap(repoPath: string) {
       if (id !== projectId) return;
       bpsync.push(null);
     });
-    const offDeleted = onRoadmapItemDeleted((id) => {
-      sync.push({ kind: "delete", id });
-      dropNote(id);
-      // The backend cascades the row's history away; drop ours too, and let a
-      // reused id (there are none, but the map shouldn't bet on that) refetch.
-      requestedEvents.current.delete(id);
-      setEvents((prev) => {
-        if (!prev.has(id)) return prev;
-        const next = new Map(prev);
-        next.delete(id);
-        return next;
-      });
-      setLatestEvents((prev) =>
-        prev.some((e) => e.item_id === id) ? prev.filter((e) => e.item_id !== id) : prev,
-      );
-    });
     // History rows, appended only to trails some card already loaded — an
     // event for a never-expanded item is dropped here and refetched whole on
     // that item's first expand, which keeps the map leak-free.
@@ -384,8 +409,6 @@ export function useRoadmap(repoPath: string) {
       // (see the drainer's `say`), so one missed during the load is not resent
       // and the card is left with no explanation at all.
       await Promise.all([
-        off,
-        offDeleted,
         offProposal,
         offProposalDeleted,
         offOrder,
@@ -405,8 +428,7 @@ export function useRoadmap(repoPath: string) {
       ]);
       if (!alive) return;
       try {
-        const [items, pending, order, latest, hold, theBrief, briefAsk] = await Promise.all([
-          api.roadmapListItems(projectId),
+        const [pending, order, latest, hold, theBrief, briefAsk] = await Promise.all([
           api.roadmapListProposals(projectId),
           api.roadmapGetOrderProposal(projectId),
           api.roadmapLatestEvents(projectId),
@@ -415,7 +437,6 @@ export function useRoadmap(repoPath: string) {
           api.roadmapGetBriefProposal(projectId),
         ]);
         if (!alive) return;
-        sync.settle(items);
         psync.settle(pending);
         // Under whatever arrived live, per item — see `mergeLatest`.
         setLatestEvents((prev) => mergeLatest(prev, latest));
@@ -423,26 +444,23 @@ export function useRoadmap(repoPath: string) {
         hsync.settle(hold);
         bsync.settle(theBrief);
         bpsync.settle(briefAsk);
-        setLoading(false);
+        setSideLoading(false);
       } catch (e) {
         if (!alive) return;
         // No snapshot to replay over — settle anyway so later events still
         // apply instead of piling up in the buffer.
-        sync.settle();
         psync.settle();
         osync.settle();
         hsync.settle();
         bsync.settle();
         bpsync.settle();
         setError(String(e));
-        setLoading(false);
+        setSideLoading(false);
       }
     })();
 
     return () => {
       alive = false;
-      void off.then((f) => f());
-      void offDeleted.then((f) => f());
       void offProposal.then((f) => f());
       void offProposalDeleted.then((f) => f());
       void offOrder.then((f) => f());
@@ -455,7 +473,20 @@ export function useRoadmap(repoPath: string) {
       void offEvent.then((f) => f());
       void offNote.then((f) => f());
     };
-  }, [projectId, workspaceReady, dropNote]);
+  }, [projectId, workspaceReady]);
+
+  /** The board's loading state: the rows *and* everything beside them. Both must
+   *  have landed before `blank` may claim there is nothing here. */
+  const loading = sideLoading || rowsLoading;
+  /** Has *this* project's row snapshot settled, either way? Distinct from
+   *  `loading`, which the six side streams also gate: a cross-screen jump has to
+   *  know whether the rows it is about to be judged against are this board's, and
+   *  on the render right after a project switch the old board's rows are still in
+   *  hand while this map already speaks about the new one. `failed` counts as
+   *  settled — a request that can never be answered must be refused, not left
+   *  pending forever. */
+  const rowsSettled =
+    projectId == null ? workspaceReady : (boardLoad.get(projectId) ?? "loading") !== "loading";
 
   /** Fetch an item's history once, on first expand. The listener above is
    *  already appending live rows for it from the moment this is called, and
@@ -530,9 +561,11 @@ export function useRoadmap(repoPath: string) {
     return by as ReadonlyMap<string, RoadmapProposal>;
   }, [proposalRows, onBoard]);
 
-  /** Every code the board holds, ghosts included — the PM quotes a code the
-   *  moment it proposes one, so a chat chip must resolve before the user has
-   *  ruled on the row.
+  /** Every code the board holds — ghosts *and* shipped items included. Ghosts
+   *  because the PM quotes a code the moment it proposes one, so a chat chip must
+   *  resolve before the user has ruled on the row; shipped items because
+   *  `revealItem` has somewhere to send them (the Activity tab), and a linkable
+   *  set is exactly the set of codes with a destination.
    *
    *  Keyed on the codes themselves rather than on `rows`: the chat re-renders
    *  every markdown block when this set's identity changes, and a retitle or a
@@ -653,14 +686,17 @@ export function useRoadmap(repoPath: string) {
   );
 
   /** Delete rows. Also how a proposal is discarded: a suggestion the user turned
-   *  down was never on the roadmap, so it leaves no trace of having been. */
+   *  down was never on the roadmap, so it leaves no trace of having been — bar one,
+   *  for a ghost the issue funnel routed: the backend records the refusal against
+   *  the issue's URL, so the inbox stops offering it (see `roadmap_delete_item`).
+   *  Any pending PM ask against the row cascades away with it. */
   const removeItems = useCallback(
     (ids: string[]) =>
       guarded(async () => {
         for (const id of ids) await api.roadmapDeleteItem(id);
-        setRows((prev) => prev.filter((r) => !ids.includes(r.id)));
+        removeRows(ids);
       }),
-    [guarded],
+    [guarded, removeRows],
   );
 
   const clearError = useCallback(() => setError(null), []);
@@ -678,22 +714,38 @@ export function useRoadmap(repoPath: string) {
     [addWorkspaceRepo, repoPath],
   );
 
-  /** Accept proposed rows: `proposed → open` is the moment a suggestion becomes
-   *  a roadmap item. The row (and its code) already exist, so nothing is
-   *  re-created and nothing is renumbered — the code the PM quoted in the chat
-   *  is the code that stays on the board. The other half of the decision is
-   *  [`removeItems`].
+  /** Say yes to pending deltas — the board's one accept, at every scale.
    *
-   *  `queue` is the "Accept & queue" click: accept and hand it to the drainer in
+   *  `ghostIds` are proposed rows to admit: `proposed → open` is the moment a
+   *  suggestion becomes a roadmap item. The row (and its code) already exist, so
+   *  nothing is re-created and nothing is renumbered — the code the PM quoted in
+   *  the chat is the code that stays on the board. `askIds` are the PM's pending
+   *  patches to apply. The other half of the decision is [`removeItems`] for a
+   *  ghost and [`rejectProposals`] for an ask.
+   *
+   *  **Admissions first, patches second, always.** A row and an ask *against that
+   *  row* can both be pending at once (the PM proposed a ticket and then revised
+   *  it), and the user rules on that pair with one click — so this is one ordered
+   *  sequence rather than two calls a caller might interleave. The order is the
+   *  meaning: the admission is the bigger question, and by the time the patch
+   *  lands the row is `open`, which the backend's `is_rulable` still allows.
+   *
+   *  A refusal in the second half leaves the first half done and the ask pending:
+   *  the item is on the roadmap, the PM's revision is still there to rule on, and
+   *  the reason is on the error bar. That is the honest outcome of "the admission
+   *  worked and the patch didn't" — and the only alternative would be to roll a
+   *  ruling back, which is not ours to undo.
+   *
+   *  `queue` is the "Accept & queue" click: admit and hand it to the drainer in
    *  one gesture. Where an accept *lands* is decided backend-side, not here — the
    *  project's autoqueue dial can queue it with `queue` unset, and a hold leaves
    *  it `open` even with `queue` set (holds trump the dial). So this reads the
    *  status off the row that comes back rather than assuming one. */
-  const acceptItems = useCallback(
-    (ids: string[], queue = false) =>
+  const acceptDeltas = useCallback(
+    (ghostIds: readonly string[], askIds: readonly string[] = [], queue = false) =>
       guarded(async () => {
         const codes: string[] = [];
-        for (const id of ids) {
+        for (const id of ghostIds) {
           // Conditional like every other status transition: accepting is only
           // meaningful on a row that is still a proposal.
           const { applied, item } = await api.roadmapUpdateItem(
@@ -706,22 +758,13 @@ export function useRoadmap(repoPath: string) {
           if (applied) codes.push(item.code);
         }
         markLanded(codes);
-      }),
-    [guarded, markLanded, upsert],
-  );
-
-  /** Apply pending PM proposals — the user's "yes" on each. The backend rules
-   *  in one lock scope per proposal: a stale ask (its item went `active` since)
-   *  is dropped there and surfaces here as the error the bar shows, while the
-   *  `roadmap:proposal-deleted` emit clears it off the card either way. */
-  const acceptProposals = useCallback(
-    (ids: string[]) =>
-      guarded(async () => {
-        // A stale ask refuses individually; it mustn't take the rest of an
-        // "Accept all" down with it, so rule on every id and report the first
-        // refusal after the fact.
+        // The backend rules in one lock scope per ask: a stale one (its item went
+        // `active` since) is dropped there and surfaces here as the error the bar
+        // shows, while the `roadmap:proposal-deleted` emit clears it off the card
+        // either way. One refusal mustn't take the rest of an "Accept all" down
+        // with it, so rule on every id and report the first after the fact.
         let refusal: unknown = null;
-        for (const id of ids) {
+        for (const id of askIds) {
           try {
             await api.roadmapAcceptProposal(id);
           } catch (e) {
@@ -730,7 +773,7 @@ export function useRoadmap(repoPath: string) {
         }
         if (refusal != null) throw refusal;
       }),
-    [guarded],
+    [guarded, markLanded, upsert],
   );
 
   /** Decline pending PM proposals. The items are untouched; each refusal lands
@@ -978,44 +1021,73 @@ export function useRoadmap(repoPath: string) {
     [loadEvents],
   );
 
-  /** Jump the board to an item: switch to the roadmap tab, expand the row,
-   *  scroll it into view (the Board's `focusCode` effect) and ring it for a
-   *  moment. Called from the PM chat's code chips, which sit beside this board,
-   *  and from the cross-screen request below. */
-  const focusItem = useCallback(
+  const setProjectScreenTab = useAppStore((s) => s.setProjectScreenTab);
+
+  /** Show the user the item a code names — wherever it actually is.
+   *
+   *  Every caller that renders a code as something clickable comes through here:
+   *  the PM chat's code chips, the "Needs you" strip, the in-flight rail, and the
+   *  cross-screen request below. They used to come through a plain board focus,
+   *  which assumed the board renders every row. It doesn't: a shipped item leaves
+   *  it entirely. So a chip for a done item was a dead click — and the standup
+   *  digest, whose whole subject is what shipped, manufactured them by the
+   *  handful.
+   *
+   *  Three destinations, decided in reveal.ts:
+   *  - a row the board draws — switch to the roadmap tab, expand it, scroll it in
+   *    (the Board's `focusCode` effect) and ring it for a moment;
+   *  - a shipped row — the Activity tab, which is where what has been built lives.
+   *    Deliberately a tab switch and nothing more: the item is a line in a record
+   *    there, not a card with a focus ring;
+   *  - no such code — a refusal on the error bar, because a click that silently
+   *    does nothing is worse than one that says why.
+   *
+   *  Returns what it did, so a caller holding a one-shot request knows it was
+   *  answered. */
+  const revealItem = useCallback(
     (code: string) => {
-      setTab("roadmap");
-      setFocusCode(code);
-      setOpenCodes((s) => new Set(s).add(code));
-      // The card lands expanded, so its trail must load exactly as if the
-      // user had expanded it by hand — otherwise the history line the caller
-      // is often pointing at ("its run failed") is invisible until a manual
-      // collapse and re-expand.
-      const row = rows.find((r) => r.code === code);
-      if (row) void loadEvents(row.id);
-      after(FOCUS_MS, () => setFocusCode(null));
+      const target = revealTarget(code, rows);
+      if (target.kind === "board") {
+        setTab("roadmap");
+        setFocusCode(code);
+        setOpenCodes((s) => new Set(s).add(code));
+        // The card lands expanded, so its trail must load exactly as if the
+        // user had expanded it by hand — otherwise the history line the caller
+        // is often pointing at ("its run failed") is invisible until a manual
+        // collapse and re-expand.
+        const row = rows.find((r) => r.code === code);
+        if (row) void loadEvents(row.id);
+        after(FOCUS_MS, () => setFocusCode(null));
+      } else if (target.kind === "shipped") {
+        setProjectScreenTab("activity");
+      } else {
+        setError(revealRefusal(target));
+      }
+      return target;
     },
-    [after, rows, loadEvents],
+    [after, rows, loadEvents, setProjectScreenTab],
   );
 
   // A jump asked for from outside this screen — a run's roadmap chip
   // (`ui.focusRoadmapItem`), which opened the project page and left the code
-  // behind. Consumed only by the board that actually holds the code, and
-  // cleared as it fires: the request is a one-shot, and a board that has just
-  // mounted for a different project must not swallow it.
+  // behind. Consumed **or refused**, never left pending: the request used to wait
+  // for a board that held the code in its *rendered* set, which meant a code that
+  // was never coming (the item shipped mid-flight, or the chip named another
+  // project's row) sat in the store forever and quietly fired at the next board
+  // that happened to hold it.
   const roadmapFocusCode = useAppStore((s) => s.roadmapFocusCode);
   const clearRoadmapFocus = useAppStore((s) => s.clearRoadmapFocus);
   useEffect(() => {
     if (!roadmapFocusCode) return;
-    // Gate on the *rendered* set, not the raw buffer: a `done` row is in
-    // `rows` but leaves the board, so matching it would consume the request,
-    // scroll nowhere, and ring nothing. (Callers already avoid sending done
-    // items here, but a race between the jump and a merge sweep can ship the
-    // item mid-flight.)
-    if (!rows.some((r) => r.code === roadmapFocusCode && isOnBoard(r))) return;
-    focusItem(roadmapFocusCode);
+    // Wait only for *this* board's rows to settle. Without that gate the render
+    // right after a project switch would judge the request against the previous
+    // board's rows and refuse it; with it, a board that can never answer (its
+    // snapshot failed, or the repo has no project) still refuses rather than
+    // holding the request hostage.
+    if (!rowsSettled) return;
+    revealItem(roadmapFocusCode);
     clearRoadmapFocus();
-  }, [roadmapFocusCode, rows, focusItem, clearRoadmapFocus]);
+  }, [roadmapFocusCode, rowsSettled, revealItem, clearRoadmapFocus]);
 
   return {
     /** The project this board belongs to; null until the workspace loads, or
@@ -1046,7 +1118,15 @@ export function useRoadmap(repoPath: string) {
     openCodes,
     toggleItem,
     focusCode,
-    focusItem,
+    /** Show the item a code names, wherever it is — the one resolution every
+     *  clickable code goes through (see `revealItem`). */
+    revealItem,
+    /** The same function under the name every caller already asks for. The chat
+     *  chips, the strip and the rail all say "focus"; what they mean is "show me
+     *  this", and for a shipped item that is not the board. Kept as an alias
+     *  rather than renamed at four call sites, two of which are another surface's
+     *  files. */
+    focusItem: revealItem,
     landed,
     /** Why a queued item isn't moving, by item id. */
     notes,
@@ -1082,8 +1162,9 @@ export function useRoadmap(repoPath: string) {
     moveItem,
     setRanks,
     removeItems,
-    acceptItems,
-    acceptProposals,
+    /** Say yes to pending deltas: admissions first, then patches. One call for a
+     *  ghost, an ask, a revised ghost, and the whole batch. */
+    acceptDeltas,
     rejectProposals,
     acceptOrder,
     rejectOrder,

--- a/src/components/Workspace/MissionControl/IssueRoadmapAction.tsx
+++ b/src/components/Workspace/MissionControl/IssueRoadmapAction.tsx
@@ -1,9 +1,9 @@
 import { Icon } from "@/components/Icon";
 import type { FunnelAction } from "./funnel";
 
-/** The roadmap half of an inbox row's actions. Three states, decided in
- *  funnel.ts: offer the route, say it's already there, or say nothing at all —
- *  no project owns the repo, or its board hasn't answered yet, and an Add
+/** The roadmap half of an inbox row's actions. Four states, decided in funnel.ts:
+ *  offer the route, say it's already there, say it was turned down, or say nothing
+ *  at all — no project owns the repo, or its board hasn't answered yet, and an Add
  *  offered without knowing what's on the board is how duplicates get made. */
 export function IssueRoadmapAction({ action, onAdd }: { action: FunnelAction; onAdd: () => void }) {
   if (action.kind === "none") return null;
@@ -16,6 +16,24 @@ export function IssueRoadmapAction({ action, onAdd }: { action: FunnelAction; on
         title="Already a roadmap item — rule on it there"
       >
         <Icon name="check" size={12} /> On roadmap
+      </button>
+    );
+  }
+  // Routed once and discarded on the board. Said out loud rather than left as a
+  // bare row, because the absence of an Add button is otherwise indistinguishable
+  // from a board that failed to load — and re-offering Add is what made a
+  // discarded issue come back on every read, forever.
+  if (action.kind === "declined") {
+    return (
+      // Same quiet statement styling as `routed`: both are facts about the board
+      // rather than things to click.
+      <button
+        type="button"
+        className="mc-btn mc-inbox-routed"
+        disabled
+        title="You discarded this from the roadmap — it won't be offered again"
+      >
+        <Icon name="close" size={12} /> Not on roadmap
       </button>
     );
   }

--- a/src/components/Workspace/MissionControl/funnel.test.ts
+++ b/src/components/Workspace/MissionControl/funnel.test.ts
@@ -5,6 +5,8 @@ import {
   distillIssueBody,
   funnelAction,
   issueToRoadmapItem,
+  parseDeclinedIssues,
+  routedIssueUrl,
   routedIssueUrls,
 } from "./funnel";
 
@@ -19,8 +21,10 @@ function issue(over: Partial<TrackerIssue> = {}): TrackerIssue {
   };
 }
 
-function row(why: string): Pick<RoadmapItem, "why"> {
-  return { why };
+/** A row as the funnel reads it. `issue_url` defaults to null so the legacy
+ *  why-line path is what a bare `row("…")` exercises. */
+function row(why: string, issue_url: string | null = null): Pick<RoadmapItem, "why" | "issue_url"> {
+  return { why, issue_url };
 }
 
 describe("distillIssueBody", () => {
@@ -78,7 +82,14 @@ describe("issueToRoadmapItem", () => {
       why: "https://x/1",
       status: "proposed",
       source: "github",
+      issue_url: "https://x/1",
     });
+  });
+
+  // The durable routing record, and the only place it is ever written.
+  it("carries the issue url as a field, not only as prose", () => {
+    const item = issueToRoadmapItem(issue({ url: "https://x/42", body: "Steps" }));
+    expect(item.issue_url).toBe("https://x/42");
   });
 
   it("maps a Linear ticket to the linear source", () => {
@@ -96,11 +107,36 @@ describe("issueToRoadmapItem", () => {
   });
 });
 
+describe("routedIssueUrl", () => {
+  it("reads the column, whatever the prose says", () => {
+    // The whole point of migration 0036: the `why` is the user's to rewrite (and
+    // the PM's to propose changes to), and dedup must not notice.
+    expect(routedIssueUrl(row("Because three people asked", "https://x/7"))).toBe("https://x/7");
+    expect(routedIssueUrl(row("", "https://x/7"))).toBe("https://x/7");
+  });
+
+  it("falls back to the first line for rows written before the column existed", () => {
+    expect(routedIssueUrl(row("https://github.com/o/r/issues/1\nLogin fails"))).toBe(
+      "https://github.com/o/r/issues/1",
+    );
+    expect(routedIssueUrl(row("https://linear.app/acme/issue/ENG-2"))).toBe(
+      "https://linear.app/acme/issue/ENG-2",
+    );
+  });
+
+  it("is null for a row nobody imported", () => {
+    expect(routedIssueUrl(row("Because users keep asking"))).toBeNull();
+    expect(routedIssueUrl(row(""))).toBeNull();
+    expect(routedIssueUrl(row("see https://github.com/o/r/issues/9 for detail"))).toBeNull();
+  });
+});
+
 describe("routedIssueUrls", () => {
-  it("reads the url off each row's first line", () => {
+  it("collects both the column and the legacy first line", () => {
     const urls = routedIssueUrls([
-      row("https://github.com/o/r/issues/1\nLogin fails"),
+      row("Rewritten rationale", "https://github.com/o/r/issues/1"),
       row("https://linear.app/acme/issue/ENG-2"),
+      row("Not from a tracker at all"),
     ]);
     expect([...urls].sort()).toEqual([
       "https://github.com/o/r/issues/1",
@@ -108,14 +144,27 @@ describe("routedIssueUrls", () => {
     ]);
   });
 
-  it("ignores a why that doesn't open with a bare url", () => {
-    expect(
-      routedIssueUrls([
-        row("Because users keep asking"),
-        row(""),
-        row("see https://github.com/o/r/issues/9 for detail"),
-      ]).size,
-    ).toBe(0);
+  it("is empty for a board of hand-written rows", () => {
+    expect(routedIssueUrls([row("Because users keep asking"), row("")]).size).toBe(0);
+  });
+});
+
+describe("parseDeclinedIssues", () => {
+  it("reads the stored JSON array", () => {
+    expect([...parseDeclinedIssues('["https://x/1","https://x/2"]')]).toEqual([
+      "https://x/1",
+      "https://x/2",
+    ]);
+  });
+
+  it("is empty for anything it can't trust", () => {
+    for (const value of [undefined, "", "not json", "{}", '"a string"', "[1,2]"]) {
+      expect(parseDeclinedIssues(value).size, String(value)).toBe(0);
+    }
+  });
+
+  it("keeps only the strings out of a mixed array", () => {
+    expect([...parseDeclinedIssues('["https://x/1",7,null]')]).toEqual(["https://x/1"]);
   });
 });
 
@@ -144,6 +193,34 @@ describe("funnelAction", () => {
 
   it("offers no action for an issue with no url to dedup on", () => {
     expect(funnelAction("p1", "", routed)).toEqual({ kind: "none" });
+  });
+
+  // The durable-refusal half: a discarded ghost used to be re-offered on every
+  // read, forever, because the record of the refusal died with the row.
+  it("reports an issue the user turned down instead of offering it again", () => {
+    const declined = new Set(["https://github.com/o/r/issues/5"]);
+    expect(funnelAction("p1", "https://github.com/o/r/issues/5", routed, declined)).toEqual({
+      kind: "declined",
+    });
+    // Untouched issues are still addable.
+    expect(funnelAction("p1", "https://github.com/o/r/issues/6", routed, declined)).toEqual({
+      kind: "add",
+      projectId: "p1",
+    });
+  });
+
+  it("lets the board outrank the tombstone when an issue was routed again", () => {
+    const declined = new Set(["https://github.com/o/r/issues/1"]);
+    expect(funnelAction("p1", "https://github.com/o/r/issues/1", routed, declined)).toEqual({
+      kind: "routed",
+    });
+  });
+
+  it("treats an unknown declined set as nothing declined", () => {
+    expect(funnelAction("p1", "https://github.com/o/r/issues/2", routed)).toEqual({
+      kind: "add",
+      projectId: "p1",
+    });
   });
 
   // The same origin repo can be pinned in two projects; each board is judged

--- a/src/components/Workspace/MissionControl/funnel.ts
+++ b/src/components/Workspace/MissionControl/funnel.ts
@@ -8,6 +8,28 @@
 
 import type { IssueSource, ItemSource, NewRoadmapItem, RoadmapItem, TrackerIssue } from "@/api";
 
+/** `project_settings` key holding the issues the user has turned down, as a JSON
+ *  array of URLs — written by the backend's delete path when it removes a
+ *  `proposed` row carrying an `issue_url` (roadmap/store.rs `decline_issue`).
+ *
+ *  A discard deletes the row, so the refusal has nowhere on the board to live;
+ *  without this the inbox re-offered a discarded issue on every read, forever. */
+export const DECLINED_ISSUES_KEY = "roadmap.declined_issues";
+
+/** Read that stored list. A missing, blank or unparseable value is an empty set:
+ *  a corrupt setting must cost the dedup, never the inbox. */
+export function parseDeclinedIssues(value: string | undefined): Set<string> {
+  if (!value) return new Set();
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return new Set(
+      Array.isArray(parsed) ? parsed.filter((u): u is string => typeof u === "string") : [],
+    );
+  } catch {
+    return new Set();
+  }
+}
+
 /** Longest body distillation carried into `why`. The `why` is the one line
  *  justifying an item's place on the board, and an issue template pasted whole
  *  would drown the card — the URL on the line above is always there for the
@@ -44,9 +66,14 @@ export function distillIssueBody(body: string | undefined, maxLen = BODY_MAX): s
 }
 
 /** The `why` a routed issue carries: its URL alone on the first line, the
- *  distilled body under it. That first line is load-bearing, not decoration —
- *  it is the *only* record that this issue was routed (see `routedIssueUrls`),
- *  which is what lets dedup survive a reload without a column of its own. */
+ *  distilled body under it.
+ *
+ *  The URL used to be load-bearing here — it was the *only* record that the issue
+ *  had been routed, which is what let dedup survive a reload without a column.
+ *  Since migration 0036 the record is `issue_url` on the row, and this line is
+ *  what it always looked like: provenance the reader can click. Dedup no longer
+ *  depends on it, so editing the rationale (or accepting a PM proposal that
+ *  rewrites it) can't re-offer an issue that is already on the board. */
 export function composeIssueWhy(issue: Pick<TrackerIssue, "url" | "body">): string {
   const body = distillIssueBody(issue.body);
   return body ? `${issue.url}\n${body}` : issue.url;
@@ -56,51 +83,79 @@ export function composeIssueWhy(issue: Pick<TrackerIssue, "url" | "body">): stri
  *  triage, not a commitment, so the item arrives as a ghost the user rules on
  *  with the same Accept/Discard every proposal gets. Horizon and rank are left
  *  to the backend's defaults — where it belongs is a planning call, made after
- *  the ruling. */
+ *  the ruling.
+ *
+ *  `issue_url` is the durable routing record; the backend accepts it only at
+ *  creation, so this call is the one place it is ever written. */
 export function issueToRoadmapItem(issue: TrackerIssue): NewRoadmapItem {
   return {
     title: issue.title,
     why: composeIssueWhy(issue),
     status: "proposed",
     source: ITEM_SOURCE[issue.source],
+    issue_url: issue.url,
   };
 }
 
-/** Every issue URL already routed onto a board, read off the rows' `why` first
- *  lines. Derived from the rows rather than remembered at the click, so the
- *  inbox still knows after a reload — and so a row discarded on the board
- *  offers its issue again. */
-export function routedIssueUrls(rows: readonly Pick<RoadmapItem, "why">[]): Set<string> {
+/** Which issue a row was routed from, or null.
+ *
+ *  `issue_url` first, because that is the column the funnel writes and nothing
+ *  edits. The `why` first line is the legacy reader, kept for rows created before
+ *  migration 0036: their URL only ever lived there, and 0036 deliberately does
+ *  not backfill (parsing user-editable prose into a column that claims to be
+ *  canonical would re-introduce the very thing the column fixes). New rows never
+ *  reach the fallback. */
+export function routedIssueUrl(row: Pick<RoadmapItem, "why" | "issue_url">): string | null {
+  if (row.issue_url) return row.issue_url;
+  const first = row.why.split("\n", 1)[0].trim();
+  return /^https?:\/\/\S+$/.test(first) ? first : null;
+}
+
+/** Every issue URL already routed onto a board. Derived from the rows rather than
+ *  remembered at the click, so the inbox agrees with the board after a reload —
+ *  and so an issue whose item was *accepted* and later shipped still reads as
+ *  routed while the row lives. */
+export function routedIssueUrls(
+  rows: readonly Pick<RoadmapItem, "why" | "issue_url">[],
+): Set<string> {
   const urls = new Set<string>();
   for (const row of rows) {
-    const first = row.why.split("\n", 1)[0].trim();
-    if (/^https?:\/\/\S+$/.test(first)) urls.add(first);
+    const url = routedIssueUrl(row);
+    if (url) urls.add(url);
   }
   return urls;
 }
 
 /** What an inbox row offers for its issue: `none` when there is no board to
  *  route onto or no way to tell the issue apart later, `routed` when the issue
- *  is already on one, else the action carrying the project to create in. */
+ *  is already on one, `declined` when the user has already turned it down, else
+ *  the action carrying the project to create in. */
 export type FunnelAction =
   | { kind: "none" }
   | { kind: "routed" }
+  | { kind: "declined" }
   | { kind: "add"; projectId: string };
 
-/** Decide that action, against the routed urls of *that project's* board — the
- *  same origin repo can be pinned in two projects, and routing an issue in one
- *  says nothing about the other. Project first: without a board there is nothing
- *  to say about the issue at all. */
+/** Decide that action, against the routed and declined urls of *that project's*
+ *  board — the same origin repo can be pinned in two projects, and routing (or
+ *  refusing) an issue in one says nothing about the other. Project first: without
+ *  a board there is nothing to say about the issue at all.
+ *
+ *  `routed` outranks `declined`: an issue that was discarded and then routed
+ *  again is on the board now, and the board is the newer fact. (The tombstone is
+ *  never cleared, deliberately — the list is small, append-only, and re-declining
+ *  is idempotent.) */
 export function funnelAction(
   projectId: string | undefined,
   issueUrl: string,
   routed: ReadonlySet<string>,
+  declined: ReadonlySet<string> = new Set(),
 ): FunnelAction {
   if (!projectId) return { kind: "none" };
-  // No url is no dedup key: the `why` first line is the only record a routing
-  // happened, so an urlless issue would offer `add` forever and stack a fresh
-  // ghost on every click. Offering nothing is the honest answer.
+  // No url is no dedup key: an urlless issue would offer `add` forever and stack
+  // a fresh ghost on every click. Offering nothing is the honest answer.
   if (!issueUrl) return { kind: "none" };
   if (routed.has(issueUrl)) return { kind: "routed" };
+  if (declined.has(issueUrl)) return { kind: "declined" };
   return { kind: "add", projectId };
 }

--- a/src/components/Workspace/MissionControl/useIssueFunnel.ts
+++ b/src/components/Workspace/MissionControl/useIssueFunnel.ts
@@ -1,18 +1,34 @@
 // MissionControl/useIssueFunnel.ts — the inbox's roadmap side: which issues are
-// already on a board, and the one call that routes a new one there. Creation
-// goes through the typed `roadmap_create_item` command, which records the
-// item's `created` history line in the same transaction — the funnel adds no
-// writer of its own. The rules it applies are pure (funnel.ts).
+// already on a board, which ones the user has turned down, and the one call that
+// routes a new one there. Creation goes through the typed `roadmap_create_item`
+// command, which records the item's `created` history line in the same
+// transaction — the funnel adds no writer of its own. The rules it applies are
+// pure (funnel.ts).
+//
+// The boards are *followed*, not polled. This used to re-read
+// `roadmap_list_items` for every project every two minutes, which bought a
+// two-minute window in which the inbox and the board disagreed: discarding a
+// routed ghost on the board left this section saying "On roadmap", and the
+// click-dedup could only see ghosts this window had created. It was the last
+// roadmap consumer beside the event spine; it now rides the same
+// `roadmap:item` / `roadmap:item-deleted` stream the board does (see
+// src/roadmapRows.ts), so "is it already there?" is answered by state that
+// changes when the board does. No safety poll: a subscription that has to be
+// re-checked on a timer is a subscription nobody trusts, and the board itself
+// has never needed one.
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api, type RoadmapItem, type TrackerIssue } from "@/api";
-import { usePoll } from "@/util/hooks";
-import { type FunnelAction, funnelAction, issueToRoadmapItem, routedIssueUrls } from "./funnel";
-
-/** Same slow cadence as the inbox itself: this only answers "is it already on
- *  the board?", and a routed row is folded in at the click, so the poll is just
- *  what catches a board changed on another surface. */
-const POLL_MS = 120_000;
+import { useRoadmapRows } from "@/roadmapRows";
+import { getProjectSettings } from "@/storage/projectSettings";
+import {
+  DECLINED_ISSUES_KEY,
+  type FunnelAction,
+  funnelAction,
+  issueToRoadmapItem,
+  parseDeclinedIssues,
+  routedIssueUrls,
+} from "./funnel";
 
 export interface IssueFunnel {
   /** What this issue's row should offer, given the project its repo belongs to
@@ -23,71 +39,124 @@ export interface IssueFunnel {
   route: (projectId: string, issue: TrackerIssue) => Promise<void>;
 }
 
-/** A project's board as the funnel knows it. A read that failed is *not* an
- *  empty board: the backend dedups nothing, so treating "we don't know" as
- *  "nothing is routed" would re-enable Add on every already-routed row and let
- *  one click stack a second ghost. A project absent from the record has not been
- *  read yet, which is the same unknown. */
-type Board = { status: "loaded"; rows: RoadmapItem[] } | { status: "failed" };
-
 export function useIssueFunnel(projectIds: string[]): IssueFunnel {
-  const [boards, setBoards] = useState<Record<string, Board>>({});
+  /** Issues declined on each board, as stored (`project_settings`). Read once per
+   *  project rather than followed: the tombstone is written by the same delete
+   *  that emits `roadmap:item-deleted`, so the live half below covers every
+   *  refusal made while this section is mounted, and this covers the ones made
+   *  before it was. */
+  const [stored, setStored] = useState<Record<string, ReadonlySet<string>>>({});
+  /** Refusals seen live — a routed ghost that was just deleted. Held separately
+   *  from `stored` so a re-read can never drop one. */
+  const [seen, setSeen] = useState<Record<string, ReadonlySet<string>>>({});
   // In-flight issue urls, in a ref rather than state: two fast clicks land in
   // the same render, and a second ghost row is not something a reload undoes.
   const inFlight = useRef(new Set<string>());
 
-  const poll = useCallback(async () => {
-    if (projectIds.length === 0) return;
-    const entries = await Promise.all(
-      projectIds.map(async (id) => {
-        try {
-          return [id, { status: "loaded", rows: await api.roadmapListItems(id) }] as const;
-        } catch {
-          return [id, { status: "failed" }] as const;
-        }
-      }),
-    );
-    setBoards(Object.fromEntries(entries));
-  }, [projectIds]);
+  const declineSeen = useCallback((projectId: string, url: string) => {
+    setSeen((prev) => {
+      const next = new Set(prev[projectId] ?? []);
+      if (next.has(url)) return prev;
+      next.add(url);
+      return { ...prev, [projectId]: next };
+    });
+  }, []);
 
-  usePoll(poll, POLL_MS, [poll]);
+  /** The rows as of the last render, for the delete listener — which needs the row
+   *  that is *going away*, and by the time a re-render carries the new list that
+   *  row is exactly what is missing from it. */
+  const rowsForDelete = useRef<ReadonlyMap<string, RoadmapItem>>(new Map());
+  const onDeleted = useCallback(
+    (id: string) => {
+      const row = rowsForDelete.current.get(id);
+      // Only a *ghost* routed from a tracker is a refusal: deleting an item the
+      // user already accepted is a different decision, and that issue is
+      // legitimately offered again. Keyed on `issue_url` alone (not the legacy
+      // `why` first line) so this agrees exactly with what the backend's delete
+      // path records — a pre-0036 row leaves no tombstone either way.
+      if (!row || row.status !== "proposed" || !row.issue_url) return;
+      declineSeen(row.project_id, row.issue_url);
+    },
+    [declineSeen],
+  );
+
+  const { rows, load } = useRoadmapRows(projectIds, { onDeleted });
+  rowsForDelete.current = useMemo(() => new Map(rows.map((r) => [r.id, r])), [rows]);
+
+  const key = projectIds.join(" ");
+  useEffect(() => {
+    const ids = key ? key.split(" ") : [];
+    if (ids.length === 0) {
+      setStored({});
+      return;
+    }
+    let alive = true;
+    void (async () => {
+      const entries = await Promise.all(
+        ids.map(async (id) => {
+          const all = await getProjectSettings(id).catch(() => ({}) as Record<string, string>);
+          return [id, parseDeclinedIssues(all[DECLINED_ISSUES_KEY])] as const;
+        }),
+      );
+      if (alive) setStored(Object.fromEntries(entries));
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [key]);
 
   // Per project, never pooled: the same origin repo pinned at two paths in two
   // projects would otherwise read "on roadmap" on both boards after one routing.
   const routedByProject = useMemo(() => {
-    const byProject: Record<string, Set<string>> = {};
-    for (const [id, board] of Object.entries(boards)) {
-      if (board.status === "loaded") byProject[id] = routedIssueUrls(board.rows);
+    const byProject = new Map<string, RoadmapItem[]>();
+    for (const row of rows) {
+      const group = byProject.get(row.project_id);
+      if (group) group.push(row);
+      else byProject.set(row.project_id, [row]);
     }
-    return byProject;
-  }, [boards]);
+    const out = new Map<string, ReadonlySet<string>>();
+    for (const [id, group] of byProject) out.set(id, routedIssueUrls(group));
+    return out;
+  }, [rows]);
+
+  /** Both halves together: what was stored before this section mounted, and what
+   *  it has watched happen since. */
+  const declinedByProject = useMemo(() => {
+    const out = new Map<string, Set<string>>();
+    for (const [id, urls] of Object.entries(stored)) out.set(id, new Set(urls));
+    for (const [id, urls] of Object.entries(seen)) {
+      const set = out.get(id) ?? new Set<string>();
+      for (const url of urls) set.add(url);
+      out.set(id, set);
+    }
+    return out;
+  }, [stored, seen]);
 
   const actionFor = useCallback(
     (projectId: string | undefined, issue: TrackerIssue) => {
-      const routed = projectId ? routedByProject[projectId] : undefined;
       // Unknown board (unread or failed) → no roadmap action, the same quiet
       // degradation the section gives a tracker that won't answer. Offering Add
-      // here is what creates duplicates.
-      if (!routed) return { kind: "none" } as const;
-      return funnelAction(projectId, issue.url, routed);
+      // here is what creates duplicates: a failed read is not an empty board.
+      if (!projectId || load.get(projectId) !== "loaded") return { kind: "none" } as const;
+      return funnelAction(
+        projectId,
+        issue.url,
+        routedByProject.get(projectId) ?? new Set(),
+        declinedByProject.get(projectId) ?? new Set(),
+      );
     },
-    [routedByProject],
+    [load, routedByProject, declinedByProject],
   );
 
   const route = useCallback(async (projectId: string, issue: TrackerIssue) => {
     if (inFlight.current.has(issue.url)) return;
     inFlight.current.add(issue.url);
     try {
-      const row = await api.roadmapCreateItem(projectId, issueToRoadmapItem(issue));
-      // Fold the stored row in rather than remembering the click: "on roadmap"
-      // stays a function of board rows, so this agrees with the next poll and
-      // with a reload. Only into a board we have actually read — inventing one
-      // from a single row would claim the rest of that board is empty.
-      setBoards((prev) => {
-        const board = prev[projectId];
-        if (board?.status !== "loaded") return prev;
-        return { ...prev, [projectId]: { status: "loaded", rows: [...board.rows, row] } };
-      });
+      // Nothing to fold in: the create emits `roadmap:item`, which the row
+      // subscription applies — the same path a ghost the PM proposed takes. The
+      // old optimistic fold-in existed only because the poll would otherwise take
+      // two minutes to agree, and it was the poll's own clobber window.
+      await api.roadmapCreateItem(projectId, issueToRoadmapItem(issue));
     } finally {
       inFlight.current.delete(issue.url);
     }

--- a/src/roadmapRows.ts
+++ b/src/roadmapRows.ts
@@ -1,0 +1,227 @@
+// The roadmap board's rows, as a subscription — for every surface that needs to
+// know what is on a board without owning one.
+//
+// Lives here rather than under `components/ProjectScreen/Roadmap/` because it has
+// three consumers in three different areas: the board itself (`useRoadmap`), the
+// workspace's issue inbox (`MissionControl/useIssueFunnel`), and a run's monitor
+// (`RunView/RoadmapChip`). The same promotion `rowSync.ts` got when its third
+// caller appeared, and for the same reason — a shared hook whose home is one
+// caller's folder makes the other two import *through* a screen they have nothing
+// to do with.
+//
+// Every surface here is event-driven, not polled. The funnel used to poll
+// (`roadmap_list_items` per project, every two minutes), which bought up to two
+// minutes of disagreement with the board: discarding a routed ghost left the
+// inbox saying "On roadmap", and the click-dedup could only see ghosts this
+// window had created. The chip fetched once per mount and never subscribed, so an
+// accepted retitle left a stale title on screen and a shipped item kept a chip
+// the board would silently swallow the click of. Both are the same defect —
+// a surface beside the spine rather than on it — and both are fixed by riding
+// `roadmap:item` / `roadmap:item-deleted` like the board does.
+//
+// The load discipline is `rowSync`'s: subscribe, then fetch, then replay what
+// arrived in between (see rowSync.ts for the two loss windows that buys). Worth
+// the ceremony for exactly the reason the board needs it — these rows have
+// writers the user isn't (the PM's propose, the queue's claim, the sweep's ship).
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { api, onRoadmapItem, onRoadmapItemDeleted, type RoadmapItem } from "@/api";
+import { applyRowEvent, createRowSync } from "@/rowSync";
+
+/** How one project's board is doing.
+ *
+ *  `failed` is not `loaded` with no rows, and callers must not fold the two: the
+ *  funnel's whole dedup rests on "what is already routed onto this board?", and a
+ *  read that failed answering "nothing" would re-enable Add on every routed row
+ *  and let one click stack a second ghost. A project absent from the map has not
+ *  been read yet, which is the same unknown. */
+export type BoardLoad = "loading" | "loaded" | "failed";
+
+export interface RoadmapRows {
+  /** Every listed project's rows, flat — `project_id` is on the row, so callers
+   *  that want them grouped group them. Includes `done` rows: what a surface
+   *  hides is its own business. */
+  rows: readonly RoadmapItem[];
+  /** Per project, how its snapshot went. */
+  load: ReadonlyMap<string, BoardLoad>;
+  /** Any listed project still waiting on its snapshot. False when nothing is
+   *  listed — "no boards" is a settled answer, not a pending one. */
+  loading: boolean;
+  /** The first snapshot failure, for a caller with an error bar. Null while every
+   *  listed board is loading or loaded. */
+  error: string | null;
+  /** Fold a row a command just returned straight in, without waiting for its
+   *  event — the optimistic half of a mutation the caller already awaited. */
+  upsert: (row: RoadmapItem) => void;
+  /** Drop rows a command just deleted, same deal. */
+  remove: (ids: readonly string[]) => void;
+}
+
+/** Side channels for a caller that needs to act on an *arrival* rather than on
+ *  the resulting state — a distinction React state can't express, because two
+ *  events in one frame collapse into one render. */
+export interface RoadmapRowsOptions {
+  /** A row arrived on `roadmap:item` (not a snapshot row, and not an optimistic
+   *  upsert). The board uses it to drop the stale queue note a moving row
+   *  invalidates. */
+  onRow?: (row: RoadmapItem) => void;
+  /** A row was deleted on `roadmap:item-deleted`. The board uses it to drop the
+   *  trail it was holding; the funnel uses it to remember a refusal. */
+  onDeleted?: (id: string) => void;
+}
+
+/** Follow the rows of one or more project boards, live.
+ *
+ *  `projectIds` may change freely — the effect keys on the *contents*, so a
+ *  caller need not memoize the array (`[a, b]` rebuilt every render resubscribes
+ *  nothing). An empty list holds no rows, no subscription, and no pending load.
+ *
+ *  Callbacks are read through a ref, so a caller can pass fresh closures without
+ *  tearing the subscription down. */
+export function useRoadmapRows(
+  projectIds: readonly string[],
+  options: RoadmapRowsOptions = {},
+): RoadmapRows {
+  const [rows, setRows] = useState<RoadmapItem[]>([]);
+  const [load, setLoad] = useState<ReadonlyMap<string, BoardLoad>>(() => new Map());
+  const [error, setError] = useState<string | null>(null);
+  // Identity-independent: the same ids in the same order are the same
+  // subscription, however the caller built the array.
+  const key = projectIds.join(" ");
+  const handlers = useRef(options);
+  handlers.current = options;
+
+  useEffect(() => {
+    const ids = key ? key.split(" ") : [];
+    if (ids.length === 0) {
+      setRows([]);
+      setLoad(new Map());
+      setError(null);
+      return;
+    }
+    let alive = true;
+    setRows([]);
+    setError(null);
+    setLoad(new Map(ids.map((id) => [id, "loading" as BoardLoad])));
+
+    const wanted = new Set(ids);
+    // One sequencer for all the listed boards: the rows are one flat list keyed
+    // by row id, and a project's snapshot replaying over it only ever adds its
+    // own rows (see `settle` below).
+    const sync = createRowSync<RoadmapItem>((update) => {
+      if (alive) setRows(update);
+    });
+    const off = onRoadmapItem((row) => {
+      if (!wanted.has(row.project_id)) return;
+      sync.push({ kind: "upsert", row });
+      handlers.current.onRow?.(row);
+    });
+    // Addressed by item id and carries no project, so it can't be filtered:
+    // a delete for a row no listed board holds removes nothing, which is the
+    // right answer anyway.
+    const offDeleted = onRoadmapItemDeleted((id) => {
+      sync.push({ kind: "delete", id });
+      handlers.current.onDeleted?.(id);
+    });
+
+    void (async () => {
+      // Awaited, not merely started: Tauri's `listen` resolves asynchronously,
+      // and an event emitted before it does is never delivered at all.
+      await Promise.all([off, offDeleted]);
+      if (!alive) return;
+      const snapshots = await Promise.all(
+        ids.map(async (id): Promise<Snapshot> => {
+          try {
+            return { id, rows: await api.roadmapListItems(id) };
+          } catch (e) {
+            return { id, failure: String(e) };
+          }
+        }),
+      );
+      if (!alive) return;
+      // One `settle` for the whole set, so the buffered live events replay
+      // exactly once and over every snapshot rather than per project.
+      sync.settle(snapshots.flatMap((s) => ("rows" in s ? s.rows : [])));
+      setLoad(new Map(snapshots.map((s) => [s.id, "rows" in s ? "loaded" : "failed"])));
+      setError(snapshots.find((s): s is Failed => "failure" in s)?.failure ?? null);
+    })();
+
+    return () => {
+      alive = false;
+      void off.then((f) => f());
+      void offDeleted.then((f) => f());
+    };
+  }, [key]);
+
+  const upsert = useCallback((row: RoadmapItem) => {
+    setRows((prev) => applyRowEvent(prev, { kind: "upsert", row }));
+  }, []);
+  const remove = useCallback((ids: readonly string[]) => {
+    setRows((prev) => prev.filter((r) => !ids.includes(r.id)));
+  }, []);
+
+  const loading = useMemo(() => [...load.values()].some((s) => s === "loading"), [load]);
+  return { rows, load, loading, error, upsert, remove };
+}
+
+/** One project's snapshot attempt — read, or a reason it wasn't. */
+type Snapshot = { id: string; rows: RoadmapItem[] } | Failed;
+type Failed = { id: string; failure: string };
+
+/** One row by id, live — for a surface that holds an item id but no board.
+ *
+ *  A run's monitor is the case: it has `wf_run.roadmap_item_id` and nothing else,
+ *  and the run outlives the screen the item was queued from. Subscribed rather
+ *  than fetched once, because everything the chip renders can change under it: an
+ *  accepted PM retitle changes the title, and the merge sweep shipping the item
+ *  changes where (or whether) the chip can go.
+ *
+ *  `null` means "no such row" *or* "not read yet" — the two are the same to a
+ *  caller that renders nothing either way, and a dead link is worse than no
+ *  link. */
+export function useRoadmapRow(itemId: string | null): RoadmapItem | null {
+  const [row, setRow] = useState<RoadmapItem | null>(null);
+
+  useEffect(() => {
+    setRow(null);
+    if (!itemId) return;
+    let alive = true;
+    // "One row or none, keyed by something we already know" is `createSingleSync`
+    // territory, but this stream is keyed by *item id* and the row carries it, so
+    // the filter is exact and the merge is the same last-write-wins. Written out
+    // rather than reused because there is no snapshot-vs-live conflict to
+    // resolve: the fetch below is the oldest possible value.
+    let live = false;
+    const off = onRoadmapItem((r) => {
+      if (!alive || r.id !== itemId) return;
+      live = true;
+      setRow(r);
+    });
+    const offDeleted = onRoadmapItemDeleted((id) => {
+      if (!alive || id !== itemId) return;
+      live = true;
+      setRow(null);
+    });
+
+    void (async () => {
+      await Promise.all([off, offDeleted]);
+      if (!alive) return;
+      try {
+        const fetched = await api.roadmapGetItem(itemId);
+        // Anything that arrived live is newer than the snapshot by construction.
+        if (alive && !live) setRow(fetched);
+      } catch {
+        // A convenience surface; a failed read leaves the caller with nothing to
+        // render, which is what it renders when the row is gone too.
+      }
+    })();
+
+    return () => {
+      alive = false;
+      void off.then((f) => f());
+      void offDeleted.then((f) => f());
+    };
+  }, [itemId]);
+
+  return row;
+}

--- a/src/rowSync.test.ts
+++ b/src/rowSync.test.ts
@@ -25,6 +25,7 @@ function item(over: Partial<RoadmapItem> & { id: string }): RoadmapItem {
     hold_reason: null,
     held_by: null,
     held_at: null,
+    issue_url: null,
     created_at: 0,
     updated_at: 0,
     ...over,

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -57,11 +57,17 @@ export interface UiSlice {
   /** Which tab of the project page is showing. Set by whoever opened the
    *  screen, so a control labelled "Project settings" lands on Settings. */
   projectScreenTab: ProjectScreenTab;
-  /** A roadmap item code the board should jump to as soon as it holds it — the
+  /** A roadmap item code the board should reveal as soon as it can — the
    *  cross-screen half of "every altitude links back to the one above it" (a
-   *  run's roadmap chip). Consumed and cleared by the board that has the code,
-   *  so it fires once; the board next to the PM chat needs none of this and
-   *  calls `focusItem` directly. */
+   *  run's roadmap chip). The board next to the PM chat needs none of this and
+   *  calls `revealItem` directly.
+   *
+   *  **Consumed or refused, never left pending.** The target board clears this the
+   *  moment its own rows have settled, whether or not it holds the code: an
+   *  unresolvable request (the item shipped mid-jump, the code belongs to another
+   *  project, the snapshot failed) used to sit here indefinitely and then fire at
+   *  whichever board next happened to hold that code. A refusal is said out loud
+   *  on that board's error bar instead — see `useRoadmap`. */
   roadmapFocusCode: string | null;
   leftCollapsed: boolean;
   rightCollapsed: boolean;

--- a/src/workflows/run/RunView/RoadmapChip.tsx
+++ b/src/workflows/run/RunView/RoadmapChip.tsx
@@ -5,18 +5,23 @@
 // never said which question. The chip names the item and jumps to it — the
 // board's own row, expanded and ringed (see `ui.focusRoadmapItem`).
 //
-// Fetched by id rather than passed in: nothing above this pane holds the board,
-// and a run outlives the screen the item was queued from. An item that has since
-// been deleted resolves to nothing and the chip renders nothing — a dead link is
-// worse than no link.
+// Followed by id rather than passed in: nothing above this pane holds the board,
+// and a run outlives the screen the item was queued from. *Followed*, not fetched
+// once — every word on the chip can change while it is on screen, and it used to
+// show whatever was true at mount: an accepted PM retitle left the old title, and
+// an item the merge sweep shipped kept a live-looking button whose click the board
+// then silently swallowed (a `done` row leaves the board, so there is nothing to
+// scroll to). One subscription (src/roadmapRows.ts, the same `roadmap:item`
+// stream the board rides) makes the title and the clickability derived rather
+// than remembered. An item that has since been deleted resolves to nothing and
+// the chip renders nothing — a dead link is worse than no link.
 
-import { useEffect, useState } from "react";
-import { api, type RoadmapItem } from "../../../api";
 import { Icon } from "../../../components/Icon";
+import { useRoadmapRow } from "../../../roadmapRows";
 import { useAppStore } from "../../../store";
 
 export function RoadmapChip({ itemId, projectId }: { itemId: string; projectId: string }) {
-  const [item, setItem] = useState<RoadmapItem | null>(null);
+  const item = useRoadmapRow(itemId);
   // The project screen is keyed by a repo path, so the jump needs the project's
   // primary repo — the first pinned repo that maps to it, which is exactly what
   // the sidebar's project group is keyed on.
@@ -24,20 +29,6 @@ export function RoadmapChip({ itemId, projectId }: { itemId: string; projectId: 
     (s) => s.workspace?.projects.find((p) => p.project_id === projectId)?.path ?? null,
   );
   const focusRoadmapItem = useAppStore((s) => s.focusRoadmapItem);
-
-  useEffect(() => {
-    let alive = true;
-    api
-      .roadmapGetItem(itemId)
-      .then((row) => {
-        if (alive) setItem(row);
-      })
-      // The chip is a convenience; a failed read leaves the header as it was.
-      .catch(() => {});
-    return () => {
-      alive = false;
-    };
-  }, [itemId]);
 
   if (!item) return null;
   const body = (
@@ -51,6 +42,8 @@ export function RoadmapChip({ itemId, projectId }: { itemId: string; projectId: 
   // or the item shipped: a `done` row leaves the board entirely, so the jump
   // would open the roadmap and land on nothing — the common case for a
   // finished run. The item is still worth naming; there is just nowhere to go.
+  // Derived from the live row, so a sweep that ships the item mid-view turns the
+  // button into that statement rather than leaving a click that does nothing.
   if (!repoPath || item.status === "done") return <span className="wf-run-rm">{body}</span>;
   return (
     <button


### PR DESCRIPTION
Part of the whole-system review fix batch (#609–#612). Three surfaces read the board through private channels and could disagree with it; the ruling grammar had an unrulable state and an undercounting batch bar; and the funnel forgot the only decision the user ever makes about a tracker issue.

## One row subscription (src/roadmapRows.ts)

`useRoadmapRows(projectIds)` / `useRoadmapRow(itemId)` — the project-scoped subscribe-then-fetch-then-replay row stream, extracted from `useRoadmap` and now consumed by it too, so there is one implementation.

- **Issue funnel**: the 120s poll is gone (up to 2 minutes of board disagreement, plus the optimistic-fold-in race the earlier review documented as F5 — dead at the root, because the fold-in no longer exists). Per-project `loading|loaded|failed` state: a failed read is never an empty board.
- **RunView's RoadmapChip**: no longer a one-shot fetch — title and clickability stay live, so it can't offer a click for an item the sweep shipped mid-session.

## Consumed-or-refused focus + revealItem

Every code now has a destination: board focus for a rendered row, the Activity tab for a `done` item (where Recently shipped lives), and a visible refusal on the board's error bar for an unknown code — instead of a request that silently dies in the store. Gated on per-project load state so a project switch can't judge a request against the previous board's rows.

## One ruling per card, one count for pending deltas

`cardRuling(ghost, proposal)` is the single answer for bar, diff, and count — closing the confirmed defect where a PM ask on a ghost rendered its diff with no way to rule it while the PM kept being told it was pending. A ghost carrying an ask now shows one bar ("accept the revised item"): accept applies admission then patch; decline discards the ghost and the ask cascades. `pendingDeltas` counts all four delta kinds (ghosts, asks, order, brief) — the batch bar previously counted two.

## The tracker issue becomes a real column (migration 0036)

`issue_url` on `roadmap_items` (plain ADD COLUMN, no rebuild) replaces URL-as-why-first-line dedup — editing `why` no longer un-dedups (F3). Declining is durable: deleting a `proposed` row with an `issue_url` writes a tombstone (`project_settings["roadmap.declined_issues"]`, same JSON-document pattern as `run_env`, capped at 500) in the same lock scope as the delete, so a discarded issue stays declined across reloads instead of being re-offered forever. Deleting an *accepted* item is a different decision and stays re-offerable. The column is not PM-patchable and not on the propose surface.

+27 TS tests (ruling, reveal, funnel) and +3 Rust (column survives edits/unpatchable, tombstone semantics, 0036 no-backfill pin). Each commit individually verified green, not just the tip.

Note: a handful of compile-forced one-line fixture updates (`issue_url: None`) touch test files that #611/#612 also edit — whichever merges second may need a trivial rebase.

Gates on this tip: tsc 0 · lint 0 · vitest 979 passed / 92 files · cargo test 1356 passed · clippy 0 · fmt clean.