### PR TITLE
fix(git): stop the diff.external override from killing every patch diff

### DIFF
--- a/src-tauri/src/git/diff.rs
+++ b/src-tauri/src/git/diff.rs
@@ -71,7 +71,10 @@ pub async fn diff_refs(
     path: Option<&str>,
 ) -> Result<String> {
     let range = format!("{from_sha}..{to_sha}");
-    let mut args = vec!["diff", "--no-color", "-U3", &range];
+    // --no-ext-diff: patch output must come from git's own engine, not a
+    // configured `diff.external` (see `hardening::NEUTRALISED` on why this
+    // can't be neutralised at the spawn seam).
+    let mut args = vec!["diff", "--no-color", "--no-ext-diff", "-U3", &range];
     if let Some(p) = path {
         args.push("--");
         args.push(p);

--- a/src-tauri/src/git/files.rs
+++ b/src-tauri/src/git/files.rs
@@ -67,6 +67,11 @@ pub async fn file_diff(checkout: &Path, base_ref: &str, path: &str) -> Result<St
 /// (agent-created, never `git add`ed) file diffs as empty; when that happens,
 /// re-diff it against /dev/null with `--no-index`, which renders the whole
 /// file as one added hunk.
+///
+/// `--no-ext-diff` because patch output otherwise runs whatever `diff.external`
+/// is configured — a user's difftastic would corrupt the parsed output, and
+/// there is no `-c` value that disables it (`hardening::NEUTRALISED` explains
+/// why it can't be neutralised at the spawn seam).
 async fn file_diff_unified(
     checkout: &Path,
     base_ref: &str,
@@ -75,7 +80,15 @@ async fn file_diff_unified(
 ) -> Result<String> {
     let out = run_git(
         checkout,
-        &["diff", "--no-color", unified, base_ref, "--", path],
+        &[
+            "diff",
+            "--no-color",
+            "--no-ext-diff",
+            unified,
+            base_ref,
+            "--",
+            path,
+        ],
         &format!("diff {unified} {base_ref} -- {path}"),
     )
     .await?;
@@ -88,6 +101,7 @@ async fn file_diff_unified(
         &[
             "diff",
             "--no-color",
+            "--no-ext-diff",
             unified,
             "--no-index",
             "--",
@@ -238,5 +252,65 @@ diff --git a/f b/f
 +b
 \\ No newline at end of file";
         assert_eq!(parse_changed_lines(diff), (vec![], vec![1]));
+    }
+}
+
+#[cfg(test)]
+mod file_diff_tests {
+    use super::super::worktree::{commit_all, init_repo};
+    use super::*;
+
+    async fn config(repo: &Path, key: &str, val: &str) {
+        let out = tokio::process::Command::new("git")
+            .current_dir(repo)
+            .args(["config", key, val])
+            .output()
+            .await
+            .unwrap();
+        assert!(out.status.success());
+    }
+
+    async fn base_repo() -> (tempfile::TempDir, std::path::PathBuf) {
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path().to_path_buf();
+        init_repo(&repo).await.unwrap();
+        config(&repo, "user.email", "t@example.com").await;
+        config(&repo, "user.name", "Tester").await;
+        std::fs::write(repo.join("base.txt"), "base\n").unwrap();
+        commit_all(&repo, "init").await.unwrap();
+        (td, repo)
+    }
+
+    /// The Code panel's new-file case: an untracked file has no index entry, so
+    /// the diff comes from the `--no-index` fallback. This runs through the
+    /// hardened spawn seam, so it also guards against a config override that
+    /// breaks patch output — `-c diff.external=` once made git exec the empty
+    /// string here and every new file showed "Couldn't load diff".
+    #[tokio::test]
+    async fn file_diff_renders_untracked_file_as_added() {
+        let (_td, repo) = base_repo().await;
+        std::fs::write(repo.join("new.txt"), "hello\nworld\n").unwrap();
+
+        let diff = file_diff(&repo, "HEAD", "new.txt").await.unwrap();
+        assert!(diff.contains("+hello"), "no added hunk in: {diff}");
+        assert!(diff.contains("+world"), "no added hunk in: {diff}");
+    }
+
+    /// A user's own repo may legitimately configure `diff.external` (difftastic
+    /// and friends). Patch output must still come from git's internal engine —
+    /// `--no-ext-diff` — or the parsed diff would be whatever that program
+    /// prints (or a hard failure, as with a value git can't exec).
+    #[tokio::test]
+    async fn file_diff_ignores_configured_external_diff() {
+        let (_td, repo) = base_repo().await;
+        config(&repo, "diff.external", "/nonexistent-external-diff").await;
+        std::fs::write(repo.join("base.txt"), "base\nedited\n").unwrap();
+
+        let diff = file_diff(&repo, "HEAD", "base.txt").await.unwrap();
+        assert!(diff.contains("+edited"), "no internal patch in: {diff}");
+
+        std::fs::write(repo.join("new.txt"), "hello\n").unwrap();
+        let diff = file_diff(&repo, "HEAD", "new.txt").await.unwrap();
+        assert!(diff.contains("+hello"), "no-index leg ran external diff: {diff}");
     }
 }

--- a/src-tauri/src/git/files.rs
+++ b/src-tauri/src/git/files.rs
@@ -311,6 +311,9 @@ mod file_diff_tests {
 
         std::fs::write(repo.join("new.txt"), "hello\n").unwrap();
         let diff = file_diff(&repo, "HEAD", "new.txt").await.unwrap();
-        assert!(diff.contains("+hello"), "no-index leg ran external diff: {diff}");
+        assert!(
+            diff.contains("+hello"),
+            "no-index leg ran external diff: {diff}"
+        );
     }
 }

--- a/src-tauri/src/git/hardening.rs
+++ b/src-tauri/src/git/hardening.rs
@@ -69,12 +69,22 @@ use crate::error::{Error, Result};
 /// commit under `commit.gpgsign` — and each needs a config *write* to exploit,
 /// which policy invariant 3 denies. The boundary belongs there, not here.
 ///
-/// Verified against git 2.50: without its row, each of `core.hooksPath`,
-/// `core.fsmonitor` and `diff.external` executes agent-authored code host-side.
+/// Verified against git 2.50: without its row, each of `core.hooksPath` and
+/// `core.fsmonitor` executes agent-authored code host-side.
+///
+/// `diff.external` is deliberately NOT here, though it belongs in spirit: git
+/// has no config value that *disables* external diff. Setting it to `""` sets
+/// it to the empty program, which git then tries to execute — killing every
+/// patch-producing `git diff` with `fatal: external diff died` (stat forms
+/// like `--numstat`/`--shortstat`/`--name-only` never invoke it). The off
+/// switch is the `--no-ext-diff` flag, passed by the patch-producing call
+/// sites themselves (`git::files::file_diff_unified`, `git::diff::diff_refs`);
+/// that also keeps a user's own `diff.external` (difftastic and friends) from
+/// corrupting parsed output. Agent checkouts that plant it are refused
+/// outright — it's in [`EXEC_CONFIG`].
 const NEUTRALISED: &[(&str, &str)] = &[
     ("core.hooksPath", "/dev/null"), // not a directory, so no hook resolves
     ("core.fsmonitor", "false"),     // fires on nearly every index refresh
-    ("diff.external", ""),           // replaces the diff engine — hit by diff polling
     ("core.pager", "cat"),           // Fletch captures output; a pager only adds a program
     ("core.editor", "false"),        // an interactive editor would hang an automated op
     ("sequence.editor", "false"),    // `rebase -i`'s todo-list editor, same hazard
@@ -272,7 +282,7 @@ mod tests {
     }
 
     /// Every row must reach git as a well-formed `-c key=value` pair, and the
-    /// three empirically-confirmed executable keys must be present.
+    /// empirically-confirmed executable keys must be present.
     #[test]
     fn overrides_are_well_formed_c_flags() {
         let overrides = config_overrides();
@@ -289,7 +299,10 @@ mod tests {
             value_of(&overrides, "core.fsmonitor").as_deref(),
             Some("false")
         );
-        assert_eq!(value_of(&overrides, "diff.external").as_deref(), Some(""));
+        // No `-c` value disables external diff — an empty value made git exec
+        // the empty string and every patch diff died (`--no-ext-diff` at the
+        // patch-producing call sites is the off switch; see the const's doc).
+        assert_eq!(value_of(&overrides, "diff.external"), None);
     }
 
     /// The keys that carry a *user's* real remote auth and signing config must

--- a/src/components/RightPanel/Code/CodeLivePanel.tsx
+++ b/src/components/RightPanel/Code/CodeLivePanel.tsx
@@ -259,6 +259,7 @@ export function CodeLivePanel({
       {diffErr ? (
         <div className="empty-msg" style={{ margin: "auto" }}>
           <div className="et">Couldn't load diff</div>
+          <div>{diffErr}</div>
           <div>Retrying on the next change.</div>
         </div>
       ) : hunks.length === 0 ? (

--- a/src/components/RightPanel/Code/DiffView.tsx
+++ b/src/components/RightPanel/Code/DiffView.tsx
@@ -10,16 +10,18 @@ import { highlightToHtml } from "@/util/highlight";
 export const extOf = (path: string) => path.split(".").pop() ?? "";
 
 /** Fetch + parse a file's unified diff vs the parent branch. `dep` lets the
- *  caller force a refetch (e.g. when the file's +/- counts move during a turn). */
+ *  caller force a refetch (e.g. when the file's +/- counts move during a turn).
+ *  `error` is the failure's actual message (null when healthy) — surfacing it
+ *  is what turns "Couldn't load diff" from a dead end into a bug report. */
 export function useFileDiff(agentId: string, path: string | null, dep?: string) {
   const [hunks, setHunks] = useState<DiffHunk[]>([]);
-  const [error, setError] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     if (!path) {
       setHunks([]);
-      setError(false);
+      setError(null);
       setLoaded(false);
       return;
     }
@@ -29,14 +31,14 @@ export function useFileDiff(agentId: string, path: string | null, dep?: string) 
       .then((t) => {
         if (!cancelled) {
           setHunks(parseUnifiedDiff(t));
-          setError(false);
+          setError(null);
           setLoaded(true);
         }
       })
-      .catch(() => {
+      .catch((e) => {
         if (!cancelled) {
           setHunks([]);
-          setError(true);
+          setError(e instanceof Error ? e.message : String(e));
           setLoaded(true);
         }
       });
@@ -124,7 +126,7 @@ export function FileDiff({
     return (
       <div className="empty-msg" style={{ margin: "auto" }}>
         <div className="et">Couldn't load diff</div>
-        <div>Try toggling back and forth, or reopen the file.</div>
+        <div>{error}</div>
       </div>
     );
   }


### PR DESCRIPTION
## Problem

Since `564fc508` (git config hardening), the Code panel shows **"Couldn't load diff"** for every file in dev builds — most visibly on freshly created files, whose tab (`U file +N`) keeps rendering fine next to the broken diff pane.

The hardening seam neutralises `diff.external` with `-c diff.external=` on every git invocation. But git has no config value that *disables* external diff — the empty value sets it to the empty program, git tries to exec it, and every patch-producing diff dies:

```
$ git -c diff.external= diff --no-index -- /dev/null NOTES.md
error: cannot run : No such file or directory
fatal: external diff died, stopping at /dev/null   # exit 128
```

Stat forms (`--numstat`, `--shortstat`, `--name-only`) never invoke the external engine, so file lists and +/− counts kept working — which masked the breakage and made it look file-specific.

## Change

- Drop the `diff.external` row from `NEUTRALISED` (with a doc explaining why it can't live at the spawn seam).
- Pass `--no-ext-diff` at the patch-producing call sites instead: `file_diff_unified` (Code panel diff + editor gutter, both the tree diff and the `--no-index` fallback for untracked files) and `diff_refs` (review surface). This is git's actual off switch, and it also keeps a user's own `diff.external` (difftastic and friends) from corrupting parsed output. `GIT_NO_EXTERNAL_DIFF` was tested and is not honored as an inbound env var, so a seam-level env fix isn't available.
- Agent checkouts that plant `diff.external` are unchanged: still refused outright via `EXEC_CONFIG`.
- Diagnosability: `useFileDiff` now captures the rejection message and both failed-diff states render it — the generic "Retrying on the next change" cost this bug two rounds of archaeology.

## Verification

- Two new regression tests in `git/files.rs`: untracked-file diff through the hardened spawn seam (reproduces the exact failure shape), and a repo with `diff.external` planted still producing internal patches. Both fail before the fix.
- Updated the hardening test that asserted the old empty-string override.
- `cargo test` 1386 passed, clippy clean; `tsc`, biome (baseline warnings only), vitest 988 passed.
- Replayed the original failing scenario (`~/.fletch/dev/workspaces/olympus/agent`, untracked `NOTES.md`) with the fixed invocation: full `+5` diff, exit 1 (accepted).