### PR TITLE
fix(readiness): a failing check blocks even when the merge gate stays open

### DIFF
--- a/src-tauri/src/exec_session.rs
+++ b/src-tauri/src/exec_session.rs
@@ -564,7 +564,23 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let script = dir.path().join("slowagent.sh");
         // Exit promptly on SIGINT; otherwise outlive the test's timeout.
-        std::fs::write(&script, "#!/bin/sh\ntrap 'exit 130' INT\nsleep 30\n").unwrap();
+        //
+        // The sleep runs in the BACKGROUND with an explicit `wait`, which is load
+        // -bearing rather than stylistic: a POSIX shell defers a trapped signal
+        // until the current FOREGROUND command finishes, so a plain `sleep 30`
+        // swallows the SIGINT for its full 30s whenever the signal lands after
+        // the sleep has started — and it does exactly that whenever this thread
+        // is descheduled between `send_user_message` publishing the child and
+        // signalling it. That made this test flaky on a loaded machine, failing
+        // as "turn never reported exit" while the code under test was fine. POSIX
+        // `wait` returns immediately on a trapped signal, so the trap now fires
+        // whenever the SIGINT arrives; the trap kills the sleep so no orphan
+        // outlives the test.
+        std::fs::write(
+            &script,
+            "#!/bin/sh\ntrap 'kill $child 2>/dev/null; exit 130' INT\nsleep 30 &\nchild=$!\nwait\n",
+        )
+        .unwrap();
         std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
 
         // Holding a write fd to the script makes exec() return ETXTBSY, so the

--- a/src/autopilot.test.ts
+++ b/src/autopilot.test.ts
@@ -216,6 +216,23 @@ describe("autopilot opens a cycle", () => {
     });
   });
 
+  it("fixes a failing check on a repo with no required checks", () => {
+    // The shape that actually reaches production, and the one that sat there doing
+    // nothing: no branch-protection required checks (GitHub's default) means a red
+    // run reports `unstable`, not `blocked`. Autopilot read that as a merge it
+    // wasn't allowed to make and waited forever. `fix-checks` must reach it — the
+    // goal is finished work, not work the forge happens to accept.
+    const softFailing: ReadinessInput = {
+      ...FAILING,
+      checks: checks({ merge_state: "unstable", required_failing: ["rust-test"], failed: 1 }),
+    };
+    expect(step({ readiness: softFailing })).toMatchObject({
+      do: "dispatch",
+      rung: "fix-checks",
+      params: { failing: "rust-test" },
+    });
+  });
+
   it("refuses to re-enter a world it already failed to change", () => {
     // Checked BEFORE the budget: a repeat of a barren world is futile even with
     // attempts to spare.

--- a/src/components/ProjectScreen/Roadmap/InFlightRail/select.test.ts
+++ b/src/components/ProjectScreen/Roadmap/InFlightRail/select.test.ts
@@ -201,7 +201,7 @@ describe("buildInFlight — active rows", () => {
 describe("buildInFlight — in-review rows", () => {
   const gates: { merge_state: PrChecks["merge_state"]; state: string; tone: string }[] = [
     { merge_state: "clean", state: "ready to merge", tone: "ready" },
-    { merge_state: "unstable", state: "optional checks failing", tone: "warn" },
+    { merge_state: "unstable", state: "checks still running", tone: "warn" },
     { merge_state: "dirty", state: "conflicts with main", tone: "attention" },
     { merge_state: "behind", state: "behind main", tone: "attention" },
     { merge_state: "draft", state: "draft", tone: "info" },

--- a/src/components/RightPanel/GitPanel/cards/PRCard.tsx
+++ b/src/components/RightPanel/GitPanel/cards/PRCard.tsx
@@ -5,16 +5,18 @@ import { describeMergeGate, type MergeGateSituation } from "@/mergeGate";
 import { ChecksSection } from "./ChecksSection";
 import { CommentsSection } from "./CommentsSection";
 
-/** The card's verbose merge-gate line. `blocked` collapses its two sub-states
- *  (failing checks vs. review gate) into one message here. */
+/** The card's verbose merge-gate line. Failing checks and a review gate get
+ *  their own message: `checks-failing` no longer implies the gate is shut (an
+ *  `unstable` PR is both red and mergeable), so one collapsed "blocked by checks
+ *  or reviews" line would misstate both halves. */
 const CARD_GATE_BY_SITUATION: Record<
   MergeGateSituation,
   { cls: string; text: (base: string) => string }
 > = {
   ready: { cls: "ok", text: () => "✓ Ready to merge" },
-  "mergeable-soft": { cls: "ok", text: () => "✓ Mergeable — optional checks failing" },
-  "checks-failing": { cls: "att", text: () => "△ Blocked by required checks or reviews" },
-  "review-required": { cls: "att", text: () => "△ Blocked by required checks or reviews" },
+  "mergeable-soft": { cls: "ok", text: () => "✓ Mergeable — checks still running" },
+  "checks-failing": { cls: "att", text: () => "△ Checks failing" },
+  "review-required": { cls: "att", text: () => "△ Blocked by a review gate" },
   behind: { cls: "att", text: (base) => `△ Behind ${base} — update your branch` },
   conflicts: { cls: "att", text: (base) => `△ Conflicts with ${base} — update your branch` },
   draft: { cls: "ok", text: () => "Draft — mark ready on GitHub to merge" },
@@ -38,7 +40,10 @@ export function PRCard({
   // One merge-gate line. Gate semantics live in describeMergeGate (spec §6);
   // the card just renders the verbose copy for the resulting situation.
   const { situation } = describeMergeGate(checks?.merge_state ?? null, {
-    checksFailed: checks?.failed ?? 0,
+    // `required_failing` (the named failing runs), not `failed` — the latter
+    // double-counts a rerun. `readiness.ts` owns that definition and every other
+    // caller now derives it the same way.
+    checksFailed: checks?.required_failing.length ?? 0,
     mergeable: pr.mergeable,
   });
   const gate = CARD_GATE_BY_SITUATION[situation];

--- a/src/components/RightPanel/primaryActions.ts
+++ b/src/components/RightPanel/primaryActions.ts
@@ -263,10 +263,15 @@ export function primaryFor(state: GitPanelState, counts?: ActionCounts): Primary
         case "ready":
           return merge("ready to merge", "success");
         case "mergeable-soft":
-          // Only NON-required checks failing — merging is allowed, but say so.
-          return merge("optional checks failing");
+          // Nothing failing, not everything green yet — merging is allowed, but
+          // say what's outstanding.
+          return merge("checks still running");
         case "checks-failing":
-          // Failing required checks are agent-fixable.
+          // A failing check is agent-fixable, so offer the fix as the primary
+          // action even when the gate would still let the merge through. Merge
+          // stays in the menu (`secondaryFor` lists it unconditionally for an
+          // open PR) and stays enabled — see `describeMergeGate`'s `unstable`
+          // arm — so this steers without taking the decision away.
           return {
             key: "agent-fix",
             label: "Fix checks with agent",

--- a/src/mergeGate.test.ts
+++ b/src/mergeGate.test.ts
@@ -13,13 +13,33 @@ const ctx = (mergeable: Mergeable, checksFailed = 0) => ({ checksFailed, mergeab
 
 describe("describeMergeGate — real merge_state", () => {
   it("opens the gate only on clean and unstable", () => {
-    // clean = green light; unstable = only non-required checks fail, still
-    // mergeable. Everything else is a closed gate.
+    // clean = green light; unstable = mergeable anyway. Everything else is a
+    // closed gate.
     expect(describeMergeGate("clean", ctx("mergeable"))).toMatchObject({
       situation: "ready",
       mergeAllowed: true,
     });
     expect(describeMergeGate("unstable", ctx("mergeable"))).toMatchObject({
+      situation: "mergeable-soft",
+      mergeAllowed: true,
+    });
+  });
+
+  it("calls a failing check failing even when the gate stays open", () => {
+    // The regression this pins. A repo with no REQUIRED status checks — GitHub's
+    // default — reports a failing run as `unstable`, not `blocked`. Classifying
+    // that as "only optional checks failing" left a red PR with no surface
+    // offering to fix it and autopilot concluding it had nothing to do.
+    expect(describeMergeGate("unstable", ctx("mergeable", 1))).toEqual({
+      situation: "checks-failing",
+      tone: "attention",
+      // Still true, and deliberately: GitHub really would take this merge. The
+      // situation names the problem; this names the forge's verdict.
+      mergeAllowed: true,
+      needsUpdate: false,
+    });
+    // Nothing failing → the arm's only remaining meaning, checks still running.
+    expect(describeMergeGate("unstable", ctx("mergeable", 0))).toMatchObject({
       situation: "mergeable-soft",
       mergeAllowed: true,
     });
@@ -138,6 +158,11 @@ describe("mergeGateLabel", () => {
   it("names the base branch on the two situations that are about it", () => {
     expect(mergeGateLabel("behind", "main")).toBe("behind main");
     expect(mergeGateLabel("conflicts", "develop")).toBe("conflicts with develop");
+  });
+
+  it("says what `mergeable-soft` now means, which is not 'optional failures'", () => {
+    expect(mergeGateLabel("mergeable-soft")).toBe("checks still running");
+    expect(mergeGateLabel("checks-failing")).toBe("checks failing");
   });
 
   it("falls back to the generic word when the caller has no base branch", () => {

--- a/src/mergeGate.ts
+++ b/src/mergeGate.ts
@@ -13,8 +13,8 @@ import type { Mergeable, MergeState } from "@/api";
  *  changes, so surfaces switch on this rather than on raw `MergeState`. */
 export type MergeGateSituation =
   | "ready" // clean — green light, merge now
-  | "mergeable-soft" // unstable — only optional (non-required) checks failing
-  | "checks-failing" // blocked by failing required checks — agent-fixable
+  | "mergeable-soft" // unstable with nothing failing — checks still running, merge allowed
+  | "checks-failing" // a check is failing — agent-fixable, whether or not it shuts the gate
   | "review-required" // blocked purely by a review/other gate — send to GitHub
   | "behind" // behind base — update the branch
   | "conflicts" // dirty — conflicts with base, update the branch
@@ -30,7 +30,11 @@ export interface MergeGate {
   situation: MergeGateSituation;
   tone: MergeGateTone;
   /** The merge CTA is actually clickable (gate open). Drives the disabled
-   *  state of a "Merge" button regardless of whether it's the primary action. */
+   *  state of a "Merge" button regardless of whether it's the primary action.
+   *
+   *  Independent of `situation`, deliberately: `checks-failing` on an `unstable`
+   *  PR is a real problem to fix AND a merge GitHub would accept. Two questions
+   *  — "is something wrong" and "would the forge take it" — so two fields. */
   mergeAllowed: boolean;
   /** Branch is out of sync with base (behind / conflicting / unmergeable
    *  fallback); gates the "Update branch with agent" remediation. */
@@ -53,7 +57,7 @@ export function mergeGateLabel(situation: MergeGateSituation, base = "base"): st
     case "ready":
       return "ready to merge";
     case "mergeable-soft":
-      return "optional checks failing";
+      return "checks still running";
     case "checks-failing":
       return "checks failing";
     case "review-required":
@@ -92,9 +96,25 @@ export function describeMergeGate(
     case "clean":
       return { situation: "ready", tone: "ready", mergeAllowed: true, needsUpdate: false };
     case "unstable":
-      return { situation: "mergeable-soft", tone: "warn", mergeAllowed: true, needsUpdate: false };
+      // A failing check is something to fix even when GitHub would let the merge
+      // through. `unstable` is exactly what a repo with no REQUIRED status checks
+      // reports for a failing run — the GitHub default, so the common case — and
+      // reading it as "merely optional" is how a red PR sat there with no surface
+      // offering to fix it and autopilot deciding it had nothing to do. Split on
+      // the failing count the same way `blocked` does; what differs between the
+      // two is only whether the gate is shut, and here it isn't — claiming
+      // otherwise would disable a merge GitHub accepts.
+      return checksFailed > 0
+        ? {
+            situation: "checks-failing",
+            tone: "attention",
+            mergeAllowed: true,
+            needsUpdate: false,
+          }
+        : { situation: "mergeable-soft", tone: "warn", mergeAllowed: true, needsUpdate: false };
     case "blocked":
-      // Failing required checks are agent-fixable; a pure review gate is not.
+      // Same split, gate shut: failing checks are agent-fixable, a pure review
+      // gate is not.
       return checksFailed > 0
         ? {
             situation: "checks-failing",

--- a/src/readiness.test.ts
+++ b/src/readiness.test.ts
@@ -145,8 +145,14 @@ describe("detectBlockers", () => {
     // Blocked with nothing failing is a pure review gate, not a checks problem.
     expect(gate({ merge_state: "blocked" })).toEqual(["review-required"]);
     expect(gate({ merge_state: "draft" })).toEqual(["draft"]);
-    // Only non-required checks failing → mergeable, so not a blocker.
+    // `unstable` with nothing failing is just "checks still running".
     expect(gate({ merge_state: "unstable", required_failing: [] })).toEqual([]);
+    // But a failing check blocks whether or not it shuts the gate. A repo with no
+    // required status checks (GitHub's default) reports every failure as
+    // `unstable`, and skipping those is how a red PR read as nothing to do.
+    expect(gate({ merge_state: "unstable", required_failing: ["rust-test"] })).toEqual([
+      "checks-failing",
+    ]);
   });
 
   it("never invents a conflict from a not-yet-computed mergeable verdict", () => {
@@ -168,15 +174,16 @@ describe("detectBlockers", () => {
     expect(b).toEqual([{ kind: "checks-failing", checks: ["build", "test (18)"] }]);
   });
 
-  it("uses required_failing, not the raw failed count, for the gate decision", () => {
-    // The drift this module ends: `failed` counts every failing run (reruns
-    // included), `required_failing` names the ones that gate the merge. A PR whose
-    // only failures are non-required must not read as agent-fixable.
+  it("reads the failing NAMES, never the raw failed count", () => {
+    // The drift this module ends: `failed` counts every failing run, so a rerun
+    // double-counts, and the fix-checks trigger needs names anyway. A report that
+    // claims failures but names none yields no blocker — there is nothing to hand
+    // an agent — rather than a phantom one off the count.
     expect(
       kinds(
         input({
           pr: pr(),
-          checks: checks({ merge_state: "unstable", failed: 3 }),
+          checks: checks({ merge_state: "unstable", failed: 3, required_failing: [] }),
           comments: comments(0),
         }),
       ),

--- a/src/readiness.ts
+++ b/src/readiness.ts
@@ -52,7 +52,10 @@ export type Blocker =
   | { kind: "diverged"; mainline: string }
   /** Failing checks. Carries their names — CI can't currently tell us which are
    *  *required* (that needs an API call the app token often can't make), so this
-   *  is every failing check, and it is deliberately NOT split into tests-vs-lint:
+   *  is every failing check, blocking whether or not it shuts the merge gate: a
+   *  repo with no required checks (GitHub's default) reports a red run as
+   *  `unstable`, and a failing spec is worth fixing there too. Deliberately NOT
+   *  split into tests-vs-lint:
    *  check names are free-form, and guessing from them would be a heuristic
    *  masquerading as a fact. The local verifier (`verify.rs`) *does* know the
    *  difference — when its report becomes an input, the split can be real. */
@@ -156,8 +159,10 @@ export function detectBlockers({ git, pr, checks, comments }: ReadinessInput): B
         break;
       default:
         // ready / mergeable-soft / no-conflicts / computing add no blocker of
-        // their own. `mergeable-soft` means only non-required checks fail, so
-        // the failing names are informational, not blocking.
+        // their own. `mergeable-soft` now means only "checks still running": a
+        // failing check reaches `checks-failing` above whether or not it shuts
+        // the merge gate, because what's being asked is "is this work finished",
+        // not "would GitHub take it as it stands".
         break;
     }
     // Split by who holds the conversation. A thread we replied to last is a

--- a/tests/components/RightPanel/primaryActions.test.ts
+++ b/tests/components/RightPanel/primaryActions.test.ts
@@ -177,11 +177,25 @@ describe("pr-open primary by merge_state (§7)", () => {
     expect(p.statusLabel).toContain("ready to merge");
   });
 
-  it("unstable → Merge PR enabled, warn status", () => {
-    const p = primaryFor("pr-open", { ...base, mergeState: "unstable", checksFailed: 1 });
+  it("unstable with nothing failing → Merge PR enabled, warn status", () => {
+    const p = primaryFor("pr-open", { ...base, mergeState: "unstable", checksFailed: 0 });
     expect(p.key).toBe("merge");
     expect(p.tone).toBeUndefined();
     expect(p.statusKind).toBe("warn");
+    expect(p.statusLabel).toContain("checks still running");
+  });
+
+  it("unstable WITH a failing check → Fix with agent, not Merge", () => {
+    // A repo with no required status checks reports every failure as `unstable`,
+    // so this — not `blocked` — is the common shape of a red PR. Offering Merge
+    // here is what let a failing spec sit unfixed. Merge stays in the menu and
+    // stays enabled (the gate really is open); it just isn't what we suggest.
+    const counts = { ...base, mergeState: "unstable" as const, checksFailed: 1 };
+    const p = primaryFor("pr-open", counts);
+    expect(p.key).toBe("agent-fix");
+    expect(p.statusKind).toBe("attention");
+    expect(p.statusLabel).toContain("1 check failing");
+    expect(secondaryFor("pr-open", counts).map((s) => s.key)).toContain("merge");
   });
 
   it("blocked with failing checks → Fix with agent", () => {


### PR DESCRIPTION
## The bug

Autopilot resolved a conflict on a checkout, then sat idle on a failing check and never fixed it — chip reading "Autopilot on", no escalation, nothing happening.

Root cause: **`fix-checks` was unreachable on any repo without required status checks.** A failing check only became a blocker when GitHub reported `mergeStateStatus: BLOCKED`, but a repo whose branch protection has no *required* checks — GitHub's default, and the case here — reports a failing run as `UNSTABLE`. `describeMergeGate` classified that as `mergeable-soft` ("only optional checks failing"), which adds no blocker, so `nextRung` skipped the `fix-checks` rung and `autopilotStep` fell through to `{ wait: "nothing-to-do" }`, every tick.

Verified live on PR #617: `mergeStateStatus: UNSTABLE`, `rust-test: FAILURE`, and `main`'s only ruleset contains `['deletion', 'non_fast_forward']` — zero required checks. The conflict half worked because `dirty`/`behind` map to their situations without consulting the failing count.

Two smaller things fell out of the same assumption: the Git panel offered **Merge PR** as the primary action on a PR with a failing test, and Mission Control already flagged `rollup === "failing"` gate-independently (`queue.ts:506`) — so the queue raised the card while readiness refused to act on it, exactly the drift `readiness.ts` exists to end.

## The fix

One decision, at the root: `describeMergeGate`'s `unstable` arm now splits on the failing count exactly like `blocked` does.

```
unstable + a failing check  →  "checks-failing"   (was "mergeable-soft")
unstable + nothing failing  →  "mergeable-soft"   (now means only "checks still running")
```

`mergeAllowed` stays `true` for both halves, deliberately: GitHub really would accept that merge, and claiming otherwise would disable a button that works. The situation names the problem; `mergeAllowed` names the forge's verdict — two questions, two fields, so a surface can steer toward the fix without taking the merge away.

Because every surface renders off that one classification, nothing else needed a logic change:

- **`readiness.ts`** — `detectBlockers` already maps `checks-failing` → blocker, so `nextRung` now reaches `fix-checks`. Comments only.
- **autopilot** — inherits it; `fix-checks` is already in `AUTOPILOT_RUNGS`, so an enrolled checkout dispatches on the next tick.
- **`primaryActions.ts`** — primary becomes "Fix checks with agent"; Merge stays in the menu (`secondaryFor` lists it unconditionally) and stays enabled.
- **`PRCard.tsx`** — `checks-failing` no longer shares "Blocked by required checks or reviews" with `review-required`, since it can now be red *and* mergeable. Also switched to `required_failing.length` from `checks.failed`, which double-counts a rerun — the last straggler on a definition `readiness.ts` owns.

## Tests

The blind spot was that every `fix-checks` fixture hardcoded `merge_state: "blocked"`, which a repo without required checks never produces. Added coverage at the shape that actually reaches production — the gate split with `mergeAllowed` staying open, the resulting blocker, the autopilot dispatch, and the panel steering toward the fix while keeping Merge reachable.

992 frontend tests pass, `tsc --noEmit` clean, lint unchanged from baseline.

## Deliberately not bundled

1. **`blocked` + zero failing reads as `review-required`.** On a repo *with* required checks, the window right after a fix pushes (checks pending, nothing failing yet) classifies as a pure review gate, so autopilot escalates `needs-human` instead of waiting. Distinguishing it needs a pending signal the gate doesn't carry.
2. **`settle` resets the rung budget** (by design, `store/autopilot.ts:191`). A check that passes locally but fails only in CI can cycle indefinitely: local verify passes → settle → CI red → fresh budget. `barren` can't catch it because each fix moves the sha. Same risk class before and after this change, but newly reachable on repos without required checks.