### PR TITLE
feat(issues): carry the issue's discussion into the composed brief

### DIFF
--- a/src-tauri/src/commands/issues.rs
+++ b/src-tauri/src/commands/issues.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use tauri::State;
 
 use crate::error::Result;
-use crate::issues::TrackerIssue;
+use crate::issues::{IssueComment, IssueSource, TrackerIssue};
 use crate::linear;
 use crate::supervisor::Supervisor;
 
@@ -39,6 +39,30 @@ pub async fn list_tracker_issues(
     linear_team_id: Option<String>,
 ) -> Result<Vec<TrackerIssue>> {
     Ok(crate::issues::issue_list(&expand_tilde(&repo_path), linear_team_id.as_deref(), 30).await)
+}
+
+/// Discussion cap for the composed brief: enough to carry a real thread's
+/// decisions without flooding the prompt (bodies are additionally clamped
+/// per-comment in `crate::issues`).
+const ISSUE_COMMENTS_LIMIT: u32 = 20;
+
+/// The picked issue's discussion, for the composer's brief — the newest
+/// [`ISSUE_COMMENTS_LIMIT`] comments, oldest-first. Degrades to `[]` on any
+/// source failure (never errors): a missing discussion must not block
+/// starting work on the issue.
+#[tauri::command]
+pub async fn issue_comments(
+    repo_path: String,
+    source: IssueSource,
+    key: String,
+) -> Result<Vec<IssueComment>> {
+    Ok(crate::issues::issue_comments(
+        &expand_tilde(&repo_path),
+        source,
+        &key,
+        ISSUE_COMMENTS_LIMIT,
+    )
+    .await)
 }
 
 /// Re-tag a running agent with the issue it's working — the composer's issue

--- a/src-tauri/src/github/issues.rs
+++ b/src-tauri/src/github/issues.rs
@@ -147,6 +147,67 @@ pub async fn issue_list(checkout: &Path, limit: u32) -> Result<Option<Vec<IssueS
     Ok(Some(issues))
 }
 
+/// One node from the REST comments payload → the normalized
+/// [`crate::issues::IssueComment`], dropping an empty body.
+fn parse_comment(node: &Value) -> Option<crate::issues::IssueComment> {
+    let body = node["body"]
+        .as_str()
+        .map(str::trim)
+        .filter(|b| !b.is_empty())?
+        .to_string();
+    Some(crate::issues::IssueComment {
+        author: node["user"]["login"].as_str().map(str::to_string),
+        body,
+    })
+}
+
+/// Parse the REST comments array (oldest-first, the endpoint's default
+/// order), keeping the trailing `limit`. Pure, so it's unit-tested without
+/// the network.
+fn parse_comment_list(body: &Value, limit: usize) -> Vec<crate::issues::IssueComment> {
+    let comments = body
+        .as_array()
+        .map(|arr| arr.iter().filter_map(parse_comment).collect())
+        .unwrap_or_default();
+    crate::issues::keep_last(comments, limit)
+}
+
+/// The comments on one issue, for the composed brief's discussion section.
+/// Same quiet read-op contract as [`issue_list`]: `Ok(None)` on any
+/// degradation — no token, non-GitHub origin, rate-limit pause, a key that
+/// isn't a bare issue number, transport/HTTP error. Plain `rest` (not the
+/// ETag-cached variant): this is an on-pick fetch, not a poll path.
+pub async fn issue_comments(
+    checkout: &Path,
+    key: &str,
+    limit: u32,
+) -> Result<Option<Vec<crate::issues::IssueComment>>> {
+    if client::is_backing_off() {
+        return Ok(None);
+    }
+    // The key is the bare issue number ("123"); anything else can't be a
+    // GitHub issue and must not reach the URL path.
+    let Ok(number) = key.parse::<u64>() else {
+        return Ok(None);
+    };
+    let Some((owner, repo)) = repo_ref(checkout).await else {
+        return Ok(None);
+    };
+    let client = match client::Client::new() {
+        Ok(c) => c,
+        Err(_) => return Ok(None),
+    };
+    let path = format!("/repos/{owner}/{repo}/issues/{number}/comments?per_page=100");
+    let (status, body) = match client.rest(reqwest::Method::GET, &path, None).await {
+        Ok(pair) => pair,
+        Err(_) => return Ok(None),
+    };
+    if !status.is_success() {
+        return Ok(None);
+    }
+    Ok(Some(parse_comment_list(&body, limit as usize)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -256,5 +317,36 @@ mod tests {
             .map(|i| i.number)
             .collect();
         assert_eq!(numbers, vec![1, 2]);
+    }
+
+    /// The comments payload parses to normalized comments (author + body),
+    /// dropping empty bodies, and a beyond-limit thread keeps the newest
+    /// entries (the array arrives oldest-first).
+    #[test]
+    fn comment_list_parses_and_keeps_newest() {
+        let body = json!([
+            { "user": { "login": "octocat" }, "body": "first" },
+            { "user": { "login": "alice" }, "body": "  " },
+            { "body": "no author" },
+            { "user": { "login": "bob" }, "body": "latest" }
+        ]);
+        let all = parse_comment_list(&body, 10);
+        assert_eq!(all.len(), 3, "the blank body must be dropped");
+        assert_eq!(all[0].author.as_deref(), Some("octocat"));
+        assert_eq!(all[1].author, None);
+        assert_eq!(all[2].body, "latest");
+
+        let capped = parse_comment_list(&body, 2);
+        assert_eq!(capped.len(), 2);
+        assert_eq!(
+            capped[0].body, "no author",
+            "capping must keep the trailing (newest) comments"
+        );
+    }
+
+    /// A non-array comments payload (an error object) parses to empty.
+    #[test]
+    fn comment_list_tolerates_non_array() {
+        assert!(parse_comment_list(&json!({ "message": "Not Found" }), 5).is_empty());
     }
 }

--- a/src-tauri/src/issues.rs
+++ b/src-tauri/src/issues.rs
@@ -40,12 +40,73 @@ pub fn live_issue_ref(agent_id: &str) -> Option<String> {
 }
 
 /// Which tracker an issue came from. Serialized lowercase — the frontend's
-/// `IssueSource` union mirrors it.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+/// `IssueSource` union mirrors it. `Deserialize` so the `issue_comments`
+/// command can take the source back from a picked issue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum IssueSource {
     Github,
     Linear,
+}
+
+/// One comment on a tracker issue — just enough for the brief's discussion
+/// section (author display name + body). Both adapters normalize to this
+/// shape, mirroring how [`TrackerIssue`] absorbs source differences.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct IssueComment {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+    pub body: String,
+}
+
+/// Per-comment body ceiling (chars): one pasted stack trace or log dump must
+/// not flood the composed brief — the agent can open the issue URL for the
+/// full text.
+const COMMENT_BODY_CAP: usize = 2000;
+
+/// Clamp a comment body to [`COMMENT_BODY_CAP`] chars, marking the cut.
+fn clamp_body(body: String) -> String {
+    if body.chars().count() <= COMMENT_BODY_CAP {
+        return body;
+    }
+    let cut: String = body.chars().take(COMMENT_BODY_CAP).collect();
+    format!("{cut}… [truncated]")
+}
+
+/// Keep the trailing `limit` comments — with a long thread, the newest
+/// comments carry the decisions that supersede the earlier discussion.
+pub(crate) fn keep_last(mut comments: Vec<IssueComment>, limit: usize) -> Vec<IssueComment> {
+    if comments.len() > limit {
+        comments.drain(..comments.len() - limit);
+    }
+    comments
+}
+
+/// The discussion on one issue — oldest-first, capped to the newest `limit`
+/// comments, each body clamped. Degrades to empty on any source failure (no
+/// token, non-GitHub origin, API error), the same quiet contract as
+/// [`issue_list`]: the brief simply composes without a discussion section.
+pub async fn issue_comments(
+    checkout: &Path,
+    source: IssueSource,
+    key: &str,
+    limit: u32,
+) -> Vec<IssueComment> {
+    let comments = match source {
+        IssueSource::Github => github::issue_comments(checkout, key, limit)
+            .await
+            .ok()
+            .flatten(),
+        IssueSource::Linear => crate::linear::issue_comments(key, limit).await.ok().flatten(),
+    };
+    comments
+        .unwrap_or_default()
+        .into_iter()
+        .map(|c| IssueComment {
+            body: clamp_body(c.body),
+            ..c
+        })
+        .collect()
 }
 
 /// One label on an issue. `color` is a 6-hex assignment with no leading `#`

--- a/src-tauri/src/issues.rs
+++ b/src-tauri/src/issues.rs
@@ -97,7 +97,10 @@ pub async fn issue_comments(
             .await
             .ok()
             .flatten(),
-        IssueSource::Linear => crate::linear::issue_comments(key, limit).await.ok().flatten(),
+        IssueSource::Linear => crate::linear::issue_comments(key, limit)
+            .await
+            .ok()
+            .flatten(),
     };
     comments
         .unwrap_or_default()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1772,6 +1772,7 @@ pub fn run() {
             commands::list_prs,
             commands::list_repo_prs,
             commands::list_tracker_issues,
+            commands::issue_comments,
             commands::set_agent_issue_ref,
             commands::linear_status,
             commands::linear_connect,

--- a/src-tauri/src/linear/mod.rs
+++ b/src-tauri/src/linear/mod.rs
@@ -9,7 +9,7 @@ pub mod client;
 use serde_json::{json, Value};
 
 use crate::error::Result;
-use crate::issues::{IssueSource, TrackerIssue, TrackerLabel};
+use crate::issues::{IssueComment, IssueSource, TrackerIssue, TrackerLabel};
 
 pub use client::{seed_token, set_token, TOKEN_SETTING};
 
@@ -110,6 +110,60 @@ pub async fn issue_list(team_id: &str, limit: u32) -> Result<Option<Vec<TrackerI
         Ok(data) => Ok(Some(parse_issue_list(&data))),
         Err(_) => Ok(None),
     }
+}
+
+/// The comments on one issue, for the composed brief's discussion section.
+/// `issue(id:)` accepts the human identifier ("ENG-123") in addition to the
+/// UUID — exactly the `key` we store. Same degradation contract as
+/// [`issue_list`]: `Ok(None)` on no key or API/transport error.
+pub async fn issue_comments(key: &str, limit: u32) -> Result<Option<Vec<IssueComment>>> {
+    let client = match client::Client::new() {
+        Ok(c) => c,
+        Err(_) => return Ok(None),
+    };
+    const QUERY: &str = r#"
+        query IssueComments($id: String!) {
+          issue(id: $id) {
+            comments(first: 100) {
+              nodes { body createdAt user { displayName } }
+            }
+          }
+        }
+    "#;
+    match client.graphql(QUERY, json!({ "id": key })).await {
+        Ok(data) => Ok(Some(parse_comment_list(&data, limit as usize))),
+        Err(_) => Ok(None),
+    }
+}
+
+/// Parse the comments payload into normalized comments ordered oldest-first
+/// (the API's node order isn't contractual, so sort by `createdAt`), keeping
+/// the trailing `limit`. Pure, so it's unit-tested without the network.
+fn parse_comment_list(data: &Value, limit: usize) -> Vec<IssueComment> {
+    let mut dated: Vec<(i64, IssueComment)> = data["issue"]["comments"]["nodes"]
+        .as_array()
+        .map(|nodes| {
+            nodes
+                .iter()
+                .filter_map(|n| {
+                    let body = n["body"]
+                        .as_str()
+                        .map(str::trim)
+                        .filter(|b| !b.is_empty())?
+                        .to_string();
+                    Some((
+                        time_ms(n, "createdAt").unwrap_or(0),
+                        IssueComment {
+                            author: n["user"]["displayName"].as_str().map(str::to_string),
+                            body,
+                        },
+                    ))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    dated.sort_by_key(|(t, _)| *t);
+    crate::issues::keep_last(dated.into_iter().map(|(_, c)| c).collect(), limit)
 }
 
 /// ISO-8601 timestamp → ms-epoch (mirror of `github::query::gh_time_ms`).
@@ -229,5 +283,42 @@ mod tests {
         let teams = parse_teams(&data);
         assert_eq!(teams.len(), 1);
         assert_eq!(teams[0].key, "ENG");
+    }
+
+    /// Comments parse oldest-first regardless of node order (sorted by
+    /// `createdAt`), blank bodies are dropped, and capping keeps the newest.
+    #[test]
+    fn comment_list_sorts_drops_blank_and_keeps_newest() {
+        let data = json!({ "issue": { "comments": { "nodes": [
+            {
+                "body": "latest decision",
+                "createdAt": "2024-01-03T00:00:00.000Z",
+                "user": { "displayName": "Ada" }
+            },
+            { "body": "  ", "createdAt": "2024-01-02T00:00:00.000Z" },
+            {
+                "body": "first question",
+                "createdAt": "2024-01-01T00:00:00.000Z",
+                "user": { "displayName": "Grace" }
+            }
+        ] } } });
+        let all = parse_comment_list(&data, 10);
+        assert_eq!(all.len(), 2, "the blank body must be dropped");
+        assert_eq!(all[0].author.as_deref(), Some("Grace"));
+        assert_eq!(all[1].body, "latest decision");
+
+        let capped = parse_comment_list(&data, 1);
+        assert_eq!(capped.len(), 1);
+        assert_eq!(
+            capped[0].body, "latest decision",
+            "capping must keep the newest comment"
+        );
+    }
+
+    /// A non-object payload (an error shape) parses to empty, not a panic.
+    #[test]
+    fn comment_list_tolerates_error_payloads() {
+        assert!(parse_comment_list(&json!(null), 5).is_empty());
+        assert!(parse_comment_list(&json!({ "issue": null }), 5).is_empty());
     }
 }

--- a/src/api/domains/issues.ts
+++ b/src/api/domains/issues.ts
@@ -1,5 +1,11 @@
 import { invoke } from "../invoke";
-import type { LinearStatus, LinearTeam, TrackerIssue } from "../types/issues";
+import type {
+  IssueComment,
+  IssueSource,
+  LinearStatus,
+  LinearTeam,
+  TrackerIssue,
+} from "../types/issues";
 
 export const issuesApi = {
   /** Open, relevant issues for a repo across every configured tracker source
@@ -13,6 +19,11 @@ export const issuesApi = {
       repoPath,
       linearTeamId: linearTeamId ?? null,
     }),
+  /** The picked issue's discussion for the composed brief — the newest ~20
+   *  comments, oldest-first, bodies clamped. Degrades to `[]` (never errors),
+   *  so a failed fetch only loses the discussion section. */
+  issueComments: (repoPath: string, source: IssueSource, key: string) =>
+    invoke<IssueComment[]>("issue_comments", { repoPath, source, key }),
   /** Re-tag a running agent with the issue it's working (a mid-session pick
    *  in the composer), so its eventual PR carries the closing trailer. */
   setAgentIssueRef: (agentId: string, issueRef: string) =>

--- a/src/api/types/issues.ts
+++ b/src/api/types/issues.ts
@@ -28,6 +28,13 @@ export interface TrackerIssue {
   body?: string;
 }
 
+/** One comment on a tracker issue — the frontend mirror of Rust's
+ *  `issues::IssueComment`. Bodies arrive pre-clamped by the backend. */
+export interface IssueComment {
+  author?: string;
+  body: string;
+}
+
 /** The human-facing form of an issue's key: GitHub numbers read as `#123`,
  *  tracker keys (`ENG-123`) as themselves. */
 export function issueDisplayKey(issue: Pick<TrackerIssue, "source" | "key">): string {

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { hasUsage } from "@/adapters/usage";
-import type { DirListing, PrSummary, TrackerIssue } from "@/api";
+import type { DirListing, IssueComment, PrSummary, TrackerIssue } from "@/api";
 import { Icon } from "@/components/Icon";
 import { Chip } from "@/components/ui/Chip";
 import { IconButton } from "@/components/ui/IconButton";
@@ -79,6 +79,10 @@ interface Props {
    *  picking one appends its brief to the prompt so the agent works that
    *  exact issue. Omit to hide the picker. */
   listIssues?: () => Promise<TrackerIssue[]>;
+  /** Fetches the picked issue's discussion so the brief carries the thread,
+   *  not just the body. Optional and best-effort: absent or failing, the
+   *  brief composes without a discussion section. */
+  listIssueComments?: (issue: TrackerIssue) => Promise<IssueComment[]>;
   /** Fired after an issue pick (in addition to the brief insert), so parents
    *  with a draft can tag it (`issueRef`) for the PR closing trailer. */
   onPickIssue?: (issue: TrackerIssue) => void;
@@ -166,6 +170,7 @@ export function Composer({
   listDir,
   listPrs,
   listIssues,
+  listIssueComments,
   onPickIssue,
   seed,
   onSeedConsumed,
@@ -381,9 +386,12 @@ export function Composer({
               onPick={(issue) => {
                 // The brief lands in the prompt for the user to review/edit;
                 // the parent additionally tags its draft so the eventual PR
-                // closes the issue.
-                input.append(composeIssueBrief(issue));
+                // closes the issue. The discussion is fetched first so the
+                // brief appends once, as one reviewable block — on a failed
+                // fetch it composes without the discussion section.
                 onPickIssue?.(issue);
+                const comments = listIssueComments?.(issue).catch(() => []) ?? Promise.resolve([]);
+                void comments.then((thread) => input.append(composeIssueBrief(issue, thread)));
               }}
             />
           )}

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -206,6 +206,11 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
               listIssues={
                 repoPath ? () => api.listTrackerIssues(repoPath, linearTeamId) : undefined
               }
+              listIssueComments={
+                repoPath
+                  ? (issue) => api.issueComments(repoPath, issue.source, issue.key)
+                  : undefined
+              }
               onPickIssue={(issue) => {
                 // Persist the pick so the agent's eventual PR closes this
                 // issue — the brief insert alone wouldn't survive to the

--- a/src/components/Workspace/EmptyWorkspace.tsx
+++ b/src/components/Workspace/EmptyWorkspace.tsx
@@ -207,6 +207,9 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
                 listDir={api.listDir}
                 listPrs={() => api.listRepoPrs(draft.repoPath)}
                 listIssues={() => api.listTrackerIssues(draft.repoPath, linearTeamId)}
+                listIssueComments={(issue) =>
+                  api.issueComments(draft.repoPath, issue.source, issue.key)
+                }
                 onPickIssue={(issue) => updateDraft(draft.id, { issueRef: issue.key })}
                 defaultModel={draft.model}
                 defaultCustomAgentId={draft.customAgentId}

--- a/src/components/Workspace/MissionControl/inbox.test.ts
+++ b/src/components/Workspace/MissionControl/inbox.test.ts
@@ -93,6 +93,23 @@ describe("composeIssueBrief", () => {
     const brief = composeIssueBrief(issue({ key: "5", title: "T", body: "  " }));
     expect(brief).not.toContain("\n\n\n");
   });
+
+  it("lays out the discussion between body and url, oldest first", () => {
+    const brief = composeIssueBrief(issue({ key: "7", title: "T", body: "B", url: "https://x/7" }), [
+      { author: "ada", body: "repro attached" },
+      { body: "fixed by the config change" },
+    ]);
+    expect(brief).toContain("Discussion on the issue (oldest first):");
+    expect(brief).toContain("ada: repro attached");
+    expect(brief).toContain("someone: fixed by the config change");
+    expect(brief.indexOf("Discussion")).toBeGreaterThan(brief.indexOf("B"));
+    expect(brief.indexOf("Discussion")).toBeLessThan(brief.indexOf("https://x/7"));
+  });
+
+  it("composes without a discussion section when there are no comments", () => {
+    expect(composeIssueBrief(issue(), [])).not.toContain("Discussion");
+    expect(composeIssueBrief(issue())).not.toContain("Discussion");
+  });
 });
 
 describe("deriveInboxRows", () => {

--- a/src/components/Workspace/MissionControl/inbox.test.ts
+++ b/src/components/Workspace/MissionControl/inbox.test.ts
@@ -95,10 +95,10 @@ describe("composeIssueBrief", () => {
   });
 
   it("lays out the discussion between body and url, oldest first", () => {
-    const brief = composeIssueBrief(issue({ key: "7", title: "T", body: "B", url: "https://x/7" }), [
-      { author: "ada", body: "repro attached" },
-      { body: "fixed by the config change" },
-    ]);
+    const brief = composeIssueBrief(
+      issue({ key: "7", title: "T", body: "B", url: "https://x/7" }),
+      [{ author: "ada", body: "repro attached" }, { body: "fixed by the config change" }],
+    );
     expect(brief).toContain("Discussion on the issue (oldest first):");
     expect(brief).toContain("ada: repro attached");
     expect(brief).toContain("someone: fixed by the config change");

--- a/src/components/Workspace/MissionControl/inbox.ts
+++ b/src/components/Workspace/MissionControl/inbox.ts
@@ -5,12 +5,7 @@
 // sources) flow through the same code. Kept side-effect-free so each piece
 // is unit-tested without the network or the store (inbox.test.ts).
 
-import {
-  type IssueComment,
-  issueDisplayKey,
-  type TrackerIssue,
-  type TrackerLabel,
-} from "@/api";
+import { type IssueComment, issueDisplayKey, type TrackerIssue, type TrackerLabel } from "@/api";
 
 /** A tracked repo's fetched issues, tagged with its display label. */
 export interface InboxRepo {
@@ -85,9 +80,7 @@ export function composeIssueBrief(issue: TrackerIssue, comments: IssueComment[] 
   const body = issue.body?.trim();
   if (body) parts.push(body);
   if (comments.length > 0) {
-    const thread = comments
-      .map((c) => `${c.author ?? "someone"}: ${c.body.trim()}`)
-      .join("\n\n");
+    const thread = comments.map((c) => `${c.author ?? "someone"}: ${c.body.trim()}`).join("\n\n");
     parts.push(`Discussion on the issue (oldest first):\n\n${thread}`);
   }
   parts.push(issue.url);

--- a/src/components/Workspace/MissionControl/inbox.ts
+++ b/src/components/Workspace/MissionControl/inbox.ts
@@ -5,7 +5,12 @@
 // sources) flow through the same code. Kept side-effect-free so each piece
 // is unit-tested without the network or the store (inbox.test.ts).
 
-import { issueDisplayKey, type TrackerIssue, type TrackerLabel } from "@/api";
+import {
+  type IssueComment,
+  issueDisplayKey,
+  type TrackerIssue,
+  type TrackerLabel,
+} from "@/api";
 
 /** A tracked repo's fetched issues, tagged with its display label. */
 export interface InboxRepo {
@@ -69,14 +74,22 @@ const SOURCE_LABEL: Record<TrackerIssue["source"], string> = {
 };
 
 /** Compose the new-task brief for "Start work" / the composer's issue picker:
- *  issue reference, title, body, and a visible/editable branch suggestion.
- *  The closing trailer (`Closes #N` / `Fixes ENG-N`) is added reliably by the
- *  backend at PR time, so the brief needn't instruct it. */
-export function composeIssueBrief(issue: TrackerIssue): string {
+ *  issue reference, title, body, the issue's discussion (when fetched), and a
+ *  visible/editable branch suggestion. The closing trailer (`Closes #N` /
+ *  `Fixes ENG-N`) is added reliably by the backend at PR time, so the brief
+ *  needn't instruct it. Comments arrive oldest-first and already capped by
+ *  the backend; here they only get laid out. */
+export function composeIssueBrief(issue: TrackerIssue, comments: IssueComment[] = []): string {
   const branch = suggestBranchName(issue);
   const parts = [`${SOURCE_LABEL[issue.source]} issue ${issueDisplayKey(issue)}: ${issue.title}`];
   const body = issue.body?.trim();
   if (body) parts.push(body);
+  if (comments.length > 0) {
+    const thread = comments
+      .map((c) => `${c.author ?? "someone"}: ${c.body.trim()}`)
+      .join("\n\n");
+    parts.push(`Discussion on the issue (oldest first):\n\n${thread}`);
+  }
   parts.push(issue.url);
   parts.push(`When you open the PR, use the branch name \`${branch}\`.`);
   return parts.join("\n\n");

--- a/src/store/drafts.ts
+++ b/src/store/drafts.ts
@@ -193,8 +193,12 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
     };
     // Seed the composer for this draft (read as its initial text on mount) with
     // the issue brief, so "Start work" lands fully prefilled — the user reviews
-    // and hits ↵ to launch (two clicks from issue to working agent).
-    get().setComposerDraft(draft.id, composeIssueBrief(issue));
+    // and hits ↵ to launch (two clicks from issue to working agent). The
+    // discussion is fetched first (best-effort — a failure only loses the
+    // section) so the seed is one complete block, not text that shifts under
+    // the user after mount.
+    const comments = await api.issueComments(repoPath, issue.source, issue.key).catch(() => []);
+    get().setComposerDraft(draft.id, composeIssueBrief(issue, comments));
     set((s) => ({
       drafts: [draft, ...s.drafts],
       activeDraftId: draft.id,


### PR DESCRIPTION
Quick-win #3 from the HumanLayer comparison: rich issue import instead of bare issue linking.

Picking an issue seeds the composer with `composeIssueBrief` — previously title + body + url + branch suggestion. The thread where requirements get clarified and decisions land never reached the agent. The brief now carries a **discussion section**.

## What changed

- **Normalized `IssueComment`** (`author`, `body`) in `issues.rs`, produced by both adapters: GitHub via REST `GET /issues/{n}/comments` (plain `rest`, not the ETag-cached poll variant — this is an on-pick fetch), Linear via GraphQL `issue(id:).comments` (sorted by `createdAt`; `issue(id:)` accepts the human identifier we already store as the key).
- **Caps**: newest 20 comments (oldest-first — with a long thread the newest carry the superseding decisions), each body clamped to 2k chars with a truncation marker. One `keep_last` + `clamp_body`, shared by both sources.
- **`issue_comments` command**, degrading to `[]` on any failure (no token, non-GitHub origin, rate-limit pause, non-numeric GitHub key, API error) — same quiet contract as `issue_list`. A missing discussion never blocks starting work.
- **`composeIssueBrief(issue, comments)`** lays the thread out between body and url; the section is absent when there are no comments.
- **All three entry points**: composer picker in a chat (`ChatView`), the new-agent draft (`EmptyWorkspace`), and Mission Control's "Start work" (`drafts.ts`) — each fetches best-effort, then appends the brief once, as a single reviewable block.

## Deliberately unchanged

Issue linking (`set_agent_issue_ref` / `issueRef` / PR closing trailers) is untouched; the fetched content is purely additive. No images, no Jira, no caching, no new settings, no new dependencies.

## Tests

- `cargo test`: 1401 passed / 0 failed (new: GitHub comment parsing + trailing-cap, Linear comment sort/blank-drop/cap + error-payload tolerance).
- `tsc --noEmit` clean; vitest 994 passed (new: discussion layout + no-section-when-empty).