### PR TITLE
feat(workflow): reviewable artifacts at approval gates + wider env membrane coverage

### DIFF
--- a/src-tauri/src/commands/run.rs
+++ b/src-tauri/src/commands/run.rs
@@ -74,7 +74,7 @@ pub async fn run_verification(
     agent_id: String,
     subdir: Option<String>,
 ) -> Result<crate::verify::VerificationReport> {
-    let (_repo, checkout) = agent_repo_checkout(&supervisor, &agent_id, subdir.as_deref())?;
+    let (repo, checkout) = agent_repo_checkout(&supervisor, &agent_id, subdir.as_deref())?;
     // Serialize against the turn-end verification (`trigger_turn_end_verification`)
     // and any other in-flight run for this agent. Both drive the same install /
     // test / lint commands in the agent's checkout, so two at once race on the
@@ -116,7 +116,17 @@ pub async fn run_verification(
         setting("run.lint"),
         VERIFY_TIMEOUT_SECS,
     )?;
-    let report = verifier.verify(&checkout).await;
+    // The project's shared run env — the verifier runs the same trust class of
+    // sandboxed process as the Run panel, so it gets the same membrane. Empty
+    // project (or nothing shared) → no vars, and the checks run as before.
+    let env = if project_id.is_empty() {
+        Vec::new()
+    } else {
+        supervisor
+            .workspace
+            .run_env(&project_id, &repo.repo_path, &agent_id, &checkout)
+    };
+    let report = verifier.verify(&checkout, &env).await;
     tracing::info!(
         agent_id = %agent_id,
         passed = report.passed(),
@@ -148,13 +158,16 @@ pub fn project_run_config(
     supervisor.project_run_config(&repo_path)
 }
 
-/// Discover the `KEY=value` pairs in a project's `.env` (in the *source* repo,
-/// where gitignored env files live), for the Run & Environment settings list.
-/// Missing/unreadable `.env` → empty. Values are returned so the UI can show
-/// them masked and flag overrides that differ; it never writes them anywhere.
+/// Discover a project's env keys (in the *source* repo, where gitignored env
+/// files live), for the Run & Environment settings list: the `KEY=value` pairs
+/// in `.env`, plus the keys only *declared* by `.env.example`/`.env.sample` —
+/// bare names, because example values are placeholders and must never be
+/// treated as real values. Missing/unreadable files → empty. `.env` values are
+/// returned so the UI can show them masked and flag overrides that differ; it
+/// never writes them anywhere.
 #[tauri::command]
-pub fn read_env_file_keys(repo_path: String) -> Result<Vec<crate::run_env::EnvEntry>> {
-    Ok(crate::run_env::read_env_file(&expand_tilde(&repo_path)))
+pub fn read_env_file_keys(repo_path: String) -> Result<crate::run_env::EnvFileKeys> {
+    Ok(crate::run_env::discover_env_keys(&expand_tilde(&repo_path)))
 }
 
 /// Read a project variable's override value (keychain-backed) so the settings

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -178,6 +178,52 @@ pub fn multi_repo_workspace_note(repos: &[crate::workspace::TrackedRepo]) -> Opt
     ))
 }
 
+/// Per-agent env-awareness note: which of the project's env keys reach the
+/// processes the app runs on the agent's behalf (the Run panel and the
+/// verifier/tests gate), and which exist — in `.env` or declared by
+/// `.env.example`/`.env.sample` — but were not shared. Composed ahead of any
+/// custom brief by the spawn path, like [`multi_repo_workspace_note`].
+///
+/// Key NAMES only, never values: a value in the system prompt would defeat the
+/// membrane (`run_env`), which never lets values into the agent's process or
+/// its checkout. `None` when the project declares no env at all, so the common
+/// case injects nothing extra.
+pub fn env_awareness_note(shared: &[String], unshared: &[String]) -> Option<String> {
+    if shared.is_empty() && unshared.is_empty() {
+        return None;
+    }
+    let list = |keys: &[String]| {
+        keys.iter()
+            .map(|k| format!("`{k}`"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    let shared_line = if shared.is_empty() {
+        "- Shared with app-run processes: none yet.\n".to_string()
+    } else {
+        format!("- Shared with app-run processes: {}.\n", list(shared))
+    };
+    let unshared_line = if unshared.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "- Present in the project's env config but NOT shared: {}.\n",
+            list(unshared)
+        )
+    };
+    Some(format!(
+        "## Project environment variables\n\n\
+         This project's env values live outside your workspace (its `.env` is gitignored and \
+         deliberately absent from this checkout). Fletch injects the shared ones into the \
+         sandboxed processes it runs for you — the Run panel and the verifier/tests gate — \
+         never into your own environment.\n\n\
+         {shared_line}{unshared_line}\n\
+         Do not fabricate `.env` files or hardcode values to compensate. Run env-dependent \
+         commands through the app (Run panel / verification), or tell the user which key you \
+         need shared."
+    ))
+}
+
 /// Per-agent heads-up for a workspace whose base branch could not be fetched
 /// from `origin` while it was being provisioned (offline, no credentials, the
 /// branch gone from the remote). Composed ahead of any custom brief by the
@@ -473,6 +519,31 @@ mod tests {
         assert!(note.contains("args"), "must point at args.repo: {note}");
         // No redundant "frontend — frontend" suffix when label == subdir.
         assert!(!note.contains("frontend/` — frontend"), "note: {note}");
+    }
+
+    #[test]
+    fn env_note_lists_key_names_only_and_is_conditional() {
+        // No env at all (the common case): no note.
+        assert_eq!(env_awareness_note(&[], &[]), None);
+
+        let note = env_awareness_note(
+            &["DATABASE_URL".into()],
+            &["SECRET_KEY".into(), "API_KEY".into()],
+        )
+        .unwrap();
+        // Both lists render by key NAME — the note carries names, never values.
+        assert!(note.contains("`DATABASE_URL`"), "note: {note}");
+        assert!(note.contains("`SECRET_KEY`"), "note: {note}");
+        assert!(note.contains("`API_KEY`"), "note: {note}");
+        assert!(note.contains("NOT shared"), "note: {note}");
+        // The failure modes the note exists to prevent.
+        assert!(note.contains("Do not fabricate"), "note: {note}");
+        assert!(note.contains("Run panel"), "note: {note}");
+
+        // Nothing shared yet, keys discovered: the note says so rather than
+        // listing an empty set.
+        let none_shared = env_awareness_note(&[], &["API_KEY".into()]).unwrap();
+        assert!(none_shared.contains("none yet"), "note: {none_shared}");
     }
 
     #[test]

--- a/src-tauri/src/run_env.rs
+++ b/src-tauri/src/run_env.rs
@@ -39,6 +39,12 @@ pub const RUN_ENV_SETTING: &str = "run_env";
 /// `.env` for now; `.env.local` and friends are a deliberate later addition.
 const ENV_FILENAME: &str = ".env";
 
+/// Example/template files read for key *discovery* only — the industry
+/// convention for declaring the keys a project needs. Their values are
+/// placeholders and are never used as real values: only [`read_env_file`]
+/// feeds resolution.
+const EXAMPLE_ENV_FILENAMES: [&str; 2] = [".env.example", ".env.sample"];
+
 /// Where a shared variable's value comes from. Serialized as a bare lowercase
 /// string (`"mirror"` / `"override"`) so the frontend document stays trivial;
 /// a future `computed` variant slots in without a document migration.
@@ -184,6 +190,44 @@ pub fn read_env_file(repo_path: &Path) -> Vec<EnvEntry> {
         Ok(text) => parse_env(&text),
         Err(_) => Vec::new(),
     }
+}
+
+/// Keys declared by the repo's example env files ([`EXAMPLE_ENV_FILENAMES`]).
+/// Discovery only: values are deliberately dropped here so a placeholder can
+/// never masquerade as a real value. Missing/unreadable files → fewer keys,
+/// never an error.
+pub fn read_example_env_keys(repo_path: &Path) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for name in EXAMPLE_ENV_FILENAMES {
+        let Ok(text) = std::fs::read_to_string(repo_path.join(name)) else {
+            continue;
+        };
+        for e in parse_env(&text) {
+            if !out.contains(&e.key) {
+                out.push(e.key);
+            }
+        }
+    }
+    out
+}
+
+/// Key discovery for the settings UI and the agent env note: the real `.env`
+/// entries plus the keys only *declared* by an example file — "declared by the
+/// project, not set" — carried as bare names because a placeholder is not a
+/// value.
+#[derive(Debug, Serialize)]
+pub struct EnvFileKeys {
+    pub env: Vec<EnvEntry>,
+    pub declared: Vec<String>,
+}
+
+pub fn discover_env_keys(repo_path: &Path) -> EnvFileKeys {
+    let env = read_env_file(repo_path);
+    let declared = read_example_env_keys(repo_path)
+        .into_iter()
+        .filter(|k| !env.iter().any(|e| &e.key == k))
+        .collect();
+    EnvFileKeys { env, declared }
 }
 
 /// Load the project's run-environment document. Absent or malformed → default
@@ -487,6 +531,56 @@ LEADING= # only a comment
             got,
             vec![("DATABASE_URL".into(), "postgres://real/dev".into())]
         );
+    }
+
+    #[test]
+    fn example_files_declare_keys_but_never_values() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".env"),
+            "DATABASE_URL=postgres://real/dev\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join(".env.example"),
+            "DATABASE_URL=placeholder\nAPI_KEY=your-key-here\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join(".env.sample"), "API_KEY=dupe\nEXTRA=x\n").unwrap();
+        let got = discover_env_keys(dir.path());
+        // `.env` keeps its real value; example keys surface once, as bare
+        // names, and a key already in `.env` is not re-declared.
+        assert_eq!(got.env.len(), 1);
+        assert_eq!(got.env[0].value, "postgres://real/dev");
+        assert_eq!(
+            got.declared,
+            vec!["API_KEY".to_string(), "EXTRA".to_string()]
+        );
+    }
+
+    #[test]
+    fn resolve_never_reads_example_values() {
+        // A shared mirror var declared only by `.env.example` has no resolvable
+        // value — skipped, never injected with the placeholder.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".env.example"), "API_KEY=placeholder\n").unwrap();
+        let db = crate::database::init(dir.path()).unwrap();
+        let conn = db.lock();
+        let project_id = seed(&conn);
+        set_doc(
+            &conn,
+            &project_id,
+            &RunEnvDoc {
+                version: 1,
+                vars: vec![EnvVar {
+                    key: "API_KEY".into(),
+                    shared: true,
+                    source: Source::Mirror,
+                }],
+            },
+        );
+        let wt = PathBuf::from("/tmp/wt");
+        assert!(resolve(&conn, &project_id, dir.path(), &ctx("a", &wt)).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -983,7 +983,18 @@ impl Supervisor {
             })
             .flatten()
             .map(crate::instructions::stale_base_note);
-        let notes = [stale_note, workspace_note]
+        // Which env keys reach app-run processes vs. exist but were withheld —
+        // key names only, never values (see `run_env`; a value in the
+        // instructions would defeat the membrane). Keyed on the primary repo,
+        // where the (gitignored) `.env` lives. Recomputed every launch, like
+        // the other layers, so a sharing change lands on the next spawn/resume.
+        let env_note = record.repos.first().and_then(|primary| {
+            let (shared, unshared) = self
+                .workspace
+                .run_env_key_names(&record.project_id, &primary.repo_path);
+            crate::instructions::env_awareness_note(&shared, &unshared)
+        });
+        let notes = [stale_note, workspace_note, env_note]
             .into_iter()
             .flatten()
             .collect::<Vec<_>>()

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -179,9 +179,14 @@ impl Supervisor {
                 return;
             }
         };
+        // The project's shared run env — same membrane as the ad-hoc
+        // `run_verification` command, resolved for this agent's checkout.
+        let env = self
+            .workspace
+            .run_env(&project_id, &primary.repo_path, &agent_id, &checkout);
         let inflight = self.verify_inflight.clone();
         tauri::async_runtime::spawn(async move {
-            let report = verifier.verify(&checkout).await;
+            let report = verifier.verify(&checkout, &env).await;
             inflight.lock().remove(&agent_id);
             emit_verification(&app, &agent_id, report);
         });

--- a/src-tauri/src/verify.rs
+++ b/src-tauri/src/verify.rs
@@ -142,18 +142,34 @@ impl Verifier {
     }
 
     /// Run the full suite — `install` (once) → `test` → `lint` — and report every
-    /// check. Used by the ad-hoc `run_verification` command.
-    pub async fn verify(&self, worktree: &Path) -> VerificationReport {
-        self.run(worktree, /* include_lint = */ true).await
+    /// check. Used by the ad-hoc `run_verification` command and the turn-end
+    /// verification. `env` is the project's shared run-env pairs
+    /// ([`crate::run_env::resolve`]) injected into every check command — these
+    /// are app-spawned sandboxed processes, the same trust class as the Run
+    /// panel, so they get the same membrane. Pass `&[]` where the caller has no
+    /// project context. A parameter rather than a field because the tests gate
+    /// resolves per step worktree (the `{{worktree}}` interpolation target),
+    /// which exists only once an attempt has spawned its agent.
+    pub async fn verify(&self, worktree: &Path, env: &[(String, String)]) -> VerificationReport {
+        self.run(worktree, /* include_lint = */ true, env).await
     }
 
     /// Run only `install` (once) → `test`, for the workflow tests gate, which has
     /// no use for a lint result and must stay byte-identical to its prior shape.
-    pub async fn verify_tests_only(&self, worktree: &Path) -> VerificationReport {
-        self.run(worktree, /* include_lint = */ false).await
+    pub async fn verify_tests_only(
+        &self,
+        worktree: &Path,
+        env: &[(String, String)],
+    ) -> VerificationReport {
+        self.run(worktree, /* include_lint = */ false, env).await
     }
 
-    async fn run(&self, worktree: &Path, include_lint: bool) -> VerificationReport {
+    async fn run(
+        &self,
+        worktree: &Path,
+        include_lint: bool,
+        env: &[(String, String)],
+    ) -> VerificationReport {
         // The checks run under the Run-panel seatbelt profile, which needs macOS
         // `sandbox-exec`. Where it isn't present we can't safely run a
         // repo-derived command, so skip every check rather than run unsandboxed
@@ -198,7 +214,8 @@ impl Verifier {
             if already {
                 checks.push(passed_cached("install", setup));
             } else {
-                let (outcome, duration_ms, tail) = self.run_check(worktree, "install", setup).await;
+                let (outcome, duration_ms, tail) =
+                    self.run_check(worktree, "install", setup, env).await;
                 if matches!(outcome, CheckOutcome::Passed) {
                     self.setup_done
                         .lock()
@@ -234,7 +251,8 @@ impl Verifier {
                     tail: Vec::new(),
                 }),
                 Some(cmd) => {
-                    let (outcome, duration_ms, tail) = self.run_check(worktree, name, cmd).await;
+                    let (outcome, duration_ms, tail) =
+                        self.run_check(worktree, name, cmd, env).await;
                     checks.push(CheckResult {
                         name: name.to_string(),
                         command: cmd.clone(),
@@ -257,9 +275,10 @@ impl Verifier {
         worktree: &Path,
         name: &str,
         cmd: &str,
+        env: &[(String, String)],
     ) -> (CheckOutcome, u64, Vec<String>) {
         let started = Instant::now();
-        let bounded = self.run_sandboxed(worktree, cmd).await;
+        let bounded = self.run_sandboxed(worktree, cmd, env).await;
         let duration_ms = started.elapsed().as_millis() as u64;
         let outcome_tail = match bounded {
             Bounded::Exited { success: true, .. } => (CheckOutcome::Passed, Vec::new()),
@@ -314,12 +333,12 @@ impl Verifier {
         Ok((PathBuf::from(crate::sandbox::SANDBOX_EXEC), args))
     }
 
-    async fn run_sandboxed(&self, worktree: &Path, cmd: &str) -> Bounded {
+    async fn run_sandboxed(&self, worktree: &Path, cmd: &str, env: &[(String, String)]) -> Bounded {
         let (program, args) = match self.sandbox_command(worktree, cmd) {
             Ok(t) => t,
             Err(e) => return Bounded::Unrunnable(format!("could not build sandbox profile: {e}")),
         };
-        run_bounded(&program, &args, worktree, self.timeout).await
+        run_bounded(&program, &args, worktree, self.timeout, env).await
     }
 }
 
@@ -428,13 +447,22 @@ enum Bounded {
 }
 
 /// Run `program args` in `cwd`, capturing combined stdout+stderr, bounded by
-/// `deadline`. On timeout the child is killed (`kill_on_drop`) and `TimedOut` is
-/// returned. Pure of any workflow/Tauri state so it is directly unit-testable.
-async fn run_bounded(program: &Path, args: &[String], cwd: &Path, deadline: Duration) -> Bounded {
+/// `deadline`. `env` is layered over the inherited environment (the shared
+/// run-env membrane; empty for callers without one). On timeout the child is
+/// killed (`kill_on_drop`) and `TimedOut` is returned. Pure of any
+/// workflow/Tauri state so it is directly unit-testable.
+async fn run_bounded(
+    program: &Path,
+    args: &[String],
+    cwd: &Path,
+    deadline: Duration,
+    env: &[(String, String)],
+) -> Bounded {
     let mut command = Command::new(program);
     command
         .args(args)
         .current_dir(cwd)
+        .envs(env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -635,6 +663,7 @@ mod tests {
             &["-c".into(), "echo ok; exit 0".into()],
             cwd.path(),
             Duration::from_secs(10),
+            &[],
         )
         .await;
         match b {
@@ -654,6 +683,7 @@ mod tests {
             &["-c".into(), "echo boom 1>&2; exit 3".into()],
             cwd.path(),
             Duration::from_secs(10),
+            &[],
         )
         .await;
         match b {
@@ -673,6 +703,7 @@ mod tests {
             &["-c".into(), "sleep 30".into()],
             cwd.path(),
             Duration::from_millis(150),
+            &[],
         )
         .await;
         assert!(matches!(b, Bounded::TimedOut));
@@ -686,9 +717,35 @@ mod tests {
             &[],
             cwd.path(),
             Duration::from_secs(5),
+            &[],
         )
         .await;
         assert!(matches!(b, Bounded::Unrunnable(_)));
+    }
+
+    #[tokio::test]
+    async fn run_bounded_injects_shared_env() {
+        // The env plumbing seam: a shared pair must reach the spawned command's
+        // environment (layered over the inherited one).
+        let cwd = tempfile::tempdir().unwrap();
+        let b = run_bounded(
+            Path::new("/bin/sh"),
+            &["-c".into(), "echo val=$FLETCH_TEST_SHARED".into()],
+            cwd.path(),
+            Duration::from_secs(10),
+            &[("FLETCH_TEST_SHARED".into(), "sesame".into())],
+        )
+        .await;
+        match b {
+            Bounded::Exited { success, tail } => {
+                assert!(success);
+                assert!(
+                    tail.iter().any(|l| l.contains("val=sesame")),
+                    "tail: {tail:?}"
+                );
+            }
+            _ => panic!("expected Exited"),
+        }
     }
 
     #[test]

--- a/src-tauri/src/workflow/attempt.rs
+++ b/src-tauri/src/workflow/attempt.rs
@@ -474,9 +474,12 @@ pub async fn run_attempt(
         } else {
             None
         };
-        let artifact_present = match &gate {
-            Gate::Artifact { path } => artifact_exists(&spawned.worktree, path),
-            _ => false,
+        // Probed for both file-naming gates: the `artifact` gate's path and an
+        // `approval` gate's reviewed artifact (spec §9) — a missing file blocks
+        // the approval pause exactly like an unmet `require`.
+        let artifact_present = match gate.artifact_path() {
+            Some(path) => artifact_exists(&spawned.worktree, path),
+            None => false,
         };
         // Tests gate (spec §9.4): resolve + run the project's tests in the step
         // worktree now, then let the pure gate turn the outcome into done/blocked.
@@ -835,19 +838,26 @@ async fn drive_turn(
     }
 }
 
-/// Existence check for the `artifact` gate. `spec.rs` already rejects absolute
-/// paths and `..` at spec time; this re-validates defensively (the path is a
-/// filesystem probe against the agent's worktree).
-fn artifact_exists(worktree: &Path, rel: &str) -> bool {
+/// Resolve a gate's artifact path inside the worktree, or `None` for a path
+/// that escapes it. `spec.rs` already rejects absolute paths and `..` at spec
+/// time; this re-validates defensively (the path is a filesystem probe against
+/// the agent's worktree). Shared by the existence check here and the evidence
+/// capture in the scheduler, so both apply one rule.
+pub(super) fn artifact_probe_path(worktree: &Path, rel: &str) -> Option<PathBuf> {
     let candidate = Path::new(rel);
     if candidate.is_absolute()
         || candidate
             .components()
             .any(|c| matches!(c, std::path::Component::ParentDir))
     {
-        return false;
+        return None;
     }
-    worktree.join(candidate).exists()
+    Some(worktree.join(candidate))
+}
+
+/// Existence check for the file-naming gates (`artifact`, `approval.artifact`).
+fn artifact_exists(worktree: &Path, rel: &str) -> bool {
+    artifact_probe_path(worktree, rel).is_some_and(|p| p.exists())
 }
 
 fn gate_mode(gate: &Gate) -> &'static str {
@@ -1194,7 +1204,10 @@ mod tests {
             d.as_ref(),
             &NeverTests,
             params(
-                Gate::Approval { require: vec![] },
+                Gate::Approval {
+                    require: vec![],
+                    artifact: None,
+                },
                 bb.path().to_path_buf(),
                 fast(),
             ),

--- a/src-tauri/src/workflow/gates.rs
+++ b/src-tauri/src/workflow/gates.rs
@@ -108,7 +108,9 @@ pub fn evaluate(gate: &Gate, inputs: &GateInputs) -> GateResult {
         Gate::Verdict => evaluate_verdict(inputs),
         Gate::Commit => evaluate_commit(inputs),
         Gate::Artifact { path } => evaluate_artifact(path, inputs),
-        Gate::Approval { require } => evaluate_approval(require, inputs),
+        Gate::Approval { require, artifact } => {
+            evaluate_approval(require, artifact.as_deref(), inputs)
+        }
         Gate::Tests => evaluate_tests(inputs),
     }
 }
@@ -155,7 +157,22 @@ fn evaluate_artifact(path: &str, inputs: &GateInputs) -> GateResult {
     }
 }
 
-fn evaluate_approval(require: &[Require], inputs: &GateInputs) -> GateResult {
+fn evaluate_approval(
+    require: &[Require],
+    artifact: Option<&str>,
+    inputs: &GateInputs,
+) -> GateResult {
+    // A declared review artifact (spec §9) is a deterministic prerequisite,
+    // exactly like `require: [tests]`: the pause is unreachable until the file
+    // exists, and a missing file blocks with the same reason the `artifact`
+    // gate would give — never `AwaitingApproval` over a document that isn't
+    // there for the human to read.
+    if let Some(path) = artifact {
+        let presence = evaluate_artifact(path, inputs);
+        if presence.outcome == GateOutcome::Blocked {
+            return presence;
+        }
+    }
     // `require: [tests]` (spec §9): the deterministic gate is evaluated first, so
     // the approval pause is unreachable while tests are red — a failing/timed-out/
     // setup-failed run blocks exactly like a `tests` gate, quoting the same reason
@@ -397,7 +414,10 @@ mod tests {
 
     #[test]
     fn approval_gate_awaits_then_passes() {
-        let bare = Gate::Approval { require: vec![] };
+        let bare = Gate::Approval {
+            require: vec![],
+            artifact: None,
+        };
         let waiting = evaluate(&bare, &GateInputs::default());
         assert_eq!(waiting.outcome, GateOutcome::AwaitingApproval);
 
@@ -412,12 +432,67 @@ mod tests {
     }
 
     #[test]
+    fn approval_with_missing_artifact_blocks_not_awaits() {
+        // An approval gate's declared artifact is a prerequisite exactly like an
+        // unmet `require: [tests]` (spec §9): while the file is missing the human
+        // pause is unreachable — the step blocks (re-prompt) with a reason naming
+        // the path, never `AwaitingApproval` over a document that doesn't exist.
+        let gate = Gate::Approval {
+            require: vec![],
+            artifact: Some("PLAN.md".into()),
+        };
+        let r = evaluate(&gate, &GateInputs::default());
+        assert_eq!(r.outcome, GateOutcome::Blocked);
+        assert!(r.reason.contains("PLAN.md"), "reason: {}", r.reason);
+
+        // Present → the ordinary approval pause; approved → done.
+        let waiting = evaluate(
+            &gate,
+            &GateInputs {
+                artifact_present: true,
+                ..Default::default()
+            },
+        );
+        assert_eq!(waiting.outcome, GateOutcome::AwaitingApproval);
+        let approved = evaluate(
+            &gate,
+            &GateInputs {
+                artifact_present: true,
+                approved: true,
+                ..Default::default()
+            },
+        );
+        assert_eq!(approved.outcome, GateOutcome::Done);
+    }
+
+    #[test]
+    fn approval_missing_artifact_blocks_even_when_approved_and_green() {
+        // The artifact prerequisite is checked before everything else: neither a
+        // prior approval nor green tests can carry the gate past a missing file.
+        let gate = Gate::Approval {
+            require: vec![Require::Tests],
+            artifact: Some("PLAN.md".into()),
+        };
+        let r = evaluate(
+            &gate,
+            &GateInputs {
+                approved: true,
+                tests: Some(&TestsOutcome::Passed),
+                ..Default::default()
+            },
+        );
+        assert_eq!(r.outcome, GateOutcome::Blocked);
+        assert!(r.reason.contains("PLAN.md"), "reason: {}", r.reason);
+    }
+
+    #[test]
     fn approval_require_tests_blocks_before_asking_a_human() {
         // With `require: [tests]`, a red test run must block (and quote the tail)
         // rather than reach the human-approval pause — the deterministic gate is
         // evaluated first (spec §9).
         let gate = Gate::Approval {
             require: vec![Require::Tests],
+            artifact: None,
         };
         let failed = TestsOutcome::Failed {
             tail: "FAIL src/x.test.ts\n  ✕ adds".into(),
@@ -439,6 +514,7 @@ mod tests {
         // pause — the engine never blocks on tests it can't or didn't fail to run.
         let gate = Gate::Approval {
             require: vec![Require::Tests],
+            artifact: None,
         };
         for outcome in [TestsOutcome::Passed, TestsOutcome::NoCommand] {
             let r = evaluate(
@@ -464,6 +540,7 @@ mod tests {
         // approve, so it blocks first.
         let gate = Gate::Approval {
             require: vec![Require::Tests],
+            artifact: None,
         };
         let v = verdict(VerdictResult::Revise, "flaky assertion");
         let r = evaluate(

--- a/src-tauri/src/workflow/prompts.rs
+++ b/src-tauri/src/workflow/prompts.rs
@@ -388,17 +388,30 @@ fn gate_statement(gate: &Gate) -> String {
         Gate::Artifact { path } => {
             format!("You are done when the file `{path}` exists in the repository.")
         }
-        Gate::Approval { require } if require.contains(&Require::Tests) => {
-            "When you believe the work is complete, write your handoff notes and \
-             `verdict.json`. The project's test suite must pass first — the workflow \
-             runs it after your turn; make it green. A human then reviews and approves \
-             before the workflow continues."
-                .to_string()
+        Gate::Approval { require, artifact } => {
+            // Compose the prerequisites the agent can act on (spec §9): the
+            // reviewed artifact and/or green tests must hold before the human
+            // pause is reachable — a step that never writes the file (or never
+            // greens the suite) can only ever block.
+            let mut s = String::from(
+                "When you believe the work is complete, write your handoff notes and \
+                 `verdict.json`.",
+            );
+            if let Some(path) = artifact {
+                s.push_str(&format!(
+                    " The file `{path}` must exist in the repository first — it is the \
+                     document the human reviews, so write it before you finish."
+                ));
+            }
+            if require.contains(&Require::Tests) {
+                s.push_str(
+                    " The project's test suite must pass first — the workflow runs it \
+                     after your turn; make it green.",
+                );
+            }
+            s.push_str(" A human then reviews and approves before the workflow continues.");
+            s
         }
-        Gate::Approval { .. } => "When you believe the work is complete, write your handoff notes \
-             and `verdict.json`. A human will review and approve before the workflow \
-             continues."
-            .to_string(),
         Gate::Tests => "You are done when the project's test suite passes. The workflow runs \
              the project's tests for you after your turn; make them green. Still write \
              `verdict.json` and handoff notes so the next step has your summary."
@@ -483,15 +496,27 @@ mod tests {
             path: "X.md".into()
         })
         .contains("X.md"));
-        assert!(gate_statement(&Gate::Approval { require: vec![] }).contains("human"));
+        assert!(gate_statement(&Gate::Approval {
+            require: vec![],
+            artifact: None,
+        })
+        .contains("human"));
         let tests = gate_statement(&Gate::Tests);
         assert!(tests.contains("test suite passes"), "{tests}");
         // An approval gate that requires tests reminds the agent about them too.
         let approval_tests = gate_statement(&Gate::Approval {
             require: vec![Require::Tests],
+            artifact: None,
         });
         assert!(approval_tests.contains("test suite"), "{approval_tests}");
         assert!(approval_tests.contains("human"), "{approval_tests}");
+        // …and one with a reviewed artifact names the file the human will read.
+        let approval_artifact = gate_statement(&Gate::Approval {
+            require: vec![],
+            artifact: Some("PLAN.md".into()),
+        });
+        assert!(approval_artifact.contains("PLAN.md"), "{approval_artifact}");
+        assert!(approval_artifact.contains("human"), "{approval_artifact}");
     }
 
     #[test]

--- a/src-tauri/src/workflow/scheduler/context.rs
+++ b/src-tauri/src/workflow/scheduler/context.rs
@@ -88,6 +88,9 @@ pub(crate) struct ChildCtx {
     pub(crate) eff: EffectiveBudgets,
     pub(crate) run_id: String,
     pub(crate) run_task: String,
+    /// The run's project — scopes the shared run-env lookup a `tests`-gated
+    /// child resolves at gate time (see `tests_gate::RunEnvSource`).
+    pub(crate) project_id: String,
     pub(crate) step: Step,
     pub(crate) agent_spec: AgentSpec,
     pub(crate) fork_base: String,
@@ -141,6 +144,9 @@ pub(crate) enum ChildStatus {
 /// loop executor share a single [`execute_step`] without a dozen positional args.
 pub(crate) struct StepEnv<'a> {
     pub(crate) repo: &'a Path,
+    /// The run's project — scopes the shared run-env lookup for the tests gate
+    /// and the approval-gate evidence checks (see `run_env`).
+    pub(crate) project_id: &'a str,
     pub(crate) run_repo: &'a Path,
     pub(crate) blackboard: &'a Path,
     pub(crate) eff: &'a EffectiveBudgets,

--- a/src-tauri/src/workflow/scheduler/drive.rs
+++ b/src-tauri/src/workflow/scheduler/drive.rs
@@ -201,6 +201,7 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
     // loop executor share a single `execute_step` (spec §6.6).
     let env = StepEnv {
         repo: &repo,
+        project_id: &run.project_id,
         run_repo: &run_repo,
         blackboard: &blackboard,
         eff: &eff,

--- a/src-tauri/src/workflow/scheduler/orchestrate.rs
+++ b/src-tauri/src/workflow/scheduler/orchestrate.rs
@@ -1429,6 +1429,7 @@ async fn resume_subrun_merge(
             };
             let env = StepEnv {
                 repo,
+                project_id: &run.project_id,
                 run_repo,
                 blackboard,
                 eff,
@@ -1524,6 +1525,7 @@ fn build_orch_child_ctx(
         eff: eff.clone(),
         run_id: run_id.to_string(),
         run_task: run.task.clone(),
+        project_id: run.project_id.clone(),
         step,
         agent_spec,
         fork_base: fork_base.to_string(),
@@ -1580,6 +1582,12 @@ async fn drive_orch_child(c: ChildCtx, stage_entry_sha: Option<String>) -> OrchC
         c.test_override.clone(),
         c.setup_override.clone(),
         step_eff.tests_timeout_secs.max(1) as u64,
+        crate::workflow::tests_gate::RunEnvSource {
+            db: c.db.clone(),
+            project_id: c.project_id.clone(),
+            repo_path: c.repo.clone(),
+            run_id: c.run_id.clone(),
+        },
     ) {
         Ok(r) => r,
         Err(e) => {

--- a/src-tauri/src/workflow/scheduler/parallel.rs
+++ b/src-tauri/src/workflow/scheduler/parallel.rs
@@ -226,6 +226,7 @@ pub(crate) async fn run_parallel_stage(
             eff: eff.clone(),
             run_id: run_id.to_string(),
             run_task: run.task.clone(),
+            project_id: run.project_id.clone(),
             step: step.clone(),
             agent_spec: agent_spec.clone(),
             fork_base: fork_base.to_string(),
@@ -794,6 +795,7 @@ async fn resume_merge_stage(
             };
             let env = StepEnv {
                 repo,
+                project_id: &run.project_id,
                 run_repo,
                 blackboard,
                 eff,
@@ -896,6 +898,12 @@ async fn drive_child(c: ChildCtx, stage_entry_sha: Option<String>) -> ChildResul
         c.test_override.clone(),
         c.setup_override.clone(),
         step_eff.tests_timeout_secs.max(1) as u64,
+        crate::workflow::tests_gate::RunEnvSource {
+            db: c.db.clone(),
+            project_id: c.project_id.clone(),
+            repo_path: c.repo.clone(),
+            run_id: c.run_id.clone(),
+        },
     ) {
         Ok(r) => r,
         Err(e) => {

--- a/src-tauri/src/workflow/scheduler/steps.rs
+++ b/src-tauri/src/workflow/scheduler/steps.rs
@@ -200,6 +200,12 @@ pub(crate) async fn execute_step(
         env.test_override.clone(),
         env.setup_override.clone(),
         step_eff.tests_timeout_secs.max(1) as u64,
+        crate::workflow::tests_gate::RunEnvSource {
+            db: ctx.db.clone(),
+            project_id: env.project_id.to_string(),
+            repo_path: env.repo.to_path_buf(),
+            run_id: run_id.to_string(),
+        },
     )?;
 
     let mut attempt_no = next_attempt_no(&ctx.db.lock(), run_id, &step.id, iteration as i64);
@@ -367,6 +373,33 @@ pub(crate) async fn execute_step(
                             pause_question(ctx, run_id, &exec_id, result.agent_id.as_deref()).await;
                             return Ok(StepFlow::Halt);
                         }
+                        // A passing autonomous `artifact` gate journals the file
+                        // it gated on (spec §9) — same `gate_evidence` payload as
+                        // an approval pause minus the checks, so an unattended
+                        // run's plan is readable after the worktree is gone.
+                        if matches!(step.gate, Gate::Artifact { .. }) {
+                            let evidence = assemble_gate_evidence(
+                                env,
+                                &step.id,
+                                &step.gate,
+                                &wt,
+                                &head,
+                                step_eff.tests_timeout_secs.max(1) as u64,
+                                ledger,
+                                false,
+                                &[],
+                            )
+                            .await;
+                            let conn = ctx.db.lock();
+                            journal_event(
+                                &conn,
+                                ctx.app.as_ref(),
+                                run_id,
+                                event_type::GATE_EVIDENCE,
+                                Some(&exec_id),
+                                &evidence,
+                            );
+                        }
                         if let Some(agent_id) = &result.agent_id {
                             let _ = ctx.driver.archive(agent_id).await;
                         }
@@ -416,13 +449,31 @@ pub(crate) async fn execute_step(
                 // spend, and the step's verdict — journaled so ReviewSurface can
                 // render it without re-deriving anything. No lock is held across
                 // the (async) verification + git work.
+                // The project's shared run env for the evidence checks — the
+                // same membrane the tests gate applies, resolved against this
+                // attempt's checkout (the step agent's id is known here).
+                let run_env = {
+                    let conn = ctx.db.lock();
+                    crate::run_env::resolve(
+                        &conn,
+                        env.project_id,
+                        env.repo,
+                        &crate::run_env::InterpCtx {
+                            agent_id: result.agent_id.as_deref().unwrap_or(run_id),
+                            worktree,
+                        },
+                    )
+                };
                 let evidence = assemble_gate_evidence(
                     env,
                     &step.id,
+                    &step.gate,
                     worktree,
                     &head,
                     step_eff.tests_timeout_secs.max(1) as u64,
                     ledger,
+                    true,
+                    &run_env,
                 )
                 .await;
                 {
@@ -584,34 +635,50 @@ pub(crate) async fn execute_step(
     }
 }
 
-/// Assemble an `approval` gate's review evidence (spec §9), as the `gate_evidence`
-/// payload (snake_case, like every IPC payload): the verification report (the
-/// shared `Verifier` primitive run install→test→lint in the step worktree —
+/// Assemble a gate's review evidence (spec §9), as the `gate_evidence` payload
+/// (snake_case, like every IPC payload): the verification report (the shared
+/// `Verifier` primitive run install→test→lint in the step worktree —
 /// all-`Skipped` when the project configures nothing or the host can't sandbox),
 /// the ferried diff versus the run base (shortstat + per-file numstat, both taken
 /// in the run repo where the ferried ref and the base commit live), budget spend
-/// versus cap, and the step's `verdict.json`. Best-effort: any piece that can't be
-/// gathered is omitted / `null` so evidence collection never blocks the pause.
-/// Holds no DB lock across its async verification + git work.
+/// versus cap, the step's `verdict.json`, and the gate's artifact (when it names
+/// one). Best-effort: any piece that can't be gathered is omitted / `null` so
+/// evidence collection never blocks the pause. Holds no DB lock across its async
+/// verification + git work.
+///
+/// Two callers: the approval pause (`run_checks` — the human decides off this,
+/// so the checks run), and a passing autonomous `artifact` gate (`!run_checks` —
+/// the gate already decided; this is capture for after-the-fact reading, and
+/// re-running the project's checks on every artifact step would be pure cost).
+#[allow(clippy::too_many_arguments)]
 async fn assemble_gate_evidence(
     env: &StepEnv<'_>,
     step_id: &str,
+    gate: &Gate,
     worktree: &Path,
     head_sha: &str,
     tests_timeout_secs: u64,
     ledger: &Ledger,
+    run_checks: bool,
+    run_env: &[(String, String)],
 ) -> Value {
     // Reuse the engine-owned verifier. Lint resolves by detection (no project
     // lint override is plumbed to the linear path); a HOME-less host yields no
-    // verifier, reported as `null` rather than a fake empty report.
-    let verification = match crate::verify::Verifier::new(
-        env.test_override.clone(),
-        env.setup_override.clone(),
-        None,
-        tests_timeout_secs,
-    ) {
-        Ok(v) => serde_json::to_value(v.verify(worktree).await).ok(),
-        Err(_) => None,
+    // verifier, reported as `null` rather than a fake empty report. `run_env`
+    // is the project's shared run env (`run_env::resolve`), resolved by the
+    // caller that runs checks; `&[]` when the checks are skipped.
+    let verification = if run_checks {
+        match crate::verify::Verifier::new(
+            env.test_override.clone(),
+            env.setup_override.clone(),
+            None,
+            tests_timeout_secs,
+        ) {
+            Ok(v) => serde_json::to_value(v.verify(worktree, run_env).await).ok(),
+            Err(_) => None,
+        }
+    } else {
+        None
     };
 
     let (additions, deletions) = crate::git::diff_shortstat(env.run_repo, env.base_sha, head_sha)
@@ -643,7 +710,34 @@ async fn assemble_gate_evidence(
             "wall_clock_cap_mins": env.eff.wall_clock_mins,
         },
         "verdict": verdict,
+        "artifact": artifact_evidence(gate, worktree),
     })
+}
+
+/// The journal is the artifact's only after-the-fact home (worktrees are
+/// pruned), but it is a SQLite row — cap the captured content so one huge file
+/// can't bloat `wf_event`. 128 KiB comfortably holds any plan a human would
+/// actually read; `truncated` tells the surface to say so.
+const ARTIFACT_EVIDENCE_CAP: usize = 128 * 1024;
+
+/// Read the gate's declared artifact from the step worktree for the evidence
+/// payload — `{ path, content, truncated }`. `Null` when the gate names no
+/// file or it can't be read (best-effort, like every other evidence piece).
+/// The one capture point for both the approval pause and a passing autonomous
+/// `artifact` gate (spec §9).
+fn artifact_evidence(gate: &Gate, worktree: &Path) -> Value {
+    let read = || -> Option<Value> {
+        let path = gate.artifact_path()?;
+        let bytes = std::fs::read(attempt::artifact_probe_path(worktree, path)?).ok()?;
+        let truncated = bytes.len() > ARTIFACT_EVIDENCE_CAP;
+        let end = bytes.len().min(ARTIFACT_EVIDENCE_CAP);
+        Some(json!({
+            "path": path,
+            "content": String::from_utf8_lossy(&bytes[..end]),
+            "truncated": truncated,
+        }))
+    };
+    read().unwrap_or(Value::Null)
 }
 
 pub(crate) fn gate_mode(gate: &Gate) -> &'static str {

--- a/src-tauri/src/workflow/scheduler/tests.rs
+++ b/src-tauri/src/workflow/scheduler/tests.rs
@@ -631,7 +631,15 @@ async fn unmet_commit_gate_pauses_blocked() {
 /// Drive a single approval-gated step to its pause and return the db + run id.
 /// commit=true so the step ferries real work; the gate then awaits a human.
 async fn drive_to_approval(tmp: &Path, run_id: &str, branch: &str) -> Db {
-    let (db, ws) = scaffold_one_step(tmp, run_id, branch, Gate::Approval { require: vec![] });
+    let (db, ws) = scaffold_one_step(
+        tmp,
+        run_id,
+        branch,
+        Gate::Approval {
+            require: vec![],
+            artifact: None,
+        },
+    );
     let ctx = RunCtx {
         db: db.clone(),
         driver: StubDriver::new(ws, true),
@@ -685,6 +693,139 @@ async fn approval_pause_journals_review_evidence() {
     assert!(v.get("diff").is_some(), "evidence has a diff: {v}");
     assert!(v.get("budget").is_some(), "evidence has a budget: {v}");
     assert!(v.get("verification").is_some(), "evidence has verification");
+}
+
+#[tokio::test]
+async fn approval_with_missing_artifact_pauses_blocked_not_approval() {
+    // §9: an approval gate's declared artifact is a prerequisite — while the
+    // file is missing the run blocks (with the path in the reason) exactly like
+    // an unmet `require`, never pausing `approval` over a document that isn't
+    // there for the human to read.
+    let tmp = tempfile::tempdir().unwrap();
+    let (db, ws) = scaffold_one_step(
+        tmp.path(),
+        "run-appr-art",
+        "wf/aa-1",
+        Gate::Approval {
+            require: vec![],
+            artifact: Some("PLAN.md".into()),
+        },
+    );
+    // commit=false: the stub never writes PLAN.md (a second commit on the
+    // re-prompt would be empty and fail the stub's `git commit`).
+    let ctx = RunCtx {
+        db: db.clone(),
+        driver: StubDriver::new(ws, false),
+        app: None,
+        cancel: Arc::new(AtomicBool::new(false)),
+        pending_ask: Arc::new(AtomicBool::new(false)),
+        deadlines: Deadlines::default(),
+        runs: None,
+    };
+    drive_run(&ctx, "run-appr-art").await;
+    let (status, reason, detail): (String, Option<String>, Option<String>) = db
+        .lock()
+        .query_row(
+            "SELECT r.status, r.paused_reason,
+                    (SELECT json_extract(payload_json,'$.detail') FROM wf_event
+                     WHERE run_id='run-appr-art' AND type='run_paused'
+                     ORDER BY seq DESC LIMIT 1)
+                 FROM wf_run r WHERE r.id='run-appr-art'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(status, "paused");
+    assert_eq!(reason.as_deref(), Some("blocked_gate"));
+    assert!(
+        detail.as_deref().unwrap_or_default().contains("PLAN.md"),
+        "the pause names the missing artifact: {detail:?}"
+    );
+}
+
+#[tokio::test]
+async fn approval_with_present_artifact_pauses_with_its_content_in_evidence() {
+    // §9: when the reviewed artifact exists, the run pauses `approval` and the
+    // `gate_evidence` payload carries `{ path, content, truncated }` read from
+    // the step worktree — what ReviewSurface renders above the diff. The stub
+    // agent writes `stub-1.txt` ("work") during its turn, so gate on that.
+    let tmp = tempfile::tempdir().unwrap();
+    let (db, ws) = scaffold_one_step(
+        tmp.path(),
+        "run-appr-doc",
+        "wf/ad-1",
+        Gate::Approval {
+            require: vec![],
+            artifact: Some("stub-1.txt".into()),
+        },
+    );
+    let ctx = RunCtx {
+        db: db.clone(),
+        driver: StubDriver::new(ws, true),
+        app: None,
+        cancel: Arc::new(AtomicBool::new(false)),
+        pending_ask: Arc::new(AtomicBool::new(false)),
+        deadlines: Deadlines::default(),
+        runs: None,
+    };
+    drive_run(&ctx, "run-appr-doc").await;
+    assert_eq!(run_status_str(&db, "run-appr-doc"), "paused");
+    let payload: String = db
+        .lock()
+        .query_row(
+            "SELECT payload_json FROM wf_event
+                 WHERE run_id='run-appr-doc' AND type=?1 LIMIT 1",
+            [event_type::GATE_EVIDENCE],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let v: Value = serde_json::from_str(&payload).unwrap();
+    assert_eq!(v["artifact"]["path"], "stub-1.txt", "{v}");
+    assert_eq!(v["artifact"]["content"], "work", "{v}");
+    assert_eq!(v["artifact"]["truncated"], false, "{v}");
+}
+
+#[tokio::test]
+async fn passing_artifact_gate_journals_the_artifact_as_evidence() {
+    // §9: a passing autonomous `artifact` gate journals the file it gated on —
+    // same `gate_evidence` payload as an approval pause minus the checks — so
+    // an unattended run's plan is readable after the worktree is pruned.
+    let tmp = tempfile::tempdir().unwrap();
+    let (db, ws) = scaffold_one_step(
+        tmp.path(),
+        "run-art-ev",
+        "wf/ae-1",
+        Gate::Artifact {
+            path: "stub-1.txt".into(),
+        },
+    );
+    let ctx = RunCtx {
+        db: db.clone(),
+        driver: StubDriver::new(ws, true),
+        app: None,
+        cancel: Arc::new(AtomicBool::new(false)),
+        pending_ask: Arc::new(AtomicBool::new(false)),
+        deadlines: Deadlines::default(),
+        runs: None,
+    };
+    drive_run(&ctx, "run-art-ev").await;
+    assert_eq!(run_status_str(&db, "run-art-ev"), "done");
+    let payload: String = db
+        .lock()
+        .query_row(
+            "SELECT payload_json FROM wf_event
+                 WHERE run_id='run-art-ev' AND type=?1 LIMIT 1",
+            [event_type::GATE_EVIDENCE],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let v: Value = serde_json::from_str(&payload).unwrap();
+    assert_eq!(v["artifact"]["path"], "stub-1.txt", "{v}");
+    assert_eq!(v["artifact"]["content"], "work", "{v}");
+    assert!(
+        v["verification"].is_null(),
+        "autonomous capture runs no checks: {v}"
+    );
 }
 
 #[tokio::test]

--- a/src-tauri/src/workflow/spec.rs
+++ b/src-tauri/src/workflow/spec.rs
@@ -154,6 +154,13 @@ pub enum Gate {
     Approval {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         require: Vec<Require>,
+        /// A repo-relative file the human reviews (spec §9) — `artifact` and
+        /// `approval` are two ends of one dial, and this is the middle: the
+        /// pause is unreachable until the file exists (missing → blocked +
+        /// re-prompt, exactly like an unmet `require`), and its content rides
+        /// in the `gate_evidence` payload. Same path rules as `Gate::Artifact`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        artifact: Option<String>,
     },
 }
 
@@ -175,8 +182,23 @@ impl Gate {
     pub fn requires_tests(&self) -> bool {
         match self {
             Gate::Tests => true,
-            Gate::Approval { require } => require.contains(&Require::Tests),
+            Gate::Approval { require, .. } => require.contains(&Require::Tests),
             _ => false,
+        }
+    }
+
+    /// The repo-relative artifact this gate watches, if any: the `artifact`
+    /// gate's path, or an `approval` gate's optional reviewed file. One answer
+    /// for validation, the attempt's existence probe, and evidence capture, so
+    /// the two gate shapes can't drift apart.
+    pub fn artifact_path(&self) -> Option<&str> {
+        match self {
+            Gate::Artifact { path } => Some(path),
+            Gate::Approval {
+                artifact: Some(path),
+                ..
+            } => Some(path),
+            _ => None,
         }
     }
 }
@@ -513,7 +535,9 @@ fn check_step(
         ));
     }
     check_agent_ref(&format!("step '{}'", step.id), &step.agent, spec, errors);
-    if let Gate::Artifact { path } = &step.gate {
+    // Both gate shapes that name a file (`artifact`, `approval.artifact`)
+    // share the repo-relative rules — one probe, one rule set.
+    if let Some(path) = step.gate.artifact_path() {
         check_artifact_path(&step.id, path, errors);
     }
     if let Some(b) = &step.budgets {
@@ -922,10 +946,41 @@ mod tests {
         for require in [vec![], vec![Require::Tests]] {
             let mut s = minimal();
             if let Block::Step(step) = &mut s.workflow[0] {
-                step.gate = Gate::Approval { require };
+                step.gate = Gate::Approval {
+                    require,
+                    artifact: None,
+                };
             }
             assert!(validate(&s).is_ok(), "{:?}", errors(&s));
         }
+    }
+
+    #[test]
+    fn approval_artifact_path_shares_the_artifact_gate_rules() {
+        // `approval.artifact` names a file exactly like the `artifact` gate, so
+        // it obeys the same repo-relative rules (no absolute path, no `..`,
+        // non-empty) — and a valid path validates.
+        for bad in ["/etc/passwd", "../secrets", "  "] {
+            let mut s = minimal();
+            if let Block::Step(step) = &mut s.workflow[0] {
+                step.gate = Gate::Approval {
+                    require: vec![],
+                    artifact: Some(bad.into()),
+                };
+            }
+            assert!(
+                !errors(&s).is_empty(),
+                "expected rejection for approval artifact '{bad}'"
+            );
+        }
+        let mut s = minimal();
+        if let Block::Step(step) = &mut s.workflow[0] {
+            step.gate = Gate::Approval {
+                require: vec![Require::Tests],
+                artifact: Some("PLAN.md".into()),
+            };
+        }
+        assert!(validate(&s).is_ok(), "{:?}", errors(&s));
     }
 
     #[test]
@@ -934,7 +989,13 @@ mod tests {
         // deserialize (empty `require`), and an empty `require` must serialize
         // back to that exact shape so old definitions round-trip byte-for-byte.
         let bare: Gate = serde_json::from_str(r#"{"type":"approval"}"#).unwrap();
-        assert_eq!(bare, Gate::Approval { require: vec![] });
+        assert_eq!(
+            bare,
+            Gate::Approval {
+                require: vec![],
+                artifact: None
+            }
+        );
         assert_eq!(
             serde_json::to_string(&bare).unwrap(),
             r#"{"type":"approval"}"#
@@ -944,12 +1005,30 @@ mod tests {
         assert_eq!(
             with,
             Gate::Approval {
-                require: vec![Require::Tests]
+                require: vec![Require::Tests],
+                artifact: None
             }
         );
         assert!(with.requires_tests());
         assert!(!bare.requires_tests());
         assert!(Gate::Tests.requires_tests());
+        // The reviewed-artifact shape round-trips, and `artifact_path` answers
+        // for both file-naming gates.
+        let reviewed: Gate =
+            serde_json::from_str(r#"{"type":"approval","artifact":"PLAN.md"}"#).unwrap();
+        assert_eq!(reviewed.artifact_path(), Some("PLAN.md"));
+        assert_eq!(
+            serde_json::to_string(&reviewed).unwrap(),
+            r#"{"type":"approval","artifact":"PLAN.md"}"#
+        );
+        assert_eq!(
+            Gate::Artifact {
+                path: "PLAN.md".into()
+            }
+            .artifact_path(),
+            Some("PLAN.md")
+        );
+        assert_eq!(bare.artifact_path(), None);
     }
 
     #[test]

--- a/src-tauri/src/workflow/tests_gate.rs
+++ b/src-tauri/src/workflow/tests_gate.rs
@@ -17,13 +17,14 @@
 //! `sandbox-exec`) yields the same `NoCommand` rather than running a repo-derived
 //! command unsandboxed.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::error::Result;
 use crate::verify::{CheckOutcome, VerificationReport, Verifier};
 
 use super::driver::BoxFuture;
 use super::gates::TestsOutcome;
+use super::Db;
 
 /// Resolves and runs the `tests` gate. Behind a trait so the attempt lifecycle
 /// is unit-testable with a scripted mock (`AgentDriver`'s pattern).
@@ -37,6 +38,38 @@ pub trait TestRunner: Send + Sync {
 /// to a [`TestsOutcome`].
 pub struct SandboxTestRunner {
     verifier: Verifier,
+    run_env: RunEnvSource,
+}
+
+/// Inputs for [`crate::run_env::resolve`] at gate time. Resolution is deferred
+/// to `run_tests` because `{{worktree}}` interpolates against the step agent's
+/// checkout, which exists only once an attempt has spawned it; the run id
+/// stands in for `{{agent_id}}` because the runner outlives any single
+/// attempt's agent.
+pub struct RunEnvSource {
+    pub db: Db,
+    pub project_id: String,
+    /// The *source* repo — where the (gitignored) `.env` lives.
+    pub repo_path: PathBuf,
+    pub run_id: String,
+}
+
+impl RunEnvSource {
+    /// The shared `(NAME, VALUE)` pairs for `worktree`. Same posture as
+    /// `run_env::resolve`: nothing configured (or nothing resolvable) is an
+    /// empty env, never an error — a missing membrane must not brick a gate.
+    fn resolve(&self, worktree: &Path) -> Vec<(String, String)> {
+        let conn = self.db.lock();
+        crate::run_env::resolve(
+            &conn,
+            &self.project_id,
+            &self.repo_path,
+            &crate::run_env::InterpCtx {
+                agent_id: &self.run_id,
+                worktree,
+            },
+        )
+    }
 }
 
 impl SandboxTestRunner {
@@ -44,10 +77,11 @@ impl SandboxTestRunner {
         test_override: Option<String>,
         setup_override: Option<String>,
         timeout_secs: u64,
+        run_env: RunEnvSource,
     ) -> Result<Self> {
         // The tests gate never lints; `lint_override` is `None`.
         let verifier = Verifier::new(test_override, setup_override, None, timeout_secs)?;
-        Ok(Self { verifier })
+        Ok(Self { verifier, run_env })
     }
 }
 
@@ -67,7 +101,13 @@ impl TestRunner for SandboxTestRunner {
                 );
                 return TestsOutcome::NoCommand;
             }
-            let report = self.verifier.verify_tests_only(worktree).await;
+            // The project's shared env, resolved against this attempt's
+            // checkout — the gate runs the same trust class of process as the
+            // Run panel, so it gets the same membrane. Without it a `tests`
+            // gate fails on a project whose tests need e.g. DATABASE_URL even
+            // though the user shared it.
+            let env = self.run_env.resolve(worktree);
+            let report = self.verifier.verify_tests_only(worktree, &env).await;
             map_tests_outcome(&report)
         })
     }

--- a/src-tauri/src/workflow/yaml.rs
+++ b/src-tauri/src/workflow/yaml.rs
@@ -509,6 +509,37 @@ finalize: { push: true, open_pr: true, pr_base: main }
     }
 
     #[test]
+    fn approval_gate_artifact_and_require_round_trip() {
+        // The full approval dial (spec §9) — `require: [tests]` plus the
+        // reviewed `artifact` — must survive spec → yaml → spec, and a bare
+        // approval must not grow either field.
+        use super::super::spec::Require;
+        let mut spec = from_yaml(CANONICAL).unwrap();
+        if let Block::Step(step) = &mut spec.workflow[0] {
+            step.gate = Gate::Approval {
+                require: vec![Require::Tests],
+                artifact: Some("PLAN.md".into()),
+            };
+        }
+        let yaml = to_yaml(&spec).unwrap();
+        assert!(yaml.contains("artifact: PLAN.md"), "{yaml}");
+        let back = from_yaml(&yaml).unwrap();
+        assert_eq!(spec, back, "approval artifact + require must round-trip");
+
+        // Bare approval stays bare on the wire.
+        if let Block::Step(step) = &mut spec.workflow[0] {
+            step.gate = Gate::Approval {
+                require: vec![],
+                artifact: None,
+            };
+        }
+        let yaml = to_yaml(&spec).unwrap();
+        assert!(!yaml.contains("artifact:"), "{yaml}");
+        assert!(!yaml.contains("require"), "{yaml}");
+        assert_eq!(from_yaml(&yaml).unwrap(), spec);
+    }
+
+    #[test]
     fn custom_agent_id_is_never_exported() {
         let mut spec = from_yaml(CANONICAL).unwrap();
         spec.agents.get_mut("coder").unwrap().custom_agent = Some("ca-local-123".into());

--- a/src-tauri/src/workspace/agents.rs
+++ b/src-tauri/src/workspace/agents.rs
@@ -562,6 +562,43 @@ impl WorkspaceManager {
         )
     }
 
+    /// Key-name facts for the per-agent env note
+    /// ([`crate::instructions::env_awareness_note`]): `(shared, unshared)`,
+    /// where `shared` are the keys the user shares into app-run processes and
+    /// `unshared` are the keys discovered in the repo's env files (`.env` plus
+    /// `.env.example`/`.env.sample`) but not shared. Names only — values never
+    /// leave `run_env`'s resolution paths. Never errors: missing files or
+    /// config simply yield fewer (or no) names.
+    pub fn run_env_key_names(
+        &self,
+        project_id: &str,
+        repo_path: &std::path::Path,
+    ) -> (Vec<String>, Vec<String>) {
+        let doc = {
+            let conn = self.db.lock();
+            crate::run_env::load_doc(&conn, project_id)
+        };
+        let shared: Vec<String> = doc
+            .vars
+            .iter()
+            .filter(|v| v.shared)
+            .map(|v| v.key.clone())
+            .collect();
+        let discovered = crate::run_env::discover_env_keys(repo_path);
+        let mut unshared: Vec<String> = Vec::new();
+        for key in discovered
+            .env
+            .iter()
+            .map(|e| e.key.as_str())
+            .chain(discovered.declared.iter().map(String::as_str))
+        {
+            if !shared.iter().any(|s| s == key) && !unshared.iter().any(|s| s == key) {
+                unshared.push(key.to_string());
+            }
+        }
+        (shared, unshared)
+    }
+
     /// Resolve the project_id for a repo path (creating the project/repo
     /// record if it doesn't exist yet — idempotent). The sidebar keys its
     /// project groups by repo path, so the Project Settings surface uses

--- a/src/api/domains/run.ts
+++ b/src/api/domains/run.ts
@@ -1,5 +1,5 @@
 import { invoke } from "../invoke";
-import type { DetectedConfig, EnvEntry, ProjectRunConfig, RunStateSnapshot } from "../types/run";
+import type { DetectedConfig, EnvFileKeys, ProjectRunConfig, RunStateSnapshot } from "../types/run";
 import type { VerificationReport } from "../types/verify";
 
 export const runApi = {
@@ -14,7 +14,7 @@ export const runApi = {
     invoke<VerificationReport>("run_verification", { agentId, subdir: subdir ?? null }),
   projectRunConfig: (repoPath: string) =>
     invoke<ProjectRunConfig>("project_run_config", { repoPath }),
-  readEnvFileKeys: (repoPath: string) => invoke<EnvEntry[]>("read_env_file_keys", { repoPath }),
+  readEnvFileKeys: (repoPath: string) => invoke<EnvFileKeys>("read_env_file_keys", { repoPath }),
   getEnvOverride: (projectId: string, key: string) =>
     invoke<string | null>("get_env_override", { projectId, key }),
   setEnvOverride: (projectId: string, key: string, value: string) =>

--- a/src/api/types/run.ts
+++ b/src/api/types/run.ts
@@ -44,6 +44,14 @@ export interface EnvEntry {
   value: string;
 }
 
+/** A project's discovered env keys (Rust `run_env::EnvFileKeys`): the real
+ *  `.env` entries plus keys only *declared* by `.env.example`/`.env.sample` —
+ *  bare names, because example values are placeholders, never real values. */
+export interface EnvFileKeys {
+  env: EnvEntry[];
+  declared: string[];
+}
+
 export interface RunOutputEvent {
   agent_id: string;
   bytes: number[];

--- a/src/api/types/verify.ts
+++ b/src/api/types/verify.ts
@@ -63,11 +63,23 @@ export interface GateVerdict {
   target: string | null;
 }
 
+/** The gate's reviewed artifact, captured into the evidence while the step
+ *  worktree is intact (spec §9): the `approval` gate's declared file at the
+ *  pause, or the file a passing autonomous `artifact` gate watched. `content`
+ *  is capped server-side (128 KiB); `truncated` marks a capped read. */
+export interface GateArtifact {
+  path: string;
+  content: string;
+  truncated: boolean;
+}
+
 /** The review evidence assembled when an approval gate pauses a run (the Rust
  *  `gate_evidence` event payload, spec §9): verification, the ferried diff vs the
  *  run base, budget spend, and the step's verdict. `verification` is null when the
- *  host couldn't build a verifier; its checks are all `skipped` when the project
- *  configures no commands. `base_sha`/`head_sha` feed `api.wfRunDiff`. */
+ *  host couldn't build a verifier (or the capture ran no checks — a passing
+ *  autonomous `artifact` gate journals the same payload); its checks are all
+ *  `skipped` when the project configures no commands. `base_sha`/`head_sha` feed
+ *  `api.wfRunDiff`. `artifact` is absent on payloads journaled before it existed. */
 export interface GateEvidence {
   base_sha: string;
   head_sha: string;
@@ -75,4 +87,5 @@ export interface GateEvidence {
   diff: GateDiff;
   budget: GateBudget;
   verdict: GateVerdict | null;
+  artifact?: GateArtifact | null;
 }

--- a/src/components/ProjectScreen/EnvVarsSection/EnvVarRow.tsx
+++ b/src/components/ProjectScreen/EnvVarsSection/EnvVarRow.tsx
@@ -9,6 +9,9 @@ interface Props {
   varKey: string;
   /** The value in the repo's `.env`; `undefined` if the var isn't in `.env`. */
   envValue: string | undefined;
+  /** Key declared by `.env.example`/`.env.sample` but absent from `.env` —
+   *  the project wants it, no value is set. */
+  declaredOnly?: boolean;
   /** The override value (from the keychain) when `cfg.source === "override"`. */
   overrideValue: string | undefined;
   cfg: EnvVarCfg;
@@ -30,6 +33,7 @@ interface Props {
 export function EnvVarRow({
   varKey,
   envValue,
+  declaredOnly,
   overrideValue,
   cfg,
   onToggleShare,
@@ -66,6 +70,10 @@ export function EnvVarRow({
       <>
         <span className="dot" /> Overridden · differs from <code>.env</code>
       </>
+    ) : declaredOnly ? (
+      <>
+        <span className="dot" /> Overridden · declared in <code>.env.example</code>
+      </>
     ) : (
       <>
         <span className="dot" /> Added · not in <code>.env</code>
@@ -74,6 +82,10 @@ export function EnvVarRow({
   ) : inEnv ? (
     <>
       from <code>.env</code>
+    </>
+  ) : declaredOnly ? (
+    <>
+      declared in <code>.env.example</code> · not set
     </>
   ) : (
     <>
@@ -96,7 +108,10 @@ export function EnvVarRow({
               <Icon name="refresh" size={12} />
             </IconButton>
           )}
-          {!inEnv && !busy && (
+          {/* A declared-only row with no override has nothing to remove — it
+              re-derives from the example file. Once overridden, remove clears
+              the override and the row falls back to "declared · not set". */}
+          {!inEnv && (!declaredOnly || isOverride) && !busy && (
             <IconButton
               size="sm"
               tip="Remove variable"

--- a/src/components/ProjectScreen/EnvVarsSection/index.tsx
+++ b/src/components/ProjectScreen/EnvVarsSection/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { api, type EnvEntry } from "@/api";
+import { api, type EnvEntry, type EnvFileKeys } from "@/api";
 import {
   loadRunEnvDoc,
   type RunEnvDoc,
@@ -24,6 +24,10 @@ interface Props {
  *  is shared by default. Autosaves per edit, like the run-config section. */
 export function EnvVarsSection({ projectId, repoPath }: Props) {
   const [entries, setEntries] = useState<EnvEntry[] | null>(null);
+  // Keys declared by `.env.example`/`.env.sample` but absent from `.env` —
+  // the project wants them, no value is set (and example placeholders are
+  // never treated as values).
+  const [declared, setDeclared] = useState<string[]>([]);
   const [doc, setDoc] = useState<RunEnvDoc>({ version: 1, vars: [] });
   // Override values (from the keychain), fetched for overridden vars so the
   // chip can show and edit them. Keyed by var name.
@@ -40,12 +44,13 @@ export function EnvVarsSection({ projectId, repoPath }: Props) {
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      const [envEntries, loadedDoc] = await Promise.all([
-        api.readEnvFileKeys(repoPath).catch(() => [] as EnvEntry[]),
+      const [envKeys, loadedDoc] = await Promise.all([
+        api.readEnvFileKeys(repoPath).catch((): EnvFileKeys => ({ env: [], declared: [] })),
         loadRunEnvDoc(projectId),
       ]);
       if (cancelled) return;
-      setEntries(envEntries);
+      setEntries(envKeys.env);
+      setDeclared(envKeys.declared);
       docRef.current = loadedDoc;
       setDoc(loadedDoc);
       // Pull the current override values for any overridden vars.
@@ -64,13 +69,20 @@ export function EnvVarsSection({ projectId, repoPath }: Props) {
 
   const envMap = useMemo(() => new Map((entries ?? []).map((e) => [e.key, e.value])), [entries]);
 
-  // Every `.env` key, plus any configured var missing from `.env` (an
-  // override-only or stale entry) so nothing the user set silently vanishes.
+  // Every `.env` key, then the project-declared keys (`.env.example` /
+  // `.env.sample`) not set in `.env`, plus any configured var missing from
+  // both (an override-only or stale entry) so nothing the user set silently
+  // vanishes.
   const rows = useMemo(() => {
-    const keys = [...envMap.keys()];
-    for (const v of doc.vars) if (!envMap.has(v.key)) keys.push(v.key);
-    return keys.map((key) => ({ key, envValue: envMap.get(key) }));
-  }, [envMap, doc]);
+    const keys = new Set(envMap.keys());
+    for (const k of declared) keys.add(k);
+    for (const v of doc.vars) keys.add(v.key);
+    return [...keys].map((key) => ({
+      key,
+      envValue: envMap.get(key),
+      declaredOnly: !envMap.has(key) && declared.includes(key),
+    }));
+  }, [envMap, declared, doc]);
 
   // Every key already on screen — for rejecting a duplicate add.
   const existingKeys = useMemo(() => new Set(rows.map((r) => r.key)), [rows]);
@@ -213,11 +225,12 @@ export function EnvVarsSection({ projectId, repoPath }: Props) {
         </div>
       ) : (
         <div className="ev-list">
-          {rows.map(({ key, envValue }) => (
+          {rows.map(({ key, envValue, declaredOnly }) => (
             <EnvVarRow
               key={key}
               varKey={key}
               envValue={envValue}
+              declaredOnly={declaredOnly}
               overrideValue={overrides[key]}
               cfg={varConfig(doc, key)}
               onToggleShare={(shared) => onToggleShare(key, shared)}

--- a/src/components/ReviewSurface/ArtifactPanel.tsx
+++ b/src/components/ReviewSurface/ArtifactPanel.tsx
@@ -1,0 +1,23 @@
+// ArtifactPanel — the gate's reviewed artifact (spec §9), rendered as markdown.
+// This is the document the reviewer reads first (the plan is the decision, the
+// diff is the consequence), so ReviewSurface mounts it above the Diff section.
+// Reuses the shared Markdown renderer and the chat's `.m-agent` prose skin
+// (the ProductBrief precedent) rather than growing a second markdown stack.
+
+import type { GateArtifact } from "../../api";
+import { Markdown } from "../Markdown";
+
+export function ArtifactPanel({ artifact }: { artifact: GateArtifact }) {
+  return (
+    <div className="rv-artifact">
+      <div className="rv-artifact-body m-agent">
+        <Markdown>{artifact.content}</Markdown>
+      </div>
+      {artifact.truncated && (
+        <div className="rv-checks-note">
+          Truncated for review — read the full <code>{artifact.path}</code> in the checkout.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ReviewSurface/ReviewSurface.css
+++ b/src/components/ReviewSurface/ReviewSurface.css
@@ -156,6 +156,24 @@
   min-height: 240px;
 }
 
+/* ── artifact (the reviewed document, above the diff) ────────────────────── */
+.rv-artifact {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+/* The `.m-agent` prose skin (Chat.css) does the markdown typography; this box
+ * frames it like the other evidence panels and keeps a runaway plan scrollable
+ * instead of swallowing the surface. */
+.rv-artifact-body {
+  padding: 10px 12px;
+  background: var(--bg-2);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-md);
+  max-height: 360px;
+  overflow-y: auto;
+}
+
 /* ── checks ──────────────────────────────────────────────────────────────── */
 .rv-checks {
   display: flex;

--- a/src/components/ReviewSurface/index.tsx
+++ b/src/components/ReviewSurface/index.tsx
@@ -7,6 +7,7 @@
 
 import type { GateEvidence } from "../../api";
 import { Icon } from "../Icon";
+import { ArtifactPanel } from "./ArtifactPanel";
 import { BudgetSummary } from "./BudgetSummary";
 import { Checks } from "./Checks";
 import { DiffPanel } from "./DiffPanel";
@@ -113,6 +114,18 @@ function Evidence({
         </div>
         <Checks verification={evidence.verification} />
       </section>
+
+      {evidence.artifact && (
+        // The reviewed document goes above the diff: at an artifact-bearing
+        // gate the plan is what the human decides on, the diff is how it got
+        // there. Rejection feedback stays the existing note — no thread UI.
+        <section className="rv-sect">
+          <div className="rv-sect-head">
+            <Icon name="file" size={13} /> {evidence.artifact.path}
+          </div>
+          <ArtifactPanel artifact={evidence.artifact} />
+        </section>
+      )}
 
       <section className="rv-sect rv-sect-diff">
         <div className="rv-sect-head">

--- a/src/starterPack/presets.ts
+++ b/src/starterPack/presets.ts
@@ -178,8 +178,8 @@ export function buildFeaturePipelineSpec(idByRole: Record<string, string>): Spec
         step: {
           id: "plan",
           agent: "architect",
-          goal: "Analyze the task and write PLAN.md describing small, independently testable slices in dependency order.",
-          gate: { type: "artifact", path: "PLAN.md" },
+          goal: "Analyze the task and write PLAN.md describing small, independently testable slices in dependency order. The run pauses on PLAN.md for human review before implementation.",
+          gate: { type: "approval", artifact: "PLAN.md" },
         },
       },
       {

--- a/src/workflows/builder/inspector/StepInspector.tsx
+++ b/src/workflows/builder/inspector/StepInspector.tsx
@@ -15,12 +15,20 @@ export function StepInspector({ step, ctx }: { step: EStep; ctx: BuilderCtx }) {
 
   const pickGate = (kind: GateKind) => {
     const cur = step.gate;
+    // `artifact` and `approval.artifact` are one dial (autonomous ↔ reviewed),
+    // so the file path survives switching between them instead of being retyped.
+    const path =
+      cur.type === "artifact" ? cur.path : cur.type === "approval" ? cur.artifact : undefined;
     const gate: Gate =
       kind === "artifact"
-        ? { type: "artifact", path: cur.type === "artifact" ? cur.path : "" }
+        ? { type: "artifact", path: path ?? "" }
         : // Re-picking approval preserves any existing `require: [tests]`.
           kind === "approval"
-          ? { type: "approval", require: cur.type === "approval" ? cur.require : undefined }
+          ? {
+              type: "approval",
+              require: cur.type === "approval" ? cur.require : undefined,
+              artifact: path || undefined,
+            }
           : { type: kind };
     ctx.patchStep(step.nid, { gate });
   };
@@ -32,8 +40,10 @@ export function StepInspector({ step, ctx }: { step: EStep; ctx: BuilderCtx }) {
     });
   };
 
-  const requireTests =
-    step.gate.type === "approval" && (step.gate.require?.includes("tests") ?? false);
+  // A narrowed binding so the patch closures below can spread the approval
+  // gate without TS losing the discriminant.
+  const approvalGate = step.gate.type === "approval" ? step.gate : null;
+  const requireTests = approvalGate?.require?.includes("tests") ?? false;
 
   return (
     <>
@@ -88,21 +98,36 @@ export function StepInspector({ step, ctx }: { step: EStep; ctx: BuilderCtx }) {
             }
           />
         )}
-        {step.gate.type === "approval" && (
-          // One extra prerequisite the approval gate can require first — the human
-          // pause stays unreachable until the project's tests pass (spec §9).
-          <label className="wb-toggle" style={{ marginTop: 9 }}>
+        {approvalGate && (
+          <>
+            {/* The optional reviewed file (spec §9): the pause waits for it to
+                exist and shows it for your review, above the diff. */}
             <input
-              type="checkbox"
-              checked={requireTests}
+              className="ca-input"
+              style={{ marginTop: 9 }}
+              value={approvalGate.artifact ?? ""}
+              placeholder="Optional: a file to pause for your review, e.g. PLAN.md"
               onChange={(e) =>
                 ctx.patchStep(step.nid, {
-                  gate: { type: "approval", require: e.target.checked ? ["tests"] : undefined },
+                  gate: { ...approvalGate, artifact: e.target.value || undefined },
                 })
               }
             />
-            Require passing tests first
-          </label>
+            {/* One extra prerequisite the approval gate can require first — the
+                human pause stays unreachable until the project's tests pass (§9). */}
+            <label className="wb-toggle" style={{ marginTop: 9 }}>
+              <input
+                type="checkbox"
+                checked={requireTests}
+                onChange={(e) =>
+                  ctx.patchStep(step.nid, {
+                    gate: { ...approvalGate, require: e.target.checked ? ["tests"] : undefined },
+                  })
+                }
+              />
+              Require passing tests first
+            </label>
+          </>
         )}
       </Field>
 

--- a/src/workflows/builder/model.ts
+++ b/src/workflows/builder/model.ts
@@ -474,6 +474,11 @@ function validateStep(s: EStep, v: Validation, seen: Map<string, EStep>): void {
   if (s.gate.type === "artifact" && badArtifactPath(s.gate.path)) {
     push("artifact path must be repo-relative (no leading '/' and no '..')");
   }
+  // An approval gate's reviewed file obeys the same rules when set (spec §9);
+  // unset means an ordinary approval pause, so only a present value is checked.
+  if (s.gate.type === "approval" && s.gate.artifact && badArtifactPath(s.gate.artifact)) {
+    push("the reviewed file must be repo-relative (no leading '/' and no '..')");
+  }
   validateBudgets(s.budgets, push);
   if (errs.length) v.byNode[s.nid] = errs;
 }

--- a/src/workflows/spec.ts
+++ b/src/workflows/spec.ts
@@ -69,13 +69,15 @@ export type Require = "tests";
 
 /** The deterministic predicate that marks a step attempt done (spec §9). An
  *  `approval` gate may list `require: [tests]` — the human pause is unreachable
- *  until the project's tests pass (optional, defaults to none). */
+ *  until the project's tests pass (optional, defaults to none) — and may name a
+ *  repo-relative `artifact` the human reviews: the pause is likewise unreachable
+ *  until that file exists, and its content rides in the gate evidence. */
 export type Gate =
   | { type: "verdict" }
   | { type: "commit" }
   | { type: "artifact"; path: string }
   | { type: "tests" }
-  | { type: "approval"; require?: Require[] };
+  | { type: "approval"; require?: Require[]; artifact?: string };
 
 export interface Step {
   id: string;


### PR DESCRIPTION
Two independent usability changes, both reusing existing machinery.

## Reviewable artifacts at workflow gates

Makes plan/design review a per-step choice: a step can run fully autonomously (`artifact` gate), or pause for human review of the artifact it produced (`approval` gate with the new optional `artifact` field).

- `Gate::Approval` gains `artifact: Option<String>` (serde-default, existing specs/YAML round-trip byte-identical). Path validation reuses the `artifact` gate's rules.
- Semantics: a missing artifact blocks the approval pause exactly like an unmet `require: [tests]` — blocked + re-prompt naming the path, never an approvable pause without the file.
- The artifact's content (128 KiB cap, truncation-flagged) is captured into the journaled `gate_evidence` via one shared helper — at the approval pause **and** when an autonomous `artifact` gate passes, so unattended runs journal the plan for after-the-fact reading.
- ReviewSurface renders it as markdown above the diff (reuses the shared `Markdown` component / chat prose skin). Feedback stays the existing reject-with-note loop.
- Builder: optional review-file input on approval gates; switching `artifact` ↔ `approval` preserves the path.
- Starter pack: the Plan step now writes `PLAN.md` and gates on `approval + artifact: PLAN.md`.

## Env membrane: coverage, awareness, discovery

The opt-in env membrane previously reached only the Run panel; values stay app-layer (keychain / live `.env` mirror), nothing new lands on disk.

- **Verifier injection**: `verify()` / `verify_tests_only()` take resolved shared env at verify time (the tests gate's `{{worktree}}` target only exists once an attempt spawns). Threaded into the tests gate (linear/parallel/orchestrate), turn-end verification, and `run_verification` — so a `tests` gate no longer fails on projects whose tests need a shared `DATABASE_URL`.
- **Agent awareness note** (names only, never values): agents are told which keys are available to app-run processes and which exist but aren't shared, with guidance to use the Run panel/verifier or ask instead of fabricating `.env` files.
- **`.env.example` / `.env.sample` discovery**: declared keys surface as "declared · not set" rows in the project env section; example values are never used as real values.

Invariants preserved: env values never touch workspace clones, the agent process env, SQLite, the journal, instructions, or logs.

## Tests

- `cargo test`: 1397 passed, 0 failed (new: spec validation + JSON/YAML round-trip, missing-artifact-blocks-approval gate tests, scheduler integration tests for both pause shapes and autonomous capture, run_env example-file tests, verifier env-plumbing seam, instructions names-only note).
- `tsc --noEmit` clean, vitest 992 passed.