### PR TITLE
feat(env): extend the env membrane to every app-run process

### DIFF
--- a/src-tauri/src/commands/run.rs
+++ b/src-tauri/src/commands/run.rs
@@ -74,7 +74,7 @@ pub async fn run_verification(
     agent_id: String,
     subdir: Option<String>,
 ) -> Result<crate::verify::VerificationReport> {
-    let (_repo, checkout) = agent_repo_checkout(&supervisor, &agent_id, subdir.as_deref())?;
+    let (repo, checkout) = agent_repo_checkout(&supervisor, &agent_id, subdir.as_deref())?;
     // Serialize against the turn-end verification (`trigger_turn_end_verification`)
     // and any other in-flight run for this agent. Both drive the same install /
     // test / lint commands in the agent's checkout, so two at once race on the
@@ -116,7 +116,17 @@ pub async fn run_verification(
         setting("run.lint"),
         VERIFY_TIMEOUT_SECS,
     )?;
-    let report = verifier.verify(&checkout).await;
+    // The project's shared run env — the verifier runs the same trust class of
+    // sandboxed process as the Run panel, so it gets the same membrane. Empty
+    // project (or nothing shared) → no vars, and the checks run as before.
+    let env = if project_id.is_empty() {
+        Vec::new()
+    } else {
+        supervisor
+            .workspace
+            .run_env(&project_id, &repo.repo_path, &agent_id, &checkout)
+    };
+    let report = verifier.verify(&checkout, &env).await;
     tracing::info!(
         agent_id = %agent_id,
         passed = report.passed(),
@@ -148,13 +158,16 @@ pub fn project_run_config(
     supervisor.project_run_config(&repo_path)
 }
 
-/// Discover the `KEY=value` pairs in a project's `.env` (in the *source* repo,
-/// where gitignored env files live), for the Run & Environment settings list.
-/// Missing/unreadable `.env` → empty. Values are returned so the UI can show
-/// them masked and flag overrides that differ; it never writes them anywhere.
+/// Discover a project's env keys (in the *source* repo, where gitignored env
+/// files live), for the Run & Environment settings list: the `KEY=value` pairs
+/// in `.env`, plus the keys only *declared* by `.env.example`/`.env.sample` —
+/// bare names, because example values are placeholders and must never be
+/// treated as real values. Missing/unreadable files → empty. `.env` values are
+/// returned so the UI can show them masked and flag overrides that differ; it
+/// never writes them anywhere.
 #[tauri::command]
-pub fn read_env_file_keys(repo_path: String) -> Result<Vec<crate::run_env::EnvEntry>> {
-    Ok(crate::run_env::read_env_file(&expand_tilde(&repo_path)))
+pub fn read_env_file_keys(repo_path: String) -> Result<crate::run_env::EnvFileKeys> {
+    Ok(crate::run_env::discover_env_keys(&expand_tilde(&repo_path)))
 }
 
 /// Read a project variable's override value (keychain-backed) so the settings

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -178,6 +178,52 @@ pub fn multi_repo_workspace_note(repos: &[crate::workspace::TrackedRepo]) -> Opt
     ))
 }
 
+/// Per-agent env-awareness note: which of the project's env keys reach the
+/// processes the app runs on the agent's behalf (the Run panel and the
+/// verifier/tests gate), and which exist — in `.env` or declared by
+/// `.env.example`/`.env.sample` — but were not shared. Composed ahead of any
+/// custom brief by the spawn path, like [`multi_repo_workspace_note`].
+///
+/// Key NAMES only, never values: a value in the system prompt would defeat the
+/// membrane (`run_env`), which never lets values into the agent's process or
+/// its checkout. `None` when the project declares no env at all, so the common
+/// case injects nothing extra.
+pub fn env_awareness_note(shared: &[String], unshared: &[String]) -> Option<String> {
+    if shared.is_empty() && unshared.is_empty() {
+        return None;
+    }
+    let list = |keys: &[String]| {
+        keys.iter()
+            .map(|k| format!("`{k}`"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    let shared_line = if shared.is_empty() {
+        "- Shared with app-run processes: none yet.\n".to_string()
+    } else {
+        format!("- Shared with app-run processes: {}.\n", list(shared))
+    };
+    let unshared_line = if unshared.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "- Present in the project's env config but NOT shared: {}.\n",
+            list(unshared)
+        )
+    };
+    Some(format!(
+        "## Project environment variables\n\n\
+         This project's env values live outside your workspace (its `.env` is gitignored and \
+         deliberately absent from this checkout). Fletch injects the shared ones into the \
+         sandboxed processes it runs for you — the Run panel and the verifier/tests gate — \
+         never into your own environment.\n\n\
+         {shared_line}{unshared_line}\n\
+         Do not fabricate `.env` files or hardcode values to compensate. Run env-dependent \
+         commands through the app (Run panel / verification), or tell the user which key you \
+         need shared."
+    ))
+}
+
 /// Per-agent heads-up for a workspace whose base branch could not be fetched
 /// from `origin` while it was being provisioned (offline, no credentials, the
 /// branch gone from the remote). Composed ahead of any custom brief by the
@@ -473,6 +519,31 @@ mod tests {
         assert!(note.contains("args"), "must point at args.repo: {note}");
         // No redundant "frontend — frontend" suffix when label == subdir.
         assert!(!note.contains("frontend/` — frontend"), "note: {note}");
+    }
+
+    #[test]
+    fn env_note_lists_key_names_only_and_is_conditional() {
+        // No env at all (the common case): no note.
+        assert_eq!(env_awareness_note(&[], &[]), None);
+
+        let note = env_awareness_note(
+            &["DATABASE_URL".into()],
+            &["SECRET_KEY".into(), "API_KEY".into()],
+        )
+        .unwrap();
+        // Both lists render by key NAME — the note carries names, never values.
+        assert!(note.contains("`DATABASE_URL`"), "note: {note}");
+        assert!(note.contains("`SECRET_KEY`"), "note: {note}");
+        assert!(note.contains("`API_KEY`"), "note: {note}");
+        assert!(note.contains("NOT shared"), "note: {note}");
+        // The failure modes the note exists to prevent.
+        assert!(note.contains("Do not fabricate"), "note: {note}");
+        assert!(note.contains("Run panel"), "note: {note}");
+
+        // Nothing shared yet, keys discovered: the note says so rather than
+        // listing an empty set.
+        let none_shared = env_awareness_note(&[], &["API_KEY".into()]).unwrap();
+        assert!(none_shared.contains("none yet"), "note: {none_shared}");
     }
 
     #[test]

--- a/src-tauri/src/run_env.rs
+++ b/src-tauri/src/run_env.rs
@@ -39,6 +39,12 @@ pub const RUN_ENV_SETTING: &str = "run_env";
 /// `.env` for now; `.env.local` and friends are a deliberate later addition.
 const ENV_FILENAME: &str = ".env";
 
+/// Example/template files read for key *discovery* only — the industry
+/// convention for declaring the keys a project needs. Their values are
+/// placeholders and are never used as real values: only [`read_env_file`]
+/// feeds resolution.
+const EXAMPLE_ENV_FILENAMES: [&str; 2] = [".env.example", ".env.sample"];
+
 /// Where a shared variable's value comes from. Serialized as a bare lowercase
 /// string (`"mirror"` / `"override"`) so the frontend document stays trivial;
 /// a future `computed` variant slots in without a document migration.
@@ -184,6 +190,44 @@ pub fn read_env_file(repo_path: &Path) -> Vec<EnvEntry> {
         Ok(text) => parse_env(&text),
         Err(_) => Vec::new(),
     }
+}
+
+/// Keys declared by the repo's example env files ([`EXAMPLE_ENV_FILENAMES`]).
+/// Discovery only: values are deliberately dropped here so a placeholder can
+/// never masquerade as a real value. Missing/unreadable files → fewer keys,
+/// never an error.
+pub fn read_example_env_keys(repo_path: &Path) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for name in EXAMPLE_ENV_FILENAMES {
+        let Ok(text) = std::fs::read_to_string(repo_path.join(name)) else {
+            continue;
+        };
+        for e in parse_env(&text) {
+            if !out.contains(&e.key) {
+                out.push(e.key);
+            }
+        }
+    }
+    out
+}
+
+/// Key discovery for the settings UI and the agent env note: the real `.env`
+/// entries plus the keys only *declared* by an example file — "declared by the
+/// project, not set" — carried as bare names because a placeholder is not a
+/// value.
+#[derive(Debug, Serialize)]
+pub struct EnvFileKeys {
+    pub env: Vec<EnvEntry>,
+    pub declared: Vec<String>,
+}
+
+pub fn discover_env_keys(repo_path: &Path) -> EnvFileKeys {
+    let env = read_env_file(repo_path);
+    let declared = read_example_env_keys(repo_path)
+        .into_iter()
+        .filter(|k| !env.iter().any(|e| &e.key == k))
+        .collect();
+    EnvFileKeys { env, declared }
 }
 
 /// Load the project's run-environment document. Absent or malformed → default
@@ -487,6 +531,56 @@ LEADING= # only a comment
             got,
             vec![("DATABASE_URL".into(), "postgres://real/dev".into())]
         );
+    }
+
+    #[test]
+    fn example_files_declare_keys_but_never_values() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".env"),
+            "DATABASE_URL=postgres://real/dev\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join(".env.example"),
+            "DATABASE_URL=placeholder\nAPI_KEY=your-key-here\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join(".env.sample"), "API_KEY=dupe\nEXTRA=x\n").unwrap();
+        let got = discover_env_keys(dir.path());
+        // `.env` keeps its real value; example keys surface once, as bare
+        // names, and a key already in `.env` is not re-declared.
+        assert_eq!(got.env.len(), 1);
+        assert_eq!(got.env[0].value, "postgres://real/dev");
+        assert_eq!(
+            got.declared,
+            vec!["API_KEY".to_string(), "EXTRA".to_string()]
+        );
+    }
+
+    #[test]
+    fn resolve_never_reads_example_values() {
+        // A shared mirror var declared only by `.env.example` has no resolvable
+        // value — skipped, never injected with the placeholder.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".env.example"), "API_KEY=placeholder\n").unwrap();
+        let db = crate::database::init(dir.path()).unwrap();
+        let conn = db.lock();
+        let project_id = seed(&conn);
+        set_doc(
+            &conn,
+            &project_id,
+            &RunEnvDoc {
+                version: 1,
+                vars: vec![EnvVar {
+                    key: "API_KEY".into(),
+                    shared: true,
+                    source: Source::Mirror,
+                }],
+            },
+        );
+        let wt = PathBuf::from("/tmp/wt");
+        assert!(resolve(&conn, &project_id, dir.path(), &ctx("a", &wt)).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -983,7 +983,18 @@ impl Supervisor {
             })
             .flatten()
             .map(crate::instructions::stale_base_note);
-        let notes = [stale_note, workspace_note]
+        // Which env keys reach app-run processes vs. exist but were withheld —
+        // key names only, never values (see `run_env`; a value in the
+        // instructions would defeat the membrane). Keyed on the primary repo,
+        // where the (gitignored) `.env` lives. Recomputed every launch, like
+        // the other layers, so a sharing change lands on the next spawn/resume.
+        let env_note = record.repos.first().and_then(|primary| {
+            let (shared, unshared) = self
+                .workspace
+                .run_env_key_names(&record.project_id, &primary.repo_path);
+            crate::instructions::env_awareness_note(&shared, &unshared)
+        });
+        let notes = [stale_note, workspace_note, env_note]
             .into_iter()
             .flatten()
             .collect::<Vec<_>>()

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -179,9 +179,14 @@ impl Supervisor {
                 return;
             }
         };
+        // The project's shared run env — same membrane as the ad-hoc
+        // `run_verification` command, resolved for this agent's checkout.
+        let env = self
+            .workspace
+            .run_env(&project_id, &primary.repo_path, &agent_id, &checkout);
         let inflight = self.verify_inflight.clone();
         tauri::async_runtime::spawn(async move {
-            let report = verifier.verify(&checkout).await;
+            let report = verifier.verify(&checkout, &env).await;
             inflight.lock().remove(&agent_id);
             emit_verification(&app, &agent_id, report);
         });

--- a/src-tauri/src/verify.rs
+++ b/src-tauri/src/verify.rs
@@ -142,18 +142,34 @@ impl Verifier {
     }
 
     /// Run the full suite — `install` (once) → `test` → `lint` — and report every
-    /// check. Used by the ad-hoc `run_verification` command.
-    pub async fn verify(&self, worktree: &Path) -> VerificationReport {
-        self.run(worktree, /* include_lint = */ true).await
+    /// check. Used by the ad-hoc `run_verification` command and the turn-end
+    /// verification. `env` is the project's shared run-env pairs
+    /// ([`crate::run_env::resolve`]) injected into every check command — these
+    /// are app-spawned sandboxed processes, the same trust class as the Run
+    /// panel, so they get the same membrane. Pass `&[]` where the caller has no
+    /// project context. A parameter rather than a field because the tests gate
+    /// resolves per step worktree (the `{{worktree}}` interpolation target),
+    /// which exists only once an attempt has spawned its agent.
+    pub async fn verify(&self, worktree: &Path, env: &[(String, String)]) -> VerificationReport {
+        self.run(worktree, /* include_lint = */ true, env).await
     }
 
     /// Run only `install` (once) → `test`, for the workflow tests gate, which has
     /// no use for a lint result and must stay byte-identical to its prior shape.
-    pub async fn verify_tests_only(&self, worktree: &Path) -> VerificationReport {
-        self.run(worktree, /* include_lint = */ false).await
+    pub async fn verify_tests_only(
+        &self,
+        worktree: &Path,
+        env: &[(String, String)],
+    ) -> VerificationReport {
+        self.run(worktree, /* include_lint = */ false, env).await
     }
 
-    async fn run(&self, worktree: &Path, include_lint: bool) -> VerificationReport {
+    async fn run(
+        &self,
+        worktree: &Path,
+        include_lint: bool,
+        env: &[(String, String)],
+    ) -> VerificationReport {
         // The checks run under the Run-panel seatbelt profile, which needs macOS
         // `sandbox-exec`. Where it isn't present we can't safely run a
         // repo-derived command, so skip every check rather than run unsandboxed
@@ -198,7 +214,8 @@ impl Verifier {
             if already {
                 checks.push(passed_cached("install", setup));
             } else {
-                let (outcome, duration_ms, tail) = self.run_check(worktree, "install", setup).await;
+                let (outcome, duration_ms, tail) =
+                    self.run_check(worktree, "install", setup, env).await;
                 if matches!(outcome, CheckOutcome::Passed) {
                     self.setup_done
                         .lock()
@@ -234,7 +251,8 @@ impl Verifier {
                     tail: Vec::new(),
                 }),
                 Some(cmd) => {
-                    let (outcome, duration_ms, tail) = self.run_check(worktree, name, cmd).await;
+                    let (outcome, duration_ms, tail) =
+                        self.run_check(worktree, name, cmd, env).await;
                     checks.push(CheckResult {
                         name: name.to_string(),
                         command: cmd.clone(),
@@ -257,9 +275,10 @@ impl Verifier {
         worktree: &Path,
         name: &str,
         cmd: &str,
+        env: &[(String, String)],
     ) -> (CheckOutcome, u64, Vec<String>) {
         let started = Instant::now();
-        let bounded = self.run_sandboxed(worktree, cmd).await;
+        let bounded = self.run_sandboxed(worktree, cmd, env).await;
         let duration_ms = started.elapsed().as_millis() as u64;
         let outcome_tail = match bounded {
             Bounded::Exited { success: true, .. } => (CheckOutcome::Passed, Vec::new()),
@@ -314,12 +333,12 @@ impl Verifier {
         Ok((PathBuf::from(crate::sandbox::SANDBOX_EXEC), args))
     }
 
-    async fn run_sandboxed(&self, worktree: &Path, cmd: &str) -> Bounded {
+    async fn run_sandboxed(&self, worktree: &Path, cmd: &str, env: &[(String, String)]) -> Bounded {
         let (program, args) = match self.sandbox_command(worktree, cmd) {
             Ok(t) => t,
             Err(e) => return Bounded::Unrunnable(format!("could not build sandbox profile: {e}")),
         };
-        run_bounded(&program, &args, worktree, self.timeout).await
+        run_bounded(&program, &args, worktree, self.timeout, env).await
     }
 }
 
@@ -428,13 +447,22 @@ enum Bounded {
 }
 
 /// Run `program args` in `cwd`, capturing combined stdout+stderr, bounded by
-/// `deadline`. On timeout the child is killed (`kill_on_drop`) and `TimedOut` is
-/// returned. Pure of any workflow/Tauri state so it is directly unit-testable.
-async fn run_bounded(program: &Path, args: &[String], cwd: &Path, deadline: Duration) -> Bounded {
+/// `deadline`. `env` is layered over the inherited environment (the shared
+/// run-env membrane; empty for callers without one). On timeout the child is
+/// killed (`kill_on_drop`) and `TimedOut` is returned. Pure of any
+/// workflow/Tauri state so it is directly unit-testable.
+async fn run_bounded(
+    program: &Path,
+    args: &[String],
+    cwd: &Path,
+    deadline: Duration,
+    env: &[(String, String)],
+) -> Bounded {
     let mut command = Command::new(program);
     command
         .args(args)
         .current_dir(cwd)
+        .envs(env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -635,6 +663,7 @@ mod tests {
             &["-c".into(), "echo ok; exit 0".into()],
             cwd.path(),
             Duration::from_secs(10),
+            &[],
         )
         .await;
         match b {
@@ -654,6 +683,7 @@ mod tests {
             &["-c".into(), "echo boom 1>&2; exit 3".into()],
             cwd.path(),
             Duration::from_secs(10),
+            &[],
         )
         .await;
         match b {
@@ -673,6 +703,7 @@ mod tests {
             &["-c".into(), "sleep 30".into()],
             cwd.path(),
             Duration::from_millis(150),
+            &[],
         )
         .await;
         assert!(matches!(b, Bounded::TimedOut));
@@ -686,9 +717,35 @@ mod tests {
             &[],
             cwd.path(),
             Duration::from_secs(5),
+            &[],
         )
         .await;
         assert!(matches!(b, Bounded::Unrunnable(_)));
+    }
+
+    #[tokio::test]
+    async fn run_bounded_injects_shared_env() {
+        // The env plumbing seam: a shared pair must reach the spawned command's
+        // environment (layered over the inherited one).
+        let cwd = tempfile::tempdir().unwrap();
+        let b = run_bounded(
+            Path::new("/bin/sh"),
+            &["-c".into(), "echo val=$FLETCH_TEST_SHARED".into()],
+            cwd.path(),
+            Duration::from_secs(10),
+            &[("FLETCH_TEST_SHARED".into(), "sesame".into())],
+        )
+        .await;
+        match b {
+            Bounded::Exited { success, tail } => {
+                assert!(success);
+                assert!(
+                    tail.iter().any(|l| l.contains("val=sesame")),
+                    "tail: {tail:?}"
+                );
+            }
+            _ => panic!("expected Exited"),
+        }
     }
 
     #[test]

--- a/src-tauri/src/workflow/scheduler/context.rs
+++ b/src-tauri/src/workflow/scheduler/context.rs
@@ -88,6 +88,9 @@ pub(crate) struct ChildCtx {
     pub(crate) eff: EffectiveBudgets,
     pub(crate) run_id: String,
     pub(crate) run_task: String,
+    /// The run's project — scopes the shared run-env lookup a `tests`-gated
+    /// child resolves at gate time (see `tests_gate::RunEnvSource`).
+    pub(crate) project_id: String,
     pub(crate) step: Step,
     pub(crate) agent_spec: AgentSpec,
     pub(crate) fork_base: String,
@@ -141,6 +144,9 @@ pub(crate) enum ChildStatus {
 /// loop executor share a single [`execute_step`] without a dozen positional args.
 pub(crate) struct StepEnv<'a> {
     pub(crate) repo: &'a Path,
+    /// The run's project — scopes the shared run-env lookup for the tests gate
+    /// and the approval-gate evidence checks (see `run_env`).
+    pub(crate) project_id: &'a str,
     pub(crate) run_repo: &'a Path,
     pub(crate) blackboard: &'a Path,
     pub(crate) eff: &'a EffectiveBudgets,

--- a/src-tauri/src/workflow/scheduler/drive.rs
+++ b/src-tauri/src/workflow/scheduler/drive.rs
@@ -201,6 +201,7 @@ async fn drive_run_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
     // loop executor share a single `execute_step` (spec §6.6).
     let env = StepEnv {
         repo: &repo,
+        project_id: &run.project_id,
         run_repo: &run_repo,
         blackboard: &blackboard,
         eff: &eff,

--- a/src-tauri/src/workflow/scheduler/orchestrate.rs
+++ b/src-tauri/src/workflow/scheduler/orchestrate.rs
@@ -1429,6 +1429,7 @@ async fn resume_subrun_merge(
             };
             let env = StepEnv {
                 repo,
+                project_id: &run.project_id,
                 run_repo,
                 blackboard,
                 eff,
@@ -1524,6 +1525,7 @@ fn build_orch_child_ctx(
         eff: eff.clone(),
         run_id: run_id.to_string(),
         run_task: run.task.clone(),
+        project_id: run.project_id.clone(),
         step,
         agent_spec,
         fork_base: fork_base.to_string(),
@@ -1580,6 +1582,12 @@ async fn drive_orch_child(c: ChildCtx, stage_entry_sha: Option<String>) -> OrchC
         c.test_override.clone(),
         c.setup_override.clone(),
         step_eff.tests_timeout_secs.max(1) as u64,
+        crate::workflow::tests_gate::RunEnvSource {
+            db: c.db.clone(),
+            project_id: c.project_id.clone(),
+            repo_path: c.repo.clone(),
+            run_id: c.run_id.clone(),
+        },
     ) {
         Ok(r) => r,
         Err(e) => {

--- a/src-tauri/src/workflow/scheduler/parallel.rs
+++ b/src-tauri/src/workflow/scheduler/parallel.rs
@@ -226,6 +226,7 @@ pub(crate) async fn run_parallel_stage(
             eff: eff.clone(),
             run_id: run_id.to_string(),
             run_task: run.task.clone(),
+            project_id: run.project_id.clone(),
             step: step.clone(),
             agent_spec: agent_spec.clone(),
             fork_base: fork_base.to_string(),
@@ -794,6 +795,7 @@ async fn resume_merge_stage(
             };
             let env = StepEnv {
                 repo,
+                project_id: &run.project_id,
                 run_repo,
                 blackboard,
                 eff,
@@ -896,6 +898,12 @@ async fn drive_child(c: ChildCtx, stage_entry_sha: Option<String>) -> ChildResul
         c.test_override.clone(),
         c.setup_override.clone(),
         step_eff.tests_timeout_secs.max(1) as u64,
+        crate::workflow::tests_gate::RunEnvSource {
+            db: c.db.clone(),
+            project_id: c.project_id.clone(),
+            repo_path: c.repo.clone(),
+            run_id: c.run_id.clone(),
+        },
     ) {
         Ok(r) => r,
         Err(e) => {

--- a/src-tauri/src/workflow/scheduler/steps.rs
+++ b/src-tauri/src/workflow/scheduler/steps.rs
@@ -200,6 +200,12 @@ pub(crate) async fn execute_step(
         env.test_override.clone(),
         env.setup_override.clone(),
         step_eff.tests_timeout_secs.max(1) as u64,
+        crate::workflow::tests_gate::RunEnvSource {
+            db: ctx.db.clone(),
+            project_id: env.project_id.to_string(),
+            repo_path: env.repo.to_path_buf(),
+            run_id: run_id.to_string(),
+        },
     )?;
 
     let mut attempt_no = next_attempt_no(&ctx.db.lock(), run_id, &step.id, iteration as i64);
@@ -416,6 +422,21 @@ pub(crate) async fn execute_step(
                 // spend, and the step's verdict — journaled so ReviewSurface can
                 // render it without re-deriving anything. No lock is held across
                 // the (async) verification + git work.
+                // The project's shared run env for the evidence checks — the
+                // same membrane the tests gate applies, resolved against this
+                // attempt's checkout (the step agent's id is known here).
+                let run_env = {
+                    let conn = ctx.db.lock();
+                    crate::run_env::resolve(
+                        &conn,
+                        env.project_id,
+                        env.repo,
+                        &crate::run_env::InterpCtx {
+                            agent_id: result.agent_id.as_deref().unwrap_or(run_id),
+                            worktree,
+                        },
+                    )
+                };
                 let evidence = assemble_gate_evidence(
                     env,
                     &step.id,
@@ -423,6 +444,7 @@ pub(crate) async fn execute_step(
                     &head,
                     step_eff.tests_timeout_secs.max(1) as u64,
                     ledger,
+                    &run_env,
                 )
                 .await;
                 {
@@ -600,17 +622,20 @@ async fn assemble_gate_evidence(
     head_sha: &str,
     tests_timeout_secs: u64,
     ledger: &Ledger,
+    run_env: &[(String, String)],
 ) -> Value {
     // Reuse the engine-owned verifier. Lint resolves by detection (no project
     // lint override is plumbed to the linear path); a HOME-less host yields no
-    // verifier, reported as `null` rather than a fake empty report.
+    // verifier, reported as `null` rather than a fake empty report. `run_env`
+    // is the project's shared run env (`run_env::resolve`), resolved by the
+    // caller against this attempt's checkout.
     let verification = match crate::verify::Verifier::new(
         env.test_override.clone(),
         env.setup_override.clone(),
         None,
         tests_timeout_secs,
     ) {
-        Ok(v) => serde_json::to_value(v.verify(worktree).await).ok(),
+        Ok(v) => serde_json::to_value(v.verify(worktree, run_env).await).ok(),
         Err(_) => None,
     };
 

--- a/src-tauri/src/workflow/tests_gate.rs
+++ b/src-tauri/src/workflow/tests_gate.rs
@@ -17,13 +17,14 @@
 //! `sandbox-exec`) yields the same `NoCommand` rather than running a repo-derived
 //! command unsandboxed.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::error::Result;
 use crate::verify::{CheckOutcome, VerificationReport, Verifier};
 
 use super::driver::BoxFuture;
 use super::gates::TestsOutcome;
+use super::Db;
 
 /// Resolves and runs the `tests` gate. Behind a trait so the attempt lifecycle
 /// is unit-testable with a scripted mock (`AgentDriver`'s pattern).
@@ -37,6 +38,38 @@ pub trait TestRunner: Send + Sync {
 /// to a [`TestsOutcome`].
 pub struct SandboxTestRunner {
     verifier: Verifier,
+    run_env: RunEnvSource,
+}
+
+/// Inputs for [`crate::run_env::resolve`] at gate time. Resolution is deferred
+/// to `run_tests` because `{{worktree}}` interpolates against the step agent's
+/// checkout, which exists only once an attempt has spawned it; the run id
+/// stands in for `{{agent_id}}` because the runner outlives any single
+/// attempt's agent.
+pub struct RunEnvSource {
+    pub db: Db,
+    pub project_id: String,
+    /// The *source* repo — where the (gitignored) `.env` lives.
+    pub repo_path: PathBuf,
+    pub run_id: String,
+}
+
+impl RunEnvSource {
+    /// The shared `(NAME, VALUE)` pairs for `worktree`. Same posture as
+    /// `run_env::resolve`: nothing configured (or nothing resolvable) is an
+    /// empty env, never an error — a missing membrane must not brick a gate.
+    fn resolve(&self, worktree: &Path) -> Vec<(String, String)> {
+        let conn = self.db.lock();
+        crate::run_env::resolve(
+            &conn,
+            &self.project_id,
+            &self.repo_path,
+            &crate::run_env::InterpCtx {
+                agent_id: &self.run_id,
+                worktree,
+            },
+        )
+    }
 }
 
 impl SandboxTestRunner {
@@ -44,10 +77,11 @@ impl SandboxTestRunner {
         test_override: Option<String>,
         setup_override: Option<String>,
         timeout_secs: u64,
+        run_env: RunEnvSource,
     ) -> Result<Self> {
         // The tests gate never lints; `lint_override` is `None`.
         let verifier = Verifier::new(test_override, setup_override, None, timeout_secs)?;
-        Ok(Self { verifier })
+        Ok(Self { verifier, run_env })
     }
 }
 
@@ -67,7 +101,13 @@ impl TestRunner for SandboxTestRunner {
                 );
                 return TestsOutcome::NoCommand;
             }
-            let report = self.verifier.verify_tests_only(worktree).await;
+            // The project's shared env, resolved against this attempt's
+            // checkout — the gate runs the same trust class of process as the
+            // Run panel, so it gets the same membrane. Without it a `tests`
+            // gate fails on a project whose tests need e.g. DATABASE_URL even
+            // though the user shared it.
+            let env = self.run_env.resolve(worktree);
+            let report = self.verifier.verify_tests_only(worktree, &env).await;
             map_tests_outcome(&report)
         })
     }

--- a/src-tauri/src/workspace/agents.rs
+++ b/src-tauri/src/workspace/agents.rs
@@ -562,6 +562,43 @@ impl WorkspaceManager {
         )
     }
 
+    /// Key-name facts for the per-agent env note
+    /// ([`crate::instructions::env_awareness_note`]): `(shared, unshared)`,
+    /// where `shared` are the keys the user shares into app-run processes and
+    /// `unshared` are the keys discovered in the repo's env files (`.env` plus
+    /// `.env.example`/`.env.sample`) but not shared. Names only — values never
+    /// leave `run_env`'s resolution paths. Never errors: missing files or
+    /// config simply yield fewer (or no) names.
+    pub fn run_env_key_names(
+        &self,
+        project_id: &str,
+        repo_path: &std::path::Path,
+    ) -> (Vec<String>, Vec<String>) {
+        let doc = {
+            let conn = self.db.lock();
+            crate::run_env::load_doc(&conn, project_id)
+        };
+        let shared: Vec<String> = doc
+            .vars
+            .iter()
+            .filter(|v| v.shared)
+            .map(|v| v.key.clone())
+            .collect();
+        let discovered = crate::run_env::discover_env_keys(repo_path);
+        let mut unshared: Vec<String> = Vec::new();
+        for key in discovered
+            .env
+            .iter()
+            .map(|e| e.key.as_str())
+            .chain(discovered.declared.iter().map(String::as_str))
+        {
+            if !shared.iter().any(|s| s == key) && !unshared.iter().any(|s| s == key) {
+                unshared.push(key.to_string());
+            }
+        }
+        (shared, unshared)
+    }
+
     /// Resolve the project_id for a repo path (creating the project/repo
     /// record if it doesn't exist yet — idempotent). The sidebar keys its
     /// project groups by repo path, so the Project Settings surface uses

--- a/src/api/domains/run.ts
+++ b/src/api/domains/run.ts
@@ -1,5 +1,5 @@
 import { invoke } from "../invoke";
-import type { DetectedConfig, EnvEntry, ProjectRunConfig, RunStateSnapshot } from "../types/run";
+import type { DetectedConfig, EnvFileKeys, ProjectRunConfig, RunStateSnapshot } from "../types/run";
 import type { VerificationReport } from "../types/verify";
 
 export const runApi = {
@@ -14,7 +14,7 @@ export const runApi = {
     invoke<VerificationReport>("run_verification", { agentId, subdir: subdir ?? null }),
   projectRunConfig: (repoPath: string) =>
     invoke<ProjectRunConfig>("project_run_config", { repoPath }),
-  readEnvFileKeys: (repoPath: string) => invoke<EnvEntry[]>("read_env_file_keys", { repoPath }),
+  readEnvFileKeys: (repoPath: string) => invoke<EnvFileKeys>("read_env_file_keys", { repoPath }),
   getEnvOverride: (projectId: string, key: string) =>
     invoke<string | null>("get_env_override", { projectId, key }),
   setEnvOverride: (projectId: string, key: string, value: string) =>

--- a/src/api/types/run.ts
+++ b/src/api/types/run.ts
@@ -44,6 +44,14 @@ export interface EnvEntry {
   value: string;
 }
 
+/** A project's discovered env keys (Rust `run_env::EnvFileKeys`): the real
+ *  `.env` entries plus keys only *declared* by `.env.example`/`.env.sample` —
+ *  bare names, because example values are placeholders, never real values. */
+export interface EnvFileKeys {
+  env: EnvEntry[];
+  declared: string[];
+}
+
 export interface RunOutputEvent {
   agent_id: string;
   bytes: number[];

--- a/src/components/ProjectScreen/EnvVarsSection/EnvVarRow.tsx
+++ b/src/components/ProjectScreen/EnvVarsSection/EnvVarRow.tsx
@@ -9,6 +9,9 @@ interface Props {
   varKey: string;
   /** The value in the repo's `.env`; `undefined` if the var isn't in `.env`. */
   envValue: string | undefined;
+  /** Key declared by `.env.example`/`.env.sample` but absent from `.env` —
+   *  the project wants it, no value is set. */
+  declaredOnly?: boolean;
   /** The override value (from the keychain) when `cfg.source === "override"`. */
   overrideValue: string | undefined;
   cfg: EnvVarCfg;
@@ -30,6 +33,7 @@ interface Props {
 export function EnvVarRow({
   varKey,
   envValue,
+  declaredOnly,
   overrideValue,
   cfg,
   onToggleShare,
@@ -66,6 +70,10 @@ export function EnvVarRow({
       <>
         <span className="dot" /> Overridden · differs from <code>.env</code>
       </>
+    ) : declaredOnly ? (
+      <>
+        <span className="dot" /> Overridden · declared in <code>.env.example</code>
+      </>
     ) : (
       <>
         <span className="dot" /> Added · not in <code>.env</code>
@@ -74,6 +82,10 @@ export function EnvVarRow({
   ) : inEnv ? (
     <>
       from <code>.env</code>
+    </>
+  ) : declaredOnly ? (
+    <>
+      declared in <code>.env.example</code> · not set
     </>
   ) : (
     <>
@@ -96,7 +108,10 @@ export function EnvVarRow({
               <Icon name="refresh" size={12} />
             </IconButton>
           )}
-          {!inEnv && !busy && (
+          {/* A declared-only row with no override has nothing to remove — it
+              re-derives from the example file. Once overridden, remove clears
+              the override and the row falls back to "declared · not set". */}
+          {!inEnv && (!declaredOnly || isOverride) && !busy && (
             <IconButton
               size="sm"
               tip="Remove variable"

--- a/src/components/ProjectScreen/EnvVarsSection/index.tsx
+++ b/src/components/ProjectScreen/EnvVarsSection/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { api, type EnvEntry } from "@/api";
+import { api, type EnvEntry, type EnvFileKeys } from "@/api";
 import {
   loadRunEnvDoc,
   type RunEnvDoc,
@@ -24,6 +24,10 @@ interface Props {
  *  is shared by default. Autosaves per edit, like the run-config section. */
 export function EnvVarsSection({ projectId, repoPath }: Props) {
   const [entries, setEntries] = useState<EnvEntry[] | null>(null);
+  // Keys declared by `.env.example`/`.env.sample` but absent from `.env` —
+  // the project wants them, no value is set (and example placeholders are
+  // never treated as values).
+  const [declared, setDeclared] = useState<string[]>([]);
   const [doc, setDoc] = useState<RunEnvDoc>({ version: 1, vars: [] });
   // Override values (from the keychain), fetched for overridden vars so the
   // chip can show and edit them. Keyed by var name.
@@ -40,12 +44,13 @@ export function EnvVarsSection({ projectId, repoPath }: Props) {
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      const [envEntries, loadedDoc] = await Promise.all([
-        api.readEnvFileKeys(repoPath).catch(() => [] as EnvEntry[]),
+      const [envKeys, loadedDoc] = await Promise.all([
+        api.readEnvFileKeys(repoPath).catch((): EnvFileKeys => ({ env: [], declared: [] })),
         loadRunEnvDoc(projectId),
       ]);
       if (cancelled) return;
-      setEntries(envEntries);
+      setEntries(envKeys.env);
+      setDeclared(envKeys.declared);
       docRef.current = loadedDoc;
       setDoc(loadedDoc);
       // Pull the current override values for any overridden vars.
@@ -64,13 +69,20 @@ export function EnvVarsSection({ projectId, repoPath }: Props) {
 
   const envMap = useMemo(() => new Map((entries ?? []).map((e) => [e.key, e.value])), [entries]);
 
-  // Every `.env` key, plus any configured var missing from `.env` (an
-  // override-only or stale entry) so nothing the user set silently vanishes.
+  // Every `.env` key, then the project-declared keys (`.env.example` /
+  // `.env.sample`) not set in `.env`, plus any configured var missing from
+  // both (an override-only or stale entry) so nothing the user set silently
+  // vanishes.
   const rows = useMemo(() => {
-    const keys = [...envMap.keys()];
-    for (const v of doc.vars) if (!envMap.has(v.key)) keys.push(v.key);
-    return keys.map((key) => ({ key, envValue: envMap.get(key) }));
-  }, [envMap, doc]);
+    const keys = new Set(envMap.keys());
+    for (const k of declared) keys.add(k);
+    for (const v of doc.vars) keys.add(v.key);
+    return [...keys].map((key) => ({
+      key,
+      envValue: envMap.get(key),
+      declaredOnly: !envMap.has(key) && declared.includes(key),
+    }));
+  }, [envMap, declared, doc]);
 
   // Every key already on screen — for rejecting a duplicate add.
   const existingKeys = useMemo(() => new Set(rows.map((r) => r.key)), [rows]);
@@ -213,11 +225,12 @@ export function EnvVarsSection({ projectId, repoPath }: Props) {
         </div>
       ) : (
         <div className="ev-list">
-          {rows.map(({ key, envValue }) => (
+          {rows.map(({ key, envValue, declaredOnly }) => (
             <EnvVarRow
               key={key}
               varKey={key}
               envValue={envValue}
+              declaredOnly={declaredOnly}
               overrideValue={overrides[key]}
               cfg={varConfig(doc, key)}
               onToggleShare={(shared) => onToggleShare(key, shared)}


### PR DESCRIPTION
First of two stacked PRs splitting #619 (this one lands first; the artifact-review PR is based on it).

The opt-in env membrane (`run_env.rs` — per-var share toggles, keychain overrides, live `.env` mirroring) previously reached only the Run panel process. This widens its coverage without changing the model: values still never touch workspace clones, the agent's own process env, SQLite, the journal, instructions, or logs.

- **Verifier injection**: `verify()` / `verify_tests_only()` take resolved shared env at verify time (a constructor-time field can't work — the tests gate's `{{worktree}}` interpolation target exists only once an attempt spawns). Threaded into the tests gate (linear/parallel/orchestrate via a lazy `RunEnvSource`), turn-end verification, approval-gate evidence checks, and `run_verification`. A `tests` gate no longer fails on projects whose tests need a shared `DATABASE_URL`.
- **Agent awareness note** (names only, never values): agents learn which keys are available to app-run processes and which exist but aren't shared, with guidance to use the Run panel/verifier or ask — instead of fabricating `.env` files or hardcoding values.
- **`.env.example` / `.env.sample` discovery**: declared keys surface as "declared · not set" rows in the project env section. Example values inform discovery only and are never used as real values.

InterpCtx per call site: real agent id for `run_verification` and turn-end; run id stands in for the tests gate (the runner outlives per-attempt agents); the step agent's id for approval evidence.

Tests: `cargo test` 1390 passed / 0 failed (new: example-file discovery, resolve-never-reads-example-values, verifier env seam, names-only note); `tsc --noEmit` clean; vitest 992 passed.