### PR TITLE
feat(workflow): reviewable artifacts at approval gates

### DIFF
--- a/src-tauri/src/workflow/attempt.rs
+++ b/src-tauri/src/workflow/attempt.rs
@@ -474,9 +474,12 @@ pub async fn run_attempt(
         } else {
             None
         };
-        let artifact_present = match &gate {
-            Gate::Artifact { path } => artifact_exists(&spawned.worktree, path),
-            _ => false,
+        // Probed for both file-naming gates: the `artifact` gate's path and an
+        // `approval` gate's reviewed artifact (spec §9) — a missing file blocks
+        // the approval pause exactly like an unmet `require`.
+        let artifact_present = match gate.artifact_path() {
+            Some(path) => artifact_exists(&spawned.worktree, path),
+            None => false,
         };
         // Tests gate (spec §9.4): resolve + run the project's tests in the step
         // worktree now, then let the pure gate turn the outcome into done/blocked.
@@ -835,19 +838,26 @@ async fn drive_turn(
     }
 }
 
-/// Existence check for the `artifact` gate. `spec.rs` already rejects absolute
-/// paths and `..` at spec time; this re-validates defensively (the path is a
-/// filesystem probe against the agent's worktree).
-fn artifact_exists(worktree: &Path, rel: &str) -> bool {
+/// Resolve a gate's artifact path inside the worktree, or `None` for a path
+/// that escapes it. `spec.rs` already rejects absolute paths and `..` at spec
+/// time; this re-validates defensively (the path is a filesystem probe against
+/// the agent's worktree). Shared by the existence check here and the evidence
+/// capture in the scheduler, so both apply one rule.
+pub(super) fn artifact_probe_path(worktree: &Path, rel: &str) -> Option<PathBuf> {
     let candidate = Path::new(rel);
     if candidate.is_absolute()
         || candidate
             .components()
             .any(|c| matches!(c, std::path::Component::ParentDir))
     {
-        return false;
+        return None;
     }
-    worktree.join(candidate).exists()
+    Some(worktree.join(candidate))
+}
+
+/// Existence check for the file-naming gates (`artifact`, `approval.artifact`).
+fn artifact_exists(worktree: &Path, rel: &str) -> bool {
+    artifact_probe_path(worktree, rel).is_some_and(|p| p.exists())
 }
 
 fn gate_mode(gate: &Gate) -> &'static str {
@@ -1194,7 +1204,10 @@ mod tests {
             d.as_ref(),
             &NeverTests,
             params(
-                Gate::Approval { require: vec![] },
+                Gate::Approval {
+                    require: vec![],
+                    artifact: None,
+                },
                 bb.path().to_path_buf(),
                 fast(),
             ),

--- a/src-tauri/src/workflow/gates.rs
+++ b/src-tauri/src/workflow/gates.rs
@@ -108,7 +108,9 @@ pub fn evaluate(gate: &Gate, inputs: &GateInputs) -> GateResult {
         Gate::Verdict => evaluate_verdict(inputs),
         Gate::Commit => evaluate_commit(inputs),
         Gate::Artifact { path } => evaluate_artifact(path, inputs),
-        Gate::Approval { require } => evaluate_approval(require, inputs),
+        Gate::Approval { require, artifact } => {
+            evaluate_approval(require, artifact.as_deref(), inputs)
+        }
         Gate::Tests => evaluate_tests(inputs),
     }
 }
@@ -155,7 +157,22 @@ fn evaluate_artifact(path: &str, inputs: &GateInputs) -> GateResult {
     }
 }
 
-fn evaluate_approval(require: &[Require], inputs: &GateInputs) -> GateResult {
+fn evaluate_approval(
+    require: &[Require],
+    artifact: Option<&str>,
+    inputs: &GateInputs,
+) -> GateResult {
+    // A declared review artifact (spec §9) is a deterministic prerequisite,
+    // exactly like `require: [tests]`: the pause is unreachable until the file
+    // exists, and a missing file blocks with the same reason the `artifact`
+    // gate would give — never `AwaitingApproval` over a document that isn't
+    // there for the human to read.
+    if let Some(path) = artifact {
+        let presence = evaluate_artifact(path, inputs);
+        if presence.outcome == GateOutcome::Blocked {
+            return presence;
+        }
+    }
     // `require: [tests]` (spec §9): the deterministic gate is evaluated first, so
     // the approval pause is unreachable while tests are red — a failing/timed-out/
     // setup-failed run blocks exactly like a `tests` gate, quoting the same reason
@@ -397,7 +414,10 @@ mod tests {
 
     #[test]
     fn approval_gate_awaits_then_passes() {
-        let bare = Gate::Approval { require: vec![] };
+        let bare = Gate::Approval {
+            require: vec![],
+            artifact: None,
+        };
         let waiting = evaluate(&bare, &GateInputs::default());
         assert_eq!(waiting.outcome, GateOutcome::AwaitingApproval);
 
@@ -412,12 +432,67 @@ mod tests {
     }
 
     #[test]
+    fn approval_with_missing_artifact_blocks_not_awaits() {
+        // An approval gate's declared artifact is a prerequisite exactly like an
+        // unmet `require: [tests]` (spec §9): while the file is missing the human
+        // pause is unreachable — the step blocks (re-prompt) with a reason naming
+        // the path, never `AwaitingApproval` over a document that doesn't exist.
+        let gate = Gate::Approval {
+            require: vec![],
+            artifact: Some("PLAN.md".into()),
+        };
+        let r = evaluate(&gate, &GateInputs::default());
+        assert_eq!(r.outcome, GateOutcome::Blocked);
+        assert!(r.reason.contains("PLAN.md"), "reason: {}", r.reason);
+
+        // Present → the ordinary approval pause; approved → done.
+        let waiting = evaluate(
+            &gate,
+            &GateInputs {
+                artifact_present: true,
+                ..Default::default()
+            },
+        );
+        assert_eq!(waiting.outcome, GateOutcome::AwaitingApproval);
+        let approved = evaluate(
+            &gate,
+            &GateInputs {
+                artifact_present: true,
+                approved: true,
+                ..Default::default()
+            },
+        );
+        assert_eq!(approved.outcome, GateOutcome::Done);
+    }
+
+    #[test]
+    fn approval_missing_artifact_blocks_even_when_approved_and_green() {
+        // The artifact prerequisite is checked before everything else: neither a
+        // prior approval nor green tests can carry the gate past a missing file.
+        let gate = Gate::Approval {
+            require: vec![Require::Tests],
+            artifact: Some("PLAN.md".into()),
+        };
+        let r = evaluate(
+            &gate,
+            &GateInputs {
+                approved: true,
+                tests: Some(&TestsOutcome::Passed),
+                ..Default::default()
+            },
+        );
+        assert_eq!(r.outcome, GateOutcome::Blocked);
+        assert!(r.reason.contains("PLAN.md"), "reason: {}", r.reason);
+    }
+
+    #[test]
     fn approval_require_tests_blocks_before_asking_a_human() {
         // With `require: [tests]`, a red test run must block (and quote the tail)
         // rather than reach the human-approval pause — the deterministic gate is
         // evaluated first (spec §9).
         let gate = Gate::Approval {
             require: vec![Require::Tests],
+            artifact: None,
         };
         let failed = TestsOutcome::Failed {
             tail: "FAIL src/x.test.ts\n  ✕ adds".into(),
@@ -439,6 +514,7 @@ mod tests {
         // pause — the engine never blocks on tests it can't or didn't fail to run.
         let gate = Gate::Approval {
             require: vec![Require::Tests],
+            artifact: None,
         };
         for outcome in [TestsOutcome::Passed, TestsOutcome::NoCommand] {
             let r = evaluate(
@@ -464,6 +540,7 @@ mod tests {
         // approve, so it blocks first.
         let gate = Gate::Approval {
             require: vec![Require::Tests],
+            artifact: None,
         };
         let v = verdict(VerdictResult::Revise, "flaky assertion");
         let r = evaluate(

--- a/src-tauri/src/workflow/prompts.rs
+++ b/src-tauri/src/workflow/prompts.rs
@@ -388,17 +388,30 @@ fn gate_statement(gate: &Gate) -> String {
         Gate::Artifact { path } => {
             format!("You are done when the file `{path}` exists in the repository.")
         }
-        Gate::Approval { require } if require.contains(&Require::Tests) => {
-            "When you believe the work is complete, write your handoff notes and \
-             `verdict.json`. The project's test suite must pass first — the workflow \
-             runs it after your turn; make it green. A human then reviews and approves \
-             before the workflow continues."
-                .to_string()
+        Gate::Approval { require, artifact } => {
+            // Compose the prerequisites the agent can act on (spec §9): the
+            // reviewed artifact and/or green tests must hold before the human
+            // pause is reachable — a step that never writes the file (or never
+            // greens the suite) can only ever block.
+            let mut s = String::from(
+                "When you believe the work is complete, write your handoff notes and \
+                 `verdict.json`.",
+            );
+            if let Some(path) = artifact {
+                s.push_str(&format!(
+                    " The file `{path}` must exist in the repository first — it is the \
+                     document the human reviews, so write it before you finish."
+                ));
+            }
+            if require.contains(&Require::Tests) {
+                s.push_str(
+                    " The project's test suite must pass first — the workflow runs it \
+                     after your turn; make it green.",
+                );
+            }
+            s.push_str(" A human then reviews and approves before the workflow continues.");
+            s
         }
-        Gate::Approval { .. } => "When you believe the work is complete, write your handoff notes \
-             and `verdict.json`. A human will review and approve before the workflow \
-             continues."
-            .to_string(),
         Gate::Tests => "You are done when the project's test suite passes. The workflow runs \
              the project's tests for you after your turn; make them green. Still write \
              `verdict.json` and handoff notes so the next step has your summary."
@@ -483,15 +496,27 @@ mod tests {
             path: "X.md".into()
         })
         .contains("X.md"));
-        assert!(gate_statement(&Gate::Approval { require: vec![] }).contains("human"));
+        assert!(gate_statement(&Gate::Approval {
+            require: vec![],
+            artifact: None,
+        })
+        .contains("human"));
         let tests = gate_statement(&Gate::Tests);
         assert!(tests.contains("test suite passes"), "{tests}");
         // An approval gate that requires tests reminds the agent about them too.
         let approval_tests = gate_statement(&Gate::Approval {
             require: vec![Require::Tests],
+            artifact: None,
         });
         assert!(approval_tests.contains("test suite"), "{approval_tests}");
         assert!(approval_tests.contains("human"), "{approval_tests}");
+        // …and one with a reviewed artifact names the file the human will read.
+        let approval_artifact = gate_statement(&Gate::Approval {
+            require: vec![],
+            artifact: Some("PLAN.md".into()),
+        });
+        assert!(approval_artifact.contains("PLAN.md"), "{approval_artifact}");
+        assert!(approval_artifact.contains("human"), "{approval_artifact}");
     }
 
     #[test]

--- a/src-tauri/src/workflow/scheduler/steps.rs
+++ b/src-tauri/src/workflow/scheduler/steps.rs
@@ -373,6 +373,33 @@ pub(crate) async fn execute_step(
                             pause_question(ctx, run_id, &exec_id, result.agent_id.as_deref()).await;
                             return Ok(StepFlow::Halt);
                         }
+                        // A passing autonomous `artifact` gate journals the file
+                        // it gated on (spec §9) — same `gate_evidence` payload as
+                        // an approval pause minus the checks, so an unattended
+                        // run's plan is readable after the worktree is gone.
+                        if matches!(step.gate, Gate::Artifact { .. }) {
+                            let evidence = assemble_gate_evidence(
+                                env,
+                                &step.id,
+                                &step.gate,
+                                &wt,
+                                &head,
+                                step_eff.tests_timeout_secs.max(1) as u64,
+                                ledger,
+                                false,
+                                &[],
+                            )
+                            .await;
+                            let conn = ctx.db.lock();
+                            journal_event(
+                                &conn,
+                                ctx.app.as_ref(),
+                                run_id,
+                                event_type::GATE_EVIDENCE,
+                                Some(&exec_id),
+                                &evidence,
+                            );
+                        }
                         if let Some(agent_id) = &result.agent_id {
                             let _ = ctx.driver.archive(agent_id).await;
                         }
@@ -440,10 +467,12 @@ pub(crate) async fn execute_step(
                 let evidence = assemble_gate_evidence(
                     env,
                     &step.id,
+                    &step.gate,
                     worktree,
                     &head,
                     step_eff.tests_timeout_secs.max(1) as u64,
                     ledger,
+                    true,
                     &run_env,
                 )
                 .await;
@@ -606,37 +635,50 @@ pub(crate) async fn execute_step(
     }
 }
 
-/// Assemble an `approval` gate's review evidence (spec §9), as the `gate_evidence`
-/// payload (snake_case, like every IPC payload): the verification report (the
-/// shared `Verifier` primitive run install→test→lint in the step worktree —
+/// Assemble a gate's review evidence (spec §9), as the `gate_evidence` payload
+/// (snake_case, like every IPC payload): the verification report (the shared
+/// `Verifier` primitive run install→test→lint in the step worktree —
 /// all-`Skipped` when the project configures nothing or the host can't sandbox),
 /// the ferried diff versus the run base (shortstat + per-file numstat, both taken
 /// in the run repo where the ferried ref and the base commit live), budget spend
-/// versus cap, and the step's `verdict.json`. Best-effort: any piece that can't be
-/// gathered is omitted / `null` so evidence collection never blocks the pause.
-/// Holds no DB lock across its async verification + git work.
+/// versus cap, the step's `verdict.json`, and the gate's artifact (when it names
+/// one). Best-effort: any piece that can't be gathered is omitted / `null` so
+/// evidence collection never blocks the pause. Holds no DB lock across its async
+/// verification + git work.
+///
+/// Two callers: the approval pause (`run_checks` — the human decides off this,
+/// so the checks run), and a passing autonomous `artifact` gate (`!run_checks` —
+/// the gate already decided; this is capture for after-the-fact reading, and
+/// re-running the project's checks on every artifact step would be pure cost).
+#[allow(clippy::too_many_arguments)]
 async fn assemble_gate_evidence(
     env: &StepEnv<'_>,
     step_id: &str,
+    gate: &Gate,
     worktree: &Path,
     head_sha: &str,
     tests_timeout_secs: u64,
     ledger: &Ledger,
+    run_checks: bool,
     run_env: &[(String, String)],
 ) -> Value {
     // Reuse the engine-owned verifier. Lint resolves by detection (no project
     // lint override is plumbed to the linear path); a HOME-less host yields no
     // verifier, reported as `null` rather than a fake empty report. `run_env`
     // is the project's shared run env (`run_env::resolve`), resolved by the
-    // caller against this attempt's checkout.
-    let verification = match crate::verify::Verifier::new(
-        env.test_override.clone(),
-        env.setup_override.clone(),
-        None,
-        tests_timeout_secs,
-    ) {
-        Ok(v) => serde_json::to_value(v.verify(worktree, run_env).await).ok(),
-        Err(_) => None,
+    // caller that runs checks; `&[]` when the checks are skipped.
+    let verification = if run_checks {
+        match crate::verify::Verifier::new(
+            env.test_override.clone(),
+            env.setup_override.clone(),
+            None,
+            tests_timeout_secs,
+        ) {
+            Ok(v) => serde_json::to_value(v.verify(worktree, run_env).await).ok(),
+            Err(_) => None,
+        }
+    } else {
+        None
     };
 
     let (additions, deletions) = crate::git::diff_shortstat(env.run_repo, env.base_sha, head_sha)
@@ -668,7 +710,34 @@ async fn assemble_gate_evidence(
             "wall_clock_cap_mins": env.eff.wall_clock_mins,
         },
         "verdict": verdict,
+        "artifact": artifact_evidence(gate, worktree),
     })
+}
+
+/// The journal is the artifact's only after-the-fact home (worktrees are
+/// pruned), but it is a SQLite row — cap the captured content so one huge file
+/// can't bloat `wf_event`. 128 KiB comfortably holds any plan a human would
+/// actually read; `truncated` tells the surface to say so.
+const ARTIFACT_EVIDENCE_CAP: usize = 128 * 1024;
+
+/// Read the gate's declared artifact from the step worktree for the evidence
+/// payload — `{ path, content, truncated }`. `Null` when the gate names no
+/// file or it can't be read (best-effort, like every other evidence piece).
+/// The one capture point for both the approval pause and a passing autonomous
+/// `artifact` gate (spec §9).
+fn artifact_evidence(gate: &Gate, worktree: &Path) -> Value {
+    let read = || -> Option<Value> {
+        let path = gate.artifact_path()?;
+        let bytes = std::fs::read(attempt::artifact_probe_path(worktree, path)?).ok()?;
+        let truncated = bytes.len() > ARTIFACT_EVIDENCE_CAP;
+        let end = bytes.len().min(ARTIFACT_EVIDENCE_CAP);
+        Some(json!({
+            "path": path,
+            "content": String::from_utf8_lossy(&bytes[..end]),
+            "truncated": truncated,
+        }))
+    };
+    read().unwrap_or(Value::Null)
 }
 
 pub(crate) fn gate_mode(gate: &Gate) -> &'static str {

--- a/src-tauri/src/workflow/scheduler/tests.rs
+++ b/src-tauri/src/workflow/scheduler/tests.rs
@@ -631,7 +631,15 @@ async fn unmet_commit_gate_pauses_blocked() {
 /// Drive a single approval-gated step to its pause and return the db + run id.
 /// commit=true so the step ferries real work; the gate then awaits a human.
 async fn drive_to_approval(tmp: &Path, run_id: &str, branch: &str) -> Db {
-    let (db, ws) = scaffold_one_step(tmp, run_id, branch, Gate::Approval { require: vec![] });
+    let (db, ws) = scaffold_one_step(
+        tmp,
+        run_id,
+        branch,
+        Gate::Approval {
+            require: vec![],
+            artifact: None,
+        },
+    );
     let ctx = RunCtx {
         db: db.clone(),
         driver: StubDriver::new(ws, true),
@@ -685,6 +693,139 @@ async fn approval_pause_journals_review_evidence() {
     assert!(v.get("diff").is_some(), "evidence has a diff: {v}");
     assert!(v.get("budget").is_some(), "evidence has a budget: {v}");
     assert!(v.get("verification").is_some(), "evidence has verification");
+}
+
+#[tokio::test]
+async fn approval_with_missing_artifact_pauses_blocked_not_approval() {
+    // §9: an approval gate's declared artifact is a prerequisite — while the
+    // file is missing the run blocks (with the path in the reason) exactly like
+    // an unmet `require`, never pausing `approval` over a document that isn't
+    // there for the human to read.
+    let tmp = tempfile::tempdir().unwrap();
+    let (db, ws) = scaffold_one_step(
+        tmp.path(),
+        "run-appr-art",
+        "wf/aa-1",
+        Gate::Approval {
+            require: vec![],
+            artifact: Some("PLAN.md".into()),
+        },
+    );
+    // commit=false: the stub never writes PLAN.md (a second commit on the
+    // re-prompt would be empty and fail the stub's `git commit`).
+    let ctx = RunCtx {
+        db: db.clone(),
+        driver: StubDriver::new(ws, false),
+        app: None,
+        cancel: Arc::new(AtomicBool::new(false)),
+        pending_ask: Arc::new(AtomicBool::new(false)),
+        deadlines: Deadlines::default(),
+        runs: None,
+    };
+    drive_run(&ctx, "run-appr-art").await;
+    let (status, reason, detail): (String, Option<String>, Option<String>) = db
+        .lock()
+        .query_row(
+            "SELECT r.status, r.paused_reason,
+                    (SELECT json_extract(payload_json,'$.detail') FROM wf_event
+                     WHERE run_id='run-appr-art' AND type='run_paused'
+                     ORDER BY seq DESC LIMIT 1)
+                 FROM wf_run r WHERE r.id='run-appr-art'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(status, "paused");
+    assert_eq!(reason.as_deref(), Some("blocked_gate"));
+    assert!(
+        detail.as_deref().unwrap_or_default().contains("PLAN.md"),
+        "the pause names the missing artifact: {detail:?}"
+    );
+}
+
+#[tokio::test]
+async fn approval_with_present_artifact_pauses_with_its_content_in_evidence() {
+    // §9: when the reviewed artifact exists, the run pauses `approval` and the
+    // `gate_evidence` payload carries `{ path, content, truncated }` read from
+    // the step worktree — what ReviewSurface renders above the diff. The stub
+    // agent writes `stub-1.txt` ("work") during its turn, so gate on that.
+    let tmp = tempfile::tempdir().unwrap();
+    let (db, ws) = scaffold_one_step(
+        tmp.path(),
+        "run-appr-doc",
+        "wf/ad-1",
+        Gate::Approval {
+            require: vec![],
+            artifact: Some("stub-1.txt".into()),
+        },
+    );
+    let ctx = RunCtx {
+        db: db.clone(),
+        driver: StubDriver::new(ws, true),
+        app: None,
+        cancel: Arc::new(AtomicBool::new(false)),
+        pending_ask: Arc::new(AtomicBool::new(false)),
+        deadlines: Deadlines::default(),
+        runs: None,
+    };
+    drive_run(&ctx, "run-appr-doc").await;
+    assert_eq!(run_status_str(&db, "run-appr-doc"), "paused");
+    let payload: String = db
+        .lock()
+        .query_row(
+            "SELECT payload_json FROM wf_event
+                 WHERE run_id='run-appr-doc' AND type=?1 LIMIT 1",
+            [event_type::GATE_EVIDENCE],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let v: Value = serde_json::from_str(&payload).unwrap();
+    assert_eq!(v["artifact"]["path"], "stub-1.txt", "{v}");
+    assert_eq!(v["artifact"]["content"], "work", "{v}");
+    assert_eq!(v["artifact"]["truncated"], false, "{v}");
+}
+
+#[tokio::test]
+async fn passing_artifact_gate_journals_the_artifact_as_evidence() {
+    // §9: a passing autonomous `artifact` gate journals the file it gated on —
+    // same `gate_evidence` payload as an approval pause minus the checks — so
+    // an unattended run's plan is readable after the worktree is pruned.
+    let tmp = tempfile::tempdir().unwrap();
+    let (db, ws) = scaffold_one_step(
+        tmp.path(),
+        "run-art-ev",
+        "wf/ae-1",
+        Gate::Artifact {
+            path: "stub-1.txt".into(),
+        },
+    );
+    let ctx = RunCtx {
+        db: db.clone(),
+        driver: StubDriver::new(ws, true),
+        app: None,
+        cancel: Arc::new(AtomicBool::new(false)),
+        pending_ask: Arc::new(AtomicBool::new(false)),
+        deadlines: Deadlines::default(),
+        runs: None,
+    };
+    drive_run(&ctx, "run-art-ev").await;
+    assert_eq!(run_status_str(&db, "run-art-ev"), "done");
+    let payload: String = db
+        .lock()
+        .query_row(
+            "SELECT payload_json FROM wf_event
+                 WHERE run_id='run-art-ev' AND type=?1 LIMIT 1",
+            [event_type::GATE_EVIDENCE],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let v: Value = serde_json::from_str(&payload).unwrap();
+    assert_eq!(v["artifact"]["path"], "stub-1.txt", "{v}");
+    assert_eq!(v["artifact"]["content"], "work", "{v}");
+    assert!(
+        v["verification"].is_null(),
+        "autonomous capture runs no checks: {v}"
+    );
 }
 
 #[tokio::test]

--- a/src-tauri/src/workflow/spec.rs
+++ b/src-tauri/src/workflow/spec.rs
@@ -154,6 +154,13 @@ pub enum Gate {
     Approval {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         require: Vec<Require>,
+        /// A repo-relative file the human reviews (spec §9) — `artifact` and
+        /// `approval` are two ends of one dial, and this is the middle: the
+        /// pause is unreachable until the file exists (missing → blocked +
+        /// re-prompt, exactly like an unmet `require`), and its content rides
+        /// in the `gate_evidence` payload. Same path rules as `Gate::Artifact`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        artifact: Option<String>,
     },
 }
 
@@ -175,8 +182,23 @@ impl Gate {
     pub fn requires_tests(&self) -> bool {
         match self {
             Gate::Tests => true,
-            Gate::Approval { require } => require.contains(&Require::Tests),
+            Gate::Approval { require, .. } => require.contains(&Require::Tests),
             _ => false,
+        }
+    }
+
+    /// The repo-relative artifact this gate watches, if any: the `artifact`
+    /// gate's path, or an `approval` gate's optional reviewed file. One answer
+    /// for validation, the attempt's existence probe, and evidence capture, so
+    /// the two gate shapes can't drift apart.
+    pub fn artifact_path(&self) -> Option<&str> {
+        match self {
+            Gate::Artifact { path } => Some(path),
+            Gate::Approval {
+                artifact: Some(path),
+                ..
+            } => Some(path),
+            _ => None,
         }
     }
 }
@@ -513,7 +535,9 @@ fn check_step(
         ));
     }
     check_agent_ref(&format!("step '{}'", step.id), &step.agent, spec, errors);
-    if let Gate::Artifact { path } = &step.gate {
+    // Both gate shapes that name a file (`artifact`, `approval.artifact`)
+    // share the repo-relative rules — one probe, one rule set.
+    if let Some(path) = step.gate.artifact_path() {
         check_artifact_path(&step.id, path, errors);
     }
     if let Some(b) = &step.budgets {
@@ -922,10 +946,41 @@ mod tests {
         for require in [vec![], vec![Require::Tests]] {
             let mut s = minimal();
             if let Block::Step(step) = &mut s.workflow[0] {
-                step.gate = Gate::Approval { require };
+                step.gate = Gate::Approval {
+                    require,
+                    artifact: None,
+                };
             }
             assert!(validate(&s).is_ok(), "{:?}", errors(&s));
         }
+    }
+
+    #[test]
+    fn approval_artifact_path_shares_the_artifact_gate_rules() {
+        // `approval.artifact` names a file exactly like the `artifact` gate, so
+        // it obeys the same repo-relative rules (no absolute path, no `..`,
+        // non-empty) — and a valid path validates.
+        for bad in ["/etc/passwd", "../secrets", "  "] {
+            let mut s = minimal();
+            if let Block::Step(step) = &mut s.workflow[0] {
+                step.gate = Gate::Approval {
+                    require: vec![],
+                    artifact: Some(bad.into()),
+                };
+            }
+            assert!(
+                !errors(&s).is_empty(),
+                "expected rejection for approval artifact '{bad}'"
+            );
+        }
+        let mut s = minimal();
+        if let Block::Step(step) = &mut s.workflow[0] {
+            step.gate = Gate::Approval {
+                require: vec![Require::Tests],
+                artifact: Some("PLAN.md".into()),
+            };
+        }
+        assert!(validate(&s).is_ok(), "{:?}", errors(&s));
     }
 
     #[test]
@@ -934,7 +989,13 @@ mod tests {
         // deserialize (empty `require`), and an empty `require` must serialize
         // back to that exact shape so old definitions round-trip byte-for-byte.
         let bare: Gate = serde_json::from_str(r#"{"type":"approval"}"#).unwrap();
-        assert_eq!(bare, Gate::Approval { require: vec![] });
+        assert_eq!(
+            bare,
+            Gate::Approval {
+                require: vec![],
+                artifact: None
+            }
+        );
         assert_eq!(
             serde_json::to_string(&bare).unwrap(),
             r#"{"type":"approval"}"#
@@ -944,12 +1005,30 @@ mod tests {
         assert_eq!(
             with,
             Gate::Approval {
-                require: vec![Require::Tests]
+                require: vec![Require::Tests],
+                artifact: None
             }
         );
         assert!(with.requires_tests());
         assert!(!bare.requires_tests());
         assert!(Gate::Tests.requires_tests());
+        // The reviewed-artifact shape round-trips, and `artifact_path` answers
+        // for both file-naming gates.
+        let reviewed: Gate =
+            serde_json::from_str(r#"{"type":"approval","artifact":"PLAN.md"}"#).unwrap();
+        assert_eq!(reviewed.artifact_path(), Some("PLAN.md"));
+        assert_eq!(
+            serde_json::to_string(&reviewed).unwrap(),
+            r#"{"type":"approval","artifact":"PLAN.md"}"#
+        );
+        assert_eq!(
+            Gate::Artifact {
+                path: "PLAN.md".into()
+            }
+            .artifact_path(),
+            Some("PLAN.md")
+        );
+        assert_eq!(bare.artifact_path(), None);
     }
 
     #[test]

--- a/src-tauri/src/workflow/yaml.rs
+++ b/src-tauri/src/workflow/yaml.rs
@@ -509,6 +509,37 @@ finalize: { push: true, open_pr: true, pr_base: main }
     }
 
     #[test]
+    fn approval_gate_artifact_and_require_round_trip() {
+        // The full approval dial (spec §9) — `require: [tests]` plus the
+        // reviewed `artifact` — must survive spec → yaml → spec, and a bare
+        // approval must not grow either field.
+        use super::super::spec::Require;
+        let mut spec = from_yaml(CANONICAL).unwrap();
+        if let Block::Step(step) = &mut spec.workflow[0] {
+            step.gate = Gate::Approval {
+                require: vec![Require::Tests],
+                artifact: Some("PLAN.md".into()),
+            };
+        }
+        let yaml = to_yaml(&spec).unwrap();
+        assert!(yaml.contains("artifact: PLAN.md"), "{yaml}");
+        let back = from_yaml(&yaml).unwrap();
+        assert_eq!(spec, back, "approval artifact + require must round-trip");
+
+        // Bare approval stays bare on the wire.
+        if let Block::Step(step) = &mut spec.workflow[0] {
+            step.gate = Gate::Approval {
+                require: vec![],
+                artifact: None,
+            };
+        }
+        let yaml = to_yaml(&spec).unwrap();
+        assert!(!yaml.contains("artifact:"), "{yaml}");
+        assert!(!yaml.contains("require"), "{yaml}");
+        assert_eq!(from_yaml(&yaml).unwrap(), spec);
+    }
+
+    #[test]
     fn custom_agent_id_is_never_exported() {
         let mut spec = from_yaml(CANONICAL).unwrap();
         spec.agents.get_mut("coder").unwrap().custom_agent = Some("ca-local-123".into());

--- a/src/api/types/verify.ts
+++ b/src/api/types/verify.ts
@@ -63,11 +63,23 @@ export interface GateVerdict {
   target: string | null;
 }
 
+/** The gate's reviewed artifact, captured into the evidence while the step
+ *  worktree is intact (spec §9): the `approval` gate's declared file at the
+ *  pause, or the file a passing autonomous `artifact` gate watched. `content`
+ *  is capped server-side (128 KiB); `truncated` marks a capped read. */
+export interface GateArtifact {
+  path: string;
+  content: string;
+  truncated: boolean;
+}
+
 /** The review evidence assembled when an approval gate pauses a run (the Rust
  *  `gate_evidence` event payload, spec §9): verification, the ferried diff vs the
  *  run base, budget spend, and the step's verdict. `verification` is null when the
- *  host couldn't build a verifier; its checks are all `skipped` when the project
- *  configures no commands. `base_sha`/`head_sha` feed `api.wfRunDiff`. */
+ *  host couldn't build a verifier (or the capture ran no checks — a passing
+ *  autonomous `artifact` gate journals the same payload); its checks are all
+ *  `skipped` when the project configures no commands. `base_sha`/`head_sha` feed
+ *  `api.wfRunDiff`. `artifact` is absent on payloads journaled before it existed. */
 export interface GateEvidence {
   base_sha: string;
   head_sha: string;
@@ -75,4 +87,5 @@ export interface GateEvidence {
   diff: GateDiff;
   budget: GateBudget;
   verdict: GateVerdict | null;
+  artifact?: GateArtifact | null;
 }

--- a/src/components/ReviewSurface/ArtifactPanel.tsx
+++ b/src/components/ReviewSurface/ArtifactPanel.tsx
@@ -1,0 +1,23 @@
+// ArtifactPanel — the gate's reviewed artifact (spec §9), rendered as markdown.
+// This is the document the reviewer reads first (the plan is the decision, the
+// diff is the consequence), so ReviewSurface mounts it above the Diff section.
+// Reuses the shared Markdown renderer and the chat's `.m-agent` prose skin
+// (the ProductBrief precedent) rather than growing a second markdown stack.
+
+import type { GateArtifact } from "../../api";
+import { Markdown } from "../Markdown";
+
+export function ArtifactPanel({ artifact }: { artifact: GateArtifact }) {
+  return (
+    <div className="rv-artifact">
+      <div className="rv-artifact-body m-agent">
+        <Markdown>{artifact.content}</Markdown>
+      </div>
+      {artifact.truncated && (
+        <div className="rv-checks-note">
+          Truncated for review — read the full <code>{artifact.path}</code> in the checkout.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ReviewSurface/ReviewSurface.css
+++ b/src/components/ReviewSurface/ReviewSurface.css
@@ -156,6 +156,24 @@
   min-height: 240px;
 }
 
+/* ── artifact (the reviewed document, above the diff) ────────────────────── */
+.rv-artifact {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+/* The `.m-agent` prose skin (Chat.css) does the markdown typography; this box
+ * frames it like the other evidence panels and keeps a runaway plan scrollable
+ * instead of swallowing the surface. */
+.rv-artifact-body {
+  padding: 10px 12px;
+  background: var(--bg-2);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-md);
+  max-height: 360px;
+  overflow-y: auto;
+}
+
 /* ── checks ──────────────────────────────────────────────────────────────── */
 .rv-checks {
   display: flex;

--- a/src/components/ReviewSurface/index.tsx
+++ b/src/components/ReviewSurface/index.tsx
@@ -7,6 +7,7 @@
 
 import type { GateEvidence } from "../../api";
 import { Icon } from "../Icon";
+import { ArtifactPanel } from "./ArtifactPanel";
 import { BudgetSummary } from "./BudgetSummary";
 import { Checks } from "./Checks";
 import { DiffPanel } from "./DiffPanel";
@@ -113,6 +114,18 @@ function Evidence({
         </div>
         <Checks verification={evidence.verification} />
       </section>
+
+      {evidence.artifact && (
+        // The reviewed document goes above the diff: at an artifact-bearing
+        // gate the plan is what the human decides on, the diff is how it got
+        // there. Rejection feedback stays the existing note — no thread UI.
+        <section className="rv-sect">
+          <div className="rv-sect-head">
+            <Icon name="file" size={13} /> {evidence.artifact.path}
+          </div>
+          <ArtifactPanel artifact={evidence.artifact} />
+        </section>
+      )}
 
       <section className="rv-sect rv-sect-diff">
         <div className="rv-sect-head">

--- a/src/starterPack/presets.ts
+++ b/src/starterPack/presets.ts
@@ -178,8 +178,8 @@ export function buildFeaturePipelineSpec(idByRole: Record<string, string>): Spec
         step: {
           id: "plan",
           agent: "architect",
-          goal: "Analyze the task and write PLAN.md describing small, independently testable slices in dependency order.",
-          gate: { type: "artifact", path: "PLAN.md" },
+          goal: "Analyze the task and write PLAN.md describing small, independently testable slices in dependency order. The run pauses on PLAN.md for human review before implementation.",
+          gate: { type: "approval", artifact: "PLAN.md" },
         },
       },
       {

--- a/src/workflows/builder/inspector/StepInspector.tsx
+++ b/src/workflows/builder/inspector/StepInspector.tsx
@@ -15,12 +15,20 @@ export function StepInspector({ step, ctx }: { step: EStep; ctx: BuilderCtx }) {
 
   const pickGate = (kind: GateKind) => {
     const cur = step.gate;
+    // `artifact` and `approval.artifact` are one dial (autonomous ↔ reviewed),
+    // so the file path survives switching between them instead of being retyped.
+    const path =
+      cur.type === "artifact" ? cur.path : cur.type === "approval" ? cur.artifact : undefined;
     const gate: Gate =
       kind === "artifact"
-        ? { type: "artifact", path: cur.type === "artifact" ? cur.path : "" }
+        ? { type: "artifact", path: path ?? "" }
         : // Re-picking approval preserves any existing `require: [tests]`.
           kind === "approval"
-          ? { type: "approval", require: cur.type === "approval" ? cur.require : undefined }
+          ? {
+              type: "approval",
+              require: cur.type === "approval" ? cur.require : undefined,
+              artifact: path || undefined,
+            }
           : { type: kind };
     ctx.patchStep(step.nid, { gate });
   };
@@ -32,8 +40,10 @@ export function StepInspector({ step, ctx }: { step: EStep; ctx: BuilderCtx }) {
     });
   };
 
-  const requireTests =
-    step.gate.type === "approval" && (step.gate.require?.includes("tests") ?? false);
+  // A narrowed binding so the patch closures below can spread the approval
+  // gate without TS losing the discriminant.
+  const approvalGate = step.gate.type === "approval" ? step.gate : null;
+  const requireTests = approvalGate?.require?.includes("tests") ?? false;
 
   return (
     <>
@@ -88,21 +98,36 @@ export function StepInspector({ step, ctx }: { step: EStep; ctx: BuilderCtx }) {
             }
           />
         )}
-        {step.gate.type === "approval" && (
-          // One extra prerequisite the approval gate can require first — the human
-          // pause stays unreachable until the project's tests pass (spec §9).
-          <label className="wb-toggle" style={{ marginTop: 9 }}>
+        {approvalGate && (
+          <>
+            {/* The optional reviewed file (spec §9): the pause waits for it to
+                exist and shows it for your review, above the diff. */}
             <input
-              type="checkbox"
-              checked={requireTests}
+              className="ca-input"
+              style={{ marginTop: 9 }}
+              value={approvalGate.artifact ?? ""}
+              placeholder="Optional: a file to pause for your review, e.g. PLAN.md"
               onChange={(e) =>
                 ctx.patchStep(step.nid, {
-                  gate: { type: "approval", require: e.target.checked ? ["tests"] : undefined },
+                  gate: { ...approvalGate, artifact: e.target.value || undefined },
                 })
               }
             />
-            Require passing tests first
-          </label>
+            {/* One extra prerequisite the approval gate can require first — the
+                human pause stays unreachable until the project's tests pass (§9). */}
+            <label className="wb-toggle" style={{ marginTop: 9 }}>
+              <input
+                type="checkbox"
+                checked={requireTests}
+                onChange={(e) =>
+                  ctx.patchStep(step.nid, {
+                    gate: { ...approvalGate, require: e.target.checked ? ["tests"] : undefined },
+                  })
+                }
+              />
+              Require passing tests first
+            </label>
+          </>
         )}
       </Field>
 

--- a/src/workflows/builder/model.ts
+++ b/src/workflows/builder/model.ts
@@ -474,6 +474,11 @@ function validateStep(s: EStep, v: Validation, seen: Map<string, EStep>): void {
   if (s.gate.type === "artifact" && badArtifactPath(s.gate.path)) {
     push("artifact path must be repo-relative (no leading '/' and no '..')");
   }
+  // An approval gate's reviewed file obeys the same rules when set (spec §9);
+  // unset means an ordinary approval pause, so only a present value is checked.
+  if (s.gate.type === "approval" && s.gate.artifact && badArtifactPath(s.gate.artifact)) {
+    push("the reviewed file must be repo-relative (no leading '/' and no '..')");
+  }
   validateBudgets(s.budgets, push);
   if (errs.length) v.byNode[s.nid] = errs;
 }

--- a/src/workflows/spec.ts
+++ b/src/workflows/spec.ts
@@ -69,13 +69,15 @@ export type Require = "tests";
 
 /** The deterministic predicate that marks a step attempt done (spec §9). An
  *  `approval` gate may list `require: [tests]` — the human pause is unreachable
- *  until the project's tests pass (optional, defaults to none). */
+ *  until the project's tests pass (optional, defaults to none) — and may name a
+ *  repo-relative `artifact` the human reviews: the pause is likewise unreachable
+ *  until that file exists, and its content rides in the gate evidence. */
 export type Gate =
   | { type: "verdict" }
   | { type: "commit" }
   | { type: "artifact"; path: string }
   | { type: "tests" }
-  | { type: "approval"; require?: Require[] };
+  | { type: "approval"; require?: Require[]; artifact?: string };
 
 export interface Step {
   id: string;


### PR DESCRIPTION
Second of two stacked PRs splitting #619 — **based on #620** (env membrane), which lands first; this PR's evidence checks thread the shared run env through the Verifier signature that #620 introduces.

Makes plan/design review a per-step choice: a step can run fully autonomously (`artifact` gate), or pause for human review of the artifact it produced (`approval` gate with the new optional `artifact` field).

- `Gate::Approval` gains `artifact: Option<String>` (serde-default; existing specs and YAML round-trip byte-identical). Path validation reuses the `artifact` gate's rules via the shared helper.
- Semantics: a missing artifact blocks the approval pause exactly like an unmet `require: [tests]` — blocked + re-prompt naming the path, never an approvable pause without the file.
- The artifact's content (128 KiB cap, truncation-flagged) is captured into the journaled `gate_evidence` by one shared helper — at the approval pause **and** when an autonomous `artifact` gate passes, so unattended runs journal the plan for after-the-fact reading (worktrees are pruned; the journal is the artifact's only durable home).
- ReviewSurface renders the artifact as markdown above the diff (reuses the shared `Markdown` component / chat prose skin — no new dependency). Reviewer feedback stays the existing reject-with-note loop.
- Builder: optional "file to pause for your review" input on approval gates; the gate-type picker preserves the path across `artifact` ↔ `approval` switches.
- Starter pack: the Plan step now writes `PLAN.md` and gates on `approval + artifact: PLAN.md`.

Tests: this branch's tip tree is byte-identical to the fully verified combined tree — `cargo test` 1397 passed / 0 failed (new: spec validation + JSON/YAML round-trip, missing-artifact-blocks-approval gate tests, scheduler integration tests for both pause shapes and autonomous capture); `tsc --noEmit` clean; vitest 992 passed.