### PR TITLE
fix(workflow): a step reports while it runs, and the tests gate runs the project's tests

### DIFF
--- a/src-tauri/src/run_detect/node.rs
+++ b/src-tauri/src/run_detect/node.rs
@@ -95,12 +95,17 @@ impl RunDetector for NodeDetector {
             ));
         }
 
+        // `run` is mandatory for `build`/`test`: bun reserves both as built-in
+        // subcommands (`bun test` is bun's own test runner, `bun build` its
+        // bundler), so the bare form silently runs something other than the
+        // project's script. `npm/pnpm/yarn run <script>` is equally valid, so
+        // one spelling serves every package manager.
         if script("build").is_some() {
             rows.push(DetectedRow::new(
                 "build",
                 RowGroup::Scripts,
                 "Build",
-                format!("{pm} build"),
+                format!("{pm} run build"),
                 "package.json · scripts.build",
             ));
         }
@@ -109,7 +114,7 @@ impl RunDetector for NodeDetector {
                 "test",
                 RowGroup::Scripts,
                 "Test",
-                format!("{pm} test"),
+                format!("{pm} run test"),
                 "package.json · scripts.test",
             ));
         }
@@ -243,8 +248,25 @@ mod tests {
         )])
         .unwrap();
         assert_eq!(val(&cfg, "dev"), "pnpm dev");
-        assert_eq!(val(&cfg, "build"), "pnpm build");
-        assert_eq!(val(&cfg, "test"), "pnpm test");
+        assert_eq!(val(&cfg, "build"), "pnpm run build");
+        assert_eq!(val(&cfg, "test"), "pnpm run test");
+    }
+
+    #[test]
+    fn bun_test_and_build_go_through_run() {
+        // `bun test` is bun's own test runner and `bun build` its bundler —
+        // neither runs the package's script. Without `run`, the tests gate
+        // verifies a suite the project never asked for.
+        let cfg = detect(&[
+            (
+                "package.json",
+                r#"{"scripts":{"build":"vite build","test":"vitest run"}}"#,
+            ),
+            ("bun.lock", ""),
+        ])
+        .unwrap();
+        assert_eq!(val(&cfg, "test"), "bun run test");
+        assert_eq!(val(&cfg, "build"), "bun run build");
     }
 
     #[test]

--- a/src-tauri/src/verify.rs
+++ b/src-tauri/src/verify.rs
@@ -519,7 +519,9 @@ mod tests {
             r#"{"scripts":{"test":"vitest"}}"#,
         );
         let r = resolve(dir.path(), &None, &None, &None);
-        assert_eq!(r.test.as_deref(), Some("npm test"));
+        // `run` is explicit so the script is what runs under every package
+        // manager — `bun test` would be bun's own runner (see `run_detect::node`).
+        assert_eq!(r.test.as_deref(), Some("npm run test"));
         assert_eq!(r.install.as_deref(), Some("npm install"));
     }
 

--- a/src-tauri/src/workflow/attempt.rs
+++ b/src-tauri/src/workflow/attempt.rs
@@ -100,6 +100,9 @@ pub struct AttemptParams {
     /// in the RPC watcher task) and this attempt observe the same flag. Defaults
     /// to a never-set flag for runs without comms and for `MockDriver` tests.
     pub pending_ask: Arc<AtomicBool>,
+    /// Live journal for this attempt (see [`AttemptJournal`]). Every production
+    /// call site supplies one; `None` in the pure lifecycle tests.
+    pub journal: Option<AttemptJournal>,
 }
 
 /// The terminal outcome of an attempt (maps onto the §6.2 attempt states).
@@ -129,14 +132,100 @@ pub enum AttemptOutcome {
     Canceled,
 }
 
-/// One journalable event the attempt produced, in order. The scheduler attaches
-/// the `step_exec_id` and appends each to the run journal (S4b); returning them
-/// as data keeps the attempt free of DB/transaction concerns and lets S4a tests
-/// assert that every transition is journaled with a cause (spec §16).
+/// One journalable event the attempt produced, in order. Returning them as data
+/// keeps the attempt's own state machine free of DB concerns and lets tests
+/// assert that every transition is journaled with a cause (spec §16); an
+/// [`AttemptJournal`] writes them through as they happen.
 #[derive(Debug, Clone)]
 pub struct AttemptEvent {
     pub event_type: &'static str,
     pub payload: Value,
+}
+
+/// Writes an attempt's events to the run journal *as they happen*, and links the
+/// agent to its `wf_step_exec` row the moment the spawn returns.
+///
+/// Without this the whole attempt's events are journaled in one batch when it
+/// ends, and `agent_id` is stamped just as late — so for the entire length of a
+/// step (minutes) no `wf:event` fires, the monitor never refetches, and the run
+/// reads as stuck with an empty chat pane (§7.2, §14.2). Optional so the
+/// `MockDriver` lifecycle tests keep running with no DB.
+pub struct AttemptJournal {
+    pub db: super::Db,
+    pub app: Option<tauri::AppHandle>,
+    pub run_id: String,
+}
+
+impl AttemptJournal {
+    fn write(&self, exec_id: &str, e: &AttemptEvent) {
+        let conn = self.db.lock();
+        super::scheduler::journal_event(
+            &conn,
+            self.app.as_ref(),
+            &self.run_id,
+            e.event_type,
+            Some(exec_id),
+            &e.payload,
+        );
+    }
+
+    /// Link the live agent to its attempt row and mark the row `running`. This is
+    /// what lets the monitor mount the step's chat (it resolves the agent through
+    /// `wf_step_exec.agent_id`) while the turn is still in flight.
+    fn stamp_spawned(&self, exec_id: &str, agent_id: &str) {
+        let conn = self.db.lock();
+        let _ = conn.execute(
+            "UPDATE wf_step_exec SET agent_id = ?1, status = 'running', started_at = ?2
+             WHERE id = ?3",
+            rusqlite::params![agent_id, super::now_ms(), exec_id],
+        );
+    }
+}
+
+/// The attempt's event list, journaled through to `AttemptJournal` on each push.
+/// Every event is still collected for the returned [`AttemptRun`], so callers and
+/// tests see the same ordered list they always did.
+struct EventLog {
+    events: Vec<AttemptEvent>,
+    journal: Option<AttemptJournal>,
+    exec_id: String,
+}
+
+impl EventLog {
+    fn new(journal: Option<AttemptJournal>, exec_id: String) -> Self {
+        Self {
+            events: Vec::new(),
+            journal,
+            exec_id,
+        }
+    }
+
+    /// A log with nowhere to write through to — the orchestrator turn driver,
+    /// whose caller journals per turn (not per stage) and so is never blind.
+    fn detached() -> Self {
+        Self {
+            events: Vec::new(),
+            journal: None,
+            exec_id: String::new(),
+        }
+    }
+
+    fn push(&mut self, e: AttemptEvent) {
+        if let Some(j) = &self.journal {
+            j.write(&self.exec_id, &e);
+        }
+        self.events.push(e);
+    }
+
+    fn stamp_spawned(&self, agent_id: &str) {
+        if let Some(j) = &self.journal {
+            j.stamp_spawned(&self.exec_id, agent_id);
+        }
+    }
+
+    fn into_events(self) -> Vec<AttemptEvent> {
+        self.events
+    }
 }
 
 /// The result of driving one attempt.
@@ -147,6 +236,11 @@ pub struct AttemptRun {
     /// commit + ferry after a `done` (§6.3 steps 7–8). `None` if spawn failed.
     pub worktree: Option<PathBuf>,
     pub outcome: AttemptOutcome,
+    /// Every event this attempt produced, in order. Now that an [`AttemptJournal`]
+    /// writes them through as they happen, no scheduler path re-reads this list —
+    /// it remains the lifecycle tests' window into the state machine, which they
+    /// assert without a DB.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub events: Vec<AttemptEvent>,
 }
 
@@ -188,12 +282,14 @@ pub async fn run_attempt(
         reprompt_on_block,
         cancel,
         pending_ask,
+        journal,
     } = params;
 
     let fork_base = spawn_req.fork_base.clone();
-    let mut events: Vec<AttemptEvent> = Vec::new();
+    let mut events = EventLog::new(journal, exec_id.clone());
 
     // ── 1. Spawn (or adopt a pre-spawned agent, §10.2) ───────────────────
+    let spawned_here = pre_spawned.is_none();
     let spawned = match pre_spawned {
         Some(s) => s,
         None => match driver.spawn(spawn_req).await {
@@ -205,13 +301,19 @@ pub async fn run_attempt(
                     agent_id: None,
                     worktree: None,
                     outcome: AttemptOutcome::Error { error },
-                    events,
+                    events: events.into_events(),
                 };
             }
         },
     };
     let agent_id = spawned.agent_id.clone();
     let worktree = spawned.worktree.clone();
+    // Stamp the row before the first event, so a listener that refetches on that
+    // event already finds the agent linked. A pre-spawned agent was stamped by
+    // the caller that spawned it.
+    if spawned_here {
+        events.stamp_spawned(&agent_id);
+    }
     events.push(ev(
         event_type::ATTEMPT_SPAWNED,
         json!({ "agent_id": agent_id, "fork_base": fork_base }),
@@ -357,7 +459,7 @@ pub async fn run_attempt(
                 agent_id: Some(agent_id),
                 worktree: Some(worktree),
                 outcome: AttemptOutcome::AwaitingAnswer,
-                events,
+                events: events.into_events(),
             };
         }
 
@@ -425,7 +527,7 @@ pub async fn run_attempt(
                     agent_id: Some(agent_id),
                     worktree: Some(worktree),
                     outcome: AttemptOutcome::Done { verdict },
-                    events,
+                    events: events.into_events(),
                 }
             }
             GateOutcome::AwaitingApproval => {
@@ -433,7 +535,7 @@ pub async fn run_attempt(
                     agent_id: Some(agent_id),
                     worktree: Some(worktree),
                     outcome: AttemptOutcome::AwaitingApproval,
-                    events,
+                    events: events.into_events(),
                 }
             }
             GateOutcome::Blocked => {
@@ -449,7 +551,7 @@ pub async fn run_attempt(
                     outcome: AttemptOutcome::Blocked {
                         reason: result.reason,
                     },
-                    events,
+                    events: events.into_events(),
                 };
             }
         }
@@ -484,7 +586,7 @@ pub(super) async fn drive_prompt_turn(
     prompt_kind: &'static str,
     deadlines: &Deadlines,
 ) -> (OrchTurn, Vec<AttemptEvent>) {
-    let mut events = Vec::new();
+    let mut events = EventLog::detached();
     // Subscribe BEFORE sending so an arbitrarily fast Running→Idle flap is
     // unlosable (spec §6.3 step 4) — the same discipline as `run_attempt`.
     let mut rx = driver.subscribe();
@@ -492,7 +594,7 @@ pub(super) async fn drive_prompt_turn(
     if let Err(e) = driver.send_message(agent_id, prompt).await {
         let error = format!("send failed: {e}");
         events.push(ev(event_type::ATTEMPT_ERROR, json!({ "error": error })));
-        return (OrchTurn::Error(error), events);
+        return (OrchTurn::Error(error), events.into_events());
     }
     events.push(ev(event_type::PROMPT_SENT, json!({ "kind": prompt_kind })));
 
@@ -516,7 +618,7 @@ pub(super) async fn drive_prompt_turn(
         // never on its own — unreachable here (no cancel is raced).
         TurnEnd::Canceled => OrchTurn::Error("orchestrator turn canceled".into()),
     };
-    (result, events)
+    (result, events.into_events())
 }
 
 /// Stop the (still-live) agent and return an `Error` outcome. Errored/timed-out
@@ -526,7 +628,7 @@ async fn terminal_error(
     driver: &dyn AgentDriver,
     agent_id: &str,
     error: &str,
-    mut events: Vec<AttemptEvent>,
+    mut events: EventLog,
 ) -> AttemptRun {
     let _ = driver.stop(agent_id).await;
     events.push(ev(event_type::ATTEMPT_ERROR, json!({ "error": error })));
@@ -536,7 +638,7 @@ async fn terminal_error(
         outcome: AttemptOutcome::Error {
             error: error.to_string(),
         },
-        events,
+        events: events.into_events(),
     }
 }
 
@@ -547,14 +649,14 @@ async fn terminal_error(
 async fn terminal_canceled(
     driver: &dyn AgentDriver,
     agent_id: &str,
-    events: Vec<AttemptEvent>,
+    events: EventLog,
 ) -> AttemptRun {
     let _ = driver.stop(agent_id).await;
     AttemptRun {
         agent_id: Some(agent_id.to_string()),
         worktree: None,
         outcome: AttemptOutcome::Canceled,
-        events,
+        events: events.into_events(),
     }
 }
 
@@ -574,7 +676,7 @@ fn budget_exceeded_run(
     agent_id: String,
     worktree: PathBuf,
     which: BudgetLimit,
-    mut events: Vec<AttemptEvent>,
+    mut events: EventLog,
 ) -> AttemptRun {
     events.push(ev(
         event_type::BUDGET_EXCEEDED,
@@ -586,7 +688,7 @@ fn budget_exceeded_run(
         outcome: AttemptOutcome::BudgetExceeded {
             which: which.as_str().to_string(),
         },
-        events,
+        events: events.into_events(),
     }
 }
 
@@ -666,7 +768,7 @@ async fn drive_turn(
     rx: &mut Receiver<StatusEvent>,
     snapshot: Option<AgentStatus>,
     d: &Deadlines,
-    events: &mut Vec<AttemptEvent>,
+    events: &mut EventLog,
 ) -> TurnEnd {
     let mut seen_running = matches!(snapshot, Some(AgentStatus::Running));
     let start_deadline = Instant::now() + d.turn_start_timeout;
@@ -815,6 +917,7 @@ mod tests {
             reprompt_on_block: true,
             cancel: Arc::new(AtomicBool::new(false)),
             pending_ask: Arc::new(AtomicBool::new(false)),
+            journal: None,
         }
     }
 

--- a/src-tauri/src/workflow/comms/mod.rs
+++ b/src-tauri/src/workflow/comms/mod.rs
@@ -154,8 +154,7 @@ fn body_str<'a>(body: &'a Value, key: &str) -> &'a str {
 /// `None` when the op is not a message at all (`wf_decide` / `wf_compose` record
 /// decisions, which are engine plumbing) or the run is not building a board item.
 ///
-/// This side only *attributes* the message — the sender is resolvable here and
-/// nowhere else, because `wf_step_exec.agent_id` is stamped after the turn. What
+/// This side only *attributes* the message. What
 /// is worth forwarding is the roadmap's decision, not the engine's: every comms
 /// *message* kind is handed over and [`crate::roadmap::review::routes_midrun`] is
 /// the single gate (notably, it never routes an `ask` — that is the user's

--- a/src-tauri/src/workflow/comms/sender.rs
+++ b/src-tauri/src/workflow/comms/sender.rs
@@ -55,15 +55,15 @@ fn step_caps(spec: &Spec, step_id: &str) -> Option<Vec<CommsCap>> {
     walk(&spec.workflow, step_id).map(<[CommsCap]>::to_vec)
 }
 
-/// Resolve the live step attempt behind a run-owned agent's mailbox. Keyed by
+/// Resolve the live step attempt behind a run-owned agent's mailbox. Scoped by
 /// `run_id` (which the dispatcher captures from the agent's `owner_run_id` at
-/// spawn) rather than `agent_id`: the scheduler only stamps `wf_step_exec.
-/// agent_id` *after* the turn completes, so during the turn — exactly when a
-/// comms op fires — that column is still NULL and an agent-id lookup would miss.
-/// When the row is already linked to `agent_id` (a future/parallel case) that
-/// row is preferred; otherwise the run's single in-flight attempt is used, and
-/// concurrent in-flight attempts (parallel comms, unsupported in v1) are an
-/// explicit error rather than a silent misattribution.
+/// spawn), then matched on `agent_id`: every attempt now stamps that column when
+/// its spawn returns, so the exact match is the normal path — including for a
+/// parallel stage's concurrent children.
+///
+/// The fallback covers a row not yet linked (an attempt whose spawn is still in
+/// flight): the run's single in-flight attempt is used, and concurrent in-flight
+/// attempts are an explicit error rather than a silent misattribution.
 pub(super) fn resolve_sender(conn: &Connection, run_id: &str, agent_id: &str) -> Result<Sender> {
     let live: Vec<(String, String, Option<String>)> = conn
         .prepare(

--- a/src-tauri/src/workflow/gates.rs
+++ b/src-tauri/src/workflow/gates.rs
@@ -234,15 +234,28 @@ fn tests_block_reason(tests: Option<&TestsOutcome>) -> Option<String> {
     }
 }
 
+/// How much of the runner's output tail rides in a gate reason. The verifier
+/// keeps 100 lines, which is right for a log pane but not for a reason string:
+/// this one becomes the run's `error` (the monitor's failure banner) and the
+/// re-prompt, and a per-test runner fills 100 lines with passes. Every runner
+/// prints its failure summary last, so the final lines are the signal.
+const REASON_TAIL_LINES: usize = 20;
+
 /// Compose a gate reason from a headline plus an optional output tail. The tail
 /// rides in the reason so it reaches both the `gate_evaluated` journal event and
 /// the re-prompt (spec §9.4) through the existing blocked-reason plumbing.
 fn with_tail(headline: &str, tail: &str) -> String {
     let tail = tail.trim_end();
     if tail.is_empty() {
-        headline.to_string()
+        return headline.to_string();
+    }
+    let lines: Vec<&str> = tail.lines().collect();
+    let start = lines.len().saturating_sub(REASON_TAIL_LINES);
+    let kept = lines[start..].join("\n");
+    if start > 0 {
+        format!("{headline} (last {REASON_TAIL_LINES} lines):\n{kept}")
     } else {
-        format!("{headline}:\n{tail}")
+        format!("{headline}:\n{kept}")
     }
 }
 

--- a/src-tauri/src/workflow/scheduler/orchestrate.rs
+++ b/src-tauri/src/workflow/scheduler/orchestrate.rs
@@ -1736,6 +1736,13 @@ async fn drive_orch_child(c: ChildCtx, stage_entry_sha: Option<String>) -> OrchC
             reprompt_on_block: true,
             cancel: c.stage_cancel.clone(),
             pending_ask: Arc::new(AtomicBool::new(false)),
+            // Journal live, like every other attempt. The exec row was already
+            // stamped with this pre-spawned agent above.
+            journal: Some(attempt::AttemptJournal {
+                db: c.db.clone(),
+                app: c.app.clone(),
+                run_id: c.run_id.clone(),
+            }),
         };
 
         let started = crate::workflow::now_ms();
@@ -1753,16 +1760,6 @@ async fn drive_orch_child(c: ChildCtx, stage_entry_sha: Option<String>) -> OrchC
                 "UPDATE wf_step_exec SET started_at = ?1 WHERE id = ?2 AND started_at IS NULL",
                 rusqlite::params![started, exec_id],
             );
-            for e in &result.events {
-                journal_event(
-                    &conn,
-                    c.app.as_ref(),
-                    &c.run_id,
-                    e.event_type,
-                    Some(&exec_id),
-                    &e.payload,
-                );
-            }
         }
 
         // Drain the mailbox so a `wf_ask` from this turn is persisted (§10.4).

--- a/src-tauri/src/workflow/scheduler/parallel.rs
+++ b/src-tauri/src/workflow/scheduler/parallel.rs
@@ -981,9 +981,16 @@ async fn drive_child(c: ChildCtx, stage_entry_sha: Option<String>) -> ChildResul
             // linear-run concern in S10); a never-set flag preserves existing
             // behavior until orchestrator routing lands (S11).
             pending_ask: Arc::new(AtomicBool::new(false)),
+            // Journal live (linear-path parity): each child writes its own events
+            // and stamps its exec row as it goes, so a stage's children are
+            // visible while they run rather than only once they finish.
+            journal: Some(attempt::AttemptJournal {
+                db: c.db.clone(),
+                app: c.app.clone(),
+                run_id: c.run_id.clone(),
+            }),
         };
 
-        let started = crate::workflow::now_ms();
         let result = attempt::run_attempt(
             c.driver.as_ref(),
             &test_runner,
@@ -992,27 +999,6 @@ async fn drive_child(c: ChildCtx, stage_entry_sha: Option<String>) -> ChildResul
             &step_eff,
         )
         .await;
-
-        // Journal the attempt's events + stamp its agent id (linear-path parity).
-        {
-            let conn = c.db.lock();
-            if let Some(agent_id) = &result.agent_id {
-                let _ = conn.execute(
-                    "UPDATE wf_step_exec SET agent_id = ?1, started_at = ?2 WHERE id = ?3",
-                    rusqlite::params![agent_id, started, exec_id],
-                );
-            }
-            for e in &result.events {
-                journal_event(
-                    &conn,
-                    c.app.as_ref(),
-                    &c.run_id,
-                    e.event_type,
-                    Some(&exec_id),
-                    &e.payload,
-                );
-            }
-        }
 
         match result.outcome {
             AttemptOutcome::Done { .. } => {

--- a/src-tauri/src/workflow/scheduler/steps.rs
+++ b/src-tauri/src/workflow/scheduler/steps.rs
@@ -314,31 +314,22 @@ pub(crate) async fn execute_step(
             // Shared with the run's `RunHandle` so the comms router and this
             // attempt observe the same pending-ask flag (§10.4).
             pending_ask: ctx.pending_ask.clone(),
+            // Journal live: the attempt writes each event and stamps the exec row
+            // as it goes, so the monitor shows this step while it runs.
+            journal: Some(attempt::AttemptJournal {
+                db: ctx.db.clone(),
+                app: ctx.app.clone(),
+                run_id: run_id.to_string(),
+            }),
         };
 
-        let started = crate::workflow::now_ms();
         let result =
             attempt::run_attempt(ctx.driver.as_ref(), &test_runner, params, ledger, &step_eff)
                 .await;
-        // Journal the attempt's events, stamp its agent id, persist the ledger.
+        // The attempt journaled its own events and stamped its agent id; persist
+        // the ledger it advanced.
         {
             let conn = ctx.db.lock();
-            if let Some(agent_id) = &result.agent_id {
-                let _ = conn.execute(
-                    "UPDATE wf_step_exec SET agent_id = ?1, started_at = ?2 WHERE id = ?3",
-                    rusqlite::params![agent_id, started, exec_id],
-                );
-            }
-            for e in &result.events {
-                journal_event(
-                    &conn,
-                    ctx.app.as_ref(),
-                    run_id,
-                    e.event_type,
-                    Some(&exec_id),
-                    &e.payload,
-                );
-            }
             ledger.checkpoint_wall(crate::workflow::now_ms());
             persist_spent(&conn, run_id, ledger);
         }

--- a/src-tauri/src/workflow/scheduler/tests.rs
+++ b/src-tauri/src/workflow/scheduler/tests.rs
@@ -29,6 +29,9 @@ struct StubDriver {
     /// Whether the "agent" commits during its turn. `false` models an agent
     /// that does nothing, so a `commit` gate stays unmet (blocked-gate test).
     commit: bool,
+    /// When set, the first prompt snapshots what the monitor could see *at that
+    /// moment* (see `peeked`) — the mid-attempt visibility the live journal buys.
+    peek: Option<Db>,
     tx: broadcast::Sender<StatusEvent>,
     state: parking_lot::Mutex<StubState>,
 }
@@ -40,15 +43,30 @@ struct StubState {
     /// How many times `stop` was called — lets a test prove that entering
     /// `paused` stops the live step agent (§6.5).
     stops: usize,
+    /// (exec.agent_id, exec.status, journaled event count) as of the first prompt.
+    peeked: Option<(Option<String>, String, i64)>,
 }
 impl StubDriver {
     fn new(root: PathBuf, commit: bool) -> Arc<Self> {
         Arc::new(Self {
             root,
             commit,
+            peek: None,
             tx: broadcast::channel(256).0,
             state: parking_lot::Mutex::new(StubState::default()),
         })
+    }
+    fn with_peek(root: PathBuf, commit: bool, db: Db) -> Arc<Self> {
+        Arc::new(Self {
+            root,
+            commit,
+            peek: Some(db),
+            tx: broadcast::channel(256).0,
+            state: parking_lot::Mutex::new(StubState::default()),
+        })
+    }
+    fn peeked(&self) -> Option<(Option<String>, String, i64)> {
+        self.state.lock().peeked.clone()
     }
     fn set(&self, id: &str, s: AgentStatus) {
         self.state.lock().statuses.insert(id.to_string(), s.clone());
@@ -107,6 +125,26 @@ impl AgentDriver for StubDriver {
     ) -> super::super::driver::BoxFuture<'a, Result<()>> {
         Box::pin(async move {
             let wt = self.state.lock().worktrees.get(id).cloned().unwrap();
+            if let Some(db) = &self.peek {
+                // Read the row the monitor reads, mid-attempt. Taken before any
+                // state lock so this never nests the two locks.
+                let row = {
+                    let conn = db.lock();
+                    conn.query_row(
+                        "SELECT agent_id, status,
+                                (SELECT COUNT(*) FROM wf_event WHERE run_id = e.run_id)
+                         FROM wf_step_exec e WHERE e.agent_id = ?1 OR e.agent_id IS NULL
+                         ORDER BY e.agent_id IS NULL LIMIT 1",
+                        [id],
+                        |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+                    )
+                    .ok()
+                };
+                let mut st = self.state.lock();
+                if st.peeked.is_none() {
+                    st.peeked = row;
+                }
+            }
             self.set(id, AgentStatus::Running);
             if self.commit {
                 std::fs::write(wt.join(format!("{id}.txt")), "work").unwrap();
@@ -493,6 +531,43 @@ async fn cancel_marks_run_canceled_and_runs_no_step() {
         })
         .unwrap();
     assert_eq!(status, "canceled");
+}
+
+#[tokio::test]
+async fn a_step_is_visible_while_it_runs_not_only_once_it_ends() {
+    // The monitor resolves a step's chat through `wf_step_exec.agent_id` and only
+    // refetches when a `wf:event` lands. Both used to happen after the attempt
+    // returned, so a running step showed an empty pane for its whole duration and
+    // the run read as stuck. Assert the row is linked and events are journaled by
+    // the time the agent is prompted — i.e. while the step is still working.
+    let tmp = tempfile::tempdir().unwrap();
+    let (db, ws) = scaffold_one_step(tmp.path(), "run-live", "wf/l-1", Gate::Commit);
+    let driver = StubDriver::with_peek(ws, true, db.clone());
+    let ctx = RunCtx {
+        db: db.clone(),
+        driver: driver.clone(),
+        app: None,
+        cancel: Arc::new(AtomicBool::new(false)),
+        pending_ask: Arc::new(AtomicBool::new(false)),
+        deadlines: Deadlines::default(),
+        runs: None,
+    };
+    drive_run(&ctx, "run-live").await;
+
+    let (agent_id, status, events) = driver.peeked().expect("the agent was prompted");
+    assert_eq!(
+        agent_id.as_deref(),
+        Some("stub-1"),
+        "the attempt row must name its live agent before the turn"
+    );
+    assert_eq!(
+        status, "running",
+        "a live attempt must not still read 'spawning'"
+    );
+    assert!(
+        events > 0,
+        "spawn/ready must already be journaled, so the monitor refetches mid-step"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Three faults, found while diagnosing "the run appears in the sidebar, shows as loading, but does nothing" — which turned out to be one bug wearing three faces.

## The tests gate ran the wrong command

`run_detect/node.rs` built the `test` and `build` rows as `{pm} <script>`. bun reserves both names as built-in subcommands: `bun test` is bun's own test runner, `bun build` its bundler — neither runs the package script. So the gate ran bun's runner over every `*.test.*` in the repo (931 tests across 93 files) instead of `vitest run`, reported 13 failures and 8 errors the project does not have, and failed a run whose own `bun run test` was 988/988 green.

Both rows now go through `run` — the spelling the `lint` row already used, and equally valid for npm/pnpm/yarn. `dev`/`start` are untouched (bun does not reserve those).

## A gate failure dumped the whole log into the banner

The reason string carried the verifier's full 100-line output tail into `wf_run.error`, so the monitor's failure banner was a wall of `(pass)` lines. `with_tail` now keeps the last 20 (`REASON_TAIL_LINES`) and says so when it truncates; the verifier keeps its 100 lines for the log pane. Every runner prints its failure summary last, so the signal survives.

## A step was invisible until it finished

`attempt.rs` buffered all 17 event kinds in a `Vec` and returned them; `steps.rs` / `parallel.rs` / `orchestrate.rs` journaled that batch — and stamped `wf_step_exec.agent_id` — only after `run_attempt` returned. Both run views refetch solely on `wf:event` (no polling), and the chat pane resolves its agent through `agent_id`. So from ~1s after launch until the attempt ended, nothing updated: no step children in the sidebar, an empty chat, an empty timeline, then everything at once.

Measured on run `wf/feature-workflow-1f9a780d`: each handoff between steps was 3–6s and first agent output came ~4s after each prompt, yet the timeline stamped *every* entry — turn ended, budget updated, gate blocked, re-prompted, nudge sent — at one instant, 18:39:12.

`AttemptJournal` (db + app + run_id) now writes each event through as it is pushed, and stamps `agent_id` / `status='running'` / `started_at` when the spawn returns. The three call sites supply it and drop their write-back loops; the pre-spawned orchestrate path skips the stamp, since its caller owns that spawn. `AttemptRun::events` survives as the lifecycle tests' window into the state machine.

No frontend change was needed. As a side effect `autoAttempt` now selects the live attempt, because the row finally reads `running` while it runs.

### A real bug fell out of it

`comms::sender::resolve_sender` matches the sending agent on `wf_step_exec.agent_id`, falling back to "the run's single live attempt". With the column NULL mid-turn, every `wf_ask`/`wf_report` from a **parallel** stage's child hit the ambiguous-sender arm and failed with "cannot attribute a comms op among concurrent steps". The exact match works now. The two comments that documented the old stamp-after-the-turn invariant are updated.

## Tests

`a_step_is_visible_while_it_runs_not_only_once_it_ends` snapshots what the monitor could see at prompt time, through a peeking stub driver — verified to fail without the fix (`left: None, right: Some("stub-1")`). Plus `bun_test_and_build_go_through_run`, and two existing expectations updated to the `run` spelling.

1384 lib tests pass; clippy and fmt clean.

## Not in scope

The stall watchdog behind that timeline's "No activity — nudging the agent" (`stall_timeout: 600s`, `nudge_timeout: 300s`). Live journaling now puts real timestamps on the stall and the nudge, which is the evidence needed to tell a genuinely quiet agent from a missed Running→Idle transition.