### PR TITLE
feat(code-panel): persisted diff-base switch — all changes vs uncommitted

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -23,6 +23,19 @@ pub(super) fn diff_base(repo: &TrackedRepo) -> Option<String> {
     repo.base_sha.clone().or_else(|| repo.parent_branch.clone())
 }
 
+/// Which ref the Code panel's diff surfaces measure against — the user's
+/// persisted base switch. `Fork` is everything the agent changed in this
+/// workspace (vs [`diff_base`]); `Head` is only uncommitted work (vs the
+/// checkout's latest commit), matching the base the file lists already use
+/// (`git_state::query` reads status/numstat vs HEAD).
+#[derive(Debug, Clone, Copy, Default, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiffBaseMode {
+    #[default]
+    Fork,
+    Head,
+}
+
 // ---------------------------------------------------------------------------
 // File panel — browse the checkout, view & edit file contents.
 // ---------------------------------------------------------------------------
@@ -461,14 +474,21 @@ pub async fn list_dir(path: String) -> Result<DirListing> {
 }
 
 /// Read a checkout file for the viewer/editor: contents, language hint,
-/// git status, and the changed-line numbers driving the gutter.
+/// git status, and the changed-line numbers driving the gutter. `base_mode`
+/// picks the ref the gutter (and a deleted file's prior contents) diff
+/// against; omitted means the fork point.
 #[tauri::command]
 pub async fn read_checkout_file(
     supervisor: State<'_, Arc<Supervisor>>,
     agent_id: String,
     path: String,
+    base_mode: Option<DiffBaseMode>,
 ) -> Result<CheckoutFileContents> {
     let (checkout, parent, path) = checkout_scope_for_path(&supervisor, &agent_id, &path)?;
+    let parent = match base_mode.unwrap_or_default() {
+        DiffBaseMode::Head => "HEAD".to_string(),
+        DiffBaseMode::Fork => parent,
+    };
     let abs = safe_join(&checkout, &path)?;
     let lang = lang_for(&path);
 
@@ -528,15 +548,21 @@ pub async fn read_checkout_file(
     })
 }
 
-/// Full unified diff of one checkout file versus the parent branch — the data
-/// behind the Code panel's Live view. Returns "" when the file is unchanged.
+/// Full unified diff of one checkout file — the data behind the Code panel's
+/// Live view and the editor's Diff toggle. `base_mode` picks the base ref
+/// (fork point when omitted). Returns "" when the file is unchanged.
 #[tauri::command]
 pub async fn get_file_diff(
     supervisor: State<'_, Arc<Supervisor>>,
     agent_id: String,
     path: String,
+    base_mode: Option<DiffBaseMode>,
 ) -> Result<String> {
     let (checkout, parent, path) = checkout_scope_for_path(&supervisor, &agent_id, &path)?;
+    let parent = match base_mode.unwrap_or_default() {
+        DiffBaseMode::Head => "HEAD".to_string(),
+        DiffBaseMode::Fork => parent,
+    };
     git::file_diff(&checkout, &parent, &path).await
 }
 

--- a/src/api/domains/files.ts
+++ b/src/api/domains/files.ts
@@ -1,5 +1,10 @@
 import { invoke } from "../invoke";
-import type { CheckoutFile, CheckoutFileContents, DirListing } from "../types/checkout";
+import type {
+  CheckoutFile,
+  CheckoutFileContents,
+  DiffBaseMode,
+  DirListing,
+} from "../types/checkout";
 
 export const filesApi = {
   listCheckoutTree: (agentId: string) => invoke<CheckoutFile[]>("list_checkout_tree", { agentId }),
@@ -7,10 +12,10 @@ export const filesApi = {
   // Draft (new-workspace) composer variants, keyed by repo path since a draft
   // has no agent/checkout yet.
   listRepoTree: (repoPath: string) => invoke<string[]>("list_repo_tree", { repoPath }),
-  readCheckoutFile: (agentId: string, path: string) =>
-    invoke<CheckoutFileContents>("read_checkout_file", { agentId, path }),
-  getFileDiff: (agentId: string, path: string) =>
-    invoke<string>("get_file_diff", { agentId, path }),
+  readCheckoutFile: (agentId: string, path: string, baseMode?: DiffBaseMode) =>
+    invoke<CheckoutFileContents>("read_checkout_file", { agentId, path, baseMode }),
+  getFileDiff: (agentId: string, path: string, baseMode?: DiffBaseMode) =>
+    invoke<string>("get_file_diff", { agentId, path, baseMode }),
   writeCheckoutFile: (agentId: string, path: string, contents: string) =>
     invoke<void>("write_checkout_file", { agentId, path, contents }),
   renameCheckoutPath: (agentId: string, from: string, to: string) =>

--- a/src/api/types/checkout.ts
+++ b/src/api/types/checkout.ts
@@ -1,3 +1,9 @@
+/** Which ref the Code panel's diff surfaces measure against — the panel's
+ *  persisted base switch. "fork" = everything the agent changed in this
+ *  workspace (vs its starting commit); "head" = only uncommitted work (vs the
+ *  checkout's latest commit). */
+export type DiffBaseMode = "fork" | "head";
+
 /** One file in the checkout, as returned by `list_checkout_tree`.
  *  `status` is the single-letter git status vs the parent branch
  *  ("M" | "A" | "D" | "R"), or null when the file is unchanged.

--- a/src/components/RightPanel/Code/Code.css
+++ b/src/components/RightPanel/Code/Code.css
@@ -16,6 +16,10 @@
    an inset filled-thumb pill, not an underline tab — so it reads as a control
    within the Code panel rather than as switching between panels. */
 .code-modes {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
   padding: 7px 10px;
   border-bottom: 1px solid var(--bd-soft);
   background: var(--bg-1);

--- a/src/components/RightPanel/Code/CodeLivePanel.tsx
+++ b/src/components/RightPanel/Code/CodeLivePanel.tsx
@@ -7,7 +7,7 @@
 // and fetches each file's diff via `get_file_diff`. True edit-streaming (a
 // typing cursor per keystroke) is a deferred follow-up.
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { AgentRecord, FileStatus } from "@/api";
+import type { AgentRecord, DiffBaseMode, FileStatus } from "@/api";
 import { Icon } from "@/components/Icon";
 import { useAppStore } from "@/store";
 import { useHljsTheme } from "@/util/codeTheme";
@@ -18,6 +18,8 @@ interface CodeLivePanelProps {
   agent: AgentRecord;
   /** The file shared with Files mode; may be null or point at an unchanged file. */
   selectedPath: string | null;
+  /** The Code panel's base switch: what the rendered diff measures against. */
+  diffBase: DiffBaseMode;
   onSelect: (path: string) => void;
   onOpenInEditor: (path: string) => void;
 }
@@ -46,6 +48,7 @@ const sigOf = (f: FileStatus) => `${f.additions}:${f.deletions}`;
 export function CodeLivePanel({
   agent,
   selectedPath,
+  diffBase,
   onSelect,
   onOpenInEditor,
 }: CodeLivePanelProps) {
@@ -147,7 +150,7 @@ export function CodeLivePanel({
 
   // ── diff fetch ──────────────────────────────────────────────────────────
   // Refetch when the shown file changes or its +/- counts move during a turn.
-  const { hunks, error: diffErr } = useFileDiff(agent.id, displayPath, displaySigStr);
+  const { hunks, error: diffErr } = useFileDiff(agent.id, displayPath, displaySigStr, diffBase);
 
   // ── fresh-line highlighting ──────────────────────────────────────────────
   // Mark added lines that weren't present last time we rendered this same file

--- a/src/components/RightPanel/Code/DiffView.tsx
+++ b/src/components/RightPanel/Code/DiffView.tsx
@@ -2,16 +2,22 @@
 // editor's "Diff" toggle both fetch a file's unified diff and render it here,
 // so there's a single implementation of the diff markup + syntax highlighting.
 import { useEffect, useMemo, useState } from "react";
-import { api } from "@/api";
+import { api, type DiffBaseMode } from "@/api";
 import { hljsLang } from "@/data/languages";
 import { type DiffHunk, type DiffLine, parseUnifiedDiff } from "@/util/diff";
 import { highlightToHtml } from "@/util/highlight";
 
 export const extOf = (path: string) => path.split(".").pop() ?? "";
 
-/** Fetch + parse a file's unified diff vs the parent branch. `dep` lets the
- *  caller force a refetch (e.g. when the file's +/- counts move during a turn). */
-export function useFileDiff(agentId: string, path: string | null, dep?: string) {
+/** Fetch + parse a file's unified diff vs `base` (fork point when omitted).
+ *  `dep` lets the caller force a refetch (e.g. when the file's +/- counts move
+ *  during a turn). */
+export function useFileDiff(
+  agentId: string,
+  path: string | null,
+  dep?: string,
+  base?: DiffBaseMode,
+) {
   const [hunks, setHunks] = useState<DiffHunk[]>([]);
   const [error, setError] = useState(false);
   const [loaded, setLoaded] = useState(false);
@@ -25,7 +31,7 @@ export function useFileDiff(agentId: string, path: string | null, dep?: string) 
     }
     let cancelled = false;
     api
-      .getFileDiff(agentId, path)
+      .getFileDiff(agentId, path, base)
       .then((t) => {
         if (!cancelled) {
           setHunks(parseUnifiedDiff(t));
@@ -43,7 +49,7 @@ export function useFileDiff(agentId: string, path: string | null, dep?: string) 
     return () => {
       cancelled = true;
     };
-  }, [agentId, path, dep]);
+  }, [agentId, path, dep, base]);
 
   return { hunks, error, loaded };
 }
@@ -105,13 +111,15 @@ export function FileDiff({
   path,
   lang,
   isBuiltInTheme,
+  base,
 }: {
   agentId: string;
   path: string;
   lang: string;
   isBuiltInTheme: boolean;
+  base?: DiffBaseMode;
 }) {
-  const { hunks, error, loaded } = useFileDiff(agentId, path);
+  const { hunks, error, loaded } = useFileDiff(agentId, path, undefined, base);
 
   if (!loaded) {
     return (

--- a/src/components/RightPanel/Code/index.tsx
+++ b/src/components/RightPanel/Code/index.tsx
@@ -7,7 +7,7 @@
 // cross-links work: the editor's "Diff" button jumps to Live on that file, and
 // Live's "Edit" button opens the file back in Files mode.
 import { useEffect, useState } from "react";
-import type { AgentRecord } from "@/api";
+import type { AgentRecord, DiffBaseMode } from "@/api";
 import { Icon } from "@/components/Icon";
 import { FilePanel } from "@/components/RightPanel/FilePanel";
 import { useAppStore } from "@/store";
@@ -15,13 +15,19 @@ import { CodeLivePanel } from "./CodeLivePanel";
 
 type Mode = "files" | "live";
 const MODE_KEY = "q2:codeMode";
+const BASE_KEY = "q2:diffBase";
 
 function loadMode(): Mode {
   return localStorage.getItem(MODE_KEY) === "live" ? "live" : "files";
 }
 
+function loadBase(): DiffBaseMode {
+  return localStorage.getItem(BASE_KEY) === "head" ? "head" : "fork";
+}
+
 export function CodePanel({ agent }: { agent: AgentRecord }) {
   const [mode, setMode] = useState<Mode>(loadMode);
+  const [diffBase, setDiffBase] = useState<DiffBaseMode>(loadBase);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
 
   // The selected file is per-agent; drop it when the agent changes.
@@ -34,17 +40,31 @@ export function CodePanel({ agent }: { agent: AgentRecord }) {
     localStorage.setItem(MODE_KEY, m);
   };
 
+  const changeBase = (b: DiffBaseMode) => {
+    setDiffBase(b);
+    localStorage.setItem(BASE_KEY, b);
+  };
+
   return (
     <div className="code-panel">
-      <ModeSwitch agent={agent} mode={mode} onChange={changeMode} />
+      <div className="code-modes">
+        <ModeSwitch agent={agent} mode={mode} onChange={changeMode} />
+        <BaseSwitch value={diffBase} onChange={changeBase} />
+      </div>
       <div className="code-panel-body">
         {mode === "files" ? (
-          <FilePanel agent={agent} openPath={selectedPath} onOpenPath={setSelectedPath} />
+          <FilePanel
+            agent={agent}
+            openPath={selectedPath}
+            onOpenPath={setSelectedPath}
+            diffBase={diffBase}
+          />
         ) : (
           <CodeLivePanel
             agent={agent}
             selectedPath={selectedPath}
             onSelect={setSelectedPath}
+            diffBase={diffBase}
             onOpenInEditor={(p) => {
               setSelectedPath(p);
               changeMode("files");
@@ -52,6 +72,43 @@ export function CodePanel({ agent }: { agent: AgentRecord }) {
           />
         )}
       </div>
+    </div>
+  );
+}
+
+// What the diffs measure against: the workspace's starting commit (everything
+// the agent has done here) or the latest commit (only uncommitted work). The
+// file lists always count vs the latest commit, so "Uncommitted" is the mode
+// where the diff matches the +/− counts beside it.
+function BaseSwitch({
+  value,
+  onChange,
+}: {
+  value: DiffBaseMode;
+  onChange: (b: DiffBaseMode) => void;
+}) {
+  return (
+    <div className="code-modeswitch" role="tablist" aria-label="Diff base">
+      <button
+        role="tab"
+        aria-selected={value === "fork"}
+        className={`cms-seg iflex-center text-xs ${value === "fork" ? "active" : ""} tip`}
+        data-tip-down
+        data-tip="Diff everything changed in this workspace, since it started"
+        onClick={() => onChange("fork")}
+      >
+        <span>All</span>
+      </button>
+      <button
+        role="tab"
+        aria-selected={value === "head"}
+        className={`cms-seg iflex-center text-xs ${value === "head" ? "active" : ""} tip`}
+        data-tip-down
+        data-tip="Diff only uncommitted work, since the last commit"
+        onClick={() => onChange("head")}
+      >
+        <span>Uncommitted</span>
+      </button>
     </div>
   );
 }
@@ -77,32 +134,30 @@ function ModeSwitch({
   const busy = useAppStore((s) => s.managedBusy[agent.id] ?? false);
 
   return (
-    <div className="code-modes flex-center">
-      <div className="code-modeswitch" role="tablist" aria-label="Code view mode">
-        <button
-          role="tab"
-          aria-selected={mode === "files"}
-          className={`cms-seg iflex-center text-xs ${mode === "files" ? "active" : ""} tip`}
-          data-tip-down
-          data-tip="Browse and edit any file in the checkout"
-          onClick={() => onChange("files")}
-        >
-          <Icon name="folder" size={12} />
-          <span>Explore</span>
-        </button>
-        <button
-          role="tab"
-          aria-selected={mode === "live"}
-          className={`cms-seg iflex-center text-xs ${mode === "live" ? "active" : ""} tip`}
-          data-tip-down
-          data-tip="Watch the agent's changes as they happen"
-          onClick={() => onChange("live")}
-        >
-          <Icon name="zap" size={12} />
-          <span>Live</span>
-          {(hasChanges || busy) && <span className={`cms-live-dot ${busy ? "on" : ""}`}></span>}
-        </button>
-      </div>
+    <div className="code-modeswitch" role="tablist" aria-label="Code view mode">
+      <button
+        role="tab"
+        aria-selected={mode === "files"}
+        className={`cms-seg iflex-center text-xs ${mode === "files" ? "active" : ""} tip`}
+        data-tip-down
+        data-tip="Browse and edit any file in the checkout"
+        onClick={() => onChange("files")}
+      >
+        <Icon name="folder" size={12} />
+        <span>Explore</span>
+      </button>
+      <button
+        role="tab"
+        aria-selected={mode === "live"}
+        className={`cms-seg iflex-center text-xs ${mode === "live" ? "active" : ""} tip`}
+        data-tip-down
+        data-tip="Watch the agent's changes as they happen"
+        onClick={() => onChange("live")}
+      >
+        <Icon name="zap" size={12} />
+        <span>Live</span>
+        {(hasChanges || busy) && <span className={`cms-live-dot ${busy ? "on" : ""}`}></span>}
+      </button>
     </div>
   );
 }

--- a/src/components/RightPanel/FilePanel/FileEditor.tsx
+++ b/src/components/RightPanel/FilePanel/FileEditor.tsx
@@ -3,7 +3,7 @@
 // Edit, ⌘S to save, Revert to restore the agent's version. The "Diff" toggle
 // swaps the editor for a read-only unified diff of the agent's changes.
 import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
-import { type AgentRecord, api, type CheckoutFileContents } from "@/api";
+import { type AgentRecord, api, type CheckoutFileContents, type DiffBaseMode } from "@/api";
 import { Icon } from "@/components/Icon";
 import { FileDiff } from "@/components/RightPanel/Code/DiffView";
 import { CODE_THEMES } from "@/data/codeThemes";
@@ -19,10 +19,11 @@ interface FileEditorProps {
   name: string;
   dir: string;
   file: CheckoutFileContents;
+  diffBase: DiffBaseMode;
   onBack: () => void;
 }
 
-export function FileEditor({ agent, path, name, dir, file, onBack }: FileEditorProps) {
+export function FileEditor({ agent, path, name, dir, file, diffBase, onBack }: FileEditorProps) {
   const originalText = file.text;
   const [value, setValue] = useState(originalText);
   // Files auto-save a short beat after you stop typing — no Save button. This
@@ -217,7 +218,13 @@ export function FileEditor({ agent, path, name, dir, file, onBack }: FileEditorP
       />
 
       {diffView ? (
-        <FileDiff agentId={agent.id} path={path} lang={file.lang} isBuiltInTheme={isBuiltInTheme} />
+        <FileDiff
+          agentId={agent.id}
+          path={path}
+          lang={file.lang}
+          isBuiltInTheme={isBuiltInTheme}
+          base={diffBase}
+        />
       ) : (
         <>
           {isDeleted && (

--- a/src/components/RightPanel/FilePanel/FileViewer.tsx
+++ b/src/components/RightPanel/FilePanel/FileViewer.tsx
@@ -2,7 +2,7 @@
 // preview" message for binary / too-large / unreadable files, a loading
 // state, or the editable FileEditor.
 import { useEffect, useState } from "react";
-import { type AgentRecord, api, type CheckoutFileContents } from "@/api";
+import { type AgentRecord, api, type CheckoutFileContents, type DiffBaseMode } from "@/api";
 import { basename, parentDir } from "@/util/format";
 import { FileEditor } from "./FileEditor";
 import { ViewerHeader } from "./ViewerHeader";
@@ -10,10 +10,11 @@ import { ViewerHeader } from "./ViewerHeader";
 interface FileViewerProps {
   agent: AgentRecord;
   path: string;
+  diffBase: DiffBaseMode;
   onBack: () => void;
 }
 
-export function FileViewer({ agent, path, onBack }: FileViewerProps) {
+export function FileViewer({ agent, path, diffBase, onBack }: FileViewerProps) {
   const name = basename(path);
   const dir = parentDir(path);
 
@@ -25,7 +26,7 @@ export function FileViewer({ agent, path, onBack }: FileViewerProps) {
     setContents(null);
     setError(false);
     api
-      .readCheckoutFile(agent.id, path)
+      .readCheckoutFile(agent.id, path, diffBase)
       .then((c) => {
         if (!cancelled) setContents(c);
       })
@@ -35,7 +36,7 @@ export function FileViewer({ agent, path, onBack }: FileViewerProps) {
     return () => {
       cancelled = true;
     };
-  }, [agent.id, path]);
+  }, [agent.id, path, diffBase]);
 
   if (error || (contents && (contents.binary || contents.too_large))) {
     return (
@@ -80,6 +81,7 @@ export function FileViewer({ agent, path, onBack }: FileViewerProps) {
       name={name}
       dir={dir}
       file={contents}
+      diffBase={diffBase}
       onBack={onBack}
     />
   );

--- a/src/components/RightPanel/FilePanel/index.tsx
+++ b/src/components/RightPanel/FilePanel/index.tsx
@@ -15,7 +15,7 @@
 // Faithful port of the design (fletch v2 files.jsx), wired to the real
 // checkout via the `*_checkout_*` Tauri commands.
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { type AgentRecord, api, type CheckoutFile } from "@/api";
+import { type AgentRecord, api, type CheckoutFile, type DiffBaseMode } from "@/api";
 import { type ContextMenuEntry, FileContextMenu } from "@/components/RightPanel/FileContextMenu";
 import { joinPath, parentDir } from "@/util/format";
 import { usePoll } from "@/util/hooks";
@@ -38,9 +38,12 @@ interface FilePanelProps {
   // Live mode (and so "Open in editor" from Live can target it).
   openPath: string | null;
   onOpenPath: (path: string | null) => void;
+  // The Code panel's base switch: what the editor's gutter and Diff view
+  // measure against.
+  diffBase: DiffBaseMode;
 }
 
-export function FilePanel({ agent, openPath, onOpenPath }: FilePanelProps) {
+export function FilePanel({ agent, openPath, onOpenPath, diffBase }: FilePanelProps) {
   const [files, setFiles] = useState<CheckoutFile[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [query, setQuery] = useState("");
@@ -285,6 +288,7 @@ export function FilePanel({ agent, openPath, onOpenPath }: FilePanelProps) {
         key={openPath}
         agent={agent}
         path={openPath}
+        diffBase={diffBase}
         onBack={() => {
           onOpenPath(null);
           void refresh();


### PR DESCRIPTION
## Problem

The Code panel's diffs always measure against the workspace's fork-point commit (`TrackedRepo.base_sha`), while the Live tabs and their +/− counts already measure against HEAD (`git status` + `git diff --numstat HEAD`). Once the agent commits mid-session, the two disagree: a file the agent created, committed, then tweaked by two lines shows "+2" on its tab but renders as one whole-file-added hunk — making incremental review after a commit effectively impossible.

## Change

- **`DiffBaseMode` (`fork` | `head`)** on the two commands that resolve a diff base:
  - `get_file_diff` — the Live view's diff body and the editor's Diff toggle
  - `read_checkout_file` — the editor's change gutter and a deleted file's prior contents
  `head` diffs against the checkout's latest commit; omitted/`fork` keeps the existing fork-point behavior, so all other callers are untouched.
- **"All / Uncommitted" segmented control** in the Code panel header, next to the Explore/Live switch, applying to both modes. Tooltips explain each base. The choice persists in localStorage (`q2:diffBase`), following the existing `q2:codeMode` pattern, and flipping it refetches the open diff immediately.
- Plumbing: `useFileDiff`/`FileDiff` take the base; the prop threads through `CodeLivePanel` and `FilePanel → FileViewer → FileEditor`.

In "Uncommitted" mode the diff body now matches the +/− counts beside it; "All" keeps the cumulative pre-PR review view.

## Not included (follow-up)

In "All" mode the tab counts still measure vs HEAD (today's behavior), so a committed file's tab can undercount its cumulative diff. Making the lists follow the fork point would need a fork-based file-status query.

## Verification

`cargo check` / `clippy` / `cargo test` (1384 passed); `tsc --noEmit`, `biome check` (baseline warnings only), `vitest` (988 passed).